### PR TITLE
Adding method to print head of sample collection

### DIFF
--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -18,6 +18,7 @@ from builtins import *
 # pragma pylint: enable=unused-wildcard-import
 # pragma pylint: enable=wildcard-import
 
+import itertools
 import logging
 
 import eta.core.utils as etau
@@ -53,6 +54,14 @@ class SampleCollection(object):
 
     def __iter__(self):
         return self.iter_samples()
+
+    def head(self, num_samples=3):
+        """Prints the first few samples in the collection.
+
+        Args:
+            num_samples (3): the number of samples to print
+        """
+        print("\n".join(str(s) for s in itertools.islice(self, num_samples)))
 
     def get_tags(self):
         """Returns the list of tags in the collection.


### PR DESCRIPTION
Alright second shot at this:

Should it be `head()`, `print_head()`, something else? Just trying to provide a minimal characters way to see something in my dataset

```py
import fiftyone.zoo as foz

dataset = foz.load_zoo_dataset("cifar10")

dataset.head()
```

outputs:

```
{
    "_id": {
        "$oid": "5eb56c7cbe5f73ff2e8e7062"
    },
    "_cls": "ODMDocument.ODMSample",
    "dataset": "cifar10",
    "filepath": "/Users/Brian/fiftyone/cifar10/test/data/00001.jpg",
    "metadata": null,
    "tags": [],
    "insights": {},
    "labels": {
        "ground_truth": {
            "_cls": "ODMClassificationLabel",
            "label": "cat",
            "confidence": null,
            "logits": null
        }
    }
}
{
    "_id": {
        "$oid": "5eb56c7cbe5f73ff2e8e7063"
    },
    "_cls": "ODMDocument.ODMSample",
    "dataset": "cifar10",
    "filepath": "/Users/Brian/fiftyone/cifar10/test/data/00002.jpg",
    "metadata": null,
    "tags": [],
    "insights": {},
    "labels": {
        "ground_truth": {
            "_cls": "ODMClassificationLabel",
            "label": "ship",
            "confidence": null,
            "logits": null
        }
    }
}
{
    "_id": {
        "$oid": "5eb56c7cbe5f73ff2e8e7064"
    },
    "_cls": "ODMDocument.ODMSample",
    "dataset": "cifar10",
    "filepath": "/Users/Brian/fiftyone/cifar10/test/data/00003.jpg",
    "metadata": null,
    "tags": [],
    "insights": {},
    "labels": {
        "ground_truth": {
            "_cls": "ODMClassificationLabel",
            "label": "ship",
            "confidence": null,
            "logits": null
        }
    }
}
```