### PR TITLE
Adding prettier config

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,12 @@
+{
+    "overrides": [
+        {
+            "files": "*.md",
+            "options": {
+                "printWidth": 79,
+                "proseWrap": "always",
+                "tabWidth": 4
+            }
+        }
+    ]
+}


### PR DESCRIPTION
I just discovered the magic of `prettier` in our pre-commit hooks, which I believe is being used to prettify the JS code in the repo (awesome!)

It also prettifies markdown, and I would like to configure it as shown in this PR.

I'm unsure if this will interfere with the current prettification of the JS code.