### PR TITLE
Enabling multiple fiftyone.XXX packages

### DIFF
--- a/fiftyone/__init__.py
+++ b/fiftyone/__init__.py
@@ -20,6 +20,16 @@ from builtins import *
 # pragma pylint: enable=unused-wildcard-import
 # pragma pylint: enable=wildcard-import
 
+from pkgutil import extend_path
+
+#
+# This statement allows multiple `fiftyone.XXX` packages to be installed in the
+# same environment and used simultaneously.
+#
+# https://docs.python.org/3/library/pkgutil.html#pkgutil.extend_path
+#
+__path__ = extend_path(__path__, __name__)
+
 import fiftyone.core.config as foc
 import fiftyone.core.service as fos
 


### PR DESCRIPTION
This will enable us to develop `fiftyone.XXX` subpackages in other repositories that can be installed and used together with this repository.

Used successfully by https://github.com/voxel51/api-py and https://github.com/voxel51/platform-sdk, for example.