### PR TITLE
ODMDetectionLabels fix

### DIFF
--- a/fiftyone/core/document.py
+++ b/fiftyone/core/document.py
@@ -137,7 +137,6 @@ class BackedByDocument(object):
         Returns:
             a :class:`BackedByDocument`
         """
-        print(cls._ODM_DOCUMENT_CLS)
         return cls(cls._ODM_DOCUMENT_CLS(**kwargs))
 
     def _save(self):


### PR DESCRIPTION
The following changes allow for detection labels to be ingested.
```json
In [6]: print(next(d.iter_samples()))                                                                                 
{
    "_id": {
        "$oid": "5ebc30b690917b30dc2bb766"
    },
    "_cls": "ODMDocument.ODMSample",
    "dataset": "test",
    "filepath": "/home/ben/code/single-sampled/data/test-18.jpg",
    "metadata": null,
    "tags": [],
    "insights": {},
    "labels": {
        "ground_truth": {
            "_cls": "ODMDetectionLabels",
            "detections": [
                {
                    "label": "road sign",
                    "bounding_box": [
                        0.65753,
                        0.297278,
                        0.03583600000000009,
                        0.025797000000000014
                    ],
                    "confidence": 1.0
                }
            ]
        }
    }
}
```