### PR TITLE
Adding `split` to zoo dataset name

### DIFF
--- a/fiftyone/zoo/base.py
+++ b/fiftyone/zoo/base.py
@@ -184,6 +184,11 @@ class ZooDatasetInfo(etas.Serializable):
         self._dataset_type = format
 
     @property
+    def has_split(self):
+        """Whether the dataset has a split."""
+        return self.split is not None
+
+    @property
     def dataset_type(self):
         """The :class:`fiftyone.types.DatasetType` of the dataset."""
         return self._dataset_type


### PR DESCRIPTION
Previously:

```py
d1 = foz.load_zoo_dataset("cifar10", split="train")
d1.name  # cifar10

d2 = foz.load_zoo_dataset("cifar10", split="test")
d2.name  # cifar10
```

Now:

```py
d1 = foz.load_zoo_dataset("cifar10", split="train")
d1.name  # cifar10-train

d2 = foz.load_zoo_dataset("cifar10", split="test")
d2.name  # cifar10-test
```