### PR TITLE
Bug Fix: `sample.copy()` when not in database

### DIFF
--- a/fiftyone/core/odm/document.py
+++ b/fiftyone/core/odm/document.py
@@ -153,7 +153,8 @@ class ODMDocument(SerializableDocument, Document):
             a :class:`ODMDocument`
         """
         doc = super(ODMDocument, self).copy()
-        doc.id = None
+        if doc.id is not None:
+            doc.id = None
         return doc
 
     @property

--- a/fiftyone/core/odm/sample.py
+++ b/fiftyone/core/odm/sample.py
@@ -381,9 +381,13 @@ class ODMNoDatasetSample(ODMSample):
     def __init__(self, *args, **kwargs):
         fields = set(self.field_names)
 
-        # Initialize existing fields
-        existing_fields = {k: v for k, v in iteritems(kwargs) if k in fields}
-        super(ODMNoDatasetSample, self).__init__(*args, **existing_fields)
+        # Pull the new fields before calling init of super
+        new_fields = {}
+        for k in list(kwargs.keys()):
+            if k not in fields and not k.startswith("_"):
+                new_fields[k] = kwargs.pop(k)
+
+        super(ODMNoDatasetSample, self).__init__(*args, **kwargs)
 
         # Convert fields to instance attributes
         # This allows each sample to have bespoke attributes
@@ -391,7 +395,7 @@ class ODMNoDatasetSample(ODMSample):
         self._fields_ordered = deepcopy(self._fields_ordered)
 
         # Add new fields
-        for field_name, value in iteritems(kwargs):
+        for field_name, value in iteritems(new_fields):
             if field_name not in fields:
                 self.set_field(field_name, value, create=True)
 

--- a/tests/unittests.py
+++ b/tests/unittests.py
@@ -333,6 +333,41 @@ class SampleInDatasetTest(unittest.TestCase):
 
         check_add_to_sample()
 
+    def test_add_from_another_dataset(self):
+        dataset_name = self.test_scoped_schema_changes.__name__ + "_%d"
+        dataset1 = fo.Dataset(name=dataset_name % 1)
+        dataset2 = fo.Dataset(name=dataset_name % 2)
+
+        sample = fo.Sample(filepath="test.png")
+
+        sample_id = dataset1.add_sample(sample)
+        self.assertIs(dataset1[sample_id], sample)
+        self.assertEqual(sample.dataset_name, dataset1.name)
+
+        sample_id = dataset2.add_sample(sample)
+        sample2 = dataset2[sample_id]
+        self.assertIs(dataset1[sample.id], sample)
+        self.assertIsNot(dataset2[sample_id], sample)
+        self.assertEqual(sample2.dataset_name, dataset2.name)
+
+    def test_copy_sample(self):
+        dataset_name = self.test_copy_sample.__name__
+        dataset = fo.Dataset(name=dataset_name)
+
+        sample = fo.Sample(filepath="test.png")
+
+        sample_copy = sample.copy()
+        self.assertIsNot(sample_copy, sample)
+        self.assertIsNone(sample_copy.id)
+        self.assertIsNone(sample_copy.dataset_name)
+
+        dataset.add_sample(sample)
+
+        sample_copy = sample.copy()
+        self.assertIsNot(sample_copy, sample)
+        self.assertIsNone(sample_copy.id)
+        self.assertIsNone(sample_copy.dataset_name)
+
 
 class LabelsTest(unittest.TestCase):
     def test_create(self):


### PR DESCRIPTION
Attempting:

```python
sample = fo.Sample(filepath="test.png")
sample_copy = sample.copy()
```
had two errors that needed to be fixed:
1. `kwargs` starting with `_` should be passed to super as non-field arguments
2. `sample.id` is already `None` if the sample is not in the database, so it should not be set.
