### PR TITLE
Fix deduplication list formatting

### DIFF
--- a/examples/image_deduplication/README.md
+++ b/examples/image_deduplication/README.md
@@ -144,14 +144,14 @@ dataset
 
 We have two ways to visualize this new information:
 
-1. From your terminal:
+1\. From your terminal:
 
 ```python
 sample = dataset.view().first()
 print(sample)
 ```
 
-2. By refreshing the dashboard:
+2\. By refreshing the dashboard:
 
 ```python
 session.dataset = dataset


### PR DESCRIPTION
Fixes #129

This isn't technically a list when rendered as markdown anymore, but it still looks okay:

![image](https://user-images.githubusercontent.com/3719547/83444334-3fd0af00-a419-11ea-80b8-3eb1432f7b42.png)

and m2r handles it now for the Sphinx docs (this is actually rendered as a list still):

![image](https://user-images.githubusercontent.com/3719547/83444361-47905380-a419-11ea-8aeb-9868267e50a4.png)
