### PR TITLE
Prevent image caching on filepath

### DIFF
--- a/electron/app/components/Sample.tsx
+++ b/electron/app/components/Sample.tsx
@@ -17,9 +17,9 @@ const Sample = ({
   setView,
 }) => {
   const host = `http://127.0.0.1:${port}`;
-  const src = `${host}?path=${sample.filepath}`;
-  const socket = getSocket(port, "state");
   const id = sample._id.$oid;
+  const src = `${host}?path=${sample.filepath}&id=${id}`;
+  const socket = getSocket(port, "state");
   const s = sample;
   const {
     activeLabels,


### PR DESCRIPTION
Resolves #119 

Electron (chromium) caches images based on the `src`. A filepath (i.e. the `src`) can have its image change, especially across sessions, like when removing a `~/fiftyone` dataset and re-downloading it.

Passing the sample `oid`/`id` as a `src` parameter prevents this type of excessive caching.

I knew this would be relatively straightforward. Turns out it was dead simple.