### PR TITLE
Dataset.reload and Dataset.save

### DIFF
--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -389,7 +389,7 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
         A samples only needs to be saved if it has non-persisted changes and
         still exists in memory.
         """
-        fos.Sample.save_dataset_samples(self.name)
+        fos.Sample._save_dataset_samples(self.name)
 
     def reload(self):
         """Reloads the fields for sample instances in memory belonging to the
@@ -397,7 +397,7 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
         If multiple processes or users are accessing the same database this
         will keep the dataset in sync.
         """
-        fos.Sample.reload_dataset_samples(self.name)
+        fos.Sample._reload_dataset_samples(self.name)
 
     def add_image_classification_samples(
         self, samples, label_field="ground_truth", tags=None, classes=None,

--- a/fiftyone/core/sample.py
+++ b/fiftyone/core/sample.py
@@ -290,7 +290,7 @@ class Sample(object):
         self._doc.reload()
 
     @classmethod
-    def save_dataset_samples(cls, dataset_name):
+    def _save_dataset_samples(cls, dataset_name):
         """Saves all changes to samples instances in memory belonging to the
         specified dataset to the database.
         A samples only needs to be saved if it has non-persisted changes and
@@ -302,7 +302,7 @@ class Sample(object):
             sample.save()
 
     @classmethod
-    def reload_dataset_samples(cls, dataset_name):
+    def _reload_dataset_samples(cls, dataset_name):
         """Reloads the fields for sample instances in memory belonging to the
         specified dataset from the database.
         If multiple processes or users are accessing the same database this
@@ -312,28 +312,6 @@ class Sample(object):
         """
         for sample in cls._instances[dataset_name].values():
             sample.reload()
-
-    @classmethod
-    def save_all_samples(cls):
-        """Saves all changes to all samples instances in memory to the
-        database.
-        A samples only needs to be saved if it has non-persisted changes and
-        still exists in memory.
-        """
-        for dataset_instances in cls._instances.values():
-            for sample in dataset_instances.values():
-                sample.save()
-
-    @classmethod
-    def reload_all_samples(cls):
-        """Reloads the fields for all sample instances in memory from the
-        database.
-        If multiple processes or users are accessing the same database this
-        will keep the samples in sync.
-        """
-        for dataset_instances in cls._instances.values():
-            for sample in dataset_instances.values():
-                sample.reload()
 
     def _delete(self):
         """Deletes the document from the database."""


### PR DESCRIPTION
This is *NOT* a final solution, but it seems better than what we have now.

Samples are now saved in their destructor. I.e.:

```python
for sample in dataset:
    sample.tags.append("new tag")
```
will work beautifully.

But be careful!!!
```python
sample = dataset.view().first()
sample.tags.append("a never-before-seen tag")
dataset.get_tags()
# >>> []
```
In this second example, the sample modification has not been written to the database because the sample's destructor was never called. To save these changes to the database, call any of the following:
```python
sample.save()
dataset.save()
fo.Sample.save_all_samples()
```
Then:
```python
dataset.get_tags()
# >>> ["a never-before-seen tag"]
```