### PR TITLE
Removing ConfigBuilder from ViewStage

### DIFF
--- a/fiftyone/core/stages.py
+++ b/fiftyone/core/stages.py
@@ -33,9 +33,6 @@ class ViewStage(object):
             arguments
     """
 
-    def __call__(self, view):
-        return view._copy_with_new_stage(self)
-
     def to_mongo(self):
         """Returns the MongoDB version of the
         :class:`fiftyone.core.stages.ViewStage` instance

--- a/fiftyone/core/state.py
+++ b/fiftyone/core/state.py
@@ -13,7 +13,6 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 from builtins import *
-from future.utils import itervalues
 
 # pragma pylint: enable=redefined-builtin
 # pragma pylint: enable=unused-wildcard-import

--- a/fiftyone/core/view.py
+++ b/fiftyone/core/view.py
@@ -18,7 +18,6 @@ from builtins import *
 # pragma pylint: enable=unused-wildcard-import
 # pragma pylint: enable=wildcard-import
 
-from functools import wraps
 from copy import copy, deepcopy
 import numbers
 
@@ -114,7 +113,7 @@ class DatasetView(foc.SampleCollection):
         Args:
             stage: a :class:`fiftyone.core.stages.ViewStage`
         """
-        return stage(self)
+        return self._copy_with_new_stage(stage)
 
     def aggregate(self, pipeline=None):
         """Calls the current MongoDB aggregation pipeline on the view.


### PR DESCRIPTION
I figured making this PR was just as easy as starting the conversation. I'm advocating that we don't use the `ConfigBuilder` class. We could throw in validation at some point if we feel it is necessary but it doesn't seem to be to me.

Also note I remove `name` from `ViewStage._serialize` because this is redundant information and can be equivalently retrieved from:
```python
stage._serialize()["_cls"].split(".")[-1]
```