### PR TITLE
Fix CORS kwarg argument for Flask Socket IO

### DIFF
--- a/fiftyone/server/main.py
+++ b/fiftyone/server/main.py
@@ -43,7 +43,7 @@ foo.get_db_conn()
 app = Flask(__name__)
 app.config["SECRET_KEY"] = "fiftyone"
 
-socketio = SocketIO(app, async_mode="eventlet", cors_allowed_origin="*")
+socketio = SocketIO(app, async_mode="eventlet", cors_allowed_origins="*")
 
 
 @app.route("/")


### PR DESCRIPTION
`cors_allowed_origins` is the correct kwarg for flask socket io.

The App is currently unable to connect from what I am seeing. This fixes that.