### PR TITLE
Pretty Print ViewStages

### DIFF
--- a/fiftyone/core/stages.py
+++ b/fiftyone/core/stages.py
@@ -18,10 +18,16 @@ from builtins import *
 # pragma pylint: enable=unused-wildcard-import
 # pragma pylint: enable=wildcard-import
 
+import reprlib
+
 from bson import ObjectId
 from pymongo import ASCENDING, DESCENDING
 
 import eta.core.utils as etau
+
+
+# max number of list elements to print
+reprlib.aRepr.maxlist = 3
 
 
 class ViewStage(object):
@@ -32,6 +38,16 @@ class ViewStage(object):
         **kwargs: the concrete :class:`fiftyone.core.stages.ViewStage`
             arguments
     """
+
+    def __str__(self):
+        kwarg_str = ", ".join(
+            ["%s=%s" % (k, reprlib.repr(v)) for k, v in self._kwargs().items()]
+        )
+
+        return "%s(%s)" % (self.__class__.__name__, kwarg_str)
+
+    def __repr__(self):
+        return str(self)
 
     def to_mongo(self):
         """Returns the MongoDB version of the


### PR DESCRIPTION
Prettier printing of `ViewStage` instances

Test:
```python
import fiftyone as fo

dataset = fo.Dataset("example")

view = (
    dataset.view()
        .sort_by("filename")[5:10]
        .match_tag("train")
        .match({"_id": "XXXXXX"})
        .exclude(["F" * 24] * 10)
)

print(view)
```

OUT:
```
Dataset:        example
Num samples:    0
Tags:           []
Sample fields:
    filepath: fiftyone.core.fields.StringField
    tags:     fiftyone.core.fields.ListField(fiftyone.core.fields.StringField)
    metadata: fiftyone.core.fields.EmbeddedDocumentField(fiftyone.core.metadata.Metadata)
Pipeline stages:
    1. SortBy(field='filename', reverse=False)
    2. Skip(skip=5)
    3. Limit(limit=5)
    4. MatchTag(tag='train')
    5. Match(filter={'_id': 'XXXXXX'})
    6. Exclude(sample_ids=['FFFFFFFFFFFFFFFFFFFFFFFF', 'FFFFFFFFFFFFFFFFFFFFFFFF', 'FFFFFFFFFFFFFFFFFFFFFFFF', ...])
```

Closes #219