### PR TITLE
No actions on draft PRs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ on:
     tags:
       - v*
   pull_request:
-    types: [review_requested, ready_for_review]
+    types: [synchronize, ready_for_review]
     branches:
       - develop
       - rel-*
@@ -19,6 +19,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-18.04
+    if: github.event.pull_request.draft == false
     steps:
       - name: Clone fiftyone
         uses: actions/checkout@v2
@@ -40,6 +41,7 @@ jobs:
 
   test:
     runs-on: ubuntu-18.04
+    if: github.event.pull_request.draft == false
     needs: build
     strategy:
       fail-fast: false


### PR DESCRIPTION
This update to the build workflow should prevent actions from being run on PRs that are not ready for review (in draft mode) and do not have a review(er) explicitly requested.

See https://help.github.com/en/actions/reference/events-that-trigger-workflows#pull-request-event-pull_request.