### PR TITLE
Fix broken link

### DIFF
--- a/docs/source/substitutions.rst
+++ b/docs/source/substitutions.rst
@@ -1,7 +1,10 @@
 .. |Dataset| replace:: :class:`Dataset <fiftyone.core.dataset.Dataset>`
 
 .. |Dataset2| replace:: ``Dataset``
-.. _Dataset2: ../user_guide/basics.html#what-is-a-fiftyone-dataset-and-what-can-it-do-for-me 
+.. _Dataset2: ../user_guide/basics.html#what-is-a-fiftyone-dataset 
+
+.. |Dataset3| replace:: ``Dataset``
+.. _Dataset3: ../../user_guide/basics.html#what-is-a-fiftyone-dataset 
 
 .. |DatasetView| replace:: :class:`DatasetView <fiftyone.core.view.DatasetView>`
 

--- a/docs/source/user_guide/dataset_creation/index.rst
+++ b/docs/source/user_guide/dataset_creation/index.rst
@@ -11,7 +11,7 @@ also provides support for easily create custom data formats as well.
 .. note::
 
 
-    When you create a FiftyOne |Dataset2|_, its samples and all of their fields
+    When you create a FiftyOne |Dataset3|_, its samples and all of their fields
     (metadata, labels, custom fields, etc.) are written to FiftyOne's backing
     database.
 


### PR DESCRIPTION
The link to the `Basics` user guide section `What is a FiftyOne Dataset?` was broken because the header was renamed and because one file linked to the wrong location.