### PR TITLE
Fixing bug when creating datasets with default name

### DIFF
--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -159,12 +159,16 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
     raw media is stored on disk and the dataset provides paths to the data.
 
     Args:
-        name: a name for the dataset
+        name (None): the name of the dataset. By default,
+            :func:`get_default_dataset_name` is used
         persistent (False): whether the dataset will persist in the database
-            once the session terminates.
+            once the session terminates
     """
 
-    def __init__(self, name, persistent=False, _create=True):
+    def __init__(self, name=None, persistent=False, _create=True):
+        if name is None:
+            name = get_default_dataset_name()
+
         self._name = name
         self._deleted = False
 

--- a/fiftyone/core/singleton.py
+++ b/fiftyone/core/singleton.py
@@ -41,14 +41,15 @@ class DatasetSingleton(type):
         cls._instances = weakref.WeakValueDictionary()
         return cls
 
-    def __call__(cls, name, _create=True, *args, **kwargs):
+    def __call__(cls, name=None, _create=True, *args, **kwargs):
         if (
             _create
             or name not in cls._instances
             or cls._instances[name].deleted
         ):
-            instance = cls.__new__(cls, name)
-            instance.__init__(name, _create=_create, *args, **kwargs)
+            instance = cls.__new__(cls)
+            instance.__init__(name=name, _create=_create, *args, **kwargs)
+            name = instance.name  # `__init__` may have changed `name`
             cls._instances[name] = instance
 
         return cls._instances[name]


### PR DESCRIPTION
Fixes a bug where `fo.Dataset()` was supposed to create a dataset with a default name, but would actually fail. Now it works as expected