### PR TITLE
Fix server on macOS

### DIFF
--- a/fiftyone/core/service.py
+++ b/fiftyone/core/service.py
@@ -23,7 +23,6 @@ import logging
 import multiprocessing
 import os
 import re
-import socket
 import subprocess
 import sys
 
@@ -151,13 +150,12 @@ class Service(object):
         )
         def find_port():
             child_connections = itertools.chain.from_iterable(  # flatten
-                child.connections()
+                child.connections(kind="tcp")
                 for child in self.child.children(recursive=True)
             )
             for conn in child_connections:
                 if (
-                    conn.type == socket.SOCK_STREAM  # TCP
-                    and not conn.raddr  # not connected to a remote socket
+                    not conn.raddr  # not connected to a remote socket
                     and conn.status == psutil.CONN_LISTEN
                 ):
                     local_port = conn.laddr[1]


### PR DESCRIPTION
The server was failing to start on macOS due to https://psutil.readthedocs.io/en/latest/#psutil.net_connections requiring root access.

https://voxel51.slack.com/archives/C0128P8LGGK/p1594321614007800