### PR TITLE
Adding data field to store arbitrary dict data in labels

### DIFF
--- a/fiftyone/core/labels.py
+++ b/fiftyone/core/labels.py
@@ -136,6 +136,7 @@ class Classification(ImageLabel):
         label (None): the label string
         confidence (None): a confidence in ``[0, 1]`` for the label
         logits (None): logits associated with the labels
+        data ({}): a dict of additional data
     """
 
     meta = {"allow_inheritance": True}
@@ -143,6 +144,7 @@ class Classification(ImageLabel):
     label = fof.StringField()
     confidence = fof.FloatField()
     logits = fof.VectorField()
+    data = fof.DictField()
 
     def to_image_labels(self, attr_name="label"):
         """Returns an ``eta.core.image.ImageLabels`` representation of this
@@ -176,6 +178,7 @@ class Detection(ODMEmbeddedDocument):
         confidence (None): a confidence in ``[0, 1]`` for the label
         attributes ({}): a dict mapping attribute names to :class:`Attribute`
             instances
+        data ({}): a dict of additional data
     """
 
     meta = {"allow_inheritance": True}
@@ -184,6 +187,7 @@ class Detection(ODMEmbeddedDocument):
     bounding_box = fof.VectorField()
     confidence = fof.FloatField()
     attributes = fof.DictField(fof.EmbeddedDocumentField(Attribute))
+    data = fof.DictField()
 
     def get_attribute_value(self, attr_name, default=no_default):
         """Gets the value of the attribute with the given name.


### PR DESCRIPTION
**DEPRECATED IN FAVOR OF https://github.com/voxel51/fiftyone/pull/263**

New feature for discussion: ability to store arbitrary data in a `data` field of `Classification` and `Detection` labels:

```py

import fiftyone as fo

sample = fo.Sample(filepath="path/to/image.png")

classification = fo.Classification(
    label="weather",
    data={
        "powerball_numbers": [27, 47, 61, 62, 69, 4]
    }
)

detection = fo.Detection(
    label="cat",
    bounding_box=[0.5, 0.5, 0.4, 0.3],
    attributes={
        "age": fo.NumericAttribute(value=51),
        "mood": fo.CategoricalAttribute(value="salty"),
    },
    data={
        "quality": 89.7,
        "keypoints": [[31, 27], [63, 72]],
        "geo_json": {
            "type": "Feature",
            "geometry": {
                "type": "Point",
                "coordinates": [125.6, 10.1]
            },
            "properties": {
                "name": "camera"
            }
        }
    }
)

sample["classification"] = classification
sample["detections"] = fo.Detections(detections=[detection])

print(sample)
```

```
<Sample: {
    'id': None,
    'filepath': 'path/to/image.png',
    'tags': [],
    'metadata': None,
    'classification': <Classification: {
        'label': 'weather',
        'confidence': None,
        'logits': None,
        'data': BaseDict({'powerball_numbers': [27, 47, 61, 62, 69, 4]}),
    }>,
    'detections': <Detections: {
        'detections': BaseList([
            <Detection: {
                'label': 'cat',
                'bounding_box': array([0.5, 0.5, 0.4, 0.3]),
                'confidence': None,
                'attributes': BaseDict({
                    'age': <NumericAttribute: {'value': 51.0}>,
                    'mood': <CategoricalAttribute: {'value': 'salty', 'confidence': None, 'logits': None}>,
                }),
                'data': BaseDict({
                    'quality': 89.7,
                    'keypoints': [[31, 27], [63, 72]],
                    'geo_json': {
                        'type': 'Feature',
                        'geometry': {'type': 'Point', 'coordinates': [125.6, 10.1]},
                        'properties': {'name': 'camera'},
                    },
                }),
            }>,
        ]),
    }>,
}>
```
