### PR TITLE
Supporting legacy dataset types

### DIFF
--- a/fiftyone/zoo/__init__.py
+++ b/fiftyone/zoo/__init__.py
@@ -459,25 +459,23 @@ class ZooDatasetInfo(etas.Serializable):
             a :class:`ZooDatasetInfo`
         """
         try:
-            # @legacy
+            # @legacy field name
             zoo_dataset = d["zoo_dataset_cls"]
         except KeyError:
             zoo_dataset = d["zoo_dataset"]
 
         try:
-            # @legacy
+            # @legacy field name
             dataset_type = d["format_cls"]
         except KeyError:
             dataset_type = d["dataset_type"]
 
-        # @legacy
-        _dataset_types = "fiftyone.types.dataset_types"
+        # @legacy dataset types
+        _dt = "fiftyone.types.dataset_types"
         if dataset_type.endswith(".ImageClassificationDataset"):
-            dataset_type = (
-                _dataset_types + ".FiftyOneImageClassificationDataset"
-            )
+            dataset_type = _dt + ".FiftyOneImageClassificationDataset"
         if dataset_type.endswith(".ImageDetectionDataset"):
-            dataset_type = _dataset_types + ".FiftyOneImageDetectionDataset"
+            dataset_type = _dt + ".FiftyOneImageDetectionDataset"
 
         zoo_dataset = etau.get_class(zoo_dataset)()
         dataset_type = etau.get_class(dataset_type)()


### PR DESCRIPTION
https://github.com/voxel51/fiftyone/pull/239 renamed a couple dataset types:

 ```
fiftyone.types.ImageClassificationDataset --> fiftyone.types.FiftyOneImageClassificationDataset
fiftyone.types.ImageDetectionDataset --> fiftyone.types.FiftyOneImageDetectionDataset
```

This is potentially problematic for FO users that downloaded zoo datasets using a previous version of FO and are now trying to load their datasets using a newer version, since loading a zoo dataset requires reading the `dataset_type` of the dataset from the `info.json` file written in that directory.

This PR adds a quick fix that monkey patches the old dataset types to their new names _when loading zoo datasets_, so that users with older zoo datasets should still be able to load them
