### PR TITLE
Check that installed fiftyone version matches setup.py when building docs

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -9,8 +9,20 @@ https://www.sphinx-doc.org/en/master/usage/configuration.html
 |
 """
 
+import re
+
 import fiftyone.constants as foc
 
+
+with open("../../setup.py") as f:
+    setup_version = re.search(r'version="(.+?)"', f.read()).group(1)
+
+if setup_version != foc.VERSION:
+    raise RuntimeError(
+        "FiftyOne version in setup.py (%r) does not match installed version "
+        "(%r). If this is a dev install, reinstall with `pip install -e .` "
+        "and try again." % (setup_version, foc.VERSION)
+    )
 
 # -- Path setup --------------------------------------------------------------
 


### PR DESCRIPTION
Apparently the fiftyone version is only pulled from setup.py when `pip install -e` is run - if you update fiftyone but don't reinstall it, `fiftyone --version` and the documentation will still report the old version. This is probably why the website mentioned fiftyone 0.2.1 until 0.4.0 was deployed.