### PR TITLE
ViewStage fixes

### DIFF
--- a/fiftyone/core/stages.py
+++ b/fiftyone/core/stages.py
@@ -335,7 +335,7 @@ class MatchTags(ViewStage):
     """Returns a view containing the samples that have any of the given
     tags.
 
-    To match samples that contain a single, use :class:`MatchTag`
+    To match samples that contain a single, use :class:`MatchTag`.
 
     Args:
         tags: an iterable of tags


### PR DESCRIPTION
Fixes two bugs related to `ViewStage`s:

**Bug 1**
The docs for the `Limit` stage suggested that a non-positive `limit` could be provided, in which case an empty `DatasetView` would be returned. However, this was not actually allowed.

I updated so that this is now allowable:

```py
import fiftyone.zoo as foz

dataset = foz.load_zoo_dataset("cifar10", split="test")

dataset[5:5]  # empty view
```

```
Dataset:        cifar10-test
Num samples:    0
Tags:           []
Sample fields:
    filepath:     fiftyone.core.fields.StringField
    tags:         fiftyone.core.fields.ListField(fiftyone.core.fields.StringField)
    metadata:     fiftyone.core.fields.EmbeddedDocumentField(fiftyone.core.metadata.Metadata)
    ground_truth: fiftyone.core.fields.EmbeddedDocumentField(fiftyone.core.labels.Classification)
Pipeline stages:
    1. Skip(skip=5)
    2. Limit(limit=0)
```

**Bug 2**
Resolves https://github.com/voxel51/fiftyone/issues/308.

The issue was that `_kwargs()` can now contain `ViewExpression`s, which must be appropriately serialized.

```py
import fiftyone as fo
from fiftyone import ViewField as F
import fiftyone.core.stages as fos

dataset = fo.Dataset()

view = dataset.list_filter("ground_truth.detections", F("confidence") > 0.75)

stage = view.stages[0]

d = stage._serialize()

stage2 = fos.ViewStage._from_dict(d)

print(stage)
print(stage2)

print(stage._serialize())
print(stage2._serialize())
```

```
ListFilter(field='predictions.detections', filter={'$gt': ['$$this.confidence', 0.75]})
ListFilter(field='predictions.detections', filter={'$gt': ['$$this.confidence', 0.75]})
{'kwargs': {'field': 'predictions.detections', 'filter': {'$gt': ['$$this.confidence', 0.75]}}, '_cls': 'fiftyone.core.stages.ListFilter'}
{'kwargs': {'field': 'predictions.detections', 'filter': {'$gt': ['$$this.confidence', 0.75]}}, '_cls': 'fiftyone.core.stages.ListFilter'}
```

Note that `_serialize()` and `_from_dict()` are not fully symmetric:

```
print(type(stage.filter))
print(type(stage2.filter))
```

```
<class 'fiftyone.core.expressions.ViewExpression'>
<class 'dict'>
```

When parsing the JSON dict, the filter is just stored as a MongoDB dict, not parsed into a `ViewExpression`. This is fine, as the two representations are equivalent, and the only reason to use `ViewExpression` is to make the syntax of creating the `ViewExpression` cleaner. In this case, the expression has already been constructed.