### PR TITLE
Removing broken/unused `iter_samples_with_index()` method

### DIFF
--- a/fiftyone/core/view.py
+++ b/fiftyone/core/view.py
@@ -134,21 +134,6 @@ class DatasetView(foc.SampleCollection):
                     "due to an invalid stage in the DatasetView"
                 ) from e
 
-    def iter_samples_with_index(self):
-        """Returns an iterator over the samples in the view together with
-        their integer index in the collection.
-
-        Returns:
-            an iterator that emits ``(index, sample)`` tuples, where:
-                - ``index`` is an integer index relative to the offset, where
-                  ``offset <= view_idx < offset + limit``
-                - ``sample`` is a :class:`fiftyone.core.sample.Sample`
-        """
-        offset = self._get_latest_offset()
-        iterator = self.iter_samples()
-        for idx, sample in enumerate(iterator, start=offset):
-            yield idx, sample
-
     def get_field_schema(self, ftype=None, embedded_doc_type=None):
         """Returns a schema dictionary describing the fields of the samples in
         the view.
@@ -280,10 +265,3 @@ class DatasetView(foc.SampleCollection):
         view = copy(self)
         view._stages.append(stage)
         return view
-
-    def _get_latest_offset(self):
-        for stage in self._stages[::-1]:
-            if "$skip" in stage:
-                return stage["$skip"]
-
-        return 0


### PR DESCRIPTION
The `DatasetView.iter_samples_with_index()` method is unused, and the underlying `DatasetView. _get_latest_offset()` method has been flat out broken for awhile now, ever since `ViewStage` was introduced.

I believe the intention was for this method to be used to implement pagination, e.g., in `fiftyone/server/main.py`, but it looks like that module rolls its own pagination https://github.com/voxel51/fiftyone/blob/a193562c0009f7805ed392cfe1a05c185d9675b7/fiftyone/server/main.py#L166

If we want to provide an abstraction for efficient pagination, it's probably best done without the hack of checking for a `$skip` stage in the view, since `$skip` requires a scan of all documents in the collection, and thus is not terribly desirable as a mechanism to read pages from a view