### PR TITLE
Build a non-universal wheel (i.e. Python 3 only) by default

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,8 +13,6 @@ from wheel.bdist_wheel import bdist_wheel
 class BdistWheelCustom(bdist_wheel):
     def finalize_options(self):
         bdist_wheel.finalize_options(self)
-        # pure Python, so build a wheel for any Python version
-        self.universal = True
         # make just the wheel require these packages, since they aren't needed
         # for a development installation
         self.distribution.install_requires += [


### PR DESCRIPTION
Attempted installs under Python 2 will fail sooner now.
(This was a holdover from when the core package had some Python 2 support.)