### PR TITLE
Remove tokens from install instructions

### DIFF
--- a/docs/source/getting_started/install.rst
+++ b/docs/source/getting_started/install.rst
@@ -39,7 +39,7 @@ virtual environment that you are using, then run:
 .. code-block:: shell
 
    pip install --upgrade pip setuptools wheel
-   pip install --index pypi.voxel51.com fiftyone
+   pip install --index https://pypi.voxel51.com fiftyone
 
 This will install FiftyOne and all of its dependencies, which may take some
 time. Once this has completed, you can verify that FiftyOne is installed in
@@ -117,7 +117,7 @@ upgrade an existing FiftyOne installation:
 
 .. code-block:: shell
 
-   pip install --index pypi.voxel51.com --upgrade fiftyone
+   pip install --index https://pypi.voxel51.com --upgrade fiftyone
 
 Uninstalling FiftyOne
 ---------------------
@@ -154,13 +154,13 @@ these packages must be installed *after* the `fiftyone` package; if you install
 
     .. code-block:: shell
 
-      pip install --index pypi.voxel51.com fiftyone-db-ubuntu1604
+      pip install --index https://pypi.voxel51.com fiftyone-db-ubuntu1604
 
   .. tab:: Debian 9
 
     .. code-block:: shell
 
-      pip install --index pypi.voxel51.com fiftyone-db-debian9
+      pip install --index https://pypi.voxel51.com fiftyone-db-debian9
 
 Manual installation
 ~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Removing token from install instructions slipped through the cracks.. @lethosor is `pip install --index pypi.voxel51.com fiftyone` valid or does it need to be `pip install --index https://pypi.voxel51.com fiftyone`?