### PR TITLE
Deleted Datasets and python interpreters

### DIFF
--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -195,7 +195,12 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
         self.remove_sample(sample_id)
 
     def __getattribute__(self, name):
-        if name in ["name", "deleted", "_name", "_deleted"]:
+        if name.startswith("__") or name in [
+            "name",
+            "deleted",
+            "_name",
+            "_deleted",
+        ]:
             return super().__getattribute__(name)
 
         if getattr(self, "_deleted", False):


### PR DESCRIPTION
Funky bug that @brimoor found. The interpreter tries to access the `Dataset.__class__` attribute of a deleted dataset.

Test that is now working: open a `python`/`ipython` terminal:
```
In [1]: import fiftyone as fo 
   ...:  
   ...: dataset1 = fo.Dataset("test") 
   ...: dataset1.persistent = True 
   ...: dataset1.delete()                                             

In [2]: dataset1 = 51 
```

Closes #352 