### PR TITLE
Ignore _rand when getting labels

### DIFF
--- a/fiftyone/server/main.py
+++ b/fiftyone/server/main.py
@@ -270,6 +270,7 @@ def _numeric_bounds(view, numerics):
 
 def _get_label_fields(view):
     pipeline = [
+        {"$project": {"_rand": False}},
         {"$project": {"field": {"$objectToArray": "$$ROOT"}}},
         {"$unwind": "$field"},
         {"$group": {"_id": {"field": "$field.k", "cls": "$field.v._cls"}}},


### PR DESCRIPTION
## What changes are proposed in this pull request?

Filter out `_rand` the server's labels pipleine. This removes `_rand` from the Scalars section of the sidebar. I do not know enough about our ODM to resolve the introduction of `_rand` in `get_field_schema()`. I tried, but to no avail. Heading back to App work.

## How is this patch tested? If it is not, in a single sentence please explain why.

Tests exist.

## Release Notes

### Is this a user-facing change?

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.
