### PR TITLE
Small bugfix in ViewStage repr

### DIFF
--- a/fiftyone/core/stages.py
+++ b/fiftyone/core/stages.py
@@ -16,16 +16,6 @@ from fiftyone.core.odm.sample import default_sample_fields
 import eta.core.utils as etau
 
 
-class _StageRepr(reprlib.Repr):
-    def repr_ViewExpression(self, expr, level):
-        return self.repr1(expr.to_mongo(), level=level)
-
-
-_aRepr = _StageRepr()
-_aRepr.maxlevel = 2
-_aRepr.maxlist = 3
-
-
 class ViewStage(object):
     """Abstract base class for all :class:`fiftyone.core.view.DatasetView`
     stages.
@@ -45,7 +35,7 @@ class ViewStage(object):
 
     def __repr__(self):
         kwargs_str = ", ".join(
-            ["%s=%s" % (k, _aRepr.repr(v)) for k, v in self._kwargs().items()]
+            ["%s=%s" % (k, _repr.repr(v)) for k, v in self._kwargs().items()]
         )
 
         return "%s(%s)" % (self.__class__.__name__, kwargs_str)
@@ -648,3 +638,18 @@ class Take(ViewStage):
 
     def _kwargs(self):
         return {"size": self._size}
+
+
+class _ViewStageRepr(reprlib.Repr):
+    def repr_ViewExpression(self, expr, level):
+        return self.repr1(expr.to_mongo(), level=level - 1)
+
+
+_repr = _ViewStageRepr()
+_repr.maxlevel = 2
+_repr.maxdict = 3
+_repr.maxlist = 3
+_repr.maxtuple = 3
+_repr.maxset = 3
+_repr.maxstring = 30
+_repr.maxother = 30


### PR DESCRIPTION
Fixes a small bug in `ViewStage.__repr__()`:

Per the [reprlib docs](https://docs.python.org/3/library/reprlib.html#repr-objects), `repr_TYPE` needs to be implemented as follows:

```
Repr.repr_TYPE(obj, level)

    Formatting methods for specific types are implemented as methods with a name based on the
    type name. In the method name, TYPE is replaced by '_'.join(type(obj).__name__.split()).
    Dispatch to these methods is handled by repr1(). Type-specific methods which need to recursively
    format a value should call self.repr1(subobj, level - 1).
```

The current implementation passed `level`, not `level - 1`, which could have resulted in more than `maxlevel` levels being rendered. In practice, since `maxstring == 30`, this couldn't have continued on for too long; but, nonetheless, now we won't get `> maxlevel` levels.

I also took the opportunity to limit other iterable types to a length of 3, and used a style-compliant variable name (`_repr`, not `aRepr`).