### PR TITLE
App: Fixes adding ViewStages to the ViewBar

### DIFF
--- a/electron/app/components/ViewBar/ViewStage/viewStageMachine.ts
+++ b/electron/app/components/ViewBar/ViewStage/viewStageMachine.ts
@@ -147,6 +147,7 @@ const viewStageMachine = Machine(
                       n.toLowerCase().includes(stage.toLowerCase())
                     ),
                 currentResult: null,
+                focusOnInit: false,
               }),
               "focusInput",
               sendParent((ctx) => ({


### PR DESCRIPTION
## What changes are proposed in this pull request?

A regression fix to the `viewStageMachine` of the `ViewBar`. Currently, users cannot add stages to an existing view with more than one stage when the stage being added has more than one parameter.

## How is this patch tested? If it is not, in a single sentence please explain why.

A test framework has not been established for the App, yet.

## Release Notes

Allow completing a new ViewStage in the ViewBar when more than one ViewStage already exists and the new ViewStage being added has more than one parameter. Previously, the ViewStage would fall back to stage selection.

### Is this a user-facing change?

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

### What areas of FiftyOne does this PR affect?

-   [x] `App`: FiftyOne application changes
-   [ ] `Build`: Build and test infrastructure changes
-   [ ] `Core`: Core `fiftyone` Python library changes
-   [ ] `Documentation`: FiftyOne documentation changes
-   [ ] `Other`

### Should this PR be mentioned in the release notes? If so, please choose on category:

-   [ ] `breaking-change` - The PR will be mentioned in the "Breaking Changes"
        section
-   [ ] `feature` - A new user-facing feature worth mentioning in the release
        notes
-   [x] `bug-fix` - A user-facing bug fix worth mentioning in the release notes
-   [ ] `documentation` - A user-facing documentation change worth mentioning
        in the release notes
