### PR TITLE
Remove deleted branch from Chromatic workflow PR branches

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -14,7 +14,6 @@ on:
       - develop
       - rel-*
       - release-*
-      - team-setup
     paths:
       - electron/
       - .github/workflows/chromatic.yml


### PR DESCRIPTION
## What changes are proposed in this pull request?

The initial App design shipment has been released, and the working branch `team-setup` is no longer needed in the Chromatic workflow.

## How is this patch tested? If it is not, in a single sentence please explain why.

N/A

## Release Notes

### Is this a user-facing change?

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.
