### PR TITLE
App: Fit last row to match tiling threshold in samples list

### DIFF
--- a/electron/app/utils/tile.ts
+++ b/electron/app/utils/tile.ts
@@ -1,4 +1,6 @@
-export default function tile(data, newHasMore, state, host) {
+const THRESHOLD = 5;
+
+export default function tile(data, newHasMore, state) {
   const samplesToFit = [...state.remainder, ...data];
   const rows = [...state.rows];
   const newRows = [];
@@ -14,7 +16,7 @@ export default function tile(data, newHasMore, state, host) {
       continue;
     }
 
-    if (currentWidth / currentHeight >= 5) {
+    if (currentWidth / currentHeight >= THRESHOLD) {
       newRows.push(currentRow);
       currentRow = [s];
       currentWidth = s.width;
@@ -26,7 +28,6 @@ export default function tile(data, newHasMore, state, host) {
   }
 
   let remainder = [];
-  const newRemainder = Boolean(newHasMore) ? currentRow : [];
   if (!Boolean(newHasMore) && currentRow.length) newRows.push(currentRow);
   else remainder = currentRow;
 
@@ -34,10 +35,14 @@ export default function tile(data, newHasMore, state, host) {
     const row = newRows[i];
     const columns = [];
     const baseHeight = row[0].height;
-    const refWidth = row.reduce(
-      (acc, val) => acc + (baseHeight / val.height) * val.width,
-      0
-    );
+    const refWidth =
+      !Boolean(newHasMore) && i === String(newRows.length - 1)
+        ? baseHeight * THRESHOLD
+        : row.reduce(
+            (acc, val) => acc + (baseHeight / val.height) * val.width,
+            0
+          );
+
     for (const j in row) {
       const sample = row[j];
       const sampleWidth = (baseHeight * sample.width) / sample.height;


### PR DESCRIPTION
## What changes are proposed in this pull request?

Fit the last row to match the tiling threshold when tiling.

### Before

![Screenshot from 2020-08-12 12-56-13](https://user-images.githubusercontent.com/19821840/90044560-cddbd800-dc9b-11ea-8bb0-95215569fcfb.png)
![Screenshot from 2020-08-12 12-57-02](https://user-images.githubusercontent.com/19821840/90044552-ccaaab00-dc9b-11ea-9b93-86d3cc36f54b.png)

### After

![Screenshot from 2020-08-12 12-54-31](https://user-images.githubusercontent.com/19821840/90044573-d16f5f00-dc9b-11ea-89a9-67addcc1f23b.png)
![Screenshot from 2020-08-12 12-54-11](https://user-images.githubusercontent.com/19821840/90044574-d207f580-dc9b-11ea-9b0a-4fcb047e39ac.png)

## How is this patch tested? If it is not, in a single sentence please explain why.

A test framework for the App does not exist, yet.

## Release Notes

### Is this a user-facing change?

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

Consistently size the last row of samples in the sample listing.

### What areas of FiftyOne does this PR affect?

-   [x] `App`: FiftyOne application changes
-   [ ] `Build`: Build and test infrastructure changes
-   [ ] `Core`: Core `fiftyone` Python library changes
-   [ ] `Documentation`: FiftyOne documentation changes
-   [ ] `Other`

### Should this PR be mentioned in the release notes? If so, please choose on category:

-   [ ] `breaking-change` - The PR will be mentioned in the "Breaking Changes"
        section
-   [ ] `feature` - A new user-facing feature worth mentioning in the release
        notes
-   [x] `bug-fix` - A user-facing bug fix worth mentioning in the release notes
-   [ ] `documentation` - A user-facing documentation change worth mentioning
        in the release notes
