### PR TITLE
Fix session updates from App changes

### DIFF
--- a/fiftyone/core/session.py
+++ b/fiftyone/core/session.py
@@ -222,6 +222,7 @@ class Session(foc.HasClient):
     # PRIVATE #################################################################
 
     def _update_state(self):
+        # see fiftyone.core.client if you would like to understand this
         self.state = self.state
 
 

--- a/fiftyone/core/session.py
+++ b/fiftyone/core/session.py
@@ -116,9 +116,6 @@ class Session(foc.HasClient):
     _HC_ATTR_TYPE = StateDescription
 
     def __init__(self, dataset=None, view=None, port=5151, remote=False):
-        if session is not None:
-            raise ValueError("Only one session is permitted")
-
         self._port = port
         self._remote = remote
 

--- a/tests/isolated/server_tests.py
+++ b/tests/isolated/server_tests.py
@@ -172,6 +172,15 @@ class ServerServiceTests(unittest.TestCase):
         self.assertIs(len(client), 1)
         self.assertEqual(client[0]["data"], [{"key": "null", "count": 2}])
 
+    def step_sessions(self):
+        other_session = Session(remote=True)
+        other_session.dataset = self.dataset
+        self.wait_for_response(session=True)
+        self.assertEqual(str(self.session.dataset), str(other_session.dataset))
+        other_session.view = self.dataset.limit(1)
+        self.wait_for_response(session=True)
+        self.assertEqual(str(self.session.view), str(other_session.view))
+
     def test_steps(self):
         for name, step in self.steps():
             try:


### PR DESCRIPTION
## What changes are proposed in this pull request?

Some logic seems to have been written  in the `Session` class that ignored `StateDescription` updates from other clients (the App, in this case). This fixes that. So we now have true bidirectional state communication between a `Session` and the App.

I have removed the session singleton restriction in service of writing tests, primarily, although I can tweak that because it could certainly cause issues in messy scripting by users due to the asynchronous nature of these updates.

## How is this patch tested? If it is not, in a single sentence please explain why.

A basic test has been added to the server tests. Dataset and view checks are included in the test.

## Release Notes

### Is this a user-facing change?

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

Feature
* `Session` is no longer a singleton, i.e. more than one `Session` instance be created.

Bug
* `Session` instances are kept in sync with changes made in the App's view bar.

### What areas of FiftyOne does this PR affect?

-   [x] `App`: FiftyOne application changes
-   [ ] `Build`: Build and test infrastructure changes
-   [x] `Core`: Core `fiftyone` Python library changes
-   [ ] `Documentation`: FiftyOne documentation changes
-   [ ] `Other`

### Should this PR be mentioned in the release notes? If so, please choose on category:

-   [ ] `breaking-change` - The PR will be mentioned in the "Breaking Changes"
        section
-   [x] `feature` - A new user-facing feature worth mentioning in the release
        notes
-   [x] `bug-fix` - A user-facing bug fix worth mentioning in the release notes
-   [ ] `documentation` - A user-facing documentation change worth mentioning
        in the release notes
