### PR TITLE
Renaming list_dataset_names() to list_datasets()

### DIFF
--- a/docs/source/user_guide/using_datasets.rst
+++ b/docs/source/user_guide/using_datasets.rst
@@ -27,13 +27,13 @@ Instantiating a |Dataset| object creates a **new** dataset.
     dataset2 = fo.Dataset(name="my_second_dataset")
     dataset3 = fo.Dataset()  # generates a default unique name
 
-Check to see what datasets exist at any time via :meth:`list_dataset_names()
-<fiftyone.core.dataset.list_dataset_names>`:
+Check to see what datasets exist at any time via :meth:`list_datasets()
+<fiftyone.core.dataset.list_datasets>`:
 
 .. code-block:: python
     :linenos:
 
-    print(fo.list_dataset_names())
+    print(fo.list_datasets())
     # ['my_first_dataset', 'my_second_dataset', '2020.08.04.12.36.29']
 
 Load a dataset using
@@ -85,7 +85,7 @@ In a new Python session:
 
     import fiftyone as fo
 
-    print(fo.list_dataset_names())
+    print(fo.list_datasets())
     # ['my_first_dataset']
 
 Note that the `my_second_dataset` and `2020.08.04.12.36.29` datasets have been
@@ -145,7 +145,7 @@ attributes, but calling any other attribute or method will raise a
     dataset = fo.load_dataset("my_first_dataset")
     dataset.delete()
 
-    print(fo.list_dataset_names())
+    print(fo.list_datasets())
     # []
 
     print(dataset.name)

--- a/fiftyone/__public__.py
+++ b/fiftyone/__public__.py
@@ -16,7 +16,7 @@ config = foc.load_config()
 
 from .core.dataset import (
     Dataset,
-    list_dataset_names,
+    list_datasets,
     dataset_exists,
     load_dataset,
     delete_dataset,

--- a/fiftyone/core/cli.py
+++ b/fiftyone/core/cli.py
@@ -284,7 +284,7 @@ class DatasetsListCommand(Command):
 
     @staticmethod
     def execute(parser, args):
-        datasets = fod.list_dataset_names()
+        datasets = fod.list_datasets()
 
         if datasets:
             for dataset in sorted(datasets):

--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -33,7 +33,7 @@ import fiftyone.utils.data as foud
 logger = logging.getLogger(__name__)
 
 
-def list_dataset_names():
+def list_datasets():
     """Returns the list of available FiftyOne datasets.
 
     Returns:
@@ -89,7 +89,7 @@ def get_default_dataset_name():
     """
     now = datetime.datetime.now()
     name = now.strftime("%Y.%m.%d.%H.%M.%S")
-    if name in list_dataset_names():
+    if name in list_datasets():
         name = now.strftime("%Y.%m.%d.%H.%M.%S.%f")
 
     return name
@@ -130,7 +130,7 @@ def delete_dataset(name):
 
 def delete_non_persistent_datasets():
     """Deletes all non-persistent datasets."""
-    for dataset_name in list_dataset_names():
+    for dataset_name in list_datasets():
         dataset = load_dataset(dataset_name)
         if not dataset.persistent:
             dataset.delete()

--- a/tests/unittests.py
+++ b/tests/unittests.py
@@ -238,7 +238,7 @@ class ScopedObjectsSynchronizationTest(unittest.TestCase):
             fo.load_dataset(dataset_name)
 
         def check_create_dataset_via_load():
-            self.assertIn(dataset_name, fo.list_dataset_names())
+            self.assertIn(dataset_name, fo.list_datasets())
             dataset = fo.load_dataset(dataset_name)
 
         check_create_dataset()
@@ -657,34 +657,34 @@ class MultiProcessSynchronizationTest(unittest.TestCase):
 
 class DatasetTest(unittest.TestCase):
     @drop_datasets
-    def test_list_dataset_names(self):
-        self.assertIsInstance(fo.list_dataset_names(), list)
+    def test_list_datasets(self):
+        self.assertIsInstance(fo.list_datasets(), list)
 
     @drop_datasets
     def test_delete_dataset(self):
-        IGNORED_DATASET_NAMES = fo.list_dataset_names()
+        IGNORED_DATASET_NAMES = fo.list_datasets()
 
-        def list_dataset_names():
+        def list_datasets():
             return [
                 name
-                for name in fo.list_dataset_names()
+                for name in fo.list_datasets()
                 if name not in IGNORED_DATASET_NAMES
             ]
 
         dataset_names = ["test_%d" % i for i in range(10)]
 
         datasets = {name: fo.Dataset(name) for name in dataset_names}
-        self.assertListEqual(list_dataset_names(), dataset_names)
+        self.assertListEqual(list_datasets(), dataset_names)
 
         name = dataset_names.pop(0)
         datasets[name].delete()
-        self.assertListEqual(list_dataset_names(), dataset_names)
+        self.assertListEqual(list_datasets(), dataset_names)
         with self.assertRaises(fod.DoesNotExistError):
             len(datasets[name])
 
         name = dataset_names.pop(0)
         fo.delete_dataset(name)
-        self.assertListEqual(list_dataset_names(), dataset_names)
+        self.assertListEqual(list_datasets(), dataset_names)
         with self.assertRaises(fod.DoesNotExistError):
             len(datasets[name])
 


### PR DESCRIPTION
Renames `fo.list_dataset_names()` to `fo.list_datasets()`.

The latter is cleaner, fewer characters, and also more consistent with other methods like `fo.load_dataset(name)` and `foz.load_zoo_dataset(name)`, which take dataset names as input but don't say, for example, `fo.load_dataset_by_name()`, which is unnecessary.