### PR TITLE
Allowing a single sample ID in Select() and Exclude() stages

### DIFF
--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -212,7 +212,7 @@ class SampleCollection(object):
         """Excludes the samples with the given IDs from the collection.
 
         Args:
-            sample_ids: an iterable of sample IDs
+            sample_ids: a sample ID or iterable of sample IDs
 
         Returns:
             a :class:`fiftyone.core.view.DatasetView`
@@ -362,7 +362,7 @@ class SampleCollection(object):
         """Returns a view containing only the samples with the given IDs.
 
         Args:
-            sample_ids: an iterable of sample IDs
+            sample_ids: a sample ID or iterable of sample IDs
 
         Returns:
             a :class:`fiftyone.core.view.DatasetView`

--- a/fiftyone/core/stages.py
+++ b/fiftyone/core/stages.py
@@ -109,6 +109,8 @@ class Exclude(ViewStage):
         else:
             self._sample_ids = list(sample_ids)
 
+        self._validate()
+
     @property
     def sample_ids(self):
         """The list of sample IDs to exclude."""
@@ -129,6 +131,10 @@ class Exclude(ViewStage):
     @classmethod
     def _params(cls):
         return [{"name": "sample_ids", "type": ["list", "str"]}]
+
+    def _validate(self):
+        # ensures ObjectIDs are valid
+        _ = self.to_mongo()
 
 
 class ExcludeFields(ViewStage):
@@ -514,6 +520,8 @@ class Select(ViewStage):
         else:
             self._sample_ids = list(sample_ids)
 
+        self._validate()
+
     @property
     def sample_ids(self):
         """The list of sample IDs to select."""
@@ -534,6 +542,10 @@ class Select(ViewStage):
     @classmethod
     def _params(cls):
         return [{"name": "sample_ids", "type": ["list", "str"]}]
+
+    def _validate(self):
+        # ensures ObjectIDs are valid
+        _ = self.to_mongo()
 
 
 class SelectFields(ViewStage):

--- a/fiftyone/core/stages.py
+++ b/fiftyone/core/stages.py
@@ -133,8 +133,8 @@ class Exclude(ViewStage):
         return [{"name": "sample_ids", "type": ["list", "str"]}]
 
     def _validate(self):
-        # ensures ObjectIDs are valid
-        _ = self.to_mongo()
+        # Ensures that ObjectIDs are valid
+        self.to_mongo()
 
 
 class ExcludeFields(ViewStage):
@@ -544,8 +544,8 @@ class Select(ViewStage):
         return [{"name": "sample_ids", "type": ["list", "str"]}]
 
     def _validate(self):
-        # ensures ObjectIDs are valid
-        _ = self.to_mongo()
+        # Ensures that ObjectIDs are valid
+        self.to_mongo()
 
 
 class SelectFields(ViewStage):

--- a/fiftyone/core/stages.py
+++ b/fiftyone/core/stages.py
@@ -100,11 +100,14 @@ class Exclude(ViewStage):
     """Excludes the samples with the given IDs from the view.
 
     Args:
-        sample_ids: an iterable of sample IDs
+        sample_ids: a sample ID or iterable of sample IDs
     """
 
     def __init__(self, sample_ids):
-        self._sample_ids = list(sample_ids)
+        if etau.is_str(sample_ids):
+            self._sample_ids = [sample_ids]
+        else:
+            self._sample_ids = list(sample_ids)
 
     @property
     def sample_ids(self):
@@ -502,11 +505,14 @@ class Select(ViewStage):
     """Selects the samples with the given IDs from the view.
 
     Args:
-        sample_ids: an iterable of sample IDs
+        sample_ids: a sample ID or iterable of sample IDs
     """
 
     def __init__(self, sample_ids):
-        self._sample_ids = list(sample_ids)
+        if etau.is_str(sample_ids):
+            self._sample_ids = [sample_ids]
+        else:
+            self._sample_ids = list(sample_ids)
 
     @property
     def sample_ids(self):


### PR DESCRIPTION
Makes `view.select("5f33069b96cd78e8c41a6fcb")` and `view.exclude("5f33069b96cd78e8c41a6fcb")` do the right thing.

Previously an error would be raised because "5f33069b96cd78e8c41a6fcb" was being converted to `["5", "f", ..., "b"]` and then MongoDB was complaining that ObjectID's must be 24 characters.

Humorously, the `_params` methods of these stages _already_ documented that either `list` or `str` inputs are permitted, which wasn't quite true yet.