### PR TITLE
Adding sample fields to `dir(Sample)`

### DIFF
--- a/fiftyone/core/sample.py
+++ b/fiftyone/core/sample.py
@@ -23,6 +23,9 @@ class _Sample(object):
     def __init__(self):
         self._dataset = self._get_dataset()
 
+    def __dir__(self):
+        return super().__dir__() + list(self.field_names)
+
     def __getattr__(self, name):
         try:
             return super().__getattribute__(name)


### PR DESCRIPTION
Easy fix!

Here's the code to test it:

```python
import fiftyone as fo


sample = fo.Sample(filepath="image1.jpg", test_field1="testing")

print("test_field1" in dir(sample)) # True
print("test_field2" in dir(sample)) # False

sample["test_field2"] = 51
print("test_field1" in dir(sample)) # True
print("test_field2" in dir(sample)) # True
```

Closes #366 