### PR TITLE
Dataset.iter_samples() 10X faster

### DIFF
--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -412,7 +412,8 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
         Returns:
             an iterator over :class:`fiftyone.core.sample.Sample` instances
         """
-        for doc in self._get_query_set():
+        for d in self._collection.find():
+            doc = self._sample_dict_to_doc(d)
             yield fos.Sample.from_doc(doc)
 
     def add_sample(self, sample, expand_schema=True):

--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -187,15 +187,14 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
         if isinstance(sample_id_or_slice, slice):
             return self.view()[sample_id_or_slice]
 
-        try:
-            d = self._collection.find_one(
-                {"_id": ObjectId(sample_id_or_slice)}
-            )
-            doc = self._sample_dict_to_doc(d)
+        d = self._collection.find_one({"_id": ObjectId(sample_id_or_slice)})
 
-            return fos.Sample.from_doc(doc)
-        except DoesNotExist:
+        if d is None:
             raise KeyError("No sample found with ID '%s'" % sample_id_or_slice)
+
+        doc = self._sample_dict_to_doc(d)
+
+        return fos.Sample.from_doc(doc)
 
     def __delitem__(self, sample_id):
         self.remove_sample(sample_id)

--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -188,7 +188,11 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
             return self.view()[sample_id_or_slice]
 
         try:
-            doc = self._get_query_set().get(id=sample_id_or_slice)
+            d = self._collection.find_one(
+                {"_id": ObjectId(sample_id_or_slice)}
+            )
+            doc = self._sample_dict_to_doc(d)
+
             return fos.Sample.from_doc(doc)
         except DoesNotExist:
             raise KeyError("No sample found with ID '%s'" % sample_id_or_slice)
@@ -1290,10 +1294,6 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
 
     def _sample_dict_to_doc(self, d):
         return self._sample_doc_cls.from_dict(d, extended=False)
-
-    def _get_query_set(self, **kwargs):
-        # pylint: disable=no-member
-        return self._sample_doc_cls.objects(**kwargs)
 
     def _to_fields_str(self, field_schema):
         fields_dict = {


### PR DESCRIPTION
Wow! we need to drop `mongoengine` asap! I just replaced the `mongoengine` querying in `Dataset.iter_samples()` with effectively the same thing in `pymongo` and it's almost 10X as fast. This is such a basic operation. Who knows what other things are unnecessarily slow...

```python
import time
import fiftyone as fo

dataset = fo.load_dataset("oibenchmark")

NUM_SAMPLES = 10

start = time.time()
iterator = dataset.iter_samples()
samples = []
for i in range(NUM_SAMPLES):
    samples.append(next(iterator))
print("Dataset.iter_samples: %f" % (time.time() - start))

start = time.time()
iterator = dataset.view().iter_samples()
samples = []
for i in range(NUM_SAMPLES):
    samples.append(next(iterator))
print("DatasetView.iter_samples: %f" % (time.time() - start))

start = time.time()
iterator = dataset.aggregate()
samples = []
for i in range(NUM_SAMPLES):
    samples.append(next(iterator))
print("Dataset.aggregate: %f" % (time.time() - start))

start = time.time()
iterator = dataset.view().aggregate()
samples = []
for i in range(NUM_SAMPLES):
    samples.append(next(iterator))
print("DatasetView.aggregate: %f" % (time.time() - start))
```

BEFORE:
```
Dataset.iter_samples:       3.419131
DatasetView.iter_samples:   0.414041
Dataset.aggregate:          0.105867
DatasetView.aggregate:      0.143441
```

PROPOSED:
```
Dataset.iter_samples:       0.399038
DatasetView.iter_samples:   0.432330
Dataset.aggregate:          0.077051
DatasetView.aggregate:      0.108943
```