### PR TITLE
Including pycocotools as explicit dependency

### DIFF
--- a/fiftyone/core/utils.py
+++ b/fiftyone/core/utils.py
@@ -135,15 +135,6 @@ def ensure_torch():
     _ensure_package("torchvision")
 
 
-def ensure_pycocotools():
-    """Verifies that pycocotools is installed on the host machine.
-
-    Raises:
-        ImportError: if ``pycocotools`` could not be imported
-    """
-    _ensure_package("pycocotools")
-
-
 def _ensure_package(package_name, min_version=None):
     has_min_ver = min_version is not None
 

--- a/fiftyone/utils/eval/coco.py
+++ b/fiftyone/utils/eval/coco.py
@@ -22,12 +22,9 @@ from builtins import *
 import logging
 
 import numpy as np
+from pycocotools import mask as mask_utils
 
 import fiftyone.core.utils as fou
-
-mask_utils = fou.lazy_import(
-    "pycocotools.mask", callback=fou.ensure_pycocotools
-)
 
 
 logger = logging.getLogger(__name__)

--- a/fiftyone/zoo/torch.py
+++ b/fiftyone/zoo/torch.py
@@ -281,7 +281,6 @@ class COCO2014Dataset(TorchVisionDataset):
 
     def _download_and_prepare(self, dataset_dir, scratch_dir, split):
         def download_fcn(download_dir):
-            fou.ensure_pycocotools()
             images_dir, anno_path = fouc.download_coco_dataset_split(
                 download_dir, split, year="2014", cleanup=True
             )
@@ -329,7 +328,6 @@ class COCO2017Dataset(TorchVisionDataset):
 
     def _download_and_prepare(self, dataset_dir, scratch_dir, split):
         def download_fcn(download_dir):
-            fou.ensure_pycocotools()
             images_dir, anno_path = fouc.download_coco_dataset_split(
                 download_dir, split, year="2017", cleanup=True
             )

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -8,6 +8,7 @@ mongoengine==0.20.0
 packaging==20.3
 pprintpp==0.4.0
 psutil==5.7.0
+pycocotools==2.0.1
 pymongo==3.10.1
 python-engineio[client]==3.12.1
 python-socketio[client]==4.5.1

--- a/setup.py
+++ b/setup.py
@@ -54,6 +54,7 @@ setup(
         "Pillow<7,>=6.2",
         "pprintpp",
         "psutil",
+        "pycocotools",
         "pymongo",
         "python-engineio[client]",
         "python-socketio[client]",


### PR DESCRIPTION
Addresses user feedback from Slack community:

> Hey, I had installed fiftyone. Then when I tried running the sample script in #announcements channel, I got the pycocotools import error (ImportError: The requested operation requires that 'pycocotools' is installed on your machine). I then fixed this with : pip install "git+https://github.com/philferriere/cocoapi.git#egg=pycocotools&subdirectory=PythonAPI". In the next attempt, the script seems to be downloading the coco dataset (Downloading images zip to '/home/kritik/fiftyone/coco-2017/tmp-download/val2017.zip'). Perhaps the download progress should also be shown since it has not been downloaded in the past 10-15min and I cant figure out if it is working or not

Specifically, adds `pycocotools` as an explicit dependency (it's small), and fixes the lack of progress bar when downloading COCO.

The lack of progress bar was addressed by https://github.com/voxel51/eta/commit/336a27a0e0ac0ed6afbd02a204582b77d27ac1d2 and https://github.com/voxel51/eta/commit/03d3101d8f0a103c9130fa7d75959ed032359ee9, which will make their way into FiftyOne when running `dataset = foz.load_zoo_dataset("coco-2017", split="validation")` with a build of FiftyOne that includes the latest ETA.