### PR TITLE
View bar feedback part 2

### DIFF
--- a/electron/app/components/ViewBar/ViewBar.tsx
+++ b/electron/app/components/ViewBar/ViewBar.tsx
@@ -54,6 +54,7 @@ const viewBarKeyMap = {
   VIEW_BAR_PREVIOUS: "left",
   VIEW_BAR_NEXT_STAGE: "shift+right",
   VIEW_BAR_PREVIOUS_STAGE: "shift+left",
+  VIEW_BAR_DELETE: "del",
 };
 
 const ViewBar = () => {
@@ -81,6 +82,7 @@ const ViewBar = () => {
     VIEW_BAR_PREVIOUS: useCallback(() => send("PREVIOUS"), []),
     VIEW_BAR_NEXT_STAGE: useCallback(() => send("NEXT_STAGE"), []),
     VIEW_BAR_PREVIOUS_STAGE: useCallback(() => send("PREVIOUS_STAGE"), []),
+    VIEW_BAR_DELETE: useCallback(() => send("DELETE_ACTIVE_STAGE"), []),
   };
 
   useOutsideClick(

--- a/electron/app/components/ViewBar/ViewBar.tsx
+++ b/electron/app/components/ViewBar/ViewBar.tsx
@@ -54,7 +54,7 @@ const viewBarKeyMap = {
   VIEW_BAR_PREVIOUS: "left",
   VIEW_BAR_NEXT_STAGE: "shift+right",
   VIEW_BAR_PREVIOUS_STAGE: "shift+left",
-  VIEW_BAR_DELETE: "del",
+  VIEW_BAR_DELETE: "backspace,del",
 };
 
 const ViewBar = () => {

--- a/electron/app/components/ViewBar/ViewBar.tsx
+++ b/electron/app/components/ViewBar/ViewBar.tsx
@@ -49,10 +49,11 @@ const IconsContainer = styled.div`
 `;
 
 const viewBarKeyMap = {
-  VIEW_BAR_FOCUS: "alt+shift+v",
-  VIEW_BAR_BLUR: "esc",
+  VIEW_BAR_TOGGLE_FOCUS: "esc",
   VIEW_BAR_NEXT: "right",
   VIEW_BAR_PREVIOUS: "left",
+  VIEW_BAR_NEXT_STAGE: "shift+right",
+  VIEW_BAR_PREVIOUS_STAGE: "shift+left",
 };
 
 const ViewBar = () => {
@@ -75,10 +76,11 @@ const ViewBar = () => {
   const barRef = useRef(null);
 
   const handlers = {
-    VIEW_BAR_FOCUS: useCallback(() => send("FOCUS"), []),
-    VIEW_BAR_BLUR: useCallback(() => send("BLUR"), []),
+    VIEW_BAR_TOGGLE_FOCUS: useCallback(() => send("TOGGLE_FOCUS"), []),
     VIEW_BAR_NEXT: useCallback(() => send("NEXT"), []),
     VIEW_BAR_PREVIOUS: useCallback(() => send("PREVIOUS"), []),
+    VIEW_BAR_NEXT_STAGE: useCallback(() => send("NEXT_STAGE"), []),
+    VIEW_BAR_PREVIOUS_STAGE: useCallback(() => send("PREVIOUS_STAGE"), []),
   };
 
   useOutsideClick(barRef, () => send("BLUR"));

--- a/electron/app/components/ViewBar/ViewBar.tsx
+++ b/electron/app/components/ViewBar/ViewBar.tsx
@@ -83,12 +83,20 @@ const ViewBar = () => {
     VIEW_BAR_PREVIOUS_STAGE: useCallback(() => send("PREVIOUS_STAGE"), []),
   };
 
-  useOutsideClick(barRef, () => send("BLUR"));
+  useOutsideClick(
+    barRef,
+    () => state.matches("running.focus.focused") && send("TOGGLE_FOCUS")
+  );
 
   return (
     <ViewBarContainer>
       <GlobalHotKeys handlers={handlers} keyMap={viewBarKeyMap} />
-      <ViewBarDiv onClick={() => send("FOCUS")} ref={barRef}>
+      <ViewBarDiv
+        onClick={() =>
+          state.matches("running.focus.blurred") && send("TOGGLE_FOCUS")
+        }
+        ref={barRef}
+      >
         {state.matches("running")
           ? stages.map((stage, i) => {
               return (

--- a/electron/app/components/ViewBar/ViewBar.tsx
+++ b/electron/app/components/ViewBar/ViewBar.tsx
@@ -53,7 +53,7 @@ const viewBarKeyMap = {
   VIEW_BAR_PREVIOUS: "left",
   VIEW_BAR_NEXT_STAGE: "shift+right",
   VIEW_BAR_PREVIOUS_STAGE: "shift+left",
-  VIEW_BAR_DELETE: "backspace,del",
+  VIEW_BAR_DELETE: ["del", "backspace"],
 };
 
 const ViewBar = () => {

--- a/electron/app/components/ViewBar/ViewBar.tsx
+++ b/electron/app/components/ViewBar/ViewBar.tsx
@@ -1,6 +1,5 @@
 import React, { useEffect, useCallback, useMemo, useRef } from "react";
 import styled from "styled-components";
-import { useSpring } from "react-spring";
 import { useMachine } from "@xstate/react";
 import { useRecoilState, useRecoilValue } from "recoil";
 import { GlobalHotKeys } from "react-hotkeys";

--- a/electron/app/components/ViewBar/ViewStage/ErrorMessage.tsx
+++ b/electron/app/components/ViewBar/ViewStage/ErrorMessage.tsx
@@ -1,27 +1,35 @@
-import React, { useEffect, useRef, useState } from "react";
+import React, { useContext, useEffect, useRef, useState } from "react";
 import { animated, useSpring } from "react-spring";
-import styled from "styled-components";
+import styled, { ThemeContext } from "styled-components";
 import { useService } from "@xstate/react";
+import { ReportProblem, VerticalAlignBottom } from "@material-ui/icons";
 
 import { useOutsideClick } from "../../../utils/hooks";
 
 const ErrorMessageDiv = animated(styled.div`
   box-sizing: border-box;
-  border: 2px solid ${({ theme }) => theme.error};
-  background-color: ${({ theme }) => theme.backgroundDark};
+  border-radius: 3px;
+  background-color: #191c1f;
+  box-shadow: 0 2px 25px 0 rgba(0, 0, 0, 0.16);
   color: ${({ theme }) => theme.fontDark};
   border-radius: 2px;
   padding: 0.5rem;
   line-height: 1rem;
   margin-top: 2.5rem;
   font-weight: bold;
-  box-shadow: 0 2px 20px ${({ theme }) => theme.backgroundDark};
   position: fixed;
   width: auto;
   z-index: 800;
 `);
 
+const ErrorHeader = styled.div`
+  color: ${({ theme }) => theme.font};
+  display: flex;
+  padding-bottom: 0.5rem;
+`;
+
 const ErrorMessage = React.memo(({ serviceRef, style }) => {
+  const theme = useContext(ThemeContext);
   const [state, send] = useService(serviceRef);
   const ref = useRef();
   const [errorTimeout, setErrorTimeout] = useState(null);
@@ -45,7 +53,19 @@ const ErrorMessage = React.memo(({ serviceRef, style }) => {
       ref={ref}
       style={{ ...animations, display: error ? "block" : "none", ...style }}
     >
-      {error}
+      {error ? (
+        <>
+          <ErrorHeader>
+            <ReportProblem
+              style={{ color: theme.error, marginRight: "0.5rem" }}
+            />
+            <div
+              style={{ marginTop: "0.25rem" }}
+            >{`Invalid ${error.name}.`}</div>
+          </ErrorHeader>
+          {error.error}
+        </>
+      ) : null}
     </ErrorMessageDiv>
   );
 });

--- a/electron/app/components/ViewBar/ViewStage/ViewStage.tsx
+++ b/electron/app/components/ViewBar/ViewStage/ViewStage.tsx
@@ -263,12 +263,6 @@ const ViewStage = React.memo(({ stageRef }) => {
     config: config.stiff,
   });
 
-  useEffect(() => {
-    inputRef.current && send({ type: "FOCUS", inputRef: inputRef });
-  }, [inputRef.current]);
-
-  console.log(state.toStrings(), state.event);
-
   return (
     <>
       <ViewStageContainer style={containerProps}>

--- a/electron/app/components/ViewBar/ViewStage/ViewStage.tsx
+++ b/electron/app/components/ViewBar/ViewStage/ViewStage.tsx
@@ -1,10 +1,8 @@
 import React, { useContext, useEffect, useRef, useMemo, useState } from "react";
 import styled, { ThemeContext } from "styled-components";
 import { animated, useSpring, config } from "react-spring";
-import { useRecoilValue } from "recoil";
 import { useService } from "@xstate/react";
 import AuosizeInput from "react-input-autosize";
-import { GlobalHotKeys } from "react-hotkeys";
 import { Add, KeyboardReturn as Arrow, Close } from "@material-ui/icons";
 
 import SearchResults from "./SearchResults";

--- a/electron/app/components/ViewBar/ViewStage/ViewStage.tsx
+++ b/electron/app/components/ViewBar/ViewStage/ViewStage.tsx
@@ -201,11 +201,11 @@ const ViewStage = React.memo(({ stageRef }) => {
   const {
     stage,
     parameters,
-    active,
     results,
     currentResult,
     length,
     index,
+    focusOnInit,
   } = state.context;
 
   const isCompleted = [
@@ -214,10 +214,8 @@ const ViewStage = React.memo(({ stageRef }) => {
   ].some(state.matches);
 
   const deleteProps = useSpring({
-    borderStyle: isCompleted ? "solid" : "dashed",
-    backgroundColor: isCompleted
-      ? theme.brandTransparent
-      : theme.brandMoreTransparent,
+    borderStyle: "solid",
+    backgroundColor: theme.brandTransparent,
     opacity: 1,
     from: {
       opacity: 0,
@@ -229,7 +227,11 @@ const ViewStage = React.memo(({ stageRef }) => {
     backgroundColor: isCompleted
       ? theme.brandTransparent
       : theme.brandMoreTransparent,
-    borderRightWidth: !isCompleted && index === 0 && length === 1 ? 2 : 0,
+    borderRightWidth:
+      (!parameters.length && index === 0 && length === 1) ||
+      (index !== 0 && !parameters.length)
+        ? 2
+        : 0,
     borderTopRightRadius: state.matches("delible") && !isCompleted ? 3 : 0,
     borderBottomRightRadius: state.matches("delible") && !isCompleted ? 3 : 0,
     opacity: 1,
@@ -274,6 +276,7 @@ const ViewStage = React.memo(({ stageRef }) => {
           <ViewStageInput
             placeholder="+ add stage"
             value={stage}
+            autoFocus={focusOnInit}
             onFocus={() => !state.matches("input.editing") && send("EDIT")}
             onBlur={(e) => {
               state.matches("input.editing.searchResults.notHovering") &&

--- a/electron/app/components/ViewBar/ViewStage/ViewStage.tsx
+++ b/electron/app/components/ViewBar/ViewStage/ViewStage.tsx
@@ -198,7 +198,15 @@ const ViewStage = React.memo(({ stageRef }) => {
   const [state, send] = useService(stageRef);
   const inputRef = useRef(null);
 
-  const { stage, parameters, active, results, currentResult } = state.context;
+  const {
+    stage,
+    parameters,
+    active,
+    results,
+    currentResult,
+    length,
+    index,
+  } = state.context;
 
   const isCompleted = [
     "input.reading.selected",
@@ -221,7 +229,7 @@ const ViewStage = React.memo(({ stageRef }) => {
     backgroundColor: isCompleted
       ? theme.brandTransparent
       : theme.brandMoreTransparent,
-    borderRightWidth: isCompleted ? 0 : 2,
+    borderRightWidth: !isCompleted && index === 0 && length === 1 ? 2 : 0,
     borderTopRightRadius: state.matches("delible") && !isCompleted ? 3 : 0,
     borderBottomRightRadius: state.matches("delible") && !isCompleted ? 3 : 0,
     opacity: 1,
@@ -256,6 +264,8 @@ const ViewStage = React.memo(({ stageRef }) => {
   useEffect(() => {
     inputRef.current && send({ type: "FOCUS", inputRef: inputRef });
   }, [inputRef.current]);
+
+  console.log(state.toStrings(), state.event);
 
   return (
     <>
@@ -292,13 +302,9 @@ const ViewStage = React.memo(({ stageRef }) => {
             ref={inputRef}
           />
         </ViewStageDiv>
-        {isCompleted &&
-          parameters.map((parameter) => (
-            <ViewStageParameter
-              key={parameter.id}
-              parameterRef={parameter.ref}
-            />
-          ))}
+        {parameters.map((parameter) => (
+          <ViewStageParameter key={parameter.id} parameterRef={parameter.ref} />
+        ))}
         {state.matches("delible.yes") ? (
           <ViewStageDelete spring={deleteProps} send={send} />
         ) : null}

--- a/electron/app/components/ViewBar/ViewStage/ViewStage.tsx
+++ b/electron/app/components/ViewBar/ViewStage/ViewStage.tsx
@@ -3,7 +3,8 @@ import styled, { ThemeContext } from "styled-components";
 import { animated, useSpring, config } from "react-spring";
 import { useService } from "@xstate/react";
 import AuosizeInput from "react-input-autosize";
-import { Add, KeyboardReturn as Arrow, Close } from "@material-ui/icons";
+import { Add, KeyboardReturn as Arrow, Close, Help } from "@material-ui/icons";
+import { shell } from "electron";
 
 import SearchResults from "./SearchResults";
 import ViewStageParameter from "./ViewStageParameter";
@@ -296,6 +297,21 @@ const ViewStage = React.memo(({ stageRef }) => {
             style={{ fontSize: "1rem" }}
             ref={inputRef}
           />
+          {isCompleted && (
+            <Help
+              onClick={() =>
+                shell.openExternal(
+                  `https://voxel51.com/docs/fiftyone/api/fiftyone.core.stages.html#fiftyone.core.stages.${stage}`
+                )
+              }
+              style={{
+                cursor: "pointer",
+                width: "1rem",
+                height: "1rem",
+                margin: "0.5rem 0.5rem 0.5rem 0",
+              }}
+            />
+          )}
         </ViewStageDiv>
         {parameters.map((parameter) => (
           <ViewStageParameter key={parameter.id} parameterRef={parameter.ref} />

--- a/electron/app/components/ViewBar/ViewStage/ViewStageParameter.tsx
+++ b/electron/app/components/ViewBar/ViewStage/ViewStageParameter.tsx
@@ -164,7 +164,7 @@ const ObjectEditor = ({ parameterRef, inputRef }) => {
             }}
             onKeyDown={(e) => {
               if (e.key === "Escape") {
-                send({ type: "CANCEL" });
+                send("COMMIT");
               }
             }}
             value={value}

--- a/electron/app/components/ViewBar/ViewStage/ViewStageParameter.tsx
+++ b/electron/app/components/ViewBar/ViewStage/ViewStageParameter.tsx
@@ -238,7 +238,7 @@ const ViewStageParameter = React.memo(({ parameterRef }) => {
               placeholder={makePlaceholder(parameter, type, defaultValue)}
               value={value}
               onFocus={() => !isEditing && send({ type: "EDIT" })}
-              onBlur={() => isEditing && send({ type: "BLUR" })}
+              onBlur={() => isEditing && send("COMMIT")}
               onChange={(e) => {
                 send({ type: "CHANGE", value: e.target.value });
               }}

--- a/electron/app/components/ViewBar/ViewStage/ViewStageParameter.tsx
+++ b/electron/app/components/ViewBar/ViewStage/ViewStageParameter.tsx
@@ -238,7 +238,7 @@ const ViewStageParameter = React.memo(({ parameterRef }) => {
               placeholder={makePlaceholder(parameter, type, defaultValue)}
               value={value}
               onFocus={() => !isEditing && send({ type: "EDIT" })}
-              onBlur={() => isEditing && send("COMMIT")}
+              onBlur={() => isEditing && send({ type: "COMMIT" })}
               onChange={(e) => {
                 send({ type: "CHANGE", value: e.target.value });
               }}
@@ -249,7 +249,7 @@ const ViewStageParameter = React.memo(({ parameterRef }) => {
               }}
               onKeyDown={(e) => {
                 if (e.key === "Escape") {
-                  send({ type: "CANCEL" });
+                  send({ type: "COMMIT" });
                 }
               }}
               ref={inputRef}

--- a/electron/app/components/ViewBar/ViewStage/viewStageMachine.ts
+++ b/electron/app/components/ViewBar/ViewStage/viewStageMachine.ts
@@ -95,7 +95,6 @@ const viewStageMachine = Machine(
                 target: "decide",
                 actions: assign({
                   inputRef: (_, { inputRef }) => inputRef,
-                  focusOnInit: true,
                 }),
               },
             },
@@ -143,7 +142,7 @@ const viewStageMachine = Machine(
                       n.toLowerCase().includes(stage.toLowerCase())
                     ),
                 currentResult: null,
-                focusOnInit: false,
+                focusOnInit: true,
               }),
             ],
             type: "parallel",
@@ -152,6 +151,7 @@ const viewStageMachine = Machine(
                 initial: "focused",
                 states: {
                   focused: {
+                    entry: "focusInput",
                     on: {
                       UNFOCUS_INPUT: "unfocused",
                     },
@@ -198,6 +198,7 @@ const viewStageMachine = Machine(
                   target: "reading.selected",
                   actions: [
                     assign({
+                      focusOnInit: false,
                       stage: (ctx, { stage }) => stage,
                       parameters: (ctx, { stage }) => {
                         const result = ctx.stageInfo.filter((s) =>

--- a/electron/app/components/ViewBar/ViewStage/viewStageMachine.ts
+++ b/electron/app/components/ViewBar/ViewStage/viewStageMachine.ts
@@ -417,7 +417,7 @@ const viewStageMachine = Machine(
                     idx += 1;
                   }
                   idx = refIndex - 1;
-                  while (idx) {
+                  while (idx >= 0) {
                     if (!ctx.parameters[idx].submitted) {
                       return ctx.parameters[idx].ref;
                     }

--- a/electron/app/components/ViewBar/ViewStage/viewStageMachine.ts
+++ b/electron/app/components/ViewBar/ViewStage/viewStageMachine.ts
@@ -238,8 +238,12 @@ const viewStageMachine = Machine(
                   actions: [
                     assign({
                       submitted: () => false,
-                      error: (_, { stage }) =>
-                        `${stage === "" ? '""' : stage} is not a valid stage`,
+                      error: (_, { stage }) => ({
+                        name: "stage",
+                        error: `${
+                          stage === "" ? '""' : stage
+                        } is not a valid stage`,
+                      }),
                       errorId: uuid(),
                     }),
                   ],

--- a/electron/app/components/ViewBar/ViewStage/viewStageParameterMachine.ts
+++ b/electron/app/components/ViewBar/ViewStage/viewStageParameterMachine.ts
@@ -75,7 +75,7 @@ export const PARSER = {
   },
   "list<str>": {
     castFrom: (value) => {
-      return JSON.stringify(value);
+      return value === "string" ? JSON.stringify(value) : value;
     },
     castTo: (value) => JSON.parse(value).map((e) => PARSER.str.castTo(e)),
     parse: (value) => {
@@ -97,7 +97,10 @@ export const PARSER = {
     castFrom: (value) => {
       return JSON.stringify(value);
     },
-    castTo: (value) => JSON.parse(value).map((e) => PARSER.str.castTo(e)),
+    castTo: (value) =>
+      typeof value === "string"
+        ? JSON.parse(value).map((e) => PARSER.str.castTo(e))
+        : value,
     parse: (value) => {
       const array = JSON.parse(value);
       return JSON.stringify(array.map((e) => PARSER.id.parse(e)));
@@ -121,7 +124,7 @@ export const PARSER = {
   },
   dict: {
     castFrom: (value) => JSON.stringify(value),
-    castTo: (value) => JSON.parse(value),
+    castTo: (value) => (typeof value === "string" ? JSON.parse(value) : value),
     parse: (value) => value,
     validate: (value) => {
       try {

--- a/electron/app/components/ViewBar/ViewStage/viewStageParameterMachine.ts
+++ b/electron/app/components/ViewBar/ViewStage/viewStageParameterMachine.ts
@@ -227,8 +227,10 @@ export default Machine(
             {
               actions: [
                 assign({
-                  error: ({ type }) =>
-                    `Invalid value. Expected type "${toTypeAnnotation(type)}"`,
+                  error: ({ type }) => ({
+                    name: "value",
+                    error: `Expected type "${toTypeAnnotation(type)}"`,
+                  }),
                   errorId: uuid(),
                 }),
               ],

--- a/electron/app/components/ViewBar/viewBarMachine.ts
+++ b/electron/app/components/ViewBar/viewBarMachine.ts
@@ -245,6 +245,12 @@ const viewBarMachine = Machine(
                       to: stages[activeStage].ref,
                     })),
                   },
+                  DELETE_ACTIVE_STAGE: {
+                    actions: send(({ activeStage, stages }) => ({
+                      type: "STAGE.DELETE",
+                      stage: stages[activeStage],
+                    })),
+                  },
                 },
               },
               blurred: {
@@ -359,14 +365,16 @@ const viewBarMachine = Machine(
       },
       "STAGE.DELETE": {
         actions: [
+          (ctx, e) => console.log(e),
           assign({
-            activeStage: ({ activeStage }) => activeStage,
+            activeStage: ({ activeStage }) => Math.max(activeStage - 1, 0),
             stages: ({ stages }, e) =>
               stages
                 .filter(
                   (stage) => stage.id !== e.stage.id || stages.length === 1
                 )
                 .map((stage, index) => {
+                  console.log("ererere");
                   const newStage = stage.id === e.stage.id ? e.stage : stage;
                   newStage.index = index;
                   newStage.length = Math.max(stages.length - 1, 1);

--- a/electron/app/components/ViewBar/viewBarMachine.ts
+++ b/electron/app/components/ViewBar/viewBarMachine.ts
@@ -186,7 +186,7 @@ const viewBarMachine = Machine(
                     ),
                 ],
                 on: {
-                  BLUR: {
+                  TOGGLE_FOCUS: {
                     target: "blurred",
                   },
                   NEXT: {
@@ -247,11 +247,12 @@ const viewBarMachine = Machine(
                   },
                 },
               },
-              blurred: {},
-            },
-            on: {
-              FOCUS: {
-                target: "focus.focused",
+              blurred: {
+                on: {
+                  TOGGLE_FOCUS: {
+                    target: "focused",
+                  },
+                },
               },
             },
           },

--- a/electron/app/components/ViewBar/viewBarMachine.ts
+++ b/electron/app/components/ViewBar/viewBarMachine.ts
@@ -31,8 +31,6 @@ export const createStage = (
 
 import { getSocket } from "../../utils/socket";
 
-const { choose } = actions;
-
 function getStageInfo(context) {
   return fetch(`http://127.0.0.1:${context.port}/stages`).then((response) =>
     response.json()
@@ -62,7 +60,7 @@ function serializeView(stages, stageMap) {
 }
 
 function makeEmptyView(stageInfo) {
-  const stage = createStage("", 0, stageInfo, false, 0, true, [], false);
+  const stage = createStage("", 0, stageInfo, false, 1, true, [], false);
   return [
     {
       ...stage,

--- a/electron/app/shared/colors.ts
+++ b/electron/app/shared/colors.ts
@@ -64,7 +64,7 @@ export const darkTheme = {
 
   secondary: blue53,
 
-  error: red,
+  error: "#EF2020",
 };
 
 // for storybook


### PR DESCRIPTION
## What changes are proposed in this pull request?

Stability improvements, more flexible parameter and stage editing, and a small set of keyboard shortcuts. A couple non-ideal behaviors (mostly with styles) have arise with these changes, but I think the pros outweigh the cons. They will be fixed with the next ViewBar PR.

## How is this patch tested? If it is not, in a single sentence please explain why.

Locally tested.

## Release Notes

### Is this a user-facing change?

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

Features
* Initial keyboard shortcuts
  * TAB, ENTER, and ESC submit parameters, and submit the stage or focus the next parameter depending on what has been filled out
  * DEL and BACKSPACE delete the active stage
  * ESC toggles ViewBar focus
  * LEFT and RIGHT ARROW traverse stages and add buttons
  * SHIFT LEFT and SHIFT RIGHT ARROW traverse stages
 * General improvements to stability

Bugs
* Clicking on another parameter while editing another parameter is now possible
* Edge case fixes when serializing views 


### What areas of FiftyOne does this PR affect?

-   [x] `App`: FiftyOne application changes
-   [ ] `Build`: Build and test infrastructure changes
-   [ ] `Core`: Core `fiftyone` Python library changes
-   [ ] `Documentation`: FiftyOne documentation changes
-   [ ] `Other`

### Should this PR be mentioned in the release notes? If so, please choose on category:

-   [ ] `breaking-change` - The PR will be mentioned in the "Breaking Changes"
        section
-   [x] `feature` - A new user-facing feature worth mentioning in the release
        notes
-   [x] `bug-fix` - A user-facing bug fix worth mentioning in the release notes
-   [ ] `documentation` - A user-facing documentation change worth mentioning
        in the release notes
