### PR TITLE
Global server services map

### DIFF
--- a/fiftyone/core/client.py
+++ b/fiftyone/core/client.py
@@ -13,7 +13,6 @@ from retrying import retry
 import socketio
 
 import fiftyone.constants as foc
-import fiftyone.core.service as fos
 
 logging.getLogger("socketio").setLevel(logging.ERROR)
 logging.getLogger("engineio").setLevel(logging.ERROR)
@@ -97,7 +96,6 @@ class HasClient(object):
     _HC_ATTR_TYPE = None
 
     def __init__(self, port):
-        self._server_service = fos.ServerService(port)
         self._hc_sio = socketio.Client()
         # the following is a monkey patch to set threads to daemon mode
         self._hc_sio.eio.start_background_task = _start_background_task
@@ -127,13 +125,6 @@ class HasClient(object):
             self._hc_client.update(value)
         else:
             super().__setattr__(name, value)
-
-    @property
-    def server_port(self):
-        """Getter for the port number the :class:`ServerService` is listening
-        on.
-        """
-        return self._server_service.port
 
 
 def _start_background_task(target, *args, **kwargs):

--- a/fiftyone/core/session.py
+++ b/fiftyone/core/session.py
@@ -16,6 +16,8 @@ logger = logging.getLogger(__name__)
 
 # Global session singleton
 session = None
+# Global server services map
+_server_services = {}
 
 
 def launch_app(dataset=None, view=None, port=5151, remote=False):
@@ -118,6 +120,9 @@ class Session(foc.HasClient):
     def __init__(self, dataset=None, view=None, port=5151, remote=False):
         self._port = port
         self._remote = remote
+        global _server_services
+        if port not in _server_services:
+            _server_services[port] = fos.ServerService(port)
 
         super().__init__(self._port)
 
@@ -157,6 +162,10 @@ class Session(foc.HasClient):
         session, if any.
         """
         self.state.dataset = None
+
+    @property
+    def server_port(self):
+        return self._port
 
     @property
     def view(self):


### PR DESCRIPTION
## What changes are proposed in this pull request?

Resolves #380. Service objects kill their subprocess upon garbage collection, which is what was occurring in #380. Maintaining a global map (with `port` as the key) of server services prevents this, and allows us to only start a new service when necessary.

## How is this patch tested? If it is not, in a single sentence please explain why.

(Details)

## Release Notes

### Is this a user-facing change?

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

Improved stability in the `Session` object. The App is now able to connect to the server after being closed by the "x" in the top right, and opened again via `Session()` or `launch_app()`.

### What areas of FiftyOne does this PR affect?

-   [x] `App`: FiftyOne application changes
-   [ ] `Build`: Build and test infrastructure changes
-   [x] `Core`: Core `fiftyone` Python library changes
-   [ ] `Documentation`: FiftyOne documentation changes
-   [ ] `Other`

### Should this PR be mentioned in the release notes? If so, please choose on category:

-   [ ] `breaking-change` - The PR will be mentioned in the "Breaking Changes"
        section
-   [ ] `feature` - A new user-facing feature worth mentioning in the release
        notes
-   [x] `bug-fix` - A user-facing bug fix worth mentioning in the release notes
-   [ ] `documentation` - A user-facing documentation change worth mentioning
        in the release notes
