### PR TITLE
Preventing `None` dataset names

### DIFF
--- a/fiftyone/core/cli.py
+++ b/fiftyone/core/cli.py
@@ -287,7 +287,7 @@ class DatasetsListCommand(Command):
         datasets = fod.list_datasets()
 
         if datasets:
-            for dataset in sorted(datasets):
+            for dataset in datasets:
                 print(dataset)
         else:
             print("No datasets found")

--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -657,6 +657,9 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
         Returns:
             a :class:`Dataset`
         """
+        if name is None:
+            name = get_default_dataset_name()
+
         if dataset_exists(name):
             raise ValueError(
                 "Dataset '%s' already exists; invalid to clone dataset." % name

--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -223,8 +223,13 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
 
     @name.setter
     def name(self, name):
-        self._doc.name = name
-        self._doc.save()
+        _name = self._doc.name
+        try:
+            self._doc.name = name
+            self._doc.save()
+        except:
+            self._doc.name = _name
+            raise
 
     @property
     def persistent(self):
@@ -235,8 +240,13 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
 
     @persistent.setter
     def persistent(self, value):
-        self._doc.persistent = value
-        self._doc.save()
+        _value = self._doc.persistent
+        try:
+            self._doc.persistent = value
+            self._doc.save()
+        except:
+            self._doc.persistent = _value
+            raise
 
     @property
     def info(self):

--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -155,15 +155,15 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
     Args:
         name (None): the name of the dataset. By default,
             :func:`get_default_dataset_name` is used
-        persistent (False): whether the dataset will persist in the database
-            once the session terminates
+        persistent (False): whether the dataset should persist in the database
+            after the session terminates
     """
 
     # Batch size used when commiting samples to the database
     _BATCH_SIZE = 128
 
     def __init__(self, name=None, persistent=False, _create=True):
-        if name is None:
+        if name is None and _create:
             name = get_default_dataset_name()
 
         if _create:

--- a/fiftyone/core/odm/dataset.py
+++ b/fiftyone/core/odm/dataset.py
@@ -96,8 +96,8 @@ class DatasetDocument(Document):
 
     meta = {"collection": "datasets"}
 
-    name = StringField(unique=True)
-    sample_collection_name = StringField(unique=True)
+    name = StringField(unique=True, required=True)
+    sample_collection_name = StringField(unique=True, required=True)
     persistent = BooleanField(default=False)
     info = DictField(default=dict)
     sample_fields = EmbeddedDocumentListField(


### PR DESCRIPTION
Fixes a bug in `Dataset.clone(name)` where a default dataset name was not being generated if `name == None` was passed.

Also, prevents dataset names from being `None`, which, along with the work in https://github.com/voxel51/fiftyone/pull/407, completely resolves https://github.com/voxel51/fiftyone/issues/205.

```py
import fiftyone as fo

dataset = fo.Dataset()
dataset.name = None  # raises an error, does not change `dataset.name`
```
