### PR TITLE
Adding View stage examples to docs

### DIFF
--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -653,7 +653,6 @@ class SampleCollection(object):
         Examples::
 
             import fiftyone as fo
-            from fiftyone.core.stages import Select
 
             dataset = fo.load_dataset(...)
 
@@ -661,12 +660,11 @@ class SampleCollection(object):
             # Select the samples with the given IDs from the dataset
             #
 
-            stage = Select([
+            view = dataset.select([
                 "5f3c298768fd4d3baf422d34",
                 "5f3c298768fd4d3baf422d35",
                 "5f3c298768fd4d3baf422d36",
             ])
-            view = dataset.add_stage(stage)
 
             #
             # Create a view containing the currently selected samples in the
@@ -677,8 +675,7 @@ class SampleCollection(object):
 
             # Select samples in the App...
 
-            stage = Select(session.selected)
-            view = dataset.add_stage(stage)
+            view = dataset.select(session.selected)
 
         Args:
             sample_ids: a sample ID or iterable of sample IDs
@@ -733,7 +730,6 @@ class SampleCollection(object):
         Examples::
 
             import fiftyone as fo
-            from fiftyone.core.stages import Shuffle
 
             dataset = fo.load_dataset(...)
 

--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -240,6 +240,27 @@ class SampleCollection(object):
     def exclude(self, sample_ids):
         """Excludes the samples with the given IDs from the collection.
 
+        Examples::
+
+            import fiftyone as fo
+
+            dataset = fo.load_dataset(...)
+
+            #
+            # Exclude a single sample from a dataset
+            #
+
+            view = dataset.exclude("5f3c298768fd4d3baf422d2f")
+
+            #
+            # Exclude a list of samples from a dataset
+            #
+
+            view = dataset.exclude([
+                "5f3c298768fd4d3baf422d2f",
+                "5f3c298768fd4d3baf422d30"
+            ])
+
         Args:
             sample_ids: a sample ID or iterable of sample IDs
 
@@ -253,7 +274,25 @@ class SampleCollection(object):
         """Excludes the fields with the given names from the returned
         :class:`fiftyone.core.sample.SampleView` instances.
 
-        Note: Default fields cannot be excluded.
+        Note that default fields cannot be excluded.
+
+        Examples::
+
+            import fiftyone as fo
+
+            dataset = fo.load_dataset(...)
+
+            #
+            # Exclude a field from all samples in a dataset
+            #
+
+            view = dataset.exclude_fields("predictions")
+
+            #
+            # Exclude a list of fields from all samples in a dataset
+            #
+
+            view = dataset.exclude_fields(["ground_truth", "predictions"])
 
         Args:
             field_names: a field name or iterable of field names to exclude
@@ -267,6 +306,19 @@ class SampleCollection(object):
     def exists(self, field):
         """Returns a view containing the samples that have a non-``None`` value
         for the given field.
+
+        Examples::
+
+            import fiftyone as fo
+
+            dataset = fo.load_dataset(...)
+
+            #
+            # Only include samples that have a value in their `predictions`
+            # field
+            #
+
+            view = dataset.exists("predictions")
 
         Args:
             field: the field
@@ -282,6 +334,28 @@ class SampleCollection(object):
 
         Values of ``field`` for which ``filter`` returns ``False`` are
         replaced with ``None``.
+
+        Examples::
+
+            import fiftyone as fo
+            from fiftyone import ViewField as F
+
+            dataset = fo.load_dataset(...)
+
+            #
+            # Only include classifications in the `predictions` field (assume
+            # it is a `Classification` field) whose `label` is "cat"
+            #
+
+            view = dataset.filter_field("predictions", F.label == "cat")
+
+            #
+            # Only include classifications in the `predictions` field (assume
+            # it is a `Classification` field) whose `confidence` is greater
+            # than 0.8
+            #
+
+            view = dataset.filter_field("predictions", F.confidence > 0.8)
 
         Args:
             field: the field to filter
@@ -302,6 +376,31 @@ class SampleCollection(object):
         Elements of ``<field>.classifications`` for which ``filter`` returns
         ``False`` are omitted from the field.
 
+        Examples::
+
+            import fiftyone as fo
+            from fiftyone import ViewField as F
+
+            dataset = fo.load_dataset(...)
+
+            #
+            # Only include classifications in the `predictions` field whose
+            # `confidence` greater than 0.8
+            #
+
+            view = dataset.filter_classifications(
+                "predictions", F.confidence > 0.8
+            )
+
+            #
+            # Only include classifications in the `predictions` field whose
+            # `label` is "cat" or "dog"
+            #
+
+            view = dataset.filter_classifications(
+                "predictions", F.label.is_in(["cat", "dog"])
+            )
+
         Args:
             field: the :class:`fiftyone.core.labels.Classifications` field
             filter: a :class:`fiftyone.core.expressions.ViewExpression` or
@@ -321,6 +420,39 @@ class SampleCollection(object):
         Elements of ``<field>.detections`` for which ``filter`` returns
         ``False`` are omitted from the field.
 
+        Examples::
+
+            import fiftyone as fo
+            from fiftyone import ViewField as F
+
+            dataset = fo.load_dataset(...)
+
+            #
+            # Only include detections in the `predictions` field whose
+            # `confidence` is greater than 0.8
+            #
+
+            view = dataset.filter_detections("predictions", F.confidence > 0.8)
+
+            #
+            # Only include detections in the `predictions` field whose `label`
+            # is "cat" or "dog"
+            #
+
+            view = dataset.filter_detections(
+                "predictions", F.label.is_in(["cat", "dog"])
+            )
+
+            #
+            # Only include detections in the `predictions` field whose bounding box
+            # area is smaller than 0.2
+            #
+
+            # bbox is in [top-left-x, top-left-y, width, height] format
+            bbox_area = F.bounding_box[2] * F.bounding_box[3]
+
+            view = dataset.filter_detections("predictions", bbox_area < 0.2)
+
         Args:
             field: the :class:`fiftyone.core.labels.Detections` field
             filter: a :class:`fiftyone.core.expressions.ViewExpression` or
@@ -335,6 +467,18 @@ class SampleCollection(object):
     @view_stage
     def limit(self, limit):
         """Returns a view with at most the given number of samples.
+
+        Examples::
+
+            import fiftyone as fo
+
+            dataset = fo.load_dataset(...)
+
+            #
+            # Only include the first 10 samples in the view
+            #
+
+            view = dataset.limit(10)
 
         Args:
             limit: the maximum number of samples to return. If a non-positive
@@ -351,6 +495,45 @@ class SampleCollection(object):
 
         Samples for which ``filter`` returns ``False`` are omitted.
 
+        Examples::
+
+            import fiftyone as fo
+            from fiftyone import ViewField as F
+
+            dataset = fo.load_dataset(...)
+
+            #
+            # Only include samples whose `filepath` ends with ".jpg"
+            #
+
+            view = dataset.match(F.filepath.ends_with(".jpg"))
+
+            #
+            # Only include samples whose `predictions` field (assume it is a
+            # `Classification` field) has `label` of "cat"
+            #
+
+            view = dataset.match(F.predictions.label == "cat"))
+
+            #
+            # Only include samples whose `predictions` field (assume it is a
+            # `Detections` field) has at least 5 detections
+            #
+
+            view = dataset.match(F.predictions.detections.length() >= 5)
+
+            #
+            # Only include samples whose `predictions` field (assume it is a
+            # `Detections` field) has at least one detection with area smaller
+            # than 0.2
+            #
+
+            # bbox is in [top-left-x, top-left-y, width, height] format
+            pred_bbox = F.predictions.detections.bounding_box
+            pred_bbox_area = pred_bbox[2] * pred_bbox[3]
+
+            view = dataset.match((pred_bbox_area < 0.2).length() > 0)
+
         Args:
             filter: a :class:`fiftyone.core.expressions.ViewExpression` or
                 `MongoDB expression <https://docs.mongodb.com/manual/meta/aggregation-quick-reference/#aggregation-expressions>`_
@@ -364,6 +547,18 @@ class SampleCollection(object):
     @view_stage
     def match_tag(self, tag):
         """Returns a view containing the samples that have the given tag.
+
+        Examples::
+
+            import fiftyone as fo
+
+            dataset = fo.load_dataset(...)
+
+            #
+            # Only include samples that have the "test" tag
+            #
+
+            view = dataset.match_tag("test")
 
         Args:
             tag: a tag
@@ -381,6 +576,19 @@ class SampleCollection(object):
         To match samples that must contain multiple tags, chain multiple
         :meth:`match_tag` or :meth:`match_tags` calls together.
 
+        Examples::
+
+            import fiftyone as fo
+
+            dataset = fo.load_dataset(...)
+
+            #
+            # Only include samples that have either the "test" or "validation"
+            # tag
+            #
+
+            view = dataset.match_tags(["test", "validation"])
+
         Args:
             tags: an iterable of tags
 
@@ -396,6 +604,38 @@ class SampleCollection(object):
         See `MongoDB aggregation pipelines <https://docs.mongodb.com/manual/core/aggregation-pipeline/>`_
         for more details.
 
+        Examples::
+
+            import fiftyone as fo
+
+            dataset = fo.load_dataset(...)
+
+            #
+            # Extract a view containing the 6th through 15th samples in the
+            # dataset
+            #
+
+            view = dataset.mongo([{"$skip": 5}, {"$limit": 10}])
+
+            #
+            # Sort by the number of detections in the `precictions` field of
+            # the samples (assume it is a `Detections` field)
+            #
+
+            view = dataset.mongo([
+                {
+                    "$addFields": {
+                        "_sort_field": {
+                            "$size": {
+                                "$ifNull": ["$predictions.detections", []]
+                            }
+                        }
+                    }
+                },
+                {"$sort": {"_sort_field": -1}},
+                {"$unset": "_sort_field"}
+            ])
+
         Args:
             pipeline: a MongoDB aggregation pipeline (list of dicts)
 
@@ -407,6 +647,36 @@ class SampleCollection(object):
     @view_stage
     def select(self, sample_ids):
         """Returns a view containing only the samples with the given IDs.
+
+        Examples::
+
+            import fiftyone as fo
+            from fiftyone.core.stages import Select
+
+            dataset = fo.load_dataset(...)
+
+            #
+            # Select the samples with the given IDs from the dataset
+            #
+
+            stage = Select([
+                "5f3c298768fd4d3baf422d34",
+                "5f3c298768fd4d3baf422d35",
+                "5f3c298768fd4d3baf422d36",
+            ])
+            view = dataset.add_stage(stage)
+
+            #
+            # Create a view containing the currently selected samples in the
+            # App
+            #
+
+            session = fo.launch_app(dataset=dataset)
+
+            # Select samples in the App...
+
+            stage = Select(session.selected)
+            view = dataset.add_stage(stage)
 
         Args:
             sample_ids: a sample ID or iterable of sample IDs
@@ -422,8 +692,27 @@ class SampleCollection(object):
         present in the returned :class:`fiftyone.core.sample.SampleView`
         instances. All other fields are excluded.
 
-        Note: Default sample fields are always selected and will be added if
-        not included in ``field_names``.
+        Note that default sample fields are always selected and will be added
+        if not included in ``field_names``.
+
+        Examples::
+
+            import fiftyone as fo
+
+            dataset = fo.load_dataset(...)
+
+            #
+            # Include only the default fields on each sample
+            #
+
+            view = dataset.select_fields()
+
+            #
+            # Include only the `ground_truth` field (and the default fields) on
+            # each sample
+            #
+
+            view = dataset.select_fields("ground_truth")
 
         Args:
             field_names (None): a field name or iterable of field names to
@@ -439,6 +728,26 @@ class SampleCollection(object):
     def shuffle(self, seed=None):
         """Randomly shuffles the samples in the collection.
 
+        Examples::
+
+            import fiftyone as fo
+            from fiftyone.core.stages import Shuffle
+
+            dataset = fo.load_dataset(...)
+
+            #
+            # Return a view that contains a randomly shuffled version of the
+            # samples in the dataset
+            #
+
+            view = dataset.shuffle()
+
+            #
+            # Shuffle the samples with a set random seed
+            #
+
+            view = dataset.shuffle(seed=51)
+
         Args:
             seed (None): an optional random seed to use when shuffling the
                 samples
@@ -451,6 +760,18 @@ class SampleCollection(object):
     @view_stage
     def skip(self, skip):
         """Omits the given number of samples from the head of the collection.
+
+        Examples::
+
+            import fiftyone as fo
+
+            dataset = fo.load_dataset(...)
+
+            #
+            # Omit the first 10 samples from the dataset
+            #
+
+            view = dataset.skip(10)
 
         Args:
             skip: the number of samples to skip. If a non-positive number is
@@ -471,6 +792,32 @@ class SampleCollection(object):
         `MongoDB expression <https://docs.mongodb.com/manual/meta/aggregation-quick-reference/#aggregation-expressions>`_
         that defines the quantity to sort by.
 
+        Examples::
+
+            import fiftyone as fo
+            from fiftyone import ViewField as F
+
+            dataset = fo.load_dataset(...)
+
+            #
+            # Sorts the samples in descending order by the `confidence` of
+            # their `predictions` field (assume it is a `Classification` field)
+            #
+
+            view = dataset.sort_by("predictions.confidence", reverse=True)
+
+            #
+            # Sorts the samples in ascending order by the number of detections
+            # in their `predictions` field (assume it is a `Detections` field)
+            # whose bounding box area is at most 0.2
+            #
+
+            # bbox is in [top-left-x, top-left-y, width, height] format
+            pred_bbox = F.predictions.detections.bounding_box
+            pred_bbox_area = pred_bbox[2] * pred_bbox[3]
+
+            view = dataset.sort_by((pred_bbox_area < 0.2).length())
+
         Args:
             field_or_expr: the field or expression to sort by
             reverse (False): whether to return the results in descending order
@@ -483,6 +830,24 @@ class SampleCollection(object):
     @view_stage
     def take(self, size, seed=None):
         """Randomly samples the given number of samples from the collection.
+
+        Examples::
+
+            import fiftyone as fo
+
+            dataset = fo.load_dataset(...)
+
+            #
+            # Take 10 random samples from the dataset
+            #
+
+            view = dataset.take(10)
+
+            #
+            # Take 10 random samples from the dataset with a set seed
+            #
+
+            view = dataset.take(10, seed=51)
 
         Args:
             size: the number of samples to return. If a non-positive number is

--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -347,7 +347,7 @@ class SampleCollection(object):
             # it is a `Classification` field) whose `label` is "cat"
             #
 
-            view = dataset.filter_field("predictions", F.label == "cat")
+            view = dataset.filter_field("predictions", F("label") == "cat")
 
             #
             # Only include classifications in the `predictions` field (assume
@@ -355,7 +355,7 @@ class SampleCollection(object):
             # than 0.8
             #
 
-            view = dataset.filter_field("predictions", F.confidence > 0.8)
+            view = dataset.filter_field("predictions", F("confidence") > 0.8)
 
         Args:
             field: the field to filter
@@ -389,7 +389,7 @@ class SampleCollection(object):
             #
 
             view = dataset.filter_classifications(
-                "predictions", F.confidence > 0.8
+                "predictions", F("confidence") > 0.8
             )
 
             #
@@ -398,7 +398,7 @@ class SampleCollection(object):
             #
 
             view = dataset.filter_classifications(
-                "predictions", F.label.is_in(["cat", "dog"])
+                "predictions", F("label").is_in(["cat", "dog"])
             )
 
         Args:
@@ -432,7 +432,9 @@ class SampleCollection(object):
             # `confidence` is greater than 0.8
             #
 
-            view = dataset.filter_detections("predictions", F.confidence > 0.8)
+            view = dataset.filter_detections(
+                "predictions", F("confidence") > 0.8
+            )
 
             #
             # Only include detections in the `predictions` field whose `label`
@@ -440,16 +442,16 @@ class SampleCollection(object):
             #
 
             view = dataset.filter_detections(
-                "predictions", F.label.is_in(["cat", "dog"])
+                "predictions", F("label").is_in(["cat", "dog"])
             )
 
             #
-            # Only include detections in the `predictions` field whose bounding box
-            # area is smaller than 0.2
+            # Only include detections in the `predictions` field whose bounding
+            # box area is smaller than 0.2
             #
 
             # bbox is in [top-left-x, top-left-y, width, height] format
-            bbox_area = F.bounding_box[2] * F.bounding_box[3]
+            bbox_area = F("bounding_box")[2] * F("bounding_box")[3]
 
             view = dataset.filter_detections("predictions", bbox_area < 0.2)
 
@@ -506,21 +508,21 @@ class SampleCollection(object):
             # Only include samples whose `filepath` ends with ".jpg"
             #
 
-            view = dataset.match(F.filepath.ends_with(".jpg"))
+            view = dataset.match(F("filepath").ends_with(".jpg"))
 
             #
             # Only include samples whose `predictions` field (assume it is a
             # `Classification` field) has `label` of "cat"
             #
 
-            view = dataset.match(F.predictions.label == "cat"))
+            view = dataset.match(F("predictions").label == "cat"))
 
             #
             # Only include samples whose `predictions` field (assume it is a
             # `Detections` field) has at least 5 detections
             #
 
-            view = dataset.match(F.predictions.detections.length() >= 5)
+            view = dataset.match(F("predictions").detections.length() >= 5)
 
             #
             # Only include samples whose `predictions` field (assume it is a
@@ -529,7 +531,7 @@ class SampleCollection(object):
             #
 
             # bbox is in [top-left-x, top-left-y, width, height] format
-            pred_bbox = F.predictions.detections.bounding_box
+            pred_bbox = F("predictions.detections.bounding_box")
             pred_bbox_area = pred_bbox[2] * pred_bbox[3]
 
             view = dataset.match((pred_bbox_area < 0.2).length() > 0)
@@ -813,7 +815,7 @@ class SampleCollection(object):
             #
 
             # bbox is in [top-left-x, top-left-y, width, height] format
-            pred_bbox = F.predictions.detections.bounding_box
+            pred_bbox = F("predictions.detections.bounding_box")
             pred_bbox_area = pred_bbox[2] * pred_bbox[3]
 
             view = dataset.sort_by((pred_bbox_area < 0.2).length())

--- a/fiftyone/core/expressions.py
+++ b/fiftyone/core/expressions.py
@@ -639,7 +639,7 @@ class ViewField(ViewExpression, metaclass=_MetaViewField):
     You can use `dot notation <https://docs.mongodb.com/manual/core/document/#dot-notation>`_
     to refer to subfields of embedded objects within fields.
 
-    Example uses::
+    Examples::
 
         from fiftyone import ViewField as F
 

--- a/fiftyone/core/stages.py
+++ b/fiftyone/core/stages.py
@@ -320,7 +320,7 @@ class FilterField(ViewStage):
         # a `Classification` field) whose `label` is "cat"
         #
 
-        stage = FilterField("predictions", F.label == "cat")
+        stage = FilterField("predictions", F("label") == "cat")
         view = dataset.add_stage(stage)
 
         #
@@ -328,7 +328,7 @@ class FilterField(ViewStage):
         # a `Classification` field) whose `confidence` is greater than 0.8
         #
 
-        stage = FilterField("predictions", F.confidence > 0.8)
+        stage = FilterField("predictions", F("confidence") > 0.8)
         view = dataset.add_stage(stage)
 
     Args:
@@ -458,7 +458,7 @@ class FilterClassifications(_FilterListField):
         # `confidence` greater than 0.8
         #
 
-        stage = FilterClassifications("predictions", F.confidence > 0.8)
+        stage = FilterClassifications("predictions", F("confidence") > 0.8)
         view = dataset.add_stage(stage)
 
         #
@@ -467,7 +467,7 @@ class FilterClassifications(_FilterListField):
         #
 
         stage = FilterClassifications(
-            "predictions", F.label.is_in(["cat", "dog"])
+            "predictions", F("label").is_in(["cat", "dog"])
         )
         view = dataset.add_stage(stage)
 
@@ -510,7 +510,7 @@ class FilterDetections(_FilterListField):
         # is greater than 0.8
         #
 
-        stage = FilterDetections("predictions", F.confidence > 0.8)
+        stage = FilterDetections("predictions", F("confidence") > 0.8)
         view = dataset.add_stage(stage)
 
         #
@@ -519,7 +519,7 @@ class FilterDetections(_FilterListField):
         #
 
         stage = FilterDetections(
-            "predictions", F.label.is_in(["cat", "dog"])
+            "predictions", F("label").is_in(["cat", "dog"])
         )
         view = dataset.add_stage(stage)
 
@@ -529,7 +529,7 @@ class FilterDetections(_FilterListField):
         #
 
         # bbox is in [top-left-x, top-left-y, width, height] format
-        bbox_area = F.bounding_box[2] * F.bounding_box[3]
+        bbox_area = F("bounding_box")[2] * F("bounding_box")[3]
 
         stage = FilterDetections("predictions", bbox_area < 0.2)
         view = dataset.add_stage(stage)
@@ -616,7 +616,7 @@ class Match(ViewStage):
         # Only include samples whose `filepath` ends with ".jpg"
         #
 
-        stage = Match(F.filepath.ends_with(".jpg"))
+        stage = Match(F("filepath").ends_with(".jpg"))
         view = dataset.add_stage(stage)
 
         #
@@ -624,7 +624,7 @@ class Match(ViewStage):
         # `Classification` field) has `label` of "cat"
         #
 
-        stage = Match(F.predictions.label == "cat"))
+        stage = Match(F("predictions").label == "cat"))
         view = dataset.add_stage(stage)
 
         #
@@ -632,7 +632,7 @@ class Match(ViewStage):
         # `Detections` field) has at least 5 detections
         #
 
-        stage = Match(F.predictions.detections.length() >= 5)
+        stage = Match(F("predictions").detections.length() >= 5)
         view = dataset.add_stage(stage)
 
         #
@@ -642,7 +642,7 @@ class Match(ViewStage):
         #
 
         # bbox is in [top-left-x, top-left-y, width, height] format
-        pred_bbox = F.predictions.detections.bounding_box
+        pred_bbox = F("predictions.detections.bounding_box")
         pred_bbox_area = pred_bbox[2] * pred_bbox[3]
 
         stage = Match((pred_bbox_area < 0.2).length() > 0)
@@ -1132,7 +1132,7 @@ class SortBy(ViewStage):
         #
 
         # bbox is in [top-left-x, top-left-y, width, height] format
-        pred_bbox = F.predictions.detections.bounding_box
+        pred_bbox = F("predictions.detections.bounding_box")
         pred_bbox_area = pred_bbox[2] * pred_bbox[3]
 
         stage = SortBy((pred_bbox_area < 0.2).length())

--- a/fiftyone/core/stages.py
+++ b/fiftyone/core/stages.py
@@ -99,6 +99,34 @@ class ViewStageError(Exception):
 class Exclude(ViewStage):
     """Excludes the samples with the given IDs from the view.
 
+    Example uses::
+
+        import fiftyone as fo
+        from fiftyone.core.stages import Exclude
+
+        dataset = fo.load_dataset(...)
+
+        view = dataset.view()
+
+        #
+        # Example 1
+        # Exclude a single sample from a view
+        #
+
+        stage = Exclude("5f3c298768fd4d3baf422d2f")
+        new_view = view.add_stage(stage)
+
+        #
+        # Example 2
+        # Exclude a list of samples from a view
+        #
+
+        stage = Exclude([
+            "5f3c298768fd4d3baf422d2f",
+            "5f3c298768fd4d3baf422d30"
+        ])
+        new_view = view.add_stage(stage)
+
     Args:
         sample_ids: a sample ID or iterable of sample IDs
     """
@@ -140,7 +168,32 @@ class Exclude(ViewStage):
 class ExcludeFields(ViewStage):
     """Excludes the fields with the given names from the samples in the view.
 
-    Note: Default fields cannot be excluded.
+    Note that default fields cannot be excluded.
+
+    Example uses::
+
+        import fiftyone as fo
+        from fiftyone.core.stages import ExcludeFields
+
+        dataset = fo.load_dataset(...)
+
+        view = dataset.view()
+
+        #
+        # Example 1
+        # Exclude a field from all samples in the view
+        #
+
+        stage = ExcludeFields("predictions")
+        new_view = view.add_stage(stage)
+
+        #
+        # Example 2
+        # Exclude a list of fields from all samples in the view
+        #
+
+        stage = ExcludeFields(["ground_truth", "predictions"])
+        new_view = view.add_stage(stage)
 
     Args:
         field_names: a field name or iterable of field names to exclude
@@ -184,6 +237,23 @@ class ExcludeFields(ViewStage):
 class Exists(ViewStage):
     """Returns a view containing the samples that have a non-``None`` value
     for the given field.
+
+    Example uses::
+
+        import fiftyone as fo
+        from fiftyone.core.stages import Exists
+
+        dataset = fo.load_dataset(...)
+
+        view = dataset.view()
+
+        #
+        # Example
+        # Only include samples that have a value in their `predictions` field
+        #
+
+        stage = Exists("predictions")
+        new_view = view.add_stage(stage)
 
     Args:
         field: the field
@@ -297,6 +367,34 @@ class FilterClassifications(_FilterList):
     """Filters the :class:`fiftyone.core.labels.Classification` elements in the
     specified :class:`fiftyone.core.labels.Classifications` field of the
     samples in a view.
+
+    Example uses::
+
+        import fiftyone as fo
+        from fiftyone.core.stages import FilterClassifications
+        from fiftyone import ViewField as F
+
+        dataset = fo.load_dataset(...)
+
+        view = dataset.view()
+
+        #
+        # Example 1
+        # Only include classifications with confidence > 0.8
+        #
+
+        stage = FilterClassifications("predictions", F("confidence") > 0.8)
+        new_view = view.add_stage(stage)
+
+        #
+        # Example 2
+        # Only include classifications whose label is "cat" or "dog"
+        #
+
+        stage = FilterClassifications(
+            "predictions", F("label").is_in(["cat", "dog"])
+        )
+        new_view = view.add_stage(stage)
 
     Args:
         field: the field to filter, which must be a


### PR DESCRIPTION
The App links directly into the docs when help icons for view bar stages are clicked. This PR adds plenty of examples to help the user understand how to use the various stages.