### PR TITLE
[WIP] sample change tracking and tests

### DIFF
--- a/tests/unittests.py
+++ b/tests/unittests.py
@@ -2139,6 +2139,138 @@ class ViewStageTests(unittest.TestCase):
         self.assertIs(len(result), 1)
 
 
+class ChangeTrackerTest(unittest.TestCase):
+    @drop_datasets
+    def test_changed_fields(self):
+        # @todo These tests will all need to be passing before support for:
+        #    1. tracking what fields/subfields of a sample have been modified
+        #    2. (1) gives way to: smart updates that only update necessary
+        #       fields instead of replacing the entire document
+        #    3. (1) gives way to: automatic saves when a field/subfield is
+        #       modified, rather than requiring a call to sample.save()
+
+        dataset = fo.Dataset()
+
+        sample = fo.Sample(
+            filepath="test1.png",
+            tags=["test"],
+            my_bool=True,
+            my_int=51,
+            my_float=5.1,
+            my_str="fiftyone",
+            my_list=["fifty", "one", []],
+            my_dict={"fiftyone": 51, "nested_dict": {}},
+            my_vector=np.array([1, 2, 3]),
+            my_array=np.array([[1, 2, 3], [4, 5, 6]]),
+            my_classification=fo.Classification(
+                label="friend", confidence=0.9
+            ),
+            my_dets=fo.Detections(
+                detections=[
+                    fo.Detection(
+                        label="friend",
+                        confidence=0.5,
+                        bounding_box=[0, 0, 1, 1],
+                    ),
+                    fo.Detection(
+                        label="stopper",
+                        confidence=0.1,
+                        bounding_box=[0, 0, 0.5, 0.5],
+                    ),
+                ]
+            ),
+        )
+
+        dataset.add_sample(sample)
+
+        # test "change" to same value
+        self.assertListEqual(sample._changed_fields, [])
+        sample.my_bool = True
+        self.assertListEqual(sample._changed_fields, [])
+
+        # test change primitives
+
+        # test bool
+        self.assertListEqual(sample._changed_fields, [])
+        sample.my_bool = False
+        self.assertListEqual(sample._changed_fields, ["my_bool"])
+        sample.reload()
+        # test int
+        self.assertListEqual(sample._changed_fields, [])
+        sample.my_int = 52
+        self.assertListEqual(sample._changed_fields, ["my_int"])
+        sample.reload()
+        # test float
+        self.assertListEqual(sample._changed_fields, [])
+        sample.my_float = 5.2
+        self.assertListEqual(sample._changed_fields, ["my_float"])
+        sample.reload()
+        # test str
+        self.assertListEqual(sample._changed_fields, [])
+        sample.my_str = "fiftytwo"
+        self.assertListEqual(sample._changed_fields, ["my_str"])
+        sample.reload()
+
+        # test change list
+
+        # modify nested list
+        self.assertListEqual(sample._changed_fields, [])
+        sample.my_list[2].append(51)
+        self.assertListEqual(sample._changed_fields, ["my_list.2"])
+        sample.reload()
+        # modify list element
+        self.assertListEqual(sample._changed_fields, [])
+        sample.my_list[0] += "Asdf"
+        self.assertListEqual(sample._changed_fields, ["my_list"])
+        sample.reload()
+        # modify list
+        self.assertListEqual(sample._changed_fields, [])
+        sample.my_list.pop(0)
+        self.assertListEqual(sample._changed_fields, ["my_list"])
+        sample.reload()
+        # set list
+        self.assertListEqual(sample._changed_fields, [])
+        sample.my_list = [5, 6]
+        self.assertListEqual(sample._changed_fields, ["my_list"])
+        sample.reload()
+
+        # test change dict
+
+        # # modify nested dict
+        # self.assertListEqual(sample._changed_fields, [])
+        # sample.my_dict["nested_dict"]["fifty"] = 1
+        # print(sample._changed_fields)
+        # sample.reload()
+        # sample.my_dict["nested_dict"] = 1
+        # print(sample._changed_fields)
+        # sample.reload()
+        # sample.my_dict = {"a": 4}
+        # print(sample._changed_fields)
+        # sample.reload()
+        # # self.assertListEqual(sample._changed_fields, ["my_list.2"])
+        # sample.reload()
+
+        # # modify vector element
+        # self.assertListEqual(sample._changed_fields, [])
+        # sample.my_vector[0] = 5
+        # # self.assertListEqual(sample._changed_fields, ["my_list"])
+        # print(sample._changed_fields)
+        # sample.reload()
+        # # set vector
+        # self.assertListEqual(sample._changed_fields, [])
+        # sample.my_vector = np.array([6, 7, 8])
+        # print(sample._changed_fields)
+        # # self.assertListEqual(sample._changed_fields, ["my_list"])
+        # sample.reload()
+
+        # test embedded documents
+
+        self.assertListEqual(sample._changed_fields, [])
+        sample.my_classification.label = "hex"
+        self.assertListEqual(sample._changed_fields, ["my_classification"])
+        sample.reload()
+
+
 if __name__ == "__main__":
     fo.config.show_progress_bars = False
     unittest.main(verbosity=2)


### PR DESCRIPTION
This is a WIP on supporting the behavior of tracking changes made to the fields and subfields of samples *without* `mongoengine`, (although heavily inspired by it).

## Why?

The current implementation does a complete document replacement via `collection.find_one_and_replace({...})` whenever `sample.save()` is *explicitly called*. Alternatively, if the changes to sample fields and their subfields were tracked, we could support:
- automatic saving (no calls to `sample.save()`)
- "smart" saving that only saves the modified fields. It is unclear how beneficial this would be but it could potentially be a performance improvement, and it may help with special cases like `SampleView.filtered_fields`

## Why is it a WIP?

The challenge of this is dealing with nested structures. It's easy to send a signal every time a field is replaced:
```python
sample.my_str = "new value"
```
but what about this?!
```python
sample.my_dict["a"]["b"][0].detections[3].bounding_box[0] = 0.5
```
Obviously this example is a bit contrived but you kinda need to do an all or nothing.

## The idea
Here is the general concept behind this functionality:
1. *every* structure that can be assigned to a field of a sample has a child class that watches for changes by wrapping *every* method on the class that can modify it. For examples of this see `mongoengine.base.BaseList/BaseDict`. The supported structures we would need this for would include at least: `dict`, `list`, `set`, `numpy.array`, `EmbeddedDocument`
2. the backing dictionary of a sample, `_Sample._data`, needs to be composed of these "change-tracking" classes. For example, when reading data via `pymongo.Collection.find_one({...})` the fields of the returned `dict` need to be cast to `BaseList`, `BaseDict`, `EmbeddedDocument`, etc.
3. Implement the method `_Sample._mark_as_changed(field_name)` which could do one of many potential things:
    - add the `field_name` to a `sample._changed_fields` list such that it is known what fields need to be updated when calling `sample.save()`. (this is what `mongoengine` does)
    - automatically save the field. this could remove the need to call `sample.save()`!
    - generate an update and add it to an update queue on the dataset. the dataset could then flush these updates every X changes or when explicitly called or...

## The current state of things
`TrackedDict` is playing the role of task 2. Whenever it is instantiated or modified it replaces instances of `list` with `BaseList`, `dict` with `BaseDict`, etc.

`_Sample._mark_as_changed` is currently doing the first proposed idea in task 3.

Some tests have been written and are partially complete. The challenge of making this implementation work is ensuring that no matter what `type` of object and no matter what nesting level a field/subfield we are dealing with, it always calls `_mark_as_changed`. Even if the end goal is to autosave or batch update from the dataset, the tests should ensure that `_Sample._mark_as_changed` is called for any sub-field.

Currently it seems like lists and nested lists are working, but dictionaries, sets, `EmbeddedDocument`s and `numpy.array`s are not.

Also, if using `mongoengine.BaseList/BaseDict/EmbeddedDocument` the name of the method on `_Sample` *MUST BE* `_Sample._mark_as_changed`. If you implement your own versions of these classes it can be called whatever you want 🙃
