### PR TITLE
Display a friendly error when using the dataset zoo with no ML backend installed

### DIFF
--- a/docs/source/user_guide/dataset_creation/zoo.rst
+++ b/docs/source/user_guide/dataset_creation/zoo.rst
@@ -6,6 +6,22 @@ FiftyOne Dataset Zoo
 FiftyOne provides a Dataset Zoo that contains a collection of common datasets
 that you can download and load into FiftyOne via a few simple commands.
 
+.. note::
+
+    Behind the scenes, FiftyOne's Dataset Zoo uses the
+    `TorchVision Datasets <https://pytorch.org/docs/stable/torchvision/datasets.html>`_ or
+    `TensorFlow Datasets <https://www.tensorflow.org/datasets>`_
+    libraries to wrangle certain datasets, depending on which ML library you
+    have installed.
+
+    If you do not have the proper packages installed when attempting to
+    download a zoo dataset, you will receive an error message that will help
+    you resolve the issue.
+
+    See :ref:`customizing your ML backend <zoo-customizing-your-ml-backend>`
+    for more information about configuring the backend behavior of the Dataset
+    Zoo.
+
 You can interact with the Dataset Zoo either via the Python library or
 the CLI.
 
@@ -429,6 +445,8 @@ of your :doc:`FiftyOne config </user_guide/config>`.
             import fiftyone.core.config as foc
 
             foc.set_config_settings(default_dataset_dir="/your/custom/directory")
+
+.. _zoo-customizing-your-ml-backend:
 
 Customizing your ML backend
 ---------------------------

--- a/fiftyone/core/cli.py
+++ b/fiftyone/core/cli.py
@@ -948,17 +948,21 @@ class ZooListCommand(Command):
     @staticmethod
     def execute(parser, args):
         all_datasets = foz._get_zoo_datasets()
-        all_sources = foz._get_zoo_dataset_sources()
+        all_sources, has_default = foz._get_zoo_dataset_sources()
 
         base_dir = args.base_dir
         downloaded_datasets = foz.list_downloaded_zoo_datasets(
             base_dir=base_dir
         )
 
-        _print_zoo_dataset_list(all_datasets, all_sources, downloaded_datasets)
+        _print_zoo_dataset_list(
+            downloaded_datasets, all_datasets, all_sources, has_default
+        )
 
 
-def _print_zoo_dataset_list(all_datasets, all_sources, downloaded_datasets):
+def _print_zoo_dataset_list(
+    downloaded_datasets, all_datasets, all_sources, has_default
+):
     available_datasets = defaultdict(dict)
     for source, datasets in all_datasets.items():
         for name, zoo_dataset_cls in datasets.items():
@@ -1015,9 +1019,10 @@ def _print_zoo_dataset_list(all_datasets, all_sources, downloaded_datasets):
                 (name, split, is_downloaded, split_dir) + tuple(srcs)
             )
 
+    first_suffix = " (*)" if has_default else ""
     headers = (
         ["name", "split", "downloaded", "dataset_dir"]
-        + ["%s (*)" % all_sources[0]]
+        + ["%s%s" % (all_sources[0], first_suffix)]
         + all_sources[1:]
     )
     table_str = tabulate(records, headers=headers, tablefmt=_TABLE_FORMAT)

--- a/fiftyone/core/utils.py
+++ b/fiftyone/core/utils.py
@@ -105,37 +105,46 @@ def indent_lines(s, indent=4, skip=0):
     return s
 
 
-def ensure_tf():
+def ensure_tf(error_msg=None):
     """Verifies that TensorFlow is installed on the host machine.
+
+    Args:
+        error_msg (None): an optional custom error message to print
 
     Raises:
         ImportError: if ``tensorflow`` could not be imported
     """
-    _ensure_package("tensorflow")
+    _ensure_package("tensorflow", error_msg=error_msg)
 
 
-def ensure_tfds():
+def ensure_tfds(error_msg=None):
     """Verifies that the ``tensorflow_datasets`` package is installed on the
     host machine.
+
+    Args:
+        error_msg (None): an optional custom error message to print
 
     Raises:
         ImportError: if ``tensorflow_datasets`` could not be imported
     """
-    _ensure_package("tensorflow", min_version="1.15")
-    _ensure_package("tensorflow_datasets")
+    _ensure_package("tensorflow", min_version="1.15", error_msg=error_msg)
+    _ensure_package("tensorflow_datasets", error_msg=error_msg)
 
 
-def ensure_torch():
+def ensure_torch(error_msg=None):
     """Verifies that PyTorch is installed on the host machine.
+
+    Args:
+        error_msg (None): an optional custom error message to print
 
     Raises:
         ImportError: if ``torch`` or ``torchvision`` could not be imported
     """
-    _ensure_package("torch")
-    _ensure_package("torchvision")
+    _ensure_package("torch", error_msg=error_msg)
+    _ensure_package("torchvision", error_msg=error_msg)
 
 
-def _ensure_package(package_name, min_version=None):
+def _ensure_package(package_name, min_version=None, error_msg=None):
     has_min_ver = min_version is not None
 
     if has_min_ver:
@@ -148,6 +157,9 @@ def _ensure_package(package_name, min_version=None):
             pkg_str = "%s>=%s" % (package_name, min_version)
         else:
             pkg_str = package_name
+
+        if error_msg is not None:
+            raise ImportError(error_msg) from e
 
         raise ImportError(
             "The requested operation requires that '%s' is installed on your "

--- a/fiftyone/zoo/__init__.py
+++ b/fiftyone/zoo/__init__.py
@@ -281,7 +281,8 @@ def get_zoo_dataset(name):
         the :class:`ZooDataset` instance
     """
     all_datasets = _get_zoo_datasets()
-    for source in _get_zoo_dataset_sources():
+    all_sources, _ = _get_zoo_dataset_sources()
+    for source in all_sources:
         if source not in all_datasets:
             continue
 
@@ -330,9 +331,12 @@ def _get_zoo_dataset_sources():
 
     try:
         all_sources.remove(default_source)
-        return [default_source] + all_sources
+        all_sources = [default_source] + all_sources
+        has_default = True
     except ValueError:
-        return all_sources
+        has_default = False
+
+    return all_sources, has_default
 
 
 def _parse_dataset_details(name, dataset_dir):

--- a/fiftyone/zoo/tf.py
+++ b/fiftyone/zoo/tf.py
@@ -11,7 +11,21 @@ import fiftyone.utils.imagenet as foui
 import fiftyone.utils.data as foud
 import fiftyone.zoo as foz
 
-tfds = fou.lazy_import("tensorflow_datasets", callback=fou.ensure_tfds)
+
+_TFDS_IMPORT_ERROR = """
+
+You tried to download a dataset from the FiftyOne Dataset Zoo using the
+TensorFlow backend, but you do not have the necessary packages installed.
+
+Ensure that you have `tensorflow` and `tensorflow_datasets` installed on your
+machine, and then try running this command again.
+
+See https://voxel51.com/docs/fiftyone/user_guide/dataset_creation/zoo.html
+for more information about working with the Dataset Zoo.
+"""
+
+_callback = lambda: fou.ensure_tfds(error_msg=_TFDS_IMPORT_ERROR)
+tfds = fou.lazy_import("tensorflow_datasets", callback=_callback)
 
 
 class TFDSDataset(foz.ZooDataset):

--- a/fiftyone/zoo/torch.py
+++ b/fiftyone/zoo/torch.py
@@ -13,7 +13,21 @@ import fiftyone.utils.imagenet as foui
 import fiftyone.utils.voc as fouv
 import fiftyone.zoo as foz
 
-torchvision = fou.lazy_import("torchvision", fou.ensure_torch)
+
+_TORCH_IMPORT_ERROR = """
+
+You tried to download a dataset from the FiftyOne Dataset Zoo using the PyTorch
+backend, but you do not have the necessary packages installed.
+
+Ensure that you have `torch` and `torchvision` installed on your machine, and
+then try running this command again.
+
+See https://voxel51.com/docs/fiftyone/user_guide/dataset_creation/zoo.html
+for more information about working with the Dataset Zoo.
+"""
+
+_callback = lambda: fou.ensure_torch(error_msg=_TORCH_IMPORT_ERROR)
+torchvision = fou.lazy_import("torchvision", callback=_callback)
 
 
 class TorchVisionDataset(foz.ZooDataset):


### PR DESCRIPTION
Previously the error would simply say "the requested operation requires that PyTorch is installed". Now it provides some more context specifically relating to the dataset zoo, and links into the docs for more details.

Experience when trying to download the `fashion-mnist` dataset from the zoo with no ML backends installed:

```shell
$ fiftyone zoo download fashion-mnist

Downloading split 'test' to '/Users/Brian/fiftyone/fashion-mnist/test'
Uncaught exception
Traceback (most recent call last):
...
ModuleNotFoundError: No module named 'torch'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
...
ImportError: 

You tried to download a dataset from the FiftyOne Dataset Zoo using the PyTorch
backend, but you do not have the necessary packages installed.

Ensure that you have `torch` and `torchvision` installed on your machine, and
then try running this command again.

See https://voxel51.com/docs/fiftyone/user_guide/dataset_creation/zoo.html
for more information about working with the Dataset Zoo.
```