### PR TITLE
Revert "installing pycocotools by default"

### DIFF
--- a/fiftyone/core/utils.py
+++ b/fiftyone/core/utils.py
@@ -144,6 +144,15 @@ def ensure_torch(error_msg=None):
     _ensure_package("torchvision", error_msg=error_msg)
 
 
+def ensure_pycocotools():
+    """Verifies that pycocotools is installed on the host machine.
+
+    Raises:
+        ImportError: if ``pycocotools`` could not be imported
+    """
+    _ensure_package("pycocotools")
+
+
 def _ensure_package(package_name, min_version=None, error_msg=None):
     has_min_ver = min_version is not None
 

--- a/fiftyone/utils/eval/coco.py
+++ b/fiftyone/utils/eval/coco.py
@@ -22,9 +22,12 @@ from builtins import *
 import logging
 
 import numpy as np
-from pycocotools import mask as mask_utils
 
 import fiftyone.core.utils as fou
+
+mask_utils = fou.lazy_import(
+    "pycocotools.mask", callback=fou.ensure_pycocotools
+)
 
 
 logger = logging.getLogger(__name__)

--- a/fiftyone/zoo/torch.py
+++ b/fiftyone/zoo/torch.py
@@ -295,6 +295,7 @@ class COCO2014Dataset(TorchVisionDataset):
 
     def _download_and_prepare(self, dataset_dir, scratch_dir, split):
         def download_fcn(download_dir):
+            fou.ensure_pycocotools()
             images_dir, anno_path = fouc.download_coco_dataset_split(
                 download_dir, split, year="2014", cleanup=True
             )
@@ -342,6 +343,7 @@ class COCO2017Dataset(TorchVisionDataset):
 
     def _download_and_prepare(self, dataset_dir, scratch_dir, split):
         def download_fcn(download_dir):
+            fou.ensure_pycocotools()
             images_dir, anno_path = fouc.download_coco_dataset_split(
                 download_dir, split, year="2017", cleanup=True
             )

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -8,7 +8,6 @@ mongoengine==0.20.0
 packaging==20.3
 pprintpp==0.4.0
 psutil==5.7.0
-pycocotools==2.0.1
 pymongo==3.10.1
 python-engineio[client]==3.12.1
 python-socketio[client]==4.5.1

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,6 @@ setup(
         "Pillow<7,>=6.2",
         "pprintpp",
         "psutil",
-        "pycocotools",
         "pymongo",
         "python-engineio[client]",
         "python-socketio[client]",


### PR DESCRIPTION
This package has C code but no wheels, so it's the only dependency that requires a compiler on all supported platforms, including Windows. Making it optional will make the installation process easier for Windows users.

This reverts #410 (commit 99d68df51149228931f32ab083fc37acdda74881).

Conflicts:
	fiftyone/core/utils.py

## What changes are proposed in this pull request?

See above

## How is this patch tested? If it is not, in a single sentence please explain why.

Not yet, waiting for build

## Release Notes

### Is this a user-facing change?

Unsure

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

### What areas of FiftyOne does this PR affect?

-   [ ] `App`: FiftyOne application changes
-   [ ] `Build`: Build and test infrastructure changes
-   [x] `Core`: Core `fiftyone` Python library changes
-   [ ] `Documentation`: FiftyOne documentation changes
-   [ ] `Other`

### Should this PR be mentioned in the release notes? If so, please choose on category:

-   [ ] `breaking-change` - The PR will be mentioned in the "Breaking Changes"
        section
-   [ ] `feature` - A new user-facing feature worth mentioning in the release
        notes
-   [ ] `bug-fix` - A user-facing bug fix worth mentioning in the release notes
-   [ ] `documentation` - A user-facing documentation change worth mentioning
        in the release notes
