### PR TITLE
Highlight quickstart on install page

### DIFF
--- a/docs/source/getting_started/install.rst
+++ b/docs/source/getting_started/install.rst
@@ -9,6 +9,12 @@ FiftyOne Installation
   Virtual environments <virtualenv>
   Troubleshooting <troubleshooting>
 
+.. note::
+
+    FiftyOne is rapidly growing.
+    `Sign up for the mailing list <https://share.hsforms.com/1zpJ60ggaQtOoVeBqIZdaaA2ykyk>`_
+    so we can keep you posted on new features as they come out!
+
 Prerequisites
 -------------
 
@@ -28,14 +34,8 @@ We encourage installing FiftyOne in a virtual environment. See
 Installing FiftyOne
 -------------------
 
-.. note::
-
-    FiftyOne is rapidly growing.
-    `Sign up for the mailing list <https://share.hsforms.com/1zpJ60ggaQtOoVeBqIZdaaA2ykyk>`_
-    so we can keep you posted on new features as they come out!
-
-To install FiftyOne in a virtual environment, ensure you have activated any
-virtual environment that you are using, then run:
+To install FiftyOne, ensure you have activated any virtual environment that you
+are using, then run:
 
 .. code-block:: shell
 
@@ -59,16 +59,27 @@ your virtual environment by importing the `fiftyone` package:
 A successful installation of FiftyOne should result in no output when
 `fiftyone` is imported.
 
+.. _fiftyone-quickstart:
+
+Quickstart
+----------
+
 .. note::
 
-    Dive right into FiftyOne by running the command below. It will download a
-    small dataset, launch the App, and print some suggestions for exploring the
-    dataset!
+    Get started in seconds by running the quickstart!
 
-    .. code-block:: shell
+Dive right into FiftyOne by running the command below. It will download a small
+dataset, launch the App, and print some suggestions for exploring the dataset!
 
-        # Launch the FiftyOne quickstart
-        fiftyone quickstart
+.. code-block:: shell
+
+    # Launch the FiftyOne quickstart
+    fiftyone quickstart
+
+.. _install-troubleshooting:
+
+Troubleshooting
+---------------
 
 If you run into any installation issues, review the suggestions below or check
 the :ref:`troubleshooting page <troubleshooting>` for more details.
@@ -127,6 +138,8 @@ packages via `pip` in your virtual environment:
 For your own work, FiftyOne does not strictly require any of these packages, so
 you can install only what you need.
 
+.. _upgrading-fiftyone
+
 Upgrading FiftyOne
 ------------------
 
@@ -137,6 +150,8 @@ upgrade an existing FiftyOne installation:
 
    pip install --index https://pypi.voxel51.com --upgrade fiftyone
 
+.. _uninstalling-fiftyone
+
 Uninstalling FiftyOne
 ---------------------
 
@@ -145,10 +160,3 @@ FiftyOne and all of its subpackages can be uninstalled with:
 .. code-block:: shell
 
    pip uninstall fiftyone fiftyone-brain fiftyone-db fiftyone-gui
-
-Troubleshooting
----------------
-
-If you encounter any issues when installing FiftyOne, verify that you have
-installed any system dependencies as described above, then see the
-:doc:`troubleshooting page <troubleshooting>`.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -36,7 +36,7 @@ models with dependable performance.
 *"Become one with your data"*
 
 FiftyOne does more than improve your dataset; it gets you closer to your data.
-Rapidly gain insight by visualizing samples overlayed with with dynamic and
+Rapidly gain insight by visualizing samples overlayed with dynamic and
 queryable fields such as ground truth and predicted labels, dataset splits, and
 much more!
 

--- a/docs/source/user_guide/app.rst
+++ b/docs/source/user_guide/app.rst
@@ -98,68 +98,70 @@ _______________
 
 If your data is stored on a remote machine, you can forward a session from
 the remote machine to the FiftyOne App on your local machine and seemlessly
-browse your remote |Dataset|.
+browse your remote dataset.
 
 Remote machine
 --------------
 
-First log into the **remote machine**, load a FiftyOne |Dataset|, and create a
-session with the argument `remote=True`. This will send the session to port
-`5151`:
+On the remote machine, load a |Dataset| and launch a session using
+:meth:`launch_app() <fiftyone.core.session.launch_app>` with the `remote=True`
+argument. This will open the session on port `5151` on your machine:
 
 .. code-block:: python
     :linenos:
 
-    # Remote Machine
+    # On remote machine
+
     import fiftyone as fo
 
     dataset = fo.Dataset(name="my_dataset")
     session = fo.launch_app(dataset=dataset, remote=True)
 
-This is the session that will be modified to change what is being displayed.
+You can manipulate the `session` object as usual to programmatically interact
+with the remote App instance that you'll connect to next.
 
 Local machine
 -------------
 
-The easiest way to port forward and load the FiftyOne App is using the CLI.
-Alternatively, the port forwarding and App launching steps can be run
-separately.
+On the local machine, you can launch an App instance connected to a remote
+session via the CLI. Alternatively, you can manually setup port forwarding on
+your local machine via `ssh` and connect to the App via Python.
 
 .. tabs::
 
   .. group-tab:: CLI
 
-    On the local machine, the :doc:`FiftyOne CLI <../cli/index>` can be used to
-    forward the port `5151` and open the FiftyOne App locally.
+    On the local machine, you can :ref:`use the CLI <cli-fiftyone-app-connect>`
+    to automatically configure port forwarding and open the App.
 
     In a local terminal, run the command:
 
     .. code-block:: shell
 
-        # Local machine
+        # On local machine
         fiftyone app connect --destination username@remote_machine_ip --port 5151
 
   .. group-tab:: Python
 
-    Open two terminal windows on the **local machine**. In order to forward the
+    Open two terminal windows on the local machine. In order to forward the
     port `5151` from the remote machine to the local machine, run the following
-    command directly in one of the terminal windows and leave this command
-    running:
+    command in one terminal and leave the process running:
 
     .. code-block:: shell
 
-        # Local machine
+        # On local machine
         ssh -N -L 5151:127.0.0.1:5151 username@remote_machine_ip
 
-    The port `5151` is now being forwarded from the remote machine to port
-    `5151` of the local machine through a process running in the background.
-    Now in the other terminal window, open the FiftyOne App locally by starting
-    Python and running the following commands:
+    Port `5151` is now being forwarded from the remote machine to port
+    `5151` of the local machine.
+
+    In the other terminal, launch the FiftyOne App locally by starting Python
+    and running the following commands:
 
     .. code-block:: python
         :linenos:
 
-        # Local machine
+        # On local machine
         import fiftyone.core.session as fos
 
         fos.launch_app()


### PR DESCRIPTION
Also fixes typo on main page 😓 and tweaks the remote session instructions.

**BEFORE**
<img width="1276" alt="Screen Shot 2020-08-27 at 1 19 19 PM" src="https://user-images.githubusercontent.com/25985824/91474290-0668dd80-e868-11ea-8384-ad946fd3289e.png">

**AFTER**
(Quickstart has its own section, and the note is simpler to read)
<img width="1276" alt="Screen Shot 2020-08-27 at 1 19 01 PM" src="https://user-images.githubusercontent.com/25985824/91474279-036ded00-e868-11ea-85cc-abd8b405a7d6.png">
