### PR TITLE
Add option to display confidence

### DIFF
--- a/electron/app/components/CheckboxGrid.tsx
+++ b/electron/app/components/CheckboxGrid.tsx
@@ -25,6 +25,7 @@ const Body = styled.div`
 
     .MuiTypography-body1 {
       font-size: unset;
+      align-items: center;
     }
 
     .MuiCheckbox-root {

--- a/electron/app/components/Player51.tsx
+++ b/electron/app/components/Player51.tsx
@@ -99,6 +99,8 @@ export default ({
       },
       overlay: overlay,
       colorMap: playerColorMap,
+      activeLabels,
+      filter,
     })
   );
   const props = thumbnail
@@ -109,11 +111,11 @@ export default ({
       if (thumbnail) {
         player.thumbnailMode();
       }
-      player.render(id, activeLabels, filter);
+      player.render(id);
       setInitLoad(true);
       onLoad();
     } else {
-      player.renderer.processFrame(activeLabels, filter);
+      player.updateOptions({ activeLabels, filter });
     }
   }, [filter, overlay, activeLabels]);
   return <div id={id} style={style} {...props} />;


### PR DESCRIPTION
## What changes are proposed in this pull request?

An option to hide/show confidence on detections and classifications
(most changes are in player51)
Closes #439 

## How is this patch tested? If it is not, in a single sentence please explain why.

Locally with {Classification,Detection}{,s}

## Release Notes

### Is this a user-facing change?

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

See above


### What areas of FiftyOne does this PR affect?

-   [x] `App`: FiftyOne application changes
-   [ ] `Build`: Build and test infrastructure changes
-   [ ] `Core`: Core `fiftyone` Python library changes
-   [ ] `Documentation`: FiftyOne documentation changes
-   [ ] `Other`

### Should this PR be mentioned in the release notes? If so, please choose on category:

-   [ ] `breaking-change` - The PR will be mentioned in the "Breaking Changes"
        section
-   [x] `feature` - A new user-facing feature worth mentioning in the release
        notes
-   [ ] `bug-fix` - A user-facing bug fix worth mentioning in the release notes
-   [ ] `documentation` - A user-facing documentation change worth mentioning
        in the release notes
