### PR TITLE
subprocess error handling improvements

### DIFF
--- a/fiftyone/core/service.py
+++ b/fiftyone/core/service.py
@@ -165,9 +165,12 @@ class Service(object):
             for child in fosu.normalize_wrapper_process(self.child).children(
                 recursive=True
             ):
-                for local_port in fosu.get_listening_tcp_ports(child):
-                    if port is None or port == local_port:
-                        return local_port
+                try:
+                    for local_port in fosu.get_listening_tcp_ports(child):
+                        if port is None or port == local_port:
+                            return local_port
+                except psutil.Error:
+                    pass
             raise ServiceListenTimeout(etau.get_class_name(self), port)
 
         return find_port()
@@ -288,7 +291,7 @@ class DatabaseService(MultiClientService):
                 for child in psutil.Process().children()
                 for port in fosu.get_listening_tcp_ports(child)
             )
-        except StopIteration:
+        except (StopIteration, psutil.Error):
             # mongod may have exited - ok to wait until next time
             return
 

--- a/fiftyone/core/service.py
+++ b/fiftyone/core/service.py
@@ -249,7 +249,7 @@ class DatabaseService(MultiClientService):
 
     @property
     def command(self):
-        return [
+        args = [
             DatabaseService.find_mongod(),
             "--dbpath",
             foc.DB_PATH,
@@ -257,8 +257,10 @@ class DatabaseService(MultiClientService):
             foc.DB_LOG_PATH,
             "--port",
             "0",
-            "--nounixsocket",
         ]
+        if not sys.platform.startswith("win"):
+            args.append("--nounixsocket")
+        return args
 
     @property
     def port(self):

--- a/fiftyone/service/main.py
+++ b/fiftyone/service/main.py
@@ -293,7 +293,9 @@ def shutdown():
     # "yarn dev" doesn't pass SIGTERM to its children - to be safe, kill all
     # subprocesses of the child process first
     try:
-        for subchild in child.children(recursive=True):
+        # children() returns parent processes first - start with children
+        # instead to make killing "yarn dev" more reliable
+        for subchild in reversed(child.children(recursive=True)):
             try:
                 subchild.terminate()
             except psutil.NoSuchProcess:


### PR DESCRIPTION
## What changes are proposed in this pull request?

* Added error handling in `_wait_for_child_port`, specifically to address an error seen in https://github.com/voxel51/fiftyone/runs/1038315825#step:10:22. I'm unsure why an `AccessDenied` error would be raised for accessing a child process, but this should handle any psutil errors in a reasonable way now.
*  Changed the order in which subprocesses are terminated in an effort to fix an issue where a dev instance of the app would sometimes leave blank windows behind.

## How is this patch tested? If it is not, in a single sentence please explain why.

Ran `fiftyone app launch` several times to reproduce the second point, was unable to reproduce after https://github.com/voxel51/fiftyone/commit/20e732926348af796e77e24f25738594183bd9bc

## Release Notes

### Is this a user-facing change?

Probably not
