### PR TITLE
Display options in the sample modal

### DIFF
--- a/electron/app/components/CheckboxGrid.tsx
+++ b/electron/app/components/CheckboxGrid.tsx
@@ -32,6 +32,11 @@ export const Body = styled.div`
       font-size: unset;
       align-items: center;
       padding-right: 4px;
+      max-width: 100%;
+    }
+
+    .MuiTypography-body1.with-checkbox {
+      max-width: calc(100% - 24px);
     }
 
     .MuiCheckbox-root {
@@ -73,6 +78,7 @@ export const Body = styled.div`
         overflow-x: hidden;
         text-overflow: ellipsis;
         flex-grow: 1;
+        max-width: 100%;
         line-height: 24px;
       }
 
@@ -119,7 +125,6 @@ const Entry = ({ entry, onCheck }) => {
       onCheck({ ...entry, selected: !entry.selected });
     }
   };
-  console.log(entry);
 
   return (
     <div key={entry.name}>
@@ -147,6 +152,9 @@ const Entry = ({ entry, onCheck }) => {
               )}
           </>
         }
+        classes={{
+          label: entry.hideCheckbox ? "" : "with-checkbox",
+        }}
         style={{
           backgroundColor:
             entry.hideCheckbox || entry.selected

--- a/electron/app/components/CheckboxGrid.tsx
+++ b/electron/app/components/CheckboxGrid.tsx
@@ -105,9 +105,10 @@ const Body = styled.div`
     svg, input[type=checkbox] {
       display: none;
     }
+  }
 
-    .MuiFormControlLabel-label {
-    }
+  && .no-checkbox {
+    cursor: default;
   }
 `;
 
@@ -136,6 +137,8 @@ const Entry = ({ entry, onCheck, modal }) => {
   };
   const atoms = modal ? MODAL_ATOMS : GLOBAL_ATOMS;
 
+  const checkboxClass = entry.hideCheckbox ? "no-checkbox" : "with-checkbox";
+
   return (
     <div key={entry.name}>
       <FormControlLabel
@@ -163,7 +166,8 @@ const Entry = ({ entry, onCheck, modal }) => {
           </>
         }
         classes={{
-          label: entry.hideCheckbox ? "" : "with-checkbox",
+          root: checkboxClass,
+          label: checkboxClass,
         }}
         style={{
           backgroundColor:

--- a/electron/app/components/CheckboxGrid.tsx
+++ b/electron/app/components/CheckboxGrid.tsx
@@ -21,7 +21,7 @@ const MODAL_ATOMS = {
   confidenceRange: atoms.modalFilterLabelConfidenceRange,
 };
 
-export const Body = styled.div`
+const Body = styled.div`
   vertical-align: middle;
 
   label {
@@ -208,5 +208,7 @@ const CheckboxGrid = ({ entries, onCheck, modal }: Props) => {
     </Body>
   );
 };
+
+CheckboxGrid.Body = Body;
 
 export default CheckboxGrid;

--- a/electron/app/components/CheckboxGrid.tsx
+++ b/electron/app/components/CheckboxGrid.tsx
@@ -67,10 +67,12 @@ const Body = styled.div`
         overflow-x: hidden;
         text-overflow: ellipsis;
         flex-grow: 1;
+        line-height: 24px;
       }
 
       span.data {
         margin-left: 0.5em;
+        line-height: 24px;
       }
     }
   }

--- a/electron/app/components/CheckboxGrid.tsx
+++ b/electron/app/components/CheckboxGrid.tsx
@@ -17,19 +17,25 @@ export const Body = styled.div`
 
   label {
     width: 100%;
+    height: 32px;
     margin-top: 3px;
     margin-bottom: 3px;
     margin-left: 0;
     margin-right: 0;
+    padding: 0.2em;
     border-radius: 2px;
+    display: flex;
+    justify-content: space-between;
 
     .MuiTypography-body1 {
+      flex: 1;
       font-size: unset;
       align-items: center;
+      padding-right: 4px;
     }
 
     .MuiCheckbox-root {
-      padding: ${CHECKBOX_PADDING}px;
+      padding: 0;
 
       .MuiIconButton-label {
         position: relative;
@@ -54,9 +60,7 @@ export const Body = styled.div`
 
     .MuiFormControlLabel-label {
       display: inline-flex;
-      min-width: 100%;
       font-weight: bold;
-      padding-right: ${CHECKBOX_TOTAL_SIZE + LABEL_PADDING_RIGHT}px;
       color: unset;
 
       span {
@@ -64,6 +68,7 @@ export const Body = styled.div`
       }
 
       span.name {
+        padding-left: 4px;
         white-space: nowrap;
         overflow-x: hidden;
         text-overflow: ellipsis;
@@ -87,7 +92,6 @@ export const Body = styled.div`
     }
 
     .MuiFormControlLabel-label {
-      padding-right: ${LABEL_PADDING_RIGHT + 2 * CHECKBOX_PADDING}px;
     }
   }
 `;
@@ -115,6 +119,7 @@ const Entry = ({ entry, onCheck }) => {
       onCheck({ ...entry, selected: !entry.selected });
     }
   };
+  console.log(entry);
 
   return (
     <div key={entry.name}>
@@ -143,24 +148,30 @@ const Entry = ({ entry, onCheck }) => {
           </>
         }
         style={{
-          backgroundColor: entry.selected ? theme.backgroundLight : undefined,
+          backgroundColor:
+            entry.hideCheckbox || entry.selected
+              ? theme.backgroundLight
+              : undefined,
           width: "100%",
-          color: entry.selected
-            ? theme.font
-            : entry.disabled
-            ? theme.fontDarkest
-            : theme.fontDark,
+          color:
+            entry.selected || entry.hideCheckbox
+              ? theme.font
+              : entry.disabled
+              ? theme.fontDarkest
+              : theme.fontDark,
         }}
         control={
           <Checkbox
             checked={entry.selected}
             onChange={() => handleCheck(entry)}
             style={{
-              color: entry.selected
-                ? entry.color
-                : entry.disabled
-                ? theme.fontDarkest
-                : theme.fontDark,
+              display: entry.hideCheckbox ? "none" : "block",
+              color:
+                entry.selected || entry.hideCheckbox
+                  ? entry.color
+                  : entry.disabled
+                  ? theme.fontDarkest
+                  : theme.fontDark,
             }}
           />
         }

--- a/electron/app/components/CheckboxGrid.tsx
+++ b/electron/app/components/CheckboxGrid.tsx
@@ -125,15 +125,21 @@ const Entry = ({ entry, onCheck }) => {
             <span className="name" title={entry.name}>
               {entry.name}
             </span>
-            <span className="data">{entry.data}</span>
-            {entry.selected && entry.type && entry.count > 0 && (
-              <ArrowDropDown
-                onClick={(e) => {
-                  e.preventDefault();
-                  setExpanded(!expanded);
-                }}
-              />
-            )}
+            {entry.data}
+            {!(
+              entry.icon &&
+              !["Detections", "Classifications"].includes(entry.type)
+            ) &&
+              entry.selected &&
+              entry.type &&
+              entry.count > 0 && (
+                <ArrowDropDown
+                  onClick={(e) => {
+                    e.preventDefault();
+                    setExpanded(!expanded);
+                  }}
+                />
+              )}
           </>
         }
         style={{

--- a/electron/app/components/CheckboxGrid.tsx
+++ b/electron/app/components/CheckboxGrid.tsx
@@ -12,6 +12,20 @@ const CHECKBOX_PADDING = 3;
 const CHECKBOX_TOTAL_SIZE = CHECKBOX_SIZE + 2 * CHECKBOX_PADDING;
 const LABEL_PADDING_RIGHT = 6;
 
+const GLOBAL_ATOMS = {
+  includeLabels: atoms.filterIncludeLabels,
+  invertInclude: atoms.filterInvertIncludeLabels,
+  includeNoConfidence: atoms.filterLabelIncludeNoConfidence,
+  confidenceRange: atoms.filterLabelConfidenceRange,
+};
+
+const MODAL_ATOMS = {
+  includeLabels: atoms.modalFilterIncludeLabels,
+  invertInclude: atoms.modalFilterInvertIncludeLabels,
+  includeNoConfidence: atoms.modalFilterLabelIncludeNoConfidence,
+  confidenceRange: atoms.modalFilterLabelConfidenceRange,
+};
+
 export const Body = styled.div`
   vertical-align: middle;
 
@@ -116,7 +130,7 @@ type Props = {
   onCheck: (entry: Entry) => void;
 };
 
-const Entry = ({ entry, onCheck }) => {
+const Entry = ({ entry, onCheck, modal }) => {
   const [expanded, setExpanded] = useState(false);
   const theme = useContext(ThemeContext);
 
@@ -125,6 +139,7 @@ const Entry = ({ entry, onCheck }) => {
       onCheck({ ...entry, selected: !entry.selected });
     }
   };
+  const atoms = modal ? MODAL_ATOMS : GLOBAL_ATOMS;
 
   return (
     <div key={entry.name}>
@@ -184,26 +199,16 @@ const Entry = ({ entry, onCheck }) => {
           />
         }
       />
-      {expanded && entry.selected && (
-        <Filter
-          entry={entry}
-          {...{
-            includeLabels: atoms.filterIncludeLabels,
-            invertInclude: atoms.filterInvertIncludeLabels,
-            includeNoConfidence: atoms.filterLabelIncludeNoConfidence,
-            confidenceRange: atoms.filterLabelConfidenceRange,
-          }}
-        />
-      )}
+      {expanded && entry.selected && <Filter entry={entry} {...atoms} />}
     </div>
   );
 };
 
-const CheckboxGrid = ({ entries, onCheck }: Props) => {
+const CheckboxGrid = ({ entries, onCheck, modal }: Props) => {
   return (
     <Body>
       {entries.map((entry) => (
-        <Entry key={entry.name} entry={entry} onCheck={onCheck} />
+        <Entry key={entry.name} entry={entry} onCheck={onCheck} modal={modal} />
       ))}
     </Body>
   );

--- a/electron/app/components/CheckboxGrid.tsx
+++ b/electron/app/components/CheckboxGrid.tsx
@@ -137,6 +137,7 @@ const Entry = ({ entry, onCheck }) => {
         }
         style={{
           backgroundColor: entry.selected ? theme.backgroundLight : undefined,
+          width: "100%",
           color: entry.selected
             ? theme.font
             : entry.disabled

--- a/electron/app/components/CheckboxGrid.tsx
+++ b/electron/app/components/CheckboxGrid.tsx
@@ -12,7 +12,7 @@ const CHECKBOX_PADDING = 3;
 const CHECKBOX_TOTAL_SIZE = CHECKBOX_SIZE + 2 * CHECKBOX_PADDING;
 const LABEL_PADDING_RIGHT = 6;
 
-const Body = styled.div`
+export const Body = styled.div`
   vertical-align: middle;
 
   label {

--- a/electron/app/components/CheckboxGrid.tsx
+++ b/electron/app/components/CheckboxGrid.tsx
@@ -7,11 +7,6 @@ import * as atoms from "../recoil/atoms";
 
 import Filter from "./Filter";
 
-const CHECKBOX_SIZE = 24;
-const CHECKBOX_PADDING = 3;
-const CHECKBOX_TOTAL_SIZE = CHECKBOX_SIZE + 2 * CHECKBOX_PADDING;
-const LABEL_PADDING_RIGHT = 6;
-
 const GLOBAL_ATOMS = {
   includeLabels: atoms.filterIncludeLabels,
   invertInclude: atoms.filterInvertIncludeLabels,

--- a/electron/app/components/DisplayOptionsSidebar.tsx
+++ b/electron/app/components/DisplayOptionsSidebar.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from "react";
 import styled from "styled-components";
+import { useRecoilValue, useSetRecoilState } from "recoil";
 
 import {
   Autorenew,
@@ -14,6 +15,8 @@ import CheckboxGrid from "./CheckboxGrid";
 import DropdownCell from "./DropdownCell";
 import SelectionTag from "./Tags/SelectionTag";
 import { Button } from "./utils";
+import { colorMap as colorMapAtom } from "../recoil/atoms";
+import { refreshColorMap as refreshColorMapSelector } from "../recoil/selectors";
 
 export type Entry = {
   name: string;
@@ -78,7 +81,7 @@ const Container = styled.div`
   }
 `;
 
-const Cell = ({ label, icon, entries, onSelect, colorMap, title }) => {
+const Cell = ({ label, icon, entries, onSelect, colorMap, title, modal }) => {
   const [expanded, setExpanded] = useState(true);
   const numSelected = entries.filter((e) => e.selected).length;
   const handleClear = (e) => {
@@ -138,19 +141,21 @@ const Cell = ({ label, icon, entries, onSelect, colorMap, title }) => {
 const DisplayOptionsSidebar = React.forwardRef(
   (
     {
+      modal = false,
       tags = [],
-      colorMap = {},
       labels = [],
       scalars = [],
       unsupported = [],
       onSelectTag,
       onSelectLabel,
       onSelectScalar,
-      resetColors,
       ...rest
     }: Props,
     ref
   ) => {
+    const refreshColorMap = useSetRecoilState(refreshColorMapSelector);
+    const colorMap = useRecoilValue(colorMapAtom);
+    const cellRest = { modal };
     return (
       <Container ref={ref} {...rest}>
         <Cell
@@ -159,6 +164,7 @@ const DisplayOptionsSidebar = React.forwardRef(
           icon={<PhotoLibrary />}
           entries={tags}
           onSelect={onSelectTag}
+          {...cellRest}
         />
         <Cell
           colorMap={colorMap}
@@ -166,6 +172,7 @@ const DisplayOptionsSidebar = React.forwardRef(
           icon={<Label style={{ transform: "rotate(180deg)" }} />}
           entries={labels}
           onSelect={onSelectLabel}
+          {...cellRest}
         />
         <Cell
           colorMap={colorMap}
@@ -173,6 +180,7 @@ const DisplayOptionsSidebar = React.forwardRef(
           icon={<BarChart />}
           entries={scalars}
           onSelect={onSelectScalar}
+          {...cellRest}
         />
         {unsupported.length ? (
           <Cell
@@ -185,10 +193,11 @@ const DisplayOptionsSidebar = React.forwardRef(
               selected: false,
               disabled: true,
             }))}
+            {...cellRest}
           />
         ) : null}
         {tags.length || labels.length || scalars.length ? (
-          <Button onClick={resetColors}>
+          <Button onClick={refreshColorMap}>
             <Autorenew />
             Refresh colors
           </Button>

--- a/electron/app/components/DisplayOptionsSidebar.tsx
+++ b/electron/app/components/DisplayOptionsSidebar.tsx
@@ -124,7 +124,7 @@ const Cell = ({ label, icon, entries, onSelect, colorMap, title }) => {
             name: e.name,
             selected: e.selected,
             type: e.type,
-            data: [(e.count || 0).toLocaleString()],
+            data: e.icon ? e.icon : [(e.count || 0).toLocaleString()],
             count: e.count,
             color: colorMap[e.name],
             disabled: Boolean(e.disabled),

--- a/electron/app/components/DisplayOptionsSidebar.tsx
+++ b/electron/app/components/DisplayOptionsSidebar.tsx
@@ -1,5 +1,6 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import styled from "styled-components";
+import { useSetRecoilState, useRecoilValue } from "recoil";
 
 import { BarChart, Help, Label, PhotoLibrary } from "@material-ui/icons";
 
@@ -7,6 +8,8 @@ import CellHeader from "./CellHeader";
 import CheckboxGrid from "./CheckboxGrid";
 import DropdownCell from "./DropdownCell";
 import SelectionTag from "./Tags/SelectionTag";
+
+import * as selectors from "../recoil/selectors";
 
 export type Entry = {
   name: string;
@@ -141,6 +144,11 @@ const DisplayOptionsSidebar = React.forwardRef(
     }: Props,
     ref
   ) => {
+    const filters = useRecoilValue(selectors.labelFilters);
+    const setModalFilters = useSetRecoilState(selectors.modalLabelFilters);
+    useEffect(() => {
+      setModalFilters(filters);
+    }, [filters]);
     return (
       <Container ref={ref} {...rest}>
         <Cell

--- a/electron/app/components/DisplayOptionsSidebar.tsx
+++ b/electron/app/components/DisplayOptionsSidebar.tsx
@@ -144,13 +144,15 @@ const DisplayOptionsSidebar = React.forwardRef(
   ) => {
     return (
       <Container ref={ref} {...rest}>
-        <Cell
-          colorMapping={colorMapping}
-          label="Tags"
-          icon={<PhotoLibrary />}
-          entries={tags}
-          onSelect={onSelectTag}
-        />
+        {tags && (
+          <Cell
+            colorMapping={colorMapping}
+            label="Tags"
+            icon={<PhotoLibrary />}
+            entries={tags}
+            onSelect={onSelectTag}
+          />
+        )}
         <Cell
           colorMapping={colorMapping}
           label="Labels"

--- a/electron/app/components/DisplayOptionsSidebar.tsx
+++ b/electron/app/components/DisplayOptionsSidebar.tsx
@@ -25,6 +25,15 @@ type Props = {
 
 const Container = styled.div`
   margin-bottom: 2px;
+  &::-webkit-scrollbar {
+    width: 0px;
+    background: transparent;
+    display: none;
+  }
+  &::-webkit-scrollbar-thumb {
+    width: 0px;
+    display: none;
+  }
 
   .MuiCheckbox-root {
     padding: 4px 8px 4px 4px;

--- a/electron/app/components/DisplayOptionsSidebar.tsx
+++ b/electron/app/components/DisplayOptionsSidebar.tsx
@@ -131,7 +131,7 @@ const DisplayOptionsSidebar = React.forwardRef(
   (
     {
       colorMapping = {},
-      tags = [],
+      tags = null,
       labels = [],
       scalars = [],
       unsupported = [],

--- a/electron/app/components/DisplayOptionsSidebar.tsx
+++ b/electron/app/components/DisplayOptionsSidebar.tsx
@@ -127,6 +127,7 @@ const Cell = ({ label, icon, entries, onSelect, colorMap, title, modal }) => {
             data: e.icon ? e.icon : [(e.count || 0).toLocaleString()],
             count: e.count,
             color: colorMap[e.name],
+            hideCheckbox: e.hideCheckbox,
             disabled: Boolean(e.disabled),
           }))}
           onCheck={onSelect}

--- a/electron/app/components/DisplayOptionsSidebar.tsx
+++ b/electron/app/components/DisplayOptionsSidebar.tsx
@@ -131,6 +131,7 @@ const Cell = ({ label, icon, entries, onSelect, colorMap, title, modal }) => {
             disabled: Boolean(e.disabled),
           }))}
           onCheck={onSelect}
+          modal={modal}
         />
       ) : (
         <span>No options available</span>

--- a/electron/app/components/DisplayOptionsSidebar.tsx
+++ b/electron/app/components/DisplayOptionsSidebar.tsx
@@ -28,6 +28,7 @@ type Props = {
 
 const Container = styled.div`
   margin-bottom: 2px;
+  height: 100%;
   &::-webkit-scrollbar {
     width: 0px;
     background: transparent;

--- a/electron/app/components/DisplayOptionsSidebar.tsx
+++ b/electron/app/components/DisplayOptionsSidebar.tsx
@@ -15,7 +15,7 @@ import CheckboxGrid from "./CheckboxGrid";
 import DropdownCell from "./DropdownCell";
 import SelectionTag from "./Tags/SelectionTag";
 import { Button } from "./utils";
-import { colorMap as colorMapAtom } from "../recoil/atoms";
+import * as atoms from "../recoil/atoms";
 import { refreshColorMap as refreshColorMapSelector } from "../recoil/selectors";
 
 export type Entry = {
@@ -156,7 +156,7 @@ const DisplayOptionsSidebar = React.forwardRef(
     ref
   ) => {
     const refreshColorMap = useSetRecoilState(refreshColorMapSelector);
-    const colorMap = useRecoilValue(colorMapAtom);
+    const colorMap = useRecoilValue(atoms.colorMap);
     const cellRest = { modal };
     return (
       <Container ref={ref} {...rest}>

--- a/electron/app/components/DisplayOptionsSidebar.tsx
+++ b/electron/app/components/DisplayOptionsSidebar.tsx
@@ -1,6 +1,5 @@
-import React, { useEffect, useState } from "react";
+import React, { useState } from "react";
 import styled from "styled-components";
-import { useSetRecoilState, useRecoilValue } from "recoil";
 
 import { BarChart, Help, Label, PhotoLibrary } from "@material-ui/icons";
 
@@ -8,8 +7,6 @@ import CellHeader from "./CellHeader";
 import CheckboxGrid from "./CheckboxGrid";
 import DropdownCell from "./DropdownCell";
 import SelectionTag from "./Tags/SelectionTag";
-
-import * as selectors from "../recoil/selectors";
 
 export type Entry = {
   name: string;
@@ -145,11 +142,6 @@ const DisplayOptionsSidebar = React.forwardRef(
     }: Props,
     ref
   ) => {
-    const filters = useRecoilValue(selectors.labelFilters);
-    const setModalFilters = useSetRecoilState(selectors.modalLabelFilters);
-    useEffect(() => {
-      setModalFilters(filters);
-    }, [filters]);
     return (
       <Container ref={ref} {...rest}>
         <Cell

--- a/electron/app/components/DisplayOptionsSidebar.tsx
+++ b/electron/app/components/DisplayOptionsSidebar.tsx
@@ -32,7 +32,6 @@ type Props = {
 
 const Container = styled.div`
   margin-bottom: 2px;
-<<<<<<< HEAD
   height: 100%;
   &::-webkit-scrollbar {
     width: 0px;
@@ -43,9 +42,7 @@ const Container = styled.div`
     width: 0px;
     display: none;
   }
-=======
   padding-bottom: 1em;
->>>>>>> improve-colors
 
   .MuiCheckbox-root {
     padding: 4px 8px 4px 4px;

--- a/electron/app/components/DropdownCell.tsx
+++ b/electron/app/components/DropdownCell.tsx
@@ -11,23 +11,24 @@ const BoxedWrapper = styled.div`
 `;
 
 const BoxedHeader = styled(DropdownHandle)`
-  width: 15rem;
+  width: 100% !important;
 `;
 
 const StandardHeader = styled(BoxedHeader)`
   border-radius: 0;
   border-width: 0 0 1px 0;
   padding: 0.5em 0 0.5em 0;
+  width: 100%;
 `;
 
 const StandardBody = styled.div`
-  width: 15rem;
+  width: 100%;
   padding-top: 0.5em;
   margin-bottom: 1em;
 `;
 
 const BoxedBody = styled(Box)`
-  width: 15rem;
+  width: 100%;
   border-top: none;
 `;
 

--- a/electron/app/components/DropdownHandle.tsx
+++ b/electron/app/components/DropdownHandle.tsx
@@ -5,7 +5,7 @@ import { Add, ExpandLess, ExpandMore, Remove } from "@material-ui/icons";
 import CellHeader from "./CellHeader";
 
 const Body = styled(CellHeader)`
-  width: 15rem;
+  width: 100%;
 
   svg {
     font-size: 1.25em;

--- a/electron/app/components/Filter.tsx
+++ b/electron/app/components/Filter.tsx
@@ -29,19 +29,53 @@ const SearchResultsWrapper = styled.div`
 const SliderContainer = styled.div`
   font-weight: bold;
   display: flex;
-  padding: 0.5rem;
+  padding: 1.5rem 0.5rem 0.5rem;
+  line-height: 1.9rem;
 `;
 
 const Slider = styled(SliderUnstyled)`
   && {
     color: ${({ theme }) => theme.brand};
-    margin: 0.1rem 0.75rem 0 0.75rem;
+    margin: 0 0.7rem 0 0.5rem;
     height: 3px;
   }
 
   && .MuiSlider-rail {
     height: 7px;
-    background: ${({ theme }) => theme.background};
+    border-radius: 6px;
+    background: ${({ theme }) => theme.backgroundLight};
+  }
+
+  && .MuiSlider-track {
+    height: 7px;
+    border-radius: 6px;
+    background: ${({ theme }) => theme.brand};
+  }
+
+  && .MuiSlider-thumb {
+    height: 1rem;
+    width: 1rem;
+    border-radius: 0.5rem;
+    background: ${({ theme }) => theme.brand};
+    box-shadow: none;
+  }
+
+  && .MuiSlider-thumb > span {
+    margin-left: -0.5rem;
+  }
+
+  && .MuiSlider-thumb [class*="PrivateValueLabel-circle-"] {
+    color: transparent;
+    display: flex !important;
+  }
+
+  && .MuiSlider-thumb [class*="PrivateValueLabel-label-"] {
+    color: ${({ theme }) => theme.font};
+    font-weight: bold;
+    font-family: "Palanquin", sans-serif;
+    margin-top: 2rem;
+    font-size: 14px;
+    display: flex !important;
   }
 `;
 
@@ -66,6 +100,7 @@ const RangeSlider = ({ atom, ...rest }) => {
         valueLabelDisplay="auto"
         aria-labelledby="range-slider"
         getAriaValueText={valuetext}
+        valueLabelDisplay={"on"}
         {...rest}
       />
       1

--- a/electron/app/components/Filter.tsx
+++ b/electron/app/components/Filter.tsx
@@ -80,6 +80,7 @@ const FilterDiv = styled.div`
   padding: 0.5rem;
   font-weight: bold;
   font-size: 14px;
+  margin: 3px 0;
 `;
 
 const classFilterMachine = Machine({
@@ -232,7 +233,7 @@ const ClassInput = styled.input`
   width: 100%;
   background: ${({ theme }) => theme.backgroundDark};
   border: 1px solid #191c1f;
-  box-shadow: 0 7px 35px 0 rgba(0, 0, 0, 0.43);
+  box-shadow: 0 8px 15px 0 rgba(0, 0, 0, 0.43);
   border-radius: 2px;
   font-size: 14px;
   line-height: 1.2rem;
@@ -379,7 +380,7 @@ const ClassFilter = ({ name, atoms }) => {
 
 const ConfidenceContainer = styled.div`
   background: ${({ theme }) => theme.backgroundDark};
-  box-shadow: 0 10px 35px 0 rgba(0, 0, 0, 0.43);
+  box-shadow: 0 8px 15px 0 rgba(0, 0, 0, 0.43);
   border: 1px solid #191c1f;
   border-radius: 2px;
   margin-top: 0.5rem;

--- a/electron/app/components/Filter.tsx
+++ b/electron/app/components/Filter.tsx
@@ -248,7 +248,6 @@ const classFilterMachine = Machine({
         assign({
           classes: (_, { classes }) => classes,
           results: ({ inputValue }, { classes }) =>
-            console.log(classes) &&
             classes.filter((c) =>
               c.toLowerCase().includes(inputValue.toLowerCase())
             ),
@@ -464,11 +463,7 @@ const Filter = React.memo(({ style, entry, ...atoms }) => {
               checked={includeNoConfidence}
               onChange={() => setIncludeNoConfidence(!includeNoConfidence)}
               style={{
-                color: entry.selected
-                  ? entry.color
-                  : entry.disabled
-                  ? theme.fontDarkest
-                  : theme.fontDark,
+                color: entry.selected ? entry.color : theme.fontDark,
               }}
             />
           }

--- a/electron/app/components/Filter.tsx
+++ b/electron/app/components/Filter.tsx
@@ -38,6 +38,11 @@ const Slider = styled(SliderUnstyled)`
     margin: 0.1rem 0.75rem 0 0.75rem;
     height: 3px;
   }
+
+  && .MuiSlider-rail {
+    height: 7px;
+    background: ${({ theme }) => theme.background};
+  }
 `;
 
 const RangeSlider = ({ atom, ...rest }) => {
@@ -226,12 +231,14 @@ const classFilterMachine = Machine({
 const ClassInput = styled.input`
   width: 100%;
   background: ${({ theme }) => theme.backgroundDark};
-  border: 1px ${({ theme }) => theme.backgroundDarkBorder};
+  border: 1px solid #191c1f;
+  box-shadow: 0 7px 35px 0 rgba(0, 0, 0, 0.43);
   border-radius: 2px;
   font-size: 14px;
   line-height: 1.2rem;
   font-weight: bold;
   padding: 0.5rem;
+  margin-bottom: 0.5rem;
 
   &:focus {
     outline: none;
@@ -247,12 +254,14 @@ const Selected = styled.div`
 
 const ClassButton = styled.button`
   background: ${({ theme }) => theme.background};
-  border: 1px solid ${({ theme }) => theme.backgroundDarkBorder};
+  border: 2px solid #393C3F;
+  background-color: #2D3034;
   border-radius: 11px;
   text-align: center
   vertical-align: middle;
   margin: 0.5rem 0.25rem 0;
   padding: 0 0.5rem;
+  line-height: 20px;
   font-weight: bold;
   cursor: pointer;
   &:focus {
@@ -371,7 +380,7 @@ const ClassFilter = ({ name, atoms }) => {
 const ConfidenceContainer = styled.div`
   background: ${({ theme }) => theme.backgroundDark};
   box-shadow: 0 10px 35px 0 rgba(0, 0, 0, 0.43);
-  border: 1px solid ${({ theme }) => theme.backgroundLightBorder};
+  border: 1px solid #191c1f;
   border-radius: 2px;
   margin-top: 0.5rem;
   color: ${({ theme }) => theme.fontDark};
@@ -409,7 +418,7 @@ const Filter = React.memo(({ entry, ...atoms }) => {
           step={0.01}
         />
         <FormControlLabel
-          label={<div>Show no confidence</div>}
+          label={<div style={{ lineHeight: "20px" }}>Show no confidence</div>}
           control={
             <Checkbox
               checked={includeNoConfidence}

--- a/electron/app/components/Filter.tsx
+++ b/electron/app/components/Filter.tsx
@@ -36,7 +36,7 @@ const SliderContainer = styled.div`
 const Slider = styled(SliderUnstyled)`
   && {
     color: ${({ theme }) => theme.brand};
-    margin: 0 0.7rem 0 0.5rem;
+    margin: 0 1rem 0 0.8rem;
     height: 3px;
   }
 
@@ -76,6 +76,8 @@ const Slider = styled(SliderUnstyled)`
     margin-top: 2rem;
     font-size: 14px;
     display: flex !important;
+    padding: 0.2rem;
+    border-radius: 6rem;
   }
 `;
 
@@ -92,7 +94,7 @@ const RangeSlider = ({ atom, ...rest }) => {
       0
       <Slider
         value={[...localValue]}
-        onChange={(e, v) => setLocalValue([...v])}
+        onChange={(_, v) => setLocalValue([...v])}
         onChangeCommitted={(e, v) => {
           setLocalValue([...v]);
           setValue([...v]);
@@ -116,6 +118,7 @@ const FilterDiv = styled.div`
   font-weight: bold;
   font-size: 14px;
   margin: 3px 0;
+  border-radius: 2px;
 `;
 
 const classFilterMachine = Machine({
@@ -245,6 +248,7 @@ const classFilterMachine = Machine({
         assign({
           classes: (_, { classes }) => classes,
           results: ({ inputValue }, { classes }) =>
+            console.log(classes) &&
             classes.filter((c) =>
               c.toLowerCase().includes(inputValue.toLowerCase())
             ),
@@ -422,7 +426,7 @@ const ConfidenceContainer = styled.div`
   color: ${({ theme }) => theme.fontDark};
 `;
 
-const Filter = React.memo(({ entry, ...atoms }) => {
+const Filter = React.memo(({ style, entry, ...atoms }) => {
   const [includeNoConfidence, setIncludeNoConfidence] = useRecoilState(
     atoms.includeNoConfidence(entry.name)
   );
@@ -432,7 +436,7 @@ const Filter = React.memo(({ entry, ...atoms }) => {
   const isDefaultRange = range[0] === 0 && range[1] === 1;
 
   return (
-    <FilterDiv>
+    <FilterDiv style={style}>
       <ClassFilter name={entry.name} atoms={atoms} />
       <div style={{ display: "flex", justifyContent: "space-between" }}>
         Confidence{" "}

--- a/electron/app/components/ImageContainerHeader.tsx
+++ b/electron/app/components/ImageContainerHeader.tsx
@@ -13,7 +13,7 @@ type Props = {
 const Wrapper = styled.div`
   background: ${({ theme }) => theme.background};
   display: grid;
-  grid-template-columns: 17rem auto auto;
+  grid-template-columns: 264px auto auto;
   padding-top: 5px;
   padding-bottom: 5px;
 
@@ -49,6 +49,7 @@ const ImageContainerHeader = ({
           label="Display Options"
           expanded={showSidebar}
           onClick={onShowSidebar && (() => onShowSidebar(!showSidebar))}
+          style={{ width: 240 }}
         />
       </div>
       <div>

--- a/electron/app/components/JSONView.tsx
+++ b/electron/app/components/JSONView.tsx
@@ -20,6 +20,15 @@ const Body = styled.div`
     flex-grow: 1;
     overflow-y: auto;
   }
+  pre::-webkit-scrollbar {
+    width: 0px;
+    background: transparent;
+    display: none;
+  }
+  pre::-webkit-scrollbar-thumb {
+    width: 0px;
+    display: none;
+  }
 
   ${ModalFooter} {
     flex-direction: column;

--- a/electron/app/components/Player51.tsx
+++ b/electron/app/components/Player51.tsx
@@ -6,8 +6,7 @@ import clickHandler from "../utils/click.ts";
 import { RESERVED_FIELDS, VALID_SCALAR_TYPES } from "../utils/labels";
 import { useRecoilValue, useSetRecoilState } from "recoil";
 
-import { colorMap as colorMapAtom } from "../recoil/atoms";
-import { refreshColorMap as refreshColorMapSelector } from "../recoil/selectors";
+import * as atoms from "../recoil/atoms";
 
 const PARSERS = {
   Classification: [
@@ -86,7 +85,7 @@ export default ({
   filterSelector,
 }) => {
   const filter = useRecoilValue(filterSelector);
-  const colorMap = useRecoilValue(colorMapAtom);
+  const colorMap = useRecoilValue(atoms.colorMap);
   let [overlay, playerColorMap] = loadOverlay(
     sample,
     colorMap,

--- a/electron/app/components/Player51.tsx
+++ b/electron/app/components/Player51.tsx
@@ -4,7 +4,10 @@ import uuid from "react-uuid";
 import Player51 from "../player51/build/cjs/player51.min.js";
 import clickHandler from "../utils/click.ts";
 import { RESERVED_FIELDS, VALID_SCALAR_TYPES } from "../utils/labels";
-import { useRecoilValue } from "recoil";
+import { useRecoilValue, useSetRecoilState } from "recoil";
+
+import { colorMap as colorMapAtom } from "../recoil/atoms";
+import { refreshColorMap as refreshColorMapSelector } from "../recoil/selectors";
 
 const PARSERS = {
   Classification: [
@@ -71,7 +74,6 @@ const loadOverlay = (sample, colorMap, fieldSchema, filter) => {
 };
 
 export default ({
-  colorMap,
   thumbnail,
   sample,
   src,
@@ -84,7 +86,8 @@ export default ({
   filterSelector,
 }) => {
   const filter = useRecoilValue(filterSelector);
-  const [overlay, playerColorMap] = loadOverlay(
+  const colorMap = useRecoilValue(colorMapAtom);
+  let [overlay, playerColorMap] = loadOverlay(
     sample,
     colorMap,
     fieldSchema,
@@ -117,8 +120,15 @@ export default ({
       setInitLoad(true);
       onLoad();
     } else {
-      player.updateOptions({ activeLabels, filter });
+      [overlay, playerColorMap] = loadOverlay(
+        sample,
+        colorMap,
+        fieldSchema,
+        filter
+      );
+      player.updateOptions({ activeLabels, filter, colorMap: playerColorMap });
     }
-  }, [filter, overlay, activeLabels]);
+  }, [filter, overlay, activeLabels, colorMap]);
+
   return <div id={id} style={style} {...props} />;
 };

--- a/electron/app/components/Player51.tsx
+++ b/electron/app/components/Player51.tsx
@@ -4,6 +4,7 @@ import uuid from "react-uuid";
 import Player51 from "../player51/build/cjs/player51.min.js";
 import clickHandler from "../utils/click.ts";
 import { RESERVED_FIELDS, VALID_SCALAR_TYPES } from "../utils/labels";
+import { useRecoilValue } from "recoil";
 
 const PARSERS = {
   Classification: [
@@ -80,8 +81,9 @@ export default ({
   onLoad = () => {},
   activeLabels,
   fieldSchema = {},
-  filter,
+  filterSelector,
 }) => {
+  const filter = useRecoilValue(filterSelector);
   const [overlay, playerColorMap] = loadOverlay(
     sample,
     colorMapping,

--- a/electron/app/components/Sample.tsx
+++ b/electron/app/components/Sample.tsx
@@ -93,7 +93,7 @@ const Sample = ({
         thumbnail={true}
         activeLabels={activeLabels}
         {...eventHandlers}
-        filter={filter}
+        filterSelector={selectors.labelFilters}
       />
       <div className="sample-info" {...eventHandlers}>
         {Object.keys(sample)

--- a/electron/app/components/Sample.tsx
+++ b/electron/app/components/Sample.tsx
@@ -6,12 +6,12 @@ import { getSocket } from "../utils/socket";
 import connect from "../utils/connect";
 import Player51 from "./Player51";
 import Tag from "./Tags/Tag";
+import * as atoms from "../recoil/atoms";
 import * as selectors from "../recoil/selectors";
 import { getLabelText, stringify } from "../utils/labels";
 
 const Sample = ({
   displayProps,
-  colorMap,
   dispatch,
   sample,
   port,
@@ -25,6 +25,7 @@ const Sample = ({
   const socket = getSocket(port, "state");
   const { activeLabels, activeTags, activeOther } = displayProps;
   const filter = useRecoilValue(selectors.labelFilters);
+  const colorMap = useRecoilValue(atoms.colorMap);
 
   const handleClick = () => {
     const newSelected = { ...selected };
@@ -88,7 +89,6 @@ const Sample = ({
           width: "100%",
           position: "relative",
         }}
-        colorMap={colorMap}
         sample={sample}
         thumbnail={true}
         activeLabels={activeLabels}

--- a/electron/app/components/SampleModal.tsx
+++ b/electron/app/components/SampleModal.tsx
@@ -13,7 +13,11 @@ import * as selectors from "../recoil/selectors";
 import * as atoms from "../recoil/atoms";
 
 import { useKeydownHandler, useResizeHandler } from "../utils/hooks";
-import { formatMetadata, makeLabelNameGroups } from "../utils/labels";
+import {
+  formatMetadata,
+  makeLabelNameGroups,
+  stringify,
+} from "../utils/labels";
 
 type Props = {
   sample: object;
@@ -295,14 +299,13 @@ const SampleModal = ({
       hideCheckbox,
       name,
       type,
-      icon:
-        typeof countOrExists[name] === "boolean" ? (
-          countOrExists[name] ? (
-            <Check style={{ color: colorMap[name] }} />
-          ) : (
-            <Close style={{ color: colorMap[name] }} />
-          )
-        ) : undefined,
+      icon: ["boolean", "undefined"].includes(typeof countOrExists[name]) ? (
+        countOrExists[name] ? (
+          <Check style={{ color: colorMap[name] }} />
+        ) : (
+          <Close style={{ color: colorMap[name] }} />
+        )
+      ) : undefined,
       count: countOrExists[name],
       selected: Boolean(selected[name]),
     }));
@@ -344,7 +347,10 @@ const SampleModal = ({
   const scalarSampleValues = labelNameGroups.scalars.reduce(
     (obj, { name }) => ({
       ...obj,
-      [name]: sample[name] ? sample[name] : false,
+      [name]:
+        sample[name] !== undefined && sample[name] !== null
+          ? stringify(sample[name])
+          : undefined,
     }),
     {}
   );

--- a/electron/app/components/SampleModal.tsx
+++ b/electron/app/components/SampleModal.tsx
@@ -160,14 +160,25 @@ const Container = styled(Body)`
   }
 
   .row {
+    display: flex;
+    justify-content: space-between;
+    width: 100%;
+    flex-wrap: wrap;
+
     > label {
       font-weight: bold;
+      display: block;
+      padding-right: 0.5rem;
+      width: auto;
     }
-    > span {
-      float: right;
+    > div {
+      display: block;
+      max-width: 100%;
     }
     span {
-      word-wrap: break-word;
+      flex-grow: 2;
+      overflow-wrap: break-word;
+      vertical-align: middle;
     }
   }
 `;
@@ -209,10 +220,10 @@ const TopRightNavButton = ({ icon, title, onClick }) => {
 const Row = ({ name, renderedName, value, children, ...rest }) => (
   <div className="row" {...rest}>
     <label>{renderedName || name}&nbsp;</label>
-    <span style={{ display: "flex", justifyContent: "space-between" }}>
+    <div>
       <span>{value}</span>
-      {children}
-    </span>
+    </div>
+    {children}
   </div>
 );
 

--- a/electron/app/components/SampleModal.tsx
+++ b/electron/app/components/SampleModal.tsx
@@ -16,6 +16,7 @@ import { Button, ModalFooter } from "./utils";
 import * as selectors from "../recoil/selectors";
 import * as atoms from "../recoil/atoms";
 import Filter from "./Filter";
+import { Body } from "./CheckboxGrid";
 
 import { useKeydownHandler, useResizeHandler } from "../utils/hooks";
 import {
@@ -34,7 +35,7 @@ type Props = {
   sampleUrl: string;
 };
 
-const Container = styled.div`
+const Container = styled(Body)`
   display: grid;
   grid-template-columns: auto 280px;
   width: 90vw;
@@ -141,9 +142,6 @@ const Container = styled.div`
   }
 
   .row {
-    display: flex;
-    justify-content: space-between;
-    flex-wrap: wrap;
     > label {
       font-weight: bold;
     }

--- a/electron/app/components/SampleModal.tsx
+++ b/electron/app/components/SampleModal.tsx
@@ -158,7 +158,24 @@ const Row = ({ name, renderedName, value, children, ...rest }) => (
 );
 
 const LabelRow = (props) => {
-  return <Row {...props}></Row>;
+  const [expanded, setExpanded] = useState(false);
+  return (
+    <Row {...props}>
+      {expanded && entry.selected && (
+        <Filter
+          entry={{
+            name,
+          }}
+          {...{
+            includeLabels: atoms.modalFilterIncludeLabels,
+            invertInclude: atoms.modalFilterInvertIncludeLabels,
+            includeNoConfidence: atoms.modalFilterLabelIncludeNoConfidence,
+            confidenceRange: atoms.modalFilterLabelConfidenceRange,
+          }}
+        />
+      )}
+    </Row>
+  );
 };
 
 const SampleModal = ({

--- a/electron/app/components/SampleModal.tsx
+++ b/electron/app/components/SampleModal.tsx
@@ -30,7 +30,7 @@ type Props = {
 
 const Container = styled(Body)`
   display: grid;
-  grid-template-columns: 280px auto;
+  grid-template-columns: auto 280px;
   width: 90vw;
   height: 80vh;
   background-color: ${({ theme }) => theme.background};
@@ -125,7 +125,7 @@ const Container = styled(Body)`
     position: relative;
     display: flex;
     flex-direction: column;
-    border-right: 2px solid ${({ theme }) => theme.border};
+    border-left: 2px solid ${({ theme }) => theme.border};
     max-height: 100%;
     overflow-y: auto;
 
@@ -201,9 +201,9 @@ const TopRightNavButtonContainer = styled.div`
   justify-content: center;
 `;
 
-const TopRightNavButton = ({ icon, title, onClick }) => {
+const TopRightNavButton = ({ icon, title, onClick, ...rest }) => {
   return (
-    <TopRightNavButtonContainer title={title} onClick={onClick}>
+    <TopRightNavButtonContainer title={title} onClick={onClick} {...rest}>
       {icon}
     </TopRightNavButtonContainer>
   );
@@ -366,6 +366,51 @@ const SampleModal = ({
 
   return (
     <Container className={fullscreen ? "fullscreen" : ""}>
+      <div className="player" ref={playerContainerRef}>
+        {showJSON ? (
+          <JSONView object={sample} />
+        ) : (
+          <Player51
+            key={sampleUrl} // force re-render when this changes
+            src={sampleUrl}
+            onLoad={handleResize}
+            style={{
+              position: "relative",
+              ...playerStyle,
+            }}
+            sample={sample}
+            colorMap={colorMap}
+            activeLabels={activeLabels}
+            fieldSchema={fieldSchema}
+            filterSelector={selectors.modalLabelFilters}
+          />
+        )}
+        {onPrevious ? (
+          <div
+            className="nav-button left"
+            onClick={onPrevious}
+            title="Previous sample (Left arrow)"
+          >
+            &lt;
+          </div>
+        ) : null}
+        {onNext ? (
+          <div
+            className="nav-button right"
+            onClick={onNext}
+            title="Next sample (Right arrow)"
+          >
+            &gt;
+          </div>
+        ) : null}
+        <TopRightNavButtons>
+          <TopRightNavButton
+            onClick={() => setFullscreen(!fullscreen)}
+            title={fullscreen ? "Unmaximize (Esc)" : "Maximize"}
+            icon={fullscreen ? <FullscreenExit /> : <Fullscreen />}
+          />
+        </TopRightNavButtons>
+      </div>
       <div className="sidebar">
         <div className="sidebar-content">
           <h2>
@@ -412,62 +457,18 @@ const SampleModal = ({
               height: "auto",
             }}
           />
+          <TopRightNavButton
+            onClick={onClose}
+            title={"Close"}
+            icon={<Close />}
+            style={{ position: "absolute", top: 0, right: 0 }}
+          />
         </div>
         <ModalFooter>
           <Button onClick={() => setShowJSON(!showJSON)}>
             {showJSON ? "Hide" : "Show"} JSON
           </Button>
         </ModalFooter>
-      </div>
-      <div className="player" ref={playerContainerRef}>
-        {showJSON ? (
-          <JSONView object={sample} />
-        ) : (
-          <Player51
-            key={sampleUrl} // force re-render when this changes
-            src={sampleUrl}
-            onLoad={handleResize}
-            style={{
-              position: "relative",
-              ...playerStyle,
-            }}
-            sample={sample}
-            colorMap={colorMap}
-            activeLabels={activeLabels}
-            fieldSchema={fieldSchema}
-            filterSelector={selectors.modalLabelFilters}
-          />
-        )}
-        {onPrevious ? (
-          <div
-            className="nav-button left"
-            onClick={onPrevious}
-            title="Previous sample (Left arrow)"
-          >
-            &lt;
-          </div>
-        ) : null}
-        {onNext ? (
-          <div
-            className="nav-button right"
-            onClick={onNext}
-            title="Next sample (Right arrow)"
-          >
-            &gt;
-          </div>
-        ) : null}
-        <TopRightNavButtons>
-          <TopRightNavButton
-            onClick={() => setFullscreen(!fullscreen)}
-            title={fullscreen ? "Unmaximize (Esc)" : "Maximize"}
-            icon={fullscreen ? <FullscreenExit /> : <Fullscreen />}
-          />
-          <TopRightNavButton
-            onClick={onClose}
-            title={"Close"}
-            icon={<Close />}
-          />
-        </TopRightNavButtons>
       </div>
     </Container>
   );

--- a/electron/app/components/SampleModal.tsx
+++ b/electron/app/components/SampleModal.tsx
@@ -144,6 +144,15 @@ const Container = styled(Body)`
       flex-grow: 1;
       overflow-y: auto;
     }
+    .sidebar-content::-webkit-scrollbar {
+      width: 0px;
+      background: transparent;
+      display: none;
+    }
+    .sidebar-content::-webkit-scrollbar-thumb {
+      width: 0px;
+      display: none;
+    }
 
     ${ModalFooter} {
       align-items: flex-start;

--- a/electron/app/components/SampleModal.tsx
+++ b/electron/app/components/SampleModal.tsx
@@ -7,7 +7,7 @@ import {
   Fullscreen,
   FullscreenExit,
 } from "@material-ui/icons";
-import { useRecoilValue, useRecoilState } from "recoil";
+import { useRecoilState } from "recoil";
 
 import JSONView from "./JSONView";
 import Player51 from "./Player51";
@@ -37,7 +37,7 @@ type Props = {
 
 const Container = styled(Body)`
   display: grid;
-  grid-template-columns: auto 280px;
+  grid-template-columns: 280px auto;
   width: 90vw;
   height: 80vh;
   background-color: ${({ theme }) => theme.background};
@@ -124,7 +124,7 @@ const Container = styled(Body)`
     position: relative;
     display: flex;
     flex-direction: column;
-    border-left: 2px solid ${({ theme }) => theme.border};
+    border-right: 2px solid ${({ theme }) => theme.border};
     max-height: 100%;
     overflow-y: auto;
 
@@ -336,51 +336,6 @@ const SampleModal = ({
 
   return (
     <Container className={fullscreen ? "fullscreen" : ""}>
-      <div className="player" ref={playerContainerRef}>
-        {showJSON ? (
-          <JSONView object={sample} />
-        ) : (
-          <Player51
-            key={sampleUrl} // force re-render when this changes
-            src={sampleUrl}
-            onLoad={handleResize}
-            style={{
-              position: "relative",
-              ...playerStyle,
-            }}
-            sample={sample}
-            colorMapping={colorMapping}
-            activeLabels={activeLabels}
-            fieldSchema={fieldSchema}
-            filterSelector={selectors.modalLabelFilters}
-          />
-        )}
-        {onPrevious ? (
-          <div
-            className="nav-button left"
-            onClick={onPrevious}
-            title="Previous sample (Left arrow)"
-          >
-            &lt;
-          </div>
-        ) : null}
-        {onNext ? (
-          <div
-            className="nav-button right"
-            onClick={onNext}
-            title="Next sample (Right arrow)"
-          >
-            &gt;
-          </div>
-        ) : null}
-        <div
-          className="nav-button fullscreen"
-          title={fullscreen ? "Unmaximize (Esc)" : "Maximize"}
-          onClick={() => setFullscreen(!fullscreen)}
-        >
-          {fullscreen ? <FullscreenExit /> : <Fullscreen />}
-        </div>
-      </div>
       <div className="sidebar">
         <div className="sidebar-content">
           <h2>
@@ -428,6 +383,51 @@ const SampleModal = ({
             {showJSON ? "Hide" : "Show"} JSON
           </Button>
         </ModalFooter>
+      </div>
+      <div className="player" ref={playerContainerRef}>
+        {showJSON ? (
+          <JSONView object={sample} />
+        ) : (
+          <Player51
+            key={sampleUrl} // force re-render when this changes
+            src={sampleUrl}
+            onLoad={handleResize}
+            style={{
+              position: "relative",
+              ...playerStyle,
+            }}
+            sample={sample}
+            colorMapping={colorMapping}
+            activeLabels={activeLabels}
+            fieldSchema={fieldSchema}
+            filterSelector={selectors.modalLabelFilters}
+          />
+        )}
+        {onPrevious ? (
+          <div
+            className="nav-button left"
+            onClick={onPrevious}
+            title="Previous sample (Left arrow)"
+          >
+            &lt;
+          </div>
+        ) : null}
+        {onNext ? (
+          <div
+            className="nav-button right"
+            onClick={onNext}
+            title="Next sample (Right arrow)"
+          >
+            &gt;
+          </div>
+        ) : null}
+        <div
+          className="nav-button fullscreen"
+          title={fullscreen ? "Unmaximize (Esc)" : "Maximize"}
+          onClick={() => setFullscreen(!fullscreen)}
+        >
+          {fullscreen ? <FullscreenExit /> : <Fullscreen />}
+        </div>
       </div>
     </Container>
   );

--- a/electron/app/components/SampleModal.tsx
+++ b/electron/app/components/SampleModal.tsx
@@ -238,7 +238,6 @@ const SampleModal = ({
   const [activeTags, setActiveTags] = useRecoilState(atoms.modalActiveTags);
   const tagNames = useRecoilValue(selectors.tagNames);
 
-  const [activeOther, setActiveOther] = useRecoilState(atoms.modalActiveOther);
   const fieldSchema = useRecoilValue(selectors.fieldSchema);
   const labelNames = useRecoilValue(selectors.labelNames);
   const labelTypes = useRecoilValue(selectors.labelTypes);
@@ -294,8 +293,14 @@ const SampleModal = ({
     [onClose, onPrevious, onNext, fullscreen]
   );
 
-  const getDisplayOptions = (values, countOrExists, selected) => {
+  const getDisplayOptions = (
+    values,
+    countOrExists,
+    selected,
+    hideCheckbox = false
+  ) => {
     return [...values].sort().map(({ name, type }) => ({
+      hideCheckbox,
       name,
       type,
       icon:
@@ -381,7 +386,8 @@ const SampleModal = ({
             tags={getDisplayOptions(
               tagNames.map((t) => ({ name: t })),
               tagSampleExists,
-              activeTags
+              activeTags,
+              true
             )}
             labels={getDisplayOptions(
               labelNameGroups.labels,

--- a/electron/app/components/SampleModal.tsx
+++ b/electron/app/components/SampleModal.tsx
@@ -125,13 +125,6 @@ const Container = styled(Body)`
     &.right {
       right: 0;
     }
-
-    &.top-right {
-      right: 0;
-      top: 0;
-      margin-top: 0;
-      height: 2em;
-    }
   }
 
   .sidebar {
@@ -192,7 +185,6 @@ const TopRightNavButtonContainer = styled.div`
   display: flex;
   align-items: center;
   justify-content: center;
-  margin-left: 0.25rem;
 `;
 
 const TopRightNavButton = ({ icon, title, onClick }) => {

--- a/electron/app/components/SampleModal.tsx
+++ b/electron/app/components/SampleModal.tsx
@@ -346,9 +346,9 @@ const SampleModal = ({
       icon:
         typeof countOrExists[name] === "boolean" ? (
           countOrExists[name] ? (
-            <Check />
+            <Check style={{ color: colorMap[name] }} />
           ) : (
-            <Close />
+            <Close style={{ color: colorMap[name] }} />
           )
         ) : undefined,
       count: countOrExists[name],
@@ -371,37 +371,31 @@ const SampleModal = ({
     {}
   );
 
-  const labelSampleValues = labelNameGroups.labels.reduce((obj, label) => {
-    let value;
-    if (!sample[label]) {
-      value = false;
-    } else {
-      const type = sample[label].type;
-      value = ["Detections", "Classifcations"].includes(type)
-        ? sample[label][type.toLowerCase()].length
-        : true;
-    }
-    return {
-      ...obj,
-      [label]: value,
-    };
-  }, {});
+  const labelSampleValues = labelNameGroups.labels.reduce(
+    (obj, { name, type }) => {
+      let value;
+      if (!sample[name]) {
+        value = false;
+      } else {
+        value = ["Detections", "Classifcations"].includes(type)
+          ? sample[name][type.toLowerCase()].length
+          : true;
+      }
+      return {
+        ...obj,
+        [name]: value,
+      };
+    },
+    {}
+  );
 
-  const scalarSampleValues = labelNameGroups.labels.reduce((obj, label) => {
-    let value;
-    if (!sample[label]) {
-      value = false;
-    } else {
-      const type = sample[label].type;
-      value = ["Detections", "Classifcations"].includes(type)
-        ? sample[label][type.toLowerCase()].length
-        : true;
-    }
-    return {
+  const scalarSampleValues = labelNameGroups.labels.reduce(
+    (obj, { name }) => ({
       ...obj,
-      [label]: value,
-    };
-  }, {});
+      [name]: sample[name] ? sample[name] : false,
+    }),
+    {}
+  );
 
   const otherSampleValues = labelNameGroups.unsupported.reduce((obj, label) => {
     return {

--- a/electron/app/components/SampleModal.tsx
+++ b/electron/app/components/SampleModal.tsx
@@ -1,23 +1,15 @@
 import React, { useState, useEffect, useRef } from "react";
 import styled from "styled-components";
 
-import {
-  ArrowDropDown,
-  Check,
-  Close,
-  Fullscreen,
-  FullscreenExit,
-} from "@material-ui/icons";
+import { Check, Close, Fullscreen, FullscreenExit } from "@material-ui/icons";
 import { useRecoilState, useRecoilValue } from "recoil";
 
 import JSONView from "./JSONView";
 import Player51 from "./Player51";
-import Tag from "./Tags/Tag";
 import { Button, ModalFooter } from "./utils";
 import * as selectors from "../recoil/selectors";
 import * as atoms from "../recoil/atoms";
-import Filter from "./Filter";
-import { Body } from "./CheckboxGrid";
+import * as CheckboxGrid from "./CheckboxGrid";
 import DisplayOptionsSidebar from "./DisplayOptionsSidebar";
 
 import { useKeydownHandler, useResizeHandler } from "../utils/hooks";
@@ -28,7 +20,7 @@ type Props = {
   sampleUrl: string;
 };
 
-const Container = styled(Body)`
+const Container = styled(CheckboxGrid.Body)`
   display: grid;
   grid-template-columns: auto 280px;
   width: 90vw;

--- a/electron/app/components/SampleModal.tsx
+++ b/electron/app/components/SampleModal.tsx
@@ -213,56 +213,11 @@ const Row = ({ name, renderedName, value, children, ...rest }) => (
   <div className="row" {...rest}>
     <label>{renderedName || name}&nbsp;</label>
     <div>
-      <span>{value}</span>
+      <span title={value}>{value}</span>
     </div>
     {children}
   </div>
 );
-
-const LabelRow = ({ color, field, ...rest }) => {
-  const [expanded, setExpanded] = useState(false);
-  const [activeLabels, setActiveLabels] = useRecoilState(
-    atoms.modalActiveLabels
-  );
-  return (
-    <React.Fragment key={rest.key}>
-      <Row {...rest}>
-        {activeLabels[rest.name] && field._cls && (
-          <ArrowDropDown
-            onClick={(e) => {
-              e.preventDefault();
-              setExpanded(!expanded);
-            }}
-            style={{
-              lineHeight: "31px",
-              cursor: "pointer",
-            }}
-          />
-        )}
-      </Row>
-      {expanded && activeLabels[rest.name] && (
-        <Filter
-          key={`${rest.key}-filter`}
-          style={{
-            margin: "0.5rem 0",
-            border: "1px solid hsl(200,2%,37%)",
-          }}
-          entry={{
-            name: rest.name,
-            color,
-            selected: activeLabels[rest.name],
-          }}
-          {...{
-            includeLabels: atoms.modalFilterIncludeLabels,
-            invertInclude: atoms.modalFilterInvertIncludeLabels,
-            includeNoConfidence: atoms.modalFilterLabelIncludeNoConfidence,
-            confidenceRange: atoms.modalFilterLabelConfidenceRange,
-          }}
-        />
-      )}
-    </React.Fragment>
-  );
-};
 
 const SampleModal = ({
   sample,
@@ -417,6 +372,10 @@ const SampleModal = ({
           {formatMetadata(sample.metadata).map(({ name, value }) => (
             <Row key={"metadata-" + name} name={name} value={value} />
           ))}
+          <h2>
+            Display Options
+            <span className="push-right" />
+          </h2>
           <DisplayOptionsSidebar
             colorMap={colorMap}
             tags={getDisplayOptions(

--- a/electron/app/components/SampleModal.tsx
+++ b/electron/app/components/SampleModal.tsx
@@ -269,6 +269,7 @@ const SampleModal = ({
     atoms.modalActiveLabels
   );
   const [activeTags, setActiveTags] = useRecoilState(atoms.modalActiveTags);
+  const labelSampleCounts = useRecoilValue(selectors.labelSampleCounts);
   const [activeOther, setActiveOther] = useRecoilState(atoms.modalActiveOther);
   const fieldSchema = useRecoilValue(selectors.fieldSchema);
   const labelNames = useRecoilValue(selectors.labelNames);
@@ -386,6 +387,22 @@ const SampleModal = ({
       );
     });
 
+  const getDisplayOptions = (values, counts, selected) => {
+    return [...values].sort().map(({ name, type }) => ({
+      name,
+      type,
+      count: counts[name],
+      selected: Boolean(selected[name]),
+    }));
+  };
+
+  const handleSetDisplayOption = (setSelected) => (entry) => {
+    setSelected((selected) => ({
+      ...selected,
+      [entry.name]: entry.selected,
+    }));
+  };
+
   return (
     <Container className={fullscreen ? "fullscreen" : ""}>
       <div className="sidebar">
@@ -401,17 +418,11 @@ const SampleModal = ({
           ))}
           <DisplayOptionsSidebar
             colorMapping={colorMapping}
-            tags={getDisplayOptions(
-              tagNames.map((t) => ({ name: t })),
-              tagSampleCounts,
-              activeTags
-            )}
             labels={getDisplayOptions(
               labelNameGroups.labels,
               labelSampleCounts,
               activeLabels
             )}
-            onSelectTag={handleSetDisplayOption(setActiveTags)}
             onSelectLabel={handleSetDisplayOption(setActiveLabels)}
             scalars={getDisplayOptions(
               labelNameGroups.scalars,
@@ -425,14 +436,12 @@ const SampleModal = ({
               activeLabels
             )}
             style={{
-              maxHeight: sidebarHeight,
               overflowY: "auto",
               overflowX: "hidden",
               paddingRight: 25,
               marginRight: -25,
               scrollbarWidth: "thin",
             }}
-            ref={sidebarRef}
           />
         </div>
         <ModalFooter>

--- a/electron/app/components/SampleModal.tsx
+++ b/electron/app/components/SampleModal.tsx
@@ -27,6 +27,7 @@ import {
   VALID_OBJECT_TYPES,
   RESERVED_FIELDS,
 } from "../utils/labels";
+import { sample } from "lodash";
 
 type Props = {
   sample: object;
@@ -140,11 +141,17 @@ const Container = styled.div`
   }
 
   .row {
+    display: flex;
+    justify-content: space-between;
+    flex-wrap: wrap;
     > label {
       font-weight: bold;
     }
     > span {
       float: right;
+    }
+    span {
+      word-wrap: break-word;
     }
   }
 `;
@@ -152,17 +159,40 @@ const Container = styled.div`
 const Row = ({ name, renderedName, value, children, ...rest }) => (
   <div className="row" {...rest}>
     <label>{renderedName || name}&nbsp;</label>
-    <span>{value}</span>
-    {children}
+    <span style={{ display: "flex", justifyContent: "space-between" }}>
+      <span>{value}</span>
+      {children}
+    </span>
   </div>
 );
 
 const LabelRow = (props) => {
   const [expanded, setExpanded] = useState(false);
+  const [activeLabels, setActiveLabels] = useRecoilState(
+    atoms.modalActiveLabels
+  );
   return (
-    <Row {...props}>
-      {expanded && entry.selected && (
+    <>
+      <Row {...props}>
+        {activeLabels[props.name] && props.field._cls && (
+          <ArrowDropDown
+            onClick={(e) => {
+              e.preventDefault();
+              setExpanded(!expanded);
+            }}
+            style={{
+              lineHeight: "31px",
+              cursor: "pointer",
+            }}
+          />
+        )}
+      </Row>
+      {expanded && activeLabels[props.name] && (
         <Filter
+          style={{
+            margin: "0.5rem 0",
+            border: "1px solid hsl(200,2%,37%)",
+          }}
           entry={{
             name,
           }}
@@ -174,7 +204,7 @@ const LabelRow = (props) => {
           }}
         />
       )}
-    </Row>
+    </>
   );
 };
 
@@ -268,6 +298,7 @@ const SampleModal = ({
       return {
         key: k,
         name: k,
+        field: sample[k],
         renderedName: makeTag(k),
         value,
       };
@@ -280,6 +311,7 @@ const SampleModal = ({
         key: k,
         name: k,
         renderedName: makeTag(k),
+        field: sample[k],
         value: `${len} detection${len == 1 ? "" : "s"}`,
       };
     });

--- a/electron/app/components/SampleModal.tsx
+++ b/electron/app/components/SampleModal.tsx
@@ -456,6 +456,7 @@ const SampleModal = ({
               overflowX: "hidden",
               height: "auto",
             }}
+            modal={true}
           />
           <TopRightNavButton
             onClick={onClose}

--- a/electron/app/components/SampleModal.tsx
+++ b/electron/app/components/SampleModal.tsx
@@ -4,13 +4,13 @@ import styled from "styled-components";
 import { Check, Close, Fullscreen, FullscreenExit } from "@material-ui/icons";
 import { useRecoilState, useRecoilValue } from "recoil";
 
+import CheckboxGrid from "./CheckboxGrid";
+import DisplayOptionsSidebar from "./DisplayOptionsSidebar";
 import JSONView from "./JSONView";
 import Player51 from "./Player51";
 import { Button, ModalFooter } from "./utils";
 import * as selectors from "../recoil/selectors";
 import * as atoms from "../recoil/atoms";
-import * as CheckboxGrid from "./CheckboxGrid";
-import DisplayOptionsSidebar from "./DisplayOptionsSidebar";
 
 import { useKeydownHandler, useResizeHandler } from "../utils/hooks";
 import { formatMetadata, makeLabelNameGroups } from "../utils/labels";

--- a/electron/app/components/SampleModal.tsx
+++ b/electron/app/components/SampleModal.tsx
@@ -458,9 +458,7 @@ const SampleModal = ({
             style={{
               overflowY: "auto",
               overflowX: "hidden",
-              paddingRight: 25,
-              marginRight: -25,
-              scrollbarWidth: "thin",
+              height: "auto",
             }}
           />
         </div>

--- a/electron/app/components/SampleModal.tsx
+++ b/electron/app/components/SampleModal.tsx
@@ -344,7 +344,7 @@ const SampleModal = ({
     {}
   );
 
-  const scalarSampleValues = labelNameGroups.labels.reduce(
+  const scalarSampleValues = labelNameGroups.scalars.reduce(
     (obj, { name }) => ({
       ...obj,
       [name]: sample[name] ? sample[name] : false,

--- a/electron/app/components/SampleModal.tsx
+++ b/electron/app/components/SampleModal.tsx
@@ -28,7 +28,6 @@ import {
   VALID_OBJECT_TYPES,
   RESERVED_FIELDS,
 } from "../utils/labels";
-import { sample } from "lodash";
 
 type Props = {
   sample: object;
@@ -89,6 +88,21 @@ const Container = styled(Body)`
     }
   }
 
+  .top-right-nav-buttons {
+    position: absolute;
+    top: 0;
+    right: 0;
+    display: flex;
+    height: 5em;
+    font-size: 150%;
+    font-weight: bold;
+    user-select: none;
+
+    & > svg {
+      height: 2em;
+    }
+  }
+
   .nav-button {
     position: absolute;
     z-index: 1000;
@@ -112,7 +126,7 @@ const Container = styled(Body)`
       right: 0;
     }
 
-    &.fullscreen {
+    &.top-right {
       right: 0;
       top: 0;
       margin-top: 0;
@@ -153,6 +167,41 @@ const Container = styled(Body)`
     }
   }
 `;
+
+const TopRightNavButtonsContainer = styled.div`
+  position: absolute;
+  top: 0;
+  right: 0;
+  display: flex;
+`;
+
+const TopRightNavButtons = ({ children }) => {
+  return <TopRightNavButtonsContainer>{children}</TopRightNavButtonsContainer>;
+};
+
+const TopRightNavButtonContainer = styled.div`
+  display: block;
+  background-color: ${({ theme }) => theme.overlayButton};
+  cursor: pointer;
+  font-size: 150%;
+  font-weight: bold;
+  user-select: none;
+  width: 2em;
+  margin-top: 0;
+  height: 2em;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-left: 0.25rem;
+`;
+
+const TopRightNavButton = ({ icon, title, onClick }) => {
+  return (
+    <TopRightNavButtonContainer title={title} onClick={onClick}>
+      {icon}
+    </TopRightNavButtonContainer>
+  );
+};
 
 const Row = ({ name, renderedName, value, children, ...rest }) => (
   <div className="row" {...rest}>
@@ -341,9 +390,6 @@ const SampleModal = ({
           <h2>
             Metadata
             <span className="push-right" />
-            <span className="close-wrapper" title="Close">
-              <Close onClick={onClose} />
-            </span>
           </h2>
           <Row name="ID" value={sample._id.$oid} />
           <Row name="Source" value={sample.filepath} />
@@ -421,13 +467,18 @@ const SampleModal = ({
             &gt;
           </div>
         ) : null}
-        <div
-          className="nav-button fullscreen"
-          title={fullscreen ? "Unmaximize (Esc)" : "Maximize"}
-          onClick={() => setFullscreen(!fullscreen)}
-        >
-          {fullscreen ? <FullscreenExit /> : <Fullscreen />}
-        </div>
+        <TopRightNavButtons>
+          <TopRightNavButton
+            onClick={() => setFullscreen(!fullscreen)}
+            title={fullscreen ? "Unmaximize (Esc)" : "Maximize"}
+            icon={fullscreen ? <FullscreenExit /> : <Fullscreen />}
+          />
+          <TopRightNavButton
+            onClick={onClose}
+            title={"Close"}
+            icon={<Close />}
+          />
+        </TopRightNavButtons>
       </div>
     </Container>
   );

--- a/electron/app/components/SampleModal.tsx
+++ b/electron/app/components/SampleModal.tsx
@@ -170,7 +170,7 @@ const LabelRow = ({ color, field, ...rest }) => {
     atoms.modalActiveLabels
   );
   return (
-    <>
+    <React.Fragment key={rest.key}>
       <Row {...rest}>
         {activeLabels[rest.name] && field._cls && (
           <ArrowDropDown
@@ -187,6 +187,7 @@ const LabelRow = ({ color, field, ...rest }) => {
       </Row>
       {expanded && activeLabels[rest.name] && (
         <Filter
+          key={`${rest.key}-filter`}
           style={{
             margin: "0.5rem 0",
             border: "1px solid hsl(200,2%,37%)",
@@ -204,7 +205,7 @@ const LabelRow = ({ color, field, ...rest }) => {
           }}
         />
       )}
-    </>
+    </React.Fragment>
   );
 };
 
@@ -222,7 +223,6 @@ const SampleModal = ({
   const [playerStyle, setPlayerStyle] = useState({ height: "100%" });
   const [showJSON, setShowJSON] = useState(false);
   const [fullscreen, setFullscreen] = useState(false);
-  const [filter, setFilter] = useRecoilState(selectors.labelFilters);
   const [activeLabels, setActiveLabels] = useRecoilState(
     atoms.modalActiveLabels
   );
@@ -352,7 +352,7 @@ const SampleModal = ({
             colorMapping={colorMapping}
             activeLabels={activeLabels}
             fieldSchema={fieldSchema}
-            filter={filter}
+            filterSelector={selectors.modalLabelFilters}
           />
         )}
         {onPrevious ? (

--- a/electron/app/components/SampleModal.tsx
+++ b/electron/app/components/SampleModal.tsx
@@ -335,11 +335,11 @@ const SampleModal = ({
     (obj, { name, type }) => {
       let value;
       if (!sample[name]) {
-        value = false;
+        value = 0;
       } else {
         value = ["Detections", "Classifcations"].includes(type)
           ? sample[name][type.toLowerCase()].length
-          : true;
+          : 1;
       }
       return {
         ...obj,

--- a/electron/app/components/SampleModal.tsx
+++ b/electron/app/components/SampleModal.tsx
@@ -164,15 +164,15 @@ const Row = ({ name, renderedName, value, children, ...rest }) => (
   </div>
 );
 
-const LabelRow = (props) => {
+const LabelRow = ({ color, field, ...rest }) => {
   const [expanded, setExpanded] = useState(false);
   const [activeLabels, setActiveLabels] = useRecoilState(
     atoms.modalActiveLabels
   );
   return (
     <>
-      <Row {...props}>
-        {activeLabels[props.name] && props.field._cls && (
+      <Row {...rest}>
+        {activeLabels[rest.name] && field._cls && (
           <ArrowDropDown
             onClick={(e) => {
               e.preventDefault();
@@ -185,14 +185,16 @@ const LabelRow = (props) => {
           />
         )}
       </Row>
-      {expanded && activeLabels[props.name] && (
+      {expanded && activeLabels[rest.name] && (
         <Filter
           style={{
             margin: "0.5rem 0",
             border: "1px solid hsl(200,2%,37%)",
           }}
           entry={{
-            name,
+            name: rest.name,
+            color,
+            selected: activeLabels[rest.name],
           }}
           {...{
             includeLabels: atoms.modalFilterIncludeLabels,
@@ -299,6 +301,7 @@ const SampleModal = ({
         field: sample[k],
         renderedName: makeTag(k),
         value,
+        color: colorMapping[k],
       };
     });
   const detections = Object.keys(sample)
@@ -311,6 +314,7 @@ const SampleModal = ({
         renderedName: makeTag(k),
         field: sample[k],
         value: `${len} detection${len == 1 ? "" : "s"}`,
+        color: colorMapping[k],
       };
     });
   const labels = [...classifications, ...detections]

--- a/electron/app/components/Samples.tsx
+++ b/electron/app/components/Samples.tsx
@@ -8,7 +8,7 @@ import tile from "./Samples.hooks";
 import * as atoms from "../recoil/atoms";
 
 function Samples(props) {
-  const { displayProps, state, setView, port, colorMap } = props;
+  const { displayProps, state, setView, port } = props;
   const initialSelected = state.selected.reduce((obj, id) => {
     return {
       ...obj,
@@ -47,7 +47,6 @@ function Samples(props) {
             <Grid.Column key={j} style={{ padding: 0, width: "100%" }}>
               <Sample
                 displayProps={displayProps}
-                colorMap={colorMap}
                 sample={s}
                 selected={selected}
                 setSelected={setSelected}

--- a/electron/app/components/ViewBar/ViewStage/SearchResults.tsx
+++ b/electron/app/components/ViewBar/ViewStage/SearchResults.tsx
@@ -7,6 +7,7 @@ const SearchResultDiv = animated(styled.div`
   margin: 0.25rem 0.25rem;
   padding: 0 0.25rem;
   font-weight: bold;
+  color: ${({ theme }) => theme.fontDark};
 `);
 
 interface SearchResultProps {
@@ -56,10 +57,10 @@ const SearchResult = React.memo(
 );
 
 const SearchResultsDiv = animated(styled.div`
-  background-color: ${({ theme }) => theme.backgroundDark};
-  border: 2px solid ${({ theme }) => theme.backgroundDarkBorder};
+  background: ${({ theme }) => theme.backgroundDark};
+  box-shadow: 0 8px 15px 0 rgba(0, 0, 0, 0.43);
+  border: 1px solid #191c1f;
   border-radius: 2px;
-  box-shadow: 0 2px 20px ${({ theme }) => theme.backgroundDark};
   box-sizing: border-box;
   margin-top: 2.5rem;
   position: fixed;

--- a/electron/app/containers/Dataset.tsx
+++ b/electron/app/containers/Dataset.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from "react";
 import { Switch, Route, Redirect, useRouteMatch } from "react-router-dom";
-import { useRecoilValue } from "recoil";
+import { useRecoilValue, useSetRecoilState } from "recoil";
 import { Container, Message, Segment } from "semantic-ui-react";
 
 import SamplesContainer from "./SamplesContainer";
@@ -11,7 +11,6 @@ import { ModalWrapper, Overlay } from "../components/utils";
 import routes from "../constants/routes.json";
 import * as atoms from "../recoil/atoms";
 import * as selectors from "../recoil/selectors";
-import { generateColorMap } from "../utils/colors";
 import connect from "../utils/connect";
 import { VALID_LABEL_TYPES } from "../utils/labels";
 
@@ -33,7 +32,8 @@ function Dataset(props) {
     sample: null,
     activeLabels: {},
   });
-  const [colorMap, setColorMap] = useState({});
+  const colorMap = useRecoilValue(atoms.colorMap);
+  const refreshColorMap = useSetRecoilState(selectors.refreshColorMap);
 
   const datasetName = useRecoilValue(selectors.datasetName);
   const currentSamples = useRecoilValue(atoms.currentSamples);
@@ -44,11 +44,8 @@ function Dataset(props) {
 
   // update color map
   useEffect(() => {
-    setColorMap(generateColorMap([...tagNames, ...labelNames], colorMap));
+    refreshColorMap(colorMap);
   }, [labelNames, tagNames]);
-  const resetColors = () => {
-    setColorMap(generateColorMap([...tagNames, ...labelNames]));
-  };
 
   // select any new labels by default
   useEffect(() => {
@@ -151,7 +148,6 @@ function Dataset(props) {
                   }
                   displayProps={displayProps}
                   colorMap={colorMap}
-                  resetColors={resetColors}
                 />
               </Route>
               <Route path={routes.LABELS}>

--- a/electron/app/containers/SamplesContainer.tsx
+++ b/electron/app/containers/SamplesContainer.tsx
@@ -96,6 +96,7 @@ const DisplayOptionsWrapper = (props) => {
       >
         <DisplayOptionsSidebar
           colorMap={colorMap}
+          resetColors={resetColors}
           tags={getDisplayOptions(
             tagNames.map((t) => ({ name: t })),
             tagSampleCounts,
@@ -167,7 +168,7 @@ const SamplesContainer = (props) => {
           />
         ) : null}
         <Grid.Column className="content-column">
-          <Samples {...props} colorMap={colorMap} />
+          <Samples {...props} />
         </Grid.Column>
       </Grid>
     </Root>

--- a/electron/app/containers/SamplesContainer.tsx
+++ b/electron/app/containers/SamplesContainer.tsx
@@ -28,7 +28,13 @@ const Root = styled.div`
 `;
 
 const DisplayOptionsWrapper = (props) => {
-  const { containerRef, sidebarRef, stickyHeaderRef, displayProps } = props;
+  const {
+    containerRef,
+    sidebarRef,
+    sidebarHeight,
+    displayProps,
+    headerHeight,
+  } = props;
   const {
     activeTags,
     activeLabels,
@@ -42,7 +48,7 @@ const DisplayOptionsWrapper = (props) => {
   const tagSampleCounts = useRecoilValue(selectors.tagSampleCounts);
   const filters = useRecoilValue(selectors.labelFilters);
   const setModalFilters = useSetRecoilState(selectors.modalLabelFilters);
-  const [sidebarHeight, setSidebarHeight] = useState("unset");
+
   const fieldSchema = useRecoilValue(selectors.fieldSchema);
   const labelNames = useRecoilValue(selectors.labelNames);
   const labelTypes = useRecoilValue(selectors.labelTypes);
@@ -50,7 +56,6 @@ const DisplayOptionsWrapper = (props) => {
   useEffect(() => {
     setModalFilters(filters);
   }, [filters]);
-  let headerHeight = 0;
 
   const getDisplayOptions = (values, counts, selected) => {
     return [...values].sort().map(({ name, type }) => ({
@@ -66,19 +71,7 @@ const DisplayOptionsWrapper = (props) => {
       [entry.name]: entry.selected,
     }));
   };
-  if (stickyHeaderRef.current && stickyHeaderRef.current.stickyRect) {
-    headerHeight = stickyHeaderRef.current.stickyRect.height;
-  }
-  const updateSidebarHeight = () => {
-    if (sidebarRef.current) {
-      setSidebarHeight(
-        window.innerHeight - sidebarRef.current.getBoundingClientRect().top
-      );
-    }
-  };
-  useResizeHandler(updateSidebarHeight, [sidebarRef.current]);
-  useScrollHandler(updateSidebarHeight, [sidebarRef.current]);
-  useEffect(updateSidebarHeight, []);
+
   const labelNameGroups = makeLabelNameGroups(
     fieldSchema,
     labelNames,
@@ -87,12 +80,7 @@ const DisplayOptionsWrapper = (props) => {
 
   return (
     <Grid.Column className="sidebar-column">
-      <Sticky
-        context={containerRef}
-        offset={headerHeight}
-        style={{ height: "100%" }}
-        styleElement={{ height: "100%" }}
-      >
+      <Sticky context={containerRef} offset={headerHeight}>
         <DisplayOptionsSidebar
           tags={getDisplayOptions(
             tagNames.map((t) => ({ name: t })),
@@ -140,6 +128,21 @@ const SamplesContainer = (props) => {
   const containerRef = useRef();
   const stickyHeaderRef = useRef();
   const sidebarRef = useRef();
+  const [sidebarHeight, setSidebarHeight] = useState("unset");
+  let headerHeight = 0;
+  if (stickyHeaderRef.current && stickyHeaderRef.current.stickyRect) {
+    headerHeight = stickyHeaderRef.current.stickyRect.height;
+  }
+  const updateSidebarHeight = () => {
+    if (sidebarRef.current) {
+      setSidebarHeight(
+        window.innerHeight - sidebarRef.current.getBoundingClientRect().top
+      );
+    }
+  };
+  useResizeHandler(updateSidebarHeight, [sidebarRef.current]);
+  useScrollHandler(updateSidebarHeight, [sidebarRef.current]);
+  useEffect(updateSidebarHeight, []);
 
   return (
     <Root ref={containerRef} showSidebar={showSidebar}>
@@ -161,6 +164,8 @@ const SamplesContainer = (props) => {
             sidebarRef={sidebarRef}
             stickyHeaderRef={stickyHeaderRef}
             containerRef={containerRef}
+            sidebarHeight={sidebarHeight}
+            headerHeight={headerHeight}
             {...props}
           />
         ) : null}

--- a/electron/app/containers/SamplesContainer.tsx
+++ b/electron/app/containers/SamplesContainer.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useRef } from "react";
-import { useRecoilState, useRecoilValue } from "recoil";
+import { useRecoilState, useRecoilValue, useSetRecoilState } from "recoil";
 import styled from "styled-components";
 
 import { Grid, Sticky } from "semantic-ui-react";
@@ -27,7 +27,8 @@ const Root = styled.div`
   }
 `;
 
-const SamplesContainer = (props) => {
+const DisplayOptionsWrapper = (props) => {
+  const { containerRef, sidebarRef, stickyHeaderRef, displayProps } = props;
   const {
     activeTags,
     activeLabels,
@@ -35,40 +36,22 @@ const SamplesContainer = (props) => {
     setActiveTags,
     setActiveLabels,
     setActiveOther,
-    labelData,
-  } = props.displayProps;
-
-  const [showSidebar, setShowSidebar] = useRecoilState(atoms.sidebarVisible);
-  const [sidebarHeight, setSidebarHeight] = useState("unset");
-  const [stuck, setStuck] = useState(false);
-  const datasetName = useRecoilValue(selectors.datasetName);
-  const numSamples = useRecoilValue(selectors.numSamples);
+  } = displayProps;
+  const labelSampleCounts = useRecoilValue(selectors.labelSampleCounts);
+  const colorMapping = useRecoilValue(selectors.labelColorMapping);
   const tagNames = useRecoilValue(selectors.tagNames);
   const tagSampleCounts = useRecoilValue(selectors.tagSampleCounts);
+  const filters = useRecoilValue(selectors.labelFilters);
+  const setModalFilters = useSetRecoilState(selectors.modalLabelFilters);
+  const [sidebarHeight, setSidebarHeight] = useState("unset");
   const fieldSchema = useRecoilValue(selectors.fieldSchema);
   const labelNames = useRecoilValue(selectors.labelNames);
   const labelTypes = useRecoilValue(selectors.labelTypes);
-  const labelSampleCounts = useRecoilValue(selectors.labelSampleCounts);
-  const colorMapping = useRecoilValue(selectors.labelColorMapping);
 
-  const containerRef = useRef();
-  const stickyHeaderRef = useRef();
-  const sidebarRef = useRef();
-
-  const labelNameGroups = {
-    labels: [],
-    scalars: [],
-    unsupported: [],
-  };
-  for (const name of labelNames) {
-    if (VALID_LABEL_TYPES.includes(labelTypes[name])) {
-      labelNameGroups.labels.push({ name, type: labelTypes[name] });
-    } else if (VALID_SCALAR_TYPES.includes(fieldSchema[name])) {
-      labelNameGroups.scalars.push({ name });
-    } else {
-      labelNameGroups.unsupported.push({ name });
-    }
-  }
+  useEffect(() => {
+    setModalFilters(filters);
+  }, [filters]);
+  let headerHeight = 0;
 
   const getDisplayOptions = (values, counts, selected) => {
     return [...values].sort().map(({ name, type }) => ({
@@ -84,12 +67,9 @@ const SamplesContainer = (props) => {
       [entry.name]: entry.selected,
     }));
   };
-
-  let headerHeight = 0;
   if (stickyHeaderRef.current && stickyHeaderRef.current.stickyRect) {
     headerHeight = stickyHeaderRef.current.stickyRect.height;
   }
-
   const updateSidebarHeight = () => {
     if (sidebarRef.current) {
       setSidebarHeight(
@@ -100,16 +80,82 @@ const SamplesContainer = (props) => {
   useResizeHandler(updateSidebarHeight, [sidebarRef.current]);
   useScrollHandler(updateSidebarHeight, [sidebarRef.current]);
   useEffect(updateSidebarHeight, []);
+  const labelNameGroups = {
+    labels: [],
+    scalars: [],
+    unsupported: [],
+  };
+  for (const name of labelNames) {
+    if (VALID_LABEL_TYPES.includes(labelTypes[name])) {
+      labelNameGroups.labels.push({ name, type: labelTypes[name] });
+    } else if (VALID_SCALAR_TYPES.includes(fieldSchema[name])) {
+      labelNameGroups.scalars.push({ name });
+    } else {
+      labelNameGroups.unsupported.push({ name });
+    }
+  }
+
+  return (
+    <Grid.Column className="sidebar-column">
+      <Sticky
+        context={containerRef}
+        offset={headerHeight}
+        style={{ height: "100%" }}
+        styleElement={{ height: "100%" }}
+      >
+        <DisplayOptionsSidebar
+          colorMapping={colorMapping}
+          tags={getDisplayOptions(
+            tagNames.map((t) => ({ name: t })),
+            tagSampleCounts,
+            activeTags
+          )}
+          labels={getDisplayOptions(
+            labelNameGroups.labels,
+            labelSampleCounts,
+            activeLabels
+          )}
+          onSelectTag={handleSetDisplayOption(activeTags, setActiveTags)}
+          onSelectLabel={handleSetDisplayOption(activeLabels, setActiveLabels)}
+          scalars={getDisplayOptions(
+            labelNameGroups.scalars,
+            labelSampleCounts,
+            activeOther
+          )}
+          onSelectScalar={handleSetDisplayOption(activeOther, setActiveOther)}
+          unsupported={getDisplayOptions(
+            labelNameGroups.unsupported,
+            labelSampleCounts,
+            activeLabels
+          )}
+          style={{
+            maxHeight: sidebarHeight,
+            overflowY: "auto",
+            overflowX: "hidden",
+            paddingRight: 25,
+            marginRight: -25,
+            scrollbarWidth: "thin",
+          }}
+          ref={sidebarRef}
+        />
+      </Sticky>
+    </Grid.Column>
+  );
+};
+
+const SamplesContainer = (props) => {
+  const [showSidebar, setShowSidebar] = useRecoilState(atoms.sidebarVisible);
+  const datasetName = useRecoilValue(selectors.datasetName);
+  const numSamples = useRecoilValue(selectors.numSamples);
+
+  const containerRef = useRef();
+  const stickyHeaderRef = useRef();
+  const sidebarRef = useRef();
 
   return (
     <Root ref={containerRef} showSidebar={showSidebar}>
       <VerticalSpacer opaque height={5} />
-      <Sticky
-        ref={stickyHeaderRef}
-        context={containerRef}
-        onStick={() => setStuck(true)}
-        onUnstick={() => setStuck(false)}
-      >
+      <Sticky ref={stickyHeaderRef} context={containerRef}>
         <ViewBar />
         <VerticalSpacer opaque height={5} />
         <ImageContainerHeader
@@ -122,56 +168,12 @@ const SamplesContainer = (props) => {
       </Sticky>
       <Grid>
         {showSidebar ? (
-          <Grid.Column className="sidebar-column">
-            <Sticky
-              context={containerRef}
-              offset={headerHeight}
-              style={{ height: "100%" }}
-              styleElement={{ height: "100%" }}
-            >
-              <DisplayOptionsSidebar
-                colorMapping={colorMapping}
-                tags={getDisplayOptions(
-                  tagNames.map((t) => ({ name: t })),
-                  tagSampleCounts,
-                  activeTags
-                )}
-                labels={getDisplayOptions(
-                  labelNameGroups.labels,
-                  labelSampleCounts,
-                  activeLabels
-                )}
-                onSelectTag={handleSetDisplayOption(activeTags, setActiveTags)}
-                onSelectLabel={handleSetDisplayOption(
-                  activeLabels,
-                  setActiveLabels
-                )}
-                scalars={getDisplayOptions(
-                  labelNameGroups.scalars,
-                  labelSampleCounts,
-                  activeOther
-                )}
-                onSelectScalar={handleSetDisplayOption(
-                  activeOther,
-                  setActiveOther
-                )}
-                unsupported={getDisplayOptions(
-                  labelNameGroups.unsupported,
-                  labelSampleCounts,
-                  activeLabels
-                )}
-                style={{
-                  maxHeight: sidebarHeight,
-                  overflowY: "auto",
-                  overflowX: "hidden",
-                  paddingRight: 25,
-                  marginRight: -25,
-                  scrollbarWidth: "thin",
-                }}
-                ref={sidebarRef}
-              />
-            </Sticky>
-          </Grid.Column>
+          <DisplayOptionsWrapper
+            sidebarRef={sidebarRef}
+            stickyHeaderRef={stickyHeaderRef}
+            containerRef={containerRef}
+            {...props}
+          />
         ) : null}
         <Grid.Column className="content-column">
           <Samples {...props} />

--- a/electron/app/containers/SamplesContainer.tsx
+++ b/electron/app/containers/SamplesContainer.tsx
@@ -123,7 +123,12 @@ const SamplesContainer = (props) => {
       <Grid>
         {showSidebar ? (
           <Grid.Column className="sidebar-column">
-            <Sticky context={containerRef} offset={headerHeight}>
+            <Sticky
+              context={containerRef}
+              offset={headerHeight}
+              style={{ height: "100%" }}
+              styleElement={{ height: "100%" }}
+            >
               <DisplayOptionsSidebar
                 colorMapping={colorMapping}
                 tags={getDisplayOptions(

--- a/electron/app/containers/SamplesContainer.tsx
+++ b/electron/app/containers/SamplesContainer.tsx
@@ -13,7 +13,7 @@ import { VerticalSpacer } from "../components/utils";
 import * as atoms from "../recoil/atoms";
 import * as selectors from "../recoil/selectors";
 import { useResizeHandler, useScrollHandler } from "../utils/hooks";
-import { VALID_LABEL_TYPES, VALID_SCALAR_TYPES } from "../utils/labels";
+import { makeLabelNameGroups } from "../utils/labels";
 
 const Root = styled.div`
   .ui.grid > .sidebar-column {
@@ -61,7 +61,7 @@ const DisplayOptionsWrapper = (props) => {
       selected: Boolean(selected[name]),
     }));
   };
-  const handleSetDisplayOption = (selected, setSelected) => (entry) => {
+  const handleSetDisplayOption = (setSelected) => (entry) => {
     setSelected((selected) => ({
       ...selected,
       [entry.name]: entry.selected,
@@ -80,20 +80,11 @@ const DisplayOptionsWrapper = (props) => {
   useResizeHandler(updateSidebarHeight, [sidebarRef.current]);
   useScrollHandler(updateSidebarHeight, [sidebarRef.current]);
   useEffect(updateSidebarHeight, []);
-  const labelNameGroups = {
-    labels: [],
-    scalars: [],
-    unsupported: [],
-  };
-  for (const name of labelNames) {
-    if (VALID_LABEL_TYPES.includes(labelTypes[name])) {
-      labelNameGroups.labels.push({ name, type: labelTypes[name] });
-    } else if (VALID_SCALAR_TYPES.includes(fieldSchema[name])) {
-      labelNameGroups.scalars.push({ name });
-    } else {
-      labelNameGroups.unsupported.push({ name });
-    }
-  }
+  const labelNameGroups = makeLabelNameGroups(
+    fieldSchema,
+    labelNames,
+    labelTypes
+  );
 
   return (
     <Grid.Column className="sidebar-column">
@@ -115,14 +106,14 @@ const DisplayOptionsWrapper = (props) => {
             labelSampleCounts,
             activeLabels
           )}
-          onSelectTag={handleSetDisplayOption(activeTags, setActiveTags)}
-          onSelectLabel={handleSetDisplayOption(activeLabels, setActiveLabels)}
+          onSelectTag={handleSetDisplayOption(setActiveTags)}
+          onSelectLabel={handleSetDisplayOption(setActiveLabels)}
           scalars={getDisplayOptions(
             labelNameGroups.scalars,
             labelSampleCounts,
             activeOther
           )}
-          onSelectScalar={handleSetDisplayOption(activeOther, setActiveOther)}
+          onSelectScalar={handleSetDisplayOption(setActiveOther)}
           unsupported={getDisplayOptions(
             labelNameGroups.unsupported,
             labelSampleCounts,

--- a/electron/app/containers/SamplesContainer.tsx
+++ b/electron/app/containers/SamplesContainer.tsx
@@ -38,7 +38,6 @@ const DisplayOptionsWrapper = (props) => {
     setActiveOther,
   } = displayProps;
   const labelSampleCounts = useRecoilValue(selectors.labelSampleCounts);
-  const { colorMap, resetColors } = props;
   const tagNames = useRecoilValue(selectors.tagNames);
   const tagSampleCounts = useRecoilValue(selectors.tagSampleCounts);
   const filters = useRecoilValue(selectors.labelFilters);
@@ -95,8 +94,6 @@ const DisplayOptionsWrapper = (props) => {
         styleElement={{ height: "100%" }}
       >
         <DisplayOptionsSidebar
-          colorMap={colorMap}
-          resetColors={resetColors}
           tags={getDisplayOptions(
             tagNames.map((t) => ({ name: t })),
             tagSampleCounts,

--- a/electron/app/recoil/atoms.ts
+++ b/electron/app/recoil/atoms.ts
@@ -5,6 +5,11 @@ export const port = atom({
   default: parseInt(process.env.FIFTYONE_SERVER_PORT) || 5151,
 });
 
+export const colorMap = atom({
+  key: "colorMap",
+  default: {},
+});
+
 export const stateDescription = atom({
   key: "stateDescription",
   default: {},

--- a/electron/app/recoil/atoms.ts
+++ b/electron/app/recoil/atoms.ts
@@ -86,7 +86,17 @@ export const activeOther = atom({
   default: {},
 });
 
+export const modalActiveOther = atom({
+  key: "modalActiveOther",
+  default: {},
+});
+
 export const activeTags = atom({
   key: "activeTags",
+  default: {},
+});
+
+export const modalActiveTags = atom({
+  key: "modalActiveTags",
   default: {},
 });

--- a/electron/app/recoil/selectors.ts
+++ b/electron/app/recoil/selectors.ts
@@ -1,5 +1,6 @@
 import { selector, selectorFamily } from "recoil";
 import * as atoms from "./atoms";
+import { generateColorMap } from "../utils/colors";
 
 export const viewStages = selector({
   key: "viewStages",
@@ -171,5 +172,16 @@ export const modalLabelFilters = selector({
         get(atoms.filterIncludeLabels(label))
       );
     }
+  },
+});
+
+export const refreshColorMap = selector({
+  key: "refreshColorMap",
+  get: ({ get }) => get(atoms.colorMap),
+  set: ({ get, set }, colorMap) => {
+    set(
+      atoms.colorMap,
+      generateColorMap([...get(tagNames), ...get(labelNames)], colorMap)
+    );
   },
 });

--- a/electron/app/utils/colors.ts
+++ b/electron/app/utils/colors.ts
@@ -1,8 +1,6 @@
 import _ from "lodash";
 import randomColor from "randomcolor";
 
-import { RESERVED_FIELDS } from "./labels";
-
 const FIXED_COLORS = [
   "#ee0000",
   "#ee6600",

--- a/electron/app/utils/labels.ts
+++ b/electron/app/utils/labels.ts
@@ -65,3 +65,21 @@ export const formatMetadata = (metadata) => {
     value: field.value ? field.value(metadata) : metadata[field.key],
   })).filter(({ value }) => value !== undefined);
 };
+
+export function makeLabelNameGroups(fieldSchema, labelNames, labelTypes) {
+  const labelNameGroups = {
+    labels: [],
+    scalars: [],
+    unsupported: [],
+  };
+  for (const name of labelNames) {
+    if (VALID_LABEL_TYPES.includes(labelTypes[name])) {
+      labelNameGroups.labels.push({ name, type: labelTypes[name] });
+    } else if (VALID_SCALAR_TYPES.includes(fieldSchema[name])) {
+      labelNameGroups.scalars.push({ name });
+    } else {
+      labelNameGroups.unsupported.push({ name });
+    }
+  }
+  return labelNameGroups;
+}


### PR DESCRIPTION
## What changes are proposed in this pull request?

Initial changes to the filtering controls for the sample modal. The underlying motivation is to be consistent with the UI components and design patterns displayed to the user. An obvious benefit is it reduces the number of controls a user has to learn. 

Any field that is not a list is handled somewhat differently than in the image grid display options, as displaying an aggregate value does not make sense. There is only one value. Instead, a checkmark or "x" is used to indicate existence. Or the value itself, if it is a `scalar` field.

![Screenshot from 2020-08-31 20-15-02](https://user-images.githubusercontent.com/19821840/91781355-20882000-ebc8-11ea-870f-31d112de9a1e.png)


TODOs:
-  [ ] test
-  [ ] display `label` value for `fo.Classification` if the value exists
-  [ ] fix regression in image grid sticky nav. it does not always stick at the moment

## How is this patch tested? If it is not, in a single sentence please explain why.

No App test framework. Still needs more human testing.

## Release Notes

Display Options have been added to the sample modal, including the new confidence and label filters.

### Is this a user-facing change?

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

Display options have been added to the sample modal, including the new confidence and label filters.

### What areas of FiftyOne does this PR affect?

-   [x] `App`: FiftyOne application changes
-   [ ] `Build`: Build and test infrastructure changes
-   [ ] `Core`: Core `fiftyone` Python library changes
-   [ ] `Documentation`: FiftyOne documentation changes
-   [ ] `Other`

### Should this PR be mentioned in the release notes? If so, please choose on category:

-   [ ] `breaking-change` - The PR will be mentioned in the "Breaking Changes"
        section
-   [x] `feature` - A new user-facing feature worth mentioning in the release
        notes
-   [ ] `bug-fix` - A user-facing bug fix worth mentioning in the release notes
-   [ ] `documentation` - A user-facing documentation change worth mentioning
        in the release notes
