### PR TITLE
Detection attribute display

### DIFF
--- a/electron/app/components/CheckboxGrid.tsx
+++ b/electron/app/components/CheckboxGrid.tsx
@@ -213,6 +213,4 @@ const CheckboxGrid = ({ entries, onCheck, modal }: Props) => {
   );
 };
 
-CheckboxGrid.Body = Body;
-
 export default CheckboxGrid;

--- a/electron/app/components/Player51.tsx
+++ b/electron/app/components/Player51.tsx
@@ -117,7 +117,6 @@ export default ({
       },
       defaultOverlayOptions: {
         action: "hover",
-        labelsOnlyOnClick: true,
         attrRenderMode: "attr-value",
       },
     })

--- a/electron/app/components/Player51.tsx
+++ b/electron/app/components/Player51.tsx
@@ -109,6 +109,9 @@ export default ({
       colorMap: playerColorMap,
       activeLabels,
       filter,
+      defaultOverlayOptions: {
+        attrRenderMode: "attr-value",
+      },
     })
   );
   const props = thumbnail

--- a/electron/app/components/Player51.tsx
+++ b/electron/app/components/Player51.tsx
@@ -113,6 +113,8 @@ export default ({
         attrRenderMode: false,
       },
       defaultOverlayOptions: {
+        action: "hover",
+        labelsOnlyOnClick: true,
         attrRenderMode: "attr-value",
       },
     })

--- a/electron/app/components/Player51.tsx
+++ b/electron/app/components/Player51.tsx
@@ -109,6 +109,9 @@ export default ({
       colorMap: playerColorMap,
       activeLabels,
       filter,
+      enableOverlayOptions: {
+        attrRenderMode: false,
+      },
       defaultOverlayOptions: {
         attrRenderMode: "attr-value",
       },

--- a/electron/app/components/Player51.tsx
+++ b/electron/app/components/Player51.tsx
@@ -3,7 +3,13 @@ import uuid from "react-uuid";
 
 import Player51 from "../player51/build/cjs/player51.min.js";
 import clickHandler from "../utils/click.ts";
-import { RESERVED_FIELDS, VALID_SCALAR_TYPES } from "../utils/labels";
+import {
+  RESERVED_FIELDS,
+  VALID_LABEL_TYPES,
+  VALID_SCALAR_TYPES,
+  getDetectionAttributes,
+  convertAttributesToETA,
+} from "../utils/labels";
 
 const PARSERS = {
   Classification: [
@@ -21,6 +27,7 @@ const PARSERS = {
     "objects",
     (name, obj) => {
       const bb = obj.bounding_box;
+      const attrs = convertAttributesToETA(getDetectionAttributes(obj));
       return {
         type: "eta.core.objects.DetectedObject",
         name,
@@ -30,6 +37,7 @@ const PARSERS = {
           top_left: { x: bb[0], y: bb[1] },
           bottom_right: { x: bb[0] + bb[2], y: bb[1] + bb[3] },
         },
+        attrs: { attrs },
       };
     },
   ],

--- a/electron/app/components/SampleModal.tsx
+++ b/electron/app/components/SampleModal.tsx
@@ -24,7 +24,7 @@ type Props = {
   sampleUrl: string;
 };
 
-const Container = styled(CheckboxGrid.Body)`
+const Container = styled.div`
   display: grid;
   grid-template-columns: auto 280px;
   width: 90vw;

--- a/electron/app/utils/labels.ts
+++ b/electron/app/utils/labels.ts
@@ -10,6 +10,12 @@ export const VALID_SCALAR_TYPES = [
 ];
 
 export const RESERVED_FIELDS = ["metadata", "_id", "tags", "filepath"];
+export const RESERVED_DETECTION_FIELDS = [
+  "label",
+  "bounding_box",
+  "confidence",
+  "attributes",
+];
 
 export const METADATA_FIELDS = [
   { name: "Size (bytes)", key: "size_bytes" },
@@ -64,4 +70,41 @@ export const formatMetadata = (metadata) => {
     name: field.name,
     value: field.value ? field.value(metadata) : metadata[field.key],
   })).filter(({ value }) => value !== undefined);
+};
+
+export type Attrs = {
+  [name: string]: {
+    name: string;
+    value: string;
+  };
+};
+
+const _formatAttributes = (obj) =>
+  Object.fromEntries(
+    Object.entries(obj).filter(
+      ([key, value]) =>
+        !key.startsWith("_") &&
+        !RESERVED_DETECTION_FIELDS.includes(key) &&
+        ["string", "number", "boolean"].includes(typeof value)
+    )
+    // if we want to control string representations fiftyone-side:
+    // .map(([key, value]) => [key, stringify(value)])
+  );
+
+export const getDetectionAttributes = (detection: object): Attrs => {
+  return {
+    ..._formatAttributes(detection),
+    ..._formatAttributes(
+      Object.fromEntries(
+        Object.entries(detection.attributes).map(([key, value]) => [
+          key,
+          value.value,
+        ])
+      )
+    ),
+  };
+};
+
+export const convertAttributesToETA = (attrs: Attrs): object[] => {
+  return Object.entries(attrs).map(([name, value]) => ({ name, value }));
 };


### PR DESCRIPTION
## What changes are proposed in this pull request?

Added support for displaying detections, as well as some corresponding player51-side changes to enable the relevant options to be configured more flexibly from the fiftyone side.

Closes #452 (except for overflow behavior, which should probably be split into a separate issue)

## How is this patch tested? If it is not, in a single sentence please explain why.

Locally, with a couple test datasets

## Release Notes

### Is this a user-facing change?

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

Above

### What areas of FiftyOne does this PR affect?

-   [x] `App`: FiftyOne application changes
-   [ ] `Build`: Build and test infrastructure changes
-   [ ] `Core`: Core `fiftyone` Python library changes
-   [ ] `Documentation`: FiftyOne documentation changes
-   [ ] `Other`

### Should this PR be mentioned in the release notes? If so, please choose on category:

-   [ ] `breaking-change` - The PR will be mentioned in the "Breaking Changes"
        section
-   [x] `feature` - A new user-facing feature worth mentioning in the release
        notes
-   [ ] `bug-fix` - A user-facing bug fix worth mentioning in the release notes
-   [ ] `documentation` - A user-facing documentation change worth mentioning
        in the release notes
