### PR TITLE
Add back port form modal

### DIFF
--- a/electron/app/containers/App.tsx
+++ b/electron/app/containers/App.tsx
@@ -1,10 +1,13 @@
 import { remote, ipcRenderer } from "electron";
 import React, { ReactNode, useState, useEffect, useRef } from "react";
 import ReactGA from "react-ga";
+import { Button, Modal, Label } from "semantic-ui-react";
 import { useSetRecoilState } from "recoil";
 import { ErrorBoundary } from "react-error-boundary";
 
 import Header from "../components/Header";
+import PortForm from "../components/PortForm";
+import { updatePort } from "../actions/update";
 
 import { updateState, updateConnected, updateLoading } from "../actions/update";
 import { getSocket, useSubscribe } from "../utils/socket";
@@ -117,6 +120,31 @@ function App(props: Props) {
       <div className={showInfo ? "" : "hide-info"} style={bodyStyle}>
         <Header />
         {children}
+        <Modal
+          trigger={
+            <Button
+              style={{ padding: "1rem", display: "none" }}
+              ref={portRef}
+            ></Button>
+          }
+          size="tiny"
+          onClose={() => {
+            dispatch(updatePort(result.port));
+            setSocket(getSocket(result.port, "state"));
+          }}
+        >
+          <Modal.Header>Port number</Modal.Header>
+          <Modal.Content>
+            <Modal.Description>
+              <PortForm
+                setResult={setResultFromForm}
+                connected={connected}
+                port={port}
+                invalid={false}
+              />
+            </Modal.Description>
+          </Modal.Content>
+        </Modal>
       </div>
     </ErrorBoundary>
   );


### PR DESCRIPTION
## What changes are proposed in this pull request?

Adds the port form modal back to `App.tsx`.

## How is this patch tested? If it is not, in a single sentence please explain why.

Locally.

## Release Notes

### Is this a user-facing change?

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

### What areas of FiftyOne does this PR affect?

-   [x] `App`: FiftyOne application changes
-   [ ] `Build`: Build and test infrastructure changes
-   [ ] `Core`: Core `fiftyone` Python library changes
-   [ ] `Documentation`: FiftyOne documentation changes
-   [ ] `Other`

### Should this PR be mentioned in the release notes? If so, please choose on category:

-   [ ] `breaking-change` - The PR will be mentioned in the "Breaking Changes"
        section
-   [ ] `feature` - A new user-facing feature worth mentioning in the release
        notes
-   [ ] `bug-fix` - A user-facing bug fix worth mentioning in the release notes
-   [ ] `documentation` - A user-facing documentation change worth mentioning
        in the release notes
