### PR TITLE
Adjust issue/PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report_template.md
+++ b/.github/ISSUE_TEMPLATE/bug_report_template.md
@@ -8,11 +8,10 @@ title: "[BUG]"
 ### Instructions
 
 Thank you for submitting an issue. Please refer to our
-[issue policy](https://www.github.com/voxel51/fiftyone/blob/master/ISSUE_POLICY.md)
+[issue policy](https://www.github.com/voxel51/fiftyone/blob/develop/ISSUE_POLICY.md)
 for information on what types of issues we address.
 
-**Please fill in this bug report template to ensure a timely and thorough
-response.**
+**Please fill in this template to ensure a timely and thorough response.**
 
 -   Place an "x" between the brackets next to an option if it applies. Example:
     -   [x] Selected option

--- a/.github/ISSUE_TEMPLATE/bug_report_template.md
+++ b/.github/ISSUE_TEMPLATE/bug_report_template.md
@@ -5,6 +5,8 @@ labels: "bug"
 title: "[BUG]"
 ---
 
+### Instructions
+
 Thank you for submitting an issue. Please refer to our
 [issue policy](https://www.github.com/voxel51/fiftyone/blob/master/ISSUE_POLICY.md)
 for information on what types of issues we address.
@@ -12,16 +14,15 @@ for information on what types of issues we address.
 **Please fill in this bug report template to ensure a timely and thorough
 response.**
 
-### Instructions
-
--   Place an "x" between the brackets of an item if it applies.
--   Feel free to add more labels to the issue when applicable
--   Please delete this section before submitting the issue
+-   Place an "x" between the brackets next to an option if it applies. Example:
+    -   [x] Selected option
+-   Please delete this section (all content above this line) before submitting
+    the issue
 
 ### System information
 
 -   **OS Platform and Distribution (e.g., Linux Ubuntu 16.04)**:
--   **FiftyOne installed from (source or pip)**:
+-   **FiftyOne installed from (pip or source)**:
 -   **FiftyOne version (run `fiftyone --version`)**:
 -   **Python version**:
 

--- a/.github/ISSUE_TEMPLATE/documentation_issue_template.md
+++ b/.github/ISSUE_TEMPLATE/documentation_issue_template.md
@@ -8,11 +8,10 @@ title: "[DOCUMENTATION]"
 ### Instructions
 
 Thank you for submitting an issue. Please refer to our
-[issue policy](https://www.github.com/voxel51/fiftyone/blob/master/ISSUE_POLICY.md)
+[issue policy](https://www.github.com/voxel51/fiftyone/blob/develop/ISSUE_POLICY.md)
 for information on what types of issues we address.
 
-**Please fill in this bug report template to ensure a timely and thorough
-response.**
+**Please fill in this template to ensure a timely and thorough response.**
 
 -   Place an "x" between the brackets next to an option if it applies. Example:
     -   [x] Selected option

--- a/.github/ISSUE_TEMPLATE/documentation_issue_template.md
+++ b/.github/ISSUE_TEMPLATE/documentation_issue_template.md
@@ -5,18 +5,19 @@ labels: "documentation"
 title: "[DOCUMENTATION]"
 ---
 
-Thank you for submitting an issue. Please refer to our
-[issue policy](https://www.github.com/voxel51/fiftyone/blob/develop/ISSUE_POLICY.md)
-for information on what types of issues we address.
-
-**Please fill in this documentation issue template to ensure a timely and
-thorough response.**
-
 ### Instructions
 
--   Place an "x" between the brackets of an item if it applies.
--   Feel free to add more labels to the issue when applicable
--   Please delete this section before submitting the issue
+Thank you for submitting an issue. Please refer to our
+[issue policy](https://www.github.com/voxel51/fiftyone/blob/master/ISSUE_POLICY.md)
+for information on what types of issues we address.
+
+**Please fill in this bug report template to ensure a timely and thorough
+response.**
+
+-   Place an "x" between the brackets next to an option if it applies. Example:
+    -   [x] Selected option
+-   Please delete this section (all content above this line) before submitting
+    the issue
 
 ### URL(s) with the issue:
 

--- a/.github/ISSUE_TEMPLATE/feature_request_template.md
+++ b/.github/ISSUE_TEMPLATE/feature_request_template.md
@@ -8,11 +8,10 @@ title: "[FR]"
 ### Instructions
 
 Thank you for submitting an issue. Please refer to our
-[issue policy](https://www.github.com/voxel51/fiftyone/blob/master/ISSUE_POLICY.md)
+[issue policy](https://www.github.com/voxel51/fiftyone/blob/develop/ISSUE_POLICY.md)
 for information on what types of issues we address.
 
-**Please fill in this bug report template to ensure a timely and thorough
-response.**
+**Please fill in this template to ensure a timely and thorough response.**
 
 -   Place an "x" between the brackets next to an option if it applies. Example:
     -   [x] Selected option

--- a/.github/ISSUE_TEMPLATE/feature_request_template.md
+++ b/.github/ISSUE_TEMPLATE/feature_request_template.md
@@ -5,18 +5,19 @@ labels: "enhancement"
 title: "[FR]"
 ---
 
-Thank you for submitting an issue. Please refer to our
-[issue policy](https://www.github.com/voxel51/fiftyone/blob/develop/ISSUE_POLICY.md)
-for information on what types of issues we address.
-
-**Please fill in this feature request template to ensure a timely and thorough
-response.**
-
 ### Instructions
 
--   Place an "x" between the brackets of an item if it applies.
--   Feel free to add more labels to the issue when applicable
--   Please delete this section before submitting the issue
+Thank you for submitting an issue. Please refer to our
+[issue policy](https://www.github.com/voxel51/fiftyone/blob/master/ISSUE_POLICY.md)
+for information on what types of issues we address.
+
+**Please fill in this bug report template to ensure a timely and thorough
+response.**
+
+-   Place an "x" between the brackets next to an option if it applies. Example:
+    -   [x] Selected option
+-   Please delete this section (all content above this line) before submitting
+    the issue
 
 ### Proposal Summary
 
@@ -35,9 +36,9 @@ request)
 
 ### What areas of FiftyOne does this feature affect?
 
--   [ ] `App`: FiftyOne application
--   [ ] `Core`: Core `fiftyone` Python library
--   [ ] `Server`: FiftyOne server
+-   [ ] App: FiftyOne application
+-   [ ] Core: Core `fiftyone` Python library
+-   [ ] Server: FiftyOne server
 
 ### Details
 

--- a/.github/ISSUE_TEMPLATE/installation_issue_template.md
+++ b/.github/ISSUE_TEMPLATE/installation_issue_template.md
@@ -9,11 +9,10 @@ title: "[SETUP-BUG]"
 ### Instructions
 
 Thank you for submitting an issue. Please refer to our
-[issue policy](https://www.github.com/voxel51/fiftyone/blob/master/ISSUE_POLICY.md)
+[issue policy](https://www.github.com/voxel51/fiftyone/blob/develop/ISSUE_POLICY.md)
 for information on what types of issues we address.
 
-**Please fill in this bug report template to ensure a timely and thorough
-response.**
+**Please fill in this template to ensure a timely and thorough response.**
 
 -   Place an "x" between the brackets next to an option if it applies. Example:
     -   [x] Selected option

--- a/.github/ISSUE_TEMPLATE/installation_issue_template.md
+++ b/.github/ISSUE_TEMPLATE/installation_issue_template.md
@@ -6,22 +6,24 @@ labels: "bug"
 title: "[SETUP-BUG]"
 ---
 
-Thank you for submitting an issue. Please refer to our
-[issue policy](https://www.github.com/voxel51/fiftyone/blob/develop/ISSUE_POLICY.md)
-for information on what types of issues we address.
-
-**Please fill in this installation issue template to ensure a timely and
-thorough response.**
-
 ### Instructions
 
--   Place an "x" between the brackets of an item if it applies.
--   Please delete this section before submitting the issue
+Thank you for submitting an issue. Please refer to our
+[issue policy](https://www.github.com/voxel51/fiftyone/blob/master/ISSUE_POLICY.md)
+for information on what types of issues we address.
+
+**Please fill in this bug report template to ensure a timely and thorough
+response.**
+
+-   Place an "x" between the brackets next to an option if it applies. Example:
+    -   [x] Selected option
+-   Please delete this section (all content above this line) before submitting
+    the issue
 
 ### System information
 
 -   **OS Platform and Distribution (e.g., Linux Ubuntu 16.04)**:
--   **FiftyOne installed from (source or pip)**:
+-   **FiftyOne installed from (pip or source)**:
 -   **FiftyOne version (run `fiftyone --version`)**:
 -   **Python version**:
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,13 +2,19 @@
 
 (Please fill in changes proposed in this fix)
 
-## How is this patch tested? If it is not, in a single sentence please explain why.
+## How is this patch tested? If it is not, please explain why.
 
 (Details)
 
 ## Release Notes
 
-### Is this a user-facing change?
+### Is this a user-facing change that should be mentioned in the release notes?
+
+<!--
+Please fill in relevant options below with an "x", or by clicking the checkboxes
+after submitting this pull request. Example:
+-   [x] Selected option
+-->
 
 -   [ ] No. You can skip the rest of this section.
 -   [ ] Yes. Give a description of this change to be included in the release
@@ -19,18 +25,8 @@ if this PR is part of a larger change.)
 
 ### What areas of FiftyOne does this PR affect?
 
--   [ ] `App`: FiftyOne application changes
--   [ ] `Build`: Build and test infrastructure changes
--   [ ] `Core`: Core `fiftyone` Python library changes
--   [ ] `Documentation`: FiftyOne documentation changes
--   [ ] `Other`
-
-### Should this PR be mentioned in the release notes? If so, please choose on category:
-
--   [ ] `breaking-change` - The PR will be mentioned in the "Breaking Changes"
-        section
--   [ ] `feature` - A new user-facing feature worth mentioning in the release
-        notes
--   [ ] `bug-fix` - A user-facing bug fix worth mentioning in the release notes
--   [ ] `documentation` - A user-facing documentation change worth mentioning
-        in the release notes
+-   [ ] App: FiftyOne application changes
+-   [ ] Build: Build and test infrastructure changes
+-   [ ] Core: Core `fiftyone` Python library changes
+-   [ ] Documentation: FiftyOne documentation changes
+-   [ ] Other


### PR DESCRIPTION
## What changes are proposed in this pull request?

Changes for a couple things I've noticed with the existing templates:
- The changelog category options didn't match up to the ones used in the changelog
- People without write access to the repo can't add labels to issues, so the templates shouldn't suggest it

## How is this patch tested? If it is not, in a single sentence please explain why.

n/a

## Release Notes

### Is this a user-facing change?

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] `App`: FiftyOne application changes
-   [ ] `Build`: Build and test infrastructure changes
-   [ ] `Core`: Core `fiftyone` Python library changes
-   [ ] `Documentation`: FiftyOne documentation changes
-   [x] `Other`
