### PR TITLE
GitHub actions: test on Windows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,6 +55,9 @@ jobs:
         exclude:
           - os: windows
             python-version: 3.5
+    defaults:
+      run:
+        shell: bash
     steps:
       - name: Clone fiftyone
         uses: actions/checkout@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,15 +40,21 @@ jobs:
           path: dist/*.whl
 
   test:
-    runs-on: ubuntu-18.04
+    runs-on: ${{ matrix.os }}
     if: github.event.pull_request.draft == false
     needs: build
     strategy:
       fail-fast: false
       matrix:
+        os:
+          - ubuntu-18.04
+          - windows-latest
         python-version:
           - 3.5
           - 3.8
+        exclude:
+          - os: windows
+            python-version: 3.5
     steps:
       - name: Clone fiftyone
         uses: actions/checkout@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,9 +87,15 @@ jobs:
       - name: Install fiftyone
         run: |
           pip install -e .
-      - name: Install test dependencies
+      - name: Install test dependencies (non-Windows)
+        if: ${{ !startsWith(matrix.os, 'windows') }}
         run: |
           pip install pytest tensorflow tensorflow-datasets torch torchvision
+      - name: Install test dependencies (Windows)
+        if: ${{ startsWith(matrix.os, 'windows') }}
+        run: |
+          pip install pytest tensorflow tensorflow-datasets
+          pip install torch==1.6.0+cpu torchvision==0.7.0+cpu -f https://download.pytorch.org/whl/torch_stable.html
       - name: Run tests
         run: |
           pytest tests/ --verbose --ignore tests/benchmarking/ --ignore tests/isolated/ --ignore tests/utils/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,7 +53,7 @@ jobs:
           - 3.5
           - 3.8
         exclude:
-          - os: windows
+          - os: windows-latest
             python-version: 3.5
     defaults:
       run:

--- a/tests/unittests.py
+++ b/tests/unittests.py
@@ -768,13 +768,13 @@ class SampleTests(unittest.TestCase):
 
     @drop_datasets
     def test_get_field(self):
-        filepath = "/path/to/image.jpg"
-        sample = fo.Sample(filepath=filepath)
+        field_value = "custom_value"
+        sample = fo.Sample(filepath="/path/to/image.jpg", field1=field_value)
 
         # get valid
-        self.assertEqual(sample.get_field("filepath"), filepath)
-        self.assertEqual(sample["filepath"], filepath)
-        self.assertEqual(sample.filepath, filepath)
+        self.assertEqual(sample.get_field("field1"), field_value)
+        self.assertEqual(sample["field1"], field_value)
+        self.assertEqual(sample.field1, field_value)
 
         # get missing
         with self.assertRaises(AttributeError):


### PR DESCRIPTION
## What changes are proposed in this pull request?

Added a matrix entry to run tests on Windows. Other than installation, only one test was failing!

Note that this is considerably slower on Windows (as of the last run, a bit over 9 minutes, vs. 5 minutes on Linux). The zoo test seems to account for a decent amount of this (maybe disk I/O is slower on the Windows runners?), so we could disable that on Windows or try to cache whatever it downloads somehow.

I also disabled Python 3.5 on Windows because I didn't think it was necessary, although I'm open to discussion there. My experience is that Windows users are somewhat more likely to have a more recent Python version installed, and previous test-related issues we've had haven't been specific to Windows *and* Python 3.5.

## How is this patch tested? If it is not, please explain why.

GitHub tested it for me.

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [x] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
