### PR TITLE
Prevent modal navigation when an input is in focus

### DIFF
--- a/electron/app/components/SampleModal.tsx
+++ b/electron/app/components/SampleModal.tsx
@@ -274,7 +274,9 @@ const SampleModal = ({
 
   useKeydownHandler(
     (e) => {
-      if (e.key == "Escape") {
+      if (document.activeElement.tagName.toLowerCase() === "input") {
+        return;
+      } else if (e.key == "Escape") {
         if (fullscreen) {
           setFullscreen(false);
         } else if (onClose) {

--- a/electron/app/components/SampleModal.tsx
+++ b/electron/app/components/SampleModal.tsx
@@ -274,7 +274,10 @@ const SampleModal = ({
 
   useKeydownHandler(
     (e) => {
-      if (document.activeElement.tagName.toLowerCase() === "input") {
+      if (
+        document.activeElement &&
+        document.activeElement.tagName.toLowerCase() === "input"
+      ) {
         return;
       } else if (e.key == "Escape") {
         if (fullscreen) {


### PR DESCRIPTION
## What changes are proposed in this pull request?

Resolves #490. This is probably not the best practice solution, but `e.stopPropagation()` did not work, and `e.preventDefault()` did too much.

## How is this patch tested? If it is not, please explain why.

Locally

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

Arrow key navigation is now disabled in the sample modal when using editing in a label filter input.

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
