### PR TITLE
Sample modal focus tweaks

### DIFF
--- a/electron/app/components/SampleModal.tsx
+++ b/electron/app/components/SampleModal.tsx
@@ -262,8 +262,9 @@ const SampleModal = ({
     (e) => {
       if (
         document.activeElement &&
-        document.activeElement.tagName.toLowerCase() === "input" &&
-        !["checkbox", "radio"].includes(document.activeElement.type)
+        ((document.activeElement.tagName.toLowerCase() === "input" &&
+          !["checkbox", "radio"].includes(document.activeElement.type)) ||
+          document.activeElement.getAttribute("role") === "slider")
       ) {
         return;
       } else if (e.key == "Escape") {

--- a/electron/app/components/SampleModal.tsx
+++ b/electron/app/components/SampleModal.tsx
@@ -262,7 +262,8 @@ const SampleModal = ({
     (e) => {
       if (
         document.activeElement &&
-        document.activeElement.tagName.toLowerCase() === "input"
+        document.activeElement.tagName.toLowerCase() === "input" &&
+        !["checkbox", "radio"].includes(document.activeElement.type)
       ) {
         return;
       } else if (e.key == "Escape") {


### PR DESCRIPTION
Followup to #499 - allows arrow keys to work immediately after clicking a checkbox, but not when using a slider (since arrow keys also adjust sliders)