### PR TITLE
Fix matching some special characters in string fields

### DIFF
--- a/fiftyone/core/expressions.py
+++ b/fiftyone/core/expressions.py
@@ -763,10 +763,10 @@ class ViewField(ViewExpression, metaclass=_MetaViewField):
 
 
 def _escape_regex_chars(str_or_strs):
-    # Must escape `]` and `-` because they have special meaning inside the `[]`
-    # that will be used in the replacement regex
-    regex_chars = "[\]{}()*+\-?.,\\^$|#"
-    _escape = lambda s: re.sub(r"([%s])" % "".join(regex_chars), r"\\\1", s)
+    # Must escape `[`, `]`, `-`, and `\` because they have special meaning
+    # inside the `[]` that will be used in the replacement regex
+    regex_chars = r"\[\]{}()*+\-?.,\\^$|#"
+    _escape = lambda s: re.sub(r"([%s])" % regex_chars, r"\\\1", s)
 
     if etau.is_str(str_or_strs):
         return _escape(str_or_strs)

--- a/tests/unittests.py
+++ b/tests/unittests.py
@@ -1502,12 +1502,17 @@ class ViewExpressionTests(unittest.TestCase):
 
     @drop_datasets
     def test_str(self):
+        special_chars = r"[]{}()*+-?.,\\^$|#"
         self.dataset = fo.Dataset()
         self.dataset.add_samples(
             [
                 fo.Sample(filepath="test1.jpg", test="test1.jpg"),
                 fo.Sample(filepath="test2.jpg", test="test2.jpg"),
-                fo.Sample(filepath="test3.jpg", test="test3.jpg"),
+                fo.Sample(
+                    filepath="test3.jpg",
+                    test="test3.jpg",
+                    special_chars=special_chars,
+                ),
             ]
         )
 
@@ -1570,6 +1575,16 @@ class ViewExpressionTests(unittest.TestCase):
             len(
                 self.dataset.match(
                     F("test").matches_str("TEST1.JPG", case_sensitive=False)
+                )
+            ),
+            1,
+        )
+
+        # test escaping
+        self.assertEqual(
+            len(
+                self.dataset.match(
+                    F("special_chars").matches_str(special_chars)
                 )
             ),
             1,


### PR DESCRIPTION
## What changes are proposed in this pull request?

Fixed some escaping issues:

* `\` was not properly escaped, so it could not be matched.
* Also, `[` needed to be escaped to avoid a warning in Python 3.7+: https://bugs.python.org/issue30349
  An example of this warning:
```
fiftyone/core/expressions.py:769: FutureWarning: Possible nested set at position 2
    _escape = lambda s: re.sub(r"([%s])" % "".join(regex_chars), r"\\\1", s)
```

## How is this patch tested? If it is not, please explain why.

Added a test (see diff)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

Unlikely that anyone has run into this yet

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
