### PR TITLE
Add support for filtering sample JSON

### DIFF
--- a/electron/app/components/JSONView.tsx
+++ b/electron/app/components/JSONView.tsx
@@ -2,14 +2,15 @@ import React from "react";
 import styled from "styled-components";
 import copy from "copy-to-clipboard";
 import { Checkbox, FormControlLabel } from "@material-ui/core";
+import { useRecoilValue } from "recoil";
 
-import { RESERVED_FIELDS } from "../utils/labels";
 import { Button, ModalFooter } from "./utils";
+import * as selectors from "../recoil/selectors";
 
 type Props = {
   object: object;
-  filter: { [key: string]: boolean };
   enableFilter: (enabled: boolean) => void;
+  filterJSON: boolean;
 };
 
 const Body = styled.div`
@@ -58,15 +59,10 @@ const Body = styled.div`
   }
 `;
 
-const JSONView = ({ object, filter, enableFilter }: Props) => {
-  if (filter) {
-    object = Object.fromEntries(
-      Object.entries(object).filter(
-        ([key]) => filter[key] || RESERVED_FIELDS.includes(key)
-      )
-    );
-  }
-  const str = JSON.stringify(object, null, 4);
+const JSONView = ({ object, enableFilter, filterJSON }: Props) => {
+  const filter = useRecoilValue(selectors.sampleModalFilter);
+  const str = JSON.stringify(filterJSON ? filter(object) : object, null, 4);
+
   return (
     <Body>
       <pre>{str}</pre>
@@ -78,8 +74,8 @@ const JSONView = ({ object, filter, enableFilter }: Props) => {
               classes={{ label: "label" }}
               control={
                 <Checkbox
-                  checked={Boolean(filter)}
-                  onChange={() => enableFilter(!filter)}
+                  checked={Boolean(filterJSON)}
+                  onChange={() => enableFilter(!filterJSON)}
                   classes={{ root: "checkbox", checked: "checked" }}
                 />
               }

--- a/electron/app/components/JSONView.tsx
+++ b/electron/app/components/JSONView.tsx
@@ -1,11 +1,15 @@
 import React from "react";
 import styled from "styled-components";
 import copy from "copy-to-clipboard";
+import { Checkbox, FormControlLabel } from "@material-ui/core";
 
+import { RESERVED_FIELDS } from "../utils/labels";
 import { Button, ModalFooter } from "./utils";
 
 type Props = {
   object: object;
+  filter: { [key: string]: boolean };
+  enableFilter: (enabled: boolean) => void;
 };
 
 const Body = styled.div`
@@ -33,16 +37,56 @@ const Body = styled.div`
   ${ModalFooter} {
     flex-direction: column;
     align-items: flex-end;
+
+    > div.controls {
+      display: flex;
+
+      .label {
+        font-weight: bold;
+        font-family: unset;
+      }
+
+      .checkbox {
+        padding: 0 5px;
+        color: ${({ theme }) => theme.fontDark};
+
+        &.checked {
+          color: ${({ theme }) => theme.brand};
+        }
+      }
+    }
   }
 `;
 
-const JSONView = ({ object }: Props) => {
+const JSONView = ({ object, filter, enableFilter }: Props) => {
+  if (filter) {
+    object = Object.fromEntries(
+      Object.entries(object).filter(
+        ([key]) => filter[key] || RESERVED_FIELDS.includes(key)
+      )
+    );
+  }
   const str = JSON.stringify(object, null, 4);
   return (
     <Body>
       <pre>{str}</pre>
       <ModalFooter>
-        <Button onClick={() => copy(str)}>Copy JSON</Button>
+        <div className="controls">
+          {enableFilter ? (
+            <FormControlLabel
+              label="Filter"
+              classes={{ label: "label" }}
+              control={
+                <Checkbox
+                  checked={Boolean(filter)}
+                  onChange={() => enableFilter(!filter)}
+                  classes={{ root: "checkbox", checked: "checked" }}
+                />
+              }
+            />
+          ) : null}
+          <Button onClick={() => copy(str)}>Copy JSON</Button>
+        </div>
       </ModalFooter>
     </Body>
   );

--- a/electron/app/components/Player51.tsx
+++ b/electron/app/components/Player51.tsx
@@ -36,10 +36,15 @@ const PARSERS = {
         name,
         label: `${obj.label}`,
         confidence: obj.confidence,
-        bounding_box: {
-          top_left: { x: bb[0], y: bb[1] },
-          bottom_right: { x: bb[0] + bb[2], y: bb[1] + bb[3] },
-        },
+        bounding_box: bb
+          ? {
+              top_left: { x: bb[0], y: bb[1] },
+              bottom_right: { x: bb[0] + bb[2], y: bb[1] + bb[3] },
+            }
+          : {
+              top_left: { x: 0, y: 0 },
+              bottom_right: { x: 0, y: 0 },
+            },
         attrs: { attrs },
       };
     },

--- a/electron/app/components/SampleModal.tsx
+++ b/electron/app/components/SampleModal.tsx
@@ -362,7 +362,7 @@ const SampleModal = ({
         {showJSON ? (
           <JSONView
             object={sample}
-            filter={enableJSONFilter ? activeLabels : null}
+            filterJSON={enableJSONFilter}
             enableFilter={setEnableJSONFilter}
           />
         ) : (

--- a/electron/app/components/SampleModal.tsx
+++ b/electron/app/components/SampleModal.tsx
@@ -213,6 +213,7 @@ const SampleModal = ({
   const playerContainerRef = useRef();
   const [playerStyle, setPlayerStyle] = useState({ height: "100%" });
   const [showJSON, setShowJSON] = useState(false);
+  const [enableJSONFilter, setEnableJSONFilter] = useState(true);
   const [fullscreen, setFullscreen] = useState(false);
   const [activeLabels, setActiveLabels] = useRecoilState(
     atoms.modalActiveLabels
@@ -359,7 +360,11 @@ const SampleModal = ({
     <Container className={fullscreen ? "fullscreen" : ""}>
       <div className="player" ref={playerContainerRef}>
         {showJSON ? (
-          <JSONView object={sample} />
+          <JSONView
+            object={sample}
+            filter={enableJSONFilter ? activeLabels : null}
+            enableFilter={setEnableJSONFilter}
+          />
         ) : (
           <Player51
             key={sampleUrl} // force re-render when this changes

--- a/electron/app/recoil/selectors.ts
+++ b/electron/app/recoil/selectors.ts
@@ -191,12 +191,11 @@ export const sampleModalFilter = selector({
   key: "sampleModalFilter",
   get: ({ get }) => {
     const filters = get(modalLabelFilters);
-    const activeTags = get(atoms.activeTags);
     const activeLabels = get(atoms.modalActiveLabels);
     return (sample) => {
       return Object.entries(sample).reduce((acc, [key, value]) => {
         if (key === "tags") {
-          acc[key] = value.filter((tag) => activeTags[tag]);
+          acc[key] = value;
         } else if (value && VALID_LIST_TYPES.includes(value._cls)) {
           acc[key] = value[value._cls.toLowerCase()].filter(filters[key]);
         } else if (value && filters[key] && filters[key](value)) {

--- a/electron/app/recoil/selectors.ts
+++ b/electron/app/recoil/selectors.ts
@@ -195,13 +195,11 @@ export const sampleModalFilter = selector({
     const activeLabels = get(atoms.modalActiveLabels);
     return (sample) => {
       return Object.entries(sample).reduce((acc, [key, value]) => {
-        if (value === null) {
-          return acc;
-        } else if (key === "tags") {
+        if (key === "tags") {
           acc[key] = value.filter((tag) => activeTags[tag]);
-        } else if (VALID_LIST_TYPES.includes(value._cls)) {
+        } else if (value && VALID_LIST_TYPES.includes(value._cls)) {
           acc[key] = value[value._cls.toLowerCase()].filter(filters[key]);
-        } else if (filters[key] && filters[key](value)) {
+        } else if (value && filters[key] && filters[key](value)) {
           acc[key] = value;
         } else if (RESERVED_FIELDS.includes(key)) {
           acc[key] = value;

--- a/electron/app/utils/labels.ts
+++ b/electron/app/utils/labels.ts
@@ -1,5 +1,6 @@
 export const VALID_OBJECT_TYPES = ["Detection", "Detections"];
 export const VALID_CLASS_TYPES = ["Classification", "Classifications"];
+export const VALID_LIST_TYPES = ["Classifications", "Detections"];
 export const VALID_LABEL_TYPES = [...VALID_CLASS_TYPES, ...VALID_OBJECT_TYPES];
 
 export const VALID_SCALAR_TYPES = [


### PR DESCRIPTION
## What changes are proposed in this pull request?

Ability to filter the JSON view. Closes #387.
This is enabled by default when opening the modal, but can be disabled.
![image](https://user-images.githubusercontent.com/3719547/92257902-f5d9e800-eea3-11ea-984c-769b62b9aeb2.png)

## How is this patch tested? If it is not, please explain why.

Locally

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [X] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

Title

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
