### PR TITLE
Selection options

### DIFF
--- a/electron/app/components/ImageContainerHeader.tsx
+++ b/electron/app/components/ImageContainerHeader.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import styled from "styled-components";
 
 import DropdownHandle from "./DropdownHandle";
+import SelectionMenu from "./SelectionMenu";
 
 type Props = {
   datasetName: string;
@@ -53,11 +54,7 @@ const ImageContainerHeader = ({
         />
       </div>
       <div>
-        {datasetName ? (
-          <div>
-            Dataset: <strong>{datasetName}</strong>
-          </div>
-        ) : null}
+        <SelectionMenu />
       </div>
       <div>
         <div className="total">

--- a/electron/app/components/Samples.tsx
+++ b/electron/app/components/Samples.tsx
@@ -9,17 +9,9 @@ import * as atoms from "../recoil/atoms";
 
 function Samples(props) {
   const { displayProps, state, setView, port } = props;
-  const initialSelected = state.selected.reduce((obj, id) => {
-    return {
-      ...obj,
-      [id]: true,
-    };
-  }, {});
-
-  const [selected, setSelected] = useState(initialSelected);
-  const [scrollState, setScrollState] = tile(port);
-
   const setCurrentSamples = useSetRecoilState(atoms.currentSamples);
+
+  const [scrollState, setScrollState] = tile(port);
   useEffect(() => {
     setCurrentSamples(scrollState.rows.map((row) => row.samples).flat());
   }, [scrollState.rows]);
@@ -48,8 +40,6 @@ function Samples(props) {
               <Sample
                 displayProps={displayProps}
                 sample={s}
-                selected={selected}
-                setSelected={setSelected}
                 setView={setView}
               />
             </Grid.Column>

--- a/electron/app/components/SelectionMenu.tsx
+++ b/electron/app/components/SelectionMenu.tsx
@@ -35,6 +35,12 @@ const SelectionMenu = ({ port, dispatch }) => {
   return (
     <DropdownTag
       name={selectedSamples.size + " selected"}
+      disabled={!selectedSamples.size}
+      title={
+        selectedSamples.size
+          ? undefined
+          : "Click on samples below to select them"
+      }
       onSelect={(item) => item.action()}
       menuItems={[
         {

--- a/electron/app/components/SelectionMenu.tsx
+++ b/electron/app/components/SelectionMenu.tsx
@@ -38,7 +38,6 @@ const SelectionMenu = ({ port, dispatch }) => {
     });
     newState.view.view = JSON.stringify(newView);
     socket.emit("update", { data: newState, include_self: true }, () => {
-      handleStateUpdate(newState);
       callback();
     });
   };
@@ -57,8 +56,7 @@ const SelectionMenu = ({ port, dispatch }) => {
         },
         {
           name: "Only show selected",
-          action: () =>
-            addStage("Select", () => setSelectedSamples(selectedSamples)),
+          action: () => addStage("Select"),
         },
         {
           name: "Hide selected",

--- a/electron/app/components/SelectionMenu.tsx
+++ b/electron/app/components/SelectionMenu.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import { useRecoilState } from "recoil";
-import styled from "styled-components";
 
 import { updateState } from "../actions/update";
 import * as atoms from "../recoil/atoms";

--- a/electron/app/components/SelectionMenu.tsx
+++ b/electron/app/components/SelectionMenu.tsx
@@ -43,6 +43,9 @@ const SelectionMenu = ({ port, dispatch }) => {
   };
 
   const size = selectedSamples.size;
+  if (size == 0) {
+    return <span>0 samples selected</span>;
+  }
   return (
     <DropdownTag
       name={`${size} sample${size == 1 ? "" : "s"} selected`}

--- a/electron/app/components/SelectionMenu.tsx
+++ b/electron/app/components/SelectionMenu.tsx
@@ -22,11 +22,24 @@ const SelectionMenu = ({ port, dispatch }) => {
     });
   };
 
+  const sendEvent = (event) => {
+    socket.emit(event, (data) => {
+      dispatch(updateState(data));
+    });
+  };
+
   return (
     <DropdownTag
       name={selectedSamples.size + " selected"}
       onSelect={(item) => item.action()}
-      menuItems={[{ name: "Clear selection", action: clearSelection }]}
+      menuItems={[
+        { name: "Clear selection", action: clearSelection },
+        { name: "Hide selected", action: () => sendEvent("exclude_selected") },
+        {
+          name: "Only show selected",
+          action: () => sendEvent("select_selected"),
+        },
+      ]}
       menuZIndex={500}
     />
   );

--- a/electron/app/components/SelectionMenu.tsx
+++ b/electron/app/components/SelectionMenu.tsx
@@ -32,15 +32,12 @@ const SelectionMenu = ({ port, dispatch }) => {
     socket.emit(event, handleStateUpdate);
   };
 
+  const size = selectedSamples.size;
   return (
     <DropdownTag
-      name={selectedSamples.size + " selected"}
-      disabled={!selectedSamples.size}
-      title={
-        selectedSamples.size
-          ? undefined
-          : "Click on samples below to select them"
-      }
+      name={`${size} sample${size == 1 ? "" : "s"} selected`}
+      disabled={!size}
+      title={size ? undefined : "Click on samples below to select them"}
       onSelect={(item) => item.action()}
       menuItems={[
         {

--- a/electron/app/components/SelectionMenu.tsx
+++ b/electron/app/components/SelectionMenu.tsx
@@ -1,8 +1,9 @@
 import React from "react";
-import { useRecoilValue } from "recoil";
+import { useRecoilState } from "recoil";
 import styled from "styled-components";
 
 import { updateState } from "../actions/update";
+import * as atoms from "../recoil/atoms";
 import connect from "../utils/connect";
 import { getSocket } from "../utils/socket";
 
@@ -10,18 +11,20 @@ import DropdownTag from "./Tags/DropdownTag";
 
 const SelectionMenu = ({ port, dispatch }) => {
   const socket = getSocket(port, "state");
+  const [selectedSamples, setSelectedSamples] = useRecoilState(
+    atoms.selectedSamples
+  );
 
   const clearSelection = () => {
-    // setSelected([]);
+    setSelectedSamples(new Set());
     socket.emit("clear_selection", (data) => {
-      console.log("updateState", data);
       dispatch(updateState(data));
     });
   };
 
   return (
     <DropdownTag
-      name="foo selected"
+      name={selectedSamples.size + " selected"}
       onSelect={(item) => item.action()}
       menuItems={[{ name: "Clear selection", action: clearSelection }]}
       menuZIndex={500}

--- a/electron/app/components/SelectionMenu.tsx
+++ b/electron/app/components/SelectionMenu.tsx
@@ -1,0 +1,32 @@
+import React from "react";
+import { useRecoilValue } from "recoil";
+import styled from "styled-components";
+
+import { updateState } from "../actions/update";
+import connect from "../utils/connect";
+import { getSocket } from "../utils/socket";
+
+import DropdownTag from "./Tags/DropdownTag";
+
+const SelectionMenu = ({ port, dispatch }) => {
+  const socket = getSocket(port, "state");
+
+  const clearSelection = () => {
+    // setSelected([]);
+    socket.emit("clear_selection", (data) => {
+      console.log("updateState", data);
+      dispatch(updateState(data));
+    });
+  };
+
+  return (
+    <DropdownTag
+      name="foo selected"
+      onSelect={(item) => item.action()}
+      menuItems={[{ name: "Clear selection", action: clearSelection }]}
+      menuZIndex={500}
+    />
+  );
+};
+
+export default connect(SelectionMenu);

--- a/electron/app/components/SelectionMenu.tsx
+++ b/electron/app/components/SelectionMenu.tsx
@@ -30,7 +30,7 @@ const SelectionMenu = ({ port, dispatch }) => {
     socket.emit("clear_selection");
   };
 
-  const addStage = (name, callback) => {
+  const addStage = (name, callback = () => {}) => {
     const newState = JSON.parse(JSON.stringify(stateDescription));
     const newView = JSON.parse(newState.view.view);
     newView.push({
@@ -38,11 +38,10 @@ const SelectionMenu = ({ port, dispatch }) => {
       kwargs: [["sample_ids", Array.from(selectedSamples)]],
     });
     newState.view.view = JSON.stringify(newView);
-    socket.emit("update", { data: newState, include_self: true }, callback);
-  };
-
-  const sendEvent = (event) => {
-    socket.emit(event, handleStateUpdate);
+    socket.emit("update", { data: newState, include_self: true }, () => {
+      handleStateUpdate(newState);
+      callback();
+    });
   };
 
   const size = selectedSamples.size;
@@ -59,7 +58,8 @@ const SelectionMenu = ({ port, dispatch }) => {
         },
         {
           name: "Only show selected",
-          action: () => addStage("Select"),
+          action: () =>
+            addStage("Select", () => setSelectedSamples(selectedSamples)),
         },
         {
           name: "Hide selected",

--- a/electron/app/components/Tags/DropdownTag.stories.tsx
+++ b/electron/app/components/Tags/DropdownTag.stories.tsx
@@ -1,0 +1,18 @@
+import React from "react";
+import DropdownTag from "./DropdownTag";
+
+export default {
+  component: DropdownTag,
+  title: "Tags/DropdownTag",
+};
+
+export const standard = () => (
+  <DropdownTag
+    name="menu"
+    menuItems={[
+      { name: "Option 1" },
+      { name: "Option 2" },
+      { name: "Option 3" },
+    ]}
+  />
+);

--- a/electron/app/components/Tags/DropdownTag.tsx
+++ b/electron/app/components/Tags/DropdownTag.tsx
@@ -16,6 +16,8 @@ import Menu from "./Menu";
 import SelectionTag from "./SelectionTag";
 
 const Container = styled.div`
+  cursor: ${({ disabled }) => (disabled ? "not-allowed" : undefined)};
+
   .popper {
     z-index: ${({ menuZIndex }) => menuZIndex};
   }
@@ -31,6 +33,8 @@ const DropdownTag = ({
   name,
   menuItems,
   menuZIndex = 1,
+  disabled = false,
+  title,
   onSelect,
   ...rest
 }) => {
@@ -46,8 +50,8 @@ const DropdownTag = ({
   };
 
   return (
-    <Container menuZIndex={menuZIndex}>
-      <Button ref={anchorRef} onClick={handleToggle}>
+    <Container menuZIndex={menuZIndex} disabled={disabled} title={title}>
+      <Button ref={anchorRef} onClick={handleToggle} disabled={disabled}>
         <Body {...rest}>
           {name} <ArrowDropDown />
         </Body>

--- a/electron/app/components/Tags/DropdownTag.tsx
+++ b/electron/app/components/Tags/DropdownTag.tsx
@@ -18,6 +18,17 @@ import SelectionTag from "./SelectionTag";
 const Container = styled.div`
   cursor: ${({ disabled }) => (disabled ? "not-allowed" : undefined)};
 
+  .dropdown-button {
+    font-family: unset;
+    padding-left: 0;
+    padding-right: 0;
+
+    .dropdown-icon {
+      color: ${({ theme, disabled }) =>
+        disabled ? theme.fontDarkest : undefined};
+    }
+  }
+
   .popper {
     z-index: ${({ menuZIndex }) => menuZIndex};
   }
@@ -27,6 +38,7 @@ const Body = styled(SelectionTag.Body)`
   display: flex;
   align-items: center;
   text-transform: none;
+  padding-right: 0.5em;
 `;
 
 const DropdownTag = ({
@@ -51,9 +63,14 @@ const DropdownTag = ({
 
   return (
     <Container menuZIndex={menuZIndex} disabled={disabled} title={title}>
-      <Button ref={anchorRef} onClick={handleToggle} disabled={disabled}>
-        <Body {...rest}>
-          {name} <ArrowDropDown />
+      <Button
+        classes={{ root: "dropdown-button" }}
+        ref={anchorRef}
+        onClick={handleToggle}
+        disabled={disabled}
+      >
+        <Body disabled={disabled} {...rest}>
+          {name} <ArrowDropDown className="dropdown-icon" />
         </Body>
       </Button>
       <Popper

--- a/electron/app/components/Tags/DropdownTag.tsx
+++ b/electron/app/components/Tags/DropdownTag.tsx
@@ -17,7 +17,7 @@ import SelectionTag from "./SelectionTag";
 
 const Container = styled.div`
   .popper {
-    z-index: 1;
+    z-index: ${({ menuZIndex }) => menuZIndex};
   }
 `;
 
@@ -27,17 +27,26 @@ const Body = styled(SelectionTag.Body)`
   text-transform: none;
 `;
 
-const DropdownTag = ({ name, menuItems, ...rest }) => {
+const DropdownTag = ({
+  name,
+  menuItems,
+  menuZIndex = 1,
+  onSelect,
+  ...rest
+}) => {
   // adapted from https://material-ui.com/components/menus/#menulist-composition
   const [isOpen, setOpen] = useState(false);
   const anchorRef = useRef(null);
 
   const handleToggle = () => setOpen(!isOpen);
   const handleClose = () => setOpen(false);
-  const handleSelect = () => setOpen(false);
+  const handleSelect = (item) => {
+    onSelect(item);
+    setOpen(false);
+  };
 
   return (
-    <Container>
+    <Container menuZIndex={menuZIndex}>
       <Button ref={anchorRef} onClick={handleToggle}>
         <Body {...rest}>
           {name} <ArrowDropDown />

--- a/electron/app/components/Tags/DropdownTag.tsx
+++ b/electron/app/components/Tags/DropdownTag.tsx
@@ -1,0 +1,62 @@
+import React, { useRef, useState } from "react";
+import styled from "styled-components";
+
+import {
+  Button,
+  ClickAwayListener,
+  Grow,
+  Paper,
+  Popper,
+  MenuItem,
+  MenuList,
+} from "@material-ui/core";
+import { ArrowDropDown } from "@material-ui/icons";
+
+import Menu from "./Menu";
+import SelectionTag from "./SelectionTag";
+
+const Container = styled.div``;
+
+const Body = styled(SelectionTag.Body)`
+  display: flex;
+  align-items: center;
+  text-transform: none;
+`;
+
+const DropdownTag = ({ name, menuItems, ...rest }) => {
+  // adapted from https://material-ui.com/components/menus/#menulist-composition
+  const [isOpen, setOpen] = useState(false);
+  const anchorRef = useRef(null);
+
+  const handleToggle = () => setOpen(!isOpen);
+  const handleClose = () => setOpen(false);
+  const handleSelect = () => setOpen(false);
+
+  return (
+    <Container>
+      <Button ref={anchorRef} onClick={handleToggle}>
+        <Body {...rest}>
+          {name} <ArrowDropDown />
+        </Body>
+      </Button>
+      <Popper
+        open={isOpen}
+        anchorEl={anchorRef.current}
+        role={undefined}
+        transition
+        disablePortal
+      >
+        <Menu
+          autoFocusItem={isOpen}
+          items={menuItems}
+          onClose={handleClose}
+          onSelect={handleSelect}
+        />
+      </Popper>
+    </Container>
+  );
+};
+
+DropdownTag.Body = Body;
+
+export default DropdownTag;

--- a/electron/app/components/Tags/DropdownTag.tsx
+++ b/electron/app/components/Tags/DropdownTag.tsx
@@ -15,7 +15,11 @@ import { ArrowDropDown } from "@material-ui/icons";
 import Menu from "./Menu";
 import SelectionTag from "./SelectionTag";
 
-const Container = styled.div``;
+const Container = styled.div`
+  .popper {
+    z-index: 1;
+  }
+`;
 
 const Body = styled(SelectionTag.Body)`
   display: flex;
@@ -45,6 +49,7 @@ const DropdownTag = ({ name, menuItems, ...rest }) => {
         role={undefined}
         transition
         disablePortal
+        className="popper"
       >
         <Menu
           autoFocusItem={isOpen}

--- a/electron/app/components/Tags/Menu.tsx
+++ b/electron/app/components/Tags/Menu.tsx
@@ -16,6 +16,16 @@ const Container = styled.div`
     background-color: ${({ theme }) => theme.menuBackground};
     border: 2px solid ${({ theme }) => theme.menuBorder};
     box-shadow: 0 2px 20px 0 ${({ theme }) => theme.menuShadow};
+
+    .item {
+      color: ${({ theme }) => theme.fontDark};
+      font-family: unset;
+      font-weight: bold;
+      font-size: 14px;
+      line-height: 29px;
+      padding-top: 0;
+      padding-bottom: 0;
+    }
   }
 `;
 
@@ -25,7 +35,11 @@ const Menu = ({ items, onClose, onSelect, ...rest }) => {
       <ClickAwayListener onClickAway={onClose}>
         <MenuList classes={{ root: "menu" }} {...rest}>
           {items.map((item, i) => (
-            <MenuItem key={i} onClick={() => onSelect(item)}>
+            <MenuItem
+              key={i}
+              onClick={() => onSelect(item)}
+              classes={{ root: "item" }}
+            >
               {item.name}
             </MenuItem>
           ))}

--- a/electron/app/components/Tags/Menu.tsx
+++ b/electron/app/components/Tags/Menu.tsx
@@ -15,7 +15,7 @@ const Container = styled.div`
   .menu {
     background-color: ${({ theme }) => theme.menuBackground};
     border: 2px solid ${({ theme }) => theme.menuBorder};
-    box-shadow: 0 2px 20px 0 ${({ theme }) => theme.menuShadow};
+    box-shadow: 0 2px 20px 0 ${({ theme }) => theme.darkerShadow};
 
     .item {
       color: ${({ theme }) => theme.fontDark};

--- a/electron/app/components/Tags/Menu.tsx
+++ b/electron/app/components/Tags/Menu.tsx
@@ -1,0 +1,38 @@
+import React, { useRef, useState } from "react";
+import styled from "styled-components";
+
+import {
+  Button,
+  ClickAwayListener,
+  Grow,
+  Paper,
+  Popper,
+  MenuItem,
+  MenuList,
+} from "@material-ui/core";
+
+const Container = styled.div`
+  .menu {
+    background-color: ${({ theme }) => theme.menuBackground};
+    border: 2px solid ${({ theme }) => theme.menuBorder};
+    box-shadow: 0 2px 20px 0 ${({ theme }) => theme.menuShadow};
+  }
+`;
+
+const Menu = ({ items, onClose, onSelect, ...rest }) => {
+  return (
+    <Container>
+      <ClickAwayListener onClickAway={onClose}>
+        <MenuList classes={{ root: "menu" }} {...rest}>
+          {items.map((item, i) => (
+            <MenuItem key={i} onClick={() => onSelect(item)}>
+              {item.name}
+            </MenuItem>
+          ))}
+        </MenuList>
+      </ClickAwayListener>
+    </Container>
+  );
+};
+
+export default Menu;

--- a/electron/app/containers/App.tsx
+++ b/electron/app/containers/App.tsx
@@ -12,7 +12,7 @@ import { updatePort } from "../actions/update";
 import { updateState, updateConnected, updateLoading } from "../actions/update";
 import { getSocket, useSubscribe } from "../utils/socket";
 import connect from "../utils/connect";
-import { stateDescription } from "../recoil/atoms";
+import { stateDescription, selectedSamples } from "../recoil/atoms";
 import gaConfig from "../constants/ga.json";
 import Error from "./Error";
 
@@ -28,9 +28,11 @@ function App(props: Props) {
   const [result, setResultFromForm] = useState({ port, connected });
   const [socket, setSocket] = useState(getSocket(result.port, "state"));
   const setStateDescription = useSetRecoilState(stateDescription);
+  const setSelectedSamples = useSetRecoilState(selectedSamples);
 
   const handleStateUpdate = (data) => {
     setStateDescription(data);
+    setSelectedSamples(new Set(data.selected));
     dispatch(updateState(data));
   };
 

--- a/electron/app/recoil/atoms.ts
+++ b/electron/app/recoil/atoms.ts
@@ -15,6 +15,11 @@ export const stateDescription = atom({
   default: {},
 });
 
+export const selectedSamples = atom({
+  key: "selectedSamples",
+  default: new Set(),
+});
+
 export const stageInfo = atom({
   key: "stageInfo",
   default: undefined,

--- a/electron/app/shared/colors.ts
+++ b/electron/app/shared/colors.ts
@@ -24,9 +24,8 @@ export const blue50 = "hsl(210, 20%, 50%)";
 export const blue15 = "hsl(210, 20%, 15%)";
 
 // Dark theme colors
-const black0a14 = "hsla(0, 0%, 0%, 0.14)";
 const black0a16 = "hsla(0, 0%, 0%, 0.16)";
-const black0a25 = "hsla(0, 0%, 0%, 0.16)";
+const black0a25 = "hsla(0, 0%, 0%, 0.25)";
 const grey11 = "hsl(210, 11%, 11%)";
 const grey15 = "hsl(210, 11%, 15%)";
 const grey19 = "hsl(214, 7%, 19%)";
@@ -60,7 +59,6 @@ export const darkTheme = {
   overlayButton: grey46a30,
   menuBackground: grey15,
   menuBorder: grey11,
-  menuShadow: black0a14,
   darkShadow: black0a16,
   darkerShadow: black0a25,
 

--- a/electron/app/shared/colors.ts
+++ b/electron/app/shared/colors.ts
@@ -24,6 +24,8 @@ export const blue50 = "hsl(210, 20%, 50%)";
 export const blue15 = "hsl(210, 20%, 15%)";
 
 // Dark theme colors
+const black0a14 = "hsla(0, 0%, 0%, 0.14)";
+const grey11 = "hsl(210, 11%, 11%)";
 const grey15 = "hsl(210, 11%, 15%)";
 const grey19 = "hsl(214, 7%, 19%)";
 const grey19a50 = "hsla(214, 7%, 19%, 0.5)";
@@ -55,6 +57,9 @@ export const darkTheme = {
   buttonBorder: grey24,
   overlay: grey46a70,
   overlayButton: grey46a30,
+  menuBackground: grey15,
+  menuBorder: grey11,
+  menuShadow: black0a14,
 
   brand: orange49,
   brandTransparent: orange49a40,

--- a/fiftyone/server/main.py
+++ b/fiftyone/server/main.py
@@ -191,6 +191,21 @@ class StateController(Namespace):
         state.selected = list(selected)
         return state
 
+    @_load_state
+    def on_clear_selection(self, state):
+        """Remove all samples from the selected samples list
+
+        Args:
+            state: the current
+                :class:`fiftyone.core.state.StateDescriptionWithDerivables`
+
+        Returns:
+            the updated
+                :class:`fiftyone.core.state.StateDescriptionWithDerivables`
+        """
+        state.selected = []
+        return state
+
     def on_page(self, page, page_length=20):
         """Gets the requested page of samples.
 

--- a/fiftyone/server/main.py
+++ b/fiftyone/server/main.py
@@ -264,6 +264,48 @@ class StateController(Namespace):
 
         return _get_distributions(view, group)
 
+    @_load_state
+    def on_select_selected(self, state):
+        """Adds a Select stage containing the selected samples to the current
+        view (creating a view if necessary).
+
+        Args:
+            state: the current
+                :class:`fiftyone.core.state.StateDescriptionWithDerivables`
+
+        Returns:
+            the updated
+                :class:`fiftyone.core.state.StateDescriptionWithDerivables`
+        """
+        if not state.dataset or not state.selected:
+            return state
+
+        if state.view is None:
+            state.view = state.dataset.view()
+        state.view = state.view.select(state.selected)
+        return state
+
+    @_load_state
+    def on_exclude_selected(self, state):
+        """Adds an Exclude stage containing the selected samples to the current
+        view (creating a view if necessary).
+
+        Args:
+            state: the current
+                :class:`fiftyone.core.state.StateDescriptionWithDerivables`
+
+        Returns:
+            the updated
+                :class:`fiftyone.core.state.StateDescriptionWithDerivables`
+        """
+        if not state.dataset or not state.selected:
+            return state
+
+        if state.view is None:
+            state.view = state.dataset.view()
+        state.view = state.view.exclude(state.selected)
+        return state
+
 
 def _get_distributions(view, group):
     pipeline = DISTRIBUTION_PIPELINES[group]

--- a/fiftyone/server/main.py
+++ b/fiftyone/server/main.py
@@ -272,49 +272,6 @@ class StateController(Namespace):
 
         return _get_distributions(view, group)
 
-    @_load_state(trigger_update=True)
-    def on_select_selected(self, state):
-        """Adds a Select stage containing the selected samples to the current
-        view (creating a view if necessary).
-
-        Args:
-            state: the current
-                :class:`fiftyone.core.state.StateDescriptionWithDerivables`
-
-        Returns:
-            the updated
-                :class:`fiftyone.core.state.StateDescriptionWithDerivables`
-        """
-        if not state.dataset or not state.selected:
-            return state
-
-        if state.view is None:
-            state.view = state.dataset.view()
-        state.view = state.view.select(state.selected)
-        return state
-
-    @_load_state(trigger_update=True)
-    def on_exclude_selected(self, state):
-        """Adds an Exclude stage containing the selected samples to the current
-        view (creating a view if necessary).
-
-        Args:
-            state: the current
-                :class:`fiftyone.core.state.StateDescriptionWithDerivables`
-
-        Returns:
-            the updated
-                :class:`fiftyone.core.state.StateDescriptionWithDerivables`
-        """
-        if not state.dataset or not state.selected:
-            return state
-
-        if state.view is None:
-            state.view = state.dataset.view()
-        state.view = state.view.exclude(state.selected)
-        state.selected = []
-        return state
-
 
 def _get_distributions(view, group):
     pipeline = DISTRIBUTION_PIPELINES[group]


### PR DESCRIPTION
## What changes are proposed in this pull request?

A new menu that allows some basic operations to be performed from the UI
![image](https://user-images.githubusercontent.com/3719547/92491034-bd961a80-f1bf-11ea-9319-4df6f906b1f8.png)

Clearing is new (and could only be done previously by manually unselecting everything). The other two can also be done by creating stages from Python. Note that they are implemented by creating view stages for simplicity.

Closes #391
Related: #113 

## How is this patch tested? If it is not, please explain why.

Local testing

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [X] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

Added the ability to clear, select, and exclude the selected samples from the app

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
