### PR TITLE
Add ImageDetectionDirectoryTree

### DIFF
--- a/fiftyone/types/dataset_types.py
+++ b/fiftyone/types/dataset_types.py
@@ -242,6 +242,37 @@ class ImageClassificationDirectoryTree(ImageClassificationDataset):
         return foud.ImageClassificationDirectoryTreeExporter
 
 
+class ImageDetectionDirectoryTree(ImageDetectionDataset):
+    """A directory tree whose subfolders define an image detection
+    dataset.
+
+    Datasets of this type are read/written in the following format::
+
+        <dataset_dir>/
+            <classA>/
+                <image1>.<ext>
+                <image2>.<ext>
+                ...
+            <classB>/
+                <image1>.<ext>
+                <image2>.<ext>
+                ...
+            ...
+
+    Unlabeled images are stored in a subdirectory named ``_unlabeled``.
+    """
+
+    def get_dataset_importer_cls(self):
+        import fiftyone.utils.data as foud
+
+        return foud.ImageDetectionDirectoryTreeImporter
+
+    def get_dataset_exporter_cls(self):
+        import fiftyone.utils.data as foud
+
+        return foud.ImageDetectionDirectoryTreeExporter
+
+
 class TFImageClassificationDataset(ImageClassificationDataset):
     """A labeled dataset consisting of images and their associated
     classification labels stored as

--- a/fiftyone/utils/data/parsers.py
+++ b/fiftyone/utils/data/parsers.py
@@ -633,8 +633,12 @@ class ImageDetectionSampleParser(LabeledImageTupleSampleParser):
     def label_cls(self):
         return fol.Detections
 
-    def get_label(self):
+    def get_label(self, class_only=False):
         """Returns the label for the current sample.
+
+        Args:
+            class_only (False): whether the label of each sample is just a
+                classification we want to store as a detection
 
         Returns:
             a :class:`fiftyone.core.labels.Detections` instance
@@ -648,7 +652,22 @@ class ImageDetectionSampleParser(LabeledImageTupleSampleParser):
         else:
             img = None
 
-        return self._parse_label(target, img=img)
+        if class_only:
+            return self._parse_class(target)
+
+        else:
+            return self._parse_label(target, img=img)
+
+    def _parse_class(self, target):
+        if target is None:
+            return None
+
+        try:
+            label = self.classes[target]
+        except:
+            label = str(target)
+
+        return fol.Detections(detections=[fol.Detection(label=label)])
 
     def _parse_label(self, target, img=None):
         if target is None:


### PR DESCRIPTION
In response to the following slack message by user Martin Møller Jensen:

> I would like to create a COCO dataset from a DirectoryTree without bounding boxes or anything.
How can I convert an "ImageClassificationDirectoryTree" dataset into a "COCODetectionDataset"? They seem incompatible because one uses Classification type and the other uses Detection.
I tried to do it manually by replacing each Classification ground truth in each sample of the dataset with a Detection ground truth, just without a bounding box, but it all seems quite a little heavy for something so simple.


Add a new `ImageDetectionDirectoryTree` type with corresponding importer and exporter. This will load an image directory tree and create a single detection for each sample where the label corresponds to the sample classification. There are no bounding boxes for these detections. 

Slight changes needed to be made to the detection sample parser to output detections in the desired format.

The importing and exporting have been manually tested.


Another approach to solving this would be to just load the dataset with Classifications and then provide a new method that converts them to the desired detections.


Update: This is most likely not the correct approach. Looking into ways of automatically exporting detections for a detection-based exporter even when the dataset uses classifications.