### PR TITLE
Adding support for exporting classification labels in detection format

### DIFF
--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -1169,6 +1169,18 @@ def _get_default_label_field_for_exporter(sample_collection, dataset_exporter):
             if issubclass(field_type.document_type, label_cls):
                 return field
 
+        #
+        # SPECIAL CASE
+        #
+        # The export routine can convert `Classification` labels to Detections`
+        # format just-in-time, if necessary. So, allow a `Classification` field
+        # to be returned here
+        #
+        if label_cls is fol.Detections:
+            for field, field_type in label_fields.items():
+                if issubclass(field_type.document_type, fol.Classification):
+                    return field
+
         raise ValueError(
             "No compatible label field of type %s found" % label_cls
         )

--- a/fiftyone/core/odm/sample.py
+++ b/fiftyone/core/odm/sample.py
@@ -84,18 +84,23 @@ def _generate_rand(filepath=None):
     return _random.random() * 0.001 + 0.999
 
 
-def default_sample_fields(include_private=False):
+def default_sample_fields(include_private=False, include_id=False):
     """The default fields present on all :class:`SampleDocument` objects.
 
     Args:
         include_private (False): whether to include fields that start with `_`
+        include_id (False): whether to include the ``id`` field
 
     Returns:
         a tuple of field names
     """
-    return DatasetSampleDocument._get_fields_ordered(
+    fields = DatasetSampleDocument._get_fields_ordered(
         include_private=include_private
     )
+    if include_id:
+        fields = ("id",) + fields
+
+    return fields
 
 
 def no_delete_default_field(func):

--- a/fiftyone/utils/data/base.py
+++ b/fiftyone/utils/data/base.py
@@ -134,6 +134,7 @@ def convert_classification_field_to_detections(
 
     overwrite = detections_field == classification_field
     if overwrite:
+        keep_classification_field = False
         detections_field = make_unique_field_name(
             dataset, root=classification_field
         )
@@ -155,7 +156,7 @@ def convert_classification_field_to_detections(
 
             sample.save()
 
-    if overwrite or not keep_classification_field:
+    if not keep_classification_field:
         dataset.delete_sample_field(classification_field)
 
     # @todo replace with `dataset.rename_field()` when such a method exists

--- a/fiftyone/utils/data/base.py
+++ b/fiftyone/utils/data/base.py
@@ -74,6 +74,66 @@ def parse_image_classification_dir_tree(dataset_dir):
     return samples, classes
 
 
+def convert_classification_field_to_detections(
+    dataset,
+    classification_field,
+    detections_field=None,
+    keep_classification_field=False,
+):
+    """Converts the :class:`fiftyone.core.labels.Classification` field of the
+    dataset into a :class:`fiftyone.core.labels.Detections` field containing
+    the classification label.
+
+    The detections are given bounding boxes that span the entire image.
+
+    Args:
+        dataset: a :class:`fiftyone.core.dataset.Dataset`
+        classification_field: the name of the
+            :class:`fiftyone.core.labels.Classification` field to convert to
+            detections
+        detections_field (None): the name of the
+            :class:`fiftyone.core.labels.Detections` field to create. By
+            default, ``classification_field`` is overwritten
+        keep_classification_field (False): whether to keep
+            ``classification_field`` after the conversion is completed. By
+            default, the field is deleted from the dataset. If
+            ``classification_field`` is being overwritten, this flag has no
+            effect
+    """
+    if detections_field is None:
+        detections_field = classification_field
+
+    overwrite = detections_field == classification_field
+    if overwrite:
+        # @todo handle field name clash here
+        detections_field += "_tmp"
+
+    with fou.ProgressBar() as pb:
+        for sample in pb(dataset):
+            label = sample[classification_field]
+            if label is None:
+                continue
+
+            detection = fol.Detection(
+                label=label.label,
+                bounding_box=[0, 0, 1, 1],  # entire image
+                confidence=label.confidence,
+            )
+            sample[detections_field] = fol.Detections(detections=[detection])
+            if not keep_classification_field:
+                sample.clear_field(classification_field)
+
+            sample.save()
+
+    if overwrite or not keep_classification_field:
+        dataset.delete_sample_field(classification_field)
+
+    # @todo replace with `dataset.rename_field()`
+    if overwrite:
+        dataset.clone_field(detections_field, classification_field)
+        dataset.delete_sample_field(detections_field)
+
+
 def expand_image_labels_field(
     dataset,
     label_field,

--- a/fiftyone/utils/data/exporters.py
+++ b/fiftyone/utils/data/exporters.py
@@ -8,6 +8,7 @@ Dataset exporters.
 from collections import defaultdict
 import inspect
 import os
+import warnings
 
 import eta.core.datasets as etad
 import eta.core.image as etai
@@ -126,6 +127,32 @@ def write_dataset(
 
                 if labeled_images:
                     label = sample_parser.get_label()
+
+                    #
+                    # SPECIAL CASE
+                    #
+                    # Convert `Classification` labels to `Detections` format,
+                    # if necessary
+                    #
+                    if (
+                        dataset_exporter.label_cls is fol.Detections
+                        and isinstance(label, fol.Classification)
+                    ):
+                        warnings.warn(
+                            "Dataset exporter expects labels in %s format, "
+                            "but found %s. Converting labels to detections "
+                            "whose bounding boxes span the entire image"
+                            % (fol.Detections, label.__class__)
+                        )
+                        label = fol.Detections(
+                            detections=[
+                                fol.Detection(
+                                    label=label.label,
+                                    bounding_box=[0, 0, 1, 1],  # entire image
+                                    confidence=label.confidence,
+                                )
+                            ]
+                        )
 
                     dataset_exporter.export_sample(
                         image_or_path, label, metadata=metadata

--- a/fiftyone/utils/data/exporters.py
+++ b/fiftyone/utils/data/exporters.py
@@ -138,12 +138,13 @@ def write_dataset(
                         dataset_exporter.label_cls is fol.Detections
                         and isinstance(label, fol.Classification)
                     ):
-                        warnings.warn(
+                        msg = (
                             "Dataset exporter expects labels in %s format, "
                             "but found %s. Converting labels to detections "
                             "whose bounding boxes span the entire image"
                             % (fol.Detections, label.__class__)
                         )
+                        warnings.warn(msg)
                         label = fol.Detections(
                             detections=[
                                 fol.Detection(


### PR DESCRIPTION
Adds support for exporting `Classification` labels in `Detections` format.

For example, you can now export CIFAR-10 in COCO format:

```py
import fiftyone as fo
import fiftyone.zoo as foz

dataset = foz.load_zoo_dataset("cifar10", split="test")

dataset.take(10).export("/tmp/cifar10-in-coco-format", fo.types.COCODetectionDataset)
```

Output:

```
UserWarning: Dataset exporter expects labels in <class 'fiftyone.core.labels.Detections'> format, but found <class 'fiftyone.core.labels.Classification'>. Converting labels to detections whose bounding boxes span the entire image
 100% |███████████████████████| 10/10 [71.5ms elapsed, 0s remaining, 139.9 samples/s]     
```

There is also a `fiftyone.utils.data.convert_classification_field_to_detections()` method that allows for explicit conversion of a `Classification` field of a dataset to `Detections` format:

```py
import fiftyone.zoo as foz
import fiftyone.utils.data as foud

dataset = foz.load_zoo_dataset("cifar10", split="test", dataset_name="tmp")

# Convert `ground_truth` field from `Classification` format to `Detections` format
foud.convert_classification_field_to_detections(dataset, "ground_truth")
```

BEFORE

```
Name:           tmp
Num samples:    10000
Persistent:     False
Info:           {'classes': ['airplane', 'automobile', 'bird', ...]}
Tags:           ['test']
Sample fields:
    filepath:     fiftyone.core.fields.StringField
    tags:         fiftyone.core.fields.ListField(fiftyone.core.fields.StringField)
    metadata:     fiftyone.core.fields.EmbeddedDocumentField(fiftyone.core.metadata.Metadata)
    ground_truth: fiftyone.core.fields.EmbeddedDocumentField(fiftyone.core.labels.Classification)
```

AFTER

```
Name:           tmp
Num samples:    10000
Persistent:     False
Info:           {'classes': ['airplane', 'automobile', 'bird', ...]}
Tags:           ['test']
Sample fields:
    filepath:     fiftyone.core.fields.StringField
    tags:         fiftyone.core.fields.ListField(fiftyone.core.fields.StringField)
    metadata:     fiftyone.core.fields.EmbeddedDocumentField(fiftyone.core.metadata.Metadata)
    ground_truth: fiftyone.core.fields.EmbeddedDocumentField(fiftyone.core.labels.Detections)
```
