### PR TITLE
Docs header updates

### DIFF
--- a/docs/source/_static/css/custom.css
+++ b/docs/source/_static/css/custom.css
@@ -320,6 +320,14 @@ article.pytorch-article .reference.download.internal {
   }
 }
 
+.nav__item {
+  padding: 0 10px;
+}
+
+.nav__main .fa-header-icon {
+  font-size: 25px;
+}
+
 .footer-wrapper {
   background-color: var(--bg-dark-secondary);
 }

--- a/docs/source/_static/css/voxel51-website.css
+++ b/docs/source/_static/css/voxel51-website.css
@@ -119,9 +119,18 @@
   text-decoration: underline;
 }
 
+@media only screen and (min-device-width: 850px) {
+  .mobile_only {
+    display: none;
+  }
+}
+
 /* mobile responsive nav elements all here */
 @media only screen and (min-device-width: 320px) and (max-device-width: 850px) {
   /* navs do not stay at top in mobile mode */
+  .desktop_only {
+    display: none;
+  }
   .stay_at_top {
     position: relative;
   }

--- a/docs/source/_templates/layout.html
+++ b/docs/source/_templates/layout.html
@@ -34,15 +34,19 @@
         <a href="{{link_docs_fiftyone}}">Docs</a>
       </div>
       <div class="nav__item">
+        <a href="{{link_voxel51_slack}}">Community</a>
+      </div>
+      <div class="nav__item">
         <a href="{{link_ourstory}}">Company</a>
       </div>
       <div class="nav__item">
         <a href="{{link_press}}">Press</a>
       </div>
-      <div class="nav__spacer">
+      <div class="nav__item desktop_only">
+        &nbsp <a href="{{link_voxel51_github}}fiftyone"><i class="fa fa-github fa-header-icon"></i></a>
       </div>
-      <div class="nav__item nav__item--brand">
-        <a href="{{link_fiftyone}}#beta">Try FiftyOne</a>
+      <div class="nav__item mobile_only">
+        <a href="{{link_voxel51_github}}fiftyone">GitHub</a>
       </div>
     </div>
   </nav>

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -173,6 +173,7 @@ html_context = {
     "link_voxel51_facebook": "https://www.facebook.com/voxel51/",
     "link_voxel51_github": "https://github.com/voxel51/",
     "link_voxel51_linkedin": "https://www.linkedin.com/company/voxel51/",
+    "link_voxel51_slack": "https://join.slack.com/t/fiftyone-users/shared_invite/zt-gtpmm76o-9AjvzNPBOzevBySKzt02gg",
     "link_voxel51_twitter": "https://twitter.com/voxel51",
 }
 

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ class BdistWheelCustom(bdist_wheel):
         # for a development installation
         self.distribution.install_requires += [
             "fiftyone-brain>=0.1.8,<0.2",
-            "fiftyone-gui>=0.5.2,<0.6",
+            "fiftyone-gui>=0.5.4,<0.6",
             "fiftyone-db>=0.1.1,<0.2",
         ]
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

Updates for the docs header to match voxel51.com

Note that the "Try FiftyOne" button is left out here, because it links to a page which links to the installation page, which is already linked directly in the sidebar on all docs pages. Open to alternatives, though.

Once https://github.com/voxel51/fiftyone/runs/1097314125 is done, you can get a pre-built copy by downloading the docs.zip artifact.

## How is this patch tested? If it is not, please explain why.

Local build

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [x] Documentation: FiftyOne documentation changes
-   [ ] Other
