### PR TITLE
Session.wait(): add support for remote sessions and attempt to detect when it should be used

### DIFF
--- a/fiftyone/core/cli.py
+++ b/fiftyone/core/cli.py
@@ -727,11 +727,9 @@ def _watch_session(session, remote=False):
     try:
         if remote:
             print("\nTo exit, press ctrl + c\n")
-            while True:
-                time.sleep(60)
         else:
             print("\nTo exit, close the app or press ctrl + c\n")
-            session.wait()
+        session.wait()
     except KeyboardInterrupt:
         pass
 

--- a/fiftyone/core/session.py
+++ b/fiftyone/core/session.py
@@ -274,14 +274,16 @@ class Session(foc.HasClient):
         self._update_state()
 
     def wait(self):
-        """Waits for the FiftyOne App to be closed by the user.
+        """Waits for the session to be closed by the user.
 
-        This requires a local (not remote) session.
+        For local sessions, this will wait until the app is closed by the user.
+        For remote sessions, this will wait until the server shuts down, which
+        typically requires interrupting the calling process with Ctrl-C.
         """
         if self._remote:
-            raise ValueError("Cannot `wait()` for remote sessions to close")
-
-        self._app_service.wait()
+            _server_services[self._port].wait()
+        else:
+            self._app_service.wait()
 
     # PRIVATE #################################################################
 

--- a/tests/session_tests.py
+++ b/tests/session_tests.py
@@ -16,18 +16,22 @@ import fiftyone.core.session as fos
 
 def _run_helper(*args):
     # -u: unbuffered output, to ensure that the warning gets captured
-    return subprocess.check_output(
-        [
-            sys.executable,
-            "-u",
-            os.path.join(
-                os.path.dirname(os.path.abspath(__file__)),
-                "utils",
-                "session_helper.py",
-            ),
-        ]
-        + list(args)
-    ).decode()
+    return (
+        subprocess.check_output(
+            [
+                sys.executable,
+                "-u",
+                os.path.join(
+                    os.path.dirname(os.path.abspath(__file__)),
+                    "utils",
+                    "session_helper.py",
+                ),
+            ]
+            + list(args)
+        )
+        .decode()
+        .replace("\r", "")
+    )
 
 
 def test_fast_shutdown(capsys):

--- a/tests/session_tests.py
+++ b/tests/session_tests.py
@@ -1,0 +1,34 @@
+"""
+Tests related to Session behavior.
+
+| Copyright 2017-2020, Voxel51, Inc.
+| `voxel51.com <https://voxel51.com/>`_
+|
+"""
+
+import time
+
+import fiftyone as fo
+import fiftyone.core.session as fos
+
+
+def test_fast_shutdown(capsys):
+    session = fo.Session()
+    session.__del__()
+    out, _ = capsys.readouterr()
+    assert fos._WAIT_INSTRUCTIONS in out
+
+
+def test_fast_shutdown_remote(capsys):
+    session = fo.Session(remote=True)
+    session.__del__()
+    out, _ = capsys.readouterr()
+    assert fos._WAIT_INSTRUCTIONS in out
+
+
+def test_slow_shutdown(capsys, monkeypatch):
+    session = fo.Session(remote=True)
+    monkeypatch.setattr(session, "_start_time", time.perf_counter() - 3600)
+    session.__del__()
+    out, _ = capsys.readouterr()
+    assert fos._WAIT_INSTRUCTIONS not in out

--- a/tests/utils/session_helper.py
+++ b/tests/utils/session_helper.py
@@ -1,0 +1,14 @@
+import argparse
+import sys
+
+import fiftyone as fo
+
+parser = argparse.ArgumentParser()
+parser.add_argument("--remote", action="store_true")
+parser.add_argument("--slow", action="store_true")
+args = parser.parse_args()
+
+session = fo.launch_app(remote=args.remote)
+if args.slow:
+    assert isinstance(session._start_time, float)
+    session._start_time -= 3600

--- a/tests/utils/session_helper.py
+++ b/tests/utils/session_helper.py
@@ -10,5 +10,5 @@ args = parser.parse_args()
 
 session = fo.launch_app(remote=args.remote)
 if args.slow:
-    assert isinstance(session._start_time, float)
-    session._start_time -= 3600
+    assert isinstance(session._disable_wait_warning, bool)
+    session._disable_wait_warning = True


### PR DESCRIPTION
## What changes are proposed in this pull request?

* Fixes #281 by attempting to detect when a session is destroyed soon after it is created and printing a message suggesting the use of `.wait()`.
* Fixes #451 by allowing `.wait()` to work for remote sessions. See the issue for rationale. Note that this never returns under normal circumstances, so a warning about that might be helpful.

## How is this patch tested? If it is not, please explain why.

Tests + some additional local testing

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

Added support for calling `wait()` on remote sessions
(The other point from above may not be worth mentioning, since it's fairly self-explanatory to anyone who sees the message)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
