### PR TITLE
App::ViewStageParameter: Simpler parameter placeholders

### DIFF
--- a/electron/app/components/ViewBar/ViewStage/ViewStageParameter.tsx
+++ b/electron/app/components/ViewBar/ViewStage/ViewStageParameter.tsx
@@ -130,11 +130,10 @@ const convert = (value, placeholder) => {
   return value;
 };
 
-const makePlaceholder = (parameter, type, defaultValue) =>
-  [
-    defaultValue ? [parameter, defaultValue].join("=") : parameter,
-    toTypeAnnotation(type),
-  ].join(": ");
+const makePlaceholder = ({ placeholder, parameter }) => {
+  if (typeof placeholder !== undefined) return placeholder;
+  return parameter;
+};
 
 const ObjectEditor = ({
   barRef,
@@ -251,7 +250,7 @@ const ObjectEditor = ({
       >
         {state.matches("reading") ? (
           <div style={{ padding: "0.5em", whiteSpace: "nowrap" }}>
-            {convert(value, makePlaceholder(parameter, type, defaultValue))}
+            {convert(value, makePlaceholder(state.context))}
           </div>
         ) : (
           <>
@@ -312,7 +311,7 @@ const ViewStageParameter = React.memo(({ parameterRef, barRef, stageRef }) => {
     return () => parameterRef.listeners.delete(listener);
   }, []);
 
-  const { defaultValue, parameter, tail, type, value, active } = state.context;
+  const { tail, type, value, active } = state.context;
   const hasObjectType = typeof type === "string" && type.includes("dict");
 
   const props = useSpring({
@@ -357,7 +356,7 @@ const ViewStageParameter = React.memo(({ parameterRef, barRef, stageRef }) => {
       ) : (
         <ViewStageParameterDiv style={props}>
           <ViewStageParameterInput
-            placeholder={makePlaceholder(parameter, type, defaultValue)}
+            placeholder={makePlaceholder(state.context)}
             autoFocus={state.matches("editing")}
             value={
               state.matches("reading") && value.length > 24

--- a/electron/app/components/ViewBar/ViewStage/ViewStageParameter.tsx
+++ b/electron/app/components/ViewBar/ViewStage/ViewStageParameter.tsx
@@ -11,7 +11,7 @@ import styled, { ThemeContext } from "styled-components";
 import { useService } from "@xstate/react";
 import AutosizeInput from "react-input-autosize";
 
-import { PARSER, toTypeAnnotation } from "./viewStageParameterMachine";
+import { PARSER } from "./viewStageParameterMachine";
 import { useOutsideClick } from "../../../utils/hooks";
 import ErrorMessage from "./ErrorMessage";
 
@@ -131,7 +131,7 @@ const convert = (value, placeholder) => {
 };
 
 const makePlaceholder = ({ placeholder, parameter }) => {
-  if (typeof placeholder !== undefined) return placeholder;
+  if (placeholder !== undefined) return placeholder;
   return parameter;
 };
 

--- a/electron/app/components/ViewBar/ViewStage/viewStageMachine.ts
+++ b/electron/app/components/ViewBar/ViewStage/viewStageMachine.ts
@@ -14,7 +14,8 @@ export const createParameter = (
   submitted,
   focusOnInit,
   tail,
-  active
+  active,
+  placeholder
 ) => ({
   id: uuid(),
   defaultValue,
@@ -29,6 +30,7 @@ export const createParameter = (
   currentResult: null,
   results: [],
   active,
+  placeholder,
 });
 
 const isValidStage = (stageInfo, stage) => {
@@ -246,7 +248,8 @@ const viewStageMachine = Machine(
                             false,
                             i === 0,
                             i === result.length - 1,
-                            ctx.active
+                            ctx.active,
+                            parameter.placeholder
                           )
                         );
                         return parameters.map((parameter) => ({

--- a/electron/app/components/ViewBar/ViewStage/viewStageParameterMachine.ts
+++ b/electron/app/components/ViewBar/ViewStage/viewStageParameterMachine.ts
@@ -1,6 +1,6 @@
 import uuid from "uuid-v4";
 import { Machine, actions, sendParent } from "xstate";
-const { assign, cancel, send } = actions;
+const { assign } = actions;
 
 const convert = (v) => (typeof v !== "string" ? String(v) : v);
 

--- a/electron/app/components/ViewBar/viewBarMachine.ts
+++ b/electron/app/components/ViewBar/viewBarMachine.ts
@@ -16,7 +16,8 @@ export const createStage = (
   active,
   parameters,
   submitted,
-  loaded
+  loaded,
+  placeholder
 ) => ({
   id: uuid(),
   stage: stage,
@@ -110,7 +111,8 @@ function setStages(ctx, stageInfo) {
               true,
               false,
               j === stageInfoResult.params.length - 1,
-              i === Math.min(view.length - 1, ctx.activeStage)
+              i === Math.min(view.length - 1, ctx.activeStage),
+              stageInfoResult.params[j].placeholder
             );
           }),
         true,

--- a/electron/app/components/ViewBar/viewBarMachine.ts
+++ b/electron/app/components/ViewBar/viewBarMachine.ts
@@ -16,8 +16,7 @@ export const createStage = (
   active,
   parameters,
   submitted,
-  loaded,
-  placeholder
+  loaded
 ) => ({
   id: uuid(),
   stage: stage,

--- a/fiftyone/core/stages.py
+++ b/fiftyone/core/stages.py
@@ -202,7 +202,13 @@ class Exclude(ViewStage):
 
     @classmethod
     def _params(cls):
-        return [{"name": "sample_ids", "type": "list<id>|id"}]
+        return [
+            {
+                "name": "sample_ids",
+                "type": "list<id>|id",
+                "placeholder": "list,of,sample,ids",
+            }
+        ]
 
     def _validate_params(self):
         # Ensures that ObjectIDs are valid
@@ -267,7 +273,13 @@ class ExcludeFields(ViewStage):
 
     @classmethod
     def _params(self):
-        return [{"name": "field_names", "type": "list<str>"}]
+        return [
+            {
+                "name": "field_names",
+                "type": "list<str>",
+                "placeholder": "list,of,fields",
+            }
+        ]
 
     def _validate_params(self):
         default_fields = set(default_sample_fields())
@@ -361,7 +373,12 @@ class Exists(ViewStage):
     def _params(cls):
         return [
             {"name": "field", "type": "str"},
-            {"name": "bool", "type": "bool", "default": "True"},
+            {
+                "name": "bool",
+                "type": "bool",
+                "default": "True",
+                "placeholder": "bool (default=True)",
+            },
         ]
 
 
@@ -450,7 +467,7 @@ class FilterField(ViewStage):
     def _params(self):
         return [
             {"name": "field", "type": "str"},
-            {"name": "filter", "type": "dict"},
+            {"name": "filter", "type": "dict", "placeholder": ""},
         ]
 
     def _validate_params(self):
@@ -663,7 +680,7 @@ class Limit(ViewStage):
 
     @classmethod
     def _params(cls):
-        return [{"name": "limit", "type": "int"}]
+        return [{"name": "limit", "type": "int", "placeholder": "int"}]
 
 
 class Match(ViewStage):
@@ -754,7 +771,7 @@ class Match(ViewStage):
 
     @classmethod
     def _params(cls):
-        return [{"name": "filter", "type": "dict"}]
+        return [{"name": "filter", "type": "dict", "placeholder": ""}]
 
 
 class MatchTag(ViewStage):
@@ -847,7 +864,13 @@ class MatchTags(ViewStage):
 
     @classmethod
     def _params(cls):
-        return [{"name": "tags", "type": "list<str>"}]
+        return [
+            {
+                "name": "tags",
+                "type": "list<str>",
+                "placeholder": "list,of,tags",
+            }
+        ]
 
 
 class Mongo(ViewStage):
@@ -913,7 +936,7 @@ class Mongo(ViewStage):
 
     @classmethod
     def _params(self):
-        return [{"name": "pipeline", "type": "dict"}]
+        return [{"name": "pipeline", "type": "dict", "placeholder": ""}]
 
 
 class Select(ViewStage):
@@ -979,7 +1002,13 @@ class Select(ViewStage):
 
     @classmethod
     def _params(cls):
-        return [{"name": "sample_ids", "type": "list<id>|id"}]
+        return [
+            {
+                "name": "sample_ids",
+                "type": "list<id>|id",
+                "placeholder": "list,of,sample,ids",
+            }
+        ]
 
     def _validate_params(self):
         # Ensures that ObjectIDs are valid
@@ -1054,6 +1083,7 @@ class SelectFields(ViewStage):
                 "name": "field_names",
                 "type": "list<str>|NoneType",
                 "default": "None",
+                "placeholder": "list,of,fields",
             }
         ]
 
@@ -1124,7 +1154,14 @@ class Shuffle(ViewStage):
 
     @classmethod
     def _params(self):
-        return [{"name": "seed", "type": "float|NoneType", "default": "None"}]
+        return [
+            {
+                "name": "seed",
+                "type": "float|NoneType",
+                "default": "None",
+                "placeholder": "seed (default=None",
+            }
+        ]
 
 
 class Skip(ViewStage):
@@ -1173,7 +1210,7 @@ class Skip(ViewStage):
 
     @classmethod
     def _params(cls):
-        return [{"name": "skip", "type": "int"}]
+        return [{"name": "skip", "type": "int", "placeholder": "int"}]
 
 
 class SortBy(ViewStage):
@@ -1270,7 +1307,12 @@ class SortBy(ViewStage):
     def _params(cls):
         return [
             {"name": "field_or_expr", "type": "dict|str"},
-            {"name": "reverse", "type": "bool", "default": "False"},
+            {
+                "name": "reverse",
+                "type": "bool",
+                "default": "False",
+                "placeholder": "reverse (default=False)",
+            },
         ]
 
     def validate(self, sample_collection):
@@ -1350,8 +1392,13 @@ class Take(ViewStage):
     @classmethod
     def _params(cls):
         return [
-            {"name": "size", "type": "int"},
-            {"name": "seed", "type": "float|NoneType", "default": "None"},
+            {"name": "size", "type": "int", "placeholder": "int"},
+            {
+                "name": "seed",
+                "type": "float|NoneType",
+                "default": "None",
+                "placeholder": "reverse (default=False)",
+            },
         ]
 
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

Switches view stage parameter placeholders to user-friendly hints. Type annotations are retained in error messages.

Follows:
```
Exclude: list,of,sample,ids
ExcludeFields: list,of,fields
Exists: field
FilterClassifications: field and (blank)
FilterDetections: field and (blank)
Limit: int
Match:  (blank)
MatchTag: tag
MatchTags: list,of,tags
Mongo: (blank)
Shuffle: seed (default=None)
Select: list,of,sample,ids
SelectFields: list,of,fields
SortBy: field and reverse (default=False)
Skip: int
Take: int and seed (default=None)
```

## How is this patch tested? If it is not, please explain why.

Locally.

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

Friendly parameter placeholders that describe valid view stage parameter inputs.

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
