### PR TITLE
Speed up image selection

### DIFF
--- a/electron/app/components/Player51.tsx
+++ b/electron/app/components/Player51.tsx
@@ -3,7 +3,6 @@ import uuid from "react-uuid";
 import { useRecoilValue, useSetRecoilState } from "recoil";
 
 import Player51 from "../player51/build/cjs/player51.min.js";
-import clickHandler from "../utils/click.ts";
 import {
   RESERVED_FIELDS,
   VALID_SCALAR_TYPES,
@@ -99,7 +98,6 @@ export default ({
   const filter = useRecoilValue(filterSelector);
   const colorMap = useRecoilValue(atoms.colorMap);
   const [overlay, playerColorMap] = loadOverlay(sample, colorMap, fieldSchema);
-  const [handleClick, handleDoubleClick] = clickHandler(onClick, onDoubleClick);
   const [initLoad, setInitLoad] = useState(false);
   const id = uuid();
   const [player] = useState(
@@ -127,9 +125,7 @@ export default ({
   if (playerRef) {
     playerRef.current = player;
   }
-  const props = thumbnail
-    ? { onClick: handleClick, onDoubleClick: handleDoubleClick }
-    : {};
+  const props = thumbnail ? { onClick, onDoubleClick } : {};
   useEffect(() => {
     if (!initLoad) {
       if (thumbnail) {

--- a/electron/app/components/Sample.tsx
+++ b/electron/app/components/Sample.tsx
@@ -9,6 +9,7 @@ import Tag from "./Tags/Tag";
 import * as atoms from "../recoil/atoms";
 import * as selectors from "../recoil/selectors";
 import { getLabelText, stringify } from "../utils/labels";
+import { useFastRerender } from "../utils/hooks";
 
 const Sample = ({ displayProps, dispatch, sample, port, setView }) => {
   const host = `http://127.0.0.1:${port}`;
@@ -21,6 +22,7 @@ const Sample = ({ displayProps, dispatch, sample, port, setView }) => {
   const [selectedSamples, setSelectedSamples] = useRecoilState(
     atoms.selectedSamples
   );
+  const rerender = useFastRerender();
 
   const handleClick = () => {
     const newSelected = new Set(selectedSamples);
@@ -33,6 +35,7 @@ const Sample = ({ displayProps, dispatch, sample, port, setView }) => {
       event = "add_selection";
     }
     setSelectedSamples(newSelected);
+    rerender();
     socket.emit(event, id, (data) => {
       dispatch(updateState(data));
     });

--- a/electron/app/utils/hooks.ts
+++ b/electron/app/utils/hooks.ts
@@ -1,4 +1,4 @@
-import { useEffect, useLayoutEffect } from "react";
+import { useState, useEffect, useLayoutEffect } from "react";
 
 export const useResizeHandler = (handler, deps = []) => {
   useEffect(() => {
@@ -69,4 +69,12 @@ export const useFollow = (leaderRef, followerRef, set, deps = []) => {
         window.removeEventListener("scroll", follow);
       })();
   }, [leaderRef.current, followerRef.current, ...deps]);
+};
+
+// allows re-rendering before recoil's Batcher updates
+export const useFastRerender = () => {
+  const [counter, setCounter] = useState(0);
+  return () => {
+    setCounter((prev) => prev + 1);
+  };
 };


### PR DESCRIPTION
## What changes are proposed in this pull request?

Some responsiveness improvements when selecting images.
Note that removing the custom click/double-click logic causes images to sometimes briefly display as selected/unselected when opening the modal by double-clicking on them. Their actual state doesn't change, as the click event fires twice in this case. This is a tradeoff that needs to be made to improve single-clicking speed, and is worth prioritizing since double-clicking will eventually be replaced.

## How is this patch tested? If it is not, please explain why.

Locally

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

Made selecting samples in the app faster

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
