### PR TITLE
Style scrollbars

### DIFF
--- a/electron/app/components/DisplayOptionsSidebar.tsx
+++ b/electron/app/components/DisplayOptionsSidebar.tsx
@@ -14,7 +14,7 @@ import CellHeader from "./CellHeader";
 import CheckboxGrid from "./CheckboxGrid";
 import DropdownCell from "./DropdownCell";
 import SelectionTag from "./Tags/SelectionTag";
-import { Button } from "./utils";
+import { Button, scrollbarStyles } from "./utils";
 import * as atoms from "../recoil/atoms";
 import { refreshColorMap as refreshColorMapSelector } from "../recoil/selectors";
 
@@ -36,16 +36,8 @@ type Props = {
 const Container = styled.div`
   margin-bottom: 2px;
   height: 100%;
-  &::-webkit-scrollbar {
-    width: 0px;
-    background: transparent;
-    display: none;
-  }
-  &::-webkit-scrollbar-thumb {
-    width: 0px;
-    display: none;
-  }
   padding-bottom: 1em;
+  ${scrollbarStyles};
 
   .MuiCheckbox-root {
     padding: 4px 8px 4px 4px;

--- a/electron/app/components/JSONView.tsx
+++ b/electron/app/components/JSONView.tsx
@@ -4,7 +4,7 @@ import copy from "copy-to-clipboard";
 import { Checkbox, FormControlLabel } from "@material-ui/core";
 import { useRecoilValue } from "recoil";
 
-import { Button, ModalFooter } from "./utils";
+import { Button, ModalFooter, scrollbarStyles } from "./utils";
 import * as selectors from "../recoil/selectors";
 
 type Props = {
@@ -24,15 +24,7 @@ const Body = styled.div`
     padding: 2em;
     flex-grow: 1;
     overflow-y: auto;
-  }
-  pre::-webkit-scrollbar {
-    width: 0px;
-    background: transparent;
-    display: none;
-  }
-  pre::-webkit-scrollbar-thumb {
-    width: 0px;
-    display: none;
+    ${scrollbarStyles};
   }
 
   ${ModalFooter} {

--- a/electron/app/components/utils.tsx
+++ b/electron/app/components/utils.tsx
@@ -66,3 +66,18 @@ export const ModalFooter = styled.footer`
   padding: 1em;
   background-color: ${({ theme }) => theme.backgroundLight};
 `;
+
+export const scrollbarStyles = ({ theme }) => `
+  &::-webkit-scrollbar {
+    width: 10px;
+    background: transparent;
+  }
+  &::-webkit-scrollbar-thumb {
+    border-radius: 5px;
+    background-color: transparent;
+    transition: background-color linear 0.5s;
+  }
+  &:hover::-webkit-scrollbar-thumb {
+    background-color: ${theme.fontDarkest};
+  }
+`;

--- a/electron/app/components/utils.tsx
+++ b/electron/app/components/utils.tsx
@@ -73,6 +73,7 @@ export const scrollbarStyles = ({ theme }) => `
     background: transparent;
   }
   &::-webkit-scrollbar-thumb {
+    width: 10px;
     border-radius: 5px;
     background-color: transparent;
     transition: background-color linear 0.5s;

--- a/electron/app/shared/global.ts
+++ b/electron/app/shared/global.ts
@@ -1,5 +1,6 @@
 import { createGlobalStyle, css } from "styled-components";
 import { color, typography } from "./styles";
+import { scrollbarStyles } from "../components/utils";
 
 export const styles = css`
   body,
@@ -16,6 +17,13 @@ export const styles = css`
     margin: 0 !important;
     padding: 0 !important;
     background-color: ${({ theme }) => theme.background};
+  }
+
+  body {
+    ${scrollbarStyles};
+    ::-webkit-scrollbar {
+      background-color: ${({ theme }) => theme.background};
+    }
   }
 
   input {


### PR DESCRIPTION
## What changes are proposed in this pull request?

Some scrollbar styling:
![image](https://user-images.githubusercontent.com/3719547/93240876-ac668400-f752-11ea-9c07-d30f6cc7e4f4.png)

They're only shown on hover. Making them fade in gradually is apparently very hard. I also wasn't able to make the background when the scrollbar is hidden match both the header background and grid background, so I opted for the latter.

## How is this patch tested? If it is not, please explain why.

Locally

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [X] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
