### PR TITLE
Server: Skip bounds calculations when no fields are present

### DIFF
--- a/fiftyone/core/state.py
+++ b/fiftyone/core/state.py
@@ -275,6 +275,9 @@ def _get_label_fields(view):
 
 
 def _get_bounds(fields, view, facets):
+    if len(facets) == 0:
+        return {}
+
     pipeline = [{"$facet": facets}]
 
     try:

--- a/tests/isolated/server_tests.py
+++ b/tests/isolated/server_tests.py
@@ -200,6 +200,13 @@ class ServerServiceTests(unittest.TestCase):
         self.assertEqual(len(_subscribed_sessions[port]), 0)
         self.assertEqual(len(_server_services), 1)
 
+    def step_empty_derivables(self):
+        self.session.dataset = fo.Dataset()
+        response = self.wait_for_response()
+        self.assertEqual(
+            _serialize(self.session.state), _serialize(self.client.data)
+        )
+
     def test_steps(self):
         for name, step in self.steps():
             try:


### PR DESCRIPTION
## What changes are proposed in this pull request?

Skips bounds calculations when there are no fields that need bounds to calculated. Previously, an empty dataset would fail to load in the App because the server would fail to calculate these bounds and the state would never get sent to the app.

MongoDB expects at least one entry (pipeline) in a `$facet` stage.

## How is this patch tested? If it is not, please explain why.

`step_empty_derivables()` in `isolated/server_tests.py`.

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

Datasets without numeric scalars or labels will now successfully load in the App.

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
