### PR TITLE
Fix some errors related to empty datasets/views

### DIFF
--- a/electron/app/recoil/selectors.ts
+++ b/electron/app/recoil/selectors.ts
@@ -297,17 +297,10 @@ export const fieldIsFiltered = selectorFamily({
   },
 });
 
-export const viewStats = selector({
-  key: "viewStats",
-  get: ({ get }) => {
-    return get(atoms.stateDescription).view_stats || {};
-  },
-});
-
 export const labelConfidenceBounds = selectorFamily({
   key: "labelConfidenceBounds",
   get: (label) => ({ get }) => {
-    const labels = get(viewStats).labels;
+    const labels = get(datasetStats).labels;
     return labels && labels[label]
       ? labels[label].confidence_bounds
       : [null, null];
@@ -317,7 +310,7 @@ export const labelConfidenceBounds = selectorFamily({
 export const numericFieldBounds = selectorFamily({
   key: "numericFieldBounds",
   get: (label) => ({ get }) => {
-    const bounds = get(viewStats).numeric_field_bounds;
+    const bounds = get(datasetStats).numeric_field_bounds;
     return bounds && bounds[label] ? bounds[label] : [null, null];
   },
 });

--- a/electron/app/recoil/selectors.ts
+++ b/electron/app/recoil/selectors.ts
@@ -56,7 +56,8 @@ export const totalCount = selector({
 export const filterStage = selectorFamily({
   key: "filterStage",
   get: (fieldName: string) => ({ get }) => {
-    return get(atoms.stateDescription).filter_stages[fieldName];
+    const state = get(atoms.stateDescription);
+    return state.filter_stages ? state.filter_stages[fieldName] : null;
   },
 });
 
@@ -70,8 +71,7 @@ export const filteredCount = selector({
 export const tagNames = selector({
   key: "tagNames",
   get: ({ get }) => {
-    const stateDescription = get(atoms.stateDescription);
-    return stateDescription.tags || [];
+    return get(atoms.stateDescription).tags || [];
   },
 });
 
@@ -128,7 +128,8 @@ export const labelTypes = selector({
 export const labelClasses = selectorFamily({
   key: "labelClasses",
   get: (label) => ({ get }) => {
-    return get(atoms.stateDescription).view_stats.labels[label].classes || [];
+    const stats = get(datasetStats);
+    return stats.labels ? stats.labels[label].classes : [];
   },
 });
 

--- a/electron/app/recoil/selectors.ts
+++ b/electron/app/recoil/selectors.ts
@@ -8,20 +8,6 @@ import {
   makeLabelNameGroups,
 } from "../utils/labels";
 
-export const viewStages = selector({
-  key: "viewStages",
-  get: ({ get }) => {
-    return get(atoms.stateDescription).viewStages;
-  },
-});
-
-export const numViewStages = selector({
-  key: "numStages",
-  get: ({ get }) => {
-    return get(viewStages).length;
-  },
-});
-
 export const datasetName = selector({
   key: "datasetName",
   get: ({ get }) => {

--- a/electron/app/recoil/selectors.ts
+++ b/electron/app/recoil/selectors.ts
@@ -130,7 +130,7 @@ export const labelTypes = selector({
 export const labelClasses = selectorFamily({
   key: "labelClasses",
   get: (label) => ({ get }) => {
-    return get(atoms.stateDescription).view_stats.labels[label].classes;
+    return get(atoms.stateDescription).view_stats.labels[label].classes || [];
   },
 });
 

--- a/electron/app/recoil/selectors.ts
+++ b/electron/app/recoil/selectors.ts
@@ -34,7 +34,7 @@ export const datasetStats = selector({
   key: "datasetStats",
   get: ({ get }) => {
     const stateDescription = get(atoms.stateDescription);
-    return stateDescription.view_stats ? stateDescription.view_stats : {};
+    return stateDescription.view_stats || {};
   },
 });
 
@@ -42,9 +42,7 @@ export const extendedDatasetStats = selector({
   key: "extendedDatasetStats",
   get: ({ get }) => {
     const stateDescription = get(atoms.stateDescription);
-    return stateDescription.extended_view_stats
-      ? stateDescription.extended_view_stats
-      : {};
+    return stateDescription.extended_view_stats || {};
   },
 });
 
@@ -80,14 +78,14 @@ export const tagNames = selector({
 export const tagSampleCounts = selector({
   key: "tagSampleCounts",
   get: ({ get }) => {
-    return get(atoms.stateDescription).view_stats.tags || {};
+    return get(datasetStats).tags || {};
   },
 });
 
 export const filteredTagSampleCounts = selector({
   key: "filteredTagSampleCounts",
   get: ({ get }) => {
-    return get(atoms.stateDescription).extended_view_stats.tags || {};
+    return get(extendedDatasetStats).tags || {};
   },
 });
 
@@ -310,7 +308,9 @@ export const labelConfidenceBounds = selectorFamily({
   key: "labelConfidenceBounds",
   get: (label) => ({ get }) => {
     const labels = get(viewStats).labels;
-    return labels[label] ? labels[label].confidence_bounds : [null, null];
+    return labels && labels[label]
+      ? labels[label].confidence_bounds
+      : [null, null];
   },
 });
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

* Fixed an error when a view was empty
* Some selectors could throw errors when switching between empty and non-empty views. This tended to happen in development when the server and app live-reloaded at the same time, and not always predictably. These changes should cut down on the number of "oops" screens seen during development, even if they wouldn't come up in normal use.

## How is this patch tested? If it is not, please explain why.

Locally - verified directly that some changed selectors are still getting called and working

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(first point above)

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
