### PR TITLE
Update COCO importer to use label.json filenames

### DIFF
--- a/fiftyone/utils/coco.py
+++ b/fiftyone/utils/coco.py
@@ -187,7 +187,7 @@ class COCODetectionDatasetImporter(foud.LabeledImageDatasetImporter):
         self._supercategory_map = supercategory_map
         self._images_map = {i["file_name"]: i for i in images.values()}
         self._annotations = annotations
-        self._filenames = etau.list_files(self._data_dir, abs_paths=False)
+        self._filenames = self._images_map.keys()
 
     def get_dataset_info(self):
         return self._info


### PR DESCRIPTION
## What changes are proposed in this pull request?

The COCO Importer currently looks at all the files in the `data/` directory to determine the dataset's filenames.  However, this is unnecessary as the filenames are already specified in the `labels.json`'s images (which are saved as the keys to `_images_map`).  Furthermore (as in my case), any extra files in `data/` will mess with the import.  I believe any files not listed in `labels.json` should be ignored by the importer.

## How is this patch tested? If it is not, please explain why.

Assuming `labels.json` specifies all the correct filenames, this should not break anything.  It allows for `data/` directories with extra files, as well as `data/` directories of different structures, such as ones with sub-directories.

I have tested this patch locally with a few of my own datasets, but not sure if there's a test case that covers this... Let me know if I need to do anything more on this front.

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
