### PR TITLE
Adding support for merging dataset contents

### DIFF
--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -590,8 +590,6 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
                     ):
                         continue
 
-                    # @todo merge list-like fields such as `tags`?
-
                     existing_sample[name] = value
 
                 existing_sample.save()

--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -689,6 +689,21 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
 
         return num_cloned, num_skipped
 
+    def rename_field(self, field_name, new_field_name):
+        """Renames the sample field to the given new name.
+
+        Args:
+            field_name: the field name
+            new_field_name: the new field name
+        """
+        # @todo optimize this
+        with fou.ProgressBar() as pb:
+            for sample in pb(self.select_fields(field_name)):
+                sample[new_field_name] = sample[field_name]
+                sample.save()
+
+        self.delete_sample_field(field_name)
+
     def save(self):
         """Saves dataset-level information such as its ``info`` to the
         database.

--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -696,6 +696,12 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
             field_name: the field name
             new_field_name: the new field name
         """
+        default_fields = foos.default_sample_fields(
+            include_private=True, include_id=True
+        )
+        if field_name in default_fields:
+            raise ValueError("Cannot rename default field '%s'" % field_name)
+
         # @todo optimize this
         with fou.ProgressBar() as pb:
             for sample in pb(self.select_fields(field_name)):

--- a/fiftyone/core/sample.py
+++ b/fiftyone/core/sample.py
@@ -166,8 +166,11 @@ class _Sample(object):
         self._doc.clear_field(field_name=field_name)
 
     def iter_fields(self):
-        """Returns an iterator over the field (name, value) pairs of the
-        sample.
+        """Returns an iterator over the ``(name, value)`` pairs of the fields
+        of the sample.
+
+        Returns:
+            an iterator that emits ``(name, value)`` tuples
         """
         for field_name in self.field_names:
             yield field_name, self.get_field(field_name)

--- a/tests/unittests.py
+++ b/tests/unittests.py
@@ -798,6 +798,25 @@ class DatasetTests(unittest.TestCase):
         common21 = common21_view.first()
         self.assertEqual(common21.field, common2.field)
 
+    @drop_datasets
+    def test_rename_field(self):
+        dataset = fo.Dataset()
+
+        value = 1
+        sample = fo.Sample(filepath="/path/to/image.jpg", field=value)
+
+        dataset.add_sample(sample)
+
+        dataset.rename_field("field", "new_field")
+
+        self.assertFalse("field" in dataset.get_field_schema())
+        self.assertTrue("new_field" in dataset.get_field_schema())
+
+        with self.assertRaises(KeyError):
+            sample["field"]
+
+        self.assertEqual(sample["new_field"], value)
+
 
 class SampleTests(unittest.TestCase):
     @drop_datasets

--- a/tests/unittests.py
+++ b/tests/unittests.py
@@ -752,6 +752,52 @@ class DatasetTests(unittest.TestCase):
         dataset1c = fo.load_dataset(dataset_name)
         self.assertIs(dataset1c, dataset1)
 
+    @drop_datasets
+    def test_merge_samples(self):
+        dataset1 = fo.Dataset()
+        dataset2 = fo.Dataset()
+
+        common_filepath = "/path/to/image.png"
+        filepath1 = "/path/to/image1.png"
+        filepath2 = "/path/to/image2.png"
+
+        common1 = fo.Sample(filepath=common_filepath, field=1)
+        common2 = fo.Sample(filepath=common_filepath, field=2)
+
+        dataset1.add_sample(fo.Sample(filepath=filepath1, field=1))
+        dataset1.add_sample(common1)
+
+        dataset2.add_sample(fo.Sample(filepath=filepath2, field=2))
+        dataset2.add_sample(common2)
+
+        #
+        # Non-overwriting
+        #
+
+        dataset12 = dataset1.clone()
+        dataset12.merge_samples(dataset2, overwrite=False)
+        self.assertEqual(len(dataset12), 3)
+
+        common12_view = dataset12.match(F("filepath") == common_filepath)
+        self.assertEqual(len(common12_view), 1)
+
+        common12 = common12_view.first()
+        self.assertEqual(common12.field, common1.field)
+
+        #
+        # Overwriting
+        #
+
+        dataset21 = dataset1.clone()
+        dataset21.merge_samples(dataset2, overwrite=True)
+        self.assertEqual(len(dataset21), 3)
+
+        common21_view = dataset21.match(F("filepath") == common_filepath)
+        self.assertEqual(len(common21_view), 1)
+
+        common21 = common21_view.first()
+        self.assertEqual(common21.field, common2.field)
+
 
 class SampleTests(unittest.TestCase):
     @drop_datasets


### PR DESCRIPTION
Adds support for merging datasets by joining on `filepath`.

This allows, for example, to merge two copies of a dataset that contain predictions from two different versions of a model in appropriately named (i.e., different) label fields into a single dataset with two label fields.

```py
import fiftyone as fo
import fiftyone.zoo as foz
from fiftyone import ViewField as F

_zoo_dataset = foz.load_zoo_dataset("cifar10", split="test")

# A dataset of 10 random samples with labels in the `ground_truth` field
dataset = fo.Dataset()
dataset.add_samples(_zoo_dataset.take(10))

# A dataset that contains 5 samples from `dataset` and 5 new samples with
# labels in the `predictions` field
_dataset = fo.Dataset()
_dataset.add_samples(dataset.take(5))
_dataset.add_samples(
    _zoo_dataset
    .match(
        ~F("filepath").is_in([s.filepath for s in dataset.select_fields()])
    ).take(5)
)
_dataset.rename_field("ground_truth", "predictions")
_dataset.compute_metadata()

# Merge the datasets
dataset.merge_samples(_dataset)

# Verify that the merging happened as expected
print(dataset)
for sample in dataset:
    print(sample)
```
