### PR TITLE
GitHub actions: add another job that requires all tests to pass

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -131,10 +131,11 @@ jobs:
           find tests/isolated/ -name '*.py' -print0 | xargs -0 --verbose -n1 python tests/utils/pytest_wrapper.py --verbose
 
   all-tests:
-    runs-on: ubuntu-latest
     needs: test
+    if: always()
+    runs-on: ubuntu-latest
     steps:
-      - run: "true"
+      - run: sh -c ${{ needs.test.result == 'success' }}
 
   publish:
     needs: [build, check, test]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -130,6 +130,12 @@ jobs:
         run: |
           find tests/isolated/ -name '*.py' -print0 | xargs -0 --verbose -n1 python tests/utils/pytest_wrapper.py --verbose
 
+  all-tests:
+    runs-on: ubuntu-latest
+    needs: test
+    steps:
+      - run: "true"
+
   publish:
     needs: [build, check, test]
     if: startsWith(github.ref, 'refs/tags/v')


### PR DESCRIPTION
Intended to be used as a job that is required for PRs to be merged.

Currently, PRs cannot be merged because both "test" and "test (ubuntu-18.04, 3.8)" (as well as others in the test matrix) are required. These criteria are impossible to meet because "test" is only present when tests are skipped (e.g. on draft PRs), and the others are only present when tests are run. Requiring the "publish" job apparently does not work either because it is skipped even when tests fail.