### PR TITLE
Serializes numpy arrays as lists for server

### DIFF
--- a/fiftyone/server/json_util.py
+++ b/fiftyone/server/json_util.py
@@ -10,6 +10,16 @@ from flask.json import JSONEncoder
 
 from fiftyone.core.sample import Sample, SampleView
 from fiftyone.core.stages import ViewStage
+import fiftyone.core.utils as fou
+
+
+def _handle_bytes(o):
+    for k, v in o.items():
+        if isinstance(v, bytes):
+            o[k] = fou.deserialize_numpy_array(v).tolist()
+        if isinstance(v, dict):
+            o[k] = _handle_bytes(v)
+    return o
 
 
 class FiftyOneJSONEncoder(JSONEncoder):
@@ -29,7 +39,7 @@ class FiftyOneJSONEncoder(JSONEncoder):
             str
         """
         if isinstance(o, (Sample, SampleView)):
-            return o.to_mongo_dict()
+            return _handle_bytes(o.to_mongo_dict())
         if issubclass(type(o), ViewStage):
             return o._serialize()
         if isinstance(o, ObjectId):

--- a/fiftyone/server/json_util.py
+++ b/fiftyone/server/json_util.py
@@ -16,7 +16,7 @@ import fiftyone.core.utils as fou
 def _handle_bytes(o):
     for k, v in o.items():
         if isinstance(v, bytes):
-            o[k] = fou.deserialize_numpy_array(v).tolist()
+            o[k] = str(fou.deserialize_numpy_array(v).shape)
         if isinstance(v, dict):
             o[k] = _handle_bytes(v)
     return o

--- a/tests/isolated/server_tests.py
+++ b/tests/isolated/server_tests.py
@@ -215,7 +215,7 @@ class ServerServiceTests(unittest.TestCase):
         self.assertEqual(enc.dumps(float("nan")), '"NaN"')
         self.assertEqual(enc.dumps(float("inf")), '"Infinity"')
         sample = fo.Sample(filepath="/path.jpg", field=np.array([[1]]))
-        self.assertEqual(enc.loads(enc.dumps(sample))["field"], [[1]])
+        self.assertEqual(enc.loads(enc.dumps(sample))["field"], "(1, 1)")
 
     def test_steps(self):
         for name, step in self.steps():

--- a/tests/isolated/server_tests.py
+++ b/tests/isolated/server_tests.py
@@ -18,6 +18,7 @@ import unittest
 import urllib
 
 from bson import ObjectId
+import numpy as np
 import socketio
 
 import eta.core.utils as etau
@@ -31,6 +32,7 @@ from fiftyone.core.session import (
     _subscribed_sessions,
 )
 from fiftyone.core.state import StateDescriptionWithDerivables
+import fiftyone.core.utils as fou
 from fiftyone.server.json_util import FiftyOneJSONEncoder
 
 
@@ -212,6 +214,8 @@ class ServerServiceTests(unittest.TestCase):
         self.assertEqual(enc.dumps(ObjectId(oid)), '{"$oid": "%s"}' % oid)
         self.assertEqual(enc.dumps(float("nan")), '"NaN"')
         self.assertEqual(enc.dumps(float("inf")), '"Infinity"')
+        sample = fo.Sample(filepath="/path.jpg", field=np.array([[1]]))
+        self.assertEqual(enc.loads(enc.dumps(sample))["field"], [[1]])
 
     def test_steps(self):
         for name, step in self.steps():


### PR DESCRIPTION
## What changes are proposed in this pull request?

Resolves #556. This is not the cleanest solution, but currently we rely on MongoEngine for field serialization, and changing that would be quite the lift.

## How is this patch tested? If it is not, please explain why.

A check has been added to the encoder step in the server tests.

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

NumPy arrays are now serialized and sent to the App. Previously, an error was raised by the server when a dataset contained `VectorField`s or `ArrayField`s. 

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
