### PR TITLE
Serialize numpy arrays

### DIFF
--- a/fiftyone/server/json_util.py
+++ b/fiftyone/server/json_util.py
@@ -16,7 +16,7 @@ import fiftyone.core.utils as fou
 def _handle_bytes(o):
     for k, v in o.items():
         if isinstance(v, bytes):
-            o[k] = fou.deserialize_numpy_array(v)
+            o[k] = fou.deserialize_numpy_array(v).tolist()
         if isinstance(v, dict):
             o[k] = _handle_bytes(v)
     return o

--- a/fiftyone/server/json_util.py
+++ b/fiftyone/server/json_util.py
@@ -16,7 +16,7 @@ import fiftyone.core.utils as fou
 def _handle_bytes(o):
     for k, v in o.items():
         if isinstance(v, bytes):
-            o[k] = str(fou.deserialize_numpy_array(v).shape)
+            o[k] = fou.deserialize_numpy_array(v)
         if isinstance(v, dict):
             o[k] = _handle_bytes(v)
     return o


### PR DESCRIPTION
@brimoor This is only part of a fix. It looks like the quickstart is broken on develop. Specifically, detection bounding boxes are not handled now due to the numpy serializtion changes.

Because detections use a vector field for bounding boxes, I am changing server serialization to always return the full array.