### PR TITLE
Fixes bounding box bug

### DIFF
--- a/WALKTHROUGH.md
+++ b/WALKTHROUGH.md
@@ -248,7 +248,7 @@ Sample fields:
             <Detection: {
                 'id': '5f42f54b9fff295adf837b72',
                 'label': 'potted plant',
-                'bounding_box': array([0.37028125, 0.33453052, 0.03859375, 0.16314554]),
+                'bounding_box': BaseList([0.37028125, 0.33453052, 0.03859375, 0.16314554]),
                 'confidence': None,
                 'attributes': BaseDict({
                     'area': <NumericAttribute: {'value': 531.8071000000001}>,
@@ -402,7 +402,7 @@ print(predictions_view.first())
             <Detection: {
                 'id': '5f42f5539fff295adf83bcbe',
                 'label': 'horse',
-                'bounding_box': array([0.460625  , 0.79220833, 0.03951562, 0.04891667]),
+                'bounding_box': BaseList([0.460625  , 0.79220833, 0.03951562, 0.04891667]),
                 'confidence': None,
                 'attributes': BaseDict({
                     'area': <NumericAttribute: {'value': 207.45490000000035}>,
@@ -417,7 +417,7 @@ print(predictions_view.first())
             <Detection: {
                 'id': '5f42f73a9fff295adf84aece',
                 'label': 'horse',
-                'bounding_box': array([0.46101789, 0.79770222, 0.03865576, 0.04035403]),
+                'bounding_box': BaseList([0.46101789, 0.79770222, 0.03865576, 0.04035403]),
                 'confidence': 0.9759229421615601,
                 'attributes': BaseDict({}),
             }>,

--- a/docs/source/tutorials/evaluate_detections.ipynb
+++ b/docs/source/tutorials/evaluate_detections.ipynb
@@ -158,7 +158,7 @@
       "<Detection: {\n",
       "    'id': '5f46a8e098ce209ec9da498f',\n",
       "    'label': 'potted plant',\n",
-      "    'bounding_box': array([0.37028125, 0.33453052, 0.03859375, 0.16314554]),\n",
+      "    'bounding_box': BaseList([0.37028125, 0.33453052, 0.03859375, 0.16314554]),\n",
       "    'confidence': None,\n",
       "    'attributes': BaseDict({\n",
       "        'area': <NumericAttribute: {'value': 531.8071000000001}>,\n",
@@ -339,7 +339,7 @@
       "<Detection: {\n",
       "    'id': '5f46a90698ce209ec9db7c8b',\n",
       "    'label': 'dog',\n",
-      "    'bounding_box': array([0.38723122, 0.5448051 , 0.56090901, 0.40119233]),\n",
+      "    'bounding_box': BaseList([0.38723122, 0.54480510, 0.56090901, 0.40119233]),\n",
       "    'confidence': 0.9992108345031738,\n",
       "    'attributes': BaseDict({}),\n",
       "}>\n"

--- a/docs/source/user_guide/basics.rst
+++ b/docs/source/user_guide/basics.rst
@@ -256,13 +256,13 @@ FiftyOne provides a |Label| subclass for common tasks:
             'detections': BaseList([
                 <Detection: {
                     'label': 'cat',
-                    'bounding_box': array([0.5, 0.5, 0.4, 0.3]),
+                    'bounding_box': BaseList([0.5, 0.5, 0.4, 0.3]),
                     'confidence': None,
                     'attributes': BaseDict({}),
                 }>,
                 <Detection: {
                     'label': 'dog',
-                    'bounding_box': array([0.2, 0.2, 0.2, 0.4]),
+                    'bounding_box': BaseList([0.2, 0.2, 0.2, 0.4]),
                     'confidence': None,
                     'attributes': BaseDict({}),
                 }>,

--- a/docs/source/user_guide/using_datasets.rst
+++ b/docs/source/user_guide/using_datasets.rst
@@ -852,7 +852,7 @@ detection can be stored in the
             'detections': BaseList([
                 <Detection: {
                     'label': 'cat',
-                    'bounding_box': array([0.5, 0.5, 0.4, 0.3]),
+                    'bounding_box': BaseList([0.5, 0.5, 0.4, 0.3]),
                     'confidence': None,
                     'attributes': BaseDict({}),
                 }>,
@@ -862,7 +862,7 @@ detection can be stored in the
             'detections': BaseList([
                 <Detection: {
                     'label': 'cat',
-                    'bounding_box': array([0.48 , 0.513, 0.397, 0.288]),
+                    'bounding_box': BaseList([0.480, 0.513, 0.397, 0.288]),
                     'confidence': 0.96,
                     'attributes': BaseDict({}),
                 }>,
@@ -949,7 +949,7 @@ schema of the attributes that you're storing.
             'detections': BaseList([
                 <Detection: {
                     'label': 'cat',
-                    'bounding_box': array([0.5, 0.5, 0.4, 0.3]),
+                    'bounding_box': BaseList([0.5, 0.5, 0.4, 0.3]),
                     'confidence': None,
                     'attributes': BaseDict({
                         'age': <NumericAttribute: {'value': 51.0}>,
@@ -962,7 +962,7 @@ schema of the attributes that you're storing.
             'detections': BaseList([
                 <Detection: {
                     'label': 'cat',
-                    'bounding_box': array([0.48 , 0.513, 0.397, 0.288]),
+                    'bounding_box': BaseList([0.480, 0.513, 0.397, 0.288]),
                     'confidence': 0.96,
                     'attributes': BaseDict({
                         'age': <NumericAttribute: {'value': 51.0}>,

--- a/fiftyone/__public__.py
+++ b/fiftyone/__public__.py
@@ -40,7 +40,7 @@ from .core.labels import (
     BooleanAttribute,
     CategoricalAttribute,
     NumericAttribute,
-    VectorAttribute,
+    ListAttribute,
     Classification,
     Classifications,
     Detection,

--- a/fiftyone/core/labels.py
+++ b/fiftyone/core/labels.py
@@ -88,14 +88,16 @@ class NumericAttribute(Attribute):
     value = fof.FloatField()
 
 
-class VectorAttribute(Attribute):
-    """A vector attribute.
+class ListAttribute(Attribute):
+    """A list attribute.
+
+    The list can store arbitrary JSON-serialiable values.
 
     Args:
         value (None): the attribute value
     """
 
-    value = fof.VectorField()
+    value = fof.ListField()
 
 
 class ImageLabel(Label):

--- a/fiftyone/core/labels.py
+++ b/fiftyone/core/labels.py
@@ -266,7 +266,7 @@ class Detection(ImageLabel):
         required=True, default=ObjectId, unique=True, primary_key=True
     )
     label = fof.StringField()
-    bounding_box = fof.VectorField()
+    bounding_box = fof.ListField()
     confidence = fof.FloatField()
     attributes = fof.DictField(fof.EmbeddedDocumentField(Attribute))
 

--- a/fiftyone/core/utils.py
+++ b/fiftyone/core/utils.py
@@ -471,7 +471,7 @@ def serialize_numpy_array(array, ascii=False):
     """Serializes a numpy array.
 
     Args:
-        array: a numpy array
+        array: a numpy array-like
         ascii (False): whether to return a base64-encoded ASCII string instead
             of raw bytes
 
@@ -479,7 +479,7 @@ def serialize_numpy_array(array, ascii=False):
         the serialized bytes
     """
     with io.BytesIO() as f:
-        np.save(f, array, allow_pickle=False)
+        np.save(f, np.asarray(array), allow_pickle=False)
         bytes_str = zlib.compress(f.getvalue())
 
     if ascii:

--- a/fiftyone/utils/kitti.py
+++ b/fiftyone/utils/kitti.py
@@ -298,15 +298,15 @@ def _parse_kitti_detection_row(row, frame_size):
     ]
 
     try:
-        attributes["dimensions"] = fol.VectorAttribute(
-            value=np.array(list(map(float, row[8:11])))
+        attributes["dimensions"] = fol.ListAttribute(
+            value=list(map(float, row[8:11]))
         )
     except IndexError:
         pass
 
     try:
-        attributes["location"] = fol.VectorAttribute(
-            value=np.array(list(map(float, row[11:14])))
+        attributes["location"] = fol.ListAttribute(
+            value=list(map(float, row[11:14]))
         )
     except IndexError:
         pass

--- a/fiftyone/utils/kitti.py
+++ b/fiftyone/utils/kitti.py
@@ -289,7 +289,7 @@ def _parse_kitti_detection_row(row, frame_size):
     attributes["alpha"] = fol.NumericAttribute(value=float(row[3]))
 
     width, height = frame_size
-    xtl, ytl, xbr, ybr = map(float, row[4:8])
+    xtl, ytl, xbr, ybr = tuple(map(float, row[4:8]))
     bounding_box = [
         xtl / width,
         ytl / height,
@@ -299,14 +299,14 @@ def _parse_kitti_detection_row(row, frame_size):
 
     try:
         attributes["dimensions"] = fol.VectorAttribute(
-            value=np.asarray(map(float, row[8:11]))
+            value=np.array(list(map(float, row[8:11])))
         )
     except IndexError:
         pass
 
     try:
         attributes["location"] = fol.VectorAttribute(
-            value=np.asarray(map(float, row[11:14]))
+            value=np.array(list(map(float, row[11:14])))
         )
     except IndexError:
         pass

--- a/fiftyone/utils/tf.py
+++ b/fiftyone/utils/tf.py
@@ -426,7 +426,12 @@ class TFObjectDetectionSampleParser(TFRecordSampleParser):
             detections.append(
                 fol.Detection(
                     label=label,
-                    bounding_box=[xmin, ymin, xmax - xmin, ymax - ymin],
+                    bounding_box=[
+                        float(xmin),
+                        float(ymin),
+                        float(xmax - xmin),
+                        float(ymax - ymin),
+                    ],
                 )
             )
 


### PR DESCRIPTION
Closes https://github.com/voxel51/fiftyone/issues/567.

The issue is that bounding boxes were previously stored as `VectorField`s, which were serialized to the DB as lists but then loaded as numpy arrays. Now that `VectorField`s are always serialized as numpy arrays, bounding boxes need to be represented as `ListField`.

Fortunately, this change is backwards compatible with any datasets that may exist out in the wild. The next time a user loads their dataset, `bounding_box` will be a list instead of a numpy array in-memory, but the documentation already implies that bounding boxes are, in fact, stored as "lists", so it should be fine.