### PR TITLE
Sort by, shuffle, and take large datasets

### DIFF
--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -296,6 +296,15 @@ class SampleCollection(object):
                     % (field_name, ftype, field)
                 )
 
+    def create_index(self, field):
+        """Updates the underlying database to create an index on a field for
+        efficient sorting
+
+        Args:
+            field: the name of the field to make an index over
+        """
+        raise NotImplementedError("Subclass must implement make_index()")
+
     def get_tags(self):
         """Returns the list of unique tags of samples in the collection.
 
@@ -941,6 +950,10 @@ class SampleCollection(object):
         Returns:
             a :class:`fiftyone.core.view.DatasetView`
         """
+
+        if isinstance(field_or_expr, str):
+            self.create_index(field_or_expr)
+
         return self._add_view_stage(fos.SortBy(field_or_expr, reverse=reverse))
 
     @view_stage

--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -424,6 +424,15 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
         self._sample_doc_cls.delete_field(field_name)
         fos.Sample._purge_field(self._sample_collection_name, field_name)
 
+    def create_index(self, field):
+        """Updates the underlying database to create an index on a field for
+        efficient sorting
+
+        Args:
+            field: the name of the field to make an index over
+        """
+        self._sample_collection.create_index(field)
+
     def get_tags(self):
         """Returns the list of unique tags of samples in the dataset.
 
@@ -1213,7 +1222,8 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
         if pipeline is None:
             pipeline = []
 
-        return self._sample_collection.aggregate(pipeline)
+        return self._sample_collection.aggregate(pipeline,
+                allowDiskUse=True)
 
     def serialize(self):
         """Serializes the dataset.

--- a/fiftyone/core/view.py
+++ b/fiftyone/core/view.py
@@ -209,6 +209,15 @@ class DatasetView(foc.SampleCollection):
 
         return field_schema
 
+    def create_index(self, field):
+        """Updates the underlying database to create an index on a field for
+        efficient sorting
+
+        Args:
+            field: the name of the field to make an index over
+        """
+        self._dataset.create_index(field)
+
     def get_tags(self):
         """Returns the list of unique tags of samples in the view.
 


### PR DESCRIPTION
Any operation that requires a MongoDB `sort` errors out for large datasets.

Added a way to create index when sorting by a field and will allow disk use for shuffling, taking, and sorting by an expression.
Using disk takes a few seconds longer to run the aggregation pipeline. In the app, using a large dataset with lots of labels like BDD is already really slow so it is hard to gauge the performance hit by allowing disk use.

A version of BDD is on BB1 under `/data2/external_datasets/image_datasets/bdd100k/validation`, it can be loaded with:

```
fo.Dataset.from_dir(dataset_dir, fo.types.BDDDataset)
```