### PR TITLE
Including frame field schemas in summaries for video datasets/views

### DIFF
--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -254,9 +254,10 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
 
         if media_type not in fom.MEDIA_TYPES:
             raise ValueError(
-                'media_type can only be one of "image" or "video". Received "%s"'
-                % media_type
+                'media_type can only be one of %s; received "%s"'
+                % (fom.MEDIA_TYPES, media_type)
             )
+
         self._doc.media_type = media_type
 
         self._doc.save()

--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -314,18 +314,26 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
         Returns:
             a string summary
         """
-        return "\n".join(
-            [
-                "Name:           %s" % self.name,
-                "Media type      %s" % self.media_type,
-                "Num samples:    %d" % len(self),
-                "Persistent:     %s" % self.persistent,
-                "Info:           %s" % _info_repr.repr(self.info),
-                "Tags:           %s" % self.get_tags(),
-                "Sample fields:",
-                self._to_fields_str(self.get_field_schema()),
-            ]
-        )
+        elements = [
+            "Name:           %s" % self.name,
+            "Media type      %s" % self.media_type,
+            "Num samples:    %d" % len(self),
+            "Persistent:     %s" % self.persistent,
+            "Info:           %s" % _info_repr.repr(self.info),
+            "Tags:           %s" % self.get_tags(),
+            "Sample fields:",
+            self._to_fields_str(self.get_field_schema()),
+        ]
+
+        if self.media_type == fom.VIDEO:
+            elements.extend(
+                [
+                    "Frame fields:",
+                    self._to_fields_str(self.get_frames_field_schema()),
+                ]
+            )
+
+        return "\n".join(elements)
 
     def first(self):
         """Returns the first sample in the dataset.

--- a/fiftyone/core/sample.py
+++ b/fiftyone/core/sample.py
@@ -32,7 +32,7 @@ class _DatasetSample(_Sample):
         return super().__getattr__(name)
 
     def __getitem__(self, field_name):
-        if fofu.is_frame_number(field_name) and self.media_type == "video":
+        if fofu.is_frame_number(field_name) and self.media_type == fomm.VIDEO:
             return self.frames[field_name]
 
         if field_name == "frames" and self.media_type == fomm.VIDEO:
@@ -46,7 +46,7 @@ class _DatasetSample(_Sample):
             )
 
     def __setitem__(self, field_name, value):
-        if fofu.is_frame_number(field_name) and (self.media_type == "video"):
+        if fofu.is_frame_number(field_name) and self.media_type == fomm.VIDEO:
             self.frames[field_name] = value
             return
 
@@ -60,9 +60,9 @@ class _DatasetSample(_Sample):
 
     def compute_metadata(self):
         """Populates the ``metadata`` field of the sample."""
-        if self.media_type == "image":
+        if self.media_type == fomm.IMAGE:
             self.metadata = fom.ImageMetadata.build_for(self.filepath)
-        elif self.media_type == "video":
+        elif self.media_type == fomm.VIDEO:
             self.metadata = fom.VideoMetadata.build_for(self.filepath)
         else:
             self.metadata = fom.Metadata.build_for(self.filepath)

--- a/fiftyone/core/view.py
+++ b/fiftyone/core/view.py
@@ -12,6 +12,7 @@ import numbers
 from bson import ObjectId
 
 import fiftyone.core.collections as foc
+import fiftyone.core.media as fom
 import fiftyone.core.sample as fos
 
 
@@ -117,8 +118,23 @@ class DatasetView(foc.SampleCollection):
         Returns:
             a string summary
         """
-        field_schema = self.get_field_schema()
-        fields_str = self._dataset._to_fields_str(field_schema)
+        elements = [
+            "Dataset:        %s" % self.dataset_name,
+            "Num samples:    %d" % len(self),
+            "Tags:           %s" % self.get_tags(),
+            "Sample fields:",
+            self._dataset._to_fields_str(self.get_field_schema()),
+        ]
+
+        if self.media_type == fom.VIDEO:
+            elements.extend(
+                [
+                    "Frame fields:",
+                    self._dataset._to_fields_str(
+                        self.get_frames_field_schema()
+                    ),
+                ]
+            )
 
         if self._stages:
             pipeline_str = "    " + "\n    ".join(
@@ -130,17 +146,9 @@ class DatasetView(foc.SampleCollection):
         else:
             pipeline_str = "    ---"
 
-        return "\n".join(
-            [
-                "Dataset:        %s" % self.dataset_name,
-                "Num samples:    %d" % len(self),
-                "Tags:           %s" % self.get_tags(),
-                "Sample fields:",
-                fields_str,
-                "Pipeline stages:",
-                pipeline_str,
-            ]
-        )
+        elements.extend(["Pipeline stages:", pipeline_str])
+
+        return "\n".join(elements)
 
     def iter_samples(self):
         """Returns an iterator over the samples in the view.


### PR DESCRIPTION
```py
import fiftyone.zoo as foz                                                                                                                                                   

dataset = foz.load_zoo_dataset("quickstart-video")
print(dataset)
```

```
Name:           quickstart-video
Media type      video
Num samples:    10
Persistent:     False
Info:           {'description': 'quickstart-video'}
Tags:           []
Sample fields:
    media_type: fiftyone.core.fields.StringField
    filepath:   fiftyone.core.fields.StringField
    tags:       fiftyone.core.fields.ListField(fiftyone.core.fields.StringField)
    metadata:   fiftyone.core.fields.EmbeddedDocumentField(fiftyone.core.metadata.Metadata)
    frames:     fiftyone.core.fields.FramesField
Frame fields:
    frame_number: fiftyone.core.fields.FrameNumberField
    objs:         fiftyone.core.fields.EmbeddedDocumentField(fiftyone.core.labels.Detections)
```
