### PR TITLE
Add support for drawing labels on video samples

### DIFF
--- a/docs/source/recipes/draw_labels.ipynb
+++ b/docs/source/recipes/draw_labels.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "# Drawing Labels on Samples\n",
     "\n",
-    "This recipe demonstrates how to use FiftyOne to render annotated versions of [samples](https://voxel51.com/docs/fiftyone/user_guide/using_datasets.html#samples) with their [label field(s)](https://voxel51.com/docs/fiftyone/user_guide/using_datasets.html#labels) overlaid."
+    "This recipe demonstrates how to use FiftyOne to render annotated versions of image and video [samples](https://voxel51.com/docs/fiftyone/user_guide/using_datasets.html#samples) with their [label field(s)](https://voxel51.com/docs/fiftyone/user_guide/using_datasets.html#labels) overlaid."
    ]
   },
   {
@@ -280,7 +280,145 @@
    "source": [
     "Here's an example of an annotated image that was generated:\n",
     "\n",
-    "![caltech101-annotated](images/draw_labels_caltech101.jpg)"
+    "<img src=\"images/draw_labels_caltech101.jpg\" width=\"350\">"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Drawing labels on videos\n",
+    "\n",
+    "FiftyOne can also render frame labels onto video samples.\n",
+    "\n",
+    "To demonstrate, let's work with the (small) video quickstart dataset from the zoo:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Dataset already downloaded\n",
+      "Loading 'quickstart-video'\n",
+      " 100% |█████████| 10/10 [15.9s elapsed, 0s remaining, 0.6 samples/s]     \n",
+      "Name:           quickstart-video\n",
+      "Media type      video\n",
+      "Num samples:    10\n",
+      "Persistent:     False\n",
+      "Info:           {'description': 'quickstart-video'}\n",
+      "Tags:           []\n",
+      "Sample fields:\n",
+      "    media_type: fiftyone.core.fields.StringField\n",
+      "    filepath:   fiftyone.core.fields.StringField\n",
+      "    tags:       fiftyone.core.fields.ListField(fiftyone.core.fields.StringField)\n",
+      "    metadata:   fiftyone.core.fields.EmbeddedDocumentField(fiftyone.core.metadata.Metadata)\n",
+      "    frames:     fiftyone.core.fields.FramesField\n",
+      "Frame fields:\n",
+      "    frame_number: fiftyone.core.fields.FrameNumberField\n",
+      "    objs:         fiftyone.core.fields.EmbeddedDocumentField(fiftyone.core.labels.Detections)\n"
+     ]
+    }
+   ],
+   "source": [
+    "import fiftyone.zoo as foz\n",
+    "\n",
+    "# Load a small video dataset\n",
+    "dataset = foz.load_zoo_dataset(\"quickstart-video\")\n",
+    "\n",
+    "print(dataset)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note that the dataset contains frame-level detections in the `objs` field of each frame.\n",
+    "\n",
+    "Let's make a [DatasetView](https://voxel51.com/docs/fiftyone/user_guide/using_datasets.html#datasetviews) that contains a couple random videos from the dataset and render them as annotated videos with the frame-level detections overlaid:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Writing annotated videos to '/tmp/fiftyone/draw_labels/quickstart-video-anno'\n",
+      "Rendering video 1/2: '/tmp/fiftyone/draw_labels/quickstart-video-anno/0587e1cfc2344523922652d8b227fba4-000014-video_052.mp4'\n",
+      " 100% |████████| 120/120 [19.0s elapsed, 0s remaining, 6.7 frames/s]      \n",
+      "Rendering video 2/2: '/tmp/fiftyone/draw_labels/quickstart-video-anno/0587e1cfc2344523922652d8b227fba4-000014-video_164.mp4'\n",
+      " 100% |████████| 120/120 [27.2s elapsed, 0s remaining, 4.3 frames/s]      \n",
+      "Annotation complete\n"
+     ]
+    }
+   ],
+   "source": [
+    "import fiftyone.utils.annotations as foua\n",
+    "\n",
+    "# Directory to write the output annotations\n",
+    "anno_dir = \"/tmp/fiftyone/draw_labels/quickstart-video-anno\"\n",
+    "\n",
+    "# Extract two random samples\n",
+    "view = dataset.take(2)\n",
+    "\n",
+    "#\n",
+    "# You can customize the look-and-feel of the annotations\n",
+    "# For more information, see:\n",
+    "# https://voxel51.com/docs/fiftyone/user_guide/draw_labels.html#customizing-annotation-rendering\n",
+    "#\n",
+    "annotation_config = foua.AnnotationConfig({\n",
+    "    \"per_object_label_colors\": True\n",
+    "})\n",
+    "\n",
+    "# Render the labels\n",
+    "print(\"Writing annotated videos to '%s'\" % anno_dir)\n",
+    "view.draw_labels(anno_dir, annotation_config=annotation_config)\n",
+    "print(\"Annotation complete\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's list the output directory to verify that the annotations have been generated:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "total 34832\r\n",
+      "drwxr-xr-x  4 Brian  wheel   128B Oct  7 23:57 \u001b[34m.\u001b[m\u001b[m\r\n",
+      "drwxr-xr-x  3 Brian  wheel    96B Oct  7 23:57 \u001b[34m..\u001b[m\u001b[m\r\n",
+      "-rw-r--r--  1 Brian  wheel   7.5M Oct  7 23:57 0587e1cfc2344523922652d8b227fba4-000014-video_052.mp4\r\n",
+      "-rw-r--r--  1 Brian  wheel   8.5M Oct  7 23:58 0587e1cfc2344523922652d8b227fba4-000014-video_164.mp4\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "!ls -lah /tmp/fiftyone/draw_labels/quickstart-video-anno"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Here's a snippet of an annotated video that was generated:\n",
+    "\n",
+    "![quickstart-video-annotated](images/draw_labels_quickstart_video.gif)"
    ]
   },
   {

--- a/docs/source/user_guide/config.rst
+++ b/docs/source/user_guide/config.rst
@@ -34,7 +34,9 @@ FiftyOne supports the configuration options described below:
 | `default_sequence_idx` | `FIFTYONE_DEFAULT_SEQUENCE_IDX` | `%06d`                 | The default numeric string pattern to use when writing sequential lists of             |
 |                        |                                 |                        | files.                                                                                 |
 +------------------------+---------------------------------+------------------------+----------------------------------------------------------------------------------------+
-| `default_image_ext`    | `FIFTYONE_DEFAULT_IMAGE_EXT`    | `.jpg`                 | The default image encoding to use when writing images to disk.                         |
+| `default_image_ext`    | `FIFTYONE_DEFAULT_IMAGE_EXT`    | `.jpg`                 | The default image format to use when writing images to disk.                           |
++------------------------+---------------------------------+------------------------+----------------------------------------------------------------------------------------+
+| `default_video_ext`    | `FIFTYONE_DEFAULT_VIDEO_EXT`    | `.mp4`                 | The default video format to use when writing videos to disk.                           |
 +------------------------+---------------------------------+------------------------+----------------------------------------------------------------------------------------+
 | `show_progress_bars`   | `FIFTYONE_SHOW_PROGRESS_BARS`   | `True`                 | Controls whether progress bars are printed to the terminal when performing             |
 |                        |                                 |                        | operations such reading/writing large datasets or activiating FiftyOne                 |
@@ -68,6 +70,7 @@ described in the next section) at any time via the Python library and the CLI.
             "default_ml_backend": "torch",
             "default_sequence_idx": "%08d",
             "default_image_ext": ".jpg",
+            "default_video_ext": ".mp4",
             "show_progress_bars": true
         }
 
@@ -90,6 +93,7 @@ described in the next section) at any time via the Python library and the CLI.
             "default_ml_backend": "torch",
             "default_sequence_idx": "%08d",
             "default_image_ext": ".jpg",
+            "default_video_ext": ".mp4",
             "show_progress_bars": true
         }
 
@@ -123,6 +127,7 @@ For example, a valid config JSON file is:
       "default_ml_backend": "tensorflow",
       "default_sequence_idx": "%08d",
       "default_image_ext": ".png",
+      "default_video_ext": ".mp4",
       "show_progress_bars": true
     }
 
@@ -171,5 +176,6 @@ For example, you can customize your FiftyOne config at runtime as follows:
         default_ml_backend="tensorflow",
         default_sequence_idx="%08d",
         default_image_ext=".png",
+        default_video_ext=".mp4",
         show_progress_bars=True,
     )

--- a/docs/source/user_guide/draw_labels.rst
+++ b/docs/source/user_guide/draw_labels.rst
@@ -3,8 +3,9 @@ Drawing Labels on Samples
 
 .. default-role:: code
 
-FiftyOne provides native support for rendering annotated versions of samples
-with :ref:`label fields <using-labels>` overlaid on the source media.
+FiftyOne provides native support for rendering annotated versions of image and
+video samples with :ref:`label fields <using-labels>` overlaid on the source
+media.
 
 Basic recipe
 ------------
@@ -68,7 +69,8 @@ You can also annotate individual samples directly by using the various methods
 exposed in the :mod:`fiftyone.utils.annotations` module.
 
 For example, you can draw an annotated version of an image sample with
-|Classification| and |Detections| labels overlaid as follows:
+|Classification| and |Detections| labels overlaid via
+:func:`draw_labeled_image() <fiftyone.utils.annotations.draw_labeled_image>`:
 
 .. code-block:: python
     :linenos:
@@ -119,6 +121,10 @@ For example, you can draw an annotated version of an image sample with
 .. image:: ../images/draw_labels_example1.jpg
    :alt: image-annotated.jpg
    :align: center
+
+Similarly, you can draw an annotated version of a video sample with its frame
+labels overlaid via
+:func:`draw_labeled_video() <fiftyone.utils.annotations.draw_labeled_video>`.
 
 Customizing annotation rendering
 --------------------------------

--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -1053,6 +1053,17 @@ class SampleCollection(object):
                     anno_dir,
                 )
 
+        if self.media_type == fom.VIDEO:
+            if label_fields is None:
+                label_fields = _get_frame_label_fields(self)
+
+                return foua.draw_labeled_videos(
+                    self,
+                    anno_dir,
+                    label_fields=label_fields,
+                    annotation_config=annotation_config,
+                )
+
         if label_fields is None:
             label_fields = _get_image_label_fields(self)
 
@@ -1320,6 +1331,13 @@ def _get_random_characters(n):
 
 def _get_image_label_fields(sample_collection):
     label_fields = sample_collection.get_field_schema(
+        ftype=fof.EmbeddedDocumentField, embedded_doc_type=fol.ImageLabel
+    )
+    return list(label_fields.keys())
+
+
+def _get_frame_label_fields(sample_collection):
+    label_fields = sample_collection.get_frames_field_schema(
         ftype=fof.EmbeddedDocumentField, embedded_doc_type=fol.ImageLabel
     )
     return list(label_fields.keys())

--- a/fiftyone/core/config.py
+++ b/fiftyone/core/config.py
@@ -13,6 +13,7 @@ try:
 except ImportError:
     import importlib_metadata  # Python < 3.8
 
+import eta
 from eta.core.config import EnvConfig
 
 import fiftyone as fo
@@ -66,6 +67,23 @@ class FiftyOneConfig(EnvConfig):
 
         self._set_defaults()
         self._validate()
+
+    @property
+    def show_progress_bars(self):
+        return self._show_progress_bars
+
+    @show_progress_bars.setter
+    def show_progress_bars(self, value):
+        self._show_progress_bars = value
+        try:
+            # Keep ETA config in-sync
+            eta.config.show_progress_bars = value
+        except:
+            pass
+
+    def attributes(self):
+        # Includes `show_progress_bars`
+        return super().custom_attributes(dynamic=True)
 
     def _set_defaults(self):
         if self.default_dataset_dir is None:

--- a/fiftyone/core/config.py
+++ b/fiftyone/core/config.py
@@ -50,6 +50,13 @@ class FiftyOneConfig(EnvConfig):
             env_var="FIFTYONE_DEFAULT_IMAGE_EXT",
             default=".jpg",
         )
+        self.default_video_ext = self.parse_string(
+            d,
+            "default_video_ext",
+            env_var="FIFTYONE_DEFAULT_VIDEO_EXT",
+            default=".mp4",
+        )
+        self._show_progress_bars = None  # declare
         self.show_progress_bars = self.parse_bool(
             d,
             "show_progress_bars",

--- a/fiftyone/core/frame.py
+++ b/fiftyone/core/frame.py
@@ -91,6 +91,15 @@ class Frames(object):
                 str(key)
             ] = NoDatasetFrameSampleDocument.from_dict(d)
 
+    @property
+    def field_names(self):
+        """An ordered tuple of the names of the fields on the frames."""
+        try:
+            frame = next(self.values())
+            return frame.field_names
+        except:
+            return ("frame_number",)
+
     def keys(self):
         """Returns an iterator over the frame numbers with labels in the
         sample.

--- a/fiftyone/core/utils.py
+++ b/fiftyone/core/utils.py
@@ -381,6 +381,7 @@ class ProgressBar(etau.ProgressBar):
 
 @contextmanager
 def disable_progress_bars():
+    """Context manager that temporarily disables all progress bars."""
     prev_show_progress_bars = fo.config.show_progress_bars
     try:
         fo.config.show_progress_bars = False

--- a/fiftyone/utils/annotations.py
+++ b/fiftyone/utils/annotations.py
@@ -5,17 +5,24 @@ Data annotation utilities.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+import logging
+
 import eta.core.annotations as etaa
+import eta.core.frames as etaf
 import eta.core.image as etai
+import eta.core.video as etav
 
 import fiftyone as fo
 import fiftyone.core.labels as fol
 import fiftyone.core.utils as fou
 
 
+logger = logging.getLogger(__name__)
+
+
 #
-# NOTE: The default values for `per_object_label_colors` and
-# `per_polyline_label_colors` in the docstring are incorrect...
+# @todo: the default values for the fields customized in `__init__()` below are
+# incorrect in the generated docstring
 #
 class AnnotationConfig(etaa.AnnotationConfig):
     """.. autoclass:: eta.core.annotations.AnnotationConfig"""
@@ -101,30 +108,126 @@ def draw_labeled_image(
         annotation_config (None): an :class:`AnnotationConfig` specifying how
             to render the annotations
     """
-    if label_fields is None:
-        label_fields = _get_image_label_fields(sample)
-
     if annotation_config is None:
         annotation_config = AnnotationConfig.default()
 
-    image_labels = etai.ImageLabels()
-    for label_field in label_fields:
-        label = sample[label_field]
-        if label is None:
-            continue
-
-        image_labels.merge_labels(label.to_image_labels(name=label_field))
-
     img = etai.read(sample.filepath)
+    frame_labels = _to_frame_labels(sample, label_fields=label_fields)
 
     anno_img = etaa.annotate_image(
-        img, image_labels, annotation_config=annotation_config
+        img, frame_labels, annotation_config=annotation_config
     )
 
     etai.write(anno_img, outpath)
 
 
-def _get_image_label_fields(sample):
-    return [
-        f for f in sample.field_names if isinstance(sample[f], fol.ImageLabel)
-    ]
+def draw_labeled_videos(
+    samples, anno_dir, label_fields=None, annotation_config=None
+):
+    """Renders annotated versions of the video samples with label field(s)
+    overlaid to the given directory.
+
+    The filenames of the sample videos are maintained, unless a name conflict
+    would occur in ``anno_dir``, in which case an index of the form
+    ``"-%d" % count`` is appended to the base filename.
+
+    The videos are written in format ``fo.config.default_video_ext``.
+
+    Args:
+        samples: an iterable of :class:`fiftyone.core.sample.Sample` instances
+        anno_dir: the directory to write the annotated videos
+        label_fields (None): a list of :class:`fiftyone.core.labels.ImageLabel`
+            fields on the frames of the samples to render. If omitted, all
+            compatiable fields are rendered
+        annotation_config (None): an :class:`AnnotationConfig` specifying how
+            to render the annotations
+
+    Returns:
+        the list of paths to the labeled videos
+    """
+    if annotation_config is None:
+        annotation_config = AnnotationConfig.default()
+
+    filename_maker = fou.UniqueFilenameMaker(output_dir=anno_dir)
+    output_ext = fo.config.default_video_ext
+
+    try:
+        num_samples = len(samples)
+    except:
+        num_samples = None
+
+    outpaths = []
+
+    for idx, sample in enumerate(samples, 1):
+        outpath = filename_maker.get_output_path(
+            sample.filepath, output_ext=output_ext
+        )
+
+        if num_samples is not None:
+            logger.info(
+                "Rendering video %d/%d: '%s'", idx, num_samples, outpath
+            )
+        else:
+            logger.info("Rendering video %d: '%s'", idx, outpath)
+
+        draw_labeled_video(
+            sample,
+            outpath,
+            label_fields=label_fields,
+            annotation_config=annotation_config,
+        )
+        outpaths.append(outpath)
+
+    return outpaths
+
+
+def draw_labeled_video(
+    sample, outpath, label_fields=None, annotation_config=None
+):
+    """Draws an annotated version of the video sample with its label field(s)
+    overlaid to disk.
+
+    Args:
+        sample: a :class:`fiftyone.core.sample.Sample` instance
+        outpath: the path to write the annotated image
+        label_fields (None): a list of :class:`fiftyone.core.labels.ImageLabel`
+            fields on the frames of the sample to render. If omitted, all
+            compatiable fields are rendered
+        annotation_config (None): an :class:`AnnotationConfig` specifying how
+            to render the annotations
+    """
+    if annotation_config is None:
+        annotation_config = AnnotationConfig.default()
+
+    video_path = sample.filepath
+    video_labels = _to_video_labels(sample, label_fields=label_fields)
+
+    etaa.annotate_video(
+        video_path, video_labels, outpath, annotation_config=annotation_config
+    )
+
+
+def _to_frame_labels(sample_or_frame, label_fields=None):
+    frame_labels = etaf.FrameLabels()
+
+    if label_fields is None:
+        for name, field in sample_or_frame.iter_fields():
+            if isinstance(field, fol.ImageLabel):
+                frame_labels.merge_labels(field.to_image_labels(name=name))
+    else:
+        for name in label_fields:
+            label = sample_or_frame[name]
+            if label is not None:
+                frame_labels.merge_labels(label.to_image_labels(name=name))
+
+    return frame_labels
+
+
+def _to_video_labels(sample, label_fields=None):
+    video_labels = etav.VideoLabels()
+    for frame_number, frame in sample.frames.items():
+        video_labels[frame_number] = _to_frame_labels(
+            frame, label_fields=label_fields
+        )
+
+    return video_labels


### PR DESCRIPTION
Labels can now be rendered on video samples.

See the new video section of the drawing labels recipe for more details.

Example usage:

```py
import fiftyone.zoo as foz
import fiftyone.utils.annotations as foua

ANNO_PATH = "/tmp/video-anno.mp4"
ANNO_DIR = "/tmp/video-anno"

dataset = foz.load_zoo_dataset("quickstart-video", max_samples=5)

# Single video
sample = dataset.first()
foua.draw_labeled_video(sample, ANNO_PATH)

# Collection of videos
dataset.take(2).draw_labels(ANNO_DIR)
```