### PR TITLE
Adding support for filtering polylines and keypoints

### DIFF
--- a/docs/source/user_guide/using_views.rst
+++ b/docs/source/user_guide/using_views.rst
@@ -384,26 +384,72 @@ stages to select or exclude fields from the returned |SampleView|:
         print(sample.tags)     # AttributeError: `tags` was excluded
     )
 
-The :meth:`filter_classifications() <fiftyone.core.view.DatasetView.filter_classifications>`
-and :meth:`filter_detections() <fiftyone.core.view.DatasetView.filter_detections>`
+The :meth:`filter_classifications() <fiftyone.core.view.DatasetView.filter_classifications>`,
+:meth:`filter_detections() <fiftyone.core.view.DatasetView.filter_detections>`,
+:meth:`filter_polylines() <fiftyone.core.view.DatasetView.filter_polylines>`, and
+:meth:`filter_keypoints() <fiftyone.core.view.DatasetView.filter_keypoints>`
 stages are powerful stages that allow you to filter the contents of
-|Classifications| and |Detections| fields, respectively.
+|Detections|, |Classifications|, |Polylines|, and |Keypoints| fields,
+respectively.
 
-Here are some examples:
+Here are some examples for each task:
+
+.. tabs::
+
+    .. tab:: Classifications
+
+        .. code-block:: python
+            :linenos:
+
+            # Only include labels in the `my_classifications` field of each sample with
+            # label "friend" and confidence greater than 0.5
+            confident_friends_view = dataset.filter_classifications(
+                "my_classifications", (F("confidence") > 0.5) & (F("label") == "friend")
+            )
+
+    .. tab:: Detections
+
+        .. code-block:: python
+            :linenos:
+
+            # Only include detections in the `my_detections` field of each sample
+            # whose bounding boxes have an area of at least 0.5
+            large_boxes_view = dataset.filter_detections(
+                "my_detections", F("bounding_box")[2] * F("bounding_box")[3] >= 0.5
+            )
+
+    .. tab:: Polylines
+
+        .. code-block:: python
+            :linenos:
+
+            # Only include polylines in the `my_polylines` field that are filled
+            # (i.e., are polygons)
+            filled_polygons_view = dataset.filter_polylines(
+                "my_polylines", F("filled")
+            )
+
+    .. tab:: Keypoints
+
+        .. code-block:: python
+            :linenos:
+
+            # Only include keypoints in the `my_keypoints`  field of each sample
+            # that have at most 10 vertices
+            many_points_view = dataset.filter_keypoints(
+                "my_keypoints", F("points").length() >= 10
+            )
+
+You can also use the :meth:`filter_field() <fiftyone.core.view.DatasetView.filter_field>`
+stage to filter the contents of arbitrarily-typed fields:
 
 .. code-block:: python
     :linenos:
 
-    # Only include labels in the `my_classifications` field of each sample with
-    # label "friend" and confidence greater than 0.5
-    confident_friends_view = dataset.filter_classifications(
-        "my_classifications", (F("confidence") > 0.5) & (F("label") == "friend")
-    )
-
-    # Only include detections in the `my_detections` field whose boxes have
-    # an area of at least 0.5
-    large_boxes_view = dataset.filter_detections(
-        "my_detections", F("bounding_box")[2] * F("bounding_box")[3] >= 0.5
+    # Only include values for the `my_string` field that are either "awesome" or
+    # "cool"
+    awesome_cool_view = dataset.filter_field(
+        "my_string", F().is_in(["awesome", "cool"])
     )
 
 .. note::

--- a/electron/app/components/Filter.tsx
+++ b/electron/app/components/Filter.tsx
@@ -318,6 +318,10 @@ const CLS_TO_STAGE = {
   Classifications: "FilterClassifications",
   Detection: "FilterField",
   Detections: "FilterDetections",
+  Polyline: "FilterField",
+  Polylines: "FilterPolylines",
+  Keypoint: "FilterField",
+  Keypoints: "FilterKeypoints",
 };
 
 const makeFilter = (fieldName, cls, labels, range, includeNone, hasBounds) => {

--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -622,6 +622,99 @@ class SampleCollection(object):
         return self._add_view_stage(fos.FilterDetections(field, filter))
 
     @view_stage
+    def filter_polylines(self, field, filter):
+        """Filters the polylines of the given
+        :class:`fiftyone.core.labels.Polylines` field.
+
+        Elements of ``<field>.polylines`` for which ``filter`` returns
+        ``False`` are omitted from the field.
+
+        Examples::
+
+            import fiftyone as fo
+            from fiftyone import ViewField as F
+            from fiftyone.core.stages import FilterPolylines
+
+            dataset = fo.load_dataset(...)
+
+            #
+            # Only include polylines in the `predictions` field that are filled
+            #
+
+            stage = FilterPolylines("predictions", F("filled"))
+            view = dataset.add_stage(stage)
+
+            #
+            # Only include polylines in the `predictions` field whose `label`
+            # is "lane"
+            #
+
+            stage = FilterPolylines("predictions", F("label") == "lane")
+            view = dataset.add_stage(stage)
+
+            #
+            # Only include polylines in the `predictions` field with at least
+            # 10 vertices
+            #
+
+            stage = FilterPolylines("predictions", F("points").length() >= 10)
+            view = dataset.add_stage(stage)
+
+        Args:
+            field: the :class:`fiftyone.core.labels.Polylines` field
+            filter: a :class:`fiftyone.core.expressions.ViewExpression` or
+                `MongoDB expression <https://docs.mongodb.com/manual/meta/aggregation-quick-reference/#aggregation-expressions>`_
+                that returns a boolean describing the filter to apply
+
+        Returns:
+            a :class:`fiftyone.core.view.DatasetView`
+        """
+        return self._add_view_stage(fos.FilterPolylines(field, filter))
+
+    @view_stage
+    def filter_keypoints(self, field, filter):
+        """Filters the keypoints of the given
+        :class:`fiftyone.core.labels.Keypoints` field.
+
+        Elements of ``<field>.keypoints`` for which ``filter`` returns
+        ``False`` are omitted from the field.
+
+        Examples::
+
+            import fiftyone as fo
+            from fiftyone import ViewField as F
+            from fiftyone.core.stages import FilterKeypoints
+
+            dataset = fo.load_dataset(...)
+
+            #
+            # Only include keypoints in the `predictions` field whose `label`
+            # is "face"
+            #
+
+            stage = FilterKeypoints("predictions", F("label") == "face")
+            view = dataset.add_stage(stage)
+
+            #
+            # Only include keypoints in the `predictions` field with at least
+            # 10 points
+            #
+
+            stage = FilterKeypoints("predictions", F("points").length() >= 10)
+            view = dataset.add_stage(stage)
+
+        Args:
+            field: the :class:`fiftyone.core.labels.Keypoints` field
+            filter: a :class:`fiftyone.core.expressions.ViewExpression` or
+                `MongoDB expression <https://docs.mongodb.com/manual/meta/aggregation-quick-reference/#aggregation-expressions>`_
+                that returns a boolean describing the filter to apply
+
+        Returns:
+            a :class:`fiftyone.core.view.DatasetView`
+        """
+        return self._add_view_stage(fos.FilterKeypoints(field, filter))
+
+    @view_stage
     def limit(self, limit):
         """Returns a view with at most the given number of samples.
 

--- a/fiftyone/core/stages.py
+++ b/fiftyone/core/stages.py
@@ -646,6 +646,111 @@ class FilterDetections(_FilterListField):
         )
 
 
+class FilterPolylines(_FilterListField):
+    """Filters the :class:`fiftyone.core.labels.Polyline` elements in the
+    specified :class:`fiftyone.core.labels.Polylines` field of the samples in
+    the stage.
+
+    Examples::
+
+        import fiftyone as fo
+        from fiftyone import ViewField as F
+        from fiftyone.core.stages import FilterPolylines
+
+        dataset = fo.load_dataset(...)
+
+        #
+        # Only include polylines in the `predictions` field that are filled
+        #
+
+        stage = FilterPolylines("predictions", F("filled"))
+        view = dataset.add_stage(stage)
+
+        #
+        # Only include polylines in the `predictions` field whose `label` is
+        # "lane"
+        #
+
+        stage = FilterPolylines("predictions", F("label") == "lane")
+        view = dataset.add_stage(stage)
+
+        #
+        # Only include polylines in the `predictions` field with at least
+        # 10 vertices
+        #
+
+        stage = FilterPolylines("predictions", F("points").length() >= 10)
+        view = dataset.add_stage(stage)
+
+    Args:
+        field: the field to filter, which must be a
+            :class:`fiftyone.core.labels.Polylines`
+        filter: a :class:`fiftyone.core.expressions.ViewExpression` or
+            `MongoDB expression <https://docs.mongodb.com/manual/meta/aggregation-quick-reference/#aggregation-expressions>`_
+            that returns a boolean describing the filter to apply
+    """
+
+    @property
+    def _filter_field(self):
+        return self.field + ".polylines"
+
+    def validate(self, sample_collection):
+        sample_collection.validate_field_type(
+            self.field,
+            fof.EmbeddedDocumentField,
+            embedded_doc_type=fol.Polylines,
+        )
+
+
+class FilterKeypoints(_FilterListField):
+    """Filters the :class:`fiftyone.core.labels.Keypoint` elements in the
+    specified :class:`fiftyone.core.labels.Keypoints` field of the samples in
+    the stage.
+
+    Examples::
+
+        import fiftyone as fo
+        from fiftyone import ViewField as F
+        from fiftyone.core.stages import FilterKeypoints
+
+        dataset = fo.load_dataset(...)
+
+        #
+        # Only include keypoints in the `predictions` field whose `label` is
+        # "face"
+        #
+
+        stage = FilterKeypoints("predictions", F("label") == "face")
+        view = dataset.add_stage(stage)
+
+        #
+        # Only include keypoints in the `predictions` field with at least
+        # 10 points
+        #
+
+        stage = FilterKeypoints("predictions", F("points").length() >= 10)
+        view = dataset.add_stage(stage)
+
+    Args:
+        field: the field to filter, which must be a
+            :class:`fiftyone.core.labels.Keypoints`
+        filter: a :class:`fiftyone.core.expressions.ViewExpression` or
+            `MongoDB expression <https://docs.mongodb.com/manual/meta/aggregation-quick-reference/#aggregation-expressions>`_
+            that returns a boolean describing the filter to apply
+    """
+
+    @property
+    def _filter_field(self):
+        return self.field + ".keypoints"
+
+    def validate(self, sample_collection):
+        sample_collection.validate_field_type(
+            self.field,
+            fof.EmbeddedDocumentField,
+            embedded_doc_type=fol.Keypoints,
+        )
+
+
 class Limit(ViewStage):
     """Limits the view to the given number of samples.
 
@@ -1458,6 +1563,8 @@ _STAGES = [
     FilterField,
     FilterClassifications,
     FilterDetections,
+    FilterPolylines,
+    FilterKeypoints,
     Limit,
     Match,
     MatchTag,

--- a/fiftyone/server/main.py
+++ b/fiftyone/server/main.py
@@ -142,6 +142,8 @@ def _load_state(trigger_update=False):
 _WITHOUT_PAGINATION_EXTENDED_STAGES = {
     fosg.FilterClassifications,
     fosg.FilterDetections,
+    fosg.FilterPolylines,
+    fosg.FilterKeypoints,
     fosg.FilterField,
 }
 


### PR DESCRIPTION
Works like a charm:

```py
import fiftyone as fo
from fiftyone import ViewField as F

DATASET_DIR = "/path/to/bdd100k/validation"

dataset = fo.Dataset.from_dir(
    DATASET_DIR,
    fo.types.BDDDataset,
    expand=True,
    shuffle=True,
    max_samples=25,
)

session = fo.launch_app(dataset)

# Lanes only
session.view = dataset.filter_polylines("polylines", F("label") == "lane")

# Drivable area only
session.view = dataset.filter_polylines("polylines", F("label") == "drivable area")
```

<img width="1239" alt="Screen Shot 2020-10-08 at 1 26 34 AM" src="https://user-images.githubusercontent.com/25985824/95419701-229c7780-0908-11eb-9629-9dd84e25b4df.png">

<img width="1195" alt="Screen Shot 2020-10-08 at 1 26 42 AM" src="https://user-images.githubusercontent.com/25985824/95419705-24663b00-0908-11eb-8d39-fc79f4c0c04a.png">
