### PR TITLE
Allowing missing media_type when importing FiftyOneDataset

### DIFF
--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -1737,7 +1737,7 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
         # @todo support importing video datasets?
         # This should never actually be run, as serializing video datasets is
         # not supported in the first place
-        if d["media_type"] == fom.VIDEO:
+        if d.get("media_type", fom.IMAGE) == fom.VIDEO:
             raise ValueError(
                 "Importing serialized video datasets is not supported"
             )

--- a/fiftyone/utils/data/importers.py
+++ b/fiftyone/utils/data/importers.py
@@ -740,8 +740,9 @@ class FiftyOneDatasetImporter(GenericSampleDatasetImporter):
         metadata_path = os.path.join(self.dataset_dir, "metadata.json")
         if os.path.isfile(metadata_path):
             metadata = etas.load_json(metadata_path)
+            media_type = metadata.get("media_type", None)
             self._metadata = metadata
-            self._is_video_dataset = metadata["media_type"] == fomm.VIDEO
+            self._is_video_dataset = media_type == fomm.VIDEO
         else:
             self._metadata = {}
 

--- a/fiftyone/utils/data/importers.py
+++ b/fiftyone/utils/data/importers.py
@@ -740,7 +740,7 @@ class FiftyOneDatasetImporter(GenericSampleDatasetImporter):
         metadata_path = os.path.join(self.dataset_dir, "metadata.json")
         if os.path.isfile(metadata_path):
             metadata = etas.load_json(metadata_path)
-            media_type = metadata.get("media_type", None)
+            media_type = metadata.get("media_type", fomm.IMAGE)
             self._metadata = metadata
             self._is_video_dataset = media_type == fomm.VIDEO
         else:


### PR DESCRIPTION
Existing datasets on disk in `FiftyOneDataset` format may not have the `media_type` key in their `metadata.json` files. This PR makes that field optional.