### PR TITLE
GitHub actions: test quickstart

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -47,7 +47,7 @@ jobs:
         run: |
           pip install --upgrade pip setuptools wheel
           mkdir -p pip-cache
-          echo ::set-env name=PIP_CACHE_DIR::pip-cache
+          echo "PIP_CACHE_DIR=pip-cache" >> $GITHUB_ENV
       - name: Fetch pip cache
         uses: actions/cache@v2
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -147,6 +147,9 @@ jobs:
         if: success() || failure()
         run: |
           find tests/isolated/ -name '*.py' -print0 | xargs -0 --verbose -n1 python tests/utils/pytest_wrapper.py --verbose
+      - name: Test quickstart
+        run: |
+          fiftyone quickstart
 
   all-tests:
     needs: test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -107,11 +107,17 @@ jobs:
         run: |
           python setup.py bdist_wheel
           pip install dist/*.whl
+      - name: Install fiftyone-gui stub
+        working-directory: package/gui
+        run: |
+          cp "$(which true)" ./FiftyOne-stub.AppImage
+          export FIFTYONE_GUI_EXE_PATH=./FiftyOne-stub.AppImage
+          python setup.py bdist_wheel
+          pip install dist/*.whl
       - name: Install fiftyone
         env:
           PIP_INDEX_URL: https://voxel51-ci@pypi.voxel51.com
         run: |
-          pip install -e package/gui/
           pip install -e . fiftyone-brain
       - name: Upgrade ETA to pre-release
         if: ${{ !startsWith(github.ref, 'refs/heads/rel') && !startsWith(github.ref, 'refs/tags/') }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -153,7 +153,7 @@ jobs:
         run: |
           find tests/isolated/ -name '*.py' -print0 | xargs -0 --verbose -n1 python tests/utils/pytest_wrapper.py --verbose
       - name: Test quickstarts
-        if: ${{ steps.test_config.outputs.run_integration }}
+        if: ${{ steps.test_config.outputs.run_integration == 'true' }}
         env:
           PYTHONUNBUFFERED: 1
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -82,7 +82,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip setuptools wheel
           mkdir -p pip-cache
-          echo ::set-env name=PIP_CACHE_DIR::pip-cache
+          echo "PIP_CACHE_DIR=pip-cache" >> $GITHUB_ENV
       - name: Fetch pip cache
         uses: actions/cache@v2
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -110,8 +110,13 @@ jobs:
       - name: Install fiftyone-gui stub
         working-directory: package/gui
         run: |
-          cp "$(which true)" ./FiftyOne-stub.AppImage
-          export FIFTYONE_GUI_EXE_PATH=./FiftyOne-stub.AppImage
+          if [[ ${{ matrix.os }} = windows-* ]]; then
+            ext=exe
+          else
+            ext=AppImage
+          fi
+          cp -v "$(which true)" ./FiftyOne-stub.${ext}
+          export FIFTYONE_GUI_EXE_PATH=./FiftyOne-stub.${ext}
           python setup.py bdist_wheel
           pip install dist/*.whl
       - name: Install fiftyone

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -140,6 +140,9 @@ jobs:
         run: |
           pip install pytest tensorflow tensorflow-datasets
           pip install torch==1.6.0+cpu torchvision==0.7.0+cpu -f https://download.pytorch.org/whl/torch_stable.html
+      - name: Configure FiftyOne for tests
+        run: |
+          python tests/utils/setup_config.py
       - name: Run tests
         run: |
           python tests/utils/pytest_wrapper.py tests/ --verbose --ignore tests/benchmarking/ --ignore tests/isolated/ --ignore tests/utils/ --ignore tests/import_export/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -151,9 +151,11 @@ jobs:
         run: |
           find tests/isolated/ -name '*.py' -print0 | xargs -0 --verbose -n1 python tests/utils/pytest_wrapper.py --verbose
       - name: Test quickstarts
+        env:
+          PYTHONUNBUFFERED: 1
         run: |
-          fiftyone quickstart
-          fiftyone quickstart --video
+          python tests/utils/command_wrapper.py fiftyone quickstart
+          python tests/utils/command_wrapper.py fiftyone quickstart --video
 
   all-tests:
     needs: test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -140,7 +140,7 @@ jobs:
         run: |
           pip install pytest tensorflow tensorflow-datasets
           pip install torch==1.6.0+cpu torchvision==0.7.0+cpu -f https://download.pytorch.org/whl/torch_stable.html
-      - name: Configure FiftyOne for tests
+      - name: Configure fiftyone for tests
         run: |
           python tests/utils/setup_config.py
       - name: Run tests
@@ -150,9 +150,10 @@ jobs:
         if: success() || failure()
         run: |
           find tests/isolated/ -name '*.py' -print0 | xargs -0 --verbose -n1 python tests/utils/pytest_wrapper.py --verbose
-      - name: Test quickstart
+      - name: Test quickstarts
         run: |
           fiftyone quickstart
+          fiftyone quickstart --video
 
   all-tests:
     needs: test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -141,8 +141,10 @@ jobs:
           pip install pytest tensorflow tensorflow-datasets
           pip install torch==1.6.0+cpu torchvision==0.7.0+cpu -f https://download.pytorch.org/whl/torch_stable.html
       - name: Configure fiftyone for tests
+        id: test_config
         run: |
           python tests/utils/setup_config.py
+          python tests/utils/github_actions_flags.py
       - name: Run tests
         run: |
           python tests/utils/pytest_wrapper.py tests/ --verbose --ignore tests/benchmarking/ --ignore tests/isolated/ --ignore tests/utils/ --ignore tests/import_export/
@@ -151,6 +153,7 @@ jobs:
         run: |
           find tests/isolated/ -name '*.py' -print0 | xargs -0 --verbose -n1 python tests/utils/pytest_wrapper.py --verbose
       - name: Test quickstarts
+        if: ${{ steps.test_config.outputs.run_integration }}
         env:
           PYTHONUNBUFFERED: 1
         run: |

--- a/package/gui/setup.py
+++ b/package/gui/setup.py
@@ -54,7 +54,9 @@ class CustomBdistWheel(bdist_wheel):
             self.bdist_dir, self.data_dir, "purelib", "fiftyone", "gui", "bin"
         )
 
-        if self.plat_name.startswith("linux"):
+        if os.environ.get("FIFTYONE_GUI_EXE_PATH"):
+            apps = [os.environ["FIFTYONE_GUI_EXE_PATH"]]
+        elif self.plat_name.startswith("linux"):
             apps = glob.glob(os.path.join(release_dir, "FiftyOne*.AppImage"))
         elif self.plat_name.startswith("mac"):
             apps = glob.glob(os.path.join(release_dir, "mac", "FiftyOne*.app"))

--- a/tests/utils/command_wrapper.py
+++ b/tests/utils/command_wrapper.py
@@ -1,14 +1,14 @@
 """
-Wrapper around pytest that cleans up subprocesses
+Wrapper around an arbitrary command that cleans up subprocesses
 """
 
+import subprocess
 import sys
 
 import psutil
-import pytest
 
 try:
-    code = pytest.main(sys.argv[1:])
+    subprocess.check_call(sys.argv[1:])
 finally:
     for child in reversed(psutil.Process().children(recursive=True)):
         try:
@@ -16,5 +16,3 @@ finally:
             child.wait()
         except psutil.Error:
             pass
-
-exit(code)

--- a/tests/utils/github_actions_flags.py
+++ b/tests/utils/github_actions_flags.py
@@ -1,0 +1,18 @@
+"""
+Sets up flags used by GitHub Actions to determine which tests to run.
+"""
+
+import os
+
+flags = {"run_integration": False}
+ref = os.environ.get("GITHUB_REF", "")
+
+if (
+    ref.startswith("refs/heads/rel-")
+    or ref.startswith("refs/heads/release-")
+    or ref.startswith("refs/tags/v")
+):
+    flags["run_integration"] = True
+
+for k, v in flags.items():
+    print("::set-output name=%s::%s" % (k, str(v).lower()))

--- a/tests/utils/github_actions_flags.py
+++ b/tests/utils/github_actions_flags.py
@@ -15,4 +15,6 @@ if (
     flags["run_integration"] = True
 
 for k, v in flags.items():
-    print("::set-output name=%s::%s" % (k, str(v).lower()))
+    v = str(v).lower()
+    print("flag %s = %s" % (k, v))
+    print("::set-output name=%s::%s" % (k, v))

--- a/tests/utils/setup_config.py
+++ b/tests/utils/setup_config.py
@@ -1,3 +1,7 @@
+import os
+
+os.environ["FIFTYONE_DISABLE_SERVICES"] = "1"
+
 from fiftyone import config
 from fiftyone.constants import FIFTYONE_CONFIG_PATH
 

--- a/tests/utils/setup_config.py
+++ b/tests/utils/setup_config.py
@@ -1,0 +1,5 @@
+from fiftyone import config
+from fiftyone.constants import FIFTYONE_CONFIG_PATH
+
+config.show_progress_bars = False
+config.write_json(FIFTYONE_CONFIG_PATH)


### PR DESCRIPTION
## What changes are proposed in this pull request?

* Some integration tests that run variations of `fiftyone quickstart`. These currently only run on release branches, but the logic could be customized to also run on commits matching a certain message, for instance. They also only test the backend currently (the app is replaced by a stub that immediately exits).
* Some additional test cleanup - fixed a couple warnings due to GitHub deprecating `set-env`, and a potential issue that could cause subprocesses to not shut down cleanly.

## How is this patch tested? If it is not, please explain why.

Several GitHub actions runs 

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [x] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
