### PR TITLE
Data model improvements

### DIFF
--- a/fiftyone/core/_sample.py
+++ b/fiftyone/core/_sample.py
@@ -173,18 +173,20 @@ class _Sample(object):
 
         Args:
             sample: a :class:`fiftyone.core.sample.Sample`
-            overwrite (True): whether to overwrite existing fields
+            overwrite (True): whether to overwrite existing fields. Note that
+                existing fields whose values are ``None`` are always
+                overwritten
         """
-        if overwrite:
-            for field_name, value in sample.iter_fields():
-                self.set_field(field_name, value)
-
-            return
-
         existing_field_names = self.field_names
         for field_name, value in sample.iter_fields():
-            if field_name not in existing_field_names:
-                self.set_field(field_name, value)
+            if (
+                not overwrite
+                and field_name in existing_field_names
+                and self[field_name] is not None
+            ):
+                continue
+
+            self.set_field(field_name, value)
 
     def copy(self):
         """Returns a deep copy of the sample that has not been added to the

--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -745,8 +745,7 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
         self._sample_collection.delete_one({"_id": ObjectId(sample_id)})
 
         fos.Sample._reset_backing_docs(
-            collection_name=self._sample_collection_name,
-            sample_ids=[sample_id],
+            self._sample_collection_name, [sample_id]
         )
 
     def remove_samples(self, samples_or_ids):
@@ -773,7 +772,7 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
         )
 
         fos.Sample._reset_backing_docs(
-            collection_name=self._sample_collection_name, sample_ids=sample_ids
+            self._sample_collection_name, sample_ids
         )
 
     def clone_field(self, field_name, new_field_name, samples=None):

--- a/fiftyone/core/document.py
+++ b/fiftyone/core/document.py
@@ -1,18 +1,24 @@
 """
-Generic interface for pseudo-documents.
+Base class for objects that are backed by database documents.
 
 | Copyright 2017-2020, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
-
 from copy import deepcopy
 
 import eta.core.serial as etas
 
 
-class _Sample(object):
-    """Base class for :class:`Sample` and :class:`SampleView`."""
+class Document(object):
+    """Base class for objects that are associated with
+    :class:`fiftyone.core.dataset.Dataset` instances and are backed by
+    documents in database collections.
+
+    Args:
+        dataset (None): the :class:`fiftyone.core.dataset.Dataset` to which the
+            document belongs
+    """
 
     def __init__(self, dataset=None):
         self._dataset = dataset
@@ -78,8 +84,20 @@ class _Sample(object):
         return self._doc.ingest_time
 
     @property
+    def in_dataset(self):
+        """Whether the document has been added to a dataset."""
+        return self.dataset is not None
+
+    @property
+    def dataset(self):
+        """The dataset to which this document belongs, or ``None`` if it has
+        not been added to a dataset.
+        """
+        return self._dataset
+
+    @property
     def field_names(self):
-        """An ordered tuple of the names of the fields of this sample."""
+        """An ordered tuple of the names of the fields of this document."""
         return self._doc.field_names
 
     @property
@@ -90,12 +108,14 @@ class _Sample(object):
         return self._doc.in_db
 
     @property
-    def _immutable_field_names(self):
-        """A tuple of names of immutable fields."""
+    def _skip_iter_field_names(self):
+        """A tuple of names of fields to skip when :meth:`iter_fields` is
+        called.
+        """
         return tuple()
 
     def get_field(self, field_name):
-        """Accesses the value of a field of the sample.
+        """Gets the value of a field of the document.
 
         Args:
             field_name: the field name
@@ -109,7 +129,7 @@ class _Sample(object):
         return self._doc.get_field(field_name)
 
     def set_field(self, field_name, value, create=True):
-        """Sets the value of a field of the sample.
+        """Sets the value of a field of the document.
 
         Args:
             field_name: the field name
@@ -129,7 +149,7 @@ class _Sample(object):
         self._doc.set_field(field_name, value, create=create)
 
     def update_fields(self, fields_dict, create=True):
-        """Sets the dictionary of fields on the sample.
+        """Sets the dictionary of fields on the document.
 
         Args:
             fields_dict: a dict mapping field names to values
@@ -139,7 +159,7 @@ class _Sample(object):
             self.set_field(field_name, value, create=create)
 
     def clear_field(self, field_name):
-        """Clears the value of a field of the sample.
+        """Clears the value of a field of the document.
 
         Args:
             field_name: the name of the field to clear
@@ -149,36 +169,30 @@ class _Sample(object):
         """
         self._doc.clear_field(field_name=field_name)
 
-    def iter_fields(self, include_immutable=False):
+    def iter_fields(self):
         """Returns an iterator over the ``(name, value)`` pairs of the fields
-        of the sample.
-
-        Args:
-            include_immutable (False): whether to include immutable fields
+        of the document.
 
         Returns:
             an iterator that emits ``(name, value)`` tuples
         """
-        field_names = self.field_names
-        if not include_immutable:
-            field_names = tuple(
-                f for f in field_names if f not in self._immutable_field_names
-            )
-
+        field_names = tuple(
+            f for f in self.field_names if f not in self._skip_iter_field_names
+        )
         for field_name in field_names:
             yield field_name, self.get_field(field_name)
 
-    def merge(self, sample, overwrite=True):
-        """Merges the fields of the sample into this sample.
+    def merge(self, document, overwrite=True):
+        """Merges the fields of the document into this document.
 
         Args:
-            sample: a :class:`fiftyone.core.sample.Sample`
+            document: a :class:`Document` of the same type
             overwrite (True): whether to overwrite existing fields. Note that
                 existing fields whose values are ``None`` are always
                 overwritten
         """
         existing_field_names = self.field_names
-        for field_name, value in sample.iter_fields():
+        for field_name, value in document.iter_fields():
             if (
                 not overwrite
                 and field_name in existing_field_names
@@ -189,17 +203,17 @@ class _Sample(object):
             self.set_field(field_name, value)
 
     def copy(self):
-        """Returns a deep copy of the sample that has not been added to the
+        """Returns a deep copy of the document that has not been added to the
         database.
 
         Returns:
-            a :class:`Sample`
+            a :class:`Document`
         """
-        kwargs = {f: deepcopy(self[f]) for f in self.field_names}
+        kwargs = {k: deepcopy(v) for k, v in self.iter_fields()}
         return self.__class__(**kwargs)
 
     def to_dict(self):
-        """Serializes the sample to a JSON dictionary.
+        """Serializes the document to a JSON dictionary.
 
         Sample IDs and private fields are excluded in this representation.
 
@@ -210,7 +224,7 @@ class _Sample(object):
         return {k: v for k, v in d.items() if not k.startswith("_")}
 
     def to_json(self, pretty_print=False):
-        """Serializes the sample to a JSON string.
+        """Serializes the document to a JSON string.
 
         Sample IDs and private fields are excluded in this representation.
 
@@ -224,7 +238,7 @@ class _Sample(object):
         return etas.json_to_str(self.to_dict(), pretty_print=pretty_print)
 
     def to_mongo_dict(self):
-        """Serializes the sample to a BSON dictionary equivalent to the
+        """Serializes the document to a BSON dictionary equivalent to the
         representation that would be stored in the database.
 
         Returns:
@@ -233,101 +247,45 @@ class _Sample(object):
         return self._doc.to_dict(extended=False)
 
     def save(self):
-        """Saves the sample to the database."""
+        """Saves the document to the database."""
         self._doc.save()
 
     def reload(self):
-        """Reloads the sample from the database."""
+        """Reloads the document from the database."""
         self._doc.reload()
 
     def _delete(self):
         """Deletes the document from the database."""
         self._doc.delete()
 
-    @property
-    def in_dataset(self):
-        """Whether the sample has been added to a dataset."""
-        return self.dataset is not None
-
-    @property
-    def dataset(self):
-        """The dataset to which this sample belongs, or ``None`` if it has not
-        been added to a dataset.
-        """
-        return self._dataset
-
     @classmethod
     def from_dict(cls, d):
-        """Loads the sample from a JSON dictionary.
+        """Loads the document from a JSON dictionary.
 
-        The returned sample will not belong to a dataset.
+        The returned document will not belong to a dataset.
 
         Returns:
-            a :class:`Sample`
+            a :class:`Document`
         """
         doc = cls._NO_COLL_CLS.from_dict(d, extended=True)
         return cls.from_doc(doc)
 
     @classmethod
     def from_json(cls, s):
-        """Loads the sample from a JSON string.
+        """Loads the document from a JSON string.
 
         Args:
             s: the JSON string
 
         Returns:
-            a :class:`Sample`
+            a :class:`Document`
         """
         doc = cls._NO_COLL_CL.from_json(s)
         return cls.from_doc(doc)
 
     @classmethod
-    def _save_dataset_samples(cls, collection_name):
-        """Saves all changes to in-memory sample instances that belong to the
-        specified collection.
-
-        Args:
-            collection_name: the name of the MongoDB collection
-        """
-        for sample in cls._instances[collection_name].values():
-            sample.save()
-
-    @classmethod
-    def _reload_dataset_sample(cls, collection_name, sample_id):
-        """Reloads the fields for the in-memory sample instance that belong to
-        the specified collection.
-
-        If the sample does not exist in-memory, nothing is done.
-
-        Args:
-            collection_name: the name of the MongoDB collection
-            sample_id: the sample ID
-
-        Returns:
-            True/False whether the sample was reloaded
-        """
-        dataset_instances = cls._instances[collection_name]
-        sample = dataset_instances.get(sample_id, None)
-        if sample:
-            sample.reload()
-            return True
-
-        return False
-
-    @classmethod
-    def _reload_dataset_samples(cls, collection_name):
-        """Reloads the fields for in-memory sample instances that belong to the
-        specified collection.
-
-        Args:
-            collection_name: the name of the MongoDB collection
-        """
-        for sample in cls._instances[collection_name].values():
-            sample.reload()
-
-    @classmethod
     def _rename_field(cls, collection_name, field_name, new_field_name):
-        """Renames any field values for in-memory sample instances that belong
+        """Renames any field values for in-memory document instances that belong
         to the specified collection.
 
         Args:
@@ -335,29 +293,29 @@ class _Sample(object):
             field_name: the name of the field to rename
             new_field_name: the new field name
         """
-        for sample in cls._instances[collection_name].values():
-            data = sample._doc._data
+        for document in cls._instances[collection_name].values():
+            data = document._doc._data
             data[new_field_name] = data.pop(field_name, None)
 
     @classmethod
     def _purge_field(cls, collection_name, field_name):
-        """Removes values for the given field from all in-memory sample
+        """Removes values for the given field from all in-memory document
         instances that belong to the specified collection.
 
         Args:
             collection_name: the name of the MongoDB collection
             field_name: the name of the field to purge
         """
-        for sample in cls._instances[collection_name].values():
-            sample._doc._data.pop(field_name, None)
+        for document in cls._instances[collection_name].values():
+            document._doc._data.pop(field_name, None)
 
     def _set_backing_doc(self, doc, dataset=None):
-        """Sets the backing doc for the sample.
+        """Sets the backing doc for the document.
 
         Args:
             doc: a :class:`fiftyone.core.odm.SampleDocument`
             dataset (None): the :class:`fiftyone.core.dataset.Dataset` to which
-                the sample belongs, if any
+                the document belongs, if any
         """
         # Ensure the doc is saved to the database
         if not doc.id:
@@ -373,25 +331,22 @@ class _Sample(object):
         self._dataset = dataset
 
     @classmethod
-    def _reset_backing_docs(cls, collection_name, sample_ids):
-        """Resets the samples' backing documents to
-        :class:`fiftyone.core.odm.NoDatasetSampleDocument` instances.
+    def _reset_backing_docs(cls, collection_name, doc_ids):
+        """Resets the document(s) backing documents.
 
         Args:
             collection_name: the name of the MongoDB collection
-            sample_ids: a list of sample IDs
+            doc_ids: a list of document IDs
         """
         dataset_instances = cls._instances[collection_name]
-        for sample_id in sample_ids:
-            sample = dataset_instances.pop(sample_id, None)
-            if sample is not None:
-                sample._reset_backing_doc()
+        for doc_id in doc_ids:
+            document = dataset_instances.pop(doc_id, None)
+            if document is not None:
+                document._reset_backing_doc()
 
     @classmethod
     def _reset_all_backing_docs(cls, collection_name):
-        """Resets the sample's backing document to a
-        :class:`fiftyone.core.odm.NoDatasetSampleDocument` instance for all
-        samples in the specified collection.
+        """Resets the backing documents for all documents in the collection.
 
         Args:
             collection_name: the name of the MongoDB collection
@@ -400,8 +355,8 @@ class _Sample(object):
             return
 
         dataset_instances = cls._instances.pop(collection_name)
-        for sample in dataset_instances.values():
-            sample._reset_backing_doc()
+        for document in dataset_instances.values():
+            document._reset_backing_doc()
 
     def _reset_backing_doc(self):
         self._doc = self.copy()._doc

--- a/fiftyone/core/fields.py
+++ b/fiftyone/core/fields.py
@@ -83,13 +83,10 @@ class FrameNumberField(IntField):
     """A video frame number field."""
 
     def validate(self, value):
-        if not isinstance(value, six.integer_types):
-            self.error("Frame numbers must be integers; found %s" % value)
-
-        if value < 1:
-            self.error(
-                "Frame numbers must be 1-based integers; found %s" % value
-            )
+        try:
+            fofu.validate_frame_number(value)
+        except fofu.FrameError as e:
+            self.error(str(e))
 
 
 class FloatField(mongoengine.FloatField, Field):
@@ -272,12 +269,6 @@ class FramesField(mongoengine.fields.MapField, Field):
             mongoengine.fields.ReferenceField(self._frame_doc_cls),
             db_field="frames",
         )
-
-    def validate(self, value):
-        try:
-            fofu.is_frame_number(value)
-        except fofu.FrameError as e:
-            self.error(str(e))
 
 
 class EmbeddedDocumentField(mongoengine.EmbeddedDocumentField, Field):

--- a/fiftyone/core/frame.py
+++ b/fiftyone/core/frame.py
@@ -8,7 +8,7 @@ Video frames.
 from collections import defaultdict
 import weakref
 
-from fiftyone.core._sample import _Sample
+from fiftyone.core.document import Document
 import fiftyone.core.frame_utils as fofu
 import fiftyone.core.utils as fou
 
@@ -187,7 +187,7 @@ class Frames(object):
         return self._sample._doc.frames.__class__
 
 
-class Frame(_Sample):
+class Frame(Document):
     """A frame in a video :class:`fiftyone.core.sample.Sample`.
 
     :class:`Frame` instances can hold any :class:`fiftyone.core.label.Label`

--- a/fiftyone/core/frame.py
+++ b/fiftyone/core/frame.py
@@ -177,7 +177,10 @@ class Frames(object):
             overwrite (True): whether to overwrite existing fields
         """
         for frame_number, frame in frames.items():
-            self[frame_number].merge(frame, overwrite=overwrite)
+            if frame_number in self:
+                self[frame_number].merge(frame, overwrite=overwrite)
+            else:
+                self[frame_number] = frame
 
     def _serve(self, sample):
         self._sample = sample

--- a/fiftyone/core/frame_utils.py
+++ b/fiftyone/core/frame_utils.py
@@ -7,6 +7,8 @@ Frame utilites.
 """
 import six
 
+import eta.core.utils as etau
+
 
 def is_frame_number(value):
     """Determines whether the provided value is a frame number.
@@ -23,19 +25,17 @@ def is_frame_number(value):
         :class:`FrameError` if ``value`` is an integer but is not strictly
         positive
     """
-    if isinstance(value, six.integer_types):
-        if value < 1:
-            raise FrameError(
-                "Frame numbers must be 1-based integers; found %s" % value
-            )
-
+    try:
+        validate_frame_number(value)
         return True
-
-    return False
+    except:
+        return False
 
 
 def validate_frame_number(value):
     """Validates that the provided value is a frame number.
+
+    Frame numbers are strictly positive integers.
 
     Args:
         value: a value
@@ -43,7 +43,12 @@ def validate_frame_number(value):
     Raises:
         :class:`FrameError` if ``value`` is not a frame number
     """
-    if not isinstance(value, six.integer_types) or value < 1:
+    if not isinstance(value, six.integer_types):
+        raise FrameError(
+            "Frame numbers must be integers; found %s" % type(value)
+        )
+
+    if value < 1:
         raise FrameError(
             "Frame numbers must be 1-based integers; found %s" % value
         )

--- a/fiftyone/core/frame_utils.py
+++ b/fiftyone/core/frame_utils.py
@@ -25,11 +25,15 @@ def is_frame_number(value):
         :class:`FrameError` if ``value`` is an integer but is not strictly
         positive
     """
-    try:
-        validate_frame_number(value)
+    if isinstance(value, six.integer_types):
+        if value < 1:
+            raise FrameError(
+                "Frame numbers must be integers; found %s" % type(value)
+            )
+
         return True
-    except:
-        return False
+
+    return False
 
 
 def validate_frame_number(value):

--- a/fiftyone/core/frame_utils.py
+++ b/fiftyone/core/frame_utils.py
@@ -7,8 +7,6 @@ Frame utilites.
 """
 import six
 
-import eta.core.utils as etau
-
 
 def is_frame_number(value):
     """Determines whether the provided value is a frame number.

--- a/fiftyone/core/odm/frame.py
+++ b/fiftyone/core/odm/frame.py
@@ -1,49 +1,6 @@
 """
 Backing document classes for :class:`fiftyone.core.frame.Frame` instances.
 
-Class hierarchy::
-
-    SampleDocument
-    ├── NoDatasetFrameSampleDocument
-    └── DatasetFrameSampleDocument
-        ├── my_custom_dataset
-        ├── another_dataset
-        └── ...
-
-Design invariants:
-
--   A :class:`fiftyone.core.frame.Frame` always has a backing
-    ``frame._doc``, which is an instance of a subclass of
-    :class:`SampleDocument`
-
--   A :class:`fiftyone.core.dataset.Dataset` of media_type "video" always has
-    a backing ``dataset._frame_doc_cls`` which is a subclass of
-    :class:`DatasetFrameSampleDocument``.
-
-**Implementation details**
-
-When a new :class:`fiftyone.core.frame.Frame` is created, its ``_doc``
-attribute is an instance of :class:`NoDatasetFrameSampleDocument`::
-
-    import fiftyone as fo
-
-    frame = fo.Frame()
-    frame._doc  # NoDatasetFrameSampleDocument
-
-When a new :class:`fiftyone.core.dataset.Dataset` is assigned the "video" media
-type, its ``_frame_doc_cls`` attribute holds a dynamically created subclass of
-:class:`DatasetFrameSampleDocument`::
-
-    dataset = fo.Dataset(name="my_dataset")
-    dataset._frame_doc_cls  # time stamped name
-
-When a frame is added to a sample that is in a dataset, its ``_doc`` attribute
-is changed from type :class:`NoDatasetSampleDocument` to type
-``dataset._frame_doc_cls``::
-
-    sample_in_dataset[frame_numer] = frame
-    frame._doc.__name__  # sample.dataset._frame_doc_cls
-
 | Copyright 2017-2020, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |

--- a/fiftyone/core/odm/mixins.py
+++ b/fiftyone/core/odm/mixins.py
@@ -85,7 +85,7 @@ def no_delete_default_field(func):
 
 class DatasetMixin(object):
     """Mixin for concrete :class:`fiftyone.core.odm.document.SampleDocument`
-    subtypes that are backed by a dataset
+    subtypes that are backed by a dataset.
     """
 
     def __setattr__(self, name, value):

--- a/fiftyone/core/odm/sample.py
+++ b/fiftyone/core/odm/sample.py
@@ -102,6 +102,7 @@ class DatasetSampleDocument(DatasetMixin, Document, SampleDocument):
     meta = {"abstract": True}
 
     media_type = fof.StringField()
+
     # The path to the data on disk
     filepath = fof.StringField(unique=True)
 
@@ -113,12 +114,6 @@ class DatasetSampleDocument(DatasetMixin, Document, SampleDocument):
 
     # Random float used for random dataset operations (e.g. shuffle)
     _rand = fof.FloatField(default=_generate_rand)
-
-    def set_field(self, field_name, value, create=True):
-        if field_name == "frames" and isinstance(value, fofr.Frames):
-            value = value.doc.frames
-
-        super().set_field(field_name, value, create=create)
 
 
 class NoDatasetSampleDocument(NoDatasetMixin, SampleDocument):
@@ -138,13 +133,13 @@ class NoDatasetSampleDocument(NoDatasetMixin, SampleDocument):
         media_type = fomm.get_media_type(filepath)
         if "media_type" in kwargs and kwargs["media_type"] != media_type:
             raise fomm.MediaTypeError("media_type cannot be set")
+
         kwargs["media_type"] = media_type
 
         if media_type == fomm.VIDEO:
             kwargs["frames"] = {}
 
         for field_name in self.default_fields_ordered:
-
             value = kwargs.pop(field_name, None)
 
             if field_name == "_rand":
@@ -159,9 +154,3 @@ class NoDatasetSampleDocument(NoDatasetMixin, SampleDocument):
             self._data[field_name] = value
 
         self._data.update(kwargs)
-
-    def set_field(self, field_name, value, create=True):
-        if field_name == "frames" and isinstance(value, fofr.Frames):
-            value = value.doc.frames
-
-        super().set_field(field_name, value, create=create)

--- a/fiftyone/core/sample.py
+++ b/fiftyone/core/sample.py
@@ -83,14 +83,6 @@ class _DatasetSample(Document):
         super().set_field(field_name, value, create=create)
 
     def clear_field(self, field_name):
-        """Clears the value of a field of the sample.
-
-        Args:
-            field_name: the name of the field to clear
-
-        Raises:
-            ValueError: if the field does not exist
-        """
         if field_name == "frames" and self.media_type == fomm.VIDEO:
             # @todo support `clear_field("frames")`
             raise ValueError("Clearing frames is not yet supported")

--- a/fiftyone/core/sample.py
+++ b/fiftyone/core/sample.py
@@ -58,6 +58,10 @@ class _DatasetSample(_Sample):
         """The basename of the data filepath."""
         return os.path.basename(self.filepath)
 
+    @property
+    def _immutable_field_names(self):
+        return ("media_type",)
+
     def compute_metadata(self):
         """Populates the ``metadata`` field of the sample."""
         if self.media_type == fomm.IMAGE:

--- a/fiftyone/core/sample.py
+++ b/fiftyone/core/sample.py
@@ -15,28 +15,32 @@ import eta.core.serial as etas
 import eta.core.utils as etau
 import eta.core.video as etav
 
+from fiftyone.core.document import Document
 import fiftyone.core.fields as fof
 import fiftyone.core.frame as fofr
 import fiftyone.core.frame_utils as fofu
 import fiftyone.core.metadata as fom
 import fiftyone.core.media as fomm
 import fiftyone.core.odm as foo
-from fiftyone.core._sample import _Sample
 
 
-class _DatasetSample(_Sample):
+class _DatasetSample(Document):
     def __getattr__(self, name):
         if name == "frames" and self.media_type == fomm.VIDEO:
             return self._frames._serve(self)
 
         return super().__getattr__(name)
 
+    def __setattr__(self, name, value):
+        if name == "frames" and self.media_type == fomm.VIDEO:
+            # @todo support `__setattr__("frames", value)`
+            raise ValueError("Setting frames is not yet supported")
+
+        super().__setattr__(name, value)
+
     def __getitem__(self, field_name):
         if fofu.is_frame_number(field_name) and self.media_type == fomm.VIDEO:
             return self.frames[field_name]
-
-        if field_name == "frames" and self.media_type == fomm.VIDEO:
-            return self._frames._serve(self)
 
         try:
             return self.get_field(field_name)
@@ -55,12 +59,43 @@ class _DatasetSample(_Sample):
 
     @property
     def filename(self):
-        """The basename of the data filepath."""
+        """The basename of the media's filepath."""
         return os.path.basename(self.filepath)
 
     @property
-    def _immutable_field_names(self):
+    def _skip_iter_field_names(self):
+        if self.media_type == fomm.VIDEO:
+            return ("media_type", "frames")
+
         return ("media_type",)
+
+    def get_field(self, field_name):
+        if field_name == "frames" and self.media_type == fomm.VIDEO:
+            return self._frames._serve(self)
+
+        return super().get_field(field_name)
+
+    def set_field(self, field_name, value, create=True):
+        if field_name == "frames" and self.media_type == fomm.VIDEO:
+            # @todo support `set_field("frames")`
+            raise ValueError("Setting frames is not yet supported")
+
+        super().set_field(field_name, value, create=create)
+
+    def clear_field(self, field_name):
+        """Clears the value of a field of the sample.
+
+        Args:
+            field_name: the name of the field to clear
+
+        Raises:
+            ValueError: if the field does not exist
+        """
+        if field_name == "frames" and self.media_type == fomm.VIDEO:
+            # @todo support `clear_field("frames")`
+            raise ValueError("Clearing frames is not yet supported")
+
+        super().clear_field(field_name)
 
     def compute_metadata(self):
         """Populates the ``metadata`` field of the sample."""
@@ -72,6 +107,26 @@ class _DatasetSample(_Sample):
             self.metadata = fom.Metadata.build_for(self.filepath)
 
         self.save()
+
+    def merge(self, sample, overwrite=True):
+        """Merges the fields of the sample into this sample.
+
+        Args:
+            sample: a :class:`fiftyone.core.sample.Sample`
+            overwrite (True): whether to overwrite existing fields. Note that
+                existing fields whose values are ``None`` are always
+                overwritten
+        """
+        if sample.media_type != self.media_type:
+            raise ValueError(
+                "Cannot merge sample with media type '%s' into sample with "
+                "media type '%s'" % (sample.media_type, self.media_type)
+            )
+
+        super().merge(sample, overwrite=overwrite)
+
+        if self.media_type == fomm.VIDEO:
+            self.frames.merge(sample.frames, overwrite=overwrite)
 
     def _secure_media(self, field_name, value):
         if field_name == "media_type" and value != self.media_type:
@@ -160,18 +215,21 @@ class Sample(_DatasetSample):
         Returns:
             a :class:`Sample`
         """
-        video = self.media_type == fomm.VIDEO
-        kwargs = {
-            f: deepcopy(self[f])
-            for f in self.field_names
-            if f != "frames" or not video
-        }
-        if video:
-            kwargs["frames"] = {
-                str(k): v.copy()._doc for k, v in self.frames.items()
-            }
+        kwargs = {k: deepcopy(v) for k, v in self.iter_fields()}
+        sample = self.__class__(**kwargs)
 
-        return self.__class__(**kwargs)
+        if self.media_type == fomm.VIDEO:
+            sample.frames.update({k: v.copy() for k, v in self.frames.items()})
+
+        return sample
+
+    def save(self):
+        """Saves the sample to the database."""
+        if self.media_type == fomm.VIDEO:
+            for frame in self.frames.values():
+                frame.save()  # @todo batch
+
+        super().save()
 
     @classmethod
     def from_doc(cls, doc, dataset=None):
@@ -282,40 +340,7 @@ class Sample(_DatasetSample):
         for sample in cls._instances[collection_name].values():
             sample.reload()
 
-    @classmethod
-    def _rename_field(cls, collection_name, field_name, new_field_name):
-        """Renames any field values for in-memory sample instances that belong
-        to the specified collection.
-
-        Args:
-            collection_name: the name of the MongoDB collection
-            field_name: the name of the field to rename
-            new_field_name: the new field name
-        """
-        for sample in cls._instances[collection_name].values():
-            data = sample._doc._data
-            data[new_field_name] = data.pop(field_name, None)
-
-    @classmethod
-    def _purge_field(cls, collection_name, field_name):
-        """Removes values for the given field from all in-memory sample
-        instances that belong to the specified collection.
-
-        Args:
-            collection_name: the name of the MongoDB collection
-            field_name: the name of the field to purge
-        """
-        for sample in cls._instances[collection_name].values():
-            sample._doc._data.pop(field_name, None)
-
     def _set_backing_doc(self, doc, dataset=None):
-        """Sets the backing doc for the sample.
-
-        Args:
-            doc: a :class:`fiftyone.core.odm.SampleDocument`
-            dataset (None): the :class:`fiftyone.core.dataset.Dataset` to which
-                the sample belongs, if any
-        """
         if isinstance(self._doc, foo.DatasetSampleDocument):
             raise TypeError("Sample already belongs to a dataset")
 
@@ -325,60 +350,7 @@ class Sample(_DatasetSample):
                 % (foo.DatasetSampleDocument, type(doc))
             )
 
-        # Ensure the doc is saved to the database
-        if not doc.id:
-            doc.save()
-
-        self._doc = doc
-
-        # Save weak reference
-        dataset_instances = self._instances[doc.collection_name]
-        if self.id not in dataset_instances:
-            dataset_instances[self.id] = self
-
-        self._dataset = dataset
-
-    @classmethod
-    def _reset_backing_docs(cls, collection_name, sample_ids):
-        """Resets the samples' backing documents to
-        :class:`fiftyone.core.odm.NoDatasetSampleDocument` instances.
-
-        Args:
-            collection_name: the name of the MongoDB collection
-            sample_ids: a list of sample IDs
-        """
-        dataset_instances = cls._instances[collection_name]
-        for sample_id in sample_ids:
-            sample = dataset_instances.pop(sample_id, None)
-            if sample is not None:
-                sample._reset_backing_doc()
-
-    @classmethod
-    def _reset_all_backing_docs(cls, collection_name):
-        """Resets the sample's backing document to a
-        :class:`fiftyone.core.odm.NoDatasetSampleDocument` instance for all
-        samples in the specified collection.
-
-        Args:
-            collection_name: the name of the MongoDB collection
-        """
-        if collection_name not in cls._instances:
-            return
-
-        dataset_instances = cls._instances.pop(collection_name)
-        for sample in dataset_instances.values():
-            sample._reset_backing_doc()
-
-    def _reset_backing_doc(self):
-        self._doc = self.copy()._doc
-        self._dataset = None
-
-    def save(self):
-        """Saves the sample to the database."""
-        if self.media_type == fomm.VIDEO:
-            for frame in self.frames.values():
-                frame.save()  # @todo batch
-        super().save()
+        super()._set_backing_doc(doc, dataset=dataset)
 
 
 class SampleView(_DatasetSample):


### PR DESCRIPTION
Change log:
- Renames `fiftyone.core._sample._Sample` to `fiftyone.core.document.Document`, to reflect the fact that this class is a base class for all user-facing objects backed by documents in the DB
- Adds a `Document.merge()` method for merging fields of arbitrary `fiftyone.core.document.Document` instances together
- Updates `Dataset.merge_samples()` to properly merge the frame-by-frame contents of video samples
- Fixes a bug where `sample.copy()` would not create a copy of the `frames` of a video sample
- Adds a variety of usability improvements to `sample.frames` for video samples, including:
    - `print(sample.frames)` will print the actual frame contents (`repr(sample.frames)` still just shows # frames, for readability)
    - `frame_number in sample.frames # True/False` now works
    - Adds a `sample.frames.update(new_frames)` method to set entire `Frame`s
    - Adds a `sample.frames.merge(other_frames)` method, which will merge fields of `Frame`s
- Raises informative errors for `frames`-related operations that are not yet supported for video samples, such as clearing, setting the entire object, etc
- Removes various bits of duplicate/unnecessary code throughout

I'll note that all of this functionality really needs thorough unit tests. The video release introduced quite a few bugs relating to video samples and the `Dataset`/`Sample` interfaces, but no unit tests existed to really enforce the details of desired behavior around copying, merging, getting/settting/iterating fields, etc...

Example of merging video samples:

```py

import fiftyone as fo

sample1 = fo.Sample(filepath="video.mp4")
sample1.frames[1] = fo.Frame(
    gt=fo.Classification(label="cat"),
    pred=fo.Classification(label="dog"),
)

sample2 = fo.Sample(filepath="video.mp4")
sample2.frames[1] = fo.Frame(
    gt=fo.Classification(label="kitten"),
    other_pred=fo.Classification(label="doggo"),
)

dataset = fo.Dataset()
dataset.add_sample(sample1)

# Merge the samples, which will merge the frame-by-frame labels, NOT
# overwriting any existing values
dataset.merge_samples([sample2])
print(dataset.first())
print(dataset.first().frames)

# Merge again, but this time overwrite existing values
dataset.merge_samples([sample2], overwrite=True)
print(dataset.first())
print(dataset.first().frames)
```
