### PR TITLE
Adding scikit-image as dependency

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -11,6 +11,7 @@ psutil==5.7.0
 pymongo==3.10.1
 python-engineio[client]==3.12.1
 python-socketio[client]==4.5.1
+scikit-image==0.16.2
 setuptools==45.2.0
 tabulate==0.8.5
 xmltodict==0.12.0

--- a/setup.py
+++ b/setup.py
@@ -58,6 +58,7 @@ setup(
         "python-engineio[client]",
         "python-socketio[client]",
         "retrying",
+        "scikit-image",
         "setuptools",
         "tabulate",
         "xmltodict",


### PR DESCRIPTION
https://github.com/voxel51/fiftyone/pull/594 added a dependency on `scikit-image` in `fiftyone/utils/coco.py`.

This is also a dependency of (the bleeding edge `develop` of) ETA, so will be implicitly available for future releases. However, for completeness, it should be added as an explicit dependency of `fiftyone` itself.

Unlike `scikit-learn`, this package is pretty small at only 17.2MB for the version I just downloaded, so it shouldn't be an issue to force all users to install this. However, if we don't want this explicit dependency, we could adopt a `fou.lazy_import("skimage.measure")` strategy for importing this library JIT, as per things like `pycocotools`.