### PR TITLE
Fix label counts for video datasets in the App

### DIFF
--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -264,7 +264,7 @@ class SampleCollection(object):
         if etau.is_str(field_or_fields):
             field_or_fields = [field_or_fields]
 
-        schema = self.get_field_schema()
+        schema = self.get_field_schema(include_private=True)
         default_fields = set(
             default_sample_fields(
                 DatasetSampleDocument, include_private=True, include_id=True

--- a/fiftyone/core/state.py
+++ b/fiftyone/core/state.py
@@ -236,7 +236,7 @@ def get_view_stats(dataset_or_view):
     else:
         view = dataset_or_view
 
-    custom_fields_schema = view.get_field_schema().copy()
+    custom_fields_schema = view.get_field_schema(include_private=True).copy()
     for field_name in fod.Dataset.get_default_sample_fields(
         include_private=True
     ):
@@ -408,7 +408,9 @@ def _get_field_count(view, field, prefix=""):
         prefix += "."
     if view.media_type == fom.VIDEO and field.name == "frames":
         view = view._with_frames()
-        custom_fields_schema = view.get_frame_field_schema().copy()
+        custom_fields_schema = view.get_frame_field_schema(
+            include_private=True
+        ).copy()
         for frame_field_name in fod.Dataset.get_default_frame_fields(
             include_private=True
         ):
@@ -438,6 +440,7 @@ def _get_field_count(view, field, prefix=""):
             array_field += "%s.points" % array_field
         else:
             array_field = None
+
         if array_field:
             # sum of lengths of arrays for each document
             pipeline = [

--- a/fiftyone/utils/data/parsers.py
+++ b/fiftyone/utils/data/parsers.py
@@ -221,8 +221,10 @@ def add_videos(dataset, samples, sample_parser, tags=None):
         num_samples = None
 
     _samples = map(parse_sample, samples)
+
+    # @todo: skip schema expansion and set media type before adding samples
     return dataset.add_samples(
-        _samples, num_samples=num_samples, expand_schema=False
+        _samples, num_samples=num_samples, expand_schema=True
     )
 
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

Label counts are not computed on `develop` for video datasets . This fixes that.

Introduced by https://github.com/voxel51/fiftyone/commit/114351f1a38a96143cb631eb3215a0ec90138bac.

![Screenshot from 2020-10-15 15-55-43](https://user-images.githubusercontent.com/19821840/96179703-46ab1a80-0eff-11eb-8c91-8186a7c8499f.png)

## How is this patch tested? If it is not, please explain why.

Locally.

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?
-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.