### PR TITLE
Adding support for only including samples that match filters

### DIFF
--- a/docs/source/user_guide/using_views.rst
+++ b/docs/source/user_guide/using_views.rst
@@ -408,6 +408,14 @@ Here are some examples for each task:
                 "my_classifications", (F("confidence") > 0.5) & (F("label") == "friend")
             )
 
+            # Same as above, but only include samples with at least one classification
+            # after filtering
+            confident_friends_view = dataset.filter_classifications(
+                "my_classifications",
+                (F("confidence") > 0.5) & (F("label") == "friend"),
+                only_matches=True,
+            )
+
     .. tab:: Detections
 
         .. code-block:: python
@@ -417,6 +425,14 @@ Here are some examples for each task:
             # whose bounding boxes have an area of at least 0.5
             large_boxes_view = dataset.filter_detections(
                 "my_detections", F("bounding_box")[2] * F("bounding_box")[3] >= 0.5
+            )
+
+            # Same as above, but only include samples with at least one detection
+            # after filtering
+            large_boxes_view = dataset.filter_detections(
+                "my_detections",
+                F("bounding_box")[2] * F("bounding_box")[3] >= 0.5,
+                only_matches=True,
             )
 
     .. tab:: Polylines
@@ -430,6 +446,12 @@ Here are some examples for each task:
                 "my_polylines", F("filled")
             )
 
+            # Same as above, but only include samples with at least one polyline
+            # after filtering
+            filled_polygons_view = dataset.filter_polylines(
+                "my_polylines", F("filled"), only_matches=True
+            )
+
     .. tab:: Keypoints
 
         .. code-block:: python
@@ -439,6 +461,12 @@ Here are some examples for each task:
             # that have at least 10 vertices
             many_points_view = dataset.filter_keypoints(
                 "my_keypoints", F("points").length() >= 10
+            )
+
+            # Same as above, but only include samples with at least one keypoint
+            # after filtering
+            many_points_view = dataset.filter_keypoints(
+                "my_keypoints", F("points").length() >= 10, only_matches=True
             )
 
 You can also use the :meth:`filter_field() <fiftyone.core.view.DatasetView.filter_field>`

--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -493,7 +493,7 @@ class SampleCollection(object):
         return self._add_view_stage(fos.Exists(field, bool=bool))
 
     @view_stage
-    def filter_field(self, field, filter):
+    def filter_field(self, field, filter, only_matches=False):
         """Filters the values of the given field of the samples.
 
         Values of ``field`` for which ``filter`` returns ``False`` are
@@ -526,14 +526,18 @@ class SampleCollection(object):
             filter: a :class:`fiftyone.core.expressions.ViewExpression` or
                 `MongoDB expression <https://docs.mongodb.com/manual/meta/aggregation-quick-reference/#aggregation-expressions>`_
                 that returns a boolean describing the filter to apply
+            only_matches (False): whether to only include samples that match
+                the filter
 
         Returns:
             a :class:`fiftyone.core.view.DatasetView`
         """
-        return self._add_view_stage(fos.FilterField(field, filter))
+        return self._add_view_stage(
+            fos.FilterField(field, filter, only_matches=only_matches)
+        )
 
     @view_stage
-    def filter_classifications(self, field, filter):
+    def filter_classifications(self, field, filter, only_matches=False):
         """Filters the classifications of the given
         :class:`fiftyone.core.labels.Classifications` field.
 
@@ -558,11 +562,12 @@ class SampleCollection(object):
 
             #
             # Only include classifications in the `predictions` field whose
-            # `label` is "cat" or "dog"
+            # `label` is "cat" or "dog", and only show samples with at least
+            # one classification after filtering
             #
 
             view = dataset.filter_classifications(
-                "predictions", F("label").is_in(["cat", "dog"])
+                "predictions", F("label").is_in(["cat", "dog"]), only_matches=True
             )
 
         Args:
@@ -570,14 +575,18 @@ class SampleCollection(object):
             filter: a :class:`fiftyone.core.expressions.ViewExpression` or
                 `MongoDB expression <https://docs.mongodb.com/manual/meta/aggregation-quick-reference/#aggregation-expressions>`_
                 that returns a boolean describing the filter to apply
+            only_matches (False): whether to only include samples with at least
+                one classification after filtering
 
         Returns:
             a :class:`fiftyone.core.view.DatasetView`
         """
-        return self._add_view_stage(fos.FilterClassifications(field, filter))
+        return self._add_view_stage(
+            fos.FilterClassifications(field, filter, only_matches=only_matches)
+        )
 
     @view_stage
-    def filter_detections(self, field, filter):
+    def filter_detections(self, field, filter, only_matches=False):
         """Filters the detections of the given
         :class:`fiftyone.core.labels.Detections` field.
 
@@ -602,11 +611,12 @@ class SampleCollection(object):
 
             #
             # Only include detections in the `predictions` field whose `label`
-            # is "cat" or "dog"
+            # is "cat" or "dog", and only show samples with at least one
+            # detection after filtering
             #
 
             view = dataset.filter_detections(
-                "predictions", F("label").is_in(["cat", "dog"])
+                "predictions", F("label").is_in(["cat", "dog"]), only_matches=True
             )
 
             #
@@ -624,14 +634,18 @@ class SampleCollection(object):
             filter: a :class:`fiftyone.core.expressions.ViewExpression` or
                 `MongoDB expression <https://docs.mongodb.com/manual/meta/aggregation-quick-reference/#aggregation-expressions>`_
                 that returns a boolean describing the filter to apply
+            only_matches (False): whether to only include samples with at least
+                one detection after filtering
 
         Returns:
             a :class:`fiftyone.core.view.DatasetView`
         """
-        return self._add_view_stage(fos.FilterDetections(field, filter))
+        return self._add_view_stage(
+            fos.FilterDetections(field, filter, only_matches=only_matches)
+        )
 
     @view_stage
-    def filter_polylines(self, field, filter):
+    def filter_polylines(self, field, filter, only_matches=False):
         """Filters the polylines of the given
         :class:`fiftyone.core.labels.Polylines` field.
 
@@ -655,10 +669,13 @@ class SampleCollection(object):
 
             #
             # Only include polylines in the `predictions` field whose `label`
-            # is "lane"
+            # is "lane", and only show samples with at least one polyline after
+            # filtering
             #
 
-            stage = FilterPolylines("predictions", F("label") == "lane")
+            stage = FilterPolylines(
+                "predictions", F("label") == "lane", only_matches=True
+            )
             view = dataset.add_stage(stage)
 
             #
@@ -675,14 +692,18 @@ class SampleCollection(object):
             filter: a :class:`fiftyone.core.expressions.ViewExpression` or
                 `MongoDB expression <https://docs.mongodb.com/manual/meta/aggregation-quick-reference/#aggregation-expressions>`_
                 that returns a boolean describing the filter to apply
+            only_matches (False): whether to only include samples with at least
+                one polyline after filtering
 
         Returns:
             a :class:`fiftyone.core.view.DatasetView`
         """
-        return self._add_view_stage(fos.FilterPolylines(field, filter))
+        return self._add_view_stage(
+            fos.FilterPolylines(field, filter, only_matches=only_matches)
+        )
 
     @view_stage
-    def filter_keypoints(self, field, filter):
+    def filter_keypoints(self, field, filter, only_matches=False):
         """Filters the keypoints of the given
         :class:`fiftyone.core.labels.Keypoints` field.
 
@@ -699,10 +720,13 @@ class SampleCollection(object):
 
             #
             # Only include keypoints in the `predictions` field whose `label`
-            # is "face"
+            # is "face", and only show samples with at least one keypoint after
+            # filtering
             #
 
-            stage = FilterKeypoints("predictions", F("label") == "face")
+            stage = FilterKeypoints(
+                "predictions", F("label") == "face", only_matches=True
+            )
             view = dataset.add_stage(stage)
 
             #
@@ -718,11 +742,15 @@ class SampleCollection(object):
             filter: a :class:`fiftyone.core.expressions.ViewExpression` or
                 `MongoDB expression <https://docs.mongodb.com/manual/meta/aggregation-quick-reference/#aggregation-expressions>`_
                 that returns a boolean describing the filter to apply
+            only_matches (False): whether to only include samples with at least
+                one keypoint after filtering
 
         Returns:
             a :class:`fiftyone.core.view.DatasetView`
         """
-        return self._add_view_stage(fos.FilterKeypoints(field, filter))
+        return self._add_view_stage(
+            fos.FilterKeypoints(field, filter, only_matches=only_matches)
+        )
 
     @view_stage
     def limit(self, limit):


### PR DESCRIPTION
Adds a boolean `only_matches` parameter to all filter stages that enables the user to specify that a view should only contain samples that match the given filter.

The typical use case for this is to do something like `filter_detections(..., only_matches=True)`, which only returns samples with at least one detection that matches the provided filter.

For example, using `only_matches=True` allows the `match()` stage below to be removed:

```py
import fiftyone as fo
import fiftyone.zoo as foz
from fiftyone import ViewField as F

dataset = foz.load_zoo_dataset("coco-2017", split="validation")

# Filter, then match non-empty
person_view1 = (
    dataset
    .filter_detections("ground_truth", F("label") == "person")
    .match(F("ground_truth.detections").length() > 0)
)

# Equivalent
person_view2 = dataset.filter_detections(
    "ground_truth", F("label") == "person", only_matches=True
)

print(person_view1)
print(person_view2)

session = fo.launch_app(view=person_view2)
```

<img width="1258" alt="Screen Shot 2020-10-19 at 8 06 52 PM" src="https://user-images.githubusercontent.com/25985824/96524759-2228a880-1247-11eb-87ea-90a33611da6e.png">
