### PR TITLE
Adding util to re-encode videos in a sample collection

### DIFF
--- a/electron/app/components/Player51.tsx
+++ b/electron/app/components/Player51.tsx
@@ -6,6 +6,7 @@ import { useRecoilValue } from "recoil";
 import CircularProgress from "@material-ui/core/CircularProgress";
 import { Warning } from "@material-ui/icons";
 
+import ExternalLink from "./ExternalLink";
 import Player51 from "../player51/build/cjs/player51.min.js";
 import { useEventHandler } from "../utils/hooks";
 import { convertSampleToETA } from "../utils/labels";
@@ -16,6 +17,8 @@ import * as selectors from "../recoil/selectors";
 const InfoWrapper = styled.div`
   display: flex;
   flex-direction: column;
+  position: relative;
+  z-index: 100;
   width: 100%;
   height: 100%;
   align-items: center;
@@ -28,6 +31,9 @@ const InfoWrapper = styled.div`
   }
   svg.error {
     color: ${({ theme }) => theme.error};
+  }
+  p {
+    margin: 0;
   }
 `;
 
@@ -130,7 +136,20 @@ export default ({
   useEventHandler(player, "load", onLoad);
   useEventHandler(player, "error", () =>
     setError(
-      `This video failed to load. Its type (${mimetype}) may be unsupported.`
+      <>
+        <p>
+          This video failed to load. Its type ({mimetype}) may be unsupported.
+        </p>
+        <p>
+          You can use{" "}
+          <code>
+            <ExternalLink href="https://voxel51.com/docs/fiftyone/api/fiftyone.utils.video.html#fiftyone.utils.video.reencode_videos">
+              fiftyone.utils.video.reencode_videos()
+            </ExternalLink>
+          </code>{" "}
+          to re-encode videos in a supported format.
+        </p>
+      </>
     )
   );
   onMouseEnter && useEventHandler(player, "mouseenter", onMouseEnter);

--- a/fiftyone/utils/data/importers.py
+++ b/fiftyone/utils/data/importers.py
@@ -722,7 +722,7 @@ class LabeledVideoDatasetImporter(DatasetImporter):
                 :class:`fiftyone.core.metadata.VideoMetadata` instances for the
                 video, or ``None`` if :meth:`has_video_metadata` is ``False``
             -   ``labels``: sample-level labels for the video, which can be any
-                of the following::
+                of the following:
 
                 -   a :class:`fiftyone.core.labels.Label` instance
                 -   a dictionary mapping label fields to
@@ -730,7 +730,7 @@ class LabeledVideoDatasetImporter(DatasetImporter):
                 -   ``None`` if the sample has no sample-level labels
 
             -   ``frames``: frame-level labels for the video, which can
-                be any of the following::
+                be any of the following:
 
                 -   a dictionary mapping frame numbers to dictionaries that
                     map label fields to :class:`fiftyone.core.labels.Label`

--- a/fiftyone/utils/video.py
+++ b/fiftyone/utils/video.py
@@ -15,25 +15,46 @@ import eta.core.video as etav
 import fiftyone.core.utils as fou
 
 
-def reencode_videos(sample_collection, delete_originals=False, **kwargs):
+def reencode_videos(
+    sample_collection,
+    delete_originals=False,
+    ext=".mp4",
+    verbose=False,
+    **kwargs
+):
     """Re-encodes the videos in the sample collection as MP4s that can be
     visualized in the FiftyOne App.
 
     The ``filepath`` of the samples are updated to point to the re-encoded
     videos.
 
+    You can configure parameters of the re-encoding such as codec, compression,
+    resolution, and frame rate by passing keyword arguments for
+    ``eta.core.video.FFmpeg(**kwargs)`` to this function.
+
+    By default, the re-encoding is performed via the following ``ffmpeg``
+    command::
+
+        ffmpeg \
+            -loglevel error -vsync 0 -i $INPUT \
+            -c:v libx264 -preset medium -crf 23 -pix_fmt yuv420p -vsync 0 -an \
+            $OUTPUT
+
     Args:
         sample_collection: a
             :class:`fiftyone.core.collections.SampleCollection`
         delete_originals (False): whether to delete the original videos after
             re-encoding
+        ext (".mp4"): the video container format to use
+        verbose (False): whether to log the ``ffmpeg`` commands that are
+            executed
         **kwargs: keyword arguments for ``eta.core.video.FFmpeg(**kwargs)``
     """
     with fou.ProgressBar() as pb:
         with etav.FFmpeg(**kwargs) as ffmpeg:
             for sample in pb(sample_collection.select_fields()):
                 inpath = sample.filepath
-                outpath = os.path.splitext(inpath)[0] + ".mp4"
+                outpath = os.path.splitext(inpath)[0] + ext
 
                 # Must move original to avoid overwriting
                 if outpath == inpath:
@@ -42,7 +63,7 @@ def reencode_videos(sample_collection, delete_originals=False, **kwargs):
                     etau.move_file(_inpath, inpath)
 
                 # Re-encode video
-                ffmpeg.run(inpath, outpath)
+                ffmpeg.run(inpath, outpath, verbose=verbose)
 
                 sample.filepath = outpath
                 sample.save()

--- a/fiftyone/utils/video.py
+++ b/fiftyone/utils/video.py
@@ -35,10 +35,10 @@ def reencode_videos(
     By default, the re-encoding is performed via the following ``ffmpeg``
     command::
 
-        ffmpeg \
-            -loglevel error -vsync 0 -i $INPUT \
-            -c:v libx264 -preset medium -crf 23 -pix_fmt yuv420p -vsync 0 -an \
-            $OUTPUT
+        ffmpeg \\
+            -loglevel error -vsync 0 -i $INPUT_PATH \\
+            -c:v libx264 -preset medium -crf 23 -pix_fmt yuv420p -vsync 0 -an \\
+            $OUTPUT_PATH
 
     Args:
         sample_collection: a

--- a/fiftyone/utils/video.py
+++ b/fiftyone/utils/video.py
@@ -16,7 +16,7 @@ import fiftyone.core.utils as fou
 
 
 def reencode_videos(sample_collection, delete_originals=False, **kwargs):
-    """Re-encodes the videos in the given sample collection as MP4s that can be
+    """Re-encodes the videos in the sample collection as MP4s that can be
     visualized in the FiftyOne App.
 
     The ``filepath`` of the samples are updated to point to the re-encoded

--- a/fiftyone/utils/video.py
+++ b/fiftyone/utils/video.py
@@ -1,0 +1,51 @@
+"""
+Video utilities.
+
+| Copyright 2017-2020, Voxel51, Inc.
+| `voxel51.com <https://voxel51.com/>`_
+|
+"""
+import os
+import random
+import string
+
+import eta.core.utils as etau
+import eta.core.video as etav
+
+import fiftyone.core.utils as fou
+
+
+def reencode_videos(sample_collection, delete_originals=False, **kwargs):
+    """Re-encodes the videos in the given sample collection as MP4s that can be
+    visualized in the FiftyOne App.
+
+    The ``filepath`` of the samples are updated to point to the re-encoded
+    videos.
+
+    Args:
+        sample_collection: a
+            :class:`fiftyone.core.collections.SampleCollection`
+        delete_originals (False): whether to delete the original videos after
+            re-encoding
+        **kwargs: keyword arguments for ``eta.core.video.FFmpeg(**kwargs)``
+    """
+    with fou.ProgressBar() as pb:
+        with etav.FFmpeg(**kwargs) as ffmpeg:
+            for sample in pb(sample_collection.select_fields()):
+                inpath = sample.filepath
+                outpath = os.path.splitext(inpath)[0] + ".mp4"
+
+                # Must move original to avoid overwriting
+                if outpath == inpath:
+                    _inpath = inpath
+                    inpath = etau.make_unique_path(inpath, suffix="-original")
+                    etau.move_file(_inpath, inpath)
+
+                # Re-encode video
+                ffmpeg.run(inpath, outpath)
+
+                sample.filepath = outpath
+                sample.save()
+
+                if delete_originals:
+                    etau.delete_file(inpath)


### PR DESCRIPTION
Adding a utility to re-encode the videos in a sample collection so that they will be visualizable in the FiftyOne App.

Example usage of making HMDB51 viewable:

```py
import fiftyone as fo
import fiftyone.zoo as foz
import fiftyone.utils.video as fouv

# Load some samples from HMDB51
dataset = foz.load_zoo_dataset(
    "hmdb51", split="test", shuffle=True, max_samples=10
)

# Try to visualize (videos have unsupported type)
session = fo.launch_app(dataset)

# Re-encode videos
dataset2 = dataset.clone("hmdb51-mp4")
fouv.reencode_videos(dataset2)

# Now we can visualize!
session.dataset = dataset2
```

<img width="1315" alt="Screen Shot 2020-10-20 at 4 22 21 PM" src="https://user-images.githubusercontent.com/25985824/96640013-8bb0c180-12f0-11eb-8948-f9fa594fbaad.png">
