### PR TITLE
Minimal sample-level labels support for video datasets in the App

### DIFF
--- a/electron/app/components/SampleModal.tsx
+++ b/electron/app/components/SampleModal.tsx
@@ -380,12 +380,12 @@ const SampleModal = ({
           : 1;
       };
 
-      if (isVideo && frameData) {
+      if (!(name in s) && isVideo && frameData) {
         for (const frame of frameData) {
           if (frame[name])
             value += resolver(filterData ? filter(frame) : frame);
         }
-      } else if (isVideo) {
+      } else if (!(name in s) && isVideo) {
         value = "-";
       } else {
         value += resolver(s);

--- a/electron/app/recoil/selectors.ts
+++ b/electron/app/recoil/selectors.ts
@@ -143,7 +143,11 @@ export const labelSampleCounts = selector({
   get: ({ get }) => {
     const fields = get(datasetStats).custom_fields || {};
     if (get(mediaType) === "video") {
-      return fields.frames || {};
+      const frames = fields.frames || {};
+      return {
+        ...fields,
+        ...frames,
+      };
     }
     return fields;
   },
@@ -154,7 +158,11 @@ export const filteredLabelSampleCounts = selector({
   get: ({ get }) => {
     const fields = get(extendedDatasetStats).custom_fields || {};
     if (get(mediaType) === "video") {
-      return fields.frames || {};
+      const frames = fields.frames || {};
+      return {
+        ...fields,
+        ...frames,
+      };
     }
     return fields;
   },

--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -1857,7 +1857,7 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
         for sample in samples:
             self._validate_media_type(sample)
             if self.media_type == fom.VIDEO:
-                self._expand_frame_schema(sample.frames)
+                frame_schema = self._expand_frame_schema(sample.frames, fields)
 
             for field_name in sample.to_mongo_dict():
                 if field_name == "_id":
@@ -1870,6 +1870,11 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
                 if value is None:
                     continue
 
+                if field_name in frame_schema:
+                    raise ValueError(
+                        "field name collision: '%s' is already a field name at the frame-level"
+                    )
+
                 self._sample_doc_cls.add_implied_field(
                     field_name, value, frame_doc_cls=self._frame_doc_cls,
                 )
@@ -1877,7 +1882,7 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
 
         self._doc.reload()
 
-    def _expand_frame_schema(self, frames):
+    def _expand_frame_schema(self, frames, field_schema):
         fields = self.get_frame_field_schema(include_private=True)
         for frame in frames.values():
             for field_name in frame.to_mongo_dict():
@@ -1891,10 +1896,17 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
                 if value is None:
                     continue
 
+                if field_name in field_schema:
+                    raise ValueError(
+                        "field name collision: '%s' is already a field name at the sample-level"
+                    )
+
                 self._frame_doc_cls.add_implied_field(
                     field_name, value, frame_doc_cls=self._frame_doc_cls,
                 )
                 fields = self.get_frame_field_schema(include_private=True)
+
+        return fields
 
     def _validate_media_type(self, sample):
         if self.media_type != sample.media_type:

--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -1858,6 +1858,8 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
             self._validate_media_type(sample)
             if self.media_type == fom.VIDEO:
                 frame_schema = self._expand_frame_schema(sample.frames, fields)
+            else:
+                frame_schema = {}
 
             for field_name in sample.to_mongo_dict():
                 if field_name == "_id":

--- a/fiftyone/core/frame.py
+++ b/fiftyone/core/frame.py
@@ -159,8 +159,8 @@ class Frames(object):
             self._sample._doc.frames["frame_count"] += 1
         elif self._sample._in_db:
             if (
-                self._iter is not None
-                or frame_number != self._iter_doc.get_field("frame_number")
+                self._iter_doc is not None
+                and frame_number != self._iter_doc.get_field("frame_number")
             ):
                 find_d = {
                     "_sample_id": self._sample._id,


### PR DESCRIPTION
This is a very quick approach to supporting sample-level labels for video datasets in the App.

Sample labels are copied into ETA frame labels for player51 visualization, and some checks are made to prevent field name collisions (field names must be unique among the frame schema and sample schema). Collisions are still possible when adding the samples/frames that have already been added to a dataset.

Much, if not all, of this code will be changed or removed when the next iteration of video optimizations are ready. I am hoping to support a field name at the sample level and frame level in the next set of optimizations.