### PR TITLE
Allow for insertion case when saving frames

### DIFF
--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -613,7 +613,7 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
 
         if self.media_type == fom.VIDEO:
             sample.frames._serve(self)
-            sample.frames._save()
+            sample.frames._save(insert=True)
 
         return str(d["_id"])
 
@@ -688,7 +688,7 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
 
             if self.media_type == fom.VIDEO:
                 sample.frames._serve(self)
-                sample.frames._save()
+                sample.frames._save(insert=True)
 
         return [str(d["_id"]) for d in dicts]
 

--- a/fiftyone/core/frame.py
+++ b/fiftyone/core/frame.py
@@ -65,10 +65,7 @@ class Frames(object):
 
         if insert:
             self._frame_collection.insert_many(
-                [
-                    self._make_dict(doc)
-                    for frame_number, doc in self._replacements.items()
-                ]
+                [self._make_dict(doc) for doc in self._replacements.values()]
             )
         else:
             self._frame_collection.bulk_write(


### PR DESCRIPTION
Adds an optional `insert` flag to the private `fiftyone.core.Frames._save()` method.

This flag can be used to use `insert_many` when we are sure that the frames are new and can be inserted (not replaced).