### PR TITLE
Adding utils for working with image patches in Torch

### DIFF
--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -5,7 +5,6 @@ FiftyOne datasets.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
-from collections import defaultdict
 from copy import deepcopy
 import datetime
 import fnmatch
@@ -2092,8 +2091,9 @@ def _load_dataset(name):
         runner = get_migration_runner(dataset_doc.version, VERSION)
         if runner.has_revisions:
             logger.info(
-                "Migrating dataset '%s' to the current version (%s)"
-                % (dataset_doc.name, VERSION)
+                "Migrating dataset '%s' to the current version (%s)",
+                dataset_doc.name,
+                VERSION,
             )
             runner.run(dataset_names=[dataset_doc.name])
 

--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -1016,7 +1016,7 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
             add_info=add_info,
         )
 
-    def add_images(self, samples, sample_parser, tags=None):
+    def add_images(self, samples, sample_parser=None, tags=None):
         """Adds the given images to the dataset.
 
         This operation does not read the images.
@@ -1026,8 +1026,11 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
         :class:`UnlabeledImageSampleParser <fiftyone.utils.data.parsers.UnlabeledImageSampleParser>`.
 
         Args:
-            samples: an iterable of samples
-            sample_parser: a
+            samples: an iterable of samples. If no ``sample_parser`` is
+                provided, this must be an iterable of image paths. If a
+                ``sample_parser`` is provided, this can be an arbitrary
+                iterable whose elements can be parsed by the sample parser
+            sample_parser (None): a
                 :class:`fiftyone.utils.data.parsers.UnlabeledImageSampleParser`
                 instance to use to parse the samples
             tags (None): an optional list of tags to attach to each sample
@@ -1035,6 +1038,9 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
         Returns:
             a list of IDs of the samples that were added to the dataset
         """
+        if sample_parser is None:
+            sample_parser = foud.ImageSampleParser()
+
         return foud.add_images(self, samples, sample_parser, tags=tags)
 
     def add_labeled_images(
@@ -1120,7 +1126,7 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
     def ingest_images(
         self,
         samples,
-        sample_parser,
+        sample_parser=None,
         tags=None,
         dataset_dir=None,
         image_format=None,
@@ -1134,8 +1140,11 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
         :class:`UnlabeledImageSampleParser <fiftyone.utils.data.parsers.UnlabeledImageSampleParser>`.
 
         Args:
-            samples: an iterable of samples
-            sample_parser: a
+            samples: an iterable of samples. If no ``sample_parser`` is
+                provided, this must be an iterable of image paths. If a
+                ``sample_parser`` is provided, this can be an arbitrary
+                iterable whose elements can be parsed by the sample parser
+            sample_parser (None): a
                 :class:`fiftyone.utils.data.parsers.UnlabeledImageSampleParser`
                 instance to use to parse the samples
             tags (None): an optional list of tags to attach to each sample
@@ -1147,6 +1156,9 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
         Returns:
             a list of IDs of the samples in the dataset
         """
+        if sample_parser is None:
+            sample_parser = foud.ImageSampleParser()
+
         if dataset_dir is None:
             dataset_dir = get_default_dataset_dir(self.name)
 
@@ -1215,25 +1227,31 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
             expand_schema=expand_schema,
         )
 
-    def add_videos(self, samples, sample_parser, tags=None):
+    def add_videos(self, samples, sample_parser=None, tags=None):
         """Adds the given videos to the dataset.
 
-        This operation does not read the images.
+        This operation does not read the videos.
 
         See :ref:`this guide <custom-sample-parser>` for more details about
         adding videos to a dataset by defining your own
         :class:`UnlabeledVideoSampleParser <fiftyone.utils.data.parsers.UnlabeledVideoSampleParser>`.
 
         Args:
-            samples: an iterable of samples
-            sample_parser: a
-                :class:`fiftyone.utils.data.parsers.UnlabeledVideoSampleParser`
+            samples: an iterable of samples. If no ``sample_parser`` is
+                provided, this must be an iterable of video paths. If a
+                ``sample_parser`` is provided, this can be an arbitrary
+                iterable whose elements can be parsed by the sample parser
+            sample_parser (None): a
+                :class:`fiftyone.utils.data.parsers.UnlabeledImageSampleParser`
                 instance to use to parse the samples
             tags (None): an optional list of tags to attach to each sample
 
         Returns:
             a list of IDs of the samples that were added to the dataset
         """
+        if sample_parser is None:
+            sample_parser = foud.VideoSampleParser()
+
         return foud.add_videos(self, samples, sample_parser, tags=tags)
 
     def add_labeled_videos(
@@ -1316,7 +1334,7 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
         return self.add_videos(video_paths, sample_parser, tags=tags)
 
     def ingest_videos(
-        self, samples, sample_parser, tags=None, dataset_dir=None,
+        self, samples, sample_parser=None, tags=None, dataset_dir=None,
     ):
         """Ingests the given iterable of videos into the dataset.
 
@@ -1327,9 +1345,12 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
         :class:`UnlabeledVideoSampleParser <fiftyone.utils.data.parsers.UnlabeledVideoSampleParser>`.
 
         Args:
-            samples: an iterable of samples
-            sample_parser: a
-                :class:`fiftyone.utils.data.parsers.UnlabeledVideoSampleParser`
+            samples: an iterable of samples. If no ``sample_parser`` is
+                provided, this must be an iterable of video paths. If a
+                ``sample_parser`` is provided, this can be an arbitrary
+                iterable whose elements can be parsed by the sample parser
+            sample_parser (None): a
+                :class:`fiftyone.utils.data.parsers.UnlabeledImageSampleParser`
                 instance to use to parse the samples
             tags (None): an optional list of tags to attach to each sample
             dataset_dir (None): the directory in which the videos will be
@@ -1338,6 +1359,9 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
         Returns:
             a list of IDs of the samples in the dataset
         """
+        if sample_parser is None:
+            sample_parser = foud.VideoSampleParser()
+
         if dataset_dir is None:
             dataset_dir = get_default_dataset_dir(self.name)
 

--- a/fiftyone/utils/torch.py
+++ b/fiftyone/utils/torch.py
@@ -7,13 +7,13 @@ PyTorch utilities.
 """
 import logging
 
-import PIL
-
-import eta.core.utils as etau
+import numpy as np
+from PIL import Image
 
 import fiftyone.core.utils as fou
 
 fou.ensure_torch()
+import torch
 import torchvision
 from torch.utils.data import Dataset
 
@@ -22,17 +22,17 @@ logger = logging.getLogger(__name__)
 
 
 class TorchImageDataset(Dataset):
-    """A ``torch.utils.data.Dataset`` of unlabeled images.
+    """A ``torch.utils.data.Dataset`` of images.
 
-    Instances of this class emit PIL images with no associated targets, either
-    directly or as ``(image, sample_id)`` pairs if ``sample_ids`` are provided.
+    Instances of this class emit images, or ``(image, sample_id)`` pairs if
+    ``sample_ids`` are provided.
 
     Args:
         image_paths: an iterable of image paths
         sample_ids (None): an iterable of :class:`fiftyone.core.sample.Sample`
-            IDs
+            IDs corresponding to each image
         transform (None): an optional transform to apply to the images
-        force_rgb (False): force convert the images to RGB
+        force_rgb (False): whether to force convert the images to RGB
     """
 
     def __init__(
@@ -47,7 +47,7 @@ class TorchImageDataset(Dataset):
         return len(self.image_paths)
 
     def __getitem__(self, idx):
-        img = PIL.Image.open(self.image_paths[idx])
+        img = Image.open(self.image_paths[idx])
 
         if self.force_rgb:
             img = img.convert("RGB")
@@ -70,17 +70,17 @@ class TorchImageDataset(Dataset):
 class TorchImageClassificationDataset(Dataset):
     """A ``torch.utils.data.Dataset`` for image classification.
 
-    Instances of this dataset emit PIL images and their associated targets,
-    either directly as ``(image, target)`` pairs or as
-    ``(image, target, sample_id)`` pairs if ``sample_ids`` are provided.
+    Instances of this dataset emit images and their associated targets, either
+    directly as ``(image, target)`` pairs or as ``(image, target, sample_id)``
+    pairs if ``sample_ids`` are provided.
 
     Args:
         image_paths: an iterable of image paths
         targets: an iterable of targets
         sample_ids (None): an iterable of :class:`fiftyone.core.sample.Sample`
-            IDs
+            IDs corresponding to each image
         transform (None): an optional transform to apply to the images
-        force_rgb (False): force convert the images to RGB
+        force_rgb (False): whether to force convert the images to RGB
     """
 
     def __init__(
@@ -101,7 +101,7 @@ class TorchImageClassificationDataset(Dataset):
         return len(self.image_paths)
 
     def __getitem__(self, idx):
-        img = PIL.Image.open(self.image_paths[idx])
+        img = Image.open(self.image_paths[idx])
         target = self.targets[idx]
 
         if self.force_rgb:
@@ -115,6 +115,92 @@ class TorchImageClassificationDataset(Dataset):
             return img, target, self.sample_ids[idx]
 
         return img, target
+
+    @property
+    def has_sample_ids(self):
+        """Whether this dataset has sample IDs."""
+        return self.sample_ids is not None
+
+
+class TorchImagePatchesDataset(Dataset):
+    """A ``torch.utils.data.Dataset`` of image patch tensors extracted from a
+    list of images.
+
+    Instances of this class emit Torch tensors containing the stacked
+    (along axis 0) patches from each image, or ``(patch_tensor, sample_id)``
+    pairs if ``sample_ids`` are provided.
+
+    The provided ``transform`` must ensure that all image patches are resized
+    to the same shape and formatted as torch Tensors so that they can be
+    stacked.
+
+    Args:
+        image_paths: an iterable of image paths
+        detections: an iterable of :class:`fiftyone.core.labels.Detections`
+            instances specifying the image patch(es) to extract from each
+            image
+        transform: a torchvision transform to apply to each image patch
+        sample_ids (None): an iterable of :class:`fiftyone.core.sample.Sample`
+            IDs corresponding to each image
+        force_rgb (False): whether to force convert the images to RGB
+        force_square (False): whether to minimally manipulate the patch
+            bounding boxes into squares prior to extraction
+    """
+
+    def __init__(
+        self,
+        image_paths,
+        detections,
+        transform,
+        sample_ids=None,
+        force_rgb=False,
+        force_square=False,
+    ):
+        self.image_paths = list(image_paths)
+        self.detections = list(detections)
+        self.transform = transform
+        self.sample_ids = list(sample_ids) if sample_ids else None
+        self.force_rgb = force_rgb
+        self.force_square = force_square
+
+    def __len__(self):
+        return len(self.image_paths)
+
+    def __getitem__(self, idx):
+        image_path = self.image_paths[idx]
+        img = Image.open(image_path)
+
+        if self.force_rgb:
+            img = img.convert("RGB")
+
+        detections = self.detections[idx].detections
+
+        if not detections:
+            raise ValueError(
+                "No patches to extract from image '%s'" % image_path
+            )
+
+        img_patches = []
+        for detection in detections:
+            dobj = detection.to_detected_object()
+
+            # @todo avoid PIL <-> numpy casts
+            img_patch = dobj.bounding_box.extract_from(
+                np.array(img), force_square=self.force_square
+            )
+            img_patch = Image.fromarray(img_patch)
+
+            img_patch = self.transform(img_patch)
+
+            img_patches.append(img_patch)
+
+        img_patches = torch.stack(img_patches, dim=0)
+
+        if self.has_sample_ids:
+            # pylint: disable=unsubscriptable-object
+            return img_patches, self.sample_ids[idx]
+
+        return img_patches
 
     @property
     def has_sample_ids(self):

--- a/tests/misc/torch_tests.py
+++ b/tests/misc/torch_tests.py
@@ -1,0 +1,104 @@
+"""
+Tests for the :mod:`fiftyone.utils.torch` module.
+
+| Copyright 2017-2020, Voxel51, Inc.
+| `voxel51.com <https://voxel51.com/>`_
+|
+"""
+import unittest
+
+import numpy as np
+from PIL import Image
+import torch
+import torchvision
+
+import fiftyone as fo
+import fiftyone.utils.torch as fout
+
+
+@unittest.skip("Must be run manually")
+def test_torch_image_patches_dataset():
+
+    image_path = "/path/to/an/image.png"
+
+    dataset = fo.Dataset()
+
+    sample = fo.Sample(filepath=image_path)
+
+    polylines = fo.Polylines(
+        polylines=[
+            fo.Polyline(
+                label="square",
+                points=[[(0.1, 0.1), (0.1, 0.4), (0.4, 0.4), (0.4, 0.1)]],
+                closed=True,
+                filled=True,
+            ),
+            fo.Polyline(
+                label="triangle",
+                points=[[(0.6, 0.1), (0.9, 0.1), (0.9, 0.4)]],
+                closed=True,
+                filled=True,
+            ),
+            fo.Polyline(
+                label="diamond",
+                points=[[(0.1, 0.75), (0.25, 0.6), (0.4, 0.75), (0.25, 0.9)]],
+                closed=True,
+                filled=True,
+            ),
+            fo.Polyline(
+                label="triangle",
+                points=[[(0.6, 0.6), (0.6, 0.9), (0.9, 0.9)]],
+                closed=True,
+                filled=True,
+            ),
+        ]
+    )
+
+    sample["polylines"] = polylines
+    sample["detections"] = sample["polylines"].to_detections(
+        mask_size=(64, 64)
+    )
+    sample["polylines2"] = sample["detections"].to_polylines()
+
+    dataset.add_sample(sample)
+
+    image_paths = [sample.filepath]
+    detections = [sample.detections]
+    transform = torchvision.transforms.Compose(
+        [
+            torchvision.transforms.Resize(
+                size=[32, 32], interpolation=Image.BILINEAR
+            ),
+            torchvision.transforms.ToTensor(),
+        ]
+    )
+
+    torch_dataset = fout.TorchImagePatchesDataset(
+        image_paths, detections, transform
+    )
+
+    data_loader = torch.utils.data.DataLoader(
+        torch_dataset, batch_size=1, num_workers=4
+    )
+
+    patches = next(iter(data_loader))
+    patches = torch.squeeze(patches, dim=0)
+    imgs = np.transpose(patches.numpy(), axes=(0, 2, 3, 1))
+    imgs = np.array(255.0 * imgs, dtype=np.uint8)
+    dataset.ingest_images(imgs)
+
+    print(dataset)
+
+    #
+    # Inspect App to verity that detection <-> polyline conversion happened as
+    # expected, and that the appropriate image patches were extracted from the
+    # source image
+    #
+
+    session = fo.launch_app(dataset)
+    session.wait()
+
+
+if __name__ == "__main__":
+    fo.config.show_progress_bars = False
+    unittest.main(verbosity=2)


### PR DESCRIPTION
Adds a `fiftyone.utils.torch.TorchImagePatchesDataset` dataset that emits tensors of patches extracted from images defined by sets of `Detections` associated with the images.

A test was added to `tests/misc/torch_tests.py` that verifies the functionality, although it must be run manually.

Also includes two other minor things:
- makes `sample_parser` arg optional for methods like `Dataset.ingest_images()`, where the typical case is to directly pass in  images (for which the default `ImageSampleParser` works just fine)
- Allows `Polyine.to_detection()` and `Detection.to_polyline()` to ignore instance masks