### PR TITLE
Fixing ObjectId bug in selection utils

### DIFF
--- a/fiftyone/core/expressions.py
+++ b/fiftyone/core/expressions.py
@@ -8,6 +8,8 @@ Expressions for :class:`fiftyone.core.stages.ViewStage` definitions.
 from copy import deepcopy
 import re
 
+import bson
+
 import eta.core.utils as etau
 
 import fiftyone.core.utils as fou
@@ -793,6 +795,42 @@ class ViewField(ViewExpression, metaclass=_MetaViewField):
             return prefix + "." + self._expr if self._expr else prefix
 
         return "$" + self._expr if self._expr else "$this"
+
+
+class ObjectId(ViewExpression, metaclass=_MetaViewField):
+    """A :class:`ViewExpression` that refers to an
+    `ObjectId <https://docs.mongodb.com/manual/reference/method/ObjectId>`_ of
+    a document.
+
+    The typical use case for this class is writing an expression that involves
+    checking if the ID of a document matches a particular known ID.
+
+    Example::
+
+        from fiftyone import ViewField as F
+        from fiftyone.core.expressions import ObjectId
+
+        # Check if the ID of the document matches the given ID
+        expr = F("_id") == ObjectId("5f452489ef00e6374aad384a")
+
+    Args:
+        oid: the object ID string
+    """
+
+    def __init__(self, oid):
+        _ = bson.ObjectId(oid)  # validates that `oid` is valid value
+        super().__init__(oid)
+
+    def to_mongo(self, prefix=None):
+        """Returns a MongoDB representation of the ObjectId.
+
+        Args:
+            prefix (None): unused
+
+        Returns:
+            a string
+        """
+        return {"$toObjectId": self._expr}
 
 
 def _escape_regex_chars(str_or_strs):

--- a/fiftyone/core/expressions.py
+++ b/fiftyone/core/expressions.py
@@ -828,7 +828,7 @@ class ObjectId(ViewExpression, metaclass=_MetaViewField):
             prefix (None): unused
 
         Returns:
-            a string
+            a MongoDB expression
         """
         return {"$toObjectId": self._expr}
 

--- a/fiftyone/core/labels.py
+++ b/fiftyone/core/labels.py
@@ -5,7 +5,7 @@ Labels stored in dataset samples.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
-from bson.objectid import ObjectId
+from bson import ObjectId
 
 import eta.core.data as etad
 import eta.core.geometry as etag

--- a/fiftyone/core/odm/document.py
+++ b/fiftyone/core/odm/document.py
@@ -9,8 +9,7 @@ from copy import deepcopy
 import json
 import re
 
-from bson import json_util
-from bson.objectid import ObjectId
+from bson import json_util, ObjectId
 import mongoengine
 import pymongo
 

--- a/fiftyone/core/stages.py
+++ b/fiftyone/core/stages.py
@@ -108,9 +108,9 @@ class ViewStage(object):
             self._uuid = str(uuid.uuid4())
 
         return {
-            "kwargs": self._kwargs(),
             "_cls": etau.get_class_name(self),
             "_uuid": self._uuid,
+            "kwargs": self._kwargs(),
         }
 
     def _kwargs(self):

--- a/fiftyone/utils/selection.py
+++ b/fiftyone/utils/selection.py
@@ -8,10 +8,9 @@ Utilities for selecting content from datasets.
 from collections import defaultdict
 import warnings
 
-from bson import ObjectId
-
 import fiftyone.core.fields as fof
 import fiftyone.core.labels as fol
+from fiftyone.core.expressions import ObjectId
 from fiftyone.core.expressions import ViewField as F
 
 
@@ -85,7 +84,7 @@ def select_objects(sample_collection, objects):
     view = view.select_fields(list(object_ids.keys()))
 
     for field, object_ids in object_ids.items():
-        label_filter = F("_id").is_in(object_ids)
+        label_filter = F("_id").is_in([ObjectId(oid) for oid in object_ids])
         view = _apply_label_filter(view, label_schema, field, label_filter)
 
     return view
@@ -128,7 +127,7 @@ def exclude_objects(sample_collection, objects):
 
     view = sample_collection
     for field, object_ids in object_ids.items():
-        label_filter = ~F("_id").is_in(object_ids)
+        label_filter = ~F("_id").is_in([ObjectId(oid) for oid in object_ids])
         view = _apply_label_filter(view, label_schema, field, label_filter)
 
     return view
@@ -139,7 +138,7 @@ def _parse_objects(objects):
     object_ids = defaultdict(set)
     for obj in objects:
         sample_ids.add(obj["sample_id"])
-        object_ids[obj["field"]].add(ObjectId(obj["object_id"]))
+        object_ids[obj["field"]].add(obj["object_id"])
 
     return sample_ids, object_ids
 


### PR DESCRIPTION
Closes https://github.com/voxel51/fiftyone/issues/636.

Introduces a `fiftyone.core.expressions.ObjectId` class that can be used to refer to object IDs when constructing `ViewExpression`s, which must be JSON serializable (the error message being shown was reasonable; the offending code just needed to be fixed).

Tested by running `pytest tests/misc/selection_tests.py` and verifying that the views created within can be successfully viewed in the App.