### PR TITLE
Adding support for filtering generic label fields, limiting labels, and other related expressions

### DIFF
--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -537,6 +537,153 @@ class SampleCollection(object):
         )
 
     @view_stage
+    def filter_labels(self, field, filter, only_matches=False):
+        """Filters the :class:`fiftyone.core.labels.Label` elements in a labels
+        list field of each sample.
+
+        The specified ``field`` must be one of the following types:
+
+        -   :class:`fiftyone.core.labels.Classifications`
+        -   :class:`fiftyone.core.labels.Detections`
+        -   :class:`fiftyone.core.labels.Polylines`
+        -   :class:`fiftyone.core.labels.Keypoints`
+
+        Classifications Examples::
+
+            import fiftyone as fo
+            from fiftyone import ViewField as F
+
+            dataset = fo.load_dataset(...)
+
+            #
+            # Only include classifications in the `predictions` field whose
+            # `confidence` greater than 0.8
+            #
+
+            view = dataset.filter_labels("predictions", F("confidence") > 0.8)
+
+            #
+            # Only include classifications in the `predictions` field whose
+            # `label` is "cat" or "dog", and only show samples with at least
+            # one classification after filtering
+            #
+
+            view = dataset.filter_labels(
+                "predictions",
+                F("label").is_in(["cat", "dog"]),
+                only_matches=True,
+            )
+
+        Detections Examples::
+
+            import fiftyone as fo
+            from fiftyone import ViewField as F
+
+            dataset = fo.load_dataset(...)
+
+            #
+            # Only include detections in the `predictions` field whose
+            # `confidence` is greater than 0.8
+            #
+
+            stage = filter_labels("predictions", F("confidence") > 0.8)
+            view = dataset.add_stage(stage)
+
+            #
+            # Only include detections in the `predictions` field whose `label`
+            # is "cat" or "dog", and only show samples with at least one
+            # detection after filtering
+            #
+
+            view = dataset.filter_labels(
+                "predictions",
+                F("label").is_in(["cat", "dog"]),
+                only_matches=True,
+            )
+
+            #
+            # Only include detections in the `predictions` field whose bounding
+            # box area is smaller than 0.2
+            #
+
+            # bbox is in [top-left-x, top-left-y, width, height] format
+            bbox_area = F("bounding_box")[2] * F("bounding_box")[3]
+
+            view = dataset.filter_labels("predictions", bbox_area < 0.2)
+
+        Polylines Examples::
+
+            import fiftyone as fo
+            from fiftyone import ViewField as F
+
+            dataset = fo.load_dataset(...)
+
+            #
+            # Only include polylines in the `predictions` field that are filled
+            #
+
+            view = dataset.filter_labels("predictions", F("filled"))
+
+            #
+            # Only include polylines in the `predictions` field whose `label`
+            # is "lane", and only show samples with at least one polyline after
+            # filtering
+            #
+
+            view = dataset.filter_labels(
+                "predictions", F("label") == "lane", only_matches=True
+            )
+
+            #
+            # Only include polylines in the `predictions` field with at least
+            # 10 vertices
+            #
+
+            num_vertices = F("points").map(F().length()).sum()
+            view = dataset.filter_labels("predictions", num_vertices >= 10)
+
+        Keypoints Examples::
+
+            import fiftyone as fo
+            from fiftyone import ViewField as F
+
+            dataset = fo.load_dataset(...)
+
+            #
+            # Only include keypoints in the `predictions` field whose `label`
+            # is "face", and only show samples with at least one keypoint after
+            # filtering
+            #
+
+            view = dataset.filter_labels(
+                "predictions", F("label") == "face", only_matches=True
+            )
+
+            #
+            # Only include keypoints in the `predictions` field with at least
+            # 10 points
+            #
+
+            view = dataset.filter_labels(
+                "predictions", F("points").length() >= 10
+            )
+
+        Args:
+            field: the labels list field to filter
+            filter: a :class:`fiftyone.core.expressions.ViewExpression` or
+                `MongoDB expression <https://docs.mongodb.com/manual/meta/aggregation-quick-reference/#aggregation-expressions>`_
+                that returns a boolean describing the filter to apply
+            only_matches (False): whether to only include samples with at least
+                one label after filtering
+
+        Returns:
+            a :class:`fiftyone.core.view.DatasetView`
+        """
+        return self._add_view_stage(
+            fos.FilterLabels(field, filter, only_matches=only_matches)
+        )
+
+    @view_stage
     def filter_classifications(self, field, filter, only_matches=False):
         """Filters the classifications of the given
         :class:`fiftyone.core.labels.Classifications` field.
@@ -776,6 +923,38 @@ class SampleCollection(object):
             a :class:`fiftyone.core.view.DatasetView`
         """
         return self._add_view_stage(fos.Limit(limit))
+
+    @view_stage
+    def limit_labels(self, field, limit):
+        """Limits the number of :class:`fiftyone.core.labels.Label` instances
+        in the specified labels list field of each sample.
+
+        The specified ``field`` must be one of the following types:
+
+        -   :class:`fiftyone.core.labels.Classifications`
+        -   :class:`fiftyone.core.labels.Detections`
+        -   :class:`fiftyone.core.labels.Polylines`
+        -   :class:`fiftyone.core.labels.Keypoints`
+
+        Examples::
+
+            import fiftyone as fo
+
+            dataset = fo.load_dataset(...)
+
+            #
+            # Only include the first 5 detections in the `ground_truth` field of
+            # the view
+            #
+
+            view = dataset.limit_labels("ground_truth", 5)
+
+        Args:
+            field: the labels list field to filter
+            limit: the maximum number of labels to include in each labels list.
+                If a non-positive number is provided, all lists will be empty
+        """
+        return self._add_view_stage(fos.LimitLabels(field, limit))
 
     @view_stage
     def match(self, filter):

--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -494,7 +494,7 @@ class SampleCollection(object):
 
     @view_stage
     def filter_field(self, field, filter, only_matches=False):
-        """Filters the values of the given field of the samples.
+        """Filters the values of a given sample (or embedded document) field.
 
         Values of ``field`` for which ``filter`` returns ``False`` are
         replaced with ``None``.

--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -591,9 +591,9 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
             the ID of the sample in the dataset
 
         Raises:
-            :class:`mongoengine.errors.ValidationError` if a field of the
-            sample has a type that is inconsistent with the dataset schema, or
-            if ``expand_schema == False`` and a new field is encountered
+            ``mongoengine.errors.ValidationError``: if a field of the sample
+                has a type that is inconsistent with the dataset schema, or if
+                ``expand_schema == False`` and a new field is encountered
         """
         if expand_schema:
             self._expand_schema([sample])
@@ -639,9 +639,9 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
             a list of IDs of the samples in the dataset
 
         Raises:
-            :class:`mongoengine.errors.ValidationError` if a field of a sample
-            has a type that is inconsistent with the dataset schema, or if
-            ``expand_schema == False`` and a new field is encountered
+            ``mongoengine.errors.ValidationError``: if a field of a sample has
+                a type that is inconsistent with the dataset schema, or if
+                ``expand_schema == False`` and a new field is encountered
         """
         if num_samples is None:
             try:

--- a/fiftyone/core/expressions.py
+++ b/fiftyone/core/expressions.py
@@ -505,6 +505,32 @@ class ViewExpression(object):
         """
         return ViewExpression({"$in": [value, self]})
 
+    def first(self):
+        """Returns the first value in the expression, which must resolve to an
+        array.
+
+        Returns:
+            a :class:`ViewExpression`
+        """
+        return ViewExpression({"$first": self})
+
+    def last(self):
+        """Returns the last value in the expression, which must resolve to an
+        array.
+
+        Returns:
+            a :class:`ViewExpression`
+        """
+        return ViewExpression({"$last": self})
+
+    def reverse(self):
+        """Reverses the order of the elements in the array expression.
+
+        Returns:
+            a :class:`ViewExpression`
+        """
+        return ViewExpression({"$reverseArray": self})
+
     def filter(self, expr):
         """Applies the given filter to the elements of this expression, which
         must resolve to an array.
@@ -543,12 +569,40 @@ class ViewExpression(object):
             {"$map": {"input": self, "in": expr.to_mongo(prefix="$$this")}}
         )
 
+    def min(self):
+        """Returns the minimum value in this expression, which must resolve to
+        a numeric array.
+
+        Missing or ``None``-valued elements are ignored.
+
+        Returns:
+            a :class:`ViewExpression`
+        """
+        return ViewExpression({"$min": self})
+
+    def max(self):
+        """Returns the maximum value in this expression, which must resolve to
+        a numeric array.
+
+        Missing or ``None``-valued elements are ignored.
+
+        Returns:
+            a :class:`ViewExpression`
+        """
+        return ViewExpression({"$max": self})
+
     def sum(self):
         """Returns the sum of the values in this expression, which must resolve
         to a numeric array.
 
+        Missing, non-numeric, or ``None``-valued elements are ignored.
+
         Returns:
             a :class:`ViewExpression`
+        """
+        return ViewExpression({"$sum": self})
+
+        # @todo is this version needed?
         """
         return ViewExpression(
             {
@@ -559,6 +613,7 @@ class ViewExpression(object):
                 }
             }
         )
+        """
 
     # String expression operators #############################################
 

--- a/fiftyone/core/expressions.py
+++ b/fiftyone/core/expressions.py
@@ -405,6 +405,36 @@ class ViewExpression(object):
         """
         return ViewExpression({"$trunc": [self, place]})
 
+    # Field expression operators ##############################################
+
+    def apply(self, expr):
+        """Applies the given expression to this expression.
+
+        Examples::
+
+            from fiftyone import ViewField as F
+
+            # Show samples whose first detection in the `predictions` field
+            # has confidence > 0.95
+            view = dataset.match(
+                F("predictions.detections")[0].apply(F("confidence") > 0.95)
+            )
+
+        Args:
+            expr: a :class:`ViewExpression`
+
+        Returns:
+            a :class:`ViewExpression`
+        """
+        return ViewExpression(
+            {
+                "$let": {
+                    "vars": {"field": self},
+                    "in": expr.to_mongo(prefix="$$field"),
+                }
+            }
+        )
+
     # Array expression operators ##############################################
 
     def __getitem__(self, idx_or_slice):
@@ -505,24 +535,6 @@ class ViewExpression(object):
         """
         return ViewExpression({"$in": [value, self]})
 
-    def first(self):
-        """Returns the first value in the expression, which must resolve to an
-        array.
-
-        Returns:
-            a :class:`ViewExpression`
-        """
-        return ViewExpression({"$first": self})
-
-    def last(self):
-        """Returns the last value in the expression, which must resolve to an
-        array.
-
-        Returns:
-            a :class:`ViewExpression`
-        """
-        return ViewExpression({"$last": self})
-
     def reverse(self):
         """Reverses the order of the elements in the array expression.
 
@@ -614,6 +626,17 @@ class ViewExpression(object):
             }
         )
         """
+
+    def mean(self):
+        """Returns the average value in this expression, which must resolve to
+        a numeric array.
+
+        Missing or ``None``-valued elements are ignored.
+
+        Returns:
+            a :class:`ViewExpression`
+        """
+        return ViewExpression({"$avg": self})
 
     # String expression operators #############################################
 

--- a/fiftyone/core/frame_utils.py
+++ b/fiftyone/core/frame_utils.py
@@ -20,8 +20,8 @@ def is_frame_number(value):
         True/False
 
     Raises:
-        :class:`FrameError` if ``value`` is an integer but is not strictly
-        positive
+        :class:`FrameError`: if ``value`` is an integer but is not strictly
+            positive
     """
     if isinstance(value, six.integer_types):
         if value < 1:
@@ -43,7 +43,7 @@ def validate_frame_number(value):
         value: a value
 
     Raises:
-        :class:`FrameError` if ``value`` is not a frame number
+        :class:`FrameError`: if ``value`` is not a frame number
     """
     if not isinstance(value, six.integer_types):
         raise FrameError(

--- a/fiftyone/core/stages.py
+++ b/fiftyone/core/stages.py
@@ -1092,11 +1092,13 @@ class LimitLabels(ViewStage):
                 % self.__class__
             )
 
+        limit = max(self._limit, 0)
+
         return [
             {
                 "$addFields": {
                     self._labels_list_field: {
-                        "$slice": ["$" + self._labels_list_field, self._limit]
+                        "$slice": ["$" + self._labels_list_field, limit]
                     }
                 }
             }

--- a/fiftyone/core/stages.py
+++ b/fiftyone/core/stages.py
@@ -93,8 +93,8 @@ class ViewStage(object):
                 :class:`fiftyone.core.collections.SampleCollection`
 
         Raises:
-            :class:`ViewStageError` if the stage cannot be applied to the
-            collection
+            :class:`ViewStageError`: if the stage cannot be applied to the
+                collection
         """
         pass
 

--- a/fiftyone/core/state.py
+++ b/fiftyone/core/state.py
@@ -113,9 +113,9 @@ class StateDescription(etas.Serializable):
         if dataset is not None:
             view = fov.DatasetView(dataset)
             if view_ is not None:
-                view._stages = [
-                    fos.ViewStage._from_dict(s) for s in view_["view"]
-                ]
+                for stage_dict in view_["view"]:
+                    stage = fos.ViewStage._from_dict(stage_dict)
+                    view = view.add_stage(stage)
 
         selected = d.get("selected", [])
 


### PR DESCRIPTION
Change log
- Adds a `filter_labels()` view stage that will perform the same action as `filter_classifications/detections/polylines/keypoints` without the user having to hard-code the field type in the stage name
- Adds a `limit_labels()` view stage that can be used to set an upper bound on the number of labels (e.g., detections) you want to see in each field of a sample
- Adds some additional `ViewExpression`s, including `max()`, `min()`, `mean()`, `reverse()`, and `apply()`

Now that `filter_labels()` exists, I wish we could just delete the other `filter_XXX` methods; but I fear that users are likely using those...

There are unit tests for `filter_labels()` and `limit_labels()` in the PR. For the others, I just ran the following:

```py

import fiftyone as fo
import fiftyone.zoo as foz
from fiftyone import ViewField as F


dataset = foz.load_zoo_dataset("quickstart")

session = fo.launch_app(dataset)

# Use generic `filter_labels()`, which will filter any labels list field
# Also limit to at most 5 labels in each field
session.view = (
    dataset
    .filter_labels("predictions", F("confidence") > 0.75, only_matches=True)
    .sort_by(F("predictions.detections").length(), reverse=True)
    .limit_labels("ground_truth", 5)
    .limit_labels("predictions", 5)
)

# Only show samples whose first prediction has confidence > 0.99
session.view = (
    dataset
    .match(F("predictions.detections")[0].apply(F("confidence") > 0.99))
)

# Sort by sum-total prediction confidence
session.view = (
    dataset
    .sort_by(F("predictions.detections").map(F("confidence")).sum(), reverse=True)
)

# Sort by min prediction confidence
session.view = (
    dataset
    .sort_by(F("predictions.detections").map(F("confidence")).min(), reverse=False)
)

# Sort by max prediction confidence
session.view = (
    dataset
    .sort_by(F("predictions.detections").map(F("confidence")).max(), reverse=True)
)

# Sort by average prediction confidence
session.view = (
    dataset
    .sort_by(F("predictions.detections").map(F("confidence")).mean(), reverse=True)
)
```