### PR TITLE
Allow clearing hidden objects in filter widgets

### DIFF
--- a/electron/app/components/Filter.tsx
+++ b/electron/app/components/Filter.tsx
@@ -10,10 +10,12 @@ import useMeasure from "react-use-measure";
 import * as atoms from "../recoil/atoms";
 import { getSocket } from "../utils/socket";
 import * as selectors from "../recoil/selectors";
+import { SampleContext } from "../utils/context";
 import { useOutsideClick } from "../utils/hooks";
 import SearchResults from "./ViewBar/ViewStage/SearchResults";
 import { NamedRangeSlider } from "./RangeSlider";
 import { VALID_LIST_TYPES } from "../utils/labels";
+import { removeObjectIDsFromSelection } from "../utils/selection";
 
 const classFilterMachine = Machine({
   id: "classFilter",
@@ -191,6 +193,16 @@ const classFilterMachine = Machine({
   },
 });
 
+const FilterHeader = styled.div`
+  display: flex;
+  justify-content: space-between;
+
+  a {
+    cursor: pointer;
+    text-decoration: underline;
+  }
+`;
+
 const ClassInput = styled.input`
   width: 100%;
   background: ${({ theme }) => theme.backgroundDark};
@@ -268,17 +280,12 @@ const ClassFilter = ({ name, atoms }) => {
 
   return (
     <>
-      <div style={{ display: "flex", justifyContent: "space-between" }}>
+      <FilterHeader>
         Labels{" "}
         {selected.length ? (
-          <a
-            style={{ cursor: "pointer", textDecoration: "underline" }}
-            onClick={() => send({ type: "CLEAR" })}
-          >
-            clear {selected.length}
-          </a>
+          <a onClick={() => send({ type: "CLEAR" })}>clear {selected.length}</a>
         ) : null}
-      </div>
+      </FilterHeader>
       <ClassFilterContainer>
         <div ref={inputRef}>
           <ClassInput
@@ -391,6 +398,36 @@ const makeFilter = (fieldName, cls, labels, range, includeNone, hasBounds) => {
   };
 };
 
+const HiddenObjectFilter = ({ entry }) => {
+  const fieldName = entry.name;
+  const sample = useContext(SampleContext);
+  const [hiddenObjects, setHiddenObjects] = useRecoilState(atoms.hiddenObjects);
+  if (!sample) {
+    return null;
+  }
+
+  const sampleHiddenObjectIDs = Object.entries(hiddenObjects)
+    .filter(
+      ([object_id, data]) =>
+        data.sample_id === sample._id && data.field === fieldName
+    )
+    .map(([object_id]) => object_id);
+  if (!sampleHiddenObjectIDs.length) {
+    return null;
+  }
+  const clear = () =>
+    setHiddenObjects((hiddenObjects) =>
+      removeObjectIDsFromSelection(hiddenObjects, sampleHiddenObjectIDs)
+    );
+
+  return (
+    <FilterHeader>
+      Manually hidden: {sampleHiddenObjectIDs.length}
+      <a onClick={clear}>reset</a>
+    </FilterHeader>
+  );
+};
+
 const Filter = React.memo(({ expanded, style, entry, modal, ...rest }) => {
   const port = useRecoilValue(atoms.port);
   const socket = getSocket(port, "state");
@@ -480,6 +517,7 @@ const Filter = React.memo(({ expanded, style, entry, modal, ...rest }) => {
     <animated.div style={{ ...props, overflow }}>
       <div ref={ref}>
         <div style={{ margin: 3 }}>
+          <HiddenObjectFilter entry={entry} />
           <ClassFilter name={entry.name} atoms={rest} />
           <NamedRangeSlider
             color={entry.color}

--- a/electron/app/components/SampleModal.tsx
+++ b/electron/app/components/SampleModal.tsx
@@ -11,6 +11,7 @@ import SelectObjectsMenu from "./SelectObjectsMenu";
 import { Button, ModalFooter } from "./utils";
 import * as selectors from "../recoil/selectors";
 import * as atoms from "../recoil/atoms";
+import { SampleContext } from "../utils/context";
 import { getSocket } from "../utils/socket";
 
 import {
@@ -446,138 +447,140 @@ const SampleModal = ({
   }, {});
 
   return (
-    <Container className={fullscreen ? "fullscreen" : ""}>
-      <div className="player" ref={playerContainerRef}>
-        {showJSON ? (
-          <JSONView
-            object={sample}
-            filterJSON={enableJSONFilter}
-            enableFilter={setEnableJSONFilter}
-          />
-        ) : (
-          <Player51
-            key={sampleUrl} // force re-render when this changes
-            src={sampleUrl}
-            onLoad={handleResize}
-            style={{
-              position: "relative",
-              ...playerStyle,
-            }}
-            sample={sample}
-            overlay={videoLabels}
-            metadata={metadata}
-            colorMap={colorMap}
-            activeLabels={activeLabels}
-            fieldSchema={fieldSchema}
-            filterSelector={selectors.modalLabelFilters}
-            playerRef={playerRef}
-            defaultOverlayOptions={savedOverlayOptions}
-            selectedObjects={selectedObjectIDs}
-            onSelectObject={({ id, name }) => {
-              toggleSelectedObject(id, {
-                sample_id: sample._id,
-                field: name,
-                frame_number: frameNumberRef.current,
-              });
-            }}
-          />
-        )}
-        {onPrevious ? (
-          <div
-            className="nav-button left"
-            onClick={onPrevious}
-            title="Previous sample (Left arrow)"
-          >
-            &lt;
-          </div>
-        ) : null}
-        {onNext ? (
-          <div
-            className="nav-button right"
-            onClick={onNext}
-            title="Next sample (Right arrow)"
-          >
-            &gt;
-          </div>
-        ) : null}
-        <TopRightNavButtons>
-          <TopRightNavButton
-            onClick={() => setFullscreen(!fullscreen)}
-            title={fullscreen ? "Unmaximize (Esc)" : "Maximize"}
-            icon={fullscreen ? <FullscreenExit /> : <Fullscreen />}
-          />
-        </TopRightNavButtons>
-      </div>
-      <div className="sidebar">
-        <div className="sidebar-content">
-          <h2>
-            Metadata
-            <span className="push-right" />
-          </h2>
-          <Row name="ID" value={sample._id} />
-          <Row name="Source" value={sample.filepath} />
-          <Row name="Media type" value={sample.media_type} />
-          {formatMetadata(sample.metadata).map(({ name, value }) => (
-            <Row key={"metadata-" + name} name={name} value={value} />
-          ))}
-          <h2>
-            Display Options
-            <span className="push-right" />
-          </h2>
-          <div className="select-objects-wrapper">
-            <SelectObjectsMenu
+    <SampleContext.Provider value={sample}>
+      <Container className={fullscreen ? "fullscreen" : ""}>
+        <div className="player" ref={playerContainerRef}>
+          {showJSON ? (
+            <JSONView
+              object={sample}
+              filterJSON={enableJSONFilter}
+              enableFilter={setEnableJSONFilter}
+            />
+          ) : (
+            <Player51
+              key={sampleUrl} // force re-render when this changes
+              src={sampleUrl}
+              onLoad={handleResize}
+              style={{
+                position: "relative",
+                ...playerStyle,
+              }}
               sample={sample}
-              frameNumberRef={frameNumberRef}
+              overlay={videoLabels}
+              metadata={metadata}
+              colorMap={colorMap}
+              activeLabels={activeLabels}
+              fieldSchema={fieldSchema}
+              filterSelector={selectors.modalLabelFilters}
+              playerRef={playerRef}
+              defaultOverlayOptions={savedOverlayOptions}
+              selectedObjects={selectedObjectIDs}
+              onSelectObject={({ id, name }) => {
+                toggleSelectedObject(id, {
+                  sample_id: sample._id,
+                  field: name,
+                  frame_number: frameNumberRef.current,
+                });
+              }}
+            />
+          )}
+          {onPrevious ? (
+            <div
+              className="nav-button left"
+              onClick={onPrevious}
+              title="Previous sample (Left arrow)"
+            >
+              &lt;
+            </div>
+          ) : null}
+          {onNext ? (
+            <div
+              className="nav-button right"
+              onClick={onNext}
+              title="Next sample (Right arrow)"
+            >
+              &gt;
+            </div>
+          ) : null}
+          <TopRightNavButtons>
+            <TopRightNavButton
+              onClick={() => setFullscreen(!fullscreen)}
+              title={fullscreen ? "Unmaximize (Esc)" : "Maximize"}
+              icon={fullscreen ? <FullscreenExit /> : <Fullscreen />}
+            />
+          </TopRightNavButtons>
+        </div>
+        <div className="sidebar">
+          <div className="sidebar-content">
+            <h2>
+              Metadata
+              <span className="push-right" />
+            </h2>
+            <Row name="ID" value={sample._id} />
+            <Row name="Source" value={sample.filepath} />
+            <Row name="Media type" value={sample.media_type} />
+            {formatMetadata(sample.metadata).map(({ name, value }) => (
+              <Row key={"metadata-" + name} name={name} value={value} />
+            ))}
+            <h2>
+              Display Options
+              <span className="push-right" />
+            </h2>
+            <div className="select-objects-wrapper">
+              <SelectObjectsMenu
+                sample={sample}
+                frameNumberRef={frameNumberRef}
+              />
+            </div>
+            <DisplayOptionsSidebar
+              colorMap={colorMap}
+              tags={getDisplayOptions(
+                tagNames.map((t) => ({ name: t })),
+                tagSampleExists,
+                activeTags,
+                true
+              )}
+              labels={getDisplayOptions(
+                labelNameGroups.labels,
+                labelSampleValues,
+                activeLabels,
+                false,
+                filteredLabelSampleValues
+              )}
+              onSelectLabel={handleSetDisplayOption(setActiveLabels)}
+              scalars={getDisplayOptions(
+                labelNameGroups.scalars,
+                scalarSampleValues,
+                activeLabels
+              )}
+              onSelectScalar={handleSetDisplayOption(setActiveLabels)}
+              unsupported={getDisplayOptions(
+                labelNameGroups.unsupported,
+                otherSampleValues,
+                activeLabels
+              )}
+              style={{
+                overflowY: "auto",
+                overflowX: "hidden",
+                height: "auto",
+              }}
+              modal={true}
+            />
+            <TopRightNavButton
+              onClick={onClose}
+              title={"Close"}
+              icon={<Close />}
+              style={{ position: "absolute", top: 0, right: 0 }}
             />
           </div>
-          <DisplayOptionsSidebar
-            colorMap={colorMap}
-            tags={getDisplayOptions(
-              tagNames.map((t) => ({ name: t })),
-              tagSampleExists,
-              activeTags,
-              true
-            )}
-            labels={getDisplayOptions(
-              labelNameGroups.labels,
-              labelSampleValues,
-              activeLabels,
-              false,
-              filteredLabelSampleValues
-            )}
-            onSelectLabel={handleSetDisplayOption(setActiveLabels)}
-            scalars={getDisplayOptions(
-              labelNameGroups.scalars,
-              scalarSampleValues,
-              activeLabels
-            )}
-            onSelectScalar={handleSetDisplayOption(setActiveLabels)}
-            unsupported={getDisplayOptions(
-              labelNameGroups.unsupported,
-              otherSampleValues,
-              activeLabels
-            )}
-            style={{
-              overflowY: "auto",
-              overflowX: "hidden",
-              height: "auto",
-            }}
-            modal={true}
-          />
-          <TopRightNavButton
-            onClick={onClose}
-            title={"Close"}
-            icon={<Close />}
-            style={{ position: "absolute", top: 0, right: 0 }}
-          />
+          <ModalFooter>
+            <Button onClick={() => setShowJSON(!showJSON)}>
+              {showJSON ? "Hide" : "Show"} JSON
+            </Button>
+          </ModalFooter>
         </div>
-        <ModalFooter>
-          <Button onClick={() => setShowJSON(!showJSON)}>
-            {showJSON ? "Hide" : "Show"} JSON
-          </Button>
-        </ModalFooter>
-      </div>
-    </Container>
+      </Container>
+    </SampleContext.Provider>
   );
 };
 

--- a/electron/app/components/SelectObjectsMenu.tsx
+++ b/electron/app/components/SelectObjectsMenu.tsx
@@ -64,17 +64,16 @@ const SelectObjectsMenu = ({ sample, frameNumberRef }) => {
     (obj) => selectedObjects[obj._id]
   ).length;
 
+  const _getObjectSelectionData = (object) => ({
+    object_id: object._id,
+    sample_id: sample._id,
+    field: object.name,
+    frame_number: object.frame_number,
+  });
+
   const _selectAll = (objects) => {
     setSelectedObjects((selection) =>
-      addObjectsToSelection(
-        selection,
-        objects.map((obj) => ({
-          object_id: obj._id,
-          sample_id: sample._id,
-          field: obj.name,
-          frame_number: obj.frame_number,
-        }))
-      )
+      addObjectsToSelection(selection, objects.map(_getObjectSelectionData))
     );
   };
 
@@ -98,25 +97,24 @@ const SelectObjectsMenu = ({ sample, frameNumberRef }) => {
   const hideSelected = () => {
     const ids = Object.keys(selectedObjects);
     resetSelectedObjects();
-    setHiddenObjects((hiddenObjects) => {
-      const newHidden = new Set(hiddenObjects);
-      for (const id of ids) {
-        newHidden.add(id);
-      }
-      return newHidden;
-    });
+    // can copy data directly from selectedObjects since it's in the same format
+    setHiddenObjects((hiddenObjects) =>
+      addObjectsToSelection(
+        hiddenObjects,
+        ids.map((object_id) => ({ object_id, ...selectedObjects[object_id] }))
+      )
+    );
   };
 
   const hideOthers = (objects) => {
-    setHiddenObjects((hiddenObjects) => {
-      const newHidden = new Set(hiddenObjects);
-      for (const obj of objects) {
-        if (!selectedObjects[obj._id]) {
-          newHidden.add(obj._id);
-        }
-      }
-      return newHidden;
-    });
+    setHiddenObjects((hiddenObjects) =>
+      addObjectsToSelection(
+        hiddenObjects,
+        objects
+          .filter((obj) => !selectedObjects[obj._id])
+          .map(_getObjectSelectionData)
+      )
+    );
   };
 
   const refresh = useFastRerender();

--- a/electron/app/recoil/atoms.ts
+++ b/electron/app/recoil/atoms.ts
@@ -27,9 +27,9 @@ export const selectedObjects = atom<SelectedObjectMap>({
   default: {},
 });
 
-export const hiddenObjects = atom<Set<string>>({
+export const hiddenObjects = atom<SelectedObjectMap>({
   key: "hiddenObjects",
-  default: new Set(),
+  default: {},
 });
 
 export const stageInfo = atom({

--- a/electron/app/recoil/selectors.ts
+++ b/electron/app/recoil/selectors.ts
@@ -200,7 +200,7 @@ export const modalLabelFilters = selector({
       const none = get(atoms.modalFilterLabelIncludeNoConfidence(label));
       const include = get(atoms.modalFilterIncludeLabels(label));
       filters[label] = (s) => {
-        if (hiddenObjects.has(s.id)) {
+        if (hiddenObjects[s.id]) {
           return false;
         }
         const inRange =

--- a/electron/app/utils/context.ts
+++ b/electron/app/utils/context.ts
@@ -1,0 +1,3 @@
+import { createContext } from "react";
+
+export const SampleContext = createContext(null);


### PR DESCRIPTION
## What changes are proposed in this pull request?

Closes #644 

![image](https://user-images.githubusercontent.com/3719547/97470647-270feb00-191e-11eb-8965-53f4d3cc6e9b.png)

The only thing left is to highlight the relevant filters when this control is available - @benjaminpkane what controls that color?

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

Extension of #637

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
