### PR TITLE
Remove stage validation from aggregate

### DIFF
--- a/fiftyone/core/view.py
+++ b/fiftyone/core/view.py
@@ -278,7 +278,6 @@ class DatasetView(foc.SampleCollection):
 
         _frames_pipeline = []
         for s in self._stages:
-            s.validate(self)  # @todo don't re-validate here
             _pipeline.extend(s.to_mongo(self))
 
         if pipeline is not None:

--- a/fiftyone/server/main.py
+++ b/fiftyone/server/main.py
@@ -268,8 +268,12 @@ class StateController(Namespace):
         state = fos.StateDescription.from_dict(self.state)
         if state.dataset is None:
             return []
+
         view = fov.DatasetView(state.dataset)
-        view._stages = [fosg.ViewStage._from_dict(s) for s in stages]
+        for stage_dict in stages:
+            stage = fosg.ViewStage._from_dict(stage_dict)
+            view.add_stage(stage)
+
         return fos.DatasetStatistics(view).serialize()["stats"]
 
     @_catch_errors


### PR DESCRIPTION
* Removes improper `_stages =` usage from the server, which skips stage validation
* Removes redundant validation from `SampleCollections.aggregate()` 