### PR TITLE
Only show filtered count when informative

### DIFF
--- a/electron/app/components/ImageContainerHeader.tsx
+++ b/electron/app/components/ImageContainerHeader.tsx
@@ -41,7 +41,7 @@ const ImageContainerHeader = ({ showSidebar, onShowSidebar }: Props) => {
   const totalCount = useRecoilValue(selectors.totalCount);
   const filteredCount = useRecoilValue(selectors.filteredCount);
   const countStr =
-    typeof filteredCount === "number"
+    typeof filteredCount === "number" && filteredCount !== totalCount
       ? `${filteredCount.toLocaleString()} of ${totalCount.toLocaleString()}`
       : (totalCount || 0).toLocaleString();
   return (


### PR DESCRIPTION
## What changes are proposed in this pull request?

Resolves #652 . Only shows the total when no filtered count has been calculated, or the filtered count is equal to the total count.

## How is this patch tested? If it is not, please explain why.

Locally.

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.