### PR TITLE
Compare _cls and kwargs when comparing view stages in the App

### DIFF
--- a/electron/app/components/ViewBar/viewBarMachine.ts
+++ b/electron/app/components/ViewBar/viewBarMachine.ts
@@ -101,7 +101,8 @@ function makeEmptyView(fieldNames, stageInfo) {
   ];
 }
 
-const viewCompareMapper = (stages) => stages.map((stage) => stage.kwargs);
+const viewCompareMapper = (stages) =>
+  stages.map(({ kwargs, _cls }) => ({ kwargs, _cls }));
 
 const viewsAreEqual = (viewOne, viewTwo) => {
   return (


### PR DESCRIPTION
## What changes are proposed in this pull request?

Resolves #647. Previously, view equality in the view bar was only informed by `kwargs` and not the classes of the stages. This meant that the view bar considered different stage classes with the same arguments to be equal.

## How is this patch tested? If it is not, please explain why.

Locally.

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.