### PR TITLE
Expandable plots

### DIFF
--- a/electron/app/Routes.tsx
+++ b/electron/app/Routes.tsx
@@ -7,6 +7,8 @@ import Dataset from "./containers/Dataset";
 import Setup from "./containers/Setup";
 import Loading from "./containers/Loading";
 
+export const PLOTS = ["labels", "scalars", "tags"];
+
 function Routes() {
   return (
     <App>

--- a/electron/app/app.global.css
+++ b/electron/app/app.global.css
@@ -48,17 +48,6 @@ body.noscroll {
   height: 100%;
 }
 
-.sample-info {
-  position: absolute;
-  width: 100%;
-  max-height: 100%;
-  display: block;
-  z-index: 100;
-  overflow-y: hidden;
-  padding: 0.5rem;
-  bottom: 0;
-}
-
 .hide-info .sample:not(:hover) .sample-info {
   display: none !important;
 }

--- a/electron/app/app.global.css
+++ b/electron/app/app.global.css
@@ -32,6 +32,7 @@ body.noscroll {
 
 #root {
   height: 100%;
+  overflow: hidden;
 }
 
 .ui.vertical.inverted.menu .menu span.item {

--- a/electron/app/components/DisplayOptionsSidebar.tsx
+++ b/electron/app/components/DisplayOptionsSidebar.tsx
@@ -38,9 +38,7 @@ type Props = {
 };
 
 const Container = styled.div`
-  margin-bottom: 2px;
   height: 100%;
-  padding-bottom: 1em;
   ${scrollbarStyles};
 
   .MuiCheckbox-root {
@@ -248,6 +246,7 @@ const DisplayOptionsSidebar = React.forwardRef(
             Refresh colors
           </Button>
         ) : null}
+        <div style={{ height: "1rem", width: "100%" }} />
       </Container>
     );
   }

--- a/electron/app/components/Distributions.tsx
+++ b/electron/app/components/Distributions.tsx
@@ -1,12 +1,22 @@
 import React, { useState, useRef, PureComponent } from "react";
 import { Bar, BarChart, XAxis, YAxis, Tooltip } from "recharts";
 import { useRecoilValue } from "recoil";
-import { Dimmer, Header, Loader, Message, Segment } from "semantic-ui-react";
+import styled from "styled-components";
+import { Dimmer, Header, Loader, Message } from "semantic-ui-react";
 import _ from "lodash";
+import { scrollbarStyles } from "./utils";
 
 import { useSubscribe } from "../utils/socket";
 import { isFloat } from "../utils/generic";
 import * as selectors from "../recoil/selectors";
+
+const Container = styled.div`
+  ${scrollbarStyles}
+  overflow-y: hidden;
+  overflow-x: scroll;
+  width: 100%;
+  padding-left: 1rem;
+`;
 
 class CustomizedAxisTick extends PureComponent {
   render() {
@@ -29,10 +39,14 @@ class CustomizedAxisTick extends PureComponent {
   }
 }
 
+const Title = styled.div`
+  font-weight: bold;
+  font-size: 1rem;
+`;
+
 const Distribution = ({ distribution }) => {
   const { name, type, data } = distribution;
   const barWidth = 30;
-  const [rightMargin, setRightMargin] = useState(0);
   const container = useRef(null);
   const stroke = "hsl(210, 20%, 90%)";
   const fill = stroke;
@@ -40,15 +54,15 @@ const Distribution = ({ distribution }) => {
   const padding = isNumeric ? 0 : 20;
 
   return (
-    <Segment style={{ overflowY: "auto", margin: "2rem 0" }}>
-      <Header as="h3">{`${name}: ${type}`}</Header>
+    <Container>
+      <Title>{`${name}: ${type}`}</Title>
       <BarChart
         ref={container}
-        height={500}
+        height={300}
         width={data.length * (barWidth + padding)}
         barCategoryGap={"20px"}
         data={data}
-        margin={{ top: 0, left: 0, bottom: 0, right: rightMargin + 5 }}
+        margin={{ top: 0, left: 0, bottom: 0, right: 5 }}
       >
         <XAxis
           dataKey="key"
@@ -79,17 +93,18 @@ const Distribution = ({ distribution }) => {
           barSize={barWidth}
         />
       </BarChart>
-    </Segment>
+    </Container>
   );
 };
 
-function NoDistributions({ name }) {
-  return (
-    <Segment>
-      <Message>No {name}</Message>
-    </Segment>
-  );
-}
+const DistributionsContainer = styled.div`
+  padding: 1rem 0;
+  overflow-y: scroll;
+  overflow-x: hidden;
+  width: 100%;
+  height: 100%;
+  ${scrollbarStyles}
+`;
 
 const Distributions = ({ group }) => {
   const socket = useRecoilValue(selectors.socket);
@@ -122,16 +137,12 @@ const Distributions = ({ group }) => {
     );
   }
 
-  if (!data.length) {
-    return <NoDistributions name={group} />;
-  }
-
   return (
-    <>
+    <DistributionsContainer>
       {data.map((distribution, i) => {
         return <Distribution key={i} distribution={distribution} />;
       })}
-    </>
+    </DistributionsContainer>
   );
 };
 

--- a/electron/app/components/Distributions.tsx
+++ b/electron/app/components/Distributions.tsx
@@ -59,7 +59,6 @@ const Distribution = ({ distribution }) => {
   const stroke = "hsl(210, 20%, 90%)";
   const fill = stroke;
   const isNumeric = _.indexOf(["int", "float"], type) >= 0;
-  const padding = 20;
 
   return (
     <Container ref={ref}>
@@ -67,8 +66,8 @@ const Distribution = ({ distribution }) => {
       <BarChart
         ref={container}
         height={height - 32}
-        width={data.length * (barWidth + 20) + 50}
-        barCategoryGap={"20px"}
+        width={data.length * (barWidth + 4) + 50}
+        barCategoryGap={"4px"}
         data={data}
         margin={{ top: 0, left: 0, bottom: 0, right: 0 }}
       >

--- a/electron/app/components/Distributions.tsx
+++ b/electron/app/components/Distributions.tsx
@@ -98,11 +98,10 @@ const Distribution = ({ distribution }) => {
 };
 
 const DistributionsContainer = styled.div`
-  padding: 1rem 0;
   overflow-y: scroll;
   overflow-x: hidden;
   width: 100%;
-  height: 100%;
+  height: calc(100% - 2rem);
   ${scrollbarStyles}
 `;
 

--- a/electron/app/components/Distributions.tsx
+++ b/electron/app/components/Distributions.tsx
@@ -54,7 +54,7 @@ const Title = styled.div`
 const Distribution = ({ distribution }) => {
   const { name, type, data } = distribution;
   const [ref, { height }] = useMeasure();
-  const barWidth = 30;
+  const barWidth = 24;
   const container = useRef(null);
   const stroke = "hsl(210, 20%, 90%)";
   const fill = stroke;

--- a/electron/app/components/Distributions.tsx
+++ b/electron/app/components/Distributions.tsx
@@ -33,7 +33,6 @@ class CustomizedAxisTick extends PureComponent {
           textAnchor="end"
           fill={fill}
           transform="rotate(-80)"
-          xlinkTitle={v}
         >
           {isFloat(v)
             ? v.toFixed(3)

--- a/electron/app/components/Distributions.tsx
+++ b/electron/app/components/Distributions.tsx
@@ -2,6 +2,7 @@ import React, { useState, useRef, PureComponent } from "react";
 import { Bar, BarChart, XAxis, YAxis, Tooltip } from "recharts";
 import { useRecoilValue } from "recoil";
 import styled from "styled-components";
+import useMeasure from "react-use-measure";
 import { Dimmer, Header, Loader, Message } from "semantic-ui-react";
 import _ from "lodash";
 import { scrollbarStyles } from "./utils";
@@ -15,6 +16,7 @@ const Container = styled.div`
   overflow-y: hidden;
   overflow-x: scroll;
   width: 100%;
+  height: 100%;
   padding-left: 1rem;
 `;
 
@@ -31,8 +33,13 @@ class CustomizedAxisTick extends PureComponent {
           textAnchor="end"
           fill={fill}
           transform="rotate(-80)"
+          xlinkTitle={v}
         >
-          {isFloat(v) ? v.toFixed(3) : v}
+          {isFloat(v)
+            ? v.toFixed(3)
+            : v.length > 24
+            ? v.slice(0, 21) + "..."
+            : v}
         </text>
       </g>
     );
@@ -42,33 +49,35 @@ class CustomizedAxisTick extends PureComponent {
 const Title = styled.div`
   font-weight: bold;
   font-size: 1rem;
+  line-height: 2rem;
 `;
 
 const Distribution = ({ distribution }) => {
   const { name, type, data } = distribution;
+  const [ref, { height }] = useMeasure();
   const barWidth = 30;
   const container = useRef(null);
   const stroke = "hsl(210, 20%, 90%)";
   const fill = stroke;
   const isNumeric = _.indexOf(["int", "float"], type) >= 0;
-  const padding = isNumeric ? 0 : 20;
+  const padding = 20;
 
   return (
-    <Container>
+    <Container ref={ref}>
       <Title>{`${name}: ${type}`}</Title>
       <BarChart
         ref={container}
-        height={300}
-        width={data.length * (barWidth + padding)}
+        height={height - 32}
+        width={data.length * (barWidth + 20) + 50}
         barCategoryGap={"20px"}
         data={data}
-        margin={{ top: 0, left: 0, bottom: 0, right: 5 }}
+        margin={{ top: 0, left: 0, bottom: 0, right: 0 }}
       >
         <XAxis
           dataKey="key"
           type="category"
           interval={isNumeric ? "preserveStartEnd" : 0}
-          height={100}
+          height={0.2 * height}
           axisLine={false}
           tick={<CustomizedAxisTick {...{ fill }} />}
           tickLine={{ stroke }}
@@ -101,7 +110,7 @@ const DistributionsContainer = styled.div`
   overflow-y: scroll;
   overflow-x: hidden;
   width: 100%;
-  height: calc(100% - 2rem);
+  height: calc(100% - 3rem);
   ${scrollbarStyles}
 `;
 

--- a/electron/app/components/DropdownHandle.tsx
+++ b/electron/app/components/DropdownHandle.tsx
@@ -6,6 +6,7 @@ import CellHeader from "./CellHeader";
 
 const Body = styled(CellHeader)`
   width: 100%;
+  padding: 0.5rem;
 
   svg {
     font-size: 1.25em;

--- a/electron/app/components/Header.tsx
+++ b/electron/app/components/Header.tsx
@@ -18,7 +18,7 @@ const HeaderDiv = styled.div`
 
 const LogoDiv = styled.div`
   height: 40px;
-  margin: 1rem 1rem 1rem 2rem;
+  margin: 1rem;
 `;
 
 const LogoImg = styled.img`
@@ -37,7 +37,7 @@ const LeftDiv = styled.div`
 
 const RightDiv = styled.div`
   margin-left: auto;
-  padding-right: 1.5rem;
+  padding-right: 0.5rem;
 `;
 
 const TitleDiv = styled.div`

--- a/electron/app/components/Header.tsx
+++ b/electron/app/components/Header.tsx
@@ -14,9 +14,6 @@ const HeaderDiv = styled.div`
   justify-content: space-between;
   width: 100%;
   border-bottom: 1px ${({ theme }) => theme.backgroundDarkBorder} solid;
-  position: fixed;
-  z-index: 1000;
-  top: 0;
 `;
 
 const LogoDiv = styled.div`

--- a/electron/app/components/Header.tsx
+++ b/electron/app/components/Header.tsx
@@ -16,6 +16,7 @@ const HeaderDiv = styled.div`
   border-bottom: 1px ${({ theme }) => theme.backgroundDarkBorder} solid;
   position: fixed;
   z-index: 1000;
+  top: 0;
 `;
 
 const LogoDiv = styled.div`

--- a/electron/app/components/Header.tsx
+++ b/electron/app/components/Header.tsx
@@ -14,6 +14,8 @@ const HeaderDiv = styled.div`
   justify-content: space-between;
   width: 100%;
   border-bottom: 1px ${({ theme }) => theme.backgroundDarkBorder} solid;
+  position: fixed;
+  z-index: 1000;
 `;
 
 const LogoDiv = styled.div`

--- a/electron/app/components/HorizontalNav.stories.tsx
+++ b/electron/app/components/HorizontalNav.stories.tsx
@@ -10,12 +10,5 @@ export default {
 };
 
 export const standard = () => (
-  <HorizontalNav
-    entries={[
-      { name: "Link 1", path: "/1" },
-      { name: "Link 2", path: "/2" },
-      { name: "Link 3", path: "/3" },
-    ]}
-    currentPath="/1"
-  />
+  <HorizontalNav entries={["labels", "scalars", "tags"]} />
 );

--- a/electron/app/components/HorizontalNav.tsx
+++ b/electron/app/components/HorizontalNav.tsx
@@ -8,12 +8,13 @@ import KeyboardArrowUpIcon from "@material-ui/icons/KeyboardArrowUp";
 
 import Distributions from "./Distributions";
 import * as atoms from "../recoil/atoms";
+import { Resizable } from "re-resizable";
 
 export type Props = {
   entries: string[];
 };
 
-const Container = animated(styled.div`
+const Container = animated(styled(Resizable)`
   padding: 1rem 0 0;
   background-color: ${({ theme }) => theme.backgroundDark};
   border-bottom: 1px ${({ theme }) => theme.backgroundDarkBorder} solid;

--- a/electron/app/components/HorizontalNav.tsx
+++ b/electron/app/components/HorizontalNav.tsx
@@ -14,7 +14,7 @@ export type Props = {
 };
 
 const Container = animated(styled.div`
-  padding: 1rem 0;
+  padding: 1rem 0 0;
   background-color: ${({ theme }) => theme.backgroundDark};
   border-bottom: 1px ${({ theme }) => theme.backgroundDarkBorder} solid;
 `);
@@ -50,6 +50,7 @@ const PlotButton = styled.div`
 
 const TogglePlotsButton = animated(styled.div`
   line-height: 2rem;
+  padding: 0 0.5rem;
   cursor: pointer;
   background-color: ${({ theme }) => theme.button};
   height: 2rem;
@@ -61,6 +62,11 @@ const TogglePlotsButton = animated(styled.div`
 
   &.hidden {
     background-color: ${({ theme }) => theme.brand};
+  }
+  & > svg {
+    padding: 0.25rem;
+    height: 2rem;
+    width: 2rem;
   }
 `);
 
@@ -77,7 +83,7 @@ const HorizontalNav = ({ entries }: Props) => {
   });
 
   const container = useSpring({
-    height: expanded ? 408 : 64,
+    height: expanded ? 392 : 64,
   });
 
   return (
@@ -87,8 +93,11 @@ const HorizontalNav = ({ entries }: Props) => {
           {entries.map((e) => (
             <PlotButton
               key={e}
-              className={e === activePlot ? "active" : ""}
-              onClick={() => setActivePlot(e)}
+              className={e === activePlot && expanded ? "active" : ""}
+              onClick={() => {
+                setExpanded(true);
+                setActivePlot(e);
+              }}
             >
               {e}
             </PlotButton>
@@ -99,13 +108,11 @@ const HorizontalNav = ({ entries }: Props) => {
           style={togglePlotButton}
         >
           <AssessmentIcon />
-          <span style={{ padding: "0 1rem" }}>
-            {expanded ? "Hide" : "Show"}
-          </span>
+          <span>{expanded ? "Hide" : "Show"}</span>
           {expanded ? <KeyboardArrowDownIcon /> : <KeyboardArrowUpIcon />}
         </TogglePlotsButton>
       </Nav>
-      {expanded && <Distributions group={activePlot} />}
+      {expanded && <Distributions key={activePlot} group={activePlot} />}
     </Container>
   );
 };

--- a/electron/app/components/HorizontalNav.tsx
+++ b/electron/app/components/HorizontalNav.tsx
@@ -13,13 +13,14 @@ export type Props = {
 };
 
 const Body = styled.div`
-  margin: 0 -2rem;
   padding: 1rem 2rem;
   background-color: ${({ theme }) => theme.backgroundDark};
   border-bottom: 1px ${({ theme }) => theme.backgroundDarkBorder} solid;
   position: fixed;
   margin-top: 73px;
   z-index: 1000;
+  width: 100%;
+  top: 0;
 `;
 
 const Item = styled(Link)`

--- a/electron/app/components/HorizontalNav.tsx
+++ b/electron/app/components/HorizontalNav.tsx
@@ -1,25 +1,26 @@
-import React from "react";
-import { Link } from "react-router-dom";
+import React, { useState } from "react";
+import { useRecoilValue } from "recoil";
 import styled from "styled-components";
+import { capitalize } from "lodash";
 
-export type Entry = {
-  path: string;
-  name: string;
-};
+import * as atoms from "../recoil/atoms";
 
 export type Props = {
-  entries: Entry[];
-  currentPath: string;
+  entries: string[];
 };
 
 const Body = styled.div`
-  padding: 1rem 2rem;
+  padding: 1rem;
   background-color: ${({ theme }) => theme.backgroundDark};
   border-bottom: 1px ${({ theme }) => theme.backgroundDarkBorder} solid;
   width: 100%;
+  display: flex;
+  justify-content: space-between;
 `;
 
-const Item = styled(Link)`
+const Plots = styled.div``;
+
+const Plot = styled.div`
   display: inline-block;
   margin-right: 5px;
   padding: 0 1em;
@@ -35,18 +36,22 @@ const Item = styled(Link)`
   }
 `;
 
-const HorizontalNav = ({ entries, currentPath }: Props) => {
+const TogglePlots = styled.button``;
+
+const HorizontalNav = ({ entries }: Props) => {
+  const activePlot = useRecoilValue(atoms.activePlot);
+  const [expanded, setExpanded] = useState(false);
+
   return (
     <Body>
-      {entries.map((e) => (
-        <Item
-          key={e.path}
-          to={e.path}
-          className={e.path == currentPath ? "active" : ""}
-        >
-          {e.name}
-        </Item>
-      ))}
+      <Plots>
+        {entries.map((e) => (
+          <Plot key={e} className={e === activePlot ? "active" : ""}>
+            {capitalize(e)}
+          </Plot>
+        ))}
+      </Plots>
+      <TogglePlots>hello</TogglePlots>
     </Body>
   );
 };

--- a/electron/app/components/HorizontalNav.tsx
+++ b/electron/app/components/HorizontalNav.tsx
@@ -162,13 +162,15 @@ const HorizontalNav = ({ entries }: Props) => {
           ))}
         </PlotsButtons>
         <NavButtons>
-          <ToggleMaximize
-            maximized={maximized}
-            setMaximized={() => {
-              setMaximized(!maximized);
-              setExpanded(true);
-            }}
-          />
+          {expanded && (
+            <ToggleMaximize
+              maximized={maximized}
+              setMaximized={() => {
+                setMaximized(!maximized);
+                setExpanded(true);
+              }}
+            />
+          )}
           <TogglePlotsButton
             onClick={() => {
               setExpanded(!expanded);

--- a/electron/app/components/HorizontalNav.tsx
+++ b/electron/app/components/HorizontalNav.tsx
@@ -1,7 +1,10 @@
-import React, { useState } from "react";
+import React, { useContext, useState } from "react";
+import { animated, useSpring } from "react-spring";
 import { useRecoilValue } from "recoil";
-import styled from "styled-components";
-import { capitalize } from "lodash";
+import styled, { ThemeContext } from "styled-components";
+import AssessmentIcon from "@material-ui/icons/Assessment";
+import KeyboardArrowDownIcon from "@material-ui/icons/KeyboardArrowDown";
+import KeyboardArrowUpIcon from "@material-ui/icons/KeyboardArrowUp";
 
 import * as atoms from "../recoil/atoms";
 
@@ -18,40 +21,73 @@ const Body = styled.div`
   justify-content: space-between;
 `;
 
-const Plots = styled.div``;
+const PlotsButtons = styled.div``;
 
-const Plot = styled.div`
+const PlotButton = styled.div`
+  height: 1.5rem;
+  line-height: 1.5rem;
+  margin: 0.25rem 0.25rem 0.25rem 0;
+  cursor: pointer;
   display: inline-block;
   margin-right: 5px;
   padding: 0 1em;
   color: ${({ theme }) => theme.font};
   background-color: ${({ theme }) => theme.backgroundLight};
   text-decoration: none;
-  font-weight: bold;
   text-transform: capitalize;
   border-radius: 2px;
+  font-weight: bold;
 
   &.active {
     background-color: ${({ theme }) => theme.secondary};
   }
 `;
 
-const TogglePlots = styled.button``;
+const TogglePlotsButton = animated(styled.div`
+  line-height: 2rem;
+  cursor: pointer;
+  background-color: ${({ theme }) => theme.button};
+  height: 2rem;
+  border-radius: 1rem;
+  border: none;
+  font-weight: bold;
+  display: flex;
+  justify-content: space-between;
+
+  &.hidden {
+    background-color: ${({ theme }) => theme.brand};
+  }
+`);
 
 const HorizontalNav = ({ entries }: Props) => {
+  const theme = useContext(ThemeContext);
   const activePlot = useRecoilValue(atoms.activePlot);
   const [expanded, setExpanded] = useState(false);
+  const togglePlotButton = useSpring({
+    opacity: 1,
+    backgroundColor: expanded ? theme.button : theme.brand,
+    from: {
+      opacity: 0,
+    },
+  });
 
   return (
     <Body>
-      <Plots>
+      <PlotsButtons>
         {entries.map((e) => (
-          <Plot key={e} className={e === activePlot ? "active" : ""}>
-            {capitalize(e)}
-          </Plot>
+          <PlotButton key={e} className={e === activePlot ? "active" : ""}>
+            {e}
+          </PlotButton>
         ))}
-      </Plots>
-      <TogglePlots>hello</TogglePlots>
+      </PlotsButtons>
+      <TogglePlotsButton
+        onClick={() => setExpanded(!expanded)}
+        style={togglePlotButton}
+      >
+        <AssessmentIcon />
+        <span style={{ padding: "0 1rem" }}>{expanded ? "Hide" : "Show"}</span>
+        {expanded ? <KeyboardArrowDownIcon /> : <KeyboardArrowUpIcon />}
+      </TogglePlotsButton>
     </Body>
   );
 };

--- a/electron/app/components/HorizontalNav.tsx
+++ b/electron/app/components/HorizontalNav.tsx
@@ -17,6 +17,9 @@ const Body = styled.div`
   padding: 1rem 2rem;
   background-color: ${({ theme }) => theme.backgroundDark};
   border-bottom: 1px ${({ theme }) => theme.backgroundDarkBorder} solid;
+  position: fixed;
+  margin-top: 73px;
+  z-index: 1000;
 `;
 
 const Item = styled(Link)`

--- a/electron/app/components/HorizontalNav.tsx
+++ b/electron/app/components/HorizontalNav.tsx
@@ -16,11 +16,7 @@ const Body = styled.div`
   padding: 1rem 2rem;
   background-color: ${({ theme }) => theme.backgroundDark};
   border-bottom: 1px ${({ theme }) => theme.backgroundDarkBorder} solid;
-  position: fixed;
-  margin-top: 73px;
-  z-index: 1000;
   width: 100%;
-  top: 0;
 `;
 
 const Item = styled(Link)`

--- a/electron/app/components/HorizontalNav.tsx
+++ b/electron/app/components/HorizontalNav.tsx
@@ -109,7 +109,7 @@ const HorizontalNav = ({ entries }: Props) => {
         >
           <AssessmentIcon />
           <span>{expanded ? "Hide" : "Show"}</span>
-          {expanded ? <KeyboardArrowDownIcon /> : <KeyboardArrowUpIcon />}
+          {expanded ? <KeyboardArrowUpIcon /> : <KeyboardArrowDownIcon />}
         </TogglePlotsButton>
       </Nav>
       {expanded && <Distributions key={activePlot} group={activePlot} />}

--- a/electron/app/components/HorizontalNav.tsx
+++ b/electron/app/components/HorizontalNav.tsx
@@ -14,11 +14,11 @@ export type Props = {
   entries: string[];
 };
 
-const Container = animated(styled(Resizable)`
+const Container = styled(Resizable)`
   padding: 1rem 0 0;
   background-color: ${({ theme }) => theme.backgroundDark};
   border-bottom: 1px ${({ theme }) => theme.backgroundDarkBorder} solid;
-`);
+`;
 
 const Nav = styled.div`
   padding: 0 1rem;
@@ -27,7 +27,9 @@ const Nav = styled.div`
   justify-content: space-between;
 `;
 
-const PlotsButtons = styled.div``;
+const PlotsButtons = styled.div`
+  padding-bottom: 1rem;
+`;
 
 const PlotButton = styled.div`
   height: 1.5rem;
@@ -75,6 +77,8 @@ const HorizontalNav = ({ entries }: Props) => {
   const theme = useContext(ThemeContext);
   const [activePlot, setActivePlot] = useRecoilState(atoms.activePlot);
   const [expanded, setExpanded] = useState(false);
+  const [openedHeight, setOpenedHeight] = useState(392);
+  const closedHeight = 64;
   const togglePlotButton = useSpring({
     opacity: 1,
     backgroundColor: expanded ? theme.button : theme.brand,
@@ -83,12 +87,26 @@ const HorizontalNav = ({ entries }: Props) => {
     },
   });
 
-  const container = useSpring({
-    height: expanded ? 392 : 64,
-  });
+  const height = expanded ? openedHeight : closedHeight;
 
   return (
-    <Container style={container}>
+    <Container
+      size={{ height }}
+      minHeight={closedHeight}
+      enable={{
+        top: false,
+        right: false,
+        bottom: expanded,
+        left: false,
+        topRight: false,
+        bottomRight: false,
+        bottomLeft: false,
+        topLeft: false,
+      }}
+      onResizeStop={(e, direction, ref, d) => {
+        setOpenedHeight(height + d.height);
+      }}
+    >
       <Nav>
         <PlotsButtons>
           {entries.map((e) => (

--- a/electron/app/components/HorizontalNav.tsx
+++ b/electron/app/components/HorizontalNav.tsx
@@ -1,21 +1,26 @@
 import React, { useContext, useState } from "react";
 import { animated, useSpring } from "react-spring";
-import { useRecoilValue } from "recoil";
+import { useRecoilState } from "recoil";
 import styled, { ThemeContext } from "styled-components";
 import AssessmentIcon from "@material-ui/icons/Assessment";
 import KeyboardArrowDownIcon from "@material-ui/icons/KeyboardArrowDown";
 import KeyboardArrowUpIcon from "@material-ui/icons/KeyboardArrowUp";
 
+import Distributions from "./Distributions";
 import * as atoms from "../recoil/atoms";
 
 export type Props = {
   entries: string[];
 };
 
-const Body = styled.div`
-  padding: 1rem;
+const Container = animated(styled.div`
+  padding: 1rem 0;
   background-color: ${({ theme }) => theme.backgroundDark};
   border-bottom: 1px ${({ theme }) => theme.backgroundDarkBorder} solid;
+`);
+
+const Nav = styled.div`
+  padding: 0 1rem;
   width: 100%;
   display: flex;
   justify-content: space-between;
@@ -61,7 +66,7 @@ const TogglePlotsButton = animated(styled.div`
 
 const HorizontalNav = ({ entries }: Props) => {
   const theme = useContext(ThemeContext);
-  const activePlot = useRecoilValue(atoms.activePlot);
+  const [activePlot, setActivePlot] = useRecoilState(atoms.activePlot);
   const [expanded, setExpanded] = useState(false);
   const togglePlotButton = useSpring({
     opacity: 1,
@@ -71,24 +76,37 @@ const HorizontalNav = ({ entries }: Props) => {
     },
   });
 
+  const container = useSpring({
+    height: expanded ? 408 : 64,
+  });
+
   return (
-    <Body>
-      <PlotsButtons>
-        {entries.map((e) => (
-          <PlotButton key={e} className={e === activePlot ? "active" : ""}>
-            {e}
-          </PlotButton>
-        ))}
-      </PlotsButtons>
-      <TogglePlotsButton
-        onClick={() => setExpanded(!expanded)}
-        style={togglePlotButton}
-      >
-        <AssessmentIcon />
-        <span style={{ padding: "0 1rem" }}>{expanded ? "Hide" : "Show"}</span>
-        {expanded ? <KeyboardArrowDownIcon /> : <KeyboardArrowUpIcon />}
-      </TogglePlotsButton>
-    </Body>
+    <Container style={container}>
+      <Nav>
+        <PlotsButtons>
+          {entries.map((e) => (
+            <PlotButton
+              key={e}
+              className={e === activePlot ? "active" : ""}
+              onClick={() => setActivePlot(e)}
+            >
+              {e}
+            </PlotButton>
+          ))}
+        </PlotsButtons>
+        <TogglePlotsButton
+          onClick={() => setExpanded(!expanded)}
+          style={togglePlotButton}
+        >
+          <AssessmentIcon />
+          <span style={{ padding: "0 1rem" }}>
+            {expanded ? "Hide" : "Show"}
+          </span>
+          {expanded ? <KeyboardArrowDownIcon /> : <KeyboardArrowUpIcon />}
+        </TogglePlotsButton>
+      </Nav>
+      {expanded && <Distributions group={activePlot} />}
+    </Container>
   );
 };
 

--- a/electron/app/components/HorizontalNav.tsx
+++ b/electron/app/components/HorizontalNav.tsx
@@ -4,6 +4,7 @@ import { useRecoilState } from "recoil";
 import styled, { ThemeContext } from "styled-components";
 import {
   Assessment,
+  DragHandle,
   Fullscreen,
   FullscreenExit,
   KeyboardArrowDown,
@@ -19,6 +20,17 @@ export type Props = {
   entries: string[];
 };
 
+const Drag = styled(DragHandle)`
+  position: absolute;
+  bottom: -0.8rem;
+  height: 1rem;
+  width: 1rem;
+  left: 50%;
+  margin-left: -0.5rem;
+  z-index: 1000;
+  pointer-events: none;
+`;
+
 const Container = styled(Resizable)`
   padding: 1rem 0 0;
   background-color: ${({ theme }) => theme.backgroundDark};
@@ -28,6 +40,11 @@ const Container = styled(Resizable)`
 const Nav = styled.div`
   padding: 0 1rem;
   width: 100%;
+  display: flex;
+  justify-content: space-between;
+`;
+
+const NavButtons = styled.div`
   display: flex;
   justify-content: space-between;
 `;
@@ -79,12 +96,10 @@ const TogglePlotsButton = animated(styled.div`
 `);
 
 const ToggleMaximizeContainer = styled.div`
-  position: absolute;
-  bottom: 1rem;
-  right: 1rem;
   cursor: pointer;
   width: 1.5rem;
   height: 1.5rem;
+  margin: 0.25rem;
 `;
 
 const ToggleMaximize = React.memo(({ maximized, setMaximized }) => {
@@ -146,22 +161,29 @@ const HorizontalNav = ({ entries }: Props) => {
             </PlotButton>
           ))}
         </PlotsButtons>
-        <TogglePlotsButton
-          onClick={() => {
-            setExpanded(!expanded);
-            expanded && setMaximized(false);
-          }}
-          style={togglePlotButton}
-        >
-          <Assessment />
-          <span>{expanded ? "Hide" : "Show"}</span>
-          {expanded ? <KeyboardArrowUp /> : <KeyboardArrowDown />}
-        </TogglePlotsButton>
+        <NavButtons>
+          <ToggleMaximize
+            maximized={maximized}
+            setMaximized={() => {
+              setMaximized(!maximized);
+              setExpanded(true);
+            }}
+          />
+          <TogglePlotsButton
+            onClick={() => {
+              setExpanded(!expanded);
+              expanded && setMaximized(false);
+            }}
+            style={togglePlotButton}
+          >
+            <Assessment />
+            <span>{expanded ? "Hide" : "Show"}</span>
+            {expanded ? <KeyboardArrowUp /> : <KeyboardArrowDown />}
+          </TogglePlotsButton>
+        </NavButtons>
       </Nav>
       {expanded && <Distributions key={activePlot} group={activePlot} />}
-      {expanded && (
-        <ToggleMaximize maximized={maximized} setMaximized={setMaximized} />
-      )}
+      {expanded && !maximized && <Drag />}
     </Container>
   );
 };

--- a/electron/app/components/HorizontalNav.tsx
+++ b/electron/app/components/HorizontalNav.tsx
@@ -2,11 +2,16 @@ import React, { useContext, useState } from "react";
 import { animated, useSpring } from "react-spring";
 import { useRecoilState } from "recoil";
 import styled, { ThemeContext } from "styled-components";
-import AssessmentIcon from "@material-ui/icons/Assessment";
-import KeyboardArrowDownIcon from "@material-ui/icons/KeyboardArrowDown";
-import KeyboardArrowUpIcon from "@material-ui/icons/KeyboardArrowUp";
+import {
+  Assessment,
+  Fullscreen,
+  FullscreenExit,
+  KeyboardArrowDown,
+  KeyboardArrowUp,
+} from "@material-ui/icons";
 
 import Distributions from "./Distributions";
+import { useWindowSize } from "../utils/hooks";
 import * as atoms from "../recoil/atoms";
 import { Resizable } from "re-resizable";
 
@@ -73,11 +78,30 @@ const TogglePlotsButton = animated(styled.div`
   }
 `);
 
+const ToggleMaximizeContainer = styled.div`
+  position: absolute;
+  bottom: 1rem;
+  right: 1rem;
+  cursor: pointer;
+  width: 1.5rem;
+  height: 1.5rem;
+`;
+
+const ToggleMaximize = React.memo(({ maximized, setMaximized }) => {
+  return (
+    <ToggleMaximizeContainer onClick={() => setMaximized(!maximized)}>
+      {maximized ? <FullscreenExit /> : <Fullscreen />}
+    </ToggleMaximizeContainer>
+  );
+});
+
 const HorizontalNav = ({ entries }: Props) => {
   const theme = useContext(ThemeContext);
+  const { height: windowHeight } = useWindowSize();
   const [activePlot, setActivePlot] = useRecoilState(atoms.activePlot);
   const [expanded, setExpanded] = useState(false);
   const [openedHeight, setOpenedHeight] = useState(392);
+  const [maximized, setMaximized] = useState(false);
   const closedHeight = 64;
   const togglePlotButton = useSpring({
     opacity: 1,
@@ -91,12 +115,12 @@ const HorizontalNav = ({ entries }: Props) => {
 
   return (
     <Container
-      size={{ height }}
+      size={{ height: maximized ? windowHeight - 73 : height }}
       minHeight={closedHeight}
       enable={{
         top: false,
         right: false,
-        bottom: expanded,
+        bottom: expanded && !maximized,
         left: false,
         topRight: false,
         bottomRight: false,
@@ -123,15 +147,21 @@ const HorizontalNav = ({ entries }: Props) => {
           ))}
         </PlotsButtons>
         <TogglePlotsButton
-          onClick={() => setExpanded(!expanded)}
+          onClick={() => {
+            setExpanded(!expanded);
+            expanded && setMaximized(false);
+          }}
           style={togglePlotButton}
         >
-          <AssessmentIcon />
+          <Assessment />
           <span>{expanded ? "Hide" : "Show"}</span>
-          {expanded ? <KeyboardArrowUpIcon /> : <KeyboardArrowDownIcon />}
+          {expanded ? <KeyboardArrowUp /> : <KeyboardArrowDown />}
         </TogglePlotsButton>
       </Nav>
       {expanded && <Distributions key={activePlot} group={activePlot} />}
+      {expanded && (
+        <ToggleMaximize maximized={maximized} setMaximized={setMaximized} />
+      )}
     </Container>
   );
 };

--- a/electron/app/components/ImageContainerHeader.tsx
+++ b/electron/app/components/ImageContainerHeader.tsx
@@ -14,12 +14,8 @@ type Props = {
 const Wrapper = styled.div`
   background: ${({ theme }) => theme.background};
   display: flex;
-  padding-top: 5px;
-  padding-bottom: 5px;
 
   ${DropdownHandle.Body} {
-    padding-top: 0.5em;
-    padding-bottom: 0.5em;
     width: 264px;
   }
 `;
@@ -28,6 +24,8 @@ const SamplesHeader = styled.div`
   display: flex;
   justify-content: space-between;
   flex-grow: 1;
+  height: 2rem;
+  padding-left: 25px;
 `;
 
 const ImageContainerHeader = ({ showSidebar, onShowSidebar }: Props) => {
@@ -39,14 +37,12 @@ const ImageContainerHeader = ({ showSidebar, onShowSidebar }: Props) => {
       : (totalCount || 0).toLocaleString();
   return (
     <Wrapper>
-      <div>
-        <DropdownHandle
-          label="Display Options"
-          expanded={showSidebar}
-          onClick={onShowSidebar && (() => onShowSidebar(!showSidebar))}
-          style={{ width: 240 }}
-        />
-      </div>
+      <DropdownHandle
+        label="Display Options"
+        expanded={showSidebar}
+        onClick={onShowSidebar && (() => onShowSidebar(!showSidebar))}
+        style={{ width: 240 }}
+      />
       <SamplesHeader>
         <SelectionMenu />
         <div className="total">

--- a/electron/app/components/ImageContainerHeader.tsx
+++ b/electron/app/components/ImageContainerHeader.tsx
@@ -13,28 +13,21 @@ type Props = {
 
 const Wrapper = styled.div`
   background: ${({ theme }) => theme.background};
-  display: grid;
-  grid-template-columns: 264px auto auto;
+  display: flex;
   padding-top: 5px;
   padding-bottom: 5px;
-
-  > div {
-    display: flex;
-    align-items: center;
-  }
-
-  > div:last-child {
-    justify-content: flex-end;
-  }
-
-  > div > div {
-    display: inline-block;
-  }
 
   ${DropdownHandle.Body} {
     padding-top: 0.5em;
     padding-bottom: 0.5em;
+    width: 264px;
   }
+`;
+
+const SamplesHeader = styled.div`
+  display: flex;
+  justify-content: space-between;
+  flex-grow: 1;
 `;
 
 const ImageContainerHeader = ({ showSidebar, onShowSidebar }: Props) => {
@@ -54,14 +47,12 @@ const ImageContainerHeader = ({ showSidebar, onShowSidebar }: Props) => {
           style={{ width: 240 }}
         />
       </div>
-      <div>
+      <SamplesHeader>
         <SelectionMenu />
-      </div>
-      <div>
         <div className="total">
           Viewing <strong>{countStr} samples</strong>
         </div>
-      </div>
+      </SamplesHeader>
     </Wrapper>
   );
 };

--- a/electron/app/components/ImageContainerHeader.tsx
+++ b/electron/app/components/ImageContainerHeader.tsx
@@ -14,6 +14,7 @@ type Props = {
 const Wrapper = styled.div`
   background: ${({ theme }) => theme.background};
   display: flex;
+  margin-bottom: 0.5rem;
 
   ${DropdownHandle.Body} {
     width: 264px;
@@ -24,8 +25,10 @@ const SamplesHeader = styled.div`
   display: flex;
   justify-content: space-between;
   flex-grow: 1;
-  height: 2rem;
-  padding-left: 25px;
+  height: 45px;
+  overflow-x: hidden;
+  margin-left: 1rem;
+  margin-right: -1rem;
 `;
 
 const ImageContainerHeader = ({ showSidebar, onShowSidebar }: Props) => {
@@ -45,7 +48,7 @@ const ImageContainerHeader = ({ showSidebar, onShowSidebar }: Props) => {
       />
       <SamplesHeader>
         <SelectionMenu />
-        <div className="total">
+        <div className="total" style={{ paddingRight: "1rem" }}>
           Viewing <strong>{countStr} samples</strong>
         </div>
       </SamplesHeader>

--- a/electron/app/components/Sample.tsx
+++ b/electron/app/components/Sample.tsx
@@ -17,6 +17,26 @@ const SampleDiv = animated(styled.div`
   background-color: ${({ theme }) => theme.backgroundLight};
 `);
 
+const SampleInfo = styled.div`
+  position: absolute;
+  width: 100%;
+  max-height: 100%;
+  display: block;
+  z-index: 100;
+  overflow-y: hidden;
+  padding: 0.5rem;
+  bottom: 0;
+  &::-webkit-scrollbar {
+    width: 0px;
+    background: transparent;
+    display: none;
+  }
+  &::-webkit-scrollbar-thumb {
+    width: 0px;
+    display: none;
+  }
+`;
+
 const LoadingBar = animated(styled.div`
   position: absolute;
   bottom: 0;
@@ -190,7 +210,7 @@ const Sample = ({ sample, metadata, setView }) => {
         onMouseEnter={onMouseEnter}
         onMouseLeave={onMouseLeave}
       />
-      <div className="sample-info" {...eventHandlers}>
+      <SampleInfo {...eventHandlers}>
         {Object.keys(sample)
           .sort()
           .reduce((acc, name) => {
@@ -214,7 +234,7 @@ const Sample = ({ sample, metadata, setView }) => {
           ) : null;
         })}
         {Object.keys(sample).sort().map(renderScalar)}
-      </div>
+      </SampleInfo>
       {selectedSamples.has(id) ? (
         <div
           style={{

--- a/electron/app/components/Samples.hooks.ts
+++ b/electron/app/components/Samples.hooks.ts
@@ -2,7 +2,7 @@ import { useEffect, useState } from "react";
 import { useRecoilValue } from "recoil";
 
 import * as selectors from "../recoil/selectors";
-import { getSocket, useSubscribe } from "../utils/socket";
+import { useSubscribe } from "../utils/socket";
 import tile from "../utils/tile";
 
 export default () => {

--- a/electron/app/components/Samples.tsx
+++ b/electron/app/components/Samples.tsx
@@ -5,10 +5,18 @@ import { useSetRecoilState, useRecoilValue } from "recoil";
 import { Grid } from "semantic-ui-react";
 import { ThemeContext } from "styled-components";
 import CircularProgress from "@material-ui/core/CircularProgress";
+import styled from "styled-components";
 
 import Sample from "./Sample";
 import tile from "./Samples.hooks";
 import * as atoms from "../recoil/atoms";
+import { scrollbarStyles } from "./utils";
+
+const Container = styled.div`
+  ${scrollbarStyles}
+  overflow: auto;
+  height: 100%;
+`;
 
 function Samples({ setView }) {
   const theme = useContext(ThemeContext);
@@ -22,7 +30,7 @@ function Samples({ setView }) {
   }, [scrollState.rows]);
 
   return (
-    <div ref={containerRef}>
+    <Container ref={containerRef}>
       <InfiniteScroll
         pageStart={1}
         initialLoad={true}
@@ -32,7 +40,7 @@ function Samples({ setView }) {
             : null
         }
         hasMore={scrollState.hasMore}
-        useWindow={true}
+        useWindow={false}
       >
         {scrollState.rows.map((r, i) => (
           <React.Fragment key={i}>
@@ -69,7 +77,7 @@ function Samples({ setView }) {
               ))}
             </Grid>
             <div
-              style={{ width: "100%", display: "block", paddingTop: "0.5%" }}
+              style={{ width: "100%", display: "block", paddingTop: "0.2%" }}
             />
           </React.Fragment>
         ))}
@@ -87,7 +95,7 @@ function Samples({ setView }) {
           </Grid>
         ) : null}
       </InfiniteScroll>
-    </div>
+    </Container>
   );
 }
 

--- a/electron/app/components/Samples.tsx
+++ b/electron/app/components/Samples.tsx
@@ -14,7 +14,8 @@ import { scrollbarStyles } from "./utils";
 
 const Container = styled.div`
   ${scrollbarStyles}
-  overflow: scroll;
+  overflow-y: scroll;
+  overflow-x: hidden;
   height: 100%;
 `;
 

--- a/electron/app/components/Samples.tsx
+++ b/electron/app/components/Samples.tsx
@@ -14,7 +14,7 @@ import { scrollbarStyles } from "./utils";
 
 const Container = styled.div`
   ${scrollbarStyles}
-  overflow: auto;
+  overflow: scroll;
   height: 100%;
 `;
 
@@ -46,7 +46,10 @@ function Samples({ setView }) {
           <React.Fragment key={i}>
             <Grid
               columns={r.columns}
-              style={{ ...r.style, height: bounds.width / r.aspectRatio }}
+              style={{
+                ...r.style,
+                height: (bounds.width - 16) / r.aspectRatio,
+              }}
               key={i}
             >
               {r.samples.map((s, j) => (

--- a/electron/app/components/utils.tsx
+++ b/electron/app/components/utils.tsx
@@ -70,7 +70,6 @@ export const ModalFooter = styled.footer`
 export const scrollbarStyles = ({ theme }) => `
 ::-webkit-scrollbar {
   width: 16px;
-  right: -16px;
 }
 
 ::-webkit-scrollbar-track {

--- a/electron/app/components/utils.tsx
+++ b/electron/app/components/utils.tsx
@@ -68,17 +68,22 @@ export const ModalFooter = styled.footer`
 `;
 
 export const scrollbarStyles = ({ theme }) => `
-  &::-webkit-scrollbar {
-    width: 10px;
-    background: transparent;
-  }
-  &::-webkit-scrollbar-thumb {
-    width: 10px;
-    border-radius: 5px;
-    background-color: transparent;
-    transition: background-color linear 0.5s;
-  }
-  &:hover::-webkit-scrollbar-thumb {
-    background-color: ${theme.fontDarkest};
-  }
+::-webkit-scrollbar {
+  width: 16px;
+  right: -16px;
+}
+
+::-webkit-scrollbar-track {
+  border: solid 4px transparent;
+}
+
+::-webkit-scrollbar-thumb {
+  box-shadow: inset 0 0 10px 10px transparent;
+  border: solid 4px transparent;
+  border-radius: 16px;
+  transition: box-shadow linear 0.5s;
+}
+&:hover::-webkit-scrollbar-thumb {
+  box-shadow: inset 0 0 10px 10px ${theme.fontDarkest};
+}
 `;

--- a/electron/app/constants/routes.json
+++ b/electron/app/constants/routes.json
@@ -1,9 +1,5 @@
 {
   "DATASET": "/",
-  "LABELS": "/labels",
   "LOADING": "/loading",
-  "SAMPLES": "/samples",
-  "SCALARS": "/scalars",
-  "SETUP": "/setup",
-  "TAGS": "/tags"
+  "SETUP": "/setup"
 }

--- a/electron/app/containers/App.tsx
+++ b/electron/app/containers/App.tsx
@@ -53,7 +53,6 @@ const useGA = (socket) => {
 };
 
 function App(props: Props) {
-  const [showInfo] = useState(true);
   const addNotification = useRef(null);
   const [reset, setReset] = useState(false);
   const { children } = props;
@@ -67,10 +66,8 @@ function App(props: Props) {
   const [viewCounterValue, setViewCounter] = useRecoilState(atoms.viewCounter);
   const [result, setResultFromForm] = useState({ port, connected });
   const setDatasetStats = useSetRecoilState(atoms.datasetStats);
-  const view = useRecoilValue(selectors.view);
   const setSelectedObjects = useSetRecoilState(atoms.selectedObjects);
   const setExtendedDatasetStats = useSetRecoilState(atoms.extendedDatasetStats);
-  const extendedView = useRecoilValue(selectors.extendedView);
 
   useGA(socket);
   const getStats = (view, setter) => {
@@ -157,31 +154,29 @@ function App(props: Props) {
       resetKeys={[reset]}
     >
       <Header />
-      <div className={showInfo ? "" : "hide-info"} style={bodyStyle}>
-        {children}
-        <Modal
-          trigger={
-            <Button
-              style={{ padding: "1rem", display: "none" }}
-              ref={portRef}
-            ></Button>
-          }
-          size="tiny"
-          onClose={() => setPort(result.port)}
-        >
-          <Modal.Header>Port number</Modal.Header>
-          <Modal.Content>
-            <Modal.Description>
-              <PortForm
-                setResult={setResultFromForm}
-                connected={connected}
-                port={port}
-                invalid={false}
-              />
-            </Modal.Description>
-          </Modal.Content>
-        </Modal>
-      </div>
+      {children}
+      <Modal
+        trigger={
+          <Button
+            style={{ padding: "1rem", display: "none" }}
+            ref={portRef}
+          ></Button>
+        }
+        size="tiny"
+        onClose={() => setPort(result.port)}
+      >
+        <Modal.Header>Port number</Modal.Header>
+        <Modal.Content>
+          <Modal.Description>
+            <PortForm
+              setResult={setResultFromForm}
+              connected={connected}
+              port={port}
+              invalid={false}
+            />
+          </Modal.Description>
+        </Modal.Content>
+      </Modal>
       <NotificationHub children={(add) => (addNotification.current = add)} />
     </ErrorBoundary>
   );

--- a/electron/app/containers/Dataset.tsx
+++ b/electron/app/containers/Dataset.tsx
@@ -20,13 +20,9 @@ import * as selectors from "../recoil/selectors";
 import { VALID_LABEL_TYPES } from "../utils/labels";
 
 const Body = styled.div`
-  margin-top: 132px;
   padding: 0 1rem;
-  position: fixed;
-  top: 0;
   width: 100%;
-  height: calc(100% - 132px);
-  overflow: hidden;
+  height: calc(100% - 131px);
 `;
 
 function NoDataset() {

--- a/electron/app/containers/Dataset.tsx
+++ b/electron/app/containers/Dataset.tsx
@@ -6,7 +6,8 @@ import {
   useSetRecoilState,
   useResetRecoilState,
 } from "recoil";
-import { Container, Message, Segment } from "semantic-ui-react";
+import { Message, Segment } from "semantic-ui-react";
+import styled from "styled-components";
 
 import SamplesContainer from "./SamplesContainer";
 import Distributions from "../components/Distributions";
@@ -17,6 +18,16 @@ import routes from "../constants/routes.json";
 import * as atoms from "../recoil/atoms";
 import * as selectors from "../recoil/selectors";
 import { VALID_LABEL_TYPES } from "../utils/labels";
+
+const Body = styled.div`
+  margin-top: 132px;
+  padding: 0 1rem;
+  position: fixed;
+  top: 0;
+  width: 100%;
+  height: calc(100% - 132px);
+  overflow: hidden;
+`;
 
 function NoDataset() {
   return (
@@ -182,40 +193,42 @@ function Dataset(props) {
         currentPath={props.location.pathname}
         entries={tabs.map((path) => ({ path, name: path.slice(1) }))}
       />
-      <Switch>
-        <Route exact path={routes.DATASET}>
-          <Redirect to={routes.SAMPLES} />
-        </Route>
-        {hasDataset ? (
-          <>
-            <Route path={routes.SAMPLES}>
-              <SamplesContainer
-                {...props.socket}
-                setView={(sample, metadata) =>
-                  setModal({
-                    ...modal,
-                    visible: true,
-                    sample,
-                    metadata,
-                  })
-                }
-                colorMap={colorMap}
-              />
-            </Route>
-            <Route path={routes.LABELS}>
-              <Distributions group="labels" />
-            </Route>
-            <Route path={routes.TAGS}>
-              <Distributions group="tags" />
-            </Route>
-            <Route path={routes.SCALARS}>
-              <Distributions group="scalars" />
-            </Route>
-          </>
-        ) : (
-          <NoDataset />
-        )}
-      </Switch>
+      <Body>
+        <Switch>
+          <Route exact path={routes.DATASET}>
+            <Redirect to={routes.SAMPLES} />
+          </Route>
+          {hasDataset ? (
+            <>
+              <Route path={routes.SAMPLES}>
+                <SamplesContainer
+                  {...props.socket}
+                  setView={(sample, metadata) =>
+                    setModal({
+                      ...modal,
+                      visible: true,
+                      sample,
+                      metadata,
+                    })
+                  }
+                  colorMap={colorMap}
+                />
+              </Route>
+              <Route path={routes.LABELS}>
+                <Distributions group="labels" />
+              </Route>
+              <Route path={routes.TAGS}>
+                <Distributions group="tags" />
+              </Route>
+              <Route path={routes.SCALARS}>
+                <Distributions group="scalars" />
+              </Route>
+            </>
+          ) : (
+            <NoDataset />
+          )}
+        </Switch>
+      </Body>
     </>
   );
 }

--- a/electron/app/containers/Dataset.tsx
+++ b/electron/app/containers/Dataset.tsx
@@ -184,7 +184,7 @@ function Dataset(props) {
           />
         </ModalWrapper>
       ) : null}
-      <HorizontalNav entries={PLOTS} />
+      {hasDataset && <HorizontalNav entries={PLOTS} />}
       <Body>
         <Switch>
           {hasDataset ? (

--- a/electron/app/containers/Dataset.tsx
+++ b/electron/app/containers/Dataset.tsx
@@ -9,8 +9,8 @@ import {
 import { Message, Segment } from "semantic-ui-react";
 import styled from "styled-components";
 
+import { PLOTS } from "../Routes";
 import SamplesContainer from "./SamplesContainer";
-import Distributions from "../components/Distributions";
 import HorizontalNav from "../components/HorizontalNav";
 import SampleModal from "../components/SampleModal";
 import { ModalWrapper, Overlay } from "../components/utils";
@@ -44,7 +44,6 @@ const applyActiveLabels = (tuples, current, setter) => {
 };
 
 function Dataset(props) {
-  const tabs = [routes.SAMPLES, routes.TAGS, routes.LABELS, routes.SCALARS];
   const [modal, setModal] = useState({
     visible: false,
     sample: null,
@@ -185,18 +184,12 @@ function Dataset(props) {
           />
         </ModalWrapper>
       ) : null}
-      <HorizontalNav
-        currentPath={props.location.pathname}
-        entries={tabs.map((path) => ({ path, name: path.slice(1) }))}
-      />
+      <HorizontalNav entries={PLOTS} />
       <Body>
         <Switch>
-          <Route exact path={routes.DATASET}>
-            <Redirect to={routes.SAMPLES} />
-          </Route>
           {hasDataset ? (
             <>
-              <Route path={routes.SAMPLES}>
+              <Route path={routes.DATASET}>
                 <SamplesContainer
                   {...props.socket}
                   setView={(sample, metadata) =>
@@ -209,15 +202,6 @@ function Dataset(props) {
                   }
                   colorMap={colorMap}
                 />
-              </Route>
-              <Route path={routes.LABELS}>
-                <Distributions group="labels" />
-              </Route>
-              <Route path={routes.TAGS}>
-                <Distributions group="tags" />
-              </Route>
-              <Route path={routes.SCALARS}>
-                <Distributions group="scalars" />
               </Route>
             </>
           ) : (

--- a/electron/app/containers/Dataset.tsx
+++ b/electron/app/containers/Dataset.tsx
@@ -178,46 +178,44 @@ function Dataset(props) {
           />
         </ModalWrapper>
       ) : null}
-      <Container fluid={true}>
-        <HorizontalNav
-          currentPath={props.location.pathname}
-          entries={tabs.map((path) => ({ path, name: path.slice(1) }))}
-        />
-        <Switch>
-          <Route exact path={routes.DATASET}>
-            <Redirect to={routes.SAMPLES} />
-          </Route>
-          {hasDataset ? (
-            <>
-              <Route path={routes.SAMPLES}>
-                <SamplesContainer
-                  {...props.socket}
-                  setView={(sample, metadata) =>
-                    setModal({
-                      ...modal,
-                      visible: true,
-                      sample,
-                      metadata,
-                    })
-                  }
-                  colorMap={colorMap}
-                />
-              </Route>
-              <Route path={routes.LABELS}>
-                <Distributions group="labels" />
-              </Route>
-              <Route path={routes.TAGS}>
-                <Distributions group="tags" />
-              </Route>
-              <Route path={routes.SCALARS}>
-                <Distributions group="scalars" />
-              </Route>
-            </>
-          ) : (
-            <NoDataset />
-          )}
-        </Switch>
-      </Container>
+      <HorizontalNav
+        currentPath={props.location.pathname}
+        entries={tabs.map((path) => ({ path, name: path.slice(1) }))}
+      />
+      <Switch>
+        <Route exact path={routes.DATASET}>
+          <Redirect to={routes.SAMPLES} />
+        </Route>
+        {hasDataset ? (
+          <>
+            <Route path={routes.SAMPLES}>
+              <SamplesContainer
+                {...props.socket}
+                setView={(sample, metadata) =>
+                  setModal({
+                    ...modal,
+                    visible: true,
+                    sample,
+                    metadata,
+                  })
+                }
+                colorMap={colorMap}
+              />
+            </Route>
+            <Route path={routes.LABELS}>
+              <Distributions group="labels" />
+            </Route>
+            <Route path={routes.TAGS}>
+              <Distributions group="tags" />
+            </Route>
+            <Route path={routes.SCALARS}>
+              <Distributions group="scalars" />
+            </Route>
+          </>
+        ) : (
+          <NoDataset />
+        )}
+      </Switch>
     </>
   );
 }

--- a/electron/app/containers/SamplesContainer.tsx
+++ b/electron/app/containers/SamplesContainer.tsx
@@ -17,14 +17,12 @@ import ViewBar from "../components/ViewBar/ViewBar";
 
 import * as atoms from "../recoil/atoms";
 import * as selectors from "../recoil/selectors";
-import { useResizeHandler, useScrollHandler } from "../utils/hooks";
 
 const Root = styled.div`
   .ui.grid > .sidebar-column {
     flex: 0 0 17rem;
     z-index: 400;
     margin-right: -0.5em;
-    width: 400px;
   }
 
   .ui.grid > .content-column {
@@ -33,7 +31,6 @@ const Root = styled.div`
 `;
 
 const DisplayOptionsWrapper = (props) => {
-  const { containerRef, sidebarRef, sidebarHeight, headerHeight } = props;
   const [activeTags, setActiveTags] = useRecoilState(atoms.activeTags);
   const [activeLabels, setActiveLabels] = useRecoilState(
     atoms.activeLabels("sample")
@@ -91,113 +88,67 @@ const DisplayOptionsWrapper = (props) => {
 
   return (
     <Grid.Column className="sidebar-column">
-      <Sticky
-        context={containerRef}
-        offset={headerHeight}
-        styleElement={{
-          paddingTop: "1rem",
-          width: 240,
+      <DisplayOptionsSidebar
+        tags={getDisplayOptions(
+          tagNames.map((t) => ({ name: t })),
+          filteredLabelSampleCounts,
+          tagSampleCounts,
+          activeTags
+        )}
+        frameLabels={getDisplayOptions(
+          frameLabelNameGroups.labels,
+          filteredFrameLabelSampleCounts,
+          frameLabelSampleCounts,
+          activeFrameLabels
+        )}
+        labels={getDisplayOptions(
+          labelNameGroups.labels,
+          filteredLabelSampleCounts,
+          labelSampleCounts,
+          activeLabels
+        )}
+        onSelectTag={handleSetDisplayOption(setActiveTags)}
+        onSelectLabel={handleSetDisplayOption(setActiveLabels)}
+        onSelectFrameLabel={handleSetDisplayOption(setActiveFrameLabels)}
+        scalars={getDisplayOptions(
+          labelNameGroups.scalars,
+          filteredLabelSampleCounts,
+          labelSampleCounts,
+          activeOther
+        )}
+        onSelectScalar={handleSetDisplayOption(setActiveOther)}
+        unsupported={getDisplayOptions(
+          labelNameGroups.unsupported,
+          filteredLabelSampleCounts,
+          labelSampleCounts,
+          activeLabels
+        )}
+        style={{
+          overflowY: "auto",
+          overflowX: "hidden",
+          paddingRight: 25,
+          marginRight: -25,
+          scrollbarWidth: "thin",
         }}
-      >
-        <DisplayOptionsSidebar
-          tags={getDisplayOptions(
-            tagNames.map((t) => ({ name: t })),
-            filteredLabelSampleCounts,
-            tagSampleCounts,
-            activeTags
-          )}
-          frameLabels={getDisplayOptions(
-            frameLabelNameGroups.labels,
-            filteredFrameLabelSampleCounts,
-            frameLabelSampleCounts,
-            activeFrameLabels
-          )}
-          labels={getDisplayOptions(
-            labelNameGroups.labels,
-            filteredLabelSampleCounts,
-            labelSampleCounts,
-            activeLabels
-          )}
-          onSelectTag={handleSetDisplayOption(setActiveTags)}
-          onSelectLabel={handleSetDisplayOption(setActiveLabels)}
-          onSelectFrameLabel={handleSetDisplayOption(setActiveFrameLabels)}
-          scalars={getDisplayOptions(
-            labelNameGroups.scalars,
-            filteredLabelSampleCounts,
-            labelSampleCounts,
-            activeOther
-          )}
-          onSelectScalar={handleSetDisplayOption(setActiveOther)}
-          unsupported={getDisplayOptions(
-            labelNameGroups.unsupported,
-            filteredLabelSampleCounts,
-            labelSampleCounts,
-            activeLabels
-          )}
-          style={{
-            maxHeight: sidebarHeight,
-            overflowY: "auto",
-            overflowX: "hidden",
-            paddingRight: 25,
-            marginRight: -25,
-            scrollbarWidth: "thin",
-          }}
-          ref={sidebarRef}
-        />
-      </Sticky>
+      />
     </Grid.Column>
   );
 };
 
 const SamplesContainer = (props) => {
   const [showSidebar, setShowSidebar] = useRecoilState(atoms.sidebarVisible);
-
-  const theme = useContext(ThemeContext);
-
   const containerRef = useRef();
-  const stickyHeaderRef = useRef();
-  const sidebarRef = useRef();
-  const [sidebarHeight, setSidebarHeight] = useState("unset");
-  let headerHeight = 0;
-  if (stickyHeaderRef.current && stickyHeaderRef.current.stickyRect) {
-    headerHeight = stickyHeaderRef.current.stickyRect.height;
-  }
-  const updateSidebarHeight = () => {
-    if (sidebarRef.current) {
-      setSidebarHeight(
-        window.innerHeight - sidebarRef.current.getBoundingClientRect().top
-      );
-    }
-  };
-  useResizeHandler(updateSidebarHeight);
-  useScrollHandler(updateSidebarHeight);
-  useLayoutEffect(updateSidebarHeight, []);
 
   return (
     <Root ref={containerRef} showSidebar={showSidebar}>
-      <Sticky
-        ref={stickyHeaderRef}
-        context={containerRef}
-        styleElement={{
-          background: theme.background,
-        }}
-      >
-        <ViewBar />
-        <ImageContainerHeader
-          showSidebar={showSidebar}
-          onShowSidebar={setShowSidebar}
-        />
-      </Sticky>
+      <ViewBar />
+      <ImageContainerHeader
+        showSidebar={showSidebar}
+        onShowSidebar={setShowSidebar}
+      />
       <Grid>
         {showSidebar ? (
-          <DisplayOptionsWrapper
-            sidebarRef={sidebarRef}
-            stickyHeaderRef={stickyHeaderRef}
-            containerRef={containerRef}
-            sidebarHeight={sidebarHeight}
-            headerHeight={headerHeight}
-            {...props}
-          />
+          <DisplayOptionsWrapper containerRef={containerRef} {...props} />
         ) : null}
         <Grid.Column className="content-column">
           <Samples {...props} />

--- a/electron/app/containers/SamplesContainer.tsx
+++ b/electron/app/containers/SamplesContainer.tsx
@@ -20,6 +20,7 @@ import * as selectors from "../recoil/selectors";
 
 const Root = styled.div`
   height: 100%;
+  overflow: hidden;
   .ui.grid > .sidebar-column {
     flex: 0 0 17rem;
     z-index: 400;
@@ -153,7 +154,7 @@ const SamplesContainer = (props) => {
         ) : null}
         <Grid.Column
           className="content-column"
-          style={{ height: "100%", paddingRight: 0 }}
+          style={{ height: "100%", paddingRight: 0, paddingTop: 0 }}
         >
           <Samples {...props} />
         </Grid.Column>

--- a/electron/app/containers/SamplesContainer.tsx
+++ b/electron/app/containers/SamplesContainer.tsx
@@ -19,6 +19,7 @@ import * as atoms from "../recoil/atoms";
 import * as selectors from "../recoil/selectors";
 
 const Root = styled.div`
+  height: 100%;
   .ui.grid > .sidebar-column {
     flex: 0 0 17rem;
     z-index: 400;
@@ -146,11 +147,14 @@ const SamplesContainer = (props) => {
         showSidebar={showSidebar}
         onShowSidebar={setShowSidebar}
       />
-      <Grid>
+      <Grid style={{ height: "100%", overflow: "hidden" }}>
         {showSidebar ? (
           <DisplayOptionsWrapper containerRef={containerRef} {...props} />
         ) : null}
-        <Grid.Column className="content-column">
+        <Grid.Column
+          className="content-column"
+          style={{ height: "100%", paddingRight: 0 }}
+        >
           <Samples {...props} />
         </Grid.Column>
       </Grid>

--- a/electron/app/containers/SamplesContainer.tsx
+++ b/electron/app/containers/SamplesContainer.tsx
@@ -2,34 +2,29 @@ import React, { useEffect, useRef } from "react";
 import { useRecoilState, useRecoilValue, useSetRecoilState } from "recoil";
 import styled from "styled-components";
 
-import { Grid } from "semantic-ui-react";
-
 import DisplayOptionsSidebar from "../components/DisplayOptionsSidebar";
-import ImageContainerHeader from "../components/ImageContainerHeader";
+import ContainerHeader from "../components/ImageContainerHeader";
 import Samples from "../components/Samples";
 import ViewBar from "../components/ViewBar/ViewBar";
-import { scrollbarStyles } from "./utils";
+import { scrollbarStyles } from "../components/utils";
 
 import * as atoms from "../recoil/atoms";
 import * as selectors from "../recoil/selectors";
 
-const Root = styled.div`
+const SidebarColumn = styled.div`
+  ${scrollbarStyles}
+  z-index: 400;
   height: 100%;
-  overlflow-y: hidden;
-  .ui.grid > .sidebar-column {
-    ${scrollbarStyles}
-    flex: 0 0 17rem;
-    z-index: 400;
-    margin-right: -0.5em;
-  }
-
-  .ui.grid > .content-column {
-    flex: 1;
-    padding-bottom: 0;
-  }
+  overflow-y: scroll;
+  width 256px;
 `;
 
-const DisplayOptionsWrapper = (props) => {
+const ContentColumn = styled.div`
+  flex: 1;
+  height: 100%;
+`;
+
+const DisplayOptionsWrapper = () => {
   const [activeTags, setActiveTags] = useRecoilState(atoms.activeTags);
   const [activeLabels, setActiveLabels] = useRecoilState(
     atoms.activeLabels("sample")
@@ -86,7 +81,7 @@ const DisplayOptionsWrapper = (props) => {
   };
 
   return (
-    <Grid.Column className="sidebar-column">
+    <SidebarColumn>
       <DisplayOptionsSidebar
         tags={getDisplayOptions(
           tagNames.map((t) => ({ name: t })),
@@ -126,33 +121,35 @@ const DisplayOptionsWrapper = (props) => {
           scrollbarWidth: "thin",
         }}
       />
-    </Grid.Column>
+    </SidebarColumn>
   );
 };
 
+const Container = styled.div`
+  display: flex;
+  justify-content: space-between;
+  height: 100%;
+  margin-right: -1rem;
+  height: calc(100% - 129px);
+`;
+
 const SamplesContainer = (props) => {
   const [showSidebar, setShowSidebar] = useRecoilState(atoms.sidebarVisible);
-  const containerRef = useRef();
 
   return (
-    <Root ref={containerRef} showSidebar={showSidebar}>
+    <>
       <ViewBar />
-      <ImageContainerHeader
+      <ContainerHeader
         showSidebar={showSidebar}
         onShowSidebar={setShowSidebar}
       />
-      <Grid style={{ height: "100%", overflow: "hidden" }}>
-        {showSidebar ? (
-          <DisplayOptionsWrapper containerRef={containerRef} {...props} />
-        ) : null}
-        <Grid.Column
-          className="content-column"
-          style={{ height: "100%", paddingRight: 0, paddingTop: 0 }}
-        >
+      <Container>
+        {showSidebar ? <DisplayOptionsWrapper /> : null}
+        <ContentColumn>
           <Samples {...props} />
-        </Grid.Column>
-      </Grid>
-    </Root>
+        </ContentColumn>
+      </Container>
+    </>
   );
 };
 

--- a/electron/app/containers/SamplesContainer.tsx
+++ b/electron/app/containers/SamplesContainer.tsx
@@ -1,27 +1,23 @@
-import React, {
-  useState,
-  useEffect,
-  useLayoutEffect,
-  useRef,
-  useContext,
-} from "react";
+import React, { useEffect, useRef } from "react";
 import { useRecoilState, useRecoilValue, useSetRecoilState } from "recoil";
-import styled, { ThemeContext } from "styled-components";
+import styled from "styled-components";
 
-import { Grid, Sticky } from "semantic-ui-react";
+import { Grid } from "semantic-ui-react";
 
 import DisplayOptionsSidebar from "../components/DisplayOptionsSidebar";
 import ImageContainerHeader from "../components/ImageContainerHeader";
 import Samples from "../components/Samples";
 import ViewBar from "../components/ViewBar/ViewBar";
+import { scrollbarStyles } from "./utils";
 
 import * as atoms from "../recoil/atoms";
 import * as selectors from "../recoil/selectors";
 
 const Root = styled.div`
   height: 100%;
-  overflow: hidden;
+  overlflow-y: hidden;
   .ui.grid > .sidebar-column {
+    ${scrollbarStyles}
     flex: 0 0 17rem;
     z-index: 400;
     margin-right: -0.5em;
@@ -29,6 +25,7 @@ const Root = styled.div`
 
   .ui.grid > .content-column {
     flex: 1;
+    padding-bottom: 0;
   }
 `;
 
@@ -126,10 +123,6 @@ const DisplayOptionsWrapper = (props) => {
           activeLabels
         )}
         style={{
-          overflowY: "auto",
-          overflowX: "hidden",
-          paddingRight: 25,
-          marginRight: -25,
           scrollbarWidth: "thin",
         }}
       />

--- a/electron/app/recoil/atoms.ts
+++ b/electron/app/recoil/atoms.ts
@@ -12,6 +12,11 @@ export const connected = atom({
   default: false,
 });
 
+export const activePlot = atom({
+  key: "activePlot",
+  default: "labels",
+});
+
 export const datasetStats = atom({
   key: "datasetStats",
   default: [],

--- a/electron/app/utils/hooks.ts
+++ b/electron/app/utils/hooks.ts
@@ -129,3 +129,26 @@ export const useVideoData = (socket, sample, callback = null) => {
     },
   ];
 };
+
+export const useWindowSize = () => {
+  const [windowSize, setWindowSize] = useState({
+    width: undefined,
+    height: undefined,
+  });
+
+  const handleResize = () => {
+    // Set window width/height to state
+    setWindowSize({
+      width: window.innerWidth,
+      height: window.innerHeight,
+    });
+  };
+
+  useEventHandler(window, "resize", handleResize);
+
+  useEffect(() => {
+    handleResize();
+  }, []);
+
+  return windowSize;
+};

--- a/electron/app/utils/tile.ts
+++ b/electron/app/utils/tile.ts
@@ -76,18 +76,18 @@ export default function tile(data, newHasMore, state) {
     let gridColumns = columns
       .map((c) => {
         return (
-          (c * (100 - (columns.length - 1 + extraMargins) / 2)).toFixed(2) + "%"
+          (c * (100 - (columns.length - 1 + extraMargins) / 5)).toFixed(2) + "%"
         );
       })
       .reduce((acc, cur, i) => {
         if (i < columns.length - 1) {
-          return [...acc, cur, "0.5%"];
+          return [...acc, cur, "0.2%"];
         }
         return [...acc, cur];
       }, []);
 
     gridColumns = gridColumns.concat(
-      Array.from(Array(extraMargins).keys()).map(() => "0.5%")
+      Array.from(Array(extraMargins).keys()).map(() => "0.2%")
     );
     const gridColumnsLength = gridColumns.length;
     const rowStyle = {
@@ -103,7 +103,7 @@ export default function tile(data, newHasMore, state) {
       samples: row.map(({ sample, ...rest }) => ({ sample, metadata: rest })),
       aspectRatio:
         (refWidth +
-          ((columns.length - 1 + extraMargins) / 2) * (refWidth / 100)) /
+          ((columns.length - 1 + extraMargins) / 5) * (refWidth / 100)) /
         baseHeight,
       extraMargins,
     });

--- a/electron/package.json
+++ b/electron/package.json
@@ -289,6 +289,7 @@
     "mime-types": "^2.1.27",
     "randomcolor": "^0.5.4",
     "raw-loader": "^4.0.1",
+    "re-resizable": "^6.8.0",
     "react": "17.0.0",
     "react-dom": "17.0.0",
     "react-error-boundary": "^2.3.1",

--- a/electron/yarn.lock
+++ b/electron/yarn.lock
@@ -8760,6 +8760,11 @@ fast-levenshtein@^2.0.6, fast-levenshtein@~2.0.6:
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
   integrity sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=
 
+fast-memoize@^2.5.1:
+  version "2.5.2"
+  resolved "https://registry.yarnpkg.com/fast-memoize/-/fast-memoize-2.5.2.tgz#79e3bb6a4ec867ea40ba0e7146816f6cdce9b57e"
+  integrity sha512-Ue0LwpDYErFbmNnZSF0UH6eImUwDmogUO1jyE+JbN2gsQz/jICm1Ve7t9QT0rNSsfJt+Hs4/S3GnsDVjL4HVrw==
+
 fastparse@^1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/fastparse/-/fastparse-1.1.2.tgz#91728c5a5942eced8531283c79441ee4122c35a9"
@@ -15422,6 +15427,13 @@ rc@^1.2.1, rc@^1.2.8:
     ini "~1.3.0"
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
+
+re-resizable@^6.8.0:
+  version "6.8.0"
+  resolved "https://registry.yarnpkg.com/re-resizable/-/re-resizable-6.8.0.tgz#8a99d98a37032276aea62c1c344612f7e8ddc506"
+  integrity sha512-MffuegFHq5juSvLTe/lecTikc2DqIsLjrTAAZ44goPcNavjYgiCqwJa5RydGPsDOZ+OUZAZk1DP9S4AEu0Q1fQ==
+  dependencies:
+    fast-memoize "^2.5.1"
 
 react-addons-create-fragment@^15.6.2:
   version "15.6.2"


### PR DESCRIPTION
## What changes are proposed in this pull request?

Per official design documents, encapsulate plots within an expandable window in the main dataset page.

In order to simplify things, sticky nav behavior was dropped. Resolves #546.

![Screenshot from 2020-11-03 16-16-02](https://user-images.githubusercontent.com/19821840/98041665-5035ed00-1df0-11eb-9bb2-7fc60b6be028.png)
![Screenshot from 2020-11-03 16-15-57](https://user-images.githubusercontent.com/19821840/98041687-5926be80-1df0-11eb-8b72-a3d18e0fdd51.png)


## How is this patch tested? If it is not, please explain why.

Locally.

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

Plots are now held within an expandable window of the main dataset page as opposed to their own pages.
### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
