### PR TITLE
Adding Cityscapes dataset to the zoo

### DIFF
--- a/docs/source/cli/index.rst
+++ b/docs/source/cli/index.rst
@@ -1027,8 +1027,8 @@ Load zoo datasets as persistent FiftyOne datasets.
 
 .. _cli-fiftyone-zoo-delete:
 
-Deletes zoo datasets from disk
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Delete zoo datasets on disk
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Deletes the local copy of the zoo dataset on disk.
 

--- a/docs/source/cli/index.rst
+++ b/docs/source/cli/index.rst
@@ -917,13 +917,8 @@ Print information about datasets in the FiftyOne Dataset Zoo.
 
 .. code-block:: shell
 
-    # Print information about a downloaded zoo dataset
+    # Print information about a zoo dataset
     fiftyone zoo info <name>
-
-.. code-block:: shell
-
-    # Print information about the zoo dataset downloaded to the specified base directory
-    fiftyone zoo info <name> --base-dir <base-dir>
 
 .. _cli-fiftyone-zoo-download:
 

--- a/docs/source/cli/index.rst
+++ b/docs/source/cli/index.rst
@@ -887,6 +887,8 @@ Locate the downloaded zoo dataset on disk.
     # Print the location of the downloaded zoo dataset on disk
     fiftyone zoo find <name>
 
+.. code-block:: shell
+
     # Print the location of a specific split of the dataset
     fiftyone zoo find <name> --split <split>
 
@@ -1022,3 +1024,38 @@ Load zoo datasets as persistent FiftyOne datasets.
 
     # Load a random subset of the zoo dataset
     fiftyone zoo load <name> --shuffle --max-samples <max-samples>
+
+.. _cli-fiftyone-zoo-delete:
+
+Deletes zoo datasets from disk
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Deletes the local copy of the zoo dataset on disk.
+
+.. code-block:: text
+
+    fiftyone zoo delete [-h] [-s SPLIT] NAME
+
+**Arguments**
+
+.. code-block:: text
+
+    positional arguments:
+      NAME                  the name of the dataset
+
+    optional arguments:
+      -h, --help            show this help message and exit
+      -s SPLIT, --split SPLIT
+                            a dataset split
+
+**Examples**
+
+.. code-block:: shell
+
+    # Delete an entire zoo dataset from disk
+    fiftyone zoo delete <name>
+
+.. code-block:: shell
+
+    # Delete a specific split of a zoo dataset from disk
+    fiftyone zoo delete <name> --split <split>

--- a/docs/source/user_guide/dataset_creation/zoo.rst
+++ b/docs/source/user_guide/dataset_creation/zoo.rst
@@ -125,7 +125,9 @@ Getting information about zoo datasets
 
     Each zoo dataset is represented by a
     :class:`ZooDataset <fiftyone.zoo.ZooDataset>` subclass, which contains
-    information about the dataset, its available splits, and more.
+    information about the dataset, its available splits, and more. You can
+    access this object for a given dataset via the
+    :meth:`get_zoo_dataset() <fiftyone.zoo.get_zoo_dataset>` method.
 
     For example, let's print some information about the CIFAR-10 dataset:
 
@@ -137,7 +139,7 @@ Getting information about zoo datasets
         zoo_dataset = foz.get_zoo_dataset("cifar10")
 
         print("***** Dataset description *****")
-        print(zoo_dataset.__doc__)
+        print("    " + zoo_dataset.__doc__)
 
         print("***** Supported splits *****")
         print("%s\n" % ", ".join(zoo_dataset.supported_splits))
@@ -145,7 +147,7 @@ Getting information about zoo datasets
     .. code-block:: text
 
         ***** Dataset description *****
-        The CIFAR-10 dataset consists of 60000 32 x 32 color images in 10
+            The CIFAR-10 dataset consists of 60000 32 x 32 color images in 10
             classes, with 6000 images per class. There are 50000 training images and
             10000 test images.
 
@@ -227,7 +229,7 @@ Getting information about zoo datasets
         $ fiftyone zoo info cifar10
 
         ***** Dataset description *****
-        The CIFAR-10 dataset consists of 60000 32 x 32 color images in 10
+            The CIFAR-10 dataset consists of 60000 32 x 32 color images in 10
             classes, with 6000 images per class. There are 50000 training images and
             10000 test images.
 
@@ -404,6 +406,41 @@ Loading zoo datasets
         Loading 'cifar10' split 'test'
          100% |██████████████████████████████████████████████| 10/10 [3.2ms elapsed, 0s remaining, 2.9K samples/s]
         Dataset 'cifar10-test' created
+
+Loading zoo datasets with manual downloads
+------------------------------------------
+
+Some zoo datasets such as :class:`BDD100K <fiftyone.zoo.base.BDD100KDataset>`
+and :class:`Cityscapes <fiftyone.zoo.base.CityscapesDataset>` require that you
+create accounts on a website and manually download the source files. In such
+cases, the :class:`ZooDataset <fiftyone.zoo.ZooDataset>` class will provide
+additional argument(s) that let you specify the paths to these files that you
+have manually downloaded on disk.
+
+You can load these datasets into FiftyOne by first calling
+:meth:`download_zoo_dataset() <fiftyone.zoo.download_zoo_dataset>` with the
+appropriate keyword arguments (which are passed to the underlying
+:class:`ZooDataset <fiftyone.zoo.ZooDataset>` constructor) to wrangle the raw
+download into FiftyOne format, and then calling
+:meth:`load_zoo_dataset() <fiftyone.zoo.load_zoo_dataset>` or using
+:ref:`fiftyone zoo load <cli-fiftyone-zoo-load>` to load the dataset into
+FiftyOne.
+
+For example, the following snippet shows how to load the BDD100K dataset from
+the zoo:
+
+.. code-block:: python
+    :linenos:
+
+    import fiftyone.zoo as foz
+
+    # First parse the manually downloaded files in `source_dir`
+    foz.download_zoo_dataset(
+        "bdd100k", source_dir="/path/to/dir-with-bdd100k-files"
+    )
+
+    # Now load into FiftyOne
+    dataset = foz.load_zoo_dataset("bdd100k", split="validation")
 
 Controlling where zoo datasets are downloaded
 ---------------------------------------------

--- a/fiftyone/__public__.py
+++ b/fiftyone/__public__.py
@@ -29,6 +29,7 @@ from .core.dataset import (
     delete_datasets,
     delete_non_persistent_datasets,
     get_default_dataset_name,
+    make_unique_dataset_name,
     get_default_dataset_dir,
 )
 from .core.expressions import (

--- a/fiftyone/core/cli.py
+++ b/fiftyone/core/cli.py
@@ -1098,6 +1098,7 @@ class ZooCommand(Command):
         _register_command(subparsers, "info", ZooInfoCommand)
         _register_command(subparsers, "download", ZooDownloadCommand)
         _register_command(subparsers, "load", ZooLoadCommand)
+        _register_command(subparsers, "delete", ZooDeleteCommand)
 
     @staticmethod
     def execute(parser, args):
@@ -1425,6 +1426,34 @@ class ZooLoadCommand(Command):
 
         dataset.persistent = True
         print("Dataset '%s' created" % dataset.name)
+
+
+class ZooDeleteCommand(Command):
+    """Deletes the local copy of the zoo dataset on disk.
+
+    Examples::
+
+        # Delete an entire zoo dataset from disk
+        fiftyone zoo delete <name>
+
+        # Delete a specific split of a zoo dataset from disk
+        fiftyone zoo delete <name> --split <split>
+    """
+
+    @staticmethod
+    def setup(parser):
+        parser.add_argument(
+            "name", metavar="NAME", help="the name of the dataset"
+        )
+        parser.add_argument(
+            "-s", "--split", metavar="SPLIT", help="a dataset split",
+        )
+
+    @staticmethod
+    def execute(parser, args):
+        name = args.name
+        split = args.split
+        foz.delete_zoo_dataset(name, split=split)
 
 
 def _parse_dataset_import_kwargs(args):

--- a/fiftyone/core/cli.py
+++ b/fiftyone/core/cli.py
@@ -1274,7 +1274,7 @@ class ZooInfoCommand(Command):
 
         # Print dataset info
         zoo_dataset = foz.get_zoo_dataset(name)
-        print("***** Dataset description *****\n%s" % zoo_dataset.__doc__)
+        print("***** Dataset description *****\n    %s" % zoo_dataset.__doc__)
 
         # Check if dataset is downloaded
         base_dir = args.base_dir

--- a/fiftyone/core/cli.py
+++ b/fiftyone/core/cli.py
@@ -1245,16 +1245,12 @@ class ZooFindCommand(Command):
 
 
 class ZooInfoCommand(Command):
-    """Print information about downloaded zoo datasets.
+    """Print information about datasets in the FiftyOne Dataset Zoo.
 
     Examples::
 
-        # Print information about a downloaded zoo dataset
+        # Print information about a zoo dataset
         fiftyone zoo info <name>
-
-        # Print information about the zoo dataset downloaded to the specified
-        # base directory
-        fiftyone zoo info <name> --base-dir <base-dir>
     """
 
     @staticmethod

--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -12,7 +12,9 @@ import inspect
 import logging
 import numbers
 import os
+import random
 import reprlib
+import string
 
 from bson import ObjectId
 from mongoengine.errors import DoesNotExist, FieldDoesNotExist
@@ -101,6 +103,27 @@ def get_default_dataset_name():
     name = now.strftime("%Y.%m.%d.%H.%M.%S")
     if name in list_datasets():
         name = now.strftime("%Y.%m.%d.%H.%M.%S.%f")
+
+    return name
+
+
+def make_unique_dataset_name(root):
+    """Makes a unique dataset name with the given root name.
+
+    Args:
+        root: the root name for the dataset
+
+    Returns:
+        the dataset name
+    """
+    name = root
+    dataset_names = list_datasets()
+
+    if name in dataset_names:
+        name += "_" + _get_random_characters(6)
+
+    while name in dataset_names:
+        name += _get_random_characters(1)
 
     return name
 
@@ -2060,6 +2083,12 @@ _info_repr.maxtuple = 3
 _info_repr.maxset = 3
 _info_repr.maxstring = 63
 _info_repr.maxother = 63
+
+
+def _get_random_characters(n):
+    return "".join(
+        random.choice(string.ascii_lowercase + string.digits) for _ in range(n)
+    )
 
 
 def _create_dataset(name, persistent=False, media_type=None):

--- a/fiftyone/utils/cityscapes.py
+++ b/fiftyone/utils/cityscapes.py
@@ -235,8 +235,7 @@ def _export_split(
     else:
         person_annos_map = {}
 
-    name = fod.make_unique_dataset_name("cityscapes-" + split)
-    dataset = fod.Dataset(name=name)
+    dataset = fod.Dataset()
     dataset.media_type = fom.IMAGE
 
     has_fine_annos = bool(fine_annos_map)
@@ -284,6 +283,8 @@ def _export_split(
                 sample["gt_person"] = person_annos_map.get(uuid, None)
 
             exporter.export_sample(sample)
+
+    dataset.delete()
 
 
 def _extract_images(images_zip_path, scratch_dir):

--- a/fiftyone/utils/cityscapes.py
+++ b/fiftyone/utils/cityscapes.py
@@ -1,0 +1,345 @@
+"""
+Utilities for working with the
+`Cityscapes dataset <https://www.cityscapes-dataset.com>`_.
+
+| Copyright 2017-2020, Voxel51, Inc.
+| `voxel51.com <https://voxel51.com/>`_
+|
+"""
+import logging
+import os
+
+import eta.core.serial as etas
+import eta.core.utils as etau
+
+import fiftyone.core.dataset as fod
+import fiftyone.core.fields as fof
+import fiftyone.core.labels as fol
+import fiftyone.core.media as fom
+import fiftyone.core.sample as fos
+import fiftyone.core.utils as fou
+import fiftyone.utils.data as foud
+
+
+logger = logging.getLogger(__name__)
+
+
+_SUPPORTED_SPLITS = ("train", "test", "validation")
+_IMAGES_ZIP = "leftImg8bit_trainvaltest.zip"
+_FINE_ANNOS_ZIP = "gtFine_trainvaltest.zip"
+_COARSE_ANNOS_ZIP = "gtCoarse.zip"
+_PERSON_ANNOS_ZIP = "gtBbox_cityPersons_trainval.zip"
+
+
+def parse_cityscapes_dataset(
+    dataset_dir,
+    scratch_dir,
+    splits,
+    fine_annos=False,
+    coarse_annos=False,
+    person_annos=False,
+):
+    """Parses the Cityscapes archive(s) in the specified directory.
+
+    The archives must have been manually downloaded into the directory before
+    this method is called.
+
+    The dataset splits will saved in subdirectories of ``dataset_dir`` in
+    :class:`fiftyone.types.dataset_types.FiftyOneDataset` format.
+
+    Args:
+        dataset_dir: the dataset directory
+        scratch_dir: a scratch directory to use for temporary files
+        splits: a list of splits to parse. Supported values are
+            ``(train, test, validation)``
+        fine_annos (False): whether to parse the fine annotations
+        coarse_annos (False): whether to parse the coarse annotations
+        person_annos (False): whether to parse the person annotations
+    """
+    _splits = [_parse_split(s) for s in splits]
+
+    images_dir = _extract_images(dataset_dir, scratch_dir)
+
+    if fine_annos:
+        fine_annos_dir = _extract_fine_annos(dataset_dir, scratch_dir)
+    else:
+        fine_annos_dir = None
+
+    if coarse_annos:
+        coarse_annos_dir = _extract_coarse_annos(dataset_dir, scratch_dir)
+    else:
+        coarse_annos_dir = None
+
+    if person_annos:
+        person_annos_dir = _extract_person_annos(dataset_dir, scratch_dir)
+    else:
+        person_annos_dir = None
+
+    for split, _split in zip(splits, _splits):
+        split_dir = os.path.join(dataset_dir, split)
+        _export_split(
+            _split,
+            split_dir,
+            images_dir,
+            fine_annos_dir,
+            coarse_annos_dir,
+            person_annos_dir,
+        )
+
+
+def _parse_split(split):
+    if split == "validation":
+        return "val"
+
+    if split not in ("test", "train"):
+        raise ValueError(
+            "Invalid split '%s''; supported values are %s"
+            % (split, _SUPPORTED_SPLITS)
+        )
+
+    return split
+
+
+def _export_split(
+    split,
+    split_dir,
+    images_dir,
+    fine_annos_dir,
+    coarse_annos_dir,
+    person_annos_dir,
+):
+    name = fod.make_unique_dataset_name("cityscapes-" + split)
+    dataset = fod.Dataset(name=name)
+    dataset.media_type = fom.IMAGE
+
+    images_map = _parse_images(images_dir, split)
+
+    if fine_annos_dir:
+        fine_annos_map = _parse_fine_annos(fine_annos_dir, split)
+        dataset.add_sample_field(
+            "gt_fine",
+            fof.EmbeddedDocumentField,
+            embedded_doc_type=fol.Polylines,
+        )
+    else:
+        fine_annos_map = {}
+
+    if coarse_annos_dir:
+        coarse_annos_map = _parse_coarse_annos(coarse_annos_dir, split)
+        dataset.add_sample_field(
+            "gt_coarse",
+            fof.EmbeddedDocumentField,
+            embedded_doc_type=fol.Polylines,
+        )
+    else:
+        coarse_annos_map = {}
+
+    if person_annos_dir:
+        person_annos_map = _parse_person_annos(person_annos_dir, split)
+        dataset.add_sample_field(
+            "gt_person",
+            fof.EmbeddedDocumentField,
+            embedded_doc_type=fol.Detections,
+        )
+    else:
+        person_annos_map = {}
+
+    uuids = sorted(
+        set(fine_annos_map.keys())
+        | set(coarse_annos_map.keys())
+        | set(person_annos_map.keys())
+    )
+
+    logger.info("Finalizing split '%s'...", split)
+    exporter = foud.FiftyOneDatasetExporter(split_dir, move_media=False)
+    pb = fou.ProgressBar()
+    with exporter, pb:
+        exporter.log_collection(dataset)
+        for uuid in pb(uuids):
+            sample = fos.Sample(filepath=images_map[uuid])
+
+            if fine_annos_dir:
+                sample["gt_fine"] = fine_annos_map.get(uuid, None)
+
+            if coarse_annos_dir:
+                sample["gt_coarse"] = coarse_annos_map.get(uuid, None)
+
+            if person_annos_dir:
+                sample["gt_person"] = person_annos_map.get(uuid, None)
+
+            exporter.export_sample(sample)
+
+
+def _extract_images(dataset_dir, scratch_dir):
+    images_zip = os.path.join(dataset_dir, _IMAGES_ZIP)
+    tmp_dir = os.path.join(scratch_dir, "images")
+    images_dir = os.path.join(tmp_dir, "leftImg8bit")
+
+    if os.path.isdir(images_dir):
+        return images_dir
+
+    _ensure_archive(_IMAGES_ZIP, dataset_dir)
+
+    logger.info("Extracting images...")
+    etau.extract_zip(images_zip, outdir=tmp_dir, delete_zip=False)
+
+    return images_dir
+
+
+def _extract_fine_annos(dataset_dir, scratch_dir):
+    fine_annos_zip = os.path.join(dataset_dir, _FINE_ANNOS_ZIP)
+    tmp_dir = os.path.join(scratch_dir, "fine-annos")
+    fine_annos_dir = os.path.join(tmp_dir, "gtFine")
+
+    if os.path.isdir(fine_annos_dir):
+        return fine_annos_dir
+
+    _ensure_archive(_FINE_ANNOS_ZIP, dataset_dir)
+
+    logger.info("Extracting fine annotations...")
+    etau.extract_zip(fine_annos_zip, outdir=tmp_dir, delete_zip=False)
+
+    return fine_annos_dir
+
+
+def _extract_coarse_annos(dataset_dir, scratch_dir):
+    coarse_annos_zip = os.path.join(dataset_dir, _COARSE_ANNOS_ZIP)
+    tmp_dir = os.path.join(scratch_dir, "coarse-annos")
+    coarse_annos_dir = os.path.join(tmp_dir, "gtCoarse")
+
+    if os.path.isdir(coarse_annos_dir):
+        return coarse_annos_dir
+
+    _ensure_archive(_COARSE_ANNOS_ZIP, dataset_dir)
+
+    logger.info("Extracting coarse annotations...")
+    etau.extract_zip(coarse_annos_zip, outdir=tmp_dir, delete_zip=False)
+
+    return coarse_annos_dir
+
+
+def _extract_person_annos(dataset_dir, scratch_dir):
+    person_annos_zip = os.path.join(dataset_dir, _PERSON_ANNOS_ZIP)
+    tmp_dir = os.path.join(scratch_dir, "person-annos")
+    person_annos_dir = os.path.join(tmp_dir, "gtBboxCityPersons")
+
+    if os.path.isdir(person_annos_dir):
+        return person_annos_dir
+
+    _ensure_archive(_PERSON_ANNOS_ZIP, dataset_dir)
+
+    logger.info("Extracting person annotations...")
+    etau.extract_zip(person_annos_zip, outdir=tmp_dir, delete_zip=False)
+
+    return person_annos_dir
+
+
+def _parse_images(images_dir, split):
+    paths_patt = os.path.join(images_dir, split, "*", "*")
+    images_map = {}
+    for image_path in etau.get_glob_matches(paths_patt):
+        uuid = os.path.splitext(os.path.basename(image_path))[0][
+            : -len("_leftImg8bit")
+        ]
+        images_map[uuid] = image_path
+
+    return images_map
+
+
+def _parse_fine_annos(fine_annos_dir, split):
+    glob_patt = os.path.join(fine_annos_dir, split, "*", "*.json")
+    return _parse_polygon_annos(glob_patt, split, "fine", "_gtFine_polygons")
+
+
+def _parse_coarse_annos(coarse_annos_dir, split):
+    glob_patt = os.path.join(coarse_annos_dir, split, "*", "*.json")
+    return _parse_polygon_annos(
+        glob_patt, split, "coarse", "_gtCoarse_polygons"
+    )
+
+
+def _parse_polygon_annos(glob_patt, split, anno_type, suffix):
+    anno_paths = etau.get_glob_matches(glob_patt)
+    if not anno_paths:
+        return {}
+
+    logger.info("Parsing %s annotations for split '%s'...", anno_type, split)
+    annos_map = {}
+    with fou.ProgressBar() as pb:
+        for anno_path in pb(anno_paths):
+            uuid = os.path.splitext(os.path.basename(anno_path))[0][
+                : -len(suffix)
+            ]
+            annos_map[uuid] = _parse_polygons_file(anno_path)
+
+    return annos_map
+
+
+def _parse_person_annos(person_annos_dir, split):
+    paths_patt = os.path.join(person_annos_dir, split, "*", "*.json")
+    anno_paths = etau.get_glob_matches(paths_patt)
+    if not anno_paths:
+        return {}
+
+    logger.info("Parsing person annotations for split '%s'...", split)
+    detections_map = {}
+    with fou.ProgressBar() as pb:
+        for anno_path in pb(anno_paths):
+            uuid = os.path.splitext(os.path.basename(anno_path))[0][
+                : -len("_gtBboxCityPersons")
+            ]
+            detections_map[uuid] = _parse_bbox_file(anno_path)
+
+    return detections_map
+
+
+def _parse_polygons_file(json_path):
+    d = etas.load_json(json_path)
+
+    width = d["imgWidth"]
+    height = d["imgHeight"]
+
+    polylines = []
+    for obj in d.get("objects", []):
+        label = obj["label"]
+        points = [(x / width, y / height) for x, y in obj["polygon"]]
+        polyline = fol.Polyline(
+            label=label, points=[points], closed=True, filled=True
+        )
+        polylines.append(polyline)
+
+    return fol.Polylines(polylines=polylines)
+
+
+def _parse_bbox_file(json_path):
+    d = etas.load_json(json_path)
+
+    width = d["imgWidth"]
+    height = d["imgHeight"]
+
+    detections = []
+    for obj in d.get("objects", []):
+        label = obj["label"]
+        x, y, w, h = obj["bbox"]
+        bounding_box = [x / width, y / height, w / width, h / height]
+        detection = fol.Detection(label=label, bounding_box=bounding_box)
+        detections.append(detection)
+
+    return fol.Detections(detections=detections)
+
+
+def _ensure_archive(archive_name, dataset_dir):
+    archive_path = os.path.join(dataset_dir, archive_name)
+    if not os.path.isfile(archive_path):
+        raise OSError(
+            (
+                "Archive '%s' not found in directory '%s'."
+                "\n\n"
+                "You must download the source files for the Cityscapes "
+                "dataset manually to the above directory."
+                "\n\n"
+                "Register at https://www.cityscapes-dataset.com/register in "
+                "order to get links to download the data"
+            )
+            % (archive_name, dataset_dir)
+        )

--- a/fiftyone/utils/data/exporters.py
+++ b/fiftyone/utils/data/exporters.py
@@ -806,13 +806,16 @@ class FiftyOneDatasetExporter(GenericSampleDatasetExporter):
 
     Args:
         export_dir: the directory to write the export
+        move_media (False): whether to move (True) or copy (False) the source
+            media into its output destination
         pretty_print (False): whether to render the JSON in human readable
             format with newlines and indentations
     """
 
-    def __init__(self, export_dir, pretty_print=False):
+    def __init__(self, export_dir, move_media=False, pretty_print=False):
         export_dir = os.path.abspath(os.path.expanduser(export_dir))
         super().__init__(export_dir)
+        self.move_media = move_media
         self.pretty_print = pretty_print
         self._data_dir = None
         self._frame_labels_dir = None
@@ -851,7 +854,10 @@ class FiftyOneDatasetExporter(GenericSampleDatasetExporter):
 
     def export_sample(self, sample):
         out_filepath = self._filename_maker.get_output_path(sample.filepath)
-        etau.copy_file(sample.filepath, out_filepath)
+        if self.move_media:
+            etau.move_file(sample.filepath, out_filepath)
+        else:
+            etau.copy_file(sample.filepath, out_filepath)
 
         sd = sample.to_dict()
         sd["filepath"] = os.path.relpath(out_filepath, self.export_dir)

--- a/fiftyone/utils/imagenet.py
+++ b/fiftyone/utils/imagenet.py
@@ -13,12 +13,12 @@ _VAL_IMAGES_DIR = "ILSVRC2012_img_val.tar"
 _DEVKIT_TAR = "ILSVRC2012_devkit_t12.tar.gz"
 
 
-def ensure_imagenet_manual_download(dataset_dir, split, devkit=False):
+def ensure_imagenet_manual_download(source_dir, split, devkit=False):
     """Ensures that the ImageNet archive(s) for the requested split have been
     manually downloaded to the required locations.
 
     Args:
-        dataset_dir: the dataset directory
+        source_dir: the dataset directory
         split: the split of interest. Supported values are
             ``("train", "validation")``
         devkit (False): whether to ensure that the devkit archive is present
@@ -36,25 +36,35 @@ def ensure_imagenet_manual_download(dataset_dir, split, devkit=False):
             "('train', 'validation')"
         )
 
-    _ensure_archive(archive_name, dataset_dir)
+    _ensure_archive(archive_name, source_dir)
 
     if devkit:
         devkit_name = _DEVKIT_TAR
-        _ensure_archive(devkit_name, dataset_dir)
+        _ensure_archive(devkit_name, source_dir)
 
 
-def _ensure_archive(archive_name, dataset_dir):
-    archive_path = os.path.join(dataset_dir, archive_name)
-    if not os.path.isfile(archive_path):
-        raise OSError(
-            (
-                "Archive '%s' not found in directory '%s'."
-                "\n\n"
-                "You must download the source files for the ImageNet dataset "
-                "manually to the above directory."
-                "\n\n"
-                "Register at http://www.image-net.org/download-images in "
-                "order to get the link to download the dataset"
-            )
-            % (archive_name, dataset_dir)
+def _ensure_archive(archive_name, source_dir):
+    if source_dir is None:
+        _raise_imagenet_error(
+            "You must provide a `source_dir` in order to load the ImageNet "
+            "dataset."
         )
+
+    archive_path = os.path.join(source_dir, archive_name)
+    if not os.path.isfile(archive_path):
+        _raise_imagenet_error(
+            "Archive '%s' not found in directory '%s'."
+            % (archive_name, source_dir)
+        )
+
+
+def _raise_imagenet_error(msg):
+    raise OSError(
+        "\n\n"
+        + msg
+        + "\n\n"
+        + "You must download the source files for the ImageNet dataset "
+        "manually."
+        + "\n\n"
+        + "Run `fiftyone zoo info imagenet-2012` for more information"
+    )

--- a/fiftyone/zoo/__init__.py
+++ b/fiftyone/zoo/__init__.py
@@ -242,7 +242,8 @@ def find_zoo_dataset(name, split=None):
         the directory containing the dataset
 
     Raises:
-        ValueError: if the dataset or split has not been downloaded
+        ValueError: if the dataset or split does not exist or has not been
+            downloaded
     """
     zoo_dataset, dataset_dir = _parse_dataset_details(name, None)
     try:

--- a/fiftyone/zoo/__init__.py
+++ b/fiftyone/zoo/__init__.py
@@ -699,7 +699,10 @@ class ZooDataset(object):
             if info is not None:
                 _splits = []
                 for split in splits:
-                    if split in info.downloaded_splits:
+                    split_dir = self.get_split_dir(dataset_dir, split)
+                    if split in info.downloaded_splits and os.path.isdir(
+                        split_dir
+                    ):
                         logger.info("Split '%s' already downloaded", split)
                     else:
                         _splits.append(split)

--- a/fiftyone/zoo/base.py
+++ b/fiftyone/zoo/base.py
@@ -328,8 +328,6 @@ class CityscapesDataset(FiftyOneDataset):
             not (False), or only if the ZIP file exists (None)
         person_annos (None): whether to load the personn detections (True), or
             not (False), or only if the ZIP file exists (None)
-        include_unlabeled (False): whether to include unlabeled images in the
-            output dataset
     """
 
     def __init__(
@@ -338,13 +336,11 @@ class CityscapesDataset(FiftyOneDataset):
         fine_annos=None,
         coarse_annos=None,
         person_annos=None,
-        include_unlabeled=False,
     ):
         self.source_dir = source_dir
         self.fine_annos = fine_annos
         self.coarse_annos = coarse_annos
         self.person_annos = person_annos
-        self.include_unlabeled = include_unlabeled
 
     @property
     def name(self):
@@ -371,7 +367,6 @@ class CityscapesDataset(FiftyOneDataset):
                 fine_annos=self.fine_annos,
                 coarse_annos=self.coarse_annos,
                 person_annos=self.person_annos,
-                include_unlabeled=self.include_unlabeled,
             )
 
         # Get metadata

--- a/fiftyone/zoo/base.py
+++ b/fiftyone/zoo/base.py
@@ -252,7 +252,7 @@ class LabeledFacesInTheWildDataset(FiftyOneDataset):
         #
         # LFW is distributed as a single download that contains all splits,
         # so we remove the split from `dataset_dir` and download the whole
-        # dataset (only if necessary)
+        # dataset (if necessary)
         #
         dataset_dir = os.path.dirname(dataset_dir)  # remove split dir
         split_dir = os.path.join(dataset_dir, split)
@@ -320,7 +320,7 @@ class CityscapesDataset(FiftyOneDataset):
         #
         # Cityscapes is distributed as a single download that contains all
         # splits (which must be manually downloaded), so we remove the split
-        # from `dataset_dir` and download the whole dataset (only if necessary)
+        # from `dataset_dir` and download the whole dataset (if necessary)
         #
         dataset_dir = os.path.dirname(dataset_dir)  # remove split dir
         split_dir = os.path.join(dataset_dir, split)
@@ -415,8 +415,7 @@ class BDD100KDataset(FiftyOneDataset):
         # `self.source_dir` or `scratch_dir`
         #
         # The download contains all splits, so we remove the split from
-        # `dataset_dir` and download the whole
-        # dataset (only if necessary)
+        # `dataset_dir` and download the whole dataset (if necessary)
         #
         dataset_dir = os.path.dirname(dataset_dir)  # remove split dir
         split_dir = os.path.join(dataset_dir, split)
@@ -469,7 +468,7 @@ class HMDB51Dataset(FiftyOneDataset):
         #
         # HMDB51 is distributed as a single download that contains all splits,
         # so we remove the split from `dataset_dir` and download the whole
-        # dataset (only if necessary)
+        # dataset (if necessary)
         #
         dataset_dir = os.path.dirname(dataset_dir)  # remove split dir
         split_dir = os.path.join(dataset_dir, split)
@@ -541,7 +540,7 @@ class UCF101Dataset(FiftyOneDataset):
         #
         # UCF101 is distributed as a single download that contains all splits,
         # so we remove the split from `dataset_dir` and download the whole
-        # dataset (only if necessary)
+        # dataset (if necessary)
         #
         dataset_dir = os.path.dirname(dataset_dir)  # remove split dir
         split_dir = os.path.join(dataset_dir, split)

--- a/fiftyone/zoo/base.py
+++ b/fiftyone/zoo/base.py
@@ -362,15 +362,10 @@ class BDD100KDataset(FiftyOneDataset):
     the videos as described above, together with the image classification,
     detection, and segmentation labels.
 
-    **Manual download instructions**
+    In order to load the BDD100k dataset, you must download the source data
+    manually into ``source_dir`` as follows::
 
-    This dataset requires you to download the source data manually. You must
-    register at https://bdd-data.berkeley.edu/ in order to get the link to
-    download the dataset.
-
-    After extracting the download, you will find contents similar to::
-
-        bdd100k/
+        source_dir/
             labels/
                 bdd100k_labels_images_train.json
                 bdd100k_labels_images_val.json
@@ -379,10 +374,21 @@ class BDD100KDataset(FiftyOneDataset):
                     train/
                     test/
                     val/
-            ...
 
-    You must provide the path to the above ``bdd100k/`` folder when loading
-    this dataset.
+    You can register at `https://bdd-data.berkeley.edu`_ in order to get links
+    to download the data.
+
+    Example usage::
+
+        import fiftyone.zoo as foz
+
+        # First parse the manually downloaded files in `source_dir`
+        foz.download_zoo_dataset(
+            "bdd100k", source_dir="/path/to/dir-with-bdd100k-files"
+        )
+
+        # Now load into FiftyOne
+        dataset = foz.load_zoo_dataset("bdd100k", split="validation")
 
     Dataset size:
         7.1GB
@@ -391,8 +397,8 @@ class BDD100KDataset(FiftyOneDataset):
         https://bdd-data.berkeley.edu
 
     Args:
-        source_dir (None): the path to the downloaded ``bdd100k/`` folder on
-            disk
+        source_dir (None): the directory containing the manually downloaded
+            BDD100k files
         copy_files (True): whether to move (False) or create copies (True) of
             the source files when populating the dataset directory
     """
@@ -411,18 +417,16 @@ class BDD100KDataset(FiftyOneDataset):
 
     def _download_and_prepare(self, dataset_dir, scratch_dir, split):
         #
-        # BDD100k must be manually downloaded by the user and placed in
-        # `self.source_dir` or `scratch_dir`
+        # BDD100k must be manually downloaded by the user in `source_dir`
         #
         # The download contains all splits, so we remove the split from
-        # `dataset_dir` and download the whole dataset (if necessary)
+        # `dataset_dir` here and wrangle the whole dataset (if necessary)
         #
         dataset_dir = os.path.dirname(dataset_dir)  # remove split dir
         split_dir = os.path.join(dataset_dir, split)
         if not os.path.exists(split_dir):
-            bdd100k_dir = self.source_dir or scratch_dir
-            foub.wrangle_bdd100k_download(
-                bdd100k_dir, dataset_dir, copy_files=self.copy_files
+            foub.parse_bdd100k_dataset(
+                self.source_dir, dataset_dir, copy_files=self.copy_files
             )
 
         # Get metadata

--- a/fiftyone/zoo/base.py
+++ b/fiftyone/zoo/base.py
@@ -337,16 +337,10 @@ class CityscapesDataset(FiftyOneDataset):
         # Get metadata
         logger.info("Parsing dataset metadata")
         dataset_type = fot.FiftyOneDataset()
-        importer = foud.FiftyOneDatasetImporter
-        classes = sorted(
-            importer.get_classes(os.path.join(dataset_dir, "train"))
-            + importer.get_classes(os.path.join(dataset_dir, "test"))
-            + importer.get_classes(os.path.join(dataset_dir, "validation"))
-        )
-        num_samples = importer.get_num_samples(split_dir)
+        num_samples = foud.FiftyOneDatasetImporter.get_num_samples(split_dir)
         logger.info("Found %d samples", num_samples)
 
-        return dataset_type, num_samples, classes
+        return dataset_type, num_samples, None
 
 
 class BDD100KDataset(FiftyOneDataset):

--- a/fiftyone/zoo/base.py
+++ b/fiftyone/zoo/base.py
@@ -15,6 +15,8 @@ import eta.core.web as etaw
 import fiftyone.types as fot
 import fiftyone.utils.bdd as foub
 import fiftyone.utils.coco as fouc
+
+# import fiftyone.utils.cityscapes as foucs
 import fiftyone.utils.data as foud
 import fiftyone.utils.hmdb51 as fouh
 import fiftyone.utils.lfw as foul
@@ -274,6 +276,81 @@ class LabeledFacesInTheWildDataset(FiftyOneDataset):
         return dataset_type, num_samples, classes
 
 
+class CityscapesDataset(FiftyOneDataset):
+    """Cityscapes is a large-scale dataset that contains a diverse set of
+    stereo video sequences recorded in street scenes from 50 different cities,
+    with high quality pixel-level annotations of 5,000 frames in addition to a
+    arger set of 20,000 weakly annotated frames.
+
+    The dataset is intended for:
+
+    -   assessing the performance of vision algorithms for major tasks of
+    semantic urban scene understanding: pixel-level, instance-level, and
+    panoptic semantic labeling
+    -   supporting research that aims to exploit large volumes of (weakly)
+    annotated data, e.g. for training deep neural networks
+
+    Dataset size:
+        11.8 GB
+
+    Source:
+        https://www.cityscapes-dataset.com
+
+    Args:
+        fine_annos (False): whether to load the fine annotations
+        coarse_annos (False): whether to load the coarse annotations
+        person_annos (False): whether to load the person annotations
+    """
+
+    def __init__(
+        self, fine_annos=False, coarse_annos=False, person_annos=False
+    ):
+        self.fine_annos = fine_annos
+        self.coarse_annos = coarse_annos
+        self.person_annos = person_annos
+
+    @property
+    def name(self):
+        return "cityscapes"
+
+    @property
+    def supported_splits(self):
+        return ("train", "test", "validation")
+
+    def _download_and_prepare(self, dataset_dir, scratch_dir, split):
+        #
+        # Cityscapes is distributed as a single download that contains all
+        # splits (which must be manually downloaded), so we remove the split
+        # from `dataset_dir` and download the whole dataset (only if necessary)
+        #
+        dataset_dir = os.path.dirname(dataset_dir)  # remove split dir
+        split_dir = os.path.join(dataset_dir, split)
+        if not os.path.exists(split_dir):
+            """
+            foucs.parse_cityscapes_dataset(
+                dataset_dir,
+                scratch_dir,
+                fine_annos=self.fine_annos,
+                coarse_annos=self.coarse_annos,
+                person_annos=self.person_annos,
+            )
+            """
+
+        # Get metadata
+        logger.info("Parsing dataset metadata")
+        dataset_type = fot.FiftyOneDataset()
+        importer = foud.FiftyOneDatasetImporter
+        classes = sorted(
+            importer.get_classes(os.path.join(dataset_dir, "train"))
+            + importer.get_classes(os.path.join(dataset_dir, "test"))
+            + importer.get_classes(os.path.join(dataset_dir, "validation"))
+        )
+        num_samples = importer.get_num_samples(split_dir)
+        logger.info("Found %d samples", num_samples)
+
+        return dataset_type, num_samples, classes
+
+
 class BDD100KDataset(FiftyOneDataset):
     """The Berkeley Deep Drive (BDD) dataset is one of the largest and most
     diverese video datasets for autonomous vehicles.
@@ -501,6 +578,7 @@ AVAILABLE_DATASETS = {
     "coco-2014-segmentation": COCO2014Dataset,
     "coco-2017-segmentation": COCO2017Dataset,
     "lfw": LabeledFacesInTheWildDataset,
+    "cityscapes": CityscapesDataset,
     "bdd100k": BDD100KDataset,
     "hmdb51": HMDB51Dataset,
     "ucf101": UCF101Dataset,

--- a/fiftyone/zoo/base.py
+++ b/fiftyone/zoo/base.py
@@ -279,15 +279,39 @@ class CityscapesDataset(FiftyOneDataset):
     """Cityscapes is a large-scale dataset that contains a diverse set of
     stereo video sequences recorded in street scenes from 50 different cities,
     with high quality pixel-level annotations of 5,000 frames in addition to a
-    arger set of 20,000 weakly annotated frames.
+    larger set of 20,000 weakly annotated frames.
 
     The dataset is intended for:
 
-    -   assessing the performance of vision algorithms for major tasks of
+    -   Assessing the performance of vision algorithms for major tasks of
     semantic urban scene understanding: pixel-level, instance-level, and
     panoptic semantic labeling
-    -   supporting research that aims to exploit large volumes of (weakly)
+    -   Supporting research that aims to exploit large volumes of (weakly)
     annotated data, e.g. for training deep neural networks
+
+    In order to load the Cityscapes dataset, you must download the source ZIP
+    files manually ``source_dir`` as follows::
+
+        source_dir/
+            leftImg8bit_trainvaltest.zip
+            gtFine_trainvaltest.zip         # optional
+            gtCoarse.zip                    # optional
+            gtBbox_cityPersons_trainval     # optional
+
+    You can register at `https://www.cityscapes-dataset.com/register`_ in order
+    to get links to download the data.
+
+    Example usage::
+
+        import fiftyone.zoo as foz
+
+        # First parse the manually downloaded files in `source_dir`
+        foz.download_zoo_dataset(
+            "cityscapes", source_dir="/path/to/dir-with-cityscapes-files"
+        )
+
+        # Now load into FiftyOne
+        dataset = foz.load_zoo_dataset("cityscapes", split="validation")
 
     Dataset size:
         11.8 GB
@@ -296,17 +320,31 @@ class CityscapesDataset(FiftyOneDataset):
         https://www.cityscapes-dataset.com
 
     Args:
-        fine_annos (False): whether to load the fine annotations
-        coarse_annos (False): whether to load the coarse annotations
-        person_annos (False): whether to load the person annotations
+        source_dir (None): a directory containing the manually downloaded
+            Cityscapes files
+        fine_annos (None): whether to load the fine annotations (True), or not
+            (False), or only if the ZIP file exists (None)
+        coarse_annos (None): whether to load the coarse annotations (True), or
+            not (False), or only if the ZIP file exists (None)
+        person_annos (None): whether to load the personn detections (True), or
+            not (False), or only if the ZIP file exists (None)
+        include_unlabeled (False): whether to include unlabeled images in the
+            output dataset
     """
 
     def __init__(
-        self, fine_annos=False, coarse_annos=False, person_annos=False
+        self,
+        source_dir=None,
+        fine_annos=None,
+        coarse_annos=None,
+        person_annos=None,
+        include_unlabeled=False,
     ):
+        self.source_dir = source_dir
         self.fine_annos = fine_annos
         self.coarse_annos = coarse_annos
         self.person_annos = person_annos
+        self.include_unlabeled = include_unlabeled
 
     @property
     def name(self):
@@ -326,12 +364,14 @@ class CityscapesDataset(FiftyOneDataset):
         split_dir = os.path.join(dataset_dir, split)
         if not os.path.exists(split_dir):
             foucs.parse_cityscapes_dataset(
+                self.source_dir,
                 dataset_dir,
                 scratch_dir,
                 [split],
                 fine_annos=self.fine_annos,
                 coarse_annos=self.coarse_annos,
                 person_annos=self.person_annos,
+                include_unlabeled=self.include_unlabeled,
             )
 
         # Get metadata

--- a/fiftyone/zoo/base.py
+++ b/fiftyone/zoo/base.py
@@ -15,8 +15,7 @@ import eta.core.web as etaw
 import fiftyone.types as fot
 import fiftyone.utils.bdd as foub
 import fiftyone.utils.coco as fouc
-
-# import fiftyone.utils.cityscapes as foucs
+import fiftyone.utils.cityscapes as foucs
 import fiftyone.utils.data as foud
 import fiftyone.utils.hmdb51 as fouh
 import fiftyone.utils.lfw as foul
@@ -326,7 +325,6 @@ class CityscapesDataset(FiftyOneDataset):
         dataset_dir = os.path.dirname(dataset_dir)  # remove split dir
         split_dir = os.path.join(dataset_dir, split)
         if not os.path.exists(split_dir):
-            """
             foucs.parse_cityscapes_dataset(
                 dataset_dir,
                 scratch_dir,
@@ -335,7 +333,6 @@ class CityscapesDataset(FiftyOneDataset):
                 coarse_annos=self.coarse_annos,
                 person_annos=self.person_annos,
             )
-            """
 
         # Get metadata
         logger.info("Parsing dataset metadata")

--- a/fiftyone/zoo/base.py
+++ b/fiftyone/zoo/base.py
@@ -330,6 +330,7 @@ class CityscapesDataset(FiftyOneDataset):
             foucs.parse_cityscapes_dataset(
                 dataset_dir,
                 scratch_dir,
+                [split],
                 fine_annos=self.fine_annos,
                 coarse_annos=self.coarse_annos,
                 person_annos=self.person_annos,

--- a/fiftyone/zoo/tf.py
+++ b/fiftyone/zoo/tf.py
@@ -5,8 +5,6 @@ FiftyOne Zoo Datasets provided by ``tensorflow_datasets``.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
-import os
-
 import fiftyone.core.utils as fou
 import fiftyone.types as fot
 import fiftyone.utils.imagenet as foui
@@ -275,26 +273,43 @@ class ImageNet2012Dataset(TFDSDataset):
     hierarchy.
 
     Note that labels were never publicly released for the test set, so only the
-    training and validation sets are provided here.
+    training and validation sets are provided.
 
-    **Manual download instructions**
-
-    This dataset requires you to download the source data manually. You must
-    register at http://www.image-net.org/download-images in order to get the
-    link to download the dataset.
-
-    In particular, you must provide the following files::
+    In order to load the ImageNet dataset, you must download the source data
+    manually into ``source_dir`` as follows::
 
             both splits: ILSVRC2012_devkit_t12.tar.gz
             train split: ILSVRC2012_img_train.tar
        validation split: ILSVRC2012_img_val.tar
+
+    You can register at `http://www.image-net.org/download-images`_ in order to
+    get links to download the data.
+
+    Example usage::
+
+        import fiftyone.zoo as foz
+
+        # First parse the manually downloaded files in `source_dir`
+        foz.download_zoo_dataset(
+            "imagenet-2012", source_dir="/path/to/dir-with-imagenet-files"
+        )
+
+        # Now load into FiftyOne
+        dataset = foz.load_zoo_dataset("imagenet-2012", split="validation")
 
     Dataset size:
         144.02 GiB
 
     Source:
         http://image-net.org
+
+    Args:
+        source_dir (None): the directory containing the manually downloaded
+            ImageNet files
     """
+
+    def __init__(self, source_dir=None):
+        self.source_dir = source_dir
 
     @property
     def name(self):
@@ -306,8 +321,7 @@ class ImageNet2012Dataset(TFDSDataset):
 
     def _download_and_prepare(self, dataset_dir, _, split):
         # Ensure that the source files have been manually downloaded
-        root_dir = os.path.dirname(dataset_dir)  # remove split dir
-        foui.ensure_imagenet_manual_download(root_dir, split)
+        foui.ensure_imagenet_manual_download(self.source_dir, split)
 
         if split == "validation":
             _split = "val"
@@ -318,7 +332,7 @@ class ImageNet2012Dataset(TFDSDataset):
             return tfds.load(
                 "imagenet2012",
                 split=_split,
-                data_dir=root_dir,
+                data_dir=self.source_dir,
                 download=False,
                 with_info=True,
             )

--- a/fiftyone/zoo/torch.py
+++ b/fiftyone/zoo/torch.py
@@ -5,8 +5,6 @@ FiftyOne Zoo Datasets provided by ``torchvision.datasets``.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
-import os
-
 import fiftyone.core.utils as fou
 import fiftyone.types as fot
 import fiftyone.utils.coco as fouc
@@ -213,26 +211,43 @@ class ImageNet2012Dataset(TorchVisionDataset):
     hierarchy.
 
     Note that labels were never publicly released for the test set, so only the
-    training and validation sets are provided here.
+    training and validation sets are provided.
 
-    **Manual download instructions**
-
-    This dataset requires you to download the source data manually. You must
-    register at http://www.image-net.org/download-images in order to get the
-    link to download the dataset.
-
-    In particular, you must provide the following files::
+    In order to load the ImageNet dataset, you must download the source data
+    manually into ``source_dir`` as follows::
 
             both splits: ILSVRC2012_devkit_t12.tar.gz
             train split: ILSVRC2012_img_train.tar
        validation split: ILSVRC2012_img_val.tar
+
+    You can register at `http://www.image-net.org/download-images`_ in order to
+    get links to download the data.
+
+    Example usage::
+
+        import fiftyone.zoo as foz
+
+        # First parse the manually downloaded files in `source_dir`
+        foz.download_zoo_dataset(
+            "imagenet-2012", source_dir="/path/to/dir-with-imagenet-files"
+        )
+
+        # Now load into FiftyOne
+        dataset = foz.load_zoo_dataset("imagenet-2012", split="validation")
 
     Dataset size:
         144.02 GiB
 
     Source:
         http://image-net.org
+
+    Args:
+        source_dir (None): the directory containing the manually downloaded
+            ImageNet files
     """
+
+    def __init__(self, source_dir=None):
+        self.source_dir = source_dir
 
     @property
     def name(self):
@@ -244,8 +259,7 @@ class ImageNet2012Dataset(TorchVisionDataset):
 
     def _download_and_prepare(self, dataset_dir, _, split):
         # Ensure that the source files have been manually downloaded
-        root_dir = os.path.dirname(dataset_dir)  # remove split dir
-        foui.ensure_imagenet_manual_download(root_dir, split)
+        foui.ensure_imagenet_manual_download(self.source_dir, split)
 
         if split == "validation":
             _split = "val"
@@ -253,7 +267,7 @@ class ImageNet2012Dataset(TorchVisionDataset):
             _split = split
 
         def download_fcn(_):
-            return torchvision.datasets.ImageNet(root_dir, split=_split)
+            return torchvision.datasets.ImageNet(self.source_dir, split=_split)
 
         get_class_labels_fcn = _parse_classification_labels
         sample_parser = foud.ImageClassificationSampleParser()


### PR DESCRIPTION
Adds the [Cityscapes dataset](https://www.cityscapes-dataset.com) to the dataset zoo.

Also adds some documentation to the user guide about working with zoo datasets whose source files must be manually downloaded from the web (eg b/c accounts must be created to download them). Towards this end, the implementation of BDD100k and ImageNet were updated slightly to make their syntax consistent with Cityscapes.

Example of loading the validation split of Cityscapes into FiftyOne:

```py
import fiftyone as fo
import fiftyone.zoo as foz

# Parse the manually downloaded files
foz.download_zoo_dataset("cityscapes", source_dir="/path/to/cityscapes-downloaded-files")

# Load Cityscapes validation split
dataset = foz.load_zoo_dataset("cityscapes", split="validation")

# View in App
session = fo.launch_app(dataset)
```

<img width="1302" alt="Screen Shot 2020-11-04 at 4 12 21 PM" src="https://user-images.githubusercontent.com/25985824/98168527-b25a2500-1eb8-11eb-9e2d-0ebaaa374438.png">
