### PR TITLE
View Bar fixes

### DIFF
--- a/electron/app/components/Filter.tsx
+++ b/electron/app/components/Filter.tsx
@@ -69,12 +69,12 @@ const classFilterMachine = Machine({
           states: {
             hovering: {
               on: {
-                MOUSELEAVE_RESULTS: "notHovering",
+                MOUSELEAVE: "notHovering",
               },
             },
             notHovering: {
               on: {
-                MOUSEENTER_RESULTS: "hovering",
+                MOUSEENTER: "hovering",
               },
             },
           },

--- a/electron/app/components/ViewBar/ViewStage/SearchResults.tsx
+++ b/electron/app/components/ViewBar/ViewStage/SearchResults.tsx
@@ -18,41 +18,45 @@ interface SearchResultProps {
   send: any;
 }
 
-const SearchResult = React.memo(({ result, isActive, send, followRef }) => {
-  const theme = useContext(ThemeContext);
-  const [props, set] = useSpring(() => ({
-    backgroundColor: isActive ? theme.backgroundLight : theme.backgroundDark,
-    color: isActive ? theme.font : theme.fontDark,
-  }));
-
-  useEffect(() => {
-    set({
+const SearchResult = React.memo(
+  ({ result, isActive, send }: SearchResultProps) => {
+    const theme = useContext(ThemeContext);
+    const [props, set] = useSpring(() => ({
       backgroundColor: isActive ? theme.backgroundLight : theme.backgroundDark,
       color: isActive ? theme.font : theme.fontDark,
-    });
-  }, [isActive]);
+    }));
 
-  const handleMouseEnter = () =>
-    set({ backgroundColor: theme.backgroundLight, color: theme.font });
+    useEffect(() => {
+      set({
+        backgroundColor: isActive
+          ? theme.backgroundLight
+          : theme.backgroundDark,
+        color: isActive ? theme.font : theme.fontDark,
+      });
+    }, [isActive]);
 
-  const handleMouseLeave = () =>
-    set({ backgroundColor: theme.backgroundDark, color: theme.fontDark });
+    const handleMouseEnter = () =>
+      set({ backgroundColor: theme.backgroundLight, color: theme.font });
 
-  const setResult = (e) =>
-    send({ type: "COMMIT", value: e.target.dataset.result });
+    const handleMouseLeave = () =>
+      set({ backgroundColor: theme.backgroundDark, color: theme.fontDark });
 
-  return (
-    <SearchResultDiv
-      onClick={setResult}
-      onMouseEnter={handleMouseEnter}
-      onMouseLeave={handleMouseLeave}
-      style={props}
-      data-result={result}
-    >
-      {result}
-    </SearchResultDiv>
-  );
-});
+    const setResult = (e) =>
+      send({ type: "COMMIT", value: e.target.dataset.result });
+
+    return (
+      <SearchResultDiv
+        onClick={setResult}
+        onMouseEnter={handleMouseEnter}
+        onMouseLeave={handleMouseLeave}
+        style={props}
+        data-result={result}
+      >
+        {result}
+      </SearchResultDiv>
+    );
+  }
+);
 
 const SearchResultsDiv = animated(styled.div`
   background-color: ${({ theme }) => theme.backgroundDark};
@@ -64,7 +68,8 @@ const SearchResultsDiv = animated(styled.div`
   position: fixed;
   width: auto;
   z-index: 801;
-  padding: 0.5rem 0;
+  max-height: 328px;
+  overflow-y: scroll;
 
   &::-webkit-scrollbar {
     width: 0px;
@@ -108,8 +113,8 @@ const SearchResults = React.memo(
     return (
       <SearchResultsDiv
         style={props}
-        onMouseEnter={() => send("MOUSEENTER_RESULTS")}
-        onMouseLeave={() => send("MOUSELEAVE_RESULTS")}
+        onMouseEnter={() => send("MOUSEENTER")}
+        onMouseLeave={() => send("MOUSELEAVE")}
         {...rest}
       >
         {results.map((result, i) => (

--- a/electron/app/components/ViewBar/ViewStage/ViewStageParameter.tsx
+++ b/electron/app/components/ViewBar/ViewStage/ViewStageParameter.tsx
@@ -383,7 +383,9 @@ const ViewStageParameter = React.memo(({ parameterRef, barRef, stageRef }) => {
                   : value
               }
               onFocus={() => !isEditing && send({ type: "EDIT" })}
-              onBlur={() => send({ type: "COMMIT" })}
+              onBlur={() =>
+                state.matches("editing.notHovering") && send({ type: "COMMIT" })
+              }
               onChange={(e) => {
                 send({ type: "CHANGE", value: e.target.value });
               }}
@@ -424,6 +426,8 @@ const ViewStageParameter = React.memo(({ parameterRef, barRef, stageRef }) => {
                   color: theme.font,
                   marginTop: "0.2em",
                 }}
+                onMouseEnter={() => send("MOUSEENTER")}
+                onMouseLeave={() => send("MOUSELEAVE")}
                 onClick={() => setExpanded(true)}
               />
             )}

--- a/electron/app/components/ViewBar/ViewStage/viewStageMachine.ts
+++ b/electron/app/components/ViewBar/ViewStage/viewStageMachine.ts
@@ -185,12 +185,12 @@ const viewStageMachine = Machine(
                 states: {
                   hovering: {
                     on: {
-                      MOUSELEAVE_RESULTS: "notHovering",
+                      MOUSELEAVE: "notHovering",
                     },
                   },
                   notHovering: {
                     on: {
-                      MOUSEENTER_RESULTS: "hovering",
+                      MOUSEENTER: "hovering",
                     },
                   },
                 },

--- a/electron/app/components/ViewBar/ViewStage/viewStageParameterMachine.ts
+++ b/electron/app/components/ViewBar/ViewStage/viewStageParameterMachine.ts
@@ -201,12 +201,12 @@ export default Machine(
         states: {
           hovering: {
             on: {
-              MOUSELEAVE_RESULTS: "notHovering",
+              MOUSELEAVE: "notHovering",
             },
           },
           notHovering: {
             on: {
-              MOUSEENTER_RESULTS: "hovering",
+              MOUSEENTER: "hovering",
             },
           },
         },


### PR DESCRIPTION
## What changes are proposed in this pull request?

* Fixes the SortBy `field_or_expr` caret (it expands into Object mode when clicked now).
* Limits results in the view bar to at most 10

Resolves #663 
Resolves #665 

## How is this patch tested? If it is not, please explain why.

Locally.

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

* Fixes the SortBy  `field_or_expr` caret by expanding into Object mode when clicked
* Limits results in the view bar to at most 10

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
