### PR TITLE
Only expand sample labels to frames for App

### DIFF
--- a/fiftyone/server/main.py
+++ b/fiftyone/server/main.py
@@ -381,6 +381,8 @@ class StateController(Namespace):
             frame_labels = etav.VideoFrameLabels(frame_number=frame_number)
             for k, v in sample.items():
                 if isinstance(v, dict) and k != "frames" and "_cls" in v:
+                    if v["_cls"] == "VideoMetadata":
+                        continue
                     field_labels = _make_frame_labels(k, v, frame_number)
                     for obj in field_labels.objects:
                         obj.frame_number = frame_number

--- a/fiftyone/server/main.py
+++ b/fiftyone/server/main.py
@@ -375,19 +375,27 @@ class StateController(Namespace):
 
             labels.add_frame(frame_labels)
 
+        sample_schema = state.dataset.get_field_schema()
         for frame_number in range(
             1, etav.get_frame_count(sample["filepath"]) + 1
         ):
             frame_labels = etav.VideoFrameLabels(frame_number=frame_number)
             for k, v in sample.items():
-                if isinstance(v, dict) and k != "frames" and "_cls" in v:
-                    if v["_cls"] == "VideoMetadata":
-                        continue
-                    field_labels = _make_frame_labels(k, v, frame_number)
-                    for obj in field_labels.objects:
-                        obj.frame_number = frame_number
+                if k not in sample_schema:
+                    continue
 
-                    frame_labels.merge_labels(field_labels)
+                field = sample_schema[k]
+                if not isinstance(field, fof.EmbeddedDocumentField):
+                    continue
+
+                if not issubclass(field.document_type, fol.Label):
+                    continue
+
+                field_labels = _make_frame_labels(k, v, frame_number)
+                for obj in field_labels.objects:
+                    obj.frame_number = frame_number
+
+                frame_labels.merge_labels(field_labels)
 
             labels.add_frame(frame_labels, overwrite=False)
 


### PR DESCRIPTION
The previous check for expanding sample labels into frames for the App was not robust and only assumed an embedded document field needed a `_cls` to deserve conversion into frame labels. Resolves #626.