### PR TITLE
Adding support for exporting/importing labels to/from Scale AI

### DIFF
--- a/fiftyone/utils/labelbox.py
+++ b/fiftyone/utils/labelbox.py
@@ -55,6 +55,40 @@ def import_from_labelbox(
     FiftyOne sample are added to the FiftyOne dataset, and their media is
     downloaded into ``download_dir``.
 
+    The provided ``json_path`` should contain a JSON file in the following
+    format::
+
+        [
+            {
+                "ID": <labelbox-id>,
+                "Labeled Data": <url-or-None>,
+                "Label": {...},
+            }
+        ]
+
+    When importing image labels, the ``"Label"`` field should contain a dict
+    of `Labelbox image labels <https://labelbox.com/docs/exporting-data/export-format-detail#images>`_::
+
+        {
+            "objects": [...],
+            "classifications": [...]
+        }
+
+    When importing video labels, the ``"Label"`` field should contain a dict
+    as follows::
+
+        {
+            "frames": <url-or-filepath>
+        }
+
+    where the ``"frames"`` field can either contain a URL, in which case the
+    file is downloaded from the web, or the path to NDJSON file on disk of
+    `Labelbox video labels <https://labelbox.com/docs/exporting-data/export-format-detail#video>`_::
+
+        {"frameNumber": 1, "objects": [...], "classifications": [...]}
+        {"frameNumber": 2, "objects": [...], "classifications": [...]}
+        ...
+
     Args:
         dataset: a :class:`fiftyone.core.dataset.Dataset`
         json_path: the path to the Labelbox JSON export to load

--- a/fiftyone/utils/labelbox.py
+++ b/fiftyone/utils/labelbox.py
@@ -66,22 +66,22 @@ def import_from_labelbox(
             }
         ]
 
-    When importing image labels, the ``"Label"`` field should contain a dict
-    of `Labelbox image labels <https://labelbox.com/docs/exporting-data/export-format-detail#images>`_::
+    When importing image labels, the ``Label`` field should contain a dict of
+    `Labelbox image labels <https://labelbox.com/docs/exporting-data/export-format-detail#images>`_::
 
         {
             "objects": [...],
             "classifications": [...]
         }
 
-    When importing video labels, the ``"Label"`` field should contain a dict
-    as follows::
+    When importing video labels, the ``Label`` field should contain a dict as
+    follows::
 
         {
             "frames": <url-or-filepath>
         }
 
-    where the ``"frames"`` field can either contain a URL, in which case the
+    where the ``frames`` field can either contain a URL, in which case the
     file is downloaded from the web, or the path to NDJSON file on disk of
     `Labelbox video labels <https://labelbox.com/docs/exporting-data/export-format-detail#video>`_::
 
@@ -439,7 +439,7 @@ def convert_labelbox_export_to_import(inpath, outpath=None, video_outdir=None):
     The output JSON file will have the same format that is generated when
     `exporting a Labelbox project's labels <https://labelbox.com/docs/exporting-data/export-overview>`_.
 
-    The ``"Labeled Data"`` fields of the output labels will be ``None``.
+    The ``Labeled Data`` fields of the output labels will be ``None``.
 
     Args:
         inpath: the path to an NDJSON file generated (for example) by

--- a/fiftyone/utils/labelbox.py
+++ b/fiftyone/utils/labelbox.py
@@ -62,7 +62,7 @@ def import_from_labelbox(
             {
                 "ID": <labelbox-id>,
                 "Labeled Data": <url-or-None>,
-                "Label": {...},
+                "Label": {...}
             }
         ]
 

--- a/fiftyone/utils/labelbox.py
+++ b/fiftyone/utils/labelbox.py
@@ -61,6 +61,7 @@ def import_from_labelbox(
         labelbox_project_or_json_path: a ``labelbox.schema.project.Project`` or
             the path to the JSON export of a Labelbox project on disk
         label_prefix (None): a prefix to prepend to the sample label field(s)
+            that are created, separated by an underscore
         download_dir (None): a directory into which to download the media for
             any Labelbox IDs with no corresponding sample with the matching
             ``labelbox_id_field`` value. This can be omitted if all IDs are

--- a/fiftyone/utils/scale.py
+++ b/fiftyone/utils/scale.py
@@ -248,7 +248,7 @@ def export_to_scale(
     sample_collection,
     json_path,
     video_labels_dir=None,
-    events_dir=None,
+    video_events_dir=None,
     video_playback=False,
     label_field=None,
     label_prefix=None,
@@ -332,7 +332,7 @@ def export_to_scale(
             "annotations": {...}
         }
 
-    When exporting labels for videos and the ``events_dir`` parameter is
+    When exporting labels for videos and the ``video_events_dir`` parameter is
     provided, the ``hypothesis`` fields of the JSON written to ``json_path``
     will include an ``events`` field::
 
@@ -346,9 +346,9 @@ def export_to_scale(
         }
 
     whose ``url`` field will contain the paths on disk to per-sample JSON files
-    that are written to ``events_dir`` as follows::
+    that are written to ``video_events_dir`` as follows::
 
-        events_dir/
+        video_events_dir/
             <sample-id1>.json
             <sample-id2>.json
             ...
@@ -366,8 +366,8 @@ def export_to_scale(
         json_path: the path to write the JSON export
         video_labels_dir (None): a directory to write the per-sample video
             labels. Only applicable for video samples
-        events_dir (None): a directory to write the per-sample video events.
-            Only applicable for video samples
+        video_events_dir (None): a directory to write the per-sample video
+            events. Only applicable for video samples
         video_playback (False): whether to export video labels in a suitable
             format for use with the
             `Video Playback <https://docs.scale.com/reference#video-playback>`_ task.
@@ -412,11 +412,11 @@ def export_to_scale(
         )
 
         if frame_label_fields and (
-            video_labels_dir is None and events_dir is None
+            video_labels_dir is None and video_events_dir is None
         ):
             raise ValueError(
-                "Must provide `video_labels_dir` and/or `events_dir` when "
-                "exporting labels for video samples"
+                "Must provide `video_labels_dir` and/or `video_events_dir` "
+                "when exporting labels for video samples"
             )
 
     # Export the labels
@@ -450,7 +450,7 @@ def export_to_scale(
             # Export frame-level labels
             if is_video and frame_label_fields:
                 frames = _get_frame_labels(sample, frame_label_fields)
-                make_events = events_dir is not None
+                make_events = video_events_dir is not None
                 if video_playback:
                     annotations, events = _to_scale_video_playback_labels(
                         frames, frame_size, make_events=make_events
@@ -471,8 +471,10 @@ def export_to_scale(
                     anno_dict["annotations"] = {"url": anno_path}
 
                 # Write events
-                if events_dir:
-                    events_path = os.path.join(events_dir, sample.id + ".json")
+                if video_events_dir:
+                    events_path = os.path.join(
+                        video_events_dir, sample.id + ".json"
+                    )
                     etas.write_json(events, events_path)
                     anno_dict["events"] = {"url": events_path}
 

--- a/fiftyone/utils/scale.py
+++ b/fiftyone/utils/scale.py
@@ -122,11 +122,11 @@ def import_from_scale(
             [
                 {
                     "annotations": [...],
-                    "global_attributes: {...}
+                    "global_attributes": {...}
                 },
                 {
                     "annotations": [...],
-                    "global_attributes: {...}
+                    "global_attributes": {...}
                 },
                 ...
             ]
@@ -271,11 +271,11 @@ def export_to_scale(
         {
             <sample-id1>: {
                 "filepath": <filepath1>,
-                "hypothesis": {...},
+                "hypothesis": {...}
             },
             <sample-id2>: {
                 "filepath": <filepath2>,
-                "hypothesis": {...},
+                "hypothesis": {...}
             },
             ...
         }
@@ -287,7 +287,7 @@ def export_to_scale(
 
             {
                 "annotations": [...],
-                "global_attributes: {...}
+                "global_attributes": {...}
             }
 
     -   Video samples::
@@ -313,11 +313,11 @@ def export_to_scale(
         [
             {
                 "annotations": [...],
-                "global_attributes: {...}
+                "global_attributes": {...}
             },
             {
                 "annotations": [...],
-                "global_attributes: {...}
+                "global_attributes": {...}
             },
             ...
         ]
@@ -329,7 +329,7 @@ def export_to_scale(
     `Video Playback format <https://docs.scale.com/reference#video-playback>`_::
 
         {
-            "annotations": {...},
+            "annotations": {...}
         }
 
     When exporting labels for videos and the ``events_dir`` parameter is

--- a/fiftyone/utils/scale.py
+++ b/fiftyone/utils/scale.py
@@ -330,13 +330,14 @@ def export_to_scale(
             with the given prefix will be exported
         labels_dict (None): a dictionary mapping label field names to keys; all
             fields whose names are in this dictionary will be exported
-        frame_labels_field (None): the name of a frame labels field to export
+        frame_labels_field (None): the name of a frame labels field to export.
+            Only applicable for video samples
         frame_labels_prefix (None): a frame labels field prefix; all
             frame-level fields whose name starts with the given prefix will be
-            exported
+            exported. Only applicable for video samples
         frame_labels_dict (None): a dictionary mapping frame label fields to
             keys; all frame-level fields whose names are in this dictionary
-            will be exported
+            will be exported. Only applicable for video samples
     """
     is_video = sample_collection.media_type == fomm.VIDEO
 

--- a/fiftyone/utils/scale.py
+++ b/fiftyone/utils/scale.py
@@ -75,7 +75,7 @@ def import_from_scale(
     where each JSON file contains only the contents of the ``response`` field
     for the task.
 
-    The contents of the ``response`` field should be as follows::
+    The contents of the ``response`` field should be as follows:
 
     -   `General Image Annotation <https://docs.scale.com/reference#general-image-annotation>`_::
 
@@ -259,23 +259,23 @@ def export_to_scale(
             ...
         }
 
-    The format of the ``hypothesis`` field depends on the label type::
+    The format of the ``hypothesis`` field depends on the label type:
 
-        -   Sample-level classifications, detections, polylines, polygons, and
-            keypoints::
+    -   Sample-level classifications, detections, polylines, polygons, and
+        keypoints::
 
-                {
-                    "annotations": [...],
-                    "global_attributes: {...}
+            {
+                "annotations": [...],
+                "global_attributes: {...}
+            }
+
+    -   Video samples::
+
+            {
+                "annotations": {
+                    "url": <frame-labels-filepath>
                 }
-
-        -   Video samples::
-
-                {
-                    "annotations": {
-                        "url": <frame-labels-filepath>
-                    }
-                }
+            }
 
     When exporting frame labels for video samples, the ``url`` field will
     contain the paths on disk to per-sample JSON files that are written to

--- a/fiftyone/utils/scale.py
+++ b/fiftyone/utils/scale.py
@@ -579,7 +579,7 @@ def _to_scale_video_playback_labels(frames, frame_size):
 
                     if key not in traj_uuids:
                         uuid = str(uuid4())
-                        annotations[uuid] = _init_video_box(label)
+                        annotations[uuid] = _init_video_box(detection.label)
 
                         if key is not None:
                             traj_uuids[key] = uuid

--- a/fiftyone/utils/scale.py
+++ b/fiftyone/utils/scale.py
@@ -1,0 +1,1075 @@
+"""
+Utilities for working with annotations in
+`Scale AI format <https://docs.scale.com/reference#annotation>`_.
+
+| Copyright 2017-2020, Voxel51, Inc.
+| `voxel51.com <https://voxel51.com/>`_
+|
+"""
+from collections import defaultdict
+from copy import deepcopy
+import logging
+import os
+from uuid import uuid4
+import warnings
+
+import numpy as np
+
+import eta.core.image as etai
+import eta.core.serial as etas
+import eta.core.utils as etau
+import eta.core.web as etaw
+
+import fiftyone.core.collections as foc
+import fiftyone.core.labels as fol
+import fiftyone.core.media as fomm
+import fiftyone.core.metadata as fom
+import fiftyone.core.utils as fou
+
+
+logger = logging.getLogger(__name__)
+
+
+def import_from_scale(
+    dataset, labels_dir_or_json, label_prefix=None, scale_id_field="scale_id",
+):
+    """Imports the Scale AI labels into the FiftyOne dataset.
+
+    This method supports importing annotations from the following Scale API
+    endpoints:
+
+    -   `General Image Annotation <https://docs.scale.com/reference#general-image-annotation>`_
+    -   `Semantic Segmentation Annotation <https://docs.scale.com/reference#semantic-segmentation-annotation>`_
+    -   `General Video Annotation <https://docs.scale.com/reference#general-video-annotation>`_
+    -   `Video Playback <https://docs.scale.com/reference#video-playback>`_
+
+    The ``scale_id_field`` of the FiftyOne samples are used to associate
+    samples with their corresponding Scale task IDs.
+
+    The provided ``labels_dir_or_json`` can either be the path to a JSON
+    export in the following format::
+
+        [
+            {
+                "task_id": <scale-task-id1>,
+                "response": {...},
+                ...
+            },
+            {
+                "task_id": <scale-task-id2>,
+                "response": {...},
+                ...
+            },
+            ...
+        ]
+
+    or a directory of per-task JSON files, which can either (a) directly
+    contain the elements of the list above, or (b) contain task labels
+    organized in the following format::
+
+        labels_dir/
+            <scale-task-id1>.json
+            <scale-task-id2>.json
+            ...
+
+    where each JSON file contains only the contents of the ``response`` field
+    for the task.
+
+    The contents of the ``response`` field should be as follows::
+
+    -   `General Image Annotation <https://docs.scale.com/reference#general-image-annotation>`_::
+
+            {
+                "annotations": [...]
+                "global_attributes": {...}
+            }
+
+    -   `Semantic Segmentation Annotation <https://docs.scale.com/reference#semantic-segmentation-annotation>`_::
+
+            {
+                "annotations": {
+                    ...
+                    "combined": {
+                        ...
+                        "indexedImage": <url-or-filepath>
+                    }
+                },
+                "labelMapping": {...}
+            }
+
+        where the ``indexedImage`` field (which is the only version of the
+        segmentation used by this method) can contain either a URL, in which
+        case the mask is downloaded from the web, or the path to the mask on
+        disk.
+
+    -   `General Video Annotation <https://docs.scale.com/reference#general-video-annotation>`_::
+
+            {
+                "annotations": {
+                    "url": <url-or-filepath>
+                }
+            }
+
+        where the ``url`` field can contain either a URL, in which case the
+        file is downloaded from the web, or the path to JSON file on disk
+        containing the per-frame annotations in the following format::
+
+            [
+                {
+                    "annotations": [...],
+                    "global_attributes: {...}
+                },
+                {
+                    "annotations": [...],
+                    "global_attributes: {...}
+                },
+                ...
+            ]
+
+        where the n-th element in the list contains the labels for the n-th
+        frame that was labeled.
+
+        Note that, if parameters such as ``duration_time``, ``frame_rate``, and
+        ``start_time`` were used to specify which frames of the video to
+        annotate, then you must ensure that the ``labels_dir_or_json`` JSON
+        that you provide to this method contains the ``task`` fields for each
+        Scale task so that the correct frame numbers can be determined from
+        these values.
+
+    -   `Video Playback <https://docs.scale.com/reference#video-playback>`_::
+
+            {
+                "annotations": {
+                    "url": <url-or-filepath>
+                }
+            }
+
+        where the ``url`` field can contain either a URL, in which case the
+        file is downloaded from the web, or the path to JSON file on disk
+        containing the video playback annotations in the following format::
+
+            {
+                "annotations": [...],
+                "events": [...],
+            }
+
+    Args:
+        dataset: a :class:`fiftyone.core.dataset.Dataset`
+        labels_dir_or_json: the path to a Scale AI JSON export or a directory
+            of JSON exports as per the formats described above
+        label_prefix (None): a prefix to prepend to the sample label field(s)
+            that are created
+        scale_id_field ("scale_id"): the sample field to use to associate Scale
+            task IDs with FiftyOne samples
+    """
+    # Load labels
+    if labels_dir_or_json.endswith(".json"):
+        labels = _load_labels(labels_dir_or_json)
+    else:
+        labels = _load_labels_dir(labels_dir_or_json)
+
+    id_map = {}
+    for sample in dataset.select_fields(scale_id_field):
+        id_map[sample[scale_id_field]] = sample.id
+
+    if label_prefix:
+        label_key = lambda k: label_prefix + "_" + k
+    else:
+        label_key = lambda k: k
+
+    is_video = dataset.media_type == fomm.VIDEO
+
+    # ref: https://github.com/Labelbox/labelbox/blob/7c79b76310fa867dd38077e83a0852a259564da1/exporters/coco-exporter/coco_exporter.py#L33
+    with fou.ProgressBar(total=len(labels)) as pb:
+        for task_id, task_labels in pb(labels.items()):
+            if task_id not in id_map:
+                logger.info(
+                    "Skipping labels for unknown Scale ID '%s'", task_id
+                )
+                continue
+
+            sample = dataset[id_map[task_id]]
+
+            if sample.metadata is None:
+                if is_video:
+                    sample.metadata = fom.VideoMetadata.build_for(
+                        sample.filepath
+                    )
+                else:
+                    sample.metadata = fom.ImageMetadata.build_for(
+                        sample.filepath
+                    )
+
+            if is_video:
+                frames = _parse_video_labels(task_labels, sample.metadata)
+                sample.frames.merge(
+                    {
+                        frame_number: {
+                            label_key(fname): flabel
+                            for fname, flabel in frame_dict.items()
+                        }
+                        for frame_number, frame_dict in frames.items()
+                    }
+                )
+            else:
+                frame_size = (sample.metadata.width, sample.metadata.height)
+                anno_dict = task_labels["response"]
+                labels_dict = _parse_image_labels(anno_dict, frame_size)
+                sample.update_fields(
+                    {label_key(k): v for k, v in labels_dict.items()}
+                )
+
+            sample.save()
+
+
+# @todo add support for `duration_time`, `frame_rate`, and `start_time`
+# parameters when exporting general video annotation labels?
+def export_to_scale(
+    sample_collection,
+    json_path,
+    video_labels_dir=None,
+    video_playback=False,
+    label_field=None,
+    label_prefix=None,
+    labels_dict=None,
+    frame_labels_field=None,
+    frame_labels_prefix=None,
+    frame_labels_dict=None,
+):
+    """Exports labels from the FiftyOne samples to Scale AI format.
+
+    This function is useful for generating pre-annotations that can be provided
+    to Scale AI via the ``hypothesis`` parameter of the following endpoints:
+
+    -   `General Image Annotation <https://docs.scale.com/reference#general-image-annotation>`_
+    -   `General Video Annotation <https://docs.scale.com/reference#general-video-annotation>`_
+    -   `Video Playback <https://docs.scale.com/reference#video-playback>`_
+
+    The output ``json_path`` will be a JSON file in the following format::
+
+        {
+            <sample-id1>: {
+                "filepath": <filepath1>,
+                "hypothesis": {...},
+            },
+            <sample-id2>: {
+                "filepath": <filepath2>,
+                "hypothesis": {...},
+            },
+            ...
+        }
+
+    The format of the ``hypothesis`` field depends on the label type::
+
+        -   Sample-level classifications, detections, polylines, polygons, and
+            keypoints::
+
+                {
+                    "annotations": [...],
+                    "global_attributes: {...}
+                }
+
+        -   Video samples::
+
+                {
+                    "annotations": {
+                        "url": <frame-labels-filepath>
+                    }
+                }
+
+    When exporting frame labels for video samples, the ``url`` field will
+    contain the paths on disk to per-sample JSON files that are written to
+    ``video_labels_dir`` as follows::
+
+        video_labels_dir/
+            <sample-id1>.json
+            <sample-id2>.json
+            ...
+
+    When ``video_playback == False``, the per-sample JSON files are written in
+    `General Video Annotation format <https://docs.scale.com/reference#general-video-annotation>`_::
+
+        [
+            {
+                "annotations": [...],
+                "global_attributes: {...}
+            },
+            {
+                "annotations": [...],
+                "global_attributes: {...}
+            },
+            ...
+        ]
+
+    where the n-th element in the list contains the labels for the n-th frame
+    of the video.
+
+    When ``video_playback == True``, the per-sample JSON files are written in
+    `Video Playback format <https://docs.scale.com/reference#video-playback>`_::
+
+        {
+            "annotations": [...],
+            "events": [...],
+        }
+
+    Args:
+        sample_collection: a
+            :class:`fiftyone.core.collections.SampleCollection`
+            the path to write an NDJSON export of the labels
+        json_path: the path to write the JSON export
+        video_labels_dir (None): a directory to write the per-sample video
+            labels. Only applicable for video samples
+        video_playback (False): whether to export video labels in a suitable
+            format for use with the
+            `Video Playback <https://docs.scale.com/reference#video-playback>`_ task.
+            By default, video labels are exported for in a suitable format for
+            the `General Video Annotation <https://docs.scale.com/reference#general-video-annotation>`_
+            task. Only applicable for video samples
+        label_field (None): the name of a label field to export
+        label_prefix (None): a label field prefix; all fields whose name starts
+            with the given prefix will be exported
+        labels_dict (None): a dictionary mapping label field names to keys; all
+            fields whose names are in this dictionary will be exported
+        frame_labels_field (None): the name of a frame labels field to export
+        frame_labels_prefix (None): a frame labels field prefix; all
+            frame-level fields whose name starts with the given prefix will be
+            exported
+        frame_labels_dict (None): a dictionary mapping frame label fields to
+            keys; all frame-level fields whose names are in this dictionary
+            will be exported
+    """
+    is_video = sample_collection.media_type == fomm.VIDEO
+
+    # Get label fields to export
+    label_fields = foc.get_label_fields(
+        sample_collection,
+        label_field=label_field,
+        label_prefix=label_prefix,
+        labels_dict=labels_dict,
+        required=False,
+        force_dict=True,
+    )
+
+    # Get frame label fields to export
+    if is_video:
+        frame_label_fields = foc.get_frame_labels_fields(
+            sample_collection,
+            frame_labels_field=frame_labels_field,
+            frame_labels_prefix=frame_labels_prefix,
+            frame_labels_dict=frame_labels_dict,
+            required=False,
+            force_dict=True,
+        )
+
+        if frame_label_fields and video_labels_dir is None:
+            raise ValueError(
+                "Must provide `video_labels_dir` when exporting frame labels "
+                "for video samples"
+            )
+
+    # Export the labels
+    labels = {}
+    with fou.ProgressBar() as pb:
+        for sample in pb(sample_collection):
+            # Compute metadata if necessary
+            if sample.metadata is None:
+                if is_video:
+                    metadata = fom.VideoMetadata.build_for(sample.filepath)
+                else:
+                    metadata = fom.ImageMetadata.build_for(sample.filepath)
+
+                sample.metadata = metadata
+                sample.save()
+
+            # Get frame size
+            if is_video:
+                frame_size = (
+                    sample.metadata.frame_width,
+                    sample.metadata.frame_height,
+                )
+            else:
+                frame_size = (sample.metadata.width, sample.metadata.height)
+
+            # Export sample-level labels
+            if label_fields:
+                labels_dict = _get_labels(sample, label_fields)
+                anno_dict = _to_scale_image_labels(labels_dict, frame_size)
+
+            # Export frame-level labels
+            if is_video and frame_label_fields:
+                frames = _get_frame_labels(sample, frame_label_fields)
+                if video_playback:
+                    annotations = _to_scale_video_playback_labels(
+                        frames, frame_size
+                    )
+                else:
+                    annotations = _to_scale_video_annotation_labels(
+                        frames, frame_size
+                    )
+
+                video_labels_path = os.path.join(
+                    video_labels_dir, sample.id + ".json"
+                )
+                etas.write_json(annotations, video_labels_path)
+                anno_dict = {"url": video_labels_path}
+
+            labels[sample.id] = {
+                "filepath": sample.filepath,
+                "hypothesis": anno_dict,
+            }
+
+    etas.write_json(labels, json_path)
+
+
+def convert_scale_export_to_import(inpath, outpath):
+    """Converts a Scale AI JSON export generated by :meth:`export_to_scale`
+    into the format expected by :meth:`import_from_scale`.
+
+    The output JSON file will have the same format that is generated when
+    performing a bulk export of a Scale AI project's labels.
+
+    Args:
+        inpath: the path to an JSON file generated (for example) by
+            :meth:`export_to_scale`
+        outpath: the path to write a JSON file containing the converted labels
+
+    Returns:
+        a dictionary mapping sample IDs to the task IDs that were generated for
+        each sample
+    """
+    labels = etas.read_json(inpath)
+
+    id_map = {}
+    annos = []
+    for sample_id, task_dict in labels.items():
+        task_id = str(uuid4())
+        id_map[sample_id] = task_id
+        annos.append({"task_id": task_id, "response": task_dict["hypothesis"]})
+
+    etas.write_json(annos, outpath)
+
+    return id_map
+
+
+def _load_labels(json_path):
+    d_list = etas.read_json(json_path)
+    return {d["task_id"]: d for d in d_list}
+
+
+def _load_labels_dir(labels_dir):
+    labels = {}
+    json_patt = os.path.join(labels_dir, "*.json")
+    for json_path in etau.get_glob_matches(json_patt):
+        task_id, task_labels = _load_task_labels(json_path)
+        labels[task_id] = task_labels
+
+    return labels
+
+
+def _load_task_labels(json_path):
+    d = etas.read_json(json_path)
+
+    if "task_id" in d:
+        task_id = d["task_id"]
+        labels = d
+    else:
+        task_id = os.path.splitext(os.path.basename(json_path))[0]
+        labels = {
+            "task_id": task_id,
+            "response": d,
+            "task": None,
+        }
+
+    return task_id, labels
+
+
+def _get_labels(sample_or_frame, label_fields):
+    labels_dict = {}
+    for field, key in label_fields.items():
+        value = sample_or_frame[field]
+        if value is not None:
+            labels_dict[key] = value
+
+    return labels_dict
+
+
+def _get_frame_labels(sample, frame_label_fields):
+    frames = {}
+    for frame_number, frame in sample.frames.items():
+        frames[frame_number] = _get_labels(frame, frame_label_fields)
+
+    return frames
+
+
+# https://docs.scale.com/reference#general-image-annotation
+def _to_scale_image_labels(labels_dict, frame_size):
+    annotations = []
+    global_attributes = {}
+    for name, label in labels_dict.items():
+        if isinstance(label, fol.Classification):
+            attrs_dict = _to_classification(name, label)
+            global_attributes.update(attrs_dict)
+        elif isinstance(label, (fol.Detection, fol.Detections)):
+            annos = _to_detections(label, frame_size)
+            annotations.extend(annos)
+        elif isinstance(label, (fol.Polyline, fol.Polylines)):
+            annos = _to_polylines(label, frame_size)
+            annotations.extend(annos)
+        elif isinstance(label, (fol.Keypoint, fol.Keypoints)):
+            annos = _to_points(label, frame_size)
+            annotations.extend(annos)
+        elif label is not None:
+            msg = "Ignoring unsupported label type '%s'" % label.__class__
+            warnings.warn(msg)
+
+    anno_dict = {"annotations": annotations}
+
+    if global_attributes:
+        anno_dict["global_attributes"] = global_attributes
+
+    return anno_dict
+
+
+# https://docs.scale.com/reference#general-video-annotation
+def _to_scale_video_annotation_labels(frames, frame_size):
+    annotations = []
+    for labels_dict in frames.values():
+        anno_dict = _to_scale_image_labels(labels_dict, frame_size)
+        annotations.append(anno_dict)
+
+    return annotations
+
+
+# https://docs.scale.com/reference#video-playback
+def _to_scale_video_playback_labels(frames, frame_size):
+    traj_uuids = {}
+    in_progress_events = {}
+    annotations = {}
+    events = []
+    for frame_number, frame in frames.items():
+        # Ingst new labels
+        for label in frame.values():
+            if isinstance(label, (fol.Classification, fol.Classifications)):
+                if isinstance(label, fol.Classification):
+                    classifications = [label]
+                else:
+                    classifications = label.classifications
+
+                for classification in classifications:
+                    event_label = classification.label
+                    if label in in_progress_events:
+                        start = in_progress_events[event_label][0]
+                    else:
+                        start = frame_number
+
+                    in_progress_events[event_label] = (start, frame_number)
+
+            elif isinstance(label, (fol.Detection, fol.Detections)):
+                if isinstance(label, fol.Detection):
+                    detections = [label]
+                else:
+                    detections = label.detections
+
+                for detection in detections:
+                    if detection.index is None:
+                        key = None
+                    else:
+                        key = (detection.label, detection.index)
+
+                    if key not in traj_uuids:
+                        uuid = str(uuid4())
+                        annotations[uuid] = _init_video_box(label)
+
+                        if key is not None:
+                            traj_uuids[key] = uuid
+
+                    annotations[uuid]["frames"].append(
+                        _make_video_box_frame(
+                            detection, frame_number, frame_size
+                        )
+                    )
+
+            elif label is not None:
+                msg = "Ignoring unsupported label type '%s'" % label.__class__
+                warnings.warn(msg)
+
+        # Handle in-progress events
+        for event_label in list(in_progress_events.keys()):
+            start, last = in_progress_events[event_label]
+            if last != frame_number:
+                events.append(_make_event(event_label, start, last))
+                del in_progress_events[event_label]
+
+    # Flush remaining events
+    for event_label, (start, last) in in_progress_events.items():
+        events.append(_make_event(event_label, start, last))
+
+    return {
+        "annotations": annotations,
+        "events": events,
+    }
+
+
+# https://docs.scale.com/reference#events
+def _make_event(label, start, end):
+    if end == start:
+        return {
+            "label": label,
+            "type": "point",
+            "start": start,
+        }
+
+    return {
+        "label": label,
+        "type": "range",
+        "start": start,
+        "end": end,
+    }
+
+
+# https://docs.scale.com/reference#video-playback
+def _init_video_box(label):
+    return {
+        "label": label,
+        "geometry": "box",
+        "frames": [],
+    }
+
+
+# https://docs.scale.com/reference#video-playback
+def _make_video_box_frame(detection, frame_number, frame_size):
+    x, y, w, h = detection.bounding_box
+    width, height = frame_size
+    frame_dict = {
+        "key": frame_number,
+        "x": round(x * width, 1),
+        "y": round(y * height, 1),
+        "width": round(w * width, 1),
+        "height": round(h * height, 1),
+    }
+    if detection.attributes:
+        frame_dict["attributes"] = _to_attributes(detection.attributes)
+
+    return frame_dict
+
+
+# https://docs.scale.com/reference#global-attributes
+def _to_classification(name, label):
+    return {name: label.label}
+
+
+# https://docs.scale.com/reference#attributes-overview
+def _to_attributes(attributes):
+    attrs = {}
+    for name, attr in attributes.items():
+        if not isinstance(
+            attr, (fol.CategoricalAttribute, fol.NumericAttribute)
+        ):
+            msg = "Ignoring unsupported attribute type '%s'" % attr.__class__
+            warnings.warn(msg)
+            continue
+
+        attrs[name] = attr.value
+
+    return attrs
+
+
+# https://docs.scale.com/reference#boxes
+def _to_detections(label, frame_size):
+    if isinstance(label, fol.Detections):
+        detections = label.detections
+    else:
+        detections = [label]
+
+    annos = []
+    for detection in detections:
+        anno = _make_base_anno("box", detection.label)
+        anno.update(_make_bbox(detection.bounding_box, frame_size))
+        if detection.attributes:
+            anno["attributes"] = _to_attributes(detection.attributes)
+
+        annos.append(anno)
+
+    return annos
+
+
+# https://docs.scale.com/reference#polygons
+# https://docs.scale.com/reference#line
+def _to_polylines(label, frame_size):
+    if isinstance(label, fol.Polylines):
+        polylines = label.polylines
+    else:
+        polylines = [label]
+
+    annos = []
+    for polyline in polylines:
+        type_ = "polygon" if polyline.filled else "line"
+        if polyline.attributes:
+            attributes = _to_attributes(polyline.attributes)
+        else:
+            attributes = None
+
+        for points in polyline.points:
+            anno = _make_base_anno(type_, polyline.label)
+            anno["vertices"] = [_make_point(p, frame_size) for p in points]
+            if attributes is not None:
+                anno["attributes"] = attributes
+
+            annos.append(anno)
+
+    return annos
+
+
+# https://docs.scale.com/reference#points
+def _to_points(label, frame_size):
+    if isinstance(label, fol.Keypoints):
+        keypoints = label.keypoints
+    else:
+        keypoints = [keypoints]
+
+    annos = []
+    for keypoint in keypoints:
+        if keypoint.attributes:
+            attributes = _to_attributes(keypoint.attributes)
+        else:
+            attributes = None
+
+        for point in keypoint.points:
+            anno = _make_base_anno("point", keypoint.label)
+            anno.update(_make_point(point, frame_size))
+            if attributes is not None:
+                anno["attributes"] = attributes
+
+            annos.append(anno)
+
+    return annos
+
+
+def _make_base_anno(type_, label):
+    return {
+        "type": type_,
+        "label": label,
+        "uuid": str(uuid4()),
+    }
+
+
+def _make_bbox(bounding_box, frame_size):
+    x, y, w, h = bounding_box
+    width, height = frame_size
+    return {
+        "left": round(x * width, 1),
+        "top": round(y * height, 1),
+        "width": round(w * width, 1),
+        "height": round(h * height, 1),
+    }
+
+
+def _make_point(point, frame_size):
+    x, y = point
+    width, height = frame_size
+    return {"x": round(x * width, 1), "y": round(y * height, 1)}
+
+
+def _parse_video_labels(task_labels, metadata):
+    anno_dict = task_labels["response"]
+    annos = _download_or_load_json(anno_dict["url"])
+
+    if isinstance(annos, list):
+        task = task_labels.get("task", None)
+        return _parse_video_annotation_labels(annos, metadata, task=task)
+
+    return _parse_video_playback_labels(annos, metadata)
+
+
+# https://docs.scale.com/reference#general-video-annotation
+def _parse_video_annotation_labels(annos, metadata, task=None):
+    frame_numbers = None
+    if task is not None:
+        try:
+            frame_numbers = _get_frame_numbers(task, metadata)
+        except:
+            pass
+
+    if frame_numbers is None:
+        frame_numbers = range(1, len(annos) + 1)
+
+    if len(frame_numbers) != len(annos):
+        logger.warning(
+            "Unable to determine which frame numbers have labels. You may "
+            "need to inspect the labels that are loaded..."
+        )
+
+    frame_size = (metadata.frame_width, metadata.frame_height)
+
+    frames = {}
+    for frame_number, anno_dict in zip(frame_numbers, annos):
+        frames[frame_number] = _parse_image_labels(anno_dict, frame_size)
+
+    return frames
+
+
+def _get_frame_numbers(task, metadata):
+    params = task["params"]
+
+    if params["attachment_type"] != "video":
+        return None
+
+    frame_rate = metadata.frame_rate
+
+    start_time = params.get("start_time", None)
+    if start_time is not None:
+        first_frame = 1 + int(round(frame_rate * start_time))
+    else:
+        first_frame = 1
+
+    duration = params.get("duration_time", None)
+    if duration is not None:
+        last_frame = 1 + int(round(frame_rate * duration))
+    else:
+        last_frame = metadata.total_frame_count
+
+    sampling_rate = params.get("frame_rate", frame_rate)
+    accel = frame_rate / sampling_rate
+
+    return sorted(
+        set(int(round(f)) for f in np.arange(first_frame, last_frame, accel))
+    )
+
+
+# https://docs.scale.com/reference#video-playback
+def _parse_video_playback_labels(anno_dict, metadata):
+    frames = defaultdict(dict)
+
+    # Parse events
+    events = anno_dict.get("events", [])
+    _parse_video_playback_events(frames, events)
+
+    # Parse video objects
+    annotations = anno_dict.get("annotations", {})
+    _parse_video_playback_objects(frames, annotations, metadata)
+
+    return frames
+
+
+def _parse_video_playback_events(frames, events):
+    events_map = defaultdict(list)
+    for event in events:
+        type_ = event["type"]
+        label = event["label"]
+        start = event["start"]
+        if type_ == "range":
+            end = event["end"]
+        elif type_ == "point":
+            end = start
+        else:
+            msg = "Ignoring unsupported event type '%s'" % type_
+            warnings.warn(msg)
+            continue
+
+        attributes = _parse_classifications(event.get("attributes", {}))
+
+        for frame_number in range(start, end + 1):
+            events_map[frame_number].append(fol.Classification(label=label))
+            if attributes:
+                frames[frame_number].update(deepcopy(attributes))
+
+    for frame_number, classifications in events_map.items():
+        frames[frame_number]["events"] = fol.Classifications(
+            classifications=classifications
+        )
+
+
+def _parse_video_playback_objects(frames, annotations, metadata):
+    frame_size = (metadata.frame_width, metadata.frame_height)
+
+    index = 0
+    detections_map = defaultdict(list)
+    for _, video_obj in annotations.items():
+        index += 1
+        label = video_obj["label"]
+        type_ = video_obj["geometry"]
+        if type_ != "box":
+            msg = "Ignoring unsupported video annotation geometry '%s'" % type_
+            warnings.warn(msg)
+            continue
+
+        for frame_dict in video_obj["frames"]:
+            frame_number = frame_dict["key"]
+            attributes = _parse_attributes(frame_dict.get("attributes", {}))
+            bounding_box = _parse_video_bbox(frame_dict, frame_size)
+            detection = fol.Detection(
+                label=label,
+                index=index,
+                bounding_box=bounding_box,
+                attributes=attributes,
+            )
+            detections_map[frame_number].append(detection)
+
+    for frame_number, detections in detections_map.items():
+        frames[frame_number]["detections"] = fol.Detections(
+            detections=detections
+        )
+
+
+# https://docs.scale.com/reference#general-image-annotation
+def _parse_image_labels(anno_dict, frame_size):
+    labels = {}
+
+    # Parse classifications
+    attrs = anno_dict.get("global_attributes", {})
+    classifications = _parse_classifications(attrs)
+    labels.update(classifications)
+
+    # Parse objects
+    objects = _parse_objects(anno_dict, frame_size)
+    labels.update(objects)
+
+    return labels
+
+
+def _parse_classifications(attrs):
+    return {k: fol.Classification(label=v) for k, v in attrs.items()}
+
+
+def _parse_attributes(attrs):
+    return {k: fol.CategoricalAttribute(value=v) for k, v in attrs.items()}
+
+
+def _parse_objects(anno_dict, frame_size):
+    annos = anno_dict.get("annotations", [])
+
+    if isinstance(annos, dict):
+        return {"segmentation": _parse_mask(anno_dict)}
+
+    detections = []
+    polylines = []
+    keypoints = []
+    for anno in annos:
+        type_ = anno["type"]
+        label = anno.get("label", None)  # Scale supports unlabeled tasks
+
+        attributes = _parse_attributes(anno.get("attributes", {}))
+
+        if type_ == "box":
+            # Detection
+            bounding_box = _parse_bbox(anno, frame_size)
+            detections.append(
+                fol.Detection(
+                    label=label,
+                    bounding_box=bounding_box,
+                    attributes=attributes,
+                )
+            )
+        elif type_ == "polygon":
+            # Polyline
+            points = _parse_points(anno["vertices"], frame_size)
+            polylines.append(
+                fol.Polyline(
+                    label=label,
+                    points=[points],
+                    closed=True,
+                    filled=True,
+                    attributes=attributes,
+                )
+            )
+        elif type_ == "line":
+            # Polyline
+            points = _parse_points(anno["vertices"], frame_size)
+            polylines.append(
+                fol.Polyline(
+                    label=label,
+                    points=[points],
+                    closed=True,
+                    filled=False,
+                    attributes=attributes,
+                )
+            )
+        elif type_ == "point":
+            # Polyline
+            point = _parse_point(anno, frame_size)
+            keypoints.append(
+                fol.Keypoint(
+                    label=label, points=[point], attributes=attributes,
+                )
+            )
+        else:
+            msg = "Ignoring unsupported label type '%s'" % type_
+            warnings.warn(msg)
+
+    labels = {}
+
+    if detections:
+        labels["detections"] = fol.Detections(detections=detections)
+
+    if polylines:
+        labels["polylines"] = fol.Polylines(polylines=polylines)
+
+    if keypoints:
+        labels["keypoints"] = fol.Keypoints(keypoints=keypoints)
+
+    return labels
+
+
+def _parse_bbox(anno, frame_size):
+    width, height = frame_size
+    x = anno["left"] / width
+    y = anno["top"] / height
+    w = anno["width"] / width
+    h = anno["height"] / height
+    return [x, y, w, h]
+
+
+def _parse_video_bbox(anno, frame_size):
+    width, height = frame_size
+    x = anno["x"] / width
+    y = anno["y"] / height
+    w = anno["width"] / width
+    h = anno["height"] / height
+    return [x, y, w, h]
+
+
+def _parse_points(vertices, frame_size):
+    return [_parse_point(vertex, frame_size) for vertex in vertices]
+
+
+def _parse_point(vertex, frame_size):
+    width, height = frame_size
+    return (vertex["x"] / width, vertex["y"] / height)
+
+
+# https://docs.scale.com/reference#segmentannotation-callback-format
+def _parse_mask(anno_dict):
+    indexed_image_uri = anno_dict["annotations"]["combined"]["indexedImage"]
+    mask = _download_or_load_image(indexed_image_uri)
+
+    segmentation = fol.Segmentation(mask=mask)
+
+    label_mapping = anno_dict.get("labelMapping", None)
+    if label_mapping is not None:
+        label_map = {}
+        for label, value in label_mapping.items():
+            if isinstance(value, dict):
+                value = [value]
+
+            for instance in value:
+                label_map[instance["index"]] = label
+
+        segmentation.label_map = label_map
+
+    return segmentation
+
+
+def _download_or_load_json(url_or_filepath):
+    if url_or_filepath.startswith("http"):
+        json_bytes = etaw.download_file(url_or_filepath, quiet=True)
+        return etas.load_json(json_bytes)
+
+    return etas.read_json(url_or_filepath)
+
+
+def _download_or_load_image(url_or_filepath):
+    if url_or_filepath.startswith("http"):
+        img_bytes = etaw.download_file(url_or_filepath, quiet=True)
+        return etai.decode(img_bytes)
+
+    return etai.read(url_or_filepath)

--- a/fiftyone/utils/scale.py
+++ b/fiftyone/utils/scale.py
@@ -577,7 +577,8 @@ def _to_scale_video_playback_labels(frames, frame_size):
                     else:
                         key = (detection.label, detection.index)
 
-                    if key not in traj_uuids:
+                    uuid = traj_uuids.get(key, None)
+                    if uuid is None:
                         uuid = str(uuid4())
                         annotations[uuid] = _init_video_box(detection.label)
 

--- a/fiftyone/utils/scale.py
+++ b/fiftyone/utils/scale.py
@@ -558,7 +558,7 @@ def _to_scale_video_playback_labels(frames, frame_size):
 
                 for classification in classifications:
                     event_label = classification.label
-                    if label in in_progress_events:
+                    if event_label in in_progress_events:
                         start = in_progress_events[event_label][0]
                     else:
                         start = frame_number

--- a/fiftyone/utils/scale.py
+++ b/fiftyone/utils/scale.py
@@ -412,7 +412,7 @@ def export_to_scale(
                     video_labels_dir, sample.id + ".json"
                 )
                 etas.write_json(annotations, video_labels_path)
-                anno_dict = {"url": video_labels_path}
+                anno_dict = {"annotations": {"url": video_labels_path}}
 
             labels[sample.id] = {
                 "filepath": sample.filepath,
@@ -773,7 +773,7 @@ def _make_point(point, frame_size):
 
 def _parse_video_labels(task_labels, metadata):
     anno_dict = task_labels["response"]
-    annos = _download_or_load_json(anno_dict["url"])
+    annos = _download_or_load_json(anno_dict["annotations"]["url"])
 
     if isinstance(annos, list):
         task = task_labels.get("task", None)

--- a/tests/misc/labelbox_tests.py
+++ b/tests/misc/labelbox_tests.py
@@ -19,11 +19,9 @@ import fiftyone.utils.labelbox as foul
 @unittest.skip("Must be run manually")
 def test_labelbox_image():
     # Image dataset
-    _dataset = foz.load_zoo_dataset(
+    dataset = foz.load_zoo_dataset(
         "bdd100k", split="validation", shuffle=True, max_samples=10
     )
-    dataset = fo.Dataset()
-    dataset.add_samples(_dataset.take(10))
 
     _test_labelbox_image(dataset)
 

--- a/tests/misc/scale_tests.py
+++ b/tests/misc/scale_tests.py
@@ -1,0 +1,134 @@
+"""
+Tests for the :mod:`fiftyone.utils.scale` module.
+
+| Copyright 2017-2020, Voxel51, Inc.
+| `voxel51.com <https://voxel51.com/>`_
+|
+"""
+import unittest
+
+import fiftyone as fo
+import fiftyone.zoo as foz
+import fiftyone.utils.scale as fous
+
+
+@unittest.skip("Must be run manually")
+def test_scale_image():
+    # Image dataset
+    _dataset = foz.load_zoo_dataset(
+        "bdd100k", split="validation", shuffle=True, max_samples=10
+    )
+    dataset = fo.Dataset()
+    dataset.add_samples(_dataset.take(10))
+
+    _test_scale_image(dataset)
+
+
+@unittest.skip("Must be run manually")
+def test_scale_video_objects():
+    # Video dataset with objects
+    dataset = foz.load_zoo_dataset("quickstart-video", max_samples=10)
+
+    _test_scale_video(dataset)
+
+
+@unittest.skip("Must be run manually")
+def test_scale_video_events():
+    # Video dataset with events
+    dataset = fo.Dataset()
+
+    events = [
+        {"label": "sunny", "frames": [1, 10]},
+        {"label": "cloudy", "frames": [11, 20]},
+        {"label": "sunny", "frames": [21, 30]},
+    ]
+
+    sample = fo.Sample(filepath="/path/to/road.mp4")
+
+    for event in events:
+        label = event["label"]
+        frames = event["frames"]
+        for frame_number in range(frames[0], frames[1] + 1):
+            sample.frames[frame_number]["weather"] = fo.Classification(
+                label=label
+            )
+
+    dataset.add_sample(sample)
+
+    _test_scale_video(dataset)
+
+
+def _test_scale_image(dataset):
+    scale_export_path = "/tmp/scale-image-export.json"
+    scale_import_path = "/tmp/scale-image-import.json"
+    scale_id_field = "scale_id"
+
+    # Export labels in Scale format
+    fous.export_to_scale(
+        dataset, scale_export_path, label_prefix="",  # all fields
+    )
+
+    # Convert to Scale import format
+    id_map = fous.convert_scale_export_to_import(
+        scale_export_path, scale_import_path
+    )
+
+    for sample_id, task_id in id_map.items():
+        sample = dataset[sample_id]
+        sample[scale_id_field] = task_id
+        sample.save()
+
+    # Import labels from Scale
+    fous.import_from_scale(
+        dataset,
+        scale_import_path,
+        label_prefix="scale",
+        scale_id_field=scale_id_field,
+    )
+
+    # Verify that we have two copies of the same labels
+    session = fo.launch_app(dataset)
+    session.wait()
+
+
+def _test_scale_video(dataset):
+    scale_export_dir = "/tmp/scale-video-export"
+    scale_export_path = "/tmp/scale-video-export.json"
+    scale_import_path = "/tmp/scale-video-import.json"
+    scale_id_field = "scale_id"
+
+    # Export labels in Scale format
+    fous.export_to_scale(
+        dataset,
+        scale_export_path,
+        video_labels_dir=scale_export_dir,
+        video_playback=True,  # try both `True` and `False` here
+        frame_labels_prefix="",  # all frame fields
+    )
+
+    # Convert to Scale import format
+    id_map = fous.convert_scale_export_to_import(
+        scale_export_path, scale_import_path
+    )
+
+    for sample_id, task_id in id_map.items():
+        sample = dataset[sample_id]
+        sample[scale_id_field] = task_id
+        sample.save()
+
+    # Import labels from Scale
+    fous.import_from_scale(
+        dataset,
+        scale_import_path,
+        label_prefix="scale",
+        scale_id_field=scale_id_field,
+    )
+
+    # Verify that we have two copies of the same labels
+    session = fo.launch_app(dataset)
+    session.wait()
+
+
+if __name__ == "__main__":
+    fo.config.show_progress_bars = False
+    unittest.main(verbosity=2)

--- a/tests/misc/scale_tests.py
+++ b/tests/misc/scale_tests.py
@@ -101,18 +101,23 @@ def _test_scale_image(dataset):
 
 
 def _test_scale_video(dataset):
-    scale_export_dir = "/tmp/scale-video-export"
     scale_export_path = "/tmp/scale-video-export.json"
     scale_import_path = "/tmp/scale-video-import.json"
+
+    scale_video_labels_dir = "/tmp/scale-video-labels"
+    scale_video_events_dir = "/tmp/scale-video-events"
+
     scale_id_field = "scale_id"
 
-    etau.ensure_empty_dir(scale_export_dir, cleanup=True)
+    etau.ensure_empty_dir(scale_video_labels_dir, cleanup=True)
+    etau.ensure_empty_dir(scale_video_events_dir, cleanup=True)
 
     # Export labels in Scale format
     fous.export_to_scale(
         dataset,
         scale_export_path,
-        video_labels_dir=scale_export_dir,
+        video_labels_dir=scale_video_labels_dir,
+        video_events_dir=scale_video_events_dir,
         video_playback=True,  # try both `True` and `False` here
         frame_labels_prefix="",  # all frame fields
     )

--- a/tests/misc/scale_tests.py
+++ b/tests/misc/scale_tests.py
@@ -8,6 +8,7 @@ Tests for the :mod:`fiftyone.utils.scale` module.
 import unittest
 
 import eta.core.utils as etau
+import eta.core.web as etaw
 
 import fiftyone as fo
 import fiftyone.zoo as foz
@@ -36,6 +37,12 @@ def test_scale_video_objects():
 
 @unittest.skip("Must be run manually")
 def test_scale_video_events():
+    # Download a video to work with
+    filepath = "/tmp/road.mp4"
+    etaw.download_google_drive_file(
+        "1nWyKZyV6pG0hjY_gvBNShulsxLRlC6xg", path=filepath
+    )
+
     # Video dataset with events
     dataset = fo.Dataset()
 
@@ -45,7 +52,7 @@ def test_scale_video_events():
         {"label": "sunny", "frames": [21, 30]},
     ]
 
-    sample = fo.Sample(filepath="/path/to/road.mp4")
+    sample = fo.Sample(filepath=filepath)
 
     for event in events:
         label = event["label"]
@@ -99,7 +106,7 @@ def _test_scale_video(dataset):
     scale_import_path = "/tmp/scale-video-import.json"
     scale_id_field = "scale_id"
 
-    etau.ensure_empty_dir(scale_export_dir)
+    etau.ensure_empty_dir(scale_export_dir, cleanup=True)
 
     # Export labels in Scale format
     fous.export_to_scale(

--- a/tests/misc/scale_tests.py
+++ b/tests/misc/scale_tests.py
@@ -7,6 +7,8 @@ Tests for the :mod:`fiftyone.utils.scale` module.
 """
 import unittest
 
+import eta.core.utils as etau
+
 import fiftyone as fo
 import fiftyone.zoo as foz
 import fiftyone.utils.scale as fous
@@ -97,6 +99,8 @@ def _test_scale_video(dataset):
     scale_import_path = "/tmp/scale-video-import.json"
     scale_id_field = "scale_id"
 
+    etau.ensure_empty_dir(scale_export_dir)
+
     # Export labels in Scale format
     fous.export_to_scale(
         dataset,
@@ -130,5 +134,5 @@ def _test_scale_video(dataset):
 
 
 if __name__ == "__main__":
-    fo.config.show_progress_bars = False
+    fo.config.show_progress_bars = True
     unittest.main(verbosity=2)

--- a/tests/misc/scale_tests.py
+++ b/tests/misc/scale_tests.py
@@ -18,11 +18,9 @@ import fiftyone.utils.scale as fous
 @unittest.skip("Must be run manually")
 def test_scale_image():
     # Image dataset
-    _dataset = foz.load_zoo_dataset(
+    dataset = foz.load_zoo_dataset(
         "bdd100k", split="validation", shuffle=True, max_samples=10
     )
-    dataset = fo.Dataset()
-    dataset.add_samples(_dataset.take(10))
 
     _test_scale_image(dataset)
 


### PR DESCRIPTION
Adds support for importing labels in [Scale AI format](https://docs.scale.com/reference#general-image-annotation), as well as exporting labels in a format that can be uploaded as pre-annotations via Scale AI tasks' `hypothesis` parameter.

All of the following label types are supported:

Images
- [General image annotation](https://docs.scale.com/reference#general-image-annotation), including boxes, polylines, polygons, and keypoints
- [Semantic segmentation](https://docs.scale.com/reference#semantic-segmentation-annotation)

Videos
- [General video annotation](https://docs.scale.com/reference#general-video-annotation)
- [Video playback](https://docs.scale.com/reference#video-playback)

Here's an example of exporting BDD labels into Scale AI format and then importing them back into the same dataset using the API introduced in this PR:

See `tests/misc/scale_tests.py` for additional tests.

```py
import fiftyone as fo
import fiftyone.zoo as foz
import fiftyone.utils.scale as fous

SCALE_EXPORT_PATH = "/tmp/scale-image-export.json"
SCALE_IMPORT_PATH = "/tmp/scale-image-import.json"
SCALE_ID_FIELD = "scale_id"

_dataset = foz.load_zoo_dataset("bdd100k", split="validation", shuffle=True, max_samples=10)
dataset = fo.Dataset()
dataset.add_samples(_dataset.take(10))

# Export labels in Scale format
fous.export_to_scale(
    dataset,
    SCALE_EXPORT_PATH,
    label_prefix="",  # all fields
)

# Convert to Scale import format
id_map = fous.convert_scale_export_to_import(
    SCALE_EXPORT_PATH, SCALE_IMPORT_PATH
)

for sample_id, task_id in id_map.items():
    sample = dataset[sample_id]
    sample[SCALE_ID_FIELD] = task_id
    sample.save()

# Import labels from Scale
fous.import_from_scale(
    dataset,
    SCALE_IMPORT_PATH,
    label_prefix="scale",
    scale_id_field=SCALE_ID_FIELD,
)

# Verify that we have two copies of the same labels
session = fo.launch_app(dataset)
```

<img width="1374" alt="Screen Shot 2020-11-09 at 9 07 32 PM" src="https://user-images.githubusercontent.com/25985824/98618638-9fd45700-22cf-11eb-8159-cef3a4aa4c8a.png">
