### PR TITLE
Environments and FAQ Doc updates

### DIFF
--- a/docs/source/environments/index.rst
+++ b/docs/source/environments/index.rst
@@ -1,7 +1,5 @@
 FiftyOne Environments
 =====================
-.. _environments:
-
 .. default-role:: code
 
 This is a guide to using FiftyOne with data stored in various environments, for

--- a/docs/source/environments/index.rst
+++ b/docs/source/environments/index.rst
@@ -1,0 +1,362 @@
+FiftyOne Environments
+=====================
+.. _environments:
+
+.. default-role:: code
+
+This is a guide to using FiftyOne with data stored in various environments, for
+example, how to work with remote data.
+
+
+Terminology:
+
+* :ref:`Local Machine <local-data>` - Data is stored on the same machine on which FiftyOne
+  is installed
+
+* :ref:`Remote Machine <remote-data>` - Data is stored on a disk remotely
+
+* :ref:`Cloud <cloud-data>` - Data is stored in a cloud bucket like :ref:`AWS <AWS>`/:ref:`Azure <Azure>`/:ref:`GCS <google-cloud>`
+
+
+.. _local-data:
+
+Local Data
+__________
+
+When working with data that is stored on disk on the same machine that is
+running FiftyOne, the data can be loaded into the App directly.
+
+.. code-block:: python
+    :linenos:
+
+    import fiftyone as fo
+
+    dataset = fo.Dataset(name="my_dataset")
+
+    session = fo.launch_app(dataset)
+
+
+The FiftyOne App will then be launched with the |Dataset| loaded. The suggested workflow
+is to use the App in conjuction with an `ipython` session where you loaded
+your |Dataset|.
+
+
+.. _remote-data:
+
+Remote Data
+___________
+
+If you are accessing data that is stored on a remote machine that you have
+`ssh`
+access to, you can easily load up a FiftyOne dataset remotely and view it
+locally.
+
+
+First `ssh` into your remote machine.
+Then :doc:`create a Dataset in FiftyOne </user_guide/dataset_creation/index>` using Python on the remote machine and
+launch a remote session. 
+
+.. code-block:: python
+    :linenos:
+
+    # On remote machine
+
+    import fiftyone as fo
+
+    dataset = fo.Dataset(name="my_dataset")
+
+    session = fo.launch_app(dataset, remote=True) # (Optional) port=XXXX
+
+
+Leave this session running and go back to your local
+machine.
+On your local machine, you need to set up port forwarding via `ssh` and connect
+to the App. This can be done either through the CLI or Python.
+
+.. tabs::
+
+  .. group-tab:: CLI
+
+    On the local machine, you can :ref:`use the CLI <cli-fiftyone-app-connect>`
+    to automatically configure port forwarding and open the App.
+
+    In a local terminal, run the command:
+
+    .. code-block:: shell
+
+        # On local machine
+        fiftyone app connect --destination username@remote_machine_ip --port 5151
+
+  .. group-tab:: Python
+
+    Open two terminal windows on the local machine. In order to forward the
+    port `5151` from the remote machine to the local machine, run the following
+    command in one terminal and leave the process running:
+
+    .. code-block:: shell
+
+        # On local machine
+        ssh -N -L 5151:127.0.0.1:5151 username@remote_machine_ip
+
+    Port `5151` is now being forwarded from the remote machine to port
+    `5151` of the local machine.
+
+    In the other terminal, launch the FiftyOne App locally by starting Python
+    and running the following commands:
+
+    .. code-block:: python
+        :linenos:
+
+        # On local machine
+        import fiftyone.core.session as fos
+
+        fos.launch_app()
+
+
+The default port is `5151`, but if you entered an optional port, then
+use that port here.
+You will have to use a separate port in order to launch two remote sessions
+from the same machine
+
+.. _cloud-data:
+
+Cloud Data
+__________
+
+
+FiftyOne does not yet support accessing data directly in a cloud bucket, but
+there are best practices for mounting data stored in:
+
+* :ref:`AWS <AWS>`
+
+* :ref:`Azure <Azure>`
+
+* :ref:`Google Cloud <google-cloud>`
+
+
+
+
+.. _AWS:
+
+AWS
+---
+
+You can use FiftyOne if your data is stored in an AWS S3 bucket.
+For the best results, it is recommended to mount the container in an AWS VM
+instance
+and then access the data remotely from there. The steps to do so are outline
+below.
+
+Step 1
+^^^^^^
+
+`Start a Linux VM on AWS that you can ssh into.
+<https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EC2_GetStarted.html>`_
+
+
+Step 2
+^^^^^^
+
+`ssh into the VM and install FiftyOne.
+<https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/AccessingInstancesLinux.html>`_
+
+.. code-block:: bash
+    
+    pip install --index https://pypi.voxel51.com fiftyone
+
+
+Step 3
+^^^^^^
+
+Mount the S3 bucket in the VM.
+We recommend you use the open source project `s3fs-fuse
+<https://github.com/s3fs-fuse/s3fs-fuse>`_. You will need to make a
+`.passwd-s3fs` file including your AWS credentials as outlined in the `s3fs-fuse
+<https://github.com/s3fs-fuse/s3fs-fuse>`_ README.
+
+.. code-block:: bash
+
+    s3fs <bucket name> /path/to/mount/point -o passwd_file=.passwd-s3fs -o umask=0007,uid=<your user id>
+
+
+Step 4
+^^^^^^
+
+Now that you can access your data from within the VM, start up Python and
+:doc:`create a FiftyOne Dataset. </user_guide/dataset_creation/index>`
+
+Then start a remote FiftyOne session.
+
+.. code-block:: python
+
+    session = fo.launch_app(dataset, remote=True) # (optional) port=XXXX
+
+
+Step 5
+^^^^^^
+
+On your local machine, connect to the port on the VM and launch the local App.
+
+First open an `ssh` connection connecting to port `5151` (or any other port if you
+set an optional port in the previous step)
+
+.. code-block:: bash
+
+    ssh -N -L 5151:127.0.0.1:5151 -i <key>.pem <user>@<VM address>
+
+
+Then launch the App from python on your local machine.
+
+.. code-block:: python
+
+    import fiftyone as fo
+    fo.launch_app()
+
+
+
+
+.. _Azure:
+
+Azure
+-----
+
+You can use FiftyOne if your data is stored in an Azure storage container.
+For the best results, it is recommended to mount the container in an Azure VM
+and then access the data remotely from there. The steps to do so are outline
+below.
+
+Step 1
+^^^^^^
+
+`Start a Linux VM on Azure that you can ssh into. <https://docs.microsoft.com/en-us/azure/virtual-machines/linux/quick-create-portal>`_
+
+
+Step 2
+^^^^^^
+
+`ssh into the VM and install FiftyOne. <https://docs.microsoft.com/en-us/azure/virtual-machines/linux/quick-create-portal#connect-to-virtual-machine>`_
+
+.. code-block:: bash
+    
+    pip install --index https://pypi.voxel51.com fiftyone
+
+
+Step 3
+^^^^^^
+
+Mount the Azure storage container in the VM.
+
+This is fairly straight forward if your data is stored in a blob container. 
+In this case, we recommend you use the open source project `blobfuse <https://github.com/Azure/azure-storage-fuse>`_
+
+
+Step 4
+^^^^^^
+
+Now that you can access your data from within the VM, start up Python and
+:doc:`create a FiftyOne Dataset. </user_guide/dataset_creation/index>`
+
+Then start a remote FiftyOne session.
+
+.. code-block:: python
+
+    session = fo.launch_app(dataset, remote=True) # (optional) port=XXXX
+
+
+Step 5
+^^^^^^
+
+On your local machine, connect to the port on the VM and launch the local App.
+
+First open an `ssh` connection connecting to port `5151` (or any other port if you
+set an optional port in the previous step)
+
+.. code-block:: bash
+
+    ssh -N -L 5151:127.0.0.1:5151 -i <key>.pem <user>@<VM ip address>
+
+
+Then launch the App from python on your local machine.
+
+.. code-block:: python
+
+    import fiftyone as fo
+    fo.launch_app()
+
+
+.. _google-cloud:
+
+Google Cloud
+------------
+
+You can use FiftyOne if your data is stored in an Google Cloud storage bucket.
+For the best results, it is recommended to mount the container in a Google
+Cloud Platform VM
+and then access the data remotely from there. The steps to do so are outline
+below.
+
+Step 1
+^^^^^^
+
+`Start a Linux VM on Google Cloud that you can ssh into.
+<https://cloud.google.com/compute/docs/quickstart-linux>`_
+
+
+Step 2
+^^^^^^
+
+`ssh into the VM and install FiftyOne.
+<https://cloud.google.com/compute/docs/quickstart-linux#connect_to_your_instance>`_
+
+.. code-block:: bash
+    
+    pip install --index https://pypi.voxel51.com fiftyone
+
+
+Step 3
+^^^^^^
+
+Mount the Google Cloud storage bucket in the VM.
+In this case, we recommend you use the open source project `gcsfuse
+<https://github.com/GoogleCloudPlatform/gcsfuse>`_
+
+.. code-block:: bash
+
+    gcsfuse my-bucket /path/to/mount --implicit-dirs
+
+
+
+Step 4
+^^^^^^
+
+Now that you can access your data from within the VM, start up Python and
+:doc:`create a FiftyOne Dataset. </user_guide/dataset_creation/index>`
+
+Then start a remote FiftyOne session.
+
+.. code-block:: python
+
+    session = fo.launch_app(dataset, remote=True) # (optional) port=XXXX
+
+
+Step 5
+^^^^^^
+
+On your local machine, connect to the port on the VM and launch the local App.
+
+First open an `ssh` connection connecting to port `5151` (or any other port if you
+set an optional port in the previous step).
+You may need to `set up your ssh key.
+<https://cloud.google.com/compute/docs/instances/adding-removing-ssh-keys#project-wide>`_
+
+.. code-block:: bash
+
+    ssh -N -L 5151:127.0.0.1:5151 -i <key> <user>@<VM ip address>
+
+
+Then launch the App from Python on your local machine.
+
+.. code-block:: python
+
+    import fiftyone as fo
+    fo.launch_app()

--- a/docs/source/environments/index.rst
+++ b/docs/source/environments/index.rst
@@ -8,10 +8,10 @@ example, how to work with remote data.
 
 Terminology:
 
-* :ref:`Local Machine <local-data>` - Data is stored on the same machine on which FiftyOne
-  is installed
+* :ref:`Local Machine <local-data>` - Data is stored on the same personal computer or laptop with a GUI that will be used to launch the App
 
-* :ref:`Remote Machine <remote-data>` - Data is stored on a disk remotely
+* :ref:`Remote Machine <remote-data>` - Data is stored on disk on a machine
+  separate from the one that will be used to launch the App
 
 * :ref:`Cloud <cloud-data>` - Data is stored in a cloud bucket like :ref:`AWS <AWS>`/:ref:`Azure <Azure>`/:ref:`GCS <google-cloud>`
 
@@ -50,7 +50,7 @@ access to, you can easily load up a FiftyOne dataset remotely and view it
 locally.
 
 
-First `ssh` into your remote machine, and :doc:`install FiftyOne </getting_started/install.html>` if it is not already.
+First `ssh` into your remote machine, and :doc:`install FiftyOne </getting_started/install>` if it is not already.
 Then :doc:`create a Dataset in FiftyOne </user_guide/dataset_creation/index>` using Python on the remote machine and
 launch a remote session. 
 

--- a/docs/source/environments/index.rst
+++ b/docs/source/environments/index.rst
@@ -50,7 +50,7 @@ access to, you can easily load up a FiftyOne dataset remotely and view it
 locally.
 
 
-First `ssh` into your remote machine.
+First `ssh` into your remote machine, and :doc:`install FiftyOne </getting_started/install.html>` if it is not already.
 Then :doc:`create a Dataset in FiftyOne </user_guide/dataset_creation/index>` using Python on the remote machine and
 launch a remote session. 
 

--- a/docs/source/faq/index.rst
+++ b/docs/source/faq/index.rst
@@ -5,12 +5,12 @@ FiftyOne Frequently Asked Questions
 
 **Can I run this in a browser?**
 
-Browers are not yet supported, but see the :ref:`Environments <environments>` page for instructions for using
+Browers are not yet supported, but see the :doc:`Environments </environments/index>` page for instructions for using
 FiftyOne in common local, remote, and cloud environments.
 
 **Can I access data stored in the cloud or on a remote server like on AWS, Azure, or Google Cloud from my client application?**
 
-Yes! If you install FiftyOne on both your :ref:`remote server and your local machine <remote-data>`, then you can load a dataset remotely and :ref:`explore it with the App <creating-an-app-session>` locally. See the :ref:`Environments <environments>` section for details.
+Yes! If you install FiftyOne on both your :ref:`remote server and your local machine <remote-data>`, then you can load a dataset remotely and :ref:`explore it with the App <creating-an-app-session>` locally. See the :doc:`Environments </environments/index>` section for details.
 
 **What label types are supported?**
 

--- a/docs/source/faq/index.rst
+++ b/docs/source/faq/index.rst
@@ -1,0 +1,52 @@
+FiftyOne Frequently Asked Questions
+===================================
+
+.. default-role:: code
+
+**Can I run this in a browser?**
+
+Browers are not yet supported, but see the :ref:`Environments <environments>` page for instructions for using
+FiftyOne in common local, remote, and cloud environments.
+
+**Can I access data stored in the cloud or on a remote server like on AWS, Azure, or Google Cloud from my client application?**
+
+Yes! If you install FiftyOne on both your :ref:`remote server and your local machine <remote-data>`, then you can load a dataset remotely and :ref:`explore it with the App <creating-an-app-session>` locally. See the :ref:`Environments <environments>` section for details.
+
+**What label types are supported?**
+
+FiftyOne provides both image and video support for :ref:`classifications (including
+multi label classifications), object detections in multiple coordinate formats,
+semantic and instance segmentation, key points, and polylines.
+<manually-building-datasets>`
+
+**What image file types are supported?**
+
+Most standard image types like `JPEG`, `PNG`, and `BMP` are supported. In general,
+all `image types supported by Chromium
+<https://en.wikipedia.org/wiki/Comparison_of_browser_engines_(graphics_support)>`_ are supported by FiftyOne.
+
+**What video file types are supported?**
+
+Any video filetype that is supported by HTML5 video, like `.mp4`, is able to be
+viewed in the App. If you are
+having trouble viewing your video file, use the provided :func:`reencode_videos() <fiftyone.utils.video.reencode_videos>`
+untility to reencode the source video so it is viewable in the app.
+
+**What operating systems does FiftyOne support?**
+
+FiftyOne is guaranteed to support the latest versions of popular Linux Distributions, Windows and MacOS (ex. Ubuntu 18.04, Windows 10) along with :ref:`specific install instructions for older versions like Ubuntu 16.04 and Debian 9. <alternative-builds>`
+
+**Can you share a dataset with someone else?**
+
+You can easily :doc:`export a dataset </user_guide/export_datasets>` in one line of code, zip it, and send it to someone else who can then :doc:`load it in a few lines of code. </user_guide/dataset_creation/datasets>`
+
+Alternatively, you could launch a :ref:`remote session <remote-data>` of the FiftyOne App on your
+machine that
+another user can access using FiftyOne on their local machine.
+
+**Are the Brain methods open-source?**
+
+No, FiftyOne is open core. The :doc:`Brain methods </user_guide/brain>` exist in a separate repository that is
+installed along-side the core FiftyOne repository. However, the :doc:`documentation
+includes detailed instructions of how to use Brain methods. </user_guide/brain>`
+

--- a/docs/source/getting_started/troubleshooting.rst
+++ b/docs/source/getting_started/troubleshooting.rst
@@ -127,6 +127,9 @@ your distribution, you may encounter an error similar to:
 To resolve this, you can install an alternative package on some distributions,
 detailed below, or install a compatible version of MongoDB system-wide.
 
+
+.. _alternative-builds:
+
 Alternative builds
 ~~~~~~~~~~~~~~~~~~
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -216,9 +216,11 @@ or reach out to us at support@voxel51.com.
 
    Overview <self>
    Installation <getting_started/install>
+   Environments <environments/index>
    Tutorials <tutorials/index>
    Recipes <recipes/index>
    User Guide <user_guide/index>
    Release Notes <release-notes>
    CLI Documentation <cli/index>
    API Reference <api/fiftyone>
+   FAQ <faq/index>

--- a/docs/source/user_guide/app.rst
+++ b/docs/source/user_guide/app.rst
@@ -97,8 +97,8 @@ _______________
 
 If your data is stored on a remote machine, you can forward a session from
 the remote machine to the FiftyOne App on your local machine and seemlessly
-browse your remote dataset. This is defined in detail in the :ref:`Environments
-<environments>` section.
+browse your remote dataset. This is defined in detail in the :doc:`Environments
+</environments/index>` section.
 
 Remote machine
 --------------

--- a/docs/source/user_guide/app.rst
+++ b/docs/source/user_guide/app.rst
@@ -97,7 +97,8 @@ _______________
 
 If your data is stored on a remote machine, you can forward a session from
 the remote machine to the FiftyOne App on your local machine and seemlessly
-browse your remote dataset.
+browse your remote dataset. This is defined in detail in the :ref:`Environments
+<environments>` section.
 
 Remote machine
 --------------


### PR DESCRIPTION
Added top-level sections in the Docs for Environments and FAQ. The FAQ is fairly limited at the moment but is expected to grow as we get more questions. 

The environments doc currently goes through how to work with local, remote, or cloud data and goes into step-by-step detail of how to mount your cloud data in a cloud instance and use a FiftyOne remote sessions from there. Having tried out AWS, Azure, and GCP, the results worked surprisingly well. The data was loaded at least as fast as working on a remote server, and it felt like it was even a bit faster than when I used to use BB1 but I didn't benchmark it.