### PR TITLE
[WIP] Lazy start database service

### DIFF
--- a/fiftyone/__public__.py
+++ b/fiftyone/__public__.py
@@ -6,9 +6,7 @@ FiftyOne's public interface.
 |
 """
 import fiftyone.core.config as foc
-import fiftyone.core.service as fos
 
-_database_service = fos.DatabaseService()
 config = foc.load_config()
 
 from .core.aggregations import (

--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -52,6 +52,7 @@ def list_datasets():
         a list of :class:`Dataset` names
     """
     # pylint: disable=no-member
+    foo.start_db_service_if_necessary()
     return sorted(foo.DatasetDocument.objects.distinct("name"))
 
 
@@ -66,6 +67,7 @@ def dataset_exists(name):
     """
     try:
         # pylint: disable=no-member
+        foo.start_db_service_if_necessary()
         foo.DatasetDocument.objects.get(name=name)
         return True
     except DoesNotExist:
@@ -2174,6 +2176,7 @@ def _create_frame_document_cls(frame_collection_name):
 def _load_dataset(name):
     try:
         # pylint: disable=no-member
+        foo.start_db_service_if_necessary()
         dataset_doc = foo.DatasetDocument.objects.get(name=name)
     except DoesNotExist:
         raise DoesNotExistError("Dataset '%s' not found" % name)
@@ -2259,6 +2262,7 @@ def _load_dataset(name):
 def _drop_dataset(name, drop_persistent=True):
     try:
         # pylint: disable=no-member
+        foo.start_db_service_if_necessary()
         dataset_doc = foo.DatasetDocument.objects.get(name=name)
     except DoesNotExist:
         raise DoesNotExistError("Dataset '%s' not found" % name)

--- a/fiftyone/core/odm/__init__.py
+++ b/fiftyone/core/odm/__init__.py
@@ -5,7 +5,14 @@ ODM package declaration.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
-from .database import get_db_conn, get_async_db_conn, drop_database, ASC
+from .database import (
+    start_db_service_if_necessary,
+    get_db_conn,
+    get_async_db_conn,
+    drop_database,
+    ASC,
+    DESC,
+)
 from .dataset import SampleFieldDocument, DatasetDocument
 from .document import (
     Document,

--- a/fiftyone/core/odm/database.py
+++ b/fiftyone/core/odm/database.py
@@ -9,27 +9,40 @@ from mongoengine import connect
 import motor
 import pymongo
 
+import fiftyone.core.service as fos
+
 
 _DEFAULT_DATABASE = "fiftyone"
 _client = None
 _async_client = None
 _default_port = 27017
+_database_service = fos.DatabaseService(start=False)
 
 
 ASC = pymongo.ASCENDING
 DESC = pymongo.DESCENDING
 
 
+def start_db_service_if_necessary():
+    """Starts the database service, if necessary."""
+    if not _database_service.is_running:
+        _database_service.start()
+
+
 def _connect():
     global _client
+
     if _client is None:
+        start_db_service_if_necessary()
         connect(_DEFAULT_DATABASE, port=_default_port)
         _client = pymongo.MongoClient(port=_default_port)
 
 
 def _async_connect():
     global _async_client
+
     if _async_client is None:
+        start_db_service_if_necessary()
         _async_client = motor.motor_tornado.MotorClient(
             "localhost", _default_port
         )

--- a/fiftyone/core/odm/document.py
+++ b/fiftyone/core/odm/document.py
@@ -13,9 +13,9 @@ from bson import json_util, ObjectId
 import mongoengine
 import pymongo
 
-import fiftyone.core.utils as fou
-
 import eta.core.serial as etas
+
+import fiftyone.core.utils as fou
 
 
 class SerializableDocument(object):

--- a/fiftyone/core/service.py
+++ b/fiftyone/core/service.py
@@ -319,6 +319,7 @@ class DatabaseService(MultiClientService):
             # mongod may have exited - ok to wait until next time
             return
 
+        # @todo this fails...
         food.set_default_port(port)
         food.get_db_conn()
         fod.delete_non_persistent_datasets()


### PR DESCRIPTION
Only stars the database service when necessary. The main motivation here is to keep import time low so that simple non-DB CLI commands (for example) can run faster.

Marked as WIP until the following two items are addressed:
- Define a more robust interface for "things that require DB access". The current approach is probably doesn't cover all cases
- Resolve error that currently occurs when service `cleanup()` is called when exiting a process that established a DB connection