### PR TITLE
Adding support for customizing local port when connecting to App via CLI

### DIFF
--- a/docs/source/cli/index.rst
+++ b/docs/source/cli/index.rst
@@ -788,6 +788,7 @@ Connect to a remote FiftyOne App.
       -p PORT, --port PORT  the remote port to connect to
       -l PORT, --local-port PORT
                             the local port to use to serve the App
+      -i KEY, --ssh-key KEY an optional ssh key used to login 
 
 **Examples**
 
@@ -800,6 +801,11 @@ Connect to a remote FiftyOne App.
 
     # Connect to a remote App session
     fiftyone app connect --destination <destination> --port <port>
+
+.. code-block:: shell
+
+   # Connect to a remote App session using an ssh key
+   fiftyone app connect --destination <destination> --port <port> --ssh-key <path/to/key>
 
 .. code-block:: shell
 

--- a/docs/source/cli/index.rst
+++ b/docs/source/cli/index.rst
@@ -786,6 +786,8 @@ Connect to a remote FiftyOne App.
       -d DESTINATION, --destination DESTINATION
                             the destination to connect to, e.g., [username@]hostname
       -p PORT, --port PORT  the remote port to connect to
+      -l PORT, --local-port PORT
+                            the local port to use to serve the App
 
 **Examples**
 
@@ -798,6 +800,11 @@ Connect to a remote FiftyOne App.
 
     # Connect to a remote App session
     fiftyone app connect --destination <destination> --port <port>
+
+.. code-block:: shell
+
+    # Connect to a remote App using a custom local port
+    fiftyone app connect --local-port <port>
 
 .. _cli-fiftyone-zoo:
 

--- a/docs/source/cli/index.rst
+++ b/docs/source/cli/index.rst
@@ -97,7 +97,7 @@ Launch a FiftyOne quickstart.
       -h, --help            show this help message and exit
       -v, --video           launch the quickstart with a video dataset
       -p PORT, --port PORT  the port number to use
-      -r, --remote          whether to launch a remote app session
+      -r, --remote          whether to launch a remote App session
 
 **Examples**
 
@@ -717,7 +717,7 @@ View datasets in the FiftyOne App without persisting them to the database.
       --max-samples MAX_SAMPLES
                             a maximum number of samples to import. By default, all samples are imported
       -p PORT, --port PORT  the port number to use
-      -r, --remote          whether to launch a remote app session
+      -r, --remote          whether to launch a remote App session
 
 **Examples**
 
@@ -733,22 +733,22 @@ View datasets in the FiftyOne App without persisting them to the database.
 
 .. code-block:: shell
 
-    # View a directory of images in the app
+    # View a directory of images in the App
     fiftyone app view --images-dir <images-dir>
 
 .. code-block:: shell
 
-    # View a glob pattern of images in the app
+    # View a glob pattern of images in the App
     fiftyone app view --images-patt <images-patt>
 
 .. code-block:: shell
 
-    # View a directory of videos in the app
+    # View a directory of videos in the App
     fiftyone app view --videos-dir <videos-dir>
 
 .. code-block:: shell
 
-    # View a glob pattern of videos in the app
+    # View a glob pattern of videos in the App
     fiftyone app view --videos-patt <videos-patt>
 
 .. code-block:: shell
@@ -758,7 +758,7 @@ View datasets in the FiftyOne App without persisting them to the database.
 
 .. code-block:: shell
 
-    # View a random subset of the data stored on disk in the app
+    # View a random subset of the data stored on disk in the App
     fiftyone app view ... --shuffle --max-samples <max-samples>
 
 .. code-block:: shell

--- a/docs/source/environments/index.rst
+++ b/docs/source/environments/index.rst
@@ -78,63 +78,23 @@ machine and launch a remote session:
 Leave this session running, and note that instructions for connecting to this
 remote session were printed to your terminal (these are described below).
 
-On your local machine, you need to set up `ssh` port forwarding so that you can
-connect to the App. This can be done either through the CLI or Python.
+On the local machine, you can :ref:`use the CLI <cli-fiftyone-app-connect>`
+to automatically configure port forwarding and open the App.
 
-.. tabs::
+In a local terminal, run the command:
 
-  .. group-tab:: CLI
+.. code-block:: shell
 
-    On the local machine, you can :ref:`use the CLI <cli-fiftyone-app-connect>`
-    to automatically configure port forwarding and open the App.
+    # On local machine
+    fiftyone app connect --destination <user>@<remote-ip-address> --port 5151 # (Optional) --ssh-key /path/to/key
 
-    In a local terminal, run the command:
+.. note::
 
-    .. code-block:: shell
-
-        # On local machine
-        fiftyone app connect --destination <user>@<remote-ip-address> --port 5151
-
-    Alternatively, you can manually configure port forwarding:
-
-    .. code-block:: shell
-
-        # On local machine
-        ssh -N -L 5151:127.0.0.1:5151 <user>@<remote-ip-address>
-
-    and then connect to the App via:
-
-    .. code-block:: shell
-
-        # On local machine
-        fiftyone app connect
-
-  .. group-tab:: Python
-
-    Open two terminal windows on the local machine.
-
-    In order to forward the port `5151` from the remote machine to the local
-    machine, run the following command in one terminal and leave the process
-    running:
-
-    .. code-block:: shell
-
-        # On local machine
-        ssh -N -L 5151:127.0.0.1:5151 <user>@<remote-ip-address>
-
-    Port `5151` is now being forwarded from the remote machine to port
-    `5151` of the local machine.
-
-    In the other terminal, launch the FiftyOne App locally by starting Python
-    and running the following commands:
-
-    .. code-block:: python
-        :linenos:
-
-        # On local machine
-        import fiftyone.core.session as fos
-
-        fos.launch_app()
+    If you are using :ref:`ssh keys instead of a password to login <cli-fiftyone-app-connect>` then you
+    can use the kwarg `--ssh-key`. Though if you are using this key
+    more often, `it is recommended to add it
+    <https://unix.stackexchange.com/a/494485>`_ to your `~/.ssh/config` as
+    the default `IdentityFile`.
 
 The above instructions assume that you used the default port `5151` when
 launching the remote session on the remote machine. If you used a custom port,
@@ -227,21 +187,23 @@ the mount point you specified above. Then launch the App as a
 Finally, on your local machine, connect to the remote session that you started
 on the cloud instance.
 
-To do so, first open an `ssh` connection connecting to port `5151` (or the
-custom port you chose in the previous step):
-
-.. code-block:: shell
+.. code-block:: bash
 
     # On local machine
-    ssh -N -L 5151:127.0.0.1:5151 -i <key>.pem <user>@<ec2-instance-ip-address>
+    fiftyone app connect --destination <user>@<remote-ip-address> --port 5151 # (Optional) --ssh-key /path/to/key
 
-Then launch an App instance connected to the remote session via the FiftyOne
-CLI:
+The above instructions assume that you used the default port `5151` when
+launching the remote session on the remote machine. If you used a custom port,
+then substitute the appropriate value in the local commands too.
 
-.. code-block:: shell
+.. note::
 
-    # On local machine
-    fiftyone app connect
+    If you are using :ref:`ssh keys instead of a password to login <cli-fiftyone-app-connect>` then you
+    can use the kwarg `--ssh-key`. Though if you are using this key
+    more often, `it is recommended to add it
+    <https://unix.stackexchange.com/a/494485>`_ to your `~/.ssh/config` as
+    the default `IdentityFile`.
+
 
 .. _google-cloud:
 
@@ -308,25 +270,22 @@ the mount point you specified above. Then launch the App as a
 Finally, on your local machine, connect to the remote session that you started
 on the cloud instance.
 
-To do so, first open an `ssh` connection connecting to port `5151` (or the
-custom port you chose in the previous step):
-
-.. code-block:: shell
+.. code-block:: bash
 
     # On local machine
-    ssh -N -L 5151:127.0.0.1:5151 -i <key> <user>@<gc-instance-ip-address>
+    fiftyone app connect --destination <user>@<remote-ip-address> --port 5151 # (Optional) --ssh-key /path/to/key
 
-You may need to
-`set up your ssh key <https://cloud.google.com/compute/docs/instances/adding-removing-ssh-keys#project-wide>`_
-in order to run the above command.
+The above instructions assume that you used the default port `5151` when
+launching the remote session on the remote machine. If you used a custom port,
+then substitute the appropriate value in the local commands too.
 
-Then launch an App instance connected to the remote session via the FiftyOne
-CLI:
+.. note::
 
-.. code-block:: shell
-
-    # On local machine
-    fiftyone app connect
+    If you are using :ref:`ssh keys instead of a password to login <cli-fiftyone-app-connect>` then you
+    can use the kwarg `--ssh-key`. Though if you are using this key
+    more often, `it is recommended to add it
+    <https://unix.stackexchange.com/a/494485>`_ to your `~/.ssh/config` as
+    the default `IdentityFile`.
 
 .. _azure:
 
@@ -389,21 +348,22 @@ the mount point you specified above. Then launch the App as a
 Finally, on your local machine, connect to the remote session that you started
 on the cloud instance.
 
-To do so, first open an `ssh` connection connecting to port `5151` (or the
-custom port you chose in the previous step):
-
-.. code-block:: shell
+.. code-block:: bash
 
     # On local machine
-    ssh -N -L 5151:127.0.0.1:5151 -i <key>.pem <user>@<azure-instance-ip-address>
+    fiftyone app connect --destination <user>@<remote-ip-address> --port 5151 # (Optional) --ssh-key /path/to/key
 
-Then launch an App instance connected to the remote session via the FiftyOne
-CLI:
+The above instructions assume that you used the default port `5151` when
+launching the remote session on the remote machine. If you used a custom port,
+then substitute the appropriate value in the local commands too.
 
-.. code-block:: shell
+.. note::
 
-    # On local machine
-    fiftyone app connect
+    If you are using :ref:`ssh keys instead of a password to login <cli-fiftyone-app-connect>` then you
+    can use the kwarg `--ssh-key`. Though if you are using this key
+    more often, `it is recommended to add it
+    <https://unix.stackexchange.com/a/494485>`_ to your `~/.ssh/config` as
+    the default `IdentityFile`.
 
 .. _compute-instance-setup:
 
@@ -450,3 +410,4 @@ successfully :ref:`install FiftyOne <installing-fiftyone>`.
     # Python packages
     pip install --upgrade pip setuptools wheel
     pip install ipython
+

--- a/docs/source/user_guide/app.rst
+++ b/docs/source/user_guide/app.rst
@@ -141,7 +141,7 @@ your local machine via `ssh` and connect to the App via Python.
     .. code-block:: shell
 
         # On local machine
-        fiftyone app connect --destination username@remote_machine_ip --port 5151
+        fiftyone app connect --destination username@remote_machine_ip --port 5151 # Optional --ssh-key /path/to/key
 
   .. group-tab:: Python
 

--- a/fiftyone/core/cli.py
+++ b/fiftyone/core/cli.py
@@ -1015,6 +1015,9 @@ class AppConnectCommand(Command):
 
         # Connect to a remote App session
         fiftyone app connect --destination <destination> --port <port>
+
+        # Connect to a remote App using a custom local port
+        fiftyone app connect --local-port <port>
     """
 
     @staticmethod
@@ -1033,6 +1036,14 @@ class AppConnectCommand(Command):
             default=5151,
             type=int,
             help="the remote port to connect to",
+        )
+        parser.add_argument(
+            "-l",
+            "--local-port",
+            metavar="PORT",
+            default=5151,
+            type=int,
+            help="the local port to use to serve the App",
         )
 
     @staticmethod
@@ -1082,7 +1093,7 @@ class AppConnectCommand(Command):
 
             fou.call_on_exit(stop_port_forward)
 
-        session = fos.launch_app()
+        session = fos.launch_app(port=args.local_port)
 
         _watch_session(session)
 

--- a/fiftyone/core/cli.py
+++ b/fiftyone/core/cli.py
@@ -1069,7 +1069,7 @@ class AppConnectCommand(Command):
                     "-S",
                     control_path,
                     "-L",
-                    "5151:127.0.0.1:%d" % args.port,
+                    "%d:127.0.0.1:%d" % (args.local_port, args.port),
                     args.destination,
                 ]
             )

--- a/fiftyone/core/cli.py
+++ b/fiftyone/core/cli.py
@@ -116,7 +116,7 @@ class QuickstartCommand(Command):
             "-r",
             "--remote",
             action="store_true",
-            help="whether to launch a remote app session",
+            help="whether to launch a remote App session",
         )
 
     @staticmethod
@@ -770,10 +770,10 @@ class AppLaunchCommand(Command):
 
     Examples::
 
-        # Launch the app with the given dataset
+        # Launch the App with the given dataset
         fiftyone app launch <name>
 
-        # Launch a remote app session
+        # Launch a remote App session
         fiftyone app launch <name> --remote
     """
 
@@ -794,7 +794,7 @@ class AppLaunchCommand(Command):
             "-r",
             "--remote",
             action="store_true",
-            help="whether to launch a remote app session",
+            help="whether to launch a remote App session",
         )
 
     @staticmethod
@@ -812,7 +812,7 @@ def _watch_session(session, remote=False):
         if remote:
             print("\nTo exit, press ctrl + c\n")
         else:
-            print("\nTo exit, close the app or press ctrl + c\n")
+            print("\nTo exit, close the App or press ctrl + c\n")
         session.wait()
     except KeyboardInterrupt:
         pass
@@ -823,31 +823,31 @@ class AppViewCommand(Command):
 
     Examples::
 
-        # View a dataset stored on disk in the app
+        # View a dataset stored on disk in the App
         fiftyone app view --dataset-dir <dataset-dir> --type <type>
 
-        # View a zoo dataset in the app
+        # View a zoo dataset in the App
         fiftyone app view --zoo-dataset <name> --splits <split1> ...
 
-        # View a directory of images in the app
+        # View a directory of images in the App
         fiftyone app view --images-dir <images-dir>
 
-        # View a glob pattern of images in the app
+        # View a glob pattern of images in the App
         fiftyone app view --images-patt <images-patt>
 
-        # View a directory of videos in the app
+        # View a directory of videos in the App
         fiftyone app view --videos-dir <videos-dir>
 
-        # View a glob pattern of videos in the app
+        # View a glob pattern of videos in the App
         fiftyone app view --videos-patt <videos-patt>
 
-        # View a dataset stored in JSON format on disk in the app
+        # View a dataset stored in JSON format on disk in the App
         fiftyone app view --json-path <json-path>
 
-        # View a random subset of the data stored on disk in the app
+        # View a random subset of the data stored on disk in the App
         fiftyone app view ... --shuffle --max-samples <max-samples>
 
-        # View the dataset in a remote app session
+        # View the dataset in a remote App session
         fiftyone app view ... --remote
     """
 
@@ -942,7 +942,7 @@ class AppViewCommand(Command):
             "-r",
             "--remote",
             action="store_true",
-            help="whether to launch a remote app session",
+            help="whether to launch a remote App session",
         )
 
     @staticmethod
@@ -1010,10 +1010,10 @@ class AppConnectCommand(Command):
 
     Examples::
 
-        # Connect to a remote app with port forwarding already configured
+        # Connect to a remote App with port forwarding already configured
         fiftyone app connect
 
-        # Connect to a remote app session
+        # Connect to a remote App session
         fiftyone app connect --destination <destination> --port <port>
     """
 


### PR DESCRIPTION
Previously when using `fiftyone app connect`, the _local port_ used was hard-coded to 5151, which prevented a user from launching two separate App instances using `fiftyone app connect` on the same machine.

Below is an example of connecting to two different remote App sessions from the same machine via pure CLI commands:

**On remote machine**

```shell
# Remote shell #1
fiftyone app launch <dataset1> --remote --port 1111
```

```shell
# Remote shell #2
fiftyone app launch <dataset2> --remote --port 2222
```

**On local machine**

```shell
# Local shell #1
fiftyone app connect --destination <destination> --port 1111 --local-port 3333
```

```shell
# Local shell #2
fiftyone app connect --destination <destination> --port 2222 --local-port 4444
```
