### PR TITLE
Add ssh-key kwarg to CLI app connect

### DIFF
--- a/docs/source/cli/index.rst
+++ b/docs/source/cli/index.rst
@@ -788,6 +788,7 @@ Connect to a remote FiftyOne App.
       -p PORT, --port PORT  the remote port to connect to
       -l PORT, --local-port PORT
                             the local port to use to serve the App
+      -i KEY, --ssh-key KEY an optional ssh key used to login 
 
 **Examples**
 
@@ -800,6 +801,11 @@ Connect to a remote FiftyOne App.
 
     # Connect to a remote App session
     fiftyone app connect --destination <destination> --port <port>
+
+.. code-block:: shell
+
+   # Connect to a remote App session using an ssh key
+   fiftyone app connect --destination <destination> --port <port> --ssh-key <path/to/key>
 
 .. code-block:: shell
 

--- a/docs/source/environments/index.rst
+++ b/docs/source/environments/index.rst
@@ -78,63 +78,23 @@ machine and launch a remote session:
 Leave this session running, and note that instructions for connecting to this
 remote session were printed to your terminal (these are described below).
 
-On your local machine, you need to set up `ssh` port forwarding so that you can
-connect to the App. This can be done either through the CLI or Python.
+On the local machine, you can :ref:`use the CLI <cli-fiftyone-app-connect>`
+to automatically configure port forwarding and open the App.
 
-.. tabs::
+In a local terminal, run the command:
 
-  .. group-tab:: CLI
+.. code-block:: shell
 
-    On the local machine, you can :ref:`use the CLI <cli-fiftyone-app-connect>`
-    to automatically configure port forwarding and open the App.
+    # On local machine
+    fiftyone app connect --destination <user>@<remote-ip-address> --port 5151 # (Optional) --ssh-key /path/to/key
 
-    In a local terminal, run the command:
+.. note::
 
-    .. code-block:: shell
-
-        # On local machine
-        fiftyone app connect --destination <user>@<remote-ip-address> --port 5151
-
-    Alternatively, you can manually configure port forwarding:
-
-    .. code-block:: shell
-
-        # On local machine
-        ssh -N -L 5151:127.0.0.1:5151 <user>@<remote-ip-address>
-
-    and then connect to the App via:
-
-    .. code-block:: shell
-
-        # On local machine
-        fiftyone app connect
-
-  .. group-tab:: Python
-
-    Open two terminal windows on the local machine.
-
-    In order to forward the port `5151` from the remote machine to the local
-    machine, run the following command in one terminal and leave the process
-    running:
-
-    .. code-block:: shell
-
-        # On local machine
-        ssh -N -L 5151:127.0.0.1:5151 <user>@<remote-ip-address>
-
-    Port `5151` is now being forwarded from the remote machine to port
-    `5151` of the local machine.
-
-    In the other terminal, launch the FiftyOne App locally by starting Python
-    and running the following commands:
-
-    .. code-block:: python
-        :linenos:
-
-        # On local machine
-        import fiftyone.core.session as fos
-
-        fos.launch_app()
+    If you are using :ref:`ssh keys instead of a password to login <cli-fiftyone-app-connect>` then you
+    can use the kwarg `--ssh-key`. Though if you are using this key
+    more often, `it is recommended to add it
+    <https://unix.stackexchange.com/a/494485>`_ to your `~/.ssh/config` as
+    the default `IdentityFile`.
 
 The above instructions assume that you used the default port `5151` when
 launching the remote session on the remote machine. If you used a custom port,
@@ -227,21 +187,23 @@ the mount point you specified above. Then launch the App as a
 Finally, on your local machine, connect to the remote session that you started
 on the cloud instance.
 
-To do so, first open an `ssh` connection connecting to port `5151` (or the
-custom port you chose in the previous step):
-
-.. code-block:: shell
+.. code-block:: bash
 
     # On local machine
-    ssh -N -L 5151:127.0.0.1:5151 -i <key>.pem <user>@<ec2-instance-ip-address>
+    fiftyone app connect --destination <user>@<remote-ip-address> --port 5151 # (Optional) --ssh-key /path/to/key
 
-Then launch an App instance connected to the remote session via the FiftyOne
-CLI:
+The above instructions assume that you used the default port `5151` when
+launching the remote session on the remote machine. If you used a custom port,
+then substitute the appropriate value in the local commands too.
 
-.. code-block:: shell
+.. note::
 
-    # On local machine
-    fiftyone app connect
+    If you are using :ref:`ssh keys instead of a password to login <cli-fiftyone-app-connect>` then you
+    can use the kwarg `--ssh-key`. Though if you are using this key
+    more often, `it is recommended to add it
+    <https://unix.stackexchange.com/a/494485>`_ to your `~/.ssh/config` as
+    the default `IdentityFile`.
+
 
 .. _google-cloud:
 
@@ -308,25 +270,22 @@ the mount point you specified above. Then launch the App as a
 Finally, on your local machine, connect to the remote session that you started
 on the cloud instance.
 
-To do so, first open an `ssh` connection connecting to port `5151` (or the
-custom port you chose in the previous step):
-
-.. code-block:: shell
+.. code-block:: bash
 
     # On local machine
-    ssh -N -L 5151:127.0.0.1:5151 -i <key> <user>@<gc-instance-ip-address>
+    fiftyone app connect --destination <user>@<remote-ip-address> --port 5151 # (Optional) --ssh-key /path/to/key
 
-You may need to
-`set up your ssh key <https://cloud.google.com/compute/docs/instances/adding-removing-ssh-keys#project-wide>`_
-in order to run the above command.
+The above instructions assume that you used the default port `5151` when
+launching the remote session on the remote machine. If you used a custom port,
+then substitute the appropriate value in the local commands too.
 
-Then launch an App instance connected to the remote session via the FiftyOne
-CLI:
+.. note::
 
-.. code-block:: shell
-
-    # On local machine
-    fiftyone app connect
+    If you are using :ref:`ssh keys instead of a password to login <cli-fiftyone-app-connect>` then you
+    can use the kwarg `--ssh-key`. Though if you are using this key
+    more often, `it is recommended to add it
+    <https://unix.stackexchange.com/a/494485>`_ to your `~/.ssh/config` as
+    the default `IdentityFile`.
 
 .. _azure:
 
@@ -389,21 +348,22 @@ the mount point you specified above. Then launch the App as a
 Finally, on your local machine, connect to the remote session that you started
 on the cloud instance.
 
-To do so, first open an `ssh` connection connecting to port `5151` (or the
-custom port you chose in the previous step):
-
-.. code-block:: shell
+.. code-block:: bash
 
     # On local machine
-    ssh -N -L 5151:127.0.0.1:5151 -i <key>.pem <user>@<azure-instance-ip-address>
+    fiftyone app connect --destination <user>@<remote-ip-address> --port 5151 # (Optional) --ssh-key /path/to/key
 
-Then launch an App instance connected to the remote session via the FiftyOne
-CLI:
+The above instructions assume that you used the default port `5151` when
+launching the remote session on the remote machine. If you used a custom port,
+then substitute the appropriate value in the local commands too.
 
-.. code-block:: shell
+.. note::
 
-    # On local machine
-    fiftyone app connect
+    If you are using :ref:`ssh keys instead of a password to login <cli-fiftyone-app-connect>` then you
+    can use the kwarg `--ssh-key`. Though if you are using this key
+    more often, `it is recommended to add it
+    <https://unix.stackexchange.com/a/494485>`_ to your `~/.ssh/config` as
+    the default `IdentityFile`.
 
 .. _compute-instance-setup:
 
@@ -450,3 +410,4 @@ successfully :ref:`install FiftyOne <installing-fiftyone>`.
     # Python packages
     pip install --upgrade pip setuptools wheel
     pip install ipython
+

--- a/docs/source/user_guide/app.rst
+++ b/docs/source/user_guide/app.rst
@@ -141,7 +141,7 @@ your local machine via `ssh` and connect to the App via Python.
     .. code-block:: shell
 
         # On local machine
-        fiftyone app connect --destination username@remote_machine_ip --port 5151
+        fiftyone app connect --destination username@remote_machine_ip --port 5151 # Optional --ssh-key /path/to/key
 
   .. group-tab:: Python
 

--- a/fiftyone/core/cli.py
+++ b/fiftyone/core/cli.py
@@ -1050,8 +1050,9 @@ class AppConnectCommand(Command):
             help="the local port to use to serve the App",
         )
         parser.add_argument(
-            "-k",
+            "-i",
             "--ssh-key",
+            metavar="KEY",
             default=None,
             type=str,
             help="optional ssh key to use to login",

--- a/fiftyone/core/cli.py
+++ b/fiftyone/core/cli.py
@@ -1016,6 +1016,10 @@ class AppConnectCommand(Command):
         # Connect to a remote App session
         fiftyone app connect --destination <destination> --port <port>
 
+        # Connect to a remote App session using an ssh key
+        fiftyone app connect --destination <destination> --port <port> \\
+            --ssh-key <path/to/key>
+
         # Connect to a remote App using a custom local port
         fiftyone app connect --local-port <port>
     """

--- a/fiftyone/core/cli.py
+++ b/fiftyone/core/cli.py
@@ -1045,6 +1045,13 @@ class AppConnectCommand(Command):
             type=int,
             help="the local port to use to serve the App",
         )
+        parser.add_argument(
+            "-k",
+            "--ssh-key",
+            default=None,
+            type=str,
+            help="optional ssh key to use to login",
+        )
 
     @staticmethod
     def execute(parser, args):
@@ -1059,20 +1066,24 @@ class AppConnectCommand(Command):
             )
             etau.ensure_basedir(control_path)
 
+            ssh_call = [
+                "ssh",
+                "-f",
+                "-N",
+                "-M",
+                "-S",
+                control_path,
+                "-L",
+                "%d:127.0.0.1:%d" % (args.local_port, args.port),
+            ]
+
+            if args.ssh_key:
+                ssh_call += ["-i", args.ssh_key]
+
+            ssh_call.append(args.destination)
+
             # Port forwarding
-            ret = subprocess.call(
-                [
-                    "ssh",
-                    "-f",
-                    "-N",
-                    "-M",
-                    "-S",
-                    control_path,
-                    "-L",
-                    "%d:127.0.0.1:%d" % (args.local_port, args.port),
-                    args.destination,
-                ]
-            )
+            ret = subprocess.call(ssh_call)
             if ret != 0:
                 print("ssh failed with exit code %r" % ret)
                 return


### PR DESCRIPTION
Be able to call use the CLI to connect to a remote app instead of having to manually open the ssh connection if you need to use an ssh key instead of password login.
```
fiftyone app connect --destination <destination> --ssh-key </path/to/key>
```
Also updated environment, CLI, and remote session docs with this and best practices of adding the `IdentityFile` to your `ssh_config` if it is used often.