### PR TITLE
Dataset dropdown

### DIFF
--- a/electron/app/components/Distributions.tsx
+++ b/electron/app/components/Distributions.tsx
@@ -129,6 +129,7 @@ const Distributions = ({ group }) => {
 
   useEffect(() => {
     setData([]);
+    setLoading(true);
   }, [JSON.stringify(view), datasetName, refresh]);
 
   if (loading) {

--- a/electron/app/components/Distributions.tsx
+++ b/electron/app/components/Distributions.tsx
@@ -9,6 +9,7 @@ import { scrollbarStyles } from "./utils";
 import Loading from "./Loading";
 import { isFloat } from "../utils/generic";
 import { useMessageHandler, useSendMessage } from "../utils/hooks";
+import * as atoms from "../recoil/atoms";
 import * as selectors from "../recoil/selectors";
 
 const Container = styled.div`
@@ -116,6 +117,7 @@ const Distributions = ({ group }) => {
   const view = useRecoilValue(selectors.view);
   const datasetName = useRecoilValue(selectors.datasetName);
   const [loading, setLoading] = useState(true);
+  const refresh = useRecoilValue(atoms.refresh);
   const [data, setData] = useState([]);
 
   useSendMessage("distributions", { group }, null, [view, datasetName]);
@@ -127,7 +129,7 @@ const Distributions = ({ group }) => {
 
   useEffect(() => {
     setData([]);
-  }, [JSON.stringify(view), datasetName]);
+  }, [JSON.stringify(view), datasetName, refresh]);
 
   if (loading) {
     return <Loading />;

--- a/electron/app/components/Header.tsx
+++ b/electron/app/components/Header.tsx
@@ -60,12 +60,14 @@ const TitleDiv = styled.div`
   margin-right: 1rem;
   cursor: pointer;
   height: 40px;
+  display: flex;
 `;
 
 const LogoImg = animated(styled.img`
   height: 100%;
   width: auto;
   cursor: pointer;
+  margin-right: 1rem;
 `);
 
 const LeftDiv = styled.div`
@@ -76,6 +78,14 @@ const LeftDiv = styled.div`
 const RightDiv = styled.div`
   margin-left: auto;
   padding-right: 0.5rem;
+`;
+
+const FiftyOneDiv = styled.div`
+  color: ${(theme) => theme.font};
+  font-weight: bold;
+  font-size: 1.8rem;
+  align-items: center;
+  display: flex;
 `;
 
 const DatasetDiv = styled.div`
@@ -385,6 +395,7 @@ const Header = () => {
           }}
         >
           <LogoImg style={logoProps} src={logo} />
+          <FiftyOneDiv>FiftyOne</FiftyOneDiv>
         </TitleDiv>
         <DatasetSelector />
       </LeftDiv>

--- a/electron/app/components/Header.tsx
+++ b/electron/app/components/Header.tsx
@@ -196,8 +196,8 @@ const selectorMachine = Machine({
               if (currentResult === null) return results[0];
               return results[Math.min(currentResult + 1, results.length - 1)];
             },
+            bestMatch: {},
           }),
-          bestMatch: {},
         },
         PREVIOUS_RESULT: {
           actions: assign({
@@ -210,15 +210,14 @@ const selectorMachine = Machine({
                 return prevValue;
               return results[currentResult - 1];
             },
+            bestMatch: {},
           }),
-          bestMatch: {},
         },
         BLUR: {
           target: "reading",
           actions: [
             assign({
-              value: ({ value, prevValue, values }) =>
-                values.indexOf(value) > 0 ? value : prevValue,
+              value: ({ value, prevValue, values }) => prevValue,
             }),
           ],
         },
@@ -254,7 +253,6 @@ const selectorMachine = Machine({
             assign({
               value: (_, { value }) => value,
               results: ({ values }) => values,
-              prevValue: ({ value }) => value,
               errorId: null,
               currentResult: ({ values }, { value }) => {
                 const i = values.indexOf(value);
@@ -313,7 +311,10 @@ const DatasetSelector = React.memo(() => {
     <DatasetDiv>
       <DatasetContainerInput>
         <DatasetInput
-          placeholder={"Select a dataset"}
+          placeholder={
+            datasets.length > 0 ? "Select a dataset" : "No datasets available"
+          }
+          disabled={!datasets.length}
           value={value}
           onFocus={() => state.matches("reading") && send("EDIT")}
           onBlur={(e) => {

--- a/electron/app/components/Header.tsx
+++ b/electron/app/components/Header.tsx
@@ -1,12 +1,49 @@
-import React from "react";
+import React, { useEffect, useRef } from "react";
 import styled from "styled-components";
 import { useRecoilValue } from "recoil";
+import AuosizeInput from "react-input-autosize";
+import { Machine, assign } from "xstate";
+import { useMachine } from "@xstate/react";
+import uuid from "uuid-v4";
+import { BestMatchDiv } from "./ViewBar/ViewStage/BestMatch";
+import ErrorMessage from "./ViewBar/ViewStage/ErrorMessage";
+import { getMatch, computeBestMatchString } from "./ViewBar/ViewStage/utils";
+import { packageMessage } from "../utils/socket";
 
 import ExternalLink from "./ExternalLink";
 import * as selectors from "../recoil/selectors";
 import logo from "../logo.png";
 import { GitHub, MenuBook } from "@material-ui/icons";
 import { Slack } from "../icons";
+import SearchResults from "./ViewBar/ViewStage/SearchResults";
+
+const DatasetContainerInput = styled.div`
+  font-size: 1.2rem;
+  border-bottom: 1px ${({ theme }) => theme.brand} solid;
+`;
+
+const DatasetInput = styled(AuosizeInput)`
+  & input {
+    background-color: transparent;
+    border: none;
+    color: ${({ theme }) => theme.font};
+    line-height: 40px;
+    font-size: 1.2rem;
+    border: none;
+    font-weight: bold;
+  }
+
+  & input:focus {
+    border: none;
+    outline: none;
+    font-weight: bold;
+  }
+
+  & ::placeholder {
+    color: ${({ theme }) => theme.font};
+    font-weight: bold;
+  }
+`;
 
 const HeaderDiv = styled.div`
   background-color: ${({ theme }) => theme.backgroundDark};
@@ -16,23 +53,23 @@ const HeaderDiv = styled.div`
   border-bottom: 1px ${({ theme }) => theme.backgroundDarkBorder} solid;
 `;
 
-const LogoDiv = styled.div`
+const TitleDiv = styled.div`
+  margin-right: 1rem;
+  cursor: pointer;
   height: 40px;
-  margin: 1rem;
+  display: flex;
 `;
 
 const LogoImg = styled.img`
   height: 100%;
   width: auto;
-  margin-top: 2px;
-  padding: 0.25rem 1rem 0.25rem 0;
-  border-right-width: 1px;
-  border-color: ${({ theme }) => theme.backgroundDarkBorder};
-  border-right-style: solid;
+  cursor: pointer;
+  margin-right: 1rem;
 `;
 
 const LeftDiv = styled.div`
   display: flex;
+  padding: 1rem;
 `;
 
 const RightDiv = styled.div`
@@ -40,20 +77,20 @@ const RightDiv = styled.div`
   padding-right: 0.5rem;
 `;
 
-const TitleDiv = styled.div`
-  padding: 0.5rem 0;
-`;
-
 const FiftyOneDiv = styled.div`
   color: ${(theme) => theme.font};
   font-weight: bold;
-  font-size: 1.5rem;
-  line-height: 1.5;
+  font-size: 1.8rem;
+  align-items: center;
+  display: flex;
 `;
 
 const DatasetDiv = styled.div`
-  line-height: 1;
   font-weight: bold;
+  padding-left: 1rem;
+  border-left-width: 1px;
+  border-color: ${({ theme }) => theme.backgroundDarkBorder};
+  border-left-style: solid;
 `;
 
 const IconWrapper = styled.div`
@@ -75,21 +112,269 @@ const IconWrapper = styled.div`
   }
 `;
 
-const Header = () => {
-  const datasetNameValue = useRecoilValue(selectors.datasetName);
+const selectorMachine = Machine({
+  id: "selectorMachine",
+  initial: "reading",
+  context: {
+    error: undefined,
+    values: [],
+    value: "",
+    selected: [],
+    currentResult: null,
+    errorId: null,
+    results: [],
+    prevValue: "",
+    bestMatch: {},
+    onCommit: () => {},
+  },
+  states: {
+    reading: {
+      entry: assign({
+        errorId: null,
+      }),
+      on: {
+        EDIT: {
+          target: "editing",
+        },
+      },
+    },
+    editing: {
+      entry: [
+        assign({
+          errorId: null,
+          currentResult: ({ values, value }) => values.indexOf(value),
+          prevValue: ({ value }) => value,
+          results: ({ values }) => values,
+          bestMatch: ({ values, value }) =>
+            computeBestMatchString(values, value),
+        }),
+      ],
+      type: "parallel",
+      states: {
+        input: {
+          initial: "focused",
+          states: {
+            focused: {
+              on: {
+                UNFOCUS_INPUT: "unfocused",
+              },
+            },
+            unfocused: {
+              on: {
+                FOCUS_INPUT: "focused",
+              },
+            },
+          },
+        },
+        searchResults: {
+          initial: "notHovering",
+          states: {
+            hovering: {
+              on: {
+                MOUSELEAVE: "notHovering",
+              },
+            },
+            notHovering: {
+              on: {
+                MOUSEENTER: "hovering",
+              },
+            },
+          },
+        },
+      },
+      on: {
+        NEXT_RESULT: {
+          actions: assign({
+            currentResult: ({ currentResult, results }) => {
+              if (currentResult === null) return 0;
+              return Math.min(currentResult + 1, results.length - 1);
+            },
+            value: ({ currentResult, results }) => {
+              if (currentResult === null) return results[0];
+              return results[Math.min(currentResult + 1, results.length - 1)];
+            },
+          }),
+          bestMatch: {},
+        },
+        PREVIOUS_RESULT: {
+          actions: assign({
+            currentResult: ({ currentResult }) => {
+              if (currentResult === 0 || currentResult === null) return null;
+              return currentResult - 1;
+            },
+            value: ({ currentResult, prevValue, results }) => {
+              if (currentResult === 0 || currentResult === null)
+                return prevValue;
+              return results[currentResult - 1];
+            },
+          }),
+          bestMatch: {},
+        },
+        BLUR: {
+          target: "reading",
+        },
+        COMMIT: [
+          {
+            target: "reading",
+            actions: [
+              assign({
+                value: (_, { value }) => value,
+                valid: true,
+              }),
+              ({ onCommit, prevValue }, { value }) => {
+                value !== prevValue && onCommit(value);
+              },
+            ],
+            cond: ({ values }, { value }) => {
+              return values.some((v) => v === value);
+            },
+          },
+          {
+            actions: assign({
+              error: (_, { value }) => ({
+                name: "name",
+                error: `${value === "" ? '""' : value} does not exist`,
+              }),
+              errorId: uuid(),
+              valid: false,
+            }),
+          },
+        ],
+        CHANGE: {
+          actions: [
+            assign({
+              value: (_, { value }) => value,
+              results: ({ values }) => values,
+              prevValue: ({ value }) => value,
+              errorId: null,
+              currentResult: ({ values }, { value }) => {
+                const i = values.indexOf(value);
+                if (i > 0) return i;
+                return null;
+              },
+              bestMatch: ({ values, value }) =>
+                computeBestMatchString(values, value),
+            }),
+          ],
+        },
+      },
+    },
+  },
+  on: {
+    SET_VALUES: {
+      target: "reading",
+      actions: [
+        assign({
+          value: (_, { value }) => value,
+          values: (_, { values }) => values,
+          onCommit: (_, { onCommit }) => onCommit,
+        }),
+      ],
+    },
+  },
+});
 
+const DatasetSelector = () => {
+  const datasetName = useRecoilValue(selectors.datasetName);
+  const socket = useRecoilValue(selectors.socket);
+  const datasets = useRecoilValue(selectors.datasets);
+  const [state, send] = useMachine(selectorMachine);
+  const inputRef = useRef();
+  const { results, currentResult, value, bestMatch, values } = state.context;
+
+  useEffect(() => {
+    send({
+      type: "SET_VALUES",
+      value: datasetName ?? "",
+      values: datasets,
+      onCommit: (v) => {
+        socket.send(packageMessage("set_dataset", { dataset_name: v }));
+      },
+    });
+  }, [datasetName, datasets, socket]);
+
+  const isEditing = state.matches("editing");
+  useEffect(() => {
+    isEditing && inputRef.current && inputRef.current.focus();
+    !isEditing && inputRef.current && inputRef.current.blur();
+  }, [isEditing, inputRef.current]);
+
+  return (
+    <DatasetDiv>
+      <DatasetContainerInput>
+        <DatasetInput
+          placeholder={"Choose a dataset"}
+          value={value}
+          onFocus={() => state.matches("reading") && send("EDIT")}
+          onBlur={(e) => {
+            state.matches("editing.searchResults.notHovering") && send("BLUR");
+          }}
+          ref={inputRef}
+          onChange={(e) => send({ type: "CHANGE", value: e.target.value })}
+          onKeyPress={(e) => {
+            if (e.key === "Enter") {
+              const match = getMatch(values, e.target.value);
+              send({
+                type: "COMMIT",
+                value: match
+                  ? match
+                  : bestMatch.value
+                  ? bestMatch.value
+                  : e.target.value,
+              });
+            }
+          }}
+          onKeyDown={(e) => {
+            switch (e.key) {
+              case "Escape":
+                send("BLUR");
+                break;
+              case "ArrowDown":
+                send("NEXT_RESULT");
+                break;
+              case "ArrowUp":
+                send("PREVIOUS_RESULT");
+                break;
+              case "ArrowRight":
+                e.target.selectionStart === e.target.value.length &&
+                  bestMatch.value &&
+                  send({ type: "CHANGE", value: bestMatch.value });
+                break;
+            }
+          }}
+        />
+        {state.matches("editing") || value === "" ? (
+          <BestMatchDiv>{bestMatch ? bestMatch.placeholder : ""}</BestMatchDiv>
+        ) : null}
+      </DatasetContainerInput>
+      {state.matches("editing") && (
+        <SearchResults
+          results={results}
+          send={send}
+          currentResult={currentResult}
+          bestMatch={bestMatch.value}
+          style={{
+            marginTop: 8,
+            fontSize: "1.2rem",
+            maxHeight: 212,
+            overflowY: "scroll",
+          }}
+        />
+      )}
+      <ErrorMessage machine={[state, send]} style={{ marginTop: 8 }} />
+    </DatasetDiv>
+  );
+};
+
+const Header = () => {
   return (
     <HeaderDiv>
       <LeftDiv>
-        <LogoDiv>
+        <TitleDiv onClick={() => window.location.reload()}>
           <LogoImg src={logo} />
-        </LogoDiv>
-        <TitleDiv>
           <FiftyOneDiv>FiftyOne</FiftyOneDiv>
-          <DatasetDiv>
-            {datasetNameValue ? datasetNameValue : "NO DATASET LOADED"}
-          </DatasetDiv>
         </TitleDiv>
+        <DatasetSelector />
       </LeftDiv>
       <RightDiv>
         <IconWrapper>

--- a/electron/app/components/Header.tsx
+++ b/electron/app/components/Header.tsx
@@ -19,6 +19,7 @@ import SearchResults from "./ViewBar/ViewStage/SearchResults";
 
 const DatasetContainerInput = styled.div`
   font-size: 1.2rem;
+  display: flex;
   border-bottom: 1px ${({ theme }) => theme.brand} solid;
 `;
 
@@ -212,6 +213,12 @@ const selectorMachine = Machine({
         },
         BLUR: {
           target: "reading",
+          actions: [
+            assign({
+              value: ({ value, prevValue, values }) =>
+                values.indexOf(value) > 0 ? value : prevValue,
+            }),
+          ],
         },
         COMMIT: [
           {
@@ -252,7 +259,7 @@ const selectorMachine = Machine({
                 if (i > 0) return i;
                 return null;
               },
-              bestMatch: ({ values, value }) =>
+              bestMatch: ({ values }, { value }) =>
                 computeBestMatchString(values, value),
             }),
           ],
@@ -303,7 +310,7 @@ const DatasetSelector = () => {
     <DatasetDiv>
       <DatasetContainerInput>
         <DatasetInput
-          placeholder={"Choose a dataset"}
+          placeholder={"Select a dataset"}
           value={value}
           onFocus={() => state.matches("reading") && send("EDIT")}
           onBlur={(e) => {
@@ -344,7 +351,9 @@ const DatasetSelector = () => {
           }}
         />
         {state.matches("editing") || value === "" ? (
-          <BestMatchDiv>{bestMatch ? bestMatch.placeholder : ""}</BestMatchDiv>
+          <BestMatchDiv style={{ lineHeight: "40px", margin: 0 }}>
+            {bestMatch ? bestMatch.placeholder : ""}
+          </BestMatchDiv>
         ) : null}
       </DatasetContainerInput>
       {state.matches("editing") && (
@@ -367,10 +376,11 @@ const DatasetSelector = () => {
 };
 
 const Header = () => {
+  const socket = useRecoilValue(selectors.socket);
   return (
     <HeaderDiv>
       <LeftDiv>
-        <TitleDiv onClick={() => window.location.reload()}>
+        <TitleDiv onClick={() => socket.send(packageMessage("refresh", {}))}>
           <LogoImg src={logo} />
           <FiftyOneDiv>FiftyOne</FiftyOneDiv>
         </TitleDiv>

--- a/electron/app/components/Header.tsx
+++ b/electron/app/components/Header.tsx
@@ -60,14 +60,12 @@ const TitleDiv = styled.div`
   margin-right: 1rem;
   cursor: pointer;
   height: 40px;
-  display: flex;
 `;
 
 const LogoImg = animated(styled.img`
   height: 100%;
   width: auto;
   cursor: pointer;
-  margin-right: 1rem;
 `);
 
 const LeftDiv = styled.div`
@@ -78,14 +76,6 @@ const LeftDiv = styled.div`
 const RightDiv = styled.div`
   margin-left: auto;
   padding-right: 0.5rem;
-`;
-
-const FiftyOneDiv = styled.div`
-  color: ${(theme) => theme.font};
-  font-weight: bold;
-  font-size: 1.8rem;
-  align-items: center;
-  display: flex;
 `;
 
 const DatasetDiv = styled.div`
@@ -395,7 +385,6 @@ const Header = () => {
           }}
         >
           <LogoImg style={logoProps} src={logo} />
-          <FiftyOneDiv>FiftyOne</FiftyOneDiv>
         </TitleDiv>
         <DatasetSelector />
       </LeftDiv>

--- a/electron/app/components/Sample.tsx
+++ b/electron/app/components/Sample.tsx
@@ -264,4 +264,4 @@ const Sample = ({ sample, metadata, setView }) => {
   );
 };
 
-export default Sample;
+export default React.memo(Sample);

--- a/electron/app/components/Samples.hooks.ts
+++ b/electron/app/components/Samples.hooks.ts
@@ -5,6 +5,7 @@ import tile from "../utils/tile";
 import { packageMessage } from "../utils/socket";
 import { viewsAreEqual } from "../utils/view";
 
+import * as atoms from "../recoil/atoms";
 import * as selectors from "../recoil/selectors";
 import { filter } from "lodash";
 
@@ -15,6 +16,7 @@ export default () => {
   const datasetName = useRecoilValue(selectors.datasetName);
   const view = useRecoilValue(selectors.view);
   const [prevView, setPrevView] = useState([]);
+  const refresh = useRecoilValue(atoms.refresh);
 
   const empty = {
     initialized: false,
@@ -45,7 +47,7 @@ export default () => {
 
   useEffect(() => {
     setState(empty);
-  }, [datasetName]);
+  }, [datasetName, refresh]);
 
   useEffect(() => {
     if (!state.loadMore || state.isLoading || !state.hasMore) return;

--- a/electron/app/components/Samples.tsx
+++ b/electron/app/components/Samples.tsx
@@ -94,4 +94,4 @@ function Samples({ setView }) {
   );
 }
 
-export default Samples;
+export default React.memo(Samples);

--- a/electron/app/components/ViewBar/ViewStage/ErrorMessage.tsx
+++ b/electron/app/components/ViewBar/ViewStage/ErrorMessage.tsx
@@ -28,59 +28,66 @@ const ErrorHeader = styled.div`
   padding-bottom: 0.5rem;
 `;
 
-const ErrorMessage = React.memo(({ barRef, followRef, serviceRef, style }) => {
-  const theme = useContext(ThemeContext);
-  const [state, send] = useService(serviceRef);
-  const ref = useRef();
-  const [errorTimeout, setErrorTimeout] = useState(null);
-  const { error, errorId } = state.context;
-  const [props, set] = useSpring(() => {
-    const obj = followRef
-      ? {
-          left: followRef.current.getBoundingClientRect().x,
-          top: followRef.current.getBoundingClientRect().y,
-        }
-      : {};
-    return {
-      ...obj,
-      opacity: errorId ? 1 : 0,
-      from: {
-        opacity: 0,
-      },
-      config: config.stiff,
-    };
-  });
+const ErrorMessage = React.memo(
+  ({ barRef, followRef, serviceRef, style, machine }) => {
+    const theme = useContext(ThemeContext);
+    let state, send;
+    if (machine) {
+      [state, send] = machine;
+    } else {
+      [state, send] = useService(serviceRef);
+    }
+    const ref = useRef();
+    const [errorTimeout, setErrorTimeout] = useState(null);
+    const { error, errorId } = state.context;
+    const [props, set] = useSpring(() => {
+      const obj = followRef
+        ? {
+            left: followRef.current.getBoundingClientRect().x,
+            top: followRef.current.getBoundingClientRect().y,
+          }
+        : {};
+      return {
+        ...obj,
+        opacity: errorId ? 1 : 0,
+        from: {
+          opacity: 0,
+        },
+        config: config.stiff,
+      };
+    });
 
-  useEffect(() => {
-    errorTimeout && clearTimeout(errorTimeout);
-    !errorId && setErrorTimeout(setTimeout(() => send("CLEAR_ERROR"), 1000));
-    set({ opacity: errorId ? 1 : 0 });
-  }, [errorId]);
+    useEffect(() => {
+      errorTimeout && clearTimeout(errorTimeout);
+      !errorId && setErrorTimeout(setTimeout(() => send("CLEAR_ERROR"), 1000));
+      set({ opacity: errorId ? 1 : 0 });
+    }, [errorId]);
 
-  useOutsideClick(ref, () => send("CLEAR_ERROR_ID"));
+    useOutsideClick(ref, () => send("CLEAR_ERROR_ID"));
 
-  useFollow(barRef, followRef, set);
+    useFollow(barRef, followRef, set);
 
-  return (
-    <ErrorMessageDiv
-      ref={ref}
-      style={{ ...props, display: error ? "block" : "none", ...style }}
-    >
-      {error ? (
-        <>
-          <ErrorHeader>
-            <ReportProblem
-              style={{ color: theme.error, marginRight: "0.5rem" }}
-            />
-            <div
-              style={{ marginTop: "0.25rem" }}
-            >{`Invalid ${error.name}.`}</div>
-          </ErrorHeader>
-          {error.error}
-        </>
-      ) : null}
-    </ErrorMessageDiv>
-  );
-});
+    return (
+      <ErrorMessageDiv
+        ref={ref}
+        style={{ ...props, display: error ? "block" : "none", ...style }}
+      >
+        {error ? (
+          <>
+            <ErrorHeader>
+              <ReportProblem
+                style={{ color: theme.error, marginRight: "0.5rem" }}
+              />
+              <div
+                style={{ marginTop: "0.25rem" }}
+              >{`Invalid ${error.name}.`}</div>
+            </ErrorHeader>
+            {error.error}
+          </>
+        ) : null}
+      </ErrorMessageDiv>
+    );
+  }
+);
 
 export default ErrorMessage;

--- a/electron/app/components/ViewBar/ViewStage/SearchResults.tsx
+++ b/electron/app/components/ViewBar/ViewStage/SearchResults.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useLayoutEffect, useEffect, useRef } from "react";
+import React, { useContext, useEffect, useRef } from "react";
 import { animated, config, useSpring } from "react-spring";
 import styled, { ThemeContext } from "styled-components";
 
@@ -20,6 +20,7 @@ interface SearchResultProps {
 
 const SearchResult = React.memo(
   ({ result, isActive, send }: SearchResultProps) => {
+    const ref = useRef(null);
     const theme = useContext(ThemeContext);
     const [props, set] = useSpring(() => ({
       backgroundColor: isActive ? theme.backgroundLight : theme.backgroundDark,
@@ -33,12 +34,14 @@ const SearchResult = React.memo(
           : theme.backgroundDark,
         color: isActive ? theme.font : theme.fontDark,
       });
-    }, [isActive]);
+      isActive && ref.current && ref.current.scrollIntoView();
+    }, [isActive, ref.current]);
 
     const handleMouseEnter = () =>
       set({ backgroundColor: theme.backgroundLight, color: theme.font });
 
     const handleMouseLeave = () =>
+      !isActive &&
       set({ backgroundColor: theme.backgroundDark, color: theme.fontDark });
 
     const setResult = (e) =>
@@ -46,6 +49,7 @@ const SearchResult = React.memo(
 
     return (
       <SearchResultDiv
+        ref={ref}
         onClick={setResult}
         onMouseEnter={handleMouseEnter}
         onMouseLeave={handleMouseLeave}

--- a/electron/app/containers/App.tsx
+++ b/electron/app/containers/App.tsx
@@ -98,6 +98,7 @@ function App(props: Props) {
 
   useEventHandler(socket, "close", () => {
     setConnected(false);
+    setStateDescription({});
   });
   useMessageHandler("update", ({ state }) => {
     setViewCounter(viewCounterValue + 1);

--- a/electron/app/containers/Dataset.tsx
+++ b/electron/app/containers/Dataset.tsx
@@ -217,7 +217,7 @@ function Dataset(props) {
             />
           </Body>
         ) : (
-          <Loading text={"No dataset loaded"} />
+          <Loading text={"No dataset selected"} />
         )}
       </Container>
     </>

--- a/electron/app/recoil/atoms.ts
+++ b/electron/app/recoil/atoms.ts
@@ -12,6 +12,11 @@ export const connected = atom({
   default: false,
 });
 
+export const refresh = atom({
+  key: "refresh",
+  default: false,
+});
+
 export const activePlot = atom({
   key: "activePlot",
   default: "labels",

--- a/electron/app/recoil/selectors.ts
+++ b/electron/app/recoil/selectors.ts
@@ -30,6 +30,13 @@ export const datasetName = selector({
   },
 });
 
+export const datasets = selector({
+  key: "datasets",
+  get: ({ get }) => {
+    return get(atoms.stateDescription).datasets ?? [];
+  },
+});
+
 export const hasDataset = selector({
   key: "hasDataset",
   get: ({ get }) => Boolean(get(datasetName)),

--- a/fiftyone/core/session.py
+++ b/fiftyone/core/session.py
@@ -9,6 +9,7 @@ from collections import defaultdict
 import logging
 import time
 
+import fiftyone.core.dataset as fod
 import fiftyone.core.client as foc
 import fiftyone.core.service as fos
 from fiftyone.core.state import StateDescription
@@ -82,6 +83,7 @@ def close_app():
 def _update_state(func):
     def wrapper(self, *args, **kwargs):
         result = func(self, *args, **kwargs)
+        self.state.datasets = fod.list_datasets()
         self._update_state()
         return result
 

--- a/fiftyone/core/state.py
+++ b/fiftyone/core/state.py
@@ -49,6 +49,7 @@ class StateDescription(etas.Serializable):
         close=False,
         connected=False,
         dataset=None,
+        datasets=None,
         selected=None,
         selected_objects=None,
         view=None,
@@ -61,6 +62,7 @@ class StateDescription(etas.Serializable):
         self.selected = selected or []
         self.selected_objects = selected_objects or []
         self.filters = filters
+        self.datasets = datasets or fod.list_datasets()
         super().__init__()
 
     def serialize(self, reflective=False):

--- a/fiftyone/server/main.py
+++ b/fiftyone/server/main.py
@@ -30,6 +30,7 @@ import eta.core.video as etav
 os.environ["FIFTYONE_SERVER"] = "1"
 import fiftyone.core.aggregations as foa
 import fiftyone.constants as foc
+import fiftyone.core.dataset as fod
 import fiftyone.core.fields as fof
 import fiftyone.core.labels as fol
 import fiftyone.core.media as fom
@@ -388,6 +389,17 @@ class StateHandler(tornado.websocket.WebSocketHandler):
 
         StateHandler.state["selected_objects"] = selected_objects
         await self.send_updates(ignore=self)
+
+    async def on_set_dataset(self, dataset_name):
+        """Event for setting the current dataset by name.
+
+        Args:
+            dataset_name: the dataset name
+        """
+        StateHandler.state["dataset"] = fod.load_dataset(
+            dataset_name
+        )._serialize()
+        await self.on_update(StateHandler.state)
 
     async def on_get_video_data(self, _id, filepath):
         """Gets the frame labels for video samples.

--- a/fiftyone/server/main.py
+++ b/fiftyone/server/main.py
@@ -503,7 +503,7 @@ class StateHandler(tornado.websocket.WebSocketHandler):
 
         Args:
             ignore (None): a client to not send the update to
-            only (None): the onle client to send the update to
+            only (None): a client to restrict the updates to
         """
         response = {"type": "update", "state": StateHandler.state}
         if only:

--- a/fiftyone/server/main.py
+++ b/fiftyone/server/main.py
@@ -623,7 +623,7 @@ class StateHandler(tornado.websocket.WebSocketHandler):
         else:
             results = []
 
-        for stage_dict in state.filters:
+        for stage_dict in state.filters.values():
             stage = fosg.ViewStage._from_dict(stage_dict)
             view = view.add_stage(stage)
 

--- a/fiftyone/server/main.py
+++ b/fiftyone/server/main.py
@@ -405,9 +405,8 @@ class StateHandler(tornado.websocket.WebSocketHandler):
         Args:
             dataset_name: the dataset name
         """
-        StateHandler.state["dataset"] = fod.load_dataset(
-            dataset_name
-        )._serialize()
+        dataset = fod.load_dataset(dataset_name)
+        StateHandler.state = fos.StateDescription(dataset=dataset).serialize()
         await self.on_update(StateHandler.state)
 
     async def on_get_video_data(self, _id, filepath):


### PR DESCRIPTION
## What changes are proposed in this pull request?

Code is still being cleaned, but ready for feedback. I found the previous logo and title layout to be prohibitively small when trying to add selection functionality, so the dataset name now lies in the row as its own element.

I also found the arrow dropdown to be clunky. I can add it, but I don't think our users need that to understand that is where to change datasets.

* Adds dataset selection via a FiftyOne style input/dropdown
* Label graphs now include Fields Sidebar filters (the extended view). See #693 
* Refresh the App by clicking the Logo or `FiftyOne`
![Screenshot from 2020-11-20 15-24-58](https://user-images.githubusercontent.com/19821840/99855695-9c996080-2b44-11eb-87b6-fdec7d303c62.png)
## How is this patch tested? If it is not, please explain why.

Locally.

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

* Added the ability to change datasets via the dataset name input in the header
* Added the ability to refresh the App by clicking the logo in the top left
* Added the inclusion of Fields Sidebar filters when calculating distribution plots

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
