### PR TITLE
Improved range sliders and loading states

### DIFF
--- a/electron/app/components/CheckboxGrid.tsx
+++ b/electron/app/components/CheckboxGrid.tsx
@@ -19,10 +19,9 @@ import NumericFieldFilter from "./NumericFieldFilter";
 
 const GLOBAL_ATOMS = {
   colorByLabel: atoms.colorByLabel,
-  includeLabels: atoms.filterIncludeLabels,
-  invertInclude: atoms.filterInvertIncludeLabels,
-  includeNoConfidence: atoms.filterLabelIncludeNoConfidence,
-  confidenceRange: atoms.filterLabelConfidenceRange,
+  includeLabels: selectors.filterIncludeLabels,
+  includeNoConfidence: selectors.filterLabelIncludeNoConfidence,
+  confidenceRange: selectors.filterLabelConfidenceRange,
   confidenceBounds: selectors.labelConfidenceBounds,
   fieldIsFiltered: selectors.fieldIsFiltered,
 };
@@ -30,7 +29,6 @@ const GLOBAL_ATOMS = {
 const MODAL_ATOMS = {
   colorByLabel: atoms.modalColorByLabel,
   includeLabels: atoms.modalFilterIncludeLabels,
-  invertInclude: atoms.modalFilterInvertIncludeLabels,
   includeNoConfidence: atoms.modalFilterLabelIncludeNoConfidence,
   confidenceRange: atoms.modalFilterLabelConfidenceRange,
   confidenceBounds: selectors.labelConfidenceBounds,
@@ -260,12 +258,7 @@ const Entry = ({ entry, onCheck, modal }) => {
         <NumericFieldFilter expanded={expanded} entry={entry} />
       ) : null}
       {entry.type && labelTypeIsFilterable(entry.type) ? (
-        <Filter
-          expanded={expanded}
-          entry={entry}
-          {...filterAtoms}
-          modal={modal}
-        />
+        <Filter expanded={expanded} entry={entry} {...filterAtoms} />
       ) : null}
     </CheckboxContainer>
   );

--- a/electron/app/components/CheckboxGrid.tsx
+++ b/electron/app/components/CheckboxGrid.tsx
@@ -196,7 +196,7 @@ const Entry = ({ entry, onCheck, modal }) => {
             <span className="name" title={entry.name}>
               {entry.name}
             </span>
-            {entry.data !== undefined ? (
+            {entry.data !== null ? (
               <>
                 <span className="count" title={entry.data}>
                   {entry.data}

--- a/electron/app/components/FieldsSidebar.tsx
+++ b/electron/app/components/FieldsSidebar.tsx
@@ -209,8 +209,9 @@ const makeData = (filteredCount, totalCount) => {
     typeof totalCount === "number"
   ) {
     return `${filteredCount.toLocaleString()} of ${totalCount.toLocaleString()}`;
-  }
-  if (typeof totalCount === "number") {
+  } else if (filteredCount === null) {
+    return null;
+  } else if (typeof totalCount === "number") {
     return totalCount.toLocaleString();
   }
   return totalCount;

--- a/electron/app/components/Filter.tsx
+++ b/electron/app/components/Filter.tsx
@@ -250,7 +250,7 @@ const ClassFilterContainer = styled.div`
   margin: 0.25rem 0;
 `;
 
-const ClassFilter = ({ entry: { path, type, color }, atoms }) => {
+const ClassFilter = ({ entry: { path }, atoms }) => {
   const theme = useContext(ThemeContext);
   const classes = useRecoilValue(selectors.labelClasses(path));
   const [selectedClasses, setSelectedClasses] = useRecoilState(
@@ -261,8 +261,9 @@ const ClassFilter = ({ entry: { path, type, color }, atoms }) => {
 
   useEffect(() => {
     send({ type: "SET_CLASSES", classes });
-    setSelectedClasses(selectedClasses.filter((c) => classes.includes(c)));
-  }, [classes]);
+    selectedClasses.length &&
+      setSelectedClasses(selectedClasses.filter((c) => classes.includes(c)));
+  }, [classes, selectedClasses]);
 
   useOutsideClick(inputRef, () => send("BLUR"));
   const { inputValue, results, currentResult, selected } = state.context;
@@ -349,17 +350,6 @@ const ClassFilter = ({ entry: { path, type, color }, atoms }) => {
       </ClassFilterContainer>
     </>
   );
-};
-
-const CLS_TO_STAGE = {
-  Classification: "FilterField",
-  Classifications: "FilterClassifications",
-  Detection: "FilterField",
-  Detections: "FilterDetections",
-  Polyline: "FilterField",
-  Polylines: "FilterPolylines",
-  Keypoint: "FilterField",
-  Keypoints: "FilterKeypoints",
 };
 
 const HiddenObjectFilter = ({ entry }) => {

--- a/electron/app/components/Filter.tsx
+++ b/electron/app/components/Filter.tsx
@@ -482,7 +482,6 @@ const Filter = React.memo(({ expanded, style, entry, modal, ...rest }) => {
     useEffect(() => {
       const newState = JSON.parse(JSON.stringify(stateDescription));
       if (!fieldIsFiltered && !(entry.name in newState.filters)) return;
-      setExtendedDatasetStats([]);
       const filter = makeFilter(
         entry.path,
         entry.type,

--- a/electron/app/components/HorizontalNav.tsx
+++ b/electron/app/components/HorizontalNav.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useState } from "react";
+import React, { useContext, useEffect, useState } from "react";
 import { animated, useSpring } from "react-spring";
 import { useRecoilState } from "recoil";
 import styled, { ThemeContext } from "styled-components";
@@ -20,21 +20,11 @@ export type Props = {
   entries: string[];
 };
 
-const Drag = styled(DragHandle)`
-  position: absolute;
-  bottom: -0.8rem;
-  height: 1rem;
-  width: 1rem;
-  left: 50%;
-  margin-left: -0.5rem;
-  z-index: 1000;
-  pointer-events: none;
-`;
-
-const Container = styled(Resizable)`
+const Container = styled(animated(Resizable))`
   padding: 1rem 0 0;
   background-color: ${({ theme }) => theme.backgroundDark};
-  border-bottom: 1px ${({ theme }) => theme.backgroundDarkBorder} solid;
+  border-bottom-width: 1px;
+  border-bottom-style: solid;
 `;
 
 const Nav = styled.div`
@@ -127,6 +117,11 @@ const HorizontalNav = ({ entries }: Props) => {
   });
 
   const height = expanded ? openedHeight : closedHeight;
+  const resizable = expanded;
+
+  const props = useSpring({
+    borderBottomColor: resizable ? theme.brand : theme.backgroundDarkBorder,
+  });
 
   return (
     <Container
@@ -145,6 +140,7 @@ const HorizontalNav = ({ entries }: Props) => {
       onResizeStop={(e, direction, ref, d) => {
         setOpenedHeight(height + d.height);
       }}
+      style={props}
     >
       <Nav>
         <PlotsButtons>
@@ -185,7 +181,6 @@ const HorizontalNav = ({ entries }: Props) => {
         </NavButtons>
       </Nav>
       {expanded && <Distributions key={activePlot} group={activePlot} />}
-      {expanded && !maximized && <Drag />}
     </Container>
   );
 };

--- a/electron/app/components/HorizontalNav.tsx
+++ b/electron/app/components/HorizontalNav.tsx
@@ -20,11 +20,21 @@ export type Props = {
   entries: string[];
 };
 
-const Container = styled(animated(Resizable))`
+const Drag = styled(DragHandle)`
+  position: absolute;
+  bottom: -0.8rem;
+  height: 1rem;
+  width: 1rem;
+  left: 50%;
+  margin-left: -0.5rem;
+  z-index: 1000;
+  pointer-events: none;
+`;
+
+const Container = styled(Resizable)`
   padding: 1rem 0 0;
   background-color: ${({ theme }) => theme.backgroundDark};
-  border-bottom-width: 1px;
-  border-bottom-style: solid;
+  border-bottom: 1px ${({ theme }) => theme.backgroundDarkBorder} solid;
 `;
 
 const Nav = styled.div`
@@ -119,10 +129,6 @@ const HorizontalNav = ({ entries }: Props) => {
   const height = expanded ? openedHeight : closedHeight;
   const resizable = expanded;
 
-  const props = useSpring({
-    borderBottomColor: resizable ? theme.brand : theme.backgroundDarkBorder,
-  });
-
   return (
     <Container
       size={{ height: maximized ? windowHeight - 73 : height }}
@@ -140,7 +146,6 @@ const HorizontalNav = ({ entries }: Props) => {
       onResizeStop={(e, direction, ref, d) => {
         setOpenedHeight(height + d.height);
       }}
-      style={props}
     >
       <Nav>
         <PlotsButtons>
@@ -181,6 +186,7 @@ const HorizontalNav = ({ entries }: Props) => {
         </NavButtons>
       </Nav>
       {expanded && <Distributions key={activePlot} group={activePlot} />}
+      {expanded && !maximized && <Drag />}
     </Container>
   );
 };

--- a/electron/app/components/NotificationHub/NotificationHub.tsx
+++ b/electron/app/components/NotificationHub/NotificationHub.tsx
@@ -7,10 +7,8 @@ const Container = styled("div")`
   position: fixed;
   z-index: 10000;
   width: 0 auto;
-  top: ${(props) => (props.top ? "2em" : "unset")};
   bottom: ${(props) => (props.top ? "unset" : "2em")};
   margin: 0 auto;
-  left: 2em;
   right: 2em;
   font-weight: bold;
   display: flex;

--- a/electron/app/components/NumericFieldFilter.tsx
+++ b/electron/app/components/NumericFieldFilter.tsx
@@ -57,7 +57,8 @@ const NumericFieldFilter = ({ expanded, entry }) => {
     setRange(bounds);
   }, [filterStage]);
   useEffect(() => {
-    localBounds.some((b, i) => b !== bounds[i]) && setRange(bounds);
+    localBounds.some((b, i) => b !== bounds[i] && bounds[i] !== null) &&
+      setRange(bounds);
   }, [bounds, localBounds]);
   useEffect(() => {
     if (!hasBounds) {

--- a/electron/app/components/NumericFieldFilter.tsx
+++ b/electron/app/components/NumericFieldFilter.tsx
@@ -35,62 +35,10 @@ const makeFilter = (fieldName, range, includeNone, isDefaultRange) => {
 };
 
 const NumericFieldFilter = ({ expanded, entry }) => {
-  const socket = useRecoilValue(selectors.socket);
   const boundsAtom = selectors.numericFieldBounds(entry.path);
-  const rangeAtom = atoms.filterNumericFieldRange(entry.path);
-  const includeNoneAtom = atoms.filterNumericFieldIncludeNone(entry.path);
-  const [includeNone, setIncludeNone] = useRecoilState(includeNoneAtom);
-  const [stateDescription, setStateDescription] = useRecoilState(
-    atoms.stateDescription
-  );
-  const bounds = useRecoilValue(boundsAtom);
-  const [range, setRange] = useRecoilState(rangeAtom);
-  const hasBounds = bounds.every((b) => b !== null);
+  const rangeAtom = selectors.filterNumericFieldRange(entry.path);
+  const includeNoneAtom = selectors.filterNumericFieldIncludeNone(entry.path);
   const [overflow, setOverflow] = useState("hidden");
-  const [localBounds, setLocalBounds] = useState([null, null]);
-  const isDefaultRange = range[0] === bounds[0] && range[1] === bounds[1];
-  const filterStage = useRecoilValue(selectors.filterStage(entry.path));
-
-  useEffect(() => {
-    if (filterStage) return;
-    setIncludeNone(true);
-    setRange(bounds);
-  }, [filterStage]);
-  useEffect(() => {
-    localBounds.some((b, i) => b !== bounds[i] && bounds[i] !== null) &&
-      setRange(bounds);
-  }, [bounds, localBounds]);
-  useEffect(() => {
-    if (!hasBounds) {
-      return;
-    }
-    setLocalBounds(bounds);
-    if (localBounds.some((b, i) => b !== bounds[i] && b !== null)) {
-      setRange([...bounds]);
-    }
-  }, [bounds]);
-
-  useEffect(() => {
-    const newState = JSON.parse(JSON.stringify(stateDescription));
-    if (range.every((e) => e === null)) return;
-    if (includeNone && isDefaultRange && !(entry.path in newState.filters))
-      return;
-    const filter = makeFilter(entry.name, range, includeNone, isDefaultRange);
-    if (JSON.stringify(filter) === JSON.stringify(newState.filters[entry.path]))
-      return;
-    if (isDefaultRange && includeNone && newState.filters[entry.path]) {
-      delete newState.filters[entry.path];
-    } else {
-      newState.filters[entry.path] = filter;
-    }
-    if (!hasBounds) return;
-    socket.send(
-      packageMessage("update", {
-        state: newState,
-      })
-    );
-    setStateDescription(newState);
-  }, [range, includeNone]);
 
   const [ref, { height }] = useMeasure();
   const props = useSpring({

--- a/electron/app/components/RangeSlider.tsx
+++ b/electron/app/components/RangeSlider.tsx
@@ -88,13 +88,9 @@ const RangeSlider = ({ rangeAtom, boundsAtom, maxMin, minMax }: Props) => {
 
   const hasBounds = bounds.every((b) => b !== null);
   const hasValue = value.every((v) => v !== null);
-  const stretchedBounds = [
-    maxMin < bounds[0] ? maxMin : bounds[0],
-    minMax > bounds[1] ? minMax : bounds[1],
-  ];
   return hasBounds && hasValue ? (
     <SliderContainer>
-      {stretchedBounds[0].toFixed(2)}
+      {bounds[0].toFixed(2)}
       <Slider
         value={localValue.map((i) => (i ? Number(i.toFixed(2)) : i))}
         onChange={(_, v: Range) =>
@@ -112,11 +108,11 @@ const RangeSlider = ({ rangeAtom, boundsAtom, maxMin, minMax }: Props) => {
         }}
         aria-labelledby="range-slider"
         valueLabelDisplay={"on"}
-        max={Number(stretchedBounds[1].toFixed(2))}
-        min={Number(stretchedBounds[0].toFixed(2))}
-        step={(stretchedBounds[1] - stretchedBounds[0]) / 100}
+        max={Number(bounds[1].toFixed(2))}
+        min={Number(bounds[0].toFixed(2))}
+        step={(bounds[1] - bounds[0]) / 100}
       />
-      {stretchedBounds[1].toFixed(2)}
+      {bounds[1].toFixed(2)}
     </SliderContainer>
   ) : null;
 };
@@ -152,18 +148,6 @@ type NamedProps = {
   color: string;
 };
 
-const getMinAndMax = (bounds, minMax, maxMin) => {
-  const min =
-    maxMin !== undefined && maxMin < bounds[0] && bounds[1] !== bounds[0]
-      ? maxMin
-      : bounds[0];
-  const max =
-    minMax !== undefined && minMax > bounds[1] && bounds[1] !== bounds[0]
-      ? minMax
-      : bounds[1];
-  return { min, max };
-};
-
 const isDefaultRange = (range, bounds) => {
   return bounds.every((b, i) => b === range[i]);
 };
@@ -180,13 +164,10 @@ export const NamedRangeSlider = React.forwardRef(
     ref
   ) => {
     const theme = useContext(ThemeContext);
-    const { maxMin, minMax } = rangeSliderProps;
     const [includeNone, setIncludeNone] = useRecoilState(includeNoneAtom);
     const [range, setRange] = useRecoilState(rangeSliderProps.rangeAtom);
     const bounds = useRecoilValue(rangeSliderProps.boundsAtom);
-
-    const { min, max } = getMinAndMax(bounds, minMax, maxMin);
-    const hasDefaultRange = isDefaultRange(range, [min, max]);
+    const hasDefaultRange = isDefaultRange(range, bounds);
     const hasBounds = bounds.every((b) => b !== null);
     const isSingleValue = hasBounds && bounds[0] === bounds[1];
 
@@ -198,7 +179,7 @@ export const NamedRangeSlider = React.forwardRef(
             <a
               style={{ cursor: "pointer", textDecoration: "underline" }}
               onClick={() => {
-                setRange([min, max]);
+                setRange(bounds);
                 setIncludeNone(true);
               }}
             >

--- a/electron/app/components/RangeSlider.tsx
+++ b/electron/app/components/RangeSlider.tsx
@@ -90,14 +90,12 @@ const RangeSlider = ({ rangeAtom, boundsAtom, maxMin, minMax }: Props) => {
   const hasValue = value.every((v) => v !== null);
   return hasBounds && hasValue ? (
     <SliderContainer>
-      {bounds[0].toFixed(2)}
+      {bounds[0]}
       <Slider
-        value={localValue.map((i) => (i ? Number(i.toFixed(2)) : i))}
-        onChange={(_, v: Range) =>
-          setLocalValue(v.map((i) => (i ? Number(i.toFixed(2)) : i)))
-        }
+        value={[...localValue]}
+        onChange={(_, v: Range) => setLocalValue(v)}
         onChangeCommitted={(_, v: Range) => {
-          setValue([...v]);
+          setValue(v);
         }}
         classes={{
           thumb: "thumb",
@@ -108,11 +106,11 @@ const RangeSlider = ({ rangeAtom, boundsAtom, maxMin, minMax }: Props) => {
         }}
         aria-labelledby="range-slider"
         valueLabelDisplay={"on"}
-        max={Number(bounds[1].toFixed(2))}
-        min={Number(bounds[0].toFixed(2))}
+        max={bounds[1]}
+        min={bounds[0]}
         step={(bounds[1] - bounds[0]) / 100}
       />
-      {bounds[1].toFixed(2)}
+      {bounds[1]}
     </SliderContainer>
   ) : null;
 };

--- a/electron/app/components/SampleModal.tsx
+++ b/electron/app/components/SampleModal.tsx
@@ -580,7 +580,8 @@ const SampleModal = ({
               scalars={getDisplayOptions(
                 labelNameGroups.scalars,
                 scalarSampleValues,
-                activeLabels
+                activeLabels,
+                true
               )}
               onSelectScalar={handleSetDisplayOption(setActiveLabels)}
               unsupported={getDisplayOptions(

--- a/electron/app/containers/App.tsx
+++ b/electron/app/containers/App.tsx
@@ -74,13 +74,15 @@ function App(props: Props) {
   const [connected, setConnected] = useRecoilState(atoms.connected);
   const [loading, setLoading] = useRecoilState(atoms.loading);
   const socket = useRecoilValue(selectors.socket);
-  const setStateDescription = useSetRecoilState(atoms.stateDescription);
+  const [stateDescription, setStateDescription] = useRecoilState(
+    atoms.stateDescription
+  );
   const setSelectedSamples = useSetRecoilState(atoms.selectedSamples);
   const [viewCounterValue, setViewCounter] = useRecoilState(atoms.viewCounter);
   const [result, setResultFromForm] = useState({ port, connected });
   const setSelectedObjects = useSetRecoilState(atoms.selectedObjects);
   const setDatasetStatsLoading = useSetRecoilState(atoms.datasetStatsLoading);
-  const setDExtendedatasetStatsLoading = useSetRecoilState(
+  const setExtendedatasetStatsLoading = useSetRecoilState(
     atoms.extendedDatasetStatsLoading
   );
 
@@ -108,7 +110,8 @@ function App(props: Props) {
       remote.getCurrentWindow().close();
     }
     setDatasetStatsLoading(true);
-    setDExtendedatasetStatsLoading(true);
+    Object.keys(stateDescription.filters ?? []).length &&
+      setExtendedatasetStatsLoading(true);
     setLoading(false);
     handleStateUpdate(state);
   });

--- a/electron/app/containers/App.tsx
+++ b/electron/app/containers/App.tsx
@@ -79,8 +79,10 @@ function App(props: Props) {
   const [viewCounterValue, setViewCounter] = useRecoilState(atoms.viewCounter);
   const [result, setResultFromForm] = useState({ port, connected });
   const setSelectedObjects = useSetRecoilState(atoms.selectedObjects);
-  const setDatasetStats = useSetRecoilState(atoms.datasetStats);
-  const setDExtendedatasetStats = useSetRecoilState(atoms.extendedDatasetStats);
+  const setDatasetStatsLoading = useSetRecoilState(atoms.datasetStatsLoading);
+  const setDExtendedatasetStatsLoading = useSetRecoilState(
+    atoms.extendedDatasetStatsLoading
+  );
 
   useGA();
   const handleStateUpdate = (state) => {
@@ -104,8 +106,8 @@ function App(props: Props) {
     if (state.close) {
       remote.getCurrentWindow().close();
     }
-    setDatasetStats([]);
-    setDExtendedatasetStats([]);
+    setDatasetStatsLoading(true);
+    setDExtendedatasetStatsLoading(true);
     setLoading(false);
     handleStateUpdate(state);
   });

--- a/electron/app/containers/Dataset.tsx
+++ b/electron/app/containers/Dataset.tsx
@@ -78,6 +78,7 @@ function Dataset(props) {
   );
   const activeOther = useRecoilValue(atoms.activeOther("sample"));
   const activeFrameOther = useRecoilValue(atoms.activeOther("frame"));
+  const view = useRecoilValue(selectors.view);
 
   useMessageHandler("statistics", ({ stats, extended }) => {
     if (extended) {
@@ -86,6 +87,7 @@ function Dataset(props) {
     } else {
       setDatasetStatsLoading(false);
       setDatasetStats(stats);
+      view.length === 0 && setExtendedDatasetStatsLoading(false);
     }
   });
   useSendMessage("as_app", {});
@@ -111,7 +113,6 @@ function Dataset(props) {
   // are destroyed before they can handle it
   const resetSelectedObjects = useResetRecoilState(atoms.selectedObjects);
   const resetHiddenObjects = useResetRecoilState(atoms.hiddenObjects);
-  const socket = useRecoilValue(selectors.socket);
   const handleHideModal = () => {
     setModal({ visible: false, sample: null });
     resetSelectedObjects();

--- a/electron/app/containers/Dataset.tsx
+++ b/electron/app/containers/Dataset.tsx
@@ -80,7 +80,6 @@ function Dataset(props) {
   const activeFrameOther = useRecoilValue(atoms.activeOther("frame"));
 
   useMessageHandler("statistics", ({ stats, extended }) => {
-    console.log("STATS", extended, stats);
     if (extended) {
       setExtendedDatasetStatsLoading(false);
       setExtendedDatasetStats(stats);

--- a/electron/app/containers/Dataset.tsx
+++ b/electron/app/containers/Dataset.tsx
@@ -80,6 +80,7 @@ function Dataset(props) {
   const activeFrameOther = useRecoilValue(atoms.activeOther("frame"));
 
   useMessageHandler("statistics", ({ stats, extended }) => {
+    console.log("STATS", extended, stats);
     if (extended) {
       setExtendedDatasetStatsLoading(false);
       setExtendedDatasetStats(stats);

--- a/electron/app/containers/Dataset.tsx
+++ b/electron/app/containers/Dataset.tsx
@@ -65,7 +65,11 @@ function Dataset(props) {
   const frameLabelTuples = useRecoilValue(selectors.labelTuples("frame"));
   const tagNames = useRecoilValue(selectors.tagNames);
   const setExtendedDatasetStats = useSetRecoilState(atoms.extendedDatasetStats);
+  const setExtendedDatasetStatsLoading = useSetRecoilState(
+    atoms.extendedDatasetStatsLoading
+  );
   const setDatasetStats = useSetRecoilState(atoms.datasetStats);
+  const setDatasetStatsLoading = useSetRecoilState(atoms.datasetStatsLoading);
   const [activeLabels, setActiveLabels] = useRecoilState(
     atoms.activeLabels("sample")
   );
@@ -76,8 +80,13 @@ function Dataset(props) {
   const activeFrameOther = useRecoilValue(atoms.activeOther("frame"));
 
   useMessageHandler("statistics", ({ stats, extended }) => {
-    extended && setExtendedDatasetStats(stats);
-    !extended && setDatasetStats(stats);
+    if (extended) {
+      setExtendedDatasetStatsLoading(false);
+      setExtendedDatasetStats(stats);
+    } else {
+      setDatasetStatsLoading(false);
+      setDatasetStats(stats);
+    }
   });
   useSendMessage("as_app", {});
 

--- a/electron/app/containers/SamplesContainer.tsx
+++ b/electron/app/containers/SamplesContainer.tsx
@@ -59,6 +59,10 @@ const FieldsWrapper = () => {
   const frameLabelNameGroups = useRecoilValue(
     selectors.labelNameGroups("frame")
   );
+  const datasetStatsLoading = useRecoilValue(atoms.datasetStatsLoading);
+  const extendedDatasetStatsLoading = useRecoilValue(
+    atoms.extendedDatasetStatsLoading
+  );
 
   useEffect(() => {
     setModalFilters(filters);
@@ -68,8 +72,10 @@ const FieldsWrapper = () => {
     return [...values].sort().map(({ name, type }) => ({
       name,
       type,
-      totalCount: totalCounts[name],
-      filteredCount: filteredCounts[name],
+      totalCount: datasetStatsLoading ? undefined : totalCounts[name],
+      filteredCount: extendedDatasetStatsLoading
+        ? undefined
+        : filteredCounts[name],
       selected: Boolean(selected[name]),
     }));
   };

--- a/electron/app/containers/SamplesContainer.tsx
+++ b/electron/app/containers/SamplesContainer.tsx
@@ -72,7 +72,10 @@ const FieldsWrapper = () => {
     return [...values].sort().map(({ name, type }) => ({
       name,
       type,
-      totalCount: datasetStatsLoading ? undefined : totalCounts[name],
+      totalCount:
+        datasetStatsLoading || extendedDatasetStatsLoading
+          ? undefined
+          : totalCounts[name],
       filteredCount: extendedDatasetStatsLoading
         ? undefined
         : filteredCounts[name],

--- a/electron/app/containers/SamplesContainer.tsx
+++ b/electron/app/containers/SamplesContainer.tsx
@@ -72,10 +72,7 @@ const FieldsWrapper = () => {
     return [...values].sort().map(({ name, type }) => ({
       name,
       type,
-      totalCount:
-        datasetStatsLoading || extendedDatasetStatsLoading
-          ? undefined
-          : totalCounts[name],
+      totalCount: datasetStatsLoading ? undefined : totalCounts[name],
       filteredCount: extendedDatasetStatsLoading
         ? undefined
         : filteredCounts[name],

--- a/electron/app/containers/SamplesContainer.tsx
+++ b/electron/app/containers/SamplesContainer.tsx
@@ -72,10 +72,8 @@ const FieldsWrapper = () => {
     return [...values].sort().map(({ name, type }) => ({
       name,
       type,
-      totalCount: datasetStatsLoading ? undefined : totalCounts[name],
-      filteredCount: extendedDatasetStatsLoading
-        ? undefined
-        : filteredCounts[name],
+      totalCount: datasetStatsLoading ? null : totalCounts[name],
+      filteredCount: extendedDatasetStatsLoading ? null : filteredCounts[name],
       selected: Boolean(selected[name]),
     }));
   };

--- a/electron/app/recoil/atoms.ts
+++ b/electron/app/recoil/atoms.ts
@@ -22,9 +22,19 @@ export const datasetStats = atom({
   default: [],
 });
 
+export const datasetStatsLoading = atom({
+  key: "datasetStatsLoading",
+  default: true,
+});
+
 export const extendedDatasetStats = atom({
   key: "extendedDatasetStats",
   default: [],
+});
+
+export const extendedDatasetStatsLoading = atom({
+  key: "extendedDatasetStatsLoading",
+  default: true,
 });
 
 export const loading = atom({

--- a/electron/app/recoil/atoms.ts
+++ b/electron/app/recoil/atoms.ts
@@ -82,31 +82,6 @@ export const currentSamples = atom({
   default: [],
 });
 
-export const filterInvertIncludeLabels = atomFamily({
-  key: "filterInvertIncludeLabels",
-  default: false,
-});
-
-export const modalFilterInvertIncludeLabels = atomFamily({
-  key: "modalFilterInvertIncludeLabels",
-  default: false,
-});
-
-export const filterIncludeLabels = atomFamily({
-  key: "filterIncludeLabels",
-  default: [],
-});
-
-export const filterLabelConfidenceRange = atomFamily({
-  key: "filterLabelConfidenceRange",
-  default: [null, null],
-});
-
-export const filterLabelIncludeNoConfidence = atomFamily({
-  key: "filterLabelIncludeNoConfidence",
-  default: true,
-});
-
 export const modalFilterIncludeLabels = atomFamily({
   key: "modalFilterIncludeLabels",
   default: [],
@@ -150,16 +125,6 @@ export const activeTags = atom({
 export const modalActiveTags = atom({
   key: "modalActiveTags",
   default: {},
-});
-
-export const filterNumericFieldRange = atomFamily({
-  key: "filterNumericFieldRange",
-  default: [null, null],
-});
-
-export const filterNumericFieldIncludeNone = atomFamily({
-  key: "filterNumericFieldIncludeNone",
-  default: true,
 });
 
 export const sampleVideoLabels = atomFamily({

--- a/electron/app/recoil/selectors.ts
+++ b/electron/app/recoil/selectors.ts
@@ -56,8 +56,8 @@ export const view = selector({
       ...state,
       view: stages,
     };
-    set(atoms.datasetStats, []);
-    set(atoms.extendedDatasetStats, []);
+    set(atoms.datasetStatsLoading, true);
+    set(atoms.extendedDatasetStatsLoading, true);
     set(atoms.stateDescription, newState);
     get(socket).send(packageMessage("update", { state: newState }));
   },

--- a/electron/app/recoil/selectors.ts
+++ b/electron/app/recoil/selectors.ts
@@ -64,7 +64,9 @@ export const view = selector({
       view: stages,
     };
     set(atoms.datasetStatsLoading, true);
-    set(atoms.extendedDatasetStatsLoading, true);
+    if (Object.keys(state.filters).length) {
+      set(atoms.extendedDatasetStatsLoading, true);
+    }
     set(atoms.stateDescription, newState);
     get(socket).send(packageMessage("update", { state: newState }));
   },

--- a/electron/app/recoil/selectors.ts
+++ b/electron/app/recoil/selectors.ts
@@ -571,7 +571,19 @@ export const labelConfidenceBounds = selectorFamily({
     return get(atoms.datasetStats).reduce(
       (acc, cur) => {
         if (cur.name === label && cur._CLS === CONFIDENCE_BOUNDS_CLS) {
-          return cur.bounds;
+          let bounds = cur.bounds;
+          bounds = [
+            0 < bounds[0] ? 0 : bounds[0],
+            1 > bounds[1] ? 1 : bounds[1],
+          ];
+          return [
+            bounds[0] !== null && bounds[0] !== 0
+              ? Number((bounds[0] - 0.01).toFixed(2))
+              : bounds[0],
+            bounds[1] !== null && bounds[1] !== 1
+              ? Number((bounds[1] + 0.01).toFixed(2))
+              : bounds[1],
+          ];
         }
         return acc;
       },
@@ -586,7 +598,15 @@ export const numericFieldBounds = selectorFamily({
     return get(atoms.datasetStats).reduce(
       (acc, cur) => {
         if (cur.name === label && cur._CLS === BOUNDS_CLS) {
-          return cur.bounds;
+          const { bounds } = cur;
+          return [
+            bounds[0] !== null && bounds[0] !== 0
+              ? Number((bounds[0] - 0.01).toFixed(2))
+              : bounds[0],
+            bounds[1] !== null && bounds[1] !== 1
+              ? Number((bounds[1] + 0.01).toFixed(2))
+              : bounds[1],
+          ];
         }
         return acc;
       },
@@ -697,12 +717,7 @@ export const filterLabelConfidenceRange = selectorFamily({
   get: (path) => ({ get }) => {
     const filter = get(filterStage(path));
     if (filter?.range) return filter.range;
-    const bounds = get(labelConfidenceBounds(path));
-    const stretchedBounds = [
-      0 < bounds[0] ? 0 : bounds[0],
-      1 > bounds[1] ? 1 : bounds[1],
-    ];
-    return stretchedBounds;
+    return get(labelConfidenceBounds(path));
   },
   set: (path) => ({ get, set }, range) => {
     const bounds = get(labelConfidenceBounds(path));

--- a/electron/app/recoil/selectors.ts
+++ b/electron/app/recoil/selectors.ts
@@ -83,7 +83,7 @@ export const filterStages = selector({
 export const filterStage = selectorFamily({
   key: "filterStage",
   get: (path) => ({ get }) => {
-    return get(filterStages)[path];
+    return get(filterStages)?.[path] ?? {};
   },
   set: (path: string) => ({ get, set }, value) => {
     const filters = Object.assign({}, get(filterStages));

--- a/fiftyone/core/stages.py
+++ b/fiftyone/core/stages.py
@@ -2158,12 +2158,23 @@ def _get_rng(seed):
     return _random
 
 
-def _get_labels_list_field(field_name, sample_collection):
-    schema = sample_collection.get_field_schema()
+def _get_labels_list_field(field_path, sample_collection):
+    if field_path.startswith("frames."):
+        if sample_collection.media_type != fom.VIDEO:
+            raise ValueError(
+                "Field '%s' is a frames field but '%s' is not a video dataset"
+                % (field_path, sample_collection.name)
+            )
+
+        field_name = field_path[len("frames.") :]
+        schema = sample_collection.get_frame_field_schema()
+    else:
+        field_name = field_path
+        schema = sample_collection.get_field_schema()
     field = schema.get(field_name, None)
 
     if field is None:
-        raise ValueError("Field '%s' does not exist" % field_name)
+        raise ValueError("Field '%s' does not exist" % field_path)
 
     if isinstance(field, fof.EmbeddedDocumentField):
         document_type = field.document_type
@@ -2188,7 +2199,7 @@ def _get_labels_list_field(field_name, sample_collection):
 
     raise ValueError(
         "Field '%s' must be a labels list type %s; found '%s'"
-        % (field_name, allowed_types, field)
+        % (field_path, allowed_types, field)
     )
 
 

--- a/fiftyone/core/stages.py
+++ b/fiftyone/core/stages.py
@@ -2179,16 +2179,16 @@ def _get_labels_list_field(field_path, sample_collection):
     if isinstance(field, fof.EmbeddedDocumentField):
         document_type = field.document_type
         if document_type is fol.Classifications:
-            return field_name + ".classifications"
+            return field_path + ".classifications"
 
         if document_type is fol.Detections:
-            return field_name + ".detections"
+            return field_path + ".detections"
 
         if document_type is fol.Polylines:
-            return field_name + ".polylines"
+            return field_path + ".polylines"
 
         if document_type is fol.Keypoints:
-            return field_name + ".keypoints"
+            return field_path + ".keypoints"
 
     allowed_types = (
         fol.Classifications,

--- a/fiftyone/server/main.py
+++ b/fiftyone/server/main.py
@@ -614,8 +614,7 @@ class StateHandler(tornado.websocket.WebSocketHandler):
         else:
             results = []
 
-        for stage_dict in state.filters.values():
-            stage = fosg.ViewStage._from_dict(stage_dict)
+        for stage in _make_filter_stages(state.dataset, state.filters):
             view = view.add_stage(stage)
 
         if group == LABELS and results is None:

--- a/fiftyone/server/main.py
+++ b/fiftyone/server/main.py
@@ -664,10 +664,10 @@ def _make_range_expression(f, args):
         if args.get("none", False):
             expr |= ~f
     elif "none" in args:
-        if not none:
+        if args["none"]:
             expr = f
         else:
-            raise ValueError("invalid")
+            expr = ~f
 
     return expr
 

--- a/fiftyone/server/main.py
+++ b/fiftyone/server/main.py
@@ -691,10 +691,8 @@ def _make_range_expression(f, args):
         if args.get("none", False):
             expr |= ~f
     elif "none" in args:
-        if args["none"]:
+        if not args["none"]:
             expr = f
-        else:
-            expr = ~f
 
     return expr
 

--- a/fiftyone/server/main.py
+++ b/fiftyone/server/main.py
@@ -320,7 +320,7 @@ class StateHandler(tornado.websocket.WebSocketHandler):
         state = StateHandler.state
         view = state["view"] or []
         await self.send_statistics(
-            view + list(state["filters"].values()), extended=True
+            view + _make_filter_stages(state["filters"]), extended=True
         )
 
     async def on_page(self, **kwargs):
@@ -468,7 +468,7 @@ class StateHandler(tornado.websocket.WebSocketHandler):
         if len(state["filters"]):
             awaitables.append(
                 self.send_statistics(
-                    view + list(state["filters"].values()),
+                    view + _make_filter_stages(state["filters"]),
                     extended=True,
                     only=only,
                 )
@@ -659,6 +659,11 @@ class StateHandler(tornado.websocket.WebSocketHandler):
             )
 
         self.write_message({"type": "distributions", "results": results})
+
+
+def _make_filter_stages(filters):
+    for path, args in filters.values():
+        pass
 
 
 async def _get_distributions(coll, view, group):


### PR DESCRIPTION
## What changes are proposed in this pull request?

Resolves #693 

What is lacking right now is that all new extended statistics need to be computed when a confidence slider is changed, which shows loading indicators for all fields. This does not need to happen, as only the counts for the label field in question will change. Then again, when an `only_matches` option (blocked by only matches support for frame labels) is added, all extended statistics do need to be recomputed...

I think more granular loading will be best addressed when the Fields Sidebar is generalized.

## How is this patch tested? If it is not, please explain why.

Locally

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

TBD

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
