### PR TITLE
Session tweaks

### DIFF
--- a/docs/source/environments/index.rst
+++ b/docs/source/environments/index.rst
@@ -137,7 +137,9 @@ To use FiftyOne in a notebook, simply install `fiftyone` via `pip`:
 
     !pip install fiftyone
 
-and load datasets and create sessions as usual:
+and load datasets as usual. When you run
+:meth:`launch_app() <fiftyone.core.session.launch_app>` in a notebook, an App
+window will be opened in the output of your current cell.
 
 .. code-block:: python
     :linenos:
@@ -146,36 +148,108 @@ and load datasets and create sessions as usual:
 
     dataset = fo.Dataset(name="my_dataset")
 
-    session = fo.Session(dataset)
+    # Creates a session and opens the App in the output of the cell
+    session = fo.launch_app(dataset)
 
-Anytime you would like visualize your data in the App, simply call the
-:meth:`session.show() <fiftyone.core.session.Session.show>`, and an App
-instance will be created in the cell's output:
+This App window will remain connected to your ``session`` object, so if you
+modify your session and refresh/reactivate this App winodw, it will sync with
+the current state of the ``session``.
+
+Any time you update the state of your ``session`` object; e.g., by setting
+:meth:`session.dataset <fiftyone.core.session.Session.dataset>` or
+:meth:`session.view <fiftyone.core.session.Session.view>`, a new App window
+will be automatically opened in the output of the current cell.
 
 .. code-block:: python
-   :linenos:
+    :linenos:
 
-   # Opens an App instance in the cell's output
-   session.show()
-
-This App instance will remain connected to your `session` object, so it will
-continue to update as you work in the notebook.
+    # A new App window will be created in the output of this cell
+    session.view = dataset.take(10)
 
 .. note::
 
-    If you run :meth:`session.show() <fiftyone.core.session.Session.show>` in
-    multiple cells, only the most recently run cell will be active (connected
-    to the `session` object).
+    Only the most recently opened App window will be active, i.e, synced with
+    the ``session`` object.
 
     You can reactive an older cell by clicking `Activate` in the App window,
     or by running the cell again. This will deactivate the previously active
     cell.
 
+Manually controlling App instances
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If you would like to manually control when new App instances are created in a
+notebook, you can pass the ``auto=False`` flag to
+:meth:`launch_app() <fiftyone.core.session.launch_app>`:
+
+.. code-block:: python
+    :linenos:
+
+    # Creates a session but does not open an App instance
+    session = fo.launch_app(dataset, auto=False)
+
+When ``auto=False`` is provided, a new App window is created only when you call
+:meth:`session.show() <fiftyone.core.session.Session.show>`:
+
+.. code-block:: python
+    :linenos:
+
+    # Update the session's view
+    # No App window is created
+    session.view = dataset.take(10)
+
+    # In another cell
+
+    # Now open an App window in the cell's output
+    session.show()
+
+As usual, this App window will remain connected to your ``session`` object, so
+it will stay in-sync with your session whenever it is active.
+
 .. note::
 
-    You can open any App instance in a dedicated browser window or tab by
-    retrieving the URL of the session from its
-    :attr:`session.url <fiftyone.core.session.Session.url>` property.
+    If you run :meth:`session.show() <fiftyone.core.session.Session.show>` in
+    multiple cells, only the most recently created App window will be active,
+    i.e., synced with the ``session`` object.
+
+    You can reactive an older cell by clicking `Activate` in the App window,
+    or by running the cell again. This will deactivate the previously active
+    cell.
+
+Opening the App in a dedicated tab
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If you are working from a Jupyter notebook, you can open the App in a separate
+browser tab rather than working with it in cell output(s).
+
+To do this, pass the ``auto=False`` flag to
+:meth:`launch_app() <fiftyone.core.session.launch_app>` when you launch the
+App and then call
+:meth:`session.open_tab() <fiftyone.core.session.Session.open_tab>`:
+
+.. code-block:: python
+    :linenos:
+
+    # Launch the App in a dedicated browser tab
+    session = fo.launch_app(dataset, auto=False)
+    session.open_tab()
+
+Using the desktop App
+~~~~~~~~~~~~~~~~~~~~~
+
+If you are working from a Jupyter notebook on a machine with the
+:ref:`FiftyOne Desktop App <installing-fiftyone-desktop>` installed, you can
+optionally open the desktop App rather than working with the App in cell
+output(s).
+
+To do this, pass the ``desktop=True`` flag to
+:meth:`launch_app() <fiftyone.core.session.launch_app>`:
+
+.. code-block:: python
+    :linenos:
+
+    # Creates a session and launches the desktop App
+    session = fo.launch_app(dataset, desktop=True)
 
 .. _cloud-storage:
 

--- a/docs/source/environments/index.rst
+++ b/docs/source/environments/index.rst
@@ -171,9 +171,9 @@ will be automatically opened in the output of the current cell.
     Only the most recently opened App window will be active, i.e, synced with
     the ``session`` object.
 
-    You can reactive an older cell by clicking `Activate` in the App window,
-    or by running the cell again. This will deactivate the previously active
-    cell.
+    You can reactivate an older cell by clicking the link in the deactivated
+    App window, or by running the cell again. This will deactivate the
+    previously active cell.
 
 Manually controlling App instances
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -194,8 +194,7 @@ When ``auto=False`` is provided, a new App window is created only when you call
 .. code-block:: python
     :linenos:
 
-    # Update the session's view
-    # No App window is created
+    # Update the session's view; no App windows is created
     session.view = dataset.take(10)
 
     # In another cell
@@ -212,9 +211,9 @@ it will stay in-sync with your session whenever it is active.
     multiple cells, only the most recently created App window will be active,
     i.e., synced with the ``session`` object.
 
-    You can reactive an older cell by clicking `Activate` in the App window,
-    or by running the cell again. This will deactivate the previously active
-    cell.
+    You can reactivate an older cell by clicking the link in the deactivated
+    App window, or by running the cell again. This will deactivate the
+    previously active cell.
 
 Opening the App in a dedicated tab
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/source/faq/index.rst
+++ b/docs/source/faq/index.rst
@@ -40,47 +40,17 @@ FiftyOne in all common local, remote, cloud, and notebook environments.
 
 .. _faq-notebook-support:
 
-Can I run this in a notebook?
------------------------------
+Can I use FiftyOne in a notebook?
+---------------------------------
 
 Yes! FiftyOne supports both `Jupyter Notebooks <https://jupyter.org>`_ and
 `Google Colab Notebooks <https://colab.research.google.com>`_.
 
-All the usual FiftyOne commands can be run in notebook environments. The only
-difference is that you call
-:meth:`session.show() <fiftyone.core.session.Session.show>` to open the App
-in the output of a cell.
+All the usual FiftyOne commands can be run in notebook environments, and the
+App will launch/update in the output of your notebook cells!
 
-For example, a typical workflow is:
-
-.. code-block:: python
-    :linenos:
-
-    import fiftyone as fo
-
-    # Load a FiftyOne dataset
-    dataset = fo.load_dataset(...)
-
-    # Create an App session
-    session = fo.Session(dataset)
-
-.. code-block:: python
-    :linenos:
-
-    # Open the App in this cell's output
-    session.show()
-
-.. code-block:: python
-    :linenos:
-
-    # Updates the App in the prior cell's output
-    session.view = dataset.take(10)
-
-.. note::
-
-    If you run :meth:`session.show() <fiftyone.core.session.Session.show>` in
-    multiple cells, only the most recent instance will be connected to your
-    |Session| object.
+Check out the :ref:`notebook environment guide <notebooks>` for more
+information about running FiftyOne in notebooks.
 
 .. _faq-remote-server-data:
 

--- a/docs/source/getting_started/install.rst
+++ b/docs/source/getting_started/install.rst
@@ -46,14 +46,6 @@ are using, then run:
 
    pip install fiftyone
 
-.. note::
-
-    If you run into install errors, you should upgrade these packages and try
-    again:
-
-    `pip install --upgrade pip setuptools wheel`
-
-
 This will install FiftyOne and all of its dependencies, which may take some
 time. Once this has completed, you can verify that FiftyOne is installed in
 your virtual environment by importing the `fiftyone` package:
@@ -120,6 +112,16 @@ Troubleshooting
 
 If you run into any installation issues, review the suggestions below or check
 the :ref:`troubleshooting page <troubleshooting>` for more details.
+
+.. note::
+
+    Most installation issues can be fixed by upgrading some packages and then
+    rerunning the FiftyOne install:
+
+    .. code-block:: shell
+
+        pip install --upgrade pip setuptools wheel
+        pip install fiftyone
 
 **Mac users:**
 

--- a/docs/source/getting_started/install.rst
+++ b/docs/source/getting_started/install.rst
@@ -44,8 +44,15 @@ are using, then run:
 
 .. code-block:: shell
 
-   pip install --upgrade pip setuptools wheel
    pip install fiftyone
+
+.. note::
+
+    If you run into install errors, you should upgrade these packages and try
+    again:
+
+    `pip install --upgrade pip setuptools wheel`
+
 
 This will install FiftyOne and all of its dependencies, which may take some
 time. Once this has completed, you can verify that FiftyOne is installed in

--- a/docs/source/getting_started/troubleshooting.rst
+++ b/docs/source/getting_started/troubleshooting.rst
@@ -6,6 +6,13 @@ Install Troubleshooting
 
 .. default-role:: code
 
+.. note::
+
+    Most errors raised by pip when installing can be fixed by upgrading
+    these packages:
+
+    `pip install --upgrade pip setuptools wheel`
+
 This page lists common issues encountered when installing FiftyOne and possible
 solutions. If you encounter an issue that this page doesn't help you resolve,
 feel free to

--- a/docs/source/getting_started/troubleshooting.rst
+++ b/docs/source/getting_started/troubleshooting.rst
@@ -6,18 +6,23 @@ Install Troubleshooting
 
 .. default-role:: code
 
-.. note::
-
-    Most errors raised by pip when installing can be fixed by upgrading
-    these packages:
-
-    `pip install --upgrade pip setuptools wheel`
-
 This page lists common issues encountered when installing FiftyOne and possible
 solutions. If you encounter an issue that this page doesn't help you resolve,
 feel free to
 `open an issue on GitHub <https://github.com/voxel51/fiftyone/issues/new?labels=bug&template=installation_issue_template.md&title=%5BSETUP-BUG%5D>`_
 or `contact us on Slack <https://join.slack.com/t/fiftyone-users/shared_invite/zt-gtpmm76o-9AjvzNPBOzevBySKzt02gg>`_.
+
+.. note::
+
+    Most installation issues can be fixed by upgrading some packages and then
+    rerunning the FiftyOne install.
+
+    Try this first before reading on:
+
+    .. code-block:: shell
+
+        pip install --upgrade pip setuptools wheel
+        pip install fiftyone
 
 Python/pip incompatibilities
 ----------------------------

--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -2119,7 +2119,7 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
                 )
                 fields = self.get_field_schema(include_private=True)
 
-        self._doc.reload()
+        self._reload()
 
     def _expand_frame_schema(self, frames):
         fields = self.get_frame_field_schema(include_private=True)
@@ -2188,6 +2188,9 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
                 continue
 
             field.validate(value)
+
+    def _reload(self):
+        self._doc.reload()
 
 
 class DoesNotExistError(Exception):

--- a/fiftyone/core/session.py
+++ b/fiftyone/core/session.py
@@ -137,9 +137,10 @@ def launch_app(
         logger.info(_REMOTE_INSTRUCTIONS.strip().format(_session.server_port))
     elif _session.desktop:
         logger.info(_APP_DESKTOP_MESSAGE.strip())
-    elif focx._get_context() != focx._NONE and not auto:
-        logger.info(_APP_NOTEBOOK_MESSAGE.strip())
-    elif focx._get_context() == focx._NONE:
+    elif focx._get_context() != focx._NONE:
+        if not auto:
+            logger.info(_APP_NOTEBOOK_MESSAGE.strip())
+    else:
         logger.info(_APP_WEB_MESSAGE.strip().format(port))
 
     return _session

--- a/fiftyone/core/session.py
+++ b/fiftyone/core/session.py
@@ -372,7 +372,7 @@ class Session(foc.HasClient):
     @_update_state
     def dataset(self, dataset):
         if dataset is not None:
-            dataset._doc.reload()
+            dataset._reload()
 
         self.state.dataset = dataset
         self.state.view = None
@@ -406,7 +406,7 @@ class Session(foc.HasClient):
         self.state.view = view
         if view is not None:
             self.state.dataset = self.state.view._dataset
-            self.state.dataset._doc.reload()
+            self.state.dataset._reload()
 
         self.state.selected = []
         self.state.selected_objects = []

--- a/fiftyone/core/session.py
+++ b/fiftyone/core/session.py
@@ -249,11 +249,6 @@ class Session(foc.HasClient):
         _subscribed_sessions[port].add(self)
         super().__init__(self._port)
 
-        if view is not None:
-            self.view = view
-        elif dataset is not None:
-            self.dataset = dataset
-
         if desktop is None:
             if self._context == focx._NONE:
                 desktop = fo.config.desktop_app
@@ -261,8 +256,12 @@ class Session(foc.HasClient):
                 desktop = False
 
         self._desktop = desktop
-
         self._start_time = self._get_time()
+
+        if view is not None:
+            self.view = view
+        elif dataset is not None:
+            self.dataset = dataset
 
         if self._remote:
             if self._context != focx._NONE:

--- a/fiftyone/core/session.py
+++ b/fiftyone/core/session.py
@@ -292,7 +292,7 @@ class Session(foc.HasClient):
             else:
                 self.open()
         elif self._context != focx._NONE and self._auto:
-            self.show(self._height)
+            self.show()
         elif self._desktop:
             raise ValueError(
                 "Cannot open a Desktop App instance from a notebook. Use "
@@ -358,6 +358,10 @@ class Session(foc.HasClient):
         if self.dataset is not None:
             self.dataset._doc.reload()
         self.state.datasets = fod.list_datasets()
+        if height != 800:
+            pass
+        elif self._height != 800:
+            height = self._height
         display(self._port, height=height)
 
     @property

--- a/fiftyone/core/session.py
+++ b/fiftyone/core/session.py
@@ -143,9 +143,9 @@ def launch_app(
         logger.info(_REMOTE_INSTRUCTIONS.strip().format(_session.server_port))
     elif _session.desktop:
         logger.info(_APP_DESKTOP_MESSAGE.strip())
-    elif focx._get_context() != focx._NONE:
+    elif focx._get_context() != focx._NONE and not auto:
         logger.info(_APP_NOTEBOOK_MESSAGE.strip())
-    else:
+    elif focx._get_context() == focx._NONE:
         logger.info(_APP_WEB_MESSAGE.strip().format(port))
 
     return _session
@@ -167,9 +167,6 @@ def _update_state(func):
         result = func(self, *args, **kwargs)
         self.state.datasets = fod.list_datasets()
         self._update_state()
-        if self._context != focx._NONE and self._auto:
-            self.show()
-
         return result
 
     return wrapper
@@ -291,8 +288,6 @@ class Session(foc.HasClient):
                 self._app_service = fos.AppService(server_port=port)
             else:
                 self.open()
-        elif self._context != focx._NONE and self._auto:
-            self.show()
         elif self._desktop:
             raise ValueError(
                 "Cannot open a Desktop App instance from a notebook. Use "
@@ -384,6 +379,7 @@ class Session(foc.HasClient):
         self.state.selected = []
         self.state.selected_objects = []
         self.state.filters = {}
+        self._auto_show()
 
     @_update_state
     def clear_dataset(self):
@@ -415,6 +411,7 @@ class Session(foc.HasClient):
         self.state.selected = []
         self.state.selected_objects = []
         self.state.filters = {}
+        self._auto_show()
 
     @_update_state
     def clear_view(self):
@@ -422,6 +419,7 @@ class Session(foc.HasClient):
         session, if any.
         """
         self.state.view = None
+        self._auto_show()
 
     @property
     def selected(self):
@@ -462,7 +460,7 @@ class Session(foc.HasClient):
     def refresh(self):
         """Refreshes the App, reloading the current dataset/view."""
         # @todo achieve same behavoir as if CTRL + R were pressed in the App
-        pass
+        self._auto_show()
 
     def open(self):
         """Opens the session.
@@ -555,6 +553,10 @@ class Session(foc.HasClient):
     def _update_state(self):
         # see fiftyone.core.client if you would like to understand this
         self.state = self.state
+
+    def _auto_show(self):
+        if self._context != focx._NONE and self._auto:
+            self.show()
 
 
 def display(port=None, height=None):

--- a/fiftyone/core/session.py
+++ b/fiftyone/core/session.py
@@ -315,7 +315,8 @@ class Session(foc.HasClient):
             RuntimeError: if this command is run in a non-notebook environment
         """
         if self._context == focx._NONE:
-            raise RuntimeError("Cannot show App in a non-notebook environment")
+            logger.warn("`Session.show()` is a no-op outside of notebooks")
+            return
         if self.dataset is not None:
             self.dataset._doc.reload()
         self.state.datasets = fod.list_datasets()

--- a/fiftyone/utils/quickstart.py
+++ b/fiftyone/utils/quickstart.py
@@ -17,7 +17,13 @@ _EXIT = os.environ.get("FIFTYONE_EXIT", False)
 
 
 def quickstart(
-    interactive=True, video=False, port=5151, remote=False, desktop=None
+    interactive=True,
+    video=False,
+    port=5151,
+    remote=False,
+    desktop=None,
+    auto=True,
+    height=800,
 ):
     """Runs the FiftyOne quickstart.
 
@@ -34,6 +40,11 @@ def quickstart(
         desktop (None): whether to launch the App in the browser (False) or as
             a desktop App (True). If None, ``fiftyone.config.desktop_app`` is
             used. Not applicable to notebook contexts (e.g., Jupyter and Colab)
+        auto (True): whether to automatically show a new App window
+            whenever the state of the session is updated. Only applicable
+            in notebook contexts
+        height (800): a height, in pixels, for the App. Only applicable in
+            notebook contexts
 
     Returns:
         If ``interactive`` is ``True``, a tuple is returned containing:
@@ -45,12 +56,14 @@ def quickstart(
         If ``interactive`` is ``False``, ``None`` is returned
     """
     if video:
-        return _video_quickstart(interactive, port, remote, desktop)
+        return _video_quickstart(
+            interactive, port, remote, desktop, auto, height
+        )
     else:
-        return _quickstart(interactive, port, remote, desktop)
+        return _quickstart(interactive, port, remote, desktop, auto, height)
 
 
-def _quickstart(interactive, port, remote, desktop):
+def _quickstart(interactive, port, remote, desktop, auto, height):
     if interactive:
         print(_QUICKSTART_GUIDE % (_FILTER_DETECTIONS_IN_PYTHON))
     else:
@@ -58,7 +71,12 @@ def _quickstart(interactive, port, remote, desktop):
 
     dataset = fozd.load_zoo_dataset("quickstart")
     session = fos.launch_app(
-        dataset=dataset, port=port, remote=remote, desktop=desktop
+        dataset=dataset,
+        port=port,
+        remote=remote,
+        desktop=desktop,
+        auto=auto,
+        height=height,
     )
 
     if interactive:
@@ -70,12 +88,17 @@ def _quickstart(interactive, port, remote, desktop):
     return None
 
 
-def _video_quickstart(interactive, port, remote, desktop):
+def _video_quickstart(interactive, port, remote, desktop, auto, height):
     print(_VIDEO_QUICKSTART_GUIDE)
 
     dataset = fozd.load_zoo_dataset("quickstart-video")
     session = fos.launch_app(
-        dataset=dataset, port=port, remote=remote, desktop=desktop
+        dataset=dataset,
+        port=port,
+        remote=remote,
+        desktop=desktop,
+        auto=auto,
+        height=height,
     )
 
     if interactive:

--- a/fiftyone/utils/quickstart.py
+++ b/fiftyone/utils/quickstart.py
@@ -39,7 +39,7 @@ def quickstart(
             should not be attempted
         desktop (None): whether to launch the App in the browser (False) or as
             a desktop App (True). If None, ``fiftyone.config.desktop_app`` is
-            used. Not applicable to notebook contexts (e.g., Jupyter and Colab)
+            used. Not applicable to notebook contexts
         auto (True): whether to automatically show a new App window
             whenever the state of the session is updated. Only applicable
             in notebook contexts

--- a/fiftyone/utils/uid.py
+++ b/fiftyone/utils/uid.py
@@ -10,15 +10,6 @@ import uuid
 import fiftyone.constants as foc
 
 
-_TRACKING_NOTE = """
-FiftyOne tracks UUID based import and App usage by default. We are a small team
-looking to grow, and usage data is critical to that end.
-
-To disable tracking, use the `FIFTYONE_DO_NOT_TRACK=true` environment
-variable.
-"""
-
-
 def _get_user_id():
     """Gets the UUID of the current user
 
@@ -39,6 +30,5 @@ def _get_user_id():
         with open(uid_path, "w") as f:
             f.write(str(uuid.uuid4()))
 
-        print(_TRACKING_NOTE)
         return read(), True
     return read(), False


### PR DESCRIPTION
* Adds `auto` and `height` kwargs to `Session()` and `launch_app`.
* Setting `session.view` or `session.dataset` (and `session.clear_view()`) shows the App when `auto` is `True` in a notebook.
* Moved `pip`, `setuptools`, and `wheel` upgrade steps to notes in installation docs
