### PR TITLE
Making default App port configurable via fiftyone config

### DIFF
--- a/docs/source/cli/index.rst
+++ b/docs/source/cli/index.rst
@@ -658,14 +658,14 @@ Launch the FiftyOne App.
 
 .. code-block:: text
 
-    fiftyone app launch [-h] [-p PORT] [-r] NAME
+    fiftyone app launch [-h] [-p PORT] [-r] [-a] [NAME]
 
 **Arguments**
 
 .. code-block:: text
 
     positional arguments:
-      NAME                  the name of the dataset to open
+      NAME                  the name of a dataset to open
 
     optional arguments:
       -h, --help            show this help message and exit
@@ -677,13 +677,23 @@ Launch the FiftyOne App.
 
 .. code-block:: shell
 
-    # Launch the App with the given dataset
+    # Launch the App
+    fiftyone app launch
+
+.. code-block:: shell
+
+    # Launch the App with the given dataset loaded
     fiftyone app launch <name>
 
 .. code-block:: shell
 
     # Launch a remote App session
-    fiftyone app launch <name> --remote
+    fiftyone app launch ... --remote
+
+.. code-block:: shell
+
+    # Launch a desktop App session
+    fiftyone app launch ... --desktop
 
 .. _cli-fiftyone-app-view:
 

--- a/docs/source/environments/index.rst
+++ b/docs/source/environments/index.rst
@@ -103,19 +103,23 @@ In a local terminal, run the command:
 .. code-block:: shell
 
     # On local machine
-    fiftyone app connect --destination <user>@<remote-ip-address> --port 5151 # (Optional) --ssh-key /path/to/key
-
-.. note::
-
-    If you are using :ref:`ssh keys instead of a password to login <cli-fiftyone-app-connect>` then you
-    can use the kwarg `--ssh-key`. Though if you are using this key
-    more often, `it is recommended to add it
-    <https://unix.stackexchange.com/a/494485>`_ to your `~/.ssh/config` as
-    the default `IdentityFile`.
+    fiftyone app connect --destination <user>@<remote-ip-address> --port 5151
 
 The above instructions assume that you used the default port `5151` when
 launching the remote session on the remote machine. If you used a custom port,
-then substitute the appropriate value in the local commands too.
+(or if you customized your default port via the ``default_app_port`` parameter
+of your :ref:`FiftyOne config <configuring-fiftyone>`), then substitute the
+appropriate value in the local commands too.
+
+.. note::
+
+    If you use ssh keys to connect to your remote machine, you can use the
+    optional `--ssh-key` argument of the
+    :ref:`fiftyone app connect <cli-fiftyone-app-connect>` command.
+
+    However, if you are using this key regularly,
+    `it is recommended <https://unix.stackexchange.com/a/494485>`_ to to add it
+    to your `~/.ssh/config` as the default `IdentityFile`.
 
 .. note::
 
@@ -335,20 +339,28 @@ on the cloud instance.
 .. code-block:: bash
 
     # On local machine
-    fiftyone app connect --destination <user>@<remote-ip-address> --port 5151 # (Optional) --ssh-key /path/to/key
+    fiftyone app connect --destination <user>@<remote-ip-address> --port 5151
 
 The above instructions assume that you used the default port `5151` when
 launching the remote session on the remote machine. If you used a custom port,
-then substitute the appropriate value in the local commands too.
+(or if you customized your default port via the ``default_app_port`` parameter
+of your :ref:`FiftyOne config <configuring-fiftyone>`), then substitute the
+appropriate value in the local commands too.
 
 .. note::
 
-    If you are using :ref:`ssh keys instead of a password to login <cli-fiftyone-app-connect>` then you
-    can use the kwarg `--ssh-key`. Though if you are using this key
-    more often, `it is recommended to add it
-    <https://unix.stackexchange.com/a/494485>`_ to your `~/.ssh/config` as
-    the default `IdentityFile`.
+    If you use ssh keys to connect to your remote machine, you can use the
+    optional `--ssh-key` argument of the
+    :ref:`fiftyone app connect <cli-fiftyone-app-connect>` command.
 
+    However, if you are using this key regularly,
+    `it is recommended <https://unix.stackexchange.com/a/494485>`_ to to add it
+    to your `~/.ssh/config` as the default `IdentityFile`.
+
+.. note::
+
+    You can use custom ports when launching remote sessions in order to serve
+    multiple remote sessions simultaneously.
 
 .. _google-cloud:
 
@@ -418,19 +430,28 @@ on the cloud instance.
 .. code-block:: bash
 
     # On local machine
-    fiftyone app connect --destination <user>@<remote-ip-address> --port 5151 # (Optional) --ssh-key /path/to/key
+    fiftyone app connect --destination <user>@<remote-ip-address> --port 5151
 
 The above instructions assume that you used the default port `5151` when
 launching the remote session on the remote machine. If you used a custom port,
-then substitute the appropriate value in the local commands too.
+(or if you customized your default port via the ``default_app_port`` parameter
+of your :ref:`FiftyOne config <configuring-fiftyone>`), then substitute the
+appropriate value in the local commands too.
 
 .. note::
 
-    If you are using :ref:`ssh keys instead of a password to login <cli-fiftyone-app-connect>` then you
-    can use the kwarg `--ssh-key`. Though if you are using this key
-    more often, `it is recommended to add it
-    <https://unix.stackexchange.com/a/494485>`_ to your `~/.ssh/config` as
-    the default `IdentityFile`.
+    If you use ssh keys to connect to your remote machine, you can use the
+    optional `--ssh-key` argument of the
+    :ref:`fiftyone app connect <cli-fiftyone-app-connect>` command.
+
+    However, if you are using this key regularly,
+    `it is recommended <https://unix.stackexchange.com/a/494485>`_ to to add it
+    to your `~/.ssh/config` as the default `IdentityFile`.
+
+.. note::
+
+    You can use custom ports when launching remote sessions in order to serve
+    multiple remote sessions simultaneously.
 
 .. _azure:
 
@@ -496,19 +517,28 @@ on the cloud instance.
 .. code-block:: bash
 
     # On local machine
-    fiftyone app connect --destination <user>@<remote-ip-address> --port 5151 # (Optional) --ssh-key /path/to/key
+    fiftyone app connect --destination <user>@<remote-ip-address> --port 5151
 
 The above instructions assume that you used the default port `5151` when
 launching the remote session on the remote machine. If you used a custom port,
-then substitute the appropriate value in the local commands too.
+(or if you customized your default port via the ``default_app_port`` parameter
+of your :ref:`FiftyOne config <configuring-fiftyone>`), then substitute the
+appropriate value in the local commands too.
 
 .. note::
 
-    If you are using :ref:`ssh keys instead of a password to login <cli-fiftyone-app-connect>` then you
-    can use the kwarg `--ssh-key`. Though if you are using this key
-    more often, `it is recommended to add it
-    <https://unix.stackexchange.com/a/494485>`_ to your `~/.ssh/config` as
-    the default `IdentityFile`.
+    If you use ssh keys to connect to your remote machine, you can use the
+    optional `--ssh-key` argument of the
+    :ref:`fiftyone app connect <cli-fiftyone-app-connect>` command.
+
+    However, if you are using this key regularly,
+    `it is recommended <https://unix.stackexchange.com/a/494485>`_ to to add it
+    to your `~/.ssh/config` as the default `IdentityFile`.
+
+.. note::
+
+    You can use custom ports when launching remote sessions in order to serve
+    multiple remote sessions simultaneously.
 
 .. _compute-instance-setup:
 

--- a/docs/source/environments/index.rst
+++ b/docs/source/environments/index.rst
@@ -118,7 +118,7 @@ appropriate value in the local commands too.
     :ref:`fiftyone app connect <cli-fiftyone-app-connect>` command.
 
     However, if you are using this key regularly,
-    `it is recommended <https://unix.stackexchange.com/a/494485>`_ to to add it
+    `it is recommended <https://unix.stackexchange.com/a/494485>`_ to add it
     to your `~/.ssh/config` as the default `IdentityFile`.
 
 .. note::
@@ -354,7 +354,7 @@ appropriate value in the local commands too.
     :ref:`fiftyone app connect <cli-fiftyone-app-connect>` command.
 
     However, if you are using this key regularly,
-    `it is recommended <https://unix.stackexchange.com/a/494485>`_ to to add it
+    `it is recommended <https://unix.stackexchange.com/a/494485>`_ to add it
     to your `~/.ssh/config` as the default `IdentityFile`.
 
 .. note::
@@ -445,7 +445,7 @@ appropriate value in the local commands too.
     :ref:`fiftyone app connect <cli-fiftyone-app-connect>` command.
 
     However, if you are using this key regularly,
-    `it is recommended <https://unix.stackexchange.com/a/494485>`_ to to add it
+    `it is recommended <https://unix.stackexchange.com/a/494485>`_ to add it
     to your `~/.ssh/config` as the default `IdentityFile`.
 
 .. note::
@@ -532,7 +532,7 @@ appropriate value in the local commands too.
     :ref:`fiftyone app connect <cli-fiftyone-app-connect>` command.
 
     However, if you are using this key regularly,
-    `it is recommended <https://unix.stackexchange.com/a/494485>`_ to to add it
+    `it is recommended <https://unix.stackexchange.com/a/494485>`_ to add it
     to your `~/.ssh/config` as the default `IdentityFile`.
 
 .. note::

--- a/docs/source/user_guide/app.rst
+++ b/docs/source/user_guide/app.rst
@@ -139,7 +139,9 @@ using either the Python library or the CLI.
         session = fo.launch_app(dataset, remote=True)  # optional: port=XXXX
 
     You can use the optional ``port`` parameter to choose the port of your
-    remote machine on which to serve the App. The default is ``5151``.
+    remote machine on which to serve the App. The default is ``5151``, which
+    can be customized via the ``default_app_port`` parameter of your
+    :ref:`FiftyOne config <configuring-fiftyone>`.
 
     Note that you can manipulate the `session` object on the remote machine as
     usual to programmatically interact with the App instance that you'll
@@ -157,7 +159,9 @@ using either the Python library or the CLI.
         fiftyone app launch <dataset-name> --remote  # optional: --port XXXX
 
     You can use the optional ``--port`` flag to choose the port of your
-    remote machine on which to serve the App. The default is ``5151``.
+    remote machine on which to serve the App. The default is ``5151``, which
+    can be customized via the ``default_app_port`` parameter of your
+    :ref:`FiftyOne config <configuring-fiftyone>`.
 
 .. _remote-app-local-machine:
 

--- a/docs/source/user_guide/config.rst
+++ b/docs/source/user_guide/config.rst
@@ -49,6 +49,8 @@ FiftyOne supports the configuration options described below:
 +------------------------------+-------------------------------------+-------------------------+----------------------------------------------------------------------------------------+
 | `default_video_ext`          | `FIFTYONE_DEFAULT_VIDEO_EXT`        | `.mp4`                  | The default video format to use when writing videos to disk.                           |
 +------------------------------+-------------------------------------+-------------------------+----------------------------------------------------------------------------------------+
+| `default_app_port`           | `FIFTYONE_DEFAULT_APP_PORT`         | `5151`                  | The default port to use to serve the :ref:`FiftyOne App <fiftyone-app>`.               |
++------------------------------+-------------------------------------+-------------------------+----------------------------------------------------------------------------------------+
 | `desktop_app`                | `FIFTYONE_DESKTOP_APP`              | `False`                 | Whether to launch the FiftyOne App in the browser (False) or as a desktop App (True)   |
 |                              |                                     |                         | by default. If True, the :ref:`FiftyOne Desktop App <installing-fiftyone-desktop>`     |
 |                              |                                     |                         | must be installed.                                                                     |
@@ -91,6 +93,7 @@ described in the next section) at any time via the Python library and the CLI.
         {
             "dataset_zoo_dir": "~/fiftyone",
             "dataset_zoo_manifest_paths": null,
+            "default_app_port": 5151,
             "default_batch_size": null,
             "default_dataset_dir": "~/fiftyone",
             "default_ml_backend": "torch",
@@ -122,6 +125,7 @@ described in the next section) at any time via the Python library and the CLI.
         {
             "dataset_zoo_dir": "~/fiftyone",
             "dataset_zoo_manifest_paths": null,
+            "default_app_port": 5151,
             "default_batch_size": null,
             "default_dataset_dir": "~/fiftyone",
             "default_ml_backend": "torch",

--- a/fiftyone/core/cli.py
+++ b/fiftyone/core/cli.py
@@ -786,20 +786,26 @@ class AppLaunchCommand(Command):
 
     Examples::
 
-        # Launch the App with the given dataset
+        # Launch the App
+        fiftyone app launch
+
+        # Launch the App with the given dataset loaded
         fiftyone app launch <name>
 
         # Launch a remote App session
-        fiftyone app launch <name> --remote
+        fiftyone app launch ... --remote
 
         # Launch a desktop App session
-        fiftyone app launch <name> --desktop
+        fiftyone app launch ... --desktop
     """
 
     @staticmethod
     def setup(parser):
         parser.add_argument(
-            "name", metavar="NAME", help="the name of the dataset to open",
+            "name",
+            metavar="NAME",
+            nargs="?",
+            help="the name of a dataset to open",
         )
         parser.add_argument(
             "-p",
@@ -827,7 +833,10 @@ class AppLaunchCommand(Command):
         # If desktop wasn't explicitly requested, fallback to default
         desktop = args.desktop or None
 
-        dataset = fod.load_dataset(args.name)
+        if args.name:
+            dataset = fod.load_dataset(args.name)
+        else:
+            dataset = None
 
         session = fos.launch_app(
             dataset=dataset,

--- a/fiftyone/core/cli.py
+++ b/fiftyone/core/cli.py
@@ -114,7 +114,7 @@ class QuickstartCommand(Command):
             "-p",
             "--port",
             metavar="PORT",
-            default=5151,
+            default=None,
             type=int,
             help="the port number to use",
         )
@@ -805,7 +805,7 @@ class AppLaunchCommand(Command):
             "-p",
             "--port",
             metavar="PORT",
-            default=5151,
+            default=None,
             type=int,
             help="the port number to use",
         )
@@ -969,7 +969,7 @@ class AppViewCommand(Command):
             "-p",
             "--port",
             metavar="PORT",
-            default=5151,
+            default=None,
             type=int,
             help="the port number to use",
         )
@@ -1086,7 +1086,7 @@ class AppConnectCommand(Command):
             "-p",
             "--port",
             metavar="PORT",
-            default=5151,
+            default=None,
             type=int,
             help="the remote port to connect to",
         )
@@ -1094,7 +1094,7 @@ class AppConnectCommand(Command):
             "-l",
             "--local-port",
             metavar="PORT",
-            default=5151,
+            default=None,
             type=int,
             help="the local port to use to serve the App",
         )
@@ -1115,6 +1115,9 @@ class AppConnectCommand(Command):
 
     @staticmethod
     def execute(parser, args):
+        remote_port = args.port or fo.config.default_app_port
+        local_port = args.local_port or fo.config.default_app_port
+
         if args.destination:
             if sys.platform.startswith("win"):
                 raise RuntimeError(
@@ -1134,7 +1137,7 @@ class AppConnectCommand(Command):
                 "-S",
                 control_path,
                 "-L",
-                "%d:127.0.0.1:%d" % (args.local_port, args.port),
+                "%d:127.0.0.1:%d" % (local_port, remote_port),
             ]
 
             if args.ssh_key:
@@ -1167,7 +1170,7 @@ class AppConnectCommand(Command):
         # If desktop wasn't explicitly requested, fallback to default
         desktop = args.desktop or None
 
-        session = fos.launch_app(port=args.local_port, desktop=desktop)
+        session = fos.launch_app(port=local_port, desktop=desktop)
 
         _watch_session(session)
 

--- a/fiftyone/core/config.py
+++ b/fiftyone/core/config.py
@@ -84,6 +84,12 @@ class FiftyOneConfig(EnvConfig):
             env_var="FIFTYONE_DEFAULT_VIDEO_EXT",
             default=".mp4",
         )
+        self.default_app_port = self.parse_int(
+            d,
+            "default_app_port",
+            env_var="FIFTYONE_DEFAULT_APP_PORT",
+            default=5151,
+        )
         self.desktop_app = self.parse_bool(
             d, "desktop_app", env_var="FIFTYONE_DESKTOP_APP", default=False,
         )

--- a/fiftyone/core/session.py
+++ b/fiftyone/core/session.py
@@ -79,7 +79,7 @@ call `session.wait()` to keep the session (and the script) alive.
 def launch_app(
     dataset=None,
     view=None,
-    port=5151,
+    port=None,
     remote=False,
     desktop=None,
     auto=True,
@@ -95,7 +95,8 @@ def launch_app(
             load
         view (None): an optional :class:`fiftyone.core.view.DatasetView` to
             load
-        port (5151): the port number to use
+        port (None): the port number to serve the App. If None,
+            ``fiftyone.config.default_app_port`` is used
         remote (False): whether this is a remote session, and opening the App
             should not be attempted
         desktop (None): whether to launch the App in the browser (False) or as
@@ -141,7 +142,7 @@ def launch_app(
         if not auto:
             logger.info(_APP_NOTEBOOK_MESSAGE.strip())
     else:
-        logger.info(_APP_WEB_MESSAGE.strip().format(port))
+        logger.info(_APP_WEB_MESSAGE.strip().format(_session.server_port))
 
     return _session
 
@@ -203,7 +204,8 @@ class Session(foc.HasClient):
             load
         view (None): an optional :class:`fiftyone.core.view.DatasetView` to
             load
-        port (5151): the port number to use
+        port (None): the port number to serve the App. If None,
+            ``fiftyone.config.default_app_port`` is used
         remote (False): whether this is a remote session, and opening the App
             should not be attempted
         desktop (None): whether to launch the App in the browser (False) or as
@@ -224,12 +226,15 @@ class Session(foc.HasClient):
         self,
         dataset=None,
         view=None,
-        port=5151,
+        port=None,
         remote=False,
         desktop=None,
         auto=True,
         height=800,
     ):
+        if port is None:
+            port = fo.config.default_app_port
+
         self._context = focx._get_context()
         self._port = port
         self._remote = remote

--- a/fiftyone/server/main.py
+++ b/fiftyone/server/main.py
@@ -27,7 +27,7 @@ import eta.core.utils as etau
 import eta.core.video as etav
 
 os.environ["FIFTYONE_SERVER"] = "1"
-from fiftyone import config
+import fiftyone as fo
 import fiftyone.core.aggregations as foa
 import fiftyone.constants as foc
 from fiftyone.core.expressions import ViewField as F
@@ -94,7 +94,7 @@ class FiftyOneHandler(RequestHandler):
         return {
             "version": foc.VERSION,
             "user_id": uid,
-            "do_not_track": config.do_not_track,
+            "do_not_track": fo.config.do_not_track,
             "dev_install": foc.DEV_INSTALL,
         }
 
@@ -365,7 +365,7 @@ class StateHandler(tornado.websocket.WebSocketHandler):
 
     @_catch_errors
     async def on_message(self, message):
-        """On message, call the associated event awaitable, with respect to 
+        """On message, call the associated event awaitable, with respect to
         the provided message type.
 
         Args:
@@ -640,7 +640,7 @@ class StateHandler(tornado.websocket.WebSocketHandler):
     def get_statistics_awaitables(cls, only=None):
         """Gets statistic awaitables that will send statistics to the relevant
         client(s) when executed
-    
+
         Args:
             only (None): a client to restrict the messages to
 
@@ -991,7 +991,7 @@ if __name__ == "__main__":
     etau.ensure_basedir(log_path)
     # pylint: disable=no-member
     parser = argparse.ArgumentParser()
-    parser.add_argument("--port", type=int, default=5151)
+    parser.add_argument("--port", type=int, default=fo.config.default_app_port)
     args = parser.parse_args()
     app = Application(debug=foc.DEV_INSTALL)
     app.listen(args.port)

--- a/fiftyone/utils/quickstart.py
+++ b/fiftyone/utils/quickstart.py
@@ -19,7 +19,7 @@ _EXIT = os.environ.get("FIFTYONE_EXIT", False)
 def quickstart(
     interactive=True,
     video=False,
-    port=5151,
+    port=None,
     remote=False,
     desktop=None,
     auto=True,
@@ -34,7 +34,8 @@ def quickstart(
         interactive (True): whether to launch the session asynchronously and
             return a session
         video (False): whether to launch a video dataset
-        port (5151): the port number to serve the App
+        port (None): the port number to serve the App. If None,
+            ``fiftyone.config.default_app_port`` is used
         remote (False): whether this is a remote session, and opening the App
             should not be attempted
         desktop (None): whether to launch the App in the browser (False) or as


### PR DESCRIPTION
Allows the default App port to be customized via your FiftyOne config:

```shell
fiftyone quickstart
# ... App launched. Point your web browser to http://localhost:5151

export FIFTYONE_DEFAULT_APP_PORT=2222
fiftyone quickstart
# ... App launched. Point your web browser to http://localhost:2222
```

Also allows the App to be launched via the CLI with no dataset loaded:

```shell
# Can use the UI to select the dataset to open
fiftyone app launch
```