### PR TITLE
Analytics fixes

### DIFF
--- a/fiftyone/__init__.py
+++ b/fiftyone/__init__.py
@@ -31,7 +31,7 @@ def _log_import_if_allowed():
     if config.do_not_track:
         return
 
-    if _os.environ.get("FIFTYONE_SERVER", False):
+    if _os.environ.get("FIFTYONE_DISABLE_SERVICES", False):
         return
 
     uid, first_import = _get_user_id()

--- a/fiftyone/constants.py
+++ b/fiftyone/constants.py
@@ -20,12 +20,6 @@ FIFTYONE_CONFIG_PATH = os.path.join(FIFTYONE_CONFIG_DIR, "config.json")
 BASE_DIR = os.path.dirname(FIFTYONE_DIR)
 RESOURCES_DIR = os.path.join(FIFTYONE_DIR, "resources")
 
-DEV_INSTALL = os.path.isdir(
-    os.path.normpath(
-        os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", ".git")
-    )
-)
-
 # Package metadata
 _META = metadata("fiftyone")
 NAME = _META["name"]
@@ -37,6 +31,17 @@ URL = _META["home-page"]
 LICENSE = _META["license"]
 VERSION_LONG = "%s v%s, %s" % (NAME, VERSION, AUTHOR)
 COPYRIGHT = "2017-%d, %s" % (datetime.now().year, AUTHOR)
+
+DEV_INSTALL = (
+    os.path.isdir(
+        os.path.normpath(
+            os.path.join(
+                os.path.dirname(os.path.abspath(__file__)), "..", ".git"
+            )
+        )
+    )
+    or "rc" in VERSION
+)
 
 # MongoDB setup
 try:

--- a/fiftyone/constants.py
+++ b/fiftyone/constants.py
@@ -32,16 +32,12 @@ LICENSE = _META["license"]
 VERSION_LONG = "%s v%s, %s" % (NAME, VERSION, AUTHOR)
 COPYRIGHT = "2017-%d, %s" % (datetime.now().year, AUTHOR)
 
-DEV_INSTALL = (
-    os.path.isdir(
-        os.path.normpath(
-            os.path.join(
-                os.path.dirname(os.path.abspath(__file__)), "..", ".git"
-            )
-        )
+DEV_INSTALL = os.path.isdir(
+    os.path.normpath(
+        os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", ".git")
     )
-    or "rc" in VERSION
 )
+RC_INSTALL = "rc" in VERSION
 
 # MongoDB setup
 try:
@@ -71,4 +67,4 @@ except ImportError:
 # Analytics
 UA_DEV = "UA-141773487-10"
 UA_PROD = "UA-141773487-9"
-UA_ID = UA_DEV if DEV_INSTALL else UA_PROD
+UA_ID = UA_DEV if DEV_INSTALL or RC_INSTALL else UA_PROD

--- a/fiftyone/server/main.py
+++ b/fiftyone/server/main.py
@@ -95,7 +95,7 @@ class FiftyOneHandler(RequestHandler):
             "version": foc.VERSION,
             "user_id": uid,
             "do_not_track": fo.config.do_not_track,
-            "dev_install": foc.DEV_INSTALL,
+            "dev_install": foc.DEV_INSTALL or foc.RC_INSTALL,
         }
 
 


### PR DESCRIPTION
This PR ensures new COLAB import events are recorded. Currently, when first importing in COLAB, the DB service would register an new NONE import event, and then a returning COLAB import event would register. In general, almost all COLAB import events will be new.

It also removes on redundant import events from services, in general.

* Restricts import events to the main process by skipping service processes
* Changes release candidate installs to be considered development installs with respect to GA tracking