### PR TITLE
Firefox tweaks

### DIFF
--- a/app/src/components/CheckboxGrid.tsx
+++ b/app/src/components/CheckboxGrid.tsx
@@ -66,7 +66,7 @@ const Body = styled.div`
     .MuiTypography-body1.with-checkbox {
       max-width: calc(100% - 24px);
     }
-
+    overflow: "hidden",
     .MuiCheckbox-root {
       padding: 0;
 
@@ -103,7 +103,7 @@ const Body = styled.div`
       span.name {
         padding: 0 4px;
         white-space: nowrap;
-        overflow-x: hidden;
+        overflow: hidden;
         text-overflow: ellipsis;
         flex-grow: 1;
         max-width: 100%;

--- a/app/src/components/SampleModal.tsx
+++ b/app/src/components/SampleModal.tsx
@@ -122,7 +122,12 @@ const Container = styled.div`
       padding-bottom: 1em;
       flex-grow: 1;
       overflow-y: auto;
+      scrollbar-width: none;
+      @-moz-document url-prefix() {
+        padding-right: 16px;
+      }
     }
+
     .sidebar-content::-webkit-scrollbar {
       width: 0px;
       background: transparent;

--- a/app/src/components/ViewBar/ViewBar.tsx
+++ b/app/src/components/ViewBar/ViewBar.tsx
@@ -28,6 +28,7 @@ const ViewBarDiv = styled.div`
   padding: 0 0.25rem;
   display: flex;
   overflow-x: scroll;
+  scrollbar-width: none;
 
   &::-webkit-scrollbar {
     width: 0px;

--- a/app/src/components/ViewBar/ViewStage/SearchResults.tsx
+++ b/app/src/components/ViewBar/ViewStage/SearchResults.tsx
@@ -74,6 +74,7 @@ const SearchResultsDiv = animated(styled.div`
   z-index: 801;
   max-height: 328px;
   overflow-y: scroll;
+  scrollbar-width: none;
 
   &::-webkit-scrollbar {
     width: 0px;

--- a/app/src/components/utils.tsx
+++ b/app/src/components/utils.tsx
@@ -71,9 +71,13 @@ export const scrollbarStyles = ({ theme }) => `
 ::-webkit-scrollbar {
   width: 16px;
 }
+scrollbar-width: none;
+@-moz-document url-prefix() {
+  padding-right: 16px;
+}
 
 ::-webkit-scrollbar-track {
-  border: solid 4px transparent;
+  border: solid 4px transparent ${theme.fontDarkest};
 }
 
 ::-webkit-scrollbar-thumb {

--- a/app/src/containers/App.tsx
+++ b/app/src/containers/App.tsx
@@ -26,6 +26,7 @@ const Body = styled.div`
   flex-grow: 1;
   display: flex;
   flex-direction: column;
+  padding-right: 0 !important;
 `;
 
 const GA = () => {


### PR DESCRIPTION
Proposing we hide scrollbars in firefox until a proper JS library can be used. Things are fairly consistent beyond scrollbars.

Before:
![Screenshot from 2021-01-06 19-34-01](https://user-images.githubusercontent.com/19821840/103844116-6f523480-5056-11eb-9920-57d191a56b7a.png)
After:
![Screenshot from 2021-01-06 19-34-46](https://user-images.githubusercontent.com/19821840/103844114-6e210780-5056-11eb-8c03-da16a71ea783.png)

