### PR TITLE
Index all datasets by _rand to enable efficient shuffling

### DIFF
--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -2520,8 +2520,11 @@ def _create_dataset(name, persistent=False, media_type=None):
 
 def _create_indexes(sample_collection_name, frames_collection_name):
     conn = foo.get_db_conn()
+
     collection = conn[sample_collection_name]
     collection.create_index("filepath", unique=True)
+    collection.create_index("_rand")
+
     frames_collection = conn[frames_collection_name]
     frames_collection.create_index(
         [("sample_id", foo.ASC), ("frame_number", foo.ASC)]

--- a/fiftyone/migrations/revisions/v0_7_2.py
+++ b/fiftyone/migrations/revisions/v0_7_2.py
@@ -1,0 +1,24 @@
+"""
+FiftyOne v0.7.2 revision
+
+| Copyright 2017-2020, Voxel51, Inc.
+| `voxel51.com <https://voxel51.com/>`_
+|
+"""
+
+
+def up(db, dataset_name):
+    match_d = {"name": dataset_name}
+    dataset_dict = db.datasets.find_one(match_d)
+    sample_coll = db[dataset_dict["sample_collection_name"]]
+    sample_coll.create_index("_rand")
+
+
+def down(db, dataset_name):
+    match_d = {"name": dataset_name}
+    dataset_dict = db.datasets.find_one(match_d)
+    sample_coll = db[dataset_dict["sample_collection_name"]]
+    index_info = sample_coll.index_information()
+    index_map = {v["key"][0][0]: k for k, v in index_info.items()}
+    if "_rand" in index_map:
+        sample_coll.drop_index(index_map["_rand"])


### PR DESCRIPTION
Indexing all dataset by `_rand` enables `dataset.shuffle()` to be efficient regardless of the dataset size.

Previously, shuffling moderately-sized dataset like the validation split of BDD100k would result in MongoDB out-of-memory errors.
