### PR TITLE
Adding back support for indexing by embedded fields

### DIFF
--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -1795,7 +1795,7 @@ class SampleCollection(object):
         Indexes enable efficient sorting, merging, and other such operations.
 
         Args:
-            field: the field name
+            field: the field name or ``embedded.field.name``
             unique (False): whether to add a uniqueness constraint to the index
         """
         raise NotImplementedError("Subclass must implement create_index()")
@@ -1804,7 +1804,7 @@ class SampleCollection(object):
         """Drops the index on the given field.
 
         Args:
-            field: the field name
+            field: the field name or ``embedded.field.name``
         """
         raise NotImplementedError("Subclass must implement drop_index()")
 

--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -2107,10 +2107,10 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
         Indexes enable efficient sorting, merging, and other such operations.
 
         Args:
-            field: the field name
+            field: the field name or ``embedded.field.name``
             unique (False): whether to add a uniqueness constraint to the index
         """
-        if field not in self.get_field_schema():
+        if ("." not in field) and (field not in self.get_field_schema()):
             raise ValueError("Dataset has no field '%s'" % field)
 
         index_info = self._sample_collection.index_information()
@@ -2132,15 +2132,15 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
         """Drops the index on the given field.
 
         Args:
-            field: the field name
+            field: the field name or ``embedded.field.name``
         """
-        if field not in self.get_field_schema():
-            raise ValueError("Dataset has no field '%s'" % field)
-
         index_info = self._sample_collection.index_information()
         index_map = {v["key"][0][0]: k for k, v in index_info.items()}
 
         if field not in index_map:
+            if ("." not in field) and (field not in self.get_field_schema()):
+                raise ValueError("Dataset has no field '%s'" % field)
+
             raise ValueError("Dataset field '%s' is not indexed" % field)
 
         self._sample_collection.drop_index(index_map[field])

--- a/fiftyone/core/view.py
+++ b/fiftyone/core/view.py
@@ -261,7 +261,7 @@ class DatasetView(foc.SampleCollection):
         Indexes enable efficient sorting, merging, and other such operations.
 
         Args:
-            field: the field name
+            field: the field name or ``embedded.field.name``
             unique (False): whether to add a uniqueness constraint to the index
         """
         self._dataset.create_index(field, unique=unique)
@@ -270,7 +270,7 @@ class DatasetView(foc.SampleCollection):
         """Drops the index on the given field.
 
         Args:
-            field: the field name
+            field: the field name or ``embedded.field.name``
         """
         self._dataset.drop_index(field)
 

--- a/tests/unittests/view_tests.py
+++ b/tests/unittests/view_tests.py
@@ -690,6 +690,16 @@ class ViewStageTests(unittest.TestCase):
         self.dataset.add_sample(self.sample1)
         self.dataset.add_sample(self.sample2)
 
+    def _setUp_classification(self):
+        self.sample1["test_clf"] = fo.Classification(
+            label="friend", confidence=0.9
+        )
+        self.sample1.save()
+        self.sample2["test_clf"] = fo.Classification(
+            label="enemy", confidence=0.99
+        )
+        self.sample2.save()
+
     def _setUp_classifications(self):
         self.sample1["test_clfs"] = fo.Classifications(
             classifications=[
@@ -929,6 +939,13 @@ class ViewStageTests(unittest.TestCase):
         result = list(self.dataset.sort_by("filepath", reverse=True))
         self.assertIs(len(result), 2)
         self.assertEqual(result[0].id, self.sample2.id)
+
+    def test_sort_by_embedded(self):
+        self._setUp_classification()
+
+        result = list(self.dataset.sort_by("test_clf.label"))
+        self.assertEqual(result[0]["test_clf"].label, "enemy")
+        self.assertEqual(result[1]["test_clf"].label, "friend")
 
     def test_take(self):
         result = list(self.dataset.take(1))


### PR DESCRIPTION
Fixes https://github.com/voxel51/fiftyone/issues/760, and adds a unit test to ensure it stays this way.

```py
import fiftyone as fo
import fiftyone.zoo as foz

dataset = foz.load_zoo_dataset("cifar10", split="test")
session = fo.launch_app(dataset)
session.view = dataset.sort_by("ground_truth.label")  # now works again
```