### PR TITLE
Patch release 0.7.1.3

### DIFF
--- a/package/db/setup.py
+++ b/package/db/setup.py
@@ -35,7 +35,7 @@ MONGODB_BINARIES = ["mongod"]
 LINUX_DISTRO = os.environ.get("FIFTYONE_DB_BUILD_LINUX_DISTRO")
 
 
-VERSION = "0.3.0"
+VERSION = "0.2.1"
 
 
 def get_version():

--- a/setup.py
+++ b/setup.py
@@ -18,11 +18,11 @@ class BdistWheelCustom(bdist_wheel):
         # for a development installation
         self.distribution.install_requires += [
             "fiftyone-brain>=0.2,<0.3",
-            "fiftyone-db>=0.3.0,<0.4",
+            "fiftyone-db>=0.2.1,<0.3",
         ]
 
 
-VERSION = "0.7.1.2"
+VERSION = "0.7.1.3"
 
 
 def get_version():


### PR DESCRIPTION
Resolves #765 as much as possible.

Publishing `fiftyone-db` version `0.3.0` as version `0.2.1` allows a downgrade from `fiftyone` version `0.7.1` to version `0.7.0` to retain the new version of mongodb (4.4). This prevents the issue in #765.

`fiftyone` versions `0.7.1`, `0.7.1.1`, and `0.7.1.2` will continue be affected by #765 unless the user upgrades to `0.7.1.3` before downgrading to `0.7.0`.

This should have been the original requirements scheme, my mistake. Note that this has nothing to do with running admin migrations, as admin migrations were just introduced in `0.7.1`. The downgrade will never be run. It is merely opportunistic versioning, as previous versions of `fiftyone` can use mongodb 4.4 without issue.