### PR TITLE
Fix label mistakes tutorial

### DIFF
--- a/docs/source/tutorials/label_mistakes.ipynb
+++ b/docs/source/tutorials/label_mistakes.ipynb
@@ -70,28 +70,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Cloning into 'PyTorch_CIFAR10'...\n",
-      "remote: Enumerating objects: 61, done.\u001b[K\n",
-      "remote: Counting objects: 100% (61/61), done.\u001b[K\n",
-      "remote: Compressing objects: 100% (44/44), done.\u001b[K\n",
-      "remote: Total 613 (delta 23), reused 42 (delta 17), pack-reused 552\u001b[K\n",
-      "Receiving objects: 100% (613/613), 6.58 MiB | 7.63 MiB/s, done.\n",
-      "Resolving deltas: 100% (206/206), done.\n",
-      "Downloading '1dGfpeFK_QG0kV-U6QDHMX2EOGXPqaNzu' to 'PyTorch_CIFAR10/cifar10_models/state_dicts/resnet50.pt'\n",
-      " 100% |████|  719.8Mb/719.8Mb [19.2s elapsed, 0s remaining, 34.0Mb/s]      \n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Download the software\n",
-    "!git clone https://github.com/huyvnphan/PyTorch_CIFAR10\n",
+    "!git clone --depth 1 --branch v2.1 https://github.com/huyvnphan/PyTorch_CIFAR10.git\n",
     "\n",
     "# Download the pretrained model (90MB)\n",
     "!eta gdrive download --public \\\n",


### PR DESCRIPTION
[PyTorch_CIFAR10](https://github.com/huyvnphan/PyTorch_CIFAR10) was recently updated and breaks the label mistakes tutorial when the `master` branch is used..

Cloning the repository at tag `v2.1` resolves the issue.