### PR TITLE
A couple small tweaks

### DIFF
--- a/docs/source/cli/index.rst
+++ b/docs/source/cli/index.rst
@@ -161,7 +161,7 @@ Tools for working with your FiftyOne config.
 
 .. code-block:: shell
 
-    # Print the location of your config
+    # Print the location of your config on disk (if one exists)
     fiftyone config --locate
 
 .. _cli-fiftyone-constants:

--- a/docs/source/user_guide/config.rst
+++ b/docs/source/user_guide/config.rst
@@ -149,14 +149,19 @@ described in the next section) at any time via the Python library and the CLI.
 Modifying your config
 ---------------------
 
-You can modify your FiftyOne config in any of the ways listed below.
+You can modify your FiftyOne config in a variety of ways. The following
+sections describe these options in detail.
 
-The order of precedence for config modifications is as follows:
+Order of precedence
+~~~~~~~~~~~~~~~~~~~
+
+The following order of precedence is used to assign values to your FiftyOne
+config settings at runtime:
 
 1. Config settings applied at runtime via
    :func:`fiftyone.core.config.set_config_settings`
 2. `FIFTYONE_XXX` environment variables
-3. Settings in your JSON config at `~/.fiftyone/config.json`
+3. Settings in your JSON config (`~/.fiftyone/config.json`)
 4. The default config values described in the table above
 
 Editing your JSON config
@@ -177,6 +182,11 @@ For example, a valid config JSON file is:
 
 When `fiftyone` is imported, any options from your JSON config are applied,
 as per the order of precedence described above.
+
+.. note::
+
+    You can customize the location from which your JSON config is read by
+    setting the `FIFTYONE_CONFIG_PATH` environment variable.
 
 Setting environment variables
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/fiftyone/core/cli.py
+++ b/fiftyone/core/cli.py
@@ -22,6 +22,7 @@ import eta.core.utils as etau
 
 import fiftyone as fo
 import fiftyone.constants as foc
+import fiftyone.core.config as focg
 import fiftyone.core.dataset as fod
 import fiftyone.core.session as fos
 import fiftyone.core.utils as fou
@@ -158,7 +159,7 @@ class ConfigCommand(Command):
         # Print a specific config field
         fiftyone config <field>
 
-        # Print the location of your config
+        # Print the location of your config on disk (if one exists)
         fiftyone config --locate
     """
 
@@ -177,13 +178,11 @@ class ConfigCommand(Command):
     @staticmethod
     def execute(parser, args):
         if args.locate:
-            if os.path.isfile(foc.FIFTYONE_CONFIG_PATH):
-                print(foc.FIFTYONE_CONFIG_PATH)
+            config_path = focg.locate_config()
+            if os.path.isfile(config_path):
+                print(config_path)
             else:
-                print(
-                    "No config file found at '%s'.\n"
-                    % foc.FIFTYONE_CONFIG_PATH
-                )
+                print("No config file found at '%s'" % config_path)
 
             return
 

--- a/fiftyone/core/config.py
+++ b/fiftyone/core/config.py
@@ -162,15 +162,43 @@ class FiftyOneConfig(EnvConfig):
             self.default_ml_backend = self.default_ml_backend.lower()
 
 
+def locate_config():
+    """Returns the path to the FiftyOne config on disk.
+
+    The default location is ``~/.fiftyone/config.json``, but you can override
+    this path by setting the ``FIFTYONE_CONFIG_PATH`` environment variable.
+
+    Note that a config file may not actually exist on disk in the default
+    location, in which case the default config settings will be used.
+
+    Returns:
+        the path to the config
+
+    Raises:
+        OSError: if the FiftyOne config path has been customized but the file
+            does not exist on disk
+    """
+    if "FIFTYONE_CONFIG_PATH" not in os.environ:
+        return foc.FIFTYONE_CONFIG_PATH
+
+    config_path = os.environ["FIFTYONE_CONFIG_PATH"]
+    if not os.path.isfile(config_path):
+        raise OSError("Config file '%s' not found" % config_path)
+
+    return config_path
+
+
 def load_config():
     """Loads the FiftyOne config.
 
     Returns:
         a ``fiftyone.config.FiftyOneConfig`` instance
     """
-    # If a config file is not found on disk, the default config is created by
-    # calling `FiftyOneConfig()`
-    return FiftyOneConfig.from_json(foc.FIFTYONE_CONFIG_PATH)
+    config_path = locate_config()
+    if os.path.isfile(config_path):
+        return FiftyOneConfig.from_json(config_path)
+
+    return FiftyOneConfig({})
 
 
 def set_config_settings(**kwargs):

--- a/fiftyone/zoo/datasets/__init__.py
+++ b/fiftyone/zoo/datasets/__init__.py
@@ -206,6 +206,9 @@ def load_zoo_dataset(
         if splits is not None:
             dataset_name += "-" + "-".join(splits)
 
+        if "max_samples" in kwargs:
+            dataset_name += "-%s" % kwargs["max_samples"]
+
     if fo.dataset_exists(dataset_name):
         if not drop_existing_dataset:
             logger.info(


### PR DESCRIPTION
A couple small tweaks here:
- Allow FiftyOne config path to be customized by setting the `FIFTYONE_CONFIG_PATH` environment variable
- If `max_samples` is provided to `foz.load_zoo_dataset()`, include this in the dataset's default name to avoid clashing with other copies of the dataset that may have been loaded

The latter change is a small convenience for those that often experience the workflow below

```py
import fiftyone.zoo as foz

# I've already done this
dataset = foz.load_zoo_dataset("coco-2017", split="validation")
dataset.persistent = True
dataset.name  # "coco-2017-validation"

# THIS PR: Load just a few samples temporarily for prototyping, separately
# from the existing `coco-2017-validation` dataset
dataset = foz.load_zoo_dataset(
    "coco-2017",
    split="validation",
    max_samples=100,
)

# PREVIOUSLY: I had to type extra characters to achive this
dataset = foz.load_zoo_dataset(
    "coco-2017",
    split="validation",
    dataset_name="extra-characters-to-type",
    max_samples=100,
)
```