### PR TITLE
Adding support for checking whether a field exists

### DIFF
--- a/fiftyone/core/expressions.py
+++ b/fiftyone/core/expressions.py
@@ -92,6 +92,9 @@ class ViewExpression(object):
         Returns:
             a :class:`ViewExpression`
         """
+        if other is None:
+            return ~self.exists()
+
         return ViewExpression({"$eq": [self, other]})
 
     def __ge__(self, other):
@@ -157,7 +160,20 @@ class ViewExpression(object):
         Returns:
             a :class:`ViewExpression`
         """
+        if other is None:
+            return self.exists()
+
         return ViewExpression({"$ne": [self, other]})
+
+    def exists(self):
+        """Creates an expression that returns a boolean indicating whether the
+        expression, which must resolve to a field, exists and is not None.
+
+        Returns:
+            a :class:`ViewExpression`
+        """
+        # https://stackoverflow.com/a/25515046
+        return ViewExpression({"$gt": [self, None]})
 
     # Logical expression operators ############################################
 


### PR DESCRIPTION
Allows for checking whether fields exist and are not None in view operations.

Previously this didn't work as expected due to subtleties in how MongoDB treats comparison with `null`.

```py
import fiftyone as fo
from fiftyone import ViewField as F

dataset = fo.Dataset()

dataset.add_samples(
    [
        fo.Sample(
            filepath="/path/to/image1.png",
            classification=fo.Classification(label="cat"),
            detections=fo.Detections(
                detections=[
                    fo.Detection(label="fox", confidence=0.5),
                    fo.Detection(label="squirrel", confidence=0.7),
                ]
            ),
        ),
        fo.Sample(
            filepath="/path/to/image2.png",
            classification=fo.Classification(label="dog", confidence=0.9),
            detections=fo.Detections(
                detections=[
                    fo.Detection(label="cow", confidence=0.3),
                    fo.Detection(label="emu"),
                ]
            ),
        ),
    ]
)

dataset.match(F("classification.confidence") == None).select_fields("classification").head()
dataset.match(F("classification.confidence") != None).select_fields("classification").head()

dataset.filter_labels("detections", F("confidence") == None).select_fields("detections").head()
dataset.filter_labels("detections", F("confidence") != None).select_fields("detections").head()
```