### PR TITLE
Declaring float type of bounding box coordinates

### DIFF
--- a/fiftyone/core/labels.py
+++ b/fiftyone/core/labels.py
@@ -328,7 +328,7 @@ class Detection(ImageLabel, _HasID, _HasAttributes):
     meta = {"allow_inheritance": True}
 
     label = fof.StringField()
-    bounding_box = fof.ListField()
+    bounding_box = fof.ListField(fof.FloatField())
     mask = fof.ArrayField()
     confidence = fof.FloatField()
     index = fof.IntField()


### PR DESCRIPTION
Per our documentation, bounding box coordinates are floats in `[0, 1] x [0, 1]`, so we declare as such in the data model.