### PR TITLE
Adds HistogramValues aggregation stage and exposes aggregations directly on SampleCollection

### DIFF
--- a/docs/source/user_guide/using_datasets.rst
+++ b/docs/source/user_guide/using_datasets.rst
@@ -623,8 +623,8 @@ dataset splits or mark low quality images:
         ]
     )
 
-    print(dataset.get_tags())
-    # {"test", "low_quality", "train"}
+    print(dataset.distinct("tags").values)
+    # ["test", "low_quality", "train"]
 
 The `tags` field can be treated like a standard Python `list`:
 

--- a/docs/source/user_guide/using_views.rst
+++ b/docs/source/user_guide/using_views.rst
@@ -53,8 +53,8 @@ You can access specific information about a view in the natural ways:
     len(view)
     # 10000
 
-    view.get_tags()
-    # ['test']
+    view.media_type
+    # "image"
 
 .. note::
 

--- a/fiftyone/__public__.py
+++ b/fiftyone/__public__.py
@@ -19,6 +19,7 @@ from .core.aggregations import (
     CountValues,
     Distinct,
     DistinctLabels,
+    HistogramValues,
 )
 from .core.dataset import (
     Dataset,

--- a/fiftyone/__public__.py
+++ b/fiftyone/__public__.py
@@ -88,6 +88,32 @@ from .core.models import (
     ModelManager,
 )
 from .core.sample import Sample
+from .core.stages import (
+    Exclude,
+    ExcludeFields,
+    ExcludeObjects,
+    Exists,
+    FilterField,
+    FilterLabels,
+    FilterClassifications,
+    FilterDetections,
+    FilterPolylines,
+    FilterKeypoints,
+    Limit,
+    LimitLabels,
+    MapLabels,
+    Match,
+    MatchTag,
+    MatchTags,
+    Mongo,
+    Shuffle,
+    Select,
+    SelectFields,
+    SelectObjects,
+    Skip,
+    SortBy,
+    Take,
+)
 from .core.session import (
     close_app,
     launch_app,

--- a/fiftyone/core/aggregations.py
+++ b/fiftyone/core/aggregations.py
@@ -411,8 +411,8 @@ class CountResult(AggregationResult):
 
 
 class CountLabels(Aggregation):
-    """Computes a histogram of ``label`` values in a
-    :class:`fiftyone.core.labels.Label` field of a collection.
+    """Counts the ``label`` values in a :class:`fiftyone.core.labels.Label`
+    field of a collection.
 
     Examples::
 

--- a/fiftyone/core/aggregations.py
+++ b/fiftyone/core/aggregations.py
@@ -7,7 +7,10 @@ Aggregations.
 """
 from bson import ObjectId
 
+import numpy as np
+
 import eta.core.serial as etas
+import eta.core.utils as etau
 
 import fiftyone.core.fields as fof
 import fiftyone.core.labels as fol
@@ -75,6 +78,7 @@ class Aggregation(object):
         else:
             field_name = self._field_name
             pipeline = []
+
         try:
             field = schema[field_name]
             path = "$%s" % field_name
@@ -87,7 +91,8 @@ class Aggregation(object):
                 return "frames", "$frames", _unwind_frames()
 
             raise AggregationError(
-                "field `%s` does not exist on this Dataset" % self._field_name
+                "Field '%s' does not exist on dataset '%s'"
+                % (self._field_name, dataset.name)
             )
 
 
@@ -193,6 +198,7 @@ class Bounds(Aggregation):
         field, path, pipeline = self._get_field_path_pipeline(
             schema, frame_schema, dataset
         )
+
         if isinstance(field, fof.ListField) and isinstance(
             field.field, _NUMERIC_FIELDS
         ):
@@ -202,29 +208,26 @@ class Bounds(Aggregation):
         elif isinstance(field, fof.ListField):
             raise AggregationError(
                 "Unsupported field '%s' (%s). You can only compute bounds of "
-                "a ListField whose `field` type is explicitly declared as "
-                "numeric" % (self._field_name, field)
+                "a ListField whose `field` type is explicitly declared as a "
+                "numeric type: %s" % (self._field_name, field, _NUMERIC_FIELDS)
             )
         else:
             raise AggregationError(
                 "Unsupported field '%s' of type %s" % (self._field_name, field)
             )
 
-        pipeline += [
+        if unwind:
+            pipeline.append({"$unwind": path})
+
+        pipeline.append(
             {
                 "$group": {
                     "_id": None,
                     "min": {"$min": path},
                     "max": {"$max": path},
                 }
-            },
-        ]
-        if unwind:
-            pipeline = (
-                pipeline[: len(pipeline) - 1]
-                + [{"$unwind": path}]
-                + pipeline[len(pipeline) - 1 :]
-            )
+            }
+        )
 
         return pipeline
 
@@ -291,7 +294,9 @@ class ConfidenceBounds(Aggregation):
         if not isinstance(field, fof.EmbeddedDocumentField) or not issubclass(
             field.document_type, fol.Label
         ):
-            raise AggregationError("field '%s' is not a Label")
+            raise AggregationError(
+                "Field '%s' is not a Label" % self._field_name
+            )
 
         if field.document_type in _LABEL_LIST_FIELDS:
             path = "%s.%s" % (path, field.document_type.__name__.lower())
@@ -457,7 +462,9 @@ class CountLabels(Aggregation):
         if not isinstance(field, fof.EmbeddedDocumentField) or not issubclass(
             field.document_type, fol.Label
         ):
-            raise AggregationError("field '%s' is not a Label")
+            raise AggregationError(
+                "Field '%s' is not a Label" % self._field_name
+            )
 
         if field.document_type in _LABEL_LIST_FIELDS:
             path = "%s.%s" % (path, field.document_type.__name__.lower())
@@ -489,6 +496,180 @@ class CountLabelsResult(AggregationResult):
     def __init__(self, name, labels):
         self.name = name
         self.labels = labels
+
+
+class HistogramValues(Aggregation):
+    """Computes a histogram of the numeric values in a field or list field of a
+    collection.
+
+    Examples::
+
+        import fiftyone as fo
+
+        dataset = fo.load_dataset(...)
+
+        #
+        # Compute a histogram of values in the float field "uniqueness"
+        #
+
+        histogram_values = fo.HistogramValues(
+            "uniqueness", bins=50, range=(0, 1)
+        )
+        r = dataset.aggregate(histogram_values)
+        r.counts  # list of counts
+        r.edges  # list of bin edges
+
+    Args:
+        field_name: the name of the field to histogram
+        bins (None): can be either an integer number of bins to generate or a
+            monotonically increasing sequence specifying the bin edges to use.
+            By default, 10 bins are created. If ``bins`` is an integer and no
+            ``range`` is specified, bin edges are automatically distributed in
+            an attempt to evenly distribute the counts in each bin
+        range (None): a ``(lower, upper)`` tuple specifying a range in which to
+            generate equal-width bins. Only applicable when ``bins`` is an
+            integer
+    """
+
+    def __init__(self, field_name, bins=None, range=None):
+        super().__init__(field_name)
+        self.bins = bins
+        self.range = range
+
+        self._bins = None
+        self._edges = None
+        self._parse_args()
+
+    def _parse_args(self):
+        if self.bins is None:
+            bins = 10
+        else:
+            bins = self.bins
+
+        if etau.is_numeric(bins):
+            if self.range is None:
+                # Automatic bins
+                self._bins = bins
+                return
+
+            # Linearly-spaced bins within `range`
+            self._edges = list(
+                np.linspace(self.range[0], self.range[1], bins + 1)
+            )
+            return
+
+        # User-provided bin edges
+        self._edges = list(bins)
+
+    def _get_default_result(self):
+        return HistogramValuesResult(self._field_name, [], [], 0)
+
+    def _get_output_field(self, *args):
+        return "%s-histogram-values" % self._field_name_path
+
+    def _get_result(self, d):
+        if self._edges is not None:
+            return self._get_result_edges(d)
+
+        return self._get_result_auto(d)
+
+    def _get_result_edges(self, d):
+        _edges_array = np.array(self._edges)
+        edges = list(_edges_array)
+        counts = [0] * (len(edges) - 1)
+        other = 0
+        for di in d["bins"]:
+            left = di["_id"]
+            if left == "other":
+                other = di["count"]
+            else:
+                idx = np.abs(_edges_array - left).argmin()
+                counts[idx] = di["count"]
+
+        return HistogramValuesResult(self._field_name, counts, edges, other)
+
+    def _get_result_auto(self, d):
+        counts = []
+        edges = []
+        for di in d["bins"]:
+            counts.append(di["count"])
+            edges.append(di["_id"]["min"])
+
+        edges.append(di["_id"]["max"])
+
+        return HistogramValuesResult(self._field_name, counts, edges, 0)
+
+    def _to_mongo(self, dataset, schema, frame_schema):
+        field, path, pipeline = self._get_field_path_pipeline(
+            schema, frame_schema, dataset
+        )
+
+        if isinstance(field, fof.ListField) and isinstance(
+            field.field, _NUMERIC_FIELDS
+        ):
+            unwind = True
+        elif isinstance(field, _NUMERIC_FIELDS):
+            unwind = False
+        elif isinstance(field, fof.ListField):
+            raise AggregationError(
+                "Unsupported field '%s' (%s). You can only compute histograms "
+                "of a ListField whose `field` type is explicitly declared as "
+                "a numeric type: %s"
+                % (self._field_name, field, _NUMERIC_FIELDS)
+            )
+        else:
+            raise AggregationError(
+                "Unsupported field '%s' of type %s" % (self._field_name, field)
+            )
+
+        if unwind:
+            pipeline.append({"$unwind": path})
+
+        if self._edges is not None:
+            pipeline.append(
+                {
+                    "$bucket": {
+                        "groupBy": path,
+                        "boundaries": self._edges,
+                        "default": "other",  # counts documents outside of bins
+                        "output": {"count": {"$sum": 1}},
+                    }
+                }
+            )
+        else:
+            pipeline.append(
+                {
+                    "$bucketAuto": {
+                        "groupBy": path,
+                        "buckets": self._bins,
+                        "output": {"count": {"$sum": 1}},
+                    }
+                }
+            )
+
+        pipeline.append({"$group": {"_id": None, "bins": {"$push": "$$ROOT"}}})
+
+        return pipeline
+
+
+class HistogramValuesResult(AggregationResult):
+    """The result of the execution of a :class:`HistogramValues` instance.
+
+    Attributes:
+        name: the name of the field that was histogramed
+        counts: a list of counts in each bin
+        edges: an increasing list of bin edges of length ``len(counts) + 1``.
+            Note that each bin is treated as having an inclusive lower boundary
+            and exclusive upper boundary, ``[lower, upper)``, including the
+            rightmost bin
+        other: the number of items outside the bins
+    """
+
+    def __init__(self, name, counts, edges, other):
+        self.name = name
+        self.counts = counts
+        self.edges = edges
+        self.other = other
 
 
 class CountValues(Aggregation):
@@ -543,7 +724,7 @@ class CountValues(Aggregation):
             raise AggregationError(
                 "Unsupported field '%s' (%s). You can only count values of "
                 "a ListField whose `field` type is explicitly declared as a "
-                "countable type (%s)"
+                "countable type: %s"
                 % (self._field_name, field, _COUNTABLE_FIELDS)
             )
         else:
@@ -627,6 +808,7 @@ class Distinct(Aggregation):
         field, path, pipeline = self._get_field_path_pipeline(
             schema, frame_schema, dataset
         )
+
         if isinstance(field, fof.ListField) and isinstance(
             field.field, _COUNTABLE_FIELDS
         ):
@@ -637,7 +819,7 @@ class Distinct(Aggregation):
             raise AggregationError(
                 "Unsupported field '%s' (%s). You can only compute distinct "
                 "values of a ListField whose `field` type is explicitly "
-                "declared as a countable type (%s)"
+                "declared as a countable type: %s"
                 % (self._field_name, field, _COUNTABLE_FIELDS)
             )
         else:
@@ -645,21 +827,17 @@ class Distinct(Aggregation):
                 "Unsupported field '%s' of type %s" % (self._field_name, field)
             )
 
-        pipeline += [
+        if unwind:
+            pipeline.append({"$unwind": path})
+
+        pipeline.append(
             {
                 "$group": {
-                    "_id": "None",
+                    "_id": None,
                     self._field_name_path: {"$addToSet": path},
                 }
-            },
-        ]
-
-        if unwind:
-            pipeline = (
-                pipeline[: len(pipeline) - 1]
-                + [{"$unwind": path}]
-                + pipeline[len(pipeline) - 1 :]
-            )
+            }
+        )
 
         return pipeline
 
@@ -726,7 +904,9 @@ class DistinctLabels(Aggregation):
         if not isinstance(field, fof.EmbeddedDocumentField) or not issubclass(
             field.document_type, fol.Label
         ):
-            raise AggregationError("field '%s' is not a Label")
+            raise AggregationError(
+                "Field '%s' is not a Label" % self._field_name
+            )
 
         if field.document_type in _LABEL_LIST_FIELDS:
             path = "%s.%s" % (path, field.document_type.__name__.lower())

--- a/fiftyone/core/aggregations.py
+++ b/fiftyone/core/aggregations.py
@@ -119,15 +119,14 @@ class AggregationResult(etas.Serializable):
 
 
 class AggregationError(RuntimeError):
-    """An error raised during the execution of an :class:`Aggregation` by a
-    dataset or view.
-    """
+    """An error raised during the execution of an :class:`Aggregation`."""
 
     pass
 
 
 class Bounds(Aggregation):
-    """Computes the bounds of a numeric field or numeric list field.
+    """Computes the bounds of a numeric field or numeric list field of a
+    collection.
 
     Examples::
 
@@ -245,7 +244,7 @@ class BoundsResult(AggregationResult):
 
 class ConfidenceBounds(Aggregation):
     """Computes the bounds of the ``confidence`` of a
-    :class:`fiftyone.core.labels.Label` field.
+    :class:`fiftyone.core.labels.Label` field of a collection.
 
     Examples::
 
@@ -328,7 +327,8 @@ class ConfidenceBoundsResult(AggregationResult):
 
 
 class Count(Aggregation):
-    """Counts the number of samples or number of items with respect to a field.
+    """Counts the number of samples or number of items with respect to a field
+    of a collection.
 
     If a ``field`` is provided, it can be a
     :class:`fiftyone.core.fields.ListField` or a
@@ -412,7 +412,7 @@ class CountResult(AggregationResult):
 
 class CountLabels(Aggregation):
     """Computes a histogram of ``label`` values in a
-    :class:`fiftyone.core.labels.Label` field.
+    :class:`fiftyone.core.labels.Label` field of a collection.
 
     Examples::
 
@@ -493,7 +493,7 @@ class CountLabelsResult(AggregationResult):
 
 class CountValues(Aggregation):
     """Counts the occurrences of values in a countable field or list of
-    countable fields.
+    countable fields of a collection.
 
     Countable fields are:
 
@@ -578,7 +578,7 @@ class CountValuesResult(AggregationResult):
 
 class Distinct(Aggregation):
     """Computes the distinct values of a countable field or a list of countable
-    fields.
+    fields of a collection.
 
     Countable fields are:
 
@@ -679,7 +679,7 @@ class DistinctResult(AggregationResult):
 
 class DistinctLabels(Aggregation):
     """Computes the distinct label values of a
-    :class:`fiftyone.core.labels.Label` field.
+    :class:`fiftyone.core.labels.Label` field of a collection.
 
     Examples::
 
@@ -704,7 +704,7 @@ class DistinctLabels(Aggregation):
         r.labels  # list of distinct labels
 
     Args:
-        field_name: the name of the label field to compute distinct labels for
+        field_name: the name of the label field
     """
 
     def __init__(self, field_name):

--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -1156,17 +1156,6 @@ class SampleCollection(object):
         """Maps the ``label`` values of :class:`fiftyone.core.labels.Label`
         fields to new values.
 
-        The specified ``field`` must be one of the following types:
-
-        -   :class:`fiftyone.core.labels.Classification`
-        -   :class:`fiftyone.core.labels.Classifications`
-        -   :class:`fiftyone.core.labels.Detection`
-        -   :class:`fiftyone.core.labels.Detections`
-        -   :class:`fiftyone.core.labels.Keypoint`
-        -   :class:`fiftyone.core.labels.Keypoints`
-        -   :class:`fiftyone.core.labels.Polyline`
-        -   :class:`fiftyone.core.labels.Polylines`
-
         Examples::
 
             import fiftyone as fo

--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -1713,8 +1713,8 @@ class SampleCollection(object):
 
     @aggregation
     def count_labels(self, field_name):
-        """Computes a histogram of ``label`` values in a
-        :class:`fiftyone.core.labels.Label` field of a collection.
+        """Counts the ``label`` values in a :class:`fiftyone.core.labels.Label`
+        field of a collection.
 
         Examples::
 

--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -378,14 +378,6 @@ class SampleCollection(object):
                     % (field_name, ftype, field)
                 )
 
-    def get_tags(self):
-        """Returns the list of unique tags of samples in the collection.
-
-        Returns:
-            a list of tags
-        """
-        raise NotImplementedError("Subclass must implement get_tags()")
-
     def compute_metadata(self, overwrite=False, num_workers=None):
         """Populates the ``metadata`` field of all samples in the collection.
 

--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -14,7 +14,7 @@ import string
 import eta.core.serial as etas
 import eta.core.utils as etau
 
-from fiftyone.core.aggregations import Aggregation
+import fiftyone.core.aggregations as foa
 import fiftyone.core.fields as fof
 import fiftyone.core.labels as fol
 import fiftyone.core.media as fom
@@ -56,8 +56,11 @@ def _make_registrar():
     return registrar
 
 
-# Keeps track of all view stage methods
+# Keeps track of all `ViewStage` methods
 view_stage = _make_registrar()
+
+# Keeps track of all `Aggregation` methods
+aggregation = _make_registrar()
 
 
 class SampleCollection(object):
@@ -1599,6 +1602,271 @@ class SampleCollection(object):
         """
         return self._add_view_stage(fos.Take(size, seed=seed))
 
+    @aggregation
+    def bounds(self, field_name):
+        """Computes the bounds of a numeric field or numeric list field of a
+        collection.
+
+        Examples::
+
+            import fiftyone as fo
+
+            dataset = fo.Dataset()
+            dataset.add_samples(
+                [
+                    fo.Sample(
+                        filepath="/path/to/image1.png",
+                        numeric_field=1.0,
+                        numeric_list_field=[1.0, 2.0, 3.0],
+                    ),
+                    fo.Sample(
+                        filepath="/path/to/image2.png",
+                        numeric_field=4.0,
+                        numeric_list_field=[1.5, 2.5],
+                    ),
+                ]
+            )
+
+            # Add a generic list field
+            dataset.add_sample_field("list_field", fo.ListField)
+
+            #
+            # Compute the bounds of a numeric field
+            #
+
+            r = dataset.bounds("numeric_field")
+            r.bounds  # (min, max)
+
+            #
+            # Compute the a bounds of a numeric list field
+            #
+
+            r = dataset.bounds("numeric_list_field")
+            r.bounds  # (min, max)
+
+            #
+            # Cannot compute bounds of a generic list field
+            #
+
+            dataset.bounds("list_field")  # error
+
+        Args:
+            field_name: the name of the field to compute bounds for
+
+        Returns:
+            :class:`fiftyone.core.aggregations.BoundsResult`
+        """
+        return self.aggregate(foa.Bounds(field_name))
+
+    @aggregation
+    def confidence_bounds(self, field_name):
+        """Computes the bounds of the ``confidence`` of a
+        :class:`fiftyone.core.labels.Label` field of a collection.
+
+        Examples::
+
+            import fiftyone as fo
+
+            dataset = fo.load_dataset(...)
+
+            #
+            # Compute the confidence bounds of a `Classification` field
+            #
+
+            r = dataset.confidence_bounds("predictions")
+            r.bounds  # (min, max)
+
+            #
+            # Compute the confidence bounds of a `Detections` field
+            #
+
+            r = dataset.confidence_bounds("detections")
+            r.bounds  # (min, max)
+
+        Args:
+            field_name: the name of the label field to compute confidence
+                bounds for
+
+        Returns:
+            :class:`fiftyone.core.aggregations.ConfidenceBoundsResult`
+        """
+        return self.aggregate(foa.ConfidenceBounds(field_name))
+
+    @aggregation
+    def count(self, field_name=None):
+        """Counts the number of samples or number of items with respect to a
+        field of a collection.
+
+        If a ``field`` is provided, it can be a
+        :class:`fiftyone.core.fields.ListField` or a
+        :class:`fiftyone.core.labels.Label` list field.
+
+        Examples::
+
+            import fiftyone as fo
+
+            dataset = fo.load_dataset(...)
+
+            #
+            # Compute the number of samples in a dataset
+            #
+
+            r = dataset.count()
+            r.count
+
+            #
+            # Compute the number of objects in a `Detections` field
+            #
+
+            r = dataset.count("detections")
+            r.count
+
+        Args:
+            field_name (None): the field whose items to count. If no field name
+                is provided, the samples themselves are counted
+
+        Returns:
+            :class:`fiftyone.core.aggregations.CountResult`
+        """
+        return self.aggregate(foa.Count(field_name=field_name))
+
+    @aggregation
+    def count_labels(self, field_name):
+        """Computes a histogram of ``label`` values in a
+        :class:`fiftyone.core.labels.Label` field of a collection.
+
+        Examples::
+
+            import fiftyone as fo
+
+            dataset = fo.load_dataset(...)
+
+            #
+            # Compute label counts for a `Classification` field called "class"
+            #
+
+            r = dataset.count_labels("class")
+            r.labels  # dict mapping labels to counts
+
+            #
+            # Compute label counts for a `Detections` field called "objects"
+            #
+
+            r = dataset.count_labels("objects")
+            r.labels  # dict mapping labels to counts
+
+        Args:
+            field_name: the name of the label field
+
+        Returns:
+            :class:`fiftyone.core.aggregations.CountLabelsResult`
+        """
+        return self.aggregate(foa.CountLabels(field_name))
+
+    @aggregation
+    def count_values(self, field_name):
+        """Counts the occurrences of values in a countable field or list of
+        countable fields of a collection.
+
+        Countable fields are:
+
+        -   :class:`fiftyone.core.fields.BooleanField`
+        -   :class:`fiftyone.core.fields.IntField`
+        -   :class:`fiftyone.core.fields.StringField`
+
+        Examples::
+
+            import fiftyone as fo
+
+            dataset = fo.load_dataset(...)
+
+            #
+            # Compute the tag counts in the dataset
+            #
+
+            r = dataset.count_values("tags")
+            r.values  # dict mapping tags to counts
+
+        Args:
+            field_name: the name of the countable field
+
+        Returns:
+            :class:`fiftyone.core.aggregations.CountValuesResult`
+        """
+        return self.aggregate(foa.CountValues(field_name))
+
+    @aggregation
+    def distinct(self, field_name):
+        """Computes the distinct values of a countable field or a list of
+        countable fields of a collection.
+
+        Countable fields are:
+
+        -   :class:`fiftyone.core.fields.BooleanField`
+        -   :class:`fiftyone.core.fields.IntField`
+        -   :class:`fiftyone.core.fields.StringField`
+
+        Examples::
+
+            import fiftyone as fo
+
+            dataset = fo.load_dataset(...)
+
+            #
+            # Compute the distinct values of a StringField named `kind`
+            #
+
+            r = dataset.distinct("kind")
+            r.values  # list of distinct values
+
+            #
+            # Compute the a bounds of the `tags field
+            #
+
+            r = dataset.distinct("tags")
+            r.values  # list of distinct values
+
+        Args:
+            field_name: the name of the field to compute distinct values for
+
+        Returns:
+            :class:`fiftyone.core.aggregations.DistinctResult`
+        """
+        return self.aggregate(foa.Distinct(field_name))
+
+    @aggregation
+    def distinct_labels(self, field_name):
+        """Computes the distinct label values of a
+        :class:`fiftyone.core.labels.Label` field of a collection.
+
+        Examples::
+
+            import fiftyone as fo
+
+            dataset = fo.load_dataset(...)
+
+            #
+            # Compute the distinct labels of a `Classification` field
+            #
+
+            r = dataset.distinct_labels("predictions")
+            r.labels  # list of distinct labels
+
+            #
+            # Compute the distinct labels of a `Detections` field
+            #
+
+            r = dataset.distinct_labels("detections")
+            r.labels  # list of distinct labels
+
+        Args:
+            field_name: the name of the label field
+
+        Returns:
+            :class:`fiftyone.core.aggregations.DistinctLabelsResult`
+        """
+        return self.aggregate(foa.DistinctLabels(field_name))
+
     def draw_labels(
         self,
         anno_dir,
@@ -2130,7 +2398,7 @@ class SampleCollection(object):
         return self._process_aggregations(aggregations, result, scalar_result)
 
     def _build_aggregation(self, aggregations):
-        scalar_result = isinstance(aggregations, Aggregation)
+        scalar_result = isinstance(aggregations, foa.Aggregation)
         if scalar_result:
             aggregations = [aggregations]
         elif not aggregations:
@@ -2145,7 +2413,7 @@ class SampleCollection(object):
 
         pipelines = {}
         for agg in aggregations:
-            if not isinstance(agg, Aggregation):
+            if not isinstance(agg, foa.Aggregation):
                 raise TypeError("'%s' is not an Aggregation" % agg.__class__)
 
             field = agg._get_output_field(self)

--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -1848,6 +1848,41 @@ class SampleCollection(object):
         """
         return self.aggregate(foa.DistinctLabels(field_name))
 
+    @aggregation
+    def histogram_values(self, field_name, bins=None, range=None):
+        """Computes a histogram of the numeric values in a field or list field
+        of a collection.
+
+        Examples::
+
+            import fiftyone as fo
+
+            dataset = fo.load_dataset(...)
+
+            #
+            # Compute a histogram of values in the float field "uniqueness"
+            #
+
+            r = dataset.histogram_values("uniqueness", bins=50, range=(0, 1))
+            r.counts  # list of counts
+            r.edges  # list of bin edges
+
+        Args:
+            field_name: the name of the field to histogram
+            bins (None): can be either an integer number of bins to generate or
+                a monotonically increasing sequence specifying the bin edges to
+                use. By default, 10 bins are created. If ``bins`` is an integer
+                and no ``range`` is specified, bin edges are automatically
+                distributed in an attempt to evenly distribute the counts in
+                each bin
+            range (None): a ``(lower, upper)`` tuple specifying a range in
+                which to generate equal-width bins. Only applicable when
+                ``bins`` is an integer
+        """
+        return self.aggregate(
+            foa.HistogramValues(field_name, bins=bins, range=range)
+        )
+
     def draw_labels(
         self,
         anno_dir,

--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -824,29 +824,6 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
             self._frame_doc_cls._delete_field(field_name, is_frame_field=True)
             fofr.Frame._purge_field(self._frame_collection_name, field_name)
 
-    def get_tags(self):
-        """Returns the list of unique tags of samples in the dataset.
-
-        Returns:
-            a list of tags
-        """
-        return self.aggregate(foa.Distinct("tags")).values
-
-    def distinct(self, field):
-        """Finds all distinct values of a sample field across the dataset.
-
-        If the field is a list, the distinct values will be distinct elements
-        across all sample field lists.
-
-        Args:
-            field: a sample field like ``"tags"`` or a subfield like
-                ``"ground_truth.label"``
-
-        Returns:
-            the set of distinct values
-        """
-        return set(self._sample_collection.distinct(field))
-
     def iter_samples(self):
         """Returns an iterator over the samples in the dataset.
 

--- a/fiftyone/core/odm/mixins.py
+++ b/fiftyone/core/odm/mixins.py
@@ -1027,20 +1027,19 @@ def get_implied_field_kwargs(value, **kwargs):
             "embedded_doc_type": type(value),
         }
 
-    if isinstance(value, bool):
-        return {"ftype": fof.BooleanField}
-
-    if isinstance(value, six.integer_types):
-        return {"ftype": fof.IntField}
-
-    if isinstance(value, numbers.Number):
-        return {"ftype": fof.FloatField}
-
-    if isinstance(value, six.string_types):
-        return {"ftype": fof.StringField}
+    ftype = _get_scalar_field_type(value)
+    if ftype is not None:
+        return {"ftype": ftype}
 
     if isinstance(value, (list, tuple)):
-        return {"ftype": fof.ListField}
+        kwargs = {"ftype": fof.ListField}
+
+        if value:
+            subtype = _get_scalar_field_type(value[0])
+            if subtype is not None:
+                kwargs["subfield"] = subtype()
+
+        return kwargs
 
     if isinstance(value, np.ndarray):
         if value.ndim == 1:
@@ -1052,6 +1051,22 @@ def get_implied_field_kwargs(value, **kwargs):
         return {"ftype": fof.DictField}
 
     raise TypeError("Unsupported field value '%s'" % type(value))
+
+
+def _get_scalar_field_type(value):
+    if isinstance(value, bool):
+        return fof.BooleanField
+
+    if isinstance(value, six.integer_types):
+        return fof.IntField
+
+    if isinstance(value, numbers.Number):
+        return fof.FloatField
+
+    if isinstance(value, six.string_types):
+        return fof.StringField
+
+    return None
 
 
 def _create_field(

--- a/fiftyone/core/stages.py
+++ b/fiftyone/core/stages.py
@@ -197,7 +197,6 @@ class Exclude(ViewStage):
     Examples::
 
         import fiftyone as fo
-        from fiftyone.core.stages import Exclude
 
         dataset = fo.load_dataset(...)
 
@@ -205,14 +204,14 @@ class Exclude(ViewStage):
         # Exclude a single sample from a dataset
         #
 
-        stage = Exclude("5f3c298768fd4d3baf422d2f")
+        stage = fo.Exclude("5f3c298768fd4d3baf422d2f")
         view = dataset.add_stage(stage)
 
         #
         # Exclude a list of samples from a dataset
         #
 
-        stage = Exclude([
+        stage = fo.Exclude([
             "5f3c298768fd4d3baf422d2f",
             "5f3c298768fd4d3baf422d30"
         ])
@@ -266,7 +265,6 @@ class ExcludeFields(ViewStage):
     Examples::
 
         import fiftyone as fo
-        from fiftyone.core.stages import ExcludeFields
 
         dataset = fo.load_dataset(...)
 
@@ -274,14 +272,14 @@ class ExcludeFields(ViewStage):
         # Exclude a field from all samples in a dataset
         #
 
-        stage = ExcludeFields("predictions")
+        stage = fo.ExcludeFields("predictions")
         view = dataset.add_stage(stage)
 
         #
         # Exclude a list of fields from all samples in a dataset
         #
 
-        stage = ExcludeFields(["ground_truth", "predictions"])
+        stage = fo.ExcludeFields(["ground_truth", "predictions"])
         view = dataset.add_stage(stage)
 
     Args:
@@ -396,7 +394,6 @@ class ExcludeObjects(ViewStage):
     Examples::
 
         import fiftyone as fo
-        from fiftyone.core.stages import ExcludeObjects
 
         dataset = fo.load_dataset(...)
 
@@ -408,7 +405,7 @@ class ExcludeObjects(ViewStage):
 
         # Select some objects in the App...
 
-        stage = ExcludeObjects(session.selected_objects)
+        stage = fo.ExcludeObjects(session.selected_objects)
         view = dataset.add_stage(stage)
 
     Args:
@@ -478,7 +475,6 @@ class Exists(ViewStage):
     Examples::
 
         import fiftyone as fo
-        from fiftyone.core.stages import Exists
 
         dataset = fo.load_dataset(...)
 
@@ -486,7 +482,7 @@ class Exists(ViewStage):
         # Only include samples that have a value in their `predictions` field
         #
 
-        stage = Exists("predictions")
+        stage = fo.Exists("predictions")
         view = dataset.add_stage(stage)
 
         #
@@ -494,7 +490,7 @@ class Exists(ViewStage):
         # field
         #
 
-        stage = Exists("predictions", False)
+        stage = fo.Exists("predictions", False)
         view = dataset.add_stage(stage)
 
     Args:
@@ -560,7 +556,6 @@ class FilterField(ViewStage):
 
         import fiftyone as fo
         from fiftyone import ViewField as F
-        from fiftyone.core.stages import FilterField
 
         dataset = fo.load_dataset(...)
 
@@ -569,7 +564,7 @@ class FilterField(ViewStage):
         # a `Classification` field) whose `label` is "cat"
         #
 
-        stage = FilterField("predictions", F("label") == "cat")
+        stage = fo.FilterField("predictions", F("label") == "cat")
         view = dataset.add_stage(stage)
 
         #
@@ -577,7 +572,7 @@ class FilterField(ViewStage):
         # a `Classification` field) whose `confidence` is greater than 0.8
         #
 
-        stage = FilterField("predictions", F("confidence") > 0.8)
+        stage = fo.FilterField("predictions", F("confidence") > 0.8)
         view = dataset.add_stage(stage)
 
     Args:
@@ -802,7 +797,6 @@ class FilterLabels(_FilterListField):
 
         import fiftyone as fo
         from fiftyone import ViewField as F
-        from fiftyone.core.stages import FilterLabels
 
         dataset = fo.load_dataset(...)
 
@@ -811,7 +805,7 @@ class FilterLabels(_FilterListField):
         # `confidence` greater than 0.8
         #
 
-        stage = FilterLabels("predictions", F("confidence") > 0.8)
+        stage = fo.FilterLabels("predictions", F("confidence") > 0.8)
         view = dataset.add_stage(stage)
 
         #
@@ -820,7 +814,7 @@ class FilterLabels(_FilterListField):
         # classification after filtering
         #
 
-        stage = FilterLabels(
+        stage = fo.FilterLabels(
             "predictions", F("label").is_in(["cat", "dog"]), only_matches=True
         )
         view = dataset.add_stage(stage)
@@ -829,7 +823,6 @@ class FilterLabels(_FilterListField):
 
         import fiftyone as fo
         from fiftyone import ViewField as F
-        from fiftyone.core.stages import FilterLabels
 
         dataset = fo.load_dataset(...)
 
@@ -838,7 +831,7 @@ class FilterLabels(_FilterListField):
         # is greater than 0.8
         #
 
-        stage = FilterLabels("predictions", F("confidence") > 0.8)
+        stage = fo.FilterLabels("predictions", F("confidence") > 0.8)
         view = dataset.add_stage(stage)
 
         #
@@ -847,7 +840,7 @@ class FilterLabels(_FilterListField):
         # after filtering
         #
 
-        stage = FilterLabels(
+        stage = fo.FilterLabels(
             "predictions", F("label").is_in(["cat", "dog"]), only_matches=True
         )
         view = dataset.add_stage(stage)
@@ -860,14 +853,13 @@ class FilterLabels(_FilterListField):
         # bbox is in [top-left-x, top-left-y, width, height] format
         bbox_area = F("bounding_box")[2] * F("bounding_box")[3]
 
-        stage = FilterLabels("predictions", bbox_area < 0.2)
+        stage = fo.FilterLabels("predictions", bbox_area < 0.2)
         view = dataset.add_stage(stage)
 
     Polylines Examples::
 
         import fiftyone as fo
         from fiftyone import ViewField as F
-        from fiftyone.core.stages import FilterLabels
 
         dataset = fo.load_dataset(...)
 
@@ -875,7 +867,7 @@ class FilterLabels(_FilterListField):
         # Only include polylines in the `predictions` field that are filled
         #
 
-        stage = FilterLabels("predictions", F("filled"))
+        stage = fo.FilterLabels("predictions", F("filled"))
         view = dataset.add_stage(stage)
 
         #
@@ -884,7 +876,7 @@ class FilterLabels(_FilterListField):
         # filtering
         #
 
-        stage = FilterLabels(
+        stage = fo.FilterLabels(
             "predictions", F("label") == "lane", only_matches=True
         )
         view = dataset.add_stage(stage)
@@ -895,14 +887,13 @@ class FilterLabels(_FilterListField):
         #
 
         num_vertices = F("points").map(F().length()).sum()
-        stage = FilterLabels("predictions", num_vertices >= 10)
+        stage = fo.FilterLabels("predictions", num_vertices >= 10)
         view = dataset.add_stage(stage)
 
     Keypoints Examples::
 
         import fiftyone as fo
         from fiftyone import ViewField as F
-        from fiftyone.core.stages import FilterLabels
 
         dataset = fo.load_dataset(...)
 
@@ -912,7 +903,7 @@ class FilterLabels(_FilterListField):
         # filtering
         #
 
-        stage = FilterLabels(
+        stage = fo.FilterLabels(
             "predictions", F("label") == "face", only_matches=True
         )
         view = dataset.add_stage(stage)
@@ -922,7 +913,7 @@ class FilterLabels(_FilterListField):
         # 10 points
         #
 
-        stage = FilterLabels("predictions", F("points").length() >= 10)
+        stage = fo.FilterLabels("predictions", F("points").length() >= 10)
         view = dataset.add_stage(stage)
 
     Args:
@@ -963,6 +954,7 @@ class FilterLabels(_FilterListField):
         )
 
 
+# @todo remove; deprecated by FilterLabels
 class FilterClassifications(_FilterListField):
     """Filters the :class:`fiftyone.core.labels.Classification` elements in the
     specified :class:`fiftyone.core.labels.Classifications` field of each
@@ -972,7 +964,6 @@ class FilterClassifications(_FilterListField):
 
         import fiftyone as fo
         from fiftyone import ViewField as F
-        from fiftyone.core.stages import FilterClassifications
 
         dataset = fo.load_dataset(...)
 
@@ -981,7 +972,7 @@ class FilterClassifications(_FilterListField):
         # `confidence` greater than 0.8
         #
 
-        stage = FilterClassifications("predictions", F("confidence") > 0.8)
+        stage = fo.FilterClassifications("predictions", F("confidence") > 0.8)
         view = dataset.add_stage(stage)
 
         #
@@ -990,7 +981,7 @@ class FilterClassifications(_FilterListField):
         # classification after filtering
         #
 
-        stage = FilterClassifications(
+        stage = fo.FilterClassifications(
             "predictions", F("label").is_in(["cat", "dog"]), only_matches=True
         )
         view = dataset.add_stage(stage)
@@ -1017,6 +1008,7 @@ class FilterClassifications(_FilterListField):
         )
 
 
+# @todo remove; deprecated by FilterLabels
 class FilterDetections(_FilterListField):
     """Filters the :class:`fiftyone.core.labels.Detection` elements in the
     specified :class:`fiftyone.core.labels.Detections` field of each sample.
@@ -1025,7 +1017,6 @@ class FilterDetections(_FilterListField):
 
         import fiftyone as fo
         from fiftyone import ViewField as F
-        from fiftyone.core.stages import FilterDetections
 
         dataset = fo.load_dataset(...)
 
@@ -1034,7 +1025,7 @@ class FilterDetections(_FilterListField):
         # is greater than 0.8
         #
 
-        stage = FilterDetections("predictions", F("confidence") > 0.8)
+        stage = fo.FilterDetections("predictions", F("confidence") > 0.8)
         view = dataset.add_stage(stage)
 
         #
@@ -1043,7 +1034,7 @@ class FilterDetections(_FilterListField):
         # after filtering
         #
 
-        stage = FilterDetections(
+        stage = fo.FilterDetections(
             "predictions", F("label").is_in(["cat", "dog"]), only_matches=True
         )
         view = dataset.add_stage(stage)
@@ -1056,7 +1047,7 @@ class FilterDetections(_FilterListField):
         # bbox is in [top-left-x, top-left-y, width, height] format
         bbox_area = F("bounding_box")[2] * F("bounding_box")[3]
 
-        stage = FilterDetections("predictions", bbox_area < 0.2)
+        stage = fo.FilterDetections("predictions", bbox_area < 0.2)
         view = dataset.add_stage(stage)
 
     Args:
@@ -1081,6 +1072,7 @@ class FilterDetections(_FilterListField):
         )
 
 
+# @todo remove; deprecated by FilterLabels
 class FilterPolylines(_FilterListField):
     """Filters the :class:`fiftyone.core.labels.Polyline` elements in the
     specified :class:`fiftyone.core.labels.Polylines` field of each sample.
@@ -1089,7 +1081,6 @@ class FilterPolylines(_FilterListField):
 
         import fiftyone as fo
         from fiftyone import ViewField as F
-        from fiftyone.core.stages import FilterPolylines
 
         dataset = fo.load_dataset(...)
 
@@ -1097,7 +1088,7 @@ class FilterPolylines(_FilterListField):
         # Only include polylines in the `predictions` field that are filled
         #
 
-        stage = FilterPolylines("predictions", F("filled"))
+        stage = fo.FilterPolylines("predictions", F("filled"))
         view = dataset.add_stage(stage)
 
         #
@@ -1106,7 +1097,7 @@ class FilterPolylines(_FilterListField):
         # filtering
         #
 
-        stage = FilterPolylines(
+        stage = fo.FilterPolylines(
             "predictions", F("label") == "lane", only_matches=True
         )
         view = dataset.add_stage(stage)
@@ -1117,7 +1108,7 @@ class FilterPolylines(_FilterListField):
         #
 
         num_vertices = F("points").map(F().length()).sum()
-        stage = FilterPolylines("predictions", num_vertices >= 10)
+        stage = fo.FilterPolylines("predictions", num_vertices >= 10)
         view = dataset.add_stage(stage)
 
     Args:
@@ -1142,6 +1133,7 @@ class FilterPolylines(_FilterListField):
         )
 
 
+# @todo remove; deprecated by FilterLabels
 class FilterKeypoints(_FilterListField):
     """Filters the :class:`fiftyone.core.labels.Keypoint` elements in the
     specified :class:`fiftyone.core.labels.Keypoints` field of each sample.
@@ -1150,7 +1142,6 @@ class FilterKeypoints(_FilterListField):
 
         import fiftyone as fo
         from fiftyone import ViewField as F
-        from fiftyone.core.stages import FilterKeypoints
 
         dataset = fo.load_dataset(...)
 
@@ -1160,7 +1151,7 @@ class FilterKeypoints(_FilterListField):
         # filtering
         #
 
-        stage = FilterKeypoints(
+        stage = fo.FilterKeypoints(
             "predictions", F("label") == "face", only_matches=True
         )
         view = dataset.add_stage(stage)
@@ -1170,7 +1161,7 @@ class FilterKeypoints(_FilterListField):
         # 10 points
         #
 
-        stage = FilterKeypoints("predictions", F("points").length() >= 10)
+        stage = fo.FilterKeypoints("predictions", F("points").length() >= 10)
         view = dataset.add_stage(stage)
 
     Args:
@@ -1201,7 +1192,6 @@ class Limit(ViewStage):
     Examples::
 
         import fiftyone as fo
-        from fiftyone.core.stages import Limit
 
         dataset = fo.load_dataset(...)
 
@@ -1209,7 +1199,7 @@ class Limit(ViewStage):
         # Only include the first 10 samples in the view
         #
 
-        stage = Limit(10)
+        stage = fo.Limit(10)
         view = dataset.add_stage(stage)
 
     Args:
@@ -1253,7 +1243,6 @@ class LimitLabels(ViewStage):
     Examples::
 
         import fiftyone as fo
-        from fiftyone.core.stages import LimitLabels
 
         dataset = fo.load_dataset(...)
 
@@ -1262,7 +1251,7 @@ class LimitLabels(ViewStage):
         # the view
         #
 
-        stage = LimitLabels("ground_truth", 5)
+        stage = fo.LimitLabels("ground_truth", 5)
         view = dataset.add_stage(stage)
 
     Args:
@@ -1326,21 +1315,9 @@ class MapLabels(ViewStage):
     """Maps the ``label`` values of :class:`fiftyone.core.labels.Label` fields
     to new values.
 
-    The specified ``field`` must be one of the following types:
-
-    -   :class:`fiftyone.core.labels.Classification`
-    -   :class:`fiftyone.core.labels.Classifications`
-    -   :class:`fiftyone.core.labels.Detection`
-    -   :class:`fiftyone.core.labels.Detections`
-    -   :class:`fiftyone.core.labels.Keypoint`
-    -   :class:`fiftyone.core.labels.Keypoints`
-    -   :class:`fiftyone.core.labels.Polyline`
-    -   :class:`fiftyone.core.labels.Polylines`
-
     Examples::
 
         import fiftyone as fo
-        from fiftyone.core.stages import MapLabels
 
         dataset = fo.load_dataset(...)
 
@@ -1348,7 +1325,7 @@ class MapLabels(ViewStage):
         # Map "cat" and "dog" label values to "pet"
         #
 
-        stage = MapLabels("ground_truth", {"cat": "pet", "dog":, "pet"})
+        stage = fo.MapLabels("ground_truth", {"cat": "pet", "dog":, "pet"})
         view = dataset.add_stage(stage)
 
     Args:
@@ -1441,7 +1418,6 @@ class Match(ViewStage):
 
         import fiftyone as fo
         from fiftyone import ViewField as F
-        from fiftyone.core.stages import Match
 
         dataset = fo.load_dataset(...)
 
@@ -1449,7 +1425,7 @@ class Match(ViewStage):
         # Only include samples whose `filepath` ends with ".jpg"
         #
 
-        stage = Match(F("filepath").ends_with(".jpg"))
+        stage = fo.Match(F("filepath").ends_with(".jpg"))
         view = dataset.add_stage(stage)
 
         #
@@ -1457,7 +1433,7 @@ class Match(ViewStage):
         # `Classification` field) has `label` of "cat"
         #
 
-        stage = Match(F("predictions").label == "cat"))
+        stage = fo.Match(F("predictions").label == "cat"))
         view = dataset.add_stage(stage)
 
         #
@@ -1465,7 +1441,7 @@ class Match(ViewStage):
         # `Detections` field) has at least 5 detections
         #
 
-        stage = Match(F("predictions").detections.length() >= 5)
+        stage = fo.Match(F("predictions").detections.length() >= 5)
         view = dataset.add_stage(stage)
 
         #
@@ -1478,7 +1454,7 @@ class Match(ViewStage):
         pred_bbox = F("predictions.detections.bounding_box")
         pred_bbox_area = pred_bbox[2] * pred_bbox[3]
 
-        stage = Match((pred_bbox_area < 0.2).length() > 0)
+        stage = fo.Match((pred_bbox_area < 0.2).length() > 0)
         view = dataset.add_stage(stage)
 
     Args:
@@ -1526,7 +1502,6 @@ class MatchTag(ViewStage):
     Examples::
 
         import fiftyone as fo
-        from fiftyone.core.stages import MatchTag
 
         dataset = fo.load_dataset(...)
 
@@ -1534,7 +1509,7 @@ class MatchTag(ViewStage):
         # Only include samples that have the "test" tag
         #
 
-        stage = MatchTag("test")
+        stage = fo.MatchTag("test")
         view = dataset.add_stage(stage)
 
     Args:
@@ -1569,7 +1544,6 @@ class MatchTags(ViewStage):
     Examples::
 
         import fiftyone as fo
-        from fiftyone.core.stages import MatchTags
 
         dataset = fo.load_dataset(...)
 
@@ -1577,7 +1551,7 @@ class MatchTags(ViewStage):
         # Only include samples that have either the "test" or "validation" tag
         #
 
-        stage = MatchTags(["test", "validation"])
+        stage = fo.MatchTags(["test", "validation"])
         view = dataset.add_stage(stage)
 
     Args:
@@ -1618,7 +1592,6 @@ class Mongo(ViewStage):
     Examples::
 
         import fiftyone as fo
-        from fiftyone.core.stages import Mongo
 
         dataset = fo.load_dataset(...)
 
@@ -1626,7 +1599,7 @@ class Mongo(ViewStage):
         # Extract a view containing the 6th through 15th samples in the dataset
         #
 
-        stage = Mongo([{"$skip": 5}, {"$limit": 10}])
+        stage = fo.Mongo([{"$skip": 5}, {"$limit": 10}])
         view = dataset.add_stage(stage)
 
         #
@@ -1634,7 +1607,7 @@ class Mongo(ViewStage):
         # samples (assume it is a `Detections` field)
         #
 
-        stage = Mongo([
+        stage = fo.Mongo([
             {
                 "$addFields": {
                     "_sort_field": {
@@ -1676,7 +1649,6 @@ class Select(ViewStage):
     Examples::
 
         import fiftyone as fo
-        from fiftyone.core.stages import Select
 
         dataset = fo.load_dataset(...)
 
@@ -1684,7 +1656,7 @@ class Select(ViewStage):
         # Select the samples with the given IDs from the dataset
         #
 
-        stage = Select([
+        stage = fo.Select([
             "5f3c298768fd4d3baf422d34",
             "5f3c298768fd4d3baf422d35",
             "5f3c298768fd4d3baf422d36",
@@ -1699,7 +1671,7 @@ class Select(ViewStage):
 
         # Select samples in the App...
 
-        stage = Select(session.selected)
+        stage = fo.Select(session.selected)
         view = dataset.add_stage(stage)
 
     Args:
@@ -1752,7 +1724,6 @@ class SelectFields(ViewStage):
     Examples::
 
         import fiftyone as fo
-        from fiftyone.core.stages import SelectFields
 
         dataset = fo.load_dataset(...)
 
@@ -1760,7 +1731,7 @@ class SelectFields(ViewStage):
         # Include only the default fields on each sample
         #
 
-        stage = SelectFields()
+        stage = fo.SelectFields()
         view = dataset.add_stage(stage)
 
         #
@@ -1768,7 +1739,7 @@ class SelectFields(ViewStage):
         # each sample
         #
 
-        stage = SelectFields("ground_truth")
+        stage = fo.SelectFields("ground_truth")
         view = dataset.add_stage(stage)
 
     Args:
@@ -1883,7 +1854,6 @@ class SelectObjects(ViewStage):
     Examples::
 
         import fiftyone as fo
-        from fiftyone.core.stages import SelectObjects
 
         dataset = fo.load_dataset(...)
 
@@ -1895,7 +1865,7 @@ class SelectObjects(ViewStage):
 
         # Select some objects in the App...
 
-        stage = SelectObjects(session.selected_objects)
+        stage = fo.SelectObjects(session.selected_objects)
         view = dataset.add_stage(stage)
 
     Args:
@@ -1973,7 +1943,6 @@ class Shuffle(ViewStage):
     Examples::
 
         import fiftyone as fo
-        from fiftyone.core.stages import Shuffle
 
         dataset = fo.load_dataset(...)
 
@@ -1982,14 +1951,14 @@ class Shuffle(ViewStage):
         # samples in the dataset
         #
 
-        stage = Shuffle()
+        stage = fo.Shuffle()
         view = dataset.add_stage(stage)
 
         #
         # Shuffle the samples with a set random seed
         #
 
-        stage = Shuffle(seed=51)
+        stage = fo.Shuffle(seed=51)
         view = dataset.add_stage(stage)
 
     Args:
@@ -2035,7 +2004,6 @@ class Skip(ViewStage):
     Examples::
 
         import fiftyone as fo
-        from fiftyone.core.stages import Skip
 
         dataset = fo.load_dataset(...)
 
@@ -2043,7 +2011,7 @@ class Skip(ViewStage):
         # Omit the first 10 samples from the dataset
         #
 
-        stage = Skip(10)
+        stage = fo.Skip(10)
         view = dataset.add_stage(stage)
 
     Args:
@@ -2085,7 +2053,6 @@ class SortBy(ViewStage):
 
         import fiftyone as fo
         from fiftyone import ViewField as F
-        from fiftyone.core.stages import SortBy
 
         dataset = fo.load_dataset(...)
 
@@ -2094,7 +2061,7 @@ class SortBy(ViewStage):
         # `predictions` field (assume it is a `Classification` field)
         #
 
-        stage = SortBy("predictions.confidence", reverse=True)
+        stage = fo.SortBy("predictions.confidence", reverse=True)
         view = dataset.add_stage(stage)
 
         #
@@ -2107,7 +2074,7 @@ class SortBy(ViewStage):
         pred_bbox = F("predictions.detections.bounding_box")
         pred_bbox_area = pred_bbox[2] * pred_bbox[3]
 
-        stage = SortBy((pred_bbox_area < 0.2).length())
+        stage = fo.SortBy((pred_bbox_area < 0.2).length())
         view = dataset.add_stage(stage)
 
     Args:
@@ -2189,7 +2156,6 @@ class Take(ViewStage):
     Examples::
 
         import fiftyone as fo
-        from fiftyone.core.stages import Take
 
         dataset = fo.load_dataset(...)
 
@@ -2197,14 +2163,14 @@ class Take(ViewStage):
         # Take 10 random samples from the dataset
         #
 
-        stage = Take(10)
+        stage = fo.Take(10)
         view = dataset.add_stage(stage)
 
         #
         # Take 10 random samples from the dataset with a set seed
         #
 
-        stage = Take(10, seed=51)
+        stage = fo.Take(10, seed=51)
         view = dataset.add_stage(stage)
 
     Args:

--- a/fiftyone/core/view.py
+++ b/fiftyone/core/view.py
@@ -233,14 +233,6 @@ class DatasetView(foc.SampleCollection):
 
         return self._get_filtered_schema(field_schema, frames=True)
 
-    def get_tags(self):
-        """Returns the list of unique tags of samples in the view.
-
-        Returns:
-            a list of tags
-        """
-        return self.aggregate(foa.Distinct("tags")).values
-
     def list_indexes(self):
         """Returns the fields of the dataset that are indexed.
 


### PR DESCRIPTION
## Histograms
Adds a `HistogramValues` aggregation stage that allows for computing histograms of numeric fields. See below for example usage.

**Example usage**

```py
import numpy as np
import matplotlib.pyplot as plt

import fiftyone as fo
import fiftyone.zoo as foz


def plot_hist(counts, edges, cumulative=False, density=False):
    counts = np.asarray(counts)
    edges = np.asarray(edges)

    if cumulative:
        heights = np.insert(np.cumsum(counts), 0, 0.0)
        if density:
            heights = heights / heights[-1]

        plt.step(edges, heights, where="pre")
    else:
        left_edges = edges[:-1]
        widths = edges[1:] - edges[:-1]

        if density:
            heights = (counts / np.sum(counts)) / widths
        else:
            heights = counts

        plt.bar(left_edges, heights, width=widths, align="edge")


# Manual bins
#BINS = [0.0, 0.25, 0.50, 0.75, 1.01]
#RANGE = None

# Equally-spaced bins
BINS = 28
RANGE = [0, 1]

# Dynamic equal-count bins
#BINS = 28
#RANGE = None

dataset = foz.load_zoo_dataset("quickstart")

# Use aggregation
r = dataset.histogram_values("uniqueness", bins=BINS, range=RANGE)

# Use numpy
values = [s.uniqueness for s in dataset.select_fields("uniqueness")]
np_counts, np_edges = np.histogram(values, bins=BINS, range=RANGE)

# Plot results
plt.subplot(121)
plot_hist(r.counts, r.edges)
plt.title("histogram_values()")

plt.subplot(122)
plot_hist(np_counts, np_edges)
plt.title("np.histogram()")

plt.show(block=False)
```

![histogram_values](https://user-images.githubusercontent.com/25985824/104616124-f22b4e80-5657-11eb-8613-f8f2a7b80de0.png)

### Adding list fields
When adding new list fields to dataset, use the type of the first element of the list to set the field type. If the user wants a generic list field, they can declare it first: `dataset.add_sample_field("list_field", fo.ListField)`.

Previously, the situation was opposite: the user had to manually declare fields if they wanted them to be treated as homogenous: `dataset.add_sample_field("list_field", fo.ListField, subfield=fo.FloatField())`.

I think that homogeneous fields are the more common case, so this default behavior is preferable. Also, this enables aggregations like `count()` and `distinct()` to work in the examples below without having to manually declare field types.

### SampleCollection methods

Exposes all aggregations directly as methods on `SampleCollection`, for consistency with how `ViewStage`s are also exposed. This allows for cleaner syntax:

```py
# previous
dataset.match().aggregate(fo.Count("countable_field"))

# now
dataset.match(...).count("countable_field")
```

Multiple aggregations can list be run via `sample_collection.aggregate([agg1, agg2, ...])` for efficiency, if desired.

**Example usage**

```py
import fiftyone as fo

dataset = fo.Dataset()

dataset.add_sample_field("list_field", fo.ListField)  # generic list field
dataset.add_samples(
    [
        fo.Sample(
            filepath="/path/to/image1.png",
            tags=["A"],
            list_field=[1, 2.0],
            countable_field="cat",
            countable_list_field=[1, 2, 3],
            numeric_field=1.0,
            numeric_list_field=[1.0, 2.0, 3.0],
        ),
        fo.Sample(
            filepath="/path/to/image2.png",
            tags=["B"],
            list_field=[3.0, 4],
            countable_field="dog",
            countable_list_field=[1, 2, 3],
            numeric_field=4.0,
            numeric_list_field=[1.5, 2.5],

        ),
    ]
)

# Get tags
print(dataset.distinct("tags").values)

# bounds()
print(dataset.bounds("numeric_field"))
print(dataset.bounds("numeric_list_field"))
dataset.bounds("list_field")  # error: generic list field

# count()
print(dataset.count())
print(dataset.count("countable_list_field"))
print(dataset.count("numeric_list_field"))

# count_values()
print(dataset.count_values("countable_field"))
print(dataset.count_values("countable_list_field"))

# distinct()
print(dataset.distinct("countable_field"))
print(dataset.distinct("countable_list_field"))
```
