### PR TITLE
2021 Copyrights

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright 2020, Voxel51, Inc. All rights reserved.
+Copyright 2021, Voxel51, Inc. All rights reserved.
 
                                  Apache License
                            Version 2.0, January 2004

--- a/LICENSE-BRAIN
+++ b/LICENSE-BRAIN
@@ -1,4 +1,4 @@
-Copyright 2020, Voxel51, Inc.
+Copyright 2021, Voxel51, Inc.
 All rights reserved.
 
 FREEWARE LICENSE AND END-USER LICENSE AGREEMENT

--- a/app/README.md
+++ b/app/README.md
@@ -43,4 +43,4 @@ That's it!
 
 ## Copyright
 
-Copyright 2017-2020, Voxel51, Inc.<br> voxel51.com
+Copyright 2017-2021, Voxel51, Inc.<br> voxel51.com

--- a/docs/docs_guide.md
+++ b/docs/docs_guide.md
@@ -60,4 +60,4 @@ A few commands are available:
 
 ## Copyright
 
-Copyright 2017-2020, Voxel51, Inc.<br> voxel51.com
+Copyright 2017-2021, Voxel51, Inc.<br> voxel51.com

--- a/docs/scripts/make_model_zoo_docs.py
+++ b/docs/scripts/make_model_zoo_docs.py
@@ -2,7 +2,7 @@
 Script for generating the model zoo docs page contents
 ``docs/source/user_guide/model_zoo/models.rst``.
 
-| Copyright 2017-2020, Voxel51, Inc.
+| Copyright 2017-2021, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/docs/source/_templates/layout.html
+++ b/docs/source/_templates/layout.html
@@ -143,7 +143,7 @@
   <div class="footer__copyright">
     <ul class="list-inline">
       <li>
-        &copy; 2020 Voxel51 Inc.
+        &copy; 2021 Voxel51 Inc.
       </li>
       <li>
         <a href="{{link_privacypolicy}}">Privacy Policy</a>

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -4,7 +4,7 @@ Sphinx configuration file.
 For a full list of available options, see:
 https://www.sphinx-doc.org/en/master/usage/configuration.html
 
-| Copyright 2017-2020, Voxel51, Inc.
+| Copyright 2017-2021, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/docs/source/custom_directives.py
+++ b/docs/source/custom_directives.py
@@ -1,7 +1,7 @@
 """
 Sphinx custom directives.
 
-| Copyright 2017-2020, Voxel51, Inc.
+| Copyright 2017-2021, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/docs/source/recipes/image_deduplication_helpers.py
+++ b/docs/source/recipes/image_deduplication_helpers.py
@@ -15,7 +15,7 @@ Downloads a subset of CIFAR-100 and stores it to disk as follows::
 
 A random 5% of the samples are duplicates, instead of the original samples.
 
-| Copyright 2017-2020, Voxel51, Inc.
+| Copyright 2017-2021, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/docs/source/redirects.py
+++ b/docs/source/redirects.py
@@ -4,7 +4,7 @@ Sphinx utility that generates HTML page redirects specified in the
 
 Inspired by https://github.com/sphinx-contrib/redirects.
 
-| Copyright 2017-2020, Voxel51, Inc.
+| Copyright 2017-2021, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/docs/source/tutorials/query_flickr.py
+++ b/docs/source/tutorials/query_flickr.py
@@ -4,7 +4,7 @@ Simple utility to download images from Flickr based on a text query.
 Requires a user-specified API key, which can be obtained for free at
 https://www.flickr.com/services/apps/create.
 
-Copyright 2017-2020, Voxel51, Inc.
+Copyright 2017-2021, Voxel51, Inc.
 voxel51.com
 """
 import argparse

--- a/fiftyone/__init__.py
+++ b/fiftyone/__init__.py
@@ -3,7 +3,7 @@ FiftyOne: a powerful package for dataset curation, analysis, and visualization.
 
 See https://voxel51.com/fiftyone for more information.
 
-| Copyright 2017-2020, Voxel51, Inc.
+| Copyright 2017-2021, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/__public__.py
+++ b/fiftyone/__public__.py
@@ -1,7 +1,7 @@
 """
 FiftyOne's public interface.
 
-| Copyright 2017-2020, Voxel51, Inc.
+| Copyright 2017-2021, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/constants.py
+++ b/fiftyone/constants.py
@@ -1,7 +1,7 @@
 """
 Package-wide constants.
 
-| Copyright 2017-2020, Voxel51, Inc.
+| Copyright 2017-2021, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/core/__init__.py
+++ b/fiftyone/core/__init__.py
@@ -1,5 +1,5 @@
 """
-| Copyright 2017-2020, Voxel51, Inc.
+| Copyright 2017-2021, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/core/aggregations.py
+++ b/fiftyone/core/aggregations.py
@@ -1,7 +1,7 @@
 """
 Aggregations.
 
-| Copyright 2017-2020, Voxel51, Inc.
+| Copyright 2017-2021, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/core/cli.py
+++ b/fiftyone/core/cli.py
@@ -1,7 +1,7 @@
 """
 Definition of the `fiftyone` command-line interface (CLI).
 
-| Copyright 2017-2020, Voxel51, Inc.
+| Copyright 2017-2021, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/core/client.py
+++ b/fiftyone/core/client.py
@@ -1,7 +1,7 @@
 """
 Web socket client mixins.
 
-| Copyright 2017-2020, Voxel51, Inc.
+| Copyright 2017-2021, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -1,7 +1,7 @@
 """
 Base classes for collections of samples.
 
-| Copyright 2017-2020, Voxel51, Inc.
+| Copyright 2017-2021, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/core/config.py
+++ b/fiftyone/core/config.py
@@ -1,7 +1,7 @@
 """
 FiftyOne config.
 
-| Copyright 2017-2020, Voxel51, Inc.
+| Copyright 2017-2021, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/core/context.py
+++ b/fiftyone/core/context.py
@@ -1,7 +1,7 @@
 """
 Context utilities.
 
-| Copyright 2017-2020, Voxel51, Inc.
+| Copyright 2017-2021, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -1,7 +1,7 @@
 """
 FiftyOne datasets.
 
-| Copyright 2017-2020, Voxel51, Inc.
+| Copyright 2017-2021, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/core/document.py
+++ b/fiftyone/core/document.py
@@ -1,7 +1,7 @@
 """
 Base class for objects that are backed by database documents.
 
-| Copyright 2017-2020, Voxel51, Inc.
+| Copyright 2017-2021, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/core/eta_utils.py
+++ b/fiftyone/core/eta_utils.py
@@ -2,7 +2,7 @@
 Utilities for interfacing with the
 `ETA library <https://github.com/voxel51/eta>`_.
 
-| Copyright 2017-2020, Voxel51, Inc.
+| Copyright 2017-2021, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/core/expressions.py
+++ b/fiftyone/core/expressions.py
@@ -1,7 +1,7 @@
 """
 Expressions for :class:`fiftyone.core.stages.ViewStage` definitions.
 
-| Copyright 2017-2020, Voxel51, Inc.
+| Copyright 2017-2021, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/core/fields.py
+++ b/fiftyone/core/fields.py
@@ -1,7 +1,7 @@
 """
 Dataset sample fields.
 
-| Copyright 2017-2020, Voxel51, Inc.
+| Copyright 2017-2021, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/core/frame.py
+++ b/fiftyone/core/frame.py
@@ -1,7 +1,7 @@
 """
 Video frames.
 
-| Copyright 2017-2020, Voxel51, Inc.
+| Copyright 2017-2021, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/core/frame_utils.py
+++ b/fiftyone/core/frame_utils.py
@@ -1,7 +1,7 @@
 """
 Frame utilites.
 
-| Copyright 2017-2020, Voxel51, Inc.
+| Copyright 2017-2021, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/core/labels.py
+++ b/fiftyone/core/labels.py
@@ -1,7 +1,7 @@
 """
 Labels stored in dataset samples.
 
-| Copyright 2017-2020, Voxel51, Inc.
+| Copyright 2017-2021, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/core/media.py
+++ b/fiftyone/core/media.py
@@ -1,7 +1,7 @@
 """
 Sample media utilities.
 
-| Copyright 2017-2020, Voxel51, Inc.
+| Copyright 2017-2021, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/core/metadata.py
+++ b/fiftyone/core/metadata.py
@@ -1,7 +1,7 @@
 """
 Metadata stored in dataset samples.
 
-| Copyright 2017-2020, Voxel51, Inc.
+| Copyright 2017-2021, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/core/models.py
+++ b/fiftyone/core/models.py
@@ -1,7 +1,7 @@
 """
 FiftyOne models.
 
-| Copyright 2017-2020, Voxel51, Inc.
+| Copyright 2017-2021, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/core/odm/__init__.py
+++ b/fiftyone/core/odm/__init__.py
@@ -1,7 +1,7 @@
 """
 ODM package declaration.
 
-| Copyright 2017-2020, Voxel51, Inc.
+| Copyright 2017-2021, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/core/odm/database.py
+++ b/fiftyone/core/odm/database.py
@@ -1,7 +1,7 @@
 """
 Database connection.
 
-| Copyright 2017-2020, Voxel51, Inc.
+| Copyright 2017-2021, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/core/odm/dataset.py
+++ b/fiftyone/core/odm/dataset.py
@@ -1,7 +1,7 @@
 """
 Documents that track datasets and their sample schemas in the database.
 
-| Copyright 2017-2020, Voxel51, Inc.
+| Copyright 2017-2021, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/core/odm/document.py
+++ b/fiftyone/core/odm/document.py
@@ -1,7 +1,7 @@
 """
 Base classes for documents that back dataset contents.
 
-| Copyright 2017-2020, Voxel51, Inc.
+| Copyright 2017-2021, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/core/odm/frame.py
+++ b/fiftyone/core/odm/frame.py
@@ -1,7 +1,7 @@
 """
 Backing document classes for :class:`fiftyone.core.frame.Frame` instances.
 
-| Copyright 2017-2020, Voxel51, Inc.
+| Copyright 2017-2021, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/core/odm/mixins.py
+++ b/fiftyone/core/odm/mixins.py
@@ -1,7 +1,7 @@
 """
 Mixins and helpers for sample backing documents.
 
-| Copyright 2017-2020, Voxel51, Inc.
+| Copyright 2017-2021, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/core/odm/sample.py
+++ b/fiftyone/core/odm/sample.py
@@ -43,7 +43,7 @@ type :class:`NoDatasetSampleDocument` to type ``dataset._sample_doc_cls``::
     dataset.add_sample(sample)
     sample._doc  # my_dataset(DatasetSampleDocument)
 
-| Copyright 2017-2020, Voxel51, Inc.
+| Copyright 2017-2021, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/core/sample.py
+++ b/fiftyone/core/sample.py
@@ -1,7 +1,7 @@
 """
 Dataset samples.
 
-| Copyright 2017-2020, Voxel51, Inc.
+| Copyright 2017-2021, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/core/service.py
+++ b/fiftyone/core/service.py
@@ -1,7 +1,7 @@
 """
 FiftyOne Services.
 
-| Copyright 2017-2020, Voxel51, Inc.
+| Copyright 2017-2021, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/core/session.py
+++ b/fiftyone/core/session.py
@@ -1,7 +1,7 @@
 """
 Session class for interacting with the FiftyOne App.
 
-| Copyright 2017-2020, Voxel51, Inc.
+| Copyright 2017-2021, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/core/singleton.py
+++ b/fiftyone/core/singleton.py
@@ -1,7 +1,7 @@
 """
 FiftyOne singleton metaclasses.
 
-| Copyright 2017-2020, Voxel51, Inc.
+| Copyright 2017-2021, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/core/stages.py
+++ b/fiftyone/core/stages.py
@@ -1,7 +1,7 @@
 """
 View stages.
 
-| Copyright 2017-2020, Voxel51, Inc.
+| Copyright 2017-2021, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/core/state.py
+++ b/fiftyone/core/state.py
@@ -1,7 +1,7 @@
 """
 Defines the shared state between the FiftyOne App and SDK.
 
-| Copyright 2017-2020, Voxel51, Inc.
+| Copyright 2017-2021, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/core/utils.py
+++ b/fiftyone/core/utils.py
@@ -1,7 +1,7 @@
 """
 Core utilities.
 
-| Copyright 2017-2020, Voxel51, Inc.
+| Copyright 2017-2021, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/core/validation.py
+++ b/fiftyone/core/validation.py
@@ -1,7 +1,7 @@
 """
 Validation utilities.
 
-| Copyright 2017-2020, Voxel51, Inc.
+| Copyright 2017-2021, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/core/view.py
+++ b/fiftyone/core/view.py
@@ -1,7 +1,7 @@
 """
 Dataset views.
 
-| Copyright 2017-2020, Voxel51, Inc.
+| Copyright 2017-2021, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/migrations/__init__.py
+++ b/fiftyone/migrations/__init__.py
@@ -1,7 +1,7 @@
 """
 FiftyOne's migration interface.
 
-| Copyright 2017-2020, Voxel51, Inc.
+| Copyright 2017-2021, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/migrations/revisions/admin/v0_7_1.py
+++ b/fiftyone/migrations/revisions/admin/v0_7_1.py
@@ -1,7 +1,7 @@
 """
 FiftyOne v0.7.1 revision
 
-| Copyright 2017-2020, Voxel51, Inc.
+| Copyright 2017-2021, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/migrations/revisions/v0_6_2.py
+++ b/fiftyone/migrations/revisions/v0_6_2.py
@@ -1,7 +1,7 @@
 """
 FiftyOne v0.6.2 revision
 
-| Copyright 2017-2020, Voxel51, Inc.
+| Copyright 2017-2021, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/migrations/revisions/v0_6_5.py
+++ b/fiftyone/migrations/revisions/v0_6_5.py
@@ -1,7 +1,7 @@
 """
 FiftyOne v0.6.5 revision
 
-| Copyright 2017-2020, Voxel51, Inc.
+| Copyright 2017-2021, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/migrations/runner.py
+++ b/fiftyone/migrations/runner.py
@@ -1,7 +1,7 @@
 """
 FiftyOne migrations runner.
 
-| Copyright 2017-2020, Voxel51, Inc.
+| Copyright 2017-2021, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/server/README.md
+++ b/fiftyone/server/README.md
@@ -6,5 +6,4 @@ Project FiftyOne Flask Server
 
 ## Copyright
 
-Copyright 2017-2021, Voxel51, Inc.<br>
-voxel51.com
+Copyright 2017-2021, Voxel51, Inc.<br> voxel51.com

--- a/fiftyone/server/README.md
+++ b/fiftyone/server/README.md
@@ -6,5 +6,5 @@ Project FiftyOne Flask Server
 
 ## Copyright
 
-Copyright 2017-2020, Voxel51, Inc.<br>
+Copyright 2017-2021, Voxel51, Inc.<br>
 voxel51.com

--- a/fiftyone/server/json_util.py
+++ b/fiftyone/server/json_util.py
@@ -1,7 +1,7 @@
 """
 FiftyOne server json utilies.
 
-| Copyright 2017-2020, Voxel51, Inc.
+| Copyright 2017-2021, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/server/main.py
+++ b/fiftyone/server/main.py
@@ -1,7 +1,7 @@
 """
 FiftyOne Tornado server.
 
-| Copyright 2017-2020, Voxel51, Inc.
+| Copyright 2017-2021, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/server/pipelines.py
+++ b/fiftyone/server/pipelines.py
@@ -1,7 +1,7 @@
 """
 FiftyOne App pipeline definiutions.
 
-| Copyright 2017-2020, Voxel51, Inc.
+| Copyright 2017-2021, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/server/util.py
+++ b/fiftyone/server/util.py
@@ -5,7 +5,7 @@ Taken from https://github.com/scardine/image_size/blob/master/get_image_size.py
 
 TODO (BEN): clean up, document, and fit into fiftyone.core
 
-| Copyright 2017-2020, Voxel51, Inc.
+| Copyright 2017-2021, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/service/__init__.py
+++ b/fiftyone/service/__init__.py
@@ -1,7 +1,7 @@
 """
 FiftyOne service support.
 
-| Copyright 2017-2020, Voxel51, Inc.
+| Copyright 2017-2021, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/service/ipc.py
+++ b/fiftyone/service/ipc.py
@@ -1,7 +1,7 @@
 """
 Inter-process communication handling.
 
-| Copyright 2017-2020, Voxel51, Inc.
+| Copyright 2017-2021, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/service/main.py
+++ b/fiftyone/service/main.py
@@ -23,7 +23,7 @@ script will continue running in the background and keep the child process alive
 until all registered clients, including the original parent process, have
 exited.
 
-| Copyright 2017-2020, Voxel51, Inc.
+| Copyright 2017-2021, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/service/util.py
+++ b/fiftyone/service/util.py
@@ -1,7 +1,7 @@
 """
 FiftyOne service utilities.
 
-| Copyright 2017-2020, Voxel51, Inc.
+| Copyright 2017-2021, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/types/__init__.py
+++ b/fiftyone/types/__init__.py
@@ -1,7 +1,7 @@
 """
 FiftyOne types.
 
-| Copyright 2017-2020, Voxel51, Inc.
+| Copyright 2017-2021, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/types/dataset_types.py
+++ b/fiftyone/types/dataset_types.py
@@ -1,7 +1,7 @@
 """
 FiftyOne dataset types.
 
-| Copyright 2017-2020, Voxel51, Inc.
+| Copyright 2017-2021, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/utils/__init__.py
+++ b/fiftyone/utils/__init__.py
@@ -1,5 +1,5 @@
 """
-| Copyright 2017-2020, Voxel51, Inc.
+| Copyright 2017-2021, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/utils/annotations.py
+++ b/fiftyone/utils/annotations.py
@@ -1,7 +1,7 @@
 """
 Data annotation utilities.
 
-| Copyright 2017-2020, Voxel51, Inc.
+| Copyright 2017-2021, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/utils/bdd.py
+++ b/fiftyone/utils/bdd.py
@@ -2,7 +2,7 @@
 Utilities for working with datasets in
 `Berkeley DeepDrive (BDD) format <https://bdd-data.berkeley.edu>`_.
 
-| Copyright 2017-2020, Voxel51, Inc.
+| Copyright 2017-2021, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/utils/cityscapes.py
+++ b/fiftyone/utils/cityscapes.py
@@ -2,7 +2,7 @@
 Utilities for working with the
 `Cityscapes dataset <https://www.cityscapes-dataset.com>`_.
 
-| Copyright 2017-2020, Voxel51, Inc.
+| Copyright 2017-2021, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/utils/coco.py
+++ b/fiftyone/utils/coco.py
@@ -2,7 +2,7 @@
 Utilities for working with datasets in
 `COCO format <https://cocodataset.org/#format-data>`_.
 
-| Copyright 2017-2020, Voxel51, Inc.
+| Copyright 2017-2021, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/utils/cvat.py
+++ b/fiftyone/utils/cvat.py
@@ -2,7 +2,7 @@
 Utilities for working with datasets in
 `CVAT format <https://github.com/opencv/cvat>`_.
 
-| Copyright 2017-2020, Voxel51, Inc.
+| Copyright 2017-2021, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/utils/data/__init__.py
+++ b/fiftyone/utils/data/__init__.py
@@ -1,7 +1,7 @@
 """
 Data utilities.
 
-| Copyright 2017-2020, Voxel51, Inc.
+| Copyright 2017-2021, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/utils/data/base.py
+++ b/fiftyone/utils/data/base.py
@@ -1,7 +1,7 @@
 """
 Data utilities.
 
-| Copyright 2017-2020, Voxel51, Inc.
+| Copyright 2017-2021, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/utils/data/converters.py
+++ b/fiftyone/utils/data/converters.py
@@ -1,7 +1,7 @@
 """
 Dataset format conversion utilities.
 
-| Copyright 2017-2020, Voxel51, Inc.
+| Copyright 2017-2021, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/utils/data/exporters.py
+++ b/fiftyone/utils/data/exporters.py
@@ -1,7 +1,7 @@
 """
 Dataset exporters.
 
-| Copyright 2017-2020, Voxel51, Inc.
+| Copyright 2017-2021, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/utils/data/importers.py
+++ b/fiftyone/utils/data/importers.py
@@ -1,7 +1,7 @@
 """
 Dataset importers.
 
-| Copyright 2017-2020, Voxel51, Inc.
+| Copyright 2017-2021, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/utils/data/ingestors.py
+++ b/fiftyone/utils/data/ingestors.py
@@ -1,7 +1,7 @@
 """
 Dataset ingestors.
 
-| Copyright 2017-2020, Voxel51, Inc.
+| Copyright 2017-2021, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/utils/data/parsers.py
+++ b/fiftyone/utils/data/parsers.py
@@ -1,7 +1,7 @@
 """
 Sample parsers.
 
-| Copyright 2017-2020, Voxel51, Inc.
+| Copyright 2017-2021, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/utils/eval/__init__.py
+++ b/fiftyone/utils/eval/__init__.py
@@ -1,7 +1,7 @@
 """
 Evaluation utilities.
 
-| Copyright 2017-2020, Voxel51, Inc.
+| Copyright 2017-2021, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/utils/eval/coco.py
+++ b/fiftyone/utils/eval/coco.py
@@ -1,7 +1,7 @@
 """
 COCO-style detection evaluation.
 
-| Copyright 2017-2020, Voxel51, Inc.
+| Copyright 2017-2021, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/utils/hmdb51.py
+++ b/fiftyone/utils/hmdb51.py
@@ -2,7 +2,7 @@
 Utilities for working with the
 `HMDB51 dataset <https://serre-lab.clps.brown.edu/resource/hmdb-a-large-human-motion-database>`_.
 
-| Copyright 2017-2020, Voxel51, Inc.
+| Copyright 2017-2021, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/utils/image.py
+++ b/fiftyone/utils/image.py
@@ -1,7 +1,7 @@
 """
 Image utilities.
 
-| Copyright 2017-2020, Voxel51, Inc.
+| Copyright 2017-2021, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/utils/imagenet.py
+++ b/fiftyone/utils/imagenet.py
@@ -1,7 +1,7 @@
 """
 Utilities for working with the `ImageNet dataset <http://www.image-net.org>`_.
 
-| Copyright 2017-2020, Voxel51, Inc.
+| Copyright 2017-2021, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/utils/kitti.py
+++ b/fiftyone/utils/kitti.py
@@ -2,7 +2,7 @@
 Utilities for working with datasets in
 `KITTI format <http://www.cvlibs.net/datasets/kitti/eval_object.php>`_.
 
-| Copyright 2017-2020, Voxel51, Inc.
+| Copyright 2017-2021, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/utils/labelbox.py
+++ b/fiftyone/utils/labelbox.py
@@ -2,7 +2,7 @@
 Utilities for working with annotations in
 `Labelbox format <https://labelbox.com/docs/exporting-data/export-format-detail>`_.
 
-| Copyright 2017-2020, Voxel51, Inc.
+| Copyright 2017-2021, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/utils/lfw.py
+++ b/fiftyone/utils/lfw.py
@@ -2,7 +2,7 @@
 Utilities for working with the
 `Labeled Faces in the Wild dataset <http://vis-www.cs.umass.edu/lfw>`_.
 
-| Copyright 2017-2020, Voxel51, Inc.
+| Copyright 2017-2021, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/utils/metadata.py
+++ b/fiftyone/utils/metadata.py
@@ -1,7 +1,7 @@
 """
 Metadata utilities.
 
-| Copyright 2017-2020, Voxel51, Inc.
+| Copyright 2017-2021, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/utils/quickstart.py
+++ b/fiftyone/utils/quickstart.py
@@ -1,7 +1,7 @@
 """
 FiftyOne quickstart.
 
-| Copyright 2017-2020, Voxel51, Inc.
+| Copyright 2017-2021, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/utils/scale.py
+++ b/fiftyone/utils/scale.py
@@ -2,7 +2,7 @@
 Utilities for working with annotations in
 `Scale AI format <https://docs.scale.com/reference#annotation>`_.
 
-| Copyright 2017-2020, Voxel51, Inc.
+| Copyright 2017-2021, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/utils/tf.py
+++ b/fiftyone/utils/tf.py
@@ -1,7 +1,7 @@
 """
 TensorFlow utilities.
 
-| Copyright 2017-2020, Voxel51, Inc.
+| Copyright 2017-2021, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/utils/torch.py
+++ b/fiftyone/utils/torch.py
@@ -1,7 +1,7 @@
 """
 PyTorch utilities.
 
-| Copyright 2017-2020, Voxel51, Inc.
+| Copyright 2017-2021, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/utils/ucf101.py
+++ b/fiftyone/utils/ucf101.py
@@ -2,7 +2,7 @@
 Utilities for working with the
 `UCF101 dataset <https://www.crcv.ucf.edu/research/data-sets/ucf101>`_.
 
-| Copyright 2017-2020, Voxel51, Inc.
+| Copyright 2017-2021, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/utils/uid.py
+++ b/fiftyone/utils/uid.py
@@ -1,6 +1,6 @@
 """Utilities for usage analytics
 
-| Copyright 2017-2020, Voxel51, Inc.
+| Copyright 2017-2021, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/utils/video.py
+++ b/fiftyone/utils/video.py
@@ -1,7 +1,7 @@
 """
 Video utilities.
 
-| Copyright 2017-2020, Voxel51, Inc.
+| Copyright 2017-2021, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/utils/voc.py
+++ b/fiftyone/utils/voc.py
@@ -2,7 +2,7 @@
 Utilities for working with datasets in
 `VOC format <http://host.robots.ox.ac.uk/pascal/VOC>`_.
 
-| Copyright 2017-2020, Voxel51, Inc.
+| Copyright 2017-2021, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/utils/yolo.py
+++ b/fiftyone/utils/yolo.py
@@ -2,7 +2,7 @@
 Utilities for working with datasets in
 `YOLO format <https://github.com/AlexeyAB/darknet>`_.
 
-| Copyright 2017-2020, Voxel51, Inc.
+| Copyright 2017-2021, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/zoo/__init__.py
+++ b/fiftyone/zoo/__init__.py
@@ -1,7 +1,7 @@
 """
 The FiftyOne Zoo.
 
-Copyright 2017-2020, Voxel51, Inc.
+Copyright 2017-2021, Voxel51, Inc.
 voxel51.com
 """
 from .datasets import *

--- a/fiftyone/zoo/datasets/__init__.py
+++ b/fiftyone/zoo/datasets/__init__.py
@@ -4,7 +4,7 @@ The FiftyOne Dataset Zoo.
 This package defines a collection of open source datasets made available for
 download via FiftyOne.
 
-| Copyright 2017-2020, Voxel51, Inc.
+| Copyright 2017-2021, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/zoo/datasets/base.py
+++ b/fiftyone/zoo/datasets/base.py
@@ -1,7 +1,7 @@
 """
 FiftyOne Zoo Datasets provided natively by the library.
 
-| Copyright 2017-2020, Voxel51, Inc.
+| Copyright 2017-2021, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/zoo/datasets/tf.py
+++ b/fiftyone/zoo/datasets/tf.py
@@ -1,7 +1,7 @@
 """
 FiftyOne Zoo Datasets provided by ``tensorflow_datasets``.
 
-| Copyright 2017-2020, Voxel51, Inc.
+| Copyright 2017-2021, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/zoo/datasets/torch.py
+++ b/fiftyone/zoo/datasets/torch.py
@@ -1,7 +1,7 @@
 """
 FiftyOne Zoo Datasets provided by ``torchvision.datasets``.
 
-| Copyright 2017-2020, Voxel51, Inc.
+| Copyright 2017-2021, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/zoo/models/__init__.py
+++ b/fiftyone/zoo/models/__init__.py
@@ -1,7 +1,7 @@
 """
 The FiftyOne Model Zoo.
 
-| Copyright 2017-2020, Voxel51, Inc.
+| Copyright 2017-2021, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/zoo/models/torch.py
+++ b/fiftyone/zoo/models/torch.py
@@ -1,7 +1,7 @@
 """
 FiftyOne Zoo models provided by ``torchvision.models``.
 
-| Copyright 2017-2020, Voxel51, Inc.
+| Copyright 2017-2021, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/install.bash
+++ b/install.bash
@@ -4,7 +4,7 @@
 # Usage:
 #   bash install.bash
 #
-# Copyright 2017-2020, Voxel51, Inc.
+# Copyright 2017-2021, Voxel51, Inc.
 # voxel51.com
 #
 

--- a/package/db/setup.py
+++ b/package/db/setup.py
@@ -2,7 +2,7 @@
 """
 Installs FiftyOne.
 
-| Copyright 2017-2020, Voxel51, Inc.
+| Copyright 2017-2021, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/package/desktop/setup.py
+++ b/package/desktop/setup.py
@@ -2,7 +2,7 @@
 """
 Installs FiftyOne Desktop.
 
-| Copyright 2017-2020, Voxel51, Inc.
+| Copyright 2017-2021, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 """
 Installs FiftyOne.
 
-| Copyright 2017-2020, Voxel51, Inc.
+| Copyright 2017-2021, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/tests/README.md
+++ b/tests/README.md
@@ -30,4 +30,4 @@ pytest unittests/<file>.py
 
 ## Copyright
 
-Copyright 2017-2020, Voxel51, Inc.<br> voxel51.com
+Copyright 2017-2021, Voxel51, Inc.<br> voxel51.com

--- a/tests/benchmarking/add_samples_benchmark.py
+++ b/tests/benchmarking/add_samples_benchmark.py
@@ -3,7 +3,7 @@ Benchmarking for :func:`fiftyone.core.dataset.Dataset.add_samples`.
 
 Results are written to `add_samples_benchmark.log`.
 
-| Copyright 2017-2020, Voxel51, Inc.
+| Copyright 2017-2021, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/tests/benchmarking/cifar10_benchmark.py
+++ b/tests/benchmarking/cifar10_benchmark.py
@@ -3,7 +3,7 @@ Benchmarking CRUD operations on CIFAR10.
 
 Results are appended to `cifar10_benchmark.log`.
 
-| Copyright 2017-2020, Voxel51, Inc.
+| Copyright 2017-2021, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/tests/intensive/dataset_zoo_tests.py
+++ b/tests/intensive/dataset_zoo_tests.py
@@ -1,7 +1,7 @@
 """
 Dataset zoo tests.
 
-| Copyright 2017-2020, Voxel51, Inc.
+| Copyright 2017-2021, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/tests/intensive/import_export_tests.py
+++ b/tests/intensive/import_export_tests.py
@@ -1,7 +1,7 @@
 """
 Dataset import/export tests.
 
-| Copyright 2017-2020, Voxel51, Inc.
+| Copyright 2017-2021, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/tests/intensive/model_zoo_tests.py
+++ b/tests/intensive/model_zoo_tests.py
@@ -1,7 +1,7 @@
 """
 Model zoo tests.
 
-| Copyright 2017-2020, Voxel51, Inc.
+| Copyright 2017-2021, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/tests/intensive/utils_tests.py
+++ b/tests/intensive/utils_tests.py
@@ -1,7 +1,7 @@
 """
 Utils tests.
 
-| Copyright 2017-2020, Voxel51, Inc.
+| Copyright 2017-2021, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/tests/ipc_tests.py
+++ b/tests/ipc_tests.py
@@ -1,7 +1,7 @@
 """
 Tests related to inter-process communication (for services).
 
-| Copyright 2017-2020, Voxel51, Inc.
+| Copyright 2017-2021, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/tests/isolated/import_deps_test.py
+++ b/tests/isolated/import_deps_test.py
@@ -1,7 +1,7 @@
 """
 Test that the fiftyone core does not depend on Tensorflow or PyTorch.
 
-| Copyright 2017-2020, Voxel51, Inc.
+| Copyright 2017-2021, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/tests/isolated/import_time_test.py
+++ b/tests/isolated/import_time_test.py
@@ -1,7 +1,7 @@
 """
 Test that fiftyone can be imported in a reasonable amount of time.
 
-| Copyright 2017-2020, Voxel51, Inc.
+| Copyright 2017-2021, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/tests/isolated/server_tests.py
+++ b/tests/isolated/server_tests.py
@@ -7,7 +7,7 @@ To run a single test, modify the main code to::
     singletest.addTest(TESTCASE("<TEST METHOD NAME>"))
     unittest.TextTestRunner().run(singletest)
 
-| Copyright 2017-2020, Voxel51, Inc.
+| Copyright 2017-2021, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/tests/isolated/service_tests.py
+++ b/tests/isolated/service_tests.py
@@ -1,7 +1,7 @@
 """
 Service tests.
 
-| Copyright 2017-2020, Voxel51, Inc.
+| Copyright 2017-2021, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/tests/misc/labelbox_tests.py
+++ b/tests/misc/labelbox_tests.py
@@ -1,7 +1,7 @@
 """
 Tests for the :mod:`fiftyone.utils.labelbox` module.
 
-| Copyright 2017-2020, Voxel51, Inc.
+| Copyright 2017-2021, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/tests/misc/scale_tests.py
+++ b/tests/misc/scale_tests.py
@@ -1,7 +1,7 @@
 """
 Tests for the :mod:`fiftyone.utils.scale` module.
 
-| Copyright 2017-2020, Voxel51, Inc.
+| Copyright 2017-2021, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/tests/misc/selection_tests.py
+++ b/tests/misc/selection_tests.py
@@ -2,7 +2,7 @@
 Unit tests for :class:`fiftyone.core.stages.SelectObjects` and
 :class:`fiftyone.core.stages.ExcludeObjects`.
 
-| Copyright 2017-2020, Voxel51, Inc.
+| Copyright 2017-2021, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/tests/misc/torch_tests.py
+++ b/tests/misc/torch_tests.py
@@ -1,7 +1,7 @@
 """
 Tests for the :mod:`fiftyone.utils.torch` module.
 
-| Copyright 2017-2020, Voxel51, Inc.
+| Copyright 2017-2021, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/tests/session_tests.py
+++ b/tests/session_tests.py
@@ -1,7 +1,7 @@
 """
 Tests related to Session behavior.
 
-| Copyright 2017-2020, Voxel51, Inc.
+| Copyright 2017-2021, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/tests/unittests/aggregation_tests.py
+++ b/tests/unittests/aggregation_tests.py
@@ -1,7 +1,7 @@
 """
 FiftyOne aggregation-related unit tests.
 
-| Copyright 2017-2020, Voxel51, Inc.
+| Copyright 2017-2021, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/tests/unittests/dataset_tests.py
+++ b/tests/unittests/dataset_tests.py
@@ -1,7 +1,7 @@
 """
 FiftyOne dataset-related unit tests.
 
-| Copyright 2017-2020, Voxel51, Inc.
+| Copyright 2017-2021, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/tests/unittests/decorators.py
+++ b/tests/unittests/decorators.py
@@ -1,7 +1,7 @@
 """
 Decorator utils for unit tests.
 
-| Copyright 2017-2020, Voxel51, Inc.
+| Copyright 2017-2021, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/tests/unittests/sample_tests.py
+++ b/tests/unittests/sample_tests.py
@@ -1,7 +1,7 @@
 """
 FiftyOne sample-related unit tests.
 
-| Copyright 2017-2020, Voxel51, Inc.
+| Copyright 2017-2021, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/tests/unittests/synchronization_tests.py
+++ b/tests/unittests/synchronization_tests.py
@@ -1,7 +1,7 @@
 """
 FiftyOne synchronization-related unit tests.
 
-| Copyright 2017-2020, Voxel51, Inc.
+| Copyright 2017-2021, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/tests/unittests/utils_tests.py
+++ b/tests/unittests/utils_tests.py
@@ -1,7 +1,7 @@
 """
 FiftyOne utilities unit tests.
 
-| Copyright 2017-2020, Voxel51, Inc.
+| Copyright 2017-2021, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/tests/unittests/view_tests.py
+++ b/tests/unittests/view_tests.py
@@ -1,7 +1,7 @@
 """
 FiftyOne view-related unit tests.
 
-| Copyright 2017-2020, Voxel51, Inc.
+| Copyright 2017-2021, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/tests/utils/command_wrapper.py
+++ b/tests/utils/command_wrapper.py
@@ -1,7 +1,7 @@
 """
 Wrapper around an arbitrary command that cleans up subprocesses.
 
-| Copyright 2017-2020, Voxel51, Inc.
+| Copyright 2017-2021, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/tests/utils/github_actions_flags.py
+++ b/tests/utils/github_actions_flags.py
@@ -1,7 +1,7 @@
 """
 Sets up flags used by GitHub Actions to determine which tests to run.
 
-| Copyright 2017-2020, Voxel51, Inc.
+| Copyright 2017-2021, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/tests/utils/interactive_python.py
+++ b/tests/utils/interactive_python.py
@@ -2,7 +2,7 @@
 A script that simulates a Python shell and accepts arbitrary commands to
 execute. For use by service tests.
 
-| Copyright 2017-2020, Voxel51, Inc.
+| Copyright 2017-2021, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/tests/utils/pytest_wrapper.py
+++ b/tests/utils/pytest_wrapper.py
@@ -1,7 +1,7 @@
 """
 Wrapper around pytest that cleans up subprocesses.
 
-| Copyright 2017-2020, Voxel51, Inc.
+| Copyright 2017-2021, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/tests/utils/session_helper.py
+++ b/tests/utils/session_helper.py
@@ -1,7 +1,7 @@
 """
 A script that sets up and tears down a session. For use by session tests.
 
-| Copyright 2017-2020, Voxel51, Inc.
+| Copyright 2017-2021, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/tests/utils/setup_config.py
+++ b/tests/utils/setup_config.py
@@ -1,7 +1,7 @@
 """
 Sets up configuration for tests.
 
-| Copyright 2017-2020, Voxel51, Inc.
+| Copyright 2017-2021, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """


### PR DESCRIPTION
Updates all of the copyright lines I could find to 2021.

Useful command:
```
find . -type f -name "*" -print0 | xargs -0 sed -i "s/Copyright 2017-2020, Voxel51, Inc/Copyright 2017-2021, Voxel51, Inc/g"
```