### PR TITLE
Clarifying how to close browser App sessions

### DIFF
--- a/fiftyone/core/cli.py
+++ b/fiftyone/core/cli.py
@@ -846,15 +846,16 @@ class AppLaunchCommand(Command):
             desktop=desktop,
         )
 
-        _watch_session(session, remote=args.remote)
+        _watch_session(session)
 
 
-def _watch_session(session, remote=False):
+def _watch_session(session):
     try:
-        if remote:
-            print("\nTo exit, press ctrl + c\n")
-        else:
+        if session.desktop:
             print("\nTo exit, close the App or press ctrl + c\n")
+        else:
+            print("\nTo exit, press ctrl + c\n")
+
         session.wait()
     except KeyboardInterrupt:
         pass
@@ -1059,7 +1060,7 @@ class AppViewCommand(Command):
             desktop=desktop,
         )
 
-        _watch_session(session, remote=args.remote)
+        _watch_session(session)
 
 
 class AppConnectCommand(Command):


### PR DESCRIPTION
My response to https://github.com/voxel51/fiftyone/issues/790.

```shell
$ fiftyone app launch
App launched. Point your web browser to http://localhost:5151

To exit, press ctrl + c
```

```
$ fiftyone app launch --desktop
Desktop App launched.

To exit, close the App or press ctrl + c
```

```shell
$ fiftyone app launch --remote
You have launched a remote App on port 5151. To connect to this App from another
machine, issue the following command:

fiftyone app connect --destination [<username>@]<hostname> --port 5151

where `[<username>@]<hostname>` refers to your current machine. Alternatively,
you can manually configure port forwarding on another machine as follows:

ssh -N -L 5151:127.0.0.1:5151 [<username>@]<hostname>

The App can then be viewed in your browser at http://localhost:5151.

See https://voxel51.com/docs/fiftyone/user_guide/app.html#remote-sessions
for more information about remote sessions.

To exit, press ctrl + c
```
