### PR TITLE
Improved plotting

### DIFF
--- a/app/src/components/Distributions.tsx
+++ b/app/src/components/Distributions.tsx
@@ -21,6 +21,36 @@ const Container = styled.div`
   padding-left: 1rem;
 `;
 
+const TooltipDiv = styled.div`
+  box-sizing: border-box;
+  border-radius: 3px;
+  background-color: ${({ theme }) => theme.backgroundDarker};
+  box-shadow: 0 2px 25px 0 ${({ theme }) => theme.darkShadow};
+  color: ${({ theme }) => theme.fontDark};
+  border-radius: 2px;
+  padding: 0.5rem;
+  line-height: 1rem;
+  margin-top: 2.5rem;
+  font-weight: bold;
+  width: auto;
+  z-index: 802;
+`;
+
+const TooltipHeader = styled.div`
+  color: ${({ theme }) => theme.font};
+  display: flex;
+  padding-bottom: 0.5rem;
+`;
+
+const PlotTooltip = ({ title, count }) => {
+  return (
+    <TooltipDiv>
+      <TooltipHeader>{title}</TooltipHeader>
+      Count: {count}
+    </TooltipDiv>
+  );
+};
+
 class CustomizedAxisTick extends PureComponent {
   render() {
     const { x, y, payload, fill } = this.props;
@@ -53,7 +83,7 @@ const Title = styled.div`
 `;
 
 const Distribution = ({ distribution }) => {
-  const { name, data, ticks } = distribution;
+  const { name, data, ticks, type } = distribution;
   const [ref, { height }] = useMeasure();
   const barWidth = 24;
   const container = useRef(null);
@@ -65,14 +95,14 @@ const Distribution = ({ distribution }) => {
       : {
           ticks,
         };
+
   const map = data.reduce(
     (acc, cur) => ({
-      [cur.key]: cur.edges,
       ...acc,
+      [cur.key]: cur.edges,
     }),
     {}
   );
-  console.log(map);
 
   return (
     <Container ref={ref}>
@@ -103,11 +133,15 @@ const Distribution = ({ distribution }) => {
           cursor={false}
           content={(point) => {
             const key = point?.payload[0]?.payload?.key;
-            console.log(key);
+            const count = point?.payload[0]?.payload?.count;
+            if (typeof count !== "number") return;
+            let title = key;
             if (map[key]) {
-              return `[${map[key].map((e) => e.toFixed(3)).join(", ")})`;
+              title = `Range: [${map[key]
+                .map((e) => (type === "IntField" ? e : e.toFixed(3)))
+                .join(", ")})`;
             }
-            return "hello";
+            return <PlotTooltip title={title} count={count} />;
           }}
           contentStyle={{
             background: "hsl(210, 20%, 23%)",

--- a/app/src/components/Distributions.tsx
+++ b/app/src/components/Distributions.tsx
@@ -65,6 +65,14 @@ const Distribution = ({ distribution }) => {
       : {
           ticks,
         };
+  const map = data.reduce(
+    (acc, cur) => ({
+      [cur.key]: cur.edges,
+      ...acc,
+    }),
+    {}
+  );
+  console.log(map);
 
   return (
     <Container ref={ref}>
@@ -93,6 +101,14 @@ const Distribution = ({ distribution }) => {
         />
         <Tooltip
           cursor={false}
+          content={(point) => {
+            const key = point?.payload[0]?.payload?.key;
+            console.log(key);
+            if (map[key]) {
+              return `[${map[key].map((e) => e.toFixed(3)).join(", ")})`;
+            }
+            return "hello";
+          }}
           contentStyle={{
             background: "hsl(210, 20%, 23%)",
             borderColor: "rgb(255, 109, 4)",

--- a/app/src/components/Distributions.tsx
+++ b/app/src/components/Distributions.tsx
@@ -59,6 +59,12 @@ const Distribution = ({ distribution }) => {
   const container = useRef(null);
   const stroke = "hsl(210, 20%, 90%)";
   const fill = stroke;
+  const ticksSetting =
+    ticks === 0
+      ? { interval: ticks }
+      : {
+          ticks,
+        };
 
   return (
     <Container ref={ref}>
@@ -77,7 +83,7 @@ const Distribution = ({ distribution }) => {
           axisLine={false}
           tick={<CustomizedAxisTick {...{ fill }} />}
           tickLine={{ stroke }}
-          interval={ticks}
+          {...ticksSetting}
         />
         <YAxis
           dataKey="count"

--- a/app/src/components/Distributions.tsx
+++ b/app/src/components/Distributions.tsx
@@ -135,7 +135,7 @@ const Distribution = ({ distribution }) => {
             const key = point?.payload[0]?.payload?.key;
             const count = point?.payload[0]?.payload?.count;
             if (typeof count !== "number") return;
-            let title = key;
+            let title = `Value: ${key}`;
             if (map[key]) {
               title = `Range: [${map[key]
                 .map((e) => (type === "IntField" ? e : e.toFixed(3)))

--- a/app/src/components/Distributions.tsx
+++ b/app/src/components/Distributions.tsx
@@ -53,13 +53,12 @@ const Title = styled.div`
 `;
 
 const Distribution = ({ distribution }) => {
-  const { name, type, data } = distribution;
+  const { name, data, ticks } = distribution;
   const [ref, { height }] = useMeasure();
   const barWidth = 24;
   const container = useRef(null);
   const stroke = "hsl(210, 20%, 90%)";
   const fill = stroke;
-  const isNumeric = _.indexOf(["IntField", "FloatField"], type) >= 0;
 
   return (
     <Container ref={ref}>
@@ -74,12 +73,11 @@ const Distribution = ({ distribution }) => {
       >
         <XAxis
           dataKey="key"
-          type="category"
-          interval={isNumeric ? "preserveStartEnd" : 0}
           height={0.2 * height}
           axisLine={false}
           tick={<CustomizedAxisTick {...{ fill }} />}
           tickLine={{ stroke }}
+          interval={ticks}
         />
         <YAxis
           dataKey="count"

--- a/fiftyone/server/main.py
+++ b/fiftyone/server/main.py
@@ -918,7 +918,7 @@ def _parse_histogram_values(result, field):
             {
                 "key": round((k + result.edges[idx + 1]) / 2, 4),
                 "count": v,
-                "edges": (result.edges[0], result.edges[1]),
+                "edges": (k, result.edges[idx + 1]),
             }
             for idx, (k, v) in enumerate(zip(result.edges, result.counts))
         ],
@@ -1043,6 +1043,9 @@ async def _numeric_histograms(coll, view, schema, prefix=""):
         range_ = result.bounds
         bins = _DEFAULT_NUM_HISTOGRAM_BINS
         num_ticks = None
+        if range_[0] == range_[1]:
+            bins = 1
+
         if range_ == (None, None):
             range_ = (0, 1)
         elif fos._meets_type(field, fof.IntField):


### PR DESCRIPTION
Resolves #798.

Changes:
* Empty counts are filtered from plots
* Integers are binned up to 100, and then floating points take over
* ~5 tick marks are used when binning in floating point values

I can decrease the max number of integer bins, of course. Really, I could make nice clean bins for all integer ranges...maxing out at say 25 bins.

![Screenshot from 2021-01-20 14-29-37](https://user-images.githubusercontent.com/19821840/105243551-71bf8e80-5b2c-11eb-9533-8c81bb582c76.png)
![Screenshot from 2021-01-20 14-29-31](https://user-images.githubusercontent.com/19821840/105243555-72582500-5b2c-11eb-99f3-e3242bc93744.png)
![Screenshot from 2021-01-20 14-29-24](https://user-images.githubusercontent.com/19821840/105243556-72582500-5b2c-11eb-8d70-fbc4d7e88c37.png)
