### PR TITLE
Prevent Colab from caching requests in notebooks

### DIFF
--- a/fiftyone/server/main.py
+++ b/fiftyone/server/main.py
@@ -58,6 +58,7 @@ class RequestHandler(tornado.web.RequestHandler):
         self.set_header("Access-Control-Allow-Origin", "*")
         self.set_header("Access-Control-Allow-Headers", "x-requested-with")
         self.set_header("Access-Control-Allow-Methods", "POST, GET, OPTIONS")
+        self.set_header("x-colab-notebook-cache-control", "no-cache")
 
     async def get(self):
         self.write(self.get_response())
@@ -1075,6 +1076,7 @@ class FileHandler(tornado.web.StaticFileHandler):
         self.set_header("Access-Control-Allow-Headers", "x-requested-with")
         self.set_header("Access-Control-Allow-Methods", "GET, HEAD, OPTIONS")
         self.set_header("content-length", self.get_content_size())
+        self.set_header("x-colab-notebook-cache-control", "no-cache")
 
 
 class Application(tornado.web.Application):


### PR DESCRIPTION
Turns cache control off for all server requests in Colab. This prevents the responses from being saved in the notebook json.

Without Colab's cache control turned off, Colab notebook jsons will become huge while using the App, quickly becoming unusable.

See [here](https://colab.research.google.com/notebooks/snippets/advanced_outputs.ipynb#scrollTo=R8ZvCXC5A0wT)