### PR TITLE
lstrip error when saving sample

### DIFF
--- a/fiftyone/core/odm/mixins.py
+++ b/fiftyone/core/odm/mixins.py
@@ -715,7 +715,9 @@ class DatasetMixin(object):
             for d in update_doc.values():
                 for k in d.keys():
                     for ff in filtered_fields:
-                        if k.startswith(ff) and not k.lstrip(ff).count("."):
+                        if k.startswith(ff) and not k.replace(
+                            ff, "", 1
+                        ).lstrip(".").count("."):
                             raise ValueError(
                                 "Modifying root of filtered list field '%s' "
                                 "is not allowed" % k
@@ -768,7 +770,11 @@ class DatasetMixin(object):
         for field_name in filtered_field.split("."):
             el = el[field_name]
 
-        el_fields = list_element_field.lstrip(filtered_field).split(".")
+        el_fields = (
+            list_element_field.replace(filtered_field, "", 1)
+            .lstrip(".")
+            .split(".")
+        )
         idx = int(el_fields.pop(0))
 
         el = el[idx]

--- a/fiftyone/core/odm/mixins.py
+++ b/fiftyone/core/odm/mixins.py
@@ -715,9 +715,9 @@ class DatasetMixin(object):
             for d in update_doc.values():
                 for k in d.keys():
                     for ff in filtered_fields:
-                        if k.startswith(ff) and not k.replace(
-                            ff, "", 1
-                        ).lstrip(".").count("."):
+                        if k.startswith(ff) and not k[len(ff) :].lstrip(
+                            "."
+                        ).count("."):
                             raise ValueError(
                                 "Modifying root of filtered list field '%s' "
                                 "is not allowed" % k
@@ -771,9 +771,7 @@ class DatasetMixin(object):
             el = el[field_name]
 
         el_fields = (
-            list_element_field.replace(filtered_field, "", 1)
-            .lstrip(".")
-            .split(".")
+            list_element_field[len(filtered_field) :].lstrip(".").split(".")
         )
         idx = int(el_fields.pop(0))
 


### PR DESCRIPTION
There is a bug in the logic here: https://github.com/voxel51/fiftyone/blob/a07d3ddb4b4b20143b67f08b9bcf27a6e9311d5a/fiftyone/core/odm/mixins.py#L708

The goal is to match
```
        #   my_detections.detections          <- MATCH
        #   my_detections.detections.1        <- MATCH
        #   my_detections.detections.1.label  <- NO MATCH
```

But if the field name includes a number, then this will fail. For example,
```
        #   my_detections1.detections          <- MATCH
        #   my_detections1.detections.1        <- MATCH
        #   my_detections1.detections.1.label  <- MATCH
```

Code to replicate:
``` python
import fiftyone as fo
from fiftyone import ViewField as F

dataset, session = fo.quickstart()

dataset.clone_sample_field("predictions", "predictions1")

view = dataset.filter_detections("predictions1", F("confidence") > 0.01)

sample = view.first()

for det in sample.predictions1.detections:
    det["test"] = "test"

sample.save()
```

```
ValueError: Modifying root of filtered list field 'predictions1.detections.1.test' is not allowed
```

The problem was that `k.lstrip(ff)` would strip the `1` in `detections.1.test` as well since `1` is in `predictions1`.

