### PR TITLE
Dataset and ViewStage method args improvements

### DIFF
--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -583,7 +583,16 @@ class SampleCollection(object):
             view = dataset.exclude(sample_ids)
 
         Args:
-            sample_ids: a sample ID or iterable of sample IDs
+            sample_ids: the samples to exclude. Can be any of the following:
+
+                -   a sample ID
+                -   an iterable of sample IDs
+                -   a :class:`fiftyone.core.sample.Sample` or
+                    :class:`fiftyone.core.sample.SampleView`
+                -   an iterable of sample IDs
+                -   a :class:`fiftyone.core.collections.SampleCollection`
+                -   an iterable of :class:`fiftyone.core.sample.Sample` or
+                    :class:`fiftyone.core.sample.SampleView` instances
 
         Returns:
             a :class:`fiftyone.core.view.DatasetView`
@@ -1668,7 +1677,7 @@ class SampleCollection(object):
             view = dataset.match_tags(["test", "train"])
 
         Args:
-            tag: the tag or iterable of tags to match
+            tags: the tag or iterable of tags to match
 
         Returns:
             a :class:`fiftyone.core.view.DatasetView`
@@ -1791,7 +1800,16 @@ class SampleCollection(object):
             view = dataset.select(session.selected)
 
         Args:
-            sample_ids: a sample ID or iterable of sample IDs
+            sample_ids: the samples to select. Can be any of the following:
+
+                -   a sample ID
+                -   an iterable of sample IDs
+                -   a :class:`fiftyone.core.sample.Sample` or
+                    :class:`fiftyone.core.sample.SampleView`
+                -   an iterable of sample IDs
+                -   a :class:`fiftyone.core.collections.SampleCollection`
+                -   an iterable of :class:`fiftyone.core.sample.Sample` or
+                    :class:`fiftyone.core.sample.SampleView` instances
 
         Returns:
             a :class:`fiftyone.core.view.DatasetView`


### PR DESCRIPTION
- Allows any notion of sample (`Sample`, `SampleView`, `SampleCollection`, list of `Sample`s, etc) to be passed to methods like `remove_samples()`, `select()`, and `exclude()`
- Always converts tags to a list in `match_tags()`, and updates kwarg names to be consistent

```py
import fiftyone.zoo as foz

dataset = foz.load_zoo_dataset("quickstart")

dataset.exclude(tuple(s.id for s in dataset.take(5)))
dataset.exclude(dataset.take(1).first())
dataset.exclude(dataset.take(4))

dataset.select(tuple(s.id for s in dataset.take(5)))
dataset.select(dataset.take(1).first())
dataset.select(dataset.take(4))

dataset.remove_sample(dataset.take(1).first())
dataset.remove_sample(dataset.take(1).first().id)

dataset.remove_samples(dataset.take(1).first())
dataset.remove_samples(dataset.take(1).first().id)
dataset.remove_samples(tuple(s.id for s in dataset.take(5)))
dataset.remove_samples(dataset.take(5))

dataset.match_tags("validation")
dataset.match_tags(["validation"])
```
