### PR TITLE
Adding support for aggregating on expressions

### DIFF
--- a/docs/source/user_guide/using_aggregations.rst
+++ b/docs/source/user_guide/using_aggregations.rst
@@ -84,8 +84,8 @@ detailed examples of using each aggregation.
     ``embedded.field.name`` syntax.
 
     In addition, you can aggregate the elements of array fields. Some array
-    fields are automatically handled, but you can manually unwind an array
-    using the ``embedded.array[].field`` syntax. See
+    fields are automatically handled, but you can always manually unwind an
+    array using the ``embedded.array[].field`` syntax. See
     :ref:`this section <aggregations-list-fields>` for more details.
 
 .. _aggregations-bounds:

--- a/docs/source/user_guide/using_aggregations.rst
+++ b/docs/source/user_guide/using_aggregations.rst
@@ -47,9 +47,6 @@ explict loops over your dataset to compute a statistic:
     :linenos:
 
     from collections import defaultdict
-    import fiftyone.zoo as foz
-
-    dataset = foz.load_zoo_dataset("quickstart")
 
     # Compute label histogram manually
     manual_counts = defaultdict(int)
@@ -61,6 +58,22 @@ explict loops over your dataset to compute a statistic:
     counts = dataset.count_values("ground_truth.detections.label")
     print(counts)  # same as `manual_counts` above
 
+You can even :ref:`aggregate on expressions <aggregations-expressions>` that
+transform the data in arbitrarily complex ways:
+
+.. code-block:: python
+    :linenos:
+
+    from fiftyone import ViewField as F
+
+    num_objects = F("detections").length()
+
+    # The `(min, max)` number of predictions per sample
+    print(dataset.bounds("predictions", expr=num_objects))
+
+    # The average number of predictions per sample
+    print(dataset.mean("predictions", expr=num_objects))
+
 The sections below discuss the available aggregations in more detail. You can
 also refer to the :mod:`fiftyone.core.aggregations` module documentation for
 detailed examples of using each aggregation.
@@ -70,8 +83,9 @@ detailed examples of using each aggregation.
     All aggregations can operate on embedded sample fields using the
     ``embedded.field.name`` syntax.
 
-    In addition, you can aggregate the elements of array fields using the
-    ``embedded.array[].field`` syntax. See
+    In addition, you can aggregate the elements of array fields. Some array
+    fields are automatically handled, but you can manually unwind an array
+    using the ``embedded.array[].field`` syntax. See
     :ref:`this section <aggregations-list-fields>` for more details.
 
 .. _aggregations-bounds:
@@ -201,7 +215,6 @@ aggregation to compute the histograms of numeric fields of a collection:
 
     import fiftyone.zoo as foz
 
-
     def plot_hist(counts, edges):
         counts = np.asarray(counts)
         edges = np.asarray(edges)
@@ -209,20 +222,13 @@ aggregation to compute the histograms of numeric fields of a collection:
         widths = edges[1:] - edges[:-1]
         plt.bar(left_edges, counts, width=widths, align="edge")
 
-
     dataset = foz.load_zoo_dataset("quickstart")
 
     #
     # Compute a histogram of the `uniqueness` field
     #
 
-    # Compute bounds automatically
-    bounds = dataset.bounds("uniqueness")
-    limits = (bounds[0], bounds[1] + 1e-6)  # right interval is open
-
-    counts, edges, other = dataset.histogram_values(
-        "uniqueness", bins=50, range=limits
-    )
+    counts, edges, other = dataset.histogram_values("uniqueness", bins=50)
 
     plot_hist(counts, edges)
     plt.show(block=False)
@@ -250,9 +256,52 @@ compute the sum of the (non-``None``) values of a field in a collection:
     # Compute average confidence of detections in the `predictions` field
     print(
         dataset.sum("predictions.detections.confidence") /
-        dataset.count("predictions.detections")
+        dataset.count("predictions.detections.confidence")
     )
     # 0.34994137249820706
+
+.. _aggregations-mean:
+
+Mean values
+___________
+
+You can use the
+:meth:`mean() <fiftyone.core.collections.SampleCollection.mean>` aggregation to
+compute the arithmetic mean of the (non-``None``) values of a field in a
+collection:
+
+.. code-block:: python
+    :linenos:
+
+    import fiftyone.zoo as foz
+
+    dataset = foz.load_zoo_dataset("quickstart")
+
+    # Compute average confidence of detections in the `predictions` field
+    print(dataset.mean("predictions.detections.confidence"))
+    # 0.34994137249820706
+
+.. _aggregations-std:
+
+Standard deviation
+__________________
+
+You can use the
+:meth:`std() <fiftyone.core.collections.SampleCollection.std>` aggregation to
+compute the standard deviation of the (non-``None``) values of a field in a
+collection:
+
+.. code-block:: python
+    :linenos:
+
+    import fiftyone.zoo as foz
+
+    dataset = foz.load_zoo_dataset("quickstart")
+
+    # Compute standard deviation of the confidence of detections in the
+    # `predictions` field
+    print(dataset.std("predictions.detections.confidence"))
+    # 0.3184061813934825
 
 .. _aggregations-advanced:
 
@@ -319,6 +368,137 @@ The example below demonstrates this capability:
     attribute; i.e., ``ground_truth.detections.label`` is automatically
     coerced to ``ground_truth.detections[].label``, if necessary.
 
+.. _aggregations-expressions:
+
+Aggregating expressions
+-----------------------
+
+Aggregations also support performing more complex computations on fields via
+the optional :class:`expr <fiftyone.core.aggregations.Aggregation>` argument,
+which is supported by all aggregations and allows you to specify a
+|ViewExpression| defining an arbitrary transformation of the field you're
+operating on prior to aggregating.
+
+The following examples demonstrate the power of aggregating with expressions:
+
+.. tabs::
+
+    .. tab:: Object statistics
+
+        The code sample below computes some statistics about the number of
+        predicted objects in a dataset:
+
+        .. code-block:: python
+            :linenos:
+
+            import fiftyone as fo
+            import fiftyone.zoo as foz
+            from fiftyone import ViewField as F
+
+            dataset = foz.load_zoo_dataset("quickstart")
+
+            # Expression that computes the number of objects in a `Detections` field
+            num_objects = F("detections").length()
+
+            # The `(min, max)` number of predictions per sample
+            print(dataset.bounds("predictions", expr=num_objects))
+
+            # The average number of predictions per sample
+            print(dataset.mean("predictions", expr=num_objects))
+
+            # Two equivalent ways of computing the total number of predictions
+            print(dataset.sum("predictions", expr=num_objects))
+            print(dataset.count("predictions.detections"))
+
+    .. tab:: Normalized labels
+
+        The code sample below computes some statistics about predicted object
+        labels after doing some normalization:
+
+        .. code-block:: python
+            :linenos:
+
+            import fiftyone as fo
+            import fiftyone.zoo as foz
+            from fiftyone import ViewField as F
+
+            dataset = foz.load_zoo_dataset("quickstart")
+
+            ANIMALS = [
+                "bear", "bird", "cat", "cow", "dog", "elephant", "giraffe",
+                "horse", "sheep", "zebra"
+            ]
+
+            # Expression that replaces all animal labels with "animal" and then
+            # capitalizes all labels
+            normed_labels = F("label").map_values({a: "animal" for a in ANIMALS}).upper()
+
+            # A histogram of normalized predicted labels
+            print(dataset.count_values("predictions.detections[]", expr=normed_labels))
+
+    .. tab:: Bounding box areas
+
+        The code sample below computes some statistics about the sizes of
+        ground truth and predicted bounding boxes in a dataset, in pixels:
+
+        .. code-block:: python
+            :linenos:
+
+            import fiftyone as fo
+            import fiftyone.zoo as foz
+            from fiftyone import ViewField as F
+
+            dataset = foz.load_zoo_dataset("quickstart")
+            dataset.compute_metadata()
+
+            # Expression that computes the area of a bounding box, in pixels
+            # Bboxes are in [top-left-x, top-left-y, width, height] format
+            bbox_width = F("bounding_box")[2] * F("$metadata.width")
+            bbox_height = F("bounding_box")[3] * F("$metadata.height")
+            bbox_area = bbox_width * bbox_height
+
+            # Compute (min, max, mean) of ground truth bounding boxes
+            print(dataset.bounds("ground_truth.detections[]", expr=bbox_area))
+            print(dataset.mean("ground_truth.detections[]", expr=bbox_area))
+
+            # Compute same statistics for the predictions
+            print(dataset.bounds("predictions.detections[]", expr=bbox_area))
+            print(dataset.mean("predictions.detections[]", expr=bbox_area))
+
+.. note::
+
+    When aggregating with expressions, field names may contain list fields, and
+    such field paths are handled as
+    :ref:`explained above <aggregations-list-fields>`.
+
+    However, there is one important exception when expressions are involved:
+    fields paths that **end** in array fields are not automatically unwound,
+    you must specify that they should be unwound by appending ``[]``. This
+    change in default behavior allows for the possiblity that the
+    |ViewExpression| you provide is intended to operate on the array as a
+    whole.
+
+    .. code-block:: python
+
+        import fiftyone as fo
+        import fiftyone.zoo as foz
+        from fiftyone import ViewField as F
+
+        dataset = foz.load_zoo_dataset("quickstart")
+
+        # Counts the number of predicted objects
+        # Here, ``predictions.detections`` is treated as ``predictions.detections[]``
+        print(dataset.count("predictions.detections"))
+
+        # Counts the number of predicted objects with confidence > 0.9
+        # Here, ``predictions.detections`` is not automatically unwound
+        print(
+            dataset.sum(
+                "predictions.detections",
+                expr=F().filter(F("confidence") > 0.9).length()
+            )
+        )
+
 .. _aggregations-batching:
 
 Batching aggregations
@@ -341,9 +521,7 @@ only to the parameters such as field name that define it.
     count_values = fo.CountValues("ground_truth.detections.label")
 
     # will compute a histogram of the `uniqueness` field
-    histogram_values = fo.HistogramValues(
-        "uniqueness", bins=50, range=(0, 1)
-    )
+    histogram_values = fo.HistogramValues("uniqueness", bins=50)
 
 Instantiating aggregations in this way allows you to execute multiple
 aggregations on a dataset or view efficiently in a batch via

--- a/fiftyone/__public__.py
+++ b/fiftyone/__public__.py
@@ -20,6 +20,8 @@ from .core.aggregations import (
     Distinct,
     HistogramValues,
     Sum,
+    Mean,
+    Std,
 )
 from .core.config import AppConfig
 from .core.dataset import (

--- a/fiftyone/core/aggregations.py
+++ b/fiftyone/core/aggregations.py
@@ -9,6 +9,7 @@ import numpy as np
 
 import eta.core.utils as etau
 
+import fiftyone.core.expressions as foe
 import fiftyone.core.media as fom
 
 
@@ -19,16 +20,28 @@ class Aggregation(object):
     of a :class:`fiftyone.core.collections.SampleCollection` instance.
 
     Args:
-        field_name: the name of the field to compute on
+        field_name: the name of the field to operate on
+        expr (None): an optional
+            :class:`fiftyone.core.expressions.ViewExpression` or
+            `MongoDB expression <https://docs.mongodb.com/manual/meta/aggregation-quick-reference/#aggregation-expressions>`_
+            to apply to the field before aggregating
     """
 
-    def __init__(self, field_name):
+    def __init__(self, field_name, expr=None):
         self._field_name = field_name
+        self._expr = expr
 
     @property
     def field_name(self):
         """The field name being computed on."""
         return self._field_name
+
+    @property
+    def expr(self):
+        """The :class:`fiftyone.core.expressions.ViewExpression` or MongoDB
+        expression that will be applied to the field before aggregating, if any.
+        """
+        return self._expr
 
     def to_mongo(self, sample_collection):
         """Returns the MongoDB aggregation pipeline for this aggregation.
@@ -62,6 +75,11 @@ class Aggregation(object):
         """
         raise NotImplementedError("subclasses must implement default_result()")
 
+    def _parse_field_name(self, sample_collection):
+        return _parse_field_name(
+            sample_collection, self._field_name, expr=self._expr
+        )
+
 
 class AggregationError(Exception):
     """An error raised during the execution of an :class:`Aggregation`."""
@@ -83,6 +101,7 @@ class Bounds(Aggregation):
     Examples::
 
         import fiftyone as fo
+        from fiftyone import ViewField as F
 
         dataset = fo.Dataset()
         dataset.add_samples(
@@ -121,8 +140,20 @@ class Bounds(Aggregation):
         bounds = dataset.aggregate(aggregation)
         print(bounds)  # (min, max)
 
+        #
+        # Compute the bounds of a transformation of a numeric field
+        #
+
+        aggregation = fo.Bounds("numeric_field", expr=2 * (F() + 1))
+        bounds = dataset.aggregate(aggregation)
+        print(bounds)  # (min, max)
+
     Args:
-        field_name: the name of the field to compute bounds for
+        field_name: the name of the field to operate on
+        expr (None): an optional
+            :class:`fiftyone.core.expressions.ViewExpression` or
+            `MongoDB expression <https://docs.mongodb.com/manual/meta/aggregation-quick-reference/#aggregation-expressions>`_
+            to apply to the field before aggregating
     """
 
     def default_result(self):
@@ -145,12 +176,7 @@ class Bounds(Aggregation):
         return d["min"], d["max"]
 
     def to_mongo(self, sample_collection):
-        path, pipeline, list_fields = _parse_field_name(
-            sample_collection, self._field_name
-        )
-
-        for list_field in list_fields:
-            pipeline.append({"$unwind": "$" + list_field})
+        path, pipeline = self._parse_field_name(sample_collection)
 
         pipeline.append(
             {
@@ -194,6 +220,7 @@ class Count(Aggregation):
                         detections=[
                             fo.Detection(label="cat"),
                             fo.Detection(label="rabbit"),
+                            fo.Detection(label="squirrel"),
                         ]
                     ),
                 ),
@@ -228,13 +255,26 @@ class Count(Aggregation):
         count = dataset.aggregate(aggregation)
         print(count)  # the count
 
+        #
+        # Count the number of samples with more than 2 predictions
+        #
+
+        expr = (F("detections").length() > 2).if_else(F("detections"), None)
+        aggregation = fo.Count("predictions", expr=expr)
+        count = dataset.aggregate(aggregation)
+        print(count)  # the count
+
     Args:
-        field_name (None): the name of the field whose values to count. If none
-            is provided, the samples themselves are counted
+        field_name (None): the name of the field to operate on. If none is
+            provided, the samples themselves are counted
+        expr (None): an optional
+            :class:`fiftyone.core.expressions.ViewExpression` or
+            `MongoDB expression <https://docs.mongodb.com/manual/meta/aggregation-quick-reference/#aggregation-expressions>`_
+            to apply to the field before aggregating
     """
 
-    def __init__(self, field_name=None):
-        super().__init__(field_name)
+    def __init__(self, field_name=None, expr=None):
+        super().__init__(field_name, expr=expr)
 
     def default_result(self):
         """Returns the default result for this aggregation.
@@ -259,17 +299,14 @@ class Count(Aggregation):
         if self._field_name is None:
             return [{"$count": "count"}]
 
-        path, pipeline, list_fields = _parse_field_name(
-            sample_collection, self._field_name
-        )
-
-        for list_field in list_fields:
-            pipeline.append({"$unwind": "$" + list_field})
+        path, pipeline = self._parse_field_name(sample_collection)
 
         if sample_collection.media_type != fom.VIDEO or path != "frames":
             pipeline.append({"$match": {"$expr": {"$gt": ["$" + path, None]}}})
 
-        return pipeline + [{"$count": "count"}]
+        pipeline.append({"$count": "count"})
+
+        return pipeline
 
 
 class CountValues(Aggregation):
@@ -332,8 +369,21 @@ class CountValues(Aggregation):
         counts = dataset.aggregate(aggregation)
         print(counts)  # dict mapping values to counts
 
+        #
+        # Compute the predicted label counts after some normalization
+        #
+
+        expr = F().map_values({"cat": "pet", "dog": "pet"}).upper()
+        aggregation = fo.CountValues("predictions.detections.label", expr=expr)
+        counts = dataset.aggregate(aggregation)
+        print(counts)  # dict mapping values to counts
+
     Args:
-        field_name: the name of the field to count
+        field_name: the name of the field to operate on
+        expr (None): an optional
+            :class:`fiftyone.core.expressions.ViewExpression` or
+            `MongoDB expression <https://docs.mongodb.com/manual/meta/aggregation-quick-reference/#aggregation-expressions>`_
+            to apply to the field before aggregating
     """
 
     def default_result(self):
@@ -356,12 +406,7 @@ class CountValues(Aggregation):
         return {i["k"]: i["count"] for i in d["result"]}
 
     def to_mongo(self, sample_collection):
-        path, pipeline, list_fields = _parse_field_name(
-            sample_collection, self._field_name
-        )
-
-        for list_field in list_fields:
-            pipeline.append({"$unwind": "$" + list_field})
+        path, pipeline = self._parse_field_name(sample_collection)
 
         pipeline += [
             {"$group": {"_id": "$" + path, "count": {"$sum": 1}}},
@@ -431,15 +476,28 @@ class Distinct(Aggregation):
         print(values)  # list of distinct values
 
         #
-        # Get the distint predicted labels in a dataset
+        # Get the distinct predicted labels in a dataset
         #
 
         aggregation = fo.Distinct("predictions.detections.label")
         values = dataset.aggregate(aggregation)
         print(values)  # list of distinct values
 
+        #
+        # Get the distinct predicted labels after some normalization
+        #
+
+        expr = F().map_values({"cat": "pet", "dog": "pet"}).upper()
+        aggregation = fo.Distinct("predictions.detections.label", expr=expr)
+        values = dataset.aggregate(aggregation)
+        print(values)  # list of distinct values
+
     Args:
-        field_name: the name of the field to compute distinct values for
+        field_name: the name of the field to operate on
+        expr (None): an optional
+            :class:`fiftyone.core.expressions.ViewExpression` or
+            `MongoDB expression <https://docs.mongodb.com/manual/meta/aggregation-quick-reference/#aggregation-expressions>`_
+            to apply to the field before aggregating
     """
 
     def default_result(self):
@@ -462,12 +520,7 @@ class Distinct(Aggregation):
         return sorted(d["values"])
 
     def to_mongo(self, sample_collection):
-        path, pipeline, list_fields = _parse_field_name(
-            sample_collection, self._field_name
-        )
-
-        for list_field in list_fields:
-            pipeline.append({"$unwind": "$" + list_field})
+        path, pipeline = self._parse_field_name(sample_collection)
 
         pipeline += [
             {"$match": {"$expr": {"$gt": ["$" + path, None]}}},
@@ -517,9 +570,7 @@ class HistogramValues(Aggregation):
         # Compute a histogram of a numeric field
         #
 
-        aggregation = fo.HistogramValues(
-            "numeric_field", bins=50, range=(-4, 4)
-        )
+        aggregation = fo.HistogramValues("numeric_field", bins=50)
         counts, edges, other = dataset.aggregate(aggregation)
 
         plot_hist(counts, edges)
@@ -529,13 +580,18 @@ class HistogramValues(Aggregation):
         # Compute the histogram of a numeric list field
         #
 
-        # Compute bounds automatically
-        aggregation = fo.Bounds("numeric_list_field")
-        bounds = dataset.aggregate(aggregation)
-        limits = (bounds[0], bounds[1] + 1e-6)  # right interval is open
+        aggregation = fo.HistogramValues("numeric_list_field", bins=50)
+        counts, edges, other = dataset.aggregate(aggregation)
+
+        plot_hist(counts, edges)
+        plt.show(block=False)
+
+        #
+        # Compute the histogram of a transformation of a numeric field
+        #
 
         aggregation = fo.HistogramValues(
-            "numeric_list_field", bins=50, range=limits
+            "numeric_field", expr=2 * (F() + 1), bins=50
         )
         counts, edges, other = dataset.aggregate(aggregation)
 
@@ -543,24 +599,36 @@ class HistogramValues(Aggregation):
         plt.show(block=False)
 
     Args:
-        field_name: the name of the field to histogram
+        field_name: the name of the field to operate on
+        expr (None): an optional
+            :class:`fiftyone.core.expressions.ViewExpression` or
+            `MongoDB expression <https://docs.mongodb.com/manual/meta/aggregation-quick-reference/#aggregation-expressions>`_
+            to apply to the field before aggregating
         bins (None): can be either an integer number of bins to generate or a
             monotonically increasing sequence specifying the bin edges to use.
             By default, 10 bins are created. If ``bins`` is an integer and no
-            ``range`` is specified, bin edges are automatically distributed in
-            an attempt to evenly distribute the counts in each bin
+            ``range`` is specified, bin edges are automatically computed from
+            the bounds of the field
         range (None): a ``(lower, upper)`` tuple specifying a range in which to
             generate equal-width bins. Only applicable when ``bins`` is an
-            integer
+            integer or ``None``
+        auto (False): whether to automatically choose bin edges in an attempt
+            to evenly distribute the counts in each bin. If this option is
+            chosen, ``bins`` will only be used if it is an integer, and the
+            ``range`` parameter is ignored
     """
 
-    def __init__(self, field_name, bins=None, range=None):
-        super().__init__(field_name)
-        self.bins = bins
-        self.range = range
+    def __init__(
+        self, field_name, expr=None, bins=None, range=None, auto=False
+    ):
+        super().__init__(field_name, expr=expr)
+        self._bins = bins
+        self._range = range
+        self._auto = auto
 
-        self._bins = None
+        self._num_bins = None
         self._edges = None
+        self._edges_last_used = None
         self._parse_args()
 
     def default_result(self):
@@ -591,36 +659,37 @@ class HistogramValues(Aggregation):
                 ``[lower, upper)``, including the rightmost bin
             -   other: the number of items outside the bins
         """
-        if self._edges is not None:
-            return self._parse_result_edges(d)
+        if self._auto:
+            return self._parse_result_auto(d)
 
-        return self._parse_result_auto(d)
+        return self._parse_result_edges(d)
 
     def to_mongo(self, sample_collection):
-        path, pipeline, list_fields = _parse_field_name(
-            sample_collection, self._field_name
-        )
+        path, pipeline = self._parse_field_name(sample_collection)
 
-        for list_field in list_fields:
-            pipeline.append({"$unwind": "$" + list_field})
-
-        if self._edges is not None:
+        if self._auto:
             pipeline.append(
                 {
-                    "$bucket": {
+                    "$bucketAuto": {
                         "groupBy": "$" + path,
-                        "boundaries": self._edges,
-                        "default": "other",  # counts documents outside of bins
+                        "buckets": self._num_bins,
                         "output": {"count": {"$sum": 1}},
                     }
                 }
             )
         else:
+            if self._edges is not None:
+                edges = self._edges
+            else:
+                edges = self._compute_bin_edges(sample_collection)
+
+            self._edges_last_used = edges
             pipeline.append(
                 {
-                    "$bucketAuto": {
+                    "$bucket": {
                         "groupBy": "$" + path,
-                        "buckets": self._bins,
+                        "boundaries": edges,
+                        "default": "other",  # counts documents outside of bins
                         "output": {"count": {"$sum": 1}},
                     }
                 }
@@ -631,28 +700,41 @@ class HistogramValues(Aggregation):
         return pipeline
 
     def _parse_args(self):
-        if self.bins is None:
+        if self._bins is None:
             bins = 10
         else:
-            bins = self.bins
+            bins = self._bins
 
-        if etau.is_numeric(bins):
-            if self.range is None:
-                # Automatic bins
-                self._bins = bins
-                return
+        if self._auto:
+            if etau.is_numeric(bins):
+                self._num_bins = bins
+            else:
+                self._num_bins = 10
 
-            # Linearly-spaced bins within `range`
-            self._edges = list(
-                np.linspace(self.range[0], self.range[1], bins + 1)
-            )
             return
 
-        # User-provided bin edges
-        self._edges = list(bins)
+        if not etau.is_numeric(bins):
+            # User-provided bin edges
+            self._edges = list(bins)
+            return
+
+        if self._range is not None:
+            # Linearly-spaced bins within `range`
+            self._edges = list(
+                np.linspace(self._range[0], self._range[1], bins + 1)
+            )
+        else:
+            # Compute bin edges from bounds
+            self._num_bins = bins
+
+    def _compute_bin_edges(self, sample_collection):
+        bounds = sample_collection.bounds(self._field_name, expr=self._expr)
+        return list(
+            np.linspace(bounds[0], bounds[1] + 1e-6, self._num_bins + 1)
+        )
 
     def _parse_result_edges(self, d):
-        _edges_array = np.array(self._edges)
+        _edges_array = np.array(self._edges_last_used)
         edges = list(_edges_array)
         counts = [0] * (len(edges) - 1)
         other = 0
@@ -676,6 +758,205 @@ class HistogramValues(Aggregation):
         edges.append(di["_id"]["max"])
 
         return counts, edges, 0
+
+
+class Mean(Aggregation):
+    """Computes the arithmetic mean of the field values of a collection.
+
+    ``None``-valued fields are ignored.
+
+    This aggregation is typically applied to *numeric* field types (or lists of
+    such types):
+
+    -   :class:`fiftyone.core.fields.IntField`
+    -   :class:`fiftyone.core.fields.FloatField`
+
+    Examples::
+
+        import fiftyone as fo
+
+        dataset = fo.Dataset()
+        dataset.add_samples(
+            [
+                fo.Sample(
+                    filepath="/path/to/image1.png",
+                    numeric_field=1.0,
+                    numeric_list_field=[1, 2, 3],
+                ),
+                fo.Sample(
+                    filepath="/path/to/image2.png",
+                    numeric_field=4.0,
+                    numeric_list_field=[1, 2],
+                ),
+                fo.Sample(
+                    filepath="/path/to/image3.png",
+                    numeric_field=None,
+                    numeric_list_field=None,
+                ),
+            ]
+        )
+
+        #
+        # Compute the mean of a numeric field
+        #
+
+        aggregation = fo.Mean("numeric_field")
+        mean = dataset.aggregate(aggregation)
+        print(mean)  # the mean
+
+        #
+        # Compute the mean of a numeric list field
+        #
+
+        aggregation = fo.Mean("numeric_list_field")
+        mean = dataset.aggregate(aggregation)
+        print(mean)  # the mean
+
+        #
+        # Compute the mean of a transformation of a numeric field
+        #
+
+        aggregation = fo.Mean("numeric_field", expr=2 * (F() + 1))
+        mean = dataset.aggregate(aggregation)
+        print(mean)  # the mean
+
+    Args:
+        field_name: the name of the field to operate on
+        expr (None): an optional
+            :class:`fiftyone.core.expressions.ViewExpression` or
+            `MongoDB expression <https://docs.mongodb.com/manual/meta/aggregation-quick-reference/#aggregation-expressions>`_
+            to apply to the field before aggregating
+    """
+
+    def default_result(self):
+        """Returns the default result for this aggregation.
+
+        Returns:
+            ``0``
+        """
+        return 0
+
+    def parse_result(self, d):
+        """Parses the output of :meth:`to_mongo`.
+
+        Args:
+            d: the result dict
+
+        Returns:
+            the mean
+        """
+        return d["mean"]
+
+    def to_mongo(self, sample_collection):
+        path, pipeline = self._parse_field_name(sample_collection)
+
+        pipeline.append(
+            {"$group": {"_id": None, "mean": {"$avg": "$" + path}}}
+        )
+
+        return pipeline
+
+
+class Std(Aggregation):
+    """Computes the standard deviation of the field values of a collection.
+
+    ``None``-valued fields are ignored.
+
+    This aggregation is typically applied to *numeric* field types (or lists of
+    such types):
+
+    -   :class:`fiftyone.core.fields.IntField`
+    -   :class:`fiftyone.core.fields.FloatField`
+
+    Examples::
+
+        import fiftyone as fo
+
+        dataset = fo.Dataset()
+        dataset.add_samples(
+            [
+                fo.Sample(
+                    filepath="/path/to/image1.png",
+                    numeric_field=1.0,
+                    numeric_list_field=[1, 2, 3],
+                ),
+                fo.Sample(
+                    filepath="/path/to/image2.png",
+                    numeric_field=4.0,
+                    numeric_list_field=[1, 2],
+                ),
+                fo.Sample(
+                    filepath="/path/to/image3.png",
+                    numeric_field=None,
+                    numeric_list_field=None,
+                ),
+            ]
+        )
+
+        #
+        # Compute the standard deviation of a numeric field
+        #
+
+        aggregation = fo.Std("numeric_field")
+        std = dataset.aggregate(aggregation)
+        print(std)  # the standard deviation
+
+        #
+        # Compute the standard deviation of a numeric list field
+        #
+
+        aggregation = fo.Std("numeric_list_field")
+        std = dataset.aggregate(aggregation)
+        print(std)  # the standard deviation
+
+        #
+        # Compute the standard deviation of a transformation of a numeric field
+        #
+
+        aggregation = fo.Std("numeric_field", expr=2 * (F() + 1))
+        std = dataset.aggregate(aggregation)
+        print(std)  # the standard deviation
+
+    Args:
+        field_name: the name of the field to operate on
+        expr (None): an optional
+            :class:`fiftyone.core.expressions.ViewExpression` or
+            `MongoDB expression <https://docs.mongodb.com/manual/meta/aggregation-quick-reference/#aggregation-expressions>`_
+            to apply to the field before aggregating
+        sample (False): whether to compute the sample standard deviation rather
+            than the population standard deviation
+    """
+
+    def __init__(self, field_name, expr=None, sample=False):
+        super().__init__(field_name, expr=expr)
+        self._sample = sample
+
+    def default_result(self):
+        """Returns the default result for this aggregation.
+
+        Returns:
+            ``0``
+        """
+        return 0
+
+    def parse_result(self, d):
+        """Parses the output of :meth:`to_mongo`.
+
+        Args:
+            d: the result dict
+
+        Returns:
+            the standard deviation
+        """
+        return d["std"]
+
+    def to_mongo(self, sample_collection):
+        path, pipeline = self._parse_field_name(sample_collection)
+
+        op = "$stdDevSamp" if self._sample else "$stdDevPop"
+        pipeline.append({"$group": {"_id": None, "std": {op: "$" + path}}})
+
+        return pipeline
 
 
 class Sum(Aggregation):
@@ -730,12 +1011,21 @@ class Sum(Aggregation):
         total = dataset.aggregate(aggregation)
         print(total)  # the sum
 
-    Args:
-        field_name: the name of the field to sum
-    """
+        #
+        # Compute the sum of a transformation of a numeric field
+        #
 
-    def __init__(self, field_name):
-        super().__init__(field_name)
+        aggregation = fo.Sum("numeric_field", expr=2 * (F() + 1))
+        total = dataset.aggregate(aggregation)
+        print(total)  # the sum
+
+    Args:
+        field_name: the name of the field to operate on
+        expr (None): an optional
+            :class:`fiftyone.core.expressions.ViewExpression` or
+            `MongoDB expression <https://docs.mongodb.com/manual/meta/aggregation-quick-reference/#aggregation-expressions>`_
+            to apply to the field before aggregating
+    """
 
     def default_result(self):
         """Returns the default result for this aggregation.
@@ -757,19 +1047,14 @@ class Sum(Aggregation):
         return d["sum"]
 
     def to_mongo(self, sample_collection):
-        path, pipeline, list_fields = _parse_field_name(
-            sample_collection, self._field_name
-        )
-
-        for list_field in list_fields:
-            pipeline.append({"$unwind": "$" + list_field})
+        path, pipeline = self._parse_field_name(sample_collection)
 
         pipeline.append({"$group": {"_id": None, "sum": {"$sum": "$" + path}}})
 
         return pipeline
 
 
-def _parse_field_name(sample_collection, field_name):
+def _parse_field_name(sample_collection, field_name, expr=None):
     path, is_frame_field, list_fields = sample_collection._parse_field_name(
         field_name
     )
@@ -782,4 +1067,24 @@ def _parse_field_name(sample_collection, field_name):
     else:
         pipeline = []
 
-    return path, pipeline, list_fields
+    if expr is not None:
+        # Don't unroll terminal lists unless explicitly requested
+        list_fields = [lf for lf in list_fields if lf != field_name]
+
+    for list_field in list_fields:
+        pipeline.append({"$unwind": "$" + list_field})
+
+    if expr is not None:
+        expr = _get_mongo_expr(expr, prefix="$" + path)
+        pipeline.append({"$project": {path: expr}})
+    else:
+        pipeline.append({"$project": {path: True}})
+
+    return path, pipeline
+
+
+def _get_mongo_expr(expr, prefix=None):
+    if isinstance(expr, foe.ViewExpression):
+        return expr.to_mongo(prefix=prefix)
+
+    return expr

--- a/fiftyone/core/expressions.py
+++ b/fiftyone/core/expressions.py
@@ -451,7 +451,8 @@ class ViewExpression(object):
     # Numeric expression operators ############################################
 
     def __abs__(self):
-        """Computes the absolute value of this numeric expression.
+        """Computes the absolute value of this expression, which must resolve
+        to a numeric value.
 
         Examples::
 
@@ -471,7 +472,8 @@ class ViewExpression(object):
         return self.abs()
 
     def __add__(self, other):
-        """Adds the given value to this numeric expression, ``self + other``.
+        """Adds the given value to this expression, which must resolve to a
+        numeric value, ``self + other``.
 
         Examples::
 
@@ -499,7 +501,8 @@ class ViewExpression(object):
         return ViewExpression({"$add": [self, other]})
 
     def __ceil__(self):
-        """Computes the ceiling of this numeric expression.
+        """Computes the ceiling of this expression, which must resolve to a
+        numeric value.
 
         Examples::
 
@@ -521,7 +524,8 @@ class ViewExpression(object):
         return self.ceil()
 
     def __floor__(self):
-        """Computes the floor of this numeric expression.
+        """Computes the floor of this expression, which must resolve to a
+        numeric value.
 
         Examples::
 
@@ -543,7 +547,8 @@ class ViewExpression(object):
         return self.floor()
 
     def __round__(self, place=0):
-        """Rounds this numeric expression at the given decimal place.
+        """Rounds this expression, which must resolve to a numeric value, at
+        the given decimal place.
 
         Positive values of ``place`` will round to ``place`` decimal
         places::
@@ -576,7 +581,8 @@ class ViewExpression(object):
         return self.round(place=place)
 
     def __mod__(self, other):
-        """Computes the modulus of this numeric expression, ``self % other``.
+        """Computes the modulus of this expression, which must resolve to a
+        numeric value, ``self % other``.
 
         Examples::
 
@@ -602,8 +608,8 @@ class ViewExpression(object):
         return ViewExpression({"$mod": [self, other]})
 
     def __mul__(self, other):
-        """Computes the product of the given value and this numeric expression,
-        ``self * other``.
+        """Computes the product of the given value and this expression, which
+        must resolve to a numeric value, ``self * other``.
 
         Examples::
 
@@ -628,8 +634,8 @@ class ViewExpression(object):
 
     # pylint: disable=unused-argument
     def __pow__(self, power, modulo=None):
-        """Raises this numeric expression to the given power,
-        ``self ** power``.
+        """Raises this expression, which must resolve to a numeric value, to
+        the given power, ``self ** power``.
 
         Examples::
 
@@ -680,8 +686,8 @@ class ViewExpression(object):
         return ViewExpression({"$divide": [other, self]})
 
     def __sub__(self, other):
-        """Subtracts the given value from this numeric expression,
-        ``self - other``.
+        """Subtracts the given value from this expression, which must resolve
+        to a numeric value, ``self - other``.
 
         Examples::
 
@@ -717,8 +723,8 @@ class ViewExpression(object):
         return ViewExpression({"$subtract": [self, other]})
 
     def __truediv__(self, other):
-        """Divides this numeric expression by the given value,
-        ``self / other``.
+        """Divides this expression, which must resolve to a numeric value, by
+        the given value, ``self / other``.
 
         Examples::
 
@@ -753,7 +759,8 @@ class ViewExpression(object):
         return ViewExpression({"$divide": [self, other]})
 
     def abs(self):
-        """Computes the absolute value of the numeric expression.
+        """Computes the absolute value of this expression, which must resolve
+        to a numeric value.
 
         Examples::
 
@@ -773,7 +780,8 @@ class ViewExpression(object):
         return ViewExpression({"$abs": self})
 
     def floor(self):
-        """Computes the floor of this numeric expression.
+        """Computes the floor of this expression, which must resolve to a
+        numeric value.
 
         Examples::
 
@@ -793,7 +801,8 @@ class ViewExpression(object):
         return ViewExpression({"$floor": self})
 
     def ceil(self):
-        """Computes the ceiling of this numeric expression.
+        """Computes the ceiling of this expression, which must resolve to a
+        numeric value.
 
         Examples::
 
@@ -813,7 +822,8 @@ class ViewExpression(object):
         return ViewExpression({"$ceil": self})
 
     def round(self, place=0):
-        """Rounds this numeric expression at the given decimal place.
+        """Rounds this expression, which must resolve to a numeric value, at
+        the given decimal place.
 
         Positive values of ``place`` will round to ``place`` decimal
         places::
@@ -847,7 +857,8 @@ class ViewExpression(object):
         return ViewExpression({"$round": [self, place]})
 
     def trunc(self, place=0):
-        """Truncates this numeric expression at the specified decimal place.
+        """Truncates this expression, which must resolve to a numeric value, at
+        the specified decimal place.
 
         Positive values of ``place`` will truncate to ``place`` decimal
         places::
@@ -881,7 +892,8 @@ class ViewExpression(object):
         return ViewExpression({"$trunc": [self, place]})
 
     def exp(self):
-        """Raises Euler's number to this numeric expression.
+        """Raises Euler's number to this expression, which must resolve to a
+        numeric value.
 
         Returns:
             a :class:`ViewExpression`
@@ -889,7 +901,8 @@ class ViewExpression(object):
         return ViewExpression({"$exp": self})
 
     def ln(self):
-        """Computes the natural logarithm of this numeric expression.
+        """Computes the natural logarithm of this expression, which must
+        resolve to a numeric value.
 
         Examples::
 
@@ -911,7 +924,8 @@ class ViewExpression(object):
         return ViewExpression({"$ln": self})
 
     def log(self, base):
-        """Computes logarithm base ``base`` of this numeric expression.
+        """Computes logarithm base ``base`` of this expression, which must
+        resolve to a numeric value.
 
         Examples::
 
@@ -936,7 +950,8 @@ class ViewExpression(object):
         return ViewExpression({"$log": [self, base]})
 
     def log10(self):
-        """Computes logarithm base 10 of this numeric expression.
+        """Computes logarithm base 10 of this expression, which must resolve to
+        a numeric value.
 
         Examples::
 
@@ -958,8 +973,8 @@ class ViewExpression(object):
         return ViewExpression({"$log10": self})
 
     def pow(self, power):
-        """Raises this numeric expression to the given power,
-        ``self ** power``.
+        """Raises this expression, which must resolve to a numeric value, to
+        the given power, ``self ** power``.
 
         Examples::
 
@@ -992,7 +1007,8 @@ class ViewExpression(object):
         return ViewExpression({"$pow": [self, power]})
 
     def sqrt(self):
-        """Computes the square root of this numeric expression.
+        """Computes the square root of this expression, which must resolve to a
+        numeric value.
 
         Examples::
 
@@ -1424,7 +1440,7 @@ class ViewExpression(object):
 
     def set_field(self, field, value_or_expr):
         """Sets the specified field or embedded field of this expression, which
-        must evaluate to a document, to the given value or expression.
+        must resolve to a document, to the given value or expression.
 
         The provided expression is computed by applying it to this expression
         via ``self.apply(value_or_expr)``.
@@ -1532,8 +1548,9 @@ class ViewExpression(object):
         return ViewExpression({"$let": {"vars": {var: self}, "in": in_expr}})
 
     def min(self, value=None):
-        """Returns the minimum value of either this array expression, or the
-        minimum of this expression and the given value.
+        """Returns the minimum value of either this expression, which must
+        resolve to an array, or the minimum of this expression and the given
+        value.
 
         Missing or ``None`` values are ignored.
 
@@ -1569,8 +1586,9 @@ class ViewExpression(object):
         return ViewExpression({"$min": self})
 
     def max(self, value=None):
-        """Returns the maximum value of either this array expression, or the
-        maximum of this expression and the given value.
+        """Returns the maximum value of either this expression, which must
+        resolve to an array, or the maximum of this expression and the given
+        value.
 
         Missing or ``None`` values are ignored.
 
@@ -1608,7 +1626,8 @@ class ViewExpression(object):
     # Array expression operators ##############################################
 
     def __getitem__(self, idx_or_slice):
-        """Returns the element or slice of this array expression.
+        """Returns the element or slice of this expression, which must resolve
+        to an array.
 
         All of the typical slicing operations are supported, except for
         specifying a non-unit step::
@@ -1689,7 +1708,8 @@ class ViewExpression(object):
         )
 
     def length(self):
-        """Computes the length of this array expression.
+        """Computes the length of this expression, which must resolve to an
+        array.
 
         If this expression's value is null or missing, zero is returned.
 
@@ -1713,7 +1733,8 @@ class ViewExpression(object):
         return ViewExpression({"$size": {"$ifNull": [self, []]}})
 
     def contains(self, value):
-        """Checks whether the given value is in this array expression.
+        """Checks whether the given value is in this expression, which must
+        resolve to an array.
 
         Examples::
 
@@ -1740,7 +1761,8 @@ class ViewExpression(object):
         return ViewExpression({"$in": [value, self]})
 
     def reverse(self):
-        """Reverses the order of the elements in the array expression.
+        """Reverses the order of the elements in the expression, which must
+        resolve to an array.
 
         Examples::
 
@@ -1893,7 +1915,7 @@ class ViewExpression(object):
 
     def map(self, expr):
         """Applies the given expression to the elements of this expression,
-        which must be an array.
+        which must resolve to an array.
 
         The output will be an array with the applied results.
 
@@ -1949,20 +1971,15 @@ class ViewExpression(object):
         Args:
             *args: one or more arrays or :class:`ViewExpression` instances that
                 resolve to array expressions
-            before (False): whether to position ``args`` before this array in
-                the output array
 
         Returns:
             a :class:`ViewExpression`
         """
-        if before:
-            return ViewExpression({"$concatArrays": list(args) + [self]})
-
         return ViewExpression({"$concatArrays": [self] + list(args)})
 
     def sum(self):
-        """Returns the sum of the values in this expression, which must be a
-        numeric array.
+        """Returns the sum of the values in this expression, which must resolve
+        to a numeric array.
 
         Missing, non-numeric, or ``None``-valued elements are ignored.
 
@@ -2017,8 +2034,8 @@ class ViewExpression(object):
         return ViewExpression({"$avg": self})
 
     def reduce(self, expr, init_val=0):
-        """Applies the given reduction to this expression, which must be an
-        array, and returns the single value computed.
+        """Applies the given reduction to this expression, which must resolve
+        to an array, and returns the single value computed.
 
         The provided ``expr`` must include the :const:`VALUE` expression to
         properly define the reduction.
@@ -2082,8 +2099,8 @@ class ViewExpression(object):
         )
 
     def join(self, delimiter):
-        """Joins the element of this expression, which must be a string array,
-        by the given delimiter.
+        """Joins the elements of this expression, which must resolve to a
+        string array, by the given delimiter.
 
         Examples::
 
@@ -2114,7 +2131,8 @@ class ViewExpression(object):
     # String expression operators #############################################
 
     def substr(self, start=None, end=None, count=None):
-        """Extracts the specified substring from this string expression.
+        """Extracts the specified substring from this expression, which must
+        resolve to a string.
 
         Examples::
 
@@ -2169,7 +2187,8 @@ class ViewExpression(object):
         return self.let_in(expr)
 
     def strlen(self):
-        """Computes the length of this string expression.
+        """Computes the length of this expression, which must resolve to a
+        string.
 
         If this expression's value is null or missing, zero is returned.
 
@@ -2196,7 +2215,8 @@ class ViewExpression(object):
         return ViewExpression({"$strLenBytes": {"$ifNull": [self, ""]}})
 
     def lower(self):
-        """Converts the string expression to lowercase.
+        """Converts this expression, which must resolve to a string, to
+        lowercase.
 
         Examples::
 
@@ -2219,7 +2239,8 @@ class ViewExpression(object):
         return ViewExpression({"$toLower": self})
 
     def upper(self):
-        """Converts the string expression to uppercase.
+        """Converts this expression, which must resolve to a string, to
+        uppercase.
 
         Examples::
 
@@ -2241,8 +2262,9 @@ class ViewExpression(object):
         """
         return ViewExpression({"$toUpper": self})
 
-    def concat(self, *args, before=False):
-        """Concatenates the given string(s) to this string expression.
+    def concat(self, *args):
+        """Concatenates the given string(s) to this expression, which must
+        resolve to a string.
 
         Examples::
 
@@ -2268,26 +2290,26 @@ class ViewExpression(object):
         Returns:
             a :class:`ViewExpression`
         """
-        if before:
-            return ViewExpression({"$concat": list(args) + [self]})
-
         return ViewExpression({"$concat": [self] + list(args)})
 
     def strip(self, chars=None):
-        """Removes whitespace characters from the beginning and end of the
-        string expression. Or, if ``chars`` is provided, remove those
-        characters instead.
+        """Removes whitespace characters from the beginning and end of this
+        expression, which must resolve to a string.
+
+        If ``chars`` is provided, those characters are removed instead of
+        whitespace.
 
         Examples::
 
             import fiftyone as fo
             import fiftyone.zoo as foz
+            from fiftyone import ViewExpression as E
             from fiftyone import ViewField as F
 
             dataset = foz.load_zoo_dataset("quickstart")
 
             # Adds and then strips whitespace from each tag
-            transform_tag = F().concat(" ", before=True).concat(" ").rstrip()
+            transform_tag = E(" ").concat(F(), " ").rstrip()
             view = dataset.set_field("tags", F("tags").map(transform_tag))
 
             print(dataset.distinct("tags"))
@@ -2308,20 +2330,23 @@ class ViewExpression(object):
         return ViewExpression({"$trim": trim})
 
     def lstrip(self, chars=None):
-        """Removes whitespace characters from the beginning of the string
-        expression. Or, if ``chars`` is provided, remove those characters
-        instead.
+        """Removes whitespace characters from the beginning of this expression,
+        which must resolve to a string.
+
+        If ``chars`` is provided, those characters are removed instead of
+        whitespace.
 
         Examples::
 
             import fiftyone as fo
             import fiftyone.zoo as foz
+            from fiftyone import ViewExpression as E
             from fiftyone import ViewField as F
 
             dataset = foz.load_zoo_dataset("quickstart")
 
             # Adds and then strips whitespace from the beginning of each tag
-            transform_tag = F().concat(" ", before=True).lstrip()
+            transform_tag = E(" ").concat(F()).lstrip()
             view = dataset.set_field("tags", F("tags").map(transform_tag))
 
             print(dataset.distinct("tags"))
@@ -2342,8 +2367,11 @@ class ViewExpression(object):
         return ViewExpression({"$ltrim": ltrim})
 
     def rstrip(self, chars=None):
-        """Removes whitespace characters from the end of the string expression.
-        Or, if ``chars`` is provided, remove those characters instead.
+        """Removes whitespace characters from the end of this expression, which
+        must resolve to a string.
+
+        If ``chars`` is provided, those characters are removed instead of
+        whitespace.
 
         Examples::
 
@@ -2375,8 +2403,8 @@ class ViewExpression(object):
         return ViewExpression({"$rtrim": rtrim})
 
     def replace(self, old, new):
-        """Replaces all occurances of ``old`` with ``new`` in the string
-        expression.
+        """Replaces all occurances of ``old`` with ``new`` in this expression,
+        which must resolve to a string.
 
         Examples::
 
@@ -2462,8 +2490,8 @@ class ViewExpression(object):
         )
 
     def starts_with(self, str_or_strs, case_sensitive=True):
-        """Determines whether this string expression starts with the given
-        string (or any of a list of strings).
+        """Determines whether this expression, which must resolve to a string,
+        starts with the given string or string(s).
 
         Examples::
 
@@ -2497,8 +2525,8 @@ class ViewExpression(object):
         return self.re_match(regex, options=options)
 
     def ends_with(self, str_or_strs, case_sensitive=True):
-        """Determines whether this string expression ends with the given string
-        (or any of a list of strings).
+        """Determines whether this expression, which must resolve to a string,
+        ends with the given string or string(s).
 
         Examples::
 
@@ -2532,8 +2560,8 @@ class ViewExpression(object):
         return self.re_match(regex, options=options)
 
     def contains_str(self, str_or_strs, case_sensitive=True):
-        """Determines whether this string expression contains the given string
-        (or any of a list of strings).
+        """Determines whether this expression, which must resolve to a string,
+        contains the given string or string(s).
 
         Examples::
 
@@ -2568,8 +2596,8 @@ class ViewExpression(object):
         return self.re_match(regex, options=options)
 
     def matches_str(self, str_or_strs, case_sensitive=True):
-        """Determines whether this string expression exactly matches the given
-        string (or any of a list of strings).
+        """Determines whether this expression, which must resolve to a string,
+        exactly matches the given string or string(s).
 
         Examples::
 
@@ -2622,13 +2650,13 @@ class ViewExpression(object):
 
             dataset = foz.load_zoo_dataset("quickstart")
 
-            # Add "-good" to the first tag and then split on "-" to create
-            # multiple tags for each sample
+            # Add "-good" to the first tag and then split on "-" to create two
+            # tags for each sample
             view = dataset.set_field(
                 "tags", F("tags")[0].concat("-good").split("-")
             )
 
-            print(view.distinct("tags"))
+            print(view.first().tags)
 
         Args:
             delimiter: the delimiter string or :class:`ViewExpression`
@@ -2740,6 +2768,42 @@ class ViewField(ViewExpression):
         return "$" + self._expr if self._expr else "$this"
 
 
+class ObjectId(ViewExpression):
+    """A :class:`ViewExpression` that refers to an
+    `ObjectId <https://docs.mongodb.com/manual/reference/method/ObjectId>`_ of
+    a document.
+
+    The typical use case for this class is writing an expression that involves
+    checking if the ID of a document matches a particular known ID.
+
+    Example::
+
+        from fiftyone import ViewField as F
+        from fiftyone.core.expressions import ObjectId
+
+        # Check if the ID of the document matches the given ID
+        expr = F("_id") == ObjectId("5f452489ef00e6374aad384a")
+
+    Args:
+        oid: the object ID string
+    """
+
+    def __init__(self, oid):
+        _ = bson.ObjectId(oid)  # validates that `oid` is valid value
+        super().__init__(oid)
+
+    def to_mongo(self, prefix=None):
+        """Returns a MongoDB representation of the ObjectId.
+
+        Args:
+            prefix (None): unused
+
+        Returns:
+            a MongoDB expression
+        """
+        return {"$toObjectId": self._expr}
+
+
 def _do_recurse(val, fcn):
     if isinstance(val, ViewExpression):
         return fcn(val)
@@ -2781,49 +2845,12 @@ def _do_apply_memo(val, old, new):
     return _do_recurse(val, fcn)
 
 
-#: A :class:`ViewExpression` that refers to the current `$$value` in a MongoDB
-# reduction expression. See :meth:`ViewExpression.reduce`.
 VALUE = ViewField("$$value")
+"""A :class:`ViewExpression` that refers to the current ``$$value`` in a
+MongoDB reduction expression.
 
-#: A :class:`ViewExpression` that generates a random float in ``[0, 1]`` each
-# time it is called.
-RAND = ViewExpression({"$rand": {}})
-
-
-class ObjectId(ViewExpression):
-    """A :class:`ViewExpression` that refers to an
-    `ObjectId <https://docs.mongodb.com/manual/reference/method/ObjectId>`_ of
-    a document.
-
-    The typical use case for this class is writing an expression that involves
-    checking if the ID of a document matches a particular known ID.
-
-    Example::
-
-        from fiftyone import ViewField as F
-        from fiftyone.core.expressions import ObjectId
-
-        # Check if the ID of the document matches the given ID
-        expr = F("_id") == ObjectId("5f452489ef00e6374aad384a")
-
-    Args:
-        oid: the object ID string
-    """
-
-    def __init__(self, oid):
-        _ = bson.ObjectId(oid)  # validates that `oid` is valid value
-        super().__init__(oid)
-
-    def to_mongo(self, prefix=None):
-        """Returns a MongoDB representation of the ObjectId.
-
-        Args:
-            prefix (None): unused
-
-        Returns:
-            a MongoDB expression
-        """
-        return {"$toObjectId": self._expr}
+See :meth:`ViewExpression.reduce` for more information.
+"""
 
 
 def _escape_regex_chars(str_or_strs):

--- a/fiftyone/core/expressions.py
+++ b/fiftyone/core/expressions.py
@@ -2121,6 +2121,48 @@ class ViewExpression(object):
         """
         return ViewExpression({"$avg": self})
 
+    def std(self, sample=False):
+        """Returns the standard deviation of the values in this expression,
+        which must resolve to a numeric array.
+
+        Missing or ``None``-valued elements are ignored.
+
+        By default, the population standard deviation is returned. If you wish
+        to compute the sample standard deviation instead, set ``sample=True``.
+
+        See https://en.wikipedia.org/wiki/Standard_deviation#Estimation for
+        more information on population (biased) vs sample (unbiased) standard
+        deviation.
+
+        Examples::
+
+            import fiftyone as fo
+            import fiftyone.zoo as foz
+            from fiftyone import ViewField as F
+
+            dataset = foz.load_zoo_dataset("quickstart")
+
+            # Add a field to each `predictions` object that records the
+            # standard deviation of the confidences
+            view = dataset.set_field(
+                "predictions.conf_std",
+                F("detections").map(F("confidence")).std()
+            )
+
+            print(view.bounds("predictions.conf_std"))
+
+        Args:
+            sample (False): whether to compute the sample standard deviation
+                rather than the population standard deviation
+
+        Returns:
+            a :class:`ViewExpression`
+        """
+        if sample:
+            return ViewExpression({"$stdDevSamp": self})
+
+        return ViewExpression({"$stdDevPop": self})
+
     def reduce(self, expr, init_val=0):
         """Applies the given reduction to this expression, which must resolve
         to an array, and returns the single value computed.

--- a/fiftyone/core/expressions.py
+++ b/fiftyone/core/expressions.py
@@ -1388,24 +1388,22 @@ class ViewExpression(object):
             import fiftyone.zoo as foz
             from fiftyone import ViewField as F
 
-            dataset = foz.load_zoo_dataset("quickstart")
-
             ANIMALS = [
                 "bear", "bird", "cat", "cow", "dog", "elephant", "giraffe",
                 "horse", "sheep", "zebra"
             ]
 
+            dataset = foz.load_zoo_dataset("quickstart")
+
             #
             # Replace the `label` of all animal objects in the `predictions`
             # field with "animal"
             #
+            mapping = {a: "animal" for a in ANIMALS}
             view = dataset.set_field(
                 "predictions.detections",
                 F("detections").map(
-                    F().set_field(
-                        "label",
-                        F("label").map_values({a: "animal" for a in ANIMALS}),
-                    )
+                    F().set_field("label", F("label").map_values(mapping))
                 )
             )
 
@@ -2112,11 +2110,11 @@ class ViewExpression(object):
             # Add a field to each `predictions` object that records the average
             # confidence of the predictions
             view = dataset.set_field(
-                "predictions.avg_conf",
+                "predictions.conf_mean",
                 F("detections").map(F("confidence")).mean()
             )
 
-            print(view.bounds("predictions.avg_conf"))
+            print(view.bounds("predictions.conf_mean"))
 
         Returns:
             a :class:`ViewExpression`

--- a/fiftyone/core/expressions.py
+++ b/fiftyone/core/expressions.py
@@ -1672,11 +1672,12 @@ class ViewExpression(object):
             )
 
         if s.start is not None:
-            if s.stop is None:
-                n = s.start
-                return ViewExpression({"$slice": [self, n]})
-
             position = s.start
+            if s.stop is None:
+                n = self.length()
+                expr = ViewExpression({"$slice": [self, position, n]})
+                return self.let_in(expr)
+
             n = s.stop - position
             if n < 0:
                 return ViewExpression({"$literal": []})

--- a/fiftyone/core/expressions.py
+++ b/fiftyone/core/expressions.py
@@ -1941,22 +1941,120 @@ class ViewExpression(object):
             {"$map": {"input": self, "as": "this", "in": expr}}
         )
 
-    def extend(self, *args, before=False):
-        """Concatenates the given array(s) or array expression(s) to this array
-        expression.
+    def prepend(self, value):
+        """Prepends the given value to this expression, which must resolve to
+        an array.
 
         Examples::
 
             import fiftyone as fo
-            import fiftyone.zoo as foz
             from fiftyone import ViewField as F
 
-            dataset = foz.load_zoo_dataset("quickstart")
-
-            # Adds the "good" and "ready" tags to each sample
-            view = dataset.set_field(
-                "tags", F("tags").extend(["good", "ready"])
+            dataset = fo.Dataset()
+            dataset.add_samples(
+                [
+                    fo.Sample(filepath="image1.jpg", tags=["b", "c"]),
+                    fo.Sample(filepath="image2.jpg", tags=["b", "c"]),
+                ]
             )
+
+            # Adds the "a" tag to each sample
+            view = dataset.set_field("tags", F("tags").prepend("a"))
+
+            print(view.first().tags)
+
+        Args:
+            value: the value or :class:`ViewExpression`
+
+        Returns:
+            a :class:`ViewExpression`
+        """
+        return ViewExpression([value]).extend(self)
+
+    def append(self, value):
+        """Appends the given value to this expression, which must resolve to an
+        array.
+
+        Examples::
+
+            import fiftyone as fo
+            from fiftyone import ViewField as F
+
+            dataset = fo.Dataset()
+            dataset.add_samples(
+                [
+                    fo.Sample(filepath="image1.jpg", tags=["a", "b"]),
+                    fo.Sample(filepath="image2.jpg", tags=["a", "b"]),
+                ]
+            )
+
+            # Appends the "c" tag to each sample
+            view = dataset.set_field("tags", F("tags").append("c"))
+
+            print(view.first().tags)
+
+        Args:
+            value: the value or :class:`ViewExpression`
+
+        Returns:
+            a :class:`ViewExpression`
+        """
+        return self.extend([value])
+
+    def insert(self, index, value):
+        """Inserts the value before the given index in this expression, which
+        must resolve to an array.
+
+        If ``index <= 0``, the value is prepended to this array.
+        If ``index >= self.length()``, the value is appended to this array.
+
+        Examples::
+
+            import fiftyone as fo
+            from fiftyone import ViewField as F
+
+            dataset = fo.Dataset()
+            dataset.add_samples(
+                [
+                    fo.Sample(filepath="image1.jpg", tags=["a", "c"]),
+                    fo.Sample(filepath="image2.jpg", tags=["a", "c"]),
+                ]
+            )
+
+            # Adds the "ready" tag to each sample
+            view = dataset.set_field("tags", F("tags").insert(1, "b"))
+
+            print(view.first().tags)
+
+        Args:
+            index: the index at which to insert the value
+            value: the value or :class:`ViewExpression`
+
+        Returns:
+            a :class:`ViewExpression`
+        """
+        expr = self[:index].extend([value], self[index:])
+        return self.let_in(expr)
+
+    def extend(self, *args):
+        """Concatenates the given array(s) or array expression(s) to this
+        expression, which must resolve to an array.
+
+        Examples::
+
+            import fiftyone as fo
+            from fiftyone import ViewField as F
+
+            dataset = fo.Dataset()
+            dataset.add_samples(
+                [
+                    fo.Sample(filepath="image1.jpg", tags=["a", "b"]),
+                    fo.Sample(filepath="image2.jpg", tags=["a", "b"]),
+                ]
+            )
+
+            # Adds the "c" and "d" tags to each sample
+            view = dataset.set_field("tags", F("tags").extend(["c", "d"]))
 
             print(view.first().tags)
 

--- a/fiftyone/core/expressions.py
+++ b/fiftyone/core/expressions.py
@@ -95,7 +95,7 @@ class ViewExpression(object):
         #
         # Create a view that only contains predictions whose bounding boxes
         # have area < 0.2 with confidence > 0.9, and only include samples with
-        # at least 10 such objects
+        # at least 15 such objects
         #
         view = dataset.filter_labels(
             "predictions",

--- a/fiftyone/core/expressions.py
+++ b/fiftyone/core/expressions.py
@@ -1791,11 +1791,11 @@ class ViewExpression(object):
     def sort(self, key=None, reverse=False):
         """Sorts this expression, which must resolve to an array.
 
-        If no ``field`` is provided, this array must contain elements whose
+        If no ``key`` is provided, this array must contain elements whose
         BSON representation can be sorted by JavaScript's ``.sort()`` method.
 
-        If a ``field`` is provided, the array must contain documents, which are
-        sorted by the specified field or embedded field.
+        If a ``key`` is provided, the array must contain documents, which are
+        sorted by ``key``, which must be a field or embedded field.
 
         Examples::
 

--- a/fiftyone/core/stages.py
+++ b/fiftyone/core/stages.py
@@ -1845,6 +1845,7 @@ def _make_set_field_pipeline(sample_collection, field, expr):
 
     # Don't unroll terminal lists unless explicitly requested
     list_fields = [lf for lf in list_fields if lf != field]
+
     # Case 1: no list fields
     if not list_fields:
         if "." in path:


### PR DESCRIPTION
Adds support for aggregating on *expressions* applied to fields. 

Any expression is allowed, but here's a simple example:

```py
import fiftyone.zoo as foz
from fiftyone import ViewField as F

dataset = foz.load_zoo_dataset("quickstart")

num_objects = F("detections").length()

# The `(min, max)` number of predictions per sample
print(dataset.bounds("predictions", expr=num_objects))

# The average number of predictions per sample
print(dataset.mean("predictions", expr=num_objects))
```

This new `Aggregation(field, expr)` syntax is available on all `Aggregation` classes and is effectively shorthand for operations that previously required a `set_field()` view stage to create the new field being aggregated over:

```py
# This is equivalent to the above
view = dataset.set_field("predictions.num_objects", F("detections").length())
print(view.bounds("predictions.num_objects"))
print(view.mean("predictions.num_objects"))
```

Other enhancements include:
- Added `Mean` and `Std` aggregations to compute the arithmetic mean and standard deviation of numeric fields, respectively
- `HistogramValues` will now automatically computes the bounds of the specified field by default (by running a `bounds()` aggregation). Previously, the default behavior was to use MongoDB's `$bucketAuto` to generate bin edges such that the bins have equal counts, but this is not typically what CV/ML users want; they want to see equal-width histograms. The previous behavior can be recovered by setting a new `auto=True` flag
- Fixes a bug in `ViewExpression.__getitem__` when the `expr[n:]` syntax is used
- Merged the `sort()` and `sort_by()` methods of `ViewExpression` into a single method with kwargs analogous to Python's `sorted()` builtin
- Added a number of new `ViewExpression` methods:
    - `prepend()`, `append()`, `insert()`, `extend()` - the familiar array methods
    - `std()` - compute the stdev of an array
    - `split(..., maxsplit)` - added support for `maxsplit` argument
    - `rsplit(..., maxsplit)` - right-hand version of `split()`
    - `literal()` - adds ability to write expressions that involve special MongoDB characters like `$` as literal characters
    - `rand()` - generates a random number in `[0, 1]` every time it is called
    - `range()`, `enumerate()`, `zip()` - more familiar array methods
- Updated `Using aggregations` docs page to include a discussion of aggregating on expressions
- Added examples of aggregating expressions to all `Aggregation` classes and `SampleCollection` methods
