### PR TITLE
Adding support for accessing samples by filepath

### DIFF
--- a/docs/source/user_guide/using_datasets.rst
+++ b/docs/source/user_guide/using_datasets.rst
@@ -312,16 +312,19 @@ last samples in a dataset, respectively:
     first_sample = dataset.first()
     last_sample = dataset.last()
 
-Samples can be accessed directly from datasets by their IDs. The |Sample|
-that is returned when accessing a |Dataset| will always provide the same
-instance:
+Samples can be accessed directly from datasets by their IDs or their filepaths.
+|Sample| objects are singletons, so the same |Sample| instance is returned
+whenever accessing the sample from the |Dataset|:
 
 .. code-block:: python
     :linenos:
 
     same_sample = dataset[sample.id]
-
     print(same_sample is sample)
+    # True
+
+    also_same_sample = dataset[sample.filepath]
+    print(also_same_sample is sample)
     # True
 
 You can use :ref:`dataset views <using-views>` to perform more sophisticated

--- a/docs/source/user_guide/using_views.rst
+++ b/docs/source/user_guide/using_views.rst
@@ -182,11 +182,11 @@ equivalently, by using array slicing:
     range_view2 = dataset[2:5]
 
 Samples can be accessed from views in
-:ref:`all the same ways as for datasets <accessing-samples-in-a-dataset>`.
-This includes using :meth:`first() <fiftyone.core.dataset.Dataset.first>` and
-:meth:`last() <fiftyone.core.dataset.Dataset.last>` to retrieve the first and
-last samples in a dataset, respectively, or accessing a |Sample| directly from
-a |DatasetView| by its ID.
+:ref:`all the same ways <accessing-samples-in-a-dataset>` as for datasets.
+This includes using :meth:`first() <fiftyone.core.view.DatasetView.first>` and
+:meth:`last() <fiftyone.core.view.DatasetView.last>` to retrieve the first and
+last samples in a view, respectively, or accessing a sample directly from a
+|DatasetView| by its ID or filepath.
 
 .. note::
 

--- a/docs/source/user_guide/using_views.rst
+++ b/docs/source/user_guide/using_views.rst
@@ -71,18 +71,21 @@ Like datasets, you access the samples in a view by iterating over it:
     for sample in view:
         # Do something with `sample`
 
-Or, you can access individual samples in a view by their ID:
+Or, you can access individual samples in a view by their ID or filepath:
 
 .. code-block:: python
     :linenos:
 
-    # Grab the ID of a random sample
-    sample_id = view.take(1).first().id
+    sample = view.take(1).first()
 
-    sample = view[sample_id]
+    print(type(sample))
+    # fiftyone.core.sample.SampleView
+
+    same_sample = view[sample.id]
+    also_same_sample = view[sample.filepath]
 
     view[other_sample_id]
-    # KeyError: if the specified sample is not in the view
+    # KeyError: sample non-existent or not in view
 
 .. note::
 
@@ -188,13 +191,15 @@ a |DatasetView| by its ID.
 .. note::
 
     Accessing a sample by its integer index in a |DatasetView| is not allowed.
-    The best practice is to lookup individual samples by ID, or use array
-    slicing to extract a range of samples, and iterate over samples in a view.
+    The best practice is to lookup individual samples by ID or filepath, or use
+    array slicing to extract a range of samples, and iterate over samples in a
+    view.
 
     .. code-block:: python
 
         view[0]
-        # KeyError: "Accessing samples by numeric index is not supported. Use sample IDs or slices"
+        # KeyError: "Accessing samples by numeric index is not supported.
+        # Use sample IDs, filepaths, or slices"
 
 Shuffling
 _________

--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -94,7 +94,7 @@ class SampleCollection(object):
 
         return True
 
-    def __getitem__(self, sample_id_or_slice):
+    def __getitem__(self, id_filepath_slice):
         raise NotImplementedError("Subclass must implement __getitem__()")
 
     def __iter__(self):


### PR DESCRIPTION
Adds support for accessing samples via `dataset[filepath]` and `view[filepath]`.

I wanted to get this out there and think about it a bit. Let's start with the impetus: I was training a model with `fastai` and wanted to add the predictions to my dataset. Here was my workflow:

**Step 1:** Load data into FiftyOne:

```py
import fiftyone as fo

# A classification dataset stored in the typical classification directory tree structure on disk
DATASET_DIR = "/path/to/dataset"

dataset = fo.Dataset.from_dir(DATASET_DIR, fo.types.ImageClassificationDirectoryTree)
```

**Step 2:** Load data into fastai, train model, and get predictions on a split of the dataset

```py
from fastai.data.all import *
from fastai.vision.data import *
from fastai.vision.all import *

# Load data into Fast AI
path = Path(DATASET_DIR)
splitter = RandomSplitter(valid_pct=0.2)  # splits into train and val
data_block = DataBlock(splitter, ...)
data = data_block.dataloaders(path, bs=64)
classes = list(data.vocab)

# Train model
learner = cnn_learner(data, ...)
learner.fine_tune(10)

# Perform inference on validation split
preds, _ = learner.get_preds()
```

**Step 3:** Add predictions to FiftyOne dataset

Here I need to add the predictions on the validation split to my dataset, and I have three things:
- `dataset`: my FiftyOne dataset
- `data.valid.items`: a list of filepaths that I ran inference on
- `preds`: a `num_valid x num_classes` array of prediction scores for the aforementioned filepaths

Currently, the cleanest syntax I could come up with was this:

```py
import numpy as np
from fiftyone import ViewField as F

def save_predictions(dataset, filepaths, predictions, classes):
    for filepath, scores in zip(filepaths, predictions):
        sample = dataset.match(F("filepath") == filepath).first()
        target = np.argmax(scores)
        sample["predictions"] = fo.Classification(
            label=classes[target],
            confidence=scores[target],
        )
        sample.save()

save_predictions(dataset, data.valid.items, preds, classes)
```

With this PR, the line:

```py
sample = dataset.match(F("filepath") == filepath).first()
```

could be replaced by

```py
sample = dataset[filepath]
```

A related thought here is that, regardless of what happens to this PR, perhaps we should provide a `fiftyone.utils.fastai` module with a higher-level API like `save_predictions(fiftyone_dataset, fastai_learner)` that abstracts all of this away from the users.

With all that said, here are the pros and cons of this change as I see them:

Pros
- Cleaner syntax
- All datasets are already indexed by `filepath`, which is enforced to be unique, so `dataset[filepath]` is efficient

Cons
- `dataset[id]` and `dataset[filepath]` are not technically well-defined, as both are strings. As it stands, if `dataset[arg]` is provided with a 24 character hexadecimal string, it is interpreted as an ID; otherwise it is interpreted as a filepath. Now, a hexadecimal-only filepath doesn't really make sense (it would have no extension or path separators, for instance), but, these two notions are *technically* conflicting nonetheless
- `view[filepath]` is a bit of an anti-pattern because calling it in a loop to access multiple samples would run the entire aggregation pipeline for each sample access. But, that said, this is already true for `view[id]` and cannot be helped (the view may omit samples or normalize the fields in question, so it must be run)