### PR TITLE
Adds support for returning a single sample matching an expression

### DIFF
--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -180,6 +180,67 @@ class SampleCollection(object):
         """
         return [s for s in self[-num_samples:]]
 
+    def one(self, expr, exact=False):
+        """Returns a single sample in this collection matching the expression.
+
+        Examples::
+
+            import fiftyone as fo
+            import fiftyone.zoo as foz
+            from fiftyone import ViewField as F
+
+            dataset = foz.load_zoo_dataset("quickstart")
+
+            #
+            # Get a sample by filepath
+            #
+
+            # A random filepath in the dataset
+            filepath = dataset.take(1).first().filepath
+
+            # Get sample by filepath
+            sample = dataset.one(F("filepath") == filepath)
+
+            #
+            # Dealing with multiple matches
+            #
+
+            # Get a sample whose image is JPEG
+            sample = dataset.one(F("filepath").ends_with(".jpg"))
+
+            # Raises an error since there are multiple JPEGs
+            dataset.one(F("filepath").ends_with(".jpg"), exact=True)
+
+        Args:
+            expr: a :class:`fiftyone.core.expressions.ViewExpression` or
+                `MongoDB expression <https://docs.mongodb.com/manual/meta/aggregation-quick-reference/#aggregation-expressions>`_
+                that evaluates to ``True`` for the sample to match
+            exact (False): whether to raise an error if multiple samples match
+                the expression
+
+        Returns:
+            a :class:`fiftyone.core.sample.SampleView`
+        """
+        view = self.match(expr)
+        matches = iter(view)
+
+        try:
+            sample = next(matches)
+        except StopIteration:
+            raise ValueError("No samples match the given expression")
+
+        if exact:
+            try:
+                next(matches)
+                raise ValueError(
+                    "Expected one matching sample, but found %d matches"
+                    % len(view)
+                )
+            except StopIteration:
+                pass
+
+        return sample
+
     def iter_samples(self):
         """Returns an iterator over the samples in the collection.
 
@@ -523,67 +584,6 @@ class SampleCollection(object):
             force_square=force_square,
             alpha=alpha,
         )
-
-    def match_one(self, expr, exact=False):
-        """Returns a single sample in this collection matching the expression.
-
-        Examples::
-
-            import fiftyone as fo
-            import fiftyone.zoo as foz
-            from fiftyone import ViewField as F
-
-            dataset = foz.load_zoo_dataset("quickstart")
-
-            #
-            # Get a sample by filepath
-            #
-
-            # A random filepath in the dataset
-            filepath = dataset.take(1).first().filepath
-
-            # Get sample by filepath
-            sample = dataset.match_one(F("filepath") == filepath)
-
-            #
-            # Dealing with multiple matches
-            #
-
-            # Get a sample whose image is JPEG
-            sample = dataset.match_one(F("filepath").ends_with(".jpg"))
-
-            # Raises an error since there are multiple JPEGs
-            dataset.match_one(F("filepath").ends_with(".jpg"), exact=True)
-
-        Args:
-            expr: a :class:`fiftyone.core.expressions.ViewExpression` or
-                `MongoDB expression <https://docs.mongodb.com/manual/meta/aggregation-quick-reference/#aggregation-expressions>`_
-                that evaluates to ``True`` for the sample to match
-            exact (False): whether to raise an error if multiple samples match
-                the expression
-
-        Returns:
-            a :class:`fiftyone.core.sample.SampleView`
-        """
-        view = self.match(expr)
-        matches = iter(view)
-
-        try:
-            sample = next(matches)
-        except StopIteration:
-            raise ValueError("No samples match the given expression")
-
-        if exact:
-            try:
-                next(matches)
-                raise ValueError(
-                    "Expected one matching sample, but found %d matches"
-                    % len(view)
-                )
-            except StopIteration:
-                pass
-
-        return sample
 
     @classmethod
     def list_view_stages(cls):

--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -535,23 +535,25 @@ class SampleCollection(object):
 
             dataset = foz.load_zoo_dataset("quickstart")
 
-            filepath = dataset.take(1).first().filepath
-
             #
             # Get a sample by filepath
             #
 
+            # A random filepath in the dataset
+            filepath = dataset.take(1).first().filepath
+
+            # Get sample by filepath
             sample = dataset.match_one(F("filepath") == filepath)
 
             #
             # Dealing with multiple matches
             #
 
-            # Get one sample (out of many) whose image is a JPEG
+            # Get a sample whose image is JPEG
             sample = dataset.match_one(F("filepath").ends_with(".jpg"))
 
-            # Wrongly insist that only one JPEG image exists
-            dataset.match_one(F("filepath").ends_with(".jpg"), exact=True)  # error
+            # Raises an error since there are multiple JPEGs
+            dataset.match_one(F("filepath").ends_with(".jpg"), exact=True)
 
         Args:
             expr: a :class:`fiftyone.core.expressions.ViewExpression` or


### PR DESCRIPTION
Adds a `SampleCollection.one()` method that returns a single `Sample` matching a given expression.

`collection.one(expr)` is essentially shorthand for `collection.match(expr).first()`, with an additional `exact=True` argument if you would like to strictly enforce that a single match must exist.

The impetus for this was trying to find a suitable replacement for accessing a sample by filepath over in https://github.com/voxel51/fiftyone/pull/841:

```py
# too much of a mouthful...
sample = dataset.match(F("filepath") == filepath).first()
```

which could now be written as:

```py
sample = dataset.one(F("filepath") == filepath)
```

Of course it has to be said that https://github.com/voxel51/fiftyone/pull/841 would enable the *even* shorter `dataset[filepath]` syntax, but I can imagine cases where extracting a sample based on a more general expression may be called for.

I marked this as needs discussion in case anyone has any thoughts about appropriate generalizations or restrictions of this method that make it easier to use. Ease of use is key here because this is purely shorthand for `match().first()`.

Example usage taken from docs:

```py
import fiftyone as fo
import fiftyone.zoo as foz
from fiftyone import ViewField as F

dataset = foz.load_zoo_dataset("quickstart")

#
# Get a sample by filepath
#

# A random filepath in the dataset
filepath = dataset.take(1).first().filepath

# Get sample by filepath
sample = dataset.one(F("filepath") == filepath)

#
# Dealing with multiple matches
#

# Get a sample whose image is JPEG
sample = dataset.one(F("filepath").ends_with(".jpg"))

# Raises an error since there are multiple JPEGs
dataset.one(F("filepath").ends_with(".jpg"), exact=True)
```