### PR TITLE
Remove `--index` flag from troutblshooting page installs

### DIFF
--- a/docs/source/getting_started/troubleshooting.rst
+++ b/docs/source/getting_started/troubleshooting.rst
@@ -185,13 +185,15 @@ installation by adding `--force-reinstall` to the commands below.
 
     .. code-block:: shell
 
-      pip install --index https://pypi.voxel51.com fiftyone-db-ubuntu1604
+      # be sure you have libcurl3 installed
+      # apt install libcurl3
+      pip install fiftyone-db-ubuntu1604
 
   .. tab:: Debian 9
 
     .. code-block:: shell
 
-      pip install --index https://pypi.voxel51.com fiftyone-db-debian9
+      pip install fiftyone-db-debian9
 
 Manual installation
 ~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Resolves #845.

These commands should have been updated when the transition to PyPI first occurred (v0.7.0).