### PR TITLE
Filehandling

### DIFF
--- a/app/src/components/Player51.tsx
+++ b/app/src/components/Player51.tsx
@@ -59,6 +59,7 @@ export default ({
   onSelectObject,
   savedOverlayOptions,
 }) => {
+  const isVideo = useRecoilValue(selectors.isVideoDataset);
   const filter = useRecoilValue(filterSelector);
   const fps = useRecoilValue(atoms.sampleFrameRate(sample._id));
   const overlayOptions = useRecoilValue(selectors.playerOverlayOptions);
@@ -168,16 +169,22 @@ export default ({
     setError(
       <>
         <p>
-          This video failed to load. Its type ({mimetype}) may be unsupported.
+          This {isVideo ? "video" : "image"} failed to load. The file may not
+          exist, or its type ({mimetype}) may be unsupported.
         </p>
         <p>
-          You can use{" "}
-          <code>
-            <ExternalLink href="https://voxel51.com/docs/fiftyone/api/fiftyone.utils.video.html#fiftyone.utils.video.reencode_videos">
-              fiftyone.utils.video.reencode_videos()
-            </ExternalLink>
-          </code>{" "}
-          to re-encode videos in a supported format.
+          {isVideo && (
+            <>
+              {" "}
+              You can use{" "}
+              <code>
+                <ExternalLink href="https://voxel51.com/docs/fiftyone/api/fiftyone.utils.video.html#fiftyone.utils.video.reencode_videos">
+                  fiftyone.utils.video.reencode_videos()
+                </ExternalLink>
+              </code>{" "}
+              to re-encode videos in a supported format.
+            </>
+          )}
         </p>
       </>
     )

--- a/app/src/components/Sample.tsx
+++ b/app/src/components/Sample.tsx
@@ -113,7 +113,7 @@ const useHoverLoad = (socket, sample) => {
 const Sample = ({ sample, metadata, setView }) => {
   const http = useRecoilValue(selectors.http);
   const id = sample._id;
-  const src = `${http}/filepath${sample.filepath}?id=${id}`;
+  const src = `${http}/filepath${encodeURI(sample.filepath)}?id=${id}`;
   const socket = useRecoilValue(selectors.socket);
   const filter = useRecoilValue(labelFilters(false));
   const colorMap = useRecoilValue(selectors.colorMap);

--- a/app/src/components/Sample.tsx
+++ b/app/src/components/Sample.tsx
@@ -113,7 +113,7 @@ const useHoverLoad = (socket, sample) => {
 const Sample = ({ sample, metadata, setView }) => {
   const http = useRecoilValue(selectors.http);
   const id = sample._id;
-  const src = `${http}/filepath${encodeURI(sample.filepath)}?id=${id}`;
+  const src = `${http}/filepath/${encodeURI(sample.filepath)}?id=${id}`;
   const socket = useRecoilValue(selectors.socket);
   const filter = useRecoilValue(labelFilters(false));
   const colorMap = useRecoilValue(selectors.colorMap);

--- a/app/src/containers/Dataset.tsx
+++ b/app/src/containers/Dataset.tsx
@@ -146,7 +146,7 @@ function Dataset(props) {
   if (modal.sample) {
     const path = modal.sample.filepath;
     const id = modal.sample._id;
-    src = `${http}/filepath${encodeURI(path)}?id=${id}`;
+    src = `${http}/filepath/${encodeURI(path)}?id=${id}`;
     s = modal.sample;
   }
 

--- a/app/src/containers/Dataset.tsx
+++ b/app/src/containers/Dataset.tsx
@@ -146,7 +146,7 @@ function Dataset(props) {
   if (modal.sample) {
     const path = modal.sample.filepath;
     const id = modal.sample._id;
-    src = `${http}/filepath${path}?id=${id}`;
+    src = `${http}/filepath${encodeURI(path)}?id=${id}`;
     s = modal.sample;
   }
 

--- a/fiftyone/server/main.py
+++ b/fiftyone/server/main.py
@@ -556,12 +556,6 @@ class StateHandler(tornado.websocket.WebSocketHandler):
             r["height"] = h
             # default to image
 
-        for r in results:
-            s = r["sample"]
-            s["filepath"] = (
-                s["filepath"].replace(os.sep, posixpath.sep).split(":")[-1]
-            )
-
         message = {
             "type": "page",
             "page": page,
@@ -1199,12 +1193,15 @@ class FileHandler(tornado.web.StaticFileHandler):
         self.set_header("content-length", self.get_content_size())
         self.set_header("x-colab-notebook-cache-control", "no-cache")
 
+    @classmethod
+    def get_absolute_path(cls, root, path):
+        return path
+
 
 class Application(tornado.web.Application):
     """FiftyOne Tornado Application"""
 
     def __init__(self, **settings):
-        static_path = "C:/" if os.name == "nt" else "/"
         server_path = os.path.dirname(os.path.abspath(__file__))
         rel_web_path = "static"
         web_path = os.path.join(server_path, rel_web_path)
@@ -1212,7 +1209,7 @@ class Application(tornado.web.Application):
             (r"/fiftyone", FiftyOneHandler),
             (r"/polling", PollingHandler),
             (r"/feedback", FeedbackHandler),
-            (r"/filepath/(.*)", FileHandler, {"path": static_path},),
+            (r"/filepath/(.*)", FileHandler, {"path": ""},),
             (r"/notebook", NotebookHandler),
             (r"/stages", StagesHandler),
             (r"/state", StateHandler),

--- a/fiftyone/server/main.py
+++ b/fiftyone/server/main.py
@@ -1195,6 +1195,8 @@ class FileHandler(tornado.web.StaticFileHandler):
         self.set_header("content-length", self.get_content_size())
         self.set_header("x-colab-notebook-cache-control", "no-cache")
 
+
+class MediaHandler(FileHandler):
     @classmethod
     def get_absolute_path(cls, root, path):
         return path
@@ -1226,7 +1228,7 @@ class Application(tornado.web.Application):
             (r"/fiftyone", FiftyOneHandler),
             (r"/polling", PollingHandler),
             (r"/feedback", FeedbackHandler),
-            (r"/filepath/(.*)", FileHandler, {"path": ""},),
+            (r"/filepath/(.*)", MediaHandler, {"path": ""},),
             (r"/notebook", NotebookHandler),
             (r"/stages", StagesHandler),
             (r"/state", StateHandler),

--- a/fiftyone/server/main.py
+++ b/fiftyone/server/main.py
@@ -12,6 +12,7 @@ import math
 import os
 import posixpath
 import traceback
+import urllib
 
 from bson import ObjectId
 import tornado.escape
@@ -19,6 +20,7 @@ import tornado.ioloop
 import tornado.iostream
 import tornado.options
 import tornado.web
+from tornado.web import HTTPError
 import tornado.websocket
 
 import eta.core.labels as etal
@@ -1196,6 +1198,21 @@ class FileHandler(tornado.web.StaticFileHandler):
     @classmethod
     def get_absolute_path(cls, root, path):
         return path
+
+    def validate_absolute_path(self, root, absolute_path):
+        if os.path.isdir(absolute_path) and self.default_filename is not None:
+            if not self.request.path.endswith("/"):
+                self.redirect(self.request.path + "/", permanent=True)
+                return None
+
+            absolute_path = os.path.join(absolute_path, self.default_filename)
+        if not os.path.exists(absolute_path):
+            raise HTTPError(404)
+
+        if not os.path.isfile(absolute_path):
+            raise HTTPError(403, "%s is not a file", self.path)
+
+        return absolute_path
 
 
 class Application(tornado.web.Application):

--- a/fiftyone/server/util.py
+++ b/fiftyone/server/util.py
@@ -41,17 +41,20 @@ def get_file_dimensions(file_path):
     Returns:
         tuple: (width, height) as integers
     """
-    mime_type, _ = mimetypes.guess_type(file_path)
-    if mime_type is None:
-        raise UnknownFileFormat(
-            "Cannot identify mime type from %r" % file_path
-        )
-    category = mime_type.split("/")[0]
-    if category == "image":
-        return get_image_size(file_path)
-    elif category == "video":
-        return etav.get_frame_size(file_path)
-    raise UnknownFileFormat("Unhandled mime type: %r" % mime_type)
+    try:
+        mime_type, _ = mimetypes.guess_type(file_path)
+        if mime_type is None:
+            raise UnknownFileFormat(
+                "Cannot identify mime type from %r" % file_path
+            )
+        category = mime_type.split("/")[0]
+        if category == "image":
+            return get_image_size(file_path)
+        elif category == "video":
+            return etav.get_frame_size(file_path)
+        raise UnknownFileFormat("Unhandled mime type: %r" % mime_type)
+    except:
+        return 512, 512
 
 
 types = collections.OrderedDict()

--- a/tests/isolated/server_tests.py
+++ b/tests/isolated/server_tests.py
@@ -51,11 +51,10 @@ class RouteTests(TestCase):
     def test_filepath(self):
         data = {"hello": "world"}
         with etau.TempDir() as tmp:
-            path = os.path.join(tmp, "data.json")
+            path = os.path.join(tmp, "data%20.json")
             etas.write_json(data, path)
             response = self.fetch_and_parse(
-                "/filepath%s"
-                % path.replace(os.sep, posixpath.sep).split(":")[-1]
+                "/filepath/%s" % urllib.parse.quote(path, safe="")
             )
 
         self.assertEqual(response, data)
@@ -77,7 +76,7 @@ class StateTests(TestCase):
     image_url = "https://user-images.githubusercontent.com/3719547/74191434-8fe4f500-4c21-11ea-8d73-555edfce0854.png"
     test_one = os.path.abspath("./test_one.png")
     test_two = os.path.abspath("./test_two.png")
-    dataset = fo.Dataset("test")
+    dataset = fo.Dataset()
     sample1 = fo.Sample(filepath=test_one)
     sample2 = fo.Sample(filepath=test_two)
 


### PR DESCRIPTION
Improves static file handling (images and videos).

Changelog:
* Adds graceful failing for missing images and video in the App (see screenshots)
* Adds drive specific file handling for Windows
* Adds support for unsafe media filepaths, e.g. `%20.png`

Issues:
* Resolves #861 
* Resolves #860
* Resolves #839

![Screenshot from 2021-02-12 16-34-50](https://user-images.githubusercontent.com/19821840/107833430-7bfe3280-6d50-11eb-880b-ec24d2cc6358.png)
![Screenshot from 2021-02-12 16-34-40](https://user-images.githubusercontent.com/19821840/107833432-7c96c900-6d50-11eb-84e0-6f5bc1189c9a.png)
