### PR TITLE
Adding support for extracting values from nested array fields

### DIFF
--- a/fiftyone/core/aggregations.py
+++ b/fiftyone/core/aggregations.py
@@ -77,8 +77,8 @@ class Aggregation(object):
         """
         raise NotImplementedError("subclasses must implement default_result()")
 
-    def _parse_field_name(self, sample_collection, auto_unwind=True):
-        return _parse_field_name(
+    def _parse_field_and_expr(self, sample_collection, auto_unwind=True):
+        return _parse_field_and_expr(
             sample_collection, self._field_name, auto_unwind, self._expr
         )
 
@@ -178,7 +178,7 @@ class Bounds(Aggregation):
         return d["min"], d["max"]
 
     def to_mongo(self, sample_collection):
-        path, pipeline, _ = self._parse_field_name(sample_collection)
+        path, pipeline, _ = self._parse_field_and_expr(sample_collection)
 
         pipeline.append(
             {
@@ -301,7 +301,7 @@ class Count(Aggregation):
         if self._field_name is None:
             return [{"$count": "count"}]
 
-        path, pipeline, _ = self._parse_field_name(sample_collection)
+        path, pipeline, _ = self._parse_field_and_expr(sample_collection)
 
         if sample_collection.media_type != fom.VIDEO or path != "frames":
             pipeline.append({"$match": {"$expr": {"$gt": ["$" + path, None]}}})
@@ -408,7 +408,7 @@ class CountValues(Aggregation):
         return {i["k"]: i["count"] for i in d["result"]}
 
     def to_mongo(self, sample_collection):
-        path, pipeline, _ = self._parse_field_name(sample_collection)
+        path, pipeline, _ = self._parse_field_and_expr(sample_collection)
 
         pipeline += [
             {"$group": {"_id": "$" + path, "count": {"$sum": 1}}},
@@ -522,7 +522,7 @@ class Distinct(Aggregation):
         return sorted(d["values"])
 
     def to_mongo(self, sample_collection):
-        path, pipeline, _ = self._parse_field_name(sample_collection)
+        path, pipeline, _ = self._parse_field_and_expr(sample_collection)
 
         pipeline += [
             {"$match": {"$expr": {"$gt": ["$" + path, None]}}},
@@ -667,7 +667,7 @@ class HistogramValues(Aggregation):
         return self._parse_result_edges(d)
 
     def to_mongo(self, sample_collection):
-        path, pipeline, _ = self._parse_field_name(sample_collection)
+        path, pipeline, _ = self._parse_field_and_expr(sample_collection)
 
         if self._auto:
             pipeline.append(
@@ -850,7 +850,7 @@ class Mean(Aggregation):
         return d["mean"]
 
     def to_mongo(self, sample_collection):
-        path, pipeline, _ = self._parse_field_name(sample_collection)
+        path, pipeline, _ = self._parse_field_and_expr(sample_collection)
 
         pipeline.append(
             {"$group": {"_id": None, "mean": {"$avg": "$" + path}}}
@@ -953,7 +953,7 @@ class Std(Aggregation):
         return d["std"]
 
     def to_mongo(self, sample_collection):
-        path, pipeline, _ = self._parse_field_name(sample_collection)
+        path, pipeline, _ = self._parse_field_and_expr(sample_collection)
 
         op = "$stdDevSamp" if self._sample else "$stdDevPop"
         pipeline.append({"$group": {"_id": None, "std": {op: "$" + path}}})
@@ -1049,7 +1049,7 @@ class Sum(Aggregation):
         return d["sum"]
 
     def to_mongo(self, sample_collection):
-        path, pipeline, _ = self._parse_field_name(sample_collection)
+        path, pipeline, _ = self._parse_field_and_expr(sample_collection)
 
         pipeline.append({"$group": {"_id": None, "sum": {"$sum": "$" + path}}})
 
@@ -1124,17 +1124,12 @@ class Values(Aggregation):
             :class:`fiftyone.core.expressions.ViewExpression` or
             `MongoDB expression <https://docs.mongodb.com/manual/meta/aggregation-quick-reference/#aggregation-expressions>`_
             to apply to the field before aggregating
-        omit_missing (False): whether to omit missing or ``None``-valued fields
-            from the output list
         missing_value (None): a value to insert for missing or ``None``-valued
-            fields. Only applicable when ``omit_missing`` is ``False``
+            fields
     """
 
-    def __init__(
-        self, field_name, expr=None, omit_missing=False, missing_value=None
-    ):
+    def __init__(self, field_name, expr=None, missing_value=None):
         super().__init__(field_name, expr=expr)
-        self._omit_missing = omit_missing
         self._missing_value = missing_value
         self._found_array_field = False
 
@@ -1168,70 +1163,59 @@ class Values(Aggregation):
         return values
 
     def to_mongo(self, sample_collection):
-        path, pipeline, other_list_fields = self._parse_field_name(
+        path, pipeline, other_list_fields = self._parse_field_and_expr(
             sample_collection, auto_unwind=False
         )
 
         self._found_array_field = sample_collection._is_array_field(path)
 
-        if other_list_fields:
-            root = other_list_fields[0]
-            leaf = path[len(root) + 1 :]
-        else:
-            root = path
-            leaf = None
-
-        if self._omit_missing:
-            pipeline.append(
-                {"$match": {"$expr": (F(root) != None).to_mongo()}}
-            )
-
-            if leaf:
-                pipeline.append(
-                    {
-                        "$set": {
-                            root: F(root)
-                            .filter(F(leaf) != None)
-                            .map(F(leaf))
-                            .to_mongo()
-                        }
-                    }
-                )
-        elif leaf:
-            pipeline.append(
-                {
-                    "$set": {
-                        root: F(root)
-                        .map(
-                            (F(leaf) != None).if_else(
-                                F(leaf), self._missing_value
-                            )
-                        )
-                        .to_mongo()
-                    }
-                }
-            )
-        else:
-            # This is important, even when `self._missing_value is None`,
-            # because it inserts `None` for missing fields
-            pipeline.append(
-                {
-                    "$set": {
-                        root: (F(root) != None)
-                        .if_else(F(root), self._missing_value)
-                        .to_mongo()
-                    }
-                }
-            )
-
-        pipeline.append(
-            {"$group": {"_id": None, "values": {"$push": "$" + root}}}
+        pipeline += _make_extract_values_pipeline(
+            path, other_list_fields, self._missing_value
         )
 
         return pipeline
 
 
-def _parse_field_name(sample_collection, field_name, auto_unwind, expr):
+def _make_extract_values_pipeline(path, list_fields, missing_value):
+    if not list_fields:
+        root = path
+    else:
+        root = list_fields[0]
+
+    expr = (F() != None).if_else(F(), missing_value)
+
+    if list_fields:
+        subfield = path[len(list_fields[-1]) + 1 :]
+        expr = _extract_list_values(subfield, expr)
+
+    if len(list_fields) > 1:
+        for list_field1, list_field2 in zip(
+            reversed(list_fields[:-1]), reversed(list_fields[1:])
+        ):
+            inner_list_field = list_field2[len(list_field1) + 1 :]
+            expr = _extract_list_values(inner_list_field, expr)
+
+    return [
+        {"$set": {root: expr.to_mongo(prefix="$" + root)}},
+        {"$group": {"_id": None, "values": {"$push": "$" + root}}},
+    ]
+
+
+def _extract_list_values(subfield, expr):
+    if subfield:
+        map_expr = foe.ViewField(subfield).apply(expr)
+    else:
+        map_expr = expr
+
+    return foe.ViewField().map(map_expr)
+
+
+def _parse_field_and_expr(sample_collection, field_name, auto_unwind, expr):
+    if expr is not None:
+        pipeline = sample_collection._make_set_field_pipeline(field_name, expr)
+    else:
+        pipeline = []
+
     (
         path,
         is_frame_field,
@@ -1241,29 +1225,19 @@ def _parse_field_name(sample_collection, field_name, auto_unwind, expr):
         field_name, auto_unwind=auto_unwind
     )
 
-    if is_frame_field:
-        pipeline = [
-            {"$unwind": "$frames"},
-            {"$replaceRoot": {"newRoot": "$frames"}},
-        ]
-    else:
-        pipeline = []
-
-    if expr is not None:
-        # Expressions are applied to terminal lists themselves, not their
-        # elements, unless `[]` was explicitly specified
-        unwind_list_fields = [
-            lf for lf in unwind_list_fields if lf != field_name
-        ]
-        other_list_fields = [
-            lf for lf in other_list_fields if lf != field_name
-        ]
-
-    if len(other_list_fields) > 1:
-        raise ValueError("Aggregations support at most one unwound list field")
+    if is_frame_field and auto_unwind:
+        pipeline.extend(
+            [{"$unwind": "$frames"}, {"$replaceRoot": {"newRoot": "$frames"}}]
+        )
 
     for list_field in unwind_list_fields:
         pipeline.append({"$unwind": "$" + list_field})
+
+    if other_list_fields:
+        # Don't unroll terminal lists unless explicitly requested
+        other_list_fields = [
+            lf for lf in other_list_fields if lf != field_name
+        ]
 
     if other_list_fields:
         root = other_list_fields[0]
@@ -1272,29 +1246,6 @@ def _parse_field_name(sample_collection, field_name, auto_unwind, expr):
         root = path
         leaf = None
 
-    if expr is not None:
-        if leaf:
-            expr = (
-                F(root)
-                .map(
-                    F().set_field(
-                        leaf, _get_mongo_expr(expr, prefix="$$this." + leaf)
-                    )
-                )
-                .to_mongo()
-            )
-        else:
-            expr = _get_mongo_expr(expr, prefix="$" + root)
-
-        pipeline.append({"$project": {root: expr}})
-    else:
-        pipeline.append({"$project": {root: True}})
+    pipeline.append({"$project": {root: True}})
 
     return path, pipeline, other_list_fields
-
-
-def _get_mongo_expr(expr, prefix=None):
-    if isinstance(expr, foe.ViewExpression):
-        return expr.to_mongo(prefix=prefix)
-
-    return expr

--- a/fiftyone/core/aggregations.py
+++ b/fiftyone/core/aggregations.py
@@ -9,7 +9,6 @@ import numpy as np
 
 import eta.core.utils as etau
 
-import fiftyone.core.expressions as foe
 from fiftyone.core.expressions import ViewField as F
 import fiftyone.core.media as fom
 import fiftyone.core.utils as fou
@@ -1203,11 +1202,11 @@ def _make_extract_values_pipeline(path, list_fields, missing_value):
 
 def _extract_list_values(subfield, expr):
     if subfield:
-        map_expr = foe.ViewField(subfield).apply(expr)
+        map_expr = F(subfield).apply(expr)
     else:
         map_expr = expr
 
-    return foe.ViewField().map(map_expr)
+    return F().map(map_expr)
 
 
 def _parse_field_and_expr(sample_collection, field_name, auto_unwind, expr):

--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -17,6 +17,7 @@ import eta.core.serial as etas
 import eta.core.utils as etau
 
 import fiftyone.core.aggregations as foa
+import fiftyone.core.expressions as foe
 import fiftyone.core.fields as fof
 import fiftyone.core.labels as fol
 import fiftyone.core.media as fom
@@ -3052,9 +3053,7 @@ class SampleCollection(object):
         return self.aggregate(foa.Sum(field_name, expr=expr))
 
     @aggregation
-    def values(
-        self, field_name, expr=None, omit_missing=False, missing_value=None
-    ):
+    def values(self, field_name, expr=None, missing_value=None):
         """Extracts the values of a field from all samples in the collection.
 
         .. note::
@@ -3119,22 +3118,14 @@ class SampleCollection(object):
                 :class:`fiftyone.core.expressions.ViewExpression` or
                 `MongoDB expression <https://docs.mongodb.com/manual/meta/aggregation-quick-reference/#aggregation-expressions>`_
                 to apply to the field before aggregating
-            omit_missing (False): whether to omit missing or ``None``-valued
-                fields from the output list
             missing_value (None): a value to insert for missing or
-                ``None``-valued fields. Only applicable when ``omit_missing``
-                is ``False``
+                ``None``-valued fields
 
         Returns:
             the list of values
         """
         return self.aggregate(
-            foa.Values(
-                field_name,
-                expr=expr,
-                omit_missing=omit_missing,
-                missing_value=missing_value,
-            )
+            foa.Values(field_name, expr=expr, missing_value=missing_value)
         )
 
     def draw_labels(
@@ -3721,6 +3712,9 @@ class SampleCollection(object):
         if not self.has_sample_field(field_name):
             self._dataset.add_sample_field(field_name, ftype, **kwargs)
 
+    def _make_set_field_pipeline(self, field, expr, embedded_root=False):
+        return _make_set_field_pipeline(self, field, expr, embedded_root)
+
 
 def get_label_fields(
     sample_collection,
@@ -4042,6 +4036,13 @@ def _parse_field_name(sample_collection, field_name, auto_unwind):
     unwind_list_fields = sorted(unwind_list_fields)
     other_list_fields = sorted(other_list_fields)
 
+    if is_frame_field and not auto_unwind:
+        prefix = sample_collection._FRAMES_PREFIX
+        field_name = prefix + field_name
+        unwind_list_fields = [prefix + f for f in unwind_list_fields]
+        other_list_fields = [prefix + f for f in other_list_fields]
+        other_list_fields.insert(0, "frames")
+
     return field_name, is_frame_field, unwind_list_fields, other_list_fields
 
 
@@ -4088,6 +4089,89 @@ def _is_field_type(field, field_path, types):
         return False
 
     return _is_field_type(field, field_path, types)
+
+
+def _make_set_field_pipeline(sample_collection, field, expr, embedded_root):
+    path, is_frame_field, list_fields, _ = sample_collection._parse_field_name(
+        field
+    )
+
+    if is_frame_field and path != "frames":
+        path = sample_collection._FRAMES_PREFIX + path
+        list_fields = ["frames"] + [
+            sample_collection._FRAMES_PREFIX + lf for lf in list_fields
+        ]
+
+    # Don't unroll terminal lists unless explicitly requested
+    list_fields = [lf for lf in list_fields if lf != field]
+
+    # Case 1: no list fields
+    if not list_fields:
+        path_expr = _render_expr(expr, path, embedded_root)
+        return [{"$set": {path: path_expr}}]
+
+    # Case 2: one list field
+    if len(list_fields) == 1:
+        list_field = list_fields[0]
+        subfield = path[len(list_field) + 1 :]
+        expr = _set_terminal_list_field(
+            list_field, subfield, expr, embedded_root
+        )
+        return [{"$set": {list_field: expr.to_mongo()}}]
+
+    # Case 3: multiple list fields
+
+    # Handle last list field
+    last_list_field = list_fields[-1]
+    terminal_prefix = last_list_field[len(list_fields[-2]) + 1 :]
+    subfield = path[len(last_list_field) + 1 :]
+    expr = _set_terminal_list_field(
+        terminal_prefix, subfield, expr, embedded_root
+    )
+
+    for list_field1, list_field2 in zip(
+        reversed(list_fields[:-1]), reversed(list_fields[1:])
+    ):
+        inner_list_field = list_field2[len(list_field1) + 1 :]
+        expr = foe.ViewField().map(
+            foe.ViewField().set_field(inner_list_field, expr)
+        )
+
+    expr = expr.to_mongo(prefix="$" + list_fields[0])
+
+    return [{"$set": {list_fields[0]: expr}}]
+
+
+def _set_terminal_list_field(list_field, subfield, expr, embedded_root):
+    map_path = "$this"
+    if subfield:
+        map_path += "." + subfield
+
+    map_expr = _render_expr(expr, map_path, embedded_root)
+
+    if subfield:
+        map_expr = foe.ViewField().set_field(subfield, map_expr)
+    else:
+        map_expr = foe.ViewExpression(map_expr)
+
+    return foe.ViewField(list_field).map(map_expr)
+
+
+def _render_expr(expr, path, embedded_root):
+    if not isinstance(expr, foe.ViewExpression):
+        return expr
+
+    if not embedded_root:
+        prefix = path
+    elif "." in path:
+        prefix = path.rsplit(".", 1)[0]
+    else:
+        prefix = None
+
+    if prefix:
+        prefix = "$" + prefix
+
+    return expr.to_mongo(prefix=prefix)
 
 
 def _get_random_characters(n):

--- a/tests/unittests/aggregation_tests.py
+++ b/tests/unittests/aggregation_tests.py
@@ -275,11 +275,6 @@ class DatasetTests(unittest.TestCase):
         )
 
         self.assertListEqual(
-            d.values("predictions.detections.label", omit_missing=True),
-            [["cat", "dog"], ["cat", "rabbit", "squirrel"], ["elephant"]],
-        )
-
-        self.assertListEqual(
             d.values("predictions.detections.label", missing_value="missing"),
             [
                 ["cat", "dog"],
@@ -293,11 +288,6 @@ class DatasetTests(unittest.TestCase):
         self.assertListEqual(
             d.values("predictions.detections[].label"),
             ["cat", "dog", "cat", "rabbit", "squirrel", "elephant", None],
-        )
-
-        self.assertListEqual(
-            d.values("predictions.detections[].label", omit_missing=True),
-            ["cat", "dog", "cat", "rabbit", "squirrel", "elephant"],
         )
 
         self.assertListEqual(


### PR DESCRIPTION
The `values()` aggregation previously did not support cases where there were two or more array fields involved, for example extracting the labels for all detections of frame-level fields. This PR adds support for this.

This arose as I was working on evaluation for video datasets, where I wanted to write aggregations to extract all classifications or detections at the frame-level.

mea culpa: I haven't added aggregation tests for frame-level fields, but there are fairly comprehensive tests for sample-level fields, and this PR passes those. So at best this PR adds full support for video datasets, and at worst it replaces existing video bugs with new ones.

```py
import random

import fiftyone as fo
import fiftyone.zoo as foz
from fiftyone import ViewField as F

dataset = foz.load_zoo_dataset("quickstart-video").clone()

with fo.ProgressBar() as pb:
    for sample in pb(dataset):
        for frame in sample.frames.values():
            label = random.choice(["sunny", "cloudy", "rainy"])
            frame["weather"] = fo.Classification(label=label)

        sample.save()

def check(dataset, path, expr):
    print(dataset.distinct(path, expr=expr))
    print(dataset.count_values(path, expr=expr))

    values = dataset.values(path, expr=expr)
    print(len(values))  # number of samples
    print(len(values[0]))  # number of frames in first sample
    print(values[0][0])  # values for first frame of first sample

# Extract frame-level classifications
check(dataset, "frames.weather.label", None)
check(dataset, "frames.weather.label", F().upper())

# Extract frame-level object labels
check(dataset, "frames.ground_truth_detections.detections.label", None)
check(dataset, "frames.ground_truth_detections.detections.label", F().upper())
```
