### PR TITLE
Adding support for evaluating video classifications

### DIFF
--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -974,17 +974,24 @@ class SampleCollection(object):
         """
         return foue.get_evaluation_info(self, eval_key)
 
-    def load_evaluation_view(self, eval_key):
+    def load_evaluation_view(self, eval_key, select_fields=False):
         """Loads the :class:`fiftyone.core.view.DatasetView` on which the
         specified evaluation was performed on this collection.
 
         Args:
             eval_key: an evaluation key
+            select_fields (False): whether to select only the fields involved
+                in the evaluation. If true, only the predicted and ground truth
+                fields involved in the evaluation will be selected, and any
+                ancillary fields populated on those samples by other
+                evaluations will be excluded
 
         Returns:
             a :class:`fiftyone.core.view.DatasetView`
         """
-        return foue.load_evaluation_view(self, eval_key)
+        return foue.load_evaluation_view(
+            self, eval_key, select_fields=select_fields
+        )
 
     def delete_evaluation(self, eval_key):
         """Deletes the evaluation results associated with the given evaluation

--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -511,6 +511,7 @@ class SampleCollection(object):
             field_name: a field or ``embedded.field.name``
             values: an iterable of values
         """
+        # @todo support frame fields
         field_name, is_frame_field = self._handle_frame_field(field_name)
         if is_frame_field:
             raise ValueError("set_values() only supports sample fields")
@@ -3677,19 +3678,6 @@ class SampleCollection(object):
             return next(result)["ids"]
         except StopIteration:
             return []
-
-    def _attach_frames(self):
-        # pylint: disable=no-member
-        return [
-            {
-                "$lookup": {
-                    "from": self._frame_collection_name,
-                    "localField": "_id",
-                    "foreignField": "_sample_id",
-                    "as": "frames",
-                }
-            }
-        ]
 
     async def _async_aggregate(self, sample_collection, aggregations):
         scalar_result, aggregations, facets = self._build_aggregation(

--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -676,8 +676,18 @@ class SampleCollection(object):
         top-k matching can be configured via the ``method`` and ``config``
         parameters.
 
-        If an ``eval_key`` is specified, this method will record whether each
-        prediction is correct in this field.
+        If an ``eval_key`` is specified, then this method will record some
+        statistics on each sample:
+
+        -   When evaluating sample-level fields, an ``eval_key`` field will be
+            populated on each sample recording whether that sample's prediction
+            is correct.
+
+        -   When evaluating frame-level fields, an ``eval_key`` field will be
+            populated on each frame recording whether that frame's prediction
+            is correct. In addition, an ``eval_key`` field will be populated on
+            each sample that records the average accuracy of the frame
+            predictions of the sample.
 
         Args:
             pred_field: the name of the field containing the predicted
@@ -744,6 +754,13 @@ class SampleCollection(object):
                 TP: sample.<eval_key>_tp
                 FP: sample.<eval_key>_fp
                 FN: sample.<eval_key>_fn
+
+            In addition, when evaluating frame-level objects, TP/FP/FN counts
+            are recorded for each frame::
+
+                TP: frame.<eval_key>_tp
+                FP: frame.<eval_key>_fp
+                FN: frame.<eval_key>_fn
 
         -   The fields listed below are populated on each individual
             :class:`fiftyone.core.labels.Detection` instance; these fields
@@ -813,11 +830,19 @@ class SampleCollection(object):
         it is resized to match the ground truth.
 
         If an ``eval_key`` is provided, the accuracy, precision, and recall of
-        each sample is recorded in top-level fields of the samples::
+        each sample is recorded in top-level fields of each sample::
 
              Accuracy: sample.<eval_key>_accuracy
             Precision: sample.<eval_key>_precision
                Recall: sample.<eval_key>_recall
+
+       In addition, when evaluating frame-level masks, the accuracy, precision,
+       and recall of each frame if recorded in the following frame-level
+       fields::
+
+             Accuracy: frame.<eval_key>_accuracy
+            Precision: frame.<eval_key>_precision
+               Recall: frame.<eval_key>_recall
 
         .. note::
 

--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -4273,7 +4273,7 @@ def _make_set_values_pipeline(field_name, value, list_fields):
 
     if len(list_fields) > 1:
         raise ValueError(
-            "At most one nested array field can be unwound when setting values"
+            "At most one array field can be unwound when setting values"
         )
 
     root = list_fields[0]

--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -3795,31 +3795,6 @@ class SampleCollection(object):
             attach_frames=True,
         )
 
-        """
-        result = self._dataset._frame_collection.aggregate(
-            [
-                {
-                    "$group": {
-                        "_id": "$_sample_id",
-                        "sample_id": {"$first": "$_sample_id"},
-                        "frame_ids": {"$push": "$_id"},
-                    }
-                },
-                {
-                    "$group": {
-                        "_id": None,
-                        "result": {
-                            "$push": {
-                                "sample_id": "$sample_id",
-                                "frame_ids": "$frame_ids",
-                            }
-                        }
-                    }
-                }
-            ]
-        )
-        """
-
         try:
             return next(result)["result"]
         except StopIteration:

--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -1151,27 +1151,27 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
 
         return [str(d["_id"]) for d in dicts]
 
-    def _bulk_update(self, sample_ids, updates, ordered=False):
+    def _bulk_update(self, ids, updates, frames=False, ordered=False):
         ops = [
             UpdateOne({"_id": _id}, update)
-            for _id, update in zip(sample_ids, updates)
+            for _id, update in zip(ids, updates)
         ]
-        self._bulk_write(ops, ordered=ordered)
+        self._bulk_write(ops, frames=frames, ordered=ordered)
 
-        # Equivalent with loops
-        # coll = self._sample_collection
-        # with fou.ProgressBar() as pb:
-        #     for _id, update in zip(pb(sample_ids), updates):
-        #         coll.update_one({"_id": _id}, update)
+        if frames:
+            fofr.Frame._reload_docs(self._frame_collection_name)
+        else:
+            fos.Sample._reload_docs(self._sample_collection_name)
 
-        fos.Sample._reload_docs(self._sample_collection_name)
+    def _bulk_write(self, ops, frames=False, ordered=False):
+        if frames:
+            coll = self._frame_collection
+        else:
+            coll = self._sample_collection
 
-    def _bulk_write(self, ops, ordered=False):
         try:
             for ops_batch in fou.iter_batches(ops, 100000):  # mongodb limit
-                self._sample_collection.bulk_write(
-                    list(ops_batch), ordered=ordered
-                )
+                coll.bulk_write(list(ops_batch), ordered=ordered)
         except BulkWriteError as bwe:
             msg = bwe.details["writeErrors"][0]["errmsg"]
             raise ValueError(msg) from bwe

--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -2466,7 +2466,16 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
             attach_frames = True
 
         if attach_frames and (self.media_type == fom.VIDEO):
-            _pipeline = self._attach_frames()
+            _pipeline = [
+                {
+                    "$lookup": {
+                        "from": self._frame_collection_name,
+                        "localField": "_id",
+                        "foreignField": "_sample_id",
+                        "as": "frames",
+                    }
+                }
+            ]
         else:
             _pipeline = []
 

--- a/fiftyone/core/expressions.py
+++ b/fiftyone/core/expressions.py
@@ -1553,12 +1553,12 @@ class ViewExpression(object):
             }
         )
 
-    def set_field(self, field, value_or_expr):
+    def set_field(self, field, value_or_expr, relative=True):
         """Sets the specified field or embedded field of this expression, which
         must resolve to a document, to the given value or expression.
 
-        The provided expression is computed by applying it to this expression
-        via ``self.apply(value_or_expr)``.
+        By default, the provided expression is computed by applying it to this
+        expression via ``self.apply(value_or_expr)``.
 
         Examples::
 
@@ -1591,12 +1591,15 @@ class ViewExpression(object):
             field: the "field" or "embedded.field.name" to set
             value_or_expr: a literal value or :class:`ViewExpression` defining
                 the field to set
+            relative (True): whether to compute ``value_or_expr`` by applying
+                it to this expression (True), or to use it untouched (False)
 
         Returns:
             a :class:`ViewExpression`
         """
         if (
             isinstance(value_or_expr, ViewExpression)
+            and relative
             and not value_or_expr.is_frozen
         ):
             value = self.apply(value_or_expr)

--- a/fiftyone/core/expressions.py
+++ b/fiftyone/core/expressions.py
@@ -1222,6 +1222,122 @@ class ViewExpression(object):
 
         return ViewExpression({"$in": [self, list(values)]})
 
+    def to_bool(self):
+        """Converts the expression to a boolean value.
+
+        See
+        `this page <https://docs.mongodb.com/manual/reference/operator/aggregation/toBool>`__
+        for conversion rules.
+
+        Examples::
+
+            import fiftyone as fo
+            import fiftyone.zoo as foz
+            from fiftyone import ViewField as F
+
+            dataset = foz.load_zoo_dataset("quickstart").clone()
+
+            # Adds a `uniqueness_bool` field that is False when
+            # `uniqueness < 0.5` and True when `uniqueness >= 0.5`
+            dataset.add_sample_field("uniqueness_bool", fo.BooleanField)
+            view = dataset.set_field(
+                "uniqueness_bool", (2.0 * F("uniqueness")).floor().to_bool()
+            )
+
+            print(view.count_values("uniqueness_bool"))
+
+        Returns:
+            a :class:`ViewExpression`
+        """
+        return ViewExpression({"$toBool": self})
+
+    def to_int(self):
+        """Converts the expression to an integer value.
+
+        See
+        `this page <https://docs.mongodb.com/manual/reference/operator/aggregation/toInt>`__
+        for conversion rules.
+
+        Examples::
+
+            import fiftyone as fo
+            import fiftyone.zoo as foz
+            from fiftyone import ViewField as F
+
+            dataset = foz.load_zoo_dataset("quickstart").clone()
+
+            # Adds a `uniqueness_int` field that contains the value of the
+            # first decimal point of the `uniqueness` field
+            dataset.add_sample_field("uniqueness_int", fo.IntField)
+            view = dataset.set_field(
+                "uniqueness_int", (10.0 * F("uniqueness")).floor().to_int()
+            )
+
+            print(view.count_values("uniqueness_int"))
+
+        Returns:
+            a :class:`ViewExpression`
+        """
+        return ViewExpression({"$toInt": self})
+
+    def to_double(self):
+        """Converts the expression to a double precision value.
+
+        Examples::
+
+            import fiftyone as fo
+            import fiftyone.zoo as foz
+            from fiftyone import ViewField as F
+
+            dataset = foz.load_zoo_dataset("quickstart").clone()
+
+            # Adds a `uniqueness_float` field that is 0.0 when
+            # `uniqueness < 0.5` and 1.0 when `uniqueness >= 0.5`
+            dataset.add_sample_field("uniqueness_float", fo.FloatField)
+            view = dataset.set_field(
+                "uniqueness_float", (F("uniqueness") >= 0.5).to_double()
+            )
+
+            print(view.count_values("uniqueness_float"))
+
+        See
+        `this page <https://docs.mongodb.com/manual/reference/operator/aggregation/toDouble>`__
+        for conversion rules.
+
+        Returns:
+            a :class:`ViewExpression`
+        """
+        return ViewExpression({"$toDouble": self})
+
+    def to_string(self):
+        """Converts the expression to a string value.
+
+        See
+        `this page <https://docs.mongodb.com/manual/reference/operator/aggregation/toString>`__
+        for conversion rules.
+
+        Examples::
+
+            import fiftyone as fo
+            import fiftyone.zoo as foz
+            from fiftyone import ViewField as F
+
+            dataset = foz.load_zoo_dataset("quickstart").clone()
+
+            # Adds a `uniqueness_str` field that is "true" when
+            # `uniqueness >= 0.5` and "false" when `uniqueness < 0.5`
+            dataset.add_sample_field("uniqueness_str", fo.StringField)
+            view = dataset.set_field(
+                "uniqueness_str", (F("uniqueness") >= 0.5).to_string()
+            )
+
+            print(view.count_values("uniqueness_str"))
+
+        Returns:
+            a :class:`ViewExpression`
+        """
+        return ViewExpression({"$toString": self})
+
     def apply(self, expr):
         """Applies the given expression to this expression.
 
@@ -2607,7 +2723,7 @@ class ViewExpression(object):
             regex: the regular expression to apply. Must be a Perl Compatible
                 Regular Expression (PCRE). See
                 `this page <https://docs.mongodb.com/manual/reference/operator/aggregation/regexMatch/#regexmatch-regex>`__
-                for  details
+                for details
             options (None): an optional string of regex options to apply. See
                 `this page <https://docs.mongodb.com/manual/reference/operator/aggregation/regexMatch/#regexmatch-options>`__
                 for the available options

--- a/fiftyone/core/stages.py
+++ b/fiftyone/core/stages.py
@@ -705,7 +705,7 @@ class FilterField(ViewStage):
         return field
 
     def _needs_frames(self, sample_collection):
-        return sample_collection._handle_frame_field(self._field)[1]
+        return sample_collection._is_frame_field(self._field)
 
     def _kwargs(self):
         return [
@@ -1176,7 +1176,7 @@ class FilterLabels(FilterField):
         )
 
     def _needs_frames(self, sample_collection):
-        return sample_collection._handle_frame_field(self._labels_field)[1]
+        return sample_collection._is_frame_field(self._labels_field)
 
     def _get_mongo_filter(self):
         if self._is_labels_list_field:

--- a/fiftyone/core/stages.py
+++ b/fiftyone/core/stages.py
@@ -1940,6 +1940,14 @@ class SetField(ViewStage):
         """The expression to apply."""
         return self._expr
 
+    def _needs_frames(self, sample_collection):
+        if sample_collection.media_type != fom.VIDEO:
+            return False
+
+        is_frame_field = sample_collection._is_frame_field(self._field)
+        is_frame_expr = _is_frames_expr(self._get_mongo_expr())
+        return is_frame_field or is_frame_expr
+
     def to_mongo(self, sample_collection, **_):
         return sample_collection._make_set_field_pipeline(
             self._field, self._expr, embedded_root=True
@@ -3051,6 +3059,19 @@ def _make_label_filter_stage(label_schema, field, label_filter):
     msg = "Ignoring unsupported field '%s' (%s)" % (field, label_type)
     warnings.warn(msg)
     return None
+
+
+def _is_frames_expr(val):
+    if etau.is_str(val):
+        return val == "$frames" or val.startswith("$frames.")
+
+    if isinstance(val, dict):
+        return {_is_frames_expr(k): _is_frames_expr(v) for k, v in val.items()}
+
+    if isinstance(val, list):
+        return [_is_frames_expr(v) for v in val]
+
+    return False
 
 
 class _ViewStageRepr(reprlib.Repr):

--- a/fiftyone/server/main.py
+++ b/fiftyone/server/main.py
@@ -1128,7 +1128,7 @@ def _make_scalar_expression(f, args):
         expr = f.is_in(values)
         exclude = args["exclude"]
 
-        if exclude and expr:
+        if exclude:
             # pylint: disable=invalid-unary-operand-type
             expr = ~expr
 
@@ -1199,6 +1199,9 @@ class FileHandler(tornado.web.StaticFileHandler):
 class MediaHandler(FileHandler):
     @classmethod
     def get_absolute_path(cls, root, path):
+        if os.name != "nt":
+            path = os.path.join("/", path)
+
         return path
 
     def validate_absolute_path(self, root, absolute_path):

--- a/fiftyone/utils/eval/base.py
+++ b/fiftyone/utils/eval/base.py
@@ -137,6 +137,19 @@ class Evaluation(Configurable):
         config: an :class:`EvaluationConfig`
     """
 
+    def get_fields(self, samples, eval_key):
+        """Gets the evaluation fields that were populated by the given
+        evaluation.
+
+        Args:
+            samples: a :class:`fiftyone.core.collections.SampleCollection`
+            eval_key: an evaluation key
+
+        Returns:
+            a list of fields
+        """
+        raise NotImplementedError("subclass must implement get_fields()")
+
     def cleanup(self, samples, eval_key):
         """Deletes any results for the evaluation with the given key from the
         collection.
@@ -230,20 +243,49 @@ def save_evaluation_info(samples, eval_info):
     samples._dataset.save()
 
 
-def load_evaluation_view(samples, eval_key):
+def load_evaluation_view(samples, eval_key, select_fields=False):
     """Loads the :class:`fiftyone.core.view.DatasetView` on which the specified
     evaluation was performed.
 
     Args:
         samples: a :class:`fiftyone.core.collections.SampleCollection`
         eval_key: an evaluation key
+        select_fields (False): whether to select only the fields involved
+            in the evaluation. If true, only the predicted and ground truth
+            fields involved in the evaluation will be selected, and any
+            ancillary fields populated on those samples by other evaluations
+            will be excluded
 
     Returns:
         a :class:`fiftyone.core.view.DatasetView`
     """
     eval_doc = _get_evaluation_doc(samples, eval_key)
     stage_dicts = [json.loads(s) for s in eval_doc.view_stages]
-    return fov.DatasetView._build(samples._dataset, stage_dicts)
+    view = fov.DatasetView._build(samples._dataset, stage_dicts)
+
+    if select_fields:
+        select = []
+        exclude = []
+        for _eval_key in list_evaluations(samples):
+            eval_info = get_evaluation_info(samples, _eval_key)
+            eval_method = eval_info.config.build()
+            eval_fields = eval_method.get_fields(samples, _eval_key)
+            if _eval_key == eval_key:
+                gt = eval_info.gt_field
+                pred = eval_info.pred_field
+                select.extend([gt, pred])
+
+                # We don't need to select embedded fields of `gt` and `pred`
+                skip_prefixes = (pred + ".", gt + ".")
+                for field in eval_fields:
+                    if not field.startswith(skip_prefixes):
+                        select.append(field)
+            else:
+                exclude.extend(eval_fields)
+
+        view = view.exclude_fields(exclude).select_fields(select)
+
+    return view
 
 
 def delete_evaluation(samples, eval_key):

--- a/fiftyone/utils/eval/classification.py
+++ b/fiftyone/utils/eval/classification.py
@@ -145,6 +145,15 @@ class ClassificationEvaluation(Evaluation):
         """
         raise NotImplementedError("subclass must implement evaluate_samples()")
 
+    def get_fields(self, samples, eval_key):
+        eval_info = samples.get_evaluation_info(eval_key)
+
+        eval_fields = [eval_key]
+        if samples._is_frame_field(eval_info.gt_field):
+            return eval_fields.append(samples._FRAMES_PREFIX + eval_key)
+
+        return eval_fields
+
     def cleanup(self, samples, eval_key):
         eval_info = samples.get_evaluation_info(eval_key)
         samples._dataset.delete_sample_field(eval_key)

--- a/fiftyone/utils/eval/classification.py
+++ b/fiftyone/utils/eval/classification.py
@@ -342,9 +342,12 @@ def _evaluate_top_k(ytrue, ypred, logits, k, targets_map):
                 ypred[idx] = _ytrue
                 logit = _logits[target]
                 _correct = True
-            else:
+            elif ypred[idx] is not None:
                 # Truth is not in top-k; retain actual prediction
                 logit = _logits[targets_map[ypred[idx]]]
+                _correct = False
+            else:
+                logit = -np.inf
                 _correct = False
 
             _conf = np.exp(logit) / np.sum(np.exp(_logits))

--- a/fiftyone/utils/eval/classification.py
+++ b/fiftyone/utils/eval/classification.py
@@ -203,18 +203,18 @@ class SimpleEvaluation(ClassificationEvaluation):
             gt = gt[len(samples._FRAMES_PREFIX) :]
             pred = pred[len(samples._FRAMES_PREFIX) :]
 
-            # Save sample-level accuracies
+            # Sample-level accuracies
             samples._add_field_if_necessary(eval_key, fof.FloatField)
             samples.set_field(
                 eval_key,
                 F("frames").map((F(gt) == F(pred)).to_double()).mean(),
             ).save(eval_key)
 
-            # Save per-frame accuracies
+            # Per-frame accuracies
             samples._add_field_if_necessary(eval_frame, fof.BooleanField)
             samples.set_field(eval_frame, F(gt) == F(pred)).save(eval_frame)
         else:
-            # Save per-sample accuracies
+            # Per-sample accuracies
             samples._add_field_if_necessary(eval_key, fof.BooleanField)
             samples.set_field(eval_key, F(gt) == F(pred)).save(eval_key)
 
@@ -306,14 +306,15 @@ class TopKEvaluation(ClassificationEvaluation):
         if is_frame_field:
             eval_frame = samples._FRAMES_PREFIX + eval_key
 
-            # Save sample-level accuracies
+            # Sample-level accuracies
             samples._add_field_if_necessary(eval_key, fof.FloatField)
             samples.set_values(eval_key, [np.mean(c) for c in correct])
 
-            # Save per-frame accuracies
+            # Per-frame accuracies
             samples._add_field_if_necessary(eval_frame, fof.BooleanField)
             samples.set_values(eval_frame, correct)
         else:
+            # Per-sample accuracies
             samples._add_field_if_necessary(eval_key, fof.BooleanField)
             samples.set_values(eval_key, correct)
 
@@ -428,14 +429,14 @@ class BinaryEvaluation(ClassificationEvaluation):
             gt = gt[len(samples._FRAMES_PREFIX) :]
             pred = pred[len(samples._FRAMES_PREFIX) :]
 
-            # Save sample-level accuracies
+            # Sample-level accuracies
             samples._add_field_if_necessary(eval_key, fof.FloatField)
             samples.set_field(
                 eval_key,
                 F("frames").map((F(gt) == F(pred)).to_double()).mean(),
             ).save(eval_key)
 
-            # Save per-frame accuracies
+            # Per-frame accuracies
             samples._add_field_if_necessary(eval_frame, fof.StringField)
             samples.set_field(
                 eval_frame,
@@ -449,7 +450,7 @@ class BinaryEvaluation(ClassificationEvaluation):
                 ),
             ).save(eval_frame)
         else:
-            # Save per-sample accuracies
+            # Per-sample accuracies
             samples._add_field_if_necessary(eval_key, fof.StringField)
             samples.set_field(
                 eval_key,

--- a/fiftyone/utils/eval/detection.py
+++ b/fiftyone/utils/eval/detection.py
@@ -131,6 +131,11 @@ def evaluate_detections(
                 sample_fp += fp
                 sample_fn += fn
 
+                if processing_frames and eval_key is not None:
+                    image["%s_tp" % eval_key] = tp
+                    image["%s_fp" % eval_key] = fp
+                    image["%s_fn" % eval_key] = fn
+
             if eval_key is not None:
                 sample["%s_tp" % eval_key] = sample_tp
                 sample["%s_fp" % eval_key] = sample_fp
@@ -148,6 +153,9 @@ def _cleanup_evaluate_detections(samples, pred_field, gt_field, eval_key):
     gt_field, _ = samples._handle_frame_field(gt_field)
 
     fields = [
+        "%s_tp" % eval_key,
+        "%s_fp" % eval_key,
+        "%s_fn" % eval_key,
         "%s.detections.%s_id" % (pred_field, eval_key),
         "%s.detections.%s_iou" % (pred_field, eval_key),
         "%s.detections.%s_id" % (gt_field, eval_key),
@@ -155,13 +163,12 @@ def _cleanup_evaluate_detections(samples, pred_field, gt_field, eval_key):
     ]
 
     if is_frame_field:
+        samples._dataset.delete_sample_fields(
+            ["%s_tp" % eval_key, "%s_fp" % eval_key, "%s_fn" % eval_key]
+        )
         samples._dataset.delete_frame_fields(fields)
     else:
         samples._dataset.delete_sample_fields(fields)
-
-    samples._dataset.delete_sample_fields(
-        ["%s_tp" % eval_key, "%s_fp" % eval_key, "%s_fn" % eval_key]
-    )
 
 
 class DetectionEvaluationConfig(EvaluationConfig):

--- a/fiftyone/utils/eval/detection.py
+++ b/fiftyone/utils/eval/detection.py
@@ -148,29 +148,6 @@ def evaluate_detections(
     return DetectionResults(matches, classes=classes, missing=missing)
 
 
-def _cleanup_evaluate_detections(samples, pred_field, gt_field, eval_key):
-    pred_field, is_frame_field = samples._handle_frame_field(pred_field)
-    gt_field, _ = samples._handle_frame_field(gt_field)
-
-    fields = [
-        "%s_tp" % eval_key,
-        "%s_fp" % eval_key,
-        "%s_fn" % eval_key,
-        "%s.detections.%s_id" % (pred_field, eval_key),
-        "%s.detections.%s_iou" % (pred_field, eval_key),
-        "%s.detections.%s_id" % (gt_field, eval_key),
-        "%s.detections.%s_iou" % (gt_field, eval_key),
-    ]
-
-    if is_frame_field:
-        samples._dataset.delete_sample_fields(
-            ["%s_tp" % eval_key, "%s_fp" % eval_key, "%s_fn" % eval_key]
-        )
-        samples._dataset.delete_frame_fields(fields)
-    else:
-        samples._dataset.delete_sample_fields(fields)
-
-
 class DetectionEvaluationConfig(EvaluationConfig):
     """Base class for configuring :class:`DetectionEvaluation` instances.
 
@@ -213,14 +190,55 @@ class DetectionEvaluation(Evaluation):
         """
         raise NotImplementedError("subclass must implement evaluate_image()")
 
+    def get_fields(self, samples, eval_key):
+        eval_info = samples.get_evaluation_info(eval_key)
+
+        eval_fields = [
+            "%s_tp" % eval_key,
+            "%s_fp" % eval_key,
+            "%s_fn" % eval_key,
+            "%s.detections.%s_id" % (eval_info.pred_field, eval_key),
+            "%s.detections.%s_iou" % (eval_info.pred_field, eval_key),
+            "%s.detections.%s_id" % (eval_info.gt_field, eval_key),
+            "%s.detections.%s_iou" % (eval_info.gt_field, eval_key),
+        ]
+
+        if samples._is_frame_field(eval_info.gt_field):
+            eval_fields.extend(
+                [
+                    "frames.%s_tp" % eval_key,
+                    "frames.%s_fp" % eval_key,
+                    "frames.%s_fn" % eval_key,
+                ]
+            )
+
+        return eval_fields
+
     def cleanup(self, samples, eval_key):
         eval_info = samples.get_evaluation_info(eval_key)
-        _cleanup_evaluate_detections(
-            samples,
-            eval_info.pred_field,
-            eval_info.gt_field,
-            eval_info.eval_key,
+
+        pred_field, is_frame_field = samples._handle_frame_field(
+            eval_info.pred_field
         )
+        gt_field, _ = samples._handle_frame_field(eval_info.gt_field)
+
+        fields = [
+            "%s_tp" % eval_key,
+            "%s_fp" % eval_key,
+            "%s_fn" % eval_key,
+            "%s.detections.%s_id" % (pred_field, eval_key),
+            "%s.detections.%s_iou" % (pred_field, eval_key),
+            "%s.detections.%s_id" % (gt_field, eval_key),
+            "%s.detections.%s_iou" % (gt_field, eval_key),
+        ]
+
+        if is_frame_field:
+            samples._dataset.delete_sample_fields(
+                ["%s_tp" % eval_key, "%s_fp" % eval_key, "%s_fn" % eval_key]
+            )
+            samples._dataset.delete_frame_fields(fields)
+        else:
+            samples._dataset.delete_sample_fields(fields)
 
 
 class DetectionResults(ClassificationResults):

--- a/fiftyone/utils/eval/detection.py
+++ b/fiftyone/utils/eval/detection.py
@@ -197,8 +197,10 @@ class DetectionEvaluation(Evaluation):
             "%s_tp" % eval_key,
             "%s_fp" % eval_key,
             "%s_fn" % eval_key,
+            "%s.detections.%s" % (eval_info.pred_field, eval_key),
             "%s.detections.%s_id" % (eval_info.pred_field, eval_key),
             "%s.detections.%s_iou" % (eval_info.pred_field, eval_key),
+            "%s.detections.%s" % (eval_info.gt_field, eval_key),
             "%s.detections.%s_id" % (eval_info.gt_field, eval_key),
             "%s.detections.%s_iou" % (eval_info.gt_field, eval_key),
         ]
@@ -226,8 +228,10 @@ class DetectionEvaluation(Evaluation):
             "%s_tp" % eval_key,
             "%s_fp" % eval_key,
             "%s_fn" % eval_key,
+            "%s.detections.%s" % (pred_field, eval_key),
             "%s.detections.%s_id" % (pred_field, eval_key),
             "%s.detections.%s_iou" % (pred_field, eval_key),
+            "%s.detections.%s" % (gt_field, eval_key),
             "%s.detections.%s_id" % (gt_field, eval_key),
             "%s.detections.%s_iou" % (gt_field, eval_key),
         ]

--- a/fiftyone/utils/eval/detection.py
+++ b/fiftyone/utils/eval/detection.py
@@ -51,6 +51,13 @@ def evaluate_detections(
             FP: sample.<eval_key>_fp
             FN: sample.<eval_key>_fn
 
+        In addition, when evaluating frame-level objects, TP/FP/FN counts are
+        recorded for each frame::
+
+            TP: frame.<eval_key>_tp
+            FP: frame.<eval_key>_fp
+            FN: frame.<eval_key>_fn
+
     -   The fields listed below are populated on each individual
         :class:`fiftyone.core.labels.Detection` instance; these fields tabulate
         the TP/FP/FN status of the object, the ID of the matching object

--- a/fiftyone/utils/eval/segmentation.py
+++ b/fiftyone/utils/eval/segmentation.py
@@ -45,11 +45,18 @@ def evaluate_segmentations(
     is resized to match the ground truth.
 
     If an ``eval_key`` is provided, the accuracy, precision, and recall of each
-    sample is recorded in top-level fields of the samples::
+    sample is recorded in top-level fields of each sample::
 
          Accuracy: sample.<eval_key>_accuracy
         Precision: sample.<eval_key>_precision
            Recall: sample.<eval_key>_recall
+
+   In addition, when evaluating frame-level masks, the accuracy, precision, and
+   recall of each frame if recorded in the following frame-level fields::
+
+         Accuracy: frame.<eval_key>_accuracy
+        Precision: frame.<eval_key>_precision
+           Recall: frame.<eval_key>_recall
 
     .. note::
 

--- a/fiftyone/utils/eval/segmentation.py
+++ b/fiftyone/utils/eval/segmentation.py
@@ -140,8 +140,35 @@ class SegmentationEvaluation(Evaluation):
         """
         pass
 
+    def get_fields(self, samples, eval_key):
+        eval_info = samples.get_evaluation_info(eval_key)
+
+        eval_fields = [
+            "%s_tp" % eval_key,
+            "%s_fp" % eval_key,
+            "%s_fn" % eval_key,
+        ]
+
+        if samples._is_frame_field(eval_info.gt_field):
+            prefix = samples._FRAMES_PREFIX + eval_key
+            eval_fields.extend(
+                ["%s_tp" % prefix, "%s_fp" % prefix, "%s_fn" % prefix]
+            )
+
+        return eval_fields
+
     def cleanup(self, samples, eval_key):
-        pass
+        eval_info = samples.get_evaluation_info(eval_key)
+
+        fields = [
+            "%s_accuracy" % eval_key,
+            "%s_precision" % eval_key,
+            "%s_recall" % eval_key,
+        ]
+
+        samples._dataset.delete_sample_fields(fields)
+        if samples._is_frame_field(eval_info.gt_field):
+            samples._dataset.delete_frame_fields(fields)
 
 
 class SimpleEvaluationConfig(SegmentationEvaluationConfig):
@@ -253,19 +280,6 @@ class SimpleEvaluation(SegmentationEvaluation):
 
         missing = classes[0] if values[0] == 0 else None
         return SegmentationResults(confusion_matrix, classes, missing=missing)
-
-    def cleanup(self, samples, eval_key):
-        eval_info = samples.get_evaluation_info(eval_key)
-
-        fields = [
-            "%s_accuracy" % eval_key,
-            "%s_precision" % eval_key,
-            "%s_recall" % eval_key,
-        ]
-
-        samples._dataset.delete_sample_fields(fields)
-        if samples._is_frame_field(eval_info.pred_field):
-            samples._dataset.delete_frame_fields(fields)
 
 
 class SegmentationResults(ClassificationResults):

--- a/tests/intensive/collections_tests.py
+++ b/tests/intensive/collections_tests.py
@@ -1,0 +1,137 @@
+"""
+Sample collections tests.
+
+| Copyright 2017-2021, Voxel51, Inc.
+| `voxel51.com <https://voxel51.com/>`_
+|
+"""
+import random
+import unittest
+
+import fiftyone as fo
+import fiftyone.zoo as foz
+from fiftyone import ViewField as F
+
+
+_ANIMALS = [
+    "bear",
+    "bird",
+    "cat",
+    "cow",
+    "dog",
+    "elephant",
+    "giraffe",
+    "horse",
+    "sheep",
+    "zebra",
+]
+
+
+def test_set_values():
+    dataset = foz.load_zoo_dataset("quickstart").clone()
+
+    with fo.ProgressBar() as pb:
+        for sample in pb(dataset):
+            sample["animal"] = fo.Classification(label=random.choice(_ANIMALS))
+            sample.save()
+
+    # Test simple fields
+
+    path = "animal.label"
+    path_upper = path + "_upper"
+    path_check = path + "_check"
+
+    values = dataset.values(path)
+    print(dataset.count_values(path))
+
+    values_upper = _to_upper(values)
+
+    dataset.set_values(path_upper, values_upper)
+    print(dataset.count_values(path_upper))
+
+    view = dataset.set_field(
+        path_check, F("label").upper() == F("label_upper")
+    )
+    print(view.count_values(path_check))
+
+    # Test array fields
+
+    path = "predictions.detections.label"
+    path_upper = path + "_upper"
+    path_check = path + "_check"
+
+    values = dataset.values(path)
+    print(dataset.count_values(path))
+
+    values_upper = _to_upper(values)
+
+    dataset.set_values(path_upper, values_upper)
+    print(dataset.count_values(path_upper))
+
+    view = dataset.set_field(
+        path_check, F("label").upper() == F("label_upper")
+    )
+    print(view.count_values(path_check))
+
+
+def test_set_values_frames():
+    dataset = foz.load_zoo_dataset("quickstart-video").clone()
+
+    with fo.ProgressBar() as pb:
+        for sample in pb(dataset):
+            for frame in sample.frames.values():
+                frame["animal"] = fo.Classification(
+                    label=random.choice(_ANIMALS)
+                )
+
+            sample.save()
+
+    # Test simple fields
+
+    path = "frames.animal.label"
+    path_upper = path + "_upper"
+    path_check = path + "_check"
+
+    values = dataset.values(path)
+    print(dataset.count_values(path))
+
+    values_upper = _to_upper(values)
+
+    dataset.set_values(path_upper, values_upper)
+    print(dataset.count_values(path_upper))
+
+    view = dataset.set_field(
+        path_check, F("label").upper() == F("label_upper")
+    )
+    print(view.count_values(path_check))
+
+    # Test array fields
+
+    path = "frames.ground_truth_detections.detections.label"
+    path_upper = path + "_upper"
+    path_check = path + "_check"
+
+    values = dataset.values(path)
+    print(dataset.count_values(path))
+
+    values_upper = _to_upper(values)
+
+    dataset.set_values(path_upper, values_upper)
+    print(dataset.count_values(path_upper))
+
+    view = dataset.set_field(
+        path_check, F("label").upper() == F("label_upper")
+    )
+    print(view.count_values(path_check))
+
+
+def _to_upper(values):
+    if isinstance(values, list):
+        return [_to_upper(v) for v in values]
+
+    return values.upper()
+
+
+if __name__ == "__main__":
+    fo.config.show_progress_bars = True
+    unittest.main(verbosity=2)

--- a/tests/intensive/evaluation_tests.py
+++ b/tests/intensive/evaluation_tests.py
@@ -379,9 +379,9 @@ def test_evaluate_segmentations():
 
     results.print_report()
 
-    print(dataset.values("%s_accuracy" % EVAL_KEY))
-    print(dataset.values("%s_precision" % EVAL_KEY))
-    print(dataset.values("%s_recall" % EVAL_KEY))
+    print(dataset.bounds("%s_accuracy" % EVAL_KEY))
+    print(dataset.bounds("%s_precision" % EVAL_KEY))
+    print(dataset.bounds("%s_recall" % EVAL_KEY))
     print(dataset.get_evaluation_info(EVAL_KEY))
 
     #
@@ -400,9 +400,9 @@ def test_evaluate_segmentations():
 
     results.print_report()
 
-    print(dataset.values("%s_accuracy" % EVAL_KEY_BW))
-    print(dataset.values("%s_precision" % EVAL_KEY_BW))
-    print(dataset.values("%s_recall" % EVAL_KEY_BW))
+    print(dataset.bounds("%s_accuracy" % EVAL_KEY_BW))
+    print(dataset.bounds("%s_precision" % EVAL_KEY_BW))
+    print(dataset.bounds("%s_recall" % EVAL_KEY_BW))
     print(dataset.get_evaluation_info(EVAL_KEY_BW))
 
     #

--- a/tests/intensive/evaluation_tests.py
+++ b/tests/intensive/evaluation_tests.py
@@ -1,0 +1,417 @@
+"""
+Evaluation tests.
+
+| Copyright 2017-2021, Voxel51, Inc.
+| `voxel51.com <https://voxel51.com/>`_
+|
+"""
+import random
+import unittest
+
+import numpy as np
+
+import fiftyone as fo
+import fiftyone.zoo as foz
+from fiftyone import ViewField as F
+from fiftyone.utils.eval.coco import COCOEvaluationConfig
+
+
+_ANIMALS = [
+    "bear",
+    "bird",
+    "cat",
+    "cow",
+    "dog",
+    "elephant",
+    "giraffe",
+    "horse",
+    "sheep",
+    "zebra",
+]
+_NUM_CLASSES = len(_ANIMALS)
+_MISSING = "-"
+
+
+def test_evaluate_classifications():
+    dataset = foz.load_zoo_dataset("imagenet-sample").clone()
+    logits_classes = dataset.info["classes"]
+
+    model = foz.load_zoo_model("resnet50-imagenet-torch")
+    dataset.take(25).apply_model(model, "predictions", store_logits=True)
+
+    view = dataset.exists("predictions").set_field(
+        "predictions.label", (F("confidence") > 0.9).if_else(F("label"), None)
+    )
+
+    # Restrict evaluation to 10 classes, for brevity
+    classes = view.distinct("predictions.label")
+    classes = classes[:9] + [_MISSING]
+
+    #
+    # Simple classification
+    #
+
+    SIMPLE_EVAL_KEY = "eval_simple"
+
+    results = view.evaluate_classifications(
+        "predictions",
+        gt_field="ground_truth",
+        eval_key=SIMPLE_EVAL_KEY,
+        missing=_MISSING,
+    )
+
+    results.print_report()
+    results.print_report(classes=classes)
+
+    print(view.count_values(SIMPLE_EVAL_KEY))
+    print(view.get_evaluation_info(SIMPLE_EVAL_KEY))
+
+    #
+    # Top-k classification
+    #
+
+    TOP_K_EVAL_KEY = "eval_top_k"
+
+    results = view.evaluate_classifications(
+        "predictions",
+        gt_field="ground_truth",
+        eval_key=TOP_K_EVAL_KEY,
+        classes=logits_classes,
+        missing=_MISSING,
+        method="top-k",
+        k=5,
+    )
+
+    results.print_report(classes=classes)
+
+    print(view.count_values(TOP_K_EVAL_KEY))
+    print(view.get_evaluation_info(TOP_K_EVAL_KEY))
+
+    #
+    # Binary classification
+    #
+
+    BINARY_EVAL_KEY = "eval_binary"
+
+    neg_label = "other"
+    pos_label = view.distinct("predictions.label")[0]
+
+    binarize = (F("label") == pos_label).if_else(F("label"), neg_label)
+    binary_view = view.set_field("ground_truth.label", binarize).set_field(
+        "predictions.label", binarize
+    )
+
+    print(binary_view.count_values("ground_truth.label"))
+    print(binary_view.count_values("predictions.label"))
+
+    binary_results = binary_view.evaluate_classifications(
+        "predictions",
+        gt_field="ground_truth",
+        eval_key=BINARY_EVAL_KEY,
+        method="binary",
+        classes=[neg_label, pos_label],
+    )
+
+    print(view.count_values(BINARY_EVAL_KEY))
+    print(view.get_evaluation_info(BINARY_EVAL_KEY))
+
+    #
+    # Cleanup
+    #
+
+    dataset.delete_evaluations()
+
+
+def test_evaluate_classifications_frames():
+    dataset = foz.load_zoo_dataset("quickstart-video").clone()
+    for sample in dataset:
+        for frame in sample.frames.values():
+            gt_idx = random.randint(0, _NUM_CLASSES - 1)
+
+            logits = np.random.rand(_NUM_CLASSES)
+            logits = np.log(logits / np.sum(logits))
+            if random.random() < 0.8:
+                logits[gt_idx] = 0.0
+
+            gt_label = _ANIMALS[gt_idx]
+            pred_label = _ANIMALS[np.argmax(logits)]
+
+            frame["gt_animal"] = fo.Classification(label=gt_label)
+            frame["pred_animal"] = fo.Classification(
+                label=pred_label, logits=logits
+            )
+
+        sample.save()
+
+    #
+    # Simple classification
+    #
+
+    SIMPLE_EVAL_KEY = "eval_simple"
+
+    results = dataset.evaluate_classifications(
+        "frames.pred_animal",
+        gt_field="frames.gt_animal",
+        eval_key=SIMPLE_EVAL_KEY,
+    )
+
+    print(dataset.bounds(SIMPLE_EVAL_KEY))
+    print(dataset.count_values("frames." + SIMPLE_EVAL_KEY))
+    print(dataset.get_evaluation_info(SIMPLE_EVAL_KEY))
+
+    #
+    # Top-k classification
+    #
+
+    TOP_K_EVAL_KEY = "eval_top_k"
+
+    results = dataset.evaluate_classifications(
+        "frames.pred_animal",
+        gt_field="frames.gt_animal",
+        eval_key=TOP_K_EVAL_KEY,
+        method="top-k",
+        classes=_ANIMALS,
+        k=2,
+    )
+
+    print(dataset.bounds(TOP_K_EVAL_KEY))
+    print(dataset.count_values("frames." + TOP_K_EVAL_KEY))
+    print(dataset.get_evaluation_info(TOP_K_EVAL_KEY))
+
+    #
+    # Binary classification
+    #
+
+    BINARY_EVAL_KEY = "eval_binary"
+
+    binarize = (F("label") == "cat").if_else(F("label"), "other")
+    binary_view = dataset.set_field(
+        "frames.gt_animal.label", binarize
+    ).set_field("frames.pred_animal.label", binarize)
+
+    print(binary_view.count_values("frames.gt_animal.label"))
+    print(binary_view.count_values("frames.pred_animal.label"))
+
+    binary_results = binary_view.evaluate_classifications(
+        "frames.pred_animal",
+        gt_field="frames.gt_animal",
+        eval_key=BINARY_EVAL_KEY,
+        method="binary",
+        classes=["other", "cat"],
+    )
+
+    print(dataset.bounds(BINARY_EVAL_KEY))
+    print(dataset.count_values("frames." + BINARY_EVAL_KEY))
+    print(dataset.list_evaluations())
+    print(dataset.get_evaluation_info(BINARY_EVAL_KEY))
+
+    #
+    # Cleanup
+    #
+
+    dataset.delete_evaluations()
+
+
+def test_evaluate_detections():
+    dataset = foz.load_zoo_dataset("quickstart").clone()
+
+    classes = dataset.distinct("predictions.detections.label")
+    classes = classes[:9] + [_MISSING]
+
+    view = dataset.set_field(
+        "predictions.detections.label",
+        (F("confidence") > 0.9).if_else(F("label"), None),
+    )
+
+    #
+    # COCO evaluation
+    #
+
+    EVAL_KEY = "eval_coco"
+
+    results = view.evaluate_detections(
+        "predictions",
+        gt_field="ground_truth",
+        eval_key=EVAL_KEY,
+        missing=_MISSING,
+    )
+
+    results.print_report(classes=classes)
+
+    print(dataset.bounds(EVAL_KEY + "_tp"))
+    print(dataset.bounds(EVAL_KEY + "_fp"))
+    print(dataset.bounds(EVAL_KEY + "_fn"))
+    print(dataset.get_evaluation_info(EVAL_KEY))
+
+    #
+    # Customized COCO evaluation evaluation
+    #
+
+    config = COCOEvaluationConfig()
+    config.iou = 0.5
+    config.classwise = False
+
+    results = view.evaluate_detections(
+        "predictions",
+        gt_field="ground_truth",
+        eval_key=EVAL_KEY,
+        config=config,
+    )
+
+    results.print_report(classes=classes)
+
+    print(dataset.bounds(EVAL_KEY + "_tp"))
+    print(dataset.bounds(EVAL_KEY + "_fp"))
+    print(dataset.bounds(EVAL_KEY + "_fn"))
+    print(dataset.get_evaluation_info(EVAL_KEY))
+
+    #
+    # Cleanup
+    #
+
+    dataset.delete_evaluations()
+
+
+def test_evaluate_detections_frames():
+    dataset = foz.load_zoo_dataset("quickstart-video").clone()
+
+    dataset.rename_frame_field("ground_truth_detections", "ground_truth")
+    dataset.clone_frame_field("ground_truth", "predictions")
+
+    classes = dataset.distinct("frames.ground_truth.detections.label")
+
+    def jitter(val):
+        if isinstance(val, list):
+            return [jitter(v) for v in val]
+
+        if random.random() < 0.90:
+            return val
+
+        return random.choice(classes)
+
+    values = dataset.values("frames.ground_truth.detections.label")
+    dataset.set_values("frames.predictions.detections.label", jitter(values))
+
+    print(dataset.count_values("frames.ground_truth.detections.label"))
+    print(dataset.count_values("frames.predictions.detections.label"))
+
+    #
+    # COCO evaluation
+    #
+
+    EVAL_KEY = "eval_coco"
+
+    results = dataset.evaluate_detections(
+        "frames.predictions",
+        gt_field="frames.ground_truth",
+        eval_key=EVAL_KEY,
+    )
+
+    results.print_report()
+
+    print(dataset.bounds(EVAL_KEY + "_tp"))
+    print(dataset.bounds(EVAL_KEY + "_fp"))
+    print(dataset.bounds(EVAL_KEY + "_fn"))
+
+    print(dataset.bounds("frames." + EVAL_KEY + "_tp"))
+    print(dataset.bounds("frames." + EVAL_KEY + "_fp"))
+    print(dataset.bounds("frames." + EVAL_KEY + "_fn"))
+
+    print(dataset.get_evaluation_info(EVAL_KEY))
+
+    #
+    # Cleanup
+    #
+
+    dataset.delete_evaluations()
+
+
+def test_evaluate_segmentations():
+    dataset = foz.load_zoo_dataset(
+        "coco-2017", split="validation", max_samples=10, shuffle=True,
+    ).clone()
+
+    # These are the VOC classes
+    CLASSES = [
+        "background",
+        "aeroplane",
+        "bicycle",
+        "bird",
+        "boat",
+        "bottle",
+        "bus",
+        "car",
+        "cat",
+        "chair",
+        "cow",
+        "diningtable",
+        "dog",
+        "horse",
+        "motorbike",
+        "person",
+        "pottedplant",
+        "sheep",
+        "sofa",
+        "train",
+        "tvmonitor",
+    ]
+
+    MASK_INDEX = {idx: label for idx, label in enumerate(CLASSES)}
+
+    model = foz.load_zoo_model("deeplabv3-resnet50-coco-torch")
+    dataset.apply_model(model, "resnet50")
+
+    model = foz.load_zoo_model("deeplabv3-resnet101-coco-torch")
+    dataset.apply_model(model, "resnet101")
+
+    #
+    # Full evaluation
+    #
+
+    EVAL_KEY = "eval_resnet"
+
+    results = dataset.evaluate_segmentations(
+        "resnet50",
+        gt_field="resnet101",
+        eval_key=EVAL_KEY,
+        mask_index=MASK_INDEX,
+    )
+
+    results.print_report()
+
+    print(dataset.values("%s_accuracy" % EVAL_KEY))
+    print(dataset.values("%s_precision" % EVAL_KEY))
+    print(dataset.values("%s_recall" % EVAL_KEY))
+    print(dataset.get_evaluation_info(EVAL_KEY))
+
+    #
+    # Bandwidth evaluation
+    #
+
+    EVAL_KEY_BW = "eval_resnet_bw"
+
+    results = dataset.evaluate_segmentations(
+        "resnet50",
+        gt_field="resnet101",
+        eval_key=EVAL_KEY_BW,
+        mask_index=MASK_INDEX,
+        bandwidth=5,
+    )
+
+    results.print_report()
+
+    print(dataset.values("%s_accuracy" % EVAL_KEY_BW))
+    print(dataset.values("%s_precision" % EVAL_KEY_BW))
+    print(dataset.values("%s_recall" % EVAL_KEY_BW))
+    print(dataset.get_evaluation_info(EVAL_KEY_BW))
+
+    #
+    # Cleanup
+    #
+
+    dataset.delete_evaluations()
+
+
+if __name__ == "__main__":
+    fo.config.show_progress_bars = True
+    unittest.main(verbosity=2)

--- a/tests/intensive/evaluation_tests.py
+++ b/tests/intensive/evaluation_tests.py
@@ -72,7 +72,7 @@ def test_evaluate_classifications():
 
     TOP_K_EVAL_KEY = "eval_top_k"
 
-    results = view.evaluate_classifications(
+    top_k_results = view.evaluate_classifications(
         "predictions",
         gt_field="ground_truth",
         eval_key=TOP_K_EVAL_KEY,
@@ -82,7 +82,7 @@ def test_evaluate_classifications():
         k=5,
     )
 
-    results.print_report(classes=classes)
+    top_k_results.print_report(classes=classes)
 
     print(view.count_values(TOP_K_EVAL_KEY))
     print(view.get_evaluation_info(TOP_K_EVAL_KEY))
@@ -111,6 +111,8 @@ def test_evaluate_classifications():
         method="binary",
         classes=[neg_label, pos_label],
     )
+
+    binary_results.print_report()
 
     print(view.count_values(BINARY_EVAL_KEY))
     print(view.get_evaluation_info(BINARY_EVAL_KEY))
@@ -155,6 +157,8 @@ def test_evaluate_classifications_frames():
         eval_key=SIMPLE_EVAL_KEY,
     )
 
+    results.print_report()
+
     print(dataset.bounds(SIMPLE_EVAL_KEY))
     print(dataset.count_values("frames." + SIMPLE_EVAL_KEY))
     print(dataset.get_evaluation_info(SIMPLE_EVAL_KEY))
@@ -165,7 +169,7 @@ def test_evaluate_classifications_frames():
 
     TOP_K_EVAL_KEY = "eval_top_k"
 
-    results = dataset.evaluate_classifications(
+    top_k_results = dataset.evaluate_classifications(
         "frames.pred_animal",
         gt_field="frames.gt_animal",
         eval_key=TOP_K_EVAL_KEY,
@@ -173,6 +177,8 @@ def test_evaluate_classifications_frames():
         classes=_ANIMALS,
         k=2,
     )
+
+    top_k_results.print_report()
 
     print(dataset.bounds(TOP_K_EVAL_KEY))
     print(dataset.count_values("frames." + TOP_K_EVAL_KEY))
@@ -199,6 +205,8 @@ def test_evaluate_classifications_frames():
         method="binary",
         classes=["other", "cat"],
     )
+
+    binary_results.print_report()
 
     print(dataset.bounds(BINARY_EVAL_KEY))
     print(dataset.count_values("frames." + BINARY_EVAL_KEY))


### PR DESCRIPTION
This PR adds support for running classification evaluation on frame-level labels.

I also added a `select_fields` flag to `SampleCollection.load_evaluation_view()` that will automatically select only the fields involved in the evaluation, excluding any other evaluation fields (even embedded fields on the same GT/pred fields that were populated by other evaluation runs). The utility here is that it enables you to easily load up a view that only contains the results of one evaluation, in case you have run multiple evaluations on the same dataset. 

In order to implement the frame-level evaluation cleanly, I invested some time in upgrading the `SampleCollection.set_values()` method so that it now supports setting batches of frame-level fields and batches of sample- or frame-level array fields. So, basically `set_values()` is now a proper inverse of the `values()` aggregation.

An `evaluation_tests.py` module is added that runs (intensive) integration tests of all supported evaluation methods.

Example usage of frame-level evaluation:

```py
import random

import numpy as np

import fiftyone as fo
import fiftyone.zoo as foz
from fiftyone import ViewField as F

ANIMALS = [
    "bear", "bird", "cat", "cow", "dog", "elephant", "giraffe",
    "horse", "sheep", "zebra"
]
NUM_CLASSES = len(ANIMALS)

dataset = foz.load_zoo_dataset("quickstart-video").clone()

with fo.ProgressBar() as pb:
    for sample in pb(dataset):
        for frame in sample.frames.values():
            gt_idx = random.randint(0, NUM_CLASSES - 1)

            logits = np.random.rand(NUM_CLASSES)
            logits = np.log(logits / np.sum(logits))
            if random.random() < 0.8:
                logits[gt_idx] = 0.0

            gt_label = ANIMALS[gt_idx]
            pred_label = ANIMALS[np.argmax(logits)]

            frame["gt_animal"] = fo.Classification(label=gt_label)
            frame["pred_animal"] = fo.Classification(
                label=pred_label, logits=logits
            )

        sample.save()

#
# Multiclass classification
#

EVAL_KEY = "eval_class"

results = dataset.evaluate_classifications(
    "frames.pred_animal", gt_field="frames.gt_animal", eval_key=EVAL_KEY
)

results.print_report()
results.plot_confusion_matrix()

print(dataset.bounds(EVAL_KEY))
print(dataset.count_values("frames." + EVAL_KEY))

print(dataset.list_evaluations())
print(dataset.get_evaluation_info(EVAL_KEY))

#
# Top-k classification
#

TOP_K_EVAL_KEY = "eval_top_k"

results = dataset.evaluate_classifications(
    "frames.pred_animal",
    gt_field="frames.gt_animal",
    eval_key=TOP_K_EVAL_KEY,
    method="top-k",
    classes=ANIMALS,
    k=2,
)

results.print_report()
results.plot_confusion_matrix()

print(dataset.bounds(TOP_K_EVAL_KEY))
print(dataset.count_values("frames." + TOP_K_EVAL_KEY))

print(dataset.list_evaluations())
print(dataset.get_evaluation_info(TOP_K_EVAL_KEY))

#
# Binary classification
#

BINARY_EVAL_KEY = "eval_binary"

binarize = (F("label") == "cat").if_else(F("label"), "other")

binary_view = (
    dataset
    .set_field("frames.gt_animal.label", binarize)
    .set_field("frames.pred_animal.label", binarize)
)

print(binary_view.count_values("frames.gt_animal.label"))
print(binary_view.count_values("frames.pred_animal.label"))

binary_results = binary_view.evaluate_classifications(
    "frames.pred_animal",
    gt_field="frames.gt_animal",
    eval_key=BINARY_EVAL_KEY,
    method="binary",
    classes=["other", "cat"],
)

binary_results.print_report()
binary_results.plot_confusion_matrix()

print(dataset.bounds(BINARY_EVAL_KEY))
print(dataset.count_values("frames." + BINARY_EVAL_KEY))

print(dataset.list_evaluations())
print(dataset.get_evaluation_info(BINARY_EVAL_KEY))

#
# Cleanup
#

print(dataset.list_evaluations())
dataset.delete_evaluations()
print(dataset.list_evaluations())
```

Example usage of `load_evaluation_view()`:

```py
import fiftyone as fo
import fiftyone.zoo as foz
from fiftyone import ViewField as F

EVAL_KEY1 = "eval1"
EVAL_KEY2 = "eval2"

dataset = foz.load_zoo_dataset("quickstart").clone()
results1 = dataset.evaluate_detections("predictions", eval_key=EVAL_KEY1)

view = dataset.take(100)
results2 = view.evaluate_detections("predictions", eval_key=EVAL_KEY2, iou=0.5)

eval_view1 = dataset.load_evaluation_view(EVAL_KEY1, select_fields=True)
eval_view2 = dataset.load_evaluation_view(EVAL_KEY2, select_fields=True)

session = fo.launch_app(dataset)

# View *only* results from first evaluation
session.view = (
    eval_view1
    .sort_by(EVAL_KEY1 + "_fp", reverse=True)
    .filter_labels("predictions", F(EVAL_KEY1) == "fp")
)

# View *only* results from second evaluation
session.view = (
    eval_view2
    .sort_by(EVAL_KEY2 + "_fp", reverse=True)
    .filter_labels("predictions", F(EVAL_KEY2) == "fp")
)
```
