### PR TITLE
Limit progress bar width to 90 characters in notebook contexts

### DIFF
--- a/fiftyone/core/context.py
+++ b/fiftyone/core/context.py
@@ -13,6 +13,16 @@ _NONE = "NONE"
 _context = None
 
 
+def is_notebook_context():
+    """Determines whether this process is running in a notebook context, either
+    Colab or Jupyter.
+
+    Returns:
+        True/False
+    """
+    return _get_context() != _NONE
+
+
 def _get_context():
     """Determine the most specific context that we're in.
 

--- a/fiftyone/core/utils.py
+++ b/fiftyone/core/utils.py
@@ -38,6 +38,7 @@ import eta
 import eta.core.utils as etau
 
 import fiftyone as fo
+import fiftyone.core.context as foc
 
 
 logger = logging.getLogger(__name__)
@@ -469,6 +470,11 @@ class ProgressBar(etau.ProgressBar):
 
         if "iters_str" not in kwargs:
             kwargs["iters_str"] = "samples"
+
+        # For progress bars in notebooks, use a fixed size so that they will
+        # read well across browsers, in HTML format, etc
+        if foc.is_notebook_context() and "max_width" not in kwargs:
+            kwargs["max_width"] = 90
 
         super().__init__(*args, **kwargs)
 


### PR DESCRIPTION
Limits the width of progress bars in notebook contexts to 90 characters. This is done to avoid the pesky problem of progress bars wrapping multiple lines in the HTML versions of notebooks that we publish to the web (the reader's viewport will never match the code runner's, so the fit-to-terminal option doesn't make sense for publishing content).

On a related note, you may have noticed that our progress bars expand gradually as their percentage increases. This is due to [a known Jupyter bug](https://github.com/jupyter/notebook/issues/4354) and I discuss this a bit in https://github.com/voxel51/fiftyone/issues/885. In any case, the 90 character limit comes in handy here too, since the buggy expansion caps out at about 100 characters, which doesn't cause wrapping for most practical browser window sizes.