### PR TITLE
Add missing installation steps to App README

### DIFF
--- a/app/README.md
+++ b/app/README.md
@@ -9,11 +9,14 @@ Project FiftyOne React/Electron App
 The following installation steps are a part of the
 [install script](../install.bash)
 
-Install [`nvm`](https://github.com/nvm-sh/nvm) and set your node version to
-`v12.16.2`:
+Install [`nvm`](https://github.com/nvm-sh/nvm) and install andset your node
+version to `v12.16.2`. And then install `yarn` globally in your node
+environment with `npm`:
 
 ```sh
+nvm install v12.16.2
 nvm use v12.16.2
+npm -g install yarn
 ```
 
 Install the app with `yarn` in this directory (`./fiftyone/app`):

--- a/app/README.md
+++ b/app/README.md
@@ -9,13 +9,17 @@ Project FiftyOne React/Electron App
 The following installation steps are a part of the
 [install script](../install.bash)
 
-Install [`nvm`](https://github.com/nvm-sh/nvm) and install andset your node
-version to `v12.16.2`. And then install `yarn` globally in your node
-environment with `npm`:
+First, install [`nvm`](https://github.com/nvm-sh/nvm) and install and set your
+node version to `v12.16.2` using `nvm`.
 
 ```sh
 nvm install v12.16.2
 nvm use v12.16.2
+```
+
+Then install `yarn` globally in your node environment with `npm`:
+
+```
 npm -g install yarn
 ```
 


### PR DESCRIPTION
Adds missing App installation steps to the App README, specifically node version installation and setup, and yarn installation.