### PR TITLE
Utilities for tagging and visualizing samples and labels

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -136,7 +136,7 @@ jobs:
           git clone https://github.com/voxel51/eta eta --depth 1 --branch develop
           cd eta
           python setup.py bdist_wheel
-          pip install ./dist/*.whl
+          pip install ./dist/*.whl --force-reinstall
       # obtained from "Windows, pip" instructions at
       # https://pytorch.org/get-started/locally/ - unaware of a way to update
       # the version number automatically, but tests on other platforms should

--- a/app/src/components/Player51.tsx
+++ b/app/src/components/Player51.tsx
@@ -153,9 +153,6 @@ export default ({
     fps,
     overlayOptions,
   ]);
-  if (!thumbnail) {
-    console.log(selectedObjects);
-  }
 
   useEffect(() => {
     if (player && selectedObjects) {

--- a/app/src/components/Player51.tsx
+++ b/app/src/components/Player51.tsx
@@ -153,6 +153,9 @@ export default ({
     fps,
     overlayOptions,
   ]);
+  if (!thumbnail) {
+    console.log(selectedObjects);
+  }
 
   useEffect(() => {
     if (player && selectedObjects) {

--- a/app/src/components/SelectObjectsMenu.tsx
+++ b/app/src/components/SelectObjectsMenu.tsx
@@ -34,8 +34,8 @@ const SelectObjectsMenu = ({ sample, frameNumberRef }) => {
   const frameNumber = isVideo ? frameNumberRef.current : null;
 
   useSendMessage(
-    "set_selected_objects",
-    { selected_objects: convertSelectedObjectsMapToList(selectedObjects) },
+    "set_selected_labels",
+    { selected_labels: convertSelectedObjectsMapToList(selectedObjects) },
     null,
     [selectedObjects]
   );
@@ -63,7 +63,7 @@ const SelectObjectsMenu = ({ sample, frameNumberRef }) => {
   ).length;
 
   const _getObjectSelectionData = (object) => ({
-    object_id: object._id,
+    label_id: object._id,
     sample_id: sample._id,
     field: object.name,
     frame_number: object.frame_number,
@@ -99,7 +99,7 @@ const SelectObjectsMenu = ({ sample, frameNumberRef }) => {
     setHiddenObjects((hiddenObjects) =>
       addObjectsToSelection(
         hiddenObjects,
-        ids.map((object_id) => ({ object_id, ...selectedObjects[object_id] }))
+        ids.map((label_id) => ({ label_id, ...selectedObjects[label_id] }))
       )
     );
   };

--- a/app/src/containers/App.tsx
+++ b/app/src/containers/App.tsx
@@ -44,7 +44,7 @@ function App() {
   const handleStateUpdate = (state) => {
     setStateDescription(state);
     setSelectedSamples(new Set(state.selected));
-    setSelectedObjects(convertSelectedObjectsListToMap(state.selected_objects));
+    setSelectedObjects(convertSelectedObjectsListToMap(state.selected_labels));
   };
 
   useEventHandler(socket, "open", () => {

--- a/app/src/containers/Dataset.tsx
+++ b/app/src/containers/Dataset.tsx
@@ -139,7 +139,7 @@ function Dataset(props) {
     }
   }, [hideModal]);
 
-  useSendMessage("set_selected_objects", { selected_objects: [] }, !hideModal);
+  useSendMessage("set_selected_labels", { selected_labels: [] }, !hideModal);
 
   let src = null;
   let s = null;

--- a/app/src/utils/selection.ts
+++ b/app/src/utils/selection.ts
@@ -57,7 +57,7 @@ export const removeMatchingObjectsFromSelection = (
 ) => {
   const newSelection = { ...selection };
   if (Object.keys(filter).length) {
-    for (const [object_id, data] of Object.entries(selection)) {
+    for (const [label_id, data] of Object.entries(selection)) {
       if (
         (filter.sample_id === undefined ||
           filter.sample_id === data.sample_id) &&
@@ -65,7 +65,7 @@ export const removeMatchingObjectsFromSelection = (
         (filter.frame_number === undefined ||
           filter.frame_number === data.frame_number)
       ) {
-        delete newSelection[object_id];
+        delete newSelection[label_id];
       }
     }
   }

--- a/app/src/utils/selection.ts
+++ b/app/src/utils/selection.ts
@@ -7,21 +7,21 @@ export interface SelectedObjectData {
 }
 
 export interface SelectedObject extends SelectedObjectData {
-  object_id: string;
+  label_id: string;
 }
 
 export type SelectedObjectMap = {
-  [object_id: string]: SelectedObjectData;
+  [label_id: string]: SelectedObjectData;
 };
 
 export const useToggleSelectionObject = (atom) => {
   const setSelection = useSetRecoilState(atom);
-  return (object_id: string, data: SelectedObjectData) =>
+  return (label_id: string, data: SelectedObjectData) =>
     setSelection((selection: SelectedObjectMap) => {
-      if (selection.hasOwnProperty(object_id)) {
-        return removeObjectIDsFromSelection(selection, [object_id]);
+      if (selection.hasOwnProperty(label_id)) {
+        return removeObjectIDsFromSelection(selection, [label_id]);
       } else {
-        return addObjectsToSelection(selection, [{ object_id, ...data }]);
+        return addObjectsToSelection(selection, [{ label_id, ...data }]);
       }
     });
 };
@@ -31,11 +31,11 @@ export const addObjectsToSelection = (
   objects: SelectedObject[]
 ): SelectedObjectMap => {
   const newSelection = { ...selection };
-  for (const { object_id, ...data } of objects) {
+  for (const { label_id, ...data } of objects) {
     if (data.frame_number === null) {
       delete data.frame_number;
     }
-    newSelection[object_id] = data;
+    newSelection[label_id] = data;
   }
   return newSelection;
 };
@@ -75,8 +75,8 @@ export const removeMatchingObjectsFromSelection = (
 export const convertSelectedObjectsMapToList = (
   map: SelectedObjectMap
 ): SelectedObject[] => {
-  return Object.entries(map).map(([object_id, data]) => ({
-    object_id,
+  return Object.entries(map).map(([label_id, data]) => ({
+    label_id,
     ...data,
   }));
 };
@@ -84,7 +84,7 @@ export const convertSelectedObjectsMapToList = (
 export const convertSelectedObjectsListToMap = (
   list: SelectedObject[]
 ): SelectedObjectMap => {
-  return list.reduce((map, { object_id, ...data }) => {
+  return list.reduce((map, { label_id, ...data }) => {
     map[object_id] = data;
     return map;
   }, {});

--- a/app/src/utils/selection.ts
+++ b/app/src/utils/selection.ts
@@ -85,7 +85,7 @@ export const convertSelectedObjectsListToMap = (
   list: SelectedObject[]
 ): SelectedObjectMap => {
   return list.reduce((map, { label_id, ...data }) => {
-    map[object_id] = data;
+    map[label_id] = data;
     return map;
   }, {});
 };

--- a/docs/source/user_guide/using_aggregations.rst
+++ b/docs/source/user_guide/using_aggregations.rst
@@ -83,9 +83,9 @@ detailed examples of using each aggregation.
     All aggregations can operate on embedded sample fields using the
     ``embedded.field.name`` syntax.
 
-    In addition, you can aggregate the elements of array fields. Some array
-    fields are automatically handled, but you can always manually unwind an
-    array using the ``embedded.array[].field`` syntax. See
+    Aggregation fields can also include array fields. Most array fields are
+    automatically unwound, but you can always manually unwind an array using
+    the ``embedded.array[].field`` syntax. See
     :ref:`this section <aggregations-list-fields>` for more details.
 
 .. _aggregations-bounds:
@@ -381,14 +381,18 @@ The example below demonstrates this capability:
 
 .. note::
 
-    There are two cases where FiftyOne will automatically unwind array fields
+    There are three cases where FiftyOne will automatically unwind array fields
     without requiring you to explicitly specify this via the ``[]`` syntax:
 
-    **Top-level lists:** when you write an aggregation that refers to a
+    **Top-level lists:** When you write an aggregation that refers to a
     top-level list field of a dataset; i.e., ``list_field`` is automatically
     coerced to ``list_field[]``, if necessary.
 
-    **List fields:** When you write an aggregation that refers to the list
+    **Tags fields:** When you write an aggregation that refers to the ``tags``
+    attribute of a |Sample| or |Label| object; i.e., ``tags`` is automatically
+    coerced to ``tags[]``, if necessary.
+
+    **Label lists:** When you write an aggregation that refers to the list
     field of a |Label| class, such as the
     :attr:`Detections.detections <fiftyone.core.labels.Detections.detections>`
     attribute; i.e., ``ground_truth.detections.label`` is automatically

--- a/fiftyone/__public__.py
+++ b/fiftyone/__public__.py
@@ -96,7 +96,7 @@ from .core.sample import Sample
 from .core.stages import (
     Exclude,
     ExcludeFields,
-    ExcludeObjects,
+    ExcludeLabels,
     Exists,
     FilterField,
     FilterLabels,
@@ -113,7 +113,7 @@ from .core.stages import (
     Shuffle,
     Select,
     SelectFields,
-    SelectObjects,
+    SelectLabels,
     SetField,
     Skip,
     SortBy,

--- a/fiftyone/core/aggregations.py
+++ b/fiftyone/core/aggregations.py
@@ -1061,9 +1061,9 @@ class Values(Aggregation):
     .. note::
 
         Unlike other aggregations, :class:`Values` does not *automatically*
-        unwind top-level list fields and label list fields. This default
-        behavior ensures that there is a 1-1 correspondence between the
-        elements of the output list and the samples in the collection.
+        unwind list fields. This ensures that there is a 1-1 correspondence
+        between the elements of the output list and the samples in the
+        collection.
 
         You can opt-in to unwinding list fields using the ``[]`` syntax.
 

--- a/fiftyone/core/client.py
+++ b/fiftyone/core/client.py
@@ -5,7 +5,7 @@ Web socket client mixins.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
-import asyncio
+import asyncio  # pylint: disable=unused-import
 from collections import defaultdict
 import logging
 import requests
@@ -14,7 +14,6 @@ from threading import Thread
 import time
 
 from bson import json_util
-from tornado import gen
 from tornado.ioloop import IOLoop
 from tornado.websocket import websocket_connect
 
@@ -45,6 +44,7 @@ class HasClient(object):
         self._client = None
         self._initial_connection = True
         self._url = "ws://%s:%d/%s" % (SERVER_NAME, port, self._HC_NAMESPACE)
+        self._listeners = {}
 
         async def connect():
             try:
@@ -76,16 +76,19 @@ class HasClient(object):
                             )
                         except:
                             print(
-                                "\r\nCould not connect session, trying again in 10 seconds\r\n"
+                                "\r\nCould not connect session, trying again "
+                                "in 10 seconds\r\n"
                             )
                             time.sleep(10)
 
                     if message is None and _printer[self._url] == self:
                         print("\r\nSession reconnected\r\n")
+
                     continue
 
                 message = json_util.loads(message)
                 event = message.pop("type")
+
                 if event == "update":
                     config = None
                     if self._data:
@@ -93,13 +96,18 @@ class HasClient(object):
                             "config"
                         ] = self._data.config.serialize()
                         config = self._data.config
+
                     self._data = self._HC_ATTR_TYPE.from_dict(
                         message["state"], with_config=config
                     )
+                    self._update_listeners()
+
                 if event == "notification":
                     self.on_notification(message)
+
                 if event == "capture":
                     self.on_capture(message)
+
                 if event == "reactivate":
                     self.on_reactivate(message)
 
@@ -109,6 +117,74 @@ class HasClient(object):
 
         self._thread = Thread(target=run_client, daemon=True)
         self._thread.start()
+
+    def get_listeners(self):
+        return self._listeners
+
+    def add_listener(self, key, callback):
+        self._listeners[key] = callback
+
+    def delete_listener(self, key):
+        self._listeners.pop(key, None)
+
+    def delete_listeners(self):
+        self._listeners = {}
+
+    def _update_listeners(self):
+        for listener in self._listeners.values():
+            listener(self)
+
+    def __getattr__(self, name):
+        """Gets the data via the attribute defined by ``_HC_ATTR_NAME``."""
+        if name == self._HC_ATTR_NAME:
+            if self._client is None and not self._initial_connection:
+                raise RuntimeError("Session is not connected")
+
+            while self._data is None:
+                time.sleep(0.2)
+
+            return self._data
+
+        return None
+
+    def __setattr__(self, name, value):
+        """Sets the data to the attribute defined by ``_HC_ATTR_NAME``."""
+        if name == self._HC_ATTR_NAME:
+            if self._HC_ATTR_TYPE is not None and not isinstance(
+                value, self._HC_ATTR_TYPE
+            ):
+                raise ValueError(
+                    "Client expected type %s, but got type %s"
+                    % (self._HC_ATTR_TYPE, type(value))
+                )
+
+            if self._client is None and not self._initial_connection:
+                raise RuntimeError("Session is not connected")
+
+            while self._data is None:
+                time.sleep(0.2)
+
+            self._data = value
+            self._client.write_message(
+                json_util.dumps({"type": "update", "state": value.serialize()})
+            )
+        else:
+            super().__setattr__(name, value)
+
+    def __del__(self):
+        _printer[self._url] = None
+
+    def on_capture(self, data):
+        self._capture(data)
+
+    def _capture(self, data):
+        raise NotImplementedError("subclasses must implement _capture()")
+
+    def on_reactivate(self, data):
+        self._reactivate(data)
+
+    def _reactivate(self, data):
+        raise NotImplementedError("subclasses must implement _reactivate()")
 
     def on_notification(self, data):
         global _printer
@@ -124,51 +200,3 @@ class HasClient(object):
         print()
         for value in data["session_items"]:
             print(value)
-
-    def _capture(self, data):
-        raise NotImplementedError("subclasses must implement capture()")
-
-    def on_capture(self, data):
-        self._capture(data)
-
-    def _capture(self, data):
-        raise NotImplementedError("subclasses must implement reactivate()")
-
-    def on_reactivate(self, data):
-        self._reactivate(data)
-
-    def __del__(self):
-        _printer[self._url] = None
-
-    def __getattr__(self, name):
-        """Gets the data via the attribute defined by ``_HC_ATTR_NAME``."""
-        if name == self._HC_ATTR_NAME:
-            if self._client is None and not self._initial_connection:
-                raise RuntimeError("Session is not connected")
-            while self._data is None:
-                time.sleep(0.2)
-            return self._data
-
-        return None
-
-    def __setattr__(self, name, value):
-        """Sets the data to the attribute defined by ``_HC_ATTR_NAME``."""
-        if name == self._HC_ATTR_NAME:
-            if self._HC_ATTR_TYPE is not None and not isinstance(
-                value, self._HC_ATTR_TYPE
-            ):
-                raise ValueError(
-                    "Client expected type %s, but got type %s"
-                    % (self._HC_ATTR_TYPE, type(value))
-                )
-            if self._client is None and not self._initial_connection:
-                raise RuntimeError("Session is not connected")
-            while self._data is None:
-                time.sleep(0.2)
-
-            self._data = value
-            self._client.write_message(
-                json_util.dumps({"type": "update", "state": value.serialize()})
-            )
-        else:
-            super().__setattr__(name, value)

--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -546,6 +546,10 @@ class SampleCollection(object):
             field_name
         )
 
+        if list_fields:
+            # Don't unroll terminal lists unless explicitly requested
+            list_fields = [lf for lf in list_fields if lf != field_name]
+
         if is_frame_field:
             self._set_frame_values(field_name, values, list_fields)
         else:

--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -541,8 +541,8 @@ class SampleCollection(object):
         """
         return self.count_values("tags")
 
-    def tag_objects(self, tag, label_fields=None):
-        """Adds the tag to all objects in the specified label field(s) of this
+    def tag_labels(self, tag, label_fields=None):
+        """Adds the tag to all labels in the specified label field(s) of this
         collection, if necessary.
 
         Args:
@@ -561,10 +561,10 @@ class SampleCollection(object):
 
             return tags + [tag]
 
-        self._edit_object_tags(_add_tag, label_fields=label_fields)
+        self._edit_label_tags(_add_tag, label_fields=label_fields)
 
-    def untag_objects(self, tag, label_fields=None):
-        """Removes the tag from all objects in the specified label field(s) of
+    def untag_labels(self, tag, label_fields=None):
+        """Removes the tag from all labels in the specified label field(s) of
         this collection, if necessary.
 
         Args:
@@ -580,9 +580,9 @@ class SampleCollection(object):
 
             return [t for t in tags if t != tag]
 
-        self._edit_object_tags(_remove_tag, label_fields=label_fields)
+        self._edit_label_tags(_remove_tag, label_fields=label_fields)
 
-    def _edit_object_tags(self, edit_fcn, label_fields=None):
+    def _edit_label_tags(self, edit_fcn, label_fields=None):
         if label_fields is None:
             label_fields = self._get_label_fields()
         elif etau.is_str(label_fields):
@@ -601,8 +601,8 @@ class SampleCollection(object):
             tags = _transform_values(tags, edit_fcn, level=level)
             self.set_values(tags_path, tags)
 
-    def count_object_tags(self, label_fields=None):
-        """Counts the occurrences of all object tags in the specified label
+    def count_label_tags(self, label_fields=None):
+        """Counts the occurrences of all label tags in the specified label
         field(s) of this collection.
 
         Args:
@@ -1385,22 +1385,22 @@ class SampleCollection(object):
         return self._add_view_stage(fos.ExcludeFields(field_names))
 
     @view_stage
-    def exclude_objects(self, objects):
-        """Excludes the specified objects from the collection.
+    def exclude_labels(self, labels):
+        """Excludes the specified labels from the collection.
 
-        The returned view will omit the objects specified in the provided
-        ``objects`` argument, which should have the following format::
+        The returned view will omit the labels specified in the provided
+        ``labels`` argument, which should have the following format::
 
             [
                 {
                     "sample_id": "5f8d254a27ad06815ab89df4",
                     "field": "ground_truth",
-                    "object_id": "5f8d254a27ad06815ab89df3",
+                    "label_id": "5f8d254a27ad06815ab89df3",
                 },
                 {
                     "sample_id": "5f8d255e27ad06815ab93bf8",
                     "field": "ground_truth",
-                    "object_id": "5f8d255e27ad06815ab93bf6",
+                    "label_id": "5f8d255e27ad06815ab93bf6",
                 },
                 ...
             ]
@@ -1413,22 +1413,22 @@ class SampleCollection(object):
             dataset = foz.load_zoo_dataset("quickstart")
 
             #
-            # Exclude the objects currently selected in the App
+            # Exclude the labels currently selected in the App
             #
 
             session = fo.launch_app(dataset)
 
-            # Select some objects in the App...
+            # Select some labels in the App...
 
-            view = dataset.exclude_objects(session.selected_objects)
+            view = dataset.exclude_labels(session.selected_labels)
 
         Args:
-            objects: a list of dicts specifying the objects to exclude
+            labels: a list of dicts specifying the labels to exclude
 
         Returns:
             a :class:`fiftyone.core.view.DatasetView`
         """
-        return self._add_view_stage(fos.ExcludeObjects(objects))
+        return self._add_view_stage(fos.ExcludeLabels(labels))
 
     @view_stage
     def exists(self, field, bool=True):
@@ -2596,30 +2596,30 @@ class SampleCollection(object):
         return self._add_view_stage(fos.SelectFields(field_names))
 
     @view_stage
-    def select_objects(self, objects=None, ids=None, tags=None, fields=None):
-        """Selects only the specified objects from the collection.
+    def select_labels(self, labels=None, ids=None, tags=None, fields=None):
+        """Selects only the specified labels from the collection.
 
         The returned view will omit samples, sample fields, and individual
-        objects that do not match the specified selection criteria.
+        labels that do not match the specified selection criteria.
 
         You can perform a selection via one of the following methods:
 
         -   Provide one or both of the ``ids`` and ``tags`` arguments, and
             optionally the ``fields`` argument
 
-        -   Provide the ``objects`` argument, which should have the following
+        -   Provide the ``labels`` argument, which should have the following
             format::
 
                 [
                     {
                         "sample_id": "5f8d254a27ad06815ab89df4",
                         "field": "ground_truth",
-                        "object_id": "5f8d254a27ad06815ab89df3",
+                        "label_id": "5f8d254a27ad06815ab89df3",
                     },
                     {
                         "sample_id": "5f8d255e27ad06815ab93bf8",
                         "field": "ground_truth",
-                        "object_id": "5f8d255e27ad06815ab93bf6",
+                        "label_id": "5f8d255e27ad06815ab93bf6",
                     },
                     ...
                 ]
@@ -2632,65 +2632,63 @@ class SampleCollection(object):
             dataset = foz.load_zoo_dataset("quickstart")
 
             #
-            # Only include the objects currently selected in the App
+            # Only include the labels currently selected in the App
             #
 
             session = fo.launch_app(dataset)
 
-            # Select some objects in the App...
+            # Select some labels in the App...
 
-            view = dataset.select_objects(objects=session.selected_objects)
+            view = dataset.select_labels(labels=session.selected_labels)
 
             #
-            # Only include objects with the specified IDs
+            # Only include labels with the specified IDs
             #
 
-            # Grab some object IDs
+            # Grab some label IDs
             ids = [
                 dataset.first().ground_truth.detections[0].id,
                 dataset.last().predictions.detections[0].id,
             ]
 
-            view = dataset.select_objects(ids=ids)
+            view = dataset.select_labels(ids=ids)
 
             print(view.count("ground_truth.detections"))
             print(view.count("predictions.detections"))
 
             #
-            # Only include objects with the specified tags
+            # Only include labels with the specified tags
             #
 
-            # Grab some object IDs
+            # Grab some label IDs
             ids = [
                 dataset.first().ground_truth.detections[0].id,
                 dataset.last().predictions.detections[0].id,
             ]
 
-            # Give the objects a "test" tag
+            # Give the labels a "test" tag
             dataset = dataset.clone()  # create a copy since we're modifying data
-            dataset.select_objects(ids=ids).tag_objects("test")
+            dataset.select_labels(ids=ids).tag_labels("test")
 
-            print(dataset.count_object_tags())
+            print(dataset.count_label_tags())
 
-            # Retrieve the objects via their tag
-            view = dataset.select_objects(tags=["test"])
+            # Retrieve the labels via their tag
+            view = dataset.select_labels(tags=["test"])
 
             print(view.count("ground_truth.detections"))
             print(view.count("predictions.detections"))
 
         Args:
-            objects (None): a list of dicts specifying the objects to select
-            ids (None): a list of IDs of the objects to select
-            tags (None): a list of tags of objects to select
-            fields (None): a list of fields from which to select objects
+            labels (None): a list of dicts specifying the labels to select
+            ids (None): a list of IDs of the labels to select
+            tags (None): a list of tags of labels to select
+            fields (None): a list of fields from which to select labels
 
         Returns:
             a :class:`fiftyone.core.view.DatasetView`
         """
         return self._add_view_stage(
-            fos.SelectObjects(
-                objects=objects, ids=ids, tags=tags, fields=fields
-            )
+            fos.SelectLabels(labels=labels, ids=ids, tags=tags, fields=fields)
         )
 
     @view_stage

--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -2546,7 +2546,6 @@ class SampleCollection(object):
 
             view = dataset.select_objects(ids=ids)
 
-            print(view)
             print(view.count("ground_truth.detections"))
             print(view.count("predictions.detections"))
 
@@ -2570,7 +2569,6 @@ class SampleCollection(object):
             # Retrieve the objects via their tag
             view = dataset.select_objects(tags=["test"])
 
-            print(view)
             print(view.count("ground_truth.detections"))
             print(view.count("predictions.detections"))
 

--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -2670,8 +2670,7 @@ class SampleCollection(object):
             dataset = dataset.clone()  # create a copy since we're modifying data
             dataset.select_objects(ids=ids).tag_objects("test")
 
-            print(dataset.count_values("ground_truth.detections.tags"))
-            print(dataset.count_values("predictions.detections.tags"))
+            print(dataset.count_object_tags())
 
             # Retrieve the objects via their tag
             view = dataset.select_objects(tags=["test"])

--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -580,8 +580,13 @@ class SampleCollection(object):
             label_fields = [label_fields]
 
         for label_field in label_fields:
-            _, tags_path = self._get_label_field_path(label_field, "tags")
-            level = 3 if self._is_frame_field(tags_path) else 2
+            label_type, tags_path = self._get_label_field_path(
+                label_field, "tags"
+            )
+
+            level = 1
+            level += issubclass(label_type, fol._LABEL_LIST_FIELDS)
+            level += self._is_frame_field(tags_path)
 
             tags = self.values(tags_path)
             tags = _transform_values(tags, edit_fcn, level=level)

--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -2490,12 +2490,15 @@ class SampleCollection(object):
 
     @view_stage
     def select_objects(self, objects=None, ids=None, tags=None, fields=None):
-        """Selects only the specified objects from a collection.
+        """Selects only the specified objects from the collection.
 
         The returned view will omit samples, sample fields, and individual
         objects that do not match the specified selection criteria.
 
         You can perform a selection via one of the following methods:
+
+        -   Provide one or both of the ``ids`` and ``tags`` arguments, and
+            optionally the ``fields`` argument
 
         -   Provide the ``objects`` argument, which should have the following
             format::
@@ -2513,9 +2516,6 @@ class SampleCollection(object):
                     },
                     ...
                 ]
-
-        -   Provide one or both of the ``ids`` and ``tags`` arguments, and
-            optionally the ``fields`` argument
 
         Examples::
 

--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -493,7 +493,7 @@ class SampleCollection(object):
                     % (field_name, ftype, field)
                 )
 
-    def add_sample_tag(self, tag):
+    def tag_samples(self, tag):
         """Adds the tag to all samples in this collection, if necessary.
 
         Args:
@@ -513,7 +513,7 @@ class SampleCollection(object):
         tags = [_add_tag(t) for t in tags]
         self.set_values("tags", tags)
 
-    def remove_sample_tag(self, tag):
+    def untag_samples(self, tag):
         """Removes the tag from all samples in this collection, if necessary.
 
         Args:
@@ -530,7 +530,7 @@ class SampleCollection(object):
         tags = [_remove_tag(t) for t in tags]
         self.set_values("tags", tags)
 
-    def add_label_tag(self, label_field, tag):
+    def tag_objects(self, label_field, tag):
         """Adds the tag to all objects in the specified label field of this
         collection, if necessary.
 
@@ -556,7 +556,7 @@ class SampleCollection(object):
         ]
         self.set_values(tags_path, tags)
 
-    def remove_label_tag(self, label_field, tag):
+    def untag_objects(self, label_field, tag):
         """Removes the given tag from all objects in the specified label field
         of this collection, if necessary.
 

--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -3022,6 +3022,9 @@ def _get_sample_ids(samples_or_ids):
     if isinstance(samples_or_ids, foc.SampleCollection):
         return [str(_id) for _id in samples_or_ids._get_sample_ids()]
 
+    if not samples_or_ids:
+        return []
+
     if isinstance(next(iter(samples_or_ids)), (fos.Sample, fos.SampleView)):
         return [s.id for s in samples_or_ids]
 

--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -17,7 +17,6 @@ import string
 
 from bson import ObjectId
 import mongoengine.errors as moe
-from pymongo import UpdateOne
 from pymongo.errors import BulkWriteError
 
 import eta.core.serial as etas
@@ -1172,18 +1171,6 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
 
         return [str(d["_id"]) for d in dicts]
 
-    def _bulk_update(self, ids, updates, frames=False, ordered=False):
-        ops = [
-            UpdateOne({"_id": _id}, update)
-            for _id, update in zip(ids, updates)
-        ]
-        self._bulk_write(ops, frames=frames, ordered=ordered)
-
-        if frames:
-            fofr.Frame._reload_docs(self._frame_collection_name)
-        else:
-            fos.Sample._reload_docs(self._sample_collection_name)
-
     def _bulk_write(self, ops, frames=False, ordered=False):
         if frames:
             coll = self._frame_collection
@@ -1196,6 +1183,11 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
         except BulkWriteError as bwe:
             msg = bwe.details["writeErrors"][0]["errmsg"]
             raise ValueError(msg) from bwe
+
+        if frames:
+            fofr.Frame._reload_docs(self._frame_collection_name)
+        else:
+            fos.Sample._reload_docs(self._sample_collection_name)
 
     def merge_samples(
         self,

--- a/fiftyone/core/labels.py
+++ b/fiftyone/core/labels.py
@@ -874,7 +874,13 @@ class _FrameLabels(Label):
     pass
 
 
-_SINGLE_LABEL_FIELDS = (Classification, Detection, Polyline, Keypoint)
+_SINGLE_LABEL_FIELDS = (
+    Classification,
+    Detection,
+    Polyline,
+    Keypoint,
+    Segmentation,
+)
 _LABEL_LIST_FIELDS = (Classifications, Detections, Polylines, Keypoints)
 _LABEL_FIELDS = _SINGLE_LABEL_FIELDS + _LABEL_LIST_FIELDS
 

--- a/fiftyone/core/labels.py
+++ b/fiftyone/core/labels.py
@@ -151,8 +151,8 @@ class _HasAttributes(Label):
 
 
 class _HasID(Label):
-    """Mixin for :class:`Label` classes that expose an ``id`` property that
-    contains a unique identifier for the label.
+    """Mixin for :class:`Label` classes that expose a UUID via an ``id``
+    property, as well as a ``tags`` attribute.
     """
 
     meta = {"allow_inheritance": True}
@@ -160,6 +160,7 @@ class _HasID(Label):
     _id = fof.ObjectIdField(
         required=True, default=ObjectId, unique=True, primary_key=True
     )
+    tags = fof.ListField(fof.StringField())
 
     @property
     def id(self):

--- a/fiftyone/core/labels.py
+++ b/fiftyone/core/labels.py
@@ -829,7 +829,7 @@ class Keypoints(ImageLabel, _HasLabelList):
         )
 
 
-class Segmentation(ImageLabel):
+class Segmentation(ImageLabel, _HasID):
     """A semantic segmentation mask for an image.
 
     Args:

--- a/fiftyone/core/sample.py
+++ b/fiftyone/core/sample.py
@@ -646,9 +646,6 @@ def _apply_confidence_thresh(label, confidence_thresh):
             k: _apply_confidence_thresh(v, confidence_thresh)
             for k, v in label.items()
         }
-    elif isinstance(label, fol._SINGLE_LABEL_FIELDS):
-        if label.confidence is None or label.confidence < confidence_thresh:
-            label = None
     elif isinstance(label, fol._LABEL_LIST_FIELDS):
         labels = [
             l
@@ -656,6 +653,11 @@ def _apply_confidence_thresh(label, confidence_thresh):
             if l.confidence is not None and l.confidence >= confidence_thresh
         ]
         setattr(label, label._LABEL_LIST_FIELD, labels)
+    elif isinstance(label, fol._SINGLE_LABEL_FIELDS) and hasattr(
+        label, "confidence"
+    ):
+        if label.confidence is None or label.confidence < confidence_thresh:
+            label = None
 
     return label
 

--- a/fiftyone/core/session.py
+++ b/fiftyone/core/session.py
@@ -424,7 +424,7 @@ class Session(foc.HasClient):
         self.state.dataset = dataset
         self.state.view = None
         self.state.selected = []
-        self.state.selected_objects = []
+        self.state.selected_labels = []
         self.state.filters = {}
 
     @_update_state
@@ -450,7 +450,7 @@ class Session(foc.HasClient):
             self.state.dataset._reload()
 
         self.state.selected = []
-        self.state.selected_objects = []
+        self.state.selected_labels = []
         self.state.filters = {}
 
     @_update_state
@@ -473,18 +473,18 @@ class Session(foc.HasClient):
         return list(self.state.selected)
 
     @property
-    def selected_objects(self):
-        """A list of objects currently selected in the App.
+    def selected_labels(self):
+        """A list of labels currently selected in the App.
 
         Items are dictionaries with the following keys:
 
-            -   ``object_id``: the internal ID of the object
-            -   ``sample_id``: the ID of the sample containing the object
-            -   ``field``: the field name containing the object
-            -   ``frame_number``: the frame number containing the object (only
+            -   ``label_id``: the ID of the label
+            -   ``sample_id``: the ID of the sample containing the label
+            -   ``field``: the field name containing the label
+            -   ``frame_number``: the frame number containing the label (only
                 applicable to video samples)
         """
-        return list(self.state.selected_objects)
+        return list(self.state.selected_labels)
 
     def summary(self):
         """Returns a string summary of the session.
@@ -508,7 +508,7 @@ class Session(foc.HasClient):
                     "Media type:       %s" % media_type,
                     "Num samples:      %d" % num_samples,
                     "Selected samples: %d" % len(self.selected),
-                    "Selected objects: %d" % len(self.selected_objects),
+                    "Selected labels:  %d" % len(self.selected_labels),
                 ]
             )
 

--- a/fiftyone/core/session.py
+++ b/fiftyone/core/session.py
@@ -697,7 +697,6 @@ class Session(foc.HasClient):
     def _update_state(self, state=None):
         # see fiftyone.core.client if you would like to understand this
         self.state = state or self.state
-        self._update_listeners()
 
 
 def _display(session, handle, uuid, port=None, height=None, update=False):

--- a/fiftyone/core/session.py
+++ b/fiftyone/core/session.py
@@ -697,6 +697,7 @@ class Session(foc.HasClient):
     def _update_state(self, state=None):
         # see fiftyone.core.client if you would like to understand this
         self.state = state or self.state
+        self._update_listeners()
 
 
 def _display(session, handle, uuid, port=None, height=None, update=False):

--- a/fiftyone/core/stages.py
+++ b/fiftyone/core/stages.py
@@ -2564,8 +2564,8 @@ class SelectObjects(ViewStage):
         dataset = dataset.clone()  # create a copy since we're modifying data
         dataset.select_objects(ids=ids).tag_objects("test")
 
-        print(dataset.count_values("ground_truth.detections.tags[]"))
-        print(dataset.count_values("predictions.detections.tags[]"))
+        print(dataset.count_values("ground_truth.detections.tags"))
+        print(dataset.count_values("predictions.detections.tags"))
 
         # Retrieve the objects via their tag
         stage = fo.SelectObjects(tags=["test"])

--- a/fiftyone/core/stages.py
+++ b/fiftyone/core/stages.py
@@ -2183,7 +2183,7 @@ class MatchTags(ViewStage):
         return [
             {
                 "name": "tags",
-                "type": "list<str>",
+                "type": "list<str>|str",
                 "placeholder": "list,of,tags",
             }
         ]

--- a/fiftyone/core/stages.py
+++ b/fiftyone/core/stages.py
@@ -2547,7 +2547,6 @@ class SelectObjects(ViewStage):
         stage = fo.SelectObjects(ids=ids)
         view = dataset.add_stage(stage)
 
-        print(view)
         print(view.count("ground_truth.detections"))
         print(view.count("predictions.detections"))
 
@@ -2572,7 +2571,6 @@ class SelectObjects(ViewStage):
         stage = fo.SelectObjects(tags=["test"])
         view = dataset.add_stage(stage)
 
-        print(view)
         print(view.count("ground_truth.detections"))
         print(view.count("predictions.detections"))
 

--- a/fiftyone/core/stages.py
+++ b/fiftyone/core/stages.py
@@ -3126,6 +3126,9 @@ def _get_sample_ids(samples_or_ids):
     if isinstance(samples_or_ids, foc.SampleCollection):
         return [s.id for s in samples_or_ids.select_fields()]
 
+    if not samples_or_ids:
+        return []
+
     if isinstance(next(iter(samples_or_ids)), (fos.Sample, fos.SampleView)):
         return [s.id for s in samples_or_ids]
 

--- a/fiftyone/core/stages.py
+++ b/fiftyone/core/stages.py
@@ -432,9 +432,9 @@ class ExcludeObjects(ViewStage):
     """
 
     def __init__(self, objects):
-        _, object_ids = _parse_objects(objects)
+        _, objects_map = _parse_objects(objects)
         self._objects = objects
-        self._object_ids = object_ids
+        self._objects_map = objects_map
         self._pipeline = None
 
     @property
@@ -470,9 +470,9 @@ class ExcludeObjects(ViewStage):
         )
 
         pipeline = []
-        for field, object_ids in self._object_ids.items():
+        for field, objects_map in self._objects_map.items():
             label_filter = ~F("_id").is_in(
-                [foe.ObjectId(oid) for oid in object_ids]
+                [foe.ObjectId(oid) for oid in objects_map]
             )
             stage = _make_label_filter_stage(label_schema, field, label_filter)
             if stage is None:
@@ -2492,22 +2492,29 @@ class SelectObjects(ViewStage):
     """Selects only the specified objects from a collection.
 
     The returned view will omit samples, sample fields, and individual objects
-    that do not appear in the provided ``objects`` argument, which should have
-    the following format::
+    that do not match the specified selection criteria.
 
-        [
-            {
-                "sample_id": "5f8d254a27ad06815ab89df4",
-                "field": "ground_truth",
-                "object_id": "5f8d254a27ad06815ab89df3",
-            },
-            {
-                "sample_id": "5f8d255e27ad06815ab93bf8",
-                "field": "ground_truth",
-                "object_id": "5f8d255e27ad06815ab93bf6",
-            },
-            ...
-        ]
+    You can perform a selection via one of the following methods:
+
+    -   Provide the ``objects`` argument, which should have the following
+        format::
+
+            [
+                {
+                    "sample_id": "5f8d254a27ad06815ab89df4",
+                    "field": "ground_truth",
+                    "object_id": "5f8d254a27ad06815ab89df3",
+                },
+                {
+                    "sample_id": "5f8d255e27ad06815ab93bf8",
+                    "field": "ground_truth",
+                    "object_id": "5f8d255e27ad06815ab93bf6",
+                },
+                ...
+            ]
+
+    -   Provide one or both of the ``ids`` and ``tags`` arguments, and
+        optionally the ``fields`` argument
 
     Examples::
 
@@ -2524,24 +2531,105 @@ class SelectObjects(ViewStage):
 
         # Select some objects in the App...
 
-        stage = fo.SelectObjects(session.selected_objects)
+        stage = fo.SelectObjects(objects=session.selected_objects)
         view = dataset.add_stage(stage)
 
+        #
+        # Only include objects with the specified IDs
+        #
+
+        # Grab some object IDs
+        ids = [
+            dataset.first().ground_truth.detections[0].id,
+            dataset.last().predictions.detections[0].id,
+        ]
+
+        stage = fo.SelectObjects(ids=ids)
+        view = dataset.add_stage(stage)
+
+        print(view)
+        print(view.count("ground_truth.detections"))
+        print(view.count("predictions.detections"))
+
+        #
+        # Only include objects with the specified tags
+        #
+
+        # Grab some object IDs
+        ids = [
+            dataset.first().ground_truth.detections[0].id,
+            dataset.last().predictions.detections[0].id,
+        ]
+
+        # Give the objects a "test" tag
+        dataset = dataset.clone()  # create a copy since we're modifying data
+        dataset.select_objects(ids=ids).tag_objects("test")
+
+        print(dataset.count_values("ground_truth.detections.tags[]"))
+        print(dataset.count_values("predictions.detections.tags[]"))
+
+        # Retrieve the objects via their tag
+        stage = fo.SelectObjects(tags=["test"])
+        view = dataset.add_stage(stage)
+
+        print(view)
+        print(view.count("ground_truth.detections"))
+        print(view.count("predictions.detections"))
+
     Args:
-        objects: a list of dicts specifying the objects to select
+        objects (None): a list of dicts specifying the objects to select
+        ids (None): a list of IDs of the objects to select
+        tags (None): a list of tags of objects to select
+        fields (None): a list of fields from which to select objects
     """
 
-    def __init__(self, objects):
-        sample_ids, object_ids = _parse_objects(objects)
+    def __init__(self, objects=None, ids=None, tags=None, fields=None):
+        if objects is None and ids is None and tags is None:
+            raise ValueError(
+                "One of `objects`, `ids`, or `tags` must be provided"
+            )
+
+        if objects is not None:
+            sample_ids, objects_map = _parse_objects(objects)
+        else:
+            sample_ids, objects_map = None, None
+
+        if etau.is_str(ids):
+            ids = [ids]
+
+        if etau.is_str(tags):
+            tags = [tags]
+
+        if etau.is_str(fields):
+            fields = [fields]
+
         self._objects = objects
+        self._ids = ids
+        self._tags = tags
+        self._fields = fields
         self._sample_ids = sample_ids
-        self._object_ids = object_ids
+        self._objects_map = objects_map
         self._pipeline = None
 
     @property
     def objects(self):
         """A list of dicts specifying the objects to select."""
         return self._objects
+
+    @property
+    def ids(self):
+        """A list of IDs of objects to select."""
+        return self._ids
+
+    @property
+    def tags(self):
+        """A list of tags of objects to select."""
+        return self._tags
+
+    @property
+    def fields(self):
+        """A list of fields from which objects are being selected."""
+        return self._fields
 
     def to_mongo(self, _, **__):
         if self._pipeline is None:
@@ -2553,19 +2641,43 @@ class SelectObjects(ViewStage):
         return self._pipeline
 
     def _kwargs(self):
-        return [["objects", self._objects]]
+        return [
+            ["objects", self._objects],
+            ["ids", self._ids],
+            ["tags", self._tags],
+            ["fields", self._fields],
+        ]
 
     @classmethod
     def _params(self):
         return [
             {
                 "name": "objects",
-                "type": "dict",  # @todo use "list<dict>" when supported
+                "type": "dict|NoneType",  # @todo use "list<dict>" when supported
                 "placeholder": "[{...}]",
-            }
+                "default": "None",
+            },
+            {
+                "name": "ids",
+                "type": "list<id>|id|NoneType",
+                "placeholder": "...",
+                "default": "None",
+            },
+            {
+                "name": "tags",
+                "type": "list<str>|str|NoneType",
+                "placeholder": "...",
+                "default": "None",
+            },
+            {
+                "name": "fields",
+                "type": "list<str>|str|NoneType",
+                "placeholder": "...",
+                "default": "None",
+            },
         ]
 
-    def _make_pipeline(self, sample_collection):
+    def _make_objects_pipeline(self, sample_collection):
         label_schema = sample_collection.get_field_schema(
             ftype=fof.EmbeddedDocumentField, embedded_doc_type=fol.Label
         )
@@ -2576,13 +2688,13 @@ class SelectObjects(ViewStage):
         stage.validate(sample_collection)
         pipeline.extend(stage.to_mongo(sample_collection))
 
-        stage = SelectFields(list(self._object_ids.keys()))
+        stage = SelectFields(list(self._objects_map.keys()))
         stage.validate(sample_collection)
         pipeline.extend(stage.to_mongo(sample_collection))
 
-        for field, object_ids in self._object_ids.items():
+        for field, objects_map in self._objects_map.items():
             label_filter = F("_id").is_in(
-                [foe.ObjectId(oid) for oid in object_ids]
+                [foe.ObjectId(_id) for _id in objects_map]
             )
             stage = _make_label_filter_stage(label_schema, field, label_filter)
             if stage is None:
@@ -2590,10 +2702,76 @@ class SelectObjects(ViewStage):
 
             stage.validate(sample_collection)
             pipeline.extend(stage.to_mongo(sample_collection))
+
+        return pipeline
+
+    def _make_pipeline(self, sample_collection):
+        if self._fields is not None:
+            fields = self._fields
+        else:
+            fields = list(
+                sample_collection.get_field_schema(
+                    ftype=fof.EmbeddedDocumentField,
+                    embedded_doc_type=fol.Label,
+                ).keys()
+            )
+
+        pipeline = []
+
+        stage = SelectFields(fields)
+        stage.validate(sample_collection)
+        pipeline.extend(stage.to_mongo(sample_collection))
+
+        num_fields = len(fields)
+        if num_fields == 0:
+            return pipeline + [{"$match": {"_id": None}}]
+
+        only_matches = num_fields == 1
+
+        filter_expr = None
+        if self._ids is not None:
+            filter_expr = F("_id").is_in([ObjectId(_id) for _id in self._ids])
+
+        if self._tags is not None:
+            tag_expr = (F("tags") != None).if_else(
+                F("tags").contains(self._tags), False
+            )
+            if filter_expr is not None:
+                filter_expr &= tag_expr
+            else:
+                filter_expr = tag_expr
+
+        for field in fields:
+            stage = FilterLabels(field, filter_expr, only_matches=only_matches)
+            stage.validate(sample_collection)
+            pipeline.extend(stage.to_mongo(sample_collection))
+
+        if num_fields <= 1:
+            return pipeline
+
+        match_exprs = []
+        for field in fields:
+            label_type = sample_collection._get_label_field_type(field)
+            if issubclass(label_type, fol._LABEL_LIST_FIELDS):
+                match_expr = (
+                    F(field + "." + label_type._LABEL_LIST_FIELD).length() > 0
+                )
+            else:
+                match_expr = F(field) != None
+
+            match_exprs.append(match_expr)
+
+        stage = Match(F.any(match_exprs))
+        stage.validate(sample_collection)
+        pipeline.extend(stage.to_mongo(sample_collection))
+
         return pipeline
 
     def validate(self, sample_collection):
-        self._pipeline = self._make_pipeline(sample_collection)
+        if self._objects is not None:
+            self._pipeline = self._make_objects_pipeline(sample_collection)
+        else:
+            self._pipeline = self._make_pipeline(sample_collection)
 
 
 class Shuffle(ViewStage):
@@ -3027,12 +3205,12 @@ def _get_field(sample_collection, field_path):
 
 def _parse_objects(objects):
     sample_ids = set()
-    object_ids = defaultdict(set)
+    objects_map = defaultdict(set)
     for obj in objects:
         sample_ids.add(obj["sample_id"])
-        object_ids[obj["field"]].add(obj["object_id"])
+        objects_map[obj["field"]].add(obj["object_id"])
 
-    return sample_ids, object_ids
+    return sample_ids, objects_map
 
 
 def _make_label_filter_stage(label_schema, field, label_filter):

--- a/fiftyone/core/stages.py
+++ b/fiftyone/core/stages.py
@@ -389,26 +389,33 @@ class ExcludeFields(ViewStage):
         self._dataset.validate_fields_exist(self.field_names)
 
 
-# @todo add support for `ids` and `tags` fields
 class ExcludeLabels(ViewStage):
     """Excludes the specified labels from a collection.
 
-    The returned view will omit the labels specified in the provided ``labels``
-    argument, which should have the following format::
+    The returned view will omit samples, sample fields, and individual labels
+    that do not match the specified selection criteria.
 
-        [
-            {
-                "sample_id": "5f8d254a27ad06815ab89df4",
-                "field": "ground_truth",
-                "label_id": "5f8d254a27ad06815ab89df3",
-            },
-            {
-                "sample_id": "5f8d255e27ad06815ab93bf8",
-                "field": "ground_truth",
-                "label_id": "5f8d255e27ad06815ab93bf6",
-            },
-            ...
-        ]
+    You can perform an exclusion via one of the following methods:
+
+    -   Provide one or both of the ``ids`` and ``tags`` arguments, and
+        optionally the ``fields`` argument
+
+    -   Provide the ``labels`` argument, which should have the following
+        format::
+
+            [
+                {
+                    "sample_id": "5f8d254a27ad06815ab89df4",
+                    "field": "ground_truth",
+                    "label_id": "5f8d254a27ad06815ab89df3",
+                },
+                {
+                    "sample_id": "5f8d255e27ad06815ab93bf8",
+                    "field": "ground_truth",
+                    "label_id": "5f8d255e27ad06815ab93bf6",
+                },
+                ...
+            ]
 
     Examples::
 
@@ -425,16 +432,82 @@ class ExcludeLabels(ViewStage):
 
         # Select some labels in the App...
 
-        stage = fo.ExcludeLabels(session.selected_labels)
+        stage = fo.ExcludeLabels(labels=session.selected_labels)
         view = dataset.add_stage(stage)
 
+        #
+        # Exclude labels with the specified IDs
+        #
+
+        # Grab some label IDs
+        ids = [
+            dataset.first().ground_truth.detections[0].id,
+            dataset.last().predictions.detections[0].id,
+        ]
+
+        stage = fo.ExcludeLabels(ids=ids)
+        view = dataset.add_stage(stage)
+
+        print(dataset.count("ground_truth.detections"))
+        print(view.count("ground_truth.detections"))
+
+        print(dataset.count("predictions.detections"))
+        print(view.count("predictions.detections"))
+
+        #
+        # Exclude labels with the specified tags
+        #
+
+        # Grab some label IDs
+        ids = [
+            dataset.first().ground_truth.detections[0].id,
+            dataset.last().predictions.detections[0].id,
+        ]
+
+        # Give the labels a "test" tag
+        dataset = dataset.clone()  # create a copy since we're modifying data
+        dataset.select_labels(ids=ids).tag_labels("test")
+
+        print(dataset.count_values("ground_truth.detections.tags"))
+        print(dataset.count_values("predictions.detections.tags"))
+
+        # Exclude the labels via their tag
+        stage = fo.ExcludeLabels(tags=["test"])
+        view = dataset.add_stage(stage)
+
+        print(dataset.count("ground_truth.detections"))
+        print(view.count("ground_truth.detections"))
+
+        print(dataset.count("predictions.detections"))
+        print(view.count("predictions.detections"))
+
     Args:
-        labels: a list of dicts specifying the labels to exclude
+        labels (None): a list of dicts specifying the labels to exclude
+        ids (None): a list of IDs of the labels to exclude
+        tags (None): a list of tags of labels to exclude
+        fields (None): a list of fields from which to exclude labels
     """
 
-    def __init__(self, labels):
-        _, labels_map = _parse_labels(labels)
+    def __init__(self, labels=None, ids=None, tags=None, fields=None):
+        if labels is not None:
+            sample_ids, labels_map = _parse_labels(labels)
+        else:
+            sample_ids, labels_map = None, None
+
+        if etau.is_str(ids):
+            ids = [ids]
+
+        if etau.is_str(tags):
+            tags = [tags]
+
+        if etau.is_str(fields):
+            fields = [fields]
+
         self._labels = labels
+        self._ids = ids
+        self._tags = tags
+        self._fields = fields
+        self._sample_ids = sample_ids
         self._labels_map = labels_map
         self._pipeline = None
 
@@ -442,6 +515,21 @@ class ExcludeLabels(ViewStage):
     def labels(self):
         """A list of dicts specifying the labels to exclude."""
         return self._labels
+
+    @property
+    def ids(self):
+        """A list of IDs of labels to exclude."""
+        return self._ids
+
+    @property
+    def tags(self):
+        """A list of tags of labels to exclude."""
+        return self._tags
+
+    @property
+    def fields(self):
+        """A list of fields from which labels are being excluded."""
+        return self._fields
 
     def to_mongo(self, _, **__):
         if self._pipeline is None:
@@ -453,19 +541,43 @@ class ExcludeLabels(ViewStage):
         return self._pipeline
 
     def _kwargs(self):
-        return [["labels", self._labels]]
+        return [
+            ["labels", self._labels],
+            ["ids", self._ids],
+            ["tags", self._tags],
+            ["fields", self._fields],
+        ]
 
     @classmethod
     def _params(self):
         return [
             {
                 "name": "labels",
-                "type": "dict",  # @todo use "list<dict>" when supported
+                "type": "dict|NoneType",  # @todo use "list<dict>" when supported
                 "placeholder": "[{...}]",
-            }
+                "default": "None",
+            },
+            {
+                "name": "ids",
+                "type": "list<id>|id|NoneType",
+                "placeholder": "...",
+                "default": "None",
+            },
+            {
+                "name": "tags",
+                "type": "list<str>|str|NoneType",
+                "placeholder": "...",
+                "default": "None",
+            },
+            {
+                "name": "fields",
+                "type": "list<str>|str|NoneType",
+                "placeholder": "...",
+                "default": "None",
+            },
         ]
 
-    def _make_pipeline(self, sample_collection):
+    def _make_labels_pipeline(self, sample_collection):
         label_schema = sample_collection.get_field_schema(
             ftype=fof.EmbeddedDocumentField, embedded_doc_type=fol.Label
         )
@@ -473,7 +585,7 @@ class ExcludeLabels(ViewStage):
         pipeline = []
         for field, labels_map in self._labels_map.items():
             label_filter = ~F("_id").is_in(
-                [foe.ObjectId(oid) for oid in labels_map]
+                [foe.ObjectId(_id) for _id in labels_map]
             )
             stage = _make_label_filter_stage(label_schema, field, label_filter)
             if stage is None:
@@ -484,8 +596,76 @@ class ExcludeLabels(ViewStage):
 
         return pipeline
 
+    def _make_pipeline(self, sample_collection):
+        if self._fields is not None:
+            fields = self._fields
+        else:
+            fields = list(
+                sample_collection.get_field_schema(
+                    ftype=fof.EmbeddedDocumentField,
+                    embedded_doc_type=fol.Label,
+                ).keys()
+            )
+
+        pipeline = []
+
+        # Handle early exit
+        num_fields = len(fields)
+        if num_fields == 0 or (self._ids is None and self._tags is None):
+            # No filtering to do
+            return pipeline
+
+        #
+        # Filter labels that match `tags` or `id`
+        #
+
+        only_matches = num_fields == 1
+
+        filter_expr = None
+        if self._ids is not None:
+            filter_expr = ~F("_id").is_in([ObjectId(_id) for _id in self._ids])
+
+        if self._tags is not None:
+            tag_expr = (F("tags") != None).if_else(
+                ~F("tags").contains(self._tags), False
+            )
+            if filter_expr is not None:
+                filter_expr &= tag_expr
+            else:
+                filter_expr = tag_expr
+
+        for field in fields:
+            stage = FilterLabels(field, filter_expr, only_matches=only_matches)
+            stage.validate(sample_collection)
+            pipeline.extend(stage.to_mongo(sample_collection))
+
+        if num_fields <= 1:
+            return pipeline
+
+        # Filter empty samples
+        match_exprs = []
+        for field in fields:
+            label_type = sample_collection._get_label_field_type(field)
+            if issubclass(label_type, fol._LABEL_LIST_FIELDS):
+                match_expr = (
+                    F(field + "." + label_type._LABEL_LIST_FIELD).length() > 0
+                )
+            else:
+                match_expr = F(field) != None
+
+            match_exprs.append(match_expr)
+
+        stage = Match(F.any(match_exprs))
+        stage.validate(sample_collection)
+        pipeline.extend(stage.to_mongo(sample_collection))
+
+        return pipeline
+
     def validate(self, sample_collection):
-        self._pipeline = self._make_pipeline(sample_collection)
+        if self._labels is not None:
+            self._pipeline = self._make_labels_pipeline(sample_collection)
+        else:
+            self._pipeline = self._make_pipeline(sample_collection)
 
 
 class Exists(ViewStage):
@@ -2712,13 +2892,20 @@ class SelectLabels(ViewStage):
 
         pipeline = []
 
+        # We know that only `fields` will have matches, so select them
         stage = SelectFields(fields)
         stage.validate(sample_collection)
         pipeline.extend(stage.to_mongo(sample_collection))
 
+        # Handle early exit
         num_fields = len(fields)
         if num_fields == 0 or (self._ids is None and self._tags is None):
+            # Nothing will match
             return pipeline + [{"$match": {"_id": None}}]
+
+        #
+        # Filter labels that don't match `tags` and `ids
+        #
 
         only_matches = num_fields == 1
 
@@ -2743,6 +2930,7 @@ class SelectLabels(ViewStage):
         if num_fields <= 1:
             return pipeline
 
+        # Filter empty samples
         match_exprs = []
         for field in fields:
             label_type = sample_collection._get_label_field_type(field)

--- a/fiftyone/core/stages.py
+++ b/fiftyone/core/stages.py
@@ -2496,6 +2496,9 @@ class SelectObjects(ViewStage):
 
     You can perform a selection via one of the following methods:
 
+    -   Provide one or both of the ``ids`` and ``tags`` arguments, and
+        optionally the ``fields`` argument
+
     -   Provide the ``objects`` argument, which should have the following
         format::
 
@@ -2512,9 +2515,6 @@ class SelectObjects(ViewStage):
                 },
                 ...
             ]
-
-    -   Provide one or both of the ``ids`` and ``tags`` arguments, and
-        optionally the ``fields`` argument
 
     Examples::
 

--- a/fiftyone/core/stages.py
+++ b/fiftyone/core/stages.py
@@ -553,25 +553,25 @@ class ExcludeLabels(ViewStage):
         return [
             {
                 "name": "labels",
-                "type": "dict|NoneType",  # @todo use "list<dict>" when supported
+                "type": "NoneType|dict",  # @todo use "list<dict>" when supported
                 "placeholder": "[{...}]",
                 "default": "None",
             },
             {
                 "name": "ids",
-                "type": "list<id>|id|NoneType",
+                "type": "NoneType|list<id>|id",
                 "placeholder": "...",
                 "default": "None",
             },
             {
                 "name": "tags",
-                "type": "list<str>|str|NoneType",
+                "type": "NoneType|list<str>|str",
                 "placeholder": "...",
                 "default": "None",
             },
             {
                 "name": "fields",
-                "type": "list<str>|str|NoneType",
+                "type": "NoneType|list<str>|str",
                 "placeholder": "...",
                 "default": "None",
             },
@@ -2827,25 +2827,25 @@ class SelectLabels(ViewStage):
         return [
             {
                 "name": "labels",
-                "type": "dict|NoneType",  # @todo use "list<dict>" when supported
+                "type": "NoneType|dict",  # @todo use "list<dict>" when supported
                 "placeholder": "[{...}]",
                 "default": "None",
             },
             {
                 "name": "ids",
-                "type": "list<id>|id|NoneType",
+                "type": "NoneType|list<id>|id",
                 "placeholder": "...",
                 "default": "None",
             },
             {
                 "name": "tags",
-                "type": "list<str>|str|NoneType",
+                "type": "NoneType|list<str>|str",
                 "placeholder": "...",
                 "default": "None",
             },
             {
                 "name": "fields",
-                "type": "list<str>|str|NoneType",
+                "type": "NoneType|list<str>|str",
                 "placeholder": "...",
                 "default": "None",
             },
@@ -3025,11 +3025,11 @@ class Shuffle(ViewStage):
         return [
             {
                 "name": "seed",
-                "type": "float|NoneType",
+                "type": "NoneType|float",
                 "default": "None",
                 "placeholder": "seed (default=None)",
             },
-            {"name": "_randint", "type": "int|NoneType", "default": "None"},
+            {"name": "_randint", "type": "NoneType|int", "default": "None"},
         ]
 
 
@@ -3294,11 +3294,11 @@ class Take(ViewStage):
             {"name": "size", "type": "int", "placeholder": "int"},
             {
                 "name": "seed",
-                "type": "float|NoneType",
+                "type": "NoneType|float",
                 "default": "None",
                 "placeholder": "seed (default=None)",
             },
-            {"name": "_randint", "type": "int|NoneType", "default": "None"},
+            {"name": "_randint", "type": "NoneType|int", "default": "None"},
         ]
 
 

--- a/fiftyone/core/stages.py
+++ b/fiftyone/core/stages.py
@@ -2582,11 +2582,6 @@ class SelectObjects(ViewStage):
     """
 
     def __init__(self, objects=None, ids=None, tags=None, fields=None):
-        if objects is None and ids is None and tags is None:
-            raise ValueError(
-                "One of `objects`, `ids`, or `tags` must be provided"
-            )
-
         if objects is not None:
             sample_ids, objects_map = _parse_objects(objects)
         else:
@@ -2721,7 +2716,7 @@ class SelectObjects(ViewStage):
         pipeline.extend(stage.to_mongo(sample_collection))
 
         num_fields = len(fields)
-        if num_fields == 0:
+        if num_fields == 0 or (self._ids is None and self._tags is None):
             return pipeline + [{"$match": {"_id": None}}]
 
         only_matches = num_fields == 1

--- a/fiftyone/core/state.py
+++ b/fiftyone/core/state.py
@@ -30,11 +30,11 @@ class StateDescription(etas.Serializable):
     a corresponding :class:`fiftyone.core.session.Session`.
 
     Args:
-        close (False): whether to close the app
-        connected (False): whether the session is connected to an app
+        close (False): whether to close the App
+        connected (False): whether the session is connected to an App
         dataset (None): the current :class:`fiftyone.core.dataset.Dataset`
         selected (None): the list of currently selected samples
-        selected_objects (None): the list of currently selected objects
+        selected_labels (None): the list of currently selected labels
         view (None): the current :class:`fiftyone.core.view.DatasetView`
         config (None): an optional :class:`fiftyone.core.config.AppConfig`
         refresh (False): a boolean toggle for forcing an App refresh
@@ -48,7 +48,7 @@ class StateDescription(etas.Serializable):
         dataset=None,
         datasets=None,
         selected=None,
-        selected_objects=None,
+        selected_labels=None,
         view=None,
         filters={},
         config=None,
@@ -60,7 +60,7 @@ class StateDescription(etas.Serializable):
         self.dataset = dataset
         self.view = view
         self.selected = selected or []
-        self.selected_objects = selected_objects or []
+        self.selected_labels = selected_labels or []
         self.filters = filters
         self.datasets = datasets or fod.list_datasets()
         self.active_handle = active_handle
@@ -113,7 +113,7 @@ class StateDescription(etas.Serializable):
         connected = d.get("connected", False)
         filters = d.get("filters", {})
         selected = d.get("selected", [])
-        selected_objects = d.get("selected_objects", [])
+        selected_labels = d.get("selected_labels", [])
         refresh = d.get("refresh", False)
 
         dataset = d.get("dataset", None)
@@ -133,7 +133,7 @@ class StateDescription(etas.Serializable):
             connected=connected,
             dataset=dataset,
             selected=selected,
-            selected_objects=selected_objects,
+            selected_labels=selected_labels,
             view=view,
             filters=filters,
             refresh=refresh,

--- a/fiftyone/server/main.py
+++ b/fiftyone/server/main.py
@@ -649,16 +649,16 @@ class StateHandler(tornado.websocket.WebSocketHandler):
         await self.send_updates(ignore=self)
 
     @staticmethod
-    async def on_set_selected_objects(self, selected_objects):
+    async def on_set_selected_labels(self, selected_labels):
         """Event for setting the entire selected objects list.
 
         Args:
-            selected_object: a list of selected objects
+            selected_labels: a list of selected labels
         """
-        if not isinstance(selected_objects, list):
-            raise TypeError("selected_objects must be a list")
+        if not isinstance(selected_labels, list):
+            raise TypeError("selected_labels must be a list")
 
-        StateHandler.state["selected_objects"] = selected_objects
+        StateHandler.state["selected_labels"] = selected_labels
         await self.send_updates(ignore=self)
 
     @staticmethod

--- a/fiftyone/utils/plot/__init__.py
+++ b/fiftyone/utils/plot/__init__.py
@@ -6,5 +6,6 @@ Plotting utilities.
 |
 """
 
+from .location import location_scatterplot
 from .selector import PointSelector
 from .scatter import scatterplot

--- a/fiftyone/utils/plot/__init__.py
+++ b/fiftyone/utils/plot/__init__.py
@@ -7,3 +7,4 @@ Plotting utilities.
 """
 
 from .selector import PointSelector
+from .scatter import scatterplot

--- a/fiftyone/utils/plot/__init__.py
+++ b/fiftyone/utils/plot/__init__.py
@@ -1,0 +1,9 @@
+"""
+Plotting utilities.
+
+| Copyright 2017-2021, Voxel51, Inc.
+| `voxel51.com <https://voxel51.com/>`_
+|
+"""
+
+from .selector import PointSelector

--- a/fiftyone/utils/plot/location.py
+++ b/fiftyone/utils/plot/location.py
@@ -1,0 +1,110 @@
+"""
+Location utilities.
+
+| Copyright 2017-2021, Voxel51, Inc.
+| `voxel51.com <https://voxel51.com/>`_
+|
+"""
+import numpy as np
+import matplotlib
+import matplotlib.pyplot as plt
+
+import eta.core.image as etai
+import eta.core.utils as etau
+
+import fiftyone.core.utils as fou
+
+from .scatter import scatterplot
+
+# requires all of these packages to be installed:
+# salem pyproj netCDF4 xarray shapely descartes pandas motionless
+salem = fou.lazy_import("salem", callback=lambda: etau.ensure_package("salem"))
+
+
+def location_scatterplot(
+    locations,
+    samples,
+    map_type="satellite",
+    show_scale_bar=False,
+    api_key=None,
+    ax=None,
+    **kwargs,
+):
+    """Generates an interactive scatterplot of the given location coordinates.
+
+    This method is a thin layer on top of
+    :meth:`fiftyone.utils.plot.scatter.scatterplot` that renders a background
+    image using Google Maps and performs the necessary coordinate
+    transformations so that the locations can be visualized.
+
+    Args:
+        locations: a ``num_samples x 2`` array of ``(longitude, latitude)``
+            coordinates
+        samples: the :class:`fiftyone.core.collections.SampleCollection` whose
+            sample locations are being visualized
+        map_type ("satellite"): the map type to render. Supported values are
+            ``("roadmap", "satellite", "hybrid", "terrain")``
+        show_scale_bar (False): whether to render a scale bar on the plot
+        api_key (None): a Google Maps API key to use
+        **kwargs: keyword arguments for
+            :meth:`fiftyone.utils.plot.scatter.scatterplot`
+
+    Returns:
+        a :class:`fiftyone.utils.plot.selector.PointSelector`
+    """
+    if ax is None:
+        fig = plt.figure()
+        ax = fig.add_subplot(111)
+    else:
+        fig = ax.figure
+
+    locations = np.asarray(locations)
+
+    locations = _plot_map_background(
+        ax, locations, api_key, map_type, show_scale_bar
+    )
+
+    # Add button that can toggle the map
+
+    def _onclick(event):
+        for child in ax.get_children():
+            if isinstance(child, matplotlib.image.AxesImage):
+                child.set_visible(not child.get_visible())
+
+        ax.figure.canvas.draw_idle()
+
+    buttons = {"map": _onclick}
+
+    return scatterplot(locations, samples, ax=ax, buttons=buttons, **kwargs)
+
+
+def _plot_map_background(ax, locations, api_key, map_type, show_scale_bar):
+    min_lon, min_lat = locations.min(axis=0)
+    max_lon, max_lat = locations.max(axis=0)
+
+    kwargs = {}
+    if api_key is not None:
+        kwargs["key"] = api_key
+
+    google_map = salem.GoogleVisibleMap(
+        x=[min_lon, max_lon],
+        y=[min_lat, max_lat],
+        scale=2,  # 1 or 2, resolution factor
+        maptype=map_type,
+        **kwargs,
+    )
+    img = google_map.get_vardata()
+
+    salem_map = salem.Map(google_map.grid, factor=1, countries=False)
+    salem_map.set_rgb(img)
+    if show_scale_bar:
+        salem_map.set_scale_bar(location=(0.88, 0.94))
+
+    salem_map.visualize(ax=ax)
+
+    # Transform into axis coordinates
+    x, y = locations[:, 0], locations[:, 1]
+    x, y = salem_map.grid.transform(x, y)
+    locations = np.stack((x, y), axis=1)
+
+    return locations

--- a/fiftyone/utils/plot/location.py
+++ b/fiftyone/utils/plot/location.py
@@ -9,12 +9,12 @@ import numpy as np
 import matplotlib
 import matplotlib.pyplot as plt
 
-import eta.core.image as etai
 import eta.core.utils as etau
 
 import fiftyone.core.utils as fou
 
 from .scatter import scatterplot
+from .utils import BUTTON_ICONS, load_icon
 
 
 def location_scatterplot(
@@ -67,7 +67,8 @@ def location_scatterplot(
 
         ax.figure.canvas.draw_idle()
 
-    buttons = {"map": _onclick}
+    map_icon = load_icon(BUTTON_ICONS["map"])
+    buttons = [("map", map_icon, _onclick)]
 
     return scatterplot(locations, ax=ax, buttons=buttons, **kwargs)
 

--- a/fiftyone/utils/plot/location.py
+++ b/fiftyone/utils/plot/location.py
@@ -16,18 +16,13 @@ import fiftyone.core.utils as fou
 
 from .scatter import scatterplot
 
-# requires all of these packages to be installed:
-# salem pyproj netCDF4 xarray shapely descartes pandas motionless
-salem = fou.lazy_import("salem", callback=lambda: etau.ensure_package("salem"))
-
 
 def location_scatterplot(
     locations,
-    samples,
+    ax=None,
     map_type="satellite",
     show_scale_bar=False,
     api_key=None,
-    ax=None,
     **kwargs,
 ):
     """Generates an interactive scatterplot of the given location coordinates.
@@ -37,11 +32,12 @@ def location_scatterplot(
     image using Google Maps and performs the necessary coordinate
     transformations so that the locations can be visualized.
 
+    See :meth:`fiftyone.utils.plot.scatter.scatterplot` for more usage details.
+
     Args:
         locations: a ``num_samples x 2`` array of ``(longitude, latitude)``
             coordinates
-        samples: the :class:`fiftyone.core.collections.SampleCollection` whose
-            sample locations are being visualized
+        ax (None): an optional matplotlib axis to plot in
         map_type ("satellite"): the map type to render. Supported values are
             ``("roadmap", "satellite", "hybrid", "terrain")``
         show_scale_bar (False): whether to render a scale bar on the plot
@@ -64,8 +60,6 @@ def location_scatterplot(
         ax, locations, api_key, map_type, show_scale_bar
     )
 
-    # Add button that can toggle the map
-
     def _onclick(event):
         for child in ax.get_children():
             if isinstance(child, matplotlib.image.AxesImage):
@@ -75,7 +69,7 @@ def location_scatterplot(
 
     buttons = {"map": _onclick}
 
-    return scatterplot(locations, samples, ax=ax, buttons=buttons, **kwargs)
+    return scatterplot(locations, ax=ax, buttons=buttons, **kwargs)
 
 
 def _plot_map_background(ax, locations, api_key, map_type, show_scale_bar):
@@ -108,3 +102,33 @@ def _plot_map_background(ax, locations, api_key, map_type, show_scale_bar):
     locations = np.stack((x, y), axis=1)
 
     return locations
+
+
+def _ensure_salem():
+    # pip installing `salem` does not automatically install these...
+    required_packages = [
+        "salem",
+        "pyproj",
+        "netCDF4",
+        "xarray",
+        "shapely",
+        "descartes",
+        "pandas",
+        "motionless",
+    ]
+
+    missing_packages = []
+    for pkg in required_packages:
+        try:
+            etau.ensure_package(pkg)
+        except:
+            missing_packages.append(pkg)
+
+    if missing_packages:
+        raise ImportError(
+            "The requested operation requires that the following packages are "
+            "installed on your machine: %s" % (tuple(missing_packages),)
+        )
+
+
+salem = fou.lazy_import("salem", callback=_ensure_salem)

--- a/fiftyone/utils/plot/location.py
+++ b/fiftyone/utils/plot/location.py
@@ -14,7 +14,7 @@ import eta.core.utils as etau
 import fiftyone.core.utils as fou
 
 from .scatter import scatterplot
-from .utils import BUTTON_ICONS, load_icon
+from .utils import load_button_icon
 
 
 def location_scatterplot(
@@ -67,7 +67,7 @@ def location_scatterplot(
 
         ax.figure.canvas.draw_idle()
 
-    map_icon = load_icon(BUTTON_ICONS["map"])
+    map_icon = load_button_icon("map")
     buttons = [("map", map_icon, _onclick)]
 
     return scatterplot(locations, ax=ax, buttons=buttons, **kwargs)

--- a/fiftyone/utils/plot/scatter.py
+++ b/fiftyone/utils/plot/scatter.py
@@ -1,0 +1,234 @@
+"""
+Scatterplot utilities.
+
+| Copyright 2017-2021, Voxel51, Inc.
+| `voxel51.com <https://voxel51.com/>`_
+|
+"""
+import logging
+
+import numpy as np
+import matplotlib as mpl
+import matplotlib.pyplot as plt
+from mpl_toolkits.axes_grid1 import make_axes_locatable
+from mpl_toolkits.mplot3d import Axes3D  # pylint: disable=unused-import
+
+import eta.core.utils as etau
+
+from fiftyone.core.view import DatasetView
+
+from .selector import PointSelector
+
+
+logger = logging.getLogger(__name__)
+
+
+def scatterplot(
+    points,
+    samples,
+    field=None,
+    labels=None,
+    classes=None,
+    session=None,
+    buttons=None,
+    marker_size=None,
+    cmap=None,
+    ax=None,
+    figsize=None,
+    style="seaborn-ticks",
+    block=False,
+    **kwargs,
+):
+    """Generates an interactive scatterplot of the given points.
+
+    This method supports 2D or 3D visualizations, but interactive point
+    selection is only aviailable in 2D.
+
+    Args:
+        points: a ``num_samples x num_dims`` array of points
+        samples: the :class:`fiftyone.core.collections.SampleCollection` whose
+            sample locations are being visualized
+        field (None): a sample field or ``embedded.field.name`` to use to
+            color the points. Can be numeric or strings
+        labels (None): a list of numeric or string values to use to color
+            the points
+        classes (None): an optional list of classes whose points to plot.
+            Only applicable when ``labels`` contains strings
+        session (None): a :class:`fiftyone.core.session.Session` object to
+            link with the interactive plot
+        buttons (None): a dict mapping button names to callbacks defining
+            buttons to add to the plot
+        marker_size (None): the marker size to use
+        cmap (None): a colormap recognized by ``matplotlib``
+        ax (None): an optional matplotlib axis to plot in
+        figsize (None): an optional ``(width, height)`` for the figure, in
+            inches
+        style ("seaborn-ticks"): a style to use for the plot
+        block (False): whether to block execution when the plot is
+            displayed via ``matplotlib.pyplot.show(block=block)``
+        **kwargs: optional keyword arguments for matplotlib's ``scatter()``
+
+    Returns:
+        a :class:`fiftyone.utils.plot.selector.PointSelector`
+    """
+    points = np.asarray(points)
+    num_dims = points.shape[1]
+
+    if num_dims not in {2, 3}:
+        raise ValueError("This method only supports 2D or 3D points")
+
+    if session is not None and num_dims != 2:
+        logger.warning("Interactive selection is only supported in 2D")
+
+    if field is not None:
+        labels = samples.values(field)
+
+    if labels is not None:
+        if len(labels) != len(points):
+            raise ValueError(
+                "Number of labels (%d) does not match number of points (%d). "
+                "You may have missing data/labels that you need to omit from "
+                "your view before visualizing" % (len(labels), len(points))
+            )
+
+    with plt.style.context(style):
+        collection, inds = _plot_scatter(
+            points,
+            labels=labels,
+            classes=classes,
+            marker_size=marker_size,
+            cmap=cmap,
+            ax=ax,
+            figsize=figsize,
+            **kwargs,
+        )
+
+    if num_dims != 2:
+        plt.tight_layout()
+        plt.show(block=block)
+        return None
+
+    sample_ids = _get_sample_ids(samples)
+
+    if session is not None:
+        if inds is not None:
+            sample_ids = sample_ids[inds]
+
+        if isinstance(samples, DatasetView):
+            session.view = samples
+        else:
+            session.dataset = samples
+
+    with plt.style.context(style):
+        selector = PointSelector(
+            collection, session=session, sample_ids=sample_ids, buttons=buttons
+        )
+
+    plt.show(block=block)
+
+    return selector
+
+
+def _plot_scatter(
+    points,
+    labels=None,
+    classes=None,
+    marker_size=None,
+    cmap=None,
+    ax=None,
+    figsize=None,
+    **kwargs,
+):
+    if labels is not None:
+        points, values, classes, inds, categorical = _parse_data(
+            points, labels, classes
+        )
+    else:
+        values, classes, inds, categorical = None, None, None, None
+
+    scatter_3d = points.shape[1] == 3
+
+    if ax is None:
+        projection = "3d" if scatter_3d else None
+        fig = plt.figure()
+        ax = fig.add_subplot(111, projection=projection)
+    else:
+        fig = ax.figure
+
+    if cmap is None:
+        cmap = "Spectral" if categorical else "viridis"
+
+    cmap = plt.get_cmap(cmap)
+
+    if categorical:
+        boundaries = np.arange(0, len(classes) + 1)
+        norm = mpl.colors.BoundaryNorm(boundaries, cmap.N)
+    else:
+        norm = None
+
+    if marker_size is None:
+        marker_size = 10 ** (4 - np.log10(points.shape[0]))
+        marker_size = max(0.1, min(marker_size, 25))
+        marker_size = round(marker_size, 0 if marker_size >= 1 else 1)
+
+    args = [points[:, 0], points[:, 1]]
+    if scatter_3d:
+        args.append(points[:, 2])
+
+    collection = ax.scatter(
+        *args, c=values, s=marker_size, cmap=cmap, norm=norm, **kwargs,
+    )
+
+    if values is not None:
+        divider = make_axes_locatable(ax)
+        cax = divider.append_axes(
+            "right", size="5%", pad=0.1, axes_class=mpl.axes.Axes
+        )
+
+        if categorical:
+            ticks = 0.5 + np.arange(0, len(classes))
+            cbar = mpl.colorbar.ColorbarBase(
+                cax,
+                cmap=cmap,
+                norm=norm,
+                spacing="proportional",
+                boundaries=boundaries,
+                ticks=ticks,
+            )
+            cbar.set_ticklabels(classes)
+        else:
+            mappable = mpl.cm.ScalarMappable(cmap=cmap, norm=norm)
+            mappable.set_array(values)
+            fig.colorbar(mappable, cax=cax)
+
+    if figsize is not None:
+        fig.set_size_inches(*figsize)
+
+    return collection, inds
+
+
+def _parse_data(points, labels, classes):
+    if not labels:
+        return points, None, None, None, False
+
+    if not etau.is_str(labels[0]):
+        return points, labels, None, None, False
+
+    if classes is None:
+        classes = sorted(set(labels))
+
+    values_map = {c: i for i, c in enumerate(classes)}
+    values = np.array([values_map.get(l, -1) for l in labels])
+
+    found = values >= 0
+    if not np.all(found):
+        points = points[found, :]
+        values = values[found]
+    else:
+        found = None
+
+    return points, values, classes, found, True
+
+
+def _get_sample_ids(samples):
+    return np.array([str(_id) for _id in samples._get_sample_ids()])

--- a/fiftyone/utils/plot/scatter.py
+++ b/fiftyone/utils/plot/scatter.py
@@ -17,6 +17,7 @@ from mpl_toolkits.mplot3d import Axes3D  # pylint: disable=unused-import
 import eta.core.utils as etau
 
 import fiftyone.core.labels as fol
+import fiftyone.core.utils as fou
 from fiftyone.core.view import DatasetView
 
 from .selector import PointSelector
@@ -190,10 +191,13 @@ def scatterplot(
                 sample_ids = sample_ids[inds]
 
     if session is not None:
-        if isinstance(samples, DatasetView):
-            session.view = samples
-        else:
-            session.dataset = samples
+        # Temporarily set `session._auto` to False since this update should not
+        # spawn new a App instance in notebook contexts
+        with fou.SetAttributes(session, _auto=False):
+            if isinstance(samples, DatasetView):
+                session.view = samples
+            else:
+                session.dataset = samples
 
     with plt.style.context(style):
         selector = PointSelector(

--- a/fiftyone/utils/plot/selector.py
+++ b/fiftyone/utils/plot/selector.py
@@ -18,7 +18,7 @@ from fiftyone.core.expressions import ObjectId
 import fiftyone.core.labels as fol
 import fiftyone.core.utils as fou
 
-from .utils import BUTTON_ICONS, load_icon
+from .utils import load_button_icon
 
 
 class PointSelector(object):
@@ -86,10 +86,10 @@ class PointSelector(object):
             button_defs = []
 
         if session is not None:
-            sync_icon = load_icon(BUTTON_ICONS["sync"])
+            sync_icon = load_button_icon("sync")
             button_defs.append(("sync", sync_icon, self._onsync))
 
-        disconnect_icon = load_icon(BUTTON_ICONS["disconnect"])
+        disconnect_icon = load_button_icon("disconnect")
         button_defs.append(("disconnect", disconnect_icon, self._ondisconnect))
 
         self.collection = collection

--- a/fiftyone/utils/plot/selector.py
+++ b/fiftyone/utils/plot/selector.py
@@ -6,14 +6,10 @@ Point selection utilities.
 |
 """
 import itertools
-import math
 
 import numpy as np
-import matplotlib as mpl
 from matplotlib.widgets import Button, LassoSelector
 from matplotlib.path import Path
-import matplotlib.pyplot as plt
-from mpl_toolkits.axes_grid1 import make_axes_locatable
 from mpl_toolkits.axes_grid1.inset_locator import InsetPosition
 import sklearn.metrics.pairwise as skp
 
@@ -21,6 +17,8 @@ from fiftyone import ViewField as F
 from fiftyone.core.expressions import ObjectId
 import fiftyone.core.labels as fol
 import fiftyone.core.utils as fou
+
+from .utils import BUTTON_ICONS, load_icon
 
 
 class PointSelector(object):
@@ -55,8 +53,8 @@ class PointSelector(object):
         label_ids (None): a list of label IDs corresponding to ``collection``
         label_field (None): the sample field containing the labels in
             ``collection``
-        buttons (None): a dict mapping button names to callbacks defining
-            buttons to add to the plot
+        buttons (None): a list of ``(label, icon_image, callback)`` tuples
+            defining buttons to add to the plot
         alpha_other (0.25): a transparency value for unselected points
         expand_selected (3.0): expand the size of selected points by this
             amount
@@ -83,14 +81,16 @@ class PointSelector(object):
             label_ids = np.asarray(label_ids)
 
         if buttons is not None:
-            button_defs = list(buttons.items())
+            button_defs = list(buttons)
         else:
             button_defs = []
 
         if session is not None:
-            button_defs.append(("sync", self._onsync))
+            sync_icon = load_icon(BUTTON_ICONS["sync"])
+            button_defs.append(("sync", sync_icon, self._onsync))
 
-        button_defs.append(("disconnect", self._ondisconnect))
+        disconnect_icon = load_icon(BUTTON_ICONS["disconnect"])
+        button_defs.append(("disconnect", disconnect_icon, self._ondisconnect))
 
         self.collection = collection
         self.ax = collection.axes
@@ -365,11 +365,11 @@ class PointSelector(object):
 
             return _callback
 
-        for button, (_, callback) in zip(self._buttons, self._button_defs):
+        for button, (_, _, callback) in zip(self._buttons, self._button_defs):
             _callback = _make_callback(button, callback)
             button.on_clicked(_callback)
 
-        self._title.set_text("  Click or drag to select points")
+        self._title.set_text("Click or drag to select points")
 
         self._figure_events = [
             self._canvas.mpl_connect("figure_enter_event", self._onenter),
@@ -419,25 +419,21 @@ class PointSelector(object):
     def _init_hud(self):
         # Button styling
         gap = 0.02
-        width = 0.2
-        height = 0.1
-        color = "#DBEBFC"  # "#FFF0E5"
-        hovercolor = "#499CEF"  # "#FF6D04"
+        size = 0.1
+        color = "#DBEBFC"
+        hovercolor = "#499CEF"
 
-        self._title = self.ax.set_title("", loc="left")
+        self._title = self.ax.set_title("")
 
         num_buttons = len(self._button_defs)
         self._buttons = []
-        for i, (label, _) in enumerate(self._button_defs):
+        for i, (label, icon_img, _) in enumerate(self._button_defs):
             bax = self.ax.figure.add_axes([0, 0, 1, 1], label=label)
-            bpos = [
-                1 - (num_buttons - i) * width - (num_buttons - i - 1) * gap,
-                1 + gap,
-                width,
-                height,
-            ]
+            bpos = [1 + gap, 1 - (i + 1) * size - i * gap, size, size]
             bax.set_axes_locator(InsetPosition(self.ax, bpos))
-            button = Button(bax, label, color=color, hovercolor=hovercolor)
+            button = Button(
+                bax, "", color=color, hovercolor=hovercolor, image=icon_img
+            )
             self._buttons.append(button)
 
     def _update_hud(self, visible):
@@ -463,13 +459,13 @@ class PointSelector(object):
     def _onkeypress(self, event):
         if event.key == "shift":
             self._shift = True
-            self._title.set_text("  Click or drag to add/remove points")
+            self._title.set_text("Click or drag to add/remove points")
             self._canvas.draw_idle()
 
     def _onkeyrelease(self, event):
         if event.key == "shift":
             self._shift = False
-            self._title.set_text("  Click or drag to select points")
+            self._title.set_text("Click or drag to select points")
             self._canvas.draw_idle()
 
     def _onselect(self, vertices):

--- a/fiftyone/utils/plot/selector.py
+++ b/fiftyone/utils/plot/selector.py
@@ -1,0 +1,568 @@
+"""
+Point selection utilities.
+
+| Copyright 2017-2021, Voxel51, Inc.
+| `voxel51.com <https://voxel51.com/>`_
+|
+"""
+import math
+
+import numpy as np
+import matplotlib as mpl
+from matplotlib.widgets import Button, LassoSelector
+from matplotlib.path import Path
+import matplotlib.pyplot as plt
+from mpl_toolkits.axes_grid1 import make_axes_locatable
+from mpl_toolkits.axes_grid1.inset_locator import InsetPosition
+import sklearn.metrics.pairwise as skp
+
+from fiftyone import ViewField as F
+from fiftyone.core.expressions import ObjectId
+import fiftyone.core.utils as fou
+
+
+class PointSelector(object):
+    """Class that manages an interactive UI for selecting points in a
+    matplotlib plot.
+
+    The currently selected points are given a visually distinctive style, and
+    the user can modify their selection by either clicking on individual points
+    or drawing a lasso around new points.
+
+    When the shift key is pressed, new selections are added to the selected
+    set, or subtracted if the new selection is a subset of the current
+    selection.
+
+    You can provide a ``session`` object together with one of the following to
+    link the currently selected points to a FiftyOne App instance:
+
+    -   Sample selection: If ``sample_ids`` is provided, then when points are
+        selected, a view containing the corresponding samples will be loaded in
+        the App
+
+    -   Object selection: If ``object_ids`` and ``object_field`` are provided,
+        then when points are selected, a view containing the corresponding
+        objects in ``object_field`` will be loaded in the App
+
+    Args:
+        collection: a ``matplotlib.collections.Collection`` to select points
+            from
+        session (None): a :class:`fiftyone.core.session.Session` to link with
+            this selector
+        sample_ids (None): a list of sample IDs corresponding to ``collection``
+        object_ids (None): a list of object IDs corresponding to ``collection``
+        object_field (None): the sample field containing the objects in
+            ``collection``
+        alpha_other (0.25): a transparency value for unselected points
+        expand_selected (3.0): expand the size of selected points by this
+            amount
+        click_tolerance (0.02): a click distance tolerance in ``[0, 1]`` when
+            clicking individual points
+    """
+
+    def __init__(
+        self,
+        collection,
+        session=None,
+        sample_ids=None,
+        object_ids=None,
+        object_field=None,
+        alpha_other=0.25,
+        expand_selected=3.0,
+        click_tolerance=0.02,
+    ):
+        if sample_ids is not None:
+            sample_ids = np.asarray(sample_ids)
+
+        if object_ids is not None:
+            object_ids = np.asarray(object_ids)
+
+        self.collection = collection
+        self.ax = collection.axes
+        self.session = session
+        self.bidirectional = False
+        self.sample_ids = sample_ids
+        self.object_ids = object_ids
+        self.object_field = object_field
+        self.alpha_other = alpha_other
+        self.expand_selected = expand_selected
+        self.click_tolerance = click_tolerance
+
+        self._canvas = self.ax.figure.canvas
+        self._xy = collection.get_offsets()
+        self._num_pts = len(self._xy)
+        self._fc = collection.get_facecolors()
+        self._ms = collection.get_sizes()
+        self._init_ms = self._ms[0]
+        self._click_thresh = click_tolerance * min(
+            np.max(self._xy, axis=0) - np.min(self._xy, axis=0)
+        )
+
+        self._inds = np.array([], dtype=int)
+        self._selected_sample_ids = None
+        self._selected_object_ids = None
+        self._canvas.mpl_connect("close_event", lambda e: self._disconnect())
+
+        self._connected = False
+        self._session = None
+        self._lock_session = False
+        self._init_view = None
+        self._lasso = None
+        self._shift = False
+        self._title = None
+        self._sync_button = None
+        self._disconnect_button = None
+        self._figure_events = []
+        self._keypress_events = []
+
+        self._init_hud()
+
+        self.connect()
+
+    @property
+    def is_connected(self):
+        """Whether this selector is currently linked to its plot and session
+        (if any).
+        """
+        return self._connected
+
+    @property
+    def has_linked_session(self):
+        """Whether this object has a linked
+        :class:`fiftone.core.session.Session` that can be updated when points
+        are selected.
+        """
+        return self._session is not None
+
+    @property
+    def is_selecting_samples(self):
+        """Whether this selector is selecting samples from a collection."""
+        return self.sample_ids is not None
+
+    @property
+    def is_selecting_objects(self):
+        """Whether this selector is selecting objects from a field of a sample
+        collection.
+        """
+        return self.object_ids is not None and self.object_field is not None
+
+    @property
+    def any_selected(self):
+        """Whether any points are currently selected."""
+        return self._inds.size > 0
+
+    @property
+    def selected_inds(self):
+        """A list of indices of the currently selected points."""
+        return list(self._inds)
+
+    @property
+    def selected_samples(self):
+        """A list of the currently selected samples, or None if
+        :meth:`is_selecting_samples` is False.
+        """
+        return self._selected_sample_ids
+
+    @property
+    def selected_objects(self):
+        """A list of the currently selected objects, or None if
+        :meth:`is_selecting_objects` is False.
+        """
+        return self._selected_object_ids
+
+    def select_samples(self, sample_ids):
+        """Selects the points corresponding to the given sample IDs.
+
+        Args:
+            sample_ids: a list of sample IDs
+        """
+        if not self.is_selecting_samples:
+            raise ValueError("This selector cannot select samples")
+
+        _sample_ids = set(sample_ids)
+        inds = np.nonzero([_id in _sample_ids for _id in self.sample_ids])[0]
+        self._select_inds(inds)
+
+    def select_objects(self, object_ids):
+        """Selects the points corresponding to the objects with the given IDs.
+
+        Args:
+            object_ids: a list of object IDs
+        """
+        if not self.is_selecting_objects:
+            raise ValueError("This selector cannot select objects")
+
+        _object_ids = set(object_ids)
+        inds = np.nonzero([_id in _object_ids for _id in self.object_ids])[0]
+        self._select_inds(inds)
+
+    def select_session(self):
+        """Selects the contents of the currently linked session.
+
+        The rules listed below are used to determine what to select.
+
+        If this selector is selecting samples:
+
+        -   If samples are selected in the session (``session.selected``), only
+            select those
+        -   Otherwise, select all samples in the current view
+
+        If this selector is selecting objects:
+
+        -   If objects are selected in the session
+            (``session.selected_objects``), only select those
+        -   Else if samples are selected (``session.selected``), only select
+            their objects
+        -   Otherwise, select all objects in the current view
+        """
+        if not self.has_linked_session:
+            raise ValueError("This selector is not linked to a session")
+
+        if self._lock_session:
+            return
+
+        if self._session.view is not None:
+            view = self._session.view
+        else:
+            view = self._session.dataset
+
+        if self.is_selecting_samples:
+            if self._session.selected:
+                sample_ids = self._session.selected
+            else:
+                sample_ids = self._get_selected_samples(view)
+
+            # Lock the session so that it is not updated, since we are
+            # responding to the state of the current session
+            with fou.SetAttributes(self, _lock_session=True):
+                self.select_samples(sample_ids)
+
+        if self.is_selecting_objects:
+            if self._session.selected_objects:
+                object_ids = [
+                    o["object_id"] for o in self._session.selected_objects
+                ]
+            else:
+                selected = self._session.selected or None
+                object_ids = self._get_selected_objects(
+                    view, self.object_field, selected=selected
+                )
+
+            # Lock the session so that it is not updated, since we are
+            # responding to the state of the current session
+            with fou.SetAttributes(self, _lock_session=True):
+                self.select_objects(object_ids)
+
+    def tag_selected(self, tag):
+        """Adds the tag to the currently selected samples/objects, if
+        necessary.
+
+        Args:
+            tag: a tag
+        """
+        view = self.selected_view()
+
+        if view is None:
+            return
+
+        if self.is_selecting_samples:
+            view.tag_samples(tag)
+
+        if self.is_selecting_objects:
+            view.tag_objects(tag, label_fields=[self.object_field])
+
+        self.refresh()
+
+    def untag_selected(self, tag):
+        """Removes the tag from the currently selected samples/objects, if
+        necessary.
+
+        Args:
+            tag: a tag
+        """
+        view = self.selected_view()
+
+        if view is None:
+            return
+
+        if self.is_selecting_samples:
+            view.untag_samples(tag)
+
+        if self.is_selecting_objects:
+            view.untag_objects(tag, label_fields=[self.object_field])
+
+        self.refresh()
+
+    def selected_view(self):
+        """Returns a :class:`fiftyone.core.view.DatasetView` containing the
+        currently selected samples/objects.
+
+        Returns:
+            a :class:`fiftyone.core.view.DatasetView`, or None if no points are
+            selected
+        """
+        if not self.has_linked_session:
+            raise ValueError("This selector is not linked to a session")
+
+        if not self.any_selected:
+            return None
+
+        if self.is_selecting_samples:
+            return self._init_view.select(self._selected_sample_ids)
+
+        if self.is_selecting_objects:
+            _object_ids = [ObjectId(_id) for _id in self._selected_object_ids]
+            return self._init_view.select_fields(
+                self.object_field
+            ).filter_labels(self.object_field, F("_id").is_in(_object_ids))
+
+        return None
+
+    def connect(self):
+        """Connects this selector to its plot and session (if any)."""
+        if self.is_connected:
+            return
+
+        session = self.session
+        if session is not None:
+            if session.view is not None:
+                self._init_view = session.view
+            else:
+                self._init_view = session.dataset.view()
+
+            if self.bidirectional:
+                session.add_listener("point_selector", self._onsessionupdate)
+
+        self._lasso = LassoSelector(self.ax, onselect=self._onselect)
+        self._session = session
+
+        self._title.set_text("  Click or drag to select points")
+        self._sync_button.on_clicked(self._onsync)
+        self._disconnect_button.on_clicked(self._ondisconnect)
+
+        self._figure_events = [
+            self._canvas.mpl_connect("figure_enter_event", self._onenter),
+            self._canvas.mpl_connect("figure_leave_event", self._onexit),
+        ]
+
+        self._keypress_events = [
+            self._canvas.mpl_connect("key_press_event", self._onkeypress),
+            self._canvas.mpl_connect("key_release_event", self._onkeyrelease),
+        ]
+
+        self._update_hud(False)
+
+        self._connected = True
+
+        self._canvas.draw_idle()
+
+    def refresh(self):
+        """Refreshes the selector's plot and linked session (if any)."""
+        self._canvas.draw_idle()
+        if not self._lock_session:
+            self._update_session()
+
+    def disconnect(self,):
+        """Disconnects this selector from its plot and sesssion (if any)."""
+        if not self.is_connected:
+            return
+
+        self._lasso.disconnect_events()
+        self._lasso = None
+
+        for cid in self._figure_events:
+            self._canvas.mpl_disconnect(cid)
+
+        for cid in self._keypress_events:
+            self._canvas.mpl_disconnect(cid)
+
+        self._shift = False
+        self._figure_events = []
+        self._keypress_events = []
+        self._update_hud(False)
+
+        self._canvas.draw_idle()
+
+        self._disconnect()
+
+    def _init_hud(self):
+        # button sizing
+        gap = 0.02
+        width = 0.2
+        height = 0.1
+        color = "#DBEBFC"  # "#FFF0E5"
+        hovercolor = "#499CEF"  # "#FF6D04"
+
+        self._title = self.ax.set_title("", loc="left")
+
+        rax = self.ax.figure.add_axes([0, 0, 1, 1], label="refresh")
+        rax.set_axes_locator(
+            InsetPosition(
+                self.ax, [1 - 2 * width - gap, 1 + gap, width, height]
+            )
+        )
+        self._sync_button = Button(
+            rax, "sync", color=color, hovercolor=hovercolor
+        )
+
+        dax = self.ax.figure.add_axes([0, 0, 1, 1], label="disconnect")
+        dax.set_axes_locator(
+            InsetPosition(self.ax, [1 - width, 1 + gap, width, height])
+        )
+        self._disconnect_button = Button(
+            dax, "disconnect", color=color, hovercolor=hovercolor
+        )
+
+    def _update_hud(self, visible):
+        self._title.set_visible(visible)
+        self._sync_button.ax.set_visible(visible and self.has_linked_session)
+        self._disconnect_button.ax.set_visible(visible)
+
+    def _disconnect(self):
+        if self.session is not None and self.bidirectional:
+            self.session.delete_listener("point_selector")
+
+        self._session = None
+        self._connected = False
+
+    def _onenter(self, event):
+        self._update_hud(True)
+        self._canvas.draw_idle()
+
+    def _onexit(self, event):
+        self._update_hud(False)
+        self._canvas.draw_idle()
+
+    def _onkeypress(self, event):
+        if event.key == "shift":
+            self._shift = True
+            self._title.set_text("  Click or drag to add/remove points")
+            self._canvas.draw_idle()
+
+    def _onkeyrelease(self, event):
+        if event.key == "shift":
+            self._shift = False
+            self._title.set_text("  Click or drag to select points")
+            self._canvas.draw_idle()
+
+    def _onselect(self, vertices):
+        if self._is_click(vertices):
+            dists = skp.euclidean_distances(self._xy, np.array([vertices[0]]))
+            click_ind = np.argmin(dists)
+            if dists[click_ind] < self._click_thresh:
+                inds = [click_ind]
+            else:
+                inds = []
+
+            inds = np.array(inds, dtype=int)
+        else:
+            path = Path(vertices)
+            inds = np.nonzero(path.contains_points(self._xy))[0]
+
+        self._select_inds(inds)
+
+    def _onsessionupdate(self):
+        self.select_session()
+
+    def _onsync(self, event):
+        # Change to non-hover color to convey to user that something happened
+        # https://stackoverflow.com/a/28079210
+        self._sync_button.ax.set_facecolor(self._sync_button.color)
+        self._canvas.draw_idle()
+        self.select_session()
+
+    def _ondisconnect(self, event):
+        self.disconnect()
+
+    def _is_click(self, vertices):
+        return np.abs(np.diff(vertices, axis=0)).sum() < self._click_thresh
+
+    def _select_inds(self, inds):
+        if self._shift:
+            new_inds = set(inds)
+            inds = set(self._inds)
+            if new_inds.issubset(inds):
+                # The new selection is a subset of the current selection, so
+                # remove the selection
+                inds.difference_update(new_inds)
+            else:
+                # The new selection contains new points, so add them
+                inds.update(new_inds)
+
+            inds = np.array(sorted(inds), dtype=int)
+        else:
+            inds = np.unique(inds)
+
+        if inds.size == self._inds.size and np.all(inds == self._inds):
+            self._canvas.draw_idle()
+            return
+
+        self._inds = inds
+
+        if self.is_selecting_samples:
+            self._selected_sample_ids = list(self.sample_ids[inds])
+
+        if self.is_selecting_objects:
+            self._selected_object_ids = list(self.object_ids[inds])
+
+        self._update_plot()
+        self.refresh()
+
+    def _update_plot(self):
+        self._prep_collection()
+
+        inds = self._inds
+        if inds.size == 0:
+            self._fc[:, -1] = 1
+        else:
+            self._fc[:, -1] = self.alpha_other
+            self._fc[inds, -1] = 1
+
+        self.collection.set_facecolors(self._fc)
+
+        if self.expand_selected is not None:
+            self._ms[:] = self._init_ms
+            self._ms[inds] = self.expand_selected * self._init_ms
+
+        self.collection.set_sizes(self._ms)
+
+    def _update_session(self):
+        if not self.has_linked_session:
+            return
+
+        if self.any_selected:
+            view = self.selected_view()
+        else:
+            view = self._init_view
+
+        with fou.SetAttributes(self, _lock_session=True):
+            self._session.view = view
+
+    def _prep_collection(self):
+        # @todo why is this necessary? We do this JIT here because it seems
+        # that when __init__() runs, `get_facecolors()` doesn't have all the
+        # data yet...
+        if len(self._fc) < self._num_pts:
+            self._fc = self.collection.get_facecolors()
+
+        if len(self._fc) < self._num_pts:
+            self._fc = np.tile(self._fc[0], (self._num_pts, 1))
+
+        if self.expand_selected is not None:
+            if len(self._ms) < self._num_pts:
+                self._ms = np.tile(self._ms[0], self._num_pts)
+
+    @staticmethod
+    def _get_selected_samples(view, selected=None):
+        if selected is not None:
+            view = view.select(selected)
+
+        return [str(_id) for _id in view._get_sample_ids()]
+
+    @staticmethod
+    def _get_selected_objects(view, object_field, selected=None):
+        if selected is not None:
+            view = view.select(selected)
+
+        _, id_path = view._get_label_field_path(object_field, "_id")
+        return [str(_id) for _id in view.values(id_path)]

--- a/fiftyone/utils/plot/selector.py
+++ b/fiftyone/utils/plot/selector.py
@@ -118,6 +118,10 @@ class PointSelector(object):
         self._selected_label_ids = None
         self._canvas.mpl_connect("close_event", lambda e: self._disconnect())
 
+        # Hides the pesky `Figure X` header visible in notebooks
+        # https://github.com/matplotlib/ipympl/issues/134
+        self._canvas.header_visible = False
+
         self._connected = False
         self._session = None
         self._lock_session = False
@@ -555,7 +559,10 @@ class PointSelector(object):
             view = self._init_view
 
         with fou.SetAttributes(self, _lock_session=True):
-            self._session.view = view
+            # Temporarily set `session._auto` to False since this update should
+            # not spawn a new App instance in notebook contexts
+            with fou.SetAttributes(self._session, _auto=False):
+                self._session.view = view
 
     def _prep_collection(self):
         # @todo why is this necessary? We do this JIT here because it seems

--- a/fiftyone/utils/plot/utils.py
+++ b/fiftyone/utils/plot/utils.py
@@ -22,6 +22,20 @@ BUTTON_ICONS = {
 }
 
 
+def load_button_icon(name):
+    """Loads the button icon with the given name.
+
+    The available buttons are :const:`BUTTON_ICONS`.
+
+    Args:
+        name: the button name
+
+    Returns:
+        the numpy image
+    """
+    return load_icon(BUTTON_ICONS[name])
+
+
 def load_icon(icon_bytes):
     """Loads the icon image from bytes.
 

--- a/fiftyone/utils/plot/utils.py
+++ b/fiftyone/utils/plot/utils.py
@@ -1,0 +1,73 @@
+"""
+Plotting utils.
+
+| Copyright 2017-2021, Voxel51, Inc.
+| `voxel51.com <https://voxel51.com/>`_
+|
+"""
+import os
+
+import numpy as np
+
+import eta.core.image as etai
+import eta.core.serial as etas
+import eta.core.utils as etau
+
+
+# Original images from https://www.iconfinder.com
+BUTTON_ICONS = {
+    "map": "eJztk79LG2Ech9+jcgdddFKaLDcYTiWNuCTQVeymyWCGTiXEJEdbGklMl7aT4FKERAeJk/4Dpd1bx3avm0bQrFl00Io/+nr33q/3vfu+74VS6PI+w4V88+QZPiHbS8XFwgsFvUPvjZVKs9wwnunGh9ackdaNar2x1ii9fVlvrFTs+/PSm2bFujfN0mrFej+Vy6b1XHY6rX/U/5LHSCL5LxQ3ng7lZQoTMUbqBGN8+iS2lPqK8eWCyBjbvMM2v9vi2tjmja0d8Y0Rc4A9rjuJITyuMn+Iabg1yuOU7AFCgDXGA0vuALG1kCccAF+R5xlcowfltIIB7rtl8qpWqdpWEvBegS1qgINZtOw6aq0fqsEeZ4BeXkGUw9ZmuJ6HUvUHuGhq9oV26BoWeA7r/gA7486FdbRwjePZnLvKN//vHHbYGt9DyDGOlxTEdzTTq4k9cvihUhfo99FMctwTe+SwjITOsJ5syZZsyZZsyZZsyRZB3ScnU4tpqT/jWkr+GDv02RrP4zuZ7ziAqXG8c15rvHuPGfo1NcZbh1ta6wJH8GugN6gqUEsp9Dzj5tPM1rVfO3NqoDeKENCaPfC//GXSOifDNY4Xbb3e/eMZv+bdDxIdpkZey4AXbvkMao+Cj5gaeV6BHtiKDEDXRF60FR0ArkEe24IGgGo8L2jBA7i1dlATeehINEC4div2Fi6tAVLCEql9tlK9OG+ikIkt2aQ3ikN5Esk/5wFTASSi",
+    "sync": "eJztll9IU1Ecx28u7zWVCp1BS2tPbtP1UISDIIIeon8zJ/2hBwnJifRHZTezKImQ2V5FEgwpIoIKzTR76yGSWAZFT6EvZS77o840N/8s9XbVc86uu+fcc67tKfZ92u73y+ee39nvd86aCo87i06t4S5xVy1lbvGMx7LbbLlWs8NiN1vKqzwXPaWVp6s8Ze7F5/tLz4tu+blYUVrtlr9bHQV2s6PAZjfXmVepVC6hhBKKkcEhtvYMBCML4UDv/Zo9PDLyusOhLis7iC9un5BWKPTkpLCMWjLGWWFGb1DCKNiwSTa7l790MpHSfGEcaVFhbzoHzEkWlCtAIi0q4ISf6KSU21okpaio7A+sKCrL+oUZRWNZh5Xheb/XlZ/BJ623FTX0LuhkZStXNVhrUno5dd/1sFIUezVSnqyyxXF2Vks09yADF9j8nJXlQqmIW2XKM6hjv9JRi4YPqlETsSRNlg+t6oDa7FajNFhZqAZ1gRyHG1Ayy4u2HeeG1CjybPPwkBnG/oJdalYHkVUMI+VY2zoeixrLJbLaQWRQ1aIA1jm5osAOMmrtbxCqJUaY5QCoeRM9S5MIWP5/R3GtgOWNA6sHsFxxYA0AVn4cWLBTsY2qUxHA4unR+LN2vpgOP8vDWnprtC1NwYQN5+ndezBybTgP9kQxG0qYBgOOM2GvNrCx9oH4DM70APMNG6sJxPtxJprtLSwoHl7v93CuAd4zl1lYJfAYO4G124AbYOiwpI/wREzH+uiiraCz3DDbivf5UeCPZtJQWXC3FuyERD182UMaC26H9JSUyERXIKXKKpibIw8Jumz/HNZCOedgrpkcSkV/5KY0YIemYGpoo8YbCyW0srOkTFkEhY5orZ5rRjnpkREX2HA3mmjURHHC+2g0eE6ItQ0l36L+a8L9jmT6HA1LQ1dylF7mhT6F2ZdFQXFc7k9FXpp/e/PYdqMgGG2u668iSiewlYqSYcqVEdW/jQEll/mOjuqlF7gs4RYN1ajj4nMOaJG+HmUnyUqtnySRZn1pulCyMm6M4EhjPqYjPFbJhY9/rQSF2kt0rwnJsKu65eWnkdmZH/3+O5V7160alFBC/63+Asl9Dog=",
+    "disconnect": "eJztmG9IE2Ecx28ribQ/qGQUledGTHFSYWpYRilYUYqCRoYh1i6tLG2rREosaC8Mk2gQlI2cK6NQ8nUJ0ZtSiBaCEigpkdpfnTqkctu16e+5u9nzPHc4e7fvu/t+v8/n7rk9z90xS25hTl6RirnEXNYZONMJoy6d1V25uE2nZ3UnK40XjKXnSiqNBs7vZ5dWmDifbyovreJ8x/FpqXo2LTVBz9ayC1Q4E1JIIf1vxZjs9vNrFgV1dIr3afLwIqAOeflZebKDRqk/8qAPqmBZKbygLcGyCkVWXrCsIyKrYAHDUzumXG0aMkvb7ppxHFSEOubxD/wWR2Jpv8/+rEUKUAfccyOfkljtc0d/smRRm50wcorEcsHhWJwMKuwdGumUY/HdS+msq8LIFhLrmWDUUFGaX6g3up7ESvYgY3ojjfUY1b4mMCQWwwmOjYKKR6ecTkYWbq3WI8etwXP8uoNKnGDh9tCSN8i6RUSFT0DluehtF1lJgpk4A9bPZSQWugZPouipBxCqT9K8h8wcEssOhTapuQ/uoTtTYmrRjb1PYo1AITPALZyd+Xh+gNkJ1SECKhbyUXWgH11htZ6JCvTK0CTX4Vm5EDeTrlsiLWLtx+cmiMsUsJgfUD6Ljxsh3qWE9RrK9fjYBjGrhNUG5SZ8/ATiaCWsB1B+iI9bIY5RwkJrkbC970JM2bCiOqBswcc3IN6thPUWymZ8fBpigwKUaoJezoLYqoClR2s1A5/HQDyogFUJXW8kodALhR3yrC6oOkgFCxSIDxJBwhQbSI09UPi9QY71CLHSSQ3VEDRaZFAp6FHYT+7UotPRvxXC0OLiq8mlyEnojFD30U2EGltJaZlRqzuCXBLftXW0M674jGovV5E6JW7UGVxOYzEFwjkd+E8idZ3Q4HOpKIZpEZrOYkzMvhBRssswok8sv5q/2aKvT4tpD32Gfmm+iHW+69RaIQjba3VJouFNsiiG2erkpeq115YXH6+63ekKsMeT5El+2Cgvq2FlKN80e+VQPbEKUb6Pp2Y6qkn+tkuU/4lMGpJbV/MVcc2JJ43VLeD/pNU1A/+S+quJe0tGOxvfe0WO19FAfPQpUlQGZ7bYbBazIYP0mggppJAWSX8Bi5hqdQ==",
+}
+
+
+def load_icon(icon_bytes):
+    """Loads the icon image from bytes.
+
+    Args:
+        icon_bytes:
+
+    Returns:
+        the numpy image
+    """
+    alpha = etas.deserialize_numpy_array(icon_bytes)
+    h, w = alpha.shape
+    img = np.zeros((h, w, 4), dtype=alpha.dtype)
+    img[:, :, -1] = alpha
+    return img
+
+
+def serialize_icon(img):
+    """Serializes the icon image into a compressed bytes representation.
+
+    The icon must be defined purely by alpha-channel values.
+
+    Args:
+        img: a numpy image
+
+    Returns:
+        a bytes string
+    """
+    if img.shape[2] < 4 or np.any(img[:, :, :-1] > 0):
+        raise ValueError("Image must be alpha-only")
+
+    alpha = img[:, :, -1]
+    return etas.serialize_numpy_array(alpha)
+
+
+def pad_icon(img, pad, fill=0):
+    """Pads the icon by the
+
+    Args:
+        img: a numpy image
+        pad: the number of pixels of padding
+        fill (0): the fill value
+
+    Returns:
+         a numpy image
+    """
+    h, w, c = img.shape[:3]
+    img_pad = np.full((h + 2 * pad, w + 2 * pad, c), fill, dtype=img.dtype)
+    img_pad[pad : (pad + h), pad : (pad + w), :] = img
+    return img_pad

--- a/tests/intensive/collections_tests.py
+++ b/tests/intensive/collections_tests.py
@@ -142,39 +142,39 @@ def test_tag_classification():
 
     view = dataset.take(100)
 
-    view.tag_objects("test", "ground_truth")
-    print(dataset.count_object_tags("ground_truth"))
+    view.tag_labels("test", "ground_truth")
+    print(dataset.count_label_tags("ground_truth"))
 
-    view.untag_objects("test", "ground_truth")
-    print(dataset.count_object_tags("ground_truth"))
+    view.untag_labels("test", "ground_truth")
+    print(dataset.count_label_tags("ground_truth"))
 
 
 def test_tag_detections():
     dataset = foz.load_zoo_dataset("quickstart").clone()
-    print(dataset.count_object_tags("predictions"))
+    print(dataset.count_label_tags("predictions"))
 
     view = dataset.filter_labels("predictions", F("confidence") > 0.99)
 
-    view.tag_objects("test", "predictions")
-    print(dataset.count_object_tags("predictions"))
+    view.tag_labels("test", "predictions")
+    print(dataset.count_label_tags("predictions"))
 
-    view.untag_objects("test", "predictions")
-    print(dataset.count_object_tags("predictions"))
+    view.untag_labels("test", "predictions")
+    print(dataset.count_label_tags("predictions"))
 
 
 def test_tag_detections_frames():
     dataset = foz.load_zoo_dataset("quickstart-video").clone()
     dataset.rename_frame_field("ground_truth_detections", "ground_truth")
 
-    print(dataset.count_object_tags("frames.ground_truth"))
+    print(dataset.count_label_tags("frames.ground_truth"))
 
     view = dataset.filter_labels("frames.ground_truth", F("index") == 1)
 
-    view.tag_objects("test", "frames.ground_truth")
-    print(dataset.count_object_tags("frames.ground_truth"))
+    view.tag_labels("test", "frames.ground_truth")
+    print(dataset.count_label_tags("frames.ground_truth"))
 
-    view.untag_objects("test", "frames.ground_truth")
-    print(dataset.count_object_tags("frames.ground_truth"))
+    view.untag_labels("test", "frames.ground_truth")
+    print(dataset.count_label_tags("frames.ground_truth"))
 
 
 def _to_upper(values):

--- a/tests/intensive/collections_tests.py
+++ b/tests/intensive/collections_tests.py
@@ -131,10 +131,10 @@ def test_tag_classification():
     view = dataset.take(100)
 
     view.tag_objects("test", "ground_truth")
-    print(dataset.count_values("ground_truth.tags[]"))
+    print(dataset.count_values("ground_truth.tags"))
 
     view.untag_objects("test", "ground_truth")
-    print(dataset.count_values("ground_truth.tags[]"))
+    print(dataset.count_values("ground_truth.tags"))
 
 
 def test_tag_detections():
@@ -144,13 +144,13 @@ def test_tag_detections():
 
     print(dataset.count("predictions.detections"))
     print(view.count("predictions.detections"))
-    print(dataset.count_values("predictions.detections.tags[]"))
+    print(dataset.count_values("predictions.detections.tags"))
 
     view.tag_objects("test", "predictions")
-    print(dataset.count_values("predictions.detections.tags[]"))
+    print(dataset.count_values("predictions.detections.tags"))
 
     view.untag_objects("test", "predictions")
-    print(dataset.count_values("predictions.detections.tags[]"))
+    print(dataset.count_values("predictions.detections.tags"))
 
 
 def test_tag_detections_frames():
@@ -161,15 +161,15 @@ def test_tag_detections_frames():
 
     print(dataset.count("frames.predictions.detections"))
     print(view.count("frames.predictions.detections"))
-    print(dataset.count_values("frames.predictions.detections.tags[]"))
+    print(dataset.count_values("frames.predictions.detections.tags"))
 
     view.tag_objects("test", "frames.predictions")
     print(dataset.count("frames.predictions.detections"))
-    print(dataset.count_values("frames.predictions.detections.tags[]"))
+    print(dataset.count_values("frames.predictions.detections.tags"))
 
     view.untag_objects("test", "frames.predictions")
     print(dataset.count("frames.predictions.detections"))
-    print(dataset.count_values("frames.predictions.detections.tags[]"))
+    print(dataset.count_values("frames.predictions.detections.tags"))
 
 
 def _to_upper(values):

--- a/tests/intensive/collections_tests.py
+++ b/tests/intensive/collections_tests.py
@@ -125,51 +125,56 @@ def test_set_values_frames():
     print(view.count_values(path_check))
 
 
+def test_tag_samples():
+    dataset = foz.load_zoo_dataset("imagenet-sample").clone()
+
+    view = dataset.take(100)
+
+    view.tag_samples("test")
+    print(dataset.count_sample_tags())
+
+    view.untag_samples("test")
+    print(dataset.count_sample_tags())
+
+
 def test_tag_classification():
     dataset = foz.load_zoo_dataset("imagenet-sample").clone()
 
     view = dataset.take(100)
 
     view.tag_objects("test", "ground_truth")
-    print(dataset.count_values("ground_truth.tags"))
+    print(dataset.count_object_tags("ground_truth"))
 
     view.untag_objects("test", "ground_truth")
-    print(dataset.count_values("ground_truth.tags"))
+    print(dataset.count_object_tags("ground_truth"))
 
 
 def test_tag_detections():
     dataset = foz.load_zoo_dataset("quickstart").clone()
+    print(dataset.count_object_tags("predictions"))
 
     view = dataset.filter_labels("predictions", F("confidence") > 0.99)
 
-    print(dataset.count("predictions.detections"))
-    print(view.count("predictions.detections"))
-    print(dataset.count_values("predictions.detections.tags"))
-
     view.tag_objects("test", "predictions")
-    print(dataset.count_values("predictions.detections.tags"))
+    print(dataset.count_object_tags("predictions"))
 
     view.untag_objects("test", "predictions")
-    print(dataset.count_values("predictions.detections.tags"))
+    print(dataset.count_object_tags("predictions"))
 
 
 def test_tag_detections_frames():
     dataset = foz.load_zoo_dataset("quickstart-video").clone()
-    dataset.rename_frame_field("ground_truth_detections", "predictions")
+    dataset.rename_frame_field("ground_truth_detections", "ground_truth")
 
-    view = dataset.filter_labels("frames.predictions", F("index") == 1)
+    print(dataset.count_object_tags("frames.ground_truth"))
 
-    print(dataset.count("frames.predictions.detections"))
-    print(view.count("frames.predictions.detections"))
-    print(dataset.count_values("frames.predictions.detections.tags"))
+    view = dataset.filter_labels("frames.ground_truth", F("index") == 1)
 
-    view.tag_objects("test", "frames.predictions")
-    print(dataset.count("frames.predictions.detections"))
-    print(dataset.count_values("frames.predictions.detections.tags"))
+    view.tag_objects("test", "frames.ground_truth")
+    print(dataset.count_object_tags("frames.ground_truth"))
 
-    view.untag_objects("test", "frames.predictions")
-    print(dataset.count("frames.predictions.detections"))
-    print(dataset.count_values("frames.predictions.detections.tags"))
+    view.untag_objects("test", "frames.ground_truth")
+    print(dataset.count_object_tags("frames.ground_truth"))
 
 
 def _to_upper(values):

--- a/tests/intensive/collections_tests.py
+++ b/tests/intensive/collections_tests.py
@@ -125,6 +125,53 @@ def test_set_values_frames():
     print(view.count_values(path_check))
 
 
+def test_tag_classification():
+    dataset = foz.load_zoo_dataset("imagenet-sample").clone()
+
+    view = dataset.take(100)
+
+    view.tag_objects("test", "ground_truth")
+    print(dataset.count_values("ground_truth.tags[]"))
+
+    view.untag_objects("test", "ground_truth")
+    print(dataset.count_values("ground_truth.tags[]"))
+
+
+def test_tag_detections():
+    dataset = foz.load_zoo_dataset("quickstart").clone()
+
+    view = dataset.filter_labels("predictions", F("confidence") > 0.99)
+
+    print(dataset.count("predictions.detections"))
+    print(view.count("predictions.detections"))
+    print(dataset.count_values("predictions.detections.tags[]"))
+
+    view.tag_objects("test", "predictions")
+    print(dataset.count_values("predictions.detections.tags[]"))
+
+    view.untag_objects("test", "predictions")
+    print(dataset.count_values("predictions.detections.tags[]"))
+
+
+def test_tag_detections_frames():
+    dataset = foz.load_zoo_dataset("quickstart-video").clone()
+    dataset.rename_frame_field("ground_truth_detections", "predictions")
+
+    view = dataset.filter_labels("frames.predictions", F("index") == 1)
+
+    print(dataset.count("frames.predictions.detections"))
+    print(view.count("frames.predictions.detections"))
+    print(dataset.count_values("frames.predictions.detections.tags[]"))
+
+    view.tag_objects("test", "frames.predictions")
+    print(dataset.count("frames.predictions.detections"))
+    print(dataset.count_values("frames.predictions.detections.tags[]"))
+
+    view.untag_objects("test", "frames.predictions")
+    print(dataset.count("frames.predictions.detections"))
+    print(dataset.count_values("frames.predictions.detections.tags[]"))
+
+
 def _to_upper(values):
     if isinstance(values, list):
         return [_to_upper(v) for v in values]

--- a/tests/intensive/utils_plot_tests.py
+++ b/tests/intensive/utils_plot_tests.py
@@ -1,0 +1,31 @@
+"""
+Tests for the ::`fiftyone.utils.plot.selector` module.
+
+| Copyright 2017-2021, Voxel51, Inc.
+| `voxel51.com <https://voxel51.com/>`_
+|
+"""
+import unittest
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+import fiftyone as fo
+from fiftyone.utils.plot.selector import PointSelector
+
+
+def test_point_selector():
+    fig, ax = plt.subplots()
+
+    data = np.random.rand(100, 2)
+    pts = ax.scatter(data[:, 0], data[:, 1], s=80)
+    selector = PointSelector(pts)
+
+    plt.show(block=False)
+
+    input("Press enter to continue...")
+
+
+if __name__ == "__main__":
+    fo.config.show_progress_bars = True
+    unittest.main(verbosity=2)

--- a/tests/misc/selection_tests.py
+++ b/tests/misc/selection_tests.py
@@ -15,59 +15,59 @@ import fiftyone.zoo as foz
 
 
 class SelectionTests(unittest.TestCase):
-    def test_select_objects(self):
+    def test_select_labels(self):
         num_samples_to_select = 5
-        max_objects_per_sample_to_select = 3
+        max_labels_per_sample_to_select = 3
 
         dataset = foz.load_zoo_dataset(
             "quickstart", dataset_name=fod.get_default_dataset_name(),
         )
 
         # Generate some random selections
-        selected_objects = []
+        selected_labels = []
         for sample in dataset.take(num_samples_to_select):
             detections = sample.ground_truth.detections
 
-            max_num_objects = min(
-                len(detections), max_objects_per_sample_to_select
+            max_num_labels = min(
+                len(detections), max_labels_per_sample_to_select
             )
-            if max_num_objects >= 1:
-                num_objects = random.randint(1, max_num_objects)
+            if max_num_labels >= 1:
+                num_labels = random.randint(1, max_num_labels)
             else:
-                num_objects = 0
+                num_labels = 0
 
-            for detection in random.sample(detections, num_objects):
-                selected_objects.append(
+            for detection in random.sample(detections, num_labels):
+                selected_labels.append(
                     {
                         "sample_id": sample.id,
                         "field": "ground_truth",
-                        "object_id": detection.id,
+                        "label_id": detection.id,
                     }
                 )
 
-        selected_view = dataset.select_objects(selected_objects)
-        excluded_view = dataset.exclude_objects(selected_objects)
+        selected_view = dataset.select_labels(selected_labels)
+        excluded_view = dataset.exclude_labels(selected_labels)
 
-        total_objects = _count_detections(dataset, "ground_truth")
-        num_selected_objects = len(selected_objects)
-        num_objects_in_selected_view = _count_detections(
+        total_labels = _count_detections(dataset, "ground_truth")
+        num_selected_labels = len(selected_labels)
+        num_labels_in_selected_view = _count_detections(
             selected_view, "ground_truth"
         )
-        num_objects_in_excluded_view = _count_detections(
+        num_labels_in_excluded_view = _count_detections(
             excluded_view, "ground_truth"
         )
-        num_objects_excluded = total_objects - num_objects_in_excluded_view
+        num_labels_excluded = total_labels - num_labels_in_excluded_view
 
-        self.assertEqual(num_selected_objects, num_objects_in_selected_view)
-        self.assertEqual(num_selected_objects, num_objects_excluded)
+        self.assertEqual(num_selected_labels, num_labels_in_selected_view)
+        self.assertEqual(num_selected_labels, num_labels_excluded)
 
 
 def _count_detections(sample_collection, label_field):
-    num_objects = 0
+    num_labels = 0
     for sample in sample_collection:
-        num_objects += len(sample[label_field].detections)
+        num_labels += len(sample[label_field].detections)
 
-    return num_objects
+    return num_labels
 
 
 if __name__ == "__main__":

--- a/tests/unittests/view_tests.py
+++ b/tests/unittests/view_tests.py
@@ -906,11 +906,11 @@ class ViewStageTests(unittest.TestCase):
         self.assertEqual(num_samples, 1)
 
         view.tag_objects("test", "test_clf")
-        tags = self.dataset.count_values("test_clf.tags")
+        tags = self.dataset.count_object_tags("test_clf")
         self.assertDictEqual(tags, {"test": 1})
 
         view.untag_objects("test", "test_clf")
-        tags = self.dataset.count_values("test_clf.tags")
+        tags = self.dataset.count_object_tags("test_clf")
         self.assertDictEqual(tags, {})
 
         view = self.dataset.filter_labels("test_dets", F("confidence") > 0.7)
@@ -920,11 +920,11 @@ class ViewStageTests(unittest.TestCase):
         self.assertEqual(num_objects, 3)
 
         view.tag_objects("test", "test_dets")
-        tags = self.dataset.count_values("test_dets.detections.tags")
+        tags = self.dataset.count_object_tags("test_dets")
         self.assertDictEqual(tags, {"test": 3})
 
         view.untag_objects("test", "test_dets")
-        tags = self.dataset.count_values("test_dets.detections.tags")
+        tags = self.dataset.count_object_tags("test_dets")
         self.assertDictEqual(tags, {})
 
     def test_match(self):

--- a/tests/unittests/view_tests.py
+++ b/tests/unittests/view_tests.py
@@ -568,36 +568,6 @@ class ViewExpressionTests(unittest.TestCase):
         )
 
 
-class AggregationTests(unittest.TestCase):
-    @drop_datasets
-    def test_aggregate(self):
-        dataset = fo.Dataset()
-        dataset.add_samples(
-            [
-                fo.Sample("1.jpg", tags=["tag1"]),
-                fo.Sample("2.jpg", tags=["tag1", "tag2"]),
-                fo.Sample("3.jpg", tags=["tag2", "tag3"]),
-            ]
-        )
-
-        counts = {
-            "tag1": 2,
-            "tag2": 2,
-            "tag3": 1,
-        }
-
-        pipeline = [
-            {"$unwind": "$tags"},
-            {"$group": {"_id": "$tags", "count": {"$sum": 1}}},
-        ]
-
-        for ds in dataset, dataset.view():
-            for d in ds._aggregate(pipeline):
-                tag = d["_id"]
-                count = d["count"]
-                self.assertEqual(count, counts[tag])
-
-
 class SliceTests(unittest.TestCase):
     @drop_datasets
     def test_slice(self):
@@ -829,7 +799,7 @@ class ViewStageTests(unittest.TestCase):
                     else:
                         self.assertEqual(lv.label, l.label)
 
-    def test_set_field1(self):
+    def test_set_field(self):
         self._setUp_numeric()
 
         # Clip all negative values of `numeric_field` to zero
@@ -867,7 +837,7 @@ class ViewStageTests(unittest.TestCase):
                 else:
                     self.assertTrue(fv >= 0)
 
-    def test_set_field2(self):
+    def test_set_embedded_field(self):
         self._setUp_detections()
 
         # Set a new embedded list field
@@ -910,6 +880,45 @@ class ViewStageTests(unittest.TestCase):
             for det in sample.test_dets.detections:
                 for coord in det.bounding_box:
                     self.assertEqual(coord, 0)
+
+    def test_tag_samples(self):
+        view = self.dataset[:1]
+
+        tags = self.dataset.count_values("tags")
+        self.assertEqual(tags, {})
+
+        view.tag_samples("test")
+        self.assertEqual(tags, {"test": 1})
+
+        view.untag_samples("test")
+        self.assertEqual(tags, {})
+
+    def test_tag_objects(self):
+        self._setUp_classification()
+        self._setUp_detections()
+
+        view = self.dataset.filter_labels("test_clf", F("confidence") > 0.95)
+        self.assertEqual(len(view), 1)
+
+        view.tag_objects("test", "test_clf")
+        tags = self.dataset.count_values("test_clf.tags[]")
+        self.assertEqual(tags, {"test": 1})
+
+        view.untag_objects("test", "test_clf")
+        tags = self.dataset.count_values("test_clf.tags[]")
+        self.assertEqual(tags, {})
+
+        view = self.dataset.filter_labels("test_dets", F("confidence") > 0.7)
+        self.assertEqual(len(view), 2)
+        self.assertEqual(view.count("test_dets.detections"), 2)
+
+        view.tag_objects("test", "test_dets")
+        tags = self.dataset.count_values("test_dets.tags[]")
+        self.assertEqual(tags, {"test": 2})
+
+        view.untag_objects("test", "test_dets")
+        tags = self.dataset.count_values("test_dets.tags[]")
+        self.assertEqual(tags, {})
 
     def test_match(self):
         self.sample1["value"] = "value"

--- a/tests/unittests/view_tests.py
+++ b/tests/unittests/view_tests.py
@@ -897,7 +897,7 @@ class ViewStageTests(unittest.TestCase):
         tags = self.dataset.count_values("tags")
         self.assertDictEqual(tags, {})
 
-    def test_tag_objects(self):
+    def test_tag_labels(self):
         self._setUp_classification()
         self._setUp_detections()
 
@@ -905,26 +905,26 @@ class ViewStageTests(unittest.TestCase):
         num_samples = len(view)
         self.assertEqual(num_samples, 1)
 
-        view.tag_objects("test", "test_clf")
-        tags = self.dataset.count_object_tags("test_clf")
+        view.tag_labels("test", "test_clf")
+        tags = self.dataset.count_label_tags("test_clf")
         self.assertDictEqual(tags, {"test": 1})
 
-        view.untag_objects("test", "test_clf")
-        tags = self.dataset.count_object_tags("test_clf")
+        view.untag_labels("test", "test_clf")
+        tags = self.dataset.count_label_tags("test_clf")
         self.assertDictEqual(tags, {})
 
         view = self.dataset.filter_labels("test_dets", F("confidence") > 0.7)
         num_samples = len(view)
-        num_objects = view.count("test_dets.detections")
+        num_labels = view.count("test_dets.detections")
         self.assertEqual(num_samples, 2)
-        self.assertEqual(num_objects, 3)
+        self.assertEqual(num_labels, 3)
 
-        view.tag_objects("test", "test_dets")
-        tags = self.dataset.count_object_tags("test_dets")
+        view.tag_labels("test", "test_dets")
+        tags = self.dataset.count_label_tags("test_dets")
         self.assertDictEqual(tags, {"test": 3})
 
-        view.untag_objects("test", "test_dets")
-        tags = self.dataset.count_object_tags("test_dets")
+        view.untag_labels("test", "test_dets")
+        tags = self.dataset.count_label_tags("test_dets")
         self.assertDictEqual(tags, {})
 
     def test_match(self):

--- a/tests/unittests/view_tests.py
+++ b/tests/unittests/view_tests.py
@@ -906,11 +906,11 @@ class ViewStageTests(unittest.TestCase):
         self.assertEqual(num_samples, 1)
 
         view.tag_objects("test", "test_clf")
-        tags = self.dataset.count_values("test_clf.tags[]")
+        tags = self.dataset.count_values("test_clf.tags")
         self.assertDictEqual(tags, {"test": 1})
 
         view.untag_objects("test", "test_clf")
-        tags = self.dataset.count_values("test_clf.tags[]")
+        tags = self.dataset.count_values("test_clf.tags")
         self.assertDictEqual(tags, {})
 
         view = self.dataset.filter_labels("test_dets", F("confidence") > 0.7)
@@ -920,11 +920,11 @@ class ViewStageTests(unittest.TestCase):
         self.assertEqual(num_objects, 3)
 
         view.tag_objects("test", "test_dets")
-        tags = self.dataset.count_values("test_dets.detections.tags[]")
+        tags = self.dataset.count_values("test_dets.detections.tags")
         self.assertDictEqual(tags, {"test": 3})
 
         view.untag_objects("test", "test_dets")
-        tags = self.dataset.count_values("test_dets.detections.tags[]")
+        tags = self.dataset.count_values("test_dets.detections.tags")
         self.assertDictEqual(tags, {})
 
     def test_match(self):


### PR DESCRIPTION
Resolves https://github.com/voxel51/fiftyone/issues/891.

**BREAKING CHANGE**
- All notions of "object" have been replaced by "label" in reference to entities with `id` attributes that can be selected in the App. This includes the following changes:
    - `session.selected_objects` -> `session.selected_labels`
    - `SampleCollection.select_objects()` -> `SampleCollection.select_labels()`
    - `SampleCollection.exclude_objects()` -> `SampleCollection.exclude_labels()`
    - `SelectObjects` -> `SelectLabels`
    - `ExcludeObjects` -> `ExcludeLabels`

**DESCRIPTION**

This PR adds more full-featured support for tagging sample as well as individual labels, which I believe will be pretty heavily used by users as we roll out more upcoming features that make it easy to identify groups of samples/labels of interest :)

Specifically, the `select_labels()` and `exclude_labels()` stages support new syntaxes for selecting labels from a collection:

```py
    @view_stage
    def select_labels(self, labels=None, ids=None, tags=None, fields=None):
        """Selects only the specified labels from the collection.

        The returned view will omit samples, sample fields, and individual
        labels that do not match the specified selection criteria.

        You can perform a selection via one of the following methods:

        -   Provide one or both of the ``ids`` and ``tags`` arguments, and
            optionally the ``fields`` argument

        -   Provide the ``labels`` argument

        Args:
            labels (None): a list of dicts specifying the labels to select
            ids (None): a list of IDs of the labels to select
            tags (None): a list of tags of labels to select
            fields (None): a list of fields from which to select labels
        """
```

A few related tagging utilities were also added to `SampleCollection`:

- `tag_samples()` - add tag to samples, if necessary
- `untag_samples()` - remove tag from samples, if necessary
- `count_sample_tags()` - compute histogram of sample tags
- `tag_labels()` - add tag to labels in one or more fields, if necessary
- `untag_labels()` - remove tag from labels in one or more fields, if necessary
- `count_label_tags()` - histogram of label tags in one or more fields 

Also, since "tags" are now first-class citizens in FiftyOne, the `tags` attribute is now declared on all `Label` types.

Notes
- `count_sample_tags()` is a simple alias for `count_values("tags")`, but I added it nonetheless for consistency with the other tags operations
- In the case of a single label field, `count_label_tags()` is also a simple alias for `count_values("field.name.tags")`, but I thought it would be handy to have a version that will consider all label fields by default, similar to how `select_labels(tags=["tag"])` works when no `fields=` argument is provided.
- I chose not to implement `count_label_tags()` as an `Aggregation` because all other aggregations refer to a specific field while this one can refer to multiple fields. And, if a user really is interested in a single field, then they can already compute a tag histogram via the `count_values("field.name.tags")` syntax
- There might be a more efficient way to implement `count_label_tags()` as a single `$group` stage without having to use `$facet`, but I didn't invest the time to look into that

**DISCUSSION**

- ~~The term "object" is used in this PR for consistency with the existing `Session.selected_objects` and `SampleCollection.select_objects()` terminology. However, "object" really refers to any `Label` with an `id`, which includes `Classification`, `Detection`, `Polyline`, `Keypoint`, and `Segmentation`, and excludes label list types like `Detections`. I worry that "object" is a confusing term because it will likely be associated only with `Detection`, and not things like `Classification` that do not have a spatial component. I wonder if a more appropriate term would be "label"? Making this change would come at the price of a breaking API change~~

**VISUALIZATION**

This PR also provides some handy utilities (implemented via `matplotlib`, for now) for visualizing samples/objects that can optionally be connected to a `Session` instance and interactively explored via clicking/lassoing:

The relevant user-facing utilities are:
- `fiftyone.utils.plot.scatter.scatterplot()`- an interactive scatterplot of arbitrary 2D/3D points
- `fiftyone.utils.plot.location.location_scatterplot()` - an interactive scatterplot of lat-lon coordinates

**EXAMPLE VISUALIZATION**

![location_scatterplot_opt](https://user-images.githubusercontent.com/25985824/110169845-48e71600-7dc7-11eb-9163-814fb81eef0a.gif)

<img width="1125" alt="scatterplot" src="https://user-images.githubusercontent.com/25985824/110169842-4684bc00-7dc7-11eb-8111-fbf326ed0cc8.png">

**EXAMPLE SELECTION USAGE**

The new examples in the `select_labels()` docstring demonstrate this functionality nicely:

```py
import fiftyone as fo
import fiftyone.zoo as foz

dataset = foz.load_zoo_dataset("quickstart")

#
# Only include the labels currently selected in the App
#

session = fo.launch_app(dataset)

# Select some labels in the App...

view = dataset.select_labels(labels=session.selected_labels)

#
# Create a view that only includes labels with the specified IDs
#

# Grab some label IDs
ids = [
    dataset.first().ground_truth.detections[0].id,
    dataset.last().predictions.detections[0].id,
]

view = dataset.select_labels(ids=ids)

print(view.count("ground_truth.detections"))
print(view.count("predictions.detections"))

#
# Create a view that only includes labels with the specified tags
#

# Grab some label IDs
ids = [
    dataset.first().ground_truth.detections[0].id,
    dataset.last().predictions.detections[0].id,
]

# Give the labels a "test" tag
dataset = dataset.clone()  # create a copy since we're modifying data
dataset.select_labels(ids=ids).tag_labels("test")

print(dataset.count_label_tags())

# Retrieve the labels via their tag
view = dataset.select_labels(tags=["test"])

print(view.count("ground_truth.detections"))
print(view.count("predictions.detections"))
```
