### PR TITLE
Build view along with pipeline when aggregating views

### DIFF
--- a/fiftyone/core/view.py
+++ b/fiftyone/core/view.py
@@ -49,9 +49,12 @@ class DatasetView(foc.SampleCollection):
         dataset: a :class:`fiftyone.core.dataset.Dataset`
     """
 
-    def __init__(self, dataset):
+    def __init__(self, dataset, _stages=None):
+        if _stages is None:
+            _stages = []
+
         self.__dataset__ = dataset
-        self._stages = []
+        self._stages = _stages
 
     def __len__(self):
         return self.count()
@@ -84,9 +87,8 @@ class DatasetView(foc.SampleCollection):
             )
 
     def __copy__(self):
-        view = self.__class__(self._dataset)
-        view._stages = deepcopy(self._stages)
-        return view
+        _stages = deepcopy(self._stages)
+        return self.__class__(self._dataset, _stages=_stages)
 
     @property
     def _dataset(self):
@@ -214,7 +216,10 @@ class DatasetView(foc.SampleCollection):
             return "    ---"
 
         return "    " + "\n    ".join(
-            ["%d. %s" % (idx, str(d)) for idx, d in enumerate(self._stages, 1)]
+            [
+                "%d. %s" % (idx, str(stage))
+                for idx, stage in enumerate(self._stages, 1)
+            ]
         )
 
     def view(self):
@@ -634,8 +639,8 @@ class DatasetView(foc.SampleCollection):
         return d
 
     def _needs_frames(self):
-        for s in self._stages:
-            if s._needs_frames(self):
+        for stage in self._stages:
+            if stage._needs_frames(self):
                 return True
 
         return False
@@ -647,9 +652,11 @@ class DatasetView(foc.SampleCollection):
         detach_frames=False,
         frames_only=False,
     ):
+        _view = self._dataset.view()
         _pipeline = []
-        for s in self._stages:
-            _pipeline.extend(s.to_mongo(self))
+        for stage in self._stages:
+            _view = _view.add_stage(stage)
+            _pipeline.extend(stage.to_mongo(_view))
 
         if pipeline is not None:
             _pipeline.extend(pipeline)
@@ -682,7 +689,7 @@ class DatasetView(foc.SampleCollection):
         return self._dataset._doc
 
     def _serialize(self):
-        return [s._serialize() for s in self._stages]
+        return [stage._serialize() for stage in self._stages]
 
     @staticmethod
     def _build(dataset, stage_dicts):


### PR DESCRIPTION
Resolves https://github.com/voxel51/fiftyone/issues/910.

The issue was that `DatasetView._pipeline()` was passing the final view to `ViewStage.to_mongo(view)`, but technically it should have been passing a view that contains only stages `1-n` when serializing the `n`th stage. In most cases the two are equivalent, but not when certain view stages modify the schema, for example.

```py
import fiftyone.zoo as foz
from fiftyone import ViewField as F

dataset = foz.load_zoo_dataset("quickstart")
view = dataset.filter_labels("ground_truth", F("label") == "person")

# now works
view.select_fields("filepath")
```
