### PR TITLE
Updating remote session instructions

### DIFF
--- a/app/src/containers/Setup.tsx
+++ b/app/src/containers/Setup.tsx
@@ -32,8 +32,7 @@ const Code = styled.pre`
   border-radius: 3px;
 `;
 
-const remoteSnippet = `
-import fiftyone as fo
+const remoteSnippet = `import fiftyone as fo
 
 # Load your FiftyOne dataset
 dataset = fo.load_dataset(...)
@@ -43,8 +42,7 @@ session = fo.launch_app(dataset, remote=True, port=XXXX)
 `;
 
 const LocalInstructions = () => {
-  const localSnippet = `
-import fiftyone as fo
+  const localSnippet = `import fiftyone as fo
 
 # Load your FiftyOne dataset
 dataset = fo.load_dataset(...)
@@ -62,16 +60,13 @@ session = fo.launch_app(dataset, port=${port})
 };
 
 const RemoteInstructions = () => {
-  const bashSnippet = `
-# Option 1
-# Use the CLI to connect to the remote session
-fiftyone app connect \\
-    --destination <username>@<remote-ip-address> \\
-    --port XXXX --local-port ${port}
+  const bashSnippet = `# Option 1: Configure port forwaring
+# Then open http://localhost:${port} in your web browser
+ssh -N -L ${port}:127.0.0.1:XXXX [<username>@]<hostname>
 
-# Option 2
-# Manually configure port forwarding
-ssh -N -L ${port}:127.0.0.1:XXXX <username>@<remote-ip-address>
+# Option 2: Use the CLI
+fiftyone app connect --destination [<username>@]<hostname> \\
+    --port XXXX --local-port ${port}
 `;
   return (
     <>
@@ -157,7 +152,7 @@ function Setup() {
 
   return (
     <SetupContainer>
-      <Title>Welcome to FiftyOne</Title>
+      <Title>Welcome to FiftyOne!</Title>
       <Subtitle>It looks like you are not connected to a session</Subtitle>
       {isNotebook ? (
         <NotebookInstructions />

--- a/docs/docs_guide.md
+++ b/docs/docs_guide.md
@@ -1,46 +1,62 @@
 # FiftyOne Documentation Guide
 
 Instructions for contributing to the FiftyOne Documentation, available publicly
-at https://voxel51.com/docs/fiftyone.
+at [fiftyone.ai](http://fiftyone.ai).
 
 ## Building
 
-This project uses
+This project uses [Sphinx](https://www.sphinx-doc.org/en/master) and
 [Sphinx-Napoleon](https://pypi.python.org/pypi/sphinxcontrib-napoleon) to
-generate its documentation from source. To generate the documentation (requires
-a developer installation), run the `generate_docs.bash` script in this folder:
+generate its documentation and API reference from source.
+
+You can build the docs from source by running the `generate_docs.bash` script
+in this folder:
 
 ```shell
 bash generate_docs.bash
 ```
 
-The script requires that `fiftyone` and `fiftyone-brain` installed in your
+The script expects that you have performed a developer install of `fiftyone`
+(see main README) and that the `fiftyone-brain` package is installed in your
 environment.
 
-A few flags are supported:
+A couple flags are supported:
 
--   `-c` performs a clean build by removing the docs/build folder beforehand.
+-   `-c` performs a clean build by removing the `docs/build` folder beforehand.
     This is sometimes necessary to force updates, e.g. if you have edited a
     template and want to see how it affects pages whose source files haven't
-    changed.
+    changed
 -   `-s` will update static files only (i.e. `custom.css` and `custom.js`
-    mentioned below).
+    mentioned below)
 
 ## Contributing
+
+### Main content
+
+The main content is located in the `docs/source` folder. The files are written
+in [Sphinx RST format](https://sphinx-tutorial.readthedocs.io/step-1).
+
+The API documentation is automatically generated from the Python source code,
+whose docstrings are written in
+[Sphinx-Napoleon](https://pypi.python.org/pypi/sphinxcontrib-napoleon) format.
+
+Check out the existing patterns in the source files and you'll catch on.
+
+### Themes
 
 Theme files are located in the `docs/theme` folder. However, you should prefer
 to make changes in the following locations instead of the theme itself whenever
 possible:
 
 -   `docs/source/_static` contains `custom.css` and `custom.js` files, where
-    any CSS overrides or custom JS should be added.
+    any CSS overrides or custom JS should be added
 -   `docs/source/_templates` contains HTML files (Jinja2 templates) that
     override theme templates of the same name. These should extend the theme
     templates - see the existing templates for how to do this. If you need to
     override part of the theme template that isn't conveniently marked as a
     block (and isn't a separate file that you can override), our convention is
     to add a block prefixed with `custom_` to the theme template, then override
-    that block locally.
+    that block locally
 
 To work on the theme JavaScript (not `custom.js`), you will need to install a
 couple dependencies for the build process:
@@ -57,7 +73,3 @@ A few commands are available:
 -   `yarn deploy` builds and copies this file into the built documentation
     (which avoids the need to run `generate_docs.bash` again)
 -   `yarn watch` re-runs `yarn deploy` whenever a JS source file changes
-
-## Copyright
-
-Copyright 2017-2021, Voxel51, Inc.<br> voxel51.com

--- a/docs/source/cli/index.rst
+++ b/docs/source/cli/index.rst
@@ -1096,11 +1096,11 @@ View datasets in the FiftyOne App without persisting them to the database.
 Connect to remote App
 ~~~~~~~~~~~~~~~~~~~~~
 
-Connect to a remote FiftyOne App.
+Connect to a remote FiftyOne App in your web browser.
 
 .. code-block:: text
 
-    fiftyone app connect [-h] [-d DESTINATION] [-p PORT]
+    fiftyone app connect [-h] [-d DESTINATION] [-p PORT] [-l PORT] [-i KEY]
 
 **Arguments**
 
@@ -1113,8 +1113,8 @@ Connect to a remote FiftyOne App.
       -p PORT, --port PORT  the remote port to connect to
       -l PORT, --local-port PORT
                             the local port to use to serve the App
-      -i KEY, --ssh-key KEY an optional ssh key used to login
-      -a, --desktop         whether to launch a desktop App instance
+      -i KEY, --ssh-key KEY
+                            optional ssh key to use to login
 
 **Examples**
 
@@ -1130,18 +1130,13 @@ Connect to a remote FiftyOne App.
 
 .. code-block:: shell
 
-   # Connect to a remote App session using an ssh key
-   fiftyone app connect ... --ssh-key <path/to/key>
+    # Connect to a remote App session using an ssh key
+    fiftyone app connect ... --ssh-key <path/to/key>
 
 .. code-block:: shell
 
     # Connect to a remote App using a custom local port
     fiftyone app connect ... --local-port <port>
-
-.. code-block:: shell
-
-    # Connect to a remote session using the desktop App
-    fiftyone app connect ... --desktop
 
 .. _cli-fiftyone-zoo:
 

--- a/docs/source/environments/index.rst
+++ b/docs/source/environments/index.rst
@@ -77,38 +77,55 @@ machine and launch a remote session:
     # On remote machine
     import fiftyone as fo
 
-    dataset = fo.Dataset(name="my_dataset")
+    dataset = fo.load_dataset(...)
 
-    session = fo.launch_app(dataset, remote=True)  # (optional) port=XXXX
+    session = fo.launch_app(dataset, remote=True)  # optional: port=XXXX
 
-Leave this session running, and note that instructions for connecting to this
-remote session were printed to your terminal (these are described below).
+Leave the Python REPL running and follow the instructions for connecting to
+this session remotely were printed to your terminal (also described below).
 
-If you do not have `fiftyone` installed on your local machine, and do not want
-to install it, you can set up port forwarding manually, and view the App in
-your browser.
+.. note::
 
-.. code-block:: shell
+    You can manipulate the `session` object on the remote machine as usual to
+    programmatically interact with the App instance that you view locally.
 
-    # `[<username>@]<hostname>` refers to your remote machine
-    ssh -N -L 5151:127.0.0.1:%d [<username>@]<hostname>
-
-If you have `fiftyone` installed on the local machine, you can
-:ref:`use the CLI <cli-fiftyone-app-connect>` to automatically configure port
-forwarding and open the App in either the desktop App or your web browser.
-
-In a local terminal, run the command:
+If you do not have `fiftyone` installed on your local machine, open a new
+terminal window on your local machine and execute the following command to
+setup port forwarding to connect to your remote session:
 
 .. code-block:: shell
 
     # On local machine
-    fiftyone app connect --destination <user>@<remote-ip-address> --port 5151
+    ssh -N -L 5151:127.0.0.1:XXXX [<username>@]<hostname>
 
-The above instructions assume that you used the default port `5151` when
-launching the remote session on the remote machine. If you used a custom port,
-(or if you customized your default port via the ``default_app_port`` parameter
-of your :ref:`FiftyOne config <configuring-fiftyone>`), then substitute the
-appropriate value in the local commands too.
+Leave this process running and open http://localhost:5151 in your browser to
+access the App.
+
+In the above, `[<username>@]<hostname>` specifies the remote machine to connect
+to, `XXXX` refers to the port that you chose when you launched the session on
+your remote machine (the default is 5151), and `5151` specifies the local port
+to use to connect to the App (and can be customized).
+
+Alternatively, if you have FiftyOne installed on your local machine, you can
+:ref:`use the CLI <cli-fiftyone-app-connect>` to automatically configure port
+forwarding and open the App in your browser as follows:
+
+.. code-block:: shell
+
+    # On local machine
+    fiftyone app connect --destination [<username>@]<hostname>
+
+If you choose a custom port `XXXX` on the remote machine, add a ``--port XXXX``
+flag to the above command.
+
+If you would like to use a custom local port, add a ``--local-port YYYY`` flag
+to the above command.
+
+.. note::
+
+    You can customize the local/remote ports used when launching remote
+    sessions in order to connect/servce multiple remote sessions
+    simultaneously.
 
 .. note::
 
@@ -119,11 +136,6 @@ appropriate value in the local commands too.
     However, if you are using this key regularly,
     `it is recommended <https://unix.stackexchange.com/a/494485>`_ to add it
     to your `~/.ssh/config` as the default `IdentityFile`.
-
-.. note::
-
-    You can use custom ports when launching remote sessions in order to serve
-    multiple remote sessions simultaneously.
 
 .. _notebooks:
 
@@ -322,49 +334,8 @@ credentials as outlined in the
 
 Now that you can access your data from the compute instance, start up Python
 and :ref:`create a FiftyOne dataset <loading-datasets>` whose filepaths are in
-the mount point you specified above. Then launch the App as a
-:ref:`remote session <remote-session>`:
-
-.. code-block:: python
-    :linenos:
-
-    # On remote machine
-    import fiftyone as fo
-
-    dataset = fo.Dataset(name="my_dataset")
-
-    session = fo.launch_app(dataset, remote=True)  # (optional) port=XXXX
-
-**Step 5**
-
-Finally, on your local machine, connect to the remote session that you started
-on the cloud instance.
-
-.. code-block:: bash
-
-    # On local machine
-    fiftyone app connect --destination <user>@<remote-ip-address> --port 5151
-
-The above instructions assume that you used the default port `5151` when
-launching the remote session on the remote machine. If you used a custom port,
-(or if you customized your default port via the ``default_app_port`` parameter
-of your :ref:`FiftyOne config <configuring-fiftyone>`), then substitute the
-appropriate value in the local commands too.
-
-.. note::
-
-    If you use ssh keys to connect to your remote machine, you can use the
-    optional `--ssh-key` argument of the
-    :ref:`fiftyone app connect <cli-fiftyone-app-connect>` command.
-
-    However, if you are using this key regularly,
-    `it is recommended <https://unix.stackexchange.com/a/494485>`_ to add it
-    to your `~/.ssh/config` as the default `IdentityFile`.
-
-.. note::
-
-    You can use custom ports when launching remote sessions in order to serve
-    multiple remote sessions simultaneously.
+the mount point you specified above. Then you can launch the App and work with
+it locally in your browser using :ref:`remote sessions <remote-data>`.
 
 .. _google-cloud:
 
@@ -413,49 +384,8 @@ to do this:
 
 Now that you can access your data from the compute instance, start up Python
 and :ref:`create a FiftyOne dataset <loading-datasets>` whose filepaths are in
-the mount point you specified above. Then launch the App as a
-:ref:`remote session <remote-session>`:
-
-.. code-block:: python
-    :linenos:
-
-    # On remote machine
-    import fiftyone as fo
-
-    dataset = fo.Dataset(name="my_dataset")
-
-    session = fo.launch_app(dataset, remote=True)  # (optional) port=XXXX
-
-**Step 5**
-
-Finally, on your local machine, connect to the remote session that you started
-on the cloud instance.
-
-.. code-block:: bash
-
-    # On local machine
-    fiftyone app connect --destination <user>@<remote-ip-address> --port 5151
-
-The above instructions assume that you used the default port `5151` when
-launching the remote session on the remote machine. If you used a custom port,
-(or if you customized your default port via the ``default_app_port`` parameter
-of your :ref:`FiftyOne config <configuring-fiftyone>`), then substitute the
-appropriate value in the local commands too.
-
-.. note::
-
-    If you use ssh keys to connect to your remote machine, you can use the
-    optional `--ssh-key` argument of the
-    :ref:`fiftyone app connect <cli-fiftyone-app-connect>` command.
-
-    However, if you are using this key regularly,
-    `it is recommended <https://unix.stackexchange.com/a/494485>`_ to add it
-    to your `~/.ssh/config` as the default `IdentityFile`.
-
-.. note::
-
-    You can use custom ports when launching remote sessions in order to serve
-    multiple remote sessions simultaneously.
+the mount point you specified above. Then you can launch the App and work with
+it locally in your browser using :ref:`remote sessions <remote-data>`.
 
 .. _azure:
 
@@ -500,49 +430,8 @@ for this.
 
 Now that you can access your data from the compute instance, start up Python
 and :ref:`create a FiftyOne dataset <loading-datasets>` whose filepaths are in
-the mount point you specified above. Then launch the App as a
-:ref:`remote session <remote-session>`:
-
-.. code-block:: python
-    :linenos:
-
-    # On remote machine
-    import fiftyone as fo
-
-    dataset = fo.Dataset(name="my_dataset")
-
-    session = fo.launch_app(dataset, remote=True)  # (optional) port=XXXX
-
-**Step 5**
-
-Finally, on your local machine, connect to the remote session that you started
-on the cloud instance.
-
-.. code-block:: bash
-
-    # On local machine
-    fiftyone app connect --destination <user>@<remote-ip-address> --port 5151
-
-The above instructions assume that you used the default port `5151` when
-launching the remote session on the remote machine. If you used a custom port,
-(or if you customized your default port via the ``default_app_port`` parameter
-of your :ref:`FiftyOne config <configuring-fiftyone>`), then substitute the
-appropriate value in the local commands too.
-
-.. note::
-
-    If you use ssh keys to connect to your remote machine, you can use the
-    optional `--ssh-key` argument of the
-    :ref:`fiftyone app connect <cli-fiftyone-app-connect>` command.
-
-    However, if you are using this key regularly,
-    `it is recommended <https://unix.stackexchange.com/a/494485>`_ to add it
-    to your `~/.ssh/config` as the default `IdentityFile`.
-
-.. note::
-
-    You can use custom ports when launching remote sessions in order to serve
-    multiple remote sessions simultaneously.
+the mount point you specified above. Then you can launch the App and work with
+it locally in your browser using :ref:`remote sessions <remote-data>`.
 
 .. _compute-instance-setup:
 

--- a/docs/source/environments/index.rst
+++ b/docs/source/environments/index.rst
@@ -82,7 +82,8 @@ machine and launch a remote session:
     session = fo.launch_app(dataset, remote=True)  # optional: port=XXXX
 
 Leave the Python REPL running and follow the instructions for connecting to
-this session remotely were printed to your terminal (also described below).
+this session remotely that were printed to your terminal (also described
+below).
 
 .. note::
 

--- a/docs/source/user_guide/app.rst
+++ b/docs/source/user_guide/app.rst
@@ -126,7 +126,7 @@ _______________
 
 If your data is stored on a remote machine, you can forward a session from
 the remote machine to your local machine and seemlessly browse your remote
-dataset via the App.
+dataset from you web browser.
 
 Check out the :ref:`environments page <environments>` for more information on
 possible configurations of local/remote/cloud data and App access.
@@ -158,12 +158,12 @@ using either the Python library or the CLI.
 
     You can use the optional ``port`` parameter to choose the port of your
     remote machine on which to serve the App. The default is ``5151``, which
-    can be customized via the ``default_app_port`` parameter of your
+    can also be customized via the ``default_app_port`` parameter of your
     :ref:`FiftyOne config <configuring-fiftyone>`.
 
     Note that you can manipulate the `session` object on the remote machine as
     usual to programmatically interact with the App instance that you'll
-    connect to next.
+    connect to locally next.
 
   .. group-tab:: CLI
 
@@ -178,7 +178,7 @@ using either the Python library or the CLI.
 
     You can use the optional ``--port`` flag to choose the port of your
     remote machine on which to serve the App. The default is ``5151``, which
-    can be customized via the ``default_app_port`` parameter of your
+    can also be customized via the ``default_app_port`` parameter of your
     :ref:`FiftyOne config <configuring-fiftyone>`.
 
 .. _remote-app-local-machine:
@@ -186,58 +186,39 @@ using either the Python library or the CLI.
 Local machine
 -------------
 
-On the local machine, you can launch an App instance connected to a remote
-session using either the Python library or the CLI (recommended).
+On the local machine, you can access an App instance connected to the remote
+session by either manually configuring port forwarding or via the FiftyOne CLI:
 
 .. tabs::
 
-  .. group-tab:: Python
+  .. group-tab:: Manual
 
-    Open two terminal windows on the local machine.
-
-    The first step is to configure port forwarding of the remote machine's port
-    to your local machine. Do this by running the following command in one
-    terminal and leave the process running:
+    Open a new terminal window on your local machine and execute the following
+    command to setup port forwarding to connect to your remote session:
 
     .. code-block:: shell
 
         # On local machine
+        ssh -N -L 5151:127.0.0.1:XXXX [<username>@]<hostname>
 
-        ssh -N -L 5151:127.0.0.1:5151 username@remote_machine_ip
+    Leave this process running and open http://localhost:5151 in your browser
+    to access the App.
 
-    If you chose a custom port `XXXX` on the remote machine, substitute it
-    for the second `5151` in the above command.
+    In the above, `[<username>@]<hostname>` specifies the remote machine to
+    connect to, `XXXX` refers to the port that you chose when you launched the
+    session on your remote machine (the default is 5151), and `5151` specifies
+    the local port to use to connect to the App (and can be customized).
 
-    If you would like to use a custom local port to serve the App, substitute
-    it for the first `5151` in the above command.
+  .. group-tab:: FiftyOne
 
-    In the other terminal, launch the FiftyOne App locally by starting Python
-    and running the following commands:
-
-    .. code-block:: python
-        :linenos:
-
-        # On local machine
-
-        import fiftyone as fo
-
-        fo.launch_app()  # optional: port=YYYY
-
-    If you chose a custom local port when configuring port forwarding, specify
-    it via the ``port`` parameter of
-    :meth:`launch_app() <fiftyone.core.session.launch_app>`.
-
-  .. group-tab:: CLI
-
-    On the local machine, use the
-    :ref:`fiftyone app connect <cli-fiftyone-app-connect>` command to connect
-    to a remote session:
+    If you have FiftyOne installed on your local machine, you can
+    :ref:`use the CLI <cli-fiftyone-app-connect>` to automatically configure
+    port forwarding and open the App in your browser as follows:
 
     .. code-block:: shell
 
         # On local machine
-
-        fiftyone app connect --destination username@remote_machine_ip
+        fiftyone app connect --destination [<username>@]<hostname>
 
     If you choose a custom port `XXXX` on the remote machine, add a
     ``--port XXXX`` flag to the above command.

--- a/fiftyone/core/cli.py
+++ b/fiftyone/core/cli.py
@@ -11,10 +11,12 @@ import json
 import os
 import subprocess
 import sys
+import time
 import textwrap
 
 import argcomplete
 from tabulate import tabulate
+import webbrowser
 
 import eta.core.serial as etas
 import eta.core.utils as etau
@@ -944,6 +946,16 @@ def _watch_session(session):
         pass
 
 
+def _wait():
+    print("\nTo exit, press ctrl + c\n")
+
+    try:
+        while True:
+            time.sleep(0.5)
+    except KeyboardInterrupt:
+        pass
+
+
 class AppViewCommand(Command):
     """View datasets in the App without persisting them to the database.
 
@@ -1147,7 +1159,7 @@ class AppViewCommand(Command):
 
 
 class AppConnectCommand(Command):
-    """Connect to a remote FiftyOne App.
+    """Connect to a remote FiftyOne App in your web browser.
 
     Examples::
 
@@ -1162,9 +1174,6 @@ class AppConnectCommand(Command):
 
         # Connect to a remote App using a custom local port
         fiftyone app connect ... --local-port <port>
-
-        # Connect to a remote session using the desktop App
-        fiftyone app connect ... --desktop
     """
 
     @staticmethod
@@ -1200,12 +1209,6 @@ class AppConnectCommand(Command):
             type=str,
             help="optional ssh key to use to login",
         )
-        parser.add_argument(
-            "-a",
-            "--desktop",
-            action="store_true",
-            help="whether to launch a desktop App instance",
-        )
 
     @staticmethod
     def execute(parser, args):
@@ -1215,7 +1218,7 @@ class AppConnectCommand(Command):
         if args.destination:
             if sys.platform.startswith("win"):
                 raise RuntimeError(
-                    "This command is currently not supported on Windows."
+                    "This command is currently not supported on Windows"
                 )
 
             control_path = os.path.join(
@@ -1261,12 +1264,10 @@ class AppConnectCommand(Command):
 
             fou.call_on_exit(stop_port_forward)
 
-        # If desktop wasn't explicitly requested, fallback to default
-        desktop = args.desktop or None
+        url = "http://localhost:%d/" % local_port
+        webbrowser.open(url, new=2)
 
-        session = fos.launch_app(port=local_port, desktop=desktop)
-
-        _watch_session(session)
+        _wait()
 
 
 class ZooCommand(Command):

--- a/fiftyone/core/session.py
+++ b/fiftyone/core/session.py
@@ -62,16 +62,16 @@ Session launched. Run `session.show()` to open the App in a cell output.
 
 _REMOTE_INSTRUCTIONS = """
 You have launched a remote App on port {0}. To connect to this App from another
-machine, issue the following command:
-
-fiftyone app connect --destination [<username>@]<hostname> --port {0}
-
-where `[<username>@]<hostname>` refers to your current machine. Alternatively,
-you can manually configure port forwarding on another machine as follows:
+machine, issue the following command to configure port forwarding:
 
 ssh -N -L 5151:127.0.0.1:{0} [<username>@]<hostname>
 
-The App can then be viewed in your browser at http://localhost:5151.
+where `[<username>@]<hostname>` refers to your current machine. The App can
+then be viewed in your browser at http://localhost:5151.
+
+Alternatively, if you have FiftyOne installed on your local machine, just run:
+
+fiftyone app connect --destination [<username>@]<hostname> --port {0}
 
 See https://voxel51.com/docs/fiftyone/user_guide/app.html#remote-sessions
 for more information about remote sessions.


### PR DESCRIPTION
Resolves https://github.com/voxel51/fiftyone/issues/208.

This PR updates the remote session instructions to first recommend manual port forwarding on your local machine, which doesn't require a local FiftyOne install.

It also resolves https://github.com/voxel51/fiftyone/issues/208 by re-implementing the `fiftyone app connect` CLI method to simply execute the port forward command and then open a browser tab without calling `fo.launch_app()`.

I thought about removing `fiftyone app connect` completely, but, now that it is harmless, I think its okay to keep it as a convenience to users (as a second option). The one thing that *is* removed is the `--desktop` flag, which goes too far.

```py
# On remote machine
import fiftyone as fo
import fiftyone.zoo as foz

dataset = foz.load_zoo_dataset("quickstart")
session = fo.launch_app(dataset, remote=True)
```

```
You have launched a remote App on port 5151. To connect to this App from another
machine, issue the following command to configure port forwarding:

ssh -N -L 5151:127.0.0.1:5151 [<username>@]<hostname>

where `[<username>@]<hostname>` refers to your current machine. The App can
then be viewed in your browser at http://localhost:5151.

Alternatively, if you have FiftyOne installed on your local machine, just run:

fiftyone app connect --destination [<username>@]<hostname> --port 5151

See https://voxel51.com/docs/fiftyone/user_guide/app.html#remote-sessions
for more information about remote sessions.
```