### PR TITLE
Bump ETA requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -90,7 +90,7 @@ setup(
         "xmltodict",
         "universal-analytics-python3>=1.0.1,<2",
         # internal packages
-        "voxel51-eta>=0.3,<0.4",
+        "voxel51-eta>=0.4,<0.5",
         # ETA dependency - restricted to a maximum version known to provide
         # wheels here because it tends to publish sdists several hours before
         # wheels. When users install FiftyOne in this window, they will need to


### PR DESCRIPTION
Bump ETA requirement to >=0.4 to match ETA's version on develop.