### PR TITLE
Adding support for efficiently merging video datasets

### DIFF
--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -3163,9 +3163,9 @@ def _merge_samples(
     # here, but here's the current workflow:
     #
     # - Store the `key_field` value on each frame document in both the source
-    #   and destination collection corresopnding to its parent sample in a
+    #   and destination collections corresopnding to its parent sample in a
     #   temporary `frame_key_field` field
-    # - Merge the sample documents
+    # - Merge the sample documents without frames attached
     # - Merge the frame documents on key `[frame_key_field, frame_number]` with
     #   their old `_sample_id`s unset
     # - Generate a mapping from `key_field` -> `_id` for the post-merge

--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -12,7 +12,6 @@ import logging
 import numbers
 import os
 import random
-import reprlib
 import string
 
 from bson import ObjectId
@@ -29,11 +28,9 @@ import fiftyone.constants as focn
 import fiftyone.core.collections as foc
 import fiftyone.core.fields as fof
 import fiftyone.core.frame as fofr
-import fiftyone.core.labels as fol
 import fiftyone.core.media as fom
 import fiftyone.migrations as fomi
 import fiftyone.core.odm as foo
-import fiftyone.core.odm.sample as foos
 import fiftyone.core.sample as fos
 from fiftyone.core.singleton import DatasetSingleton
 import fiftyone.core.view as fov

--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -3285,7 +3285,7 @@ def _drop_index(coll, index_spec):
 
 
 def _index_frames(sample_collection, key_field, frame_key_field):
-    aggs = [foa.Values("_id", _allow_missing=True), foa.Values(key_field)]
+    aggs = [foa.Values("_id"), foa.Values(key_field)]
     keys_map = {k: v for k, v in zip(*sample_collection.aggregate(aggs))}
 
     all_sample_ids = sample_collection.values("frames._sample_id")
@@ -3305,7 +3305,7 @@ def _index_frames(sample_collection, key_field, frame_key_field):
 
 
 def _finalize_frames(sample_collection, key_field, frame_key_field):
-    aggs = [foa.Values(key_field), foa.Values("_id", _allow_missing=True)]
+    aggs = [foa.Values(key_field), foa.Values("_id")]
     ids_map = {k: v for k, v in zip(*sample_collection.aggregate(aggs))}
 
     all_frame_keys = sample_collection.values(

--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -3159,8 +3159,8 @@ def _merge_samples(
     #
     # The trouble is that the `_sample_id` of the frame documents need to match
     # the `_id` of the sample documents after merging. There may be a more
-    # clever way to make this happen via `$lookup` what is implemented here,
-    # but here's how we currently achieve it:
+    # clever way to make this happen via `$lookup` than what is implemented
+    # here, but here's the current workflow:
     #
     # - Store the `key_field` value on each frame document in both the source
     #   and destination collection corresopnding to its parent sample in a

--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -3148,10 +3148,10 @@ def _merge_samples(
 
         # Must create unique indexes in order to use `$merge`
         frame_index_spec = [(frame_key_field, 1), ("frame_number", 1)]
-        dst_dataset._frame_collection.create_index(
+        dst_frame_index = dst_dataset._frame_collection.create_index(
             frame_index_spec, unique=True
         )
-        src_dataset._frame_collection.create_index(
+        src_frame_index = src_dataset._frame_collection.create_index(
             frame_index_spec, unique=True
         )
 
@@ -3267,21 +3267,13 @@ def _merge_samples(
         src_collection.drop_index(key_field)
 
     if is_video:
-        _drop_index(dst_dataset._frame_collection, frame_index_spec)
-        _drop_index(src_dataset._frame_collection, frame_index_spec)
+        dst_dataset._frame_collection.drop_index(dst_frame_index)
+        src_dataset._frame_collection.drop_index(src_frame_index)
 
     # Reload docs
     fos.Sample._reload_docs(dst_dataset._sample_collection_name)
     if is_video:
         fofr.Frame._reload_docs(dst_dataset._frame_collection_name)
-
-
-def _drop_index(coll, index_spec):
-    index_info = coll.index_information()
-    index_map = {
-        v["key"][0][0]: k for k, v in index_info.items()
-    }  # @todo fix?
-    coll.drop_index(index_map[index_spec])
 
 
 def _index_frames(sample_collection, key_field, frame_key_field):

--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -3166,10 +3166,10 @@ def _merge_samples(
     #   and destination collections corresopnding to its parent sample in a
     #   temporary `frame_key_field` field
     # - Merge the sample documents without frames attached
-    # - Merge the frame documents on key `[frame_key_field, frame_number]` with
+    # - Merge the frame documents on `[frame_key_field, frame_number]` with
     #   their old `_sample_id`s unset
-    # - Generate a mapping from `key_field` -> `_id` for the post-merge
-    #   sample documents, then make a pass over the frame documents and set
+    # - Generate a `key_field` -> `_id` mapping for the post-merge sample docs,
+    #   then make a pass over the frame documents and set
     #   their `_sample_id` to the corresponding value from this mapping
     # - The merge is complete, so delete `frame_key_field` from both frame
     #   collections

--- a/fiftyone/core/view.py
+++ b/fiftyone/core/view.py
@@ -682,9 +682,6 @@ class DatasetView(foc.SampleCollection):
         if not attach_frames:
             attach_frames = self._needs_frames()
 
-        if not attach_frames:
-            detach_frames = False
-
         return self._dataset._pipeline(
             pipeline=_pipeline,
             attach_frames=attach_frames,

--- a/tests/intensive/merge_tests.py
+++ b/tests/intensive/merge_tests.py
@@ -1,0 +1,143 @@
+"""
+Collection merge tests.
+
+| Copyright 2017-2021, Voxel51, Inc.
+| `voxel51.com <https://voxel51.com/>`_
+|
+"""
+import os
+
+import pytest
+
+import eta.core.utils as etau
+
+import fiftyone as fo
+import fiftyone.zoo as foz
+from fiftyone import ViewField as F
+
+
+@pytest.fixture
+def basedir():
+    with etau.TempDir() as tmpdir:
+        print(tmpdir)
+        yield tmpdir
+
+
+def test_merge_samples_image(basedir):
+    images_dir = os.path.join(basedir, "merge_samples_image")
+    label = "person"
+
+    dataset = foz.load_zoo_dataset("quickstart").clone()
+
+    dataset1 = dataset.clone()
+    dataset2 = dataset.clone()
+    dataset3 = dataset.clone()
+
+    # Give `dataset2` new field names
+    dataset2.rename_sample_field("ground_truth", "gt")
+
+    # Give `dataset3` new image locations
+    inpaths = dataset3.values("filepath")
+    outpaths = [os.path.join(images_dir, os.path.basename(f)) for f in inpaths]
+    for inpath, outpath in zip(inpaths, outpaths):
+        etau.copy_file(inpath, outpath)
+
+    dataset3.set_values("filepath", outpaths)
+
+    # Only merge `person` labels
+    view2 = dataset2.filter_labels("gt", F("label") == label)
+    view3 = dataset3.filter_labels("ground_truth", F("label") == label)
+
+    # Perform the merges
+    dataset.merge_samples(view2)
+    dataset.merge_samples(view3)
+
+    # Check that schema is correct
+    schema = dataset.get_field_schema()
+
+    assert "ground_truth" in schema
+    assert "gt" in schema
+
+    #
+    # `dataset` should contain:
+    #   `view2` counts in its `gt` field
+    #   `dataset1` + `view3` counts in its `ground_truth` field
+    #
+
+    dataset_counts = dataset.count_values("ground_truth.detections.label")
+    dataset1_counts = dataset1.count_values("ground_truth.detections.label")
+    view3_counts = view3.count_values("ground_truth.detections.label")
+
+    assert dataset_counts[label] == (
+        dataset1_counts[label] + view3_counts[label]
+    )
+
+    dataset_counts = dataset.count_values("gt.detections.label")
+    view2_counts = view2.count_values("gt.detections.label")
+
+    assert dataset_counts[label] == view2_counts[label]
+
+
+def test_merge_samples_video(basedir):
+    videos_dir = os.path.join(basedir, "merge_samples_video")
+    label = "vehicle"
+
+    dataset = foz.load_zoo_dataset("quickstart-video").clone()
+    dataset.rename_frame_field("ground_truth_detections", "ground_truth")
+
+    dataset1 = dataset.clone()
+    dataset2 = dataset.clone()
+    dataset3 = dataset.clone()
+
+    # Give `dataset2` new field names
+    dataset2.rename_frame_field("ground_truth", "gt")
+
+    # Give `dataset3` new video locations
+    inpaths = dataset3.values("filepath")
+    outpaths = [os.path.join(videos_dir, os.path.basename(f)) for f in inpaths]
+    for inpath, outpath in zip(inpaths, outpaths):
+        etau.copy_file(inpath, outpath)
+
+    dataset3.set_values("filepath", outpaths)
+
+    # Only merge `vehicle` labels
+    view2 = dataset2.filter_labels("frames.gt", F("label") == label)
+    view3 = dataset3.filter_labels("frames.ground_truth", F("label") == label)
+
+    # Perform the merges
+    dataset.merge_samples(view2)
+    dataset.merge_samples(view3)
+
+    # Check that schema is correct
+    schema = dataset.get_frame_field_schema()
+
+    assert "ground_truth" in schema
+    assert "gt" in schema
+
+    #
+    # `dataset` should contain:
+    #   `view2` counts in its `gt` field
+    #   `dataset1` + `view3` counts in its `ground_truth` field
+    #
+
+    dataset_counts = dataset.count_values(
+        "frames.ground_truth.detections.label"
+    )
+    dataset1_counts = dataset1.count_values(
+        "frames.ground_truth.detections.label"
+    )
+    view3_counts = view3.count_values("frames.ground_truth.detections.label")
+
+    assert dataset_counts[label] == (
+        dataset1_counts[label] + view3_counts[label]
+    )
+
+    dataset_counts = dataset.count_values("frames.gt.detections.label")
+    view2_counts = view2.count_values("frames.gt.detections.label")
+
+    assert dataset_counts[label] == view2_counts[label]
+
+
+if __name__ == "__main__":
+    fo.config.show_progress_bars = True
+    pytest.main([__file__])


### PR DESCRIPTION
Adds support for efficiently merging video datasets using aggregations, as opposed to explicit iteration over the samples.

This efficient implementation is automatically used when `Dataset.merge_samples()` is called as long as no optional kwargs are passed that prevents its use.

### Benchmarking

The examples below can be reverted to the non-efficient implementation by passing `overwrite=False` to `merge_samples()`. Here are the benchmarking results for each example:

Image example
- This PR: `63.7 ms`
- Previous: `6.1 seconds`

Video example:
- This PR: `2.6 seconds`
- Previous: `34.0 seconds`

### Example: merging an image dataset

```py
import os

import eta.core.utils as etau

import fiftyone as fo
import fiftyone.zoo as foz
from fiftyone import ViewField as F

IMAGES_DIR = "/tmp/quickstart"

dataset = foz.load_zoo_dataset("quickstart").clone()

dataset1 = dataset.clone()
dataset2 = dataset.clone()
dataset3 = dataset.clone()

# Give `dataset2` new field names
dataset2.rename_sample_field("ground_truth", "gt")

# Give `dataset3` new image locations
inpaths = dataset3.values("filepath")
outpaths = [os.path.join(IMAGES_DIR, os.path.basename(f)) for f in inpaths]
for inpath, outpath in zip(inpaths, outpaths):
    etau.copy_file(inpath, outpath)

dataset3.set_values("filepath", outpaths)

# Only merge `person` labels
view2 = dataset2.filter_labels("gt", F("label") == "person")
view3 = dataset3.filter_labels("ground_truth", F("label") == "person")

# Perform the merges
dataset.merge_samples(view2)
dataset.merge_samples(view3)

# Check that schema is correct
print(dataset)

#
# `dataset` should contain:
#   `view2` counts in its `gt` field
#   `dataset1` + `view3` counts in its `ground_truth` field
#

print(dataset.count_values("ground_truth.detections.label"))
print(dataset1.count_values("ground_truth.detections.label"))
print(view3.count_values("ground_truth.detections.label"))

print(dataset.count_values("gt.detections.label"))
print(view2.count_values("gt.detections.label"))

# Double-check everything is working in App
session = fo.launch_app(dataset)
```

### Example: merging a video dataset

```py
import os

import eta.core.utils as etau

import fiftyone as fo
import fiftyone.zoo as foz
from fiftyone import ViewField as F

VIDEOS_DIR = "/tmp/quickstart-video"

dataset = foz.load_zoo_dataset("quickstart-video").clone()
dataset.rename_frame_field("ground_truth_detections", "ground_truth")

dataset1 = dataset.clone()
dataset2 = dataset.clone()
dataset3 = dataset.clone()

# Give `dataset2` new field names
dataset2.rename_frame_field("ground_truth", "gt")

# Give `dataset3` new video locations
inpaths = dataset3.values("filepath")
outpaths = [os.path.join(VIDEOS_DIR, os.path.basename(f)) for f in inpaths]
for inpath, outpath in zip(inpaths, outpaths):
    etau.copy_file(inpath, outpath)

dataset3.set_values("filepath", outpaths)

# Only merge `vehicle` labels
view2 = dataset2.filter_labels("frames.gt", F("label") == "vehicle")
view3 = dataset3.filter_labels("frames.ground_truth", F("label") == "vehicle")

dataset.merge_samples(view2)
dataset.merge_samples(view3)

# Check that schema is correct
print(dataset)

#
# `dataset` should contain:
#   `view2` counts in its `gt` field
#   `dataset1` + `view3` counts in its `ground_truth` field
#

print(dataset.count_values("frames.ground_truth.detections.label"))
print(dataset1.count_values("frames.ground_truth.detections.label"))
print(view3.count_values("frames.ground_truth.detections.label"))

print(dataset.count_values("frames.gt.detections.label"))
print(view2.count_values("frames.gt.detections.label"))

# Double-check everything is working in App
session = fo.launch_app(dataset)
```

