### PR TITLE
Hide label attributes by default in Player51

### DIFF
--- a/docs/source/user_guide/config.rst
+++ b/docs/source/user_guide/config.rst
@@ -258,7 +258,7 @@ The FiftyOne App can be configured in the ways described below:
 +-------------------+---------------------------------+-----------------------------+------------------------------------------------------------------------------------------+
 | `notebook_height` | `FIFTYONE_APP_NOTEBOOK_HEIGHT`  | `800`                       | The default height of App instances displayed in notebook cells.                         |
 +-------------------+---------------------------------+-----------------------------+------------------------------------------------------------------------------------------+
-| `show_attributes` | `FIFTYONE_APP_SHOW_ATTRIBUTES`  | `True`                      | Whether to show attributes when rendering labels in the App's expanded sample view.      |
+| `show_attributes` | `FIFTYONE_APP_SHOW_ATTRIBUTES`  | `False`                     | Whether to show attributes when rendering labels in the App's expanded sample view.      |
 +-------------------+---------------------------------+-----------------------------+------------------------------------------------------------------------------------------+
 | `show_confidence` | `FIFTYONE_APP_SHOW_CONFIDENCE`  | `True`                      | Whether to show confidences when rendering labels in the App's expanded sample view.     |
 +-------------------+---------------------------------+-----------------------------+------------------------------------------------------------------------------------------+

--- a/fiftyone/core/config.py
+++ b/fiftyone/core/config.py
@@ -221,7 +221,7 @@ class AppConfig(EnvConfig):
             d,
             "show_attributes",
             env_var="FIFTYONE_APP_SHOW_ATTRIBUTES",
-            default=True,
+            default=False,
         )
         self.show_confidence = self.parse_bool(
             d,


### PR DESCRIPTION
Per user feedback, it makes sense to not render attributes in detection bounding boxes now that the tooltip exists and is shown by default.