### PR TITLE
Adding type checks for Session property setters

### DIFF
--- a/fiftyone/core/session.py
+++ b/fiftyone/core/session.py
@@ -18,6 +18,7 @@ import fiftyone as fo
 import fiftyone.constants as focn
 import fiftyone.core.dataset as fod
 import fiftyone.core.client as foc
+from fiftyone.core.config import AppConfig
 import fiftyone.core.context as focx
 import fiftyone.core.frame as fof
 import fiftyone.core.media as fom
@@ -25,6 +26,7 @@ import fiftyone.core.plots as fop
 import fiftyone.core.sample as fosa
 import fiftyone.core.service as fos
 import fiftyone.core.utils as fou
+import fiftyone.core.view as fov
 import fiftyone.utils.templates as fout
 from fiftyone.core.state import StateDescription
 
@@ -425,6 +427,15 @@ class Session(foc.HasClient):
 
     @config.setter
     def config(self, config):
+        if config is None:
+            config = fo.app_config.copy()
+
+        if not isinstance(config, AppConfig):
+            raise ValueError(
+                "`Session.config` must be a %s or None; found %s"
+                % (AppConfig, type(config))
+            )
+
         self.state.config = config
 
     @property
@@ -446,6 +457,12 @@ class Session(foc.HasClient):
     @dataset.setter
     @_update_state(auto_show=True)
     def dataset(self, dataset):
+        if dataset is not None and not isinstance(dataset, fod.Dataset):
+            raise ValueError(
+                "`Session.dataset` must be a %s or None; found %s"
+                % (fod.Dataset, type(dataset))
+            )
+
         if dataset is not None:
             dataset._reload()
 
@@ -472,7 +489,14 @@ class Session(foc.HasClient):
     @view.setter
     @_update_state(auto_show=True)
     def view(self, view):
+        if view is not None and not isinstance(view, fov.DatasetView):
+            raise ValueError(
+                "`Session.view` must be a %s or None; found %s"
+                % (fov.DatasetView, type(view))
+            )
+
         self.state.view = view
+
         if view is not None:
             self.state.dataset = self.state.view._dataset
             self.state.dataset._reload()
@@ -502,6 +526,12 @@ class Session(foc.HasClient):
 
     @plots.setter
     def plots(self, plots):
+        if plots is not None and not isinstance(plots, fop.PlotManager):
+            raise ValueError(
+                "`Session.plots` must be a %s or None; found %s"
+                % (fop.PlotManager, type(plots))
+            )
+
         if plots is None:
             plots = fop.PlotManager(self)
         else:


### PR DESCRIPTION
Resolves https://github.com/voxel51/fiftyone/issues/944.

#### Example usage

```py
import fiftyone as fo
import fiftyone.zoo as foz

dataset = foz.load_zoo_dataset("quickstart")
other_dataset = dataset.clone()

session = fo.launch_app(dataset)

# these are all allowed
session.view = dataset.view()
session.view = other_dataset.view()
session.dataset = other_dataset
session.config = session.config.copy()
session.view = None
session.dataset = None
session.config = None

# these are not allowed and now raise informative error messages
session.dataset = dataset.view()
session.view = other_dataset
session.config = {}
session.plots = {}
```

#### Side note

I thought about performing the following silent "type casts", but I think its preferable to force the user to provide the correct type data to ensure they understand the difference between changing a view into a dataset versus changing the entire dataset
- `session.view = dataset` --> `session.view = dataset.view()`
- `session.dataset = view` --> `session.dataset = view._dataset`
