### PR TITLE
Updating migration revision

### DIFF
--- a/fiftyone/migrations/revisions/v0_8_0.py
+++ b/fiftyone/migrations/revisions/v0_8_0.py
@@ -1,5 +1,5 @@
 """
-FiftyOne v0.7.5 revision.
+FiftyOne v0.8.0 revision.
 
 | Copyright 2017-2021, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_


### PR DESCRIPTION
The bleeding edge migrations had been accumulating under v0.7.5, but the next release ended up being v0.8.0.