### PR TITLE
Proper handling of lists of expressions in view stages

### DIFF
--- a/app/src/components/ViewBar/ViewBar.tsx
+++ b/app/src/components/ViewBar/ViewBar.tsx
@@ -83,6 +83,7 @@ const ViewBar = React.memo(() => {
   const [state, send] = useMachine(viewBarMachine);
   const [view, setView] = useRecoilState(selectors.view);
   const fieldPaths = useRecoilValue(selectors.fieldPaths);
+  console.log(view);
 
   useEffect(() => {
     send({

--- a/app/src/components/ViewBar/ViewBar.tsx
+++ b/app/src/components/ViewBar/ViewBar.tsx
@@ -83,7 +83,6 @@ const ViewBar = React.memo(() => {
   const [state, send] = useMachine(viewBarMachine);
   const [view, setView] = useRecoilState(selectors.view);
   const fieldPaths = useRecoilValue(selectors.fieldPaths);
-  console.log(view);
 
   useEffect(() => {
     send({

--- a/app/src/components/ViewBar/ViewStage/ViewStageParameter.tsx
+++ b/app/src/components/ViewBar/ViewStage/ViewStageParameter.tsx
@@ -379,7 +379,7 @@ const ViewStageParameter = React.memo(({ parameterRef, barRef, stageRef }) => {
               autoFocus={state.matches("editing")}
               value={
                 isObject
-                  ? "..."
+                  ? ". . ."
                   : state.matches("reading") && value.length > 24
                   ? value.slice(0, 25) + "..."
                   : value

--- a/app/src/components/ViewBar/ViewStage/ViewStageParameter.tsx
+++ b/app/src/components/ViewBar/ViewStage/ViewStageParameter.tsx
@@ -125,7 +125,7 @@ const Submit = React.memo(({ send }) => {
 
 const convert = (value, placeholder) => {
   const isObject = PARSER.dict.validate(value);
-  if (isObject) return "{ ... }";
+  if (isObject) return "  . . .  ";
   else if (value === "") {
     return placeholder;
   }
@@ -307,9 +307,11 @@ const ViewStageParameter = React.memo(({ parameterRef, barRef, stageRef }) => {
     results,
     bestMatch,
   } = state.context;
-  const hasObjectType = typeof type === "string" && type.includes("dict");
+  const hasObjectType = type
+    .split("|")
+    .some((t) => ["dict", "json"].includes(t));
 
-  const hasExpansion = state.context.type === "dict|str";
+  const hasExpansion = type === "dict|str";
   const isObjectEditor = hasObjectType && (!hasExpansion || expanded);
   let isObject = false;
   try {
@@ -377,7 +379,7 @@ const ViewStageParameter = React.memo(({ parameterRef, barRef, stageRef }) => {
               autoFocus={state.matches("editing")}
               value={
                 isObject
-                  ? "{ ... }"
+                  ? "..."
                   : state.matches("reading") && value.length > 24
                   ? value.slice(0, 25) + "..."
                   : value

--- a/app/src/components/ViewBar/ViewStage/viewStageParameterMachine.ts
+++ b/app/src/components/ViewBar/ViewStage/viewStageParameterMachine.ts
@@ -29,12 +29,6 @@ export const toTypeAnnotation = (type: string): string => {
  * for details about numbers and javascript
  */
 export const PARSER = {
-  NoneType: {
-    castFrom: (value) => (value === null ? "None" : value),
-    castTo: () => null,
-    parse: () => "None",
-    validate: (value) => [null, "None", ""].some((v) => value === v),
-  },
   bool: {
     castFrom: (value) => (value ? "True" : "False"),
     castTo: (value) => ["true", "false"].indexOf(value.toLowerCase()) === 0,
@@ -63,58 +57,6 @@ export const PARSER = {
       return stripped !== "" && !isNaN(+stripped);
     },
   },
-  id: {
-    castFrom: (value) => value,
-    castTo: (value) => value,
-    parse: (value) => value,
-    validate: (value) => /[0-9A-Fa-f]{24}/g.test(value),
-  },
-  int: {
-    castFrom: (value) => String(value).replace(/\B(?=(\d{3})+(?!\d))/g, ","),
-    castTo: (value) => +value.replace(/[,\s]/g, ""),
-    parse: (value) =>
-      String(+value.replace(/[,\s]/g, "")).replace(
-        /\B(?=(\d{3})+(?!\d))/g,
-        ","
-      ),
-    validate: (value) => /^\d+$/.test(convert(value).replace(/[,\s]/g, "")),
-  },
-  "list<str>": {
-    castFrom: (value) => value.join(","),
-    castTo: (value) => value.split(","),
-    parse: (value) => value.replace(/[\s\'\"\[\]]/g, ""),
-    validate: (value) => {
-      const stripped = value.replace(/[\s]/g, "");
-      let array = null;
-      try {
-        array = JSON.parse(stripped);
-      } catch {
-        array = stripped.split(",");
-      }
-      return Array.isArray(array) && array.every((e) => PARSER.str.validate(e));
-    },
-  },
-  "list<id>": {
-    castFrom: (value) => value.join(","),
-    castTo: (value) => value.split(","),
-    parse: (value) => value.replace(/[\s\'\"\[\]]/g, ""),
-    validate: (value) => {
-      const stripped = value.replace(/[\s]/g, "");
-      let array = null;
-      try {
-        array = JSON.parse(stripped);
-      } catch {
-        array = stripped.split(",");
-      }
-      return Array.isArray(array) && array.every((e) => PARSER.id.validate(e));
-    },
-  },
-  str: {
-    castFrom: (value) => value,
-    castTo: (value) => value,
-    parse: (value) => value,
-    validate: () => true,
-  },
   field: {
     castFrom: (value) => value,
     castTo: (value) => value,
@@ -136,6 +78,22 @@ export const PARSER = {
       }
     },
   },
+  id: {
+    castFrom: (value) => value,
+    castTo: (value) => value,
+    parse: (value) => value,
+    validate: (value) => /[0-9A-Fa-f]{24}/g.test(value),
+  },
+  int: {
+    castFrom: (value) => String(value).replace(/\B(?=(\d{3})+(?!\d))/g, ","),
+    castTo: (value) => +value.replace(/[,\s]/g, ""),
+    parse: (value) =>
+      String(+value.replace(/[,\s]/g, "")).replace(
+        /\B(?=(\d{3})+(?!\d))/g,
+        ","
+      ),
+    validate: (value) => /^\d+$/.test(convert(value).replace(/[,\s]/g, "")),
+  },
   json: {
     castFrom: (value) => JSON.stringify(value, null, 2),
     castTo: (value) => (typeof value === "string" ? JSON.parse(value) : value),
@@ -148,6 +106,66 @@ export const PARSER = {
         return false;
       }
     },
+  },
+  "list<field>": {
+    castFrom: (value) => value.join(","),
+    castTo: (value) => value.split(","),
+    parse: (value) => value.replace(/[\s\'\"\[\]]/g, ""),
+    validate: (value, fields) => {
+      const stripped = value.replace(/[\s]/g, "");
+      let array = null;
+      try {
+        array = JSON.parse(stripped);
+      } catch {
+        array = stripped.split(",");
+      }
+      return (
+        Array.isArray(array) &&
+        array.every((e) => PARSER.field.validate(e, fields))
+      );
+    },
+  },
+  "list<id>": {
+    castFrom: (value) => value.join(","),
+    castTo: (value) => value.split(","),
+    parse: (value) => value.replace(/[\s\'\"\[\]]/g, ""),
+    validate: (value) => {
+      const stripped = value.replace(/[\s]/g, "");
+      let array = null;
+      try {
+        array = JSON.parse(stripped);
+      } catch {
+        array = stripped.split(",");
+      }
+      return Array.isArray(array) && array.every((e) => PARSER.id.validate(e));
+    },
+  },
+  "list<str>": {
+    castFrom: (value) => value.join(","),
+    castTo: (value) => value.split(","),
+    parse: (value) => value.replace(/[\s\'\"\[\]]/g, ""),
+    validate: (value) => {
+      const stripped = value.replace(/[\s]/g, "");
+      let array = null;
+      try {
+        array = JSON.parse(stripped);
+      } catch {
+        array = stripped.split(",");
+      }
+      return Array.isArray(array) && array.every((e) => PARSER.str.validate(e));
+    },
+  },
+  NoneType: {
+    castFrom: (value) => (value === null ? "None" : value),
+    castTo: () => null,
+    parse: () => "None",
+    validate: (value) => [null, "None", ""].some((v) => value === v),
+  },
+  str: {
+    castFrom: (value) => value,
+    castTo: (value) => value,
+    parse: (value) => value,
+    validate: () => true,
   },
 };
 

--- a/app/src/components/ViewBar/ViewStage/viewStageParameterMachine.ts
+++ b/app/src/components/ViewBar/ViewStage/viewStageParameterMachine.ts
@@ -7,7 +7,7 @@ const { assign } = actions;
 
 const convert = (v) => (typeof v !== "string" ? String(v) : v);
 
-export const toTypeAnnotation = (type) => {
+export const toTypeAnnotation = (type: string): string => {
   if (type.includes("|")) {
     return [
       "Union[",
@@ -131,6 +131,19 @@ export const PARSER = {
       try {
         const v = typeof value === "string" ? JSON.parse(value) : value;
         return v instanceof Object && !Array.isArray(value);
+      } catch {
+        return false;
+      }
+    },
+  },
+  json: {
+    castFrom: (value) => JSON.stringify(value, null, 2),
+    castTo: (value) => (typeof value === "string" ? JSON.parse(value) : value),
+    parse: (value) => value,
+    validate: (value) => {
+      try {
+        JSON.parse(value);
+        return true;
       } catch {
         return false;
       }

--- a/app/src/utils/generic.ts
+++ b/app/src/utils/generic.ts
@@ -1,4 +1,4 @@
-export const isElectron = () => {
+export const isElectron = (): boolean => {
   return (
     window.process &&
     window.process.versions &&
@@ -6,6 +6,6 @@ export const isElectron = () => {
   );
 };
 
-export const isFloat = (n) => {
+export const isFloat = (n: number): boolean => {
   return Number(n) === n && n % 1 !== 0;
 };

--- a/fiftyone/core/aggregations.py
+++ b/fiftyone/core/aggregations.py
@@ -1266,7 +1266,9 @@ def _parse_field_and_expr(
     sample_collection, field_name, expr, auto_unwind, allow_missing
 ):
     if expr is not None:
-        pipeline = sample_collection._make_set_field_pipeline(field_name, expr)
+        pipeline, _ = sample_collection._make_set_field_pipeline(
+            field_name, expr
+        )
     else:
         pipeline = []
 

--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -1767,8 +1767,8 @@ class SampleCollection(object):
 
     @view_stage
     def filter_field(self, field, filter, only_matches=True):
-        """Filters the values of a given sample (or embedded document) field
-        of each sample in the collection.
+        """Filters the values of a field or embedded field of each sample in
+        the collection.
 
         Values of ``field`` for which ``filter`` returns ``False`` are
         replaced with ``None``.
@@ -1816,7 +1816,7 @@ class SampleCollection(object):
             view = dataset.filter_field("numeric_field", F() > 0)
 
         Args:
-            field: the name of the field to filter
+            field: the field name or ``embedded.field.name``
             filter: a :class:`fiftyone.core.expressions.ViewExpression` or
                 `MongoDB expression <https://docs.mongodb.com/manual/meta/aggregation-quick-reference/#aggregation-expressions>`_
                 that returns a boolean describing the filter to apply
@@ -2093,7 +2093,7 @@ class SampleCollection(object):
             view = dataset.filter_labels("predictions", F("points").length() < 4)
 
         Args:
-            field: the labels field to filter
+            field: the label field to filter
             filter: a :class:`fiftyone.core.expressions.ViewExpression` or
                 `MongoDB expression <https://docs.mongodb.com/manual/meta/aggregation-quick-reference/#aggregation-expressions>`_
                 that returns a boolean describing the filter to apply
@@ -2684,7 +2684,7 @@ class SampleCollection(object):
             print(view.count_values("predictions.detections.is_animal"))
 
         Args:
-            field: the field or embedded field to set
+            field: the field or ``embedded.field.name`` to set
             expr: a :class:`fiftyone.core.expressions.ViewExpression` or
                 `MongoDB expression <https://docs.mongodb.com/manual/meta/aggregation-quick-reference/#aggregation-expressions>`_
                 that defines the field value to set
@@ -3237,11 +3237,6 @@ class SampleCollection(object):
         """Sorts the samples in the collection by the given field or
         expression.
 
-        When sorting by an expression, ``field_or_expr`` can either be a
-        :class:`fiftyone.core.expressions.ViewExpression` or a
-        `MongoDB expression <https://docs.mongodb.com/manual/meta/aggregation-quick-reference/#aggregation-expressions>`_
-        that defines the quantity to sort by.
-
         Examples::
 
             import fiftyone as fo
@@ -3270,7 +3265,10 @@ class SampleCollection(object):
             view = dataset.sort_by(small_boxes.length(), reverse=True)
 
         Args:
-            field_or_expr: the field or expression to sort by
+            field_or_expr: the field or ``embedded.field.name`` to sort by, or
+                a :class:`fiftyone.core.expressions.ViewExpression` or a
+                `MongoDB expression <https://docs.mongodb.com/manual/meta/aggregation-quick-reference/#aggregation-expressions>`_
+                that defines the quantity to sort by
             reverse (False): whether to return the results in descending order
 
         Returns:

--- a/fiftyone/core/expressions.py
+++ b/fiftyone/core/expressions.py
@@ -19,6 +19,33 @@ from fiftyone.core.odm.document import MongoEngineBaseDocument
 import fiftyone.core.utils as fou
 
 
+def to_mongo(expr, prefix=None):
+    """Converts an expression to its MongoDB representation.
+
+    Args:
+        expr: a :class:`ViewExpression` or an already serialized
+            `MongoDB expression <https://docs.mongodb.com/manual/meta/aggregation-quick-reference/#aggregation-expressions>`_
+        prefix (None): an optional prefix to prepend to all :class:`ViewField`
+            instances in the expression
+
+    Returns:
+        a MongoDB expression
+    """
+    if isinstance(expr, ViewExpression):
+        return expr.to_mongo(prefix=prefix)
+
+    if isinstance(expr, dict):
+        return {
+            to_mongo(k, prefix=prefix): to_mongo(v, prefix=prefix)
+            for k, v in expr.items()
+        }
+
+    if isinstance(expr, (list, tuple)):
+        return [to_mongo(e, prefix=prefix) for e in expr]
+
+    return expr
+
+
 class ViewExpression(object):
     """An expression defining a possibly-complex manipulation of a document.
 

--- a/fiftyone/core/stages.py
+++ b/fiftyone/core/stages.py
@@ -954,7 +954,7 @@ class FilterField(ViewStage):
     @classmethod
     def _params(self):
         return [
-            {"name": "field", "type": "field"},
+            {"name": "field", "type": "field|str"},
             {"name": "filter", "type": "json", "placeholder": ""},
             {
                 "name": "only_matches",

--- a/fiftyone/core/stages.py
+++ b/fiftyone/core/stages.py
@@ -600,7 +600,7 @@ class ExcludeLabels(ViewStage):
         return [
             {
                 "name": "labels",
-                "type": "NoneType|dict",  # @todo use "list<dict>" when supported
+                "type": "NoneType|json",
                 "placeholder": "[{...}]",
                 "default": "None",
             },
@@ -814,7 +814,7 @@ class Exists(ViewStage):
     @classmethod
     def _params(cls):
         return [
-            {"name": "field", "type": "field"},
+            {"name": "field", "type": "field|str"},
             {
                 "name": "bool",
                 "type": "bool",
@@ -825,8 +825,8 @@ class Exists(ViewStage):
 
 
 class FilterField(ViewStage):
-    """Filters the values of a given sample (or embedded document) field of
-    each sample in a collection.
+    """Filters the values of a given field or embedded field of each sample in
+    a collection.
 
     Values of ``field`` for which ``filter`` returns ``False`` are
     replaced with ``None``.
@@ -876,7 +876,7 @@ class FilterField(ViewStage):
         view = dataset.add_stage(stage)
 
     Args:
-        field: the name of the field to filter
+        field: the field name or ``embedded.field.name``
         filter: a :class:`fiftyone.core.expressions.ViewExpression` or
             `MongoDB aggregation expression <https://docs.mongodb.com/manual/meta/aggregation-quick-reference/#aggregation-expressions>`_
             that returns a boolean describing the filter to apply
@@ -955,7 +955,7 @@ class FilterField(ViewStage):
     def _params(self):
         return [
             {"name": "field", "type": "field"},
-            {"name": "filter", "type": "dict", "placeholder": ""},
+            {"name": "filter", "type": "json", "placeholder": ""},
             {
                 "name": "only_matches",
                 "type": "bool",
@@ -1335,7 +1335,7 @@ class FilterLabels(FilterField):
         view = dataset.add_stage(stage)
 
     Args:
-        field: the labels field to filter
+        field: the label field to filter
         filter: a :class:`fiftyone.core.expressions.ViewExpression` or
             `MongoDB aggregation expression <https://docs.mongodb.com/manual/meta/aggregation-quick-reference/#aggregation-expressions>`_
             that returns a boolean describing the filter to apply
@@ -1870,10 +1870,10 @@ class GeoNear(_GeoStage):
     @classmethod
     def _params(self):
         return [
-            {"name": "point", "type": "dict", "placeholder": ""},
+            {"name": "point", "type": "json", "placeholder": ""},
             {
                 "name": "location_field",
-                "type": "NoneType|field",
+                "type": "NoneType|field|str",
                 "placeholder": "",
                 "default": "None",
             },
@@ -1982,10 +1982,10 @@ class GeoWithin(_GeoStage):
     @classmethod
     def _params(self):
         return [
-            {"name": "boundary", "type": "dict", "placeholder": ""},
+            {"name": "boundary", "type": "json", "placeholder": ""},
             {
                 "name": "location_field",
-                "type": "NoneType|field",
+                "type": "NoneType|field|str",
                 "placeholder": "",
                 "default": "None",
             },
@@ -2408,7 +2408,7 @@ class SetField(ViewStage):
         print(view.count_values("predictions.detections.is_animal"))
 
     Args:
-        field: the field or embedded field to set
+        field: the field or ``embedded.field.name`` to set
         expr: a :class:`fiftyone.core.expressions.ViewExpression or
             `MongoDB aggregation expression <https://docs.mongodb.com/manual/meta/aggregation-quick-reference/#aggregation-expressions>`_
             that defines the field value to set
@@ -2630,7 +2630,7 @@ class Match(ViewStage):
 
     @classmethod
     def _params(cls):
-        return [{"name": "filter", "type": "dict", "placeholder": ""}]
+        return [{"name": "filter", "type": "json", "placeholder": ""}]
 
 
 class MatchTags(ViewStage):
@@ -2818,7 +2818,7 @@ class Mongo(ViewStage):
 
     @classmethod
     def _params(self):
-        return [{"name": "pipeline", "type": "dict", "placeholder": ""}]
+        return [{"name": "pipeline", "type": "json", "placeholder": ""}]
 
 
 class Select(ViewStage):
@@ -3035,7 +3035,7 @@ class SelectFields(ViewStage):
         return [
             {
                 "name": "field_names",
-                "type": "NoneType|list<str>",
+                "type": "NoneType|list<field>|field|list<str>|str",
                 "default": "None",
                 "placeholder": "list,of,fields",
             }
@@ -3216,7 +3216,7 @@ class SelectLabels(ViewStage):
         return [
             {
                 "name": "labels",
-                "type": "NoneType|dict",  # @todo use "list<dict>" when supported
+                "type": "NoneType|json",
                 "placeholder": "[{...}]",
                 "default": "None",
             },
@@ -3234,7 +3234,7 @@ class SelectLabels(ViewStage):
             },
             {
                 "name": "fields",
-                "type": "NoneType|list<str>|str",
+                "type": "NoneType|list<field>|field|list<str>|str",
                 "placeholder": "...",
                 "default": "None",
             },
@@ -3514,11 +3514,6 @@ class Skip(ViewStage):
 class SortBy(ViewStage):
     """Sorts the samples in a collection by the given field or expression.
 
-    When sorting by an expression, ``field_or_expr`` can either be a
-    :class:`fiftyone.core.expressions.ViewExpression` or a
-    `MongoDB aggregation expression <https://docs.mongodb.com/manual/meta/aggregation-quick-reference/#aggregation-expressions>`_
-    that defines the quantity to sort by.
-
     Examples::
 
         import fiftyone as fo
@@ -3548,7 +3543,10 @@ class SortBy(ViewStage):
         view = dataset.add_stage(stage)
 
     Args:
-        field_or_expr: the field or expression to sort by
+        field_or_expr: the field or ``embedded.field.name`` to sort by, or a
+            :class:`fiftyone.core.expressions.ViewExpression` or a
+            `MongoDB aggregation expression <https://docs.mongodb.com/manual/meta/aggregation-quick-reference/#aggregation-expressions>`_
+            that defines the quantity to sort by
         reverse (False): whether to return the results in descending order
     """
 
@@ -3598,7 +3596,7 @@ class SortBy(ViewStage):
     @classmethod
     def _params(cls):
         return [
-            {"name": "field_or_expr", "type": "dict|str"},
+            {"name": "field_or_expr", "type": "field|str|json"},
             {
                 "name": "reverse",
                 "type": "bool",

--- a/fiftyone/core/stages.py
+++ b/fiftyone/core/stages.py
@@ -607,19 +607,19 @@ class ExcludeLabels(ViewStage):
             {
                 "name": "ids",
                 "type": "NoneType|list<id>|id",
-                "placeholder": "...",
+                "placeholder": "ids",
                 "default": "None",
             },
             {
                 "name": "tags",
                 "type": "NoneType|list<str>|str",
-                "placeholder": "...",
+                "placeholder": "tags",
                 "default": "None",
             },
             {
                 "name": "fields",
                 "type": "NoneType|list<str>|str",
-                "placeholder": "...",
+                "placeholder": "fields",
                 "default": "None",
             },
         ]
@@ -2901,7 +2901,7 @@ class Select(ViewStage):
                 "name": "ordered",
                 "type": "bool",
                 "default": "False",
-                "placeholder": "bool (default=False)",
+                "placeholder": "ordered (default=False)",
             },
         ]
 
@@ -3223,19 +3223,19 @@ class SelectLabels(ViewStage):
             {
                 "name": "ids",
                 "type": "NoneType|list<id>|id",
-                "placeholder": "...",
+                "placeholder": "ids",
                 "default": "None",
             },
             {
                 "name": "tags",
                 "type": "NoneType|list<str>|str",
-                "placeholder": "...",
+                "placeholder": "tags",
                 "default": "None",
             },
             {
                 "name": "fields",
                 "type": "NoneType|list<field>|field|list<str>|str",
-                "placeholder": "...",
+                "placeholder": "fields",
                 "default": "None",
             },
         ]

--- a/fiftyone/core/stages.py
+++ b/fiftyone/core/stages.py
@@ -2460,11 +2460,9 @@ class SetField(ViewStage):
 
     @classmethod
     def _params(self):
-        # @todo `expr` can actually be any valid JSON, including ints, strings
-        # lists, etc
         return [
-            {"name": "field", "type": "field"},
-            {"name": "expr", "type": "NoneType|dict", "placeholder": ""},
+            {"name": "field", "type": "field|str"},
+            {"name": "expr", "type": "json", "placeholder": ""},
         ]
 
     def _get_mongo_expr(self):


### PR DESCRIPTION
* Resolves #962
* Resolves #948

```py
import fiftyone as fo
import fiftyone.zoo as foz
from fiftyone import ViewField as F

dataset = foz.load_zoo_dataset("quickstart")

upper_bbox = [F("bounding_box")[0], F("bounding_box")[1], F("bounding_box")[2], F("bounding_box")[3] / 2]

view = dataset.set_field("predictions.detections.bounding_box", upper_bbox)

# previously did not work, now does
session = fo.launch_app(view=view)
```
