### PR TITLE
Expanded view counts and selection

### DIFF
--- a/app/src/components/Actions/ActionsRow.tsx
+++ b/app/src/components/Actions/ActionsRow.tsx
@@ -69,7 +69,13 @@ const Tag = ({ modal }) => {
   );
 };
 
-const Selected = ({ modal, frameNumberRef }) => {
+const Selected = ({
+  modal,
+  frameNumber,
+}: {
+  modal: boolean;
+  frameNumber?: number;
+}) => {
   const [open, setOpen] = useState(false);
   const selectedSamples = useRecoilValue(atoms.selectedSamples);
   const selectedObjects = useRecoilValue(selectors.selectedLabels);
@@ -101,7 +107,7 @@ const Selected = ({ modal, frameNumberRef }) => {
         <Selector
           modal={modal}
           close={() => setOpen(false)}
-          frameNumberRef={frameNumberRef}
+          frameNumber={frameNumber}
           bounds={bounds}
         />
       )}
@@ -213,11 +219,11 @@ const ActionsRowDiv = styled.div`
 
 type ActionsRowProps = {
   modal: boolean;
-  frameNumberRef?: any;
+  frameNumber?: number;
   children: any;
 };
 
-const ActionsRow = ({ modal, frameNumberRef }: ActionsRowProps) => {
+const ActionsRow = ({ modal, frameNumber }: ActionsRowProps) => {
   const style = modal
     ? {
         overflowX: "auto",
@@ -233,7 +239,7 @@ const ActionsRow = ({ modal, frameNumberRef }: ActionsRowProps) => {
       <Tag modal={modal} />
       {modal && <Hidden />}
       {!modal && <SaveFilters />}
-      <Selected modal={modal} frameNumberRef={frameNumberRef} />
+      <Selected modal={modal} frameNumber={frameNumber} />
     </ActionsRowDiv>
   );
 };

--- a/app/src/components/Actions/ActionsRow.tsx
+++ b/app/src/components/Actions/ActionsRow.tsx
@@ -1,4 +1,10 @@
-import React, { useEffect, useLayoutEffect, useRef, useState } from "react";
+import React, {
+  MutableRefObject,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from "react";
 import { CircularProgress } from "@material-ui/core";
 import {
   Check,
@@ -71,10 +77,12 @@ const Tag = ({ modal }) => {
 
 const Selected = ({
   modal,
-  frameNumber,
+  playerRef,
+  frameNumberRef,
 }: {
   modal: boolean;
-  frameNumber?: number;
+  playerRef?: any;
+  frameNumberRef?: MutableRefObject<number>;
 }) => {
   const [open, setOpen] = useState(false);
   const selectedSamples = useRecoilValue(atoms.selectedSamples);
@@ -107,7 +115,8 @@ const Selected = ({
         <Selector
           modal={modal}
           close={() => setOpen(false)}
-          frameNumber={frameNumber}
+          playerRef={playerRef}
+          frameNumberRef={frameNumberRef}
           bounds={bounds}
         />
       )}
@@ -219,11 +228,11 @@ const ActionsRowDiv = styled.div`
 
 type ActionsRowProps = {
   modal: boolean;
-  frameNumber?: number;
+  playerRef?: any;
   children: any;
 };
 
-const ActionsRow = ({ modal, frameNumber }: ActionsRowProps) => {
+const ActionsRow = ({ modal, playerRef }: ActionsRowProps) => {
   const style = modal
     ? {
         overflowX: "auto",
@@ -239,7 +248,7 @@ const ActionsRow = ({ modal, frameNumber }: ActionsRowProps) => {
       <Tag modal={modal} />
       {modal && <Hidden />}
       {!modal && <SaveFilters />}
-      <Selected modal={modal} frameNumber={frameNumber} />
+      <Selected modal={modal} playerRef={playerRef} />
     </ActionsRowDiv>
   );
 };

--- a/app/src/components/Actions/ActionsRow.tsx
+++ b/app/src/components/Actions/ActionsRow.tsx
@@ -229,10 +229,11 @@ const ActionsRowDiv = styled.div`
 type ActionsRowProps = {
   modal: boolean;
   playerRef?: any;
+  frameNumberRef: MutableRefObject<number>;
   children: any;
 };
 
-const ActionsRow = ({ modal, playerRef }: ActionsRowProps) => {
+const ActionsRow = ({ modal, playerRef, frameNumberRef }: ActionsRowProps) => {
   const style = modal
     ? {
         overflowX: "auto",
@@ -248,7 +249,11 @@ const ActionsRow = ({ modal, playerRef }: ActionsRowProps) => {
       <Tag modal={modal} />
       {modal && <Hidden />}
       {!modal && <SaveFilters />}
-      <Selected modal={modal} playerRef={playerRef} />
+      <Selected
+        modal={modal}
+        playerRef={playerRef}
+        frameNumberRef={frameNumberRef}
+      />
     </ActionsRowDiv>
   );
 };

--- a/app/src/components/Actions/Popout.tsx
+++ b/app/src/components/Actions/Popout.tsx
@@ -14,7 +14,7 @@ const Popout = ({ modal, children, style = {}, bounds }) => {
       duration: 100,
     },
   });
-  const { height, width } = useWindowSize();
+  const { width } = useWindowSize();
   const position =
     modal && bounds
       ? {

--- a/app/src/components/Actions/Selected.tsx
+++ b/app/src/components/Actions/Selected.tsx
@@ -15,7 +15,6 @@ import { packageMessage } from "../../utils/socket";
 import { listSampleLabels } from "../../utils/labels";
 import * as labelAtoms from "../Filters/LabelFieldFilters.state";
 import { useSendMessage } from "../../utils/hooks";
-import { update } from "xstate/lib/actionTypes";
 
 type ActionOptionProps = {
   onClick: () => void;

--- a/app/src/components/Actions/Selected.tsx
+++ b/app/src/components/Actions/Selected.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { MutableRefObject } from "react";
 import {
   selector,
   selectorFamily,
@@ -206,11 +206,11 @@ const hasSetDiff = <T extends unknown>(a: Set<T>, b: Set<T>): boolean =>
 const hasSetInt = <T extends unknown>(a: Set<T>, b: Set<T>): boolean =>
   new Set([...a].filter((e) => b.has(e))).size > 0;
 
-const useModalActions = (frameNumber, close) => {
+const useModalActions = (frameNumberRef, close) => {
   const selectedLabels = useRecoilValue(selectors.selectedLabelIds);
   const visibleSampleLabels = useRecoilValue(visibleModalSampleLabelIds);
   const visibleFrameLabels = useRecoilValue(
-    visibleModalCurrentFrameLabelIds(frameNumber)
+    visibleModalCurrentFrameLabelIds(frameNumberRef.current)
   );
   const isVideo = useRecoilValue(selectors.isVideoDataset);
   const closeAndCall = (callback) => {
@@ -234,7 +234,7 @@ const useModalActions = (frameNumber, close) => {
     isVideo && {
       text: "Select visible (current frame)",
       disabled: !hasSetDiff(visibleFrameLabels, selectedLabels),
-      onClick: closeAndCall(useSelectVisibleFrame(frameNumber)),
+      onClick: closeAndCall(useSelectVisibleFrame(frameNumberRef.current)),
     },
     {
       text: "Clear selection",
@@ -257,18 +257,21 @@ const useModalActions = (frameNumber, close) => {
 interface SelectionActionsProps {
   modal: boolean;
   close: () => void;
-  frameNumber?: number;
+  playerRef?: any;
+  frameNumberRef: MutableRefObject<number>;
   bounds: any;
 }
 
 const SelectionActions = ({
   modal,
   close,
-  frameNumber,
+  playerRef,
+  frameNumberRef,
   bounds,
 }: SelectionActionsProps) => {
+  playerRef.current && playerRef.current.pause && playerRef.current.pause();
   const actions = modal
-    ? useModalActions(frameNumber, close)
+    ? useModalActions(frameNumberRef, close)
     : useGridActions(close);
 
   return (

--- a/app/src/components/Actions/Selected.tsx
+++ b/app/src/components/Actions/Selected.tsx
@@ -287,7 +287,7 @@ const SelectionActions = ({
   frameNumberRef,
   bounds,
 }: SelectionActionsProps) => {
-  playerRef.current && playerRef.current.pause && playerRef.current.pause();
+  playerRef?.current?.pause && playerRef.current.pause();
   const actions = modal
     ? useModalActions(frameNumberRef, close)
     : useGridActions(close);

--- a/app/src/components/Actions/Selected.tsx
+++ b/app/src/components/Actions/Selected.tsx
@@ -1,20 +1,19 @@
 import React from "react";
 import {
+  RecoilValueReadOnly,
+  selector,
+  selectorFamily,
   useRecoilCallback,
-  useRecoilState,
   useRecoilValue,
-  useSetRecoilState,
 } from "recoil";
 
 import Popout from "./Popout";
 import { HoverItemDiv, useHighlightHover } from "./utils";
 import * as atoms from "../../recoil/atoms";
 import * as selectors from "../../recoil/selectors";
+import * as labelAtoms from "../Filters/LabelFieldFilters.state";
 import socket from "../../shared/connection";
 import { packageMessage } from "../../utils/socket";
-import { listSampleLabels } from "../../utils/labels";
-import * as labelAtoms from "../Filters/LabelFieldFilters.state";
-import { useSendMessage } from "../../utils/hooks";
 
 type ActionOptionProps = {
   onClick: () => void;
@@ -42,39 +41,6 @@ const ActionOption = ({
       {text}
     </HoverItemDiv>
   );
-};
-
-const addLabelsToSelection = (
-  selection: atoms.SelectedLabelMap,
-  addition: atoms.SelectedLabel[]
-) => {
-  return {
-    ...selection,
-    ...Object.fromEntries(
-      addition.map(({ label_id, ...rest }) => [label_id, rest])
-    ),
-  };
-};
-
-const removeMatchingLabelsFromSelection = (
-  selection: atoms.SelectedLabelMap,
-  filter: atoms.SelectedLabelData
-) => {
-  const newSelection = { ...selection };
-  if (Object.keys(filter).length) {
-    for (const [label_id, data] of Object.entries(selection)) {
-      if (
-        (filter.sample_id === undefined ||
-          filter.sample_id === data.sample_id) &&
-        (filter.field === undefined || filter.field === data.field) &&
-        (filter.frame_number === undefined ||
-          filter.frame_number === data.frame_number)
-      ) {
-        delete newSelection[label_id];
-      }
-    }
-  }
-  return newSelection;
 };
 
 const getGridActions = (close: () => void) => {
@@ -129,173 +95,123 @@ const getGridActions = (close: () => void) => {
   ];
 };
 
-const _addFrameNumberToLabels = (labels, frame_number) =>
-  labels.map((label) => ({ ...label, frame_number }));
+const visibleModalSampleLabels = selector<atoms.SelectedLabel[]>({
+  key: "visibleModalSampleLabels",
+  get: ({ get }) => {
+    return get(labelAtoms.modalLabels).filter(
+      ({ frame_number }) => typeof frame_number !== "number"
+    );
+  },
+});
+
+const visibleModalSampleLabelIds = selector<Set<string>>({
+  key: "visibleModalSampleLabelIds",
+  get: ({ get }) => {
+    return new Set(
+      get(visibleModalSampleLabels).map(({ label_id }) => label_id)
+    );
+  },
+});
+
+const visibleModalFrameLabelIds = selector<Set<string>>({
+  key: "visibleModalFrameLabelIds",
+  get: ({ get }) => {
+    return new Set(
+      get(labelAtoms.modalLabels)
+        .filter(({ frame_number }) => typeof frame_number === "number")
+        .map(({ label_id }) => label_id)
+    );
+  },
+});
+
+const visibleModalCurrentFrameLabelIds = selectorFamily<Set<string>, number>({
+  key: "visibleModalCurrentFrameLabelIds",
+  get: (frameNumber) => ({ get }) => {
+    return new Set(
+      get(labelAtoms.modalLabels)
+        .filter(({ frame_number }) => frame_number === frameNumber)
+        .map(({ label_id }) => label_id)
+    );
+  },
+});
+
+const toLabelMap = (labels: atoms.SelectedLabel[]) =>
+  Object.fromEntries(labels.map(({ label_id, ...rest }) => [label_id, rest]));
+
+const useSelectVisible = () => {
+  return useRecoilCallback(({ snapshot, set }) => async () => {
+    const selected = await snapshot.getPromise(selectors.selectedLabels);
+    const visible = await snapshot.getPromise(visibleModalSampleLabels);
+    set(selectors.selectedLabels, {
+      ...selected,
+      ...toLabelMap(visible),
+    });
+  });
+};
+
+const useClearSelectedLabels = () => {
+  return useRecoilCallback(({ set }) => async () =>
+    set(selectors.selectedLabels, {})
+  );
+};
+
+const useHideSelected = () => {
+  return useRecoilCallback(({ snapshot, set }) => async () => {
+    const selected = await snapshot.getPromise(selectors.selectedLabels);
+    const hidden = await snapshot.getPromise(atoms.hiddenLabels);
+    set(selectors.selectedLabels, {});
+    set(atoms.hiddenLabels, { ...hidden, ...selected });
+  });
+};
+
+const useHideOthers = () => {
+  return useRecoilCallback(({ snapshot, set }) => async () => {
+    const selected = await snapshot.getPromise(selectors.selectedLabelIds);
+    const visible = await snapshot.getPromise(visibleModalSampleLabels);
+    const hidden = await snapshot.getPromise(atoms.hiddenLabels);
+    set(atoms.hiddenLabels, {
+      ...hidden,
+      ...toLabelMap(visible.filter(({ label_id }) => !selected.has(label_id))),
+    });
+  });
+};
+
+const hasSetDiff = <T extends unknown>(a: Set<T>, b: Set<T>): boolean =>
+  new Set([...a].filter((e) => !b.has(e))).size > 0;
 
 const getModalActions = (frameNumberRef, close) => {
-  const sample = useRecoilValue(selectors.modalSample);
-  const [selectedLabels, setSelectedLabels] = useRecoilState(
-    selectors.selectedLabels
-  );
-  const filter = useRecoilValue(labelAtoms.sampleModalFilter);
-  const setHiddenLabels = useSetRecoilState(atoms.hiddenLabels);
-  const hiddenLabelIds = useRecoilValue(selectors.hiddenLabelIds);
-
-  const sampleFrameData =
-    useRecoilValue(atoms.sampleFrameData(sample._id)) || [];
-  const isVideo = useRecoilValue(selectors.mediaType) == "video";
-  const frameNumber = isVideo ? frameNumberRef.current : null;
-
-  useSendMessage(
-    "set_selected_labels",
-    {
-      selected_labels: Object.entries(
-        selectedLabels
-      ).map(([label_id, label]) => ({ label_id, ...label })),
-    },
-    null,
-    [selectedLabels]
-  );
-
-  const sampleLabels = isVideo
-    ? sampleFrameData
-        .map(listSampleLabels)
-        .filter((o) => hiddenLabelIds.has(o._id))
-        .map((arr, i) => _addFrameNumberToLabels(arr, i + 1))
-        .flat()
-    : listSampleLabels(filter(sample));
-  const frameLabels =
-    isVideo && frameNumber && sampleFrameData[frameNumber - 1]
-      ? _addFrameNumberToLabels(
-          listSampleLabels(
-            filter(sampleFrameData[frameNumber - 1], "frames.")
-          ).filter((l) => !hiddenLabelIds.has(l._id)),
-          frameNumber
-        )
-      : [];
-
-  const numTotalSelectedObjects = Object.keys(selectedLabels).length;
-  const numSampleSelectedObjects = sampleLabels.filter(
-    (label) => selectedLabels[label._id]
-  ).length;
-  const numFrameSelectedObjects = frameLabels.filter(
-    (label) => selectedLabels[label._id]
-  ).length;
-
-  const _getLabelSelectionData = (object) => ({
-    label_id: object._id,
-    sample_id: sample._id,
-    field: object.name,
-    frame_number: object.frame_number,
-  });
-
-  const _selectAll = (labels) => {
-    close();
-    setSelectedLabels((selection) => ({
-      ...selection,
-      ...Object.fromEntries(
-        labels
-          .map(_getLabelSelectionData)
-          .map(({ label_id, ...rest }) => [label_id, rest])
-      ),
-    }));
+  const selectedLabels = useRecoilValue(selectors.selectedLabelIds);
+  const visibleSampleLabels = useRecoilValue(visibleModalSampleLabelIds);
+  const closeAndCall = (useCallback) => {
+    const callback = useCallback();
+    return () => {
+      close();
+      callback();
+    };
   };
 
-  const selectAllInSample = () => _selectAll(sampleLabels);
-
-  const unselectAllInSample = () => {
-    close();
-    setSelectedLabels((selection) =>
-      removeMatchingLabelsFromSelection(selection, { sample_id: sample._id })
-    );
-  };
-
-  const selectAllInFrame = () => _selectAll(frameLabels);
-
-  const unselectAllInFrame = () => {
-    close();
-    setSelectedLabels((selection) =>
-      removeMatchingLabelsFromSelection(selection, {
-        sample_id: sample._id,
-        frame_number: frameNumberRef.current,
-      })
-    );
-  };
-
-  const hideSelected = () => {
-    close();
-    const ids = Object.keys(selectedLabels);
-    setSelectedLabels({});
-    // can copy data directly from selectedObjects since it's in the same format
-    setHiddenLabels((hiddenObjects) =>
-      addLabelsToSelection(
-        hiddenObjects,
-        ids.map((label_id) => ({ label_id, ...selectedLabels[label_id] }))
-      )
-    );
-  };
-
-  const hideOthers = (labels) => {
-    close();
-    console.log(
-      labels
-        .filter((label) => !selectedLabels[label._id])
-        .map(_getLabelSelectionData)
-    );
-    setHiddenLabels((hiddenLabels) =>
-      addLabelsToSelection(
-        hiddenLabels,
-        labels
-          .filter((label) => !selectedLabels[label._id])
-          .map(_getLabelSelectionData)
-      )
-    );
-  };
   return [
-    sampleLabels.length && {
+    {
       text: "Select all (current sample)",
-      disabled: numSampleSelectedObjects >= sampleLabels.length,
-      onClick: () => selectAllInSample(),
-    },
-    sampleLabels.length && {
-      text: "Unselect all (current sample)",
-      disabled: !numSampleSelectedObjects,
-      onClick: () => unselectAllInSample(),
-    },
-    frameLabels.length && {
-      text: "Select all (current frame)",
-      disabled: numFrameSelectedObjects >= frameLabels.length,
-      onClick: () => selectAllInFrame(),
-    },
-    frameLabels.length && {
-      text: "Unselect all (current frame)",
-      disabled: !numFrameSelectedObjects,
-      onClick: () => unselectAllInFrame(),
+      disabled: hasSetDiff(visibleSampleLabels, selectedLabels),
+      onClick: closeAndCall(useSelectVisible),
     },
     {
       text: "Clear selection",
-      disabled: !numTotalSelectedObjects,
-      onClick: () => {
-        close();
-        setSelectedLabels({});
-      },
+      disabled: hasSetDiff(selectedLabels, visibleSampleLabels),
+      onClick: closeAndCall(useClearSelectedLabels),
     },
     {
       text: "Hide selected",
-      disabled: numTotalSelectedObjects == 0,
-      onClick: () => hideSelected(),
+      disabled: selectedLabels.size > 0,
+      onClick: closeAndCall(useHideSelected),
     },
-    sampleLabels.length && {
+    {
       text: "Hide others (current sample)",
-      disabled: numSampleSelectedObjects == 0,
-      onClick: () => hideOthers(sampleLabels),
+      disabled: hasSetDiff(visibleSampleLabels, selectedLabels),
+      onClick: closeAndCall(useHideOthers),
     },
-    frameLabels.length && {
-      text: "Hide others (current frame)",
-      disabled: numFrameSelectedObjects == 0,
-      onClick: () => hideOthers(frameLabels),
-    },
-  ].filter(Boolean);
+  ].filter(({ disabled }) => !disabled);
 };
 
 const SelectionActions = ({ modal, close, frameNumberRef, bounds }) => {

--- a/app/src/components/Actions/utils.tsx
+++ b/app/src/components/Actions/utils.tsx
@@ -31,7 +31,7 @@ export const HoverItemDiv = animated(styled.div`
   color: ${({ theme }) => theme.fontDark};
 `);
 
-export const useHighlightHover = (disabled, override) => {
+export const useHighlightHover = (disabled, override = null) => {
   const [hovering, setHovering] = useState(false);
   const theme = useTheme();
   const on =

--- a/app/src/components/FieldsSidebar.tsx
+++ b/app/src/components/FieldsSidebar.tsx
@@ -65,7 +65,7 @@ type CellProps = {
   title: string;
   modal: boolean;
   onSelect: (entry: Entry) => void;
-  handleClear: () => void;
+  handleClear: (event: Event) => void;
   entries: Entry[];
   icon: any;
   children?: any;
@@ -150,7 +150,7 @@ const makeTagData = (
   matchedTags: Set<string>,
   name: string,
   theme,
-  toggleFilter: () => void,
+  toggleFilter: (event: Event) => void,
   labels: boolean
 ): any => {
   const color = matchedTags.has(name) ? theme.font : theme.fontDark;
@@ -284,7 +284,7 @@ const SampleTagsCell = ({ modal }: TagsCellProps) => {
                 matchedTags,
                 name,
                 theme,
-                (e) => {
+                (e: Event) => {
                   e.stopPropagation();
                   e.preventDefault();
                   const newMatch = new Set(matchedTags);
@@ -596,7 +596,7 @@ const UnsupportedCell = ({ modal }: UnsupportedCellProps) => {
       icon={<Help />}
       entries={unsupported.map((e) => ({
         name: e,
-        path: name,
+        path: e,
         title: e,
         data: null,
         disabled: true,

--- a/app/src/components/Filters/LabelFieldFilter.tsx
+++ b/app/src/components/Filters/LabelFieldFilter.tsx
@@ -88,6 +88,7 @@ const LabelFilter = ({ expanded, entry, modal }: Props) => {
     <animated.div style={{ ...props }}>
       <div ref={ref}>
         <div style={{ margin: 3 }}>
+          {modal && <HiddenLabelFilter entry={entry} />}
           <NamedStringFilter
             color={entry.color}
             name={"Labels"}
@@ -96,7 +97,6 @@ const LabelFilter = ({ expanded, entry, modal }: Props) => {
             selectedValuesAtom={selectedLabels(lPath)}
             excludeAtom={exclude(lPath)}
           />
-          {modal && <HiddenLabelFilter entry={entry} />}
           {CONFIDENCE_LABELS.includes(entry.labelType) && (
             <NamedRangeSlider
               color={entry.color}

--- a/app/src/components/Filters/LabelFieldFilter.tsx
+++ b/app/src/components/Filters/LabelFieldFilter.tsx
@@ -16,6 +16,7 @@ import * as stringField from "./StringFieldFilter";
 const FilterHeader = styled.div`
   display: flex;
   justify-content: space-between;
+  margin: 3px;
 
   a {
     cursor: pointer;

--- a/app/src/components/Filters/LabelFieldFilters.state.tsx
+++ b/app/src/components/Filters/LabelFieldFilters.state.tsx
@@ -402,8 +402,8 @@ export const filteredLabelSampleModalCounts = selectorFamily<
 
     return labels.reduce((acc, path) => {
       const result = sampleCountResolver(sample[path], types[path]);
+      acc[path] = !acc[path] ? 0 : acc[path];
       if (result > 0) {
-        acc[path] = !acc[path] ? 0 : acc[path];
         acc[path] += result;
       }
       return acc;

--- a/app/src/components/Filters/LabelFieldFilters.state.tsx
+++ b/app/src/components/Filters/LabelFieldFilters.state.tsx
@@ -174,7 +174,7 @@ export const sampleModalFilter = selector({
     const labels = get(activeFields(true));
     const hiddenLabels = get(atoms.hiddenLabels);
     const fields = get(activeFields(false));
-    return (sample, prefix = null) => {
+    return (sample, prefix = null, allFields = false) => {
       return Object.entries(sample).reduce((acc, [key, value]) => {
         if (value && hiddenLabels[value.id ?? value._id]) {
           return acc;
@@ -187,9 +187,9 @@ export const sampleModalFilter = selector({
         } else if (
           value &&
           VALID_LIST_TYPES.includes(value._cls) &&
-          labels.includes(key)
+          (labels.includes(key) || allFields)
         ) {
-          if (fields.includes(key)) {
+          if (allFields || fields.includes(key)) {
             acc[key] =
               filters[key] && value !== null
                 ? {
@@ -206,14 +206,14 @@ export const sampleModalFilter = selector({
           value !== null &&
           filters[key] &&
           filters[key](value) &&
-          labels.includes(key)
+          (labels.includes(key) || allFields)
         ) {
           acc[key] = value;
         } else if (RESERVED_FIELDS.includes(key)) {
           acc[key] = value;
         } else if (
           ["string", "number", "null"].includes(typeof value) &&
-          labels.includes(key)
+          (labels.includes(key) || allFields)
         ) {
           acc[key] = value;
         }
@@ -383,14 +383,14 @@ export const filteredLabelSampleModalCounts = selectorFamily<
     const labels = get(selectors.labelNames(dimension));
     const types = get(selectors.labelTypesMap);
     const filter = get(sampleModalFilter);
-    const sample = filter(get(selectors.modalSample) || {});
+    const sample = filter(get(selectors.modalSample) || {}, null, true);
     const frameData = get(atoms.sampleFrameData(sample._id));
     if (dimension === "frame") {
       return labels.reduce((acc, path) => {
         if (!(path in acc)) acc[path] = 0;
         if (!Boolean(frameData)) return acc;
         for (const frame of frameData) {
-          const filtered = filter(frame, "frames.");
+          const filtered = filter(frame, "frames.", true);
           acc[path] += sampleCountResolver(
             filtered["frames." + path],
             types["frames." + path]
@@ -507,12 +507,5 @@ export const modalLabels = selector<atoms.SelectedLabel[]>({
         );
     }
     return labels;
-  },
-});
-
-export const visibleModalLabelIds = selector<Set<string>>({
-  key: "visibleModalLabelIds",
-  get: ({ get }) => {
-    return new Set(get(modalLabels).map(({ label_id }) => label_id));
   },
 });

--- a/app/src/components/Filters/LabelFieldFilters.state.tsx
+++ b/app/src/components/Filters/LabelFieldFilters.state.tsx
@@ -509,3 +509,10 @@ export const modalLabels = selector<atoms.SelectedLabel[]>({
     return labels;
   },
 });
+
+export const visibleModalLabelIds = selector<Set<string>>({
+  key: "visibleModalLabelIds",
+  get: ({ get }) => {
+    return new Set(get(modalLabels).map(({ label_id }) => label_id));
+  },
+});

--- a/app/src/components/JSONView.tsx
+++ b/app/src/components/JSONView.tsx
@@ -25,10 +25,16 @@ const modalSampleOrCurrentFrame = selectorFamily<
       }
       object = {
         ...object,
-        frames: { currentFrame: op(frame, "frames.") },
+        frames: {
+          frameNumber: Object.fromEntries(
+            Object.entries(op(frame, "frames.")).map(([k, v]) => [k, v])
+          ),
+        },
       };
     }
-    return Object.entries(sample).filter(([k]) => !k.startsWith("_"));
+    return Object.fromEntries(
+      Object.entries(object).filter(([k]) => !k.startsWith("_"))
+    );
   },
 });
 

--- a/app/src/components/SampleModal.tsx
+++ b/app/src/components/SampleModal.tsx
@@ -382,7 +382,7 @@ const SampleModal = ({ onClose }: Props, ref) => {
       <div className="player" ref={playerContainerRef}>
         {showJSON ? (
           <JSONView
-            object={sample}
+            currentFrame={frameNumberRef.current}
             filterJSON={enableJSONFilter}
             enableFilter={setEnableJSONFilter}
           />

--- a/app/src/components/SampleModal.tsx
+++ b/app/src/components/SampleModal.tsx
@@ -443,7 +443,7 @@ const SampleModal = ({ onClose }: Props, ref) => {
             position: "relative",
           }}
         >
-          <Actions modal={true} frameNumber={frameNumberRef.current} />
+          <Actions modal={true} playerRef={playerRef} />
         </ModalFooter>
         <div className="sidebar-content">
           <h2>

--- a/app/src/components/SampleModal.tsx
+++ b/app/src/components/SampleModal.tsx
@@ -443,7 +443,7 @@ const SampleModal = ({ onClose }: Props, ref) => {
             position: "relative",
           }}
         >
-          <Actions modal={true} frameNumberRef={frameNumberRef} />
+          <Actions modal={true} frameNumber={frameNumberRef.current} />
         </ModalFooter>
         <div className="sidebar-content">
           <h2>

--- a/app/src/components/SampleModal.tsx
+++ b/app/src/components/SampleModal.tsx
@@ -443,7 +443,11 @@ const SampleModal = ({ onClose }: Props, ref) => {
             position: "relative",
           }}
         >
-          <Actions modal={true} playerRef={playerRef} />
+          <Actions
+            modal={true}
+            playerRef={playerRef}
+            frameNumberRef={frameNumberRef}
+          />
         </ModalFooter>
         <div className="sidebar-content">
           <h2>

--- a/app/src/components/utils.tsx
+++ b/app/src/components/utils.tsx
@@ -133,7 +133,7 @@ const PillButtonDiv = animated(styled.div`
 `);
 
 type PillButton = {
-  onClick: () => void;
+  onClick: (event: Event) => void;
   open: boolean;
   highlight: boolean;
   text?: string;


### PR DESCRIPTION
### Issues

* Resolves #672  (although, I believe this was mostly resolved already)
* Resolves #651

### Behavior

With respect to #651, `Clear selection` and `Hide selected` are the only actions that do not account for the current visibility of labels. Actions that would result in a noop are not shown (e.g. no visible labels means that are not selected means `Select visible (current sample)` will not be shown.

![Screenshot from 2021-04-14 08-50-29](https://user-images.githubusercontent.com/19821840/114731387-f28ec080-9cfe-11eb-8f03-b4b5818ffb94.png)

