### PR TITLE
Adding ordered flag to select stage

### DIFF
--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -2948,7 +2948,7 @@ class SampleCollection(object):
         return self._add_view_stage(fos.Mongo(pipeline))
 
     @view_stage
-    def select(self, sample_ids):
+    def select(self, sample_ids, ordered=False):
         """Selects the samples with the given IDs from the collection.
 
         Examples::
@@ -2980,10 +2980,13 @@ class SampleCollection(object):
                 -   an iterable of :class:`fiftyone.core.sample.Sample` or
                     :class:`fiftyone.core.sample.SampleView` instances
 
+        ordered (False): whether to sort the samples in the returned view to
+            match the order of the provided IDs
+
         Returns:
             a :class:`fiftyone.core.view.DatasetView`
         """
-        return self._add_view_stage(fos.Select(sample_ids))
+        return self._add_view_stage(fos.Select(sample_ids, ordered=ordered))
 
     @view_stage
     def select_fields(self, field_names=None):

--- a/fiftyone/core/stages.py
+++ b/fiftyone/core/stages.py
@@ -2843,10 +2843,14 @@ class Select(ViewStage):
             -   a :class:`fiftyone.core.collections.SampleCollection`
             -   an iterable of :class:`fiftyone.core.sample.Sample` or
                 :class:`fiftyone.core.sample.SampleView` instances
+
+        ordered (False): whether to sort the samples in the returned view to
+            match the order of the provided IDs
     """
 
-    def __init__(self, sample_ids):
+    def __init__(self, sample_ids, ordered=False):
         self._sample_ids = _get_sample_ids(sample_ids)
+        self._ordered = ordered
         self._validate_params()
 
     @property
@@ -2854,12 +2858,26 @@ class Select(ViewStage):
         """The list of sample IDs to select."""
         return self._sample_ids
 
+    @property
+    def ordered(self):
+        """Whether to sort the samples in the same order as the IDs."""
+        return self._ordered
+
     def to_mongo(self, _):
-        sample_ids = [ObjectId(_id) for _id in self._sample_ids]
-        return [{"$match": {"_id": {"$in": sample_ids}}}]
+        ids = [ObjectId(_id) for _id in self._sample_ids]
+
+        if not self._ordered:
+            return [{"$match": {"_id": {"$in": ids}}}]
+
+        return [
+            {"$set": {"_select_order": {"$indexOfArray": [ids, "$_id"]}}},
+            {"$match": {"_select_order": {"$gt": -1}}},
+            {"$sort": {"_select_order": ASCENDING}},
+            {"$unset": "_rand_shuffle"},
+        ]
 
     def _kwargs(self):
-        return [["sample_ids", self._sample_ids]]
+        return [["sample_ids", self._sample_ids], ["ordered", self._ordered]]
 
     @classmethod
     def _params(cls):
@@ -2868,7 +2886,13 @@ class Select(ViewStage):
                 "name": "sample_ids",
                 "type": "list<id>|id",
                 "placeholder": "list,of,sample,ids",
-            }
+            },
+            {
+                "name": "ordered",
+                "type": "bool",
+                "default": "False",
+                "placeholder": "bool (default=False)",
+            },
         ]
 
     def _validate_params(self):

--- a/fiftyone/core/stages.py
+++ b/fiftyone/core/stages.py
@@ -2873,7 +2873,7 @@ class Select(ViewStage):
             {"$set": {"_select_order": {"$indexOfArray": [ids, "$_id"]}}},
             {"$match": {"_select_order": {"$gt": -1}}},
             {"$sort": {"_select_order": ASCENDING}},
-            {"$unset": "_rand_shuffle"},
+            {"$unset": "_select_order"},
         ]
 
     def _kwargs(self):

--- a/tests/unittests/view_tests.py
+++ b/tests/unittests/view_tests.py
@@ -962,6 +962,13 @@ class ViewStageTests(unittest.TestCase):
         self.assertIs(len(result), 1)
         self.assertEqual(result[0].id, self.sample1.id)
 
+    def test_select_ordered(self):
+        ids = [self.sample2.id, self.sample1.id]
+        view = self.dataset.select(ids, ordered=True)
+        self.assertIs(len(view), 2)
+        for sample, _id in zip(view, ids):
+            self.assertEqual(sample.id, _id)
+
     def test_select_fields(self):
         self.dataset.add_sample_field("select_fields_field", fo.IntField)
 


### PR DESCRIPTION
Adds an optional `ordered=True` flag to `Select()` that will cause the samples in the returned view to appear in the same order as the list of IDs you provide:

```py
import fiftyone as fo
import fiftyone.zoo as foz

dataset = foz.load_zoo_dataset("quickstart")

view = dataset.limit(3)
reversed_view = dataset.select(view.values("id")[::-1], ordered=True)

print(view.values("id"))
print(reversed_view.values("id"))
```
