### PR TITLE
Stricter `str` stage parameter validation

### DIFF
--- a/app/src/components/ViewBar/ViewStage/viewStageParameterMachine.ts
+++ b/app/src/components/ViewBar/ViewStage/viewStageParameterMachine.ts
@@ -165,7 +165,17 @@ export const PARSER = {
     castFrom: (value) => value,
     castTo: (value) => value,
     parse: (value) => value,
-    validate: () => true,
+    validate: (value) => {
+      if (typeof value !== "string") {
+        return false;
+      }
+      try {
+        JSON.parse(value);
+        return false;
+      } catch {
+        return true;
+      }
+    },
   },
 };
 

--- a/fiftyone/core/stages.py
+++ b/fiftyone/core/stages.py
@@ -3603,7 +3603,11 @@ class SortBy(ViewStage):
     @classmethod
     def _params(cls):
         return [
-            {"name": "field_or_expr", "type": "field|str|json"},
+            {
+                "name": "field_or_expr",
+                "type": "field|str|json",
+                "placeholder": "field or expression",
+            },
             {
                 "name": "reverse",
                 "type": "bool",


### PR DESCRIPTION
Resolves #971 

Obviously, there is so much to improve in the view bar, including parameter handling. This band-aid requires the `str` type to not be valid JSON...

* `iamastring` -> valid
*  `"notastring"` -> invalid
* `1` -> invalid
* `"[1]"` -> invalid
* `'{ "one": 1}'` -> invalid

Allows for proper handling of `str|json` types.