### PR TITLE
Adding method to delete labels from datasets

### DIFF
--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -1612,22 +1612,9 @@ class SampleCollection(object):
         -   Provide one or both of the ``ids`` and ``tags`` arguments, and
             optionally the ``fields`` argument
 
-        -   Provide the ``labels`` argument, which should have the following
-            format::
-
-                [
-                    {
-                        "sample_id": "5f8d254a27ad06815ab89df4",
-                        "field": "ground_truth",
-                        "label_id": "5f8d254a27ad06815ab89df3",
-                    },
-                    {
-                        "sample_id": "5f8d255e27ad06815ab93bf8",
-                        "field": "ground_truth",
-                        "label_id": "5f8d255e27ad06815ab93bf6",
-                    },
-                    ...
-                ]
+        -   Provide the ``labels`` argument, which should contain a list of
+            dicts in the format returned by
+            :meth:`fiftyone.core.session.Session.selected_labels`
 
         Examples::
 
@@ -1691,7 +1678,9 @@ class SampleCollection(object):
             print(view.count("predictions.detections"))
 
         Args:
-            labels (None): a list of dicts specifying the labels to exclude
+            labels (None): a list of dicts specifying the labels to exclude in
+                the format returned by
+                :meth:`fiftyone.core.session.Session.selected_labels`
             ids (None): an ID or iterable of IDs of the labels to exclude
             tags (None): a tag or iterable of tags of labels to exclude
             fields (None): a field or iterable of fields from which to exclude
@@ -3068,22 +3057,9 @@ class SampleCollection(object):
         -   Provide one or both of the ``ids`` and ``tags`` arguments, and
             optionally the ``fields`` argument
 
-        -   Provide the ``labels`` argument, which should have the following
-            format::
-
-                [
-                    {
-                        "sample_id": "5f8d254a27ad06815ab89df4",
-                        "field": "ground_truth",
-                        "label_id": "5f8d254a27ad06815ab89df3",
-                    },
-                    {
-                        "sample_id": "5f8d255e27ad06815ab93bf8",
-                        "field": "ground_truth",
-                        "label_id": "5f8d255e27ad06815ab93bf6",
-                    },
-                    ...
-                ]
+        -   Provide the ``labels`` argument, which should contain a list of
+            dicts in the format returned by
+            :meth:`fiftyone.core.session.Session.selected_labels`
 
         Examples::
 
@@ -3140,7 +3116,9 @@ class SampleCollection(object):
             print(view.count("predictions.detections"))
 
         Args:
-            labels (None): a list of dicts specifying the labels to select
+            labels (None): a list of dicts specifying the labels to select in
+                the format returned by
+                :meth:`fiftyone.core.session.Session.selected_labels`
             ids (None): an ID or iterable of IDs of the labels to select
             tags (None): a tag or iterable of tags of labels to select
             fields (None): a field or iterable of fields from which to select

--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -4708,24 +4708,30 @@ class SampleCollection(object):
         return any(issubclass(label_type, t) for t in label_type_or_types)
 
     def _get_label_fields(self):
-        fields = list(
+        fields = self._get_sample_label_fields()
+
+        if self.media_type == fom.VIDEO:
+            fields.extend(self._get_frame_label_fields())
+
+        return fields
+
+    def _get_sample_label_fields(self):
+        return list(
             self.get_field_schema(
                 ftype=fof.EmbeddedDocumentField, embedded_doc_type=fol.Label
             ).keys()
         )
 
-        if self.media_type == fom.VIDEO:
-            fields.extend(
-                [
-                    self._FRAMES_PREFIX + field
-                    for field in self.get_frame_field_schema(
-                        ftype=fof.EmbeddedDocumentField,
-                        embedded_doc_type=fol.Label,
-                    ).keys()
-                ]
-            )
+    def _get_frame_label_fields(self):
+        if self.media_type != fom.VIDEO:
+            return None
 
-        return fields
+        return [
+            self._FRAMES_PREFIX + field
+            for field in self.get_frame_field_schema(
+                ftype=fof.EmbeddedDocumentField, embedded_doc_type=fol.Label
+            ).keys()
+        ]
 
     def _get_label_field_type(self, field_name):
         field_name, is_frame_field = self._handle_frame_field(field_name)

--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -1761,9 +1761,9 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
                     for sample_id, label_ids in _labels_map.items():
                         # If the data is well-formed, `label_ids` should have
                         # exactly one element, and this is redundant anyhow
-                        # since `sample_id` should uniquely define the label to
-                        # delete, but we still include `label_id` in the query
-                        # just to be safe
+                        # since `sample_id` and `frame_number` should uniquely
+                        # define the label to delete, but we still include
+                        # `label_id` in the query just to be safe
                         for label_id in label_ids:
                             sample_ops.append(
                                 UpdateOne(

--- a/fiftyone/core/stages.py
+++ b/fiftyone/core/stages.py
@@ -441,22 +441,9 @@ class ExcludeLabels(ViewStage):
     -   Provide one or both of the ``ids`` and ``tags`` arguments, and
         optionally the ``fields`` argument
 
-    -   Provide the ``labels`` argument, which should have the following
-        format::
-
-            [
-                {
-                    "sample_id": "5f8d254a27ad06815ab89df4",
-                    "field": "ground_truth",
-                    "label_id": "5f8d254a27ad06815ab89df3",
-                },
-                {
-                    "sample_id": "5f8d255e27ad06815ab93bf8",
-                    "field": "ground_truth",
-                    "label_id": "5f8d255e27ad06815ab93bf6",
-                },
-                ...
-            ]
+    -   Provide the ``labels`` argument, which should contain a list of dicts
+        in the format returned by
+        :meth:`fiftyone.core.session.Session.selected_labels`
 
     Examples::
 
@@ -523,7 +510,9 @@ class ExcludeLabels(ViewStage):
         print(view.count("predictions.detections"))
 
     Args:
-        labels (None): a list of dicts specifying the labels to exclude
+        labels (None): a list of dicts specifying the labels to exclude in the
+            format returned by
+            :meth:`fiftyone.core.session.Session.selected_labels`
         ids (None): an ID or iterable of IDs of the labels to exclude
         tags (None): a tag or iterable of tags of labels to exclude
         fields (None): a field or iterable of fields from which to exclude
@@ -3072,22 +3061,9 @@ class SelectLabels(ViewStage):
     -   Provide one or both of the ``ids`` and ``tags`` arguments, and
         optionally the ``fields`` argument
 
-    -   Provide the ``labels`` argument, which should have the following
-        format::
-
-            [
-                {
-                    "sample_id": "5f8d254a27ad06815ab89df4",
-                    "field": "ground_truth",
-                    "label_id": "5f8d254a27ad06815ab89df3",
-                },
-                {
-                    "sample_id": "5f8d255e27ad06815ab93bf8",
-                    "field": "ground_truth",
-                    "label_id": "5f8d255e27ad06815ab93bf6",
-                },
-                ...
-            ]
+    -   Provide the ``labels`` argument, which should contain a list of dicts
+        in the format returned by
+        :meth:`fiftyone.core.session.Session.selected_labels`
 
     Examples::
 
@@ -3148,7 +3124,9 @@ class SelectLabels(ViewStage):
         print(view.count("predictions.detections"))
 
     Args:
-        labels (None): a list of dicts specifying the labels to select
+        labels (None): a list of dicts specifying the labels to select in the
+            format returned by
+            :meth:`fiftyone.core.session.Session.selected_labels`
         ids (None): an ID or iterable of IDs of the labels to select
         tags (None): a tag or iterable of tags of labels to select
         fields (None): a field or iterable of fields from which to select


### PR DESCRIPTION
Adds a `Dataset.delete_labels()` method that allows for efficiently deleting `Label`s from datasets via a variety of natural syntaxes:
- Selected labels in the App: `dataset.delete_labels(labels=session.selected_labels)`
- By ID: `dataset.delete_labels(ids=list_of_ids)`
- By tag: `dataset.delete_labels(tags=list_of_tags)`
- By constructing a view: `dataset.delete_labels(view=view_of_labels_to_delete)`

Also renames `Dataset.remove_samples()` to `Dataset.delete_samples()` for consistency, and marks both `Dataset.remove_sample()` and `Dataset.remove_samples()` as deprecated.

### Notes

- I believe the original reasoning for choosing "remove" over "delete" is that if a deleted `Sample` exists in-memory, it will still technically exist but have `in_dataset == False`, but I now consider this an unimportant detail and think its better to use "delete" for consistency with all the other types of deletion operations (`delete_labels()`, `delete_sample_field()`, etc)

- I specifically chose to implement label deletion as a method on `Dataset` as opposed `SampleCollection` for consistency with the notion that views should be treated as read-only operations and not dataset-altering operations.

- Related to the above point, it is worth noting that label deletion is actually already possible without this PR by creating a view that omits all unwanted labels and then calling `view.save()`. However, `save()` overwrites the entire DB collection, so (a) it can be significantly slower than the dedicated `delete_labels()` method, and (b) `save()` is potentially over-powerful and/or dangerous as the user may have performed other operations such as label normalization, etc. in order to isolate the labels to delete, and calling `.save()` would persist those changes as well. In fact, `dataset.delete_labels(view=bad_labels_view)` is a safer alternative to `good_labels_view.save()` that will guarantee that changes are limited only to label deletion

### Image example  on image detections

```py
import eta.core.utils as etau

import fiftyone as fo
import fiftyone.zoo as foz

dataset = foz.load_zoo_dataset("quickstart")

ids = [
    dataset.first().ground_truth.detections[0].id,
    dataset.last().predictions.detections[-1].id,
]

# Mimic label selection in the App
labels = [
    {
        "sample_id": dataset.first().id,
        "field": "ground_truth",
        "label_id": dataset.first().ground_truth.detections[0].id,
    },
    {
        "sample_id": dataset.last().id,
        "field": "predictions",
        "label_id": dataset.last().predictions.detections[-1].id,
    }
]

print(dataset.count("ground_truth.detections"))
print(dataset.count("predictions.detections"))

# Method 1: delete by ID

_dataset = dataset.clone()

with etau.Timer():
    _dataset.delete_labels(ids=ids)

print(_dataset.count("ground_truth.detections"))
print(_dataset.count("predictions.detections"))

# Method 2: delete by tag

_dataset = dataset.clone()
_dataset.select_labels(ids=ids).tag_labels("test")

with etau.Timer():
    _dataset.delete_labels(tags="test")

print(_dataset.count("ground_truth.detections"))
print(_dataset.count("predictions.detections"))

# Method 3: delete by view

_dataset = dataset.clone()
view = _dataset.select_labels(ids=ids)

with etau.Timer():
    _dataset.delete_labels(view=view)

print(_dataset.count("ground_truth.detections"))
print(_dataset.count("predictions.detections"))

# Method 4: delete selected labels

_dataset = dataset.clone()

with etau.Timer():
    _dataset.delete_labels(labels=labels)

print(_dataset.count("ground_truth.detections"))
print(_dataset.count("predictions.detections"))

# Method 5: delete via `.save()`

_dataset = dataset.clone()

with etau.Timer():
    _dataset.exclude_labels(ids=ids).save()

print(_dataset.count("ground_truth.detections"))
print(_dataset.count("predictions.detections"))
```

```
1232
5620
Time elapsed: 5.1ms
1231
5619
Time elapsed: 4.7ms
1231
5619
Time elapsed: 25.7ms
1231
5619
Time elapsed: 1.3ms
1231
5619
Time elapsed: 109.2ms
1231
5619
```

### Video example

```py
import eta.core.utils as etau

import fiftyone as fo
import fiftyone.zoo as foz

dataset = foz.load_zoo_dataset("quickstart-video")

ids = [
    dataset.first().frames[1].ground_truth_detections.detections[0].id,
    dataset.last().frames[120].ground_truth_detections.detections[-1].id,
]

labels = [
    {
        "sample_id": dataset.first().id,
        "field": "frames.ground_truth_detections",
        "frame_number": 1,
        "label_id": dataset.first().frames[1].ground_truth_detections.detections[0].id,
    },
    {
        "sample_id": dataset.last().id,
        "field": "frames.ground_truth_detections",
        "frame_number": 120,
        "label_id": dataset.last().frames[120].ground_truth_detections.detections[-1].id,
    }
]

print(dataset.count("frames.ground_truth_detections.detections"))

# Method 1: delete by ID

_dataset = dataset.clone()

with etau.Timer():
    _dataset.delete_labels(ids=ids)

print(_dataset.count("frames.ground_truth_detections.detections"))

# Method 2: delete by tag

_dataset = dataset.clone()
_dataset.select_labels(ids=ids).tag_labels("test")

with etau.Timer():
    _dataset.delete_labels(tags="test")

print(_dataset.count("frames.ground_truth_detections.detections"))

# Method 3: delete by view

_dataset = dataset.clone()
view = _dataset.select_labels(ids=ids)

with etau.Timer():
    _dataset.delete_labels(view=view)

print(_dataset.count("frames.ground_truth_detections.detections"))

# Method 4: delete by selected labels

_dataset = dataset.clone()

with etau.Timer():
    _dataset.delete_labels(labels=labels)

print(_dataset.count("frames.ground_truth_detections.detections"))

# Method 5: delete via `.save()`

_dataset = dataset.clone()

with etau.Timer():
    _dataset.exclude_labels(ids=ids).save()

print(_dataset.count("frames.ground_truth_detections.detections"))
```

```
11345
Time elapsed: 11.3ms
11343
Time elapsed: 10.3ms
11343
Time elapsed: 43.5ms
11343
Time elapsed: 2.7ms
11343
Time elapsed: 370.4ms
11343
```
