### PR TITLE
Adding class summaries to API docs

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -73,7 +73,6 @@ autodoc_default_options = {
     "inherited-members": True,
     "member-order": "bysource",
     "autosummary": True,
-    "autosummary-no-nesting": True,
 }
 autodoc_inherit_docstrings = True
 autoclass_content = "class"


### PR DESCRIPTION
Resolves https://github.com/voxel51/fiftyone/issues/975.

Adds method/attribute summary tables to all class definitions in the API docs.

For example, with this change, clicking on the `Dataset` class in the summary table of the `fiftyone.core.dataset` module will link to the `CLASS Dataset` section, which now contains a similar table summarizing the methods/attributes of the `Dataset` class:

The `fiftyone.core.dataset` module:

<img width="1278" alt="Screen Shot 2021-04-20 at 10 49 00 AM" src="https://user-images.githubusercontent.com/25985824/115443648-8110af80-a1e1-11eb-9d39-e18ae28a4530.png">

The `Dataset` class:

<img width="1275" alt="Screen Shot 2021-04-20 at 10 49 13 AM" src="https://user-images.githubusercontent.com/25985824/115443658-83730980-a1e1-11eb-8c29-cc8460e5a906.png">

