### PR TITLE
Adding a sort_by_similarity() view stage

### DIFF
--- a/fiftyone/__public__.py
+++ b/fiftyone/__public__.py
@@ -147,6 +147,7 @@ from .core.stages import (
     SetField,
     Skip,
     SortBy,
+    SortBySimilarity,
     Take,
 )
 from .core.session import (

--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -3327,7 +3327,9 @@ class SampleCollection(object):
         return self._add_view_stage(fos.SortBy(field_or_expr, reverse=reverse))
 
     @view_stage
-    def sort_by_similarity(self, query_ids, brain_key=None, reverse=False):
+    def sort_by_similarity(
+        self, query_ids, k=None, reverse=False, brain_key=None
+    ):
         """Sorts the samples in the collection by visual similiarity to a
         specified set of query ID(s).
 
@@ -3356,18 +3358,20 @@ class SampleCollection(object):
         Args:
             query_ids: an ID or iterable of query IDs. These may be sample IDs
                 or label IDs depending on ``brain_key``
+            k (None): the number of matches to return. By default, the entire
+                collection is sorted
+            reverse (False): whether to sort by least similarity
             brain_key (None): the brain key of an existing
                 :meth:`fiftyone.brain.compute_similarity` run on the dataset.
                 If not provided, the dataset must have exactly one similarity
                 run, which will be used
-            reverse (False): whether to sort by least similarity
 
         Returns:
             a :class:`fiftyone.core.view.DatasetView`
         """
         return self._add_view_stage(
             fos.SortBySimilarity(
-                query_ids, brain_key=brain_key, reverse=reverse
+                query_ids, k=k, reverse=reverse, brain_key=brain_key
             )
         )
 

--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -1477,23 +1477,32 @@ class SampleCollection(object):
         """Deletes all brain method runs from this collection."""
         fob.BrainMethod.delete_runs(self)
 
-    def _get_similarity_keys(self):
+    def _get_similarity_keys(self, **kwargs):
         from fiftyone.brain import SimilarityConfig
 
-        return self._get_brain_runs_with_type(SimilarityConfig)
+        return self._get_brain_runs_with_type(SimilarityConfig, **kwargs)
 
-    def _get_visualization_keys(self):
+    def _get_visualization_keys(self, **kwargs):
         from fiftyone.brain import VisualizationConfig
 
-        return self._get_brain_runs_with_type(VisualizationConfig)
+        return self._get_brain_runs_with_type(VisualizationConfig, **kwargs)
 
-    def _get_brain_runs_with_type(self, run_type):
+    def _get_brain_runs_with_type(self, run_type, **kwargs):
         brain_keys = []
         for brain_key in self.list_brain_runs():
             brain_info = self.get_brain_info(brain_key)
+
             run_cls = etau.get_class(brain_info.config.cls)
-            if issubclass(run_cls, run_type):
-                brain_keys.append(brain_key)
+            if not issubclass(run_cls, run_type):
+                continue
+
+            if any(
+                getattr(brain_info.config, key) != value
+                for key, value in kwargs.items()
+            ):
+                continue
+
+            brain_keys.append(brain_key)
 
         return brain_keys
 

--- a/fiftyone/core/runs.py
+++ b/fiftyone/core/runs.py
@@ -7,7 +7,7 @@ Dataset runs framework.
 """
 from copy import copy
 import datetime
-import json
+from bson import json_util
 
 import numpy as np
 
@@ -298,7 +298,7 @@ class Run(Configurable):
                 same key
         """
         key = run_info.key
-        view_stages = [json.dumps(s) for s in samples.view()._serialize()]
+        view_stages = [json_util.dumps(s) for s in samples.view()._serialize()]
         run_docs = getattr(samples._dataset._doc, cls._runs_field())
 
         if key in run_docs:
@@ -394,7 +394,7 @@ class Run(Configurable):
         import fiftyone.core.view as fov
 
         run_doc = cls._get_run_doc(samples, key)
-        stage_dicts = [json.loads(s) for s in run_doc.view_stages]
+        stage_dicts = [json_util.loads(s) for s in run_doc.view_stages]
         view = fov.DatasetView._build(samples._dataset, stage_dicts)
 
         if not select_fields:
@@ -471,8 +471,8 @@ class Run(Configurable):
         run_doc = run_docs.get(key, None)
         if run_doc is None:
             raise ValueError(
-                "%s key '%s' not found on collection '%s'"
-                % (cls._run_str().capitalize(), key, samples.name)
+                "%s key '%s' not found on dataset '%s'"
+                % (cls._run_str().capitalize(), key, samples._dataset.name)
             )
 
         return run_doc

--- a/fiftyone/core/view.py
+++ b/fiftyone/core/view.py
@@ -674,11 +674,11 @@ class DatasetView(foc.SampleCollection):
         detach_frames=False,
         frames_only=False,
     ):
-        _view = self._dataset.view()
         _pipeline = []
+        _view = self._dataset.view()
         for stage in self._stages:
-            _view = _view.add_stage(stage)
             _pipeline.extend(stage.to_mongo(_view))
+            _view._stages.append(stage)
 
         if pipeline is not None:
             _pipeline.extend(pipeline)


### PR DESCRIPTION
Requires the corresponding similarity PR from `fiftyone-brain` in order to function.

Adds a `sort_by_similarity()` view stage that enables sorting by visual similarity based on the results of a `fiftyone.brain.compute_similarity()` brain run.

### Images usage

```py
import fiftyone as fo
import fiftyone.brain as fob
import fiftyone.zoo as foz

dataset = foz.load_zoo_dataset("quickstart")

fob.compute_similarity(dataset, brain_key="similarity")

session = fo.launch_app(dataset)

# Sort by visual similarity to a sample
query_id = dataset.first().id
session.view = dataset.sort_by_similarity(query_id, brain_key="similarity")

# Sort by visual similarity to selected samples in the App
session.view = dataset.sort_by_similarity(session.selected, brain_key="similarity")
```

<img width="1275" alt="Screen Shot 2021-04-21 at 3 34 13 PM" src="https://user-images.githubusercontent.com/25985824/115610576-0ca84000-a2b7-11eb-8e3f-4fe3db24b5df.png">

### Objects example

```py
import fiftyone as fo
import fiftyone.zoo as foz
import fiftyone.brain as fob

dataset = foz.load_zoo_dataset("quickstart")

fob.compute_similarity(dataset, patches_field="ground_truth", brain_key="similarity_obj")

session = fo.launch_app(dataset)

# Sort by visual similarity to an object
label_id = dataset.first().ground_truth.detections[0].id
session.view = dataset.sort_by_similarity(label_id, k=25, brain_key="similarity_obj")

# Sort by visual similarity to selected objects in the App
label_ids = [l["label_id"] for l in session.selected_labels]
session.view = dataset.sort_by_similarity(label_ids, k=25, brain_key="similarity_obj")
```

<img width="1272" alt="Screen Shot 2021-04-21 at 4 25 52 PM" src="https://user-images.githubusercontent.com/25985824/115616504-46307980-a2be-11eb-9baa-1c272df44b22.png">
