### PR TITLE
Adding support for embedded documents in values() and set_values()

### DIFF
--- a/docs/source/user_guide/using_aggregations.rst
+++ b/docs/source/user_guide/using_aggregations.rst
@@ -393,8 +393,9 @@ The example below demonstrates this capability:
 
 .. note::
 
-    There are four cases where FiftyOne will automatically unwind array fields
-    without requiring you to explicitly specify this via the ``[]`` syntax:
+    FiftyOne will automatically unwind all array fields that are defined in the
+    dataset's schema without requiring you to explicitly specify this via the
+    ``[]`` syntax. This includes the following cases:
 
     **Top-level lists:** When you write an aggregation that refers to a
     top-level list field of a dataset; i.e., ``list_field`` is automatically

--- a/fiftyone/core/aggregations.py
+++ b/fiftyone/core/aggregations.py
@@ -1072,6 +1072,16 @@ class Sum(Aggregation):
 class Values(Aggregation):
     """Extracts the values of the field from all samples in a collection.
 
+    Values aggregations are useful for efficiently extracting a slice of field
+    or embedded field values across all samples in a collection. See the
+    examples below for more details.
+
+    The dual function of :class:`Values` is
+    :meth:`set_values() <fiftyone.core.collections.SampleCollection.set_values>`,
+    which can be used to efficiently set a field or embedded field of all
+    samples in a collection by providing lists of values of same structure
+    returned by this aggregation.
+
     .. note::
 
         Unlike other aggregations, :class:`Values` does not automatically
@@ -1086,6 +1096,7 @@ class Values(Aggregation):
     Examples::
 
         import fiftyone as fo
+        import fiftyone.zoo as foz
         from fiftyone import ViewField as F
 
         dataset = fo.Dataset()
@@ -1132,6 +1143,24 @@ class Values(Aggregation):
         aggregation = fo.Values("numeric_field", expr=2 * (F() + 1))
         values = dataset.aggregate(aggregation)
         print(values)  # [4.0, 10.0, None]
+
+        #
+        # Get values from a label list field
+        #
+
+        dataset = foz.load_zoo_dataset("quickstart")
+
+        # list of `Detections`
+        aggregation = fo.Values("ground_truth")
+        detections = dataset.aggregate(aggregation)
+
+        # list of lists of `Detection` instances
+        aggregation = fo.Values("ground_truth.detections")
+        detections = dataset.aggregate(aggregation)
+
+        # list of lists of detection labels
+        aggregation = fo.Values("ground_truth.detections.label")
+        labels = dataset.aggregate(aggregation)
 
     Args:
         field_name: the name of the field to operate on

--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -772,6 +772,32 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
         )
         self._reload()
 
+    def _add_sample_field_if_necessary(
+        self, field_name, ftype, embedded_doc_type=None, subfield=None
+    ):
+        field_kwargs = dict(
+            ftype=ftype,
+            embedded_doc_type=embedded_doc_type,
+            subfield=subfield,
+        )
+
+        schema = self.get_field_schema()
+        if field_name in schema:
+            foo.validate_fields_match(
+                field_name, field_kwargs, schema[field_name]
+            )
+        else:
+            self.add_sample_field(field_name, **field_kwargs)
+
+    def _add_implied_sample_field(self, field_name, value):
+        self._sample_doc_cls.add_implied_field(field_name, value)
+        self._reload()
+
+    def _add_implied_sample_field_if_necessary(self, field_name, value):
+        self._add_sample_field_if_necessary(
+            field_name, **foo.get_implied_field_kwargs(value)
+        )
+
     def add_frame_field(
         self, field_name, ftype, embedded_doc_type=None, subfield=None
     ):
@@ -802,6 +828,35 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
             subfield=subfield,
         )
         self._reload()
+
+    def _add_frame_field_if_necessary(
+        self, field_name, ftype, embedded_doc_type=None, subfield=None
+    ):
+        field_kwargs = dict(
+            ftype=ftype,
+            embedded_doc_type=embedded_doc_type,
+            subfield=subfield,
+        )
+
+        schema = self.get_frame_field_schema()
+        if field_name in schema:
+            foo.validate_fields_match(
+                field_name, field_kwargs, schema[field_name]
+            )
+        else:
+            self.add_frame_field(field_name, **field_kwargs)
+
+    def _add_implied_frame_field(self, field_name, value):
+        if self.media_type != fom.VIDEO:
+            raise ValueError("Only video datasets have frame fields")
+
+        self._frame_doc_cls.add_implied_field(field_name, value)
+        self._reload()
+
+    def _add_implied_frame_field_if_necessary(self, field_name, value):
+        self._add_frame_field_if_necessary(
+            field_name, **foo.get_implied_field_kwargs(value)
+        )
 
     def rename_sample_field(self, field_name, new_field_name):
         """Renames the sample field to the given new name.
@@ -3908,7 +3963,10 @@ def _index_frames(sample_collection, key_field, frame_key_field):
         frame_keys.append(sample_keys)
 
     sample_collection.set_values(
-        "frames." + frame_key_field, frame_keys, _allow_missing=True
+        "frames." + frame_key_field,
+        frame_keys,
+        expand_schema=False,
+        _allow_missing=True,
     )
 
 

--- a/fiftyone/core/fields.py
+++ b/fiftyone/core/fields.py
@@ -533,4 +533,10 @@ class EmbeddedDocumentListField(
 
 
 _ARRAY_FIELDS = (VectorField, ArrayField)
-_PRIMITIVE_FIELDS = (IntField, FloatField, StringField, BooleanField)
+_PRIMITIVE_FIELDS = (
+    ObjectIdField,
+    IntField,
+    FloatField,
+    StringField,
+    BooleanField,
+)

--- a/fiftyone/core/fields.py
+++ b/fiftyone/core/fields.py
@@ -533,3 +533,4 @@ class EmbeddedDocumentListField(
 
 
 _ARRAY_FIELDS = (VectorField, ArrayField)
+_PRIMITIVE_FIELDS = (IntField, FloatField, StringField, BooleanField)

--- a/fiftyone/core/odm/__init__.py
+++ b/fiftyone/core/odm/__init__.py
@@ -45,7 +45,12 @@ from .frame import (
     DatasetFrameSampleDocument,
     NoDatasetFrameSampleDocument,
 )
-from .mixins import get_default_fields
+from .mixins import (
+    get_default_fields,
+    get_field_kwargs,
+    get_implied_field_kwargs,
+    validate_fields_match,
+)
 from .sample import (
     DatasetSampleDocument,
     NoDatasetSampleDocument,

--- a/fiftyone/core/odm/mixins.py
+++ b/fiftyone/core/odm/mixins.py
@@ -55,7 +55,7 @@ def validate_fields_match(
     the existing field.
 
     Args:
-        field_name: the name of the fiel
+        field_name: the name of the field
         field_or_kwargs: a :class:`fiftyone.core.fields.Field` instance or a
             dict of keyword arguments describing it
         existing_field_or_kwargs: a :class:`fiftyone.core.fields.Field` instance or

--- a/fiftyone/core/odm/mixins.py
+++ b/fiftyone/core/odm/mixins.py
@@ -48,6 +48,133 @@ def get_default_fields(cls, include_private=False, include_id=False):
     return fields
 
 
+def validate_fields_match(
+    field_name, field_or_kwargs, existing_field_or_kwargs
+):
+    """Validates that a given field or field description matches the type of
+    the existing field.
+
+    Args:
+        field_name: the name of the fiel
+        field_or_kwargs: a :class:`fiftyone.core.fields.Field` instance or a
+            dict of keyword arguments describing it
+        existing_field_or_kwargs: a :class:`fiftyone.core.fields.Field` instance or
+            dict of keyword arguments defining the reference field type
+
+    Raises:
+        ValueError: if the proposed field does not match the reference field
+    """
+    if isinstance(field_or_kwargs, dict):
+        field = create_field(field_name, **field_or_kwargs)
+    else:
+        field = field_or_kwargs
+
+    if isinstance(existing_field_or_kwargs, dict):
+        existing_field = create_field(field_name, **existing_field_or_kwargs)
+    else:
+        existing_field = existing_field_or_kwargs
+
+    if type(field) is not type(existing_field):
+        raise ValueError(
+            "Field '%s' type %s does not match existing field "
+            "type %s" % (field_name, field, existing_field)
+        )
+
+    if isinstance(field, fof.EmbeddedDocumentField):
+        if not issubclass(field.document_type, existing_field.document_type):
+            raise ValueError(
+                "Embedded document field '%s' type %s does not match existing "
+                "field type %s"
+                % (
+                    field_name,
+                    field.document_type,
+                    existing_field.document_type,
+                )
+            )
+
+    if isinstance(field, (fof.ListField, fof.DictField)):
+        if (existing_field.field is not None) and not isinstance(
+            field.field, type(existing_field.field)
+        ):
+            raise ValueError(
+                "%s '%s' type %s does not match existing "
+                "field type %s"
+                % (
+                    field.__class__.__name__,
+                    field_name,
+                    field.field,
+                    existing_field.field,
+                )
+            )
+
+
+def get_field_kwargs(field):
+    """Constructs the field keyword arguments dictionary for the given
+    :class:`fiftyone.core.fields.Field` instance.
+
+    Args:
+        field: a :class:`fiftyone.core.fields.Field`
+
+    Returns:
+        a field specification dict
+    """
+    ftype = type(field)
+    kwargs = {"ftype": ftype}
+
+    if issubclass(ftype, fof.EmbeddedDocumentField):
+        kwargs["embedded_doc_type"] = field.document_type
+
+    if issubclass(ftype, (fof.ListField, fof.DictField)):
+        kwargs["subfield"] = field.field
+
+    return kwargs
+
+
+def get_implied_field_kwargs(value):
+    """Infers the field keyword arguments dictionary for a field that can hold
+    values of the given type.
+
+    Args:
+        value: a value
+
+    Returns:
+        a field specification dict
+    """
+    if isinstance(value, BaseEmbeddedDocument):
+        return {
+            "ftype": fof.EmbeddedDocumentField,
+            "embedded_doc_type": type(value),
+        }
+
+    if isinstance(value, bool):
+        return {"ftype": fof.BooleanField}
+
+    if isinstance(value, six.integer_types):
+        return {"ftype": fof.IntField}
+
+    if isinstance(value, numbers.Number):
+        return {"ftype": fof.FloatField}
+
+    if isinstance(value, six.string_types):
+        return {"ftype": fof.StringField}
+
+    if isinstance(value, (list, tuple)):
+        return {"ftype": fof.ListField}
+
+    if isinstance(value, np.ndarray):
+        if value.ndim == 1:
+            return {"ftype": fof.VectorField}
+
+        return {"ftype": fof.ArrayField}
+
+    if isinstance(value, dict):
+        return {"ftype": fof.DictField}
+
+    raise TypeError(
+        "Cannot infer an appropriate field type for value '%s'" % value
+    )
+
+
 class DatasetMixin(object):
     """Mixin for concrete :class:`fiftyone.core.odm.document.SampleDocument`
     subtypes that are backed by a dataset.
@@ -993,92 +1120,6 @@ class NoDatasetMixin(object):
         nothing.
         """
         pass
-
-
-def validate_fields_match(field_name, field, ref_field):
-    if type(field) is not type(ref_field):
-        raise ValueError(
-            "Field '%s' type %s does not match existing field "
-            "type %s" % (field_name, field, ref_field)
-        )
-
-    if isinstance(field, fof.EmbeddedDocumentField):
-        if not issubclass(field.document_type, ref_field.document_type):
-            raise ValueError(
-                "Embedded document field '%s' type %s does not match existing "
-                "field type %s"
-                % (field_name, field.document_type, ref_field.document_type)
-            )
-
-    if isinstance(field, (fof.ListField, fof.DictField)):
-        if (ref_field.field is not None) and not isinstance(
-            field.field, type(ref_field.field)
-        ):
-            raise ValueError(
-                "%s '%s' type %s does not match existing "
-                "field type %s"
-                % (
-                    field.__class__.__name__,
-                    field_name,
-                    field.field,
-                    ref_field.field,
-                )
-            )
-
-
-def get_field_kwargs(field):
-    ftype = type(field)
-    kwargs = {"ftype": ftype}
-
-    if issubclass(ftype, fof.EmbeddedDocumentField):
-        kwargs["embedded_doc_type"] = field.document_type
-
-    if issubclass(ftype, (fof.ListField, fof.DictField)):
-        kwargs["subfield"] = field.field
-
-    return kwargs
-
-
-def get_implied_field_kwargs(value):
-    if isinstance(value, BaseEmbeddedDocument):
-        return {
-            "ftype": fof.EmbeddedDocumentField,
-            "embedded_doc_type": type(value),
-        }
-
-    ftype = _get_scalar_field_type(value)
-    if ftype is not None:
-        return {"ftype": ftype}
-
-    if isinstance(value, (list, tuple)):
-        return {"ftype": fof.ListField}
-
-    if isinstance(value, np.ndarray):
-        if value.ndim == 1:
-            return {"ftype": fof.VectorField}
-
-        return {"ftype": fof.ArrayField}
-
-    if isinstance(value, dict):
-        return {"ftype": fof.DictField}
-
-    raise TypeError("Unsupported field value '%s'" % type(value))
-
-
-def _get_scalar_field_type(value):
-    if isinstance(value, bool):
-        return fof.BooleanField
-
-    if isinstance(value, six.integer_types):
-        return fof.IntField
-
-    if isinstance(value, numbers.Number):
-        return fof.FloatField
-
-    if isinstance(value, six.string_types):
-        return fof.StringField
-
-    return None
 
 
 def _rename_field(field, new_field_name):

--- a/fiftyone/utils/eval/classification.py
+++ b/fiftyone/utils/eval/classification.py
@@ -222,24 +222,25 @@ class SimpleEvaluation(ClassificationEvaluation):
         if eval_key is None:
             return results
 
+        dataset = samples._dataset
         if is_frame_field:
             eval_frame = samples._FRAMES_PREFIX + eval_key
             gt = gt[len(samples._FRAMES_PREFIX) :]
             pred = pred[len(samples._FRAMES_PREFIX) :]
 
             # Sample-level accuracies
-            samples._add_field_if_necessary(eval_key, fof.FloatField)
+            dataset._add_sample_field_if_necessary(eval_key, fof.FloatField)
             samples.set_field(
                 eval_key,
                 F("frames").map((F(gt) == F(pred)).to_double()).mean(),
             ).save(eval_key)
 
             # Per-frame accuracies
-            samples._add_field_if_necessary(eval_frame, fof.BooleanField)
+            dataset._add_frame_field_if_necessary(eval_key, fof.BooleanField)
             samples.set_field(eval_frame, F(gt) == F(pred)).save(eval_frame)
         else:
             # Per-sample accuracies
-            samples._add_field_if_necessary(eval_key, fof.BooleanField)
+            dataset._add_sample_field_if_necessary(eval_key, fof.BooleanField)
             samples.set_field(eval_key, F(gt) == F(pred)).save(eval_key)
 
         return results
@@ -343,15 +344,12 @@ class TopKEvaluation(ClassificationEvaluation):
             eval_frame = samples._FRAMES_PREFIX + eval_key
 
             # Sample-level accuracies
-            samples._add_field_if_necessary(eval_key, fof.FloatField)
             samples.set_values(eval_key, [np.mean(c) for c in correct])
 
             # Per-frame accuracies
-            samples._add_field_if_necessary(eval_frame, fof.BooleanField)
             samples.set_values(eval_frame, correct)
         else:
             # Per-sample accuracies
-            samples._add_field_if_necessary(eval_key, fof.BooleanField)
             samples.set_values(eval_key, correct)
 
         return results
@@ -481,20 +479,21 @@ class BinaryEvaluation(ClassificationEvaluation):
         if eval_key is None:
             return results
 
+        dataset = samples._dataset
         if is_frame_field:
             eval_frame = samples._FRAMES_PREFIX + eval_key
             gt = gt[len(samples._FRAMES_PREFIX) :]
             pred = pred[len(samples._FRAMES_PREFIX) :]
 
             # Sample-level accuracies
-            samples._add_field_if_necessary(eval_key, fof.FloatField)
+            dataset._add_sample_field_if_necessary(eval_key, fof.FloatField)
             samples.set_field(
                 eval_key,
                 F("frames").map((F(gt) == F(pred)).to_double()).mean(),
             ).save(eval_key)
 
             # Per-frame accuracies
-            samples._add_field_if_necessary(eval_frame, fof.StringField)
+            dataset._add_frame_field_if_necessary(eval_key, fof.StringField)
             samples.set_field(
                 eval_frame,
                 F().switch(
@@ -508,7 +507,7 @@ class BinaryEvaluation(ClassificationEvaluation):
             ).save(eval_frame)
         else:
             # Per-sample accuracies
-            samples._add_field_if_necessary(eval_key, fof.StringField)
+            dataset._add_sample_field_if_necessary(eval_key, fof.StringField)
             samples.set_field(
                 eval_key,
                 F().switch(

--- a/tests/unittests/view_tests.py
+++ b/tests/unittests/view_tests.py
@@ -590,6 +590,68 @@ class SliceTests(unittest.TestCase):
         self.assertEqual(len(view), 0)
 
 
+class ViewValuesTests(unittest.TestCase):
+    @drop_datasets
+    def setUp(self):
+        self.dataset = fo.Dataset()
+        self.dataset.add_samples(
+            [
+                fo.Sample(filepath="test1.png", int_field=1),
+                fo.Sample(filepath="test2.png", int_field=2),
+                fo.Sample(filepath="test3.png", int_field=3),
+                fo.Sample(filepath="test4.png", int_field=4),
+            ]
+        )
+
+    def test_set_values_dataset(self):
+        n = len(self.dataset)
+
+        int_values = [int(i) for i in range(n)]
+        float_values = [float(i) for i in range(n)]
+        str_values = [str(i) for i in range(n)]
+        classification_values = [
+            fo.Classification(label=str(i)) for i in range(n)
+        ]
+        detections_values = [
+            fo.Detections(
+                detections=[fo.Detection(label=str(j)) for j in range(i)]
+            )
+            for i in range(n)
+        ]
+
+        # Set existing field
+        self.dataset.set_values("int_field", int_values)
+        _int_values = self.dataset.values("int_field")
+        self.assertListEqual(_int_values, int_values)
+
+        # Test no schema expanding
+        with self.assertRaises(ValueError):
+            self.dataset.set_values(
+                "float_field", float_values, expand_schema=False
+            )
+
+        # Set new primitive field
+        self.dataset.set_values("str_field", str_values)
+        schema = self.dataset.get_field_schema()
+        self.assertIn("str_field", schema)
+        _str_values = self.dataset.values("str_field")
+        self.assertListEqual(_str_values, str_values)
+
+        # Set new Classification field
+        self.dataset.set_values("classification_field", classification_values)
+        schema = self.dataset.get_field_schema()
+        self.assertIn("classification_field", schema)
+        _classification_values = self.dataset.values("classification_field")
+        self.assertListEqual(_classification_values, classification_values)
+
+        # Set new Detections field
+        self.dataset.set_values("detections_field", detections_values)
+        schema = self.dataset.get_field_schema()
+        self.assertIn("detections_field", schema)
+        _detections_values = self.dataset.values("detections_field")
+        self.assertListEqual(_detections_values, detections_values)
+
+
 class ViewStageTests(unittest.TestCase):
     @drop_datasets
     def setUp(self):

--- a/tests/unittests/view_tests.py
+++ b/tests/unittests/view_tests.py
@@ -7,7 +7,9 @@ FiftyOne view-related unit tests.
 """
 from copy import deepcopy
 import math
+
 import unittest
+import numpy as np
 
 import fiftyone as fo
 from fiftyone import ViewField as F, VALUE
@@ -590,7 +592,7 @@ class SliceTests(unittest.TestCase):
         self.assertEqual(len(view), 0)
 
 
-class ViewValuesTests(unittest.TestCase):
+class SetValuesTests(unittest.TestCase):
     @drop_datasets
     def setUp(self):
         self.dataset = fo.Dataset()
@@ -610,11 +612,31 @@ class ViewValuesTests(unittest.TestCase):
         float_values = [float(i) for i in range(n)]
         str_values = [str(i) for i in range(n)]
         classification_values = [
-            fo.Classification(label=str(i)) for i in range(n)
+            fo.Classification(label=str(i), custom=float(i)) for i in range(n)
+        ]
+        classifications_values = [
+            fo.Classifications(
+                classifications=[
+                    fo.Classification(
+                        label=str(j),
+                        logits=np.random.randn(5),
+                        custom=float(j),
+                    )
+                    for j in range(i)
+                ]
+            )
+            for i in range(n)
         ]
         detections_values = [
             fo.Detections(
-                detections=[fo.Detection(label=str(j)) for j in range(i)]
+                detections=[
+                    fo.Detection(
+                        label=str(j),
+                        bounding_box=list(np.random.rand(4)),
+                        custom=float(j),
+                    )
+                    for j in range(i)
+                ]
             )
             for i in range(n)
         ]
@@ -638,18 +660,181 @@ class ViewValuesTests(unittest.TestCase):
         self.assertListEqual(_str_values, str_values)
 
         # Set new Classification field
+
         self.dataset.set_values("classification_field", classification_values)
+
         schema = self.dataset.get_field_schema()
         self.assertIn("classification_field", schema)
+
         _classification_values = self.dataset.values("classification_field")
         self.assertListEqual(_classification_values, classification_values)
 
+        _label_values = self.dataset.values("classification_field.label")
+        self.assertEqual(type(_label_values), list)
+        self.assertEqual(type(_label_values[-1]), str)
+
+        _custom_values = self.dataset.values("classification_field.custom")
+        self.assertEqual(type(_custom_values), list)
+        self.assertEqual(type(_custom_values[-1]), float)
+
+        # Set new Classifications field
+
+        self.dataset.set_values(
+            "classifications_field", classifications_values
+        )
+
+        schema = self.dataset.get_field_schema()
+        self.assertIn("classifications_field", schema)
+
+        _classifications_values = self.dataset.values("classifications_field")
+        self.assertListEqual(_classifications_values, classifications_values)
+
+        _label_list_values = self.dataset.values(
+            "classifications_field.classifications"
+        )
+        self.assertEqual(type(_label_list_values), list)
+        self.assertEqual(type(_label_list_values[-1]), list)
+        self.assertEqual(type(_label_list_values[-1][0]), fo.Classification)
+
+        _label_values = self.dataset.values(
+            "classifications_field.classifications.label"
+        )
+        self.assertEqual(type(_label_values), list)
+        self.assertEqual(type(_label_values[-1]), list)
+        self.assertEqual(type(_label_values[-1][0]), str)
+
+        _logits_values = self.dataset.values(
+            "classifications_field.classifications.logits"
+        )
+        self.assertEqual(type(_logits_values), list)
+        self.assertEqual(type(_logits_values[-1]), list)
+        self.assertEqual(type(_logits_values[-1][0]), np.ndarray)
+
+        _custom_values = self.dataset.values(
+            "classifications_field.classifications.custom"
+        )
+        self.assertEqual(type(_custom_values), list)
+        self.assertEqual(type(_custom_values[-1]), list)
+        self.assertEqual(type(_custom_values[-1][0]), float)
+
         # Set new Detections field
+
         self.dataset.set_values("detections_field", detections_values)
+
         schema = self.dataset.get_field_schema()
         self.assertIn("detections_field", schema)
+
         _detections_values = self.dataset.values("detections_field")
         self.assertListEqual(_detections_values, detections_values)
+
+        _label_list_values = self.dataset.values("detections_field.detections")
+        self.assertEqual(type(_label_list_values), list)
+        self.assertEqual(type(_label_list_values[-1]), list)
+        self.assertEqual(type(_label_list_values[-1][0]), fo.Detection)
+
+        _label_values = self.dataset.values(
+            "detections_field.detections.label"
+        )
+        self.assertEqual(type(_label_values), list)
+        self.assertEqual(type(_label_values[-1]), list)
+        self.assertEqual(type(_label_values[-1][0]), str)
+
+        _bbox_values = self.dataset.values(
+            "detections_field.detections.bounding_box"
+        )
+        self.assertEqual(type(_bbox_values), list)
+        self.assertEqual(type(_bbox_values[-1]), list)
+        self.assertEqual(type(_bbox_values[-1][0]), list)
+
+        _custom_values = self.dataset.values(
+            "detections_field.detections.custom"
+        )
+        self.assertEqual(type(_custom_values), list)
+        self.assertEqual(type(_custom_values[-1]), list)
+        self.assertEqual(type(_custom_values[-1][0]), float)
+
+    def test_set_values_view(self):
+        n = len(self.dataset)
+
+        classification_values = [
+            fo.Classification(label=str(i)) for i in range(n)
+        ]
+        detections_values = [
+            fo.Detections(
+                detections=[
+                    fo.Detection(
+                        label=str(j), bounding_box=list(np.random.rand(4))
+                    )
+                    for j in range(i)
+                ]
+            )
+            for i in range(n)
+        ]
+
+        self.dataset.set_values("classification", classification_values)
+        self.dataset.set_values("detections", detections_values)
+
+        # Set existing field
+        view = self.dataset.skip(1).limit(2)
+        view.set_values("int_field", [0, 0])
+        _int_values = self.dataset.values("int_field")
+        self.assertListEqual(_int_values, [1, 0, 0, 4])
+
+        # Set new field
+        view = self.dataset.skip(1).limit(2)
+        view.set_values("str_field", ["hello", "world"])
+        _str_values = self.dataset.values("str_field")
+        self.assertListEqual(_str_values, [None, "hello", "world", None])
+
+        #
+        # Set filtered label field
+        #
+
+        view = self.dataset.filter_labels("classification", F("label") == "1")
+
+        # Primitive field
+        view.set_values("classification.custom", ["hello"])
+        _custom_values = self.dataset.values("classification.custom")
+        self.assertListEqual(_custom_values, [None, "hello", None, None])
+
+        # Label field
+
+        labels = view.values("classification")
+        for label in labels:
+            label.label = "ONE"
+
+        view.set_values("classification", labels)
+
+        _dataset_labels = self.dataset.values("classification.label")
+        self.assertListEqual(_dataset_labels, ["0", "ONE", "2", "3"])
+
+        #
+        # Set filtered label list fields
+        #
+
+        view = self.dataset.filter_labels("detections", F("label") == "1")
+
+        # Primitive field
+        view.set_values("detections.detections.custom", [["hello"], ["hello"]])
+        _custom_values = self.dataset.values("detections.detections.custom")
+        self.assertListEqual(
+            _custom_values,
+            [[], [None], [None, "hello"], [None, "hello", None]],
+        )
+
+        # Label list field
+
+        dets = view.values("detections.detections")
+        for _dets in dets:
+            for det in _dets:
+                det.label = "ONE"
+
+        view.set_values("detections.detections", dets)
+
+        _dataset_labels = self.dataset.values("detections.detections.label")
+        self.assertListEqual(
+            _dataset_labels, [[], ["0"], ["0", "ONE"], ["0", "ONE", "2"]],
+        )
 
 
 class ViewStageTests(unittest.TestCase):


### PR DESCRIPTION
Adds full support for passing/retrieving embedded documents using `values()` and `set_values()`. Previously these methods only supported setting/getting primitive fields like `int`, `float`, `str`, etc. that required no conversion between Python and Mongo representations.

With this PR, `values()` is now a proper dual of `set_values()` in the sense that objects like `Detections`, `list(Detection)`, and so forth can be passed to `values()` and then directly retrieved from `set_values()`:

```py
dataset.set_values("embedded.field", values)
also_values = dataset.values("embedded.field")

values == also_values  # true, even if values is, say, a nested list of `Detections` objects
```

With this work, `set_values()` also now more fully delivers on the promise of equivalent loop-based syntaxes that it makes in its docstring; if you can write it as you see below, then you can do it more efficiently via `set_values(...)` instead.

```py
"""Sets the field or embedded field on each sample or frame in the
collection to the given values.

When setting a sample field ``embedded.field.name``, this function is
an efficient implementation of the following loop::

    for sample, value in zip(sample_collection, values):
        sample.embedded.field.name = value
        sample.save()

When modifying a sample field that contains an array, say
``embedded.array.field.name``, this function is an efficient
implementation of the following loop::

    for sample, array_values in zip(sample_collection, values):
        for doc, value in zip(sample.embedded.array):
            doc.field.name = value

        sample.save()

...
"""
```

Another notable change is that `set_values()` is now allowed to add new top-level fields to the dataset's schema, consistent with how one is allowed to set a new field on a `SampleView` object and then `.save()` it to commit the addition.

One must still explicitly declare new sample fields before using `set_field()`, however, since it is not straightforward to infer a proper type for any newly created fields.

New unit tests are added that provide relatively comprehensive testing of this functionality.