### PR TITLE
Adding support for passing expressions directly to aggregations

### DIFF
--- a/docs/source/user_guide/plots.rst
+++ b/docs/source/user_guide/plots.rst
@@ -583,7 +583,7 @@ notebook:
     dataset.compute_metadata()
 
     # Define some interesting plots
-    plot1 = fo.NumericalHistogram("metadata.size_bytes", expr=F() / 1024, bins=50, xlabel="image size (KB)")
+    plot1 = fo.NumericalHistogram(F("metadata.size_bytes") / 1024, bins=50, xlabel="image size (KB)")
     plot2 = fo.NumericalHistogram("predictions.detections.confidence", bins=50)
     plot3 = fo.CategoricalHistogram("ground_truth.detections.label", order="frequency")
     plot4 = fo.CategoricalHistogram("predictions.detections.label", order="frequency")

--- a/docs/source/user_guide/using_aggregations.rst
+++ b/docs/source/user_guide/using_aggregations.rst
@@ -66,13 +66,14 @@ transform the data in arbitrarily complex ways:
 
     from fiftyone import ViewField as F
 
-    num_objects = F("detections").length()
+    # Expression that computes the number of predicted objects
+    num_objects = F("predictions.detections").length()
 
     # The `(min, max)` number of predictions per sample
-    print(dataset.bounds("predictions", expr=num_objects))
+    print(dataset.bounds(num_objects))
 
     # The average number of predictions per sample
-    print(dataset.mean("predictions", expr=num_objects))
+    print(dataset.mean(num_objects))
 
 The sections below discuss the available aggregations in more detail. You can
 also refer to the :mod:`fiftyone.core.aggregations` module documentation for
@@ -444,17 +445,17 @@ The following examples demonstrate the power of aggregating with expressions:
 
             dataset = foz.load_zoo_dataset("quickstart")
 
-            # Expression that computes the number of objects in a `Detections` field
-            num_objects = F("detections").length()
+            # Expression that computes the number of predicted objects
+            num_objects = F("predictions.detections").length()
 
             # The `(min, max)` number of predictions per sample
-            print(dataset.bounds("predictions", expr=num_objects))
+            print(dataset.bounds(num_objects))
 
             # The average number of predictions per sample
-            print(dataset.mean("predictions", expr=num_objects))
+            print(dataset.mean(num_objects))
 
             # Two equivalent ways of computing the total number of predictions
-            print(dataset.sum("predictions", expr=num_objects))
+            print(dataset.sum(num_objects))
             print(dataset.count("predictions.detections"))
 
     .. tab:: Normalized labels
@@ -478,10 +479,12 @@ The following examples demonstrate the power of aggregating with expressions:
 
             # Expression that replaces all animal labels with "animal" and then
             # capitalizes all labels
-            normed_labels = F("label").map_values({a: "animal" for a in ANIMALS}).upper()
+            normed_labels = F("predictions.detections.label").map_values(
+                {a: "animal" for a in ANIMALS}
+            ).upper()
 
             # A histogram of normalized predicted labels
-            print(dataset.count_values("predictions.detections[]", expr=normed_labels))
+            print(dataset.count_values(normed_labels))
 
     .. tab:: Bounding box areas
 
@@ -504,18 +507,17 @@ The following examples demonstrate the power of aggregating with expressions:
             bbox_height = F("bounding_box")[3] * F("$metadata.height")
             bbox_area = bbox_width * bbox_height
 
-            # Compute (min, max, mean) of ground truth bounding boxes
-            print(dataset.bounds("ground_truth.detections[]", expr=bbox_area))
-            print(dataset.mean("ground_truth.detections[]", expr=bbox_area))
+            # Expression that computes the area of ground truth bboxes
+            gt_areas = F("ground_truth.detections[]").apply(bbox_area)
 
-            # Compute same statistics for the predictions
-            print(dataset.bounds("predictions.detections[]", expr=bbox_area))
-            print(dataset.mean("predictions.detections[]", expr=bbox_area))
+            # Compute (min, max, mean) of ground truth bounding boxes
+            print(dataset.bounds(gt_areas))
+            print(dataset.mean(gt_areas))
 
 .. note::
 
-    When aggregating with expressions, field names may contain list fields, and
-    such field paths are handled as
+    When aggregating expressions, field names may contain list fields, and such
+    field paths are handled as
     :ref:`explained above <aggregations-list-fields>`.
 
     However, there is one important exception when expressions are involved:
@@ -534,17 +536,19 @@ The following examples demonstrate the power of aggregating with expressions:
         dataset = foz.load_zoo_dataset("quickstart")
 
         # Counts the number of predicted objects
-        # Here, ``predictions.detections`` is treated as ``predictions.detections[]``
+        # Here, `predictions.detections` is treated as `predictions.detections[]`
         print(dataset.count("predictions.detections"))
 
         # Counts the number of predicted objects with confidence > 0.9
-        # Here, ``predictions.detections`` is not automatically unwound
-        print(
-            dataset.sum(
-                "predictions.detections",
-                expr=F().filter(F("confidence") > 0.9).length()
-            )
-        )
+        # Here, `predictions.detections` is not automatically unwound
+        num_preds = F("predictions.detections").filter(F("confidence") > 0.9).length()
+        print(dataset.sum(num_preds))
+
+        # Computes the (min, max) bounding box area in normalized coordinates
+        # Here we must manually specify that we want to unwind terminal list field
+        # `predictions.detections` by appending `[]`
+        bbox_area = F("bounding_box")[2] * F("bounding_box")[3]
+        print(dataset.bounds(F("ground_truth.detections[]").apply(bbox_area)))
 
 .. _aggregations-batching:
 

--- a/fiftyone/core/aggregations.py
+++ b/fiftyone/core/aggregations.py
@@ -24,7 +24,7 @@ class Aggregation(object):
     of a :class:`fiftyone.core.collections.SampleCollection` instance.
 
     Args:
-        field_or_expr: a field name,
+        field_or_expr: a field name, ``embedded.field.name``,
             :class:`fiftyone.core.expressions.ViewExpression`, or
             `MongoDB expression <https://docs.mongodb.com/manual/meta/aggregation-quick-reference/#aggregation-expressions>`_
             defining the field or expression to aggregate
@@ -167,12 +167,12 @@ class Bounds(Aggregation):
         # Compute the bounds of a transformation of a numeric field
         #
 
-        aggregation = fo.Bounds("numeric_field", expr=2 * (F() + 1))
+        aggregation = fo.Bounds(2 * (F("numeric_field") + 1))
         bounds = dataset.aggregate(aggregation)
         print(bounds)  # (min, max)
 
     Args:
-        field_or_expr: a field name,
+        field_or_expr: a field name, ``embedded.field.name``,
             :class:`fiftyone.core.expressions.ViewExpression`, or
             `MongoDB expression <https://docs.mongodb.com/manual/meta/aggregation-quick-reference/#aggregation-expressions>`_
             defining the field or expression to aggregate
@@ -227,6 +227,7 @@ class Count(Aggregation):
     Examples::
 
         import fiftyone as fo
+        from fiftyone import ViewField as F
 
         dataset = fo.Dataset()
         dataset.add_samples(
@@ -282,16 +283,19 @@ class Count(Aggregation):
         print(count)  # the count
 
         #
-        # Count the number of samples with more than 2 predictions
+        # Count the number of objects in samples with > 2 predictions
         #
 
-        expr = (F("detections").length() > 2).if_else(F("detections"), None)
-        aggregation = fo.Count("predictions", expr=expr)
+        aggregation = fo.Count(
+            (F("predictions.detections").length() > 2).if_else(
+                F("predictions.detections"), None
+            )
+        )
         count = dataset.aggregate(aggregation)
         print(count)  # the count
 
     Args:
-        field_or_expr (None): a field name,
+        field_or_expr (None): a field name, ``embedded.field.name``,
             :class:`fiftyone.core.expressions.ViewExpression`, or
             `MongoDB expression <https://docs.mongodb.com/manual/meta/aggregation-quick-reference/#aggregation-expressions>`_
             defining the field or expression to aggregate. If neither
@@ -352,6 +356,7 @@ class CountValues(Aggregation):
     Examples::
 
         import fiftyone as fo
+        from fiftyone import ViewField as F
 
         dataset = fo.Dataset()
         dataset.add_samples(
@@ -403,13 +408,16 @@ class CountValues(Aggregation):
         # Compute the predicted label counts after some normalization
         #
 
-        expr = F().map_values({"cat": "pet", "dog": "pet"}).upper()
-        aggregation = fo.CountValues("predictions.detections.label", expr=expr)
+        aggregation = fo.CountValues(
+            F("predictions.detections.label").map_values(
+                {"cat": "pet", "dog": "pet"}
+            ).upper()
+        )
         counts = dataset.aggregate(aggregation)
         print(counts)  # dict mapping values to counts
 
     Args:
-        field_or_expr: a field name,
+        field_or_expr: a field name, ``embedded.field.name``,
             :class:`fiftyone.core.expressions.ViewExpression`, or
             `MongoDB expression <https://docs.mongodb.com/manual/meta/aggregation-quick-reference/#aggregation-expressions>`_
             defining the field or expression to aggregate
@@ -469,6 +477,7 @@ class Distinct(Aggregation):
     Examples::
 
         import fiftyone as fo
+        from fiftyone import ViewField as F
 
         dataset = fo.Dataset()
         dataset.add_samples(
@@ -520,13 +529,16 @@ class Distinct(Aggregation):
         # Get the distinct predicted labels after some normalization
         #
 
-        expr = F().map_values({"cat": "pet", "dog": "pet"}).upper()
-        aggregation = fo.Distinct("predictions.detections.label", expr=expr)
+        aggregation = fo.Distinct(
+            F("predictions.detections.label").map_values(
+                {"cat": "pet", "dog": "pet"}
+            ).upper()
+        )
         values = dataset.aggregate(aggregation)
         print(values)  # list of distinct values
 
     Args:
-        field_or_expr: a field name,
+        field_or_expr: a field name, ``embedded.field.name``,
             :class:`fiftyone.core.expressions.ViewExpression`, or
             `MongoDB expression <https://docs.mongodb.com/manual/meta/aggregation-quick-reference/#aggregation-expressions>`_
             defining the field or expression to aggregate
@@ -581,6 +593,7 @@ class HistogramValues(Aggregation):
         import matplotlib.pyplot as plt
 
         import fiftyone as fo
+        from fiftyone import ViewField as F
 
         samples = []
         for idx in range(100):
@@ -626,16 +639,14 @@ class HistogramValues(Aggregation):
         # Compute the histogram of a transformation of a numeric field
         #
 
-        aggregation = fo.HistogramValues(
-            "numeric_field", expr=2 * (F() + 1), bins=50
-        )
+        aggregation = fo.HistogramValues(2 * (F("numeric_field") + 1), bins=50)
         counts, edges, other = dataset.aggregate(aggregation)
 
         plot_hist(counts, edges)
         plt.show(block=False)
 
     Args:
-        field_or_expr: a field name,
+        field_or_expr: a field name, ``embedded.field.name``,
             :class:`fiftyone.core.expressions.ViewExpression`, or
             `MongoDB expression <https://docs.mongodb.com/manual/meta/aggregation-quick-reference/#aggregation-expressions>`_
             defining the field or expression to aggregate
@@ -816,6 +827,7 @@ class Mean(Aggregation):
     Examples::
 
         import fiftyone as fo
+        from fiftyone import ViewField as F
 
         dataset = fo.Dataset()
         dataset.add_samples(
@@ -858,12 +870,12 @@ class Mean(Aggregation):
         # Compute the mean of a transformation of a numeric field
         #
 
-        aggregation = fo.Mean("numeric_field", expr=2 * (F() + 1))
+        aggregation = fo.Mean(2 * (F("numeric_field") + 1))
         mean = dataset.aggregate(aggregation)
         print(mean)  # the mean
 
     Args:
-        field_or_expr: a field name,
+        field_or_expr: a field name, ``embedded.field.name``,
             :class:`fiftyone.core.expressions.ViewExpression`, or
             `MongoDB expression <https://docs.mongodb.com/manual/meta/aggregation-quick-reference/#aggregation-expressions>`_
             defining the field or expression to aggregate
@@ -916,6 +928,7 @@ class Std(Aggregation):
     Examples::
 
         import fiftyone as fo
+        from fiftyone import ViewField as F
 
         dataset = fo.Dataset()
         dataset.add_samples(
@@ -958,12 +971,12 @@ class Std(Aggregation):
         # Compute the standard deviation of a transformation of a numeric field
         #
 
-        aggregation = fo.Std("numeric_field", expr=2 * (F() + 1))
+        aggregation = fo.Std(2 * (F("numeric_field") + 1))
         std = dataset.aggregate(aggregation)
         print(std)  # the standard deviation
 
     Args:
-        field_or_expr: a field name,
+        field_or_expr: a field name, ``embedded.field.name``,
             :class:`fiftyone.core.expressions.ViewExpression`, or
             `MongoDB expression <https://docs.mongodb.com/manual/meta/aggregation-quick-reference/#aggregation-expressions>`_
             defining the field or expression to aggregate
@@ -1021,6 +1034,7 @@ class Sum(Aggregation):
     Examples::
 
         import fiftyone as fo
+        from fiftyone import ViewField as F
 
         dataset = fo.Dataset()
         dataset.add_samples(
@@ -1063,12 +1077,12 @@ class Sum(Aggregation):
         # Compute the sum of a transformation of a numeric field
         #
 
-        aggregation = fo.Sum("numeric_field", expr=2 * (F() + 1))
+        aggregation = fo.Sum(2 * (F("numeric_field") + 1))
         total = dataset.aggregate(aggregation)
         print(total)  # the sum
 
     Args:
-        field_or_expr: a field name,
+        field_or_expr: a field name, ``embedded.field.name``,
             :class:`fiftyone.core.expressions.ViewExpression`, or
             `MongoDB expression <https://docs.mongodb.com/manual/meta/aggregation-quick-reference/#aggregation-expressions>`_
             defining the field or expression to aggregate
@@ -1165,12 +1179,12 @@ class Values(Aggregation):
         # Get all values of transformed field
         #
 
-        aggregation = fo.Values("numeric_field", expr=2 * (F() + 1))
+        aggregation = fo.Values(2 * (F("numeric_field") + 1))
         values = dataset.aggregate(aggregation)
         print(values)  # [4.0, 10.0, None]
 
     Args:
-        field_or_expr: a field name,
+        field_or_expr: a field name, ``embedded.field.name``,
             :class:`fiftyone.core.expressions.ViewExpression`, or
             `MongoDB expression <https://docs.mongodb.com/manual/meta/aggregation-quick-reference/#aggregation-expressions>`_
             defining the field or expression to aggregate

--- a/fiftyone/core/aggregations.py
+++ b/fiftyone/core/aggregations.py
@@ -1268,7 +1268,7 @@ def _parse_field_and_expr(
         )
 
     if field_name is None:
-        field_name, expr = _normalize_expression(expr)
+        field_name, expr = _extract_prefix_from_expression(expr)
 
     if expr is not None:
         if field_name is None:
@@ -1321,7 +1321,7 @@ def _parse_field_and_expr(
     return path, pipeline, other_list_fields
 
 
-def _normalize_expression(expr):
+def _extract_prefix_from_expression(expr):
     prefixes = []
     _find_prefixes(expr, prefixes)
 

--- a/fiftyone/core/aggregations.py
+++ b/fiftyone/core/aggregations.py
@@ -5,10 +5,13 @@ Aggregations.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+from copy import deepcopy
+
 import numpy as np
 
 import eta.core.utils as etau
 
+import fiftyone.core.expressions as foe
 from fiftyone.core.expressions import ViewField as F
 import fiftyone.core.media as fom
 import fiftyone.core.utils as fou
@@ -21,14 +24,13 @@ class Aggregation(object):
     of a :class:`fiftyone.core.collections.SampleCollection` instance.
 
     Args:
-        field_name: the name of the field to operate on
-        expr (None): an optional
-            :class:`fiftyone.core.expressions.ViewExpression` or
+        field_name (None): the field to operate on
+        expr (None): a :class:`fiftyone.core.expressions.ViewExpression` or
             `MongoDB expression <https://docs.mongodb.com/manual/meta/aggregation-quick-reference/#aggregation-expressions>`_
             to apply to the field before aggregating
     """
 
-    def __init__(self, field_name, expr=None):
+    def __init__(self, field_name=None, expr=None):
         self._field_name = field_name
         self._expr = expr
 
@@ -40,7 +42,8 @@ class Aggregation(object):
     @property
     def expr(self):
         """The :class:`fiftyone.core.expressions.ViewExpression` or MongoDB
-        expression that will be applied to the field before aggregating, if any.
+        expression that will be applied to the field before aggregating, if
+        any.
         """
         return self._expr
 
@@ -156,9 +159,8 @@ class Bounds(Aggregation):
         print(bounds)  # (min, max)
 
     Args:
-        field_name: the name of the field to operate on
-        expr (None): an optional
-            :class:`fiftyone.core.expressions.ViewExpression` or
+        field_name (None): the field to operate on
+        expr (None): a :class:`fiftyone.core.expressions.ViewExpression` or
             `MongoDB expression <https://docs.mongodb.com/manual/meta/aggregation-quick-reference/#aggregation-expressions>`_
             to apply to the field before aggregating
     """
@@ -272,16 +274,15 @@ class Count(Aggregation):
         print(count)  # the count
 
     Args:
-        field_name (None): the name of the field to operate on. If none is
-            provided, the samples themselves are counted
-        expr (None): an optional
-            :class:`fiftyone.core.expressions.ViewExpression` or
+        field_name (None): the field to operate on. If neither ``field_name``
+            or ``expr`` is provided, the samples themselves are counted
+        expr (None): a :class:`fiftyone.core.expressions.ViewExpression` or
             `MongoDB expression <https://docs.mongodb.com/manual/meta/aggregation-quick-reference/#aggregation-expressions>`_
             to apply to the field before aggregating
     """
 
     def __init__(self, field_name=None, expr=None):
-        super().__init__(field_name, expr=expr)
+        super().__init__(field_name=field_name, expr=expr)
 
     def default_result(self):
         """Returns the default result for this aggregation.
@@ -303,7 +304,7 @@ class Count(Aggregation):
         return d["count"]
 
     def to_mongo(self, sample_collection):
-        if self._field_name is None:
+        if self._field_name is None and self._expr is None:
             return [{"$count": "count"}]
 
         path, pipeline, _ = self._parse_field_and_expr(sample_collection)
@@ -386,9 +387,8 @@ class CountValues(Aggregation):
         print(counts)  # dict mapping values to counts
 
     Args:
-        field_name: the name of the field to operate on
-        expr (None): an optional
-            :class:`fiftyone.core.expressions.ViewExpression` or
+        field_name (None): the field to operate on
+        expr (None): a :class:`fiftyone.core.expressions.ViewExpression` or
             `MongoDB expression <https://docs.mongodb.com/manual/meta/aggregation-quick-reference/#aggregation-expressions>`_
             to apply to the field before aggregating
     """
@@ -500,9 +500,8 @@ class Distinct(Aggregation):
         print(values)  # list of distinct values
 
     Args:
-        field_name: the name of the field to operate on
-        expr (None): an optional
-            :class:`fiftyone.core.expressions.ViewExpression` or
+        field_name (None): the field to operate on
+        expr (None): a :class:`fiftyone.core.expressions.ViewExpression` or
             `MongoDB expression <https://docs.mongodb.com/manual/meta/aggregation-quick-reference/#aggregation-expressions>`_
             to apply to the field before aggregating
     """
@@ -606,9 +605,8 @@ class HistogramValues(Aggregation):
         plt.show(block=False)
 
     Args:
-        field_name: the name of the field to operate on
-        expr (None): an optional
-            :class:`fiftyone.core.expressions.ViewExpression` or
+        field_name (None): the field to operate on
+        expr (None): a :class:`fiftyone.core.expressions.ViewExpression` or
             `MongoDB expression <https://docs.mongodb.com/manual/meta/aggregation-quick-reference/#aggregation-expressions>`_
             to apply to the field before aggregating
         bins (None): can be either an integer number of bins to generate or a
@@ -626,9 +624,9 @@ class HistogramValues(Aggregation):
     """
 
     def __init__(
-        self, field_name, expr=None, bins=None, range=None, auto=False
+        self, field_name=None, expr=None, bins=None, range=None, auto=False
     ):
-        super().__init__(field_name, expr=expr)
+        super().__init__(field_name=field_name, expr=expr)
         self._bins = bins
         self._range = range
         self._auto = auto
@@ -831,9 +829,8 @@ class Mean(Aggregation):
         print(mean)  # the mean
 
     Args:
-        field_name: the name of the field to operate on
-        expr (None): an optional
-            :class:`fiftyone.core.expressions.ViewExpression` or
+        field_name (None): the field to operate on
+        expr (None): a :class:`fiftyone.core.expressions.ViewExpression` or
             `MongoDB expression <https://docs.mongodb.com/manual/meta/aggregation-quick-reference/#aggregation-expressions>`_
             to apply to the field before aggregating
     """
@@ -928,17 +925,16 @@ class Std(Aggregation):
         print(std)  # the standard deviation
 
     Args:
-        field_name: the name of the field to operate on
-        expr (None): an optional
-            :class:`fiftyone.core.expressions.ViewExpression` or
+        field_name (None): the field to operate on
+        expr (None): a :class:`fiftyone.core.expressions.ViewExpression` or
             `MongoDB expression <https://docs.mongodb.com/manual/meta/aggregation-quick-reference/#aggregation-expressions>`_
             to apply to the field before aggregating
         sample (False): whether to compute the sample standard deviation rather
             than the population standard deviation
     """
 
-    def __init__(self, field_name, expr=None, sample=False):
-        super().__init__(field_name, expr=expr)
+    def __init__(self, field_name=None, expr=None, sample=False):
+        super().__init__(field_name=field_name, expr=expr)
         self._sample = sample
 
     def default_result(self):
@@ -1030,9 +1026,8 @@ class Sum(Aggregation):
         print(total)  # the sum
 
     Args:
-        field_name: the name of the field to operate on
-        expr (None): an optional
-            :class:`fiftyone.core.expressions.ViewExpression` or
+        field_name (None): the field to operate on
+        expr (None): a :class:`fiftyone.core.expressions.ViewExpression` or
             `MongoDB expression <https://docs.mongodb.com/manual/meta/aggregation-quick-reference/#aggregation-expressions>`_
             to apply to the field before aggregating
     """
@@ -1129,9 +1124,8 @@ class Values(Aggregation):
         print(values)  # [4.0, 10.0, None]
 
     Args:
-        field_name: the name of the field to operate on
-        expr (None): an optional
-            :class:`fiftyone.core.expressions.ViewExpression` or
+        field_name (None): the field to operate on
+        expr (None): a :class:`fiftyone.core.expressions.ViewExpression` or
             `MongoDB expression <https://docs.mongodb.com/manual/meta/aggregation-quick-reference/#aggregation-expressions>`_
             to apply to the field before aggregating
         missing_value (None): a value to insert for missing or ``None``-valued
@@ -1142,14 +1136,14 @@ class Values(Aggregation):
 
     def __init__(
         self,
-        field_name,
+        field_name=None,
         expr=None,
         missing_value=None,
         unwind=False,
         _allow_missing=False,
     ):
         field_name, found_id_field = _handle_id_fields(field_name)
-        super().__init__(field_name, expr=expr)
+        super().__init__(field_name=field_name, expr=expr)
 
         self._missing_value = missing_value
         self._unwind = unwind
@@ -1206,7 +1200,9 @@ class Values(Aggregation):
 
 
 def _handle_id_fields(field_name):
-    if field_name == "id":
+    if field_name is None:
+        found_id_field = False
+    elif field_name == "id":
         field_name = "_id"
         found_id_field = True
     elif field_name.endswith(".id"):
@@ -1265,9 +1261,29 @@ def _extract_list_values(subfield, expr):
 def _parse_field_and_expr(
     sample_collection, field_name, expr, auto_unwind, allow_missing
 ):
+    if field_name is None and expr is None:
+        raise ValueError(
+            "You must provide a field and/or an expression in order to "
+            "perform an aggregation"
+        )
+
+    if field_name is None:
+        field_name, expr = _normalize_expression(expr)
+
     if expr is not None:
+        if field_name is None:
+            field_name = "value"
+            embedded_root = True
+            allow_missing = True
+        else:
+            embedded_root = False
+            allow_missing = False
+
         pipeline, _ = sample_collection._make_set_field_pipeline(
-            field_name, expr
+            field_name,
+            expr,
+            embedded_root=embedded_root,
+            allow_missing=allow_missing,
         )
     else:
         pipeline = []
@@ -1297,11 +1313,84 @@ def _parse_field_and_expr(
 
     if other_list_fields:
         root = other_list_fields[0]
-        leaf = path[len(root) + 1 :]
     else:
         root = path
-        leaf = None
 
     pipeline.append({"$project": {root: True}})
 
     return path, pipeline, other_list_fields
+
+
+def _normalize_expression(expr):
+    prefixes = []
+    _find_prefixes(expr, prefixes)
+
+    common = _get_common_prefix(prefixes)
+    if common:
+        expr = deepcopy(expr)
+        _remove_prefix(expr, common)
+
+    return common, expr
+
+
+def _find_prefixes(expr, prefixes):
+    if isinstance(expr, foe.ViewExpression):
+        if expr.is_frozen:
+            return
+
+        if isinstance(expr, foe.ViewField):
+            prefixes.append(expr._expr)
+        else:
+            _find_prefixes(expr._expr, prefixes)
+
+    elif isinstance(expr, (list, tuple)):
+        for e in expr:
+            _find_prefixes(e, prefixes)
+
+    elif isinstance(expr, dict):
+        for e in expr.values():
+            _find_prefixes(e, prefixes)
+
+
+def _get_common_prefix(prefixes):
+    if not prefixes:
+        return None
+
+    chunks = [p.split(".") for p in prefixes]
+    min_chunks = min(len(c) for c in chunks)
+
+    common = None
+    idx = 0
+    pre = [c[0] for c in chunks]
+    while len(set(pre)) == 1:
+        common = pre[0]
+        idx += 1
+
+        if idx >= min_chunks:
+            break
+
+        pre = [common + "." + c[idx] for c in chunks]
+
+    return common
+
+
+def _remove_prefix(expr, prefix):
+    if isinstance(expr, foe.ViewExpression):
+        if expr.is_frozen:
+            return
+
+        if isinstance(expr, foe.ViewField):
+            if expr._expr == prefix:
+                expr._expr = ""
+            elif expr._expr.startswith(prefix + "."):
+                expr._expr = expr._expr[len(prefix) + 1 :]
+        else:
+            _remove_prefix(expr._expr, prefix)
+
+    elif isinstance(expr, (list, tuple)):
+        for e in expr:
+            _remove_prefix(e, prefix)
+
+    elif isinstance(expr, dict):
+        for e in expr.values():
+            _remove_prefix(e, prefix)

--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -3354,6 +3354,7 @@ class SampleCollection(object):
         Examples::
 
             import fiftyone as fo
+            from fiftyone import ViewField as F
 
             dataset = fo.Dataset()
             dataset.add_samples(
@@ -3394,11 +3395,11 @@ class SampleCollection(object):
             # Compute the bounds of a transformation of a numeric field
             #
 
-            bounds = dataset.bounds("numeric_field", expr=2 * (F() + 1))
+            bounds = dataset.bounds(2 * (F("numeric_field") + 1))
             print(bounds)  # (min, max)
 
         Args:
-            field_or_expr: a field name,
+            field_or_expr: a field name, ``embedded.field.name``,
                 :class:`fiftyone.core.expressions.ViewExpression`, or
                 `MongoDB expression <https://docs.mongodb.com/manual/meta/aggregation-quick-reference/#aggregation-expressions>`_
                 defining the field or expression to aggregate
@@ -3423,6 +3424,7 @@ class SampleCollection(object):
         Examples::
 
             import fiftyone as fo
+            from fiftyone import ViewField as F
 
             dataset = fo.Dataset()
             dataset.add_samples(
@@ -3475,15 +3477,18 @@ class SampleCollection(object):
             print(count)  # the count
 
             #
-            # Count the number of samples with more than 2 predictions
+            # Count the number of objects in samples with > 2 predictions
             #
 
-            expr = (F("detections").length() > 2).if_else(F("detections"), None)
-            count = dataset.count("predictions", expr=expr)
+            count = dataset.count(
+                (F("predictions.detections").length() > 2).if_else(
+                    F("predictions.detections"), None
+                )
+            )
             print(count)  # the count
 
         Args:
-            field_or_expr (None): a field name,
+            field_or_expr (None): a field name, ``embedded.field.name``,
                 :class:`fiftyone.core.expressions.ViewExpression`, or
                 `MongoDB expression <https://docs.mongodb.com/manual/meta/aggregation-quick-reference/#aggregation-expressions>`_
                 defining the field or expression to aggregate. If neither
@@ -3515,6 +3520,7 @@ class SampleCollection(object):
         Examples::
 
             import fiftyone as fo
+            from fiftyone import ViewField as F
 
             dataset = fo.Dataset()
             dataset.add_samples(
@@ -3564,12 +3570,15 @@ class SampleCollection(object):
             # Compute the predicted label counts after some normalization
             #
 
-            expr = F().map_values({"cat": "pet", "dog": "pet"}).upper()
-            counts = dataset.count_values("predictions.detections.label", expr=expr)
+            counts = dataset.count_values(
+                F("predictions.detections.label").map_values(
+                    {"cat": "pet", "dog": "pet"}
+                ).upper()
+            )
             print(counts)  # dict mapping values to counts
 
         Args:
-            field_or_expr: a field name,
+            field_or_expr: a field name, ``embedded.field.name``,
                 :class:`fiftyone.core.expressions.ViewExpression`, or
                 `MongoDB expression <https://docs.mongodb.com/manual/meta/aggregation-quick-reference/#aggregation-expressions>`_
                 defining the field or expression to aggregate
@@ -3599,6 +3608,7 @@ class SampleCollection(object):
         Examples::
 
             import fiftyone as fo
+            from fiftyone import ViewField as F
 
             dataset = fo.Dataset()
             dataset.add_samples(
@@ -3648,12 +3658,15 @@ class SampleCollection(object):
             # Get the distinct predicted labels after some normalization
             #
 
-            expr = F().map_values({"cat": "pet", "dog": "pet"}).upper()
-            values = dataset.distinct("predictions.detections.label", expr=expr)
+            values = dataset.distinct(
+                F("predictions.detections.label").map_values(
+                    {"cat": "pet", "dog": "pet"}
+                ).upper()
+            )
             print(values)  # list of distinct values
 
         Args:
-            field_or_expr: a field name,
+            field_or_expr: a field name, ``embedded.field.name``,
                 :class:`fiftyone.core.expressions.ViewExpression`, or
                 `MongoDB expression <https://docs.mongodb.com/manual/meta/aggregation-quick-reference/#aggregation-expressions>`_
                 defining the field or expression to aggregate
@@ -3685,6 +3698,7 @@ class SampleCollection(object):
             import matplotlib.pyplot as plt
 
             import fiftyone as fo
+            from fiftyone import ViewField as F
 
             samples = []
             for idx in range(100):
@@ -3733,14 +3747,14 @@ class SampleCollection(object):
             #
 
             counts, edges, other = dataset.histogram_values(
-                "numeric_field", expr=2 * (F() + 1), bins=50
+                2 * (F("numeric_field") + 1), bins=50
             )
 
             plot_hist(counts, edges)
             plt.show(block=False)
 
         Args:
-            field_or_expr: a field name,
+            field_or_expr: a field name, ``embedded.field.name``,
                 :class:`fiftyone.core.expressions.ViewExpression`, or
                 `MongoDB expression <https://docs.mongodb.com/manual/meta/aggregation-quick-reference/#aggregation-expressions>`_
                 defining the field or expression to aggregate
@@ -3793,6 +3807,7 @@ class SampleCollection(object):
         Examples::
 
             import fiftyone as fo
+            from fiftyone import ViewField as F
 
             dataset = fo.Dataset()
             dataset.add_samples(
@@ -3833,11 +3848,11 @@ class SampleCollection(object):
             # Compute the mean of a transformation of a numeric field
             #
 
-            mean = dataset.mean("numeric_field", expr=2 * (F() + 1))
+            mean = dataset.mean(2 * (F("numeric_field") + 1))
             print(mean)  # the mean
 
         Args:
-            field_or_expr: a field name,
+            field_or_expr: a field name, ``embedded.field.name``,
                 :class:`fiftyone.core.expressions.ViewExpression`, or
                 `MongoDB expression <https://docs.mongodb.com/manual/meta/aggregation-quick-reference/#aggregation-expressions>`_
                 defining the field or expression to aggregate
@@ -3867,6 +3882,7 @@ class SampleCollection(object):
         Examples::
 
             import fiftyone as fo
+            from fiftyone import ViewField as F
 
             dataset = fo.Dataset()
             dataset.add_samples(
@@ -3907,11 +3923,11 @@ class SampleCollection(object):
             # Compute the standard deviation of a transformation of a numeric field
             #
 
-            std = dataset.std("numeric_field", expr=2 * (F() + 1))
+            std = dataset.std(2 * (F("numeric_field") + 1))
             print(std)  # the standard deviation
 
         Args:
-            field_or_expr: a field name,
+            field_or_expr: a field name, ``embedded.field.name``,
                 :class:`fiftyone.core.expressions.ViewExpression`, or
                 `MongoDB expression <https://docs.mongodb.com/manual/meta/aggregation-quick-reference/#aggregation-expressions>`_
                 defining the field or expression to aggregate
@@ -3942,6 +3958,7 @@ class SampleCollection(object):
         Examples::
 
             import fiftyone as fo
+            from fiftyone import ViewField as F
 
             dataset = fo.Dataset()
             dataset.add_samples(
@@ -3982,11 +3999,11 @@ class SampleCollection(object):
             # Compute the sum of a transformation of a numeric field
             #
 
-            total = dataset.sum("numeric_field", expr=2 * (F() + 1))
+            total = dataset.sum(2 * (F("numeric_field") + 1))
             print(total)  # the sum
 
         Args:
-            field_or_expr: a field name,
+            field_or_expr: a field name, ``embedded.field.name``,
                 :class:`fiftyone.core.expressions.ViewExpression`, or
                 `MongoDB expression <https://docs.mongodb.com/manual/meta/aggregation-quick-reference/#aggregation-expressions>`_
                 defining the field or expression to aggregate
@@ -4066,11 +4083,11 @@ class SampleCollection(object):
             # Get all values of transformed field
             #
 
-            values = dataset.values("numeric_field", expr=2 * (F() + 1))
+            values = dataset.values(2 * (F("numeric_field") + 1))
             print(values)  # [4.0, 10.0, None]
 
         Args:
-            field_or_expr: a field name,
+            field_or_expr: a field name, ``embedded.field.name``,
                 :class:`fiftyone.core.expressions.ViewExpression`, or
                 `MongoDB expression <https://docs.mongodb.com/manual/meta/aggregation-quick-reference/#aggregation-expressions>`_
                 defining the field or expression to aggregate

--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -3340,7 +3340,7 @@ class SampleCollection(object):
         return list(aggregation.all)
 
     @aggregation
-    def bounds(self, field_name=None, expr=None):
+    def bounds(self, field_or_expr, expr=None):
         """Computes the bounds of a numeric field of the collection.
 
         ``None``-valued fields are ignored.
@@ -3398,18 +3398,22 @@ class SampleCollection(object):
             print(bounds)  # (min, max)
 
         Args:
-            field_name (None): the field to operate on
+            field_or_expr: a field name,
+                :class:`fiftyone.core.expressions.ViewExpression`, or
+                `MongoDB expression <https://docs.mongodb.com/manual/meta/aggregation-quick-reference/#aggregation-expressions>`_
+                defining the field or expression to aggregate
             expr (None): a :class:`fiftyone.core.expressions.ViewExpression` or
                 `MongoDB expression <https://docs.mongodb.com/manual/meta/aggregation-quick-reference/#aggregation-expressions>`_
-                to apply to the field before aggregating
+                to apply to ``field_or_expr`` (which must be a field) before
+                aggregating
 
         Returns:
             the ``(min, max)`` bounds
         """
-        return self.aggregate(foa.Bounds(field_name=field_name, expr=expr))
+        return self.aggregate(foa.Bounds(field_or_expr, expr=expr))
 
     @aggregation
-    def count(self, field_name=None, expr=None):
+    def count(self, field_or_expr=None, expr=None):
         """Counts the number of field values in the collection.
 
         ``None``-valued fields are ignored.
@@ -3479,20 +3483,26 @@ class SampleCollection(object):
             print(count)  # the count
 
         Args:
-            field_name (None): the field to operate on. If neither
-                ``field_name`` or ``expr`` is provided, the samples themselves
-                are counted
+            field_or_expr (None): a field name,
+                :class:`fiftyone.core.expressions.ViewExpression`, or
+                `MongoDB expression <https://docs.mongodb.com/manual/meta/aggregation-quick-reference/#aggregation-expressions>`_
+                defining the field or expression to aggregate. If neither
+                ``field_or_expr`` or ``expr`` is provided, the samples
+                themselves are counted
             expr (None): a :class:`fiftyone.core.expressions.ViewExpression` or
                 `MongoDB expression <https://docs.mongodb.com/manual/meta/aggregation-quick-reference/#aggregation-expressions>`_
-                to apply to the field before aggregating
+                to apply to ``field_or_expr`` (which must be a field) before
+                aggregating
 
         Returns:
             the count
         """
-        return self.aggregate(foa.Count(field_name=field_name, expr=expr))
+        return self.aggregate(
+            foa.Count(field_or_expr=field_or_expr, expr=expr)
+        )
 
     @aggregation
-    def count_values(self, field_name=None, expr=None):
+    def count_values(self, field_or_expr, expr=None):
         """Counts the occurrences of field values in the collection.
 
         This aggregation is typically applied to *countable* field types (or
@@ -3559,20 +3569,22 @@ class SampleCollection(object):
             print(counts)  # dict mapping values to counts
 
         Args:
-            field_name (None): the field to operate on
+            field_or_expr: a field name,
+                :class:`fiftyone.core.expressions.ViewExpression`, or
+                `MongoDB expression <https://docs.mongodb.com/manual/meta/aggregation-quick-reference/#aggregation-expressions>`_
+                defining the field or expression to aggregate
             expr (None): a :class:`fiftyone.core.expressions.ViewExpression` or
                 `MongoDB expression <https://docs.mongodb.com/manual/meta/aggregation-quick-reference/#aggregation-expressions>`_
-                to apply to the field before aggregating
+                to apply to ``field_or_expr`` (which must be a field) before
+                aggregating
 
         Returns:
             a dict mapping values to counts
         """
-        return self.aggregate(
-            foa.CountValues(field_name=field_name, expr=expr)
-        )
+        return self.aggregate(foa.CountValues(field_or_expr, expr=expr))
 
     @aggregation
-    def distinct(self, field_name=None, expr=None):
+    def distinct(self, field_or_expr, expr=None):
         """Computes the distinct values of a field in the collection.
 
         ``None``-valued fields are ignored.
@@ -3641,19 +3653,23 @@ class SampleCollection(object):
             print(values)  # list of distinct values
 
         Args:
-            field_name (None): the field to operate on
+            field_or_expr: a field name,
+                :class:`fiftyone.core.expressions.ViewExpression`, or
+                `MongoDB expression <https://docs.mongodb.com/manual/meta/aggregation-quick-reference/#aggregation-expressions>`_
+                defining the field or expression to aggregate
             expr (None): a :class:`fiftyone.core.expressions.ViewExpression` or
                 `MongoDB expression <https://docs.mongodb.com/manual/meta/aggregation-quick-reference/#aggregation-expressions>`_
-                to apply to the field before aggregating
+                to apply to ``field_or_expr`` (which must be a field) before
+                aggregating
 
         Returns:
             a sorted list of distinct values
         """
-        return self.aggregate(foa.Distinct(field_name=field_name, expr=expr))
+        return self.aggregate(foa.Distinct(field_or_expr, expr=expr))
 
     @aggregation
     def histogram_values(
-        self, field_name=None, expr=None, bins=None, range=None, auto=False
+        self, field_or_expr, expr=None, bins=None, range=None, auto=False
     ):
         """Computes a histogram of the field values in the collection.
 
@@ -3724,10 +3740,14 @@ class SampleCollection(object):
             plt.show(block=False)
 
         Args:
-            field_name (None): the field to operate on
+            field_or_expr: a field name,
+                :class:`fiftyone.core.expressions.ViewExpression`, or
+                `MongoDB expression <https://docs.mongodb.com/manual/meta/aggregation-quick-reference/#aggregation-expressions>`_
+                defining the field or expression to aggregate
             expr (None): a :class:`fiftyone.core.expressions.ViewExpression` or
                 `MongoDB expression <https://docs.mongodb.com/manual/meta/aggregation-quick-reference/#aggregation-expressions>`_
-                to apply to the field before aggregating
+                to apply to ``field_or_expr`` (which must be a field) before
+                aggregating
             bins (None): can be either an integer number of bins to generate or
                 a monotonically increasing sequence specifying the bin edges to
                 use. By default, 10 bins are created. If ``bins`` is an integer
@@ -3754,16 +3774,12 @@ class SampleCollection(object):
         """
         return self.aggregate(
             foa.HistogramValues(
-                field_name=field_name,
-                expr=expr,
-                bins=bins,
-                range=range,
-                auto=auto,
+                field_or_expr, expr=expr, bins=bins, range=range, auto=auto
             )
         )
 
     @aggregation
-    def mean(self, field_name=None, expr=None):
+    def mean(self, field_or_expr, expr=None):
         """Computes the arithmetic mean of the field values of the collection.
 
         ``None``-valued fields are ignored.
@@ -3821,18 +3837,22 @@ class SampleCollection(object):
             print(mean)  # the mean
 
         Args:
-            field_name (None): the field to operate on
+            field_or_expr: a field name,
+                :class:`fiftyone.core.expressions.ViewExpression`, or
+                `MongoDB expression <https://docs.mongodb.com/manual/meta/aggregation-quick-reference/#aggregation-expressions>`_
+                defining the field or expression to aggregate
             expr (None): a :class:`fiftyone.core.expressions.ViewExpression` or
                 `MongoDB expression <https://docs.mongodb.com/manual/meta/aggregation-quick-reference/#aggregation-expressions>`_
-                to apply to the field before aggregating
+                to apply to ``field_or_expr`` (which must be a field) before
+                aggregating
 
         Returns:
             the mean
         """
-        return self.aggregate(foa.Mean(field_name=field_name, expr=expr))
+        return self.aggregate(foa.Mean(field_or_expr, expr=expr))
 
     @aggregation
-    def std(self, field_name=None, expr=None, sample=False):
+    def std(self, field_or_expr, expr=None, sample=False):
         """Computes the standard deviation of the field values of the
         collection.
 
@@ -3891,22 +3911,24 @@ class SampleCollection(object):
             print(std)  # the standard deviation
 
         Args:
-            field_name (None): the field to operate on
+            field_or_expr: a field name,
+                :class:`fiftyone.core.expressions.ViewExpression`, or
+                `MongoDB expression <https://docs.mongodb.com/manual/meta/aggregation-quick-reference/#aggregation-expressions>`_
+                defining the field or expression to aggregate
             expr (None): a :class:`fiftyone.core.expressions.ViewExpression` or
                 `MongoDB expression <https://docs.mongodb.com/manual/meta/aggregation-quick-reference/#aggregation-expressions>`_
-                to apply to the field before aggregating
+                to apply to ``field_or_expr`` (which must be a field) before
+                aggregating
             sample (False): whether to compute the sample standard deviation rather
                 than the population standard deviation
 
         Returns:
             the standard deviation
         """
-        return self.aggregate(
-            foa.Std(field_name=field_name, expr=expr, sample=sample)
-        )
+        return self.aggregate(foa.Std(field_or_expr, expr=expr, sample=sample))
 
     @aggregation
-    def sum(self, field_name=None, expr=None):
+    def sum(self, field_or_expr, expr=None):
         """Computes the sum of the field values of the collection.
 
         ``None``-valued fields are ignored.
@@ -3964,20 +3986,24 @@ class SampleCollection(object):
             print(total)  # the sum
 
         Args:
-            field_name (None): the field to operate on
+            field_or_expr: a field name,
+                :class:`fiftyone.core.expressions.ViewExpression`, or
+                `MongoDB expression <https://docs.mongodb.com/manual/meta/aggregation-quick-reference/#aggregation-expressions>`_
+                defining the field or expression to aggregate
             expr (None): a :class:`fiftyone.core.expressions.ViewExpression` or
                 `MongoDB expression <https://docs.mongodb.com/manual/meta/aggregation-quick-reference/#aggregation-expressions>`_
-                to apply to the field before aggregating
+                to apply to ``field_or_expr`` (which must be a field) before
+                aggregating
 
         Returns:
             the sum
         """
-        return self.aggregate(foa.Sum(field_name=field_name, expr=expr))
+        return self.aggregate(foa.Sum(field_or_expr, expr=expr))
 
     @aggregation
     def values(
         self,
-        field_name=None,
+        field_or_expr,
         expr=None,
         missing_value=None,
         unwind=False,
@@ -4044,10 +4070,14 @@ class SampleCollection(object):
             print(values)  # [4.0, 10.0, None]
 
         Args:
-            field_name (None): the field to operate on
+            field_or_expr: a field name,
+                :class:`fiftyone.core.expressions.ViewExpression`, or
+                `MongoDB expression <https://docs.mongodb.com/manual/meta/aggregation-quick-reference/#aggregation-expressions>`_
+                defining the field or expression to aggregate
             expr (None): a :class:`fiftyone.core.expressions.ViewExpression` or
                 `MongoDB expression <https://docs.mongodb.com/manual/meta/aggregation-quick-reference/#aggregation-expressions>`_
-                to apply to the field before aggregating
+                to apply to ``field_or_expr`` (which must be a field) before
+                aggregating
             missing_value (None): a value to insert for missing or
                 ``None``-valued fields
             unwind (False): whether to automatically unwind all recognized list
@@ -4058,7 +4088,7 @@ class SampleCollection(object):
         """
         return self.aggregate(
             foa.Values(
-                field_name=field_name,
+                field_or_expr,
                 expr=expr,
                 missing_value=missing_value,
                 unwind=unwind,

--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -3340,7 +3340,7 @@ class SampleCollection(object):
         return list(aggregation.all)
 
     @aggregation
-    def bounds(self, field_name, expr=None):
+    def bounds(self, field_name=None, expr=None):
         """Computes the bounds of a numeric field of the collection.
 
         ``None``-valued fields are ignored.
@@ -3398,16 +3398,15 @@ class SampleCollection(object):
             print(bounds)  # (min, max)
 
         Args:
-            field_name: the name of the field to operate on
-            expr (None): an optional
-                :class:`fiftyone.core.expressions.ViewExpression` or
+            field_name (None): the field to operate on
+            expr (None): a :class:`fiftyone.core.expressions.ViewExpression` or
                 `MongoDB expression <https://docs.mongodb.com/manual/meta/aggregation-quick-reference/#aggregation-expressions>`_
                 to apply to the field before aggregating
 
         Returns:
             the ``(min, max)`` bounds
         """
-        return self.aggregate(foa.Bounds(field_name, expr=expr))
+        return self.aggregate(foa.Bounds(field_name=field_name, expr=expr))
 
     @aggregation
     def count(self, field_name=None, expr=None):
@@ -3480,10 +3479,10 @@ class SampleCollection(object):
             print(count)  # the count
 
         Args:
-            field_name (None): the name of the field to operate on. If none is
-                provided, the samples themselves are counted
-            expr (None): an optional
-                :class:`fiftyone.core.expressions.ViewExpression` or
+            field_name (None): the field to operate on. If neither
+                ``field_name`` or ``expr`` is provided, the samples themselves
+                are counted
+            expr (None): a :class:`fiftyone.core.expressions.ViewExpression` or
                 `MongoDB expression <https://docs.mongodb.com/manual/meta/aggregation-quick-reference/#aggregation-expressions>`_
                 to apply to the field before aggregating
 
@@ -3493,7 +3492,7 @@ class SampleCollection(object):
         return self.aggregate(foa.Count(field_name=field_name, expr=expr))
 
     @aggregation
-    def count_values(self, field_name, expr=None):
+    def count_values(self, field_name=None, expr=None):
         """Counts the occurrences of field values in the collection.
 
         This aggregation is typically applied to *countable* field types (or
@@ -3560,19 +3559,20 @@ class SampleCollection(object):
             print(counts)  # dict mapping values to counts
 
         Args:
-            field_name: the name of the field to operate on
-            expr (None): an optional
-                :class:`fiftyone.core.expressions.ViewExpression` or
+            field_name (None): the field to operate on
+            expr (None): a :class:`fiftyone.core.expressions.ViewExpression` or
                 `MongoDB expression <https://docs.mongodb.com/manual/meta/aggregation-quick-reference/#aggregation-expressions>`_
                 to apply to the field before aggregating
 
         Returns:
             a dict mapping values to counts
         """
-        return self.aggregate(foa.CountValues(field_name, expr=expr))
+        return self.aggregate(
+            foa.CountValues(field_name=field_name, expr=expr)
+        )
 
     @aggregation
-    def distinct(self, field_name, expr=None):
+    def distinct(self, field_name=None, expr=None):
         """Computes the distinct values of a field in the collection.
 
         ``None``-valued fields are ignored.
@@ -3641,20 +3641,19 @@ class SampleCollection(object):
             print(values)  # list of distinct values
 
         Args:
-            field_name: the name of the field to operate on
-            expr (None): an optional
-                :class:`fiftyone.core.expressions.ViewExpression` or
+            field_name (None): the field to operate on
+            expr (None): a :class:`fiftyone.core.expressions.ViewExpression` or
                 `MongoDB expression <https://docs.mongodb.com/manual/meta/aggregation-quick-reference/#aggregation-expressions>`_
                 to apply to the field before aggregating
 
         Returns:
             a sorted list of distinct values
         """
-        return self.aggregate(foa.Distinct(field_name, expr=expr))
+        return self.aggregate(foa.Distinct(field_name=field_name, expr=expr))
 
     @aggregation
     def histogram_values(
-        self, field_name, expr=None, bins=None, range=None, auto=False
+        self, field_name=None, expr=None, bins=None, range=None, auto=False
     ):
         """Computes a histogram of the field values in the collection.
 
@@ -3725,9 +3724,8 @@ class SampleCollection(object):
             plt.show(block=False)
 
         Args:
-            field_name: the name of the field to operate on
-            expr (None): an optional
-                :class:`fiftyone.core.expressions.ViewExpression` or
+            field_name (None): the field to operate on
+            expr (None): a :class:`fiftyone.core.expressions.ViewExpression` or
                 `MongoDB expression <https://docs.mongodb.com/manual/meta/aggregation-quick-reference/#aggregation-expressions>`_
                 to apply to the field before aggregating
             bins (None): can be either an integer number of bins to generate or
@@ -3756,12 +3754,16 @@ class SampleCollection(object):
         """
         return self.aggregate(
             foa.HistogramValues(
-                field_name, expr=expr, bins=bins, range=range, auto=auto
+                field_name=field_name,
+                expr=expr,
+                bins=bins,
+                range=range,
+                auto=auto,
             )
         )
 
     @aggregation
-    def mean(self, field_name, expr=None):
+    def mean(self, field_name=None, expr=None):
         """Computes the arithmetic mean of the field values of the collection.
 
         ``None``-valued fields are ignored.
@@ -3819,19 +3821,18 @@ class SampleCollection(object):
             print(mean)  # the mean
 
         Args:
-            field_name: the name of the field to operate on
-            expr (None): an optional
-                :class:`fiftyone.core.expressions.ViewExpression` or
+            field_name (None): the field to operate on
+            expr (None): a :class:`fiftyone.core.expressions.ViewExpression` or
                 `MongoDB expression <https://docs.mongodb.com/manual/meta/aggregation-quick-reference/#aggregation-expressions>`_
                 to apply to the field before aggregating
 
         Returns:
             the mean
         """
-        return self.aggregate(foa.Mean(field_name, expr=expr))
+        return self.aggregate(foa.Mean(field_name=field_name, expr=expr))
 
     @aggregation
-    def std(self, field_name, expr=None, sample=False):
+    def std(self, field_name=None, expr=None, sample=False):
         """Computes the standard deviation of the field values of the
         collection.
 
@@ -3890,9 +3891,8 @@ class SampleCollection(object):
             print(std)  # the standard deviation
 
         Args:
-            field_name: the name of the field to operate on
-            expr (None): an optional
-                :class:`fiftyone.core.expressions.ViewExpression` or
+            field_name (None): the field to operate on
+            expr (None): a :class:`fiftyone.core.expressions.ViewExpression` or
                 `MongoDB expression <https://docs.mongodb.com/manual/meta/aggregation-quick-reference/#aggregation-expressions>`_
                 to apply to the field before aggregating
             sample (False): whether to compute the sample standard deviation rather
@@ -3901,10 +3901,12 @@ class SampleCollection(object):
         Returns:
             the standard deviation
         """
-        return self.aggregate(foa.Std(field_name, expr=expr, sample=sample))
+        return self.aggregate(
+            foa.Std(field_name=field_name, expr=expr, sample=sample)
+        )
 
     @aggregation
-    def sum(self, field_name, expr=None):
+    def sum(self, field_name=None, expr=None):
         """Computes the sum of the field values of the collection.
 
         ``None``-valued fields are ignored.
@@ -3962,21 +3964,20 @@ class SampleCollection(object):
             print(total)  # the sum
 
         Args:
-            field_name: the name of the field to operate on
-            expr (None): an optional
-                :class:`fiftyone.core.expressions.ViewExpression` or
+            field_name (None): the field to operate on
+            expr (None): a :class:`fiftyone.core.expressions.ViewExpression` or
                 `MongoDB expression <https://docs.mongodb.com/manual/meta/aggregation-quick-reference/#aggregation-expressions>`_
                 to apply to the field before aggregating
 
         Returns:
             the sum
         """
-        return self.aggregate(foa.Sum(field_name, expr=expr))
+        return self.aggregate(foa.Sum(field_name=field_name, expr=expr))
 
     @aggregation
     def values(
         self,
-        field_name,
+        field_name=None,
         expr=None,
         missing_value=None,
         unwind=False,
@@ -4043,9 +4044,8 @@ class SampleCollection(object):
             print(values)  # [4.0, 10.0, None]
 
         Args:
-            field_name: the name of the field to operate on
-            expr (None): an optional
-                :class:`fiftyone.core.expressions.ViewExpression` or
+            field_name (None): the field to operate on
+            expr (None): a :class:`fiftyone.core.expressions.ViewExpression` or
                 `MongoDB expression <https://docs.mongodb.com/manual/meta/aggregation-quick-reference/#aggregation-expressions>`_
                 to apply to the field before aggregating
             missing_value (None): a value to insert for missing or
@@ -4058,7 +4058,7 @@ class SampleCollection(object):
         """
         return self.aggregate(
             foa.Values(
-                field_name,
+                field_name=field_name,
                 expr=expr,
                 missing_value=missing_value,
                 unwind=unwind,

--- a/fiftyone/core/plots/base.py
+++ b/fiftyone/core/plots/base.py
@@ -202,6 +202,9 @@ def scatterplot(
 
             -   the name of a sample field or ``embedded.field.name`` of
                 ``samples`` from which to extract numeric or string values
+            -   a :class:`fiftyone.core.expressions.ViewExpression` defining
+                numeric or string values to compute from ``samples`` via
+                :meth:`fiftyone.core.collections.SampleCollection.values`
             -   a list or array-like of numeric or string values
             -   a list of lists of numeric or string values, if ``link_field``
                 refers to a label list field like
@@ -212,6 +215,9 @@ def scatterplot(
 
             -   the name of a sample field or ``embedded.field.name`` of
                 ``samples`` from which to extract numeric values
+            -   a :class:`fiftyone.core.expressions.ViewExpression` defining
+                numeric values to compute from ``samples`` via
+                :meth:`fiftyone.core.collections.SampleCollection.values`
             -   a list or array-like of numeric values
             -   a list of lists of numeric or string values, if ``link_field``
                 refers to a label list field like
@@ -297,6 +303,9 @@ def location_scatterplot(
 
             -   the name of a sample field or ``embedded.field.name`` of
                 ``samples`` from which to extract numeric or string values
+            -   a :class:`fiftyone.core.expressions.ViewExpression` defining
+                numeric or string values to compute from ``samples`` via
+                :meth:`fiftyone.core.collections.SampleCollection.values`
             -   a list or array-like of numeric or string values
 
         sizes (None): data to use to scale the sizes of the points. Can be any
@@ -304,6 +313,9 @@ def location_scatterplot(
 
             -   the name of a sample field or ``embedded.field.name`` of
                 ``samples`` from which to extract numeric values
+            -   a :class:`fiftyone.core.expressions.ViewExpression` defining
+                numeric values to compute from ``samples`` via
+                :meth:`fiftyone.core.collections.SampleCollection.values`
             -   a list or array-like of numeric values
 
         classes (None): an optional list of classes whose points to plot.

--- a/fiftyone/core/plots/matplotlib.py
+++ b/fiftyone/core/plots/matplotlib.py
@@ -23,6 +23,7 @@ import sklearn.metrics as skm
 import eta.core.utils as etau
 
 import fiftyone.core.context as foc
+import fiftyone.core.expressions as foe
 import fiftyone.core.fields as fof
 import fiftyone.core.labels as fol
 import fiftyone.core.utils as fou
@@ -260,6 +261,9 @@ def scatterplot(
 
             -   the name of a sample field or ``embedded.field.name`` of
                 ``samples`` from which to extract numeric or string values
+            -   a :class:`fiftyone.core.expressions.ViewExpression` defining
+                numeric or string values to compute from ``samples`` via
+                :meth:`fiftyone.core.collections.SampleCollection.values`
             -   a list or array-like of numeric or string values
             -   a list of lists of numeric or string values, if ``link_field``
                 refers to a label list field like
@@ -270,6 +274,9 @@ def scatterplot(
 
             -   the name of a sample field or ``embedded.field.name`` of
                 ``samples`` from which to extract numeric values
+            -   a :class:`fiftyone.core.expressions.ViewExpression` defining
+                numeric values to compute from ``samples`` via
+                :meth:`fiftyone.core.collections.SampleCollection.values`
             -   a list or array-like of numeric values
             -   a list of lists of numeric or string values, if ``link_field``
                 refers to a label list field like
@@ -350,7 +357,7 @@ def _get_data_for_points(points, samples, values, parameter):
     if values is None:
         return None
 
-    if etau.is_str(values):
+    if etau.is_str(values) or isinstance(values, foe.ViewExpression):
         if samples is None:
             raise ValueError(
                 "You must provide `samples` in order to extract field values "
@@ -448,6 +455,9 @@ def location_scatterplot(
 
             -   the name of a sample field or ``embedded.field.name`` of
                 ``samples`` from which to extract numeric or string values
+            -   a :class:`fiftyone.core.expressions.ViewExpression` defining
+                numeric or string values to compute from ``samples`` via
+                :meth:`fiftyone.core.collections.SampleCollection.values`
             -   a list or array-like of numeric or string values
 
         sizes (None): data to use to scale the sizes of the points. Can be any
@@ -455,6 +465,9 @@ def location_scatterplot(
 
             -   the name of a sample field or ``embedded.field.name`` of
                 ``samples`` from which to extract numeric values
+            -   a :class:`fiftyone.core.expressions.ViewExpression` defining
+                numeric values to compute from ``samples`` via
+                :meth:`fiftyone.core.collections.SampleCollection.values`
             -   a list or array-like of numeric values
 
         classes (None): an optional list of classes whose points to plot.

--- a/fiftyone/core/plots/plotly.py
+++ b/fiftyone/core/plots/plotly.py
@@ -20,6 +20,7 @@ import eta.core.utils as etau
 
 import fiftyone as fo
 import fiftyone.core.context as foc
+import fiftyone.core.expressions as foe
 import fiftyone.core.fields as fof
 import fiftyone.core.labels as fol
 import fiftyone.core.utils as fou
@@ -439,6 +440,9 @@ def scatterplot(
 
             -   the name of a sample field or ``embedded.field.name`` of
                 ``samples`` from which to extract numeric or string values
+            -   a :class:`fiftyone.core.expressions.ViewExpression` defining
+                numeric or string values to compute from ``samples`` via
+                :meth:`fiftyone.core.collections.SampleCollection.values`
             -   a list or array-like of numeric or string values
             -   a list of lists of numeric or string values, if ``link_field``
                 refers to a label list field like
@@ -449,6 +453,9 @@ def scatterplot(
 
             -   the name of a sample field or ``embedded.field.name`` of
                 ``samples`` from which to extract numeric values
+            -   a :class:`fiftyone.core.expressions.ViewExpression` defining
+                numeric values to compute from ``samples`` via
+                :meth:`fiftyone.core.collections.SampleCollection.values`
             -   a list or array-like of numeric values
             -   a list of lists of numeric or string values, if ``link_field``
                 refers to a label list field like
@@ -623,7 +630,7 @@ def _get_data_for_points(points, samples, values, parameter):
     if values is None:
         return None
 
-    if etau.is_str(values):
+    if etau.is_str(values) or isinstance(values, foe.ViewExpression):
         if samples is None:
             raise ValueError(
                 "You must provide `samples` in order to extract field values "
@@ -746,6 +753,9 @@ def location_scatterplot(
 
             -   the name of a sample field or ``embedded.field.name`` of
                 ``samples`` from which to extract numeric or string values
+            -   a :class:`fiftyone.core.expressions.ViewExpression` defining
+                numeric or string values to compute from ``samples`` via
+                :meth:`fiftyone.core.collections.SampleCollection.values`
             -   a list or array-like of numeric or string values
 
         sizes (None): data to use to scale the sizes of the points. Can be any
@@ -753,6 +763,9 @@ def location_scatterplot(
 
             -   the name of a sample field or ``embedded.field.name`` of
                 ``samples`` from which to extract numeric values
+            -   a :class:`fiftyone.core.expressions.ViewExpression` defining
+                numeric values to compute from ``samples`` via
+                :meth:`fiftyone.core.collections.SampleCollection.values`
             -   a list or array-like of numeric values
 
         classes (None): an optional list of classes whose points to plot.

--- a/fiftyone/core/plots/views.py
+++ b/fiftyone/core/plots/views.py
@@ -177,11 +177,15 @@ class CategoricalHistogram(PlotlyViewPlot):
     """A histogram of a categorial field.
 
     Args:
-        field: the name of the field or ``embedded.field.name`` to plot
+        field_or_expr: a field name, ``embedded.field.name``,
+            :class:`fiftyone.core.expressions.ViewExpression`, or
+            `MongoDB expression <https://docs.mongodb.com/manual/meta/aggregation-quick-reference/#aggregation-expressions>`_
+            defining the field or expression to plot
         expr (None): an optional
             :class:`fiftyone.core.expressions.ViewExpression` or
             `MongoDB expression <https://docs.mongodb.com/manual/meta/aggregation-quick-reference/#aggregation-expressions>`_
-            to apply to the field before aggregating
+            to apply to ``field_or_expr`` (which must be a field) before
+            plotting
         order ("alphabetical"): the x-axis ordering strategy to use. Can be
             "alphabetical" to sort by field value, or "frequency" to sort in
             descending order of frequency, or a function suitable for
@@ -201,7 +205,7 @@ class CategoricalHistogram(PlotlyViewPlot):
 
     def __init__(
         self,
-        field,
+        field_or_expr,
         expr=None,
         order="alphabetical",
         xlabel=None,
@@ -212,7 +216,7 @@ class CategoricalHistogram(PlotlyViewPlot):
         init_view=None,
         **kwargs,
     ):
-        self.field = field
+        self.field_or_expr = field_or_expr
         self.expr = expr
         self.order = order
         self.xlabel = xlabel
@@ -234,7 +238,7 @@ class CategoricalHistogram(PlotlyViewPlot):
 
         self._figure = self._make_histogram()
 
-        self._aggregations = [foa.CountValues(field, expr=expr)]
+        self._aggregations = [foa.CountValues(field_or_expr, expr=expr)]
 
         widget = self._make_widget()
 
@@ -244,7 +248,10 @@ class CategoricalHistogram(PlotlyViewPlot):
         return go.FigureWidget(self._figure)
 
     def _make_histogram(self):
-        _field = self.field.rsplit(".", 1)[-1]
+        if etau.is_str(self.field_or_expr):
+            _field = self.field_or_expr.rsplit(".", 1)[-1]
+        else:
+            _field = "value"
 
         hover_lines = [
             "<b>%s: %%{x}</b>" % _field,
@@ -265,8 +272,10 @@ class CategoricalHistogram(PlotlyViewPlot):
 
         if self.xlabel is not None:
             xaxis_title = self.xlabel
+        elif etau.is_str(self.field_or_expr):
+            xaxis_title = self.field_or_expr
         else:
-            xaxis_title = self.field
+            xaxis_title = None
 
         layout = _DEFAULT_LAYOUT.copy()
 
@@ -315,11 +324,15 @@ class NumericalHistogram(PlotlyViewPlot):
     """A histogram of a numerical field.
 
     Args:
-        field: the name of the field or ``embedded.field.name`` to plot
+        field_or_expr: a field name, ``embedded.field.name``,
+            :class:`fiftyone.core.expressions.ViewExpression`, or
+            `MongoDB expression <https://docs.mongodb.com/manual/meta/aggregation-quick-reference/#aggregation-expressions>`_
+            defining the field or expression to plot
         expr (None): an optional
             :class:`fiftyone.core.expressions.ViewExpression` or
             `MongoDB expression <https://docs.mongodb.com/manual/meta/aggregation-quick-reference/#aggregation-expressions>`_
-            to apply to the field before aggregating
+            to apply to ``field_or_expr`` (which must be a field) before
+            plotting
         bins (None): can be either an integer number of bins to generate or a
             monotonically increasing sequence specifying the bin edges to use.
             By default, 10 bins are created. If ``bins`` is an integer and no
@@ -341,7 +354,7 @@ class NumericalHistogram(PlotlyViewPlot):
 
     def __init__(
         self,
-        field,
+        field_or_expr,
         expr=None,
         bins=None,
         range=None,
@@ -352,7 +365,7 @@ class NumericalHistogram(PlotlyViewPlot):
         init_view=None,
         **kwargs,
     ):
-        self.field = field
+        self.field_or_expr = field_or_expr
         self.expr = expr
         self.bins = bins
         self.range = range
@@ -365,7 +378,9 @@ class NumericalHistogram(PlotlyViewPlot):
         self._figure = self._make_histogram()
 
         self._aggregations = [
-            foa.HistogramValues(field, expr=expr, bins=bins, range=range)
+            foa.HistogramValues(
+                field_or_expr, expr=expr, bins=bins, range=range
+            )
         ]
 
         widget = self._make_widget()
@@ -376,7 +391,10 @@ class NumericalHistogram(PlotlyViewPlot):
         return go.FigureWidget(self._figure)
 
     def _make_histogram(self):
-        _field = self.field.rsplit(".", 1)[-1]
+        if etau.is_str(self.field_or_expr):
+            _field = self.field_or_expr.rsplit(".", 1)[-1]
+        else:
+            _field = "value"
 
         hover_lines = [
             "<b>count: %{y}</b>",
@@ -398,8 +416,10 @@ class NumericalHistogram(PlotlyViewPlot):
 
         if self.xlabel is not None:
             xaxis_title = self.xlabel
+        elif etau.is_str(self.field_or_expr):
+            xaxis_title = self.field_or_expr
         else:
-            xaxis_title = self.field
+            xaxis_title = None
 
         layout = _DEFAULT_LAYOUT.copy()
 


### PR DESCRIPTION
It has been bugging me for awhile that you couldn't pass expressions directly to aggregations, such as `dataset.bounds(F("ground_truth.detections").length())`. You can currently compute this, but you must use the syntax `dataset.bounds("ground_truth.detections", expr=F().length())`, which is less clean.

With this PR, all aggregations now accept field strings or arbitrary expressions as their first argument. The `expr` keyword is now redundant and unnecessary, but I left it to avoid a breaking change.

This also enables plots like `scatterplot(..., labels=field_or_expr, sizes=field_or_expr, ...)` and `CategoricalHistogram(field_or_expr, ...)` to accept expressions defining the values to use in the plots. The examples at the end demonstrate the utility of this 😄 

The reason I didn't implement this from the start is that some care was required to properly support expressions that contain nested list fields, since the lists need to be detected and automatically unwound. The new implementation works by introspecting the provided expression, extracting the longest common (non-frozen) `ViewField` prefix, and then computing the expression with proper unwinding as a `field, expr` pair using the existing implementation.

### Examples of aggregating expressions

```py
import fiftyone as fo
import fiftyone.zoo as foz
from fiftyone import ViewField as F

dataset = foz.load_zoo_dataset("quickstart")
dataset.compute_metadata()

avg_bbox_area = F("ground_truth.detections").map(
    F("bounding_box")[2] * F("$metadata.height")
    * F("bounding_box")[3] * F("$metadata.width")
).mean()

print(dataset.take(5).values(avg_bbox_area))

print(dataset.bounds(F("ground_truth.detections").length()))

print(dataset.count_values("ground_truth.detections.label"))
print(dataset.count_values(F("ground_truth.detections.label")))  # equivalent
```

### Examples of passing expressions to scatterplot()

```py
import fiftyone as fo
import fiftyone.brain as fob
import fiftyone.zoo as foz
from fiftyone import ViewField as F

dataset = foz.load_zoo_dataset("quickstart")

results = fob.compute_visualization(dataset)

# directly pass an expression for `sizes`
plot = results.visualize(labels="uniqueness", sizes=F("ground_truth.detections").length())
plot.show(height=512)
```

<img width="1275" alt="Screen Shot 2021-04-27 at 12 06 22 PM" src="https://user-images.githubusercontent.com/25985824/116274900-14e9fa80-a751-11eb-928e-f7b4d5852b50.png">

### Examples of passing expressions to ViewPlots

```py
import fiftyone as fo
import fiftyone.zoo as foz
from fiftyone import ViewField as F

dataset = foz.load_zoo_dataset("quickstart")
dataset.compute_metadata()

# directly pass an expression to histogram
plot1 = fo.NumericalHistogram(F("metadata.size_bytes") / 1024, bins=50, xlabel="image size (KB)")

plot2 = fo.NumericalHistogram("predictions.detections.confidence", bins=50)
plot3 = fo.CategoricalHistogram("ground_truth.detections.label", order="frequency")
plot4 = fo.CategoricalHistogram("predictions.detections.label", order="frequency")

plot = fo.ViewGrid([plot1, plot2, plot3, plot4], init_view=dataset)
plot.show(height=720)
```

<img width="1277" alt="Screen Shot 2021-04-27 at 12 06 44 PM" src="https://user-images.githubusercontent.com/25985824/116274881-10254680-a751-11eb-873f-8fbcdb17dd2d.png">
