### PR TITLE
Require eager execution mode when exporting datasets in TF format

### DIFF
--- a/fiftyone/core/utils.py
+++ b/fiftyone/core/utils.py
@@ -163,16 +163,41 @@ def fill_patterns(string):
     return etau.fill_patterns(string, available_patterns())
 
 
-def ensure_tf(error_msg=None):
+def ensure_tf(eager=False, error_msg=None):
     """Verifies that TensorFlow is installed and importable.
 
     Args:
+        eager (False): whether to require that TF is executing eagerly. If
+            True and TF is not currently executing eagerly, this method will
+            attempt to enable it
         error_msg (None): an optional custom error message to print
 
     Raises:
         ImportError: if ``tensorflow`` could not be imported
     """
     _ensure_import("tensorflow", error_msg=error_msg)
+
+    if not eager:
+        return
+
+    import tensorflow as tf
+
+    try:
+        if tf.executing_eagerly():
+            return
+
+        try:
+            # pylint: disable=no-member
+            tf.compat.v1.enable_eager_execution()
+        except AttributeError:
+            # pylint: disable=no-member
+            tf.enable_eager_execution()
+    except Exception as e:
+        raise ValueError(
+            "The requested operation requires that TensorFlow's eager "
+            "execution mode is activated. We tried to enable it but "
+            "encountered an error"
+        ) from e
 
 
 def ensure_tfds(error_msg=None):

--- a/fiftyone/utils/tf.py
+++ b/fiftyone/utils/tf.py
@@ -17,7 +17,7 @@ import fiftyone.core.metadata as fom
 import fiftyone.core.utils as fou
 import fiftyone.utils.data as foud
 
-fou.ensure_tf()
+fou.ensure_tf(eager=True)
 import tensorflow as tf
 
 


### PR DESCRIPTION
I recently tried exporting a dataset in `fo.types.TFObjectDetectionDataset` format on a new machine and found errors related to eager vs non-eager TF execution mode.

I struggle to understand why this hasn't been an issue before, but it seems that the `fiftyone.utils.tf` module *requires* eager execution mode, so I updated the code to enable if necessary and raise a helpful error if that couldn't be achieved.

This issue is only relevant for TF 1.X users. Things have and will continue to work as expected for TF 2.X users.

Tested by verifying that the snippet below runs under TF 1.12, 1.15, and 2.X.

```py
import fiftyone as fo
import fiftyone.zoo as foz

dataset = foz.load_zoo_dataset("quickstart")
dataset.export("/tmp/test", fo.types.TFObjectDetectionDataset, label_field="ground_truth")
```
