### PR TITLE
`Session.wait()` support for browsers

### DIFF
--- a/fiftyone/core/client.py
+++ b/fiftyone/core/client.py
@@ -114,6 +114,9 @@ class HasClient(object):
                 if event == "reload":
                     self.on_reload()
 
+                if event == "close":
+                    self.on_close()
+
         def run_client():
             io_loop = IOLoop(make_current=True)
             io_loop.run_sync(connect)
@@ -168,6 +171,12 @@ class HasClient(object):
 
     def _capture(self, data):
         raise NotImplementedError("subclasses must implement _capture()")
+
+    def on_close(self):
+        self._close()
+
+    def _close(self):
+        raise NotImplementedError("subclasses must implement _close()")
 
     def on_reactivate(self, data):
         self._reactivate(data)

--- a/fiftyone/server/main.py
+++ b/fiftyone/server/main.py
@@ -415,6 +415,8 @@ class StateHandler(tornado.websocket.WebSocketHandler):
         """
         StateHandler.clients.remove(self)
         StateHandler.app_clients.discard(self)
+        if not StateHandler.app_clients:
+            _write_message({"type": "close"}, session=True)
 
     @_catch_errors
     async def on_message(self, message):


### PR DESCRIPTION
Resolves #998 

This is a relatively minor feature, so it has a minimal implementation.

Desktop waiting has not changed. An exit is triggered when the `AppService` (process) is closed.

For browsers, if a session waits, all browser connections (windows/tabs) must be lost (closed) for the wait to exit.

Snippet:
```py
import fiftyone as fo

dataset, session = fo.quickstart()

session.wait()
# close the browser, and we exit

print("CLOSED")
```