### PR TITLE
Recover from cursor timeouts

### DIFF
--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -20,7 +20,7 @@ from bson import ObjectId
 from deprecated import deprecated
 import mongoengine.errors as moe
 from pymongo import UpdateMany, UpdateOne
-from pymongo.errors import BulkWriteError
+from pymongo.errors import CursorNotFound, BulkWriteError
 
 import eta.core.serial as etas
 import eta.core.utils as etau
@@ -1254,11 +1254,19 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
         Returns:
             an iterator over :class:`fiftyone.core.sample.Sample` instances
         """
-        for d in self._aggregate(detach_frames=True):
-            doc = self._sample_dict_to_doc(d)
-            sample = fos.Sample.from_doc(doc, dataset=self)
+        index = 0
+        try:
+            for d in self._aggregate(detach_frames=True):
+                doc = self._sample_dict_to_doc(d)
+                sample = fos.Sample.from_doc(doc, dataset=self)
+                index += 1
+                yield sample
 
-            yield sample
+        # the cursor has timed so we yield from a new one with the last offset
+        except CursorNotFound:
+            view = self.skip(index)
+            for sample in view.iter_samples():
+                yield sample
 
     def add_sample(self, sample, expand_schema=True):
         """Adds the given sample to the dataset.

--- a/fiftyone/core/view.py
+++ b/fiftyone/core/view.py
@@ -264,6 +264,7 @@ class DatasetView(foc.SampleCollection):
         filtered_fields = self._get_filtered_fields()
 
         index = 0
+
         try:
             for d in self._aggregate(detach_frames=True):
                 try:
@@ -280,12 +281,14 @@ class DatasetView(foc.SampleCollection):
 
                 except Exception as e:
                     raise ValueError(
-                        "Failed to load sample from the database. This is likely "
-                        "due to an invalid stage in the DatasetView"
+                        "Failed to load sample from the database. This is "
+                        "likely due to an invalid stage in the DatasetView"
                     ) from e
 
-        # the cursor has timed so we yield from a new one with the last offset
         except CursorNotFound:
+            # The cursor has timed out so we yield from a new one after
+            # skipping to the last offset
+
             view = self.skip(index)
             for sample in view.iter_samples():
                 yield sample

--- a/fiftyone/core/view.py
+++ b/fiftyone/core/view.py
@@ -10,6 +10,7 @@ from copy import copy, deepcopy
 import numbers
 
 from bson import ObjectId
+from pymongo.errors import CursorNotFound
 
 import eta.core.utils as etau
 
@@ -262,23 +263,32 @@ class DatasetView(foc.SampleCollection):
         selected_fields, excluded_fields = self._get_selected_excluded_fields()
         filtered_fields = self._get_filtered_fields()
 
-        for d in self._aggregate(detach_frames=True):
-            try:
-                doc = self._dataset._sample_dict_to_doc(d)
-                sample = sample_cls(
-                    doc,
-                    self,
-                    selected_fields=selected_fields,
-                    excluded_fields=excluded_fields,
-                    filtered_fields=filtered_fields,
-                )
+        index = 0
+        try:
+            for d in self._aggregate(detach_frames=True):
+                try:
+                    doc = self._dataset._sample_dict_to_doc(d)
+                    sample = sample_cls(
+                        doc,
+                        self,
+                        selected_fields=selected_fields,
+                        excluded_fields=excluded_fields,
+                        filtered_fields=filtered_fields,
+                    )
+                    index += 1
+                    yield sample
 
+                except Exception as e:
+                    raise ValueError(
+                        "Failed to load sample from the database. This is likely "
+                        "due to an invalid stage in the DatasetView"
+                    ) from e
+
+        # the cursor has timed so we yield from a new one with the last offset
+        except CursorNotFound:
+            view = self.skip(index)
+            for sample in view.iter_samples():
                 yield sample
-            except Exception as e:
-                raise ValueError(
-                    "Failed to load sample from the database. This is likely "
-                    "due to an invalid stage in the DatasetView"
-                ) from e
 
     def get_field_schema(
         self, ftype=None, embedded_doc_type=None, include_private=False


### PR DESCRIPTION
Resolves #1002

In dataset and view `iter_samples()`, if a cursor has timed out we continue with a new view offset from the last index.

I can't think of any other likely reason `CusorNotFound` would raise in this try/except. I suppose a recursion limit would be reached if that was the case.