### PR TITLE
Adding flag to extract eval patches from evaluation view

### DIFF
--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -3761,7 +3761,7 @@ class SampleCollection(object):
         return self._add_view_stage(fos.ToPatches(field))
 
     @view_stage
-    def to_evaluation_patches(self, eval_key):
+    def to_evaluation_patches(self, eval_key, use_eval_view=False):
         """Creates a view based on the results of the evaluation with the
         given key that contains one sample for each true positive, false
         positive, and false negative example in the collection, respectively.
@@ -3781,6 +3781,19 @@ class SampleCollection(object):
         well as a ``sample_id`` field recording the sample ID of the example,
         and a ``crowd`` field if the evaluation protocol defines a crowd
         attribute.
+
+        .. note::
+
+            By default, when ``use_eval_view`` is False, the returned view
+            will contain patches for the contents of this collection, which
+            may differ from the view on which the ``eval_key`` evaluation was
+            performed. This may exclude some labels that were evaluated and/or
+            include labels that were not evaluated.
+
+            Conversely, if you set ``use_eval_view`` to True, the returned view
+            will contain patches for the exact view on which the evaluation was
+            run, regardless of any view stages that this collection may
+            contain.
 
         Examples::
 
@@ -3806,11 +3819,15 @@ class SampleCollection(object):
                 ground truth/predicted fields that are of type
                 :class:`fiftyone.core.labels.Detections` or
                 :class:`fiftyone.core.labels.Polylines`
+            use_eval_view (False): whether to use the exact view on which the
+                ``eval_key`` evaluation was run to generate patches
 
         Returns:
             a :class:`fiftyone.core.patches.EvaluationPatchesView`
         """
-        return self._add_view_stage(fos.ToEvaluationPatches(eval_key))
+        return self._add_view_stage(
+            fos.ToEvaluationPatches(eval_key, use_eval_view=use_eval_view)
+        )
 
     @classmethod
     def list_aggregations(cls):

--- a/fiftyone/utils/patches.py
+++ b/fiftyone/utils/patches.py
@@ -230,7 +230,18 @@ def _make_eval_view(
 
     if skip_matched:
         view = view.mongo(
-            [{"$match": {"$expr": {"$eq": ["$" + eval_id, _NO_MATCH_ID]}}}]
+            [
+                {
+                    "$match": {
+                        "$expr": {
+                            "$or": [
+                                {"$eq": ["$" + eval_id, _NO_MATCH_ID]},
+                                {"$not": {"$gt": ["$" + eval_id, None]}},
+                            ]
+                        }
+                    }
+                }
+            ]
         )
 
     view = view.mongo(


### PR DESCRIPTION
Previously, `to_evaluation_patches()` would ignore the collection to which the stage was being added and always extract patches from the view on which the evaluation was performed.

This PR changes the default behavior to instead extract patches from the collection to which `to_evaluation_patches()` is being applied. This may result in both omitting labels that were evaluated as well as including labels which were not evaluated, but that's okay. In the case of labels which were not evaluated, for example, each label will get its own patch with `type == None`.

This also resolves a bug in the current implementation where, effectively, `use_eval_view=True` was always being used when `to_evaluation_patches()` is called, but the view stages of the returned view were not correctly updated to reflect the fact that the evaluation view was being used.

### TODO

@benjaminpkane the `use_eval_true=True` parameter is a bit different from other view stages in that it can result in a view where the previously constructed view stages are deleted and replaced with different stages. A simple way to reproduce this effect is to run the snippet below. Can you look into whether the indicated error can be avoided?

```py
import fiftyone as fo
import fiftyone.zoo as foz

dataset = foz.load_zoo_dataset("quickstart").clone()

# Evaluate part of the dataset
dataset.limit(100).evaluate_detections("predictions", eval_key="eval")

session = fo.launch_app(dataset)

# Creates patches for contents of view, some of which were evaluated and some of which were not
session.view = dataset.skip(50).to_evaluation_patches("eval")

# Now in the App view bar, change `use_eval_view` parameter from `False` to `True`
# This raises an error in the App and in the terminal, although the view does seem to load afterwards

# Achieves the same result, but no errors as the view is created first
session.view = dataset.skip(50).to_evaluation_patches("eval", use_eval_view=True)
```

### Example usage

```py
import fiftyone as fo
import fiftyone.zoo as foz

dataset = foz.load_zoo_dataset("quickstart").clone()

# Evaluate part of dataset
dataset.limit(100).evaluate_detections("predictions", eval_key="eval")

session = fo.launch_app(dataset)

# Creates eval patches for entire dataset. Labels that weren't included in the
# evaluation get their own patches with ``type == None``
session.view = dataset.to_evaluation_patches("eval")

# Creates patches for contents of view, some of which were evaluated and some of which were not
session.view = dataset.skip(50).to_evaluation_patches("eval")

# Creates patches for evaluation view, regardless of prior view stages
session.view = dataset.skip(50).to_evaluation_patches("eval", use_eval_view=True)

# Test complete mismatch; all labels have ``type == None``
session.view = dataset.skip(100).to_evaluation_patches("eval")
```
