### PR TITLE
Restrict string field graphs to fields with small distinct counts

### DIFF
--- a/app/src/components/Distributions.tsx
+++ b/app/src/components/Distributions.tsx
@@ -3,7 +3,6 @@ import { Bar, BarChart, XAxis, YAxis, Tooltip } from "recharts";
 import { selectorFamily, useRecoilValue } from "recoil";
 import styled from "styled-components";
 import useMeasure from "react-use-measure";
-import _ from "lodash";
 import { scrollbarStyles } from "./utils";
 
 import Loading from "./Loading";
@@ -11,7 +10,6 @@ import { ContentDiv, ContentHeader } from "./utils";
 import { isFloat, prettify } from "../utils/generic";
 import { useMessageHandler, useSendMessage } from "../utils/hooks";
 import * as selectors from "../recoil/selectors";
-import { stat } from "fs";
 import { AGGS } from "../utils/labels";
 
 const Container = styled.div`
@@ -163,13 +161,13 @@ const omitDistributions = selectorFamily<string[], string>({
         }
         return acc;
       }, {});
-      const omit = ["tags"];
+      const omit = ["tags", "filepath", "sample_id"];
       scalars.forEach((name) => {
         if (distinct[name] && distinct[name] > 100) {
           omit.push(name);
         }
       });
-      return omit;
+      return [...new Set(omit)];
     }
     return [];
   },

--- a/app/src/components/FieldsSidebar.tsx
+++ b/app/src/components/FieldsSidebar.tsx
@@ -550,29 +550,31 @@ const ScalarsCell = ({ modal }: ScalarsCellProps) => {
     <Cell
       label="Scalar fields"
       icon={<BarChart />}
-      entries={scalars.map((name) => {
-        return {
-          name,
-          disabled: false,
-          hideCheckbox: modal,
-          hasDropdown: !modal,
-          selected: activeScalars.includes(name),
-          color: colorByLabel ? theme.brand : colorMap[name],
-          title: modal ? prettify(count[name], false) : name,
-          path: name,
-          type: "values",
-          data:
-            count && subCount && !modal
-              ? makeData(subCount[name], count[name])
-              : modal
-              ? prettify(count[name])
-              : null,
-          totalCount: !modal && count ? count[name] : null,
-          filteredCount: !modal && subCount ? subCount[name] : null,
-          modal,
-          canFilter: !modal,
-        };
-      })}
+      entries={scalars
+        .filter((name) => !(name === "filepath" && modal))
+        .map((name) => {
+          return {
+            name,
+            disabled: false,
+            hideCheckbox: modal,
+            hasDropdown: !modal,
+            selected: activeScalars.includes(name),
+            color: colorByLabel ? theme.brand : colorMap[name],
+            title: modal ? prettify(count[name], false) : name,
+            path: name,
+            type: "values",
+            data:
+              count && subCount && !modal
+                ? makeData(subCount[name], count[name])
+                : modal
+                ? prettify(count[name])
+                : null,
+            totalCount: !modal && count ? count[name] : null,
+            filteredCount: !modal && subCount ? subCount[name] : null,
+            modal,
+            canFilter: !modal,
+          };
+        })}
       onSelect={
         !modal
           ? ({ name, selected }) => {

--- a/app/src/components/HorizontalNav.tsx
+++ b/app/src/components/HorizontalNav.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { useRecoilState } from "recoil";
+import { useRecoilState, useRecoilValue } from "recoil";
 import styled from "styled-components";
 import {
   Assessment,
@@ -12,6 +12,7 @@ import { PillButton } from "./utils";
 import Distributions from "./Distributions";
 import { useWindowSize } from "../utils/hooks";
 import * as atoms from "../recoil/atoms";
+import * as selectors from "../recoil/selectors";
 import { Resizable } from "re-resizable";
 
 export type Props = {
@@ -99,6 +100,7 @@ const HorizontalNav = ({ entries }: Props) => {
   const [expanded, setExpanded] = useState(false);
   const [openedHeight, setOpenedHeight] = useState(392);
   const [maximized, setMaximized] = useState(false);
+  const isRoot = useRecoilValue(selectors.isRootView);
   const closedHeight = 64;
 
   const height = expanded ? openedHeight : closedHeight;
@@ -136,7 +138,7 @@ const HorizontalNav = ({ entries }: Props) => {
                 }
               }}
             >
-              {e}
+              {isRoot ? e : e === "Sample tags" ? "Patch tags" : e}
             </PlotButton>
           ))}
         </PlotsButtons>

--- a/app/src/recoil/selectors.ts
+++ b/app/src/recoil/selectors.ts
@@ -460,7 +460,15 @@ const labelFilter = (f) => {
 };
 
 const scalarFilter = (f) => {
-  return VALID_SCALAR_TYPES.includes(f.ftype) && !f.name.startsWith("_");
+  if (f.name.startsWith("_") || f.name === "tags") {
+    return false;
+  }
+
+  if (VALID_SCALAR_TYPES.includes(f.ftype)) {
+    return true;
+  }
+
+  return false;
 };
 
 const fields = selectorFamily<{ [key: string]: SerializableParam }, string>({

--- a/fiftyone/server/main.py
+++ b/fiftyone/server/main.py
@@ -1017,9 +1017,7 @@ class StateHandler(tornado.websocket.WebSocketHandler):
         elif results is None:
 
             def filter(field):
-                if field.name in {"filepath", "tags"} or field.name.startswith(
-                    "_"
-                ):
+                if field.name in {"tags"} or field.name.startswith("_"):
                     return None
 
                 if fos._meets_type(field, (fof.BooleanField, fof.StringField)):

--- a/fiftyone/server/main.py
+++ b/fiftyone/server/main.py
@@ -960,7 +960,7 @@ class StateHandler(tornado.websocket.WebSocketHandler):
         _write_message(message, app=True, only=self)
 
     @classmethod
-    async def on_distributions(cls, self, group):
+    async def on_distributions(cls, self, group, omit=[]):
         """Sends distribution data with respect to a group to the requesting
         client.
 
@@ -1017,7 +1017,11 @@ class StateHandler(tornado.websocket.WebSocketHandler):
         elif results is None:
 
             def filter(field):
-                if field.name in {"tags"} or field.name.startswith("_"):
+                if (
+                    field.name in {"tags"}
+                    or field.name in omit
+                    or field.name.startswith("_")
+                ):
                     return None
 
                 if fos._meets_type(field, (fof.BooleanField, fof.StringField)):


### PR DESCRIPTION
I think there is a bright future for plots in FiftyOne.

In the meantime, I think silently restricting string field graphs to those with distinct counts less than 100 (currently). `tags` (redundant), `filepath` and `sample_id` are always omitted. Note that the graphs support lists with scalar subfields, unlike the sidebar.

A somewhat lazy solution to preventing excessive information in the App (and possible freezing) but I think there are bigger fish to fry. :fish: 