### PR TITLE
TensorFlow VGG zoo model only supports TF1

### DIFF
--- a/fiftyone/zoo/models/manifest-tf.json
+++ b/fiftyone/zoo/models/manifest-tf.json
@@ -1217,7 +1217,7 @@
             "date_added": "2020-12-11 13:45:51"
         },
         {
-            "base_name": "vgg16-imagenet-tf",
+            "base_name": "vgg16-imagenet-tf1",
             "base_filename": "vgg16-imagenet.npz",
             "version": null,
             "description": "VGG-16 model from `Very Deep Convolutional Networks for Large-Scale Image Recognition <https://arxiv.org/abs/1409.1556>`_ trained on ImageNet",
@@ -1243,11 +1243,11 @@
             "requirements": {
                 "cpu": {
                     "support": true,
-                    "packages": ["tensorflow"]
+                    "packages": ["tensorflow<2"]
                 },
                 "gpu": {
                     "support": true,
-                    "packages": ["tensorflow-gpu|tensorflow>=2"]
+                    "packages": ["tensorflow-gpu<2"]
                 }
             },
             "tags": [
@@ -1255,7 +1255,7 @@
                 "embeddings",
                 "logits",
                 "imagenet",
-                "tf"
+                "tf1"
             ],
             "date_added": "2020-12-11 13:45:51"
         },


### PR DESCRIPTION
I believe #995 caused the `vgg16-imagenet-tf` zoo model to no longer support TF2.

In any case, I now get an error when trying to run it in TF2. This is an old model and an old implementation that was written in TF 1.12 or something, so it was mostly miraculous that we managed to get it to run under TF2 in the first place using `tf.compat.v1` tricks.

So, this PR renames `vgg16-imagenet-tf` to `vgg16-imagenet-tf1` (per existing convention) and updates the install requirements to reflect TF1-only support. The name change is breaking, but I'm okay with it for consistency with the naming convention in-place.

I checked other models that promise to support TF1 and TF2 and they still seem to work in both environments.

Tested by verifying that the autogenerated code snippet in the zoo model listing runs as expected:

```py
import fiftyone as fo
import fiftyone.zoo as foz

dataset = foz.load_zoo_dataset(
    "imagenet-sample",
    dataset_name=fo.get_default_dataset_name(),
    max_samples=50,
    shuffle=True,
)

model = foz.load_zoo_model("vgg16-imagenet-tf1")

dataset.apply_model(model, label_field="predictions")

session = fo.launch_app(dataset)
```