### PR TITLE
Fixing multiprocess initialization bug when loading Open Images dataset (#1)

### DIFF
--- a/fiftyone/utils/openimages.py
+++ b/fiftyone/utils/openimages.py
@@ -1575,8 +1575,6 @@ def _initialize_worker():
 
 def _do_s3_download(args):
     filepath, filepath_download = args
-
-    global s3_client
     s3_client.download_file(_BUCKET_NAME, filepath_download, filepath)
 
 

--- a/fiftyone/utils/openimages.py
+++ b/fiftyone/utils/openimages.py
@@ -1559,19 +1559,14 @@ def _download_specific_images(
             len(inputs),
         )
 
-    global s3_client
-    s3_client = None
-
     with fou.ProgressBar(total=len(inputs)) as pb:
-        with multiprocessing.Pool(num_workers) as pool:
+        with multiprocessing.Pool(num_workers, _initialize_worker) as pool:
             for _ in pool.imap_unordered(_do_s3_download, inputs):
                 pb.update()
 
 
-def _initialize_pool():
+def _initialize_worker():
     global s3_client
-    if s3_client:
-        return
     s3_client = boto3.client(
         "s3",
         config=botocore.config.Config(signature_version=botocore.UNSIGNED),
@@ -1579,8 +1574,9 @@ def _initialize_pool():
 
 
 def _do_s3_download(args):
-    _initialize_pool()
     filepath, filepath_download = args
+
+    global s3_client
     s3_client.download_file(_BUCKET_NAME, filepath_download, filepath)
 
 


### PR DESCRIPTION
Resolves https://github.com/voxel51/fiftyone/issues/1035.

Fixes a bug in the way that the `multiprocessing` module was being used that was causing Mac users running Python >= 3.8 to encounter an error when downloading the Open Images dataset.

Verified that this fixes the bug under Python 3.8:

```
conda create -n fifty3 python=3.8
conda activate fifty3

git clone https://github.com/voxel51/fiftyone
cd fiftyone
git checkout --track origin/oi-hotfix
bash install.bash
```

```py
import fiftyone.zoo as foz

# now works
dataset = foz.load_zoo_dataset(
    "open-images-v6", 
    split="validation", 
    label_types=["detections"], 
    max_samples=10,
)
```
