### PR TITLE
Adding support for merging list fields, plus other goodies

### DIFF
--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -463,33 +463,18 @@ class SampleCollection(object):
 
         return field_name in self.get_frame_field_schema()
 
-    def validate_fields_exist(self, field_or_fields):
-        """Validates that the collection has fields with the given names.
+    def validate_fields_exist(self, fields):
+        """Validates that the collection has field(s) with the given name(s).
 
-        If ``field_or_fields`` contains an embedded field name such as
-        ``field_name.document.field``, only the root ``field_name`` is checked
-        for existence.
+        If embedded field names are provided, only the root field is checked.
 
         Args:
-            field_or_fields: a field name or iterable of field names
+            fields: a field name or iterable of field names
 
         Raises:
             ValueError: if one or more of the fields do not exist
         """
-        if etau.is_str(field_or_fields):
-            fields = [field_or_fields]
-        else:
-            fields = field_or_fields
-
-        if self.media_type == fom.VIDEO:
-            frame_fields = list(
-                filter(lambda n: n.startswith(self._FRAMES_PREFIX), fields)
-            )
-            fields = list(
-                filter(lambda n: not n.startswith(self._FRAMES_PREFIX), fields)
-            )
-        else:
-            frame_fields = []
+        fields, frame_fields = self._split_frame_fields(fields)
 
         if fields:
             schema = self.get_field_schema(include_private=True)
@@ -522,7 +507,7 @@ class SampleCollection(object):
 
             for field in frame_fields:
                 # We only validate that the root field exists
-                field_name = field.split(".", 2)[1]  # removes "frames."
+                field_name = field.split(".", 1)[0]
                 if (
                     field_name not in frame_schema
                     and field_name not in default_frame_fields
@@ -5360,6 +5345,15 @@ class SampleCollection(object):
             "    %s %s" % ((field_name + ":").ljust(max_len), str(field))
             for field_name, field in field_schema.items()
         )
+
+    def _split_frame_fields(self, fields):
+        if etau.is_str(fields):
+            fields = [fields]
+
+        if self.media_type != fom.VIDEO:
+            return fields, []
+
+        return fou.split_frame_fields(fields)
 
     def _parse_field_name(
         self,

--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -1439,6 +1439,7 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
         insert_new=True,
         expand_schema=True,
         omit_default_fields=False,
+        merge_lists=False,
         overwrite=True,
         include_info=True,
         overwrite_info=False,
@@ -1472,8 +1473,11 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
                 if a sample's schema is not a subset of the dataset schema
             omit_default_fields (False): whether to omit default sample fields
                 when merging. If ``True``, ``insert_new`` must be ``False``
+            merge_lists (False): whether to merge top-level list fields and the
+                elements of label list fields. If ``True``, this parameter
+                supercedes the ``overwrite`` parameter for list fields
             overwrite (True): whether to overwrite (True) or skip (False)
-                existing sample fields
+                existing fields
             include_info (True): whether to merge dataset-level information
                 such as ``info`` and ``classes``. Only applicable when
                 ``samples`` is a
@@ -1488,6 +1492,7 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
             isinstance(samples, foc.SampleCollection)
             and key_fcn is None
             and overwrite
+            and not merge_lists
         ):
             _merge_samples(
                 samples,
@@ -1498,6 +1503,7 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
                 insert_new=insert_new,
                 expand_schema=expand_schema,
                 omit_default_fields=omit_default_fields,
+                merge_lists=merge_lists,
                 include_info=include_info,
                 overwrite_info=overwrite_info,
             )
@@ -1544,6 +1550,7 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
                             sample,
                             omit_fields=omit_fields,
                             omit_none_fields=omit_none_fields,
+                            merge_lists=merge_lists,
                             overwrite=overwrite,
                             expand_schema=expand_schema,
                         )
@@ -3817,6 +3824,7 @@ def _merge_samples(
     insert_new=True,
     expand_schema=True,
     omit_default_fields=False,
+    merge_lists=False,
     include_info=True,
     overwrite_info=False,
 ):
@@ -3940,6 +3948,8 @@ def _merge_samples(
                 }
             }
         )
+
+    # @todo support `overwrite=False` and `merge_lists=True`
 
     sample_pipeline.append(
         {

--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -4181,7 +4181,6 @@ def _merge_docs(
 
     if merge_lists:
         list_fields = []
-        label_list_fields = []
         elem_fields = []
         for field, field_type in schema.items():
             if fields is not None and field not in fields:
@@ -4195,7 +4194,6 @@ def _merge_docs(
             elif isinstance(
                 field_type, fof.EmbeddedDocumentField
             ) and issubclass(field_type.document_type, fol._LABEL_LIST_FIELDS):
-                label_list_fields.append(field)
                 elem_fields.append(
                     field + "." + field_type.document_type._LABEL_LIST_FIELD
                 )
@@ -4292,7 +4290,7 @@ def _merge_label_list_field(doc, elem_field, overwrite=False):
                                 "$reverseArray": "$$new." + elem_field
                             },
                             "in": {
-                                "cond": {
+                                "$cond": {
                                     "if": {
                                         "$not": {
                                             "$in": ["$$this._id", "$$new_ids"]
@@ -4330,7 +4328,7 @@ def _merge_label_list_field(doc, elem_field, overwrite=False):
                         "input": "$$new." + elem_field,
                         "initialValue": "$" + elem_field,
                         "in": {
-                            "cond": {
+                            "$cond": {
                                 "if": {
                                     "$not": {
                                         "$in": ["$$this._id", "$$existing_ids"]

--- a/fiftyone/core/document.py
+++ b/fiftyone/core/document.py
@@ -236,7 +236,7 @@ class _Document(object):
         """Merges the fields of the document into this document.
 
         Args:
-            document: a :class:`Document` or :class:`DocumentView` the same
+            document: a :class:`Document` or :class:`DocumentView` of the same
                 type
             fields (None): an optional field or iterable of fields to which to
                 restrict the merge

--- a/fiftyone/core/document.py
+++ b/fiftyone/core/document.py
@@ -267,7 +267,7 @@ class _Document(object):
         if not overwrite:
             existing_field_names = set(self.field_names)
 
-        fields = self._parse_fields(fields=fields, omit_fields=omit_fields)
+        fields = document._parse_fields(fields=fields, omit_fields=omit_fields)
 
         for field_name in fields:
             value = document[field_name]

--- a/fiftyone/core/document.py
+++ b/fiftyone/core/document.py
@@ -229,7 +229,7 @@ class _Document(object):
         fields=None,
         omit_fields=None,
         omit_none_fields=True,
-        merge_lists=False,
+        merge_lists=True,
         overwrite=True,
         expand_schema=True,
     ):
@@ -244,17 +244,18 @@ class _Document(object):
                 exclude from the merge
             omit_none_fields (True): whether to omit ``None``-valued fields of
                 the provided document
-            merge_lists (False): whether to merge top-level list fields and the
-                elements of label list fields. If ``True``, this parameter
-                supercedes the ``overwrite`` parameter for list fields, and,
-                for label lists fields, existing
+            merge_lists (True): whether to merge the elements of top-level list
+                fields (e.g., ``tags``) and label list fields (e.g.,
+                :class:`fiftyone.core.labels.Detections` fields) rather than
+                merging the entire top-level field like other field types.
+                For label lists fields, existing
                 :class:`fiftyone.core.label.Label` elements are either replaced
                 (when ``overwrite`` is True) or kept (when ``overwrite`` is
-                False) when their ``id`` matches a
-                :class:`fiftyone.core.label.Label` from the provided document
-            overwrite (True): whether to overwrite existing fields. Note that
-                existing fields whose values are ``None`` are always
-                overwritten
+                False) when their ``id`` matches a label from the provided
+                document
+            overwrite (True): whether to overwrite (True) or skip (False)
+                existing fields. Note that fields whose values are ``None`` or
+                missing are always overwritten
             expand_schema (True): whether to dynamically add new fields
                 encountered to the document schema. If False, an error is
                 raised if any fields are not in the document schema

--- a/fiftyone/core/expressions.py
+++ b/fiftyone/core/expressions.py
@@ -2175,9 +2175,9 @@ class ViewExpression(object):
         """
         return ViewExpression({"$size": {"$ifNull": [self, []]}})
 
-    def contains(self, value_or_values):
-        """Checks whether the given value (or any of the given values) is in
-        this expression, which must resolve to an array.
+    def contains(self, values):
+        """Checks whether any of the given value(s) are in this expression,
+        which must resolve to an array.
 
         Examples::
 
@@ -2204,15 +2204,16 @@ class ViewExpression(object):
             print(view.count())
 
         Args:
-            value_or_values: a value or iterable of values
+            values: a value or iterable of values, which may be
+                :class:`ViewExpression` instances
 
         Returns:
             a :class:`ViewExpression`
         """
-        if etau.is_container(value_or_values):
-            values = list(value_or_values)
+        if isinstance(values, ViewExpression) or not etau.is_container(values):
+            values = [values]
         else:
-            values = [value_or_values]
+            values = list(values)
 
         expr = ViewExpression.any(
             [ViewExpression({"$in": [value, self]}) for value in values]
@@ -3528,10 +3529,10 @@ class ViewExpression(object):
         Returns:
             a :class:`ViewExpression`
         """
-        if etau.is_container(exprs):
-            exprs = list(exprs)
-        else:
+        if isinstance(exprs, ViewExpression) or not etau.is_container(exprs):
             exprs = [exprs]
+        else:
+            exprs = list(exprs)
 
         num_exprs = len(exprs)
 
@@ -3576,10 +3577,10 @@ class ViewExpression(object):
         Returns:
             a :class:`ViewExpression`
         """
-        if etau.is_container(exprs):
-            exprs = list(exprs)
-        else:
+        if isinstance(exprs, ViewExpression) or not etau.is_container(exprs):
             exprs = [exprs]
+        else:
+            exprs = list(exprs)
 
         num_exprs = len(exprs)
 

--- a/fiftyone/core/frame.py
+++ b/fiftyone/core/frame.py
@@ -265,6 +265,7 @@ class Frames(object):
         frames,
         omit_fields=None,
         omit_none_fields=True,
+        merge_lists=False,
         overwrite=True,
         expand_schema=True,
     ):
@@ -283,6 +284,9 @@ class Frames(object):
             omit_fields (None): an optional list of fields to omit
             omit_none_fields (True): whether to omit ``None``-valued fields of
                 the provided frames
+            merge_lists (False): whether to merge top-level list fields and the
+                elements of label list fields. If ``True``, this parameter
+                supercedes the ``overwrite`` parameter for list fields
             overwrite (True): whether to overwrite existing fields
             expand_schema (True): whether to dynamically add new frame fields
                 encountered to the dataset schema. If False, an error is raised
@@ -297,6 +301,7 @@ class Frames(object):
                     frame,
                     omit_fields=omit_fields,
                     omit_none_fields=omit_none_fields,
+                    merge_lists=merge_lists,
                     overwrite=overwrite,
                     expand_schema=expand_schema,
                 )

--- a/fiftyone/core/frame.py
+++ b/fiftyone/core/frame.py
@@ -293,6 +293,7 @@ class Frames(object):
             as a whole rather than merging their elements
         -   Whether to merge (a) only specific fields or (b) all but certain
             fields
+        -   Mapping input frame fields to different field names of this frame
 
         Args:
             frames: can be any of the following
@@ -305,7 +306,8 @@ class Frames(object):
                     instances
 
             fields (None): an optional field or iterable of fields to which to
-                restrict the merge
+                restrict the merge. This can also be a dict mapping field names
+                of the input frame to field names of this frame
             omit_fields (None): an optional field or iterable of fields to
                 exclude from the merge
             merge_lists (True): whether to merge the elements of list fields

--- a/fiftyone/core/frame.py
+++ b/fiftyone/core/frame.py
@@ -8,8 +8,6 @@ Video frames.
 from pymongo import ReplaceOne, UpdateOne, DeleteOne
 from pymongo.errors import BulkWriteError
 
-import eta.core.utils as etau
-
 from fiftyone.core.document import Document, DocumentView
 import fiftyone.core.frame_utils as fofu
 import fiftyone.core.odm as foo

--- a/fiftyone/core/frame.py
+++ b/fiftyone/core/frame.py
@@ -266,12 +266,33 @@ class Frames(object):
         frames,
         fields=None,
         omit_fields=None,
-        omit_none_fields=True,
         merge_lists=True,
         overwrite=True,
         expand_schema=True,
     ):
         """Merges the given frames into this instance.
+
+        The behavior of this method is highly customizable. By default, all
+        top-level fields from the provided frames are merged into existing
+        frames with the same frame numbers (and new frames created as
+        necessary), overwriting any existing values for those fields, with the
+        exception of list fields (e.g., ``tags``) and label list fields (e.g.,
+        :class:`fiftyone.core.labels.Detections` fields), in which case the
+        elements of the lists themselves are merged. In the case of label list
+        fields, labels with the same ``id`` in both frames are updated rather
+        than duplicated.
+
+        To avoid confusion between missing fields and fields whose value is
+        ``None``, ``None``-valued fields are always treated as missing while
+        merging.
+
+        This method can be configured in numerous ways, including:
+
+        -   Whether new fields can be added to the frame schema
+        -   Whether list fields should be treated as ordinary fields and merged
+            as a whole rather than merging their elements
+        -   Whether to merge (a) only specific fields or (b) all but certain
+            fields
 
         Args:
             frames: can be any of the following
@@ -287,8 +308,6 @@ class Frames(object):
                 restrict the merge
             omit_fields (None): an optional field or iterable of fields to
                 exclude from the merge
-            omit_none_fields (True): whether to omit ``None``-valued fields of
-                the provided frames
             merge_lists (True): whether to merge the elements of list fields
                 (e.g., ``tags``) and label list fields (e.g.,
                 :class:`fiftyone.core.labels.Detections` fields) rather than
@@ -299,8 +318,7 @@ class Frames(object):
                 False) when their ``id`` matches a label from the provided
                 frames
             overwrite (True): whether to overwrite (True) or skip (False)
-                existing fields. Note that fields whose values are ``None`` or
-                missing are always overwritten
+                existing fields and label elements
             expand_schema (True): whether to dynamically add new frame fields
                 encountered to the dataset schema. If False, an error is raised
                 if the frame's schema is not a subset of the dataset schema
@@ -314,7 +332,6 @@ class Frames(object):
                     frame,
                     fields=fields,
                     omit_fields=omit_fields,
-                    omit_none_fields=omit_none_fields,
                     merge_lists=merge_lists,
                     overwrite=overwrite,
                     expand_schema=expand_schema,

--- a/fiftyone/core/frame.py
+++ b/fiftyone/core/frame.py
@@ -267,7 +267,7 @@ class Frames(object):
         fields=None,
         omit_fields=None,
         omit_none_fields=True,
-        merge_lists=False,
+        merge_lists=True,
         overwrite=True,
         expand_schema=True,
     ):
@@ -289,15 +289,18 @@ class Frames(object):
                 exclude from the merge
             omit_none_fields (True): whether to omit ``None``-valued fields of
                 the provided frames
-            merge_lists (False): whether to merge top-level list fields and the
-                elements of label list fields. If ``True``, this parameter
-                supercedes the ``overwrite`` parameter for list fields, and,
-                for label lists fields, existing
+            merge_lists (True): whether to merge the elements of list fields
+                (e.g., ``tags``) and label list fields (e.g.,
+                :class:`fiftyone.core.labels.Detections` fields) rather than
+                merging the entire top-level field like other field types.
+                For label lists fields, existing
                 :class:`fiftyone.core.label.Label` elements are either replaced
                 (when ``overwrite`` is True) or kept (when ``overwrite`` is
-                False) when their ``id`` matches a
-                :class:`fiftyone.core.label.Label` from the provided document
-            overwrite (True): whether to overwrite existing fields
+                False) when their ``id`` matches a label from the provided
+                frames
+            overwrite (True): whether to overwrite (True) or skip (False)
+                existing fields. Note that fields whose values are ``None`` or
+                missing are always overwritten
             expand_schema (True): whether to dynamically add new frame fields
                 encountered to the dataset schema. If False, an error is raised
                 if the frame's schema is not a subset of the dataset schema

--- a/fiftyone/core/sample.py
+++ b/fiftyone/core/sample.py
@@ -216,12 +216,32 @@ class _SampleMixin(object):
         sample,
         fields=None,
         omit_fields=None,
-        omit_none_fields=True,
         merge_lists=True,
         overwrite=True,
         expand_schema=True,
     ):
-        """Merges the fields of the sample into this sample.
+        """Merges the fields of the given sample into this sample.
+
+        The behavior of this method is highly customizable. By default, all
+        top-level fields from the provided sample are merged in, overwriting
+        any existing values for those fields, with the exception of list fields
+        (e.g., ``tags``) and label list fields (e.g.,
+        :class:`fiftyone.core.labels.Detections` fields), in which case the
+        elements of the lists themselves are merged. In the case of label list
+        fields, labels with the same ``id`` in both samples are updated rather
+        than duplicated.
+
+        To avoid confusion between missing fields and fields whose value is
+        ``None``, ``None``-valued fields are always treated as missing while
+        merging.
+
+        This method can be configured in numerous ways, including:
+
+        -   Whether new fields can be added to the dataset schema
+        -   Whether list fields should be treated as ordinary fields and merged
+            as a whole rather than merging their elements
+        -   Whether to merge (a) only specific fields or (b) all but certain
+            fields
 
         Args:
             sample: a :class:`fiftyone.core.sample.Sample`
@@ -230,8 +250,6 @@ class _SampleMixin(object):
             omit_fields (None): an optional field or iterable of fields to
                 exclude from the merge. May contain frame fields for video
                 samples
-            omit_none_fields (True): whether to omit ``None``-valued fields of
-                the provided sample
             merge_lists (True): whether to merge the elements of list fields
                 (e.g., ``tags``) and label list fields (e.g.,
                 :class:`fiftyone.core.labels.Detections` fields) rather than
@@ -242,8 +260,7 @@ class _SampleMixin(object):
                 False) when their ``id`` matches a label from the provided
                 sample
             overwrite (True): whether to overwrite (True) or skip (False)
-                existing fields. Note that fields whose values are ``None`` or
-                missing are always overwritten
+                existing fields and label elements
             expand_schema (True): whether to dynamically add new fields
                 encountered to the dataset schema. If False, an error is raised
                 if any fields are not in the dataset schema
@@ -268,7 +285,6 @@ class _SampleMixin(object):
             sample,
             fields=fields,
             omit_fields=omit_fields,
-            omit_none_fields=omit_none_fields,
             merge_lists=merge_lists,
             overwrite=overwrite,
             expand_schema=expand_schema,
@@ -279,7 +295,6 @@ class _SampleMixin(object):
                 sample.frames,
                 fields=frame_fields,
                 omit_fields=omit_frame_fields,
-                omit_none_fields=omit_none_fields,
                 merge_lists=merge_lists,
                 overwrite=overwrite,
                 expand_schema=expand_schema,

--- a/fiftyone/core/sample.py
+++ b/fiftyone/core/sample.py
@@ -217,7 +217,7 @@ class _SampleMixin(object):
         fields=None,
         omit_fields=None,
         omit_none_fields=True,
-        merge_lists=False,
+        merge_lists=True,
         overwrite=True,
         expand_schema=True,
     ):
@@ -232,17 +232,18 @@ class _SampleMixin(object):
                 samples
             omit_none_fields (True): whether to omit ``None``-valued fields of
                 the provided sample
-            merge_lists (False): whether to merge top-level list fields and the
-                elements of label list fields. If ``True``, this parameter
-                supercedes the ``overwrite`` parameter for list fields, and,
-                for label lists fields, existing
+            merge_lists (True): whether to merge the elements of list fields
+                (e.g., ``tags``) and label list fields (e.g.,
+                :class:`fiftyone.core.labels.Detections` fields) rather than
+                merging the entire top-level field like other field types.
+                For label lists fields, existing
                 :class:`fiftyone.core.label.Label` elements are either replaced
                 (when ``overwrite`` is True) or kept (when ``overwrite`` is
-                False) when their ``id`` matches a
-                :class:`fiftyone.core.label.Label` from the provided document
-            overwrite (True): whether to overwrite existing fields. Note that
-                existing fields whose values are ``None`` are always
-                overwritten
+                False) when their ``id`` matches a label from the provided
+                sample
+            overwrite (True): whether to overwrite (True) or skip (False)
+                existing fields. Note that fields whose values are ``None`` or
+                missing are always overwritten
             expand_schema (True): whether to dynamically add new fields
                 encountered to the dataset schema. If False, an error is raised
                 if any fields are not in the dataset schema

--- a/fiftyone/core/sample.py
+++ b/fiftyone/core/sample.py
@@ -216,6 +216,7 @@ class _SampleMixin(object):
         omit_fields=None,
         omit_frame_fields=None,
         omit_none_fields=True,
+        merge_lists=False,
         overwrite=True,
         expand_schema=True,
     ):
@@ -227,6 +228,9 @@ class _SampleMixin(object):
             omit_frame_fields (None): an optional lits of frame fields to omit
             omit_none_fields (True): whether to omit ``None``-valued fields of
                 the provided sample
+            merge_lists (False): whether to merge top-level list fields and the
+                elements of label list fields. If ``True``, this parameter
+                supercedes the ``overwrite`` parameter for list fields
             overwrite (True): whether to overwrite existing fields. Note that
                 existing fields whose values are ``None`` are always
                 overwritten
@@ -244,6 +248,7 @@ class _SampleMixin(object):
             sample,
             omit_fields=omit_fields,
             omit_none_fields=omit_none_fields,
+            merge_lists=merge_lists,
             overwrite=overwrite,
             expand_schema=expand_schema,
         )
@@ -253,6 +258,7 @@ class _SampleMixin(object):
                 sample.frames,
                 omit_fields=omit_frame_fields,
                 omit_none_fields=omit_none_fields,
+                merge_lists=merge_lists,
                 overwrite=overwrite,
                 expand_schema=expand_schema,
             )

--- a/fiftyone/core/sample.py
+++ b/fiftyone/core/sample.py
@@ -7,8 +7,6 @@ Dataset samples.
 """
 import os
 
-import eta.core.utils as etau
-
 from fiftyone.core.document import Document, DocumentView
 import fiftyone.core.frame as fofr
 import fiftyone.core.frame_utils as fofu

--- a/fiftyone/core/sample.py
+++ b/fiftyone/core/sample.py
@@ -242,11 +242,14 @@ class _SampleMixin(object):
             as a whole rather than merging their elements
         -   Whether to merge (a) only specific fields or (b) all but certain
             fields
+        -   Mapping input sample fields to different field names of this sample
 
         Args:
             sample: a :class:`fiftyone.core.sample.Sample`
             fields (None): an optional field or iterable of fields to which to
-                restrict the merge. May contain frame fields for video samples
+                restrict the merge. May contain frame fields for video samples.
+                This can also be a dict mapping field names of the input sample
+                to field names of this sample
             omit_fields (None): an optional field or iterable of fields to
                 exclude from the merge. May contain frame fields for video
                 samples
@@ -409,7 +412,8 @@ class Sample(_SampleMixin, Document, metaclass=SampleSingleton):
 
         Args:
             fields (None): an optional field or iterable of fields to which to
-                restrict the copy
+                restrict the copy. This can also be a dict mapping existing
+                field names to new field names
             omit_fields (None): an optional field or iterable of fields to
                 exclude from the copy
 

--- a/fiftyone/core/utils.py
+++ b/fiftyone/core/utils.py
@@ -74,6 +74,38 @@ def pformat(obj, indent=4, width=80, depth=None):
     return _pprint.pformat(obj, indent=indent, width=width, depth=depth)
 
 
+def split_frame_fields(fields):
+    """Splits the given fields into sample and frame fields.
+
+    Frame fields are those prefixed by ``"frames."``, and this prefix is
+    removed from the returned frame fields.
+
+    Args:
+        fields: a field or iterable of fields
+
+    Returns:
+        a tuple of:
+
+        -   a list of sample fields
+        -   a list of frame fields
+    """
+    if etau.is_str(fields):
+        fields = [fields]
+
+    frames_prefix = "frames."
+    n = len(frames_prefix)
+
+    sample_fields = []
+    frame_fields = []
+    for field in fields:
+        if field.startswith(frames_prefix):
+            frame_fields.append(field[n:])
+        else:
+            sample_fields.append(field)
+
+    return sample_fields, frame_fields
+
+
 def stream_objects(objects):
     """Streams the iterable of objects to stdout via ``less``.
 

--- a/fiftyone/core/utils.py
+++ b/fiftyone/core/utils.py
@@ -18,6 +18,7 @@ import logging
 import os
 import signal
 import subprocess
+import timeit
 import types
 import zlib
 
@@ -565,6 +566,114 @@ class ProgressBar(etau.ProgressBar):
             kwargs["max_width"] = 90
 
         super().__init__(*args, **kwargs)
+
+
+class DynamicBatcher(object):
+    """Class for iterating over the elements of an iterable with a dynamic
+    batch size to achieve a desired latency.
+
+    The batch sizes emitted when iterating over this object are dynamically
+    scaled such that the latency between ``next()`` calls is as close as
+    possible to a specified target latency.
+
+    This class is often used in conjunction with a :class:`ProgressBar` to keep
+    the user appraised on the status of a long-running task.
+
+    Example usage::
+
+        import fiftyone.core.utils as fou
+
+        total = int(1e7)
+        elements = range(total)
+
+        batches = fou.DynamicBatcher(elements, 0.1, max_batch_beta=2.0)
+
+        with fou.ProgressBar(total) as pb:
+            for batch in batches:
+                batch_size = len(batch)
+                print("batch size: %d" % batch_size)
+                pb.update(count=batch_size)
+
+    Args:
+        iterable: an iterable
+        target_latency_seconds: the target latency between ``next()`` calls,
+            in seconds
+        init_batch_size (1): the initial batch size to use
+        min_batch_size (1): the minimum allowed batch size
+        max_batch_size (None): an optional maximum allowed batch size
+        max_batch_beta (None): an optional lower/upper bound on the ratio
+            between successive batch sizes
+    """
+
+    def __init__(
+        self,
+        iterable,
+        target_latency_seconds,
+        init_batch_size=1,
+        min_batch_size=1,
+        max_batch_size=None,
+        max_batch_beta=None,
+    ):
+        self.iterable = iterable
+        self.target_latency_seconds = target_latency_seconds
+        self.init_batch_size = init_batch_size
+        self.min_batch_size = min_batch_size
+        self.max_batch_size = max_batch_size
+        self.max_batch_beta = max_batch_beta
+
+        self._iter = None
+        self._last_time = None
+        self._last_batch_size = None
+
+    def __iter__(self):
+        self._iter = iter(self.iterable)
+        self._last_batch_size = None
+        return self
+
+    def __next__(self):
+        current_time = timeit.default_timer()
+
+        if self._last_batch_size is None:
+            batch_size = self.init_batch_size
+        else:
+            # Compute optimal batch size
+            try:
+                beta = self.target_latency_seconds / (
+                    current_time - self._last_time
+                )
+            except ZeroDivisionError:
+                beta = 1e6
+
+            if self.max_batch_beta is not None:
+                if beta >= 1:
+                    beta = min(beta, self.max_batch_beta)
+                else:
+                    beta = max(beta, 1 / self.max_batch_beta)
+
+            batch_size = int(round(beta * self._last_batch_size))
+
+            if self.min_batch_size is not None:
+                batch_size = max(batch_size, self.min_batch_size)
+
+            if self.max_batch_size is not None:
+                batch_size = min(batch_size, self.max_batch_size)
+
+        self._last_batch_size = batch_size
+        self._last_time = current_time
+
+        batch = []
+
+        try:
+            idx = 0
+            while idx < batch_size:
+                batch.append(next(self._iter))
+                idx += 1
+
+        except StopIteration:
+            if not batch:
+                raise StopIteration
+
+        return batch
 
 
 @contextmanager

--- a/fiftyone/core/utils.py
+++ b/fiftyone/core/utils.py
@@ -109,14 +109,18 @@ def split_frame_fields(fields):
     removed from the returned frame fields.
 
     Args:
-        fields: a field or iterable of fields
+        fields: a field, iterable of fields, or dict mapping field names to new
+            field names
 
     Returns:
         a tuple of:
 
-        -   a list of sample fields
-        -   a list of frame fields
+        -   a list or dict of sample fields
+        -   a list or dict of frame fields
     """
+    if isinstance(fields, dict):
+        return _split_frame_fields_dict(fields)
+
     if etau.is_str(fields):
         fields = [fields]
 
@@ -130,6 +134,21 @@ def split_frame_fields(fields):
             frame_fields.append(field[n:])
         else:
             sample_fields.append(field)
+
+    return sample_fields, frame_fields
+
+
+def _split_frame_fields_dict(fields):
+    frames_prefix = "frames."
+    n = len(frames_prefix)
+
+    sample_fields = {}
+    frame_fields = {}
+    for src_field, dst_field in fields.items():
+        if src_field.startswith(frames_prefix):
+            frame_fields[src_field[n:]] = dst_field[n:]
+        else:
+            sample_fields[src_field] = dst_field
 
     return sample_fields, frame_fields
 

--- a/tests/intensive/merge_tests.py
+++ b/tests/intensive/merge_tests.py
@@ -90,7 +90,7 @@ def test_merge_samples_and_labels_image():
     ).save()
 
     d1 = dataset1.clone()
-    d1.merge_samples(dataset2, merge_lists=True, overwrite=True)
+    d1.merge_samples(dataset2)
 
     num_objects1 = d1.count("ground_truth.detections")
     num_objects1_ref = dataset.count("ground_truth.detections")
@@ -103,7 +103,7 @@ def test_merge_samples_and_labels_image():
     assert counts1["AIRPLANE"] == counts1_ref2["AIRPLANE"]
 
     d2 = dataset1.clone()
-    d2.merge_samples(dataset2, merge_lists=True, overwrite=False)
+    d2.merge_samples(dataset2, overwrite=False)
 
     num_objects2 = d2.count("ground_truth.detections")
     num_objects2_ref = dataset.count("ground_truth.detections")
@@ -189,7 +189,7 @@ def test_merge_samples_and_labels_video():
     ).save()
 
     d1 = dataset1.clone()
-    d1.merge_samples(dataset2, merge_lists=True, overwrite=True)
+    d1.merge_samples(dataset2)
 
     num_objects1 = d1.count("frames.ground_truth.detections")
     num_objects1_ref = dataset.count("frames.ground_truth.detections")
@@ -206,7 +206,7 @@ def test_merge_samples_and_labels_video():
     assert counts1["VEHICLE"] == counts1_ref2["VEHICLE"]
 
     d2 = dataset1.clone()
-    d2.merge_samples(dataset2, merge_lists=True, overwrite=False)
+    d2.merge_samples(dataset2, overwrite=False)
 
     num_objects2 = d2.count("frames.ground_truth.detections")
     num_objects2_ref = dataset.count("frames.ground_truth.detections")

--- a/tests/unittests/dataset_tests.py
+++ b/tests/unittests/dataset_tests.py
@@ -610,6 +610,42 @@ class DatasetTests(unittest.TestCase):
                 [None, None, ["foo", "bar"], None, ["foo", "bar"], None],
             )
 
+        for key_fcn in (None, filepath_fcn):
+            d10 = dataset1.clone()
+            d10.merge_samples(
+                dataset2,
+                fields={"hello": "hello2", "predictions2": "predictions1"},
+                key_fcn=key_fcn,
+            )
+
+            d10_schema = d10.get_field_schema()
+            self.assertIn("hello", d10_schema)
+            self.assertIn("hello2", d10_schema)
+            self.assertIn("predictions1", d10_schema)
+            self.assertNotIn("predictions2", d10_schema)
+
+            self.assertListEqual(
+                d10.values("tags"), [[], ["hello"], ["world"], [], [], []],
+            )
+            self.assertListEqual(
+                d10.values("hello"),
+                [None, "world", "world", "world", None, None],
+            )
+            self.assertListEqual(
+                d10.values("hello2"), [None, None, "bar", None, "bar", None],
+            )
+            self.assertListEqual(
+                d10.values("predictions1.detections.label"),
+                [
+                    None,
+                    ["hello", "world"],
+                    ["hello", "world", "foo", "bar"],
+                    None,
+                    ["foo", "bar"],
+                    None,
+                ],
+            )
+
     @drop_datasets
     def test_rename_fields(self):
         dataset = fo.Dataset()

--- a/tests/unittests/sample_tests.py
+++ b/tests/unittests/sample_tests.py
@@ -9,10 +9,7 @@ import datetime
 import os
 import unittest
 
-from mongoengine.errors import (
-    FieldDoesNotExist,
-    ValidationError,
-)
+from mongoengine.errors import ValidationError
 import numpy as np
 
 import fiftyone as fo
@@ -226,7 +223,7 @@ class SampleInDatasetTests(unittest.TestCase):
 
         sample[field_name] = value
 
-        with self.assertRaises(FieldDoesNotExist):
+        with self.assertRaises(ValueError):
             dataset.add_sample(sample, expand_schema=False)
 
         # ensure sample was not inserted
@@ -248,7 +245,7 @@ class SampleInDatasetTests(unittest.TestCase):
 
         sample[field_name] = value
 
-        with self.assertRaises(FieldDoesNotExist):
+        with self.assertRaises(ValueError):
             dataset.add_samples([sample], expand_schema=False)
 
         dataset.add_samples([sample])

--- a/tests/unittests/sample_tests.py
+++ b/tests/unittests/sample_tests.py
@@ -517,23 +517,6 @@ class VideoSampleTests(unittest.TestCase):
         self.assertTrue(1 in s.frames)
         self.assertFalse(2 in s.frames)
 
-    def test_merge(self):
-        d = fo.Dataset()
-        s1 = fo.Sample(filepath="video.mp4")
-        s1[1]["one"] = "one"
-        s2 = fo.Sample(filepath="video.mp4")
-        s2[1]["two"] = "two"
-        other = fo.Sample(filepath="video_other.mp4")
-        d.add_sample(s1)
-        d.merge_samples([s2, other])
-        self.assertEqual(len(d), 2)
-        for s in d:
-            if s.filepath.endswith("video.mp4"):
-                self.assertEqual(s[1]["one"], "one")
-                self.assertEqual(s[1]["two"], "two")
-            else:
-                self.assertFalse(1 in s.frames)
-
     def test_copy(self):
         sample = fo.Sample("video.mp4")
         sample.frames[1]["label"] = "label"

--- a/tests/unittests/video_tests.py
+++ b/tests/unittests/video_tests.py
@@ -922,6 +922,46 @@ class VideoTests(unittest.TestCase):
                 [[], [None, None, ["foo", "bar"], None, ["foo", "bar"]], []],
             )
 
+        for key_fcn in (None, filepath_fcn):
+            d10 = dataset1.clone()
+            d10.merge_samples(
+                dataset2,
+                fields={
+                    "frames.hello": "frames.hello2",
+                    "frames.predictions2": "frames.predictions1",
+                },
+                key_fcn=key_fcn,
+            )
+
+            d10_frame_schema = d10.get_frame_field_schema()
+            self.assertIn("hello", d10_frame_schema)
+            self.assertIn("hello2", d10_frame_schema)
+            self.assertIn("predictions1", d10_frame_schema)
+            self.assertNotIn("predictions2", d10_frame_schema)
+
+            self.assertListEqual(
+                d10.values("frames.hello"),
+                [[], [None, "world", "world", "world", None], []],
+            )
+            self.assertListEqual(
+                d10.values("frames.hello2"),
+                [[], [None, None, "bar", None, "bar"], []],
+            )
+            self.assertListEqual(
+                d10.values("frames.predictions1.detections.label"),
+                [
+                    [],
+                    [
+                        None,
+                        ["hello", "world"],
+                        ["hello", "world", "foo", "bar"],
+                        None,
+                        ["foo", "bar"],
+                    ],
+                    [],
+                ],
+            )
+
 
 if __name__ == "__main__":
     fo.config.show_progress_bars = False

--- a/tests/unittests/video_tests.py
+++ b/tests/unittests/video_tests.py
@@ -561,6 +561,367 @@ class VideoTests(unittest.TestCase):
         self.assertEqual(frame4["field1"], "a")
         self.assertEqual(frame4["field2"], "b")
 
+    @drop_datasets
+    def test_merge_video_samples_and_labels(self):
+        sample11 = fo.Sample(filepath="video1.mp4")
+
+        sample12 = fo.Sample(filepath="video2.mp4")
+        sample12.frames[1] = fo.Frame()
+        sample12.frames[2] = fo.Frame(
+            ground_truth=fo.Detections(
+                detections=[
+                    fo.Detection(label="hello"),
+                    fo.Detection(label="world"),
+                ]
+            ),
+            predictions1=fo.Detections(
+                detections=[
+                    fo.Detection(label="hello", confidence=0.99),
+                    fo.Detection(label="world", confidence=0.99),
+                ]
+            ),
+            hello="world",
+        )
+        sample12.frames[3] = fo.Frame(
+            ground_truth=fo.Detections(
+                detections=[
+                    fo.Detection(label="hello"),
+                    fo.Detection(label="world"),
+                    fo.Detection(label="common"),
+                ]
+            ),
+            predictions1=fo.Detections(
+                detections=[
+                    fo.Detection(label="hello", confidence=0.99),
+                    fo.Detection(label="world", confidence=0.99),
+                ]
+            ),
+            hello="world",
+        )
+        sample12.frames[4] = fo.Frame(
+            ground_truth=fo.Detections(
+                detections=[
+                    fo.Detection(label="hi"),
+                    fo.Detection(label="there"),
+                ]
+            ),
+            hello="world",
+        )
+        sample12.frames[5] = fo.Frame(ground_truth=None, hello=None)
+
+        dataset1 = fo.Dataset()
+        dataset1.add_samples([sample11, sample12])
+
+        ref = sample12.frames[3].ground_truth.detections[2]
+        common = ref.copy()
+        common._id = ref._id
+        common.label = "COMMON"
+
+        sample22 = fo.Sample(filepath="video2.mp4")
+
+        sample22.frames[2] = fo.Frame()
+        sample22.frames[3] = fo.Frame(
+            ground_truth=fo.Detections(
+                detections=[
+                    common,
+                    fo.Detection(label="foo"),
+                    fo.Detection(label="bar"),
+                ]
+            ),
+            predictions2=fo.Detections(
+                detections=[
+                    fo.Detection(label="foo", confidence=0.99),
+                    fo.Detection(label="bar", confidence=0.99),
+                ]
+            ),
+            hello="bar",
+        )
+        sample22.frames[4] = fo.Frame(ground_truth=None, hello=None)
+        sample22.frames[5] = fo.Frame(
+            ground_truth=fo.Detections(
+                detections=[
+                    fo.Detection(label="foo"),
+                    fo.Detection(label="bar"),
+                ]
+            ),
+            predictions2=fo.Detections(
+                detections=[
+                    fo.Detection(label="foo", confidence=0.99),
+                    fo.Detection(label="bar", confidence=0.99),
+                ]
+            ),
+            hello="bar",
+        )
+        sample23 = fo.Sample(filepath="video3.mp4")
+
+        dataset2 = fo.Dataset()
+        dataset2.add_samples([sample22, sample23])
+
+        filepath_fcn = lambda sample: sample.filepath
+
+        for key_fcn in (None, filepath_fcn):
+            d1 = dataset1.clone()
+            d1.merge_samples(dataset2, skip_existing=True, key_fcn=key_fcn)
+
+            fields1 = set(dataset1.get_frame_field_schema().keys())
+            fields2 = set(d1.get_frame_field_schema().keys())
+            new_fields = fields2 - fields1
+
+            self.assertEqual(len(d1), 3)
+            for s1, s2 in zip(dataset1, d1):
+                for f1, f2 in zip(s1.frames.values(), s2.frames.values()):
+                    for field in fields1:
+                        self.assertEqual(f1[field], f2[field])
+
+                    for field in new_fields:
+                        self.assertIsNone(f2[field])
+
+        for key_fcn in (None, filepath_fcn):
+            d2 = dataset1.clone()
+            d2.merge_samples(dataset2, insert_new=False, key_fcn=key_fcn)
+
+            self.assertEqual(len(d2), len(dataset1))
+
+        for key_fcn in (None, filepath_fcn):
+            with self.assertRaises(ValueError):
+                d3 = dataset1.clone()
+                d3.merge_samples(
+                    dataset2, expand_schema=False, key_fcn=key_fcn
+                )
+
+        for key_fcn in (None, filepath_fcn):
+            d3 = dataset1.clone()
+            d3.merge_samples(
+                dataset2, merge_lists=False, overwrite=True, key_fcn=key_fcn
+            )
+
+            self.assertListEqual(
+                d3.values("frames.hello"),
+                [[], [None, "world", "bar", "world", "bar"], []],
+            )
+            self.assertListEqual(
+                d3.values("frames.ground_truth.detections.label"),
+                [
+                    [],
+                    [
+                        None,
+                        ["hello", "world"],
+                        ["COMMON", "foo", "bar"],
+                        ["hi", "there"],
+                        ["foo", "bar"],
+                    ],
+                    [],
+                ],
+            )
+            self.assertListEqual(
+                d3.values("frames.predictions1.detections.label"),
+                [
+                    [],
+                    [None, ["hello", "world"], ["hello", "world"], None, None],
+                    [],
+                ],
+            )
+            self.assertListEqual(
+                d3.values("frames.predictions2.detections.label"),
+                [[], [None, None, ["foo", "bar"], None, ["foo", "bar"]], []],
+            )
+
+        for key_fcn in (None, filepath_fcn):
+            d4 = dataset1.clone()
+            d4.merge_samples(
+                dataset2, merge_lists=False, overwrite=False, key_fcn=key_fcn
+            )
+
+            self.assertListEqual(
+                d4.values("frames.hello"),
+                [[], [None, "world", "world", "world", "bar"], []],
+            )
+            self.assertListEqual(
+                d4.values("frames.ground_truth.detections.label"),
+                [
+                    [],
+                    [
+                        None,
+                        ["hello", "world"],
+                        ["hello", "world", "common"],
+                        ["hi", "there"],
+                        ["foo", "bar"],
+                    ],
+                    [],
+                ],
+            )
+            self.assertListEqual(
+                d4.values("frames.predictions1.detections.label"),
+                [
+                    [],
+                    [None, ["hello", "world"], ["hello", "world"], None, None],
+                    [],
+                ],
+            )
+            self.assertListEqual(
+                d4.values("frames.predictions2.detections.label"),
+                [[], [None, None, ["foo", "bar"], None, ["foo", "bar"]], []],
+            )
+
+        for key_fcn in (None, filepath_fcn):
+            d5 = dataset1.clone()
+            d5.merge_samples(dataset2, fields="frames.hello", key_fcn=key_fcn)
+
+            # ensures documents are valid
+            for sample in d5:
+                self.assertIsNotNone(sample.id)
+                for frame in sample.frames.values():
+                    self.assertIsNotNone(frame.id)
+
+            self.assertNotIn("predictions2", d5.get_frame_field_schema())
+            self.assertListEqual(
+                d5.values("frames.hello"),
+                [[], [None, "world", "bar", "world", "bar"], []],
+            )
+            self.assertListEqual(
+                d5.values("frames.ground_truth.detections.label"),
+                [
+                    [],
+                    [
+                        None,
+                        ["hello", "world"],
+                        ["hello", "world", "common"],
+                        ["hi", "there"],
+                        None,
+                    ],
+                    [],
+                ],
+            )
+
+        for key_fcn in (None, filepath_fcn):
+            d6 = dataset1.clone()
+            d6.merge_samples(
+                dataset2,
+                omit_fields=["frames.ground_truth", "frames.predictions2"],
+                key_fcn=key_fcn,
+            )
+
+            # ensures documents are valid
+            for sample in d6:
+                self.assertIsNotNone(sample.id)
+                for frame in sample.frames.values():
+                    self.assertIsNotNone(frame.id)
+
+            self.assertNotIn("predictions2", d6.get_frame_field_schema())
+            self.assertListEqual(
+                d6.values("frames.hello"),
+                [[], [None, "world", "bar", "world", "bar"], []],
+            )
+            self.assertListEqual(
+                d6.values("frames.ground_truth.detections.label"),
+                [
+                    [],
+                    [
+                        None,
+                        ["hello", "world"],
+                        ["hello", "world", "common"],
+                        ["hi", "there"],
+                        None,
+                    ],
+                    [],
+                ],
+            )
+
+        for key_fcn in (None, filepath_fcn):
+            d7 = dataset1.clone()
+            d7.merge_samples(
+                dataset2, merge_lists=False, overwrite=True, key_fcn=key_fcn
+            )
+
+            self.assertListEqual(
+                d7.values("frames.hello"),
+                [[], [None, "world", "bar", "world", "bar"], []],
+            )
+            self.assertListEqual(
+                d7.values("frames.ground_truth.detections.label"),
+                [
+                    [],
+                    [
+                        None,
+                        ["hello", "world"],
+                        ["COMMON", "foo", "bar"],
+                        ["hi", "there"],
+                        ["foo", "bar"],
+                    ],
+                    [],
+                ],
+            )
+
+        for key_fcn in (None, filepath_fcn):
+            d8 = dataset1.clone()
+            d8.merge_samples(dataset2, key_fcn=key_fcn)
+
+            self.assertListEqual(
+                d8.values("frames.hello"),
+                [[], [None, "world", "bar", "world", "bar"], []],
+            )
+            self.assertListEqual(
+                d8.values("frames.ground_truth.detections.label"),
+                [
+                    [],
+                    [
+                        None,
+                        ["hello", "world"],
+                        ["hello", "world", "COMMON", "foo", "bar"],
+                        ["hi", "there"],
+                        ["foo", "bar"],
+                    ],
+                    [],
+                ],
+            )
+            self.assertListEqual(
+                d8.values("frames.predictions1.detections.label"),
+                [
+                    [],
+                    [None, ["hello", "world"], ["hello", "world"], None, None],
+                    [],
+                ],
+            )
+            self.assertListEqual(
+                d8.values("frames.predictions2.detections.label"),
+                [[], [None, None, ["foo", "bar"], None, ["foo", "bar"]], []],
+            )
+
+        for key_fcn in (None, filepath_fcn):
+            d9 = dataset1.clone()
+            d9.merge_samples(dataset2, overwrite=False, key_fcn=key_fcn)
+
+            self.assertListEqual(
+                d9.values("frames.hello"),
+                [[], [None, "world", "world", "world", "bar"], []],
+            )
+            self.assertListEqual(
+                d9.values("frames.ground_truth.detections.label"),
+                [
+                    [],
+                    [
+                        None,
+                        ["hello", "world"],
+                        ["hello", "world", "common", "foo", "bar"],
+                        ["hi", "there"],
+                        ["foo", "bar"],
+                    ],
+                    [],
+                ],
+            )
+            self.assertListEqual(
+                d9.values("frames.predictions1.detections.label"),
+                [
+                    [],
+                    [None, ["hello", "world"], ["hello", "world"], None, None],
+                    [],
+                ],
+            )
+            self.assertListEqual(
+                d9.values("frames.predictions2.detections.label"),
+                [[], [None, None, ["foo", "bar"], None, ["foo", "bar"]], []],
+            )
+
 
 if __name__ == "__main__":
     fo.config.show_progress_bars = False


### PR DESCRIPTION
### Merging improvements

Adds a number of useful options to `Dataset.merge_samples()` and `Document.merge()`, including:

- `fields (None)`: an optional field or iterable of fields to which to restrict the merge. If provided, fields other than these are omitted from `samples` when merging or adding samples. Can also be dict mapping source field names to destination field names
- `omit_fields (None)`: an optional field or iterable of fields to exclude from the merge. If provided, these fields are omitted from `samples`, if present, when merging or adding samples
- `merge_lists (True)`: whether to merge the elements of list fields (e.g., `tags`) and label list fields (e.g., `Detections` fields) rather than  merging the entire top-level field like other field types. For label lists fields, existing `Label` elements are either replaced (when `overwrite` is True) or kept (when `overwrite` is False) when their `id` matches a label from the provided samples

The default value of `merge_lists` is True, which means that the default behavior of `merge_samples()` has changed slightly, as list fields will now have their elements merged, rather than either overwriting or skipping the entire field.

A few other improvements were added to `Dataset.merge_samples()`, including:
- The `Dataset.merge_samples(overwrite=False)` syntax will now be implemented via efficient aggregation pipelines rather than loading the samples in-memory. The only case where in-memory samples is used is when a `key_fcn` is provided
- Fixes a bug where non-unique indexes would be permanently upgraded to unique indexes when merging (the user may later want to add duplicate `filepath` samples, for example, which should always be allowed, except when merging on `filepath`)

Extensive unit tests are added to ensure that all the various options work as expected.

### Other enhancements

- Added optional `Document.copy(fields=None, omit_fields=None)` parameters to only include a subset of a document's fields when copying it
- Fixed a bug that prevented `ViewExpression.contains(value)` from working when `value` is a `ViewExpression` rather than a primitive value

### Performance improvements

Also, in **PERFORMANCE NEWS**, importing datasets may now be up to 2x faster or more!

```py
import fiftyone as fo
import fiftyone.zoo as foz

# Now 2x faster on my machine
dataset = foz.load_zoo_dataset("cifar10", split="test")
```

The issue was that `Dataset.add_samples()` used to choose a batch size of 128 for image datasets and 1 for video datasets, **BUT** for empty datasets with no `media_type`, it conservatively had to choose a batch size of 1 in case the samples happened to be videos, which would happen when importing *any* dataset using `load_zoo_dataset()` as well as `Dataset.from_*()` factory methods. 🤦 🤦 🤦 

So, I finally got around to implementing a dynamic batching strategy in `Dataset.add_samples()` whereby samples will be inserted into the database in dynamically-sized batches such that the time between insertions is ~0.2 seconds. This value was chosen so that the progress bar always updates at a reasonable frame rate.

Note that `Dataset.add_samples(samples)` accepts not just an in-memory list of samples, but also things like generators, which could, for example, involve parsing some binary data, reading from disk, downloading a file from the web, etc. In any case, the point is that the progress bar tracks more than just DB insertion time, it may also magically track sample preparation times if the user provides a generator. I think that's pretty nifty. 

### Example usage

A primary motivating use case for this feature is exporting annotations to an annotation vendor, where annotations could be edited and then loaded back into a dataset. The following snippet demonstrates how such a workflow is now possible:

```py
import fiftyone as fo
import fiftyone.zoo as foz
from fiftyone import ViewField as F

dataset = foz.load_zoo_dataset("quickstart")
print(dataset.count("predictions.detections"))

# Export low confidence predictions for correction
low_conf_preds = dataset.filter_labels("predictions", F("confidence") < 0.5)
low_conf_preds.export("/tmp/cvat/export", fo.types.CVATImageDataset, label_field="predictions")

# Add, delete, or modify annotations in CVAT

# Load edits
edits = fo.Dataset.from_dir("/tmp/cvat/export", fo.types.CVATImageDataset, label_field="")

# Merge edits into dataset
dataset.filter_labels("predictions", F("confidence") >= 0.5).save()  # deletes edited predictions
dataset.merge_samples(edits, fields={"detections": "predictions"})  # add replacements
print(dataset.count("predictions.detections"))
```
