### PR TITLE
Adding a match_labels() stage

### DIFF
--- a/fiftyone/__public__.py
+++ b/fiftyone/__public__.py
@@ -138,6 +138,7 @@ from .core.stages import (
     GeoWithin,
     MapLabels,
     Match,
+    MatchLabels,
     MatchTags,
     Mongo,
     Shuffle,

--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -1984,6 +1984,9 @@ class SampleCollection(object):
 
         -   Provide the ``tags`` argument to exclude labels with specific tags
 
+        If multiple criteria are specified, labels must match all of them in
+        order to be excluded.
+
         By default, the exclusion is applied to all
         :class:`fiftyone.core.labels.Label` fields, but you can provide the
         ``fields`` argument to explicitly define the field(s) in which to
@@ -3205,6 +3208,9 @@ class SampleCollection(object):
             :class:`fiftyone.core.expressions.ViewExpression` that is applied
             to each individual :class:`fiftyone.core.labels.Label` element
 
+        If multiple criteria are specified, labels must match all of them in
+        order to trigger a sample match.
+
         By default, the selection is applied to all
         :class:`fiftyone.core.labels.Label` fields, but you can provide the
         ``fields`` argument to explicitly define the field(s) in which to
@@ -3569,6 +3575,9 @@ class SampleCollection(object):
         -   Provide the ``ids`` argument to select labels with specific IDs
 
         -   Provide the ``tags`` argument to select labels with specific tags
+
+        If multiple criteria are specified, labels must match all of them in
+        order to be selected.
 
         By default, the selection is applied to all
         :class:`fiftyone.core.labels.Label` fields, but you can provide the

--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -1966,7 +1966,13 @@ class SampleCollection(object):
 
     @view_stage
     def exclude_labels(
-        self, labels=None, ids=None, tags=None, fields=None, omit_empty=True
+        self,
+        labels=None,
+        ids=None,
+        tags=None,
+        fields=None,
+        omit_empty=True,
+        only_samples=False,
     ):
         """Excludes the specified labels from the collection.
 
@@ -2052,6 +2058,9 @@ class SampleCollection(object):
             fields (None): a field or iterable of fields from which to exclude
             omit_empty (True): whether to omit samples that have no labels
                 after filtering
+            only_samples (False): whether to omit samples that contain at least
+                one matching label rather than filtering only the excluded
+                labels from them
 
         Returns:
             a :class:`fiftyone.core.view.DatasetView`
@@ -2063,6 +2072,7 @@ class SampleCollection(object):
                 tags=tags,
                 fields=fields,
                 omit_empty=omit_empty,
+                only_samples=only_samples,
             )
         )
 
@@ -3411,7 +3421,13 @@ class SampleCollection(object):
 
     @view_stage
     def select_labels(
-        self, labels=None, ids=None, tags=None, fields=None, omit_empty=True
+        self,
+        labels=None,
+        ids=None,
+        tags=None,
+        fields=None,
+        omit_empty=True,
+        only_samples=False,
     ):
         """Selects only the specified labels from the collection.
 
@@ -3490,6 +3506,9 @@ class SampleCollection(object):
             fields (None): a field or iterable of fields from which to select
             omit_empty (True): whether to omit samples that have no labels
                 after filtering
+            only_samples (False): whether to select samples that contain at
+                least one matching label without filtering the non-matching
+                labels in those samples
 
         Returns:
             a :class:`fiftyone.core.view.DatasetView`
@@ -3501,6 +3520,7 @@ class SampleCollection(object):
                 tags=tags,
                 fields=fields,
                 omit_empty=omit_empty,
+                only_samples=only_samples,
             )
         )
 

--- a/fiftyone/core/expressions.py
+++ b/fiftyone/core/expressions.py
@@ -3538,11 +3538,10 @@ class ViewExpression(object):
         if num_exprs == 0:
             return ViewExpression(False)
 
-        any_expr = exprs[0]
-        for expr in exprs[1:]:
-            any_expr |= expr
+        if num_exprs == 1:
+            return exprs[0]
 
-        return any_expr
+        return ViewExpression({"$or": exprs})
 
     @staticmethod
     def all(exprs):
@@ -3586,11 +3585,10 @@ class ViewExpression(object):
         if num_exprs == 0:
             return ViewExpression(True)
 
-        any_expr = exprs[0]
-        for expr in exprs[1:]:
-            any_expr &= expr
+        if num_exprs == 1:
+            return exprs[0]
 
-        return any_expr
+        return ViewExpression({"$and": exprs})
 
     @staticmethod
     def range(start, stop=None):

--- a/fiftyone/core/stages.py
+++ b/fiftyone/core/stages.py
@@ -3199,7 +3199,7 @@ class MatchTags(ViewStage):
 
     def to_mongo(self, _):
         if self._bool:
-            [{"$match": {"tags": {"$in": self._tags}}}]
+            return [{"$match": {"tags": {"$in": self._tags}}}]
 
         return [{"$match": {"tags": {"$nin": self._tags}}}]
 

--- a/fiftyone/core/stages.py
+++ b/fiftyone/core/stages.py
@@ -3019,7 +3019,7 @@ class MatchLabels(ViewStage):
         for field in fields:
             if sample_collection._is_frame_field(field):
                 frames, leaf = field.split(".", 1)
-                new_field = frames + "__" + leaf
+                new_field = frames + ".__" + leaf
             else:
                 new_field = "__" + field
 
@@ -4734,11 +4734,12 @@ def _get_label_field_only_matches_expr(
     sample_collection, field, prefix="", new_field=None
 ):
     label_type = sample_collection._get_label_field_type(field)
-    field, is_frame_field = sample_collection._handle_frame_field(field)
     is_label_list_field = issubclass(label_type, fol._LABEL_LIST_FIELDS)
 
     if new_field is not None:
         field = new_field
+
+    field, is_frame_field = sample_collection._handle_frame_field(field)
 
     if is_label_list_field:
         field += "." + label_type._LABEL_LIST_FIELD


### PR DESCRIPTION
### Label matching

Adds a new `match_labels()` view stage that enables matching samples that have specific labels, but without actually filtering the non-matching labels.

Matches can be specified via either `ids` or `tags`, like `select_labels()`, or via a `filter` expression that defines the matching labels, like `filter_labels()`.

This stage is useful in cases such as inspecting detection evaluation results where one may want to inspect an *entire* sample that contains a false positive prediction without actually filtering the true positives, since one needs to see the whole situation to diagnose why a particular label was deemed a false positive.

### Other updates

- Adds an optional `bool` flag to `MatchTags()` that allows for optionally matching samples **without** the specified tags
- Adds missing implementations of `get_filtered_fields()` to `SelectLabels` and `ExcludeLabels`
- Fixes a bug in `LimitLabels()` that would cause views to contain empty label lists if the source dataset contains `None`-valued fields

### Example usage

```py
import fiftyone as fo
import fiftyone.zoo as foz
from fiftyone import ViewField as F

dataset = foz.load_zoo_dataset("quickstart")

#
# Only show samples whose labels are currently selected in the App
#

session = fo.launch_app(dataset)

# Select some labels in the App...

view = dataset.match_labels(labels=session.selected_labels)

#
# Only include samples that contain labels with the specified IDs
#

# Grab some label IDs
ids = [
    dataset.first().ground_truth.detections[0].id,
    dataset.last().predictions.detections[0].id,
]

view = dataset.match_labels(ids=ids)

print(len(view))
print(view.count("ground_truth.detections"))
print(view.count("predictions.detections"))

#
# Only include samples that contain labels with the specified tags
#

# Grab some label IDs
ids = [
    dataset.first().ground_truth.detections[0].id,
    dataset.last().predictions.detections[0].id,
]

# Give the labels a "test" tag
dataset = dataset.clone()  # create copy since we're modifying data
dataset.select_labels(ids=ids).tag_labels("test")

print(dataset.count_values("ground_truth.detections.tags"))
print(dataset.count_values("predictions.detections.tags"))

# Retrieve the labels via their tag
view = dataset.match_labels(tags="test")

print(len(view))
print(view.count("ground_truth.detections"))
print(view.count("predictions.detections"))

#
# Only include samples that contain labels matching a filter
#

filter = F("confidence") > 0.99
view = dataset.match_labels(filter=filter, fields="predictions")

print(len(view))
print(view.count("ground_truth.detections"))
print(view.count("predictions.detections"))
```
