### PR TITLE
Adding support for exporting image patches

### DIFF
--- a/docs/source/user_guide/using_views.rst
+++ b/docs/source/user_guide/using_views.rst
@@ -641,44 +641,10 @@ non-patch views:
 -   Any new fields that you add to an object patches view will not be added to
     the source dataset
 
-.. _exporting-object-patches:
+.. note::
 
-Exporting object patches
-------------------------
-
-Object patches views are able to be exported to disk as a classification
-dataset containing cropped object patches. 
-
-In fact, even outside of patches views, whenever a |Detection| 
-or |Detections| field and a classification dataset format (like an
-:class:`ImageClassificationDirectoryTree <fiftyone.types.dataset_types.ImageClassificationDirectoryTree>`)
-are specified when exporting a |Dataset|,
-then the individual cropped detection image patches will be exported automatically.
-
-.. code-block:: python
-    :linenos:
-
-    import fiftyone as fo
-    import fiftyone.zoo as foz
-
-    # Load some data and create a patches view
-    dataset = foz.load_zoo_dataset("quickstart").limit(5).clone()
-    view = dataset.to_patches("ground_truth")
-
-    # Export a patches view as a ImageClassificationDirectoryTree
-    view.export(
-        "/tmp/quickstart/tree",
-        fo.types.ImageClassificationDirectoryTree, 
-        label_field="ground_truth",
-    )
-
-    # Export unlabled image patches in a directory 
-    dataset.export(
-        "/tmp/quickstart/images",
-        fo.types.ImageDirectory, 
-        label_field="ground_truth",
-    )
-
+    Did you know? You can :ref:`export object patches <export-label-coercion>`
+    as classification datasets!
 
 .. _eval-patches-views:
 

--- a/docs/source/user_guide/using_views.rst
+++ b/docs/source/user_guide/using_views.rst
@@ -641,6 +641,45 @@ non-patch views:
 -   Any new fields that you add to an object patches view will not be added to
     the source dataset
 
+.. _exporting-object-patches:
+
+Exporting object patches
+------------------------
+
+Object patches views are able to be exported to disk as a classification
+dataset containing cropped object patches. 
+
+In fact, even outside of patches views, whenever a |Detection| 
+or |Detections| field and a classification dataset format (like an
+:class:`ImageClassificationDirectoryTree <fiftyone.types.dataset_types.ImageClassificationDirectoryTree>`)
+are specified when exporting a |Dataset|,
+then the individual cropped detection image patches will be exported automatically.
+
+.. code-block:: python
+    :linenos:
+
+    import fiftyone as fo
+    import fiftyone.zoo as foz
+
+    # Load some data and create a patches view
+    dataset = foz.load_zoo_dataset("quickstart").limit(5).clone()
+    view = dataset.to_patches("ground_truth")
+
+    # Export a patches view as a ImageClassificationDirectoryTree
+    view.export(
+        "/tmp/quickstart/tree",
+        fo.types.ImageClassificationDirectoryTree, 
+        label_field="ground_truth",
+    )
+
+    # Export unlabled image patches in a directory 
+    dataset.export(
+        "/tmp/quickstart/images",
+        fo.types.ImageDirectory, 
+        label_field="ground_truth",
+    )
+
+
 .. _eval-patches-views:
 
 Evaluation patches

--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -4739,13 +4739,13 @@ class SampleCollection(object):
 
         See :ref:`this guide <custom-dataset-exporter>` for more details about
         exporting datasets in custom formats by defining your own
-        :class:`DatasetExporter <fiftyone.utils.data.exporters.DatasetExporter>`.
+        :class:`fiftyone.utils.data.exporters.DatasetExporter`.
 
         This method will automatically coerce the data to match the requested
         export in the following cases:
 
         -   When exporting in either an unlabeled image or image classification
-            format, if ``label_field_or_dict`` is a spatial field
+            format, if a spatial label field is provided
             (:class:`fiftyone.core.labels.Detection`,
             :class:`fiftyone.core.labels.Detections`,
             :class:`fiftyone.core.labels.Polyline`, or
@@ -4756,16 +4756,16 @@ class SampleCollection(object):
             list-type labels (:class:`fiftyone.core.labels.Classifications`,
             :class:`fiftyone.core.labels.Detections`,
             :class:`fiftyone.core.labels.Keypoints`, or
-            :class:`fiftyone.core.labels.Polylines`), if
-            ``label_field_or_dict`` contains labels in non-list format
+            :class:`fiftyone.core.labels.Polylines`), if a label field contains
+            labels in non-list format
             (e.g., :class:`fiftyone.core.labels.Classification`), the labels
             will be automatically upgraded to single-label lists
 
         -   When exporting in labeled image dataset formats that expect
-            :class:`fiftyone.core.labels.Detections` labels, if
-            ``label_field_or_dict`` is a
-            :class:`fiftyone.core.labels.Classification` field, the labels will
-            be automatically upgraded to detections that span the entire images
+            :class:`fiftyone.core.labels.Detections` labels, if a
+            :class:`fiftyone.core.labels.Classification` field is provided, the
+            labels will be automatically upgraded to detections that span the
+            entire images
 
         Args:
             export_dir (None): the directory to which to export the samples in
@@ -5148,7 +5148,7 @@ class SampleCollection(object):
 
         Args:
             aggregations: an :class:`fiftyone.core.aggregations.Aggregation` or
-                iterable of :class:`<fiftyone.core.aggregations.Aggregation>`
+                iterable of :class:`fiftyone.core.aggregations.Aggregation`
                 instances
 
         Returns:

--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -4885,8 +4885,8 @@ class SampleCollection(object):
                 )
         else:
             # Other (unlabeled, entire samples, etc)
-            label_field_or_dict = None
-            frame_labels_field_or_dict = None
+            label_field_or_dict = label_field
+            frame_labels_field_or_dict = frame_labels_field
 
         # Export the dataset
         foud.export_samples(

--- a/fiftyone/core/labels.py
+++ b/fiftyone/core/labels.py
@@ -974,13 +974,29 @@ _SINGLE_LABEL_FIELDS = (
     Polyline,
     Segmentation,
 )
+
 _LABEL_LIST_FIELDS = (
     Classifications,
     Detections,
     Keypoints,
     Polylines,
 )
+
 _LABEL_FIELDS = _SINGLE_LABEL_FIELDS + _LABEL_LIST_FIELDS
+
+_PATCHES_FIELDS = (
+    Detection,
+    Detections,
+    Polyline,
+    Polylines,
+)
+
+_LABEL_LIST_TO_SINGLE_MAP = {
+    Classifications: Classification,
+    Detections: Detection,
+    Keypoints: Keypoint,
+    Polylines: Polyline,
+}
 
 
 def _from_geo_json_single(d):

--- a/fiftyone/core/utils.py
+++ b/fiftyone/core/utils.py
@@ -44,6 +44,32 @@ import fiftyone.core.context as foc
 logger = logging.getLogger(__name__)
 
 
+def extract_kwargs_for_class(cls, kwargs):
+    """Extracts the keyword arguments for the given class from the given
+    dictionary.
+
+    Args:
+        cls: a class
+        kwargs: a dictionary of keyword arguments
+
+    Returns:
+        a tuple of:
+
+        -   ``class_kwargs``: a dictionary of keyword arguments for ``cls``
+        -   ``other_kwargs``: a dictionary containing the remaining ``kwargs``
+    """
+    class_kwargs = {}
+    other_kwargs = {}
+    spec = inspect.getfullargspec(cls)
+    for k, v in kwargs.items():
+        if k in spec.args:
+            class_kwargs[k] = v
+        else:
+            other_kwargs[k] = v
+
+    return class_kwargs, other_kwargs
+
+
 def pprint(obj, stream=None, indent=4, width=80, depth=None):
     """Pretty-prints the Python object.
 

--- a/fiftyone/core/utils.py
+++ b/fiftyone/core/utils.py
@@ -45,8 +45,8 @@ logger = logging.getLogger(__name__)
 
 
 def extract_kwargs_for_class(cls, kwargs):
-    """Extracts the keyword arguments for the given class from the given
-    dictionary.
+    """Extracts keyword arguments for a class from the given dictionary of
+    arguments.
 
     Args:
         cls: a class

--- a/fiftyone/utils/bdd.py
+++ b/fiftyone/utils/bdd.py
@@ -593,7 +593,7 @@ def _make_bdd_annotation(labels, metadata, filename):
         if isinstance(_labels, fol.Classification):
             frame_attrs[name] = _labels.label
         elif isinstance(_labels, fol.Classifications):
-            frame_attrs[name] = [l.label for l in _labels]
+            frame_attrs[name] = [l.label for l in _labels.classifications]
         elif isinstance(_labels, fol.Detection):
             objects.append(_detection_to_bdd(_labels, frame_size))
         elif isinstance(_labels, fol.Detections):

--- a/fiftyone/utils/data/exporters.py
+++ b/fiftyone/utils/data/exporters.py
@@ -134,6 +134,7 @@ def export_samples(
                 **patches_kwargs,
             )
             sample_parser = ImageSampleParser()
+            num_samples = len(samples)
         else:
             sample_parser = FiftyOneUnlabeledImageSampleParser(
                 compute_metadata=True
@@ -152,6 +153,7 @@ def export_samples(
                 **patches_kwargs,
             )
             sample_parser = ImageClassificationSampleParser()
+            num_samples = len(samples)
         else:
             sample_parser = FiftyOneLabeledImageSampleParser(
                 label_field_or_dict, compute_metadata=True
@@ -437,33 +439,36 @@ def _check_for_patches_export(
     if isinstance(
         dataset_exporter, UnlabeledImageDatasetExporter
     ) and etau.is_str(label_field_or_dict):
-        field_type = samples._get_field_type(label_field_or_dict)
-        if issubclass(field_type, fol._PATCHES_FIELDS):
-            found_patches = True
-            patches_kwargs, kwargs = fou.extract_kwargs_for_class(
-                foup.ImagePatchesExtractor, kwargs
-            )
+        try:
+            label_type = samples._get_label_field_type(label_field_or_dict)
+            found_patches = issubclass(label_type, fol._PATCHES_FIELDS)
+        except:
+            pass
 
+        if found_patches:
             msg = (
                 "Detected an unlabeled image exporter and a label field '%s' "
-                "with patches type %s. Exporting image patches..."
-                % (label_field_or_dict, field_type)
+                "of type %s. Exporting image patches..."
+                % (label_field_or_dict, label_type)
             )
             warnings.warn(msg)
 
-    if (
+    elif (
         isinstance(dataset_exporter, LabeledImageDatasetExporter)
         and dataset_exporter.label_cls is fol.Classification
         and etau.is_str(label_field_or_dict)
     ):
-        field_type = samples._get_field_type(label_field_or_dict)
-        if issubclass(field_type, fol._PATCHES_FIELDS):
-            found_patches = True
+        try:
+            label_type = samples._get_label_field_type(label_field_or_dict)
+            found_patches = issubclass(label_type, fol._PATCHES_FIELDS)
+        except:
+            pass
 
+        if found_patches:
             msg = (
                 "Detected an image classification exporter and a label field "
-                "'%s' with patches type %s. Exporting image patches..."
-                % (label_field_or_dict, field_type)
+                "'%s' of type %s. Exporting image patches..."
+                % (label_field_or_dict, label_type)
             )
             warnings.warn(msg)
 

--- a/fiftyone/utils/data/exporters.py
+++ b/fiftyone/utils/data/exporters.py
@@ -60,7 +60,7 @@ def export_samples(
     export in the following cases:
 
     -   When exporting in either an unlabeled image or image classification
-        format, if ``label_field_or_dict`` is a spatial field
+        format, if a spatial label field is provided
         (:class:`fiftyone.core.labels.Detection`,
         :class:`fiftyone.core.labels.Detections`,
         :class:`fiftyone.core.labels.Polyline`, or
@@ -71,16 +71,16 @@ def export_samples(
         labels (:class:`fiftyone.core.labels.Classifications`,
         :class:`fiftyone.core.labels.Detections`,
         :class:`fiftyone.core.labels.Keypoints`, or
-        :class:`fiftyone.core.labels.Polylines`), if ``label_field_or_dict``
-        contains labels in non-list format
+        :class:`fiftyone.core.labels.Polylines`), if a label field contains
+        labels in non-list format
         (e.g., :class:`fiftyone.core.labels.Classification`), the labels will
         be automatically upgraded to single-label lists
 
     -   When exporting in labeled image dataset formats that expect
-        :class:`fiftyone.core.labels.Detections` labels, if
-        ``label_field_or_dict`` is a
-        :class:`fiftyone.core.labels.Classification` field, the labels will be
-        automatically upgraded to detections that span the entire images
+        :class:`fiftyone.core.labels.Detections` labels, if a
+        :class:`fiftyone.core.labels.Classification` field is provided, the
+        labels will be automatically upgraded to detections that span the
+        entire images
 
     Args:
         samples: a :class:`fiftyone.core.collections.SampleCollection`

--- a/fiftyone/utils/data/ingestors.py
+++ b/fiftyone/utils/data/ingestors.py
@@ -98,7 +98,7 @@ class UnlabeledImageDatasetIngestor(
 
     Args:
         dataset_dir: the directory where input images will be ingested into
-        samples: an iterable of samples
+        samples: an iterable of samples that can be parsed by ``sample_parser``
         sample_parser: an
             :class:`fiftyone.utils.data.parsers.UnlabeledImageSampleParser` to
             use to parse the samples
@@ -206,7 +206,7 @@ class LabeledImageDatasetIngestor(LabeledImageDatasetImporter, ImageIngestor):
 
     Args:
         dataset_dir: the directory where input images will be ingested into
-        samples: an iterable of samples
+        samples: an iterable of samples that can be parsed by ``sample_parser``
         sample_parser: an
             :class:`fiftyone.utils.data.parsers.LabeledImageSampleParser` to
             use to parse the samples
@@ -351,7 +351,7 @@ class UnlabeledVideoDatasetIngestor(
 
     Args:
         dataset_dir: the directory where input videos will be ingested into
-        samples: an iterable of samples
+        samples: an iterable of samples that can be parsed by ``sample_parser``
         sample_parser: an
             :class:`fiftyone.utils.data.parsers.UnlabeledVideoSampleParser` to
             use to parse the samples
@@ -440,7 +440,7 @@ class LabeledVideoDatasetIngestor(LabeledVideoDatasetImporter, VideoIngestor):
 
     Args:
         dataset_dir: the directory where input videos will be ingested into
-        samples: an iterable of samples
+        samples: an iterable of samples that can be parsed by ``sample_parser``
         sample_parser: an
             :class:`fiftyone.utils.data.parsers.LabeledVideoSampleParser` to
             use to parse the samples

--- a/fiftyone/utils/data/parsers.py
+++ b/fiftyone/utils/data/parsers.py
@@ -8,10 +8,8 @@ Sample parsers.
 import numpy as np
 
 import eta.core.image as etai
-import eta.core.frames as etaf
 import eta.core.serial as etas
 import eta.core.utils as etau
-import eta.core.video as etav
 
 import fiftyone.core.eta_utils as foe
 import fiftyone.core.labels as fol
@@ -1334,15 +1332,24 @@ class FiftyOneLabeledImageSampleParser(LabeledImageSampleParser):
             :class:`fiftyone.core.labels.Label` field of the samples to parse,
             or a dictionary mapping label field names to keys in the returned
             label dictionary
+        label_fcn_or_dict (None): an optional function or dictionary mapping
+            label field names to functions (must match ``label_field_or_dict``)
+            to apply to each label before returning it
         compute_metadata (False): whether to compute
             :class:`fiftyone.core.metadata.ImageMetadata` instances on-the-fly
             if :func:`get_image_metadata` is called and no metadata is
             available
     """
 
-    def __init__(self, label_field_or_dict, compute_metadata=False):
+    def __init__(
+        self,
+        label_field_or_dict,
+        label_fcn_or_dict=None,
+        compute_metadata=False,
+    ):
         super().__init__()
         self.label_field_or_dict = label_field_or_dict
+        self.label_fcn_or_dict = label_fcn_or_dict
         self.compute_metadata = compute_metadata
 
     @property
@@ -1373,13 +1380,27 @@ class FiftyOneLabeledImageSampleParser(LabeledImageSampleParser):
         return metadata
 
     def get_label(self):
-        if isinstance(self.label_field_or_dict, dict):
-            return {
-                v: self.current_sample[k]
-                for k, v in self.label_field_or_dict.items()
-            }
+        sample = self.current_sample
+        label_field = self.label_field_or_dict
+        coerce_fcn = self.label_fcn_or_dict
 
-        return self.current_sample[self.label_field_or_dict]
+        if isinstance(label_field, dict):
+            if coerce_fcn is not None:
+                label = {}
+                for k, v in label_field.items():
+                    f = coerce_fcn.get(k, None)
+                    if f is not None:
+                        label[v] = f(sample[k])
+                    else:
+                        label[v] = sample[k]
+            else:
+                label = {v: sample[k] for k, v in label_field.items()}
+        else:
+            label = sample[label_field]
+            if coerce_fcn is not None:
+                label = coerce_fcn(label)
+
+        return label
 
 
 class FiftyOneUnlabeledVideoSampleParser(UnlabeledVideoSampleParser):
@@ -1426,6 +1447,13 @@ class FiftyOneLabeledVideoSampleParser(LabeledVideoSampleParser):
         frame_labels_field_or_dict (None): the name of the frame label field to
             export, or a dictionary mapping field names to output keys
             describing the frame label fields to export
+        label_fcn_or_dict (None): an optional function or dictionary mapping
+            label field names to functions (must match ``label_field_or_dict``)
+            to apply to each sample label before returning it
+        frame_labels_fcn_or_dict (None): an optional function or dictionary
+            mapping frame label field names to functions (must match
+            ``frame_labels_field_or_dict``) to apply to each frame label before
+            returning it
         compute_metadata (False): whether to compute
             :class:`fiftyone.core.metadata.VideoMetadata` instances on-the-fly
             if :func:`get_video_metadata` is called and no metadata is
@@ -1436,13 +1464,19 @@ class FiftyOneLabeledVideoSampleParser(LabeledVideoSampleParser):
         self,
         label_field_or_dict=None,
         frame_labels_field_or_dict=None,
+        label_fcn_or_dict=None,
+        frame_labels_fcn_or_dict=None,
         compute_metadata=False,
     ):
+        frame_labels_dict, frame_fcn_dict = self._parse_frame_args(
+            frame_labels_field_or_dict, frame_labels_fcn_or_dict
+        )
+
         super().__init__()
         self.label_field_or_dict = label_field_or_dict
-        self.frame_labels_dict = self._parse_labels_dict(
-            frame_labels_field_or_dict
-        )
+        self.frame_labels_dict = frame_labels_dict
+        self.label_fcn_or_dict = label_fcn_or_dict
+        self.frame_fcn_dict = frame_fcn_dict
         self.compute_metadata = compute_metadata
 
     @property
@@ -1470,36 +1504,76 @@ class FiftyOneLabeledVideoSampleParser(LabeledVideoSampleParser):
         return metadata
 
     def get_label(self):
-        if self.label_field_or_dict is None:
+        sample = self.current_sample
+        label_field = self.label_field_or_dict
+        coerce_fcn = self.label_fcn_or_dict
+
+        if label_field is None:
             return None
 
-        if isinstance(self.label_field_or_dict, dict):
-            return {
-                v: self.current_sample[k]
-                for k, v in self.label_field_or_dict.items()
-            }
+        if isinstance(label_field, dict):
+            if coerce_fcn is not None:
+                label = {}
+                for k, v in label_field.items():
+                    f = coerce_fcn.get(k, None)
+                    if f is not None:
+                        label[v] = f(sample[k])
+                    else:
+                        label[v] = sample[k]
+            else:
+                label = {v: sample[k] for k, v in label_field.items()}
+        else:
+            label = sample[label_field]
+            if coerce_fcn is not None:
+                label = coerce_fcn(label)
 
-        return self.current_sample[self.label_field_or_dict]
+        return label
 
     def get_frame_labels(self):
-        if self.frame_labels_dict is None:
+        frames = self.current_sample.frames
+        frame_labels_dict = self.frame_labels_dict
+        frame_coerce_fcn = self.frame_fcn_dict
+
+        if frame_labels_dict is None:
             return None
 
-        frames = self.current_sample.frames
-        new_frames = {}
-        for frame_number, frame in frames.items():
-            new_frames[frame_number] = {
-                v: frame[k] for k, v in self.frame_labels_dict.items()
-            }
+        if frame_coerce_fcn is not None:
+            new_frames = {}
+            for frame_number, frame in frames.items():
+                new_frame = {}
+                for k, v in frame_labels_dict.items():
+                    f = frame_coerce_fcn.get(k, None)
+                    if f is not None:
+                        new_frame[v] = f(frame[k])
+                    else:
+                        new_frame[v] = frame[k]
+
+                new_frames[frame_number] = new_frame
+        else:
+            new_frames = {}
+            for frame_number, frame in frames.items():
+                new_frames[frame_number] = {
+                    v: frame[k] for k, v in frame_labels_dict.items()
+                }
 
         return new_frames
 
     @staticmethod
-    def _parse_labels_dict(labels_field_or_dict):
-        if labels_field_or_dict is None:
-            return None
+    def _parse_frame_args(
+        frame_labels_field_or_dict, frame_labels_fcn_or_dict
+    ):
+        if frame_labels_field_or_dict is None:
+            return None, None
 
-        if not isinstance(labels_field_or_dict, dict):
-            return {labels_field_or_dict: labels_field_or_dict}
+        if not isinstance(frame_labels_field_or_dict, dict):
+            label_field = frame_labels_field_or_dict
+            frame_labels_dict = {label_field: label_field}
+            if frame_labels_fcn_or_dict is not None:
+                frame_fcn_dict = {label_field: frame_labels_fcn_or_dict}
+            else:
+                frame_fcn_dict = None
+        else:
+            frame_labels_dict = frame_labels_field_or_dict
+            frame_fcn_dict = frame_labels_fcn_or_dict
 
-        return labels_field_or_dict
+        return frame_labels_dict, frame_fcn_dict

--- a/fiftyone/utils/data/parsers.py
+++ b/fiftyone/utils/data/parsers.py
@@ -30,7 +30,7 @@ def add_images(dataset, samples, sample_parser, tags=None):
 
     Args:
         dataset: a :class:`fiftyone.core.dataset.Dataset`
-        samples: an iterable of samples
+        samples: an iterable of samples that can be parsed by ``sample_parser``
         sample_parser: a
             :class:`fiftyone.utils.data.parsers.UnlabeledImageSampleParser`
             instance to use to parse the samples
@@ -103,7 +103,7 @@ def add_labeled_images(
 
     Args:
         dataset: a :class:`fiftyone.core.dataset.Dataset`
-        samples: an iterable of samples
+        samples: an iterable of samples that can be parsed by ``sample_parser``
         sample_parser: a
             :class:`fiftyone.utils.data.parsers.LabeledImageSampleParser`
             instance to use to parse the samples
@@ -202,7 +202,7 @@ def add_videos(dataset, samples, sample_parser, tags=None):
 
     Args:
         dataset: a :class:`fiftyone.core.dataset.Dataset`
-        samples: an iterable of samples
+        samples: an iterable of samples that can be parsed by ``sample_parser``
         sample_parser: a
             :class:`fiftyone.utils.data.parsers.UnlabeledVideoSampleParser`
             instance to use to parse the samples
@@ -270,7 +270,7 @@ def add_labeled_videos(
 
     Args:
         dataset: a :class:`fiftyone.core.dataset.Dataset`
-        samples: an iterable of samples
+        samples: an iterable of samples that can be parsed by ``sample_parser``
         sample_parser: a
             :class:`fiftyone.utils.data.parsers.LabeledVideoSampleParser`
             instance to use to parse the samples

--- a/fiftyone/utils/labelbox.py
+++ b/fiftyone/utils/labelbox.py
@@ -255,8 +255,9 @@ def export_to_labelbox(
         label_field=label_field,
         label_prefix=label_prefix,
         labels_dict=labels_dict,
-        required=False,
+        allow_coersion=False,
         force_dict=True,
+        required=False,
     )
 
     # Get frame label fields to export
@@ -266,8 +267,9 @@ def export_to_labelbox(
             frame_labels_field=frame_labels_field,
             frame_labels_prefix=frame_labels_prefix,
             frame_labels_dict=frame_labels_dict,
-            required=False,
+            allow_coersion=False,
             force_dict=True,
+            required=False,
         )
 
         if frame_label_fields and video_labels_dir is None:

--- a/fiftyone/utils/patches.py
+++ b/fiftyone/utils/patches.py
@@ -58,7 +58,7 @@ class ImagePatchesExtractor(object):
         self.alpha = alpha
 
     def __len__(self):
-        label_path = self.samples._get_label_field_path(self.patches_field)
+        _, label_path = self.samples._get_label_field_path(self.patches_field)
         return self.samples.count(label_path)
 
     def __iter__(self):

--- a/fiftyone/utils/patches.py
+++ b/fiftyone/utils/patches.py
@@ -1,0 +1,167 @@
+"""
+Image patch utilities.
+
+| Copyright 2017-2021, Voxel51, Inc.
+| `voxel51.com <https://voxel51.com/>`_
+|
+"""
+import cv2
+
+import eta.core.image as etai
+
+import fiftyone.core.frame as fof
+import fiftyone.core.labels as fol
+
+
+class ImagePatchesExtractor(object):
+    """Class for iterating over the labeled/unlabeled image patches in a
+    collection.
+
+    By default, this class emits only the image patches, but you can set
+    ``include_labels`` to True to emit ``(img_patch, label)`` tuples.
+
+    Args:
+        samples: a :class:`fiftyone.core.collections.SampleCollection`
+        patches_field: the name of the field defining the image patches in each
+            sample to extract. Must be of type
+            :class:`fiftyone.core.labels.Detection`,
+            :class:`fiftyone.core.labels.Detections`,
+            :class:`fiftyone.core.labels.Polyline`, or
+            :class:`fiftyone.core.labels.Polylines`
+        include_labels (False): whether to emit ``(img_patch, label)`` tuples
+            rather than just image patches
+        force_rgb (False): whether to force convert the images to RGB
+        force_square (False): whether to minimally manipulate the patch
+            bounding boxes into squares prior to extraction
+        alpha (None): an optional expansion/contraction to apply to the patches
+            before extracting them, in ``[-1, \infty)``. If provided, the
+            length and width of the box are expanded (or contracted, when
+            ``alpha < 0``) by ``(100 * alpha)%``. For example, set
+            ``alpha = 1.1`` to expand the boxes by 10%, and set ``alpha = 0.9``
+            to contract the boxes by 10%
+    """
+
+    def __init__(
+        self,
+        samples,
+        patches_field,
+        include_labels=False,
+        force_rgb=False,
+        force_square=False,
+        alpha=None,
+    ):
+        self.samples = samples
+        self.patches_field = patches_field
+        self.include_labels = include_labels
+        self.force_rgb = force_rgb
+        self.force_square = force_square
+        self.alpha = alpha
+
+    def __len__(self):
+        label_path = self.samples._get_label_field_path(self.patches_field)
+        return self.samples.count(label_path)
+
+    def __iter__(self):
+        for sample in self.samples.select_fields(self.patches_field):
+            patches = parse_patches(
+                sample, self.patches_field, handle_missing="skip"
+            )
+
+            if patches is not None:
+                img = _load_image(sample.filepath, force_rgb=self.force_rgb)
+                for detection in patches.detections:
+                    patch = extract_patch(
+                        img,
+                        detection,
+                        force_square=self.force_square,
+                        alpha=self.alpha,
+                    )
+                    if self.include_labels:
+                        yield patch, detection.label
+                    else:
+                        yield patch
+
+
+def parse_patches(doc, patches_field, handle_missing="skip"):
+    """Parses the patches from the given document.
+
+    Args:
+        patches_field: the name of the field defining the image patches. Must
+            be of type :class:`fiftyone.core.labels.Detection`,
+            :class:`fiftyone.core.labels.Detections`,
+            :class:`fiftyone.core.labels.Polyline`, or
+            :class:`fiftyone.core.labels.Polylines`
+        handle_missing ("skip"): how to handle documents with no patches.
+            Supported values are:
+
+                -   "skip": skip the document and return ``None``
+                -   "image": use the whole image as a single patch
+                -   "error": raise an error
+
+    Returns:
+        a :class:`fiftyone.core.labels.Detections` instance, or ``None``
+    """
+    label = doc[patches_field]
+
+    if isinstance(label, fol.Detections):
+        patches = label
+    elif isinstance(label, fol.Detection):
+        patches = fol.Detections(detections=[label])
+    elif isinstance(label, fol.Polyline):
+        patches = fol.Detections(detections=[label.to_detection()])
+    elif isinstance(label, fol.Polylines):
+        patches = label.to_detections()
+    elif label is None:
+        patches = None
+    else:
+        raise ValueError(
+            "Field '%s' with value type %s is not a valid patches field"
+            % (patches_field, type(label))
+        )
+
+    if patches is None or not patches.detections:
+        if handle_missing == "skip":
+            patches = None
+        elif handle_missing == "image":
+            patches = fol.Detections(
+                detections=[fol.Detection(bounding_box=[0, 0, 1, 1])]
+            )
+        else:
+            dtype = "Frame" if isinstance(doc, fof.Frame) else "Sample"
+            raise ValueError("%s '%s' has no patches" % (dtype, doc.id))
+
+    return patches
+
+
+def extract_patch(img, detection, force_square=False, alpha=None):
+    """Extracts the patch from the image.
+
+    Args:
+        img: a numpy image array
+        detection: a :class:`fiftyone.core.labels.Detection` defining the
+            patch
+        force_square (False): whether to minimally manipulate the patch
+            bounding box into a square prior to extraction
+        alpha (None): an optional expansion/contraction to apply to the patch
+            before extracting it, in ``[-1, \infty)``. If provided, the length
+            and width of the box are expanded (or contracted, when
+            ``alpha < 0``) by ``(100 * alpha)%``. For example, set
+            ``alpha = 1.1`` to expand the box by 10%, and set ``alpha = 0.9``
+            to contract the box by 10%
+
+    Returns:
+        the image patch
+    """
+    dobj = detection.to_detected_object()
+
+    bbox = dobj.bounding_box
+    if alpha is not None:
+        bbox = bbox.pad_relative(alpha)
+
+    return bbox.extract_from(img, force_square=force_square)
+
+
+def _load_image(image_path, force_rgb=False):
+    # pylint: disable=no-member
+    flag = cv2.IMREAD_COLOR if force_rgb else cv2.IMREAD_UNCHANGED
+    return etai.read(image_path, flag=flag)

--- a/fiftyone/utils/scale.py
+++ b/fiftyone/utils/scale.py
@@ -396,8 +396,9 @@ def export_to_scale(
         label_field=label_field,
         label_prefix=label_prefix,
         labels_dict=labels_dict,
-        required=False,
+        allow_coersion=False,
         force_dict=True,
+        required=False,
     )
 
     # Get frame label fields to export
@@ -407,6 +408,7 @@ def export_to_scale(
             frame_labels_field=frame_labels_field,
             frame_labels_prefix=frame_labels_prefix,
             frame_labels_dict=frame_labels_dict,
+            allow_coersion=False,
             required=False,
             force_dict=True,
         )

--- a/fiftyone/zoo/datasets/__init__.py
+++ b/fiftyone/zoo/datasets/__init__.py
@@ -9,7 +9,6 @@ download via FiftyOne.
 |
 """
 from collections import OrderedDict
-import inspect
 import logging
 import os
 
@@ -17,6 +16,7 @@ import eta.core.serial as etas
 import eta.core.utils as etau
 
 import fiftyone as fo
+import fiftyone.core.utils as fou
 
 
 logger = logging.getLogger(__name__)
@@ -121,19 +121,6 @@ def download_zoo_dataset(
     )
 
 
-def _extract_kwargs_for_class(cls, kwargs):
-    class_kwargs = {}
-    other_kwargs = {}
-    spec = inspect.getfullargspec(cls)
-    for k, v in kwargs.items():
-        if k in spec.args:
-            class_kwargs[k] = v
-        else:
-            other_kwargs[k] = v
-
-    return class_kwargs, other_kwargs
-
-
 def load_zoo_dataset(
     name,
     split=None,
@@ -195,7 +182,9 @@ def load_zoo_dataset(
 
     if download_if_necessary:
         zoo_dataset_cls = _get_zoo_dataset_cls(name)
-        download_kwargs, _ = _extract_kwargs_for_class(zoo_dataset_cls, kwargs)
+        download_kwargs, _ = fou.extract_kwargs_for_class(
+            zoo_dataset_cls, kwargs
+        )
 
         info, dataset_dir = download_zoo_dataset(
             name,
@@ -212,7 +201,7 @@ def load_zoo_dataset(
 
     dataset_type = info.get_dataset_type()
     dataset_importer = dataset_type.get_dataset_importer_cls()
-    importer_kwargs, _ = _extract_kwargs_for_class(dataset_importer, kwargs)
+    importer_kwargs, _ = fou.extract_kwargs_for_class(dataset_importer, kwargs)
 
     if dataset_name is None:
         dataset_name = zoo_dataset.name


### PR DESCRIPTION
Resolves #1049.

When a dataset export involving a spatial field (eg `Detections`) and a classification dataset format (eg `ImageClassificationDirectoryTree`) is detected, the export routine will automatically assume that the user wants to export the *image patches*.

Also adds support for automatically coercing single label fields like `Detection` into `Detections` if the exporter expects list-type fields.

One more thing: previously label type coercions were only applied when a single `label_field` is being exported. Now, label coercions are applied if possible even when multiple fields are being exported.

### Example usage

```py
import fiftyone as fo
import fiftyone.zoo as foz

dataset = foz.load_zoo_dataset("quickstart").limit(5).clone()

for idx, sample in enumerate(dataset):
    sample["attribute"] = fo.Classification(label=str(idx))
    sample.save()

view = dataset.to_patches("ground_truth")

#
# Automatic upgrade from `Detection` to `Detections`
#
# This also demonstrates that exporters gracefully handle path collisions when
# the same image is exported multiple times
#
view.export("/tmp/quickstart/coco", fo.types.COCODetectionDataset)

#
# Exporting unlabeled image patches
#
# If `label_field` is omitted, the raw images are exported. However, since a `label_field` is
# provided that is a valid patches type, image patches are exported instead
#
dataset.export("/tmp/quickstart/images1", fo.types.ImageDirectory, label_field="ground_truth")
view.export("/tmp/quickstart/images2", fo.types.ImageDirectory, label_field="ground_truth")

#
# Exporting labeled image patches
#
# `label_field` is a `Detections` field, so the image patches are exported as a classification dataset
#
dataset.export("/tmp/quickstart/tree1", fo.types.ImageClassificationDirectoryTree, label_field="ground_truth")

#
# Automatic export of labeled image patches
#
# In this case, `label_field` is not explicitly specified, so the routine first checks for a `Classification`
# field to export, and then checks (and finds) a spatial field to export patches
#
view.export("/tmp/quickstart/tree2", fo.types.ImageClassificationDirectoryTree)

#
# Multi-field exports
#
# BDD format supports both classifications and detections. So, the first applicable detections field
# (`ground_truth`) is exported, and the `attribute` field is coerced into lists and exported as well
#
# In the second variation, only `attribute` is exported, still with coercion into lists for compatibility 
#
dataset.export("/tmp/quickstart/bdd1", fo.types.BDDDataset)
dataset.export("/tmp/quickstart/bdd2", fo.types.BDDDataset, label_field="attribute")
```
