### PR TITLE
Syntax sugar for running multiple aggregations of the same type

### DIFF
--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -3917,7 +3917,10 @@ class SampleCollection(object):
             field_or_expr: a field name, ``embedded.field.name``,
                 :class:`fiftyone.core.expressions.ViewExpression`, or
                 `MongoDB expression <https://docs.mongodb.com/manual/meta/aggregation-quick-reference/#aggregation-expressions>`_
-                defining the field or expression to aggregate
+                defining the field or expression to aggregate. This can also
+                be a list or tuple of such arguments, in which case a tuple of
+                corresponding aggregation results (each receiving the same
+                additional keyword arguments, if any) will be returned
             expr (None): a :class:`fiftyone.core.expressions.ViewExpression` or
                 `MongoDB expression <https://docs.mongodb.com/manual/meta/aggregation-quick-reference/#aggregation-expressions>`_
                 to apply to ``field_or_expr`` (which must be a field) before
@@ -3926,7 +3929,8 @@ class SampleCollection(object):
         Returns:
             the ``(min, max)`` bounds
         """
-        return self.aggregate(foa.Bounds(field_or_expr, expr=expr))
+        make = lambda field_or_expr: foa.Bounds(field_or_expr, expr=expr)
+        return self._make_and_aggregate(make, field_or_expr)
 
     @aggregation
     def count(self, field_or_expr=None, expr=None):
@@ -4008,7 +4012,10 @@ class SampleCollection(object):
                 `MongoDB expression <https://docs.mongodb.com/manual/meta/aggregation-quick-reference/#aggregation-expressions>`_
                 defining the field or expression to aggregate. If neither
                 ``field_or_expr`` or ``expr`` is provided, the samples
-                themselves are counted
+                themselves are counted. This can also be a list or tuple of
+                such arguments, in which case a tuple of corresponding
+                aggregation results (each receiving the same additional keyword
+                arguments, if any) will be returned
             expr (None): a :class:`fiftyone.core.expressions.ViewExpression` or
                 `MongoDB expression <https://docs.mongodb.com/manual/meta/aggregation-quick-reference/#aggregation-expressions>`_
                 to apply to ``field_or_expr`` (which must be a field) before
@@ -4017,9 +4024,8 @@ class SampleCollection(object):
         Returns:
             the count
         """
-        return self.aggregate(
-            foa.Count(field_or_expr=field_or_expr, expr=expr)
-        )
+        make = lambda field_or_expr: foa.Count(field_or_expr, expr=expr)
+        return self._make_and_aggregate(make, field_or_expr)
 
     @aggregation
     def count_values(self, field_or_expr, expr=None):
@@ -4096,7 +4102,10 @@ class SampleCollection(object):
             field_or_expr: a field name, ``embedded.field.name``,
                 :class:`fiftyone.core.expressions.ViewExpression`, or
                 `MongoDB expression <https://docs.mongodb.com/manual/meta/aggregation-quick-reference/#aggregation-expressions>`_
-                defining the field or expression to aggregate
+                defining the field or expression to aggregate. This can also
+                be a list or tuple of such arguments, in which case a tuple of
+                corresponding aggregation results (each receiving the same
+                additional keyword arguments, if any) will be returned
             expr (None): a :class:`fiftyone.core.expressions.ViewExpression` or
                 `MongoDB expression <https://docs.mongodb.com/manual/meta/aggregation-quick-reference/#aggregation-expressions>`_
                 to apply to ``field_or_expr`` (which must be a field) before
@@ -4105,7 +4114,8 @@ class SampleCollection(object):
         Returns:
             a dict mapping values to counts
         """
-        return self.aggregate(foa.CountValues(field_or_expr, expr=expr))
+        make = lambda field_or_expr: foa.CountValues(field_or_expr, expr=expr)
+        return self._make_and_aggregate(make, field_or_expr)
 
     @aggregation
     def distinct(self, field_or_expr, expr=None):
@@ -4184,7 +4194,10 @@ class SampleCollection(object):
             field_or_expr: a field name, ``embedded.field.name``,
                 :class:`fiftyone.core.expressions.ViewExpression`, or
                 `MongoDB expression <https://docs.mongodb.com/manual/meta/aggregation-quick-reference/#aggregation-expressions>`_
-                defining the field or expression to aggregate
+                defining the field or expression to aggregate. This can also
+                be a list or tuple of such arguments, in which case a tuple of
+                corresponding aggregation results (each receiving the same
+                additional keyword arguments, if any) will be returned
             expr (None): a :class:`fiftyone.core.expressions.ViewExpression` or
                 `MongoDB expression <https://docs.mongodb.com/manual/meta/aggregation-quick-reference/#aggregation-expressions>`_
                 to apply to ``field_or_expr`` (which must be a field) before
@@ -4193,7 +4206,8 @@ class SampleCollection(object):
         Returns:
             a sorted list of distinct values
         """
-        return self.aggregate(foa.Distinct(field_or_expr, expr=expr))
+        make = lambda field_or_expr: foa.Distinct(field_or_expr, expr=expr)
+        return self._make_and_aggregate(make, field_or_expr)
 
     @aggregation
     def histogram_values(
@@ -4272,7 +4286,10 @@ class SampleCollection(object):
             field_or_expr: a field name, ``embedded.field.name``,
                 :class:`fiftyone.core.expressions.ViewExpression`, or
                 `MongoDB expression <https://docs.mongodb.com/manual/meta/aggregation-quick-reference/#aggregation-expressions>`_
-                defining the field or expression to aggregate
+                defining the field or expression to aggregate. This can also
+                be a list or tuple of such arguments, in which case a tuple of
+                corresponding aggregation results (each receiving the same
+                additional keyword arguments, if any) will be returned
             expr (None): a :class:`fiftyone.core.expressions.ViewExpression` or
                 `MongoDB expression <https://docs.mongodb.com/manual/meta/aggregation-quick-reference/#aggregation-expressions>`_
                 to apply to ``field_or_expr`` (which must be a field) before
@@ -4301,11 +4318,10 @@ class SampleCollection(object):
                 ``[lower, upper)``, including the rightmost bin
             -   other: the number of items outside the bins
         """
-        return self.aggregate(
-            foa.HistogramValues(
-                field_or_expr, expr=expr, bins=bins, range=range, auto=auto
-            )
+        make = lambda field_or_expr: foa.HistogramValues(
+            field_or_expr, expr=expr, bins=bins, range=range, auto=auto
         )
+        return self._make_and_aggregate(make, field_or_expr)
 
     @aggregation
     def mean(self, field_or_expr, expr=None):
@@ -4370,7 +4386,10 @@ class SampleCollection(object):
             field_or_expr: a field name, ``embedded.field.name``,
                 :class:`fiftyone.core.expressions.ViewExpression`, or
                 `MongoDB expression <https://docs.mongodb.com/manual/meta/aggregation-quick-reference/#aggregation-expressions>`_
-                defining the field or expression to aggregate
+                defining the field or expression to aggregate. This can also
+                be a list or tuple of such arguments, in which case a tuple of
+                corresponding aggregation results (each receiving the same
+                additional keyword arguments, if any) will be returned
             expr (None): a :class:`fiftyone.core.expressions.ViewExpression` or
                 `MongoDB expression <https://docs.mongodb.com/manual/meta/aggregation-quick-reference/#aggregation-expressions>`_
                 to apply to ``field_or_expr`` (which must be a field) before
@@ -4379,7 +4398,8 @@ class SampleCollection(object):
         Returns:
             the mean
         """
-        return self.aggregate(foa.Mean(field_or_expr, expr=expr))
+        make = lambda field_or_expr: foa.Mean(field_or_expr, expr=expr)
+        return self._make_and_aggregate(make, field_or_expr)
 
     @aggregation
     def std(self, field_or_expr, expr=None, sample=False):
@@ -4445,7 +4465,10 @@ class SampleCollection(object):
             field_or_expr: a field name, ``embedded.field.name``,
                 :class:`fiftyone.core.expressions.ViewExpression`, or
                 `MongoDB expression <https://docs.mongodb.com/manual/meta/aggregation-quick-reference/#aggregation-expressions>`_
-                defining the field or expression to aggregate
+                defining the field or expression to aggregate. This can also
+                be a list or tuple of such arguments, in which case a tuple of
+                corresponding aggregation results (each receiving the same
+                additional keyword arguments, if any) will be returned
             expr (None): a :class:`fiftyone.core.expressions.ViewExpression` or
                 `MongoDB expression <https://docs.mongodb.com/manual/meta/aggregation-quick-reference/#aggregation-expressions>`_
                 to apply to ``field_or_expr`` (which must be a field) before
@@ -4456,7 +4479,10 @@ class SampleCollection(object):
         Returns:
             the standard deviation
         """
-        return self.aggregate(foa.Std(field_or_expr, expr=expr, sample=sample))
+        make = lambda field_or_expr: foa.Std(
+            field_or_expr, expr=expr, sample=sample
+        )
+        return self._make_and_aggregate(make, field_or_expr)
 
     @aggregation
     def sum(self, field_or_expr, expr=None):
@@ -4521,7 +4547,10 @@ class SampleCollection(object):
             field_or_expr: a field name, ``embedded.field.name``,
                 :class:`fiftyone.core.expressions.ViewExpression`, or
                 `MongoDB expression <https://docs.mongodb.com/manual/meta/aggregation-quick-reference/#aggregation-expressions>`_
-                defining the field or expression to aggregate
+                defining the field or expression to aggregate. This can also
+                be a list or tuple of such arguments, in which case a tuple of
+                corresponding aggregation results (each receiving the same
+                additional keyword arguments, if any) will be returned
             expr (None): a :class:`fiftyone.core.expressions.ViewExpression` or
                 `MongoDB expression <https://docs.mongodb.com/manual/meta/aggregation-quick-reference/#aggregation-expressions>`_
                 to apply to ``field_or_expr`` (which must be a field) before
@@ -4530,7 +4559,8 @@ class SampleCollection(object):
         Returns:
             the sum
         """
-        return self.aggregate(foa.Sum(field_or_expr, expr=expr))
+        make = lambda field_or_expr: foa.Sum(field_or_expr, expr=expr)
+        return self._make_and_aggregate(make, field_or_expr)
 
     @aggregation
     def values(
@@ -4632,7 +4662,10 @@ class SampleCollection(object):
             field_or_expr: a field name, ``embedded.field.name``,
                 :class:`fiftyone.core.expressions.ViewExpression`, or
                 `MongoDB expression <https://docs.mongodb.com/manual/meta/aggregation-quick-reference/#aggregation-expressions>`_
-                defining the field or expression to aggregate
+                defining the field or expression to aggregate. This can also
+                be a list or tuple of such arguments, in which case a tuple of
+                corresponding aggregation results (each receiving the same
+                additional keyword arguments, if any) will be returned
             expr (None): a :class:`fiftyone.core.expressions.ViewExpression` or
                 `MongoDB expression <https://docs.mongodb.com/manual/meta/aggregation-quick-reference/#aggregation-expressions>`_
                 to apply to ``field_or_expr`` (which must be a field) before
@@ -4645,17 +4678,16 @@ class SampleCollection(object):
         Returns:
             the list of values
         """
-        return self.aggregate(
-            foa.Values(
-                field_or_expr,
-                expr=expr,
-                missing_value=missing_value,
-                unwind=unwind,
-                _allow_missing=_allow_missing,
-                _big_result=_big_result,
-                _raw=_raw,
-            )
+        make = lambda field_or_expr: foa.Values(
+            field_or_expr,
+            expr=expr,
+            missing_value=missing_value,
+            unwind=unwind,
+            _allow_missing=_allow_missing,
+            _big_result=_big_result,
+            _raw=_raw,
         )
+        return self._make_and_aggregate(make, field_or_expr)
 
     def draw_labels(
         self,
@@ -5289,6 +5321,12 @@ class SampleCollection(object):
             the aggregation result dict
         """
         raise NotImplementedError("Subclass must implement _aggregate()")
+
+    def _make_and_aggregate(self, make, args):
+        if isinstance(args, (list, tuple)):
+            return tuple(self.aggregate([make(arg) for arg in args]))
+
+        return self.aggregate(make(args))
 
     def _build_aggregation(self, aggregations):
         scalar_result = isinstance(aggregations, foa.Aggregation)

--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -19,6 +19,7 @@ import string
 from bson import ObjectId
 from deprecated import deprecated
 import mongoengine.errors as moe
+import numpy as np
 from pymongo import UpdateMany, UpdateOne
 from pymongo.errors import CursorNotFound, BulkWriteError
 
@@ -1523,8 +1524,7 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
             )
 
         if key_fcn is None:
-            aggs = [foa.Values(key_field), foa.Values("id")]
-            id_map = {key: _id for key, _id in zip(*self.aggregate(aggs))}
+            id_map = {k: v for k, v in zip(*self.values([key_field, "id"]))}
             key_fcn = lambda sample: sample[key_field]
         else:
             id_map = {}
@@ -4026,10 +4026,10 @@ def _merge_samples(
 
 
 def _index_frames(sample_collection, key_field, frame_key_field):
-    aggs = [foa.Values("_id"), foa.Values(key_field)]
-    keys_map = {k: v for k, v in zip(*sample_collection.aggregate(aggs))}
-
-    all_sample_ids = sample_collection.values("frames._sample_id")
+    ids, keys, all_sample_ids = sample_collection.values(
+        ["_id", key_field, "frames._sample_id"]
+    )
+    keys_map = {k: v for k, v in zip(ids, keys)}
 
     frame_keys = []
     for sample_ids in all_sample_ids:
@@ -4064,8 +4064,8 @@ def _always_select_field(sample_collection, field):
 
 
 def _finalize_frames(sample_collection, key_field, frame_key_field):
-    aggs = [foa.Values(key_field), foa.Values("_id")]
-    ids_map = {k: v for k, v in zip(*sample_collection.aggregate(aggs))}
+    results = sample_collection.values([key_field, "_id"])
+    ids_map = {k: v for k, v in zip(*results)}
 
     frame_coll = sample_collection._frame_collection
 
@@ -4088,6 +4088,9 @@ def _get_sample_ids(samples_or_ids):
 
     if isinstance(samples_or_ids, foc.SampleCollection):
         return samples_or_ids.values("id")
+
+    if isinstance(samples_or_ids, np.ndarray):
+        return list(samples_or_ids)
 
     if not samples_or_ids:
         return []

--- a/fiftyone/core/metadata.py
+++ b/fiftyone/core/metadata.py
@@ -5,6 +5,7 @@ Metadata stored in dataset samples.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+import itertools
 import logging
 import multiprocessing
 import os
@@ -213,12 +214,12 @@ def _compute_metadata_multi(sample_collection, num_workers, overwrite=False):
     if not overwrite:
         sample_collection = sample_collection.exists("metadata", False)
 
-    inputs = [
-        (sample.id, sample.filepath, sample.media_type)
-        for sample in sample_collection.select_fields()
-    ]
+    ids, filepaths = sample_collection.values(["id", "filepath"])
+    media_types = itertools.repeat(sample_collection.media_type)
 
+    inputs = list(zip(ids, filepaths, media_types))
     num_samples = len(inputs)
+
     if num_samples == 0:
         return
 

--- a/fiftyone/core/patches.py
+++ b/fiftyone/core/patches.py
@@ -281,9 +281,7 @@ class _PatchesView(fov.DatasetView):
 
         _, id_path = self._get_label_field_path(field, "id")
 
-        sample_ids, label_ids = self.aggregate(
-            [foa.Values("id"), foa.Values(id_path)]
-        )
+        sample_ids, label_ids = self.values(["id", id_path])
 
         ids_map = {}
         if is_list_field:

--- a/fiftyone/core/stages.py
+++ b/fiftyone/core/stages.py
@@ -14,6 +14,7 @@ import warnings
 
 from bson import ObjectId
 from deprecated import deprecated
+import numpy as np
 
 import eta.core.utils as etau
 
@@ -4158,6 +4159,9 @@ def _get_sample_ids(samples_or_ids):
 
     if isinstance(samples_or_ids, foc.SampleCollection):
         return samples_or_ids.values("id")
+
+    if isinstance(samples_or_ids, np.ndarray):
+        return list(samples_or_ids)
 
     if not samples_or_ids:
         return []

--- a/fiftyone/utils/eval/classification.py
+++ b/fiftyone/utils/eval/classification.py
@@ -11,7 +11,6 @@ import warnings
 import numpy as np
 import sklearn.metrics as skm
 
-import fiftyone.core.aggregations as foa
 import fiftyone.core.evaluation as foe
 from fiftyone.core.expressions import ViewField as F
 import fiftyone.core.fields as fof
@@ -190,14 +189,8 @@ class SimpleEvaluation(ClassificationEvaluation):
         pred_id = pred_field + ".id"
         pred_conf = pred_field + ".confidence"
 
-        ytrue, ytrue_ids, ypred, ypred_ids, confs = samples.aggregate(
-            [
-                foa.Values(gt),
-                foa.Values(gt_id),
-                foa.Values(pred),
-                foa.Values(pred_id),
-                foa.Values(pred_conf),
-            ]
+        ytrue, ytrue_ids, ypred, ypred_ids, confs = samples.values(
+            [gt, gt_id, pred, pred_id, pred_conf]
         )
 
         if is_frame_field:
@@ -294,13 +287,13 @@ class TopKEvaluation(ClassificationEvaluation):
 
         # This extracts a potentially huge number of logits
         # @todo consider sample iteration for very large datasets
-        ytrue, ytrue_ids, ypred, ypred_ids, logits = samples.aggregate(
+        ytrue, ytrue_ids, ypred, ypred_ids, logits = samples.values(
             [
-                foa.Values(gt_field + ".label"),
-                foa.Values(gt_field + ".id"),
-                foa.Values(pred_field + ".label"),
-                foa.Values(pred_field + ".id"),
-                foa.Values(pred_field + ".logits"),
+                gt_field + ".label",
+                gt_field + ".id",
+                pred_field + ".label",
+                pred_field + ".id",
+                pred_field + ".logits",
             ]
         )
 
@@ -450,14 +443,8 @@ class BinaryEvaluation(ClassificationEvaluation):
         pred_id = pred_field + ".id"
         pred_conf = pred_field + ".confidence"
 
-        ytrue, ytrue_ids, ypred, ypred_ids, confs = samples.aggregate(
-            [
-                foa.Values(gt),
-                foa.Values(gt_id),
-                foa.Values(pred),
-                foa.Values(pred_id),
-                foa.Values(pred_conf),
-            ]
+        ytrue, ytrue_ids, ypred, ypred_ids, confs = samples.values(
+            [gt, gt_id, pred, pred_id, pred_conf]
         )
 
         if is_frame_field:

--- a/fiftyone/utils/labelbox.py
+++ b/fiftyone/utils/labelbox.py
@@ -111,9 +111,7 @@ def import_from_labelbox(
     if labelbox_id_field not in dataset.get_field_schema():
         dataset.add_sample_field(labelbox_id_field, fof.StringField)
 
-    id_map = {}
-    for sample in dataset.select_fields(labelbox_id_field):
-        id_map[sample[labelbox_id_field]] = sample.id
+    id_map = {k: v for k, v in zip(*dataset.values([labelbox_id_field, "id"]))}
 
     if label_prefix:
         label_key = lambda k: label_prefix + "_" + k

--- a/fiftyone/utils/scale.py
+++ b/fiftyone/utils/scale.py
@@ -189,9 +189,7 @@ def import_from_scale(
     else:
         labels = _load_labels_dir(labels_dir_or_json)
 
-    id_map = {}
-    for sample in dataset.select_fields(scale_id_field):
-        id_map[sample[scale_id_field]] = sample.id
+    id_map = {k: v for k, v in zip(*dataset.values([scale_id_field, "id"]))}
 
     if label_prefix:
         label_key = lambda k: label_prefix + "_" + k


### PR DESCRIPTION
Adds support for executing an aggregation on multiple fields via an abbreviated syntax:

```
tuple, of, results = SampleCollection.<aggregation_method>(("tuple", "of", "fields"), **kwargs)
```

Example usage:

```py
import fiftyone as fo
import fiftyone.zoo as foz

dataset = foz.load_zoo_dataset("quickstart")

# old way
ids, filepaths = dataset.aggregate([fo.Values("id"), fo.Values("filepath")])

# new option
ids, filepaths = dataset.values(["id", "filepath"])
```
