### PR TITLE
Adds support for using hashlib to compute filehashes

### DIFF
--- a/fiftyone/core/utils.py
+++ b/fiftyone/core/utils.py
@@ -627,13 +627,16 @@ class UniqueFilenameMaker(object):
         return os.path.join(self.output_dir, filename)
 
 
-def compute_filehash(filepath, method=None):
+def compute_filehash(filepath, method=None, chunk_size=None):
     """Computes the hash of the given file.
 
     Args:
         filepath: the path to the file
         method (None): an optional ``hashlib`` method to use. If not specified,
             the builtin ``str.__hash__`` will be used
+        chunk_size (None): an optional chunk size to use to read the file. Only
+            applicable when a ``method`` is provided. If negative, the entire
+            file is read at once
 
     Returns:
         the hash
@@ -642,10 +645,13 @@ def compute_filehash(filepath, method=None):
         with open(filepath, "rb") as f:
             return hash(f.read())
 
+    if chunk_size is None:
+        chunk_size = 65536
+
     hasher = getattr(hashlib, method)()
     with open(filepath, "rb") as f:
         while True:
-            data = f.read(65536)
+            data = f.read(chunk_size)
             if not data:
                 break
 

--- a/fiftyone/core/utils.py
+++ b/fiftyone/core/utils.py
@@ -634,9 +634,9 @@ def compute_filehash(filepath, method=None, chunk_size=None):
         filepath: the path to the file
         method (None): an optional ``hashlib`` method to use. If not specified,
             the builtin ``str.__hash__`` will be used
-        chunk_size (None): an optional chunk size to use to read the file. Only
-            applicable when a ``method`` is provided. If negative, the entire
-            file is read at once
+        chunk_size (None): an optional chunk size to use to read the file, in
+            bytes. Only applicable when a ``method`` is provided. The default
+            is 64kB. If negative, the entire file is read at once
 
     Returns:
         the hash


### PR DESCRIPTION
Adds support for using `hashlib` to compute filehashes.

This is useful because it allows for computing filehashes of very large files with a fixed amount of RAM.

```py
import fiftyone.core.utils as fou                                                                                                                                            

filepath = "/path/to/video.mp4"

fou.compute_filehash(filepath)                                                                                                                       
# -8704232419244082

fou.compute_filehash(filepath, method="md5")  # 64kb chunks by default                                                                  
# '9d80923030974a4316e468f67a5be1e1'

fou.compute_filehash(filepath, method="md5", chunk_size=-1)  # no chunking
# '9d80923030974a4316e468f67a5be1e1'
```
