### PR TITLE
Server: Always set mime type to text/javascript for .js files

### DIFF
--- a/fiftyone/server/main.py
+++ b/fiftyone/server/main.py
@@ -1398,6 +1398,12 @@ class FileHandler(tornado.web.StaticFileHandler):
         self.set_header("content-length", self.get_content_size())
         self.set_header("x-colab-notebook-cache-control", "no-cache")
 
+    def get_content_type(self):
+        if self.absolute_path.endswith(".js"):
+            return "text/javascript"
+
+        return super().get_content_type()
+
 
 class MediaHandler(FileHandler):
     @classmethod


### PR DESCRIPTION
Resolves #1060 

Tornado, our web server, relies on the `mimetypes` package to set mime types for static files served. And `mimetypes` relies on system configuration which, at least on Windows, is unreliable.

Currently, the override only accounts for `.js` files, which is the only known issue.