### PR TITLE
Open csv files related to open images with a utf8 encoding

### DIFF
--- a/fiftyone/utils/openimages.py
+++ b/fiftyone/utils/openimages.py
@@ -780,7 +780,7 @@ def _get_seg_classes(dataset_dir, classes_map=None, download=True):
         dataset_dir, "segmentation_classes.csv", annot_link, download=download
     )
 
-    with open(seg_cls_txt, "r") as f:
+    with open(seg_cls_txt, "r", encoding="utf8") as f:
         seg_classes_oi = [l.rstrip("\n") for l in f]
 
     seg_classes = [classes_map[c] for c in seg_classes_oi]
@@ -840,7 +840,7 @@ def _parse_csv(filename, dataframe=False):
         data = pd.read_csv(filename)
 
     else:
-        with open(filename, "r", newline="") as csvfile:
+        with open(filename, "r", newline="", encoding="utf8") as csvfile:
             dialect = csv.Sniffer().sniff(csvfile.read(10240))
             csvfile.seek(0)
             if dialect.delimiter in _CSV_DELIMITERS:
@@ -867,7 +867,7 @@ def _parse_image_ids(
     else:
         id_file_ext = os.path.splitext(image_ids_file)[-1]
         if id_file_ext == ".txt":
-            with open(image_ids_file, "r") as f:
+            with open(image_ids_file, "r", encoding="utf8") as f:
                 _image_ids = [i for i in f.readlines()]
 
         elif id_file_ext == ".json":


### PR DESCRIPTION
On Windows, issues can arise when attempting to open UTF-8 encoded files with specifying the encoding when calling `open()`. 

This PR fixes that issue when loading open images.

```shell
Uncaught exception
Traceback (most recent call last):
  File "move.py", line 40, in <module>
    dataset = foz.load_zoo_dataset("open-images-v6", split="validation",)
  File "C:\Users\hkeglovi\Miniconda3\envs\ims\lib\site-packages\fiftyone\zoo\datasets\__init__.py", line 206, in load_zoo_dataset
    **download_kwargs
  File "C:\Users\hkeglovi\Miniconda3\envs\ims\lib\site-packages\fiftyone\zoo\datasets\__init__.py", line 120, in download_zoo_dataset
    cleanup=cleanup,
  File "C:\Users\hkeglovi\Miniconda3\envs\ims\lib\site-packages\fiftyone\zoo\datasets\__init__.py", line 962, in download_and_prepare
    ) = self._download_and_prepare(split_dir, scratch_dir, split)
  File "C:\Users\hkeglovi\Miniconda3\envs\ims\lib\site-packages\fiftyone\zoo\datasets\base.py", line 996, in _download_and_prepare
    max_samples=self.max_samples,
  File "C:\Users\hkeglovi\Miniconda3\envs\ims\lib\site-packages\fiftyone\utils\openimages.py", line 488, in download_open_images_split
    dataset_dir, split, download=True
  File "C:\Users\hkeglovi\Miniconda3\envs\ims\lib\site-packages\fiftyone\utils\openimages.py", line 1512, in _load_all_image_ids
    csv_data = _parse_csv(csv_filepath)
  File "C:\Users\hkeglovi\Miniconda3\envs\ims\lib\site-packages\fiftyone\utils\openimages.py", line 844, in _parse_csv
    dialect = csv.Sniffer().sniff(csvfile.read(10240))
  File "C:\Users\hkeglovi\Miniconda3\envs\ims\lib\encodings\cp1252.py", line 23, in decode
    return codecs.charmap_decode(input,self.errors,decoding_table)[0]
UnicodeDecodeError: 'charmap' codec can't decode byte 0x81 in position 2946: character maps to <undefined>
```