### PR TITLE
Fixes display issues for the `sample_id` patches view field

### DIFF
--- a/app/src/components/FieldsSidebar.tsx
+++ b/app/src/components/FieldsSidebar.tsx
@@ -33,7 +33,7 @@ import { labelModalTagCounts } from "./Actions/utils";
 import * as fieldAtoms from "./Filters/utils";
 import * as labelAtoms from "./Filters/LabelFieldFilters.state";
 import * as selectors from "../recoil/selectors";
-import { FILTERABLE_TYPES, handleKey } from "../utils/labels";
+import { FILTERABLE_TYPES } from "../utils/labels";
 import { useTheme } from "../utils/hooks";
 import { PillButton } from "./utils";
 import { prettify } from "../utils/generic";
@@ -601,6 +601,7 @@ const ScalarsCell = ({ modal }: ScalarsCellProps) => {
   const count = useRecoilValue(countAtom);
   const colorByLabel = useRecoilValue(atoms.colorByLabel(modal));
   const theme = useTheme();
+  const dbFields = useRecoilValue(selectors.scalarsDbMap("sample"));
 
   return (
     <Cell
@@ -620,14 +621,14 @@ const ScalarsCell = ({ modal }: ScalarsCellProps) => {
             hasDropdown: !modal,
             selected: activeScalars.includes(name),
             color: colorByLabel ? theme.brand : colorMap(name),
-            title: modal ? prettify(count[handleKey(name)], false) : name,
+            title: modal ? prettify(count[dbFields[name]], false) : name,
             path: name,
             type: "values",
             data:
               count && subCount && !modal
                 ? makeData(subCount[name], count[name])
                 : modal
-                ? prettify(count[handleKey(name)])
+                ? prettify(count[dbFields[name]])
                 : null,
             totalCount: !modal && count ? count[name] : null,
             filteredCount: !modal && subCount ? subCount[name] : null,

--- a/app/src/components/FieldsSidebar.tsx
+++ b/app/src/components/FieldsSidebar.tsx
@@ -33,7 +33,7 @@ import { labelModalTagCounts } from "./Actions/utils";
 import * as fieldAtoms from "./Filters/utils";
 import * as labelAtoms from "./Filters/LabelFieldFilters.state";
 import * as selectors from "../recoil/selectors";
-import { FILTERABLE_TYPES } from "../utils/labels";
+import { FILTERABLE_TYPES, handleKey } from "../utils/labels";
 import { useTheme } from "../utils/hooks";
 import { PillButton } from "./utils";
 import { prettify } from "../utils/generic";
@@ -620,14 +620,14 @@ const ScalarsCell = ({ modal }: ScalarsCellProps) => {
             hasDropdown: !modal,
             selected: activeScalars.includes(name),
             color: colorByLabel ? theme.brand : colorMap(name),
-            title: modal ? prettify(count[name], false) : name,
+            title: modal ? prettify(count[handleKey(name)], false) : name,
             path: name,
             type: "values",
             data:
               count && subCount && !modal
                 ? makeData(subCount[name], count[name])
                 : modal
-                ? prettify(count[name])
+                ? prettify(count[handleKey(name)])
                 : null,
             totalCount: !modal && count ? count[name] : null,
             filteredCount: !modal && subCount ? subCount[name] : null,

--- a/app/src/components/Sample.tsx
+++ b/app/src/components/Sample.tsx
@@ -13,7 +13,11 @@ import * as selectors from "../recoil/selectors";
 import socket, { http } from "../shared/connection";
 import { packageMessage } from "../utils/socket";
 import { useVideoData, useTheme } from "../utils/hooks";
-import { VALID_CLASS_TYPES, VALID_LIST_TYPES } from "../utils/labels";
+import {
+  handleKey,
+  VALID_CLASS_TYPES,
+  VALID_LIST_TYPES,
+} from "../utils/labels";
 import { prettify } from "../utils/generic";
 
 const SampleDiv = animated(styled.div`
@@ -163,9 +167,9 @@ const SampleInfo = React.memo(({ id }) => {
       }
     } else if (
       scalars.includes(cur) &&
-      ![null, undefined].includes(sample[cur === "id" ? "_id" : cur])
+      ![null, undefined].includes(sample[handleKey(cur)])
     ) {
-      const value = prettify(sample[cur === "id" ? "_id" : cur], false);
+      const value = prettify(sample[handleKey(cur)], false);
       acc = [
         ...acc,
         <Tag

--- a/app/src/components/Sample.tsx
+++ b/app/src/components/Sample.tsx
@@ -13,11 +13,7 @@ import * as selectors from "../recoil/selectors";
 import socket, { http } from "../shared/connection";
 import { packageMessage } from "../utils/socket";
 import { useVideoData, useTheme } from "../utils/hooks";
-import {
-  handleKey,
-  VALID_CLASS_TYPES,
-  VALID_LIST_TYPES,
-} from "../utils/labels";
+import { VALID_CLASS_TYPES, VALID_LIST_TYPES } from "../utils/labels";
 import { prettify } from "../utils/generic";
 
 const SampleDiv = animated(styled.div`
@@ -133,6 +129,8 @@ const SampleInfo = React.memo(({ id }) => {
   const labelTypes = useRecoilValue(selectors.labelTypesMap);
   const sample = useRecoilValue(atoms.sample(id));
 
+  const dbFields = useRecoilValue(selectors.scalarsDbMap("sample"));
+
   const bubbles = activeFields.reduce((acc, cur) => {
     if (
       cur.startsWith("tags.") &&
@@ -167,9 +165,9 @@ const SampleInfo = React.memo(({ id }) => {
       }
     } else if (
       scalars.includes(cur) &&
-      ![null, undefined].includes(sample[handleKey(cur)])
+      ![null, undefined].includes(sample[dbFields[cur]])
     ) {
-      const value = prettify(sample[handleKey(cur)], false);
+      const value = prettify(sample[dbFields[cur]], false);
       acc = [
         ...acc,
         <Tag

--- a/app/src/recoil/selectors.ts
+++ b/app/src/recoil/selectors.ts
@@ -27,6 +27,7 @@ export const deactivated = selector({
   get: ({ get }) => {
     const handle = handleId;
     const activeHandle = get(atoms.stateDescription)?.active_handle;
+
     const notebook = isNotebook;
     if (notebook) {
       return handle !== activeHandle && typeof activeHandle === "string";
@@ -679,6 +680,20 @@ export const scalarsMap = selectorFamily<{ [key: string]: string }, string>({
       (acc, cur, i) => ({
         ...acc,
         [cur]: types[i],
+      }),
+      {}
+    );
+  },
+});
+
+export const scalarsDbMap = selectorFamily<{ [key: string]: string }, string>({
+  key: "scalarsMap",
+  get: (dimension) => ({ get }) => {
+    const values = get(scalars(dimension));
+    return get(scalarNames(dimension)).reduce(
+      (acc, cur, i) => ({
+        ...acc,
+        [cur]: values[i].db_field,
       }),
       {}
     );

--- a/app/src/utils/labels.ts
+++ b/app/src/utils/labels.ts
@@ -442,16 +442,3 @@ export const listSampleLabels = (sample: { [key: string]: Label }) => {
   }
   return labels;
 };
-
-const IDS = {
-  sample_id: "_sample_id",
-  id: "_id",
-};
-
-export const handleKey = (key) => {
-  if (IDS.hasOwnProperty(key)) {
-    return IDS[key];
-  }
-
-  return key;
-};

--- a/app/src/utils/labels.ts
+++ b/app/src/utils/labels.ts
@@ -442,3 +442,16 @@ export const listSampleLabels = (sample: { [key: string]: Label }) => {
   }
   return labels;
 };
+
+const IDS = {
+  sample_id: "_sample_id",
+  id: "_id",
+};
+
+export const handleKey = (key) => {
+  if (IDS.hasOwnProperty(key)) {
+    return IDS[key];
+  }
+
+  return key;
+};


### PR DESCRIPTION
Previously, the `sample_id` tag would not show up on samples in the grid. `None` would also be displayed in the expanded view  for the `sample_id` field.

![Screenshot from 2021-06-22 07-45-26](https://user-images.githubusercontent.com/19821840/122936136-27864780-d32e-11eb-9985-62030cfbbfd9.png)
![Screenshot from 2021-06-22 07-45-17](https://user-images.githubusercontent.com/19821840/122936153-29e8a180-d32e-11eb-881c-138fdb58719f.png)