### PR TITLE
Adding select_by() and exclude_by() stages

### DIFF
--- a/fiftyone/__public__.py
+++ b/fiftyone/__public__.py
@@ -124,6 +124,7 @@ from .core.plots import (
 from .core.sample import Sample
 from .core.stages import (
     Exclude,
+    ExcludeBy,
     ExcludeFields,
     ExcludeFrames,
     ExcludeLabels,
@@ -146,6 +147,7 @@ from .core.stages import (
     Mongo,
     Shuffle,
     Select,
+    SelectBy,
     SelectFields,
     SelectFrames,
     SelectLabels,

--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -1943,6 +1943,52 @@ class SampleCollection(object):
         return self._add_view_stage(fos.Exclude(sample_ids))
 
     @view_stage
+    def exclude_by(self, field, values):
+        """Excludes the samples with the given field values from the
+        collection.
+
+        This stage is typically used to work with categorical fields (strings,
+        ints, and bools). If you want to exclude samples based on floating
+        point fields, use :meth:`match`.
+
+        Examples::
+
+            import fiftyone as fo
+
+            dataset = fo.Dataset()
+            dataset.add_samples(
+                [
+                    fo.Sample(filepath="image%d.jpg" % i, int=i, str=str(i))
+                    for i in range(10)
+                ]
+            )
+
+            #
+            # Create a view excluding samples whose `int` field have the given
+            # values
+            #
+
+            view = dataset.exclude_by("int", [1, 9, 3, 7, 5])
+            print(view.head(5))
+
+            #
+            # Create a view excluding samples whose `str` field have the given
+            # values
+            #
+
+            view = dataset.exclude_by("str", ["1", "9", "3", "7", "5"])
+            print(view.head(5))
+
+        Args:
+            field: a field or ``embedded.field.name``
+            values: a value or iterable of values to exclude by
+
+        Returns:
+            a :class:`fiftyone.core.view.DatasetView`
+        """
+        return self._add_view_stage(fos.ExcludeBy(field, values))
+
+    @view_stage
     def exclude_fields(self, field_names, _allow_missing=False):
         """Excludes the fields with the given names from the samples in the
         collection.
@@ -3612,6 +3658,57 @@ class SampleCollection(object):
             a :class:`fiftyone.core.view.DatasetView`
         """
         return self._add_view_stage(fos.Select(sample_ids, ordered=ordered))
+
+    @view_stage
+    def select_by(self, field, values, ordered=False):
+        """Selects the samples with the given field values from the collection.
+
+        This stage is typically used to work with categorical fields (strings,
+        ints, and bools). If you want to select samples based on floating point
+        fields, use :meth:`match`.
+
+        Examples::
+
+            import fiftyone as fo
+
+            dataset = fo.Dataset()
+            dataset.add_samples(
+                [
+                    fo.Sample(filepath="image%d.jpg" % i, int=i, str=str(i))
+                    for i in range(100)
+                ]
+            )
+
+            #
+            # Create a view containing samples whose `int` field have the given
+            # values
+            #
+
+            view = dataset.select_by("int", [1, 51, 11, 41, 21, 31])
+            print(view.head(6))
+
+            #
+            # Create a view containing samples whose `str` field have the given
+            # values, in order
+            #
+
+            view = dataset.select_by(
+                "str", ["1", "51", "11", "41", "21", "31"], ordered=True
+            )
+            print(view.head(6))
+
+        Args:
+            field: a field or ``embedded.field.name``
+            values: a value or iterable of values to select by
+            ordered (False): whether to sort the samples in the returned view
+                to match the order of the provided values
+
+        Returns:
+            a :class:`fiftyone.core.view.DatasetView`
+        """
+        return self._add_view_stage(
+            fos.SelectBy(field, values, ordered=ordered)
+        )
 
     @view_stage
     def select_fields(self, field_names=None, _allow_missing=False):
@@ -5830,6 +5927,9 @@ class SampleCollection(object):
         return _parse_field_name(
             self, field_name, auto_unwind, omit_terminal_lists, allow_missing
         )
+
+    def _handle_id_fields(self, field_name):
+        return _handle_id_fields(self, field_name)
 
     def _handle_frame_field(self, field_name):
         is_frame_field = self._is_frame_field(field_name)

--- a/fiftyone/core/stages.py
+++ b/fiftyone/core/stages.py
@@ -422,7 +422,7 @@ class ExcludeBy(ViewStage):
     @classmethod
     def _params(cls):
         return [
-            {"name": "field", "type": "field|str", "placeholder": "field",},
+            {"name": "field", "type": "field|str", "placeholder": "field"},
             {
                 "name": "values",
                 "type": "json",
@@ -3834,7 +3834,7 @@ class SelectBy(ViewStage):
     @classmethod
     def _params(cls):
         return [
-            {"name": "field", "type": "field|str", "placeholder": "field",},
+            {"name": "field", "type": "field|str", "placeholder": "field"},
             {
                 "name": "values",
                 "type": "json",

--- a/fiftyone/core/stages.py
+++ b/fiftyone/core/stages.py
@@ -340,6 +340,97 @@ class Exclude(ViewStage):
         ]
 
 
+class ExcludeBy(ViewStage):
+    """Excludes the samples with the given field values from a collection.
+
+    This stage is typically used to work with categorical fields (strings,
+    ints, and bools). If you want to exclude samples based on floating point
+    fields, use :class:`Match`.
+
+    Examples::
+
+        import fiftyone as fo
+
+        dataset = fo.Dataset()
+        dataset.add_samples(
+            [
+                fo.Sample(filepath="image%d.jpg" % i, int=i, str=str(i))
+                for i in range(10)
+            ]
+        )
+
+        #
+        # Create a view excluding samples whose `int` field have the given
+        # values
+        #
+
+        stage = fo.ExcludeBy("int", [1, 9, 3, 7, 5])
+        view = dataset.add_stage(stage)
+        print(view.head(5))
+
+        #
+        # Create a view excluding samples whose `str` field have the given
+        # values
+        #
+
+        stage = fo.ExcludeBy("str", ["1", "9", "3", "7", "5"])
+        view = dataset.add_stage(stage)
+        print(view.head(5))
+
+    Args:
+        field: a field or ``embedded.field.name``
+        values: a value or iterable of values to exclude by
+    """
+
+    def __init__(self, field, values):
+        if etau.is_container(values):
+            values = list(values)
+        else:
+            values = [values]
+
+        self._field = field
+        self._values = values
+
+    @property
+    def field(self):
+        """The field whose values to exclude by."""
+        return self._field
+
+    @property
+    def values(self):
+        """The list of values to exclude by."""
+        return self._values
+
+    def to_mongo(self, sample_collection):
+        field_name, is_id_field, _ = sample_collection._handle_id_fields(
+            self._field
+        )
+
+        if is_id_field:
+            values = [
+                value if isinstance(value, ObjectId) else ObjectId(value)
+                for value in self._values
+            ]
+        else:
+            values = self._values
+
+        return [{"$match": {field_name: {"$not": {"$in": values}}}}]
+
+    def _kwargs(self):
+        return [["field", self._field], ["values", self._values]]
+
+    @classmethod
+    def _params(cls):
+        return [
+            {"name": "field", "type": "field|str", "placeholder": "field",},
+            {
+                "name": "values",
+                "type": "json",
+                "placeholder": "list,of,values",
+            },
+        ]
+
+
 class ExcludeFields(ViewStage):
     """Excludes the fields with the given names from the samples in a
     collection.
@@ -3633,6 +3724,131 @@ class Select(ViewStage):
         ]
 
 
+class SelectBy(ViewStage):
+    """Selects the samples with the given field values from a collection.
+
+    This stage is typically used to work with categorical fields (strings,
+    ints, and bools). If you want to select samples based on floating point
+    fields, use :class:`Match`.
+
+    Examples::
+
+        import fiftyone as fo
+
+        dataset = fo.Dataset()
+        dataset.add_samples(
+            [
+                fo.Sample(filepath="image%d.jpg" % i, int=i, str=str(i))
+                for i in range(100)
+            ]
+        )
+
+        #
+        # Create a view containing samples whose `int` field have the given
+        # values
+        #
+
+        stage = fo.SelectBy("int", [1, 51, 11, 41, 21, 31])
+        view = dataset.add_stage(stage)
+        print(view.head(6))
+
+        #
+        # Create a view containing samples whose `str` field have the given
+        # values, in order
+        #
+
+        stage = fo.SelectBy(
+            "str", ["1", "51", "11", "41", "21", "31"], ordered=True
+        )
+        view = dataset.add_stage(stage)
+        print(view.head(6))
+
+    Args:
+        field: a field or ``embedded.field.name``
+        values: a value or iterable of values to select by
+        ordered (False): whether to sort the samples in the returned view to
+            match the order of the provided values
+    """
+
+    def __init__(self, field, values, ordered=False):
+        if etau.is_container(values):
+            values = list(values)
+        else:
+            values = [values]
+
+        self._field = field
+        self._values = values
+        self._ordered = ordered
+
+    @property
+    def field(self):
+        """The field whose values to select by."""
+        return self._field
+
+    @property
+    def values(self):
+        """The list of values to select by."""
+        return self._values
+
+    @property
+    def ordered(self):
+        """Whether to sort the samples in the same order as the IDs."""
+        return self._ordered
+
+    def to_mongo(self, sample_collection):
+        field_name, is_id_field, _ = sample_collection._handle_id_fields(
+            self._field
+        )
+
+        if is_id_field:
+            values = [
+                value if isinstance(value, ObjectId) else ObjectId(value)
+                for value in self._values
+            ]
+        else:
+            values = self._values
+
+        if not self._ordered:
+            return [{"$match": {field_name: {"$in": values}}}]
+
+        return [
+            {
+                "$set": {
+                    "_select_order": {
+                        "$indexOfArray": [values, "$" + field_name]
+                    }
+                }
+            },
+            {"$match": {"_select_order": {"$gt": -1}}},
+            {"$sort": {"_select_order": 1}},
+            {"$unset": "_select_order"},
+        ]
+
+    def _kwargs(self):
+        return [
+            ["field", self._field],
+            ["values", self._values],
+            ["ordered", self._ordered],
+        ]
+
+    @classmethod
+    def _params(cls):
+        return [
+            {"name": "field", "type": "field|str", "placeholder": "field",},
+            {
+                "name": "values",
+                "type": "json",
+                "placeholder": "list,of,values",
+            },
+            {
+                "name": "ordered",
+                "type": "bool",
+                "default": "False",
+                "placeholder": "ordered (default=False)",
+            },
+        ]
+
+
 class SelectFields(ViewStage):
     """Selects only the fields with the given names from the samples in the
     collection. All other fields are excluded.
@@ -5350,6 +5566,7 @@ _repr.maxother = 30
 # Simple registry for the server to grab available view stages
 _STAGES = [
     Exclude,
+    ExcludeBy,
     ExcludeFields,
     ExcludeFrames,
     ExcludeLabels,
@@ -5372,6 +5589,7 @@ _STAGES = [
     Mongo,
     Shuffle,
     Select,
+    SelectBy,
     SelectFields,
     SelectFrames,
     SelectLabels,


### PR DESCRIPTION
Adding variants of `Select()` and `Exclude()` that allow for selecting/excluding by categorial fields other than just `id`.

These are useful, for example, when your dataset contains an "external" ID field like `coco_id` (int) or `open_images_id` (str) and you'd like to add predictions to your dataset based on these external IDs.

```py
import fiftyone as fo

dataset = fo.Dataset()
dataset.add_samples(
    [
        fo.Sample(filepath="image%d.jpg" % i, int=i, str=str(i))
        for i in range(100)
    ]
)

#
# Create a view containing samples whose `int` field have the given
# values
#

view = dataset.select_by("int", [1, 51, 11, 41, 21, 31])
print(view.head(6))

#
# Create a view containing samples whose `str` field have the given
# values, in order
#

view = dataset.select_by(
    "str", ["1", "51", "11", "41", "21", "31"], ordered=True
)
print(view.head(6))
```
