### PR TITLE
Optimizing implementation of batch aggregations

### DIFF
--- a/docs/source/user_guide/using_aggregations.rst
+++ b/docs/source/user_guide/using_aggregations.rst
@@ -382,12 +382,22 @@ The example below demonstrates this capability:
         ]
     )
 
+    #
     # Count the number of keypoints in the dataset
-    count = dataset.count("keypoints.points[]")
+    #
+    # The `points` list attribute is declared on the `Keypoint` class, so it is
+    # automatically unwound
+    #
+    count = dataset.count("keypoints.points")
     print(count)
     # 5
 
-    # Compute the values in the custom `friends` field of the predictions
+    #
+    # Compute the values in the `friends` field of the predictions
+    #
+    # The `friends` list attribute is a dynamic custom attribute, so we must
+    # explicitly request that it be unwound
+    #
     counts = dataset.count_values("classes.friends[]")
     print(counts)
     # {'dog': 1, 'squirrel': 2, 'rabbit': 1}
@@ -398,24 +408,23 @@ The example below demonstrates this capability:
     dataset's schema without requiring you to explicitly specify this via the
     ``[]`` syntax. This includes the following cases:
 
-    **Top-level lists:** When you write an aggregation that refers to a
+    **Top-level list fields:** When you write an aggregation that refers to a
     top-level list field of a dataset; i.e., ``list_field`` is automatically
     coerced to ``list_field[]``, if necessary.
 
-    **Label lists:** When you write an aggregation that refers to the list
-    field of a |Label| class, such as the
-    :attr:`Detections.detections <fiftyone.core.labels.Detections.detections>`
-    attribute; i.e., ``ground_truth.detections.label`` is automatically
-    coerced to ``ground_truth.detections[].label``, if necessary.
-
     **Frame fields:** When you write an aggregation that refers to a
-    frame-level field of a video dataset; i.e..,
+    frame-level field of a video dataset; i.e.,
     ``frames.classification.label`` is automatically coerced to
     ``frames[].classifcation.label`` if necessary.
 
-    **Tags fields:** When you write an aggregation that refers to the ``tags``
-    attribute of a |Sample| or |Label| object; i.e., ``classification.tags`` is
-    automatically coerced to ``classification.tags[]``, if necessary.
+    **Embedded list fields:** When you write an aggregation that refers to a
+    list attribute that is declared on a |Sample|, |Frame|, or |Label| class,
+    such as the
+    :attr:`Classification.tags <fiftyone.core.labels.Classification.tags>`,
+    :attr:`Detections.detections <fiftyone.core.labels.Detections.detections>`,
+    or :attr:`Keypoint.points <fiftyone.core.labels.Keypoint.points>`
+    attributes; i.e., ``ground_truth.detections.label`` is automatically
+    coerced to ``ground_truth.detections[].label``, if necessary.
 
 .. _aggregations-expressions:
 

--- a/fiftyone/core/aggregations.py
+++ b/fiftyone/core/aggregations.py
@@ -1561,6 +1561,22 @@ def _parse_field_and_expr(
     elif unwind_list_fields:
         pipeline.append({"$project": {path: True}})
 
+    #
+    # @todo remove this restriction?
+    #
+    # `$unwind` cannot be used here. We would need to use a `set_field()` like
+    # approach to manually unwind the nested array field
+    #
+    if unwind_list_fields and other_list_fields:
+        for ufield in unwind_list_fields:
+            for ofield in other_list_fields:
+                if ufield.startswith(ofield + "."):
+                    raise ValueError(
+                        "Cannot unwind nested array field '%s' without also "
+                        "unwinding higher-level array field '%s'"
+                        % (ufield, ofield)
+                    )
+
     for list_field in unwind_list_fields:
         pipeline.append({"$unwind": "$" + list_field})
 

--- a/fiftyone/core/aggregations.py
+++ b/fiftyone/core/aggregations.py
@@ -13,7 +13,6 @@ import eta.core.utils as etau
 
 import fiftyone.core.expressions as foe
 from fiftyone.core.expressions import ViewField as F
-import fiftyone.core.fields as fof
 import fiftyone.core.media as fom
 
 
@@ -64,6 +63,21 @@ class Aggregation(object):
     def _has_big_result(self):
         """Whether the aggregation's result is returned across multiple
         documents.
+
+        This property affects the data passed to :meth:`to_mongo` at runtime.
+        """
+        return False
+
+    @property
+    def _is_big_batchable(self):
+        """Whether the aggregation has big results and its pipeline is defined
+        by a single ``$project`` stage and thus can be combined with other such
+        aggregations.
+
+        :class:`Aggregation` classes for which :meth:`_is_big_batchable` may be
+        ``True`` must accept an optional ``big_field`` parameter in their
+        :meth:`to_mongo` method that specifies the field name to use in its
+        ``$project`` stage.
         """
         return False
 
@@ -84,7 +98,8 @@ class Aggregation(object):
         """Parses the output of :meth:`to_mongo`.
 
         Args:
-            d: the result dict
+            d: the result dict, or, when :meth:`_is_big_batchable` is True, the
+                iterable of result dicts
 
         Returns:
             the aggregation result
@@ -93,6 +108,9 @@ class Aggregation(object):
 
     def default_result(self):
         """Returns the default result for this aggregation.
+
+        Default results are used when aggregations are applied to empty
+        collections.
 
         Returns:
             the aggregation result
@@ -1332,6 +1350,7 @@ class Values(Aggregation):
         self._unwind = unwind
         self._allow_missing = _allow_missing
         self._big_result = _big_result
+        self._big_field = None
         self._raw = _raw
         self._parse_fcn = None
         self._num_list_fields = None
@@ -1339,6 +1358,16 @@ class Values(Aggregation):
     @property
     def _has_big_result(self):
         return self._big_result
+
+    @property
+    def _is_big_batchable(self):
+        return (
+            self._big_result
+            and not self._unwind
+            and self._expr is None
+            and self._field_name is not None
+            and "[]" not in self._field_name
+        )
 
     def default_result(self):
         """Returns the default result for this aggregation.
@@ -1358,7 +1387,7 @@ class Values(Aggregation):
             the list of field values
         """
         if self._big_result:
-            values = [di["value"] for di in d]
+            values = [di[self._big_field] for di in d]
         else:
             values = d["values"]
 
@@ -1371,7 +1400,7 @@ class Values(Aggregation):
 
         return values
 
-    def to_mongo(self, sample_collection):
+    def to_mongo(self, sample_collection, big_field="values"):
         path, pipeline, list_fields, id_to_str = _parse_field_and_expr(
             sample_collection,
             self._field_name,
@@ -1389,6 +1418,7 @@ class Values(Aggregation):
             if field_type is not None:
                 parse_fcn = field_type.to_python
 
+        self._big_field = big_field
         self._parse_fcn = parse_fcn
         self._num_list_fields = len(list_fields)
 
@@ -1399,6 +1429,7 @@ class Values(Aggregation):
                 id_to_str,
                 self._missing_value,
                 self._big_result,
+                big_field,
             )
         )
 
@@ -1416,7 +1447,7 @@ def _transform_values(values, fcn, level=1):
 
 
 def _make_extract_values_pipeline(
-    path, list_fields, id_to_str, missing_value, big_result
+    path, list_fields, id_to_str, missing_value, big_result, big_field
 ):
     if not list_fields:
         root = path
@@ -1424,6 +1455,9 @@ def _make_extract_values_pipeline(
         root = list_fields[0]
 
     expr = F().to_string() if id_to_str else F()
+
+    # This is important, even if `missing_value` is None, since we need to
+    # insert `None` for documents with missing fields
     expr = (F() != None).if_else(expr, missing_value)
 
     if list_fields:
@@ -1437,16 +1471,13 @@ def _make_extract_values_pipeline(
             inner_list_field = list_field2[len(list_field1) + 1 :]
             expr = _extract_list_values(inner_list_field, expr)
 
-    pipeline = [{"$set": {root: expr.to_mongo(prefix="$" + root)}}]
-
     if big_result:
-        pipeline.append({"$project": {"value": "$" + root}})
-    else:
-        pipeline.append(
-            {"$group": {"_id": None, "values": {"$push": "$" + root}}}
-        )
+        return [{"$project": {big_field: expr.to_mongo(prefix="$" + root)}}]
 
-    return pipeline
+    return [
+        {"$project": {"value": expr.to_mongo(prefix="$" + root)}},
+        {"$group": {"_id": None, "values": {"$push": "$value"}}},
+    ]
 
 
 def _extract_list_values(subfield, expr):
@@ -1509,20 +1540,20 @@ def _parse_field_and_expr(
     if expr is not None:
         id_to_str = False  # we have no way of knowing what type expr outputs
 
-    if is_frame_field and auto_unwind:
-        pipeline.extend(
-            [{"$unwind": "$frames"}, {"$replaceRoot": {"newRoot": "$frames"}}]
-        )
+    if auto_unwind:
+        if is_frame_field:
+            pipeline.extend(
+                [
+                    {"$project": {"frames." + path: True}},
+                    {"$unwind": "$frames"},
+                    {"$replaceRoot": {"newRoot": "$frames"}},
+                ]
+            )
+        else:
+            pipeline.append({"$project": {path: True}})
 
     for list_field in unwind_list_fields:
         pipeline.append({"$unwind": "$" + list_field})
-
-    if other_list_fields:
-        root = other_list_fields[0]
-    else:
-        root = path
-
-    pipeline.append({"$project": {root: True}})
 
     return path, pipeline, other_list_fields, id_to_str
 

--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -5687,6 +5687,7 @@ class SampleCollection(object):
             attach_frames |= _attach_frames
 
             try:
+                assert len(_pipeline) == 1
                 project[big_field] = _pipeline[0]["$project"][big_field]
             except:
                 raise ValueError(

--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -5558,8 +5558,8 @@ class SampleCollection(object):
         :class:`fiftyone.core.aggregations.Aggregation` instances.
 
         Note that it is best practice to group aggregations into a single call
-        to :meth:`aggregate() <aggregate>`, as this will be more efficient than
-        performing multiple aggregations in series.
+        to :meth:`aggregate`, as this will be more efficient than performing
+        multiple aggregations in series.
 
         Args:
             aggregations: an :class:`fiftyone.core.aggregations.Aggregation` or
@@ -5578,21 +5578,35 @@ class SampleCollection(object):
         if scalar_result:
             aggregations = [aggregations]
 
-        # Partition into big and facet-able aggregations
-        big_aggs, facet_aggs = self._parse_aggregations(aggregations)
+        # Partition aggregations by type
+        big_aggs, batch_aggs, facet_aggs = self._parse_aggregations(
+            aggregations, allow_big=True
+        )
 
         # Placeholder to store results
         results = [None] * len(aggregations)
 
         # Run big aggregations
         for idx, aggregation in big_aggs.items():
-            pipeline, attach_frames = self._build_pipeline(aggregation)
+            pipeline, attach_frames = self._build_big_pipeline(aggregation)
 
             result = self._aggregate(
                 pipeline=pipeline, attach_frames=attach_frames
             )
 
             results[idx] = self._parse_big_results(aggregation, result)
+
+        # Run batched big aggregations
+        if batch_aggs:
+            pipeline, attach_frames = self._build_batch_pipeline(batch_aggs)
+
+            result = self._aggregate(
+                pipeline=pipeline, attach_frames=attach_frames
+            )
+            result = list(result)
+
+            for idx, aggregation in batch_aggs.items():
+                results[idx] = self._parse_big_results(aggregation, result)
 
         # Run faceted aggregations
         if facet_aggs:
@@ -5616,17 +5630,11 @@ class SampleCollection(object):
         if scalar_result:
             aggregations = [aggregations]
 
-        # Partition into big and facet-able aggregations
-        big_aggs, facet_aggs = self._parse_aggregations(aggregations)
+        _, _, facet_aggs = self._parse_aggregations(
+            aggregations, allow_big=False
+        )
 
-        # Placeholder to store results
         results = [None] * len(aggregations)
-
-        if big_aggs:
-            raise ValueError(
-                "This method does not support aggregations that return big "
-                "results"
-            )
 
         if facet_aggs:
             pipeline, attach_frames = self._build_faceted_pipeline(facet_aggs)
@@ -5643,27 +5651,52 @@ class SampleCollection(object):
 
         return results[0] if scalar_result else results
 
-    def _parse_aggregations(self, aggregations):
+    def _parse_aggregations(self, aggregations, allow_big=True):
         big_aggs = {}
+        batch_aggs = {}
         facet_aggs = {}
         for idx, aggregation in enumerate(aggregations):
-            if aggregation._has_big_result:
+            if aggregation._is_big_batchable:
+                batch_aggs[idx] = aggregation
+            elif aggregation._has_big_result:
                 big_aggs[idx] = aggregation
             else:
                 facet_aggs[idx] = aggregation
 
-        return big_aggs, facet_aggs
+        if not allow_big and (big_aggs or batch_aggs):
+            raise ValueError(
+                "This method does not support aggregations that return big "
+                "results"
+            )
 
-    def _build_pipeline(self, aggregation):
-        pipeline = aggregation.to_mongo(self)
+        return big_aggs, batch_aggs, facet_aggs
+
+    def _build_big_pipeline(self, aggregation, big_field="values"):
+        pipeline = aggregation.to_mongo(self, big_field=big_field)
         attach_frames = aggregation._needs_frames(self)
         return pipeline, attach_frames
 
-    def _parse_big_results(self, aggregation, result):
-        if result:
-            return aggregation.parse_result(result)
+    def _build_batch_pipeline(self, aggs_map):
+        project = {}
+        attach_frames = False
+        for idx, aggregation in aggs_map.items():
+            big_field = "value%d" % idx
+            _pipeline, _attach_frames = self._build_big_pipeline(
+                aggregation, big_field=big_field
+            )
+            attach_frames |= _attach_frames
 
-        return aggregation.default_result()
+            try:
+                project[big_field] = _pipeline[0]["$project"][big_field]
+            except:
+                raise ValueError(
+                    "Batchable aggregations must have pipelines with a single "
+                    "$project stage; found %s" % _pipeline
+                )
+
+        pipeline = [{"$project": project}]
+
+        return pipeline, attach_frames
 
     def _build_faceted_pipeline(self, aggs_map):
         facets = {}
@@ -5676,6 +5709,12 @@ class SampleCollection(object):
         facet_pipeline = [{"$facet": facets}]
 
         return facet_pipeline, attach_frames
+
+    def _parse_big_results(self, aggregation, result):
+        if result:
+            return aggregation.parse_result(result)
+
+        return aggregation.default_result()
 
     def _parse_faceted_results(self, aggs_map, result, results):
         for idx, aggregation in aggs_map.items():


### PR DESCRIPTION
A common pattern in various places in the codebase are batch aggregations like this:

```py
list, of, results = dataset.values(["list", "of", "fields"])

list, of, results = dataset.aggregate([fo.Values("list"), fo.Values("of"), fo.Values("fields")])
```

For aggregations **other than** `Values()`, such operations are already quite efficient, as they are executed via `$facet` with a single pass over the documents in the DB.

For `Values()`, `$facet` is not an option because it returns results in a single document, which could easily violate the 16MB limit. Thus, currently, if an aggregation is executed that contains multiple `Values()` instances, those aggregations are run in series, each requiring a separate pass over the DB.

For `Values()` operations that involve unwinding of fields, I don't see any obvious ways to avoid these multiple passes. However, when multiple `Values()` calls with no unwinding are executed as a batch, they could be executed in a single pass over the database by merging their `$project` stages into a single stage. This PR implements this merging + subsequent unpacking of the aggregation results into separate lists.

The benchmarks below show that this change can 2x+ the performance of aggregations that involve multiple `Values()` invocations.

```py
import eta.core.utils as etau
import fiftyone.zoo as foz

dataset = foz.load_zoo_dataset("bdd100k", split="validation")

#
# before and after: uses facets (but would not scale >16MB)
# Time elapsed: 1.1 seconds
#

with etau.Timer():
    dataset.values(
        [
            "id",
            "filepath",
            "ground_truth_detections.detections.label",
            "ground_truth_detections.detections.confidence",
            "ground_truth_polylines.polylines.label",
            "ground_truth_polylines.polylines.confidence",
            "ground_truth_polylines.polylines.filled",
            "ground_truth_polylines.polylines.closed",
        ],
        _big_result=False,  # forces $facet to be used
    )

#
# before: runs aggregations in series
# Time elapsed: 1.6 seconds
#
# after: single aggregation pass
# Time elapsed: 709.9ms
#

with etau.Timer():
    dataset.values(
        [
            "id",
            "filepath",
            "ground_truth_detections.detections.label",
            "ground_truth_detections.detections.confidence",
            "ground_truth_polylines.polylines.label",
            "ground_truth_polylines.polylines.confidence",
            "ground_truth_polylines.polylines.filled",
            "ground_truth_polylines.polylines.closed",
        ]
    )
```
