### PR TITLE
Don't allow migrations involving future FiftyOne versions

### DIFF
--- a/docs/source/getting_started/install.rst
+++ b/docs/source/getting_started/install.rst
@@ -232,9 +232,9 @@ Here's the workflow for downgrading to an older version of FiftyOne:
     pip install fiftyone==$VERSION
 
 If you are reading this after encountering an error resulting from downgrading
-your ``fiftyone`` package without first running ``fiftyone migrate``, don't
-worry, you simply need to reinstall the newer version of FiftyOne and then
-follow these instructions.
+your ``fiftyone`` package without first running
+:ref:`fiftyone migrate <cli-fiftyone-migrate>`, don't worry, you simply need to
+reinstall the newer version of FiftyOne and then follow these instructions.
 
 .. note::
 

--- a/docs/source/getting_started/install.rst
+++ b/docs/source/getting_started/install.rst
@@ -211,24 +211,30 @@ If you need to downgrade to an older version of FiftyOne for any reason, you
 can do so.
 
 Since new releases occasionally introduce backwards-incompatible changes to the
-data model, we provide a :ref:`fiftyone migrate <cli-fiftyone-migrate>` command
-that can perform any necessary downward database migrations.
+data model, you must use the :ref:`fiftyone migrate <cli-fiftyone-migrate>`
+command to perform any necessary downward database migrations
+**before installing the older version of FiftyOne**.
 
 Here's the workflow for downgrading to an older version of FiftyOne:
 
 .. code-block:: shell
 
     # The version that you wish to downgrade to
-    VERSION=0.7.1  # for example
+    VERSION=0.9.4  # for example
 
     # Migrate the database
     fiftyone migrate --all -v $VERSION
 
-    # Verify that all of your datasets were migrated
+    # Optional: verify that your datasets were migrated
     fiftyone migrate --info
 
     # Now install the older version of `fiftyone`
     pip install fiftyone==$VERSION
+
+If you are reading this after encountering an error resulting from downgrading
+FiftyOne without first running ``fiftyone migrate``, don't worry, you simply
+need to reinstall the newer version of FiftyOne and then follow these
+instructions.
 
 .. note::
 

--- a/docs/source/getting_started/install.rst
+++ b/docs/source/getting_started/install.rst
@@ -232,9 +232,9 @@ Here's the workflow for downgrading to an older version of FiftyOne:
     pip install fiftyone==$VERSION
 
 If you are reading this after encountering an error resulting from downgrading
-FiftyOne without first running ``fiftyone migrate``, don't worry, you simply
-need to reinstall the newer version of FiftyOne and then follow these
-instructions.
+your ``fiftyone`` package without first running ``fiftyone migrate``, don't
+worry, you simply need to reinstall the newer version of FiftyOne and then
+follow these instructions.
 
 .. note::
 

--- a/fiftyone/migrations/runner.py
+++ b/fiftyone/migrations/runner.py
@@ -177,7 +177,7 @@ def migrate_dataset_if_necessary(name, destination=None, verbose=False):
 
     if Version(destination) >= Version("0.6.2"):
         conn = foo.get_db_conn()
-        dataset_doc = conn.datasets.update_one(
+        conn.datasets.update_one(
             {"name": name}, {"$set": {"version": destination}}
         )
     else:
@@ -205,6 +205,17 @@ class MigrationRunner(object):
 
         if destination is None:
             destination = foc.VERSION
+
+        pkg_ver = Version(foc.VERSION)
+        head_ver = Version(head)
+        dest_ver = Version(destination)
+        if head_ver > pkg_ver or dest_ver > pkg_ver:
+            raise ValueError(
+                "Cannot migrate from v%s to v%s using fiftyone==%s. See "
+                "https://voxel51.com/docs/fiftyone/getting_started/install.html#downgrading-fiftyone "
+                "for information about downgrading FiftyOne"
+                % (head_ver, dest_ver, pkg_ver)
+            )
 
         if _revisions is None:
             _revisions = _get_all_revisions()

--- a/fiftyone/migrations/runner.py
+++ b/fiftyone/migrations/runner.py
@@ -210,11 +210,12 @@ class MigrationRunner(object):
         head_ver = Version(head)
         dest_ver = Version(destination)
         if head_ver > pkg_ver or dest_ver > pkg_ver:
-            raise ValueError(
-                "Cannot migrate from v%s to v%s using fiftyone==%s. See "
-                "https://voxel51.com/docs/fiftyone/getting_started/install.html#downgrading-fiftyone "
-                "for information about downgrading FiftyOne"
-                % (head_ver, dest_ver, pkg_ver)
+            raise EnvironmentError(
+                "You must have fiftyone>=%s installed in order to migrate "
+                "from v%s to v%s, but you are currently running fiftyone==%s."
+                "\n\nSee https://voxel51.com/docs/fiftyone/getting_started/install.html#downgrading-fiftyone "
+                "for information about downgrading FiftyOne."
+                % (max(head_ver, dest_ver), head_ver, dest_ver, pkg_ver)
             )
 
         if _revisions is None:

--- a/tests/unittests/utils_tests.py
+++ b/tests/unittests/utils_tests.py
@@ -215,6 +215,26 @@ class MigrationTests(unittest.TestCase):
         )
         self.assertEqual(runner.revisions, ["0.3", "0.2", "0.1"])
 
+    def test_future(self):
+        pkg_ver = foc.VERSION
+        future_ver = str(int(pkg_ver[0]) + 1) + pkg_ver[1:]
+
+        # Uprading to a future version is not allowed
+
+        with self.assertRaises(EnvironmentError):
+            MigrationRunner(destination=future_ver)
+
+        with self.assertRaises(EnvironmentError):
+            MigrationRunner(head="0.1", destination=future_ver)
+
+        # Downgrading from a future version is not allowed
+
+        with self.assertRaises(EnvironmentError):
+            MigrationRunner(head=future_ver)
+
+        with self.assertRaises(EnvironmentError):
+            MigrationRunner(head=future_ver, destination="0.1")
+
 
 class UIDTests(unittest.TestCase):
     def test_log_import(self):


### PR DESCRIPTION
Resolves https://github.com/voxel51/fiftyone/issues/1094
Resolves https://github.com/voxel51/fiftyone/issues/1095

Running a migration that involves a future version of the FiftyOne package should not be allowed, since the currently installed version of `fiftyone` is not aware of any upward/downward migrations that may be introduced in future versions of the package.

**For discussion:**
Although this is technically correct, I wonder if there is some middle ground we can achieve here, since this will now *always* raise an error whenever anyone tries to downgrade their installation without following the docs instructions, while many times no migration would be required...

This can be tested as follows:

```shell
# manually increase version in `setup.py` to a future version, say 0.11.2
pip install -e .
fiftyone zoo datasets load quickstart

# undo `setup.py` change
pip install -e .
fiftyone datasets info quickstart  # raises error shown below
```

```
OSError: You must have fiftyone>=0.11.2 installed in order to migrate from v0.11.2 to v0.11.1, but you are currently running fiftyone==0.11.1.

See https://voxel51.com/docs/fiftyone/getting_started/install.html#downgrading-fiftyone for information about downgrading FiftyOne.
```

Updated documentation:

<img width="865" alt="Screen Shot 2021-07-02 at 2 59 45 PM" src="https://user-images.githubusercontent.com/25985824/124323026-2d5a0500-db46-11eb-85ee-59b9a8efc5ab.png">
