### PR TITLE
Fixed aws error 404 bug on windows

### DIFF
--- a/fiftyone/utils/openimages.py
+++ b/fiftyone/utils/openimages.py
@@ -14,6 +14,7 @@ import multiprocessing
 import os
 import random
 import warnings
+import re
 
 import boto3
 import botocore
@@ -1628,7 +1629,7 @@ def _download_images_if_necessary(
     num_existing = 0
     for image_id in image_ids:
         fp = os.path.join(data_dir, image_id + ".jpg")
-        fp_download = os.path.join(split, image_id + ".jpg")
+        fp_download = re.sub(r"\\", "/", os.path.join(split, image_id + ".jpg"))
         if not os.path.isfile(fp):
             inputs.append((fp, fp_download))
         else:


### PR DESCRIPTION
At the moment, an error 404 is raised when calling "_download_images_if_necessary" on windows, since windows style paths are used when downloading from the s3 storage. This changes should prevent this bug. For details, see stackoverflow: https://stackoverflow.com/questions/68229288/fail-to-load-a-subpart-of-open-images-v6-with-fiftyone/

## What changes are proposed in this pull request?

Added a regex to convert windows stype paths to linux for s3 downloads.

## How is this patch tested? If it is not, please explain why.

Tested on windows 10 with python 3.9. Changes should not have any effect on other os.

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [X] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.


### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [X] Other
