### PR TITLE
Handling unlabeled datasets in COCODetectionDatasetImporter

### DIFF
--- a/fiftyone/utils/coco.py
+++ b/fiftyone/utils/coco.py
@@ -382,7 +382,15 @@ class COCODetectionDatasetImporter(
         image_metadata = fom.ImageMetadata(width=width, height=height)
 
         if self._annotations is None:
-            return image_path, image_metadata, None
+            if "coco_id" in self.label_types:
+                if self._has_scalar_labels:
+                    label = image_id
+                else:
+                    label = {"coco_id": image_id}
+            else:
+                label = None
+
+            return image_path, image_metadata, label
 
         coco_objects = self._annotations.get(image_id, [])
         frame_size = (width, height)
@@ -1412,7 +1420,7 @@ def _download_coco_dataset_split(
         )
 
     if classes is not None and split == "test":
-        logger.warning("Test split is unlabeled; ignoring `classes`")
+        logger.warning("Test split is unlabeled; ignoring classes requirement")
         classes = None
 
     if scratch_dir is None:
@@ -1746,6 +1754,10 @@ def _do_download(args):
 def _get_images_with_classes(
     image_ids, annotations, target_classes, all_classes
 ):
+    if annotations is None:
+        logger.warning("Dataset is unlabeled; ignoring classes requirement")
+        return image_ids, []
+
     if etau.is_str(target_classes):
         target_classes = [target_classes]
 


### PR DESCRIPTION
Previously, providing a `classes` requirement to `COCODetectionDatasetImporter` when loading an unlabeled dataset would raise an error. Now, the `classes` will be ignored in this case and a warning to this effect printed.

This change allows the code below to successfully run (with a warning), which is a better behavior than an unhelpful error message:

```py
import fiftyone as fo
import fiftyone.zoo as foz

# warns that classes requirement must be ignored for test split, which is unlabeled
dataset = foz.load_zoo_dataset(
    "coco-2017",
    splits=["train", "test"],
    classes=["person", "dog", "car", "clock", "horse"],
    only_matching=True,
    include_id=True,
    max_samples=100,
)

print(dataset)
```
