### PR TITLE
Add progress flag to track iter_samples() progress

### DIFF
--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -345,8 +345,12 @@ class SampleCollection(object):
         """
         raise NotImplementedError("Subclass must implement view()")
 
-    def iter_samples(self):
+    def iter_samples(self, progress=False):
         """Returns an iterator over the samples in the collection.
+
+        Args:
+            progress (False): whether to render a progress bar tracking the
+                iterator's progress
 
         Returns:
             an iterator over :class:`fiftyone.core.sample.Sample` or

--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -1257,16 +1257,25 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
             self._frame_doc_cls._delete_embedded_fields(embedded_fields)
             fofr.Frame._reload_docs(self._frame_collection_name)
 
-    def iter_samples(self):
+    def iter_samples(self, progress=False):
         """Returns an iterator over the samples in the dataset.
+
+        Args:
+            progress (False): whether to render a progress bar tracking the
+                iterator's progress
 
         Returns:
             an iterator over :class:`fiftyone.core.sample.Sample` instances
         """
         pipeline = self._pipeline(detach_frames=True)
 
-        for sample in self._iter_samples(pipeline):
-            yield sample
+        if progress:
+            with fou.ProgressBar(total=len(self)) as pb:
+                for sample in pb(self._iter_samples(pipeline)):
+                    yield sample
+        else:
+            for sample in self._iter_samples(pipeline):
+                yield sample
 
     def _iter_samples(self, pipeline):
         index = 0

--- a/fiftyone/core/view.py
+++ b/fiftyone/core/view.py
@@ -265,12 +265,25 @@ class DatasetView(foc.SampleCollection):
         """
         return copy(self)
 
-    def iter_samples(self):
+    def iter_samples(self, progress=False):
         """Returns an iterator over the samples in the view.
+
+        Args:
+            progress (False): whether to render a progress bar tracking the
+                iterator's progress
 
         Returns:
             an iterator over :class:`fiftyone.core.sample.SampleView` instances
         """
+        if progress:
+            with fou.ProgressBar(total=len(self)) as pb:
+                for sample in pb(self._iter_samples()):
+                    yield sample
+        else:
+            for sample in self._iter_samples():
+                yield sample
+
+    def _iter_samples(self):
         sample_cls = self._SAMPLE_CLS
         selected_fields, excluded_fields = self._get_selected_excluded_fields()
         filtered_fields = self._get_filtered_fields()

--- a/tests/unittests/dataset_tests.py
+++ b/tests/unittests/dataset_tests.py
@@ -116,6 +116,19 @@ class DatasetTests(unittest.TestCase):
         self.assertIs(dataset1c, dataset1)
 
     @drop_datasets
+    def test_iter_samples(self):
+        dataset = fo.Dataset()
+        dataset.add_samples(
+            [fo.Sample(filepath="image%d.jpg" % i) for i in range(50)]
+        )
+
+        for sample in dataset:
+            pass
+
+        for sample in dataset.iter_samples(progress=True):
+            pass
+
+    @drop_datasets
     def test_merge_samples1(self):
         # Windows compatibility
         def expand_path(path):

--- a/tests/unittests/view_tests.py
+++ b/tests/unittests/view_tests.py
@@ -21,6 +21,23 @@ from decorators import drop_datasets
 
 class DatasetViewTests(unittest.TestCase):
     @drop_datasets
+    def test_iter_samples(self):
+        dataset = fo.Dataset()
+        dataset.add_samples(
+            [fo.Sample(filepath="image%d.jpg" % i) for i in range(50)]
+        )
+
+        view = dataset.view()
+
+        self.assertEqual(len(dataset), len(view))
+
+        for sample in view:
+            pass
+
+        for sample in view.iter_samples(progress=True):
+            pass
+
+    @drop_datasets
     def test_view(self):
         dataset = fo.Dataset()
         dataset.add_sample_field(


### PR DESCRIPTION
Adds an optional `progress` flag to `SampleCollection.iter_samples()` that provides a convenient way to render a progress bar tracking the progress of an operation:

```py
import fiftyone.zoo as foz

dataset = foz.load_zoo_dataset("quickstart")

for sample in dataset.iter_samples(progress=True):
    pass

for sample in dataset.take(100).iter_samples(progress=True):
    pass
```
