### PR TITLE
Improvements to Open Images partial downloads

### DIFF
--- a/fiftyone/utils/coco.py
+++ b/fiftyone/utils/coco.py
@@ -324,10 +324,9 @@ class COCODetectionDatasetImporter(
             default="labels.json",
         )
 
-        label_types = _parse_label_types(label_types)
-
+        _label_types = _parse_label_types(label_types)
         if include_id:
-            label_types.append("coco_id")
+            _label_types.append("coco_id")
 
         super().__init__(
             dataset_dir=dataset_dir,
@@ -346,6 +345,7 @@ class COCODetectionDatasetImporter(
         self.use_polylines = use_polylines
         self.tolerance = tolerance
 
+        self._label_types = _label_types
         self._info = None
         self._classes = None
         self._supercategory_map = None
@@ -394,7 +394,7 @@ class COCODetectionDatasetImporter(
 
         label = {}
 
-        if "detections" in self.label_types:
+        if "detections" in self._label_types:
             detections = _coco_objects_to_detections(
                 coco_objects,
                 frame_size,
@@ -405,7 +405,7 @@ class COCODetectionDatasetImporter(
             if detections is not None:
                 label["detections"] = detections
 
-        if "segmentations" in self.label_types:
+        if "segmentations" in self._label_types:
             if self.use_polylines:
                 segmentations = _coco_objects_to_polylines(
                     coco_objects,
@@ -426,7 +426,7 @@ class COCODetectionDatasetImporter(
             if segmentations is not None:
                 label["segmentations"] = segmentations
 
-        if "keypoints" in self.label_types:
+        if "keypoints" in self._label_types:
             keypoints = _coco_objects_to_keypoints(
                 coco_objects, frame_size, self._classes
             )
@@ -434,7 +434,7 @@ class COCODetectionDatasetImporter(
             if keypoints is not None:
                 label["keypoints"] = keypoints
 
-        if "coco_id" in self.label_types:
+        if "coco_id" in self._label_types:
             label["coco_id"] = image_id
 
         if self._has_scalar_labels:
@@ -452,7 +452,7 @@ class COCODetectionDatasetImporter(
 
     @property
     def _has_scalar_labels(self):
-        return len(self.label_types) == 1
+        return len(self._label_types) == 1
 
     @property
     def label_cls(self):
@@ -465,9 +465,9 @@ class COCODetectionDatasetImporter(
         }
 
         if self._has_scalar_labels:
-            return types[self.label_types[0]]
+            return types[self._label_types[0]]
 
-        return {k: v for k, v in types.items() if k in self.label_types}
+        return {k: v for k, v in types.items() if k in self._label_types}
 
     def setup(self):
         self._image_paths_map = self._load_data_map(self.data_path)

--- a/fiftyone/utils/openimages.py
+++ b/fiftyone/utils/openimages.py
@@ -14,7 +14,6 @@ import multiprocessing
 import os
 import random
 import warnings
-import re
 
 import boto3
 import botocore
@@ -97,10 +96,9 @@ class OpenImagesV6DatasetImporter(foud.LabeledImageDatasetImporter):
         seed=None,
         max_samples=None,
     ):
-        label_types = _parse_label_types(label_types)
-
+        _label_types = _parse_label_types(label_types)
         if include_id:
-            label_types.append("open_images_id")
+            _label_types.append("open_images_id")
 
         super().__init__(
             dataset_dir=dataset_dir,
@@ -116,6 +114,7 @@ class OpenImagesV6DatasetImporter(foud.LabeledImageDatasetImporter):
         self.only_matching = only_matching
         self.load_hierarchy = load_hierarchy
 
+        self._label_types = _label_types
         self._images_map = None
         self._info = None
         self._classes_map = None
@@ -141,7 +140,7 @@ class OpenImagesV6DatasetImporter(foud.LabeledImageDatasetImporter):
 
         label = {}
 
-        if "classifications" in self.label_types:
+        if "classifications" in self._label_types:
             # Add labels
             pos_labels, neg_labels = _create_classifications(
                 self._cls_data, image_id, self._classes_map
@@ -152,7 +151,7 @@ class OpenImagesV6DatasetImporter(foud.LabeledImageDatasetImporter):
             if neg_labels is not None:
                 label["negative_labels"] = neg_labels
 
-        if "detections" in self.label_types:
+        if "detections" in self._label_types:
             # Add detections
             detections = _create_detections(
                 self._det_data, image_id, self._classes_map
@@ -160,7 +159,7 @@ class OpenImagesV6DatasetImporter(foud.LabeledImageDatasetImporter):
             if detections is not None:
                 label["detections"] = detections
 
-        if "segmentations" in self.label_types:
+        if "segmentations" in self._label_types:
             # Add segmentations
             segmentations = _create_segmentations(
                 self._seg_data, image_id, self._classes_map, self.dataset_dir,
@@ -168,7 +167,7 @@ class OpenImagesV6DatasetImporter(foud.LabeledImageDatasetImporter):
             if segmentations is not None:
                 label["segmentations"] = segmentations
 
-        if "relationships" in self.label_types:
+        if "relationships" in self._label_types:
             # Add relationships
             relationships = _create_relationships(
                 self._rel_data, image_id, self._classes_map, self._attrs_map
@@ -176,7 +175,7 @@ class OpenImagesV6DatasetImporter(foud.LabeledImageDatasetImporter):
             if relationships is not None:
                 label["relationships"] = relationships
 
-        if "open_images_id" in self.label_types:
+        if "open_images_id" in self._label_types:
             label["open_images_id"] = image_id
 
         if self._has_scalar_labels:
@@ -195,8 +194,8 @@ class OpenImagesV6DatasetImporter(foud.LabeledImageDatasetImporter):
     @property
     def _has_scalar_labels(self):
         return (
-            len(self.label_types) == 1
-            and self.label_types[0] != "classifications"
+            len(self._label_types) == 1
+            and self._label_types[0] != "classifications"
         )
 
     @property
@@ -210,9 +209,9 @@ class OpenImagesV6DatasetImporter(foud.LabeledImageDatasetImporter):
         }
 
         if self._has_scalar_labels:
-            return types[self.label_types[0]]
+            return types[self._label_types[0]]
 
-        return {k: v for k, v in types.items() if k in self.label_types}
+        return {k: v for k, v in types.items() if k in self._label_types}
 
     def setup(self):
         dataset_dir = self.dataset_dir
@@ -248,7 +247,6 @@ class OpenImagesV6DatasetImporter(foud.LabeledImageDatasetImporter):
             image_ids = available_ids
 
         (
-            label_types,
             classes_map,
             all_classes,
             classes,
@@ -279,9 +277,9 @@ class OpenImagesV6DatasetImporter(foud.LabeledImageDatasetImporter):
         ) = _get_all_label_data(
             dataset_dir,
             image_ids,
-            label_types,
-            classes,
-            oi_classes,
+            label_types=label_types,
+            classes=classes,
+            oi_classes=oi_classes,
             attrs=attrs,
             oi_attrs=oi_attrs,
             seg_classes=seg_classes,
@@ -616,8 +614,6 @@ def _download_open_images_split(
 ):
     _verify_version(version)
 
-    label_types = _parse_label_types(label_types)
-
     if image_ids is not None:
         image_ids = _parse_and_verify_image_ids(
             image_ids, dataset_dir, split, download=download
@@ -630,7 +626,6 @@ def _download_open_images_split(
     downloaded_ids = _get_downloaded_image_ids(dataset_dir)
 
     (
-        label_types,
         classes_map,
         all_classes,
         classes,
@@ -654,7 +649,6 @@ def _download_open_images_split(
     _get_hierarchy(dataset_dir, classes_map=classes_map, download=download)
 
     num_samples = _download(
-        label_types,
         image_ids,
         downloaded_ids,
         oi_classes,
@@ -662,6 +656,7 @@ def _download_open_images_split(
         seg_classes,
         dataset_dir,
         split,
+        label_types=label_types,
         classes=classes,
         attrs=attrs,
         max_samples=max_samples,
@@ -682,6 +677,8 @@ def _setup(
     max_samples=None,
     download=False,
 ):
+    label_types = _parse_label_types(label_types)
+
     if etau.is_str(classes):
         classes = [classes]
 
@@ -760,7 +757,6 @@ def _setup(
         seg_classes = None
 
     return (
-        label_types,
         classes_map,
         all_classes,
         classes,
@@ -1027,7 +1023,7 @@ def _get_downloaded_image_ids(dataset_dir):
 def _get_all_label_data(
     dataset_dir,
     image_ids,
-    label_types,
+    label_types=None,
     classes=None,
     oi_classes=None,
     attrs=None,
@@ -1043,11 +1039,18 @@ def _get_all_label_data(
     det_data = {}
     rel_data = {}
     seg_data = {}
-    seg_ids = set()
-    all_label_ids = None
-    any_label_ids = None
 
-    if "classifications" in label_types:
+    seg_ids = set()
+
+    all_classes_ids = set(image_ids)
+    any_classes_ids = set()
+
+    all_attrs_ids = set(image_ids)
+    any_attrs_ids = set()
+
+    _label_types = _parse_label_types(label_types)
+
+    if "classifications" in _label_types:
         url = None
         if download:
             url = _ANNOTATION_DOWNLOAD_URLS[split]["classifications"]
@@ -1065,17 +1068,13 @@ def _get_all_label_data(
             download=download,
         )
 
-        if all_label_ids is None:
-            all_label_ids = cls_all_ids
-        elif classes is not None:
-            all_label_ids &= cls_all_ids
+        # Classifications only capture the label schema, so don't use them for
+        # ID list purposes unless they were the only label type requested
+        if len(_label_types) == 1:
+            all_classes_ids &= cls_all_ids
+            any_classes_ids |= cls_any_ids
 
-        if any_label_ids is None:
-            any_label_ids = cls_any_ids
-        elif classes is not None:
-            any_label_ids &= cls_any_ids
-
-    if "detections" in label_types:
+    if "detections" in _label_types:
         url = None
         if download:
             url = _ANNOTATION_DOWNLOAD_URLS[split]["detections"]
@@ -1093,17 +1092,10 @@ def _get_all_label_data(
             only_matching=only_matching,
         )
 
-        if all_label_ids is None:
-            all_label_ids = det_all_ids
-        elif classes is not None:
-            all_label_ids &= det_all_ids
+        all_classes_ids &= det_all_ids
+        any_classes_ids |= det_any_ids
 
-        if any_label_ids is None:
-            any_label_ids = det_any_ids
-        elif classes is not None:
-            any_label_ids &= det_any_ids
-
-    if "relationships" in label_types:
+    if "relationships" in _label_types:
         url = None
         if download:
             url = _ANNOTATION_DOWNLOAD_URLS[split]["relationships"]
@@ -1121,18 +1113,11 @@ def _get_all_label_data(
             download=download,
         )
 
-        if all_label_ids is None:
-            all_label_ids = rel_all_ids
-        elif attrs is not None:
-            all_label_ids &= rel_all_ids
+        all_attrs_ids &= rel_all_ids
+        any_attrs_ids |= rel_any_ids
 
-        if any_label_ids is None:
-            any_label_ids = rel_any_ids
-        elif attrs is not None:
-            any_label_ids &= rel_any_ids
-
-    if "segmentations" in label_types:
-        if classes is not None:
+    if "segmentations" in _label_types:
+        if classes is not None and label_types is not None:
             non_seg_classes = sorted(set(classes) - set(seg_classes))
             if non_seg_classes:
                 logger.warning(
@@ -1161,21 +1146,22 @@ def _get_all_label_data(
 
         seg_ids = seg_any_ids
 
-        if all_label_ids is None:
-            all_label_ids = seg_all_ids
-        elif classes is not None:
-            all_label_ids &= seg_all_ids
+        all_classes_ids &= seg_all_ids
+        any_classes_ids |= seg_any_ids
 
-        if any_label_ids is None:
-            any_label_ids = seg_any_ids
-        elif classes is not None:
-            any_label_ids &= seg_any_ids
+    if classes is not None:
+        all_label_ids = all_classes_ids
+        any_label_ids = any_classes_ids
 
-    if all_label_ids is None:
-        all_label_ids = set()
-
-    if any_label_ids is None:
-        any_label_ids = set()
+        if attrs is not None:
+            all_label_ids &= all_attrs_ids
+            any_label_ids &= any_attrs_ids
+    elif attrs is not None:
+        all_label_ids = all_attrs_ids
+        any_label_ids = any_attrs_ids
+    else:
+        all_label_ids = all_classes_ids & all_attrs_ids
+        any_label_ids = any_classes_ids | any_attrs_ids
 
     return (
         cls_data,
@@ -1264,7 +1250,6 @@ def _get_label_data(
 
 
 def _download(
-    label_types,
     image_ids,
     downloaded_ids,
     oi_classes,
@@ -1272,6 +1257,7 @@ def _download(
     seg_classes,
     dataset_dir,
     split,
+    label_types=None,
     classes=None,
     attrs=None,
     max_samples=None,
@@ -1282,7 +1268,7 @@ def _download(
     _, _, _, _, seg_ids, all_label_ids, any_label_ids = _get_all_label_data(
         dataset_dir,
         image_ids,
-        label_types,
+        label_types=label_types,
         classes=classes,
         oi_classes=oi_classes,
         attrs=attrs,
@@ -1368,6 +1354,7 @@ def _download(
             download=download,
         )
 
+        label_types = _parse_label_types(label_types)
         if "segmentations" in label_types:
             _download_masks_if_necessary(
                 all_ids, seg_ids, dataset_dir, split, download=download
@@ -1628,10 +1615,10 @@ def _download_images_if_necessary(
     inputs = []
     num_existing = 0
     for image_id in image_ids:
-        fp = os.path.join(data_dir, image_id + ".jpg")
-        fp_download = re.sub(r"\\", "/", os.path.join(split, image_id + ".jpg"))
-        if not os.path.isfile(fp):
-            inputs.append((fp, fp_download))
+        filepath = os.path.join(data_dir, image_id + ".jpg")
+        obj = split + "/" + image_id + ".jpg"  # AWS path, always use "/"
+        if not os.path.isfile(filepath):
+            inputs.append((filepath, obj))
         else:
             num_existing += 1
 
@@ -1661,8 +1648,8 @@ def _download_images_if_necessary(
             config=botocore.config.Config(signature_version=botocore.UNSIGNED),
         )
         with fou.ProgressBar() as pb:
-            for path, obj in pb(inputs):
-                s3_client.download_file(_BUCKET_NAME, obj, path)
+            for filepath, obj in pb(inputs):
+                s3_client.download_file(_BUCKET_NAME, obj, filepath)
     else:
         with fou.ProgressBar(total=num_images) as pb:
             with multiprocessing.Pool(num_workers, _initialize_worker) as pool:
@@ -1679,8 +1666,8 @@ def _initialize_worker():
 
 
 def _do_s3_download(args):
-    filepath, filepath_download = args
-    s3_client.download_file(_BUCKET_NAME, filepath_download, filepath)
+    filepath, obj = args
+    s3_client.download_file(_BUCKET_NAME, obj, filepath)
 
 
 def _verify_version(version):

--- a/tests/intensive/dataset_zoo_tests.py
+++ b/tests/intensive/dataset_zoo_tests.py
@@ -1,35 +1,459 @@
 """
 Dataset zoo tests.
 
+You must run these tests interactively as follows::
+
+    pytest tests/intensive/dataset_zoo_tests.py -s -k <test_case>
+
 | Copyright 2017-2021, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+import unittest
+
 import fiftyone as fo
-
-# import fiftyone.core.config as foc
-# foc.set_config_settings(default_ml_backend="torch")
-# foc.set_config_settings(default_ml_backend="tensorflow")
-
 import fiftyone.zoo as foz
+from fiftyone import ViewField as F
 
 
-def test_zoo():
-    # List available datasets
+def test_zoo_basic():
     print(foz.list_zoo_datasets())
 
-    # Load a dataset
-    dataset = foz.load_zoo_dataset("cifar10", drop_existing_dataset=True)
-
-    # Print the dataset summary
+    dataset = foz.load_zoo_dataset(
+        "cifar10", split="test", drop_existing_dataset=True
+    )
     print(dataset)
 
-    # Print a few random samples from the dataset
     view = dataset.take(5)
     for sample in view:
         label = sample.ground_truth.label
         print("%s: %s" % (label, sample.filepath))
 
 
+def test_zoo_partial():
+    dataset = foz.load_zoo_dataset(
+        "cifar10", drop_existing_dataset=True, max_samples=5, shuffle=True
+    )
+
+    assert len(dataset) == 10
+    assert len(dataset.match_tags("train")) == 5
+    assert len(dataset.match_tags("test")) == 5
+
+
+def test_coco_2017():
+    dataset = foz.load_zoo_dataset(
+        "coco-2017", splits=("test", "validation"), max_samples=5,
+    )
+    schema = dataset.get_field_schema()
+
+    assert "ground_truth" in schema
+    assert len(dataset) == 10
+    assert len(dataset.match_tags("test")) == 5
+    assert len(dataset.match_tags("validation")) == 5
+    dataset.delete()
+
+    dataset = foz.load_zoo_dataset(
+        "coco-2017",
+        splits=("test", "validation"),
+        max_samples=5,
+        label_field="gt",
+    )
+    schema = dataset.get_field_schema()
+
+    assert "gt" in schema
+    dataset.delete()
+
+    dataset = foz.load_zoo_dataset(
+        "coco-2017",
+        splits=("test", "validation"),
+        label_types=("detections", "segmentations"),
+        max_samples=5,
+    )
+    schema = dataset.get_field_schema()
+
+    assert "detections" in schema
+    assert "segmentations" in schema
+    dataset.delete()
+
+    dataset = foz.load_zoo_dataset(
+        "coco-2017",
+        splits=("test", "validation"),
+        label_types=("detections", "segmentations"),
+        max_samples=5,
+        label_field="gt",
+    )
+    schema = dataset.get_field_schema()
+
+    assert "gt_detections" in schema
+    assert "gt_segmentations" in schema
+    dataset.delete()
+
+    dataset = foz.load_zoo_dataset(
+        "coco-2017",
+        splits=("test", "validation"),
+        label_types=("detections", "segmentations"),
+        include_id=True,
+        max_samples=5,
+    )
+    schema = dataset.get_field_schema()
+
+    assert "detections" in schema
+    assert "segmentations" in schema
+    assert "coco_id" in schema
+    dataset.delete()
+
+    dataset = foz.load_zoo_dataset(
+        "coco-2017",
+        splits=("test", "validation"),
+        label_types=[],
+        max_samples=5,
+    )
+    schema = dataset.get_field_schema()
+
+    assert "ground_truth" not in schema
+    assert "detections" not in schema
+    assert "coco_id" not in schema
+    dataset.delete()
+
+    dataset = foz.load_zoo_dataset(
+        "coco-2017",
+        split="validation",
+        label_types=["detections"],
+        classes="person",
+        max_samples=25,
+    )
+
+    assert len(dataset.count_values("ground_truth.detections.label")) > 1
+    assert (
+        len(
+            dataset.match_labels(
+                fields="ground_truth", filter=F("label") == "person"
+            )
+        )
+        == 25
+    )
+    dataset.delete()
+
+    dataset = foz.load_zoo_dataset(
+        "coco-2017",
+        split="validation",
+        classes="person",
+        max_samples=25,
+        only_matching=True,
+    )
+
+    assert len(dataset.count_values("ground_truth.detections.label")) == 1
+    assert (
+        len(
+            dataset.match_labels(
+                fields="ground_truth", filter=F("label") == "person"
+            )
+        )
+        == 25
+    )
+    dataset.delete()
+
+    dataset = foz.load_zoo_dataset(
+        "coco-2017",
+        split="validation",
+        label_types=["detections", "segmentations"],
+        classes="person",
+        max_samples=25,
+    )
+
+    assert (
+        len(
+            dataset.match_labels(
+                fields="detections", filter=F("label") == "person"
+            )
+        )
+        == 25
+    )
+    assert (
+        len(
+            dataset.match_labels(
+                fields="segmentations", filter=F("label") == "person"
+            )
+        )
+        == 25
+    )
+    dataset.delete()
+
+    dataset = foz.load_zoo_dataset(
+        "coco-2017",
+        split="validation",
+        label_types="segmentations",
+        classes="person",
+        max_samples=25,
+        use_polylines=True,
+        include_id=True,
+    )
+    schema = dataset.get_field_schema()
+    counts = dataset.count_values("segmentations.polylines.label")
+
+    assert "segmentations" in schema
+    assert "coco_id" in schema
+    assert (
+        len(
+            dataset.match_labels(
+                fields="segmentations", filter=F("label") == "person"
+            )
+        )
+        == 25
+    )
+    assert "person" in counts
+    assert counts["person"] >= 25
+    dataset.delete()
+
+
+def test_open_images_v6():
+    dataset = foz.load_zoo_dataset(
+        "open-images-v6", split="validation", max_samples=5,
+    )
+    schema = dataset.get_field_schema()
+
+    assert "positive_labels" in schema
+    assert "negative_labels" in schema
+    assert "detections" in schema
+    assert "relationships" in schema
+    assert "segmentations" in schema
+    assert "open_images_id" in schema
+    assert len(dataset) == 5
+    assert len(dataset.match_tags("validation")) == 5
+    dataset.delete()
+
+    dataset = foz.load_zoo_dataset(
+        "open-images-v6", split="validation", max_samples=5, label_field="gt",
+    )
+    schema = dataset.get_field_schema()
+
+    assert "gt_positive_labels" in schema
+    assert "gt_negative_labels" in schema
+    assert "gt_detections" in schema
+    assert "gt_relationships" in schema
+    assert "gt_segmentations" in schema
+    assert "gt_open_images_id" in schema
+    assert len(dataset) == 5
+    assert len(dataset.match_tags("validation")) == 5
+    dataset.delete()
+
+    dataset = foz.load_zoo_dataset(
+        "open-images-v6",
+        split="validation",
+        label_types=["segmentations"],
+        max_samples=25,
+    )
+
+    assert len(dataset) == 25
+    dataset.delete()
+
+    dataset = foz.load_zoo_dataset(
+        "open-images-v6",
+        split="validation",
+        label_types=[],
+        label_field="oi_id",
+        max_samples=5,
+    )
+    schema = dataset.get_field_schema()
+
+    assert "oi_id" in schema
+    assert "positive_labels" not in schema
+    assert "negative_labels" not in schema
+    assert "detections" not in schema
+    assert "relationships" not in schema
+    assert "segmentations" not in schema
+    assert len(dataset) == 5
+    assert len(dataset.match_tags("validation")) == 5
+    dataset.delete()
+
+    dataset = foz.load_zoo_dataset(
+        "open-images-v6",
+        split="validation",
+        label_types=[],
+        include_id=False,
+        max_samples=5,
+    )
+    schema = dataset.get_field_schema()
+
+    assert "ground_truth" not in schema
+    assert "positive_labels" not in schema
+    assert "negative_labels" not in schema
+    assert "detections" not in schema
+    assert "relationships" not in schema
+    assert "segmentations" not in schema
+    assert "open_images_id" not in schema
+    assert len(dataset) == 5
+    assert len(dataset.match_tags("validation")) == 5
+    dataset.delete()
+
+    dataset = foz.load_zoo_dataset(
+        "open-images-v6",
+        split="validation",
+        label_types="detections",
+        include_id=False,
+        max_samples=5,
+    )
+    schema = dataset.get_field_schema()
+
+    assert "ground_truth" in schema
+    assert "open_images_id" not in schema
+    dataset.delete()
+
+    dataset = foz.load_zoo_dataset(
+        "open-images-v6",
+        split="validation",
+        label_types=["detections", "relationships"],
+        classes=["Piano", "Fedora"],
+        max_samples=50,
+    )
+    schema = dataset.get_field_schema()
+
+    assert "detections" in schema
+    assert "relationships" in schema
+    assert "open_images_id" in schema
+    assert (
+        len(
+            dataset.match_labels(
+                filter=F("label").is_in(["Fedora", "Piano"]),
+                fields="detections",
+            )
+        )
+        == 50
+    )
+    assert len(dataset.count_values("detections.detections.label")) > 1
+    dataset.delete()
+
+    dataset = foz.load_zoo_dataset(
+        "open-images-v6",
+        split="validation",
+        label_types=["detections", "relationships"],
+        classes=["Piano", "Fedora"],
+        only_matching=True,
+        max_samples=50,
+    )
+    schema = dataset.get_field_schema()
+
+    assert "detections" in schema
+    assert "relationships" in schema
+    assert "open_images_id" in schema
+    assert (
+        len(
+            dataset.match_labels(
+                filter=F("label").is_in(["Fedora", "Piano"]),
+                fields="detections",
+            )
+        )
+        == 50
+    )
+    assert len(dataset.count_values("detections.detections.label")) == 2
+    dataset.delete()
+
+    dataset = foz.load_zoo_dataset(
+        "open-images-v6",
+        split="validation",
+        label_types=["detections", "relationships"],
+        attrs="Plastic",
+        max_samples=50,
+    )
+    schema = dataset.get_field_schema()
+
+    assert "detections" in schema
+    assert "relationships" in schema
+    assert "open_images_id" in schema
+    assert (
+        len(
+            dataset.match_labels(
+                filter=(F("Label1") == "Plastic") | (F("Label2") == "Plastic"),
+                fields="relationships",
+            )
+        )
+        == 50
+    )
+    dataset.delete()
+
+    dataset = foz.load_zoo_dataset(
+        "open-images-v6",
+        split="validation",
+        label_types=["detections", "relationships"],
+        attrs="Plastic",
+        only_matching=True,
+        max_samples=50,
+    )
+    schema = dataset.get_field_schema()
+
+    assert "detections" in schema
+    assert "relationships" in schema
+    assert "open_images_id" in schema
+    assert (
+        len(
+            dataset.match_labels(
+                filter=(F("Label1") == "Plastic") | (F("Label2") == "Plastic"),
+                fields="relationships",
+            )
+        )
+        == 50
+    )
+    dataset.delete()
+
+    dataset = foz.load_zoo_dataset(
+        "open-images-v6",
+        split="validation",
+        label_types=["detections", "relationships"],
+        classes=["Piano", "Fedora"],
+        attrs="Plastic",
+        max_samples=50,
+    )
+    schema = dataset.get_field_schema()
+
+    assert "detections" in schema
+    assert "relationships" in schema
+    assert "open_images_id" in schema
+    assert len(
+        dataset.match_labels(
+            filter=F("label").is_in(["Fedora", "Piano"]), fields="detections"
+        )
+    ) == len(dataset)
+    assert len(
+        dataset.match_labels(
+            filter=(F("Label1") == "Plastic") | (F("Label2") == "Plastic"),
+            fields="relationships",
+        )
+    ) == len(dataset)
+    dataset.delete()
+
+    dataset = foz.load_zoo_dataset(
+        "open-images-v6", split="validation", classes="Violin", max_samples=25,
+    )
+
+    assert (
+        len(
+            dataset.match_labels(
+                fields="detections", filter=F("label") == "Violin"
+            )
+        )
+        == 25
+    )
+    dataset.delete()
+
+    dataset = foz.load_zoo_dataset(
+        "open-images-v6",
+        split="validation",
+        label_types=["detections", "segmentations"],
+        classes="Violin",
+        max_samples=25,
+    )
+
+    assert (
+        len(
+            dataset.match_labels(
+                fields="detections", filter=F("label") == "Violin"
+            )
+        )
+        == 25
+    )
+    dataset.delete()
+
+
 if __name__ == "__main__":
-    test_zoo()
+    fo.config.show_progress_bars = True
+    unittest.main(verbosity=2)

--- a/tests/intensive/import_export_tests.py
+++ b/tests/intensive/import_export_tests.py
@@ -1,6 +1,10 @@
 """
 Dataset import/export tests.
 
+You must run these tests interactively as follows::
+
+    pytest tests/intensive/import_export_tests.py -s -k <test_case>
+
 | Copyright 2017-2021, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |


### PR DESCRIPTION
This PR makes some improvements to how `classes` and `attrs` requirements are handled for partial downloads of the Open Images dataset.

### Change log

The changes are as follows:
- "classifications" are excluded from `classes` requirements, since they only describe the label schema and do not actually indicate the presence of that label type. The exception to this is that, if **only** "classifications" labels are requested, then the `classes` requirement **will** be applied
- `classes` requirements were previously being AND-ed across all label types that support classes ("detections" and "segmentations"), but the more natural behavior is to OR across label types. In other words, if you want samples containing particular classes, they can appear across any label type you requested, not necessarily ALL label types. (When `max_samples` is specified, priority will still be given to samples that really do contain the classes in each label type)

In addition, pretty thorough unit tests are now included in `tests/intensive/dataset_zoo_tests.py` to ensure that the expected behaviors are occurring when partially downloading COCO and Open Images.

### Editorial comment

These partial download implementations have turned out to be quite annoying, as its actually not so straightforward to provide an intuitive behavior across all of the partial download parameters that we support... With the data loaded into FiftyOne, querying for exactly what you want becomes much easier 😃 

### Example usage

This PR was motivated by the example below. It so happens that `Violin` is only used for detections, not segmentations, but, nonetheless, I would expect the code below to load 25 samples with violins. Currently, it returns an empty dataset because it is requiring "Violin" to be present as both a detection and segmentation label.

```py
import fiftyone as fo
import fiftyone.zoo as foz
from fiftyone import ViewField as F

dataset = foz.load_zoo_dataset(
    "open-images-v6",
    split="validation",
    classes="Violin",
    max_samples=25,
)

# currently fail but now succeed
assert len(dataset) == 25
assert len(dataset.match_labels(fields="detections", filter=F("label") == "Violin")) == 25
```
