### PR TITLE
Adds support for evaluating polygons and instance segmentations

### DIFF
--- a/docs/source/integrations/coco.rst
+++ b/docs/source/integrations/coco.rst
@@ -335,7 +335,7 @@ You can also explicitly request that COCO-style evaluation be used by setting
 the ``method`` parameter to ``"coco"``.
 
 See :ref:`this page <evaluating-detections>` for more information about using
-FiftyOne to analyze detection models.
+FiftyOne to analyze object detection models.
 
 .. note::
 
@@ -373,13 +373,13 @@ populated on each sample and its predicted/ground truth objects:
         FP: sample.<eval_key>_fp
         FN: sample.<eval_key>_fn
 
--   The fields listed below are populated on each individual |Detection|
-    instance; these fields tabulate the TP/FP/FN status of the object, the ID
-    of the matching object (if any), and the matching IoU::
+-   The fields listed below are populated on each individual object instance;
+    these fields tabulate the TP/FP/FN status of the object, the ID of the
+    matching object (if any), and the matching IoU::
 
-        TP/FP/FN: detection.<eval_key>
-              ID: detection.<eval_key>_id
-             IoU: detection.<eval_key>_iou
+        TP/FP/FN: object.<eval_key>
+              ID: object.<eval_key>_id
+             IoU: object.<eval_key>_iou
 
 .. note::
 
@@ -404,7 +404,7 @@ The example below demonstrates COCO-style detection evaluation on the
     dataset = foz.load_zoo_dataset("quickstart")
     print(dataset)
 
-    # Evaluate the detections in the `predictions` field with respect to the
+    # Evaluate the objects in the `predictions` field with respect to the
     # objects in the `ground_truth` field
     results = dataset.evaluate_detections(
         "predictions",
@@ -463,7 +463,7 @@ mAP and PR curves
 ~~~~~~~~~~~~~~~~~
 
 You can compute mean average precision (mAP) and precision-recall (PR) curves
-for your detections by passing the ``compute_mAP=True`` flag to
+for your predictions by passing the ``compute_mAP=True`` flag to
 :meth:`evaluate_detections() <fiftyone.core.collections.SampleCollection.evaluate_detections>`:
 
 .. note::
@@ -507,8 +507,8 @@ the results of COCO-style evaluations.
 In order for the confusion matrix to capture anything other than false
 positive/negative counts, you will likely want to set the
 :class:`classwise <fiftyone.utils.eval.coco.COCOEvaluationConfig>` parameter
-to ``False`` during evaluation so that detections can be matched with ground
-truth objects of different classes.
+to ``False`` during evaluation so that predicted objects can be matched with
+ground truth objects of different classes.
 
 .. code-block:: python
     :linenos:

--- a/docs/source/integrations/open_images.rst
+++ b/docs/source/integrations/open_images.rst
@@ -234,13 +234,13 @@ populated on each sample and its predicted/ground truth objects:
         FP: sample.<eval_key>_fp
         FN: sample.<eval_key>_fn
 
--   The fields listed below are populated on each individual |Detection|
-    instance; these fields tabulate the TP/FP/FN status of the object, the ID
-    of the matching object (if any), and the matching IoU::
+-   The fields listed below are populated on each individual object instance;
+    these fields tabulate the TP/FP/FN status of the object, the ID of the
+    matching object (if any), and the matching IoU::
 
-        TP/FP/FN: detection.<eval_key>
-              ID: detection.<eval_key>_id
-             IoU: detection.<eval_key>_iou
+        TP/FP/FN: object.<eval_key>
+              ID: object.<eval_key>_id
+             IoU: object.<eval_key>_iou
 
 .. note::
 
@@ -265,7 +265,7 @@ The example below demonstrates Open Images-style detection evaluation on the
     dataset = foz.load_zoo_dataset("quickstart")
     print(dataset)
 
-    # Evaluate the detections in the `predictions` field with respect to the
+    # Evaluate the objects in the `predictions` field with respect to the
     # objects in the `ground_truth` field
     results = dataset.evaluate_detections(
         "predictions",
@@ -367,8 +367,8 @@ the results of Open Images-style evaluations.
 In order for the confusion matrix to capture anything other than false
 positive/negative counts, you will likely want to set the
 :class:`classwise <fiftyone.utils.eval.openimages.OpenImagesEvaluationConfig>`
-parameter to ``False`` during evaluation so that detections can be matched with
-ground truth objects of different classes.
+parameter to ``False`` during evaluation so that predicted objects can be
+matched with ground truth objects of different classes.
 
 .. code-block:: python
     :linenos:

--- a/docs/source/user_guide/evaluation.rst
+++ b/docs/source/user_guide/evaluation.rst
@@ -531,7 +531,7 @@ __________
 You can use the
 :meth:`evaluate_detections() <fiftyone.core.collections.SampleCollection.evaluate_detections>`
 method to evaluate the predictions of an object detection model stored in a
-|Detections| field of your dataset.
+|Detections| or |Polylines| field of your dataset.
 
 Invoking
 :meth:`evaluate_detections() <fiftyone.core.collections.SampleCollection.evaluate_detections>`
@@ -550,6 +550,49 @@ samples.
     by default, but
     :ref:`Open Images-style <evaluating-detections-open-images>` evaluation is
     also natively supported.
+
+.. _evaluation-detection-types:
+
+Supported types
+---------------
+
+The :meth:`evaluate_detections() <fiftyone.core.collections.SampleCollection.evaluate_detections>`
+method supports all of the following task types:
+
+-   :ref:`Object detection <object-detection>`
+-   :ref:`Instance segmentations <objects-with-instance-segmentations>`
+-   :ref:`Polygon detection <polylines>`
+
+The only difference between each task type is in how the IoU between objects is
+calculated. Specifically, for instance segmentations and polygons, IoUs are
+computed between the polgyonal shapes rather than their rectangular bounding
+boxes.
+
+For object detection tasks, the ground truth and predicted objects should be
+stored in |Detections| format.
+
+For instance segmentation tasks, the ground truth and predicted objects should
+be stored in |Detections| format, and each |Detection| instance should have its
+:attr:`mask <fiftyone.core.labels.Detection.mask>` attribute populated to
+define the extent of the object within its bounding box.
+
+.. note::
+
+    In order to use instance masks for IoU calculations, pass ``use_masks=True``
+    to :meth:`evaluate_detections() <fiftyone.core.collections.SampleCollection.evaluate_detections>`.
+
+For polygon detection tasks, the ground truth and predicted objects should be
+stored in |Polylines| format with their
+:attr:`filled <fiftyone.core.labels.Polyline.filled>` attribute set to
+``True`` to indicate that they represent closed polygons (as opposed to
+polylines).
+
+.. note::
+
+    If you are evaluating polygons but would rather use bounding boxes rather
+    than the actual polygonal geometries for IoU calculations, you can pass
+    ``use_boxes=True`` to
+    :meth:`evaluate_detections() <fiftyone.core.collections.SampleCollection.evaluate_detections>`.
 
 .. _evaluation-patches:
 

--- a/docs/source/user_guide/evaluation.rst
+++ b/docs/source/user_guide/evaluation.rst
@@ -6,8 +6,8 @@ Evaluating Models
 .. default-role:: code
 
 FiftyOne provides a variety of builtin methods for evaluating your model
-predictions, including classifications, detections, and semantic segmentations,
-on both image and video datasets.
+predictions, including classifications, detections, polygons, instance and
+semantic segmentations, on both image and video datasets.
 
 When you evaluate a model in FiftyOne, you get access to the standard aggregate
 metrics such as classification reports, confusion matrices, and PR curves
@@ -51,7 +51,7 @@ method:
     dataset = foz.load_zoo_dataset("quickstart")
     print(dataset)
 
-    # Evaluate the detections in the `predictions` field with respect to the
+    # Evaluate the objects in the `predictions` field with respect to the
     # objects in the `ground_truth` field
     results = dataset.evaluate_detections(
         "predictions",
@@ -172,7 +172,7 @@ see the true positive examples of that class in the App.
 Likewise, whenever you modify the Session's view, either in the App or by
 programmatically setting
 :meth:`session.view <fiftyone.core.session.Session.view>`, the confusion matrix
-is automatically updated to show the cell counts for only those detections that
+is automatically updated to show the cell counts for only those objects that
 are included in the current view.
 
 .. code-block:: python
@@ -764,13 +764,13 @@ populated on each sample and its predicted/ground truth objects:
         FP: sample.<eval_key>_fp
         FN: sample.<eval_key>_fn
 
--   The fields listed below are populated on each individual |Detection|
-    instance; these fields tabulate the TP/FP/FN status of the object, the ID
-    of the matching object (if any), and the matching IoU::
+-   The fields listed below are populated on each individual object instance;
+    these fields tabulate the TP/FP/FN status of the object, the ID of the
+    matching object (if any), and the matching IoU::
 
-        TP/FP/FN: detection.<eval_key>
-              ID: detection.<eval_key>_id
-             IoU: detection.<eval_key>_iou
+        TP/FP/FN: object.<eval_key>
+              ID: object.<eval_key>_id
+             IoU: object.<eval_key>_iou
 
 .. note::
 
@@ -795,7 +795,7 @@ The example below demonstrates COCO-style detection evaluation on the
     dataset = foz.load_zoo_dataset("quickstart")
     print(dataset)
 
-    # Evaluate the detections in the `predictions` field with respect to the
+    # Evaluate the objects in the `predictions` field with respect to the
     # objects in the `ground_truth` field
     results = dataset.evaluate_detections(
         "predictions",
@@ -853,7 +853,7 @@ mAP and PR curves
 ~~~~~~~~~~~~~~~~~
 
 You can compute mean average precision (mAP) and precision-recall (PR) curves
-for your detections by passing the ``compute_mAP=True`` flag to
+for your objects by passing the ``compute_mAP=True`` flag to
 :meth:`evaluate_detections() <fiftyone.core.collections.SampleCollection.evaluate_detections>`:
 
 .. note::
@@ -896,8 +896,8 @@ the results of COCO-style evaluations.
 In order for the confusion matrix to capture anything other than false
 positive/negative counts, you will likely want to set the
 :class:`classwise <fiftyone.utils.eval.coco.COCOEvaluationConfig>` parameter
-to ``False`` during evaluation so that detections can be matched with ground
-truth objects of different classes.
+to ``False`` during evaluation so that predicted objects can be matched with
+ground truth objects of different classes.
 
 .. code-block:: python
     :linenos:
@@ -997,9 +997,9 @@ populated on each sample and its predicted/ground truth objects:
     instance; these fields tabulate the TP/FP/FN status of the object, the ID
     of the matching object (if any), and the matching IoU::
 
-        TP/FP/FN: detection.<eval_key>
-              ID: detection.<eval_key>_id
-             IoU: detection.<eval_key>_iou
+        TP/FP/FN: object.<eval_key>
+              ID: object.<eval_key>_id
+             IoU: object.<eval_key>_iou
 
 .. note::
 
@@ -1024,7 +1024,7 @@ The example below demonstrates Open Images-style detection evaluation on the
     dataset = foz.load_zoo_dataset("quickstart")
     print(dataset)
 
-    # Evaluate the detections in the `predictions` field with respect to the
+    # Evaluate the objects in the `predictions` field with respect to the
     # objects in the `ground_truth` field
     results = dataset.evaluate_detections(
         "predictions",
@@ -1126,8 +1126,8 @@ the results of Open Images-style evaluations.
 In order for the confusion matrix to capture anything other than false
 positive/negative counts, you will likely want to set the
 :class:`classwise <fiftyone.utils.eval.openimages.OpenImagesEvaluationConfig>`
-parameter to ``False`` during evaluation so that detections can be matched with
-ground truth objects of different classes.
+parameter to ``False`` during evaluation so that predicted objects can be
+matched with ground truth objects of different classes.
 
 .. code-block:: python
     :linenos:

--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -1544,7 +1544,7 @@ class SampleCollection(object):
         configued via the ``method`` and ``config`` parameters.
 
         If an ``eval_key`` is provided, a number of fields are populated at the
-        detection- and sample-level recording the results of the evaluation:
+        object- and sample-level recording the results of the evaluation:
 
         -   True positive (TP), false positive (FP), and false negative (FN)
             counts for the each sample are saved in top-level fields of each
@@ -1561,20 +1561,21 @@ class SampleCollection(object):
                 FP: frame.<eval_key>_fp
                 FN: frame.<eval_key>_fn
 
-        -   The fields listed below are populated on each individual
-            :class:`fiftyone.core.labels.Detection` instance; these fields
-            tabulate the TP/FP/FN status of the object, the ID of the matching
-            object (if any), and the matching IoU::
+        -   The fields listed below are populated on each individual object;
+            these fields tabulate the TP/FP/FN status of the object, the ID of
+            the matching object (if any), and the matching IoU::
 
-                TP/FP/FN: detection.<eval_key>
-                      ID: detection.<eval_key>_id
-                     IoU: detection.<eval_key>_iou
+                TP/FP/FN: object.<eval_key>
+                      ID: object.<eval_key>_id
+                     IoU: object.<eval_key>_iou
 
         Args:
             pred_field: the name of the field containing the predicted
-                :class:`fiftyone.core.labels.Detections` to evaluate
+                :class:`fiftyone.core.labels.Detections` or
+                :class:`fiftyone.core.labels.Polylines`
             gt_field ("ground_truth"): the name of the field containing the
-                ground truth :class:`fiftyone.core.labels.Detections`
+                ground truth :class:`fiftyone.core.labels.Detections` or
+                :class:`fiftyone.core.labels.Polylines`
             eval_key (None): an evaluation key to use to refer to this
                 evaluation
             classes (None): the list of possible classes. If not provided,

--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -1533,6 +1533,7 @@ class SampleCollection(object):
         missing=None,
         method="coco",
         iou=0.50,
+        use_masks=False,
         classwise=True,
         config=None,
         **kwargs,
@@ -1589,6 +1590,9 @@ class SampleCollection(object):
             method ("coco"): a string specifying the evaluation method to use.
                 Supported values are ``("coco")``
             iou (0.50): the IoU threshold to use to determine matches
+            use_masks (False): whether to compute IoUs using the instances
+                masks in the ``mask`` attribute of the provided objects, which
+                must be :class:`fiftyone.core.labels.Detection` instances
             classwise (True): whether to only match objects with the same class
                 label (True) or allow matches between classes (False)
             config (None): a
@@ -1612,6 +1616,7 @@ class SampleCollection(object):
             missing=missing,
             method=method,
             iou=iou,
+            use_masks=use_masks,
             classwise=classwise,
             config=config,
             **kwargs,

--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -7,7 +7,6 @@ Interface for sample collections.
 """
 from collections import defaultdict
 import itertools
-import inspect
 import logging
 import os
 import random
@@ -1540,6 +1539,14 @@ class SampleCollection(object):
     ):
         """Evaluates the specified predicted detections in this collection with
         respect to the specified ground truth detections.
+
+        This method supports evaluating the following spatial data types:
+
+        -   Object detections in :class:`fiftyone.core.labels.Detections`
+            format
+        -   Instance segmentations in :class:`fiftyone.core.labels.Detections`
+            format with their ``mask`` attributes populated
+        -   Polygons in :class:`fiftyone.core.labels.Polylines` format
 
         By default, this method uses COCO-style evaluation, but this can be
         configued via the ``method`` and ``config`` parameters.

--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -1533,6 +1533,7 @@ class SampleCollection(object):
         method="coco",
         iou=0.50,
         use_masks=False,
+        use_boxes=False,
         classwise=True,
         config=None,
         **kwargs,
@@ -1600,6 +1601,9 @@ class SampleCollection(object):
             use_masks (False): whether to compute IoUs using the instances
                 masks in the ``mask`` attribute of the provided objects, which
                 must be :class:`fiftyone.core.labels.Detection` instances
+            use_boxes (False): whether to compute IoUs using the bounding boxes
+                of the provided :class:`fiftyone.core.labels.Polyline`
+                instances rather than using their actual geometries
             classwise (True): whether to only match objects with the same class
                 label (True) or allow matches between classes (False)
             config (None): a
@@ -1624,6 +1628,7 @@ class SampleCollection(object):
             method=method,
             iou=iou,
             use_masks=use_masks,
+            use_boxes=use_boxes,
             classwise=classwise,
             config=config,
             **kwargs,

--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -1458,7 +1458,6 @@ class SampleCollection(object):
         classes=None,
         missing=None,
         method="simple",
-        config=None,
         **kwargs,
     ):
         """Evaluates the classification predictions in this collection with
@@ -1466,8 +1465,18 @@ class SampleCollection(object):
 
         By default, this method simply compares the ground truth and prediction
         for each sample, but other strategies such as binary evaluation and
-        top-k matching can be configured via the ``method`` and ``config``
-        parameters.
+        top-k matching can be configured via the ``method`` parameter.
+
+        You can customize the evaluation method by passing additional
+        parameters for the method's
+        :class:`fiftyone.utils.eval.classification.ClassificationEvaluationConfig`
+        class as ``kwargs``.
+
+        The supported ``method`` values and their associated configs are:
+
+        -   ``"simple"``: :class:`fiftyone.utils.eval.classification.SimpleEvaluationConfig`
+        -   ``"top-k"``: :class:`fiftyone.utils.eval.classification.TopKEvaluationConfig`
+        -   ``"binary"``: :class:`fiftyone.utils.eval.classification.BinaryEvaluationConfig`
 
         If an ``eval_key`` is specified, then this method will record some
         statistics on each sample:
@@ -1500,10 +1509,6 @@ class SampleCollection(object):
                 are given this label for results purposes
             method ("simple"): a string specifying the evaluation method to use.
                 Supported values are ``("simple", "binary", "top-k")``
-            config (None): a
-                :class:`fiftyone.utils.eval.classification.ClassificationEvaluationConfig`
-                specifying the evaluation method to use. If a ``config`` is
-                provided, the ``method`` and ``kwargs`` parameters are ignored
             **kwargs: optional keyword arguments for the constructor of the
                 :class:`fiftyone.utils.eval.classification.ClassificationEvaluationConfig`
                 being used
@@ -1519,7 +1524,6 @@ class SampleCollection(object):
             classes=classes,
             missing=missing,
             method=method,
-            config=config,
             **kwargs,
         )
 
@@ -1535,7 +1539,6 @@ class SampleCollection(object):
         use_masks=False,
         use_boxes=False,
         classwise=True,
-        config=None,
         **kwargs,
     ):
         """Evaluates the specified predicted detections in this collection with
@@ -1549,8 +1552,17 @@ class SampleCollection(object):
             format with their ``mask`` attributes populated
         -   Polygons in :class:`fiftyone.core.labels.Polylines` format
 
-        By default, this method uses COCO-style evaluation, but this can be
-        configued via the ``method`` and ``config`` parameters.
+        By default, this method uses COCO-style evaluation, but you can use the
+        ``method`` parameter to select a different method, and you can
+        optionally customize the method by passing additional parameters for
+        the method's
+        :class:`fiftyone.utils.eval.detection.DetectionEvaluationConfig` class
+        as ``kwargs``.
+
+        The supported ``method`` values and their associated configs are:
+
+        -   ``"coco"``: :class:`fiftyone.utils.eval.coco.COCOEvaluationConfig`
+        -   ``"open-images"``: :class:`fiftyone.utils.eval.openimages.OpenImagesEvaluationConfig`
 
         If an ``eval_key`` is provided, a number of fields are populated at the
         object- and sample-level recording the results of the evaluation:
@@ -1606,11 +1618,6 @@ class SampleCollection(object):
                 instances rather than using their actual geometries
             classwise (True): whether to only match objects with the same class
                 label (True) or allow matches between classes (False)
-            config (None): a
-                :class:`fiftyone.utils.eval.detection.DetectionEvaluationConfig`
-                specifying the evaluation method to use. If a ``config`` is
-                provided, the ``method``, ``iou``, ``classwise``, and
-                ``kwargs`` parameters are ignored
             **kwargs: optional keyword arguments for the constructor of the
                 :class:`fiftyone.utils.eval.detection.DetectionEvaluationConfig`
                 being used
@@ -1630,7 +1637,6 @@ class SampleCollection(object):
             use_masks=use_masks,
             use_boxes=use_boxes,
             classwise=classwise,
-            config=config,
             **kwargs,
         )
 
@@ -1641,7 +1647,6 @@ class SampleCollection(object):
         eval_key=None,
         mask_targets=None,
         method="simple",
-        config=None,
         **kwargs,
     ):
         """Evaluates the specified semantic segmentation masks in this
@@ -1649,6 +1654,16 @@ class SampleCollection(object):
 
         If the size of a predicted mask does not match the ground truth mask,
         it is resized to match the ground truth.
+
+        By default, this method simply performs pixelwise evaluation of the
+        full masks, but other strategies such as boundary-only evaluation can
+        be configured by passing additional parameters for the method's
+        :class:`fiftyone.utils.eval.segmentation.SegmentationEvaluationConfig`
+        class as ``kwargs``.
+
+        The supported ``method`` values and their associated configs are:
+
+        -   ``"simple"``: :class:`fiftyone.utils.eval.segmentation.SimpleEvaluationConfig`
 
         If an ``eval_key`` is provided, the accuracy, precision, and recall of
         each sample is recorded in top-level fields of each sample::
@@ -1685,10 +1700,6 @@ class SampleCollection(object):
                 possible, or else the observed pixel values are used
             method ("simple"): a string specifying the evaluation method to
                 use. Supported values are ``("simple")``
-            config (None): a
-                :class:`fiftyone.utils.eval.segmentation.SegmentationEvaluationConfig`
-                specifying the evaluation method to use. If a ``config`` is
-                provided, the ``method`` and ``kwargs`` parameters are ignored
             **kwargs: optional keyword arguments for the constructor of the
                 :class:`fiftyone.utils.eval.segmentation.SegmentationEvaluationConfig`
                 being used
@@ -1703,7 +1714,6 @@ class SampleCollection(object):
             eval_key=eval_key,
             mask_targets=mask_targets,
             method=method,
-            config=config,
             **kwargs,
         )
 

--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -1170,9 +1170,9 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
             field_name: the field name or ``embedded.field.name``
             error_level (0): the error level to use. Valid values are:
 
-                0: raise error if a top-level field cannot be deleted
-                1: log warning if a top-level field cannot be deleted
-                2: ignore top-level fields that cannot be deleted
+            -   0: raise error if a top-level field cannot be deleted
+            -   1: log warning if a top-level field cannot be deleted
+            -   2: ignore top-level fields that cannot be deleted
         """
         self._delete_sample_fields(field_name, error_level)
 
@@ -1186,9 +1186,9 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
             field_names: the field name or iterable of field names
             error_level (0): the error level to use. Valid values are:
 
-                0: raise error if a top-level field cannot be deleted
-                1: log warning if a top-level field cannot be deleted
-                2: ignore top-level fields that cannot be deleted
+            -   0: raise error if a top-level field cannot be deleted
+            -   1: log warning if a top-level field cannot be deleted
+            -   2: ignore top-level fields that cannot be deleted
         """
         self._delete_sample_fields(field_names, error_level)
 
@@ -1204,9 +1204,9 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
             field_name: the field name or ``embedded.field.name``
             error_level (0): the error level to use. Valid values are:
 
-                0: raise error if a top-level field cannot be deleted
-                1: log warning if a top-level field cannot be deleted
-                2: ignore top-level fields that cannot be deleted
+            -   0: raise error if a top-level field cannot be deleted
+            -   1: log warning if a top-level field cannot be deleted
+            -   2: ignore top-level fields that cannot be deleted
         """
         self._delete_frame_fields(field_name, error_level)
 
@@ -1222,9 +1222,9 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
             field_names: a field name or iterable of field names
             error_level (0): the error level to use. Valid values are:
 
-                0: raise error if a top-level field cannot be deleted
-                1: log warning if a top-level field cannot be deleted
-                2: ignore top-level fields that cannot be deleted
+            -   0: raise error if a top-level field cannot be deleted
+            -   1: log warning if a top-level field cannot be deleted
+            -   2: ignore top-level fields that cannot be deleted
         """
         self._delete_frame_fields(field_names, error_level)
 

--- a/fiftyone/core/labels.py
+++ b/fiftyone/core/labels.py
@@ -363,7 +363,8 @@ class Detection(ImageLabel, _HasID, _HasAttributes):
 
         Args:
             tolerance (2): a tolerance, in pixels, when generating an
-                approximate polyline for the instance mask
+                approximate polyline for the instance mask. Typical values are
+                1-3 pixels
             filled (True): whether the polyline should be filled
 
         Returns:

--- a/fiftyone/core/labels.py
+++ b/fiftyone/core/labels.py
@@ -5,6 +5,8 @@ Labels stored in dataset samples.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+import itertools
+
 from bson import ObjectId
 
 import eta.core.data as etad
@@ -20,6 +22,9 @@ import fiftyone.core.fields as fof
 import fiftyone.core.utils as fou
 
 foug = fou.lazy_import("fiftyone.utils.geojson")
+sg = fou.lazy_import(
+    "shapely.geometry", callback=lambda: fou.ensure_package("shapely")
+)
 
 
 class _NoDefault(object):
@@ -370,6 +375,28 @@ class Detection(ImageLabel, _HasID, _HasAttributes):
         )
         return Polyline.from_eta_polyline(polyline)
 
+    def to_shapely(self, frame_size=None):
+        """Returns a Shapely representation of this instance.
+
+        Args:
+            frame_size (None): the ``(width, height)`` of the image. If
+                provided, the returned geometry will use absolute coordinates
+
+        Returns:
+            a ``shapely.geometry.polygon.Polygon``
+        """
+        # pylint: disable=unpacking-non-sequence
+        x, y, w, h = self.bounding_box
+
+        if frame_size is not None:
+            width, height = frame_size
+            x *= width
+            y *= height
+            w *= width
+            h *= height
+
+        return sg.box(x, y, x + w, y + h)
+
     def to_detected_object(self, name=None):
         """Returns an ``eta.core.objects.DetectedObject`` representation of
         this instance.
@@ -580,6 +607,56 @@ class Polyline(ImageLabel, _HasID, _HasAttributes):
             tags=self.tags,
         )
 
+    def to_shapely(self, frame_size=None):
+        """Returns a Shapely representation of this instance.
+
+        The type of geometry returned depends on the number of shapes
+        (:attr:`points`) and whether they are polygons or lines
+        (:attr:`filled`).
+
+        Args:
+            frame_size (None): the ``(width, height)`` of the image. If
+                provided, the returned geometry will use absolute coordinates
+
+        Returns:
+            one of the following:
+
+            -   ``shapely.geometry.polygon.Polygon``: if :attr:`filled` is True
+                and :attr:`points` contains a single shape
+            -   ``shapely.geometry.multipolygon.MultiPolygon``: if
+                :attr:`filled` is True and :attr:`points` contains multiple
+                shapes
+            -   ``shapely.geometry.linestring.LineString``: if :attr:`filled`
+                is False and :attr:`points` contains a single shape
+            -   ``shapely.geometry.multilinestring.MultiLineString``: if
+                :attr:`filled` is False and :attr:`points` contains multiple
+                shapes
+        """
+        if self.closed:
+            points = []
+            for shape in self.points:  # pylint: disable=not-an-iterable
+                if shape:
+                    shape = list(shape) + [shape[0]]
+
+                points.append(shape)
+        else:
+            points = self.points
+
+        if frame_size is not None:
+            w, h = frame_size
+            points = [[(x * w, y * h) for x, y in shape] for shape in points]
+
+        if len(points) == 1:
+            if self.filled:
+                return sg.Polygon(points[0])
+
+            return sg.LineString(points[0])
+
+        if self.filled:
+            return sg.MultiPolygon(list(zip(points, itertools.repeat(None))))
+
+        return sg.MultiLineString(points)
+
     def to_eta_polyline(self, name=None):
         """Returns an ``eta.core.polylines.Polyline`` representation of this
         instance.
@@ -730,6 +807,25 @@ class Keypoint(ImageLabel, _HasID, _HasAttributes):
     points = fof.KeypointsField()
     confidence = fof.FloatField()
     index = fof.IntField()
+
+    def to_shapely(self, frame_size=None):
+        """Returns a Shapely representation of this instance.
+
+        Args:
+            frame_size (None): the ``(width, height)`` of the image. If
+                provided, the returned geometry will use absolute coordinates
+
+        Returns:
+            a ``shapely.geometry.multipoint.MultiPoint``
+        """
+        # pylint: disable=not-an-iterable
+        points = self.points
+
+        if frame_size is not None:
+            w, h = frame_size
+            points = [(x * w, y * h) for x, y in points]
+
+        return sg.MultiPoint(points)
 
     def to_eta_keypoints(self, name=None):
         """Returns an ``eta.core.keypoints.Keypoints`` representation of this

--- a/fiftyone/core/models.py
+++ b/fiftyone/core/models.py
@@ -9,7 +9,6 @@ import contextlib
 import inspect
 import itertools
 import logging
-import warnings
 
 import numpy as np
 
@@ -21,7 +20,6 @@ import eta.core.video as etav
 import eta.core.web as etaw
 
 import fiftyone as fo
-import fiftyone.core.frame as fof
 import fiftyone.core.labels as fol
 import fiftyone.core.media as fom
 import fiftyone.core.utils as fou
@@ -1258,8 +1256,10 @@ def compute_patch_embeddings(
         if embeddings_field is not None:
             embeddings_field, _ = samples._handle_frame_field(embeddings_field)
 
-        fov.validate_collection_frame_label_fields(
-            samples, patches_field, _ALLOWED_PATCH_TYPES
+        fov.validate_collection_label_fields(
+            samples,
+            samples._FRAMES_PREFIX + patches_field,
+            _ALLOWED_PATCH_TYPES,
         )
     else:
         fov.validate_collection_label_fields(

--- a/fiftyone/core/odm/mixins.py
+++ b/fiftyone/core/odm/mixins.py
@@ -550,14 +550,14 @@ class DatasetMixin(object):
         for field_name in field_names:
             # pylint: disable=no-member
             if field_name in default_fields:
-                _handle_error(
+                fou.handle_error(
                     ValueError(
                         "Cannot delete default field '%s'" % field_name
                     ),
                     error_level,
                 )
             elif field_name not in cls._fields:
-                _handle_error(
+                fou.handle_error(
                     AttributeError("Field '%s' does not exist" % field_name),
                     error_level,
                 )
@@ -1099,14 +1099,3 @@ def _rename_field(field, new_field_name):
     field.db_field = new_field_name
     field.name = new_field_name
     return field
-
-
-def _handle_error(error, error_level):
-    if error_level > 1:
-        return
-
-    if error_level == 1:
-        logger.warning(error)
-        return
-
-    raise error

--- a/fiftyone/core/odm/mixins.py
+++ b/fiftyone/core/odm/mixins.py
@@ -538,9 +538,9 @@ class DatasetMixin(object):
             are_frame_fields (False): whether these are frame-level fields
             error_level (0): the error level to use. Valid values are:
 
-                0: raise error if a field cannot be deleted
-                1: log warning if a field cannot be deleted
-                2: ignore fields that cannot be deleted
+            -   0: raise error if a field cannot be deleted
+            -   1: log warning if a field cannot be deleted
+            -   2: ignore fields that cannot be deleted
         """
         default_fields = get_default_fields(
             cls.__bases__[0], include_private=True

--- a/fiftyone/core/patches.py
+++ b/fiftyone/core/patches.py
@@ -18,8 +18,6 @@ import fiftyone.core.sample as fos
 import fiftyone.core.utils as fou
 import fiftyone.core.view as fov
 
-fouc = fou.lazy_import("fiftyone.utils.eval.coco")
-
 
 _SINGLE_TYPES_MAP = {
     fol.Detections: fol.Detection,
@@ -513,7 +511,7 @@ def make_evaluation_dataset(sample_collection, eval_key, name=None):
     eval_info = sample_collection.get_evaluation_info(eval_key)
     pred_field = eval_info.config.pred_field
     gt_field = eval_info.config.gt_field
-    if isinstance(eval_info.config, fouc.COCOEvaluationConfig):
+    if hasattr(eval_info.config, "iscrowd"):
         crowd_attr = eval_info.config.iscrowd
     else:
         crowd_attr = None

--- a/fiftyone/core/runs.py
+++ b/fiftyone/core/runs.py
@@ -7,6 +7,8 @@ Dataset runs framework.
 """
 from copy import copy
 import datetime
+import logging
+
 from bson import json_util
 
 import numpy as np
@@ -16,6 +18,9 @@ import eta.core.utils as etau
 
 from fiftyone.core.config import Config, Configurable
 from fiftyone.core.odm.runs import RunDocument
+
+
+logger = logging.getLogger(__name__)
 
 
 class RunInfo(Config):
@@ -56,9 +61,10 @@ class RunConfig(Config):
 
     def __init__(self, **kwargs):
         if kwargs:
-            raise ValueError(
-                "%s has no parameters %s"
-                % (self.__class__, set(kwargs.keys()))
+            logger.warning(
+                "Ignoring unsupported parameters %s for %s",
+                set(kwargs.keys()),
+                type(self),
             )
 
     @property

--- a/fiftyone/core/utils.py
+++ b/fiftyone/core/utils.py
@@ -479,9 +479,9 @@ def handle_error(error, error_level, base_error=None):
         error: an Exception instance
         error_level: the error level to use, defined as:
 
-            0: raise the error
-            1: log the error as a warning
-            2: ignore the error
+        -   0: raise the error
+        -   1: log the error as a warning
+        -   2: ignore the error
 
         base_error: (optional) a base Exception from which to raise ``error``
     """

--- a/fiftyone/core/utils.py
+++ b/fiftyone/core/utils.py
@@ -33,7 +33,6 @@ except:
     import pprint as _pprint
 
 import numpy as np
-import packaging.version
 import xmltodict
 
 import eta
@@ -407,7 +406,7 @@ def ensure_tf(eager=False, error_level=None, error_msg=None):
 
         error_msg += "\n\n" + _REQUIREMENT_ERROR_SUFFIX
 
-        etau.handle_error(ValueError(error_msg), error_level, base_error=e)
+        handle_error(ValueError(error_msg), error_level, base_error=e)
 
         return False
 
@@ -471,6 +470,63 @@ def ensure_torch(error_level=None, error_msg=None):
     )
 
     return success1 & success2
+
+
+def handle_error(error, error_level, base_error=None):
+    """Handles the error at the specified error level.
+
+    Args:
+        error: an Exception instance
+        error_level: the error level to use, defined as:
+
+            0: raise the error
+            1: log the error as a warning
+            2: ignore the error
+
+        base_error: (optional) a base Exception from which to raise ``error``
+    """
+    etau.handle_error(error, error_level, base_error=base_error)
+
+
+class LoggingLevel(object):
+    """Context manager that allows for a temporary change to the level of a
+    ``logging.Logger``.
+
+    Example::
+
+        import logging
+        import fiftyone.core.utils as fou
+
+        with fou.LoggingLevel(logging.CRITICAL):
+            # do things with all logging at CRITICAL
+
+        with fou.LoggingLevel(logging.ERROR, logger="fiftyone"):
+            # do things with FiftyOne logging at ERROR
+
+     Args:
+        level: the logging level to use, e.g., ``logging.ERROR``
+        logger (None): a ``logging.Logger`` or the name of a logger. By
+            default, the root logger is used
+    """
+
+    def __init__(self, level, logger=None):
+        if logger is None or etau.is_str(logger):
+            logger = logging.getLogger(logger)
+
+        if level is None:
+            level = logging.NOTSET
+
+        self._logger = logger
+        self._level = level
+        self._level_orig = None
+
+    def __enter__(self):
+        self._level_orig = self._logger.level
+        self._logger.setLevel(self._level)
+        return self
+
+    def __exit__(self, *args):
+        self._logger.setLevel(self._level_orig)
 
 
 def lazy_import(module_name, callback=None):
@@ -624,8 +680,9 @@ class ResourceLimit(object):
     Example::
 
         import resource
+        import fiftyone.core.utils as fou
 
-        with ResourceLimit(resource.RLIMIT_NOFILE, soft=4096):
+        with fou.ResourceLimit(resource.RLIMIT_NOFILE, soft=4096):
             # temporarily do things with up to 4096 open files
 
      Args:
@@ -642,7 +699,7 @@ class ResourceLimit(object):
 
     def __init__(self, limit, soft=None, hard=None, warn_on_failure=False):
         try:
-            import resource
+            import resource  # pylint: disable=unused-import
 
             self._supported_platform = True
         except ImportError as e:

--- a/fiftyone/utils/eval/classification.py
+++ b/fiftyone/utils/eval/classification.py
@@ -27,15 +27,24 @@ def evaluate_classifications(
     classes=None,
     missing=None,
     method="simple",
-    config=None,
     **kwargs,
 ):
     """Evaluates the classification predictions in the given collection with
     respect to the specified ground truth labels.
 
-    By default, this method simply compares the ground truth and prediction for
-    each sample, but other strategies such as binary evaluation and top-k
-    matching can be configured via the ``method`` and ``config`` parameters.
+    By default, this method simply compares the ground truth and prediction
+    for each sample, but other strategies such as binary evaluation and
+    top-k matching can be configured via the ``method`` parameter.
+
+    You can customize the evaluation method by passing additional
+    parameters for the method's :class:`ClassificationEvaluationConfig` class
+    as ``kwargs``.
+
+    The supported ``method`` values and their associated configs are:
+
+    -   ``"simple"``: :class:`SimpleEvaluationConfig`
+    -   ``"top-k"``: :class:`TopKEvaluationConfig`
+    -   ``"binary"``: :class:`BinaryEvaluationConfig`
 
     If an ``eval_key`` is specified, then this method will record some
     statistics on each sample:
@@ -66,9 +75,6 @@ def evaluate_classifications(
             given this label for results purposes
         method ("simple"): a string specifying the evaluation method to use.
             Supported values are ``("simple", "binary", "top-k")``
-        config (None): an :class:`ClassificationEvaluationConfig` specifying
-            the evaluation method to use. If a ``config`` is provided, the
-            ``method`` and ``kwargs`` parameters are ignored
         **kwargs: optional keyword arguments for the constructor of the
             :class:`ClassificationEvaluationConfig` being used
 
@@ -87,7 +93,7 @@ def evaluate_classifications(
         elif samples.default_classes:
             classes = samples.default_classes
 
-    config = _parse_config(config, pred_field, gt_field, method, **kwargs)
+    config = _parse_config(pred_field, gt_field, method, **kwargs)
     eval_method = config.build()
     eval_method.register_run(samples, eval_key)
 
@@ -1009,10 +1015,7 @@ class BinaryClassificationResults(ClassificationResults):
         )
 
 
-def _parse_config(config, pred_field, gt_field, method, **kwargs):
-    if config is not None:
-        return config
-
+def _parse_config(pred_field, gt_field, method, **kwargs):
     if method is None:
         method = "simple"
 

--- a/fiftyone/utils/eval/classification.py
+++ b/fiftyone/utils/eval/classification.py
@@ -14,7 +14,9 @@ import sklearn.metrics as skm
 import fiftyone.core.evaluation as foe
 from fiftyone.core.expressions import ViewField as F
 import fiftyone.core.fields as fof
+import fiftyone.core.labels as fol
 import fiftyone.core.plots as fop
+import fiftyone.core.validation as fov
 
 
 def evaluate_classifications(
@@ -73,6 +75,10 @@ def evaluate_classifications(
     Returns:
         a :class:`ClassificationResults`
     """
+    fov.validate_collection_label_fields(
+        samples, (pred_field, gt_field), fol.Classification, same_type=True
+    )
+
     if classes is None:
         if pred_field in samples.classes:
             classes = samples.classes[pred_field]

--- a/fiftyone/utils/eval/coco.py
+++ b/fiftyone/utils/eval/coco.py
@@ -44,6 +44,9 @@ class COCOEvaluationConfig(DetectionEvaluationConfig):
         use_masks (False): whether to compute IoUs using the instances masks in
             the ``mask`` attribute of the provided objects, which must be
             :class:`fiftyone.core.labels.Detection` instances
+        use_boxes (False): whether to compute IoUs using the bounding boxes
+            of the provided :class:`fiftyone.core.labels.Polyline` instances
+            rather than using their actual geometries
         tolerance (None): a tolerance, in pixels, when generating approximate
             polylines for instance masks. Typical values are 1-3 pixels
         compute_mAP (False): whether to perform the necessary computations so
@@ -72,6 +75,7 @@ class COCOEvaluationConfig(DetectionEvaluationConfig):
         classwise=None,
         iscrowd="iscrowd",
         use_masks=False,
+        use_boxes=False,
         tolerance=None,
         compute_mAP=False,
         iou_threshs=None,
@@ -91,6 +95,7 @@ class COCOEvaluationConfig(DetectionEvaluationConfig):
 
         self.iscrowd = iscrowd
         self.use_masks = use_masks
+        self.use_boxes = use_boxes
         self.tolerance = tolerance
         self.compute_mAP = compute_mAP
         self.iou_threshs = iou_threshs
@@ -496,8 +501,12 @@ def _coco_evaluation_setup(
     classwise = config.classwise
 
     iou_kwargs = dict(iscrowd=iscrowd, error_level=config.error_level)
+
     if config.use_masks:
         iou_kwargs.update(use_masks=True, tolerance=config.tolerance)
+
+    if config.use_boxes:
+        iou_kwargs.update(use_boxes=True)
 
     # Organize preds and GT by category
     cats = defaultdict(lambda: defaultdict(list))

--- a/fiftyone/utils/eval/coco.py
+++ b/fiftyone/utils/eval/coco.py
@@ -59,9 +59,9 @@ class COCOEvaluationConfig(DetectionEvaluationConfig):
         error_level (1): the error level to use when manipulating instance
             masks or polylines. Valid values are:
 
-                0: raise geometric errors that are encountered
-                1: log warnings if geometric errors are encountered
-                2: ignore geometric errors
+            -   0: raise geometric errors that are encountered
+            -   1: log warnings if geometric errors are encountered
+            -   2: ignore geometric errors
 
             If ``error_level > 0``, any calculation that raises a geometric
             error will default to an IoU of 0

--- a/fiftyone/utils/eval/detection.py
+++ b/fiftyone/utils/eval/detection.py
@@ -11,7 +11,9 @@ import logging
 import numpy as np
 
 import fiftyone.core.evaluation as foe
+import fiftyone.core.labels as fol
 import fiftyone.core.utils as fou
+import fiftyone.core.validation as fov
 
 from .classification import ClassificationResults
 
@@ -109,6 +111,13 @@ def evaluate_detections(
     Returns:
         a :class:`DetectionResults`
     """
+    fov.validate_collection_label_fields(
+        samples,
+        (pred_field, gt_field),
+        (fol.Detections, fol.Polylines),
+        same_type=True,
+    )
+
     if classes is None:
         if pred_field in samples.classes:
             classes = samples.classes[pred_field]
@@ -463,7 +472,7 @@ def _parse_config(config, pred_field, gt_field, method, **kwargs):
 
         return COCOEvaluationConfig(pred_field, gt_field, **kwargs)
 
-    elif method == "open-images":
+    if method == "open-images":
         from .openimages import OpenImagesEvaluationConfig
 
         return OpenImagesEvaluationConfig(pred_field, gt_field, **kwargs)

--- a/fiftyone/utils/eval/detection.py
+++ b/fiftyone/utils/eval/detection.py
@@ -36,6 +36,13 @@ def evaluate_detections(
     """Evaluates the predicted detections in the given samples with respect to
     the specified ground truth detections.
 
+    This method supports evaluating the following spatial data types:
+
+    -   Object detections in :class:`fiftyone.core.labels.Detections` format
+    -   Instance segmentations in :class:`fiftyone.core.labels.Detections`
+        format with their ``mask`` attributes populated
+    -   Polygons in :class:`fiftyone.core.labels.Polylines` format
+
     By default, this method uses COCO-style evaluation, but this can be
     configued via the ``method`` and ``config`` parameters.
 

--- a/fiftyone/utils/eval/detection.py
+++ b/fiftyone/utils/eval/detection.py
@@ -28,6 +28,7 @@ def evaluate_detections(
     missing=None,
     method="coco",
     iou=0.50,
+    use_masks=False,
     classwise=True,
     config=None,
     **kwargs
@@ -82,6 +83,9 @@ def evaluate_detections(
         method ("coco"): a string specifying the evaluation method to use.
             Supported values are ``("coco", "open-images")``
         iou (0.50): the IoU threshold to use to determine matches
+        use_masks (False): whether to compute IoUs using the instances masks in
+            the ``mask`` attribute of the provided objects, which must be
+            :class:`fiftyone.core.labels.Detection` instances
         classwise (True): whether to only match objects with the same class
             label (True) or allow matches between classes (False)
         config (None): an :class:`DetectionEvaluationConfig` specifying the
@@ -108,6 +112,7 @@ def evaluate_detections(
         gt_field,
         method,
         iou=iou,
+        use_masks=use_masks,
         classwise=classwise,
         **kwargs,
     )

--- a/fiftyone/utils/eval/detection.py
+++ b/fiftyone/utils/eval/detection.py
@@ -33,7 +33,6 @@ def evaluate_detections(
     use_masks=False,
     use_boxes=False,
     classwise=True,
-    config=None,
     **kwargs,
 ):
     """Evaluates the predicted detections in the given samples with respect to
@@ -46,8 +45,15 @@ def evaluate_detections(
         format with their ``mask`` attributes populated
     -   Polygons in :class:`fiftyone.core.labels.Polylines` format
 
-    By default, this method uses COCO-style evaluation, but this can be
-    configued via the ``method`` and ``config`` parameters.
+    By default, this method uses COCO-style evaluation, but you can use the
+    ``method`` parameter to select a different method, and you can optionally
+    customize the method by passing additional parameters for the method's
+    :class:`DetectionEvaluationConfig` class as ``kwargs``.
+
+    The supported ``method`` values and their associated configs are:
+
+    -   ``"coco"``: :class:`fiftyone.utils.eval.coco.COCOEvaluationConfig`
+    -   ``"open-images"``: :class:`fiftyone.utils.eval.openimages.OpenImagesEvaluationConfig`
 
     If an ``eval_key`` is provided, a number of fields are populated at the
     object- and sample-level recording the results of the evaluation:
@@ -101,10 +107,6 @@ def evaluate_detections(
             rather than using their actual geometries
         classwise (True): whether to only match objects with the same class
             label (True) or allow matches between classes (False)
-        config (None): an :class:`DetectionEvaluationConfig` specifying the
-            evaluation method to use. If a ``config`` is provided, the
-            ``method``, ``iou``, ``classwise``, and ``kwargs`` parameters are
-            ignored
         **kwargs: optional keyword arguments for the constructor of the
             :class:`DetectionEvaluationConfig` being used
 
@@ -127,7 +129,6 @@ def evaluate_detections(
             classes = samples.default_classes
 
     config = _parse_config(
-        config,
         pred_field,
         gt_field,
         method,
@@ -460,10 +461,7 @@ class DetectionResults(ClassificationResults):
         )
 
 
-def _parse_config(config, pred_field, gt_field, method, **kwargs):
-    if config is not None:
-        return config
-
+def _parse_config(pred_field, gt_field, method, **kwargs):
     if method is None:
         method = "coco"
 

--- a/fiftyone/utils/eval/detection.py
+++ b/fiftyone/utils/eval/detection.py
@@ -29,9 +29,10 @@ def evaluate_detections(
     method="coco",
     iou=0.50,
     use_masks=False,
+    use_boxes=False,
     classwise=True,
     config=None,
-    **kwargs
+    **kwargs,
 ):
     """Evaluates the predicted detections in the given samples with respect to
     the specified ground truth detections.
@@ -93,6 +94,9 @@ def evaluate_detections(
         use_masks (False): whether to compute IoUs using the instances masks in
             the ``mask`` attribute of the provided objects, which must be
             :class:`fiftyone.core.labels.Detection` instances
+        use_boxes (False): whether to compute IoUs using the bounding boxes
+            of the provided :class:`fiftyone.core.labels.Polyline` instances
+            rather than using their actual geometries
         classwise (True): whether to only match objects with the same class
             label (True) or allow matches between classes (False)
         config (None): an :class:`DetectionEvaluationConfig` specifying the
@@ -120,6 +124,7 @@ def evaluate_detections(
         method,
         iou=iou,
         use_masks=use_masks,
+        use_boxes=use_boxes,
         classwise=classwise,
         **kwargs,
     )

--- a/fiftyone/utils/eval/openimages.py
+++ b/fiftyone/utils/eval/openimages.py
@@ -50,9 +50,9 @@ class OpenImagesEvaluationConfig(DetectionEvaluationConfig):
         error_level (1): the error level to use when manipulating instance
             masks or polylines. Valid values are:
 
-                0: raise geometric errors that are encountered
-                1: log warnings if geometric errors are encountered
-                2: ignore geometric errors
+            -   0: raise geometric errors that are encountered
+            -   1: log warnings if geometric errors are encountered
+            -   2: ignore geometric errors
 
             If ``error_level > 0``, any calculation that raises a geometric
             error will default to an IoU of 0

--- a/fiftyone/utils/eval/openimages.py
+++ b/fiftyone/utils/eval/openimages.py
@@ -40,6 +40,9 @@ class OpenImagesEvaluationConfig(DetectionEvaluationConfig):
         use_masks (False): whether to compute IoUs using the instances masks in
             the ``mask`` attribute of the provided objects, which must be
             :class:`fiftyone.core.labels.Detection` instances
+        use_boxes (False): whether to compute IoUs using the bounding boxes
+            of the provided :class:`fiftyone.core.labels.Polyline` instances
+            rather than using their actual geometries
         tolerance (None): a tolerance, in pixels, when generating approximate
             polylines for instance masks. Typical values are 1-3 pixels
         max_preds (None): the maximum number of predicted objects to evaluate
@@ -76,6 +79,7 @@ class OpenImagesEvaluationConfig(DetectionEvaluationConfig):
         classwise=None,
         iscrowd="IsGroupOf",
         use_masks=False,
+        use_boxes=False,
         tolerance=None,
         max_preds=None,
         error_level=1,
@@ -92,6 +96,7 @@ class OpenImagesEvaluationConfig(DetectionEvaluationConfig):
 
         self.iscrowd = iscrowd
         self.use_masks = use_masks
+        self.use_boxes = use_boxes
         self.tolerance = tolerance
         self.max_preds = max_preds
         self.error_level = error_level
@@ -542,8 +547,12 @@ def _open_images_evaluation_setup(
     classwise = config.classwise
 
     iou_kwargs = dict(iscrowd=iscrowd, error_level=config.error_level)
+
     if config.use_masks:
         iou_kwargs.update(use_masks=True, tolerance=config.tolerance)
+
+    if config.use_boxes:
+        iou_kwargs.update(use_boxes=True)
 
     # Organize preds and GT by category
     cats = defaultdict(lambda: defaultdict(list))

--- a/fiftyone/utils/eval/segmentation.py
+++ b/fiftyone/utils/eval/segmentation.py
@@ -31,7 +31,6 @@ def evaluate_segmentations(
     eval_key=None,
     mask_targets=None,
     method="simple",
-    config=None,
     **kwargs,
 ):
     """Evaluates the specified semantic segmentation masks in the given
@@ -39,6 +38,15 @@ def evaluate_segmentations(
 
     If the size of a predicted mask does not match the ground truth mask, it
     is resized to match the ground truth.
+
+    By default, this method simply performs pixelwise evaluation of the full
+    masks, but other strategies such as boundary-only evaluation can be
+    configured by passing additional parameters for the method's
+    :class:`SegmentationEvaluationConfig` class as ``kwargs``.
+
+    The supported ``method`` values and their associated configs are:
+
+    -   ``"simple"``: :class:`SimpleEvaluationConfig`
 
     If an ``eval_key`` is provided, the accuracy, precision, and recall of each
     sample is recorded in top-level fields of each sample::
@@ -73,9 +81,6 @@ def evaluate_segmentations(
             possible, or else the observed pixel values are used
         method ("simple"): a string specifying the evaluation method to use.
             Supported values are ``("simple")``
-        config (None): a :class:`SegmentationEvaluationConfig` specifying the
-            evaluation method to use. If a ``config`` is provided, the
-            ``method`` and ``kwargs`` parameters are ignored
         **kwargs: optional keyword arguments for the constructor of the
             :class:`SegmentationEvaluationConfig` being used
 
@@ -94,7 +99,7 @@ def evaluate_segmentations(
         elif samples.default_mask_targets:
             mask_targets = samples.default_mask_targets
 
-    config = _parse_config(config, pred_field, gt_field, method, **kwargs)
+    config = _parse_config(pred_field, gt_field, method, **kwargs)
     eval_method = config.build()
     eval_method.register_run(samples, eval_key)
 
@@ -378,10 +383,7 @@ class SegmentationResults(ClassificationResults):
         return ytrue, ypred, weights
 
 
-def _parse_config(config, pred_field, gt_field, method, **kwargs):
-    if config is not None:
-        return config
-
+def _parse_config(pred_field, gt_field, method, **kwargs):
     if method is None:
         method = "simple"
 

--- a/fiftyone/utils/eval/segmentation.py
+++ b/fiftyone/utils/eval/segmentation.py
@@ -14,7 +14,9 @@ import sklearn.metrics as skm
 import eta.core.image as etai
 
 import fiftyone.core.evaluation as foe
+import fiftyone.core.labels as fol
 import fiftyone.core.utils as fou
+import fiftyone.core.validation as fov
 
 from .classification import ClassificationResults
 
@@ -80,6 +82,10 @@ def evaluate_segmentations(
     Returns:
         a :class:`SegmentationResults`
     """
+    fov.validate_collection_label_fields(
+        samples, (pred_field, gt_field), fol.Segmentation, same_type=True
+    )
+
     if mask_targets is None:
         if pred_field in samples.mask_targets:
             mask_targets = samples.mask_targets[pred_field]

--- a/fiftyone/utils/eval/utils.py
+++ b/fiftyone/utils/eval/utils.py
@@ -5,12 +5,17 @@ Evaluation utilities.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+import contextlib
+import logging
+
 import numpy as np
+
+import eta.core.numutils as etan
 
 import fiftyone.core.labels as fol
 import fiftyone.core.utils as fou
 
-se = fou.lazy_import("shapely.errors")
+sg = fou.lazy_import("shapely.geometry")
 so = fou.lazy_import("shapely.ops")
 
 
@@ -39,7 +44,9 @@ def make_iscrowd_fcn(iscrowd_attr):
     return _iscrowd
 
 
-def compute_ious(preds, gts, iscrowd=None, use_masks=False, tolerance=None):
+def compute_ious(
+    preds, gts, iscrowd=None, use_masks=False, tolerance=None, error_level=1
+):
     """Computes the pairwise IoUs between the predicted and ground truth
     objects.
 
@@ -58,6 +65,15 @@ def compute_ious(preds, gts, iscrowd=None, use_masks=False, tolerance=None):
             :class:`fiftyone.core.labels.Detection` instances
         tolerance (None): a tolerance, in pixels, when generating approximate
             polylines for instance masks. Typical values are 1-3 pixels
+        error_level (1): the error level to use when manipulating instance
+            masks or polylines. Valid values are:
+
+                0: raise geometric errors that are encountered
+                1: log warnings if geometric errors are encountered
+                2: ignore geometric errors
+
+            If ``error_level > 0``, any calculation that raises a geometric
+            error will default to an IoU of 0
 
     Returns:
         a ``num_preds x num_gts`` array of IoUs
@@ -66,11 +82,16 @@ def compute_ious(preds, gts, iscrowd=None, use_masks=False, tolerance=None):
         return np.zeros((len(preds), len(gts)))
 
     if isinstance(preds[0], fol.Polyline):
-        return _compute_polyline_ious(preds, gts, iscrowd=iscrowd)
+        return _compute_polyline_ious(preds, gts, error_level, iscrowd=iscrowd)
 
     if use_masks:
+        # @todo when tolerance is None, consider using dense masks rather than
+        # polygonal approximations?
+        if tolerance is None:
+            tolerance = 2
+
         return _compute_mask_ious(
-            preds, gts, iscrowd=iscrowd, tolerance=tolerance
+            preds, gts, tolerance, error_level, iscrowd=iscrowd,
         )
 
     return _compute_bbox_ious(preds, gts, iscrowd=iscrowd)
@@ -99,85 +120,132 @@ def _compute_bbox_ious(preds, gts, iscrowd=None):
 
             inter = h * w
             union = pred_area if gt_crowd else pred_area + gt_area - inter
-            ious[i, j] = min(inter / union, 1)
+            ious[i, j] = min(etan.safe_divide(inter, union), 1)
 
     return ious
 
 
-def _compute_polyline_ious(preds, gts, iscrowd=None, gt_crowds=None):
-    num_pred = len(preds)
-    pred_polys = _to_shapely(preds)
-    pred_areas = [pred_poly.area for pred_poly in pred_polys]
+def _compute_polyline_ious(
+    preds, gts, error_level, iscrowd=None, gt_crowds=None
+):
+    with contextlib.ExitStack() as context:
+        # We're ignoring errors, so suppress shapely logging that occurs when
+        # invalid geometries are encountered
+        if error_level > 1:
+            # pylint: disable=no-member
+            context.enter_context(
+                fou.LoggingLevel(logging.CRITICAL, logger="shapely")
+            )
 
-    num_gt = len(gts)
-    gt_polys = _to_shapely(gts)
-    gt_areas = [gt_poly.area for gt_poly in gt_polys]
+        num_pred = len(preds)
+        pred_polys = _polylines_to_shapely(preds, error_level)
+        pred_areas = [pred_poly.area for pred_poly in pred_polys]
 
-    if iscrowd is not None:
-        gt_crowds = [iscrowd(gt) for gt in gts]
-    elif gt_crowds is None:
-        gt_crowds = [False] * num_gt
+        num_gt = len(gts)
+        gt_polys = _polylines_to_shapely(gts, error_level)
+        gt_areas = [gt_poly.area for gt_poly in gt_polys]
 
-    ious = np.zeros((num_pred, num_gt))
-    for j, (gt_poly, gt_area, gt_crowd) in enumerate(
-        zip(gt_polys, gt_areas, gt_crowds)
-    ):
-        for i, (pred_poly, pred_area) in enumerate(
-            zip(pred_polys, pred_areas)
+        if iscrowd is not None:
+            gt_crowds = [iscrowd(gt) for gt in gts]
+        elif gt_crowds is None:
+            gt_crowds = [False] * num_gt
+
+        ious = np.zeros((num_pred, num_gt))
+        for j, (gt_poly, gt_area, gt_crowd) in enumerate(
+            zip(gt_polys, gt_areas, gt_crowds)
         ):
-            try:
-                inter = gt_poly.intersection(pred_poly).area
-            except se.TopologicalError as e:
-                raise ValueError(
-                    "Failed to compute intersection of predicted object "
-                    "'%s' and ground truth object '%s'. See above for "
-                    "details" % (preds[i].id, gts[j].id)
-                ) from e
+            for i, (pred_poly, pred_area) in enumerate(
+                zip(pred_polys, pred_areas)
+            ):
+                try:
+                    inter = gt_poly.intersection(pred_poly).area
+                except Exception as e:
+                    inter = 0.0
+                    fou.handle_error(
+                        ValueError(
+                            "Failed to compute intersection of predicted object "
+                            "'%s' and ground truth object '%s'"
+                            % (preds[i].id, gts[j].id)
+                        ),
+                        error_level,
+                        base_error=e,
+                    )
 
-            if gt_crowd:
-                union = pred_area
-            else:
-                union = pred_area + gt_area - inter
+                if gt_crowd:
+                    union = pred_area
+                else:
+                    union = pred_area + gt_area - inter
 
-            ious[i, j] = min(inter / union, 1)
+                ious[i, j] = min(etan.safe_divide(inter, union), 1)
 
-    return ious
+        return ious
 
 
-def _compute_mask_ious(preds, gts, iscrowd=None, tolerance=None):
-    # @todo when tolerance is None, consider using dense masks rather than polygonal approximations?
-    if tolerance is None:
-        tolerance = 2
+def _compute_mask_ious(preds, gts, tolerance, error_level, iscrowd=None):
+    with contextlib.ExitStack() as context:
+        # We're ignoring errors, so suppress shapely logging that occurs when
+        # invalid geometries are encountered
+        if error_level > 1:
+            # pylint: disable=no-member
+            context.enter_context(
+                fou.LoggingLevel(logging.CRITICAL, logger="shapely")
+            )
 
-    pred_polys = _to_polylines(preds, tolerance=tolerance)
-    gt_polys = _to_polylines(gts, tolerance=tolerance)
+        pred_polys = _masks_to_polylines(preds, tolerance, error_level)
+        gt_polys = _masks_to_polylines(gts, tolerance, error_level)
 
     if iscrowd is not None:
         gt_crowds = [iscrowd(gt) for gt in gts]
     else:
         gt_crowds = [False] * len(gts)
 
-    return _compute_polyline_ious(pred_polys, gt_polys, gt_crowds=gt_crowds)
+    return _compute_polyline_ious(
+        pred_polys, gt_polys, error_level, gt_crowds=gt_crowds
+    )
 
 
-def _to_polylines(detections, tolerance=None):
+def _masks_to_polylines(detections, tolerance, error_level):
     polylines = []
     for detection in detections:
-        polyline = detection.to_polyline(tolerance=tolerance)
+        try:
+            polyline = detection.to_polyline(tolerance=tolerance)
+        except Exception as e:
+            polyline = fol.Polyline()
+            fou.handle_error(
+                ValueError(
+                    "Failed to convert instance mask for object '%s' to "
+                    "polygons" % detection.id
+                ),
+                error_level,
+                base_error=e,
+            )
+
         polyline._id = detection._id  # keep same ID
         polylines.append(polyline)
 
     return polylines
 
 
-def _to_shapely(polylines):
+def _polylines_to_shapely(polylines, error_level):
     polys = []
     for polyline in polylines:
-        poly = polyline.to_shapely()
+        try:
+            poly = polyline.to_shapely()
 
-        # Cleanup invalid (eg overlapping) geometries
-        # https://shapely.readthedocs.io/en/stable/manual.html#shapely.ops.unary_union
-        poly = so.unary_union(poly)
+            # Cleanup invalid (eg overlapping or self-intersecting) geometries
+            # https://shapely.readthedocs.io/en/stable/manual.html#shapely.ops.unary_union
+            # https://shapely.readthedocs.io/en/stable/manual.html#object.buffer
+            poly = so.unary_union(poly).buffer(0)
+        except Exception as e:
+            poly = sg.Polygon()
+            fou.handle_error(
+                ValueError(
+                    "Failed to convert polygon for object '%s' to Shapely "
+                    "format" % polyline.id
+                ),
+                error_level,
+                base_error=e,
+            )
 
         polys.append(poly)
 

--- a/fiftyone/utils/eval/utils.py
+++ b/fiftyone/utils/eval/utils.py
@@ -1,0 +1,184 @@
+"""
+Evaluation utilities.
+
+| Copyright 2017-2021, Voxel51, Inc.
+| `voxel51.com <https://voxel51.com/>`_
+|
+"""
+import numpy as np
+
+import fiftyone.core.labels as fol
+import fiftyone.core.utils as fou
+
+se = fou.lazy_import("shapely.errors")
+so = fou.lazy_import("shapely.ops")
+
+
+def make_iscrowd_fcn(iscrowd_attr):
+    """Returns a boolean function that determines whether a
+    :class:`fiftyone.core.labels.Label` is a crowd by checking for an attribute
+    with the given name.
+
+    Args:
+        iscrowd_attr: the name of the crowd attribute
+
+    Returns:
+        a boolean function
+    """
+
+    def _iscrowd(label):
+        try:
+            return bool(label[iscrowd_attr])
+        except KeyError:
+            # @todo remove Attribute usage
+            if iscrowd_attr in label.attributes:
+                return bool(label.attributes[iscrowd_attr].value)
+
+            return False
+
+    return _iscrowd
+
+
+def compute_ious(preds, gts, iscrowd=None, use_masks=False, tolerance=None):
+    """Computes the pairwise IoUs between the predicted and ground truth
+    objects.
+
+    Args:
+        preds: a list of predicted :class:`fiftyone.core.labels.Detection` or
+            :class:`fiftyone.core.labels.Polyline` instances
+        gt_field: a list of ground truth
+            :class:`fiftyone.core.labels.Detection` or
+            :class:`fiftyone.core.labels.Polyline` instances
+        iscrowd (None): an optional boolean function that determines whether a
+            ground truth object is a crowd. If provided, the area of the
+            predicted object is used as the "union" area for IoU calculations
+            involving crowd objects
+        use_masks (False): whether to compute IoUs using the instances masks in
+            the ``mask`` attribute of the provided objects, which must be
+            :class:`fiftyone.core.labels.Detection` instances
+        tolerance (None): a tolerance, in pixels, when generating approximate
+            polylines for instance masks. Typical values are 1-3 pixels
+
+    Returns:
+        a ``num_preds x num_gts`` array of IoUs
+    """
+    if not preds or not gts:
+        return np.zeros((len(preds), len(gts)))
+
+    if isinstance(preds[0], fol.Polyline):
+        return _compute_polyline_ious(preds, gts, iscrowd=iscrowd)
+
+    if use_masks:
+        return _compute_mask_ious(
+            preds, gts, iscrowd=iscrowd, tolerance=tolerance
+        )
+
+    return _compute_bbox_ious(preds, gts, iscrowd=iscrowd)
+
+
+def _compute_bbox_ious(preds, gts, iscrowd=None):
+    ious = np.zeros((len(preds), len(gts)))
+    for j, gt in enumerate(gts):
+        gx, gy, gw, gh = gt.bounding_box
+        gt_area = gh * gw
+        gt_crowd = iscrowd(gt) if iscrowd is not None else False
+
+        for i, pred in enumerate(preds):
+            px, py, pw, ph = pred.bounding_box
+            pred_area = ph * pw
+
+            # Width of intersection
+            w = min(px + pw, gx + gw) - max(px, gx)
+            if w <= 0:
+                continue
+
+            # Height of intersection
+            h = min(py + ph, gy + gh) - max(py, gy)
+            if h <= 0:
+                continue
+
+            inter = h * w
+            union = pred_area if gt_crowd else pred_area + gt_area - inter
+            ious[i, j] = min(inter / union, 1)
+
+    return ious
+
+
+def _compute_polyline_ious(preds, gts, iscrowd=None, gt_crowds=None):
+    num_pred = len(preds)
+    pred_polys = _to_shapely(preds)
+    pred_areas = [pred_poly.area for pred_poly in pred_polys]
+
+    num_gt = len(gts)
+    gt_polys = _to_shapely(gts)
+    gt_areas = [gt_poly.area for gt_poly in gt_polys]
+
+    if iscrowd is not None:
+        gt_crowds = [iscrowd(gt) for gt in gts]
+    elif gt_crowds is None:
+        gt_crowds = [False] * num_gt
+
+    ious = np.zeros((num_pred, num_gt))
+    for j, (gt_poly, gt_area, gt_crowd) in enumerate(
+        zip(gt_polys, gt_areas, gt_crowds)
+    ):
+        for i, (pred_poly, pred_area) in enumerate(
+            zip(pred_polys, pred_areas)
+        ):
+            try:
+                inter = gt_poly.intersection(pred_poly).area
+            except se.TopologicalError as e:
+                raise ValueError(
+                    "Failed to compute intersection of predicted object "
+                    "'%s' and ground truth object '%s'. See above for "
+                    "details" % (preds[i].id, gts[j].id)
+                ) from e
+
+            if gt_crowd:
+                union = pred_area
+            else:
+                union = pred_area + gt_area - inter
+
+            ious[i, j] = min(inter / union, 1)
+
+    return ious
+
+
+def _compute_mask_ious(preds, gts, iscrowd=None, tolerance=None):
+    # @todo when tolerance is None, consider using dense masks rather than polygonal approximations?
+    if tolerance is None:
+        tolerance = 2
+
+    pred_polys = _to_polylines(preds, tolerance=tolerance)
+    gt_polys = _to_polylines(gts, tolerance=tolerance)
+
+    if iscrowd is not None:
+        gt_crowds = [iscrowd(gt) for gt in gts]
+    else:
+        gt_crowds = [False] * len(gts)
+
+    return _compute_polyline_ious(pred_polys, gt_polys, gt_crowds=gt_crowds)
+
+
+def _to_polylines(detections, tolerance=None):
+    polylines = []
+    for detection in detections:
+        polyline = detection.to_polyline(tolerance=tolerance)
+        polyline._id = detection._id  # keep same ID
+        polylines.append(polyline)
+
+    return polylines
+
+
+def _to_shapely(polylines):
+    polys = []
+    for polyline in polylines:
+        poly = polyline.to_shapely()
+
+        # Cleanup invalid (eg overlapping) geometries
+        # https://shapely.readthedocs.io/en/stable/manual.html#shapely.ops.unary_union
+        poly = so.unary_union(poly)
+
+        polys.append(poly)
+
+    return polys

--- a/fiftyone/utils/eval/utils.py
+++ b/fiftyone/utils/eval/utils.py
@@ -77,9 +77,9 @@ def compute_ious(
         error_level (1): the error level to use when manipulating instance
             masks or polylines. Valid values are:
 
-                0: raise geometric errors that are encountered
-                1: log warnings if geometric errors are encountered
-                2: ignore geometric errors
+            -   0: raise geometric errors that are encountered
+            -   1: log warnings if geometric errors are encountered
+            -   2: ignore geometric errors
 
             If ``error_level > 0``, any calculation that raises a geometric
             error will default to an IoU of 0

--- a/tests/intensive/evaluation_tests.py
+++ b/tests/intensive/evaluation_tests.py
@@ -325,7 +325,7 @@ def test_evaluate_detections():
     dataset.delete_evaluations()
 
 
-def test_evaluate_polylines():
+def test_evaluate_polygons():
     dataset = foz.load_zoo_dataset(
         "coco-2017",
         split="validation",
@@ -391,13 +391,9 @@ def test_evaluate_polylines():
             sample.save()
 
     results1 = dataset.evaluate_detections(
-        "pred_det",
-        gt_field="detections",
-        eval_key="det_coco",
-        method="coco",
-        compute_mAP=True,
+        "pred_det", gt_field="detections", eval_key="det_coco", method="coco"
     )
-    print(results1.mAP())
+    print(results1.metrics())
 
     results2 = dataset.evaluate_detections(
         "pred_seg",
@@ -405,18 +401,13 @@ def test_evaluate_polylines():
         eval_key="seg_coco",
         method="coco",
         use_masks=True,
-        compute_mAP=True,
     )
-    print(results2.mAP())
+    print(results2.metrics())
 
     results3 = dataset.evaluate_detections(
-        "pred_pol",
-        gt_field="polylines",
-        eval_key="pol_coco",
-        method="coco",
-        compute_mAP=True,
+        "pred_pol", gt_field="polylines", eval_key="pol_coco", method="coco"
     )
-    print(results3.mAP())
+    print(results3.metrics())
 
     results4 = dataset.evaluate_detections(
         "pred_pol",
@@ -424,9 +415,8 @@ def test_evaluate_polylines():
         eval_key="pol_coco",
         method="coco",
         use_boxes=True,
-        compute_mAP=True,
     )
-    print(results4.mAP())
+    print(results4.metrics())
 
     results1 = dataset.evaluate_detections(
         "pred_det",
@@ -434,7 +424,7 @@ def test_evaluate_polylines():
         eval_key="det_oi",
         method="open-images",
     )
-    print(results1.mAP())
+    print(results1.metrics())
 
     results2 = dataset.evaluate_detections(
         "pred_seg",
@@ -443,7 +433,7 @@ def test_evaluate_polylines():
         method="open-images",
         use_masks=True,
     )
-    print(results2.mAP())
+    print(results2.metrics())
 
     results3 = dataset.evaluate_detections(
         "pred_pol",
@@ -451,7 +441,7 @@ def test_evaluate_polylines():
         eval_key="pol_oi",
         method="open-images",
     )
-    print(results3.mAP())
+    print(results3.metrics())
 
     results4 = dataset.evaluate_detections(
         "pred_pol",
@@ -460,7 +450,7 @@ def test_evaluate_polylines():
         method="open-images",
         use_boxes=True,
     )
-    print(results4.mAP())
+    print(results4.metrics())
 
 
 def test_evaluate_detections_frames():

--- a/tests/intensive/evaluation_tests.py
+++ b/tests/intensive/evaluation_tests.py
@@ -37,7 +37,7 @@ _MISSING = "-"
 
 def test_evaluate_classifications():
     dataset = foz.load_zoo_dataset("imagenet-sample").clone()
-    logits_classes = dataset.info["classes"]
+    logits_classes = dataset.default_classes
 
     model = foz.load_zoo_model("resnet50-imagenet-torch")
     dataset.take(25).apply_model(model, "predictions", store_logits=True)
@@ -613,7 +613,8 @@ def test_classification_results():
     results.print_report()
 
     # Includes all 3 classes
-    results.plot_confusion_matrix()
+    plot = results.plot_confusion_matrix()
+    plot.show()
 
     classes = ["cat", "dog"]
 
@@ -623,10 +624,12 @@ def test_classification_results():
 
     # Only include `cat` and `dog` rows (GT); associated non-cat/dog
     # predictions are captured in an "other" column
-    results.plot_confusion_matrix(classes=classes)
+    plot = results.plot_confusion_matrix(classes=classes)
+    plot.show()
 
     # Only include `cat` and `dog` rows (GT) and columns (predictions)
-    results.plot_confusion_matrix(classes=classes, include_other=False)
+    plot = results.plot_confusion_matrix(classes=classes, include_other=False)
+    plot.show()
 
     input("Press enter to continue...")
 
@@ -643,7 +646,8 @@ def test_classification_results_missing_data():
 
     # Data includes missing GT/preds, so includes a "none" row/column when
     # plotting confusion matrix
-    results.plot_confusion_matrix()
+    plot = results.plot_confusion_matrix()
+    plot.show()
 
     classes = ["cat", "dog"]
 
@@ -653,10 +657,12 @@ def test_classification_results_missing_data():
 
     # Shows per-class metrics for only `cat` and `dog` classes, but other
     # predictions when GT=cat/dog are taken into account for P/R/F1 scores
-    results.plot_confusion_matrix(classes=classes)
+    plot = results.plot_confusion_matrix(classes=classes)
+    plot.show()
 
     # Only include `cat` and `dog` rows (GT) and columns (predictions)
-    results.plot_confusion_matrix(classes=classes, include_other=False)
+    plot = results.plot_confusion_matrix(classes=classes, include_other=False)
+    plot.show()
 
     input("Press enter to continue...")
 
@@ -677,18 +683,22 @@ def test_detection_results():
     results.print_report(classes=classes)
 
     # Should contain "other" and "none" columns
-    results.plot_confusion_matrix(classes=classes)
+    plot = results.plot_confusion_matrix(classes=classes)
+    plot.show()
 
     # Should not contain "other" or "none" columns
-    results.plot_confusion_matrix(classes=classes, include_other=False)
+    plot = results.plot_confusion_matrix(classes=classes, include_other=False)
+    plot.show()
 
     # Should contain "other" and "none" columns, as well as a "none" row
-    results.plot_confusion_matrix(classes=classes + [results.missing])
+    plot = results.plot_confusion_matrix(classes=classes + [results.missing])
+    plot.show()
 
     # Should contain "none" row and columns
-    results.plot_confusion_matrix(
+    plot = results.plot_confusion_matrix(
         classes=classes + [results.missing], include_other=False
     )
+    plot.show()
 
     input("Press enter to continue...")
 


### PR DESCRIPTION
Resolves https://github.com/voxel51/fiftyone/issues/1101.

### Description

The `evaluate_detections()` method now supports evaluating `Polylines` and `Detections` with instance masks. Both COCO and Open Images flavored evaluations are supported, as the only difference for these new cases is how IoU is computed.

The user will be prompted to install [Shapely](https://github.com/Toblerity/Shapely) the first time they run an evaluation that requires polgyon computations. Thanks to the awesome Shapely library, IoU computation on polygons should be quite robust, as things like self-overlapping and self-intersecting shapes will be appropriately handled.

**Note:** I decided against including `shapely` as a builtin requirement because, while it is cross-platform and stable, is does rely on compiled C++ code and thus some users may want/need to tweak their install slightly beyond what `pip install shapely` provides. Also, polygon evaluation is a fairly niche thing.

**Note:** Currently, instance segmentations are first converted to polygons with a default tolerance of 2 pixels and then IoU calculations are performed on those. If users are interested in computing IoUs directly from the array masks, then we could look into it, but the implementation would take a bit more work that I didn't feel like doing just yet.

### Misc

One small additional change added here is the removal of the `config` parameter from `compute_*()`, which was intended to offer an alternative to specifying `method` + `**kwargs` to configure the evaluation method.

This change was motivated by realizing that the configs hold the names of the GT and predicted fields, but the predicted field is also a mandatory positional argument for the `compute_*()` methods themselves, which is confusing. Also, removing the `config` option avoids the potential confusion resulting from multiple syntaxes to achieve the same thing...

### Example usage

```py
import random
import numpy as np

import fiftyone as fo
import fiftyone.zoo as foz

# Create dataset

def jitter(labels, delta=0.03):
    if isinstance(labels, fo.Detections):
        for detection in labels.detections:
            alpha = random.random()
            bounding_box = np.array(detection.bounding_box)
            bounding_box += alpha * delta * np.array([1, 1, 0, 0])
            detection.bounding_box = bounding_box.tolist()
            detection.confidence = alpha

    if isinstance(labels, fo.Polylines):
        for polyline in labels.polylines:
            alpha = random.random()
            points = []
            for _points in polyline.points:
                _points = np.array(_points)
                _points += alpha * delta * np.ones(_points.shape)
                points.append(_points.tolist())

            polyline.points = points
            polyline.confidence = alpha

    return labels

dataset = foz.load_zoo_dataset(
    "coco-2017",
    split="validation",
    label_types=["detections", "segmentations"],
    max_samples=50,
)

# Add polylines
with fo.ProgressBar() as pb:
    for sample in pb(dataset):
        sample["polylines"] = sample["segmentations"].to_polylines()
        sample.save()

# Add mock predictions
with fo.ProgressBar() as pb:
    for sample in pb(dataset):
        sample["pred_det"] = jitter(sample["detections"].copy())
        sample["pred_seg"] = jitter(sample["segmentations"].copy())
        sample["pred_pol"] = jitter(sample["polylines"].copy())
        sample.save()

print(dataset)

# Detection evaluation
results1 = dataset.evaluate_detections(
    "pred_det",
    gt_field="detections",
    eval_key="det_coco",
)
print(results1.metrics())

# Instance segmentation evaluation
results2 = dataset.evaluate_detections(
    "pred_seg",
    gt_field="segmentations",
    eval_key="seg_coco",
    use_masks=True,
)
print(results2.metrics())

# Polygon evaluation
results3 = dataset.evaluate_detections(
    "pred_pol",
    gt_field="polylines",
    eval_key="pol_coco",
)
print(results3.metrics())

# Polygon evaluation but use bounding boxes for IoU calculations
results4 = dataset.evaluate_detections(
    "pred_pol",
    gt_field="polylines",
    eval_key="pol_coco",
    use_boxes=True,
)
print(results4.metrics())
```

### Documentation

<img width="794" alt="Screen Shot 2021-07-09 at 1 55 48 AM" src="https://user-images.githubusercontent.com/25985824/125030338-fb223900-e058-11eb-9b5e-4c4322c70013.png">
