### PR TITLE
Adding support for loading COCO license data

### DIFF
--- a/docs/source/integrations/coco.rst
+++ b/docs/source/integrations/coco.rst
@@ -133,6 +133,14 @@ COCO-2014 and COCO-2017 by passing them to
 -   ``include_id``: whether to include the COCO ID of each sample in the loaded
     labels. By default, this is False
 
+-   ``include_license``: whether to include the COCO license of each sample in
+    the loaded labels, if available. The supported values are:
+
+    -   ``"False"`` (default): don't load the license
+    -   ``True``/``"id"``: store the integer license ID
+    -   ``"name"``: store the string license name
+    -   ``"url"``: store the license URL
+
 -   ``only_matching``: whether to only load labels that match the ``classes``
     or ``attrs`` requirements that you provide (True), or to load all labels
     for samples that match the requirements (False). By default, this is False

--- a/docs/source/integrations/coco.rst
+++ b/docs/source/integrations/coco.rst
@@ -137,8 +137,8 @@ COCO-2014 and COCO-2017 by passing them to
     the loaded labels, if available. The supported values are:
 
     -   ``"False"`` (default): don't load the license
-    -   ``True``/``"id"``: store the integer license ID
-    -   ``"name"``: store the string license name
+    -   ``True``/``"name"``: store the string license name
+    -   ``"id"``: store the integer license ID
     -   ``"url"``: store the license URL
 
 -   ``only_matching``: whether to only load labels that match the ``classes``

--- a/docs/source/user_guide/dataset_creation/datasets.rst
+++ b/docs/source/user_guide/dataset_creation/datasets.rst
@@ -897,15 +897,15 @@ where ``labels.json`` is a JSON file in the following format:
 .. code-block:: text
 
     {
-        "info": {
-            "year": "",
-            "version": "",
-            "description": "Exported from FiftyOne",
-            "contributor": "",
-            "url": "https://voxel51.com/fiftyone",
-            "date_created": "2020-06-19T09:48:27"
-        },
-        "licenses": [],
+        "info": {...},
+        "licenses": [
+            {
+                "id": 1,
+                "name": "Attribution-NonCommercial-ShareAlike License",
+                "url": "http://creativecommons.org/licenses/by-nc-sa/2.0/",
+            },
+            ...
+        ],
         "categories": [
             ...
             {
@@ -918,7 +918,7 @@ where ``labels.json`` is a JSON file in the following format:
         "images": [
             {
                 "id": 1,
-                "license": null,
+                "license": 1,
                 "file_name": "<filename0>.<ext>",
                 "height": 480,
                 "width": 640,

--- a/docs/source/user_guide/dataset_zoo/datasets.rst
+++ b/docs/source/user_guide/dataset_zoo/datasets.rst
@@ -543,8 +543,8 @@ COCO-2014 by passing them to
     the loaded labels, if available. The supported values are:
 
     -   ``"False"`` (default): don't load the license
-    -   ``True``/``"id"``: store the integer license ID
-    -   ``"name"``: store the string license name
+    -   ``True``/``"name"``: store the string license name
+    -   ``"id"``: store the integer license ID
     -   ``"url"``: store the license URL
 
 -   ``only_matching``: whether to only load labels that match the ``classes``

--- a/docs/source/user_guide/dataset_zoo/datasets.rst
+++ b/docs/source/user_guide/dataset_zoo/datasets.rst
@@ -539,6 +539,14 @@ COCO-2014 by passing them to
 -   ``include_id``: whether to include the COCO ID of each sample in the loaded
     labels. By default, this is False
 
+-   ``include_license``: whether to include the COCO license of each sample in
+    the loaded labels, if available. The supported values are:
+
+    -   ``"False"`` (default): don't load the license
+    -   ``True``/``"id"``: store the integer license ID
+    -   ``"name"``: store the string license name
+    -   ``"url"``: store the license URL
+
 -   ``only_matching``: whether to only load labels that match the ``classes``
     or ``attrs`` requirements that you provide (True), or to load all labels
     for samples that match the requirements (False). By default, this is False
@@ -766,6 +774,9 @@ COCO-2017 by passing them to
 
 -   ``include_id``: whether to include the COCO ID of each sample in the loaded
     labels. By default, this is False
+
+-   ``include_license``: whether to include the COCO license of each sample in
+    the loaded labels. By default, this is False
 
 -   ``only_matching``: whether to only load labels that match the ``classes``
     or ``attrs`` requirements that you provide (True), or to load all labels

--- a/fiftyone/types/dataset_types.py
+++ b/fiftyone/types/dataset_types.py
@@ -509,7 +509,14 @@ class COCODetectionDataset(ImageDetectionDataset):
                 "url": "https://voxel51.com/fiftyone",
                 "date_created": "2020-06-19T09:48:27"
             },
-            "licenses": [],
+            "licenses": [
+                {
+                    "id": 1,
+                    "name": "Attribution-NonCommercial-ShareAlike License",
+                    "url": "http://creativecommons.org/licenses/by-nc-sa/2.0/",
+                },
+                ...
+            ],
             "categories": [
                 ...
                 {
@@ -524,7 +531,7 @@ class COCODetectionDataset(ImageDetectionDataset):
             "images": [
                 {
                     "id": 1,
-                    "license": null,
+                    "license": 1,
                     "file_name": "<filename0>.<ext>",
                     "height": 480,
                     "width": 640,

--- a/fiftyone/utils/coco.py
+++ b/fiftyone/utils/coco.py
@@ -273,8 +273,8 @@ class COCODetectionDatasetImporter(
             sample in the loaded labels, if available. Supported values are:
 
             -   ``"False"``: don't load the license
-            -   ``True``/``"id"``: store the integer license ID
-            -   ``"name"``: store the string license name
+            -   ``True``/``"name"``: store the string license name
+            -   ``"id"``: store the integer license ID
             -   ``"url"``: store the license URL
 
             Note that the license descriptions (if available) are always loaded
@@ -1701,7 +1701,7 @@ def _parse_include_license(include_license):
         )
 
     if include_license == True:
-        include_license = "id"
+        include_license = "name"
 
     return include_license
 

--- a/fiftyone/utils/coco.py
+++ b/fiftyone/utils/coco.py
@@ -269,6 +269,8 @@ class COCODetectionDatasetImporter(
                 two formats
         include_id (False): whether to include the COCO ID of each sample in the
             loaded labels
+        include_license (False): whether to include the license ID of each
+            sample in the loaded labels
         extra_attrs (None): whether to load extra annotation attributes onto
             the imported labels. Supported values are:
 
@@ -306,6 +308,7 @@ class COCODetectionDatasetImporter(
         classes=None,
         image_ids=None,
         include_id=False,
+        include_license=False,
         extra_attrs=None,
         only_matching=False,
         use_polylines=False,
@@ -328,6 +331,9 @@ class COCODetectionDatasetImporter(
 
         if include_id:
             label_types.append("coco_id")
+
+        if include_license:
+            label_types.append("license")
 
         super().__init__(
             dataset_dir=dataset_dir,
@@ -445,6 +451,9 @@ class COCODetectionDatasetImporter(
         if "coco_id" in self.label_types:
             label["coco_id"] = image_id
 
+        if "license" in self.label_types:
+            label["license"] = image_dict.get("license", None)
+
         if self._has_scalar_labels:
             label = next(iter(label.values())) if label else None
 
@@ -470,6 +479,7 @@ class COCODetectionDatasetImporter(
             "segmentations": seg_type,
             "keypoints": fol.Keypoints,
             "coco_id": int,
+            "license": int,
         }
 
         if self._has_scalar_labels:


### PR DESCRIPTION
Resolves https://github.com/voxel51/fiftyone/issues/1108.

`COCODetectionDatasetImporter` now provides an optional `include_license` flag that will load the license data for the images, if available.

```
include_license (False): whether to include the license ID of each
    sample in the loaded labels, if available. Supported values are:

    -   ``"False"``: don't load the license
    -   ``True``/``"name"``: store the string license name
    -   ``"id"``: store the integer license ID
    -   ``"url"``: store the license URL

    Note that the license descriptions (if available) are always loaded
    into ``dataset.info["licenses"]`` and can be used to convert
    between ID, name, and URL later
```

Example usage:

```py
import fiftyone as fo
import fiftyone.zoo as foz
from fiftyone import ViewField as F

dataset = foz.load_zoo_dataset(
    "coco-2017",
    split="validation",
    classes="person",
    max_samples=50,
    include_license=True,
)

print(dataset.info["licenses"])
print(dataset.count_values("license"))

session = fo.launch_app(dataset)

session.view = dataset.match(
    F("license").is_in(
        [
            "Attribution License",
            "Attribution-ShareAlike License",
        ]
    )
)

session.view = dataset.match(F("license").contains_str("NoDerivs"))
```

It's also quite convenient to use the filter sidebar in the App to search for licenses of interest:

<img width="1272" alt="Screen Shot 2021-07-10 at 10 34 16 AM" src="https://user-images.githubusercontent.com/25985824/125166664-aa026a00-e16a-11eb-877e-04ca0a468e02.png">
