### PR TITLE
Adding plotly<5 requirement to fix interactive plotting

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -81,7 +81,7 @@ setup(
         "packaging",
         "pandas",
         "Pillow>=6.2",
-        "plotly>=4.14",
+        "plotly>=4.14,<5",
         "pprintpp",
         "psutil",
         "pymongo>=3.11,<4",


### PR DESCRIPTION
[Interactive plotting](https://voxel51.com/docs/fiftyone/user_guide/plots.html) seems to be broken by some backwards incompatible changes introduced in `plotly>=5`... The plots still render, but selection callbacks are no longer triggered.

We'll need to investigate further, but, for now, I've verified that requiring `plotly>=4.14,<5` is sufficient to regain callbacks.