### PR TITLE
Added RHEL7 install for fiftyone-db

### DIFF
--- a/.github/workflows/build-db.yml
+++ b/.github/workflows/build-db.yml
@@ -67,6 +67,12 @@ jobs:
         run: |
           cd package/db
           python setup.py bdist_wheel --plat-name linux-x86_64
+      - name: Build wheel (RHEL/CentOS 7 x86_64)
+        env:
+          FIFTYONE_DB_BUILD_LINUX_DISTRO: rhel7
+        run: |
+          cd package/db
+          python setup.py bdist_wheel --plat-name linux-x86_64
       - name: Upload wheel (linux-86_64)
         uses: actions/upload-artifact@v2
         with:
@@ -87,6 +93,11 @@ jobs:
         with:
           name: wheel-debian9
           path: package/db/dist/*debian9*.whl
+      - name: Upload wheel (RHEL/CentOS 7)
+        uses: actions/upload-artifact@v2
+        with:
+          name: wheel-rhel7
+          path: package/db/dist/*rhel7*.whl
       - name: Upload wheel (macOS)
         uses: actions/upload-artifact@v2
         with:

--- a/docs/source/getting_started/troubleshooting.rst
+++ b/docs/source/getting_started/troubleshooting.rst
@@ -194,6 +194,12 @@ installation by adding `--force-reinstall` to the commands below.
 
       pip install fiftyone-db-debian9
 
+  .. tab:: RHEL 7
+
+    .. code-block:: shell
+
+      pip install fiftyone-db-rhel7
+
 Manual installation
 ~~~~~~~~~~~~~~~~~~~
 

--- a/package/db/setup.py
+++ b/package/db/setup.py
@@ -35,6 +35,9 @@ MONGODB_DOWNLOAD_URLS = {
     "debian9": {
         "manylinux1_x86_64": "https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-debian92-4.4.2.tgz",
     },
+    "rhel7": {
+        "manylinux1_x86_64": "https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-rhel70-4.4.2.tgz",
+    },
 }
 
 # mongodb binaries to distribute

--- a/package/test-envs/dockerfiles/centos7
+++ b/package/test-envs/dockerfiles/centos7
@@ -1,0 +1,9 @@
+FROM centos:7
+
+RUN yum install -y python3-devel python3-pip gcc
+
+ENV PATH="/root/.local/bin:${PATH}"
+
+RUN pip3 install --user --upgrade pip setuptools wheel
+
+WORKDIR /test


### PR DESCRIPTION
## Fix 
This patch fixes the install issue  #1097 when installing fiftyone on RHEL7.
The changes include adding download url option to the db package's `setup.py` for rhel7 distribution.
```python 
MONGODB_DOWNLOAD_URLS = {
    "linux-x86_64": "https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-ubuntu1804-4.4.2.tgz",
    "linux-aarch64": "https://fastdl.mongodb.org/linux/mongodb-linux-aarch64-ubuntu1804-4.4.2.tgz",
    "mac": "https://fastdl.mongodb.org/osx/mongodb-macos-x86_64-4.4.2.tgz",
    "win": "https://fastdl.mongodb.org/windows/mongodb-windows-x86_64-4.4.2.zip",
    "ubuntu1604": {
        "manylinux1_x86_64": "https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-ubuntu1604-4.4.2.tgz",
    },
    "debian9": {
        "manylinux1_x86_64": "https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-debian92-4.4.2.tgz",
    },
    "rhel7": {
        "manylinux1_x86_64": "https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-rhel70-4.4.2.tgz",
    },
}

```
## Tests

This patch was testing by creating a local wheel package add installing it using docker test-envs for Centos7. 

```
FROM centos:7

RUN yum install -y python3-devel python3-pip gcc

ENV PATH="/root/.local/bin:${PATH}"

RUN pip3 install --user --upgrade pip setuptools wheel

WORKDIR /test
```

Added a tab in `docs/getting-started/troubleshooting` for rhel7 install fix.


-   [ ] App: FiftyOne application changes
-   [x] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
