### PR TITLE
Catch exception when trying to patch plotly on read-only FS

### DIFF
--- a/fiftyone/core/plots/plotly.py
+++ b/fiftyone/core/plots/plotly.py
@@ -2419,8 +2419,12 @@ def _patch_perform_plotly_relayout():
     if find in code:
         logger.debug("Patching '%s'", filepath)
         fixed = code.replace(find, replace)
-        with open(filepath, "w") as f:
-            f.write(fixed)
+        try:
+            with open(filepath, "w") as f:
+                f.write(fixed)
+        except OSError as e:
+            logger.debug("Unable to patch '%s'", filepath)
+            logger.debug(e)
     elif replace in code:
         logger.debug("Already patched '%s'", filepath)
     else:


### PR DESCRIPTION
## What changes are proposed in this pull request?

Patching plotly fails when running in a read-only filesystem (e.g. inside [Singularity](https://sylabs.io/guides/3.8/user-guide/)).
This just catches the exception and logs it. 

## How is this patch tested? If it is not, please explain why.

Tested by running fiftyone in Singularity and verifying that it doesn't crash the process anymore.

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
