### PR TITLE
width height mismatch from coco formatted data

### DIFF
--- a/fiftyone/utils/coco.py
+++ b/fiftyone/utils/coco.py
@@ -187,7 +187,7 @@ def add_coco_labels(
     labels = []
     for coco_id, height, width in zip(coco_ids, heights, widths):
         coco_objects = coco_objects_map[coco_id]
-        frame_size = (height, width)
+        frame_size = (width, height)
 
         if label_type == "detections":
             _labels = _coco_objects_to_detections(


### PR DESCRIPTION
## What changes are proposed in this pull request?

Found a bug where for non-square images the bounding boxes were being imported wrong into Voxel51.  Found that width and height had been swapped in one line of the coco utils.  All the documentation gives a `(width, height)` format, which matches coco format, but one line has the `frame_size` swapped to a `(height, width)` format.

## How is this patch tested? If it is not, please explain why.

Swapped width and height normalization parameters in test data and observed that although the numbers in the prediction file don't match pixel locations the boxes are drawn correctly. 

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.
Bugfix in MSCOCO Detection Import Utility to correctly draw bounding boxes.

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
