### PR TITLE
Handling degenerate masks when exporting COCO segmentations

### DIFF
--- a/fiftyone/utils/coco.py
+++ b/fiftyone/utils/coco.py
@@ -2048,7 +2048,15 @@ def _make_coco_segmentation(detection, frame_size, iscrowd, tolerance):
         return None
 
     dobj = detection.to_detected_object()
-    mask = etai.render_instance_image(dobj.mask, dobj.bounding_box, frame_size)
+
+    try:
+        mask = etai.render_instance_image(
+            dobj.mask, dobj.bounding_box, frame_size
+        )
+    except:
+        # Either mask or bounding box is too small to render
+        width, height = frame_size
+        mask = np.zeros((height, width), dtype=bool)
 
     if iscrowd:
         return _mask_to_rle(mask)


### PR DESCRIPTION
Resolves #1138.

If an object instance is too small to be rendered when exporting in COCO format, it will now be given an empty `segmentations` field, where previous an image resizing error would have been raised.

