### PR TITLE
Fixing #1146

### DIFF
--- a/fiftyone/utils/cityscapes.py
+++ b/fiftyone/utils/cityscapes.py
@@ -266,7 +266,7 @@ def _export_split(
     uuids = sorted(images_map.keys())
 
     logger.info("Finalizing split '%s'...", split)
-    exporter = foud.FiftyOneDatasetExporter(split_dir, move_media=False)
+    exporter = foud.FiftyOneDatasetExporter(split_dir)
     pb = fou.ProgressBar()
     with exporter, pb:
         exporter.log_collection(dataset)

--- a/fiftyone/utils/cityscapes.py
+++ b/fiftyone/utils/cityscapes.py
@@ -19,6 +19,7 @@ import fiftyone.core.media as fom
 import fiftyone.core.sample as fos
 import fiftyone.core.utils as fou
 import fiftyone.utils.data as foud
+import fiftyone.types as fot
 
 
 logger = logging.getLogger(__name__)
@@ -266,7 +267,7 @@ def _export_split(
     uuids = sorted(images_map.keys())
 
     logger.info("Finalizing split '%s'...", split)
-    exporter = foud.FiftyOneDatasetExporter(split_dir)
+    exporter = foud.LegacyFiftyOneDatasetExporter(split_dir)
     pb = fou.ProgressBar()
     with exporter, pb:
         exporter.log_collection(dataset)

--- a/fiftyone/utils/data/exporters.py
+++ b/fiftyone/utils/data/exporters.py
@@ -1329,7 +1329,6 @@ class LegacyFiftyOneDatasetExporter(GenericSampleDatasetExporter):
             -   ``"move"``: move media files into the export directory
             -   ``"symlink"``: create symlinks to each media file in the export
                 directory
-
         relative_filepaths (True): whether to store relative (True) or absolute
             (False) filepaths to media files on disk in the output dataset
         pretty_print (False): whether to render the JSON in human readable
@@ -1493,7 +1492,6 @@ class FiftyOneDatasetExporter(BatchDatasetExporter):
             -   ``"move"``: move media files into the export directory
             -   ``"symlink"``: create symlinks to each media file in the export
                 directory
-
         rel_dir (None): a relative directory to remove from the ``filepath`` of
             each sample, if possible. The path is converted to an absolute path
             (if necessary) via ``os.path.abspath(os.path.expanduser(rel_dir))``.


### PR DESCRIPTION
Resolves #1146.

We unfortunately don't have unit tests for zoo datasets that require manually downloaded source files. Cityscapes is one of those and some recent changes caused a regression. This particular bug is specific to Cityscapes; no other zoo datasets.

Verified by running the following successfully:

```py
import fiftyone as fo
import fiftyone.zoo as foz

# The path to the source files that you manually downloaded
source_dir = "/path/to/source/files"

dataset = foz.load_zoo_dataset("cityscapes", split="validation", source_dir=source_dir)
```
