### PR TITLE
Open Images download hotfix

### DIFF
--- a/fiftyone/utils/openimages.py
+++ b/fiftyone/utils/openimages.py
@@ -283,8 +283,8 @@ class OpenImagesV6DatasetImporter(foud.LabeledImageDatasetImporter):
             attrs=attrs,
             oi_attrs=oi_attrs,
             seg_classes=seg_classes,
-            track_all_ids=max_samples is not None,
             ids_only=False,
+            track_all_ids=max_samples is not None,
             only_matching=self.only_matching,
             download=False,
         )
@@ -961,8 +961,9 @@ def _get_all_label_data(
     attrs=None,
     oi_attrs=None,
     seg_classes=None,
-    track_all_ids=True,
+    download_only=False,
     ids_only=False,
+    track_all_ids=True,
     only_matching=False,
     split=None,
     download=False,
@@ -994,8 +995,9 @@ def _get_all_label_data(
             "classifications",
             classes=classes,
             oi_classes=oi_classes,
-            track_all_ids=track_all_ids,
+            download_only=download_only,
             ids_only=ids_only,
+            track_all_ids=track_all_ids,
             only_matching=only_matching,
             url=url,
             download=download,
@@ -1022,8 +1024,9 @@ def _get_all_label_data(
             oi_classes=oi_classes,
             url=url,
             download=download,
-            track_all_ids=track_all_ids,
+            download_only=download_only,
             ids_only=ids_only,
+            track_all_ids=track_all_ids,
             only_matching=only_matching,
         )
         did_download |= _did_download
@@ -1043,8 +1046,9 @@ def _get_all_label_data(
             "relationships",
             classes=attrs,
             oi_classes=oi_attrs,
-            track_all_ids=track_all_ids,
+            download_only=download_only,
             ids_only=ids_only,
+            track_all_ids=track_all_ids,
             only_matching=only_matching,
             url=url,
             download=download,
@@ -1076,8 +1080,9 @@ def _get_all_label_data(
             "segmentations",
             classes=classes,
             oi_classes=oi_classes,
-            track_all_ids=track_all_ids,
+            download_only=download_only,
             ids_only=ids_only,
+            track_all_ids=track_all_ids,
             only_matching=only_matching,
             url=url,
             download=download,
@@ -1118,8 +1123,9 @@ def _get_label_data(
     label_type,
     classes=None,
     oi_classes=None,
-    track_all_ids=True,
+    download_only=False,
     ids_only=False,
+    track_all_ids=True,
     only_matching=False,
     url=None,
     download=True,
@@ -1128,6 +1134,9 @@ def _get_label_data(
     did_download = _download_file_if_necessary(
         csv_path, url, quiet=0, download=download
     )
+
+    if download_only:
+        return set(), set(), {}, did_download
 
     df = _parse_csv(csv_path, dataframe=True)
     df.set_index("ImageID", drop=False, inplace=True)
@@ -1204,36 +1213,36 @@ def _download(
     num_workers=None,
     download=True,
 ):
-    did_download = False
+    # Download any necessary labels, and, if specific classes/attributes are
+    # requested, determine which image IDs have the specified labels
+    (
+        _,
+        _,
+        _,
+        _,
+        all_label_ids,
+        any_label_ids,
+        did_download,
+    ) = _get_all_label_data(
+        dataset_dir,
+        image_ids,
+        label_types=label_types,
+        classes=classes,
+        oi_classes=oi_classes,
+        attrs=attrs,
+        oi_attrs=oi_attrs,
+        seg_classes=seg_classes,
+        download_only=classes is None and attrs is None,
+        ids_only=True,
+        track_all_ids=max_samples is not None,
+        split=split,
+        download=download,
+    )
+
     downloaded_ids = set(downloaded_ids)
 
     # Make list of `target_ids`
     if classes is not None or attrs is not None:
-        # Determine which samples have specified classes/attributes
-        (
-            _,
-            _,
-            _,
-            _,
-            all_label_ids,
-            any_label_ids,
-            _did_download,
-        ) = _get_all_label_data(
-            dataset_dir,
-            image_ids,
-            label_types=label_types,
-            classes=classes,
-            oi_classes=oi_classes,
-            attrs=attrs,
-            oi_attrs=oi_attrs,
-            seg_classes=seg_classes,
-            track_all_ids=max_samples is not None,
-            ids_only=True,
-            split=split,
-            download=download,
-        )
-        did_download |= _did_download
-
         if max_samples is not None:
             #
             # Bias sampling to meet user requirements per the priorities below:

--- a/fiftyone/utils/openimages.py
+++ b/fiftyone/utils/openimages.py
@@ -592,7 +592,7 @@ def _setup(
     download=False,
 ):
     did_download = False
-    label_types = _parse_label_types(label_types)
+    _label_types = _parse_label_types(label_types)
 
     if etau.is_str(classes):
         classes = [classes]
@@ -633,7 +633,7 @@ def _setup(
     else:
         oi_classes = None
 
-    if "relationships" in label_types:
+    if "relationships" in _label_types:
         # Map of attribute IDs to attribute names
         attrs_map, _did_download = _get_attrs_map(
             dataset_dir, download=download
@@ -670,7 +670,7 @@ def _setup(
         oi_attrs = None
         all_attrs = None
 
-    if "segmentations" in label_types:
+    if "segmentations" in _label_types:
         seg_classes, _did_download = _get_seg_classes(
             dataset_dir, classes_map=classes_map, download=download
         )

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ class BdistWheelCustom(bdist_wheel):
         ]
 
 
-VERSION = "0.11.3"
+VERSION = "0.11.2.1"
 
 
 def get_version():

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ class BdistWheelCustom(bdist_wheel):
         ]
 
 
-VERSION = "0.11.2"
+VERSION = "0.11.3"
 
 
 def get_version():

--- a/tests/intensive/dataset_zoo_tests.py
+++ b/tests/intensive/dataset_zoo_tests.py
@@ -208,36 +208,6 @@ def test_coco_2017():
 
 def test_open_images_v6():
     dataset = foz.load_zoo_dataset(
-        "open-images-v6", split="validation", max_samples=5,
-    )
-    schema = dataset.get_field_schema()
-
-    assert "positive_labels" in schema
-    assert "negative_labels" in schema
-    assert "detections" in schema
-    assert "relationships" in schema
-    assert "segmentations" in schema
-    assert "open_images_id" in schema
-    assert len(dataset) == 5
-    assert len(dataset.match_tags("validation")) == 5
-    dataset.delete()
-
-    dataset = foz.load_zoo_dataset(
-        "open-images-v6", split="validation", max_samples=5, label_field="gt",
-    )
-    schema = dataset.get_field_schema()
-
-    assert "gt_positive_labels" in schema
-    assert "gt_negative_labels" in schema
-    assert "gt_detections" in schema
-    assert "gt_relationships" in schema
-    assert "gt_segmentations" in schema
-    assert "gt_open_images_id" in schema
-    assert len(dataset) == 5
-    assert len(dataset.match_tags("validation")) == 5
-    dataset.delete()
-
-    dataset = foz.load_zoo_dataset(
         "open-images-v6",
         split="validation",
         label_types=["segmentations"],
@@ -297,6 +267,36 @@ def test_open_images_v6():
 
     assert "ground_truth" in schema
     assert "open_images_id" not in schema
+    dataset.delete()
+
+    dataset = foz.load_zoo_dataset(
+        "open-images-v6", split="validation", max_samples=5,
+    )
+    schema = dataset.get_field_schema()
+
+    assert "positive_labels" in schema
+    assert "negative_labels" in schema
+    assert "detections" in schema
+    assert "relationships" in schema
+    assert "segmentations" in schema
+    assert "open_images_id" in schema
+    assert len(dataset) == 5
+    assert len(dataset.match_tags("validation")) == 5
+    dataset.delete()
+
+    dataset = foz.load_zoo_dataset(
+        "open-images-v6", split="validation", max_samples=5, label_field="gt",
+    )
+    schema = dataset.get_field_schema()
+
+    assert "gt_positive_labels" in schema
+    assert "gt_negative_labels" in schema
+    assert "gt_detections" in schema
+    assert "gt_relationships" in schema
+    assert "gt_segmentations" in schema
+    assert "gt_open_images_id" in schema
+    assert len(dataset) == 5
+    assert len(dataset.match_tags("validation")) == 5
     dataset.delete()
 
     dataset = foz.load_zoo_dataset(


### PR DESCRIPTION
Fixes a bug where label files were not being downloaded when running a `load_zoo_dataset()` call that does not include `classes` or `attrs` options in an environment where Open Images has never been downloaded:

```py
import fiftyone.zoo as foz

foz.delete_zoo_dataset("open-images-v6", split="validation")

# previously would fail, now succeeds
dataset = foz.load_zoo_dataset("open-images-v6", split="validation", max_samples=5)
```