### PR TITLE
Only load matching samples when classes/attrs requirements are provided

### DIFF
--- a/fiftyone/utils/openimages.py
+++ b/fiftyone/utils/openimages.py
@@ -311,7 +311,12 @@ class OpenImagesV6DatasetImporter(foud.LabeledImageDatasetImporter):
             valid_ids = all_label_ids + not_all_ids + extra_ids
             valid_ids = valid_ids[:max_samples]
         else:
-            valid_ids = sorted(image_ids)
+            if self.classes is None and self.attrs is None:
+                # No requirements were provided, so always make all samples
+                # available
+                valid_ids = sorted(image_ids)
+            else:
+                valid_ids = sorted(any_label_ids)
 
             if shuffle:
                 random.shuffle(valid_ids)


### PR DESCRIPTION
Resolves https://github.com/voxel51/fiftyone/issues/1153.

Fixes a bug where `classes/attrs` requirements were being ignored when loading the Open Images dataset with no `max_samples` requirement.

The *download* portion of the code was respecting the requirements, but the *import* portion was not (when no `max_samples` requirement was provided), so, as the example below demonstrates, running multiple loads could currently cause issues:

```py
import fiftyone.zoo as foz

# Download some samples
foz.load_zoo_dataset(
    "open-images-v6",
    split="validation",
    max_samples=50,
)

# This previously loaded all downloaded samples, but now only loads `House` samples, as expected
dataset = foz.load_zoo_dataset(
    "open-images-v6",
    split="validation",
    classes=["House"],
)
```
