### PR TITLE
Adding session.wait() instructions in key places

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,9 +86,14 @@ dataset = foz.load_zoo_dataset("quickstart")
 session = fo.launch_app(dataset)
 ```
 
-You can also check out
+Then check out
 [this Colab notebook](https://colab.research.google.com/github/voxel51/fiftyone-examples/blob/master/examples/quickstart.ipynb)
 to see some common workflows on the quickstart dataset.
+
+Note that if you are running the above code in a script, you must include
+`session.wait()` to block execution until you close the App. See
+[this page](https://voxel51.com/docs/fiftyone/user_guide/app.html#creating-a-session)
+for more information.
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -72,11 +72,12 @@ FiftyOne.
 
 ## Quickstart
 
-Dive right into FiftyOne by running the snippet below, which downloads a
+Dive right into FiftyOne by opening a Python shell and running the snippet
+below, which downloads a
 [small dataset](https://voxel51.com/docs/fiftyone/user_guide/dataset_zoo/datasets.html#quickstart)
 and launches the
 [FiftyOne App](https://voxel51.com/docs/fiftyone/user_guide/app.html) so you
-can explore it!
+can explore it:
 
 ```py
 import fiftyone as fo

--- a/docs/source/faq/index.rst
+++ b/docs/source/faq/index.rst
@@ -37,6 +37,36 @@ default.
 Check out the :ref:`enviornments guide <environments>` to see how to use
 FiftyOne in all common local, remote, cloud, and notebook environments.
 
+.. _faq-app-no-session:
+
+Why isn't the App opening? Not connected to a session?
+------------------------------------------------------
+
+When you call :func:`fo.launch_app() <fiftyone.core.session.launch_app>` to
+launch the :ref:`FiftyOne App <fiftyone-app>`, the App will launch
+asynchronously and return control to your Python process. The App will then
+remain connected until the process exits.
+
+If you are using the App in a script, you should use
+:meth:`session.wait() <fiftyone.core.session.Session.wait>` to block execution
+until you close it manually:
+
+.. code-block:: python
+
+    # Launch the App
+    session = fo.launch_app(...)
+
+    # (Perform any additional operations here)
+
+    # Blocks execution until the App is closed
+    session.wait()
+
+If you launch the App in a script without including
+:meth:`session.wait() <fiftyone.core.session.Session.wait>`, the App's
+connection will close when the script exits, and you will see a message like
+"It looks like you are not connected to a session" in the browser tab that was
+opened.
+
 .. _faq-notebook-support:
 
 Can I use FiftyOne in a notebook?

--- a/docs/source/getting_started/install.rst
+++ b/docs/source/getting_started/install.rst
@@ -30,8 +30,7 @@ note that `tensorflow` does not yet support 3.9.
 On Linux, we recommended installing Python through your system package manager
 (APT, YUM, etc.) if it is available. On other platforms, Python can be
 downloaded `from python.org <https://www.python.org/downloads>`_. To verify that
-a suitable Python version is installed and accessible, run `python3 --version`
-or `python --version`.
+a suitable Python version is installed and accessible, run `python --version`.
 
 We encourage installing FiftyOne in a virtual environment. See
 :doc:`setting up a virtual environment <virtualenv>` for more details.
@@ -48,9 +47,9 @@ are using, then run:
 
    pip install fiftyone
 
-This will install FiftyOne and all of its dependencies, which may take some
-time. Once this has completed, you can verify that FiftyOne is installed in
-your virtual environment by importing the `fiftyone` package:
+This will install FiftyOne and all of its dependencies. Once this has
+completed, you can verify that FiftyOne is installed in your virtual
+environment by importing the `fiftyone` package:
 
 .. code-block:: text
 
@@ -67,9 +66,9 @@ A successful installation of FiftyOne should result in no output when
 Quickstart
 ----------
 
-Dive right into FiftyOne by launching Python and running the snippet below,
-which downloads a :ref:`small dataset <dataset-zoo-quickstart>` and launches
-the :ref:`FiftyOne App <fiftyone-app>` so you can explore it!
+Dive right into FiftyOne by opening a Python shell and running the snippet
+below, which downloads a :ref:`small dataset <dataset-zoo-quickstart>` and
+launches the :ref:`FiftyOne App <fiftyone-app>` so you can explore it!
 
 .. code-block:: python
     :linenos:

--- a/docs/source/getting_started/install.rst
+++ b/docs/source/getting_started/install.rst
@@ -80,6 +80,11 @@ the :ref:`FiftyOne App <fiftyone-app>` so you can explore it!
     dataset = foz.load_zoo_dataset("quickstart")
     session = fo.launch_app(dataset)
 
+Note that if you are running this code in a script, you must include
+:meth:`session.wait() <fiftyone.core.session.Session.wait>` to block execution
+until you close the App. See :ref:`this page <creating-an-app-session>` for
+more information.
+
 .. _installing-fiftyone-desktop:
 
 FiftyOne Desktop App

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -59,10 +59,8 @@ failure modes, finding annotation mistakes, and much more!
     :button_text: Install FiftyOne!
     :button_link: getting_started/install.html
 
-**The pandas for visual datasets**
-
 FiftyOne integrates naturally with your favorite tools. Click on a logo to
-learn how!
+learn how:
 
 .. raw:: html
 
@@ -256,15 +254,15 @@ adding custom tags, model predictions and more.
     datasets in custom formats.
 
     Check out :doc:`loading datasets <user_guide/dataset_creation/index>` to see
-    how to load your data into FiftyOne!
+    how to load your data into FiftyOne.
 
 :doc:`FiftyOne App <user_guide/app>`
 ------------------------------------
 
-The FiftyOne App is a graphical user interface (GUI) that makes it easy to
-rapidly gain intuition into your datasets. You can visualize labels, bounding
-boxes and segmentations overlayed on the samples; sort, query and slice your
-dataset into any aspect you need; and more.
+The FiftyOne App is a graphical user interface that makes it easy to explore
+and rapidly gain intuition into your datasets. You can visualize labels like
+bounding boxes and segmentations overlaid on the samples; sort, query and
+slice your dataset into any subset of interest; and more.
 
 .. custombutton::
     :button_text: See more of the App

--- a/docs/source/user_guide/app.rst
+++ b/docs/source/user_guide/app.rst
@@ -60,7 +60,7 @@ would like to run the App as a desktop application.
     App asynchronously and return control to your Python process. The App will
     then remain connected until the process exits.
 
-    If you are using the App in a non-interactive script, you should use
+    If you are using the App in a script, you should use
     :meth:`session.wait() <fiftyone.core.session.Session.wait>` to block
     execution until you close it manually:
 


### PR DESCRIPTION
A common user issue is using `launch_app()` in a script without including `session.wait()`.

This PR attempts to document the correct usage of the FiftyOne App from scripts in the primary places where (I think?) new users might be going wrong:

<img width="789" alt="Screen Shot 2021-08-02 at 12 36 17 PM" src="https://user-images.githubusercontent.com/25985824/127894920-3d3d3b45-ec64-4a38-8916-0666dd310178.png">

<img width="781" alt="Screen Shot 2021-08-02 at 12 36 26 PM" src="https://user-images.githubusercontent.com/25985824/127894931-15d9e565-7b9e-4ccb-884a-b153af4bb2ec.png">

<img width="877" alt="Screen Shot 2021-08-02 at 12 36 47 PM" src="https://user-images.githubusercontent.com/25985824/127894945-6f1b1f1b-4522-4bdc-9e8d-fdbc66a2763c.png">
