### PR TITLE
Gracefully ignore None-valued new fields when expanding dataset schemas

### DIFF
--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -934,6 +934,8 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
             )
             fos.Sample._reload_docs(self._sample_collection_name)
 
+        self._reload()
+
     def _rename_frame_fields(self, field_mapping, view=None):
         if self.media_type != fom.VIDEO:
             raise ValueError("Only video datasets have frame fields")
@@ -959,6 +961,8 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
                 embedded_fields, embedded_new_fields, sample_collection
             )
             fofr.Frame._reload_docs(self._frame_collection_name)
+
+        self._reload()
 
     def clone_sample_field(self, field_name, new_field_name):
         """Clones the given sample field into a new field of the dataset.
@@ -1030,6 +1034,7 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
             )
 
         fos.Sample._reload_docs(self._sample_collection_name)
+        self._reload()
 
     def _clone_frame_fields(self, field_mapping, view=None):
         if self.media_type != fom.VIDEO:
@@ -1052,6 +1057,7 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
             )
 
         fofr.Frame._reload_docs(self._frame_collection_name)
+        self._reload()
 
     def clear_sample_field(self, field_name):
         """Clears the values of the field from all samples in the dataset.
@@ -1227,6 +1233,8 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
             self._sample_doc_cls._delete_embedded_fields(embedded_fields)
             fos.Sample._reload_docs(self._sample_collection_name)
 
+        self._reload()
+
     def _delete_frame_fields(self, field_names, error_level):
         if self.media_type != fom.VIDEO:
             raise ValueError("Only video datasets have frame fields")
@@ -1242,6 +1250,8 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
         if embedded_fields:
             self._frame_doc_cls._delete_embedded_fields(embedded_fields)
             fofr.Frame._reload_docs(self._frame_collection_name)
+
+        self._reload()
 
     def iter_samples(self, progress=False):
         """Returns an iterator over the samples in the dataset.

--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -4047,8 +4047,8 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
                     if value is not None or not field.null:
                         try:
                             field.validate(value)
-                        except Exception as e:
-                            raise ValueError(
+                        except moe.ValidationError as e:
+                            raise moe.ValidationError(
                                 "Invalid value for field '%s'. Reason: %s"
                                 % (field_name, str(e))
                             )

--- a/fiftyone/core/frame.py
+++ b/fiftyone/core/frame.py
@@ -547,9 +547,16 @@ class Frames(object):
         doc = self._dataset._frame_dict_to_doc(d)
         return Frame.from_doc(doc, dataset=self._dataset)
 
-    def _make_dict(self, frame):
-        d = frame.to_mongo_dict()
+    def _make_dict(self, frame, include_id=False):
+        d = frame.to_mongo_dict(include_id=include_id)
+
+        # We omit None here to allow frames with None-valued new fields to
+        # be added without raising nonexistent field errors. This is safe
+        # because None and missing are equivalent in our data model
+        d = {k: v for k, v in d.items() if v is not None}
+
         d["_sample_id"] = self._sample._id
+
         return d
 
     def _to_frames_dict(self):

--- a/fiftyone/core/labels.py
+++ b/fiftyone/core/labels.py
@@ -1368,6 +1368,8 @@ def _to_eta_attributes(label):
             _attr = etad.NumericAttribute(name, value)
         elif isinstance(value, bool):
             _attr = etad.BooleanAttribute(name, value)
+        elif value is None:
+            continue
         else:
             msg = "Ignoring unsupported attribute type '%s'" % type(value)
             warnings.warn(msg)

--- a/fiftyone/core/runs.py
+++ b/fiftyone/core/runs.py
@@ -342,11 +342,8 @@ class Run(Configurable):
                 same key
         """
         key = run_info.key
-        dataset_doc = samples._root_dataset._doc
-        view_stages = [json_util.dumps(s) for s in samples.view()._serialize()]
-        run_docs = getattr(dataset_doc, cls._runs_field())
 
-        if key in run_docs:
+        if key in cls.list_runs(samples):
             if overwrite:
                 cls.delete_run(samples, key)
             else:
@@ -354,6 +351,10 @@ class Run(Configurable):
                     "%s with key '%s' already exists"
                     % (cls._run_str().capitalize(), key)
                 )
+
+        dataset_doc = samples._root_dataset._doc
+        run_docs = getattr(dataset_doc, cls._runs_field())
+        view_stages = [json_util.dumps(s) for s in samples.view()._serialize()]
 
         run_docs[key] = RunDocument(
             key=key,

--- a/tests/unittests/dataset_tests.py
+++ b/tests/unittests/dataset_tests.py
@@ -6,10 +6,10 @@ FiftyOne dataset-related unit tests.
 |
 """
 import gc
-import unittest
 import os
 
 import numpy as np
+import unittest
 
 import eta.core.utils as etau
 

--- a/tests/unittests/dataset_tests.py
+++ b/tests/unittests/dataset_tests.py
@@ -9,6 +9,8 @@ import gc
 import unittest
 import os
 
+import numpy as np
+
 import eta.core.utils as etau
 
 import fiftyone as fo
@@ -713,6 +715,58 @@ class DatasetTests(unittest.TestCase):
                     None,
                 ],
             )
+
+    @drop_datasets
+    def test_expand_schema(self):
+        # None-valued new fields are ignored for schema expansion
+
+        dataset = fo.Dataset()
+
+        sample = fo.Sample(filepath="image.jpg", ground_truth=None)
+        dataset.add_sample(sample)
+
+        self.assertNotIn("ground_truth", dataset.get_field_schema())
+
+        # None-valued new fields are allowed when a later sample determines the
+        # appropriate field type
+
+        dataset = fo.Dataset()
+
+        samples = [
+            fo.Sample(filepath="image1.jpg", ground_truth=None),
+            fo.Sample(filepath="image2.jpg", ground_truth=fo.Classification()),
+        ]
+        dataset.add_samples(samples)
+
+        self.assertIn("ground_truth", dataset.get_field_schema())
+
+        # Test implied field types
+
+        dataset = fo.Dataset()
+
+        sample = fo.Sample(
+            filepath="image.jpg",
+            bool_field=True,
+            int_field=1,
+            str_field="hi",
+            float_field=1.0,
+            list_field=[1, 2, 3],
+            dict_field={"hello": "world"},
+            vector_field=np.arange(5),
+            array_field=np.random.randn(3, 4),
+        )
+
+        dataset.add_sample(sample)
+        schema = dataset.get_field_schema()
+
+        self.assertIsInstance(schema["bool_field"], fo.BooleanField)
+        self.assertIsInstance(schema["int_field"], fo.IntField)
+        self.assertIsInstance(schema["str_field"], fo.StringField)
+        self.assertIsInstance(schema["float_field"], fo.FloatField)
+        self.assertIsInstance(schema["list_field"], fo.ListField)
+        self.assertIsInstance(schema["dict_field"], fo.DictField)
+        self.assertIsInstance(schema["vector_field"], fo.VectorField)
+        self.assertIsInstance(schema["array_field"], fo.ArrayField)
 
     @drop_datasets
     def test_rename_fields(self):


### PR DESCRIPTION
The impetus for this PR is that I wanted the following to work (which it now does):

```py
import fiftyone as fo

dataset = fo.Dataset()

samples = [
    fo.Sample(filepath="image1.jpg", ground_truth=None),
    fo.Sample(filepath="image2.jpg", ground_truth=fo.Classification()),
]
dataset.add_samples(samples)

print(dataset)  # has `ground_truth` field
```

Previously, an error would be raised because we weren't able to infer an appropriate field type for `ground_truth` after only seeing the first sample.

A consequence of this change is that, in the following example, no `ground_truth` field will be added to the dataset, since we don't know what type to use for the field:

```py
import fiftyone as fo

sample = fo.Sample(filepath="image.jpg", ground_truth=None)

dataset = fo.Dataset()
dataset.add_sample(sample)

print(dataset)  # no `ground_truth` field
```

I think this consequence is fine, since our data model ensures complete equivalence between `None`-valued and missing fields on samples.
