### PR TITLE
Documenting batch actions

### DIFF
--- a/docs/source/user_guide/using_datasets.rst
+++ b/docs/source/user_guide/using_datasets.rst
@@ -1813,7 +1813,7 @@ Label tags
 
 All |Label| instances have a `tags` field, which is a string list. By default,
 this list is empty, but you can use it to store application-specific
-information like whether the label is mistaken:
+information like whether the label is incorrect:
 
 .. code-block:: python
     :linenos:
@@ -2233,9 +2233,9 @@ Cloning, renaming, clearing, and deleting fields
 You can use the
 :meth:`clone_sample_field() <fiftyone.core.dataset.Dataset.clone_sample_field>`,
 :meth:`rename_sample_field() <fiftyone.core.dataset.Dataset.rename_sample_field>`,
-:meth:`clear_sample_field() <fiftyone.core.dataset.Dataset.rename_sample_field>`,
+:meth:`clear_sample_field() <fiftyone.core.dataset.Dataset.clear_sample_field>`,
 and
-:meth:`delete_sample_field() <fiftyone.core.dataset.Dataset.rename_sample_field>`
+:meth:`delete_sample_field() <fiftyone.core.dataset.Dataset.delete_sample_field>`
 methods to efficiently perform common actions on the sample fields of a
 |Dataset|:
 

--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -855,7 +855,7 @@ class SampleCollection(object):
             import fiftyone.zoo as foz
             from fiftyone import ViewField as F
 
-            dataset = foz.load_zoo_dataset("quickstart").clone()
+            dataset = foz.load_zoo_dataset("quickstart")
 
             #
             # Create a new sample field
@@ -875,7 +875,7 @@ class SampleCollection(object):
             detections = view.values("predictions.detections")
             for sample_detections in detections:
                 for detection in sample_detections:
-                    detection.tags.append("low confidence")
+                    detection.tags.append("low_confidence")
 
             view.set_values("predictions.detections", detections)
 
@@ -4131,7 +4131,7 @@ class SampleCollection(object):
             import fiftyone.brain as fob
             import fiftyone.zoo as foz
 
-            dataset = foz.load_zoo_dataset("quickstart").clone()
+            dataset = foz.load_zoo_dataset("quickstart")
 
             fob.compute_similarity(dataset, brain_key="similarity")
 

--- a/fiftyone/core/session.py
+++ b/fiftyone/core/session.py
@@ -614,11 +614,11 @@ class Session(foc.HasClient):
 
         Items are dictionaries with the following keys:
 
-            -   ``label_id``: the ID of the label
-            -   ``sample_id``: the ID of the sample containing the label
-            -   ``field``: the field name containing the label
-            -   ``frame_number``: the frame number containing the label (only
-                applicable to video samples)
+        -   ``label_id``: the ID of the label
+        -   ``sample_id``: the ID of the sample containing the label
+        -   ``field``: the field name containing the label
+        -   ``frame_number``: the frame number containing the label (only
+            applicable to video samples)
         """
         return list(self.state.selected_labels)
 
@@ -657,7 +657,7 @@ class Session(foc.HasClient):
     def tag_selected_samples(self, tag):
         """Adds the tag to the currently selected samples, if necessary.
 
-        The currently selected labels are :meth:`Sesssion.selected`.
+        The currently selected labels are :attr:`Session.selected`.
 
         Args:
             tag: a tag
@@ -668,7 +668,7 @@ class Session(foc.HasClient):
     def untag_selected_samples(self, tag):
         """Removes the tag from the currently selected samples, if necessary.
 
-        The currently selected labels are :meth:`Sesssion.selected`.
+        The currently selected labels are :attr:`Session.selected`.
 
         Args:
             tag: a tag
@@ -679,7 +679,7 @@ class Session(foc.HasClient):
     def tag_selected_labels(self, tag):
         """Adds the tag to the currently selected labels, if necessary.
 
-        The currently selected labels are :meth:`Sesssion.selected_labels`.
+        The currently selected labels are :attr:`Session.selected_labels`.
 
         Args:
             tag: a tag
@@ -692,7 +692,7 @@ class Session(foc.HasClient):
     def untag_selected_labels(self, tag):
         """Removes the tag from the currently selected labels, if necessary.
 
-        The currently selected labels are :meth:`Sesssion.selected_labels`.
+        The currently selected labels are :attr:`Session.selected_labels`.
 
         Args:
             tag: a tag
@@ -700,6 +700,35 @@ class Session(foc.HasClient):
         self._collection.select_labels(
             labels=self.selected_labels
         ).untag_labels(tag)
+
+    @property
+    def selected_view(self):
+        """A :class:`fiftyone.core.view.DatasetView` containing the currently
+        selected content in the App.
+
+        The selected view is defined as follows:
+
+        -   If both samples and labels are selected, the view will contain only
+            the :attr:`selected_labels` from within the :attr:`selected`
+            samples
+        -   If samples are selected, the view will only contain the
+            :attr:`selected` samples
+        -   If labels are selected, the view will only contain the
+            :attr:`selected_labels`
+        -   If no samples or labels are selected, the view will be ``None``
+        """
+        if self.selected:
+            view = self._collection.select(self.selected)
+
+            if self.selected_labels:
+                return view.select_labels(labels=self.selected_labels)
+
+            return view
+
+        if self.selected_labels:
+            return self._collection.select_labels(labels=self.selected_labels)
+
+        return None
 
     def summary(self):
         """Returns a string summary of the session.

--- a/fiftyone/utils/geojson.py
+++ b/fiftyone/utils/geojson.py
@@ -332,7 +332,7 @@ class GeoJSONDatasetImporter(
         property_parsers (None): an optional dict mapping property names to
             functions that parse the property values (e.g., into the
             appropriate) :class:`fiftyone.core.labels.Label` types). By
-            default, all properies are stored as primitive field values
+            default, all properties are stored as primitive field values
         skip_missing_media (False): whether to skip (True) or raise an error
             (False) when features with no ``filename`` property are encountered
         include_all_data (False): whether to generate samples for all media in

--- a/tests/misc/selection_tests.py
+++ b/tests/misc/selection_tests.py
@@ -45,29 +45,21 @@ class SelectionTests(unittest.TestCase):
                     }
                 )
 
-        selected_view = dataset.select_labels(selected_labels)
-        excluded_view = dataset.exclude_labels(selected_labels)
+        selected_view = dataset.select_labels(labels=selected_labels)
+        excluded_view = dataset.exclude_labels(labels=selected_labels)
 
-        total_labels = _count_detections(dataset, "ground_truth")
+        num_labels = dataset.count("ground_truth.detections")
         num_selected_labels = len(selected_labels)
-        num_labels_in_selected_view = _count_detections(
-            selected_view, "ground_truth"
+        num_labels_in_selected_view = selected_view.count(
+            "ground_truth.detections"
         )
-        num_labels_in_excluded_view = _count_detections(
-            excluded_view, "ground_truth"
+        num_labels_in_excluded_view = excluded_view.count(
+            "ground_truth.detections"
         )
-        num_labels_excluded = total_labels - num_labels_in_excluded_view
+        num_labels_excluded = num_labels - num_labels_in_excluded_view
 
         self.assertEqual(num_selected_labels, num_labels_in_selected_view)
         self.assertEqual(num_selected_labels, num_labels_excluded)
-
-
-def _count_detections(sample_collection, label_field):
-    num_labels = 0
-    for sample in sample_collection:
-        num_labels += len(sample[label_field].detections)
-
-    return num_labels
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Adds some documentation for various "batch" operations that can be performed on datasets and views via methods like `set_values()`, `tag_samples()`, `tag_labels()`, `clone_sample_field()`, and so on.

Also adds `Session.selected_view` property that returns a view containing only the currently selected samples/labels in the App, if any.