### PR TITLE
Zoom fix for empty samples

### DIFF
--- a/app/packages/looker/src/index.ts
+++ b/app/packages/looker/src/index.ts
@@ -555,7 +555,7 @@ export class FrameLooker extends Looker<HTMLVideoElement, FrameState> {
 
     if (this.state.zoomToContent) {
       toggleZoom(this.state, this.currentOverlays);
-    } else if (this.state.setZoom && this.pluckedOverlays.length) {
+    } else if (this.state.setZoom) {
       if (this.state.options.zoom) {
         this.state = zoomToContent(this.state, this.pluckedOverlays);
       } else {
@@ -647,7 +647,7 @@ export class ImageLooker extends Looker<HTMLImageElement, ImageState> {
 
     if (this.state.zoomToContent) {
       toggleZoom(this.state, this.currentOverlays);
-    } else if (this.state.setZoom && this.pluckedOverlays.length) {
+    } else if (this.state.setZoom) {
       if (this.state.options.zoom) {
         this.state = zoomToContent(this.state, this.pluckedOverlays);
       } else {


### PR DESCRIPTION
Resolves #1175 

```py
import fiftyone as fo
import fiftyone.zoo as foz

dataset = foz.load_zoo_dataset("quickstart")
view = dataset.select_fields()

# Open expanded sample modal, zoom in, then press ESC
# Nothing happens, but view should reset to full image
session = fo.launch_app(view=view)
```