### PR TITLE
Fix next/previous click controls in notebooks

### DIFF
--- a/app/packages/looker/src/elements/base.ts
+++ b/app/packages/looker/src/elements/base.ts
@@ -44,9 +44,7 @@ export abstract class BaseElement<
       this.events[eventType] = (event) =>
         handler({ event, update, dispatchEvent });
       this.element &&
-        this.element.addEventListener(eventType, this.events[eventType], {
-          passive: eventType === "wheel",
-        });
+        this.element.addEventListener(eventType, this.events[eventType]);
     }
   }
   applyChildren(children: BaseElement<State>[]) {

--- a/app/packages/looker/src/elements/common/actions.ts
+++ b/app/packages/looker/src/elements/common/actions.ts
@@ -31,10 +31,6 @@ import {
 import { dispatchTooltipEvent } from "./util";
 import closeIcon from "../../icons/close.svg";
 
-export const IS_NOTEBOOK = new URLSearchParams(window.location.search).get(
-  "notebook"
-);
-
 const readActions = <State extends BaseState>(
   actions: ControlMap<State>
 ): ControlMap<State> => {
@@ -119,7 +115,7 @@ export const controls: Control = {
 
 export const wheel: Control = {
   title: "Zoom",
-  shortcut: IS_NOTEBOOK ? "Shift+Wheel" : "Wheel",
+  shortcut: "Wheel",
   eventKeys: null,
   detail: "Zoom in and out",
   action: () => null,
@@ -127,33 +123,33 @@ export const wheel: Control = {
 
 export const next: Control = {
   title: "Next sample",
-  shortcut: IS_NOTEBOOK ? "Shift+&#8594;" : "&#8594;",
+  shortcut: "&#8594;",
   eventKeys: "ArrowRight",
   detail: "Go to the next sample",
-  action: (_, dispatchEvent, eventKey, shiftKey) => {
-    (!IS_NOTEBOOK || shiftKey) && dispatchEvent("next");
+  action: (_, dispatchEvent) => {
+    dispatchEvent("next");
   },
 };
 
 export const previous: Control = {
   title: "Previous sample",
-  shortcut: IS_NOTEBOOK ? "Shift+&#8592;" : "&#8592;",
+  shortcut: "&#8592;",
   eventKeys: "ArrowLeft",
   detail: "Go to the previous sample",
-  action: (_, dispatchEvent, eventKey, shiftKey) => {
-    (!IS_NOTEBOOK || shiftKey) && dispatchEvent("previous");
+  action: (_, dispatchEvent) => {
+    dispatchEvent("previous");
   },
 };
 
 export const rotatePrevious: Control = {
   title: "Rotate label forward",
-  shortcut: IS_NOTEBOOK ? "Shift+&#8595;" : "&#8595;",
+  shortcut: "&#8595;",
   eventKeys: "ArrowUp",
   detail: "Rotate the bottom label to the back",
-  action: (update, dispatchEvent, eventKey, shiftKey) =>
+  action: (update, dispatchEvent) =>
     update(
       ({ disableOverlays, rotate }) => {
-        if (!disableOverlays && (!IS_NOTEBOOK || shiftKey)) {
+        if (!disableOverlays) {
           return { rotate: Math.max(0, rotate - 1) };
         }
         return {};
@@ -166,13 +162,13 @@ export const rotatePrevious: Control = {
 
 export const rotateNext: Control = {
   title: "Rotate label backward",
-  shortcut: IS_NOTEBOOK ? "Shift+&#8593;" : "&#8593;",
+  shortcut: "&#8593;",
   eventKeys: "ArrowDown",
   detail: "Rotate the current label to the back",
-  action: (update, dispatchEvent, eventKey, shiftKey) =>
+  action: (update, dispatchEvent) =>
     update(
       ({ disableOverlays, rotate }) => {
-        if (!disableOverlays && (!IS_NOTEBOOK || shiftKey)) {
+        if (!disableOverlays) {
           return {
             rotate: rotate + 1,
           };

--- a/app/packages/looker/src/elements/common/canvas.ts
+++ b/app/packages/looker/src/elements/common/canvas.ts
@@ -9,7 +9,6 @@ import { BaseElement, Events } from "../base";
 import { dispatchTooltipEvent } from "./util";
 
 import { invisible, lookerCanvas } from "./canvas.module.css";
-import { IS_NOTEBOOK } from "./actions";
 
 export class CanvasElement<State extends BaseState> extends BaseElement<
   State,
@@ -124,9 +123,8 @@ export class CanvasElement<State extends BaseState> extends BaseElement<
                 return {};
               }
 
-              if (IS_NOTEBOOK && !event.shiftKey) {
-                return {};
-              }
+              event.preventDefault();
+              event.stopImmediatePropagation();
 
               const x = event.x - tlx;
               const y = event.y - tly;

--- a/app/packages/looker/src/elements/common/controls.ts
+++ b/app/packages/looker/src/elements/common/controls.ts
@@ -36,7 +36,7 @@ export class NextElement<State extends BaseState> extends BaseElement<
       click: ({ update, event, dispatchEvent }) => {
         event.stopPropagation();
         event.preventDefault();
-        next.action(update, dispatchEvent);
+        next.action(update, dispatchEvent, null, true);
       },
       mouseenter: ({ update }) => {
         update({ hoveringControls: true });
@@ -92,7 +92,7 @@ export class PreviousElement<State extends BaseState> extends BaseElement<
       click: ({ update, event, dispatchEvent }) => {
         event.stopPropagation();
         event.preventDefault();
-        previous.action(update, dispatchEvent);
+        previous.action(update, dispatchEvent, null, true);
       },
       mouseenter: ({ update }) => {
         update({ hoveringControls: true });

--- a/docs/source/user_guide/app.rst
+++ b/docs/source/user_guide/app.rst
@@ -333,6 +333,13 @@ available actions and their associated hotkeys.
     :alt: image-visualizer
     :align: center
 
+.. note::
+
+    When working in :ref:`Jupyter/Colab notebooks <notebooks>`, you can hold
+    down the `SHIFT` key when zoom-scrolling or using the arrow keys to
+    navigate between samples/labels to restrict your inputs to the App and thus
+    prevent them from also affecting your browser window.
+
 .. _app-video-visualizer:
 
 Using the video visualizer
@@ -370,6 +377,13 @@ hovering, a slider appears to adjust the setting manually.
 .. image:: /images/app/app-video-visualizer.gif
     :alt: video-visualizer
     :align: center
+
+.. note::
+
+    When working in :ref:`Jupyter/Colab notebooks <notebooks>`, you can hold
+    down the `SHIFT` key when zoom-scrolling or using the arrow keys to
+    navigate between samples/labels to restrict your inputs to the App and thus
+    prevent them from also affecting your browser window.
 
 .. _app-stats-tabs:
 


### PR DESCRIPTION
Resolves #1174

Fixes the click arrows for next/previous actions in notebook Lookers.

Regarding the arrow keys, notebooks currently require the shift key for wheeling and arrow shortcuts, as the App is within an iframe and these events interfere with scrolling (horizontal or vertical) unless `Shift` key is active.

I am unaware of any horizontal scrolling that could be possible, so I could remove the shift key requirement for left/right arrows. But it would interfere, if horizontal scrolling is available.

![Screenshot from 2021-08-11 08-52-51](https://user-images.githubusercontent.com/19821840/129053490-4a73c1d4-63e4-4994-bdc1-08465e39105a.png)