### PR TITLE
fixed loading yolov5 yaml with multiply paths

### DIFF
--- a/docs/source/user_guide/using_datasets.rst
+++ b/docs/source/user_guide/using_datasets.rst
@@ -2330,7 +2330,7 @@ which samples to merge:
 
     Did you know? You can use
     :meth:`merge_dir() <fiftyone.core.dataset.Dataset.merge_dir>` to directly
-    directly merge the contents of a dataset on disk into an existing FiftyOne
+    merge the contents of a dataset on disk into an existing FiftyOne
     dataset without first
     :ref:`loading it <loading-datasets-from-disk>` into a temporary dataset and
     then using

--- a/fiftyone/utils/yolo.py
+++ b/fiftyone/utils/yolo.py
@@ -298,7 +298,7 @@ class YOLOv5DatasetImporter(
         data = d[self.split]
         classes = d.get("names", None)
 
-        if data.endswith(".txt"):
+        if etau.is_str(data) and data.endswith(".txt"):
             txt_path = _parse_yolo_v5_data_path(data, self.yaml_path)
             image_paths = _read_file_lines(txt_path)
         else:


### PR DESCRIPTION
## What changes are proposed in this pull request?

This commit fixed loading yolov5 yaml with multiply paths for one dataset split. 

## How is this patch tested? If it is not, please explain why.

The change is minimum, and I have tested it with my own yolov5 yaml.

The yolov5 yaml supports using a list of paths in each data split. e.g.

```yaml
train: [/path/to/split/one,
        /path/to/split/two]
test: /path/to/test/set
```
Current yolov5 yaml load function will  raise `AttributeError` as follow:

```python
AttributeError: 'list' object has no attribute 'endswith'
```

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [X] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [X] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
