### PR TITLE
Adding a group_by() view stage

### DIFF
--- a/fiftyone/__public__.py
+++ b/fiftyone/__public__.py
@@ -139,6 +139,7 @@ from .core.stages import (
     LimitLabels,
     GeoNear,
     GeoWithin,
+    GroupBy,
     MapLabels,
     Match,
     MatchFrames,

--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -2937,6 +2937,56 @@ class SampleCollection(object):
         )
 
     @view_stage
+    def group_by(self, field_or_expr, sort_expr=None, reverse=False):
+        """Creates a view that reorganizes the samples in the collection so
+        that they are grouped by a specified field or expression.
+
+        Examples::
+
+            import fiftyone as fo
+            import fiftyone.zoo as foz
+            from fiftyone import ViewField as F
+
+            dataset = foz.load_zoo_dataset("cifar10", split="test")
+
+            # Take a random sample of 1000 samples and organize them by ground
+            # truth label with groups arranged in decreasing order of size
+            view = dataset.take(1000).group_by(
+                "ground_truth.label",
+                sort_expr=F().length(),
+                reverse=True,
+            )
+
+            print(view.values("ground_truth.label"))
+            print(
+                sorted(
+                    view.count_values("ground_truth.label").items(),
+                    key=lambda kv: kv[1],
+                    reverse=True,
+                )
+            )
+
+        Args:
+            field_or_expr: the field or ``embedded.field.name`` to group by, or
+                a :class:`fiftyone.core.expressions.ViewExpression` or
+                `MongoDB aggregation expression <https://docs.mongodb.com/manual/meta/aggregation-quick-reference/#aggregation-expressions>`_
+                that defines the value to group by
+            sort_expr (None): an optional
+                :class:`fiftyone.core.expressions.ViewExpression` or
+                `MongoDB aggregation expression <https://docs.mongodb.com/manual/meta/aggregation-quick-reference/#aggregation-expressions>`_
+                that defines how to sort the groups in the output view. If
+                provided, this expression will be evaluated on the list of
+                samples in each group
+            reverse (False): whether to return the results in descending order
+
+        Returns:
+            a :class:`fiftyone.core.view.DatasetView`
+        """
+        return self._add_view_stage(
+            fos.GroupBy(field_or_expr, sort_expr=sort_expr, reverse=reverse)
+        )
+
+    @view_stage
     def limit(self, limit):
         """Returns a view with at most the given number of samples.
 

--- a/fiftyone/core/stages.py
+++ b/fiftyone/core/stages.py
@@ -2303,7 +2303,7 @@ class GroupBy(ViewStage):
         # truth label with groups arranged in decreasing order of size
         stage = fo.GroupBy(
             "ground_truth.label",
-            sort_expr=F().length(),  # computes number of samples in each group
+            sort_expr=F().length(),
             reverse=True,
         )
         view = dataset.take(1000).add_stage(stage)

--- a/fiftyone/core/stages.py
+++ b/fiftyone/core/stages.py
@@ -2287,6 +2287,163 @@ class GeoWithin(_GeoStage):
         ]
 
 
+class GroupBy(ViewStage):
+    """Creates a view that reorganizes the samples in a collection so that they
+    are grouped by a specified field or expression.
+
+    Examples::
+
+        import fiftyone as fo
+        import fiftyone.zoo as foz
+        from fiftyone import ViewField as F
+
+        dataset = foz.load_zoo_dataset("cifar10", split="test")
+
+        # Take a random sample of 1000 samples and organize them by ground
+        # truth label with groups arranged in decreasing order of size
+        stage = fo.GroupBy(
+            "ground_truth.label",
+            sort_expr=F().length(),  # computes number of samples in each group
+            reverse=True,
+        )
+        view = dataset.take(1000).add_stage(stage)
+
+        print(view.values("ground_truth.label"))
+        print(
+            sorted(
+                view.count_values("ground_truth.label").items(),
+                key=lambda kv: kv[1],
+                reverse=True,
+            )
+        )
+
+    Args:
+        field_or_expr: the field or ``embedded.field.name`` to group by, or a
+            :class:`fiftyone.core.expressions.ViewExpression` or
+            `MongoDB aggregation expression <https://docs.mongodb.com/manual/meta/aggregation-quick-reference/#aggregation-expressions>`_
+            that defines the value to group by
+        sort_expr (None): an optional
+            :class:`fiftyone.core.expressions.ViewExpression` or
+            `MongoDB aggregation expression <https://docs.mongodb.com/manual/meta/aggregation-quick-reference/#aggregation-expressions>`_
+            that defines how to sort the groups in the output view. If
+            provided, this expression will be evaluated on the list of samples
+            in each group
+        reverse (False): whether to return the results in descending order
+    """
+
+    def __init__(self, field_or_expr, sort_expr=None, reverse=False):
+        self._field_or_expr = field_or_expr
+        self._sort_expr = sort_expr
+        self._reverse = reverse
+
+    @property
+    def field_or_expr(self):
+        """The field or expression to group by."""
+        return self._field_or_expr
+
+    @property
+    def sort_expr(self):
+        """An expression defining how the sort the groups in the output view.
+        """
+        return self._sort_expr
+
+    @property
+    def reverse(self):
+        """Whether to sort the groups in descending order."""
+        return self._reverse
+
+    def to_mongo(self, _):
+        field_or_expr = self._get_mongo_field_or_expr()
+        sort_expr = self._get_mongo_sort_expr()
+
+        if etau.is_str(field_or_expr):
+            group_expr = "$" + field_or_expr
+        else:
+            group_expr = field_or_expr
+
+        pipeline = [
+            {"$group": {"_id": group_expr, "docs": {"$push": "$$ROOT"}}}
+        ]
+
+        if sort_expr is not None:
+            order = -1 if self._reverse else 1
+            pipeline.extend(
+                [
+                    {"$set": {"_sort_field": sort_expr}},
+                    {"$sort": {"_sort_field": order}},
+                    {"$unset": "_sort_field"},
+                ]
+            )
+
+        pipeline.extend(
+            [{"$unwind": "$docs"}, {"$replaceRoot": {"newRoot": "$docs"}}]
+        )
+
+        return pipeline
+
+    def _needs_frames(self, sample_collection):
+        if sample_collection.media_type != fom.VIDEO:
+            return False
+
+        field_or_expr = self._get_mongo_field_or_expr()
+
+        if etau.is_str(field_or_expr):
+            return sample_collection._is_frame_field(field_or_expr)
+
+        return _is_frames_expr(field_or_expr)
+
+    def _get_mongo_field_or_expr(self):
+        if isinstance(self._field_or_expr, foe.ViewField):
+            return self._field_or_expr._expr
+
+        if isinstance(self._field_or_expr, foe.ViewExpression):
+            return self._field_or_expr.to_mongo()
+
+        return self._field_or_expr
+
+    def _get_mongo_sort_expr(self):
+        if isinstance(self._sort_expr, foe.ViewExpression):
+            return self._sort_expr.to_mongo(prefix="$docs")
+
+        return self._sort_expr
+
+    def _kwargs(self):
+        return [
+            ["field_or_expr", self._get_mongo_field_or_expr()],
+            ["sort_expr", self._get_mongo_sort_expr()],
+            ["reverse", self._reverse],
+        ]
+
+    @classmethod
+    def _params(cls):
+        return [
+            {
+                "name": "field_or_expr",
+                "type": "field|str|json",
+                "placeholder": "field or expression",
+            },
+            {
+                "name": "sort_expr",
+                "type": "NoneType|json",
+                "placeholder": "sort expression",
+                "default": "None",
+            },
+            {
+                "name": "reverse",
+                "type": "bool",
+                "default": "False",
+                "placeholder": "reverse (default=False)",
+            },
+        ]
+
+    def validate(self, sample_collection):
+        field_or_expr = self._get_mongo_field_or_expr()
+
+        if etau.is_str(field_or_expr):
+            sample_collection.validate_fields_exist(field_or_expr)
+            sample_collection.create_index(field_or_expr)
+
+
 class Limit(ViewStage):
     """Creates a view with at most the given number of samples.
 
@@ -4693,13 +4850,8 @@ class SortBy(ViewStage):
     def validate(self, sample_collection):
         field_or_expr = self._get_mongo_field_or_expr()
 
-        # If sorting by a field, not an expression
         if etau.is_str(field_or_expr):
-            # Make sure the field exists
             sample_collection.validate_fields_exist(field_or_expr)
-
-            # Create an index on the field, if necessary, to make sorting
-            # more efficient
             sample_collection.create_index(field_or_expr)
 
 
@@ -5579,6 +5731,7 @@ _STAGES = [
     FilterKeypoints,
     GeoNear,
     GeoWithin,
+    GroupBy,
     Limit,
     LimitLabels,
     MapLabels,


### PR DESCRIPTION
Adds a `group_by()` stage that allows for reorganizing the samples in a collection so that they are grouped by a specified field or expression. The groups can also be sorted.

A use case for this came up last night as I was working on brain stuff; happy to discuss offline if anyone is interested.

A note of warning here is that, since the `$group` aggregation used here stores a list of sample documents in each group, this stage could easily produce documents internally in the MongoDB pipeline that exceed 100MB and must therefore leverage the `useDiskSpace = true` option (which we have enabled). So, for very large collections with large groups, this stage could be quite intensive. But, I didn't see any easy way to avoid this when implementing the stage. Anybody know if I missed any easy solution?

Example usage:

```py
import fiftyone as fo
import fiftyone.zoo as foz
from fiftyone import ViewField as F

dataset = foz.load_zoo_dataset("cifar10", split="test")

# Take a random sample of 1000 samples and organize them by ground
# truth label with groups arranged in decreasing order of size
view = dataset.take(1000).group_by(
    "ground_truth.label",
    sort_expr=F().length(),
    reverse=True,
)

print(view.values("ground_truth.label"))
print(
    sorted(
        view.count_values("ground_truth.label").items(),
        key=lambda kv: kv[1],
        reverse=True,
    )
)
```
