### PR TITLE
Fix duplicate app rendering in IPython notebooks

### DIFF
--- a/fiftyone/core/session.py
+++ b/fiftyone/core/session.py
@@ -978,8 +978,8 @@ class Session(foc.HasClient):
 
         import IPython.display
 
-        handle = IPython.display.display(display_id=True)
         uuid = str(uuid4())
+        handle = IPython.display.DisplayHandle(display_id=uuid)
 
         # @todo isn't it bad to set this here? The first time this is called
         # is before `self.state` has been initialized


### PR DESCRIPTION
## Issues

* Resolves #1187 
* Resolves #1126 

## Notes

`Session` objects now create `DisplayHandle()` instances directly when working in IPython notebooks. Using the convenience function `display()` seems to cause an unwanted initial display object (App window).

This issue does not seem to arise in source installs, but I have tested with a built package and things are working correctly now in VSCode, Jupyter Lab, etc.
