### PR TITLE
Fix initial patch zoom for grid thumbnails

### DIFF
--- a/app/packages/looker/src/index.ts
+++ b/app/packages/looker/src/index.ts
@@ -555,7 +555,7 @@ export class FrameLooker extends Looker<HTMLVideoElement, FrameState> {
 
     if (this.state.zoomToContent) {
       toggleZoom(this.state, this.currentOverlays);
-    } else if (this.state.setZoom) {
+    } else if (this.state.setZoom && this.state.overlaysPrepared) {
       if (this.state.options.zoom) {
         this.state = zoomToContent(this.state, this.pluckedOverlays);
       } else {
@@ -647,7 +647,7 @@ export class ImageLooker extends Looker<HTMLImageElement, ImageState> {
 
     if (this.state.zoomToContent) {
       toggleZoom(this.state, this.currentOverlays);
-    } else if (this.state.setZoom) {
+    } else if (this.state.setZoom && this.state.overlaysPrepared) {
       if (this.state.options.zoom) {
         this.state = zoomToContent(this.state, this.pluckedOverlays);
       } else {


### PR DESCRIPTION
On `develop`, patches are not set in the thumbnails. Not an issue in v0.12.0.

![Screenshot from 2021-08-16 13-09-58](https://user-images.githubusercontent.com/19821840/129616961-d8489035-7da9-4f2b-90ac-e982005bb0ce.png)