### PR TITLE
Adding support for BDD score field

### DIFF
--- a/docs/source/user_guide/dataset_creation/datasets.rst
+++ b/docs/source/user_guide/dataset_creation/datasets.rst
@@ -2541,7 +2541,8 @@ where `labels.json` is a JSON file in the following format:
                         "x2": 1040.626872,
                         "y1": 281.992415,
                         "y2": 326.91156
-                    }
+                    },
+                    "score": 0.95
                 },
                 ...
                 {
@@ -2562,7 +2563,8 @@ where `labels.json` is a JSON file in the following format:
                                 ...
                             ]
                         }
-                    ]
+                    ],
+                    "score": 0.87
                 },
                 ...
                 {
@@ -2586,6 +2588,7 @@ where `labels.json` is a JSON file in the following format:
                             ]
                         }
                     ],
+                    "score": 0.98
                 },
                 ...
             }

--- a/docs/source/user_guide/export_datasets.rst
+++ b/docs/source/user_guide/export_datasets.rst
@@ -2211,7 +2211,8 @@ where `labels.json` is a JSON file in the following format:
                         "x2": 1040.626872,
                         "y1": 281.992415,
                         "y2": 326.91156
-                    }
+                    },
+                    "score": 0.95
                 },
                 ...
                 {
@@ -2232,7 +2233,8 @@ where `labels.json` is a JSON file in the following format:
                                 ...
                             ]
                         }
-                    ]
+                    ],
+                    "score": 0.87
                 },
                 ...
                 {
@@ -2256,6 +2258,7 @@ where `labels.json` is a JSON file in the following format:
                             ]
                         }
                     ],
+                    "score": 0.98
                 },
                 ...
             }

--- a/fiftyone/utils/bdd.py
+++ b/fiftyone/utils/bdd.py
@@ -523,6 +523,7 @@ def _parse_frame_labels(attrs_dict):
 
 def _parse_bdd_detection(d, frame_size, extra_attrs):
     label = d["category"]
+    confidence = d.get("score", None)
 
     width, height = frame_size
     box2d = d["box2d"]
@@ -536,11 +537,17 @@ def _parse_bdd_detection(d, frame_size, extra_attrs):
     attributes = d.get("attributes", {})
     attributes = _filter_attributes(attributes, extra_attrs)
 
-    return fol.Detection(label=label, bounding_box=bounding_box, **attributes)
+    return fol.Detection(
+        label=label,
+        bounding_box=bounding_box,
+        confidence=confidence,
+        **attributes,
+    )
 
 
 def _parse_bdd_polylines(d, frame_size, extra_attrs):
     label = d["category"]
+    confidence = d.get("score", None)
 
     attributes = d.get("attributes", {})
 
@@ -563,6 +570,7 @@ def _parse_bdd_polylines(d, frame_size, extra_attrs):
             fol.Polyline(
                 label=label,
                 points=[points],
+                confidence=confidence,
                 closed=closed,
                 filled=filled,
                 **_attributes,
@@ -651,7 +659,7 @@ def _detection_to_bdd(detection, frame_size, extra_attrs):
 
     attributes = _get_attributes(detection, extra_attrs)
 
-    return {
+    d = {
         "id": None,
         "category": detection.label,
         "manualAttributes": True,
@@ -659,6 +667,11 @@ def _detection_to_bdd(detection, frame_size, extra_attrs):
         "attributes": attributes,
         "box2d": box2d,
     }
+
+    if detection.confidence is not None:
+        d["score"] = detection.confidence
+
+    return d
 
 
 def _polyline_to_bdd(polyline, frame_size, extra_attrs):
@@ -677,7 +690,7 @@ def _polyline_to_bdd(polyline, frame_size, extra_attrs):
             {"types": types, "closed": polyline.closed, "vertices": vertices,}
         )
 
-    return {
+    d = {
         "id": None,
         "category": polyline.label,
         "manualAttributes": True,
@@ -685,6 +698,11 @@ def _polyline_to_bdd(polyline, frame_size, extra_attrs):
         "attributes": attributes,
         "poly2d": poly2d,
     }
+
+    if polyline.confidence is not None:
+        d["score"] = polyline.confidence
+
+    return d
 
 
 def _get_attributes(label, extra_attrs):


### PR DESCRIPTION
Resolves #1206.

```py
import os

import fiftyone as fo
import fiftyone.zoo as foz
from fiftyone import ViewField as F

dataset = foz.load_zoo_dataset("quickstart")

data_path = os.path.dirname(dataset.first().filepath)
labels_path = "/tmp/bdd.json"

dataset.export(
    label_field="ground_truth",
    labels_path=labels_path,
    dataset_type=fo.types.BDDDataset,
)

dataset2 = fo.Dataset.from_dir(
    data_path=data_path,
    labels_path=labels_path,
    dataset_type=fo.types.BDDDataset,
)

sample = dataset.select_fields("ground_truth").first()
sample2 = dataset2.one(F("filepath") == sample.filepath)

print(sample)
print(sample2)
```
