### PR TITLE
Adding support for datetime fields

### DIFF
--- a/docs/source/_includes/substitutions.rst
+++ b/docs/source/_includes/substitutions.rst
@@ -25,6 +25,7 @@
 .. |IntField| replace:: :class:`IntField <fiftyone.core.fields.IntField>`
 .. |FloatField| replace:: :class:`FloatField <fiftyone.core.fields.FloatField>`
 .. |StringField| replace:: :class:`StringField <fiftyone.core.fields.StringField>`
+.. |DateTimeField| replace:: :class:`DateTimeField <fiftyone.core.fields.DateTimeField>`
 .. |ListField| replace:: :class:`ListField <fiftyone.core.fields.ListField>`
 .. |DictField| replace:: :class:`DictField <fiftyone.core.fields.DictField>`
 .. |VectorField| replace:: :class:`VectorField <fiftyone.core.fields.VectorField>`

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -147,6 +147,7 @@ intersphinx_mapping = {
     "mongoengine": ("https://docs.mongoengine.org/", None),
     "sklearn": ("https://scikit-learn.org/stable/", None),
     "pydicom": ("https://pydicom.github.io/pydicom/stable/", None),
+    "pytz": ("http://pytz.sourceforge.net/", None),
 }
 
 # -- Options for HTML output -------------------------------------------------

--- a/docs/source/user_guide/basics.rst
+++ b/docs/source/user_guide/basics.rst
@@ -146,6 +146,7 @@ Custom fields can contain any Python primitive data type:
 -   |IntField|: contains Python `int` instances
 -   |FloatField|: contains Python `float` instances
 -   |StringField|: contains Python `str` instances
+-   |DateTimeField|: contains Python `datetime` instances
 -   |ListField|: contains Python `list` instances
 -   |DictField|: contains Python `dict` instances
 

--- a/docs/source/user_guide/config.rst
+++ b/docs/source/user_guide/config.rst
@@ -292,7 +292,7 @@ Configuring a timezone
 ----------------------
 
 By default, FiftyOne loads all datetimes in FiftyOne datasets as naive
-`datetime` objects in UTC time.
+`datetime` objects expressed in UTC time.
 
 However, you can configure FiftyOne to express datetimes in a specific timezone
 by setting the `timezone` property of your FiftyOne config.
@@ -334,8 +334,8 @@ Or, you can even dynamically change the timezone while you work in Python:
 
 .. note::
 
-    This setting does not affect the internal database representation of
-    datetimes, which are always stored in UTC timestamps.
+    The `timezone` setting does not affect the internal database representation
+    of datetimes, which are always stored as UTC timestamps.
 
 .. _configuring-fiftyone-app:
 

--- a/docs/source/user_guide/config.rst
+++ b/docs/source/user_guide/config.rst
@@ -24,6 +24,10 @@ FiftyOne supports the configuration options described below:
 |                               |                                     |                               | specifying a custom MongoDB database to which to connect. See                          |
 |                               |                                     |                               | :ref:`this section <configuring-mongodb-connection>` for more information.             |
 +-------------------------------+-------------------------------------+-------------------------------+----------------------------------------------------------------------------------------+
+| `timezone`                    | `FIFTYONE_TIMEZONE`                 | `None`                        | An optional timzone string. If provided, all datetimes read from FiftyOne datasets     |
+|                               |                                     |                               | will be expressed in this timezone. See :ref:`this section <configuring-timezone>` for |
+|                               |                                     |                               | more information.                                                                      |
++-------------------------------+-------------------------------------+-------------------------------+----------------------------------------------------------------------------------------+
 | `dataset_zoo_dir`             | `FIFTYONE_DATASET_ZOO_DIR`          | `~/fiftyone`                  | The default directory in which to store datasets that are downloaded from the          |
 |                               |                                     |                               | :ref:`FiftyOne Dataset Zoo <dataset-zoo>`.                                             |
 +-------------------------------+-------------------------------------+-------------------------------+----------------------------------------------------------------------------------------+
@@ -100,6 +104,7 @@ and the CLI:
         {
             "database_dir": "~/.fiftyone/var/lib/mongo",
             "database_uri": null,
+            "timezone": null,
             "dataset_zoo_dir": "~/fiftyone",
             "dataset_zoo_manifest_paths": null,
             "default_app_config_path": "~/.fiftyone/app_config.json",
@@ -135,6 +140,7 @@ and the CLI:
         {
             "database_dir": "~/.fiftyone/var/lib/mongo",
             "database_uri": null,
+            "timezone": null,
             "dataset_zoo_dir": "~/fiftyone",
             "dataset_zoo_manifest_paths": null,
             "default_app_config_path": "~/.fiftyone/app_config.json",
@@ -279,6 +285,57 @@ with administrative privileges.
     .. code-block:: shell
 
         brew install mongodb-community@4.4
+
+.. _configuring-timezone:
+
+Configuring a timezone
+----------------------
+
+By default, FiftyOne loads all datetimes in FiftyOne datasets as naive
+`datetime` objects in UTC time.
+
+However, you can configure FiftyOne to express datetimes in a specific timezone
+by setting the `timezone` property of your FiftyOne config.
+
+The `timezone` property can be set to any timezone string supported by
+:func:`pytz:pytz.timezone`, or `"local"` to use your current local timezone.
+
+For example, you could set the `FIFTYONE_TIMEZONE` environment variable:
+
+.. code-block:: shell
+
+    # Local timezone
+    export FIFTYONE_TIMEZONE=local
+
+    # US Eastern timezone
+    export FIFTYONE_TIMEZONE=US/Eastern
+
+Or, you can even dynamically change the timezone while you work in Python:
+
+.. code-block:: python
+    :linenos:
+
+    from datetime import datetime
+    import fiftyone as fo
+
+    sample = fo.Sample(filepath="image.png", creation_date=datetime.utcnow())
+
+    dataset = fo.Dataset()
+    dataset.add_sample(sample)
+
+    print(sample.creation_date)
+    # 2021-08-24 20:24:09.723021
+
+    fo.config.timezone = "local"
+    dataset.reload()
+
+    print(sample.creation_date)
+    # 2021-08-24 16:24:09.723000-04:00
+
+.. note::
+
+    This setting does not affect the internal database representation of
+    datetimes, which are always stored in UTC timestamps.
 
 .. _configuring-fiftyone-app:
 

--- a/docs/source/user_guide/using_datasets.rst
+++ b/docs/source/user_guide/using_datasets.rst
@@ -658,7 +658,7 @@ updated to reflect the new field:
         integer_field: fiftyone.core.fields.IntField
 
 A |Field| can be any primitive type, such as `bool`, `int`, `float`, `str`,
-`list`, `dict`, or more complex data structures
+`datetime`, `list`, `dict`, or more complex data structures
 :ref:`like label types <using-labels>`:
 
 .. code-block:: python
@@ -958,6 +958,72 @@ some workflows when it is available.
                 }>,
                 'frames': <Frames: 0>,
             }>
+
+.. _using-datetimes:
+
+Datetime fields
+_______________
+
+You can store dates and times in FiftyOne datasets by populating fields with
+`datetime` values:
+
+.. code-block:: python
+    :linenos:
+
+    from datetime import datetime
+    import fiftyone as fo
+
+    dataset = fo.Dataset()
+    dataset.add_samples(
+        [
+            fo.Sample(
+                filepath="image1.png",
+                creation_date=datetime(2021, 8, 24, 21, 18, 7),
+            ),
+            fo.Sample(
+                filepath="image2.png",
+                creation_date=datetime.utcnow(),
+            ),
+        ]
+    )
+
+    print(dataset)
+    print(dataset.head())
+
+Internally, FiftyOne stores all datetimes as UTC timestamps, but you can
+provide any valid `datetime` object when setting a |DateTimeField| of a sample,
+including timezone-aware datetimes, which are internally converted to UTC
+format for safekeeping.
+
+.. code-block:: python
+    :linenos:
+
+    # A datetime in your local timezone
+    now = datetime.utcnow().astimezone()
+
+    sample = fo.Sample(filepath="image.png", creation_date=now)
+
+    dataset = fo.Dataset()
+    dataset.add_sample(sample)
+
+    # Samples are singletons
+    dataset.reload()
+    sample.creation_date.tzinfo  # None
+
+By default, when you access a datetime field of a sample in a dataset, it is
+retrieved as a naive `datetime` instance in UTC format.
+
+However, if you prefer you can :ref:`configure FiftyOne <configuring-timezone>`
+to load datetime fields as timezone-aware `datetime` instances in a timezone of
+your choice.
+
+.. warning::
+
+    FiftyOne assumes that all `datetime` instances with no explicit timezone
+    are stored in UTC format.
+
+    Therefore, never use `datetime.datetime.now()` when populating a datetime
+    field of a FiftyOne dataset! Instead, use `datetime.datetime.utcnow()`.
 
 .. _using-labels:
 

--- a/docs/source/user_guide/using_datasets.rst
+++ b/docs/source/user_guide/using_datasets.rst
@@ -964,7 +964,7 @@ some workflows when it is available.
 Datetime fields
 _______________
 
-You can store dates and times in FiftyOne datasets by populating fields with
+You can store date information in FiftyOne datasets by populating fields with
 `datetime` values:
 
 .. code-block:: python
@@ -990,6 +990,11 @@ You can store dates and times in FiftyOne datasets by populating fields with
     print(dataset)
     print(dataset.head())
 
+.. note::
+
+    Did you know? You can :ref:`create dataset views <datetime-views>` with
+    date-based queries!
+
 Internally, FiftyOne stores all datetimes as UTC timestamps, but you can
 provide any valid `datetime` object when setting a |DateTimeField| of a sample,
 including timezone-aware datetimes, which are internally converted to UTC
@@ -1006,16 +1011,18 @@ format for safekeeping.
     dataset = fo.Dataset()
     dataset.add_sample(sample)
 
-    # Samples are singletons
+    # Samples are singletons, so we reload so `sample` will contain values as
+    # loaded from the database
     dataset.reload()
+
     sample.creation_date.tzinfo  # None
 
 By default, when you access a datetime field of a sample in a dataset, it is
-retrieved as a naive `datetime` instance in UTC format.
+retrieved as a naive `datetime` instance expressed in UTC format.
 
-However, if you prefer you can :ref:`configure FiftyOne <configuring-timezone>`
-to load datetime fields as timezone-aware `datetime` instances in a timezone of
-your choice.
+However, if you prefer, you can
+:ref:`configure FiftyOne <configuring-timezone>` to load datetime fields as
+timezone-aware `datetime` instances in a timezone of your choice.
 
 .. warning::
 

--- a/docs/source/user_guide/using_views.rst
+++ b/docs/source/user_guide/using_views.rst
@@ -557,6 +557,67 @@ stage to filter the contents of arbitrarily-typed fields:
             # are deleted
             sample.save()
 
+
+.. _datetime-views:
+
+Datetime views
+______________
+
+If your dataset contains :ref:`datetime fields <using-datetimes>`, then you
+can construct dataset views that query/filter based on this information by
+simply defining the appropriate |ViewExpression|, using  `datetime.datetime`
+and/or `datetime.timedelta` objects to define the required logic.
+
+For example, you can use the
+:meth:`match() <fiftyone.core.collections.SampleCollection.match>` stage to
+filter a dataset via date-based conditions as follows:
+
+.. code-block:: python
+    :linenos:
+
+    from datetime import datetime, timedelta
+
+    import fiftyone as fo
+    from fiftyone import ViewField as F
+
+    dataset = fo.Dataset()
+    dataset.add_samples(
+        [
+            fo.Sample(
+                filepath="image1.png",
+                creation_date=datetime(2021, 8, 24, 1, 0, 0),
+            ),
+            fo.Sample(
+                filepath="image2.png",
+                creation_date=datetime(2021, 8, 24, 2, 0, 0),
+            ),
+            fo.Sample(
+                filepath="image3.png",
+                creation_date=datetime(2021, 8, 24, 3, 0, 0),
+            ),
+        ]
+    )
+
+    query_date = datetime(2021, 8, 24, 2, 1, 0)
+    query_delta = timedelta(minutes=30)
+
+    # Samples with creation date after 2021-08-24 02:01:00
+    view = dataset.match(F("creation_date") > query_date)
+    print(view)
+
+    # Samples with creation date within 30 minutes of 2021-08-24 02:01:00
+    view = dataset.match(abs(F("creation_date") - query_date) < query_delta)
+    print(view)
+
+.. note::
+
+    As the example above demonstrates, |ViewExpression| instances may contain
+    `datetime.datetime` and `datetime.timedelta` objects.
+
+    Note that, internally, subtracting two dates will result in the number of
+    milliseconds between them. Using `datetime.timedelta` allows these units to
+    be abstracted away from the API user.
+
 .. _object-patches-views:
 
 Object patches

--- a/docs/source/user_guide/using_views.rst
+++ b/docs/source/user_guide/using_views.rst
@@ -563,14 +563,14 @@ stage to filter the contents of arbitrarily-typed fields:
 Datetime views
 ______________
 
-If your dataset contains :ref:`datetime fields <using-datetimes>`, then you
-can construct dataset views that query/filter based on this information by
-simply defining the appropriate |ViewExpression|, using  `datetime` and
-`timedelta` objects to define the required logic.
+If your dataset contains :ref:`datetime fields <using-datetimes>`, you can
+construct dataset views that query/filter based on this information by simply
+writing the appropriate |ViewExpression|, using  `datetime` and `timedelta`
+objects to define the required logic.
 
 For example, you can use the
 :meth:`match() <fiftyone.core.collections.SampleCollection.match>` stage to
-filter a dataset via date-based conditions as follows:
+filter a dataset by date as follows:
 
 .. code-block:: python
     :linenos:
@@ -585,15 +585,15 @@ filter a dataset via date-based conditions as follows:
         [
             fo.Sample(
                 filepath="image1.png",
-                creation_date=datetime(2021, 8, 24, 1, 0, 0),
+                capture_date=datetime(2021, 8, 24, 1, 0, 0),
             ),
             fo.Sample(
                 filepath="image2.png",
-                creation_date=datetime(2021, 8, 24, 2, 0, 0),
+                capture_date=datetime(2021, 8, 24, 2, 0, 0),
             ),
             fo.Sample(
                 filepath="image3.png",
-                creation_date=datetime(2021, 8, 24, 3, 0, 0),
+                capture_date=datetime(2021, 8, 24, 3, 0, 0),
             ),
         ]
     )
@@ -601,22 +601,20 @@ filter a dataset via date-based conditions as follows:
     query_date = datetime(2021, 8, 24, 2, 1, 0)
     query_delta = timedelta(minutes=30)
 
-    # Samples with creation date after 2021-08-24 02:01:00
-    view = dataset.match(F("creation_date") > query_date)
+    # Samples with capture date after 2021-08-24 02:01:00
+    view = dataset.match(F("capture_date") > query_date)
     print(view)
 
-    # Samples with creation date within 30 minutes of 2021-08-24 02:01:00
-    view = dataset.match(abs(F("creation_date") - query_date) < query_delta)
+    # Samples with capture date within 30 minutes of 2021-08-24 02:01:00
+    view = dataset.match(abs(F("capture_date") - query_date) < query_delta)
     print(view)
 
 .. note::
 
     As the example above demonstrates, |ViewExpression| instances may contain
-    `datetime` and `timedelta` objects.
-
-    Note that, internally, subtracting two dates will result in the number of
-    milliseconds between them. Using `timedelta` allows these units to be
-    abstracted away from the API user.
+    `datetime` and `timedelta` objects. Internally, subtracting two dates
+    returns the number of milliseconds between them. Using `timedelta` allows
+    these units to be abstracted away from the user.
 
 .. _object-patches-views:
 

--- a/docs/source/user_guide/using_views.rst
+++ b/docs/source/user_guide/using_views.rst
@@ -565,8 +565,8 @@ ______________
 
 If your dataset contains :ref:`datetime fields <using-datetimes>`, then you
 can construct dataset views that query/filter based on this information by
-simply defining the appropriate |ViewExpression|, using  `datetime.datetime`
-and/or `datetime.timedelta` objects to define the required logic.
+simply defining the appropriate |ViewExpression|, using  `datetime` and
+`timedelta` objects to define the required logic.
 
 For example, you can use the
 :meth:`match() <fiftyone.core.collections.SampleCollection.match>` stage to
@@ -612,11 +612,11 @@ filter a dataset via date-based conditions as follows:
 .. note::
 
     As the example above demonstrates, |ViewExpression| instances may contain
-    `datetime.datetime` and `datetime.timedelta` objects.
+    `datetime` and `timedelta` objects.
 
     Note that, internally, subtracting two dates will result in the number of
-    milliseconds between them. Using `datetime.timedelta` allows these units to
-    be abstracted away from the API user.
+    milliseconds between them. Using `timedelta` allows these units to be
+    abstracted away from the API user.
 
 .. _object-patches-views:
 

--- a/fiftyone/__public__.py
+++ b/fiftyone/__public__.py
@@ -46,6 +46,7 @@ from .core.fields import (
     ArrayField,
     BooleanField,
     ClassesField,
+    DateTimeField,
     DictField,
     EmbeddedDocumentField,
     EmbeddedDocumentListField,

--- a/fiftyone/core/config.py
+++ b/fiftyone/core/config.py
@@ -13,6 +13,8 @@ try:
 except ImportError:
     import importlib_metadata  # Python < 3.8
 
+import pytz
+
 import eta
 import eta.core.config as etac
 
@@ -70,6 +72,9 @@ class FiftyOneConfig(EnvConfig):
             "database_dir",
             env_var="FIFTYONE_DATABASE_DIR",
             default=foc.DEFAULT_DB_DIR,
+        )
+        self.timezone = self.parse_string(
+            d, "timezone", env_var="FIFTYONE_TIMEZONE", default=None
         )
         self.dataset_zoo_dir = self.parse_string(
             d,
@@ -199,6 +204,13 @@ class FiftyOneConfig(EnvConfig):
     def _validate(self):
         if self.default_ml_backend is not None:
             self.default_ml_backend = self.default_ml_backend.lower()
+
+        if self.timezone and self.timezone.lower() not in {"local", "utc"}:
+            try:
+                pytz.timezone(self.timezone)
+            except:
+                logger.warning("Ignoring invalid timezone '%s'", self.timezone)
+                self.timezone = None
 
 
 class FiftyOneConfigError(etac.EnvConfigError):

--- a/fiftyone/core/fields.py
+++ b/fiftyone/core/fields.py
@@ -5,6 +5,8 @@ Dataset sample fields.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+from datetime import datetime
+
 from bson import SON
 from bson.binary import Binary
 import mongoengine.fields
@@ -77,6 +79,14 @@ class BooleanField(mongoengine.fields.BooleanField, Field):
     """A boolean field."""
 
     pass
+
+
+class DateTimeField(mongoengine.fields.DateTimeField, Field):
+    """A datetime field."""
+
+    def validate(self, value):
+        if not isinstance(value, datetime):
+            self.error("Datetime fields must have `datetime` values")
 
 
 class FrameNumberField(IntField):
@@ -534,9 +544,10 @@ class EmbeddedDocumentListField(
 
 _ARRAY_FIELDS = (VectorField, ArrayField)
 _PRIMITIVE_FIELDS = (
-    ObjectIdField,
-    IntField,
-    FloatField,
-    StringField,
     BooleanField,
+    DateTimeField,
+    FloatField,
+    IntField,
+    ObjectIdField,
+    StringField,
 )

--- a/fiftyone/core/odm/database.py
+++ b/fiftyone/core/odm/database.py
@@ -6,18 +6,22 @@ Database utilities.
 |
 """
 from copy import copy
+from datetime import datetime
 import logging
 import os
 
 from bson import json_util
+from bson.codec_options import CodecOptions
 from mongoengine import connect
 import motor
 from packaging.version import Version
 import pymongo
 from pymongo.errors import BulkWriteError, ServerSelectionTimeoutError
+import pytz
 
 import eta.core.utils as etau
 
+import fiftyone as fo
 import fiftyone.constants as foc
 from fiftyone.core.config import FiftyOneConfigError
 import fiftyone.core.service as fos
@@ -164,7 +168,8 @@ def get_db_conn():
         a ``pymongo.database.Database``
     """
     _connect()
-    return _client[foc.DEFAULT_DATABASE]
+    db = _client[foc.DEFAULT_DATABASE]
+    return _apply_options(db)
 
 
 def get_async_db_conn():
@@ -174,7 +179,24 @@ def get_async_db_conn():
         a ``motor.motor_tornado.MotorDatabase``
     """
     _async_connect()
-    return _async_client[foc.DEFAULT_DATABASE]
+    db = _async_client[foc.DEFAULT_DATABASE]
+    return _apply_options(db)
+
+
+def _apply_options(db):
+    timezone = fo.config.timezone
+
+    if not timezone or timezone.lower() == "utc":
+        return db
+
+    if timezone.lower() == "local":
+        tzinfo = datetime.now().astimezone().tzinfo
+    else:
+        tzinfo = pytz.timezone(timezone)
+
+    return db.with_options(
+        codec_options=CodecOptions(tz_aware=True, tzinfo=tzinfo)
+    )
 
 
 def drop_database():

--- a/fiftyone/core/odm/mixins.py
+++ b/fiftyone/core/odm/mixins.py
@@ -6,6 +6,7 @@ Mixins and helpers for sample backing documents.
 |
 """
 from collections import OrderedDict
+from datetime import datetime
 import json
 import logging
 import numbers
@@ -155,6 +156,9 @@ def get_implied_field_kwargs(value):
     if isinstance(value, six.string_types):
         return {"ftype": fof.StringField}
 
+    if isinstance(value, datetime):
+        return {"ftype": fof.DateTimeField}
+
     if isinstance(value, (list, tuple)):
         kwargs = {"ftype": fof.ListField}
 
@@ -195,6 +199,9 @@ def _get_list_value_type(value):
 
     if isinstance(value, six.string_types):
         return fof.StringField
+
+    if isinstance(value, datetime):
+        return fof.DateTimeField
 
     return None
 

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -15,6 +15,7 @@ plotly==4.14.3
 pprintpp==0.4.0
 psutil==5.7.0
 pymongo==3.11.0
+pytz==2019.3
 PyYAML==5.4
 scikit-learn==0.23.2
 scikit-image==0.16.2

--- a/setup.py
+++ b/setup.py
@@ -85,6 +85,7 @@ setup(
         "pprintpp",
         "psutil",
         "pymongo>=3.11,<4",
+        "pytz",
         "PyYAML",
         "retrying",
         "scikit-learn",

--- a/tests/unittests/dataset_tests.py
+++ b/tests/unittests/dataset_tests.py
@@ -5,10 +5,12 @@ FiftyOne dataset-related unit tests.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+from datetime import datetime
 import gc
 import os
 
 import numpy as np
+import pytz
 import unittest
 
 import eta.core.utils as etau
@@ -184,6 +186,41 @@ class DatasetTests(unittest.TestCase):
 
         for sample in dataset.iter_samples(progress=True):
             pass
+
+    @drop_datasets
+    def test_datetime_fields(self):
+        dataset = fo.Dataset()
+
+        # These are all the epoch
+        date1 = datetime(1970, 1, 1, 0, 0, 0)
+        utcdate1 = date1.replace(tzinfo=pytz.utc)
+        date2 = utcdate1.astimezone(pytz.timezone("US/Eastern"))
+        date3 = utcdate1.astimezone(pytz.timezone("US/Pacific"))
+
+        # FiftyOne treats naive datetimes as UTC implicitly
+        sample1 = fo.Sample(filepath="image1.png", date=date1)
+
+        # FiftyOne accepts timezone-aware datetimes too
+        sample2 = fo.Sample(filepath="image2.png", date=date2)
+        sample3 = fo.Sample(filepath="image3.png", date=date3)
+
+        dataset.add_samples([sample1, sample2, sample3])
+
+        fo.config.timezone = "US/Eastern"
+        dataset.reload()
+
+        self.assertEqual(sample1.date.tzinfo.zone, "US/Eastern")
+        self.assertEqual(int((sample1.date - utcdate1).total_seconds()), 0)
+        self.assertEqual(int((sample1.date - sample2.date).total_seconds()), 0)
+        self.assertEqual(int((sample1.date - sample3.date).total_seconds()), 0)
+
+        fo.config.timezone = None
+        dataset.reload()
+
+        self.assertIsNone(sample1.date.tzinfo)
+        self.assertEqual(int((sample1.date - date1).total_seconds()), 0)
+        self.assertEqual(int((sample1.date - sample2.date).total_seconds()), 0)
+        self.assertEqual(int((sample1.date - sample3.date).total_seconds()), 0)
 
     @drop_datasets
     def test_merge_samples1(self):
@@ -750,10 +787,12 @@ class DatasetTests(unittest.TestCase):
             int_field=1,
             str_field="hi",
             float_field=1.0,
+            datetime_field=datetime.utcnow(),
             list_bool_field=[False, True],
             list_float_field=[1.0, 2, 4.1],
             list_int_field=[1, 2, 3],
             list_str_field=["one", "two", "three"],
+            list_datetime_field=[datetime.utcnow(), datetime.utcnow()],
             list_untyped_field=[1, {"two": "three"}, [4], "five"],
             dict_field={"hello": "world"},
             vector_field=np.arange(5),
@@ -768,6 +807,7 @@ class DatasetTests(unittest.TestCase):
         self.assertIsInstance(schema["int_field"], fo.IntField)
         self.assertIsInstance(schema["str_field"], fo.StringField)
         self.assertIsInstance(schema["float_field"], fo.FloatField)
+        self.assertIsInstance(schema["datetime_field"], fo.DateTimeField)
 
         # Lists
         self.assertIsInstance(schema["list_bool_field"], fo.ListField)
@@ -781,6 +821,11 @@ class DatasetTests(unittest.TestCase):
 
         self.assertIsInstance(schema["list_str_field"], fo.ListField)
         self.assertIsInstance(schema["list_str_field"].field, fo.StringField)
+
+        self.assertIsInstance(schema["list_datetime_field"], fo.ListField)
+        self.assertIsInstance(
+            schema["list_datetime_field"].field, fo.DateTimeField
+        )
 
         self.assertIsInstance(schema["list_untyped_field"], fo.ListField)
         self.assertEqual(schema["list_untyped_field"].field, None)

--- a/tests/unittests/video_tests.py
+++ b/tests/unittests/video_tests.py
@@ -5,6 +5,8 @@ FiftyOne video-related unit tests.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+from datetime import datetime
+
 from bson import ObjectId
 import numpy as np
 import unittest
@@ -210,6 +212,7 @@ class VideoTests(unittest.TestCase):
             int_field=1,
             str_field="hi",
             float_field=1.0,
+            datetime_field=datetime.utcnow(),
             list_field=[1, 2, 3],
             dict_field={"hello": "world"},
             vector_field=np.arange(5),
@@ -223,6 +226,7 @@ class VideoTests(unittest.TestCase):
         self.assertIsInstance(schema["int_field"], fo.IntField)
         self.assertIsInstance(schema["str_field"], fo.StringField)
         self.assertIsInstance(schema["float_field"], fo.FloatField)
+        self.assertIsInstance(schema["datetime_field"], fo.DateTimeField)
         self.assertIsInstance(schema["list_field"], fo.ListField)
         self.assertIsInstance(schema["dict_field"], fo.DictField)
         self.assertIsInstance(schema["vector_field"], fo.VectorField)

--- a/tests/unittests/view_tests.py
+++ b/tests/unittests/view_tests.py
@@ -6,6 +6,7 @@ FiftyOne view-related unit tests.
 |
 """
 from copy import deepcopy
+from datetime import datetime, timedelta
 import math
 
 import unittest
@@ -444,7 +445,6 @@ class ViewExpressionTests(unittest.TestCase):
 
     @drop_datasets
     def test_array(self):
-        dataset_name = self.test_array.__name__
         dataset = fo.Dataset()
 
         dataset.add_samples(
@@ -496,7 +496,9 @@ class ViewExpressionTests(unittest.TestCase):
     @drop_datasets
     def test_str(self):
         special_chars = r"[]{}()*+-?.,\\^$|#"
+
         self.dataset = fo.Dataset()
+
         self.dataset.add_samples(
             [
                 fo.Sample(filepath="test1.jpg", test="test1.jpg"),
@@ -582,6 +584,43 @@ class ViewExpressionTests(unittest.TestCase):
             ),
             1,
         )
+
+    @drop_datasets
+    def test_datetimes(self):
+        dataset = fo.Dataset()
+
+        date1 = datetime(2021, 8, 24, 1, 0, 0)
+        date2 = datetime(2021, 8, 24, 2, 0, 0)
+        date3 = datetime(2021, 8, 24, 3, 0, 0)
+
+        query_date = datetime(2021, 8, 24, 2, 1, 0)
+        query_delta = timedelta(minutes=30)
+
+        dataset.add_samples(
+            [
+                fo.Sample(filepath="image1.png", date=date1),
+                fo.Sample(filepath="image2.png", date=date2),
+                fo.Sample(filepath="image3.png", date=date3),
+            ]
+        )
+
+        fo.config.timezone = None
+        dataset.reload()
+
+        dates = dataset.values("date")
+        self.assertListEqual(dates, [date1, date2, date3])
+
+        min_date, max_date = dataset.bounds("date")
+        self.assertEqual(min_date, date1)
+        self.assertEqual(max_date, date3)
+
+        view = dataset.match(F("date") > query_date)
+        self.assertEqual(len(view), 1)
+        self.assertEqual(view.first().date, date3)
+
+        view = dataset.match(abs(F("date") - query_date) < query_delta)
+        self.assertEqual(len(view), 1)
+        self.assertEqual(view.first().date, date2)
 
 
 class SliceTests(unittest.TestCase):


### PR DESCRIPTION
Adds support for storing date information in FiftyOne datasets.

Timezones and date-based queries are naturally supported 🎵👂 

### TODO

- [ ] Add App-side support for filtering based on datetime fields

### Timezone example

Timezone handling is pretty clean:

```py
from datetime import datetime, timedelta
import pytz

import fiftyone as fo


dataset = fo.Dataset()

# These are all the epoch
date1 = datetime(1970, 1, 1, 0, 0, 0)
utcdate1 = date1.replace(tzinfo=pytz.utc)
date2 = utcdate1.astimezone(pytz.timezone("US/Eastern"))
date3 = utcdate1.astimezone(pytz.timezone("US/Pacific"))

# FiftyOne treats naive datetimes as UTC implicitly
sample1 = fo.Sample(filepath="image1.png", date=date1)

# FiftyOne accepts timezone-aware datetimes too
sample2 = fo.Sample(filepath="image2.png", date=date2)
sample3 = fo.Sample(filepath="image3.png", date=date3)

dataset.add_samples([sample1, sample2, sample3])

fo.config.timezone = "US/Eastern"
dataset.reload()

print(sample1.date.tzinfo.zone == "US/Eastern")
print((sample1.date - utcdate1).total_seconds())
print((sample1.date - sample2.date).total_seconds())
print((sample1.date - sample3.date).total_seconds())

fo.config.timezone = None
dataset.reload()

print(sample1.date.tzinfo is None)
print((sample1.date - date1).total_seconds())
print((sample1.date - sample2.date).total_seconds())
print((sample1.date - sample3.date).total_seconds())
```

### Dataset view example

And of course, support for date-based dataset views is there, too!

```py
from datetime import datetime, timedelta

import fiftyone as fo
from fiftyone import ViewField as F

dataset = fo.Dataset()
dataset.add_samples(
    [
        fo.Sample(
            filepath="image1.png",
            creation_date=datetime(2021, 8, 24, 1, 0, 0),
        ),
        fo.Sample(
            filepath="image2.png",
            creation_date=datetime(2021, 8, 24, 2, 0, 0),
        ),
        fo.Sample(
            filepath="image3.png",
            creation_date=datetime(2021, 8, 24, 3, 0, 0),
        ),
    ]
)

query_date = datetime(2021, 8, 24, 2, 1, 0)
query_delta = timedelta(minutes=30)

# Samples with creation date after 2021-08-24 02:01:00
view = dataset.match(F("creation_date") > query_date)
print(view)

# Samples with creation date within 30 minutes of 2021-08-24 02:01:00
view = dataset.match(abs(F("creation_date") - query_date) < query_delta)
print(view)
```
