### PR TITLE
Select only relevant objects before editing in App tagging workflow

### DIFF
--- a/fiftyone/server/utils.py
+++ b/fiftyone/server/utils.py
@@ -16,6 +16,8 @@ import warnings
 import eta.core.video as etav
 import PIL.Image
 
+from fiftyone import ViewField as F
+
 
 FILE_UNKNOWN = "Sorry, don't know how to get size for this file."
 
@@ -28,27 +30,32 @@ class UnknownImageFormat(UnknownFileFormat):
     pass
 
 
-def change_sample_tags(collection, changes):
+def change_sample_tags(sample_collection, changes):
     """Applies the changes to tags to all samples of the collection, if
     necessary.
 
     Args:
-        collection: the :class:`fiftyone.core.collections.SampleCollection`
+        sample_collection: a
+            :class:`fiftyone.core.collections.SampleCollection`
         changes: a dict of tags as keys and bools as values. A ``True`` value
             adds the tag to all samples, if necessary. A ``False`` value
             removes the tag from all samples, if necessary
     """
-    modifier = _get_tag_modifier(changes)
+    if not changes:
+        return
 
-    collection._edit_sample_tags(modifier)
+    tag_expr = _get_tag_expr(changes)
+    edit_fcn = _get_tag_modifier(changes)
+    sample_collection.match(tag_expr)._edit_sample_tags(edit_fcn)
 
 
-def change_label_tags(collection, changes, label_fields=None):
+def change_label_tags(sample_collection, changes, label_fields=None):
     """Applies the changes to tags to all labels in the specified label
     field(s) of the collection, if necessary.
 
     Args:
-        collection: the :class:`fiftyone.core.collections.SampleCollection`
+        sample_collection: a
+            :class:`fiftyone.core.collections.SampleCollection`
         changes: a dict of tags as keys and bools as values. A ``True`` value
             adds the tag to all labels, if necessary. A ``False`` value removes
             the tag from all labels, if necessary
@@ -56,9 +63,56 @@ def change_label_tags(collection, changes, label_fields=None):
             :class:`fiftyone.core.labels.Label` fields. By default, all label
             fields are used
     """
-    modifier = _get_tag_modifier(changes)
+    if not changes:
+        return
 
-    collection._edit_label_tags(modifier, label_fields=label_fields)
+    if label_fields is None:
+        label_fields = sample_collection._get_label_fields()
+
+    tag_expr = _get_tag_expr(changes)
+    edit_fcn = _get_tag_modifier(changes)
+
+    for label_field in label_fields:
+        tag_view = sample_collection.select_fields(label_field).filter_labels(
+            label_field, tag_expr
+        )
+        tag_view._edit_label_tags(edit_fcn, label_fields=[label_field])
+
+
+def _get_tag_expr(changes):
+    tag_exprs = []
+    for tag, add in changes.items():
+        if add:
+            # We need to tag objects that don't contain the tag
+            tag_exprs.append(~F("tags").contains(tag))
+        else:
+            # We need to untag objects that do contain the tag
+            tag_exprs.append(F("tags").contains(tag))
+
+    if any(changes.values()):
+        # If no tags exist, we'll always have to add
+        tag_expr = F.any([F("tags") == None] + tag_exprs)
+    else:
+        # We're only deleting tags, so we skip objects with no tags
+        tag_expr = (F("tags") != None) & F.any(tag_exprs)
+
+    return tag_expr
+
+
+def _get_tag_modifier(changes):
+    def edit_tags(tags):
+        if not tags:
+            return [tag for (tag, add) in changes.items() if add]
+
+        for tag, add in changes.items():
+            if add and tag not in tags:
+                tags = tags + [tag]
+            elif not add and tag in tags:
+                tags = [t for t in tags if t != tag]
+
+        return tags
+
+    return edit_tags
 
 
 def read_metadata(filepath, metadata=None):
@@ -397,19 +451,3 @@ def get_image_data_from_bytesio(input, size, file_path=None):
         width=width,
         height=height,
     )
-
-
-def _get_tag_modifier(changes):
-    def modify_tags(tags):
-        if not tags:
-            return [tag for (tag, add) in changes.items() if add]
-
-        for tag, add in changes.items():
-            if add and tag not in tags:
-                tags = tags + [tag]
-            elif not add and tag in tags:
-                tags = [t for t in tags if t != tag]
-
-        return tags
-
-    return modify_tags


### PR DESCRIPTION
Resolves https://github.com/voxel51/fiftyone/issues/1218.

When tagging/untagging samples/labels from the App, a view stage is now created which first selects only samples/labels whose tags need to be edited, and then the edits are applied to this minimal list.

Since the view stage is significantly faster than the equivalent no-op bulk write operations, this change effectively makes tagging workflows run in `O(# edits)` time, while the previous runtime was `O(# samples/labels)`.

This assertion was verified by applying many variants of tagging/untagging to the BDD100K validation split, which has 10K samples and 300K labels.

Tagging/untagging all 300K labels across all 5 label fields still takes some time (in fact slightly more than before, since a relatively complex view stage that ends up selecting everything is still run first, followed by the same bulk write updates), but the increase is minor, and the benefit of `O(# edits)` runtime for all practical workflows makes this a clear win.