### PR TITLE
Adding created_at and last_loaded_at properties to datasets

### DIFF
--- a/docs/source/cli/index.rst
+++ b/docs/source/cli/index.rst
@@ -336,7 +336,7 @@ Print information about FiftyOne datasets.
 
     # Print basic information about all datasets
     fiftyone datasets info
-    fiftyone datasets info --sort-by creation_date
+    fiftyone datasets info --sort-by created_at
     fiftyone datasets info --sort-by name --reverse
 
 .. code-block:: shell

--- a/docs/source/cli/index.rst
+++ b/docs/source/cli/index.rst
@@ -315,23 +315,32 @@ Print information about FiftyOne datasets.
 
 .. code-block:: text
 
-    fiftyone datasets info [-h] NAME
+    fiftyone datasets info [-h] [-s FIELD] [-r] [NAME]
 
 **Arguments**
 
 .. code-block:: text
 
     positional arguments:
-      NAME        the name of the dataset
+      NAME                  the name of a dataset
 
     optional arguments:
-      -h, --help  show this help message and exit
+      -h, --help            show this help message and exit
+      -s FIELD, --sort-by FIELD
+                            a field to sort the dataset rows by
+      -r, --reverse         whether to print the results in reverse order
 
 **Examples**
 
 .. code-block:: shell
 
-    # Print information about the given dataset
+    # Print basic information about all datasets
+    fiftyone datasets info
+    fiftyone datasets info --sort-by creation_date
+
+.. code-block:: shell
+
+    # Print information about a specific dataset
     fiftyone datasets info <name>
 
 .. _cli-fiftyone-datasets-stats:

--- a/docs/source/cli/index.rst
+++ b/docs/source/cli/index.rst
@@ -337,6 +337,7 @@ Print information about FiftyOne datasets.
     # Print basic information about all datasets
     fiftyone datasets info
     fiftyone datasets info --sort-by creation_date
+    fiftyone datasets info --sort-by name --reverse
 
 .. code-block:: shell
 

--- a/docs/source/user_guide/config.rst
+++ b/docs/source/user_guide/config.rst
@@ -318,18 +318,18 @@ Or, you can even dynamically change the timezone while you work in Python:
     from datetime import datetime
     import fiftyone as fo
 
-    sample = fo.Sample(filepath="image.png", creation_date=datetime.utcnow())
+    sample = fo.Sample(filepath="image.png", created_at=datetime.utcnow())
 
     dataset = fo.Dataset()
     dataset.add_sample(sample)
 
-    print(sample.creation_date)
+    print(sample.created_at)
     # 2021-08-24 20:24:09.723021
 
     fo.config.timezone = "local"
     dataset.reload()
 
-    print(sample.creation_date)
+    print(sample.created_at)
     # 2021-08-24 16:24:09.723000-04:00
 
 .. note::

--- a/docs/source/user_guide/using_datasets.rst
+++ b/docs/source/user_guide/using_datasets.rst
@@ -978,11 +978,11 @@ You can store date information in FiftyOne datasets by populating fields with
         [
             fo.Sample(
                 filepath="image1.png",
-                creation_date=datetime(2021, 8, 24, 21, 18, 7),
+                created_at=datetime(2021, 8, 24, 21, 18, 7),
             ),
             fo.Sample(
                 filepath="image2.png",
-                creation_date=datetime.utcnow(),
+                created_at=datetime.utcnow(),
             ),
         ]
     )
@@ -1006,7 +1006,7 @@ format for safekeeping.
     # A datetime in your local timezone
     now = datetime.utcnow().astimezone()
 
-    sample = fo.Sample(filepath="image.png", creation_date=now)
+    sample = fo.Sample(filepath="image.png", created_at=now)
 
     dataset = fo.Dataset()
     dataset.add_sample(sample)
@@ -1015,7 +1015,7 @@ format for safekeeping.
     # loaded from the database
     dataset.reload()
 
-    sample.creation_date.tzinfo  # None
+    sample.created_at.tzinfo  # None
 
 By default, when you access a datetime field of a sample in a dataset, it is
 retrieved as a naive `datetime` instance expressed in UTC format.

--- a/fiftyone/core/cli.py
+++ b/fiftyone/core/cli.py
@@ -374,7 +374,7 @@ class DatasetsInfoCommand(Command):
 
         # Print basic information about all datasets
         fiftyone datasets info
-        fiftyone datasets info --sort-by creation_date
+        fiftyone datasets info --sort-by created_at
         fiftyone datasets info --sort-by name --reverse
 
         # Print information about a specific dataset
@@ -390,7 +390,7 @@ class DatasetsInfoCommand(Command):
             "-s",
             "--sort-by",
             metavar="FIELD",
-            default="last_loaded_date",
+            default="last_loaded_at",
             help="a field to sort the dataset rows by",
         )
         parser.add_argument(
@@ -418,8 +418,8 @@ def _print_all_dataset_info(sort_by, reverse):
 
     headers = [
         "name",
-        "creation_date",
-        "last_loaded_date",
+        "created_at",
+        "last_loaded_at",
         "version",
         "persistent",
         "media_type",

--- a/fiftyone/core/cli.py
+++ b/fiftyone/core/cli.py
@@ -375,6 +375,7 @@ class DatasetsInfoCommand(Command):
         # Print basic information about all datasets
         fiftyone datasets info
         fiftyone datasets info --sort-by creation_date
+        fiftyone datasets info --sort-by name --reverse
 
         # Print information about a specific dataset
         fiftyone datasets info <name>
@@ -389,7 +390,7 @@ class DatasetsInfoCommand(Command):
             "-s",
             "--sort-by",
             metavar="FIELD",
-            default="name",
+            default="last_loaded_date",
             help="a field to sort the dataset rows by",
         )
         parser.add_argument(

--- a/fiftyone/core/cli.py
+++ b/fiftyone/core/cli.py
@@ -7,6 +7,7 @@ Definition of the `fiftyone` command-line interface (CLI).
 """
 import argparse
 from collections import defaultdict
+from datetime import datetime
 import json
 import os
 import subprocess
@@ -371,20 +372,82 @@ class DatasetsInfoCommand(Command):
 
     Examples::
 
-        # Print information about the given dataset
+        # Print basic information about all datasets
+        fiftyone datasets info
+        fiftyone datasets info --sort-by creation_date
+
+        # Print information about a specific dataset
         fiftyone datasets info <name>
     """
 
     @staticmethod
     def setup(parser):
         parser.add_argument(
-            "name", metavar="NAME", help="the name of the dataset",
+            "name", nargs="?", metavar="NAME", help="the name of a dataset",
+        )
+        parser.add_argument(
+            "-s",
+            "--sort-by",
+            metavar="FIELD",
+            default="name",
+            help="a field to sort the dataset rows by",
+        )
+        parser.add_argument(
+            "-r",
+            "--reverse",
+            action="store_true",
+            help="whether to print the results in reverse order",
         )
 
     @staticmethod
     def execute(parser, args):
-        dataset = fod.load_dataset(args.name)
-        print(dataset)
+        if args.name:
+            _print_dataset_info(args.name)
+        else:
+            _print_all_dataset_info(args.sort_by, args.reverse)
+
+
+def _print_dataset_info(name):
+    dataset = fod.load_dataset(name)
+    print(dataset)
+
+
+def _print_all_dataset_info(sort_by, reverse):
+    info = fod.list_datasets(info=True)
+
+    headers = [
+        "name",
+        "creation_date",
+        "last_loaded_date",
+        "version",
+        "persistent",
+        "media_type",
+        "num_samples",
+    ]
+
+    if sort_by in headers:
+        key = lambda d: (d[sort_by] is not None, d[sort_by])
+        info = sorted(info, key=key, reverse=not reverse)
+    else:
+        print("Ignoring invalid sort-by field '%s'" % sort_by)
+
+    records = []
+    for i in info:
+        i["persistent"] = "\u2713" if i["persistent"] else ""
+        records.append(tuple(_format_cell(i[key]) for key in headers))
+
+    table_str = tabulate(records, headers=headers, tablefmt=_TABLE_FORMAT)
+    print(table_str)
+
+
+def _format_cell(cell):
+    if cell is None:
+        return "???"
+
+    if isinstance(cell, datetime):
+        return cell.replace(microsecond=0)
+
+    return cell
 
 
 class DatasetsStatsCommand(Command):

--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -370,14 +370,14 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
             raise
 
     @property
-    def creation_date(self):
+    def created_at(self):
         """The datetime that the dataset was created."""
-        return self._doc.creation_date
+        return self._doc.created_at
 
     @property
-    def last_loaded_date(self):
+    def last_loaded_at(self):
         """The datetime that the dataset was last loaded."""
-        return self._doc.last_loaded_date
+        return self._doc.last_loaded_at
 
     @property
     def persistent(self):
@@ -4240,8 +4240,8 @@ def _list_dataset_info():
         info.append(
             {
                 "name": dataset.name,
-                "creation_date": dataset.creation_date,
-                "last_loaded_date": dataset.last_loaded_date,
+                "created_at": dataset.created_at,
+                "last_loaded_at": dataset.last_loaded_at,
                 "version": dataset.version,
                 "persistent": dataset.persistent,
                 "media_type": dataset.media_type,
@@ -4282,8 +4282,8 @@ def _create_dataset(name, persistent=False, patches=False, frames=False):
     dataset_doc = foo.DatasetDocument(
         name=name,
         version=focn.VERSION,
-        creation_date=now,
-        last_loaded_date=now,
+        created_at=now,
+        last_loaded_at=now,
         persistent=persistent,
         media_type=None,
         sample_collection_name=sample_collection_name,
@@ -4373,7 +4373,7 @@ def _load_dataset(name, virtual=False):
             frame_doc_cls._declare_field(frame_field)
 
     if not virtual:
-        dataset_doc.last_loaded_date = datetime.utcnow()
+        dataset_doc.last_loaded_at = datetime.utcnow()
         dataset_doc.save()
 
     return dataset_doc, sample_doc_cls, frame_doc_cls
@@ -4434,8 +4434,8 @@ def _clone_dataset_or_view(dataset_or_view, name):
 
     dataset_doc = dataset._doc.copy()
     dataset_doc.name = name
-    dataset_doc.creation_date = datetime.utcnow()
-    dataset_doc.last_loaded_date = None
+    dataset_doc.created_at = datetime.utcnow()
+    dataset_doc.last_loaded_at = None
     dataset_doc.persistent = False
     dataset_doc.sample_collection_name = sample_collection_name
 

--- a/fiftyone/core/odm/dataset.py
+++ b/fiftyone/core/odm/dataset.py
@@ -13,6 +13,7 @@ from fiftyone.core.fields import (
     Field,
     BooleanField,
     ClassesField,
+    DateTimeField,
     DictField,
     EmbeddedDocumentField,
     EmbeddedDocumentListField,
@@ -187,22 +188,24 @@ class DatasetDocument(Document):
 
     meta = {"collection": "datasets"}
 
-    media_type = StringField()
     name = StringField(unique=True, required=True)
-    sample_collection_name = StringField(unique=True, required=True)
+    version = StringField(required=True, null=True)
+    creation_date = DateTimeField()
+    last_loaded_date = DateTimeField()
     persistent = BooleanField(default=False)
+    media_type = StringField()
     info = DictField()
+    classes = DictField(ClassesField())
+    default_classes = ClassesField()
+    mask_targets = DictField(TargetsField())
+    default_mask_targets = TargetsField()
+    sample_collection_name = StringField(unique=True, required=True)
+    sample_fields = EmbeddedDocumentListField(
+        document_type=SampleFieldDocument
+    )
+    frame_fields = EmbeddedDocumentListField(document_type=SampleFieldDocument)
     annotation_runs = DictField(
         EmbeddedDocumentField(document_type=RunDocument)
     )
     brain_methods = DictField(EmbeddedDocumentField(document_type=RunDocument))
     evaluations = DictField(EmbeddedDocumentField(document_type=RunDocument))
-    sample_fields = EmbeddedDocumentListField(
-        document_type=SampleFieldDocument
-    )
-    frame_fields = EmbeddedDocumentListField(document_type=SampleFieldDocument)
-    classes = DictField(ClassesField())
-    default_classes = ClassesField()
-    mask_targets = DictField(TargetsField())
-    default_mask_targets = TargetsField()
-    version = StringField(required=True, null=True)

--- a/fiftyone/core/odm/dataset.py
+++ b/fiftyone/core/odm/dataset.py
@@ -190,8 +190,8 @@ class DatasetDocument(Document):
 
     name = StringField(unique=True, required=True)
     version = StringField(required=True, null=True)
-    creation_date = DateTimeField()
-    last_loaded_date = DateTimeField()
+    created_at = DateTimeField()
+    last_loaded_at = DateTimeField()
     persistent = BooleanField(default=False)
     media_type = StringField()
     info = DictField()

--- a/fiftyone/migrations/revisions/v0_14_0.py
+++ b/fiftyone/migrations/revisions/v0_14_0.py
@@ -11,11 +11,11 @@ def up(db, dataset_name):
     match_d = {"name": dataset_name}
     dataset_dict = db.datasets.find_one(match_d)
 
-    if "creation_date" not in dataset_dict:
-        dataset_dict["creation_date"] = None
+    if "created_at" not in dataset_dict:
+        dataset_dict["created_at"] = None
 
-    if "last_loaded_date" not in dataset_dict:
-        dataset_dict["last_loaded_date"] = None
+    if "last_loaded_at" not in dataset_dict:
+        dataset_dict["last_loaded_at"] = None
 
     db.datasets.replace_one(match_d, dataset_dict)
 
@@ -24,7 +24,7 @@ def down(db, dataset_name):
     match_d = {"name": dataset_name}
     dataset_dict = db.datasets.find_one(match_d)
 
-    dataset_dict.pop("creation_date", None)
-    dataset_dict.pop("last_loaded_date", None)
+    dataset_dict.pop("created_at", None)
+    dataset_dict.pop("last_loaded_at", None)
 
     db.datasets.replace_one(match_d, dataset_dict)

--- a/fiftyone/migrations/revisions/v0_14_0.py
+++ b/fiftyone/migrations/revisions/v0_14_0.py
@@ -1,0 +1,30 @@
+"""
+FiftyOne v0.14.0 revision.
+
+| Copyright 2017-2021, Voxel51, Inc.
+| `voxel51.com <https://voxel51.com/>`_
+|
+"""
+
+
+def up(db, dataset_name):
+    match_d = {"name": dataset_name}
+    dataset_dict = db.datasets.find_one(match_d)
+
+    if "creation_date" not in dataset_dict:
+        dataset_dict["creation_date"] = None
+
+    if "last_loaded_date" not in dataset_dict:
+        dataset_dict["last_loaded_date"] = None
+
+    db.datasets.replace_one(match_d, dataset_dict)
+
+
+def down(db, dataset_name):
+    match_d = {"name": dataset_name}
+    dataset_dict = db.datasets.find_one(match_d)
+
+    dataset_dict.pop("creation_date", None)
+    dataset_dict.pop("last_loaded_date", None)
+
+    db.datasets.replace_one(match_d, dataset_dict)

--- a/fiftyone/utils/data/importers.py
+++ b/fiftyone/utils/data/importers.py
@@ -1479,8 +1479,8 @@ class FiftyOneDatasetImporter(BatchDatasetImporter):
                     _id=doc.id,
                     name=doc.name,
                     persistent=doc.persistent,
-                    creation_date=doc.creation_date,
-                    last_loaded_date=doc.last_loaded_date,
+                    created_at=doc.created_at,
+                    last_loaded_at=doc.last_loaded_at,
                     sample_collection_name=doc.sample_collection_name,
                 )
             )

--- a/fiftyone/utils/data/importers.py
+++ b/fiftyone/utils/data/importers.py
@@ -1481,7 +1481,7 @@ class FiftyOneDatasetImporter(BatchDatasetImporter):
                 )
             )
 
-            # RunResults are imported separately
+            # Run results are imported separately
 
             for run_doc in dataset_dict.get("evaluations", {}).values():
                 run_doc["results"] = None
@@ -1552,7 +1552,7 @@ class FiftyOneDatasetImporter(BatchDatasetImporter):
             )
 
         #
-        # Import RunResults
+        # Import Run results
         #
 
         if empty_import:

--- a/fiftyone/utils/data/importers.py
+++ b/fiftyone/utils/data/importers.py
@@ -1466,18 +1466,22 @@ class FiftyOneDatasetImporter(BatchDatasetImporter):
 
         if empty_import:
             #
-            # The `dataset` we're importing into is empty, so we mostly replace
-            # its backing document with `dataset_dict`
+            # The `dataset` we're importing into is empty, so we replace its
+            # backing document with `dataset_dict`, except for the
+            # metadata-related fields listed below, which we keep in `dataset`
             #
             # Note that we must work with dicts instead of `DatasetDocument`s
             # here because the import may need migration
             #
+            doc = dataset._doc
             dataset_dict.update(
                 dict(
-                    _id=dataset._doc.id,
-                    name=dataset._doc.name,
-                    sample_collection_name=dataset._doc.sample_collection_name,
-                    persistent=dataset._doc.persistent,
+                    _id=doc.id,
+                    name=doc.name,
+                    persistent=doc.persistent,
+                    creation_date=doc.creation_date,
+                    last_loaded_date=doc.last_loaded_date,
+                    sample_collection_name=doc.sample_collection_name,
                 )
             )
 


### PR DESCRIPTION
Adds `created_at` and `last_loaded_at` properties to FiftyOne datasets, which are automatically populated/updated.

**Example dataset**

```py
import fiftyone as fo
import fiftyone.zoo as foz

dataset = foz.load_zoo_dataset("quickstart")

print(dataset.created_at)  # 2021-08-26 01:57:12.378000
print(dataset.last_loaded_at)  # 2021-08-26 01:57:12.378000
```

**Example use case**

One can use this information, for example, to locate recently used/created datasets. The `fiftyone datasets info` command shown below sorts by last loaded date (if known) as a helpful way to locate datasets that you've recently worked with.

```shell
fiftyone datasets info

# These are also possible
fiftyone datasets info --sort-by created_at
fiftyone datasets info --sort-by name --reverse
```

```
name                               created_at           last_loaded_at       version    persistent    media_type      num_samples
---------------------------------  -------------------  -------------------  ---------  ------------  ------------  -------------
coco-2017-validation-500           2021-08-26 01:53:31  2021-08-26 01:53:31  0.13.1     ✓             image                   500
looker-video                       ???                  2021-08-26 01:52:28  0.13.1     ✓             video                    10
looker-polylines                   ???                  2021-08-26 01:52:24  0.13.1     ✓             image                   500
open-images-v6-validation-100      2021-08-26 01:52:01  2021-08-26 01:52:01  0.13.1     ✓             image                   100
looker-image                       ???                  2021-08-25 22:42:25  0.13.1     ✓             image                   200
bdd100k-validation                 ???                  2021-08-25 22:39:34  0.13.1     ✓             image                 10000
bdd100k-validation-embeddings      ???                  ???                  0.13.1     ✓             image                 10000
bdd100k-validation-embeddings2     ???                  ???                  0.13.1     ✓             image                 10000
bdd100k-validation-location        ???                  ???                  0.13.1     ✓             image                  9994
bdd100k-validation-nyc             ???                  ???                  0.13.1     ✓             image                  7953
bdd100k-validation-similarity      ???                  ???                  0.13.1     ✓             image                 10000
cifar10-test-similarity            ???                  ???                  0.13.1     ✓             image                 10000
coco-2017-failure-modes            ???                  ???                  0.13.1     ✓             image                 45670
coco-2017-failure-modes2           ???                  ???                  0.13.1     ✓             image                 45670
coco-2017-recommendations          ???                  ???                  0.13.1     ✓             image                 45670
coco-2017-segmentation-validation  ???                  ???                  0.13.1     ✓             image                  5000
coco-2017-validation-embeddings    ???                  ???                  0.13.1     ✓             image                  5000
```
