### PR TITLE
Adding a temporal detection label type

### DIFF
--- a/app/packages/app/src/recoil/selectors.ts
+++ b/app/packages/app/src/recoil/selectors.ts
@@ -9,6 +9,7 @@ import {
   makeLabelNameGroups,
   VALID_LIST_TYPES,
   LIST_FIELD,
+  UNSUPPORTED_IMAGE,
 } from "../utils/labels";
 import { packageMessage } from "../utils/socket";
 import { viewsAreEqual } from "../utils/view";
@@ -335,10 +336,15 @@ export const fieldSchema = selectorFamily({
   },
 });
 
-const labelFilter = (f) => {
+const getLabelFilter = (video: boolean, dimension: string) => (f) => {
+  if (!f.embedded_doc_type) {
+    return false;
+  }
+
+  const type = f.embedded_doc_type.split(".").slice(-1)[0];
   return (
-    f.embedded_doc_type &&
-    VALID_LABEL_TYPES.includes(f.embedded_doc_type.split(".").slice(-1)[0])
+    ((dimension !== "frame" && video) || !UNSUPPORTED_IMAGE.includes(type)) &&
+    VALID_LABEL_TYPES.includes(type)
   );
 };
 
@@ -440,9 +446,10 @@ const labels = selectorFamily<
   key: "labels",
   get: (dimension: string) => ({ get }) => {
     const fieldsValue = get(selectedFields(dimension));
+    const video = get(isVideoDataset) && get(isRootView);
     return Object.keys(fieldsValue)
       .map((k) => fieldsValue[k])
-      .filter(labelFilter)
+      .filter(getLabelFilter(video, dimension))
       .sort((a, b) => (a.name < b.name ? -1 : 1));
   },
 });

--- a/app/packages/app/src/utils/labels.ts
+++ b/app/packages/app/src/utils/labels.ts
@@ -5,8 +5,8 @@ export const VALID_OBJECT_TYPES = [
   "Keypoints",
   "Polyline",
   "Polylines",
-  "VideoClassification",
-  "VideoClassifications",
+  "TemporalDetection",
+  "TemporalDetections",
 ];
 
 export const VALID_CLASS_TYPES = ["Classification", "Classifications"];
@@ -16,7 +16,7 @@ export const VALID_LIST_TYPES = [
   "Detections",
   "Keypoints",
   "Polylines",
-  "VideoClassifications",
+  "TemporalDetections",
 ];
 
 export const PATCHES_FIELDS = ["Detections", "Polylines"];
@@ -53,8 +53,8 @@ export const FILTERABLE_TYPES = [
   "Keypoint",
   "Polylines",
   "Polyline",
-  "VideoClassification",
-  "VideoClassifications",
+  "TemporalDetection",
+  "TemporalDetections",
 ];
 
 export const CONFIDENCE_LABELS = [
@@ -66,8 +66,8 @@ export const CONFIDENCE_LABELS = [
   "Keypoints",
   "Polyline",
   "Polylines",
-  "VideoClassification",
-  "VideoClassifications",
+  "TemporalDetection",
+  "TemporalDetections",
 ];
 
 export const LABEL_LISTS = [
@@ -75,20 +75,17 @@ export const LABEL_LISTS = [
   "Detections",
   "Keypoints",
   "Polylines",
-  "VideoClassifications",
+  "TemporalDetections",
 ];
 
-export const UNSUPPORTED_IMAGE = [
-  "VideoClassification",
-  "VideoClassifications",
-];
+export const UNSUPPORTED_IMAGE = ["TemporalDetection", "TemporalDetections"];
 
 export const LABEL_LIST = {
   Classifications: "classifications",
   Detections: "detections",
   Keypoints: "keypoints",
   Polylines: "polylines",
-  VideoClassifications: "classifications",
+  TemporalDetections: "detections",
 };
 
 export const AGGS = {

--- a/app/packages/app/src/utils/labels.ts
+++ b/app/packages/app/src/utils/labels.ts
@@ -5,6 +5,8 @@ export const VALID_OBJECT_TYPES = [
   "Keypoints",
   "Polyline",
   "Polylines",
+  "VideoClassification",
+  "VideoClassifications",
 ];
 
 export const VALID_CLASS_TYPES = ["Classification", "Classifications"];
@@ -14,6 +16,7 @@ export const VALID_LIST_TYPES = [
   "Detections",
   "Keypoints",
   "Polylines",
+  "VideoClassifications",
 ];
 
 export const PATCHES_FIELDS = ["Detections", "Polylines"];
@@ -50,6 +53,8 @@ export const FILTERABLE_TYPES = [
   "Keypoint",
   "Polylines",
   "Polyline",
+  "VideoClassification",
+  "VideoClassifications",
 ];
 
 export const CONFIDENCE_LABELS = [
@@ -61,6 +66,8 @@ export const CONFIDENCE_LABELS = [
   "Keypoints",
   "Polyline",
   "Polylines",
+  "VideoClassification",
+  "VideoClassifications",
 ];
 
 export const LABEL_LISTS = [
@@ -68,6 +75,7 @@ export const LABEL_LISTS = [
   "Detections",
   "Keypoints",
   "Polylines",
+  "VideoClassifications",
 ];
 
 export const LABEL_LIST = {
@@ -75,6 +83,7 @@ export const LABEL_LIST = {
   Detections: "detections",
   Keypoints: "keypoints",
   Polylines: "polylines",
+  VideoClassifications: "classifications",
 };
 
 export const AGGS = {

--- a/app/packages/app/src/utils/labels.ts
+++ b/app/packages/app/src/utils/labels.ts
@@ -78,6 +78,11 @@ export const LABEL_LISTS = [
   "VideoClassifications",
 ];
 
+export const UNSUPPORTED_IMAGE = [
+  "VideoClassification",
+  "VideoClassifications",
+];
+
 export const LABEL_LIST = {
   Classifications: "classifications",
   Detections: "detections",

--- a/app/packages/looker/src/constants.ts
+++ b/app/packages/looker/src/constants.ts
@@ -34,6 +34,8 @@ export const SEGMENTATION = "Segmentation";
 export const VIDEO_CLASSIFICATION = "VideoClassification";
 export const VIDEO_CLASSIFICATIONS = "VideoClassifications";
 
+export const MOMENT_CLASSIFICATIONS = [CLASSIFICATION, CLASSIFICATIONS];
+
 export const LABEL_TAGS_CLASSES = [
   CLASSIFICATION,
   CLASSIFICATIONS,

--- a/app/packages/looker/src/constants.ts
+++ b/app/packages/looker/src/constants.ts
@@ -31,16 +31,16 @@ export const KEYPOINTS = "Keypoints";
 export const POLYLINE = "Polyline";
 export const POLYLINES = "Polylines";
 export const SEGMENTATION = "Segmentation";
-export const VIDEO_CLASSIFICATION = "VideoClassification";
-export const VIDEO_CLASSIFICATIONS = "VideoClassifications";
+export const TEMPORAL_DETECTION = "TemporalDetection";
+export const TEMPORAL_DETECTIONS = "TemporalDetections";
 
 export const MOMENT_CLASSIFICATIONS = [CLASSIFICATION, CLASSIFICATIONS];
 
 export const LABEL_TAGS_CLASSES = [
   CLASSIFICATION,
   CLASSIFICATIONS,
-  VIDEO_CLASSIFICATION,
-  VIDEO_CLASSIFICATIONS,
+  TEMPORAL_DETECTION,
+  TEMPORAL_DETECTIONS,
 ];
 
 export const LABEL_LISTS = {
@@ -48,7 +48,7 @@ export const LABEL_LISTS = {
   [DETECTIONS]: "detections",
   [KEYPOINTS]: "Keypoints",
   [POLYLINES]: "polylines",
-  [VIDEO_CLASSIFICATIONS]: "classifications",
+  [TEMPORAL_DETECTIONS]: "detections",
 };
 
 export const LABELS = {
@@ -63,8 +63,8 @@ export const LABELS = {
   [POLYLINE]: POLYLINE,
   [POLYLINES]: POLYLINES,
   [SEGMENTATION]: SEGMENTATION,
-  [VIDEO_CLASSIFICATION]: VIDEO_CLASSIFICATION,
-  [VIDEO_CLASSIFICATIONS]: VIDEO_CLASSIFICATIONS,
+  [TEMPORAL_DETECTION]: TEMPORAL_DETECTION,
+  [TEMPORAL_DETECTIONS]: TEMPORAL_DETECTIONS,
 };
 
 export const MASK_LABELS = new Set([DETECTION, SEGMENTATION]);

--- a/app/packages/looker/src/constants.ts
+++ b/app/packages/looker/src/constants.ts
@@ -31,14 +31,22 @@ export const KEYPOINTS = "Keypoints";
 export const POLYLINE = "Polyline";
 export const POLYLINES = "Polylines";
 export const SEGMENTATION = "Segmentation";
+export const VIDEO_CLASSIFICATION = "VideoClassification";
+export const VIDEO_CLASSIFICATIONS = "VideoClassifications";
 
-export const LABEL_TAGS_CLASSES = [CLASSIFICATION, CLASSIFICATIONS];
+export const LABEL_TAGS_CLASSES = [
+  CLASSIFICATION,
+  CLASSIFICATIONS,
+  VIDEO_CLASSIFICATION,
+  VIDEO_CLASSIFICATIONS,
+];
 
 export const LABEL_LISTS = {
   [CLASSIFICATIONS]: "classifications",
   [DETECTIONS]: "detections",
   [KEYPOINTS]: "Keypoints",
   [POLYLINES]: "polylines",
+  [VIDEO_CLASSIFICATIONS]: "classifications",
 };
 
 export const LABELS = {
@@ -53,6 +61,8 @@ export const LABELS = {
   [POLYLINE]: POLYLINE,
   [POLYLINES]: POLYLINES,
   [SEGMENTATION]: SEGMENTATION,
+  [VIDEO_CLASSIFICATION]: VIDEO_CLASSIFICATION,
+  [VIDEO_CLASSIFICATIONS]: VIDEO_CLASSIFICATIONS,
 };
 
 export const MASK_LABELS = new Set([DETECTION, SEGMENTATION]);

--- a/app/packages/looker/src/elements/base.ts
+++ b/app/packages/looker/src/elements/base.ts
@@ -2,6 +2,7 @@
  * Copyright 2017-2021, Voxel51, Inc.
  */
 
+import { Overlay } from "../overlays/base";
 import { BaseState, DispatchEvent, Sample, StateUpdate } from "../state";
 
 type ElementEvent<State extends BaseState, E extends Event> = (args: {

--- a/app/packages/looker/src/elements/common/error.ts
+++ b/app/packages/looker/src/elements/common/error.ts
@@ -2,9 +2,7 @@
  * Copyright 2017-2021, Voxel51, Inc.
  */
 
-import mime from "mime";
-
-import { BaseState, Sample } from "../../state";
+import { BaseState } from "../../state";
 import { BaseElement } from "../base";
 
 import { lookerErrorPage } from "./error.module.css";
@@ -17,10 +15,11 @@ export class ErrorElement<State extends BaseState> extends BaseElement<State> {
     return null;
   }
 
-  renderSelf(
-    { error, config: { thumbnail } }: Readonly<State>,
-    sample: Sample
-  ) {
+  renderSelf({
+    error,
+    config: { thumbnail },
+    options: { mimetype },
+  }: Readonly<State>) {
     if (error && !this.errorElement) {
       this.errorElement = document.createElement("div");
       this.errorElement.classList.add(lookerErrorPage);
@@ -29,7 +28,6 @@ export class ErrorElement<State extends BaseState> extends BaseElement<State> {
       this.errorElement.appendChild(errorImg);
 
       if (!thumbnail) {
-        const mimetype = getMimeType(sample);
         const isVideo = mimetype.startsWith("video/");
         const text = document.createElement("p");
         const textDiv = document.createElement("div");
@@ -80,14 +78,6 @@ const onClick = (href) => {
         openExternal(href);
       }
     : null;
-};
-
-const getMimeType = (sample: any) => {
-  return (
-    (sample.metadata && sample.metadata.mime_type) ||
-    mime.getType(sample.filepath) ||
-    "image/jpg"
-  );
 };
 
 const isElectron = (): boolean => {

--- a/app/packages/looker/src/elements/common/tags.ts
+++ b/app/packages/looker/src/elements/common/tags.ts
@@ -3,11 +3,12 @@
  */
 
 import {
-  CLASSIFICATIONS,
   LABEL_LISTS,
   LABEL_TAGS_CLASSES,
+  MOMENT_CLASSIFICATIONS,
 } from "../../constants";
 import { BaseState, Sample } from "../../state";
+import { getMimeType } from "../../util";
 import { BaseElement } from "../base";
 
 import { lookerTags } from "./tags.module.css";
@@ -35,7 +36,14 @@ export class TagsElement<State extends BaseState> extends BaseElement<State> {
 
   renderSelf(
     {
-      options: { filter, activePaths, colorMap, colorByLabel, fieldsMap },
+      options: {
+        filter,
+        activePaths,
+        colorMap,
+        colorByLabel,
+        fieldsMap,
+        mimetype,
+      },
     }: Readonly<State>,
     sample: Readonly<Sample>
   ) {
@@ -80,14 +88,18 @@ export class TagsElement<State extends BaseState> extends BaseElement<State> {
         const cls = sample[path]._cls;
 
         const labels =
-          cls === CLASSIFICATIONS
-            ? sample[path][LABEL_LISTS[cls]]
-            : [sample[path]];
+          cls in LABEL_LISTS ? sample[path][LABEL_LISTS[cls]] : [sample[path]];
 
         elements = [
           ...elements,
           ...labels
-            .filter((label) => filter[path](label))
+            .filter(
+              (label) =>
+                label.label &&
+                filter[path](label) &&
+                (mimetype.includes("video") ||
+                  MOMENT_CLASSIFICATIONS.includes(label._cls))
+            )
             .map((label) => label.label)
             .map((label) => ({
               color: colorMap(colorByLabel ? label : path),

--- a/app/packages/looker/src/elements/common/tags.ts
+++ b/app/packages/looker/src/elements/common/tags.ts
@@ -87,25 +87,35 @@ export class TagsElement<State extends BaseState> extends BaseElement<State> {
       ) {
         const cls = sample[path]._cls;
 
-        const labels =
-          cls in LABEL_LISTS ? sample[path][LABEL_LISTS[cls]] : [sample[path]];
+        const isList = cls in LABEL_LISTS;
+        const labels = isList ? sample[path][LABEL_LISTS[cls]] : [sample[path]];
 
         elements = [
           ...elements,
-          ...labels
-            .filter(
-              (label) =>
-                label.label &&
-                filter[path](label) &&
-                (mimetype.includes("video") ||
-                  MOMENT_CLASSIFICATIONS.includes(label._cls))
-            )
-            .map((label) => label.label)
-            .map((label) => ({
-              color: colorMap(colorByLabel ? label : path),
-              title: `${path}: ${label}`,
-              value: label,
-            })),
+          ...Object.entries(
+            labels
+              .filter(
+                (label) =>
+                  label.label &&
+                  filter[path](label) &&
+                  (mimetype.includes("video") ||
+                    MOMENT_CLASSIFICATIONS.includes(label._cls))
+              )
+              .map((label) => label.label)
+              .reduce((acc, cur) => {
+                if (!acc[cur]) {
+                  acc[cur] = 0;
+                }
+                acc[cur] += 1;
+                return acc;
+              }, {})
+          ).map(([label, count]) => ({
+            color: colorMap(colorByLabel ? label : path),
+            title: `${path}: ${label}`,
+            value: isList
+              ? `${prettify(label)}: ${count.toLocaleString()}`
+              : prettify(label),
+          })),
         ];
       } else {
         let valuePath = path;

--- a/app/packages/looker/src/index.ts
+++ b/app/packages/looker/src/index.ts
@@ -16,7 +16,6 @@ import {
   DASH_LENGTH,
   LABEL_LISTS,
   JSON_COLORS,
-  LABELS,
   MASK_LABELS,
 } from "./constants";
 import {
@@ -72,10 +71,7 @@ export { zoomAspectRatio } from "./zoom";
 
 const labelsWorker = createWorker();
 
-export abstract class Looker<
-  ImageSource extends CanvasImageSource,
-  State extends BaseState = BaseState
-> {
+export abstract class Looker<State extends BaseState = BaseState> {
   private eventTarget: EventTarget;
   protected lookerElement: LookerElement<State>;
   private resizeObserver: ResizeObserver;
@@ -486,7 +482,7 @@ export abstract class Looker<
   }
 }
 
-export class FrameLooker extends Looker<HTMLVideoElement, FrameState> {
+export class FrameLooker extends Looker<FrameState> {
   private overlays: Overlay<FrameState>[];
 
   constructor(
@@ -578,7 +574,7 @@ export class FrameLooker extends Looker<HTMLVideoElement, FrameState> {
   }
 }
 
-export class ImageLooker extends Looker<HTMLImageElement, ImageState> {
+export class ImageLooker extends Looker<ImageState> {
   private overlays: Overlay<ImageState>[];
 
   constructor(
@@ -824,7 +820,7 @@ const { aquireReader, addFrame } = (() => {
 
 let lookerWithReader: VideoLooker | null = null;
 
-export class VideoLooker extends Looker<HTMLVideoElement, VideoState> {
+export class VideoLooker extends Looker<VideoState> {
   private sampleOverlays: Overlay<VideoState>[] = [];
   private frames: Map<number, WeakRef<Frame>> = new Map();
   private requestFrames: (frameNumber: number, force?: boolean) => void;
@@ -962,7 +958,8 @@ export class VideoLooker extends Looker<HTMLVideoElement, VideoState> {
     this.sampleOverlays = loadOverlays(
       Object.fromEntries(
         Object.entries(sample).filter(([fieldName]) => fieldName !== "frames")
-      )
+      ),
+      true
     );
 
     const providedFrames = sample.frames.length

--- a/app/packages/looker/src/index.ts
+++ b/app/packages/looker/src/index.ts
@@ -57,6 +57,7 @@ import {
   getDPR,
   getElementBBox,
   getFitRect,
+  getMimeType,
   getURL,
   mergeUpdates,
   removeFromBuffers,
@@ -94,6 +95,7 @@ export abstract class Looker<State extends BaseState = BaseState> {
     this.eventTarget = new EventTarget();
     this.updater = this.makeUpdate();
     this.state = this.getInitialState(config, options);
+    this.state.options.mimetype = getMimeType(sample);
     if (!this.state.config.thumbnail) {
       this.state.showControls = true;
     }

--- a/app/packages/looker/src/overlays/classifications.ts
+++ b/app/packages/looker/src/overlays/classifications.ts
@@ -2,8 +2,8 @@
  * Copyright 2017-2021, Voxel51, Inc.
  */
 
-import { DASH_COLOR, TEXT_COLOR } from "../constants";
-import { BaseState, BoundingBox, Coordinates } from "../state";
+import { DASH_COLOR, TEXT_COLOR, VIDEO_CLASSIFICATION } from "../constants";
+import { BaseState, BoundingBox, Coordinates, VideoState } from "../state";
 import {
   CONTAINS,
   isShown,
@@ -12,27 +12,30 @@ import {
   RegularLabel,
   SelectData,
 } from "./base";
-import { sizeBytes, t } from "./util";
+import { sizeBytes } from "./util";
 
-interface ClassificationLabel extends RegularLabel {}
+export interface Classification extends RegularLabel {}
 
-export type ClassificationLabels = [string, ClassificationLabel[]][];
+interface ClassificationLabel extends Classification {
+  _cls: "Classification";
+}
 
-export default class ClassificationsOverlay<State extends BaseState>
-  implements Overlay<State> {
-  private readonly labels: ClassificationLabels;
+export type Labels<T> = [string, T[]][];
+
+export class ClassificationsOverlay<
+  State extends BaseState,
+  Label extends Classification = ClassificationLabel
+> implements Overlay<State> {
   private labelBoundingBoxes: { [key: string]: BoundingBox };
 
-  constructor(labels: ClassificationLabels) {
+  protected readonly labels: Labels<Label>;
+
+  constructor(labels: Labels<Label>) {
     this.labels = labels;
     this.labelBoundingBoxes = {};
   }
 
-  getColor(
-    state: Readonly<State>,
-    field: string,
-    label: ClassificationLabel
-  ): string {
+  getColor(state: Readonly<State>, field: string, label: Label): string {
     const key = state.options.colorByLabel ? label.label : field;
     return state.options.colorMap(key);
   }
@@ -133,7 +136,7 @@ export default class ClassificationsOverlay<State extends BaseState>
     return bytes;
   }
 
-  private getFiltered(state: Readonly<State>): ClassificationLabels {
+  protected getFiltered(state: Readonly<State>): Labels<Label> {
     return this.labels.map(([field, labels]) => [
       field,
       labels.filter((label) => isShown(state, field, label) && label.label),
@@ -143,36 +146,31 @@ export default class ClassificationsOverlay<State extends BaseState>
   getFilteredAndFlat(
     state: Readonly<State>,
     sort: boolean = true
-  ): [string, ClassificationLabel][] {
-    let result: [string, ClassificationLabel][] = [];
+  ): [string, Label][] {
+    let result: [string, Label][] = [];
     this.getFiltered(state).forEach(([field, labels]) => {
       result = [
         ...result,
-        ...labels.map<[string, ClassificationLabel]>((label) => [field, label]),
+        ...labels.map<[string, Label]>((label) => [field, label]),
       ];
     });
 
     if (sort) {
       const store = Object.fromEntries(
-        state.options.activePaths.map<[string, ClassificationLabel[]]>((a) => [
-          a,
-          [],
-        ])
+        state.options.activePaths.map<[string, Label[]]>((a) => [a, []])
       );
       result.forEach(([field, label]) => {
         store[field].push(label);
       });
-      result = state.options.activePaths.reduce<
-        [string, ClassificationLabel][]
-      >((acc, field) => {
-        return [
-          ...acc,
-          ...store[field].map<[string, ClassificationLabel]>((label) => [
-            field,
-            label,
-          ]),
-        ];
-      }, []);
+      result = state.options.activePaths.reduce<[string, Label][]>(
+        (acc, field) => {
+          return [
+            ...acc,
+            ...store[field].map<[string, Label]>((label) => [field, label]),
+          ];
+        },
+        []
+      );
       result.sort((a, b) => {
         if (a[0] === b[0]) {
           if (a[1].label && b[1].label && a[1].label < b[1].label) {
@@ -188,7 +186,7 @@ export default class ClassificationsOverlay<State extends BaseState>
     return result;
   }
 
-  isSelected(state: Readonly<State>, label: ClassificationLabel): boolean {
+  isSelected(state: Readonly<State>, label: Label): boolean {
     return state.options.selectedLabels.includes(label.id);
   }
 
@@ -198,7 +196,7 @@ export default class ClassificationsOverlay<State extends BaseState>
     top: number,
     width: number,
     field: string,
-    label: ClassificationLabel
+    label: Label
   ): { top: number; box?: BoundingBox } {
     const text = this.getLabelText(state, label);
     if (text.length === 0) {
@@ -251,10 +249,7 @@ export default class ClassificationsOverlay<State extends BaseState>
     };
   }
 
-  private getLabelText(
-    state: Readonly<State>,
-    label: ClassificationLabel
-  ): string {
+  private getLabelText(state: Readonly<State>, label: Label): string {
     let text = label.label && state.options.showLabel ? `${label.label}` : "";
 
     if (state.options.showConfidence && !isNaN(label.confidence as number)) {
@@ -282,6 +277,37 @@ export default class ClassificationsOverlay<State extends BaseState>
     ctx.lineTo(tlx, tly + h);
     ctx.closePath();
     ctx.stroke();
+  }
+}
+
+export interface VideoClassificationLabel extends Classification {
+  support: [number, number];
+  _cls: "VideoClassification";
+}
+
+export class VideoClassificationsOverlay extends ClassificationsOverlay<
+  VideoState,
+  VideoClassificationLabel | ClassificationLabel
+> {
+  getFiltered(state: Readonly<VideoState>) {
+    console.log(this.labels);
+    return this.labels.map<
+      [string, (VideoClassificationLabel | ClassificationLabel)[]]
+    >(([field, labels]) => [
+      field,
+      labels.filter((label) => {
+        const shown = isShown(state, field, label) && label.label;
+        if (label._cls === VIDEO_CLASSIFICATION) {
+          return (
+            shown &&
+            label.support[0] <= state.frameNumber &&
+            label.support[1] >= state.frameNumber
+          );
+        }
+
+        return shown;
+      }),
+    ]);
   }
 }
 

--- a/app/packages/looker/src/overlays/classifications.ts
+++ b/app/packages/looker/src/overlays/classifications.ts
@@ -6,7 +6,7 @@ import {
   DASH_COLOR,
   MOMENT_CLASSIFICATIONS,
   TEXT_COLOR,
-  VIDEO_CLASSIFICATION,
+  TEMPORAL_DETECTION,
 } from "../constants";
 import { BaseState, BoundingBox, Coordinates, VideoState } from "../state";
 import {
@@ -290,24 +290,24 @@ export class ClassificationsOverlay<
   }
 }
 
-export interface VideoClassificationLabel extends Classification {
+export interface TemporalDetectionLabel extends Classification {
   support: [number, number];
-  _cls: "VideoClassification";
+  _cls: "TemporalDetection";
 }
 
-export class VideoClassificationsOverlay extends ClassificationsOverlay<
+export class TemporalDetectionOverlay extends ClassificationsOverlay<
   VideoState,
-  VideoClassificationLabel | ClassificationLabel
+  TemporalDetectionLabel | ClassificationLabel
 > {
   getFiltered(state: Readonly<VideoState>) {
     console.log(this.labels);
     return this.labels.map<
-      [string, (VideoClassificationLabel | ClassificationLabel)[]]
+      [string, (TemporalDetectionLabel | ClassificationLabel)[]]
     >(([field, labels]) => [
       field,
       labels.filter((label) => {
         const shown = isShown(state, field, label) && label.label;
-        if (label._cls === VIDEO_CLASSIFICATION) {
+        if (label._cls === TEMPORAL_DETECTION) {
           return (
             shown &&
             label.support[0] <= state.frameNumber &&

--- a/app/packages/looker/src/overlays/classifications.ts
+++ b/app/packages/looker/src/overlays/classifications.ts
@@ -2,7 +2,12 @@
  * Copyright 2017-2021, Voxel51, Inc.
  */
 
-import { DASH_COLOR, TEXT_COLOR, VIDEO_CLASSIFICATION } from "../constants";
+import {
+  DASH_COLOR,
+  MOMENT_CLASSIFICATIONS,
+  TEXT_COLOR,
+  VIDEO_CLASSIFICATION,
+} from "../constants";
 import { BaseState, BoundingBox, Coordinates, VideoState } from "../state";
 import {
   CONTAINS,
@@ -139,7 +144,12 @@ export class ClassificationsOverlay<
   protected getFiltered(state: Readonly<State>): Labels<Label> {
     return this.labels.map(([field, labels]) => [
       field,
-      labels.filter((label) => isShown(state, field, label) && label.label),
+      labels.filter(
+        (label) =>
+          MOMENT_CLASSIFICATIONS.includes(label._cls) &&
+          isShown(state, field, label) &&
+          label.label
+      ),
     ]);
   }
 

--- a/app/packages/looker/src/overlays/index.ts
+++ b/app/packages/looker/src/overlays/index.ts
@@ -6,7 +6,7 @@ import { BaseState } from "../state";
 import { Overlay } from "./base";
 import {
   ClassificationsOverlay,
-  VideoClassificationsOverlay,
+  TemporalDetectionOverlay,
 } from "./classifications";
 import DetectionOverlay, { getDetectionPoints } from "./detection";
 import KeypointOverlay, { getKeypointPoints } from "./keypoint";
@@ -69,7 +69,7 @@ export const loadOverlays = <State extends BaseState>(
 
   if (classifications.length > 0) {
     const overlay = video
-      ? new VideoClassificationsOverlay(classifications)
+      ? new TemporalDetectionOverlay(classifications)
       : new ClassificationsOverlay(classifications);
     overlays.push(overlay);
   }

--- a/app/packages/looker/src/processOverlays.ts
+++ b/app/packages/looker/src/processOverlays.ts
@@ -3,7 +3,7 @@
  */
 
 import { CONTAINS, Overlay } from "./overlays/base";
-import ClassificationsOverlay from "./overlays/classifications";
+import { ClassificationsOverlay } from "./overlays/classifications";
 import { BaseState } from "./state";
 import { rotate } from "./util";
 

--- a/app/packages/looker/src/state.ts
+++ b/app/packages/looker/src/state.ts
@@ -70,6 +70,7 @@ interface BaseOptions {
   selected: boolean;
   fieldsMap?: { [key: string]: string };
   inSelectionMode: boolean;
+  mimetype: string;
 }
 
 export type BoundingBox = [number, number, number, number];
@@ -231,6 +232,7 @@ const DEFAULT_BASE_OPTIONS: BaseOptions = {
   selected: false,
   fieldsMap: {},
   inSelectionMode: false,
+  mimetype: "",
 };
 
 export const DEFAULT_FRAME_OPTIONS: FrameOptions = {

--- a/app/packages/looker/src/util.ts
+++ b/app/packages/looker/src/util.ts
@@ -1,10 +1,10 @@
 /**
  * Copyright 2017-2021, Voxel51, Inc.
  */
-
+import mime from "mime";
 import { mergeWith } from "immutable";
 
-import { MIN_PIXELS, SCALE_FACTOR } from "./constants";
+import { MIN_PIXELS } from "./constants";
 import {
   BaseState,
   BoundingBox,
@@ -486,4 +486,12 @@ export const getURL = () => {
   return isElectron()
     ? `http://localhost:${port}`
     : window.location.protocol + "//" + host;
+};
+
+export const getMimeType = (sample: any) => {
+  return (
+    (sample.metadata && sample.metadata.mime_type) ||
+    mime.getType(sample.filepath) ||
+    "image/jpg"
+  );
 };

--- a/docs/source/_includes/substitutions.rst
+++ b/docs/source/_includes/substitutions.rst
@@ -45,6 +45,8 @@
 .. |Segmentation| replace:: :class:`Segmentation <fiftyone.core.labels.Segmentation>`
 .. |GeoLocation| replace:: :class:`GeoLocation <fiftyone.core.labels.GeoLocation>`
 .. |GeoLocations| replace:: :class:`GeoLocations <fiftyone.core.labels.GeoLocations>`
+.. |VideoClassification| replace:: :class:`VideoClassification <fiftyone.core.labels.VideoClassification>`
+.. |VideoClassifications| replace:: :class:`VideoClassifications <fiftyone.core.labels.VideoClassifications>`
 
 .. |Attribute| replace:: :class:`Attribute <fiftyone.core.labels.Attribute>`
 .. |BooleanAttribute| replace:: :class:`BooleanAttribute <fiftyone.core.labels.BooleanAttribute>`

--- a/docs/source/_includes/substitutions.rst
+++ b/docs/source/_includes/substitutions.rst
@@ -43,10 +43,10 @@
 .. |Keypoint| replace:: :class:`Keypoint <fiftyone.core.labels.Keypoint>`
 .. |Keypoints| replace:: :class:`Keypoints <fiftyone.core.labels.Keypoints>`
 .. |Segmentation| replace:: :class:`Segmentation <fiftyone.core.labels.Segmentation>`
+.. |TemporalDetection| replace:: :class:`TemporalDetection <fiftyone.core.labels.TemporalDetection>`
+.. |TemporalDetections| replace:: :class:`TemporalDetections <fiftyone.core.labels.TemporalDetections>`
 .. |GeoLocation| replace:: :class:`GeoLocation <fiftyone.core.labels.GeoLocation>`
 .. |GeoLocations| replace:: :class:`GeoLocations <fiftyone.core.labels.GeoLocations>`
-.. |VideoClassification| replace:: :class:`VideoClassification <fiftyone.core.labels.VideoClassification>`
-.. |VideoClassifications| replace:: :class:`VideoClassifications <fiftyone.core.labels.VideoClassifications>`
 
 .. |Attribute| replace:: :class:`Attribute <fiftyone.core.labels.Attribute>`
 .. |BooleanAttribute| replace:: :class:`BooleanAttribute <fiftyone.core.labels.BooleanAttribute>`

--- a/docs/source/user_guide/basics.rst
+++ b/docs/source/user_guide/basics.rst
@@ -296,8 +296,8 @@ FiftyOne provides a |Label| subclass for many common tasks:
 - :ref:`Keypoints <keypoints>`: a list of keypoints in an image
 - :ref:`Segmentation <semantic-segmentation>`: a semantic segmentation mask for
   an image
-- :ref:`Video classification <video-classification>`: classification label(s)
-  with temporal frame support in a video
+- :ref:`Temporal detection <temporal-detection>`: events with a temporal frame
+  support in a video
 - :ref:`GeoLocation <geolocation>`: geolocation point(s), line(s), or
   polygon(s)
 

--- a/docs/source/user_guide/basics.rst
+++ b/docs/source/user_guide/basics.rst
@@ -296,10 +296,10 @@ FiftyOne provides a |Label| subclass for many common tasks:
 - :ref:`Keypoints <keypoints>`: a list of keypoints in an image
 - :ref:`Segmentation <semantic-segmentation>`: a semantic segmentation mask for
   an image
-- :ref:`GeoLocation <geolocation>`: a single geolocation point, line, or
-  polygon
-- :ref:`GeoLocations <geolocation>`: a container of multiple geolocation
-  points, lines, and polygons
+- :ref:`Video classification <video-classification>`: classification label(s)
+  with temporal frame support in a video
+- :ref:`GeoLocation <geolocation>`: geolocation point(s), line(s), or
+  polygon(s)
 
 Using FiftyOne's |Label| types enables you to visualize your labels in the
 :ref:`the App <fiftyone-app>`.

--- a/docs/source/user_guide/dataset_creation/datasets.rst
+++ b/docs/source/user_guide/dataset_creation/datasets.rst
@@ -173,9 +173,6 @@ format when reading the dataset from disk.
     | :ref:`FiftyOneImageClassificationDataset <FiftyOneImageClassificationDataset-import>` | A labeled dataset consisting of images and their associated classification labels  |
     |                                                                                       | in a simple JSON format.                                                           |
     +---------------------------------------------------------------------------------------+------------------------------------------------------------------------------------+
-    | :ref:`FiftyOneVideoClassificationDataset <FiftyOneVideoClassificationDataset-import>` | A labeled dataset consisting of videos and their associated temporal               |
-    |                                                                                       | classification labels in a simple JSON format.                                     |
-    +---------------------------------------------------------------------------------------+------------------------------------------------------------------------------------+
     | :ref:`ImageClassificationDirectoryTree <ImageClassificationDirectoryTree-import>`     | A directory tree whose subfolders define an image classification dataset.          |
     +---------------------------------------------------------------------------------------+------------------------------------------------------------------------------------+
     | :ref:`VideoClassificationDirectoryTree <VideoClassificationDirectoryTree-import>`     | A directory tree whose subfolders define a video classification dataset.           |
@@ -185,6 +182,9 @@ format when reading the dataset from disk.
     +---------------------------------------------------------------------------------------+------------------------------------------------------------------------------------+
     | :ref:`FiftyOneImageDetectionDataset <FiftyOneImageDetectionDataset-import>`           | A labeled dataset consisting of images and their associated object detections      |
     |                                                                                       | stored in a simple JSON format.                                                    |
+    +---------------------------------------------------------------------------------------+------------------------------------------------------------------------------------+
+    | :ref:`FiftyOneTemporalDetectionDataset <FiftyOneTemporalDetectionDataset-import>`     | A labeled dataset consisting of videos and their associated temporal detections in |
+    |                                                                                       | a simple JSON format.                                                              |
     +---------------------------------------------------------------------------------------+------------------------------------------------------------------------------------+
     | :ref:`COCODetectionDataset <COCODetectionDataset-import>`                             | A labeled dataset consisting of images and their associated object detections      |
     |                                                                                       | saved in `COCO Object Detection Format <https://cocodataset.org/#format-data>`_.   |
@@ -549,147 +549,6 @@ in the above format as follows:
         fiftyone app view \
             --dataset-dir $DATASET_DIR \
             --type fiftyone.types.FiftyOneImageClassificationDataset
-
-.. _FiftyOneVideoClassificationDataset-import:
-
-FiftyOneVideoClassificationDataset
-----------------------------------
-
-The :class:`fiftyone.types.FiftyOneVideoClassificationDataset <fiftyone.types.dataset_types.FiftyOneVideoClassificationDataset>`
-type represents a labeled dataset consisting of videos and their associated
-temporal classification labels stored in a simple JSON format.
-
-Datasets of this type are read in the following format:
-
-.. code-block:: text
-
-    <dataset_dir>/
-        data/
-            <uuid1>.<ext>
-            <uuid2>.<ext>
-            ...
-        labels.json
-
-where `labels.json` is a JSON file in the following format:
-
-.. code-block:: text
-
-    {
-        "classes": [
-            "<labelA>",
-            "<labelB>",
-            ...
-        ],
-        "labels": {
-            "<uuid1>": [
-                {
-                    "label": <target>,
-                    "support": [<first-frame>, <last-frame>],
-                    "confidence": <optional-confidence>
-                },
-                {
-                    "label": <target>,
-                    "support": [<first-frame>, <last-frame>],
-                    "confidence": <optional-confidence>
-                },
-                ...
-            ],
-            "<uuid2>": [
-                {
-                    "label": <target>,
-                    "timestamps": [<start-timestamp>, <stop-timestamp>],
-                    "confidence": <optional-confidence>
-                },
-                {
-                    "label": <target>,
-                    "timestamps": [<start-timestamp>, <stop-timestamp>],
-                    "confidence": <optional-confidence>
-                },
-            ],
-            ...
-        }
-    }
-
-The temporal range of each video classification can be specified either via the
-`support` key, which should contain the `[first, last]` frame numbers of the
-classification, or the `timestamps` key, which should contain the
-`[start, stop]` timestamps of the classification in seconds.
-
-If the `classes` field is provided, the `target` values are class IDs that are
-mapped to class label strings via `classes[target]`. If no `classes` field is
-provided, then the `target` values directly store the label strings.
-
-Unlabeled videos can have a `None` (or missing) key in `labels`.
-
-The UUIDs can also be relative paths like `path/to/uuid`, in which case the
-images in `data/` should be arranged in nested subfolders with the
-corresponding names.
-
-.. note::
-
-    See :class:`FiftyOneVideoClassificationDatasetImporter <fiftyone.utils.data.importers.FiftyOneVideoClassificationDatasetImporter>`
-    for parameters that can be passed to methods like
-    :meth:`Dataset.from_dir() <fiftyone.core.dataset.Dataset.from_dir>` to
-    customize the import of datasets of this type.
-
-You can create a FiftyOne dataset from a video classification dataset stored in
-the above format as follows:
-
-.. tabs::
-
-  .. group-tab:: Python
-
-    .. code-block:: python
-        :linenos:
-
-        import fiftyone as fo
-
-        name = "my-dataset"
-        dataset_dir = "/path/to/video-classification-dataset"
-
-        # Create the dataset
-        dataset = fo.Dataset.from_dir(
-            dataset_dir=dataset_dir,
-            dataset_type=fo.types.FiftyOneVideoClassificationDataset,
-            name=name,
-        )
-
-        # View summary info about the dataset
-        print(dataset)
-
-        # Print the first few samples in the dataset
-        print(dataset.head())
-
-  .. group-tab:: CLI
-
-    .. code-block:: shell
-
-        NAME=my-dataset
-        DATASET_DIR=/path/to/video-classification-dataset
-
-        # Create the dataset
-        fiftyone datasets create \
-            --name $NAME \
-            --dataset-dir $DATASET_DIR \
-            --type fiftyone.types.FiftyOneVideoClassificationDataset
-
-        # View summary info about the dataset
-        fiftyone datasets info $NAME
-
-        # Print the first few samples in the dataset
-        fiftyone datasets head $NAME
-
-    To view a video classification dataset in the FiftyOne App without creating
-    a persistent FiftyOne dataset, you can execute:
-
-    .. code-block:: shell
-
-        DATASET_DIR=/path/to/video-classification-dataset
-
-        # View the dataset in the App
-        fiftyone app view \
-            --dataset-dir $DATASET_DIR \
-            --type fiftyone.types.FiftyOneVideoClassificationDataset
 
 .. _ImageClassificationDirectoryTree-import:
 
@@ -1128,6 +987,147 @@ above format as follows:
         fiftyone app view \
             --dataset-dir $DATASET_DIR \
             --type fiftyone.types.FiftyOneImageDetectionDataset
+
+.. _FiftyOneTemporalDetectionDataset-import:
+
+FiftyOneTemporalDetectionDataset
+--------------------------------
+
+The :class:`fiftyone.types.FiftyOneTemporalDetectionDataset <fiftyone.types.dataset_types.FiftyOneTemporalDetectionDataset>`
+type represents a labeled dataset consisting of videos and their associated
+temporal detections stored in a simple JSON format.
+
+Datasets of this type are read in the following format:
+
+.. code-block:: text
+
+    <dataset_dir>/
+        data/
+            <uuid1>.<ext>
+            <uuid2>.<ext>
+            ...
+        labels.json
+
+where `labels.json` is a JSON file in the following format:
+
+.. code-block:: text
+
+    {
+        "classes": [
+            "<labelA>",
+            "<labelB>",
+            ...
+        ],
+        "labels": {
+            "<uuid1>": [
+                {
+                    "label": <target>,
+                    "support": [<first-frame>, <last-frame>],
+                    "confidence": <optional-confidence>
+                },
+                {
+                    "label": <target>,
+                    "support": [<first-frame>, <last-frame>],
+                    "confidence": <optional-confidence>
+                },
+                ...
+            ],
+            "<uuid2>": [
+                {
+                    "label": <target>,
+                    "timestamps": [<start-timestamp>, <stop-timestamp>],
+                    "confidence": <optional-confidence>
+                },
+                {
+                    "label": <target>,
+                    "timestamps": [<start-timestamp>, <stop-timestamp>],
+                    "confidence": <optional-confidence>
+                },
+            ],
+            ...
+        }
+    }
+
+The temporal range of each detection can be specified either via the `support`
+key, which should contain the `[first, last]` frame numbers of the detection,
+or the `timestamps` key, which should contain the `[start, stop]` timestamps of
+the detection in seconds.
+
+If the `classes` field is provided, the `target` values are class IDs that are
+mapped to class label strings via `classes[target]`. If no `classes` field is
+provided, then the `target` values directly store the label strings.
+
+Unlabeled videos can have a `None` (or missing) key in `labels`.
+
+The UUIDs can also be relative paths like `path/to/uuid`, in which case the
+images in `data/` should be arranged in nested subfolders with the
+corresponding names.
+
+.. note::
+
+    See :class:`FiftyOneTemporalDetectionDatasetImporter <fiftyone.utils.data.importers.FiftyOneTemporalDetectionDatasetImporter>`
+    for parameters that can be passed to methods like
+    :meth:`Dataset.from_dir() <fiftyone.core.dataset.Dataset.from_dir>` to
+    customize the import of datasets of this type.
+
+You can create a FiftyOne dataset from a temporal detection dataset stored in
+the above format as follows:
+
+.. tabs::
+
+  .. group-tab:: Python
+
+    .. code-block:: python
+        :linenos:
+
+        import fiftyone as fo
+
+        name = "my-dataset"
+        dataset_dir = "/path/to/temporal-detection-dataset"
+
+        # Create the dataset
+        dataset = fo.Dataset.from_dir(
+            dataset_dir=dataset_dir,
+            dataset_type=fo.types.FiftyOneTemporalDetectionDataset,
+            name=name,
+        )
+
+        # View summary info about the dataset
+        print(dataset)
+
+        # Print the first few samples in the dataset
+        print(dataset.head())
+
+  .. group-tab:: CLI
+
+    .. code-block:: shell
+
+        NAME=my-dataset
+        DATASET_DIR=/path/to/temporal-detection-dataset
+
+        # Create the dataset
+        fiftyone datasets create \
+            --name $NAME \
+            --dataset-dir $DATASET_DIR \
+            --type fiftyone.types.FiftyOneTemporalDetectionDataset
+
+        # View summary info about the dataset
+        fiftyone datasets info $NAME
+
+        # Print the first few samples in the dataset
+        fiftyone datasets head $NAME
+
+    To view a temporal detection dataset in the FiftyOne App without creating
+    a persistent FiftyOne dataset, you can execute:
+
+    .. code-block:: shell
+
+        DATASET_DIR=/path/to/temporal-detection-dataset
+
+        # View the dataset in the App
+        fiftyone app view \
+            --dataset-dir $DATASET_DIR \
+            --type fiftyone.types.FiftyOneTemporalDetectionDataset
 
 .. _COCODetectionDataset-import:
 

--- a/docs/source/user_guide/dataset_creation/datasets.rst
+++ b/docs/source/user_guide/dataset_creation/datasets.rst
@@ -441,8 +441,8 @@ where `labels.json` is a JSON file in the following format:
             ...
         ],
         "labels": {
-            "<uuid1>": "<target>",
-            "<uuid2>": "<target>",
+            "<uuid1>": <target>,
+            "<uuid2>": <target>,
             ...
         }
     }
@@ -466,12 +466,12 @@ confidences in the following format:
         ],
         "labels": {
             "<uuid1>": {
-                "label": "<target>",
-                "confidence": "<optional-confidence>"
+                "label": <target>,
+                "confidence": <optional-confidence>
             },
             "<uuid2>": {
-                "label": "<target>",
-                "confidence": "<optional-confidence>"
+                "label": <target>,
+                "confidence": <optional-confidence>
             },
             ...
         }

--- a/docs/source/user_guide/dataset_creation/datasets.rst
+++ b/docs/source/user_guide/dataset_creation/datasets.rst
@@ -173,6 +173,9 @@ format when reading the dataset from disk.
     | :ref:`FiftyOneImageClassificationDataset <FiftyOneImageClassificationDataset-import>` | A labeled dataset consisting of images and their associated classification labels  |
     |                                                                                       | in a simple JSON format.                                                           |
     +---------------------------------------------------------------------------------------+------------------------------------------------------------------------------------+
+    | :ref:`FiftyOneVideoClassificationDataset <FiftyOneVideoClassificationDataset-import>` | A labeled dataset consisting of videos and their associated temporal               |
+    |                                                                                       | classification labels in a simple JSON format.                                     |
+    +---------------------------------------------------------------------------------------+------------------------------------------------------------------------------------+
     | :ref:`ImageClassificationDirectoryTree <ImageClassificationDirectoryTree-import>`     | A directory tree whose subfolders define an image classification dataset.          |
     +---------------------------------------------------------------------------------------+------------------------------------------------------------------------------------+
     | :ref:`VideoClassificationDirectoryTree <VideoClassificationDirectoryTree-import>`     | A directory tree whose subfolders define a video classification dataset.           |
@@ -438,8 +441,8 @@ where `labels.json` is a JSON file in the following format:
             ...
         ],
         "labels": {
-            "<uuid1>": "<target1>",
-            "<uuid2>": "<target2>",
+            "<uuid1>": "<target>",
+            "<uuid2>": "<target>",
             ...
         }
     }
@@ -449,6 +452,30 @@ mapped to class label strings via `classes[target]`. If no `classes` field is
 provided, then the `target` values directly store the label strings.
 
 The target value in `labels` for unlabeled images is `None` (or missing).
+
+Alternatively, `labels.json` can contain predictions with associated
+confidences in the following format:
+
+.. code-block:: text
+
+    {
+        "classes": [
+            "<labelA>",
+            "<labelB>",
+            ...
+        ],
+        "labels": {
+            "<uuid1>": {
+                "label": "<target>",
+                "confidence": "<optional-confidence>"
+            },
+            "<uuid2>": {
+                "label": "<target>",
+                "confidence": "<optional-confidence>"
+            },
+            ...
+        }
+    }
 
 The UUIDs can also be relative paths like `path/to/uuid`, in which case the
 images in `data/` should be arranged in nested subfolders with the
@@ -519,6 +546,147 @@ in the above format as follows:
         fiftyone app view \
             --dataset-dir $DATASET_DIR \
             --type fiftyone.types.FiftyOneImageClassificationDataset
+
+.. _FiftyOneVideoClassificationDataset-import:
+
+FiftyOneVideoClassificationDataset
+----------------------------------
+
+The :class:`fiftyone.types.FiftyOneVideoClassificationDataset <fiftyone.types.dataset_types.FiftyOneVideoClassificationDataset>`
+type represents a labeled dataset consisting of videos and their associated
+temporal classification labels stored in a simple JSON format.
+
+Datasets of this type are read in the following format:
+
+.. code-block:: text
+
+    <dataset_dir>/
+        data/
+            <uuid1>.<ext>
+            <uuid2>.<ext>
+            ...
+        labels.json
+
+where `labels.json` is a JSON file in the following format:
+
+.. code-block:: text
+
+    {
+        "classes": [
+            "<labelA>",
+            "<labelB>",
+            ...
+        ],
+        "labels": {
+            "<uuid1>": [
+                {
+                    "label": <target>,
+                    "support": [<first-frame>, <last-frame>],
+                    "confidence": <optional-confidence>,
+                },
+                {
+                    "label": <target>,
+                    "support": [<first-frame>, <last-frame>],
+                    "confidence": <optional-confidence>,
+                },
+                ...
+            ],
+            "<uuid2>": [
+                {
+                    "label": <target>,
+                    "timestamps": [<start-timestamp>, <stop-timestamp>],
+                    "confidence": <optional-confidence>,
+                },
+                {
+                    "label": <target>,
+                    "timestamps": [<start-timestamp>, <stop-timestamp>],
+                    "confidence": <optional-confidence>,
+                },
+            ],
+            ...
+        }
+    }
+
+The temporal range of each video classification can be specified either via the
+`support` key, which should contain the `[first, last]` frame numbers of the
+classification, or the `timestamps` key, which should contain the
+`[start, stop]` timestamps of the classification in seconds.
+
+If the `classes` field is provided, the `target` values are class IDs that are
+mapped to class label strings via `classes[target]`. If no `classes` field is
+provided, then the `target` values directly store the label strings.
+
+Unlabeled videos can have a `None` (or missing) key in `labels`.
+
+The UUIDs can also be relative paths like `path/to/uuid`, in which case the
+images in `data/` should be arranged in nested subfolders with the
+corresponding names.
+
+.. note::
+
+    See :class:`FiftyOneVideoClassificationDatasetImporter <fiftyone.utils.data.importers.FiftyOneVideoClassificationDatasetImporter>`
+    for parameters that can be passed to methods like
+    :meth:`Dataset.from_dir() <fiftyone.core.dataset.Dataset.from_dir>` to
+    customize the import of datasets of this type.
+
+You can create a FiftyOne dataset from a video classification dataset stored in
+the above format as follows:
+
+.. tabs::
+
+  .. group-tab:: Python
+
+    .. code-block:: python
+        :linenos:
+
+        import fiftyone as fo
+
+        name = "my-dataset"
+        dataset_dir = "/path/to/video-classification-dataset"
+
+        # Create the dataset
+        dataset = fo.Dataset.from_dir(
+            dataset_dir=dataset_dir,
+            dataset_type=fo.types.FiftyOneVideoClassificationDataset,
+            name=name,
+        )
+
+        # View summary info about the dataset
+        print(dataset)
+
+        # Print the first few samples in the dataset
+        print(dataset.head())
+
+  .. group-tab:: CLI
+
+    .. code-block:: shell
+
+        NAME=my-dataset
+        DATASET_DIR=/path/to/video-classification-dataset
+
+        # Create the dataset
+        fiftyone datasets create \
+            --name $NAME \
+            --dataset-dir $DATASET_DIR \
+            --type fiftyone.types.FiftyOneVideoClassificationDataset
+
+        # View summary info about the dataset
+        fiftyone datasets info $NAME
+
+        # Print the first few samples in the dataset
+        fiftyone datasets head $NAME
+
+    To view a video classification dataset in the FiftyOne App without creating
+    a persistent FiftyOne dataset, you can execute:
+
+    .. code-block:: shell
+
+        DATASET_DIR=/path/to/video-classification-dataset
+
+        # View the dataset in the App
+        fiftyone app view \
+            --dataset-dir $DATASET_DIR \
+            --type fiftyone.types.FiftyOneVideoClassificationDataset
 
 .. _ImageClassificationDirectoryTree-import:
 

--- a/docs/source/user_guide/dataset_creation/datasets.rst
+++ b/docs/source/user_guide/dataset_creation/datasets.rst
@@ -582,12 +582,12 @@ where `labels.json` is a JSON file in the following format:
                 {
                     "label": <target>,
                     "support": [<first-frame>, <last-frame>],
-                    "confidence": <optional-confidence>,
+                    "confidence": <optional-confidence>
                 },
                 {
                     "label": <target>,
                     "support": [<first-frame>, <last-frame>],
-                    "confidence": <optional-confidence>,
+                    "confidence": <optional-confidence>
                 },
                 ...
             ],
@@ -595,12 +595,12 @@ where `labels.json` is a JSON file in the following format:
                 {
                     "label": <target>,
                     "timestamps": [<start-timestamp>, <stop-timestamp>],
-                    "confidence": <optional-confidence>,
+                    "confidence": <optional-confidence>
                 },
                 {
                     "label": <target>,
                     "timestamps": [<start-timestamp>, <stop-timestamp>],
-                    "confidence": <optional-confidence>,
+                    "confidence": <optional-confidence>
                 },
             ],
             ...

--- a/docs/source/user_guide/export_datasets.rst
+++ b/docs/source/user_guide/export_datasets.rst
@@ -492,8 +492,8 @@ where `labels.json` is a JSON file in the following format:
             ...
         ],
         "labels": {
-            "<uuid1>": "<target1>",
-            "<uuid2>": "<target2>",
+            "<uuid1>": <target>,
+            "<uuid2>": <target>,
             ...
         }
     }
@@ -504,7 +504,7 @@ provided, then the `target` values directly store the label strings.
 
 The target value in `labels` for unlabeled images is `None`.
 
-Alternatively, if you include the `include_confidences=True` parameter when
+Alternatively, if you include the `include_confidence=True` parameter when
 exporting datasets of this type, the `labels.json` file will contain
 predictions with associated confidences in the following format:
 
@@ -518,12 +518,12 @@ predictions with associated confidences in the following format:
         ],
         "labels": {
             "<uuid1>": {
-                "label": "<target1>",
-                "confidence": "<confidence>"
+                "label": <target>,
+                "confidence": <optional-confidence>
             },
             "<uuid2>": {
-                "label": "<target2>",
-                "confidence": "<confidence>"
+                "label": <target>,
+                "confidence": <optional-confidence>
             },
             ...
         }

--- a/docs/source/user_guide/export_datasets.rst
+++ b/docs/source/user_guide/export_datasets.rst
@@ -610,12 +610,12 @@ where `labels.json` is a JSON file in the following format:
                 {
                     "label": <target>,
                     "support": [<first-frame>, <last-frame>],
-                    "confidence": <optional-confidence>,
+                    "confidence": <optional-confidence>
                 },
                 {
                     "label": <target>,
                     "support": [<first-frame>, <last-frame>],
-                    "confidence": <optional-confidence>,
+                    "confidence": <optional-confidence>
                 },
                 ...
             ],
@@ -623,12 +623,12 @@ where `labels.json` is a JSON file in the following format:
                 {
                     "label": <target>,
                     "timestamps": [<start-timestamp>, <stop-timestamp>],
-                    "confidence": <optional-confidence>,
+                    "confidence": <optional-confidence>
                 },
                 {
                     "label": <target>,
                     "timestamps": [<start-timestamp>, <stop-timestamp>],
-                    "confidence": <optional-confidence>,
+                    "confidence": <optional-confidence>
                 },
             ],
             ...
@@ -638,7 +638,7 @@ where `labels.json` is a JSON file in the following format:
 By default, the `support` keys will be populated with the `[first, last]` frame
 numbers of the classifications, but you can pass the `use_timestamps=True` key
 during export to instead populate the `timestamps` keys with the
-`[start, stop]` timestamps of the classifications.
+`[start, stop]` timestamps of the classifications, in seconds.
 
 If the `classes` field is provided, the `target` values are class IDs that are
 mapped to class label strings via `classes[target]`. If no `classes` field is

--- a/docs/source/user_guide/export_datasets.rst
+++ b/docs/source/user_guide/export_datasets.rst
@@ -281,9 +281,6 @@ format when writing the dataset to disk.
     | :ref:`FiftyOneImageClassificationDataset                           | A labeled dataset consisting of images and their associated classification labels  |
     | <FiftyOneImageClassificationDataset-export>`                       | in a simple JSON format.                                                           |
     +--------------------------------------------------------------------+------------------------------------------------------------------------------------+
-    | :ref:`FiftyOneVideoClassificationDataset                           | A labeled dataset consisting of videos and their associated temporal               |
-    | <FiftyOneVideoClassificationDataset-export>`                       | classification labels in a simple JSON format.                                     |
-    +--------------------------------------------------------------------+------------------------------------------------------------------------------------+
     | :ref:`ImageClassificationDirectoryTree                             | A directory tree whose subfolders define an image classification dataset.          |
     | <ImageClassificationDirectoryTree-export>`                         |                                                                                    |
     +--------------------------------------------------------------------+------------------------------------------------------------------------------------+
@@ -295,6 +292,9 @@ format when writing the dataset to disk.
     +--------------------------------------------------------------------+------------------------------------------------------------------------------------+
     | :ref:`FiftyOneImageDetectionDataset                                | A labeled dataset consisting of images and their associated object detections      |
     | <FiftyOneImageDetectionDataset-export>`                            | stored in a simple JSON format.                                                    |
+    +--------------------------------------------------------------------+------------------------------------------------------------------------------------+
+    | :ref:`FiftyOneTemporalDetectionDataset                             | A labeled dataset consisting of videos and their associated temporal detections in |
+    | <FiftyOneTemporalDetectionDataset-export>`                         | a simple JSON format.                                                              |
     +--------------------------------------------------------------------+------------------------------------------------------------------------------------+
     | :ref:`COCODetectionDataset                                         | A labeled dataset consisting of images and their associated object detections      |
     | <COCODetectionDataset-export>`                                     | saved in `COCO Object Detection Format <https://cocodataset.org/#format-data>`_.   |
@@ -574,123 +574,6 @@ disk in the above format as follows:
             --export-dir $EXPORT_DIR \
             --label-field $LABEL_FIELD \
             --type fiftyone.types.FiftyOneImageClassificationDataset
-
-.. _FiftyOneVideoClassificationDataset-export:
-
-FiftyOneVideoClassificationDataset
-----------------------------------
-
-The :class:`fiftyone.types.FiftyOneVideoClassificationDataset <fiftyone.types.dataset_types.FiftyOneVideoClassificationDataset>`
-type represents a labeled dataset consisting of videos and their associated
-temporal classification labels stored in a simple JSON format.
-
-Datasets of this type are exported in the following format:
-
-.. code-block:: text
-
-    <dataset_dir>/
-        data/
-            <uuid1>.<ext>
-            <uuid2>.<ext>
-            ...
-        labels.json
-
-where `labels.json` is a JSON file in the following format:
-
-.. code-block:: text
-
-    {
-        "classes": [
-            "<labelA>",
-            "<labelB>",
-            ...
-        ],
-        "labels": {
-            "<uuid1>": [
-                {
-                    "label": <target>,
-                    "support": [<first-frame>, <last-frame>],
-                    "confidence": <optional-confidence>
-                },
-                {
-                    "label": <target>,
-                    "support": [<first-frame>, <last-frame>],
-                    "confidence": <optional-confidence>
-                },
-                ...
-            ],
-            "<uuid2>": [
-                {
-                    "label": <target>,
-                    "timestamps": [<start-timestamp>, <stop-timestamp>],
-                    "confidence": <optional-confidence>
-                },
-                {
-                    "label": <target>,
-                    "timestamps": [<start-timestamp>, <stop-timestamp>],
-                    "confidence": <optional-confidence>
-                },
-            ],
-            ...
-        }
-    }
-
-By default, the `support` keys will be populated with the `[first, last]` frame
-numbers of the classifications, but you can pass the `use_timestamps=True` key
-during export to instead populate the `timestamps` keys with the
-`[start, stop]` timestamps of the classifications, in seconds.
-
-If the `classes` field is provided, the `target` values are class IDs that are
-mapped to class label strings via `classes[target]`. If no `classes` field is
-provided, then the `target` values directly store the label strings.
-
-The target value in `labels` for unlabeled videos is `None`.
-
-.. note::
-
-    See :class:`FiftyOneVideoClassificationDatasetExporter <fiftyone.utils.data.exporters.FiftyOneVideoClassificationDatasetExporter>`
-    for parameters that can be passed to methods like
-    :meth:`SampleCollection.export() <fiftyone.core.collections.SampleCollection.export>`
-    to customize the export of datasets of this type.
-
-You can export a FiftyOne dataset as a video classification dataset stored on
-disk in the above format as follows:
-
-.. tabs::
-
-  .. group-tab:: Python
-
-    .. code-block:: python
-        :linenos:
-
-        import fiftyone as fo
-
-        export_dir = "/path/for/video-classification-dataset"
-        label_field = "ground_truth"  # for example
-
-        # The Dataset or DatasetView to export
-        dataset_or_view = fo.Dataset(...)
-
-        # Export the dataset
-        dataset_or_view.export(
-            export_dir=export_dir,
-            dataset_type=fo.types.FiftyOneVideoClassificationDataset,
-            label_field=label_field,
-        )
-
-  .. group-tab:: CLI
-
-    .. code-block:: shell
-
-        NAME=my-dataset
-        EXPORT_DIR=/path/for/video-classification-dataset
-        LABEL_FIELD=ground_truth  # for example
-
-        # Export the dataset
-        fiftyone datasets export $NAME \
-            --export-dir $EXPORT_DIR \
-            --label-field $LABEL_FIELD \
-            --type fiftyone.types.FiftyOneVideoClassificationDataset
 
 .. _ImageClassificationDirectoryTree-export:
 
@@ -1027,6 +910,123 @@ format as follows:
             --export-dir $EXPORT_DIR \
             --label-field $LABEL_FIELD \
             --type fiftyone.types.FiftyOneImageDetectionDataset
+
+.. _FiftyOneTemporalDetectionDataset-export:
+
+FiftyOneTemporalDetectionDataset
+--------------------------------
+
+The :class:`fiftyone.types.FiftyOneTemporalDetectionDataset <fiftyone.types.dataset_types.FiftyOneTemporalDetectionDataset>`
+type represents a labeled dataset consisting of videos and their associated
+temporal detections stored in a simple JSON format.
+
+Datasets of this type are exported in the following format:
+
+.. code-block:: text
+
+    <dataset_dir>/
+        data/
+            <uuid1>.<ext>
+            <uuid2>.<ext>
+            ...
+        labels.json
+
+where `labels.json` is a JSON file in the following format:
+
+.. code-block:: text
+
+    {
+        "classes": [
+            "<labelA>",
+            "<labelB>",
+            ...
+        ],
+        "labels": {
+            "<uuid1>": [
+                {
+                    "label": <target>,
+                    "support": [<first-frame>, <last-frame>],
+                    "confidence": <optional-confidence>
+                },
+                {
+                    "label": <target>,
+                    "support": [<first-frame>, <last-frame>],
+                    "confidence": <optional-confidence>
+                },
+                ...
+            ],
+            "<uuid2>": [
+                {
+                    "label": <target>,
+                    "timestamps": [<start-timestamp>, <stop-timestamp>],
+                    "confidence": <optional-confidence>
+                },
+                {
+                    "label": <target>,
+                    "timestamps": [<start-timestamp>, <stop-timestamp>],
+                    "confidence": <optional-confidence>
+                },
+            ],
+            ...
+        }
+    }
+
+By default, the `support` keys will be populated with the `[first, last]` frame
+numbers of the detections, but you can pass the `use_timestamps=True` key
+during export to instead populate the `timestamps` keys with the
+`[start, stop]` timestamps of the detections, in seconds.
+
+If the `classes` field is provided, the `target` values are class IDs that are
+mapped to class label strings via `classes[target]`. If no `classes` field is
+provided, then the `target` values directly store the label strings.
+
+The target value in `labels` for unlabeled videos is `None`.
+
+.. note::
+
+    See :class:`FiftyOneTemporalDetectionDatasetExporter <fiftyone.utils.data.exporters.FiftyOneTemporalDetectionDatasetExporter>`
+    for parameters that can be passed to methods like
+    :meth:`SampleCollection.export() <fiftyone.core.collections.SampleCollection.export>`
+    to customize the export of datasets of this type.
+
+You can export a FiftyOne dataset as a temporal detection dataset stored on
+disk in the above format as follows:
+
+.. tabs::
+
+  .. group-tab:: Python
+
+    .. code-block:: python
+        :linenos:
+
+        import fiftyone as fo
+
+        export_dir = "/path/for/temporal-detection-dataset"
+        label_field = "ground_truth"  # for example
+
+        # The Dataset or DatasetView to export
+        dataset_or_view = fo.Dataset(...)
+
+        # Export the dataset
+        dataset_or_view.export(
+            export_dir=export_dir,
+            dataset_type=fo.types.FiftyOneTemporalDetectionDataset,
+            label_field=label_field,
+        )
+
+  .. group-tab:: CLI
+
+    .. code-block:: shell
+
+        NAME=my-dataset
+        EXPORT_DIR=/path/for/temporal-detection-dataset
+        LABEL_FIELD=ground_truth  # for example
+
+        # Export the dataset
+        fiftyone datasets export $NAME \
+            --export-dir $EXPORT_DIR \
+            --label-field $LABEL_FIELD \
+            --type fiftyone.types.FiftyOneTemporalDetectionDataset
 
 .. _COCODetectionDataset-export:
 

--- a/docs/source/user_guide/export_datasets.rst
+++ b/docs/source/user_guide/export_datasets.rst
@@ -281,6 +281,9 @@ format when writing the dataset to disk.
     | :ref:`FiftyOneImageClassificationDataset                           | A labeled dataset consisting of images and their associated classification labels  |
     | <FiftyOneImageClassificationDataset-export>`                       | in a simple JSON format.                                                           |
     +--------------------------------------------------------------------+------------------------------------------------------------------------------------+
+    | :ref:`FiftyOneVideoClassificationDataset                           | A labeled dataset consisting of videos and their associated temporal               |
+    | <FiftyOneVideoClassificationDataset-export>`                       | classification labels in a simple JSON format.                                     |
+    +--------------------------------------------------------------------+------------------------------------------------------------------------------------+
     | :ref:`ImageClassificationDirectoryTree                             | A directory tree whose subfolders define an image classification dataset.          |
     | <ImageClassificationDirectoryTree-export>`                         |                                                                                    |
     +--------------------------------------------------------------------+------------------------------------------------------------------------------------+
@@ -501,6 +504,31 @@ provided, then the `target` values directly store the label strings.
 
 The target value in `labels` for unlabeled images is `None`.
 
+Alternatively, if you include the `include_confidences=True` parameter when
+exporting datasets of this type, the `labels.json` file will contain
+predictions with associated confidences in the following format:
+
+.. code-block:: text
+
+    {
+        "classes": [
+            "<labelA>",
+            "<labelB>",
+            ...
+        ],
+        "labels": {
+            "<uuid1>": {
+                "label": "<target1>",
+                "confidence": "<confidence>"
+            },
+            "<uuid2>": {
+                "label": "<target2>",
+                "confidence": "<confidence>"
+            },
+            ...
+        }
+    }
+
 .. note::
 
     See :class:`FiftyOneImageClassificationDatasetExporter <fiftyone.utils.data.exporters.FiftyOneImageClassificationDatasetExporter>`
@@ -546,6 +574,123 @@ disk in the above format as follows:
             --export-dir $EXPORT_DIR \
             --label-field $LABEL_FIELD \
             --type fiftyone.types.FiftyOneImageClassificationDataset
+
+.. _FiftyOneVideoClassificationDataset-export:
+
+FiftyOneVideoClassificationDataset
+----------------------------------
+
+The :class:`fiftyone.types.FiftyOneVideoClassificationDataset <fiftyone.types.dataset_types.FiftyOneVideoClassificationDataset>`
+type represents a labeled dataset consisting of videos and their associated
+temporal classification labels stored in a simple JSON format.
+
+Datasets of this type are exported in the following format:
+
+.. code-block:: text
+
+    <dataset_dir>/
+        data/
+            <uuid1>.<ext>
+            <uuid2>.<ext>
+            ...
+        labels.json
+
+where `labels.json` is a JSON file in the following format:
+
+.. code-block:: text
+
+    {
+        "classes": [
+            "<labelA>",
+            "<labelB>",
+            ...
+        ],
+        "labels": {
+            "<uuid1>": [
+                {
+                    "label": <target>,
+                    "support": [<first-frame>, <last-frame>],
+                    "confidence": <optional-confidence>,
+                },
+                {
+                    "label": <target>,
+                    "support": [<first-frame>, <last-frame>],
+                    "confidence": <optional-confidence>,
+                },
+                ...
+            ],
+            "<uuid2>": [
+                {
+                    "label": <target>,
+                    "timestamps": [<start-timestamp>, <stop-timestamp>],
+                    "confidence": <optional-confidence>,
+                },
+                {
+                    "label": <target>,
+                    "timestamps": [<start-timestamp>, <stop-timestamp>],
+                    "confidence": <optional-confidence>,
+                },
+            ],
+            ...
+        }
+    }
+
+By default, the `support` keys will be populated with the `[first, last]` frame
+numbers of the classifications, but you can pass the `use_timestamps=True` key
+during export to instead populate the `timestamps` keys with the
+`[start, stop]` timestamps of the classifications.
+
+If the `classes` field is provided, the `target` values are class IDs that are
+mapped to class label strings via `classes[target]`. If no `classes` field is
+provided, then the `target` values directly store the label strings.
+
+The target value in `labels` for unlabeled videos is `None`.
+
+.. note::
+
+    See :class:`FiftyOneVideoClassificationDatasetExporter <fiftyone.utils.data.exporters.FiftyOneVideoClassificationDatasetExporter>`
+    for parameters that can be passed to methods like
+    :meth:`SampleCollection.export() <fiftyone.core.collections.SampleCollection.export>`
+    to customize the export of datasets of this type.
+
+You can export a FiftyOne dataset as a video classification dataset stored on
+disk in the above format as follows:
+
+.. tabs::
+
+  .. group-tab:: Python
+
+    .. code-block:: python
+        :linenos:
+
+        import fiftyone as fo
+
+        export_dir = "/path/for/video-classification-dataset"
+        label_field = "ground_truth"  # for example
+
+        # The Dataset or DatasetView to export
+        dataset_or_view = fo.Dataset(...)
+
+        # Export the dataset
+        dataset_or_view.export(
+            export_dir=export_dir,
+            dataset_type=fo.types.FiftyOneVideoClassificationDataset,
+            label_field=label_field,
+        )
+
+  .. group-tab:: CLI
+
+    .. code-block:: shell
+
+        NAME=my-dataset
+        EXPORT_DIR=/path/for/video-classification-dataset
+        LABEL_FIELD=ground_truth  # for example
+
+        # Export the dataset
+        fiftyone datasets export $NAME \
+            --export-dir $EXPORT_DIR \
+            --label-field $LABEL_FIELD \
+            --type fiftyone.types.FiftyOneVideoClassificationDataset
 
 .. _ImageClassificationDirectoryTree-export:
 

--- a/docs/source/user_guide/using_datasets.rst
+++ b/docs/source/user_guide/using_datasets.rst
@@ -1694,6 +1694,157 @@ is rendered as a distinct color.
     dataset in the App, label strings will appear in the App's tooltip when you
     hover over pixels.
 
+.. _video-classification:
+
+Video classification
+--------------------
+
+The |VideoClassification| class represents a classification label with a
+temporal frame support in a video.
+
+The :attr:`label <fiftyone.core.labels.VideoClassification.label>` attribute
+stores the classification label, and the
+:attr:`support <fiftyone.core.labels.VideoClassification.support>` attribute
+stores the `[first, last]` frame range of the classification in the video.
+
+The optional
+:attr:`confidence <fiftyone.core.labels.VideoClassification.confidence>`
+attribute can be used to store a model prediction score, and you can add
+:ref:`custom attributes <label-attributes>` as well, which can be visualized in
+the App.
+
+.. code-block:: python
+    :linenos:
+
+    import fiftyone as fo
+
+    sample = fo.Sample(filepath="/path/to/video.mp4")
+    sample["events"] = fo.VideoClassification(label="meeting", support=[10, 20])
+
+    print(sample)
+
+.. code-block:: text
+
+    <Sample: {
+        'id': None,
+        'media_type': 'video',
+        'filepath': '/path/to/video.mp4',
+        'tags': [],
+        'metadata': None,
+        'events': <VideoClassification: {
+            'id': '61321c8ea36cb17df655f44f',
+            'tags': BaseList([]),
+            'label': 'meeting',
+            'support': BaseList([10, 20]),
+            'confidence': None,
+        }>,
+        'frames': <Frames: 0>,
+    }>
+
+If your video classification data is represented as timestamps in seconds, you
+can use the
+:meth:`from_timestamps() <fiftyone.core.labels.VideoClassification.from_timestamps>`
+factory method to perform the necessary conversion to frames automatically
+based on the sample's :ref:`video metadata <using-metadata>`:
+
+.. code-block:: python
+    :linenos:
+
+    import fiftyone as fo
+    import fiftyone.zoo as foz
+
+    # Download a video to work with
+    dataset = foz.load_zoo_dataset("quickstart-video", max_samples=1)
+    filepath = dataset.first().filepath
+
+    sample = fo.Sample(filepath=filepath)
+    sample.compute_metadata()
+
+    sample["events"] = fo.VideoClassification.from_timestamps(
+        [1, 2], label="meeting", sample=sample
+    )
+
+    print(sample)
+
+.. code-block:: text
+
+    <Sample: {
+        'id': None,
+        'media_type': 'video',
+        'filepath': '~/fiftyone/quickstart-video/data/Ulcb3AjxM5g_053-1.mp4',
+        'tags': [],
+        'metadata': <VideoMetadata: {
+            'size_bytes': 1758809,
+            'mime_type': 'video/mp4',
+            'frame_width': 1920,
+            'frame_height': 1080,
+            'frame_rate': 29.97002997002997,
+            'total_frame_count': 120,
+            'duration': 4.004,
+            'encoding_str': 'avc1',
+        }>,
+        'events': <VideoClassification: {
+            'id': '61321e498d5f587970b29183',
+            'tags': BaseList([]),
+            'label': 'meeting',
+            'support': BaseList([31, 60]),
+            'confidence': None,
+        }>,
+        'frames': <Frames: 0>,
+    }>
+
+The |VideoClassifications| class holds a list of video classifications for a
+sample:
+
+.. code-block:: python
+    :linenos:
+
+    import fiftyone as fo
+
+    sample = fo.Sample(filepath="/path/to/video.mp4")
+    sample["events"] = fo.VideoClassifications(
+        classifications=[
+            fo.VideoClassification(label="meeting", support=[10, 20]),
+            fo.VideoClassification(label="party", support=[30, 60]),
+        ]
+    )
+
+    print(sample)
+
+.. code-block:: text
+
+    <Sample: {
+        'id': None,
+        'media_type': 'video',
+        'filepath': '/path/to/video.mp4',
+        'tags': [],
+        'metadata': None,
+        'events': <VideoClassifications: {
+            'classifications': BaseList([
+                <VideoClassification: {
+                    'id': '61321ed78d5f587970b29184',
+                    'tags': BaseList([]),
+                    'label': 'meeting',
+                    'support': BaseList([10, 20]),
+                    'confidence': None,
+                }>,
+                <VideoClassification: {
+                    'id': '61321ed78d5f587970b29185',
+                    'tags': BaseList([]),
+                    'label': 'party',
+                    'support': BaseList([30, 60]),
+                    'confidence': None,
+                }>,
+            ]),
+        }>,
+        'frames': <Frames: 0>,
+    }>
+
+.. note::
+
+    Did you know? You can :ref:`store class lists <storing-classes>` for your
+    models on your datasets.
+
 .. _geolocation:
 
 Geolocation

--- a/docs/source/user_guide/using_datasets.rst
+++ b/docs/source/user_guide/using_datasets.rst
@@ -1699,8 +1699,8 @@ is rendered as a distinct color.
 Temporal detection
 ------------------
 
-The |TemporalDetection| class represents a temporal detection occuring during a
-specified range of frames in a video.
+The |TemporalDetection| class represents an event occuring during a specified
+range of frames in a video.
 
 The :attr:`label <fiftyone.core.labels.TemporalDetection.label>` attribute
 stores the detection label, and the

--- a/docs/source/user_guide/using_datasets.rst
+++ b/docs/source/user_guide/using_datasets.rst
@@ -1694,21 +1694,21 @@ is rendered as a distinct color.
     dataset in the App, label strings will appear in the App's tooltip when you
     hover over pixels.
 
-.. _video-classification:
+.. _temporal-detection:
 
-Video classification
---------------------
+Temporal detection
+------------------
 
-The |VideoClassification| class represents a classification label with a
-temporal frame support in a video.
+The |TemporalDetection| class represents a temporal detection occuring during a
+specified range of frames in a video.
 
-The :attr:`label <fiftyone.core.labels.VideoClassification.label>` attribute
-stores the classification label, and the
-:attr:`support <fiftyone.core.labels.VideoClassification.support>` attribute
-stores the `[first, last]` frame range of the classification in the video.
+The :attr:`label <fiftyone.core.labels.TemporalDetection.label>` attribute
+stores the detection label, and the
+:attr:`support <fiftyone.core.labels.TemporalDetection.support>` attribute
+stores the `[first, last]` frame range of the detection in the video.
 
 The optional
-:attr:`confidence <fiftyone.core.labels.VideoClassification.confidence>`
+:attr:`confidence <fiftyone.core.labels.TemporalDetection.confidence>`
 attribute can be used to store a model prediction score, and you can add
 :ref:`custom attributes <label-attributes>` as well, which can be visualized in
 the App.
@@ -1719,7 +1719,7 @@ the App.
     import fiftyone as fo
 
     sample = fo.Sample(filepath="/path/to/video.mp4")
-    sample["events"] = fo.VideoClassification(label="meeting", support=[10, 20])
+    sample["events"] = fo.TemporalDetection(label="meeting", support=[10, 20])
 
     print(sample)
 
@@ -1731,7 +1731,7 @@ the App.
         'filepath': '/path/to/video.mp4',
         'tags': [],
         'metadata': None,
-        'events': <VideoClassification: {
+        'events': <TemporalDetection: {
             'id': '61321c8ea36cb17df655f44f',
             'tags': BaseList([]),
             'label': 'meeting',
@@ -1741,9 +1741,9 @@ the App.
         'frames': <Frames: 0>,
     }>
 
-If your video classification data is represented as timestamps in seconds, you
+If your temporal detection data is represented as timestamps in seconds, you
 can use the
-:meth:`from_timestamps() <fiftyone.core.labels.VideoClassification.from_timestamps>`
+:meth:`from_timestamps() <fiftyone.core.labels.TemporalDetection.from_timestamps>`
 factory method to perform the necessary conversion to frames automatically
 based on the sample's :ref:`video metadata <using-metadata>`:
 
@@ -1760,7 +1760,7 @@ based on the sample's :ref:`video metadata <using-metadata>`:
     sample = fo.Sample(filepath=filepath)
     sample.compute_metadata()
 
-    sample["events"] = fo.VideoClassification.from_timestamps(
+    sample["events"] = fo.TemporalDetection.from_timestamps(
         [1, 2], label="meeting", sample=sample
     )
 
@@ -1783,7 +1783,7 @@ based on the sample's :ref:`video metadata <using-metadata>`:
             'duration': 4.004,
             'encoding_str': 'avc1',
         }>,
-        'events': <VideoClassification: {
+        'events': <TemporalDetection: {
             'id': '61321e498d5f587970b29183',
             'tags': BaseList([]),
             'label': 'meeting',
@@ -1793,7 +1793,7 @@ based on the sample's :ref:`video metadata <using-metadata>`:
         'frames': <Frames: 0>,
     }>
 
-The |VideoClassifications| class holds a list of video classifications for a
+The |TemporalDetections| class holds a list of temporal detections for a
 sample:
 
 .. code-block:: python
@@ -1802,10 +1802,10 @@ sample:
     import fiftyone as fo
 
     sample = fo.Sample(filepath="/path/to/video.mp4")
-    sample["events"] = fo.VideoClassifications(
-        classifications=[
-            fo.VideoClassification(label="meeting", support=[10, 20]),
-            fo.VideoClassification(label="party", support=[30, 60]),
+    sample["events"] = fo.TemporalDetections(
+        detections=[
+            fo.TemporalDetection(label="meeting", support=[10, 20]),
+            fo.TemporalDetection(label="party", support=[30, 60]),
         ]
     )
 
@@ -1819,16 +1819,16 @@ sample:
         'filepath': '/path/to/video.mp4',
         'tags': [],
         'metadata': None,
-        'events': <VideoClassifications: {
-            'classifications': BaseList([
-                <VideoClassification: {
+        'events': <TemporalDetections: {
+            'detections': BaseList([
+                <TemporalDetection: {
                     'id': '61321ed78d5f587970b29184',
                     'tags': BaseList([]),
                     'label': 'meeting',
                     'support': BaseList([10, 20]),
                     'confidence': None,
                 }>,
-                <VideoClassification: {
+                <TemporalDetection: {
                     'id': '61321ed78d5f587970b29185',
                     'tags': BaseList([]),
                     'label': 'party',

--- a/fiftyone/__public__.py
+++ b/fiftyone/__public__.py
@@ -88,6 +88,8 @@ from .core.labels import (
     Segmentation,
     GeoLocation,
     GeoLocations,
+    VideoClassification,
+    VideoClassifications,
 )
 from .core.metadata import (
     Metadata,

--- a/fiftyone/__public__.py
+++ b/fiftyone/__public__.py
@@ -51,6 +51,7 @@ from .core.fields import (
     EmbeddedDocumentListField,
     Field,
     FrameNumberField,
+    FrameSupportField,
     FloatField,
     GeoPointField,
     GeoLineStringField,

--- a/fiftyone/__public__.py
+++ b/fiftyone/__public__.py
@@ -87,10 +87,10 @@ from .core.labels import (
     Keypoint,
     Keypoints,
     Segmentation,
+    TemporalDetection,
+    TemporalDetections,
     GeoLocation,
     GeoLocations,
-    VideoClassification,
-    VideoClassifications,
 )
 from .core.metadata import (
     Metadata,

--- a/fiftyone/core/fields.py
+++ b/fiftyone/core/fields.py
@@ -79,16 +79,6 @@ class BooleanField(mongoengine.fields.BooleanField, Field):
     pass
 
 
-class FrameNumberField(IntField):
-    """A video frame number field."""
-
-    def validate(self, value):
-        try:
-            fofu.validate_frame_number(value)
-        except fofu.FrameError as e:
-            self.error(str(e))
-
-
 class FloatField(mongoengine.fields.FloatField, Field):
     """A floating point number field."""
 
@@ -474,6 +464,37 @@ class ArrayField(mongoengine.fields.BinaryField, Field):
     def validate(self, value):
         if not isinstance(value, (np.ndarray, Binary)):
             self.error("Only numpy arrays may be used in an array field")
+
+
+class FrameNumberField(IntField):
+    """A video frame number field."""
+
+    def validate(self, value):
+        try:
+            fofu.validate_frame_number(value)
+        except fofu.FrameError as e:
+            self.error(str(e))
+
+
+class FrameSupportField(ListField):
+    """A ``[first, last]`` frame support in a video."""
+
+    def __init__(self, **kwargs):
+        if "field" not in kwargs:
+            kwargs["field"] = IntField()
+
+        super().__init__(**kwargs)
+
+    def validate(self, value):
+        if (
+            not isinstance(value, (list, tuple))
+            or len(value) != 2
+            or not (1 <= value[0] <= value[1])
+        ):
+            self.error(
+                "Frame support fields must contain `[first, last]` frame "
+                "numbers"
+            )
 
 
 class ClassesField(ListField):

--- a/fiftyone/core/labels.py
+++ b/fiftyone/core/labels.py
@@ -13,6 +13,7 @@ import cv2
 import numpy as np
 
 import eta.core.data as etad
+import eta.core.frameutils as etaf
 import eta.core.geometry as etag
 import eta.core.keypoints as etak
 import eta.core.image as etai
@@ -22,6 +23,7 @@ import eta.core.utils as etau
 
 from fiftyone.core.odm.document import DynamicEmbeddedDocument
 import fiftyone.core.fields as fof
+import fiftyone.core.metadata as fom
 import fiftyone.core.utils as fou
 
 foug = fou.lazy_import("fiftyone.utils.geojson")
@@ -421,8 +423,7 @@ class Classification(ImageLabel, _HasID):
 
 
 class Classifications(ImageLabel, _HasLabelList):
-    """A list of classifications (typically from a multilabel model) in an
-    image.
+    """A list of classifications for an image.
 
     Args:
         classifications (None): a list of :class:`Classification` instances
@@ -1380,6 +1381,104 @@ class GeoLocations(_HasID, Label):
         return cls(points=points, lines=lines, polygons=polygons)
 
 
+class VideoClassification(_HasID, Label):
+    """A video classification with a temporal support specified by a start
+    and end frame.
+
+    Args:
+        label (None): the label string
+        support (None): the ``[first, last]`` frame numbers, inclusive
+        confidence (None): a confidence in ``[0, 1]`` for the classification
+    """
+
+    meta = {"allow_inheritance": True}
+
+    label = fof.StringField()
+    support = fof.ListField(fof.IntField())
+    confidence = fof.FloatField()
+
+    @classmethod
+    def from_timestamps(cls, timestamps, sample=None, metadata=None, **kwargs):
+        """Creates a :class:`VideoClassification` instance from
+        ``[start, stop]`` timestamps for the specified video.
+
+        You must provide either ``sample`` or ``metadata`` to inform the
+        conversion.
+
+        Args:
+            timestamps: the ``[start, stop]`` timestamps, in seconds or
+                "HH:MM:SS.XXX" format
+            sample (None): a video :class:`fiftyone.core.sample.Sample` whose
+                ``metadata`` field is populated
+            metadata (None): a :class:`fiftyone.core.metadata.VideoMetadata`
+                instance
+            **kwargs: additional arguments for :class:`VideoClassification`
+
+        Returns:
+            a :class:`VideoClassification`
+        """
+        start, end = timestamps
+        total_frame_count, duration = _parse_video_metadata(sample, metadata)
+        support = [
+            etaf.timestamp_to_frame_number(start, duration, total_frame_count),
+            etaf.timestamp_to_frame_number(end, duration, total_frame_count),
+        ]
+        return cls(support=support, **kwargs)
+
+    def to_timestamps(self, sample=None, metadata=None):
+        """Returns the ``[start, stop]`` timestamps, in seconds, for this video
+        classification in the given video.
+
+        You must provide either ``sample`` or ``metadata`` to inform the
+        conversion.
+
+        Args:
+            sample (None): a video :class:`fiftyone.core.sample.Sample` whose
+                ``metadata`` field is populated
+            metadata (None): a :class:`fiftyone.core.metadata.VideoMetadata`
+                instance
+
+        Returns:
+            the ``[start, stop]`` timestamps of this classification, in seconds
+        """
+        first, last = self.support  # pylint: disable=unpacking-non-sequence
+        total_frame_count, duration = _parse_video_metadata(sample, metadata)
+        return [
+            etaf.frame_number_to_timestamp(first, total_frame_count, duration),
+            etaf.frame_number_to_timestamp(last, total_frame_count, duration),
+        ]
+
+
+def _parse_video_metadata(sample, metadata):
+    if sample is not None:
+        metadata = sample.metadata
+
+    if not isinstance(metadata, fom.VideoMetadata):
+        raise ValueError(
+            "You must provide either `metadata` or a `sample` whose "
+            "`metadata` field is populated containing `VideoMetadata`"
+        )
+
+    return metadata.total_frame_count, metadata.duration
+
+
+class VideoClassifications(Label, _HasLabelList):
+    """A list of video classifications for a video.
+
+    Args:
+        classifications (None): a list of :class:`VideoClassification`
+            instances
+    """
+
+    _LABEL_LIST_FIELD = "classifications"
+
+    meta = {"allow_inheritance": True}
+
+    classifications = fof.ListField(
+        fof.EmbeddedDocumentField(VideoClassification)
+    )
+
+
 _SINGLE_LABEL_FIELDS = (
     Classification,
     Detection,
@@ -1387,6 +1486,7 @@ _SINGLE_LABEL_FIELDS = (
     Keypoint,
     Polyline,
     Segmentation,
+    VideoClassification,
 )
 
 _LABEL_LIST_FIELDS = (
@@ -1394,6 +1494,7 @@ _LABEL_LIST_FIELDS = (
     Detections,
     Keypoints,
     Polylines,
+    VideoClassifications,
 )
 
 _LABEL_FIELDS = _SINGLE_LABEL_FIELDS + _LABEL_LIST_FIELDS
@@ -1410,6 +1511,7 @@ _SINGLE_LABEL_TO_LIST_MAP = {
     Detection: Detections,
     Keypoint: Keypoints,
     Polyline: Polylines,
+    VideoClassification: VideoClassifications,
 }
 
 _LABEL_LIST_TO_SINGLE_MAP = {
@@ -1417,6 +1519,7 @@ _LABEL_LIST_TO_SINGLE_MAP = {
     Detections: Detection,
     Keypoints: Keypoint,
     Polylines: Polyline,
+    VideoClassifications: VideoClassification,
 }
 
 

--- a/fiftyone/core/labels.py
+++ b/fiftyone/core/labels.py
@@ -1355,6 +1355,102 @@ class Segmentation(ImageLabel, _HasID):
         return cls(mask=mask)
 
 
+class TemporalDetection(_HasID, Label):
+    """A temporal detection in a video whose support is defined by a start and
+    end frame.
+
+    Args:
+        label (None): the label string
+        support (None): the ``[first, last]`` frame numbers, inclusive
+        confidence (None): a confidence in ``[0, 1]`` for the detection
+    """
+
+    meta = {"allow_inheritance": True}
+
+    label = fof.StringField()
+    support = fof.FrameSupportField()
+    confidence = fof.FloatField()
+
+    @classmethod
+    def from_timestamps(cls, timestamps, sample=None, metadata=None, **kwargs):
+        """Creates a :class:`TemporalDetection` instance from ``[start, stop]``
+        timestamps for the specified video.
+
+        You must provide either ``sample`` or ``metadata`` to inform the
+        conversion.
+
+        Args:
+            timestamps: the ``[start, stop]`` timestamps, in seconds or
+                "HH:MM:SS.XXX" format
+            sample (None): a video :class:`fiftyone.core.sample.Sample` whose
+                ``metadata`` field is populated
+            metadata (None): a :class:`fiftyone.core.metadata.VideoMetadata`
+                instance
+            **kwargs: additional arguments for :class:`TemporalDetection`
+
+        Returns:
+            a :class:`TemporalDetection`
+        """
+        start, end = timestamps
+        total_frame_count, duration = _parse_video_metadata(sample, metadata)
+        support = [
+            etaf.timestamp_to_frame_number(start, duration, total_frame_count),
+            etaf.timestamp_to_frame_number(end, duration, total_frame_count),
+        ]
+        return cls(support=support, **kwargs)
+
+    def to_timestamps(self, sample=None, metadata=None):
+        """Returns the ``[start, stop]`` timestamps, in seconds, for this
+        temporal detection in the given video.
+
+        You must provide either ``sample`` or ``metadata`` to inform the
+        conversion.
+
+        Args:
+            sample (None): a video :class:`fiftyone.core.sample.Sample` whose
+                ``metadata`` field is populated
+            metadata (None): a :class:`fiftyone.core.metadata.VideoMetadata`
+                instance
+
+        Returns:
+            the ``[start, stop]`` timestamps of this detection, in seconds
+        """
+        first, last = self.support  # pylint: disable=unpacking-non-sequence
+        total_frame_count, duration = _parse_video_metadata(sample, metadata)
+        return [
+            etaf.frame_number_to_timestamp(first, total_frame_count, duration),
+            etaf.frame_number_to_timestamp(last, total_frame_count, duration),
+        ]
+
+
+def _parse_video_metadata(sample, metadata):
+    if sample is not None:
+        metadata = sample.metadata
+
+    if not isinstance(metadata, fom.VideoMetadata):
+        raise ValueError(
+            "You must provide either `metadata` or a `sample` whose "
+            "`metadata` field is populated containing `VideoMetadata`"
+        )
+
+    return metadata.total_frame_count, metadata.duration
+
+
+class TemporalDetections(Label, _HasLabelList):
+    """A list of temporal detections for a video.
+
+    Args:
+        detections (None): a list of :class:`TemporalDetection`
+            instances
+    """
+
+    _LABEL_LIST_FIELD = "detections"
+
+    meta = {"allow_inheritance": True}
+
+    detections = fof.ListField(fof.EmbeddedDocumentField(TemporalDetection))
+
+
 class GeoLocation(_HasID, Label):
     """Location data in GeoJSON format.
 
@@ -1444,104 +1540,6 @@ class GeoLocations(_HasID, Label):
         return cls(points=points, lines=lines, polygons=polygons)
 
 
-class VideoClassification(_HasID, Label):
-    """A video classification with a temporal support specified by a start
-    and end frame.
-
-    Args:
-        label (None): the label string
-        support (None): the ``[first, last]`` frame numbers, inclusive
-        confidence (None): a confidence in ``[0, 1]`` for the classification
-    """
-
-    meta = {"allow_inheritance": True}
-
-    label = fof.StringField()
-    support = fof.FrameSupportField()
-    confidence = fof.FloatField()
-
-    @classmethod
-    def from_timestamps(cls, timestamps, sample=None, metadata=None, **kwargs):
-        """Creates a :class:`VideoClassification` instance from
-        ``[start, stop]`` timestamps for the specified video.
-
-        You must provide either ``sample`` or ``metadata`` to inform the
-        conversion.
-
-        Args:
-            timestamps: the ``[start, stop]`` timestamps, in seconds or
-                "HH:MM:SS.XXX" format
-            sample (None): a video :class:`fiftyone.core.sample.Sample` whose
-                ``metadata`` field is populated
-            metadata (None): a :class:`fiftyone.core.metadata.VideoMetadata`
-                instance
-            **kwargs: additional arguments for :class:`VideoClassification`
-
-        Returns:
-            a :class:`VideoClassification`
-        """
-        start, end = timestamps
-        total_frame_count, duration = _parse_video_metadata(sample, metadata)
-        support = [
-            etaf.timestamp_to_frame_number(start, duration, total_frame_count),
-            etaf.timestamp_to_frame_number(end, duration, total_frame_count),
-        ]
-        return cls(support=support, **kwargs)
-
-    def to_timestamps(self, sample=None, metadata=None):
-        """Returns the ``[start, stop]`` timestamps, in seconds, for this video
-        classification in the given video.
-
-        You must provide either ``sample`` or ``metadata`` to inform the
-        conversion.
-
-        Args:
-            sample (None): a video :class:`fiftyone.core.sample.Sample` whose
-                ``metadata`` field is populated
-            metadata (None): a :class:`fiftyone.core.metadata.VideoMetadata`
-                instance
-
-        Returns:
-            the ``[start, stop]`` timestamps of this classification, in seconds
-        """
-        first, last = self.support  # pylint: disable=unpacking-non-sequence
-        total_frame_count, duration = _parse_video_metadata(sample, metadata)
-        return [
-            etaf.frame_number_to_timestamp(first, total_frame_count, duration),
-            etaf.frame_number_to_timestamp(last, total_frame_count, duration),
-        ]
-
-
-def _parse_video_metadata(sample, metadata):
-    if sample is not None:
-        metadata = sample.metadata
-
-    if not isinstance(metadata, fom.VideoMetadata):
-        raise ValueError(
-            "You must provide either `metadata` or a `sample` whose "
-            "`metadata` field is populated containing `VideoMetadata`"
-        )
-
-    return metadata.total_frame_count, metadata.duration
-
-
-class VideoClassifications(Label, _HasLabelList):
-    """A list of video classifications for a video.
-
-    Args:
-        classifications (None): a list of :class:`VideoClassification`
-            instances
-    """
-
-    _LABEL_LIST_FIELD = "classifications"
-
-    meta = {"allow_inheritance": True}
-
-    classifications = fof.ListField(
-        fof.EmbeddedDocumentField(VideoClassification)
-    )
-
-
 _SINGLE_LABEL_FIELDS = (
     Classification,
     Detection,
@@ -1549,7 +1547,7 @@ _SINGLE_LABEL_FIELDS = (
     Keypoint,
     Polyline,
     Segmentation,
-    VideoClassification,
+    TemporalDetection,
 )
 
 _LABEL_LIST_FIELDS = (
@@ -1557,7 +1555,7 @@ _LABEL_LIST_FIELDS = (
     Detections,
     Keypoints,
     Polylines,
-    VideoClassifications,
+    TemporalDetections,
 )
 
 _LABEL_FIELDS = _SINGLE_LABEL_FIELDS + _LABEL_LIST_FIELDS
@@ -1574,7 +1572,7 @@ _SINGLE_LABEL_TO_LIST_MAP = {
     Detection: Detections,
     Keypoint: Keypoints,
     Polyline: Polylines,
-    VideoClassification: VideoClassifications,
+    TemporalDetection: TemporalDetections,
 }
 
 _LABEL_LIST_TO_SINGLE_MAP = {
@@ -1582,7 +1580,7 @@ _LABEL_LIST_TO_SINGLE_MAP = {
     Detections: Detection,
     Keypoints: Keypoint,
     Polylines: Polyline,
-    VideoClassifications: VideoClassification,
+    TemporalDetections: TemporalDetection,
 }
 
 

--- a/fiftyone/core/labels.py
+++ b/fiftyone/core/labels.py
@@ -1394,7 +1394,7 @@ class VideoClassification(_HasID, Label):
     meta = {"allow_inheritance": True}
 
     label = fof.StringField()
-    support = fof.ListField(fof.IntField())
+    support = fof.FrameSupportField()
     confidence = fof.FloatField()
 
     @classmethod

--- a/fiftyone/core/metadata.py
+++ b/fiftyone/core/metadata.py
@@ -153,7 +153,8 @@ def compute_sample_metadata(sample, skip_failures=False):
     sample.metadata = _compute_sample_metadata(
         sample.filepath, sample.media_type, skip_failures=skip_failures
     )
-    sample.save()
+    if sample._in_db:
+        sample.save()
 
 
 def compute_metadata(

--- a/fiftyone/types/dataset_types.py
+++ b/fiftyone/types/dataset_types.py
@@ -277,6 +277,27 @@ class FiftyOneImageClassificationDataset(ImageClassificationDataset):
         return foud.FiftyOneImageClassificationDatasetExporter
 
 
+class FiftyOneVideoClassificationDataset(ImageClassificationDataset):
+    """A labeled dataset consisting of videos and their associated
+    temporal classification labels stored in a simple JSON format.
+
+    See :ref:`this page <FiftyOneVideoClassificationDataset-import>` for
+    importing datasets of this type, and see
+    :ref:`this page <FiftyOneVideoClassificationDataset-export>` for exporting
+    datasets of this type.
+    """
+
+    def get_dataset_importer_cls(self):
+        import fiftyone.utils.data as foud
+
+        return foud.FiftyOneVideoClassificationDatasetImporter
+
+    def get_dataset_exporter_cls(self):
+        import fiftyone.utils.data as foud
+
+        return foud.FiftyOneVideoClassificationDatasetExporter
+
+
 class ImageClassificationDirectoryTree(ImageClassificationDataset):
     """A directory tree whose subfolders define an image classification
     dataset.

--- a/fiftyone/types/dataset_types.py
+++ b/fiftyone/types/dataset_types.py
@@ -180,7 +180,15 @@ class VideoClassificationDataset(LabeledVideoDataset):
 
 class ImageDetectionDataset(LabeledImageDataset):
     """Base type for datasets that represent a collection of images and a set
-    of associated object detections.
+    of associated detections.
+    """
+
+    pass
+
+
+class VideoDetectionDataset(LabeledVideoDataset):
+    """Base type for datasets that represent a collection of videos and a set
+    of associated video detections.
     """
 
     pass
@@ -189,14 +197,6 @@ class ImageDetectionDataset(LabeledImageDataset):
 class ImageSegmentationDataset(LabeledImageDataset):
     """Base type for datasets that represent a collection of images and a set
     of associated semantic segmentations.
-    """
-
-    pass
-
-
-class VideoDetectionDataset(LabeledVideoDataset):
-    """Base type for datasets that represent a collection of videos and a set
-    of associated video object detections.
     """
 
     pass
@@ -275,27 +275,6 @@ class FiftyOneImageClassificationDataset(ImageClassificationDataset):
         import fiftyone.utils.data as foud
 
         return foud.FiftyOneImageClassificationDatasetExporter
-
-
-class FiftyOneVideoClassificationDataset(ImageClassificationDataset):
-    """A labeled dataset consisting of videos and their associated
-    temporal classification labels stored in a simple JSON format.
-
-    See :ref:`this page <FiftyOneVideoClassificationDataset-import>` for
-    importing datasets of this type, and see
-    :ref:`this page <FiftyOneVideoClassificationDataset-export>` for exporting
-    datasets of this type.
-    """
-
-    def get_dataset_importer_cls(self):
-        import fiftyone.utils.data as foud
-
-        return foud.FiftyOneVideoClassificationDatasetImporter
-
-    def get_dataset_exporter_cls(self):
-        import fiftyone.utils.data as foud
-
-        return foud.FiftyOneVideoClassificationDatasetExporter
 
 
 class ImageClassificationDirectoryTree(ImageClassificationDataset):
@@ -380,6 +359,27 @@ class FiftyOneImageDetectionDataset(ImageDetectionDataset):
         import fiftyone.utils.data as foud
 
         return foud.FiftyOneImageDetectionDatasetExporter
+
+
+class FiftyOneTemporalDetectionDataset(VideoDetectionDataset):
+    """A labeled dataset consisting of videos and their associated temporal
+    detections stored in a simple JSON format.
+
+    See :ref:`this page <FiftyOneTemporalDetectionDataset-import>` for
+    importing datasets of this type, and see
+    :ref:`this page <FiftyOneTemporalDetectionDataset-export>` for exporting
+    datasets of this type.
+    """
+
+    def get_dataset_importer_cls(self):
+        import fiftyone.utils.data as foud
+
+        return foud.FiftyOneTemporalDetectionDatasetImporter
+
+    def get_dataset_exporter_cls(self):
+        import fiftyone.utils.data as foud
+
+        return foud.FiftyOneTemporalDetectionDatasetExporter
 
 
 class COCODetectionDataset(ImageDetectionDataset):

--- a/fiftyone/utils/data/exporters.py
+++ b/fiftyone/utils/data/exporters.py
@@ -15,6 +15,7 @@ from bson import json_util
 
 import eta.core.datasets as etad
 import eta.core.image as etai
+import eta.core.frameutils as etaf
 import eta.core.serial as etas
 import eta.core.utils as etau
 
@@ -1820,6 +1821,8 @@ class FiftyOneImageClassificationDatasetExporter(
 
             If None, the default value of this parameter will be chosen based
             on the value of the ``data_path`` parameter
+        include_confidence (False): whether to include the confidence of each
+            classifications in the exported labels
         classes (None): the list of possible class labels. If not provided,
             this list will be extracted when :meth:`log_collection` is called,
             if possible
@@ -1836,6 +1839,7 @@ class FiftyOneImageClassificationDatasetExporter(
         data_path=None,
         labels_path=None,
         export_media=None,
+        include_confidence=False,
         classes=None,
         image_format=None,
         pretty_print=False,
@@ -1858,6 +1862,7 @@ class FiftyOneImageClassificationDatasetExporter(
         self.data_path = data_path
         self.labels_path = labels_path
         self.export_media = export_media
+        self.include_confidence = include_confidence
         self.classes = classes
         self.image_format = image_format
         self.pretty_print = pretty_print
@@ -1901,7 +1906,173 @@ class FiftyOneImageClassificationDatasetExporter(
     def export_sample(self, image_or_path, classification, metadata=None):
         _, uuid = self._media_exporter.export(image_or_path)
         self._labels_dict[uuid] = _parse_classification(
-            classification, labels_map_rev=self._labels_map_rev
+            classification,
+            labels_map_rev=self._labels_map_rev,
+            include_confidence=self.include_confidence,
+        )
+
+    def close(self, *args):
+        labels = {
+            "classes": self.classes,
+            "labels": self._labels_dict,
+        }
+        etas.write_json(
+            labels, self.labels_path, pretty_print=self.pretty_print
+        )
+        self._media_exporter.close()
+
+    def _parse_classes(self):
+        if self.classes is not None:
+            self._labels_map_rev = _to_labels_map_rev(self.classes)
+
+
+class FiftyOneVideoClassificationDatasetExporter(
+    LabeledVideoDatasetExporter, ExportPathsMixin
+):
+    """Exporter that writes a temporal video classification dataset to disk in
+    FiftyOne's default format.
+
+    See :ref:`this page <FiftyOneVideoClassificationDataset-export>` for format
+    details.
+
+    Each input video is directly copied to its destination, maintaining the
+    original filename, unless a name conflict would occur, in which case an
+    index of the form ``"-%d" % count`` is appended to the base filename.
+
+    Args:
+        export_dir (None): the directory to write the export. This has no
+            effect if ``data_path`` and ``labels_path`` are absolute paths
+        data_path (None): an optional parameter that enables explicit control
+            over the location of the exported media. Can be any of the
+            following:
+
+            -   a folder name like ``"data"`` or ``"data/"`` specifying a
+                subfolder of ``export_dir`` in which to export the media
+            -   an absolute directory path in which to export the media. In
+                this case, the ``export_dir`` has no effect on the location of
+                the data
+            -   a JSON filename like ``"data.json"`` specifying the filename of
+                the manifest file in ``export_dir`` generated when
+                ``export_media`` is ``"manifest"``
+            -   an absolute filepath specifying the location to write the JSON
+                manifest file when ``export_media`` is ``"manifest"``. In this
+                case, ``export_dir`` has no effect on the location of the data
+
+            If None, the default value of this parameter will be chosen based
+            on the value of the ``export_media`` parameter
+        labels_path (None): an optional parameter that enables explicit control
+            over the location of the exported labels. Can be any of the
+            following:
+
+            -   a filename like ``"labels.json"`` specifying the location in
+                ``export_dir`` in which to export the labels
+            -   an absolute filepath to which to export the labels. In this
+                case, the ``export_dir`` has no effect on the location of the
+                labels
+
+            If None, the labels will be exported into ``export_dir`` using the
+            default filename
+        export_media (None): controls how to export the raw media. The
+            supported values are:
+
+            -   ``True``: copy all media files into the output directory
+            -   ``False``: don't export media
+            -   ``"move"``: move all media files into the output directory
+            -   ``"symlink"``: create symlinks to the media files in the output
+                directory
+            -   ``"manifest"``: create a ``data.json`` in the output directory
+                that maps UUIDs used in the labels files to the filepaths of
+                the source media, rather than exporting the actual media
+
+            If None, the default value of this parameter will be chosen based
+            on the value of the ``data_path`` parameter
+        use_timestamps (False): whether to export the support of each
+            classification in seconds rather than frame numbers
+        classes (None): the list of possible class labels. If not provided,
+            this list will be extracted when :meth:`log_collection` is called,
+            if possible
+        pretty_print (False): whether to render the JSON in human readable
+            format with newlines and indentations
+    """
+
+    def __init__(
+        self,
+        export_dir=None,
+        data_path=None,
+        labels_path=None,
+        export_media=None,
+        use_timestamps=False,
+        classes=None,
+        pretty_print=False,
+    ):
+        data_path, export_media = self._parse_data_path(
+            export_dir=export_dir,
+            data_path=data_path,
+            export_media=export_media,
+            default="data/",
+        )
+
+        labels_path = self._parse_labels_path(
+            export_dir=export_dir,
+            labels_path=labels_path,
+            default="labels.json",
+        )
+
+        super().__init__(export_dir=export_dir)
+
+        self.data_path = data_path
+        self.labels_path = labels_path
+        self.export_media = export_media
+        self.use_timestamps = use_timestamps
+        self.classes = classes
+        self.pretty_print = pretty_print
+
+        self._labels_dict = None
+        self._labels_map_rev = None
+        self._media_exporter = None
+
+    @property
+    def requires_video_metadata(self):
+        return self.use_timestamps
+
+    @property
+    def label_cls(self):
+        return fol.VideoClassifications
+
+    @property
+    def frame_labels_cls(self):
+        return None
+
+    def setup(self):
+        self._labels_dict = {}
+        self._parse_classes()
+
+        self._media_exporter = VideoExporter(
+            self.export_media, export_path=self.data_path, ignore_exts=True,
+        )
+        self._media_exporter.setup()
+
+    def log_collection(self, sample_collection):
+        if self.classes is None:
+            if sample_collection.default_classes:
+                self.classes = sample_collection.default_classes
+                self._parse_classes()
+            elif sample_collection.classes:
+                self.classes = next(iter(sample_collection.classes.values()))
+                self._parse_classes()
+            elif "classes" in sample_collection.info:
+                self.classes = sample_collection.info["classes"]
+                self._parse_classes()
+
+    def export_sample(
+        self, video_path, video_classifications, _, metadata=None
+    ):
+        _, uuid = self._media_exporter.export(video_path)
+        self._labels_dict[uuid] = _parse_video_classifications(
+            video_classifications,
+            use_timestamps=self.use_timestamps,
+            labels_map_rev=self._labels_map_rev,
+            metadata=metadata,
         )
 
     def close(self, *args):
@@ -2646,23 +2817,87 @@ class FiftyOneVideoLabelsDatasetExporter(LabeledVideoDatasetExporter):
         self._media_exporter.close()
 
 
-def _parse_classification(classification, labels_map_rev=None):
+def _parse_classification(
+    classification, labels_map_rev=None, include_confidence=False
+):
     if classification is None:
         return None
 
     label = classification.label
-    if labels_map_rev is None:
-        return label
 
-    if label not in labels_map_rev:
-        msg = (
-            "Ignoring classification with label '%s' not in provided classes"
-            % label
-        )
-        warnings.warn(msg)
+    if labels_map_rev is not None:
+        if label not in labels_map_rev:
+            msg = (
+                "Ignoring classification with label '%s' not in provided "
+                "classes" % label
+            )
+            warnings.warn(msg)
+            return None
+
+        label = labels_map_rev[label]
+
+    if include_confidence:
+        label = {
+            "label": label,
+            "confidence": classification.confidence,
+        }
+
+    return label
+
+
+def _parse_video_classifications(
+    video_classifications,
+    use_timestamps=False,
+    labels_map_rev=None,
+    metadata=None,
+):
+    if video_classifications is None:
         return None
 
-    return labels_map_rev[label]
+    if use_timestamps and metadata is None:
+        raise ValueError(
+            "Video metadata must be provided in order to export video "
+            "classifications as timestamps"
+        )
+
+    labels = []
+
+    for classification in video_classifications.classifications:
+        label = classification.label
+        if labels_map_rev is not None:
+            if label not in labels_map_rev:
+                msg = (
+                    "Ignoring video classification with label '%s' not in "
+                    "provided classes" % label
+                )
+                warnings.warn(msg)
+                continue
+
+            label = labels_map_rev[label]
+
+        label_dict = {"label": label}
+
+        if use_timestamps:
+            total_frame_count = metadata.total_frame_count
+            duration = metadata.duration
+            first, last = classification.support
+            label_dict["timestamps"] = [
+                etaf.frame_number_to_timestamp(
+                    first, total_frame_count, duration
+                ),
+                etaf.frame_number_to_timestamp(
+                    last, total_frame_count, duration
+                ),
+            ]
+        else:
+            label_dict["support"] = classification.support
+
+        if classification.confidence is not None:
+            label_dict["confidence"] = classification.confidence
+
+        labels.append(label_dict)
+
+    return labels
 
 
 def _parse_detections(detections, labels_map_rev=None):

--- a/fiftyone/utils/data/exporters.py
+++ b/fiftyone/utils/data/exporters.py
@@ -1927,170 +1927,6 @@ class FiftyOneImageClassificationDatasetExporter(
             self._labels_map_rev = _to_labels_map_rev(self.classes)
 
 
-class FiftyOneVideoClassificationDatasetExporter(
-    LabeledVideoDatasetExporter, ExportPathsMixin
-):
-    """Exporter that writes a temporal video classification dataset to disk in
-    FiftyOne's default format.
-
-    See :ref:`this page <FiftyOneVideoClassificationDataset-export>` for format
-    details.
-
-    Each input video is directly copied to its destination, maintaining the
-    original filename, unless a name conflict would occur, in which case an
-    index of the form ``"-%d" % count`` is appended to the base filename.
-
-    Args:
-        export_dir (None): the directory to write the export. This has no
-            effect if ``data_path`` and ``labels_path`` are absolute paths
-        data_path (None): an optional parameter that enables explicit control
-            over the location of the exported media. Can be any of the
-            following:
-
-            -   a folder name like ``"data"`` or ``"data/"`` specifying a
-                subfolder of ``export_dir`` in which to export the media
-            -   an absolute directory path in which to export the media. In
-                this case, the ``export_dir`` has no effect on the location of
-                the data
-            -   a JSON filename like ``"data.json"`` specifying the filename of
-                the manifest file in ``export_dir`` generated when
-                ``export_media`` is ``"manifest"``
-            -   an absolute filepath specifying the location to write the JSON
-                manifest file when ``export_media`` is ``"manifest"``. In this
-                case, ``export_dir`` has no effect on the location of the data
-
-            If None, the default value of this parameter will be chosen based
-            on the value of the ``export_media`` parameter
-        labels_path (None): an optional parameter that enables explicit control
-            over the location of the exported labels. Can be any of the
-            following:
-
-            -   a filename like ``"labels.json"`` specifying the location in
-                ``export_dir`` in which to export the labels
-            -   an absolute filepath to which to export the labels. In this
-                case, the ``export_dir`` has no effect on the location of the
-                labels
-
-            If None, the labels will be exported into ``export_dir`` using the
-            default filename
-        export_media (None): controls how to export the raw media. The
-            supported values are:
-
-            -   ``True``: copy all media files into the output directory
-            -   ``False``: don't export media
-            -   ``"move"``: move all media files into the output directory
-            -   ``"symlink"``: create symlinks to the media files in the output
-                directory
-            -   ``"manifest"``: create a ``data.json`` in the output directory
-                that maps UUIDs used in the labels files to the filepaths of
-                the source media, rather than exporting the actual media
-
-            If None, the default value of this parameter will be chosen based
-            on the value of the ``data_path`` parameter
-        use_timestamps (False): whether to export the support of each
-            classification in seconds rather than frame numbers
-        classes (None): the list of possible class labels. If not provided,
-            this list will be extracted when :meth:`log_collection` is called,
-            if possible
-        pretty_print (False): whether to render the JSON in human readable
-            format with newlines and indentations
-    """
-
-    def __init__(
-        self,
-        export_dir=None,
-        data_path=None,
-        labels_path=None,
-        export_media=None,
-        use_timestamps=False,
-        classes=None,
-        pretty_print=False,
-    ):
-        data_path, export_media = self._parse_data_path(
-            export_dir=export_dir,
-            data_path=data_path,
-            export_media=export_media,
-            default="data/",
-        )
-
-        labels_path = self._parse_labels_path(
-            export_dir=export_dir,
-            labels_path=labels_path,
-            default="labels.json",
-        )
-
-        super().__init__(export_dir=export_dir)
-
-        self.data_path = data_path
-        self.labels_path = labels_path
-        self.export_media = export_media
-        self.use_timestamps = use_timestamps
-        self.classes = classes
-        self.pretty_print = pretty_print
-
-        self._labels_dict = None
-        self._labels_map_rev = None
-        self._media_exporter = None
-
-    @property
-    def requires_video_metadata(self):
-        return self.use_timestamps
-
-    @property
-    def label_cls(self):
-        return fol.VideoClassifications
-
-    @property
-    def frame_labels_cls(self):
-        return None
-
-    def setup(self):
-        self._labels_dict = {}
-        self._parse_classes()
-
-        self._media_exporter = VideoExporter(
-            self.export_media, export_path=self.data_path, ignore_exts=True,
-        )
-        self._media_exporter.setup()
-
-    def log_collection(self, sample_collection):
-        if self.classes is None:
-            if sample_collection.default_classes:
-                self.classes = sample_collection.default_classes
-                self._parse_classes()
-            elif sample_collection.classes:
-                self.classes = next(iter(sample_collection.classes.values()))
-                self._parse_classes()
-            elif "classes" in sample_collection.info:
-                self.classes = sample_collection.info["classes"]
-                self._parse_classes()
-
-    def export_sample(
-        self, video_path, video_classifications, _, metadata=None
-    ):
-        _, uuid = self._media_exporter.export(video_path)
-        self._labels_dict[uuid] = _parse_video_classifications(
-            video_classifications,
-            use_timestamps=self.use_timestamps,
-            labels_map_rev=self._labels_map_rev,
-            metadata=metadata,
-        )
-
-    def close(self, *args):
-        labels = {
-            "classes": self.classes,
-            "labels": self._labels_dict,
-        }
-        etas.write_json(
-            labels, self.labels_path, pretty_print=self.pretty_print
-        )
-        self._media_exporter.close()
-
-    def _parse_classes(self):
-        if self.classes is not None:
-            self._labels_map_rev = _to_labels_map_rev(self.classes)
-
-
 class ImageClassificationDirectoryTreeExporter(LabeledImageDatasetExporter):
     """Exporter that writes an image classification directory tree to disk.
 
@@ -2420,6 +2256,168 @@ class FiftyOneImageDetectionDatasetExporter(
         _, uuid = self._media_exporter.export(image_or_path)
         self._labels_dict[uuid] = _parse_detections(
             detections, labels_map_rev=self._labels_map_rev
+        )
+
+    def close(self, *args):
+        labels = {
+            "classes": self.classes,
+            "labels": self._labels_dict,
+        }
+        etas.write_json(
+            labels, self.labels_path, pretty_print=self.pretty_print
+        )
+        self._media_exporter.close()
+
+    def _parse_classes(self):
+        if self.classes is not None:
+            self._labels_map_rev = _to_labels_map_rev(self.classes)
+
+
+class FiftyOneTemporalDetectionDatasetExporter(
+    LabeledVideoDatasetExporter, ExportPathsMixin
+):
+    """Exporter that writes a temporal video detection dataset to disk in
+    FiftyOne's default format.
+
+    See :ref:`this page <FiftyOneTemporalDetectionDataset-export>` for format
+    details.
+
+    Each input video is directly copied to its destination, maintaining the
+    original filename, unless a name conflict would occur, in which case an
+    index of the form ``"-%d" % count`` is appended to the base filename.
+
+    Args:
+        export_dir (None): the directory to write the export. This has no
+            effect if ``data_path`` and ``labels_path`` are absolute paths
+        data_path (None): an optional parameter that enables explicit control
+            over the location of the exported media. Can be any of the
+            following:
+
+            -   a folder name like ``"data"`` or ``"data/"`` specifying a
+                subfolder of ``export_dir`` in which to export the media
+            -   an absolute directory path in which to export the media. In
+                this case, the ``export_dir`` has no effect on the location of
+                the data
+            -   a JSON filename like ``"data.json"`` specifying the filename of
+                the manifest file in ``export_dir`` generated when
+                ``export_media`` is ``"manifest"``
+            -   an absolute filepath specifying the location to write the JSON
+                manifest file when ``export_media`` is ``"manifest"``. In this
+                case, ``export_dir`` has no effect on the location of the data
+
+            If None, the default value of this parameter will be chosen based
+            on the value of the ``export_media`` parameter
+        labels_path (None): an optional parameter that enables explicit control
+            over the location of the exported labels. Can be any of the
+            following:
+
+            -   a filename like ``"labels.json"`` specifying the location in
+                ``export_dir`` in which to export the labels
+            -   an absolute filepath to which to export the labels. In this
+                case, the ``export_dir`` has no effect on the location of the
+                labels
+
+            If None, the labels will be exported into ``export_dir`` using the
+            default filename
+        export_media (None): controls how to export the raw media. The
+            supported values are:
+
+            -   ``True``: copy all media files into the output directory
+            -   ``False``: don't export media
+            -   ``"move"``: move all media files into the output directory
+            -   ``"symlink"``: create symlinks to the media files in the output
+                directory
+            -   ``"manifest"``: create a ``data.json`` in the output directory
+                that maps UUIDs used in the labels files to the filepaths of
+                the source media, rather than exporting the actual media
+
+            If None, the default value of this parameter will be chosen based
+            on the value of the ``data_path`` parameter
+        use_timestamps (False): whether to export the support of each temporal
+            detection in seconds rather than frame numbers
+        classes (None): the list of possible class labels. If not provided,
+            this list will be extracted when :meth:`log_collection` is called,
+            if possible
+        pretty_print (False): whether to render the JSON in human readable
+            format with newlines and indentations
+    """
+
+    def __init__(
+        self,
+        export_dir=None,
+        data_path=None,
+        labels_path=None,
+        export_media=None,
+        use_timestamps=False,
+        classes=None,
+        pretty_print=False,
+    ):
+        data_path, export_media = self._parse_data_path(
+            export_dir=export_dir,
+            data_path=data_path,
+            export_media=export_media,
+            default="data/",
+        )
+
+        labels_path = self._parse_labels_path(
+            export_dir=export_dir,
+            labels_path=labels_path,
+            default="labels.json",
+        )
+
+        super().__init__(export_dir=export_dir)
+
+        self.data_path = data_path
+        self.labels_path = labels_path
+        self.export_media = export_media
+        self.use_timestamps = use_timestamps
+        self.classes = classes
+        self.pretty_print = pretty_print
+
+        self._labels_dict = None
+        self._labels_map_rev = None
+        self._media_exporter = None
+
+    @property
+    def requires_video_metadata(self):
+        return self.use_timestamps
+
+    @property
+    def label_cls(self):
+        return fol.TemporalDetections
+
+    @property
+    def frame_labels_cls(self):
+        return None
+
+    def setup(self):
+        self._labels_dict = {}
+        self._parse_classes()
+
+        self._media_exporter = VideoExporter(
+            self.export_media, export_path=self.data_path, ignore_exts=True,
+        )
+        self._media_exporter.setup()
+
+    def log_collection(self, sample_collection):
+        if self.classes is None:
+            if sample_collection.default_classes:
+                self.classes = sample_collection.default_classes
+                self._parse_classes()
+            elif sample_collection.classes:
+                self.classes = next(iter(sample_collection.classes.values()))
+                self._parse_classes()
+            elif "classes" in sample_collection.info:
+                self.classes = sample_collection.info["classes"]
+                self._parse_classes()
+
+    def export_sample(self, video_path, temporal_detections, _, metadata=None):
+        _, uuid = self._media_exporter.export(video_path)
+        self._labels_dict[uuid] = _parse_temporal_detections(
+            temporal_detections,
+            use_timestamps=self.use_timestamps,
+            labels_map_rev=self._labels_map_rev,
+            metadata=metadata,
         )
 
     def close(self, *args):
@@ -2856,29 +2854,29 @@ def _parse_classification(
     return label
 
 
-def _parse_video_classifications(
-    video_classifications,
+def _parse_temporal_detections(
+    temporal_detections,
     use_timestamps=False,
     labels_map_rev=None,
     metadata=None,
 ):
-    if video_classifications is None:
+    if temporal_detections is None:
         return None
 
     if use_timestamps and metadata is None:
         raise ValueError(
-            "Video metadata must be provided in order to export video "
-            "classifications as timestamps"
+            "Video metadata must be provided in order to export temporal "
+            "detections as timestamps"
         )
 
     labels = []
 
-    for classification in video_classifications.classifications:
-        label = classification.label
+    for detection in temporal_detections.detections:
+        label = detection.label
         if labels_map_rev is not None:
             if label not in labels_map_rev:
                 msg = (
-                    "Ignoring video classification with label '%s' not in "
+                    "Ignoring temporal detection with label '%s' not in "
                     "provided classes" % label
                 )
                 warnings.warn(msg)
@@ -2891,7 +2889,7 @@ def _parse_video_classifications(
         if use_timestamps:
             total_frame_count = metadata.total_frame_count
             duration = metadata.duration
-            first, last = classification.support
+            first, last = detection.support
             label_dict["timestamps"] = [
                 etaf.frame_number_to_timestamp(
                     first, total_frame_count, duration
@@ -2901,10 +2899,10 @@ def _parse_video_classifications(
                 ),
             ]
         else:
-            label_dict["support"] = classification.support
+            label_dict["support"] = detection.support
 
-        if classification.confidence is not None:
-            label_dict["confidence"] = classification.confidence
+        if detection.confidence is not None:
+            label_dict["confidence"] = detection.confidence
 
         labels.append(label_dict)
 

--- a/fiftyone/utils/data/importers.py
+++ b/fiftyone/utils/data/importers.py
@@ -37,7 +37,7 @@ import fiftyone.types as fot
 
 from .parsers import (
     FiftyOneImageClassificationSampleParser,
-    FiftyOneVideoClassificationSampleParser,
+    FiftyOneTemporalDetectionSampleParser,
     FiftyOneImageDetectionSampleParser,
     FiftyOneImageLabelsSampleParser,
     FiftyOneVideoLabelsSampleParser,
@@ -1955,175 +1955,6 @@ class FiftyOneImageClassificationDatasetImporter(
         return len(labels.get("labels", {}))
 
 
-class FiftyOneVideoClassificationDatasetImporter(
-    LabeledVideoDatasetImporter, ImportPathsMixin
-):
-    """Importer for temporal video classification datasets stored on disk in
-    FiftyOne's default format.
-
-    See :ref:`this page <FiftyOneVideoClassificationDataset-import>` for format
-    details.
-
-    Args:
-        dataset_dir (None): the dataset directory
-        data_path (None): an optional parameter that enables explicit control
-            over the location of the media. Can be any of the following:
-
-            -   a folder name like ``"data"`` or ``"data"/`` specifying a
-                subfolder of ``dataset_dir`` where the media files reside
-            -   an absolute directory path where the media files reside. In
-                this case, the ``dataset_dir`` has no effect on the location of
-                the data
-            -   a filename like ``"data.json"`` specifying the filename of the
-                JSON data manifest file in ``dataset_dir``
-            -   an absolute filepath specifying the location of the JSON data
-                manifest. In this case, ``dataset_dir`` has no effect on the
-                location of the data
-
-            If None, this parameter will default to whichever of ``data/`` or
-            ``data.json`` exists in the dataset directory
-        labels_path (None): an optional parameter that enables explicit control
-            over the location of the labels. Can be any of the following:
-
-            -   a filename like ``"labels.json"`` specifying the location of
-                the labels in ``dataset_dir``
-            -   an absolute filepath to the labels. In this case,
-                ``dataset_dir`` has no effect on the location of the labels
-
-            If None, the parameter will default to ``labels.json``
-        compute_metadata (False): whether to produce
-            :class:`fiftyone.core.metadata.VideoMetadata` instances for each
-            video when importing
-        shuffle (False): whether to randomly shuffle the order in which the
-            samples are imported
-        seed (None): a random seed to use when shuffling
-        max_samples (None): a maximum number of samples to import. By default,
-            all samples are imported
-    """
-
-    def __init__(
-        self,
-        dataset_dir=None,
-        data_path=None,
-        labels_path=None,
-        compute_metadata=False,
-        shuffle=False,
-        seed=None,
-        max_samples=None,
-    ):
-        data_path = self._parse_data_path(
-            dataset_dir=dataset_dir, data_path=data_path, default="data/",
-        )
-
-        labels_path = self._parse_labels_path(
-            dataset_dir=dataset_dir,
-            labels_path=labels_path,
-            default="labels.json",
-        )
-
-        super().__init__(
-            dataset_dir=dataset_dir,
-            shuffle=shuffle,
-            seed=seed,
-            max_samples=max_samples,
-        )
-
-        self.data_path = data_path
-        self.labels_path = labels_path
-        self.compute_metadata = compute_metadata
-
-        self._classes = None
-        self._sample_parser = None
-        self._video_paths_map = None
-        self._labels_map = None
-        self._uuids = None
-        self._iter_uuids = None
-        self._num_samples = None
-        self._has_labels = False
-
-    def __iter__(self):
-        self._iter_uuids = iter(self._uuids)
-        return self
-
-    def __len__(self):
-        return self._num_samples
-
-    def __next__(self):
-        uuid = next(self._iter_uuids)
-
-        video_path = self._video_paths_map[uuid]
-        labels = self._labels_map[uuid]
-
-        if self._has_labels:
-            self._sample_parser.with_sample((video_path, labels))
-            label = self._sample_parser.get_label()
-        else:
-            label = None
-
-        if self.compute_metadata:
-            video_metadata = self._sample_parser.get_video_metadata()
-        else:
-            video_metadata = None
-
-        return video_path, video_metadata, label, None
-
-    @property
-    def has_dataset_info(self):
-        return self._classes is not None
-
-    @property
-    def has_video_metadata(self):
-        return self.compute_metadata
-
-    @property
-    def label_cls(self):
-        return fol.VideoClassifications
-
-    @property
-    def frame_labels_cls(self):
-        return None
-
-    def setup(self):
-        self._sample_parser = FiftyOneVideoClassificationSampleParser(
-            compute_metadata=self.compute_metadata
-        )
-
-        self._video_paths_map = self._load_data_map(
-            self.data_path, ignore_exts=True, recursive=True
-        )
-
-        if self.labels_path is not None and os.path.isfile(self.labels_path):
-            labels = etas.load_json(self.labels_path)
-        else:
-            labels = {}
-
-        self._classes = labels.get("classes", None)
-        self._sample_parser.classes = self._classes
-        self._labels_map = labels.get("labels", {})
-        self._has_labels = any(self._labels_map.values())
-
-        uuids = sorted(self._labels_map.keys())
-        self._uuids = self._preprocess_list(uuids)
-        self._num_samples = len(self._uuids)
-
-    def get_dataset_info(self):
-        return {"classes": self._classes}
-
-    @staticmethod
-    def _get_classes(dataset_dir):
-        # Used only by dataset zoo
-        labels_path = os.path.join(dataset_dir, "labels.json")
-        labels = etas.read_json(labels_path)
-        return labels.get("classes", None)
-
-    @staticmethod
-    def _get_num_samples(dataset_dir):
-        # Used only by dataset zoo
-        labels_path = os.path.join(dataset_dir, "labels.json")
-        labels = etas.read_json(labels_path)
-        return len(labels.get("labels", {}))
-
-
 class ImageClassificationDirectoryTreeImporter(LabeledImageDatasetImporter):
     """Importer for an image classification directory tree stored on disk.
 
@@ -2488,6 +2319,175 @@ class FiftyOneImageDetectionDatasetImporter(
         self._sample_parser = FiftyOneImageDetectionSampleParser()
 
         self._image_paths_map = self._load_data_map(
+            self.data_path, ignore_exts=True, recursive=True
+        )
+
+        if self.labels_path is not None and os.path.isfile(self.labels_path):
+            labels = etas.load_json(self.labels_path)
+        else:
+            labels = {}
+
+        self._classes = labels.get("classes", None)
+        self._sample_parser.classes = self._classes
+        self._labels_map = labels.get("labels", {})
+        self._has_labels = any(self._labels_map.values())
+
+        uuids = sorted(self._labels_map.keys())
+        self._uuids = self._preprocess_list(uuids)
+        self._num_samples = len(self._uuids)
+
+    def get_dataset_info(self):
+        return {"classes": self._classes}
+
+    @staticmethod
+    def _get_classes(dataset_dir):
+        # Used only by dataset zoo
+        labels_path = os.path.join(dataset_dir, "labels.json")
+        labels = etas.read_json(labels_path)
+        return labels.get("classes", None)
+
+    @staticmethod
+    def _get_num_samples(dataset_dir):
+        # Used only by dataset zoo
+        labels_path = os.path.join(dataset_dir, "labels.json")
+        labels = etas.read_json(labels_path)
+        return len(labels.get("labels", {}))
+
+
+class FiftyOneTemporalDetectionDatasetImporter(
+    LabeledVideoDatasetImporter, ImportPathsMixin
+):
+    """Importer for temporal video detection datasets stored on disk in
+    FiftyOne's default format.
+
+    See :ref:`this page <FiftyOneTemporalDetectionDataset-import>` for format
+    details.
+
+    Args:
+        dataset_dir (None): the dataset directory
+        data_path (None): an optional parameter that enables explicit control
+            over the location of the media. Can be any of the following:
+
+            -   a folder name like ``"data"`` or ``"data"/`` specifying a
+                subfolder of ``dataset_dir`` where the media files reside
+            -   an absolute directory path where the media files reside. In
+                this case, the ``dataset_dir`` has no effect on the location of
+                the data
+            -   a filename like ``"data.json"`` specifying the filename of the
+                JSON data manifest file in ``dataset_dir``
+            -   an absolute filepath specifying the location of the JSON data
+                manifest. In this case, ``dataset_dir`` has no effect on the
+                location of the data
+
+            If None, this parameter will default to whichever of ``data/`` or
+            ``data.json`` exists in the dataset directory
+        labels_path (None): an optional parameter that enables explicit control
+            over the location of the labels. Can be any of the following:
+
+            -   a filename like ``"labels.json"`` specifying the location of
+                the labels in ``dataset_dir``
+            -   an absolute filepath to the labels. In this case,
+                ``dataset_dir`` has no effect on the location of the labels
+
+            If None, the parameter will default to ``labels.json``
+        compute_metadata (False): whether to produce
+            :class:`fiftyone.core.metadata.VideoMetadata` instances for each
+            video when importing
+        shuffle (False): whether to randomly shuffle the order in which the
+            samples are imported
+        seed (None): a random seed to use when shuffling
+        max_samples (None): a maximum number of samples to import. By default,
+            all samples are imported
+    """
+
+    def __init__(
+        self,
+        dataset_dir=None,
+        data_path=None,
+        labels_path=None,
+        compute_metadata=False,
+        shuffle=False,
+        seed=None,
+        max_samples=None,
+    ):
+        data_path = self._parse_data_path(
+            dataset_dir=dataset_dir, data_path=data_path, default="data/",
+        )
+
+        labels_path = self._parse_labels_path(
+            dataset_dir=dataset_dir,
+            labels_path=labels_path,
+            default="labels.json",
+        )
+
+        super().__init__(
+            dataset_dir=dataset_dir,
+            shuffle=shuffle,
+            seed=seed,
+            max_samples=max_samples,
+        )
+
+        self.data_path = data_path
+        self.labels_path = labels_path
+        self.compute_metadata = compute_metadata
+
+        self._classes = None
+        self._sample_parser = None
+        self._video_paths_map = None
+        self._labels_map = None
+        self._uuids = None
+        self._iter_uuids = None
+        self._num_samples = None
+        self._has_labels = False
+
+    def __iter__(self):
+        self._iter_uuids = iter(self._uuids)
+        return self
+
+    def __len__(self):
+        return self._num_samples
+
+    def __next__(self):
+        uuid = next(self._iter_uuids)
+
+        video_path = self._video_paths_map[uuid]
+        labels = self._labels_map[uuid]
+
+        if self._has_labels:
+            self._sample_parser.with_sample((video_path, labels))
+            label = self._sample_parser.get_label()
+        else:
+            label = None
+
+        if self.compute_metadata:
+            video_metadata = self._sample_parser.get_video_metadata()
+        else:
+            video_metadata = None
+
+        return video_path, video_metadata, label, None
+
+    @property
+    def has_dataset_info(self):
+        return self._classes is not None
+
+    @property
+    def has_video_metadata(self):
+        return self.compute_metadata
+
+    @property
+    def label_cls(self):
+        return fol.TemporalDetections
+
+    @property
+    def frame_labels_cls(self):
+        return None
+
+    def setup(self):
+        self._sample_parser = FiftyOneTemporalDetectionSampleParser(
+            compute_metadata=self.compute_metadata
+        )
+
+        self._video_paths_map = self._load_data_map(
             self.data_path, ignore_exts=True, recursive=True
         )
 

--- a/fiftyone/utils/data/importers.py
+++ b/fiftyone/utils/data/importers.py
@@ -37,6 +37,7 @@ import fiftyone.types as fot
 
 from .parsers import (
     FiftyOneImageClassificationSampleParser,
+    FiftyOneVideoClassificationSampleParser,
     FiftyOneImageDetectionSampleParser,
     FiftyOneImageLabelsSampleParser,
     FiftyOneVideoLabelsSampleParser,
@@ -1934,6 +1935,175 @@ class FiftyOneImageClassificationDatasetImporter(
         uuids = sorted(self._labels_map.keys())
         self._uuids = self._preprocess_list(uuids)
 
+        self._num_samples = len(self._uuids)
+
+    def get_dataset_info(self):
+        return {"classes": self._classes}
+
+    @staticmethod
+    def _get_classes(dataset_dir):
+        # Used only by dataset zoo
+        labels_path = os.path.join(dataset_dir, "labels.json")
+        labels = etas.read_json(labels_path)
+        return labels.get("classes", None)
+
+    @staticmethod
+    def _get_num_samples(dataset_dir):
+        # Used only by dataset zoo
+        labels_path = os.path.join(dataset_dir, "labels.json")
+        labels = etas.read_json(labels_path)
+        return len(labels.get("labels", {}))
+
+
+class FiftyOneVideoClassificationDatasetImporter(
+    LabeledVideoDatasetImporter, ImportPathsMixin
+):
+    """Importer for temporal video classification datasets stored on disk in
+    FiftyOne's default format.
+
+    See :ref:`this page <FiftyOneVideoClassificationDataset-import>` for format
+    details.
+
+    Args:
+        dataset_dir (None): the dataset directory
+        data_path (None): an optional parameter that enables explicit control
+            over the location of the media. Can be any of the following:
+
+            -   a folder name like ``"data"`` or ``"data"/`` specifying a
+                subfolder of ``dataset_dir`` where the media files reside
+            -   an absolute directory path where the media files reside. In
+                this case, the ``dataset_dir`` has no effect on the location of
+                the data
+            -   a filename like ``"data.json"`` specifying the filename of the
+                JSON data manifest file in ``dataset_dir``
+            -   an absolute filepath specifying the location of the JSON data
+                manifest. In this case, ``dataset_dir`` has no effect on the
+                location of the data
+
+            If None, this parameter will default to whichever of ``data/`` or
+            ``data.json`` exists in the dataset directory
+        labels_path (None): an optional parameter that enables explicit control
+            over the location of the labels. Can be any of the following:
+
+            -   a filename like ``"labels.json"`` specifying the location of
+                the labels in ``dataset_dir``
+            -   an absolute filepath to the labels. In this case,
+                ``dataset_dir`` has no effect on the location of the labels
+
+            If None, the parameter will default to ``labels.json``
+        compute_metadata (False): whether to produce
+            :class:`fiftyone.core.metadata.VideoMetadata` instances for each
+            video when importing
+        shuffle (False): whether to randomly shuffle the order in which the
+            samples are imported
+        seed (None): a random seed to use when shuffling
+        max_samples (None): a maximum number of samples to import. By default,
+            all samples are imported
+    """
+
+    def __init__(
+        self,
+        dataset_dir=None,
+        data_path=None,
+        labels_path=None,
+        compute_metadata=False,
+        shuffle=False,
+        seed=None,
+        max_samples=None,
+    ):
+        data_path = self._parse_data_path(
+            dataset_dir=dataset_dir, data_path=data_path, default="data/",
+        )
+
+        labels_path = self._parse_labels_path(
+            dataset_dir=dataset_dir,
+            labels_path=labels_path,
+            default="labels.json",
+        )
+
+        super().__init__(
+            dataset_dir=dataset_dir,
+            shuffle=shuffle,
+            seed=seed,
+            max_samples=max_samples,
+        )
+
+        self.data_path = data_path
+        self.labels_path = labels_path
+        self.compute_metadata = compute_metadata
+
+        self._classes = None
+        self._sample_parser = None
+        self._video_paths_map = None
+        self._labels_map = None
+        self._uuids = None
+        self._iter_uuids = None
+        self._num_samples = None
+        self._has_labels = False
+
+    def __iter__(self):
+        self._iter_uuids = iter(self._uuids)
+        return self
+
+    def __len__(self):
+        return self._num_samples
+
+    def __next__(self):
+        uuid = next(self._iter_uuids)
+
+        video_path = self._video_paths_map[uuid]
+        labels = self._labels_map[uuid]
+
+        if self._has_labels:
+            self._sample_parser.with_sample((video_path, labels))
+            label = self._sample_parser.get_label()
+        else:
+            label = None
+
+        if self.compute_metadata:
+            video_metadata = self._sample_parser.get_video_metadata()
+        else:
+            video_metadata = None
+
+        return video_path, video_metadata, label, None
+
+    @property
+    def has_dataset_info(self):
+        return self._classes is not None
+
+    @property
+    def has_video_metadata(self):
+        return self.compute_metadata
+
+    @property
+    def label_cls(self):
+        return fol.VideoClassifications
+
+    @property
+    def frame_labels_cls(self):
+        return None
+
+    def setup(self):
+        self._sample_parser = FiftyOneVideoClassificationSampleParser(
+            compute_metadata=self.compute_metadata
+        )
+
+        self._video_paths_map = self._load_data_map(
+            self.data_path, ignore_exts=True, recursive=True
+        )
+
+        if self.labels_path is not None and os.path.isfile(self.labels_path):
+            labels = etas.load_json(self.labels_path)
+        else:
+            labels = {}
+
+        self._classes = labels.get("classes", None)
+        self._sample_parser.classes = self._classes
+        self._labels_map = labels.get("labels", {})
+        self._has_labels = any(self._labels_map.values())
+
+        uuids = sorted(self._labels_map.keys())
+        self._uuids = self._preprocess_list(uuids)
         self._num_samples = len(self._uuids)
 
     def get_dataset_info(self):

--- a/fiftyone/utils/data/parsers.py
+++ b/fiftyone/utils/data/parsers.py
@@ -1163,10 +1163,10 @@ class FiftyOneImageClassificationSampleParser(ImageClassificationSampleParser):
         super().__init__(classes=classes)
 
 
-class FiftyOneVideoClassificationSampleParser(LabeledVideoSampleParser):
-    """Parser for samples in FiftyOne video classification datasets.
+class FiftyOneTemporalDetectionSampleParser(LabeledVideoSampleParser):
+    """Parser for samples in FiftyOne temporal detection datasets.
 
-    See :ref:`this page <FiftyOneImageClassificationDataset-import>` for format
+    See :ref:`this page <FiftyOneTemporalDetectionDataset-import>` for format
     details.
 
     Args:
@@ -1191,7 +1191,7 @@ class FiftyOneVideoClassificationSampleParser(LabeledVideoSampleParser):
 
     @property
     def label_cls(self):
-        return fol.VideoClassifications
+        return fol.TemporalDetections
 
     @property
     def frame_labels_cls(self):
@@ -1213,7 +1213,7 @@ class FiftyOneVideoClassificationSampleParser(LabeledVideoSampleParser):
         if labels is None:
             return None
 
-        classifications = []
+        detections = []
         for label_dict in labels:
             label = label_dict["label"]
 
@@ -1225,7 +1225,7 @@ class FiftyOneVideoClassificationSampleParser(LabeledVideoSampleParser):
             confidence = label_dict.get("confidence", None)
 
             if "support" in label_dict:
-                classification = fol.VideoClassification(
+                detection = fol.TemporalDetection(
                     label=label,
                     support=label_dict["support"],
                     confidence=confidence,
@@ -1237,7 +1237,7 @@ class FiftyOneVideoClassificationSampleParser(LabeledVideoSampleParser):
                     metadata = fom.VideoMetadata.build_for(video_path)
                     self._current_metadata = metadata
 
-                classification = fol.VideoClassification.from_timestamps(
+                detection = fol.TemporalDetection.from_timestamps(
                     label_dict["timestamps"],
                     metadata=metadata,
                     label=label,
@@ -1245,13 +1245,13 @@ class FiftyOneVideoClassificationSampleParser(LabeledVideoSampleParser):
                 )
             else:
                 raise ValueError(
-                    "All video classification label dicts must have either "
+                    "All temporal detection label dicts must have either "
                     "`support` or `timestamps` populated"
                 )
 
-            classifications.append(classification)
+            detections.append(detection)
 
-        return fol.VideoClassifications(classifications=classifications)
+        return fol.TemporalDetections(detections=detections)
 
     def get_frame_labels(self):
         return None

--- a/tests/unittests/import_export_tests.py
+++ b/tests/unittests/import_export_tests.py
@@ -1583,14 +1583,14 @@ class VideoClassificationDatasetTests(VideoDatasetTests):
         )
 
 
-class TemporalVideoClassificationDatasetTests(VideoDatasetTests):
+class TemporalDetectionDatasetTests(VideoDatasetTests):
     def _make_dataset(self):
         samples = [
             fo.Sample(
                 filepath=self._new_video(),
-                predictions=fo.VideoClassifications(
-                    classifications=[
-                        fo.VideoClassification(
+                predictions=fo.TemporalDetections(
+                    detections=[
+                        fo.TemporalDetection(
                             label="cat", support=[1, 3], confidence=0.9
                         )
                     ]
@@ -1598,12 +1598,12 @@ class TemporalVideoClassificationDatasetTests(VideoDatasetTests):
             ),
             fo.Sample(
                 filepath=self._new_video(),
-                predictions=fo.VideoClassifications(
-                    classifications=[
-                        fo.VideoClassification(
+                predictions=fo.TemporalDetections(
+                    detections=[
+                        fo.TemporalDetection(
                             label="cat", support=[1, 4], confidence=0.95,
                         ),
-                        fo.VideoClassification(
+                        fo.TemporalDetection(
                             label="dog", support=[2, 5], confidence=0.95,
                         ),
                     ]
@@ -1618,7 +1618,7 @@ class TemporalVideoClassificationDatasetTests(VideoDatasetTests):
         return dataset
 
     @drop_datasets
-    def test_fiftyone_video_classification_dataset(self):
+    def test_fiftyone_temporal_detection_dataset(self):
         dataset = self._make_dataset()
 
         # Standard format
@@ -1627,17 +1627,17 @@ class TemporalVideoClassificationDatasetTests(VideoDatasetTests):
 
         dataset.export(
             export_dir=export_dir,
-            dataset_type=fo.types.FiftyOneVideoClassificationDataset,
+            dataset_type=fo.types.FiftyOneTemporalDetectionDataset,
         )
 
         dataset2 = fo.Dataset.from_dir(
             dataset_dir=export_dir,
-            dataset_type=fo.types.FiftyOneVideoClassificationDataset,
+            dataset_type=fo.types.FiftyOneTemporalDetectionDataset,
             label_field="predictions",
         )
 
-        supports = dataset.values("predictions.classifications.support")
-        supports2 = dataset2.values("predictions.classifications.support")
+        supports = dataset.values("predictions.detections.support")
+        supports2 = dataset2.values("predictions.detections.support")
 
         self.assertEqual(len(dataset), len(dataset2))
 
@@ -1653,18 +1653,18 @@ class TemporalVideoClassificationDatasetTests(VideoDatasetTests):
 
         dataset.export(
             export_dir=export_dir,
-            dataset_type=fo.types.FiftyOneVideoClassificationDataset,
+            dataset_type=fo.types.FiftyOneTemporalDetectionDataset,
             use_timestamps=True,
         )
 
         dataset2 = fo.Dataset.from_dir(
             dataset_dir=export_dir,
-            dataset_type=fo.types.FiftyOneVideoClassificationDataset,
+            dataset_type=fo.types.FiftyOneTemporalDetectionDataset,
             label_field="predictions",
         )
 
-        supports = dataset.values("predictions.classifications.support")
-        supports2 = dataset2.values("predictions.classifications.support")
+        supports = dataset.values("predictions.detections.support")
+        supports2 = dataset2.values("predictions.detections.support")
 
         self.assertEqual(len(dataset), len(dataset2))
 

--- a/tests/unittests/import_export_tests.py
+++ b/tests/unittests/import_export_tests.py
@@ -299,6 +299,30 @@ class ImageClassificationDatasetTests(ImageDatasetTests):
             dataset.count("predictions"), dataset2.count("predictions")
         )
 
+        # Include confidence
+
+        export_dir = self._new_dir()
+
+        dataset.export(
+            export_dir=export_dir,
+            dataset_type=fo.types.FiftyOneImageClassificationDataset,
+            include_confidence=True,
+        )
+
+        dataset2 = fo.Dataset.from_dir(
+            dataset_dir=export_dir,
+            dataset_type=fo.types.FiftyOneImageClassificationDataset,
+            label_field="predictions",
+        )
+
+        confs = dataset.values("predictions.confidence", missing_value=-1)
+        confs2 = dataset2.values("predictions.confidence", missing_value=-1)
+
+        self.assertEqual(len(dataset), len(dataset2))
+
+        # sorting is necessary because sample order is arbitrary
+        self.assertTrue(np.allclose(sorted(confs), sorted(confs2)))
+
         # Labels-only
 
         data_path = self.images_dir

--- a/tests/unittests/import_export_tests.py
+++ b/tests/unittests/import_export_tests.py
@@ -1559,6 +1559,98 @@ class VideoClassificationDatasetTests(VideoDatasetTests):
         )
 
 
+class TemporalVideoClassificationDatasetTests(VideoDatasetTests):
+    def _make_dataset(self):
+        samples = [
+            fo.Sample(
+                filepath=self._new_video(),
+                predictions=fo.VideoClassifications(
+                    classifications=[
+                        fo.VideoClassification(
+                            label="cat", support=[1, 3], confidence=0.9
+                        )
+                    ]
+                ),
+            ),
+            fo.Sample(
+                filepath=self._new_video(),
+                predictions=fo.VideoClassifications(
+                    classifications=[
+                        fo.VideoClassification(
+                            label="cat", support=[1, 4], confidence=0.95,
+                        ),
+                        fo.VideoClassification(
+                            label="dog", support=[2, 5], confidence=0.95,
+                        ),
+                    ]
+                ),
+            ),
+            fo.Sample(filepath=self._new_video()),
+        ]
+
+        dataset = fo.Dataset()
+        dataset.add_samples(samples)
+
+        return dataset
+
+    @drop_datasets
+    def test_fiftyone_video_classification_dataset(self):
+        dataset = self._make_dataset()
+
+        # Standard format
+
+        export_dir = self._new_dir()
+
+        dataset.export(
+            export_dir=export_dir,
+            dataset_type=fo.types.FiftyOneVideoClassificationDataset,
+        )
+
+        dataset2 = fo.Dataset.from_dir(
+            dataset_dir=export_dir,
+            dataset_type=fo.types.FiftyOneVideoClassificationDataset,
+            label_field="predictions",
+        )
+
+        supports = dataset.values("predictions.classifications.support")
+        supports2 = dataset2.values("predictions.classifications.support")
+
+        self.assertEqual(len(dataset), len(dataset2))
+
+        # sorting is necessary because sample order is arbitrary
+        self.assertListEqual(
+            sorted(supports, key=lambda k: (k is None, k)),
+            sorted(supports2, key=lambda k: (k is None, k)),
+        )
+
+        # Use timestamps
+
+        export_dir = self._new_dir()
+
+        dataset.export(
+            export_dir=export_dir,
+            dataset_type=fo.types.FiftyOneVideoClassificationDataset,
+            use_timestamps=True,
+        )
+
+        dataset2 = fo.Dataset.from_dir(
+            dataset_dir=export_dir,
+            dataset_type=fo.types.FiftyOneVideoClassificationDataset,
+            label_field="predictions",
+        )
+
+        supports = dataset.values("predictions.classifications.support")
+        supports2 = dataset2.values("predictions.classifications.support")
+
+        self.assertEqual(len(dataset), len(dataset2))
+
+        # sorting is necessary because sample order is arbitrary
+        self.assertListEqual(
+            sorted(supports, key=lambda k: (k is None, k)),
+            sorted(supports2, key=lambda k: (k is None, k)),
+        )
+
+
 class MultitaskVideoDatasetTests(VideoDatasetTests):
     def _make_dataset(self):
         sample1 = fo.Sample(filepath=self._new_video())


### PR DESCRIPTION
Adds a `TemporalDetection` label type that allows a label to be assigned a `[first, last]` frame support in a video.

Also adds support for importing/exporting datasets with `TemporalDetection(s)` label fields in a new `FiftyOneTemporalDetectionDataset` type with format documented at the bottom of this PR.

Finally, for consistency with other `FiftyOne*Dataset` formats, adds support for importing/exporting predictions confidences in `FiftyOneImageClassificationDataset` format. On the export side, this is on an opt-in basis by passing an optional `include_confidence=True` flag during export.

### Basic usage

```py
import fiftyone as fo

sample = fo.Sample(
    filepath="video1.mp4",
    events=fo.TemporalDetections(
        detections=[
            fo.TemporalDetection(label="party", support=[30, 60]),
            fo.TemporalDetection(label="meeting", support=[45, 75]),
        ]
    )
)

dataset = fo.Dataset()
dataset.add_sample(sample)

print(dataset)
print(dataset.first())
```

### Creation from timestamps

```py
import fiftyone as fo
import fiftyone.zoo as foz

dataset = foz.load_zoo_dataset(
    "quickstart-video",
    max_samples=1,
    shuffle=True,
    dataset_name=fo.get_default_dataset_name()
)
dataset.compute_metadata()

# Create two events from timestamps (in seconds)
sample = dataset.first()
event1 = fo.TemporalDetection.from_timestamps(
    [1, 2], label="party", sample=sample
)
event2 = fo.TemporalDetection.from_timestamps(
    [1.5, 2.5], label="meeting", sample=sample
)
sample["events"] = fo.TemporalDetections(detections=[event1, event2])
sample.save()

print(dataset)
print(dataset.first())
```

### FiftyOneTemporalDetectionDataset format

<img width="832" alt="Screen Shot 2021-10-02 at 11 25 25 AM" src="https://user-images.githubusercontent.com/25985824/135722951-1d8f7c13-25ea-40ac-9cea-43f15c58750f.png">
