### PR TITLE
Docs formatting tweaks

### DIFF
--- a/docs/source/integrations/coco.rst
+++ b/docs/source/integrations/coco.rst
@@ -112,8 +112,8 @@ The following parameters are available to configure partial downloads of both
 COCO-2014 and COCO-2017 by passing them to
 :func:`load_zoo_dataset() <fiftyone.zoo.datasets.load_zoo_dataset>`:
 
--   **split** and **splits**: a string or list of strings, respectively,
-    specifying the splits to load. Supported values are
+-   **split** (*None*) and **splits** (*None*): a string or list of strings,
+    respectively, specifying the splits to load. Supported values are
     ``("train", "test", "validation")``. If neither is provided, all available
     splits are loaded
 

--- a/docs/source/integrations/coco.rst
+++ b/docs/source/integrations/coco.rst
@@ -112,54 +112,55 @@ The following parameters are available to configure partial downloads of both
 COCO-2014 and COCO-2017 by passing them to
 :func:`load_zoo_dataset() <fiftyone.zoo.datasets.load_zoo_dataset>`:
 
--   ``split`` and ``splits``: a string or list of strings, respectively,
+-   **split** and **splits**: a string or list of strings, respectively,
     specifying the splits to load. Supported values are
-    ``("train", "test", "validation")``
+    ``("train", "test", "validation")``. If neither is provided, all available
+    splits are loaded
 
--   ``label_types``: a label type or list of label types to load. Supported
-    values are ``("detections", "segmentations")``. By default, only
-    "detections" are loaded
+-   **label_types** (*None*): a label type or list of label types to load.
+    Supported values are ``("detections", "segmentations")``. By default, only
+    detections are loaded
 
--   ``classes``: a string or list of strings specifying required classes to
-    load. If provided, only samples containing at least one instance of a
-    specified class will be loaded
+-   **classes** (*None*): a string or list of strings specifying required
+    classes to load. If provided, only samples containing at least one instance
+    of a specified class will be loaded
 
--   ``image_ids``: a list of specific image IDs to load. The IDs can be
-    specified either as ``<split>/<image-id>`` strings or ``<image-id>`` ints
-    of strings. Alternatively, you can provide the path to a TXT
+-   **image_ids** (*None*): a list of specific image IDs to load. The IDs can
+    be specified either as ``<split>/<image-id>`` strings or ``<image-id>``
+    ints of strings. Alternatively, you can provide the path to a TXT
     (newline-separated), JSON, or CSV file containing the list of image IDs to
     load in either of the first two formats
 
--   ``include_id``: whether to include the COCO ID of each sample in the loaded
-    labels. By default, this is False
+-   **include_id** (*False*): whether to include the COCO ID of each sample in
+    the loaded labels
 
--   ``include_license``: whether to include the COCO license of each sample in
-    the loaded labels, if available. The supported values are:
+-   **include_license** (*False*): whether to include the COCO license of each
+    sample in the loaded labels, if available. The supported values are:
 
     -   ``"False"`` (default): don't load the license
     -   ``True``/``"name"``: store the string license name
     -   ``"id"``: store the integer license ID
     -   ``"url"``: store the license URL
 
--   ``only_matching``: whether to only load labels that match the ``classes``
-    or ``attrs`` requirements that you provide (True), or to load all labels
-    for samples that match the requirements (False). By default, this is False
+-   **only_matching** (*False*): whether to only load labels that match the
+    ``classes`` or ``attrs`` requirements that you provide (True), or to load
+    all labels for samples that match the requirements (False)
 
--   ``num_workers``: the number of processes to use when downloading individual
-    images
+-   **num_workers** (*None*): the number of processes to use when downloading
+    individual images. By default, `multiprocessing.cpu_count()` is used
 
--   ``shuffle``: whether to randomly shuffle the order in which samples are
-    chosen for partial downloads
+-   **shuffle** (*False*): whether to randomly shuffle the order in which
+    samples are chosen for partial downloads
 
--   ``seed``: a random seed to use when shuffling
+-   **seed** (*None*): a random seed to use when shuffling
 
--   ``max_samples``: a maximum number of samples to load per split. If
+-   **max_samples** (*None*): a maximum number of samples to load per split. If
     ``label_types`` and/or ``classes`` are also specified, first priority will
     be given to samples that contain all of the specified label types and/or
     classes, followed by samples that contain at least one of the specified
     labels types or classes. The actual number of samples loaded may be less
     than this maximum value if the dataset does not contain sufficient samples
-    matching your requirements. By default, all matching samples are loaded
+    matching your requirements
 
 .. note::
 

--- a/docs/source/integrations/open_images.rst
+++ b/docs/source/integrations/open_images.rst
@@ -107,57 +107,59 @@ The following parameters are available to configure a partial download of Open
 Images V6 by passing them to
 :func:`load_zoo_dataset() <fiftyone.zoo.datasets.load_zoo_dataset>`:
 
--   ``split`` and ``splits``: a string or list of strings, respectively,
+-   **split** and **splits**: a string or list of strings, respectively,
     specifying the splits to load. Supported values are
-    ``("train", "test", "validation")``
+    ``("train", "test", "validation")``. If neither is provided, all available
+    splits are loaded
 
--   ``label_types``: a label type or list of label types to load. Supported
-    values are ``("detections", "classifications", "relationships", "segmentations")``.
-    By default, all labels are loaded
+-   **label_types** (*None*): a label type or list of label types to load.
+    Supported values are
+    ``("detections", "classifications", "relationships", "segmentations")``.
+    By default, all labels types are loaded
 
--   ``classes``: a string or list of strings specifying required classes to
-    load. If provided, only samples containing at least one instance of a
-    specified class will be loaded. You can use
+-   **classes** (*None*): a string or list of strings specifying required
+    classes to load. If provided, only samples containing at least one instance
+    of a specified class will be loaded. You can use
     :func:`get_classes() <fiftyone.utils.openimages.get_classes>` and
     :func:`get_segmentation_classes() <fiftyone.utils.openimages.get_segmentation_classes>`
     to see the available classes and segmentation classes, respectively
 
--   ``attrs``: a string or list of strings specifying required relationship
-    attributes to load. This parameter is only applicable if ``label_types``
-    contains ``"relationships"``. If provided, only samples containing at least
-    one instance of a specified attribute will be loaded. You can use
+-   **attrs** (*None*): a string or list of strings specifying required
+    relationship attributes to load. This parameter is only applicable if
+    ``label_types`` contains ``"relationships"``. If provided, only samples
+    containing at least one instance of a specified attribute will be loaded.
+    You can use
     :func:`get_attributes() <fiftyone.utils.openimages.get_attributes>`
     to see the available attributes
 
--   ``image_ids``: a list of specific image IDs to load. The IDs can be
-    specified either as ``<split>/<image-id>`` or ``<image-id>`` strings.
+-   **image_ids** (*None*): a list of specific image IDs to load. The IDs can
+    be specified either as ``<split>/<image-id>`` or ``<image-id>`` strings.
     Alternatively, you can provide the path to a TXT (newline-separated), JSON,
     or CSV file containing the list of image IDs to load in either of the first
     two formats
 
--   ``include_id``: whether to include the Open Images ID of each sample in the
-    loaded labels. By default, this is True
+-   **include_id** (*True*): whether to include the Open Images ID of each
+    sample in the loaded labels
 
--   ``only_matching``: whether to only load labels that match the ``classes``
-    or ``attrs`` requirements that you provide (True), or to load all labels
-    for samples that match the requirements (False). By default, this is False
+-   **only_matching** (*False*): whether to only load labels that match the
+    ``classes`` or ``attrs`` requirements that you provide (True), or to load
+    all labels for samples that match the requirements (False)
 
--   ``num_workers``: the number of processes to use when downloading individual
-    images
+-   **num_workers** (*None*): the number of processes to use when downloading
+    individual images. By default, `multiprocessing.cpu_count()` is used
 
--   ``shuffle``: whether to randomly shuffle the order in which samples are
-    chosen for partial downloads
+-   **shuffle** (*False*): whether to randomly shuffle the order in which
+    samples are chosen for partial downloads
 
--   ``seed``: a random seed to use when shuffling
+-   **seed** (*None*): a random seed to use when shuffling
 
--   ``max_samples``: a maximum number of samples to load per split. If
+-   **max_samples** (*None*): a maximum number of samples to load per split. If
     ``label_types``, ``classes``, and/or ``attrs`` are also specified, first
     priority will be given to samples that contain all of the specified label
     types, classes, and/or attributes, followed by samples that contain at
     least one of the specified labels types or classes. The actual number of
     samples loaded may be less than this maximum value if the dataset does not
-    contain sufficient samples matching your requirements. By default, all
-    matching samples are loaded
+    contain sufficient samples matching your requirements
 
 .. note::
 

--- a/docs/source/integrations/open_images.rst
+++ b/docs/source/integrations/open_images.rst
@@ -107,8 +107,8 @@ The following parameters are available to configure a partial download of Open
 Images V6 by passing them to
 :func:`load_zoo_dataset() <fiftyone.zoo.datasets.load_zoo_dataset>`:
 
--   **split** and **splits**: a string or list of strings, respectively,
-    specifying the splits to load. Supported values are
+-   **split** (*None*) and **splits** (*None*): a string or list of strings,
+    respectively, specifying the splits to load. Supported values are
     ``("train", "test", "validation")``. If neither is provided, all available
     splits are loaded
 

--- a/docs/source/user_guide/dataset_zoo/datasets.rst
+++ b/docs/source/user_guide/dataset_zoo/datasets.rst
@@ -517,54 +517,55 @@ The following parameters are available to configure a partial download of
 COCO-2014 by passing them to
 :func:`load_zoo_dataset() <fiftyone.zoo.datasets.load_zoo_dataset>`:
 
--   ``split`` and ``splits``: a string or list of strings, respectively,
+-   **split** and **splits**: a string or list of strings, respectively,
     specifying the splits to load. Supported values are
-    ``("train", "test", "validation")``
+    ``("train", "test", "validation")``. If neither is provided, all available
+    splits are loaded
 
--   ``label_types``: a label type or list of label types to load. Supported
-    values are ``("detections", "segmentations")``. By default, only
-    "detections" are loaded
+-   **label_types** (*None*): a label type or list of label types to load.
+    Supported values are ``("detections", "segmentations")``. By default, only
+    detections are loaded
 
--   ``classes``: a string or list of strings specifying required classes to
-    load. If provided, only samples containing at least one instance of a
-    specified class will be loaded
+-   **classes** (*None*): a string or list of strings specifying required
+    classes to load. If provided, only samples containing at least one instance
+    of a specified class will be loaded
 
--   ``image_ids``: a list of specific image IDs to load. The IDs can be
-    specified either as ``<split>/<image-id>`` strings or ``<image-id>`` ints
-    of strings. Alternatively, you can provide the path to a TXT
+-   **image_ids** (*None*): a list of specific image IDs to load. The IDs can
+    be specified either as ``<split>/<image-id>`` strings or ``<image-id>``
+    ints of strings. Alternatively, you can provide the path to a TXT
     (newline-separated), JSON, or CSV file containing the list of image IDs to
     load in either of the first two formats
 
--   ``include_id``: whether to include the COCO ID of each sample in the loaded
-    labels. By default, this is False
+-   **include_id** (*False*): whether to include the COCO ID of each sample in
+    the loaded labels
 
--   ``include_license``: whether to include the COCO license of each sample in
-    the loaded labels, if available. The supported values are:
+-   **include_license** (*False*): whether to include the COCO license of each
+    sample in the loaded labels, if available. The supported values are:
 
     -   ``"False"`` (default): don't load the license
     -   ``True``/``"name"``: store the string license name
     -   ``"id"``: store the integer license ID
     -   ``"url"``: store the license URL
 
--   ``only_matching``: whether to only load labels that match the ``classes``
-    or ``attrs`` requirements that you provide (True), or to load all labels
-    for samples that match the requirements (False). By default, this is False
+-   **only_matching** (*False*): whether to only load labels that match the
+    ``classes`` or ``attrs`` requirements that you provide (True), or to load
+    all labels for samples that match the requirements (False)
 
--   ``num_workers``: the number of processes to use when downloading individual
-    images
+-   **num_workers** (*None*): the number of processes to use when downloading
+    individual images. By default, `multiprocessing.cpu_count()` is used
 
--   ``shuffle``: whether to randomly shuffle the order in which samples are
-    chosen for partial downloads
+-   **shuffle** (*False*): whether to randomly shuffle the order in which
+    samples are chosen for partial downloads
 
--   ``seed``: a random seed to use when shuffling
+-   **seed** (*None*): a random seed to use when shuffling
 
--   ``max_samples``: a maximum number of samples to load per split. If
+-   **max_samples** (*None*): a maximum number of samples to load per split. If
     ``label_types`` and/or ``classes`` are also specified, first priority will
     be given to samples that contain all of the specified label types and/or
     classes, followed by samples that contain at least one of the specified
     labels types or classes. The actual number of samples loaded may be less
     than this maximum value if the dataset does not contain sufficient samples
-    matching your requirements. By default, all matching samples are loaded
+    matching your requirements
 
 .. note::
 
@@ -752,49 +753,55 @@ The following parameters are available to configure a partial download of
 COCO-2017 by passing them to
 :func:`load_zoo_dataset() <fiftyone.zoo.datasets.load_zoo_dataset>`:
 
--   ``split`` and ``splits``: a string or list of strings, respectively,
+-   **split** and **splits**: a string or list of strings, respectively,
     specifying the splits to load. Supported values are
-    ``("train", "test", "validation")``
+    ``("train", "test", "validation")``. If neither is provided, all available
+    splits are loaded
 
--   ``label_types``: a label type or list of label types to load. Supported
-    values are ``("detections", "segmentations")``. By default, only
-    "detections" are loaded
+-   **label_types** (*None*): a label type or list of label types to load.
+    Supported values are ``("detections", "segmentations")``. By default, only
+    detections are loaded
 
--   ``classes``: a string or list of strings specifying required classes to
-    load. If provided, only samples containing at least one instance of a
-    specified class will be loaded
+-   **classes** (*None*): a string or list of strings specifying required
+    classes to load. If provided, only samples containing at least one instance
+    of a specified class will be loaded
 
--   ``image_ids``: a list of specific image IDs to load. The IDs can be
-    specified either as ``<split>/<image-id>`` strings or ``<image-id>`` ints
-    of strings. Alternatively, you can provide the path to a TXT
+-   **image_ids** (*None*): a list of specific image IDs to load. The IDs can
+    be specified either as ``<split>/<image-id>`` strings or ``<image-id>``
+    ints of strings. Alternatively, you can provide the path to a TXT
     (newline-separated), JSON, or CSV file containing the list of image IDs to
     load in either of the first two formats
 
--   ``include_id``: whether to include the COCO ID of each sample in the loaded
-    labels. By default, this is False
+-   **include_id** (*False*): whether to include the COCO ID of each sample in
+    the loaded labels
 
--   ``include_license``: whether to include the COCO license of each sample in
-    the loaded labels. By default, this is False
+-   **include_license** (*False*): whether to include the COCO license of each
+    sample in the loaded labels, if available. The supported values are:
 
--   ``only_matching``: whether to only load labels that match the ``classes``
-    or ``attrs`` requirements that you provide (True), or to load all labels
-    for samples that match the requirements (False). By default, this is False
+    -   ``"False"`` (default): don't load the license
+    -   ``True``/``"name"``: store the string license name
+    -   ``"id"``: store the integer license ID
+    -   ``"url"``: store the license URL
 
--   ``num_workers``: the number of processes to use when downloading individual
-    images
+-   **only_matching** (*False*): whether to only load labels that match the
+    ``classes`` or ``attrs`` requirements that you provide (True), or to load
+    all labels for samples that match the requirements (False)
 
--   ``shuffle``: whether to randomly shuffle the order in which samples are
-    chosen for partial downloads
+-   **num_workers** (*None*): the number of processes to use when downloading
+    individual images. By default, `multiprocessing.cpu_count()` is used
 
--   ``seed``: a random seed to use when shuffling
+-   **shuffle** (*False*): whether to randomly shuffle the order in which
+    samples are chosen for partial downloads
 
--   ``max_samples``: a maximum number of samples to load per split. If
+-   **seed** (*None*): a random seed to use when shuffling
+
+-   **max_samples** (*None*): a maximum number of samples to load per split. If
     ``label_types`` and/or ``classes`` are also specified, first priority will
     be given to samples that contain all of the specified label types and/or
     classes, followed by samples that contain at least one of the specified
     labels types or classes. The actual number of samples loaded may be less
     than this maximum value if the dataset does not contain sufficient samples
-    matching your requirements. By default, all matching samples are loaded
+    matching your requirements
 
 .. note::
 
@@ -1442,57 +1449,59 @@ The following parameters are available to configure a partial download of Open
 Images V6 by passing them to
 :func:`load_zoo_dataset() <fiftyone.zoo.datasets.load_zoo_dataset>`:
 
--   ``split`` and ``splits``: a string or list of strings, respectively,
+-   **split** and **splits**: a string or list of strings, respectively,
     specifying the splits to load. Supported values are
-    ``("train", "test", "validation")``
+    ``("train", "test", "validation")``. If neither is provided, all available
+    splits are loaded
 
--   ``label_types``: a label type or list of label types to load. Supported
-    values are ``("detections", "classifications", "relationships", "segmentations")``.
-    By default, all labels are loaded
+-   **label_types** (*None*): a label type or list of label types to load.
+    Supported values are
+    ``("detections", "classifications", "relationships", "segmentations")``.
+    By default, all labels types are loaded
 
--   ``classes``: a string or list of strings specifying required classes to
-    load. If provided, only samples containing at least one instance of a
-    specified class will be loaded. You can use
+-   **classes** (*None*): a string or list of strings specifying required
+    classes to load. If provided, only samples containing at least one instance
+    of a specified class will be loaded. You can use
     :func:`get_classes() <fiftyone.utils.openimages.get_classes>` and
     :func:`get_segmentation_classes() <fiftyone.utils.openimages.get_segmentation_classes>`
     to see the available classes and segmentation classes, respectively
 
--   ``attrs``: a string or list of strings specifying required relationship
-    attributes to load. This parameter is only applicable if ``label_types``
-    contains ``"relationships"``. If provided, only samples containing at least
-    one instance of a specified attribute will be loaded. You can use
+-   **attrs** (*None*): a string or list of strings specifying required
+    relationship attributes to load. This parameter is only applicable if
+    ``label_types`` contains ``"relationships"``. If provided, only samples
+    containing at least one instance of a specified attribute will be loaded.
+    You can use
     :func:`get_attributes() <fiftyone.utils.openimages.get_attributes>`
     to see the available attributes
 
--   ``image_ids``: a list of specific image IDs to load. The IDs can be
-    specified either as ``<split>/<image-id>`` or ``<image-id>`` strings.
+-   **image_ids** (*None*): a list of specific image IDs to load. The IDs can
+    be specified either as ``<split>/<image-id>`` or ``<image-id>`` strings.
     Alternatively, you can provide the path to a TXT (newline-separated), JSON,
     or CSV file containing the list of image IDs to load in either of the first
     two formats
 
--   ``include_id``: whether to include the Open Images ID of each sample in the
-    loaded labels. By default, this is True
+-   **include_id** (*True*): whether to include the Open Images ID of each
+    sample in the loaded labels
 
--   ``only_matching``: whether to only load labels that match the ``classes``
-    or ``attrs`` requirements that you provide (True), or to load all labels
-    for samples that match the requirements (False). By default, this is False
+-   **only_matching** (*False*): whether to only load labels that match the
+    ``classes`` or ``attrs`` requirements that you provide (True), or to load
+    all labels for samples that match the requirements (False)
 
--   ``num_workers``: the number of processes to use when downloading individual
-    images
+-   **num_workers** (*None*): the number of processes to use when downloading
+    individual images. By default, `multiprocessing.cpu_count()` is used
 
--   ``shuffle``: whether to randomly shuffle the order in which samples are
-    chosen for partial downloads
+-   **shuffle** (*False*): whether to randomly shuffle the order in which
+    samples are chosen for partial downloads
 
--   ``seed``: a random seed to use when shuffling
+-   **seed** (*None*): a random seed to use when shuffling
 
--   ``max_samples``: a maximum number of samples to load per split. If
+-   **max_samples** (*None*): a maximum number of samples to load per split. If
     ``label_types``, ``classes``, and/or ``attrs`` are also specified, first
     priority will be given to samples that contain all of the specified label
     types, classes, and/or attributes, followed by samples that contain at
     least one of the specified labels types or classes. The actual number of
     samples loaded may be less than this maximum value if the dataset does not
-    contain sufficient samples matching your requirements. By default, all
-    matching samples are loaded
+    contain sufficient samples matching your requirements
 
 .. note::
 

--- a/docs/source/user_guide/dataset_zoo/datasets.rst
+++ b/docs/source/user_guide/dataset_zoo/datasets.rst
@@ -517,8 +517,8 @@ The following parameters are available to configure a partial download of
 COCO-2014 by passing them to
 :func:`load_zoo_dataset() <fiftyone.zoo.datasets.load_zoo_dataset>`:
 
--   **split** and **splits**: a string or list of strings, respectively,
-    specifying the splits to load. Supported values are
+-   **split** (*None*) and **splits** (*None*): a string or list of strings,
+    respectively, specifying the splits to load. Supported values are
     ``("train", "test", "validation")``. If neither is provided, all available
     splits are loaded
 
@@ -753,8 +753,8 @@ The following parameters are available to configure a partial download of
 COCO-2017 by passing them to
 :func:`load_zoo_dataset() <fiftyone.zoo.datasets.load_zoo_dataset>`:
 
--   **split** and **splits**: a string or list of strings, respectively,
-    specifying the splits to load. Supported values are
+-   **split** (*None*) and **splits** (*None*): a string or list of strings,
+    respectively, specifying the splits to load. Supported values are
     ``("train", "test", "validation")``. If neither is provided, all available
     splits are loaded
 
@@ -1449,8 +1449,8 @@ The following parameters are available to configure a partial download of Open
 Images V6 by passing them to
 :func:`load_zoo_dataset() <fiftyone.zoo.datasets.load_zoo_dataset>`:
 
--   **split** and **splits**: a string or list of strings, respectively,
-    specifying the splits to load. Supported values are
+-   **split** (*None*) and **splits** (*None*): a string or list of strings,
+    respectively, specifying the splits to load. Supported values are
     ``("train", "test", "validation")``. If neither is provided, all available
     splits are loaded
 


### PR DESCRIPTION
We document the parameters that can be passed to `load_zoo_dataset()` for the COCO and Open Images datasets in a couple places in the docs. We do this because:
- The possible parameters are defined in a few different classes and thus linking directly to any one class doesn't fully cover the options
- These two datasets are quite popular, so we want to minimize friction in learning how to download and start using them

This PR switches from ``monospace``-style formatting to **bold** (*default*) style formatting, for consistency with how function arguments are rendered in the actual API docs. This visually helps make the parameters more readable, I think.