### PR TITLE
Facet optimization

### DIFF
--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -6232,8 +6232,9 @@ class SampleCollection(object):
 
         # Run faceted aggregations
         if facet_aggs:
-            pipelines = self._build_faceted_pipeline(facet_aggs)
-            facet_keys = list(pipelines)
+            pipelines = self._build_faceted_pipelines(facet_aggs)
+            facet_keys = list(pipelines.keys())
+
             result_list = foo.aggregate(
                 self._dataset._sample_collection,
                 [pipelines[idx] for idx in facet_keys],
@@ -6261,7 +6262,7 @@ class SampleCollection(object):
         results = [None] * len(aggregations)
 
         if facet_aggs:
-            pipelines = self._build_faceted_pipeline(facet_aggs)
+            pipelines = self._build_faceted_pipelines(facet_aggs)
             facet_keys = list(pipelines)
             collection = foo.get_async_db_conn()[
                 self._dataset._sample_collection_name
@@ -6324,7 +6325,7 @@ class SampleCollection(object):
 
         return pipeline, attach_frames
 
-    def _build_faceted_pipeline(self, aggs_map):
+    def _build_faceted_pipelines(self, aggs_map):
         pipelines = {}
         for idx, aggregation in aggs_map.items():
             pipelines[str(idx)] = self._pipeline(

--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -6234,10 +6234,11 @@ class SampleCollection(object):
         if facet_aggs:
             pipelines = self._build_faceted_pipeline(facet_aggs)
             facet_keys = list(pipelines)
+            result_list = self._aggregate(
+                [pipelines[idx] for idx in facet_keys]
+            )
 
-            result = [
-                self._aggregate(pipeline) for idx, _ in enumerate(facet_keys)
-            ]
+            result = {idx: result_list[i] for i, idx in enumerate(facet_keys)}
 
             self._parse_faceted_results(facet_aggs, result, results)
 
@@ -6320,14 +6321,10 @@ class SampleCollection(object):
     def _build_faceted_pipeline(self, aggs_map):
         pipelines = {}
         for idx, aggregation in aggs_map.items():
-            needs_frames = aggregation._needs_frames(self)
-            pipelines[str(idx)] = {
-                "attach_frames": needs_frames,
-                "pipeline": self._pipeline(
-                    pipeline=aggregation.to_mongo(self),
-                    attach_frames=needs_frames,
-                ),
-            }
+            pipelines[str(idx)] = self._pipeline(
+                pipeline=aggregation.to_mongo(self),
+                attach_frames=aggregation._needs_frames(self),
+            )
 
         return pipelines
 

--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -6263,7 +6263,8 @@ class SampleCollection(object):
 
         if facet_aggs:
             pipelines = self._build_faceted_pipelines(facet_aggs)
-            facet_keys = list(pipelines)
+            facet_keys = list(pipelines.keys())
+
             collection = foo.get_async_db_conn()[
                 self._dataset._sample_collection_name
             ]

--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -6234,8 +6234,9 @@ class SampleCollection(object):
         if facet_aggs:
             pipelines = self._build_faceted_pipeline(facet_aggs)
             facet_keys = list(pipelines)
-            result_list = self._aggregate(
-                [pipelines[idx] for idx in facet_keys]
+            result_list = foo.aggregate(
+                self._dataset._sample_collection,
+                [pipelines[idx] for idx in facet_keys],
             )
 
             result = {idx: result_list[i] for i, idx in enumerate(facet_keys)}

--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -3941,7 +3941,6 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
         detach_frames=False,
         frames_only=False,
     ):
-
         if self.media_type != fom.VIDEO:
             attach_frames = False
             detach_frames = False
@@ -5535,63 +5534,3 @@ def _extract_archive_if_necessary(archive_path, cleanup):
         )
 
     return dataset_dir
-
-
-def _process_pipelines(media_type, frame_collection_name, pipelines, **kwargs):
-    if pipelines:
-        if isinstance(pipelines[0], dict):
-            pipelines = [pipelines]
-
-    _pipelines = []
-    for pipeline in pipelines:
-        _process_pipeline(**pipeline)
-
-
-def _process_pipeline(media_type, frame_collection_name, pipeline):
-    if media_type != fom.VIDEO:
-        attach_frames = False
-        detach_frames = False
-        frames_only = False
-
-    if not attach_frames:
-        detach_frames = False
-
-    if frames_only:
-        attach_frames = True
-
-    if attach_frames:
-        _pipeline = [
-            {
-                "$lookup": {
-                    "from": frame_collection_name,
-                    "let": {"sample_id": "$_id"},
-                    "pipeline": [
-                        {
-                            "$match": {
-                                "$expr": {
-                                    "$eq": ["$$sample_id", "$_sample_id"]
-                                }
-                            }
-                        },
-                        {"$sort": {"frame_number": 1}},
-                    ],
-                    "as": "frames",
-                }
-            }
-        ]
-    else:
-        _pipeline = []
-
-    if pipeline is not None:
-        _pipeline += pipeline
-
-    if detach_frames:
-        _pipeline += [{"$project": {"frames": False}}]
-    elif frames_only:
-        _pipeline += [
-            {"$project": {"frames": True}},
-            {"$unwind": "$frames"},
-            {"$replaceRoot": {"newRoot": "$frames"}},
-        ]
-
-    return _pipeline

--- a/fiftyone/core/odm/database.py
+++ b/fiftyone/core/odm/database.py
@@ -174,6 +174,8 @@ def aggregate(collection, pipelines):
 
 
 def _do_pooled_aggregate(collection, pipelines):
+    # @todo: MongoDB 5.0 supports snapshots which we can be used to make the
+    # results consistent, i.e. read from the same snapshot time
     pool = ThreadPool(processes=len(pipelines))
     result = pool.map(
         lambda pipeline: list(

--- a/fiftyone/core/odm/database.py
+++ b/fiftyone/core/odm/database.py
@@ -148,9 +148,9 @@ def aggregate(collection, pipelines):
     """
     pipelines = list(pipelines)
 
-    is_list = not pipelines or not isinstance(pipelines[0], dict)
+    is_list = pipelines and not isinstance(pipelines[0], dict)
     if not is_list:
-        pipelines = [pipelines]
+        pipelines = [pipelines or []]
 
     num_pipelines = len(pipelines)
 
@@ -160,11 +160,14 @@ def aggregate(collection, pipelines):
 
     pool = ThreadPool(processes=num_pipelines)
     result = pool.map(
-        lambda args: list(args[0].aggregate(args[1], allowDiskUse=True)),
-        zip(repeat(collection), pipelines),
+        lambda pipeline: list(
+            collection.aggregate(pipeline, allowDiskUse=True)
+        ),
+        pipelines,
         chunksize=1,
     )
     pool.close()
+
     return result
 
 

--- a/fiftyone/core/odm/database.py
+++ b/fiftyone/core/odm/database.py
@@ -146,11 +146,11 @@ def aggregate(collection, pipelines):
         pipelines: a MongoDB aggregation pipeline or a list of pipelines
 
     Returns:
-        -   if a single pipeline is provided, a
+        -   If a single pipeline is provided, a
             ``pymongo.command_cursor.CommandCursor`` or
             ``motor.motor_tornado.MotorCommandCursor``
 
-        -   if multiple pipelines are provided, it is assumed they are a list
+        -   If multiple pipelines are provided, it is assumed they are a list
             of facets that resolve to one document each, and the cursors are
             resolved and the document list is returned
     """
@@ -190,23 +190,19 @@ def _do_pooled_aggregate(collection, pipelines):
 
 async def _do_async_pooled_aggregate(collection, pipelines):
     global _async_client
-    client = _async_client
 
-    async with await client.start_session() as session:
-        results = await asyncio.gather(
+    async with await _async_client.start_session() as session:
+        return await asyncio.gather(
             *[
                 _do_async_aggregate(collection, pipeline, session)
                 for pipeline in pipelines
             ]
         )
 
-    return results
-
 
 async def _do_async_aggregate(collection, pipeline, session):
     cursor = collection.aggregate(pipeline, allowDiskUse=True, session=session)
-    result = await cursor.to_list(1)
-    return result
+    return await cursor.to_list(1)
 
 
 def get_db_client():

--- a/fiftyone/core/odm/database.py
+++ b/fiftyone/core/odm/database.py
@@ -148,20 +148,19 @@ def aggregate(collection, pipelines):
     """
     pipelines = list(pipelines)
 
-    is_list = not pipelines or isinstance(pipelines[0], dict)
+    is_list = not pipelines or not isinstance(pipelines[0], dict)
     if not is_list:
         pipelines = [pipelines]
 
     num_pipelines = len(pipelines)
+
     if num_pipelines == 1:
         result = collection.aggregate(pipelines[0], allowDiskUse=True)
-        return [result] if is_list else result
+        return [list(result)] if is_list else result
 
     pool = ThreadPool(processes=num_pipelines)
     result = pool.map(
-        lambda collection, pipeline: list(
-            collection.aggregate(pipeline, allowDiskUse=True)
-        ),
+        lambda args: list(args[0].aggregate(args[1], allowDiskUse=True)),
         zip(repeat(collection), pipelines),
         chunksize=1,
     )

--- a/fiftyone/core/odm/database.py
+++ b/fiftyone/core/odm/database.py
@@ -155,12 +155,15 @@ def aggregate(collection, pipelines):
 
     num_pipelines = len(pipelines)
 
+    if isinstance(collection, motor.motor_tornado.MotorCollection):
+        if num_pipelines == 1 and not is_list:
+            return collection.aggregate(pipelines[0], allowDiskUse=True)
+
+        return _do_async_pooled_aggregate(collection, pipelines)
+
     if num_pipelines == 1:
         result = collection.aggregate(pipelines[0], allowDiskUse=True)
         return [list(result)] if is_list else result
-
-    if isinstance(collection, motor.motor_tornado.MotorCollection):
-        return _do_async_pooled_aggregate(collection, pipelines)
 
     return _do_pooled_aggregate(collection, pipelines)
 

--- a/fiftyone/core/odm/database.py
+++ b/fiftyone/core/odm/database.py
@@ -144,13 +144,13 @@ def aggregate(collection, pipelines):
         pipelines: a MongoDB aggregation pipeline or a list of pipelines
 
     Returns:
-        if a single pipeline is provided, a
-        `pymongo.command_cursor.CommandCursor` or 
-        `motor.motor_tornado.MotorCommandCursor`
+        -   if a single pipeline is provided, a
+            `pymongo.command_cursor.CommandCursor` or
+            `motor.motor_tornado.MotorCommandCursor`
 
-        if multiple pipelines are provided, it is assumed it is a list of
-        facets that resolve to one document each, and the cursors are resolved
-        and the document list is returned
+        -   if multiple pipelines are provided, it is assumed they are a list
+            of facets that resolve to one document each, and the cursors are
+            resolved and the document list is returned
     """
     pipelines = list(pipelines)
 

--- a/fiftyone/core/odm/database.py
+++ b/fiftyone/core/odm/database.py
@@ -174,8 +174,8 @@ def aggregate(collection, pipelines):
 
 
 def _do_pooled_aggregate(collection, pipelines):
-    # @todo: MongoDB 5.0 supports snapshots which we can be used to make the
-    # results consistent, i.e. read from the same snapshot time
+    # @todo: MongoDB 5.0 supports snapshots which can be used to make the
+    # results consistent, i.e. read from the same point in time
     pool = ThreadPool(processes=len(pipelines))
     result = pool.map(
         lambda pipeline: list(

--- a/fiftyone/core/odm/database.py
+++ b/fiftyone/core/odm/database.py
@@ -188,8 +188,8 @@ async def _do_async_aggregate(collection, pipeline, session):
 async def _do_async_pooled_aggregate(collection, pipelines):
     global _async_client
     client = _async_client
-    with client.start_session() as session:
-        results = asyncio.gather(
+    async with await client.start_session() as session:
+        results = await asyncio.gather(
             *[
                 _do_async_aggregate(collection, pipeline, session)
                 for pipeline in pipelines

--- a/fiftyone/core/odm/database.py
+++ b/fiftyone/core/odm/database.py
@@ -141,11 +141,16 @@ def aggregate(collection, pipelines):
     Args:
         collection: a `pymongo.collection.Collection` or
             `motor.motor_tornado.MotorCollection`
-        pipeline: a MongoDB aggregation pipeline
+        pipelines: a MongoDB aggregation pipeline or a list of pipelines
 
     Returns:
-        a `pymongo.command_cursor.CommandCursor` or
+        if a single pipeline is provided, a
+        `pymongo.command_cursor.CommandCursor` or 
         `motor.motor_tornado.MotorCommandCursor`
+
+        if multiple pipelines are provided, it is assumed it is a list of
+        facets that resolve to one document each, and the cursors are resolved
+        and the document list is returned
     """
     pipelines = list(pipelines)
 

--- a/fiftyone/server/main.py
+++ b/fiftyone/server/main.py
@@ -730,8 +730,7 @@ class StateHandler(tornado.websocket.WebSocketHandler):
             sample = []
         else:
             (_, tag_aggs,) = fos.DatasetStatistics.get_label_aggregations(view)
-            results = await view.aggregate(
-                StateHandler.sample_collection(),
+            results = await view._async_aggregate(
                 [foa.Distinct("tags")] + tag_aggs,
             )
             sample = results[0]
@@ -761,9 +760,7 @@ class StateHandler(tornado.websocket.WebSocketHandler):
 
         aggregations = fos.DatasetStatistics(view, filters).aggregations
 
-        results = await view.aggregate(
-            aggregations, StateHandler.sample_collection()
-        )
+        results = await view._async_aggregate(aggregations)
 
         data = []
         for agg, result in zip(aggregations, results):
@@ -887,9 +884,7 @@ class StateHandler(tornado.websocket.WebSocketHandler):
                 count_aggs,
                 tag_aggs,
             ) = fos.DatasetStatistics.get_label_aggregations(view)
-            results = await view.aggregate(
-                count_aggs + tag_aggs, StateHandler.sample_collection()
-            )
+            results = await view._async_aggregate(count_aggs + tag_aggs)
 
             count = sum(results[: len(count_aggs)])
             tags = defaultdict(int)
@@ -1005,9 +1000,7 @@ class StateHandler(tornado.websocket.WebSocketHandler):
             view = get_extended_view(view, filters)
 
             aggregations = fos.DatasetStatistics(view, filters).aggregations
-            results = await view.aggregate(
-                aggregations, StateHandler.sample_collection()
-            )
+            results = await view._async_aggregate(aggregations)
 
             for agg, result in zip(aggregations, results):
                 data.append(
@@ -1059,9 +1052,8 @@ class StateHandler(tornado.websocket.WebSocketHandler):
 
         sort_by = "count" if count else "_id"
 
-        count, first = await view.aggregate(
-            foa.CountValues(path, _first=limit, _asc=asc, _sort_by=sort_by),
-            StateHandler.sample_collection(),
+        count, first = await view._async_aggregate(
+            foa.CountValues(path, _first=limit, _asc=asc, _sort_by=sort_by)
         )
 
         message = {
@@ -1083,7 +1075,6 @@ class StateHandler(tornado.websocket.WebSocketHandler):
         """
         state = fos.StateDescription.from_dict(StateHandler.state)
         results = None
-        col = cls.sample_collection()
         if state.view is not None:
             view = state.view
         elif state.dataset is not None:
@@ -1104,7 +1095,7 @@ class StateHandler(tornado.websocket.WebSocketHandler):
                 return path
 
             aggs, fields = _count_values(filter, view)
-            results = await _gather_results(col, aggs, fields, view)
+            results = await _gather_results(aggs, fields, view)
 
         elif group == "labels" and results is None:
 
@@ -1117,13 +1108,13 @@ class StateHandler(tornado.websocket.WebSocketHandler):
                 return path
 
             aggs, fields = _count_values(filter, view)
-            results = await _gather_results(col, aggs, fields, view)
+            results = await _gather_results(aggs, fields, view)
 
         elif group == "sample tags" and results is None:
             aggs = [foa.CountValues("tags")]
             try:
                 fields = [view.get_field_schema()["tags"]]
-                results = await _gather_results(col, aggs, fields, view)
+                results = await _gather_results(aggs, fields, view)
             except:
                 results = []
 
@@ -1145,11 +1136,11 @@ class StateHandler(tornado.websocket.WebSocketHandler):
             aggs, fields = _count_values(filter, view)
 
             hist_aggs, hist_fields, ticks = await _numeric_histograms(
-                col, view, view.get_field_schema()
+                view, view.get_field_schema()
             )
             aggs.extend(hist_aggs)
             fields.extend(hist_fields)
-            results = await _gather_results(col, aggs, fields, view, ticks)
+            results = await _gather_results(aggs, fields, view, ticks)
 
         results = sorted(results, key=lambda i: i["name"])
         _write_message(
@@ -1280,8 +1271,8 @@ def _parse_count_values(result, field):
     )
 
 
-async def _gather_results(collection, aggs, fields, view, ticks=None):
-    response = await view.aggregate(aggs, collection)
+async def _gather_results(aggs, fields, view, ticks=None):
+    response = await view._async_aggregate(aggs)
 
     sorters = {
         foa.HistogramValues: _parse_histogram_values,
@@ -1356,7 +1347,7 @@ def _numeric_bounds(paths):
     return [foa.Bounds(path) for path in paths]
 
 
-async def _numeric_histograms(collection, view, schema, prefix=""):
+async def _numeric_histograms(view, schema, prefix=""):
     paths = []
     fields = []
     numerics = (fof.IntField, fof.FloatField)
@@ -1369,7 +1360,7 @@ async def _numeric_histograms(collection, view, schema, prefix=""):
             fields.append(field)
 
     aggs = _numeric_bounds(paths)
-    bounds = await view.aggregate(aggs, collection)
+    bounds = await view._async_aggregate(aggs)
     aggregations = []
     ticks = []
     for range_, field, path in zip(bounds, fields, paths):


### PR DESCRIPTION
Replaces `$facet` pipelines with logically equivalent multi-threaded aggregation pipelines. 

Facet pipelines in MongoDB run serially, which is not ideal. Moving facets into our own client-side parallelized aggregations leads to much better results.

### Threaded:
```py
from time import time
import fiftyone as fo
from fiftyone.core.state import DatasetStatistics as DS

bdd = fo.load_dataset("BDD")

start = time()
bdd.aggregate(DS(bdd).aggregations)
end = time()

print(end - start)
``` 

`develop`: 11.538496732711792
`facet-optimization`: 1.7972187995910645

### Async:
```py
from time import time

import asyncio

import fiftyone as fo
from fiftyone.core.state import DatasetStatistics as DS

bdd = fo.load_dataset("BDD")
loop = asyncio.get_event_loop()

start = time()
loop.run_until_complete(bdd._async_aggregate(DS(bdd).aggregations))
end = time()

loop.close()
print(end - start)
```

Relevant [reading](http://pauldone.blogspot.com/2018/02/parallel-mongodb-aggregation-facets.html)