### PR TITLE
Configurable session waiting

### DIFF
--- a/docs/source/cli/index.rst
+++ b/docs/source/cli/index.rst
@@ -112,7 +112,7 @@ Launch a FiftyOne quickstart.
       -a, --desktop         whether to launch a desktop App instance
       -w WAIT, --wait WAIT  the number of seconds to wait for a new App
                             connection before returning if all connections are
-                            lost. If negative, the session will serve forever,
+                            lost. If negative, the process will wait forever,
                             regardless of connections
 
 **Examples**
@@ -1049,7 +1049,7 @@ Launch the FiftyOne App.
       -a, --desktop         whether to launch a desktop App instance
       -w WAIT, --wait WAIT  the number of seconds to wait for a new App
                             connection before returning if all connections are
-                            lost. If negative, the session will serve forever,
+                            lost. If negative, the process will wait forever,
                             regardless of connections
 
 **Examples**
@@ -1118,7 +1118,7 @@ View datasets in the FiftyOne App without persisting them to the database.
       -a, --desktop         whether to launch a desktop App instance
       -w WAIT, --wait WAIT  the number of seconds to wait for a new App
                             connection before returning if all connections are
-                            lost. If negative, the session will serve forever,
+                            lost. If negative, the process will wait forever,
                             regardless of connections
       -k KEY=VAL [KEY=VAL ...], --kwargs KEY=VAL [KEY=VAL ...]
                             additional type-specific keyword arguments for

--- a/docs/source/cli/index.rst
+++ b/docs/source/cli/index.rst
@@ -98,7 +98,7 @@ Launch a FiftyOne quickstart.
 
 .. code-block:: text
 
-    fiftyone quickstart [-h] [-v] [-p PORT] [-r] [-a]
+    fiftyone quickstart [-h] [-v] [-p PORT] [-r] [-a] [-w WAIT]
 
 **Arguments**
 
@@ -110,6 +110,10 @@ Launch a FiftyOne quickstart.
       -p PORT, --port PORT  the port number to use
       -r, --remote          whether to launch a remote App session
       -a, --desktop         whether to launch a desktop App instance
+      -w WAIT, --wait WAIT  the number of seconds to wait for a new App
+                            connection before returning if all connections are
+                            lost. If negative, the session will serve forever,
+                            regardless of connections
 
 **Examples**
 
@@ -1029,7 +1033,7 @@ Launch the FiftyOne App.
 
 .. code-block:: text
 
-    fiftyone app launch [-h] [-p PORT] [-r] [-a] [NAME]
+    fiftyone app launch [-h] [-p PORT] [-r] [-a] [-w WAIT] [NAME]
 
 **Arguments**
 
@@ -1043,6 +1047,10 @@ Launch the FiftyOne App.
       -p PORT, --port PORT  the port number to use
       -r, --remote          whether to launch a remote App session
       -a, --desktop         whether to launch a desktop App instance
+      -w WAIT, --wait WAIT  the number of seconds to wait for a new App
+                            connection before returning if all connections are
+                            lost. If negative, the session will serve forever,
+                            regardless of connections
 
 **Examples**
 
@@ -1079,7 +1087,7 @@ View datasets in the FiftyOne App without persisting them to the database.
                       [-s SPLITS [SPLITS ...]] [--images-dir IMAGES_DIR]
                       [--images-patt IMAGES_PATT] [--videos-dir VIDEOS_DIR]
                       [--videos-patt VIDEOS_PATT] [-j JSON_PATH] [-p PORT]
-                      [-r] [-a] [-k KEY=VAL [KEY=VAL ...]]
+                      [-r] [-a] [-w WAIT] [-k KEY=VAL [KEY=VAL ...]]
 
 **Arguments**
 
@@ -1108,6 +1116,10 @@ View datasets in the FiftyOne App without persisting them to the database.
       -p PORT, --port PORT  the port number to use
       -r, --remote          whether to launch a remote App session
       -a, --desktop         whether to launch a desktop App instance
+      -w WAIT, --wait WAIT  the number of seconds to wait for a new App
+                            connection before returning if all connections are
+                            lost. If negative, the session will serve forever,
+                            regardless of connections
       -k KEY=VAL [KEY=VAL ...], --kwargs KEY=VAL [KEY=VAL ...]
                             additional type-specific keyword arguments for
                             `fiftyone.core.dataset.Dataset.from_dir()`

--- a/fiftyone/core/cli.py
+++ b/fiftyone/core/cli.py
@@ -142,12 +142,11 @@ class QuickstartCommand(Command):
             "--wait",
             metavar="WAIT",
             default=3,
-            type=int,
+            type=float,
             help=(
                 "the number of seconds to wait for a new App connection "
-                "before returning if all connections are lost. If 0 or a "
-                "negative value is provided, the session will server "
-                "forever. Not applicable to desktop App sessions"
+                "before returning if all connections are lost. If negative, "
+                "the session will serve forever, regardless of connections"
             ),
         )
 
@@ -1002,12 +1001,11 @@ class AppLaunchCommand(Command):
             "--wait",
             metavar="WAIT",
             default=3,
-            type=int,
+            type=float,
             help=(
                 "the number of seconds to wait for a new App connection "
-                "before returning if all connections are lost. If 0 or a "
-                "negative value is provided, the session will server "
-                "forever. Not applicable to desktop App sessions"
+                "before returning if all connections are lost. If negative, "
+                "the session will serve forever, regardless of connections"
             ),
         )
 
@@ -1037,11 +1035,7 @@ def _watch_session(session, wait):
         return
 
     try:
-        if session.desktop:
-            print("\nTo exit, close the App or press ctrl + c\n")
-        else:
-            print("\nTo exit, press ctrl + c\n")
-
+        print("\nTo exit, close the App or press ctrl + c\n")
         session.wait(wait)
     except KeyboardInterrupt:
         pass
@@ -1052,7 +1046,7 @@ def _wait():
 
     try:
         while True:
-            time.sleep(0.5)
+            time.sleep(10)
     except KeyboardInterrupt:
         pass
 
@@ -1170,6 +1164,18 @@ class AppViewCommand(Command):
             help="whether to launch a desktop App instance",
         )
         parser.add_argument(
+            "-w",
+            "--wait",
+            metavar="WAIT",
+            default=3,
+            type=float,
+            help=(
+                "the number of seconds to wait for a new App connection "
+                "before returning if all connections are lost. If negative, "
+                "the session will serve forever, regardless of connections"
+            ),
+        )
+        parser.add_argument(
             "-k",
             "--kwargs",
             nargs="+",
@@ -1178,19 +1184,6 @@ class AppViewCommand(Command):
             help=(
                 "additional type-specific keyword arguments for "
                 "`fiftyone.core.dataset.Dataset.from_dir()`"
-            ),
-        )
-        parser.add_argument(
-            "-w",
-            "--wait",
-            metavar="WAIT",
-            default=3,
-            type=int,
-            help=(
-                "the number of seconds to wait for a new App connection "
-                "before returning if all connections are lost. If 0 or a "
-                "negative value is provided, the session will server "
-                "forever. Not applicable to desktop App sessions"
             ),
         )
 

--- a/fiftyone/core/cli.py
+++ b/fiftyone/core/cli.py
@@ -146,7 +146,7 @@ class QuickstartCommand(Command):
             help=(
                 "the number of seconds to wait for a new App connection "
                 "before returning if all connections are lost. If negative, "
-                "the session will serve forever, regardless of connections"
+                "the process will wait forever, regardless of connections"
             ),
         )
 
@@ -1005,7 +1005,7 @@ class AppLaunchCommand(Command):
             help=(
                 "the number of seconds to wait for a new App connection "
                 "before returning if all connections are lost. If negative, "
-                "the session will serve forever, regardless of connections"
+                "the process will wait forever, regardless of connections"
             ),
         )
 
@@ -1172,7 +1172,7 @@ class AppViewCommand(Command):
             help=(
                 "the number of seconds to wait for a new App connection "
                 "before returning if all connections are lost. If negative, "
-                "the session will serve forever, regardless of connections"
+                "the process will wait forever, regardless of connections"
             ),
         )
         parser.add_argument(

--- a/fiftyone/core/cli.py
+++ b/fiftyone/core/cli.py
@@ -145,9 +145,9 @@ class QuickstartCommand(Command):
             type=int,
             help=(
                 "the number of seconds to wait for a new App connection "
-                " before returning if all connections are lost. If 0, the"
-                " session will server forever. Not applicable to desktop App"
-                " sessions"
+                "before returning if all connections are lost. If 0, the "
+                "session will server forever. Not applicable to desktop App "
+                "sessions"
             ),
         )
 
@@ -1005,9 +1005,9 @@ class AppLaunchCommand(Command):
             type=int,
             help=(
                 "the number of seconds to wait for a new App connection "
-                " before returning if all connections are lost. If 0, the"
-                " session will server forever. Not applicable to desktop App"
-                " sessions"
+                "before returning if all connections are lost. If 0, the "
+                "session will server forever. Not applicable to desktop App "
+                "sessions"
             ),
         )
 
@@ -1188,9 +1188,9 @@ class AppViewCommand(Command):
             type=int,
             help=(
                 "the number of seconds to wait for a new App connection "
-                " before returning if all connections are lost. If 0, the"
-                " session will server forever. Not applicable to desktop App"
-                " sessions"
+                "before returning if all connections are lost. If 0, the "
+                "session will server forever. Not applicable to desktop App "
+                "sessions"
             ),
         )
 

--- a/fiftyone/core/cli.py
+++ b/fiftyone/core/cli.py
@@ -141,7 +141,7 @@ class QuickstartCommand(Command):
             "-w",
             "--wait",
             metavar="WAIT",
-            default=1,
+            default=3,
             type=int,
             help=(
                 "the number of seconds to wait for a new App connection "
@@ -1001,7 +1001,7 @@ class AppLaunchCommand(Command):
             "-w",
             "--wait",
             metavar="WAIT",
-            default=1,
+            default=3,
             type=int,
             help=(
                 "the number of seconds to wait for a new App connection "
@@ -1184,7 +1184,7 @@ class AppViewCommand(Command):
             "-w",
             "--wait",
             metavar="WAIT",
-            default=1,
+            default=3,
             type=int,
             help=(
                 "the number of seconds to wait for a new App connection "

--- a/fiftyone/core/cli.py
+++ b/fiftyone/core/cli.py
@@ -137,6 +137,19 @@ class QuickstartCommand(Command):
             action="store_true",
             help="whether to launch a desktop App instance",
         )
+        parser.add_argument(
+            "-w",
+            "--wait",
+            metavar="WAIT",
+            default=1,
+            type=int,
+            help=(
+                "the number of seconds to wait for a new App connection "
+                " before returning if all connections are lost. If 0, the"
+                " session will server forever. Not applicable to desktop App"
+                " sessions"
+            ),
+        )
 
     @staticmethod
     def execute(parser, args):
@@ -150,7 +163,7 @@ class QuickstartCommand(Command):
             desktop=desktop,
         )
 
-        _watch_session(session)
+        _watch_session(session, args.wait)
 
 
 class ConfigCommand(Command):
@@ -984,6 +997,19 @@ class AppLaunchCommand(Command):
             action="store_true",
             help="whether to launch a desktop App instance",
         )
+        parser.add_argument(
+            "-w",
+            "--wait",
+            metavar="WAIT",
+            default=1,
+            type=int,
+            help=(
+                "the number of seconds to wait for a new App connection "
+                " before returning if all connections are lost. If 0, the"
+                " session will server forever. Not applicable to desktop App"
+                " sessions"
+            ),
+        )
 
     @staticmethod
     def execute(parser, args):
@@ -1002,10 +1028,10 @@ class AppLaunchCommand(Command):
             desktop=desktop,
         )
 
-        _watch_session(session)
+        _watch_session(session, args.wait)
 
 
-def _watch_session(session):
+def _watch_session(session, wait):
     # Automated tests may set `FIFTYONE_EXIT` so they can immediately exit
     if os.environ.get("FIFTYONE_EXIT", False):
         return
@@ -1016,7 +1042,7 @@ def _watch_session(session):
         else:
             print("\nTo exit, press ctrl + c\n")
 
-        session.wait()
+        session.wait(wait)
     except KeyboardInterrupt:
         pass
 
@@ -1154,6 +1180,19 @@ class AppViewCommand(Command):
                 "`fiftyone.core.dataset.Dataset.from_dir()`"
             ),
         )
+        parser.add_argument(
+            "-w",
+            "--wait",
+            metavar="WAIT",
+            default=1,
+            type=int,
+            help=(
+                "the number of seconds to wait for a new App connection "
+                " before returning if all connections are lost. If 0, the"
+                " session will server forever. Not applicable to desktop App"
+                " sessions"
+            ),
+        )
 
     @staticmethod
     def execute(parser, args):
@@ -1216,7 +1255,7 @@ class AppViewCommand(Command):
             desktop=desktop,
         )
 
-        _watch_session(session)
+        _watch_session(session, args.wait)
 
 
 class AppConnectCommand(Command):

--- a/fiftyone/core/cli.py
+++ b/fiftyone/core/cli.py
@@ -145,9 +145,9 @@ class QuickstartCommand(Command):
             type=int,
             help=(
                 "the number of seconds to wait for a new App connection "
-                "before returning if all connections are lost. If 0, the "
-                "session will server forever. Not applicable to desktop App "
-                "sessions"
+                "before returning if all connections are lost. If 0 or a "
+                "negative value is provided, the session will server "
+                "forever. Not applicable to desktop App sessions"
             ),
         )
 
@@ -1005,9 +1005,9 @@ class AppLaunchCommand(Command):
             type=int,
             help=(
                 "the number of seconds to wait for a new App connection "
-                "before returning if all connections are lost. If 0, the "
-                "session will server forever. Not applicable to desktop App "
-                "sessions"
+                "before returning if all connections are lost. If 0 or a "
+                "negative value is provided, the session will server "
+                "forever. Not applicable to desktop App sessions"
             ),
         )
 
@@ -1188,9 +1188,9 @@ class AppViewCommand(Command):
             type=int,
             help=(
                 "the number of seconds to wait for a new App connection "
-                "before returning if all connections are lost. If 0, the "
-                "session will server forever. Not applicable to desktop App "
-                "sessions"
+                "before returning if all connections are lost. If 0 or a "
+                "negative value is provided, the session will server "
+                "forever. Not applicable to desktop App sessions"
             ),
         )
 

--- a/fiftyone/core/session.py
+++ b/fiftyone/core/session.py
@@ -860,28 +860,28 @@ class Session(foc.HasClient):
     def wait(self, wait=3):
         """Blocks execution until the App is closed by the user.
 
-        Closing a desktop App will always exit the wait. For browser Apps, all
-        connected windows (tabs) must be closed.
+        For browser Apps, all connected windows (tabs) must be closed before
+        this method will unblock.
+
+        For desktop Apps, all positive ``wait`` values are equivalent;
+        execution will immediately unblock when the App is closed.
 
         Args:
             wait (3): the number of seconds to wait for a new App connection
-                before returning if all connections are lost. If `0` a
-                negavtive value is provided, the session will server forever,
-                regardless of the number of connections. Not applicable to
-                desktop App sessions
+                before returning if all connections are lost. If negative, the
+                session will serve forever, regardless of connections
         """
         if self._context != focx._NONE:
             logger.warning("Notebook sessions cannot wait")
             return
 
-        serve_forever = wait <= 0
-        if serve_forever:
-            wait = 10
-
         try:
-            if self._remote or not self._desktop:
+            if wait < 0:
+                while True:
+                    time.sleep(10)
+            elif self._remote or not self._desktop:
                 self._wait_closed = False
-                while not self._wait_closed or serve_forever:
+                while not self._wait_closed:
                     time.sleep(wait)
             else:
                 self._app_service.wait()

--- a/fiftyone/core/session.py
+++ b/fiftyone/core/session.py
@@ -869,7 +869,7 @@ class Session(foc.HasClient):
         Args:
             wait (3): the number of seconds to wait for a new App connection
                 before returning if all connections are lost. If negative, the
-                session will serve forever, regardless of connections
+                process will wait forever, regardless of connections
         """
         if self._context != focx._NONE:
             logger.warning("Notebook sessions cannot wait")

--- a/fiftyone/core/session.py
+++ b/fiftyone/core/session.py
@@ -857,14 +857,14 @@ class Session(foc.HasClient):
         """
         return fou.SetAttributes(self, _auto=False)
 
-    def wait(self, wait=1):
+    def wait(self, wait=3):
         """Blocks execution until the App is closed by the user.
 
         Closing a desktop App will always exit the wait. For browser Apps, all
         connected windows (tabs) must be closed.
 
         Args:
-            wait (1): the number of seconds to wait for a new App connection
+            wait (3): the number of seconds to wait for a new App connection
                 before returning if all connections are lost. If `0` a
                 negavtive value is provided, the session will server forever,
                 regardless of the number of connections. Not applicable to

--- a/fiftyone/core/session.py
+++ b/fiftyone/core/session.py
@@ -865,15 +865,16 @@ class Session(foc.HasClient):
 
         Args:
             wait (1): the number of seconds to wait for a new App connection
-                before returning if all connections are lost. If `0`, the
-                session will server forever, regardless of the number of
-                connections. Not applicable to desktop App sessions
+                before returning if all connections are lost. If `0` a
+                negavtive value is provided, the session will server forever,
+                regardless of the number of connections. Not applicable to
+                desktop App sessions
         """
         if self._context != focx._NONE:
             logger.warning("Notebook sessions cannot wait")
             return
 
-        serve_forever = wait == 0
+        serve_forever = wait <= 0
         if serve_forever:
             wait = 10
 

--- a/fiftyone/core/session.py
+++ b/fiftyone/core/session.py
@@ -857,21 +857,31 @@ class Session(foc.HasClient):
         """
         return fou.SetAttributes(self, _auto=False)
 
-    def wait(self):
+    def wait(self, wait=1):
         """Blocks execution until the App is closed by the user.
 
         Closing a desktop App will always exit the wait. For browser Apps, all
         connected windows (tabs) must be closed.
+
+        Args:
+            wait (1): the number of seconds to wait for a new App connection
+                before returning if all connections are lost. If `0`, the
+                session will server forever, regardless of the number of
+                connections. Not applicable to desktop App sessions
         """
         if self._context != focx._NONE:
             logger.warning("Notebook sessions cannot wait")
             return
 
+        serve_forever = wait == 0
+        if serve_forever:
+            wait = 10
+
         try:
             if self._remote or not self._desktop:
                 self._wait_closed = False
-                while not self._wait_closed:
-                    time.sleep(1)
+                while not self._wait_closed or serve_forever:
+                    time.sleep(wait)
             else:
                 self._app_service.wait()
         except KeyboardInterrupt:


### PR DESCRIPTION
Adds an integer keyword argument `wait` to `Session.wait()` and a corresponding `--wait` argument to relevant CLI commands.

`session.wait(-1)` permanently blocks execution until a keyboard interrupt, which is useful in cases where you are running an App session that you want to serve "forever".

`session.wait(10)` might be more appropriate than the default wait time (3 seconds) for remote sessions over slow internet connections, where refreshing the App via ctrl + R in the browser could take >3 seconds to re-establish a connection.

```py
import fiftyone as fo

dataset, session = fo.quickstart()

# ex: serve forever
session.wait(-1)

# ex: wait 10 seconds before continuing execution
session.wait(10)  
```