### PR TITLE
Release v0.13.2

### DIFF
--- a/fiftyone/core/odm/database.py
+++ b/fiftyone/core/odm/database.py
@@ -60,8 +60,9 @@ def establish_db_conn(config):
     global _db_service
     global _connection_kwargs
 
-    if os.environ.get("FIFTYONE_PRIVATE_DATABASE_PORT", None):
-        _connection_kwargs["port"] = config.database_uri
+    established_port = os.environ.get("FIFTYONE_PRIVATE_DATABASE_PORT", None)
+    if established_port is not None:
+        _connection_kwargs["port"] = int(established_port)
     if config.database_uri is not None:
         _connection_kwargs["host"] = config.database_uri
     elif _db_service is None:
@@ -72,7 +73,7 @@ def establish_db_conn(config):
             _db_service = fos.DatabaseService()
             port = _db_service.port
             _connection_kwargs["port"] = port
-            os.environ["FIFTYONE_PRIVATE_DATABASE_PORT"] = port
+            os.environ["FIFTYONE_PRIVATE_DATABASE_PORT"] = str(port)
 
         except fos.ServiceExecutableNotFound as error:
             if not fou.is_arm_mac():

--- a/fiftyone/core/odm/database.py
+++ b/fiftyone/core/odm/database.py
@@ -7,6 +7,7 @@ Database utilities.
 """
 from copy import copy
 import logging
+import multiprocessing
 import os
 
 from bson import json_util
@@ -24,10 +25,11 @@ import fiftyone.core.service as fos
 import fiftyone.core.utils as fou
 
 
-_client = None
-_async_client = None
-_connection_kwargs = {}
-_db_service = None
+if "_db_service" not in globals():
+    _client = None
+    _async_client = None
+    _connection_kwargs = {}
+    _db_service = None
 
 logger = logging.getLogger(__name__)
 
@@ -54,16 +56,12 @@ def establish_db_conn(config):
         RuntimeError: if the ``mongod`` found does not meet FiftyOne's
             requirements, or validation could not occur
     """
+    global _db_service
     global _connection_kwargs
 
     if config.database_uri is not None:
         _connection_kwargs["host"] = config.database_uri
-    else:
-        global _db_service
-
-        if _db_service is not None:
-            return
-
+    elif _db_service is None:
         if os.environ.get("FIFTYONE_DISABLE_SERVICES", False):
             return
 

--- a/fiftyone/core/service.py
+++ b/fiftyone/core/service.py
@@ -6,7 +6,6 @@ FiftyOne Services.
 |
 """
 import logging
-import multiprocessing
 import os
 import subprocess
 import sys
@@ -33,8 +32,7 @@ class ServiceException(Exception):
 
 
 class ServiceListenTimeout(ServiceException):
-    """Exception raised when a network-bound service fails to bind to a port.
-    """
+    """Exception raised when a network-bound service fails to bind to a port."""
 
     def __init__(self, name, port=None):
         self.name = name
@@ -71,13 +69,11 @@ class Service(object):
 
     def __init__(self):
         self._system = os.system
-        self._disabled = (
-            os.environ.get("FIFTYONE_DISABLE_SERVICES", False)
-            or multiprocessing.current_process().name != "MainProcess"
-            or (
-                os.environ.get("FIFTYONE_HEADLESS", False)
-                and not self.allow_headless
-            )
+        self._disabled = os.environ.get(
+            "FIFTYONE_DISABLE_SERVICES", False
+        ) or (
+            os.environ.get("FIFTYONE_HEADLESS", False)
+            and not self.allow_headless
         )
         self.child = None
         if not self._disabled:
@@ -457,4 +453,5 @@ class AppService(Service):
                 # override port 1212 used by "yarn dev" for hot-reloading
                 # (specifying port 0 doesn't work here)
                 env["PORT"] = str(self.server_port + 1)
+
         return env

--- a/fiftyone/core/uid.py
+++ b/fiftyone/core/uid.py
@@ -6,6 +6,7 @@ Utilities for usage analytics.
 |
 """
 import os
+import multiprocessing
 from socket import gaierror
 import threading
 import uuid
@@ -68,6 +69,9 @@ def log_import_if_allowed(test=False):
         return
 
     if os.environ.get("FIFTYONE_SERVER", None):
+        return
+
+    if multiprocessing.current_process().name != "MainProcess":
         return
 
     if test:

--- a/fiftyone/service/main.py
+++ b/fiftyone/service/main.py
@@ -39,6 +39,7 @@ import traceback
 
 import psutil
 
+os.environ["FIFTYONE_DISABLE_SERVICES"] = "1"
 from fiftyone.core.service import Service
 from fiftyone.service.ipc import IPCServer
 

--- a/tests/isolated/service_tests.py
+++ b/tests/isolated/service_tests.py
@@ -6,9 +6,8 @@ Service tests.
 |
 """
 from contextlib import contextmanager
+import multiprocessing
 import os
-import pickle
-import subprocess
 import sys
 import time
 import unittest
@@ -309,3 +308,12 @@ def test_db_cleanup():
             ip.run_code(_start_db_snippet)
             cur_datasets = set(ip.run_code(_list_datasets_snippet))
             assert cur_datasets == orig_datasets
+
+
+def test_multiprocessing():
+    def do_nothing(*_):
+        pass
+
+    with multiprocessing.Pool(1, do_nothing) as pool:
+        for _ in pool.imap_unordered(do_nothing, [None]):
+            pass


### PR DESCRIPTION
* Ensures a database service is only started if a `port` has not already been defined
* Skips import logging for subprocesses