### PR TITLE
[BUG] Fix importing COCO, VOC formats when exported from CVAT

### DIFF
--- a/fiftyone/utils/coco.py
+++ b/fiftyone/utils/coco.py
@@ -1121,10 +1121,10 @@ class COCOObject(object):
         Returns:
             a :class:`COCOObject`
         """
+        # Handles CVAT exported attributes
+        d.update(d.pop("attributes", {}))
+
         if extra_attrs is True:
-            if "attributes" in d:
-                d.update(d["attributes"])
-                del d["attributes"]
             return cls(**d)
 
         if etau.is_str(extra_attrs):
@@ -1135,13 +1135,7 @@ class COCOObject(object):
         else:
             attributes = {}
 
-        # Handles CVAT exported attributes
-        if "attributes" in d and extra_attrs:
-            for f in extra_attrs:
-                if attributes[f] is None:
-                    attributes[f] = d["attributes"].get(f, None)
-
-        args = dict(
+        return cls(
             id=d.get("id", None),
             image_id=d.get("image_id", None),
             category_id=d.get("category_id", None),
@@ -1151,9 +1145,8 @@ class COCOObject(object):
             score=d.get("score", None),
             area=d.get("area", None),
             iscrowd=d.get("iscrowd", None),
+            **attributes,
         )
-        args.update(attributes)
-        return cls(**args)
 
     def _get_label(self, classes):
         if classes:

--- a/fiftyone/utils/coco.py
+++ b/fiftyone/utils/coco.py
@@ -1122,6 +1122,9 @@ class COCOObject(object):
             a :class:`COCOObject`
         """
         if extra_attrs is True:
+            if "attributes" in d:
+                d.update(d["attributes"])
+                del d["attributes"]
             return cls(**d)
 
         if etau.is_str(extra_attrs):
@@ -1132,7 +1135,13 @@ class COCOObject(object):
         else:
             attributes = {}
 
-        return cls(
+        # Handles CVAT exported attributes
+        if "attributes" in d and extra_attrs:
+            for f in extra_attrs:
+                if attributes[f] is None:
+                    attributes[f] = d["attributes"].get(f, None)
+
+        args = dict(
             id=d.get("id", None),
             image_id=d.get("image_id", None),
             category_id=d.get("category_id", None),
@@ -1142,8 +1151,9 @@ class COCOObject(object):
             score=d.get("score", None),
             area=d.get("area", None),
             iscrowd=d.get("iscrowd", None),
-            **attributes,
         )
+        args.update(attributes)
+        return cls(**args)
 
     def _get_label(self, classes):
         if classes:

--- a/fiftyone/utils/voc.py
+++ b/fiftyone/utils/voc.py
@@ -513,11 +513,6 @@ class VOCObject(object):
         self.bndbox = bndbox
         self.attributes = attributes
 
-        # Handles CVAT exported attributes
-        cvat_attrs = self.attributes.pop("attributes", {}).pop("attribute", {})
-        cvat_attrs = {a["name"]: a["value"] for a in cvat_attrs}
-        self.attributes.update(cvat_attrs)
-
     @classmethod
     def from_annotation_dict(cls, d):
         """Creates a :class:`VOCObject` from a VOC annotation dict.
@@ -530,6 +525,12 @@ class VOCObject(object):
         """
         name = d["name"]
         bndbox = VOCBoundingBox.from_bndbox_dict(d["bndbox"])
+
+        # Handles CVAT exported attributes
+        cvat_attrs = d.pop("attributes", {}).pop("attribute", {})
+        cvat_attrs = {a["name"]: a["value"] for a in cvat_attrs}
+        d.update(cvat_attrs)
+
         attributes = {
             k: _parse_attribute(d[k])
             for k in set(d.keys()) - {"name", "bndbox"}

--- a/fiftyone/utils/voc.py
+++ b/fiftyone/utils/voc.py
@@ -535,7 +535,6 @@ class VOCObject(object):
             k: _parse_attribute(d[k])
             for k in set(d.keys()) - {"name", "bndbox"}
         }
-
         return cls(name, bndbox, **attributes)
 
     @classmethod
@@ -589,7 +588,6 @@ class VOCObject(object):
 
         if extra_attrs == True:
             attributes = self.attributes
-
         elif extra_attrs == False:
             attributes = {}
         else:

--- a/fiftyone/utils/voc.py
+++ b/fiftyone/utils/voc.py
@@ -794,16 +794,13 @@ def _parse_attribute(value):
     except:
         pass
 
-    try:
-        if value in {"True", "true"}:
-            return True
+    if value in {"True", "true"}:
+        return True
 
-        if value in {"False", "false"}:
-            return False
+    if value in {"False", "false"}:
+        return False
 
-        if value == "None":
-            return None
-    except:
-        pass
+    if value == "None":
+        return None
 
     return value


### PR DESCRIPTION
Exporting annotations from CVAT creates artifacts that slightly differ from existing formats. This PR updates existing importers to avoid errors and allow importing of attributes when exported from CVAT.

For example, the COCO format when exported from CVAT contains:
```json
        {
            "id": 34,
            "image_id": 9,
            "category_id": 2,
            "segmentation": [],
            "area": 6499.0,
            "bbox": [
                28.0,
                254.0,
                97.0,
                67.0
            ],
            "iscrowd": 0,
            "attributes": {
                "label_id": "5f452471ef00e6374aac53ca",
                "attribute:iscrowd": "0.0",
                "attribute:area": "4827.32605",
                "occluded": false
            }
        },
```

The Pascal VOC format contains:
```
<annotation>
  <folder></folder>
  <filename>000000.jpg</filename>
  <source>
    <database>Unknown</database>
    <annotation>Unknown</annotation>
    <image>Unknown</image>
  </source>
  <size>
    <width>640</width>
    <height>480</height>
    <depth></depth>
  </size>
  <segmented>0</segmented>
  <object>
    <name>bird</name>
    <occluded>0</occluded>
    <bndbox>
      <xmin>135.0</xmin>
      <ymin>2.0</ymin>
      <xmax>431.0</xmax>
      <ymax>455.0</ymax>
    </bndbox>
    <attributes>
      <attribute>
        <name>label_id</name>
        <value>5f452471ef00e6374aac53c8</value>
      </attribute>
      <attribute>
        <name>attribute:iscrowd</name>
        <value>0.0</value>
      </attribute>
      <attribute>
        <name>attribute:area</name>
        <value>73790.37944999996</value>
      </attribute>
    </attributes>
```

Loaded into Python, this becomes:
```python
attributes = {
    ....,
    "bndbox": ...,
    "attributes": {
        "attribute": [
            {
                "name": "label_id",
                "value": "5f452471ef00e6374aac53c8",
            }, ...
        ]
    }
}
```

* `YOLOv4Dataset` does not support attributes so it loads without issue
* CVAT does not export TF Records following the TF Object Detection API so `TFObjectDetectionDataset` is not relevant
