### PR TITLE
Fix image map keys when using subset/subdirectory in cvat dataset

### DIFF
--- a/fiftyone/utils/cvat.py
+++ b/fiftyone/utils/cvat.py
@@ -178,7 +178,16 @@ class CVATImageDatasetImporter(
             cvat_images = []
 
         self._info = info
-        self._cvat_images_map = {os.path.join(i.subset, i.name): i for i in cvat_images}
+
+        # use subset/name as the key if it exists, else just name
+        map = {}
+        for i in cvat_images:
+            if i.subset:
+                key = os.path.join(i.subset, i.name)
+            else:
+                key = i.name
+            map[key] = i
+        self._cvat_images_map = map
 
         filenames = set(self._cvat_images_map.keys())
 
@@ -1034,7 +1043,7 @@ class CVATImage(object):
         """
         id = d["@id"]
         name = d["@name"]
-        subset = d['@subset']
+        subset = d.get("@subset", None)
         width = int(d["@width"])
         height = int(d["@height"])
 

--- a/fiftyone/utils/cvat.py
+++ b/fiftyone/utils/cvat.py
@@ -178,7 +178,7 @@ class CVATImageDatasetImporter(
             cvat_images = []
 
         self._info = info
-        self._cvat_images_map = {i.name: i for i in cvat_images}
+        self._cvat_images_map = {os.path.join(i.subset, i.name): i for i in cvat_images}
 
         filenames = set(self._cvat_images_map.keys())
 
@@ -877,9 +877,11 @@ class CVATImage(object):
         polygons=None,
         polylines=None,
         points=None,
+        subset=None,
     ):
         self.id = id
         self.name = name
+        self.subset = subset
         self.width = width
         self.height = height
         self.boxes = boxes or []
@@ -1032,6 +1034,7 @@ class CVATImage(object):
         """
         id = d["@id"]
         name = d["@name"]
+        subset = d['@subset']
         width = int(d["@width"])
         height = int(d["@height"])
 
@@ -1060,6 +1063,7 @@ class CVATImage(object):
             polygons=polygons,
             polylines=polylines,
             points=points,
+            subset=subset,
         )
 
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

This simply includes the subset parameter of each image entry of a cvat dataset, in addition to its filename. The subset was already used in the _image_paths_map of the dataset, but not in the _cvat_images_map. This led to key errors when trying to retrieve an item.

This pull requests makes the _image_paths_map and _cvat_images_map consistent avoiding runtime errors when trying to read a cvat dataset with subdirectories.

## How is this patch tested? If it is not, please explain why.

This was tested on a local project.

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
