### PR TITLE
Adding missing zip to cityscapes docs

### DIFF
--- a/docs/source/release-notes.rst
+++ b/docs/source/release-notes.rst
@@ -20,7 +20,7 @@ App
 
 Core
 
-- Added support for providing compound sort criteria when usng the
+- Added support for providing compound sort criteria when using the
   :meth:`sort_by() <fiftyone.core.collections.SampleCollection.sort_by>` stage
 - Added support for configuring the wait time when using
   :meth:`Session.wait() <fiftyone.core.session.Session.wait>` to block

--- a/docs/source/user_guide/dataset_zoo/datasets.rst
+++ b/docs/source/user_guide/dataset_zoo/datasets.rst
@@ -407,9 +407,9 @@ The dataset is intended for:
 
         source_dir/
             leftImg8bit_trainvaltest.zip
-            gtFine_trainvaltest.zip         # optional
-            gtCoarse.zip                    # optional
-            gtBbox_cityPersons_trainval     # optional
+            gtFine_trainvaltest.zip             # optional
+            gtCoarse.zip                        # optional
+            gtBbox_cityPersons_trainval.zip     # optional
 
     You can register at https://www.cityscapes-dataset.com/register in order
     to get links to download the data.

--- a/fiftyone/zoo/datasets/base.py
+++ b/fiftyone/zoo/datasets/base.py
@@ -325,9 +325,9 @@ class CityscapesDataset(FiftyOneDataset):
 
         source_dir/
             leftImg8bit_trainvaltest.zip
-            gtFine_trainvaltest.zip         # optional
-            gtCoarse.zip                    # optional
-            gtBbox_cityPersons_trainval     # optional
+            gtFine_trainvaltest.zip             # optional
+            gtCoarse.zip                        # optional
+            gtBbox_cityPersons_trainval.zip     # optional
 
     You can register at https://www.cityscapes-dataset.com/register in order
     to get links to download the data.


### PR DESCRIPTION
Fixes a documentation bug discovered when resolving https://github.com/voxel51/fiftyone/issues/1252.