### PR TITLE
Limit stats results

### DIFF
--- a/app/packages/app/src/components/Distributions.tsx
+++ b/app/packages/app/src/components/Distributions.tsx
@@ -12,6 +12,7 @@ import { useMessageHandler, useSendMessage } from "../utils/hooks";
 import * as selectors from "../recoil/selectors";
 import { AGGS } from "../utils/labels";
 import { filterStages } from "./Filters/atoms";
+import { LIST_LIMIT } from "./Filters/StringFieldFilter.state";
 
 const Container = styled.div`
   ${scrollbarStyles}
@@ -81,6 +82,8 @@ const Distribution = ({ distribution }) => {
     key: prettify(key, false),
   }));
 
+  const hasMore = data.length >= LIST_LIMIT;
+
   const map = strData.reduce(
     (acc, cur) => ({
       ...acc,
@@ -91,7 +94,7 @@ const Distribution = ({ distribution }) => {
 
   return (
     <Container ref={ref}>
-      <Title>{name}</Title>
+      <Title>{`${name}${hasMore ? ` (first ${data.length})` : ""}`}</Title>
       <BarChart
         ref={container}
         height={height - 37}

--- a/fiftyone/core/aggregations.py
+++ b/fiftyone/core/aggregations.py
@@ -531,7 +531,7 @@ class CountValues(Aggregation):
             {"$group": {"_id": value, "count": {"$sum": 1}}},
         ]
 
-        if self._first:
+        if self._first is not None:
             sort = OrderedDict()
             limit = self._first
 

--- a/fiftyone/server/main.py
+++ b/fiftyone/server/main.py
@@ -1274,7 +1274,7 @@ def _parse_histogram_values(result, field):
 
 def _parse_count_values(result, field):
     return sorted(
-        [{"key": k, "count": v} for k, v in result.items()],
+        [{"key": k, "count": v} for k, v in result[1]],
         key=lambda i: i["count"],
         reverse=True,
     )
@@ -1347,7 +1347,9 @@ def _count_values(f, view):
                 continue
 
             fields.append(field)
-            aggregations.append(foa.CountValues("%s%s" % (prefix, path)))
+            aggregations.append(
+                foa.CountValues("%s%s" % (prefix, path), _first=200)
+            )
 
     return aggregations, fields
 

--- a/fiftyone/server/main.py
+++ b/fiftyone/server/main.py
@@ -1348,7 +1348,9 @@ def _count_values(f, view):
 
             fields.append(field)
             aggregations.append(
-                foa.CountValues("%s%s" % (prefix, path), _first=200)
+                foa.CountValues(
+                    "%s%s" % (prefix, path), _first=200, _asc=False
+                )
             )
 
     return aggregations, fields

--- a/fiftyone/server/main.py
+++ b/fiftyone/server/main.py
@@ -48,6 +48,11 @@ import fiftyone.server.utils as fosu
 
 
 db = foo.get_async_db_conn()
+_notebook_clients = {}
+_deactivated_clients = set()
+_DISCONNECT_TIMEOUT = 1  # seconds
+_DEFAULT_NUM_HISTOGRAM_BINS = 25
+_LIST_LIMIT = 200
 
 
 class RequestHandler(tornado.web.RequestHandler):
@@ -312,11 +317,6 @@ def _catch_errors(func):
                 )
 
     return wrapper
-
-
-_notebook_clients = {}
-_deactivated_clients = set()
-_DISCONNECT_TIMEOUT = 1  # seconds
 
 
 class PollingHandler(tornado.web.RequestHandler):
@@ -1045,7 +1045,7 @@ class StateHandler(tornado.websocket.WebSocketHandler):
         search="",
         asc=False,
         count=True,
-        limit=200,
+        limit=_LIST_LIMIT,
         sample_id=None,
     ):
         state = fos.StateDescription.from_dict(StateHandler.state)
@@ -1120,7 +1120,7 @@ class StateHandler(tornado.websocket.WebSocketHandler):
             results = await _gather_results(aggs, fields, view)
 
         elif group == "sample tags" and results is None:
-            aggs = [foa.CountValues("tags")]
+            aggs = [foa.CountValues("tags", _first=_LIST_LIMIT)]
             try:
                 fields = [view.get_field_schema()["tags"]]
                 results = await _gather_results(aggs, fields, view)
@@ -1239,9 +1239,6 @@ def _filter_deactivated_clients(clients):
     return filtered
 
 
-_DEFAULT_NUM_HISTOGRAM_BINS = 25
-
-
 def _parse_histogram_values(result, field):
     counts, edges, other = result
     data = sorted(
@@ -1349,7 +1346,7 @@ def _count_values(f, view):
             fields.append(field)
             aggregations.append(
                 foa.CountValues(
-                    "%s%s" % (prefix, path), _first=200, _asc=False
+                    "%s%s" % (prefix, path), _first=_LIST_LIMIT, _asc=False
                 )
             )
 


### PR DESCRIPTION
Limits string field histogram results to the first 200, sorted by count in descending order.


```py
import fiftyone as fo
import fiftyone.zoo as foz

F = fo.ViewField

dataset = foz.load_zoo_dataset("cifar100")
dataset.add_sample_field("list_str", fo.ListField, subfield=fo.StringField)

dataset.set_field("list_str", [F("filepath")]).save() # currently crashes the App when `Other fields` is opened

session = fo.Session(dataset)
```