### PR TITLE
Fixing video dataset reload bug

### DIFF
--- a/fiftyone/core/frame.py
+++ b/fiftyone/core/frame.py
@@ -888,6 +888,10 @@ class Frame(Document, metaclass=FrameSingleton):
 
     _NO_DATASET_DOC_CLS = foo.NoDatasetFrameSampleDocument
 
+    @property
+    def _sample_id(self):
+        return self._doc._sample_id
+
     def save(self):
         """Saves the frame to the database."""
         if not self._in_db:

--- a/tests/unittests/video_tests.py
+++ b/tests/unittests/video_tests.py
@@ -229,6 +229,27 @@ class VideoTests(unittest.TestCase):
         self.assertIsInstance(schema["array_field"], fo.ArrayField)
 
     @drop_datasets
+    def test_reload(self):
+        sample = fo.Sample(filepath="video.mp4", hello="world")
+        frame = fo.Frame(hi="there")
+
+        sample.frames[1] = frame
+
+        dataset = fo.Dataset()
+        dataset.add_sample(sample)
+
+        self.assertTrue(sample._in_db)
+        self.assertTrue(frame._in_db)
+
+        dataset.reload()
+
+        self.assertTrue(sample._in_db)
+        self.assertTrue(frame._in_db)
+
+        self.assertEqual(sample.hello, "world")
+        self.assertEqual(frame.hi, "there")
+
+    @drop_datasets
     def test_modify_video_sample(self):
         dataset = fo.Dataset()
 


### PR DESCRIPTION
Fixes a subtle bug that prevented `dataset.reload()` from working for video datasets where the user has a `Frame` instance from the dataset in-memory.

A unit test is added to ensure correct behavior.