### PR TITLE
Fixing #1265

### DIFF
--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -704,17 +704,41 @@ class SampleCollection(object):
     def _get_selected_labels(self, ids=None, tags=None, fields=None):
         view = self.select_labels(ids=ids, tags=tags, fields=fields)
 
-        sample_ids = view.values("id")
+        label_fields = view._get_label_fields()
+        if not label_fields:
+            return []
 
-        labels = []
-        for label_field in view._get_label_fields():
+        paths = ["id"]
+        is_list_fields = []
+        is_frame_fields = []
+        for label_field in label_fields:
             label_type, id_path = view._get_label_field_path(label_field, "id")
+            is_frame_field = self._is_frame_field(label_field)
             is_list_field = issubclass(label_type, fol._LABEL_LIST_FIELDS)
 
-            label_ids = view.values(id_path)
+            paths.append(id_path)
+            is_list_fields.append(is_list_field)
+            is_frame_fields.append(is_frame_field)
 
-            if self._is_frame_field(label_field):
-                frame_numbers = view.values("frames.frame_number")
+        has_frame_fields = any(is_frame_fields)
+
+        if has_frame_fields:
+            paths.insert(0, "frames.frame_number")
+
+        results = view.values(paths)
+
+        if has_frame_fields:
+            frame_numbers = results.pop(0)
+
+        sample_ids = results[0]
+        all_label_ids = results[1:]
+
+        labels = []
+
+        for label_field, label_ids, is_list_field, is_frame_field in zip(
+            label_fields, all_label_ids, is_list_fields, is_frame_fields
+        ):
+            if is_frame_field:
                 for sample_id, sample_frame_numbers, sample_label_ids in zip(
                     sample_ids, frame_numbers, label_ids
                 ):

--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -702,9 +702,18 @@ class SampleCollection(object):
             view.set_values(tags_path, tags)
 
     def _get_selected_labels(self, ids=None, tags=None, fields=None):
-        view = self.select_labels(ids=ids, tags=tags, fields=fields)
+        if ids is not None or tags is not None:
+            view = self.select_labels(ids=ids, tags=tags, fields=fields)
+        else:
+            view = self
 
-        label_fields = view._get_label_fields()
+        if fields is None:
+            label_fields = view._get_label_fields()
+        elif etau.is_str(fields):
+            label_fields = [fields]
+        else:
+            label_fields = fields
+
         if not label_fields:
             return []
 
@@ -713,8 +722,8 @@ class SampleCollection(object):
         is_frame_fields = []
         for label_field in label_fields:
             label_type, id_path = view._get_label_field_path(label_field, "id")
-            is_frame_field = self._is_frame_field(label_field)
             is_list_field = issubclass(label_type, fol._LABEL_LIST_FIELDS)
+            is_frame_field = view._is_frame_field(label_field)
 
             paths.append(id_path)
             is_list_fields.append(is_list_field)
@@ -725,7 +734,7 @@ class SampleCollection(object):
         if has_frame_fields:
             paths.insert(0, "frames.frame_number")
 
-        results = view.values(paths)
+        results = list(view.values(paths))
 
         if has_frame_fields:
             frame_numbers = results.pop(0)

--- a/fiftyone/core/plots/base.py
+++ b/fiftyone/core/plots/base.py
@@ -780,18 +780,20 @@ class InteractivePlot(ResponsivePlot):
     def _register_disconnect_callback(self, callback):
         pass
 
-    def select_ids(self, ids):
+    def select_ids(self, ids, view=None):
         """Selects the points with the given IDs in this plot.
 
         Args:
             ids: a list of IDs, or None to reset the plot to its default state
+            view (None): the :class:`fiftyone.core.view.DatasetView`
+                corresponding to the given IDs, if available
         """
         if not self.is_connected:
             return
 
-        self._select_ids(ids)
+        self._select_ids(ids, view=view)
 
-    def _select_ids(self, ids):
+    def _select_ids(self, ids, view=None):
         raise ValueError("Subclass must implement _select_ids()")
 
     def reset(self):

--- a/fiftyone/core/plots/base.py
+++ b/fiftyone/core/plots/base.py
@@ -784,7 +784,7 @@ class InteractivePlot(ResponsivePlot):
         """Selects the points with the given IDs in this plot.
 
         Args:
-            ids: a list of IDs
+            ids: a list of IDs, or None to reset the plot to its default state
         """
         if not self.is_connected:
             return

--- a/fiftyone/core/plots/manager.py
+++ b/fiftyone/core/plots/manager.py
@@ -532,17 +532,17 @@ class PlotManager(object):
                     % (name, plot.link_type)
                 )
 
+        view = self._session._collection.view()
+
         if view_plot_names:
-            self._update_view_plots(view_plot_names)
+            self._update_view_plots(view_plot_names, view)
 
         for name in interactive_plot_names:
-            self._update_interactive_plot(name)
+            self._update_interactive_plot(name, view)
 
-    def _update_view_plots(self, names):
+    def _update_view_plots(self, names, view):
         # For efficiency, aggregations for all supported `ViewPlot`s are
         # computed in a single batch
-
-        view = self._session._collection.view()
 
         # Build flat list of all aggregations
         aggregations = []
@@ -577,14 +577,14 @@ class PlotManager(object):
             plot = self._plots[name]
             plot.update_view(view, agg_results=_agg_results)
 
-    def _update_interactive_plot(self, name):
+    def _update_interactive_plot(self, name, view):
         plot = self._plots[name]
 
         if plot.link_type == "samples":
-            plot.select_ids(self._current_sample_ids)
+            plot.select_ids(self._current_sample_ids, view=view)
         elif plot.link_type == "labels":
             label_ids = self._get_current_label_ids_for_plot(plot)
-            plot.select_ids(label_ids)
+            plot.select_ids(label_ids, view=view)
         else:
             raise ValueError(
                 "InteractivePlot '%s' has unsupported link type '%s'"

--- a/fiftyone/core/plots/manager.py
+++ b/fiftyone/core/plots/manager.py
@@ -532,17 +532,17 @@ class PlotManager(object):
                     % (name, plot.link_type)
                 )
 
-        view = self._session._collection.view()
-
         if view_plot_names:
-            self._update_view_plots(view_plot_names, view)
+            self._update_view_plots(view_plot_names)
 
         for name in interactive_plot_names:
-            self._update_interactive_plot(name, view)
+            self._update_interactive_plot(name)
 
-    def _update_view_plots(self, names, view):
+    def _update_view_plots(self, names):
         # For efficiency, aggregations for all supported `ViewPlot`s are
         # computed in a single batch
+
+        view = self._session._collection.view()
 
         # Build flat list of all aggregations
         aggregations = []
@@ -577,7 +577,7 @@ class PlotManager(object):
             plot = self._plots[name]
             plot.update_view(view, agg_results=_agg_results)
 
-    def _update_interactive_plot(self, name, view):
+    def _update_interactive_plot(self, name):
         plot = self._plots[name]
 
         if plot.link_type == "samples":

--- a/fiftyone/core/plots/matplotlib.py
+++ b/fiftyone/core/plots/matplotlib.py
@@ -917,7 +917,7 @@ class InteractiveCollection(InteractiveMatplotlibPlot):
 
         self._select_inds(inds)
 
-    def _select_ids(self, ids):
+    def _select_ids(self, ids, view=None):
         if ids is not None:
             inds = [self._ids_to_inds[_id] for _id in ids]
         else:

--- a/fiftyone/core/plots/plotly.py
+++ b/fiftyone/core/plots/plotly.py
@@ -1489,10 +1489,6 @@ class InteractiveHeatmap(PlotlyInteractivePlot):
                 curr_ids[y, x].append(_id)
 
         Z = np.vectorize(lambda a: len(a))(curr_ids)
-
-        # cells = list(zip(*reversed(np.nonzero(Z))))
-        cells = []
-
         zlim = [0, Z.max()]
 
         self._curr_view = view
@@ -1500,7 +1496,7 @@ class InteractiveHeatmap(PlotlyInteractivePlot):
         self._curr_Z = Z
         self._curr_zlim = zlim
 
-        self._update_heatmap(cells, Z, Z, zlim)
+        self._update_heatmap([], Z, Z, zlim)
 
     def _on_click(self, point_inds):
         # `point_inds` is a list of `(y, x)` coordinates of selected cells


### PR DESCRIPTION
Resolves https://github.com/voxel51/fiftyone/issues/1265.

The previous implementation of interactive plotting callbacks relied on all session/plot updates finishing within 0.5 seconds. However, as https://github.com/voxel51/fiftyone/issues/1265 demonstrates, loading views created, for example, by selecting cells in a confusion matrix containing many thousands of labels in a large dataset can easily exceed 0.5 seconds. In such cases, a race condition currently ensues that causes an infinite chain of session/plot updates.

This PR improves the callback logic to prevent such self-update loops. The time-based threshold is still there (now 1 second rather than 0.5) but it's primary function now is just to prevent unnecessary updates due to incessant clicking in the App/plots.

This PR also makes a small change to the behavior of interactive confusion matrices: when updating a confusion matrix in response to an App update, the confusion matrix will "remember" the loaded view, such that any subsequent selections in the confusion matrix will only contain labels from the loaded view, not the entire confusion matrix (until either the plot or the App is reset, at which point this view will be forgotten). This change allows for certain workflows like seeing how a confusion matrix changes in response to selecting a subset of the available samples, where, after selecting a subset of samples, the user would then like to select cells in the confusion matrix to further drill down into specific classes of interest from within the chosen subset of samples (previously selecting cells in a confusion matrix would always load *all* labels in the cell from the evaluation run).