### PR TITLE
Allowing MongoDB v5 custom database usages

### DIFF
--- a/docs/source/faq/index.rst
+++ b/docs/source/faq/index.rst
@@ -112,8 +112,8 @@ including the following commands in your notebook before creating any plots:
     po.init_notebook_mode(connected=True)
 
 Note that FiftyOne currently requires `plotly>=4.14,<5`, which should have been
-automatically installed when you installed FiftyOne. If you manually upgraded
-to Plotly v5 after installing FiftyOne, some interactive plotting features may
+automatically installed when you installed FiftyOne. If your Plotly package was
+upgraded after installing FiftyOne, some interactive plotting features may
 not work as expected.
 
 .. _faq-remote-server-data:

--- a/docs/source/faq/index.rst
+++ b/docs/source/faq/index.rst
@@ -92,6 +92,21 @@ is served from a remote machine.
 Refer to :ref:`this section <remote-notebooks>` of the environment guide for
 instructions to achieve this.
 
+.. _faq-plots-not-appearing:
+
+Why aren't plots appearing in my notebook?
+------------------------------------------
+
+If you are trying to :ref:`view plots <interactive-plots>` in a Jupyter
+notebook but nothing appears after you call `plot.show()`, then you likely need
+to :ref:`follow these instructions <working-in-notebooks>` to install the
+proper packages and/or Jupyter notebook extensions.
+
+Also, note that FiftyOne currently requires `plotly>=4.14,<5`, which should
+have been automatically installed when you installed FiftyOne. If you manually
+upgraded to Plotly v5 after installing FiftyOne, some interactive plotting
+features may not work as expected.
+
 .. _faq-remote-server-data:
 
 Can I access data stored on a remote server?

--- a/docs/source/faq/index.rst
+++ b/docs/source/faq/index.rst
@@ -102,10 +102,19 @@ notebook but nothing appears after you call `plot.show()`, then you likely need
 to :ref:`follow these instructions <working-in-notebooks>` to install the
 proper packages and/or Jupyter notebook extensions.
 
-Also, note that FiftyOne currently requires `plotly>=4.14,<5`, which should
-have been automatically installed when you installed FiftyOne. If you manually
-upgraded to Plotly v5 after installing FiftyOne, some interactive plotting
-features may not work as expected.
+If the proper packages are installed but plots are still not displaying, try
+including the following commands in your notebook before creating any plots:
+
+.. code-block:: python
+
+    # Ensure that plotly.js is downloaded
+    import plotly.offline as po
+    po.init_notebook_mode(connected=True)
+
+Note that FiftyOne currently requires `plotly>=4.14,<5`, which should have been
+automatically installed when you installed FiftyOne. If you manually upgraded
+to Plotly v5 after installing FiftyOne, some interactive plotting features may
+not work as expected.
 
 .. _faq-remote-server-data:
 

--- a/docs/source/user_guide/config.rst
+++ b/docs/source/user_guide/config.rst
@@ -242,7 +242,7 @@ session.
 Configuring a MongoDB connection
 --------------------------------
 
-By default, FiftyOne is installed with its own `mongod` database distribution.
+By default, FiftyOne is installed with its own MongoDB database distribution.
 This database is managed by FiftyOne automatically as a service that runs
 whenever at least one FiftyOne Python client is alive.
 
@@ -257,8 +257,14 @@ entry:
 .. code-block:: json
 
     {
-        "database_uri": "..."
+        "database_uri": "mongodb://[username:password@]host[:port]"
     }
+
+or you can set the following environment variable:
+
+.. code-block:: shell
+
+    export FIFTYONE_DATABASE_URI=mongodb://[username:password@]host[:port]
 
 Very rarerly, upgrading your FiftyOne package may require running a database
 admin migration, in which case the `database_uri` must establish a connection
@@ -266,7 +272,17 @@ with administrative privileges.
 
 .. warning::
 
-    FiftyOne requires MongoDB v4.4.
+    FiftyOne is designed for and distributed with MongoDB v4.4.
+
+    Users have reported success connecting to MongoDB v5 databases, but you
+    should
+    `set the feature compatibility version <https://docs.mongodb.com/manual/reference/command/setFeatureCompatibilityVersion>`_
+    to 4.4 to ensure proper function:
+
+    .. code-block:: shell
+
+        mongo --shell
+        > db.adminCommand({setFeatureCompatibilityVersion: "4.4"})
 
 .. note::
 
@@ -274,11 +290,43 @@ with administrative privileges.
     Apple Silicon, so you currently must use `dataset_uri` with a MongoDB
     distribution that you have installed yourself.
 
-    Users have reported success installing MongoDB on Apple Silicon as follows:
+    Users have reported success
+    `installing MongoDB v4.4 on Apple Silicon <https://docs.mongodb.com/manual/tutorial/install-mongodb-on-os-x>`_
+    as follows:
 
     .. code-block:: shell
 
+        brew tap mongodb/brew
         brew install mongodb-community@4.4
+
+Example custom database usage
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+In order to use a custom MongoDB database with FiftyOne, you must manually
+start the database before importing FiftyOne. MongoDB provides
+`a variety of operations <https://docs.mongodb.com/manual/tutorial/manage-mongodb-processes>`_
+for this, including running the database as a daemon automatically.
+
+In the  simplest case, you can just run `mongod` in one shell:
+
+.. code-block:: shell
+
+    mkdir -p /path/for/db
+    mongod --dbpath /path/for/db
+
+Then, in another shell, configure the database URI and launch FiftyOne:
+
+.. code-block:: shell
+
+    export FIFTYONE_DATABASE_URI=mongodb://localhost
+
+.. code-block:: python
+
+    import fiftyone as fo
+    import fiftyone.zoo as foz
+
+    dataset = foz.load_zoo_dataset("quickstart")
+    session = fo.launch_app(dataset)
 
 .. _configuring-fiftyone-app:
 

--- a/docs/source/user_guide/config.rst
+++ b/docs/source/user_guide/config.rst
@@ -304,10 +304,10 @@ Example custom database usage
 
 In order to use a custom MongoDB database with FiftyOne, you must manually
 start the database before importing FiftyOne. MongoDB provides
-`a variety of operations <https://docs.mongodb.com/manual/tutorial/manage-mongodb-processes>`_
+`a variety of options <https://docs.mongodb.com/manual/tutorial/manage-mongodb-processes>`_
 for this, including running the database as a daemon automatically.
 
-In the  simplest case, you can just run `mongod` in one shell:
+In the simplest case, you can just run `mongod` in one shell:
 
 .. code-block:: shell
 

--- a/fiftyone/core/odm/database.py
+++ b/fiftyone/core/odm/database.py
@@ -121,20 +121,20 @@ def _validate_db_version(config, client):
 
     min_ver, max_ver = foc.MONGODB_VERSION_RANGE
 
-    if min_ver <= version < max_ver:
-        return
-
-    if version >= max_ver and config.database_uri is not None:
+    if config.database_uri is not None:
+        # Allow custom databases to have version > max_ver, with the assumption
+        # that the user has set their feature compatibility version
+        # https://docs.mongodb.com/manual/reference/command/setFeatureCompatibilityVersion
+        if version < min_ver:
+            raise RuntimeError(
+                "Found `mongod` version %s, but %s or later is required"
+                % (version, min_ver)
+            )
+    elif version < min_ver or version > max_ver:
         raise RuntimeError(
-            "Found `mongod` version %s, but [%s, %s) is required. Your "
-            "FiftyOne installation may be outdated; try upgrading it"
+            "Found `mongod` version %s, but [%s, %s) is required"
             % (version, min_ver, max_ver)
         )
-
-    raise RuntimeError(
-        "Found `mongod` version %s, but [%s, %s) is required"
-        % (version, min_ver, max_ver)
-    )
 
 
 def aggregate(collection, pipelines):


### PR DESCRIPTION
Motivated by https://github.com/voxel51/fiftyone/issues/1268, this PR tweaks the database version verification logic to allow MongoDB versions greater than v4.4 to be used when connecting to a self-installed database, since the preliminary investigations in https://github.com/voxel51/fiftyone/issues/1268 seem to indicate that this will work, and users in environments like Apple Silicon may find it easier to install MongoDB v5 than older versions.

The documentation for connecting to a self-installed database is also improved, including a full example.