### PR TITLE
Split labels and merge labels

### DIFF
--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -38,6 +38,7 @@ import fiftyone.core.sample as fosa
 import fiftyone.core.stages as fos
 import fiftyone.core.utils as fou
 
+fod = fou.lazy_import("fiftyone.core.dataset")
 fov = fou.lazy_import("fiftyone.core.view")
 foua = fou.lazy_import("fiftyone.utils.annotations")
 foud = fou.lazy_import("fiftyone.utils.data")
@@ -787,6 +788,73 @@ class SampleCollection(object):
                 counts[tag] += count
 
         return dict(counts)
+
+    def split_labels(self, in_field, out_field, filter=None):
+        """Splits the labels from the given input field into the given output
+        field of the collection.
+
+        This method is typically invoked on a view that has filtered the
+        contents of the specified input field, so that the labels in the view
+        are moved to the output field and the remaining labels are left
+        in-place.
+
+        Alternatively, you can provide a ``filter`` expression that selects the
+        labels of interest to move in this collection.
+
+        Args:
+            in_field: the name of the input label field
+            out_field: the name of the output label field, which will be
+                created if necessary
+            filter (None): a boolean
+                :class:`fiftyone.core.expressions.ViewExpression` to apply to
+                each label in the input field to determine whether to move it
+                (True) or leave it (False)
+        """
+        if filter is not None:
+            move_view = self.filter_labels(in_field, filter)
+        else:
+            move_view = self
+
+        move_view.merge_labels(in_field, out_field)
+
+    def merge_labels(self, in_field, out_field):
+        """Merges the labels from the given input field into the given output
+        field of the collection.
+
+        If this collection is a dataset, the input field is deleted after the
+        merge.
+
+        If this collection is a view, the input field will still exist on the
+        underlying dataset but will only contain the labels not present in this
+        view.
+
+        Args:
+            in_field: the name of the input label field
+            out_field: the name of the output label field, which will be
+                created if necessary
+        """
+        if not isinstance(self, fod.Dataset):
+            # The label IDs that we'll need to delete from `in_field`
+            _, id_path = self._get_label_field_path(in_field, "id")
+            del_ids = self.values(id_path, unwind=True)
+
+        dataset = self._dataset
+        dataset.merge_samples(
+            self,
+            key_field="id",
+            skip_existing=False,
+            insert_new=False,
+            fields={in_field: out_field},
+            merge_lists=True,
+            overwrite=True,
+            expand_schema=True,
+            include_info=False,
+        )
+
+        if isinstance(self, fod.Dataset):
+            dataset.delete_sample_field(in_field)
+        else:
+            dataset.delete_labels(ids=del_ids, fields=in_field)
 
     def set_values(
         self,

--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -4912,6 +4912,7 @@ def _merge_samples_pipeline(
     # Prepare for merge
     #
 
+    in_key_field = key_field
     db_fields_map = src_collection._get_db_fields_map()
     key_field = db_fields_map.get(key_field, key_field)
 
@@ -5029,7 +5030,7 @@ def _merge_samples_pipeline(
         _omit_fields = set()
 
     _omit_fields.add("id")
-    _omit_fields.discard(key_field)
+    _omit_fields.discard(in_key_field)
 
     if insert_new:
         # Can't omit default fields here when new samples may be inserted.


### PR DESCRIPTION
Adds `split_labels()` and `merge_labels()` methods that provide convenient syntaxes for moving labels between new and existing label fields of a dataset.

A typical use case here might be to split off low confidence predictions into a separate field, or split polylines and polygons into separate fields.

```py
import fiftyone as fo
import fiftyone.zoo as foz
from fiftyone import ViewField as F

dataset = foz.load_zoo_dataset("quickstart").clone()
print("Total predictions: %d" % dataset.count("predictions.detections"))  # 5620

# Move low confidence predictions to a new field
dataset.split_labels("predictions", "low_conf", filter=F("confidence") < 0.10)
print("Low confidence: %d" % dataset.count("low_conf.detections"))  # 1552
print("Remaining: %d" % dataset.count("predictions.detections"))  # 4068

# Move them back
dataset.merge_labels("low_conf", "predictions")
print("Total predictions: %d" % dataset.count("predictions.detections"))  # 5620

# Now move high confidence predictions to a new field
# This time we construct a view first, then split
view = dataset.filter_labels("predictions", F("confidence") > 0.99)
view.split_labels("predictions", "high_conf")
print("High confidence: %d" % dataset.count("high_conf.detections"))  # 279
print("Remaining: %d" % dataset.count("predictions.detections"))  # 5341

# Move them back
dataset.merge_labels("high_conf", "predictions")
print("Total predictions: %d" % dataset.count("predictions.detections"))  # 5620
```
