### PR TITLE
Expose CVAT API parameters to upload higher quality video

### DIFF
--- a/docs/source/integrations/cvat.rst
+++ b/docs/source/integrations/cvat.rst
@@ -404,6 +404,13 @@ provided:
     Not applicable to videos
 -   **image_quality** (*75*): an int in `[0, 100]` determining the image
     quality to upload to CVAT
+-   **use_cache** (*True*): option to use a cache when preparing data chunks.
+    This will reduce the task creation time as data will be processed
+    on-the-fly and stored in a cache when requested
+-   **use_zip_chunks** (*True*): for videos only, this option will force to use
+    zip chunks as compressed data. Note, setting this option to `False`
+    results in smoothing and a reduction in quality when uploading
+    videos at an `image_quality` of 100
 -   **task_assignee** (*None*): a username to assign the generated tasks
 -   **job_assignees** (*None*): a list of usernames to assign jobs
 -   **job_reviewers** (*None*): a list of usernames to assign job reviews

--- a/docs/source/integrations/cvat.rst
+++ b/docs/source/integrations/cvat.rst
@@ -411,8 +411,7 @@ provided:
     video frames in smaller chunks. Setting this option to `False` may result
     in reduced video quality in CVAT due to size limitations on ZIP files that
     may be uploaded to CVAT
--   **chunk_size** (*None*): the number of frames per ZIP chunk. Only
-    applicable when annotating videos and `use_zip_chunks` is True
+-   **chunk_size** (*None*): the number of frames to upload per ZIP chunk
 -   **task_assignee** (*None*): a username to assign the generated tasks
 -   **job_assignees** (*None*): a list of usernames to assign jobs
 -   **job_reviewers** (*None*): a list of usernames to assign job reviews

--- a/docs/source/integrations/cvat.rst
+++ b/docs/source/integrations/cvat.rst
@@ -404,13 +404,15 @@ provided:
     Not applicable to videos
 -   **image_quality** (*75*): an int in `[0, 100]` determining the image
     quality to upload to CVAT
--   **use_cache** (*True*): option to use a cache when preparing data chunks.
-    This will reduce the task creation time as data will be processed
-    on-the-fly and stored in a cache when requested
--   **use_zip_chunks** (*True*): for videos only, this option will force to use
-    zip chunks as compressed data. Note, setting this option to `False`
-    results in smoothing and a reduction in quality when uploading
-    videos at an `image_quality` of 100
+-   **use_cache** (*True*): whether to use a cache when uploading data. Using a
+    cache reduces task creation time as data will be processed on-the-fly and
+    stored in the cache when requested
+-   **use_zip_chunks** (*True*): when annotating videos, whether to upload
+    video frames in smaller chunks. Setting this option to `False` may result
+    in reduced video quality in CVAT due to size limitations on ZIP files that
+    may be uploaded to CVAT
+-   **chunk_size** (*None*): the number of frames per ZIP chunk. Only
+    applicable when annotating videos and `use_zip_chunks` is True
 -   **task_assignee** (*None*): a username to assign the generated tasks
 -   **job_assignees** (*None*): a list of usernames to assign jobs
 -   **job_reviewers** (*None*): a list of usernames to assign job reviews

--- a/docs/source/integrations/cvat.rst
+++ b/docs/source/integrations/cvat.rst
@@ -410,7 +410,7 @@ provided:
 -   **use_zip_chunks** (*True*): when annotating videos, whether to upload
     video frames in smaller chunks. Setting this option to `False` may result
     in reduced video quality in CVAT due to size limitations on ZIP files that
-    may be uploaded to CVAT
+    can be uploaded to CVAT
 -   **chunk_size** (*None*): the number of frames to upload per ZIP chunk
 -   **task_assignee** (*None*): a username to assign the generated tasks
 -   **job_assignees** (*None*): a list of usernames to assign jobs

--- a/fiftyone/utils/cvat.py
+++ b/fiftyone/utils/cvat.py
@@ -2437,9 +2437,9 @@ class CVATBackendConfig(foua.AnnotationBackendConfig):
             cache reduces task creation time as data will be processed
             on-the-fly and stored in the cache when requested
         use_zip_chunks (True): when annotating videos, whether to upload video
-            frames in smaller chunks. Setting this option to `False` may result
-            in reduced video quality in CVAT due to size limitations on ZIP
-            files that may be uploaded to CVAT
+            frames in smaller chunks. Setting this option to ``False`` may
+            result in reduced video quality in CVAT due to size limitations on
+            ZIP files that can be uploaded to CVAT
         chunk_size (None): the number of frames to upload per ZIP chunk
         task_assignee (None): the username to which the task(s) were assigned
         job_assignees (None): a list of usernames to which jobs were assigned
@@ -3126,9 +3126,9 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
                 a cache reduces task creation time as data will be processed
                 on-the-fly and stored in the cache when requested
             use_zip_chunks (True): when annotating videos, whether to upload
-                video frames in smaller chunks. Setting this option to `False`
-                may result in reduced video quality in CVAT due to size
-                limitations on ZIP files that may be uploaded to CVAT
+                video frames in smaller chunks. Setting this option to
+                ``False`` may result in reduced video quality in CVAT due to
+                size limitations on ZIP files that can be uploaded to CVAT
             chunk_size (None): the number of frames to upload per ZIP chunk
             job_assignees (None): a list of usernames to assign jobs
             job_reviewers (None): a list of usernames to assign job reviews
@@ -3217,9 +3217,9 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
                 a cache reduces task creation time as data will be processed
                 on-the-fly and stored in the cache when requested
             use_zip_chunks (True): when annotating videos, whether to upload
-                video frames in smaller chunks. Setting this option to `False`
-                may result in reduced video quality in CVAT due to size
-                limitations on ZIP files that may be uploaded to CVAT
+                video frames in smaller chunks. Setting this option to
+                ``False`` may result in reduced video quality in CVAT due to
+                size limitations on ZIP files that can be uploaded to CVAT
             chunk_size (None): the number of frames to upload per ZIP chunk
             task_assignee (None): the username to assign the created task(s)
             job_assignees (None): a list of usernames to assign jobs

--- a/fiftyone/utils/cvat.py
+++ b/fiftyone/utils/cvat.py
@@ -2433,6 +2433,13 @@ class CVATBackendConfig(foua.AnnotationBackendConfig):
             to videos
         image_quality (75): an int in `[0, 100]` determining the image quality
             uploaded to CVAT
+        use_cache (True): option to use a cache when preparing data chunks.
+            This will reduce the task creation time as data will be processed
+            on-the-fly and stored in a cache when requested
+        use_zip_chunks (True): for videos only, this option will force to use
+            zip chunks as compressed data. Note, setting this option to `False`
+            results in smoothing and a reduction in quality when uploading
+            videos at an `image_quality` of 100
         task_assignee (None): the username to which the task(s) were assigned
         job_assignees (None): a list of usernames to which jobs were assigned
         job_reviewers (None): a list of usernames to which job reviews were
@@ -2449,6 +2456,8 @@ class CVATBackendConfig(foua.AnnotationBackendConfig):
         password=None,
         segment_size=None,
         image_quality=75,
+        use_cache=True,
+        use_zip_chunks=True,
         task_assignee=None,
         job_assignees=None,
         job_reviewers=None,
@@ -2458,6 +2467,8 @@ class CVATBackendConfig(foua.AnnotationBackendConfig):
         self.url = url
         self.segment_size = segment_size
         self.image_quality = image_quality
+        self.use_cache = use_cache
+        self.use_zip_chunks = use_zip_chunks
         self.task_assignee = task_assignee
         self.job_assignees = job_assignees
         self.job_reviewers = job_reviewers
@@ -2547,6 +2558,8 @@ class CVATBackend(foua.AnnotationBackend):
             media_field=self.config.media_field,
             segment_size=self.config.segment_size,
             image_quality=self.config.image_quality,
+            use_cache=self.config.use_cache,
+            use_zip_chunks=self.config.use_zip_chunks,
             task_assignee=self.config.task_assignee,
             job_assignees=self.config.job_assignees,
             job_reviewers=self.config.job_reviewers,
@@ -3092,6 +3105,8 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
         task_id,
         paths,
         image_quality=75,
+        use_cache=True,
+        use_zip_chunks=True,
         job_assignees=None,
         job_reviewers=None,
     ):
@@ -3102,13 +3117,24 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
             paths: a list of media paths to upload
             image_quality (75): an int in `[0, 100]` determining the image
                 quality to upload to CVAT
+            use_cache (True): option to use a cache when preparing data chunks.
+                This will reduce the task creation time as data will be processed
+                on-the-fly and stored in a cache when requested
+            use_zip_chunks (True): for videos only, this option will force to use
+                zip chunks as compressed data. Note, setting this option to `False`
+                results in smoothing and a reduction in quality when uploading
+                videos at an `image_quality` of 100
             job_assignees (None): a list of usernames to assign jobs
             job_reviewers (None): a list of usernames to assign job reviews
 
         Returns:
             a list of the job ids created for the task
         """
-        data = {"image_quality": image_quality}
+        data = {
+            "image_quality": image_quality,
+            "use_cache": use_cache,
+            "use_zip_chunks": use_zip_chunks,
+        }
 
         files = {}
         for idx, path in enumerate(paths):
@@ -3157,6 +3183,8 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
         media_field="filepath",
         segment_size=None,
         image_quality=75,
+        use_cache=True,
+        use_zip_chunks=True,
         task_assignee=None,
         job_assignees=None,
         job_reviewers=None,
@@ -3175,6 +3203,13 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
                 Not applicable to videos
             image_quality (75): an int in `[0, 100]` determining the image
                 quality to upload to CVAT
+            use_cache (True): option to use a cache when preparing data chunks.
+                This will reduce the task creation time as data will be processed
+                on-the-fly and stored in a cache when requested. 
+            use_zip_chunks (True): for videos only, this option will force to use
+                zip chunks as compressed data. Note, setting this option to `False`
+                results in smoothing and a reduction in quality when uploading
+                videos at an `image_quality` of 100
             task_assignee (None): the username to assign the created task(s)
             job_assignees (None): a list of usernames to assign jobs
             job_reviewers (None): a list of usernames to assign job reviews
@@ -3376,6 +3411,8 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
                     task_id,
                     batch_samples.values(media_field),
                     image_quality=image_quality,
+                    use_cache=use_cache,
+                    use_zip_chunks=use_zip_chunks,
                     job_assignees=current_job_assignees,
                     job_reviewers=current_job_reviewers,
                 )

--- a/fiftyone/utils/cvat.py
+++ b/fiftyone/utils/cvat.py
@@ -2440,8 +2440,7 @@ class CVATBackendConfig(foua.AnnotationBackendConfig):
             frames in smaller chunks. Setting this option to `False` may result
             in reduced video quality in CVAT due to size limitations on ZIP
             files that may be uploaded to CVAT
-        chunk_size (None): the number of frames per ZIP chunk. Only applicable
-            when annotating videos and ``use_zip_chunks`` is True
+        chunk_size (None): the number of frames to upload per ZIP chunk
         task_assignee (None): the username to which the task(s) were assigned
         job_assignees (None): a list of usernames to which jobs were assigned
         job_reviewers (None): a list of usernames to which job reviews were
@@ -3130,9 +3129,7 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
                 video frames in smaller chunks. Setting this option to `False`
                 may result in reduced video quality in CVAT due to size
                 limitations on ZIP files that may be uploaded to CVAT
-            chunk_size (None): the number of frames per ZIP chunk. Only
-                applicable when annotating videos and ``use_zip_chunks`` is
-                True
+            chunk_size (None): the number of frames to upload per ZIP chunk
             job_assignees (None): a list of usernames to assign jobs
             job_reviewers (None): a list of usernames to assign job reviews
 
@@ -3145,7 +3142,7 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
             "use_zip_chunks": use_zip_chunks,
         }
 
-        if use_zip_chunks and chunk_size:
+        if chunk_size:
             data["chunk_size"] = chunk_size
 
         files = {}
@@ -3223,9 +3220,7 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
                 video frames in smaller chunks. Setting this option to `False`
                 may result in reduced video quality in CVAT due to size
                 limitations on ZIP files that may be uploaded to CVAT
-            chunk_size (None): the number of frames per ZIP chunk. Only
-                applicable when annotating videos and ``use_zip_chunks`` is
-                True
+            chunk_size (None): the number of frames to upload per ZIP chunk
             task_assignee (None): the username to assign the created task(s)
             job_assignees (None): a list of usernames to assign jobs
             job_reviewers (None): a list of usernames to assign job reviews


### PR DESCRIPTION
When uploading data to CVAT manually, the options for `use_cache` and `use_zip_chunks` are checked by default. https://openvinotoolkit.github.io/cvat/docs/manual/basics/creating_an_annotation_task/#advanced-configuration
![image](https://user-images.githubusercontent.com/21222883/134065964-e92659ce-29ee-4b26-9a28-c22ac66baf52.png)

Through the CVAT REST API, these options are set to `False` by default. This PR exposes these parameters to the user when calling `SampleCollection.annotate()` with the CVAT backend similar to the existing `image_quality`.

The primary issue that this resolves is that when `use_zip_chunks` is False, there is a noticeable smoothing and reduction in quality when uploading videos at an `image_quality` of 100.

When `use_zip_chunks=True`:
![image](https://user-images.githubusercontent.com/21222883/134066714-a9f224ed-039a-40ff-83ae-1e80be1b90ff.png)



When `use_zip_chunks=False`:
![image](https://user-images.githubusercontent.com/21222883/134066769-f14c255e-8a82-45e5-b676-16abb9a4dbc9.png)

This can be tested with the following code:

```python
import fiftyone as fo
import fiftyone.zoo as foz

dataset = foz.load_zoo_dataset("quickstart-video", max_samples=1)

dataset.annotate(
    "high_quality",
    label_field="high_q_field",
    label_type="scalar",
    classes=["test"],
    image_quality=100,
    launch_editor=True,
    use_zip_chunks=True,
)

dataset.annotate(
    "low_quality",
    label_field="low_q_field",
    label_type="scalar",
    classes=["test"],
    image_quality=100,
    launch_editor=True,
    use_zip_chunks=False,
)
```