### PR TITLE
Expose the mutable property for CVAT attributes

### DIFF
--- a/docs/source/integrations/cvat.rst
+++ b/docs/source/integrations/cvat.rst
@@ -532,10 +532,12 @@ attribute that you wish to label:
             "type": "radio",
             "values": [True, False],
             "default": True,
+            "mutable": True,
         },
         "weather": {
             "type": "select",
             "values": ["cloudy", "sunny", "overcast"],
+            "mutable": False,
         },
         "caption": {
             "type": "text",
@@ -545,7 +547,7 @@ attribute that you wish to label:
     view.annotate(
         anno_key,
         label_field="new_field",
-        label_type="detections",
+        label_type="frames.detections",
         classes=["dog", "cat", "person"],
         attributes=attributes,
     )
@@ -564,6 +566,7 @@ For CVAT, the following `type` values are supported:
 -   `checkbox`: a boolean checkbox UI. In this case, `default` is optional and
     `values` is unused
 
+
 When you are annotating existing label fields, the `attributes` parameter can
 take additional values:
 
@@ -575,55 +578,21 @@ take additional values:
 -   a full dictionary syntax described above
 
 
-**Other attribute information**
 
-Different backends can allow for various other types of information to be
-specified for each attribute. An example of this in CVAT is the `mutable
-property of attributes <https://openvinotoolkit.github.io/cvat/docs/manual/basics/vocabulary/>`_.
-
-The `mutable` property is relevant when annotating tracks on videos. Setting it
+**For videos**, the `mutable` property is 
+`used by CVAT <https://docs.labelbox.com/docs/model-assisted-labeling#part-1-prepare-your-json-file>`_
+when annotating object tracks. Setting it
 to `False` makes it so that the attribute is immutable throughout the track
 and as such only has to be annotated once for it to apply to every frame. When
-uploading labels with immutable attributes, it is expected that the immutable
-attributes are the same for all labels of the same index in a track in
-FiftyOne.
+uploading existing objects with an immutable attribute, it is expected that the value
+of the attribute is constant for all objects of the same index in a video in
+FiftyOne. CVAT supports the following choices for `mutable`:
 
-By default, the `mutable` property of all attributes is set to `True` unless
-specified as shown below.
+-   `True` (default): the attribute is dynamic and can have a different value
+    for every frame in which the object appears
+-   `False`: the value of the attribute is the same for every frame
+    in which the object appears
 
-.. code:: python
-    :linenos:
-
-    anno_key = "..."
-
-    attributes = {
-        "occluded": {
-            "type": "radio",
-            "values": [True, False],
-            "default": True,
-            "other": {
-                "mutable": True,
-            }
-        },
-        "weather": {
-            "type": "select",
-            "values": ["cloudy", "sunny", "overcast"],
-            "other": {
-                "mutable": False,
-            }
-        },
-        "caption": {
-            "type": "text",
-        }
-    }
-
-    view.annotate(
-        anno_key,
-        label_field="frames.new_field",
-        label_type="detections",
-        classes=["dog", "cat", "person"],
-        attributes=attributes,
-    )
 
 .. note::
 
@@ -1169,8 +1138,8 @@ videos, which captures the identity of a single object as it moves through the
 video. These tracks are stored in the `index` field of the |Label| instances
 when you import the annotations into FiftyOne.
 
-Note that CVAT does not provide a straightforward way to annotate frame-level
-classification labels. Instead, we recommend that you use sample-level fields
+Note that CVAT does not provide a straightforward way to annotate sample-level
+classification labels. Instead, we recommend that you use frame-level fields
 to record classifications for your video datasets.
 
 .. note::

--- a/docs/source/integrations/cvat.rst
+++ b/docs/source/integrations/cvat.rst
@@ -531,13 +531,11 @@ attribute that you wish to label:
         "occluded": {
             "type": "radio",
             "values": [True, False],
-            "default": True,
-            "mutable": True,
+            "default": False,
         },
-        "weather": {
+        "gender": {
             "type": "select",
-            "values": ["cloudy", "sunny", "overcast"],
-            "mutable": False,
+            "values": ["male", "female"],
         },
         "caption": {
             "type": "text",
@@ -547,7 +545,7 @@ attribute that you wish to label:
     view.annotate(
         anno_key,
         label_field="new_field",
-        label_type="frames.detections",
+        label_type="detections",
         classes=["dog", "cat", "person"],
         attributes=attributes,
     )
@@ -566,7 +564,6 @@ For CVAT, the following `type` values are supported:
 -   `checkbox`: a boolean checkbox UI. In this case, `default` is optional and
     `values` is unused
 
-
 When you are annotating existing label fields, the `attributes` parameter can
 take additional values:
 
@@ -576,23 +573,6 @@ take additional values:
 -   `False`: do not include any custom attributes in the export
 -   a list of custom attributes to include in the export
 -   a full dictionary syntax described above
-
-
-
-**For videos**, the `mutable` property is 
-`used by CVAT <https://docs.labelbox.com/docs/model-assisted-labeling#part-1-prepare-your-json-file>`_
-when annotating object tracks. Setting it
-to `False` makes it so that the attribute is immutable throughout the track
-and as such only has to be annotated once for it to apply to every frame. When
-uploading existing objects with an immutable attribute, it is expected that the value
-of the attribute is constant for all objects of the same index in a video in
-FiftyOne. CVAT supports the following choices for `mutable`:
-
--   `True` (default): the attribute is dynamic and can have a different value
-    for every frame in which the object appears
--   `False`: the value of the attribute is the same for every frame
-    in which the object appears
-
 
 .. note::
 
@@ -606,6 +586,49 @@ FiftyOne. CVAT supports the following choices for `mutable`:
     modifications to existing labels, and changing or deleting these ID
     attributes in CVAT will result in labels being overwritten rather than
     merged when loading annotations back into FiftyOne.
+
+.. _cvat-video-label-attributes:
+
+Video label attributes
+----------------------
+
+When annotating spatiotemporal objects in videos, each object attribute
+specification can include a `mutable` property that controls whether the
+attribute's value can change between frames for each object:
+
+.. code:: python
+    :linenos:
+
+    anno_key = "..."
+
+    attributes = {
+        "type": {
+            "type": "select",
+            "values": ["sedan", "suv", "truck"],
+            "mutable": False,
+        },
+        "occluded": {
+            "type": "radio",
+            "values": [True, False],
+            "default": False,
+            "mutable": True,
+        },
+    }
+
+    view.annotate(
+        anno_key,
+        label_field="frames.new_field",
+        label_type="detections",
+        classes=["vehicle"],
+        attributes=attributes,
+    )
+
+The meaning of the `mutable` attribute is defined as follows:
+
+-   `True` (default): the attribute is dynamic and can have a different value
+    for every frame in which the object track appears
+-   `False`: the attribute is static and is the same for every frame in which
+    the object track appears
 
 .. _cvat-loading-annotations:
 

--- a/docs/source/integrations/cvat.rst
+++ b/docs/source/integrations/cvat.rst
@@ -574,6 +574,57 @@ take additional values:
 -   a list of custom attributes to include in the export
 -   a full dictionary syntax described above
 
+
+**Other attribute information**
+
+Different backends can allow for various other types of information to be
+specified for each attribute. An example of this in CVAT is the `mutable
+property of attributes <https://openvinotoolkit.github.io/cvat/docs/manual/basics/vocabulary/>`_.
+
+The `mutable` property is relevant when annotating tracks on videos. Setting it
+to `False` makes it so that the attribute is immutable throughout the track
+and as such only has to be annotated once for it to apply to every frame. When
+uploading labels with immutable attributes, it is expected that the immutable
+attributes are the same for all labels of the same index in a track in
+FiftyOne.
+
+By default, the `mutable` property of all attributes is set to `True` unless
+specified as shown below.
+
+.. code:: python
+    :linenos:
+
+    anno_key = "..."
+
+    attributes = {
+        "occluded": {
+            "type": "radio",
+            "values": [True, False],
+            "default": True,
+            "other": {
+                "mutable": True,
+            }
+        },
+        "weather": {
+            "type": "select",
+            "values": ["cloudy", "sunny", "overcast"],
+            "other": {
+                "mutable": False,
+            }
+        },
+        "caption": {
+            "type": "text",
+        }
+    }
+
+    view.annotate(
+        anno_key,
+        label_field="frames.new_field",
+        label_type="detections",
+        classes=["dog", "cat", "person"],
+        attributes=attributes,
+    )
+
 .. note::
 
     Only scalar-valued label attributes are supported. Other attribute types

--- a/docs/source/user_guide/annotation.rst
+++ b/docs/source/user_guide/annotation.rst
@@ -605,13 +605,11 @@ attribute that you wish to label:
         "occluded": {
             "type": "radio",
             "values": [True, False],
-            "default": True,
-            "mutable": True,
+            "default": False,
         },
-        "weather": {
+        "gender": {
             "type": "select",
-            "values": ["cloudy", "sunny", "overcast"],
-            "mutable": False,
+            "values": ["male", "female"],
         },
         "caption": {
             "type": "text",
@@ -621,7 +619,7 @@ attribute that you wish to label:
     view.annotate(
         anno_key,
         label_field="new_field",
-        label_type="frames.detections",
+        label_type="detections",
         classes=["dog", "cat", "person"],
         attributes=attributes,
     )
@@ -644,7 +642,6 @@ For example, CVAT supports the following choices for `type`:
 -   `checkbox`: a boolean checkbox UI. In this case, `default` is optional and
     `values` is unused
 
-
 When you are annotating existing label fields, the `attributes` parameter can
 take additional values:
 
@@ -655,25 +652,53 @@ take additional values:
 -   a list of custom attributes to include in the export
 -   a full dictionary syntax described above
 
-
-**For videos,** the `mutable` property can be used by most annotation backends when
-annotating object tracks. Setting it
-to `False` makes it so that the attribute is immutable throughout the track
-and as such only has to be annotated once for it to apply to every frame. When
-uploading existing objects with an immutable attribute, it is expected that the value
-of the attribute is constant for all objects of the same index in a video in
-FiftyOne. For example, CVAT supports the following choices for `mutable`:
-
--   `True` (default): the attribute is dynamic and can have a different value
-    for every frame in which the object appears
--   `False`: the value of the attribute is the same for every frame
-    in which the object appears
-
-
 .. note::
 
     Only scalar-valued label attributes are supported. Other attribute types
     like lists, dictionaries, and arrays will be omitted.
+
+.. _annotation-video-label-attributes:
+
+Video label attributes
+----------------------
+
+When annotating spatiotemporal objects in videos, each object attribute
+specification can include a `mutable` property that controls whether the
+attribute's value can change between frames for each object:
+
+.. code:: python
+    :linenos:
+
+    anno_key = "..."
+
+    attributes = {
+        "type": {
+            "type": "select",
+            "values": ["sedan", "suv", "truck"],
+            "mutable": False,
+        },
+        "occluded": {
+            "type": "radio",
+            "values": [True, False],
+            "default": False,
+            "mutable": True,
+        },
+    }
+
+    view.annotate(
+        anno_key,
+        label_field="frames.new_field",
+        label_type="detections",
+        classes=["vehicle"],
+        attributes=attributes,
+    )
+
+The meaning of the `mutable` attribute is defined as follows:
+
+-   `True` (default): the attribute is dynamic and can have a different value
+    for every frame in which the object track appears
+-   `False`: the attribute is static and is the same for every frame in which
+    the object track appears
 
 .. _loading-annotations:
 

--- a/docs/source/user_guide/annotation.rst
+++ b/docs/source/user_guide/annotation.rst
@@ -644,8 +644,20 @@ For example, CVAT supports the following choices for `type`:
 -   `checkbox`: a boolean checkbox UI. In this case, `default` is optional and
     `values` is unused
 
-The `mutable` property can be used by most annotation backends when
-annotating object tracks in videos. Setting it
+
+When you are annotating existing label fields, the `attributes` parameter can
+take additional values:
+
+-   `True` (default): export all custom attributes observed on the existing
+    labels, using their observed values to determine the appropriate UI type
+    and possible values, if applicable
+-   `False`: do not include any custom attributes in the export
+-   a list of custom attributes to include in the export
+-   a full dictionary syntax described above
+
+
+**For videos,** the `mutable` property can be used by most annotation backends when
+annotating object tracks. Setting it
 to `False` makes it so that the attribute is immutable throughout the track
 and as such only has to be annotated once for it to apply to every frame. When
 uploading existing objects with an immutable attribute, it is expected that the value
@@ -657,15 +669,6 @@ FiftyOne. For example, CVAT supports the following choices for `mutable`:
 -   `False`: the value of the attribute is the same for every frame
     in which the object appears
 
-When you are annotating existing label fields, the `attributes` parameter can
-take additional values:
-
--   `True` (default): export all custom attributes observed on the existing
-    labels, using their observed values to determine the appropriate UI type
-    and possible values, if applicable
--   `False`: do not include any custom attributes in the export
--   a list of custom attributes to include in the export
--   a full dictionary syntax described above
 
 .. note::
 

--- a/docs/source/user_guide/annotation.rst
+++ b/docs/source/user_guide/annotation.rst
@@ -606,10 +606,12 @@ attribute that you wish to label:
             "type": "radio",
             "values": [True, False],
             "default": True,
+            "mutable": True,
         },
         "weather": {
             "type": "select",
             "values": ["cloudy", "sunny", "overcast"],
+            "mutable": False,
         },
         "caption": {
             "type": "text",
@@ -619,7 +621,7 @@ attribute that you wish to label:
     view.annotate(
         anno_key,
         label_field="new_field",
-        label_type="detections",
+        label_type="frames.detections",
         classes=["dog", "cat", "person"],
         attributes=attributes,
     )
@@ -641,6 +643,19 @@ For example, CVAT supports the following choices for `type`:
     `default` is optional
 -   `checkbox`: a boolean checkbox UI. In this case, `default` is optional and
     `values` is unused
+
+The `mutable` property can be used by most annotation backends when
+annotating object tracks in videos. Setting it
+to `False` makes it so that the attribute is immutable throughout the track
+and as such only has to be annotated once for it to apply to every frame. When
+uploading existing objects with an immutable attribute, it is expected that the value
+of the attribute is constant for all objects of the same index in a video in
+FiftyOne. For example, CVAT supports the following choices for `mutable`:
+
+-   `True` (default): the attribute is dynamic and can have a different value
+    for every frame in which the object appears
+-   `False`: the value of the attribute is the same for every frame
+    in which the object appears
 
 When you are annotating existing label fields, the `attributes` parameter can
 take additional values:

--- a/fiftyone/utils/annotations.py
+++ b/fiftyone/utils/annotations.py
@@ -1061,6 +1061,23 @@ class AnnotationBackend(foa.AnnotationMethod):
             "subclass must implement requires_attr_values()"
         )
 
+    def format_other_attr_info(self, other_attr_info):
+        """Parses and formats backend-specific properties of attributes other
+        than the default "type", "values", and "default". 
+
+        For example, CVAT allows the `mutable` property to be set on
+        attributes here.
+
+        Args:
+            other_attr_info: a dict of attribute property names mapped to the
+                value for that property for a given attribute
+
+        Returns:
+            a dict of the attribute property names to the parsed and formatted
+            property values
+        """
+        return {}
+
     def upload_annotations(self, samples, launch_editor=False):
         """Uploads the samples and relevant existing labels from the label
         schema to the annotation backend.

--- a/fiftyone/utils/annotations.py
+++ b/fiftyone/utils/annotations.py
@@ -489,6 +489,7 @@ def _format_attributes(backend, attributes):
         attr_type = attr_info.get("type", None)
         values = attr_info.get("values", None)
         default = attr_info.get("default", None)
+        other = attr_info.get("other", None)
 
         if attr_type is None:
             if values is None:
@@ -530,6 +531,9 @@ def _format_attributes(backend, attributes):
                     )
 
                 formatted_info["default"] = default
+
+        backend.format_other_attr_info(other)
+        formatted_info["other"] = other
 
         output_attrs[attr] = formatted_info
 

--- a/fiftyone/utils/annotations.py
+++ b/fiftyone/utils/annotations.py
@@ -489,7 +489,7 @@ def _format_attributes(backend, attributes):
         attr_type = attr_info.get("type", None)
         values = attr_info.get("values", None)
         default = attr_info.get("default", None)
-        other = attr_info.get("other", None)
+        mutable = attr_info.get("mutable", True)
 
         if attr_type is None:
             if values is None:
@@ -532,9 +532,7 @@ def _format_attributes(backend, attributes):
 
                 formatted_info["default"] = default
 
-        backend.format_other_attr_info(other)
-        formatted_info["other"] = other
-
+        formatted_info["mutable"] = mutable
         output_attrs[attr] = formatted_info
 
     return output_attrs
@@ -1060,23 +1058,6 @@ class AnnotationBackend(foa.AnnotationMethod):
         raise NotImplementedError(
             "subclass must implement requires_attr_values()"
         )
-
-    def format_other_attr_info(self, other_attr_info):
-        """Parses and formats backend-specific properties of attributes other
-        than the default "type", "values", and "default". 
-
-        For example, CVAT allows the `mutable` property to be set on
-        attributes here.
-
-        Args:
-            other_attr_info: a dict of attribute property names mapped to the
-                value for that property for a given attribute
-
-        Returns:
-            a dict of the attribute property names to the parsed and formatted
-            property values
-        """
-        return {}
 
     def upload_annotations(self, samples, launch_editor=False):
         """Uploads the samples and relevant existing labels from the label

--- a/fiftyone/utils/cvat.py
+++ b/fiftyone/utils/cvat.py
@@ -3525,6 +3525,7 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
                 shapes = track["shapes"]
                 for shape in shapes:
                     shape["label_id"] = label_id
+
                 immutable_attrs = track["attributes"]
 
                 track_shape_results = self._parse_shapes_tags(
@@ -3824,6 +3825,7 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
                     mutable = bool(val)
                     if not mutable:
                         immutable_attrs.append(attr_name)
+
                     cvat_attr["mutable"] = mutable
 
             cvat_attrs[attr_name] = cvat_attr
@@ -4335,6 +4337,7 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
                 for attr in shape["attributes"]:
                     attr_name = attr["spec_id"]
                     attr["spec_id"] = attr_id_map[attr_name]
+
             for attr in track["attributes"]:
                 attr_name = attr["spec_id"]
                 attr["spec_id"] = attr_id_map[attr_name]
@@ -4441,8 +4444,8 @@ class CVATShape(CVATLabel):
         attr_id_map: a dictionary mapping attribute ids attribute names for
             every label
         index (None): the track index of the shape
-        immutable_attrs (None): attributes that are immutable for all shapes in the
-            track, this shape included
+        immutable_attrs (None): immutable attributes inherited by this shape
+            from its track
     """
 
     def __init__(
@@ -4460,8 +4463,7 @@ class CVATShape(CVATLabel):
         self.points = label_dict["points"]
         self.index = index
 
-        # Immutable attributes are simply added like every other attribute to
-        # this Shape
+        # Add immutable attributes to shape
         if immutable_attrs is not None:
             for attr in immutable_attrs:
                 name = self.attr_id_map_rev[attr["spec_id"]]

--- a/fiftyone/utils/cvat.py
+++ b/fiftyone/utils/cvat.py
@@ -2523,14 +2523,6 @@ class CVATBackend(foua.AnnotationBackend):
     def requires_attr_values(self, attr_type):
         return attr_type != "text"
 
-    def format_other_attr_info(self, other_attr_info):
-        formatted_info = {"mutable": True}
-        if other_attr_info is not None:
-            mutable = other_attr_info.get("mutable", True)
-            formatted_info["mutable"] = mutable
-
-        return formatted_info
-
     def connect_to_api(self):
         return CVATAnnotationAPI(
             self.config.name,
@@ -3828,8 +3820,8 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
                     cvat_attr["values"] = [str(v) for v in val]
                 elif attr_key == "default":
                     cvat_attr["default_value"] = str(val)
-                elif attr_key == "other":
-                    mutable = val.get("mutable", True)
+                elif attr_key == "mutable":
+                    mutable = bool(val)
                     if not mutable:
                         immutable_attrs.append(attr_name)
                     cvat_attr["mutable"] = mutable

--- a/fiftyone/utils/cvat.py
+++ b/fiftyone/utils/cvat.py
@@ -2523,6 +2523,14 @@ class CVATBackend(foua.AnnotationBackend):
     def requires_attr_values(self, attr_type):
         return attr_type != "text"
 
+    def format_other_attr_info(self, other_attr_info):
+        formatted_info = {"mutable": True}
+        if other_attr_info is not None:
+            mutable = other_attr_info.get("mutable", True)
+            formatted_info["mutable"] = mutable
+
+        return formatted_info
+
     def connect_to_api(self):
         return CVATAnnotationAPI(
             self.config.name,
@@ -3214,7 +3222,7 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
         for label_field, label_info in label_schema.items():
             label_type = label_info["type"]
             classes = label_info["classes"]
-            cvat_attrs = self._construct_cvat_attributes(
+            cvat_attrs, immutable_attrs = self._construct_cvat_attributes(
                 label_info["attributes"]
             )
             is_existing_field = label_info["existing_field"]
@@ -3298,6 +3306,7 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
                             classes,
                             is_shape=True,
                             load_tracks=True,
+                            immutable_attr_names=immutable_attrs,
                         )
                     elif label_type in (
                         "classification",
@@ -3524,6 +3533,7 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
                 shapes = track["shapes"]
                 for shape in shapes:
                     shape["label_id"] = label_id
+                immutable_attrs = track["attributes"]
 
                 track_shape_results = self._parse_shapes_tags(
                     "track",
@@ -3535,6 +3545,7 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
                     frames,
                     assigned_scalar_attrs=_scalar_attrs,
                     track_index=track_index,
+                    immutable_attrs=immutable_attrs,
                 )
                 label_field_results = self._merge_results(
                     label_field_results, track_shape_results
@@ -3567,6 +3578,7 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
         frames,
         assigned_scalar_attrs=False,
         track_index=None,
+        immutable_attrs=None,
     ):
         """Parses the shapes or tags from the given CVAT annotations into a
         label results dict.
@@ -3640,6 +3652,7 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
                 frames,
                 assigned_scalar_attrs=assigned_scalar_attrs,
                 track_index=track_index,
+                immutable_attrs=immutable_attrs,
             )
 
         if (
@@ -3669,6 +3682,7 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
                 frames,
                 assigned_scalar_attrs=assigned_scalar_attrs,
                 track_index=track_index,
+                immutable_attrs=immutable_attrs,
             )
 
         return results
@@ -3686,6 +3700,7 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
         frames,
         assigned_scalar_attrs=False,
         track_index=None,
+        immutable_attrs=None,
     ):
         frame = anno["frame"]
         if len(frames) > frame:
@@ -3712,7 +3727,12 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
                     anno["attributes"] = []
 
             cvat_shape = CVATShape(
-                anno, class_map, attr_id_map, metadata, index=track_index
+                anno,
+                class_map,
+                attr_id_map,
+                metadata,
+                index=track_index,
+                immutable_attrs=immutable_attrs,
             )
             if shape_type == "rectangle":
                 label_type = "detections"
@@ -3798,6 +3818,7 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
 
     def _construct_cvat_attributes(self, attributes):
         cvat_attrs = {}
+        immutable_attrs = []
         for attr_name, info in attributes.items():
             cvat_attr = {"name": attr_name, "mutable": True}
             for attr_key, val in info.items():
@@ -3807,10 +3828,15 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
                     cvat_attr["values"] = [str(v) for v in val]
                 elif attr_key == "default":
                     cvat_attr["default_value"] = str(val)
+                elif attr_key == "other":
+                    mutable = val.get("mutable", True)
+                    if not mutable:
+                        immutable_attrs.append(attr_name)
+                    cvat_attr["mutable"] = mutable
 
             cvat_attrs[attr_name] = cvat_attr
 
-        return cvat_attrs
+        return cvat_attrs, immutable_attrs
 
     def _create_shapes_tags_tracks(
         self,
@@ -3822,6 +3848,7 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
         is_shape=False,
         load_tracks=False,
         assign_scalar_attrs=False,
+        immutable_attr_names=None,
     ):
         tags_or_shapes = []
         tracks = {}
@@ -3876,6 +3903,7 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
                             attributes,
                             class_name,
                             remapped_attrs,
+                            _,
                         ) = self._create_attributes(cls, attr_names, classes)
                         if class_name is None:
                             continue
@@ -3945,6 +3973,7 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
                         classes,
                         frame_id,
                         load_tracks=load_tracks,
+                        immutable_attr_names=immutable_attr_names,
                     )
                     remapped_attr_names.update(remapped_attrs)
                     tags_or_shapes.extend(shapes)
@@ -3985,6 +4014,8 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
                             track["shapes"]
                         )
                         if tracks[class_name][index]["frame"] > track["frame"]:
+                            # The track frame indicates the first frame with a
+                            # shape from this track
                             tracks[class_name][index]["frame"] = track["frame"]
 
         return tracks
@@ -4017,13 +4048,22 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
         classes,
         frame_id,
         load_tracks=False,
+        immutable_attr_names=None,
     ):
         shapes = []
         tracks = {}
         remapped_attr_names = {}
         for kp in keypoints:
-            attributes, class_name, remapped_attrs = self._create_attributes(
-                kp, attr_names, classes
+            (
+                attributes,
+                class_name,
+                remapped_attrs,
+                immutable_attrs,
+            ) = self._create_attributes(
+                kp,
+                attr_names,
+                classes,
+                immutable_attr_names=immutable_attr_names,
             )
             if class_name is None:
                 continue
@@ -4057,7 +4097,7 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
                     tracks[class_name][index]["shapes"] = []
                     tracks[class_name][index]["frame"] = frame_id
                     tracks[class_name][index]["group"] = 0
-                    tracks[class_name][index]["attributes"] = []
+                    tracks[class_name][index]["attributes"] = immutable_attrs
 
                 shape["outside"] = False
                 del shape["label_id"]
@@ -4076,13 +4116,22 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
         classes,
         frame_id,
         load_tracks=False,
+        immutable_attr_names=None,
     ):
         shapes = []
         tracks = {}
         remapped_attr_names = {}
         for poly in polylines:
-            attributes, class_name, remapped_attrs = self._create_attributes(
-                poly, attr_names, classes
+            (
+                attributes,
+                class_name,
+                remapped_attrs,
+                immutable_attrs,
+            ) = self._create_attributes(
+                poly,
+                attr_names,
+                classes,
+                immutable_attr_names=immutable_attr_names,
             )
             if class_name is None:
                 continue
@@ -4130,7 +4179,7 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
                     tracks[class_name][index]["shapes"] = []
                     tracks[class_name][index]["frame"] = frame_id
                     tracks[class_name][index]["group"] = 0
-                    tracks[class_name][index]["attributes"] = []
+                    tracks[class_name][index]["attributes"] = immutable_attrs
 
                 shape["outside"] = False
                 del shape["label_id"]
@@ -4149,13 +4198,22 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
         classes,
         frame_id,
         load_tracks=False,
+        immutable_attr_names=None,
     ):
         shapes = []
         tracks = {}
         remapped_attr_names = {}
         for det in detections:
-            attributes, class_name, remapped_attrs = self._create_attributes(
-                det, attr_names, classes
+            (
+                attributes,
+                class_name,
+                remapped_attrs,
+                immutable_attrs,
+            ) = self._create_attributes(
+                det,
+                attr_names,
+                classes,
+                immutable_attr_names=immutable_attr_names,
             )
             if class_name is None:
                 continue
@@ -4216,7 +4274,7 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
                     tracks[class_name][index]["shapes"] = []
                     tracks[class_name][index]["frame"] = frame_id
                     tracks[class_name][index]["group"] = 0
-                    tracks[class_name][index]["attributes"] = []
+                    tracks[class_name][index]["attributes"] = immutable_attrs
 
                 shape["outside"] = False
                 del shape["label_id"]
@@ -4226,12 +4284,19 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
 
         return shapes, tracks, remapped_attr_names
 
-    def _create_attributes(self, label, attributes, classes):
+    def _create_attributes(
+        self, label, attributes, classes, immutable_attr_names=None
+    ):
         label_attrs = []
         remapped_attr_names = {}
+        immutable_attrs = []
         label_attrs.append({"spec_id": "label_id", "value": label.id})
         for attribute in attributes:
             value = None
+            is_immutable = (immutable_attr_names is not None) and (
+                attribute in immutable_attr_names
+            )
+
             if attribute in label:
                 value = label[attribute]
 
@@ -4243,14 +4308,18 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
                     attribute = new_attribute
 
             if value is not None:
-                label_attrs.append({"spec_id": attribute, "value": str(value)})
+                attr_dict = {"spec_id": attribute, "value": str(value)}
+                if is_immutable:
+                    immutable_attrs.append(attr_dict)
+                else:
+                    label_attrs.append(attr_dict)
 
         if "label" in label and label["label"] in classes:
             class_name = label["label"]
         else:
             class_name = None
 
-        return label_attrs, class_name, remapped_attr_names
+        return label_attrs, class_name, remapped_attr_names, immutable_attrs
 
     def _remap_ids(self, shapes_or_tags, attribute_id_map, class_id_map):
         for obj in shapes_or_tags:
@@ -4274,6 +4343,9 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
                 for attr in shape["attributes"]:
                     attr_name = attr["spec_id"]
                     attr["spec_id"] = attr_id_map[attr_name]
+            for attr in track["attributes"]:
+                attr_name = attr["spec_id"]
+                attr["spec_id"] = attr_id_map[attr_name]
 
         return tracks
 
@@ -4314,10 +4386,10 @@ class CVATLabel(object):
         self.label_id = label_id
         self.class_name = class_map[label_id]
         self.attributes = {}
-        attr_id_map_rev = {v: k for k, v in attr_id_map[label_id].items()}
+        self.attr_id_map_rev = {v: k for k, v in attr_id_map[label_id].items()}
 
         for attr in label_dict["attributes"]:
-            name = attr_id_map_rev[attr["spec_id"]]
+            name = self.attr_id_map_rev[attr["spec_id"]]
             val = _parse_attribute(attr["value"])
             if val is not None and val != "":
                 self.attributes[name] = CVATAttribute(name=name, value=val)
@@ -4376,16 +4448,34 @@ class CVATShape(CVATLabel):
         class_map: a dictionary mapping label ids to class strings
         attr_id_map: a dictionary mapping attribute ids attribute names for
             every label
+        index (None): the track index of the shape
+        immutable_attrs (None): attributes that are immutable for all shapes in the
+            track, this shape included
     """
 
     def __init__(
-        self, label_dict, class_map, attr_id_map, metadata, index=None
+        self,
+        label_dict,
+        class_map,
+        attr_id_map,
+        metadata,
+        index=None,
+        immutable_attrs=None,
     ):
         super().__init__(label_dict, class_map, attr_id_map)
         self.width = metadata["width"]
         self.height = metadata["height"]
         self.points = label_dict["points"]
         self.index = index
+
+        # Immutable attributes are simply added like every other attribute to
+        # this Shape
+        if immutable_attrs is not None:
+            for attr in immutable_attrs:
+                name = self.attr_id_map_rev[attr["spec_id"]]
+                val = _parse_attribute(attr["value"])
+                if val is not None and val != "":
+                    self.attributes[name] = CVATAttribute(name=name, value=val)
 
     def _to_pairs_of_points(self, points):
         reshaped_points = np.reshape(points, (-1, 2))


### PR DESCRIPTION
When annotating object tracks on videos in CVAT, the `mutable` property of the attributes determines if the attribute can change in value from one frame to another (`mutable=True`) or if the value of the attribute must remain fixed throughout the track (`mutable=False`). At the moment (and by default in the future unless specified), all attributes are set to `mutable=True`.

This PR allows you to configure the mutable property of attributes in the label schema. It is expected that any future backend that allows for object attribute annotation in video will also support some notion of `mutable`.

Annotating new immutable attributes:
```python
import fiftyone as fo
import fiftyone.zoo as foz

dataset = foz.load_zoo_dataset("quickstart-video", max_samples=1)

attrs = {
    "occluded": {
        "type": "radio",
        "values": [0, 0.25, 0.5, 1],
        "default": 0,
        "mutable": False,
    }
}

dataset.annotate(
    "annot",
    label_field="frames.detections",
    attributes=attrs,
    launch_editor=True,
)

# Annotate some of the attributes in CVAT
input()

dataset.load_annotations("annot", cleanup=True)
session = fo.launch_app(dataset)
```

Loading existing immutable attributes from FiftyOne into CVAT:
```python
attrs = {
    "occluded": {
        "type": "radio",
        "values": [0, 0.25, 0.5, 1],
        "default": 0,
        "mutable": False,
    }
}

dataset.annotate(
    "annot2",
    label_field="frames.detections",
    attributes=attrs,
    launch_editor=True,
)

# Change some of the attributes in CVAT
input()

dataset.load_annotations("annot2", cleanup=True)
session = fo.launch_app(dataset)
```

### Updated documnetation
![Screenshot from 2021-09-21 15-16-34](https://user-images.githubusercontent.com/21222883/134233725-99377518-1908-47e9-96f6-5b3c329d97c3.png)


