### PR TITLE
Adding support for loading GeoTIFF images

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -147,6 +147,7 @@ intersphinx_mapping = {
     "mongoengine": ("https://docs.mongoengine.org/", None),
     "sklearn": ("https://scikit-learn.org/stable/", None),
     "pydicom": ("https://pydicom.github.io/pydicom/stable/", None),
+    "rasterio": ("https://rasterio.readthedocs.io/en/latest/", None),
 }
 
 # -- Options for HTML output -------------------------------------------------

--- a/docs/source/faq/index.rst
+++ b/docs/source/faq/index.rst
@@ -161,8 +161,8 @@ which includes standard image types like JPEG, PNG, and BMP.
 Some browsers like Safari natively support other image types such as TIFF,
 while others do not. You may be able to install a browser extension to work
 with additional image types. For example, you can install
-`this extension <https://chrome.google.com/webstore/detail/tiff-viewer/fciggfkkblggmebjbekbebbcffeacknj>`_
-to view TIFF images in Chrome.
+`this extension <https://github.com/my-codeworks/tiff-viewer-extension>`_ to
+view TIFF images in Chrome or Firefox.
 
 .. note::
 

--- a/docs/source/user_guide/dataset_creation/datasets.rst
+++ b/docs/source/user_guide/dataset_creation/datasets.rst
@@ -3004,7 +3004,7 @@ The dataset will contain a |GeoLocation| field whose
 `(longitude, latitude)` coordinates of each image center and whose
 :attr:`polygon <fiftyone.core.labels.GeoLocation.polygon>` attribute contains
 the `(longitude, latitude)` coordinates of the corners of the image (clockwise,
-starting from the top-left cornder).
+starting from the top-left corner).
 
 .. note::
 
@@ -3053,7 +3053,7 @@ format as follows:
         fiftyone datasets create \
             --name $NAME \
             --dataset-dir $DATASET_DIR \
-            --type fiftyone.types.GeoTIFFDataset
+            --type fiftyone.types.GeoTIFFDataset \
             --kwargs label_field=location
 
         # View summary info about the dataset

--- a/docs/source/user_guide/dataset_creation/datasets.rst
+++ b/docs/source/user_guide/dataset_creation/datasets.rst
@@ -224,6 +224,9 @@ format when reading the dataset from disk.
     | :ref:`GeoJSONDataset <GeoJSONDataset-import>`                                         | An image or video dataset whose location data and labels are stored in             |
     |                                                                                       | `GeoJSON format <https://en.wikipedia.org/wiki/GeoJSON>`_.                         |
     +---------------------------------------------------------------------------------------+------------------------------------------------------------------------------------+
+    | :ref:`GeoTIFFDataset <GeoTIFFDataset-import>`                                         | An image dataset whose image and geolocation data are stored in                    |
+    |                                                                                       | `GeoTIFF format <https://en.wikipedia.org/wiki/GeoTIFF>`_.                         |
+    +---------------------------------------------------------------------------------------+------------------------------------------------------------------------------------+
     | :ref:`FiftyOneVideoLabelsDataset <FiftyOneVideoLabelsDataset-import>`                 | A labeled dataset consisting of videos and their associated multitask predictions  |
     |                                                                                       | stored in `ETA VideoLabels format \                                                |
     |                                                                                       | <https://github.com/voxel51/eta/blob/develop/docs/video_labels_guide.md>`_.        |
@@ -2966,6 +2969,150 @@ format as follows:
         fiftyone app view \
             --dataset-dir $DATASET_DIR \
             --type fiftyone.types.GeoJSONDataset
+
+.. _GeoTIFFDataset-import:
+
+GeoTIFFDataset
+--------------
+
+The :class:`fiftyone.types.GeoTIFFDataset <fiftyone.types.dataset_types.GeoTIFFDataset>`
+type represents a dataset consisting of images and their associated geolocation
+data stored in `GeoTIFF format <https://en.wikipedia.org/wiki/GeoTIFF>`_.
+
+.. note::
+
+    You must have `rasterio <https://github.com/mapbox/rasterio>`_ installed in
+    order to load GeoTIFF datasets.
+
+The standard format for datasets of this type is the following:
+
+.. code-block:: text
+
+    <dataset_dir>/
+        <filename1>.tif
+        <filename2>.tif
+
+where each `.tif` file is a GeoTIFF image that can be read via
+:func:`rasterio.open <rasterio:rasterio.open>`.
+
+Alternatively, rather than providing a ``dataset_dir``, you can provide the
+``image_path`` argument, which can directly specify a list or glob pattern of
+GeoTIFF images to load.
+
+The dataset will contain a |GeoLocation| field whose
+:attr:`point <fiftyone.core.labels.GeoLocation.point>` attribute contains the
+`(longitude, latitude)` coordinates of each image center and whose
+:attr:`polygon <fiftyone.core.labels.GeoLocation.polygon>` attribute contains
+the `(longitude, latitude)` coordinates of the corners of the image (clockwise,
+starting from the top-left cornder).
+
+.. note::
+
+    See :class:`GeoTIFFDatasetImporter <fiftyone.utils.geotiff.GeoTIFFDatasetImporter>`
+    for parameters that can be passed to methods like
+    :meth:`Dataset.from_dir() <fiftyone.core.dataset.Dataset.from_dir>` to
+    customize the import of datasets of this type.
+
+You can create a FiftyOne dataset from a GeoTIFF dataset stored in standard
+format as follows:
+
+.. tabs::
+
+  .. group-tab:: Python
+
+    .. code-block:: python
+        :linenos:
+
+        import fiftyone as fo
+
+        name = "my-dataset"
+        dataset_dir = "/path/to/geotiff-dataset"
+
+        # Create the dataset
+        dataset = fo.Dataset.from_dir(
+            dataset_dir=dataset_dir,
+            dataset_type=fo.types.GeoTIFFDataset,
+            label_field="location",
+            name=name,
+        )
+
+        # View summary info about the dataset
+        print(dataset)
+
+        # Print the first few samples in the dataset
+        print(dataset.head())
+
+  .. group-tab:: CLI
+
+    .. code-block:: shell
+
+        NAME=my-dataset
+        DATASET_DIR=/path/to/geotiff-dataset
+
+        # Create the dataset
+        fiftyone datasets create \
+            --name $NAME \
+            --dataset-dir $DATASET_DIR \
+            --type fiftyone.types.GeoTIFFDataset
+            --kwargs label_field=location
+
+        # View summary info about the dataset
+        fiftyone datasets info $NAME
+
+        # Print the first few samples in the dataset
+        fiftyone datasets head $NAME
+
+You can create a FiftyOne dataset from a list or glob pattern of GeoTIFF images
+as follows:
+
+.. tabs::
+
+  .. group-tab:: Python
+
+    .. code-block:: python
+        :linenos:
+
+        import fiftyone as fo
+
+        name = "my-dataset"
+        image_path = "/path/to/*.tif"  # glob pattern of GeoTIFF images
+        # image_path = ["/path/to/image1.tif", ...]  # list of GeoTIFF images
+
+        # Create the dataset
+        dataset = fo.Dataset.from_dir(
+            image_path=image_path,
+            dataset_type=fo.types.GeoTIFFDataset,
+            label_field="location",
+            name=name,
+        )
+
+        # View summary info about the dataset
+        print(dataset)
+
+        # Print the first few samples in the dataset
+        print(dataset.head())
+
+  .. group-tab:: CLI
+
+    .. code-block:: shell
+
+        NAME=my-dataset
+        IMAGE_PATH='/path/to/*.tif'  # glob pattern of GeoTIFF images
+        # IMAGE_PATH='/path/to/image1.tif,...'  # list of GeoTIFF images
+
+        # Create the dataset
+        fiftyone datasets create \
+            --name $NAME \
+            --type fiftyone.types.GeoTIFFDataset \
+            --kwargs \
+                image_path=$IMAGE_PATH \
+                label_field=location
+
+        # View summary info about the dataset
+        fiftyone datasets info $NAME
+
+        # Print the first few samples in the dataset
+        fiftyone datasets head $NAME
 
 .. _FiftyOneDataset-import:
 

--- a/docs/source/user_guide/using_datasets.rst
+++ b/docs/source/user_guide/using_datasets.rst
@@ -1795,7 +1795,7 @@ can easily retrieve the raw GeoJSON data for a slice of your dataset using the
 
     dataset = foz.load_zoo_dataset("quickstart-geo")
 
-    values = dataset.take(5).values("location.point")
+    values = dataset.take(5).values("location.point", _raw=True)
     print(values)
 
 .. code-block:: text

--- a/fiftyone/types/dataset_types.py
+++ b/fiftyone/types/dataset_types.py
@@ -709,6 +709,20 @@ class GeoJSONDataset(LabeledDataset):
         return foug.GeoJSONDatasetExporter
 
 
+class GeoTIFFDataset(ImageLabelsDataset):
+    """An image dataset whose image and geolocation data are stored in
+    `GeoTIFF format <https://en.wikipedia.org/wiki/GeoTIFF>`_.
+
+    See :ref:`this page <GeoTIFFDataset-import>` for importing datasets of this
+    type.
+    """
+
+    def get_dataset_importer_cls(self):
+        import fiftyone.utils.geotiff as foug
+
+        return foug.GeoTIFFDatasetImporter
+
+
 class FiftyOneDataset(Dataset):
     """A disk representation of an entire
     :class:`fiftyone.core.dataset.Dataset` stored on disk in a serialized JSON

--- a/fiftyone/utils/geotiff.py
+++ b/fiftyone/utils/geotiff.py
@@ -1,0 +1,128 @@
+"""
+GeoTIFF utilities.
+
+| Copyright 2017-2021, Voxel51, Inc.
+| `voxel51.com <https://voxel51.com/>`_
+|
+"""
+import eta.core.image as etai
+import eta.core.utils as etau
+
+import fiftyone.core.labels as fol
+import fiftyone.core.metadata as fom
+import fiftyone.core.utils as fou
+import fiftyone.utils.data as foud
+
+pyproj = fou.lazy_import("pyproj")
+rasterio = fou.lazy_import(
+    "rasterio", callback=lambda: fou.ensure_package("rasterio")
+)
+
+
+def get_geolocation(image_path):
+    """Retrieves the geolocation information from the given GeoTIFF image.
+
+    The returned :class:`fiftyone.core.labels.GeoLocation` will contain the
+    lon/lat coordinates of the center of the image in its ``point`` attribute
+    and the coordinates of its corners (clockwise, starting from the top-left)
+    in its ``polygon`` attribute.
+
+    Args:
+        image_path: the path to the GeoTIFF image
+
+    Returns:
+        a :class:`fiftyone.core.labels.GeoLocation`
+    """
+    image = rasterio.open(image_path, "r")
+
+    center = image.transform * (0.5 * image.width, 0.5 * image.height)
+
+    proj = pyproj.Proj(image.crs)
+    cp = proj(*center, inverse=True)
+    tl = proj(image.bounds.left, image.bounds.top, inverse=True)
+    tr = proj(image.bounds.right, image.bounds.top, inverse=True)
+    br = proj(image.bounds.right, image.bounds.bottom, inverse=True)
+    bl = proj(image.bounds.left, image.bounds.bottom, inverse=True)
+    image.close()
+
+    return fol.GeoLocation(point=cp, polygon=[[tl, tr, br, bl, tl]])
+
+
+class GeoTIFFDatasetImporter(foud.LabeledImageDatasetImporter):
+    """Importer for a directory of GeoTIFF images with geolocation data.
+
+    See :ref:`this page <GeoTIFFDataset-import>` for format details.
+
+    Args:
+        dataset_dir: the dataset directory
+        recursive (True): whether to recursively traverse subdirectories
+        compute_metadata (False): whether to produce
+            :class:`fiftyone.core.metadata.ImageMetadata` instances for each
+            image when importing
+        shuffle (False): whether to randomly shuffle the order in which the
+            samples are imported
+        seed (None): a random seed to use when shuffling
+        max_samples (None): a maximum number of samples to import. By default,
+            all samples are imported
+    """
+
+    def __init__(
+        self,
+        dataset_dir,
+        recursive=True,
+        compute_metadata=False,
+        shuffle=False,
+        seed=None,
+        max_samples=None,
+    ):
+        super().__init__(
+            dataset_dir=dataset_dir,
+            shuffle=shuffle,
+            seed=seed,
+            max_samples=max_samples,
+        )
+        self.recursive = recursive
+        self.compute_metadata = compute_metadata
+        self._filepaths = None
+        self._iter_filepaths = None
+        self._num_samples = None
+
+    def __iter__(self):
+        self._iter_filepaths = iter(self._filepaths)
+        return self
+
+    def __len__(self):
+        return self._num_samples
+
+    def __next__(self):
+        image_path = next(self._iter_filepaths)
+
+        if self.compute_metadata:
+            image_metadata = fom.ImageMetadata.build_for(image_path)
+        else:
+            image_metadata = None
+
+        label = get_geolocation(image_path)
+
+        return image_path, image_metadata, label
+
+    @property
+    def has_image_metadata(self):
+        return self.compute_metadata
+
+    @property
+    def has_dataset_info(self):
+        return False
+
+    @property
+    def label_cls(self):
+        return fol.GeoLocation
+
+    def setup(self):
+        filepaths = etau.list_files(
+            self.dataset_dir, abs_paths=True, recursive=self.recursive
+        )
+        filepaths = [p for p in filepaths if etai.is_image_mime_type(p)]
+
+        self._filepaths = self._preprocess_list(filepaths)
+        self._num_samples = len(self._filepaths)

--- a/fiftyone/utils/geotiff.py
+++ b/fiftyone/utils/geotiff.py
@@ -63,11 +63,11 @@ class GeoTIFFDatasetImporter(
             over the location of the GeoTIFF images. Can be any of the
             following:
 
+            -   a list of paths to GeoTIFF images. In this case,
+                ``dataset_dir`` has no effect
             -   a glob pattern like ``"*.tif"`` specifying the location of the
                 images in ``dataset_dir``
             -   an absolute glob pattern of GeoTIFF images. In this case,
-                ``dataset_dir`` has no effect
-            -   a list of paths to GeoTIFF images. In this case,
                 ``dataset_dir`` has no effect
         recursive (True): whether to recursively traverse subdirectories. Not
             applicable when ``image_path`` is provided
@@ -111,6 +111,7 @@ class GeoTIFFDatasetImporter(
         self.image_path = image_path
         self.recursive = recursive
         self.compute_metadata = compute_metadata
+
         self._filepaths = None
         self._iter_filepaths = None
         self._num_samples = None


### PR DESCRIPTION
Adds a `GeoTIFFDataset` format with support for loading datasets of GeoTIFF images and storing their geolocation data in a `GeoLocation` field.

Since the GeoTIFF standard dictates that GeoTIFF images should be viewable as regular TIFF images, no image type conversion is performed during import. The example below demonstrates that, at least for the example images I found, this assumption is true; i.e., the dataset can be viewed in the App as expected (as long as you have an appropriate TIFF viewer browser extension installed, which I believe is required in browsers like Chrome to view any TIFF image in the first place!)

The [rasterio](https://github.com/mapbox/rasterio) package must be installed in order to work with GeoTIFF images, which seems to be a reasonably popular and stable dependency to use for this.

The geolocation information loaded when working with datasets of this type can be conveniently used to construct [geolocation views](https://voxel51.com/docs/fiftyone/user_guide/using_views.html#geolocation) and to generate [location-based scatterplots](https://voxel51.com/docs/fiftyone/user_guide/plots.html#geolocation-plots).

### Setup

Install new dependency:

```
pip install rasterio
```

Download some test data:

```
DATASET_DIR=/tmp/geotiff

mkdir -p $DATASET_DIR
wget -P $DATASET_DIR https://download.osgeo.org/geotiff/samples/GeogToWGS84GeoKey/GeogToWGS84GeoKey5.tif
wget -P $DATASET_DIR https://download.osgeo.org/geotiff/samples/gdal_eg/cea.tif
wget -P $DATASET_DIR https://download.osgeo.org/geotiff/samples/pci_eg/acea.tif
wget -P $DATASET_DIR https://download.osgeo.org/geotiff/samples/spot/chicago/SP27GTIF.TIF
```

### Example usage

```py
import fiftyone as fo

dataset = fo.Dataset.from_dir(
    dataset_dir="/tmp/geotiff",
    dataset_type=fo.types.GeoTIFFDataset,
    label_field="location",
)

print(dataset)
print(dataset.first())
print(dataset.values("location.point"))

session = fo.launch_app(dataset)

# Example geo-query: show samples within 5km of Chicago
session.view = dataset.geo_near([-87.6298, 41.8781], max_distance=5000)
```

<img width="1269" alt="Screen Shot 2021-09-21 at 4 25 53 PM" src="https://user-images.githubusercontent.com/25985824/134242475-6c99d5a3-4c6c-47bf-b2d3-1b61f668066b.png">
