### PR TITLE
Annotation improvements

### DIFF
--- a/docs/source/integrations/cvat.rst
+++ b/docs/source/integrations/cvat.rst
@@ -358,28 +358,28 @@ details:
     `label_type`
 -   **label_field** (*None*): a string indicating a new or existing label field
     to annotate
--   **label_type** (*None*): a string or type indicating the type of labels to
-    annotate. The possible label strings/types are:
+-   **label_type** (*None*): a string indicating the type of labels to
+    annotate. The possible label types are:
 
-    -   `"classification"`: :class:`fiftyone.core.labels.Classification`
-    -   `"classifications"`: :class:`fiftyone.core.labels.Classifications`
-    -   `"detection"`: :class:`fiftyone.core.labels.Detection`
-    -   `"detections"`: :class:`fiftyone.core.labels.Detections`
-    -   `"segmentation"`: :class:`fiftyone.core.labels.Detection`
-    -   `"segmentations"`: :class:`fiftyone.core.labels.Detections`
-    -   `"polyline"`: :class:`fiftyone.core.labels.Polyline`
-    -   `"polylines"`: :class:`fiftyone.core.labels.Polylines`
-    -   `"keypoint"`: :class:`fiftyone.core.labels.Keypoint`
-    -   `"keypoints"`: :class:`fiftyone.core.labels.Keypoints`
-    -   `"semantic_segmentation"`: :class:`fiftyone.core.labels.Segmentation`
-
-    You can also specify `"scalar"` for a primitive scalar field or pass any of
-    the supported scalar field types:
-
-    -   :class:`fiftyone.core.fields.IntField`
-    -   :class:`fiftyone.core.fields.FloatField`
-    -   :class:`fiftyone.core.fields.StringField`
-    -   :class:`fiftyone.core.fields.BooleanField`
+    -   ``"classification"``: a single classification stored in
+        |Classification| fields
+    -   ``"classifications"``: multilabel classifications stored in
+        |Classifications| fields
+    -   ``"detections"``: object detections stored in |Detections| fields
+    -   ``"instances"``: instance segmentations stored in |Detections| fields
+        with their :attr:`mask <fiftyone.core.labels.Detection.mask>`
+        attributes populated
+    -   ``"polylines"``: polylines stored in |Polylines| fields with their
+        :attr:`mask <fiftyone.core.labels.Polyline.filled>` attributes set to
+        `False`
+    -   ``"polygons"``: polygons stored in |Polylines| fields with their
+        :attr:`mask <fiftyone.core.labels.Polyline.filled>` attributes set to
+        `True`
+    -   ``"keypoints"``: keypoints stored in |Keypoints| fields
+    -   ``"segmentation"``: semantic segmentations stored in |Segmentation|
+        fields
+    -   ``"scalar"``: scalar labels stored in |IntField|, |FloatField|,
+        |StringField|, or |BooleanField| fields
 
     All new label fields must have their type specified via this argument or in
     `label_schema`
@@ -399,6 +399,8 @@ details:
     -   a list of label attributes to export
     -   a dict mapping attribute names to dicts specifying the `type`,
         `values`, and `default` for each attribute
+-   **mask_targets** (*None*): a dict mapping pixel values to semantic label
+    strings. Only applicable when annotating semantic segmentations
 
 In addition, the following CVAT-specific parameters from
 :class:`CVATBackendConfig <fiftyone.utils.cvat.CVATBackendConfig>` can also be
@@ -417,8 +419,8 @@ provided:
 Label schema
 ------------
 
-The `label_schema`, `label_field`, `label_type`, `classes`, and `attributes`
-parameters to
+The `label_schema`, `label_field`, `label_type`, `classes`, `attributes`, and
+`mask_targets` parameters to
 :meth:`annotate() <fiftyone.core.collections.SampleCollection.annotate>` allow
 you to define the annotation schema that you wish to be used.
 
@@ -466,8 +468,9 @@ label field:
     dataset.annotate(anno_key, label_schema=label_schema)
 
 Alternatively, if you are only editing or creating a single label field, you
-can use the `label_field`, `label_type`, `classes`, and `attributes` parameters
-to specify the components of the label schema individually:
+can use the `label_field`, `label_type`, `classes`, `attributes`, and
+`mask_targets` parameters to specify the components of the label schema
+individually:
 
 .. code:: python
     :linenos:
@@ -507,11 +510,16 @@ FiftyOne can infer the appropriate values to use:
 
 -   **label_type**: if omitted, the |Label| type of the field will be used to
     infer the appropriate value for this parameter
--   **classes**: if omitted, the class lists from the
-    :meth:`classes <fiftyone.core.dataset.Dataset.classes>` or
+-   **classes**: if omitted for a non-semantic segmentation field, the class
+    lists from the :meth:`classes <fiftyone.core.dataset.Dataset.classes>` or
     :meth:`default_classes <fiftyone.core.dataset.Dataset.default_classes>`
     properties of your dataset will be used, if available. Otherwise, the
-    observed labels on your dataset will be used to construct a classes list
+    observed labels on your dataset will be used to construct a classes list.
+-   **mask_targets**: if omitted for a semantic segmentation field, the mask
+    targets from the
+    :meth:`mask_targets <fiftyone.core.dataset.Dataset.mask_targets>` or
+    :meth:`default_mask_targets <fiftyone.core.dataset.Dataset.default_mask_targets>`
+    properties of your dataset will be used, if available
 
 .. _cvat-label-attributes:
 

--- a/docs/source/user_guide/annotation.rst
+++ b/docs/source/user_guide/annotation.rst
@@ -435,28 +435,28 @@ more details:
     If this argument is provided, it takes precedence over the remaining fields
 -   **label_field** (*None*): a string indicating a new or existing label field
     to annotate
--   **label_type** (*None*): a string or type indicating the type of labels to
-    annotate. The possible label strings/types are:
+-   **label_type** (*None*): a string indicating the type of labels to
+    annotate. The possible label types are:
 
-    -   `"classification"`: :class:`fiftyone.core.labels.Classification`
-    -   `"classifications"`: :class:`fiftyone.core.labels.Classifications`
-    -   `"detection"`: :class:`fiftyone.core.labels.Detection`
-    -   `"detections"`: :class:`fiftyone.core.labels.Detections`
-    -   `"segmentation"`: :class:`fiftyone.core.labels.Detection`
-    -   `"segmentations"`: :class:`fiftyone.core.labels.Detections`
-    -   `"polyline"`: :class:`fiftyone.core.labels.Polyline`
-    -   `"polylines"`: :class:`fiftyone.core.labels.Polylines`
-    -   `"keypoint"`: :class:`fiftyone.core.labels.Keypoint`
-    -   `"keypoints"`: :class:`fiftyone.core.labels.Keypoints`
-    -   `"semantic_segmentation"`: :class:`fiftyone.core.labels.Segmentation`
-
-    You can also specify `"scalar"` for a primitive scalar field or pass any of
-    the supported scalar field types:
-
-    -   :class:`fiftyone.core.fields.IntField`
-    -   :class:`fiftyone.core.fields.FloatField`
-    -   :class:`fiftyone.core.fields.StringField`
-    -   :class:`fiftyone.core.fields.BooleanField`
+    -   ``"classification"``: a single classification stored in
+        |Classification| fields
+    -   ``"classifications"``: multilabel classifications stored in
+        |Classifications| fields
+    -   ``"detections"``: object detections stored in |Detections| fields
+    -   ``"instances"``: instance segmentations stored in |Detections| fields
+        with their :attr:`mask <fiftyone.core.labels.Detection.mask>`
+        attributes populated
+    -   ``"polylines"``: polylines stored in |Polylines| fields with their
+        :attr:`mask <fiftyone.core.labels.Polyline.filled>` attributes set to
+        `False`
+    -   ``"polygons"``: polygons stored in |Polylines| fields with their
+        :attr:`mask <fiftyone.core.labels.Polyline.filled>` attributes set to
+        `True`
+    -   ``"keypoints"``: keypoints stored in |Keypoints| fields
+    -   ``"segmentation"``: semantic segmentations stored in |Segmentation|
+        fields
+    -   ``"scalar"``: scalar labels stored in |IntField|, |FloatField|,
+        |StringField|, or |BooleanField| fields
 
     All new label fields must have their type specified via this argument or in
     `label_schema`
@@ -476,6 +476,8 @@ more details:
     -   a list of label attributes to export
     -   a dict mapping attribute names to dicts specifying the `type`,
         `values`, and `default` for each attribute
+-   **mask_targets** (*None*): a dict mapping pixel values to semantic label
+    strings. Only applicable when annotating semantic segmentations
 
 In addition, each annotation backend can typically be configured in a variety
 of backend-specific ways. See :ref:`this section <configuring-your-backend>`
@@ -490,8 +492,8 @@ for more details.
 Label schema
 ------------
 
-The `label_schema`, `label_field`, `label_type`, `classes`, and `attributes`
-parameters to
+The `label_schema`, `label_field`, `label_type`, `classes`, `attributes`, and
+`mask_targets` parameters to
 :meth:`annotate() <fiftyone.core.collections.SampleCollection.annotate>` allow
 you to define the annotation schema that you wish to be used.
 
@@ -539,8 +541,9 @@ label field:
     dataset.annotate(anno_key, label_schema=label_schema)
 
 Alternatively, if you are only editing or creating a single label field, you
-can use the `label_field`, `label_type`, `classes`, and `attributes` parameters
-to specify the components of the label schema individually:
+can use the `label_field`, `label_type`, `classes`, `attributes`, and
+`mask_targets` parameters to specify the components of the label schema
+individually:
 
 .. code:: python
     :linenos:
@@ -580,11 +583,16 @@ FiftyOne can infer the appropriate values to use:
 
 -   **label_type**: if omitted, the |Label| type of the field will be used to
     infer the appropriate value for this parameter
--   **classes**: if omitted, the class lists from the
-    :meth:`classes <fiftyone.core.dataset.Dataset.classes>` or
+-   **classes**: if omitted for a non-semantic segmentation field, the class
+    lists from the :meth:`classes <fiftyone.core.dataset.Dataset.classes>` or
     :meth:`default_classes <fiftyone.core.dataset.Dataset.default_classes>`
     properties of your dataset will be used, if available. Otherwise, the
-    observed labels on your dataset will be used to construct a classes list
+    observed labels on your dataset will be used to construct a classes list.
+-   **mask_targets**: if omitted for a semantic segmentation field, the mask
+    targets from the
+    :meth:`mask_targets <fiftyone.core.dataset.Dataset.mask_targets>` or
+    :meth:`default_mask_targets <fiftyone.core.dataset.Dataset.default_mask_targets>`
+    properties of your dataset will be used, if available
 
 .. _annotation-label-attributes:
 

--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -5616,6 +5616,7 @@ class SampleCollection(object):
         label_type=None,
         classes=None,
         attributes=True,
+        mask_targets=None,
         media_field="filepath",
         backend=None,
         launch_editor=False,
@@ -5644,25 +5645,36 @@ class SampleCollection(object):
                 other schema-related arguments
             label_field (None): a string indicating a new or existing label
                 field to annotate
-            label_type (None): a string or type indicating the type of labels
-                to annotate. The possible label strings/types are:
+            label_type (None): a string indicating the type of labels to
+                annotate. The possible values are:
 
-                -   ``"classification"``: :class:`fiftyone.core.labels.Classification`
-                -   ``"classifications"``: :class:`fiftyone.core.labels.Classifications`
-                -   ``"detection"``: :class:`fiftyone.core.labels.Detection`
-                -   ``"detections"``: :class:`fiftyone.core.labels.Detections`
-                -   ``"polyline"``: :class:`fiftyone.core.labels.Polyline`
-                -   ``"polylines"``: :class:`fiftyone.core.labels.Polylines`
-                -   ``"keypoint"``: :class:`fiftyone.core.labels.Keypoint`
-                -   ``"keypoints"``: :class:`fiftyone.core.labels.Keypoints`
-
-                You can also specify ``"scalar"`` for a primitive scalar field
-                or pass any of the supported scalar field types:
-
-                -   :class:`fiftyone.core.fields.IntField`
-                -   :class:`fiftyone.core.fields.FloatField`
-                -   :class:`fiftyone.core.fields.StringField`
-                -   :class:`fiftyone.core.fields.BooleanField`
+                -   ``"classification"``: a single classification stored in
+                    :class:`fiftyone.core.labels.Classification` fields
+                -   ``"classifications"``: multilabel classifications stored in
+                    :class:`fiftyone.core.labels.Classifications` fields
+                -   ``"detections"``: object detections stored in
+                    :class:`fiftyone.core.labels.Detections` fields
+                -   ``"instances"``: instance segmentations stored in
+                    :class:`fiftyone.core.labels.Detections` fields with their
+                    :attr:`mask <fiftyone.core.labels.Detection.mask>`
+                    attributes populated
+                -   ``"polylines"``: polylines stored in
+                    :class:`fiftyone.core.labels.Polylines` fields with their
+                    :attr:`mask <fiftyone.core.labels.Polyline.filled>`
+                    attributes set to ``False``
+                -   ``"polygons"``: polygons stored in
+                    :class:`fiftyone.core.labels.Polylines` fields with their
+                    :attr:`mask <fiftyone.core.labels.Polyline.filled>`
+                    attributes set to ``True``
+                -   ``"keypoints"``: keypoints stored in
+                    :class:`fiftyone.core.labels.Keypoints` fields
+                -   ``"segmentation"``: semantic segmentations stored in
+                    :class:`fiftyone.core.labels.Segmentation` fields
+                -   ``"scalar"``: scalar labels stored in
+                    :class:`fiftyone.core.fields.IntField`,
+                    :class:`fiftyone.core.fields.FloatField`,
+                    :class:`fiftyone.core.fields.StringField`, or
+                    :class:`fiftyone.core.fields.BooleanField` fields
 
                 All new label fields must have their type specified via this
                 argument or in ``label_schema``. Note that annotation backends
@@ -5687,6 +5699,8 @@ class SampleCollection(object):
 
                 If provided, this parameter will apply to all label fields in
                 ``label_schema`` that do not define their attributes
+            mask_targets (None): a dict mapping pixel values to semantic label
+                strings. Only applicable when annotating semantic segmentations
             media_field ("filepath"): the field containing the paths to the
                 media files to upload
             backend (None): the annotation backend to use. The supported values
@@ -5708,6 +5722,7 @@ class SampleCollection(object):
             label_type=label_type,
             classes=classes,
             attributes=attributes,
+            mask_targets=mask_targets,
             media_field=media_field,
             backend=backend,
             launch_editor=launch_editor,
@@ -6746,20 +6761,17 @@ class SampleCollection(object):
             ignore_primitives=ignore_primitives,
         )
 
-    def _unwind_values(self, field_name, values):
+    def _unwind_values(self, field_name, values, keep_top_level=False):
         if values is None:
             return None
 
         list_fields = self._parse_field_name(field_name, auto_unwind=False)[-2]
         level = len(list_fields)
 
-        while level > 0:
-            values = list(
-                itertools.chain.from_iterable(v for v in values if v)
-            )
-            level -= 1
+        if keep_top_level:
+            return [_unwind_values(v, level - 1) for v in values]
 
-        return values
+        return _unwind_values(values, level)
 
     def _make_set_field_pipeline(
         self, field, expr, embedded_root=False, allow_missing=False
@@ -6767,6 +6779,17 @@ class SampleCollection(object):
         return _make_set_field_pipeline(
             self, field, expr, embedded_root, allow_missing=allow_missing
         )
+
+
+def _unwind_values(values, level):
+    if not values:
+        return values
+
+    while level > 0:
+        values = list(itertools.chain.from_iterable(v for v in values if v))
+        level -= 1
+
+    return values
 
 
 def _parse_label_field(

--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -1696,8 +1696,8 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
     def delete_samples(self, samples_or_ids):
         """Deletes the given sample(s) from the dataset.
 
-        If reference to a sample exists in memory, the sample object will be
-        updated such that ``sample.in_dataset == False``.
+        If reference to a sample exists in memory, the sample will be updated
+        such that ``sample.in_dataset`` is False.
 
         Args:
             samples_or_ids: the sample(s) to delete. Can be any of the
@@ -1713,22 +1713,7 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
                     :class:`fiftyone.core.sample.SampleView` instances
         """
         sample_ids = _get_sample_ids(samples_or_ids)
-        _sample_ids = [ObjectId(_id) for _id in sample_ids]
-
-        self._sample_collection.delete_many({"_id": {"$in": _sample_ids}})
-
-        fos.Sample._reset_docs(
-            self._sample_collection_name, sample_ids=sample_ids
-        )
-
-        if self.media_type == fom.VIDEO:
-            self._frame_collection.delete_many(
-                {"_sample_id": {"$in": _sample_ids}}
-            )
-
-            fofr.Frame._reset_docs(
-                self._frame_collection_name, sample_ids=sample_ids
-            )
+        self._clear(sample_ids=sample_ids)
 
     def delete_labels(
         self, labels=None, ids=None, tags=None, view=None, fields=None
@@ -2004,8 +1989,8 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
     def remove_sample(self, sample_or_id):
         """Removes the given sample from the dataset.
 
-        If reference to a sample exists in memory, the sample object will be
-        updated such that ``sample.in_dataset == False``.
+        If reference to a sample exists in memory, the sample will be updated
+        such that ``sample.in_dataset`` is False.
 
         .. warning::
 
@@ -2025,8 +2010,8 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
     def remove_samples(self, samples_or_ids):
         """Removes the given samples from the dataset.
 
-        If reference to a sample exists in memory, the sample object will be
-        updated such that ``sample.in_dataset == False``.
+        If reference to a sample exists in memory, the sample will be updated
+        such that ``sample.in_dataset`` is False.
 
         .. warning::
 
@@ -2088,14 +2073,101 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
     def clear(self):
         """Removes all samples from the dataset.
 
-        If reference to a sample exists in memory, the sample object will be
-        updated such that ``sample.in_dataset == False``.
+        If reference to a sample exists in memory, the sample will be updated
+        such that ``sample.in_dataset`` is False.
         """
-        self._sample_doc_cls.drop_collection()
-        fos.Sample._reset_docs(self._sample_collection_name)
+        self._clear()
 
-        self._frame_doc_cls.drop_collection()
-        fofr.Frame._reset_docs(self._frame_collection_name)
+    def _clear(self, view=None, sample_ids=None):
+        if view is not None:
+            sample_ids = view.values("id")
+
+        if sample_ids is not None:
+            d = {"_id": {"$in": [ObjectId(_id) for _id in sample_ids]}}
+        else:
+            sample_ids = None
+            d = {}
+
+        self._sample_collection.delete_many(d)
+        fos.Sample._reset_docs(
+            self._sample_collection_name, sample_ids=sample_ids
+        )
+
+        self._clear_frames(sample_ids=sample_ids)
+
+    def clear_frames(self):
+        """Removes all frame labels from the video dataset.
+
+        If reference to a frame exists in memory, the frame will be updated
+        such that ``frame.in_dataset`` is False.
+        """
+        self._clear_frames()
+
+    def _clear_frames(self, view=None, sample_ids=None):
+        if self.media_type != fom.VIDEO:
+            return
+
+        if view is not None:
+            sample_ids = view.values("id")
+
+        if sample_ids is not None:
+            d = {"_sample_id": {"$in": [ObjectId(_id) for _id in sample_ids]}}
+        else:
+            d = {}
+
+        self._frame_collection.delete_many(d)
+        fofr.Frame._reset_docs(
+            self._frame_collection_name, sample_ids=sample_ids
+        )
+
+    def ensure_frames(self):
+        """Ensures that the video dataset contains frame instances for every
+        frame of each sample's source video.
+
+        Empty frames will be inserted for missing frames, and already existing
+        frames are left unchanged.
+        """
+        self._ensure_frames()
+
+    def _ensure_frames(self, view=None):
+        if self.media_type != fom.VIDEO:
+            return
+
+        if view is not None:
+            sample_collection = view
+        else:
+            sample_collection = self
+
+        sample_collection.compute_metadata()
+
+        pipeline = sample_collection._pipeline()
+        pipeline.extend(
+            [
+                {
+                    "$project": {
+                        "_id": False,
+                        "_sample_id": "$_id",
+                        "frame_number": {
+                            "$range": [
+                                1,
+                                {"$add": ["$metadata.total_frame_count", 1]},
+                            ]
+                        },
+                    }
+                },
+                {"$unwind": "$frame_number"},
+                {
+                    "$merge": {
+                        "into": self._frame_collection_name,
+                        "on": ["_sample_id", "frame_number"],
+                        "whenMatched": "keepExisting",
+                        "whenNotMatched": "insert",
+                    }
+                },
+            ]
+        )
+
+        self._aggregate(pipeline=pipeline)
 
     def delete(self):
         """Deletes the dataset.
@@ -2103,8 +2175,8 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
         Once deleted, only the ``name`` and ``deleted`` attributes of a dataset
         may be accessed.
 
-        If reference to a sample exists in memory, the sample object will be
-        updated such that ``sample.in_dataset == False``.
+        If reference to a sample exists in memory, the sample will be updated
+        such that ``sample.in_dataset`` is False.
         """
         self.clear()
         _delete_dataset_doc(self._doc)

--- a/fiftyone/core/labels.py
+++ b/fiftyone/core/labels.py
@@ -812,8 +812,7 @@ class Polyline(ImageLabel, _HasID, _HasAttributesDict):
         encoding the polyline's shape is included.
 
         Alternatively, if a ``frame_size`` is provided, the required mask size
-            is then computed based off of the polyline points and
-            ``frame_size``
+        is then computed based off of the polyline points and ``frame_size``.
 
         Args:
             mask_size (None): an optional ``(width, height)`` at which to
@@ -1014,8 +1013,7 @@ class Polylines(ImageLabel, _HasLabelList):
         encoding the polyline's shape are included in each :class:`Detection`.
 
         Alternatively, if a ``frame_size`` is provided, the required mask size
-        is then computed based off of the polyline points and ``frame_size``
-
+        is then computed based off of the polyline points and ``frame_size``.
 
         Args:
             mask_size (None): an optional ``(width, height)`` at which to
@@ -1023,7 +1021,6 @@ class Polylines(ImageLabel, _HasLabelList):
             frame_size (None): used when no ``mask_size`` is provided.
                 an optional ``(width, height)`` of the frame containing these
                 polylines that is used to compute the required ``mask_size``
-
 
         Returns:
             a :class:`Detections`

--- a/fiftyone/core/labels.py
+++ b/fiftyone/core/labels.py
@@ -561,7 +561,7 @@ class Detection(ImageLabel, _HasID, _HasAttributesDict):
 
         mask, _ = _parse_to_segmentation_inputs(mask, frame_size, None)
         _render_instance(mask, self, target)
-        return Segmentation(mask=mask.astype(np.int))
+        return Segmentation(mask=mask)
 
     def to_shapely(self, frame_size=None):
         """Returns a Shapely representation of this instance.
@@ -739,7 +739,7 @@ class Detections(ImageLabel, _HasLabelList):
 
             _render_instance(mask, detection, target)
 
-        return Segmentation(mask=mask.astype(np.int))
+        return Segmentation(mask=mask)
 
     def to_image_labels(self, name=None):
         """Returns an ``eta.core.image.ImageLabels`` representation of this
@@ -878,7 +878,7 @@ class Polyline(ImageLabel, _HasID, _HasAttributesDict):
         """
         mask, _ = _parse_to_segmentation_inputs(mask, frame_size, None)
         _render_polyline(mask, self, target, thickness)
-        return Segmentation(mask=mask.astype(np.int))
+        return Segmentation(mask=mask)
 
     def to_shapely(self, frame_size=None):
         """Returns a Shapely representation of this instance.
@@ -1074,7 +1074,7 @@ class Polylines(ImageLabel, _HasLabelList):
 
             _render_polyline(mask, polyline, target, thickness)
 
-        return Segmentation(mask=mask.astype(np.int))
+        return Segmentation(mask=mask)
 
     def to_image_labels(self, name=None):
         """Returns an ``eta.core.image.ImageLabels`` representation of this

--- a/fiftyone/core/labels.py
+++ b/fiftyone/core/labels.py
@@ -711,10 +711,10 @@ class Detections(ImageLabel, _HasLabelList):
             frame_size (None): the ``(width, height)`` of the segmentation
                 mask to render. This parameter has no effect if a ``mask`` is
                 provided
-            mask_targets (None): a dict mapping integer pixel values in
-                ``[0, 255]`` to label strings defining which object classes to
-                render and which pixel values to use for each class. If
-                omitted, all objects are rendered with pixel value 255
+            mask_targets (None): a dict mapping integer pixel values to label
+                strings defining which object classes to render and which pixel
+                values to use for each class. If omitted, all objects are
+                rendered with pixel value 255
 
         Returns:
             a :class:`Segmentation`
@@ -1046,10 +1046,10 @@ class Polylines(ImageLabel, _HasLabelList):
             frame_size (None): the ``(width, height)`` of the segmentation
                 mask to render. This parameter has no effect if a ``mask`` is
                 provided
-            mask_targets (None): a dict mapping integer pixel values in
-                ``[0, 255]`` to label strings defining which object classes to
-                render and which pixel values to use for each class. If
-                omitted, all objects are rendered with pixel value 255
+            mask_targets (None): a dict mapping integer pixel values to label
+                strings defining which object classes to render and which
+                pixel values to use for each class. If omitted, all objects are
+                rendered with pixel value 255
             thickness (1): the thickness, in pixels, at which to render
                 (non-filled) polylines
 
@@ -1286,9 +1286,8 @@ class Segmentation(ImageLabel, _HasID):
         per connected region of that class in the segmentation.
 
         Args:
-            mask_targets (None): a dict mapping integer pixel values in
-                ``[0, 255]`` to label strings defining which object classes to
-                label and which pixel values to use for each class. If
+            mask_targets (None): a dict mapping integer pixel values to label
+                strings defining which classes to generate detections for. If
                 omitted, all labels are assigned to the integer pixel values
             mask_types ("stuff"): whether the classes are ``"stuff"``
                 (amorphous regions of pixels) or ``"thing"`` (connected
@@ -1318,10 +1317,10 @@ class Segmentation(ImageLabel, _HasID):
         per connected region of that class.
 
         Args:
-            mask_targets (None): a dict mapping integer pixel values in
-                ``[0, 255]`` to label strings defining which object classes to
-                label and which pixel values to use for each class. If
-                omitted, all labels are assigned to the integer pixel values
+            mask_targets (None): a dict mapping integer pixel values to label
+                strings defining which object classes to generate polylines
+                for. If omitted, all labels are assigned to the integer pixel
+                values
             mask_types ("stuff"): whether the classes are ``"stuff"``
                 (amorphous regions of pixels) or ``"thing"`` (connected
                 regions, each representing an instance of the thing). Can be

--- a/fiftyone/core/labels.py
+++ b/fiftyone/core/labels.py
@@ -733,7 +733,7 @@ class Detections(ImageLabel, _HasLabelList):
             if labels_to_targets is not None:
                 target = labels_to_targets.get(detection.label, None)
                 if target is None:
-                    continue
+                    continue  # skip unknown target
             else:
                 target = 255
 
@@ -1065,7 +1065,7 @@ class Polylines(ImageLabel, _HasLabelList):
             if labels_to_targets is not None:
                 target = labels_to_targets.get(polyline.label, None)
                 if target is None:
-                    continue
+                    continue  # skip unknown target
             else:
                 target = 255
 
@@ -1489,8 +1489,13 @@ def _parse_to_segmentation_inputs(mask, frame_size, mask_targets):
         if frame_size is None:
             raise ValueError("Either `mask` or `frame_size` must be provided")
 
+        if mask_targets is not None and max(mask_targets) > 255:
+            dtype = np.int
+        else:
+            dtype = np.uint8
+
         width, height = frame_size
-        mask = np.zeros((height, width), dtype=np.uint8)
+        mask = np.zeros((height, width), dtype=dtype)
     else:
         height, width = mask.shape[:2]
 

--- a/fiftyone/core/labels.py
+++ b/fiftyone/core/labels.py
@@ -1275,61 +1275,72 @@ class Segmentation(ImageLabel, _HasID):
         """
         return etai.ImageLabels(mask=self.mask, tags=self.tags)
 
-    def to_detections(self, mask_targets=None):
-        """Returns a :class:`Detections` representation of this instance.
+    def to_detections(self, mask_targets=None, mask_types="stuff"):
+        """Returns a :class:`Detections` representation of this instance with
+        instance masks populated.
 
-        Every class will be converted to a single :class:`Detection`.
+        Each ``"stuff"`` class will be converted to a single :class:`Detection`
+        whose instance mask spans all region(s) of the class.
+
+        Each ``"thing"`` class will result in one :class:`Detection` instance
+        per connected region of that class in the segmentation.
 
         Args:
             mask_targets (None): a dict mapping integer pixel values in
                 ``[0, 255]`` to label strings defining which object classes to
                 label and which pixel values to use for each class. If
                 omitted, all labels are assigned to the integer pixel values
+            mask_types ("stuff"): whether the classes are ``"stuff"``
+                (amorphous regions of pixels) or ``"thing"`` (connected
+                regions, each representing an instance of the thing). Can be
+                any of the following:
+
+                -   ``"stuff"`` if all classes are stuff classes
+                -   ``"thing"`` if all classes are thing classes
+                -   a dict mapping pixel values to ``"stuff"`` or ``"thing"``
+                    for each class
 
         Returns:
             a :class:`Detections`
         """
-        detections = []
-
-        # pylint: disable=no-member
-        mask_h, mask_w = self.mask.shape
-
-        for target in np.unique(self.mask):
-            if target == 0:
-                # Skip background class
-                continue
-
-            if mask_targets is not None and target in mask_targets:
-                label = mask_targets[target]
-            else:
-                label = target
-
-            label_mask = (self.mask == target).astype(int)
-
-            # Crop mask and get bbox
-
-            # pylint: disable=no-member
-            coords = cv2.findNonZero(label_mask)
-            # pylint: disable=no-member
-            x, y, w, h = cv2.boundingRect(coords)
-
-            bbox = [
-                x / mask_w,
-                y / mask_h,
-                w / mask_w,
-                h / mask_h,
-            ]
-            label_mask = label_mask[y : y + h, x : x + w]
-
-            detections.append(
-                Detection(
-                    label=str(label),
-                    bounding_box=bbox,
-                    mask=label_mask.astype(bool),
-                )
-            )
-
+        detections = _segmentation_to_detections(
+            self, mask_targets, mask_types
+        )
         return Detections(detections=detections)
+
+    def to_polylines(self, mask_targets=None, mask_types="stuff", tolerance=2):
+        """Returns a :class:`Polylines` representation of this instance.
+
+        Each ``"stuff"`` class will be converted to a single :class:`Polyline`
+        that may contain multiple disjoint shapes capturing the class.
+
+        Each ``"thing"`` class will result in one :class:`Polyline` instance
+        per connected region of that class.
+
+        Args:
+            mask_targets (None): a dict mapping integer pixel values in
+                ``[0, 255]`` to label strings defining which object classes to
+                label and which pixel values to use for each class. If
+                omitted, all labels are assigned to the integer pixel values
+            mask_types ("stuff"): whether the classes are ``"stuff"``
+                (amorphous regions of pixels) or ``"thing"`` (connected
+                regions, each representing an instance of the thing). Can be
+                any of the following:
+
+                -   ``"stuff"`` if all classes are stuff classes
+                -   ``"thing"`` if all classes are thing classes
+                -   a dict mapping pixel values to ``"stuff"`` or ``"thing"``
+                    for each class
+            tolerance (2): a tolerance, in pixels, when generating approximate
+                polylines for each region. Typical values are 1-3 pixels
+
+        Returns:
+            a :class:`Polylines`
+        """
+        polylines = _segmentation_to_polylines(
+            self, mask_targets, mask_types, tolerance
+        )
+        return Polylines(polylines=polylines)
 
     @classmethod
     def from_mask(cls, mask):
@@ -1516,6 +1527,160 @@ def _render_polyline(mask, polyline, target, thickness):
         mask = cv2.polylines(  # pylint: disable=no-member
             mask, points, polyline.closed, target, thickness=thickness
         )
+
+
+def _segmentation_to_detections(segmentation, mask_targets, mask_types):
+    if isinstance(mask_types, dict):
+        default = None
+    else:
+        default = mask_types
+        mask_types = {}
+
+    mask = segmentation.mask
+
+    detections = []
+    for target in np.unique(mask):
+        if target == 0:
+            continue  # skip background
+
+        if mask_targets is not None:
+            label = mask_targets.get(target, None)
+            if label is None:
+                continue  # skip unknown target
+        else:
+            label = str(target)
+
+        label_type = mask_types.get(target, None)
+        if label_type is None:
+            if default is None:
+                continue  # skip unknown type
+
+            label_type = default
+
+        label_mask = mask == target
+
+        if label_type == "stuff":
+            instances = [_parse_stuff_instance(label_mask)]
+        elif label_type == "thing":
+            instances = _parse_thing_instances(label_mask)
+        else:
+            raise ValueError(
+                "Unsupported mask type '%s'. Supported values are "
+                "('stuff', 'thing')"
+            )
+
+        for bbox, instance_mask in instances:
+            detections.append(
+                Detection(label=label, bounding_box=bbox, mask=instance_mask)
+            )
+
+    return detections
+
+
+def _segmentation_to_polylines(
+    segmentation, mask_targets, mask_types, tolerance
+):
+    if isinstance(mask_types, dict):
+        default = None
+    else:
+        default = mask_types
+        mask_types = {}
+
+    mask = segmentation.mask
+
+    polylines = []
+    for target in np.unique(mask):
+        if target == 0:
+            continue  # skip background
+
+        if mask_targets is not None:
+            label = mask_targets.get(target, None)
+            if label is None:
+                continue  # skip unknown target
+        else:
+            label = str(target)
+
+        label_type = mask_types.get(target, None)
+        if label_type is None:
+            if default is None:
+                continue  # skip unknown type
+
+            label_type = default
+
+        label_mask = mask == target
+
+        polygons = _get_polygons(label_mask, tolerance)
+
+        if label_type == "stuff":
+            polygons = [polygons]
+        elif label_type == "thing":
+            polygons = [[p] for p in polygons]
+        else:
+            raise ValueError(
+                "Unsupported mask type '%s'. Supported values are "
+                "('stuff', 'thing')"
+            )
+
+        for points in polygons:
+            polyline = Polyline(
+                label=label, points=points, filled=True, closed=True
+            )
+            polylines.append(polyline)
+
+    return polylines
+
+
+def _parse_stuff_instance(mask):
+    cols = np.any(mask, axis=0)
+    rows = np.any(mask, axis=1)
+    xmin, xmax = np.where(cols)[0][[0, -1]]
+    ymin, ymax = np.where(rows)[0][[0, -1]]
+
+    height, width = mask.shape
+    x = xmin / width
+    y = ymin / height
+    w = (xmax - xmin + 1) / width
+    h = (ymax - ymin + 1) / height
+
+    bbox = [x, y, w, h]
+    instance_mask = mask[ymin:ymax, xmin:xmax]
+
+    return bbox, instance_mask
+
+
+def _parse_thing_instances(mask):
+    height, width = mask.shape
+    polygons = _get_polygons(mask, 2, abs_coords=True)
+
+    instances = []
+    for p in polygons:
+        p = np.array(p)
+        xmin, ymin = np.floor(p.min(axis=0)).astype(int)
+        xmax, ymax = np.ceil(p.max(axis=0)).astype(int)
+
+        xmax = max(xmin + 1, xmax)
+        ymax = max(ymin + 1, ymax)
+
+        x = xmin / width
+        y = ymin / height
+        w = (xmax - xmin) / width
+        h = (ymax - ymin) / height
+
+        bbox = [x, y, w, h]
+        instance_mask = mask[ymin:ymax, xmin:xmax]
+
+        instances.append((bbox, instance_mask))
+
+    return instances
+
+
+def _get_polygons(mask, tolerance, abs_coords=False):
+    polygons = etai._mask_to_polygons(mask, tolerance=tolerance)
+    if abs_coords:
+        return polygons
+
+    height, width = mask.shape
+    return [[(x / width, y / height) for x, y in p] for p in polygons]
 
 
 def _from_geo_json_single(d):

--- a/fiftyone/core/patches.py
+++ b/fiftyone/core/patches.py
@@ -732,7 +732,7 @@ def _merge_matched_labels(dataset, src_collection, eval_key, field):
     eval_id = eval_key + "_id"
     eval_field = list_field + "." + eval_id
 
-    pipeline = src_collection._pipeline(detach_frames=True)
+    pipeline = src_collection._pipeline()
     pipeline.extend(
         [
             {"$project": {list_field: True}},
@@ -772,14 +772,14 @@ def _merge_matched_labels(dataset, src_collection, eval_key, field):
         ]
     )
 
-    src_collection._dataset._aggregate(pipeline=pipeline, attach_frames=False)
+    src_collection._dataset._aggregate(pipeline=pipeline)
 
 
 def _write_samples(dataset, src_collection):
     pipeline = src_collection._pipeline(detach_frames=True)
     pipeline.append({"$out": dataset._sample_collection_name})
 
-    src_collection._dataset._aggregate(pipeline=pipeline, attach_frames=False)
+    src_collection._dataset._aggregate(pipeline=pipeline)
 
 
 def _add_samples(dataset, src_collection):
@@ -795,4 +795,4 @@ def _add_samples(dataset, src_collection):
         }
     )
 
-    src_collection._dataset._aggregate(pipeline=pipeline, attach_frames=False)
+    src_collection._dataset._aggregate(pipeline=pipeline)

--- a/fiftyone/core/runs.py
+++ b/fiftyone/core/runs.py
@@ -5,7 +5,7 @@ Dataset runs framework.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
-from copy import copy
+from copy import copy, deepcopy
 import datetime
 import logging
 
@@ -49,7 +49,7 @@ class RunInfo(Config):
             key=doc.key,
             version=doc.version,
             timestamp=doc.timestamp,
-            config=cls.config_cls().from_dict(doc.config),
+            config=cls.config_cls().from_dict(deepcopy(doc.config)),
         )
 
 
@@ -360,7 +360,7 @@ class Run(Configurable):
             key=key,
             version=run_info.version,
             timestamp=run_info.timestamp,
-            config=run_info.config.serialize(),
+            config=deepcopy(run_info.config.serialize()),
             view_stages=view_stages,
             results=None,
         )

--- a/fiftyone/core/video.py
+++ b/fiftyone/core/video.py
@@ -612,7 +612,7 @@ def _populate_frames(
         ]
     )
 
-    src_collection._dataset._aggregate(pipeline=pipeline, attach_frames=False)
+    src_collection._dataset._aggregate(pipeline=pipeline)
 
     return ids_to_sample, frames_to_sample
 

--- a/fiftyone/core/view.py
+++ b/fiftyone/core/view.py
@@ -606,6 +606,23 @@ class DatasetView(foc.SampleCollection):
         """
         self._dataset._clear_frame_fields(field_names, view=self)
 
+    def clear(self):
+        """Removes all samples in the view from the underlying dataset."""
+        self._dataset._clear(view=self)
+
+    def clear_frames(self):
+        """Removes all frame labels from the samples in the view."""
+        self._dataset._clear_frames(view=self)
+
+    def ensure_frames(self):
+        """Ensures that the video view contains frame instances for every frame
+        of each sample's source video.
+
+        Empty frames will be inserted for missing frames, and already existing
+        frames are left unchanged.
+        """
+        self._dataset._ensure_frames(view=self)
+
     def save(self, fields=None):
         """Overwrites the underlying dataset with the contents of the view.
 

--- a/fiftyone/utils/annotations.py
+++ b/fiftyone/utils/annotations.py
@@ -237,6 +237,25 @@ _LABEL_TYPES_MAP = {
     "segmentation": fol.Segmentation,
 }
 
+# Mapping from label types to the return type that the backend should use to
+# store the results
+_RETURN_TYPES_MAP = {
+    "classification": "classifications",
+    "classifications": "classifications",
+    "detection": "detections",
+    "detections": "detections",
+    "instance": "detections",
+    "instances": "detections",
+    "polyline": "polylines",
+    "polylines": "polylines",
+    "polygon": "polylines",
+    "polygons": "polylines",
+    "keypoint": "keypoints",
+    "keypoints": "keypoints",
+    "segmentation": "segmentation",
+    "scalar": "scalar",
+}
+
 # The label fields that are *always* overwritten during import
 _DEFAULT_LABEL_FIELDS_MAP = {
     fol.Classification: ["label"],
@@ -701,15 +720,10 @@ def load_annotations(
 
     for label_field, label_info in label_schema.items():
         label_type = label_info["type"]
+        expected_type = _RETURN_TYPES_MAP[label_type]
         existing_field = label_info["existing_field"]
 
         anno_dict = annotations.get(label_field, {})
-
-        if label_type + "s" in _LABEL_TYPES_MAP:
-            # Backend is expected to return list types
-            expected_type = label_type + "s"
-        else:
-            expected_type = label_type
 
         #
         # First add unexpected labels to new fields, if necessary
@@ -1221,6 +1235,14 @@ class AnnotationBackend(foa.AnnotationMethod):
 
             # Label fields
             results[label_type][sample_id][frame_id][label_id] = label
+
+        The valid values for ``label_type`` are:
+
+        -   "classifications": single or multilabel classifications
+        -   "detections": detections or instance segmentations
+        -   "polylines": polygons or polylines
+        -   "segmentation": semantic segmentations
+        -   "scalar": scalar values
 
         Args:
             results: an :class:`AnnotationResults`

--- a/fiftyone/utils/annotations.py
+++ b/fiftyone/utils/annotations.py
@@ -448,7 +448,7 @@ def _get_label_type(samples, backend, label_type, label_field, label_info):
     if not _multiple_types:
         return _existing_type, True, _multiple_types
 
-    # Existing field contains multiple label types, so we must choose which
+    # Existing field contains multiple label types, so we must choose one
     if "detection" in _existing_type:
         _label_type = "detection"
     elif "detections" in _existing_type:
@@ -902,12 +902,12 @@ def _merge_labels(
         else:
             anno_ids.update(sample.keys())
 
-    deleted_ids = existing_ids - anno_ids
+    delete_ids = existing_ids - anno_ids
     new_ids = anno_ids - existing_ids
     merge_ids = anno_ids - new_ids
 
-    if deleted_ids:
-        samples._dataset.delete_labels(ids=deleted_ids, fields=label_field)
+    if delete_ids:
+        samples._dataset.delete_labels(ids=delete_ids, fields=label_field)
 
     if is_video and label_type in (
         "detections",

--- a/fiftyone/utils/annotations.py
+++ b/fiftyone/utils/annotations.py
@@ -353,16 +353,24 @@ def _build_label_schema(
 
 def _select_labels_with_type(samples, label_field, label_type):
     if label_type in ("detection", "detections"):
-        return samples.filter_labels(label_field, ~F("mask").exists())
+        return samples.filter_labels(
+            label_field, ~F("mask").exists(), only_matches=False
+        )
 
     if label_type in ("instance", "instances"):
-        return samples.filter_labels(label_field, F("mask").exists())
+        return samples.filter_labels(
+            label_field, F("mask").exists(), only_matches=False
+        )
 
     if label_type in ("polygon", "polygons"):
-        return samples.filter_labels(label_field, F("filled") == True)
+        return samples.filter_labels(
+            label_field, F("filled") == True, only_matches=False
+        )
 
     if label_type in ("polyline", "polylines"):
-        return samples.filter_labels(label_field, F("filled") == False)
+        return samples.filter_labels(
+            label_field, F("filled") == False, only_matches=False
+        )
 
     raise ValueError(
         "Field '%s' has unsupported multiple label type '%s'"

--- a/fiftyone/utils/annotations.py
+++ b/fiftyone/utils/annotations.py
@@ -968,6 +968,8 @@ def _merge_labels(samples, anno_dict, results, label_field, label_info):
 
             image_label = image[field]
 
+            # @todo this does not correctly handle cases where an annotation is
+            # deleted but then added back upon re-import
             if image_label is None:
                 # A previously unlabeled image is being labeled, or a single
                 # label (e.g. Classification) was deleted in CVAT or FiftyOne

--- a/fiftyone/utils/annotations.py
+++ b/fiftyone/utils/annotations.py
@@ -939,7 +939,9 @@ def _merge_labels(
 
         for image in images:
             if is_video:
-                image_annos = sample_annos[image.id]
+                image_annos = sample_annos.get(image.id, None)
+                if not image_annos:
+                    continue
             else:
                 image_annos = sample_annos
 

--- a/fiftyone/utils/annotations.py
+++ b/fiftyone/utils/annotations.py
@@ -889,8 +889,9 @@ def _merge_labels(samples, anno_dict, results, label_field, label_info):
     if is_video and label_type in (
         "detections",
         "instances",
-        "keypoints",
         "polylines",
+        "polygons",
+        "keypoints",
     ):
         tracking_index_map, max_tracking_index = _make_tracking_index(
             samples, label_field, anno_dict

--- a/fiftyone/utils/cvat.py
+++ b/fiftyone/utils/cvat.py
@@ -3423,9 +3423,9 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
             labels = task_json["labels"]
             for label in labels:
                 class_map[label["id"]] = label["name"]
-                attr_id_map[label["id"]] = dict(
-                    [(i["name"], i["id"]) for i in label["attributes"]]
-                )
+                attr_id_map[label["id"]] = {
+                    i["name"]: i["id"] for i in label["attributes"]
+                }
 
             task_resp = self.get(self.task_annotation_url(task_id)).json()
             shapes = task_resp["shapes"]

--- a/fiftyone/utils/cvat.py
+++ b/fiftyone/utils/cvat.py
@@ -3543,7 +3543,7 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
             # Polyline(s) corresponding to instance/semantic masks need to be
             # converted to their final format
             self._convert_polylines_to_masks(
-                label_field_results, label_schema, frames_metadata
+                label_field_results, label_info, frames_metadata
             )
 
             results = self._merge_results(
@@ -3553,7 +3553,7 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
         return results
 
     def _convert_polylines_to_masks(
-        self, results, label_schema, frames_metadata
+        self, results, label_info, frames_metadata
     ):
         for label_type, type_results in results.items():
             if label_type not in (
@@ -3564,8 +3564,6 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
                 "segmentation",
             ):
                 continue
-
-            label_info = label_schema[label_type]
 
             for sample_id, sample_results in type_results.items():
                 sample_metadata = frames_metadata[sample_id]
@@ -3596,7 +3594,7 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
         if isinstance(label, fol.Polyline):
             label = CVATShape.polyline_to_detection(label, frame_size)
         elif isinstance(label, fol.Polylines):
-            mask_targets = label_info["mask_targets"]
+            mask_targets = label_info.get("mask_targets", None)
             label = CVATShape.polylines_to_segmentation(
                 label, frame_size, mask_targets
             )
@@ -3779,7 +3777,7 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
                 if expected_label_type == "segmentation":
                     label_type = "segmentation"
                     label = cvat_shape.to_polylines(closed=True, filled=True)
-                    label.id = "None"  # @todo weird?
+                    label.id = None
                 else:
                     label = cvat_shape.to_polyline(closed=True, filled=True)
                     if expected_label_type in (
@@ -3879,8 +3877,8 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
             else:
                 _label = label
         elif isinstance(label, fol.Polylines):
-            if label.id != "None" and "None" in results:
-                _label = results.pop("None")
+            if label.id is not None and None in results:
+                _label = results.pop(None)
                 self._merge_polylines(_label, label)
                 _label.id = label.id
             elif results:

--- a/fiftyone/utils/cvat.py
+++ b/fiftyone/utils/cvat.py
@@ -3767,6 +3767,7 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
             cvat_shape = CVATShape(
                 anno, class_map, attr_id_map, metadata, index=track_index
             )
+
             if shape_type == "rectangle":
                 label_type = "detections"
                 label = cvat_shape.to_detection()
@@ -3775,6 +3776,8 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
                 if expected_label_type == "segmentation":
                     label_type = "segmentation"
                     label = cvat_shape.to_polylines(closed=True, filled=True)
+
+                    # @todo fix this?
                     try:
                         label.id = str(label._id)
                     except:

--- a/fiftyone/utils/cvat.py
+++ b/fiftyone/utils/cvat.py
@@ -4107,6 +4107,9 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
 
                 if ids is not None:
                     if is_video:
+                        if sample.id not in id_map:
+                            id_map[sample.id] = {}
+
                         id_map[sample.id][image.id] = ids
                     else:
                         id_map[sample.id] = ids

--- a/fiftyone/utils/cvat.py
+++ b/fiftyone/utils/cvat.py
@@ -3894,7 +3894,7 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
                 if is_shape:
                     frame_size = (metadata.frame_width, metadata.frame_height)
             else:
-                iamges = [sample]
+                images = [sample]
                 if is_shape:
                     frame_size = (metadata.width, metadata.height)
 

--- a/fiftyone/utils/data/exporters.py
+++ b/fiftyone/utils/data/exporters.py
@@ -12,6 +12,7 @@ import os
 import warnings
 
 from bson import json_util
+import numpy as np
 
 import eta.core.datasets as etad
 import eta.core.image as etai
@@ -2428,10 +2429,20 @@ class ImageSegmentationDirectoryExporter(
             raise ValueError("Unsupported label type '%s'" % type(label))
 
         out_mask_path = os.path.join(self.labels_path, uuid + self.mask_format)
-        etai.write(mask, out_mask_path)
+        _write_mask(mask, out_mask_path)
 
     def close(self, *args):
         self._media_exporter.close()
+
+
+def _write_mask(mask, mask_path):
+    if mask.dtype not in (np.uint8, np.uint16):
+        if mask.max() <= 255:
+            mask = mask.astype(np.uint8)
+        else:
+            mask = mask.astype(np.uint16)
+
+    etai.write(mask, mask_path)
 
 
 class FiftyOneImageLabelsDatasetExporter(LabeledImageDatasetExporter):

--- a/fiftyone/utils/data/importers.py
+++ b/fiftyone/utils/data/importers.py
@@ -2506,6 +2506,15 @@ class ImageSegmentationDirectoryImporter(
         return len(etau.list_files(os.path.join(dataset_dir, "data")))
 
 
+def _read_mask(mask_path, force_grayscale=False):
+    # pylint: disable=no-member
+    mask = etai.read(mask_path, cv2.IMREAD_UNCHANGED)
+    if force_grayscale and mask.ndim > 1:
+        mask = mask[:, :, 0]
+
+    return mask
+
+
 class FiftyOneImageLabelsDatasetImporter(LabeledImageDatasetImporter):
     """Importer for labeled image datasets whose labels are stored in
     `ETA ImageLabels format <https://github.com/voxel51/eta/blob/develop/docs/image_labels_guide.md>`_.
@@ -2747,12 +2756,3 @@ class FiftyOneVideoLabelsDatasetImporter(LabeledVideoDatasetImporter):
     def _get_num_samples(dataset_dir):
         # Used only by dataset zoo
         return len(etads.load_dataset(dataset_dir))
-
-
-def _read_mask(mask_path, force_grayscale=False):
-    # pylint: disable=no-member
-    mask = etai.read(mask_path, cv2.IMREAD_UNCHANGED)
-    if force_grayscale and mask.ndim > 1:
-        mask = mask[:, :, 0]
-
-    return mask

--- a/fiftyone/utils/labels.py
+++ b/fiftyone/utils/labels.py
@@ -93,24 +93,44 @@ def objects_to_segmentations(
 
 
 def segmentations_to_detections(
-    sample_collection, in_field, out_field, mask_targets=None,
+    sample_collection,
+    in_field,
+    out_field,
+    mask_targets=None,
+    mask_types="stuff",
 ):
-    """Converts the semantic segmentations masks in the specific field of the
-    collection into :class:`fiftyone.core.labels.Detections` with each class as
-    one instance segmentation.
+    """Converts the semantic segmentations masks in the specified field of the
+    collection into :class:`fiftyone.core.labels.Detections` with instance
+    masks populated.
+
+    Each ``"stuff"`` class will be converted to a single
+    :class:`fiftyone.core.labels.Detection` whose instance mask spans all
+    region(s) of the class.
+
+    Each ``"thing"`` class will result in one
+    :class:`fiftyone.core.labels.Detection` instance per connected region of
+    that class in the segmentation.
 
     Args:
         sample_collection: a
             :class:`fiftyone.core.collections.SampleCollection`
-        out_field: the name of the
-            :class:`fiftyone.core.labels.Detections` field to create from
-            the given segmentation masks
         in_field: the name of the :class:`fiftyone.core.labels.Segmentation`
             field to convert
+        out_field: the name of the
+            :class:`fiftyone.core.labels.Detections` field to populate
         mask_targets (None): a dict mapping integer pixel values in
             ``[0, 255]`` to label strings defining which object classes to
             label and which pixel values to use for each class. If
             omitted, all labels are assigned to the integer pixel values
+        mask_types ("stuff"): whether the classes are ``"stuff"`` (amorphous
+            regions of pixels) or ``"thing"`` (connected regions, each
+            representing an instance of the thing). Can be any of the
+            following:
+
+            -   ``"stuff"`` if all classes are stuff classes
+            -   ``"thing"`` if all classes are thing classes
+            -   a dict mapping pixel values to ``"stuff"`` or ``"thing"``
+                for each class
     """
     fov.validate_image_collection(sample_collection)
     fov.validate_collection_label_fields(
@@ -128,8 +148,75 @@ def segmentations_to_detections(
         if label is None:
             continue
 
-        detections = label.to_detections(mask_targets=mask_targets)
-        sample[out_field] = detections
+        sample[out_field] = label.to_detections(
+            mask_targets=mask_targets, mask_types=mask_types
+        )
+        sample.save()
+
+
+def segmentations_to_polylines(
+    sample_collection,
+    in_field,
+    out_field,
+    mask_targets=None,
+    mask_types="stuff",
+    tolerance=2,
+):
+    """Converts the semantic segmentations masks in the specified field of the
+    collection into :class:`fiftyone.core.labels.Polylines` instances.
+
+    Each ``"stuff"`` class will be converted to a single
+    :class:`fiftyone.core.labels.Polylines` that may contain multiple disjoint
+    shapes capturing the class.
+
+    Each ``"thing"`` class will result in one
+    :class:`fiftyone.core.labels.Polylines` instance per connected region of
+    that class.
+
+    Args:
+        sample_collection: a
+            :class:`fiftyone.core.collections.SampleCollection`
+        in_field: the name of the :class:`fiftyone.core.labels.Segmentation`
+            field to convert
+        out_field: the name of the
+            :class:`fiftyone.core.labels.Polylines` field to populate
+        mask_targets (None): a dict mapping integer pixel values in
+            ``[0, 255]`` to label strings defining which object classes to
+            label and which pixel values to use for each class. If
+            omitted, all labels are assigned to the integer pixel values
+        mask_types ("stuff"): whether the classes are ``"stuff"`` (amorphous
+            regions of pixels) or ``"thing"`` (connected regions, each
+            representing an instance of the thing). Can be any of the
+            following:
+
+            -   ``"stuff"`` if all classes are stuff classes
+            -   ``"thing"`` if all classes are thing classes
+            -   a dict mapping pixel values to ``"stuff"`` or ``"thing"``
+                for each class
+        tolerance (2): a tolerance, in pixels, when generating approximate
+                polylines for each region. Typical values are 1-3 pixels
+    """
+    fov.validate_image_collection(sample_collection)
+    fov.validate_collection_label_fields(
+        sample_collection, in_field, fol.Segmentation,
+    )
+
+    if mask_targets is None:
+        if out_field in sample_collection.mask_targets:
+            mask_targets = sample_collection.mask_targets[out_field]
+        elif sample_collection.default_mask_targets:
+            mask_targets = sample_collection.default_mask_targets
+
+    for sample in sample_collection.iter_samples(progress=True):
+        label = sample[in_field]
+        if label is None:
+            continue
+
+        sample[out_field] = label.to_polylines(
+            mask_targets=mask_targets,
+            mask_types=mask_types,
+            tolerance=tolerance,
+        )
         sample.save()
 
 


### PR DESCRIPTION
Change log
- Renames `semantic_segmentation` label type to `segmentation`
- Renames `segmentation(s)` label types to `instance(s)`
- Added support for supplying mask targets for semantic segmentation tasks
- Added support for polyline vs polygon annotations
- Added a `mask_types="stuff"/"thing"` argument to `Segementation.to_detections()` that allows for control over whether to generate one instance per class (stuff) or one instance per connected region (thing) when converting segmentation masks to detections
- Added a `Segmentation.to_polylines()` method
- Added support for importing/exporting segmentation masks with > 256 classes as uint16 masks when working with `ImageSegmentationDirectory` format
- Fixed a bug that prevented multiple imports of the same annotation run from working as expected when a label is deleted but then later re-added
- Fixed a bug that prevented annotations for new label fields of video datasets from being imported properly
- Fixed a bug that would cause things like polygons with < 3 points to be deleted when editing existing annotations in CVAT
- API cleanup

The video annotation import problem was solved by adding an `ensure_frames()` method to `Dataset`/`DatasetView` that enables methods that rely on `Frame` instances to exist to ensure that this is indeed the case. 

The polygon with < 3 points problem was solved by requiring the annotation backend to keep track of which IDs it was able to upload for annotation, rather than relying on a generic `AnnotationBackend.build_id_map()` method that assumes that all labels in the view were able to be uploaded.

### Detection/instance annotation

```py
import fiftyone as fo
import fiftyone.zoo as foz

dataset = foz.load_zoo_dataset(
    "open-images-v6",
    split="validation",
    max_samples=25,
    label_types=["segmentations", "detections"],
)

# Populate a field with detections and instances
dataset.clone_sample_field("detections", "boxes_and_instances")
dataset.clone_sample_field("segmentations", "tmp")
dataset.merge_labels("tmp", "boxes_and_instances")
print(dataset)

session = fo.launch_app(dataset)

# Edit boxes
dataset.annotate(
    "detections",
    label_field="boxes_and_instances",
    label_type="detections",
    launch_editor=True,
)

print(dataset.get_annotation_info("detections"))
print(dataset.load_annotation_view("detections"))

dataset.load_annotations("detections")
session.refresh()

# Edit instances
dataset.annotate(
    "instances",
    label_field="boxes_and_instances",
    label_type="instances",
    launch_editor=True,
)

dataset.load_annotations("instances")
session.refresh()

# Boxes are chosen by default
dataset.annotate(
    "default",
    label_field="boxes_and_instances",
    launch_editor=True,
)

dataset.load_annotations("default")
session.refresh()
```

### Polyline/polygon annotation

```py
import random
import fiftyone as fo
import fiftyone.zoo as foz
from fiftyone import ViewField as F

dataset = foz.load_zoo_dataset(
    "open-images-v6",
    split="validation",
    max_samples=20,
    label_types="segmentations",
)

# Populate some polylines and polygons
for sample in dataset:
    filled = bool(random.random() < 0.5)
    sample["polylines"] = sample.segmentations.to_polylines(filled=filled)
    sample.save()

print(dataset)

session = fo.launch_app(dataset)

# Edit polygons
dataset.annotate(
    "polygons",
    label_field="polylines",
    label_type="polygons",
    launch_editor=True,
)

print(dataset.get_annotation_info("polygons"))
print(dataset.load_annotation_view("polygons"))

dataset.load_annotations("polygons")
session.refresh()

# Edit polylines
dataset.annotate(
    "polylines",
    label_field="polylines",
    label_type="polylines",
    launch_editor=True,
)

dataset.load_annotations("polylines")
session.refresh()

# Polygons are chosen by default
dataset.annotate(
    "default",
    label_field="polylines",
    launch_editor=True,
)

dataset.load_annotations("default")
session.refresh()
```

### Semantic segmentation annotation

```py
import fiftyone as fo
import fiftyone.zoo as foz

dataset = foz.load_zoo_dataset(
    "quickstart",
    dataset_name="segmentation-eval-demo",
    max_samples=10,
    shuffle=True,
)

CLASSES = (
    "background,aeroplane,bicycle,bird,boat,bottle,bus,car,cat,chair,cow," +
    "diningtable,dog,horse,motorbike,person,pottedplant,sheep,sofa,train," +
    "tvmonitor"
)
dataset.default_mask_targets = {
    idx: label for idx, label in enumerate(CLASSES.split(","))
}

model = foz.load_zoo_model("deeplabv3-resnet50-coco-torch")
dataset.apply_model(model, "semantic_segmentations")

session = fo.launch_app(dataset)

dataset.annotate(
    "segmentations",
    label_field="semantic_segmentations",
    launch_editor=True,
)

print(dataset.get_annotation_info("segmentations"))

dataset.load_annotations("segmentations")
session.refresh()

results = dataset.load_annotation_results("segmentations")
dataset.load_annotations("segmentations")
```

### Existing video field annotation

```py
import fiftyone as fo
import fiftyone.zoo as foz

dataset = foz.load_zoo_dataset("quickstart-video").clone()

view = dataset.limit(1)

view.annotate(
    "video",
    label_field="frames.detections",
    launch_editor=True,
)

print(dataset.get_annotation_info("video"))

view = dataset.load_annotation_view("video")
session = fo.launch_app(view=view)

dataset.load_annotations("video")
session.refresh()
```

### New video field annotation

```py
import fiftyone as fo
import fiftyone.zoo as foz

dataset = foz.load_zoo_dataset("quickstart-video").clone()
dataset.clear_frames()

view = dataset.limit(1)

view.annotate(
    "video",
    label_field="frames.detections",
    launch_editor=True,
)

print(dataset.get_annotation_info("video"))

view = dataset.load_annotation_view("video")
session = fo.launch_app(view=view)

dataset.load_annotations("video")
session.refresh()
```
