### PR TITLE
Only warn during `mongod` compatibility validation

### DIFF
--- a/docs/source/user_guide/config.rst
+++ b/docs/source/user_guide/config.rst
@@ -312,7 +312,7 @@ You can achieve this by adding the following entry to your
 .. code-block:: json
 
     {
-        "database_validation": False
+        "database_validation": false
     }
 
 or you can set the following environment variable:

--- a/docs/source/user_guide/config.rst
+++ b/docs/source/user_guide/config.rst
@@ -24,6 +24,10 @@ FiftyOne supports the configuration options described below:
 |                               |                                     |                               | specifying a custom MongoDB database to which to connect. See                          |
 |                               |                                     |                               | :ref:`this section <configuring-mongodb-connection>` for more information.             |
 +-------------------------------+-------------------------------------+-------------------------------+----------------------------------------------------------------------------------------+
+| `database_validation`         | `FIFTYONE_DATABASE_VALIDATION`      | `True`                        | Whether to validate the compatibility of database, i.e. `mongod`, connections. If      |
+|                               |                                     |                               | `False`, connections to `mongod` instances that fall outside the officially supported  |
+|                               |                                     |                               | versions will be allowed.                                                              |
++-------------------------------+-------------------------------------+-------------------------------+----------------------------------------------------------------------------------------+
 | `dataset_zoo_dir`             | `FIFTYONE_DATASET_ZOO_DIR`          | `~/fiftyone`                  | The default directory in which to store datasets that are downloaded from the          |
 |                               |                                     |                               | :ref:`FiftyOne Dataset Zoo <dataset-zoo>`.                                             |
 +-------------------------------+-------------------------------------+-------------------------------+----------------------------------------------------------------------------------------+
@@ -100,6 +104,7 @@ and the CLI:
         {
             "database_dir": "~/.fiftyone/var/lib/mongo",
             "database_uri": null,
+            "database_validation": true,
             "dataset_zoo_dir": "~/fiftyone",
             "dataset_zoo_manifest_paths": null,
             "default_app_config_path": "~/.fiftyone/app_config.json",
@@ -135,6 +140,7 @@ and the CLI:
         {
             "database_dir": "~/.fiftyone/var/lib/mongo",
             "database_uri": null,
+            "database_validation": true,
             "dataset_zoo_dir": "~/fiftyone",
             "dataset_zoo_manifest_paths": null,
             "default_app_config_path": "~/.fiftyone/app_config.json",

--- a/docs/source/user_guide/config.rst
+++ b/docs/source/user_guide/config.rst
@@ -24,9 +24,8 @@ FiftyOne supports the configuration options described below:
 |                               |                                     |                               | specifying a custom MongoDB database to which to connect. See                          |
 |                               |                                     |                               | :ref:`this section <configuring-mongodb-connection>` for more information.             |
 +-------------------------------+-------------------------------------+-------------------------------+----------------------------------------------------------------------------------------+
-| `database_validation`         | `FIFTYONE_DATABASE_VALIDATION`      | `True`                        | Whether to validate the compatibility of database, i.e. `mongod`, connections. If      |
-|                               |                                     |                               | `False`, connections to `mongod` instances that fall outside the officially supported  |
-|                               |                                     |                               | versions will be allowed.                                                              |
+| `database_validation`         | `FIFTYONE_DATABASE_VALIDATION`      | `True`                        | Whether to validate the compatibility of database before connecting to it. See         |
+|                               |                                     |                               | :ref:`this section <configuring-mongodb-connection>` for more information.             |
 +-------------------------------+-------------------------------------+-------------------------------+----------------------------------------------------------------------------------------+
 | `dataset_zoo_dir`             | `FIFTYONE_DATASET_ZOO_DIR`          | `~/fiftyone`                  | The default directory in which to store datasets that are downloaded from the          |
 |                               |                                     |                               | :ref:`FiftyOne Dataset Zoo <dataset-zoo>`.                                             |
@@ -257,8 +256,8 @@ MongoDB instance. To do so, simply set the `database_uri` property of your
 FiftyOne config to any valid
 `MongoDB connection string URI <https://docs.mongodb.com/manual/reference/connection-string/>`_.
 
-For example, you can create a `~/.fiftyone/config.json` file with the following
-entry:
+You can achieve this by adding the following entry to your
+`~/.fiftyone/config.json` file:
 
 .. code-block:: json
 
@@ -271,24 +270,6 @@ or you can set the following environment variable:
 .. code-block:: shell
 
     export FIFTYONE_DATABASE_URI=mongodb://[username:password@]host[:port]
-
-Very rarerly, upgrading your FiftyOne package may require running a database
-admin migration, in which case the `database_uri` must establish a connection
-with administrative privileges.
-
-.. warning::
-
-    FiftyOne is designed for and distributed with MongoDB v4.4.
-
-    Users have reported success connecting to MongoDB v5 databases, but you
-    should
-    `set the feature compatibility version <https://docs.mongodb.com/manual/reference/command/setFeatureCompatibilityVersion>`_
-    to 4.4 to ensure proper function:
-
-    .. code-block:: shell
-
-        mongo --shell
-        > db.adminCommand({setFeatureCompatibilityVersion: "4.4"})
 
 .. note::
 
@@ -304,6 +285,41 @@ with administrative privileges.
 
         brew tap mongodb/brew
         brew install mongodb-community@4.4
+
+Using a different MongoDB version
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+FiftyOne is designed for and distributed with **MongoDB v4.4**.
+
+Users have reported success connecting to MongoDB v5 databases, but if you wish
+to do this, you should
+`set the feature compatibility version <https://docs.mongodb.com/manual/reference/command/setFeatureCompatibilityVersion>`_
+to 4.4 to ensure proper function:
+
+.. code-block:: shell
+
+    mongo --shell
+    > db.adminCommand({setFeatureCompatibilityVersion: "4.4"})
+
+If you wish to connect FiftyOne to a MongoDB database whose version is not
+explicitly supported, you will also need to set the `database_validation`
+property of your FiftyOne config to `False` to suppress a runtime error that
+will otherwise occur.
+
+You can achieve this by adding the following entry to your
+`~/.fiftyone/config.json` file:
+
+.. code-block:: json
+
+    {
+        "database_validation": False
+    }
+
+or you can set the following environment variable:
+
+.. code-block:: shell
+
+    export FIFTYONE_DATABASE_VALIDATION=False
 
 Example custom database usage
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/source/user_guide/config.rst
+++ b/docs/source/user_guide/config.rst
@@ -319,7 +319,7 @@ or you can set the following environment variable:
 
 .. code-block:: shell
 
-    export FIFTYONE_DATABASE_VALIDATION=False
+    export FIFTYONE_DATABASE_VALIDATION=false
 
 Example custom database usage
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/fiftyone/core/config.py
+++ b/fiftyone/core/config.py
@@ -84,7 +84,7 @@ class FiftyOneConfig(EnvConfig):
             default=None,
         )
         self.model_zoo_dir = self.parse_string(
-            d, "model_zoo_dir", env_var="FIFTYONE_MODEL_ZOO_DIR", default=None,
+            d, "model_zoo_dir", env_var="FIFTYONE_MODEL_ZOO_DIR", default=None
         )
         self.dataset_zoo_manifest_paths = self.parse_string_array(
             d,

--- a/fiftyone/core/config.py
+++ b/fiftyone/core/config.py
@@ -65,6 +65,12 @@ class FiftyOneConfig(EnvConfig):
         self.database_uri = self.parse_string(
             d, "database_uri", env_var="FIFTYONE_DATABASE_URI", default=None
         )
+        self.database_validation = self.parse_bool(
+            d,
+            "database_validation",
+            env_var="FIFTYONE_DATABASE_VALIDATION",
+            default=True,
+        )
         self.database_dir = self.parse_string(
             d,
             "database_dir",

--- a/fiftyone/core/odm/database.py
+++ b/fiftyone/core/odm/database.py
@@ -123,7 +123,7 @@ def _validate_db_version(config, client):
     if config.database_validation and not (min_ver <= version < max_ver):
         raise RuntimeError(
             "Found `mongod` version %s, but only [%s, %s) are compatible. "
-            "You can suppress this exception if desired by setting your "
+            "You can suppress this exception by setting your "
             "`database_validation` config parameter to `False`. See "
             "https://voxel51.com/docs/fiftyone/user_guide/config.html#configuring-a-mongodb-connection "
             "for more information" % (version, min_ver, max_ver)

--- a/fiftyone/core/odm/database.py
+++ b/fiftyone/core/odm/database.py
@@ -120,18 +120,8 @@ def _validate_db_version(config, client):
         raise RuntimeError("Failed to validate `mongod` version") from e
 
     min_ver, max_ver = foc.MONGODB_VERSION_RANGE
-
-    if config.database_uri is not None:
-        # Allow custom databases to have version > max_ver, with the assumption
-        # that the user has set their feature compatibility version
-        # https://docs.mongodb.com/manual/reference/command/setFeatureCompatibilityVersion
-        if version < min_ver:
-            logger.warning(
-                "Found `mongod` version %s, but only %s or later is compatible"
-                % (version, min_ver)
-            )
-    elif version < min_ver or version > max_ver:
-        logger.warning(
+    if config.database_validation and version < min_ver or version > max_ver:
+        raise RuntimeError(
             "Found `mongod` version %s, but only [%s, %s) are compatible"
             % (version, min_ver, max_ver)
         )

--- a/fiftyone/core/odm/database.py
+++ b/fiftyone/core/odm/database.py
@@ -126,13 +126,13 @@ def _validate_db_version(config, client):
         # that the user has set their feature compatibility version
         # https://docs.mongodb.com/manual/reference/command/setFeatureCompatibilityVersion
         if version < min_ver:
-            raise RuntimeError(
-                "Found `mongod` version %s, but %s or later is required"
+            logger.warning(
+                "Found `mongod` version %s, but only %s or later is compatible"
                 % (version, min_ver)
             )
     elif version < min_ver or version > max_ver:
-        raise RuntimeError(
-            "Found `mongod` version %s, but [%s, %s) is required"
+        logger.warning(
+            "Found `mongod` version %s, but only [%s, %s) are compatible"
             % (version, min_ver, max_ver)
         )
 

--- a/fiftyone/core/odm/database.py
+++ b/fiftyone/core/odm/database.py
@@ -120,12 +120,13 @@ def _validate_db_version(config, client):
         raise RuntimeError("Failed to validate `mongod` version") from e
 
     min_ver, max_ver = foc.MONGODB_VERSION_RANGE
-    if config.database_validation and (version < min_ver or version > max_ver):
+    if config.database_validation and not (min_ver <= version < max_ver):
         raise RuntimeError(
             "Found `mongod` version %s, but only [%s, %s) are compatible. "
-            "Please set `database_validation` to `False` in your "
-            "`fiftyone.core.config.FiftyOneConfig` to suppress this exception"
-            % (version, min_ver, max_ver)
+            "You can suppress this exception if desired by setting your "
+            "`database_validation` config parameter to `False`. See "
+            "https://voxel51.com/docs/fiftyone/user_guide/config.html#configuring-a-mongodb-connection "
+            "for more information" % (version, min_ver, max_ver)
         )
 
 

--- a/fiftyone/core/odm/database.py
+++ b/fiftyone/core/odm/database.py
@@ -120,9 +120,11 @@ def _validate_db_version(config, client):
         raise RuntimeError("Failed to validate `mongod` version") from e
 
     min_ver, max_ver = foc.MONGODB_VERSION_RANGE
-    if config.database_validation and version < min_ver or version > max_ver:
+    if config.database_validation and (version < min_ver or version > max_ver):
         raise RuntimeError(
-            "Found `mongod` version %s, but only [%s, %s) are compatible"
+            "Found `mongod` version %s, but only [%s, %s) are compatible. "
+            "Please set `database_validation` to `False` in your "
+            "`fiftyone.core.config.FiftyOneConfig` to suppress this exception"
             % (version, min_ver, max_ver)
         )
 


### PR DESCRIPTION
Relaxes `mongod` validation to only warn if an incompatible version is found. One reason for this change is it enables connections to Amazon DocumentDB (no promises).

Tested with this [guide](https://docs.aws.amazon.com/en_us/documentdb/latest/developerguide/connect-ec2.html)