### PR TITLE
Including missing GT/predictions by default in confusion matrices

### DIFF
--- a/fiftyone/utils/eval/base.py
+++ b/fiftyone/utils/eval/base.py
@@ -215,7 +215,7 @@ class BaseEvaluationResults(foe.EvaluationResults):
         Returns:
             a ``num_classes x num_classes`` confusion matrix
         """
-        labels = self._get_labels(classes)
+        labels = self._get_labels(classes, include_missing=True)
         confusion_matrix, _, _ = self._confusion_matrix(
             labels, include_other=include_other
         )


### PR DESCRIPTION
Makes a small change to the default behavior of confusion matrices plotted via the following syntax:

```py
plot = results.plot_confusion_matrix(classes=classes)
plot.show()
```

Previously, if `classes` are provided, no row/column for missing GT/predictions would be included in the confusion matrix unless you explicitly included `results.missing` in the `classes` list.

Now, the row/column for missing GT/predictions is *always* included if there are any, unless you pass the optional `include_missing=False` flag to explicitly remove them.

I think this is a better default behavior, especially for detection evaluation. The issue arose because "missing" is not generally an issue for classification evaluation, and both cases share the same code.

As the examples below demonstrate, the new default behavior now "shows the right thing" for both detection and classification.

### Detection example

```py
import fiftyone as fo
import fiftyone.zoo as foz

dataset = foz.load_zoo_dataset("quickstart").clone()

results = dataset.evaluate_detections("predictions", eval_key="eval")

results.print_report()
plot = results.plot_confusion_matrix()
plot.show()

results.print_report(classes=["person", "cat", "dog"])
plot = results.plot_confusion_matrix(classes=["person", "cat", "dog"])
plot.show()

plot = results.plot_confusion_matrix(classes=["person", "cat", "dog"], include_other=False)
plot.show()

plot = results.plot_confusion_matrix(classes=["person", "cat", "dog"], include_missing=False, include_other=False)
plot.show()
```

### Classification example

```py
import random

import fiftyone as fo
import fiftyone.zoo as foz
from fiftyone import ViewField as F

dataset = foz.load_zoo_dataset("cifar10", split="test", max_samples=1000, shuffle=True)

classes = dataset.distinct("ground_truth.label")

def jitter(val):
    if random.random() < 0.10:
        return random.choice(classes)

    return val

predictions = [
    fo.Classification(label=jitter(gt.label), confidence=random.random())
    for gt in dataset.values("ground_truth")
]

dataset.set_values("predictions", predictions)

results = dataset.evaluate_classifications("predictions", gt_field="ground_truth", eval_key="eval_simple")

results.print_report()
plot = results.plot_confusion_matrix()
plot.show()

results.print_report(classes=["airplane", "cat", "dog"])
plot = results.plot_confusion_matrix(classes=["airplane", "cat", "dog"])
plot.show()

plot = results.plot_confusion_matrix(classes=["airplane", "cat", "dog"], include_other=False)
plot.show()
```
