### PR TITLE
Adding a to_trajectories() stage

### DIFF
--- a/fiftyone/__public__.py
+++ b/fiftyone/__public__.py
@@ -162,6 +162,7 @@ from .core.stages import (
     ToPatches,
     ToEvaluationPatches,
     ToClips,
+    ToTrajectories,
     ToFrames,
 )
 from .core.session import (

--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -4606,12 +4606,16 @@ class SampleCollection(object):
 
             dataset = foz.load_zoo_dataset("quickstart-video")
 
-            # Create a trajectories view for each vehicle in the dataset
+            #
+            # Create a trajectories view for the vehicles in the dataset
+            #
+
             trajectories = (
                 dataset
                 .filter_labels("frames.detections", F("label") == "vehicle")
                 .to_trajectories("frames.detections")
             )
+
             print(trajectories)
 
         Args:

--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -4584,6 +4584,55 @@ class SampleCollection(object):
         return self._add_view_stage(fos.ToClips(field_or_expr, **kwargs))
 
     @view_stage
+    def to_trajectories(self, field, **kwargs):
+        """Creates a view that contains one clip for each unique object
+        trajectory defined by their ``(label, index)`` in a frame-level field
+        of a video collection.
+
+        The returned view will contain:
+
+        -   A ``sample_id`` field that records the sample ID from which each
+            clip was taken
+        -   A ``support`` field that records the ``[first, last]`` frame
+            support of each clip
+        -   A sample-level label field that records the ``label`` and ``index``
+            of each trajectory
+
+        Examples::
+
+            import fiftyone as fo
+            import fiftyone.zoo as foz
+            from fiftyone import ViewField as F
+
+            dataset = foz.load_zoo_dataset("quickstart-video")
+
+            # Create a trajectories view for each vehicle in the dataset
+            trajectories = (
+                dataset
+                .filter_labels("frames.detections", F("label") == "vehicle")
+                .to_trajectories("frames.detections")
+            )
+            print(trajectories)
+
+        Args:
+            field: a frame-level label list field of any of the following
+                types:
+                -   :class:`fiftyone.core.labels.Detections`
+                -   :class:`fiftyone.core.labels.Polylines`
+                -   :class:`fiftyone.core.labels.Keypoints`
+            config (None): an optional dict of keyword arguments for
+                :meth:`fiftyone.core.clips.make_clips_dataset` specifying how
+                to perform the conversion
+            **kwargs: optional keyword arguments for
+                :meth:`fiftyone.core.clips.make_clips_dataset` specifying how
+                to perform the conversion
+
+        Returns:
+            a :class:`fiftyone.core.clips.ClipsView`
+        """
+        return self._add_view_stage(fos.ToTrajectories(field, **kwargs))
+
+    @view_stage
     def to_frames(self, **kwargs):
         """Creates a view that contains one sample per frame in the video
         collection.

--- a/fiftyone/core/stages.py
+++ b/fiftyone/core/stages.py
@@ -5649,10 +5649,14 @@ class ToTrajectories(ViewStage):
 
         dataset = foz.load_zoo_dataset("quickstart-video")
 
-        # Create a trajectories view for each vehicle in the dataset
+        #
+        # Create a trajectories view for the vehicles in the dataset
+        #
+
         stage1 = fo.FilterLabels("frames.detections", F("label") == "vehicle")
         stage2 = fo.ToTrajectories("frames.detections")
         trajectories = dataset.add_stage(stage1).add_stage(stage2)
+
         print(trajectories)
 
     Args:

--- a/fiftyone/core/state.py
+++ b/fiftyone/core/state.py
@@ -14,6 +14,7 @@ import eta.core.utils as etau
 
 import fiftyone as fo
 import fiftyone.core.aggregations as foa
+import fiftyone.core.clips as foc
 import fiftyone.core.dataset as fod
 import fiftyone.core.fields as fof
 import fiftyone.core.labels as fol
@@ -83,7 +84,12 @@ class StateDescription(etas.Serializable):
 
                 if self.view is not None:
                     _view = self.view._serialize()
-                    _view_cls = etau.get_class_name(self.view)
+
+                    # @todo update App so this isn't needed
+                    if isinstance(self.view, foc.TrajectoriesView):
+                        _view_cls = etau.get_class_name(foc.ClipsView)
+                    else:
+                        _view_cls = etau.get_class_name(self.view)
 
                     # If the view uses a temporary dataset, we must use its
                     # media type and field schemas


### PR DESCRIPTION
Adds a `to_trajectories(field)` view stage that generates a clips view that contains one clip per object trajectory (ie., a collection of objects with the same `index` in a video) in a frame-level field of a video dataset.

Unlike `to_clips(field, trajectories=True)`, which also generates one clip per object trajectory (although this syntax is not prominently documented) but includes all frame-level labels, `to_trajectories()` selects *only* the single object defining the trajectory in each clip.

Note that `to_trajectories()` is the video analogue of `to_patches()` for image datasets.

### TODO

- Resolve the `@todo` in `fiftyone.core.state`

### Discussion

I'd like to let this PR bake a bit, because, with the current implementation, I've empirically observed that the aggregations for trajectories views can be quite expensive to compute, and it might be good to optimize before officially releasing this feature.

Under the hood, all frame-level labels are attached to each clip and then filtered via a `filter_labels()` stage to retrieve the defining object trajectory for each clip. The good thing about this is that (like other clips views) it avoids creating a temporary frame collection to serve the view. The bad thing is that the computations quickly explode because the number of dense frames that must be filtered in this setup is `O(# bboxes)`, which can be much greater than computing stats for the source video collection, which is `O(# video frames)`.

For example, in the snippet below, we have:

```
len(dataset)  # 10
dataset.count("frames")  # 1279

len(trajectories)  # 109
trajectories.count("frames")  # 7565
```

### Example usage

Here we create a trajectories view that contains one clip per vehicle in the dataset:

```py
import fiftyone as fo
import fiftyone.zoo as foz
from fiftyone import ViewField as F

dataset = foz.load_zoo_dataset("quickstart-video")

# Create a trajectories view for the vehicles in the dataset
trajectories = (
    dataset
    .filter_labels("frames.detections", F("label") == "vehicle")
    .to_trajectories("frames.detections")
)
print(trajectories)

session = fo.launch_app(view=trajectories)
```
