### PR TITLE
Adding set operation expressions

### DIFF
--- a/fiftyone/core/aggregations.py
+++ b/fiftyone/core/aggregations.py
@@ -1466,6 +1466,9 @@ class Values(Aggregation):
 
 
 def _is_frame_path(sample_collection, field_name):
+    if not field_name:
+        return False
+
     # Remove array references
     path = "".join(field_name.split("[]"))
 

--- a/fiftyone/core/expressions.py
+++ b/fiftyone/core/expressions.py
@@ -2281,9 +2281,11 @@ class ViewExpression(object):
             )
 
             print(dataset.values(F("tags").is_subset(F("other_tags"))))
+            # [True]
 
         Args:
-            values: an iterable of values or an array :class:`ViewExpression`
+            values: an iterable of values or a :class:`ViewExpression` that
+                resolves to an array
 
         Returns:
             a :class:`ViewExpression`
@@ -2319,6 +2321,7 @@ class ViewExpression(object):
             )
 
             print(dataset.values(F("tags").set_equals(F("other_tags"))))
+            # [True]
 
         Args:
             *args: one or more arrays or :class:`ViewExpression` instances that
@@ -2349,6 +2352,7 @@ class ViewExpression(object):
             )
 
             print(dataset.values(F("tags").unique()))
+            # [['a', 'b']]
 
         Returns:
             a :class:`ViewExpression`
@@ -2449,7 +2453,8 @@ class ViewExpression(object):
             # [['b']]
 
         Args:
-            values: an iterable of values or an array :class:`ViewExpression`
+            values: an iterable of values or a :class:`ViewExpression` that
+                resolves to an array
 
         Returns:
             a :class:`ViewExpression`

--- a/fiftyone/core/expressions.py
+++ b/fiftyone/core/expressions.py
@@ -2260,7 +2260,7 @@ class ViewExpression(object):
 
     def is_subset(self, values):
         """Checks whether this expression's contents, which must resolve to an
-        array, are a subset of the given array or array expression's values.
+        array, are a subset of the given array or array expression's contents.
 
         The arrays are treated as sets, so duplicate values are ignored.
 

--- a/fiftyone/core/expressions.py
+++ b/fiftyone/core/expressions.py
@@ -2245,10 +2245,15 @@ class ViewExpression(object):
             a :class:`ViewExpression`
         """
         if not isinstance(values, ViewExpression):
-            if not etau.is_container(values):
-                return ViewExpression({"$in": [values, self]})
+            if etau.is_container(values):
+                values = list(values)
+                if len(values) == 1:
+                    values = values[0]
 
-            values = list(values)
+            if isinstance(values, ViewExpression) or not etau.is_container(
+                values
+            ):
+                return ViewExpression({"$in": [values, self]})
 
         if not all:
             return self.intersection(values).length() > 0

--- a/fiftyone/core/stages.py
+++ b/fiftyone/core/stages.py
@@ -1926,7 +1926,7 @@ def _get_trajectories_filter(sample_collection, field, filter_arg):
 
     set_pipeline = [{"$set": {"_indexes": indexes_expr.to_mongo()}}]
     label_filter = (F("$_indexes") != None) & F("$_indexes").contains(
-        F("index")
+        [F("index")]
     )
     unset_pipeline = [{"$unset": "_indexes"}]
 


### PR DESCRIPTION
Adds `ViewExpression` methods for some previously missing set operations, including `is_subset()`, `set_equals()`, `unique()`, `union()`, `intersection()`, `difference()`, and `contains(..., all=True)`.

See the added documentation for example usages.
