### PR TITLE
Add server address option to App sessions

### DIFF
--- a/docs/source/cli/index.rst
+++ b/docs/source/cli/index.rst
@@ -98,7 +98,7 @@ Launch a FiftyOne quickstart.
 
 .. code-block:: text
 
-    fiftyone quickstart [-h] [-v] [-p PORT] [-r] [-a] [-w WAIT]
+    fiftyone quickstart [-h] [-v] [-p PORT] [-A ADDRESS] [-r] [-a] [-w WAIT]
 
 **Arguments**
 
@@ -108,6 +108,8 @@ Launch a FiftyOne quickstart.
       -h, --help            show this help message and exit
       -v, --video           launch the quickstart with a video dataset
       -p PORT, --port PORT  the port number to use
+      -A ADDRESS, --address ADDRESS
+                            the address (server name) to use
       -r, --remote          whether to launch a remote App session
       -a, --desktop         whether to launch a desktop App instance
       -w WAIT, --wait WAIT  the number of seconds to wait for a new App
@@ -1033,7 +1035,7 @@ Launch the FiftyOne App.
 
 .. code-block:: text
 
-    fiftyone app launch [-h] [-p PORT] [-r] [-a] [-w WAIT] [NAME]
+    fiftyone app launch [-h] [-p PORT] [-A ADDRESS] [-r] [-a] [-w WAIT] [NAME]
 
 **Arguments**
 
@@ -1045,6 +1047,8 @@ Launch the FiftyOne App.
     optional arguments:
       -h, --help            show this help message and exit
       -p PORT, --port PORT  the port number to use
+      -A ADDRESS, --address ADDRESS
+                            the address (server name) to use
       -r, --remote          whether to launch a remote App session
       -a, --desktop         whether to launch a desktop App instance
       -w WAIT, --wait WAIT  the number of seconds to wait for a new App
@@ -1087,7 +1091,8 @@ View datasets in the FiftyOne App without persisting them to the database.
                       [-s SPLITS [SPLITS ...]] [--images-dir IMAGES_DIR]
                       [--images-patt IMAGES_PATT] [--videos-dir VIDEOS_DIR]
                       [--videos-patt VIDEOS_PATT] [-j JSON_PATH] [-p PORT]
-                      [-r] [-a] [-w WAIT] [-k KEY=VAL [KEY=VAL ...]]
+                      [-A ADDRESS] [-r] [-a] [-w WAIT]
+                      [-k KEY=VAL [KEY=VAL ...]]
 
 **Arguments**
 
@@ -1114,6 +1119,8 @@ View datasets in the FiftyOne App without persisting them to the database.
       -j JSON_PATH, --json-path JSON_PATH
                             the path to a samples JSON file to view
       -p PORT, --port PORT  the port number to use
+      -A ADDRESS, --address ADDRESS
+                            the address (server name) to use
       -r, --remote          whether to launch a remote App session
       -a, --desktop         whether to launch a desktop App instance
       -w WAIT, --wait WAIT  the number of seconds to wait for a new App
@@ -1185,7 +1192,8 @@ Connect to a remote FiftyOne App in your web browser.
 
 .. code-block:: text
 
-    fiftyone app connect [-h] [-d DESTINATION] [-p PORT] [-l PORT] [-i KEY]
+    fiftyone app connect [-h] [-d DESTINATION] [-p PORT] [-A ADDRESS] [-l PORT]
+                         [-i KEY]
 
 **Arguments**
 

--- a/docs/source/user_guide/config.rst
+++ b/docs/source/user_guide/config.rst
@@ -61,6 +61,11 @@ FiftyOne supports the configuration options described below:
 +-------------------------------+-------------------------------------+-------------------------------+----------------------------------------------------------------------------------------+
 | `default_app_port`            | `FIFTYONE_DEFAULT_APP_PORT`         | `5151`                        | The default port to use to serve the :ref:`FiftyOne App <fiftyone-app>`.               |
 +-------------------------------+-------------------------------------+-------------------------------+----------------------------------------------------------------------------------------+
+| `default_app_address`         | `FIFTYONE_DEFAULT_APP_ADDRESS`      | `None`                        | The default address to use to serve the :ref:`FiftyOne App <fiftyone-app>`. It may be  |
+|                               |                                     |                               | either an IP address or hostname. If it's a hostname, App's will listen on all IP      |
+|                               |                                     |                               | addresses associated with the name. The default `None` or an empty string means the    |
+|                               |                                     |                               | App will listen on all available interfaces by default.                                |
++-------------------------------+-------------------------------------+-------------------------------+----------------------------------------------------------------------------------------+
 | `desktop_app`                 | `FIFTYONE_DESKTOP_APP`              | `False`                       | Whether to launch the FiftyOne App in the browser (False) or as a desktop App (True)   |
 |                               |                                     |                               | by default. If True, the :ref:`FiftyOne Desktop App <installing-fiftyone-desktop>`     |
 |                               |                                     |                               | must be installed.                                                                     |
@@ -108,6 +113,7 @@ and the CLI:
             "dataset_zoo_manifest_paths": null,
             "default_app_config_path": "~/.fiftyone/app_config.json",
             "default_app_port": 5151,
+            "default_app_address": null,
             "default_batch_size": null,
             "default_dataset_dir": "~/fiftyone",
             "default_image_ext": ".jpg",
@@ -144,6 +150,7 @@ and the CLI:
             "dataset_zoo_manifest_paths": null,
             "default_app_config_path": "~/.fiftyone/app_config.json",
             "default_app_port": 5151,
+            "default_app_address": null,
             "default_batch_size": null,
             "default_dataset_dir": "~/fiftyone",
             "default_image_ext": ".jpg",

--- a/fiftyone/constants.py
+++ b/fiftyone/constants.py
@@ -81,7 +81,6 @@ MONGODB_VERSION_RANGE = (Version("4.4"), Version("4.5"))  # [min, max)
 
 # Server setup
 SERVER_DIR = os.path.join(FIFTYONE_DIR, "server")
-SERVER_NAME = "localhost"
 
 # App setup
 try:

--- a/fiftyone/core/cli.py
+++ b/fiftyone/core/cli.py
@@ -126,6 +126,14 @@ class QuickstartCommand(Command):
             help="the port number to use",
         )
         parser.add_argument(
+            "-A",
+            "--address",
+            metavar="ADDRESS",
+            default=None,
+            type=str,
+            help="the address (server name) to use",
+        )
+        parser.add_argument(
             "-r",
             "--remote",
             action="store_true",
@@ -158,6 +166,7 @@ class QuickstartCommand(Command):
         _, session = fouq.quickstart(
             video=args.video,
             port=args.port,
+            address=args.address,
             remote=args.remote,
             desktop=desktop,
         )
@@ -985,6 +994,14 @@ class AppLaunchCommand(Command):
             help="the port number to use",
         )
         parser.add_argument(
+            "-A",
+            "--address",
+            metavar="ADDRESS",
+            default=None,
+            type=str,
+            help="the address (server name) to use",
+        )
+        parser.add_argument(
             "-r",
             "--remote",
             action="store_true",
@@ -1022,6 +1039,7 @@ class AppLaunchCommand(Command):
         session = fos.launch_app(
             dataset=dataset,
             port=args.port,
+            address=args.address,
             remote=args.remote,
             desktop=desktop,
         )
@@ -1152,6 +1170,14 @@ class AppViewCommand(Command):
             help="the port number to use",
         )
         parser.add_argument(
+            "-A",
+            "--address",
+            metavar="ADDRESS",
+            default=None,
+            type=str,
+            help="the address (server name) to use",
+        )
+        parser.add_argument(
             "-r",
             "--remote",
             action="store_true",
@@ -1244,6 +1270,7 @@ class AppViewCommand(Command):
         session = fos.launch_app(
             dataset=dataset,
             port=args.port,
+            address=args.address,
             remote=args.remote,
             desktop=desktop,
         )

--- a/fiftyone/core/client.py
+++ b/fiftyone/core/client.py
@@ -17,8 +17,6 @@ from bson import json_util
 from tornado.ioloop import IOLoop
 from tornado.websocket import websocket_connect
 
-from fiftyone.constants import SERVER_NAME
-
 
 logging.getLogger("tornado").setLevel(logging.ERROR)
 
@@ -38,12 +36,17 @@ class HasClient(object):
     _HC_ATTR_NAME = None
     _HC_ATTR_TYPE = None
 
-    def __init__(self, port):
+    def __init__(self, port, address):
         self._port = port
+        self._address = address or "localhost"
         self._data = None
         self._client = None
         self._initial_connection = True
-        self._url = "ws://%s:%d/%s" % (SERVER_NAME, port, self._HC_NAMESPACE)
+        self._url = "ws://%s:%d/%s" % (
+            self._address,
+            self._port,
+            self._HC_NAMESPACE,
+        )
         self._listeners = {}
 
         async def connect():
@@ -63,8 +66,8 @@ class HasClient(object):
                 if message is None and _leader[self._url] == self:
                     print("\r\nSession disconnected, trying to reconnect\r\n")
                     fiftyone_url = "http://%s:%d/fiftyone" % (
-                        SERVER_NAME,
-                        port,
+                        self._address,
+                        self._port,
                     )
 
                     self._client = None

--- a/fiftyone/core/config.py
+++ b/fiftyone/core/config.py
@@ -140,6 +140,12 @@ class FiftyOneConfig(EnvConfig):
             env_var="FIFTYONE_DEFAULT_APP_PORT",
             default=5151,
         )
+        self.default_app_address = self.parse_string(
+            d,
+            "default_app_address",
+            env_var="FIFTYONE_DEFAULT_APP_ADDRESS",
+            default=None,
+        )
         self.desktop_app = self.parse_bool(
             d, "desktop_app", env_var="FIFTYONE_DESKTOP_APP", default=False,
         )

--- a/fiftyone/server/main.py
+++ b/fiftyone/server/main.py
@@ -1466,7 +1466,10 @@ class Application(tornado.web.Application):
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("--port", type=int, default=fo.config.default_app_port)
+    parser.add_argument(
+        "--address", type=str, default=fo.config.default_app_address
+    )
     args = parser.parse_args()
     app = Application(debug=foc.DEV_INSTALL)
-    app.listen(args.port)
+    app.listen(args.port, address=args.address)
     tornado.ioloop.IOLoop.current().start()

--- a/fiftyone/utils/quickstart.py
+++ b/fiftyone/utils/quickstart.py
@@ -11,7 +11,9 @@ import fiftyone.core.session as fos
 import fiftyone.zoo.datasets as fozd
 
 
-def quickstart(video=False, port=None, remote=False, desktop=None):
+def quickstart(
+    video=False, port=None, address=None, remote=False, desktop=None
+):
     """Runs the FiftyOne quickstart.
 
     This method loads an interesting dataset from the Dataset Zoo, launches the
@@ -21,6 +23,8 @@ def quickstart(video=False, port=None, remote=False, desktop=None):
         video (False): whether to launch a video dataset
         port (None): the port number to serve the App. If None,
             ``fiftyone.config.default_app_port`` is used
+        address (None): the address to serve the App. If None,
+            ``fiftyone.config.default_app_address`` is used
         remote (False): whether this is a remote session, and opening the App
             should not be attempted
         desktop (None): whether to launch the App in the browser (False) or as
@@ -35,26 +39,30 @@ def quickstart(video=False, port=None, remote=False, desktop=None):
             the App that was launched
     """
     if video:
-        return _video_quickstart(port, remote, desktop)
+        return _video_quickstart(port, address, remote, desktop)
 
-    return _quickstart(port, remote, desktop)
+    return _quickstart(port, address, remote, desktop)
 
 
-def _quickstart(port, remote, desktop):
+def _quickstart(port, address, remote, desktop):
     print(_QUICKSTART_GUIDE)
     dataset = fozd.load_zoo_dataset("quickstart")
-    return _launch_app(dataset, port, remote, desktop)
+    return _launch_app(dataset, port, address, remote, desktop)
 
 
-def _video_quickstart(port, remote, desktop):
+def _video_quickstart(port, address, remote, desktop):
     print(_VIDEO_QUICKSTART_GUIDE)
     dataset = fozd.load_zoo_dataset("quickstart-video")
-    return _launch_app(dataset, port, remote, desktop)
+    return _launch_app(dataset, port, address, remote, desktop)
 
 
-def _launch_app(dataset, port, remote, desktop):
+def _launch_app(dataset, port, address, remote, desktop):
     session = fos.launch_app(
-        dataset=dataset, port=port, remote=remote, desktop=desktop
+        dataset=dataset,
+        port=port,
+        address=address,
+        remote=remote,
+        desktop=desktop,
     )
 
     return dataset, session


### PR DESCRIPTION
Adds a server address in the following places:

* `FiftyOneConfig.default_app_address`
* `address` in commands that launch a session `Session`

The default is `None`, which maintains current behavior. One use for this parameter is to restrict session's `localhost`.