### PR TITLE
[WIP] Add ActivityNet-style VideoClassification evaluation

### DIFF
--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -1840,6 +1840,59 @@ class SampleCollection(object):
             **kwargs,
         )
 
+    def evaluate_video_classifications(
+        self,
+        pred_field,
+        gt_field="ground_truth",
+        eval_key=None,
+        classes=None,
+        missing=None,
+        method="activitynet",
+        iou=0.50,
+        classwise=True,
+        **kwargs,
+    ):
+        """Evaluates the video classification predictions in the given collection with
+        respect to the specified ground truth labels. These labels are often used
+        for tasks like temporal action detection.
+    
+        Args:
+            pred_field: the name of the field containing the predicted
+                :class:`fiftyone.core.labels.VideoClassification` instances
+            gt_field ("ground_truth"): the name of the field containing the ground
+                truth :class:`fiftyone.core.labels.VideoClassification` instances
+            eval_key (None): an evaluation key to use to refer to this evaluation
+            classes (None): the list of possible classes. If not provided, classes
+                are loaded from :meth:`fiftyone.core.dataset.Dataset.classes` or
+                :meth:`fiftyone.core.dataset.Dataset.default_classes` if
+                possible, or else the observed ground truth/predicted labels are
+                used
+            missing (None): a missing label string. Any None-valued labels are
+                given this label for results purposes
+            method ("activitynet"): a string specifying the evaluation method to use.
+                Supported values are ``("activitynet")``
+            iou (0.50): the IoU threshold to use to determine segment matches
+            classwise (True): whether to only match segments with the same class
+                label (True) or allow matches between classes (False)
+            **kwargs: optional keyword arguments for the constructor of the
+                :class:`VideoClassificationEvaluationConfig` being used
+    
+        Returns:
+            a :class:`VideoClassificationResults`
+        """
+        return foue.evaluate_video_classifications(
+            self,
+            pred_field,
+            gt_field=gt_field,
+            eval_key=eval_key,
+            classes=classes,
+            missing=missing,
+            method=method,
+            iou=iou,
+            classwise=classwise,
+            **kwargs,
+        )
+
     @property
     def has_evaluations(self):
         """Whether this colection has any evaluation results."""

--- a/fiftyone/utils/eval/__init__.py
+++ b/fiftyone/utils/eval/__init__.py
@@ -18,3 +18,7 @@ from .segmentation import (
     evaluate_segmentations,
     SegmentationResults,
 )
+from .video_classification import (
+    evaluate_video_classifications,
+    VideoClassificationResults,
+)

--- a/fiftyone/utils/eval/activitynet.py
+++ b/fiftyone/utils/eval/activitynet.py
@@ -505,8 +505,8 @@ def _compute_matches(cats, pred_ious, iou_thresh, eval_key, id_key, iou_key):
                 for gt_id, iou in pred_ious[pred.id]:
                     gt = gt_map[gt_id]
 
-                    # If matching classwise=False
-                    if gt.label != pred.label:
+                    # Each gt can only match with one prediction
+                    if gt[id_key] != _NO_MATCH_ID:
                         continue
 
                     if iou < best_match_iou:
@@ -518,12 +518,9 @@ def _compute_matches(cats, pred_ious, iou_thresh, eval_key, id_key, iou_key):
                 if best_match:
                     gt = gt_map[best_match]
 
-                    # For crowd GTs, record info for first (highest confidence)
-                    # matching prediction on the GT segment
-                    if gt[id_key] == _NO_MATCH_ID:
-                        gt[eval_key] = "tp" if gt.label == pred.label else "fn"
-                        gt[id_key] = pred.id
-                        gt[iou_key] = best_match_iou
+                    gt[eval_key] = "tp" if gt.label == pred.label else "fn"
+                    gt[id_key] = pred.id
+                    gt[iou_key] = best_match_iou
 
                     pred[eval_key] = "tp" if gt.label == pred.label else "fp"
                     pred[id_key] = best_match

--- a/fiftyone/utils/eval/activitynet.py
+++ b/fiftyone/utils/eval/activitynet.py
@@ -1,0 +1,588 @@
+"""
+ActivityNet-style video classification evaluation.
+
+| Copyright 2017-2021, Voxel51, Inc.
+| `voxel51.com <https://voxel51.com/>`_
+|
+"""
+import logging
+from collections import defaultdict
+
+import numpy as np
+
+import fiftyone.core.plots as fop
+
+from .video_classification import (
+    VideoClassificationEvaluation,
+    VideoClassificationEvaluationConfig,
+    VideoClassificationResults,
+)
+from .utils import compute_segment_ious
+
+
+logger = logging.getLogger(__name__)
+
+
+class ActivityNetEvaluationConfig(VideoClassificationEvaluationConfig):
+    """ActivityNet-style evaluation config.
+
+    Args:
+        pred_field: the name of the field containing the predicted
+            :class:`fiftyone.core.labels.VideoClassification` instances
+        gt_field: the name of the field containing the ground truth
+            :class:`fiftyone.core.labels.VideoClassification` instances
+        iou (None): the IoU threshold to use to determine matches
+        classwise (None): whether to only match segments with the same class
+            label (True) or allow matches between classes (False)
+        compute_mAP (False): whether to perform the necessary computations so
+            that mAP and PR curves can be generated
+        iou_threshs (None): a list of IoU thresholds to use when computing mAP
+            and PR curves. Only applicable when ``compute_mAP`` is True
+    """
+
+    def __init__(
+        self,
+        pred_field,
+        gt_field,
+        iou=None,
+        classwise=None,
+        compute_mAP=False,
+        iou_threshs=None,
+        **kwargs,
+    ):
+        super().__init__(
+            pred_field, gt_field, iou=iou, classwise=classwise, **kwargs
+        )
+
+        if compute_mAP and iou_threshs is None:
+            iou_threshs = [x / 100 for x in range(50, 100, 5)]
+
+        self.compute_mAP = compute_mAP
+        self.iou_threshs = iou_threshs
+
+    @property
+    def method(self):
+        return "activitynet"
+
+
+class ActivityNetEvaluation(VideoClassificationEvaluation):
+    """ActivityNet-style evaluation.
+
+    Args:
+        config: a :class:`ActivityNetEvaluationConfig`
+    """
+
+    def __init__(self, config):
+        super().__init__(config)
+
+        if config.iou is None:
+            raise ValueError(
+                "You must specify an `iou` threshold in order to run "
+                "ActivityNet evaluation"
+            )
+
+        if config.classwise is None:
+            raise ValueError(
+                "You must specify a `classwise` value in order to run "
+                "ActivityNet evaluation"
+            )
+
+    def evaluate_video(self, sample, eval_key=None):
+        """Performs ActivityNet-style evaluation on the given video.
+
+        Predicted segments are matched to ground truth segments in descending
+        order of confidence, with matches requiring a minimum IoU of
+        ``self.config.iou``.
+
+        The ``self.config.classwise`` parameter controls whether to only match
+        segments with the same class label (True) or allow matches between
+        classes (False).
+
+        Args:
+            sample: a :class:`fiftyone.core.Sample`
+            eval_key (None): the evaluation key for this evaluation
+
+        Returns:
+            a list of matched
+            ``(gt_label, pred_label, iou, pred_confidence, gt_id, pred_id)``
+            tuples
+        """
+        gts = sample[self.gt_field]
+        preds = sample[self.pred_field]
+
+        if eval_key is None:
+            # Don't save results on user's data
+            eval_key = "eval"
+            gts = _copy_labels(gts)
+            preds = _copy_labels(preds)
+
+        return _activitynet_evaluation_single_iou(
+            gts, preds, eval_key, self.config
+        )
+
+    def generate_results(
+        self, samples, matches, eval_key=None, classes=None, missing=None
+    ):
+        """Generates aggregate evaluation results for the samples.
+
+        If ``self.config.compute_mAP`` is True, this method performs ActivityNet-style
+        evaluation as in :meth:`evaluate_image` to generate precision and
+        recall sweeps over the range of IoU thresholds in
+        ``self.config.iou_threshs``. In this case, a
+        :class:`ActivityNetVideoClassificationResults` instance is returned that can compute
+        mAP and PR curves.
+
+        Args:
+            samples: a :class:`fiftyone.core.SampleCollection`
+            matches: a list of
+                ``(gt_label, pred_label, iou, pred_confidence, gt_id, pred_id)``
+                matches. Either label can be ``None`` to indicate an unmatched
+                segment
+            eval_key (None): the evaluation key for this evaluation
+            classes (None): the list of possible classes. If not provided, the
+                observed ground truth/predicted labels are used for results
+                purposes
+            missing (None): a missing label string. Any unmatched segments are
+                given this label for results purposes
+
+        Returns:
+            a :class:`VideoClassificationResults`
+        """
+        gt_field = self.config.gt_field
+        pred_field = self.config.pred_field
+
+        if not self.config.compute_mAP:
+            return VideoClassificationResults(
+                matches,
+                eval_key=eval_key,
+                gt_field=gt_field,
+                pred_field=pred_field,
+                classes=classes,
+                missing=missing,
+                samples=samples,
+            )
+
+        _samples = samples.select_fields([gt_field, pred_field])
+        processing_frames = samples._is_frame_field(pred_field)
+
+        iou_threshs = self.config.iou_threshs
+        thresh_matches = {t: {} for t in iou_threshs}
+
+        if classes is None:
+            _classes = set()
+        else:
+            _classes = None
+
+        # IoU sweep
+        logger.info("Performing IoU sweep...")
+        for sample in _samples.iter_samples(progress=True):
+            if processing_frames:
+                images = sample.frames.values()
+            else:
+                images = [sample]
+
+            for image in images:
+                # Don't edit user's data during sweep
+                gts = _copy_labels(image[self.gt_field])
+                preds = _copy_labels(image[self.pred_field])
+
+                image_matches = _activitynet_evaluation_iou_sweep(
+                    gts, preds, self.config
+                )
+
+                for t, t_matches in image_matches.items():
+                    for match in t_matches:
+                        gt_label = match[0]
+                        pred_label = match[1]
+
+                        if _classes is not None:
+                            _classes.add(gt_label)
+                            _classes.add(pred_label)
+
+                        c = gt_label if gt_label is not None else pred_label
+
+                        if c not in thresh_matches[t]:
+                            thresh_matches[t][c] = {
+                                "tp": [],
+                                "fp": [],
+                                "num_gt": 0,
+                            }
+
+                        if gt_label == pred_label:
+                            thresh_matches[t][c]["tp"].append(match)
+                        elif pred_label:
+                            thresh_matches[t][c]["fp"].append(match)
+
+                        if gt_label:
+                            thresh_matches[t][c]["num_gt"] += 1
+
+        if _classes is not None:
+            _classes.discard(None)
+            classes = sorted(_classes)
+
+        # Compute precision-recall array
+        # https://github.com/activitynet/ActivityNet/blob/master/Evaluation/eval_detection.py
+        precision = -np.ones((len(iou_threshs), len(classes), 101))
+        recall = np.linspace(0, 1, 101)
+        for t in thresh_matches.keys():
+            for c in thresh_matches[t].keys():
+                tp = thresh_matches[t][c]["tp"]
+                fp = thresh_matches[t][c]["fp"]
+                num_gt = thresh_matches[t][c]["num_gt"]
+                if num_gt == 0:
+                    continue
+
+                tp_fp = [1] * len(tp) + [0] * len(fp)
+                confs = [m[3] for m in tp] + [m[3] for m in fp]
+                if None in confs:
+                    raise ValueError(
+                        "All predicted segments must have their `confidence` "
+                        "attribute populated in order to compute "
+                        "precision-recall curves"
+                    )
+
+                inds = np.argsort(-np.array(confs), kind="mergesort")
+                tp_fp = np.array(tp_fp)[inds]
+                tp_sum = np.cumsum(tp_fp).astype(dtype=float)
+                total = np.arange(1, len(tp_fp) + 1).astype(dtype=float)
+
+                pre = tp_sum / total
+                rec = tp_sum / num_gt
+
+                q = np.zeros(101)
+                for i in range(len(pre) - 1, 0, -1):
+                    if pre[i] > pre[i - 1]:
+                        pre[i - 1] = pre[i]
+
+                inds = np.searchsorted(rec, recall, side="left")
+                try:
+                    for ri, pi in enumerate(inds):
+                        q[ri] = pre[pi]
+                except:
+                    pass
+
+                precision[iou_threshs.index(t)][classes.index(c)] = q
+
+        return ActivityNetVideoClassificationResults(
+            matches,
+            precision,
+            recall,
+            iou_threshs,
+            classes,
+            eval_key=eval_key,
+            gt_field=gt_field,
+            pred_field=pred_field,
+            missing=missing,
+            samples=samples,
+        )
+
+
+class ActivityNetVideoClassificationResults(VideoClassificationResults):
+    """Class that stores the results of a ActivityNet detection evaluation.
+
+    Args:
+        matches: a list of
+            ``(gt_label, pred_label, iou, pred_confidence, gt_id, pred_id)``
+            matches. Either label can be ``None`` to indicate an unmatched
+            segment
+        precision: an array of precision values of shape
+            ``num_iou_threshs x num_classes x num_recall``
+        recall: an array of recall values
+        iou_threshs: the list of IoU thresholds
+        classes: the list of possible classes
+        eval_key (None): the evaluation key for this evaluation
+        gt_field (None): the name of the ground truth field
+        pred_field (None): the name of the predictions field
+        missing (None): a missing label string. Any unmatched segments are
+            given this label for evaluation purposes
+        samples (None): the :class:`fiftyone.core.collections.SampleCollection`
+            for which the results were computed
+    """
+
+    def __init__(
+        self,
+        matches,
+        precision,
+        recall,
+        iou_threshs,
+        classes,
+        eval_key=None,
+        gt_field=None,
+        pred_field=None,
+        missing=None,
+        samples=None,
+    ):
+        super().__init__(
+            matches,
+            eval_key=eval_key,
+            gt_field=gt_field,
+            pred_field=pred_field,
+            classes=classes,
+            missing=missing,
+            samples=samples,
+        )
+        self.precision = np.asarray(precision)
+        self.recall = np.asarray(recall)
+        self.iou_threshs = np.asarray(iou_threshs)
+        self._classwise_AP = np.mean(precision, axis=(0, 2))
+
+    def plot_pr_curves(self, classes=None, backend="plotly", **kwargs):
+        """Plots precision-recall (PR) curves for the results.
+
+        Args:
+            classes (None): a list of classes to generate curves for. By
+                default, top 3 AP classes will be plotted
+            backend ("plotly"): the plotting backend to use. Supported values
+                are ``("plotly", "matplotlib")``
+            **kwargs: keyword arguments for the backend plotting method:
+
+                -   "plotly" backend: :meth:`fiftyone.core.plots.plotly.plot_pr_curves`
+                -   "matplotlib" backend: :meth:`fiftyone.core.plots.matplotlib.plot_pr_curves`
+
+        Returns:
+            one of the following:
+
+            -   a :class:`fiftyone.core.plots.plotly.PlotlyNotebookPlot`, if
+                you are working in a notebook context and the plotly backend is
+                used
+            -   a plotly or matplotlib figure, otherwise
+        """
+        if not classes:
+            inds = np.argsort(self._classwise_AP)[::-1][:3]
+            classes = self.classes[inds]
+
+        precisions = []
+        for c in classes:
+            class_ind = self._get_class_index(c)
+            precisions.append(np.mean(self.precision[:, class_ind], axis=0))
+
+        return fop.plot_pr_curves(
+            precisions, self.recall, classes, backend=backend, **kwargs
+        )
+
+    def mAP(self, classes=None):
+        """Computes ActivityNet-style mean average precision (mAP) for the specified
+        classes.
+
+        See `this page <https://github.com/activitynet/ActivityNet/tree/master/Evaluation>`_
+        for more details about ActivityNet-style mAP.
+
+        Args:
+            classes (None): a list of classes for which to compute mAP
+
+        Returns:
+            the mAP in ``[0, 1]``
+        """
+        if classes is not None:
+            class_inds = np.array([self._get_class_index(c) for c in classes])
+            classwise_AP = self._classwise_AP[class_inds]
+        else:
+            classwise_AP = self._classwise_AP
+
+        classwise_AP = classwise_AP[classwise_AP > -1]
+        if classwise_AP.size == 0:
+            return -1
+
+        return np.mean(classwise_AP)
+
+    @classmethod
+    def _from_dict(cls, d, samples, config, **kwargs):
+        return super()._from_dict(
+            d,
+            samples,
+            config,
+            precision=d["precision"],
+            recall=d["recall"],
+            iou_threshs=d["iou_threshs"],
+            **kwargs,
+        )
+
+    def _get_class_index(self, label):
+        inds = np.where(self.classes == label)[0]
+        if inds.size == 0:
+            raise ValueError("Class '%s' not found" % label)
+
+        return inds[0]
+
+
+_NO_MATCH_ID = ""
+_NO_MATCH_IOU = None
+
+
+def _activitynet_evaluation_single_iou(gts, preds, eval_key, config):
+    iou_thresh = min(config.iou, 1 - 1e-10)
+    id_key = "%s_id" % eval_key
+    iou_key = "%s_iou" % eval_key
+
+    cats, pred_ious = _activitynet_evaluation_setup(
+        gts, preds, [id_key], iou_key, config
+    )
+
+    matches = _compute_matches(
+        cats,
+        pred_ious,
+        iou_thresh,
+        eval_key=eval_key,
+        id_key=id_key,
+        iou_key=iou_key,
+    )
+
+    return matches
+
+
+def _activitynet_evaluation_iou_sweep(gts, preds, config):
+    iou_threshs = config.iou_threshs
+    id_keys = ["eval_id_%s" % str(i).replace(".", "_") for i in iou_threshs]
+    iou_key = "eval_iou"
+
+    cats, pred_ious = _activitynet_evaluation_setup(
+        gts, preds, id_keys, iou_key, config
+    )
+
+    matches_dict = {
+        i: _compute_matches(
+            cats, pred_ious, i, eval_key="eval", id_key=k, iou_key=iou_key,
+        )
+        for i, k in zip(iou_threshs, id_keys)
+    }
+
+    return matches_dict
+
+
+def _activitynet_evaluation_setup(
+    gts, preds, id_keys, iou_key, config,
+):
+    classwise = config.classwise
+
+    # Organize ground truth and predictions by category
+
+    cats = defaultdict(lambda: defaultdict(list))
+
+    if gts is not None:
+        for obj in gts[gts._LABEL_LIST_FIELD]:
+            obj[iou_key] = _NO_MATCH_IOU
+            for id_key in id_keys:
+                obj[id_key] = _NO_MATCH_ID
+
+            label = obj.label if classwise else "all"
+            cats[label]["gts"].append(obj)
+
+    if preds is not None:
+        for obj in preds[preds._LABEL_LIST_FIELD]:
+            obj[iou_key] = _NO_MATCH_IOU
+            for id_key in id_keys:
+                obj[id_key] = _NO_MATCH_ID
+
+            label = obj.label if classwise else "all"
+            cats[label]["preds"].append(obj)
+
+    # Compute IoUs within each category
+    pred_ious = {}
+    for segments in cats.values():
+        gts = segments["gts"]
+        preds = segments["preds"]
+
+        # Highest confidence predictions first
+        preds = sorted(preds, key=lambda p: p.confidence or -1, reverse=True)
+
+        segments["preds"] = preds
+
+        # Compute ``num_preds x num_gts`` IoUs
+        ious = compute_segment_ious(preds, gts)
+
+        gt_ids = [g.id for g in gts]
+        for pred, gt_ious in zip(preds, ious):
+            pred_ious[pred.id] = list(zip(gt_ids, gt_ious))
+
+    return cats, pred_ious
+
+
+def _compute_matches(cats, pred_ious, iou_thresh, eval_key, id_key, iou_key):
+    matches = []
+
+    # Match preds to GT, highest confidence first
+    for cat, segments in cats.items():
+        gt_map = {gt.id: gt for gt in segments["gts"]}
+
+        # Match each prediction to the highest available IoU ground truth
+        for pred in segments["preds"]:
+            if pred.id in pred_ious:
+                best_match = None
+                best_match_iou = iou_thresh
+                for gt_id, iou in pred_ious[pred.id]:
+                    gt = gt_map[gt_id]
+
+                    # If matching classwise=False
+                    if gt.label != pred.label:
+                        continue
+
+                    if iou < best_match_iou:
+                        continue
+
+                    best_match_iou = iou
+                    best_match = gt_id
+
+                if best_match:
+                    gt = gt_map[best_match]
+
+                    # For crowd GTs, record info for first (highest confidence)
+                    # matching prediction on the GT segment
+                    if gt[id_key] == _NO_MATCH_ID:
+                        gt[eval_key] = "tp" if gt.label == pred.label else "fn"
+                        gt[id_key] = pred.id
+                        gt[iou_key] = best_match_iou
+
+                    pred[eval_key] = "tp" if gt.label == pred.label else "fp"
+                    pred[id_key] = best_match
+                    pred[iou_key] = best_match_iou
+
+                    matches.append(
+                        (
+                            gt.label,
+                            pred.label,
+                            best_match_iou,
+                            pred.confidence,
+                            gt.id,
+                            pred.id,
+                        )
+                    )
+                else:
+                    pred[eval_key] = "fp"
+                    matches.append(
+                        (
+                            None,
+                            pred.label,
+                            None,
+                            pred.confidence,
+                            None,
+                            pred.id,
+                        )
+                    )
+
+            elif pred.label == cat:
+                pred[eval_key] = "fp"
+                matches.append(
+                    (None, pred.label, None, pred.confidence, None, pred.id,)
+                )
+
+        # Leftover GTs are false negatives
+        for gt in segments["gts"]:
+            if gt[id_key] == _NO_MATCH_ID:
+                gt[eval_key] = "fn"
+                matches.append((gt.label, None, None, None, gt.id, None))
+
+    return matches
+
+
+def _copy_labels(labels):
+    if labels is None:
+        return None
+
+    field = labels._LABEL_LIST_FIELD
+    _labels = labels.copy()
+
+    # We need the IDs to stay the same
+    for _label, label in zip(_labels[field], labels[field]):
+        _label._id = label._id
+
+    return _labels

--- a/fiftyone/utils/eval/video_classification.py
+++ b/fiftyone/utils/eval/video_classification.py
@@ -1,0 +1,411 @@
+"""
+Video classification evaluation.
+
+| Copyright 2017-2021, Voxel51, Inc.
+| `voxel51.com <https://voxel51.com/>`_
+|
+"""
+import itertools
+import logging
+
+import numpy as np
+
+import fiftyone.core.evaluation as foe
+import fiftyone.core.fields as fof
+import fiftyone.core.labels as fol
+import fiftyone.core.validation as fov
+
+from .base import BaseEvaluationResults
+
+
+logger = logging.getLogger(__name__)
+
+
+def evaluate_video_classifications(
+    samples,
+    pred_field,
+    gt_field="ground_truth",
+    eval_key=None,
+    classes=None,
+    missing=None,
+    method="activitynet",
+    iou=0.50,
+    classwise=True,
+    **kwargs,
+):
+    """Evaluates the video classification predictions in the given collection with
+    respect to the specified ground truth labels. These labels are often used
+    for tasks like temporal action detection.
+
+    Args:
+        samples: a :class:`fiftyone.core.collections.SampleCollection`
+        pred_field: the name of the field containing the predicted
+            :class:`fiftyone.core.labels.VideoClassification` instances
+        gt_field ("ground_truth"): the name of the field containing the ground
+            truth :class:`fiftyone.core.labels.VideoClassification` instances
+        eval_key (None): an evaluation key to use to refer to this evaluation
+        classes (None): the list of possible classes. If not provided, classes
+            are loaded from :meth:`fiftyone.core.dataset.Dataset.classes` or
+            :meth:`fiftyone.core.dataset.Dataset.default_classes` if
+            possible, or else the observed ground truth/predicted labels are
+            used
+        missing (None): a missing label string. Any None-valued labels are
+            given this label for results purposes
+        method ("activitynet"): a string specifying the evaluation method to use.
+            Supported values are ``("activitynet")``
+        iou (0.50): the IoU threshold to use to determine segment matches
+        classwise (True): whether to only match segments with the same class
+            label (True) or allow matches between classes (False)
+        **kwargs: optional keyword arguments for the constructor of the
+            :class:`VideoClassificationEvaluationConfig` being used
+
+    Returns:
+        a :class:`VideoClassificationResults`
+    """
+    fov.validate_video_collection(samples)
+
+    fov.validate_collection_label_fields(
+        samples,
+        (pred_field, gt_field),
+        (fol.VideoClassifications),
+        same_type=True,
+    )
+
+    if classes is None:
+        if pred_field in samples.classes:
+            classes = samples.classes[pred_field]
+        elif gt_field in samples.classes:
+            classes = samples.classes[gt_field]
+        elif samples.default_classes:
+            classes = samples.default_classes
+
+    config = _parse_config(
+        pred_field, gt_field, method, iou=iou, classwise=classwise, **kwargs,
+    )
+    eval_method = config.build()
+    eval_method.register_run(samples, eval_key)
+
+    if not config.requires_additional_fields:
+        _samples = samples.select_fields([gt_field, pred_field])
+    else:
+        _samples = samples
+
+    if eval_key is not None:
+        tp_field = "%s_tp" % eval_key
+        fp_field = "%s_fp" % eval_key
+        fn_field = "%s_fn" % eval_key
+
+        # note: fields are manually declared so they'll exist even when
+        # `samples` is empty
+        dataset = samples._dataset
+        dataset._add_sample_field_if_necessary(tp_field, fof.IntField)
+        dataset._add_sample_field_if_necessary(fp_field, fof.IntField)
+        dataset._add_sample_field_if_necessary(fn_field, fof.IntField)
+
+    matches = []
+    logger.info("Evaluating video classifications...")
+    for sample in _samples.iter_samples(progress=True):
+        sample_tp = 0
+        sample_fp = 0
+        sample_fn = 0
+        video_matches = eval_method.evaluate_video(sample, eval_key=eval_key)
+        matches.extend(video_matches)
+
+        if eval_key is not None:
+            tp, fp, fn = _tally_matches(video_matches)
+            sample[tp_field] = tp
+            sample[fp_field] = fp
+            sample[fn_field] = fn
+            sample.save()
+
+    results = eval_method.generate_results(
+        samples, matches, eval_key=eval_key, classes=classes, missing=missing
+    )
+    eval_method.save_run_results(samples, eval_key, results)
+
+    return results
+
+
+class VideoClassificationEvaluationConfig(foe.EvaluationMethodConfig):
+    """Base class for configuring :class:`VideoClassificationEvaluation`
+    instances.
+
+    Args:
+        pred_field: the name of the field containing the predicted
+            :class:`fiftyone.core.labels.VideoClassification` instances
+        gt_field: the name of the field containing the ground truth
+            :class:`fiftyone.core.labels.VideoClassification` instances
+        iou (None): the IoU threshold to use to determine matches
+        classwise (None): whether to only match segments with the same class
+            label (True) or allow matches between classes (False)
+    """
+
+    def __init__(
+        self, pred_field, gt_field, iou=None, classwise=None, **kwargs
+    ):
+        super().__init__(**kwargs)
+        self.pred_field = pred_field
+        self.gt_field = gt_field
+        self.iou = iou
+        self.classwise = classwise
+
+    @property
+    def requires_additional_fields(self):
+        """Whether fields besides ``pred_field`` and ``gt_field`` are required
+        in order to perform evaluation.
+
+        If True then the entire samples will be loaded rather than using
+        :meth:`select_fields() <fiftyone.core.collections.SampleCollection.select_fields>`
+        to optimize.
+        """
+        return False
+
+
+class VideoClassificationEvaluation(foe.EvaluationMethod):
+    """Base class for video classification evaluation methods.
+
+    Args:
+        config: a :class:`VideoClassificationEvaluationConfig`
+    """
+
+    def __init__(self, config):
+        super().__init__(config)
+        self.gt_field = None
+        self.pred_field = None
+
+    def evaluate_video(self, sample, eval_key=None):
+        """Evaluates the ground truth and predicted segments in a video.
+
+        Args:
+            sample: a :class:`fiftyone.core.Sample`
+            eval_key (None): the evaluation key for this evaluation
+
+        Returns:
+            a list of matched ``(gt_label, pred_label, iou, pred_confidence)``
+            tuples
+        """
+        raise NotImplementedError("subclass must implement evaluate_video()")
+
+    def generate_results(
+        self, samples, matches, eval_key=None, classes=None, missing=None
+    ):
+        """Generates aggregate evaluation results for the samples.
+
+        Subclasses may perform additional computations here such as IoU sweeps
+        in order to generate mAP, PR curves, etc.
+
+        Args:
+            samples: a :class:`fiftyone.core.collections.SampleCollection`
+            matches: a list of
+                ``(gt_label, pred_label, iou, pred_confidence, gt_id, pred_id)``
+                matches. Either label can be ``None`` to indicate an unmatched
+                segment
+            eval_key (None): the evaluation key for this evaluation
+            classes (None): the list of possible classes. If not provided, the
+                observed ground truth/predicted labels are used for results
+                purposes
+            missing (None): a missing label string. Any unmatched segments are
+                given this label for results purposes
+
+        Returns:
+            a :class:`VideoClassificationResults`
+        """
+        return VideoClassificationResults(
+            matches,
+            eval_key=eval_key,
+            gt_field=self.config.gt_field,
+            pred_field=self.config.pred_field,
+            classes=classes,
+            missing=missing,
+            samples=samples,
+        )
+
+    def get_fields(self, samples, eval_key):
+        pred_field = self.config.pred_field
+        pred_type = samples._get_label_field_type(pred_field)
+        pred_key = "%s.%s.%s" % (
+            pred_field,
+            pred_type._LABEL_LIST_FIELD,
+            eval_key,
+        )
+
+        gt_field = self.config.gt_field
+        gt_type = samples._get_label_field_type(gt_field)
+        gt_key = "%s.%s.%s" % (gt_field, gt_type._LABEL_LIST_FIELD, eval_key)
+
+        fields = [
+            "%s_tp" % eval_key,
+            "%s_fp" % eval_key,
+            "%s_fn" % eval_key,
+            pred_key,
+            "%s_id" % pred_key,
+            "%s_iou" % pred_key,
+            gt_key,
+            "%s_id" % gt_key,
+            "%s_iou" % gt_key,
+        ]
+
+        return fields
+
+    def cleanup(self, samples, eval_key):
+        fields = [
+            "%s_tp" % eval_key,
+            "%s_fp" % eval_key,
+            "%s_fn" % eval_key,
+        ]
+
+        try:
+            pred_type = samples._get_label_field_type(self.config.pred_field)
+            pred_key = "%s.%s.%s" % (
+                self.config.pred_field,
+                pred_type._LABEL_LIST_FIELD,
+                eval_key,
+            )
+            fields.extend([pred_key, "%s_id" % pred_key, "%s_iou" % pred_key])
+        except ValueError:
+            # Field no longer exists, nothing to cleanup
+            pass
+
+        try:
+            gt_type = samples._get_label_field_type(self.config.gt_field)
+            gt_key = "%s.%s.%s" % (
+                self.config.gt_field,
+                gt_type._LABEL_LIST_FIELD,
+                eval_key,
+            )
+            fields.extend([gt_key, "%s_id" % gt_key, "%s_iou" % gt_key])
+        except ValueError:
+            # Field no longer exists, nothing to cleanup
+            pass
+
+        samples._dataset.delete_sample_fields(fields, error_level=1)
+
+    def _validate_run(self, samples, eval_key, existing_info):
+        self._validate_fields_match(eval_key, "pred_field", existing_info)
+        self._validate_fields_match(eval_key, "gt_field", existing_info)
+
+
+class VideoClassificationResults(BaseEvaluationResults):
+    """Class that stores the results of a video classification evaluation.
+
+    Args:
+        matches: a list of
+            ``(gt_label, pred_label, iou, pred_confidence, gt_id, pred_id)``
+            matches. Either label can be ``None`` to indicate an unmatched
+            segment
+        eval_key (None): the evaluation key for this evaluation
+        gt_field (None): the name of the ground truth field
+        pred_field (None): the name of the predictions field
+        classes (None): the list of possible classes. If not provided, the
+            observed ground truth/predicted labels are used
+        missing (None): a missing label string. Any unmatched segments are given
+            this label for evaluation purposes
+        samples (None): the :class:`fiftyone.core.collections.SampleCollection`
+            for which the results were computed
+    """
+
+    def __init__(
+        self,
+        matches,
+        eval_key=None,
+        gt_field=None,
+        pred_field=None,
+        classes=None,
+        missing=None,
+        samples=None,
+    ):
+        if matches:
+            ytrue, ypred, ious, confs, ytrue_ids, ypred_ids = zip(*matches)
+        else:
+            ytrue, ypred, ious, confs, ytrue_ids, ypred_ids = (
+                [],
+                [],
+                [],
+                [],
+                [],
+                [],
+            )
+
+        super().__init__(
+            ytrue,
+            ypred,
+            confs=confs,
+            eval_key=eval_key,
+            gt_field=gt_field,
+            pred_field=pred_field,
+            ytrue_ids=ytrue_ids,
+            ypred_ids=ypred_ids,
+            classes=classes,
+            missing=missing,
+            samples=samples,
+        )
+        self.ious = np.array(ious)
+
+    @classmethod
+    def _from_dict(cls, d, samples, config, **kwargs):
+        ytrue = d["ytrue"]
+        ypred = d["ypred"]
+        ious = d["ious"]
+
+        confs = d.get("confs", None)
+        if confs is None:
+            confs = itertools.repeat(None)
+
+        ytrue_ids = d.get("ytrue_ids", None)
+        if ytrue_ids is None:
+            ytrue_ids = itertools.repeat(None)
+
+        ypred_ids = d.get("ypred_ids", None)
+        if ypred_ids is None:
+            ypred_ids = itertools.repeat(None)
+
+        eval_key = d.get("eval_key", None)
+        gt_field = d.get("gt_field", None)
+        pred_field = d.get("pred_field", None)
+        classes = d.get("classes", None)
+        missing = d.get("missing", None)
+
+        matches = list(zip(ytrue, ypred, ious, confs, ytrue_ids, ypred_ids))
+
+        return cls(
+            matches,
+            eval_key=eval_key,
+            gt_field=gt_field,
+            pred_field=pred_field,
+            classes=classes,
+            missing=missing,
+            samples=samples,
+            **kwargs,
+        )
+
+
+def _parse_config(pred_field, gt_field, method, **kwargs):
+    if method is None:
+        method = "activitynet"
+
+    if method == "activitynet":
+        from .activitynet import ActivityNetEvaluationConfig
+
+        return ActivityNetEvaluationConfig(pred_field, gt_field, **kwargs)
+
+    raise ValueError("Unsupported evaluation method '%s'" % method)
+
+
+def _tally_matches(matches):
+    tp = 0
+    fp = 0
+    fn = 0
+    for match in matches:
+        gt_label = match[0]
+        pred_label = match[1]
+        if gt_label is None:
+            fp += 1
+        elif pred_label is None:
+            fn += 1
+        elif gt_label != pred_label:
+            fp += 1
+            fn += 1
+        else:
+            tp += 1
+
+    return tp, fp, fn

--- a/fiftyone/utils/eval/video_classification.py
+++ b/fiftyone/utils/eval/video_classification.py
@@ -84,6 +84,7 @@ def evaluate_video_classifications(
     )
     eval_method = config.build()
     eval_method.register_run(samples, eval_key)
+    eval_method.register_samples(samples)
 
     if not config.requires_additional_fields:
         _samples = samples.select_fields([gt_field, pred_field])
@@ -104,7 +105,8 @@ def evaluate_video_classifications(
 
     matches = []
     logger.info("Evaluating video classifications...")
-    for sample in _samples.iter_samples(progress=True):
+    # for sample in _samples.iter_samples(progress=True):
+    for sample in _samples:
         sample_tp = 0
         sample_fp = 0
         sample_fn = 0
@@ -172,6 +174,22 @@ class VideoClassificationEvaluation(foe.EvaluationMethod):
         super().__init__(config)
         self.gt_field = None
         self.pred_field = None
+
+    def register_samples(self, samples):
+        """Registers the sample collection on which evaluation will be
+        performed.
+
+        This method will be called before the first call to
+        :meth:`evaluate_video`. Subclasses can extend this method to perform
+        any setup required for an evaluation run.
+
+        Args:
+            samples: a :class:`fiftyone.core.collections.SampleCollection`
+        """
+        self.gt_field, _ = samples._handle_frame_field(self.config.gt_field)
+        self.pred_field, _ = samples._handle_frame_field(
+            self.config.pred_field
+        )
 
     def evaluate_video(self, sample, eval_key=None):
         """Evaluates the ground truth and predicted segments in a video.


### PR DESCRIPTION
Add support for evaluation of the temporal activity detection challenge from ActivityNet. Labels like temporal activity detections which are video-level annotations containing a class name and frame range exist in FiftyOne as `VideoClassification` labels. 

This PR adds:
* `SampleCollection.evaluate_video_classifications()` with the default method being `"activitynet"`-style

**Example**

```python
import fiftyone as fo
import fiftyone.zoo as foz

import random
random.seed(51)

def create_fake_preds(dataset):
    dataset.clone_sample_field("ground_truth", "predictions")
    for sample in dataset:
        for vc in sample.predictions.classifications:
            vc.support[0] -= random.randint(-10,10)
            vc.support[1] -= random.randint(-10,10)
            vc.support[0] = max(1, vc.support[0])
            vc.support[1] = max(1, vc.support[1])
            vc.confidence = random.random()
            if random.random() > 0.9:
                vc.label = "Other"

        sample.save()

dataset = foz.load_zoo_dataset("activitynet-200", split="validation", max_samples=10)
create_fake_preds(dataset)

results = dataset.evaluate_video_classifications(
    "predictions",
    compute_mAP=True,
    eval_key="eval",
)

print(results.mAP())

session = fo.launch_app(dataset)
```


### TODO

* Compare resulting mAP with the official implementation