### PR TITLE
Adding support for annotation backend to recommend attribute widget type

### DIFF
--- a/fiftyone/utils/annotations.py
+++ b/fiftyone/utils/annotations.py
@@ -706,9 +706,9 @@ def _get_label_attributes(samples, backend, label_field, classes=None):
     attributes = {}
     for label in labels:
         if label is not None:
-            for name, _ in label.iter_attributes():
-                if name not in attributes:
-                    attributes[name] = {"type": backend.default_attr_type}
+            for name, value in label.iter_attributes():
+                if value is not None and name not in attributes:
+                    attributes[name] = backend.recommend_attr_tool(name, value)
 
     return attributes
 
@@ -720,62 +720,62 @@ def _format_attributes(backend, attributes):
     if isinstance(attributes, list):
         attributes = {a: {} for a in attributes}
 
-    output_attrs = {}
-    for attr, attr_info in attributes.items():
-        formatted_info = {}
+    _attributes = {}
 
-        attr_type = attr_info.get("type", None)
-        values = attr_info.get("values", None)
-        default = attr_info.get("default", None)
-        mutable = attr_info.get("mutable", None)
+    for name, attr in attributes.items():
+        if not attr:
+            attr = backend.recommend_attr_tool(name, None)
+
+        attr_type = attr.get("type", None)
+        values = attr.get("values", None)
+        default = attr.get("default", None)
+        mutable = attr.get("mutable", None)
 
         if attr_type is None:
-            if values is None:
-                formatted_info["type"] = backend.default_attr_type
-            else:
-                formatted_info["type"] = backend.default_categorical_attr_type
-                formatted_info["values"] = values
-                if default not in (None, "") and default in values:
-                    formatted_info["default"] = default
-        else:
-            if attr_type in backend.supported_attr_types:
-                formatted_info["type"] = attr_type
-            else:
+            raise ValueError(
+                "Attribute definition %s is missing a `type` key" % str(attr)
+            )
+
+        if attr_type not in backend.supported_attr_types:
+            raise ValueError(
+                "Attribute '%s' has unsupported type '%s'. The '%s' "
+                "backend supports types %s"
+                % (
+                    name,
+                    attr_type,
+                    backend.config.name,
+                    backend.supported_attr_types,
+                )
+            )
+
+        _attr = {"type": attr_type}
+
+        # Parse `values` property
+        if values is not None:
+            _attr["values"] = list(values)
+        elif backend.requires_attr_values(attr_type):
+            raise ValueError(
+                "Attribute '%s' of type '%s' requires a list of values"
+                % (name, attr_type)
+            )
+
+        # Parse `default` property
+        if default is not None:
+            if values is not None and default not in values:
                 raise ValueError(
-                    "Attribute '%s' has unsupported type '%s'. The '%s' "
-                    "backend supports types %s"
-                    % (
-                        attr,
-                        attr_type,
-                        backend.config.name,
-                        backend.supported_attr_types,
-                    )
+                    "Default value '%s' for attribute '%s' does not "
+                    "appear in the list of values %s" % (default, name, values)
                 )
 
-            if values is not None:
-                formatted_info["values"] = values
-            elif backend.requires_attr_values(attr_type):
-                raise ValueError(
-                    "Attribute '%s' of type '%s' requires a list of values"
-                    % (attr, attr_type)
-                )
+            _attr["default"] = default
 
-            if default not in (None, ""):
-                if values is not None and default not in values:
-                    raise ValueError(
-                        "Default value '%s' for attribute '%s' does not "
-                        "appear in the list of values %s"
-                        % (default, attr, values)
-                    )
-
-                formatted_info["default"] = default
-
+        # Parse `mutable` property
         if mutable is not None:
-            formatted_info["mutable"] = mutable
+            _attr["mutable"] = mutable
 
-        output_attrs[attr] = formatted_info
+        _attributes[name] = _attr
 
-    return output_attrs
+    return _attributes
 
 
 def load_annotations(
@@ -1255,22 +1255,31 @@ class AnnotationBackend(foa.AnnotationMethod):
             "subclass must implement supported_attr_types"
         )
 
-    @property
-    def default_attr_type(self):
-        """The default type for attributes with values of unspecified type.
+    def recommend_attr_tool(self, name, value):
+        """Recommends an attribute tool for an attribute with the given name
+        and value.
 
-        Must be a supported type from :meth:`supported_attr_types`.
-        """
-        raise NotImplementedError("subclass must implement default_attr_type")
+        For example, a backend may recommend a tool as follows for a boolean
+        value::
 
-    @property
-    def default_categorical_attr_type(self):
-        """The default type for attributes with categorical values.
+            {
+                "type": "radio",
+                "values": [False, True],
+            }
 
-        Must be a supported type from :meth:`supported_attr_types`.
+        or a tool as follows for a generic value::
+
+            {"type": "text"}
+
+        Args:
+            name: the name of the attribute
+            value: the attribute value, which may be ``None``
+
+        Returns:
+            an attribute type dict
         """
         raise NotImplementedError(
-            "subclass must implement default_categorical_attr_type"
+            "subclass must implement recommend_attr_tool()"
         )
 
     def requires_attr_values(self, attr_type):

--- a/fiftyone/utils/cvat.py
+++ b/fiftyone/utils/cvat.py
@@ -2516,13 +2516,11 @@ class CVATBackend(foua.AnnotationBackend):
     def supported_attr_types(self):
         return ["text", "select", "radio", "checkbox"]
 
-    @property
-    def default_attr_type(self):
-        return "text"
+    def recommend_attr_tool(self, name, value):
+        if isinstance(value, bool):
+            return {"type": "checkbox"}
 
-    @property
-    def default_categorical_attr_type(self):
-        return "select"
+        return {"type": "text"}
 
     def requires_attr_values(self, attr_type):
         return attr_type in ("select", "radio")


### PR DESCRIPTION
Small update that allows the annotation backend to recommend a widget type based on the name/value of an observed attribute.

This feature is used when `attributes=True` is passed (the default) when uploading existing labels for editing.

Note that providing `name` as well as `value` may be useful in situations like detecting that an `occluded` attribute should be wired up to CVAT's dedicated occlusion button.

For example, in the snippet below, a `checkbox` widget type is used for `kite.colorful`, since boolean attribute values are detected.

```py
import random

import fiftyone as fo
import fiftyone.zoo as foz
from fiftyone import ViewField as F

dataset = foz.load_zoo_dataset("quickstart")
dataset = dataset[-1:].select_fields("ground_truth").clone()

for sample in dataset:
    for detection in sample.ground_truth.detections:
        if detection.label == "car":
            detection.type = random.choice(["sedan", "suv", "truck"])
        elif detection.label == "kite":
            detection.colorful = random.choice([False, True])
        elif detection.label == "person":
            detection.age = random.randint(1, 51)

    sample.save()

dataset.annotate(
    "test",
    label_field="ground_truth",
    classes=[
        {"classes": ["car"], "attributes": True},
        {"classes": ["kite"], "attributes": True},
        {"classes": ["person"], "attributes": True},
    ],
    attributes=["area", "iscrowd"],
    launch_editor=True,
)
print(dataset.get_annotation_info("test"))

# Create annotations in CVAT...

dataset.load_annotations("test", cleanup=True)
```
