### PR TITLE
Adding support for configuring whether label additions/deletions/spatial edits are allowed during annotation

### DIFF
--- a/docs/source/integrations/cvat.rst
+++ b/docs/source/integrations/cvat.rst
@@ -1060,11 +1060,11 @@ parameters to configure whether certain types of edits are allowed in your
 annotation run. See :ref:`this section <cvat-restricting-edits>` for more
 information about the available options.
 
-For example, suppose you have an existing `objects` field that contains
-detections of various types of objects and you would like to add new `type` and
-`occluded` attributes to all vehicles in this field while also strictly
-enforcing that no objects can be added, deleted, or have their bounding boxes
-modified. You can configure an annotation run for this as follows:
+For example, suppose you have an existing `ground_truth` field that contains
+objects of various types and you would like to add new `sex` and `age`
+attributes to all people in this field while also strictly enforcing that no
+objects can be added, deleted, or have their bounding boxes modified. You can
+configure an annotation run for this as follows:
 
 .. code:: python
     :linenos:

--- a/docs/source/integrations/cvat.rst
+++ b/docs/source/integrations/cvat.rst
@@ -415,6 +415,13 @@ details:
         `values`, and `default` for each attribute
 -   **mask_targets** (*None*): a dict mapping pixel values to semantic label
     strings. Only applicable when annotating semantic segmentations
+-   **allow_additions** (*True*): whether to allow new labels to be added. Only
+    applicable when editing existing label fields
+-   **allow_deletions** (*True*): whether to allow labels to be deleted. Only
+    applicable when editing existing label fields
+-   **allow_spatial_edits** (*True*): whether to allow edits to the spatial
+    properties (bounding boxes, vertices, keypoints, etc) of labels. Only
+    applicable when editing existing label fields
 
 |br|
 In addition, the following CVAT-specific parameters from
@@ -658,6 +665,68 @@ types like lists, dictionaries, and arrays will be omitted.
     modifications to existing labels, and changing or deleting these ID
     attributes in CVAT will result in labels being overwritten rather than
     merged when loading annotations back into FiftyOne.
+
+.. _cvat-restricting-edits:
+
+Restricting additions, deletions, and edits
+-------------------------------------------
+
+When you create annotation runs that invovle editing existing label fields, you
+can optionally specify that certain changes are not alllowed by passing the
+following flags to
+:meth:`annotate() <fiftyone.core.collections.SampleCollection.annotate>`:
+
+-   **allow_additions** (*True*): whether to allow new labels to be added
+-   **allow_deletions** (*True*): whether to allow labels to be deleted
+-   **allow_spatial_edits** (*True*): whether to allow edits to the spatial
+    properties (bounding boxes, vertices, keypoints, etc) of labels
+
+If you are using the `label_schema` parameter to provide a full annotation
+schema to
+:meth:`annotate() <fiftyone.core.collections.SampleCollection.annotate>`, you
+can also directly include the above flags in the configuration dicts for any
+existing label field(s) you wish.
+
+For example, suppose you have an existing `ground_truth` field that contains
+objects of various types and you would like to add new `sex` and `age`
+attributes to all people in this field while also strictly enforcing that no
+objects can be added, deleted, or have their bounding boxes modified. You can
+configure an annotation run for this as follows:
+
+.. code:: python
+    :linenos:
+
+    anno_key = "..."
+
+    attributes = {
+        "sex": {
+            "type": "select",
+            "values": ["male", "female"],
+        },
+        "age": {
+            "type": "text",
+        },
+    }
+
+    view.annotate(
+        anno_key,
+        label_field="ground_truth",
+        classes=["person"],
+        attributes=attributes,
+        allow_additions=False,
+        allow_deletions=False,
+        allow_spatial_edits=False,
+    )
+
+.. note::
+
+    The CVAT backend does not support restrictions to additions, deletions, and
+    spatial edits in its editing interface.
+
+    However, any restrictions that you specify via the above parameters will
+    still be enforced when you call
+    :meth:`load_annotations() <fiftyone.core.collections.SampleCollection.load_annotations>`
+    to merge the annotations back into FiftyOne.
 
 .. _cvat-labeling-videos:
 
@@ -982,6 +1051,66 @@ can be used to annotate new classes and/or attributes:
     been modified, added, or deleted, and thus editing these label IDs will
     result in labels being overwritten when
     loaded into FiftyOne rather than being merged.
+
+Restricting label edits
+-----------------------
+
+You can use the `allow_additions`, `allow_deletions`, and `allow_spatial_edits`
+parameters to configure whether certain types of edits are allowed in your
+annotation run. See :ref:`this section <cvat-restricting-edits>` for more
+information about the available options.
+
+For example, suppose you have an existing `objects` field that contains
+detections of various types of objects and you would like to add new `type` and
+`occluded` attributes to all vehicles in this field while also strictly
+enforcing that no objects can be added, deleted, or have their bounding boxes
+modified. You can configure an annotation run for this as follows:
+
+.. code:: python
+    :linenos:
+
+    import fiftyone as fo
+    import fiftyone.zoo as foz
+    from fiftyone import ViewField as F
+
+    dataset = foz.load_zoo_dataset("quickstart")
+
+    # Grab a sample that contains a person
+    view = (
+        dataset
+        .match_labels(filter=F("label") == "person", fields="ground_truth")
+        .limit(1)
+    )
+
+    anno_key = "cvat_edit_restrictions"
+
+    # The new attributes that we want to populate
+    attributes = {
+        "sex": {
+            "type": "select",
+            "values": ["male", "female"],
+        },
+        "age": {
+            "type": "text",
+        },
+    }
+
+    view.annotate(
+        anno_key,
+        label_field="ground_truth",
+        classes=["person"],
+        attributes=attributes,
+        allow_additions=False,
+        allow_deletions=False,
+        allow_spatial_edits=False,
+        launch_editor=True,
+    )
+    print(dataset.get_annotation_info(anno_key))
+
+    # Populate attributes in CVAT
+
+    dataset.load_annotations(anno_key, cleanup=True)
+    dataset.delete_annotation_run(anno_key)
 
 Annotating multiple fields
 --------------------------

--- a/docs/source/user_guide/annotation.rst
+++ b/docs/source/user_guide/annotation.rst
@@ -478,6 +478,13 @@ more details:
         `values`, and `default` for each attribute
 -   **mask_targets** (*None*): a dict mapping pixel values to semantic label
     strings. Only applicable when annotating semantic segmentations
+-   **allow_additions** (*True*): whether to allow new labels to be added. Only
+    applicable when editing existing label fields
+-   **allow_deletions** (*True*): whether to allow labels to be deleted. Only
+    applicable when editing existing label fields
+-   **allow_spatial_edits** (*True*): whether to allow edits to the spatial
+    properties (bounding boxes, vertices, keypoints, etc) of labels. Only
+    applicable when editing existing label fields
 
 |br|
 In addition, each annotation backend can typically be configured in a variety
@@ -705,6 +712,68 @@ take additional values:
 
 Note that only scalar-valued label attributes are supported. Other attribute
 types like lists, dictionaries, and arrays will be omitted.
+
+.. _annotation-restricting-edits:
+
+Restricting additions, deletions, and edits
+-------------------------------------------
+
+When you create annotation runs that invovle editing existing label fields, you
+can optionally specify that certain changes are not alllowed by passing the
+following flags to
+:meth:`annotate() <fiftyone.core.collections.SampleCollection.annotate>`:
+
+-   **allow_additions** (*True*): whether to allow new labels to be added
+-   **allow_deletions** (*True*): whether to allow labels to be deleted
+-   **allow_spatial_edits** (*True*): whether to allow edits to the spatial
+    properties (bounding boxes, vertices, keypoints, etc) of labels
+
+If you are using the `label_schema` parameter to provide a full annotation
+schema to
+:meth:`annotate() <fiftyone.core.collections.SampleCollection.annotate>`, you
+can also directly include the above flags in the configuration dicts for any
+existing label field(s) you wish.
+
+For example, suppose you have an existing `ground_truth` field that contains
+objects of various types and you would like to add new `sex` and `age`
+attributes to all people in this field while also strictly enforcing that no
+objects can be added, deleted, or have their bounding boxes modified. You can
+configure an annotation run for this as follows:
+
+.. code:: python
+    :linenos:
+
+    anno_key = "..."
+
+    attributes = {
+        "sex": {
+            "type": "select",
+            "values": ["male", "female"],
+        },
+        "age": {
+            "type": "text",
+        },
+    }
+
+    view.annotate(
+        anno_key,
+        label_field="ground_truth",
+        classes=["person"],
+        attributes=attributes,
+        allow_additions=False,
+        allow_deletions=False,
+        allow_spatial_edits=False,
+    )
+
+.. note::
+
+    Some annotation backends may not support restrictions to additions,
+    deletions, and spatial edits in their editing interface.
+
+    However, any restrictions that you specify via the above parameters will
+    still be enforced when you call
+    :meth:`load_annotations() <fiftyone.core.collections.SampleCollection.load_annotations>`
+    to merge the annotations back into FiftyOne.
 
 .. _annotation-labeling-videos:
 

--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -5729,6 +5729,9 @@ class SampleCollection(object):
         classes=None,
         attributes=True,
         mask_targets=None,
+        allow_spatial_edits=True,
+        allow_additions=True,
+        allow_deletions=True,
         media_field="filepath",
         backend=None,
         launch_editor=False,
@@ -5813,6 +5816,13 @@ class SampleCollection(object):
                 ``label_schema`` that do not define their attributes
             mask_targets (None): a dict mapping pixel values to semantic label
                 strings. Only applicable when annotating semantic segmentations
+            allow_spatial_edits (True): whether to allow edits to the spatial
+                properties (bounding boxes, vertices, keypoints, etc) of
+                labels. Only applicable when editing existing label fields
+            allow_additions (True): whether to allow new labels to be added.
+                Only applicable when editing existing label fields
+            allow_deletions (True): whether to allow labels to be deleted. Only
+                applicable when editing existing label fields
             media_field ("filepath"): the field containing the paths to the
                 media files to upload
             backend (None): the annotation backend to use. The supported values
@@ -5835,6 +5845,9 @@ class SampleCollection(object):
             classes=classes,
             attributes=attributes,
             mask_targets=mask_targets,
+            allow_spatial_edits=allow_spatial_edits,
+            allow_additions=allow_additions,
+            allow_deletions=allow_deletions,
             media_field=media_field,
             backend=backend,
             launch_editor=launch_editor,

--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -5729,9 +5729,9 @@ class SampleCollection(object):
         classes=None,
         attributes=True,
         mask_targets=None,
-        allow_spatial_edits=True,
         allow_additions=True,
         allow_deletions=True,
+        allow_spatial_edits=True,
         media_field="filepath",
         backend=None,
         launch_editor=False,
@@ -5816,13 +5816,13 @@ class SampleCollection(object):
                 ``label_schema`` that do not define their attributes
             mask_targets (None): a dict mapping pixel values to semantic label
                 strings. Only applicable when annotating semantic segmentations
-            allow_spatial_edits (True): whether to allow edits to the spatial
-                properties (bounding boxes, vertices, keypoints, etc) of
-                labels. Only applicable when editing existing label fields
             allow_additions (True): whether to allow new labels to be added.
                 Only applicable when editing existing label fields
             allow_deletions (True): whether to allow labels to be deleted. Only
                 applicable when editing existing label fields
+            allow_spatial_edits (True): whether to allow edits to the spatial
+                properties (bounding boxes, vertices, keypoints, etc) of
+                labels. Only applicable when editing existing label fields
             media_field ("filepath"): the field containing the paths to the
                 media files to upload
             backend (None): the annotation backend to use. The supported values
@@ -5845,9 +5845,9 @@ class SampleCollection(object):
             classes=classes,
             attributes=attributes,
             mask_targets=mask_targets,
-            allow_spatial_edits=allow_spatial_edits,
             allow_additions=allow_additions,
             allow_deletions=allow_deletions,
+            allow_spatial_edits=allow_spatial_edits,
             media_field=media_field,
             backend=backend,
             launch_editor=launch_editor,

--- a/fiftyone/utils/annotations.py
+++ b/fiftyone/utils/annotations.py
@@ -1118,7 +1118,7 @@ def _merge_scalars(samples, anno_dict, results, label_field, label_info):
                         image[field] = None
                 else:
                     # Edit value
-                    image[field] = value
+                    image[field] = new_value
 
         sample.save()
 

--- a/fiftyone/utils/annotations.py
+++ b/fiftyone/utils/annotations.py
@@ -42,6 +42,9 @@ def annotate(
     classes=None,
     attributes=True,
     mask_targets=None,
+    allow_spatial_edits=True,
+    allow_additions=True,
+    allow_deletions=True,
     media_field="filepath",
     backend=None,
     launch_editor=False,
@@ -127,6 +130,13 @@ def annotate(
             ``label_schema`` that do not define their attributes
         mask_targets (None): a dict mapping pixel values to semantic label
             strings. Only applicable when annotating semantic segmentations
+        allow_spatial_edits (True): whether to allow edits to the spatial
+            properties (bounding boxes, vertices, keypoints, etc) of labels.
+            Only applicable when editing existing label fields
+        allow_additions (True): whether to allow new labels to be added. Only
+            applicable when editing existing label fields
+        allow_deletions (True): whether to allow labels to be deleted. Only
+            applicable when editing existing label fields
         media_field ("filepath"): the field containing the paths to the
             media files to upload
         backend (None): the annotation backend to use. The supported values are
@@ -163,12 +173,15 @@ def annotate(
     label_schema, samples = _build_label_schema(
         samples,
         anno_backend,
-        label_schema=label_schema,
-        label_field=label_field,
-        label_type=label_type,
-        classes=classes,
-        attributes=attributes,
-        mask_targets=mask_targets,
+        label_schema,
+        label_field,
+        label_type,
+        classes,
+        attributes,
+        mask_targets,
+        allow_spatial_edits,
+        allow_additions,
+        allow_deletions,
     )
     config.label_schema = label_schema
 
@@ -258,22 +271,23 @@ _RETURN_TYPES_MAP = {
     "scalar": "scalar",
 }
 
-# The label fields that are *always* overwritten during import
+# Label fields that are always overwritten when merging labels
 _DEFAULT_LABEL_FIELDS_MAP = {
     fol.Classification: ["label"],
-    fol.Detection: ["label", "bounding_box", "index", "mask"],
-    fol.Polyline: ["label", "points", "index", "closed", "filled"],
-    fol.Keypoint: ["label", "points", "index"],
-    fol.Segmentation: ["mask"],
+    fol.Detection: ["label", "index"],
+    fol.Polyline: ["label", "index"],
+    fol.Keypoint: ["label", "index"],
+    fol.Segmentation: [],
 }
 
-# Valid field types for the scalar annotation type
-_SCALAR_TYPES = (
-    fof.IntField,
-    fof.FloatField,
-    fof.StringField,
-    fof.BooleanField,
-)
+# Label fields that are overwritten when spatial changes are allowed
+_SPATIAL_LABEL_FIELDS_MAP = {
+    fol.Classification: [],
+    fol.Detection: ["bounding_box", "mask"],
+    fol.Polyline: ["points", "closed", "filled"],
+    fol.Keypoint: ["points"],
+    fol.Segmentation: ["mask"],
+}
 
 # Label types that can be annotated as tracks in videos
 _TRACKABLE_TYPES = (
@@ -288,19 +302,29 @@ _TRACKABLE_TYPES = (
 def _build_label_schema(
     samples,
     backend,
-    label_schema=None,
-    label_field=None,
-    label_type=None,
-    classes=None,
-    attributes=None,
-    mask_targets=None,
+    label_schema,
+    label_field,
+    label_type,
+    classes,
+    attributes,
+    mask_targets,
+    allow_spatial_edits,
+    allow_additions,
+    allow_deletions,
 ):
     if label_schema is None and label_field is None:
         raise ValueError("Either `label_schema` or `label_field` is required")
 
     if label_schema is None:
         label_schema = _init_label_schema(
-            label_field, label_type, classes, attributes, mask_targets
+            label_field,
+            label_type,
+            classes,
+            attributes,
+            mask_targets,
+            allow_spatial_edits,
+            allow_additions,
+            allow_deletions,
         )
     elif isinstance(label_schema, list):
         label_schema = {lf: {} for lf in label_schema}
@@ -364,11 +388,23 @@ def _build_label_schema(
             "type": _label_type,
             "classes": _classes,
             "attributes": _attributes,
-            "existing_field": _existing_field,
         }
 
         if _mask_targets is not None:
             label_info["mask_targets"] = _mask_targets
+
+        label_info["existing_field"] = _existing_field
+
+        if _existing_field:
+            label_info["allow_spatial_edits"] = _label_info.get(
+                "allow_spatial_edits", allow_spatial_edits
+            )
+            label_info["allow_additions"] = _label_info.get(
+                "allow_additions", allow_additions
+            )
+            label_info["allow_deletions"] = _label_info.get(
+                "allow_deletions", allow_deletions
+            )
 
         if (
             _existing_field
@@ -433,7 +469,14 @@ def _select_labels_with_type(samples, label_field, label_type):
 
 
 def _init_label_schema(
-    label_field, label_type, classes, attributes, mask_targets
+    label_field,
+    label_type,
+    classes,
+    attributes,
+    mask_targets,
+    allow_spatial_edits,
+    allow_additions,
+    allow_deletions,
 ):
     d = {}
 
@@ -448,6 +491,10 @@ def _init_label_schema(
 
     if mask_targets is not None:
         d["mask_targets"] = mask_targets
+
+    d["allow_spatial_edits"] = allow_spatial_edits
+    d["allow_additions"] = allow_additions
+    d["allow_deletions"] = allow_deletions
 
     return {label_field: d}
 
@@ -551,6 +598,18 @@ def _unwrap(value):
 
 def _get_existing_label_type(samples, backend, label_field, field_type):
     if not isinstance(field_type, fof.EmbeddedDocumentField):
+        if field_type not in backend.supported_scalar_types:
+            raise ValueError(
+                "Field '%s' has unsupported scalar type %s. The '%s' backend "
+                "supports %s"
+                % (
+                    label_field,
+                    field_type,
+                    backend.config.name,
+                    backend.supported_scalar_types,
+                )
+            )
+
         return "scalar"
 
     fo_label_type = field_type.document_type
@@ -862,6 +921,8 @@ def load_annotations(
 
     for label_field, label_info in label_schema.items():
         label_type = label_info["type"]
+        allow_additions = label_info.get("allow_additions", True)
+
         expected_type = _RETURN_TYPES_MAP[label_type]
 
         anno_dict = annotations.get(label_field, {})
@@ -870,27 +931,43 @@ def load_annotations(
             if anno_type == expected_type:
                 # Expected labels
                 if label_type == "scalar":
-                    _load_scalars(samples, annos, label_field)
+                    _merge_scalars(
+                        samples, annos, results, label_field, label_info,
+                    )
                 else:
                     _merge_labels(
                         samples,
                         annos,
                         results,
                         label_field,
-                        anno_type,
-                        label_info=label_info,
+                        label_type,
+                        label_info,
                     )
             else:
                 # Unexpected labels
-                if skip_unexpected:
+                if skip_unexpected or not allow_additions:
                     new_field = None
                 else:
-                    new_field = _prompt_field(samples, anno_type, label_field)
+                    new_field = _prompt_field(
+                        samples, anno_type, label_field, label_schema
+                    )
 
                 if new_field:
-                    _merge_labels(
-                        samples, annos, results, label_field, label_type
-                    )
+                    if anno_type == "scalar":
+                        _label_info = {}
+                        _merge_scalars(
+                            samples, annos, results, new_field, _label_info
+                        )
+                    else:
+                        _label_info = {"attributes": None}  # all attributes
+                        _merge_labels(
+                            samples,
+                            annos,
+                            results,
+                            new_field,
+                            anno_type,
+                            _label_info,
+                        )
                 else:
                     logger.info(
                         "Skipping unexpected labels of type '%s' in field "
@@ -905,19 +982,19 @@ def load_annotations(
         results.cleanup()
 
 
-def _prompt_field(samples, new_type, label_field):
+def _prompt_field(samples, label_type, label_field, label_schema):
     new_field = input(
         "Found unexpected labels of type '%s' when loading annotations for "
         "field '%s'.\nPlease enter a new or compatible existing field name in "
         "which to store these annotations, or empty to skip: "
-        % (new_type, label_field)
+        % (label_type, label_field)
     )
 
     if not new_field:
         return None
 
-    if new_type != "scalar":
-        fo_label_type = _LABEL_TYPES_MAP[new_type]
+    if label_type != "scalar":
+        fo_label_type = _LABEL_TYPES_MAP[label_type]
 
     _, is_frame_field = samples._handle_frame_field(label_field)
     if is_frame_field:
@@ -926,35 +1003,51 @@ def _prompt_field(samples, new_type, label_field):
         schema = samples.get_field_schema()
 
     while True:
-        if is_frame_field:
-            if not samples._is_frame_field(new_field):
-                new_field = samples._FRAMES_PREFIX + new_field
+        is_good_field = new_field not in label_schema
 
-            field, _ = samples._handle_frame_field(new_field)
+        if is_good_field:
+            if is_frame_field:
+                if not samples._is_frame_field(new_field):
+                    new_field = samples._FRAMES_PREFIX + new_field
+
+                field, _ = samples._handle_frame_field(new_field)
+            else:
+                field = new_field
+
+            if field not in schema:
+                break  # new field
+
+            try:
+                field_type = schema[field].document_type
+            except:
+                field_type = type(schema[field])
+
+            if label_type == "scalar":
+                # As long as it is not an embedded document field, assume the
+                # user knows what they're doing
+                is_good_type = not issubclass(
+                    field_type, fof.EmbeddedDocumentField
+                )
+            else:
+                is_good_type = issubclass(field_type, fo_label_type)
         else:
-            field = new_field
+            is_good_type = False
 
-        if field not in schema:
-            break  # new field
-
-        try:
-            field_type = schema[field].document_type
-        except:
-            field_type = type(schema[field])
-
-        if new_type == "scalar":
-            is_good_type = issubclass(field_type, _SCALAR_TYPES)
-        else:
-            is_good_type = issubclass(field_type, fo_label_type)
-
-        if is_good_type:
+        if is_good_field and is_good_type:
             break
 
-        new_field = input(
-            "Existing field '%s' of type %s is not compatible with labels "
-            "of type '%s'.\nPlease enter a different field name or empty to "
-            "skip: " % (new_field, field_type, new_type)
-        )
+        if not is_good_field:
+            new_field = input(
+                "Cannot add unexpected labels to field '%s' because it is "
+                "involved in this annotation run.\nPlease enter a different "
+                "field name or empty to skip: " % new_field
+            )
+        else:
+            new_field = input(
+                "Existing field '%s' of type %s is not compatible with labels "
+                "of type '%s'.\nPlease enter a different field name or empty "
+                "to skip: " % (new_field, field_type, label_type)
+            )
 
         if not new_field:
             break
@@ -962,36 +1055,95 @@ def _prompt_field(samples, new_type, label_field):
     return new_field
 
 
-def _load_scalars(samples, anno_dict, label_field):
-    logger.info("Loading annotations for field '%s'...", label_field)
-    with fou.ProgressBar(total=len(anno_dict)) as pb:
-        for sample_id, value in pb(anno_dict.items()):
-            if isinstance(value, dict):
-                field, _ = samples._handle_frame_field(label_field)
-                sample = (
-                    samples.select(sample_id)
-                    .select_frames(list(value.keys()))
-                    .first()
-                )
-                for frame in sample.frames.values():
-                    frame[field] = value[frame.id]
+def _merge_scalars(samples, anno_dict, results, label_field, label_info):
+    allow_additions = label_info.get("allow_additions", True)
+    allow_deletions = label_info.get("allow_deletions", True)
 
-                sample.save()
+    is_video = samples._is_frame_field(label_field)
+
+    # Retrieve a view that contains all samples involved in the annotation run
+    id_map = results.id_map.get(label_field, {})
+    uploaded_ids = set(k for k, v in id_map.items() if v is not None)
+    sample_ids = list(uploaded_ids | set(anno_dict.keys()))
+    view = samples._dataset.select(sample_ids)
+
+    if is_video:
+        field, _ = view._handle_frame_field(label_field)
+        if view.has_frame_field(field):
+            view = view.select_fields(label_field)
+    else:
+        field = label_field
+        if view.has_sample_field(field):
+            view = view.select_fields(label_field)
+
+    num_additions = 0
+    num_deletions = 0
+
+    logger.info("Loading scalars for field '%s'...", label_field)
+    for sample in view.iter_samples(progress=True):
+        sample_annos = anno_dict.get(sample.id, None)
+
+        if is_video:
+            images = sample.frames.values()
+        else:
+            images = [sample]
+
+        for image in images:
+            if is_video:
+                if sample_annos is None:
+                    new_value = None
+                else:
+                    new_value = sample_annos.get(image.id, None)
             else:
-                sample = samples[sample_id]
-                sample[label_field] = value
-                sample.save()
+                new_value = sample_annos
+
+            try:
+                value = image[field]
+            except:
+                value = None  # field may not exist yet
+
+            if value != new_value:
+                if value is None:
+                    # New value
+                    num_additions += 1
+                    if allow_additions:
+                        image[field] = new_value
+                elif new_value is None:
+                    # Delete value
+                    num_deletions += 1
+                    if allow_deletions:
+                        image[field] = None
+                else:
+                    # Edit value
+                    image[field] = value
+
+        sample.save()
+
+    if num_additions and not allow_additions:
+        logger.warning(
+            "Ignored %d added scalars in field '%s' because "
+            "`allow_additions=False`",
+            num_additions,
+            label_field,
+        )
+
+    if num_deletions and not allow_deletions:
+        logger.warning(
+            "Ignored %d deleted scalars in field '%s' because "
+            "`allow_deletions=False`",
+            num_deletions,
+            label_field,
+        )
 
 
 def _merge_labels(
-    samples, anno_dict, results, label_field, label_type, label_info=None
+    samples, anno_dict, results, label_field, label_type, label_info
 ):
-    if label_info is not None:
-        attributes = label_info.get("attributes", {})
-        only_keyframes = label_info.get("only_keyframes", False)
-    else:
-        attributes = None
-        only_keyframes = False
+    attributes = label_info.get("attributes", {})
+    only_keyframes = label_info.get("only_keyframes", False)
+    allow_spatial_edits = label_info.get("allow_spatial_edits", True)
+    allow_additions = label_info.get("allow_additions", True)
+    allow_deletions = label_info.get("allow_deletions", True)
 
     fo_label_type = _LABEL_TYPES_MAP[label_type]
     if issubclass(fo_label_type, fol._LABEL_LIST_FIELDS):
@@ -1010,8 +1162,10 @@ def _merge_labels(
     id_map = results.id_map.get(label_field, {})
 
     if is_video:
+        field, _ = samples._handle_frame_field(label_field)
         added_id_map = defaultdict(lambda: defaultdict(list))
     else:
+        field = label_field
         added_id_map = defaultdict(list)
 
     existing_ids = set()
@@ -1021,6 +1175,8 @@ def _merge_labels(
                 existing_ids.update(_to_list(frame_labels))
         else:
             existing_ids.update(_to_list(sample_labels))
+
+    existing_ids.discard(None)
 
     anno_ids = set()
     for sample in anno_dict.values():
@@ -1034,24 +1190,20 @@ def _merge_labels(
     new_ids = anno_ids - existing_ids
     merge_ids = anno_ids - new_ids
 
-    if delete_ids:
+    if delete_ids and allow_deletions:
         samples._dataset.delete_labels(ids=delete_ids, fields=label_field)
 
     sample_ids = list(anno_dict.keys())
-    annotated_samples = samples._dataset.select(sample_ids).select_fields(
-        label_field
-    )
+    view = samples._dataset.select(sample_ids).select_fields(label_field)
 
     logger.info("Loading labels for field '%s'...", label_field)
-    for sample in annotated_samples.iter_samples(progress=True):
+    for sample in view.iter_samples(progress=True):
         sample_id = sample.id
         sample_annos = anno_dict[sample_id]
 
         if is_video:
-            field, _ = samples._handle_frame_field(label_field)
             images = sample.frames.values()
         else:
-            field = label_field
             images = [sample]
 
         for image in images:
@@ -1064,7 +1216,7 @@ def _merge_labels(
 
             image_label = image[field]
 
-            if image_label is None:
+            if image_label is None and allow_additions:
                 # Add new labels to `None`-valued fields
                 if is_list:
                     label_ids = list(image_annos.keys())
@@ -1098,12 +1250,13 @@ def _merge_labels(
                         _merge_label(
                             label,
                             anno_label,
-                            only_keyframes=only_keyframes,
                             attributes=attributes,
+                            allow_spatial_edits=allow_spatial_edits,
+                            only_keyframes=only_keyframes,
                         )
 
                 # Add new labels to label list fields
-                if is_list:
+                if is_list and allow_additions:
                     for anno_id, anno_label in image_annos.items():
                         if anno_id not in new_ids:
                             continue
@@ -1116,6 +1269,22 @@ def _merge_labels(
                             added_id_map[sample_id].append(anno_id)
 
         sample.save()
+
+    if new_ids and not allow_additions:
+        logger.warning(
+            "Ignored %d added labels in field '%s' because "
+            "`allow_additions=False`",
+            len(new_ids),
+            label_field,
+        )
+
+    if delete_ids and not allow_deletions:
+        logger.warning(
+            "Ignored %d deleted labels in field '%s' because "
+            "`allow_deletions=False`",
+            len(delete_ids),
+            label_field,
+        )
 
     # Record newly added IDs so that re-imports of this run will be properly
     # processed
@@ -1140,9 +1309,19 @@ def _ensure_label_field(samples, label_field, fo_label_type):
             )
 
 
-def _merge_label(label, anno_label, only_keyframes=False, attributes=None):
+def _merge_label(
+    label,
+    anno_label,
+    attributes=None,
+    allow_spatial_edits=True,
+    only_keyframes=False,
+):
     for field in _DEFAULT_LABEL_FIELDS_MAP.get(type(label), []):
         label[field] = anno_label[field]
+
+    if allow_spatial_edits:
+        for field in _SPATIAL_LABEL_FIELDS_MAP.get(type(label), []):
+            label[field] = anno_label[field]
 
     if only_keyframes:
         label.keyframe = anno_label.get_attribute_value("keyframe", None)
@@ -1313,6 +1492,21 @@ class AnnotationBackend(foa.AnnotationMethod):
         )
 
     @property
+    def supported_scalar_types(self):
+        """The list of scalar field types supported by the backend.
+
+        For example, CVAT supports the following types:
+
+        -   :class:`fiftyone.core.fields.IntField`
+        -   :class:`fiftyone.core.fields.FloatField`
+        -   :class:`fiftyone.core.fields.StringField`
+        -   :class:`fiftyone.core.fields.BooleanField`
+        """
+        raise NotImplementedError(
+            "subclass must implement supported_scalar_types"
+        )
+
+    @property
     def supported_attr_types(self):
         """The list of attribute types supported by the backend.
 
@@ -1444,9 +1638,11 @@ class AnnotationResults(foa.AnnotationResults):
     that has been initiated and is waiting for its results to be merged back
     into the FiftyOne dataset.
 
-    The ``id_map`` dictionary records the IDs of any existing labels that are
-    being edited by the annotation run. For image datasets, it should have the
-    following format::
+    The ``id_map`` dictionary must record the IDs of any **existing labels**
+    that are being edited by the annotation run. Any new label fields do not
+    need to have keys in this dictionary.
+
+    For image datasets, ``id_map`` should have the following format::
 
         {
             "<label-field>": {
@@ -1456,7 +1652,7 @@ class AnnotationResults(foa.AnnotationResults):
             ...
         }
 
-    For video datasets, it should have the following format::
+    For video datasets, ``id_map`` should have the following format::
 
         {
             "<label-field>": {
@@ -1468,6 +1664,13 @@ class AnnotationResults(foa.AnnotationResults):
             },
             ...
         }
+
+    When editing scalar fields, set the dictionary values corresponding to
+    uploaded scalars to ``True`` (since scalars do not have IDs).
+
+    If a particular sample or frame was included in the annotation run but no
+    labels/scalars were uploaded for editing, the corresponding entry in
+    ``id_map`` can be either missing or have a value of ``None``.
 
     .. note::
 

--- a/fiftyone/utils/annotations.py
+++ b/fiftyone/utils/annotations.py
@@ -1122,7 +1122,7 @@ def _merge_scalars(samples, anno_dict, results, label_field, label_info):
 
         sample.save()
 
-    if num_additions and not allow_additions:
+    if num_additions > 0 and not allow_additions:
         logger.warning(
             "Ignored %d added scalars in field '%s' because "
             "`allow_additions=False`",
@@ -1130,7 +1130,7 @@ def _merge_scalars(samples, anno_dict, results, label_field, label_info):
             label_field,
         )
 
-    if num_deletions and not allow_deletions:
+    if num_deletions > 0 and not allow_deletions:
         logger.warning(
             "Ignored %d deleted scalars in field '%s' because "
             "`allow_deletions=False`",

--- a/fiftyone/utils/annotations.py
+++ b/fiftyone/utils/annotations.py
@@ -598,7 +598,7 @@ def _unwrap(value):
 
 def _get_existing_label_type(samples, backend, label_field, field_type):
     if not isinstance(field_type, fof.EmbeddedDocumentField):
-        if field_type not in backend.supported_scalar_types:
+        if not isinstance(field_type, tuple(backend.supported_scalar_types)):
             raise ValueError(
                 "Field '%s' has unsupported scalar type %s. The '%s' backend "
                 "supports %s"

--- a/fiftyone/utils/annotations.py
+++ b/fiftyone/utils/annotations.py
@@ -42,9 +42,9 @@ def annotate(
     classes=None,
     attributes=True,
     mask_targets=None,
-    allow_spatial_edits=True,
     allow_additions=True,
     allow_deletions=True,
+    allow_spatial_edits=True,
     media_field="filepath",
     backend=None,
     launch_editor=False,
@@ -130,13 +130,13 @@ def annotate(
             ``label_schema`` that do not define their attributes
         mask_targets (None): a dict mapping pixel values to semantic label
             strings. Only applicable when annotating semantic segmentations
-        allow_spatial_edits (True): whether to allow edits to the spatial
-            properties (bounding boxes, vertices, keypoints, etc) of labels.
-            Only applicable when editing existing label fields
         allow_additions (True): whether to allow new labels to be added. Only
             applicable when editing existing label fields
         allow_deletions (True): whether to allow labels to be deleted. Only
             applicable when editing existing label fields
+        allow_spatial_edits (True): whether to allow edits to the spatial
+            properties (bounding boxes, vertices, keypoints, etc) of labels.
+            Only applicable when editing existing label fields
         media_field ("filepath"): the field containing the paths to the
             media files to upload
         backend (None): the annotation backend to use. The supported values are
@@ -179,9 +179,9 @@ def annotate(
         classes,
         attributes,
         mask_targets,
-        allow_spatial_edits,
         allow_additions,
         allow_deletions,
+        allow_spatial_edits,
     )
     config.label_schema = label_schema
 
@@ -308,9 +308,9 @@ def _build_label_schema(
     classes,
     attributes,
     mask_targets,
-    allow_spatial_edits,
     allow_additions,
     allow_deletions,
+    allow_spatial_edits,
 ):
     if label_schema is None and label_field is None:
         raise ValueError("Either `label_schema` or `label_field` is required")
@@ -322,9 +322,9 @@ def _build_label_schema(
             classes,
             attributes,
             mask_targets,
-            allow_spatial_edits,
             allow_additions,
             allow_deletions,
+            allow_spatial_edits,
         )
     elif isinstance(label_schema, list):
         label_schema = {lf: {} for lf in label_schema}
@@ -396,14 +396,14 @@ def _build_label_schema(
         label_info["existing_field"] = _existing_field
 
         if _existing_field:
-            label_info["allow_spatial_edits"] = _label_info.get(
-                "allow_spatial_edits", allow_spatial_edits
-            )
             label_info["allow_additions"] = _label_info.get(
                 "allow_additions", allow_additions
             )
             label_info["allow_deletions"] = _label_info.get(
                 "allow_deletions", allow_deletions
+            )
+            label_info["allow_spatial_edits"] = _label_info.get(
+                "allow_spatial_edits", allow_spatial_edits
             )
 
         if (
@@ -474,9 +474,9 @@ def _init_label_schema(
     classes,
     attributes,
     mask_targets,
-    allow_spatial_edits,
     allow_additions,
     allow_deletions,
+    allow_spatial_edits,
 ):
     d = {}
 
@@ -492,9 +492,9 @@ def _init_label_schema(
     if mask_targets is not None:
         d["mask_targets"] = mask_targets
 
-    d["allow_spatial_edits"] = allow_spatial_edits
     d["allow_additions"] = allow_additions
     d["allow_deletions"] = allow_deletions
+    d["allow_spatial_edits"] = allow_spatial_edits
 
     return {label_field: d}
 
@@ -1141,9 +1141,9 @@ def _merge_labels(
 ):
     attributes = label_info.get("attributes", {})
     only_keyframes = label_info.get("only_keyframes", False)
-    allow_spatial_edits = label_info.get("allow_spatial_edits", True)
     allow_additions = label_info.get("allow_additions", True)
     allow_deletions = label_info.get("allow_deletions", True)
+    allow_spatial_edits = label_info.get("allow_spatial_edits", True)
 
     fo_label_type = _LABEL_TYPES_MAP[label_type]
     if issubclass(fo_label_type, fol._LABEL_LIST_FIELDS):

--- a/fiftyone/utils/annotations.py
+++ b/fiftyone/utils/annotations.py
@@ -927,6 +927,9 @@ def load_annotations(
 
         anno_dict = annotations.get(label_field, {})
 
+        if expected_type not in anno_dict:
+            anno_dict[expected_type] = {}
+
         for anno_type, annos in anno_dict.items():
             if anno_type == expected_type:
                 # Expected labels

--- a/fiftyone/utils/cvat.py
+++ b/fiftyone/utils/cvat.py
@@ -3231,7 +3231,6 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
                             label_field,
                             label_info,
                             cvat_schema,
-                            is_shape=False,
                             assign_scalar_attrs=assign_scalar_attrs,
                         )
                     elif is_video and label_type != "segmentation":
@@ -3245,7 +3244,6 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
                             label_field,
                             label_info,
                             cvat_schema,
-                            is_shape=True,
                             load_tracks=True,
                             only_keyframes=only_keyframes,
                         )
@@ -3259,7 +3257,6 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
                             label_field,
                             label_info,
                             cvat_schema,
-                            is_shape=True,
                         )
 
                     id_map[label_field] = _id_map
@@ -3937,7 +3934,6 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
         label_field,
         label_info,
         cvat_schema,
-        is_shape=False,
         assign_scalar_attrs=False,
         load_tracks=False,
         only_keyframes=False,
@@ -3966,12 +3962,10 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
 
             if is_video:
                 images = sample.frames.values()
-                if is_shape:
-                    frame_size = (metadata.frame_width, metadata.frame_height)
+                frame_size = (metadata.frame_width, metadata.frame_height)
             else:
                 images = [sample]
-                if is_shape:
-                    frame_size = (metadata.width, metadata.height)
+                frame_size = (metadata.width, metadata.height)
 
             for image in images:
                 frame_id += 1

--- a/fiftyone/utils/cvat.py
+++ b/fiftyone/utils/cvat.py
@@ -3204,8 +3204,6 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
             )
 
             if label_type == "scalar":
-                # True: scalars are annotated as tag attributes
-                # False: scalars are annotated as tag labels
                 assigned_scalar_attrs[label_field] = assign_scalar_attrs
 
             labels_task_map[label_field] = []
@@ -3870,7 +3868,9 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
                 "mutable": True,
             }
 
-        assign_scalar_attrs = bool(classes)
+        # True: scalars are annotated as tag attributes
+        # False: scalars are annotated as tag labels
+        assign_scalar_attrs = not bool(classes)
 
         if not classes:
             classes = [label_field]


### PR DESCRIPTION
Adds optional `allow_additions`, `allow_deletions`, and `allow_spatial_edits` parameters to `annotate()` that allow for configuring whether certain types of edits are allowed in an annotation run.

For example, suppose you have an existing `ground_truth` field that contains objects of various types and you would like to add new `sex` and `age` attributes to all people in this field while also strictly enforcing that no objects can be added, deleted, or have their bounding boxes modified.

You can configure an annotation run for this as follows:

```py
import fiftyone as fo
import fiftyone.zoo as foz
from fiftyone import ViewField as F

dataset = foz.load_zoo_dataset("quickstart")

view = (
    dataset
    .match_labels(filter=F("label") == "person", fields="ground_truth")
    .limit(1)
)

anno_key = "cvat_edit_restrictions"

# The new attributes we want to populate
attributes = {
    "sex": {
        "type": "select",
        "values": ["male", "female"],
    },
    "age": {
        "type": "text",
    },
}

view.annotate(
    anno_key,
    label_field="ground_truth",
    classes=["person"],
    attributes=attributes,
    allow_additions=False,
    allow_deletions=False,
    allow_spatial_edits=False,
    launch_editor=True,
)
print(dataset.get_annotation_info(anno_key))

# Populate attributes in CVAT

dataset.load_annotations(anno_key, cleanup=True)
dataset.delete_annotation_run(anno_key)
```

And here's an example that demonstrates that these parameters can also be applied to scalar annotations:

```py
import fiftyone as fo
import fiftyone.zoo as foz

dataset = foz.load_zoo_dataset("quickstart", max_samples=3)
dataset = dataset.select_fields().clone()

# Add scalars

dataset.annotate(
    "new_scalar",
    label_field="scalar",
    label_type="scalar",
    launch_editor=True,
)
print(dataset.get_annotation_info("new_scalar"))

dataset.load_annotations("new_scalar", cleanup=True)
dataset.delete_annotation_run("new_scalar")

# Edit scalars

dataset.annotate(
    "edit_scalars",
    label_field="scalar",
    allow_additions=False,
    allow_deletions=False,
    allow_spatial_edits=False,
    launch_editor=True,
)
print(dataset.get_annotation_info("edit_scalars"))

dataset.load_annotations("edit_scalars", cleanup=True)
dataset.delete_annotation_run("edit_scalars")
```
