### PR TITLE
Adding support for read-only labels/attributes during annotation

### DIFF
--- a/docs/source/integrations/cvat.rst
+++ b/docs/source/integrations/cvat.rst
@@ -718,10 +718,42 @@ configure an annotation run for this as follows:
         allow_spatial_edits=False,
     )
 
+You can also include a `read_only=True` parameter when uploading existing
+label attributes to specify that the attribute's value should be uploaded to
+the annotation backend for informational purposes, but any edits to the
+attribute's value should not be imported back into FiftyOne.
+
+For example, if you have vehicles with their `make` attribute populated and you
+want to populate a new `model` attribute based on this information without
+allowing changes to the vehicle's `make`, you can configure an annotation run
+for this as follows:
+
+.. code:: python
+    :linenos:
+
+    anno_key = "..."
+
+    attributes = {
+        "make": {
+            "type": "text",
+            "read_only": True,
+        },
+        "model": {
+            "type": "text",
+        },
+    }
+
+    view.annotate(
+        anno_key,
+        label_field="ground_truth",
+        classes=["vehicle"],
+        attributes=attributes,
+    )
+
 .. note::
 
-    The CVAT backend does not support restrictions to additions, deletions, and
-    spatial edits in its editing interface.
+    The CVAT backend does not support restrictions to additions, deletions,
+    spatial edits, and read-only attributes in its editing interface.
 
     However, any restrictions that you specify via the above parameters will
     still be enforced when you call
@@ -1111,6 +1143,64 @@ configure an annotation run for this as follows:
 
     dataset.load_annotations(anno_key, cleanup=True)
     dataset.delete_annotation_run(anno_key)
+
+Similarly, you can include a `read_only=True` parameter when uploading existing
+label attributes to specify that the attribute's value should be uploaded to
+the annotation backend for informational purposes, but any edits to the
+attribute's value should not be imported back into FiftyOne.
+
+For example, the snippet below uploads the vehicle tracks in a video dataset
+along with their existing `type` attributes and requests that a new `make`
+attribute be populated without allowing edits of any other kind:
+
+.. code:: python
+    :linenos:
+
+    import fiftyone as fo
+    import fiftyone.zoo as foz
+
+    dataset = foz.load_zoo_dataset("quickstart-video")
+    view = dataset.take(1)
+
+    anno_key = "cvat_read_only_attrs"
+
+    # Upload existing `type` attribute as read-only and add new `make` attribute
+    attributes = {
+        "type": {
+            "type": "text",
+            "read_only": True,
+        },
+        "make": {
+            "type": "text",
+        },
+    }
+
+    view.annotate(
+        anno_key,
+        label_field="frames.detections",
+        classes=["vehicle"],
+        attributes=attributes,
+        allow_additions=False,
+        allow_deletions=False,
+        allow_spatial_edits=False,
+        launch_editor=True,
+    )
+    print(dataset.get_annotation_info(anno_key))
+
+    # Populate make attributes in CVAT
+
+    dataset.load_annotations(anno_key, cleanup=True)
+    dataset.delete_annotation_run(anno_key)
+
+.. note::
+
+    The CVAT backend does not support restrictions to additions, deletions,
+    spatial edits, and read-only attributes in its editing interface.
+
+    However, any restrictions that you specify via the above parameters will
+    still be enforced when you call
+    :meth:`load_annotations() <fiftyone.core.collections.SampleCollection.load_annotations>`
+    to merge the annotations back into FiftyOne.
 
 Annotating multiple fields
 --------------------------

--- a/docs/source/integrations/cvat.rst
+++ b/docs/source/integrations/cvat.rst
@@ -1180,6 +1180,7 @@ attribute be populated without allowing edits to the vehicle's `type`:
         },
         "make": {
             "type": "text",
+            "mutable": False,
         },
     }
 

--- a/docs/source/integrations/cvat.rst
+++ b/docs/source/integrations/cvat.rst
@@ -419,6 +419,9 @@ details:
     applicable when editing existing label fields
 -   **allow_deletions** (*True*): whether to allow labels to be deleted. Only
     applicable when editing existing label fields
+-   **allow_label_edits** (*True*): whether to allow the `label` attribute of
+    existing labels to be modified. Only applicable when editing existing label
+    fields
 -   **allow_spatial_edits** (*True*): whether to allow edits to the spatial
     properties (bounding boxes, vertices, keypoints, etc) of labels. Only
     applicable when editing existing label fields
@@ -678,6 +681,8 @@ following flags to
 
 -   **allow_additions** (*True*): whether to allow new labels to be added
 -   **allow_deletions** (*True*): whether to allow labels to be deleted
+-   **allow_label_edits** (*True*): whether to allow the `label` attribute to
+    be modified
 -   **allow_spatial_edits** (*True*): whether to allow edits to the spatial
     properties (bounding boxes, vertices, keypoints, etc) of labels
 
@@ -690,8 +695,8 @@ existing label field(s) you wish.
 For example, suppose you have an existing `ground_truth` field that contains
 objects of various types and you would like to add new `sex` and `age`
 attributes to all people in this field while also strictly enforcing that no
-objects can be added, deleted, or have their bounding boxes modified. You can
-configure an annotation run for this as follows:
+objects can be added, deleted, or have their labels or bounding boxes modified.
+You can configure an annotation run for this as follows:
 
 .. code:: python
     :linenos:
@@ -715,6 +720,7 @@ configure an annotation run for this as follows:
         attributes=attributes,
         allow_additions=False,
         allow_deletions=False,
+        allow_label_edits=False,
         allow_spatial_edits=False,
     )
 
@@ -1087,16 +1093,17 @@ can be used to annotate new classes and/or attributes:
 Restricting label edits
 -----------------------
 
-You can use the `allow_additions`, `allow_deletions`, and `allow_spatial_edits`
-parameters to configure whether certain types of edits are allowed in your
-annotation run. See :ref:`this section <cvat-restricting-edits>` for more
-information about the available options.
+You can use the `allow_additions`, `allow_deletions`, `allow_label_edits`, and
+`allow_spatial_edits` parameters to configure whether certain types of edits
+are allowed in your annotation run. See
+:ref:`this section <cvat-restricting-edits>` for more information about the
+available options.
 
 For example, suppose you have an existing `ground_truth` field that contains
 objects of various types and you would like to add new `sex` and `age`
 attributes to all people in this field while also strictly enforcing that no
-objects can be added, deleted, or have their bounding boxes modified. You can
-configure an annotation run for this as follows:
+objects can be added, deleted, or have their labels or bounding boxes modified.
+You can configure an annotation run for this as follows:
 
 .. code:: python
     :linenos:
@@ -1134,6 +1141,7 @@ configure an annotation run for this as follows:
         attributes=attributes,
         allow_additions=False,
         allow_deletions=False,
+        allow_label_edits=False,
         allow_spatial_edits=False,
         launch_editor=True,
     )
@@ -1151,7 +1159,7 @@ attribute's value should not be imported back into FiftyOne.
 
 For example, the snippet below uploads the vehicle tracks in a video dataset
 along with their existing `type` attributes and requests that a new `make`
-attribute be populated without allowing edits of any other kind:
+attribute be populated without allowing edits to the vehicle's `type`:
 
 .. code:: python
     :linenos:
@@ -1180,9 +1188,6 @@ attribute be populated without allowing edits of any other kind:
         label_field="frames.detections",
         classes=["vehicle"],
         attributes=attributes,
-        allow_additions=False,
-        allow_deletions=False,
-        allow_spatial_edits=False,
         launch_editor=True,
     )
     print(dataset.get_annotation_info(anno_key))

--- a/docs/source/user_guide/annotation.rst
+++ b/docs/source/user_guide/annotation.rst
@@ -765,10 +765,43 @@ configure an annotation run for this as follows:
         allow_spatial_edits=False,
     )
 
+You can also include a `read_only=True` parameter when uploading existing
+label attributes to specify that the attribute's value should be uploaded to
+the annotation backend for informational purposes, but any edits to the
+attribute's value should not be imported back into FiftyOne.
+
+For example, if you have vehicles with their `make` attribute populated and you
+want to populate a new `model` attribute based on this information without
+allowing changes to the vehicle's `make`, you can configure an annotation run
+for this as follows:
+
+.. code:: python
+    :linenos:
+
+    anno_key = "..."
+
+    attributes = {
+        "make": {
+            "type": "text",
+            "read_only": True,
+        },
+        "model": {
+            "type": "text",
+        },
+    }
+
+    view.annotate(
+        anno_key,
+        label_field="ground_truth",
+        classes=["vehicle"],
+        attributes=attributes,
+    )
+
 .. note::
 
     Some annotation backends may not support restrictions to additions,
-    deletions, and spatial edits in their editing interface.
+    deletions, spatial edits, and read-only attributes in their editing
+    interface.
 
     However, any restrictions that you specify via the above parameters will
     still be enforced when you call

--- a/docs/source/user_guide/annotation.rst
+++ b/docs/source/user_guide/annotation.rst
@@ -482,6 +482,9 @@ more details:
     applicable when editing existing label fields
 -   **allow_deletions** (*True*): whether to allow labels to be deleted. Only
     applicable when editing existing label fields
+-   **allow_label_edits** (*True*): whether to allow the `label` attribute of
+    existing labels to be modified. Only applicable when editing existing label
+    fields
 -   **allow_spatial_edits** (*True*): whether to allow edits to the spatial
     properties (bounding boxes, vertices, keypoints, etc) of labels. Only
     applicable when editing existing label fields
@@ -725,6 +728,8 @@ following flags to
 
 -   **allow_additions** (*True*): whether to allow new labels to be added
 -   **allow_deletions** (*True*): whether to allow labels to be deleted
+-   **allow_label_edits** (*True*): whether to allow the `label` attribute to
+    be modified
 -   **allow_spatial_edits** (*True*): whether to allow edits to the spatial
     properties (bounding boxes, vertices, keypoints, etc) of labels
 
@@ -737,8 +742,8 @@ existing label field(s) you wish.
 For example, suppose you have an existing `ground_truth` field that contains
 objects of various types and you would like to add new `sex` and `age`
 attributes to all people in this field while also strictly enforcing that no
-objects can be added, deleted, or have their bounding boxes modified. You can
-configure an annotation run for this as follows:
+objects can be added, deleted, or have their labels or bounding boxes modified.
+You can configure an annotation run for this as follows:
 
 .. code:: python
     :linenos:
@@ -762,6 +767,7 @@ configure an annotation run for this as follows:
         attributes=attributes,
         allow_additions=False,
         allow_deletions=False,
+        allow_label_edits=False,
         allow_spatial_edits=False,
     )
 

--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -5731,6 +5731,7 @@ class SampleCollection(object):
         mask_targets=None,
         allow_additions=True,
         allow_deletions=True,
+        allow_label_edits=True,
         allow_spatial_edits=True,
         media_field="filepath",
         backend=None,
@@ -5820,6 +5821,9 @@ class SampleCollection(object):
                 Only applicable when editing existing label fields
             allow_deletions (True): whether to allow labels to be deleted. Only
                 applicable when editing existing label fields
+            allow_label_edits (True): whether to allow the ``label`` attribute
+                of existing labels to be modified. Only applicable when editing
+                existing label fields
             allow_spatial_edits (True): whether to allow edits to the spatial
                 properties (bounding boxes, vertices, keypoints, etc) of
                 labels. Only applicable when editing existing label fields
@@ -5847,6 +5851,7 @@ class SampleCollection(object):
             mask_targets=mask_targets,
             allow_additions=allow_additions,
             allow_deletions=allow_deletions,
+            allow_label_edits=allow_label_edits,
             allow_spatial_edits=allow_spatial_edits,
             media_field=media_field,
             backend=backend,

--- a/fiftyone/utils/annotations.py
+++ b/fiftyone/utils/annotations.py
@@ -845,6 +845,7 @@ def _format_attributes(backend, attributes):
         values = attr.get("values", None)
         default = attr.get("default", None)
         mutable = attr.get("mutable", None)
+        read_only = attr.get("read_only", None)
 
         if attr_type is None:
             raise ValueError(
@@ -887,6 +888,10 @@ def _format_attributes(backend, attributes):
         # Parse `mutable` property
         if mutable is not None:
             _attr["mutable"] = mutable
+
+        # Parse `read_only` property
+        if read_only is not None:
+            _attr["read_only"] = read_only
 
         _attributes[name] = _attr
 
@@ -1147,6 +1152,14 @@ def _merge_labels(
     allow_additions = label_info.get("allow_additions", True)
     allow_deletions = label_info.get("allow_deletions", True)
     allow_spatial_edits = label_info.get("allow_spatial_edits", True)
+
+    # Omit read-only attributes
+    if isinstance(attributes, dict):
+        attributes = {
+            k: v
+            for k, v in attributes.items()
+            if not v.get("read_only", False)
+        }
 
     fo_label_type = _LABEL_TYPES_MAP[label_type]
     if issubclass(fo_label_type, fol._LABEL_LIST_FIELDS):


### PR DESCRIPTION
Adds optional flags that allow for configuring whether labels/attributes can be edited during an annotation run:
- Passing `allow_label_edits=False` to `annotate()` declares that existing object's `label`s cannot be changed
- Including the  `read_only=True` key when uploading existing label attributes declares that the attribute's value should be uploaded to the annotation backend for informational purposes, but the attribute's value cannot be changed

As noted in the docs, annotation backends may not be able to obey these parameters in their editing interface, but these settings will always be enforced when the annotations are imported back into FiftyOne.

For example, the snippet below uploads the vehicle tracks in a video dataset along with their existing `type` attributes and requests that a new `make` attribute be populated without allowing edits of any other kind:

```py
import fiftyone as fo
import fiftyone.zoo as foz

dataset = foz.load_zoo_dataset("quickstart-video")
view = dataset.take(1)

anno_key = "cvat_read_only_attrs"

# Upload existing `type` attribute as read-only and add new `make` attribute
attributes = {
    "type": {
        "type": "text",
        "read_only": True,
    },
    "make": {
        "type": "text",
        "mutable": False,
    },
}

view.annotate(
    anno_key,
    label_field="frames.detections",
    classes=["vehicle"],
    attributes=attributes,
    allow_additions=False,
    allow_deletions=False,
    allow_label_edits=False,
    allow_spatial_edits=False,
    launch_editor=True,
)
print(dataset.get_annotation_info(anno_key))

# Populate `make` attribute in CVAT

dataset.load_annotations(anno_key, cleanup=True)
dataset.delete_annotation_run(anno_key)
```
