### PR TITLE
Allow a list of task assignees for CVAT

### DIFF
--- a/docs/source/integrations/cvat.rst
+++ b/docs/source/integrations/cvat.rst
@@ -443,7 +443,9 @@ provided:
     in reduced video quality in CVAT due to size limitations on ZIP files that
     can be uploaded to CVAT
 -   **chunk_size** (*None*): the number of frames to upload per ZIP chunk
--   **task_assignee** (*None*): a username to assign the generated tasks
+-   **task_assignee** (*None*): the username to assign the generated tasks.
+    This argument can be a list of usernames when annotating videos as each
+    video is uploaded to a separate task 
 -   **job_assignees** (*None*): a list of usernames to assign jobs
 -   **job_reviewers** (*None*): a list of usernames to assign job reviews
 
@@ -1303,7 +1305,9 @@ to :meth:`annotate() <fiftyone.core.collections.SampleCollection.annotate>` to
 specify which users will be assigned to the created tasks:
 
 -   `segment_size`: the maximum number of images to include in a single job
--   `task_assignee`: a username to assign the generated tasks
+-   `task_assignee`: a username to assign the generated tasks. This argument
+    can be a list of usernames when annotating videos as each
+    video is uploaded to a separate task 
 -   `job_assignees`: a list of usernames to assign jobs
 -   `job_reviewers`: a list of usernames to assign job reviews
 

--- a/fiftyone/utils/cvat.py
+++ b/fiftyone/utils/cvat.py
@@ -3286,8 +3286,8 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
                             current_task_assignee = task_assignee
                         else:
                             task_assignee_ind = idx % len(task_assignee)
-                            current_task_assignee = [
-                                task_assignee[job_assignee_ind]
+                            current_task_assignee = task_assignee[
+                                task_assignee_ind
                             ]
 
                 task_name = "FiftyOne_%s_%s" % (

--- a/fiftyone/utils/cvat.py
+++ b/fiftyone/utils/cvat.py
@@ -3281,14 +3281,14 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
                             job_reviewers[job_reviewer_ind]
                         ]
 
-                    if task_assignee is not None:
-                        if isinstance(task_assignee, str):
-                            current_task_assignee = task_assignee
-                        else:
-                            task_assignee_ind = idx % len(task_assignee)
-                            current_task_assignee = task_assignee[
-                                task_assignee_ind
-                            ]
+                if task_assignee is not None:
+                    if isinstance(task_assignee, str):
+                        current_task_assignee = task_assignee
+                    else:
+                        task_assignee_ind = idx % len(task_assignee)
+                        current_task_assignee = task_assignee[
+                            task_assignee_ind
+                        ]
 
                 task_name = "FiftyOne_%s_%s" % (
                     samples_batch._root_dataset.name.replace(" ", "_"),

--- a/fiftyone/utils/cvat.py
+++ b/fiftyone/utils/cvat.py
@@ -2435,7 +2435,9 @@ class CVATBackendConfig(foua.AnnotationBackendConfig):
             result in reduced video quality in CVAT due to size limitations on
             ZIP files that can be uploaded to CVAT
         chunk_size (None): the number of frames to upload per ZIP chunk
-        task_assignee (None): the username to which the task(s) were assigned
+        task_assignee (None): the username(s) to which the task(s) were
+            assigned. This argument can be a list of usernames when annotating
+            videos as each video is uploaded to a separate task 
         job_assignees (None): a list of usernames to which jobs were assigned
         job_reviewers (None): a list of usernames to which job reviews were
             assigned
@@ -3263,6 +3265,7 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
 
                 current_job_assignees = job_assignees
                 current_job_reviewers = job_reviewers
+                current_task_assignee = task_assignee
                 if is_video:
                     # Videos are uploaded in multiple tasks with 1 job per task
                     # Assign the correct users for the current task
@@ -3278,6 +3281,15 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
                             job_reviewers[job_reviewer_ind]
                         ]
 
+                    if task_assignee is not None:
+                        if isinstance(task_assignee, str):
+                            current_task_assignee = task_assignee
+                        else:
+                            task_assignee_ind = idx % len(task_assignee)
+                            current_task_assignee = [
+                                task_assignee[job_assignee_ind]
+                            ]
+
                 task_name = "FiftyOne_%s_%s" % (
                     samples_batch._root_dataset.name.replace(" ", "_"),
                     label_field.replace(" ", "_"),
@@ -3289,7 +3301,7 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
                     schema=cvat_schema,
                     segment_size=segment_size,
                     image_quality=image_quality,
-                    task_assignee=task_assignee,
+                    task_assignee=current_task_assignee,
                 )
                 task_ids.append(task_id)
                 labels_task_map[label_field].append(task_id)


### PR DESCRIPTION
Resolve #1290 

When annotating videos in CVAT, each video is uploaded to a separate task (unlike images that are loaded into one task). The annotation parameter `task_assignee` allows you to specify the username to assign to the generated task. 

This PR allows `task_assignee` to accept a list of usernames that will be applied, round robin-style, to the created video tasks.

If a single string username is provided to `task_assignee`, it will be applied to all created tasks like before.

### Example

```python
import fiftyone as fo
import fiftyone.zoo as foz

dataset = foz.load_zoo_dataset("quickstart-video", max_samples=3).clone()

anno_key = "task_assignees"
results = dataset.annotate(
    anno_key,
    label_field="frames.detections",
    task_assignee=["user1", "user2"],
    launch_editor=True,
)

dataset.load_annotations(anno_key, cleanup=True)
dataset.delete_annotation_run(anno_key)
```