### PR TITLE
Apache beam I/O

### DIFF
--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -818,11 +818,6 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
         self._sample_doc_cls.add_implied_field(field_name, value)
         self._reload()
 
-    def _add_implied_sample_field_if_necessary(self, field_name, value):
-        self._add_sample_field_if_necessary(
-            field_name, **foo.get_implied_field_kwargs(value)
-        )
-
     def add_frame_field(
         self,
         field_name,
@@ -889,11 +884,6 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
 
         self._frame_doc_cls.add_implied_field(field_name, value)
         self._reload()
-
-    def _add_implied_frame_field_if_necessary(self, field_name, value):
-        self._add_frame_field_if_necessary(
-            field_name, **foo.get_implied_field_kwargs(value)
-        )
 
     def rename_sample_field(self, field_name, new_field_name):
         """Renames the sample field to the given new name.
@@ -1659,7 +1649,7 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
             _merge_samples_pipeline(
                 samples,
                 self,
-                key_field,
+                key_field=key_field,
                 skip_existing=skip_existing,
                 insert_new=insert_new,
                 fields=fields,
@@ -5086,7 +5076,7 @@ def _get_single_index_map(coll):
 def _merge_samples_python(
     dataset,
     samples,
-    key_field=None,
+    key_field="filepath",
     key_fcn=None,
     skip_existing=False,
     insert_new=True,
@@ -5097,6 +5087,18 @@ def _merge_samples_python(
     expand_schema=True,
     num_samples=None,
 ):
+    if fields is not None:
+        if etau.is_str(fields):
+            fields = [fields]
+        elif not isinstance(fields, dict):
+            fields = list(fields)
+
+    if omit_fields is not None:
+        if etau.is_str(omit_fields):
+            omit_fields = [omit_fields]
+        else:
+            omit_fields = list(omit_fields)
+
     if num_samples is None:
         try:
             num_samples = len(samples)
@@ -5201,7 +5203,7 @@ def _make_merge_samples_generator(
 def _merge_samples_pipeline(
     src_collection,
     dst_dataset,
-    key_field,
+    key_field="filepath",
     skip_existing=False,
     insert_new=True,
     fields=None,

--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -1449,7 +1449,6 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
 
         # Dynamically size batches so that they are as large as possible while
         # still achieving a nice frame rate on the progress bar
-
         target_latency = 0.2  # in seconds
         batcher = fou.DynamicBatcher(
             samples, target_latency, init_batch_size=1, max_batch_beta=2.0
@@ -1671,7 +1670,7 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
             _merge_samples_pipeline(
                 samples,
                 self,
-                key_field=key_field,
+                key_field,
                 skip_existing=skip_existing,
                 insert_new=insert_new,
                 fields=fields,
@@ -5109,18 +5108,6 @@ def _merge_samples_python(
     expand_schema=True,
     num_samples=None,
 ):
-    if fields is not None:
-        if etau.is_str(fields):
-            fields = [fields]
-        elif not isinstance(fields, dict):
-            fields = list(fields)
-
-    if omit_fields is not None:
-        if etau.is_str(omit_fields):
-            omit_fields = [omit_fields]
-        else:
-            omit_fields = list(omit_fields)
-
     if num_samples is None:
         try:
             num_samples = len(samples)
@@ -5216,7 +5203,7 @@ def _make_merge_samples_generator(
 def _merge_samples_pipeline(
     src_collection,
     dst_dataset,
-    key_field="filepath",
+    key_field,
     skip_existing=False,
     insert_new=True,
     fields=None,

--- a/fiftyone/core/odm/mixins.py
+++ b/fiftyone/core/odm/mixins.py
@@ -1090,7 +1090,15 @@ class NoDatasetMixin(object):
 
     @classmethod
     def from_dict(cls, d, extended=False):
-        return cls(**{k: _deserialize_value(v) for k, v in d.items()})
+        kwargs = {}
+        for k, v in d.items():
+            # @todo `use_db_field` hack
+            if k == "_id":
+                k = "id"
+
+            kwargs[k] = _deserialize_value(v)
+
+        return cls(**kwargs)
 
     def save(self):
         pass

--- a/fiftyone/core/odm/mixins.py
+++ b/fiftyone/core/odm/mixins.py
@@ -384,7 +384,7 @@ class DatasetMixin(object):
     @classmethod
     def add_implied_field(cls, field_name, value):
         """Adds the field to the document, if necessary, inferring the field
-        type from the provided value
+        type from the provided value.
 
         Args:
             field_name: the field name

--- a/fiftyone/core/odm/mixins.py
+++ b/fiftyone/core/odm/mixins.py
@@ -383,20 +383,20 @@ class DatasetMixin(object):
 
     @classmethod
     def add_implied_field(cls, field_name, value):
-        """Adds the field to the document, inferring the field type from the
-        provided value.
+        """Adds the field to the document, if necessary, inferring the field
+        type from the provided value
 
         Args:
             field_name: the field name
             value: the field value
         """
+        kwargs = get_implied_field_kwargs(value)
+
         # pylint: disable=no-member
         if field_name in cls._fields:
-            raise ValueError(
-                "%s field '%s' already exists" % (cls._doc_name(), field_name)
-            )
-
-        cls.add_field(field_name, **get_implied_field_kwargs(value))
+            validate_fields_match(field_name, kwargs, cls._fields[field_name])
+        else:
+            cls.add_field(field_name, **kwargs)
 
     def set_field(self, field_name, value, create=False):
         if field_name.startswith("_"):

--- a/fiftyone/core/odm/sample.py
+++ b/fiftyone/core/odm/sample.py
@@ -124,7 +124,9 @@ class NoDatasetSampleDocument(NoDatasetMixin, SerializableDocument):
     def __init__(self, **kwargs):
         filepath = os.path.abspath(os.path.expanduser(kwargs["filepath"]))
 
-        kwargs["id"] = None
+        if "id" not in kwargs:
+            kwargs["id"] = None
+
         kwargs["filepath"] = filepath
         kwargs["_rand"] = _generate_rand(filepath=filepath)
         kwargs["_media_type"] = fomm.get_media_type(filepath)

--- a/fiftyone/core/odm/sample.py
+++ b/fiftyone/core/odm/sample.py
@@ -124,9 +124,7 @@ class NoDatasetSampleDocument(NoDatasetMixin, SerializableDocument):
     def __init__(self, **kwargs):
         filepath = os.path.abspath(os.path.expanduser(kwargs["filepath"]))
 
-        if "id" not in kwargs:
-            kwargs["id"] = None
-
+        kwargs["id"] = kwargs.get("id", None)
         kwargs["filepath"] = filepath
         kwargs["_rand"] = _generate_rand(filepath=filepath)
         kwargs["_media_type"] = fomm.get_media_type(filepath)

--- a/fiftyone/utils/beam.py
+++ b/fiftyone/utils/beam.py
@@ -1,0 +1,156 @@
+"""
+`Apache Beam <https://beam.apache.org>`_ utilities.
+
+| Copyright 2017-2021, Voxel51, Inc.
+| `voxel51.com <https://voxel51.com/>`_
+|
+"""
+import multiprocessing
+import numpy as np
+
+import fiftyone.core.utils as fou
+import fiftyone.core.view as fov
+
+fou.ensure_import("apache_beam")
+
+import apache_beam as beam
+from apache_beam.options.pipeline_options import PipelineOptions
+
+
+def beam_export(
+    sample_collection, num_shards, options=None, render_kwargs=None, **kwargs
+):
+    """Exports the given sample collection in the specified number shards via
+    `Apache Beam <https://beam.apache.org>`_.
+
+    This function is a parallelized alternative to directly calling
+    :meth:`fiftyone.core.collections.SampleCollection.export`.
+
+    Example::
+
+        from apache_beam.options.pipeline_options import PipelineOptions
+        import eta.core.utils as etau
+
+        import fiftyone as fo
+        import fiftyone.utils.beam as foub
+        import fiftyone.zoo as foz
+
+        dataset = foz.load_zoo_dataset("quickstart")
+
+        options = PipelineOptions(
+            runner="direct",
+            direct_num_workers=10,
+            direct_running_mode="multi_threading",
+        )
+
+        etau.ensure_dir("/tmp/beam")
+
+        foub.beam_export(
+            dataset,
+            num_shards=10,
+            options=options,
+            dataset_type=fo.types.TFObjectDetectionDataset,
+            label_field="ground_truth",
+            tf_records_path="/tmp/beam/tf.records-%05d-of-00010",
+        )
+
+    Args:
+        sample_collection: a
+            :class:`fiftyone.core.collections.SampleCollection`
+        num_shards: the number of shards to write
+        options (None): a
+            ``apache_beam.options.pipeline_options.PipelineOptions`` that
+            configures how to run the pipeline. By default, the pipeline will
+            be run via Beam's direct runner using
+            ``min(num_shards, multiprocessing.cpu_count())`` processes
+        render_kwargs (None): a function that renders ``kwargs`` for the
+            current shard. The function should have signature
+            ``def render_kwargs(kwargs, idx) -> kwargs``, where ``idx`` in
+            ``[1, num_shards]`` is the shard index. By default, any
+            string-valued arguments that contain format patterns like ``%05d``
+            will be rendered via ``value % idx``
+        **kwargs: keyword arguments for
+            :meth:`fiftyone.core.collections.SampleCollection.export`
+    """
+    if options is None:
+        num_workers = min(num_shards, multiprocessing.cpu_count())
+        options = PipelineOptions(
+            runner="direct",
+            direct_num_workers=num_workers,
+            direct_running_mode="multi_processing",
+        )
+
+    if isinstance(sample_collection, fov.DatasetView):
+        dataset_name = sample_collection._root_dataset.name
+        view_stages = sample_collection._serialize()
+    else:
+        dataset_name = sample_collection.name
+        view_stages = None
+
+    export_batch = ExportBatch(
+        dataset_name, view_stages=view_stages, render_kwargs=render_kwargs,
+    )
+
+    n = len(sample_collection)
+    edges = [int(round(b)) for b in np.linspace(0, n, num_shards + 1)]
+
+    batches = [
+        {"idx": idx, "start": start, "stop": stop}
+        for idx, (start, stop) in enumerate(zip(edges[:-1], edges[1:]), 1)
+    ]
+
+    with beam.Pipeline(options=options) as pipeline:
+        _ = (
+            pipeline
+            | "CreateBatches" >> beam.Create(batches)
+            | "ExportBatches" >> beam.ParDo(export_batch, **kwargs)
+        )
+
+
+class ExportBatch(beam.DoFn):
+    def __init__(self, dataset_name, view_stages=None, render_kwargs=None):
+        self.dataset_name = dataset_name
+        self.view_stages = view_stages
+        self.render_kwargs = render_kwargs or self.default_render_kwargs
+        self._sample_collection = None
+
+    @staticmethod
+    def default_render_kwargs(kwargs, idx):
+        _kwargs = {}
+        for k, v in kwargs.items():
+            if isinstance(v, str):
+                try:
+                    _kwargs[k] = v % idx
+                except:
+                    _kwargs[k] = v
+            else:
+                _kwargs[k] = v
+
+        return _kwargs
+
+    def setup(self):
+        import fiftyone as fo
+        import fiftyone.core.view as fov
+
+        dataset = fo.load_dataset(self.dataset_name)
+
+        if self.view_stages:
+            sample_collection = fov.DatasetView._build(
+                dataset, self.view_stages
+            )
+        else:
+            sample_collection = dataset
+
+        self._sample_collection = sample_collection
+
+    def process(self, element, **kwargs):
+        import fiftyone as fo
+        import fiftyone.core.utils as fou
+
+        idx = element["idx"]
+        start = element["start"]
+        stop = element["stop"]
+        kwargs = self.render_kwargs(kwargs, idx)
+
+        with fou.SetAttributes(fo.config, show_progress_bars=False):
+            self._sample_collection[start:stop].export(**kwargs)

--- a/fiftyone/utils/beam.py
+++ b/fiftyone/utils/beam.py
@@ -43,8 +43,6 @@ def beam_import(
         import fiftyone as fo
         import fiftyone.utils.beam as foub
 
-        dataset = fo.Dataset()
-
         samples = range(10000)
 
         def make_sample(idx):
@@ -54,7 +52,10 @@ def beam_import(
         # Option 1: build the samples on the workers
         #
 
+        dataset = fo.Dataset()
+
         foub.beam_import(dataset, samples, parse_fcn=make_sample)
+        print(dataset)
 
         #
         # Option 2: build the samples in the main thread
@@ -63,8 +64,12 @@ def beam_import(
         # ``parse_fcn`` is not serializable
         #
 
+        dataset = fo.Dataset()
+
         samples = map(make_sample, samples)
+
         foub.beam_import(dataset, samples)
+        print(dataset)
 
     Args:
         dataset: a :class:`fiftyone.core.dataset.Dataset`
@@ -147,8 +152,8 @@ def beam_merge(
     Example::
 
         import fiftyone as fo
-        import fiftyone.zoo as foz
         import fiftyone.utils.beam as foub
+        import fiftyone.zoo as foz
 
         dataset = foz.load_zoo_dataset("quickstart").clone()
 


### PR DESCRIPTION
This PR adds some utilities that leverage [Apache Beam](https://beam.apache.org) to parallelize import, merge, and export operations:
- `beam_import()`: a parallelized alternative to `Dataset.add_samples()`
- `beam_merge()`: a parallelized alternative to `Dataset.merge_samples()`
- `beam_export()`: a parallelized alternative to `SampleCollection.export()`

For now these are just standalone utilities, but in the near future I think it could make sense to add an optional `num_workers` parameter to the main API methods that will optionally leverage Beam to accelerate the operations.

### Notes

The current implementation of `beam_export()` is only well-suited for export formats that are inherently sharded. For example, it is ideal for exporting a sharded TF record dataset, but not ideal for exporting in COCO format, since the current implementation lacks a way to "reduce" shards back into a single JSON file (if that's what the user wants). I'm pondering what, if anything, to add to the implementation to address this.

### Import example

```py

import fiftyone as fo
import fiftyone.utils.beam as foub

samples = range(10000)

def make_sample(idx):
    return fo.Sample(filepath="image%d.png" % idx, uuid=idx)

#
# Option 1: build the samples on the workers
#

dataset = fo.Dataset()

foub.beam_import(dataset, samples, parse_fcn=make_sample)
print(dataset)

#
# Option 2: build the samples in the main thread
# This is generally not preferred but may be necessary if your ``parse_fcn`` is not serializable
#

dataset = fo.Dataset()

samples = map(make_sample, samples)

foub.beam_import(dataset, samples)
print(dataset)
```

### Merge example

```py
import fiftyone as fo
import fiftyone.utils.beam as foub
import fiftyone.zoo as foz

dataset = foz.load_zoo_dataset("quickstart").clone()

samples = iter(dataset.select_fields("predictions"))

foub.beam_merge(dataset, samples, fields={"predictions": "predictions2"})

print(dataset.count("predictions.detections"))
print(dataset.count("predictions2.detections"))
```

### Export example

```py
from apache_beam.options.pipeline_options import PipelineOptions

import fiftyone as fo
import fiftyone.utils.beam as foub
import fiftyone.zoo as foz

dataset = foz.load_zoo_dataset("quickstart")

# Use multithreading instead of the default multiprocessing
options = PipelineOptions(
    runner="direct",
    direct_num_workers=10,
    direct_running_mode="multi_threading",
)

foub.beam_export(
    dataset,
    num_shards=20,
    options=options,
    dataset_type=fo.types.TFObjectDetectionDataset,
    label_field="ground_truth",
    tf_records_path="/tmp/beam/tf.records-%05d-of-00020",
)
```
