### PR TITLE
Always import keyframe markings when adding new video track annotations

### DIFF
--- a/fiftyone/utils/annotations.py
+++ b/fiftyone/utils/annotations.py
@@ -1202,6 +1202,7 @@ def _merge_labels(
     if label_info is None:
         label_info = {}
 
+    existing_field = label_info.get("existing_field", False)
     only_keyframes = label_info.get("only_keyframes", False)
     allow_additions = label_info.get("allow_additions", True)
     allow_deletions = label_info.get("allow_deletions", True)
@@ -1220,6 +1221,10 @@ def _merge_labels(
     is_video = samples.media_type == fom.VIDEO
 
     if is_video and label_type in _TRACKABLE_TYPES:
+        if not existing_field:
+            # Always include keyframe info when importing new video tracks
+            only_keyframes = True
+
         _update_tracks(samples, label_field, anno_dict, only_keyframes)
 
     id_map = results.id_map.get(label_field, {})


### PR DESCRIPTION
Small tweak to always import keyframe markings when adding new video track annotations. Previously, keyframe information would not be imported in this case, but it is better to include it if available, because it will then be easier to edit these annotations in the future.

```py
import fiftyone as fo
import fiftyone.zoo as foz

dataset = foz.load_zoo_dataset("quickstart-video").clone()
dataset.delete_frame_field("detections")

view = dataset.limit(1)

view.annotate(
    "new_test",
    label_field="frames.detections",
    label_type="detections",
    classes=["vehicle"],
    attributes={
        "type": {
            "type": "select",
            "values": ["sedan", "suv", "truck", "other"],
            "mutable": False,
        }
    },
    launch_editor=True,
)
print(dataset.get_annotation_info("new_test"))

view = dataset.load_annotation_view("new_test")
session = fo.launch_app(view=view)

# Add a track in CVAT...

dataset.load_annotations("new_test", cleanup=True)
session.refresh()

# Verify that keyframes were marked
print(dataset.count_values("frames.detections.detections.keyframe"))

view.annotate(
    "existing_test",
    label_field="frames.detections",
    launch_editor=True,
)
print(dataset.get_annotation_info("existing_test"))

# Make some edits to the track in CVAT...

dataset.load_annotations("existing_test", cleanup=True)
session.refresh()

# Verify that keyframes were properly modified
print(dataset.count_values("frames.detections.detections.keyframe"))
```
