### PR TITLE
Fix bug when annotating a track in CVAT up to the last frame

### DIFF
--- a/fiftyone/utils/cvat.py
+++ b/fiftyone/utils/cvat.py
@@ -5264,7 +5264,7 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
 
         # The shapes in the last frame in the track must be set to "outside"
         last_shape = shapes[-1]
-        if last_shape["frame"] < frame_count - 1:
+        if last_shape["frame"] < frame_count:
             new_shape = deepcopy(last_shape)
             new_shape["frame"] += 1
             new_shape["outside"] = True


### PR DESCRIPTION
The outside property was not being set properly when a track ends at the second to last frame of a video. This PR resolves that bug.

```python
import fiftyone as fo
import fiftyone.zoo as foz


dataset = foz.load_zoo_dataset("quickstart-video", max_samples=1).select_fields().clone()

sample = dataset.first()
num_frames = len(sample.frames)
for ind, frame in enumerate(sample.frames.values()):
    if ind < num_frames-1:
        det = fo.Detection(
            label="l1",
            bounding_box=[0.1,0.1,0.3,0.3],
            index=1,
            test_attr="false",
        )
        frame["detections"] = fo.Detections(detections=[det])
sample.save()

session = fo.launch_app(dataset)
anno_key = "last_frame_det"
results = dataset.annotate(
    anno_key,
    label_field="frames.detections",
    launch_editor=True,
)

input()


dataset.load_annotations(anno_key, cleanup=True)
session.refresh()
```