### PR TITLE
Fix bug when annotating and allow_additions is False

### DIFF
--- a/fiftyone/utils/annotations.py
+++ b/fiftyone/utils/annotations.py
@@ -1401,7 +1401,7 @@ def _merge_labels(
                         added_id_map[sample_id][frame_id] = label_id
                     else:
                         added_id_map[sample_id] = label_id
-            else:
+            elif image_label is not None:
                 if is_list:
                     labels = image_label[list_field]
                 else:


### PR DESCRIPTION
Setting `allow_additions` to `False` raised an error when a sample or frame is empty by default.

This example previously raised this error, but now works:
```python
import fiftyone as fo
import fiftyone.zoo as foz

# Annotate an empty sample with allow_additions False

dataset = (
    foz.load_zoo_dataset("quickstart", max_samples=2).select_fields("ground_truth")
).clone()

# Make one sample empty
sample = dataset.first()
sample.ground_truth = None
sample.save()

anno_key = "empty_test"

dataset.annotate(
    anno_key,
    label_field="ground_truth",
    allow_additions=False,
    launch_editor=True,
)

# Add a detection to the empty sample in CVAT
input()

dataset.load_annotations(anno_key)
```

```
Downloading labels from CVAT...
Download complete
Loading labels for field 'ground_truth'...
   0% |/------------------------------| 0/2 [1.4ms elapsed, ? remaining, ? samples/s]
Uncaught exception
Traceback (most recent call last):
  File "test.py", line 28, in <module>
    dataset.load_annotations(anno_key)
  File "/home/eric/work/fiftyone/fiftyone/fiftyone/core/collections.py", line 6146, in load_annotations
    **kwargs,
  File "/home/eric/work/fiftyone/fiftyone/fiftyone/utils/annotations.py", line 1029, in load_annotations
    class_attrs=class_attrs,
  File "/home/eric/work/fiftyone/fiftyone/fiftyone/utils/annotations.py", line 1406, in _merge_labels
    labels = image_label[list_field]
TypeError: 'NoneType' object is not subscriptable
```