### PR TITLE
Fixing import of FiftyOneDataset instances with run results

### DIFF
--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -4993,9 +4993,13 @@ def _clone_runs(dst_dataset, src_doc):
     for anno_key, run_doc in src_doc.annotation_runs.items():
         _run_doc = deepcopy(run_doc)
         dst_doc.annotation_runs[anno_key] = _run_doc
-        results = foan.AnnotationMethod.load_run_results(dst_dataset, anno_key)
+        results = foan.AnnotationMethod.load_run_results(
+            dst_dataset, anno_key, cache=False
+        )
         _run_doc.results = None
-        foan.AnnotationMethod.save_run_results(dst_dataset, anno_key, results)
+        foan.AnnotationMethod.save_run_results(
+            dst_dataset, anno_key, results, cache=False
+        )
 
     #
     # Clone brain results
@@ -5008,9 +5012,13 @@ def _clone_runs(dst_dataset, src_doc):
     for brain_key, run_doc in src_doc.brain_methods.items():
         _run_doc = deepcopy(run_doc)
         dst_doc.brain_methods[brain_key] = _run_doc
-        results = fob.BrainMethod.load_run_results(dst_dataset, brain_key)
+        results = fob.BrainMethod.load_run_results(
+            dst_dataset, brain_key, cache=False
+        )
         _run_doc.results = None
-        fob.BrainMethod.save_run_results(dst_dataset, brain_key, results)
+        fob.BrainMethod.save_run_results(
+            dst_dataset, brain_key, results, cache=False
+        )
 
     #
     # Clone evaluation results
@@ -5023,9 +5031,13 @@ def _clone_runs(dst_dataset, src_doc):
     for eval_key, run_doc in src_doc.evaluations.items():
         _run_doc = deepcopy(run_doc)
         dst_doc.evaluations[eval_key] = _run_doc
-        results = foe.EvaluationMethod.load_run_results(dst_dataset, eval_key)
+        results = foe.EvaluationMethod.load_run_results(
+            dst_dataset, eval_key, cache=False
+        )
         _run_doc.results = None
-        foe.EvaluationMethod.save_run_results(dst_dataset, eval_key, results)
+        foe.EvaluationMethod.save_run_results(
+            dst_dataset, eval_key, results, cache=False
+        )
 
     dst_doc.save()
 

--- a/fiftyone/core/runs.py
+++ b/fiftyone/core/runs.py
@@ -385,7 +385,9 @@ class Run(Configurable):
         dataset._doc.save()
 
     @classmethod
-    def save_run_results(cls, samples, key, run_results, overwrite=True):
+    def save_run_results(
+        cls, samples, key, run_results, overwrite=True, cache=True
+    ):
         """Saves the run results on the collection.
 
         Args:
@@ -394,6 +396,7 @@ class Run(Configurable):
             run_results: a :class:`RunResults`, or None
             overwrite (True): whether to overwrite an existing result with the
                 same key
+            cache (True): whether to cache the results on the collection
         """
         if key is None:
             return
@@ -420,18 +423,20 @@ class Run(Configurable):
             run_doc.results.put(results_bytes, content_type="application/json")
 
         # Cache the results for future use in this session
-        results_cache = getattr(dataset, cls._results_cache_field())
-        results_cache[key] = run_results
+        if cache:
+            results_cache = getattr(dataset, cls._results_cache_field())
+            results_cache[key] = run_results
 
         dataset._doc.save()
 
     @classmethod
-    def load_run_results(cls, samples, key):
+    def load_run_results(cls, samples, key, cache=True):
         """Loads the :class:`RunResults` for the given key on the collection.
 
         Args:
             samples: a :class:`fiftyone.core.collections.SampleCollection`
             key: a run key
+            cache (True): whether to cache the results on the collection
 
         Returns:
             a :class:`RunResults`, or None if the run did not save results
@@ -479,7 +484,8 @@ class Run(Configurable):
             ) from e
 
         # Cache the results for future use in this session
-        results_cache[key] = run_results
+        if cache:
+            results_cache[key] = run_results
 
         return run_results
 

--- a/fiftyone/utils/data/importers.py
+++ b/fiftyone/utils/data/importers.py
@@ -1638,8 +1638,11 @@ def _import_run_results(dataset, run_dir, run_cls, keys=None):
     for key in keys:
         json_path = os.path.join(run_dir, key + ".json")
         if os.path.exists(json_path):
-            results = fors.RunResults.from_json(json_path, dataset)
-            run_cls.save_run_results(dataset, key, results)
+            view = run_cls.load_run_view(dataset, key)
+            run_info = run_cls.get_run_info(dataset, key)
+            config = run_info.config
+            results = fors.RunResults.from_json(json_path, view, config)
+            run_cls.save_run_results(dataset, key, results, cache=False)
 
 
 class ImageDirectoryImporter(UnlabeledImageDatasetImporter):

--- a/tests/unittests/import_export_tests.py
+++ b/tests/unittests/import_export_tests.py
@@ -1559,6 +1559,35 @@ class MultitaskImageDatasetTests(ImageDatasetTests):
             dataset2.count("predictions.detections"),
         )
 
+        # Test import/export of run results
+
+        dataset.clone_sample_field("predictions", "ground_truth")
+
+        view = dataset.limit(2)
+        view.evaluate_detections(
+            "predictions", gt_field="ground_truth", eval_key="test"
+        )
+
+        export_dir = self._new_dir()
+
+        dataset.export(
+            export_dir=export_dir, dataset_type=fo.types.FiftyOneDataset,
+        )
+
+        dataset2 = fo.Dataset.from_dir(
+            dataset_dir=export_dir, dataset_type=fo.types.FiftyOneDataset,
+        )
+
+        self.assertTrue("test" in dataset.list_evaluations())
+        self.assertTrue("test" in dataset2.list_evaluations())
+
+        view2 = dataset2.load_evaluation_view("test")
+        self.assertEqual(len(view), len(view2))
+
+        info = dataset.get_evaluation_info("test")
+        info2 = dataset2.get_evaluation_info("test")
+        self.assertEqual(info.key, info2.key)
+
 
 class VideoDatasetTests(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
Resolves #1385 

```py
import fiftyone as fo
import fiftyone.zoo as foz

dataset = foz.load_zoo_dataset("quickstart").clone()

view = dataset.limit(1)
view.evaluate_detections("predictions", gt_field="ground_truth", eval_key="test")
view.annotate("test", label_field="ground_truth")

dataset.export(
    export_dir="/tmp/quickstart",
    dataset_type=fo.types.FiftyOneDataset,
    overwrite=True,
)

# This would previously fail, but now works
dataset2 = fo.Dataset.from_dir(
    dataset_dir="/tmp/quickstart",
    dataset_type=fo.types.FiftyOneDataset,
)

assert dataset.list_evaluations() == dataset2.list_evaluations()
assert dataset.list_annotation_runs() == dataset2.list_annotation_runs()
```
