### PR TITLE
Track label IDs using CVAT server IDs

### DIFF
--- a/docs/source/integrations/cvat.rst
+++ b/docs/source/integrations/cvat.rst
@@ -680,19 +680,6 @@ take additional values:
 Note that only scalar-valued label attributes are supported. Other attribute
 types like lists, dictionaries, and arrays will be omitted.
 
-.. warning::
-
-    When uploading existing labels to CVAT, the `id` of the labels in FiftyOne
-    are stored in a `label_id` attribute of the CVAT shapes.
-
-    **IMPORTANT**: `label_id` is the single-source of provenance for a label.
-    If this attribute is modified or deleted in CVAT, then FiftyOne will not be
-    able to merge the annotation with its existing |Label| instance when the
-    annotations are loaded back into FiftyOne. Instead, the existing label will
-    be deleted and a new |Label| will be created. This can result in data loss
-    if you sent only a subset of the label's attributes to CVAT. See
-    :ref:`this section <cvat-limitations>` for more details.
-
 .. _cvat-restricting-edits:
 
 Restricting additions, deletions, and edits
@@ -800,13 +787,12 @@ provide support for these settings natively.
 
     **IMPORTANT**: When uploading existing labels to CVAT, the `id` of the
     labels in FiftyOne are stored in a `label_id` attribute of the CVAT shapes.
-    This `label_id` is the single-source of provenance for a label, and thus,
-    if it is modified or deleted in CVAT, then FiftyOne cannot merge the
-    annotation with its existing |Label| instance; it must instead delete the
-    existing label and create a new |Label| with the shape's contents. In such
-    cases, if `allow_additions` and/or `allow_deletions` were set to `False` on
-    the annotation schema, this can result in CVAT edits being rejected.
-    See :ref:`this section <cvat-limitations>` for more details.
+    If a `label_id` is modified in CVAT, then FiftyOne may not be able to merge
+    the annotation with its existing |Label| instance; in such cases, it must
+    instead delete the existing label and create a new |Label| with the shape's
+    contents. In such cases, if `allow_additions` and/or `allow_deletions` were
+    set to `False` on the annotation schema, this can result in CVAT edits
+    being rejected. See :ref:`this section <cvat-limitations>` for details.
 
 .. _cvat-labeling-videos:
 
@@ -875,28 +861,40 @@ will be uploaded to CVAT.
     When uploading existing labels to CVAT, the `id` of the labels in FiftyOne
     are stored in a `label_id` attribute of the CVAT shapes.
 
-    **IMPORTANT**: `label_id` is the single-source of provenance for a label.
-    If this attribute is modified or deleted in CVAT, then FiftyOne will not be
-    able to merge the annotation with its existing |Label| instance when the
-    annotations are loaded back into FiftyOne. Instead, the existing label will
-    be deleted and a new |Label| will be created. This can result in data loss
-    when splitting or merging video tracks in CVAT. See
-    :ref:`this section <cvat-limitations>` for more details.
+    **IMPORTANT**:  If a `label_id` is modified in CVAT, then FiftyOne may not
+    be able to merge the annotation with its existing |Label| instance; in such
+    cases, it must instead delete the existing label and create a new |Label|
+    with the shape's contents. See :ref:`this section <cvat-limitations>` for
+    details.
 
 .. _cvat-limitations:
 
 CVAT limitations
 ----------------
 
-When uploading existing labels to CVAT, the `id` of the labels in FiftyOne are
-stored in a `label_id` attribute of the CVAT shapes. This `label_id` is the
-single-source of provenance for a label, and thus, if it is modified or deleted
-in CVAT, then FiftyOne cannot merge the annotation with its existing |Label|
-instance; it must instead delete the existing label and create a new |Label|
-with the shape's contents.
+When uploading existing labels to CVAT, FiftyOne uses two sources of provenance
+to associate |Label| instances in FiftyOne with their corresponding CVAT
+shapes:
 
-Unfortunately, CVAT automatically clears/edits all attributes of a shape,
-including the `label_id` attribute, in the following cases:
+-   The `id` of each |Label| is stored in a `label_id` attribute of the CVAT
+    shape. When importing annotations from CVAT back into FiftyOne, if the
+    `label_id` of a shape matches the ID of a label that was included in the
+    annotation run, the shape will be merged into the existing |Label|
+
+-   FiftyOne also maintains a mapping between |Label| IDs and the internal
+    CVAT shape IDs that are created when the CVAT tasks are created. If, during
+    download, a CVAT shape whose `label_id` has been deleted or otherwise
+    modified and doesn't match an existing label ID **but** has a recognized
+    CVAT ID is encountered, this shape will be merged into the existing |Label|
+
+Unfortunately,
+`CVAT does not guarantee <https://github.com/openvinotoolkit/cvat/issues/893#issuecomment-578020576>`_
+that its internal IDs are immutable. Thus, if both the `label_id` attribute and
+(unknown to the user) the internal CVAT ID of a shape are both modified,
+merging the shape with its source |Label| is impossible.
+
+CVAT automatically clears/edits all attributes of a shape, including the
+`label_id` attribute, in the following cases:
 
 -   When using a label schema with
     :ref:`per-class attributes <cvat-label-schema>`, all attributes of a shape
@@ -934,7 +932,7 @@ are:
     of their attributes to CVAT,
     :ref:`restricting label deletions <cvat-restricting-edits>` by setting
     `allow_deletions=False` provides a helpful guarantee that no labels will be
-    deleted if `label_id` snafus occur in CVAT.
+    deleted if label provenance snafus occur in CVAT.
 
 .. note::
 
@@ -1206,13 +1204,11 @@ can be used to annotate new classes and/or attributes:
     When uploading existing labels to CVAT, the `id` of the labels in FiftyOne
     are stored in a `label_id` attribute of the CVAT shapes.
 
-    **IMPORTANT**: `label_id` is the single-source of provenance for a label.
-    If this attribute is modified or deleted in CVAT, then FiftyOne will not be
-    able to merge the annotation with its existing |Label| instance when the
-    annotations are loaded back into FiftyOne. Instead, the existing label will
-    be deleted and a new |Label| will be created. This can result in data loss
-    if you sent only a subset of the label's attributes to CVAT. See
-    :ref:`this section <cvat-limitations>` for more details.
+    **IMPORTANT**:  If a `label_id` is modified in CVAT, then FiftyOne may not
+    be able to merge the annotation with its existing |Label| instance; in such
+    cases, it must instead delete the existing label and create a new |Label|
+    with the shape's contents. See :ref:`this section <cvat-limitations>` for
+    details.
 
 Restricting label edits
 -----------------------
@@ -1334,13 +1330,12 @@ attribute be populated without allowing edits to the vehicle's `type`:
 
     **IMPORTANT**: When uploading existing labels to CVAT, the `id` of the
     labels in FiftyOne are stored in a `label_id` attribute of the CVAT shapes.
-    This `label_id` is the single-source of provenance for a label, and thus,
-    if it is modified or deleted in CVAT, then FiftyOne cannot merge the
-    annotation with its existing |Label| instance; it must instead delete the
-    existing label and create a new |Label| with the shape's contents. In such
-    cases, if `allow_additions` and/or `allow_deletions` were set to `False` on
-    the annotation schema, this can result in CVAT edits being rejected.
-    See :ref:`this section <cvat-limitations>` for more details.
+    If a `label_id` is modified in CVAT, then FiftyOne may not be able to merge
+    the annotation with its existing |Label| instance; it must instead delete
+    the existing label and create a new |Label| with the shape's contents. In
+    such cases, if `allow_additions` and/or `allow_deletions` were set to
+    `False` on the annotation schema, this can result in CVAT edits being
+    rejected. See :ref:`this section <cvat-limitations>` for details.
 
 Annotating multiple fields
 --------------------------
@@ -1940,13 +1935,11 @@ every 10th frame as a keyframe to provide a better editing experience in CVAT:
     When uploading existing labels to CVAT, the `id` of the labels in FiftyOne
     are stored in a `label_id` attribute of the CVAT shapes.
 
-    **IMPORTANT**: `label_id` is the single-source of provenance for a label.
-    If this attribute is modified or deleted in CVAT, then FiftyOne will not be
-    able to merge the annotation with its existing |Label| instance when the
-    annotations are loaded back into FiftyOne. Instead, the existing label will
-    be deleted and a new |Label| will be created. This can result in data loss
-    when splitting or merging video tracks in CVAT. See
-    :ref:`this section <cvat-limitations>` for more details.
+    **IMPORTANT**:  If a `label_id` is modified in CVAT, then FiftyOne may not
+    be able to merge the annotation with its existing |Label| instance; in such
+    cases, it must instead delete the existing label and create a new |Label|
+    with the shape's contents. See :ref:`this section <cvat-limitations>` for
+    details.
 
 .. _cvat-utils:
 

--- a/docs/source/integrations/cvat.rst
+++ b/docs/source/integrations/cvat.rst
@@ -788,11 +788,11 @@ provide support for these settings natively.
     **IMPORTANT**: When uploading existing labels to CVAT, the `id` of the
     labels in FiftyOne are stored in a `label_id` attribute of the CVAT shapes.
     If a `label_id` is modified in CVAT, then FiftyOne may not be able to merge
-    the annotation with its existing |Label| instance; in such cases, it must
-    instead delete the existing label and create a new |Label| with the shape's
-    contents. In such cases, if `allow_additions` and/or `allow_deletions` were
-    set to `False` on the annotation schema, this can result in CVAT edits
-    being rejected. See :ref:`this section <cvat-limitations>` for details.
+    the annotation with its existing |Label| instance; it must instead delete
+    the existing label and create a new |Label| with the shape's contents. In
+    such cases, if `allow_additions` and/or `allow_deletions` were set to
+    `False` on the annotation schema, this can result in CVAT edits being
+    rejected. See :ref:`this section <cvat-limitations>` for details.
 
 .. _cvat-labeling-videos:
 
@@ -884,8 +884,9 @@ shapes:
 -   FiftyOne also maintains a mapping between |Label| IDs and the internal
     CVAT shape IDs that are created when the CVAT tasks are created. If, during
     download, a CVAT shape whose `label_id` has been deleted or otherwise
-    modified and doesn't match an existing label ID **but** has a recognized
-    CVAT ID is encountered, this shape will be merged into the existing |Label|
+    modified and doesn't match an existing label ID *but does have* a
+    recognized CVAT ID is encountered, this shape will be merged into the
+    existing |Label|
 
 Unfortunately,
 `CVAT does not guarantee <https://github.com/openvinotoolkit/cvat/issues/893#issuecomment-578020576>`_

--- a/fiftyone/utils/cvat.py
+++ b/fiftyone/utils/cvat.py
@@ -3621,7 +3621,7 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
                     frame_id_map[task_id],
                     label_type,
                     _id_map,
-                    server_id_map,
+                    server_id_map["tags"],
                     class_map,
                     attr_id_map,
                     frames,
@@ -3638,7 +3638,7 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
                     frame_id_map[task_id],
                     label_type,
                     _id_map,
-                    server_id_map,
+                    server_id_map["shapes"],
                     class_map,
                     attr_id_map,
                     frames,
@@ -3664,7 +3664,7 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
                         frame_id_map[task_id],
                         label_type,
                         _id_map,
-                        server_id_map,
+                        server_id_map["tracks"],
                         class_map,
                         attr_id_map,
                         frames,
@@ -3955,7 +3955,6 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
         # Create mapping from CVAT server ID to FiftyOne ObjectId for each
         # label
         server_id_map = {}
-        dup_ids = []
         types = ["shapes", "tags", "tracks"]
         label_id_map = {}
         for class_id, class_attr_map in attr_id_map.items():
@@ -3966,25 +3965,15 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
         for anno_type, anno_list in anno_resp.items():
             if anno_type not in types:
                 continue
-
+            type_id_map = {}
             for anno in anno_list:
                 server_id = anno["id"]
                 class_id = anno["label_id"]
                 for attr in anno["attributes"]:
                     if attr["spec_id"] == label_id_map[class_id]:
-                        value = attr["value"]
-                        if server_id in server_id_map:
-                            logger.warning(
-                                "Found duplicate server_id `%d` for label ids "
-                                "`%s` and `%s`"
-                                % (server_id, value, server_id_map[server_id])
-                            )
-                            dup_ids.append(server_id)
-                        else:
-                            server_id_map[server_id] = value
+                        type_id_map[server_id] = attr["value"]
 
-        for dup_id in dup_ids:
-            server_id_map.pop(dup_id)
+            server_id_map[anno_type] = type_id_map
 
         return server_id_map
 

--- a/fiftyone/utils/cvat.py
+++ b/fiftyone/utils/cvat.py
@@ -16,6 +16,7 @@ import warnings
 import webbrowser
 
 from bson import ObjectId
+from bson.errors import InvalidId
 import jinja2
 import numpy as np
 import requests
@@ -5421,7 +5422,7 @@ class CVATLabel(object):
     def _attempt_assign_id(self, label_id):
         try:
             self._id = ObjectId(label_id)
-        except:
+        except InvalidId:
             pass
 
     def _set_attributes(self, label):

--- a/fiftyone/utils/cvat.py
+++ b/fiftyone/utils/cvat.py
@@ -3957,10 +3957,11 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
         server_id_map = {}
         dup_ids = []
         types = ["shapes", "tags", "tracks"]
-        attr_id_map_rev = {}
+        label_id_map = {}
         for class_id, class_attr_map in attr_id_map.items():
-            class_attr_map_rev = {i: n for n, i in class_attr_map.items()}
-            attr_id_map_rev[class_id] = class_attr_map_rev
+            for attr_name, attr_id in class_attr_map.items():
+                if attr_name == "label_id":
+                    label_id_map[class_id] = attr_id
 
         for anno_type, anno_list in anno_resp.items():
             if anno_type not in types:
@@ -3970,10 +3971,8 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
                 server_id = anno["id"]
                 class_id = anno["label_id"]
                 for attr in anno["attributes"]:
-                    spec_id = attr["spec_id"]
-                    value = attr["value"]
-                    attr_name = attr_id_map_rev[class_id][spec_id]
-                    if attr_name == "label_id":
+                    if attr["spec_id"] == label_id_map[class_id]:
+                        value = attr["value"]
                         if server_id in server_id_map:
                             logger.warning(
                                 "Found duplicate server_id `%d` for label ids "

--- a/fiftyone/utils/cvat.py
+++ b/fiftyone/utils/cvat.py
@@ -5415,7 +5415,8 @@ class CVATLabel(object):
 
         if self._id is None:
             label_id = server_id_map.get(server_id, None)
-            self._attempt_assign_id(label_id)
+            if label_id is not None:
+                self._attempt_assign_id(label_id)
 
     def _attempt_assign_id(self, label_id):
         try:

--- a/fiftyone/utils/cvat.py
+++ b/fiftyone/utils/cvat.py
@@ -5410,14 +5410,18 @@ class CVATLabel(object):
 
         # Parse label ID
         label_id = self.attributes.pop("label_id", None)
-        if label_id is None:
-            label_id = server_id_map.get(server_id, None)
-
         if label_id is not None:
-            try:
-                self._id = ObjectId(label_id)
-            except:
-                pass
+            self._attempt_assign_id(label_id)
+
+        if self._id is None:
+            label_id = server_id_map.get(server_id, None)
+            self._attempt_assign_id(label_id)
+
+    def _attempt_assign_id(self, label_id):
+        try:
+            self._id = ObjectId(label_id)
+        except:
+            pass
 
     def _set_attributes(self, label):
         if self._id is not None:

--- a/fiftyone/utils/cvat.py
+++ b/fiftyone/utils/cvat.py
@@ -2848,7 +2848,7 @@ class CVATAnnotationResults(foua.AnnotationResults):
             samples,
             config,
             d["id_map"],
-            d.get("server_id_map", {}),
+            d.get("server_id_map", {"tags": {}, "shapes": {}, "tracks": {}}),
             d.get("project_ids", []),
             d["task_ids"],
             job_ids,
@@ -3622,7 +3622,7 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
                     frame_id_map[task_id],
                     label_type,
                     _id_map,
-                    server_id_map["tags"],
+                    server_id_map.get("tags", {}),
                     class_map,
                     attr_id_map,
                     frames,
@@ -3639,7 +3639,7 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
                     frame_id_map[task_id],
                     label_type,
                     _id_map,
-                    server_id_map["shapes"],
+                    server_id_map.get("shapes", {}),
                     class_map,
                     attr_id_map,
                     frames,
@@ -3665,7 +3665,7 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
                         frame_id_map[task_id],
                         label_type,
                         _id_map,
-                        server_id_map["tracks"],
+                        server_id_map.get("tracks", {}),
                         class_map,
                         attr_id_map,
                         frames,
@@ -3955,8 +3955,7 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
     def _create_server_id_map(self, anno_resp, attr_id_map):
         # Create mapping from CVAT server ID to FiftyOne ObjectId for each
         # label
-        server_id_map = {}
-        types = ["shapes", "tags", "tracks"]
+        server_id_map = {"tags": {}, "shapes": {}, "tracks": {}}
         label_id_map = {}
         for class_id, class_attr_map in attr_id_map.items():
             for attr_name, attr_id in class_attr_map.items():
@@ -3964,17 +3963,14 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
                     label_id_map[class_id] = attr_id
 
         for anno_type, anno_list in anno_resp.items():
-            if anno_type not in types:
+            if anno_type not in server_id_map:
                 continue
-            type_id_map = {}
             for anno in anno_list:
                 server_id = anno["id"]
                 class_id = anno["label_id"]
                 for attr in anno["attributes"]:
                     if attr["spec_id"] == label_id_map[class_id]:
-                        type_id_map[server_id] = attr["value"]
-
-            server_id_map[anno_type] = type_id_map
+                        server_id_map[anno_type][server_id] = attr["value"]
 
         return server_id_map
 

--- a/fiftyone/utils/cvat.py
+++ b/fiftyone/utils/cvat.py
@@ -2847,7 +2847,7 @@ class CVATAnnotationResults(foua.AnnotationResults):
             samples,
             config,
             d["id_map"],
-            d["server_id_map"],
+            d.get("server_id_map", {}),
             d.get("project_ids", []),
             d["task_ids"],
             job_ids,
@@ -3947,11 +3947,11 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
             num_uploaded_tags = len(anno_resp["tags"])
             num_uploaded_tracks = len(anno_resp["tracks"])
 
-        server_id_map = self._map_cvat_server_id(anno_resp, attr_id_map)
+        server_id_map = self._create_server_id_map(anno_resp, attr_id_map)
 
         return server_id_map
 
-    def _map_cvat_server_id(self, anno_resp, attr_id_map):
+    def _create_server_id_map(self, anno_resp, attr_id_map):
         # Create mapping from CVAT server ID to FiftyOne ObjectId for each
         # label
         server_id_map = {}


### PR DESCRIPTION
Labels IDs must be tracked when annotating existing labels in CVAT so that the annotations can be merged back into FiftyOne properly. Previously, the `label_id` of each label was only tracked through a text attribute. This raises issues where the `label_id` attribute can easily be erased when:
1) The class of a label is changed
2) An annotator accidentally modifies the `label_id` attribute

Internally, CVAT stores it's own unique ID for each label. However, this ID was not used in the original implementation of this integration since the CVAT server ID is [subject to change](https://github.com/openvinotoolkit/cvat/issues/893#issuecomment-578020576). 

This PR adds support for tracking the CVAT server ID in addition to the `label_id` attribute in order to add redundancy to the tracking of label IDs. 

It should be noted that it is still entirely possible that the `label_id` attribute is changed and the server ID of the label gets changed resulting in a label getting overwritten when loading annotations.

### Example

```python
import fiftyone as fo
import fiftyone.zoo as foz

dataset = foz.load_zoo_dataset("quickstart", max_samples=5).clone()

anno_key = "server_id_task"
label_schema = {
    "ground_truth": {
        "attributes": {
            "iscrowd": {
                "type": "text",
            }
        }
    }
}
results = dataset.annotate(
    anno_key,
    label_schema=label_schema,
    launch_editor=True,
)

# In CVAT, change the class of one object and save
# (this erases the `label_id`)

session = fo.launch_app(dataset)
dataset.load_annotations(anno_key, cleanup=True)
session.refresh()
```

Previously, this example would have loaded the modified detection as a new label, removing additional attributes like `area` that were not loaded into CVAT. This PR now uses the backup server ID mapping to access the label ID and merge the modified label properly.