### PR TITLE
[BUG] Fix bug when annotating new fields in CVAT

### DIFF
--- a/fiftyone/utils/cvat.py
+++ b/fiftyone/utils/cvat.py
@@ -3949,6 +3949,7 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
         num_uploaded_shapes = 0
         num_uploaded_tags = 0
         num_uploaded_tracks = 0
+        anno_resp = {}
         while (
             num_uploaded_shapes != num_shapes
             or num_uploaded_tags != num_tags


### PR DESCRIPTION
This PR fixes a bug preventing the `server_id_map` from being created when annotating a new label field in CVAT.

#### Example
This now works:

```python
import fiftyone as fo
import fiftyone.zoo as foz

dataset = foz.load_zoo_dataset("quickstart", max_samples=5).clone()

# Add classification

anno_key = "new_field"
results = dataset.annotate(
    anno_key,
    label_field="new_field",
    label_type="detections",
    classes=["test"],
    launch_editor=True,
)

# Annotate in CVAT

session = fo.launch_app(dataset)
dataset.load_annotations(anno_key, cleanup=True)
session.refresh()
```