### PR TITLE
Fix bug when annotating videos in CVAT with None label field

### DIFF
--- a/fiftyone/utils/annotations.py
+++ b/fiftyone/utils/annotations.py
@@ -1097,7 +1097,11 @@ def _prompt_field(samples, label_type, label_field, label_schema):
     if label_type != "scalar":
         fo_label_type = _LABEL_TYPES_MAP[label_type]
 
-    _, is_frame_field = samples._handle_frame_field(label_field)
+    if label_field is not None:
+        _, is_frame_field = samples._handle_frame_field(label_field)
+    else:
+        is_frame_field = samples.media_type == fom.VIDEO
+
     if is_frame_field:
         schema = samples.get_frame_field_schema()
     else:


### PR DESCRIPTION
When uploading to an existing project in CVAT, you can let the `label_field` and `label_schema` parameters be `None` so any annotations that are made will prompt a new label field upon calling `samples.load_annotations()`.

This PR fixes a bug in this workflow when using video dataset. Previously, an error was raised by the call to `samples._handle_frame_field(lable_field)` when `label_field` is `None`. This PR assumes that all annotations loaded into a video dataset are frame-level labels when `label_field` is `None`.

### Example
This now works:
```python

import fiftyone as fo
import fiftyone.zoo as foz

dataset = foz.load_zoo_dataset("quickstart-video", max_samples=2).clone()

anno_key = "anno_none"
project_name="test_none_label_field"
results = dataset.annotate(
    anno_key,
    label_field="frames.detections",
    project_name=project_name,
)

# Upload to existing project
view = dataset.take(1)

anno_key_2= "anno_none_2"
results = view.annotate(
    anno_key_2,
    project_name=project_name,
    launch_editor=True,
)

# Add annotations in CVAT

dataset.load_annotations(anno_key_2, cleanup=True)
```