### PR TITLE
bug: gcsfuse command

### DIFF
--- a/docs/source/environments/index.rst
+++ b/docs/source/environments/index.rst
@@ -500,7 +500,7 @@ to do this:
 .. code-block:: shell
 
     # On remote machine
-    gcsfuse my-bucket /path/to/mount --implicit-dirs
+    gcsfuse --implicit-dirs my-bucket /path/to/mount
 
 **Step 4**
 


### PR DESCRIPTION
The `gcsfuse` command didn't work for me.

The help says:
```
USAGE:
   gcsfuse [global options] [bucket] mountpoint
```

Reordering the arguments the command worked.

## What changes are proposed in this pull request?

(Please fill in changes proposed in this fix)

## How is this patch tested? If it is not, please explain why.

(Details)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
