### PR TITLE
[Server] Handle `None` when guessing mime type

### DIFF
--- a/fiftyone/server/utils.py
+++ b/fiftyone/server/utils.py
@@ -127,7 +127,7 @@ def read_metadata(filepath, metadata=None):
         dict
     """
     mimetype, _ = mimetypes.guess_type(filepath)
-    if mimetype.startswith("video/"):
+    if mimetype and mimetype.startswith("video/"):
         if metadata:
             width = metadata.get("frame_width", None)
             height = metadata.get("frame_height", None)


### PR DESCRIPTION
Resolves #1399

```py
import fiftyone as fo

sample = fo.Sample(filepath="/path/to/img")
dataset = fo.Dataset()
dataset.add_sample(sample)

session = fo.Session(sample)
```

In the case of images, the App will work as images are the default, but there is an expectation of properly named media files (with extensions) to distinguish between videos and images in both the Python API and App...