### PR TITLE
Fixed model oom

### DIFF
--- a/fiftyone/utils/torch.py
+++ b/fiftyone/utils/torch.py
@@ -502,6 +502,7 @@ class MinResize(object):
         size = (int(round(alpha * h)), int(round(alpha * w)))
         return F.resize(pil_image_or_tensor, size, **self._kwargs)
 
+    
 class MaxResize(object):
     """Transform that resizes the PIL image or torch Tensor, if necessary, so
     that its maximum dimensions do not cause memory overflow.

--- a/fiftyone/utils/torch.py
+++ b/fiftyone/utils/torch.py
@@ -114,6 +114,12 @@ class TorchImageModelConfig(foc.Config):
         image_min_dim (None): resize input images during preprocessing, if
             necessary, so that the smaller image dimension is at least this
             value
+        image_max_size (None): resize the input images during preprocessing, if
+            necessary to prevent OOM, so that the image dimensions are at 
+            most this ``(width, height)``
+        image_max_dim (None): resize input images during preprocessing, if
+            necessary, so that the largest image dimension is at most this
+            value to prevent out of memory
         image_size (None): a ``(width, height)`` to which to resize the input
             images during preprocessing
         image_dim (None): resize the smaller input dimension to this value
@@ -156,10 +162,17 @@ class TorchImageModelConfig(foc.Config):
         self.image_min_dim = self.parse_number(
             d, "image_min_dim", default=None
         )
+        self.image_max_size = self.parse_array(
+            d, "image_max_size", default=None
+        )
+        self.image_max_dim = self.parse_number(
+            d, "image_max_dim", default=None
+        )
         self.image_size = self.parse_array(d, "image_size", default=None)
         self.image_dim = self.parse_number(d, "image_dim", default=None)
         self.image_mean = self.parse_array(d, "image_mean", default=None)
         self.image_std = self.parse_array(d, "image_std", default=None)
+        
         self.embeddings_layer = self.parse_string(
             d, "embeddings_layer", default=None
         )
@@ -386,6 +399,11 @@ class TorchImageModel(
         elif config.image_dim:
             transforms.append(torchvision.transforms.Resize(config.image_dim))
 
+        if config.image_max_size:
+            transforms.append(MaxResize(config.image_max_size))
+        elif config.image_max_dim:
+            transforms.append(MinResize(config.image_max_dim))
+        
         # Converts PIL/numpy (HWC) to Torch tensor (CHW) in [0, 1]
         transforms.append(torchvision.transforms.ToTensor())
 
@@ -482,6 +500,43 @@ class MinResize(object):
             return pil_image_or_tensor
 
         alpha = max(minh / h, minw / w)
+        size = (int(round(alpha * h)), int(round(alpha * w)))
+        return F.resize(pil_image_or_tensor, size, **self._kwargs)
+
+class MaxResize(object):
+    """Transform that resizes the PIL image or torch Tensor, if necessary, so
+    that its maximum dimensions do not cause memory overflow.
+
+    Args:
+        max_output_size: Desired maximum output dimensions. Can either be a
+            ``(max_height, max_width)`` tuple or a single ``max_dim``
+        interpolation (None): Optional interpolation mode. Passed directly to
+            :func:`torchvision:torchvision.transforms.functional.resize`
+    """
+
+    def __init__(self, max_output_size, interpolation=None):
+        if isinstance(max_output_size, int):
+            max_output_size = (max_output_size, max_output_size)
+
+        self.max_output_size = max_output_size
+        self.interpolation = interpolation
+
+        self._kwargs = {}
+        if interpolation is not None:
+            self._kwargs["interpolation"] = interpolation
+
+    def __call__(self, pil_image_or_tensor):
+        if isinstance(pil_image_or_tensor, torch.Tensor):
+            h, w = list(pil_image_or_tensor.size())[-2:]
+        else:
+            w, h = pil_image_or_tensor.size
+
+        maxh, maxw = self.max_output_size
+        
+        if h <= maxh and w <= maxw:
+            return pil_image_or_tensor
+
+        alpha = min(maxh / h, maxw / w)
         size = (int(round(alpha * h)), int(round(alpha * w)))
         return F.resize(pil_image_or_tensor, size, **self._kwargs)
 

--- a/fiftyone/utils/torch.py
+++ b/fiftyone/utils/torch.py
@@ -114,12 +114,11 @@ class TorchImageModelConfig(foc.Config):
         image_min_dim (None): resize input images during preprocessing, if
             necessary, so that the smaller image dimension is at least this
             value
-        image_max_size (None): resize the input images during preprocessing, if
-            necessary to prevent OOM, so that the image dimensions are at 
-            most this ``(width, height)``
+        image_max_size (None): resize the input images during preprocessing so 
+            that the image dimensions are at most this ``(width, height)``
         image_max_dim (None): resize input images during preprocessing, if
             necessary, so that the largest image dimension is at most this
-            value to prevent out of memory
+            value.
         image_size (None): a ``(width, height)`` to which to resize the input
             images during preprocessing
         image_dim (None): resize the smaller input dimension to this value
@@ -402,7 +401,7 @@ class TorchImageModel(
         if config.image_max_size:
             transforms.append(MaxResize(config.image_max_size))
         elif config.image_max_dim:
-            transforms.append(MinResize(config.image_max_dim))
+            transforms.append(MaxResize(config.image_max_dim))
         
         # Converts PIL/numpy (HWC) to Torch tensor (CHW) in [0, 1]
         transforms.append(torchvision.transforms.ToTensor())

--- a/fiftyone/zoo/models/manifest-torch.json
+++ b/fiftyone/zoo/models/manifest-torch.json
@@ -21,6 +21,7 @@
                     "output_processor_cls": "fiftyone.utils.torch.ClassifierOutputProcessor",
                     "labels_path": "{{eta-resources}}/imagenet-labels-no-background.txt",
                     "image_min_dim": 224,
+                    "image_max_dim": 2048,
                     "image_mean": [0.485, 0.456, 0.406],
                     "image_std": [0.229, 0.224, 0.225],
                     "embeddings_layer": "<classifier.6"
@@ -139,6 +140,7 @@
                     "output_processor_cls": "fiftyone.utils.torch.ClassifierOutputProcessor",
                     "labels_path": "{{eta-resources}}/imagenet-labels-no-background.txt",
                     "image_min_dim": 224,
+                    "image_max_dim": 2048,
                     "image_mean": [0.485, 0.456, 0.406],
                     "image_std": [0.229, 0.224, 0.225],
                     "embeddings_layer": "<classifier"
@@ -183,6 +185,7 @@
                     "output_processor_cls": "fiftyone.utils.torch.ClassifierOutputProcessor",
                     "labels_path": "{{eta-resources}}/imagenet-labels-no-background.txt",
                     "image_min_dim": 224,
+                    "image_max_dim": 2048,
                     "image_mean": [0.485, 0.456, 0.406],
                     "image_std": [0.229, 0.224, 0.225],
                     "embeddings_layer": "<classifier"
@@ -227,6 +230,7 @@
                     "output_processor_cls": "fiftyone.utils.torch.ClassifierOutputProcessor",
                     "labels_path": "{{eta-resources}}/imagenet-labels-no-background.txt",
                     "image_min_dim": 224,
+                    "image_max_dim": 2048,
                     "image_mean": [0.485, 0.456, 0.406],
                     "image_std": [0.229, 0.224, 0.225],
                     "embeddings_layer": "<classifier"
@@ -271,6 +275,7 @@
                     "output_processor_cls": "fiftyone.utils.torch.ClassifierOutputProcessor",
                     "labels_path": "{{eta-resources}}/imagenet-labels-no-background.txt",
                     "image_min_dim": 224,
+                    "image_max_dim": 2048,
                     "image_mean": [0.485, 0.456, 0.406],
                     "image_std": [0.229, 0.224, 0.225],
                     "embeddings_layer": "<classifier"
@@ -424,6 +429,7 @@
                     "output_processor_cls": "fiftyone.utils.torch.ClassifierOutputProcessor",
                     "labels_path": "{{eta-resources}}/imagenet-labels-no-background.txt",
                     "image_min_dim": 224,
+                    "image_max_dim": 2048,
                     "image_mean": [0.485, 0.456, 0.406],
                     "image_std": [0.229, 0.224, 0.225],
                     "embeddings_layer": "<fc"
@@ -588,6 +594,7 @@
                     "output_processor_cls": "fiftyone.utils.torch.ClassifierOutputProcessor",
                     "labels_path": "{{eta-resources}}/imagenet-labels-no-background.txt",
                     "image_min_dim": 224,
+                    "image_max_dim": 2048,
                     "image_mean": [0.485, 0.456, 0.406],
                     "image_std": [0.229, 0.224, 0.225],
                     "embeddings_layer": "<classifier.1"
@@ -632,6 +639,7 @@
                     "output_processor_cls": "fiftyone.utils.torch.ClassifierOutputProcessor",
                     "labels_path": "{{eta-resources}}/imagenet-labels-no-background.txt",
                     "image_min_dim": 224,
+                    "image_max_dim": 2048,
                     "image_mean": [0.485, 0.456, 0.406],
                     "image_std": [0.229, 0.224, 0.225],
                     "embeddings_layer": "<classifier.1"
@@ -676,6 +684,7 @@
                     "output_processor_cls": "fiftyone.utils.torch.ClassifierOutputProcessor",
                     "labels_path": "{{eta-resources}}/imagenet-labels-no-background.txt",
                     "image_min_dim": 224,
+                    "image_max_dim": 2048,
                     "image_mean": [0.485, 0.456, 0.406],
                     "image_std": [0.229, 0.224, 0.225],
                     "embeddings_layer": "<classifier.1"
@@ -720,6 +729,7 @@
                     "output_processor_cls": "fiftyone.utils.torch.ClassifierOutputProcessor",
                     "labels_path": "{{eta-resources}}/imagenet-labels-no-background.txt",
                     "image_min_dim": 224,
+                    "image_max_dim": 2048,
                     "image_mean": [0.485, 0.456, 0.406],
                     "image_std": [0.229, 0.224, 0.225],
                     "embeddings_layer": "<fc"
@@ -764,6 +774,7 @@
                     "output_processor_cls": "fiftyone.utils.torch.ClassifierOutputProcessor",
                     "labels_path": "{{eta-resources}}/imagenet-labels-no-background.txt",
                     "image_min_dim": 224,
+                    "image_max_dim": 2048,
                     "image_mean": [0.485, 0.456, 0.406],
                     "image_std": [0.229, 0.224, 0.225],
                     "embeddings_layer": "<fc"
@@ -808,6 +819,7 @@
                     "output_processor_cls": "fiftyone.utils.torch.ClassifierOutputProcessor",
                     "labels_path": "{{eta-resources}}/imagenet-labels-no-background.txt",
                     "image_min_dim": 224,
+                    "image_max_dim": 2048,
                     "image_mean": [0.485, 0.456, 0.406],
                     "image_std": [0.229, 0.224, 0.225],
                     "embeddings_layer": "<fc"
@@ -852,6 +864,7 @@
                     "output_processor_cls": "fiftyone.utils.torch.ClassifierOutputProcessor",
                     "labels_path": "{{eta-resources}}/imagenet-labels-no-background.txt",
                     "image_min_dim": 224,
+                    "image_max_dim": 2048,
                     "image_mean": [0.485, 0.456, 0.406],
                     "image_std": [0.229, 0.224, 0.225],
                     "embeddings_layer": "<fc"
@@ -896,6 +909,7 @@
                     "output_processor_cls": "fiftyone.utils.torch.ClassifierOutputProcessor",
                     "labels_path": "{{eta-resources}}/imagenet-labels-no-background.txt",
                     "image_min_dim": 224,
+                    "image_max_dim": 2048,
                     "image_mean": [0.485, 0.456, 0.406],
                     "image_std": [0.229, 0.224, 0.225],
                     "embeddings_layer": "<fc"
@@ -940,6 +954,7 @@
                     "output_processor_cls": "fiftyone.utils.torch.ClassifierOutputProcessor",
                     "labels_path": "{{eta-resources}}/imagenet-labels-no-background.txt",
                     "image_min_dim": 224,
+                    "image_max_dim": 2048,
                     "image_mean": [0.485, 0.456, 0.406],
                     "image_std": [0.229, 0.224, 0.225],
                     "embeddings_layer": "<fc"
@@ -984,6 +999,7 @@
                     "output_processor_cls": "fiftyone.utils.torch.ClassifierOutputProcessor",
                     "labels_path": "{{eta-resources}}/imagenet-labels-no-background.txt",
                     "image_min_dim": 224,
+                    "image_max_dim": 2048,
                     "image_mean": [0.485, 0.456, 0.406],
                     "image_std": [0.229, 0.224, 0.225],
                     "embeddings_layer": "<fc"
@@ -1063,6 +1079,7 @@
                     "output_processor_cls": "fiftyone.utils.torch.ClassifierOutputProcessor",
                     "labels_path": "{{eta-resources}}/imagenet-labels-no-background.txt",
                     "image_min_dim": 224,
+                    "image_max_dim": 2048,
                     "image_mean": [0.485, 0.456, 0.406],
                     "image_std": [0.229, 0.224, 0.225],
                     "embeddings_layer": "<fc"
@@ -1107,6 +1124,7 @@
                     "output_processor_cls": "fiftyone.utils.torch.ClassifierOutputProcessor",
                     "labels_path": "{{eta-resources}}/imagenet-labels-no-background.txt",
                     "image_min_dim": 224,
+                    "image_max_dim": 2048,
                     "image_mean": [0.485, 0.456, 0.406],
                     "image_std": [0.229, 0.224, 0.225],
                     "embeddings_layer": "<fc"
@@ -1151,6 +1169,7 @@
                     "output_processor_cls": "fiftyone.utils.torch.ClassifierOutputProcessor",
                     "labels_path": "{{eta-resources}}/imagenet-labels-no-background.txt",
                     "image_min_dim": 224,
+                    "image_max_dim": 2048,
                     "image_mean": [0.485, 0.456, 0.406],
                     "image_std": [0.229, 0.224, 0.225]
                 }
@@ -1188,6 +1207,7 @@
                     "output_processor_cls": "fiftyone.utils.torch.ClassifierOutputProcessor",
                     "labels_path": "{{eta-resources}}/imagenet-labels-no-background.txt",
                     "image_min_dim": 224,
+                    "image_max_dim": 2048,
                     "image_mean": [0.485, 0.456, 0.406],
                     "image_std": [0.229, 0.224, 0.225]
                 }
@@ -1225,6 +1245,7 @@
                     "output_processor_cls": "fiftyone.utils.torch.ClassifierOutputProcessor",
                     "labels_path": "{{eta-resources}}/imagenet-labels-no-background.txt",
                     "image_min_dim": 224,
+                    "image_max_dim": 2048,
                     "image_mean": [0.485, 0.456, 0.406],
                     "image_std": [0.229, 0.224, 0.225],
                     "embeddings_layer": "<classifier.6"
@@ -1269,6 +1290,7 @@
                     "output_processor_cls": "fiftyone.utils.torch.ClassifierOutputProcessor",
                     "labels_path": "{{eta-resources}}/imagenet-labels-no-background.txt",
                     "image_min_dim": 224,
+                    "image_max_dim": 2048,
                     "image_mean": [0.485, 0.456, 0.406],
                     "image_std": [0.229, 0.224, 0.225],
                     "embeddings_layer": "<classifier.6"
@@ -1313,6 +1335,7 @@
                     "output_processor_cls": "fiftyone.utils.torch.ClassifierOutputProcessor",
                     "labels_path": "{{eta-resources}}/imagenet-labels-no-background.txt",
                     "image_min_dim": 224,
+                    "image_max_dim": 2048,
                     "image_mean": [0.485, 0.456, 0.406],
                     "image_std": [0.229, 0.224, 0.225],
                     "embeddings_layer": "<classifier.6"
@@ -1357,6 +1380,7 @@
                     "output_processor_cls": "fiftyone.utils.torch.ClassifierOutputProcessor",
                     "labels_path": "{{eta-resources}}/imagenet-labels-no-background.txt",
                     "image_min_dim": 224,
+                    "image_max_dim": 2048,
                     "image_mean": [0.485, 0.456, 0.406],
                     "image_std": [0.229, 0.224, 0.225],
                     "embeddings_layer": "<classifier.6"
@@ -1401,6 +1425,7 @@
                     "output_processor_cls": "fiftyone.utils.torch.ClassifierOutputProcessor",
                     "labels_path": "{{eta-resources}}/imagenet-labels-no-background.txt",
                     "image_min_dim": 224,
+                    "image_max_dim": 2048,
                     "image_mean": [0.485, 0.456, 0.406],
                     "image_std": [0.229, 0.224, 0.225],
                     "embeddings_layer": "<classifier.6"
@@ -1445,6 +1470,7 @@
                     "output_processor_cls": "fiftyone.utils.torch.ClassifierOutputProcessor",
                     "labels_path": "{{eta-resources}}/imagenet-labels-no-background.txt",
                     "image_min_dim": 224,
+                    "image_max_dim": 2048,
                     "image_mean": [0.485, 0.456, 0.406],
                     "image_std": [0.229, 0.224, 0.225],
                     "embeddings_layer": "<classifier.6"
@@ -1489,6 +1515,7 @@
                     "output_processor_cls": "fiftyone.utils.torch.ClassifierOutputProcessor",
                     "labels_path": "{{eta-resources}}/imagenet-labels-no-background.txt",
                     "image_min_dim": 224,
+                    "image_max_dim": 2048,
                     "image_mean": [0.485, 0.456, 0.406],
                     "image_std": [0.229, 0.224, 0.225],
                     "embeddings_layer": "<classifier.6"
@@ -1533,6 +1560,7 @@
                     "output_processor_cls": "fiftyone.utils.torch.ClassifierOutputProcessor",
                     "labels_path": "{{eta-resources}}/imagenet-labels-no-background.txt",
                     "image_min_dim": 224,
+                    "image_max_dim": 2048,
                     "image_mean": [0.485, 0.456, 0.406],
                     "image_std": [0.229, 0.224, 0.225],
                     "embeddings_layer": "<classifier.6"
@@ -1577,6 +1605,7 @@
                     "output_processor_cls": "fiftyone.utils.torch.ClassifierOutputProcessor",
                     "labels_path": "{{eta-resources}}/imagenet-labels-no-background.txt",
                     "image_min_dim": 224,
+                    "image_max_dim": 2048,
                     "image_mean": [0.485, 0.456, 0.406],
                     "image_std": [0.229, 0.224, 0.225],
                     "embeddings_layer": "<fc"
@@ -1621,6 +1650,7 @@
                     "output_processor_cls": "fiftyone.utils.torch.ClassifierOutputProcessor",
                     "labels_path": "{{eta-resources}}/imagenet-labels-no-background.txt",
                     "image_min_dim": 224,
+                    "image_max_dim": 2048,
                     "image_mean": [0.485, 0.456, 0.406],
                     "image_std": [0.229, 0.224, 0.225],
                     "embeddings_layer": "<fc"

--- a/tests/misc/torch_tests.py
+++ b/tests/misc/torch_tests.py
@@ -12,9 +12,47 @@ from PIL import Image
 import torch
 import torchvision
 
+import numpy as np
+from PIL import Image
+
 import fiftyone as fo
 import fiftyone.utils.torch as fout
 
+def _get_fake_img(h,w):
+    array = np.random.randint(255, size=(w, h),dtype=np.uint8)
+    return Image.fromarray(array)
+
+def test_torch_min_size():
+    image = _get_fake_img(32,32)
+    transf = fout.MinResize(64)
+    res = transf(image)
+    assert res.size == (64,64)
+    
+    image = _get_fake_img(32,32)
+    transf = fout.MinResize((64,32))
+    result = transf(image)
+    assert result.size == (64,64)
+    
+    
+def test_torch_max_size():
+    image = _get_fake_img(400, 400)
+    transf = fout.MaxResize(200)
+    result = transf(image)
+    assert result.size == (200, 200)
+    
+    image = _get_fake_img(400, 800)
+    transf = fout.MaxResize(400)
+    result = transf(image)
+    assert result.size == (200, 400)
+    
+    image = _get_fake_img(400, 400)
+    
+    transf = fout.MaxResize((400,200))
+    result = transf(image)
+    assert result.size == (200, 200)
+    
+    
+    
 
 @unittest.skip("Must be run manually")
 def test_torch_image_patches_dataset():


### PR DESCRIPTION
## What changes are proposed in this pull request?

Added a function "MaxResize" in utils.torch.py and added support for the pipeline to allow an optional parameter "image_max_dim" and "image_max_size" (very similar to image_min_dim and image_min_size". 
This parameter was also added for the model zoo for models with variable image size and was set to 2048 for largest dim of the image.

## How is this patch tested? If it is not, please explain why.

The MaxResize function is tested in "tests/misc/torch_test.py" but no test is added to verify the full pipeline.
Maybe this test should be located in the "unit-test".

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
