### PR TITLE
Updating dependencies for build workflows

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -63,8 +63,8 @@ jobs:
       - name: Install
         run: |
           sudo apt-get install pandoc
-          pip install --use-deprecated=legacy-resolver -r requirements/extras.txt
-          pip install --use-deprecated=legacy-resolver -r requirements/docs.txt
+          pip install -r requirements/extras.txt
+          pip install -r requirements/docs.txt
           pip install fiftyone-brain
           pip install pycocotools tensorflow torch torchvision
           pip install -e .

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -63,7 +63,7 @@ jobs:
       - name: Install
         run: |
           sudo apt-get install pandoc
-          pip install scikit-learn scikit-image
+          pip install --use-deprecated=legacy-resolver -r requirements/extras.txt
           pip install --use-deprecated=legacy-resolver -r requirements/docs.txt
           pip install fiftyone-brain
           pip install pycocotools tensorflow torch torchvision

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -122,7 +122,7 @@ jobs:
           pip install pytest tensorflow tensorflow-datasets torch torchvision
       - name: Install fiftyone
         run: |
-          pip install scikit-learn scikit-image shapely pydicom
+          pip install --use-deprecated=legacy-resolver -r requirements/extras.txt
           pip install --pre --extra-index-url https://test.pypi.org/simple/ fiftyone-brain voxel51-eta
           pip install -e .
       - name: Install ETA from source

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -122,7 +122,7 @@ jobs:
           pip install pytest tensorflow tensorflow-datasets torch torchvision
       - name: Install fiftyone
         run: |
-          pip install --use-deprecated=legacy-resolver -r requirements/extras.txt
+          pip install -r requirements/extras.txt
           pip install --pre --extra-index-url https://test.pypi.org/simple/ fiftyone-brain voxel51-eta
           pip install -e .
       - name: Install ETA from source

--- a/docs/source/user_guide/using_datasets.rst
+++ b/docs/source/user_guide/using_datasets.rst
@@ -166,6 +166,7 @@ Datasets can also store more specific types of ancillary information such as
 :ref:`mask targets <storing-mask-targets>`.
 
 .. code-block:: python
+    :linenos:
 
     import fiftyone as fo
 

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,10 +1,9 @@
 -r common.txt
 -r docs.txt
+-r extras.txt
 
 ipython==7.8.0
-shapely==1.7.1
 pre-commit==2.0.1
-pydicom==2.2.0
 pylint==2.3.1
 pytest==5.4.3
 twine>=3

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -1,4 +1,5 @@
 autodocsumm==0.2.7
+docutils==0.16
 ipykernel==5.3.0
 jupyter-client==6.1.3
 nbsphinx==0.8.7

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -1,8 +1,8 @@
-autodocsumm==0.2.6
+autodocsumm==0.2.7
 ipykernel==5.3.0
 jupyter-client==6.1.3
-nbsphinx==0.8.5
+nbsphinx==0.8.7
 sphinx-tabs==1.2.1
 Sphinx==2.4.4
 sphinxcontrib-napoleon==0.7
-sphinx-copybutton==0.2.12
+sphinx-copybutton==0.4.0

--- a/requirements/extras.txt
+++ b/requirements/extras.txt
@@ -1,3 +1,4 @@
-apache-beam==2.33.0
-pydicom==2.2.0
-shapely==1.7.1
+apache-beam>=2.33.0
+lightning-flash>=0.4.0
+pydicom>=2.2.0
+shapely>=1.7.1

--- a/requirements/extras.txt
+++ b/requirements/extras.txt
@@ -1,4 +1,5 @@
 apache-beam>=2.33.0
+google-api-python-client>=1.6.5
 google-cloud-storage>=1.36
 lightning-flash>=0.4.0
 pydicom>=2.2.0

--- a/requirements/extras.txt
+++ b/requirements/extras.txt
@@ -1,0 +1,3 @@
+apache-beam==2.33.0
+pydicom==2.2.0
+shapely==1.7.1

--- a/requirements/extras.txt
+++ b/requirements/extras.txt
@@ -1,4 +1,5 @@
 apache-beam>=2.33.0
+google-cloud-storage>=1.36
 lightning-flash>=0.4.0
 pydicom>=2.2.0
 shapely>=1.7.1


### PR DESCRIPTION
Adds `requirements/extras.txt` for extra packages that can be cross-platform installed via pip for certain optional features.

These requirements are now installed in docs/package build workflows (these had gotten out-of-date and were breaking the docs builds of late).

Unfortunately things like `torch`, `tensorflow`, and `pycocotools` can't be included in this because they require Windows-specific installs.