### PR TITLE
Add global occlusion widget parameter for CVAT annotation runs

### DIFF
--- a/docs/source/integrations/cvat.rst
+++ b/docs/source/integrations/cvat.rst
@@ -463,6 +463,10 @@ provided:
     otherwise a new project is created. By default, no project is used
 -   **project_id** (*None*): an optional ID of an existing CVAT project to
     which to upload the annotation tasks. By default, no project is used
+-   **occluded_attr** (*None*): an optional string indicating the attribute name
+    containing existing occluded values and/or in which to store
+    downloaded occluded values for all objects in the annotation run
+
 
 .. _cvat-label-schema:
 
@@ -1497,6 +1501,10 @@ CVAT project and avoid the need to re-specify the label schema in FiftyOne.
     will receieve command line prompt(s) at import time to provide label
     field(s) in which to store the annotations.
 
+    The `occluded_attr` argument allows you to link the occlusion widget to
+    your object attributes when uploading to existing projects.
+
+
 .. code:: python
     :linenos:
 
@@ -1777,6 +1785,49 @@ linked to the occlusion widget.
 
     dataset.load_annotations(anno_key, cleanup=True)
     dataset.delete_annotation_run(anno_key)
+
+
+The `occluded_attr` parameter is another way to upload and download occlusion
+attributes to the occlusion widget. This parameter allows you to define the
+attribute name that will be used for all spatial fields that are being
+annotated that did not explicitly have an occluded attribute defined in
+the label schema.
+
+This parameter is especially useful when working with existing projects since the
+CVAT project schema is not able to retain information about
+occluded attributes between runs. 
+
+.. code:: python
+    :linenos:
+
+    import fiftyone as fo
+    import fiftyone.zoo as foz
+
+    dataset = foz.load_zoo_dataset("quickstart").clone()
+    view = dataset.take(1)
+
+    anno_key = "cvat_occluded_widget_project"
+    project_name = "example_occluded_widget"
+    label_field = "ground_truth"
+
+    # Create project
+    view.annotate("create_proj", label_field=label_field, project_name=project_name)
+
+    # Upload to existing project
+    view.annotate(
+        anno_key,
+        label_field=label_field,
+        occluded_attr="is_occluded",
+        project_name=project_name,
+        launch_editor=True,
+    )
+    print(dataset.get_annotation_info(anno_key))
+
+    # Mark occlusions in CVAT...
+
+    dataset.load_annotations(anno_key, cleanup=True)
+    dataset.delete_annotation_run(anno_key)
+
 
 .. image:: /images/integrations/cvat_occ_widget.png
    :alt: cvat-occ-widget

--- a/docs/source/integrations/cvat.rst
+++ b/docs/source/integrations/cvat.rst
@@ -463,10 +463,9 @@ provided:
     otherwise a new project is created. By default, no project is used
 -   **project_id** (*None*): an optional ID of an existing CVAT project to
     which to upload the annotation tasks. By default, no project is used
--   **occluded_attr** (*None*): an optional string indicating the attribute name
-    containing existing occluded values and/or in which to store
-    downloaded occluded values for all objects in the annotation run
-
+-   **occluded_attr** (*None*): an optional attribute name containing existing
+    occluded values and/or in which to store downloaded occluded values for all
+    objects in the annotation run
 
 .. _cvat-label-schema:
 
@@ -1501,9 +1500,8 @@ CVAT project and avoid the need to re-specify the label schema in FiftyOne.
     will receieve command line prompt(s) at import time to provide label
     field(s) in which to store the annotations.
 
-    The `occluded_attr` argument allows you to link the occlusion widget to
-    your object attributes when uploading to existing projects.
-
+    You can also use the `occluded_attr` argument to link the state of CVAT's
+    occlusion widget to a specified attribute of your objects.
 
 .. code:: python
     :linenos:
@@ -1786,16 +1784,14 @@ linked to the occlusion widget.
     dataset.load_annotations(anno_key, cleanup=True)
     dataset.delete_annotation_run(anno_key)
 
+You can also use the `occluded_attr` parameter to sync the state of CVAT's
+occlusion widet with a specified attribute of all spatial fields that are being
+annotated that did not explicitly have an occluded attribute defined in the
+label schema.
 
-The `occluded_attr` parameter is another way to upload and download occlusion
-attributes to the occlusion widget. This parameter allows you to define the
-attribute name that will be used for all spatial fields that are being
-annotated that did not explicitly have an occluded attribute defined in
-the label schema.
-
-This parameter is especially useful when working with existing projects since the
-CVAT project schema is not able to retain information about
-occluded attributes between runs. 
+This parameter is especially useful when working with existing CVAT projects,
+since CVAT project schemas are not able to retain information about occluded
+attributes between annotation runs.
 
 .. code:: python
     :linenos:
@@ -1811,7 +1807,7 @@ occluded attributes between runs.
     label_field = "ground_truth"
 
     # Create project
-    view.annotate("create_proj", label_field=label_field, project_name=project_name)
+    view.annotate("new_proj", label_field=label_field, project_name=project_name)
 
     # Upload to existing project
     view.annotate(
@@ -1827,7 +1823,6 @@ occluded attributes between runs.
 
     dataset.load_annotations(anno_key, cleanup=True)
     dataset.delete_annotation_run(anno_key)
-
 
 .. image:: /images/integrations/cvat_occ_widget.png
    :alt: cvat-occ-widget

--- a/fiftyone/utils/cvat.py
+++ b/fiftyone/utils/cvat.py
@@ -2520,9 +2520,9 @@ class CVATBackendConfig(foua.AnnotationBackendConfig):
             default, no project is used
         project_id (None): an optional ID of an existing CVAT project to which
             to upload the annotation tasks. By default, no project is used
-        occluded_attr (None): an optional string indicating the attribute name
-            containing existing occluded values and/or in which to store
-            downloaded occluded values for all objects in the annotation run
+        occluded_attr (None): an optional attribute name containing existing
+            occluded values and/or in which to store downloaded occluded values
+            for all objects in the annotation run
     """
 
     def __init__(
@@ -3451,8 +3451,6 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
 
         # When adding to an existing project, its label schema is inherited, so
         # we need to store the updated one
-        # Providing a global occluded_attr will also result in an updated label
-        # schema
         if project_id is not None or occluded_attr is not None:
             config.label_schema = label_schema
 
@@ -4008,7 +4006,7 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
             for anno in anno_list:
                 server_id = anno["id"]
                 label_id = anno["label_id"]
-                if label_id in label_id_map.keys():
+                if label_id in label_id_map:
                     label_attr_id = label_id_map[label_id]
                     for attr in anno["attributes"]:
                         if attr["spec_id"] == label_attr_id:
@@ -4592,7 +4590,7 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
                     if occluded_attr_name is not None:
                         occluded_attrs[label_field][name] = occluded_attr_name
 
-            _prev_field_classes = _prev_field_classes.union(_field_classes)
+            _prev_field_classes |= _field_classes
 
             # Class-specific attributes
             for _class in classes:


### PR DESCRIPTION
This PR adds the `occluded_attr` parameter to the CVAT annotation backend.

This parameter accepts a string of the attribute name used to upload and download to the occlusion widget for all spatial label fields.

The primary use of this is when uploading tasks to an existing CVAT project. In this case, the label schema is ignored in favor of the CVAT schema which does not contain information regarding the attribute(s) linked to the occlusion widget. The `occluded_attr` can be used in this case to upload and download boolean values indicating occlusion to the same attribute for all spatial fields that support the occlusion widget.

### Example

```python
import fiftyone as fo
import fiftyone.zoo as foz
import random
random.seed(51)

dataset = foz.load_zoo_dataset("quickstart", max_samples=1).clone()

for sample in dataset:
    for det in sample.ground_truth.detections:
        det["occluded"] = bool(random.randint(0,1))
    sample.save()

anno_key = "project_occlusion"
project_name = "occlusion_test"

# Create project
results = dataset.annotate(
    "create_proj",
    label_field="ground_truth",
    project_name=project_name,
)

# Upload to project
results = dataset.annotate(
    anno_key,
    label_field="ground_truth",
    project_name=project_name,
    launch_editor=True,
    occluded_attr="occluded",
)

# Update the occlusion widget in CVAT

session = fo.launch_app(dataset)
dataset.load_annotations(anno_key, cleanup=True)
session.refresh()
```

This PR also fixes a bug where the occluded attribute was not properly loaded when a class was specified multiple times in the label schema.  Additionally, the label field was mistakenly appended to class names that were specified multiple times, this is also fixed.

### Example

Annotating vehicles as occluded in this example previously did not work.

```python
import fiftyone as fo
import fiftyone.zoo as foz

dataset = foz.load_zoo_dataset("quickstart-video", max_samples=1).clone()

anno_key = "occlusion_multilabel"

label_schema = {
    "frames.detections": {
        "type": "detections",
        "classes": [
            {
                "classes": ["vehicle"],
                "attributes": {
                    "attr1": {
                        "type": "text",
                    },
                },
            },
            "road_sign",
            { 
                "classes": ["vehicle", "person"],
                "attributes": {
                    "occluded": {
                        "type": "occluded",
                    },
                },
            },
        ],
        "attributes": False,
    }
}

results = dataset.annotate(
    anno_key,
    label_schema=label_schema,
    launch_editor=True,
)

# Annotate a vehicle as "occluded" in CVAT

session = fo.launch_app(dataset)
dataset.load_annotations(anno_key, cleanup=True)
session.refresh()
```