### PR TITLE
Raising error when annotating video label field not starting with "frames."

### DIFF
--- a/fiftyone/utils/annotations.py
+++ b/fiftyone/utils/annotations.py
@@ -400,6 +400,7 @@ def _build_label_schema(
                 )
             )
 
+        # Converting to return type normalizes for single vs multiple labels
         _return_type = _RETURN_TYPES_MAP[_label_type]
         _is_trackable = _is_frame_field and _return_type in _TRACKABLE_TYPES
 

--- a/fiftyone/utils/annotations.py
+++ b/fiftyone/utils/annotations.py
@@ -376,6 +376,8 @@ def _build_label_schema(
 
     _label_schema = {}
 
+    is_video = samples.media_type == fom.VIDEO
+
     for _label_field, _label_info in label_schema.items():
         (
             _label_type,
@@ -385,6 +387,17 @@ def _build_label_schema(
         ) = _get_label_type(
             samples, backend, label_type, _label_field, _label_info
         )
+
+        _return_type = _RETURN_TYPES_MAP[_label_type]
+        if (
+            is_video
+            and not samples._is_frame_field(_label_field)
+            and _return_type in _SPATIAL_TYPES
+        ):
+            logger.warning(
+                "Label field '%s' is a spatial type being annotated on a video "
+                'so it should likely start with "frames.".' % _label_field
+            )
 
         if _label_type not in backend.supported_label_types:
             raise ValueError(

--- a/fiftyone/utils/annotations.py
+++ b/fiftyone/utils/annotations.py
@@ -394,9 +394,9 @@ def _build_label_schema(
             and not samples._is_frame_field(_label_field)
             and _return_type in _SPATIAL_TYPES
         ):
-            logger.warning(
-                "Warning: Label field '%s' is a spatial type being annotated on a video "
-                'so it should likely start with "frames.".' % _label_field
+            raise ValueError(
+                "Label field '%s' is a spatial type being annotated on a video "
+                'so it must start with "frames.".' % _label_field
             )
 
         if _label_type not in backend.supported_label_types:

--- a/fiftyone/utils/annotations.py
+++ b/fiftyone/utils/annotations.py
@@ -395,7 +395,7 @@ def _build_label_schema(
             and _return_type in _SPATIAL_TYPES
         ):
             logger.warning(
-                "Label field '%s' is a spatial type being annotated on a video "
+                "Warning: Label field '%s' is a spatial type being annotated on a video "
                 'so it should likely start with "frames.".' % _label_field
             )
 

--- a/fiftyone/utils/annotations.py
+++ b/fiftyone/utils/annotations.py
@@ -388,17 +388,6 @@ def _build_label_schema(
             samples, backend, label_type, _label_field, _label_info
         )
 
-        _return_type = _RETURN_TYPES_MAP[_label_type]
-        if (
-            is_video
-            and not samples._is_frame_field(_label_field)
-            and _return_type in _SPATIAL_TYPES
-        ):
-            raise ValueError(
-                "Label field '%s' is a spatial type being annotated on a video "
-                'so it must start with "frames.".' % _label_field
-            )
-
         if _label_type not in backend.supported_label_types:
             raise ValueError(
                 "Field '%s' has unsupported label type '%s'. The '%s' backend "
@@ -411,9 +400,16 @@ def _build_label_schema(
                 )
             )
 
-        # Converting to return type normalizes for single vs multiple labels
         _return_type = _RETURN_TYPES_MAP[_label_type]
         _is_trackable = _is_frame_field and _return_type in _TRACKABLE_TYPES
+
+        if is_video and _return_type in _SPATIAL_TYPES and not _is_frame_field:
+            raise ValueError(
+                "Invalid label field '%s'. Spatial labels of type '%s' being "
+                "annotated on a video must be stored in a frame-level field, "
+                "i.e., one that starts with 'frames.'"
+                % (_label_field, _label_type)
+            )
 
         # We found an existing field with multiple label types, so we must
         # select only the relevant labels


### PR DESCRIPTION
This PR raises an error when requesting spatial annotations and the `label_field` doesn't start with `frames.`, as expected.

```py
import fiftyone as fo
import fiftyone.zoo as foz

dataset = foz.load_zoo_dataset("quickstart-video", max_samples=1).clone()

results = dataset.annotate(
    "frames_test",
    label_field="new_field",
    label_type="instances",
    classes=["test"],
)
```

```
ValueError: Invalid label field 'new_field'. Spatial labels of type 'instances' being annotated on a video must be stored in a frame-level field, i.e., one that starts with 'frames.'
```
