### PR TITLE
Retain original filenames when annotating in CVAT

### DIFF
--- a/fiftyone/utils/cvat.py
+++ b/fiftyone/utils/cvat.py
@@ -3370,7 +3370,7 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
             # IMPORTANT: CVAT organizes media within a task alphabetically by
             # filename, so we must give CVAT filenames whose alphabetical order
             # matches the order of `paths`
-            filename = "%06d%s" % (idx, os.path.splitext(path)[1])
+            filename = "%06d_%s" % (idx, os.path.basename(path))
             files["client_files[%d]" % idx] = (filename, open(path, "rb"))
 
         self.post(self.task_data_url(task_id), data=data, files=files)


### PR DESCRIPTION
Resolves #1432 

CVAT data is sorted alphabetically by filename after they are uploaded. This can cause issues when uploading annotations that are not in the same order. To resolve this, we modify the filenames of the media to ensure the correct ordering in CVAT. 

Previously, the filenames were simply overwritten with an increasing integer value. This PR prepends this integer value to the filenames in order to retain the original filename while ordering the media correctly.

The alternative is to re-order the annotations to match the original filenames sorted alphabetically, however, the view that is being annotated may be ordered in a specific way for a reason so we should not re-order it ourselves upon upload.

![image](https://user-images.githubusercontent.com/21222883/142454421-b0a504af-c378-40b3-b137-79acea3fa7f2.png)
