### PR TITLE
Optimizing image metadata calculation

### DIFF
--- a/fiftyone/core/metadata.py
+++ b/fiftyone/core/metadata.py
@@ -9,8 +9,10 @@ import itertools
 import logging
 import multiprocessing
 import os
+import requests
 
-import eta.core.image as etai
+from PIL import Image
+
 import eta.core.utils as etau
 import eta.core.video as etav
 
@@ -37,19 +39,40 @@ class Metadata(DynamicEmbeddedDocument):
     mime_type = fof.StringField()
 
     @classmethod
-    def build_for(cls, filepath):
-        """Builds a :class:`Metadata` object for the given filepath.
+    def build_for(cls, path_or_url, mime_type=None):
+        """Builds a :class:`Metadata` object for the given file.
 
         Args:
-            filepath: the path to the data on disk
+            path_or_url: the path to the data on disk or a URL
+            mime_type (None): the MIME type of the file. If not provided, it
+                will be guessed
 
         Returns:
             a :class:`Metadata`
         """
-        return cls(
-            size_bytes=os.path.getsize(filepath),
-            mime_type=etau.guess_mime_type(filepath),
-        )
+        if path_or_url.startswith("http"):
+            return cls._build_for_url(path_or_url, mime_type=mime_type)
+
+        return cls._build_for_local(path_or_url, mime_type=mime_type)
+
+    @classmethod
+    def _build_for_local(cls, filepath, mime_type=None):
+        if mime_type is None:
+            mime_type = etau.guess_mime_type(filepath)
+
+        size_bytes = os.path.getsize(filepath)
+
+        return cls(size_bytes=size_bytes, mime_type=mime_type)
+
+    @classmethod
+    def _build_for_url(cls, url, mime_type=None):
+        if mime_type is None:
+            mime_type = etau.guess_mime_type(url)
+
+        with requests.get(url, stream=True) as r:
+            size_bytes = int(r.headers["Content-Length"])
+
+        return cls(size_bytes=size_bytes, mime_type=mime_type)
 
 
 class ImageMetadata(Metadata):
@@ -68,34 +91,76 @@ class ImageMetadata(Metadata):
     num_channels = fof.IntField()
 
     @classmethod
-    def build_for(cls, image_or_path):
+    def build_for(cls, img_or_path_or_url, mime_type=None):
         """Builds an :class:`ImageMetadata` object for the given image.
 
         Args:
-            image_or_path: an image or the path to the image on disk
+            img_or_path_or_url: an image, an image path on disk, or a URL
+            mime_type (None): the MIME type of the image. If not provided, it
+                will be guessed
 
         Returns:
             an :class:`ImageMetadata`
         """
-        if etau.is_str(image_or_path):
-            # From image on disk
-            m = etai.ImageMetadata.build_for(image_or_path)
-            return cls(
-                size_bytes=m.size_bytes,
-                mime_type=m.mime_type,
-                width=m.frame_size[0],
-                height=m.frame_size[1],
-                num_channels=m.num_channels,
-            )
+        if not etau.is_str(img_or_path_or_url):
+            return cls._build_for_img(img_or_path_or_url, mime_type=mime_type)
 
-        # From in-memory image
-        height, width = image_or_path.shape[:2]
+        if img_or_path_or_url.startswith("http"):
+            return cls._build_for_url(img_or_path_or_url, mime_type=mime_type)
+
+        return cls._build_for_local(img_or_path_or_url, mime_type=mime_type)
+
+    @classmethod
+    def _build_for_local(cls, path, mime_type=None):
+        size_bytes = os.path.getsize(path)
+
+        if mime_type is None:
+            mime_type = etau.guess_mime_type(path)
+
+        with open(path, "rb") as f:
+            width, height, num_channels = get_image_info(f)
+
+        return cls(
+            size_bytes=size_bytes,
+            mime_type=mime_type,
+            width=width,
+            height=height,
+            num_channels=num_channels,
+        )
+
+    @classmethod
+    def _build_for_url(cls, url, mime_type=None):
+        if mime_type is None:
+            mime_type = etau.guess_mime_type(url)
+
+        with requests.get(url, stream=True) as r:
+            size_bytes = int(r.headers["Content-Length"])
+            width, height, num_channels = get_image_info(fou.ResponseStream(r))
+
+        return cls(
+            size_bytes=size_bytes,
+            mime_type=mime_type,
+            width=width,
+            height=height,
+            num_channels=num_channels,
+        )
+
+    @classmethod
+    def _build_for_img(cls, img, mime_type=None):
+        size_bytes = img.nbytes
+        height, width = img.shape[:2]
         try:
-            num_channels = image_or_path.shape[2]
+            num_channels = img.shape[2]
         except IndexError:
             num_channels = 1
 
-        return cls(width=width, height=height, num_channels=num_channels)
+        return cls(
+            size_bytes=size_bytes,
+            mime_type=mime_type,
+            width=width,
+            height=height,
+            num_channels=num_channels,
+        )
 
 
 class VideoMetadata(Metadata):
@@ -120,25 +185,29 @@ class VideoMetadata(Metadata):
     encoding_str = fof.StringField()
 
     @classmethod
-    def build_for(cls, video_path):
+    def build_for(cls, video_path_or_url, mime_type=None):
         """Builds an :class:`VideoMetadata` object for the given video.
 
         Args:
-            video_path: the path to a video on disk
+            video_path_or_url: the path to a video on disk or a URL
+            mime_type (None): the MIME type of the image. If not provided, it
+                will be guessed
 
         Returns:
             a :class:`VideoMetadata`
         """
-        m = etav.VideoMetadata.build_for(video_path)
+        stream_info = etav.VideoStreamInfo.build_for(
+            video_path_or_url, mime_type=mime_type
+        )
         return cls(
-            size_bytes=m.size_bytes,
-            mime_type=m.mime_type,
-            frame_width=m.frame_size[0],
-            frame_height=m.frame_size[1],
-            frame_rate=m.frame_rate,
-            total_frame_count=m.total_frame_count,
-            duration=m.duration,
-            encoding_str=m.encoding_str,
+            size_bytes=stream_info.size_bytes,
+            mime_type=stream_info.mime_type,
+            frame_width=stream_info.frame_size[0],
+            frame_height=stream_info.frame_size[1],
+            frame_rate=stream_info.frame_rate,
+            total_frame_count=stream_info.total_frame_count,
+            duration=stream_info.duration,
+            encoding_str=stream_info.encoding_str,
         )
 
 
@@ -195,6 +264,20 @@ def compute_metadata(
             logger.warning(msg)
         else:
             raise ValueError(msg)
+
+
+def get_image_info(f):
+    """Retrieves the dimensions and number of channels of the given image from
+    a file-like object that is streaming its contents.
+
+    Args:
+        f: a file-like object that supports ``read()``, ``seek()``, ``tell()``
+
+    Returns:
+        ``(width, height, num_channels)``
+    """
+    img = Image.open(f)
+    return (img.width, img.height, len(img.getbands()))
 
 
 def _compute_metadata(sample_collection, overwrite=False):

--- a/requirements/extras.txt
+++ b/requirements/extras.txt
@@ -1,6 +1,7 @@
 apache-beam>=2.33.0
 google-api-python-client>=1.6.5
 google-cloud-storage>=1.36
+httplib2<=0.15
 lightning-flash>=0.4.0
 pydicom>=2.2.0
 shapely>=1.7.1


### PR DESCRIPTION
Previously `ImageMetadata.build_for()`---which was used by `SampleCollection.compute_metadata()` to populate metadata for image samples---required loading the entire image into memory.

This PR optimizes the implementation to use `PIL.Image.open()`, which only reads the bare minimum content.

Also, all `Metadata.build_for()` methods can now accept publicly GET-able URLs.

```py
import fiftyone as fo
import fiftyone.zoo as foz

dataset = foz.load_zoo_dataset("quickstart")

# This was 50% faster when applied to BDD100k validation split (10k high resolution images) on my machine
dataset.compute_metadata(overwrite=True)
```
