### PR TITLE
Fix error when downloading VOC dataset

### DIFF
--- a/fiftyone/utils/voc.py
+++ b/fiftyone/utils/voc.py
@@ -800,6 +800,9 @@ def _parse_attribute(value):
     except:
         pass
 
+    if isinstance(value, list):
+        return value
+
     if value in {"True", "true"}:
         return True
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

Without the fix contained in this PR, running `fiftyone zoo datasets download voc-2012` fails with an error message saying that a list is not hashable. While the fix itself seems naive (I unfortunately didn't have enough availability to explore the codebase for a longer time) - it seems to be working fine, fixing the original issue.

## How is this patch tested? If it is not, please explain why.

I've tested it manually, by running the download for `voc-2012` and then loading the dataset and looking at the samples.

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
