### PR TITLE
Gracefully cast all int/float types to python primitives

### DIFF
--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -1115,9 +1115,7 @@ class SampleCollection(object):
             to_mongo = lambda _id: ObjectId(_id)
         else:
             field_type = self._get_field_type(
-                field_name,
-                is_frame_field=is_frame_field,
-                ignore_primitives=True,
+                field_name, is_frame_field=is_frame_field
             )
             if field_type is not None:
                 to_mongo = field_type.to_mongo

--- a/fiftyone/core/fields.py
+++ b/fiftyone/core/fields.py
@@ -6,13 +6,13 @@ Dataset sample fields.
 |
 """
 from datetime import date, datetime
+import numbers
 
 from bson import SON
 from bson.binary import Binary
 import mongoengine.fields
 import numpy as np
 import pytz
-import six
 
 import eta.core.utils as etau
 
@@ -61,7 +61,11 @@ class Field(mongoengine.fields.BaseField):
 class IntField(mongoengine.fields.IntField, Field):
     """A 32 bit integer field."""
 
-    pass
+    def to_mongo(self, value):
+        if value is None:
+            return None
+
+        return int(value)
 
 
 class ObjectIdField(mongoengine.fields.ObjectIdField, Field):
@@ -115,6 +119,12 @@ class DateTimeField(mongoengine.fields.DateTimeField, Field):
 
 class FloatField(mongoengine.fields.FloatField, Field):
     """A floating point number field."""
+
+    def to_mongo(self, value):
+        if value is None:
+            return None
+
+        return float(value)
 
     def validate(self, value):
         try:
@@ -256,7 +266,7 @@ class IntDictField(DictField):
         if not isinstance(value, dict):
             self.error("Value must be a dict")
 
-        if not all(map(lambda k: isinstance(k, six.integer_types), value)):
+        if not all(map(lambda k: isinstance(k, numbers.Integral), value)):
             self.error("Int dict fields must have integer keys")
 
         if self.field is not None:

--- a/fiftyone/core/frame_utils.py
+++ b/fiftyone/core/frame_utils.py
@@ -5,7 +5,7 @@ Frame utilites.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
-import six
+import numbers
 
 
 def is_frame_number(value):
@@ -23,7 +23,7 @@ def is_frame_number(value):
         :class:`FrameError`: if ``value`` is an integer but is not strictly
             positive
     """
-    if isinstance(value, six.integer_types):
+    if isinstance(value, numbers.Integral):
         if value < 1:
             raise FrameError(
                 "Frame numbers must be integers; found %s" % type(value)
@@ -45,7 +45,7 @@ def validate_frame_number(value):
     Raises:
         :class:`FrameError`: if ``value`` is not a frame number
     """
-    if not isinstance(value, six.integer_types):
+    if not isinstance(value, numbers.Integral):
         raise FrameError(
             "Frame numbers must be integers; found %s" % type(value)
         )

--- a/fiftyone/core/odm/mixins.py
+++ b/fiftyone/core/odm/mixins.py
@@ -149,7 +149,7 @@ def get_implied_field_kwargs(value):
     if isinstance(value, bool):
         return {"ftype": fof.BooleanField}
 
-    if isinstance(value, six.integer_types):
+    if isinstance(value, numbers.Integral):
         return {"ftype": fof.IntField}
 
     if isinstance(value, numbers.Number):
@@ -196,7 +196,7 @@ def _get_list_value_type(value):
     if isinstance(value, bool):
         return fof.BooleanField
 
-    if isinstance(value, six.integer_types):
+    if isinstance(value, numbers.Integral):
         return fof.IntField
 
     if isinstance(value, numbers.Number):
@@ -1115,6 +1115,14 @@ def _serialize_value(value, extended=False):
         # EmbeddedDocumentField
         return value.to_dict(extended=extended)
 
+    if isinstance(value, numbers.Integral):
+        # IntField
+        return int(value)
+
+    if isinstance(value, numbers.Number):
+        # FloatField
+        return float(value)
+
     if type(value) is date:
         # DateField
         return datetime(value.year, value.month, value.day)
@@ -1129,9 +1137,11 @@ def _serialize_value(value, extended=False):
         return json.loads(json_util.dumps(Binary(binary)))
 
     if isinstance(value, (list, tuple)):
+        # ListField
         return [_serialize_value(v, extended=extended) for v in value]
 
     if isinstance(value, dict):
+        # DictField
         return {
             k: _serialize_value(v, extended=extended) for k, v in value.items()
         }

--- a/tests/unittests/dataset_tests.py
+++ b/tests/unittests/dataset_tests.py
@@ -871,6 +871,110 @@ class DatasetTests(unittest.TestCase):
         self.assertIsInstance(schema["array_field"], fo.ArrayField)
 
     @drop_datasets
+    def test_numeric_type_coercions(self):
+        sample = fo.Sample(
+            filepath="image.png",
+            float1=1.0,
+            float2=np.float32(1.0),
+            float3=np.float64(1.0),
+            int1=1,
+            int2=np.uint8(1),
+            int3=np.int64(1),
+            list_float1=[1.0],
+            list_float2=[np.float32(1.0)],
+            list_float3=[np.float64(1.0)],
+            list_int1=[1],
+            list_int2=[np.uint8(1)],
+            list_int3=[np.int64(1)],
+        )
+
+        dataset = fo.Dataset()
+        dataset.add_sample(sample)
+
+        self.assertIsInstance(sample.float1, float)
+        self.assertIsInstance(sample.float2, float)
+        self.assertIsInstance(sample.float3, float)
+        self.assertIsInstance(sample.int1, int)
+        self.assertIsInstance(sample.int2, int)
+        self.assertIsInstance(sample.int3, int)
+
+        self.assertIsInstance(sample.list_float1[0], float)
+        self.assertIsInstance(sample.list_float2[0], float)
+        self.assertIsInstance(sample.list_float3[0], float)
+        self.assertIsInstance(sample.list_int1[0], int)
+        self.assertIsInstance(sample.list_int2[0], int)
+        self.assertIsInstance(sample.list_int3[0], int)
+
+        schema = dataset.get_field_schema()
+
+        self.assertIsInstance(schema["float1"], fo.FloatField)
+        self.assertIsInstance(schema["float2"], fo.FloatField)
+        self.assertIsInstance(schema["float3"], fo.FloatField)
+        self.assertIsInstance(schema["int1"], fo.IntField)
+        self.assertIsInstance(schema["int2"], fo.IntField)
+        self.assertIsInstance(schema["int3"], fo.IntField)
+
+        self.assertIsInstance(schema["list_float1"], fo.ListField)
+        self.assertIsInstance(schema["list_float2"], fo.ListField)
+        self.assertIsInstance(schema["list_float3"], fo.ListField)
+        self.assertIsInstance(schema["list_int1"], fo.ListField)
+        self.assertIsInstance(schema["list_int2"], fo.ListField)
+        self.assertIsInstance(schema["list_int3"], fo.ListField)
+
+        sample["float1"] = 2.0
+        sample["float2"] = np.float32(2.0)
+        sample["float3"] = np.float64(2.0)
+        sample["int1"] = 2
+        sample["int2"] = np.uint8(2)
+        sample["int3"] = np.int64(2)
+
+        sample["list_float1"][0] = 2.0
+        sample["list_float2"][0] = np.float32(2.0)
+        sample["list_float3"][0] = np.float64(2.0)
+        sample["list_int1"][0] = 2
+        sample["list_int2"][0] = np.uint8(2)
+        sample["list_int3"][0] = np.int64(2)
+
+        sample.save()
+
+        dataset.set_values("float1", [3.0])
+        dataset.set_values("float2", [np.float32(3.0)])
+        dataset.set_values("float3", [np.float64(3.0)])
+        dataset.set_values("list_float1", [[3.0]])
+        dataset.set_values("list_float2", [[np.float32(3.0)]])
+        dataset.set_values("list_float3", [[np.float64(3.0)]])
+        dataset.set_values("int1", [3])
+        dataset.set_values("int2", [np.uint8(3)])
+        dataset.set_values("int3", [np.int64(3)])
+        dataset.set_values("list_int1", [[3]])
+        dataset.set_values("list_int2", [[np.uint8(3)]])
+        dataset.set_values("list_int3", [[np.int64(3)]])
+
+        self.assertAlmostEqual(sample["float1"], 3.0)
+        self.assertAlmostEqual(sample["float2"], 3.0)
+        self.assertAlmostEqual(sample["float3"], 3.0)
+        self.assertEqual(sample["int1"], 3)
+        self.assertEqual(sample["int2"], 3)
+        self.assertEqual(sample["int3"], 3)
+
+        self.assertAlmostEqual(sample["list_float1"][0], 3.0)
+        self.assertAlmostEqual(sample["list_float2"][0], 3.0)
+        self.assertAlmostEqual(sample["list_float3"][0], 3.0)
+        self.assertEqual(sample["list_int1"][0], 3)
+        self.assertEqual(sample["list_int2"][0], 3)
+        self.assertEqual(sample["list_int3"][0], 3)
+
+        dataset.set_values("float1", [None])
+        dataset.set_values("list_float1", [None])
+        dataset.set_values("int1", [None])
+        dataset.set_values("list_int1", [None])
+
+        self.assertIsNone(sample["float1"])
+        self.assertIsNone(sample["list_float1"])
+        self.assertIsNone(sample["int1"])
+        self.assertIsNone(sample["list_int1"])
+
+    @drop_datasets
     def test_rename_fields(self):
         dataset = fo.Dataset()
         sample = fo.Sample(filepath="/path/to/image.jpg", field=1)


### PR DESCRIPTION
This PR adds support for implicitly casting int-like and float-like field values to `int` and `float` so they can be stored in the database.

Previously all of the operations below would raise errors but now are allowed:

```py
import numpy as np
import fiftyone as fo

sample = fo.Sample(
    filepath="image.png",
    float1=1.0,
    float2=np.float32(1.0),
    float3=np.float64(1.0),
    int1=1,
    int2=np.uint8(1),
    int3=np.int64(1),
    list_float1=[1.0],
    list_float2=[np.float32(1.0)],
    list_float3=[np.float64(1.0)],
    list_int1=[1],
    list_int2=[np.uint8(1)],
    list_int3=[np.int64(1)],
)

dataset = fo.Dataset()
dataset.add_sample(sample)

print(dataset)
print(sample)

sample["float1"] = 2.0
sample["float2"] = np.float32(2.0)
sample["float3"] = np.float64(2.0)
sample["int1"] = 2
sample["int2"] = np.uint8(2)
sample["int3"] = np.int64(2)

sample["list_float1"][0] = 2.0
sample["list_float2"][0] = np.float32(2.0)
sample["list_float3"][0] = np.float64(2.0)
sample["list_int1"][0] = 2
sample["list_int2"][0] = np.uint8(2)
sample["list_int3"][0] = np.int64(2)

sample.save()

dataset.set_values("float1", [3.0])
dataset.set_values("float2", [np.float32(3.0)])
dataset.set_values("float3", [np.float64(3.0)])
dataset.set_values("list_float1", [[3.0]])
dataset.set_values("list_float2", [[np.float32(3.0)]])
dataset.set_values("list_float3", [[np.float64(3.0)]])
dataset.set_values("int1", [3])
dataset.set_values("int2", [np.uint8(3)])
dataset.set_values("int3", [np.int64(3)])
dataset.set_values("list_int1", [[3]])
dataset.set_values("list_int2", [[np.uint8(3)]])
dataset.set_values("list_int3", [[np.int64(3)]])
```
