### PR TITLE
Import existing CVAT datasets into FiftyOne

### DIFF
--- a/docs/source/integrations/cvat.rst
+++ b/docs/source/integrations/cvat.rst
@@ -2020,8 +2020,8 @@ The following parameters are supported by :func:`import_dataset() <fiftyone.util
         manifest containing a mapping of CVAT filenames to absolute
         filepaths on disk
 -   **project_name** (*None*): the name of the CVAT project  containing labels to
-    load into the dataset. Required if `tasks_list` is `None`
--   **tasks_list** (*None*): a list of integer IDs of CVAT tasks containing
+    load into the dataset. Required if `task_ids` is `None`
+-   **task_ids** (*None*): a list of integer IDs of CVAT tasks containing
     labels to load into the dataset. Required if `project_name` is
     `None`
 -   **dataset_name** (*None*): an optional name to give to the dataset

--- a/docs/source/integrations/cvat.rst
+++ b/docs/source/integrations/cvat.rst
@@ -2060,15 +2060,16 @@ every 10th frame as a keyframe to provide a better editing experience in CVAT:
 
 .. _cvat-existing-tasks:
 
-Importing existing CVAT tasks
-_____________________________
+Importing existing tasks
+________________________
 
 FiftyOne's CVAT integration is designed to manage the full annotation workflow,
 from task creation to annotation import.
 
 However, if you have created CVAT tasks outside of FiftyOne, you can use the
 :func:`import_dataset() <fiftyone.utils.cvat.import_dataset>` utility to import
-a CVAT project or individual task(s) into a new or existing FiftyOne dataset:
+individual task(s) or an entire project into a new or existing FiftyOne
+dataset:
 
 .. code:: python
     :linenos:

--- a/docs/source/integrations/cvat.rst
+++ b/docs/source/integrations/cvat.rst
@@ -2014,7 +2014,8 @@ The following parameters are supported by :func:`import_dataset() <fiftyone.util
 -   **data_path**: a parameter that enables explicit control
     over the location of the media. Can be any of the following:
 
-    -   an absolute directory path where the media files reside
+    -   an absolute directory path where the media files reside, filenames 
+        on disk must match those in CVAT
     -   an absolute filepath specifying the location of the JSON data
         manifest containing a mapping of CVAT filenames to absolute
         filepaths on disk

--- a/docs/source/integrations/cvat.rst
+++ b/docs/source/integrations/cvat.rst
@@ -1988,6 +1988,86 @@ every 10th frame as a keyframe to provide a better editing experience in CVAT:
     with the shape's contents. See :ref:`this section <cvat-limitations>` for
     details.
 
+.. _cvat-importing:
+
+Importing datasets from CVAT
+____________________________
+
+The previous examples showed ways to link existing an FiftyOne |Dataset| to
+annotation tasks and projects in CVAT. However, you may have a CVAT project or
+task that you want to use to create a |Dataset|.
+
+One way to create a |Dataset| using existing data and annotations from
+CVAT is to simply export the CVAT dataset to disk and import it using the
+:ref:`CVATImageDataset <CVATImageDataset-import>`
+or 
+:ref:`CVATVideoDataset <CVATVideoDataset-import>`
+types.
+
+Alternatively, you can use the
+:func:`import_dataset() <fiftyone.utils.cvat.import_dataset>` CVAT utility to provide
+paths to local data and the name of a CVAT project or list of CVAT task IDs
+to automatically create a |Dataset|.
+
+The following parameters are supported by :func:`import_dataset() <fiftyone.utils.cvat.import_dataset>`:
+
+-   **data_path**: a parameter that enables explicit control
+    over the location of the media. Can be any of the following:
+
+    -   an absolute directory path where the media files reside
+    -   an absolute filepath specifying the location of the JSON data
+        manifest containing a mapping of CVAT filenames to absolute
+        filepaths on disk
+-   **project_name** (*None*): the name of the CVAT project  containing labels to
+    load into the dataset. Required if `tasks_list` is `None`
+-   **tasks_list** (*None*): a list of integer IDs of CVAT tasks containing
+    labels to load into the dataset. Required if `project_name` is
+    `None`
+-   **dataset_name** (*None*): an optional name to give to the dataset
+
+
+.. code:: python
+    :linenos:
+
+    import json
+    import os
+
+    import fiftyone as fo
+    import fiftyone.utils.cvat as fouc
+    import fiftyone.zoo as foz
+
+    ex_dataset = foz.load_zoo_dataset("quickstart", max_samples=3).clone()
+
+    project_name = "example_import"
+
+    # Create a CVAT project for this example
+    anno_key = "create_project"
+    results = ex_dataset.annotate(
+        anno_key,
+        label_field="ground_truth",
+        project_name=project_name,
+    )
+
+    # Path to the directory containing your media files
+    # Or path to a JSON file containing a mapping from CVAT filename to
+    # filepath on disk
+    data_path = "/tmp/cvat_import_example.json"
+    paths = ex_dataset.values("filepath")
+    filepath_map = {
+        "%06d_%s" % (idx, os.path.basename(p)): p for idx, p in enumerate(paths)
+    }
+    with open(data_path, "w") as f:
+        json.dump(filepath_map, f)
+
+    # Create Dataset from CVAT project
+    dataset = fouc.import_dataset(
+        data_path,
+        project_name=project_name,
+        dataset_name="example_dataset",
+    )
+
+    session = fo.launch_app(dataset)
+
 .. _cvat-utils:
 
 Additional utilities

--- a/fiftyone/utils/cvat.py
+++ b/fiftyone/utils/cvat.py
@@ -41,7 +41,7 @@ logger = logging.getLogger(__name__)
 
 
 def import_dataset(
-    data_path, project_name=None, tasks_list=None, dataset_name=None
+    data_path, project_name=None, task_ids=None, dataset_name=None
 ):
     """Create a FiftyOne dataset given a local directory of media and the name of a
     project or list of tasks containing corresponding annotations in CVAT.
@@ -59,7 +59,7 @@ def import_dataset(
 
         dataset = fouc.import_dataset("/path/to/data", project_name="project_name")
         
-        dataset = fouc.import_dataset("/path/to/data.json", tasks_list=[1,42,51])
+        dataset = fouc.import_dataset("/path/to/data.json", task_ids=[1,42,51])
 
 
     Any files that provided in `data_path` that do not exist in CVAT will
@@ -77,8 +77,8 @@ def import_dataset(
                 filepaths on disk
 
         project_name (None): the name of the CVAT project  containing labels to
-            load into the dataset. Required if `tasks_list` is `None`
-        tasks_list (None): a list of integer IDs of CVAT tasks containing
+            load into the dataset. Required if `task_ids` is `None`
+        task_ids (None): a list of integer IDs of CVAT tasks containing
             labels to load into the dataset. Required if `project_name` is
             `None`
         dataset_name (None): an optional name to give to the dataset
@@ -86,13 +86,13 @@ def import_dataset(
     Returns:
         a :class:`fiftyone.core.dataset.Dataset`
     """
-    if project_name is None and tasks_list is None:
+    if project_name is None and task_ids is None:
         raise ValueError(
-            "Either `project_name` or `tasks_list` must be provided."
+            "Either `project_name` or `task_ids` must be provided."
         )
-    if project_name is not None and tasks_list is not None:
+    if project_name is not None and task_ids is not None:
         raise ValueError(
-            "Only one of `project_name` or `tasks_list` is allowed."
+            "Only one of `project_name` or `task_ids` is allowed."
         )
 
     filename_map = foud.ImportPathsMixin._load_data_map(data_path)
@@ -130,7 +130,7 @@ def import_dataset(
 
     else:
         _parse_and_load_tasks(
-            tasks_list,
+            task_ids,
             api,
             filename_map,
             dataset,

--- a/fiftyone/utils/cvat.py
+++ b/fiftyone/utils/cvat.py
@@ -56,7 +56,8 @@ def import_dataset(
         data_path: a parameter that enables explicit control
             over the location of the media. Can be any of the following:
 
-            -   an absolute directory path where the media files reside
+            -   an absolute directory path where the media files reside,
+                filenames on disk must match those in CVAT
             -   an absolute filepath specifying the location of the JSON data
                 manifest containing a mapping of CVAT filenames to absolute
                 filepaths on disk

--- a/fiftyone/utils/cvat.py
+++ b/fiftyone/utils/cvat.py
@@ -58,7 +58,8 @@ def import_dataset(
 
             -   an absolute directory path where the media files reside
             -   an absolute filepath specifying the location of the JSON data
-                manifest containing a list of absolute filepaths
+                manifest containing a mapping of CVAT filenames to absolute
+                filepaths on disk
 
         project_name (None): the name of the CVAT project  containing labels to
             load into the dataset. Required if `tasks_list` is `None`
@@ -86,7 +87,7 @@ def import_dataset(
     dataset.add_samples([fos.Sample(filepath=fp) for fp in filepaths])
     dataset.ensure_frames()
 
-    anno_key = "load_from_cvat"
+    anno_key = "tmp_" + str(ObjectId())
     label_schema = {None: {"type": "tmp"}}
 
     config = foua._parse_config(
@@ -97,6 +98,7 @@ def import_dataset(
     api = anno_backend.connect_to_api()
     project_id = api.get_project_id(project_name)
     if project_id is not None:
+        # Update classes and attributes of label schema
         api._convert_cvat_schema(
             label_schema, project_id=project_id, update_server=False
         )
@@ -108,6 +110,7 @@ def import_dataset(
     frame_id_map = {}
     for task_id in task_ids:
         if project_id is None:
+            # Update classes and attributes of label schema
             api._convert_cvat_schema(
                 label_schema, task_id=task_id, update_server=False
             )


### PR DESCRIPTION
Resolves #1434 

### Summary

Previously, the best way to load a dataset from CVAT into FiftyOne was to export the dataset in `CVATImageDataset` or `CVATVideoDataset` format and import it using `Dataset.from_dir()`. 

This PR adds `fouc.import_dataset()` which takes either a CVAT `project_name` or a list of `task_ids` that will be used to load annotations alongside a `data_path` pointing to local media to construct a FiftyOne `Dataset`.

### `import_dataset()` description and parameters:

Create a FiftyOne dataset given a local directory of media and the name of a project or list of tasks containing corresponding annotations in CVAT.

```python
dataset = fouc.import_dataset("/path/to/data", project_name="project_name")
dataset = fouc.import_dataset("/path/to/data.json", task_ids=[1,42,51])
```
Parameters:
* `data_path`: a parameter that enables explicit control over the location of the media. Can be any of the following:
    - an absolute directory path where the media files reside
    - an absolute filepath specifying the location of the JSON data manifest containing a mapping of CVAT filenames to 
      absolute filepaths on disk
* `project_name` (None) – the name of the CVAT project containing labels to load into the dataset. Required if `task_id` is None
* `task_ids` (None) – a list of integer IDs of CVAT tasks containing labels to load into the dataset. Required if `project_name` is None
* `dataset_name` (None) – an optional name to give to the dataset

### Example

```python
import json
import os

import fiftyone as fo
import fiftyone.utils.cvat as fouc
import fiftyone.zoo as foz

ex_dataset = foz.load_zoo_dataset("quickstart", max_samples=3).clone()

project_name = "example_import"

# Create a CVAT project for this example
anno_key = "create_project"
results = ex_dataset.annotate(
    anno_key,
    label_field="ground_truth",
    project_name=project_name,
)

# Path to the directory containing your media files
# Or path to a JSON file containing a mapping from CVAT filename to
# filepath on disk
data_path = "/tmp/cvat_import_example.json"
paths = ex_dataset.values("filepath")
filepath_map = {
    "%06d_%s" % (idx, os.path.basename(p)): p for idx, p in enumerate(paths)
}
with open(data_path, "w") as f:
    json.dump(filepath_map, f)

# Create Dataset from CVAT project
dataset = fouc.import_dataset(
    data_path,
    project_name=project_name,
    dataset_name="example_dataset",
)

session = fo.launch_app(dataset)
```

### Points of discussion:

* Provide an optional `samples` parameter that will add labels to an existing dataset rather than creating a new dataset?
* Provide an optional `label_fields` parameter that will automatically load annotations into the specified fields rather than prompting the user for field names upon loading annotations for each task? This parameter would need to accept a mapping of field name to label type.