### PR TITLE
Adding support for importing/exporting confidence in YOLO formats

### DIFF
--- a/docs/source/user_guide/dataset_creation/datasets.rst
+++ b/docs/source/user_guide/dataset_creation/datasets.rst
@@ -1973,11 +1973,12 @@ omitted, in which case the `data/` directory is listed to determine the
 available images.
 
 The TXT files in `data/` are space-delimited files where each row corresponds
-to an object in the image of the same name, in the following format:
+to an object in the image of the same name, in one the following formats:
 
 .. code-block:: text
 
     <target> <x-center> <y-center> <width> <height>
+    <target> <x-center> <y-center> <width> <height> <confidence>
 
 where `<target>` is the zero-based integer index of the object class
 label from `obj.names` and the bounding box coordinates are expressed as
@@ -2214,11 +2215,12 @@ specific split being imported or exported is specified by the `split` argument
 to :class:`fiftyone.utils.yolo.YOLOv5DatasetImporter`.
 
 The TXT files in `labels/` are space-delimited files where each row corresponds
-to an object in the image of the same name, in the following format:
+to an object in the image of the same name, in one the following formats:
 
 .. code-block:: text
 
     <target> <x-center> <y-center> <width> <height>
+    <target> <x-center> <y-center> <width> <height> <confidence>
 
 where `<target>` is the zero-based integer index of the object class label from
 `names` and the bounding box coordinates are expressed as

--- a/docs/source/user_guide/export_datasets.rst
+++ b/docs/source/user_guide/export_datasets.rst
@@ -2058,12 +2058,13 @@ and `images.txt` contains the list of images in `data/`:
     ...
 
 and the TXT files in `data/` are space-delimited files where each row
-corresponds to an object in the image of the same name, in the following
-format:
+corresponds to an object in the image of the same name, in one of the following
+formats:
 
 .. code-block:: text
 
     <target> <x-center> <y-center> <width> <height>
+    <target> <x-center> <y-center> <width> <height> <confidence> # if include_confidence=True
 
 where `<target>` is the zero-based integer index of the object class
 label from `obj.names` and the bounding box coordinates are expressed as
@@ -2224,11 +2225,12 @@ specific split being imported or exported is specified by the `split` argument
 to :class:`fiftyone.utils.yolo.YOLOv5DatasetExporter`.
 
 The TXT files in `labels/` are space-delimited files where each row corresponds
-to an object in the image of the same name, in the following format:
+to an object in the image of the same name, in one of the following formats:
 
 .. code-block:: text
 
     <target> <x-center> <y-center> <width> <height>
+    <target> <x-center> <y-center> <width> <height> <confidence> # if include_confidence=True
 
 where `<target>` is the zero-based integer index of the object class label from
 `names` and the bounding box coordinates are expressed as

--- a/tests/unittests/import_export_tests.py
+++ b/tests/unittests/import_export_tests.py
@@ -1013,24 +1013,30 @@ class ImageDetectionDatasetTests(ImageDatasetTests):
 
         export_dir = self._new_dir()
 
-        dataset.export(
-            export_dir=export_dir,
-            dataset_type=fo.types.YOLOv4Dataset,
-            label_field="predictions",
-        )
+        for with_confidence in [False, True]:
+            dataset.export(
+                export_dir=export_dir,
+                dataset_type=fo.types.YOLOv4Dataset,
+                label_field="predictions",
+                include_confidence=with_confidence,
+            )
 
-        dataset2 = fo.Dataset.from_dir(
-            dataset_dir=export_dir,
-            dataset_type=fo.types.YOLOv4Dataset,
-            label_field="predictions",
-            include_all_data=True,
-        )
+            dataset2 = fo.Dataset.from_dir(
+                dataset_dir=export_dir,
+                dataset_type=fo.types.YOLOv4Dataset,
+                label_field="predictions",
+                include_all_data=True,
+            )
 
-        self.assertEqual(len(dataset), len(dataset2))
-        self.assertEqual(
-            dataset.count("predictions.detections"),
-            dataset2.count("predictions.detections"),
-        )
+            self.assertEqual(len(dataset), len(dataset2))
+            self.assertEqual(
+                dataset.count("predictions.detections"),
+                dataset2.count("predictions.detections"),
+            )
+            self.assertEqual(
+                dataset.bounds("predictions.detections.confidence") if with_confidence else (None, None),
+                dataset2.bounds("predictions.detections.confidence"),
+            )
 
         # Labels-only
 
@@ -1065,21 +1071,27 @@ class ImageDetectionDatasetTests(ImageDatasetTests):
 
         export_dir = self._new_dir()
 
-        dataset.export(
-            export_dir=export_dir, dataset_type=fo.types.YOLOv5Dataset,
-        )
+        for with_confidence in [False, True]:
+            dataset.export(
+                export_dir=export_dir, dataset_type=fo.types.YOLOv5Dataset,
+                include_confidence=with_confidence,
+            )
 
-        dataset2 = fo.Dataset.from_dir(
-            dataset_dir=export_dir,
-            dataset_type=fo.types.YOLOv5Dataset,
-            label_field="predictions",
-        )
+            dataset2 = fo.Dataset.from_dir(
+                dataset_dir=export_dir,
+                dataset_type=fo.types.YOLOv5Dataset,
+                label_field="predictions",
+            )
 
-        self.assertEqual(len(dataset), len(dataset2))
-        self.assertEqual(
-            dataset.count("predictions.detections"),
-            dataset2.count("predictions.detections"),
-        )
+            self.assertEqual(len(dataset), len(dataset2))
+            self.assertEqual(
+                dataset.count("predictions.detections"),
+                dataset2.count("predictions.detections"),
+            )
+            self.assertEqual(
+                dataset.bounds("predictions.detections.confidence") if with_confidence else (None, None),
+                dataset2.bounds("predictions.detections.confidence"),
+            )
 
 
 class ImageSegmentationDatasetTests(ImageDatasetTests):


### PR DESCRIPTION
## What changes are proposed in this pull request?

YOLOv4 and YOLOv5 import/export with confidence. [Issue](https://github.com/voxel51/fiftyone/issues/1460)

## How is this patch tested? If it is not, please explain why.

Assert equal detection confidence bounds between base and after export/import.
Updated tests in `tests/unittests/import_export_tests.py` to handle default `include_confidence=False`
and non-default `include_confidence=True` cases in `test_yolov4_dataset` and `test_yolov5_dataset`

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

Set `include_confidence=False` when exporting a dataset in YOLOv4/YOLOv5 formats to include confidence.
Importing datasets in YOLOv4/YOLOv5 formats automatically loads confidence if it's present in a txt file with detections.

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [x] Documentation: FiftyOne documentation changes
-   [ ] Other
