### PR TITLE
Fix CVAT single frame track bug

### DIFF
--- a/fiftyone/utils/cvat.py
+++ b/fiftyone/utils/cvat.py
@@ -5346,7 +5346,7 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
 
         # Insert new shapes into track
         for ind, shape in new_shapes[::-1]:
-            shapes.insert(ind, shape)
+            shapes.insert(ind + 1, shape)
 
         # Remove non-keyframes if necessary
         if only_keyframes:


### PR DESCRIPTION
This PR fixes a bug when annotating multiple track segments and the first segment is of length 1.

This works now:
```python
import fiftyone as fo
import fiftyone.zoo as foz

dataset = foz.load_zoo_dataset("quickstart-video", max_samples=1).select_fields().clone()
sample = dataset.first()
dataset.ensure_frames()

det = fo.Detection(label="test", bounding_box=[0.1,0.2,0.3,0.4], index=1)
dets = fo.Detections(detections=[det])

# Multiple track segments (separated by 1 frame)
# The first segment is length 1
frame_list = [1, 3] 

for frame_num in frame_list:
    frame = sample.frames[frame_num]
    frame["detections"] = dets
sample.save()
    
dataset.annotate(
    "test",
    label_field="frames.detections",
)
```

The root cause of this error is that an `outside` shape cannot be the first shape in a track (even though the frame number is an attribute of the shape so the ordering of shapes in the track does not otherwise matter). 
We insert an `outside` shape into a track when a track segment ends, this insertion was occurring to the left instead of the right of the desired element. This means that for a track segment of length 1, the first shape is now `outside` raising an error in CVAT.