### PR TITLE
Partial work on #1462

### DIFF
--- a/fiftyone/core/odm/document.py
+++ b/fiftyone/core/odm/document.py
@@ -232,7 +232,6 @@ class MongoEngineBaseDocument(SerializableDocument):
         return field_name in self._fields
 
     def get_field(self, field_name):
-        # return self._data[field_name]
         return getattr(self, field_name)
 
     def set_field(self, field_name, value, create=False):
@@ -241,7 +240,6 @@ class MongoEngineBaseDocument(SerializableDocument):
                 "%s has no field '%s'" % (self.__class__.__name__, field_name)
             )
 
-        # self._data[field_name] = value
         setattr(self, field_name, value)
 
     def clear_field(self, field_name):
@@ -250,7 +248,6 @@ class MongoEngineBaseDocument(SerializableDocument):
                 "%s has no field '%s'" % (self.__class__.__name__, field_name)
             )
 
-        # self._data.pop(field_name)
         super().__delattr__(field_name)
 
         # pylint: disable=no-member

--- a/fiftyone/core/odm/document.py
+++ b/fiftyone/core/odm/document.py
@@ -60,11 +60,7 @@ class SerializableDocument(object):
                 continue
 
             if not f.startswith("_"):
-                try:
-                    value = self.get_field(f)
-                except AttributeError:
-                    value = getattr(self, f)
-
+                value = getattr(self, f)
                 if isinstance(value, ObjectId):
                     d[f] = str(value)
                 else:

--- a/fiftyone/core/odm/mixins.py
+++ b/fiftyone/core/odm/mixins.py
@@ -222,6 +222,12 @@ class DatasetMixin(object):
     # Subtypes must declare this
     _is_frames_doc = None
 
+    def __setattr__(self, name, value):
+        if self.has_field(name):
+            self.set_field(name, value)
+        else:
+            super().__setattr__(name, value)
+
     @property
     def collection_name(self):
         return self.__class__.__name__

--- a/fiftyone/core/odm/mixins.py
+++ b/fiftyone/core/odm/mixins.py
@@ -223,10 +223,10 @@ class DatasetMixin(object):
     _is_frames_doc = None
 
     def __setattr__(self, name, value):
-        if self.has_field(name):
-            self.set_field(name, value)
-        else:
-            super().__setattr__(name, value)
+        if name in self._fields and value is not None:
+            self._fields[name].validate(value)
+
+        super().__setattr__(name, value)
 
     @property
     def collection_name(self):

--- a/fiftyone/core/odm/mixins.py
+++ b/fiftyone/core/odm/mixins.py
@@ -222,12 +222,6 @@ class DatasetMixin(object):
     # Subtypes must declare this
     _is_frames_doc = None
 
-    def __setattr__(self, name, value):
-        if name in self._fields and value is not None:
-            self._fields[name].validate(value)
-
-        super().__setattr__(name, value)
-
     @property
     def collection_name(self):
         return self.__class__.__name__
@@ -251,6 +245,34 @@ class DatasetMixin(object):
 
     def _get_field_names(self, include_private=False):
         return self._get_fields_ordered(include_private=include_private)
+
+    def has_field(self, field_name):
+        # pylint: disable=no-member
+        return field_name in self._fields
+
+    def get_field(self, field_name):
+        if not self.has_field(field_name):
+            raise AttributeError(
+                "%s has no field '%s'" % (self._doc_name(), field_name)
+            )
+
+        return super().get_field(field_name)
+
+    def set_field(self, field_name, value, create=False):
+        if not self.has_field(field_name):
+            if create:
+                self.add_implied_field(field_name, value)
+            else:
+                raise ValueError(
+                    "%s has no field '%s'" % (self._doc_name(), field_name)
+                )
+        elif value is not None:
+            self._fields[field_name].validate(value)
+
+        super().set_field(field_name, value)
+
+    def clear_field(self, field_name):
+        self.set_field(field_name, None)
 
     @classmethod
     def get_field_schema(
@@ -342,18 +364,6 @@ class DatasetMixin(object):
             field = schema[field_name]
             cls._add_field_schema(field_name, **get_field_kwargs(field))
 
-    def has_field(self, field_name):
-        # pylint: disable=no-member
-        return field_name in self._fields
-
-    def get_field(self, field_name):
-        if not self.has_field(field_name):
-            raise AttributeError(
-                "%s has no field '%s'" % (self._doc_name(), field_name)
-            )
-
-        return getattr(self, field_name)
-
     @classmethod
     def add_field(
         cls, field_name, ftype, embedded_doc_type=None, subfield=None, **kwargs
@@ -397,29 +407,6 @@ class DatasetMixin(object):
             validate_fields_match(field_name, kwargs, cls._fields[field_name])
         else:
             cls.add_field(field_name, **kwargs)
-
-    def set_field(self, field_name, value, create=False):
-        if field_name.startswith("_"):
-            raise ValueError(
-                "Invalid field name '%s'. Field names cannot start with '_'"
-                % field_name
-            )
-
-        if hasattr(self, field_name) and not self.has_field(field_name):
-            raise ValueError("Cannot use reserved keyword '%s'" % field_name)
-
-        if not self.has_field(field_name):
-            if create:
-                self.add_implied_field(field_name, value)
-            else:
-                raise ValueError(
-                    "%s has no field '%s'" % (self._doc_name(), field_name)
-                )
-
-        self.__setattr__(field_name, value)
-
-    def clear_field(self, field_name):
-        self.set_field(field_name, None)
 
     @classmethod
     def _rename_fields(cls, field_names, new_field_names):
@@ -964,23 +951,6 @@ class NoDatasetMixin(object):
     # Subtypes must declare this
     _is_frames_doc = None
 
-    def __getattr__(self, name):
-        try:
-            return super().__getattr__(name)
-        except AttributeError:
-            pass
-
-        try:
-            return self._data[name]
-        except KeyError as e:
-            raise AttributeError(e.args[0])
-
-    def __setattr__(self, name, value):
-        if name.startswith("_"):
-            super().__setattr__(name, value)
-        else:
-            self._data[name] = value
-
     def _get_field_names(self, include_private=False):
         if include_private:
             return tuple(self._data.keys())
@@ -1036,33 +1006,20 @@ class NoDatasetMixin(object):
             return False
 
     def get_field(self, field_name):
-        if not self.has_field(field_name):
+        try:
+            return self._data[field_name]
+        except KeyError:
             raise AttributeError(
                 "%s has no field '%s'" % (self._doc_name(), field_name)
             )
 
-        return getattr(self, field_name)
-
     def set_field(self, field_name, value, create=False):
-        if field_name.startswith("_"):
+        if not create and not self.has_field(field_name):
             raise ValueError(
-                "Invalid field name: '%s'. Field names cannot start with '_'"
-                % field_name
+                "%s has no field '%s'" % (self._doc_name(), field_name)
             )
 
-        if hasattr(self, field_name) and not self.has_field(field_name):
-            raise ValueError("Cannot use reserved keyword '%s'" % field_name)
-
-        if not self.has_field(field_name):
-            if create:
-                # dummy value so that it is identified by __setattr__
-                self._data[field_name] = None
-            else:
-                raise ValueError(
-                    "%s has no field '%s'" % (self._doc_name(), field_name)
-                )
-
-        self.__setattr__(field_name, value)
+        self._data[field_name] = value
 
     def clear_field(self, field_name):
         if field_name in self.default_fields:
@@ -1070,7 +1027,7 @@ class NoDatasetMixin(object):
             self.set_field(field_name, default_value)
             return
 
-        if field_name not in self._data:
+        if not self.has_field(field_name):
             raise ValueError(
                 "%s has no field '%s'" % (self._doc_name(), field_name)
             )
@@ -1111,7 +1068,7 @@ class NoDatasetMixin(object):
 
 
 def _serialize_value(value, extended=False):
-    if hasattr(value, "to_dict"):
+    if hasattr(value, "to_dict") and callable(value.to_dict):
         # EmbeddedDocumentField
         return value.to_dict(extended=extended)
 


### PR DESCRIPTION
I spent more time than I'd like to admit trying to properly fix https://github.com/voxel51/fiftyone/issues/1462, but this is where I got.

Ideally we would update the implementation of our `Document` classes so that fields can have arbitrary names and can always be accessed via `document[field]`, which is important in the case where a field clashes with a method name on the class, like `field="to_dict"`, which currently breaks things, since `document.to_dict` will currently return the user's data rather than invoke the method. This needs to be updated so that `document.to_dict` will always reference the method rather than the user's data in the case of clashes. Unfortunately, that's not easily achievable until we get rid of MongoEngine.

For now, I just removed the error that prevents `sample["objects"] = "object"` from being allowed, since as the code below shows, the other pathways for assigning an `objects` field are *not* currently blocked.

tl dr; until we get rid of MongoEngine, behavior is undefined if the user happens to choose a field name that clashes with a method name.

```py
import fiftyone as fo

# works
sample = fo.Sample(filepath="image.png", objects="object")
dataset = fo.Dataset()
dataset.add_sample(sample)

# works
dataset = fo.Dataset()
dataset.add_sample_field("objects", fo.StringField)

# previously would raise an error; now is allowed
sample = fo.Sample(filepath="image.png")
dataset = fo.Dataset()
dataset.add_sample(sample)
sample["objects"] = "object"
```
