### PR TITLE
Return sample IDs with unexpected annotations

### DIFF
--- a/docs/source/integrations/cvat.rst
+++ b/docs/source/integrations/cvat.rst
@@ -1003,6 +1003,20 @@ to see the available keys on a dataset.
     However, you can pass `cleanup=True` to delete all information associated
     with the run from the backend after the annotations are downloaded.
 
+Note that CVAT cannot explicitly prevent annotators from creating labels that
+don't obey the run's label schema. However, you can pass the optional
+`unexpected` parameter to
+:meth:`load_annotations() <fiftyone.core.collections.SampleCollection.load_annotations>`
+to configure how to deal with any such unexpected labels that are found. The
+supported values are:
+
+-   `"prompt"` (**default**): present an interactive prompt to direct/discard
+    unexpected labels
+-   `"ignore"`: automatically ignore any unexpected labels
+-   `"return"`: return a dict containing all unexpected labels, if any
+
+See :ref:`this section <cvat-unexpected-annotations>` for more details.
+
 .. _cvat-managing-annotation-runs:
 
 Managing annotation runs
@@ -1080,6 +1094,8 @@ FiftyOne dataset using the CVAT backend.
     All of the examples below assume you have configured your CVAT server and
     credentials as described in :ref:`this section <cvat-setup>`.
 
+.. _cvat-new-label-fields:
+
 Adding new label fields
 -----------------------
 
@@ -1145,6 +1161,8 @@ labeling task:
 .. image:: /images/integrations/cvat_tag.png
    :alt: cvat-tag
    :align: center
+
+.. _cvat-existing-labels:
 
 Editing existing labels
 -----------------------
@@ -1236,6 +1254,8 @@ can be used to annotate new classes and/or attributes:
     cases, it must instead delete the existing label and create a new |Label|
     with the shape's contents. See :ref:`this section <cvat-limitations>` for
     details.
+
+.. _cvat-restricting-edits:
 
 Restricting label edits
 -----------------------
@@ -1364,6 +1384,8 @@ attribute be populated without allowing edits to the vehicle's `type`:
     `False` on the annotation schema, this can result in CVAT edits being
     rejected. See :ref:`this section <cvat-limitations>` for details.
 
+.. _cvat-multiple-fields:
+
 Annotating multiple fields
 --------------------------
 
@@ -1416,19 +1438,32 @@ involves multiple fields:
    :alt: cvat-multiple-fields
    :align: center
 
+.. _cvat-unexpected-annotations:
+
 Unexpected annotations
 ----------------------
 
 The :meth:`annotate() <fiftyone.core.collections.SampleCollection.annotate>`
 method allows you to define the annotation schema that should be followed in
-CVAT. However, you or your annotators may "violate" this schema by adding
-annotations whose types differ from the pre-configured tasks.
+CVAT. However, CVAT does not explicitly allow for restricting the label types
+that can be created, so it is possible that your annotators may accidentally
+violate a task's intended schema.
+
+You can pass the optional `unexpected` parameter to
+:meth:`load_annotations() <fiftyone.core.collections.SampleCollection.load_annotations>`
+to configure how to deal with any such unexpected labels that are found. The
+supported values are:
+
+-   `"prompt"` (**default**): present an interactive prompt to direct/discard
+    unexpected labels
+-   `"ignore"`: automatically ignore any unexpected labels
+-   `"return"`: return a dict containing all unexpected labels, if any
 
 For example, suppose you upload a |Detections| field to CVAT for editing, but
-then polyline annotations are added instead. In such cases, the
+then polyline annotations are added instead. When
 :meth:`load_annotations() <fiftyone.core.collections.SampleCollection.load_annotations>`
-method will present a command prompt asking you what field(s) (if any) to store
-these unexpected new labels in:
+is called, the default behavior is to present a command prompt asking you what
+field(s) (if any) to store these unexpected labels in:
 
 .. code:: python
     :linenos:
@@ -1453,6 +1488,8 @@ these unexpected new labels in:
 .. image:: /images/integrations/cvat_polyline.png
    :alt: cvat-polyline
    :align: center
+
+.. _cvat-creating-projects:
 
 Creating projects
 -----------------
@@ -1494,6 +1531,8 @@ passing the `cleanup=True` option to
 
     dataset.load_annotations(anno_key, cleanup=True)
     dataset.delete_annotation_run(anno_key)
+
+.. _cvat-existing-projects:
 
 Uploading to existing projects
 ------------------------------
@@ -1586,6 +1625,8 @@ CVAT project and avoid the need to re-specify the label schema in FiftyOne.
     dataset.load_annotations(anno_key, cleanup=True)
     dataset.delete_annotation_run(anno_key)
 
+.. _cvat-assigning-users:
+
 Assigning users
 ---------------
 
@@ -1644,6 +1685,8 @@ will be assigned using a round-robin strategy.
     results.cleanup()
     dataset.delete_annotation_run(anno_key)
 
+.. _cvat-scalar-labels:
+
 Scalar labels
 -------------
 
@@ -1693,6 +1736,8 @@ enter the appropriate scalar in the `value` attribute of the tag.
 .. image:: /images/integrations/cvat_scalar.png
    :alt: cvat-scalar
    :align: center
+
+.. _cvat-alternate-media:
 
 Uploading alternate media
 -------------------------
@@ -1754,6 +1799,8 @@ For example, let's upload some blurred images to CVAT for annotation:
 .. image:: /images/integrations/cvat_alt_media.png
    :alt: cvat-alt-media
    :align: center
+
+.. _cvat-occlusion-widget:
 
 Using CVAT's occlusion widget
 -----------------------------

--- a/docs/source/integrations/cvat.rst
+++ b/docs/source/integrations/cvat.rst
@@ -1255,7 +1255,7 @@ can be used to annotate new classes and/or attributes:
     with the shape's contents. See :ref:`this section <cvat-limitations>` for
     details.
 
-.. _cvat-restricting-edits:
+.. _cvat-restricting-label-edits:
 
 Restricting label edits
 -----------------------

--- a/docs/source/user_guide/annotation.rst
+++ b/docs/source/user_guide/annotation.rst
@@ -915,6 +915,18 @@ to see the available keys on a dataset.
     However, you can pass `cleanup=True` to delete all information associated
     with the run from the backend after the annotations are downloaded.
 
+Some annotation backends like CVAT cannot explicitly prevent annotators from
+creating labels that don't obey the run's label schema. You can pass the
+optional `unexpected` parameter to
+:meth:`load_annotations() <fiftyone.core.collections.SampleCollection.load_annotations>`
+to configure how to deal with any such unexpected labels that are found. The
+supported values are:
+
+-   `"prompt"` (**default**): present an interactive prompt to direct/discard
+    unexpected labels
+-   `"ignore"`: automatically ignore any unexpected labels
+-   `"return"`: return a dict containing all unexpected labels, if any
+
 .. _managing-annotation-runs:
 
 Managing annotation runs

--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -6282,8 +6282,12 @@ class SampleCollection(object):
                 run from the annotation backend after loading the annotations
             **kwargs: optional keyword arguments for
                 :meth:`fiftyone.utils.annotations.AnnotationResults.load_credentials`
+
+        Returns:
+            `None` if no unexpected labels were found, otherwise a dictionary
+            of label field, unexpected label types, and sample ids
         """
-        foua.load_annotations(
+        return foua.load_annotations(
             self,
             anno_key,
             skip_unexpected=skip_unexpected,

--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -6263,7 +6263,7 @@ class SampleCollection(object):
         )
 
     def load_annotations(
-        self, anno_key, skip_unexpected=False, cleanup=False, **kwargs
+        self, anno_key, unexpected="prompt", cleanup=False, **kwargs
     ):
         """Downloads the labels from the given annotation run from the
         annotation backend and merges them into this collection.
@@ -6274,25 +6274,26 @@ class SampleCollection(object):
 
         Args:
             anno_key: an annotation key
-            skip_unexpected (False): whether to skip any unexpected labels that
-                don't match the run's label schema when merging. If False and
-                unexpected labels are encountered, you will be presented an
-                interactive prompt to deal with them
+            unexpected ("prompt"): how to deal with any unexpected labels that
+                don't match the run's label schema when importing. The
+                supported values are:
+
+                -   ``"prompt"``: present an interactive prompt to
+                    direct/discard unexpected labels
+                -   ``"ignore"``: automatically ignore any unexpected labels
+                -   ``"return"``: return a dict containing all unexpected
+                    labels, or ``None`` if there aren't any
             cleanup (False): whether to delete any informtation regarding this
                 run from the annotation backend after loading the annotations
             **kwargs: optional keyword arguments for
                 :meth:`fiftyone.utils.annotations.AnnotationResults.load_credentials`
 
         Returns:
-            `None` if no unexpected labels were found, otherwise a dictionary
-            of label field, unexpected label types, and sample ids
+            ``None``, unless ``unexpected=="return"`` and unexpected labels are
+            found, in which case a dict containing the extra labels is returned
         """
         return foua.load_annotations(
-            self,
-            anno_key,
-            skip_unexpected=skip_unexpected,
-            cleanup=cleanup,
-            **kwargs,
+            self, anno_key, unexpected=unexpected, cleanup=cleanup, **kwargs,
         )
 
     def delete_annotation_run(self, anno_key):

--- a/fiftyone/utils/annotations.py
+++ b/fiftyone/utils/annotations.py
@@ -981,7 +981,7 @@ def _format_attributes(backend, attributes):
 
 
 def load_annotations(
-    samples, anno_key, skip_unexpected=False, cleanup=False, **kwargs
+    samples, anno_key, unexpected="prompt", cleanup=False, **kwargs
 ):
     """Downloads the labels from the given annotation run from the annotation
     backend and merges them into the collection.
@@ -993,24 +993,29 @@ def load_annotations(
     Args:
         samples: a :class:`fiftyone.core.collections.SampleCollection`
         anno_key: an annotation key
-        skip_unexpected (False): whether to skip any unexpected labels that
-            don't match the run's label schema when merging. If False and
-            unexpected labels are encountered, you will be presented an
-            interactive prompt to deal with them
+        unexpected ("prompt"): how to deal with any unexpected labels that
+            don't match the run's label schema when importing. The supported
+            values are:
+
+            -   ``"prompt"``: present an interactive prompt to direct/discard
+                unexpected labels
+            -   ``"ignore"``: automatically ignore any unexpected labels
+            -   ``"return"``: return a dict containing all unexpected labels,
+                or ``None`` if there aren't any
         cleanup (False): whether to delete any informtation regarding this run
             from the annotation backend after loading the annotations
         **kwargs: optional keyword arguments for
             :meth:`AnnotationResults.load_credentials`
 
     Returns:
-        `None` if no unexpected labels were found, otherwise a dictionary
-        of label field, unexpected label types, and sample ids
+        ``None``, unless ``unexpected=="return"`` and unexpected labels are
+        found, in which case a dict containing the extra labels is returned
     """
     results = samples.load_annotation_results(anno_key, **kwargs)
     label_schema = results.config.label_schema
     annotations = results.backend.download_annotations(results)
 
-    unexpected = defaultdict(dict)
+    unexpected_annos = defaultdict(dict)
 
     for label_field, label_info in label_schema.items():
         label_type = label_info.get("type", None)
@@ -1047,12 +1052,12 @@ def load_annotations(
                     )
             else:
                 # Unexpected labels
-                if skip_unexpected or not allow_additions:
-                    new_field = None
-                else:
+                if unexpected == "prompt" and allow_additions:
                     new_field = _prompt_field(
                         samples, anno_type, label_field, label_schema
                     )
+                else:
+                    new_field = None
 
                 if new_field:
                     if anno_type == "scalar":
@@ -1068,16 +1073,17 @@ def load_annotations(
                         anno_type,
                         label_field,
                     )
-                    sample_ids = annos.keys()
-                    unexpected[label_field][anno_type] = sample_ids
+
+                    if unexpected == "return":
+                        unexpected_annos[label_field][anno_type] = annos
 
     results.backend.save_run_results(samples, anno_key, results)
 
     if cleanup:
         results.cleanup()
 
-    if unexpected:
-        return unexpected
+    if unexpected == "return":
+        return dict(unexpected_annos) if unexpected_annos else None
 
 
 def _parse_attributes(label_info):

--- a/fiftyone/utils/annotations.py
+++ b/fiftyone/utils/annotations.py
@@ -1001,10 +1001,16 @@ def load_annotations(
             from the annotation backend after loading the annotations
         **kwargs: optional keyword arguments for
             :meth:`AnnotationResults.load_credentials`
+
+    Returns:
+        `None` if no unexpected labels were found, otherwise a dictionary
+        of label field, unexpected label types, and sample ids
     """
     results = samples.load_annotation_results(anno_key, **kwargs)
     label_schema = results.config.label_schema
     annotations = results.backend.download_annotations(results)
+
+    unexpected = defaultdict(dict)
 
     for label_field, label_info in label_schema.items():
         label_type = label_info.get("type", None)
@@ -1062,11 +1068,16 @@ def load_annotations(
                         anno_type,
                         label_field,
                     )
+                    sample_ids = annos.keys()
+                    unexpected[label_field][anno_type] = sample_ids
 
     results.backend.save_run_results(samples, anno_key, results)
 
     if cleanup:
         results.cleanup()
+
+    if unexpected:
+        return unexpected
 
 
 def _parse_attributes(label_info):


### PR DESCRIPTION
Resolves #1477

When unexpected annotations have been added during an annotation run, the only way to load them currently is with access to an interactive prompt which may not always be available in all workflows. This PR replaces the old `skip_unexpected=True/False` parameter of `load_annotations()` with a more powerful `unexpected` parameter with the following options:

```
        unexpected ("prompt"): how to deal with any unexpected labels that
            don't match the run's label schema when importing. The supported
            values are:

            -   ``"prompt"``: present an interactive prompt to direct/discard
                unexpected labels
            -   ``"ignore"``: automatically ignore any unexpected labels
            -   ``"return"``: return a dict containing all unexpected labels,
                or ``None`` if there aren't any
```

Example usage:

```python
import fiftyone.zoo as foz

dataset = foz.load_zoo_dataset("quickstart", max_samples=3).clone()

anno_key = "unexpected"
dataset.annotate(
    anno_key,
    label_field="ground_truth",
    launch_editor=True,
)

# Add types other than detections and polygons

unexpected_annos = dataset.load_annotations(anno_key, unexpected="return", cleanup=True)
print(unexpected_annos)
```

