### PR TITLE
Update visual similarity stage in-place when possible in App workflows

### DIFF
--- a/fiftyone/core/view.py
+++ b/fiftyone/core/view.py
@@ -779,9 +779,30 @@ class DatasetView(foc.SampleCollection):
             view = stage.load_view(self)
         else:
             view = copy(self)
-            view._stages.append(stage)
+
+            if not self._add_sort_stage(stage, view._stages):
+                view._stages.append(stage)
 
         return view
+
+    @staticmethod
+    def _add_sort_stage(new_stage, stages):
+        if not type(new_stage) == fost.SortBySimilarity:
+            return False
+
+        sort_views = [
+            i for i, x in enumerate(stages) if type(x) == fost.SortBySimilarity
+        ]
+
+        if len(sort_views) > 0:
+            sort_views.reverse()
+            last_sort_view = sort_views[0]
+
+            if stages[last_sort_view].k == new_stage.k:
+                stages[last_sort_view] = new_stage
+                return True
+
+        return False
 
     def _get_filtered_schema(self, schema, frames=False):
         if schema is None:


### PR DESCRIPTION
Solves #1223 

## What changes are proposed in this pull request?

Visual similarity now updates the stage if the k value is unchanged from the previous one. 

## How is this patch tested? If it is not, please explain why.

Quick test:
```py
import fiftyone as fo
import fiftyone.brain as fob
import fiftyone.zoo as foz

dataset = foz.load_zoo_dataset("quickstart")
fob.compute_similarity(dataset, brain_key="image_sim")

session = fo.launch_app(dataset)

query_id = dataset.first().id
stage = fo.SortBySimilarity(query_id)
view = dataset.add_stage(stage)

query_id = dataset.last().id
stage = fo.SortBySimilarity(query_id)
view = view.add_stage(stage)

session.view = view
session.wait()
```

Before:
![Screen Shot 2021-12-22 at 20 13 49](https://user-images.githubusercontent.com/24899540/147177235-41d36856-d720-4966-95a5-f0e2bf620c5a.png)

After:
![Screen Shot 2021-12-22 at 20 09 51](https://user-images.githubusercontent.com/24899540/147176932-4c55d153-0032-4687-982b-851992fb07b0.png)

Additionally, you can try the click image + sort by similarity UI workflow. 

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
