### PR TITLE
Reverting nbsphinx version

### DIFF
--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -2,7 +2,7 @@ autodocsumm==0.2.7
 docutils==0.16
 ipykernel==5.3.0
 jupyter-client==6.1.3
-nbsphinx==0.8.7
+nbsphinx==0.8.5
 sphinx-tabs==1.2.1
 Sphinx==2.4.4
 sphinxcontrib-napoleon==0.7


### PR DESCRIPTION
The current section highlight in the RHS table of contents in the docs is currently broken in production. I believe the `nbsphinx` version change in https://github.com/voxel51/fiftyone/pull/1411 was the culprit.