### PR TITLE
Adding admin DB note to docs

### DIFF
--- a/docs/source/user_guide/config.rst
+++ b/docs/source/user_guide/config.rst
@@ -285,6 +285,22 @@ or you can set the following environment variable:
 
     export FIFTYONE_DATABASE_URI=mongodb://[username:password@]host[:port]
 
+If your MongoDB deployment is running with authentication enabled (the `--auth`
+flag), FiftyOne must connect with a root user.
+
+A root user can be created with the Mongo shell:
+
+.. code-block:: text
+
+    use admin
+    db.createUser({user: "username", pwd: passwordPrompt(), roles: ["root"]})
+
+Also, you must add `?authSource=admin` to your database URI:
+
+.. code-block:: text
+
+    mongodb://[username:password@]host[:port]/?authSource=admin
+
 .. note::
 
     **Apple Silicon users**: MongoDB does not yet provide a native build for

--- a/docs/source/user_guide/config.rst
+++ b/docs/source/user_guide/config.rst
@@ -290,12 +290,13 @@ FiftyOne must connect as a root user.
 
 You can create a root user with the Mongo shell as follows:
 
-.. code-block:: text
+.. code-block:: shell
 
-    use admin
-    db.createUser({user: "username", pwd: passwordPrompt(), roles: ["root"]})
+    mongo --shell
+    > use admin
+    > db.createUser({user: "username", pwd: passwordPrompt(), roles: ["root"]})
 
-Also, you must add `?authSource=admin` to your database URI:
+You must also add `?authSource=admin` to your database URI:
 
 .. code-block:: text
 

--- a/docs/source/user_guide/config.rst
+++ b/docs/source/user_guide/config.rst
@@ -285,10 +285,10 @@ or you can set the following environment variable:
 
     export FIFTYONE_DATABASE_URI=mongodb://[username:password@]host[:port]
 
-If your MongoDB deployment is running with authentication enabled (the `--auth`
-flag), FiftyOne must connect with a root user.
+If you are running MongoDB with authentication enabled (the `--auth` flag),
+FiftyOne must connect as a root user.
 
-A root user can be created with the Mongo shell:
+You can create a root user with the Mongo shell as follows:
 
 .. code-block:: text
 


### PR DESCRIPTION
Adds a note to the docs about connecting to custom MongoDB databases with authentication enabled.