### PR TITLE
Adding TF2 models to zoo

### DIFF
--- a/fiftyone/zoo/models/manifest-tf.json
+++ b/fiftyone/zoo/models/manifest-tf.json
@@ -1374,7 +1374,7 @@
         },
         {
             "base_name": "centernet-resnet50-v1-fpn-512-coco-tf2",
-            "base_filename": "centernet_resnet50_v1_fpn_512x512_coco17_tpu-8",
+            "base_filename": "centernet_resnet50_v1_fpn_512x512_coco17_tpu-8.tar.gz",
             "version": null,
             "description": "CenterNet model from `Objects as Points <https://arxiv.org/abs/1904.07850>`_ with the Resnet-50-v1 backbone + FPN trained on COCO resized to 512x512",
             "source": "https://github.com/tensorflow/models/blob/archive/research/object_detection/g3doc/tf2_detection_zoo.md",
@@ -1412,7 +1412,7 @@
         },
                 {
             "base_name": "centernet-resnet101-v1-fpn-512-coco-tf2",
-            "base_filename": "centernet_resnet101_v1_fpn_512x512_coco17_tpu-8",
+            "base_filename": "centernet_resnet101_v1_fpn_512x512_coco17_tpu-8.tar.gz",
             "version": null,
             "description": "CenterNet model from `Objects as Points <https://arxiv.org/abs/1904.07850>`_ with the Resnet-101v1 backbone + FPN trained on COCO resized to 512x512",
             "source": "https://github.com/tensorflow/models/blob/archive/research/object_detection/g3doc/tf2_detection_zoo.md",
@@ -1450,7 +1450,7 @@
         },
         {
             "base_name": "centernet-resnet50-v2-512-coco-tf2",
-            "base_filename": "centernet_resnet50_v2_512x512_coco17_tpu-8",
+            "base_filename": "centernet_resnet50_v2_512x512_coco17_tpu-8.tar.gz",
             "version": null,
             "description": "CenterNet model from `Objects as Points <https://arxiv.org/abs/1904.07850>`_ with the Resnet-50v2 backbone trained on COCO resized to 512x512",
             "source": "https://github.com/tensorflow/models/blob/archive/research/object_detection/g3doc/tf2_detection_zoo.md",
@@ -1488,7 +1488,7 @@
         },
          {
             "base_name": "centernet-mobilenet-v2-fpn-512-coco-tf2",
-            "base_filename": "centernet_mobilenetv2fpn_512x512_coco17_od",
+            "base_filename": "centernet_mobilenetv2fpn_512x512_coco17_od.tar.gz",
             "version": null,
             "description": "CenterNet model from `Objects as Points <https://arxiv.org/abs/1904.07850>`_ with the Mobilenet v2 backbone trained on COCO resized to 512x512",
             "source": "https://github.com/tensorflow/models/blob/archive/research/object_detection/g3doc/tf2_detection_zoo.md",
@@ -1526,7 +1526,7 @@
         },
         {
             "base_name": "efficientdet-d0-512-coco-tf2",
-            "base_filename": "efficientdet_d0_coco17_tpu-32",
+            "base_filename": "efficientdet_d0_coco17_tpu-32.tar.gz",
             "version": null,
             "description": "EfficientDet: Scalable and Efficient Object Detection<https://arxiv.org/abs/1911.09070> images are resized 512x512",
             "source": "https://github.com/tensorflow/models/blob/archive/research/object_detection/g3doc/tf2_detection_zoo.md",
@@ -1564,7 +1564,7 @@
         },
         {
             "base_name": "efficientdet-d1-640-coco-tf2",
-            "base_filename": "efficientdet_d1_coco17_tpu-32",
+            "base_filename": "efficientdet_d1_coco17_tpu-32.tar.gz",
             "version": null,
             "description": "EfficientDet: Scalable and Efficient Object Detection<https://arxiv.org/abs/1911.09070> images are resized 640x640",
             "source": "https://github.com/tensorflow/models/blob/archive/research/object_detection/g3doc/tf2_detection_zoo.md",
@@ -1602,7 +1602,7 @@
         },
         {
             "base_name": "efficientdet-d2-768-coco-tf2",
-            "base_filename": "efficientdet_d2_coco17_tpu-32",
+            "base_filename": "efficientdet_d2_coco17_tpu-32.tar.gz",
             "version": null,
             "description": "EfficientDet: Scalable and Efficient Object Detection<https://arxiv.org/abs/1911.09070> images are resized 768x768",
             "source": "https://github.com/tensorflow/models/blob/archive/research/object_detection/g3doc/tf2_detection_zoo.md",
@@ -1640,7 +1640,7 @@
         },
         {
             "base_name": "efficientdet-d3-896-coco-tf2",
-            "base_filename": "efficientdet_d3_coco17_tpu-32",
+            "base_filename": "efficientdet_d3_coco17_tpu-32.tar.gz",
             "version": null,
             "description": "EfficientDet: Scalable and Efficient Object Detection<https://arxiv.org/abs/1911.09070> images are resized 896x896",
             "source": "https://github.com/tensorflow/models/blob/archive/research/object_detection/g3doc/tf2_detection_zoo.md",
@@ -1678,7 +1678,7 @@
         },
         {
             "base_name": "efficientdet-d4-1024-coco-tf2",
-            "base_filename": "efficientdet_d4_coco17_tpu-32",
+            "base_filename": "efficientdet_d4_coco17_tpu-32.tar.gz",
             "version": null,
             "description": "EfficientDet: Scalable and Efficient Object Detection<https://arxiv.org/abs/1911.09070> images are resized 1024x1024",
             "source": "https://github.com/tensorflow/models/blob/archive/research/object_detection/g3doc/tf2_detection_zoo.md",
@@ -1716,7 +1716,7 @@
         },
         {
             "base_name": "efficientdet-d5-1280-coco-tf2",
-            "base_filename": "efficientdet_d5_coco17_tpu-32",
+            "base_filename": "efficientdet_d5_coco17_tpu-32.tar.gz",
             "version": null,
             "description": "EfficientDet: Scalable and Efficient Object Detection<https://arxiv.org/abs/1911.09070> images are resized 1280x1280",
             "source": "https://github.com/tensorflow/models/blob/archive/research/object_detection/g3doc/tf2_detection_zoo.md",
@@ -1754,7 +1754,7 @@
         },
         {
             "base_name": "efficientdet-d6-1280-coco-tf2",
-            "base_filename": "efficientdet_d6_coco17_tpu-32",
+            "base_filename": "efficientdet_d6_coco17_tpu-32.tar.gz",
             "version": null,
             "description": "EfficientDet: Scalable and Efficient Object Detection<https://arxiv.org/abs/1911.09070> images are resized 1280x1280",
             "source": "https://github.com/tensorflow/models/blob/archive/research/object_detection/g3doc/tf2_detection_zoo.md",
@@ -1792,7 +1792,7 @@
         },
         {
             "base_name": "efficientdet-d7-1536-coco-tf2",
-            "base_filename": "efficientdet_d7_coco17_tpu-32",
+            "base_filename": "efficientdet_d7_coco17_tpu-32.tar.gz",
             "version": null,
             "description": "EfficientDet: Scalable and Efficient Object Detection<https://arxiv.org/abs/1911.09070> images are resized 1536x1536",
             "source": "https://github.com/tensorflow/models/blob/archive/research/object_detection/g3doc/tf2_detection_zoo.md",
@@ -1830,7 +1830,7 @@
         },
         {
             "base_name": "ssd-mobilenet-v2-320-coco17",
-            "base_filename": "ssd_mobilenet_v2_320x320_coco17_tpu-8",
+            "base_filename": "ssd_mobilenet_v2_320x320_coco17_tpu-8.tar.gz",
             "version": null,
             "description": "MobileNetV2: Inverted Residuals and Linear Bottlenecks<https://arxiv.org/pdf/1801.04381.pdf> images are resized 320x320",
             "source": "https://github.com/tensorflow/models/blob/archive/research/object_detection/g3doc/tf2_detection_zoo.md",
@@ -1868,7 +1868,7 @@
         },
         {
             "base_name": "ssd-mobilenet-v1-fpn-640-coco17",
-            "base_filename": "ssd_mobilenet_v1_fpn_640x640_coco17_tpu-8",
+            "base_filename": "ssd_mobilenet_v1_fpn_640x640_coco17_tpu-8.tar.gz",
             "version": null,
             "description": "MobileNetV2: Inverted Residuals and Linear Bottlenecks<https://arxiv.org/pdf/1801.04381.pdf> images are resized 640x640",
             "source": "https://github.com/tensorflow/models/blob/archive/research/object_detection/g3doc/tf2_detection_zoo.md",

--- a/fiftyone/zoo/models/manifest-tf.json
+++ b/fiftyone/zoo/models/manifest-tf.json
@@ -1333,6 +1333,44 @@
             },
             "tags": ["detection", "coco", "tf2"],
             "date_added": "2021-01-6 11:01:34"
+        },
+        {
+            "base_name": "centernet-hg104-1024-coco-tf2",
+            "base_filename": "centernet_hg104_1024x1024_coco17_tpu-32",
+            "version": null,
+            "description": "CenterNet model from `Objects as Points <https://arxiv.org/abs/1904.07850>`_ with the Hourglass-104 backbone trained on COCO resized to 1024x1024",
+            "source": "https://github.com/tensorflow/models/blob/archive/research/object_detection/g3doc/tf2_detection_zoo.md",
+            "size_bytes": 1600851968,
+            "manager": {
+                "type": "fiftyone.core.models.ModelManager",
+                "config": {
+                    "url": "http://download.tensorflow.org/models/object_detection/tf2/20200711/centernet_hg104_1024x1024_coco17_tpu-32.tar.gz",
+                    "extract_archive": true,
+                    "delete_archive": true
+                }
+            },
+            "default_deployment_config_dict": {
+                "type": "fiftyone.utils.eta.ETAModel",
+                "config": {
+                    "type": "eta.detectors.TF2ModelsDetector",
+                    "config": {
+                        "labels_path": "{{eta}}/tensorflow/models/research/object_detection/data/mscoco_complete_label_map.pbtxt",
+                        "confidence_thresh": 0.3
+                    }
+                }
+            },
+            "requirements": {
+                "cpu": {
+                    "support": true,
+                    "packages": ["tensorflow>=2"]
+                },
+                "gpu": {
+                    "support": true,
+                    "packages": ["tensorflow-gpu>=2|tensorflow>=2"]
+                }
+            },
+            "tags": ["detection", "coco", "tf2"],
+            "date_added": "2021-12-26 07:04:23"
         }
     ]
 }

--- a/fiftyone/zoo/models/manifest-tf.json
+++ b/fiftyone/zoo/models/manifest-tf.json
@@ -1677,10 +1677,10 @@
             "date_added": "2021-12-27 18:42:30"
         },
         {
-            "base_name": "efficientdet-d4-896-coco-tf2",
+            "base_name": "efficientdet-d4-1024-coco-tf2",
             "base_filename": "efficientdet_d4_coco17_tpu-32",
             "version": null,
-            "description": "EfficientDet: Scalable and Efficient Object Detection<https://arxiv.org/abs/1911.09070> images are resized 896x896",
+            "description": "EfficientDet: Scalable and Efficient Object Detection<https://arxiv.org/abs/1911.09070> images are resized 1024x1024",
             "source": "https://github.com/tensorflow/models/blob/archive/research/object_detection/g3doc/tf2_detection_zoo.md",
             "size_bytes": 158496448,
             "manager": {
@@ -1715,10 +1715,10 @@
             "date_added": "2021-12-27 18:42:30"
         },
         {
-            "base_name": "efficientdet-d5-1024-coco-tf2",
+            "base_name": "efficientdet-d5-1280-coco-tf2",
             "base_filename": "efficientdet_d5_coco17_tpu-32",
             "version": null,
-            "description": "EfficientDet: Scalable and Efficient Object Detection<https://arxiv.org/abs/1911.09070> images are resized 1024x1024",
+            "description": "EfficientDet: Scalable and Efficient Object Detection<https://arxiv.org/abs/1911.09070> images are resized 1280x1280",
             "source": "https://github.com/tensorflow/models/blob/archive/research/object_detection/g3doc/tf2_detection_zoo.md",
             "size_bytes": 256286417,
             "manager": {

--- a/fiftyone/zoo/models/manifest-tf.json
+++ b/fiftyone/zoo/models/manifest-tf.json
@@ -1336,7 +1336,7 @@
         },
         {
             "base_name": "centernet-hg104-1024-coco-tf2",
-            "base_filename": "centernet_hg104_1024x1024_coco17_tpu-32",
+            "base_filename": "centernet_hg104_1024x1024_coco17_tpu-32.tar.gz",
             "version": null,
             "description": "CenterNet model from `Objects as Points <https://arxiv.org/abs/1904.07850>`_ with the Hourglass-104 backbone trained on COCO resized to 1024x1024",
             "source": "https://github.com/tensorflow/models/blob/archive/research/object_detection/g3doc/tf2_detection_zoo.md",

--- a/fiftyone/zoo/models/manifest-tf.json
+++ b/fiftyone/zoo/models/manifest-tf.json
@@ -1340,7 +1340,7 @@
             "version": null,
             "description": "CenterNet model from `Objects as Points <https://arxiv.org/abs/1904.07850>`_ with the Hourglass-104 backbone trained on COCO resized to 1024x1024",
             "source": "https://github.com/tensorflow/models/blob/archive/research/object_detection/g3doc/tf2_detection_zoo.md",
-            "size_bytes": 1600851968,
+            "size_bytes": 1426460092,
             "manager": {
                 "type": "fiftyone.core.models.ModelManager",
                 "config": {
@@ -1371,6 +1371,538 @@
             },
             "tags": ["detection", "coco", "tf2"],
             "date_added": "2021-12-26 07:04:23"
+        },
+        {
+            "base_name": "centernet-resnet50-v1-fpn-512-coco-tf2",
+            "base_filename": "centernet_resnet50_v1_fpn_512x512_coco17_tpu-8",
+            "version": null,
+            "description": "CenterNet model from `Objects as Points <https://arxiv.org/abs/1904.07850>`_ with the Resnet-50-v1 backbone + FPN trained on COCO resized to 512x512",
+            "source": "https://github.com/tensorflow/models/blob/archive/research/object_detection/g3doc/tf2_detection_zoo.md",
+            "size_bytes": 204067969,
+            "manager": {
+                "type": "fiftyone.core.models.ModelManager",
+                "config": {
+                    "url": "http://download.tensorflow.org/models/object_detection/tf2/20200711/centernet_resnet50_v1_fpn_512x512_coco17_tpu-8.tar.gz",
+                    "extract_archive": true,
+                    "delete_archive": true
+                }
+            },
+            "default_deployment_config_dict": {
+                "type": "fiftyone.utils.eta.ETAModel",
+                "config": {
+                    "type": "eta.detectors.TF2ModelsDetector",
+                    "config": {
+                        "labels_path": "{{eta}}/tensorflow/models/research/object_detection/data/mscoco_complete_label_map.pbtxt",
+                        "confidence_thresh": 0.3
+                    }
+                }
+            },
+            "requirements": {
+                "cpu": {
+                    "support": true,
+                    "packages": ["tensorflow>=2"]
+                },
+                "gpu": {
+                    "support": true,
+                    "packages": ["tensorflow-gpu>=2|tensorflow>=2"]
+                }
+            },
+            "tags": ["detection", "coco", "tf2"],
+            "date_added": "2021-12-27 14:45:23"
+        },
+                {
+            "base_name": "centernet-resnet101-v1-fpn-512-coco-tf2",
+            "base_filename": "centernet_resnet101_v1_fpn_512x512_coco17_tpu-8",
+            "version": null,
+            "description": "CenterNet model from `Objects as Points <https://arxiv.org/abs/1904.07850>`_ with the Resnet-101v1 backbone + FPN trained on COCO resized to 512x512",
+            "source": "https://github.com/tensorflow/models/blob/archive/research/object_detection/g3doc/tf2_detection_zoo.md",
+            "size_bytes": 345992335,
+            "manager": {
+                "type": "fiftyone.core.models.ModelManager",
+                "config": {
+                    "url": "http://download.tensorflow.org/models/object_detection/tf2/20200711/centernet_resnet101_v1_fpn_512x512_coco17_tpu-8.tar.gz",
+                    "extract_archive": true,
+                    "delete_archive": true
+                }
+            },
+            "default_deployment_config_dict": {
+                "type": "fiftyone.utils.eta.ETAModel",
+                "config": {
+                    "type": "eta.detectors.TF2ModelsDetector",
+                    "config": {
+                        "labels_path": "{{eta}}/tensorflow/models/research/object_detection/data/mscoco_complete_label_map.pbtxt",
+                        "confidence_thresh": 0.3
+                    }
+                }
+            },
+            "requirements": {
+                "cpu": {
+                    "support": true,
+                    "packages": ["tensorflow>=2"]
+                },
+                "gpu": {
+                    "support": true,
+                    "packages": ["tensorflow-gpu>=2|tensorflow>=2"]
+                }
+            },
+            "tags": ["detection", "coco", "tf2"],
+            "date_added": "2021-12-27 14:55:13"
+        },
+        {
+            "base_name": "centernet-resnet50-v2-512-coco-tf2",
+            "base_filename": "centernet_resnet50_v2_512x512_coco17_tpu-8",
+            "version": null,
+            "description": "CenterNet model from `Objects as Points <https://arxiv.org/abs/1904.07850>`_ with the Resnet-50v2 backbone trained on COCO resized to 512x512",
+            "source": "https://github.com/tensorflow/models/blob/archive/research/object_detection/g3doc/tf2_detection_zoo.md",
+            "size_bytes": 237977273,
+            "manager": {
+                "type": "fiftyone.core.models.ModelManager",
+                "config": {
+                    "url": "http://download.tensorflow.org/models/object_detection/tf2/20200711/centernet_resnet50_v2_512x512_coco17_tpu-8.tar.gz",
+                    "extract_archive": true,
+                    "delete_archive": true
+                }
+            },
+            "default_deployment_config_dict": {
+                "type": "fiftyone.utils.eta.ETAModel",
+                "config": {
+                    "type": "eta.detectors.TF2ModelsDetector",
+                    "config": {
+                        "labels_path": "{{eta}}/tensorflow/models/research/object_detection/data/mscoco_complete_label_map.pbtxt",
+                        "confidence_thresh": 0.3
+                    }
+                }
+            },
+            "requirements": {
+                "cpu": {
+                    "support": true,
+                    "packages": ["tensorflow>=2"]
+                },
+                "gpu": {
+                    "support": true,
+                    "packages": ["tensorflow-gpu>=2|tensorflow>=2"]
+                }
+            },
+            "tags": ["detection", "coco", "tf2"],
+            "date_added": "2021-12-27 14:59:23"
+        },
+         {
+            "base_name": "centernet-mobilenet-v2-fpn-512-coco-tf2",
+            "base_filename": "centernet_mobilenetv2fpn_512x512_coco17_od",
+            "version": null,
+            "description": "CenterNet model from `Objects as Points <https://arxiv.org/abs/1904.07850>`_ with the Mobilenet v2 backbone trained on COCO resized to 512x512",
+            "source": "https://github.com/tensorflow/models/blob/archive/research/object_detection/g3doc/tf2_detection_zoo.md",
+            "size_bytes": 44016454,
+            "manager": {
+                "type": "fiftyone.core.models.ModelManager",
+                "config": {
+                    "url": "http://download.tensorflow.org/models/object_detection/tf2/20210210/centernet_mobilenetv2fpn_512x512_coco17_od.tar.gz",
+                    "extract_archive": true,
+                    "delete_archive": true
+                }
+            },
+            "default_deployment_config_dict": {
+                "type": "fiftyone.utils.eta.ETAModel",
+                "config": {
+                    "type": "eta.detectors.TF2ModelsDetector",
+                    "config": {
+                        "labels_path": "{{eta}}/tensorflow/models/research/object_detection/data/mscoco_complete_label_map.pbtxt",
+                        "confidence_thresh": 0.3
+                    }
+                }
+            },
+            "requirements": {
+                "cpu": {
+                    "support": true,
+                    "packages": ["tensorflow>=2"]
+                },
+                "gpu": {
+                    "support": true,
+                    "packages": ["tensorflow-gpu>=2|tensorflow>=2"]
+                }
+            },
+            "tags": ["detection", "coco", "tf2"],
+            "date_added": "2021-12-27 17:05:20"
+        },
+        {
+            "base_name": "efficientdet-d0-512-coco-tf2",
+            "base_filename": "efficientdet_d0_coco17_tpu-32",
+            "version": null,
+            "description": "EfficientDet: Scalable and Efficient Object Detection<https://arxiv.org/abs/1911.09070> images are resized 512x512",
+            "source": "https://github.com/tensorflow/models/blob/archive/research/object_detection/g3doc/tf2_detection_zoo.md",
+            "size_bytes": 30736482,
+            "manager": {
+                "type": "fiftyone.core.models.ModelManager",
+                "config": {
+                    "url": "http://download.tensorflow.org/models/object_detection/tf2/20200711/efficientdet_d0_coco17_tpu-32.tar.gz",
+                    "extract_archive": true,
+                    "delete_archive": true
+                }
+            },
+            "default_deployment_config_dict": {
+                "type": "fiftyone.utils.eta.ETAModel",
+                "config": {
+                    "type": "eta.detectors.TF2ModelsDetector",
+                    "config": {
+                        "labels_path": "{{eta}}/tensorflow/models/research/object_detection/data/mscoco_complete_label_map.pbtxt",
+                        "confidence_thresh": 0.3
+                    }
+                }
+            },
+            "requirements": {
+                "cpu": {
+                    "support": true,
+                    "packages": ["tensorflow>=2"]
+                },
+                "gpu": {
+                    "support": true,
+                    "packages": ["tensorflow-gpu>=2|tensorflow>=2"]
+                }
+            },
+            "tags": ["detection", "coco", "tf2"],
+            "date_added": "2021-12-27 18:25:10"
+        },
+        {
+            "base_name": "efficientdet-d1-640-coco-tf2",
+            "base_filename": "efficientdet_d1_coco17_tpu-32",
+            "version": null,
+            "description": "EfficientDet: Scalable and Efficient Object Detection<https://arxiv.org/abs/1911.09070> images are resized 640x640",
+            "source": "https://github.com/tensorflow/models/blob/archive/research/object_detection/g3doc/tf2_detection_zoo.md",
+            "size_bytes": 51839363,
+            "manager": {
+                "type": "fiftyone.core.models.ModelManager",
+                "config": {
+                    "url": "http://download.tensorflow.org/models/object_detection/tf2/20200711/efficientdet_d1_coco17_tpu-32.tar.gz",
+                    "extract_archive": true,
+                    "delete_archive": true
+                }
+            },
+            "default_deployment_config_dict": {
+                "type": "fiftyone.utils.eta.ETAModel",
+                "config": {
+                    "type": "eta.detectors.TF2ModelsDetector",
+                    "config": {
+                        "labels_path": "{{eta}}/tensorflow/models/research/object_detection/data/mscoco_complete_label_map.pbtxt",
+                        "confidence_thresh": 0.3
+                    }
+                }
+            },
+            "requirements": {
+                "cpu": {
+                    "support": true,
+                    "packages": ["tensorflow>=2"]
+                },
+                "gpu": {
+                    "support": true,
+                    "packages": ["tensorflow-gpu>=2|tensorflow>=2"]
+                }
+            },
+            "tags": ["detection", "coco", "tf2"],
+            "date_added": "2021-12-27 18:25:10"
+        },
+        {
+            "base_name": "efficientdet-d2-768-coco-tf2",
+            "base_filename": "efficientdet_d2_coco17_tpu-32",
+            "version": null,
+            "description": "EfficientDet: Scalable and Efficient Object Detection<https://arxiv.org/abs/1911.09070> images are resized 768x768",
+            "source": "https://github.com/tensorflow/models/blob/archive/research/object_detection/g3doc/tf2_detection_zoo.md",
+            "size_bytes": 62929273,
+            "manager": {
+                "type": "fiftyone.core.models.ModelManager",
+                "config": {
+                    "url": "http://download.tensorflow.org/models/object_detection/tf2/20200711/efficientdet_d2_coco17_tpu-32.tar.gz",
+                    "extract_archive": true,
+                    "delete_archive": true
+                }
+            },
+            "default_deployment_config_dict": {
+                "type": "fiftyone.utils.eta.ETAModel",
+                "config": {
+                    "type": "eta.detectors.TF2ModelsDetector",
+                    "config": {
+                        "labels_path": "{{eta}}/tensorflow/models/research/object_detection/data/mscoco_complete_label_map.pbtxt",
+                        "confidence_thresh": 0.3
+                    }
+                }
+            },
+            "requirements": {
+                "cpu": {
+                    "support": true,
+                    "packages": ["tensorflow>=2"]
+                },
+                "gpu": {
+                    "support": true,
+                    "packages": ["tensorflow-gpu>=2|tensorflow>=2"]
+                }
+            },
+            "tags": ["detection", "coco", "tf2"],
+            "date_added": "2021-12-27 18:40:20"
+        },
+        {
+            "base_name": "efficientdet-d3-896-coco-tf2",
+            "base_filename": "efficientdet_d3_coco17_tpu-32",
+            "version": null,
+            "description": "EfficientDet: Scalable and Efficient Object Detection<https://arxiv.org/abs/1911.09070> images are resized 896x896",
+            "source": "https://github.com/tensorflow/models/blob/archive/research/object_detection/g3doc/tf2_detection_zoo.md",
+            "size_bytes": 92858658 ,
+            "manager": {
+                "type": "fiftyone.core.models.ModelManager",
+                "config": {
+                    "url": "http://download.tensorflow.org/models/object_detection/tf2/20200711/efficientdet_d3_coco17_tpu-32.tar.gz",
+                    "extract_archive": true,
+                    "delete_archive": true
+                }
+            },
+            "default_deployment_config_dict": {
+                "type": "fiftyone.utils.eta.ETAModel",
+                "config": {
+                    "type": "eta.detectors.TF2ModelsDetector",
+                    "config": {
+                        "labels_path": "{{eta}}/tensorflow/models/research/object_detection/data/mscoco_complete_label_map.pbtxt",
+                        "confidence_thresh": 0.3
+                    }
+                }
+            },
+            "requirements": {
+                "cpu": {
+                    "support": true,
+                    "packages": ["tensorflow>=2"]
+                },
+                "gpu": {
+                    "support": true,
+                    "packages": ["tensorflow-gpu>=2|tensorflow>=2"]
+                }
+            },
+            "tags": ["detection", "coco", "tf2"],
+            "date_added": "2021-12-27 18:42:30"
+        },
+        {
+            "base_name": "efficientdet-d4-896-coco-tf2",
+            "base_filename": "efficientdet_d4_coco17_tpu-32",
+            "version": null,
+            "description": "EfficientDet: Scalable and Efficient Object Detection<https://arxiv.org/abs/1911.09070> images are resized 896x896",
+            "source": "https://github.com/tensorflow/models/blob/archive/research/object_detection/g3doc/tf2_detection_zoo.md",
+            "size_bytes": 158496448,
+            "manager": {
+                "type": "fiftyone.core.models.ModelManager",
+                "config": {
+                    "url": "http://download.tensorflow.org/models/object_detection/tf2/20200711/efficientdet_d4_coco17_tpu-32.tar.gz",
+                    "extract_archive": true,
+                    "delete_archive": true
+                }
+            },
+            "default_deployment_config_dict": {
+                "type": "fiftyone.utils.eta.ETAModel",
+                "config": {
+                    "type": "eta.detectors.TF2ModelsDetector",
+                    "config": {
+                        "labels_path": "{{eta}}/tensorflow/models/research/object_detection/data/mscoco_complete_label_map.pbtxt",
+                        "confidence_thresh": 0.3
+                    }
+                }
+            },
+            "requirements": {
+                "cpu": {
+                    "support": true,
+                    "packages": ["tensorflow>=2"]
+                },
+                "gpu": {
+                    "support": true,
+                    "packages": ["tensorflow-gpu>=2|tensorflow>=2"]
+                }
+            },
+            "tags": ["detection", "coco", "tf2"],
+            "date_added": "2021-12-27 18:42:30"
+        },
+        {
+            "base_name": "efficientdet-d5-1024-coco-tf2",
+            "base_filename": "efficientdet_d5_coco17_tpu-32",
+            "version": null,
+            "description": "EfficientDet: Scalable and Efficient Object Detection<https://arxiv.org/abs/1911.09070> images are resized 1024x1024",
+            "source": "https://github.com/tensorflow/models/blob/archive/research/object_detection/g3doc/tf2_detection_zoo.md",
+            "size_bytes": 256286417,
+            "manager": {
+                "type": "fiftyone.core.models.ModelManager",
+                "config": {
+                    "url": "http://download.tensorflow.org/models/object_detection/tf2/20200711/efficientdet_d5_coco17_tpu-32.tar.gz",
+                    "extract_archive": true,
+                    "delete_archive": true
+                }
+            },
+            "default_deployment_config_dict": {
+                "type": "fiftyone.utils.eta.ETAModel",
+                "config": {
+                    "type": "eta.detectors.TF2ModelsDetector",
+                    "config": {
+                        "labels_path": "{{eta}}/tensorflow/models/research/object_detection/data/mscoco_complete_label_map.pbtxt",
+                        "confidence_thresh": 0.3
+                    }
+                }
+            },
+            "requirements": {
+                "cpu": {
+                    "support": true,
+                    "packages": ["tensorflow>=2"]
+                },
+                "gpu": {
+                    "support": true,
+                    "packages": ["tensorflow-gpu>=2|tensorflow>=2"]
+                }
+            },
+            "tags": ["detection", "coco", "tf2"],
+            "date_added": "2021-12-27 18:50:20"
+        },
+        {
+            "base_name": "efficientdet-d6-1280-coco-tf2",
+            "base_filename": "efficientdet_d6_coco17_tpu-32",
+            "version": null,
+            "description": "EfficientDet: Scalable and Efficient Object Detection<https://arxiv.org/abs/1911.09070> images are resized 1280x1280",
+            "source": "https://github.com/tensorflow/models/blob/archive/research/object_detection/g3doc/tf2_detection_zoo.md",
+            "size_bytes": 393872877 ,
+            "manager": {
+                "type": "fiftyone.core.models.ModelManager",
+                "config": {
+                    "url": "http://download.tensorflow.org/models/object_detection/tf2/20200711/efficientdet_d6_coco17_tpu-32.tar.gz",
+                    "extract_archive": true,
+                    "delete_archive": true
+                }
+            },
+            "default_deployment_config_dict": {
+                "type": "fiftyone.utils.eta.ETAModel",
+                "config": {
+                    "type": "eta.detectors.TF2ModelsDetector",
+                    "config": {
+                        "labels_path": "{{eta}}/tensorflow/models/research/object_detection/data/mscoco_complete_label_map.pbtxt",
+                        "confidence_thresh": 0.3
+                    }
+                }
+            },
+            "requirements": {
+                "cpu": {
+                    "support": true,
+                    "packages": ["tensorflow>=2"]
+                },
+                "gpu": {
+                    "support": true,
+                    "packages": ["tensorflow-gpu>=2|tensorflow>=2"]
+                }
+            },
+            "tags": ["detection", "coco", "tf2"],
+            "date_added": "2021-12-27 19:00:20"
+        },
+        {
+            "base_name": "efficientdet-d7-1536-coco-tf2",
+            "base_filename": "efficientdet_d7_coco17_tpu-32",
+            "version": null,
+            "description": "EfficientDet: Scalable and Efficient Object Detection<https://arxiv.org/abs/1911.09070> images are resized 1536x1536",
+            "source": "https://github.com/tensorflow/models/blob/archive/research/object_detection/g3doc/tf2_detection_zoo.md",
+            "size_bytes": 394474998,
+            "manager": {
+                "type": "fiftyone.core.models.ModelManager",
+                "config": {
+                    "url": "http://download.tensorflow.org/models/object_detection/tf2/20200711/efficientdet_d7_coco17_tpu-32.tar.gz",
+                    "extract_archive": true,
+                    "delete_archive": true
+                }
+            },
+            "default_deployment_config_dict": {
+                "type": "fiftyone.utils.eta.ETAModel",
+                "config": {
+                    "type": "eta.detectors.TF2ModelsDetector",
+                    "config": {
+                        "labels_path": "{{eta}}/tensorflow/models/research/object_detection/data/mscoco_complete_label_map.pbtxt",
+                        "confidence_thresh": 0.3
+                    }
+                }
+            },
+            "requirements": {
+                "cpu": {
+                    "support": true,
+                    "packages": ["tensorflow>=2"]
+                },
+                "gpu": {
+                    "support": true,
+                    "packages": ["tensorflow-gpu>=2|tensorflow>=2"]
+                }
+            },
+            "tags": ["detection", "coco", "tf2"],
+            "date_added": "2021-12-27 19:05:20"
+        },
+        {
+            "base_name": "ssd-mobilenet-v2-320-coco17",
+            "base_filename": "ssd_mobilenet_v2_320x320_coco17_tpu-8",
+            "version": null,
+            "description": "MobileNetV2: Inverted Residuals and Linear Bottlenecks<https://arxiv.org/pdf/1801.04381.pdf> images are resized 320x320",
+            "source": "https://github.com/tensorflow/models/blob/archive/research/object_detection/g3doc/tf2_detection_zoo.md",
+            "size_bytes": 46042990,
+            "manager": {
+                "type": "fiftyone.core.models.ModelManager",
+                "config": {
+                    "url": "http://download.tensorflow.org/models/object_detection/tf2/20200711/ssd_mobilenet_v2_320x320_coco17_tpu-8.tar.gz",
+                    "extract_archive": true,
+                    "delete_archive": true
+                }
+            },
+            "default_deployment_config_dict": {
+                "type": "fiftyone.utils.eta.ETAModel",
+                "config": {
+                    "type": "eta.detectors.TF2ModelsDetector",
+                    "config": {
+                        "labels_path": "{{eta}}/tensorflow/models/research/object_detection/data/mscoco_complete_label_map.pbtxt",
+                        "confidence_thresh": 0.3
+                    }
+                }
+            },
+            "requirements": {
+                "cpu": {
+                    "support": true,
+                    "packages": ["tensorflow>=2"]
+                },
+                "gpu": {
+                    "support": true,
+                    "packages": ["tensorflow-gpu>=2|tensorflow>=2"]
+                }
+            },
+            "tags": ["detection", "coco", "tf2"],
+            "date_added": "2021-12-27 20:01:40"
+        },
+        {
+            "base_name": "ssd-mobilenet-v1-fpn-640-coco17",
+            "base_filename": "ssd_mobilenet_v1_fpn_640x640_coco17_tpu-8",
+            "version": null,
+            "description": "MobileNetV2: Inverted Residuals and Linear Bottlenecks<https://arxiv.org/pdf/1801.04381.pdf> images are resized 640x640",
+            "source": "https://github.com/tensorflow/models/blob/archive/research/object_detection/g3doc/tf2_detection_zoo.md",
+            "size_bytes": 46042990,
+            "manager": {
+                "type": "fiftyone.core.models.ModelManager",
+                "config": {
+                    "url": "http://download.tensorflow.org/models/object_detection/tf2/20200711/ssd_mobilenet_v1_fpn_640x640_coco17_tpu-8.tar.gz",
+                    "extract_archive": true,
+                    "delete_archive": true
+                }
+            },
+            "default_deployment_config_dict": {
+                "type": "fiftyone.utils.eta.ETAModel",
+                "config": {
+                    "type": "eta.detectors.TF2ModelsDetector",
+                    "config": {
+                        "labels_path": "{{eta}}/tensorflow/models/research/object_detection/data/mscoco_complete_label_map.pbtxt",
+                        "confidence_thresh": 0.3
+                    }
+                }
+            },
+            "requirements": {
+                "cpu": {
+                    "support": true,
+                    "packages": ["tensorflow>=2"]
+                },
+                "gpu": {
+                    "support": true,
+                    "packages": ["tensorflow-gpu>=2|tensorflow>=2"]
+                }
+            },
+            "tags": ["detection", "coco", "tf2"],
+            "date_added": "2021-12-27 20:05:20"
         }
     ]
 }


### PR DESCRIPTION
## What changes are proposed in this pull request?

The following models are added:
centernet-hg104-1024-coco-tf2
centernet-resnet101-v1-fpn-512-coco-tf2
centernet-resnet50-v2-512-coco-tf2
centernet-mobilenet-v2-fpn-512-coco-tf2
efficientdet-d0-512-coco-tf2
efficientdet-d1-640-coco-tf2
efficientdet-d2-768-coco-tf2
efficientdet-d3-896-coco-tf2
efficientdet-d4-1024-coco-tf2
efficientdet-d5-1280-coco-tf2
efficientdet-d6-1280-coco-tf2
efficientdet-d7-1536-coco-tf2
ssd-mobilenet-v2-320-coco17
ssd-mobilenet-v1-fpn-640-coco17

## How is this patch tested? If it is not, please explain why.
```
import fiftyone as fo
import fiftyone.zoo as foz

dataset = foz.load_zoo_dataset("quickstart").select_fields().clone()
view = dataset.limit(10)

# Models you added should appear here
print(foz.list_zoo_models())

model = foz.load_zoo_model("<base-name>")

view.apply_model(model, label_field="predictions")

session = fo.launch_app(view)
```
## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [X] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ X] Other: New models are added
