### PR TITLE
[HOLD] Adding support for saving changes made to AnnotationResults

### DIFF
--- a/fiftyone/core/runs.py
+++ b/fiftyone/core/runs.py
@@ -473,7 +473,7 @@ class Run(Configurable):
         results_str = run_doc.results.read().decode()
 
         try:
-            run_results = RunResults.from_str(results_str, view, config)
+            run_results = RunResults.from_str(results_str, view, config, key)
         except Exception as e:
             if run_doc.version == foc.VERSION:
                 raise e
@@ -636,7 +636,7 @@ class RunResults(etas.Serializable):
         return ["cls"] + super().attributes()
 
     @classmethod
-    def from_dict(cls, d, samples, config):
+    def from_dict(cls, d, samples, config, key):
         """Builds a :class:`RunResults` from a JSON dict representation of it.
 
         Args:
@@ -644,6 +644,7 @@ class RunResults(etas.Serializable):
             samples: the :class:`fiftyone.core.collections.SampleCollection`
                 for the run
             config: the :class:`RunConfig` for the run
+            key: the run key
 
         Returns:
             a :class:`RunResults`
@@ -652,10 +653,10 @@ class RunResults(etas.Serializable):
             return None
 
         run_results_cls = etau.get_class(d["cls"])
-        return run_results_cls._from_dict(d, samples, config)
+        return run_results_cls._from_dict(d, samples, config, key)
 
     @classmethod
-    def _from_dict(cls, d, samples, config):
+    def _from_dict(cls, d, samples, config, key):
         """Subclass implementation of :meth:`from_dict`.
 
         Args:
@@ -663,6 +664,7 @@ class RunResults(etas.Serializable):
             samples: the :class:`fiftyone.core.collections.SampleCollection`
                 for the run
             config: the :class:`RunConfig` for the run
+            key: the run key
 
         Returns:
             a :class:`RunResults`

--- a/fiftyone/utils/data/importers.py
+++ b/fiftyone/utils/data/importers.py
@@ -1650,7 +1650,7 @@ def _import_run_results(dataset, run_dir, run_cls, keys=None):
             view = run_cls.load_run_view(dataset, key)
             run_info = run_cls.get_run_info(dataset, key)
             config = run_info.config
-            results = fors.RunResults.from_json(json_path, view, config)
+            results = fors.RunResults.from_json(json_path, view, config, key)
             run_cls.save_run_results(dataset, key, results, cache=False)
 
 

--- a/fiftyone/utils/eval/base.py
+++ b/fiftyone/utils/eval/base.py
@@ -22,7 +22,7 @@ class BaseEvaluationResults(foe.EvaluationResults):
         ypred: a list of predicted labels
         confs (None): an optional list of confidences for the predictions
         weights (None): an optional list of sample weights
-        eval_key (None): the evaluation key of the evaluation
+        eval_key (None): the evaluation key
         gt_field (None): the name of the ground truth field
         pred_field (None): the name of the predictions field
         ytrue_ids (None): a list of IDs for the ground truth labels
@@ -363,12 +363,11 @@ class BaseEvaluationResults(foe.EvaluationResults):
         return cmat, labels, ids
 
     @classmethod
-    def _from_dict(cls, d, samples, config, **kwargs):
+    def _from_dict(cls, d, samples, config, eval_key, **kwargs):
         ytrue = d["ytrue"]
         ypred = d["ypred"]
         confs = d.get("confs", None)
         weights = d.get("weights", None)
-        eval_key = d.get("eval_key", None)
         gt_field = d.get("gt_field", None)
         pred_field = d.get("pred_field", None)
         ytrue_ids = d.get("ytrue_ids", None)

--- a/fiftyone/utils/eval/classification.py
+++ b/fiftyone/utils/eval/classification.py
@@ -140,7 +140,7 @@ class ClassificationEvaluation(foe.EvaluationMethod):
 
         Args:
             samples: a :class:`fiftyone.core.collections.SampleCollection`
-            eval_key (None): an evaluation key for this evaluation
+            eval_key (None): the evaluation key
             classes (None): the list of possible classes. If not provided, the
                 observed ground truth/predicted labels are used for results
                 purposes
@@ -581,7 +581,7 @@ class ClassificationResults(BaseEvaluationResults):
         ypred: a list of predicted labels
         confs (None): an optional list of confidences for the predictions
         weights (None): an optional list of sample weights
-        eval_key (None): the evaluation key of the evaluation
+        eval_key (None): the evaluation key
         gt_field (None): the name of the ground truth field
         pred_field (None): the name of the predictions field
         ytrue_ids (None): a list of IDs for the ground truth labels
@@ -609,7 +609,7 @@ class BinaryClassificationResults(ClassificationResults):
         confs: a list of confidences for the predictions
         classes: the ``(neg_label, pos_label)`` label strings for the task
         weights (None): an optional list of sample weights
-        eval_key (None): the evaluation key of the evaluation
+        eval_key (None): the evaluation key
         gt_field (None): the name of the ground truth field
         pred_field (None): the name of the predictions field
         ytrue_ids (None): a list of IDs for the ground truth labels
@@ -743,13 +743,12 @@ class BinaryClassificationResults(ClassificationResults):
         return self.classes
 
     @classmethod
-    def _from_dict(cls, d, samples, config, **kwargs):
+    def _from_dict(cls, d, samples, config, eval_key, **kwargs):
         ytrue = d["ytrue"]
         ypred = d["ypred"]
         confs = d["confs"]
         classes = d["classes"]
         weights = d.get("weights", None)
-        eval_key = d.get("eval_key", None)
         gt_field = d.get("gt_field", None)
         pred_field = d.get("pred_field", None)
         ytrue_ids = d.get("ytrue_ids", None)

--- a/fiftyone/utils/eval/coco.py
+++ b/fiftyone/utils/eval/coco.py
@@ -146,7 +146,7 @@ class COCOEvaluation(DetectionEvaluation):
         Args:
             sample_or_frame: a :class:`fiftyone.core.Sample` or
                 :class:`fiftyone.core.frame.Frame`
-            eval_key (None): the evaluation key for this evaluation
+            eval_key (None): the evaluation key
 
         Returns:
             a list of matched
@@ -182,7 +182,7 @@ class COCOEvaluation(DetectionEvaluation):
                 ``(gt_label, pred_label, iou, pred_confidence, gt_id, pred_id)``
                 matches. Either label can be ``None`` to indicate an unmatched
                 object
-            eval_key (None): the evaluation key for this evaluation
+            eval_key (None): the evaluation key
             classes (None): the list of possible classes. If not provided, the
                 observed ground truth/predicted labels are used for results
                 purposes
@@ -238,7 +238,7 @@ class COCODetectionResults(DetectionResults):
         recall: an array of recall values
         iou_threshs: the list of IoU thresholds
         classes: the list of possible classes
-        eval_key (None): the evaluation key for this evaluation
+        eval_key (None): the evaluation key
         gt_field (None): the name of the ground truth field
         pred_field (None): the name of the predictions field
         missing (None): a missing label string. Any unmatched objects are
@@ -334,11 +334,12 @@ class COCODetectionResults(DetectionResults):
         return np.mean(classwise_AP)
 
     @classmethod
-    def _from_dict(cls, d, samples, config, **kwargs):
+    def _from_dict(cls, d, samples, config, eval_key, **kwargs):
         return super()._from_dict(
             d,
             samples,
             config,
+            eval_key,
             precision=d["precision"],
             recall=d["recall"],
             iou_threshs=d["iou_threshs"],

--- a/fiftyone/utils/eval/detection.py
+++ b/fiftyone/utils/eval/detection.py
@@ -335,7 +335,7 @@ class DetectionEvaluation(foe.EvaluationMethod):
         Args:
             sample_or_frame: a :class:`fiftyone.core.Sample` or
                 :class:`fiftyone.core.frame.Frame`
-            eval_key (None): the evaluation key for this evaluation
+            eval_key (None): the evaluation key
 
         Returns:
             a list of matched ``(gt_label, pred_label, iou, pred_confidence)``
@@ -357,7 +357,7 @@ class DetectionEvaluation(foe.EvaluationMethod):
                 ``(gt_label, pred_label, iou, pred_confidence, gt_id, pred_id)``
                 matches. Either label can be ``None`` to indicate an unmatched
                 object
-            eval_key (None): the evaluation key for this evaluation
+            eval_key (None): the evaluation key
             classes (None): the list of possible classes. If not provided, the
                 observed ground truth/predicted labels are used for results
                 purposes
@@ -465,7 +465,7 @@ class DetectionResults(BaseEvaluationResults):
             ``(gt_label, pred_label, iou, pred_confidence, gt_id, pred_id)``
             matches. Either label can be ``None`` to indicate an unmatched
             object
-        eval_key (None): the evaluation key for this evaluation
+        eval_key (None): the evaluation key
         gt_field (None): the name of the ground truth field
         pred_field (None): the name of the predictions field
         classes (None): the list of possible classes. If not provided, the
@@ -514,7 +514,7 @@ class DetectionResults(BaseEvaluationResults):
         self.ious = np.array(ious)
 
     @classmethod
-    def _from_dict(cls, d, samples, config, **kwargs):
+    def _from_dict(cls, d, samples, config, eval_key, **kwargs):
         ytrue = d["ytrue"]
         ypred = d["ypred"]
         ious = d["ious"]
@@ -531,7 +531,6 @@ class DetectionResults(BaseEvaluationResults):
         if ypred_ids is None:
             ypred_ids = itertools.repeat(None)
 
-        eval_key = d.get("eval_key", None)
         gt_field = d.get("gt_field", None)
         pred_field = d.get("pred_field", None)
         classes = d.get("classes", None)

--- a/fiftyone/utils/eval/openimages.py
+++ b/fiftyone/utils/eval/openimages.py
@@ -172,7 +172,7 @@ class OpenImagesEvaluation(DetectionEvaluation):
         Args:
             sample_or_frame: a :class:`fiftyone.core.Sample` or
                 :class:`fiftyone.core.frame.Frame`
-            eval_key (None): the evaluation key for this evaluation
+            eval_key (None): the evaluation key
 
         Returns:
             a list of matched
@@ -228,7 +228,7 @@ class OpenImagesEvaluation(DetectionEvaluation):
                 ``(gt_label, pred_label, iou, pred_confidence, gt_id, pred_id)``
                 matches. Either label can be ``None`` to indicate an unmatched
                 object
-            eval_key (None): the evaluation key for this evaluation
+            eval_key (None): the evaluation key
             classes (None): the list of possible classes. If not provided, the
                 observed ground truth/predicted labels are used for results
                 purposes
@@ -335,7 +335,7 @@ class OpenImagesDetectionResults(DetectionResults):
         precision: a dict of precision values per class
         recall: a dict of recall values per class
         classes: the list of possible classes
-        eval_key (None): the evaluation key for this evaluation
+        eval_key (None): the evaluation key
         gt_field (None): the name of the ground truth field
         pred_field (None): the name of the predictions field
         missing (None): a missing label string. Any unmatched objects are
@@ -476,11 +476,12 @@ class OpenImagesDetectionResults(DetectionResults):
         return np.mean(classwise_AP)
 
     @classmethod
-    def _from_dict(cls, d, samples, config, **kwargs):
+    def _from_dict(cls, d, samples, config, eval_key, **kwargs):
         return super()._from_dict(
             d,
             samples,
             config,
+            eval_key,
             precision=d["precision"],
             recall=d["recall"],
             **kwargs,

--- a/fiftyone/utils/eval/regression.py
+++ b/fiftyone/utils/eval/regression.py
@@ -121,7 +121,7 @@ class RegressionEvaluation(foe.EvaluationMethod):
 
         Args:
             samples: a :class:`fiftyone.core.collections.SampleCollection`
-            eval_key (None): an evaluation key for this evaluation
+            eval_key (None): the evaluation key
             missing (None): a missing value. Any None-valued regressions are
                 given this value for results purposes
 
@@ -290,7 +290,7 @@ class RegressionResults(foe.EvaluationResults):
         ytrue: a list of ground truth values
         ypred: a list of predicted values
         confs (None): an optional list of confidences for the predictions
-        eval_key (None): the evaluation key of the evaluation
+        eval_key (None): the evaluation key
         gt_field (None): the name of the ground truth field
         pred_field (None): the name of the predictions field
         ids (None): a list of sample or frame IDs corresponding to the
@@ -451,11 +451,10 @@ class RegressionResults(foe.EvaluationResults):
         )
 
     @classmethod
-    def _from_dict(cls, d, samples, config, **kwargs):
+    def _from_dict(cls, d, samples, config, eval_key, **kwargs):
         ytrue = d["ytrue"]
         ypred = d["ypred"]
         confs = d.get("confs", None)
-        eval_key = d.get("eval_key", None)
         gt_field = d.get("gt_field", None)
         pred_field = d.get("pred_field", None)
         ids = d.get("ids", None)

--- a/fiftyone/utils/eval/segmentation.py
+++ b/fiftyone/utils/eval/segmentation.py
@@ -338,7 +338,7 @@ class SegmentationResults(BaseEvaluationResults):
     Args:
         pixel_confusion_matrix: a pixel value confusion matrix
         classes: a list of class labels corresponding to the confusion matrix
-        eval_key (None): the evaluation key for the evaluation
+        eval_key (None): the evaluation key
         gt_field (None): the name of the ground truth field
         pred_field (None): the name of the predictions field
         missing (None): a missing (background) class
@@ -387,14 +387,17 @@ class SegmentationResults(BaseEvaluationResults):
         ]
 
     @classmethod
-    def _from_dict(cls, d, samples, config, **kwargs):
+    def _from_dict(cls, d, samples, config, eval_key, **kwargs):
+        gt_field = d.get("gt_field", None)
+        pred_field = d.get("pred_field", None)
+        missing = d.get("missing", None)
         return cls(
             d["pixel_confusion_matrix"],
             d["classes"],
-            eval_key=d.get("eval_key", None),
-            gt_field=d.get("gt_field", None),
-            pred_field=d.get("pred_field", None),
-            missing=d.get("missing", None),
+            eval_key=eval_key,
+            gt_field=gt_field,
+            pred_field=pred_field,
+            missing=missing,
             samples=samples,
             **kwargs,
         )


### PR DESCRIPTION
Adds an `AnnotationResults.save()` method that allows for saving changes to an existing annotation run.

In order to implement this feature, the `AnnotationResults` object needs knowledge of the `anno_key`, and it seemed to me that the best way to make that happen was to add support for passing run keys when loading all `RunResults` objects. But, this does increase the footprint of this PR, so I've marked it as a HOLD for now to ponder...

```py
# Load a CVAT annotation run
results = dataset.load_annotation_results(anno_key)

# Use API to modify tasks
api = results.connect_to_api()

# Or, delete tasks this way
results.delete_tasks(...)

# Or, delete tasks this way
results.cleanup()

# This PR adds this syntax...
results.save()

# ...because the way to achieve this before is ugly
results._backend.save_run_results(dataset, anno_key, results)
```