### PR TITLE
Adding support for passing data map directory to importers

### DIFF
--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -2258,8 +2258,8 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
                 :class:`fiftyone.types.dataset_types.Dataset` type of the
                 dataset
             data_path (None): an optional parameter that enables explicit
-                control over the location of the exported media for certain
-                dataset types. Can be any of the following:
+                control over the location of the media for certain dataset
+                types. Can be any of the following:
 
                 -   a folder name like ``"data"`` or ``"data/"`` specifying a
                     subfolder of ``dataset_dir`` in which the media lies
@@ -2273,6 +2273,7 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
                     :meth:`fiftyone.core.collections.SampleCollection.export`
                 -   an absolute filepath to a JSON manifest file. In this case,
                     ``dataset_dir`` has no effect on the location of the data
+                -   a dict mapping filenames to absolute filepaths
 
                 By default, it is assumed that the data can be located in the
                 default location within ``dataset_dir`` for the dataset type
@@ -2414,8 +2415,8 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
                 :class:`fiftyone.types.dataset_types.Dataset` type of the
                 dataset
             data_path (None): an optional parameter that enables explicit
-                control over the location of the exported media for certain
-                dataset types. Can be any of the following:
+                control over the location of the media for certain dataset
+                types. Can be any of the following:
 
                 -   a folder name like ``"data"`` or ``"data/"`` specifying a
                     subfolder of ``dataset_dir`` in which the media lies
@@ -2429,6 +2430,7 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
                     :meth:`fiftyone.core.collections.SampleCollection.export`
                 -   an absolute filepath to a JSON manifest file. In this case,
                     ``dataset_dir`` has no effect on the location of the data
+                -   a dict mapping filenames to absolute filepaths
 
                 By default, it is assumed that the data can be located in the
                 default location within ``dataset_dir`` for the dataset type
@@ -2566,8 +2568,8 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
                 :class:`fiftyone.types.dataset_types.Dataset` type of the
                 dataset in ``archive_path``
             data_path (None): an optional parameter that enables explicit
-                control over the location of the exported media for certain
-                dataset types. Can be any of the following:
+                control over the location of the media for certain dataset
+                types. Can be any of the following:
 
                 -   a folder name like ``"data"`` or ``"data/"`` specifying a
                     subfolder of ``dataset_dir`` in which the media lies
@@ -2581,6 +2583,7 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
                     :meth:`fiftyone.core.collections.SampleCollection.export`
                 -   an absolute filepath to a JSON manifest file. In this case,
                     ``archive_path`` has no effect on the location of the data
+                -   a dict mapping filenames to absolute filepaths
 
                 By default, it is assumed that the data can be located in the
                 default location within ``archive_path`` for the dataset type
@@ -2715,8 +2718,8 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
                 :class:`fiftyone.types.dataset_types.Dataset` type of the
                 dataset in ``archive_path``
             data_path (None): an optional parameter that enables explicit
-                control over the location of the exported media for certain
-                dataset types. Can be any of the following:
+                control over the location of the media for certain dataset
+                types. Can be any of the following:
 
                 -   a folder name like ``"data"`` or ``"data/"`` specifying a
                     subfolder of ``dataset_dir`` in which the media lies
@@ -2730,6 +2733,7 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
                     :meth:`fiftyone.core.collections.SampleCollection.export`
                 -   an absolute filepath to a JSON manifest file. In this case,
                     ``archive_path`` has no effect on the location of the data
+                -   a dict mapping filenames to absolute filepaths
 
                 By default, it is assumed that the data can be located in the
                 default location within ``archive_path`` for the dataset type
@@ -3475,8 +3479,8 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
                 :class:`fiftyone.types.dataset_types.Dataset` type of the
                 dataset
             data_path (None): an optional parameter that enables explicit
-                control over the location of the exported media for certain
-                dataset types. Can be any of the following:
+                control over the location of the media for certain dataset
+                types. Can be any of the following:
 
                 -   a folder name like ``"data"`` or ``"data/"`` specifying a
                     subfolder of ``dataset_dir`` in which the media lies
@@ -3490,6 +3494,7 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
                     :meth:`fiftyone.core.collections.SampleCollection.export`
                 -   an absolute filepath to a JSON manifest file. In this case,
                     ``dataset_dir`` has no effect on the location of the data
+                -   a dict mapping filenames to absolute filepaths
 
                 By default, it is assumed that the data can be located in the
                 default location within ``dataset_dir`` for the dataset type
@@ -3582,8 +3587,8 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
                 :class:`fiftyone.types.dataset_types.Dataset` type of the
                 dataset in ``archive_path``
             data_path (None): an optional parameter that enables explicit
-                control over the location of the exported media for certain
-                dataset types. Can be any of the following:
+                control over the location of the media for certain dataset
+                types. Can be any of the following:
 
                 -   a folder name like ``"data"`` or ``"data/"`` specifying a
                     subfolder of ``dataset_dir`` in which the media lies
@@ -3597,6 +3602,7 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
                     :meth:`fiftyone.core.collections.SampleCollection.export`
                 -   an absolute filepath to a JSON manifest file. In this case,
                     ``archive_path`` has no effect on the location of the data
+                -   a dict mapping filenames to absolute filepaths
 
                 By default, it is assumed that the data can be located in the
                 default location within ``archive_path`` for the dataset type

--- a/fiftyone/utils/bdd.py
+++ b/fiftyone/utils/bdd.py
@@ -46,6 +46,7 @@ class BDDDatasetImporter(
             -   an absolute filepath specifying the location of the JSON data
                 manifest. In this case, ``dataset_dir`` has no effect on the
                 location of the data
+            -   a dict mapping filenames to absolute filepaths
 
             If None, this parameter will default to whichever of ``data/`` or
             ``data.json`` exists in the dataset directory

--- a/fiftyone/utils/coco.py
+++ b/fiftyone/utils/coco.py
@@ -256,6 +256,7 @@ class COCODetectionDatasetImporter(
             -   an absolute filepath specifying the location of the JSON data
                 manifest. In this case, ``dataset_dir`` has no effect on the
                 location of the data
+            -   a dict mapping filenames to absolute filepaths
 
             If None, this parameter will default to whichever of ``data/`` or
             ``data.json`` exists in the dataset directory

--- a/fiftyone/utils/cvat.py
+++ b/fiftyone/utils/cvat.py
@@ -61,6 +61,7 @@ class CVATImageDatasetImporter(
             -   an absolute filepath specifying the location of the JSON data
                 manifest. In this case, ``dataset_dir`` has no effect on the
                 location of the data
+            -   a dict mapping filenames to absolute filepaths
 
             If None, this parameter will default to whichever of ``data/`` or
             ``data.json`` exists in the dataset directory
@@ -232,6 +233,7 @@ class CVATVideoDatasetImporter(
             -   an absolute filepath specifying the location of the JSON data
                 manifest. In this case, ``dataset_dir`` has no effect on the
                 location of the data
+            -   a dict mapping filenames to absolute filepaths
 
             If None, this parameter will default to whichever of ``data/`` or
             ``data.json`` exists in the dataset directory

--- a/fiftyone/utils/data/importers.py
+++ b/fiftyone/utils/data/importers.py
@@ -1845,6 +1845,7 @@ class FiftyOneImageClassificationDatasetImporter(
             -   an absolute filepath specifying the location of the JSON data
                 manifest. In this case, ``dataset_dir`` has no effect on the
                 location of the data
+            -   a dict mapping filenames to absolute filepaths
 
             If None, this parameter will default to whichever of ``data/`` or
             ``data.json`` exists in the dataset directory
@@ -2248,6 +2249,7 @@ class FiftyOneImageDetectionDatasetImporter(
             -   an absolute filepath specifying the location of the JSON data
                 manifest. In this case, ``dataset_dir`` has no effect on the
                 location of the data
+            -   a dict mapping filenames to absolute filepaths
 
             If None, this parameter will default to whichever of ``data/`` or
             ``data.json`` exists in the dataset directory
@@ -2418,6 +2420,7 @@ class FiftyOneTemporalDetectionDatasetImporter(
             -   an absolute filepath specifying the location of the JSON data
                 manifest. In this case, ``dataset_dir`` has no effect on the
                 location of the data
+            -   a dict mapping filenames to absolute filepaths
 
             If None, this parameter will default to whichever of ``data/`` or
             ``data.json`` exists in the dataset directory
@@ -2593,6 +2596,7 @@ class ImageSegmentationDirectoryImporter(
             -   an absolute filepath specifying the location of the JSON data
                 manifest. In this case, ``dataset_dir`` has no effect on the
                 location of the data
+            -   a dict mapping filenames to absolute filepaths
 
             If None, this parameter will default to whichever of ``data/`` or
             ``data.json`` exists in the dataset directory

--- a/fiftyone/utils/geojson.py
+++ b/fiftyone/utils/geojson.py
@@ -312,6 +312,7 @@ class GeoJSONDatasetImporter(
             -   an absolute filepath specifying the location of the JSON data
                 manifest. In this case, ``dataset_dir`` has no effect on the
                 location of the data
+            -   a dict mapping filenames to absolute filepaths
 
             If None, this parameter will default to whichever of ``data/`` or
             ``data.json`` exists in the dataset directory

--- a/fiftyone/utils/kitti.py
+++ b/fiftyone/utils/kitti.py
@@ -44,6 +44,7 @@ class KITTIDetectionDatasetImporter(
             -   an absolute filepath specifying the location of the JSON data
                 manifest. In this case, ``dataset_dir`` has no effect on the
                 location of the data
+            -   a dict mapping filenames to absolute filepaths
 
             If None, this parameter will default to whichever of ``data/`` or
             ``data.json`` exists in the dataset directory

--- a/fiftyone/utils/voc.py
+++ b/fiftyone/utils/voc.py
@@ -46,6 +46,7 @@ class VOCDetectionDatasetImporter(
             -   an absolute filepath specifying the location of the JSON data
                 manifest. In this case, ``dataset_dir`` has no effect on the
                 location of the data
+            -   a dict mapping filenames to absolute filepaths
 
             If None, this parameter will default to whichever of ``data/`` or
             ``data.json`` exists in the dataset directory


### PR DESCRIPTION
Adds support for directly passing a `filename -> filepath` mapping dict to the `data_path` parameter of importers.

Previously one could only pass the path to a JSON path on disk containing the mapping, but in many workflows it is more natural to construct + provide the mapping in-memory.