### PR TITLE
Sanitize CVAT URLs

### DIFF
--- a/fiftyone/utils/cvat.py
+++ b/fiftyone/utils/cvat.py
@@ -2936,7 +2936,7 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
 
     def __init__(self, name, url, username=None, password=None, headers=None):
         self._name = name
-        self._url = url
+        self._url = url.rstrip("/")
         self._username = username
         self._password = password
         self._headers = headers


### PR DESCRIPTION
This PR allows CVAT server URLs to contain a trailing `/` without raising errors when working with our CVAT API.

```python
import fiftyone.utils.cvat as fouc

# Works
url = "https://cvat.org"
api = fouc.CVATAnnotationAPI("cvat", url)

# Previously raised 405 error, now works
url = "https://cvat.org/"
api = fouc.CVATAnnotationAPI("cvat", url)
```