### PR TITLE
Alternative implementation for #1456

### DIFF
--- a/docs/source/integrations/cvat.rst
+++ b/docs/source/integrations/cvat.rst
@@ -2060,15 +2060,16 @@ every 10th frame as a keyframe to provide a better editing experience in CVAT:
 
 .. _cvat-existing-tasks:
 
-Importing existing CVAT tasks
-_____________________________
+Importing existing tasks
+________________________
 
 FiftyOne's CVAT integration is designed to manage the full annotation workflow,
 from task creation to annotation import.
 
 However, if you have created CVAT tasks outside of FiftyOne, you can use the
 :func:`import_dataset() <fiftyone.utils.cvat.import_dataset>` utility to import
-a CVAT project or individual task(s) into a new or existing FiftyOne dataset:
+individual task(s) or an entire project into a new or existing FiftyOne
+dataset:
 
 .. code:: python
     :linenos:

--- a/fiftyone/utils/annotations.py
+++ b/fiftyone/utils/annotations.py
@@ -180,7 +180,7 @@ def annotate(
             % samples.__class__.__name__
         )
 
-    config = _parse_config(backend, None, media_field, **kwargs)
+    config = _parse_config(backend, None, media_field=media_field, **kwargs)
     anno_backend = config.build()
     anno_backend.ensure_requirements()
 
@@ -231,7 +231,7 @@ def _get_patches_view_label_ids(patches_view):
     return ids
 
 
-def _parse_config(name, label_schema, media_field, **kwargs):
+def _parse_config(name, label_schema, **kwargs):
     if name is None:
         name = fo.annotation_config.default_backend
 
@@ -257,7 +257,7 @@ def _parse_config(name, label_schema, media_field, **kwargs):
         config_cls = etau.get_class(config_cls)
 
     params.update(**kwargs)
-    return config_cls(name, label_schema, media_field=media_field, **params)
+    return config_cls(name, label_schema, **params)
 
 
 # The supported label type strings and their corresponding FiftyOne types


### PR DESCRIPTION
Uses https://github.com/voxel51/fiftyone/pull/1505 and https://github.com/voxel51/fiftyone/pull/1506.

An alternative implementation of https://github.com/voxel51/fiftyone/pull/1456 that also implements the TODO items mentioned there.

Example usage:

```py
import os

import fiftyone as fo
import fiftyone.core.utils as fou
import fiftyone.zoo as foz
import fiftyone.utils.cvat as fouc

dataset = foz.load_zoo_dataset("quickstart")
dataset = dataset.select_fields("ground_truth").clone()

# Create a CVAT project with labels
task_size = 10
results = dataset.annotate(
    "test",
    label_field="ground_truth",
    task_size=task_size,
    segment_size=3,
    project_name="test",
)
# print(results.task_ids)  # if using `task_ids` instead of `project_name`

#
# In order to load annotations, we need a mapping from CVAT image filenames to
# filepaths on local disk
#
# Since we're using a CVAT task uploaded via FiftyOne, the mapping is a bit
# weird
#
data_map = {}
for batch in fou.iter_batches(dataset.values("filepath"), task_size):
    for idx, filepath in enumerate(batch):
        filename = "%06d_%s" % (idx, os.path.basename(filepath))
        data_map[filename] = filepath

# Default: import into fields matching the label type (eg "detections")
fouc.import_annotations(
    dataset,
    project_name="test",
    data_path=data_map,
)

# But, we can instead prompt for field names
fouc.import_annotations(
    dataset,
    project_name="test",
    data_path=data_map,
    label_types="prompt",
)

# Or we can explicitly specify where to import
fouc.import_annotations(
    dataset,
    project_name="test",
    data_path=data_map,
    label_types={"detections": "ground_truth2"},
)

session = fo.launch_app(dataset)
```
