### PR TITLE
Fixing expressions containing near-epoch dates

### DIFF
--- a/fiftyone/core/expressions.py
+++ b/fiftyone/core/expressions.py
@@ -4616,6 +4616,7 @@ def _do_to_mongo(val, prefix):
         return [_do_to_mongo(v, prefix) for v in val]
 
     if isinstance(val, (date, datetime)):
+        # The arg needs must be float (not int) to avoid errors near the epoch
         return {"$toDate": fou.datetime_to_timestamp(val)}
 
     if isinstance(val, timedelta):

--- a/fiftyone/core/utils.py
+++ b/fiftyone/core/utils.py
@@ -1267,7 +1267,7 @@ def timestamp_to_datetime(ts):
     Returns:
         a `datetime.datetime`
     """
-    dt = datetime.utcfromtimestamp(ts / 1000)
+    dt = datetime.utcfromtimestamp(ts / 1000.0)
 
     if fo.config.timezone is None:
         return dt
@@ -1285,7 +1285,9 @@ def timedelta_to_ms(td):
     Returns:
         the float number of milliseconds
     """
-    return 86400000.0 * td.days + 1000.0 * td.seconds + td.microseconds / 1000
+    return (
+        86400000.0 * td.days + 1000.0 * td.seconds + td.microseconds / 1000.0
+    )
 
 
 class ResponseStream(object):

--- a/fiftyone/core/utils.py
+++ b/fiftyone/core/utils.py
@@ -1246,7 +1246,7 @@ def datetime_to_timestamp(dt):
         dt: a `datetime.date` or `datetime.datetime`
 
     Returns:
-        the number of milliseconds since epoch
+        the float number of milliseconds since epoch
     """
     if type(dt) is date:
         dt = datetime(dt.year, dt.month, dt.day)
@@ -1254,7 +1254,7 @@ def datetime_to_timestamp(dt):
     if dt.tzinfo is None:
         dt = dt.replace(tzinfo=pytz.utc)
 
-    return int(1000 * dt.timestamp())
+    return 1000.0 * dt.timestamp()
 
 
 def timestamp_to_datetime(ts):
@@ -1283,11 +1283,9 @@ def timedelta_to_ms(td):
         td: a `datetime.timedelta`
 
     Returns:
-        the number of milliseconds
+        the float number of milliseconds
     """
-    return int(
-        86400000 * td.days + 1000 * td.seconds + td.microseconds // 1000
-    )
+    return 86400000.0 * td.days + 1000.0 * td.seconds + td.microseconds / 1000
 
 
 class ResponseStream(object):

--- a/tests/unittests/view_tests.py
+++ b/tests/unittests/view_tests.py
@@ -589,11 +589,11 @@ class ViewExpressionTests(unittest.TestCase):
     def test_dates(self):
         dataset = fo.Dataset()
 
-        date1 = date(2021, 8, 24)
-        date2 = date(2021, 8, 25)
-        date3 = date(2021, 8, 26)
+        date1 = date(1970, 1, 1)
+        date2 = date(1970, 1, 2)
+        date3 = date(1970, 1, 3)
 
-        query_date = datetime(2021, 8, 25, 1, 0, 0)
+        query_date = datetime(1970, 1, 2, 1, 0, 0)
         query_delta = timedelta(hours=2)
 
         dataset.add_samples(
@@ -626,11 +626,11 @@ class ViewExpressionTests(unittest.TestCase):
     def test_datetimes(self):
         dataset = fo.Dataset()
 
-        date1 = datetime(2021, 8, 24, 1, 0, 0)
-        date2 = datetime(2021, 8, 24, 2, 0, 0)
-        date3 = datetime(2021, 8, 24, 3, 0, 0)
+        date1 = datetime(1970, 1, 1, 1, 0, 0)
+        date2 = datetime(1970, 1, 1, 2, 0, 0)
+        date3 = datetime(1970, 1, 1, 3, 0, 0)
 
-        query_date = datetime(2021, 8, 24, 2, 1, 0)
+        query_date = datetime(1970, 1, 1, 2, 1, 0)
         query_delta = timedelta(minutes=30)
 
         dataset.add_samples(


### PR DESCRIPTION
Resolves https://github.com/voxel51/fiftyone/issues/1502.

The issue was that apparently MongoDB's `{$toDate: arg}` for some reason seems to require `arg` to be a `float` or a `long` but **NOT** an `int`. The lack of `int` support meant that expressions involving datetimes too close to the epoch would result in MongoDB expressions involving ints that would raise an error!

```py
from datetime import datetime

import fiftyone as fo
from fiftyone import ViewField as F

dataset = fo.Dataset()
dataset.add_samples(
    [
        fo.Sample(
            filepath="image1.png",
            capture_date=datetime(1970, 1, 1, 1, 0, 0),
        ),
        fo.Sample(
            filepath="image2.png",
            capture_date=datetime(1970, 1, 1, 2, 0, 0),
        ),
        fo.Sample(
            filepath="image3.png",
            capture_date=datetime(1970, 1, 1, 3, 0, 0),
        ),
    ]
)

# Used to fail; now works
print(dataset.match(F("capture_date") > datetime(1970, 1, 1, 2, 0, 0)))
```
