### PR TITLE
Import existing CVAT datasets into FiftyOne (#2)

### DIFF
--- a/docs/source/integrations/cvat.rst
+++ b/docs/source/integrations/cvat.rst
@@ -2113,6 +2113,86 @@ every 10th frame as a keyframe to provide a better editing experience in CVAT:
     with the shape's contents. See :ref:`this section <cvat-limitations>` for
     details.
 
+.. _cvat-importing:
+
+Importing datasets from CVAT
+____________________________
+
+The previous examples showed ways to link existing an FiftyOne |Dataset| to
+annotation tasks and projects in CVAT. However, you may have a CVAT project or
+task that you want to use to create a |Dataset|.
+
+One way to create a |Dataset| using existing data and annotations from
+CVAT is to simply export the CVAT dataset to disk and import it using the
+:ref:`CVATImageDataset <CVATImageDataset-import>`
+or 
+:ref:`CVATVideoDataset <CVATVideoDataset-import>`
+types.
+
+Alternatively, you can use the
+:func:`import_dataset() <fiftyone.utils.cvat.import_dataset>` CVAT utility to provide
+paths to local data and the name of a CVAT project or list of CVAT task IDs
+to automatically create a |Dataset|.
+
+The following parameters are supported by :func:`import_dataset() <fiftyone.utils.cvat.import_dataset>`:
+
+-   **data_path**: a parameter that enables explicit control
+    over the location of the media. Can be any of the following:
+
+    -   an absolute directory path where the media files reside
+    -   an absolute filepath specifying the location of the JSON data
+        manifest containing a mapping of CVAT filenames to absolute
+        filepaths on disk
+-   **project_name** (*None*): the name of the CVAT project  containing labels to
+    load into the dataset. Required if `tasks_list` is `None`
+-   **tasks_list** (*None*): a list of integer IDs of CVAT tasks containing
+    labels to load into the dataset. Required if `project_name` is
+    `None`
+-   **dataset_name** (*None*): an optional name to give to the dataset
+
+
+.. code:: python
+    :linenos:
+
+    import json
+    import os
+
+    import fiftyone as fo
+    import fiftyone.utils.cvat as fouc
+    import fiftyone.zoo as foz
+
+    ex_dataset = foz.load_zoo_dataset("quickstart", max_samples=3).clone()
+
+    project_name = "example_import"
+
+    # Create a CVAT project for this example
+    anno_key = "create_project"
+    results = ex_dataset.annotate(
+        anno_key,
+        label_field="ground_truth",
+        project_name=project_name,
+    )
+
+    # Path to the directory containing your media files
+    # Or path to a JSON file containing a mapping from CVAT filename to
+    # filepath on disk
+    data_path = "/tmp/cvat_import_example.json"
+    paths = ex_dataset.values("filepath")
+    filepath_map = {
+        "%06d_%s" % (idx, os.path.basename(p)): p for idx, p in enumerate(paths)
+    }
+    with open(data_path, "w") as f:
+        json.dump(filepath_map, f)
+
+    # Create Dataset from CVAT project
+    dataset = fouc.import_dataset(
+        data_path,
+        project_name=project_name,
+        dataset_name="example_dataset",
+    )
+
+    session = fo.launch_app(dataset)
+
 .. _cvat-utils:
 
 Additional utilities

--- a/docs/source/integrations/cvat.rst
+++ b/docs/source/integrations/cvat.rst
@@ -2122,9 +2122,8 @@ FiftyOne's CVAT integration is designed to manage the full annotation workflow,
 from task creation to annotation import.
 
 However, if you have created CVAT tasks outside of FiftyOne, you can use the
-:func:`import_dataset() <fiftyone.utils.cvat.import_dataset>` utility to import
-individual task(s) or an entire project into a new or existing FiftyOne
-dataset:
+:func:`import_annotations() <fiftyone.utils.cvat.import_annotations>` utility
+to import individual task(s) or an entire project into a FiftyOne dataset.
 
 .. code:: python
     :linenos:
@@ -2138,23 +2137,32 @@ dataset:
     dataset = foz.load_zoo_dataset("quickstart", max_samples=3).clone()
 
     # Create a pre-existing CVAT project
-    anno_key = "example_import"
     results = dataset.annotate(
-        anno_key,
+        "example_import",
         label_field="ground_truth",
         project_name="example_import",
     )
 
+    #
     # Create a mapping between filenames in the pre-existing CVAT project and
     # the locations of the media locally on disk for the FiftyOne dataset
+    #
+    # Since we're using a CVAT task uploaded via FiftyOne, the mapping is a bit
+    # weird
+    #
     filepaths = dataset.values("filepath")
-    data_path = {
+    data_map = {
         "%06d_%s" % (idx, os.path.basename(p)): p
         for idx, p in enumerate(filepaths)
     }
 
     # Create dataset from pre-existing CVAT project
-    dataset = fouc.import_dataset(data_path, project_name=project_name)
+    dataset = fo.Dataset()
+    fouc.import_annotations(
+        dataset,
+        project_name=project_name,
+        data_path=data_map,
+    )
 
     session = fo.launch_app(dataset)
 

--- a/docs/source/integrations/cvat.rst
+++ b/docs/source/integrations/cvat.rst
@@ -2113,86 +2113,56 @@ every 10th frame as a keyframe to provide a better editing experience in CVAT:
     with the shape's contents. See :ref:`this section <cvat-limitations>` for
     details.
 
-.. _cvat-importing:
+.. _cvat-existing-tasks:
 
-Importing datasets from CVAT
-____________________________
+Importing existing CVAT tasks
+_____________________________
 
-The previous examples showed ways to link existing an FiftyOne |Dataset| to
-annotation tasks and projects in CVAT. However, you may have a CVAT project or
-task that you want to use to create a |Dataset|.
+FiftyOne's CVAT integration is designed to manage the full annotation workflow,
+from task creation to annotation import.
 
-One way to create a |Dataset| using existing data and annotations from
-CVAT is to simply export the CVAT dataset to disk and import it using the
-:ref:`CVATImageDataset <CVATImageDataset-import>`
-or 
-:ref:`CVATVideoDataset <CVATVideoDataset-import>`
-types.
-
-Alternatively, you can use the
-:func:`import_dataset() <fiftyone.utils.cvat.import_dataset>` CVAT utility to provide
-paths to local data and the name of a CVAT project or list of CVAT task IDs
-to automatically create a |Dataset|.
-
-The following parameters are supported by :func:`import_dataset() <fiftyone.utils.cvat.import_dataset>`:
-
--   **data_path**: a parameter that enables explicit control
-    over the location of the media. Can be any of the following:
-
-    -   an absolute directory path where the media files reside, filenames 
-        on disk must match those in CVAT
-    -   an absolute filepath specifying the location of the JSON data
-        manifest containing a mapping of CVAT filenames to absolute
-        filepaths on disk
--   **project_name** (*None*): the name of the CVAT project  containing labels to
-    load into the dataset. Required if `task_ids` is `None`
--   **task_ids** (*None*): a list of integer IDs of CVAT tasks containing
-    labels to load into the dataset. Required if `project_name` is
-    `None`
--   **dataset_name** (*None*): an optional name to give to the dataset
-
+However, if you have created CVAT tasks outside of FiftyOne, you can use the
+:func:`import_dataset() <fiftyone.utils.cvat.import_dataset>` utility to import
+a CVAT project or individual task(s) into a new or existing FiftyOne dataset:
 
 .. code:: python
     :linenos:
 
-    import json
     import os
 
     import fiftyone as fo
     import fiftyone.utils.cvat as fouc
     import fiftyone.zoo as foz
 
-    ex_dataset = foz.load_zoo_dataset("quickstart", max_samples=3).clone()
+    dataset = foz.load_zoo_dataset("quickstart", max_samples=3).clone()
 
-    project_name = "example_import"
-
-    # Create a CVAT project for this example
-    anno_key = "create_project"
-    results = ex_dataset.annotate(
+    # Create a pre-existing CVAT project
+    anno_key = "example_import"
+    results = dataset.annotate(
         anno_key,
         label_field="ground_truth",
-        project_name=project_name,
+        project_name="example_import",
     )
 
-    # Path to the directory containing your media files
-    # Or path to a JSON file containing a mapping from CVAT filename to
-    # filepath on disk
-    data_path = "/tmp/cvat_import_example.json"
-    paths = ex_dataset.values("filepath")
-    filepath_map = {
-        "%06d_%s" % (idx, os.path.basename(p)): p for idx, p in enumerate(paths)
+    # Create a mapping between filenames in the pre-existing CVAT project and
+    # the locations of the media locally on disk for the FiftyOne dataset
+    filepaths = dataset.values("filepath")
+    data_path = {
+        "%06d_%s" % (idx, os.path.basename(p)): p
+        for idx, p in enumerate(filepaths)
     }
-    with open(data_path, "w") as f:
-        json.dump(filepath_map, f)
 
-    # Create Dataset from CVAT project
-    dataset = fouc.import_dataset(
-        data_path,
-        project_name=project_name,
-        dataset_name="example_dataset",
-    )
+    # Create dataset from pre-existing CVAT project
+    dataset = fouc.import_dataset(data_path, project_name=project_name)
 
     session = fo.launch_app(dataset)
+
+.. note::
+
+    Another strategy for importing existing CVAT annotations into FiftyOne is
+    to simply export the annotations from the CVAT UI and then import them via
+    the :ref:`CVATImageDataset <CVATImageDataset-import>` or
+    :ref:`CVATVideoDataset <CVATVideoDataset-import>` types.
 
 .. _cvat-utils:
 

--- a/docs/source/integrations/cvat.rst
+++ b/docs/source/integrations/cvat.rst
@@ -2139,7 +2139,8 @@ The following parameters are supported by :func:`import_dataset() <fiftyone.util
 -   **data_path**: a parameter that enables explicit control
     over the location of the media. Can be any of the following:
 
-    -   an absolute directory path where the media files reside
+    -   an absolute directory path where the media files reside, filenames 
+        on disk must match those in CVAT
     -   an absolute filepath specifying the location of the JSON data
         manifest containing a mapping of CVAT filenames to absolute
         filepaths on disk

--- a/docs/source/integrations/cvat.rst
+++ b/docs/source/integrations/cvat.rst
@@ -2145,8 +2145,8 @@ The following parameters are supported by :func:`import_dataset() <fiftyone.util
         manifest containing a mapping of CVAT filenames to absolute
         filepaths on disk
 -   **project_name** (*None*): the name of the CVAT project  containing labels to
-    load into the dataset. Required if `tasks_list` is `None`
--   **tasks_list** (*None*): a list of integer IDs of CVAT tasks containing
+    load into the dataset. Required if `task_ids` is `None`
+-   **task_ids** (*None*): a list of integer IDs of CVAT tasks containing
     labels to load into the dataset. Required if `project_name` is
     `None`
 -   **dataset_name** (*None*): an optional name to give to the dataset

--- a/docs/source/integrations/cvat.rst
+++ b/docs/source/integrations/cvat.rst
@@ -2115,15 +2115,16 @@ every 10th frame as a keyframe to provide a better editing experience in CVAT:
 
 .. _cvat-existing-tasks:
 
-Importing existing CVAT tasks
-_____________________________
+Importing existing tasks
+________________________
 
 FiftyOne's CVAT integration is designed to manage the full annotation workflow,
 from task creation to annotation import.
 
 However, if you have created CVAT tasks outside of FiftyOne, you can use the
 :func:`import_dataset() <fiftyone.utils.cvat.import_dataset>` utility to import
-a CVAT project or individual task(s) into a new or existing FiftyOne dataset:
+individual task(s) or an entire project into a new or existing FiftyOne
+dataset:
 
 .. code:: python
     :linenos:

--- a/fiftyone/utils/annotations.py
+++ b/fiftyone/utils/annotations.py
@@ -1065,8 +1065,10 @@ def load_annotations(
                 elif unexpected == "keep":
                     new_field = anno_type
                 elif isinstance(unexpected, dict):
+                    # Undocumented: allow dict mapping to field names
                     new_field = unexpected.get(anno_type, None)
                 elif etau.is_container(unexpected) and anno_type in unexpected:
+                    # Undocumented: allow list of label types to keep
                     new_field = anno_type
                 else:
                     new_field = None

--- a/fiftyone/utils/annotations.py
+++ b/fiftyone/utils/annotations.py
@@ -180,7 +180,7 @@ def annotate(
             % samples.__class__.__name__
         )
 
-    config = _parse_config(backend, None, media_field, **kwargs)
+    config = _parse_config(backend, None, media_field=media_field, **kwargs)
     anno_backend = config.build()
     anno_backend.ensure_requirements()
 
@@ -231,7 +231,7 @@ def _get_patches_view_label_ids(patches_view):
     return ids
 
 
-def _parse_config(name, label_schema, media_field, **kwargs):
+def _parse_config(name, label_schema, **kwargs):
     if name is None:
         name = fo.annotation_config.default_backend
 
@@ -257,7 +257,7 @@ def _parse_config(name, label_schema, media_field, **kwargs):
         config_cls = etau.get_class(config_cls)
 
     params.update(**kwargs)
-    return config_cls(name, label_schema, media_field=media_field, **params)
+    return config_cls(name, label_schema, **params)
 
 
 # The supported label type strings and their corresponding FiftyOne types

--- a/fiftyone/utils/annotations.py
+++ b/fiftyone/utils/annotations.py
@@ -1000,6 +1000,8 @@ def load_annotations(
             -   ``"prompt"``: present an interactive prompt to direct/discard
                 unexpected labels
             -   ``"ignore"``: automatically ignore any unexpected labels
+            -   ``"keep"``: automatically keep all unexpected labels in a field
+                whose name matches the the label type
             -   ``"return"``: return a dict containing all unexpected labels,
                 or ``None`` if there aren't any
         cleanup (False): whether to delete any informtation regarding this run
@@ -1052,14 +1054,28 @@ def load_annotations(
                     )
             else:
                 # Unexpected labels
-                if unexpected == "prompt" and allow_additions:
+                if not allow_additions:
+                    new_field = None
+                elif unexpected == "prompt":
                     new_field = _prompt_field(
                         samples, anno_type, label_field, label_schema
                     )
+                elif unexpected == "return":
+                    new_field = None
+                elif unexpected == "keep":
+                    new_field = anno_type
+                elif isinstance(unexpected, dict):
+                    new_field = unexpected.get(anno_type, None)
+                elif etau.is_container(unexpected) and anno_type in unexpected:
+                    new_field = anno_type
                 else:
                     new_field = None
 
                 if new_field:
+                    new_field = _handle_frame_fields(
+                        new_field, samples, label_field
+                    )
+
                     if anno_type == "scalar":
                         _merge_scalars(samples, annos, results, new_field)
                     else:
@@ -1067,12 +1083,15 @@ def load_annotations(
                             samples, annos, results, new_field, anno_type
                         )
                 else:
-                    logger.info(
-                        "Skipping unexpected labels of type '%s' in field "
-                        "'%s'",
-                        anno_type,
-                        label_field,
-                    )
+                    if label_field:
+                        logger.info(
+                            "Skipping unexpected labels of type '%s' in field "
+                            "'%s'",
+                            anno_type,
+                            label_field,
+                        )
+                    else:
+                        logger.info("Skipping labels of type '%s'", anno_type)
 
                     if unexpected == "return":
                         unexpected_annos[label_field][anno_type] = annos
@@ -1084,6 +1103,18 @@ def load_annotations(
 
     if unexpected == "return":
         return dict(unexpected_annos) if unexpected_annos else None
+
+
+def _handle_frame_fields(field, samples, ref_field):
+    if samples.media_type != fom.VIDEO:
+        return field
+
+    if (
+        ref_field is None or samples._is_frame_field(ref_field)
+    ) and not samples._is_frame_field(field):
+        field = samples._FRAMES_PREFIX + field
+
+    return field
 
 
 def _parse_attributes(label_info):
@@ -1112,12 +1143,19 @@ def _get_writeable_attributes(attributes):
 
 
 def _prompt_field(samples, label_type, label_field, label_schema):
-    new_field = input(
-        "Found unexpected labels of type '%s' when loading annotations for "
-        "field '%s'.\nPlease enter a new or compatible existing field name in "
-        "which to store these annotations, or empty to skip: "
-        % (label_type, label_field)
-    )
+    if label_field:
+        new_field = input(
+            "Found unexpected labels of type '%s' when loading annotations "
+            "for field '%s'.\nPlease enter a new or compatible existing field "
+            "name in which to store these annotations, or empty to skip: "
+            % (label_type, label_field)
+        )
+    else:
+        new_field = input(
+            "Found labels of type '%s'.\nPlease enter a new or compatible "
+            "existing field name in which to store these annotations, or "
+            "empty to skip: " % label_type
+        )
 
     if not new_field:
         return None
@@ -1171,7 +1209,7 @@ def _prompt_field(samples, label_type, label_field, label_schema):
 
         if not is_good_field:
             new_field = input(
-                "Cannot add unexpected labels to field '%s' because it is "
+                "Cannot add labels to field '%s' because it is already "
                 "involved in this annotation run.\nPlease enter a different "
                 "field name or empty to skip: " % new_field
             )
@@ -1697,8 +1735,11 @@ class AnnotationBackendConfig(foa.AnnotationMethodConfig):
     def serialize(self, *args, **kwargs):
         d = super().serialize(*args, **kwargs)
 
-        # Must serialize mask targets with string keys...
         label_schema = d.get("label_schema", {})
+        if not label_schema:
+            return d
+
+        # Must serialize mask targets with string keys...
         for label_info in label_schema.values():
             mask_targets = label_info.get("mask_targets", None)
             if isinstance(mask_targets, dict):

--- a/fiftyone/utils/cvat.py
+++ b/fiftyone/utils/cvat.py
@@ -41,7 +41,7 @@ logger = logging.getLogger(__name__)
 
 
 def import_dataset(
-    data_path, project_name=None, tasks_list=None, dataset_name=None
+    data_path, project_name=None, task_ids=None, dataset_name=None
 ):
     """Create a FiftyOne dataset given a local directory of media and the name of a
     project or list of tasks containing corresponding annotations in CVAT.
@@ -59,7 +59,7 @@ def import_dataset(
 
         dataset = fouc.import_dataset("/path/to/data", project_name="project_name")
         
-        dataset = fouc.import_dataset("/path/to/data.json", tasks_list=[1,42,51])
+        dataset = fouc.import_dataset("/path/to/data.json", task_ids=[1,42,51])
 
 
     Any files that provided in `data_path` that do not exist in CVAT will
@@ -77,8 +77,8 @@ def import_dataset(
                 filepaths on disk
 
         project_name (None): the name of the CVAT project  containing labels to
-            load into the dataset. Required if `tasks_list` is `None`
-        tasks_list (None): a list of integer IDs of CVAT tasks containing
+            load into the dataset. Required if `task_ids` is `None`
+        task_ids (None): a list of integer IDs of CVAT tasks containing
             labels to load into the dataset. Required if `project_name` is
             `None`
         dataset_name (None): an optional name to give to the dataset
@@ -86,13 +86,13 @@ def import_dataset(
     Returns:
         a :class:`fiftyone.core.dataset.Dataset`
     """
-    if project_name is None and tasks_list is None:
+    if project_name is None and task_ids is None:
         raise ValueError(
-            "Either `project_name` or `tasks_list` must be provided."
+            "Either `project_name` or `task_ids` must be provided."
         )
-    if project_name is not None and tasks_list is not None:
+    if project_name is not None and task_ids is not None:
         raise ValueError(
-            "Only one of `project_name` or `tasks_list` is allowed."
+            "Only one of `project_name` or `task_ids` is allowed."
         )
 
     filename_map = foud.ImportPathsMixin._load_data_map(data_path)
@@ -130,7 +130,7 @@ def import_dataset(
 
     else:
         _parse_and_load_tasks(
-            tasks_list,
+            task_ids,
             api,
             filename_map,
             dataset,

--- a/fiftyone/utils/cvat.py
+++ b/fiftyone/utils/cvat.py
@@ -23,6 +23,7 @@ import urllib3
 
 import eta.core.data as etad
 import eta.core.image as etai
+import eta.core.serial as etas
 import eta.core.utils as etau
 
 import fiftyone.constants as foc
@@ -131,6 +132,8 @@ def import_annotations(
     existing_filepaths = sample_collection.values("filepath")
     if data_path is None:
         data_map = {os.path.basename(f): f for f in existing_filepaths}
+    elif etau.is_str(data_path) and data_path.endswith(".json"):
+        data_map = etas.read_json(data_path)
     elif etau.is_str(data_path):
         data_map = {
             os.path.basename(f): f

--- a/fiftyone/utils/cvat.py
+++ b/fiftyone/utils/cvat.py
@@ -5772,14 +5772,9 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
         frame_id_map = {}
         frame_id = -1
 
-        sample_ids = samples.values("id")
-
         if samples.media_type == fom.VIDEO:
-            frame_ids = samples.values("frames.id")
+            sample_ids, frame_ids = samples.values(["id", "frames.id"])
             for _sample_id, _frame_ids in zip(sample_ids, frame_ids):
-                if not _frame_ids:
-                    continue
-
                 for _frame_id in _frame_ids:
                     frame_id += 1
                     frame_id_map[frame_id] = {
@@ -5787,6 +5782,7 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
                         "frame_id": _frame_id,
                     }
         else:
+            sample_ids = samples.values("id")
             for _sample_id in sample_ids:
                 frame_id += 1
                 frame_id_map[frame_id] = {"sample_id": _sample_id}

--- a/fiftyone/utils/cvat.py
+++ b/fiftyone/utils/cvat.py
@@ -40,187 +40,122 @@ import fiftyone.utils.data as foud
 logger = logging.getLogger(__name__)
 
 
-def import_dataset(
-    data_path, project_name=None, task_ids=None, dataset_name=None
+def import_annotations(
+    sample_collection,
+    project_name=None,
+    project_id=None,
+    task_ids=None,
+    data_path=None,
+    label_types=None,
+    insert_new=True,
+    backend="cvat",
 ):
-    """Create a FiftyOne dataset given a local directory of media and the name of a
-    project or list of tasks containing corresponding annotations in CVAT.
+    """Imports annotations from the specified CVAT task(s) or project into a
+    new or existing FiftyOne dataset.
 
-    Instead of a local directory, a JSON file can be provided that maps the
-    filenames of media in CVAT to the corresponding filepaths on disk::
-
-        data_map = {
-            "000000_00880.jpg": "/path/to/data/dir/00880.jpg",
-            "cvat_filename.ext": "/path/to/data/dir2/local_filename.jpg",
-            ...
-        }
-
-    Ex::
-
-        dataset = fouc.import_dataset("/path/to/data", project_name="project_name")
-        
-        dataset = fouc.import_dataset("/path/to/data.json", task_ids=[1,42,51])
-
-
-    Any files that provided in `data_path` that do not exist in CVAT will
-    remain unlabeled, and any files that exist in CVAT that are not found in
-    `data_path` will be excluded. 
+    Provide one of ``project_name``, ``project_id``, or ``task_ids`` to perform
+    an import.
 
     Args:
-        data_path: a parameter that enables explicit control
-            over the location of the media. Can be any of the following:
+        sample_collection: a
+            :class:`fiftyone.core.collections.SampleCollection`
+        project_name (None): the name of a CVAT project to import
+        project_id (None): the ID of a CVAT project to import
+        task_ids (None): a CVAT task ID or iterable of CVAT task IDs to import
+        data_path (None): a parameter that defines the correspondence between
+            the filenames
 
-            -   an absolute directory path where the media files reside,
-                filenames on disk must match those in CVAT
-            -   an absolute filepath specifying the location of the JSON data
-                manifest containing a mapping of CVAT filenames to absolute
-                filepaths on disk
+            -   a directory on disk where the media files reside. In this case,
+                the filenames must match those in CVAT
+            -   a dict mapping CVAT filenames to absolute filepaths to the
+                corresponding media on disk
+            -   the path to a JSON manifest on disk containing a mapping
+                between CVAT filenames and absolute filepaths to the media on
+                disk
 
-        project_name (None): the name of the CVAT project  containing labels to
-            load into the dataset. Required if `task_ids` is `None`
-        task_ids (None): a list of integer IDs of CVAT tasks containing
-            labels to load into the dataset. Required if `project_name` is
-            `None`
-        dataset_name (None): an optional name to give to the dataset
-    
-    Returns:
-        a :class:`fiftyone.core.dataset.Dataset`
+            By default, only annotations whose filename matches an existing
+            sample in ``sample_collection`` will be imported
+        label_types (None): a dict mapping label types to field names of
+            ``sample_collection`` in which to store the labels. By default,
+            the label types will be stored in fields of the same names
+        insert_new (False): whether to create new samples for any media for
+            which annotations are found in the CVAT tasks/project
+        backend ("cvat"): the name of the CVAT backend to use
     """
-    if project_name is None and task_ids is None:
+    if bool(project_name) + bool(project_id) + bool(task_ids) != 1:
         raise ValueError(
-            "Either `project_name` or `task_ids` must be provided."
-        )
-    if project_name is not None and task_ids is not None:
-        raise ValueError(
-            "Only one of `project_name` or `task_ids` is allowed."
+            "Exactly one of {'project_name', 'project_id', 'task_ids'} must "
+            "be provided"
         )
 
-    filename_map = foud.ImportPathsMixin._load_data_map(data_path)
-    filepaths = list(filename_map.values())
+    existing_filepaths = set(sample_collection.values("filepath"))
 
-    dataset = fod.Dataset(dataset_name)
-    dataset.add_samples([fos.Sample(filepath=fp) for fp in filepaths])
-    dataset.ensure_frames()
+    if data_path is None:
+        data_map = {os.path.basename(f): f for f in existing_filepaths}
+    elif etau.is_str(data_path):
+        data_map = {
+            os.path.basename(f): f
+            for f in etau.list_files(data_path, abs_paths=True, recursive=True)
+        }
+    else:
+        data_map = data_path
 
-    # Construct temporary annotation run and config
-    anno_key = "tmp_" + str(ObjectId())
-    label_schema = {None: {"type": "tmp"}}
-
+    label_schema = {None: {}}
     config = foua._parse_config(
-        "cvat", label_schema, "filepath", project_name=project_name
+        backend, label_schema, occluded_attr="occluded"
     )
     anno_backend = config.build()
-    anno_backend.register_run(dataset, anno_key, overwrite=False)
-
     api = anno_backend.connect_to_api()
-    project_id = api.get_project_id(project_name)
 
-    # Parse CVAT schemas and load annotations into dataset
+    if project_name is not None:
+        project_id = api.get_project_id(project_name)
+
     if project_id is not None:
-        _parse_and_load_project(
-            project_id,
-            api,
-            filename_map,
-            dataset,
-            anno_backend,
-            config,
-            anno_key,
-            label_schema,
-        )
+        task_ids = api.get_project_tasks(project_id)
 
+    if etau.is_str(task_ids):
+        task_ids = [task_ids]
     else:
-        _parse_and_load_tasks(
-            task_ids,
-            api,
-            filename_map,
-            dataset,
-            anno_backend,
-            config,
-            anno_key,
-        )
+        task_ids = list(task_ids)
 
-    dataset.delete_annotation_run(anno_key)
-
-    return dataset
-
-
-def _parse_and_load_project(
-    project_id,
-    api,
-    filename_map,
-    dataset,
-    anno_backend,
-    config,
-    anno_key,
-    label_schema,
-):
-    frame_id_map = {}
-    # Parse classes and attributes from project to label schema
-    api._convert_cvat_schema(
-        label_schema, project_id=project_id, update_server=False
-    )
-    project_json = api.get(api.project_url(project_id)).json()
-    task_ids = [task["id"] for task in project_json["tasks"]]
+    # Determine what filepaths we have annotations for
+    task_id_map = {}
     for task_id in task_ids:
-        frame_id_map[task_id] = _build_frame_id_map_for_task(
-            dataset, task_id, api, filename_map
-        )
+        task_id_map[task_id] = _build_task_id_map(api, task_id, data_map)
 
-    _load_tasks_annotations(
-        dataset,
-        task_ids,
-        label_schema,
-        anno_backend,
-        config,
-        anno_key,
-        frame_id_map,
+    filepaths = set(itertools.chain(i.keys() for i in task_id_map.values()))
+
+    if not insert_new:
+        task_filepaths = filepaths.copy()
+        filepaths &= existing_filepaths
+        if len(filepaths) < len(task_filepaths):
+            new_filepaths = task_filepaths - filepaths
+            logger.warning(
+                "Ignoring annotations for %d filepaths (eg %s) that do not "
+                "appear in the input collection",
+                len(new_filepaths),
+                new_filepaths[0],
+            )
+
+    dataset = fod.Dataset()
+    sample_ids = dataset.add_samples(
+        [fos.Sample(filepath=fp) for fp in filepaths]
     )
 
+    sample_id_map = {f: _id for f, _id in zip(filepaths, sample_ids)}
 
-def _parse_and_load_tasks(
-    task_ids, api, filename_map, dataset, anno_backend, config, anno_key
-):
+    # Determine CVAT ID -> FiftyOne ID mapping
     frame_id_map = {}
     for task_id in task_ids:
-        label_schema = {None: {"type": "tmp"}}
-        # Parse classes and attributes from task to label schema
-        api._convert_cvat_schema(
-            label_schema, task_id=task_id, update_server=False
-        )
-        frame_id_map[task_id] = _build_frame_id_map_for_task(
-            dataset, task_id, api, filename_map
-        )
-        _load_tasks_annotations(
-            dataset,
-            [task_id],
-            label_schema,
-            anno_backend,
-            config,
-            anno_key,
-            frame_id_map,
-        )
+        id_map = task_id_map[task_id]
+        frame_id_map[task_id] = _build_frame_id_map(id_map, sample_id_map)
 
-
-def _load_tasks_annotations(
-    dataset,
-    task_ids,
-    label_schema,
-    anno_backend,
-    config,
-    anno_key,
-    frame_id_map,
-):
-    label_schema[None].pop("type", None)
-    config.label_schema = label_schema
-    anno_backend.update_run_config(dataset, anno_key, config)
-
-    # All labels are considered new and will be added
     id_map = {}
     server_id_map = {}
-
     project_ids = []
     job_ids = []
     labels_task_map = {None: task_ids}
+
     results = CVATAnnotationResults(
         dataset,
         config,
@@ -234,20 +169,57 @@ def _load_tasks_annotations(
         backend=anno_backend,
     )
 
-    anno_backend.save_run_results(dataset, anno_key, results)
-    dataset.load_annotations(anno_key)
+    annotations = anno_backend.download_annotations(results)
+
+    if label_types is None:
+        label_types = list(annotations.keys())
+
+    for label_type, annos in annotations.items():
+        if label_type not in label_types:
+            continue
+
+        if label_type == "scalar":
+            dataset.set_values(label_type, annos, key_field="id")
+        else:
+            labels = {_id: list(d.values()) for _id, d in annos.items()}
+            dataset.set_values(label_type, labels, key_field="id")
+
+    # @todo remove the need for this
+    sample_collection._dataset.merge_samples(
+        dataset,
+        key_field="filepath",
+        skip_existing=False,
+        insert_new=insert_new,
+        fields=label_types,
+        merge_lists=True,
+        overwrite=True,
+        expand_schema=True,
+        include_info=False,
+    )
+
+    dataset.delete()
 
 
-def _build_frame_id_map_for_task(dataset, task_id, api, filename_map):
-    task_meta_json = api.get(api.task_data_meta_url(task_id)).json()
-    filenames = [frame["name"] for frame in task_meta_json["frames"]]
-    task_filepaths = []
-    for fn in filenames:
-        task_fp = filename_map.get(fn, None)
-        if task_fp:
-            task_filepaths.append(task_fp)
-    view = dataset.select_by("filepath", task_filepaths)
-    return api._build_frame_id_map(view)
+def _build_task_id_map(api, task_id, data_map):
+    resp = api.get(api.task_data_meta_url(task_id)).json()
+
+    id_map = {}
+    for frame in resp["frames"]:
+        filepath = data_map.get(frame["name"], None)
+        if filepath is not None:
+            id_map[filepath] = frame["id"]
+
+    return id_map
+
+
+def _build_frame_id_map(id_map, sample_id_map):
+    frame_id_map = {}
+    for filepath, frame_id in id_map.items():
+        sample_id = sample_id_map.get(filepath, None)
+        if sample_id is not None:
+            frame_id_map[frame_id] = {"sample_id": sample_id}
+
+    return frame_id_map
 
 
 class CVATImageDatasetImporter(
@@ -3483,6 +3455,18 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
             for project_id in pb(list(project_ids)):
                 self.delete_project(project_id)
 
+    def get_project_tasks(self, project_id):
+        """Returns the IDs of the tasks in the given project.
+
+        Args:
+            project_id: a project ID
+
+        Returns:
+            the list of task IDs
+        """
+        resp = self.get(self.project_url(project_id)).json()
+        return [task["id"] for task in resp.get("tasks", [])]
+
     def create_task(
         self,
         name,
@@ -4073,7 +4057,8 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
         if not self.project_exists(project_id):
             raise ValueError("Project '%s' not found" % project_id)
 
-        return self.get(self.project_url(project_id)).json()["labels"]
+        resp = self.get(self.project_url(project_id)).json()
+        return resp["labels"]
 
     def _get_task_labels(self, task_id):
         resp = self.get(self.task_url(task_id)).json()
@@ -4115,15 +4100,15 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
         occluded_attr=None,
         update_server=True,
     ):
-        if project_id is None:
-            if task_id is None:
-                raise ValueError(
-                    "Either `project_id` or `task_id` must be provided."
-                )
-            else:
-                labels = self._get_task_labels(task_id)
-        else:
+        if project_id is None and task_id is None:
+            raise ValueError(
+                "Either `project_id` or `task_id` must be provided"
+            )
+
+        if project_id is not None:
             labels = self._get_project_labels(project_id)
+        else:
+            labels = self._get_task_labels(task_id)
 
         cvat_schema = {}
         labels_to_update = []
@@ -5050,6 +5035,7 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
         remapped_attrs = {}
 
         is_video = samples.media_type == fom.VIDEO
+        samples = samples.select_fields(label_field)
 
         if is_video:
             field, _ = samples._handle_frame_field(label_field)
@@ -5704,21 +5690,27 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
         return track
 
     def _build_frame_id_map(self, samples):
-        is_video = samples.media_type == fom.VIDEO
+        frame_id_map = {}
         frame_id = -1
 
-        frame_id_map = {}
-        for sample in samples:
-            if is_video:
-                images = sample.frames.values()
-            else:
-                images = [sample]
+        sample_ids = samples.values("id")
 
-            for image in images:
+        if samples.media_type == fom.VIDEO:
+            frame_ids = samples.values("frames.id")
+            for _sample_id, _frame_ids in zip(sample_ids, frame_ids):
+                if not _frame_ids:
+                    continue
+
+                for _frame_id in _frame_ids:
+                    frame_id += 1
+                    frame_id_map[frame_id] = {
+                        "sample_id": _sample_id,
+                        "frame_id": _frame_id,
+                    }
+        else:
+            for _sample_id in sample_ids:
                 frame_id += 1
-                frame_id_map[frame_id] = {"sample_id": sample.id}
-                if is_video:
-                    frame_id_map[frame_id]["frame_id"] = image.id
+                frame_id_map[frame_id] = {"sample_id": _sample_id}
 
         return frame_id_map
 

--- a/fiftyone/utils/cvat.py
+++ b/fiftyone/utils/cvat.py
@@ -56,7 +56,8 @@ def import_dataset(
         data_path: a parameter that enables explicit control
             over the location of the media. Can be any of the following:
 
-            -   an absolute directory path where the media files reside
+            -   an absolute directory path where the media files reside,
+                filenames on disk must match those in CVAT
             -   an absolute filepath specifying the location of the JSON data
                 manifest containing a mapping of CVAT filenames to absolute
                 filepaths on disk

--- a/fiftyone/utils/cvat.py
+++ b/fiftyone/utils/cvat.py
@@ -58,7 +58,8 @@ def import_dataset(
 
             -   an absolute directory path where the media files reside
             -   an absolute filepath specifying the location of the JSON data
-                manifest containing a list of absolute filepaths
+                manifest containing a mapping of CVAT filenames to absolute
+                filepaths on disk
 
         project_name (None): the name of the CVAT project  containing labels to
             load into the dataset. Required if `tasks_list` is `None`
@@ -86,7 +87,7 @@ def import_dataset(
     dataset.add_samples([fos.Sample(filepath=fp) for fp in filepaths])
     dataset.ensure_frames()
 
-    anno_key = "load_from_cvat"
+    anno_key = "tmp_" + str(ObjectId())
     label_schema = {None: {"type": "tmp"}}
 
     config = foua._parse_config(
@@ -97,6 +98,7 @@ def import_dataset(
     api = anno_backend.connect_to_api()
     project_id = api.get_project_id(project_name)
     if project_id is not None:
+        # Update classes and attributes of label schema
         api._convert_cvat_schema(
             label_schema, project_id=project_id, update_server=False
         )
@@ -108,6 +110,7 @@ def import_dataset(
     frame_id_map = {}
     for task_id in task_ids:
         if project_id is None:
+            # Update classes and attributes of label schema
             api._convert_cvat_schema(
                 label_schema, task_id=task_id, update_server=False
             )

--- a/fiftyone/utils/cvat.py
+++ b/fiftyone/utils/cvat.py
@@ -3698,12 +3698,19 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
             data["chunk_size"] = chunk_size
 
         files = {}
-        for idx, path in enumerate(paths):
-            # IMPORTANT: CVAT organizes media within a task alphabetically by
-            # filename, so we must give CVAT filenames whose alphabetical order
-            # matches the order of `paths`
-            filename = "%06d_%s" % (idx, os.path.basename(path))
-            files["client_files[%d]" % idx] = (filename, open(path, "rb"))
+
+        if len(paths) == 1 and fom.get_media_type(paths[0]) == fom.VIDEO:
+            # Video task
+            filename = os.path.basename(paths[0])
+            files["client_files[0]"] = (filename, open(paths[0], "rb"))
+        else:
+            # Image task
+            for idx, path in enumerate(paths):
+                # IMPORTANT: CVAT organizes media within a task alphabetically
+                # by filename, so we must give CVAT filenames whose
+                # alphabetical order matches the order of `paths`
+                filename = "%06d_%s" % (idx, os.path.basename(path))
+                files["client_files[%d]" % idx] = (filename, open(path, "rb"))
 
         self.post(self.task_data_url(task_id), data=data, files=files)
 

--- a/fiftyone/utils/cvat.py
+++ b/fiftyone/utils/cvat.py
@@ -128,7 +128,6 @@ def import_annotations(
         task_ids = list(task_ids)
 
     # Build mapping from CVAT filenames to local filepaths
-    only_existing = data_path is None
     existing_filepaths = sample_collection.values("filepath")
     if data_path is None:
         data_map = {os.path.basename(f): f for f in existing_filepaths}
@@ -205,7 +204,6 @@ def import_annotations(
                 label_types,
                 anno_backend,
                 anno_key,
-                api,
                 **kwargs,
             )
         else:
@@ -224,7 +222,6 @@ def import_annotations(
                     label_types,
                     anno_backend,
                     anno_key,
-                    api,
                     **kwargs,
                 )
     finally:
@@ -258,7 +255,6 @@ def _download_annotations(
     label_types,
     anno_backend,
     anno_key,
-    api,
     **kwargs,
 ):
     config = anno_backend.config

--- a/fiftyone/utils/cvat.py
+++ b/fiftyone/utils/cvat.py
@@ -26,16 +26,129 @@ import eta.core.image as etai
 import eta.core.utils as etau
 
 import fiftyone.constants as foc
+import fiftyone.core.dataset as fod
 import fiftyone.core.fields as fof
 import fiftyone.core.labels as fol
 import fiftyone.core.media as fom
 import fiftyone.core.metadata as fomt
+import fiftyone.core.sample as fos
 import fiftyone.core.utils as fou
 import fiftyone.utils.annotations as foua
 import fiftyone.utils.data as foud
 
 
 logger = logging.getLogger(__name__)
+
+
+def import_dataset(
+    data_path, project_name=None, tasks_list=None, dataset_name=None
+):
+    """Create a FiftyOne dataset given a local directory of media and the name of a
+    project or list of tasks containing corresponding annotations in CVAT.
+
+    Ex::
+
+        dataset = fouc.import_dataset("/path/to/data", project_name="project_name")
+        
+        dataset = fouc.import_dataset("/path/to/data.json", tasks_list=[1,42,51])
+
+    Args:
+        data_path: a parameter that enables explicit control
+            over the location of the media. Can be any of the following:
+
+            -   an absolute directory path where the media files reside
+            -   an absolute filepath specifying the location of the JSON data
+                manifest containing a list of absolute filepaths
+
+        project_name (None): the name of the CVAT project  containing labels to
+            load into the dataset. Required if `tasks_list` is `None`
+        tasks_list (None): a list of integer IDs of CVAT tasks containing
+            labels to load into the dataset. Required if `project_name` is
+            `None`
+        dataset_name (None): an optional name to give to the dataset
+    
+    Returns:
+        a :class:`fiftyone.core.dataset.Dataset`
+    """
+    if project_name is None and tasks_list is None:
+        raise ValueError(
+            "Either `project_name` or `tasks_list` must be provided."
+        )
+    if project_name is not None and tasks_list is not None:
+        raise ValueError(
+            "Only one of `project_name` or `tasks_list` is allowed."
+        )
+
+    filename_map = foud.ImportPathsMixin._load_data_map(data_path)
+    filepaths = list(filename_map.values())
+
+    dataset = fod.Dataset(dataset_name)
+    dataset.add_samples([fos.Sample(filepath=fp) for fp in filepaths])
+    dataset.ensure_frames()
+
+    anno_key = "load_from_cvat"
+    label_schema = {None: {"type": "tmp"}}
+
+    config = foua._parse_config(
+        "cvat", label_schema, "filepath", project_name=project_name
+    )
+    anno_backend = config.build()
+    anno_backend.register_run(dataset, anno_key, overwrite=False)
+    api = anno_backend.connect_to_api()
+    project_id = api.get_project_id(project_name)
+    if project_id is not None:
+        api._convert_cvat_schema(
+            label_schema, project_id=project_id, update_server=False
+        )
+        project_json = api.get(api.project_url(project_id)).json()
+        task_ids = [task["id"] for task in project_json["tasks"]]
+    else:
+        task_ids = tasks_list
+
+    frame_id_map = {}
+    for task_id in task_ids:
+        if project_id is None:
+            api._convert_cvat_schema(
+                label_schema, task_id=task_id, update_server=False
+            )
+        task_meta_json = api.get(api.task_data_meta_url(task_id)).json()
+        filenames = [frame["name"] for frame in task_meta_json["frames"]]
+        task_filepaths = []
+        for fn in filenames:
+            task_fp = filename_map.get(fn, None)
+            if task_fp:
+                task_filepaths.append(task_fp)
+        view = dataset.select_by("filepath", task_filepaths)
+        frame_map = api._build_frame_id_map(view)
+        frame_id_map[task_id] = frame_map
+
+    label_schema[None].pop("type")
+    config.label_schema = label_schema
+    anno_backend.update_run_config(dataset, anno_key, config)
+
+    id_map = {}
+    server_id_map = {}
+    project_ids = []
+    job_ids = []
+    results = CVATAnnotationResults(
+        dataset,
+        config,
+        id_map,
+        server_id_map,
+        project_ids,
+        task_ids,
+        job_ids,
+        frame_id_map,
+        {None: task_ids},
+        backend=anno_backend,
+    )
+
+    anno_backend.save_run_results(dataset, anno_key, results)
+
+    dataset.load_annotations(anno_key)
+    dataset.delete_annotation_run(anno_key)
+
+    return dataset
 
 
 class CVATImageDatasetImporter(
@@ -3863,6 +3976,13 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
 
         return self.get(self.project_url(project_id)).json()["labels"]
 
+    def _get_task_labels(self, task_id):
+        resp = self.get(self.task_url(task_id)).json()
+        if "labels" not in resp:
+            raise ValueError("Task '%s' not found" % task_id)
+
+        return resp["labels"]
+
     def _parse_project_details(self, project_name, project_id):
         if project_id is not None:
             project_name = self.get_project_name(project_id)
@@ -3879,7 +3999,9 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
     ):
         if project_id is not None:
             return self._convert_cvat_schema(
-                label_schema, project_id, occluded_attr=occluded_attr
+                label_schema,
+                project_id=project_id,
+                occluded_attr=occluded_attr,
             )
 
         return self._build_cvat_schema(
@@ -3887,9 +4009,22 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
         )
 
     def _convert_cvat_schema(
-        self, label_schema, project_id, occluded_attr=None
+        self,
+        label_schema,
+        project_id=None,
+        task_id=None,
+        occluded_attr=None,
+        update_server=True,
     ):
-        labels = self._get_project_labels(project_id)
+        if project_id is None:
+            if task_id is None:
+                raise ValueError(
+                    "Either `project_id` or `task_id` must be provided."
+                )
+            else:
+                labels = self._get_task_labels(task_id)
+        else:
+            labels = self._get_project_labels(project_id)
 
         cvat_schema = {}
         labels_to_update = []
@@ -3952,7 +4087,7 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
                     c: occluded_attr for c in class_names.keys()
                 }
 
-        if labels_to_update:
+        if project_id is not None and labels_to_update and update_server:
             self._add_project_label_ids(project_id, list(labels_to_update))
 
         return (
@@ -4646,8 +4781,8 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
 
         for label_field, label_info in label_schema.items():
             _field_classes = set()
-            label_type = label_info["type"]
-            is_existing_field = label_info["existing_field"]
+            label_type = label_info.get("type", None)
+            is_existing_field = label_info.get("existing_field", False)
             classes = label_info["classes"]
             attributes, occluded_attr_name = self._to_cvat_attributes(
                 label_info["attributes"]


### PR DESCRIPTION
An alternative implementation of https://github.com/voxel51/fiftyone/pull/1456 that also implements the TODO items mentioned there.

Other changes
- Added new ``unexpected="keep"`` option to `load_annotations()`
- `%06d_` is no longer prepended to video filenames in CVAT, since it is not necessary (always one video per task)
- Optimized database I/O in `_create_shapes_tags_tracks()` and `_build_frame_id_map()`

## Image dataset example

```py
import os

import fiftyone as fo
import fiftyone.core.utils as fou
import fiftyone.zoo as foz
import fiftyone.utils.cvat as fouc

dataset = foz.load_zoo_dataset("quickstart")
dataset = dataset.select_fields("ground_truth").clone()

# Create a CVAT project with labels
task_size = 10
results = dataset.annotate(
    "test",
    label_field="ground_truth",
    task_size=task_size,
    segment_size=3,
    project_name="test",
)
# print(results.task_ids)  # if using `task_ids` instead of `project_name`

#
# In order to load annotations, we need a mapping from CVAT image filenames to
# filepaths on local disk
#
# Since we're using a CVAT task uploaded via FiftyOne, the mapping is a bit
# weird
#
data_map = {}
for batch in fou.iter_batches(dataset.values("filepath"), task_size):
    for idx, filepath in enumerate(batch):
        filename = "%06d_%s" % (idx, os.path.basename(filepath))
        data_map[filename] = filepath

# Default: import into fields matching the label type (eg "detections")
fouc.import_annotations(
    dataset,
    project_name="test",
    data_path=data_map,
)

# But, we can instead prompt for field names
fouc.import_annotations(
    dataset,
    project_name="test",
    data_path=data_map,
    label_types="prompt",
)

# Or we can explicitly specify where to import
fouc.import_annotations(
    dataset,
    project_name="test",
    data_path=data_map,
    label_types={"detections": "ground_truth2"},
)

session = fo.launch_app(dataset)
```

## Video dataset example

```py
import os

import fiftyone as fo
import fiftyone.core.utils as fou
import fiftyone.zoo as foz
import fiftyone.utils.cvat as fouc

dataset = foz.load_zoo_dataset("quickstart-video").clone()

# Create a CVAT project with labels
results = dataset.annotate(
    "test",
    label_field="frames.detections",
    project_name="test-video",
)

dataset.rename_frame_field("detections", "detections_orig")

fouc.import_annotations(dataset, project_name="test-video")

print(dataset.count_values("frames.detections_orig.detections.label"))
print(dataset.count_values("frames.detections.detections.label"))
```
