### PR TITLE
Adding support for downloading media from existing CVAT tasks/projects

### DIFF
--- a/docs/source/integrations/cvat.rst
+++ b/docs/source/integrations/cvat.rst
@@ -2144,19 +2144,34 @@ to import individual task(s) or an entire project into a FiftyOne dataset.
     )
 
     #
-    # Create a mapping between filenames in the pre-existing CVAT project and
-    # the locations of the media locally on disk for the FiftyOne dataset
+    # In the simplest case, you can download both the annotations and the media
+    # from CVAT
+    #
+
+    dataset = fo.Dataset()
+    fouc.import_annotations(
+        dataset,
+        project_name=project_name,
+        data_path="/tmp/cvat_import",
+        download_media=True,
+    )
+
+    session = fo.launch_app(dataset)
+
+    #
+    # If you already have the media stored locally, you can instead provide a
+    # mapping between filenames in the pre-existing CVAT project and the
+    # locations of the media locally on disk for the FiftyOne dataset
     #
     # Since we're using a CVAT task uploaded via FiftyOne, the mapping is a bit
     # weird
     #
-    filepaths = dataset.values("filepath")
+
     data_map = {
         "%06d_%s" % (idx, os.path.basename(p)): p
-        for idx, p in enumerate(filepaths)
+        for idx, p in enumerate(dataset.values("filepath"))
     }
 
-    # Create dataset from pre-existing CVAT project
     dataset = fo.Dataset()
     fouc.import_annotations(
         dataset,

--- a/fiftyone/utils/cvat.py
+++ b/fiftyone/utils/cvat.py
@@ -5892,7 +5892,6 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
         frame_id = -1
 
         if samples.media_type == fom.VIDEO:
-            samples.ensure_frames()
             sample_ids, frame_ids = samples.values(["id", "frames.id"])
             for _sample_id, _frame_ids in zip(sample_ids, frame_ids):
                 for _frame_id in _frame_ids:

--- a/fiftyone/utils/video.py
+++ b/fiftyone/utils/video.py
@@ -296,26 +296,6 @@ def sample_videos(
     )
 
 
-def merge_videos(input_paths, output_path, verbose=False):
-    """Merges multiple input videos into one output video using FFmpeg
-
-    Args:
-        input_paths: a list of paths to videos to merge in order
-        output_path: the path to write the output video
-        verbose (False): whether to log the ``ffmpeg`` command that is executed
-    """
-    with etau.TempDir() as tmp_dir:
-        input_list_path = os.path.join(tmp_dir, "input_list.txt")
-        with open(input_list_path, "w") as f:
-            f.write("\n".join(["file '%s'" % path for path in input_paths]))
-
-        in_opts = ["-f", "concat", "-safe", "0"]
-        out_opts = ["-c", "copy"]
-
-        with etav.FFmpeg(in_opts=in_opts, out_opts=out_opts) as ffmpeg:
-            ffmpeg.run(input_list_path, output_path, verbose=verbose)
-
-
 def reencode_video(input_path, output_path, verbose=False, **kwargs):
     """Re-encodes the video using the H.264 codec.
 
@@ -537,6 +517,26 @@ def sample_frames_uniform(
         sample_frames.append(last)
 
     return sample_frames
+
+
+def concat_videos(input_paths, output_path, verbose=False):
+    """Concatenates the given list of videos, in order, into a single video.
+
+    Args:
+        input_paths: a list of video paths
+        output_path: the path to write the output video
+        verbose (False): whether to log the ``ffmpeg`` command that is executed
+    """
+    with etau.TempDir() as tmp_dir:
+        input_list_path = os.path.join(tmp_dir, "input_list.txt")
+        with open(input_list_path, "w") as f:
+            f.write("\n".join(["file '%s'" % path for path in input_paths]))
+
+        in_opts = ["-f", "concat", "-safe", "0"]
+        out_opts = ["-c", "copy"]
+
+        with etav.FFmpeg(in_opts=in_opts, out_opts=out_opts) as ffmpeg:
+            ffmpeg.run(input_list_path, output_path, verbose=verbose)
 
 
 def _transform_videos(

--- a/fiftyone/utils/video.py
+++ b/fiftyone/utils/video.py
@@ -296,6 +296,26 @@ def sample_videos(
     )
 
 
+def merge_videos(input_paths, output_path, verbose=False):
+    """Merges multiple input videos into one output video using FFmpeg
+
+    Args:
+        input_paths: a list of paths to videos to merge in order
+        output_path: the path to write the output video
+        verbose (False): whether to log the ``ffmpeg`` command that is executed
+    """
+    with etau.TempDir() as tmp_dir:
+        input_list_path = os.path.join(tmp_dir, "input_list.txt")
+        with open(input_list_path, "w") as f:
+            f.write("\n".join(["file '%s'" % path for path in input_paths]))
+
+        in_opts = ["-f", "concat", "-safe", "0"]
+        out_opts = ["-c", "copy"]
+
+        with etav.FFmpeg(in_opts=in_opts, out_opts=out_opts) as ffmpeg:
+            ffmpeg.run(input_list_path, output_path, verbose=verbose)
+
+
 def reencode_video(input_path, output_path, verbose=False, **kwargs):
     """Re-encodes the video using the H.264 codec.
 


### PR DESCRIPTION
Adds a `download_media=True` option to `import_annotations()`  that downloads the media associated with a given CVAT project or tasks along with the annotations.

### Note

[CVAT force re-encodes all videos as MP4s at 25fps](https://github.com/openvinotoolkit/cvat/blob/cde33acf5da2c29b5c70dec7df688af60734e1a7/cvat/apps/engine/media_extractors.py#L590-L595), so, in general, this workflow is not an advisable way to distribute video datasets.

### Image dataset example

```py
import fiftyone as fo
import fiftyone.zoo as foz
import fiftyone.utils.cvat as fouc

dataset = foz.load_zoo_dataset("quickstart")

# Create a CVAT project with labels
results = dataset.annotate(
    "test",
    label_field="ground_truth",
    segment_size=3,
    project_name="test",
)

# Download dataset from CVAT
dataset = fo.Dataset()
fouc.import_annotations(
    dataset,
    project_name="test",
    data_path="/tmp/cvat_example",
    download_media=True,
)

session = fo.launch_app(dataset)
```

### Video dataset example

```py
import fiftyone as fo
import fiftyone.zoo as foz
import fiftyone.utils.cvat as fouc

dataset = foz.load_zoo_dataset("quickstart-video", max_samples=3)

# Create a CVAT project with labels
results = dataset.annotate(
    "test",
    label_field="frames.detections",
    project_name="test-video",
)

# Download dataset from CVAT
dataset = fo.Dataset()
fouc.import_annotations(
    dataset,
    project_name="test-video",
    data_path="/tmp/cvat_video_example",
    download_media=True,
)

session = fo.launch_app(dataset)
```
