### PR TITLE
Gracefully handle empty segmentation data in COCO format

### DIFF
--- a/fiftyone/utils/coco.py
+++ b/fiftyone/utils/coco.py
@@ -934,7 +934,7 @@ class COCOObject(object):
             a :class:`fiftyone.core.labels.Polyline`, or None if no
             segmentation data is available
         """
-        if self.segmentation is None:
+        if not self.segmentation:
             return None
 
         label, attributes = self._get_object_label_and_attributes(
@@ -1017,7 +1017,7 @@ class COCOObject(object):
         x, y, w, h = self.bbox
         bounding_box = [x / width, y / height, w / width, h / height]
 
-        if load_segmentation and self.segmentation is not None:
+        if load_segmentation and self.segmentation:
             mask = _coco_segmentation_to_mask(
                 self.segmentation, self.bbox, frame_size
             )


### PR DESCRIPTION
Previously an error would arise when importing segmentation data from a COCO JSON that contains an object with `segmentation: []`. Now, such an empty list will be gracefully handled as missing segmentation data.

```py
import fiftyone as fo
import eta.core.serial as etas

d = {
    "info": {},
    "licenses": [],
    "categories": [
        {
            "id": 0,
            "name": "bird",
            "supercategory": None,
        }
    ],
    "images": [
        {
            "id": 1,
            "file_name": "/path/to/image.jpg",
            "height": 480,
            "width": 640,
            "license": None,
            "coco_url": None,
        }
    ],
    "annotations": [
        {
            "id": 1,
            "image_id": 1,
            "category_id": 0,
            "bbox": [135.0, 2.0, 296.0, 453.0],
            "segmentation": [],
        },
    ]
}

labels_path = "/tmp/coco.json"

etas.write_json(d, labels_path)

# This would previously raise an error; now is allowed
dataset = fo.Dataset.from_dir(
    labels_path=labels_path,
    dataset_type=fo.types.COCODetectionDataset,
    label_types="segmentations",
)
```
