### PR TITLE
Adding support for defining custom EmbeddedDocument classes

### DIFF
--- a/docs/source/user_guide/config.rst
+++ b/docs/source/user_guide/config.rst
@@ -76,6 +76,8 @@ FiftyOne supports the configuration options described below:
 | `model_zoo_manifest_paths`    | `FIFTYONE_MODEL_ZOO_MANIFEST_PATHS` | `None`                        | A list of manifest JSON files specifying additional zoo models. See                    |
 |                               |                                     |                               | :ref:`adding models to the zoo <model-zoo-add>` for more information.                  |
 +-------------------------------+-------------------------------------+-------------------------------+----------------------------------------------------------------------------------------+
+| `module_path`                 | `FIFTYONE_MODULE_PATH`              | `None`                        | A list of modules that should be automatically imported whenever FiftyOne is imported. |
++-------------------------------+-------------------------------------+-------------------------------+----------------------------------------------------------------------------------------+
 | `requirement_error_level`     | `FIFTYONE_REQUIREMENT_ERROR_LEVEL`  | `0`                           | A default error level to use when ensuring/installing requirements such as third-party |
 |                               |                                     |                               | packages. See :ref:`loading zoo models <model-zoo-load>` for an example usage.         |
 +-------------------------------+-------------------------------------+-------------------------------+----------------------------------------------------------------------------------------+
@@ -129,6 +131,7 @@ and the CLI:
             "do_not_track": false,
             "model_zoo_dir": "~/fiftyone/__models__",
             "model_zoo_manifest_paths": null,
+            "module_path": null,
             "requirement_error_level": 0,
             "show_progress_bars": true,
             "timezone": null
@@ -167,6 +170,7 @@ and the CLI:
             "do_not_track": false,
             "model_zoo_dir": "~/fiftyone/__models__",
             "model_zoo_manifest_paths": null,
+            "module_path": null,
             "requirement_error_level": 0,
             "show_progress_bars": true,
             "timezone": null

--- a/fiftyone/core/config.py
+++ b/fiftyone/core/config.py
@@ -91,6 +91,9 @@ class FiftyOneConfig(EnvConfig):
         self.model_zoo_dir = self.parse_path(
             d, "model_zoo_dir", env_var="FIFTYONE_MODEL_ZOO_DIR", default=None
         )
+        self.module_path = self.parse_string_array(
+            d, "module_path", env_var="FIFTYONE_MODULE_PATH", default=None,
+        )
         self.dataset_zoo_manifest_paths = self.parse_path_array(
             d,
             "dataset_zoo_manifest_paths",
@@ -174,8 +177,7 @@ class FiftyOneConfig(EnvConfig):
             d, "timezone", env_var="FIFTYONE_TIMEZONE", default=None
         )
 
-        self._set_defaults()
-        self._validate()
+        self._init()
 
     @property
     def show_progress_bars(self):
@@ -194,7 +196,7 @@ class FiftyOneConfig(EnvConfig):
         # Includes `show_progress_bars`
         return super().custom_attributes(dynamic=True)
 
-    def _set_defaults(self):
+    def _init(self):
         if self.default_dataset_dir is None:
             self.default_dataset_dir = os.path.join(
                 os.path.expanduser("~"), "fiftyone"
@@ -216,9 +218,19 @@ class FiftyOneConfig(EnvConfig):
             elif "tensorflow" in installed_packages:
                 self.default_ml_backend = "tensorflow"
 
-    def _validate(self):
         if self.default_ml_backend is not None:
             self.default_ml_backend = self.default_ml_backend.lower()
+
+        if self.module_path is not None:
+            for idx, module_name in enumerate(self.module_path):
+                try:
+                    __import__(module_name)
+                except ImportError as e:
+                    logger.warning(
+                        "Failed to import fiftyone.config.module_path[%d]: %s",
+                        idx,
+                        e,
+                    )
 
         if self.timezone and self.timezone.lower() not in {"local", "utc"}:
             try:
@@ -293,7 +305,7 @@ class AppConfig(EnvConfig):
             default=False,
         )
 
-        self._validate()
+        self._init()
 
     def get_colormap(self, colorscale=None, n=256, hex_strs=False):
         """Generates a continuous colormap with the specified number of colors
@@ -338,11 +350,12 @@ class AppConfig(EnvConfig):
 
         return fop.get_colormap(colorscale, n=n, hex_strs=hex_strs)
 
-    def _validate(self):
+    def _init(self):
         if self.grid_zoom < 0 or self.grid_zoom > 10:
-            raise AppConfigError(
-                "`grid_zoom` must be in [0, 10]; found %d" % self.grid_zoom
+            logger.warning(
+                "`grid_zoom` must be in [0, 10]; found %d", self.grid_zoom
             )
+            self.grid_zoom = 5
 
 
 class AppConfigError(etac.EnvConfigError):

--- a/fiftyone/core/labels.py
+++ b/fiftyone/core/labels.py
@@ -41,8 +41,6 @@ class Label(DynamicEmbeddedDocument):
     particular task for a sample or frame in a dataset.
     """
 
-    meta = {"allow_inheritance": True}
-
     def iter_attributes(self):
         """Returns an iterator over the custom attributes of the label.
 
@@ -133,8 +131,6 @@ class Attribute(DynamicEmbeddedDocument):
         value (None): the attribute value
     """
 
-    meta = {"allow_inheritance": True}
-
     value = fof.Field()
 
 
@@ -193,8 +189,6 @@ class _HasAttributesDict(Label):
     """Mixin for :class:`Label` classes that have an :attr:`attributes` field
     that contains a dict of of :class:`Attribute` instances.
     """
-
-    meta = {"allow_inheritance": True}
 
     attributes = fof.DictField(fof.EmbeddedDocumentField(Attribute))
 
@@ -320,8 +314,6 @@ class _HasID(Label):
     property, as well as a ``tags`` attribute.
     """
 
-    meta = {"allow_inheritance": True}
-
     _id = fof.ObjectIdField(default=ObjectId, required=True, unique=True)
     tags = fof.ListField(fof.StringField())
 
@@ -354,8 +346,6 @@ class Regression(_HasID, Label):
         confidence (None): a confidence in ``[0, 1]`` for the regression
     """
 
-    meta = {"allow_inheritance": True}
-
     value = fof.FloatField()
     confidence = fof.FloatField()
 
@@ -368,8 +358,6 @@ class Classification(_HasID, Label):
         confidence (None): a confidence in ``[0, 1]`` for the classification
         logits (None): logits associated with the labels
     """
-
-    meta = {"allow_inheritance": True}
 
     label = fof.StringField()
     confidence = fof.FloatField()
@@ -384,8 +372,6 @@ class Classifications(_HasLabelList, Label):
     """
 
     _LABEL_LIST_FIELD = "classifications"
-
-    meta = {"allow_inheritance": True}
 
     classifications = fof.ListField(fof.EmbeddedDocumentField(Classification))
     logits = fof.VectorField()
@@ -409,8 +395,6 @@ class Detection(_HasID, _HasAttributesDict, Label):
         attributes ({}): a dict mapping attribute names to :class:`Attribute`
             instances
     """
-
-    meta = {"allow_inheritance": True}
 
     label = fof.StringField()
     bounding_box = fof.ListField(fof.FloatField())
@@ -524,8 +508,6 @@ class Detections(_HasLabelList, Label):
 
     _LABEL_LIST_FIELD = "detections"
 
-    meta = {"allow_inheritance": True}
-
     detections = fof.ListField(fof.EmbeddedDocumentField(Detection))
 
     def to_polylines(self, tolerance=2, filled=True):
@@ -613,8 +595,6 @@ class Polyline(_HasID, _HasAttributesDict, Label):
         attributes ({}): a dict mapping attribute names to :class:`Attribute`
             instances for the polyline
     """
-
-    meta = {"allow_inheritance": True}
 
     label = fof.StringField()
     points = fof.PolylinePointsField()
@@ -782,8 +762,6 @@ class Polylines(_HasLabelList, Label):
 
     _LABEL_LIST_FIELD = "polylines"
 
-    meta = {"allow_inheritance": True}
-
     polylines = fof.ListField(fof.EmbeddedDocumentField(Polyline))
 
     def to_detections(self, mask_size=None, frame_size=None):
@@ -867,8 +845,6 @@ class Keypoint(_HasID, _HasAttributesDict, Label):
             instances
     """
 
-    meta = {"allow_inheritance": True}
-
     label = fof.StringField()
     points = fof.KeypointsField()
     confidence = fof.FloatField()
@@ -903,8 +879,6 @@ class Keypoints(_HasLabelList, Label):
 
     _LABEL_LIST_FIELD = "keypoints"
 
-    meta = {"allow_inheritance": True}
-
     keypoints = fof.ListField(fof.EmbeddedDocumentField(Keypoint))
 
 
@@ -915,8 +889,6 @@ class Segmentation(_HasID, Label):
         mask (None): a 2D numpy array with integer values encoding the semantic
             labels
     """
-
-    meta = {"allow_inheritance": True}
 
     mask = fof.ArrayField()
 
@@ -998,8 +970,6 @@ class Heatmap(_HasID, Label):
             contains integer values
     """
 
-    meta = {"allow_inheritance": True}
-
     map = fof.ArrayField()
     range = fof.HeatmapRangeField()
 
@@ -1013,8 +983,6 @@ class TemporalDetection(_HasID, Label):
         support (None): the ``[first, last]`` frame numbers, inclusive
         confidence (None): a confidence in ``[0, 1]`` for the detection
     """
-
-    meta = {"allow_inheritance": True}
 
     label = fof.StringField()
     support = fof.FrameSupportField()
@@ -1095,8 +1063,6 @@ class TemporalDetections(_HasLabelList, Label):
 
     _LABEL_LIST_FIELD = "detections"
 
-    meta = {"allow_inheritance": True}
-
     detections = fof.ListField(fof.EmbeddedDocumentField(TemporalDetection))
 
 
@@ -1120,8 +1086,6 @@ class GeoLocation(_HasID, Label):
             where the first outer list describes the boundary of the polygon
             and any remaining entries describe holes
     """
-
-    meta = {"allow_inheritance": True}
 
     point = fof.GeoPointField(auto_index=False)
     line = fof.GeoLineStringField(auto_index=False)
@@ -1160,8 +1124,6 @@ class GeoLocations(_HasID, Label):
         lines (None): a list of lines
         polygons (None): a list of polygons
     """
-
-    meta = {"allow_inheritance": True}
 
     points = fof.GeoMultiPointField(auto_index=False)
     lines = fof.GeoMultiLineStringField(auto_index=False)

--- a/fiftyone/core/metadata.py
+++ b/fiftyone/core/metadata.py
@@ -33,8 +33,6 @@ class Metadata(DynamicEmbeddedDocument):
         mime_type (None): the MIME type of the media
     """
 
-    meta = {"allow_inheritance": True}
-
     size_bytes = fof.IntField()
     mime_type = fof.StringField()
 

--- a/fiftyone/core/odm/document.py
+++ b/fiftyone/core/odm/document.py
@@ -501,7 +501,7 @@ class EmbeddedDocument(BaseEmbeddedDocument, mongoengine.EmbeddedDocument):
     therefore are not stored in their own collection in the database.
     """
 
-    meta = {"abstract": True}
+    meta = {"abstract": True, "allow_inheritance": True}
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -518,7 +518,7 @@ class DynamicEmbeddedDocument(
     Dynamic documents can have arbitrary fields added to them.
     """
 
-    meta = {"abstract": True}
+    meta = {"abstract": True, "allow_inheritance": True}
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)


### PR DESCRIPTION
Adds support for defining custom `EmbeddedDocument` and `DynamicEmbeddedDocument` classes, which can then be used to populate arbitrary top-level sample fields or nested fields.

A new `module_path` config setting is added where you can register the modules in which your custom embedded document classes are defined. Any modules in this list will automatically be imported whenever FiftyOne is imported so that datasets with your custom fields can be loaded.

## Example usage

First, define some custom embedded document classes in a `foo.bar` module:

```py
import fiftyone.core.fields as fof
import fiftyone.core.odm as foo

class Test(foo.EmbeddedDocument):
    field = fof.IntField()

class DynamicTest(foo.DynamicEmbeddedDocument):
    field = fof.IntField()
```

Next, add `foo.bar` to FiftyOne's `module_path` config setting so that the module will always be imported whenever you import FiftyOne: 

```shell
export FIFTYONE_MODULE_PATH=foo.bar

# Verify module path
fiftyone config
```

You're now free to use the `Test` and `DynamicTest` classes as you please, whether this be top-level sample fields or nested fields:

```py
# foo/bar.py
import fiftyone as fo
import foo.bar

sample = fo.Sample(
    filepath="/path/to/image.png",
    test=Test(field=1),
    dynamic_test=DynamicTest(field=2, foo="bar"),
    dict={
        "test": Test(field=3),
        "dynamic_test": DynamicTest(field=4, spam="eggs"),
    },
)

dataset = fo.Dataset()
dataset.add_sample(sample)

dataset.name = "test"
dataset.persistent = True
```

The dataset can be loaded in future sessions with no additional work:

```py
import fiftyone as fo

dataset = fo.load_dataset("test")
print(dataset.first())
```

```
<Sample: {
    'id': '61de37ae47f305672d5040d6',
    'media_type': 'image',
    'filepath': '/path/to/image.png',
    'tags': BaseList([]),
    'metadata': None,
    'test': <Test: {'field': 1}>,
    'dynamic_test': <DynamicTest: {'field': 2, 'foo': 'bar'}>,
    'dict': BaseDict({
        'test': <Test: {'field': 3}>,
        'dynamic_test': <DynamicTest: {'field': 4, 'spam': 'eggs'}>,
    }),
}>
```
