### PR TITLE
Adding support for boolean view indexing

### DIFF
--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -4113,6 +4113,8 @@ class SampleCollection(object):
 
                 -   a sample ID
                 -   an iterable of sample IDs
+                -   an iterable of booleans of same length as the collection
+                    encoding which samples to select
                 -   a :class:`fiftyone.core.sample.Sample` or
                     :class:`fiftyone.core.sample.SampleView`
                 -   an iterable of sample IDs

--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -256,7 +256,8 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
         if isinstance(id_filepath_slice, numbers.Integral):
             raise ValueError(
                 "Accessing dataset samples by numeric index is not supported. "
-                "Use sample IDs, filepaths, or slices instead"
+                "Use sample IDs, filepaths, slices, boolean arrays, or a "
+                "boolean ViewExpression instead"
             )
 
         if isinstance(id_filepath_slice, slice):

--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -18,7 +18,6 @@ import string
 from bson import ObjectId
 from deprecated import deprecated
 import mongoengine.errors as moe
-import numpy as np
 from pymongo import InsertOne, ReplaceOne, UpdateMany, UpdateOne
 from pymongo.errors import CursorNotFound, BulkWriteError
 
@@ -31,6 +30,7 @@ import fiftyone.core.annotation as foan
 import fiftyone.core.brain as fob
 import fiftyone.constants as focn
 import fiftyone.core.collections as foc
+import fiftyone.core.expressions as foex
 import fiftyone.core.evaluation as foe
 import fiftyone.core.fields as fof
 import fiftyone.core.frame as fofr
@@ -260,6 +260,12 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
             )
 
         if isinstance(id_filepath_slice, slice):
+            return self.view()[id_filepath_slice]
+
+        if isinstance(id_filepath_slice, foex.ViewExpression):
+            return self.view()[id_filepath_slice]
+
+        if etau.is_container(id_filepath_slice):
             return self.view()[id_filepath_slice]
 
         try:
@@ -5802,16 +5808,15 @@ def _get_sample_ids(samples_or_ids):
     if isinstance(samples_or_ids, foc.SampleCollection):
         return samples_or_ids.values("id")
 
-    if isinstance(samples_or_ids, np.ndarray):
-        return list(samples_or_ids)
+    samples_or_ids = list(samples_or_ids)
 
     if not samples_or_ids:
         return []
 
-    if isinstance(next(iter(samples_or_ids)), (fos.Sample, fos.SampleView)):
+    if isinstance(samples_or_ids[0], (fos.Sample, fos.SampleView)):
         return [s.id for s in samples_or_ids]
 
-    return list(samples_or_ids)
+    return samples_or_ids
 
 
 def _parse_fields(field_names):

--- a/fiftyone/core/stages.py
+++ b/fiftyone/core/stages.py
@@ -16,6 +16,7 @@ import warnings
 
 from bson import ObjectId
 from deprecated import deprecated
+import numpy as np
 
 import eta.core.utils as etau
 
@@ -5986,7 +5987,7 @@ def _parse_sample_ids(samples_or_ids):
     if isinstance(samples_or_ids[0], (fos.Sample, fos.SampleView)):
         return [s.id for s in samples_or_ids], False
 
-    if isinstance(samples_or_ids[0], bool):
+    if isinstance(samples_or_ids[0], (bool, np.bool_)):
         return samples_or_ids, True
 
     return samples_or_ids, False

--- a/fiftyone/core/stages.py
+++ b/fiftyone/core/stages.py
@@ -8,6 +8,7 @@ View stages.
 from collections import defaultdict, OrderedDict
 import contextlib
 from copy import deepcopy
+import itertools
 import random
 import reprlib
 import uuid
@@ -15,7 +16,6 @@ import warnings
 
 from bson import ObjectId
 from deprecated import deprecated
-import numpy as np
 
 import eta.core.utils as etau
 
@@ -317,7 +317,15 @@ class Exclude(ViewStage):
     """
 
     def __init__(self, sample_ids):
-        self._sample_ids = _get_sample_ids(sample_ids)
+        sample_ids, bools = _parse_sample_ids(sample_ids)
+
+        if bools:
+            raise ValueError(
+                "Excluding samples via boolean indexing is not supported; use "
+                "select() instead"
+            )
+
+        self._sample_ids = sample_ids
 
     @property
     def sample_ids(self):
@@ -619,7 +627,7 @@ class ExcludeFrames(ViewStage):
     """
 
     def __init__(self, frame_ids, omit_empty=True):
-        self._frame_ids = _get_frame_ids(frame_ids)
+        self._frame_ids = _parse_frame_ids(frame_ids)
         self._omit_empty = omit_empty
 
     @property
@@ -4023,6 +4031,8 @@ class Select(ViewStage):
 
             -   a sample ID
             -   an iterable of sample IDs
+            -   an iterable of booleans of same length as the collection
+                encoding which samples to select
             -   a :class:`fiftyone.core.sample.Sample` or
                 :class:`fiftyone.core.sample.SampleView`
             -   an iterable of sample IDs
@@ -4035,7 +4045,9 @@ class Select(ViewStage):
     """
 
     def __init__(self, sample_ids, ordered=False):
-        self._sample_ids = _get_sample_ids(sample_ids)
+        sample_ids, bools = _parse_sample_ids(sample_ids)
+        self._sample_ids = sample_ids
+        self._bools = bools
         self._ordered = ordered
 
     @property
@@ -4049,6 +4061,11 @@ class Select(ViewStage):
         return self._ordered
 
     def to_mongo(self, _):
+        if self._bools:
+            raise ValueError(
+                "`validate()` must be called before using this stage"
+            )
+
         ids = [ObjectId(_id) for _id in self._sample_ids]
 
         if not self._ordered:
@@ -4079,6 +4096,13 @@ class Select(ViewStage):
                 "placeholder": "ordered (default=False)",
             },
         ]
+
+    def validate(self, sample_collection):
+        if self._bools:
+            ids = sample_collection.values("id")
+            selectors = self._sample_ids
+            self._sample_ids = list(itertools.compress(ids, selectors))
+            self._bools = False
 
 
 class SelectBy(ViewStage):
@@ -4406,7 +4430,7 @@ class SelectFrames(ViewStage):
     """
 
     def __init__(self, frame_ids, omit_empty=True):
-        self._frame_ids = _get_frame_ids(frame_ids)
+        self._frame_ids = _parse_frame_ids(frame_ids)
         self._omit_empty = omit_empty
 
     @property
@@ -5942,31 +5966,33 @@ class ToFrames(ViewStage):
         ]
 
 
-def _get_sample_ids(samples_or_ids):
+def _parse_sample_ids(samples_or_ids):
     from fiftyone.core.collections import SampleCollection
 
     if etau.is_str(samples_or_ids):
-        return [samples_or_ids]
+        return [samples_or_ids], False
 
     if isinstance(samples_or_ids, (fos.Sample, fos.SampleView)):
-        return [samples_or_ids.id]
+        return [samples_or_ids.id], False
 
     if isinstance(samples_or_ids, SampleCollection):
-        return samples_or_ids.values("id")
+        return samples_or_ids.values("id"), False
 
-    if isinstance(samples_or_ids, np.ndarray):
-        return list(samples_or_ids)
+    samples_or_ids = list(samples_or_ids)
 
     if not samples_or_ids:
-        return []
+        return [], False
 
-    if isinstance(next(iter(samples_or_ids)), (fos.Sample, fos.SampleView)):
-        return [s.id for s in samples_or_ids]
+    if isinstance(samples_or_ids[0], (fos.Sample, fos.SampleView)):
+        return [s.id for s in samples_or_ids], False
 
-    return list(samples_or_ids)
+    if isinstance(samples_or_ids[0], bool):
+        return samples_or_ids, True
+
+    return samples_or_ids, False
 
 
-def _get_frame_ids(frames_or_ids):
+def _parse_frame_ids(frames_or_ids):
     from fiftyone.core.collections import SampleCollection
 
     if etau.is_str(frames_or_ids):
@@ -5978,16 +6004,15 @@ def _get_frame_ids(frames_or_ids):
     if isinstance(frames_or_ids, SampleCollection):
         return frames_or_ids.values("frames.id", unwind=True)
 
-    if isinstance(frames_or_ids, np.ndarray):
-        return list(frames_or_ids)
+    frames_or_ids = list(frames_or_ids)
 
     if not frames_or_ids:
         return []
 
-    if isinstance(next(iter(frames_or_ids)), (fofr.Frame, fofr.FrameView)):
+    if isinstance(frames_or_ids[0], (fofr.Frame, fofr.FrameView)):
         return [s.id for s in frames_or_ids]
 
-    return list(frames_or_ids)
+    return frames_or_ids
 
 
 def _get_rng(seed):

--- a/fiftyone/core/view.py
+++ b/fiftyone/core/view.py
@@ -16,6 +16,7 @@ import eta.core.utils as etau
 
 import fiftyone.core.aggregations as foa
 import fiftyone.core.collections as foc
+import fiftyone.core.expressions as foe
 import fiftyone.core.media as fom
 import fiftyone.core.odm as foo
 import fiftyone.core.sample as fos
@@ -82,6 +83,12 @@ class DatasetView(foc.SampleCollection):
 
         if isinstance(id_filepath_slice, slice):
             return self._slice(id_filepath_slice)
+
+        if isinstance(id_filepath_slice, foe.ViewExpression):
+            return self.match(id_filepath_slice)
+
+        if etau.is_container(id_filepath_slice):
+            return self.select(id_filepath_slice, ordered=True)
 
         try:
             oid = ObjectId(id_filepath_slice)

--- a/fiftyone/core/view.py
+++ b/fiftyone/core/view.py
@@ -78,7 +78,8 @@ class DatasetView(foc.SampleCollection):
         if isinstance(id_filepath_slice, numbers.Integral):
             raise KeyError(
                 "Accessing samples by numeric index is not supported. "
-                "Use sample IDs, filepaths, or slices"
+                "Use sample IDs, filepaths, slices, boolean arrays, or a "
+                "boolean ViewExpression instead"
             )
 
         if isinstance(id_filepath_slice, slice):
@@ -88,7 +89,7 @@ class DatasetView(foc.SampleCollection):
             return self.match(id_filepath_slice)
 
         if etau.is_container(id_filepath_slice):
-            return self.select(id_filepath_slice, ordered=True)
+            return self.select(id_filepath_slice)
 
         try:
             oid = ObjectId(id_filepath_slice)


### PR DESCRIPTION
Adds a boolean view indexing syntax:

```py
view = sample_collection[bool_array]
```

as a shorthand for:

```py
ids = itertools.compress(sample_collection.values("id"), bool_array)
view = sample_collection.select(ids)
```

Also adds a boolean expression indexing syntax:

```py
view = sample_collection[bool_expr]
```

as shorthand for:

```py
view = sample_collection.match(bool_expr)
```

## Example usage

```py
import fiftyone as fo
import fiftyone.zoo as foz
from fiftyone import ViewField as F

dataset = foz.load_zoo_dataset("quickstart")

expr = F("uniqueness") > 0.7

# Existing syntax
view1 = dataset.match(expr)
print(view1)

# New boolean array syntax
bools = dataset.values(expr)  # list/array of booleans
view2 = dataset[bools]
print(view2)

# New boolean expression syntax
view3 = dataset[expr]
print(view3)
```
