### PR TITLE
Publish source distributions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,7 +50,7 @@ jobs:
           fi
       - name: Build dist
         run: |
-          python setup.py bdist_wheel
+          python setup.py bdist_wheel sdist
       - name: Upload dist
         uses: actions/upload-artifact@v2
         with:
@@ -216,4 +216,4 @@ jobs:
           TWINE_USERNAME: __token__
           TWINE_NON_INTERACTIVE: 1
         run: |
-          python3 -m twine upload downloads/*.whl
+          python3 -m twine upload downloads/*

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,15 @@
 global-include *
 global-exclude *.py[cod]
 
+prune .*
+prune app
+prune eta
+prune package
+prune tools
+prune tests
+
+global-exclude .*
+
 recursive-exclude fiftyone *.md
 
 recursive-exclude docs *

--- a/setup.py
+++ b/setup.py
@@ -10,18 +10,6 @@ import os
 from pkg_resources import DistributionNotFound, get_distribution
 from setuptools import setup, find_packages
 import re
-from wheel.bdist_wheel import bdist_wheel
-
-
-class BdistWheelCustom(bdist_wheel):
-    def finalize_options(self):
-        bdist_wheel.finalize_options(self)
-        # make just the wheel require these packages, since they aren't needed
-        # for a development installation
-        self.distribution.install_requires += [
-            "fiftyone-brain>=0.7.2,<0.8",
-            "fiftyone-db>=0.3,<0.4",
-        ]
 
 
 VERSION = "0.14.2"
@@ -72,6 +60,8 @@ INSTALL_REQUIRES = [
     "xmltodict",
     "universal-analytics-python3>=1.0.1,<2",
     # internal packages
+    "fiftyone-brain>=0.7.2,<0.8",
+    "fiftyone-db>=0.3,<0.4",
     "voxel51-eta>=0.6.1,<0.7",
 ]
 
@@ -160,5 +150,4 @@ setup(
     ],
     entry_points={"console_scripts": ["fiftyone=fiftyone.core.cli:main"]},
     python_requires=">=3.6",
-    cmdclass={"bdist_wheel": BdistWheelCustom},
 )

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,9 @@ Installs FiftyOne.
 |
 """
 import os
+from pkg_resources import DistributionNotFound, get_distribution
 from setuptools import setup, find_packages
+import re
 from wheel.bdist_wheel import bdist_wheel
 
 
@@ -38,6 +40,75 @@ def get_version():
     return VERSION
 
 
+INSTALL_REQUIRES = [
+    # third-party packages
+    "aiofiles",
+    "argcomplete",
+    "boto3",
+    "Deprecated",
+    "eventlet",
+    "future",
+    "Jinja2",
+    "kaleido",
+    "matplotlib",
+    "mongoengine==0.20.0",
+    "motor>=2.3,<3",
+    "numpy",
+    "packaging",
+    "pandas",
+    "Pillow>=6.2",
+    "plotly>=4.14,<5",
+    "pprintpp",
+    "psutil",
+    "pymongo>=3.11,<4",
+    "pytz",
+    "PyYAML",
+    "retrying",
+    "scikit-learn",
+    "scikit-image",
+    "setuptools",
+    "tabulate",
+    "tornado>=5.1.1,<7",
+    "xmltodict",
+    "universal-analytics-python3>=1.0.1,<2",
+    # internal packages
+    "voxel51-eta>=0.6.1,<0.7",
+]
+
+
+CHOOSE_INSTALL_REQUIRES = [
+    (
+        (
+            "opencv-python",
+            "opencv-contrib-python",
+            "opencv-contrib-python-headless",
+        ),
+        "opencv-python-headless",
+    )
+]
+
+
+def choose_requirement(mains, secondary):
+    chosen = secondary
+    for main in mains:
+        try:
+            name = re.split(r"[!<>=]", main)[0]
+            get_distribution(name)
+            chosen = main
+            break
+        except DistributionNotFound:
+            pass
+
+    return str(chosen)
+
+
+def get_install_requirements(install_requires, choose_install_requires):
+    for mains, secondary in choose_install_requires:
+        install_requires.append(choose_requirement(mains, secondary))
+
+    return install_requires
+
+
 EXTRAS_REQUIREMENTS = {"desktop": ["fiftyone-desktop>=0.19.1,<0.20"]}
 
 
@@ -65,41 +136,9 @@ setup(
         "fiftyone.tutorials": "docs/source/tutorials",
     },
     include_package_data=True,
-    install_requires=[
-        # third-party packages
-        "aiofiles",
-        "argcomplete",
-        "boto3",
-        "Deprecated",
-        "eventlet",
-        "future",
-        "Jinja2",
-        "kaleido",
-        "matplotlib",
-        "mongoengine==0.20.0",
-        "motor>=2.3,<3",
-        "numpy",
-        "opencv-python-headless",
-        "packaging",
-        "pandas",
-        "Pillow>=6.2",
-        "plotly>=4.14,<5",
-        "pprintpp",
-        "psutil",
-        "pymongo>=3.11,<4",
-        "pytz",
-        "PyYAML",
-        "retrying",
-        "scikit-learn",
-        "scikit-image",
-        "setuptools",
-        "tabulate",
-        "tornado>=5.1.1,<7",
-        "xmltodict",
-        "universal-analytics-python3>=1.0.1,<2",
-        # internal packages
-        "voxel51-eta>=0.6.1,<0.7",
-    ],
+    install_requires=get_install_requirements(
+        INSTALL_REQUIRES, CHOOSE_INSTALL_REQUIRES
+    ),
     classifiers=[
         "Development Status :: 4 - Beta",
         "Intended Audience :: Developers",

--- a/setup.py
+++ b/setup.py
@@ -120,12 +120,14 @@ setup(
     license="Apache",
     long_description=long_description,
     long_description_content_type="text/markdown",
-    packages=find_packages() + ["fiftyone.recipes", "fiftyone.tutorials"],
+    packages=find_packages(
+        exclude=["app", "eta", "package", "requirements", "tests", "tools"]
+    )
+    + ["fiftyone.recipes", "fiftyone.tutorials"],
     package_dir={
         "fiftyone.recipes": "docs/source/recipes",
         "fiftyone.tutorials": "docs/source/tutorials",
     },
-    include_package_data=True,
     install_requires=get_install_requirements(
         INSTALL_REQUIRES, CHOOSE_INSTALL_REQUIRES
     ),


### PR DESCRIPTION
Adds a source distribution for the published package, which can installed with:

```
pip install fiftyone --no-binary fiftyone
```

in which case, the opencv dependency is dynamically configured based on the environment, .e.g. Google's Colab.