### PR TITLE
I/O cleanup

### DIFF
--- a/docs/source/cli/index.rst
+++ b/docs/source/cli/index.rst
@@ -775,7 +775,7 @@ Populates the `metadata` field of all samples in the dataset.
 
 .. code-block:: text
 
-    fiftyone utils compute-metadata [-h] [-o] DATASET_NAME
+    fiftyone utils compute-metadata [-h] [-o] [-n NUM_WORKERS] [-s] DATASET_NAME
 
 **Arguments**
 
@@ -785,8 +785,13 @@ Populates the `metadata` field of all samples in the dataset.
       NAME                  the name of the dataset
 
     optional arguments:
-      -h, --help       show this help message and exit
-      -o, --overwrite  whether to overwrite existing metadata
+      -h, --help            show this help message and exit
+      -o, --overwrite       whether to overwrite existing metadata
+      -n NUM_WORKERS, --num-workers NUM_WORKERS
+                            the number of worker processes to use. The default
+                            is `multiprocessing.cpu_count()`
+      -s, --skip-failures   whether to gracefully continue without raising an
+                            error if metadata cannot be computed for a sample
 
 **Examples**
 
@@ -812,7 +817,7 @@ Transforms the images in a dataset per the specified parameters.
     fiftyone utils transform-images [-h] [--size SIZE]
                                     [--min-size MIN_SIZE]
                                     [--max-size MAX_SIZE] [-e EXT] [-f]
-                                    [-d] [-n NUM_WORKERS]
+                                    [-d] [-n NUM_WORKERS] [-s]
                                     DATASET_NAME
 
 **Arguments**
@@ -838,6 +843,8 @@ Transforms the images in a dataset per the specified parameters.
       -n NUM_WORKERS, --num-workers NUM_WORKERS
                             the number of worker processes to use. The default is
                             `multiprocessing.cpu_count()`
+      -s, --skip-failures   whether to gracefully continue without raising an
+                            error if an image cannot be transformed
 
 **Examples**
 
@@ -864,7 +871,7 @@ Transforms the videos in a dataset per the specified parameters.
                                     [--max-fps MAX_FPS] [--size SIZE]
                                     [--min-size MIN_SIZE]
                                     [--max-size MAX_SIZE] [-r] [-f] [-d]
-                                    [-v]
+                                    [-s] [-v]
                                     DATASET_NAME
 
 **Arguments**
@@ -892,6 +899,8 @@ Transforms the videos in a dataset per the specified parameters.
                             meet the specified values
       -d, --delete-originals
                             whether to delete the original videos after transforming
+      -s, --skip-failures   whether to gracefully continue without raising an
+                            error if a video cannot be transformed
       -v, --verbose         whether to log the `ffmpeg` commands that are executed
 
 **Examples**

--- a/fiftyone/core/cli.py
+++ b/fiftyone/core/cli.py
@@ -2576,11 +2576,34 @@ class ComputeMetadataCommand(Command):
             action="store_true",
             help="whether to overwrite existing metadata",
         )
+        parser.add_argument(
+            "-n",
+            "--num-workers",
+            default=None,
+            type=int,
+            help=(
+                "the number of worker processes to use. The default is "
+                "`multiprocessing.cpu_count()`"
+            ),
+        )
+        parser.add_argument(
+            "-s",
+            "--skip-failures",
+            action="store_true",
+            help=(
+                "whether to gracefully continue without raising an error if "
+                "metadata cannot be computed for a sample"
+            ),
+        )
 
     @staticmethod
     def execute(parser, args):
         dataset = fod.load_dataset(args.name)
-        dataset.compute_metadata(overwrite=args.overwrite)
+        dataset.compute_metadata(
+            overwrite=args.overwrite,
+            num_workers=args.num_workers,
+            skip_failures=args.skip_failures,
+        )
 
 
 class TransformImagesCommand(Command):
@@ -2658,6 +2681,15 @@ class TransformImagesCommand(Command):
                 "`multiprocessing.cpu_count()`"
             ),
         )
+        parser.add_argument(
+            "-s",
+            "--skip-failures",
+            action="store_true",
+            help=(
+                "whether to gracefully continue without raising an error if "
+                "an image cannot be transformed"
+            ),
+        )
 
     @staticmethod
     def execute(parser, args):
@@ -2671,6 +2703,7 @@ class TransformImagesCommand(Command):
             force_reencode=args.force_reencode,
             delete_originals=args.delete_originals,
             num_workers=args.num_workers,
+            skip_failures=args.skip_failures,
         )
 
 
@@ -2768,6 +2801,15 @@ class TransformVideosCommand(Command):
             help="whether to delete the original videos after transforming",
         )
         parser.add_argument(
+            "-s",
+            "--skip-failures",
+            action="store_true",
+            help=(
+                "whether to gracefully continue without raising an error if "
+                "a video cannot be transformed"
+            ),
+        )
+        parser.add_argument(
             "-v",
             "--verbose",
             action="store_true",
@@ -2788,6 +2830,7 @@ class TransformVideosCommand(Command):
             reencode=args.reencode,
             force_reencode=args.force_reencode,
             delete_originals=args.delete_originals,
+            skip_failures=args.skip_failures,
             verbose=args.verbose,
         )
 

--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -6013,74 +6013,29 @@ class SampleCollection(object):
                 this can also contain keyword arguments for
                 :class:`fiftyone.utils.patches.ImagePatchesExtractor`
         """
+        archive_path = None
+
+        # If the user requested an archive, first populate a directory
         if export_dir is not None and etau.is_archive(export_dir):
             archive_path = export_dir
-            export_dir = etau.split_archive(archive_path)[0]
-        else:
-            archive_path = None
-
-        if dataset_type is None and dataset_exporter is None:
-            raise ValueError(
-                "Either `dataset_type` or `dataset_exporter` must be provided"
-            )
-
-        # If no dataset exporter was provided, construct one
-        if dataset_exporter is None:
-            _handle_existing_dirs(
-                export_dir, data_path, labels_path, export_media, overwrite
-            )
-
-            dataset_exporter, kwargs = foud.build_dataset_exporter(
-                dataset_type,
-                warn_unused=False,  # don't warn yet, might be patches kwargs
-                export_dir=export_dir,
-                data_path=data_path,
-                labels_path=labels_path,
-                export_media=export_media,
-                **kwargs,
-            )
-
-        # Get label field(s) to export
-        if isinstance(dataset_exporter, foud.LabeledImageDatasetExporter):
-            # Labeled images
-            label_field = self._parse_label_field(
-                label_field,
-                dataset_exporter=dataset_exporter,
-                allow_coercion=True,
-                required=True,
-            )
-            frame_labels_field = None
-        elif isinstance(dataset_exporter, foud.LabeledVideoDatasetExporter):
-            # Labeled videos
-            label_field = self._parse_label_field(
-                label_field,
-                dataset_exporter=dataset_exporter,
-                allow_coercion=True,
-                required=False,
-            )
-            frame_labels_field = self._parse_frame_labels_field(
-                frame_labels_field,
-                dataset_exporter=dataset_exporter,
-                allow_coercion=True,
-                required=False,
-            )
-
-            if label_field is None and frame_labels_field is None:
-                raise ValueError(
-                    "Unable to locate compatible sample or frame-level "
-                    "field(s) to export"
-                )
+            export_dir, _ = etau.split_archive(archive_path)
 
         # Perform the export
-        foud.export_samples(
+        _export(
             self,
+            export_dir=export_dir,
+            dataset_type=dataset_type,
+            data_path=data_path,
+            labels_path=labels_path,
+            export_media=export_media,
             dataset_exporter=dataset_exporter,
             label_field=label_field,
             frame_labels_field=frame_labels_field,
+            overwrite=overwrite,
             **kwargs,
         )
 
-        # Archive, if requested
+        # Make archive, if requested
         if archive_path is not None:
             etau.make_archive(export_dir, archive_path, cleanup=True)
 
@@ -6573,9 +6528,9 @@ class SampleCollection(object):
             rel_dir (None): a relative directory to remove from the
                 ``filepath`` of each sample, if possible. The path is converted
                 to an absolute path (if necessary) via
-                ``os.path.abspath(os.path.expanduser(rel_dir))``. The typical
-                use case for this argument is that your source data lives in
-                a single directory and you wish to serialize relative, rather
+                :func:`fiftyone.core.utils.normalize_path`. The typical use
+                case for this argument is that your source data lives in a
+                single directory and you wish to serialize relative, rather
                 than absolute, paths to the data within that directory
             frame_labels_dir (None): a directory in which to write per-sample
                 JSON files containing the frame labels for video samples. If
@@ -6590,10 +6545,7 @@ class SampleCollection(object):
             a JSON dict
         """
         if rel_dir is not None:
-            rel_dir = (
-                os.path.abspath(os.path.expanduser(rel_dir)) + os.path.sep
-            )
-            len_rel_dir = len(rel_dir)
+            rel_dir = fou.normalize_path(rel_dir) + os.path.sep
 
         is_video = self.media_type == fom.VIDEO
         write_frame_labels = is_video and frame_labels_dir is not None
@@ -6635,7 +6587,7 @@ class SampleCollection(object):
                 etas.write_json(frames, frames_path, pretty_print=pretty_print)
 
             if rel_dir and sd["filepath"].startswith(rel_dir):
-                sd["filepath"] = sd["filepath"][len_rel_dir:]
+                sd["filepath"] = sd["filepath"][len(rel_dir) :]
 
             samples.append(sd)
 
@@ -6653,9 +6605,9 @@ class SampleCollection(object):
             rel_dir (None): a relative directory to remove from the
                 ``filepath`` of each sample, if possible. The path is converted
                 to an absolute path (if necessary) via
-                ``os.path.abspath(os.path.expanduser(rel_dir))``. The typical
-                use case for this argument is that your source data lives in
-                a single directory and you wish to serialize relative, rather
+                :func:`fiftyone.core.utils.normalize_path`. The typical use
+                case for this argument is that your source data lives in a
+                single directory and you wish to serialize relative, rather
                 than absolute, paths to the data within that directory
             frame_labels_dir (None): a directory in which to write per-sample
                 JSON files containing the frame labels for video samples. If
@@ -6689,9 +6641,9 @@ class SampleCollection(object):
             rel_dir (None): a relative directory to remove from the
                 ``filepath`` of each sample, if possible. The path is converted
                 to an absolute path (if necessary) via
-                ``os.path.abspath(os.path.expanduser(rel_dir))``. The typical
-                use case for this argument is that your source data lives in
-                a single directory and you wish to serialize relative, rather
+                :func:`fiftyone.core.utils.normalize_path`. The typical use
+                case for this argument is that your source data lives in a
+                single directory and you wish to serialize relative, rather
                 than absolute, paths to the data within that directory
             frame_labels_dir (None): a directory in which to write per-sample
                 JSON files containing the frame labels for video samples. If
@@ -8003,6 +7955,81 @@ def _get_non_none_value(values):
             return value
 
     return None
+
+
+def _export(
+    sample_collection,
+    export_dir=None,
+    dataset_type=None,
+    data_path=None,
+    labels_path=None,
+    export_media=None,
+    dataset_exporter=None,
+    label_field=None,
+    frame_labels_field=None,
+    overwrite=False,
+    **kwargs,
+):
+    if dataset_type is None and dataset_exporter is None:
+        raise ValueError(
+            "Either `dataset_type` or `dataset_exporter` must be provided"
+        )
+
+    # If no dataset exporter was provided, construct one
+    if dataset_exporter is None:
+        _handle_existing_dirs(
+            export_dir, data_path, labels_path, export_media, overwrite
+        )
+
+        dataset_exporter, kwargs = foud.build_dataset_exporter(
+            dataset_type,
+            warn_unused=False,  # don't warn yet, might be patches kwargs
+            export_dir=export_dir,
+            data_path=data_path,
+            labels_path=labels_path,
+            export_media=export_media,
+            **kwargs,
+        )
+
+    # Get label field(s) to export
+    if isinstance(dataset_exporter, foud.LabeledImageDatasetExporter):
+        # Labeled images
+        label_field = sample_collection._parse_label_field(
+            label_field,
+            dataset_exporter=dataset_exporter,
+            allow_coercion=True,
+            required=True,
+        )
+        frame_labels_field = None
+    elif isinstance(dataset_exporter, foud.LabeledVideoDatasetExporter):
+        # Labeled videos
+        label_field = sample_collection._parse_label_field(
+            label_field,
+            dataset_exporter=dataset_exporter,
+            allow_coercion=True,
+            required=False,
+        )
+        frame_labels_field = sample_collection._parse_frame_labels_field(
+            frame_labels_field,
+            dataset_exporter=dataset_exporter,
+            allow_coercion=True,
+            required=False,
+        )
+
+        if label_field is None and frame_labels_field is None:
+            raise ValueError(
+                "Unable to locate compatible sample or frame-level "
+                "field(s) to export"
+            )
+
+    # Perform the export
+    foud.export_samples(
+        sample_collection,
+        dataset_exporter=dataset_exporter,
+        label_field=label_field,
+        frame_labels_field=frame_labels_field,
+        **kwargs,
+    )
 
 
 def _handle_existing_dirs(

--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -3961,8 +3961,7 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
             rel_dir (None): a relative directory to prepend to the ``filepath``
                 of each sample if the filepath is not absolute (begins with a
                 path separator). The path is converted to an absolute path
-                (if necessary) via
-                ``os.path.abspath(os.path.expanduser(rel_dir))``
+                (if necessary) via :func:`fiftyone.core.utils.normalize_path`
             frame_labels_dir (None): a directory of per-sample JSON files
                 containing the frame labels for video samples. If omitted, it
                 is assumed that the frame labels are included directly in the
@@ -3975,7 +3974,7 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
             name = d["name"]
 
         if rel_dir is not None:
-            rel_dir = os.path.abspath(os.path.expanduser(rel_dir))
+            rel_dir = fou.normalize_path(rel_dir)
 
         name = make_unique_dataset_name(name)
         dataset = cls(name)
@@ -4001,7 +4000,7 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
         )
 
         def parse_sample(sd):
-            if rel_dir and not sd["filepath"].startswith(os.path.sep):
+            if rel_dir and not os.path.isabs(sd["filepath"]):
                 sd["filepath"] = os.path.join(rel_dir, sd["filepath"])
 
             if media_type == fom.VIDEO:
@@ -4022,6 +4021,7 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
 
         samples = d["samples"]
         num_samples = len(samples)
+
         _samples = map(parse_sample, samples)
         dataset.add_samples(
             _samples, expand_schema=False, num_samples=num_samples
@@ -4048,8 +4048,7 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
             rel_dir (None): a relative directory to prepend to the ``filepath``
                 of each sample, if the filepath is not absolute (begins with a
                 path separator). The path is converted to an absolute path
-                (if necessary) via
-                ``os.path.abspath(os.path.expanduser(rel_dir))``
+                (if necessary) via :func:`fiftyone.core.utils.normalize_path`
 
         Returns:
             a :class:`Dataset`
@@ -5849,10 +5848,7 @@ def _extract_archive_if_necessary(archive_path, cleanup):
     dataset_dir = etau.split_archive(archive_path)[0]
 
     if not os.path.isdir(dataset_dir):
-        outdir = os.path.dirname(dataset_dir)
-        etau.extract_archive(
-            archive_path, outdir=outdir, delete_archive=cleanup
-        )
+        etau.extract_archive(archive_path, delete_archive=cleanup)
 
         if not os.path.isdir(dataset_dir):
             raise ValueError(

--- a/fiftyone/core/media.py
+++ b/fiftyone/core/media.py
@@ -5,12 +5,7 @@ Sample media utilities.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
-import multiprocessing
-
-import eta.core.utils as etau
 import eta.core.video as etav
-
-import fiftyone.core.utils as fou
 
 
 # Valid media types
@@ -35,58 +30,6 @@ def get_media_type(filepath):
 
     # @todo don't assume all non-video samples are images!
     return IMAGE
-
-
-def export_media(inpaths, outpaths, mode="copy", num_workers=None):
-    """Exports the media at the given input paths to the given output paths.
-
-    Args:
-        inpaths: the list of input paths
-        outpaths: the list of output paths
-        mode ("copy"): the export mode to use. Supported values are
-            ``("copy", "move", "symlink")``
-        num_workers (None): the number of processes to use. By default,
-            ``multiprocessing.cpu_count()`` is used
-    """
-    num_files = len(inpaths)
-    if num_files == 0:
-        return
-
-    if num_workers is None:
-        num_workers = multiprocessing.cpu_count()
-
-    inputs = list(zip(inpaths, outpaths))
-    if mode == "copy":
-        op = _do_copy_file
-    elif mode == "move":
-        op = _do_move_file
-    elif mode == "symlink":
-        op = _do_symlink_file
-    else:
-        raise ValueError(
-            "Unsupported mode '%s'. Supported values are %s"
-            % (mode, ("copy", "move", "symlink"))
-        )
-
-    with fou.ProgressBar(total=num_files, iters_str="files") as pb:
-        with multiprocessing.Pool(processes=num_workers) as pool:
-            for _ in pb(pool.imap_unordered(op, inputs)):
-                pass
-
-
-def _do_move_file(args):
-    inpath, outpath = args
-    etau.move_file(inpath, outpath)
-
-
-def _do_copy_file(args):
-    inpath, outpath = args
-    etau.copy_file(inpath, outpath)
-
-
-def _do_symlink_file(args):
-    inpath, outpath = args
-    etau.symlink_file(inpath, outpath)
 
 
 class MediaTypeError(TypeError):

--- a/fiftyone/core/odm/document.py
+++ b/fiftyone/core/odm/document.py
@@ -13,9 +13,9 @@ from bson import json_util, ObjectId
 import mongoengine
 import pymongo
 
-import fiftyone.core.utils as fou
-
 import eta.core.serial as etas
+
+import fiftyone.core.utils as fou
 
 
 class SerializableDocument(object):

--- a/fiftyone/core/odm/sample.py
+++ b/fiftyone/core/odm/sample.py
@@ -46,22 +46,11 @@ type :class:`NoDatasetSampleDocument` to type ``dataset._sample_doc_cls``::
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
-from collections import defaultdict, OrderedDict
-from functools import wraps
-import json
-import numbers
+from collections import OrderedDict
 import os
 import random
 
-from bson import json_util, ObjectId
-from bson.binary import Binary
-from mongoengine.errors import InvalidQueryError
-import numpy as np
-import six
-
-import fiftyone as fo
 import fiftyone.core.fields as fof
-import fiftyone.core.frame_utils as fofu
 import fiftyone.core.metadata as fom
 import fiftyone.core.media as fomm
 import fiftyone.core.utils as fou
@@ -122,7 +111,7 @@ class NoDatasetSampleDocument(NoDatasetMixin, SerializableDocument):
     )
 
     def __init__(self, **kwargs):
-        filepath = os.path.abspath(os.path.expanduser(kwargs["filepath"]))
+        filepath = fou.normalize_path(kwargs["filepath"])
 
         kwargs["id"] = kwargs.get("id", None)
         kwargs["filepath"] = filepath

--- a/fiftyone/core/sample.py
+++ b/fiftyone/core/sample.py
@@ -328,8 +328,6 @@ class _SampleMixin(object):
         if field_name != "filepath":
             return
 
-        value = os.path.abspath(os.path.expanduser(value))
-
         new_media_type = fomm.get_media_type(value)
         if self.media_type != new_media_type:
             raise fomm.MediaTypeError(
@@ -371,7 +369,7 @@ class Sample(_SampleMixin, Document, metaclass=SampleSingleton):
     Args:
         filepath: the path to the data on disk. The path is converted to an
             absolute path (if necessary) via
-            ``os.path.abspath(os.path.expanduser(filepath))``
+            :func:`fiftyone.core.utils.normalize_path`
         tags (None): a list of tags for the sample
         metadata (None): a :class:`fiftyone.core.metadata.Metadata` instance
         **kwargs: additional fields to dynamically set on the sample

--- a/fiftyone/core/utils.py
+++ b/fiftyone/core/utils.py
@@ -291,6 +291,19 @@ def fill_patterns(string):
     return etau.fill_patterns(string, available_patterns())
 
 
+def normalize_path(path):
+    """Normalizes the given path by converting it to an absolute path and
+    expanding the user directory, if necessary.
+
+    Args:
+        path: a path
+
+    Returns:
+        the normalized path
+    """
+    return os.path.abspath(os.path.expanduser(path))
+
+
 def ensure_package(
     requirement_str, error_level=None, error_msg=None, log_success=False
 ):
@@ -769,6 +782,8 @@ class ResourceLimit(object):
 
 
 class ProgressBar(etau.ProgressBar):
+    """.. autoclass:: eta.core.utils.ProgressBar"""
+
     def __init__(self, *args, **kwargs):
         if "quiet" not in kwargs:
             kwargs["quiet"] = not fo.config.show_progress_bars
@@ -909,9 +924,9 @@ class UniqueFilenameMaker(object):
     This class provides a :meth:`get_output_path` method that generates unique
     filenames in the specified output directory.
 
-    If an input filename is provided, the filename is maintained, unless a
-    name conflict in ``output_dir`` would occur, in which case an index of the
-    form ``"-%d" % count`` is appended to the base filename.
+    If an input path is provided, its filename is maintained, unless a name
+    conflict in ``output_dir`` would occur, in which case an index of the form
+    ``"-%d" % count`` is appended to the filename.
 
     If no input filename is provided, an output filename of the form
     ``<output_dir>/<count><default_ext>`` is generated, where ``count`` is the
@@ -920,45 +935,57 @@ class UniqueFilenameMaker(object):
     If no ``output_dir`` is provided, then unique filenames with no base
     directory are generated.
 
+    If a ``rel_dir`` is provided, then this path will be stripped from each
+    input path to generate the identifier of each file (rather than just its
+    basename). This argument allows for populating nested subdirectories in
+    ``output_dir`` that match the shape of the input paths.
+
     Args:
         output_dir (None): a directory in which to generate output paths
+        rel_dir (None): an optional relative directory to strip from each path
         default_ext (None): the file extension to use when generating default
             output paths
         ignore_exts (False): whether to omit file extensions when checking for
             duplicate filenames
     """
 
-    def __init__(self, output_dir=None, default_ext=None, ignore_exts=False):
-        if output_dir is None:
-            output_dir = ""
-
-        if default_ext is None:
-            default_ext = ""
-
+    def __init__(
+        self,
+        output_dir=None,
+        rel_dir=None,
+        default_ext=None,
+        ignore_exts=False,
+    ):
         self.output_dir = output_dir
+        self.rel_dir = rel_dir
         self.default_ext = default_ext
         self.ignore_exts = ignore_exts
 
         self._filepath_map = {}
         self._filename_counts = defaultdict(int)
-        self._default_filename_patt = (
-            fo.config.default_sequence_idx + default_ext
+        self._default_filename_patt = fo.config.default_sequence_idx + (
+            default_ext or ""
         )
         self._idx = 0
 
-        if output_dir:
-            etau.ensure_dir(output_dir)
-            filenames = etau.list_files(output_dir)
-            self._idx = len(filenames)
-            for filename in filenames:
-                self._filename_counts[filename] += 1
+        self._setup()
+
+    def _setup(self):
+        if not self.output_dir:
+            return
+
+        etau.ensure_dir(self.output_dir)
+        filenames = etau.list_files(self.output_dir)
+
+        self._idx = len(filenames)
+        for filename in filenames:
+            self._filename_counts[filename] += 1
 
     def get_output_path(self, input_path=None, output_ext=None):
         """Returns a unique output path.
 
         Args:
-            input_path (None): an input path from which to derive the output
-                path
+            input_path (None): an input path
             output_ext (None): an optional output extension to use
 
         Returns:
@@ -972,9 +999,12 @@ class UniqueFilenameMaker(object):
         self._idx += 1
 
         if not found_input:
-            input_path = self._default_filename_patt % self._idx
+            filename = self._default_filename_patt % self._idx
+        elif self.rel_dir:
+            filename = os.path.relpath(input_path, self.rel_dir)
+        else:
+            filename = os.path.basename(input_path)
 
-        filename = os.path.basename(input_path)
         name, ext = os.path.splitext(filename)
 
         # URL handling
@@ -994,7 +1024,10 @@ class UniqueFilenameMaker(object):
         if count > 1:
             filename = name + ("-%d" % count) + ext
 
-        output_path = os.path.join(self.output_dir, filename)
+        if self.output_dir:
+            output_path = os.path.join(self.output_dir, filename)
+        else:
+            output_path = filename
 
         if found_input:
             self._filepath_map[input_path] = output_path

--- a/fiftyone/core/video.py
+++ b/fiftyone/core/video.py
@@ -721,12 +721,9 @@ def _parse_video_frames(
         else:
             sample_frame_numbers = doc_frame_numbers
     else:
-        # @todo is this too expensive?
-        sample_frame_numbers = [
-            fn
-            for fn in doc_frame_numbers
-            if not os.path.isfile(images_patt % fn)
-        ]
+        sample_frame_numbers = _get_non_existent_frame_numbers(
+            images_patt, doc_frame_numbers
+        )
 
         if all_frames and len(sample_frame_numbers) == len(doc_frame_numbers):
             sample_frame_numbers = None  # all frames
@@ -749,3 +746,7 @@ def _parse_video_frames(
             logger.info("Required frames already present for '%s'", video_path)
 
     return doc_frame_numbers, sample_frame_numbers
+
+
+def _get_non_existent_frame_numbers(images_patt, frame_numbers):
+    return [fn for fn in frame_numbers if not os.path.isfile(images_patt % fn)]

--- a/fiftyone/core/view.py
+++ b/fiftyone/core/view.py
@@ -787,30 +787,9 @@ class DatasetView(foc.SampleCollection):
             view = stage.load_view(self)
         else:
             view = copy(self)
-
-            if not self._add_sort_stage(stage, view._stages):
-                view._stages.append(stage)
+            view._stages.append(stage)
 
         return view
-
-    @staticmethod
-    def _add_sort_stage(new_stage, stages):
-        if not type(new_stage) == fost.SortBySimilarity:
-            return False
-
-        sort_views = [
-            i for i, x in enumerate(stages) if type(x) == fost.SortBySimilarity
-        ]
-
-        if len(sort_views) > 0:
-            sort_views.reverse()
-            last_sort_view = sort_views[0]
-
-            if stages[last_sort_view].k == new_stage.k:
-                stages[last_sort_view] = new_stage
-                return True
-
-        return False
 
     def _get_filtered_schema(self, schema, frames=False):
         if schema is None:

--- a/fiftyone/core/view.py
+++ b/fiftyone/core/view.py
@@ -654,9 +654,9 @@ class DatasetView(foc.SampleCollection):
             rel_dir (None): a relative directory to remove from the
                 ``filepath`` of each sample, if possible. The path is converted
                 to an absolute path (if necessary) via
-                ``os.path.abspath(os.path.expanduser(rel_dir))``. The typical
-                use case for this argument is that your source data lives in
-                a single directory and you wish to serialize relative, rather
+                :func:`fiftyone.core.utils.normalize_path`. The typical use
+                case for this argument is that your source data lives in a
+                single directory and you wish to serialize relative, rather
                 than absolute, paths to the data within that directory
             frame_labels_dir (None): a directory in which to write per-sample
                 JSON files containing the frame labels for video samples. If

--- a/fiftyone/utils/bdd.py
+++ b/fiftyone/utils/bdd.py
@@ -167,22 +167,24 @@ class BDDDatasetImporter(
         }
 
     def setup(self):
-        self._image_paths_map = self._load_data_map(
-            self.data_path, recursive=True
-        )
+        image_paths_map = self._load_data_map(self.data_path, recursive=True)
 
         if self.labels_path is not None and os.path.isfile(self.labels_path):
-            self._anno_dict_map = load_bdd_annotations(self.labels_path)
+            anno_dict_map = load_bdd_annotations(self.labels_path)
         else:
-            self._anno_dict_map = {}
+            anno_dict_map = {}
 
-        filenames = set(self._anno_dict_map.keys())
+        filenames = set(anno_dict_map.keys())
 
         if self.include_all_data:
-            filenames.update(self._image_paths_map.keys())
+            filenames.update(image_paths_map.keys())
 
-        self._filenames = self._preprocess_list(sorted(filenames))
-        self._num_samples = len(self._filenames)
+        filenames = self._preprocess_list(sorted(filenames))
+
+        self._image_paths_map = image_paths_map
+        self._anno_dict_map = anno_dict_map
+        self._filenames = filenames
+        self._num_samples = len(filenames)
 
     @staticmethod
     def _get_num_samples(dataset_dir):

--- a/fiftyone/utils/coco.py
+++ b/fiftyone/utils/coco.py
@@ -518,9 +518,7 @@ class COCODetectionDatasetImporter(
         return {k: v for k, v in types.items() if k in self._label_types}
 
     def setup(self):
-        self._image_paths_map = self._load_data_map(
-            self.data_path, recursive=True
-        )
+        image_paths_map = self._load_data_map(self.data_path, recursive=True)
 
         if self.labels_path is not None and os.path.isfile(self.labels_path):
             (
@@ -575,6 +573,7 @@ class COCODetectionDatasetImporter(
         self._classes = classes
         self._license_map = license_map
         self._supercategory_map = supercategory_map
+        self._image_paths_map = image_paths_map
         self._image_dicts_map = image_dicts_map
         self._annotations = annotations
         self._filenames = filenames

--- a/fiftyone/utils/data/exporters.py
+++ b/fiftyone/utils/data/exporters.py
@@ -874,7 +874,7 @@ class ExportPathsMixin(object):
         """
         if data_path is None:
             if export_media == "manifest" and default is not None:
-                data_path = os.path.normpath(default) + ".json"
+                data_path = fou.normalize_path(default) + ".json"
             elif export_dir is not None:
                 data_path = default
 
@@ -882,7 +882,7 @@ class ExportPathsMixin(object):
             data_path = os.path.expanduser(data_path)
 
             if not os.path.isabs(data_path) and export_dir is not None:
-                export_dir = os.path.abspath(os.path.expanduser(export_dir))
+                export_dir = fou.normalize_path(export_dir)
                 data_path = os.path.join(export_dir, data_path)
 
         if export_media is None:
@@ -907,7 +907,7 @@ class ExportPathsMixin(object):
             labels_path = os.path.expanduser(labels_path)
 
             if not os.path.isabs(labels_path) and export_dir is not None:
-                export_dir = os.path.abspath(os.path.expanduser(export_dir))
+                export_dir = fou.normalize_path(export_dir)
                 labels_path = os.path.join(export_dir, labels_path)
 
         return labels_path
@@ -974,14 +974,8 @@ class MediaExporter(object):
                 "%s" % (export_mode, supported_modes)
             )
 
-        if export_mode != False and export_path is None:
-            raise ValueError(
-                "An export path must be provided for export mode %s"
-                % export_mode
-            )
-
         if export_path is not None:
-            export_path = os.path.abspath(os.path.expanduser(export_path))
+            export_path = fou.normalize_path(export_path)
 
         self.export_mode = export_mode
         self.export_path = export_path
@@ -998,7 +992,7 @@ class MediaExporter(object):
 
     def _get_uuid(self, media_path):
         if self.export_mode == False and self.export_path is not None:
-            media_path = os.path.abspath(media_path)
+            media_path = fou.normalize_path(media_path)
             uuid = os.path.relpath(media_path, self.export_path)
         else:
             uuid = os.path.basename(media_path)
@@ -1018,7 +1012,7 @@ class MediaExporter(object):
         manifest_path = None
         manifest = None
 
-        if self.export_mode in {True, "move", "symlink"}:
+        if self.export_mode in (True, "move", "symlink"):
             output_dir = self.export_path
         elif self.export_mode == "manifest":
             manifest_path = self.export_path
@@ -1032,11 +1026,14 @@ class MediaExporter(object):
         self._manifest_path = manifest_path
         self._manifest = manifest
 
-    def export(self, media_or_path):
+    def export(self, media_or_path, outpath=None):
         """Exports the given media.
 
         Args:
             media_or_path: the media or path to the media on disk
+            outpath (None): a manually-specified location to which to export
+                the media. By default, the media will be exported into
+                :attr:`export_path`
 
         Returns:
             a tuple of:
@@ -1047,7 +1044,9 @@ class MediaExporter(object):
         if etau.is_str(media_or_path):
             media_path = media_or_path
 
-            if self.export_mode != False:
+            if outpath is not None:
+                uuid = self._get_uuid(outpath)
+            elif self.export_mode != False:
                 outpath = self._filename_maker.get_output_path(media_path)
                 uuid = self._get_uuid(outpath)
             else:
@@ -1056,7 +1055,7 @@ class MediaExporter(object):
 
             if self.export_mode == True:
                 etau.copy_file(media_path, outpath)
-            if self.export_mode == "move":
+            elif self.export_mode == "move":
                 etau.move_file(media_path, outpath)
             elif self.export_mode == "symlink":
                 etau.symlink_file(media_path, outpath)
@@ -1065,7 +1064,10 @@ class MediaExporter(object):
                 self._manifest[uuid] = media_path
         else:
             media = media_or_path
-            outpath = self._filename_maker.get_output_path()
+
+            if outpath is None:
+                outpath = self._filename_maker.get_output_path()
+
             uuid = self._get_uuid(outpath)
 
             if self.export_mode == True:
@@ -1079,11 +1081,7 @@ class MediaExporter(object):
         return outpath, uuid
 
     def close(self):
-        """Performs any necessary actions to complete an export.
-
-        :class:`DatasetExporter` classes implementing this mixin should invoke
-        this method in :meth:`DatasetExporter.close`.
-        """
+        """Performs any necessary actions to complete the export."""
         if self.export_mode == "manifest":
             etas.write_json(self._manifest, self._manifest_path)
 
@@ -1133,7 +1131,7 @@ class DatasetExporter(object):
 
     def __init__(self, export_dir=None):
         if export_dir is not None:
-            export_dir = os.path.abspath(os.path.expanduser(export_dir))
+            export_dir = fou.normalize_path(export_dir)
 
         self.export_dir = export_dir
 
@@ -1506,7 +1504,7 @@ class LegacyFiftyOneDatasetExporter(GenericSampleDatasetExporter):
         self._samples_path = None
         self._metadata = None
         self._samples = None
-        self._filename_maker = None
+        self._media_exporter = None
         self._is_video_dataset = False
 
     def setup(self):
@@ -1520,12 +1518,12 @@ class LegacyFiftyOneDatasetExporter(GenericSampleDatasetExporter):
         self._metadata = {}
         self._samples = []
 
-        if self.export_media != False:
-            output_dir = self._data_dir
-        else:
-            output_dir = None
-
-        self._filename_maker = fou.UniqueFilenameMaker(output_dir=output_dir)
+        self._media_exporter = MediaExporter(
+            self.export_media,
+            supported_modes=(True, False, "move", "symlink"),
+            export_path=self._data_dir,
+        )
+        self._media_exporter.setup()
 
     def log_collection(self, sample_collection):
         self._is_video_dataset = sample_collection.media_type == fomm.VIDEO
@@ -1588,17 +1586,11 @@ class LegacyFiftyOneDatasetExporter(GenericSampleDatasetExporter):
             _export_evaluation_results(dataset, self._eval_dir)
 
     def export_sample(self, sample):
+        out_filepath, _ = self._media_exporter.export(sample.filepath)
+        if out_filepath is None:
+            out_filepath = sample.filepath
+
         sd = sample.to_dict()
-
-        out_filepath = self._filename_maker.get_output_path(sample.filepath)
-
-        if self.export_media == True:
-            etau.copy_file(sample.filepath, out_filepath)
-        elif self.export_media == "move":
-            etau.move_file(sample.filepath, out_filepath)
-        elif self.export_media == "symlink":
-            etau.symlink_file(sample.filepath, out_filepath)
-
         sd["filepath"] = out_filepath
 
         if self.relative_filepaths:
@@ -1620,6 +1612,7 @@ class LegacyFiftyOneDatasetExporter(GenericSampleDatasetExporter):
         etas.write_json(
             samples, self._samples_path, pretty_print=self.pretty_print
         )
+        self._media_exporter.close()
 
     def _export_frame_labels(self, sample, uuid):
         frames_dict = {"frames": sample.frames._to_frames_dict()}
@@ -1648,7 +1641,7 @@ class FiftyOneDatasetExporter(BatchDatasetExporter):
                 directory
         rel_dir (None): a relative directory to remove from the ``filepath`` of
             each sample, if possible. The path is converted to an absolute path
-            (if necessary) via ``os.path.abspath(os.path.expanduser(rel_dir))``.
+            (if necessary) via :func:`fiftyone.core.utils.normalize_path`.
             The typical use case for this argument is that your source data
             lives in a single directory and you wish to serialize relative,
             rather than absolute, paths to the data within that directory.
@@ -1671,7 +1664,7 @@ class FiftyOneDatasetExporter(BatchDatasetExporter):
         self._metadata_path = None
         self._samples_path = None
         self._frames_path = None
-        self._filename_maker = None
+        self._media_exporter = None
 
     def setup(self):
         self._data_dir = os.path.join(self.export_dir, "data")
@@ -1682,10 +1675,12 @@ class FiftyOneDatasetExporter(BatchDatasetExporter):
         self._samples_path = os.path.join(self.export_dir, "samples.json")
         self._frames_path = os.path.join(self.export_dir, "frames.json")
 
-        if self.export_media != False:
-            self._filename_maker = fou.UniqueFilenameMaker(
-                output_dir=self._data_dir
-            )
+        self._media_exporter = MediaExporter(
+            self.export_media,
+            export_path=self._data_dir,
+            supported_modes=(True, False, "move", "symlink"),
+        )
+        self._media_exporter.setup()
 
     def export_samples(self, sample_collection):
         etau.ensure_dir(self.export_dir)
@@ -1698,21 +1693,15 @@ class FiftyOneDatasetExporter(BatchDatasetExporter):
                     "Ignoring `rel_dir` since `export_media` is True"
                 )
 
-            outpaths = [
-                self._filename_maker.get_output_path(p) for p in inpaths
-            ]
+            outpaths = [self._media_exporter.export(p)[0] for p in inpaths]
 
             # Replace filepath prefixes with `data/` for samples export
             _outpaths = ["data/" + os.path.basename(p) for p in outpaths]
         elif self.rel_dir is not None:
             # Remove `rel_dir` prefix from filepaths
-            rel_dir = (
-                os.path.abspath(os.path.expanduser(self.rel_dir)) + os.path.sep
-            )
-            len_rel_dir = len(rel_dir)
-
+            rel_dir = fou.normalize_path(self.rel_dir) + os.path.sep
             _outpaths = [
-                p[len_rel_dir:] if p.startswith(rel_dir) else p
+                p[len(rel_dir) :] if p.startswith(rel_dir) else p
                 for p in inpaths
             ]
         else:
@@ -1769,18 +1758,7 @@ class FiftyOneDatasetExporter(BatchDatasetExporter):
         if export_runs and sample_collection.has_evaluations:
             _export_evaluation_results(sample_collection, self._eval_dir)
 
-        if self.export_media == True:
-            mode = "copy"
-        elif self.export_media == "move":
-            mode = "move"
-        elif self.export_media == "symlink":
-            mode = "symlink"
-        else:
-            mode = None
-
-        if mode is not None:
-            logger.info("Exporting media...")
-            fomm.export_media(inpaths, outpaths, mode=mode)
+        self._media_exporter.close()
 
 
 def _export_annotation_results(sample_collection, anno_dir):
@@ -2121,13 +2099,6 @@ class ImageClassificationDirectoryTreeExporter(LabeledImageDatasetExporter):
         if export_media is None:
             export_media = True
 
-        supported_modes = (True, "move", "symlink")
-        if export_media not in supported_modes:
-            raise ValueError(
-                "Unsupported export_media=%s for %s. The supported values "
-                "are %s" % (export_media, type(self), supported_modes)
-            )
-
         if image_format is None:
             image_format = fo.config.default_image_ext
 
@@ -2138,6 +2109,7 @@ class ImageClassificationDirectoryTreeExporter(LabeledImageDatasetExporter):
 
         self._class_counts = None
         self._filename_counts = None
+        self._media_exporter = None
         self._default_filename_patt = (
             fo.config.default_sequence_idx + image_format
         )
@@ -2153,11 +2125,14 @@ class ImageClassificationDirectoryTreeExporter(LabeledImageDatasetExporter):
     def setup(self):
         self._class_counts = defaultdict(int)
         self._filename_counts = defaultdict(int)
+        self._media_exporter = ImageExporter(
+            self.export_media, supported_modes=(True, "move", "symlink"),
+        )
+        self._media_exporter.setup()
+
         etau.ensure_dir(self.export_dir)
 
     def export_sample(self, image_or_path, classification, metadata=None):
-        is_image_path = etau.is_str(image_or_path)
-
         _label = _parse_classifications(
             classification, include_confidence=False, include_attributes=False
         )
@@ -2167,7 +2142,7 @@ class ImageClassificationDirectoryTreeExporter(LabeledImageDatasetExporter):
 
         self._class_counts[_label] += 1
 
-        if is_image_path:
+        if etau.is_str(image_or_path):
             image_path = image_or_path
         else:
             img = image_or_path
@@ -2184,17 +2159,12 @@ class ImageClassificationDirectoryTreeExporter(LabeledImageDatasetExporter):
         if count > 1:
             filename = name + ("-%d" % count) + ext
 
-        out_image_path = os.path.join(self.export_dir, _label, filename)
+        outpath = os.path.join(self.export_dir, _label, filename)
 
-        if is_image_path:
-            if self.export_media == "move":
-                etau.move_file(image_path, out_image_path)
-            elif self.export_media == "symlink":
-                etau.symlink_file(image_path, out_image_path)
-            else:
-                etau.copy_file(image_path, out_image_path)
-        else:
-            etai.write(img, out_image_path)
+        self._media_exporter.export(image_or_path, outpath=outpath)
+
+    def close(self, *args):
+        self._media_exporter.close()
 
 
 class VideoClassificationDirectoryTreeExporter(LabeledVideoDatasetExporter):
@@ -2224,19 +2194,13 @@ class VideoClassificationDirectoryTreeExporter(LabeledVideoDatasetExporter):
         if export_media is None:
             export_media = True
 
-        supported_modes = (True, "move", "symlink")
-        if export_media not in supported_modes:
-            raise ValueError(
-                "Unsupported export_media=%s for %s. The supported values are "
-                "%s" % (export_media, type(self), supported_modes)
-            )
-
         super().__init__(export_dir=export_dir)
 
         self.export_media = export_media
 
         self._class_counts = None
         self._filename_counts = None
+        self._media_exporter = None
 
     @property
     def requires_video_metadata(self):
@@ -2253,6 +2217,11 @@ class VideoClassificationDirectoryTreeExporter(LabeledVideoDatasetExporter):
     def setup(self):
         self._class_counts = defaultdict(int)
         self._filename_counts = defaultdict(int)
+        self._media_exporter = VideoExporter(
+            self.export_media, supported_modes=(True, "move", "symlink"),
+        )
+        self._media_exporter.setup()
+
         etau.ensure_dir(self.export_dir)
 
     def export_sample(self, video_path, classification, _, metadata=None):
@@ -2274,14 +2243,12 @@ class VideoClassificationDirectoryTreeExporter(LabeledVideoDatasetExporter):
         if count > 1:
             filename = name + ("-%d" % count) + ext
 
-        out_video_path = os.path.join(self.export_dir, _label, filename)
+        outpath = os.path.join(self.export_dir, _label, filename)
 
-        if self.export_media == "move":
-            etau.move_file(video_path, out_video_path)
-        elif self.export_media == "symlink":
-            etau.symlink_file(video_path, out_video_path)
-        else:
-            etau.copy_file(video_path, out_video_path)
+        self._media_exporter.export(video_path, outpath=outpath)
+
+    def close(self, *args):
+        self._media_exporter.close()
 
 
 class FiftyOneImageDetectionDatasetExporter(
@@ -2869,7 +2836,8 @@ class FiftyOneImageLabelsDatasetExporter(LabeledImageDatasetExporter):
         self.image_format = image_format
         self.pretty_print = pretty_print
 
-        self._labeled_dataset = None
+        self._dataset_index = None
+        self._manifest_path = None
         self._data_dir = None
         self._labels_dir = None
         self._description = None
@@ -2889,11 +2857,12 @@ class FiftyOneImageLabelsDatasetExporter(LabeledImageDatasetExporter):
         }
 
     def setup(self):
-        self._labeled_dataset = etad.LabeledImageDataset.create_empty_dataset(
-            self.export_dir
+        self._dataset_index = etad.LabeledDatasetIndex(
+            etau.get_class_name(etad.LabeledImageDataset)
         )
-        self._data_dir = self._labeled_dataset.data_dir
-        self._labels_dir = self._labeled_dataset.labels_dir
+        self._manifest_path = os.path.join(self.export_dir, "manifest.json")
+        self._data_dir = os.path.join(self.export_dir, "data")
+        self._labels_dir = os.path.join(self.export_dir, "labels")
 
         self._media_exporter = ImageExporter(
             self.export_media,
@@ -2910,31 +2879,24 @@ class FiftyOneImageLabelsDatasetExporter(LabeledImageDatasetExporter):
     def export_sample(self, image_or_path, labels, metadata=None):
         out_image_path, uuid = self._media_exporter.export(image_or_path)
 
-        out_image_filename = os.path.basename(out_image_path)
-        out_labels_filename = uuid + ".json"
+        out_labels_path = os.path.join(self._labels_dir, uuid + ".json")
 
-        _image_labels = foue.to_image_labels(labels)
+        il = foue.to_image_labels(labels)
+        etas.write_json(il, out_labels_path, pretty_print=self.pretty_print)
 
-        if etau.is_str(image_or_path):
-            image_labels_path = os.path.join(
-                self._labels_dir, out_labels_filename
+        self._dataset_index.append(
+            etad.LabeledDataRecord(
+                "data/" + os.path.basename(out_image_path),
+                "labels/" + os.path.basename(out_labels_path),
             )
-            _image_labels.write_json(
-                image_labels_path, pretty_print=self.pretty_print
-            )
-
-            self._labeled_dataset.add_file(out_image_path, image_labels_path)
-        else:
-            self._labeled_dataset.add_data(
-                image_or_path,
-                _image_labels,
-                out_image_filename,
-                out_labels_filename,
-            )
+        )
 
     def close(self, *args):
-        self._labeled_dataset.set_description(self._description)
-        self._labeled_dataset.write_manifest()
+        self._dataset_index.description = self._description or ""
+        etas.write_json(
+            self._dataset_index, self._manifest_path, pretty_print=True
+        )
+
         self._media_exporter.close()
 
 
@@ -2973,7 +2935,8 @@ class FiftyOneVideoLabelsDatasetExporter(LabeledVideoDatasetExporter):
         self.export_media = export_media
         self.pretty_print = pretty_print
 
-        self._labeled_dataset = None
+        self._dataset_index = None
+        self._manifest_path = None
         self._data_dir = None
         self._labels_dir = None
         self._description = None
@@ -2997,11 +2960,12 @@ class FiftyOneVideoLabelsDatasetExporter(LabeledVideoDatasetExporter):
         }
 
     def setup(self):
-        self._labeled_dataset = etad.LabeledVideoDataset.create_empty_dataset(
-            self.export_dir
+        self._dataset_index = etad.LabeledDatasetIndex(
+            etau.get_class_name(etad.LabeledVideoDataset)
         )
-        self._data_dir = self._labeled_dataset.data_dir
-        self._labels_dir = self._labeled_dataset.labels_dir
+        self._manifest_path = os.path.join(self.export_dir, "manifest.json")
+        self._data_dir = os.path.join(self.export_dir, "data")
+        self._labels_dir = os.path.join(self.export_dir, "labels")
 
         self._media_exporter = VideoExporter(
             self.export_media,
@@ -3017,20 +2981,24 @@ class FiftyOneVideoLabelsDatasetExporter(LabeledVideoDatasetExporter):
     def export_sample(self, video_path, label, frames, metadata=None):
         out_video_path, uuid = self._media_exporter.export(video_path)
 
-        out_labels_filename = uuid + ".json"
+        out_labels_path = os.path.join(self._labels_dir, uuid + ".json")
 
-        _video_labels = foue.to_video_labels(label=label, frames=frames)
+        vl = foue.to_video_labels(label=label, frames=frames)
+        etas.write_json(vl, out_labels_path, pretty_print=self.pretty_print)
 
-        video_labels_path = os.path.join(self._labels_dir, out_labels_filename)
-        _video_labels.write_json(
-            video_labels_path, pretty_print=self.pretty_print
+        self._dataset_index.append(
+            etad.LabeledDataRecord(
+                "data/" + os.path.basename(out_video_path),
+                "labels/" + os.path.basename(out_labels_path),
+            )
         )
 
-        self._labeled_dataset.add_file(out_video_path, video_labels_path)
-
     def close(self, *args):
-        self._labeled_dataset.set_description(self._description)
-        self._labeled_dataset.write_manifest()
+        self._dataset_index.description = self._description or ""
+        etas.write_json(
+            self._dataset_index, self._manifest_path, pretty_print=True
+        )
+
         self._media_exporter.close()
 
 

--- a/fiftyone/utils/data/importers.py
+++ b/fiftyone/utils/data/importers.py
@@ -14,7 +14,7 @@ import random
 from bson import json_util
 import cv2
 
-import eta.core.datasets as etads
+import eta.core.datasets as etad
 import eta.core.image as etai
 import eta.core.serial as etas
 import eta.core.utils as etau
@@ -30,7 +30,7 @@ import fiftyone.core.metadata as fom
 import fiftyone.core.media as fomm
 import fiftyone.core.odm as foo
 import fiftyone.core.runs as fors
-import fiftyone.core.sample as fos
+from fiftyone.core.sample import Sample
 import fiftyone.core.utils as fou
 import fiftyone.migrations as fomi
 import fiftyone.types as fot
@@ -368,7 +368,7 @@ def _build_parse_sample_fcn(
 
         def parse_sample(sample):
             image_path, image_metadata = sample
-            return fos.Sample(
+            return Sample(
                 filepath=image_path, metadata=image_metadata, tags=tags,
             )
 
@@ -380,7 +380,7 @@ def _build_parse_sample_fcn(
 
         def parse_sample(sample):
             video_path, video_metadata = sample
-            return fos.Sample(
+            return Sample(
                 filepath=video_path, metadata=video_metadata, tags=tags,
             )
 
@@ -395,7 +395,7 @@ def _build_parse_sample_fcn(
 
         def parse_sample(sample):
             image_path, image_metadata, label = sample
-            sample = fos.Sample(
+            sample = Sample(
                 filepath=image_path, metadata=image_metadata, tags=tags,
             )
 
@@ -433,7 +433,7 @@ def _build_parse_sample_fcn(
         def parse_sample(sample):
             video_path, video_metadata, label, frames = sample
 
-            sample = fos.Sample(
+            sample = Sample(
                 filepath=video_path, metadata=video_metadata, tags=tags,
             )
 
@@ -622,8 +622,10 @@ class ImportPathsMixin(object):
             data_path = os.path.expanduser(data_path)
 
             if not os.path.isabs(data_path) and dataset_dir is not None:
-                dataset_dir = os.path.abspath(os.path.expanduser(dataset_dir))
+                dataset_dir = fou.normalize_path(dataset_dir)
                 data_path = os.path.join(dataset_dir, data_path)
+            else:
+                data_path = fou.normalize_path(data_path)
 
             if not os.path.exists(data_path):
                 if os.path.isfile(data_path + ".json"):
@@ -644,8 +646,10 @@ class ImportPathsMixin(object):
             labels_path = os.path.expanduser(labels_path)
 
             if not os.path.isabs(labels_path) and dataset_dir is not None:
-                dataset_dir = os.path.abspath(os.path.expanduser(dataset_dir))
+                dataset_dir = fou.normalize_path(dataset_dir)
                 labels_path = os.path.join(dataset_dir, labels_path)
+            else:
+                labels_path = fou.normalize_path(labels_path)
 
         return labels_path
 
@@ -671,7 +675,7 @@ class ImportPathsMixin(object):
                     "Data manifest '%s' does not exist" % data_path
                 )
 
-            data_map = etas.load_json(data_path)
+            data_map = etas.read_json(data_path)
             return {to_uuid(k): v for k, v in data_map.items()}
 
         if not os.path.isdir(data_path):
@@ -709,7 +713,7 @@ class DatasetImporter(object):
         self, dataset_dir=None, shuffle=False, seed=None, max_samples=None
     ):
         if dataset_dir is not None:
-            dataset_dir = os.path.abspath(os.path.expanduser(dataset_dir))
+            dataset_dir = fou.normalize_path(dataset_dir)
 
         self.dataset_dir = dataset_dir
         self.shuffle = shuffle
@@ -1243,10 +1247,10 @@ class LegacyFiftyOneDatasetImporter(GenericSampleDatasetImporter):
             labels_relpath = d.pop("frames")
             labels_path = os.path.join(self.dataset_dir, labels_relpath)
 
-            sample = fos.Sample.from_dict(d)
+            sample = Sample.from_dict(d)
             self._import_frame_labels(sample, labels_path)
         else:
-            sample = fos.Sample.from_dict(d)
+            sample = Sample.from_dict(d)
 
         return sample
 
@@ -1264,7 +1268,7 @@ class LegacyFiftyOneDatasetImporter(GenericSampleDatasetImporter):
     def setup(self):
         metadata_path = os.path.join(self.dataset_dir, "metadata.json")
         if os.path.isfile(metadata_path):
-            metadata = etas.load_json(metadata_path)
+            metadata = etas.read_json(metadata_path)
             media_type = metadata.get("media_type", fomm.IMAGE)
             self._metadata = metadata
             self._is_video_dataset = media_type == fomm.VIDEO
@@ -1277,7 +1281,7 @@ class LegacyFiftyOneDatasetImporter(GenericSampleDatasetImporter):
         self._frame_labels_dir = os.path.join(self.dataset_dir, "frames")
 
         samples_path = os.path.join(self.dataset_dir, "samples.json")
-        samples = etas.load_json(samples_path).get("samples", [])
+        samples = etas.read_json(samples_path).get("samples", [])
 
         self._samples = self._preprocess_list(samples)
         self._num_samples = len(self._samples)
@@ -1376,7 +1380,7 @@ class LegacyFiftyOneDatasetImporter(GenericSampleDatasetImporter):
         if not os.path.isfile(metadata_path):
             return None
 
-        metadata = etas.load_json(metadata_path)
+        metadata = etas.read_json(metadata_path)
 
         classes = metadata.get("default_classes", None)
         if classes:
@@ -1394,7 +1398,7 @@ class LegacyFiftyOneDatasetImporter(GenericSampleDatasetImporter):
         return len(etau.list_files(os.path.join(dataset_dir, "data")))
 
     def _import_frame_labels(self, sample, labels_path):
-        frames_map = etas.load_json(labels_path).get("frames", {})
+        frames_map = etas.read_json(labels_path).get("frames", {})
         for key, value in frames_map.items():
             sample.frames[int(key)] = fof.Frame.from_dict(value)
 
@@ -1409,7 +1413,7 @@ class FiftyOneDatasetImporter(BatchDatasetImporter):
         rel_dir (None): a relative directory to prepend to the ``filepath``
             of each sample if the filepath is not absolute. This path is
             converted to an absolute path (if necessary) via
-            ``os.path.abspath(os.path.expanduser(rel_dir))``
+            :func:`fiftyone.core.utils.normalize_path`
         shuffle (False): whether to randomly shuffle the order in which the
             samples are imported
         seed (None): a random seed to use when shuffling
@@ -1431,6 +1435,7 @@ class FiftyOneDatasetImporter(BatchDatasetImporter):
             seed=seed,
             max_samples=max_samples,
         )
+
         self.rel_dir = rel_dir
 
         self._data_dir = None
@@ -1535,19 +1540,16 @@ class FiftyOneDatasetImporter(BatchDatasetImporter):
         samples = self._preprocess_list(samples)
 
         if self.rel_dir is not None:
-            # If a `rel_dir` was provided, prepend it to all relative paths
-            rel_dir = os.path.abspath(os.path.expanduser(self.rel_dir))
-            for sample in samples:
-                filepath = sample["filepath"]
-                if not filepath.startswith(os.path.sep):
-                    sample["filepath"] = os.path.join(rel_dir, filepath)
+            # Prepend `rel_dir` to all relative paths
+            rel_dir = fou.normalize_path(self.rel_dir)
         else:
-            # Prepend `dataset_dir` to all filepaths, which were stored as
-            # relative to `dataset_dir` during export
-            for sample in samples:
-                sample["filepath"] = os.path.join(
-                    self.dataset_dir, sample["filepath"]
-                )
+            # Prepend `dataset_dir` to all relative paths
+            rel_dir = self.dataset_dir
+
+        for sample in samples:
+            filepath = sample["filepath"]
+            if not os.path.isabs(filepath):
+                sample["filepath"] = os.path.join(rel_dir, filepath)
 
         if tags is not None:
             for sample in samples:
@@ -1561,7 +1563,7 @@ class FiftyOneDatasetImporter(BatchDatasetImporter):
         # Import frames
         #
 
-        if os.path.exists(self._frames_path):
+        if os.path.isfile(self._frames_path):
             logger.info("Importing frames...")
             frames = foo.import_collection(self._frames_path).get("frames", [])
 
@@ -1607,7 +1609,7 @@ class FiftyOneDatasetImporter(BatchDatasetImporter):
     def _get_classes(dataset_dir):
         # Used only by dataset zoo
         metadata_path = os.path.join(dataset_dir, "metadata.json")
-        metadata = etas.load_json(metadata_path)
+        metadata = etas.read_json(metadata_path)
 
         classes = metadata.get("default_classes", None)
         if classes:
@@ -1623,13 +1625,13 @@ class FiftyOneDatasetImporter(BatchDatasetImporter):
     def _get_num_samples(dataset_dir):
         # Used only by dataset zoo
         samples_path = os.path.join(dataset_dir, "samples.json")
-        samples = etas.load_json(samples_path).get("samples", [])
+        samples = etas.read_json(samples_path).get("samples", [])
         return len(samples)
 
     def _is_legacy_format_data(self):
         metadata_path = os.path.join(self.dataset_dir, "metadata.json")
-        if os.path.exists(metadata_path):
-            metadata = etas.load_json(metadata_path)
+        if os.path.isfile(metadata_path):
+            metadata = etas.read_json(metadata_path)
         else:
             metadata = {}
 
@@ -1650,11 +1652,12 @@ def _import_run_results(dataset, run_dir, run_cls, keys=None):
 
     for key in keys:
         json_path = os.path.join(run_dir, key + ".json")
-        if os.path.exists(json_path):
+        if os.path.isfile(json_path):
             view = run_cls.load_run_view(dataset, key)
             run_info = run_cls.get_run_info(dataset, key)
             config = run_info.config
-            results = fors.RunResults.from_json(json_path, view, config)
+            d = etas.read_json(json_path)
+            results = fors.RunResults.from_dict(d, view, config)
             run_cls.save_run_results(dataset, key, results, cache=False)
 
 
@@ -1691,8 +1694,10 @@ class ImageDirectoryImporter(UnlabeledImageDatasetImporter):
             seed=seed,
             max_samples=max_samples,
         )
+
         self.recursive = recursive
         self.compute_metadata = compute_metadata
+
         self._filepaths = None
         self._iter_filepaths = None
         self._num_samples = None
@@ -1727,9 +1732,10 @@ class ImageDirectoryImporter(UnlabeledImageDatasetImporter):
             self.dataset_dir, abs_paths=True, recursive=self.recursive
         )
         filepaths = [p for p in filepaths if etai.is_image_mime_type(p)]
+        filepaths = self._preprocess_list(filepaths)
 
-        self._filepaths = self._preprocess_list(filepaths)
-        self._num_samples = len(self._filepaths)
+        self._filepaths = filepaths
+        self._num_samples = len(filepaths)
 
     @staticmethod
     def _get_num_samples(dataset_dir):
@@ -1772,8 +1778,10 @@ class VideoDirectoryImporter(UnlabeledVideoDatasetImporter):
             seed=seed,
             max_samples=max_samples,
         )
+
         self.recursive = recursive
         self.compute_metadata = compute_metadata
+
         self._filepaths = None
         self._iter_filepaths = None
         self._num_samples = None
@@ -1808,9 +1816,10 @@ class VideoDirectoryImporter(UnlabeledVideoDatasetImporter):
             self.dataset_dir, abs_paths=True, recursive=self.recursive
         )
         filepaths = [p for p in filepaths if etav.is_video_mime_type(p)]
+        filepaths = self._preprocess_list(filepaths)
 
-        self._filepaths = self._preprocess_list(filepaths)
-        self._num_samples = len(self._filepaths)
+        self._filepaths = filepaths
+        self._num_samples = len(filepaths)
 
     @staticmethod
     def _get_num_samples(dataset_dir):
@@ -1926,13 +1935,13 @@ class FiftyOneImageClassificationDatasetImporter(
         image_path = self._image_paths_map[uuid]
         target = self._labels_map[uuid]
 
-        self._sample_parser.with_sample((image_path, target))
-        label = self._sample_parser.get_label()
-
         if self.compute_metadata:
             image_metadata = fom.ImageMetadata.build_for(image_path)
         else:
             image_metadata = None
+
+        self._sample_parser.with_sample((image_path, target))
+        label = self._sample_parser.get_label()
 
         return image_path, image_metadata, label
 
@@ -1949,26 +1958,28 @@ class FiftyOneImageClassificationDatasetImporter(
         return (fol.Classification, fol.Classifications)
 
     def setup(self):
-        self._sample_parser = FiftyOneImageClassificationSampleParser()
-
-        self._image_paths_map = self._load_data_map(
+        image_paths_map = self._load_data_map(
             self.data_path, ignore_exts=True, recursive=True
         )
 
         if self.labels_path is not None and os.path.isfile(self.labels_path):
-            labels = etas.load_json(self.labels_path)
+            labels = etas.read_json(self.labels_path)
         else:
             labels = {}
 
-        self._classes = labels.get("classes", None)
+        labels_map = labels.get("labels", {})
+        classes = labels.get("classes", None)
+        uuids = self._preprocess_list(sorted(labels_map.keys()))
+
+        self._classes = classes
+
+        self._sample_parser = FiftyOneImageClassificationSampleParser()
         self._sample_parser.classes = self._classes
 
-        self._labels_map = labels.get("labels", {})
-
-        uuids = sorted(self._labels_map.keys())
-        self._uuids = self._preprocess_list(uuids)
-
-        self._num_samples = len(self._uuids)
+        self._uuids = uuids
+        self._image_paths_map = image_paths_map
+        self._labels_map = labels_map
+        self._num_samples = len(uuids)
 
     def get_dataset_info(self):
         return {"classes": self._classes}
@@ -2067,8 +2078,13 @@ class ImageClassificationDirectoryTreeImporter(LabeledImageDatasetImporter):
     def setup(self):
         samples = []
         classes = set()
-        for class_dir in etau.list_subdirs(self.dataset_dir, abs_paths=True):
-            label = os.path.basename(class_dir)
+
+        for relpath in etau.list_files(self.dataset_dir, recursive=True):
+            chunks = relpath.split(os.path.sep, 1)
+            if len(chunks) == 1:
+                continue
+
+            label = chunks[0]
             if label.startswith("."):
                 continue
 
@@ -2077,14 +2093,15 @@ class ImageClassificationDirectoryTreeImporter(LabeledImageDatasetImporter):
             else:
                 classes.add(label)
 
-            for path in etau.list_files(
-                class_dir, abs_paths=True, recursive=True
-            ):
-                samples.append((path, label))
+            path = os.path.join(self.dataset_dir, relpath)
+            samples.append((path, label))
 
-        self._samples = self._preprocess_list(samples)
-        self._num_samples = len(self._samples)
-        self._classes = sorted(classes)
+        classes = sorted(classes)
+        samples = self._preprocess_list(samples)
+
+        self._samples = samples
+        self._num_samples = len(samples)
+        self._classes = classes
 
     def get_dataset_info(self):
         return {"classes": self._classes}
@@ -2097,11 +2114,7 @@ class ImageClassificationDirectoryTreeImporter(LabeledImageDatasetImporter):
     @staticmethod
     def _get_num_samples(dataset_dir):
         # Used only by dataset zoo
-        num_samples = 0
-        for class_dir in etau.list_subdirs(dataset_dir, abs_paths=True):
-            num_samples += len(etau.list_files(class_dir, recursive=True))
-
-        return num_samples
+        return len(etau.list_files(dataset_dir, recursive=True))
 
 
 class VideoClassificationDirectoryTreeImporter(LabeledVideoDatasetImporter):
@@ -2187,8 +2200,13 @@ class VideoClassificationDirectoryTreeImporter(LabeledVideoDatasetImporter):
     def setup(self):
         samples = []
         classes = set()
-        for class_dir in etau.list_subdirs(self.dataset_dir, abs_paths=True):
-            label = os.path.basename(class_dir)
+
+        for relpath in etau.list_files(self.dataset_dir, recursive=True):
+            chunks = relpath.split(os.path.sep, 1)
+            if len(chunks) == 1:
+                continue
+
+            label = chunks[0]
             if label.startswith("."):
                 continue
 
@@ -2197,14 +2215,15 @@ class VideoClassificationDirectoryTreeImporter(LabeledVideoDatasetImporter):
             else:
                 classes.add(label)
 
-            for path in etau.list_files(
-                class_dir, abs_paths=True, recursive=True
-            ):
-                samples.append((path, label))
+            path = os.path.join(self.dataset_dir, relpath)
+            samples.append((path, label))
 
-        self._samples = self._preprocess_list(samples)
-        self._num_samples = len(self._samples)
-        self._classes = sorted(classes)
+        samples = self._preprocess_list(samples)
+        classes = sorted(classes)
+
+        self._samples = samples
+        self._num_samples = len(samples)
+        self._classes = classes
 
     def get_dataset_info(self):
         return {"classes": self._classes}
@@ -2217,11 +2236,7 @@ class VideoClassificationDirectoryTreeImporter(LabeledVideoDatasetImporter):
     @staticmethod
     def _get_num_samples(dataset_dir):
         # Used only by dataset zoo
-        num_samples = 0
-        for class_dir in etau.list_subdirs(dataset_dir, abs_paths=True):
-            num_samples += len(etau.list_files(class_dir, recursive=True))
-
-        return num_samples
+        return len(etau.list_files(dataset_dir, recursive=True))
 
 
 class FiftyOneImageDetectionDatasetImporter(
@@ -2331,16 +2346,16 @@ class FiftyOneImageDetectionDatasetImporter(
         image_path = self._image_paths_map[uuid]
         target = self._labels_map[uuid]
 
+        if self.compute_metadata:
+            image_metadata = fom.ImageMetadata.build_for(image_path)
+        else:
+            image_metadata = None
+
         if self._has_labels:
             self._sample_parser.with_sample((image_path, target))
             label = self._sample_parser.get_label()
         else:
             label = None
-
-        if self.compute_metadata:
-            image_metadata = fom.ImageMetadata.build_for(image_path)
-        else:
-            image_metadata = None
 
         return image_path, image_metadata, label
 
@@ -2357,25 +2372,31 @@ class FiftyOneImageDetectionDatasetImporter(
         return fol.Detections
 
     def setup(self):
-        self._sample_parser = FiftyOneImageDetectionSampleParser()
-
-        self._image_paths_map = self._load_data_map(
+        image_paths_map = self._load_data_map(
             self.data_path, ignore_exts=True, recursive=True
         )
 
         if self.labels_path is not None and os.path.isfile(self.labels_path):
-            labels = etas.load_json(self.labels_path)
+            labels = etas.read_json(self.labels_path)
         else:
             labels = {}
 
-        self._classes = labels.get("classes", None)
-        self._sample_parser.classes = self._classes
-        self._labels_map = labels.get("labels", {})
-        self._has_labels = any(self._labels_map.values())
+        classes = labels.get("classes", None)
+        labels_map = labels.get("labels", {})
 
-        uuids = sorted(self._labels_map.keys())
-        self._uuids = self._preprocess_list(uuids)
-        self._num_samples = len(self._uuids)
+        uuids = self._preprocess_list(sorted(labels_map.keys()))
+        has_labels = any(labels_map.values())
+
+        self._classes = classes
+        self._has_labels = has_labels
+
+        self._sample_parser = FiftyOneImageDetectionSampleParser()
+        self._sample_parser.classes = classes
+
+        self._image_paths_map = image_paths_map
+        self._labels_map = labels_map
+        self._uuids = uuids
+        self._num_samples = len(uuids)
 
     def get_dataset_info(self):
         return {"classes": self._classes}
@@ -2480,12 +2501,12 @@ class FiftyOneTemporalDetectionDatasetImporter(
         self.labels_path = labels_path
         self.compute_metadata = compute_metadata
 
-        self._classes = None
-        self._sample_parser = None
         self._video_paths_map = None
         self._labels_map = None
         self._uuids = None
         self._iter_uuids = None
+        self._classes = None
+        self._sample_parser = None
         self._num_samples = None
         self._has_labels = False
 
@@ -2502,16 +2523,17 @@ class FiftyOneTemporalDetectionDatasetImporter(
         video_path = self._video_paths_map[uuid]
         labels = self._labels_map[uuid]
 
-        if self._has_labels:
-            self._sample_parser.with_sample((video_path, labels))
-            label = self._sample_parser.get_label()
-        else:
-            label = None
-
         if self.compute_metadata:
             video_metadata = self._sample_parser.get_video_metadata()
         else:
             video_metadata = None
+
+        if self._has_labels:
+            sample = (video_path, labels)
+            self._sample_parser.with_sample(sample, metadata=video_metadata)
+            label = self._sample_parser.get_label()
+        else:
+            label = None
 
         return video_path, video_metadata, label, None
 
@@ -2532,27 +2554,31 @@ class FiftyOneTemporalDetectionDatasetImporter(
         return None
 
     def setup(self):
-        self._sample_parser = FiftyOneTemporalDetectionSampleParser(
-            compute_metadata=self.compute_metadata
-        )
-
-        self._video_paths_map = self._load_data_map(
+        video_paths_map = self._load_data_map(
             self.data_path, ignore_exts=True, recursive=True
         )
 
         if self.labels_path is not None and os.path.isfile(self.labels_path):
-            labels = etas.load_json(self.labels_path)
+            labels = etas.read_json(self.labels_path)
         else:
             labels = {}
 
-        self._classes = labels.get("classes", None)
-        self._sample_parser.classes = self._classes
-        self._labels_map = labels.get("labels", {})
-        self._has_labels = any(self._labels_map.values())
+        classes = labels.get("classes", None)
+        labels_map = labels.get("labels", {})
+        has_labels = any(labels_map.values())
 
-        uuids = sorted(self._labels_map.keys())
-        self._uuids = self._preprocess_list(uuids)
-        self._num_samples = len(self._uuids)
+        uuids = sorted(labels_map.keys())
+        uuids = self._preprocess_list(uuids)
+
+        self._sample_parser = FiftyOneTemporalDetectionSampleParser()
+        self._sample_parser.classes = classes
+
+        self._classes = classes
+        self._video_paths_map = video_paths_map
+        self._labels_map = labels_map
+        self._has_labels = has_labels
+        self._uuids = uuids
+        self._num_samples = len(uuids)
 
     def get_dataset_info(self):
         return {"classes": self._classes}
@@ -2666,7 +2692,7 @@ class ImageSegmentationDirectoryImporter(
         self.include_all_data = include_all_data
 
         self._image_paths_map = None
-        self._mask_paths_map = None
+        self._labels_paths_map = None
         self._uuids = None
         self._iter_uuids = None
         self._num_samples = None
@@ -2682,18 +2708,18 @@ class ImageSegmentationDirectoryImporter(
         uuid = next(self._iter_uuids)
 
         image_path = self._image_paths_map[uuid]
-        mask_path = self._mask_paths_map.get(uuid, None)
+        mask_path = self._labels_paths_map.get(uuid, None)
 
         if self.compute_metadata:
             image_metadata = fom.ImageMetadata.build_for(image_path)
         else:
             image_metadata = None
 
-        if mask_path is None:
-            return image_path, image_metadata, None
-
-        mask = _read_mask(mask_path, force_grayscale=self.force_grayscale)
-        label = fol.Segmentation(mask=mask)
+        if mask_path is not None:
+            mask = _read_mask(mask_path, force_grayscale=self.force_grayscale)
+            label = fol.Segmentation(mask=mask)
+        else:
+            label = None
 
         return image_path, image_metadata, label
 
@@ -2710,22 +2736,26 @@ class ImageSegmentationDirectoryImporter(
         return fol.Segmentation
 
     def setup(self):
-        self._image_paths_map = self._load_data_map(
+        image_paths_map = self._load_data_map(
             self.data_path, ignore_exts=True, recursive=True
         )
 
-        self._mask_paths_map = {
+        labels_paths_map = {
             os.path.splitext(p)[0]: os.path.join(self.labels_path, p)
             for p in etau.list_files(self.labels_path, recursive=True)
         }
 
-        uuids = set(self._mask_paths_map.keys())
+        uuids = set(labels_paths_map.keys())
 
         if self.include_all_data:
-            uuids.update(self._image_paths_map.keys())
+            uuids.update(image_paths_map.keys())
 
-        self._uuids = self._preprocess_list(sorted(uuids))
-        self._num_samples = len(self._uuids)
+        uuids = self._preprocess_list(sorted(uuids))
+
+        self._image_paths_map = image_paths_map
+        self._labels_paths_map = labels_paths_map
+        self._uuids = uuids
+        self._num_samples = len(uuids)
 
     @staticmethod
     def _get_num_samples(dataset_dir):
@@ -2762,6 +2792,9 @@ class FiftyOneImageLabelsDatasetImporter(LabeledImageDatasetImporter):
             :class:`fiftyone.core.labels.Classifications` instance
         skip_non_categorical (False): whether to skip non-categorical frame
             attributes (True) or cast them to strings (False)
+        shuffle (False): whether to randomly shuffle the order in which the
+            samples are imported
+        seed (None): a random seed to use when shuffling
         max_samples (None): a maximum number of samples to import. By default,
             all samples are imported
     """
@@ -2774,10 +2807,15 @@ class FiftyOneImageLabelsDatasetImporter(LabeledImageDatasetImporter):
         labels_dict=None,
         multilabel=False,
         skip_non_categorical=False,
+        shuffle=False,
+        seed=None,
         max_samples=None,
     ):
         super().__init__(
-            dataset_dir=dataset_dir, max_samples=max_samples,
+            dataset_dir=dataset_dir,
+            shuffle=shuffle,
+            seed=seed,
+            max_samples=max_samples,
         )
 
         self.compute_metadata = compute_metadata
@@ -2788,30 +2826,19 @@ class FiftyOneImageLabelsDatasetImporter(LabeledImageDatasetImporter):
 
         self._description = None
         self._sample_parser = None
-        self._labeled_dataset = None
-        self._iter_labeled_dataset = None
+        self._samples = None
+        self._iter_samples = None
         self._num_samples = None
-        self._num_imported = None
 
     def __iter__(self):
-        self._num_imported = 0
-        self._iter_labeled_dataset = zip(
-            self._labeled_dataset.iter_data_paths(),
-            self._labeled_dataset.iter_labels(),
-        )
+        self._iter_samples = iter(self._samples)
         return self
 
     def __len__(self):
         return self._num_samples
 
     def __next__(self):
-        if (
-            self.max_samples is not None
-            and self._num_imported >= self.max_samples
-        ):
-            raise StopIteration
-
-        sample = next(self._iter_labeled_dataset)
+        sample = next(self._iter_samples)
 
         self._sample_parser.with_sample(sample)
         image_path = self._sample_parser.get_image_path()
@@ -2822,7 +2849,6 @@ class FiftyOneImageLabelsDatasetImporter(LabeledImageDatasetImporter):
         else:
             image_metadata = None
 
-        self._num_imported += 1
         return image_path, image_metadata, label
 
     @property
@@ -2843,18 +2869,31 @@ class FiftyOneImageLabelsDatasetImporter(LabeledImageDatasetImporter):
         }
 
     def setup(self):
-        self._sample_parser = FiftyOneImageLabelsSampleParser(
+        sample_parser = FiftyOneImageLabelsSampleParser(
             prefix=self.prefix,
             labels_dict=self.labels_dict,
             multilabel=self.multilabel,
             skip_non_categorical=self.skip_non_categorical,
         )
-        self._labeled_dataset = etads.load_dataset(self.dataset_dir)
-        self._description = self._labeled_dataset.dataset_index.description
 
-        self._num_samples = len(self._labeled_dataset)
-        if self.max_samples is not None:
-            self._num_samples = min(self._num_samples, self.max_samples)
+        index = _load_labeled_dataset_index(self.dataset_dir)
+
+        description = index.description
+        inds = self._preprocess_list(list(range(len(index))))
+
+        image_paths = []
+        label_paths = []
+        for idx in inds:
+            record = index[idx]
+            image_paths.append(os.path.join(self.dataset_dir, record.data))
+            label_paths.append(os.path.join(self.dataset_dir, record.labels))
+
+        samples = list(zip(image_paths, label_paths))
+
+        self._sample_parser = sample_parser
+        self._samples = samples
+        self._num_samples = len(samples)
+        self._description = description
 
     def get_dataset_info(self):
         return {"description": self._description}
@@ -2862,7 +2901,7 @@ class FiftyOneImageLabelsDatasetImporter(LabeledImageDatasetImporter):
     @staticmethod
     def _get_num_samples(dataset_dir):
         # Used only by dataset zoo
-        return len(etads.load_dataset(dataset_dir))
+        return len(_load_labeled_dataset_index(dataset_dir))
 
 
 class FiftyOneVideoLabelsDatasetImporter(LabeledVideoDatasetImporter):
@@ -2889,6 +2928,9 @@ class FiftyOneVideoLabelsDatasetImporter(LabeledVideoDatasetImporter):
             :class:`fiftyone.core.labels.Classifications` instance
         skip_non_categorical (False): whether to skip non-categorical frame
             attributes (True) or cast them to strings (False)
+        shuffle (False): whether to randomly shuffle the order in which the
+            samples are imported
+        seed (None): a random seed to use when shuffling
         max_samples (None): a maximum number of samples to import. By default,
             all samples are imported
     """
@@ -2902,9 +2944,16 @@ class FiftyOneVideoLabelsDatasetImporter(LabeledVideoDatasetImporter):
         frame_labels_dict=None,
         multilabel=False,
         skip_non_categorical=False,
+        shuffle=False,
+        seed=None,
         max_samples=None,
     ):
-        super().__init__(dataset_dir=dataset_dir, max_samples=max_samples)
+        super().__init__(
+            dataset_dir=dataset_dir,
+            shuffle=shuffle,
+            seed=seed,
+            max_samples=max_samples,
+        )
 
         self.compute_metadata = compute_metadata
         self.prefix = prefix
@@ -2915,33 +2964,23 @@ class FiftyOneVideoLabelsDatasetImporter(LabeledVideoDatasetImporter):
 
         self._description = None
         self._sample_parser = None
-        self._labeled_dataset = None
-        self._iter_labeled_dataset = None
+        self._samples = None
+        self._iter_samples = None
         self._num_samples = None
-        self._num_imported = None
 
     def __iter__(self):
-        self._num_imported = 0
-        self._iter_labeled_dataset = zip(
-            self._labeled_dataset.iter_data_paths(),
-            self._labeled_dataset.iter_labels(),
-        )
+        self._iter_samples = iter(self._samples)
         return self
 
     def __len__(self):
         return self._num_samples
 
     def __next__(self):
-        if (
-            self.max_samples is not None
-            and self._num_imported >= self.max_samples
-        ):
-            raise StopIteration
-
-        sample = next(self._iter_labeled_dataset)
+        sample = next(self._iter_samples)
 
         self._sample_parser.with_sample(sample)
         video_path = self._sample_parser.get_video_path()
+        label = self._sample_parser.get_label()
         frames = self._sample_parser.get_frame_labels()
 
         if self.compute_metadata:
@@ -2949,8 +2988,7 @@ class FiftyOneVideoLabelsDatasetImporter(LabeledVideoDatasetImporter):
         else:
             video_metadata = None
 
-        self._num_imported += 1
-        return video_path, video_metadata, None, frames
+        return video_path, video_metadata, label, frames
 
     @property
     def has_dataset_info(self):
@@ -2969,19 +3007,32 @@ class FiftyOneVideoLabelsDatasetImporter(LabeledVideoDatasetImporter):
         return None
 
     def setup(self):
-        self._sample_parser = FiftyOneVideoLabelsSampleParser(
+        sample_parser = FiftyOneVideoLabelsSampleParser(
             prefix=self.prefix,
             labels_dict=self.labels_dict,
             frame_labels_dict=self.frame_labels_dict,
             multilabel=self.multilabel,
             skip_non_categorical=self.skip_non_categorical,
         )
-        self._labeled_dataset = etads.load_dataset(self.dataset_dir)
-        self._description = self._labeled_dataset.dataset_index.description
 
-        self._num_samples = len(self._labeled_dataset)
-        if self.max_samples is not None:
-            self._num_samples = min(self._num_samples, self.max_samples)
+        index = _load_labeled_dataset_index(self.dataset_dir)
+
+        description = index.description
+        inds = self._preprocess_list(list(range(len(index))))
+
+        video_paths = []
+        label_paths = []
+        for idx in inds:
+            record = index[idx]
+            video_paths.append(os.path.join(self.dataset_dir, record.data))
+            label_paths.append(os.path.join(self.dataset_dir, record.labels))
+
+        samples = list(zip(video_paths, label_paths))
+
+        self._samples = samples
+        self._sample_parser = sample_parser
+        self._num_samples = len(samples)
+        self._description = description
 
     def get_dataset_info(self):
         return {"description": self._description}
@@ -2989,4 +3040,10 @@ class FiftyOneVideoLabelsDatasetImporter(LabeledVideoDatasetImporter):
     @staticmethod
     def _get_num_samples(dataset_dir):
         # Used only by dataset zoo
-        return len(etads.load_dataset(dataset_dir))
+        return len(_load_labeled_dataset_index(dataset_dir))
+
+
+def _load_labeled_dataset_index(dataset_dir):
+    index_path = os.path.join(dataset_dir, "manifest.json")
+    d = etas.read_json(index_path)
+    return etad.LabeledDatasetIndex.from_dict(d)

--- a/fiftyone/utils/data/ingestors.py
+++ b/fiftyone/utils/data/ingestors.py
@@ -31,6 +31,9 @@ class ImageIngestor(object):
 
     Args:
         dataset_dir: the directory where input images will be ingested into
+        image_format (None): the image format to use when writing in-memory
+            images to disk. By default, ``fiftyone.config.default_image_ext``
+            is used
     """
 
     def __init__(self, dataset_dir, image_format=None):
@@ -39,6 +42,7 @@ class ImageIngestor(object):
 
         self.dataset_dir = dataset_dir
         self.image_format = image_format
+
         self._filename_maker = None
 
     def _ingest_image(self, sample_parser):
@@ -305,6 +309,7 @@ class VideoIngestor(object):
 
     def __init__(self, dataset_dir):
         self.dataset_dir = dataset_dir
+
         self._filename_maker = None
 
     def _ingest_video(self, sample_parser):

--- a/fiftyone/utils/data/parsers.py
+++ b/fiftyone/utils/data/parsers.py
@@ -17,7 +17,7 @@ import fiftyone as fo
 import fiftyone.core.clips as foc
 import fiftyone.core.labels as fol
 import fiftyone.core.metadata as fom
-import fiftyone.core.sample as fos
+from fiftyone.core.sample import Sample
 import fiftyone.core.utils as fou
 import fiftyone.core.validation as fov
 import fiftyone.utils.eta as foue
@@ -75,7 +75,7 @@ def add_images(dataset, samples, sample_parser, tags=None):
         else:
             metadata = None
 
-        return fos.Sample(filepath=image_path, metadata=metadata, tags=tags)
+        return Sample(filepath=image_path, metadata=metadata, tags=tags)
 
     try:
         num_samples = len(samples)
@@ -166,7 +166,7 @@ def add_labeled_images(
 
         label = sample_parser.get_label()
 
-        sample = fos.Sample(filepath=image_path, metadata=metadata, tags=tags)
+        sample = Sample(filepath=image_path, metadata=metadata, tags=tags)
 
         if isinstance(label, dict):
             sample.update_fields({label_key(k): v for k, v in label.items()})
@@ -241,7 +241,7 @@ def add_videos(dataset, samples, sample_parser, tags=None):
         else:
             metadata = None
 
-        return fos.Sample(filepath=video_path, metadata=metadata, tags=tags)
+        return Sample(filepath=video_path, metadata=metadata, tags=tags)
 
     try:
         num_samples = len(samples)
@@ -328,7 +328,7 @@ def add_labeled_videos(
         label = sample_parser.get_label()
         frames = sample_parser.get_frame_labels()
 
-        sample = fos.Sample(filepath=video_path, metadata=metadata, tags=tags)
+        sample = Sample(filepath=video_path, metadata=metadata, tags=tags)
 
         if isinstance(label, dict):
             sample.update_fields({label_key(k): v for k, v in label.items()})
@@ -1074,7 +1074,7 @@ class ImageDetectionSampleParser(LabeledImageTupleSampleParser):
             return None
 
         if etau.is_str(target):
-            target = etas.load_json(target)
+            target = etas.read_json(target)
 
         return fol.Detections(
             detections=[self._parse_detection(obj, img=img) for obj in target]
@@ -1230,6 +1230,10 @@ class FiftyOneTemporalDetectionSampleParser(LabeledVideoSampleParser):
     @property
     def frame_labels_cls(self):
         return None
+
+    def with_sample(self, sample, metadata=None):
+        super().with_sample(sample)
+        self._current_metadata = metadata
 
     def get_video_path(self):
         return self.current_sample[0]

--- a/fiftyone/utils/dicom.py
+++ b/fiftyone/utils/dicom.py
@@ -13,8 +13,8 @@ import numpy as np
 
 import eta.core.utils as etau
 
-import fiftyone.utils.data as foud
 import fiftyone.core.utils as fou
+import fiftyone.utils.data as foud
 
 fou.ensure_package("pydicom")
 import pydicom
@@ -112,7 +112,8 @@ class DICOMSampleParser(foud.LabeledImageSampleParser):
             if isinstance(self.current_sample, FileInstance):
                 self._ds = self.current_sample.load()
             else:
-                self._ds = pydicom.dcmread(self.current_sample)
+                with open(self.current_sample, "rb") as f:
+                    self._ds = pydicom.dcmread(f)
 
 
 class DICOMDatasetImporter(
@@ -175,7 +176,7 @@ class DICOMDatasetImporter(
         )
 
         if images_dir is None:
-            images_dir = os.path.abspath(os.path.dirname(dicom_path))
+            images_dir = os.path.dirname(dicom_path)
             logger.warning(
                 "No `images_dir` provided. Images will be unpacked to '%s'",
                 images_dir,
@@ -227,7 +228,9 @@ class DICOMDatasetImporter(
         if os.path.isfile(self.dicom_path):
             if not os.path.splitext(self.dicom_path)[1]:
                 # DICOMDIR file
-                ds = pydicom.dcmread(self.dicom_path)
+                with open(self.dicom_path, "rb") as f:
+                    ds = pydicom.dcmread(f)
+
                 samples = list(FileSet(ds))
             else:
                 # Single DICOM file

--- a/fiftyone/utils/geojson.py
+++ b/fiftyone/utils/geojson.py
@@ -13,7 +13,7 @@ import eta.core.utils as etau
 
 import fiftyone.core.fields as fof
 import fiftyone.core.labels as fol
-import fiftyone.core.sample as fos
+from fiftyone.core.sample import Sample
 import fiftyone.core.utils as fou
 import fiftyone.core.validation as fov
 import fiftyone.utils.data as foud
@@ -410,7 +410,7 @@ class GeoJSONDatasetImporter(
 
         feature = self._features_map.get(filepath, None)
         if feature is None:
-            return fos.Sample(filepath=filepath)
+            return Sample(filepath=filepath)
 
         properties = feature.get("properties", {})
 
@@ -431,7 +431,7 @@ class GeoJSONDatasetImporter(
 
         fields[self.location_field] = location
 
-        return fos.Sample(filepath=filepath, **fields)
+        return Sample(filepath=filepath, **fields)
 
     @property
     def has_sample_field_schema(self):
@@ -442,14 +442,12 @@ class GeoJSONDatasetImporter(
         return False
 
     def setup(self):
-        self._media_paths_map = self._load_data_map(
-            self.data_path, recursive=True
-        )
+        media_paths_map = self._load_data_map(self.data_path, recursive=True)
 
         features_map = {}
 
         if self.labels_path is not None and os.path.isfile(self.labels_path):
-            geojson = etas.load_json(self.labels_path)
+            geojson = etas.read_json(self.labels_path)
             _ensure_type(geojson, "FeatureCollection")
 
             for feature in geojson.get("features", []):
@@ -459,7 +457,7 @@ class GeoJSONDatasetImporter(
                     if os.path.isabs(filename):
                         filepath = filename
                     else:
-                        filepath = self._media_paths_map.get(filename, None)
+                        filepath = media_paths_map.get(filename, None)
 
                     if filepath is None:
                         if self.skip_missing_media:
@@ -482,11 +480,14 @@ class GeoJSONDatasetImporter(
         filepaths = set(features_map.keys())
 
         if self.include_all_data:
-            filepaths.update(self._media_paths_map.values())
+            filepaths.update(media_paths_map.values())
 
+        filepaths = self._preprocess_list(sorted(filepaths))
+
+        self._media_paths_map = media_paths_map
         self._features_map = features_map
-        self._filepaths = self._preprocess_list(sorted(filepaths))
-        self._num_samples = len(self._filepaths)
+        self._filepaths = filepaths
+        self._num_samples = len(filepaths)
 
 
 class GeoJSONDatasetExporter(

--- a/fiftyone/utils/geotiff.py
+++ b/fiftyone/utils/geotiff.py
@@ -35,17 +35,16 @@ def get_geolocation(image_path):
     Returns:
         a :class:`fiftyone.core.labels.GeoLocation`
     """
-    image = rasterio.open(image_path, "r")
+    with open(image_path, "rb") as f:
+        with rasterio.open(f, "r") as image:
+            center = image.transform * (0.5 * image.width, 0.5 * image.height)
 
-    center = image.transform * (0.5 * image.width, 0.5 * image.height)
-
-    proj = pyproj.Proj(image.crs)
-    cp = proj(*center, inverse=True)
-    tl = proj(image.bounds.left, image.bounds.top, inverse=True)
-    tr = proj(image.bounds.right, image.bounds.top, inverse=True)
-    br = proj(image.bounds.right, image.bounds.bottom, inverse=True)
-    bl = proj(image.bounds.left, image.bounds.bottom, inverse=True)
-    image.close()
+            proj = pyproj.Proj(image.crs)
+            cp = proj(*center, inverse=True)
+            tl = proj(image.bounds.left, image.bounds.top, inverse=True)
+            tr = proj(image.bounds.right, image.bounds.top, inverse=True)
+            br = proj(image.bounds.right, image.bounds.bottom, inverse=True)
+            bl = proj(image.bounds.left, image.bounds.bottom, inverse=True)
 
     return fol.GeoLocation(point=cp, polygon=[[tl, tr, br, bl, tl]])
 
@@ -167,5 +166,7 @@ class GeoTIFFDatasetImporter(
             )
             filepaths = [p for p in filepaths if etai.is_image_mime_type(p)]
 
-        self._filepaths = self._preprocess_list(filepaths)
-        self._num_samples = len(self._filepaths)
+        filepaths = self._preprocess_list(filepaths)
+
+        self._filepaths = filepaths
+        self._num_samples = len(filepaths)

--- a/fiftyone/utils/image.py
+++ b/fiftyone/utils/image.py
@@ -5,14 +5,18 @@ Image utilities.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+import logging
 import multiprocessing
 import os
 
 import eta.core.image as etai
 import eta.core.utils as etau
 
-import fiftyone.core.media as fom
 import fiftyone.core.utils as fou
+import fiftyone.core.validation as fov
+
+
+logger = logging.getLogger(__name__)
 
 
 def reencode_images(
@@ -21,6 +25,7 @@ def reencode_images(
     force_reencode=True,
     delete_originals=False,
     num_workers=None,
+    skip_failures=False,
 ):
     """Re-encodes the images in the sample collection to the given format.
 
@@ -37,31 +42,19 @@ def reencode_images(
             re-encoding
         num_workers (None): the number of worker processes to use. By default,
             ``multiprocessing.cpu_count()`` is used
+        skip_failures (False): whether to gracefully continue without raising
+            an error if an image cannot be re-encoded
     """
-    if sample_collection.media_type != fom.IMAGE:
-        raise ValueError(
-            "Sample collection '%s' does not contain images (media_type = "
-            "'%s')" % (sample_collection.name, sample_collection.media_type)
-        )
+    fov.validate_image_collection(sample_collection)
 
-    if num_workers is None:
-        num_workers = multiprocessing.cpu_count()
-
-    if num_workers <= 1:
-        _transform_images(
-            sample_collection,
-            ext=ext,
-            force_reencode=force_reencode,
-            delete_originals=delete_originals,
-        )
-    else:
-        _transform_images_multi(
-            sample_collection,
-            num_workers,
-            ext=ext,
-            force_reencode=force_reencode,
-            delete_originals=delete_originals,
-        )
+    _transform_images(
+        sample_collection,
+        ext=ext,
+        force_reencode=force_reencode,
+        delete_originals=delete_originals,
+        num_workers=num_workers,
+        skip_failures=skip_failures,
+    )
 
 
 def transform_images(
@@ -73,6 +66,7 @@ def transform_images(
     force_reencode=False,
     delete_originals=False,
     num_workers=None,
+    skip_failures=False,
 ):
     """Transforms the images in the sample collection according to the provided
     parameters.
@@ -101,39 +95,22 @@ def transform_images(
             transformation was applied
         num_workers (None): the number of worker processes to use. By default,
             ``multiprocessing.cpu_count()`` is used
+        skip_failures (False): whether to gracefully continue without raising
+            an error if an image cannot be transformed
     """
-    if sample_collection.media_type != fom.IMAGE:
-        raise ValueError(
-            "Sample collection '%s' does not contain images (media_type = "
-            "'%s')" % (sample_collection.name, sample_collection.media_type)
-        )
+    fov.validate_image_collection(sample_collection)
 
-    ext = _parse_ext(ext)
-
-    if num_workers is None:
-        num_workers = multiprocessing.cpu_count()
-
-    if num_workers <= 1:
-        _transform_images(
-            sample_collection,
-            size=size,
-            min_size=min_size,
-            max_size=max_size,
-            ext=ext,
-            force_reencode=force_reencode,
-            delete_originals=delete_originals,
-        )
-    else:
-        _transform_images_multi(
-            sample_collection,
-            num_workers,
-            size=size,
-            min_size=min_size,
-            max_size=max_size,
-            ext=ext,
-            force_reencode=force_reencode,
-            delete_originals=delete_originals,
-        )
+    _transform_images(
+        sample_collection,
+        size=size,
+        min_size=min_size,
+        max_size=max_size,
+        ext=ext,
+        force_reencode=force_reencode,
+        delete_originals=delete_originals,
+        num_workers=num_workers,
+        skip_failures=skip_failures,
+    )
 
 
 def reencode_image(input_path, output_path):
@@ -172,16 +149,6 @@ def transform_image(
     )
 
 
-def _parse_ext(ext):
-    if ext is None:
-        return None
-
-    if not ext.startswith("."):
-        ext = "." + ext
-
-    return ext.lower()
-
-
 def _transform_images(
     sample_collection,
     size=None,
@@ -190,9 +157,53 @@ def _transform_images(
     ext=None,
     force_reencode=False,
     delete_originals=False,
+    num_workers=None,
+    skip_failures=False,
 ):
+    ext = _parse_ext(ext)
+
+    if num_workers is None:
+        num_workers = multiprocessing.cpu_count()
+
+    if num_workers <= 1:
+        _transform_images_single(
+            sample_collection,
+            size=size,
+            min_size=min_size,
+            max_size=max_size,
+            ext=ext,
+            force_reencode=force_reencode,
+            delete_originals=delete_originals,
+            skip_failures=skip_failures,
+        )
+    else:
+        _transform_images_multi(
+            sample_collection,
+            num_workers,
+            size=size,
+            min_size=min_size,
+            max_size=max_size,
+            ext=ext,
+            force_reencode=force_reencode,
+            delete_originals=delete_originals,
+            skip_failures=skip_failures,
+        )
+
+
+def _transform_images_single(
+    sample_collection,
+    size=None,
+    min_size=None,
+    max_size=None,
+    ext=None,
+    force_reencode=False,
+    delete_originals=False,
+    skip_failures=False,
+):
+    view = sample_collection.select_fields()
+
     with fou.ProgressBar() as pb:
-        for sample in pb(sample_collection.select_fields()):
+        for sample in pb(view):
             inpath = sample.filepath
 
             if ext is not None:
@@ -208,10 +219,12 @@ def _transform_images(
                 max_size=max_size,
                 force_reencode=force_reencode,
                 delete_original=delete_originals,
+                skip_failures=skip_failures,
             )
 
-            sample.filepath = outpath
-            sample.save()
+            if outpath != inpath:
+                sample.filepath = outpath
+                sample.save()
 
 
 def _transform_images_multi(
@@ -223,11 +236,12 @@ def _transform_images_multi(
     ext=None,
     force_reencode=False,
     delete_originals=False,
+    skip_failures=False,
 ):
-    inputs = []
-    for sample in sample_collection.select_fields():
-        inpath = sample.filepath
+    sample_ids, filepaths = sample_collection.values(["id", "filepath"])
 
+    inputs = []
+    for sample_id, inpath in zip(sample_ids, filepaths):
         if ext is not None:
             outpath = os.path.splitext(inpath)[0] + ext
         else:
@@ -235,7 +249,7 @@ def _transform_images_multi(
 
         inputs.append(
             (
-                sample.id,
+                sample_id,
                 inpath,
                 outpath,
                 size,
@@ -243,22 +257,27 @@ def _transform_images_multi(
                 max_size,
                 force_reencode,
                 delete_originals,
+                skip_failures,
             )
         )
 
+    view = sample_collection.select_fields()
+
     with fou.ProgressBar(inputs) as pb:
         with multiprocessing.Pool(processes=num_workers) as pool:
-            for sample_id, outpath in pb(
+            for sample_id, inpath, outpath, _ in pb(
                 pool.imap_unordered(_do_transform, inputs)
             ):
-                sample = sample_collection[sample_id]
-                sample.filepath = outpath
-                sample.save()
+                if outpath != inpath:
+                    sample = view[sample_id]
+                    sample.filepath = outpath
+                    sample.save()
 
 
 def _do_transform(args):
-    _transform_image(*args[1:])
-    return args[0], args[2]
+    sample_id, inpath, outpath = args[:3]
+    did_transform = _transform_image(inpath, outpath, *args[3:])
+    return sample_id, inpath, outpath, did_transform
 
 
 def _transform_image(
@@ -269,42 +288,55 @@ def _transform_image(
     max_size=None,
     force_reencode=False,
     delete_original=False,
+    skip_failures=False,
 ):
-    inpath = os.path.abspath(os.path.expanduser(inpath))
-    outpath = os.path.abspath(os.path.expanduser(outpath))
+    inpath = fou.normalize_path(inpath)
+    outpath = fou.normalize_path(outpath)
     in_ext = os.path.splitext(inpath)[1]
     out_ext = os.path.splitext(outpath)[1]
 
-    if (
-        size is not None
-        or min_size is not None
-        or max_size is not None
-        or in_ext != out_ext
-        or force_reencode
-    ):
-        img = etai.read(inpath)
-        size = _parse_parameters(img, size, min_size, max_size)
+    did_transform = False
 
-    diff_params = size is not None
-    should_reencode = diff_params or force_reencode
+    try:
+        if (
+            size is not None
+            or min_size is not None
+            or max_size is not None
+            or in_ext != out_ext
+            or force_reencode
+        ):
+            img = etai.read(inpath)
+            size = _parse_parameters(img, size, min_size, max_size)
 
-    if (inpath == outpath) and should_reencode and not delete_original:
-        _inpath = inpath
-        inpath = etau.make_unique_path(inpath, suffix="-original")
-        etau.move_file(_inpath, inpath)
+        diff_params = size is not None
+        should_reencode = diff_params or force_reencode
 
-    diff_path = inpath != outpath
+        if (inpath == outpath) and should_reencode and not delete_original:
+            _inpath = inpath
+            inpath = etau.make_unique_path(inpath, suffix="-original")
+            etau.move_file(_inpath, inpath)
 
-    if diff_params:
-        img = etai.resize(img, width=size[0], height=size[1])
-        etai.write(img, outpath)
-    elif force_reencode or (in_ext != out_ext):
-        etai.write(img, outpath)
-    elif diff_path:
-        etau.copy_file(inpath, outpath)
+        diff_path = inpath != outpath
 
-    if delete_original and diff_path:
-        etau.delete_file(inpath)
+        if diff_params:
+            img = etai.resize(img, width=size[0], height=size[1])
+            etai.write(img, outpath)
+            did_transform = True
+        elif force_reencode or (in_ext != out_ext):
+            etai.write(img, outpath)
+            did_transform = True
+        elif diff_path:
+            etau.copy_file(inpath, outpath)
+
+        if delete_original and diff_path:
+            etau.delete_file(inpath)
+    except Exception as e:
+        if not skip_failures:
+            raise
+
+        logger.warning(e)
+
+    return did_transform
 
 
 def _parse_parameters(img, size, min_size, max_size):
@@ -318,3 +350,13 @@ def _parse_parameters(img, size, min_size, max_size):
     osize = etai.clip_frame_size(osize, min_size=min_size, max_size=max_size)
 
     return osize if osize != isize else None
+
+
+def _parse_ext(ext):
+    if ext is None:
+        return None
+
+    if not ext.startswith("."):
+        ext = "." + ext
+
+    return ext.lower()

--- a/fiftyone/utils/kitti.py
+++ b/fiftyone/utils/kitti.py
@@ -161,25 +161,29 @@ class KITTIDetectionDatasetImporter(
         return fol.Detections
 
     def setup(self):
-        self._image_paths_map = self._load_data_map(
+        image_paths_map = self._load_data_map(
             self.data_path, ignore_exts=True, recursive=True
         )
 
         if self.labels_path is not None and os.path.isdir(self.labels_path):
-            self._labels_paths_map = {
+            labels_paths_map = {
                 os.path.splitext(p)[0]: os.path.join(self.labels_path, p)
                 for p in etau.list_files(self.labels_path, recursive=True)
             }
         else:
-            self._labels_paths_map = {}
+            labels_paths_map = {}
 
-        uuids = set(self._labels_paths_map.keys())
+        uuids = set(labels_paths_map.keys())
 
         if self.include_all_data:
-            uuids.update(self._image_paths_map.keys())
+            uuids.update(image_paths_map.keys())
 
-        self._uuids = self._preprocess_list(sorted(uuids))
-        self._num_samples = len(self._uuids)
+        uuids = self._preprocess_list(sorted(uuids))
+
+        self._image_paths_map = image_paths_map
+        self._labels_paths_map = labels_paths_map
+        self._uuids = uuids
+        self._num_samples = len(uuids)
 
     @staticmethod
     def _get_num_samples(dataset_dir):
@@ -301,12 +305,12 @@ class KITTIDetectionDatasetExporter(
         if detections is None:
             return
 
-        out_anno_path = os.path.join(self.labels_path, uuid + ".txt")
+        out_labels_path = os.path.join(self.labels_path, uuid + ".txt")
 
         if metadata is None:
             metadata = fom.ImageMetadata.build_for(image_or_path)
 
-        self._writer.write(detections, metadata, out_anno_path)
+        self._writer.write(detections, metadata, out_labels_path)
 
     def close(self, *args):
         self._media_exporter.close()

--- a/fiftyone/utils/tf.py
+++ b/fiftyone/utils/tf.py
@@ -207,9 +207,10 @@ class TFRecordsWriter(object):
     def __init__(self, tf_records_path, num_shards=None):
         self.tf_records_path = tf_records_path
         self.num_shards = num_shards
+
+        self._idx = None
         self._num_shards = None
         self._writers = None
-        self._idx = None
         self._writers_context = None
 
     def __enter__(self):
@@ -495,7 +496,7 @@ class TFRecordsLabeledImageDatasetImporter(
         )
 
         if images_dir is None:
-            images_dir = os.path.abspath(os.path.dirname(tf_records_path))
+            images_dir = os.path.dirname(tf_records_path)
             logger.warning(
                 "No `images_dir` provided. Images will be unpacked to '%s'",
                 images_dir,

--- a/fiftyone/utils/video.py
+++ b/fiftyone/utils/video.py
@@ -6,6 +6,7 @@ Video utilities.
 |
 """
 import itertools
+import logging
 import os
 
 import eta.core.frameutils as etaf
@@ -15,10 +16,12 @@ import eta.core.utils as etau
 import eta.core.video as etav
 
 import fiftyone as fo
-import fiftyone.core.clips as foc
 import fiftyone.core.metadata as fom
 import fiftyone.core.utils as fou
 import fiftyone.core.validation as fov
+
+
+logger = logging.getLogger(__name__)
 
 
 def extract_clip(
@@ -85,6 +88,7 @@ def reencode_videos(
     sample_collection,
     force_reencode=True,
     delete_originals=False,
+    skip_failures=False,
     verbose=False,
     **kwargs
 ):
@@ -113,6 +117,8 @@ def reencode_videos(
             MP4s
         delete_originals (False): whether to delete the original videos after
             re-encoding
+        skip_failures (False): whether to gracefully continue without raising
+            an error if a video cannot be re-encoded
         verbose (False): whether to log the ``ffmpeg`` commands that are
             executed
         **kwargs: keyword arguments for ``eta.core.video.FFmpeg(**kwargs)``
@@ -124,6 +130,7 @@ def reencode_videos(
         reencode=True,
         force_reencode=force_reencode,
         delete_originals=delete_originals,
+        skip_failures=skip_failures,
         verbose=verbose,
         **kwargs
     )
@@ -140,6 +147,7 @@ def transform_videos(
     reencode=False,
     force_reencode=False,
     delete_originals=False,
+    skip_failures=False,
     verbose=False,
     **kwargs
 ):
@@ -181,6 +189,8 @@ def transform_videos(
             already satisfy the specified values
         delete_originals (False): whether to delete the original videos after
             re-encoding
+        skip_failures (False): whether to gracefully continue without raising
+            an error if a video cannot be transformed
         verbose (False): whether to log the ``ffmpeg`` commands that are
             executed
         **kwargs: keyword arguments for ``eta.core.video.FFmpeg(**kwargs)``
@@ -198,6 +208,7 @@ def transform_videos(
         reencode=reencode,
         force_reencode=force_reencode,
         delete_originals=delete_originals,
+        skip_failures=skip_failures,
         verbose=verbose,
         **kwargs
     )
@@ -215,6 +226,7 @@ def sample_videos(
     original_frame_numbers=True,
     force_sample=False,
     delete_originals=False,
+    skip_failures=False,
     verbose=False,
     **kwargs
 ):
@@ -272,6 +284,8 @@ def sample_videos(
             already exist
         delete_originals (False): whether to delete the original videos after
             sampling
+        skip_failures (False): whether to gracefully continue without raising
+            an error if a video cannot be sampled
         verbose (False): whether to log the ``ffmpeg`` commands that are
             executed
         **kwargs: keyword arguments for ``eta.core.video.FFmpeg(**kwargs)``
@@ -291,6 +305,7 @@ def sample_videos(
         frames_patt=frames_patt,
         force_reencode=force_sample,
         delete_originals=delete_originals,
+        skip_failures=skip_failures,
         verbose=verbose,
         **kwargs
     )
@@ -554,6 +569,7 @@ def _transform_videos(
     reencode=False,
     force_reencode=False,
     delete_originals=False,
+    skip_failures=False,
     verbose=False,
     **kwargs
 ):
@@ -579,7 +595,7 @@ def _transform_videos(
 
                 # If sampling was not forced and the first frame exists, assume
                 # that all frames exist
-                if not force_reencode and os.path.exists(outpath % 1):
+                if not force_reencode and os.path.isfile(outpath % 1):
                     continue
             elif reencode:
                 root, ext = os.path.splitext(inpath)
@@ -604,11 +620,12 @@ def _transform_videos(
                 reencode=reencode,
                 force_reencode=force_reencode,
                 delete_original=delete_originals,
+                skip_failures=skip_failures,
                 verbose=verbose,
                 **kwargs
             )
 
-            if not sample_frames:
+            if outpath != inpath and not sample_frames:
                 sample.filepath = outpath
                 sample.save()
 
@@ -628,11 +645,12 @@ def _transform_video(
     reencode=False,
     force_reencode=False,
     delete_original=False,
+    skip_failures=False,
     verbose=False,
     **kwargs
 ):
-    inpath = os.path.abspath(os.path.expanduser(inpath))
-    outpath = os.path.abspath(os.path.expanduser(outpath))
+    inpath = fou.normalize_path(inpath)
+    outpath = fou.normalize_path(outpath)
     in_ext = os.path.splitext(inpath)[1]
     out_ext = os.path.splitext(outpath)[1]
 
@@ -647,67 +665,85 @@ def _transform_video(
         min_fps = None
         max_fps = None
 
-    if (
-        fps is not None
-        or min_fps is not None
-        or max_fps is not None
-        or size is not None
-        or min_size is not None
-        or max_size is not None
-    ):
-        fps, size, _frames = _parse_parameters(
-            inpath,
-            fps,
-            min_fps,
-            max_fps,
-            size,
-            min_size,
-            max_size,
-            sample_frames,
-            original_frame_numbers,
+    did_transform = False
+
+    try:
+        if (
+            fps is not None
+            or min_fps is not None
+            or max_fps is not None
+            or size is not None
+            or min_size is not None
+            or max_size is not None
+        ):
+            fps, size, _frames = _parse_parameters(
+                inpath,
+                fps,
+                min_fps,
+                max_fps,
+                size,
+                min_size,
+                max_size,
+                sample_frames,
+                original_frame_numbers,
+            )
+
+            if frames is None:
+                frames = _frames
+
+        if reencode:
+            # Use default reencoding parameters from ``eta.core.video.FFmpeg``
+            kwargs["in_opts"] = None
+            kwargs["out_opts"] = None
+        else:
+            # No reencoding parameters
+            if "in_opts" not in kwargs:
+                kwargs["in_opts"] = []
+
+            if "out_opts" not in kwargs:
+                kwargs["out_opts"] = []
+
+        should_reencode = (
+            force_reencode
+            or fps is not None
+            or size is not None
+            or in_ext.lower() != out_ext.lower()
         )
 
-        if frames is None:
-            frames = _frames
+        if (inpath == outpath) and should_reencode:
+            _inpath = inpath
+            inpath = etau.make_unique_path(inpath, suffix="-original")
+            etau.move_file(_inpath, inpath)
 
-    if reencode:
-        # Use default reencoding parameters from ``eta.core.video.FFmpeg``
-        kwargs["in_opts"] = None
-        kwargs["out_opts"] = None
-    else:
-        # No reencoding parameters
-        if "in_opts" not in kwargs:
-            kwargs["in_opts"] = []
+        diff_path = inpath != outpath
 
-        if "out_opts" not in kwargs:
-            kwargs["out_opts"] = []
+        if frames is not None:
+            etav.sample_select_frames(
+                inpath, frames, output_patt=outpath, size=size, fast=True
+            )
+            did_transform = True
+        elif not etav.is_video_mime_type(outpath):
+            with etav.FFmpeg(fps=fps, size=size, **kwargs) as ffmpeg:
+                ffmpeg.run(inpath, outpath, verbose=verbose)
 
-    should_reencode = (
-        force_reencode
-        or fps is not None
-        or size is not None
-        or in_ext.lower() != out_ext.lower()
-    )
+            did_transform = True
+        elif should_reencode:
+            with etav.FFmpeg(fps=fps, size=size, **kwargs) as ffmpeg:
+                ffmpeg.run(inpath, outpath, verbose=verbose)
 
-    if (inpath == outpath) and should_reencode:
-        _inpath = inpath
-        inpath = etau.make_unique_path(inpath, suffix="-original")
-        etau.move_file(_inpath, inpath)
+            did_transform = True
+        elif diff_path:
+            etau.copy_file(inpath, outpath)
 
-    diff_path = inpath != outpath
+        if delete_original and diff_path:
+            etau.delete_file(inpath)
+    except Exception as e:
+        if not skip_failures:
+            raise
 
-    if frames is not None:
-        etav.sample_select_frames(
-            inpath, frames, output_patt=outpath, size=size, fast=True
-        )
-    elif should_reencode:
-        with etav.FFmpeg(fps=fps, size=size, **kwargs) as ffmpeg:
-            ffmpeg.run(inpath, outpath, verbose=verbose)
-    elif diff_path:
-        etau.copy_file(inpath, outpath)
+        logger.warning(e)
 
-    if delete_original and diff_path:
-        etau.delete_file(inpath)
+    return did_transform
 
 
 def _parse_parameters(
@@ -721,11 +757,11 @@ def _parse_parameters(
     sample_frames,
     original_frame_numbers,
 ):
-    video_metadata = etav.VideoMetadata.build_for(video_path)
+    metadata = fom.VideoMetadata.build_for(video_path)
 
-    ifps = video_metadata.frame_rate
-    isize = video_metadata.frame_size
-    iframe_count = video_metadata.total_frame_count
+    ifps = metadata.frame_rate
+    isize = (metadata.frame_width, metadata.frame_height)
+    iframe_count = metadata.total_frame_count
 
     ofps = fps or -1
     min_fps = min_fps or -1
@@ -761,6 +797,7 @@ def _parse_parameters(
 
     if sample_frames and original_frame_numbers and ofps is not None:
         if ofps > ifps:
+            # pylint: disable=bad-string-format-type
             raise ValueError(
                 "Cannot maintain original frame numbers when requested frame "
                 "rate (%f) exceeds native frame rate (%f) of video '%s'"

--- a/fiftyone/utils/voc.py
+++ b/fiftyone/utils/voc.py
@@ -133,7 +133,6 @@ class VOCDetectionDatasetImporter(
         labels_path = self._labels_paths_map.get(uuid, None)
         if labels_path:
             # Labeled image
-
             annotation = load_voc_detection_annotations(labels_path)
 
             # Use image filename from annotation file if possible
@@ -154,16 +153,12 @@ class VOCDetectionDatasetImporter(
             else:
                 raise ValueError("No image found for sample '%s'" % _uuid)
 
-            if annotation.metadata is None:
-                annotation.metadata = fom.ImageMetadata.build_for(image_path)
-
             image_metadata = annotation.metadata
-
             detections = annotation.to_detections(extra_attrs=self.extra_attrs)
         else:
             # Unlabeled image
             image_path = self._image_paths_map[uuid]
-            image_metadata = fom.ImageMetadata.build_for(image_path)
+            image_metadata = None
             detections = None
 
         return image_path, image_metadata, detections
@@ -181,25 +176,29 @@ class VOCDetectionDatasetImporter(
         return fol.Detections
 
     def setup(self):
-        self._image_paths_map = self._load_data_map(
+        image_paths_map = self._load_data_map(
             self.data_path, ignore_exts=True, recursive=True
         )
 
         if self.labels_path is not None and os.path.isdir(self.labels_path):
-            self._labels_paths_map = {
+            labels_paths_map = {
                 os.path.splitext(p)[0]: os.path.join(self.labels_path, p)
                 for p in etau.list_files(self.labels_path, recursive=True)
             }
         else:
-            self._labels_paths_map = {}
+            labels_paths_map = {}
 
-        uuids = set(self._labels_paths_map.keys())
+        uuids = set(labels_paths_map.keys())
 
         if self.include_all_data:
-            uuids.update(self._image_paths_map.keys())
+            uuids.update(image_paths_map.keys())
 
-        self._uuids = self._preprocess_list(sorted(uuids))
-        self._num_samples = len(self._uuids)
+        uuids = self._preprocess_list(sorted(uuids))
+
+        self._image_paths_map = image_paths_map
+        self._labels_paths_map = labels_paths_map
+        self._uuids = uuids
+        self._num_samples = len(uuids)
 
 
 class VOCDetectionDatasetExporter(
@@ -327,7 +326,7 @@ class VOCDetectionDatasetExporter(
         if detections is None:
             return
 
-        out_anno_path = os.path.join(
+        out_labels_path = os.path.join(
             self.labels_path, os.path.splitext(filename)[0] + ".xml"
         )
 
@@ -348,7 +347,7 @@ class VOCDetectionDatasetExporter(
             filename=filename,
             extra_attrs=self.extra_attrs,
         )
-        self._writer.write(annotation, out_anno_path)
+        self._writer.write(annotation, out_labels_path)
 
     def close(self, *args):
         self._media_exporter.close()

--- a/fiftyone/utils/yolo.py
+++ b/fiftyone/utils/yolo.py
@@ -296,12 +296,13 @@ class YOLOv4DatasetImporter(
 
                 image_paths.append(path)
         else:
-            logger.warning(
-                "Images file '%s' not found. Listing data directory '%s' "
-                "instead",
-                self.images_path,
-                self.data_path,
-            )
+            if self.images_path is not None:
+                logger.warning(
+                    "Images file '%s' not found. Listing data directory '%s' "
+                    "instead",
+                    self.images_path,
+                    self.data_path,
+                )
 
             image_paths = [
                 p

--- a/fiftyone/utils/yolo.py
+++ b/fiftyone/utils/yolo.py
@@ -248,8 +248,8 @@ class YOLOv4DatasetImporter(
 
         self._info = None
         self._classes = None
-        self._filepaths = None
         self._labels_paths_map = None
+        self._filepaths = None
         self._iter_filepaths = None
         self._num_samples = None
 
@@ -286,7 +286,7 @@ class YOLOv4DatasetImporter(
         return fol.Detections
 
     def setup(self):
-        if self.images_path is not None and os.path.exists(self.images_path):
+        if self.images_path is not None and os.path.isfile(self.images_path):
             root_dir = os.path.dirname(self.images_path)
 
             image_paths = []
@@ -322,12 +322,19 @@ class YOLOv4DatasetImporter(
                 # Labels are in same directory as images
                 labels_path = os.path.splitext(image_path)[0] + ".txt"
 
-            if os.path.exists(labels_path):
+            if os.path.isfile(labels_path):
                 labels_paths_map[image_path] = labels_path
+
+        filepaths = set(labels_paths_map.keys())
+
+        if self.include_all_data:
+            filepaths.update(image_paths)
+
+        filepaths = self._preprocess_list(sorted(filepaths))
 
         if self.classes is not None:
             classes = self.classes
-        elif self.objects_path is not None and os.path.exists(
+        elif self.objects_path is not None and os.path.isfile(
             self.objects_path
         ):
             classes = _read_file_lines(self.objects_path)
@@ -338,14 +345,11 @@ class YOLOv4DatasetImporter(
         if classes is not None:
             info["classes"] = classes
 
-        if not self.include_all_data:
-            image_paths = labels_paths_map.keys()
-
         self._info = info
         self._classes = classes
-        self._filepaths = self._preprocess_list(sorted(image_paths))
         self._labels_paths_map = labels_paths_map
-        self._num_samples = len(self._filepaths)
+        self._filepaths = filepaths
+        self._num_samples = len(filepaths)
 
     def get_dataset_info(self):
         return self._info
@@ -373,6 +377,9 @@ class YOLOv5DatasetImporter(
             If None, the parameter will default to ``dataset.yaml``
         split ("val"): the split to load. Typical values are
             ``("train", "val")``
+        include_all_data (False): whether to generate samples for all images in
+            the data directory (True) rather than only creating samples for
+            images with labels (False)
         shuffle (False): whether to randomly shuffle the order in which the
             samples are imported
         seed (None): a random seed to use when shuffling
@@ -385,6 +392,7 @@ class YOLOv5DatasetImporter(
         dataset_dir=None,
         yaml_path=None,
         split="val",
+        include_all_data=False,
         shuffle=False,
         seed=None,
         max_samples=None,
@@ -409,11 +417,12 @@ class YOLOv5DatasetImporter(
 
         self.yaml_path = yaml_path
         self.split = split
+        self.include_all_data = include_all_data
 
         self._info = None
         self._classes = None
-        self._filepaths = None
         self._labels_paths_map = None
+        self._filepaths = None
         self._iter_filepaths = None
         self._num_samples = None
 
@@ -480,8 +489,15 @@ class YOLOv5DatasetImporter(
         labels_paths_map = {}
         for image_path in image_paths:
             labels_path = _get_yolo_v5_labels_path(image_path)
-            if os.path.exists(labels_path):
+            if os.path.isfile(labels_path):
                 labels_paths_map[image_path] = labels_path
+
+        filepaths = set(labels_paths_map.keys())
+
+        if self.include_all_data:
+            filepaths.update(image_paths)
+
+        filepaths = self._preprocess_list(sorted(filepaths))
 
         info = {}
         if classes is not None:
@@ -490,8 +506,8 @@ class YOLOv5DatasetImporter(
         self._info = info
         self._classes = classes
         self._labels_paths_map = labels_paths_map
-        self._filepaths = self._preprocess_list(sorted(image_paths))
-        self._num_samples = len(self._filepaths)
+        self._filepaths = filepaths
+        self._num_samples = len(filepaths)
 
     def get_dataset_info(self):
         return self._info
@@ -917,7 +933,7 @@ class YOLOv5DatasetExporter(
         d["nc"] = len(classes)
         d["names"] = list(classes)
 
-        _write_yaml_file(d, self.yaml_path)
+        _write_yaml_file(d, self.yaml_path, default_flow_style=False)
 
     def _parse_classes(self):
         if self.classes is not None:
@@ -1032,11 +1048,16 @@ def _get_yolo_v5_labels_path(image_path):
     if len(chunks) == 1:
         raise ValueError(
             "Invalid image path '%s'. YOLOv5 image paths must contain '%s', "
-            "which is replaced with '%s' to locate the labels TXT file"
+            "which is replaced with '%s' to locate the corresponding labels"
             % (image_path, old, new)
         )
 
-    return os.path.splitext(new.join(chunks))[0] + ".txt"
+    root, ext = os.path.splitext(new.join(chunks))
+
+    if ext:
+        ext = ".txt"
+
+    return root + ext
 
 
 def _parse_yolo_row(row, classes):
@@ -1082,8 +1103,8 @@ def _read_yaml_file(path):
         return yaml.safe_load(f)
 
 
-def _write_yaml_file(d, path):
-    s = yaml.dump(d, default_flow_style=False)
+def _write_yaml_file(d, path, **kwargs):
+    s = yaml.dump(d, **kwargs)
     etau.write_file(s, path)
 
 

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -10,6 +10,7 @@ kaleido==0.2.1
 matplotlib==3.2.1
 mongoengine==0.20.0
 motor==2.3.0
+ndjson==0.3.1
 packaging==20.3
 pandas==1.1.5
 plotly==4.14.3

--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,7 @@ INSTALL_REQUIRES = [
     "matplotlib",
     "mongoengine==0.20.0",
     "motor>=2.3,<3",
+    "ndjson",
     "numpy",
     "packaging",
     "pandas",

--- a/tests/unittests/import_export_tests.py
+++ b/tests/unittests/import_export_tests.py
@@ -1096,6 +1096,7 @@ class ImageDetectionDatasetTests(ImageDatasetTests):
             dataset_dir=export_dir,
             dataset_type=fo.types.YOLOv5Dataset,
             label_field="predictions",
+            include_all_data=True,
         )
 
         self.assertEqual(len(dataset), len(dataset2))


### PR DESCRIPTION
Backports some import/export work from Teams. The primary outcome is cleanup and consistency, along with the following small API enhancements:
- Adds `skip_failures` flags to `foui.transform_images()` and `fouv.transform_videos()`
- Adds `include_all_data` flag to `YOLOv5DatasetImporter`
- Adds `shuffle` and `seed` parameters to `FiftyOneImageLabelsDatasetImporter` and `FiftyOneVideoLabelsDatasetImporter`
