### PR TITLE
Resolve bug when annotating existing fields with multiple label types

### DIFF
--- a/fiftyone/utils/annotations.py
+++ b/fiftyone/utils/annotations.py
@@ -693,55 +693,17 @@ def _get_existing_label_type(samples, backend, label_field, field_type):
 
     fo_label_type = field_type.document_type
 
-    if issubclass(fo_label_type, (fol.Detection, fol.Detections)):
-        # Must check for detections vs instances
-        _, label_path = samples._get_label_field_path(label_field)
-        _, mask_path = samples._get_label_field_path(label_field, "mask")
+    if issubclass(fo_label_type, fol.Detection):
+        return ["detection", "instance"]
 
-        num_labels, num_masks = samples.aggregate(
-            [foag.Count(label_path), foag.Count(mask_path)]
-        )
+    if issubclass(fo_label_type, fol.Detections):
+        return ["detections", "instances"]
 
-        label_types = []
+    if issubclass(fo_label_type, fol.Polyline):
+        return ["polygon", "polyline"]
 
-        if num_labels == 0 or num_labels > num_masks:
-            label_types.append(
-                "detection"
-                if issubclass(fo_label_type, fol.Detection)
-                else "detections"
-            )
-
-        if num_masks > 0:
-            label_types.append(
-                "instance"
-                if issubclass(fo_label_type, fol.Detection)
-                else "instances"
-            )
-
-        return _unwrap(label_types)
-
-    if issubclass(fo_label_type, (fol.Polyline, fol.Polylines)):
-        # Must check for polylines vs polygons
-        _, path = samples._get_label_field_path(label_field, "filled")
-        counts = samples.count_values(path)
-
-        label_types = []
-
-        if counts.get(True, 0) > 0:
-            label_types.append(
-                "polygon"
-                if issubclass(fo_label_type, fol.Polyline)
-                else "polygons"
-            )
-
-        if counts.get(False, 0) > 0:
-            label_types.append(
-                "polyline"
-                if issubclass(fo_label_type, fol.Detection)
-                else "polylines"
-            )
-
-        return _unwrap(label_types)
+    if issubclass(fo_label_type, fol.Polylines):
+        return ["polygons", "polylines"]
 
     if issubclass(fo_label_type, fol.Classification):
         return "classification"


### PR DESCRIPTION
When annotating an existing label field, there is logic in place to automatically detect the type of the label field being annotated. Some label fields can be associated with multiple annotation label types (detections can be bounding boxes or segmentation instances, polylines can be polylines or polygons). 

There is a bug when annotating an existing label field but all samples in the view have `None` values for the field. This PR resolves this bug by simplifying the logic to detect existing label types.

## Example

```python
import fiftyone as fo
import fiftyone.zoo as foz

d1 = foz.load_zoo_dataset("quickstart", max_samples=4).clone()
dataset = d1[:3].clone()

anno_key="anno_key"
dataset.annotate(
    anno_key, 
    label_field="segs", 
    label_type="polylines",
    classes=["a", "b"], 
    launch_editor=True,
)

# Annotate a polygon in CVAT

dataset.load_annotations(anno_key)

dataset.add_sample(fo.Sample(filepath=d1.last().filepath))
view = dataset.exists("segs", False)

anno_key2 = "anno_key2"
view.annotate(
    anno_key2, 
    label_field="segs", 
    label_type="polylines",
    classes=["a", "b"], 
    launch_editor=True,
)

# ERROR
```