### PR TITLE
Adding support for populating query distances when sorting by similarity 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -119,8 +119,8 @@ jobs:
       - name: Install fiftyone
         run: |
           pip install -r requirements/extras.txt
-          pip install --pre --extra-index-url https://test.pypi.org/simple/ fiftyone-brain voxel51-eta
           pip install -e .
+          pip install --pre --extra-index-url https://test.pypi.org/simple/ fiftyone-brain voxel51-eta
       - name: Install ETA from source
         if: ${{ !startsWith(github.ref, 'refs/heads/rel') && !startsWith(github.ref, 'refs/tags/') }}
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -120,7 +120,7 @@ jobs:
         run: |
           pip install -r requirements/extras.txt
           pip install -e .
-          pip install --pre --extra-index-url https://test.pypi.org/simple/ fiftyone-brain voxel51-eta
+          pip install --update --pre --extra-index-url https://test.pypi.org/simple/ fiftyone-brain voxel51-eta
       - name: Install ETA from source
         if: ${{ !startsWith(github.ref, 'refs/heads/rel') && !startsWith(github.ref, 'refs/tags/') }}
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -120,7 +120,7 @@ jobs:
         run: |
           pip install -r requirements/extras.txt
           pip install -e .
-          pip install --update --pre --extra-index-url https://test.pypi.org/simple/ fiftyone-brain voxel51-eta
+          pip install -U --pre --extra-index-url https://test.pypi.org/simple/ fiftyone-brain voxel51-eta
       - name: Install ETA from source
         if: ${{ !startsWith(github.ref, 'refs/heads/rel') && !startsWith(github.ref, 'refs/tags/') }}
         run: |

--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -4558,7 +4558,7 @@ class SampleCollection(object):
 
     @view_stage
     def sort_by_similarity(
-        self, query_ids, k=None, reverse=False, brain_key=None
+        self, query_ids, k=None, reverse=False, dist_field=None, brain_key=None
     ):
         """Sorts the samples in the collection by visual similiarity to a
         specified set of query ID(s).
@@ -4591,6 +4591,9 @@ class SampleCollection(object):
             k (None): the number of matches to return. By default, the entire
                 collection is sorted
             reverse (False): whether to sort by least similarity
+            dist_field (None): the name of a float field in which to store the
+                distance of each example to the specified query. The field is
+                created if necessary
             brain_key (None): the brain key of an existing
                 :meth:`fiftyone.brain.compute_similarity` run on the dataset.
                 If not specified, the dataset must have an applicable run,
@@ -4601,7 +4604,11 @@ class SampleCollection(object):
         """
         return self._add_view_stage(
             fos.SortBySimilarity(
-                query_ids, k=k, reverse=reverse, brain_key=brain_key
+                query_ids,
+                k=k,
+                reverse=reverse,
+                dist_field=dist_field,
+                brain_key=brain_key,
             )
         )
 

--- a/fiftyone/core/stages.py
+++ b/fiftyone/core/stages.py
@@ -5197,6 +5197,9 @@ class SortBySimilarity(ViewStage):
         k (None): the number of matches to return. By default, the entire
             collection is sorted
         reverse (False): whether to sort by least similarity
+        dist_field (None): the name of a float field in which to store the
+            distance of each example to the specified query. The field is
+            created if necessary
         brain_key (None): the brain key of an existing
             :meth:`fiftyone.brain.compute_similarity` run on the dataset. If
             not specified, the dataset must have an applicable run, which will
@@ -5204,7 +5207,13 @@ class SortBySimilarity(ViewStage):
     """
 
     def __init__(
-        self, query_ids, k=None, reverse=False, brain_key=None, _state=None
+        self,
+        query_ids,
+        k=None,
+        reverse=False,
+        dist_field=None,
+        brain_key=None,
+        _state=None,
     ):
         if etau.is_str(query_ids):
             query_ids = [query_ids]
@@ -5214,6 +5223,7 @@ class SortBySimilarity(ViewStage):
         self._query_ids = query_ids
         self._k = k
         self._reverse = reverse
+        self._dist_field = dist_field
         self._brain_key = brain_key
         self._state = _state
         self._pipeline = None
@@ -5232,6 +5242,11 @@ class SortBySimilarity(ViewStage):
     def reverse(self):
         """Whether to sort by least similiarity."""
         return self._reverse
+
+    @property
+    def dist_field(self):
+        """The field to store similarity distances, if any."""
+        return self._dist_field
 
     @property
     def brain_key(self):
@@ -5254,6 +5269,7 @@ class SortBySimilarity(ViewStage):
             ["query_ids", self._query_ids],
             ["k", self._k],
             ["reverse", self._reverse],
+            ["dist_field", self._dist_field],
             ["brain_key", self._brain_key],
             ["_state", self._state],
         ]
@@ -5279,6 +5295,12 @@ class SortBySimilarity(ViewStage):
                 "placeholder": "reverse (default=False)",
             },
             {
+                "name": "dist_field",
+                "type": "field|str",
+                "default": "None",
+                "placeholder": "dist_field (default=None)",
+            },
+            {
                 "name": "brain_key",
                 "type": "NoneType|str",
                 "default": "None",
@@ -5294,6 +5316,7 @@ class SortBySimilarity(ViewStage):
             "query_ids": self._query_ids,
             "k": self._k,
             "reverse": self._reverse,
+            "dist_field": self._dist_field,
             "brain_key": self._brain_key,
         }
 
@@ -5325,7 +5348,11 @@ class SortBySimilarity(ViewStage):
                 context.enter_context(results)  # pylint: disable=no-member
 
             return results.sort_by_similarity(
-                self._query_ids, k=self._k, reverse=self._reverse, _mongo=True
+                self._query_ids,
+                k=self._k,
+                reverse=self._reverse,
+                dist_field=self._dist_field,
+                _mongo=True,
             )
 
 

--- a/fiftyone/core/stages.py
+++ b/fiftyone/core/stages.py
@@ -5296,7 +5296,7 @@ class SortBySimilarity(ViewStage):
             },
             {
                 "name": "dist_field",
-                "type": "field|str",
+                "type": "NoneType|field|str",
                 "default": "None",
                 "placeholder": "dist_field (default=None)",
             },

--- a/tests/unittests/import_export_tests.py
+++ b/tests/unittests/import_export_tests.py
@@ -1164,6 +1164,7 @@ class ImageDetectionDatasetTests(ImageDatasetTests):
         )
         self.assertEqual(len(dataset), len(dataset.exists("yolo_inclusive")))
 
+    @skipwindows
     @drop_datasets
     def test_add_coco_labels(self):
         dataset = self._make_dataset()


### PR DESCRIPTION
Resolves https://github.com/voxel51/fiftyone/issues/1545.

Adds an optional `dist_field` parameter that can specify the name of a (new or existing) float field in which to store query distances when [sorting by similarity](https://voxel51.com/docs/fiftyone/user_guide/using_views.html#visual-similarity):

```py
import fiftyone as fo
import fiftyone.brain as fob
import fiftyone.zoo as foz

dataset = foz.load_zoo_dataset("quickstart")
fob.compute_similarity(dataset, brain_key="img_sim")

view = dataset.sort_by_similarity(dataset.shuffle().first().id, dist_field="dist")

session = fo.launch_app(view)
```

This feature can be used when [sorting by similarity in the App](https://voxel51.com/docs/fiftyone/user_guide/app.html#sorting-by-visual-similarity), but currently the `dist_field` must be added in the view bar after initially creating the view:

![sim-opt](https://user-images.githubusercontent.com/25985824/150240227-361aa2ff-1c84-4a9a-a582-bfa76111f9ac.gif)
