### PR TITLE
optionally treat missing labels as empty detections when adding yolo labels

### DIFF
--- a/docs/source/user_guide/dataset_creation/datasets.rst
+++ b/docs/source/user_guide/dataset_creation/datasets.rst
@@ -2166,6 +2166,7 @@ images-and-labels and labels-only data in YOLO format:
         "predictions",
         "/tmp/yolov4/predictions",
         classes=classes,
+        include_missing=False, # or set include_missing=True to treat missing labels as empty detections
     )
 
     # Verify that ground truth and predictions were imported as expected
@@ -2341,6 +2342,7 @@ images-and-labels and labels-only data in YOLO format:
         "predictions",
         "/tmp/yolov5/predictions/validation",
         classes=classes,
+        include_missing=False, # or set include_missing=True to treat missing labels as empty detections
     )
 
     # Verify that ground truth and predictions were imported as expected

--- a/docs/source/user_guide/dataset_creation/index.rst
+++ b/docs/source/user_guide/dataset_creation/index.rst
@@ -457,6 +457,7 @@ predictions to take advantage of FiftyOne's
             "predictions",
             "/tmp/yolov4/predictions",
             classes=classes,
+            include_missing=False, # or set include_missing=True to treat missing labels as empty detections
         )
 
         # Verify that ground truth and predictions were imported as expected

--- a/tests/unittests/import_export_tests.py
+++ b/tests/unittests/import_export_tests.py
@@ -18,9 +18,10 @@ import eta.core.utils as etau
 import eta.core.video as etav
 
 import fiftyone as fo
+from fiftyone.utils.coco import add_coco_labels
+from fiftyone.utils.yolo import add_yolo_labels
 
 from decorators import drop_datasets
-
 
 skipwindows = pytest.mark.skipif(
     os.name == "nt", reason="Windows hangs in workflows, fix me"
@@ -1124,6 +1125,51 @@ class ImageDetectionDatasetTests(ImageDatasetTests):
         bounds2 = dataset2.bounds("predictions.detections.confidence")
         self.assertAlmostEqual(bounds[0], bounds2[0])
         self.assertAlmostEqual(bounds[1], bounds2[1])
+
+    @drop_datasets
+    def test_add_labels_to_dataset(self):
+
+        dataset = self._make_dataset()
+        classes = dataset.distinct('predictions.detections.label')
+
+        ## YOLO
+
+        export_dir = self._new_dir()
+        dataset.export(
+            export_dir=export_dir,
+            dataset_type=fo.types.YOLOv5Dataset,
+        )
+        yolo_labels_path = os.path.join(export_dir, 'labels', 'val')
+
+        # standard
+
+        add_yolo_labels(dataset, 'yolo', labels_path=yolo_labels_path, classes=classes)
+        self.assertEqual(dataset.count_values('predictions.detections.label'),
+                         dataset.count_values('yolo.detections.label'))
+        self.assertEqual(1, len(dataset) - len(dataset.exists('yolo')))
+
+        # include missing
+
+        add_yolo_labels(dataset, 'yolo_inclusive', labels_path=yolo_labels_path, classes=classes,
+                        include_missing=True)
+        self.assertEqual(dataset.count_values('predictions.detections.label'),
+                         dataset.count_values('yolo_inclusive.detections.label'))
+        self.assertEqual(len(dataset), len(dataset.exists('yolo_inclusive')))
+
+        ## COCO
+
+        export_dir = self._new_dir()
+        dataset.export(
+            export_dir=export_dir, dataset_type=fo.types.COCODetectionDataset,
+        )
+        coco_labels_path = os.path.join(export_dir, 'labels.json')
+
+        # standard
+
+        add_coco_labels(dataset, 'coco', coco_labels_path, classes=classes)
+        self.assertEqual(dataset.count_values('predictions.detections.label'),
+                         dataset.count_values('coco.detections.label'))
+        self.assertEqual(len(dataset), len(dataset.exists('coco')))
 
 
 class ImageSegmentationDatasetTests(ImageDatasetTests):


### PR DESCRIPTION
## What changes are proposed in this pull request?

When adding yolo labels, a user can set missing predictions to empty detections `fo.Detections(detections=[]`.
[Issue](https://github.com/voxel51/fiftyone/issues/1543)

```
fouy.add_yolo_labels(
    dataset2,
    "predictions",
    "/tmp/yolov4/predictions",
    classes=classes,
    include_missing=False, # or set include_missing=True to treat missing labels as empty detections
)
```

## How is this patch tested? If it is not, please explain why.

Added a new unit-test for both `add_yolo_labels` and `add_coco_labels`.

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.


### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [x] Documentation: FiftyOne documentation changes
-   [ ] Other
