### PR TITLE
Label conversion utility improvements

### DIFF
--- a/fiftyone/core/labels.py
+++ b/fiftyone/core/labels.py
@@ -1238,9 +1238,9 @@ def _render_polyline(mask, polyline, target, thickness):
 
     if polyline.filled:
         # pylint: disable=no-member
-        mask = cv2.fillPoly(mask, points, target)
+        cv2.fillPoly(mask, points, target)
     else:
-        mask = cv2.polylines(  # pylint: disable=no-member
+        cv2.polylines(  # pylint: disable=no-member
             mask, points, polyline.closed, target, thickness=thickness
         )
 

--- a/fiftyone/core/labels.py
+++ b/fiftyone/core/labels.py
@@ -418,11 +418,23 @@ class Detection(_HasID, _HasAttributesDict, Label):
         Returns:
             a :class:`Polyline`
         """
-        dobj = foue.to_detected_object(self)
+        dobj = foue.to_detected_object(self, extra_attrs=False)
         polyline = etai.convert_object_to_polygon(
             dobj, tolerance=tolerance, filled=filled
         )
-        return foue.from_polyline(polyline)
+
+        attributes = dict(self.iter_attributes())
+
+        return Polyline(
+            label=self.label,
+            points=polyline.points,
+            confidence=self.confidence,
+            index=self.index,
+            closed=polyline.closed,
+            filled=polyline.filled,
+            tags=self.tags,
+            **attributes,
+        )
 
     def to_segmentation(self, mask=None, frame_size=None, target=255):
         """Returns a :class:`Segmentation` representation of this instance.
@@ -623,7 +635,7 @@ class Polyline(_HasID, _HasAttributesDict, Label):
         Returns:
             a :class:`Detection`
         """
-        polyline = foue.to_polyline(self)
+        polyline = foue.to_polyline(self, extra_attrs=False)
         if mask_size is not None:
             bbox, mask = etai.render_bounding_box_and_mask(polyline, mask_size)
         else:
@@ -1207,7 +1219,7 @@ def _parse_to_segmentation_inputs(mask, frame_size, mask_targets):
 
 
 def _render_instance(mask, detection, target):
-    dobj = foue.to_detected_object(detection)
+    dobj = foue.to_detected_object(detection, extra_attrs=False)
     obj_mask, offset = etai.render_instance_mask(
         dobj.mask, dobj.bounding_box, img=mask
     )
@@ -1221,7 +1233,7 @@ def _render_instance(mask, detection, target):
 
 
 def _render_polyline(mask, polyline, target, thickness):
-    points = foue.to_polyline(polyline).coords_in(img=mask)
+    points = foue.to_polyline(polyline, extra_attrs=False).coords_in(img=mask)
     points = [np.array(shape, dtype=np.int32) for shape in points]
 
     if polyline.filled:

--- a/fiftyone/utils/coco.py
+++ b/fiftyone/utils/coco.py
@@ -2138,7 +2138,7 @@ def _polyline_to_coco_segmentation(polyline, frame_size, iscrowd="iscrowd"):
 def _instance_to_coco_segmentation(
     detection, frame_size, iscrowd="iscrowd", tolerance=None
 ):
-    dobj = foue.to_detected_object(detection)
+    dobj = foue.to_detected_object(detection, extra_attrs=False)
 
     try:
         mask = etai.render_instance_image(

--- a/fiftyone/utils/labels.py
+++ b/fiftyone/utils/labels.py
@@ -31,7 +31,7 @@ def objects_to_segmentations(
             :class:`fiftyone.core.labels.Polylines`
         out_field: the name of the :class:`fiftyone.core.labels.Segmentation`
             field to populate
-        frame_size (None): the ``(width, height)`` at which to render the
+        mask_size (None): the ``(width, height)`` at which to render the
             segmentation masks. If not provided, masks will be rendered to
             match the resolution of each input image
         mask_targets (None): a dict mapping integer pixel values in
@@ -41,7 +41,6 @@ def objects_to_segmentations(
         thickness (1): the thickness, in pixels, at which to render
             (non-filled) polylines
     """
-    fov.validate_image_collection(sample_collection)
     fov.validate_collection_label_fields(
         sample_collection,
         in_field,
@@ -52,40 +51,53 @@ def objects_to_segmentations(
         sample_collection.compute_metadata()
 
     samples = sample_collection.select_fields(in_field)
+    in_field, processing_frames = samples._handle_frame_field(in_field)
+    out_field, _ = samples._handle_frame_field(out_field)
 
     for sample in samples.iter_samples(progress=True):
+        if processing_frames:
+            images = sample.frames.values()
+        else:
+            images = [sample]
+
         if mask_size is not None:
             frame_size = mask_size
+        elif processing_frames:
+            frame_size = (
+                sample.metadata.frame_width,
+                sample.metadata.frame_height,
+            )
         else:
             frame_size = (sample.metadata.width, sample.metadata.height)
 
-        label = sample[in_field]
-        if label is None:
-            continue
+        for image in images:
+            label = image[in_field]
+            if label is None:
+                continue
 
-        segmentation = None
+            segmentation = None
 
-        if isinstance(label, fol.Polyline):
-            label = fol.Polylines(polylines=[label])
+            if isinstance(label, fol.Polyline):
+                label = fol.Polylines(polylines=[label])
 
-        if isinstance(label, fol.Detection):
-            label = fol.Detections(detections=[label])
+            if isinstance(label, fol.Detection):
+                label = fol.Detections(detections=[label])
 
-        if isinstance(label, fol.Polylines):
-            segmentation = label.to_segmentation(
-                frame_size=frame_size,
-                mask_targets=mask_targets,
-                thickness=thickness,
-            )
+            if isinstance(label, fol.Polylines):
+                segmentation = label.to_segmentation(
+                    frame_size=frame_size,
+                    mask_targets=mask_targets,
+                    thickness=thickness,
+                )
 
-        if isinstance(label, fol.Detections):
-            segmentation = label.to_segmentation(
-                frame_size=frame_size, mask_targets=mask_targets,
-            )
+            if isinstance(label, fol.Detections):
+                segmentation = label.to_segmentation(
+                    frame_size=frame_size, mask_targets=mask_targets,
+                )
 
-        if segmentation is not None:
-            sample[out_field] = segmentation
-            sample.save()
+            image[out_field] = segmentation
+
+        sample.save()
 
     if mask_targets is not None:
         if not sample_collection.default_mask_targets:
@@ -134,7 +146,6 @@ def segmentations_to_detections(
             -   a dict mapping pixel values to ``"stuff"`` or ``"thing"``
                 for each class
     """
-    fov.validate_image_collection(sample_collection)
     fov.validate_collection_label_fields(
         sample_collection, in_field, fol.Segmentation,
     )
@@ -146,20 +157,29 @@ def segmentations_to_detections(
             mask_targets = sample_collection.default_mask_targets
 
     samples = sample_collection.select_fields(in_field)
+    in_field, processing_frames = samples._handle_frame_field(in_field)
+    out_field, _ = samples._handle_frame_field(out_field)
 
     for sample in samples.iter_samples(progress=True):
-        label = sample[in_field]
-        if label is None:
-            continue
+        if processing_frames:
+            images = sample.frames.values()
+        else:
+            images = [sample]
 
-        sample[out_field] = label.to_detections(
-            mask_targets=mask_targets, mask_types=mask_types
-        )
+        for image in images:
+            label = image[in_field]
+            if label is None:
+                continue
+
+            image[out_field] = label.to_detections(
+                mask_targets=mask_targets, mask_types=mask_types
+            )
+
         sample.save()
 
 
 def instances_to_polylines(
-    sample_collection, in_field, out_field, tolerance=2
+    sample_collection, in_field, out_field, tolerance=2, filled=True
 ):
     """Converts the instance segmentations in the specified field of the
     collection into :class:`fiftyone.core.labels.Polylines` instances.
@@ -176,21 +196,32 @@ def instances_to_polylines(
         out_field: the name of the :class:`fiftyone.core.labels.Polylines`
             field to populate
         tolerance (2): a tolerance, in pixels, when generating approximate
-                polylines for each region. Typical values are 1-3 pixels
+            polylines for each region. Typical values are 1-3 pixels
+        filled (True): whether the polylines should be filled
     """
-    fov.validate_image_collection(sample_collection)
     fov.validate_collection_label_fields(
         sample_collection, in_field, fol.Detections,
     )
 
     samples = sample_collection.select_fields(in_field)
+    in_field, processing_frames = samples._handle_frame_field(in_field)
+    out_field, _ = samples._handle_frame_field(out_field)
 
     for sample in samples.iter_samples(progress=True):
-        label = sample[in_field]
-        if label is None:
-            continue
+        if processing_frames:
+            images = sample.frames.values()
+        else:
+            images = [sample]
 
-        sample[out_field] = label.to_polylines(tolerance=tolerance)
+        for image in images:
+            label = image[in_field]
+            if label is None:
+                continue
+
+            image[out_field] = label.to_polylines(
+                tolerance=tolerance, filled=filled
+            )
+
         sample.save()
 
 
@@ -236,7 +267,6 @@ def segmentations_to_polylines(
         tolerance (2): a tolerance, in pixels, when generating approximate
                 polylines for each region. Typical values are 1-3 pixels
     """
-    fov.validate_image_collection(sample_collection)
     fov.validate_collection_label_fields(
         sample_collection, in_field, fol.Segmentation,
     )
@@ -248,17 +278,26 @@ def segmentations_to_polylines(
             mask_targets = sample_collection.default_mask_targets
 
     samples = sample_collection.select_fields(in_field)
+    in_field, processing_frames = samples._handle_frame_field(in_field)
+    out_field, _ = samples._handle_frame_field(out_field)
 
     for sample in samples.iter_samples(progress=True):
-        label = sample[in_field]
-        if label is None:
-            continue
+        if processing_frames:
+            images = sample.frames.values()
+        else:
+            images = [sample]
 
-        sample[out_field] = label.to_polylines(
-            mask_targets=mask_targets,
-            mask_types=mask_types,
-            tolerance=tolerance,
-        )
+        for image in images:
+            label = image[in_field]
+            if label is None:
+                continue
+
+            image[out_field] = label.to_polylines(
+                mask_targets=mask_targets,
+                mask_types=mask_types,
+                tolerance=tolerance,
+            )
+
         sample.save()
 
 
@@ -275,22 +314,30 @@ def classification_to_detections(sample_collection, in_field, out_field):
         out_field: the name of the :class:`fiftyone.core.labels.Detections`
             field to populate
     """
-    fov.validate_image_collection(sample_collection)
     fov.validate_collection_label_fields(
         sample_collection, in_field, fol.Classification
     )
 
     samples = sample_collection.select_fields(in_field)
+    in_field, processing_frames = samples._handle_frame_field(in_field)
+    out_field, _ = samples._handle_frame_field(out_field)
 
     for sample in samples.iter_samples(progress=True):
-        label = sample[in_field]
-        if label is None:
-            continue
+        if processing_frames:
+            images = sample.frames.values()
+        else:
+            images = [sample]
 
-        detection = fol.Detection(
-            label=label.label,
-            bounding_box=[0, 0, 1, 1],  # entire image
-            confidence=label.confidence,
-        )
-        sample[out_field] = fol.Detections(detections=[detection])
+        for image in images:
+            label = image[in_field]
+            if label is None:
+                continue
+
+            detection = fol.Detection(
+                label=label.label,
+                bounding_box=[0, 0, 1, 1],  # entire image
+                confidence=label.confidence,
+            )
+            image[out_field] = fol.Detections(detections=[detection])
+
         sample.save()

--- a/fiftyone/utils/patches.py
+++ b/fiftyone/utils/patches.py
@@ -154,7 +154,7 @@ def extract_patch(img, detection, force_square=False, alpha=None):
     Returns:
         the image patch
     """
-    dobj = foue.to_detected_object(detection)
+    dobj = foue.to_detected_object(detection, extra_attrs=False)
 
     bbox = dobj.bounding_box
     if alpha is not None:


### PR DESCRIPTION
Uses https://github.com/voxel51/eta/pull/545.

Change log:
- Adds a new `fiftyone.utils.labels.instances_to_polylines()` method that can convert instance segmentations (or just bboxes) to `Polylines` format
- Adds support for frame labels to all conversion methods in the `fiftyone.utils.labels` module
- Updates the implementation of `Detection.to_polyline()` so that all attributes are included rather than just ETA-supported ones

## Image example

```py
import fiftyone as fo
import fiftyone.zoo as foz
import fiftyone.utils.labels as foul

dataset = foz.load_zoo_dataset(
    "coco-2017",
    split="validation",
    label_types=["segmentations"],
    max_samples=100,
    shuffle=True,
)

classes = dataset.distinct("ground_truth.detections.label")
mask_targets = {idx: label for idx, label in enumerate(classes, 1)}

foul.objects_to_segmentations(
    dataset,
    "ground_truth",
    "segmentations",
    mask_targets=mask_targets,
)

foul.instances_to_polylines(dataset, "ground_truth", "polylines")

session = fo.launch_app(dataset)
```

## Video example

```py
import fiftyone as fo
import fiftyone.zoo as foz
import fiftyone.utils.labels as foul

dataset = foz.load_zoo_dataset("quickstart-video")

classes = dataset.distinct("frames.detections.detections.label")
mask_targets = {idx: label for idx, label in enumerate(classes, 1)}

foul.instances_to_polylines(
    dataset, "frames.detections", "frames.polylines", filled=True
)

foul.objects_to_segmentations(
    dataset,
    "frames.polylines",
    "frames.segmentations",
    mask_targets=mask_targets,
)

session = fo.launch_app(dataset)
```
