### PR TITLE
View save

### DIFF
--- a/docs/source/user_guide/using_views.rst
+++ b/docs/source/user_guide/using_views.rst
@@ -713,10 +713,11 @@ in the sense that:
     by iterating over the contents of the view or calling
     :meth:`set_values() <fiftyone.core.collections.SampleCollection.set_values>`
     will be reflected on the source dataset
--   Calling :meth:`save() <fiftyone.core.patches.PatchesView.save>` on an
-    object patches view (typically one that contains additional view stages
-    that filter or modify its contents) will sync any |Label| edits or
-    deletions with the source dataset
+-   Calling :meth:`save() <fiftyone.core.patches.PatchesView.save>` or
+    :meth:`keep() <fiftyone.core.patches.PatchesView.keep>` on an object
+    patches view (typically one that contains additional view stages that
+    filter or modify its contents) will sync any |Label| edits or deletions
+    with the source dataset
 
 However, because object patches views only contain a subset of the contents of
 a |Sample| from the source dataset, there are some differences compared to
@@ -826,8 +827,9 @@ Evaluation patches views are just like any other
     :meth:`set_values() <fiftyone.core.collections.SampleCollection.set_values>`
     will be reflected on the source dataset
 -   Calling :meth:`save() <fiftyone.core.patches.EvaluationPatchesView.save>`
-    on an evaluation patches view (typically one that contains additional view
-    stages that filter or modify its contents) will sync any |Label| edits or
+    or :meth:`keep() <fiftyone.core.patches.EvaluationPatchesView.keep>` on an
+    evaluation patches view (typically one that contains additional view stages
+    that filter or modify its contents) will sync any |Label| edits or
     deletions with the source dataset
 
 However, because evaluation patches views only contain a subset of the contents
@@ -1120,7 +1122,8 @@ sense that:
     by iterating over the contents of the view or calling
     :meth:`set_values() <fiftyone.core.collections.SampleCollection.set_values>`
     will be reflected on the source dataset
--   Calling :meth:`save() <fiftyone.core.clips.ClipsView.save>` on a clips view
+-   Calling :meth:`save() <fiftyone.core.clips.ClipsView.save>` or
+    :meth:`keep() <fiftyone.core.clips.ClipsView.keep>` on a clips view
     (typically one that contains additional view stages that filter or modify
     its contents) will sync any frame-level edits or deletions with the source
     dataset
@@ -1257,10 +1260,11 @@ Frame views are just like any other image collection view in the sense that:
     contents of the view or calling
     :meth:`set_values() <fiftyone.core.collections.SampleCollection.set_values>`
     will be reflected on the source dataset
--   Calling :meth:`save() <fiftyone.core.video.FramesView.save>` on a frames
-    view (typically one that contains additional view stages that filter or
-    modify its contents) will sync any changes to the frames of the underlying
-    video  dataset
+-   Calling :meth:`save() <fiftyone.core.video.FramesView.save>` or
+    :meth:`keep() <fiftyone.core.video.FramesView.keep>` on a frames view
+    (typically one that contains additional view stages that filter or modify
+    its contents) will sync any changes to the frames of the underlying video
+    dataset
 
 The only way in which frames views differ from regular image collections is
 that changes to the ``tags`` or ``metadata`` fields of frame samples will not
@@ -1796,8 +1800,8 @@ __________________
 
 Ordinarily, when you define a |DatasetView| that extracts a specific subset of
 a dataset and its fields, the underlying |Dataset| is not modified. However,
-you can use :meth:`save() <fiftyone.core.view.DatasetView.save>` to overwrite
-the underlying dataset with the contents of a view you've created:
+you can use :meth:`save() <fiftyone.core.view.DatasetView.save>` to save the
+contents of a view you've created to the underlying dataset:
 
 .. code-block:: python
     :linenos:
@@ -1808,16 +1812,45 @@ the underlying dataset with the contents of a view you've created:
 
     dataset = foz.load_zoo_dataset("quickstart")
 
+    # Capitalize some labels
+    rename_view = dataset.map_labels("predictions", {"cat": "CAT", "dog": "DOG"})
+    rename_view.save()
+
+    print(dataset.count_values("predictions.detections.label"))
+    # {'CAT': 35, 'DOG': 49, ...}
+
     # Discard all predictions with confidence below 0.3
-    high_conf_view = dataset.filter_labels("predictions", F("confidence") > 0.3)
+    high_conf_view = dataset.filter_labels(
+        "predictions", F("confidence") > 0.3, only_matches=False
+    )
     high_conf_view.save()
 
     print(dataset.bounds("predictions.detections.confidence"))
     # (0.3001, 0.9999)
 
-Alternatively, you can create a new |Dataset| that contains only the contents
-of a |DatasetView| using
-:meth:`clone() <fiftyone.core.view.DatasetView.clone>`:
+Note that calling :meth:`save() <fiftyone.core.view.DatasetView.save>` on a
+|DatasetView| will only save modifications to samples that are in the view; all
+other samples are left unchanged.
+
+You can use :meth:`keep() <fiftyone.core.view.DatasetView.keep>` to delete
+samples from the underlying dataset that do not appear in a view you created:
+
+.. code-block:: python
+    :linenos:
+
+    print(len(dataset))
+    # 200
+
+    # Discard all samples with no people
+    people_view = dataset.filter_labels("ground_truth", F("label") == "person")
+    people_view.keep()
+
+    print(len(dataset))
+    # 94
+
+Alternatively, you can use
+:meth:`clone() <fiftyone.core.view.DatasetView.clone>` to create a new
+|Dataset| that contains only the contents of a |DatasetView|:
 
 .. code-block:: python
     :linenos:

--- a/fiftyone/core/clips.py
+++ b/fiftyone/core/clips.py
@@ -180,12 +180,18 @@ class ClipsView(fov.DatasetView):
         self._sync_source(fields=[field], ids=ids)
 
     def save(self, fields=None):
-        """Saves the clips in this view to the underlying source dataset.
+        """Saves the clips in this view to the underlying dataset.
+
+        .. note::
+
+            This method is not a :class:`fiftyone.core.stages.ViewStage`;
+            it immediately writes the requested changes to the underlying
+            dataset.
 
         .. warning::
 
             This will permanently delete any omitted or filtered contents from
-            the source dataset.
+            the frames of the underlying dataset.
 
         Args:
             fields (None): an optional field or list of fields to save. If
@@ -199,12 +205,13 @@ class ClipsView(fov.DatasetView):
         super().save(fields=fields)
 
     def keep(self):
-        """Removes all clips that are **not** in this view from the underlying
-        source dataset.
+        """Deletes all clips that are **not** in this view from the underlying
+        dataset.
 
-        .. warning::
+        .. note::
 
-            This will permanently delete any omitted clips from the source
+            This method is not a :class:`fiftyone.core.stages.ViewStage`;
+            it immediately writes the requested changes to the underlying
             dataset.
 
         Args:

--- a/fiftyone/core/clips.py
+++ b/fiftyone/core/clips.py
@@ -180,8 +180,7 @@ class ClipsView(fov.DatasetView):
         self._sync_source(fields=[field], ids=ids)
 
     def save(self, fields=None):
-        """Overwrites the frames in the source dataset with the contents of the
-        view.
+        """Saves the clips in this view to the underlying source dataset.
 
         .. warning::
 
@@ -195,9 +194,26 @@ class ClipsView(fov.DatasetView):
         if etau.is_str(fields):
             fields = [fields]
 
-        self._sync_source(fields=fields, delete=True)
+        self._sync_source(fields=fields)
 
         super().save(fields=fields)
+
+    def keep(self):
+        """Removes all clips that are **not** in this view from the underlying
+        source dataset.
+
+        .. warning::
+
+            This will permanently delete any omitted clips from the source
+            dataset.
+
+        Args:
+            fields (None): an optional field or list of fields to save. If
+                specified, only these fields are overwritten
+        """
+        self._sync_source(update=False, delete=True)
+
+        super().keep()
 
     def reload(self):
         """Reloads this view from the source collection in the database.
@@ -237,7 +253,7 @@ class ClipsView(fov.DatasetView):
 
         self._source_collection._set_labels(field, [sample.sample_id], [doc])
 
-    def _sync_source(self, fields=None, ids=None, delete=False):
+    def _sync_source(self, fields=None, ids=None, update=True, delete=False):
         if not self._classification_field:
             return
 
@@ -280,7 +296,8 @@ class ClipsView(fov.DatasetView):
             # label to be deleted came from
             self._source_collection._delete_labels(del_ids, fields=[field])
 
-        self._source_collection._set_labels(field, update_ids, update_docs)
+        if update:
+            self._source_collection._set_labels(field, update_ids, update_docs)
 
 
 def make_clips_dataset(

--- a/fiftyone/core/clips.py
+++ b/fiftyone/core/clips.py
@@ -276,9 +276,9 @@ class ClipsView(fov.DatasetView):
         else:
             sync_view = self
 
-        del_ids = set()
         update_ids = []
         update_docs = []
+        del_ids = set()
         for label_id, sample_id, support, doc in zip(
             *sync_view.values(["id", "sample_id", "support", field], _raw=True)
         ):
@@ -298,13 +298,13 @@ class ClipsView(fov.DatasetView):
                 if sample_id not in observed_ids:
                     del_ids.add(label_id)
 
+        if update:
+            self._source_collection._set_labels(field, update_ids, update_docs)
+
         if del_ids:
             # @todo can we optimize this? we know exactly which samples each
             # label to be deleted came from
             self._source_collection._delete_labels(del_ids, fields=[field])
-
-        if update:
-            self._source_collection._set_labels(field, update_ids, update_docs)
 
 
 def make_clips_dataset(

--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -2151,10 +2151,14 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
         if self.media_type != fom.VIDEO:
             return
 
-        # Clips datasets directly use their source dataset's frame collection,
-        # so don't delete frames
         if self._is_clips:
-            return
+            if sample_ids is not None:
+                view = self.select(sample_ids)
+            elif frame_ids is None and view is None:
+                view = self
+
+            if view is not None:
+                frame_ids = view.values("frames.id", unwind=True)
 
         if frame_ids is not None:
             self._frame_collection.delete_many(
@@ -2183,10 +2187,12 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
         if self.media_type != fom.VIDEO:
             return
 
-        # Clips datasets directly use their source dataset's frame collection,
-        # so don't delete frames
         if self._is_clips:
-            return
+            if frame_ids is None and view is None:
+                view = self
+
+            if view is not None:
+                frame_ids = view.values("frames.id", unwind=True)
 
         if frame_ids is not None:
             self._frame_collection.delete_many(

--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -2130,8 +2130,13 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
 
         self._clear_frames(sample_ids=sample_ids)
 
-    def _keep(self, view):
-        self._clear(view=self.exclude(view))
+    def _keep(self, view=None, sample_ids=None):
+        if view is not None:
+            clear_view = self.exclude(view)
+        else:
+            clear_view = self.exclude(sample_ids)
+
+        self._clear(view=clear_view)
 
     def clear_frames(self):
         """Removes all frame labels from the video dataset.
@@ -2163,9 +2168,18 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
             self._frame_collection_name, sample_ids=sample_ids
         )
 
-    def _keep_frames(self, view):
+    def _keep_frames(self, view=None, frame_ids=None):
         if self.media_type != fom.VIDEO:
             return
+
+        # Clips datasets directly use their source dataset's frame collection,
+        # so don't delete frames
+        if self._is_clips:
+            return
+
+        # @todo implement this
+        if frame_ids is not None:
+            raise NotImplementedError
 
         sample_ids, frame_numbers = view.values(["id", "frames.frame_numbers"])
 

--- a/fiftyone/core/patches.py
+++ b/fiftyone/core/patches.py
@@ -197,10 +197,19 @@ class _PatchesView(fov.DatasetView):
             self._sync_source_field(field, ids=ids)
 
     def save(self, fields=None):
-        """Saves the patches in this view to the underlying source dataset.
+        """Saves the patches in this view to the underlying dataset.
 
         If this view contains any additional fields that were not extracted
-        from the source dataset, these fields are not saved.
+        from the underlying dataset, these fields are not saved.
+
+        This method **does not** delete patches from the underlying dataset
+        that this view excludes.
+
+        .. note::
+
+            This method is not a :class:`fiftyone.core.stages.ViewStage`;
+            it immediately writes the requested changes to the underlying
+            dataset.
 
         Args:
             fields (None): an optional field or list of fields to save. If
@@ -226,13 +235,14 @@ class _PatchesView(fov.DatasetView):
         self._sync_source_root(fields)
 
     def keep(self):
-        """Removes all patches that are **not** in this view from the
-        underlying source dataset.
+        """Deletes all patches that are **not** in this view from the
+        underlying dataset.
 
-        .. warning::
+        .. note::
 
-            This will permanently delete any omitted or filtered patches from
-            the source dataset.
+            This method is not a :class:`fiftyone.core.stages.ViewStage`;
+            it immediately writes the requested changes to the underlying
+            dataset.
         """
         super().keep()
 

--- a/fiftyone/core/patches.py
+++ b/fiftyone/core/patches.py
@@ -197,16 +197,10 @@ class _PatchesView(fov.DatasetView):
             self._sync_source_field(field, ids=ids)
 
     def save(self, fields=None):
-        """Overwrites the object patches in the source dataset with the
-        contents of this view.
+        """Saves the patches in this view to the underlying source dataset.
 
         If this view contains any additional fields that were not extracted
         from the source dataset, these fields are not saved.
-
-        .. warning::
-
-            This will permanently delete any omitted or filtered contents from
-            the source dataset.
 
         Args:
             fields (None): an optional field or list of fields to save. If
@@ -230,6 +224,26 @@ class _PatchesView(fov.DatasetView):
         #
 
         self._sync_source_root(fields)
+
+    def keep(self):
+        """Removes all patches that are **not** in this view from the
+        underlying source dataset.
+
+        .. warning::
+
+            This will permanently delete any omitted or filtered patches from
+            the source dataset.
+        """
+        super().keep()
+
+        #
+        # IMPORTANT: we sync the contents of `_patches_dataset`, not `self`
+        # here because the `save()` call above updated the dataset, which means
+        # this view may no longer have the same contents (e.g., if `skip()` is
+        # involved)
+        #
+
+        self._sync_source_root(self._label_fields)
 
     def reload(self):
         """Reloads this view from the source collection in the database.

--- a/fiftyone/core/singletons.py
+++ b/fiftyone/core/singletons.py
@@ -436,3 +436,34 @@ class FrameSingleton(DocumentSingleton):
 
         for frame_number in reset_fns:
             frames.pop(frame_number)
+
+    def _reset_docs_by_frame_id(cls, collection_name, frame_ids, keep=False):
+        """Resets the backing documents for all in-memory frames with the given
+        frame IDs.
+
+        When ``keep=True``, all frames whose IDs are **not** in ``frame_ids``
+        are reset instead.
+        """
+        if collection_name not in cls._instances:
+            return
+
+        samples = cls._instances[collection_name]
+
+        frame_ids = set(frame_ids)
+        reset = []
+
+        if keep:
+            for sample_id, frames in samples.items():
+                for fn, frame in frames.items():
+                    if frame.id not in frame_ids:
+                        frame._reset_backing_doc()
+                        reset.append((sample_id, fn))
+        else:
+            for sample_id, frames in samples.items():
+                for fn, frame in frames.items():
+                    if frame.id in frame_ids:
+                        frame._reset_backing_doc()
+                        reset.append((sample_id, fn))
+
+        for sample_id, fn in reset:
+            samples[sample_id].pop(fn)

--- a/fiftyone/core/singletons.py
+++ b/fiftyone/core/singletons.py
@@ -412,7 +412,7 @@ class FrameSingleton(DocumentSingleton):
         frame numbers attached to the specified sample.
 
         When ``keep=True``, all frames whose frame numbers are **not** in
-        ``frame_numbers`` are reset.
+        ``frame_numbers`` are reset instead.
         """
         if collection_name not in cls._instances:
             return

--- a/fiftyone/core/video.py
+++ b/fiftyone/core/video.py
@@ -198,9 +198,12 @@ class FramesView(fov.DatasetView):
             it immediately writes the requested changes to the underlying
             dataset.
         """
-        super().keep()
 
+        # The `keep()` operation below will delete frames, so we must sync
+        # deletions to the source dataset first
         self._sync_source(update=False, delete=True)
+
+        super().keep()
 
     def reload(self):
         """Reloads this view from the source collection in the database.

--- a/fiftyone/core/view.py
+++ b/fiftyone/core/view.py
@@ -609,22 +609,32 @@ class DatasetView(foc.SampleCollection):
         """
         self._dataset._ensure_frames(view=self)
 
-    def save(self, fields=None):
-        """Overwrites the underlying dataset with the contents of the view.
+    def save(self, fields=None, hard=False):
+        """Saves the contents of the view to the database.
 
         .. warning::
 
-            This will permanently delete any omitted, filtered, or otherwise
-            modified contents of the dataset.
+            If a view has excluded fields or filtered list values, this method
+            will permanently delete this data from the dataset, unless
+            ``fields`` is used to omit such fields from the save.
+
+            In addition, if ``hard != False``, this method will delete any
+            samples and/or frames from the dataset that do not appear in this
+            view. See below for details.
 
         Args:
             fields (None): an optional field or list of fields to save. If
-                specified, only these fields are overwritten
-        """
-        if etau.is_str(fields):
-            fields = [fields]
+                specified, only these field's contents are modified
+            hard (False): whether to use ``$out`` rather than ``$merge`` to
+                perform the save, which will cause any samples/frames omitted
+                from the view to be deleted from the dataset. The supported
+                values are:
 
-        self._dataset._save(view=self, fields=fields)
+                -   ``False``: do not delete samples/frames
+                -   ``True``: delete omitted samples and frames
+                -   ``"frames"``: delete omitted frames but not omitted samples
+        """
+        self._dataset._save(view=self, fields=fields, hard=hard)
 
     def clone(self, name=None):
         """Creates a new dataset containing only the contents of the view.

--- a/fiftyone/core/view.py
+++ b/fiftyone/core/view.py
@@ -593,7 +593,7 @@ class DatasetView(foc.SampleCollection):
         self._dataset._clear_frame_fields(field_names, view=self)
 
     def clear(self):
-        """Removes all samples in the view from the underlying dataset.
+        """Deletes all samples in the view from the underlying dataset.
 
         .. note::
 
@@ -604,7 +604,7 @@ class DatasetView(foc.SampleCollection):
         self._dataset._clear(view=self)
 
     def clear_frames(self):
-        """Removes all frame labels from the samples in the view from the
+        """Deletes all frame labels from the samples in the view from the
         underlying dataset.
 
         .. note::
@@ -616,7 +616,7 @@ class DatasetView(foc.SampleCollection):
         self._dataset._clear_frames(view=self)
 
     def keep(self):
-        """Removes all samples that are **not** in the view from the underlying
+        """Deletes all samples that are **not** in the view from the underlying
         dataset.
 
         .. note::
@@ -628,7 +628,7 @@ class DatasetView(foc.SampleCollection):
         self._dataset._keep(view=self)
 
     def keep_frames(self):
-        """For each sample in the view, removes all frames labels that are
+        """For each sample in the view, deletes all frames labels that are
         **not** in the view from the underlying dataset.
 
         .. note::

--- a/fiftyone/core/view.py
+++ b/fiftyone/core/view.py
@@ -597,8 +597,22 @@ class DatasetView(foc.SampleCollection):
         self._dataset._clear(view=self)
 
     def clear_frames(self):
-        """Removes all frame labels from the samples in the view."""
+        """Removes all frame labels from the samples in the view from the
+        underlying dataset.
+        """
         self._dataset._clear_frames(view=self)
+
+    def keep(self):
+        """Removes all samples that are **not** in the view from the underlying
+        dataset.
+        """
+        self._dataset._keep(self)
+
+    def keep_frames(self):
+        """For each sample in the view, removes all frames labels that are
+        **not** in the view from the underlying dataset.
+        """
+        self._dataset._keep_frames(self)
 
     def ensure_frames(self):
         """Ensures that the video view contains frame instances for every frame
@@ -609,8 +623,11 @@ class DatasetView(foc.SampleCollection):
         """
         self._dataset._ensure_frames(view=self)
 
-    def save(self, fields=None, hard=False):
+    def save(self, fields=None):
         """Saves the contents of the view to the database.
+
+        This method **does not** delete samples or frames from the underlying
+        dataset that this view excludes.
 
         .. warning::
 
@@ -618,23 +635,11 @@ class DatasetView(foc.SampleCollection):
             will permanently delete this data from the dataset, unless
             ``fields`` is used to omit such fields from the save.
 
-            In addition, if ``hard != False``, this method will delete any
-            samples and/or frames from the dataset that do not appear in this
-            view. See below for details.
-
         Args:
             fields (None): an optional field or list of fields to save. If
                 specified, only these field's contents are modified
-            hard (False): whether to use ``$out`` rather than ``$merge`` to
-                perform the save, which will cause any samples/frames omitted
-                from the view to be deleted from the dataset. The supported
-                values are:
-
-                -   ``False``: do not delete samples/frames
-                -   ``True``: delete omitted samples and frames
-                -   ``"frames"``: delete omitted frames but not omitted samples
         """
-        self._dataset._save(view=self, fields=fields, hard=hard)
+        self._dataset._save(view=self, fields=fields)
 
     def clone(self, name=None):
         """Creates a new dataset containing only the contents of the view.

--- a/fiftyone/core/view.py
+++ b/fiftyone/core/view.py
@@ -593,26 +593,51 @@ class DatasetView(foc.SampleCollection):
         self._dataset._clear_frame_fields(field_names, view=self)
 
     def clear(self):
-        """Removes all samples in the view from the underlying dataset."""
+        """Removes all samples in the view from the underlying dataset.
+
+        .. note::
+
+            This method is not a :class:`fiftyone.core.stages.ViewStage`;
+            it immediately writes the requested changes to the underlying
+            dataset.
+        """
         self._dataset._clear(view=self)
 
     def clear_frames(self):
         """Removes all frame labels from the samples in the view from the
         underlying dataset.
+
+        .. note::
+
+            This method is not a :class:`fiftyone.core.stages.ViewStage`;
+            it immediately writes the requested changes to the underlying
+            dataset.
         """
         self._dataset._clear_frames(view=self)
 
     def keep(self):
         """Removes all samples that are **not** in the view from the underlying
         dataset.
+
+        .. note::
+
+            This method is not a :class:`fiftyone.core.stages.ViewStage`;
+            it immediately writes the requested changes to the underlying
+            dataset.
         """
-        self._dataset._keep(self)
+        self._dataset._keep(view=self)
 
     def keep_frames(self):
         """For each sample in the view, removes all frames labels that are
         **not** in the view from the underlying dataset.
+
+        .. note::
+
+            This method is not a :class:`fiftyone.core.stages.ViewStage`;
+            it immediately writes the requested changes to the underlying
+            dataset.
         """
-        self._dataset._keep_frames(self)
+        self._dataset._keep_frames(view=self)
 
     def ensure_frames(self):
         """Ensures that the video view contains frame instances for every frame
@@ -620,6 +645,12 @@ class DatasetView(foc.SampleCollection):
 
         Empty frames will be inserted for missing frames, and already existing
         frames are left unchanged.
+
+        .. note::
+
+            This method is not a :class:`fiftyone.core.stages.ViewStage`;
+            it immediately writes the requested changes to the underlying
+            dataset.
         """
         self._dataset._ensure_frames(view=self)
 
@@ -628,6 +659,12 @@ class DatasetView(foc.SampleCollection):
 
         This method **does not** delete samples or frames from the underlying
         dataset that this view excludes.
+
+        .. note::
+
+            This method is not a :class:`fiftyone.core.stages.ViewStage`;
+            it immediately writes the requested changes to the underlying
+            dataset.
 
         .. warning::
 
@@ -646,10 +683,10 @@ class DatasetView(foc.SampleCollection):
 
         Args:
             name (None): a name for the cloned dataset. By default,
-                :func:`get_default_dataset_name` is used
+                :func:`fiftyone.core.dataset.get_default_dataset_name` is used
 
         Returns:
-            the new :class:`Dataset`
+            the new :class:`fiftyone.core.dataset.Dataset`
         """
         return self._dataset._clone(name=name, view=self)
 

--- a/tests/unittests/patches_tests.py
+++ b/tests/unittests/patches_tests.py
@@ -199,15 +199,20 @@ class PatchesTests(unittest.TestCase):
 
         view3.save()
 
+        self.assertEqual(view.count(), 6)
+        self.assertEqual(dataset.count("ground_truth.detections"), 6)
+        self.assertIn("CAT", view.count_values("ground_truth.label"))
+        self.assertIn(
+            "CAT", dataset.count_values("ground_truth.detections.label")
+        )
+
+        view3.keep()
+
         self.assertEqual(view.count(), 2)
         self.assertEqual(dataset.count("ground_truth.detections"), 2)
         self.assertNotIn("cat", view.count_values("ground_truth.label"))
-        self.assertEqual(view.count_values("ground_truth.label")["CAT"], 1)
         self.assertNotIn(
             "cat", dataset.count_values("ground_truth.detections.label")
-        )
-        self.assertEqual(
-            dataset.count_values("ground_truth.detections.label")["CAT"], 1
         )
 
         sample = view.first()
@@ -441,6 +446,17 @@ class PatchesTests(unittest.TestCase):
         )
 
         view3.save()
+
+        self.assertEqual(view.count(), 4)
+        self.assertEqual(dataset.count("ground_truth.detections"), 3)
+        self.assertIn(
+            "CAT", view.count_values("ground_truth.detections.label")
+        )
+        self.assertIn(
+            "CAT", dataset.count_values("ground_truth.detections.label")
+        )
+
+        view3.keep()
 
         self.assertEqual(view.count(), 1)
         self.assertEqual(dataset.count("ground_truth.detections"), 1)

--- a/tests/unittests/video_tests.py
+++ b/tests/unittests/video_tests.py
@@ -1313,6 +1313,19 @@ class VideoTests(unittest.TestCase):
 
         view2.save()
 
+        self.assertEqual(len(view), 4)
+        self.assertEqual(dataset.count("events.detections"), 4)
+        self.assertIn("MEETING", view.count_values("events.label"))
+        self.assertIn("PARTY", view.count_values("events.label"))
+        self.assertIn(
+            "MEETING", dataset.count_values("events.detections.label")
+        )
+        self.assertIn("PARTY", dataset.count_values("events.detections.label"))
+        self.assertIsNotNone(view.first().id)
+        self.assertIsNotNone(dataset.last().id)
+
+        view2.keep()
+
         self.assertEqual(len(view), 2)
         self.assertEqual(dataset.count("events.detections"), 2)
         self.assertDictEqual(
@@ -1577,8 +1590,28 @@ class VideoTests(unittest.TestCase):
 
         view2.save()
 
+        self.assertEqual(len(view), 9)
+        self.assertEqual(dataset.values(F("frames").length()), [3, 3])
+        self.assertIn(
+            "DOG", view.count_values("ground_truth.detections.label")
+        )
+        self.assertIn(
+            "RABBIT", view.count_values("ground_truth.detections.label")
+        )
+        self.assertIn(
+            "DOG", dataset.count_values("frames.ground_truth.detections.label")
+        )
+        self.assertIn(
+            "RABBIT",
+            dataset.count_values("frames.ground_truth.detections.label"),
+        )
+        self.assertIsNotNone(view.first().id)
+        self.assertIsNotNone(dataset.last().frames.first().id)
+
+        view2.keep()
+
         self.assertEqual(len(view), 5)
-        self.assertEqual(dataset.values(F("frames").length()), [0, 5])
+        self.assertEqual(dataset.values(F("frames").length()), [0, 3])
         self.assertDictEqual(
             view.count_values("ground_truth.detections.label"),
             {"DOG": 1, "RABBIT": 1},
@@ -1834,8 +1867,28 @@ class VideoTests(unittest.TestCase):
 
         view2.save()
 
+        self.assertEqual(len(view), 9)
+        self.assertEqual(dataset.values(F("frames").length()), [0, 3])
+        self.assertIn(
+            "DOG", view.count_values("ground_truth.detections.label")
+        )
+        self.assertIn(
+            "RABBIT", view.count_values("ground_truth.detections.label")
+        )
+        self.assertIn(
+            "DOG", dataset.count_values("frames.ground_truth.detections.label")
+        )
+        self.assertIn(
+            "RABBIT",
+            dataset.count_values("frames.ground_truth.detections.label"),
+        )
+        self.assertIsNotNone(view.first().id)
+        self.assertIsNotNone(dataset.last().frames.first().id)
+
+        view2.keep()
+
         self.assertEqual(len(view), 5)
-        self.assertEqual(dataset.values(F("frames").length()), [0, 5])
+        self.assertEqual(dataset.values(F("frames").length()), [0, 3])
         self.assertDictEqual(
             view.count_values("ground_truth.detections.label"),
             {"DOG": 1, "RABBIT": 1},
@@ -2089,6 +2142,24 @@ class VideoTests(unittest.TestCase):
 
         view3.save()
 
+        self.assertEqual(patches.count(), 4)
+        self.assertEqual(frames.count(), 9)
+        self.assertEqual(dataset.count(), 2)
+        self.assertEqual(patches.count("ground_truth"), 4)
+        self.assertEqual(frames.count("ground_truth.detections"), 4)
+        self.assertEqual(dataset.count("frames"), 6)
+        self.assertEqual(dataset.count("frames.ground_truth.detections"), 4)
+        self.assertIn("RABBIT", patches.count_values("ground_truth.label"))
+        self.assertIn(
+            "RABBIT", frames.count_values("ground_truth.detections.label")
+        )
+        self.assertIn(
+            "RABBIT",
+            dataset.count_values("frames.ground_truth.detections.label"),
+        )
+
+        view3.keep()
+
         self.assertEqual(patches.count(), 2)
         self.assertEqual(frames.count(), 9)
         self.assertEqual(dataset.count(), 2)
@@ -2272,6 +2343,19 @@ class VideoTests(unittest.TestCase):
         )
 
         view3.save()
+
+        self.assertEqual(patches.count(), 4)
+        self.assertEqual(dataset.count(), 2)
+        self.assertEqual(patches.count("ground_truth"), 4)
+        self.assertEqual(dataset.count("frames"), 6)
+        self.assertEqual(dataset.count("frames.ground_truth.detections"), 4)
+        self.assertIn("RABBIT", patches.count_values("ground_truth.label"))
+        self.assertIn(
+            "RABBIT",
+            dataset.count_values("frames.ground_truth.detections.label"),
+        )
+
+        view3.keep()
 
         self.assertEqual(patches.count(), 2)
         self.assertEqual(dataset.count(), 2)

--- a/tests/unittests/video_tests.py
+++ b/tests/unittests/video_tests.py
@@ -1868,7 +1868,7 @@ class VideoTests(unittest.TestCase):
         view2.save()
 
         self.assertEqual(len(view), 9)
-        self.assertEqual(dataset.values(F("frames").length()), [0, 3])
+        self.assertEqual(dataset.values(F("frames").length()), [3, 3])
         self.assertIn(
             "DOG", view.count_values("ground_truth.detections.label")
         )


### PR DESCRIPTION
Previously, `DatasetView.save()` would both save changes to the samples in the view *and* delete any samples that were not in the view.

This PR splits that behavior into two separate methods:
- `save()`: save changes to (only) the samples in the view to the underlying dataset
- `keep()`: delete any samples that are not in the view to the underlying dataset

This PR also adds a `keep_frames()` method that provides a slight variation on the above functionality that is relevant for video datasets: deleting omitted frames from a video view **only** for the samples in the view.

### Updated Documentation

Ordinarily, when you define a `DatasetView` that extracts a specific subset of a dataset and its fields, the underlying `Dataset` is not modified. However, you can use `save()` to save the contents of a view you've created to the underlying dataset:

```py
import fiftyone as fo
import fiftyone.zoo as foz
from fiftyone import ViewField as F

dataset = foz.load_zoo_dataset("quickstart")

# Capitalize some labels
rename_view = dataset.map_labels("predictions", {"cat": "CAT", "dog": "DOG"})
rename_view.save()

print(dataset.count_values("predictions.detections.label"))
# {'CAT': 35, 'DOG': 49, ...}

# Discard all predictions with confidence below 0.3
high_conf_view = dataset.filter_labels(
    "predictions", F("confidence") > 0.3, only_matches=False
)
high_conf_view.save()

print(dataset.bounds("predictions.detections.confidence"))
# (0.3001, 0.9999)
```

Note that calling `save()` on a `DatasetView` will only save modifications to samples that are in the view; all other samples are left unchanged.

You can use `keep()` to delete samples from the underlying dataset that do not appear in a view you created:

```py
print(len(dataset))
# 200

# Discard all samples with no people
people_view = dataset.filter_labels("ground_truth", F("label") == "person")
people_view.keep()

print(len(dataset))
# 94
```
