### PR TITLE
Update CVAT request error handling

### DIFF
--- a/fiftyone/utils/cvat.py
+++ b/fiftyone/utils/cvat.py
@@ -3541,7 +3541,7 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
         response = self._make_request(
             self._session.post,
             self.login_url,
-            print_errors=False,
+            print_error_info=False,
             data={"username": username, "password": password},
         )
 
@@ -3550,9 +3550,11 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
                 "csrftoken"
             ]
 
-    def _make_request(self, request_method, url, print_errors=True, **kwargs):
+    def _make_request(
+        self, request_method, url, print_error_info=True, **kwargs
+    ):
         response = request_method(url, verify=False, **kwargs)
-        if print_errors:
+        if print_error_info:
             self._validate(response, kwargs)
         else:
             response.raise_for_status()

--- a/fiftyone/utils/cvat.py
+++ b/fiftyone/utils/cvat.py
@@ -3538,14 +3538,25 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
         if self._headers:
             self._session.headers.update(self._headers)
 
-        response = self.post(
-            self.login_url, data={"username": username, "password": password}
+        response = self._make_request(
+            self._session.post,
+            self.login_url,
+            print_errors=False,
+            data={"username": username, "password": password},
         )
 
         if "csrftoken" in response.cookies:
             self._session.headers["X-CSRFToken"] = response.cookies[
                 "csrftoken"
             ]
+
+    def _make_request(self, request_method, url, print_errors=True, **kwargs):
+        response = request_method(url, verify=False, **kwargs)
+        if print_errors:
+            self._validate(response, kwargs)
+        else:
+            response.raise_for_status()
+        return response
 
     def get(self, url, **kwargs):
         """Sends a GET request to the given CVAT API URL.
@@ -3557,9 +3568,7 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
         Returns:
             the request response
         """
-        response = self._session.get(url, verify=False, **kwargs)
-        self._validate(response, kwargs)
-        return response
+        return self._make_request(self._session.get, url, **kwargs)
 
     def patch(self, url, **kwargs):
         """Sends a PATCH request to the given CVAT API URL.
@@ -3571,9 +3580,7 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
         Returns:
             the request response
         """
-        response = self._session.patch(url, verify=False, **kwargs)
-        self._validate(response, kwargs)
-        return response
+        return self._make_request(self._session.patch, url, **kwargs)
 
     def post(self, url, **kwargs):
         """Sends a POST request to the given CVAT API URL.
@@ -3585,9 +3592,7 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
         Returns:
             the request response
         """
-        response = self._session.post(url, verify=False, **kwargs)
-        self._validate(response, kwargs)
-        return response
+        return self._make_request(self._session.post, url, **kwargs)
 
     def put(self, url, **kwargs):
         """Sends a PUT request to the given CVAT API URL.
@@ -3599,9 +3604,7 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
         Returns:
             the request response
         """
-        response = self._session.put(url, verify=False, **kwargs)
-        self._validate(response, kwargs)
-        return response
+        return self._make_request(self._session.put, url, **kwargs)
 
     def delete(self, url, **kwargs):
         """Sends a DELETE request to the given CVAT API URL.
@@ -3613,9 +3616,7 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
         Returns:
             the request response
         """
-        response = self._session.delete(url, verify=False, **kwargs)
-        self._validate(response, kwargs)
-        return response
+        return self._make_request(self._session.delete, url, **kwargs)
 
     def get_user_id(self, username):
         """Retrieves the CVAT user ID for the given username.


### PR DESCRIPTION
Cleans up the usage of requests in the CVAT API and updates the message for authentication errors.

## Example
```python
import fiftyone as fo
import fiftyone.zoo as foz

dataset = foz.load_zoo_dataset("quickstart").take(1).clone()
dataset.annotate(
    "anno_key",
    label_field="ground_truth",
    url="https://cvat.org",
    username="fake_username",
    password="fake_password",
)
```