### PR TITLE
Add support for per-point confidences in Keypoint class

### DIFF
--- a/fiftyone/core/labels.py
+++ b/fiftyone/core/labels.py
@@ -851,7 +851,7 @@ class Keypoint(_HasID, _HasAttributesDict, Label):
     Args:
         label (None): a label for the points
         points (None): a list of ``(x, y)`` keypoints in ``[0, 1] x [0, 1]``
-        confidence (None): a confidence in ``[0, 1]`` for the points
+        confidences (None): a list of confidence in ``[0, 1]`` for each point
         index (None): an index for the keypoints
         attributes ({}): a dict mapping attribute names to :class:`Attribute`
             instances
@@ -859,7 +859,7 @@ class Keypoint(_HasID, _HasAttributesDict, Label):
 
     label = fof.StringField()
     points = fof.KeypointsField()
-    confidence = fof.FloatField()
+    confidences = fof.ListField(field=fof.FloatField(), null=True)
     index = fof.IntField()
 
     def to_shapely(self, frame_size=None):

--- a/fiftyone/utils/coco.py
+++ b/fiftyone/utils/coco.py
@@ -973,17 +973,17 @@ class COCOObject(object):
         label = self._get_label(classes)
 
         points = []
+        visible = []
         for x, y, v in fou.iter_batches(self.keypoints, 3):
             if v == 0:
-                continue
-
-            points.append((x / width, y / height))
+                points.append((float("nan"), float("nan")))
+                visible.append(False)
+            else:
+                points.append((x / width, y / height))
+                visible.append(True)
 
         return fol.Keypoint(
-            label=label,
-            points=points,
-            confidence=self.score,
-            **self.attributes,
+            label=label, points=points, visible=visible, **self.attributes,
         )
 
     def to_detection(

--- a/fiftyone/utils/eta.py
+++ b/fiftyone/utils/eta.py
@@ -753,7 +753,6 @@ def from_keypoint(keypoints):
     return fol.Keypoint(
         label=keypoints.label,
         points=keypoints.points,
-        confidence=keypoints.confidence,
         index=keypoints.index,
         tags=keypoints.tags,
         **attributes,

--- a/fiftyone/utils/eta.py
+++ b/fiftyone/utils/eta.py
@@ -730,7 +730,6 @@ def to_keypoints(keypoint, name=None, extra_attrs=True):
     return etak.Keypoints(
         name=name,
         label=keypoint.label,
-        confidence=keypoint.confidence,
         index=keypoint.index,
         points=keypoint.points,
         attrs=attrs,

--- a/fiftyone/utils/torch.py
+++ b/fiftyone/utils/torch.py
@@ -862,6 +862,7 @@ class KeypointDetectorOutputProcessor(OutputProcessor):
             ]
 
             points = [(p[0] / width, p[1] / height) for p in kpts]
+            visible = [(p[3] > 0) for p in kpts]
 
             _detections.append(
                 fol.Detection(
@@ -875,7 +876,7 @@ class KeypointDetectorOutputProcessor(OutputProcessor):
                 fol.Keypoint(
                     label=self.class_labels[label],
                     points=points,
-                    confidence=score,
+                    visible=visible,
                 )
             )
 

--- a/fiftyone/utils/torch.py
+++ b/fiftyone/utils/torch.py
@@ -845,11 +845,12 @@ class KeypointDetectorOutputProcessor(OutputProcessor):
         labels = output["labels"].detach().cpu().numpy()
         scores = output["scores"].detach().cpu().numpy()
         keypoints = output["keypoints"].detach().cpu().numpy()
+        keypoints_scores = torch.sigmoid(output["keypoints_scores"].detach().cpu()).numpy()
 
         _detections = []
         _keypoints = []
         _polylines = []
-        for box, label, score, kpts in zip(boxes, labels, scores, keypoints):
+        for box, label, score, kpts, kpt_scores in zip(boxes, labels, scores, keypoints, keypoints_scores):
             if confidence_thresh is not None and score < confidence_thresh:
                 continue
 
@@ -862,7 +863,7 @@ class KeypointDetectorOutputProcessor(OutputProcessor):
             ]
 
             points = [(p[0] / width, p[1] / height) for p in kpts]
-            visible = [(p[3] > 0) for p in kpts]
+            visible = [bool(p[2] > 0) for p in kpts]
 
             _detections.append(
                 fol.Detection(
@@ -877,6 +878,7 @@ class KeypointDetectorOutputProcessor(OutputProcessor):
                     label=self.class_labels[label],
                     points=points,
                     visible=visible,
+                    confidences=kpt_scores.tolist(),
                 )
             )
 


### PR DESCRIPTION
## What changes are proposed in this pull request?
Fixes #1581 

Replacing Keypoint.confidence to Keypoint.confidences
Fixing COCO import to not skip over v=0, instead set visible to false
Populating optional visible field in coco.py/torch.py

(Please fill in changes proposed in this fix)

## How is this patch tested? If it is not, please explain why.

Tested locally on COCO-2017 with keypoint import. This is the sample output from COCO import

```
<Keypoint: {
    'id': '61fc66d8c50045c0978ff8ed',
    'attributes': BaseDict({}),
    'tags': BaseList([]),
    'label': 'person',
    'points': BaseList([
        BaseList([0.585480093676815, 0.3328125]),
        BaseList([0.629976580796253, 0.2625]),
        BaseList([0.4894613583138173, 0.271875]),
        BaseList([nan, nan]),
        BaseList([0.26697892271662765, 0.2796875]),
        BaseList([0.9391100702576113, 0.5359375]),
        BaseList([0.09836065573770492, 0.6109375]),
        BaseList([nan, nan]),
        BaseList([nan, nan]),
        BaseList([0.8758782201405152, 0.596875]),
        BaseList([0.48243559718969553, 0.6734375]),
        BaseList([nan, nan]),
        BaseList([nan, nan]),
        BaseList([nan, nan]),
        BaseList([nan, nan]),
        BaseList([nan, nan]),
        BaseList([nan, nan]),
    ]),
    'confidences': None,
    'index': None,
    'visible':
    BaseList([
        True, True, True, False, True, True, True, False, False, True, True, False, False, False, False, False, False,
    ]),
    'num_keypoints': 8,
}>
```

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?
confidence->confidences might be something to mention in the release notes.

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

Keypoint.confidence was replaced with Keypoint.confidences which represent confidence per each point.

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
