### PR TITLE
Fixing frame aggregations

### DIFF
--- a/fiftyone/core/aggregations.py
+++ b/fiftyone/core/aggregations.py
@@ -1704,6 +1704,7 @@ def _parse_field_and_expr(
     if field_name is None:
         field_name, expr = _extract_prefix_from_expr(expr)
 
+    root = "." not in field_name
     found_expr = expr is not None
 
     field_type = _get_field_type(
@@ -1754,9 +1755,12 @@ def _parse_field_and_expr(
 
     if keep_top_level:
         if is_frame_field:
-            path = "frames." + path
-            unwind_list_fields = ["frames." + f for f in unwind_list_fields]
-            other_list_fields = ["frames." + f for f in other_list_fields]
+            if not root:
+                prefix = "frames."
+                path = prefix + path
+                unwind_list_fields = [prefix + f for f in unwind_list_fields]
+                other_list_fields = [prefix + f for f in other_list_fields]
+
             other_list_fields.insert(0, "frames")
         elif unwind_list_fields:
             first_field = unwind_list_fields.pop(0)
@@ -1765,13 +1769,14 @@ def _parse_field_and_expr(
         pipeline.append({"$project": {path: True}})
     elif auto_unwind:
         if is_frame_field:
-            pipeline.extend(
-                [
-                    {"$unwind": "$frames"},
-                    {"$project": {"frames." + path: True}},
-                    {"$replaceRoot": {"newRoot": "$frames"}},
-                ]
-            )
+            pipeline.append({"$unwind": "$frames"})
+            if not root:
+                pipeline.extend(
+                    [
+                        {"$project": {"frames." + path: True}},
+                        {"$replaceRoot": {"newRoot": "$frames"}},
+                    ]
+                )
         else:
             pipeline.append({"$project": {path: True}})
     elif unwind_list_fields:


### PR DESCRIPTION
Resolves an aggregation bug that would previously cause an error when writing aggregations on video datasets that involve applying expressions directly to `F("frames")`.

Examples:

```py
import fiftyone as fo
import fiftyone.zoo as foz
from fiftyone import ViewField as F

dataset = foz.load_zoo_dataset("quickstart-video")
dataset.compute_metadata()

# Previously failed, now works
num_objects = F("frames").map(F("detections.detections").length()).max()
print(dataset.count_values(num_objects))

# Previously failed, now works
clips = dataset.to_clips(F("detections.detections").length() > 5)
duration = F("frames").length() / F("$metadata.frame_rate")
print(clips.bounds(duration))
```
