### PR TITLE
Fix typo in docs (notebook for Writing Custom Dataset Importers)

### DIFF
--- a/docs/source/recipes/custom_importer.ipynb
+++ b/docs/source/recipes/custom_importer.ipynb
@@ -40,7 +40,7 @@
    "source": [
     "In this recipe we'll use the [FiftyOne Dataset Zoo](https://voxel51.com/docs/fiftyone/user_guide/dataset_creation/zoo_datasets.html) to download the [CIFAR-10 dataset](https://www.cs.toronto.edu/~kriz/cifar.html) to use as sample data to feed our custom importer.\n",
     "\n",
-    "Behind the scenes, FiftyOne either the\n",
+    "Behind the scenes, FiftyOne either uses the\n",
     "[TensorFlow Datasets](https://www.tensorflow.org/datasets) or\n",
     "[TorchVision Datasets](https://pytorch.org/docs/stable/torchvision/datasets.html) libraries to wrangle the datasets, depending on which ML library you have installed.\n",
     "\n",


### PR DESCRIPTION
## What changes are proposed in this pull request?

A minor typo in the docs was corrected. (from "FiftyOne either the TensorFlow..." to  "FiftyOne either uses the TensorFlow..."

## How is this patch tested? If it is not, please explain why.

Not tested.

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [x] Documentation: FiftyOne documentation changes
-   [ ] Other
