### PR TITLE
Add warnings when working with CVAT v2 servers

### DIFF
--- a/docs/source/integrations/cvat.rst
+++ b/docs/source/integrations/cvat.rst
@@ -16,6 +16,13 @@ In either case, FiftyOne provides :ref:`simple setup <cvat-setup>` instructions
 that you can use to specify the necessary account credentials and server
 endpoint to use.
 
+.. warning::
+
+    CVAT v2 is now available through self-hosted servers and
+    `cvat.org <https://cvat.org>`_ but is currently unsupported in
+    FiftyOne. Unexpected behavior may occur when connecting to a CVAT v2
+    server.
+
 CVAT provides three levels of abstraction for annotation workflows: projects,
 tasks, and jobs. A job contains one or more images and can be assigned to a
 specfic annotator or reviewer. A task defines the label schema to use for
@@ -480,7 +487,7 @@ provided:
 -   **chunk_size** (*None*): the number of frames to upload per ZIP chunk
 -   **task_assignee** (*None*): the username to assign the generated tasks.
     This argument can be a list of usernames when annotating videos as each
-    video is uploaded to a separate task 
+    video is uploaded to a separate task
 -   **job_assignees** (*None*): a list of usernames to assign jobs
 -   **job_reviewers** (*None*): a list of usernames to assign job reviews
 -   **project_name** (*None*): an optional project name to which to upload the
@@ -1639,7 +1646,7 @@ specify which users will be assigned to the created tasks:
 -   `segment_size`: the maximum number of images to include in a single job
 -   `task_assignee`: a username to assign the generated tasks. This argument
     can be a list of usernames when annotating videos as each
-    video is uploaded to a separate task 
+    video is uploaded to a separate task
 -   `job_assignees`: a list of usernames to assign jobs
 -   `job_reviewers`: a list of usernames to assign job reviews
 


### PR DESCRIPTION
Resolves #1599 

CVAT is working on a v2 release and [cvat.org](https://cvat.org) has recently been updated to v2. There are [a lot of changes]() with v2, one of which is an updated REST API URL. This PR adds support for the v2 API URL and adds warnings when working with a v2 CVAT server.

## Example
```python
import fiftyone as fo
import fiftyone.zoo as foz

dataset = foz.load_zoo_dataset("quickstart", max_samples=1).clone()

anno_key = "v2_test"
results = dataset.annotate(
    anno_key,
    label_field="ground_truth",
    url="https://cvat.org",
)
```

![image](https://user-images.githubusercontent.com/21222883/153495853-51a0665a-d35c-47b5-87f3-f3f0fa870472.png)
![image](https://user-images.githubusercontent.com/21222883/153495926-a9b9250c-3af6-4d95-b683-4d062fdab6af.png)
