### PR TITLE
TF records and conversion utility improvements

### DIFF
--- a/docs/source/cli/index.rst
+++ b/docs/source/cli/index.rst
@@ -215,8 +215,11 @@ Convert datasets on disk between supported formats.
 
 .. code-block:: text
 
-    fiftyone convert [-h] [--input-dir INPUT_DIR] [--input-type INPUT_TYPE]
-                     [--output-dir OUTPUT_DIR] [--output-type OUTPUT_TYPE]
+    fiftyone convert [-h] --input-type INPUT_TYPE --output-type OUTPUT_TYPE
+                     [--input-dir INPUT_DIR]
+                     [--input-kwargs KEY=VAL [KEY=VAL ...]]
+                     [--output-dir OUTPUT_DIR]
+                     [--output-kwargs KEY=VAL [KEY=VAL ...]] [-o]
 
 **Arguments**
 
@@ -226,10 +229,19 @@ Convert datasets on disk between supported formats.
       -h, --help            show this help message and exit
       --input-dir INPUT_DIR
                             the directory containing the dataset
-      --input-type INPUT_TYPE
-                            the fiftyone.types.Dataset type of the input dataset
+      --input-kwargs KEY=VAL [KEY=VAL ...]
+                            additional keyword arguments for
+                            `fiftyone.utils.data.convert_dataset(..., input_kwargs=)`
       --output-dir OUTPUT_DIR
                             the directory to which to write the output dataset
+      --output-kwargs KEY=VAL [KEY=VAL ...]
+                            additional keyword arguments for
+                            `fiftyone.utils.data.convert_dataset(..., output_kwargs=)`
+      -o, --overwrite       whether to overwrite an existing output directory
+
+    required arguments:
+      --input-type INPUT_TYPE
+                            the fiftyone.types.Dataset type of the input dataset
       --output-type OUTPUT_TYPE
                             the fiftyone.types.Dataset type to output
 
@@ -252,6 +264,18 @@ Convert datasets on disk between supported formats.
         --input-type fiftyone.types.COCODetectionDataset \
         --output-dir /path/for/cvat-image-dataset \
         --output-type fiftyone.types.CVATImageDataset
+
+.. code-block:: shell
+
+    # Perform a customized conversion via optional kwargs
+    fiftyone convert \
+        --input-dir /path/to/coco-detection-dataset \
+        --input-type fiftyone.types.COCODetectionDataset \
+        --input-kwargs max_samples=100 shuffle=True \
+        --output-dir /path/for/cvat-image-dataset \
+        --output-type fiftyone.types.TFObjectDetectionDataset \
+        --output-kwargs force_rgb=True \
+        --overwrite
 
 .. _cli-fiftyone-datasets:
 

--- a/docs/source/recipes/convert_datasets.ipynb
+++ b/docs/source/recipes/convert_datasets.ipynb
@@ -29,7 +29,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install fiftyone"
+    "pip install fiftyone"
    ]
   },
   {
@@ -196,15 +196,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "usage: fiftyone convert [-h] [--input-dir INPUT_DIR] [--input-type INPUT_TYPE]\n",
-      "                        [--output-dir OUTPUT_DIR] [--output-type OUTPUT_TYPE]\n",
+      "usage: fiftyone convert [-h] --input-type INPUT_TYPE --output-type OUTPUT_TYPE\n",
+      "                        [--input-dir INPUT_DIR]\n",
+      "                        [--input-kwargs KEY=VAL [KEY=VAL ...]]\n",
+      "                        [--output-dir OUTPUT_DIR]\n",
+      "                        [--output-kwargs KEY=VAL [KEY=VAL ...]] [-o]\n",
       "\n",
       "Convert datasets on disk between supported formats.\n",
       "\n",
@@ -224,14 +227,31 @@
       "            --output-dir /path/for/cvat-image-dataset \\\n",
       "            --output-type fiftyone.types.CVATImageDataset\n",
       "\n",
+      "        # Perform a customized conversion via optional kwargs\n",
+      "        fiftyone convert \\\n",
+      "            --input-dir /path/to/coco-detection-dataset \\\n",
+      "            --input-type fiftyone.types.COCODetectionDataset \\\n",
+      "            --input-kwargs max_samples=100 shuffle=True \\\n",
+      "            --output-dir /path/for/cvat-image-dataset \\\n",
+      "            --output-type fiftyone.types.TFObjectDetectionDataset \\\n",
+      "            --output-kwargs force_rgb=True \\\n",
+      "            --overwrite\n",
+      "\n",
       "optional arguments:\n",
       "  -h, --help            show this help message and exit\n",
       "  --input-dir INPUT_DIR\n",
       "                        the directory containing the dataset\n",
-      "  --input-type INPUT_TYPE\n",
-      "                        the fiftyone.types.Dataset type of the input dataset\n",
+      "  --input-kwargs KEY=VAL [KEY=VAL ...]\n",
+      "                        additional keyword arguments for `fiftyone.utils.data.convert_dataset(..., input_kwargs=)`\n",
       "  --output-dir OUTPUT_DIR\n",
       "                        the directory to which to write the output dataset\n",
+      "  --output-kwargs KEY=VAL [KEY=VAL ...]\n",
+      "                        additional keyword arguments for `fiftyone.utils.data.convert_dataset(..., output_kwargs=)`\n",
+      "  -o, --overwrite       whether to overwrite an existing output directory\n",
+      "\n",
+      "required arguments:\n",
+      "  --input-type INPUT_TYPE\n",
+      "                        the fiftyone.types.Dataset type of the input dataset\n",
       "  --output-type OUTPUT_TYPE\n",
       "                        the fiftyone.types.Dataset type to output\n"
      ]
@@ -863,21 +883,15 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
-   "name": "python3"
+   "display_name": "Bash",
+   "language": "bash",
+   "name": "bash"
   },
   "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.6.9"
+   "codemirror_mode": "shell",
+   "file_extension": ".sh",
+   "mimetype": "text/x-sh",
+   "name": "bash"
   }
  },
  "nbformat": 4,

--- a/fiftyone/core/cli.py
+++ b/fiftyone/core/cli.py
@@ -300,6 +300,16 @@ class ConvertCommand(Command):
             --input-type fiftyone.types.COCODetectionDataset \\
             --output-dir /path/for/cvat-image-dataset \\
             --output-type fiftyone.types.CVATImageDataset
+
+        # Perform a customized conversion via optional kwargs
+        fiftyone convert \\
+            --input-dir /path/to/coco-detection-dataset \\
+            --input-type fiftyone.types.COCODetectionDataset \\
+            --input-kwargs max_samples=100 shuffle=True \\
+            --output-dir /path/for/cvat-image-dataset \\
+            --output-type fiftyone.types.TFObjectDetectionDataset \\
+            --output-kwargs force_rgb=True \\
+            --overwrite
     """
 
     @staticmethod

--- a/fiftyone/core/cli.py
+++ b/fiftyone/core/cli.py
@@ -304,15 +304,34 @@ class ConvertCommand(Command):
 
     @staticmethod
     def setup(parser):
+        required = parser.add_argument_group("required arguments")
+        required.add_argument(
+            "--input-type",
+            metavar="INPUT_TYPE",
+            help="the fiftyone.types.Dataset type of the input dataset",
+            required=True,
+        )
+        required.add_argument(
+            "--output-type",
+            metavar="OUTPUT_TYPE",
+            help="the fiftyone.types.Dataset type to output",
+            required=True,
+        )
+
         parser.add_argument(
             "--input-dir",
             metavar="INPUT_DIR",
             help="the directory containing the dataset",
         )
         parser.add_argument(
-            "--input-type",
-            metavar="INPUT_TYPE",
-            help="the fiftyone.types.Dataset type of the input dataset",
+            "--input-kwargs",
+            nargs="+",
+            metavar="KEY=VAL",
+            action=_ParseKwargsAction,
+            help=(
+                "additional keyword arguments for "
+                "`fiftyone.utils.data.convert_dataset(..., input_kwargs=)`"
+            ),
         )
         parser.add_argument(
             "--output-dir",
@@ -320,24 +339,32 @@ class ConvertCommand(Command):
             help="the directory to which to write the output dataset",
         )
         parser.add_argument(
-            "--output-type",
-            metavar="OUTPUT_TYPE",
-            help="the fiftyone.types.Dataset type to output",
+            "--output-kwargs",
+            nargs="+",
+            metavar="KEY=VAL",
+            action=_ParseKwargsAction,
+            help=(
+                "additional keyword arguments for "
+                "`fiftyone.utils.data.convert_dataset(..., output_kwargs=)`"
+            ),
+        )
+        parser.add_argument(
+            "-o",
+            "--overwrite",
+            action="store_true",
+            help="whether to overwrite an existing output directory",
         )
 
     @staticmethod
     def execute(parser, args):
-        input_dir = args.input_dir
-        input_type = etau.get_class(args.input_type)
-
-        output_dir = args.output_dir
-        output_type = etau.get_class(args.output_type)
-
         foud.convert_dataset(
-            input_dir=input_dir,
-            input_type=input_type,
-            output_dir=output_dir,
-            output_type=output_type,
+            input_dir=args.input_dir,
+            input_type=etau.get_class(args.input_type),
+            input_kwargs=args.input_kwargs,
+            output_dir=args.output_dir,
+            output_type=etau.get_class(args.output_type),
+            output_kwargs=args.output_kwargs,
+            overwrite=args.overwrite,
         )
 
 

--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -6109,8 +6109,7 @@ class SampleCollection(object):
                 used
             overwrite (False): whether to delete existing directories before
                 performing the export (True) or to merge the export with
-                existing files and directories (False). Not applicable when a
-                ``dataset_exporter`` is provided
+                existing files and directories (False)
             **kwargs: optional keyword arguments to pass to the dataset
                 exporter's constructor. If you are exporting image patches,
                 this can also contain keyword arguments for
@@ -8083,12 +8082,18 @@ def _export(
             "Either `dataset_type` or `dataset_exporter` must be provided"
         )
 
+    # Overwrite existing directories or warn if files will be merged
+    _handle_existing_dirs(
+        dataset_exporter=dataset_exporter,
+        export_dir=export_dir,
+        data_path=data_path,
+        labels_path=labels_path,
+        export_media=export_media,
+        overwrite=overwrite,
+    )
+
     # If no dataset exporter was provided, construct one
     if dataset_exporter is None:
-        _handle_existing_dirs(
-            export_dir, data_path, labels_path, export_media, overwrite
-        )
-
         dataset_exporter, kwargs = foud.build_dataset_exporter(
             dataset_type,
             warn_unused=False,  # don't warn yet, might be patches kwargs
@@ -8141,8 +8146,34 @@ def _export(
 
 
 def _handle_existing_dirs(
-    export_dir, data_path, labels_path, export_media, overwrite
+    dataset_exporter=None,
+    export_dir=None,
+    data_path=None,
+    labels_path=None,
+    export_media=False,
+    overwrite=False,
 ):
+    if dataset_exporter is not None:
+        try:
+            export_dir = dataset_exporter.export_dir
+        except:
+            pass
+
+        try:
+            data_path = dataset_exporter.data_path
+        except:
+            pass
+
+        try:
+            labels_path = dataset_exporter.labels_path
+        except:
+            pass
+
+        try:
+            export_media = dataset_exporter.export_media
+        except:
+            pass
+
     if export_dir is not None and os.path.isdir(export_dir):
         if overwrite:
             etau.delete_dir(export_dir)

--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -6110,7 +6110,7 @@ class SampleCollection(object):
             overwrite (False): whether to delete existing directories before
                 performing the export (True) or to merge the export with
                 existing files and directories (False). Not applicable when a
-                ``dataset_exporter`` was provided
+                ``dataset_exporter`` is provided
             **kwargs: optional keyword arguments to pass to the dataset
                 exporter's constructor. If you are exporting image patches,
                 this can also contain keyword arguments for

--- a/fiftyone/utils/data/converters.py
+++ b/fiftyone/utils/data/converters.py
@@ -24,6 +24,7 @@ def convert_dataset(
     output_dir=None,
     output_type=None,
     dataset_exporter=None,
+    overwrite=False,
 ):
     """Converts a dataset stored on disk to another format on disk.
 
@@ -46,6 +47,10 @@ def convert_dataset(
         dataset_exporter (None): a
             :class:`fiftyone.utils.data.exporters.DatasetExporter` to use to
             export the dataset
+        overwrite (False): whether to delete existing directories before
+            performing the export (True) or to merge the export with existing
+            files and directories (False). Not applicable when a
+            ``dataset_exporter`` is provided
     """
     if input_type is None and dataset_importer is None:
         raise ValueError(
@@ -63,7 +68,11 @@ def convert_dataset(
     # Import dataset
     if dataset_importer is not None:
         # Import via ``dataset_importer``
-        logger.info("Loading dataset from '%s'", dataset_importer.dataset_dir)
+        if dataset_importer.dataset_dir is not None:
+            logger.info(
+                "Loading dataset from '%s'", dataset_importer.dataset_dir
+            )
+
         logger.info(
             "Using DatasetImporter '%s'", etau.get_class_name(dataset_importer)
         )
@@ -103,12 +112,18 @@ def convert_dataset(
     # Export dataset
     if dataset_exporter is not None:
         # Export via ``dataset_exporter``
-        logger.info("Exporting dataset to '%s'", dataset_exporter.export_dir)
+        if dataset_exporter.export_dir is not None:
+            logger.info(
+                "Exporting dataset to '%s'", dataset_exporter.export_dir
+            )
+
         logger.info(
             "Using DatasetExporter '%s'", etau.get_class_name(dataset_exporter)
         )
         dataset.export(
-            dataset_exporter=dataset_exporter, label_field=label_field
+            dataset_exporter=dataset_exporter,
+            label_field=label_field,
+            overwrite=overwrite,
         )
         logger.info("Export complete")
     else:
@@ -122,6 +137,7 @@ def convert_dataset(
             export_dir=output_dir,
             dataset_type=output_type,
             label_field=label_field,
+            overwrite=overwrite,
         )
         logger.info("Export complete")
 

--- a/fiftyone/utils/data/converters.py
+++ b/fiftyone/utils/data/converters.py
@@ -7,11 +7,15 @@ Dataset format conversion utilities.
 """
 import inspect
 import logging
+import os
 
 import eta.core.utils as etau
 
-import fiftyone as fo
+import fiftyone.core.dataset as fod
 import fiftyone.types as fot
+
+from .exporters import build_dataset_exporter
+from .importers import build_dataset_importer
 
 
 logger = logging.getLogger(__name__)
@@ -20,9 +24,11 @@ logger = logging.getLogger(__name__)
 def convert_dataset(
     input_dir=None,
     input_type=None,
+    input_kwargs=None,
     dataset_importer=None,
     output_dir=None,
     output_type=None,
+    output_kwargs=None,
     dataset_exporter=None,
     overwrite=False,
 ):
@@ -38,19 +44,24 @@ def convert_dataset(
         input_dir (None): the input dataset directory
         input_type (None): the :class:`fiftyone.types.dataset_types.Dataset`
             type of the dataset in ``input_dir``
+        input_kwargs (None): optional kwargs dict to pass to the constructor of
+            the :class:`fiftyone.utils.data.importers.DatasetImporter` for the
+            ``input_type`` you specify
         dataset_importer (None): a
             :class:`fiftyone.utils.data.importers.DatasetImporter` to use to
             import the input dataset
         output_dir (None): the directory to which to write the output dataset
         output_type (None): the :class:`fiftyone.types.dataset_types.Dataset`
             type to write to ``output_dir``
+        output_kwargs (None): optional kwargs dict to pass to the constructor
+            of the :class:`fiftyone.utils.data.exporters.DatasetExporter` for
+            the ``output_type`` you specify
         dataset_exporter (None): a
             :class:`fiftyone.utils.data.exporters.DatasetExporter` to use to
             export the dataset
         overwrite (False): whether to delete existing directories before
             performing the export (True) or to merge the export with existing
-            files and directories (False). Not applicable when a
-            ``dataset_exporter`` is provided
+            files and directories (False)
     """
     if input_type is None and dataset_importer is None:
         raise ValueError(
@@ -62,84 +73,79 @@ def convert_dataset(
             "Either `output_type` or `dataset_exporter` must be provided"
         )
 
-    # Label field used (if necessary) when converting labeled datasets
+    if input_kwargs is None:
+        input_kwargs = {}
+
+    if output_kwargs is None:
+        output_kwargs = {}
+
+    dataset = fod.Dataset()
     label_field = "label"
+    images_dir = None
 
-    # Import dataset
-    if dataset_importer is not None:
-        # Import via ``dataset_importer``
-        if dataset_importer.dataset_dir is not None:
-            logger.info(
-                "Loading dataset from '%s'", dataset_importer.dataset_dir
+    try:
+        #
+        # Import dataset
+        #
+
+        if dataset_importer is None:
+            # If the input dataset contains TFRecords, they must be unpacked
+            # into a temporary directory during conversion
+            if _is_tf_records(input_type) and "images_dir" not in input_kwargs:
+                images_dir = etau.make_temp_dir()
+                input_kwargs["images_dir"] = images_dir
+
+            dataset_importer, _ = build_dataset_importer(
+                input_type, dataset_dir=input_dir, **input_kwargs
             )
 
-        logger.info(
-            "Using DatasetImporter '%s'", etau.get_class_name(dataset_importer)
-        )
-        dataset = fo.Dataset.from_importer(
-            dataset_importer, label_field=label_field
-        )
-        logger.info("Import complete")
-    else:
-        # Import via ``input_type``
-        if inspect.isclass(input_type):
-            input_type = input_type()
-
-        # If the input dataset contains TFRecords, they must be unpacked into a
-        # temporary directory during conversion
-        if isinstance(
-            input_type,
-            (fot.TFImageClassificationDataset, fot.TFObjectDetectionDataset),
-        ):
-            with etau.TempDir() as images_dir:
-                dataset_importer_cls = input_type.get_dataset_importer_cls()
-                dataset_importer = dataset_importer_cls(input_dir, images_dir)
-                convert_dataset(
-                    dataset_importer=dataset_importer,
-                    output_dir=output_dir,
-                    output_type=output_type,
-                    dataset_exporter=dataset_exporter,
-                )
-                return
-
-        logger.info("Loading dataset from '%s'", input_dir)
-        logger.info("Input format '%s'", etau.get_class_name(input_type))
-        dataset = fo.Dataset.from_dir(
-            input_dir, input_type, label_field=label_field
-        )
-        logger.info("Import complete")
-
-    # Export dataset
-    if dataset_exporter is not None:
-        # Export via ``dataset_exporter``
-        if dataset_exporter.export_dir is not None:
+            logger.info("Input format: %s", etau.get_class_name(input_type))
+        else:
+            input_dir = dataset_importer.input_dir
             logger.info(
-                "Exporting dataset to '%s'", dataset_exporter.export_dir
+                "Using importer: %s", etau.get_class_name(dataset_importer)
             )
 
-        logger.info(
-            "Using DatasetExporter '%s'", etau.get_class_name(dataset_exporter)
-        )
+        if input_dir is not None:
+            logger.info("Loading dataset from '%s'", input_dir)
+
+        dataset.add_importer(dataset_importer, label_field=label_field)
+
+        #
+        # Export dataset
+        #
+
+        if dataset_exporter is None:
+            dataset_exporter, _ = build_dataset_exporter(
+                output_type, export_dir=output_dir, **output_kwargs
+            )
+            logger.info("Export format: %s", etau.get_class_name(output_type))
+        else:
+            output_dir = dataset_exporter.export_dir
+            logger.info(
+                "Using exporter: %s", etau.get_class_name(dataset_exporter)
+            )
+
+        if output_dir is not None:
+            logger.info("Exporting dataset to '%s'", output_dir)
+
         dataset.export(
             dataset_exporter=dataset_exporter,
             label_field=label_field,
             overwrite=overwrite,
         )
-        logger.info("Export complete")
-    else:
-        # Export via ``output_type``
-        if inspect.isclass(output_type):
-            output_type = output_type()
+    finally:
+        if images_dir is not None and os.path.isdir(images_dir):
+            etau.delete_dir(images_dir)
 
-        logger.info("Exporting dataset to '%s'", output_dir)
-        logger.info("Export format '%s'", etau.get_class_name(output_type))
-        dataset.export(
-            export_dir=output_dir,
-            dataset_type=output_type,
-            label_field=label_field,
-            overwrite=overwrite,
-        )
-        logger.info("Export complete")
+        dataset.delete()
 
-    # Cleanup
-    dataset.delete()
+
+def _is_tf_records(dataset_type):
+    if inspect.isclass(dataset_type):
+        dataset_type = dataset_type()
+
+    return isinstance(
+        dataset_type,
+        (fot.TFImageClassificationDataset, fot.TFObjectDetectionDataset),
+    )

--- a/fiftyone/utils/tf.py
+++ b/fiftyone/utils/tf.py
@@ -369,12 +369,17 @@ class TFImageClassificationSampleParser(TFRecordSampleParser):
         return img.numpy()
 
     def _parse_image_metadata(self, features):
+        if self.force_rgb:
+            num_channels = 3
+        else:
+            num_channels = features["depth"].numpy()
+
         return fom.ImageMetadata(
             size_bytes=len(features["image_bytes"].numpy()),
             mime_type="image/" + features["format"].numpy().decode(),
             width=features["width"].numpy(),
             height=features["height"].numpy(),
-            num_channels=features["depth"].numpy(),
+            num_channels=num_channels,
         )
 
     def _parse_label(self, features):
@@ -445,11 +450,17 @@ class TFObjectDetectionSampleParser(TFRecordSampleParser):
         return img.numpy()
 
     def _parse_image_metadata(self, features):
+        if self.force_rgb:
+            num_channels = 3
+        else:
+            num_channels = None
+
         return fom.ImageMetadata(
             size_bytes=len(features["image/encoded"].numpy()),
             mime_type="image/" + features["image/format"].numpy().decode(),
             width=features["image/width"].numpy(),
             height=features["image/height"].numpy(),
+            num_channels=num_channels,
         )
 
     def _parse_label(self, features):

--- a/tests/unittests/import_export_tests.py
+++ b/tests/unittests/import_export_tests.py
@@ -535,6 +535,7 @@ class ImageChannelsDatasetTests(ImageDatasetTests):
 
         return dataset
 
+    @skipwindows
     @drop_datasets
     def test_tf_image_classification_channels(self):
         orig_dataset = self._make_dataset()

--- a/tests/unittests/import_export_tests.py
+++ b/tests/unittests/import_export_tests.py
@@ -10,6 +10,7 @@ import random
 import string
 import unittest
 
+import cv2
 import numpy as np
 import pytest
 
@@ -514,6 +515,94 @@ class ImageClassificationDatasetTests(ImageDatasetTests):
         self.assertEqual(
             dataset.count("predictions"), dataset2.count("predictions")
         )
+
+
+class ImageChannelsDatasetTests(ImageDatasetTests):
+    def _make_dataset(self):
+        samples = [
+            fo.Sample(
+                filepath=self._new_image(),
+                predictions=fo.Classification(label="cat", confidence=0.9),
+            ),
+            fo.Sample(
+                filepath=self._new_image(),
+                predictions=fo.Classification(label="dog", confidence=0.95),
+            ),
+        ]
+
+        dataset = fo.Dataset()
+        dataset.add_samples(samples)
+
+        return dataset
+
+    @drop_datasets
+    def test_tf_image_classification_channels(self):
+        orig_dataset = self._make_dataset()
+
+        # Export grayscale images
+
+        export_dir1 = self._new_dir()
+
+        for idx, sample in enumerate(orig_dataset, 1):
+            label = sample.predictions.label
+            outpath = os.path.join(export_dir1, label, "%06d.png" % idx)
+
+            # pylint: disable=no-member
+            img = etai.read(sample.filepath, flag=cv2.IMREAD_GRAYSCALE)
+            etai.write(img, outpath)
+
+        gray_dataset1 = fo.Dataset.from_dir(
+            dataset_dir=export_dir1,
+            dataset_type=fo.types.ImageClassificationDirectoryTree,
+        )
+        gray_dataset1.compute_metadata()
+        self.assertEqual(gray_dataset1.first().metadata.num_channels, 1)
+
+        export_dir2 = self._new_dir()
+
+        # Export grayscale
+        gray_dataset1.export(
+            export_dir=export_dir2,
+            dataset_type=fo.types.TFImageClassificationDataset,
+            overwrite=True,
+        )
+
+        # Import grayscale
+        gray_dataset2 = fo.Dataset.from_dir(
+            dataset_dir=export_dir2,
+            dataset_type=fo.types.TFImageClassificationDataset,
+            images_dir=os.path.join(export_dir2, "images-gray"),
+        )
+        gray_dataset2.compute_metadata()
+        self.assertEqual(gray_dataset2.first().metadata.num_channels, 1)
+
+        # Force RGB at import-time
+        rgb_dataset1 = fo.Dataset.from_dir(
+            dataset_dir=export_dir2,
+            dataset_type=fo.types.TFImageClassificationDataset,
+            images_dir=os.path.join(export_dir2, "images-rgb"),
+            force_rgb=True,
+        )
+        rgb_dataset1.compute_metadata()
+        self.assertEqual(rgb_dataset1.first().metadata.num_channels, 3)
+
+        export_dir3 = self._new_dir()
+
+        # Force RGB at export-time
+        gray_dataset1.export(
+            export_dir=export_dir3,
+            dataset_type=fo.types.TFImageClassificationDataset,
+            force_rgb=True,
+        )
+
+        # Import RGB
+        rgb_dataset2 = fo.Dataset.from_dir(
+            dataset_dir=export_dir3,
+            dataset_type=fo.types.TFImageClassificationDataset,
+            images_dir=os.path.join(export_dir3, "images"),
+        )
+        rgb_dataset2.compute_metadata()
+        self.assertEqual(rgb_dataset2.first().metadata.num_channels, 3)
 
 
 class ImageClassificationsDatasetTests(ImageDatasetTests):


### PR DESCRIPTION
Change log
- Resolves https://github.com/voxel51/fiftyone/issues/1606
- Adds an optional `force_rgb=True` syntax when importing/exporting/creating TF records using all relevant methods in `fiftyone.utils.tf`
- Adds support for passing additional kwargs to the `fiftyone convert` method

## Example usages

`force_rgb=True` usage:

```py
import os
import cv2

import eta.core.image as etai
import eta.core.utils as etau

import fiftyone as fo
import fiftyone.zoo as foz

rgb_dataset1 = foz.load_zoo_dataset(
    "cifar10", split="test", max_samples=100, shuffle=True
)

rgb_dataset1.export(
    export_dir="/tmp/color",
    dataset_type=fo.types.ImageClassificationDirectoryTree,
    overwrite=True,
)

etau.ensure_empty_dir("/tmp/grayscale", cleanup=True)
for idx, sample in enumerate(rgb_dataset1, 1):
    label = sample.ground_truth.label
    outpath = os.path.join("/tmp/grayscale", label, "%06d.png" % idx)
    img = etai.read(sample.filepath, flag=cv2.IMREAD_GRAYSCALE)
    etai.write(img, outpath)

gray_dataset1 = fo.Dataset.from_dir(
    dataset_dir="/tmp/grayscale",
    dataset_type=fo.types.ImageClassificationDirectoryTree,
)
gray_dataset1.compute_metadata()
assert gray_dataset1.first().metadata.num_channels == 1

gray_dataset1.export(
    export_dir="/tmp/tf/gray",
    dataset_type=fo.types.TFImageClassificationDataset,
    overwrite=True,
)

gray_dataset1.export(
    export_dir="/tmp/tf/color",
    dataset_type=fo.types.TFImageClassificationDataset,
    force_rgb=True,
    overwrite=True,
)

rgb_dataset2 = fo.Dataset.from_dir(
    dataset_dir="/tmp/color",
    dataset_type=fo.types.ImageClassificationDirectoryTree,
)
rgb_dataset2.compute_metadata()
assert rgb_dataset2.first().metadata.num_channels == 3

gray_dataset2 = fo.Dataset.from_dir(
    dataset_dir="/tmp/tf/gray",
    dataset_type=fo.types.TFImageClassificationDataset,
    images_dir="/tmp/tf/gray/gray",
)
gray_dataset2.compute_metadata()
assert gray_dataset2.first().metadata.num_channels == 1

rgb_dataset3 = fo.Dataset.from_dir(
    dataset_dir="/tmp/tf/gray",
    dataset_type=fo.types.TFImageClassificationDataset,
    images_dir="/tmp/tf/gray/color",
    force_rgb=True,
)
rgb_dataset3.compute_metadata()
assert rgb_dataset3.first().metadata.num_channels == 3

rgb_dataset4 = fo.Dataset.from_dir(
    dataset_dir="/tmp/tf/color",
    dataset_type=fo.types.TFImageClassificationDataset,
    images_dir="/tmp/tf/color/color",
)
rgb_dataset4.compute_metadata()
assert rgb_dataset4.first().metadata.num_channels == 3
```

`fiftyone convert` usage:

```shell
fiftyone convert \
    --input-type fiftyone.types.ImageClassificationDirectoryTree \
    --input-dir /tmp/color \
    --output-type fiftyone.types.TFImageClassificationDataset \
    --output-dir /tmp/tf/color2

ls -lah /tmp/tf/color2/

fiftyone zoo datasets download coco-2017 --split validation --kwargs max_samples=100 shuffle=True
COCO_VAL_DIR=$(fiftyone zoo datasets find coco-2017 --split validation)

fiftyone convert \
    --input-type fiftyone.types.COCODetectionDataset \
    --input-dir ${COCO_VAL_DIR} \
    --input-kwargs max_samples=100 shuffle=True \
    --output-type fiftyone.types.TFImageClassificationDataset \
    --output-kwargs tf_records_path=/tmp/tf/coco/tf.records num_shards=5

ls -lah /tmp/tf/coco/

fiftyone convert \
    --input-type fiftyone.types.COCODetectionDataset \
    --input-dir ${COCO_VAL_DIR} \
    --input-kwargs max_samples=100 shuffle=True \
    --output-type fiftyone.types.TFObjectDetectionDataset \
    --output-dir /tmp/tf/coco \
    --overwrite

ls -lah /tmp/tf/coco/
```

Cleanup

```shell
rm -rf /tmp/color
rm -rf /tmp/grayscale
rm -rf /tmp/tf
```
