### PR TITLE
Adding a keep_fields() method

### DIFF
--- a/docs/source/user_guide/using_views.rst
+++ b/docs/source/user_guide/using_views.rst
@@ -709,15 +709,16 @@ in the sense that:
     :meth:`tag_labels() <fiftyone.core.collections.SampleCollection.tag_labels>`
     and :meth:`untag_labels() <fiftyone.core.collections.SampleCollection.untag_labels>`
     will be reflected on the source dataset
--   Any modifications to the |Label| elements in the patches view that you make
-    by iterating over the contents of the view or calling
+-   Any modifications to the patch labels that you make by iterating over the
+    contents of the view or calling
     :meth:`set_values() <fiftyone.core.collections.SampleCollection.set_values>`
     will be reflected on the source dataset
--   Calling :meth:`save() <fiftyone.core.patches.PatchesView.save>` or
-    :meth:`keep() <fiftyone.core.patches.PatchesView.keep>` on an object
+-   Calling :meth:`save() <fiftyone.core.patches.PatchesView.save>`,
+    :meth:`keep() <fiftyone.core.patches.PatchesView.keep>`, or
+    :meth:`keep_fields() <fiftyone.core.patches.PatchesView.keep_fields>` on a
     patches view (typically one that contains additional view stages that
-    filter or modify its contents) will sync any |Label| edits or deletions
-    with the source dataset
+    filter or modify its contents) will sync any edits or deletions to the
+    patch labels with the source dataset
 
 However, because object patches views only contain a subset of the contents of
 a |Sample| from the source dataset, there are some differences compared to
@@ -826,11 +827,12 @@ Evaluation patches views are just like any other
     calling
     :meth:`set_values() <fiftyone.core.collections.SampleCollection.set_values>`
     will be reflected on the source dataset
--   Calling :meth:`save() <fiftyone.core.patches.EvaluationPatchesView.save>`
-    or :meth:`keep() <fiftyone.core.patches.EvaluationPatchesView.keep>` on an
-    evaluation patches view (typically one that contains additional view stages
-    that filter or modify its contents) will sync any |Label| edits or
-    deletions with the source dataset
+-   Calling :meth:`save() <fiftyone.core.patches.EvaluationPatchesView.save>`,
+    :meth:`keep() <fiftyone.core.patches.EvaluationPatchesView.keep>`, or
+    :meth:`keep_fields() <fiftyone.core.patches.EvaluationPatchesView.keep_fields>`
+    on an evaluation patches view (typically one that contains additional view
+    stages that filter or modify its contents) will sync any predicted or
+    ground truth |Label| edits or deletions with the source dataset
 
 However, because evaluation patches views only contain a subset of the contents
 of a |Sample| from the source dataset, there are some differences compared to
@@ -1122,11 +1124,12 @@ sense that:
     by iterating over the contents of the view or calling
     :meth:`set_values() <fiftyone.core.collections.SampleCollection.set_values>`
     will be reflected on the source dataset
--   Calling :meth:`save() <fiftyone.core.clips.ClipsView.save>` or
-    :meth:`keep() <fiftyone.core.clips.ClipsView.keep>` on a clips view
-    (typically one that contains additional view stages that filter or modify
-    its contents) will sync any frame-level edits or deletions with the source
-    dataset
+-   Calling :meth:`save() <fiftyone.core.clips.ClipsView.save>`,
+    :meth:`keep() <fiftyone.core.clips.ClipsView.keep>`, or
+    :meth:`keep_fields() <fiftyone.core.clips.ClipsView.keep_fields>` on a
+    clips view (typically one that contains additional view stages that filter
+    or modify its contents) will sync any frame-level edits or deletions with
+    the source dataset
 
 However, because clip views represent only a subset of a |Sample| from the
 source dataset, there are some differences compared to non-clip views:
@@ -1281,11 +1284,12 @@ Frame views are just like any other image collection view in the sense that:
     contents of the view or calling
     :meth:`set_values() <fiftyone.core.collections.SampleCollection.set_values>`
     will be reflected on the source dataset
--   Calling :meth:`save() <fiftyone.core.video.FramesView.save>` or
-    :meth:`keep() <fiftyone.core.video.FramesView.keep>` on a frames view
-    (typically one that contains additional view stages that filter or modify
-    its contents) will sync any changes to the frames of the underlying video
-    dataset
+-   Calling :meth:`save() <fiftyone.core.video.FramesView.save>`,
+    :meth:`keep() <fiftyone.core.video.FramesView.keep>`, or
+    :meth:`keep_fields() <fiftyone.core.video.FramesView.keep_fields>` on a
+    frames view (typically one that contains additional view stages that filter
+    or modify its contents) will sync any changes to the frames of the
+    underlying video dataset
 
 The only way in which frames views differ from regular image collections is
 that changes to the ``tags`` or ``metadata`` fields of frame samples will not
@@ -1871,6 +1875,26 @@ samples from the underlying dataset that do not appear in a view you created:
 
     print(len(dataset))
     # 94
+
+and you can use
+:meth:`keep_fields() <fiftyone.core.view.DatasetView.keep_fields>`
+to delete any sample/frame fields from the underlying dataset that you have
+excluded from a view you created:
+
+.. code-block:: python
+    :linenos:
+
+    # Delete the `predictions` field
+    view = dataset.exclude_fields("predictions")
+    view.keep_fields()
+
+    print(dataset)
+
+    # Delete all non-default fields
+    view = dataset.select_fields()
+    view.keep_fields()
+
+    print(dataset)
 
 Alternatively, you can use
 :meth:`clone() <fiftyone.core.view.DatasetView.clone>` to create a new

--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -2138,6 +2138,19 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
 
         self._clear(view=clear_view)
 
+    def _keep_fields(self, view=None):
+        if view is None:
+            return
+
+        del_sample_fields = view._get_missing_fields()
+        if del_sample_fields:
+            self.delete_sample_fields(del_sample_fields)
+
+        if self.media_type == fom.VIDEO:
+            del_frame_fields = view._get_missing_fields(frames=True)
+            if del_frame_fields:
+                self.delete_frame_fields(del_frame_fields)
+
     def clear_frames(self):
         """Removes all frame labels from the video dataset.
 

--- a/fiftyone/core/patches.py
+++ b/fiftyone/core/patches.py
@@ -254,12 +254,9 @@ class _PatchesView(fov.DatasetView):
             it immediately writes the requested changes to the underlying
             dataset.
         """
-        del_fields = set(self._label_fields) - set(self.get_field_schema())
-        if del_fields:
-            self._dataset.delete_sample_fields(del_fields)
+        self._sync_source_keep_fields()
 
-            del_view = self._source_collection.exclude_fields(del_fields)
-            del_view.keep_fields()
+        super().keep_fields()
 
     def reload(self):
         """Reloads this view from the source collection in the database.
@@ -340,6 +337,13 @@ class _PatchesView(fov.DatasetView):
                 self._source_collection._delete_labels(
                     ids=del_ids, fields=field
                 )
+
+    def _sync_source_keep_fields(self):
+        src_schema = self.get_field_schema()
+
+        del_fields = set(self._label_fields) - set(src_schema.keys())
+        if del_fields:
+            self._source_collection.exclude_fields(del_fields).keep_fields()
 
 
 class PatchesView(_PatchesView):

--- a/fiftyone/core/video.py
+++ b/fiftyone/core/video.py
@@ -205,6 +205,28 @@ class FramesView(fov.DatasetView):
 
         super().keep()
 
+    def keep_fields(self):
+        """Deletes any sample fields that have been excluded in this view from
+        the frames of the underlying dataset.
+
+        .. note::
+
+            This method is not a :class:`fiftyone.core.stages.ViewStage`;
+            it immediately writes the requested changes to the underlying
+            dataset.
+        """
+        schema = self.get_field_schema()
+        src_schema = self._source_collection.get_frame_field_schema()
+
+        del_fields = set(src_schema.keys()) - set(schema.keys())
+        if del_fields:
+            self._dataset.delete_sample_fields(del_fields)
+
+            prefix = self._source_collection._FRAMES_PREFIX
+            del_frame_fields = [prefix + f for f in del_fields]
+            del_view = self._source_collection.exclude_fields(del_frame_fields)
+            del_view.keep_fields()
+
     def reload(self):
         """Reloads this view from the source collection in the database.
 
@@ -334,7 +356,7 @@ class FramesView(fov.DatasetView):
         src_schema = self._source_collection.get_frame_field_schema()
 
         add_fields = []
-        delete_fields = []
+        del_fields = []
 
         if fields is not None:
             # We're syncing specific fields; if they are not present in source
@@ -362,7 +384,7 @@ class FramesView(fov.DatasetView):
             if delete:
                 for field_name in src_schema.keys():
                     if field_name not in schema:
-                        delete_fields.append(field_name)
+                        del_fields.append(field_name)
 
         for field_name in add_fields:
             field_kwargs = foo.get_field_kwargs(schema[field_name])
@@ -371,7 +393,7 @@ class FramesView(fov.DatasetView):
             )
 
         if delete:
-            for field_name in delete_fields:
+            for field_name in del_fields:
                 self._source_collection._dataset.delete_frame_field(field_name)
 
 

--- a/fiftyone/core/video.py
+++ b/fiftyone/core/video.py
@@ -215,17 +215,9 @@ class FramesView(fov.DatasetView):
             it immediately writes the requested changes to the underlying
             dataset.
         """
-        schema = self.get_field_schema()
-        src_schema = self._source_collection.get_frame_field_schema()
+        self._sync_source_keep_fields()
 
-        del_fields = set(src_schema.keys()) - set(schema.keys())
-        if del_fields:
-            self._dataset.delete_sample_fields(del_fields)
-
-            prefix = self._source_collection._FRAMES_PREFIX
-            del_frame_fields = [prefix + f for f in del_fields]
-            del_view = self._source_collection.exclude_fields(del_frame_fields)
-            del_view.keep_fields()
+        super().keep_fields()
 
     def reload(self):
         """Reloads this view from the source collection in the database.
@@ -395,6 +387,16 @@ class FramesView(fov.DatasetView):
         if delete:
             for field_name in del_fields:
                 self._source_collection._dataset.delete_frame_field(field_name)
+
+    def _sync_source_keep_fields(self):
+        schema = self.get_field_schema()
+        src_schema = self._source_collection.get_frame_field_schema()
+
+        del_fields = set(src_schema.keys()) - set(schema.keys())
+        if del_fields:
+            prefix = self._source_collection._FRAMES_PREFIX
+            _del_fields = [prefix + f for f in del_fields]
+            self._source_collection.exclude_fields(_del_fields).keep_fields()
 
 
 def make_frames_dataset(

--- a/fiftyone/core/view.py
+++ b/fiftyone/core/view.py
@@ -627,6 +627,18 @@ class DatasetView(foc.SampleCollection):
         """
         self._dataset._keep(view=self)
 
+    def keep_fields(self):
+        """Deletes all fields that are excluded from the view from the
+        underlying dataset.
+
+        .. note::
+
+            This method is not a :class:`fiftyone.core.stages.ViewStage`;
+            it immediately writes the requested changes to the underlying
+            dataset.
+        """
+        self._dataset._keep_fields(view=self)
+
     def keep_frames(self):
         """For each sample in the view, deletes all frames labels that are
         **not** in the view from the underlying dataset.
@@ -899,6 +911,9 @@ class DatasetView(foc.SampleCollection):
 
     def _get_missing_fields(self, frames=False):
         if frames:
+            if self.media_type != fom.VIDEO:
+                return set()
+
             dataset_schema = self._dataset.get_frame_field_schema()
             view_schema = self.get_frame_field_schema()
         else:

--- a/tests/unittests/patches_tests.py
+++ b/tests/unittests/patches_tests.py
@@ -247,6 +247,19 @@ class PatchesTests(unittest.TestCase):
             dataset.count_values("ground_truth.detections.tags"), {}
         )
 
+        view.select_fields().keep_fields()
+
+        self.assertNotIn("ground_truth", view.get_field_schema())
+        self.assertNotIn("ground_truth", dataset.get_field_schema())
+
+        sample_view = view.first()
+        with self.assertRaises(KeyError):
+            sample_view["ground_truth"]
+
+        sample = dataset.first()
+        with self.assertRaises(KeyError):
+            sample["ground_truth"]
+
     @drop_datasets
     def test_to_evaluation_patches(self):
         dataset = fo.Dataset()
@@ -289,7 +302,9 @@ class PatchesTests(unittest.TestCase):
 
         dataset.add_sample(sample)
 
-        dataset.evaluate_detections("predictions", eval_key="eval")
+        dataset.evaluate_detections(
+            "predictions", gt_field="ground_truth", eval_key="eval"
+        )
 
         view = dataset.to_evaluation_patches("eval")
 
@@ -507,6 +522,29 @@ class PatchesTests(unittest.TestCase):
         self.assertDictEqual(
             dataset.count_values("ground_truth.detections.tags"), {}
         )
+
+        view.select_fields().keep_fields()
+
+        self.assertNotIn("ground_truth", view.get_field_schema())
+        self.assertNotIn("predictions", view.get_field_schema())
+        self.assertNotIn("ground_truth", dataset.get_field_schema())
+        self.assertNotIn("predictions", dataset.get_field_schema())
+
+        sample_view = view.first()
+
+        with self.assertRaises(KeyError):
+            sample_view["ground_truth"]
+
+        with self.assertRaises(KeyError):
+            sample_view["predictions"]
+
+        sample = dataset.first()
+
+        with self.assertRaises(KeyError):
+            sample["ground_truth"]
+
+        with self.assertRaises(KeyError):
+            sample["predictions"]
 
 
 if __name__ == "__main__":

--- a/tests/unittests/video_tests.py
+++ b/tests/unittests/video_tests.py
@@ -1188,15 +1188,7 @@ class VideoTests(unittest.TestCase):
 
         self.assertSetEqual(
             set(view.select_fields().get_field_schema().keys()),
-            {
-                "id",
-                "sample_id",
-                "filepath",
-                "support",
-                "metadata",
-                "tags",
-                "events",
-            },
+            {"id", "sample_id", "filepath", "support", "metadata", "tags"},
         )
 
         with self.assertRaises(ValueError):
@@ -1204,9 +1196,6 @@ class VideoTests(unittest.TestCase):
 
         with self.assertRaises(ValueError):
             view.exclude_fields("support")  # can't exclude default field
-
-        with self.assertRaises(ValueError):
-            view.exclude_fields("events")  # can't exclude default field
 
         index_info = view.get_index_information()
         indexes = view.list_indexes()
@@ -1360,6 +1349,32 @@ class VideoTests(unittest.TestCase):
         self.assertEqual(dataset.count_sample_tags(), {})
         self.assertEqual(view.count_sample_tags(), {})
 
+        view.exclude_fields("frames.hello").keep_fields()
+
+        self.assertNotIn("hello", view.get_frame_field_schema())
+        self.assertNotIn("hello", dataset.get_frame_field_schema())
+
+        frame_view = view.first().frames.first()
+        with self.assertRaises(KeyError):
+            frame_view["hello"]
+
+        frame = dataset.first().frames.first()
+        with self.assertRaises(KeyError):
+            frame["hello"]
+
+        view.select_fields().keep_fields()
+
+        self.assertNotIn("events", view.get_field_schema())
+        self.assertNotIn("events", dataset.get_field_schema())
+
+        sample_view = view.first()
+        with self.assertRaises(KeyError):
+            sample_view["events"]
+
+        sample = dataset.first()
+        with self.assertRaises(KeyError):
+            sample["events"]
+
     @drop_datasets
     def test_to_clips_expr(self):
         dataset = fo.Dataset()
@@ -1367,6 +1382,7 @@ class VideoTests(unittest.TestCase):
         sample1 = fo.Sample(
             filepath="video1.mp4",
             metadata=fo.VideoMetadata(total_frame_count=4),
+            hello="world",
         )
         sample1.frames[1] = fo.Frame(
             detections=fo.Detections(detections=[fo.Detection(label="cat")])
@@ -1386,6 +1402,7 @@ class VideoTests(unittest.TestCase):
         sample2 = fo.Sample(
             filepath="video2.mp4",
             metadata=fo.VideoMetadata(total_frame_count=5),
+            hello="there",
         )
         sample2.frames[2] = fo.Frame(
             detections=fo.Detections(
@@ -1431,6 +1448,29 @@ class VideoTests(unittest.TestCase):
             F("detections.detections").length() >= 2, min_len=2
         )
         self.assertListEqual(view.values("support"), [[2, 3]])
+
+        view = dataset.to_clips("frames.detections", other_fields=["hello"])
+        view.select_fields().keep_fields()
+
+        self.assertNotIn("detections", view.get_frame_field_schema())
+        self.assertNotIn("detections", dataset.get_frame_field_schema())
+
+        self.assertNotIn("hello", view.get_field_schema())
+        self.assertIn("hello", dataset.get_field_schema())
+
+        sample_view = view.first()
+        with self.assertRaises(KeyError):
+            sample_view["hello"]
+
+        frame_view = sample_view.frames.first()
+        with self.assertRaises(KeyError):
+            frame_view["detections"]
+
+        sample = dataset.first()
+        frame = sample.frames.first()
+        self.assertEqual(sample["hello"], "world")
+        with self.assertRaises(KeyError):
+            frame["detections"]
 
     @drop_datasets
     def test_to_frames(self):
@@ -1650,6 +1690,28 @@ class VideoTests(unittest.TestCase):
 
         self.assertEqual(dataset.count_sample_tags(), {})
         self.assertEqual(view.count_sample_tags(), {})
+
+        view.select_fields().keep_fields()
+
+        self.assertNotIn("hello", view.get_field_schema())
+        self.assertNotIn("ground_truth", view.get_field_schema())
+        self.assertNotIn("hello", dataset.get_frame_field_schema())
+        self.assertNotIn("ground_truth", dataset.get_frame_field_schema())
+
+        sample_view = view.last()
+        with self.assertRaises(KeyError):
+            sample_view["hello"]
+
+        with self.assertRaises(KeyError):
+            sample_view["ground_truth"]
+
+        sample = dataset.last()
+        frame = sample.frames.last()
+        with self.assertRaises(KeyError):
+            frame["hello"]
+
+        with self.assertRaises(KeyError):
+            frame["ground_truth"]
 
     @drop_datasets
     def test_to_frames_sparse(self):
@@ -1927,6 +1989,24 @@ class VideoTests(unittest.TestCase):
 
         self.assertEqual(dataset.count_sample_tags(), {})
         self.assertEqual(view.count_sample_tags(), {})
+
+        view.select_fields().keep_fields()
+
+        self.assertNotIn("ground_truth", view.get_field_schema())
+        self.assertNotIn("ground_truth", clips.get_frame_field_schema())
+        self.assertNotIn("ground_truth", dataset.get_frame_field_schema())
+
+        sample_view = view.last()
+        with self.assertRaises(KeyError):
+            sample_view["ground_truth"]
+
+        frame_view = clips.last().frames.last()
+        with self.assertRaises(KeyError):
+            frame_view["ground_truth"]
+
+        frame = dataset.last().frames.last()
+        with self.assertRaises(KeyError):
+            frame["ground_truth"]
 
     @drop_datasets
     def test_to_frame_patches(self):
@@ -2217,6 +2297,24 @@ class VideoTests(unittest.TestCase):
             dataset.count_values("frames.ground_truth.detections.tags"), {}
         )
 
+        patches.select_fields().keep_fields()
+
+        self.assertNotIn("ground_truth", patches.get_field_schema())
+        self.assertNotIn("ground_truth", frames.get_field_schema())
+        self.assertNotIn("ground_truth", dataset.get_frame_field_schema())
+
+        patch_view = patches.first()
+        with self.assertRaises(KeyError):
+            patch_view["ground_truth"]
+
+        frame_view = frames.first()
+        with self.assertRaises(KeyError):
+            frame_view["ground_truth"]
+
+        frame = dataset.first().frames.first()
+        with self.assertRaises(KeyError):
+            frame["ground_truth"]
+
     @drop_datasets
     def test_to_clip_frame_patches(self):
         dataset = fo.Dataset()
@@ -2401,6 +2499,29 @@ class VideoTests(unittest.TestCase):
         self.assertDictEqual(
             dataset.count_values("frames.ground_truth.detections.tags"), {}
         )
+
+        patches.select_fields().keep_fields()
+
+        self.assertNotIn("ground_truth", patches.get_field_schema())
+        self.assertNotIn("ground_truth", frames.get_field_schema())
+        self.assertNotIn("ground_truth", clips.get_frame_field_schema())
+        self.assertNotIn("ground_truth", dataset.get_frame_field_schema())
+
+        patch_view = patches.first()
+        with self.assertRaises(KeyError):
+            patch_view["ground_truth"]
+
+        frame_view = frames.first()
+        with self.assertRaises(KeyError):
+            frame_view["ground_truth"]
+
+        clip_frame_view = clips.first().frames.first()
+        with self.assertRaises(KeyError):
+            clip_frame_view["ground_truth"]
+
+        frame = dataset.first().frames.first()
+        with self.assertRaises(KeyError):
+            frame["ground_truth"]
 
 
 if __name__ == "__main__":

--- a/tests/unittests/view_tests.py
+++ b/tests/unittests/view_tests.py
@@ -1082,6 +1082,37 @@ class ViewSaveTest(unittest.TestCase):
         self.assertIsNone(frame12.id)
         self.assertIsNotNone(frame22.id)
 
+    def test_view_keep_fields(self):
+        dataset = self.dataset
+
+        view = dataset.exclude_fields("classifications")
+        view.keep_fields()
+
+        self.assertNotIn("classifications", view.get_field_schema())
+        self.assertNotIn("classifications", dataset.get_field_schema())
+
+        sample_view = view.first()
+        with self.assertRaises(KeyError):
+            sample_view["classifications"]
+
+        sample = dataset.first()
+        with self.assertRaises(KeyError):
+            sample["classifications"]
+
+        view = dataset.select_fields()
+        view.keep_fields()
+
+        self.assertNotIn("int_field", view.get_field_schema())
+        self.assertNotIn("int_field", dataset.get_field_schema())
+
+        sample_view = view.first()
+        with self.assertRaises(KeyError):
+            sample_view["int_field"]
+
+        sample = dataset.first()
+        with self.assertRaises(KeyError):
+            sample["int_field"]
+
 
 class ViewStageTests(unittest.TestCase):
     @drop_datasets


### PR DESCRIPTION
Adds a `keep_fields()` method to `DatasetView` and its subclasses that complements the existing `save()` and `keep()` methods:
- `view.save()`: saves the **contents** of (only) the samples/fields in the view to the source dataset
- `view.keep()`: deletes all **samples** not in the view from the source dataset
- `view.keep_fields()`: deletes all **fields** not in the view from the source dataset's schema

The behavior of `keep_fields()` for patch/frame/clip views is a bit subtle, but things are implemented in a logically consistent way. For example, calling `keep_fields()` on a frames view will delete fields from the *sample schema* of the frames view but the *frame schema* of the source video dataset.

## Example usage

```py
import fiftyone as fo
import fiftyone.zoo as foz

dataset = foz.load_zoo_dataset("quickstart")

# Delete all non-default fields
dataset1 = dataset.clone()
dataset1.select_fields().keep_fields()
print(dataset1)
print(dataset1.first())

# Deletes the `predictions` field from the source dataset
dataset2 = dataset.clone()
patches = dataset2.to_patches("predictions")
patches.select_fields().keep_fields()
print(patches)
print(dataset2)
print(patches.first())
print(dataset2.first())

dataset = foz.load_zoo_dataset("quickstart-video")

# Delete all non-default sample and frame fields from the source dataset
dataset1 = dataset.clone()
dataset1.select_fields().keep_fields()
print(dataset1)
print(dataset1.first())
print(dataset1.first().frames.first())

# Deletes all non-default *frame* fields from the source dataset
dataset2 = dataset.clone()
frames = dataset2.to_frames(sample_frames=True)
frames.select_fields().keep_fields()
print(frames)
print(dataset2)
print(frames.first())
print(dataset2.first())
print(dataset2.first().frames.first())

# Deletes all non-default frame fields from the source dataset
dataset3 = dataset.clone()
clips = dataset3.to_clips("frames.detections")
clips.select_fields().keep_fields()
print(clips)
print(dataset3)
print(clips.first())
print(clips.first().frames.first())
print(dataset3.first())
print(dataset3.first().frames.first())
```

