### PR TITLE
Use full video support in draw_labels()

### DIFF
--- a/fiftyone/core/metadata.py
+++ b/fiftyone/core/metadata.py
@@ -209,14 +209,18 @@ class VideoMetadata(Metadata):
         )
 
 
-def compute_sample_metadata(sample, skip_failures=False):
+def compute_sample_metadata(sample, overwrite=False, skip_failures=False):
     """Populates the ``metadata`` field of the sample.
 
     Args:
         sample: a :class:`fiftyone.core.sample.Sample`
+        overwrite (False): whether to overwrite existing metadata
         skip_failures (False): whether to gracefully continue without raising
             an error if metadata cannot be computed
     """
+    if not overwrite and sample.metadata is not None:
+        return
+
     sample.metadata = _compute_sample_metadata(
         sample.filepath, sample.media_type, skip_failures=skip_failures
     )

--- a/fiftyone/core/sample.py
+++ b/fiftyone/core/sample.py
@@ -102,14 +102,17 @@ class _SampleMixin(object):
 
         super().clear_field(field_name)
 
-    def compute_metadata(self, skip_failures=False):
+    def compute_metadata(self, overwrite=False, skip_failures=False):
         """Populates the ``metadata`` field of the sample.
 
         Args:
+            overwrite (False): whether to overwrite existing metadata
             skip_failures (False): whether to gracefully continue without
                 raising an error if metadata cannot be computed
         """
-        fom.compute_sample_metadata(self, skip_failures=skip_failures)
+        fom.compute_sample_metadata(
+            self, overwrite=overwrite, skip_failures=skip_failures
+        )
 
     def add_labels(
         self, labels, label_field, confidence_thresh=None, expand_schema=True

--- a/fiftyone/utils/annotations.py
+++ b/fiftyone/utils/annotations.py
@@ -2284,10 +2284,19 @@ def _to_video_labels(sample, label_fields=None):
     else:
         frame_label_fields = None
 
+    if isinstance(sample, foc.ClipView):
+        support = sample.support
+    else:
+        metadata = sample.metadata
+        if metadata is None:
+            metadata = fom.VideoMetadata.build_for(sample.filepath)
+
+        support = [1, metadata.total_frame_count]
+
     label = _get_sample_labels(sample, label_fields)
     frames = _get_frame_labels(sample, frame_label_fields)
 
-    return foue.to_video_labels(label=label, frames=frames)
+    return foue.to_video_labels(label=label, frames=frames, support=support)
 
 
 def _get_sample_labels(sample, label_fields):

--- a/fiftyone/utils/annotations.py
+++ b/fiftyone/utils/annotations.py
@@ -24,7 +24,8 @@ import fiftyone.core.clips as foc
 from fiftyone.core.expressions import ViewField as F
 import fiftyone.core.fields as fof
 import fiftyone.core.labels as fol
-import fiftyone.core.media as fom
+import fiftyone.core.media as fomm
+import fiftyone.core.metadata as fom
 import fiftyone.core.utils as fou
 import fiftyone.core.validation as fov
 import fiftyone.utils.eta as foue
@@ -378,7 +379,7 @@ def _build_label_schema(
 
     _label_schema = {}
 
-    is_video = samples.media_type == fom.VIDEO
+    is_video = samples.media_type == fomm.VIDEO
 
     for _label_field, _label_info in label_schema.items():
         (
@@ -1071,7 +1072,7 @@ def load_annotations(
 
 
 def _handle_frame_fields(field, samples, ref_field):
-    if samples.media_type != fom.VIDEO:
+    if samples.media_type != fomm.VIDEO:
         return field
 
     if (
@@ -1131,7 +1132,7 @@ def _prompt_field(samples, label_type, label_field, label_schema):
     if label_field is not None:
         _, is_frame_field = samples._handle_frame_field(label_field)
     else:
-        is_frame_field = samples.media_type == fom.VIDEO
+        is_frame_field = samples.media_type == fomm.VIDEO
 
     if is_frame_field:
         schema = samples.get_frame_field_schema()
@@ -1305,7 +1306,7 @@ def _merge_labels(
 
     _ensure_label_field(samples, label_field, fo_label_type)
 
-    is_video = samples.media_type == fom.VIDEO
+    is_video = samples.media_type == fomm.VIDEO
 
     if is_video and label_type in _TRACKABLE_TYPES:
         if not existing_field:
@@ -2238,13 +2239,17 @@ def draw_labeled_videos(samples, output_dir, label_fields=None, config=None):
     return outpaths
 
 
-def draw_labeled_video(sample, outpath, label_fields=None, config=None):
+def draw_labeled_video(
+    sample, outpath, support=None, label_fields=None, config=None
+):
     """Renders an annotated version of the sample's video with the specified
     label data overlaid to disk.
 
     Args:
         sample: a :class:`fiftyone.core.sample.Sample`
         outpath: the path to write the annotated image
+        support (None): an optional ``[first, last]`` range of frames to
+            render
         label_fields (None): a list of label fields to render. If omitted, all
             compatiable fields are rendered
         config (None): an optional :class:`DrawConfig` configuring how to draw
@@ -2256,10 +2261,8 @@ def draw_labeled_video(sample, outpath, label_fields=None, config=None):
     video_path = sample.filepath
     video_labels = _to_video_labels(sample, label_fields=label_fields)
 
-    if isinstance(sample, foc.ClipView):
+    if support is None and isinstance(sample, foc.ClipView):
         support = sample.support
-    else:
-        support = None
 
     etaa.annotate_video(
         video_path,

--- a/fiftyone/utils/eta.py
+++ b/fiftyone/utils/eta.py
@@ -462,7 +462,9 @@ def from_video_labels(
     return label, frames
 
 
-def to_video_labels(label=None, frames=None, warn_unsupported=True):
+def to_video_labels(
+    label=None, frames=None, support=None, warn_unsupported=True
+):
     """Converts the given labels to ``eta.core.video.VideoLabels`` format.
 
     Args:
@@ -472,13 +474,18 @@ def to_video_labels(label=None, frames=None, warn_unsupported=True):
         frames (None): frame-level labels provided as a dict mapping frame
             numbers to dicts mapping field names to
             :class:`fiftyone.core.labels.Label` instances
+        support (None): an optional ``[first, last]`` support to store on the
+            returned labels
         warn_unsupported (True): whether to issue warnings if unsupported label
             values are encountered
 
     Returns:
         a ``eta.core.video.VideoLabels``
     """
-    video_labels = etav.VideoLabels()
+    if support is not None:
+        support = etafu.FrameRanges.build_simple(*support)
+
+    video_labels = etav.VideoLabels(support=support)
 
     # Video labels
     if label is not None:


### PR DESCRIPTION
Resolves https://github.com/voxel51/eta/issues/555.

Previously, the example below would not render the video-level attribute on the video because video-level attributes were only added to frames that have (possibly empty) `Frame` instances.

Now, video-level attributes will always be rendered on frames `1, 2, ..., sample.metadata.total_frame_count`.

```py
import fiftyone as fo
import fiftyone.utils.annotations as foua

sample = fo.Sample(filepath="/Users/Brian/Desktop/water.mp4")
sample["weather"] = fo.Classification(label="sunny")

foua.draw_labeled_video(sample, "/tmp/labeled.mp4")
```
