### PR TITLE
Add argument to link issue tracker to CVAT tasks

### DIFF
--- a/docs/source/integrations/cvat.rst
+++ b/docs/source/integrations/cvat.rst
@@ -480,7 +480,7 @@ provided:
 -   **chunk_size** (*None*): the number of frames to upload per ZIP chunk
 -   **task_assignee** (*None*): the username to assign the generated tasks.
     This argument can be a list of usernames when annotating videos as each
-    video is uploaded to a separate task 
+    video is uploaded to a separate task
 -   **job_assignees** (*None*): a list of usernames to assign jobs
 -   **job_reviewers** (*None*): a list of usernames to assign job reviews
 -   **project_name** (*None*): an optional project name to which to upload the
@@ -491,6 +491,9 @@ provided:
 -   **occluded_attr** (*None*): an optional attribute name containing existing
     occluded values and/or in which to store downloaded occluded values for all
     objects in the annotation run
+-   **issue_tracker** (*None*): URL(s) of an issue tracker to link to the
+    created task(s). This argument can be a list of URLs when annotating videos
+    or when using `task_size` and generating multiple tasks
 
 .. _cvat-label-schema:
 
@@ -1639,7 +1642,7 @@ specify which users will be assigned to the created tasks:
 -   `segment_size`: the maximum number of images to include in a single job
 -   `task_assignee`: a username to assign the generated tasks. This argument
     can be a list of usernames when annotating videos as each
-    video is uploaded to a separate task 
+    video is uploaded to a separate task
 -   `job_assignees`: a list of usernames to assign jobs
 -   `job_reviewers`: a list of usernames to assign job reviews
 


### PR DESCRIPTION
CVAT provides the ability to link a task to the arbitrary URL of an issue tracker. This PR exposes the `issue_tracker` argument when annotating with the CVAT backend to pass in one or more URL strings to attach to the created task(s).

![image](https://user-images.githubusercontent.com/21222883/156228779-d8df4119-666b-4a63-9d2d-5a9a65b0654b.png)


## Example

```python
import fiftyone as fo
import fiftyone.zoo as foz

dataset = foz.load_zoo_dataset("quickstart", max_samples=1).clone()

dataset.annotate(
    "anno_key",
    label_field="ground_truth",
    issue_tracker="https://fiftyone.ai",
    launch_editor=True,
)

dataset.load_annotations("anno_key", cleanup=True)
```

