### PR TITLE
ViewExpression slice updates

### DIFF
--- a/fiftyone/core/aggregations.py
+++ b/fiftyone/core/aggregations.py
@@ -1704,7 +1704,7 @@ def _parse_field_and_expr(
     if field_name is None:
         field_name, expr = _extract_prefix_from_expr(expr)
 
-    root = "." not in field_name
+    root = True if not field_name else "." not in field_name
     found_expr = expr is not None
 
     field_type = _get_field_type(
@@ -1952,6 +1952,9 @@ def _remove_prefix(expr, prefix):
 
 
 def _get_field_type(sample_collection, field_name, unwind=True):
+    if field_name is None:
+        return None
+
     # Remove array references
     field_name = "".join(field_name.split("[]"))
 

--- a/fiftyone/core/aggregations.py
+++ b/fiftyone/core/aggregations.py
@@ -1704,12 +1704,16 @@ def _parse_field_and_expr(
     if field_name is None:
         field_name, expr = _extract_prefix_from_expr(expr)
 
-    root = True if not field_name else "." not in field_name
-    found_expr = expr is not None
+    if field_name is None:
+        root = True
+        field_type = None
+    else:
+        root = "." not in field_name
+        field_type = _get_field_type(
+            sample_collection, field_name, unwind=auto_unwind
+        )
 
-    field_type = _get_field_type(
-        sample_collection, field_name, unwind=auto_unwind
-    )
+    found_expr = expr is not None
 
     if safe:
         expr = _to_safe_expr(expr, field_type)
@@ -1952,9 +1956,6 @@ def _remove_prefix(expr, prefix):
 
 
 def _get_field_type(sample_collection, field_name, unwind=True):
-    if field_name is None:
-        return None
-
     # Remove array references
     field_name = "".join(field_name.split("[]"))
 

--- a/fiftyone/core/expressions.py
+++ b/fiftyone/core/expressions.py
@@ -2214,6 +2214,13 @@ class ViewExpression(object):
                 "Unsupported slice '%s'; step is not supported" % s
             )
 
+        # @todo could optimize this slightly (~10% based on rough benchmarks)
+        # if the `if_else()` calls were replaced by explicit logic when
+        # start/stop are numbers, not expressions
+
+        # @todo slices like `x[-a:b]` where sign(a) != sign(b) are not
+        # currently working
+
         if s.start is not None:
             position = s.start
             if s.stop is None:

--- a/tests/unittests/view_tests.py
+++ b/tests/unittests/view_tests.py
@@ -444,18 +444,21 @@ class ViewExpressionTests(unittest.TestCase):
                     tags=["train"],
                     my_int=5,
                     my_list=["a", "b"],
+                    my_int_list=list(range(8)),
                 ),
                 fo.Sample(
                     filepath="filepath2.jpg",
                     tags=["train"],
                     my_int=6,
                     my_list=["b", "c"],
+                    my_int_list=list(range(10)),
                 ),
                 fo.Sample(
                     filepath="filepath3.jpg",
                     tags=["test"],
                     my_int=7,
                     my_list=["c", "d"],
+                    my_int_list=list(range(10)),
                 ),
             ]
         )
@@ -474,7 +477,7 @@ class ViewExpressionTests(unittest.TestCase):
         view = dataset.match(F("my_int").is_in(my_ints))
         self.assertListEqual([sample.id for sample in view], manual_ids)
 
-        # test __getitem__
+        # test __getitem__ integer index
         idx = 1
         value = "c"
         manual_ids = [
@@ -482,6 +485,37 @@ class ViewExpressionTests(unittest.TestCase):
         ]
         view = dataset.match(F("my_list")[idx] == value)
         self.assertListEqual([sample.id for sample in view], manual_ids)
+
+        # test __getitem__ expression index
+        manual_index = [
+            sample.my_int_list[sample.my_int] for sample in dataset
+        ]
+        index = dataset.values(F("my_int_list")[F("my_int")])
+        self.assertListEqual(index, manual_index)
+
+        # test __getitem__ slice to stop
+        manual_slices = [
+            sample.my_int_list[: sample.my_int] for sample in dataset
+        ]
+        slices = dataset.values(F("my_int_list")[: F("my_int")])
+        self.assertListEqual(slices, manual_slices)
+
+        # test __getitem__ slice from start
+        manual_slices = [
+            sample.my_int_list[sample.my_int :] for sample in dataset
+        ]
+        slices = dataset.values(F("my_int_list")[F("my_int") :])
+        self.assertListEqual(slices, manual_slices)
+
+        # test __getitem__ slice start to stop
+        manual_slices = [
+            sample.my_int_list[sample.my_int - 1 : sample.my_int]
+            for sample in dataset
+        ]
+        slices = dataset.values(
+            F("my_int_list")[F("my_int") - 1 : F("my_int")]
+        )
+        self.assertListEqual(slices, manual_slices)
 
     @drop_datasets
     def test_str(self):


### PR DESCRIPTION
This PR adds the ability to slice by ViewFields and fixes a bug with expressions.


# TODO

Figure out why unwinding produces different results:
```python
import fiftyone as fo
from fiftyone import ViewField as F

dataset = fo.Dataset()
sample = fo.Sample(
    filepath="test.png",
    slice_size=5,
    test_list=list(range(10)),
)
dataset.add_sample(sample)

print(dataset.values(F("test_list")[:5], unwind=True))
# [0, 1, 2, 3, 4]

print(dataset.values(F("test_list")[:F("slice_size")], unwind=True))
# [[0, 1, 2, 3, 4]]
```

## Examples

Slicing by ViewFields:

```python
import fiftyone as fo
from fiftyone import ViewField as F

dataset = fo.Dataset()
sample = fo.Sample(
    filepath="test.png",
    slice_size=5,
    test_list=list(range(10)),
)
dataset.add_sample(sample)

print(dataset.values(F("test_list")[:5]))
print(dataset.values(F("test_list")[4:5]))
print(dataset.values(F("test_list")[5:4]))
print(dataset.values(F("test_list")[5:]))
print(dataset.values(F("test_list")[5]))
# [[0, 1, 2, 3, 4]]
# [[4]]
# [[]]
# [[5, 6, 7, 8, 9]]
# [5]

print(dataset.values(F("test_list")[:F("slice_size")]))
print(dataset.values(F("test_list")[F("slice_size")-1:F("slice_size")]))
print(dataset.values(F("test_list")[F("slice_size"):F("slice_size")-1]))
print(dataset.values(F("test_list")[F("slice_size"):]))
print(dataset.values(F("test_list")[F("slice_size")]))
# [[0, 1, 2, 3, 4]]
# [[4]]
# [[]]
# [[5, 6, 7, 8, 9]]
# [5]
```

Bug fix:
```python
import fiftyone as fo
from fiftyone import ViewField as F
from fiftyone import ViewExpression as E

dataset = fo.Dataset()

sample1 = fo.Sample(
    filepath="file1.png",
    field1=0,
    field2="a",
)

sample2 = fo.Sample(
    filepath="file1.png",
    field1=1,
    field2="a",
)

dataset.add_samples([sample1, sample2])

print(dataset.distinct(E([F("field1"), F("field2")])))
```

Previously raised:
```
Traceback (most recent call last):
  File "distinct.py", line 21, in <module>
    print(dataset.distinct(E([F("field1"), F("field2")])))
  File "/home/eric/work/fiftyone/fiftyone/fiftyone/core/collections.py", line 5397, in distinct
    return self._make_and_aggregate(make, field_or_expr)
  File "/home/eric/work/fiftyone/fiftyone/fiftyone/core/collections.py", line 7018, in _make_and_aggregate
    return self.aggregate(make(args))
  File "/home/eric/work/fiftyone/fiftyone/fiftyone/core/collections.py", line 6830, in aggregate
    facet_pipelines = self._build_faceted_pipelines(facet_aggs)
  File "/home/eric/work/fiftyone/fiftyone/fiftyone/core/collections.py", line 6947, in _build_faceted_pipelines
    pipeline=aggregation.to_mongo(self),
  File "/home/eric/work/fiftyone/fiftyone/fiftyone/core/aggregations.py", line 771, in to_mongo
    safe=self._safe,
  File "/home/eric/work/fiftyone/fiftyone/fiftyone/core/aggregations.py", line 1707, in _parse_field_and_expr
    root = "." not in field_name
TypeError: argument of type 'NoneType' is not iterable
```