### PR TITLE
in TFExampleGenerator, remove alpha channel if force_rgb=True

### DIFF
--- a/fiftyone/utils/tf.py
+++ b/fiftyone/utils/tf.py
@@ -23,6 +23,8 @@ import fiftyone.core.metadata as fom
 import fiftyone.core.utils as fou
 import fiftyone.utils.data as foud
 
+from skimage.color import rgba2rgb
+
 fou.ensure_tf(eager=True)
 import tensorflow as tf
 
@@ -942,6 +944,8 @@ class TFExampleGenerator(object):
 
             if self.force_rgb and img.shape[2] == 1:
                 img = img.repeat(3, axis=2)
+            elif self.force_rgb and img.shape[2] == 4:
+                img = rgba2rgb(img)
 
             if filename.endswith((".jpg", ".jpeg")):
                 img_bytes = tf.image.encode_jpeg(img)


### PR DESCRIPTION
## What changes are proposed in this pull request?

Simple modification to enable TFExampleGenerator to remove alpha channel if `force_rgb=True`. This addresses a current bug where attempting to export the patches of 4-channel images errors even if `force_rgb=True`.

## How is this patch tested? If it is not, please explain why.

I have not implemented automatic tests.

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?
-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
