### PR TITLE
Frame expressions fix

### DIFF
--- a/fiftyone/core/aggregations.py
+++ b/fiftyone/core/aggregations.py
@@ -144,12 +144,16 @@ class Aggregation(object):
         Returns:
             True/False
         """
-        if self._field_name is not None:
-            return _is_frame_path(sample_collection, self._field_name)
+        if sample_collection.media_type != fom.VIDEO:
+            return False
 
-        if self._expr is not None:
-            field_name, _ = _extract_prefix_from_expr(self._expr)
-            return _is_frame_path(sample_collection, field_name)
+        if self._field_name is not None:
+            expr = F(self._field_name)
+        else:
+            expr = self._expr
+
+        if expr is not None:
+            return foe.is_frames_expr(expr)
 
         return False
 
@@ -1617,16 +1621,6 @@ class Values(Aggregation):
         )
 
         return pipeline
-
-
-def _is_frame_path(sample_collection, field_name):
-    if not field_name:
-        return False
-
-    # Remove array references
-    path = "".join(field_name.split("[]"))
-
-    return sample_collection._is_frame_field(path)
 
 
 def _transform_values(values, fcn, level=1):

--- a/fiftyone/core/expressions.py
+++ b/fiftyone/core/expressions.py
@@ -60,7 +60,11 @@ def is_frames_expr(expr):
         expr = expr.to_mongo()
 
     if etau.is_str(expr):
-        return expr == "$frames" or expr.startswith("$frames.")
+        return (
+            expr == "$frames"
+            or expr.startswith("$frames.")
+            or expr.startswith("$frames[].")
+        )
 
     if isinstance(expr, dict):
         for k, v in expr.items():


### PR DESCRIPTION
Fixes a bug that prevented frames from being attached to video collections when aggregating expressions like the following:

```py
values = dataset.values((F("field") > 0) | (F("frames").length() > 10))
```

that involve both sample-level and frame-level fields.

A unit test is added to verify correct behavior going forward.