### PR TITLE
Resolve bug when annotating views with mapped labels

### DIFF
--- a/fiftyone/utils/annotations.py
+++ b/fiftyone/utils/annotations.py
@@ -769,10 +769,6 @@ def _get_classes(
     if classes:
         return classes
 
-    return _get_existing_classes(samples, label_field)
-
-
-def _get_existing_classes(samples, label_field):
     _, label_path = samples._get_label_field_path(label_field, "label")
     return sorted(
         set(samples._dataset.distinct(label_path))
@@ -1054,7 +1050,7 @@ def load_annotations(
                         _merge_scalars(samples, annos, results, new_field)
                     else:
                         _merge_labels(
-                            samples, annos, results, new_field, anno_type,
+                            samples, annos, results, new_field, anno_type
                         )
                 else:
                     if label_field:
@@ -1543,7 +1539,7 @@ def _merge_label(
     only_keyframes=False,
 ):
     for field in _DEFAULT_LABEL_FIELDS_MAP.get(type(label), []):
-        if field == "label" and not allow_label_edits:
+        if not allow_label_edits and field == "label":
             continue
 
         if not allow_index_edits and field == "index":

--- a/fiftyone/utils/annotations.py
+++ b/fiftyone/utils/annotations.py
@@ -26,7 +26,6 @@ import fiftyone.core.fields as fof
 import fiftyone.core.labels as fol
 import fiftyone.core.media as fomm
 import fiftyone.core.metadata as fom
-import fiftyone.core.stages as fos
 import fiftyone.core.utils as fou
 import fiftyone.core.validation as fov
 import fiftyone.utils.eta as foue


### PR DESCRIPTION
When creating an annotation task, there is currently a bug where views using the `MapLabels` stage will result in labels that were mapped not being uploaded to the annotation backend. This PR ensures that labels that were mapped are uploaded and that the mapping is reversed upon loading the annotated labels.

This is only applicable for labels where the class was not modified, any labels that were created or the class was modified will use the mapped class name. This is because a label mapping can result in multiple class names mapped to one, so there is no way to reverse the mapping for labels that were changed or created.

## Example

```python
import fiftyone as fo
import fiftyone.zoo as foz

dataset = (
    foz.load_zoo_dataset("quickstart", max_samples=1)
    .select_fields("ground_truth")
    .clone()
)

labels = dataset.distinct("ground_truth.detections.label")
label_map = {l: l.upper() for l in labels}

view = dataset.map_labels("ground_truth", label_map)

anno_key = "anno_key"
results = view.annotate(
    anno_key, backend="cvat", label_field="ground_truth",
)

# Create/delete/modify a detection

dataset.load_annotations(anno_key, cleanup=True)

print(dataset.values("ground_truth.detections.label"))
# ["BIRD", "bird"]
```

The newly created label has the class name "BIRD" and the unmodified labels are unmapped back to "bird".