### PR TITLE
Add note about outdated metadata in transform_images

### DIFF
--- a/fiftyone/utils/image.py
+++ b/fiftyone/utils/image.py
@@ -74,6 +74,15 @@ def transform_images(
     The ``filepath`` of the samples are updated to point to the transformed
     images.
 
+    .. note::
+
+        This method will not update any outdated metadata fields on the collection
+        after resizing. This can cause annotations to show in the wrong place. To avoid
+        this, the recommended approach is to call:
+
+            sample_collection.compute_metadata(overwrite=True)
+
+
     Args:
         sample_collection: a
             :class:`fiftyone.core.collections.SampleCollection`

--- a/fiftyone/utils/image.py
+++ b/fiftyone/utils/image.py
@@ -76,9 +76,9 @@ def transform_images(
 
     .. note::
 
-        This method will not update any outdated metadata fields on the collection
-        after resizing. This can cause annotations to show in the wrong place. To avoid
-        this, the recommended approach is to call:
+        This method will not update any outdated metadata fields on the
+        collection after resizing. This can cause annotations to show in the
+        wrong place. To avoid this, the recommended approach is to call::
 
             sample_collection.compute_metadata(overwrite=True)
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

Add documentation about outdated metadata after resizing images with `transform_images`.

## How is this patch tested? If it is not, please explain why.

Not tested. It's documentation only. Please LMK if the format is off.

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [x] Documentation: FiftyOne documentation changes
-   [ ] Other
