### PR TITLE
Adding a delete_frames() method

### DIFF
--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -2335,10 +2335,9 @@ class SampleCollection(object):
                 -   an iterable of sample IDs
                 -   a :class:`fiftyone.core.sample.Sample` or
                     :class:`fiftyone.core.sample.SampleView`
-                -   an iterable of sample IDs
-                -   a :class:`fiftyone.core.collections.SampleCollection`
                 -   an iterable of :class:`fiftyone.core.sample.Sample` or
                     :class:`fiftyone.core.sample.SampleView` instances
+                -   a :class:`fiftyone.core.collections.SampleCollection`
 
         Returns:
             a :class:`fiftyone.core.view.DatasetView`
@@ -2473,8 +2472,8 @@ class SampleCollection(object):
                     :class:`fiftyone.core.frame.FrameView`
                 -   an iterable of :class:`fiftyone.core.frame.Frame` or
                     :class:`fiftyone.core.frame.FrameView` instances
-                -   a :class:`fiftyone.core.collections.SampleCollection`, in
-                    which case the frame IDs in the collection are used
+                -   a :class:`fiftyone.core.collections.SampleCollection` whose
+                    frames to exclude
 
             omit_empty (True): whether to omit samples that have no frames
                 after excluding the specified frames
@@ -4129,10 +4128,9 @@ class SampleCollection(object):
                     encoding which samples to select
                 -   a :class:`fiftyone.core.sample.Sample` or
                     :class:`fiftyone.core.sample.SampleView`
-                -   an iterable of sample IDs
-                -   a :class:`fiftyone.core.collections.SampleCollection`
                 -   an iterable of :class:`fiftyone.core.sample.Sample` or
                     :class:`fiftyone.core.sample.SampleView` instances
+                -   a :class:`fiftyone.core.collections.SampleCollection`
 
         ordered (False): whether to sort the samples in the returned view to
             match the order of the provided IDs
@@ -4285,8 +4283,8 @@ class SampleCollection(object):
                     :class:`fiftyone.core.frame.FrameView`
                 -   an iterable of :class:`fiftyone.core.frame.Frame` or
                     :class:`fiftyone.core.frame.FrameView` instances
-                -   a :class:`fiftyone.core.collections.SampleCollection`, in
-                    which case the frame IDs in the collection are used
+                -   a :class:`fiftyone.core.collections.SampleCollection`
+                    whose frames to select
 
             omit_empty (True): whether to omit samples that have no frames
                 after selecting the specified frames

--- a/fiftyone/core/document.py
+++ b/fiftyone/core/document.py
@@ -109,6 +109,13 @@ class _Document(object):
         return self._dataset
 
     @property
+    def _collection(self):
+        """The collection from which this sample was taken, or ``None`` if the
+        document is not in a dataset.
+        """
+        return self._dataset
+
+    @property
     def field_names(self):
         """An ordered tuple of the names of the fields of this document."""
         return self._doc.field_names
@@ -626,6 +633,10 @@ class DocumentView(_Document):
             select_fields=select_fields,
             exclude_fields=self._excluded_fields,
         )
+
+    @property
+    def _collection(self):
+        return self._view
 
     @property
     def field_names(self):

--- a/fiftyone/core/document.py
+++ b/fiftyone/core/document.py
@@ -110,8 +110,8 @@ class _Document(object):
 
     @property
     def _collection(self):
-        """The collection from which this sample was taken, or ``None`` if the
-        document is not in a dataset.
+        """The :class:`fiftyone.core.collections.SampleCollection` from which
+        this document was taken, or ``None`` if it is not in a dataset.
         """
         return self._dataset
 

--- a/fiftyone/core/stages.py
+++ b/fiftyone/core/stages.py
@@ -311,10 +311,9 @@ class Exclude(ViewStage):
             -   an iterable of sample IDs
             -   a :class:`fiftyone.core.sample.Sample` or
                 :class:`fiftyone.core.sample.SampleView`
-            -   an iterable of sample IDs
-            -   a :class:`fiftyone.core.collections.SampleCollection`
             -   an iterable of :class:`fiftyone.core.sample.Sample` or
                 :class:`fiftyone.core.sample.SampleView` instances
+            -   a :class:`fiftyone.core.collections.SampleCollection`
     """
 
     def __init__(self, sample_ids):
@@ -620,8 +619,8 @@ class ExcludeFrames(ViewStage):
                 :class:`fiftyone.core.frame.FrameView`
             -   an iterable of :class:`fiftyone.core.frame.Frame` or
                 :class:`fiftyone.core.frame.FrameView` instances
-            -   a :class:`fiftyone.core.collections.SampleCollection`, in which
-                case the frame IDs in the collection are used
+            -   a :class:`fiftyone.core.collections.SampleCollection` whose
+                frames to exclude
 
         omit_empty (True): whether to omit samples that have no frames after
             excluding the specified frames
@@ -4036,10 +4035,9 @@ class Select(ViewStage):
                 encoding which samples to select
             -   a :class:`fiftyone.core.sample.Sample` or
                 :class:`fiftyone.core.sample.SampleView`
-            -   an iterable of sample IDs
-            -   a :class:`fiftyone.core.collections.SampleCollection`
             -   an iterable of :class:`fiftyone.core.sample.Sample` or
                 :class:`fiftyone.core.sample.SampleView` instances
+            -   a :class:`fiftyone.core.collections.SampleCollection`
 
         ordered (False): whether to sort the samples in the returned view to
             match the order of the provided IDs
@@ -4423,8 +4421,8 @@ class SelectFrames(ViewStage):
                 :class:`fiftyone.core.frame.FrameView`
             -   an iterable of :class:`fiftyone.core.frame.Frame` or
                 :class:`fiftyone.core.frame.FrameView` instances
-            -   a :class:`fiftyone.core.collections.SampleCollection`, in which
-                case the frame IDs in the collection are used
+            -   a :class:`fiftyone.core.collections.SampleCollection` whose
+                frames to select
 
         omit_empty (True): whether to omit samples that have no frames after
             selecting the specified frames
@@ -6020,53 +6018,53 @@ class ToFrames(ViewStage):
         ]
 
 
-def _parse_sample_ids(samples_or_ids):
+def _parse_sample_ids(arg):
     from fiftyone.core.collections import SampleCollection
 
-    if etau.is_str(samples_or_ids):
-        return [samples_or_ids], False
+    if etau.is_str(arg):
+        return [arg], False
 
-    if isinstance(samples_or_ids, (fos.Sample, fos.SampleView)):
-        return [samples_or_ids.id], False
+    if isinstance(arg, (fos.Sample, fos.SampleView)):
+        return [arg.id], False
 
-    if isinstance(samples_or_ids, SampleCollection):
-        return samples_or_ids.values("id"), False
+    if isinstance(arg, SampleCollection):
+        return arg.values("id"), False
 
-    samples_or_ids = list(samples_or_ids)
+    arg = list(arg)
 
-    if not samples_or_ids:
+    if not arg:
         return [], False
 
-    if isinstance(samples_or_ids[0], (fos.Sample, fos.SampleView)):
-        return [s.id for s in samples_or_ids], False
+    if isinstance(arg[0], (fos.Sample, fos.SampleView)):
+        return [s.id for s in arg], False
 
-    if isinstance(samples_or_ids[0], (bool, np.bool_)):
-        return samples_or_ids, True
+    if isinstance(arg[0], (bool, np.bool_)):
+        return arg, True
 
-    return samples_or_ids, False
+    return arg, False
 
 
-def _parse_frame_ids(frames_or_ids):
+def _parse_frame_ids(arg):
     from fiftyone.core.collections import SampleCollection
 
-    if etau.is_str(frames_or_ids):
-        return [frames_or_ids]
+    if etau.is_str(arg):
+        return [arg]
 
-    if isinstance(frames_or_ids, (fofr.Frame, fofr.FrameView)):
-        return [frames_or_ids.id]
+    if isinstance(arg, (fofr.Frame, fofr.FrameView)):
+        return [arg.id]
 
-    if isinstance(frames_or_ids, SampleCollection):
-        return frames_or_ids.values("frames.id", unwind=True)
+    if isinstance(arg, SampleCollection):
+        return arg.values("frames.id", unwind=True)
 
-    frames_or_ids = list(frames_or_ids)
+    arg = list(arg)
 
-    if not frames_or_ids:
+    if not arg:
         return []
 
-    if isinstance(frames_or_ids[0], (fofr.Frame, fofr.FrameView)):
-        return [s.id for s in frames_or_ids]
+    if isinstance(arg[0], (fofr.Frame, fofr.FrameView)):
+        return [s.id for s in arg]
 
-    return frames_or_ids
+    return arg
 
 
 def _get_rng(seed):

--- a/tests/unittests/dataset_tests.py
+++ b/tests/unittests/dataset_tests.py
@@ -1371,6 +1371,64 @@ class DatasetDeletionTests(unittest.TestCase):
 
         self.assertEqual(num_samples_after, num_samples - num_view)
 
+    def test_delete_frames(self):
+        self._setUp_video_classification()
+
+        frames = [
+            self.dataset.first().frames.first(),
+            self.dataset.last().frames.last(),
+        ]
+
+        num_frames = self.dataset.count("frames")
+        num_del = len(frames)
+
+        self.dataset.delete_frames(frames)
+
+        num_frames_after = self.dataset.count("frames")
+
+        self.assertEqual(num_frames_after, num_frames - num_del)
+
+    def test_delete_frames_ids(self):
+        self._setUp_video_classification()
+
+        frame_ids = [
+            self.dataset.first().frames.first().id,
+            self.dataset.last().frames.last().id,
+        ]
+
+        num_frames = self.dataset.count("frames")
+        num_del = len(frame_ids)
+
+        self.dataset.delete_frames(frame_ids)
+
+        num_frames_after = self.dataset.count("frames")
+
+        self.assertEqual(num_frames_after, num_frames - num_del)
+
+    def test_delete_frames_samples(self):
+        self._setUp_video_classification()
+
+        samples = list(self.dataset)
+        self.dataset.delete_frames(samples)
+
+        num_frames_after = self.dataset.count("frames")
+
+        self.assertEqual(num_frames_after, 0)
+
+    def test_delete_frames_view(self):
+        self._setUp_video_classification()
+
+        view = self.dataset.match_frames(F("frame_number") == 1)
+
+        num_frames = self.dataset.count("frames")
+        num_del = view.count("frames")
+
+        self.dataset.delete_frames(view)
+
+        num_frames_after = self.dataset.count("frames")
+
+        self.assertEqual(num_frames_after, num_frames - num_del)
+
     def test_delete_classification_ids(self):
         self._setUp_classification()
 


### PR DESCRIPTION
Adds a `Dataset.delete_frames()` method that allows for deleting frames by ID.

Example usage:

```py
import fiftyone as fo
import fiftyone.zoo as foz
from fiftyone import ViewField as F

dataset = foz.load_zoo_dataset("quickstart-video")
print(dataset.count("frames"))

dataset1 = dataset.clone()
sample1 = dataset1.first()
sample2 = dataset1.last()
dataset1.delete_frames([sample1, sample2])
print(dataset1.count("frames"))

dataset2 = dataset.clone()
sample = dataset2.first()
dataset2.delete_frames(sample)
print(dataset2.count("frames"))

dataset3 = dataset.clone()
del_view = dataset3.take(5)
dataset3.delete_frames(del_view)
print(dataset3.count("frames"))

dataset4 = dataset.clone()
del_view = dataset4.match_frames(F.rand() < 0.5)
frame_ids = del_view.values("frames.id", unwind=True)
dataset4.delete_frames(frame_ids)
print(dataset4.count("frames"))

dataset5 = dataset.clone()
frame_id = dataset5.take(1).frames.last().id
dataset5.delete_frames(frame_id)
print(dataset5.count("frames"))

dataset6 = dataset.clone()
frames = [
    dataset6.take(1).first().frames.first(),
    dataset6.take(1).first().frames.last(),
]
dataset6.delete_frames(frames)
print(dataset6.count("frames"))
```
