### PR TITLE
Disallow video-level annotation

### DIFF
--- a/fiftyone/utils/annotations.py
+++ b/fiftyone/utils/annotations.py
@@ -407,13 +407,21 @@ def _build_label_schema(
         _return_type = _RETURN_TYPES_MAP[_label_type]
         _is_trackable = _is_frame_field and _return_type in _TRACKABLE_TYPES
 
-        if is_video and _return_type in _SPATIAL_TYPES and not _is_frame_field:
-            raise ValueError(
-                "Invalid label field '%s'. Spatial labels of type '%s' being "
-                "annotated on a video must be stored in a frame-level field, "
-                "i.e., one that starts with 'frames.'"
-                % (_label_field, _label_type)
-            )
+        if is_video and not _is_frame_field:
+            if not backend.supports_video_sample_fields:
+                raise ValueError(
+                    "Invalid label field '%s'. Backend '%s' does not support "
+                    "annotating video fields at a sample-level. Labels must be "
+                    "stored in a frame-level field, i.e., one that starts with "
+                    "'frames.'" % (_label_field, backend.config.name)
+                )
+            elif _return_type in _SPATIAL_TYPES:
+                raise ValueError(
+                    "Invalid label field '%s'. Spatial labels of type '%s' "
+                    "being annotated on a video must be stored in a "
+                    "frame-level field, i.e., one that starts with 'frames.'"
+                    % (_label_field, _label_type)
+                )
 
         # We found an existing field with multiple label types, so we must
         # select only the relevant labels
@@ -1782,6 +1790,15 @@ class AnnotationBackend(foa.AnnotationMethod):
         existing video track annotations.
         """
         raise NotImplementedError("subclass must implement supports_keyframes")
+
+    @property
+    def supports_video_sample_fields(self):
+        """Whether this backend supports annotating video labels at a
+        sample-level or only at a frame-level.
+        """
+        raise NotImplementedError(
+            "subclass must implement supports_video_sample_fields"
+        )
 
     @property
     def requires_label_schema(self):

--- a/fiftyone/utils/annotations.py
+++ b/fiftyone/utils/annotations.py
@@ -408,19 +408,19 @@ def _build_label_schema(
         _is_trackable = _is_frame_field and _return_type in _TRACKABLE_TYPES
 
         if is_video and not _is_frame_field:
-            if not backend.supports_video_sample_fields:
-                raise ValueError(
-                    "Invalid label field '%s'. Backend '%s' does not support "
-                    "annotating video fields at a sample-level. Labels must be "
-                    "stored in a frame-level field, i.e., one that starts with "
-                    "'frames.'" % (_label_field, backend.config.name)
-                )
-            elif _return_type in _SPATIAL_TYPES:
+            if _return_type in _SPATIAL_TYPES:
                 raise ValueError(
                     "Invalid label field '%s'. Spatial labels of type '%s' "
                     "being annotated on a video must be stored in a "
                     "frame-level field, i.e., one that starts with 'frames.'"
                     % (_label_field, _label_type)
+                )
+            elif not backend.supports_video_sample_fields:
+                raise ValueError(
+                    "Invalid label field '%s'. Backend '%s' does not support "
+                    "annotating video fields at a sample-level. Labels must be "
+                    "stored in a frame-level field, i.e., one that starts with "
+                    "'frames.'" % (_label_field, backend.config.name)
                 )
 
         # We found an existing field with multiple label types, so we must
@@ -1794,7 +1794,7 @@ class AnnotationBackend(foa.AnnotationMethod):
     @property
     def supports_video_sample_fields(self):
         """Whether this backend supports annotating video labels at a
-        sample-level or only at a frame-level.
+        sample-level.
         """
         raise NotImplementedError(
             "subclass must implement supports_video_sample_fields"

--- a/fiftyone/utils/cvat.py
+++ b/fiftyone/utils/cvat.py
@@ -3130,6 +3130,10 @@ class CVATBackend(foua.AnnotationBackend):
         return True
 
     @property
+    def supports_video_sample_fields(self):
+        return False
+
+    @property
     def requires_label_schema(self):
         return False  # schemas can be inferred from existing CVAT projects
 

--- a/fiftyone/utils/labelbox.py
+++ b/fiftyone/utils/labelbox.py
@@ -142,6 +142,10 @@ class LabelboxBackend(foua.AnnotationBackend):
     def supports_keyframes(self):
         return False
 
+    @property
+    def supports_video_sample_fields(self):
+        return False  # @todo resolve FiftyOne bug to allow this to be True
+
     def recommend_attr_tool(self, name, value):
         if isinstance(value, bool):
             return {"type": "radio", "values": [True, False]}


### PR DESCRIPTION
Resolves #1430 

Adds a property to annotation backends to decide whether to allow annotation of video-level labels. CVAT does not provide a way to annotate labels at a video-level, and while Labelbox does, there is currently a bug that needs to be resolved before the annotations can be loaded: #1654 

Note: This primarily refers to classifications, spatial label can never be annotated at a video-level as that concept is not well defined.

## Example:

```python
import fiftyone.zoo as foz

dataset = foz.load_zoo_dataset("quickstart-video", max_samples=1).clone()

results = dataset.annotate(
    "anno_key",
    label_field="class",
    classes=["test"],
    launch_editor=True,
    label_type="classification",
)

dataset.load_annotations("anno_key", cleanup=True)
```

Previously would raise an error when loading annotations which would have resulted in wasted effort by annotators. Now raises an error when calling `annotate()`:

```
ValueError: Invalid label field 'class'. Backend 'cvat' does not support annotating video fields at a sample-level. Labels must be stored in a frame-level field, i.e., one that starts with 'frames.'
```