### PR TITLE
Always populate iscrowd field when exporting COCO labels

### DIFF
--- a/fiftyone/utils/coco.py
+++ b/fiftyone/utils/coco.py
@@ -656,7 +656,8 @@ class COCODetectionDatasetExporter(
             -   ``False``: do not export extra attributes
             -   a name or list of names of specific attributes to export
         iscrowd ("iscrowd"): the name of a detection attribute that indicates
-            whether an object is a crowd (only used if present)
+            whether an object is a crowd (the value is automatically set to 0
+            if the attribute is not present)
         num_decimals (None): an optional number of decimal places at which to
             round bounding box pixel coordinates. By default, no rounding is
             done
@@ -1140,8 +1141,8 @@ class COCOObject(object):
                 -   ``True``: include all extra attributes found
                 -   ``False``: do not include extra attributes
                 -   a name or list of names of specific attributes to include
-            iscrowd ("iscrowd"): the name of the crowd attribute (used if
-                present)
+            iscrowd ("iscrowd"): the name of the crowd attribute (the value is
+                automatically set to 0 if the attribute is not present)
             num_decimals (None): an optional number of decimal places at which
                 to round bounding box pixel coordinates. By default, no
                 rounding is done

--- a/fiftyone/utils/coco.py
+++ b/fiftyone/utils/coco.py
@@ -1182,18 +1182,16 @@ class COCOObject(object):
         if num_decimals is not None:
             bbox = [round(p, num_decimals) for p in bbox]
 
-        confidence = label.confidence
-
-        area = bbox[2] * bbox[3]
-
         if keypoint is not None:
             keypoints = _make_coco_keypoints(keypoint, frame_size)
         else:
             keypoints = None
 
-        _iscrowd = label.get_attribute_value(iscrowd, None)
-        if _iscrowd is not None:
-            _iscrowd = int(_iscrowd)
+        confidence = label.confidence
+
+        area = bbox[2] * bbox[3]
+
+        _iscrowd = int(label.get_attribute_value(iscrowd, None) or 0)
 
         attributes = _get_attributes(label, extra_attrs)
         attributes.pop(iscrowd, None)
@@ -1273,10 +1271,10 @@ def _parse_coco_detection_annotations(d, extra_attrs=True):
     info = d.get("info", None)
     licenses = d.get("licenses", None)
     categories = d.get("categories", None)
-    
+
     if info is None:
         info = {}
-        
+
     if licenses is not None:
         info["licenses"] = licenses
 


### PR DESCRIPTION
Previously exporting in [COCO format](https://voxel51.com/docs/fiftyone/user_guide/export_datasets.html#cocodetectiondataset) would only include the `iscrowd` attribute in the JSON if the attribute is actually populated on the collection being exported. This was problematic for certain downstream stages of COCO workflows, which will assume that `iscrowd: 0` is always populated if no crowd data is available.

This PR will now export `iscrowd: 0` if now crowd data is available.

```py
import fiftyone as fo
import fiftyone.zoo as foz

dataset = foz.load_zoo_dataset("quickstart", max_samples=1)
dataset.delete_sample_field("ground_truth.detections.attributes")

dataset.export(
    labels_path="/tmp/labels.json",
    dataset_type=fo.types.COCODetectionDataset,
    label_field="ground_truth",
)
```

```shell
# Previously would not include `iscrowd` attribute, but now does
python -m json.tool /tmp/labels.json
```
