### PR TITLE
Embedded document schema updates (take 2)

### DIFF
--- a/docs/source/integrations/coco.rst
+++ b/docs/source/integrations/coco.rst
@@ -287,7 +287,7 @@ dataset:
         id:         fiftyone.core.fields.ObjectIdField
         filepath:   fiftyone.core.fields.StringField
         tags:       fiftyone.core.fields.ListField(fiftyone.core.fields.StringField)
-        metadata:   fiftyone.core.fields.EmbeddedDocumentField(fiftyone.core.metadata.Metadata)
+        metadata:   fiftyone.core.fields.EmbeddedDocumentField(fiftyone.core.metadata.ImageMetadata)
         detections: fiftyone.core.fields.EmbeddedDocumentField(fiftyone.core.labels.Detections)
         coco_id:    fiftyone.core.fields.IntField
 

--- a/docs/source/user_guide/basics.rst
+++ b/docs/source/user_guide/basics.rst
@@ -80,7 +80,6 @@ obtain a desired subset of the samples.
     Tags:           []
     Sample fields:
         id:         fiftyone.core.fields.ObjectIdField
-        media_type: fiftyone.core.fields.StringField
         filepath:   fiftyone.core.fields.StringField
         tags:       fiftyone.core.fields.ListField(fiftyone.core.fields.StringField)
         metadata:   fiftyone.core.fields.EmbeddedDocumentField(fiftyone.core.metadata.Metadata)
@@ -196,7 +195,7 @@ schema and thus accessible on all other samples in the dataset.
         id:        fiftyone.core.fields.ObjectIdField
         filepath:  fiftyone.core.fields.StringField
         tags:      fiftyone.core.fields.ListField(fiftyone.core.fields.StringField)
-        metadata:  fiftyone.core.fields.EmbeddedDocumentField(fiftyone.core.metadata.Metadata)
+        metadata:  fiftyone.core.fields.EmbeddedDocumentField(fiftyone.core.metadata.ImageMetadata)
         quality:   fiftyone.core.fields.FloatField
         keypoints: fiftyone.core.fields.ListField
         geo_json:  fiftyone.core.fields.DictField

--- a/docs/source/user_guide/evaluation.rst
+++ b/docs/source/user_guide/evaluation.rst
@@ -795,7 +795,7 @@ results of an evaluation on the
     Patch fields:
         filepath:     fiftyone.core.fields.StringField
         tags:         fiftyone.core.fields.ListField(fiftyone.core.fields.StringField)
-        metadata:     fiftyone.core.fields.EmbeddedDocumentField(fiftyone.core.metadata.Metadata)
+        metadata:     fiftyone.core.fields.EmbeddedDocumentField(fiftyone.core.metadata.ImageMetadata)
         predictions:  fiftyone.core.fields.EmbeddedDocumentField(fiftyone.core.labels.Detections)
         ground_truth: fiftyone.core.fields.EmbeddedDocumentField(fiftyone.core.labels.Detections)
         sample_id:    fiftyone.core.fields.StringField
@@ -1915,7 +1915,7 @@ You can also view frame-level evaluation results as
         id:           fiftyone.core.fields.ObjectIdField
         filepath:     fiftyone.core.fields.StringField
         tags:         fiftyone.core.fields.ListField(fiftyone.core.fields.StringField)
-        metadata:     fiftyone.core.fields.EmbeddedDocumentField(fiftyone.core.metadata.Metadata)
+        metadata:     fiftyone.core.fields.EmbeddedDocumentField(fiftyone.core.metadata.ImageMetadata)
         predictions:  fiftyone.core.fields.EmbeddedDocumentField(fiftyone.core.labels.Detections)
         detections:   fiftyone.core.fields.EmbeddedDocumentField(fiftyone.core.labels.Detections)
         sample_id:    fiftyone.core.fields.ObjectIdField

--- a/docs/source/user_guide/using_datasets.rst
+++ b/docs/source/user_guide/using_datasets.rst
@@ -551,10 +551,10 @@ By default, all |Sample| instances have the following fields:
     | `filepath`   | string                             | **REQUIRED**  | The path to the source data on disk. Must be      |
     |              |                                    |               | provided at sample creation time                  |
     +--------------+------------------------------------+---------------+---------------------------------------------------+
+    | `tags`       | list                               | `[]`          | A list of string tags for the sample              |
+    +--------------+------------------------------------+---------------+---------------------------------------------------+
     | `metadata`   | :class:`Metadata                   | `None`        | Type-specific metadata about the source data      |
     |              | <fiftyone.core.metadata.Metadata>` |               |                                                   |
-    +--------------+------------------------------------+---------------+---------------------------------------------------+
-    | `tags`       | list                               | `[]`          | A list of string tags for the sample              |
     +--------------+------------------------------------+---------------+---------------------------------------------------+
 
 .. code-block:: python
@@ -593,12 +593,15 @@ You can retrieve detailed information about the schema of the samples in a
 .. code-block:: python
     :linenos:
 
+    dataset = fo.Dataset("a_dataset")
+    dataset.add_sample(sample)
+
     dataset.get_field_schema()
 
 .. code-block:: text
 
     OrderedDict([
-        ('media_type', <fiftyone.core.fields.StringField at 0x11c77add8>),
+        ('id', <fiftyone.core.fields.ObjectIdField at 0x7fbaa862b358>),
         ('filepath', <fiftyone.core.fields.StringField at 0x11c77ae10>),
         ('tags', <fiftyone.core.fields.ListField at 0x11c790828>),
         ('metadata', <fiftyone.core.fields.EmbeddedDocumentField at 0x11c7907b8>)
@@ -616,15 +619,14 @@ printing it:
 
     Name:           a_dataset
     Media type:     image
-    Num samples:    0
+    Num samples:    1
     Persistent:     False
     Tags:           []
     Sample fields:
         id:         fiftyone.core.fields.ObjectIdField
-        media_type: fiftyone.core.fields.StringField
         filepath:   fiftyone.core.fields.StringField
         tags:       fiftyone.core.fields.ListField(fiftyone.core.fields.StringField)
-        metadata:   fiftyone.core.fields.EmbeddedDocumentField(fiftyone.core.metadata.Metadata)
+        metadata:   fiftyone.core.fields.EmbeddedDocumentField(fiftyone.core.metadata.ImageMetadata)
 
 The value of a |Field| for a given |Sample| can be accessed either by either
 attribute or item access:
@@ -660,15 +662,14 @@ updated to reflect the new field:
 
     Name:           a_dataset
     Media type:     image
-    Num samples:    0
+    Num samples:    1
     Persistent:     False
     Tags:           []
     Sample fields:
         id:            fiftyone.core.fields.ObjectIdField
-        media_type:    fiftyone.core.fields.StringField
         filepath:      fiftyone.core.fields.StringField
         tags:          fiftyone.core.fields.ListField(fiftyone.core.fields.StringField)
-        metadata:      fiftyone.core.fields.EmbeddedDocumentField(fiftyone.core.metadata.Metadata)
+        metadata:      fiftyone.core.fields.EmbeddedDocumentField(fiftyone.core.metadata.ImageMetadata)
         integer_field: fiftyone.core.fields.IntField
 
 A |Field| can be any primitive type, such as `bool`, `int`, `float`, `str`,
@@ -2733,7 +2734,7 @@ Video samples can be added to datasets just like image samples:
         id:       fiftyone.core.fields.ObjectIdField
         filepath: fiftyone.core.fields.StringField
         tags:     fiftyone.core.fields.ListField(fiftyone.core.fields.StringField)
-        metadata: fiftyone.core.fields.EmbeddedDocumentField(fiftyone.core.metadata.Metadata)
+        metadata: fiftyone.core.fields.EmbeddedDocumentField(fiftyone.core.metadata.VideoMetadata)
     Frame fields:
         id:           fiftyone.core.fields.ObjectIdField
         frame_number: fiftyone.core.fields.FrameNumberField

--- a/docs/source/user_guide/using_views.rst
+++ b/docs/source/user_guide/using_views.rst
@@ -40,7 +40,7 @@ You can explicitly create a view that contains an entire dataset via
         id:           fiftyone.core.fields.ObjectIdField
         filepath:     fiftyone.core.fields.StringField
         tags:         fiftyone.core.fields.ListField(fiftyone.core.fields.StringField)
-        metadata:     fiftyone.core.fields.EmbeddedDocumentField(fiftyone.core.metadata.Metadata)
+        metadata:     fiftyone.core.fields.EmbeddedDocumentField(fiftyone.core.metadata.ImageMetadata)
         ground_truth: fiftyone.core.fields.EmbeddedDocumentField(fiftyone.core.labels.Detections)
         uniqueness:   fiftyone.core.fields.FloatField
         predictions:  fiftyone.core.fields.EmbeddedDocumentField(fiftyone.core.labels.Detections)
@@ -749,7 +749,7 @@ detection dataset:
         id:           fiftyone.core.fields.ObjectIdField
         filepath:     fiftyone.core.fields.StringField
         tags:         fiftyone.core.fields.ListField(fiftyone.core.fields.StringField)
-        metadata:     fiftyone.core.fields.EmbeddedDocumentField(fiftyone.core.metadata.Metadata)
+        metadata:     fiftyone.core.fields.EmbeddedDocumentField(fiftyone.core.metadata.ImageMetadata)
         sample_id:    fiftyone.core.fields.ObjectIdField
         ground_truth: fiftyone.core.fields.EmbeddedDocumentField(fiftyone.core.labels.Detection)
     View stages:
@@ -874,7 +874,7 @@ respectively.
         id:           fiftyone.core.fields.ObjectIdField
         filepath:     fiftyone.core.fields.StringField
         tags:         fiftyone.core.fields.ListField(fiftyone.core.fields.StringField)
-        metadata:     fiftyone.core.fields.EmbeddedDocumentField(fiftyone.core.metadata.Metadata)
+        metadata:     fiftyone.core.fields.EmbeddedDocumentField(fiftyone.core.metadata.ImageMetadata)
         predictions:  fiftyone.core.fields.EmbeddedDocumentField(fiftyone.core.labels.Detections)
         ground_truth: fiftyone.core.fields.EmbeddedDocumentField(fiftyone.core.labels.Detections)
         sample_id:    fiftyone.core.fields.ObjectIdField
@@ -1025,7 +1025,7 @@ temporal segment by simply passing the name of the temporal detection field to
         filepath:  fiftyone.core.fields.StringField
         support:   fiftyone.core.fields.FrameSupportField
         tags:      fiftyone.core.fields.ListField(fiftyone.core.fields.StringField)
-        metadata:  fiftyone.core.fields.EmbeddedDocumentField(fiftyone.core.metadata.Metadata)
+        metadata:  fiftyone.core.fields.EmbeddedDocumentField(fiftyone.core.metadata.VideoMetadata)
         events:    fiftyone.core.fields.EmbeddedDocumentField(fiftyone.core.labels.Classification)
     Frame fields:
         id:           fiftyone.core.fields.ObjectIdField
@@ -1128,7 +1128,7 @@ that contains at least one person:
         filepath:  fiftyone.core.fields.StringField
         support:   fiftyone.core.fields.FrameSupportField
         tags:      fiftyone.core.fields.ListField(fiftyone.core.fields.StringField)
-        metadata:  fiftyone.core.fields.EmbeddedDocumentField(fiftyone.core.metadata.Metadata)
+        metadata:  fiftyone.core.fields.EmbeddedDocumentField(fiftyone.core.metadata.VideoMetadata)
     Frame fields:
         id:           fiftyone.core.fields.ObjectIdField
         frame_number: fiftyone.core.fields.FrameNumberField
@@ -1282,7 +1282,7 @@ frame of the videos in a |Dataset| or |DatasetView|:
         id:           fiftyone.core.fields.ObjectIdField
         filepath:     fiftyone.core.fields.StringField
         tags:         fiftyone.core.fields.ListField(fiftyone.core.fields.StringField)
-        metadata:     fiftyone.core.fields.EmbeddedDocumentField(fiftyone.core.metadata.Metadata)
+        metadata:     fiftyone.core.fields.EmbeddedDocumentField(fiftyone.core.metadata.ImageMetadata)
         sample_id:    fiftyone.core.fields.ObjectIdField
         frame_number: fiftyone.core.fields.FrameNumberField
         detections:   fiftyone.core.fields.EmbeddedDocumentField(fiftyone.core.labels.Detections)
@@ -1429,7 +1429,7 @@ sample per object patch in the frames of the dataset!
         id:           fiftyone.core.fields.ObjectIdField
         filepath:     fiftyone.core.fields.StringField
         tags:         fiftyone.core.fields.ListField(fiftyone.core.fields.StringField)
-        metadata:     fiftyone.core.fields.EmbeddedDocumentField(fiftyone.core.metadata.Metadata)
+        metadata:     fiftyone.core.fields.EmbeddedDocumentField(fiftyone.core.metadata.ImageMetadata)
         sample_id:    fiftyone.core.fields.ObjectIdField
         frame_id:     fiftyone.core.fields.ObjectIdField
         frame_number: fiftyone.core.fields.FrameNumberField
@@ -2116,15 +2116,16 @@ Let's say you have a dataset that looks like this:
 
 .. code-block:: bash
 
-    Name:           open-images-v4-test
-    Num samples:    1000
-    Persistent:     True
-    Tags:           []
+    Name:        open-images-v4-test
+    Media type:  image
+    Num samples: 1000
+    Persistent:  True
+    Tags:        []
     Sample fields:
         id:                       fiftyone.core.fields.ObjectIdField
         filepath:                 fiftyone.core.fields.StringField
         tags:                     fiftyone.core.fields.ListField(StringField)
-        metadata:                 fiftyone.core.fields.EmbeddedDocumentField(fiftyone.core.metadata.Metadata)
+        metadata:                 fiftyone.core.fields.EmbeddedDocumentField(fiftyone.core.metadata.ImageMetadata)
         open_images_id:           fiftyone.core.fields.StringField
         groundtruth_image_labels: fiftyone.core.fields.EmbeddedDocumentField(fiftyone.core.labels.Classifications)
         groundtruth_detections:   fiftyone.core.fields.EmbeddedDocumentField(fiftyone.core.labels.Detections)

--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -37,6 +37,7 @@ import fiftyone.core.fields as fof
 import fiftyone.core.frame as fofr
 import fiftyone.core.labels as fol
 import fiftyone.core.media as fom
+import fiftyone.core.metadata as fome
 import fiftyone.migrations as fomi
 import fiftyone.core.odm as foo
 import fiftyone.core.sample as fos
@@ -346,7 +347,32 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
                 % (media_type, fom.MEDIA_TYPES)
             )
 
+        if media_type == self._doc.media_type:
+            return
+
         self._doc.media_type = media_type
+
+        idx = None
+        for i, field in enumerate(self._doc.sample_fields):
+            if field.name == "metadata":
+                idx = i
+
+        if idx is not None:
+            if media_type == fom.IMAGE:
+                doc_type = fome.ImageMetadata
+            elif media_type == fom.VIDEO:
+                doc_type = fome.VideoMetadata
+            else:
+                doc_type = fome.Metadata
+
+            field = foo.create_field(
+                "metadata",
+                fof.EmbeddedDocumentField,
+                embedded_doc_type=doc_type,
+            )
+            field_doc = foo.SampleFieldDocument.from_field(field)
+            self._doc.sample_fields[idx] = field_doc
+            self._sample_doc_cls._declare_field(field, field.name)
 
         if media_type == fom.VIDEO:
             # pylint: disable=no-member
@@ -4640,7 +4666,7 @@ def _create_indexes(sample_collection_name, frame_collection_name):
         )
 
 
-def _declare_fields(doc_cls, field_docs):
+def _declare_fields(doc_cls, field_docs=None):
     for field_name, field in doc_cls._fields.items():
         if isinstance(field, fof.EmbeddedDocumentField):
             field = foo.create_field(field.name, **foo.get_field_kwargs(field))
@@ -4648,9 +4674,10 @@ def _declare_fields(doc_cls, field_docs):
             doc_cls._fields[field_name] = field
             setattr(doc_cls, field_name, field)
 
-    for field_doc in field_docs or []:
-        field = field_doc.to_field()
-        doc_cls._declare_field(field, field.name)
+    if field_docs is not None:
+        for field_doc in field_docs:
+            field = field_doc.to_field()
+            doc_cls._declare_field(field, field.name)
 
 
 def _make_sample_collection_name(patches=False, frames=False, clips=False):
@@ -4681,13 +4708,13 @@ def _make_frame_collection_name(sample_collection_name):
 
 def _create_sample_document_cls(sample_collection_name, field_docs=None):
     cls = type(sample_collection_name, (foo.DatasetSampleDocument,), {})
-    _declare_fields(cls, field_docs)
+    _declare_fields(cls, field_docs=field_docs)
     return cls
 
 
 def _create_frame_document_cls(frame_collection_name, field_docs=None):
     cls = type(frame_collection_name, (foo.DatasetFrameDocument,), {})
-    _declare_fields(cls, field_docs)
+    _declare_fields(cls, field_docs=field_docs)
     return cls
 
 

--- a/fiftyone/migrations/revisions/v0_16_0.py
+++ b/fiftyone/migrations/revisions/v0_16_0.py
@@ -174,8 +174,11 @@ def _build_pipeline(path, is_list_field=False):
 
 
 def _parse_result(result):
+    if not result:
+        return []
+
     schema = defaultdict(set)
-    for name_and_type in result["schema"]:
+    for name_and_type in result[0]["schema"]:
         name, mongo_type = name_and_type.split(".", 1)
         if mongo_type == "objectId" and name.startswith("_"):
             name = name[1:]  # "_id" -> "id"

--- a/fiftyone/migrations/revisions/v0_16_0.py
+++ b/fiftyone/migrations/revisions/v0_16_0.py
@@ -11,13 +11,37 @@ def up(db, dataset_name):
     match_d = {"name": dataset_name}
     dataset_dict = db.datasets.find_one(match_d)
 
-    dataset_dict["app_sidebar_groups"] = None
+    media_type = dataset_dict.get("media_type", None)
 
-    for field in dataset_dict.get("sample_fields", []):
-        field["fields"] = []
+    embedded_doc_inds = []
+
+    for idx, field in enumerate(dataset_dict.get("sample_fields", [])):
+        name = field.get("name", None)
+        ftype = field.get("dtype", None)
+
+        if name == "metadata":
+            if media_type == "image":
+                embedded_doc_type = "fiftyone.core.metadata.ImageMetadata"
+                fields = _IMAGE_METADATA_FIELDS
+            elif media_type == "video":
+                embedded_doc_type = "fiftyone.core.metadata.VideoMetadata"
+                fields = _VIDEO_METADATA_FIELDS
+            else:
+                embedded_doc_type = "fiftyone.core.metadata.Metadata"
+                fields = _METADATA_FIELDS
+
+            field["embedded_doc_type"] = embedded_doc_type
+            field["fields"] = [_make_field_doc(n, t) for n, t in fields]
+        else:
+            field["fields"] = []
+
+        if ftype == "fiftyone.core.fields.EmbeddedDocumentField":
+            embedded_doc_inds.append(idx)
 
     for field in dataset_dict.get("frame_fields", []):
         field["fields"] = []
+
+    dataset_dict["app_sidebar_groups"] = None
 
     db.datasets.replace_one(match_d, dataset_dict)
 
@@ -26,12 +50,64 @@ def down(db, dataset_name):
     match_d = {"name": dataset_name}
     dataset_dict = db.datasets.find_one(match_d)
 
-    dataset_dict.pop("app_sidebar_groups", None)
-
     for field in dataset_dict.get("sample_fields", []):
+        if field.get("name", None) == "metadata":
+            field["embedded_doc_type"] = "fiftyone.core.metadata.Metadata"
+
         field.pop("fields", None)
 
     for field in dataset_dict.get("frame_fields", []):
         field.pop("fields", None)
 
+    dataset_dict.pop("app_sidebar_groups", None)
+
     db.datasets.replace_one(match_d, dataset_dict)
+
+
+def _make_field_doc(name, mongo_type):
+    return {
+        "_cls": "SampleFieldDocument",
+        "name": name,
+        "ftype": _MONGO_TO_FIFTYONE_TYPES[mongo_type],
+        "subfield": None,
+        "embedded_doc_type": None,
+        "db_field": name,
+        "fields": [],
+    }
+
+
+_METADATA_FIELDS = [
+    ("size_bytes", "int"),
+    ("mime_type", "string"),
+]
+
+_IMAGE_METADATA_FIELDS = [
+    ("size_bytes", "int"),
+    ("mime_type", "string"),
+    ("width", "int"),
+    ("height", "int"),
+    ("num_channels", "int"),
+]
+
+_VIDEO_METADATA_FIELDS = [
+    ("size_bytes", "int"),
+    ("mime_type", "string"),
+    ("frame_width", "int"),
+    ("frame_height", "int"),
+    ("frame_rate", "double"),
+    ("total_frame_count", "int"),
+    ("duration", "double"),
+    ("encoding_str", "string"),
+]
+
+_MONGO_TO_FIFTYONE_TYPES = {
+    "string": "fiftyone.core.fields.StringField",
+    "bool": "fiftyone.core.fields.BooleanField",
+    "int": "fiftyone.core.fields.IntField",
+    "long": "fiftyone.core.fields.IntField",
+    "double": "fiftyone.core.fields.FloatField",
+    "decimal": "fiftyone.core.fields.FloatField",
+    "array": "fiftyone.core.fields.ListField",
+    "object": "fiftyone.core.fields.DictField",
+    "objectId": "fiftyone.core.fields.ObjectIdField",
+}

--- a/fiftyone/migrations/revisions/v0_16_0.py
+++ b/fiftyone/migrations/revisions/v0_16_0.py
@@ -87,13 +87,18 @@ def down(db, dataset_name):
 
 
 def _make_field_doc(name, ftype, subfield):
+    if ftype == "fiftyone.core.fields.ObjectIdField":
+        db_field = "_" + name
+    else:
+        db_field = name
+
     return {
         "_cls": "SampleFieldDocument",
         "name": name,
         "ftype": ftype,
         "subfield": subfield,
         "embedded_doc_type": None,
-        "db_field": name,
+        "db_field": db_field,
         "fields": [],
     }
 
@@ -182,6 +187,9 @@ def _parse_result(result):
     schema = defaultdict(set)
     for name_and_type in result[0]["schema"]:
         name, mongo_type = name_and_type.split(".", 1)
+        if name == "_cls":
+            continue
+
         if mongo_type == "objectId" and name.startswith("_"):
             name = name[1:]  # "_id" -> "id"
 

--- a/fiftyone/migrations/revisions/v0_16_0.py
+++ b/fiftyone/migrations/revisions/v0_16_0.py
@@ -192,7 +192,7 @@ def _parse_result(result):
     for name, types in schema.items():
         if len(types) == 1:
             ftype = _MONGO_TO_FIFTYONE_TYPES.get(
-                types[0], "fiftyone.core.fields.Field"
+                next(iter(types)), "fiftyone.core.fields.Field"
             )
             fields.append((name, ftype, None))
 

--- a/fiftyone/migrations/revisions/v0_16_0.py
+++ b/fiftyone/migrations/revisions/v0_16_0.py
@@ -1,0 +1,37 @@
+"""
+FiftyOne v0.16.0 revision.
+
+| Copyright 2017-2022, Voxel51, Inc.
+| `voxel51.com <https://voxel51.com/>`_
+|
+"""
+
+
+def up(db, dataset_name):
+    match_d = {"name": dataset_name}
+    dataset_dict = db.datasets.find_one(match_d)
+
+    dataset_dict["app_sidebar_groups"] = None
+
+    for field in dataset_dict.get("sample_fields", []):
+        field["fields"] = []
+
+    for field in dataset_dict.get("frame_fields", []):
+        field["fields"] = []
+
+    db.datasets.replace_one(match_d, dataset_dict)
+
+
+def down(db, dataset_name):
+    match_d = {"name": dataset_name}
+    dataset_dict = db.datasets.find_one(match_d)
+
+    dataset_dict.pop("app_sidebar_groups", None)
+
+    for field in dataset_dict.get("sample_fields", []):
+        field.pop("fields", None)
+
+    for field in dataset_dict.get("frame_fields", []):
+        field.pop("fields", None)
+
+    db.datasets.replace_one(match_d, dataset_dict)

--- a/fiftyone/migrations/revisions/v0_16_0.py
+++ b/fiftyone/migrations/revisions/v0_16_0.py
@@ -174,6 +174,8 @@ def _build_pipeline(path, is_list_field=False):
 
 
 def _parse_result(result):
+    result = list(result)
+
     if not result:
         return []
 

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ import re
 from setuptools import setup, find_packages
 
 
-VERSION = "0.15.0.1"
+VERSION = "0.16.0"
 
 
 def get_version():


### PR DESCRIPTION
Change log
- Adds a database migration that infers embedded document schemas for existing datasets
- Updates the schema of the `metadata` field when a dataset's `media_type` is set