### PR TITLE
Adding database admin config setting

### DIFF
--- a/docs/source/cli/index.rst
+++ b/docs/source/cli/index.rst
@@ -718,6 +718,9 @@ FiftyOne migrations
 
 Tools for migrating the FiftyOne database.
 
+See :ref:`this page <database-migrations>` for more information about migrating
+FiftyOne deployments.
+
 .. code-block:: text
 
     fiftyone migrate [-h] [-i] [-a] [-v VERSION]

--- a/docs/source/getting_started/install.rst
+++ b/docs/source/getting_started/install.rst
@@ -267,7 +267,7 @@ Here's the workflow for downgrading to an older version of FiftyOne:
 .. code-block:: shell
 
     # The version that you wish to downgrade to
-    VERSION=0.9.4  # for example
+    VERSION=0.14.4  # for example
 
     # Migrate the database
     fiftyone migrate --all -v $VERSION

--- a/docs/source/getting_started/install.rst
+++ b/docs/source/getting_started/install.rst
@@ -242,6 +242,13 @@ your current FiftyOne version.
   will be **automatically** performed on a per-dataset basis whenever you load
   a dataset for the first time in a newer version of FiftyOne.
 
+.. note::
+
+  If you are working with a
+  :ref:`custom/shared MongoDB database <configuring-mongodb-connection>`, you
+  can use :ref:`database admin privileges <database-migrations>` to control
+  which clients are allowed to upgrade your FiftyOne deployment.
+
 .. _downgrading-fiftyone:
 
 Downgrading FiftyOne
@@ -275,6 +282,13 @@ If you are reading this after encountering an error resulting from downgrading
 your ``fiftyone`` package without first running
 :ref:`fiftyone migrate <cli-fiftyone-migrate>`, don't worry, you simply need to
 reinstall the newer version of FiftyOne and then follow these instructions.
+
+.. note::
+
+  If you are working with a
+  :ref:`custom/shared MongoDB database <configuring-mongodb-connection>`, you
+  can use :ref:`database admin privileges <database-migrations>` to control
+  which clients are allowed to downgrade your FiftyOne deployment.
 
 .. note::
 

--- a/docs/source/user_guide/config.rst
+++ b/docs/source/user_guide/config.rst
@@ -417,7 +417,7 @@ Database upgrades happen automatically in two steps:
 -   **Database**: when you import FiftyOne for the first time using a newer
     version of the Python package, the database's version is automatically
     updated to match your client version
--   **Datasets**: are lazily migrated to the current database version on a
+-   **Datasets** are lazily migrated to the current database version on a
     per-dataset basis whenever you load the dataset for the first time using a
     newer version of the FiftyOne package
 

--- a/docs/source/user_guide/config.rst
+++ b/docs/source/user_guide/config.rst
@@ -445,8 +445,11 @@ database with newer Python client versions.
 
 If you set `database_admin` to `False`, your database will refuse all
 connections from FiftyOne clients whose version does not match the database's
-current version. You can enable this behavior by adding the following entry to
-your `~/.fiftyone/config.json` file:
+current version, and datasets will refuse migrations to versions other than the
+database's current version.
+
+You can restrict migrations by adding the following entry to your
+`~/.fiftyone/config.json` file:
 
 .. code-block:: json
 

--- a/docs/source/user_guide/config.rst
+++ b/docs/source/user_guide/config.rst
@@ -17,6 +17,9 @@ FiftyOne supports the configuration options described below:
 +-------------------------------+-------------------------------------+-------------------------------+----------------------------------------------------------------------------------------+
 | Config field                  | Environment variable                | Default value                 | Description                                                                            |
 +===============================+=====================================+===============================+========================================================================================+
+| `database_admin`              | `FIFTYONE_DATABASE_ADMIN`           | `True`                        | Whether the client is allowed to trigger database migrations. See                      |
+|                               |                                     |                               | :ref:`this section <database-migrations>` for more information.                        |
++-------------------------------+-------------------------------------+-------------------------------+----------------------------------------------------------------------------------------+
 | `database_dir`                | `FIFTYONE_DATABASE_DIR`             | `~/.fiftyone/var/lib/mongo`   | The directory in which to store FiftyOne's backing database. Only applicable if        |
 |                               |                                     |                               | `database_uri` is not defined.                                                         |
 +-------------------------------+-------------------------------------+-------------------------------+----------------------------------------------------------------------------------------+
@@ -117,6 +120,7 @@ and the CLI:
     .. code-block:: text
 
         {
+            "database_admin": true,
             "database_dir": "~/.fiftyone/var/lib/mongo",
             "database_name": "fiftyone",
             "database_uri": null,
@@ -157,6 +161,7 @@ and the CLI:
     .. code-block:: text
 
         {
+            "database_admin": true,
             "database_dir": "~/.fiftyone/var/lib/mongo",
             "database_name": "fiftyone",
             "database_uri": null,
@@ -362,6 +367,13 @@ or you can set the following environment variable:
 
     export FIFTYONE_DATABASE_VALIDATION=false
 
+Controlling database migrations
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If you are working with a shared MongoDB database, you can use
+:ref:`database admin privileges <database-migrations>` to control which clients
+are allowed to migrate the shared database.
+
 Example custom database usage
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -390,6 +402,72 @@ Then, in another shell, configure the database URI and launch FiftyOne:
 
     dataset = foz.load_zoo_dataset("quickstart")
     session = fo.launch_app(dataset)
+
+.. _database-migrations:
+
+Database migrations
+-------------------
+
+New FiftyOne versions occasionally introduce data model changes that require
+database migrations when you :ref:`upgrade <upgrading-fiftyone>` or
+:ref:`downgrade <downgrading-fiftyone>`.
+
+Upgrade migrations happen automatically in two steps:
+
+-   **Database**: when you import FiftyOne for the first time using a newer
+    version of the Python package, the database's version is automatically
+    updated to match your client version
+-   **Datasets**: are lazily migrated to the current database version on a
+    per-dataset basis whenever you load the dataset for the first time using a
+    newer version of the FiftyOne package
+
+Database downgrades must be manually performed. See
+:ref:`this page <downgrading-fiftyone>` for instructions.
+
+You can use the :ref:`fiftyone migrate <cli-fiftyone-migrate>` command to view
+the current versions of your database and datasets:
+
+.. code-block:: shell
+
+    # View your client version
+    fiftyone --version
+
+    # View your database and dataset versions
+    fiftyone migrate --info
+
+Restricting migrations
+~~~~~~~~~~~~~~~~~~~~~~
+
+You can use the `database_admin` config setting to control whether a client is
+allowed to upgrade/downgrade your FiftyOne database. The default is `True`,
+which means that upgrades are automatically peformed when you connect to your
+database with newer Python client versions.
+
+If you set `database_admin` to `False`, your database will refuse all
+connections from FiftyOne clients whose version does not match the database's
+current version. You can enable this behavior by adding the following entry to
+your `~/.fiftyone/config.json` file:
+
+.. code-block:: json
+
+    {
+        "database_admin": false
+    }
+
+or by setting the following environment variable:
+
+.. code-block:: shell
+
+    export FIFTYONE_DATABASE_ADMIN=false
+
+.. note::
+
+    A common pattern when working with
+    :ref:`custom/shared MongoDB databases <configuring-mongodb-connection>` is
+    to adopt a convention that all non-administrators set their
+    `database_admin` config setting to `False` to ensure that they cannot
+    trigger automatic database upgrades by connecting to the database with
+    newer Python client versions.
 
 .. _configuring-timezone:
 

--- a/docs/source/user_guide/config.rst
+++ b/docs/source/user_guide/config.rst
@@ -412,7 +412,7 @@ New FiftyOne versions occasionally introduce data model changes that require
 database migrations when you :ref:`upgrade <upgrading-fiftyone>` or
 :ref:`downgrade <downgrading-fiftyone>`.
 
-Upgrade migrations happen automatically in two steps:
+Database upgrades happen automatically in two steps:
 
 -   **Database**: when you import FiftyOne for the first time using a newer
     version of the Python package, the database's version is automatically
@@ -443,9 +443,9 @@ allowed to upgrade/downgrade your FiftyOne database. The default is `True`,
 which means that upgrades are automatically peformed when you connect to your
 database with newer Python client versions.
 
-If you set `database_admin` to `False`, your database will refuse all
-connections from FiftyOne clients whose version does not match the database's
-current version, and datasets will refuse migrations to versions other than the
+If you set `database_admin` to `False`, your database will refuse connections
+from your FiftyOne client if its version does not match the database's current
+version, and datasets will refuse migrations to versions other than the
 database's current version.
 
 You can restrict migrations by adding the following entry to your

--- a/fiftyone/core/cli.py
+++ b/fiftyone/core/cli.py
@@ -442,7 +442,10 @@ class DatasetsInfoCommand(Command):
     @staticmethod
     def setup(parser):
         parser.add_argument(
-            "name", nargs="?", metavar="NAME", help="the name of a dataset",
+            "name",
+            nargs="?",
+            metavar="NAME",
+            help="the name of a dataset",
         )
         parser.add_argument(
             "-s",
@@ -524,7 +527,9 @@ class DatasetsStatsCommand(Command):
     @staticmethod
     def setup(parser):
         parser.add_argument(
-            "name", metavar="NAME", help="the name of the dataset",
+            "name",
+            metavar="NAME",
+            help="the name of the dataset",
         )
         parser.add_argument(
             "-m",
@@ -575,7 +580,10 @@ class DatasetsCreateCommand(Command):
     @staticmethod
     def setup(parser):
         parser.add_argument(
-            "-n", "--name", metavar="NAME", help="a name for the dataset",
+            "-n",
+            "--name",
+            metavar="NAME",
+            help="a name for the dataset",
         )
         parser.add_argument(
             "-d",
@@ -744,7 +752,9 @@ class DatasetsExportCommand(Command):
     @staticmethod
     def setup(parser):
         parser.add_argument(
-            "name", metavar="NAME", help="the name of the dataset to export",
+            "name",
+            metavar="NAME",
+            help="the name of the dataset to export",
         )
         parser.add_argument(
             "-d",
@@ -824,7 +834,9 @@ class DatasetsDrawCommand(Command):
     @staticmethod
     def setup(parser):
         parser.add_argument(
-            "name", metavar="NAME", help="the name of the dataset",
+            "name",
+            metavar="NAME",
+            help="the name of the dataset",
         )
         parser.add_argument(
             "-d",
@@ -866,10 +878,14 @@ class DatasetsRenameCommand(Command):
     @staticmethod
     def setup(parser):
         parser.add_argument(
-            "name", metavar="NAME", help="the name of the dataset",
+            "name",
+            metavar="NAME",
+            help="the name of the dataset",
         )
         parser.add_argument(
-            "new_name", metavar="NEW_NAME", help="a new name for the dataset",
+            "new_name",
+            metavar="NEW_NAME",
+            help="a new name for the dataset",
         )
 
     @staticmethod
@@ -1738,7 +1754,10 @@ class DatasetZooFindCommand(Command):
             "name", metavar="NAME", help="the name of the dataset"
         )
         parser.add_argument(
-            "-s", "--split", metavar="SPLIT", help="a dataset split",
+            "-s",
+            "--split",
+            metavar="SPLIT",
+            help="a dataset split",
         )
 
     @staticmethod
@@ -1968,7 +1987,10 @@ class DatasetZooDeleteCommand(Command):
             "name", metavar="NAME", help="the name of the dataset"
         )
         parser.add_argument(
-            "-s", "--split", metavar="SPLIT", help="a dataset split",
+            "-s",
+            "--split",
+            metavar="SPLIT",
+            help="a dataset split",
         )
 
     @staticmethod
@@ -2474,6 +2496,9 @@ class ModelZooDeleteCommand(Command):
 
 class MigrateCommand(Command):
     """Tools for migrating the FiftyOne database.
+
+    See :ref:`this page <database-migrations>` for more information about
+    migrating FiftyOne deployments.
 
     Examples::
 

--- a/fiftyone/core/config.py
+++ b/fiftyone/core/config.py
@@ -76,6 +76,12 @@ class FiftyOneConfig(EnvConfig):
             env_var="FIFTYONE_DATABASE_VALIDATION",
             default=True,
         )
+        self.database_admin = self.parse_bool(
+            d,
+            "database_admin",
+            env_var="FIFTYONE_DATABASE_ADMIN",
+            default=True,
+        )
         self.database_dir = self.parse_path(
             d,
             "database_dir",
@@ -98,7 +104,10 @@ class FiftyOneConfig(EnvConfig):
             d, "model_zoo_dir", env_var="FIFTYONE_MODEL_ZOO_DIR", default=None
         )
         self.module_path = self.parse_string_array(
-            d, "module_path", env_var="FIFTYONE_MODULE_PATH", default=None,
+            d,
+            "module_path",
+            env_var="FIFTYONE_MODULE_PATH",
+            default=None,
         )
         self.dataset_zoo_manifest_paths = self.parse_path_array(
             d,
@@ -161,7 +170,10 @@ class FiftyOneConfig(EnvConfig):
             default=None,
         )
         self.desktop_app = self.parse_bool(
-            d, "desktop_app", env_var="FIFTYONE_DESKTOP_APP", default=False,
+            d,
+            "desktop_app",
+            env_var="FIFTYONE_DESKTOP_APP",
+            default=False,
         )
         self._show_progress_bars = None  # declare
         self.show_progress_bars = self.parse_bool(
@@ -171,7 +183,10 @@ class FiftyOneConfig(EnvConfig):
             default=True,
         )
         self.do_not_track = self.parse_bool(
-            d, "do_not_track", env_var="FIFTYONE_DO_NOT_TRACK", default=False,
+            d,
+            "do_not_track",
+            env_var="FIFTYONE_DO_NOT_TRACK",
+            default=False,
         )
         self.requirement_error_level = self.parse_int(
             d,
@@ -293,10 +308,16 @@ class AppConfig(EnvConfig):
             default=True,
         )
         self.show_index = self.parse_bool(
-            d, "show_index", env_var="FIFTYONE_APP_SHOW_INDEX", default=True,
+            d,
+            "show_index",
+            env_var="FIFTYONE_APP_SHOW_INDEX",
+            default=True,
         )
         self.show_label = self.parse_bool(
-            d, "show_label", env_var="FIFTYONE_APP_SHOW_LABEL", default=True,
+            d,
+            "show_label",
+            env_var="FIFTYONE_APP_SHOW_LABEL",
+            default=True,
         )
         self.show_tooltip = self.parse_bool(
             d,

--- a/fiftyone/migrations/runner.py
+++ b/fiftyone/migrations/runner.py
@@ -88,7 +88,8 @@ def migrate_database_if_necessary(destination=None, verbose=False):
     if _migrations_disabled():
         return
 
-    if destination is None:
+    use_client_version = destination is None
+    if use_client_version:
         destination = foc.VERSION
 
     config = foo.get_db_config()
@@ -108,12 +109,20 @@ def migrate_database_if_necessary(destination=None, verbose=False):
         return
 
     if not fo.config.database_admin:
-        raise EnvironmentError(
-            "Cannot connect to database v%s with client v%s when database_admin=%s. "
-            "See https://voxel51.com/docs/fiftyone/user_guide/config.html#database-migrations "
-            "for more information"
-            % (head, destination, fo.config.database_admin)
-        )
+        if use_client_version:
+            raise EnvironmentError(
+                "Cannot connect to database v%s with client v%s when database_admin=%s. "
+                "See https://voxel51.com/docs/fiftyone/user_guide/config.html#database-migrations "
+                "for more information"
+                % (head, destination, fo.config.database_admin)
+            )
+        else:
+            raise EnvironmentError(
+                "Cannot migrate database from v%s to v%s when database_admin=%s. "
+                "See https://voxel51.com/docs/fiftyone/user_guide/config.html#database-migrations "
+                "for more information"
+                % (head, destination, fo.config.database_admin)
+            )
 
     if _database_exists():
         runner = MigrationRunner(head=head, destination=destination)

--- a/fiftyone/migrations/runner.py
+++ b/fiftyone/migrations/runner.py
@@ -109,7 +109,7 @@ def migrate_database_if_necessary(destination=None, verbose=False):
 
     if not fo.config.database_admin:
         raise EnvironmentError(
-            "Cannot migrate database from v%s to v%s when database_admin=%s. "
+            "Cannot connect to database v%s with client v%s when database_admin=%s. "
             "See https://voxel51.com/docs/fiftyone/user_guide/config.html#database-migrations "
             "for more information"
             % (head, destination, fo.config.database_admin)


### PR DESCRIPTION
Adds a `database_admin` config setting that can optionally be used to disallow database/dataset migrations.

Also fixes some migration edge cases that were missed in https://github.com/voxel51/fiftyone/pull/1666.