### PR TITLE
Export tag attributes for CVATImageDatasets

### DIFF
--- a/fiftyone/resources/cvat_image_annotation_template.xml
+++ b/fiftyone/resources/cvat_image_annotation_template.xml
@@ -45,7 +45,11 @@
 {% for image in images %}
     <image id="{{ image.id }}" name="{{ image.name }}" width="{{ image.width }}" height="{{ image.height }}">
 {% for tag in image.tags %}
-        <tag label="{{ tag.label }}"></tag>
+        <tag label="{{ tag.label }}">
+{% for attr in tag.attributes %}
+            <attribute name="{{ attr.name }}">{{ attr.value }}</attribute>
+{% endfor %}
+        </tag>
 {% endfor %}
 {% for box in image.boxes %}
         <box label="{{ box.label }}" xtl="{{ box.xtl }}" ytl="{{ box.ytl }}" xbr="{{ box.xbr }}" ybr="{{ box.ybr }}"{% if box.occluded is not none %} occluded="{{ box.occluded }}"{% else %} occluded="0"{%endif %}>

--- a/fiftyone/utils/cvat.py
+++ b/fiftyone/utils/cvat.py
@@ -1623,11 +1623,12 @@ class CVATImageTag(CVATImageAnno):
 
     Args:
         label: the tag string
+        attributes (None): a list of :class:`CVATAttribute` instances
     """
 
-    def __init__(self, label):
+    def __init__(self, label, attributes=None):
         self.label = label
-        CVATImageAnno.__init__(self)
+        CVATImageAnno.__init__(self, attributes=attributes)
 
     def to_classification(self):
         """Returns a :class:`fiftyone.core.labels.Classification`
@@ -1636,7 +1637,8 @@ class CVATImageTag(CVATImageAnno):
         Returns:
             a :class:`fiftyone.core.labels.Classification`
         """
-        return fol.Classification(label=self.label)
+        attributes = self._to_attributes()
+        return fol.Classification(label=self.label, **attributes)
 
     @classmethod
     def from_classification(cls, classification):
@@ -1650,7 +1652,9 @@ class CVATImageTag(CVATImageAnno):
             a :class:`CVATImageTag`
         """
         label = classification.label
-        return cls(label)
+
+        _, attributes = cls._parse_attributes(classification)
+        return cls(label, attributes=attributes)
 
     @classmethod
     def from_tag_dict(cls, d):
@@ -1664,7 +1668,9 @@ class CVATImageTag(CVATImageAnno):
             a :class:`CVATImageTag`
         """
         label = d["@label"]
-        return cls(label)
+
+        _, attributes = cls._parse_anno_dict(d)
+        return cls(label, attributes=attributes)
 
 
 class CVATImageBox(CVATImageAnno):


### PR DESCRIPTION
Resolves #1682 

Exports classification attributes as tag attributes in `CVATImageDataset` format.

## Example:

```python
import fiftyone as fo
import fiftyone.zoo as foz

dataset = foz.load_zoo_dataset("quickstart", max_samples=1).select_fields().clone()
sample = dataset.first()
sample["cls"] = fo.Classification(label="test", attr1="val1")
sample.save()

dataset.export(
    labels_path="/tmp/coco_test.xml",
   dataset_type=fo.types.CVATImageDataset,
)
```
`/tmp/coco_test.xml`:
```
...
        </task>
        <dumped>2022-04-15T11:35:21.237133</dumped>
    </meta>
    <image id="0" name="000880.jpg" width="640" height="480">
        <tag label="test">
            <attribute name="attr1">val1</attribute>
        </tag>
    </image>
</annotations>
```