### PR TITLE
Automatically delete non-persistent datasets when using custom database URIs

### DIFF
--- a/fiftyone/constants.py
+++ b/fiftyone/constants.py
@@ -78,6 +78,7 @@ MIGRATIONS_REVISIONS_DIR = os.path.join(
     FIFTYONE_DIR, "migrations", "revisions"
 )
 MONGODB_VERSION_RANGE = (Version("4.4"), Version("4.5"))  # [min, max)
+DATABASE_APPNAME = "51py"
 
 # Server setup
 SERVER_DIR = os.path.join(FIFTYONE_DIR, "server")

--- a/fiftyone/constants.py
+++ b/fiftyone/constants.py
@@ -78,7 +78,7 @@ MIGRATIONS_REVISIONS_DIR = os.path.join(
     FIFTYONE_DIR, "migrations", "revisions"
 )
 MONGODB_VERSION_RANGE = (Version("4.4"), Version("4.5"))  # [min, max)
-DATABASE_APPNAME = "51py"
+DATABASE_APPNAME = "fiftyone"
 
 # Server setup
 SERVER_DIR = os.path.join(FIFTYONE_DIR, "server")

--- a/fiftyone/core/odm/__init__.py
+++ b/fiftyone/core/odm/__init__.py
@@ -9,6 +9,7 @@ from .database import (
     aggregate,
     get_db_config,
     establish_db_conn,
+    get_master_connection_count,
     get_db_client,
     get_db_conn,
     get_async_db_conn,

--- a/fiftyone/core/odm/database.py
+++ b/fiftyone/core/odm/database.py
@@ -95,6 +95,7 @@ def establish_db_conn(config):
         _connection_kwargs["port"] = int(established_port)
     if config.database_uri is not None:
         _connection_kwargs["host"] = config.database_uri
+        _db_service = fos.ExternalDatabaseService()
     elif _db_service is None:
         if os.environ.get("FIFTYONE_DISABLE_SERVICES", False):
             return

--- a/fiftyone/core/odm/database.py
+++ b/fiftyone/core/odm/database.py
@@ -155,7 +155,7 @@ def _async_connect():
 
 
 def get_master_connection_count():
-    """Counts the number of master connections to database from fiftyone app.
+    """Counts the number of master connections to database from fiftyone.
 
     Returns:
         -   Integer count of master connections

--- a/fiftyone/core/odm/database.py
+++ b/fiftyone/core/odm/database.py
@@ -155,7 +155,7 @@ def _async_connect():
 
 
 def get_master_connection_count():
-    """Counts the number of master connections to database from fiftyone.
+    """Counts the number of master connections to database from FiftyOne.
 
     Returns:
         -   Integer count of master connections

--- a/fiftyone/core/odm/database.py
+++ b/fiftyone/core/odm/database.py
@@ -95,7 +95,6 @@ def establish_db_conn(config):
         _connection_kwargs["port"] = int(established_port)
     if config.database_uri is not None:
         _connection_kwargs["host"] = config.database_uri
-        _db_service = fos.ExternalDatabaseService()
     elif _db_service is None:
         if os.environ.get("FIFTYONE_DISABLE_SERVICES", False):
             return
@@ -129,6 +128,9 @@ def establish_db_conn(config):
         **_connection_kwargs, appname=foc.DATABASE_APPNAME
     )
     _validate_db_version(config, _client)
+
+    if config.database_uri is not None and _db_service is None:
+        _db_service = fos.ExternalDatabaseService()
 
     connect(foc.DEFAULT_DATABASE, **_connection_kwargs)
 

--- a/fiftyone/core/service.py
+++ b/fiftyone/core/service.py
@@ -261,7 +261,7 @@ class ExternalDatabaseService(Service):
         import fiftyone.core.odm.database as food
 
         try:
-            if food.get_master_connection_count() == 1:
+            if food.get_master_connection_count() <= 1:
                 fod.delete_non_persistent_datasets()
             food.sync_database()
         except:
@@ -346,7 +346,7 @@ class DatabaseService(MultiClientService):
             return
 
         try:
-            if food.get_master_connection_count() == 1:
+            if food.get_master_connection_count() <= 1:
                 fod.delete_non_persistent_datasets()
             food.sync_database()
         except:


### PR DESCRIPTION
## What changes are proposed in this pull request?

Resolves #1345

Automatically delete non-persistent datasets when last of some number of concurrent database connections exits.

## How is this patch tested? If it is not, please explain why.

1. Start a client and create a new non-persistent dataset
2. Start one or more additional clients and list datasets (the non-persistent dataset should appear in this list)
3. Exit all but one client and list datasets (the non-persistent dataset should still appear in this list)
4. Exit the final client 
5. Start a new client and list datasets (the non-persistent dataset should no longer appear in this list)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

Non-persistent datasets are automatically cleaned up when using the built-in database or a custom database URI.

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
