### PR TITLE
[WIP] Integrate MLFlow for experiment tracking

### DIFF
--- a/docs/source/tutorials/mlflow_experiment_tracking.ipynb
+++ b/docs/source/tutorials/mlflow_experiment_tracking.ipynb
@@ -1,0 +1,180 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "8df42ce9",
+   "metadata": {},
+   "source": [
+    "# Experiment tracking with MLFlow"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2542ec1e",
+   "metadata": {},
+   "source": [
+    "Load a FiftyOne dataset:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9f7d9eb9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import fiftyone as fo\n",
+    "import fiftyone.zoo as foz\n",
+    "\n",
+    "dataset = foz.load_zoo_dataset(\"cifar10\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a31209df",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from itertools import chain\n",
+    "\n",
+    "import eta.core.utils as etau\n",
+    "\n",
+    "from flash.core.classification import FiftyOneLabelsOutput\n",
+    "from flash.image import ImageClassificationData, ImageClassifier\n",
+    "from flash import Trainer\n",
+    "\n",
+    "import fiftyone as fo\n",
+    "import fiftyone.utils.splits as fous\n",
+    "import fiftyone.zoo as foz\n",
+    "\n",
+    "import fiftyone.utils.mlflow as foum\n",
+    "\n",
+    "from pytorch_lightning.loggers import MLFlowLogger\n",
+    "\n",
+    "\n",
+    "def train_flash_model_with_mlflow(dataset, mlf_logger, pred_field):\n",
+    "    dataset.untag_samples(\"test\")\n",
+    "\n",
+    "    # Create splits from the dataset\n",
+    "    splits = {\"train\": 0.7, \"test\": 0.1, \"val\": 0.1, \"pred\": 0.1}\n",
+    "    fous.random_split(dataset, splits)\n",
+    "\n",
+    "    train_dataset = dataset.match_tags(\"train\")\n",
+    "    test_dataset = dataset.match_tags(\"test\")\n",
+    "    val_dataset = dataset.match_tags(\"val\")\n",
+    "    predict_dataset = dataset.match_tags(\"pred\")\n",
+    "\n",
+    "    # Create the Datamodule\n",
+    "    datamodule = ImageClassificationData.from_fiftyone(\n",
+    "        train_dataset=train_dataset,\n",
+    "        test_dataset=test_dataset,\n",
+    "        val_dataset=val_dataset,\n",
+    "        predict_dataset=predict_dataset,\n",
+    "        label_field=\"ground_truth\",\n",
+    "        batch_size=4,\n",
+    "        num_workers=4,\n",
+    "    )\n",
+    "\n",
+    "    # Build the model\n",
+    "    model = ImageClassifier(\n",
+    "        backbone=\"resnet18\",\n",
+    "        labels=datamodule.labels,\n",
+    "    )\n",
+    "    trainer = Trainer(\n",
+    "        max_epochs=1, limit_train_batches=5, limit_val_batches=5,\n",
+    "        logger=mlf_logger,\n",
+    "    )\n",
+    "    trainer.finetune(model, datamodule=datamodule)\n",
+    "\n",
+    "    predictions = trainer.predict(\n",
+    "        model,\n",
+    "        datamodule=datamodule,\n",
+    "        output=FiftyOneLabelsOutput(labels=datamodule.labels),\n",
+    "    )\n",
+    "    predictions = list(chain.from_iterable(predictions))  # flatten batches\n",
+    "\n",
+    "    # Map filepaths to predictions\n",
+    "    predictions = {p[\"filepath\"]: p[\"predictions\"] for p in predictions}\n",
+    "\n",
+    "    # Add predictions to FiftyOne dataset\n",
+    "    predict_dataset.set_values(\n",
+    "        pred_field, predictions, key_field=\"filepath\",\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8393b7b2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Initialize MLFlow (for flash in this case)\n",
+    "tracking_uri = \"file:/tmp/mlruns\"\n",
+    "mlf_logger = MLFlowLogger(experiment_name=\"fiftyone_test\", tracking_uri=tracking_uri)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6939c984",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pred_field = \"flash_predictions\"\n",
+    "train_flash_model_with_mlflow(dataset, mlf_logger, pred_field)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d89c6739",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Connect FiftyOne to MLFlow\n",
+    "fields = {\n",
+    "    \"ground_truth\": \"ground_truth\",\n",
+    "    \"predictions\": pred_field,\n",
+    "}\n",
+    "mlflow_key = \"mlflow_run_1\"\n",
+    "\n",
+    "foum.connect_flash_mlflogger(dataset, mlflow_key, mlf_logger, fields, tracking_uri)\n",
+    "# OR\n",
+    "#foum.connect_to_mlflow(dataset, mlflow_key, experiment_id, run_id, fields, tracking_uri)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "205af8f0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "foum.launch_mlflow(dataset, mlflow_key)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "mlf",
+   "language": "python",
+   "name": "mlf"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/fiftyone/utils/mlflow.py
+++ b/fiftyone/utils/mlflow.py
@@ -1,0 +1,182 @@
+""" Utiliies for working with MLFlow.
+
+| Copyright 2017-2022, Voxel51, Inc.
+| `voxel51.com <https://voxel51.com/>`_
+|
+"""
+import codecs
+from nbconvert.preprocessors import ExecutePreprocessor
+from nbconvert import HTMLExporter
+import os
+import webbrowser
+
+import eta.core.utils as etau
+
+import fiftyone.core.utils as fou
+
+mlflow = fou.lazy_import(
+    "mlflow", callback=lambda: fou.ensure_import("mlflow")
+)
+nbf = fou.lazy_import(
+    "nbformat", callback=lambda: fou.ensure_import("nbformat")
+)
+
+
+def connect_flash_mlflogger(
+    sample_collection, mlflow_key, mlf_logger, fields, tracking_uri
+):
+    experiment_id = mlf_logger._experiment_id
+    run_id = mlf_logger._run_id
+    connect_to_mlflow(
+        sample_collection,
+        mlflow_key,
+        experiment_id,
+        run_id,
+        fields,
+        tracking_uri,
+    )
+
+
+def connect_to_mlflow(
+    sample_collection, mlflow_key, experiment_id, run_id, fields, tracking_uri
+):
+    mlflow.set_tracking_uri(tracking_uri)
+    mlflow.start_run(run_id=run_id)
+    _populate_run_info(
+        sample_collection, experiment_id, mlflow_key, run_id, fields
+    )
+    _add_tags_to_run(sample_collection.name, fields)
+    _add_nb_to_run(sample_collection, mlflow_key)
+
+
+def launch_mlflow(sample_collection, mlflow_key):
+    url = sample_collection.info["mlflow"][mlflow_key]["url"]
+    webbrowser.open(url, new=2)
+
+
+def _populate_run_info(
+    sample_collection, experiment_id, mlflow_key, run_id, fields
+):
+    if "mlflow" not in sample_collection.info:
+        sample_collection.info["mlflow"] = {}
+
+    url = "http://localhost:5000/#/experiments/%s/runs/%s" % (
+        experiment_id,
+        run_id,
+    )
+    exp_info_dict = {
+        "gt_field": fields["ground_truth"],
+        "pred_field": fields["predictions"],
+        "experiment_id": experiment_id,
+        "run_id": run_id,
+        "url": url,
+    }
+    sample_collection.info["mlflow"][mlflow_key] = exp_info_dict
+
+
+def _add_tags_to_run(name, fields):
+    tags = {
+        "FiftyOne Dataset Name": name,
+        "FiftyOne Ground Truth Label Field": fields["ground_truth"],
+        "FiftyOne Predictions Label Field": fields["predictions"],
+    }
+    mlflow.log_params(tags)
+
+
+def _add_nb_to_run(sample_collection, mlflow_key):
+    nb_path, html_path = _create_nb(sample_collection, mlflow_key)
+    mlflow.log_artifact(nb_path)
+    mlflow.log_artifact(html_path)
+
+    etau.delete_file(html_path)
+    etau.delete_file(nb_path)
+
+
+def _create_nb(sample_collection, mlflow_key):
+    mlflow_info = sample_collection.info["mlflow"][mlflow_key]
+    run_id = mlflow_info["run_id"]
+    experiment_id = mlflow_info["experiment_id"]
+    gt_field = mlflow_info["gt_field"]
+    pred_field = mlflow_info["pred_field"]
+
+    # https://gist.github.com/fperez/9716279
+    nb = nbf.v4.new_notebook()
+    nb["cells"] = []
+    text = """\
+# FiftyOne Summary
+This notebook was automatically generated for experiment %s, run %s.""" % (
+        experiment_id,
+        run_id,
+    )
+    nb["cells"].append(nbf.v4.new_markdown_cell(text))
+
+    code = (
+        """\
+import fiftyone as fo
+import time
+
+dataset = fo.load_dataset("%s")"""
+        % sample_collection.name
+    )
+    nb["cells"].append(nbf.v4.new_code_cell(code))
+
+    code = """\
+import fiftyone.core.context as foc
+
+print(foc._get_context())
+foc._context = foc._IPYTHON"""
+    nb["cells"].append(nbf.v4.new_code_cell(code))
+
+    code = """\
+view = dataset.select_fields(["%s", "%s"])
+
+print(foc._get_context())
+session = fo.launch_app(view)
+#time.sleep(5)""" % (
+        gt_field,
+        pred_field,
+    )
+    nb["cells"].append(nbf.v4.new_code_cell(code))
+
+    code = """\
+session.freeze()
+#time.sleep(5)"""
+    nb["cells"].append(nbf.v4.new_code_cell(code))
+
+    code = """\
+results = dataset.evaluate_classifications(
+    "%s",
+    gt_field="%s",
+    eval_key="mlflow_eval",
+)""" % (
+        pred_field,
+        gt_field,
+    )
+    nb["cells"].append(nbf.v4.new_code_cell(code))
+
+    code = """\
+plot = results.plot_confusion_matrix()
+plot.show()
+#time.sleep(2)"""
+    nb["cells"].append(nbf.v4.new_code_cell(code))
+
+    code = """\
+plot.freeze()"""
+    nb["cells"].append(nbf.v4.new_code_cell(code))
+
+    ep = ExecutePreprocessor(timeout=600, kernel_name="mlf")
+    ep.preprocess(nb, {"metadata": {"path": "/tmp"}})
+
+    nb_path = "/tmp/fiftyone.ipynb"
+    html_path = "/tmp/fiftyone.html"
+
+    # Write ipython
+    with open(nb_path, "w", encoding="utf-8") as f:
+        nbf.write(nb, nb_path)
+
+    # Write HTML to view in MLFlow UI
+    exporter = HTMLExporter()
+    output, resources = exporter.from_notebook_node(nb)
+    codecs.open(html_path, "w", encoding="utf-8").write(output)
+
+    return nb_path, html_path


### PR DESCRIPTION
This PR is a first stab at integrating MLFlow with FiftyOne to link both the experiment tracking features of MLFlow with the visualization and evaluation of FiftyOne for a given training/prediction run of a model. The goal of this PR is also to provide a way to better manage various model runs in FiftyOne and provide utilities to plot and visualize interesting results across models, utilizing MLFlow as a way to compare experiment tracking results and experimental parameters between runs.

## TODO

There are still various things to figure out. At a high level, the first things to understand are the roles played model runs and collections of model runs (experiments?)  as well as what can be done with them. 

The idea is that a model run corresponds to a single training run and one set of model predictions, containing a ground truth and prediction field and the views used for training/testing/validation/prediction. The primary use of a model run is to organize fields, evaluation results, and views used for that run, as well as information to link to an external experiment tracker. Ideally all in a way that cleans up the underlying dataset from the clutter that is generated by multiple model/eval runs as they would be more contained. One way this could be done is to store predictions and eval results of each run in a cloned dataset, but then it is difficult to compare model results directly. Even if all predictions for an experiment are stored in one dataset, then you are still missing out on other metadata in the dataset that you may want to use for evaluation. Cross dataset views would be very useful here, if that could potentially be figured out with #1662.

An experiment would be tied to multiple model runs providing the ability to actually compare the results of different models which is really the end goal of model evaluation to begin with, to let you know which model is the best. This can be done a in variety of ways like automatically providing views of interest (ex: where the given model perform most differently) or plots comparing statistics of the model predictions (ex: distribution of confidences) and even pulling experiment data directly from the experiment tracking tool. MLFlow, for example, provides a view directly comparing different runs that can be linked from FiftyOne upon request.

This implementation is just a basic first attempt, ex: model runs should not be MLFlow specific. At the moment they are also just being stored in `dataset.info` as that is the simplest way to get this up and running.

## Setup

To make use of this, you will need to install and set up MLFlow:
```
pip install mlflow
```

This example works out of a temporary directory, as defined by the `tracking_uri` which comes up later
```
cd /tmp
mlflow ui
```

## Example

This is a basic example of training a PyTorch Lightning Flash model, tracking it with MLFlow and storing run results in FiftyOne. This will also require installation of flash:
```
pip install lightning-flash lightning-flash[image]
```

```python
from itertools import chain

import eta.core.utils as etau

from flash.core.classification import FiftyOneLabelsOutput
from flash.image import ImageClassificationData, ImageClassifier
from flash import Trainer

import fiftyone as fo
import fiftyone.utils.splits as fous
import fiftyone.zoo as foz

import fiftyone.utils.mlflow as foum

from pytorch_lightning.loggers import MLFlowLogger


def train_flash_model_with_mlflow(dataset, mlf_logger, pred_field):
    dataset.untag_samples("test")

    # Create splits from the dataset
    splits = {"train": 0.7, "test": 0.1, "val": 0.1, "pred": 0.1}
    fous.random_split(dataset, splits)

    train_dataset = dataset.match_tags("train")
    test_dataset = dataset.match_tags("test")
    val_dataset = dataset.match_tags("val")
    predict_dataset = dataset.match_tags("pred")

    # Create the Datamodule
    datamodule = ImageClassificationData.from_fiftyone(
        train_dataset=train_dataset,
        test_dataset=test_dataset,
        val_dataset=val_dataset,
        predict_dataset=predict_dataset,
        label_field="ground_truth",
        batch_size=4,
        num_workers=4,
    )

    # Build the model
    model = ImageClassifier(
        backbone="resnet18",
        labels=datamodule.labels,
    )
    trainer = Trainer(
        max_epochs=1, limit_train_batches=5, limit_val_batches=5,
        logger=mlf_logger,
    )
    trainer.finetune(model, datamodule=datamodule)

    predictions = trainer.predict(
        model,
        datamodule=datamodule,
        output=FiftyOneLabelsOutput(labels=datamodule.labels),
    )
    predictions = list(chain.from_iterable(predictions))  # flatten batches

    # Map filepaths to predictions
    predictions = {p["filepath"]: p["predictions"] for p in predictions}

    # Add predictions to FiftyOne dataset
    predict_dataset.set_values(
        pred_field, predictions, key_field="filepath",
    )

dataset = foz.load_zoo_dataset("cifar10", split="test", max_samples=200).clone()

# Initialize MLFlow (for flash in this case)
tracking_uri = "file:/tmp/mlruns"
mlf_logger = MLFlowLogger(experiment_name="fiftyone_test", tracking_uri=tracking_uri)

pred_field = "flash_predictions"
train_flash_model_with_mlflow(dataset, mlf_logger, pred_field)

train_view = dataset.match_tags("train")
pred_view = dataset.match_tags("pred")

run_id = mlf_logger.run_id
experiment_id = mlf_logger.experiment_id

# Connect FiftyOne to MLFlow
# Store run in FiftyOne on the dataset
# Update MLFlow run with FiftyOne-related artifacts and parameters

run_key = "mlflow_run_1"
run = foum.add_model_run(
    run_key,
    dataset,
    tracking_uri,
    run_id,
    experiment_id,
    gt_field="ground_truth",
    pred_field=pred_field,
    train_view=train_view,
    pred_view=pred_view,
)

# Connect to MLFlow from FiftyOne
foum.launch_mlflow(dataset, run_key)

# TODO: Experiments
# experiment = fo.Experiment(dataset)
# experiment.add_model_runs([run, run2])
# experiment.evaluate(runs=[run_key, run_key2])
```

In MLFlow, you are then able to access an automatically generated Jupyter notebook evaluating the model run with FiftyOne as well as a copy-pastable code snippet that can be used to load the dataset and run corresponding to the MLFlow run. Ideally, this code snippet would also include a link to the view that contains model predictions for this run in FiftyOne to be able to access the FiftyOne App through a single click rather than Python.

![image](https://user-images.githubusercontent.com/21222883/164088499-bda5e97d-ccec-4cc9-8594-44926a224df4.png)

