### PR TITLE
Automatically delete non-persistent datasets when using custom database URIs

### DIFF
--- a/fiftyone/__init__.py
+++ b/fiftyone/__init__.py
@@ -25,7 +25,9 @@ __version__ = _foc.VERSION
 from fiftyone.__public__ import *
 from fiftyone.core.uid import log_import_if_allowed as _log_import
 from fiftyone.migrations import migrate_database_if_necessary as _migrate
+from fiftyone.core.odm import establish_db_conn as _establish_db_conn
 
+_establish_db_conn(config)
 
 if _os.environ.get("FIFTYONE_DISABLE_SERVICES", "0") != "1":
     _migrate()

--- a/fiftyone/__init__.py
+++ b/fiftyone/__init__.py
@@ -23,9 +23,9 @@ import fiftyone.constants as _foc
 __version__ = _foc.VERSION
 
 from fiftyone.__public__ import *
+from fiftyone.core.odm import establish_db_conn as _establish_db_conn
 from fiftyone.core.uid import log_import_if_allowed as _log_import
 from fiftyone.migrations import migrate_database_if_necessary as _migrate
-from fiftyone.core.odm import establish_db_conn as _establish_db_conn
 
 _establish_db_conn(config)
 

--- a/fiftyone/__public__.py
+++ b/fiftyone/__public__.py
@@ -5,13 +5,11 @@ FiftyOne's public interface.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
-import fiftyone.core.config as foc
-import fiftyone.core.odm as foo
+import fiftyone.core.config as _foc
 
-config = foc.load_config()
-annotation_config = foc.load_annotation_config()
-app_config = foc.load_app_config()
-foo.establish_db_conn(config)
+config = _foc.load_config()
+annotation_config = _foc.load_annotation_config()
+app_config = _foc.load_app_config()
 
 from .core.aggregations import (
     Bounds,

--- a/fiftyone/constants.py
+++ b/fiftyone/constants.py
@@ -80,6 +80,7 @@ MIGRATIONS_REVISIONS_DIR = os.path.join(
 )
 MONGODB_VERSION_RANGE = (Version("4.4"), Version("4.5"))  # [min, max)
 DATABASE_APPNAME = "fiftyone"
+
 # Server setup
 SERVER_DIR = os.path.join(FIFTYONE_DIR, "server")
 

--- a/fiftyone/constants.py
+++ b/fiftyone/constants.py
@@ -79,7 +79,7 @@ MIGRATIONS_REVISIONS_DIR = os.path.join(
     FIFTYONE_DIR, "migrations", "revisions"
 )
 MONGODB_VERSION_RANGE = (Version("4.4"), Version("4.5"))  # [min, max)
-
+DATABASE_APPNAME = "fiftyone"
 # Server setup
 SERVER_DIR = os.path.join(FIFTYONE_DIR, "server")
 

--- a/fiftyone/core/odm/database.py
+++ b/fiftyone/core/odm/database.py
@@ -32,6 +32,8 @@ import fiftyone.core.utils as fou
 
 from .document import Document
 
+fod = fou.lazy_import("fiftyone.core.dataset")
+
 
 logger = logging.getLogger(__name__)
 
@@ -161,8 +163,6 @@ def establish_db_conn(config):
     )
     _validate_db_version(config, _client)
 
-    _autodelete_non_persistent_datasets(config, _client)
-
     connect(config.database_name, **_connection_kwargs)
 
     config = get_db_config()
@@ -171,6 +171,8 @@ def establish_db_conn(config):
             "Cannot connect to database type '%s' with client type '%s'"
             % (config.type, foc.CLIENT_TYPE)
         )
+
+    _delete_non_persistent_datasets_if_necessary()
 
 
 def _connect():
@@ -192,39 +194,33 @@ def _async_connect():
         )
 
 
-def _autodelete_non_persistent_datasets(config, client):
+def _delete_non_persistent_datasets_if_necessary():
     try:
-        cursor = client.admin.aggregate(
-            [
-                {"$currentOp": {"allUsers": True}},
-                {"$project": {"appName": 1, "command": 1}},
-                {
-                    "$match": {
-                        "appName": foc.DATABASE_APPNAME,
-                        "command.ismaster": 1,
-                    }
-                },
-            ]        )
-
+        num_connections = len(
+            list(
+                _client.admin.aggregate(
+                    [
+                        {"$currentOp": {"allUsers": True}},
+                        {"$project": {"appName": 1, "command": 1}},
+                        {
+                            "$match": {
+                                "appName": foc.DATABASE_APPNAME,
+                                "command.ismaster": 1,
+                            }
+                        },
+                    ]
+                )
+            )
+        )
     except Exception as e:
         logger.warning(
-            'Skipping automatic non-persistent dataset cleanup. This action requires read access of the "admin" database.'
+            "Skipping automatic non-persistent dataset cleanup. This action "
+            "requires read access of the 'admin' database"
         )
         return
 
-    conn_count = len(list(cursor))
-    if conn_count is None or conn_count > 1:
-        return
-
-    db = client[config.database_name]
-    has_datasets = False
-    for doc in db.datasets.find({"persistent": False}):
-        has_datasets = True
-        db.drop_collection(doc["sample_collection_name"])
-        db.drop_collection(doc["frame_collection_name"])
-
-    if has_datasets:
-        db.datasets.delete_many({"persistent": False})
+    if num_connections <= 1:
+        fod.delete_non_persistent_datasets()
 
 
 def _validate_db_version(config, client):
@@ -700,9 +696,7 @@ def delete_annotation_run(name, anno_key, dry_run=False):
     annotation_runs = dataset_dict.get("annotation_runs", {})
     if anno_key not in annotation_runs:
         _logger.warning(
-            "Dataset '%s' has no annotation run with key '%s'",
-            name,
-            anno_key,
+            "Dataset '%s' has no annotation run with key '%s'", name, anno_key,
         )
         return
 
@@ -859,9 +853,7 @@ def delete_brain_runs(name, dry_run=False):
             _delete_run_results(result_ids)
 
     _logger.info(
-        "Deleting brain method runs %s from dataset '%s'",
-        brain_keys,
-        name,
+        "Deleting brain method runs %s from dataset '%s'", brain_keys, name,
     )
     if not dry_run:
         dataset_dict["brain_methods"] = {}

--- a/fiftyone/core/odm/database.py
+++ b/fiftyone/core/odm/database.py
@@ -198,14 +198,7 @@ def _delete_non_persistent_datasets(config, client):
     db = client[config.database_name]
 
     has_datasets = False
-    for doc in db.datasets.find(
-        {"persistent": False},
-        {
-            "_id": 0,
-            "sample_collection_name": 1,
-            "frame_collection_name": 1,
-        },
-    ):
+    for doc in db.datasets.find({"persistent": False}):
         has_datasets = True
         db.drop_collection(doc["sample_collection_name"])
         db.drop_collection(doc["frame_collection_name"])

--- a/fiftyone/core/service.py
+++ b/fiftyone/core/service.py
@@ -133,15 +133,6 @@ class Service(object):
         """Waits for the service to exit and returns its exit code."""
         return self.child.wait()
 
-    @staticmethod
-    def cleanup():
-        """Performs any necessary cleanup when the service exits.
-
-        This is called by the subprocess (cf. ``service/main.py``) and is not
-        intended to be called directly.
-        """
-        pass
-
     def _wait_for_child_port(self, port=None, timeout=60):
         """Waits for any child process of this service to bind to a TCP port.
 
@@ -177,19 +168,6 @@ class Service(object):
             raise ServiceListenTimeout(etau.get_class_name(self), port)
 
         return find_port()
-
-    @classmethod
-    def find_subclass_by_name(cls, name):
-        for subclass in cls.__subclasses__():
-            if subclass.service_name == name:
-                return subclass
-
-            try:
-                return subclass.find_subclass_by_name(name)
-            except ValueError:
-                pass
-
-        raise ValueError("Unrecognized %s subclass: %s" % (cls.__name__, name))
 
 
 class MultiClientService(Service):
@@ -296,34 +274,6 @@ class DatabaseService(MultiClientService):
     @property
     def port(self):
         return self._wait_for_child_port()
-
-    @staticmethod
-    def cleanup():
-        """Deletes non-persistent datasets when the DB shuts down."""
-        import fiftyone.core.dataset as fod
-        import fiftyone.core.odm.database as food
-        import fiftyone.service.util as fosu
-
-        try:
-            port = next(
-                port
-                for child in psutil.Process().children()
-                for port in fosu.get_listening_tcp_ports(child)
-            )
-            food._connection_kwargs["port"] = port
-            food._connect()
-        except (StopIteration, psutil.Error):
-            # mongod may have exited - ok to wait until next time
-            return
-
-        try:
-
-            fod.delete_non_persistent_datasets()
-            food.sync_database()
-        except:
-            # something weird may have happened, like a downward DB migration
-            # - ok to wait until next time
-            pass
 
     @staticmethod
     def find_mongod():

--- a/fiftyone/service/main.py
+++ b/fiftyone/service/main.py
@@ -227,7 +227,6 @@ if not command:
     raise ValueError("No command given")
 if command[0].startswith("--"):
     raise ValueError("Unhandled service argument: %s" % command[0])
-service_class = Service.find_subclass_by_name(args.service_name)
 
 if args.multi:
     client_monitor = ClientMonitor()
@@ -285,13 +284,6 @@ def shutdown():
 
     Also dumps output if the main child process fails to exit cleanly.
     """
-    # attempt to call cleanup() for the running service
-    try:
-        service_class.cleanup()
-    except Exception:
-        sys.stderr.write("Error in %s.cleanup():\n" % service_class.__name__)
-        traceback.print_exc(file=sys.stderr)
-        sys.stderr.flush()
 
     # "yarn dev" doesn't pass SIGTERM to its children - to be safe, kill all
     # subprocesses of the child process first


### PR DESCRIPTION
Resolves https://github.com/voxel51/fiftyone/issues/1345
This is an alternate solution to #1687. 

Automatically delete non-persistent datasets upon sole connection to the database. This happens on connection time instead of exit.

Quickly test by running the following steps:
1. Open a new terminal session (Session # 1) and run `python`:
    ```python
    import fiftyone as fo
    dataset = fo.Dataset()
    fo.list_datasets()  # non-persistent dataset is listed
    ```

2. Keep Session # 1 running.

3. Open another terminal session (Session # 2):
    ```bash
    fiftyone datasets list  # non-persistent dataset is listed
    ```

4. Exit `python` in  Session # 1.
5. Back to Session # 2:
    ```bash
    fiftyone datasets list  # non-persistent dataset should no longer be listed
    ```

Should work for both a built-in and external Mongo database.  

