### PR TITLE
[WIP] Add Notebook Zoo

### DIFF
--- a/fiftyone/zoo/__init__.py
+++ b/fiftyone/zoo/__init__.py
@@ -6,3 +6,4 @@ voxel51.com
 """
 from .datasets import *
 from .models import *
+from .notebooks import *

--- a/fiftyone/zoo/notebooks/__init__.py
+++ b/fiftyone/zoo/notebooks/__init__.py
@@ -1,0 +1,31 @@
+"""
+The FiftyOne Notebook Zoo.
+
+| Copyright 2017-2022, Voxel51, Inc.
+| `voxel51.com <https://voxel51.com/>`_
+|
+"""
+
+
+def print_zoo_notebooks():
+    """Print a table of available notebooks and their arguments.
+    """
+    pass
+
+
+def list_zoo_notebooks():
+    """Return a list of names of available notebooks.
+    """
+    pass
+
+
+def list_downloaded_zoo_notebooks():
+    pass
+
+
+def is_zoo_notebook_downloaded(name):
+    pass
+
+
+def launch_zoo_notebook(name, **kwargs):
+    pass

--- a/fiftyone/zoo/notebooks/__init__.py
+++ b/fiftyone/zoo/notebooks/__init__.py
@@ -5,27 +5,137 @@ The FiftyOne Notebook Zoo.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+import IPython
+import IPython.core.magic as icm
+import IPython.extensions.storemagic as ies
+import notebook.notebookapp as nn
+import os
+
+import eta.core.serial as etas
+
+import fiftyone.core.collections as foc
+import fiftyone.core.dataset as fod
+import fiftyone.core.view as fov
 
 
-def print_zoo_notebooks():
-    """Print a table of available notebooks and their arguments.
-    """
+_THIS_DIR = os.path.dirname(os.path.abspath(__file__))
+_NOTEBOOK_MANIFEST_PATH = os.path.join(_THIS_DIR, "manifest.json")
+
+
+def launch_notebook(name, **kwargs):
+    nb_path = connect_to_notebook(name, **kwargs)
+    app = nn.NotebookApp()
+    app.initialize([])
+    app.launch_instance([nb_path])
+
+
+def connect_to_notebook(name, **kwargs):
+    manifest = ZooNotebookManifest.from_json(_NOTEBOOK_MANIFEST_PATH)
+    expected_kwargs = manifest.get_notebook_kwargs(name)
+    for arg_str, arg_val in kwargs.items():
+        if arg_str in expected_kwargs:
+            store_variable(arg_str, arg_val)
+
+    return os.path.join(_THIS_DIR, manifest.get_notebook_path(name))
+
+
+def store_variable(var_str, var_value):
+    if isinstance(var_value, foc.SampleCollection):
+        # @todo store views in a way that makes it clear they are a view and
+        # need to be unserialized at load time
+        _store_view(var_str, var_value)
+    else:
+        _store_var(var_str, var_value)
+
+
+def load_variable(var_str, shell=None):
+    # @todo load either a variable or an unserialized view
     pass
 
 
-def list_zoo_notebooks():
-    """Return a list of names of available notebooks.
-    """
-    pass
+class ZooNotebookManifest(object):
+    def __init__(self, notebooks_dict):
+        self.notebooks_dict = notebooks_dict
+
+    def has_notebook(self, name):
+        return name in self.notebooks_dict
+
+    def get_notebook_kwargs(self, name):
+        return self.notebooks_dict[name]["kwargs"]
+
+    def get_notebook_path(self, name):
+        return self.notebooks_dict[name]["notebook_path"]
+
+    @classmethod
+    def from_json(cls, json_path):
+        return cls(etas.load_json(json_path))
 
 
-def list_downloaded_zoo_notebooks():
-    pass
+@icm.magics_class
+class FiftyOneMagics(icm.Magics):
+    @icm.line_magic
+    def load_fo_view(self, variable_name):
+        obj = _load_view(variable_name, shell=self.shell)
+        self.shell.user_ns[variable_name] = obj
+
+    @icm.line_magic
+    def load_fo_var(self, variable_name):
+        obj = _load_var(variable_name, shell=self.shell)
+        self.shell.user_ns[variable_name] = obj
 
 
-def is_zoo_notebook_downloaded(name):
-    pass
+# Automatically register magic when in ipython environment
+ipython = IPython.get_ipython()
+if ipython:
+    ipython.register_magics(FiftyOneMagics)
 
 
-def launch_zoo_notebook(name, **kwargs):
-    pass
+def _store_var(arg_str, arg_val):
+    locals()[arg_str] = arg_val
+    shell = IPython.InteractiveShell(user_ns=locals())
+    magics = ies.StoreMagics(shell)
+    magics.store(arg_str)
+
+
+def _store_view(arg_str, view):
+    dataset_name = view._dataset.name
+    view_dict = view.view()._serialize()
+    dn_arg = arg_str + "_dataset_name"
+    view_d_arg = arg_str + "_view_dict"
+    _store_var(dn_arg, dataset_name)
+    _store_var(view_d_arg, view_dict)
+
+
+def _load_var(var_str, shell=None):
+    if not shell:
+        shell = IPython.InteractiveShell()
+    db = shell.db
+    var_names = {}
+    for var in db.keys("autorestore/*"):
+        var_name = os.path.basename(var)
+        var_names[var_name] = var
+
+    value = None
+
+    if var_str in var_names:
+        value = db.get(var_names[var_str])
+
+    return value
+
+
+def _load_view(arg_str, shell=None):
+    dn_arg = arg_str + "_dataset_name"
+    view_d_arg = arg_str + "_view_dict"
+
+    dataset_name = _load_var(dn_arg, shell=shell)
+
+    dataset = None
+    view = None
+    if dataset_name:
+        dataset = fod.load_dataset(dataset_name)
+
+    view_dict = _load_var(view_d_arg, shell=shell)
+    if view_dict and dataset:
+        view = fov.DatasetView._build(dataset, view_dict)
+
+    return view

--- a/fiftyone/zoo/notebooks/manifest.json
+++ b/fiftyone/zoo/notebooks/manifest.json
@@ -1,0 +1,9 @@
+{
+    "test": {
+        "kwargs": {
+            "view": "The FiftyOne DatasetView to load",
+            "field": "The field of the `view` to load"
+        },
+        "notebook_path": "test_nbzoo.ipynb"
+    }
+}

--- a/fiftyone/zoo/notebooks/test_nbzoo.ipynb
+++ b/fiftyone/zoo/notebooks/test_nbzoo.ipynb
@@ -1,0 +1,98 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "limiting-consumption",
+   "metadata": {},
+   "source": [
+    "# FiftyOne Notebook Zoo Test\n",
+    "\n",
+    "Automatically load variables from FiftyOne when this notebook is launched using\n",
+    "```python\n",
+    "import fiftyone.zoo as foz\n",
+    "\n",
+    "dataset = foz.load_zoo_dataset(\"quickstart\")\n",
+    "view = dataset[1:15]\n",
+    "field = \n",
+    "foz.launch_notebook(\n",
+    "    \"test\",\n",
+    "    view=view,\n",
+    "    field=\"ground_truth\",\n",
+    ")\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "welsh-investor",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import fiftyone as fo"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "electric-academy",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%load_fo_view view\n",
+    "%load_fo_var field"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "sized-grade",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(view)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "numeric-painting",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "selected_field_view = view.select_fields(field)\n",
+    "\n",
+    "print(selected_field_view)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "established-senior",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "fo",
+   "language": "python",
+   "name": "fo"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Goal: Add a zoo for notebooks that can be accessed directly through FiftyOne, easily utilize and pass variables from Python scripts/sessions to a zoo notebook, and make it easily extensible for community contributions.

This PR currently introduces a testing notebook that can be launched through a Python session that accepts a view and label field to be used in the notebook. The idea is that a notebook is able to specify any arguments that it needs and they can be passed directly to `foz.launch_notebook()`. Variables are passed using the built-in IPython [store magic](https://ipython.readthedocs.io/en/stable/config/extensions/storemagic.html?highlight=store), serializing variables into a database accessible across IPython sessions. Any thoughts/concerns are greatly appreciated.

## Example

```python
import fiftyone.zoo as foz

dataset = foz.load_zoo_dataset("quickstart")
view = dataset[1:15]
field = "ground_truth"

foz.launch_notebook(
    "test",
    view=view,
    field="ground_truth",
)
```

This automatically launches this notebook which can then load the `view` and `field` variables that were provided:
![image](https://user-images.githubusercontent.com/21222883/164791821-cc924bfa-39bb-4e94-9560-b916778c0a21.png)




Main TODOs:

* Finalize how the interaction between FiftyOne and a notebook should look
* Automatically serialize/deserialize views in a single function with other variables
* Add descriptions for variables required by a notebook to know what to pass into `launch_notebook()`
* Figure out how to best accept notebooks from a URL (or github repo?) and parse it into the manifest
* See how this works for remote workflows
