### PR TITLE
Fix pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,13 +1,13 @@
 repos:
   - repo: https://github.com/asottile/blacken-docs
-    rev: v1.6.0
+    rev: v1.12.1
     hooks:
       - id: blacken-docs
-        additional_dependencies: [black==19.10b0]
+        additional_dependencies: [black==22.3.0]
         args: ["-l 79"]
         exclude: ^docs/theme/|\.rst$
   - repo: https://github.com/ambv/black
-    rev: 19.10b0
+    rev: 22.3.0
     hooks:
       - id: black
         language_version: python3


### PR DESCRIPTION
Updates black and blacken-docs versions. The previous versions error.

```
rm -rf ~/.cache/pre-commit
rm .git/hooks/pre-commit
pre-commit install

# make a commit to install env
```