### PR TITLE
Adding Python 3.6 back to pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,9 +1,9 @@
 repos:
   - repo: https://github.com/asottile/blacken-docs
-    rev: v1.12.1
+    rev: v1.12.0
     hooks:
       - id: blacken-docs
-        additional_dependencies: [black==22.3.0]
+        additional_dependencies: [black==21.12b0]
         args: ["-l 79"]
         exclude: ^docs/theme/|\.rst$
   - repo: https://github.com/ambv/black

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -3,7 +3,7 @@
 -r extras.txt
 
 ipython==7.16.3
-pre-commit==2.18.1
+pre-commit==2.17.0
 pylint==2.3.1
 pytest==5.4.3
 twine>=3


### PR DESCRIPTION
The FiftyOne project currently supports Python 3.6+, and I currently do my development with Python 3.6.

Unfortunately, `blacken-docs==1.12.1` and `pre-commit==2.18.1` aren't available for Python 3.6, so https://github.com/voxel51/fiftyone/pull/1703 and https://github.com/voxel51/fiftyone/pull/1704 break our-pre-commit hooks for me.

This PR reverts to the latest versions of `blacken-docs`, `black`, and `pre-commit` that are available on Python 3.6 and avoid [this blacken-docs issue](https://github.com/psf/black/issues/2829) that occurs when using `black>22.1.0`.

```shell
pre-commit uninstall
rm -rf ~/.cache/pre-commit

pre-commit install

# make a commit to install env
```
