### PR TITLE
[WIP] Fields migration

### DIFF
--- a/docs/source/integrations/coco.rst
+++ b/docs/source/integrations/coco.rst
@@ -287,7 +287,7 @@ dataset:
         id:         fiftyone.core.fields.ObjectIdField
         filepath:   fiftyone.core.fields.StringField
         tags:       fiftyone.core.fields.ListField(fiftyone.core.fields.StringField)
-        metadata:   fiftyone.core.fields.EmbeddedDocumentField(fiftyone.core.metadata.Metadata)
+        metadata:   fiftyone.core.fields.EmbeddedDocumentField(fiftyone.core.metadata.ImageMetadata)
         detections: fiftyone.core.fields.EmbeddedDocumentField(fiftyone.core.labels.Detections)
         coco_id:    fiftyone.core.fields.IntField
 

--- a/docs/source/user_guide/basics.rst
+++ b/docs/source/user_guide/basics.rst
@@ -80,7 +80,6 @@ obtain a desired subset of the samples.
     Tags:           []
     Sample fields:
         id:         fiftyone.core.fields.ObjectIdField
-        media_type: fiftyone.core.fields.StringField
         filepath:   fiftyone.core.fields.StringField
         tags:       fiftyone.core.fields.ListField(fiftyone.core.fields.StringField)
         metadata:   fiftyone.core.fields.EmbeddedDocumentField(fiftyone.core.metadata.Metadata)
@@ -196,7 +195,7 @@ schema and thus accessible on all other samples in the dataset.
         id:        fiftyone.core.fields.ObjectIdField
         filepath:  fiftyone.core.fields.StringField
         tags:      fiftyone.core.fields.ListField(fiftyone.core.fields.StringField)
-        metadata:  fiftyone.core.fields.EmbeddedDocumentField(fiftyone.core.metadata.Metadata)
+        metadata:  fiftyone.core.fields.EmbeddedDocumentField(fiftyone.core.metadata.ImageMetadata)
         quality:   fiftyone.core.fields.FloatField
         keypoints: fiftyone.core.fields.ListField
         geo_json:  fiftyone.core.fields.DictField

--- a/docs/source/user_guide/evaluation.rst
+++ b/docs/source/user_guide/evaluation.rst
@@ -795,7 +795,7 @@ results of an evaluation on the
     Patch fields:
         filepath:     fiftyone.core.fields.StringField
         tags:         fiftyone.core.fields.ListField(fiftyone.core.fields.StringField)
-        metadata:     fiftyone.core.fields.EmbeddedDocumentField(fiftyone.core.metadata.Metadata)
+        metadata:     fiftyone.core.fields.EmbeddedDocumentField(fiftyone.core.metadata.ImageMetadata)
         predictions:  fiftyone.core.fields.EmbeddedDocumentField(fiftyone.core.labels.Detections)
         ground_truth: fiftyone.core.fields.EmbeddedDocumentField(fiftyone.core.labels.Detections)
         sample_id:    fiftyone.core.fields.StringField
@@ -1915,7 +1915,7 @@ You can also view frame-level evaluation results as
         id:           fiftyone.core.fields.ObjectIdField
         filepath:     fiftyone.core.fields.StringField
         tags:         fiftyone.core.fields.ListField(fiftyone.core.fields.StringField)
-        metadata:     fiftyone.core.fields.EmbeddedDocumentField(fiftyone.core.metadata.Metadata)
+        metadata:     fiftyone.core.fields.EmbeddedDocumentField(fiftyone.core.metadata.ImageMetadata)
         predictions:  fiftyone.core.fields.EmbeddedDocumentField(fiftyone.core.labels.Detections)
         detections:   fiftyone.core.fields.EmbeddedDocumentField(fiftyone.core.labels.Detections)
         sample_id:    fiftyone.core.fields.ObjectIdField

--- a/docs/source/user_guide/using_datasets.rst
+++ b/docs/source/user_guide/using_datasets.rst
@@ -635,10 +635,10 @@ By default, all |Sample| instances have the following fields:
     | `filepath`   | string                             | **REQUIRED**  | The path to the source data on disk. Must be      |
     |              |                                    |               | provided at sample creation time                  |
     +--------------+------------------------------------+---------------+---------------------------------------------------+
+    | `tags`       | list                               | `[]`          | A list of string tags for the sample              |
+    +--------------+------------------------------------+---------------+---------------------------------------------------+
     | `metadata`   | :class:`Metadata                   | `None`        | Type-specific metadata about the source data      |
     |              | <fiftyone.core.metadata.Metadata>` |               |                                                   |
-    +--------------+------------------------------------+---------------+---------------------------------------------------+
-    | `tags`       | list                               | `[]`          | A list of string tags for the sample              |
     +--------------+------------------------------------+---------------+---------------------------------------------------+
 
 .. code-block:: python
@@ -677,12 +677,15 @@ You can retrieve detailed information about the schema of the samples in a
 .. code-block:: python
     :linenos:
 
+    dataset = fo.Dataset("a_dataset")
+    dataset.add_sample(sample)
+
     dataset.get_field_schema()
 
 .. code-block:: text
 
     OrderedDict([
-        ('media_type', <fiftyone.core.fields.StringField at 0x11c77add8>),
+        ('id', <fiftyone.core.fields.ObjectIdField at 0x7fbaa862b358>),
         ('filepath', <fiftyone.core.fields.StringField at 0x11c77ae10>),
         ('tags', <fiftyone.core.fields.ListField at 0x11c790828>),
         ('metadata', <fiftyone.core.fields.EmbeddedDocumentField at 0x11c7907b8>)
@@ -700,15 +703,14 @@ printing it:
 
     Name:           a_dataset
     Media type:     image
-    Num samples:    0
+    Num samples:    1
     Persistent:     False
     Tags:           []
     Sample fields:
         id:         fiftyone.core.fields.ObjectIdField
-        media_type: fiftyone.core.fields.StringField
         filepath:   fiftyone.core.fields.StringField
         tags:       fiftyone.core.fields.ListField(fiftyone.core.fields.StringField)
-        metadata:   fiftyone.core.fields.EmbeddedDocumentField(fiftyone.core.metadata.Metadata)
+        metadata:   fiftyone.core.fields.EmbeddedDocumentField(fiftyone.core.metadata.ImageMetadata)
 
 The value of a |Field| for a given |Sample| can be accessed either by either
 attribute or item access:
@@ -744,15 +746,14 @@ updated to reflect the new field:
 
     Name:           a_dataset
     Media type:     image
-    Num samples:    0
+    Num samples:    1
     Persistent:     False
     Tags:           []
     Sample fields:
         id:            fiftyone.core.fields.ObjectIdField
-        media_type:    fiftyone.core.fields.StringField
         filepath:      fiftyone.core.fields.StringField
         tags:          fiftyone.core.fields.ListField(fiftyone.core.fields.StringField)
-        metadata:      fiftyone.core.fields.EmbeddedDocumentField(fiftyone.core.metadata.Metadata)
+        metadata:      fiftyone.core.fields.EmbeddedDocumentField(fiftyone.core.metadata.ImageMetadata)
         integer_field: fiftyone.core.fields.IntField
 
 A |Field| can be any primitive type, such as `bool`, `int`, `float`, `str`,
@@ -2836,7 +2837,7 @@ Video samples can be added to datasets just like image samples:
         id:       fiftyone.core.fields.ObjectIdField
         filepath: fiftyone.core.fields.StringField
         tags:     fiftyone.core.fields.ListField(fiftyone.core.fields.StringField)
-        metadata: fiftyone.core.fields.EmbeddedDocumentField(fiftyone.core.metadata.Metadata)
+        metadata: fiftyone.core.fields.EmbeddedDocumentField(fiftyone.core.metadata.VideoMetadata)
     Frame fields:
         id:           fiftyone.core.fields.ObjectIdField
         frame_number: fiftyone.core.fields.FrameNumberField

--- a/docs/source/user_guide/using_views.rst
+++ b/docs/source/user_guide/using_views.rst
@@ -40,7 +40,7 @@ You can explicitly create a view that contains an entire dataset via
         id:           fiftyone.core.fields.ObjectIdField
         filepath:     fiftyone.core.fields.StringField
         tags:         fiftyone.core.fields.ListField(fiftyone.core.fields.StringField)
-        metadata:     fiftyone.core.fields.EmbeddedDocumentField(fiftyone.core.metadata.Metadata)
+        metadata:     fiftyone.core.fields.EmbeddedDocumentField(fiftyone.core.metadata.ImageMetadata)
         ground_truth: fiftyone.core.fields.EmbeddedDocumentField(fiftyone.core.labels.Detections)
         uniqueness:   fiftyone.core.fields.FloatField
         predictions:  fiftyone.core.fields.EmbeddedDocumentField(fiftyone.core.labels.Detections)
@@ -856,7 +856,7 @@ detection dataset:
         id:           fiftyone.core.fields.ObjectIdField
         filepath:     fiftyone.core.fields.StringField
         tags:         fiftyone.core.fields.ListField(fiftyone.core.fields.StringField)
-        metadata:     fiftyone.core.fields.EmbeddedDocumentField(fiftyone.core.metadata.Metadata)
+        metadata:     fiftyone.core.fields.EmbeddedDocumentField(fiftyone.core.metadata.ImageMetadata)
         sample_id:    fiftyone.core.fields.ObjectIdField
         ground_truth: fiftyone.core.fields.EmbeddedDocumentField(fiftyone.core.labels.Detection)
     View stages:
@@ -981,7 +981,7 @@ respectively.
         id:           fiftyone.core.fields.ObjectIdField
         filepath:     fiftyone.core.fields.StringField
         tags:         fiftyone.core.fields.ListField(fiftyone.core.fields.StringField)
-        metadata:     fiftyone.core.fields.EmbeddedDocumentField(fiftyone.core.metadata.Metadata)
+        metadata:     fiftyone.core.fields.EmbeddedDocumentField(fiftyone.core.metadata.ImageMetadata)
         predictions:  fiftyone.core.fields.EmbeddedDocumentField(fiftyone.core.labels.Detections)
         ground_truth: fiftyone.core.fields.EmbeddedDocumentField(fiftyone.core.labels.Detections)
         sample_id:    fiftyone.core.fields.ObjectIdField
@@ -1132,7 +1132,7 @@ temporal segment by simply passing the name of the temporal detection field to
         filepath:  fiftyone.core.fields.StringField
         support:   fiftyone.core.fields.FrameSupportField
         tags:      fiftyone.core.fields.ListField(fiftyone.core.fields.StringField)
-        metadata:  fiftyone.core.fields.EmbeddedDocumentField(fiftyone.core.metadata.Metadata)
+        metadata:  fiftyone.core.fields.EmbeddedDocumentField(fiftyone.core.metadata.VideoMetadata)
         events:    fiftyone.core.fields.EmbeddedDocumentField(fiftyone.core.labels.Classification)
     Frame fields:
         id:           fiftyone.core.fields.ObjectIdField
@@ -1235,7 +1235,7 @@ that contains at least one person:
         filepath:  fiftyone.core.fields.StringField
         support:   fiftyone.core.fields.FrameSupportField
         tags:      fiftyone.core.fields.ListField(fiftyone.core.fields.StringField)
-        metadata:  fiftyone.core.fields.EmbeddedDocumentField(fiftyone.core.metadata.Metadata)
+        metadata:  fiftyone.core.fields.EmbeddedDocumentField(fiftyone.core.metadata.VideoMetadata)
     Frame fields:
         id:           fiftyone.core.fields.ObjectIdField
         frame_number: fiftyone.core.fields.FrameNumberField
@@ -1389,7 +1389,7 @@ frame of the videos in a |Dataset| or |DatasetView|:
         id:           fiftyone.core.fields.ObjectIdField
         filepath:     fiftyone.core.fields.StringField
         tags:         fiftyone.core.fields.ListField(fiftyone.core.fields.StringField)
-        metadata:     fiftyone.core.fields.EmbeddedDocumentField(fiftyone.core.metadata.Metadata)
+        metadata:     fiftyone.core.fields.EmbeddedDocumentField(fiftyone.core.metadata.ImageMetadata)
         sample_id:    fiftyone.core.fields.ObjectIdField
         frame_number: fiftyone.core.fields.FrameNumberField
         detections:   fiftyone.core.fields.EmbeddedDocumentField(fiftyone.core.labels.Detections)
@@ -1536,7 +1536,7 @@ sample per object patch in the frames of the dataset!
         id:           fiftyone.core.fields.ObjectIdField
         filepath:     fiftyone.core.fields.StringField
         tags:         fiftyone.core.fields.ListField(fiftyone.core.fields.StringField)
-        metadata:     fiftyone.core.fields.EmbeddedDocumentField(fiftyone.core.metadata.Metadata)
+        metadata:     fiftyone.core.fields.EmbeddedDocumentField(fiftyone.core.metadata.ImageMetadata)
         sample_id:    fiftyone.core.fields.ObjectIdField
         frame_id:     fiftyone.core.fields.ObjectIdField
         frame_number: fiftyone.core.fields.FrameNumberField
@@ -2223,15 +2223,16 @@ Let's say you have a dataset that looks like this:
 
 .. code-block:: bash
 
-    Name:           open-images-v4-test
-    Num samples:    1000
-    Persistent:     True
-    Tags:           []
+    Name:        open-images-v4-test
+    Media type:  image
+    Num samples: 1000
+    Persistent:  True
+    Tags:        []
     Sample fields:
         id:                       fiftyone.core.fields.ObjectIdField
         filepath:                 fiftyone.core.fields.StringField
         tags:                     fiftyone.core.fields.ListField(StringField)
-        metadata:                 fiftyone.core.fields.EmbeddedDocumentField(fiftyone.core.metadata.Metadata)
+        metadata:                 fiftyone.core.fields.EmbeddedDocumentField(fiftyone.core.metadata.ImageMetadata)
         open_images_id:           fiftyone.core.fields.StringField
         groundtruth_image_labels: fiftyone.core.fields.EmbeddedDocumentField(fiftyone.core.labels.Classifications)
         groundtruth_detections:   fiftyone.core.fields.EmbeddedDocumentField(fiftyone.core.labels.Detections)

--- a/fiftyone/migrations/revisions/v0_16_0.py
+++ b/fiftyone/migrations/revisions/v0_16_0.py
@@ -174,8 +174,11 @@ def _build_pipeline(path, is_list_field=False):
 
 
 def _parse_result(result):
+    if not result:
+        return []
+
     schema = defaultdict(set)
-    for name_and_type in result["schema"]:
+    for name_and_type in result[0]["schema"]:
         name, mongo_type = name_and_type.split(".", 1)
         if mongo_type == "objectId" and name.startswith("_"):
             name = name[1:]  # "_id" -> "id"

--- a/fiftyone/migrations/revisions/v0_16_0.py
+++ b/fiftyone/migrations/revisions/v0_16_0.py
@@ -11,13 +11,37 @@ def up(db, dataset_name):
     match_d = {"name": dataset_name}
     dataset_dict = db.datasets.find_one(match_d)
 
-    dataset_dict["app_sidebar_groups"] = None
+    media_type = dataset_dict.get("media_type", None)
 
-    for field in dataset_dict.get("sample_fields", []):
-        field["fields"] = []
+    embedded_doc_inds = []
+
+    for idx, field in enumerate(dataset_dict.get("sample_fields", [])):
+        name = field.get("name", None)
+        ftype = field.get("dtype", None)
+
+        if name == "metadata":
+            if media_type == "image":
+                embedded_doc_type = "fiftyone.core.metadata.ImageMetadata"
+                fields = _IMAGE_METADATA_FIELDS
+            elif media_type == "video":
+                embedded_doc_type = "fiftyone.core.metadata.VideoMetadata"
+                fields = _VIDEO_METADATA_FIELDS
+            else:
+                embedded_doc_type = "fiftyone.core.metadata.Metadata"
+                fields = _METADATA_FIELDS
+
+            field["embedded_doc_type"] = embedded_doc_type
+            field["fields"] = [_make_field_doc(n, t) for n, t in fields]
+        else:
+            field["fields"] = []
+
+        if ftype == "fiftyone.core.fields.EmbeddedDocumentField":
+            embedded_doc_inds.append(idx)
 
     for field in dataset_dict.get("frame_fields", []):
         field["fields"] = []
+
+    dataset_dict["app_sidebar_groups"] = None
 
     db.datasets.replace_one(match_d, dataset_dict)
 
@@ -26,12 +50,64 @@ def down(db, dataset_name):
     match_d = {"name": dataset_name}
     dataset_dict = db.datasets.find_one(match_d)
 
-    dataset_dict.pop("app_sidebar_groups", None)
-
     for field in dataset_dict.get("sample_fields", []):
+        if field.get("name", None) == "metadata":
+            field["embedded_doc_type"] = "fiftyone.core.metadata.Metadata"
+
         field.pop("fields", None)
 
     for field in dataset_dict.get("frame_fields", []):
         field.pop("fields", None)
 
+    dataset_dict.pop("app_sidebar_groups", None)
+
     db.datasets.replace_one(match_d, dataset_dict)
+
+
+def _make_field_doc(name, mongo_type):
+    return {
+        "_cls": "SampleFieldDocument",
+        "name": name,
+        "ftype": _MONGO_TO_FIFTYONE_TYPES[mongo_type],
+        "subfield": None,
+        "embedded_doc_type": None,
+        "db_field": name,
+        "fields": [],
+    }
+
+
+_METADATA_FIELDS = [
+    ("size_bytes", "int"),
+    ("mime_type", "string"),
+]
+
+_IMAGE_METADATA_FIELDS = [
+    ("size_bytes", "int"),
+    ("mime_type", "string"),
+    ("width", "int"),
+    ("height", "int"),
+    ("num_channels", "int"),
+]
+
+_VIDEO_METADATA_FIELDS = [
+    ("size_bytes", "int"),
+    ("mime_type", "string"),
+    ("frame_width", "int"),
+    ("frame_height", "int"),
+    ("frame_rate", "double"),
+    ("total_frame_count", "int"),
+    ("duration", "double"),
+    ("encoding_str", "string"),
+]
+
+_MONGO_TO_FIFTYONE_TYPES = {
+    "string": "fiftyone.core.fields.StringField",
+    "bool": "fiftyone.core.fields.BooleanField",
+    "int": "fiftyone.core.fields.IntField",
+    "long": "fiftyone.core.fields.IntField",
+    "double": "fiftyone.core.fields.FloatField",
+    "decimal": "fiftyone.core.fields.FloatField",
+    "array": "fiftyone.core.fields.ListField",
+    "object": "fiftyone.core.fields.DictField",
+    "objectId": "fiftyone.core.fields.ObjectIdField",
+}

--- a/fiftyone/migrations/revisions/v0_16_0.py
+++ b/fiftyone/migrations/revisions/v0_16_0.py
@@ -87,13 +87,18 @@ def down(db, dataset_name):
 
 
 def _make_field_doc(name, ftype, subfield):
+    if ftype == "fiftyone.core.fields.ObjectIdField":
+        db_field = "_" + name
+    else:
+        db_field = name
+
     return {
         "_cls": "SampleFieldDocument",
         "name": name,
         "ftype": ftype,
         "subfield": subfield,
         "embedded_doc_type": None,
-        "db_field": name,
+        "db_field": db_field,
         "fields": [],
     }
 
@@ -182,6 +187,9 @@ def _parse_result(result):
     schema = defaultdict(set)
     for name_and_type in result[0]["schema"]:
         name, mongo_type = name_and_type.split(".", 1)
+        if name == "_cls":
+            continue
+
         if mongo_type == "objectId" and name.startswith("_"):
             name = name[1:]  # "_id" -> "id"
 

--- a/fiftyone/migrations/revisions/v0_16_0.py
+++ b/fiftyone/migrations/revisions/v0_16_0.py
@@ -192,7 +192,7 @@ def _parse_result(result):
     for name, types in schema.items():
         if len(types) == 1:
             ftype = _MONGO_TO_FIFTYONE_TYPES.get(
-                types[0], "fiftyone.core.fields.Field"
+                next(iter(types)), "fiftyone.core.fields.Field"
             )
             fields.append((name, ftype, None))
 

--- a/fiftyone/migrations/revisions/v0_16_0.py
+++ b/fiftyone/migrations/revisions/v0_16_0.py
@@ -1,0 +1,37 @@
+"""
+FiftyOne v0.16.0 revision.
+
+| Copyright 2017-2022, Voxel51, Inc.
+| `voxel51.com <https://voxel51.com/>`_
+|
+"""
+
+
+def up(db, dataset_name):
+    match_d = {"name": dataset_name}
+    dataset_dict = db.datasets.find_one(match_d)
+
+    dataset_dict["app_sidebar_groups"] = None
+
+    for field in dataset_dict.get("sample_fields", []):
+        field["fields"] = []
+
+    for field in dataset_dict.get("frame_fields", []):
+        field["fields"] = []
+
+    db.datasets.replace_one(match_d, dataset_dict)
+
+
+def down(db, dataset_name):
+    match_d = {"name": dataset_name}
+    dataset_dict = db.datasets.find_one(match_d)
+
+    dataset_dict.pop("app_sidebar_groups", None)
+
+    for field in dataset_dict.get("sample_fields", []):
+        field.pop("fields", None)
+
+    for field in dataset_dict.get("frame_fields", []):
+        field.pop("fields", None)
+
+    db.datasets.replace_one(match_d, dataset_dict)

--- a/fiftyone/migrations/revisions/v0_16_0.py
+++ b/fiftyone/migrations/revisions/v0_16_0.py
@@ -174,6 +174,8 @@ def _build_pipeline(path, is_list_field=False):
 
 
 def _parse_result(result):
+    result = list(result)
+
     if not result:
         return []
 

--- a/fiftyone/migrations/revisions/v0_16_0.py
+++ b/fiftyone/migrations/revisions/v0_16_0.py
@@ -5,7 +5,6 @@ FiftyOne v0.16.0 revision.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
-from collections import defaultdict
 
 
 def up(db, dataset_name):
@@ -101,34 +100,14 @@ def _infer_fields(coll, name, embedded_doc_type):
             ltype = embedded_doc_type[:-1]  # remove "s"
             field["subfield"] = "fiftyone.core.fields.EmbeddedDocumentField"
             field["embedded_doc_type"] = ltype
-            field["fields"] = _do_infer_fields(
-                coll, list_path, ltype, is_list_field=True
-            )
+            field["fields"] = _do_infer_fields(coll, list_path, ltype)
 
     return fields
 
 
-def _do_infer_fields(coll, path, embedded_doc_type, is_list_field=False):
-    pipeline = _build_pipeline(path, is_list_field=is_list_field)
-    result = coll.aggregate(pipeline, allowDiskUse=True)
-    fields = _parse_result(result)
-
-    default_fields = _DEFAULT_LABEL_FIELDS.get(embedded_doc_type, None)
-    if default_fields is not None:
-        fields = _merge_fields(fields, default_fields)
-
+def _do_infer_fields(coll, path, embedded_doc_type):
+    fields = _DEFAULT_LABEL_FIELDS.get(embedded_doc_type, [])
     return [_make_field_doc(*f) for f in fields]
-
-
-def _merge_fields(fields, default_fields):
-    merged_fields = default_fields.copy()
-    default_names = set(f[0] for f in fields)
-
-    for f in fields:
-        if f[0] not in default_names:
-            merged_fields.append(f)
-
-    return merged_fields
 
 
 def _make_field_doc(name, ftype, subfield):
@@ -146,66 +125,6 @@ def _make_field_doc(name, ftype, subfield):
         "db_field": db_field,
         "fields": [],
     }
-
-
-def _build_pipeline(path, is_list_field=False):
-    pipeline = [{"$project": {path: True}}]
-
-    if is_list_field:
-        pipeline.append({"$unwind": "$" + path})
-
-    pipeline.extend(
-        [
-            {"$project": {"fields": {"$objectToArray": "$" + path}}},
-            {"$unwind": "$fields"},
-            {
-                "$group": {
-                    "_id": None,
-                    "schema": {
-                        "$addToSet": {
-                            "$concat": [
-                                "$fields.k",
-                                ".",
-                                {"$type": "$fields.v"},
-                            ]
-                        }
-                    },
-                }
-            },
-        ]
-    )
-
-    return pipeline
-
-
-def _parse_result(result):
-    result = list(result)
-
-    if not result:
-        return []
-
-    schema = defaultdict(set)
-    for name_and_type in result[0]["schema"]:
-        name, mongo_type = name_and_type.split(".", 1)
-        if name == "_cls":
-            continue
-
-        if mongo_type == "objectId" and name.startswith("_"):
-            name = name[1:]  # "_id" -> "id"
-
-        if mongo_type is not None:
-            schema[name].add(mongo_type)
-
-    fields = []
-    for name, mongo_types in schema.items():
-        if len(mongo_types) == 1:
-            mongo_type = next(iter(mongo_types))
-            ftype = _MONGO_TO_FIFTYONE_TYPES.get(
-                mongo_type, "fiftyone.core.fields.Field"
-            )
-            fields.append((name, ftype, None))
-
-    return fields
 
 
 # format: (name, ftype, subfield)
@@ -355,16 +274,4 @@ _LABEL_LIST_FIELDS = {
     "fiftyone.core.labels.Keypoints": "keypoints",
     "fiftyone.core.labels.Polylines": "polylines",
     "fiftyone.core.labels.TemporalDetections": "detections",
-}
-
-_MONGO_TO_FIFTYONE_TYPES = {
-    "string": "fiftyone.core.fields.StringField",
-    "bool": "fiftyone.core.fields.BooleanField",
-    "int": "fiftyone.core.fields.IntField",
-    "long": "fiftyone.core.fields.IntField",
-    "double": "fiftyone.core.fields.FloatField",
-    "decimal": "fiftyone.core.fields.FloatField",
-    "array": "fiftyone.core.fields.ListField",
-    "object": "fiftyone.core.fields.DictField",
-    "objectId": "fiftyone.core.fields.ObjectIdField",
 }

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ import re
 from setuptools import setup, find_packages
 
 
-VERSION = "0.15.1"
+VERSION = "0.16.0"
 
 
 def get_version():


### PR DESCRIPTION
This PR contains the cherry-picked commits from https://github.com/voxel51/fiftyone/pull/1666 with a migration update that only records default embedded document fields (not dynamic ones).

I included the `Metadata` -> `ImageMetadata`/`VideoMetadata` upgrade because I think it is a good thing to do.