### PR TITLE
Fixing GeoTIFF list bug

### DIFF
--- a/fiftyone/utils/geotiff.py
+++ b/fiftyone/utils/geotiff.py
@@ -96,9 +96,10 @@ class GeoTIFFDatasetImporter(
                 "Either `dataset_dir` or `image_path` must be provided"
             )
 
-        image_path = self._parse_labels_path(
-            dataset_dir=dataset_dir, labels_path=image_path
-        )
+        if not etau.is_container(image_path):
+            image_path = self._parse_labels_path(
+                dataset_dir=dataset_dir, labels_path=image_path
+            )
 
         super().__init__(
             dataset_dir=dataset_dir,


### PR DESCRIPTION
Previously an error would occur when passing a list of GeoTIFF images to the `image_path` argument of `GeoTIFFDatasetImporter`. Now this works as expected:

```py
import fiftyone as fo

dataset = fo.Dataset.from_dir(
    image_path=["/path/to/image.tif"],
    dataset_type=fo.types.GeoTIFFDataset,
)
```
