### PR TITLE
Avoid non-critical errors in startup services

### DIFF
--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -4583,19 +4583,17 @@ def _get_random_characters(n):
 def _list_datasets(include_private=False):
     conn = foo.get_db_conn()
 
+    if include_private:
+        query = {}
+    else:
+        # Datasets whose sample collections don't start with `samples.` are
+        # private e.g., patches or frames datasets
+        query = {"sample_collection_name": {"$regex": "^samples\\."}}
+
     # We don't want an error here if `name == None`
     _sort = lambda l: sorted(l, key=lambda x: (x is None, x))
 
-    if include_private:
-        return _sort(conn.datasets.distinct("name"))
-
-    # Datasets whose sample collections don't start with `samples.` are private
-    # e.g., patches or frames datasets
-    return _sort(
-        conn.datasets.find(
-            {"sample_collection_name": {"$regex": "^samples\\."}}
-        ).distinct("name")
-    )
+    return _sort(conn.datasets.find(query).distinct("name"))
 
 
 def _list_dataset_info():

--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -4583,12 +4583,15 @@ def _get_random_characters(n):
 def _list_datasets(include_private=False):
     conn = foo.get_db_conn()
 
+    # We don't want an error here if `name == None`
+    _sort = lambda l: sorted(l, key=lambda x: (x is None, x))
+
     if include_private:
-        return sorted(conn.datasets.distinct("name"))
+        return _sort(conn.datasets.distinct("name"))
 
     # Datasets whose sample collections don't start with `samples.` are private
     # e.g., patches or frames datasets
-    return sorted(
+    return _sort(
         conn.datasets.find(
             {"sample_collection_name": {"$regex": "^samples\\."}}
         ).distinct("name")

--- a/fiftyone/core/odm/database.py
+++ b/fiftyone/core/odm/database.py
@@ -237,8 +237,11 @@ def delete_non_persistent_datasets_if_allowed():
         )
         return
 
-    if num_connections <= 1:
-        fod.delete_non_persistent_datasets()
+    try:
+        if num_connections <= 1:
+            fod.delete_non_persistent_datasets()
+    except:
+        logger.exception("Skipping automatic non-persistent dataset cleanup")
 
 
 def _validate_db_version(config, client):

--- a/fiftyone/core/odm/database.py
+++ b/fiftyone/core/odm/database.py
@@ -628,7 +628,7 @@ def list_datasets():
         a list of :class:`Dataset` names
     """
     conn = get_db_conn()
-    return sorted([d["name"] for d in conn.datasets.find({})])
+    return conn.datasets.distinct("name")
 
 
 def delete_dataset(name, dry_run=False):


### PR DESCRIPTION
Every so often, a user will report that they've managed to get a dataset with `name==None` into their database, despite the code's best efforts to prevent this from occurring. This currently results in an error:

```
In fiftyone/core/dataset.py", line 4591, in _list_datasets:
    return sorted(conn.datasets.distinct("name"))
TypeError: '<' not supported between instances of 'str' and 'NoneType'
```

because `sorted()` does not like None. This PR patches that.

More generally, this PR throws a try-except around everything in the non-persistent dataset cleanup routine that runs at import time, because errors that prevent `import fiftyone as fo` from succeeding are catastrophic! The user has no access to the rest of the library to potentially fix any non-critical errors that exist.