### PR TITLE
[WIP] Add Experiments API

### DIFF
--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -27,6 +27,7 @@ import fiftyone.core.brain as fob
 import fiftyone.core.expressions as foe
 from fiftyone.core.expressions import ViewField as F
 import fiftyone.core.evaluation as foev
+import fiftyone.core.experiment as foex
 import fiftyone.core.fields as fof
 import fiftyone.core.frame as fofr
 import fiftyone.core.labels as fol
@@ -2236,6 +2237,83 @@ class SampleCollection(object):
         foev.EvaluationMethod.delete_runs(self)
 
     @property
+    def has_experiments(self):
+        """Whether this colection has any experiment results."""
+        return bool(self.list_experiments())
+
+    def has_experiment(self, exp_key):
+        """Whether this collection has an experiment with the given key.
+
+        Args:
+            exp_key: an experiment key
+
+        Returns:
+            True/False
+        """
+        return exp_key in self.list_experiments()
+
+    def list_experiments(self):
+        """Returns a list of all experiment keys on this collection.
+
+        Returns:
+            a list of experiment keys
+        """
+        return foex.ExperimentMethod.list_runs(self)
+
+    def get_experiment_info(self, exp_key):
+        """Returns information about the experiment with the given key on this
+        collection.
+
+        Args:
+            exp_key: an experiment key
+
+        Returns:
+            an :class:`fiftyone.core.experiment.ExperimentInfo`
+        """
+        return foex.ExperimentMethod.get_run_info(self, exp_key)
+
+    def load_experiment_results(self, exp_key):
+        """Loads the results for the experiment with the given key on this
+        collection.
+
+        Args:
+            exp_key: an experiment key
+
+        Returns:
+            a :class:`fiftyone.core.experiment.ExperimentResults`
+        """
+        return foex.ExperimentMethod.load_run_results(self, exp_key)
+
+    def load_experiment_view(self, exp_key, select_fields=False):
+        """Loads the :class:`fiftyone.core.view.DatasetView` on which the
+        specified experiment was performed on this collection.
+
+        Args:
+            exp_key: an experiment key
+            select_fields (False): whether to select only the fields involved
+                in the experiment
+
+        Returns:
+            a :class:`fiftyone.core.view.DatasetView`
+        """
+        return foex.ExperimentMethod.load_run_view(
+            self, exp_key, select_fields=select_fields
+        )
+
+    def delete_experiment(self, exp_key):
+        """Deletes the experiment results associated with the given experiment
+        key from this collection.
+
+        Args:
+            exp_key: an experiment key
+        """
+        foex.ExperimentMethod.delete_run(self, exp_key)
+
+    def delete_experiments(self):
+        """Deletes all experiment results from this collection."""
+        foex.ExperimentMethod.delete_runs(self)
+
+    @property
     def has_brain_runs(self):
         """Whether this colection has any brain runs."""
         return bool(self.list_brain_runs())
@@ -3219,7 +3297,10 @@ class SampleCollection(object):
         """
         return self._add_view_stage(
             fos.FilterKeypoints(
-                field, filter=filter, labels=labels, only_matches=only_matches,
+                field,
+                filter=filter,
+                labels=labels,
+                only_matches=only_matches,
             )
         )
 

--- a/fiftyone/core/experiment.py
+++ b/fiftyone/core/experiment.py
@@ -1,0 +1,64 @@
+"""
+Experiment framework.
+
+| Copyright 2017-2022, Voxel51, Inc.
+| `voxel51.com <https://voxel51.com/>`_
+|
+"""
+from fiftyone.core.runs import Run, RunConfig, RunInfo, RunResults
+
+
+class ExperimentInfo(RunInfo):
+    """Information about an experiment on a dataset.
+
+    Args:
+        key: the experiment key
+        timestamp (None): the UTC ``datetime`` when the experiment run was
+            initiated
+        config (None): the :class:`ExperimentMethodConfig` for the run
+    """
+
+    @classmethod
+    def config_cls(cls):
+        return ExperimentMethodConfig
+
+
+class ExperimentMethodConfig(RunConfig):
+    """Base class for configuring :class:`ExperimentMethod` instances.
+
+    Args:
+        **kwargs: any leftover keyword arguments after subclasses have done
+            their parsing
+    """
+
+    pass
+
+
+class ExperimentMethod(Run):
+    """Base class for experiment methods.
+
+    Args:
+        config: an :class:`ExperimentMethodConfig`
+    """
+
+    @classmethod
+    def run_info_cls(cls):
+        return ExperimentInfo
+
+    @classmethod
+    def _runs_field(cls):
+        return "experiments"
+
+    @classmethod
+    def _run_str(cls):
+        return "experiment"
+
+    @classmethod
+    def _results_cache_field(cls):
+        return "_experiment_cache"
+
+
+class ExperimentResults(RunResults):
+    """Base class for experiment results."""
+
+    pass

--- a/fiftyone/core/odm/dataset.py
+++ b/fiftyone/core/odm/dataset.py
@@ -257,3 +257,4 @@ class DatasetDocument(Document):
     )
     brain_methods = DictField(EmbeddedDocumentField(document_type=RunDocument))
     evaluations = DictField(EmbeddedDocumentField(document_type=RunDocument))
+    experiments = DictField(EmbeddedDocumentField(document_type=RunDocument))

--- a/fiftyone/utils/experiments.py
+++ b/fiftyone/utils/experiments.py
@@ -1,0 +1,236 @@
+"""
+Experiment utilities.
+
+| Copyright 2017-2022, Voxel51, Inc.
+| `voxel51.com <https://voxel51.com/>`_
+|
+"""
+import logging
+
+import eta.core.utils as etau
+
+import fiftyone as fo
+import fiftyone.core.dataset as fod
+import fiftyone.core.experiment as foe
+
+
+logger = logging.getLogger(__name__)
+
+
+EXPERIMENT_PREFIX = "experiment"
+
+
+def register_experiment(
+    samples,
+    exp_key,
+    label_fields=None,
+    backend=None,
+    **kwargs,
+):
+    config = _parse_config(backend, label_fields, exp_key, **kwargs)
+    exp_backend = config.build()
+    exp_backend.ensure_requirements()
+
+    exp_dataset = exp_backend.create_experiment_dataset(samples, exp_key)
+    results = exp_backend.construct_experiment(samples, exp_key, exp_dataset)
+
+    #
+    # Don't allow overwriting an existing run with same `exp_key`, since we
+    # need the existing run in order to perform workflows like automatically
+    # cleaning up the backend's tasks
+    #
+    exp_backend.register_run(samples, exp_key, overwrite=False)
+
+    exp_backend.save_run_results(samples, exp_key, results)
+
+    return results
+
+
+def add_model_run(samples, exp_key, run_key, predictions):
+
+    results = foe.ExperimentMethod.load_run_results(samples, exp_key)
+    results.add_model_run(run_key, predictions)
+
+    # Every time a new model run is added, the config must be updated
+    exp_backend = results.backend
+    config = results.config
+    exp_backend.update_run_config(samples, exp_key, config)
+
+    exp_backend.save_run_results(samples, exp_key, results)
+
+    return results
+
+
+def _parse_config(backend, label_fields, exp_key, **kwargs):
+    if backend is None:
+        backend = "manual"
+
+    if backend == "manual":
+        return ManualExperimentBackendConfig(label_fields, exp_key, **kwargs)
+
+    # if backend == "mlflow":
+    #    return MLFlowExperimentBackendConfig(label_fields, **kwargs)
+
+    raise ValueError("Unsupported experiment backend '%s'" % backend)
+
+
+class ExperimentBackendConfig(foe.ExperimentMethodConfig):
+    def __init__(self, label_fields, **kwargs):
+        super().__init__(**kwargs)
+
+        self.label_fields = label_fields
+
+    @property
+    def method(self):
+        """The name of the experiment backend."""
+        raise NotImplementedError("subclass must implement method")
+
+    def serialize(self, *args, **kwargs):
+        d = super().serialize(*args, **kwargs)
+        return d
+
+
+class ExperimentBackend(foe.ExperimentMethod):
+    """Base class for experiment backends.
+
+    Args:
+        config: an :class:`ExperimentBackendConfig`
+    """
+
+    def cleanup(self, samples, exp_key):
+        results = samples.load_experiment_results(exp_key)
+        exp_dataset = results.experiment_dataset
+        exp_dataset.delete()
+        results.cleanup()
+
+    def construct_experiment(self, samples, exp_key):
+        """
+        Returns:
+            an :class:`ExperimentResults`
+        """
+        raise NotImplementedError(
+            "subclass must implement construct_experiment()"
+        )
+
+    def create_experiment_dataset(self, samples, exp_key):
+        label_fields = self.config.label_fields
+        view = samples.select_fields(label_fields)
+
+        exp_name = "%s-experiment-%s" % (view.name, exp_key)
+        sample_collection_name = _make_exp_collection_name(view, exp_key)
+        exp_dataset = fod._clone_dataset_or_view(
+            view,
+            exp_name,
+            sample_collection_name=sample_collection_name,
+        )
+        exp_dataset.persistent = True
+        return exp_dataset
+
+
+def _make_exp_collection_name(samples, exp_key):
+    root_coll_name = samples._root_dataset._sample_collection_name
+    exp_coll_name = "%s.%s-%s" % (EXPERIMENT_PREFIX, root_coll_name, exp_key)
+    return exp_coll_name
+
+
+def _get_parent_sample_collection_name(exp_coll_name):
+    removed_key = exp_coll_name.split("-")[0]
+    return removed_key[len(EXPERIMENT_PREFIX + ".") :]
+
+
+def get_parent_dataset(exp_dataset):
+    exp_coll_name = exp_dataset._sample_collection_name
+    parent_coll_name = _get_parent_sample_collection_name(exp_coll_name)
+    return fod._get_dataset(parent_coll_name)
+
+
+class ExperimentResults(foe.ExperimentResults):
+    def __init__(self, samples, config, exp_dataset_name, backend=None):
+        if backend is None:
+            backend = config.build()
+            backend.ensure_requirements()
+
+        self._samples = samples
+        self._backend = backend
+        self._exp_dataset_name = exp_dataset_name
+
+    @property
+    def config(self):
+        """The :class:`ExperimentBackendConfig` for these results."""
+        return self._backend.config
+
+    @property
+    def backend(self):
+        """The :class:`ExperimentBackend` for these results."""
+        return self._backend
+
+    @property
+    def experiment_dataset(self):
+        return fod.load_dataset(self._exp_dataset_name)
+
+    def add_model_run(self, run_key, predictions):
+        pass
+
+    def evaluate(self):
+        pass
+
+    def list_notebooks(self):
+        raise NotImplementedError("subclass must implement list_notebooks()")
+
+    def launch_notebook(self):
+        raise NotImplementedError("subclass must implement launch_notebook()")
+
+    def launch_tracker(self):
+        raise NotImplementedError("subclass must implement launch_tracker()")
+
+    def cleanup(self):
+        """Deletes all information for this run from the experiment backend."""
+        raise NotImplementedError("subclass must implement cleanup()")
+
+    @classmethod
+    def _from_dict(cls, d, samples, config):
+        """Builds an :class:`ExperimentResults` from a JSON dict representation
+        of it.
+
+        Args:
+            d: a JSON dict
+            samples: the :class:`fiftyone.core.collections.SampleCollection`
+                for the run
+            config: the :class:`ExperimentBackendConfig` for the run
+
+        Returns:
+            an :class:`ExperimentResults`
+        """
+        raise NotImplementedError("subclass must implement _from_dict()")
+
+
+class ManualExperimentBackendConfig(ExperimentBackendConfig):
+    def __init__(self, label_fields, exp_key, exp_dir=None, **kwargs):
+        super().__init__(label_fields, **kwargs)
+        self.exp_key = exp_key
+        self.exp_dir = exp_dir
+
+    @property
+    def method(self):
+        return "manual"
+
+
+class ManualExperimentBackend(ExperimentBackend):
+    def construct_experiment(self, samples, exp_key, exp_dataset):
+        exp_dataset_name = exp_dataset.name
+        return ManualExperimentResults(
+            samples, self.config, exp_dataset_name, backend=self
+        )
+
+
+class ManualExperimentResults(ExperimentResults):
+    @classmethod
+    def _from_dict(cls, d, samples, config):
+        return cls(
+            samples,
+            config,
+            **d,
+        )
+
+    def cleanup(self):
+        pass

--- a/fiftyone/utils/experiments.py
+++ b/fiftyone/utils/experiments.py
@@ -37,7 +37,7 @@ def register_experiment(
     #
     # Don't allow overwriting an existing run with same `exp_key`, since we
     # need the existing run in order to perform workflows like automatically
-    # cleaning up the backend's tasks
+    # cleaning up the backend
     #
     exp_backend.register_run(samples, exp_key, overwrite=False)
 
@@ -67,9 +67,6 @@ def _parse_config(backend, label_fields, exp_key, **kwargs):
 
     if backend == "manual":
         return ManualExperimentBackendConfig(label_fields, exp_key, **kwargs)
-
-    # if backend == "mlflow":
-    #    return MLFlowExperimentBackendConfig(label_fields, **kwargs)
 
     raise ValueError("Unsupported experiment backend '%s'" % backend)
 

--- a/fiftyone/utils/experiments.py
+++ b/fiftyone/utils/experiments.py
@@ -166,6 +166,8 @@ class ExperimentResults(foe.ExperimentResults):
             )
         self._model_runs.append(run_key)
         self._add_predictions(run_key, predictions, key_field=key_field)
+        self._evaluate_model_run(run_key)
+
         self._add_run_to_backend(run_key, predictions)
 
         # Every time a new model run is added, the config may be updated
@@ -199,17 +201,28 @@ class ExperimentResults(foe.ExperimentResults):
     def _get_run_field(self, run_key):
         return "predictions-%s" % run_key
 
-    def evaluate(self):
-        pass
+    def _evaluate_model_run(self, run_key):
+        pred_type = self._get_pred_type(run_key)
 
-    def list_notebooks(self):
-        raise NotImplementedError("subclass must implement list_notebooks()")
+    def _get_pred_type(self, run_key):
+        # @todo parse predictions type to get required evaluation type
+        pred_type = None
+        return pred_type
 
-    def launch_notebook(self):
-        raise NotImplementedError("subclass must implement launch_notebook()")
+    def evaluate(self, run_keys=None):
+        if run_keys is None:
+            run_keys = self._model_runs
 
-    def launch_tracker(self):
-        raise NotImplementedError("subclass must implement launch_tracker()")
+        elif isinstance(run_keys, str):
+            run_keys = [run_keys]
+
+        if not isinstance(run_keys, list):
+            raise ValueError(
+                "Expected a run key string or a list of run keys for "
+                "'run_keys' argument."
+            )
+
+        # @todo add evaluation
 
     def cleanup(self):
         """Deletes all information for this run from the experiment backend."""


### PR DESCRIPTION
This PR adds an experiment API to FiftyOne for storing and managing runs of model predictions, similar to how brain/evaluation/annotation runs are managed. These changes provide a structured way to store and evaluate model predictions without the need to manually organize and clutter your dataset with custom label fields. Additionally, when using this experiment API, you have access to a variety of evaluation methods and notebooks that can be used to efficiently explore your model predictions.

Experiments are designed to be extensible to support various experiment tracking backends that can be linked to tools like MLFlow (coming in a follow-up PR). This initial implementation adds the `ManualExperimentBackend`


## Example:

```python
import fiftyone as fo
import fiftyone.zoo as foz
import fiftyone.utils.experiments as foue

dataset = foz.load_zoo_dataset("quickstart").clone()

results = dataset.register_experiment(
    "test_exp",
    label_fields=["ground_truth"],
    method="manual",
    exp_dir="/tmp/test_exp",
)

# Add model predictions
fps = dataset.values("filepath")

preds = {
    fps[0]: fo.Classification(label="test1", confidence=0.5),
    fps[1]: fo.Classification(label="test2", confidence=0.7),
}
run_key = "run1"

results.add_model_run(
    run_key,
    preds,
    key_field="filepath",
)

results.get_model_evaluation(run_key)

# TODO
results.evaluate([run_key], launch_notebook=True)
```

## Implementation highlights

* Experiments are initialized through an `ExperimentBackendConfig` that requires a unique experiment key, dataset/view associated with the experiment, and any information needed to connect to that experiment in an experiment tracking tool (ex: tracking URI and experiment ID for MLFlow)
* Upon creation of an experiment, the dataset/view will be cloned and any model predictions will be stored on that clone to avoid cluttering the parent dataset
* The experiment `ExperimentResults` object is the primary way to interact with an experiment to do things like adding model runs and evaluation
* Add a way to store custom metadata/text descriptions for each model run

# TODO

* Support additional methods for adding predictions other than lists of FiftyOne Label objects
* Parse prediction types and run automatic evaluation
* Add convenient evaluation methods to better explore model results (ex: `results.get_high_entropy_samples([run_key1, run_key2])`)
* Add notebooks with interesting default evaluation reports for different prediction label types
* Add documentation with examples and best practices for experiment tracking and model evaluation in FiftyOne