### PR TITLE
update pandas for arm64 compatibility

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -12,12 +12,12 @@ mongoengine==0.20.0
 motor==2.3.0
 ndjson==0.3.1
 packaging==20.3
-pandas==1.1.5
+pandas==1.4.2
 plotly==4.14.3
 pprintpp==0.4.0
 psutil==5.7.0
 pymongo==3.11.0
-pytz==2019.3
+pytz==2022.1
 PyYAML==5.4
 scikit-learn>=0.23.2
 scikit-image>=0.16.2


### PR DESCRIPTION
## What changes are proposed in this pull request?

The current version of pandas is incompatible with arm64 builds - this change makes `install.bash` work without further changes.

Bump `pandas` from 1.1.5 (December, 2020) to 1.4.2 (April, 2022)
Bump `pytz` from 2019.3 to 2022.1 (`pandas` dependency)

## How is this patch tested? If it is not, please explain why.

Built on Ubuntu 20.4 locally, and Apple M1 Pro running 12.3.1 (Monterey) - basic local functionality tested

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

Upgrades `pandas` from 1.1.5 to 1.4.2

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
