### PR TITLE
Use previous "cleanup" method

### DIFF
--- a/fiftyone/__init__.py
+++ b/fiftyone/__init__.py
@@ -29,6 +29,5 @@ import fiftyone.core.uid as _fou
 import fiftyone.migrations as _fom
 
 if _os.environ.get("FIFTYONE_DISABLE_SERVICES", "0") != "1":
-    _foo.delete_non_persistent_datasets_if_allowed()
     _fom.migrate_database_if_necessary()
     _fou.log_import_if_allowed()

--- a/fiftyone/core/odm/database.py
+++ b/fiftyone/core/odm/database.py
@@ -714,7 +714,9 @@ def delete_annotation_run(name, anno_key, dry_run=False):
     annotation_runs = dataset_dict.get("annotation_runs", {})
     if anno_key not in annotation_runs:
         _logger.warning(
-            "Dataset '%s' has no annotation run with key '%s'", name, anno_key,
+            "Dataset '%s' has no annotation run with key '%s'",
+            name,
+            anno_key,
         )
         return
 
@@ -871,7 +873,9 @@ def delete_brain_runs(name, dry_run=False):
             _delete_run_results(result_ids)
 
     _logger.info(
-        "Deleting brain method runs %s from dataset '%s'", brain_keys, name,
+        "Deleting brain method runs %s from dataset '%s'",
+        brain_keys,
+        name,
     )
     if not dry_run:
         dataset_dict["brain_methods"] = {}

--- a/fiftyone/service/main.py
+++ b/fiftyone/service/main.py
@@ -228,6 +228,8 @@ if not command:
 if command[0].startswith("--"):
     raise ValueError("Unhandled service argument: %s" % command[0])
 
+service_class = Service.find_subclass_by_name(args.service_name)
+
 if args.multi:
     client_monitor = ClientMonitor()
 
@@ -284,6 +286,13 @@ def shutdown():
 
     Also dumps output if the main child process fails to exit cleanly.
     """
+    # attempt to call cleanup() for the running service
+    try:
+        service_class.cleanup()
+    except Exception:
+        sys.stderr.write("Error in %s.cleanup():\n" % service_class.__name__)
+        traceback.print_exc(file=sys.stderr)
+        sys.stderr.flush()
 
     # "yarn dev" doesn't pass SIGTERM to its children - to be safe, kill all
     # subprocesses of the child process first


### PR DESCRIPTION
Reverting to old cleanup method for non-persistent datasets. Enabling automatic cleanup for external Mongo connections will require a bigger refactor than originally estimated. 

Fixes #1741


## Testing
Make sure your config has no reference to an external Mongo database.

Run the following code in the terminal twice to ensure non-persistent datasets are cleaned up.
```py
import fiftyone as fo

fo.list_datasets() # []

fo.Dataset('test)
fo.list_datasets() # ["test"]

exit()
```
