### PR TITLE
Cloning/merging bug fixes

### DIFF
--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -5554,7 +5554,8 @@ def _merge_samples_pipeline(
     sample_pipeline = src_collection._pipeline(detach_frames=True)
 
     if fields is not None:
-        project = {}
+        project = {key_field: True}
+
         for k, v in fields.items():
             k = db_fields_map.get(k, k)
             v = db_fields_map.get(v, v)

--- a/fiftyone/core/odm/mixins.py
+++ b/fiftyone/core/odm/mixins.py
@@ -633,24 +633,34 @@ class DatasetMixin(object):
             field_names = [prefix + f for f in field_names]
             new_field_names = [prefix + f for f in new_field_names]
 
-        field_roots = set()
+            root = lambda f: ".".join(f.split(".", 2)[:2])
+        else:
+            root = lambda f: f.split(".", 1)[0]
+
         view = sample_collection.view()
         for field_name, new_field_name in zip(field_names, new_field_names):
-            field_roots.add(field_name.split(".", 1)[0])
-            field_roots.add(new_field_name.split(".", 1)[0])
-
             new_base = new_field_name.rsplit(".", 1)[0]
             if "." in field_name:
                 base, leaf = field_name.rsplit(".", 1)
             else:
                 base, leaf = field_name, ""
 
-            expr = F(leaf) if new_base == base else F("$" + field_name)
+            if new_base == base:
+                expr = F(leaf)
+            else:
+                expr = F("$" + field_name)
+
             view = view.set_field(new_field_name, expr)
 
         view = view.mongo([{"$unset": field_names}])
 
-        view.save(list(field_roots))
+        #
+        # Ideally only the embedded field would be saved, but the `$merge`
+        # operator will always overwrite top-level fields of each document, so
+        # we limit the damage by projecting onto the modified fields
+        #
+        field_roots = list(set(root(f) for f in field_names + new_field_names))
+        view.save(field_roots)
 
     @classmethod
     def _clone_fields_simple(cls, field_names, new_field_names):
@@ -671,18 +681,23 @@ class DatasetMixin(object):
             field_names = [prefix + f for f in field_names]
             new_field_names = [prefix + f for f in new_field_names]
 
-        new_field_roots = set()
+            root = lambda f: ".".join(f.split(".", 2)[:2])
+        else:
+            root = lambda f: f.split(".", 1)[0]
+
         view = sample_collection.view()
         for field_name, new_field_name in zip(field_names, new_field_names):
-            new_field_roots.add(new_field_name.split(".", 1)[0])
-
             new_base = new_field_name.rsplit(".", 1)[0]
             if "." in field_name:
                 base, leaf = field_name.rsplit(".", 1)
             else:
                 base, leaf = field_name, ""
 
-            expr = F(leaf) if new_base == base else F("$" + field_name)
+            if new_base == base:
+                expr = F(leaf)
+            else:
+                expr = F("$" + field_name)
+
             view = view.set_field(new_field_name, expr)
 
         #
@@ -690,7 +705,8 @@ class DatasetMixin(object):
         # operator will always overwrite top-level fields of each document, so
         # we limit the damage by projecting onto the modified fields
         #
-        view.save(list(new_field_roots))
+        field_roots = list(set(root(f) for f in new_field_names))
+        view.save(field_roots)
 
     @classmethod
     def _clear_fields_simple(cls, field_names):
@@ -703,14 +719,13 @@ class DatasetMixin(object):
         if cls._is_frames_doc:
             prefix = sample_collection._FRAMES_PREFIX
             field_names = [prefix + f for f in field_names]
-            n = 2
-        else:
-            n = 1
 
-        field_roots = set()
+            root = lambda f: ".".join(f.split(".", 2)[:2])
+        else:
+            root = lambda f: f.split(".", 1)[0]
+
         view = sample_collection.view()
         for field_name in field_names:
-            field_roots.add(".".join(field_name.split(".", n)[:n]))
             view = view.set_field(field_name, None)
 
         #
@@ -718,7 +733,8 @@ class DatasetMixin(object):
         # operator will always overwrite top-level fields of each document, so
         # we limit the damage by projecting onto the modified fields
         #
-        view.save(list(field_roots))
+        field_roots = list(set(root(f) for f in field_names))
+        view.save(field_roots)
 
     @classmethod
     def _delete_fields_simple(cls, field_names):

--- a/tests/unittests/dataset_tests.py
+++ b/tests/unittests/dataset_tests.py
@@ -284,6 +284,17 @@ class DatasetTests(unittest.TestCase):
         common12 = common12_view.first()
         self.assertEqual(common12.field, common2.field)
 
+        # Merge specific fields, no new samples
+
+        dataset1c = dataset1.clone()
+        dataset1c.merge_samples(dataset2, fields=["field"], insert_new=False)
+        self.assertEqual(len(dataset1c), 2)
+        common12_view = dataset1c.match(F("filepath") == common_filepath)
+        self.assertEqual(len(common12_view), 1)
+
+        common12 = common12_view.first()
+        self.assertEqual(common12.field, common2.field)
+
         # Merge a view with excluded fields
 
         dataset21 = dataset1.clone()

--- a/tests/unittests/dataset_tests.py
+++ b/tests/unittests/dataset_tests.py
@@ -1004,61 +1004,61 @@ class DatasetTests(unittest.TestCase):
         dataset = fo.Dataset()
         sample = fo.Sample(
             filepath="image.jpg",
-            predictions=fo.Classification(label="friend", field=1),
+            predictions=fo.Detections(detections=[fo.Detection(field=1)]),
         )
         dataset.add_sample(sample)
 
         dataset.rename_sample_field(
-            "predictions.field", "predictions.new_field"
+            "predictions.detections.field",
+            "predictions.detections.new_field",
         )
-        self.assertIsNotNone(sample.predictions.new_field)
+        self.assertIsNotNone(sample.predictions.detections[0].new_field)
 
-        dataset.clear_sample_field("predictions.field")
-        self.assertIsNone(sample.predictions.field)
+        dataset.clear_sample_field("predictions.detections.field")
+        self.assertIsNone(sample.predictions.detections[0].field)
 
-        dataset.delete_sample_field("predictions.field")
-        self.assertIsNotNone(sample.predictions.new_field)
+        dataset.delete_sample_field("predictions.detections.field")
+        self.assertIsNotNone(sample.predictions.detections[0].new_field)
         with self.assertRaises(AttributeError):
-            sample.predictions.field
+            sample.predictions.detections[0].field
 
         dataset.rename_sample_field(
-            "predictions.new_field", "predictions.field"
+            "predictions.detections.new_field",
+            "predictions.detections.field",
         )
-        self.assertIsNotNone(sample.predictions.field)
+        self.assertIsNotNone(sample.predictions.detections[0].field)
         with self.assertRaises(AttributeError):
-            sample.predictions.new_field
+            sample.predictions.detections[0].new_field
 
     @drop_datasets
     @unittest.skip("TODO: Fix workflow errors. Must be run manually")
     def test_clone_fields(self):
         dataset = fo.Dataset()
-        sample = fo.Sample(
-            filepath="image.jpg", predictions=fo.Classification(label="friend")
-        )
+        sample = fo.Sample(filepath="image.jpg", field=1)
         dataset.add_sample(sample)
 
-        dataset.clone_sample_field("predictions", "predictions_copy")
+        dataset.clone_sample_field("field", "field_copy")
         schema = dataset.get_field_schema()
-        self.assertIn("predictions", schema)
-        self.assertIn("predictions_copy", schema)
-        self.assertIsNotNone(sample.predictions)
-        self.assertIsNotNone(sample.predictions_copy)
+        self.assertIn("field", schema)
+        self.assertIn("field_copy", schema)
+        self.assertIsNotNone(sample.field)
+        self.assertIsNotNone(sample.field_copy)
 
-        dataset.clear_sample_field("predictions")
+        dataset.clear_sample_field("field")
         schema = dataset.get_field_schema()
-        self.assertIn("predictions", schema)
-        self.assertIsNone(sample.predictions)
-        self.assertIsNotNone(sample.predictions_copy)
+        self.assertIn("field", schema)
+        self.assertIsNone(sample.field)
+        self.assertIsNotNone(sample.field_copy)
 
-        dataset.delete_sample_field("predictions")
-        self.assertIsNotNone(sample.predictions_copy)
+        dataset.delete_sample_field("field")
+        self.assertIsNotNone(sample.field_copy)
         with self.assertRaises(AttributeError):
-            sample.predictions
+            sample.field
 
-        dataset.rename_sample_field("predictions_copy", "predictions")
-        self.assertIsNotNone(sample.predictions)
+        dataset.rename_sample_field("field_copy", "field")
+        self.assertIsNotNone(sample.field)
         with self.assertRaises(AttributeError):
-            sample.predictions_copy
+            sample.field_copy
 
     @drop_datasets
     @unittest.skip("TODO: Fix workflow errors. Must be run manually")
@@ -1066,29 +1066,96 @@ class DatasetTests(unittest.TestCase):
         dataset = fo.Dataset()
         sample = fo.Sample(
             filepath="image.jpg",
-            predictions=fo.Classification(label="friend", field=1),
+            predictions=fo.Detections(detections=[fo.Detection(field=1)]),
         )
         dataset.add_sample(sample)
 
         dataset.clone_sample_field(
-            "predictions.field", "predictions.new_field"
+            "predictions.detections.field",
+            "predictions.detections.field_copy",
         )
-        self.assertIsNotNone(sample.predictions.new_field)
+        self.assertIsNotNone(sample.predictions.detections[0].field_copy)
 
-        dataset.clear_sample_field("predictions.field")
-        self.assertIsNone(sample.predictions.field)
+        dataset.clear_sample_field("predictions.detections.field")
+        self.assertIsNone(sample.predictions.detections[0].field)
 
-        dataset.delete_sample_field("predictions.field")
-        self.assertIsNotNone(sample.predictions.new_field)
+        dataset.delete_sample_field("predictions.detections.field")
+        self.assertIsNotNone(sample.predictions.detections[0].field_copy)
         with self.assertRaises(AttributeError):
-            sample.predictions.field
+            sample.predictions.detections[0].field
 
         dataset.rename_sample_field(
-            "predictions.new_field", "predictions.field"
+            "predictions.detections.field_copy",
+            "predictions.detections.field",
         )
-        self.assertIsNotNone(sample.predictions.field)
+        self.assertIsNotNone(sample.predictions.detections[0].field)
         with self.assertRaises(AttributeError):
-            sample.predictions.new_field
+            sample.predictions.detections[0].field_copy
+
+    @drop_datasets
+    @unittest.skip("TODO: Fix workflow errors. Must be run manually")
+    def test_clone_frame_fields(self):
+        dataset = fo.Dataset()
+        sample = fo.Sample(filepath="video.mp4")
+        frame = fo.Frame(field=1)
+        sample.frames[1] = frame
+        dataset.add_sample(sample)
+
+        dataset.clone_frame_field("field", "field_copy")
+        schema = dataset.get_frame_field_schema()
+        self.assertIn("field", schema)
+        self.assertIn("field_copy", schema)
+        self.assertIsNotNone(frame.field)
+        self.assertIsNotNone(frame.field_copy)
+
+        dataset.clear_frame_field("field")
+        schema = dataset.get_frame_field_schema()
+        self.assertIn("field", schema)
+        self.assertIsNone(frame.field)
+        self.assertIsNotNone(frame.field_copy)
+
+        dataset.delete_frame_field("field")
+        self.assertIsNotNone(frame.field_copy)
+        with self.assertRaises(AttributeError):
+            frame.field
+
+        dataset.rename_frame_field("field_copy", "field")
+        self.assertIsNotNone(frame.field)
+        with self.assertRaises(AttributeError):
+            frame.field_copy
+
+    @drop_datasets
+    @unittest.skip("TODO: Fix workflow errors. Must be run manually")
+    def test_clone_embedded_frame_fields(self):
+        dataset = fo.Dataset()
+        sample = fo.Sample(filepath="video.mp4")
+        frame = fo.Frame(
+            predictions=fo.Detections(detections=[fo.Detection(field=1)])
+        )
+        sample.frames[1] = frame
+        dataset.add_sample(sample)
+
+        dataset.clone_frame_field(
+            "predictions.detections.field",
+            "predictions.detections.field_copy",
+        )
+        self.assertIsNotNone(frame.predictions.detections[0].field_copy)
+
+        dataset.clear_frame_field("predictions.detections.field")
+        self.assertIsNone(frame.predictions.detections[0].field)
+
+        dataset.delete_frame_field("predictions.detections.field")
+        self.assertIsNotNone(frame.predictions.detections[0].field_copy)
+        with self.assertRaises(AttributeError):
+            frame.predictions.detections[0].field
+
+        dataset.rename_frame_field(
+            "predictions.detections.field_copy",
+            "predictions.detections.field",
+        )
+        self.assertIsNotNone(frame.predictions.detections[0].field)
+        with self.assertRaises(AttributeError):
+            frame.predictions.detections[0].field_copy
 
     @drop_datasets
     def test_classes(self):


### PR DESCRIPTION
Found a couple bugs in `merge_samples()`, `rename_frame_field()`, and `clone_frame_field()`. This PR fixes them.

### Merging samples

```py
import fiftyone as fo
import fiftyone.zoo as foz
from fiftyone import ViewField as F

dataset = foz.load_zoo_dataset("quickstart")

small_dataset = dataset[:100].select_fields("ground_truth").clone()
model_predictions = dataset[50:150]

# Previously would raise an error; now works
small_dataset.merge_samples(
    model_predictions,
    fields="predictions",
    insert_new=False,
    include_info=False,
)

assert len(small_dataset.exists("predictions")) == 50
```

### Renaming/cloning frame fields

```py
import fiftyone as fo
import fiftyone.zoo as foz

dataset = foz.load_zoo_dataset("quickstart-video")
frame = dataset.first().frames.first()

# Previously wouldn't populate `vehicle_type`, now does
dataset.clone_frame_field(
    "detections.detections.type",
    "detections.detections.vehicle_type",
)
assert (
    frame.detections.detections[0].vehicle_type
    == frame.detections.detections[0].type
)

# Previously wouldn't populate `still_type`, now does
dataset.rename_frame_field(
    "detections.detections.vehicle_type",
    "detections.detections.still_type",
)
assert (
    frame.detections.detections[0].still_type
    == frame.detections.detections[0].type
)

dataset.clear_frame_field("detections.detections.still_type")
assert frame.detections.detections[0].still_type is None

dataset.delete_frame_field("detections.detections.still_type")
assert "still_type" not in frame.detections.detections[0]
```
