### PR TITLE
Add installation of mongodb v6 for experimental apple silicon support

### DIFF
--- a/fiftyone/core/odm/database.py
+++ b/fiftyone/core/odm/database.py
@@ -165,13 +165,13 @@ def establish_db_conn(config):
                     "connection to your own MongoDB instance or cluster "
                 )
 
-            if fou.is_arm_mac():
-                raise FiftyOneConfigError(
-                    "MongoDB is not yet supported on Apple Silicon Macs. "
-                    "Please define a `database_uri` in your "
-                    "`fiftyone.core.config.FiftyOneConfig` to define a "
-                    "connection to your own MongoDB instance or cluster"
-                )
+            # if fou.is_arm_mac():
+            #     raise FiftyOneConfigError(
+            #         "MongoDB is not yet supported on Apple Silicon Macs. "
+            #         "Please define a `database_uri` in your "
+            #         "`fiftyone.core.config.FiftyOneConfig` to define a "
+            #         "connection to your own MongoDB instance or cluster"
+            #     )
 
             raise error
 

--- a/install.bash
+++ b/install.bash
@@ -55,10 +55,8 @@ MONGODB_SUPPORTED=true
 APPLE_SILICON=false
 if [ "${OS}" = "Darwin" ] && [ $(uname -m) = "arm64" ]; then
     APPLE_SILICON=true
-    if [ ${USE_APPLE_SILICON_MONGODB} != true ]; then
-        MONGODB_SUPPORTED=false
-    fi
-    if [ ${SCRATCH_MONGODB_INSTALL} = true ]; then
+
+    if [ ${SCRATCH_MONGODB_INSTALL} = true ] && [ ${USE_APPLE_SILICON_MONGODB} != true ]; then
         echo "***** NOT INSTALLING MONGODB *****"
         echo "Installing MongoDB from scratch is not currently supported on Apple Silicon."
         echo "You can override this using the -x flag. See help for more info."


### PR DESCRIPTION
## What changes are proposed in this pull request?

Add experimental support for mongodb 6 for apple silicon.

## How is this patch tested? If it is not, please explain why.

The install has been tested. Changes will still be required to enable the experimental support within fiftyone itself.

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

Need to discuss before releasing. Essentially this adds the installation bits for enabling `bash install.bash -m` for a different version of mongodb that supports apple silicon. This would need to be released as experimental until we actually support v6. 

This is mostly a useful utility for development of features unrelated to mongo, which is why I'd like to add it.

For this set of changes, the usage is as follows:

```
bash install.bash -m -x
```

 - the `-m` option to install mongo in the `~/.fiftyone` dir stays mostly the same
 - `-x` enables installing the macos + arm64 v6 rc build of mongodb

Note: this also addresses a bug in the installer, which will throw when attempting to check the version on apple silicon when `-m` is set.

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [x] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [x] Other - install
