### PR TITLE
Allow RunResults to contain BSON

### DIFF
--- a/fiftyone/core/runs.py
+++ b/fiftyone/core/runs.py
@@ -428,8 +428,8 @@ class Run(Configurable):
             run_doc.results = None
         else:
             # Write run result to GridFS
-            # @todo should we allow `run_results` to contain BSON?
-            results_bytes = run_results.to_str().encode()
+            # We use `json_util.dumps` so that run results may contain BSON
+            results_bytes = json_util.dumps(run_results.serialize()).encode()
             run_doc.results.put(results_bytes, content_type="application/json")
 
         # Cache the results for future use in this session
@@ -471,10 +471,10 @@ class Run(Configurable):
         # Load run result from GridFS
         view = cls.load_run_view(samples, key)
         run_doc.results.seek(0)
-        results_str = run_doc.results.read().decode()
+        d = json_util.loads(run_doc.results.read().decode())
 
         try:
-            run_results = RunResults.from_str(results_str, view, config)
+            run_results = RunResults.from_dict(d, view, config)
         except Exception as e:
             if run_doc.version == foc.VERSION:
                 raise e


### PR DESCRIPTION
https://github.com/voxel51/fiftyone/commit/01bd3e72afca8db737fa2506a10ce94bd918ccd0 removed the use of `json_util.dumps()` when serializing `RunResults`, which means that run results must now contain only valid JSON, not BSON constructs like `ObjectId`. However, some users have reported errors with this limitation because their `RunResults` do contain BSON. In particular, their `CVATAnnotationResults` contain `ObjectId`s.

I didn't have time to actually reproduce the error, nor test this PR, but I believe it should add BSON support back.

**Open question**: in looking at https://github.com/voxel51/fiftyone/commit/01bd3e72afca8db737fa2506a10ce94bd918ccd0, I'm confused because, while `save_run_results()` used to use `json_util.dumps()`, `load_run_results()` did not use `json_util.loads()`, so it seems to me that BSON constructs were never being properly deserialized... Was that a bug? I added what I believe is the proper BSON deserialization in this PR.