### PR TITLE
bump matplotlib to latest

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -9,7 +9,7 @@ httpx==0.7.7
 hypercorn==0.13.2
 Jinja2==3.0.3
 kaleido==0.2.1
-matplotlib==3.2.1
+matplotlib==3.5.2
 mongoengine==0.20.0
 motor==2.3.0
 ndjson==0.3.1


### PR DESCRIPTION
## What changes are proposed in this pull request?

bump matplotlib to latest - without this change I am unable to `bash install.bash -d` apple silicon.

## How is this patch tested? If it is not, please explain why.

I've only tested install on mac+arm64 python 3.10.4.

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?


<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
