### PR TITLE
Fix initial label renders

### DIFF
--- a/app/packages/app/src/Root/Root.tsx
+++ b/app/packages/app/src/Root/Root.tsx
@@ -42,8 +42,9 @@ import { RootDatasets_query$key } from "./__generated__/RootDatasets_query.graph
 import { RootGA_query$key } from "./__generated__/RootGA_query.graphql";
 import { RootNav_query$key } from "./__generated__/RootNav_query.graphql";
 import { useSetDataset, useStateUpdate } from "../utils/hooks";
-import { isElectron } from "@fiftyone/utilities";
+import { clone, isElectron } from "@fiftyone/utilities";
 import { getDatasetName } from "../utils/generic";
+import { RGB } from "@fiftyone/looker";
 
 const rootQuery = graphql`
   query RootQuery($search: String = "", $count: Int = 10, $cursor: String) {
@@ -256,7 +257,9 @@ const Root: Route<RootQuery> = ({ children, prepared }) => {
 
   const update = useStateUpdate();
   useEffect(() => {
-    update({ state: { config, colorscale } });
+    update({
+      state: { config: clone(config), colorscale: clone(colorscale) as RGB[] },
+    });
   }, []);
 
   return (

--- a/app/packages/components/src/components/Header/Header.tsx
+++ b/app/packages/components/src/components/Header/Header.tsx
@@ -7,18 +7,11 @@ import logo from "../../images/logo.png";
 
 import style from "./Header.module.css";
 
-interface Props {
+const Header: React.FC<React.PropsWithChildren<{
   onRefresh?: () => void;
   title: string;
   datasetSelectorProps?: SelectorProps<string>;
-}
-
-const Header: React.FC<Props> = ({
-  children,
-  title,
-  onRefresh,
-  datasetSelectorProps,
-}) => {
+}>> = ({ children, title, onRefresh, datasetSelectorProps }) => {
   const [toggle, setToggle] = useState(false);
   const logoProps = useSpring({
     transform: toggle ? `rotate(0turn)` : `rotate(1turn)`,


### PR DESCRIPTION
v0.16.0 introduced a bug in the App where labels in the grid are not drawn until statistics data has loaded for the sidebar. The unintended loading state is noticeable on larger datasets like BDD.

This PR fixes the issue by creating a version of the Looker options that does not depend on statistics while they load. Ideally, the options would not depend on statistics at all, and could be fixed by improving the Recoil dataflow.

Also fixes some TypeScript errors.