### PR TITLE
updating pylint to 2.13.9

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -3,7 +3,7 @@
 -r extras.txt
 
 ipython==7.16.3
-pre-commit==2.17.0
-pylint==2.3.1
+pre-commit==2.18.1
+pylint==2.13.9
 pytest==5.4.3
 twine>=3


### PR DESCRIPTION
The existing pylint version mishandles various typing scenarios. For example when using Optional[T] you will receive Value 'Optional' is unsubscriptable. The latest version resolves this issue.