### PR TITLE
adding missing ipython_genutils dependency

### DIFF
--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -1,6 +1,7 @@
 autodocsumm==0.2.7
 docutils==0.16
 ipykernel==5.3.0
+ipython_genutils==0.2.0
 jupyter-client==6.1.3
 nbsphinx==0.8.8
 sphinx-tabs==1.2.1


### PR DESCRIPTION
Jupyter doesn't pull in ipython_genutils automatically thus producing a module not found error during the docs build.  This explicitly adds it as a dependency to resolve the issue.