### PR TITLE
Fix bad format string

### DIFF
--- a/fiftyone/core/plots/base.py
+++ b/fiftyone/core/plots/base.py
@@ -615,8 +615,7 @@ def _parse_backend(backend):
     if backend not in available_backends:
         raise ValueError(
             "Unsupported plotting backend '%s'; supported values are %s"
-            % backend,
-            available_backends,
+            % (backend, available_backends)
         )
 
     return backend


### PR DESCRIPTION
## What changes are proposed in this pull request?

The ValueError raised when asking for an unsupported plotting backend was specified in a way that caused the following error: `TypeError: not enough arguments for format string`. I put the pair of format string arguments in a tuple following the example of a similar ValueError on [line 873](https://github.com/voxel51/fiftyone/blob/1a9c9bf0fe3f1a5a332629e2f711ab8d4358a7c4/fiftyone/core/plots/base.py#L873).

## How is this patch tested? If it is not, please explain why.

I ran the same code that revealed the error (edited from [here](https://voxel51.com/docs/fiftyone/user_guide/evaluation.html#map-and-pr-curves)), and this time saw the correct error message.

```python
import fiftyone as fo
import fiftyone.zoo as foz

dataset = foz.load_zoo_dataset("quickstart")
print(dataset)

# Performs an IoU sweep so that mAP and PR curves can be computed
results = dataset.evaluate_detections(
    "predictions",
    gt_field="ground_truth",
    compute_mAP=True,
)

print(results.mAP())
# 0.3957

plot = results.plot_pr_curves(backend="bokeh", classes=["person", "kite", "car"])
```

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
