### PR TITLE
Fixing DB field bug

### DIFF
--- a/fiftyone/core/odm/mixins.py
+++ b/fiftyone/core/odm/mixins.py
@@ -1101,7 +1101,7 @@ def _get_db_field(field, new_field_name):
         return None
 
     # This is hacky, but we must account for the fact that ObjectIdField often
-    # uses `db_field = "_<field_name>"
+    # uses db_field = "_<field_name>"
     if field.db_field == "_" + field.name:
         return "_" + new_field_name
 

--- a/fiftyone/core/odm/mixins.py
+++ b/fiftyone/core/odm/mixins.py
@@ -270,6 +270,7 @@ class DatasetMixin(object):
         for field_name in add_fields:
             field = schema[field_name]
             kwargs = get_field_kwargs(field)
+            kwargs["db_field"] = _get_db_field(field, field_name)
             cls._add_field_schema(field_name, **kwargs)
 
     @classmethod

--- a/tests/unittests/dataset_tests.py
+++ b/tests/unittests/dataset_tests.py
@@ -1054,6 +1054,10 @@ class DatasetTests(unittest.TestCase):
         self.assertIn("field_copy", schema)
         self.assertIsNotNone(sample.field)
         self.assertIsNotNone(sample.field_copy)
+        self.assertEqual(sample.field, 1)
+        self.assertEqual(sample.field_copy, 1)
+        self.assertListEqual(dataset.values("field"), [1])
+        self.assertListEqual(dataset.values("field_copy"), [1])
 
         dataset.clear_sample_field("field")
         schema = dataset.get_field_schema()
@@ -1085,7 +1089,16 @@ class DatasetTests(unittest.TestCase):
             "predictions.detections.field",
             "predictions.detections.field_copy",
         )
+        self.assertIsNotNone(sample.predictions.detections[0].field)
         self.assertIsNotNone(sample.predictions.detections[0].field_copy)
+        self.assertListEqual(
+            dataset.values("predictions.detections.field", unwind=True),
+            [1],
+        )
+        self.assertListEqual(
+            dataset.values("predictions.detections.field_copy", unwind=True),
+            [1],
+        )
 
         dataset.clear_sample_field("predictions.detections.field")
         self.assertIsNone(sample.predictions.detections[0].field)
@@ -1116,8 +1129,12 @@ class DatasetTests(unittest.TestCase):
         schema = dataset.get_frame_field_schema()
         self.assertIn("field", schema)
         self.assertIn("field_copy", schema)
-        self.assertIsNotNone(frame.field)
-        self.assertIsNotNone(frame.field_copy)
+        self.assertEqual(frame.field, 1)
+        self.assertEqual(frame.field_copy, 1)
+        self.assertListEqual(dataset.values("frames.field", unwind=True), [1])
+        self.assertListEqual(
+            dataset.values("frames.field_copy", unwind=True), [1]
+        )
 
         dataset.clear_frame_field("field")
         schema = dataset.get_frame_field_schema()
@@ -1150,7 +1167,18 @@ class DatasetTests(unittest.TestCase):
             "predictions.detections.field",
             "predictions.detections.field_copy",
         )
+        self.assertIsNotNone(frame.predictions.detections[0].field)
         self.assertIsNotNone(frame.predictions.detections[0].field_copy)
+        self.assertListEqual(
+            dataset.values("frames.predictions.detections.field", unwind=True),
+            [1],
+        )
+        self.assertListEqual(
+            dataset.values(
+                "frames.predictions.detections.field_copy", unwind=True
+            ),
+            [1],
+        )
 
         dataset.clear_frame_field("predictions.detections.field")
         self.assertIsNone(frame.predictions.detections[0].field)

--- a/tests/unittests/dataset_tests.py
+++ b/tests/unittests/dataset_tests.py
@@ -1006,6 +1006,7 @@ class DatasetTests(unittest.TestCase):
         self.assertFalse("field" in dataset.get_field_schema())
         self.assertTrue("new_field" in dataset.get_field_schema())
         self.assertEqual(sample["new_field"], 1)
+        self.assertListEqual(dataset.values("new_field"), [1])
         with self.assertRaises(KeyError):
             sample["field"]
 
@@ -1023,7 +1024,13 @@ class DatasetTests(unittest.TestCase):
             "predictions.detections.field",
             "predictions.detections.new_field",
         )
-        self.assertIsNotNone(sample.predictions.detections[0].new_field)
+        self.assertEqual(sample.predictions.detections[0].new_field, 1)
+        self.assertListEqual(
+            dataset.values("predictions.detections.new_field", unwind=True),
+            [1],
+        )
+        with self.assertRaises(AttributeError):
+            sample.predictions.detections[0].field
 
         dataset.clear_sample_field("predictions.detections.field")
         self.assertIsNone(sample.predictions.detections[0].field)

--- a/tests/unittests/dataset_tests.py
+++ b/tests/unittests/dataset_tests.py
@@ -1044,7 +1044,11 @@ class DatasetTests(unittest.TestCase):
             "predictions.detections.new_field",
             "predictions.detections.field",
         )
-        self.assertIsNotNone(sample.predictions.detections[0].field)
+        self.assertEqual(sample.predictions.detections[0].field, 1)
+        self.assertListEqual(
+            dataset.values("predictions.detections.field", unwind=True),
+            [1],
+        )
         with self.assertRaises(AttributeError):
             sample.predictions.detections[0].new_field
 


### PR DESCRIPTION
Fixes a small bug I encountered where `Field.db_field` was not being properly updated when `Dataset.clone_sample_field()` and `Dataset.clone_frame_field()` are invoked.

The unit tests are now properly updated to validate the correct behavior, and I ran them locally to verify correctness. However, these tests are still not included in CI because they're being skipped due to Windows errors (and tbh I don't know how to fix them).

```py
import fiftyone as fo
import fiftyone.zoo as foz

dataset = foz.load_zoo_dataset("quickstart")

dataset.clone_sample_field("ground_truth", "gt")

assert dataset.count("ground_truth.detections") == 1232
assert dataset.count("gt.detections") == 1232

sample = dataset.first()

assert sample.ground_truth is not None  # fails on `develop`, now succeeds
assert sample.gt is not None
```
