### PR TITLE
[WIP] Adding dynamic fields to schema #2

### DIFF
--- a/fiftyone/__public__.py
+++ b/fiftyone/__public__.py
@@ -21,6 +21,7 @@ from .core.aggregations import (
     Distinct,
     HistogramValues,
     Mean,
+    Schema,
     Std,
     Sum,
     Values,

--- a/fiftyone/core/aggregations.py
+++ b/fiftyone/core/aggregations.py
@@ -5,7 +5,7 @@ Aggregations.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
-from collections import OrderedDict
+from collections import defaultdict, OrderedDict
 from copy import deepcopy
 from datetime import date, datetime
 
@@ -17,6 +17,7 @@ import fiftyone.core.expressions as foe
 from fiftyone.core.expressions import VALUE
 from fiftyone.core.expressions import ViewField as F
 import fiftyone.core.fields as fof
+import fiftyone.core.labels as fol
 import fiftyone.core.media as fom
 import fiftyone.core.utils as fou
 
@@ -1226,6 +1227,205 @@ class Mean(Aggregation):
         return pipeline
 
 
+class Schema(Aggregation):
+    """Extracts the names and types of the attributes of a specified embedded
+    document field across all samples in a collection.
+
+    Schema aggregations are useful for detecting the presence and types of
+    dynamic attributes of :class:`fiftyone.core.labels.Label` fields in across
+    a collection.
+
+    Examples::
+
+        import fiftyone as fo
+        import fiftyone.core.aggregations as foa
+
+        dataset = fo.Dataset()
+
+        sample1 = fo.Sample(
+            filepath="image1.png",
+            ground_truth=fo.Detections(
+                detections=[
+                    fo.Detection(
+                        label="cat",
+                        bounding_box=[0.1, 0.1, 0.4, 0.4],
+                        foo="bar",
+                        hello=True,
+                    ),
+                    fo.Detection(
+                        label="dog",
+                        bounding_box=[0.5, 0.5, 0.4, 0.4],
+                        hello=None,
+                    )
+                ]
+            )
+        )
+
+        sample2 = fo.Sample(
+            filepath="image2.png",
+            ground_truth=fo.Detections(
+                detections=[
+                    fo.Detection(
+                        label="rabbit",
+                        bounding_box=[0.1, 0.1, 0.4, 0.4],
+                        foo=None,
+                    ),
+                    fo.Detection(
+                        label="squirrel",
+                        bounding_box=[0.5, 0.5, 0.4, 0.4],
+                        hello="there",
+                    ),
+                ]
+            )
+        )
+
+        dataset.add_samples([sample1, sample2])
+
+        #
+        # Get schema of all dynamic attributes on the detections in a
+        # `Detections` field
+        #
+
+        aggregation = foa.Schema("ground_truth", dynamic_only=True)
+        print(dataset.aggregate(aggregation))
+        # {'foo': StringField, 'hello': [BooleanField, StringField]}
+
+    Args:
+        field_or_expr: a field name, ``embedded.field.name``,
+            :class:`fiftyone.core.expressions.ViewExpression`, or
+            `MongoDB expression <https://docs.mongodb.com/manual/meta/aggregation-quick-reference/#aggregation-expressions>`_
+            defining the field or expression to aggregate
+        expr (None): a :class:`fiftyone.core.expressions.ViewExpression` or
+            `MongoDB expression <https://docs.mongodb.com/manual/meta/aggregation-quick-reference/#aggregation-expressions>`_
+            to apply to ``field_or_expr`` (which must be a field) before
+            aggregating
+        dynamic_only (False): whether to only include dynamically added
+            attributes
+    """
+
+    def __init__(
+        self,
+        field_or_expr,
+        expr=None,
+        dynamic_only=False,
+        _include_private=False,
+        _raw=False,
+    ):
+        super().__init__(field_or_expr, expr=expr)
+        self.dynamic_only = dynamic_only
+        self._include_private = _include_private
+        self._raw = _raw
+        self._doc_type = None
+
+    def default_result(self):
+        """Returns the default result for this aggregation.
+
+        Returns:
+            ``{}``
+        """
+        return {}
+
+    def parse_result(self, d):
+        """Parses the output of :meth:`to_mongo`.
+
+        Args:
+            d: the result dict
+
+        Returns:
+            a dict mapping field names to :class:`fiftyone.core.fields.Field`
+            instances. If a field's values takes multiple non-None types, the
+            list of observed types will be returned
+        """
+        if self._doc_type is not None:
+            doc_fields = self._doc_type._fields
+        else:
+            doc_fields = {}
+
+        raw_schema = defaultdict(set)
+        for name_and_type in d["schema"]:
+            name, _type = name_and_type.split(".", 1)
+
+            if _type == "objectId" and name.startswith("_"):
+                name = name[1:]  # "_id" -> "id"
+
+            if self.dynamic_only and name in doc_fields:
+                continue
+
+            if name in doc_fields:
+                field = doc_fields[name]
+            else:
+                field_cls = _MONGO_TO_FIFTYONE_TYPES.get(_type, None)
+                field = field_cls() if field_cls is not None else None
+
+            if not self._include_private and name.startswith("_"):
+                continue
+
+            raw_schema[name].add(field)
+
+        schema = {}
+        for name, types in raw_schema.items():
+            if len(types) > 1:
+                types = [t for t in types if t != None]
+            else:
+                types = list(types)
+
+            schema[name] = types[0] if len(types) == 1 else types
+
+        return schema
+
+    def to_mongo(self, sample_collection):
+        field_name = self._field_name
+        doc_type = None
+
+        if self._expr is None:
+            if not self._raw:
+                # Coerce label list fields, if necessary
+                try:
+                    label_type = sample_collection._get_label_field_type(
+                        field_name
+                    )
+                    if issubclass(label_type, fol._LABEL_LIST_FIELDS):
+                        field_name += "." + label_type._LABEL_LIST_FIELD
+                except:
+                    pass
+
+            field_type = _get_field_type(sample_collection, field_name)
+            if isinstance(field_type, fof.ListField):
+                field_type = field_type.field
+
+            if isinstance(field_type, fof.EmbeddedDocumentField):
+                doc_type = field_type.document_type
+
+        self._doc_type = doc_type
+
+        path, pipeline, _, _, _ = _parse_field_and_expr(
+            sample_collection, field_name, expr=self._expr
+        )
+
+        pipeline.extend(
+            [
+                {"$project": {"fields": {"$objectToArray": "$" + path}}},
+                {"$unwind": "$fields"},
+                {
+                    "$group": {
+                        "_id": None,
+                        "schema": {
+                            "$addToSet": {
+                                "$concat": [
+                                    "$fields.k",
+                                    ".",
+                                    {"$type": "$fields.v"},
+                                ]
+                            }
+                        },
+                    }
+                },
+            ]
+        )
+
+        return pipeline
+
+
 class Std(Aggregation):
     """Computes the standard deviation of the field values of a collection.
 
@@ -1663,6 +1863,19 @@ class Values(Aggregation):
         )
 
         return pipeline
+
+
+_MONGO_TO_FIFTYONE_TYPES = {
+    "string": fof.StringField,
+    "bool": fof.BooleanField,
+    "int": fof.IntField,
+    "long": fof.IntField,
+    "double": fof.FloatField,
+    "decimal": fof.FloatField,
+    "array": fof.ListField,
+    "object": fof.DictField,
+    "objectId": fof.ObjectIdField,
+}
 
 
 def _transform_values(values, fcn, level=1):

--- a/fiftyone/core/aggregations.py
+++ b/fiftyone/core/aggregations.py
@@ -1394,9 +1394,8 @@ class Schema(Aggregation):
                 field_type = field_type.field
 
             if isinstance(field_type, fof.EmbeddedDocumentField):
-                doc_type = field_type.document_type
-
-        self._doc_type = doc_type
+                # self._doc_type = field_type.document_type
+                self._doc_type = field_type
 
         path, pipeline, _, _, _ = _parse_field_and_expr(
             sample_collection, field_name, expr=self._expr

--- a/fiftyone/core/clips.py
+++ b/fiftyone/core/clips.py
@@ -434,10 +434,11 @@ def make_clips_dataset(
     dataset = fod.Dataset(
         name=name, _clips=True, _src_collection=sample_collection
     )
+    dataset.media_type = fom.VIDEO
     dataset._doc.app_sidebar_groups = (
         sample_collection._dataset._doc.app_sidebar_groups
     )
-    dataset.media_type = fom.VIDEO
+
     dataset.add_sample_field(
         "sample_id", fof.ObjectIdField, db_field="_sample_id"
     )

--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -883,10 +883,11 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
         subfield=None,
         **kwargs,
     ):
-        """Adds a new sample field to the dataset.
+        """Adds a new sample field or embedded field to the dataset, if
+        necessary.
 
         Args:
-            field_name: the field name
+            field_name: the field name or ``embedded.field.name``
             ftype: the field type to create. Must be a subclass of
                 :class:`fiftyone.core.fields.Field`
             embedded_doc_type (None): the
@@ -897,42 +898,26 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
                 the contained field. Only applicable when ``ftype`` is
                 :class:`fiftyone.core.fields.ListField` or
                 :class:`fiftyone.core.fields.DictField`
+
+        Raises:
+            ValueError: if a field of the same name already exists and it is
+                not compliant with the specified values
         """
-        self._sample_doc_cls.add_field(
+        added = self._sample_doc_cls.add_field(
             field_name,
             ftype,
             embedded_doc_type=embedded_doc_type,
             subfield=subfield,
             **kwargs,
         )
-        self._reload()
 
-    def _add_sample_field_if_necessary(
-        self,
-        field_name,
-        ftype,
-        embedded_doc_type=None,
-        subfield=None,
-        **kwargs,
-    ):
-        field_kwargs = dict(
-            ftype=ftype,
-            embedded_doc_type=embedded_doc_type,
-            subfield=subfield,
-            **kwargs,
-        )
-
-        schema = self.get_field_schema()
-        if field_name in schema:
-            foo.validate_fields_match(
-                field_name, field_kwargs, schema[field_name]
-            )
-        else:
-            self.add_sample_field(field_name, **field_kwargs)
+        if added:
+            self._reload()
 
     def _add_implied_sample_field(self, field_name, value):
-        self._sample_doc_cls.add_implied_field(field_name, value)
-        self._reload()
+        added = self._sample_doc_cls.add_implied_field(field_name, value)
+        if added:
+            self._reload()
 
     def add_frame_field(
         self,
@@ -942,12 +927,13 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
         subfield=None,
         **kwargs,
     ):
-        """Adds a new frame-level field to the dataset.
+        """Adds a new frame-level field or embedded field to the dataset, if
+        necessary.
 
         Only applicable to video datasets.
 
         Args:
-            field_name: the field name
+            field_name: the field name or ``embedded.field.name``
             ftype: the field type to create. Must be a subclass of
                 :class:`fiftyone.core.fields.Field`
             embedded_doc_type (None): the
@@ -958,48 +944,32 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
                 the contained field. Only applicable when ``ftype`` is
                 :class:`fiftyone.core.fields.ListField` or
                 :class:`fiftyone.core.fields.DictField`
+
+        Raises:
+            ValueError: if a field of the same name already exists and it is
+                not compliant with the specified values
         """
         if self.media_type != fom.VIDEO:
             raise ValueError("Only video datasets have frame fields")
 
-        self._frame_doc_cls.add_field(
+        added = self._frame_doc_cls.add_field(
             field_name,
             ftype,
             embedded_doc_type=embedded_doc_type,
             subfield=subfield,
             **kwargs,
         )
-        self._reload()
 
-    def _add_frame_field_if_necessary(
-        self,
-        field_name,
-        ftype,
-        embedded_doc_type=None,
-        subfield=None,
-        **kwargs,
-    ):
-        field_kwargs = dict(
-            ftype=ftype,
-            embedded_doc_type=embedded_doc_type,
-            subfield=subfield,
-            **kwargs,
-        )
-
-        schema = self.get_frame_field_schema()
-        if field_name in schema:
-            foo.validate_fields_match(
-                field_name, field_kwargs, schema[field_name]
-            )
-        else:
-            self.add_frame_field(field_name, **field_kwargs)
+        if added:
+            self._reload()
 
     def _add_implied_frame_field(self, field_name, value):
         if self.media_type != fom.VIDEO:
             raise ValueError("Only video datasets have frame fields")
 
-        self._frame_doc_cls.add_implied_field(field_name, value)
-        self._reload()
+        added = self._frame_doc_cls.add_implied_field(field_name, value)
+        if added:
+            self._reload()
 
     def rename_sample_field(self, field_name, new_field_name):
         """Renames the sample field to the given new name.
@@ -4484,7 +4454,6 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
 
     def _expand_schema(self, samples):
         expanded = False
-        fields = self.get_field_schema(include_private=True)
         for sample in samples:
             self._validate_media_type(sample)
 
@@ -4492,41 +4461,30 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
                 expanded |= self._expand_frame_schema(sample.frames)
 
             for field_name in sample._get_field_names(include_private=True):
-                if field_name == "_id":
-                    continue
-
-                if field_name in fields:
-                    continue
-
                 value = sample[field_name]
+
                 if value is None:
                     continue
 
-                self._sample_doc_cls.add_implied_field(field_name, value)
-                fields = self.get_field_schema(include_private=True)
-                expanded = True
+                expanded |= self._sample_doc_cls.add_implied_field(
+                    field_name, value
+                )
 
         if expanded:
             self._reload()
 
     def _expand_frame_schema(self, frames):
         expanded = False
-        fields = self.get_frame_field_schema(include_private=True)
         for frame in frames.values():
             for field_name in frame._get_field_names(include_private=True):
-                if field_name == "_id":
-                    continue
-
-                if field_name in fields:
-                    continue
-
                 value = frame[field_name]
+
                 if value is None:
                     continue
 
-                self._frame_doc_cls.add_implied_field(field_name, value)
-                fields = self.get_frame_field_schema(include_private=True)
-                expanded = True
+                expanded |= self._frame_doc_cls.add_implied_field(
+                    field_name, value
+                )
 
         return expanded
 

--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -4490,6 +4490,7 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
 
     def _expand_schema(self, samples):
         expanded = False
+        fields = self.get_field_schema(include_private=True)
         for sample in samples:
             self._validate_media_type(sample)
 
@@ -4497,30 +4498,43 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
                 expanded |= self._expand_frame_schema(sample.frames)
 
             for field_name in sample._get_field_names(include_private=True):
+                if field_name == "_id":
+                    continue
+
+                if field_name in fields:
+                    continue
+
                 value = sample[field_name]
 
                 if value is None:
                     continue
 
-                expanded |= self._sample_doc_cls.add_implied_field(
-                    field_name, value
-                )
+                self._sample_doc_cls.add_implied_field(field_name, value)
+                fields = self.get_field_schema(include_private=True)
+                expanded = True
 
         if expanded:
             self._reload()
 
     def _expand_frame_schema(self, frames):
         expanded = False
+        fields = self.get_frame_field_schema(include_private=True)
         for frame in frames.values():
             for field_name in frame._get_field_names(include_private=True):
+                if field_name == "_id":
+                    continue
+
+                if field_name in fields:
+                    continue
+
                 value = frame[field_name]
 
                 if value is None:
                     continue
 
-                expanded |= self._frame_doc_cls.add_implied_field(
-                    field_name, value
-                )
+                self._frame_doc_cls.add_implied_field(field_name, value)
+                fields = self.get_frame_field_schema(include_private=True)
+                expanded = True
 
         return expanded
 

--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -917,6 +917,25 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
         if added:
             self._reload()
 
+    def add_dynamic_sample_fields(self, fields=None):
+        """Adds all dynamic sample fields to the dataset's schema.
+
+        Dynamic fields are embedded document fields with at least one non-None
+        value that have not been declared on the dataset's schema.
+
+        Args:
+            fields (None): an optional field or iterable of fields for which to
+                add dynamic fields. By default, all fields are considered
+        """
+        schema = self.get_dynamic_field_schema(fields=fields)
+
+        for path, field in schema.items():
+            if isinstance(field, fof.Field):
+                self._sample_doc_cls._add_field_schema(path, field=field)
+
+        if schema:
+            self._reload()
+
     def add_frame_field(
         self,
         field_name,
@@ -967,6 +986,25 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
 
         added = self._frame_doc_cls.add_implied_field(field_name, value)
         if added:
+            self._reload()
+
+    def add_dynamic_frame_fields(self, fields=None):
+        """Adds all dynamic frame fields to the dataset's schema.
+
+        Dynamic fields are embedded document fields with at least one non-None
+        value that have not been declared on the dataset's schema.
+
+        Args:
+            fields (None): an optional field or iterable of fields for which to
+                add dynamic fields. By default, all fields are considered
+        """
+        schema = self.get_dynamic_frame_field_schema(fields=fields)
+
+        for path, field in schema.items():
+            if isinstance(field, fof.Field):
+                self._frame_doc_cls._add_field_schema(path, field=field)
+
+        if schema:
             self._reload()
 
     def rename_sample_field(self, field_name, new_field_name):

--- a/fiftyone/core/fields.py
+++ b/fiftyone/core/fields.py
@@ -684,7 +684,11 @@ class EmbeddedDocumentField(mongoengine.fields.EmbeddedDocumentField, Field):
             )
 
         for k, v in self._fields.items():
-            val = value[k]
+            try:
+                val = value[k]
+            except KeyError:
+                val = None
+
             if val is not None:
                 v.validate(val)
 

--- a/fiftyone/core/fields.py
+++ b/fiftyone/core/fields.py
@@ -5,6 +5,7 @@ Dataset sample fields.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+from copy import deepcopy
 from datetime import date, datetime
 import numbers
 
@@ -620,16 +621,23 @@ class EmbeddedDocumentField(mongoengine.fields.EmbeddedDocumentField, Field):
 
     def __init__(self, document_type, **kwargs):
         super().__init__(document_type, **kwargs)
-        self._parent = None
-
         self.fields = kwargs.get("fields", [])
-        self._validation_schema = None
+        self.__fields = None
 
     def __str__(self):
         return "%s(%s)" % (
             etau.get_class_name(self),
             etau.get_class_name(self.document_type),
         )
+
+    @property
+    def _fields(self):
+        if self.__fields is None:
+            # Must initialize now because `document_type` could have been a
+            # string at class instantiation
+            self.__fields = deepcopy(self.document_type._fields)
+
+        return self.__fields
 
     def get_field_schema(
         self, ftype=None, embedded_doc_type=None, include_private=False
@@ -652,7 +660,7 @@ class EmbeddedDocumentField(mongoengine.fields.EmbeddedDocumentField, Field):
         """
         fields = {}
 
-        for name, field in self.document_type._fields.items():
+        for name, field in self._fields.items():
             if not include_private and name.startswith("_"):
                 continue
 
@@ -668,6 +676,33 @@ class EmbeddedDocumentField(mongoengine.fields.EmbeddedDocumentField, Field):
             fields[name] = field
 
         return fields
+
+    def validate(self, value, **kwargs):
+        if not isinstance(value, self.document_type):
+            self.error(
+                "Expected %s; found %s" % (self.document_type, type(value))
+            )
+
+        for k, v in self._fields.items():
+            val = value[k]
+            if val is not None:
+                v.validate(val)
+
+    def _declare_field(self, field_or_doc):
+        if isinstance(field_or_doc, foo.SampleFieldDocument):
+            field = field_or_doc.to_field()
+        else:
+            field = field_or_doc
+
+        self.fields = [f for f in self.fields if f.name != field.name]
+        self.fields.append(field)
+
+        prev = self._fields.pop(field.name, None)
+        self._fields[field.name] = field
+
+        if prev is not None:
+            field.required = prev.required
+            field.null = prev.null
 
 
 class EmbeddedDocumentListField(

--- a/fiftyone/core/odm/__init__.py
+++ b/fiftyone/core/odm/__init__.py
@@ -50,13 +50,13 @@ from .frame import (
     DatasetFrameDocument,
     NoDatasetFrameDocument,
 )
-from .mixins import (
-    get_default_fields,
-    get_field_kwargs,
-    validate_fields_match,
-)
+from .mixins import get_default_fields
 from .sample import (
     DatasetSampleDocument,
     NoDatasetSampleDocument,
 )
-from .utils import get_implied_field_kwargs
+from .utils import (
+    get_field_kwargs,
+    get_implied_field_kwargs,
+    validate_fields_match,
+)

--- a/fiftyone/core/odm/dataset.py
+++ b/fiftyone/core/odm/dataset.py
@@ -38,7 +38,6 @@ def create_field(
     subfield=None,
     db_field=None,
     fields=None,
-    parent=None,
     **field_kwargs
 ):
     """Creates the :class:`fiftyone.core.fields.Field` instance defined by the
@@ -69,7 +68,6 @@ def create_field(
             :class:`fiftyone.core.fields.EmbeddedDocumentField`
             Only applicable when ``ftype`` is
             :class:`fiftyone.core.fields.EmbeddedDocumentField`
-        parent (None): a parent
         **field_kwargs: mongoengine field kwargs
 
     Returns:
@@ -98,9 +96,7 @@ def create_field(
                         subfield,
                         embedded_doc_type=embedded_doc_type,
                         fields=fields or [],
-                        parent=parent,
                     )
-
                 else:
                     subfield = subfield()
 
@@ -123,9 +119,8 @@ def create_field(
                 % (embedded_doc_type, BaseEmbeddedDocument)
             )
 
-        kwargs.update(
-            {"document_type": embedded_doc_type, "fields": fields or []}
-        )
+        kwargs["document_type"] = embedded_doc_type
+        kwargs["fields"] = fields or []
 
     field = ftype(**kwargs)
     field.name = name

--- a/fiftyone/core/odm/utils.py
+++ b/fiftyone/core/odm/utils.py
@@ -50,7 +50,6 @@ def get_field_kwargs(field):
         for f in getattr(field, "fields", []) + list(
             field.document_type._fields.values()
         ):
-
             fkwargs = get_field_kwargs(f)
             fkwargs["name"] = f.name
             kwargs["fields"].append(fkwargs)

--- a/fiftyone/core/odm/utils.py
+++ b/fiftyone/core/odm/utils.py
@@ -154,6 +154,50 @@ def get_implied_field_kwargs(value):
     )
 
 
+def validate_fields_match(name, field, existing_field):
+    """Validates that the types of the given fields match.
+
+    Embedded document fields are not validated, if applicable.
+
+    Args:
+        name: the field name or ``embedded.field.name``
+        field: a :class:`fiftyone.core.fields.Field`
+        existing_field: the reference :class:`fiftyone.core.fields.Field`
+
+    Raises:
+        ValueError: if the fields do not match
+    """
+    if type(field) is not type(existing_field):
+        raise ValueError(
+            "Field '%s' type %s does not match existing field type %s"
+            % (name, field, existing_field)
+        )
+
+    if isinstance(field, fof.EmbeddedDocumentField):
+        if not issubclass(field.document_type, existing_field.document_type):
+            raise ValueError(
+                "Embedded document field '%s' type %s does not match existing "
+                "field type %s"
+                % (name, field.document_type, existing_field.document_type)
+            )
+
+    if isinstance(field, (fof.ListField, fof.DictField)):
+        if (
+            field.field is not None
+            and existing_field.field is not None
+            and not isinstance(field.field, type(existing_field.field))
+        ):
+            raise ValueError(
+                "%s '%s' type %s does not match existing field type %s"
+                % (
+                    field.__class__.__name__,
+                    name,
+                    field.field,
+                    existing_field.field,
+                )
+            )
+
+
 def _get_list_value_type(value):
     if isinstance(value, bool):
         return fof.BooleanField

--- a/fiftyone/core/patches.py
+++ b/fiftyone/core/patches.py
@@ -500,12 +500,11 @@ def make_patches_dataset(
         field_type = _get_single_label_field_type(sample_collection, field)
 
     dataset = fod.Dataset(name=name, _patches=True)
+    dataset.media_type = fom.IMAGE
     dataset._doc.app_sidebar_groups = (
         sample_collection._dataset._doc.app_sidebar_groups
     )
 
-    dataset.media_type = fom.IMAGE
-    dataset._set_metadata(sample_collection.media_type)
     dataset.add_sample_field(
         "sample_id", fof.ObjectIdField, db_field="_sample_id"
     )

--- a/fiftyone/core/video.py
+++ b/fiftyone/core/video.py
@@ -536,10 +536,11 @@ def make_frames_dataset(
     #
 
     dataset = fod.Dataset(name=name, _frames=True)
+    dataset.media_type = fom.IMAGE
     dataset._doc.app_sidebar_groups = (
         sample_collection._dataset._doc.app_sidebar_groups
     )
-    dataset.media_type = fom.IMAGE
+
     dataset.add_sample_field(
         "sample_id", fof.ObjectIdField, db_field="_sample_id"
     )
@@ -796,7 +797,7 @@ def _init_frames(
             "on disk but are not recorded on the dataset",
             len(missing_filepaths),
         )
-        src_dataset._add_frame_field_if_necessary("filepath", fof.StringField)
+        src_dataset.add_frame_field("filepath", fof.StringField)
         ops = [
             UpdateOne(
                 {"_sample_id": _sample_id, "frame_number": fn},


### PR DESCRIPTION
Alternative to https://github.com/voxel51/fiftyone/pull/1825 where dynamic fields are not automatically added to the dataset's schema as new samples are added. The user must manually declare them.

Instead, we facilitate easy schema expansion by leveraging https://github.com/voxel51/fiftyone/pull/1137 to provide some convenient utility methods.

View the available undeclared dynamic fields:
- `SampleCollection.get_dynamic_field_schema()`
- `SampleCollection.get_dynamic_frame_field_schema()`
 
Automatically add any undeclared dynamic fields to the dataset's schema:
- `Dataset.add_dynamic_sample_fields()`
- `Dataset.add_dynamic_frame_fields()`

### Example usage

```py
import fiftyone as fo
import fiftyone.zoo as foz

dataset = foz.load_zoo_dataset("quickstart")

fo.pprint(dataset.first().ground_truth.detections[0])
fo.pprint(dataset.get_dynamic_field_schema())

dataset.add_dynamic_sample_fields()

fo.pprint(dataset.get_dynamic_field_schema())

#
# Verify validation logic
#

dataset.add_sample_field("ground_truth.detections.iscrowd", fo.IntField)  # ERROR

sample = fo.Sample(
    filepath="image.jpg",
    ground_truth=fo.Detections(detections=[fo.Detection(area="bad-value")]),
)

dataset.add_sample(sample)  # ERROR
```
