### PR TITLE
Fix bug when using zoo models with newest version of Torchvision

### DIFF
--- a/fiftyone/zoo/models/manifest-torch.json
+++ b/fiftyone/zoo/models/manifest-torch.json
@@ -61,7 +61,7 @@
             "default_deployment_config_dict": {
                 "type": "fiftyone.zoo.models.torch.TorchvisionImageModel",
                 "config": {
-                    "entrypoint_fcn": "torchvision.models.segmentation.segmentation.deeplabv3_resnet101",
+                    "entrypoint_fcn": "torchvision.models.segmentation.deeplabv3_resnet101",
                     "entrypoint_args": { "pretrained": true },
                     "output_processor_cls": "fiftyone.utils.torch.SemanticSegmenterOutputProcessor",
                     "mask_targets_path": "{{eta-resources}}/voc-labels.txt",
@@ -98,7 +98,7 @@
             "default_deployment_config_dict": {
                 "type": "fiftyone.zoo.models.torch.TorchvisionImageModel",
                 "config": {
-                    "entrypoint_fcn": "torchvision.models.segmentation.segmentation.deeplabv3_resnet50",
+                    "entrypoint_fcn": "torchvision.models.segmentation.deeplabv3_resnet50",
                     "entrypoint_args": { "pretrained": true },
                     "output_processor_cls": "fiftyone.utils.torch.SemanticSegmenterOutputProcessor",
                     "mask_targets_path": "{{eta-resources}}/voc-labels.txt",
@@ -350,7 +350,7 @@
             "default_deployment_config_dict": {
                 "type": "fiftyone.zoo.models.torch.TorchvisionImageModel",
                 "config": {
-                    "entrypoint_fcn": "torchvision.models.segmentation.segmentation.fcn_resnet101",
+                    "entrypoint_fcn": "torchvision.models.segmentation.fcn_resnet101",
                     "entrypoint_args": { "pretrained": true },
                     "output_processor_cls": "fiftyone.utils.torch.SemanticSegmenterOutputProcessor",
                     "mask_targets_path": "{{eta-resources}}/voc-labels.txt",
@@ -387,7 +387,7 @@
             "default_deployment_config_dict": {
                 "type": "fiftyone.zoo.models.torch.TorchvisionImageModel",
                 "config": {
-                    "entrypoint_fcn": "torchvision.models.segmentation.segmentation.fcn_resnet50",
+                    "entrypoint_fcn": "torchvision.models.segmentation.fcn_resnet50",
                     "entrypoint_args": { "pretrained": true },
                     "output_processor_cls": "fiftyone.utils.torch.SemanticSegmenterOutputProcessor",
                     "mask_targets_path": "{{eta-resources}}/voc-labels.txt",

--- a/fiftyone/zoo/models/torch.py
+++ b/fiftyone/zoo/models/torch.py
@@ -6,6 +6,7 @@ FiftyOne Zoo models provided by :mod:`torchvision:torchvision.models`.
 |
 """
 import inspect
+from packaging import version
 
 import eta.core.utils as etau
 
@@ -111,6 +112,8 @@ def _make_load_state_dict_from_url_monkey_patcher(entrypoint, model_dir):
     loaded from ``model_dir`` and not from the Torch Hub cache directory.
     """
     entrypoint_module = inspect.getmodule(entrypoint)
+    if version.parse(torchvision.__version__) >= version.parse("0.12.0"):
+        entrypoint_module = torchvision._internally_replaced_utils
     load_state_dict_from_url = entrypoint_module.load_state_dict_from_url
 
     def custom_load_state_dict_from_url(url, **kwargs):
@@ -120,5 +123,5 @@ def _make_load_state_dict_from_url_monkey_patcher(entrypoint, model_dir):
         entrypoint_module,
         custom_load_state_dict_from_url,
         fcn_name=load_state_dict_from_url.__name__,
-        namespace=torchvision.models,
+        namespace=torchvision,
     )

--- a/fiftyone/zoo/models/torch.py
+++ b/fiftyone/zoo/models/torch.py
@@ -123,5 +123,5 @@ def _make_load_state_dict_from_url_monkey_patcher(entrypoint, model_dir):
         entrypoint_module,
         custom_load_state_dict_from_url,
         fcn_name=load_state_dict_from_url.__name__,
-        namespace=torchvision,
+        namespace=torchvision.models,
     )


### PR DESCRIPTION
Resolves #1789

We monkey patch the `load_state_dict_from_url` function used by torch models in the FiftyOne Model Zoo so that we can choose to load them from the model zoo directory on disk. As of torchvision v0.12.0, the structure of some models has been changed so the existing monkey patch no longer worked. This PR updates the location of the `load_state_dict_from_url` in the torchvision module and changes the namespace where it is applied.

To test, you can run this code from the evaluate segmentations example:
```python
import fiftyone.zoo as foz

# Load a few samples from COCO-2017
dataset = foz.load_zoo_dataset(
    "quickstart",
    max_samples=3,
).clone()

# Add DeepLabv3-ResNet50 predictions to dataset
model = foz.load_zoo_model("deeplabv3-resnet50-coco-torch")
dataset.apply_model(model, "resnet50")
```