### PR TITLE
Add utility to convert classifications to detections

### DIFF
--- a/fiftyone/utils/labels.py
+++ b/fiftyone/utils/labels.py
@@ -353,8 +353,8 @@ def classification_to_detections(sample_collection, in_field, out_field):
 def classifications_to_detections(sample_collection, in_field, out_field):
     """Converts the :class:`fiftyone.core.labels.Classifications` field of the
     collection into a :class:`fiftyone.core.labels.Detections` field containing
-    detections whose bounding boxes span the entire image with on detection for
-    each classification.
+    detections whose bounding boxes span the entire image with one detection
+    for each classification.
 
     Args:
         sample_collection: a


### PR DESCRIPTION
Adds `fiftyone.utils.labels.classifications_to_detections()` converting a `Classifications` field into a `Detections` field where each classification corresponds to one detection with a bounding box surrounding the entire image (`[0,0,1,1]`), just like `classification_to_detections()`

## Example:

```python
import fiftyone.zoo as foz
import fiftyone.utils.labels as foul

dataset = foz.load_zoo_dataset(
    "open-images-v6",
    split="validation",
    max_samples=50,
    label_types=["classifications"],
)

foul.classifications_to_detections(dataset, "positive_labels", "dets")

print(dataset.first())
```

```
<Sample: {
    'id': '62a0b31a79f8993392beb816',
    'media_type': 'image',
    'filepath': '/home/eric/fiftyone/open-images-v6/validation/data/0001eeaf4aed83f9.jpg',
    'tags': BaseList(['validation']),
    'metadata': None,
    'positive_labels': <Classifications: {
        'classifications': BaseList([
            <Classification: {
                'id': '62a0b31a79f8993392beb815',
                'tags': BaseList([]),
                'label': 'Airplane',
                'confidence': 1.0,
                'logits': None,
            }>,
        ]),
        'logits': None,
    }>,
    'negative_labels': <Classifications: {'classifications': BaseList([]), 'logits': None}>,
    'open_images_id': '0001eeaf4aed83f9',
    'dets': <Detections: {
        'detections': BaseList([
            <Detection: {
                'id': '62a0b32479f8993392beba90',
                'attributes': BaseDict({}),
                'tags': BaseList([]),
                'label': 'Airplane',
                'bounding_box': BaseList([0.0, 0.0, 1.0, 1.0]),
                'mask': None,
                'confidence': 1.0,
                'index': None,
            }>,
        ]),
    }>,
}>

```