### PR TITLE
Always use fork for multiprocessing on macOS

### DIFF
--- a/fiftyone/core/metadata.py
+++ b/fiftyone/core/metadata.py
@@ -316,7 +316,9 @@ def _compute_metadata_multi(sample_collection, num_workers, overwrite=False):
 
     view = sample_collection.select_fields()
     with fou.ProgressBar(total=num_samples) as pb:
-        with multiprocessing.Pool(processes=num_workers) as pool:
+        with fou.get_multiprocessing_context().Pool(
+            processes=num_workers
+        ) as pool:
             for sample_id, metadata in pb(
                 pool.imap_unordered(_do_compute_metadata, inputs)
             ):

--- a/fiftyone/core/utils.py
+++ b/fiftyone/core/utils.py
@@ -1356,7 +1356,7 @@ def get_multiprocessing_context():
         # default multiprocessing context, force 'fork' to be used
         #
         # Background: on macOS, multiprocessing's default context was changed
-        # from 'spawn' to 'fork' in Python 3.8, but we prefer 'fork' because
+        # from 'fork' to 'spawn' in Python 3.8, but we prefer 'fork' because
         # the startup time is much shorter. Also, this is not fully proven, but
         # @brimoor believes he's seen cases where 'spawn' causes some of our
         # `multiprocessing.Pool.imap_unordered()` calls to run twice...

--- a/fiftyone/core/utils.py
+++ b/fiftyone/core/utils.py
@@ -17,6 +17,7 @@ import inspect
 import io
 import itertools
 import logging
+import multiprocessing
 import ntpath
 import os
 import posixpath
@@ -24,6 +25,7 @@ import platform
 import signal
 import struct
 import subprocess
+import sys
 import timeit
 import types
 from xml.parsers.expat import ExpatError
@@ -1337,6 +1339,32 @@ def is_32_bit():
         True/False
     """
     return struct.calcsize("P") * 8 == 32
+
+
+def get_multiprocessing_context():
+    """Returns the preferred ``multiprocessing`` context for the current OS.
+
+    Returns:
+        a ``multiprocessing`` context
+    """
+    if (
+        sys.platform == "darwin"
+        and multiprocessing.get_start_method(allow_none=True) is None
+    ):
+        #
+        # If we're running on macOS and the user didn't manually configure the
+        # default multiprocessing context, force 'fork' to be used
+        #
+        # Background: on macOS, multiprocessing's default context was changed
+        # from 'spawn' to 'fork' in Python 3.8, but we prefer 'fork' because
+        # the startup time is much shorter. Also, this is not fully proven, but
+        # @brimoor believes he's seen cases where 'spawn' causes some of our
+        # `multiprocessing.Pool.imap_unordered()` calls to run twice...
+        #
+        return multiprocessing.get_context("fork")
+
+    # Use the default context
+    return multiprocessing.get_context()
 
 
 def datetime_to_timestamp(dt):

--- a/fiftyone/utils/data/base.py
+++ b/fiftyone/utils/data/base.py
@@ -193,7 +193,9 @@ def _download_images(inputs):
 
 def _download_images_multi(inputs, num_workers):
     with fou.ProgressBar(inputs) as pb:
-        with multiprocessing.Pool(processes=num_workers) as pool:
+        with fou.get_multiprocessing_context().Pool(
+            processes=num_workers
+        ) as pool:
             for _ in pb(pool.imap_unordered(_download_image, inputs)):
                 pass
 

--- a/fiftyone/utils/image.py
+++ b/fiftyone/utils/image.py
@@ -272,7 +272,9 @@ def _transform_images_multi(
     view = sample_collection.select_fields()
 
     with fou.ProgressBar(inputs) as pb:
-        with multiprocessing.Pool(processes=num_workers) as pool:
+        with fou.get_multiprocessing_context().Pool(
+            processes=num_workers
+        ) as pool:
             for sample_id, inpath, outpath, _ in pb(
                 pool.imap_unordered(_do_transform, inputs)
             ):


### PR DESCRIPTION
See comment in code for details.

```py
import eta.core.utils as etau

import fiftyone as fo
import fiftyone.zoo as foz
import fiftyone.utils.image as foui

foz.download_zoo_dataset("quickstart")
dataset_dir = foz.find_zoo_dataset("quickstart")
tmp_dir = "/tmp/quickstart"

etau.copy_dir(dataset_dir, tmp_dir)

dataset = fo.Dataset.from_dir(
    dataset_dir=tmp_dir,
    dataset_type=fo.types.FiftyOneDataset,
)

# Both of these operations use multiprocessing
dataset.compute_metadata()
foui.transform_images(dataset, size=(32, -1))
```
