### PR TITLE
Adding dataset tags

### DIFF
--- a/docs/source/user_guide/evaluation.rst
+++ b/docs/source/user_guide/evaluation.rst
@@ -791,7 +791,6 @@ results of an evaluation on the
     Dataset:     quickstart
     Media type:  image
     Num patches: 5363
-    Tags:        ['validation']
     Patch fields:
         filepath:     fiftyone.core.fields.StringField
         tags:         fiftyone.core.fields.ListField(fiftyone.core.fields.StringField)
@@ -1910,7 +1909,6 @@ You can also view frame-level evaluation results as
     Dataset:     video-eval-demo
     Media type:  image
     Num patches: 12112
-    Tags:        []
     Patch fields:
         id:           fiftyone.core.fields.ObjectIdField
         filepath:     fiftyone.core.fields.StringField

--- a/docs/source/user_guide/using_datasets.rst
+++ b/docs/source/user_guide/using_datasets.rst
@@ -108,6 +108,8 @@ shell and run the command again:
 you'll see that the `my_second_dataset` and `2020.08.04.12.36.29` datasets have
 been deleted because they were not persistent.
 
+.. _dataset-media-type:
+
 Dataset media type
 ------------------
 
@@ -140,6 +142,8 @@ Datasets are homogeneous; they must contain samples of the same media type:
     dataset.add_sample(fo.Sample(filepath="/path/to/video.mp4"))
     # MediaTypeError: Sample media type 'video' does not match dataset media type 'image'
 
+.. _dataset-version:
+
 Dataset version
 ---------------
 
@@ -150,6 +154,37 @@ of the dataset.
 If you upgrade your `fiftyone` package and then load a dataset that was created
 with an older version of the package, it will be automatically migrated to the
 new package version (if necessary) the first time you load it.
+
+.. _dataset-tags:
+
+Dataset tags
+------------
+
+All |Dataset| instances have a
+:meth:`tags <fiftyone.core.dataset.Dataset.tags>` property that you can use to
+store an arbitrary list of string tags.
+
+.. code-block:: python
+    :linenos:
+
+    import fiftyone as fo
+
+    dataset = fo.Dataset()
+
+    # Add some tags
+    dataset.tags = ["test", "projectA"]
+
+    # Edit the tags
+    dataset.tags.pop()
+    dataset.tags.append("projectB")
+    dataset.save()  # must save after edits
+
+.. note::
+
+    You must call
+    :meth:`dataset.save() <fiftyone.core.dataset.Dataset.save>` after updating
+    the dataset's :meth:`tags <fiftyone.core.dataset.Dataset.tags>` property
+    in-place to save the changes to the database.
 
 .. _storing-info:
 
@@ -186,8 +221,8 @@ Datasets can also store more specific types of ancillary information such as
 
     You must call
     :meth:`dataset.save() <fiftyone.core.dataset.Dataset.save>` after updating
-    the dataset's :meth:`info <fiftyone.core.dataset.Dataset.info>` property to
-    save the changes to the database.
+    the dataset's :meth:`info <fiftyone.core.dataset.Dataset.info>` property
+    in-place to save the changes to the database.
 
 .. _storing-classes:
 
@@ -245,7 +280,7 @@ require knowledge of the possible classes in a dataset or field(s).
     :meth:`dataset.save() <fiftyone.core.dataset.Dataset.save>` after updating
     the dataset's :meth:`classes <fiftyone.core.dataset.Dataset.classes>` and
     :meth:`default_classes <fiftyone.core.dataset.Dataset.default_classes>`
-    properties to save the changes to the database.
+    properties in-place to save the changes to the database.
 
 .. _storing-mask-targets:
 
@@ -308,7 +343,7 @@ require knowledge of the mask targets for a dataset or field(s).
     the dataset's
     :meth:`mask_targets <fiftyone.core.dataset.Dataset.mask_targets>` and
     :meth:`default_mask_targets <fiftyone.core.dataset.Dataset.default_mask_targets>`
-    properties to save the changes to the database.
+    properties in-place to save the changes to the database.
 
 .. _storing-keypoint-skeletons:
 
@@ -392,7 +427,7 @@ nodes:
     the dataset's
     :meth:`skeletons <fiftyone.core.dataset.Dataset.skeletons>` and
     :meth:`default_skeleton <fiftyone.core.dataset.Dataset.default_skeleton>`
-    properties to save the changes to the database.
+    properties in-place to save the changes to the database.
 
 Deleting a dataset
 ------------------

--- a/docs/source/user_guide/using_views.rst
+++ b/docs/source/user_guide/using_views.rst
@@ -35,7 +35,6 @@ You can explicitly create a view that contains an entire dataset via
     Dataset:        quickstart
     Media type:     image
     Num samples:    200
-    Tags:           ['validation']
     Sample fields:
         id:           fiftyone.core.fields.ObjectIdField
         filepath:     fiftyone.core.fields.StringField
@@ -851,7 +850,6 @@ detection dataset:
     Dataset:     quickstart
     Media type:  image
     Num patches: 1232
-    Tags:        ['validation']
     Patch fields:
         id:           fiftyone.core.fields.ObjectIdField
         filepath:     fiftyone.core.fields.StringField
@@ -976,7 +974,6 @@ respectively.
     Dataset:     quickstart
     Media type:  image
     Num patches: 5363
-    Tags:        ['validation']
     Patch fields:
         id:           fiftyone.core.fields.ObjectIdField
         filepath:     fiftyone.core.fields.StringField
@@ -1125,7 +1122,6 @@ temporal segment by simply passing the name of the temporal detection field to
     Dataset:    2021.09.03.09.44.57
     Media type: video
     Num clips:  4
-    Tags:       []
     Clip fields:
         id:        fiftyone.core.fields.ObjectIdField
         sample_id: fiftyone.core.fields.ObjectIdField
@@ -1228,7 +1224,6 @@ that contains at least one person:
     Dataset:    quickstart-video
     Media type: video
     Num clips:  8
-    Tags:       []
     Clip fields:
         id:        fiftyone.core.fields.ObjectIdField
         sample_id: fiftyone.core.fields.ObjectIdField
@@ -1384,7 +1379,6 @@ frame of the videos in a |Dataset| or |DatasetView|:
     Dataset:     quickstart-video
     Media type:  image
     Num samples: 1279
-    Tags:        []
     Sample fields:
         id:           fiftyone.core.fields.ObjectIdField
         filepath:     fiftyone.core.fields.StringField
@@ -1531,7 +1525,6 @@ sample per object patch in the frames of the dataset!
     Dataset:     quickstart-video
     Media type:  image
     Num patches: 11345
-    Tags:        []
     Patch fields:
         id:           fiftyone.core.fields.ObjectIdField
         filepath:     fiftyone.core.fields.StringField

--- a/fiftyone/core/cli.py
+++ b/fiftyone/core/cli.py
@@ -484,6 +484,7 @@ def _print_all_dataset_info(sort_by, reverse):
         "version",
         "persistent",
         "media_type",
+        "tags",
         "num_samples",
     ]
 
@@ -511,6 +512,9 @@ def _format_cell(cell):
 
     if isinstance(cell, datetime):
         return cell.replace(microsecond=0)
+
+    if etau.is_container(cell):
+        return ",".join(cell)
 
     return cell
 

--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -706,13 +706,12 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
         Returns:
             a string summary
         """
-        aggs = self.aggregate([foa.Count(), foa.Distinct("tags")])
         elements = [
             ("Name:", self.name),
             ("Media type:", self.media_type),
-            ("Num samples:", aggs[0]),
+            ("Num samples:", self.count()),
             ("Persistent:", self.persistent),
-            ("Tags:", aggs[1]),
+            ("Tags:", self.tags),
         ]
 
         elements = fou.justify_headings(elements)

--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -453,6 +453,36 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
             raise
 
     @property
+    def tags(self):
+        """A list of tags given to the dataset.
+
+        Examples::
+
+            import fiftyone as fo
+
+            dataset = fo.Dataset()
+
+            # Add some tags
+            dataset.tags = ["test", "projectA"]
+
+            # Edit the tags
+            dataset.tags.pop()
+            dataset.tags.append("projectB")
+            dataset.save()  # must save after edits
+        """
+        return self._doc.tags
+
+    @tags.setter
+    def tags(self, value):
+        _value = self._doc.tags
+        try:
+            self._doc.tags = value
+            self._doc.save()
+        except:
+            self._doc.tags = _value
+            raise
+
+    @property
     def info(self):
         """A user-facing dictionary of information about the dataset.
 
@@ -4650,6 +4680,7 @@ def _list_dataset_info():
                 "version": dataset.version,
                 "persistent": dataset.persistent,
                 "media_type": dataset.media_type,
+                "tags": dataset.tags,
                 "num_samples": num_samples,
             }
         except:
@@ -4662,6 +4693,7 @@ def _list_dataset_info():
                 "version": None,
                 "persistent": None,
                 "media_type": None,
+                "tags": None,
                 "num_samples": None,
             }
 

--- a/fiftyone/core/odm/dataset.py
+++ b/fiftyone/core/odm/dataset.py
@@ -370,6 +370,7 @@ class DatasetDocument(Document):
     frame_collection_name = StringField()
     persistent = BooleanField(default=False)
     media_type = StringField()
+    tags = ListField(StringField())
     info = DictField()
     classes = DictField(ClassesField())
     default_classes = ClassesField()

--- a/fiftyone/core/view.py
+++ b/fiftyone/core/view.py
@@ -228,12 +228,10 @@ class DatasetView(foc.SampleCollection):
         Returns:
             a string summary
         """
-        aggs = self.aggregate([foa.Count(), foa.Distinct("tags")])
         elements = [
             ("Dataset:", self.dataset_name),
             ("Media type:", self.media_type),
-            ("Num %s:" % self._elements_str, aggs[0]),
-            ("Tags:", aggs[1]),
+            ("Num %s:" % self._elements_str, self.count()),
         ]
 
         elements = fou.justify_headings(elements)

--- a/fiftyone/migrations/revisions/v0_16_3.py
+++ b/fiftyone/migrations/revisions/v0_16_3.py
@@ -1,0 +1,20 @@
+"""
+FiftyOne v0.16.3 revision.
+
+| Copyright 2017-2022, Voxel51, Inc.
+| `voxel51.com <https://voxel51.com/>`_
+|
+"""
+
+
+def up(db, dataset_name):
+    pass
+
+
+def down(db, dataset_name):
+    match_d = {"name": dataset_name}
+    dataset_dict = db.datasets.find_one(match_d)
+
+    dataset_dict.pop("tags", None)
+
+    db.datasets.replace_one(match_d, dataset_dict)

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ import re
 from setuptools import setup, find_packages
 
 
-VERSION = "0.16.2"
+VERSION = "0.16.3"
 
 
 def get_version():

--- a/tests/unittests/dataset_tests.py
+++ b/tests/unittests/dataset_tests.py
@@ -67,6 +67,44 @@ class DatasetTests(unittest.TestCase):
         )
 
     @drop_datasets
+    def test_dataset_tags(self):
+        dataset_name = self.test_dataset_tags.__name__
+
+        dataset = fo.Dataset(dataset_name)
+
+        self.assertEqual(dataset.tags, [])
+
+        dataset.tags = ["cat", "dog"]
+
+        del dataset
+        gc.collect()  # force garbage collection
+
+        dataset2 = fo.load_dataset(dataset_name)
+
+        self.assertEqual(dataset2.tags, ["cat", "dog"])
+
+        # save() must be called to persist in-place edits
+        dataset2.tags.append("rabbit")
+
+        del dataset2
+        gc.collect()  # force garbage collection
+
+        dataset3 = fo.load_dataset(dataset_name)
+
+        self.assertEqual(dataset3.tags, ["cat", "dog"])
+
+        # This will persist the edits
+        dataset3.tags.append("rabbit")
+        dataset3.save()
+
+        del dataset3
+        gc.collect()  # force garbage collection
+
+        dataset4 = fo.load_dataset(dataset_name)
+
+        self.assertEqual(dataset4.tags, ["cat", "dog", "rabbit"])
+
+    @drop_datasets
     def test_dataset_info(self):
         dataset_name = self.test_dataset_info.__name__
 


### PR DESCRIPTION
```py
import fiftyone as fo
import fiftyone.zoo as foz

dataset = foz.load_zoo_dataset("quickstart")
dataset.persistent = True

# Datasets can now store tags
dataset.tags = ["foo", "bar"]

# The dataset summary now shows *dataset* tags, not *sample* tags
# Note: this also avoids a `distinct("tags")` aggregation, which is nice
print(dataset)
```

```
Name:        quickstart
Media type:  image
Num samples: 200
Persistent:  False
Tags:        ['foo', 'bar']
Sample fields:
    id:           fiftyone.core.fields.ObjectIdField
    filepath:     fiftyone.core.fields.StringField
    tags:         fiftyone.core.fields.ListField(fiftyone.core.fields.StringField)
    metadata:     fiftyone.core.fields.EmbeddedDocumentField(fiftyone.core.metadata.ImageMetadata)
    ground_truth: fiftyone.core.fields.EmbeddedDocumentField(fiftyone.core.labels.Detections)
    uniqueness:   fiftyone.core.fields.FloatField
    predictions:  fiftyone.core.fields.EmbeddedDocumentField(fiftyone.core.labels.Detections)
```

```shell
# Tags are available via CLI
fiftyone datasets info
```

```
name        ...  version    persistent    media_type    tags       num_samples
----------  ...  ---------  ------------  ------------  -------  -------------
quickstart  ...  0.16.3     ✓             image         foo,bar            200
```

```shell
fiftyone datasets delete quickstart
```
