### PR TITLE
Let shard enumeration start from 0

### DIFF
--- a/fiftyone/utils/tf.py
+++ b/fiftyone/utils/tf.py
@@ -249,7 +249,7 @@ class TFRecordsWriter(object):
             tf_records_patt = self.tf_records_path + "-%05d-of-%05d"
             tf_records_paths = [
                 tf_records_patt % (i, self.num_shards)
-                for i in range(1, self.num_shards + 1)
+                for i in range(0, self.num_shards)
             ]
         else:
             self._num_shards = 1


### PR DESCRIPTION
## What changes are proposed in this pull request?

Let the shard enumeration of the tfrecord export start from 0 rather than 1. Fixes  #1847 

## How is this patch tested? If it is not, please explain why.

tested locally exporting a fiftyone dataset to tfrecord shards

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

TFRecord shards enumeration now starts from 0 rather than 1.

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
