### PR TITLE
Bringing back the current section highlight!

### DIFF
--- a/docs/source/_static/js/custom.js
+++ b/docs/source/_static/js/custom.js
@@ -1,11 +1,11 @@
 $(function () {
-  const sections = $("section").sort(
+  const sections = $(".section").sort(
     (a, b) => $(a).offset().top - $(b).offset().top
   );
 
   const sectionStartThreshold =
     $("#pytorch-page-level-bar").height() +
-    parseInt($("section h2").css("marginTop")) +
+    parseInt($(".section h2").css("marginTop")) +
     10;
 
   let lastSection = undefined;


### PR DESCRIPTION
Resolves https://github.com/voxel51/fiftyone/issues/1552!

@benjaminpkane why did https://github.com/voxel51/fiftyone/commit/39315eb3d0914fc4877627424e06df99f76de97a introduce the change that this reverts? Am I breaking something else?

```bash
bash docs/generate_docs.bash -c
open docs/build/html/user_guide/using_datasets.html
```

<img src="https://user-images.githubusercontent.com/25985824/172948228-8c6f6748-d55d-40a3-9991-43157ad6dabb.gif" width="400">
