### PR TITLE
Add retries for CVAT requests

### DIFF
--- a/fiftyone/core/config.py
+++ b/fiftyone/core/config.py
@@ -654,17 +654,20 @@ def _get_installed_packages():
 
 
 class HTTPRetryConfig(object):
-    """Values used to configure the behavior of the retry logic
-    of HTTP calls made throughout the app
+    """Values used to configure the behavior of the retry logic of HTTP calls
+    made throughout the library.
+
+    NOTE: calls made directly through storage clients (GCS, S3) use their own
+    internal retry logic implementation and may not perfectly match this
+    configuration. This configuration is for direct HTTP requests.
     """
 
     # HTTP codes that should trigger a retry
     RETRY_CODES = {408, 429, 500, 502, 503, 504, 509}
 
-    # Exponential backoff factor.
+    # Exponential backoff factor
     # See https://github.com/litl/backoff/blob/master/backoff/_wait_gen.py#L17
     FACTOR = 0.1
 
-    # Maximum number of times to execute a retry
-    # before throwing an exception
+    # Maximum number of times to execute a retry before throwing an exception
     MAX_TRIES = 10

--- a/fiftyone/core/config.py
+++ b/fiftyone/core/config.py
@@ -651,3 +651,20 @@ def _get_installed_packages():
     except:
         logger.debug("Failed to get installed packages")
         return set()
+
+
+class HTTPRetryConfig(object):
+    """Values used to configure the behavior of the retry logic
+    of HTTP calls made throughout the app
+    """
+
+    # HTTP codes that should trigger a retry
+    RETRY_CODES = {408, 429, 500, 502, 503, 504, 509}
+
+    # Exponential backoff factor.
+    # See https://github.com/litl/backoff/blob/master/backoff/_wait_gen.py#L17
+    FACTOR = 0.1
+
+    # Maximum number of times to execute a retry
+    # before throwing an exception
+    MAX_TRIES = 10

--- a/fiftyone/utils/cvat.py
+++ b/fiftyone/utils/cvat.py
@@ -3641,7 +3641,8 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
         requests.exceptions.RequestException,
         factor=HTTPRetryConfig.FACTOR,
         max_tries=HTTPRetryConfig.MAX_TRIES,
-        giveup=lambda e: e.error_code not in HTTPRetryConfig.RETRY_CODES,
+        giveup=lambda e: hasattr(e, "error_code")
+        and e.error_code not in HTTPRetryConfig.RETRY_CODES,
         logger=None,
     )
     def _make_request(

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -1,5 +1,6 @@
 aiofiles==0.7.0
 argcomplete==1.11.0
+backoff==1.11.1
 boto3==1.17.36
 dacite==1.6.0
 Deprecated==1.2.11

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ INSTALL_REQUIRES = [
     # third-party packages
     "aiofiles",
     "argcomplete",
+    "backoff",
     "boto3",
     "dacite>=1.6.0",
     "Deprecated",


### PR DESCRIPTION
When making calls to the CVAT REST API, some of the requests can raise errors due to server issues requiring methods like `dataset.annotate()` and `dataset.load_annotations()` to be run multiple times before succeeding. This PR introduces retries around any `requests` made by our the CVAT annotation integration.

A test was added to `fiftyone/tests/intensive/cvat.py` that is able to verify that this works correctly.
