### PR TITLE
Adds the ability to upload and download group ids from CVAT

### DIFF
--- a/docs/source/integrations/cvat.rst
+++ b/docs/source/integrations/cvat.rst
@@ -1571,9 +1571,12 @@ CVAT project and avoid the need to re-specify the label schema in FiftyOne.
     will receieve command line prompt(s) at import time to provide label
     field(s) in which to store the annotations.
 
-    You can also use the `occluded_attr` and `group_id_attr` arguments to link
-    the states of CVAT's occlusion widget and grouping capabilities to
-    specified attributes of your objects.
+.. warning::
+
+    Since the `label_schema` and `attribute` arguments are ignored, any occluded or
+    group id attributes defined there will also be ignored. In order to connect
+    occluded or group id attributes, use the `occluded_attr` and
+    `group_id_attr` arguments directly.
 
 .. code:: python
     :linenos:

--- a/docs/source/integrations/cvat.rst
+++ b/docs/source/integrations/cvat.rst
@@ -491,6 +491,9 @@ provided:
 -   **occluded_attr** (*None*): an optional attribute name containing existing
     occluded values and/or in which to store downloaded occluded values for all
     objects in the annotation run
+-   **group_id_attr** (*None*): an optional attribute name containing existing
+    group ids and/or in which to store downloaded group ids for all objects in
+    the annotation run
 -   **issue_tracker** (*None*): URL(s) of an issue tracker to link to the
     created task(s). This argument can be a list of URLs when annotating videos
     or when using `task_size` and generating multiple tasks
@@ -689,6 +692,8 @@ For CVAT, the following `type` values are supported:
     `values` is unused
 -   `occluded`: CVAT's builtin occlusion toggle icon. This widget type can only
     be specified for at most one attribute, which must be a boolean
+-   `group_id`: CVAT's grouping capabilities. This attribute type can only
+    be specified for at most one attribute, which must be an integer
 
 When you are annotating existing label fields, the `attributes` parameter can
 take additional values:
@@ -1566,8 +1571,9 @@ CVAT project and avoid the need to re-specify the label schema in FiftyOne.
     will receieve command line prompt(s) at import time to provide label
     field(s) in which to store the annotations.
 
-    You can also use the `occluded_attr` argument to link the state of CVAT's
-    occlusion widget to a specified attribute of your objects.
+    You can also use the `occluded_attr` and `group_id_attr` arguments to link
+    the states of CVAT's occlusion widget and grouping capabilities to
+    specified attributes of your objects.
 
 .. code:: python
     :linenos:
@@ -1914,7 +1920,7 @@ linked to the occlusion widget.
     dataset.delete_annotation_run(anno_key)
 
 You can also use the `occluded_attr` parameter to sync the state of CVAT's
-occlusion widet with a specified attribute of all spatial fields that are being
+occlusion widget with a specified attribute of all spatial fields that are being
 annotated that did not explicitly have an occluded attribute defined in the
 label schema.
 
@@ -1956,6 +1962,100 @@ attributes between annotation runs.
 .. image:: /images/integrations/cvat_occ_widget.png
    :alt: cvat-occ-widget
    :align: center
+
+.. _cvat-group-id:
+
+Using CVAT groups
+-----------------
+
+The CVAT UI provides a way to group objects together both visually and though
+a group id in the API.
+
+You can configure CVAT annotation runs so that the state of the group id is
+read/written to a FiftyOne label attribute of your choice by
+specifying the attribute's type as `group_id` in your label schema.
+
+In addition, if you are editing existing labels using the `attributes=True`
+syntax (the default) to infer the label schema for an existing field, if a
+boolean attribute with the name `"group_id"` is found, it will automatically be
+linked to CVAT groups.
+
+.. note::
+
+    You can only specify the `group_id` type for at most one attribute of each
+    label field/class in your label schema, and, if you are editing existing
+    labels, the attribute that you choose must contain integer values.
+
+.. code:: python
+    :linenos:
+
+    import fiftyone as fo
+    import fiftyone.zoo as foz
+
+    dataset = foz.load_zoo_dataset("quickstart").clone()
+    view = dataset.take(1)
+
+    anno_key = "cvat_group_id"
+
+    # Populate a new `group_id` attribute on the existing `ground_truth` labels
+    label_schema = {
+        "ground_truth": {
+            "attributes": {
+                "group_id": {
+                    "type": "group_id",
+                }
+            }
+        }
+    }
+
+    view.annotate(anno_key, label_schema=label_schema, launch_editor=True)
+    print(dataset.get_annotation_info(anno_key))
+
+    # Mark groups in CVAT...
+
+    dataset.load_annotations(anno_key, cleanup=True)
+    dataset.delete_annotation_run(anno_key)
+
+You can also use the `group_id_attr` parameter to sync the state of CVAT's
+group ids with a specified attribute of all spatial fields that are being
+annotated that did not explicitly have a group id attribute defined in the
+label schema.
+
+This parameter is especially useful when working with existing CVAT projects,
+since CVAT project schemas are not able to retain information about group id
+attributes between annotation runs.
+
+.. code:: python
+    :linenos:
+
+    import fiftyone as fo
+    import fiftyone.zoo as foz
+
+    dataset = foz.load_zoo_dataset("quickstart").clone()
+    view = dataset.take(1)
+
+    anno_key = "cvat_group_id_project"
+    project_name = "example_group_id"
+    label_field = "ground_truth"
+
+    # Create project
+    view.annotate("new_proj", label_field=label_field, project_name=project_name)
+
+    # Upload to existing project
+    view.annotate(
+        anno_key,
+        label_field=label_field,
+        group_id_attr="group_id_value",
+        project_name=project_name,
+        launch_editor=True,
+    )
+    print(dataset.get_annotation_info(anno_key))
+
+    # Mark groups in CVAT...
+
+    dataset.load_annotations(anno_key, cleanup=True)
+    dataset.delete_annotation_run(anno_key)
+
 
 .. _cvat-destination-field:
 

--- a/fiftyone/utils/annotations.py
+++ b/fiftyone/utils/annotations.py
@@ -1004,7 +1004,7 @@ def load_annotations(
             else:
                 logger.warning(
                     "Ignoring string `dest_field=%s` since the label "
-                    "schema contains %d > 1 fields",
+                    "schema contains %d (> 1) fields",
                     dest_field,
                     len(label_schema),
                 )

--- a/fiftyone/utils/cvat.py
+++ b/fiftyone/utils/cvat.py
@@ -6172,7 +6172,7 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
         elif dup_class_name in cvat_schema:
             class_name = dup_class_name
         else:
-            return None, None, None, None, None
+            return None, None, None, None, None, None
 
         attr_schema = cvat_schema[class_name]
 

--- a/fiftyone/utils/cvat.py
+++ b/fiftyone/utils/cvat.py
@@ -4848,7 +4848,7 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
                 (
                     _attrs,
                     _occluded_attr_name,
-                    group_id_attr_name,
+                    _group_id_attr_name,
                 ) = self._to_cvat_attributes(_class["attributes"])
                 if _occluded_attr_name is None and occluded_attr is not None:
                     _occluded_attr_name = occluded_attr

--- a/tests/intensive/cvat_tests.py
+++ b/tests/intensive/cvat_tests.py
@@ -495,7 +495,9 @@ class CVATTests(unittest.TestCase):
 
         with self.assertRaises(ValueError):
             label_schema = {
-                "ground_truth": {"attributes": {"group_id": {"type": "group"}}}
+                "ground_truth": {
+                    "attributes": {"group_id": {"type": "group_id"}}
+                }
             }
             anno_key4 = "group_id_failure"
             dataset.annotate(

--- a/tests/intensive/cvat_tests.py
+++ b/tests/intensive/cvat_tests.py
@@ -480,6 +480,30 @@ class CVATTests(unittest.TestCase):
         self.assertNotIn(project_id, results2.project_ids)
         self.assertIsNotNone(api.get_project_id(project_name))
 
+        with self.assertRaises(ValueError):
+            label_schema = {
+                "ground_truth": {
+                    "attributes": {"occluded": {"type": "occluded"}}
+                }
+            }
+            anno_key3 = "occluded_failure"
+            dataset.annotate(
+                anno_key3,
+                label_schema=label_schema,
+                project_name=project_name,
+            )
+
+        with self.assertRaises(ValueError):
+            label_schema = {
+                "ground_truth": {"attributes": {"group_id": {"type": "group"}}}
+            }
+            anno_key4 = "group_id_failure"
+            dataset.annotate(
+                anno_key4,
+                label_schema=label_schema,
+                project_name=project_name,
+            )
+
         dataset.load_annotations(anno_key, cleanup=True)
         self.assertIsNotNone(api.get_project_id(project_name))
 

--- a/tests/intensive/cvat_tests.py
+++ b/tests/intensive/cvat_tests.py
@@ -66,7 +66,14 @@ def _get_label(api, task_id, label=None):
 
 
 def _create_annotation(
-    api, task_id, shape=None, tag=None, track=None, points=None, _type=None
+    api,
+    task_id,
+    shape=None,
+    tag=None,
+    track=None,
+    points=None,
+    _type=None,
+    group_id=0,
 ):
     if points is None:
         points = [10, 20, 30, 40]
@@ -83,7 +90,7 @@ def _create_annotation(
                 "type": _type,
                 "frame": 0,
                 "label_id": label,
-                "group": 0,
+                "group": group_id,
                 "attributes": [],
                 "points": points,
                 "occluded": False,
@@ -96,7 +103,7 @@ def _create_annotation(
             tag = {
                 "frame": 0,
                 "label_id": label,
-                "group": 0,
+                "group": group_id,
                 "attributes": [],
             }
         tags = [tag]
@@ -111,7 +118,7 @@ def _create_annotation(
             track = {
                 "frame": start,
                 "label_id": label,
-                "group": 0,
+                "group": group_id,
                 "shapes": [
                     {
                         "type": _type,
@@ -157,6 +164,7 @@ def _update_shape(
     points=None,
     attributes=None,
     occluded=None,
+    group_id=None,
 ):
     anno_json = api.get(api.task_annotation_url(task_id)).json()
     shape = _find_shape(anno_json, label_id)
@@ -165,6 +173,8 @@ def _update_shape(
             shape["points"] = points
         if occluded is not None:
             shape["occluded"] = occluded
+        if group_id is not None:
+            shape["group"] = group_id
         if attributes is not None:
             attr_id_map, class_id_map = api._get_attr_class_maps(task_id)
             if label is None:
@@ -989,6 +999,62 @@ class CVATTests(unittest.TestCase):
             sorted(
                 dataset.values("frames.test_field.detections.id", unwind=True)
             ),
+        )
+
+    def test_group_id(self):
+        dataset = (
+            foz.load_zoo_dataset("quickstart", max_samples=2)
+            .select_fields("ground_truth")
+            .clone()
+        )
+        group_id_attr_name = "group_id_attr"
+
+        # Set group id attribute
+        sample = dataset.first()
+        for det in sample.ground_truth.detections:
+            det["group_id_attr"] = 1
+        sample.save()
+
+        anno_key = "cvat_group_ids"
+
+        # Populate a new `group_id` attribute on the existing `ground_truth` labels
+        label_schema = {
+            "ground_truth": {
+                "attributes": {
+                    group_id_attr_name: {
+                        "type": "group_id",
+                    }
+                }
+            }
+        }
+
+        results = dataset.annotate(
+            anno_key, label_schema=label_schema, backend="cvat"
+        )
+
+        api = results.connect_to_api()
+        task_id = results.task_ids[0]
+        shape_id = dataset.first().ground_truth.detections[0].id
+
+        test_group_id = 2
+        _update_shape(api, task_id, shape_id, group_id=test_group_id)
+
+        dataset.load_annotations(anno_key, cleanup=True)
+
+        id_group_map = dict(
+            zip(
+                *dataset.values(
+                    [
+                        "ground_truth.detections.id",
+                        "ground_truth.detections.%s" % group_id_attr_name,
+                    ],
+                    unwind=True,
+                )
+            )
+        )
+        self.assertEqual(id_group_map.pop(shape_id), test_group_id)
+        self.assertFalse(
+            any([gid == test_group_id for gid in id_group_map.values()])
         )
 
 


### PR DESCRIPTION
Resolves https://github.com/voxel51/fiftyone/issues/1849

In CVAT, you can group objects and tracks together allowing them to be visualized with the same color as well as populating the `group` attribute in the backend. This PR exposes this attribute and functionality similar to the occlusion widget #1321 letting you specify an object attribute in FiftyOne that will be used as this group id parameter in CVAT, which can then also be loaded back into the same attribute when loading annotations.

This PR also now introduces an error when attempting to start an annotation run linked to an existing project but where either the `label_schema`, `classes`, or `attributes` contains the occluded or group_id attributes. This is because when using existing projects, the label schema is overwritten with what exists in the project (since projects can't be updated). So any occluded/group id attributes defined there will be ignored resulting in unexpected behavior. When working with projects, the `occluded_attr` and `group_id_attr` arguments should be used.

## Example
Specify group id in label schema:
```python
import fiftyone as fo
import fiftyone.zoo as foz

dataset = foz.load_zoo_dataset("quickstart").clone()
view = dataset.take(1)

anno_key = "cvat_group_id"

# Populate a new `group_id` attribute on the existing `ground_truth` labels
label_schema = {
    "ground_truth": {
        "attributes": {
            "group_id": {
                "type": "group_id",
            }
        }
    }
}

view.annotate(anno_key, label_schema=label_schema, launch_editor=True)
print(dataset.get_annotation_info(anno_key))

# Mark groups in CVAT...

dataset.load_annotations(anno_key, cleanup=True)
dataset.delete_annotation_run(anno_key)
```

Use `group_id_attr`.
```python
import fiftyone as fo
import fiftyone.zoo as foz

dataset = foz.load_zoo_dataset("quickstart").clone()
view = dataset.take(1)

anno_key = "cvat_group_id_project"
project_name = "example_group_id"
label_field = "ground_truth"

# Create project
view.annotate("new_proj", label_field=label_field, project_name=project_name)

# Upload to existing project
view.annotate(
    anno_key,
    label_field=label_field,
    group_id_attr="group_id_value",
    project_name=project_name,
    launch_editor=True,
)
print(dataset.get_annotation_info(anno_key))

# Mark groups in CVAT...

dataset.load_annotations(anno_key, cleanup=True)
dataset.delete_annotation_run(anno_key)
```