### PR TITLE
Serialize views as BSON

### DIFF
--- a/app/packages/app/relay.config.json
+++ b/app/packages/app/relay.config.json
@@ -4,6 +4,8 @@
     "eagerEsModules": true,
     "language": "typescript",
     "customScalars": {
+        "BSON": "object",
+        "BSONArray": "Array",
         "Date": "string",
         "DateTime": "string",
         "JSON": "object",

--- a/app/packages/app/schema.graphql
+++ b/app/packages/app/schema.graphql
@@ -14,6 +14,8 @@ type AppConfig {
   useFrameNumber: Boolean!
 }
 
+scalar BSONArray
+
 type BrainRun implements Run {
   key: String!
   version: String!
@@ -91,8 +93,6 @@ type EvaluationRunConfig implements RunConfig {
   method: String!
 }
 
-scalar JSONArray
-
 type KeypointSkeleton {
   labels: [String!]
   edges: [[Int!]!]!
@@ -118,7 +118,7 @@ type Mutation {
   setView(
     subscription: String!
     session: String
-    view: JSONArray!
+    view: BSONArray!
     dataset: String!
   ): ViewResponse!
   storeTeamsSubmission: Boolean!
@@ -153,7 +153,7 @@ type Query {
   context: String!
   dev: Boolean!
   doNotTrack: Boolean!
-  dataset(name: String!, view: JSONArray): Dataset
+  dataset(name: String!, view: BSONArray): Dataset
   teamsSubmission: Boolean!
   uid: String!
   version: String!
@@ -197,6 +197,6 @@ type Target {
 }
 
 type ViewResponse {
-  view: JSONArray!
+  view: BSONArray!
   dataset: Dataset!
 }

--- a/app/packages/app/src/Root/Datasets/Dataset.tsx
+++ b/app/packages/app/src/Root/Datasets/Dataset.tsx
@@ -15,7 +15,7 @@ import { similarityParameters } from "../../components/Actions/Similar";
 import { toCamelCase } from "@fiftyone/utilities";
 
 const Query = graphql`
-  query DatasetQuery($name: String!, $view: JSONArray) {
+  query DatasetQuery($name: String!, $view: BSONArray) {
     dataset(name: $name, view: $view) {
       id
       name

--- a/app/packages/app/src/Root/Datasets/__generated__/DatasetQuery.graphql.ts
+++ b/app/packages/app/src/Root/Datasets/__generated__/DatasetQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<da89de60d56aea872f6230c84ef74b71>>
+ * @generated SignedSource<<db27e326179cc60eccb82de8da4d1051>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -472,16 +472,16 @@ const node: ConcreteRequest = (function () {
       selections: v11 /*: any*/,
     },
     params: {
-      cacheID: "a10011bddc050852453af75c2552678d",
+      cacheID: "2e788a38f5add212d3ac68a4ea5c3b00",
       id: null,
       metadata: {},
       name: "DatasetQuery",
       operationKind: "query",
-      text: "query DatasetQuery(\n  $name: String!\n  $view: JSONArray\n) {\n  dataset(name: $name, view: $view) {\n    id\n    name\n    mediaType\n    sampleFields {\n      ftype\n      subfield\n      embeddedDocType\n      path\n      dbField\n    }\n    frameFields {\n      ftype\n      subfield\n      embeddedDocType\n      path\n      dbField\n    }\n    appSidebarGroups {\n      name\n      paths\n    }\n    maskTargets {\n      name\n      targets {\n        target\n        value\n      }\n    }\n    defaultMaskTargets {\n      target\n      value\n    }\n    evaluations {\n      key\n      version\n      timestamp\n      viewStages\n      config {\n        cls\n        predField\n        gtField\n      }\n    }\n    brainMethods {\n      key\n      version\n      timestamp\n      viewStages\n      config {\n        cls\n        embeddingsField\n        method\n        patchesField\n      }\n    }\n    lastLoadedAt\n    createdAt\n    skeletons {\n      name\n      labels\n      edges\n    }\n    defaultSkeleton {\n      labels\n      edges\n    }\n    version\n    viewCls\n  }\n}\n",
+      text: "query DatasetQuery(\n  $name: String!\n  $view: BSONArray\n) {\n  dataset(name: $name, view: $view) {\n    id\n    name\n    mediaType\n    sampleFields {\n      ftype\n      subfield\n      embeddedDocType\n      path\n      dbField\n    }\n    frameFields {\n      ftype\n      subfield\n      embeddedDocType\n      path\n      dbField\n    }\n    appSidebarGroups {\n      name\n      paths\n    }\n    maskTargets {\n      name\n      targets {\n        target\n        value\n      }\n    }\n    defaultMaskTargets {\n      target\n      value\n    }\n    evaluations {\n      key\n      version\n      timestamp\n      viewStages\n      config {\n        cls\n        predField\n        gtField\n      }\n    }\n    brainMethods {\n      key\n      version\n      timestamp\n      viewStages\n      config {\n        cls\n        embeddingsField\n        method\n        patchesField\n      }\n    }\n    lastLoadedAt\n    createdAt\n    skeletons {\n      name\n      labels\n      edges\n    }\n    defaultSkeleton {\n      labels\n      edges\n    }\n    version\n    viewCls\n  }\n}\n",
     },
   };
 })();
 
-(node as any).hash = "613476d8b15592e50148f13c4a2c7d8e";
+(node as any).hash = "8db4b5cfa990a8b34fd487168771584c";
 
 export default node;

--- a/app/packages/app/src/mutations/__generated__/setViewMutation.graphql.ts
+++ b/app/packages/app/src/mutations/__generated__/setViewMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<b9167d3bfa672c004783b76cd9334f3b>>
+ * @generated SignedSource<<7e435fb3c4de85d786e7412919f27d22>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -523,16 +523,16 @@ const node: ConcreteRequest = (function () {
       selections: v14 /*: any*/,
     },
     params: {
-      cacheID: "40c94d07980bfe7f87ed1e874504c872",
+      cacheID: "163453844276ac7df5c2a28cd6039f5c",
       id: null,
       metadata: {},
       name: "setViewMutation",
       operationKind: "mutation",
-      text: "mutation setViewMutation(\n  $subscription: String!\n  $session: String\n  $view: JSONArray!\n  $dataset: String!\n) {\n  setView(subscription: $subscription, session: $session, view: $view, dataset: $dataset) {\n    dataset {\n      id\n      name\n      mediaType\n      sampleFields {\n        ftype\n        subfield\n        embeddedDocType\n        path\n        dbField\n      }\n      frameFields {\n        ftype\n        subfield\n        embeddedDocType\n        path\n        dbField\n      }\n      appSidebarGroups {\n        name\n        paths\n      }\n      maskTargets {\n        name\n        targets {\n          target\n          value\n        }\n      }\n      defaultMaskTargets {\n        target\n        value\n      }\n      evaluations {\n        key\n        version\n        timestamp\n        viewStages\n        config {\n          cls\n          predField\n          gtField\n        }\n      }\n      brainMethods {\n        key\n        version\n        timestamp\n        viewStages\n        config {\n          cls\n          embeddingsField\n          method\n          patchesField\n        }\n      }\n      lastLoadedAt\n      createdAt\n      version\n      viewCls\n      skeletons {\n        name\n        labels\n        edges\n      }\n      defaultSkeleton {\n        labels\n        edges\n      }\n    }\n    view\n  }\n}\n",
+      text: "mutation setViewMutation(\n  $subscription: String!\n  $session: String\n  $view: BSONArray!\n  $dataset: String!\n) {\n  setView(subscription: $subscription, session: $session, view: $view, dataset: $dataset) {\n    dataset {\n      id\n      name\n      mediaType\n      sampleFields {\n        ftype\n        subfield\n        embeddedDocType\n        path\n        dbField\n      }\n      frameFields {\n        ftype\n        subfield\n        embeddedDocType\n        path\n        dbField\n      }\n      appSidebarGroups {\n        name\n        paths\n      }\n      maskTargets {\n        name\n        targets {\n          target\n          value\n        }\n      }\n      defaultMaskTargets {\n        target\n        value\n      }\n      evaluations {\n        key\n        version\n        timestamp\n        viewStages\n        config {\n          cls\n          predField\n          gtField\n        }\n      }\n      brainMethods {\n        key\n        version\n        timestamp\n        viewStages\n        config {\n          cls\n          embeddingsField\n          method\n          patchesField\n        }\n      }\n      lastLoadedAt\n      createdAt\n      version\n      viewCls\n      skeletons {\n        name\n        labels\n        edges\n      }\n      defaultSkeleton {\n        labels\n        edges\n      }\n    }\n    view\n  }\n}\n",
     },
   };
 })();
 
-(node as any).hash = "251008764217a8dde2ed6ecc76f13c80";
+(node as any).hash = "23756673feef620b56139c134743e0bd";
 
 export default node;

--- a/app/packages/app/src/mutations/setView.ts
+++ b/app/packages/app/src/mutations/setView.ts
@@ -4,7 +4,7 @@ export default graphql`
   mutation setViewMutation(
     $subscription: String!
     $session: String
-    $view: JSONArray!
+    $view: BSONArray!
     $dataset: String!
   ) {
     setView(

--- a/fiftyone/core/state.py
+++ b/fiftyone/core/state.py
@@ -5,6 +5,8 @@ Defines the shared state between the FiftyOne App and backend.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+from bson import json_util
+import json
 import logging
 
 import eta.core.serial as etas
@@ -52,7 +54,9 @@ class StateDescription(etas.Serializable):
             if self.dataset is not None:
                 d["dataset"] = self.dataset.name
                 if self.view is not None:
-                    d["view"] = self.view._serialize()
+                    d["view"] = json.loads(
+                        json_util.dumps(self.view._serialize())
+                    )
                     d["view_cls"] = etau.get_class_name(self.view)
 
             d["config"]["timezone"] = fo.config.timezone

--- a/fiftyone/server/mutation.py
+++ b/fiftyone/server/mutation.py
@@ -19,7 +19,7 @@ import fiftyone.core.view as fov
 from fiftyone.server.data import Info
 from fiftyone.server.events import get_state, dispatch_event
 from fiftyone.server.query import Dataset
-from fiftyone.server.scalars import JSONArray
+from fiftyone.server.scalars import BSONArray
 
 
 @gql.input
@@ -32,7 +32,7 @@ class SelectedLabel:
 
 @gql.type
 class ViewResponse:
-    view: JSONArray
+    view: BSONArray
     dataset: Dataset
 
 
@@ -85,7 +85,7 @@ class Mutation:
         self,
         subscription: str,
         session: t.Optional[str],
-        view: JSONArray,
+        view: BSONArray,
         dataset: str,
         info: Info,
     ) -> ViewResponse:

--- a/fiftyone/server/query.py
+++ b/fiftyone/server/query.py
@@ -29,7 +29,7 @@ from fiftyone.server.data import Info
 from fiftyone.server.dataloader import get_dataloader_resolver
 from fiftyone.server.mixins import HasCollection
 from fiftyone.server.paginator import Connection, get_paginator_resolver
-from fiftyone.server.scalars import JSONArray
+from fiftyone.server.scalars import BSONArray
 
 ID = gql.scalar(
     t.NewType("ID", str),
@@ -165,7 +165,7 @@ class Dataset(HasCollection):
 
     @classmethod
     async def resolver(
-        cls, name: str, view: t.Optional[JSONArray], info: Info
+        cls, name: str, view: t.Optional[BSONArray], info: Info
     ) -> t.Optional["Dataset"]:
         dataset = await dataset_dataloader(name, info)
         if dataset is None:

--- a/fiftyone/server/scalars.py
+++ b/fiftyone/server/scalars.py
@@ -5,9 +5,23 @@ FiftyOne Server GraphQL scalars
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+from bson import json_util
+import json
 import typing as t
 
 import strawberry as gql
+
+BSON = gql.scalar(
+    t.NewType("BSON", object),
+    serialize=lambda v: json.loads(json_util.dumps(v)),
+    parse_value=lambda v: json_util.loads(json.dumps(v)),
+)
+
+BSONArray = gql.scalar(
+    t.NewType("BSONArray", object),
+    serialize=lambda v: json.loads(json_util.dumps(v)),
+    parse_value=lambda v: json_util.loads(json.dumps(v)),
+)
 
 JSON = gql.scalar(
     t.NewType("JSON", object),


### PR DESCRIPTION
Views should always be serialized as BSON, i.e. using `bson.json_util` in order for `ObjectId` values to be properly loaded. Resolves #1854