### PR TITLE
Fix selection and expansion for bad media files

### DIFF
--- a/app/packages/looker/src/elements/common/thumbnail.module.css
+++ b/app/packages/looker/src/elements/common/thumbnail.module.css
@@ -11,6 +11,7 @@
   width: 100%;
   height: auto;
   position: absolute;
+  z-index: 1;
   top: 0;
   left: 0;
   opacity: 0;

--- a/app/packages/looker/src/elements/frame.ts
+++ b/app/packages/looker/src/elements/frame.ts
@@ -88,15 +88,6 @@ export class FrameElement extends BaseElement<FrameState, HTMLVideoElement> {
           video.addEventListener("seeked", seeked);
 
           const error = (event) => {
-            // Chrome v60
-            if (event.path && event.path[0]) {
-              event = event.path[0].error;
-            }
-
-            // Firefox v55
-            if (event.originalTarget) {
-              event = event.originalTarget.error;
-            }
             video.removeEventListener("error", error);
             release();
             update({ error: true });
@@ -109,9 +100,9 @@ export class FrameElement extends BaseElement<FrameState, HTMLVideoElement> {
             video.removeEventListener("loadedmetadata", loaded);
           };
 
-          video.src = src;
           video.addEventListener("error", error);
           video.addEventListener("loadedmetadata", loaded);
+          video.src = src;
         });
 
         return {};

--- a/app/packages/looker/src/elements/image.ts
+++ b/app/packages/looker/src/elements/image.ts
@@ -2,6 +2,7 @@
  * Copyright 2017-2022, Voxel51, Inc.
  */
 
+import { update } from "immutable";
 import { ImageState } from "../state";
 import { BaseElement, Events } from "./base";
 
@@ -16,8 +17,8 @@ export class ImageElement extends BaseElement<ImageState, HTMLImageElement> {
 
         update({ loaded: true });
       },
-      error: ({ event, dispatchEvent }) => {
-        dispatchEvent("error", { event });
+      error: ({ update }) => {
+        update({ error: true });
       },
     };
   }

--- a/app/packages/looker/src/elements/video.ts
+++ b/app/packages/looker/src/elements/video.ts
@@ -417,10 +417,9 @@ export class VideoElement extends BaseElement<VideoState, HTMLVideoElement> {
 
   getEvents(): Events<VideoState> {
     return {
-      error: ({ update, event, dispatchEvent }) => {
+      error: ({ update }) => {
         this.releaseVideo();
         update({ error: true });
-        dispatchEvent("error", { event });
       },
       loadedmetadata: ({ update }) => {
         update(({ config: { frameRate }, frameNumber }) => {
@@ -535,16 +534,6 @@ export class VideoElement extends BaseElement<VideoState, HTMLVideoElement> {
         this.canvas.style.imageRendering = "pixelated";
         acquireThumbnailer().then(([video, release]) => {
           const error = (event) => {
-            // Chrome v60
-            if (event.path && event.path[0]) {
-              event = event.path[0].error;
-            }
-
-            // Firefox v55
-            if (event.originalTarget) {
-              event = event.originalTarget.error;
-            }
-
             video.removeEventListener("error", error);
             video.removeEventListener("seeked", seeked);
             release();
@@ -577,9 +566,9 @@ export class VideoElement extends BaseElement<VideoState, HTMLVideoElement> {
             video.removeEventListener("loadedmetadata", load);
           };
 
+          video.src = src;
           video.addEventListener("error", error);
           video.addEventListener("loadedmetadata", load);
-          video.src = src;
         });
       } else {
         this.element = document.createElement("video");


### PR DESCRIPTION
Resolves #1865

```py
import fiftyone as fo

dataset = fo.Dataset("bad")
sample = fo.Sample(filepath="bad.png")  
dataset.add_sample(sample)

# image
session = fo.Session(dataset)

dataset = fo.Dataset("bad-video")
sample = fo.Sample(filepath="bad.mp4")  
dataset.add_sample(sample)

# video
session.dataset = dataset
```