### PR TITLE
eliminate non-XML or non-TXT files from CVAT, KITTI, CVATVideo

### DIFF
--- a/fiftyone/utils/cvat.py
+++ b/fiftyone/utils/cvat.py
@@ -767,6 +767,7 @@ class CVATVideoDatasetImporter(
             labels_paths_map = {
                 os.path.splitext(p)[0]: os.path.join(labels_path, p)
                 for p in etau.list_files(labels_path, recursive=True)
+                if etau.has_extension(p, ".xml")
             }
         else:
             labels_paths_map = {}

--- a/fiftyone/utils/kitti.py
+++ b/fiftyone/utils/kitti.py
@@ -173,6 +173,7 @@ class KITTIDetectionDatasetImporter(
             labels_paths_map = {
                 os.path.splitext(p)[0]: os.path.join(labels_path, p)
                 for p in etau.list_files(labels_path, recursive=True)
+                if etau.has_extension(p, ".txt")
             }
         else:
             labels_paths_map = {}

--- a/fiftyone/utils/voc.py
+++ b/fiftyone/utils/voc.py
@@ -190,6 +190,7 @@ class VOCDetectionDatasetImporter(
             labels_paths_map = {
                 os.path.splitext(p)[0]: os.path.join(labels_path, p)
                 for p in etau.list_files(labels_path, recursive=True)
+                if etau.has_extension(p, ".xml")
             }
         else:
             labels_paths_map = {}


### PR DESCRIPTION
## What changes are proposed in this pull request?

Resolves #1778. CVAT, KITTI and CVATVideo will import only label files with valid extensions (.xml or .txt). 

## How is this patch tested? If it is not, please explain why.

I created 4 datasets (CVAT, KITTI, CVATVideo, YOLOv5) with files that have non-standard extensions in the label folder and imported those datasets with `fo.Dataset.from_dir()`. After that I checked which labels where imported.
`YOLOv5Importer` did not require any modifications since it looks first at the available images in the dataset and imports only the corresponding labels. I can also modify the importers for CVAT, KITTI and CVATVideo to work this way. Just let me know :smiley: 

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
