### PR TITLE
updates `FIFTYONE_DEFAULT_APP_ADDRESS` documentation

### DIFF
--- a/docs/source/environments/index.rst
+++ b/docs/source/environments/index.rst
@@ -143,15 +143,19 @@ to the above command.
 Restricting the App address
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-By default, the App will listen to any connection to its port. However, you can
-provide the optional `address` parameter to
+By default, the App will listen on `localhost`. However, you can provide the
+optional `address` parameter to
 :meth:`launch_app() <fiftyone.core.session.launch_app>` to specify a particular
-IP address or hostname to which to restrict access to your session.
+IP address or hostname for the App to listen on.
 
-For example, a common pattern is to set the App address to `"localhost"` so
-that the App can only be accessed via http://localhost:5151 on either the local
-machine itself or a machine that was able to setup ssh port forwarding as
+Using the default of `localhost` means the App can only be accessed from the
+local machine or a machine that was able to setup ssh port forwarding as
 described in the previous section.
+
+An alternative is to set the App address to `"0.0.0.0"` so that the App can be
+accessed from a remote host or from the local machine itself.  Using `"0.0.0.0"`
+will bind the App to all available interfaces and will allow access to the App
+from any remote resource with access to your network.
 
 .. code-block:: python
     :linenos:
@@ -160,8 +164,8 @@ described in the previous section.
 
     dataset = fo.load_dataset(...)
 
-    # Restrict to http://localhost:5151 connections made via port forwarding
-    session = fo.launch_app(dataset, remote=True, address="localhost")
+    # Enable connections from remote hosts
+    session = fo.launch_app(dataset, remote=True, address="0.0.0.0")
 
 If desired, you can permanently configure an App address by setting the
 `default_app_address` of your :ref:`FiftyOne config <configuring-fiftyone>`.
@@ -171,14 +175,14 @@ You can achieve this by adding the following entry to your
 .. code-block:: json
 
     {
-        "default_app_address": "localhost"
+        "default_app_address": "0.0.0.0"
     }
 
 or by setting the following environment variable:
 
 .. code-block:: shell
 
-    export FIFTYONE_DEFAULT_APP_ADDRESS=localhost
+    export FIFTYONE_DEFAULT_APP_ADDRESS='0.0.0.0'
 
 .. _notebooks:
 

--- a/docs/source/user_guide/config.rst
+++ b/docs/source/user_guide/config.rst
@@ -64,11 +64,11 @@ FiftyOne supports the configuration options described below:
 +-------------------------------+-------------------------------------+-------------------------------+----------------------------------------------------------------------------------------+
 | `default_app_port`            | `FIFTYONE_DEFAULT_APP_PORT`         | `5151`                        | The default port to use to serve the :ref:`FiftyOne App <fiftyone-app>`.               |
 +-------------------------------+-------------------------------------+-------------------------------+----------------------------------------------------------------------------------------+
-| `default_app_address`         | `FIFTYONE_DEFAULT_APP_ADDRESS`      | `None`                        | The default address to use to serve the :ref:`FiftyOne App <fiftyone-app>`. This may   |
+| `default_app_address`         | `FIFTYONE_DEFAULT_APP_ADDRESS`      | `localhost`                   | The default address to use to serve the :ref:`FiftyOne App <fiftyone-app>`. This may   |
 |                               |                                     |                               | be either an IP address or hostname. If it's a hostname, the App will listen to all    |
-|                               |                                     |                               | IP addresses associated with the name. The default is `None`, which means the App will |
-|                               |                                     |                               | listen on all available interfaces. See :ref:`this page <restricting-app-address>` for |
-|                               |                                     |                               | more information.                                                                      |
+|                               |                                     |                               | IP addresses associated with the name. The default is `localhost`, which means the App |
+|                               |                                     |                               | will only listen on the local interface. See :ref:`this page <restricting-app-address>`|
+|                               |                                     |                               | for more information.                                                                  |
 +-------------------------------+-------------------------------------+-------------------------------+----------------------------------------------------------------------------------------+
 | `desktop_app`                 | `FIFTYONE_DESKTOP_APP`              | `False`                       | Whether to launch the FiftyOne App in the browser (False) or as a desktop App (True)   |
 |                               |                                     |                               | by default. If True, the :ref:`FiftyOne Desktop App <installing-fiftyone-desktop>`     |


### PR DESCRIPTION
## What changes are proposed in this pull request?

The default bind address has changed from `None` to `localhost` - this updates the documentation to reflect that change.

## How is this patch tested? If it is not, please explain why.

Doc update only, sphinx files built

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [x] Documentation: FiftyOne documentation changes
-   [ ] Other
