### PR TITLE
Adding support for serializing Aggregations

### DIFF
--- a/fiftyone/__public__.py
+++ b/fiftyone/__public__.py
@@ -15,6 +15,7 @@ app_config = _foc.load_app_config()
 _foo.establish_db_conn(config)
 
 from .core.aggregations import (
+    Aggregation,
     Bounds,
     Count,
     CountValues,

--- a/fiftyone/core/aggregations.py
+++ b/fiftyone/core/aggregations.py
@@ -8,6 +8,8 @@ Aggregations.
 from collections import OrderedDict
 from copy import deepcopy
 from datetime import date, datetime
+import reprlib
+import uuid
 
 import numpy as np
 
@@ -40,6 +42,8 @@ class Aggregation(object):
             floating point values
     """
 
+    _uuid = None
+
     def __init__(self, field_or_expr, expr=None, safe=False):
         if field_or_expr is not None and not etau.is_str(field_or_expr):
             if expr is not None:
@@ -56,6 +60,22 @@ class Aggregation(object):
         self._field_name = field_name
         self._expr = expr
         self._safe = safe
+
+    def __str__(self):
+        return repr(self)
+
+    def __repr__(self):
+        kwargs_list = []
+        for k, v in self._kwargs():
+            if k.startswith("_"):
+                continue
+
+            v_repr = _repr.repr(v)
+            # v_repr = etau.summarize_long_str(v_repr, 30)
+            kwargs_list.append("%s=%s" % (k, v_repr))
+
+        kwargs_str = ", ".join(kwargs_list)
+        return "%s(%s)" % (self.__class__.__name__, kwargs_str)
 
     @property
     def field_name(self):
@@ -157,6 +177,58 @@ class Aggregation(object):
 
         return False
 
+    def _serialize(self, include_uuid=True):
+        """Returns a JSON dict representation of the :class:`Aggregation`.
+
+        Args:
+            include_uuid (True): whether to include the aggregation's UUID in
+                the JSON representation
+
+        Returns:
+            a JSON dict
+        """
+        d = {
+            "_cls": etau.get_class_name(self),
+            "kwargs": self._kwargs(),
+        }
+
+        if include_uuid:
+            if self._uuid is None:
+                self._uuid = str(uuid.uuid4())
+
+            d["_uuid"] = self._uuid
+
+        return d
+
+    def _kwargs(self):
+        """Returns a list of ``[name, value]`` lists describing the parameters
+        of this aggregation instance.
+
+        Returns:
+            a list of ``[name, value]`` lists
+        """
+        return [
+            ["field_or_expr", self._field_name],
+            ["expr", self._expr],
+            ["safe", self._safe],
+        ]
+
+    @classmethod
+    def _from_dict(cls, d):
+        """Creates an :class:`Aggregation` instance from a serialized JSON dict
+        representation of it.
+
+        Args:
+            d: a JSON dict
+
+        Returns:
+            an :class:`Aggregation`
+        """
+        aggregation_cls = etau.get_class(d["_cls"])
+        agg = aggregation_cls(**{k: v for (k, v) in d["kwargs"]})
+        agg._uuid = d.get("_uuid", None)
+        return agg
+
 
 class AggregationError(Exception):
     """An error raised during the execution of an :class:`Aggregation`."""
@@ -246,6 +318,11 @@ class Bounds(Aggregation):
         super().__init__(field_or_expr, expr=expr, safe=safe)
         self._field_type = None
         self._count_nonfinites = _count_nonfinites
+
+    def _kwargs(self):
+        return super()._kwargs() + [
+            ["_count_nonfinites", self._count_nonfinites]
+        ]
 
     def default_result(self):
         """Returns the default result for this aggregation.
@@ -423,6 +500,9 @@ class Count(Aggregation):
         super().__init__(field_or_expr, expr=expr, safe=safe)
         self._unwind = _unwind
 
+    def _kwargs(self):
+        return super()._kwargs() + [["_unwind", self._unwind]]
+
     def default_result(self):
         """Returns the default result for this aggregation.
 
@@ -565,11 +645,22 @@ class CountValues(Aggregation):
         super().__init__(field_or_expr, expr=expr, safe=safe)
         self._first = _first
         self._sort_by = _sort_by
-        self._order = 1 if _asc else -1
+        self._asc = _asc
         self._include = _include
-        self._field_type = None
         self._search = _search
         self._selected = _selected
+
+        self._field_type = None
+
+    def _kwargs(self):
+        return super()._kwargs() + [
+            ["_first", self._first],
+            ["_sort_by", self._sort_by],
+            ["_asc", self._asc],
+            ["_include", self._include],
+            ["_search", self._search],
+            ["_selected", self._selected],
+        ]
 
     def default_result(self):
         """Returns the default result for this aggregation.
@@ -671,8 +762,10 @@ class CountValues(Aggregation):
             ]
             sort["included"] = -1
 
-        sort[self._sort_by] = self._order
-        sort["count" if self._sort_by != "count" else "_id"] = self._order
+        order = 1 if self._asc else -1
+        sort[self._sort_by] = order
+        sort["count" if self._sort_by != "count" else "_id"] = order
+
         result = [
             {"$sort": sort},
             {"$limit": limit},
@@ -942,6 +1035,15 @@ class HistogramValues(Aggregation):
         self._last_edges = None
 
         self._parse_args()
+
+    def _kwargs(self):
+        return [
+            ["field_or_expr", self._field_name],
+            ["expr", self._expr],
+            ["bins", self._bins],
+            ["range", self._range],
+            ["auto", self._auto],
+        ]
 
     def default_result(self):
         """Returns the default result for this aggregation.
@@ -1306,6 +1408,9 @@ class Std(Aggregation):
         super().__init__(field_or_expr, expr=expr, safe=safe)
         self._sample = sample
 
+    def _kwargs(self):
+        return super()._kwargs() + [["sample", self._sample]]
+
     def default_result(self):
         """Returns the default result for this aggregation.
 
@@ -1585,6 +1690,17 @@ class Values(Aggregation):
         self._field_type = None
         self._num_list_fields = None
 
+    def _kwargs(self):
+        return [
+            ["field_or_expr", self._field_name],
+            ["expr", self._expr],
+            ["missing_value", self._missing_value],
+            ["unwind", self._unwind],
+            ["_allow_missing", self._allow_missing],
+            ["_big_result", self._big_result],
+            ["_raw", self._raw],
+        ]
+
     @property
     def _has_big_result(self):
         return self._big_result
@@ -1663,6 +1779,21 @@ class Values(Aggregation):
         )
 
         return pipeline
+
+
+class _AggregationRepr(reprlib.Repr):
+    def repr_ViewExpression(self, expr, level):
+        return self.repr1(expr.to_mongo(), level=level - 1)
+
+
+_repr = _AggregationRepr()
+_repr.maxlevel = 2
+_repr.maxdict = 3
+_repr.maxlist = 3
+_repr.maxtuple = 3
+_repr.maxset = 3
+_repr.maxstring = 30
+_repr.maxother = 30
 
 
 def _transform_values(values, fcn, level=1):

--- a/fiftyone/core/aggregations.py
+++ b/fiftyone/core/aggregations.py
@@ -77,6 +77,9 @@ class Aggregation(object):
         kwargs_str = ", ".join(kwargs_list)
         return "%s(%s)" % (self.__class__.__name__, kwargs_str)
 
+    def __eq__(self, other):
+        return type(self) == type(other) and self._kwargs() == other._kwargs()
+
     @property
     def field_name(self):
         """The name of the field being computed on, if any."""

--- a/fiftyone/core/aggregations.py
+++ b/fiftyone/core/aggregations.py
@@ -228,7 +228,7 @@ class Aggregation(object):
             an :class:`Aggregation`
         """
         aggregation_cls = etau.get_class(d["_cls"])
-        agg = aggregation_cls(**{k: v for (k, v) in d["kwargs"]})
+        agg = aggregation_cls(**dict(d["kwargs"]))
         agg._uuid = d.get("_uuid", None)
         return agg
 

--- a/fiftyone/core/aggregations.py
+++ b/fiftyone/core/aggregations.py
@@ -316,8 +316,9 @@ class Bounds(Aggregation):
         self, field_or_expr, expr=None, safe=False, _count_nonfinites=False
     ):
         super().__init__(field_or_expr, expr=expr, safe=safe)
-        self._field_type = None
         self._count_nonfinites = _count_nonfinites
+
+        self._field_type = None
 
     def _kwargs(self):
         return super()._kwargs() + [
@@ -874,6 +875,7 @@ class Distinct(Aggregation):
 
     def __init__(self, field_or_expr, expr=None, safe=False):
         super().__init__(field_or_expr, expr=expr, safe=safe)
+
         self._field_type = None
 
     def default_result(self):
@@ -1023,7 +1025,6 @@ class HistogramValues(Aggregation):
         self, field_or_expr, expr=None, bins=None, range=None, auto=False
     ):
         super().__init__(field_or_expr, expr=expr)
-
         self._bins = bins
         self._range = range
         self._auto = auto
@@ -1680,14 +1681,14 @@ class Values(Aggregation):
         _raw=False,
     ):
         super().__init__(field_or_expr, expr=expr)
-
         self._missing_value = missing_value
         self._unwind = unwind
         self._allow_missing = _allow_missing
         self._big_result = _big_result
-        self._big_field = None
         self._raw = _raw
+
         self._field_type = None
+        self._big_field = None
         self._num_list_fields = None
 
     def _kwargs(self):

--- a/fiftyone/core/stages.py
+++ b/fiftyone/core/stages.py
@@ -260,9 +260,8 @@ class ViewStage(object):
             a :class:`ViewStage`
         """
         view_stage_cls = etau.get_class(d["_cls"])
-        uuid = d.get("_uuid", None)
         stage = view_stage_cls(**{k: v for (k, v) in d["kwargs"]})
-        stage._uuid = uuid
+        stage._uuid = d.get("_uuid", None)
         return stage
 
 

--- a/fiftyone/core/stages.py
+++ b/fiftyone/core/stages.py
@@ -213,8 +213,8 @@ class ViewStage(object):
         """Returns a JSON dict representation of the :class:`ViewStage`.
 
         Args:
-            include_uuid (True): whether to include the stage's UUID in the JSON
-                representation
+            include_uuid (True): whether to include the stage's UUID in the
+                JSON representation
 
         Returns:
             a JSON dict
@@ -263,7 +263,7 @@ class ViewStage(object):
             a :class:`ViewStage`
         """
         view_stage_cls = etau.get_class(d["_cls"])
-        stage = view_stage_cls(**{k: v for (k, v) in d["kwargs"]})
+        stage = view_stage_cls(**dict(d["kwargs"]))
         stage._uuid = d.get("_uuid", None)
         return stage
 

--- a/fiftyone/core/stages.py
+++ b/fiftyone/core/stages.py
@@ -69,6 +69,9 @@ class ViewStage(object):
         kwargs_str = ", ".join(kwargs_list)
         return "%s(%s)" % (self.__class__.__name__, kwargs_str)
 
+    def __eq__(self, other):
+        return type(self) == type(other) and self._kwargs() == other._kwargs()
+
     @property
     def has_view(self):
         """Whether this stage's output view should be loaded via

--- a/tests/unittests/aggregation_tests.py
+++ b/tests/unittests/aggregation_tests.py
@@ -863,53 +863,6 @@ class DatasetTests(unittest.TestCase):
 
     @drop_datasets
     def test_serialize(self):
-        samples = [
-            fo.Sample(
-                filepath="image1.jpg",
-                predictions=fo.Detections(
-                    detections=[
-                        fo.Detection(
-                            label="cat",
-                            bounding_box=[0.1, 0.1, 0.4, 0.4],
-                            confidence=0.7,
-                        ),
-                        fo.Detection(
-                            label="dog",
-                            bounding_box=[0.3, 0.3, 0.5, 0.5],
-                            confidence=0.9,
-                        ),
-                    ]
-                ),
-            ),
-            fo.Sample(
-                filepath="image2.jpg",
-                predictions=fo.Detections(
-                    detections=[
-                        fo.Detection(
-                            label="rabbit",
-                            bounding_box=[0.4, 0.4, 0.2, 0.2],
-                            confidence=0.8,
-                        ),
-                    ]
-                ),
-            ),
-            fo.Sample(
-                filepath="image3.jpg",
-                predictions=fo.Detections(
-                    detections=[
-                        fo.Detection(
-                            label="squirrel",
-                            bounding_box=[0.5, 0.5, 0.5, 0.5],
-                            confidence=0.9,
-                        ),
-                    ]
-                ),
-            ),
-        ]
-
-        dataset = fo.Dataset()
-        dataset.add_samples(samples)
-
         bbox_area = F("bounding_box")[2] * F("bounding_box")[3]
 
         aggregations = [
@@ -932,9 +885,7 @@ class DatasetTests(unittest.TestCase):
         agg_dicts = [a._serialize() for a in aggregations]
         also_aggregations = [fo.Aggregation._from_dict(d) for d in agg_dicts]
 
-        results = dataset.aggregate(aggregations)
-        also_results = dataset.aggregate(also_aggregations)
-        self.assertEqual(len(results), len(also_results))
+        self.assertListEqual(aggregations, also_aggregations)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Adds support for serializing `Aggregation` instances.

This is primarily an internal-facing feature at this time, which allows, for example, for communicating aggregation definitions between Python and the App.

Example usage:

```py
import fiftyone as fo
import fiftyone.zoo as foz
from fiftyone import ViewField as F

dataset = foz.load_zoo_dataset("quickstart")
dataset.compute_metadata()

bbox_area = (
    F("bounding_box")[2] * F("$metadata.height")
    * F("bounding_box")[3] * F("$metadata.width")
)

aggregations = [
    fo.Bounds("predictions.detections.confidence"),
    fo.Count(),
    fo.Count("ground_truth.detections"),
    fo.CountValues("ground_truth.detections.label"),
    fo.Distinct("ground_truth.detections.label"),
    fo.HistogramValues("predictions.detections.confidence", bins=50, range=[0, 1]),
    fo.Mean("ground_truth.detections[]", expr=bbox_area),
    fo.Std("ground_truth.detections[]", expr=bbox_area),
    fo.Sum("predictions.detections", expr=F().length()),
    fo.Values("id"),
]

results = dataset.aggregate(aggregations)
fo.pprint(results)

agg_dicts = [a._serialize() for a in aggregations]
fo.pprint(agg_dicts)

also_aggregations = [fo.Aggregation._from_dict(d) for d in agg_dicts]

also_results = dataset.aggregate(also_aggregations)
fo.pprint(also_results)

for result, also_result in zip(results, also_results):
    assert result == also_result
```
