### PR TITLE
[BUG] Resolve bug when uploading to projects in CVAT

### DIFF
--- a/fiftyone/utils/cvat.py
+++ b/fiftyone/utils/cvat.py
@@ -4742,7 +4742,7 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
                 _,
                 occluded_attr_name,
                 group_id_attr_name,
-            ) = self._to_cvat_attributes(label_info["attributes"])
+            ) = self._to_cvat_attributes(label_info.get("attributes", {}))
 
             if occluded_attr_name or group_id_attr_name:
                 return True


### PR DESCRIPTION
When uploading to an existing CVAT project, you can choose not to provide a label schema or label field and instead use the CLI prompt to specify the names of fields into which to load annotations. This PR resolves a bug when attempting to upload to a CVAT project and no label schema is provided. 

```
Traceback (most recent call last):                                                                                                                                                                                                                                                 
  File "/home/eric/work/fiftyone/fiftyone/tests/intensive/cvat_tests.py", line 498, in test_project                                                                                                                                                                                
    results3 = dataset.annotate(                                                                                                                                                                                                                                                   
  File "/home/eric/work/fiftyone/fiftyone/fiftyone/core/collections.py", line 6482, in annotate                                                                                                                                                                                    
    return foua.annotate(                                                                                                                                                                                                                                                          
  File "/home/eric/work/fiftyone/fiftyone/fiftyone/utils/annotations.py", line 211, in annotate                                                                                                                                                                                    
    results = anno_backend.upload_annotations(                                                                                                                                                                                                                                     
  File "/home/eric/work/fiftyone/fiftyone/fiftyone/utils/cvat.py", line 3199, in upload_annotations                                                                                                                                                                                
    results = api.upload_samples(samples, self)                                                                                                                                                                                                                                    
  File "/home/eric/work/fiftyone/fiftyone/fiftyone/utils/cvat.py", line 4154, in upload_samples                                                                                                                                                                                    
    has_ignored_attributes = self._has_ignored_attributes(label_schema)                                                                                                                                                                                                            
  File "/home/eric/work/fiftyone/fiftyone/fiftyone/utils/cvat.py", line 4745, in _has_ignored_attributes                                                                                                                                                                           
    ) = self._to_cvat_attributes(label_info["attributes"])                                                                                                                                                                                                                         
KeyError: 'attributes'    
```

The project test has been updated to handle this case, it now passes.