### PR TITLE
Adding new_ids=True option to Dataset.add_collection()

### DIFF
--- a/tests/unittests/dataset_tests.py
+++ b/tests/unittests/dataset_tests.py
@@ -843,6 +843,57 @@ class DatasetTests(unittest.TestCase):
             )
 
     @drop_datasets
+    def test_add_collection(self):
+        sample1 = fo.Sample(filepath="image.jpg", foo="bar")
+        dataset1 = fo.Dataset()
+        dataset1.add_sample(sample1)
+
+        sample2 = fo.Sample(filepath="image.jpg", spam="eggs")
+        dataset2 = fo.Dataset()
+        dataset2.add_sample(sample2)
+
+        # Merge dataset
+        dataset = dataset1.clone()
+        dataset.add_collection(dataset2)
+
+        self.assertEqual(len(dataset), 2)
+        self.assertTrue("spam" in dataset.get_field_schema())
+        self.assertIsNone(dataset.first()["spam"])
+        self.assertEqual(dataset.last()["spam"], "eggs")
+
+        # Merge view
+        dataset = dataset1.clone()
+        dataset.add_collection(dataset2.exclude_fields("spam"))
+
+        self.assertEqual(len(dataset), 2)
+        self.assertTrue("spam" not in dataset.get_field_schema())
+        self.assertIsNone(dataset.last()["foo"])
+
+    @drop_datasets
+    def test_add_collection_new_ids(self):
+        sample1 = fo.Sample(filepath="image.jpg", foo="bar")
+        dataset1 = fo.Dataset()
+        dataset1.add_sample(sample1)
+
+        # Merge dataset
+        dataset = dataset1.clone()
+        dataset.add_collection(dataset, new_ids=True)
+
+        self.assertEqual(len(dataset), 2)
+        self.assertEqual(len(set(dataset.values("id"))), 2)
+        self.assertEqual(dataset.first()["foo"], "bar")
+        self.assertEqual(dataset.last()["foo"], "bar")
+
+        # Merge view
+        dataset = dataset1.clone()
+        dataset.add_collection(dataset.exclude_fields("foo"), new_ids=True)
+
+        self.assertEqual(len(dataset), 2)
+        self.assertEqual(len(set(dataset.values("id"))), 2)
+        self.assertEqual(dataset.first()["foo"], "bar")
+        self.assertIsNone(dataset.last()["foo"])
+
+    @drop_datasets
     def test_expand_schema(self):
         # None-valued new fields are ignored for schema expansion
 


### PR DESCRIPTION
Adds an optional `new_ids=True` option to `Dataset.add_collection()` that generates new sample/frame IDs when adding the samples to the collection.

This is useful, for example, to quickly exponentiate the size of a dataset for testing:

```py
# Make dataset 2 ** 4 times larger
for _ in range(4):
    dataset.add_collection(dataset, new_ids=True)
```

### Image example

```py
import fiftyone as fo
import fiftyone.zoo as foz

dataset = foz.load_zoo_dataset("quickstart")
new_ids = dataset.add_collection(dataset, new_ids=True)

assert len(dataset) == 400
assert len(set(dataset.values("id"))) == 400
```

### Video example

```py
import fiftyone as fo
import fiftyone.zoo as foz

dataset = foz.load_zoo_dataset("quickstart-video")
new_ids = dataset.add_collection(dataset, new_ids=True)

assert len(dataset) == 20
assert len(set(dataset.values("frames.id", unwind=True))) == 2558
```
