### PR TITLE
Adding quantiles aggregation

### DIFF
--- a/docs/source/user_guide/using_aggregations.rst
+++ b/docs/source/user_guide/using_aggregations.rst
@@ -282,6 +282,35 @@ collection:
     print(dataset.mean("predictions.detections.confidence"))
     # 0.34994137249820706
 
+.. _aggregations-quantiles:
+
+Quantiles
+_________
+
+You can use the
+:meth:`quantiles() <fiftyone.core.collections.SampleCollection.quantiles>`
+aggregation to compute the quantile(s) of the (non-``None``) values of a field
+in a collection:
+
+.. code-block:: python
+    :linenos:
+
+    import fiftyone.zoo as foz
+
+    dataset = foz.load_zoo_dataset("quickstart")
+
+    # Compute quantiles of the `uniqueness` field
+    print(dataset.quantiles("uniqueness", [0.25, 0.5, 0.75, 0.9]))
+    # [0.22027, 0.33771, 0.62554, 0.69488]
+
+    # Compute quantiles of detection confidence in the `predictions` field
+    quantiles = dataset.quantiles(
+        "predictions.detections.confidence",
+        [0.25, 0.5, 0.75, 0.9],
+    )
+    print(quantiles)
+    # [0.09231, 0.20251, 0.56273, 0.94354]
+
 .. _aggregations-std:
 
 Standard deviation

--- a/fiftyone/__public__.py
+++ b/fiftyone/__public__.py
@@ -22,6 +22,7 @@ from .core.aggregations import (
     Distinct,
     HistogramValues,
     Mean,
+    Quantiles,
     Std,
     Sum,
     Values,

--- a/fiftyone/core/aggregations.py
+++ b/fiftyone/core/aggregations.py
@@ -17,6 +17,7 @@ import eta.core.utils as etau
 
 import fiftyone.core.expressions as foe
 from fiftyone.core.expressions import VALUE
+from fiftyone.core.expressions import ViewExpression as E
 from fiftyone.core.expressions import ViewField as F
 import fiftyone.core.fields as fof
 import fiftyone.core.media as fom
@@ -1330,6 +1331,161 @@ class Mean(Aggregation):
         pipeline.append({"$group": {"_id": None, "mean": {"$avg": value}}})
 
         return pipeline
+
+
+class Quantiles(Aggregation):
+    """Computes the quantile(s) of the field values of a collection.
+
+    ``None``-valued fields are ignored.
+
+    This aggregation is typically applied to *numeric* field types (or lists of
+    such types):
+
+    -   :class:`fiftyone.core.fields.IntField`
+    -   :class:`fiftyone.core.fields.FloatField`
+
+    Examples::
+
+        import fiftyone as fo
+        from fiftyone import ViewField as F
+
+        dataset = fo.Dataset()
+        dataset.add_samples(
+            [
+                fo.Sample(
+                    filepath="/path/to/image1.png",
+                    numeric_field=1.0,
+                    numeric_list_field=[1, 2, 3],
+                ),
+                fo.Sample(
+                    filepath="/path/to/image2.png",
+                    numeric_field=4.0,
+                    numeric_list_field=[1, 2],
+                ),
+                fo.Sample(
+                    filepath="/path/to/image3.png",
+                    numeric_field=None,
+                    numeric_list_field=None,
+                ),
+            ]
+        )
+
+        #
+        # Compute the quantiles of a numeric field
+        #
+
+        aggregation = fo.Quantiles("numeric_field", [0.1, 0.5, 0.9])
+        quantiles = dataset.aggregate(aggregation)
+        print(quantiles)  # the quantiles
+
+        #
+        # Compute the quantiles of a numeric list field
+        #
+
+        aggregation = fo.Quantiles("numeric_list_field", [0.1, 0.5, 0.9])
+        quantiles = dataset.aggregate(aggregation)
+        print(quantiles)  # the quantiles
+
+        #
+        # Compute the mean of a transformation of a numeric field
+        #
+
+        aggregation = fo.Quantiles(2 * (F("numeric_field") + 1), [0.1, 0.5, 0.9])
+        quantiles = dataset.aggregate(aggregation)
+        print(quantiles)  # the quantiles
+
+    Args:
+        field_or_expr: a field name, ``embedded.field.name``,
+            :class:`fiftyone.core.expressions.ViewExpression`, or
+            `MongoDB expression <https://docs.mongodb.com/manual/meta/aggregation-quick-reference/#aggregation-expressions>`_
+            defining the field or expression to aggregate
+        quantiles: the quantile or iterable of quantiles to compute. Each
+            quantile must be a numeric value in ``[0, 1]``
+        expr (None): a :class:`fiftyone.core.expressions.ViewExpression` or
+            `MongoDB expression <https://docs.mongodb.com/manual/meta/aggregation-quick-reference/#aggregation-expressions>`_
+            to apply to ``field_or_expr`` (which must be a field) before
+            aggregating
+        safe (False): whether to ignore nan/inf values when dealing with
+            floating point values
+    """
+
+    def __init__(self, field_or_expr, quantiles, expr=None, safe=False):
+        quantiles, is_scalar = self._parse_quantiles(quantiles)
+
+        super().__init__(field_or_expr, expr=expr, safe=safe)
+        self._quantiles = quantiles
+        self._is_scalar = is_scalar
+
+    def default_result(self):
+        """Returns the default result for this aggregation.
+
+        Returns:
+            ``None`` or ``[None, None, None]``
+        """
+        if self._is_scalar:
+            return None
+
+        return [None] * len(self._quantiles)
+
+    def parse_result(self, d):
+        """Parses the output of :meth:`to_mongo`.
+
+        Args:
+            d: the result dict
+
+        Returns:
+            the quantile or list of quantiles
+        """
+        if self._is_scalar:
+            return d["quantiles"][0]
+
+        return d["quantiles"]
+
+    def to_mongo(self, sample_collection):
+        path, pipeline, _, id_to_str, _ = _parse_field_and_expr(
+            sample_collection,
+            self._field_name,
+            expr=self._expr,
+            safe=self._safe,
+        )
+
+        if id_to_str:
+            value = {"$toString": "$" + path}
+        else:
+            value = "$" + path
+
+        # Compute quantile
+        # Note that we don't need to explicitly handle empty `values` here
+        # because the `group` stage only outputs a document if there's at least
+        # one value to compute on!
+        array = F("values").sort()
+        idx = ((F() * array.length()).ceil() - 1).max(0)
+        quantile_expr = array.let_in(E(self._quantiles).map(array[idx]))
+
+        pipeline.extend(
+            [
+                {"$match": {"$expr": {"$isNumber": value}}},
+                {"$group": {"_id": None, "values": {"$push": value}}},
+                {"$project": {"quantiles": quantile_expr.to_mongo()}},
+            ]
+        )
+
+        return pipeline
+
+    def _parse_quantiles(self, quantiles):
+        is_scalar = not etau.is_container(quantiles)
+
+        if is_scalar:
+            quantiles = [quantiles]
+        else:
+            quantiles = list(quantiles)
+
+        if any(not etau.is_numeric(q) or q < 0 or q > 1 for q in quantiles):
+            raise ValueError(
+                "Quantiles must be numbers in [0, 1]; found %s" % quantiles
+            )
+
+        return quantiles, is_scalar
 
 
 class Std(Aggregation):

--- a/fiftyone/core/aggregations.py
+++ b/fiftyone/core/aggregations.py
@@ -1458,7 +1458,7 @@ class Quantiles(Aggregation):
         # Note that we don't need to explicitly handle empty `values` here
         # because the `group` stage only outputs a document if there's at least
         # one value to compute on!
-        array = F("values").sort()
+        array = F("values").sort(numeric=True)
         idx = ((F() * array.length()).ceil() - 1).max(0)
         quantile_expr = array.let_in(E(self._quantiles).map(array[idx]))
 

--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -5787,6 +5787,87 @@ class SampleCollection(object):
         return self._make_and_aggregate(make, field_or_expr)
 
     @aggregation
+    def quantiles(self, field_or_expr, quantiles, expr=None, safe=False):
+        """Computes the quantile(s) of the field values of a collection.
+
+        ``None``-valued fields are ignored.
+
+        This aggregation is typically applied to *numeric* field types (or
+        lists of such types):
+
+        -   :class:`fiftyone.core.fields.IntField`
+        -   :class:`fiftyone.core.fields.FloatField`
+
+        Examples::
+
+            import fiftyone as fo
+            from fiftyone import ViewField as F
+
+            dataset = fo.Dataset()
+            dataset.add_samples(
+                [
+                    fo.Sample(
+                        filepath="/path/to/image1.png",
+                        numeric_field=1.0,
+                        numeric_list_field=[1, 2, 3],
+                    ),
+                    fo.Sample(
+                        filepath="/path/to/image2.png",
+                        numeric_field=4.0,
+                        numeric_list_field=[1, 2],
+                    ),
+                    fo.Sample(
+                        filepath="/path/to/image3.png",
+                        numeric_field=None,
+                        numeric_list_field=None,
+                    ),
+                ]
+            )
+
+            #
+            # Compute the quantiles of a numeric field
+            #
+
+            quantiles = dataset.quantiles("numeric_field", [0.1, 0.5, 0.9])
+            print(quantiles)  # the quantiles
+
+            #
+            # Compute the quantiles of a numeric list field
+            #
+
+            quantiles = dataset.quantiles("numeric_list_field", [0.1, 0.5, 0.9])
+            print(quantiles)  # the quantiles
+
+            #
+            # Compute the mean of a transformation of a numeric field
+            #
+
+            quantiles = dataset.quantiles(2 * (F("numeric_field") + 1), [0.1, 0.5, 0.9])
+            print(quantiles)  # the quantiles
+
+        Args:
+            field_or_expr: a field name, ``embedded.field.name``,
+                :class:`fiftyone.core.expressions.ViewExpression`, or
+                `MongoDB expression <https://docs.mongodb.com/manual/meta/aggregation-quick-reference/#aggregation-expressions>`_
+                defining the field or expression to aggregate
+            quantiles: the quantile or iterable of quantiles to compute. Each
+                quantile must be a numeric value in ``[0, 1]``
+            expr (None): a :class:`fiftyone.core.expressions.ViewExpression` or
+                `MongoDB expression <https://docs.mongodb.com/manual/meta/aggregation-quick-reference/#aggregation-expressions>`_
+                to apply to ``field_or_expr`` (which must be a field) before
+                aggregating
+            safe (False): whether to ignore nan/inf values when dealing with
+                floating point values
+
+        Returns:
+            the quantile or list of quantiles
+        """
+        make = lambda field_or_expr: foa.Quantiles(
+            field_or_expr, quantiles, expr=expr, safe=safe
+        )
+        return self._make_and_aggregate(make, field_or_expr)
+
+    @aggregation
     def std(self, field_or_expr, expr=None, safe=False, sample=False):
         """Computes the standard deviation of the field values of the
         collection.

--- a/fiftyone/core/expressions.py
+++ b/fiftyone/core/expressions.py
@@ -2628,7 +2628,7 @@ class ViewExpression(object):
 
             view = dataset.set_field(
                 "predictions.detections",
-                F("detections").sort(key="confidence", reverse=True)
+                F("detections").sort(key="confidence", numeric=True, reverse=True)
             )
 
             sample = view.first()
@@ -2646,8 +2646,12 @@ class ViewExpression(object):
             a :class:`ViewExpression`
         """
         if key is not None:
-            # @todo this implicitly assumes `key` is numeric
-            comp = "(a, b) => a.{key} - b.{key}".format(key=key)
+            if numeric:
+                comp = "(a, b) => a.{key} - b.{key}"
+            else:
+                comp = "(a, b) => ('' + a.{key}).localeCompare(b.{key})"
+
+            comp = comp.format(key=key)
         elif numeric:
             comp = "(a, b) => a - b"
         else:

--- a/fiftyone/core/expressions.py
+++ b/fiftyone/core/expressions.py
@@ -2584,7 +2584,7 @@ class ViewExpression(object):
         """
         return ViewExpression({"$reverseArray": self})
 
-    def sort(self, key=None, reverse=False):
+    def sort(self, key=None, numeric=False, reverse=False):
         """Sorts this expression, which must resolve to an array.
 
         If no ``key`` is provided, this array must contain elements whose
@@ -2637,13 +2637,19 @@ class ViewExpression(object):
 
         Args:
             key (None): an optional field or ``embedded.field.name`` to sort by
+            numeric (False): whether the array contains numeric values. By
+                default, the values will be sorted alphabetically by their
+                string representations
             reverse (False): whether to sort in descending order
 
         Returns:
             a :class:`ViewExpression`
         """
         if key is not None:
+            # @todo this implicitly assumes `key` is numeric
             comp = "(a, b) => a.{key} - b.{key}".format(key=key)
+        elif numeric:
+            comp = "(a, b) => a - b"
         else:
             comp = ""
 

--- a/tests/unittests/aggregation_tests.py
+++ b/tests/unittests/aggregation_tests.py
@@ -9,6 +9,7 @@ from datetime import date, datetime, timedelta
 import math
 
 from bson import ObjectId
+import numpy as np
 import unittest
 
 import fiftyone as fo
@@ -219,6 +220,36 @@ class DatasetTests(unittest.TestCase):
         self.assertEqual(d.mean("numeric_field"), 2)
 
         self.assertAlmostEqual(d.mean(2.0 * (F("numeric_field") + 1)), 6.0)
+
+    @drop_datasets
+    def test_quantiles(self):
+        d = fo.Dataset()
+        d.add_sample_field("numeric_field", fo.IntField)
+        self.assertIsNone(d.quantiles("numeric_field", 0.5))
+        self.assertListEqual(d.quantiles("numeric_field", [0.5]), [None])
+
+        s = fo.Sample(filepath="image.jpeg", numeric_field=1)
+        d.add_sample(s)
+        self.assertAlmostEqual(d.quantiles("numeric_field", 0.5), 1)
+
+        s = fo.Sample(filepath="image2.jpeg", numeric_field=2)
+        d.add_sample(s)
+
+        q = np.linspace(0, 1, 11)
+
+        results1 = d.quantiles("numeric_field", q)
+        results2 = np.quantile([1, 2], q, method="inverted_cdf")
+
+        self.assertEqual(len(results1), len(results2))
+        for r1, r2 in zip(results1, results2):
+            self.assertAlmostEqual(r1, r2)
+
+        results1 = d.quantiles(2.0 * (F("numeric_field") + 1), q)
+        results2 = np.quantile([4, 6], q, method="inverted_cdf")
+
+        self.assertEqual(len(results1), len(results2))
+        for r1, r2 in zip(results1, results2):
+            self.assertAlmostEqual(r1, r2)
 
     @drop_datasets
     def test_std(self):
@@ -444,6 +475,10 @@ class DatasetTests(unittest.TestCase):
         self.assertTrue(math.isnan(dataset.sum("float")))
         self.assertTrue(math.isnan(dataset.std("float")))
 
+        self.assertTrue(math.isnan(dataset.quantiles("float", 1)))
+        self.assertTrue(math.isinf(dataset.quantiles("float", 0)))
+        self.assertAlmostEqual(dataset.quantiles("float", 0.5), 1.0)
+
         counts, edges, other = dataset.histogram_values("float")
         self.assertEqual(other, 5)  # captures None, nan, inf
 
@@ -459,6 +494,10 @@ class DatasetTests(unittest.TestCase):
         self.assertAlmostEqual(dataset.mean("float", safe=True), 1.0)
         self.assertAlmostEqual(dataset.sum("float", safe=True), 1.0)
         self.assertAlmostEqual(dataset.std("float", safe=True), 0.0)
+
+        self.assertAlmostEqual(dataset.quantiles("float", 0, safe=True), 1.0)
+        self.assertAlmostEqual(dataset.quantiles("float", 1, safe=True), 1.0)
+        self.assertAlmostEqual(dataset.quantiles("float", 0.5, safe=True), 1.0)
 
     @drop_datasets
     def test_object_ids(self):

--- a/tests/unittests/aggregation_tests.py
+++ b/tests/unittests/aggregation_tests.py
@@ -238,14 +238,20 @@ class DatasetTests(unittest.TestCase):
         q = np.linspace(0, 1, 11)
 
         results1 = d.quantiles("numeric_field", q)
-        results2 = np.quantile([1, 2], q, method="inverted_cdf")
+
+        # only available in `numpy>=1.22`
+        # results2 = np.quantile([1, 2], q, method="inverted_cdf")
+        results2 = [1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2]
 
         self.assertEqual(len(results1), len(results2))
         for r1, r2 in zip(results1, results2):
             self.assertAlmostEqual(r1, r2)
 
         results1 = d.quantiles(2.0 * (F("numeric_field") + 1), q)
-        results2 = np.quantile([4, 6], q, method="inverted_cdf")
+
+        # only available in `numpy>=1.22`
+        # results2 = np.quantile([4, 6], q, method="inverted_cdf")
+        results2 = [4, 4, 4, 4, 4, 4, 6, 6, 6, 6, 6]
 
         self.assertEqual(len(results1), len(results2))
         for r1, r2 in zip(results1, results2):

--- a/tests/unittests/aggregation_tests.py
+++ b/tests/unittests/aggregation_tests.py
@@ -251,6 +251,15 @@ class DatasetTests(unittest.TestCase):
         for r1, r2 in zip(results1, results2):
             self.assertAlmostEqual(r1, r2)
 
+        with self.assertRaises(ValueError):
+            d.quantiles("numeric_field", "bad-value")
+
+        with self.assertRaises(ValueError):
+            d.quantiles("numeric_field", -1)
+
+        with self.assertRaises(ValueError):
+            d.quantiles("numeric_field", 2)
+
     @drop_datasets
     def test_std(self):
         d = fo.Dataset()

--- a/tests/unittests/aggregation_tests.py
+++ b/tests/unittests/aggregation_tests.py
@@ -489,10 +489,11 @@ class DatasetTests(unittest.TestCase):
         self.assertTrue(math.isnan(dataset.mean("float")))
         self.assertTrue(math.isnan(dataset.sum("float")))
         self.assertTrue(math.isnan(dataset.std("float")))
-
-        self.assertTrue(math.isnan(dataset.quantiles("float", 1)))
-        self.assertTrue(math.isinf(dataset.quantiles("float", 0)))
-        self.assertAlmostEqual(dataset.quantiles("float", 0.5), 1.0)
+        self.assertTrue(math.isnan(dataset.quantiles("float", 0)))
+        self.assertTrue(math.isnan(dataset.quantiles("float", 0.25)))
+        self.assertTrue(math.isinf(dataset.quantiles("float", 0.50)))
+        self.assertAlmostEqual(dataset.quantiles("float", 0.75), 1.0)
+        self.assertTrue(math.isinf(dataset.quantiles("float", 1)))
 
         counts, edges, other = dataset.histogram_values("float")
         self.assertEqual(other, 5)  # captures None, nan, inf


### PR DESCRIPTION
Resolves https://github.com/voxel51/fiftyone/issues/1935.

Adds a `Quantiles` aggregation that can be used to compute the quantiles of numeric data.

### Notes

- Unfortunately, MongoDB has no builtin method for computing quantiles, so the implementation performs a full sort of the values. Thus `quantiles()` requires `O(n)` memory (DB-side, not client-side), not `O(1)` like other aggregations
- I benchmarked `$group` + `JS sort` versus `$sort` + `$group` on a dataset of 100K samples, and the JS sort version was faster
- I also tried https://stackoverflow.com/a/60694525/16823653, which was extremely slow

### Example usage

```py
import fiftyone as fo
import fiftyone.zoo as foz

dataset = foz.load_zoo_dataset("quickstart")

print(dataset.quantiles("uniqueness", [0.25, 0.50, 0.75]))
# [0.2202, 0.3377, 0.6255]

print(dataset.quantiles("uniqueness", 0.9))
# 0.6949

print(dataset.quantiles("predictions.detections.confidence", [0.25, 0.50, 0.75]))
# [0.0923, 0.2025, 0.5627]

print(dataset.quantiles("predictions.detections.confidence", 0.9))
# 0.9435
```
