### PR TITLE
Fix App masks

### DIFF
--- a/fiftyone/server/query.py
+++ b/fiftyone/server/query.py
@@ -151,11 +151,11 @@ class Dataset(HasCollection):
     def modifier(doc: dict) -> dict:
         doc["id"] = doc.pop("_id")
         doc["default_mask_targets"] = _convert_targets(
-            doc.get("default_mask_targets", [])
+            doc.get("default_mask_targets", {})
         )
         doc["mask_targets"] = [
             NamedTargets(name, _convert_targets(targets))
-            for name, targets in doc.get("mask_targets", []).items()
+            for name, targets in doc.get("mask_targets", {}).items()
         ]
         doc["sample_fields"] = _flatten_fields([], doc["sample_fields"])
         doc["frame_fields"] = _flatten_fields([], doc["frame_fields"])


### PR DESCRIPTION
Resolves a bug introduced in #1943.

Mask values are dicts, not lists. Fixes the default value.