### PR TITLE
#1951 and #1952

### DIFF
--- a/docs/source/integrations/coco.rst
+++ b/docs/source/integrations/coco.rst
@@ -192,8 +192,8 @@ file containing COCO-formatted labels to work with:
 
     dataset = foz.load_zoo_dataset("quickstart")
 
-    # Give the dataset a classes list so it can be exported + imported
-    dataset.default_classes = dataset.distinct("ground_truth.detections.label")
+    # Classes list
+    classes = dataset.distinct("ground_truth.detections.label")
 
     # The directory in which the dataset's images are stored
     IMAGES_DIR = os.path.dirname(dataset.first().filepath)
@@ -203,6 +203,7 @@ file containing COCO-formatted labels to work with:
         dataset_type=fo.types.COCODetectionDataset,
         label_field="ground_truth",
         labels_path="/tmp/coco.json",
+        classes=classes,
     )
 
 Now we have a ``/tmp/coco.json`` file on disk containing COCO labels

--- a/docs/source/integrations/coco.rst
+++ b/docs/source/integrations/coco.rst
@@ -269,7 +269,6 @@ dataset:
         data_path=IMAGES_DIR,
         labels_path="/tmp/coco.json",
         include_id=True,
-        label_field="",
     )
 
     # Verify that the class list for our dataset was imported

--- a/docs/source/integrations/labelbox.rst
+++ b/docs/source/integrations/labelbox.rst
@@ -440,9 +440,8 @@ details:
     `label_field` or all fields in `label_schema` without classes specified.
     All new label fields must have a class list provided via one of the
     supported methods. For existing label fields, if classes are not provided
-    by this argument nor `label_schema`, they are parsed from
-    :meth:`Dataset.classes <fiftyone.core.dataset.Dataset.classes>` or
-    :meth:`Dataset.default_classes <fiftyone.core.dataset.Dataset.default_classes>`
+    by this argument nor `label_schema`, the observed labels on your dataset
+    are used
 -   **attributes** (*True*): specifies the label attributes of each label field
     to include (other than their `label`, which is always included) in the
     annotation export. Can be any of the following:
@@ -607,16 +606,8 @@ FiftyOne can infer the appropriate values to use:
 
 -   **label_type**: if omitted, the |Label| type of the field will be used to
     infer the appropriate value for this parameter
--   **classes**: if omitted for a non-semantic segmentation field, the class
-    lists from the :meth:`classes <fiftyone.core.dataset.Dataset.classes>` or
-    :meth:`default_classes <fiftyone.core.dataset.Dataset.default_classes>`
-    properties of your dataset will be used, if available. Otherwise, the
-    observed labels on your dataset will be used to construct a classes list.
--   **mask_targets**: if omitted for a semantic segmentation field, the mask
-    targets from the
-    :meth:`mask_targets <fiftyone.core.dataset.Dataset.mask_targets>` or
-    :meth:`default_mask_targets <fiftyone.core.dataset.Dataset.default_mask_targets>`
-    properties of your dataset will be used, if available
+-   **classes**: if omitted for a non-semantic segmentation field, the observed
+    labels on your dataset will be used to construct a classes list
 
 .. note::
 

--- a/docs/source/integrations/labelbox.rst
+++ b/docs/source/integrations/labelbox.rst
@@ -453,6 +453,19 @@ details:
         `values`, and `default` for each attribute
 -   **mask_targets** (*None*): a dict mapping pixel values to semantic label
     strings. Only applicable when annotating semantic segmentations
+-   **allow_additions** (*True*): whether to allow new labels to be added. Only
+    applicable when editing existing label fields
+-   **allow_deletions** (*True*): whether to allow labels to be deleted. Only
+    applicable when editing existing label fields
+-   **allow_label_edits** (*True*): whether to allow the `label` attribute of
+    existing labels to be modified. Only applicable when editing existing
+    fields with `label` attributes
+-   **allow_index_edits** (*True*): whether to allow the `index` attribute
+    of existing video tracks to be modified. Only applicable when editing
+    existing frame fields with `index` attributes
+-   **allow_spatial_edits** (*True*): whether to allow edits to the spatial
+    properties (bounding boxes, vertices, keypoints, masks, etc) of labels.
+    Only applicable when editing existing spatial label fields
 
 |br|
 In addition, the following Labelbox-specific parameters from

--- a/fiftyone/utils/yolo.py
+++ b/fiftyone/utils/yolo.py
@@ -907,11 +907,20 @@ class YOLOv5DatasetExporter(
         if self._dynamic_classes:
             classes = _to_classes(self._labels_map_rev)
         else:
-            classes = self.classes
+            classes = list(self.classes)
+
+        if "names" in d and classes != d["names"]:
+            raise ValueError(
+                "Aborting export of YOLOv5 split '%s' because its class list "
+                "does not match the existing class list in '%s'.\nIf you are "
+                "exporting multiple splits, you must provide a common class "
+                "list via the `classes` argument"
+                % (self.split, self.yaml_path)
+            )
 
         d[self.split] = _make_yolo_v5_path(self.data_path, self.yaml_path)
         d["nc"] = len(classes)
-        d["names"] = list(classes)
+        d["names"] = classes
 
         _write_yaml_file(d, self.yaml_path, default_flow_style=False)
 


### PR DESCRIPTION
Resolves #1951
Resolves #1952 

#1951 is resolved by simply removing a stray `label_field=""` from the docs.

#1952 is resolved by adding an informative error message when trying to export multiple YOLOv5 splits without providing the `classes` parameter to ensure a common class list is used.

```py
import fiftyone as fo
import fiftyone.zoo as foz
import fiftyone.utils.splits as fous

dataset = foz.load_zoo_dataset("quickstart")

dataset = dataset.select_fields("ground_truth").clone()
dataset.untag_samples("validation")

classes = dataset.distinct("ground_truth.detections.label")

fous.random_split(dataset, {"train": 0.65, "test": 0.2, "val": 0.15})

for split in ["train", "test", "val"]:
    dataset.match_tags(split).export(
        export_dir="/tmp/yolov5",
        dataset_type=fo.types.YOLOv5Dataset,
        classes=classes,  # you'll see an error if you omit this
        split=split,
    )

dataset2 = fo.Dataset()
for split in ["train", "test", "val"]:
    dataset2.add_dir(
        dataset_dir="/tmp/yolov5",
        dataset_type=fo.types.YOLOv5Dataset,
        split=split,
        tags=split,
    )

session = fo.launch_app(dataset2)
```

