### PR TITLE
[WIP] Catch UnicodeDecodeError when reading invalid file

### DIFF
--- a/fiftyone/utils/yolo.py
+++ b/fiftyone/utils/yolo.py
@@ -1095,7 +1095,11 @@ def _write_yaml_file(d, path, **kwargs):
 
 def _read_file_lines(path):
     with open(path, "r") as f:
-        lines = [l.strip() for l in f.read().splitlines()]
+        try:
+            lines = [l.strip() for l in f.read().splitlines()]
+        except UnicodeDecodeError:
+            logger.warning("Error while decoding file %s, ignoring", path)
+            return []
         return [l for l in lines if l]
 
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

Catch a UnicodeDecodeError if you pass in an invalid file to `_read_file_lines()`. This is (from my experience) caused by passing in an image rather than a txt file, which can happen in a particular scenario where yolo labels are loaded from a folder containing both images and label text files (where the corresponding label file may not exist).

## How is this patch tested? If it is not, please explain why.

Pass an image to `_read_file_lines`. (is there something else I'm supposed to put here?)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
