### PR TITLE
update tabulate to 0.8.10 for source install

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -29,6 +29,6 @@ sseclient-py>=1.7.2
 sse-starlette>=0.10.3
 starlette==0.16.0
 strawberry-graphql==0.96.0
-tabulate==0.8.5
+tabulate==0.8.10
 universal-analytics-python3==1.0.1
 xmltodict==0.12.0


### PR DESCRIPTION
## What changes are proposed in this pull request?

Upgrade version of tabulate to 0.8.10 to fix source install issue #1978 

## How is this patch tested? If it is not, please explain why.

The changes were tested by performing a developer installation of FiftyOne from source using Python 3.10.5

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [x] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other

Resolves #1978