### PR TITLE
Adding plotly v5 support!

### DIFF
--- a/docs/source/user_guide/plots.rst
+++ b/docs/source/user_guide/plots.rst
@@ -139,8 +139,9 @@ below for your environment:
 
   .. group-tab:: Jupyter notebooks
 
-    To use interactive plots in Jupyter notebooks, ensure that you have the
-    ``notebook`` and ``ipywidgets`` packages installed:
+    To use interactive plots in Jupyter notebooks, ensure that you have
+    sufficiently new versions of the ``notebook`` and ``ipywidgets`` packages
+    installed:
 
     .. code-block:: shell
 
@@ -148,28 +149,18 @@ below for your environment:
 
   .. group-tab:: JupyterLab
 
-    To use interactive plots in JupyterLab, ensure that you have the
-    ``jupyterlab`` and ``ipywidgets`` packages installed:
+    To use interactive plots in JupyterLab, ensure that you have sufficiently
+    new versions of the ``jupyterlab`` and ``ipywidgets`` packages installed:
 
     .. code-block:: shell
 
-        pip install jupyterlab "ipywidgets>=7.5"
+        pip install "jupyterlab>=3" "ipywidgets>=7.6"
 
-    In additional, you'll need to run the following commands to install the
-    required JupyterLab extensions:
-
-    .. code-block:: shell
-
-        jupyter labextension install jupyterlab-plotly@4.14.3
-        jupyter labextension install @jupyter-widgets/jupyterlab-manager plotlywidget@4.14.3
-        jupyter lab build
-
-    The above instructions assume that you have ``plotly==4.14.3`` installed.
-    If you have a different version (``pip show plotly``), substitute the
-    appropriate version number in the commands above.
-
-    If you run into any issues in JupyterLab, refer to
-    `this troubleshooting guide <https://plotly.com/python/troubleshooting>`_.
+    If you run into any issues in JupyterLab, especially if you are trying to
+    use JupyterLab 2.X rather than 3.0+, you may need to manually install the
+    `jupyterlab-plotly` extension. Refer to
+    `this troubleshooting guide <https://plotly.com/python/troubleshooting>`_
+    for more details.
 
 If you wish to use the ``matplotlib`` backend for any interactive plots, refer
 to :ref:`this section <matplotlib-in-notebooks>` for setup instructions.

--- a/docs/source/user_guide/plots.rst
+++ b/docs/source/user_guide/plots.rst
@@ -360,6 +360,7 @@ contains |GeoLocation| data in its ``location`` field:
     from fiftyone import ViewField as F
 
     dataset = foz.load_zoo_dataset("quickstart-geo")
+    fob.compute_uniqueness(dataset)
 
     # A list of ``[longitude, latitude]`` coordinates
     locations = dataset.values("location.point.coordinates")
@@ -437,8 +438,6 @@ notebook:
     import fiftyone.zoo as foz
 
     dataset = foz.load_zoo_dataset("quickstart-geo")
-
-    # Index the dataset by visual uniqueness
     fob.compute_uniqueness(dataset)
 
     session = fo.launch_app(dataset)
@@ -989,7 +988,6 @@ For example, you can save a :ref:`histogram view plot <view-plots>`:
     :linenos:
 
     import fiftyone as fo
-    import fiftyone.brain as fob
     import fiftyone.zoo as foz
 
     dataset = foz.load_zoo_dataset("quickstart")
@@ -1012,6 +1010,8 @@ Or you can save an :ref:`embedding scatterplot <embeddings-plots>`:
 
 .. code-block:: python
     :linenos:
+
+    import fiftyone.brain as fob
 
     results = fob.compute_visualization(dataset)
 

--- a/fiftyone/core/plots/plotly.py
+++ b/fiftyone/core/plots/plotly.py
@@ -1998,7 +1998,7 @@ class InteractiveScatter(PlotlyInteractivePlot):
     This wrapper responds to selection and deselection events (if available)
     triggered on the figure's traces via Plotly's lasso and box selector tools.
 
-    Traces whose ``customdata`` attribute contain numpy arrays are assumed to
+    Traces whose ``customdata`` attribute contain lists/arrays are assumed to
     contain the IDs of the points in the trace. Traces with no ``customdata``
     are allowed, but will not have any selection events.
 
@@ -2022,7 +2022,7 @@ class InteractiveScatter(PlotlyInteractivePlot):
 
     def _init_traces(self):
         for idx, trace in enumerate(self._traces):
-            trace_ids = trace.customdata
+            trace_ids = np.asarray(trace.customdata)
             if trace_ids.ndim > 1:
                 trace_ids = trace_ids[:, 0]
 
@@ -2063,7 +2063,7 @@ class InteractiveScatter(PlotlyInteractivePlot):
         self._traces = [
             trace
             for trace in widget.data
-            if isinstance(trace.customdata, np.ndarray)
+            if etau.is_container(trace.customdata)
         ]
         self._init_traces()
         return widget

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -15,7 +15,7 @@ motor==2.3.0
 ndjson==0.3.1
 packaging==20.3
 pandas==1.4.2
-plotly==4.14.3
+plotly==5.9.0
 pprintpp==0.4.0
 psutil==5.7.0
 pymongo==3.11.0

--- a/requirements/extras.txt
+++ b/requirements/extras.txt
@@ -2,8 +2,8 @@ apache-beam>=2.33.0
 google-api-python-client>=1.6.5
 google-cloud-storage>=1.36
 httplib2<=0.15
-ipywidgets==7.7.1
+ipywidgets>=7.5
 lightning-flash>=0.4.0
-notebook==6.4.12
+notebook>=5.3
 pydicom>=2.2.0
 shapely>=1.7.1

--- a/requirements/extras.txt
+++ b/requirements/extras.txt
@@ -2,6 +2,8 @@ apache-beam>=2.33.0
 google-api-python-client>=1.6.5
 google-cloud-storage>=1.36
 httplib2<=0.15
+ipywidgets==7.7.1
 lightning-flash>=0.4.0
+notebook==6.4.12
 pydicom>=2.2.0
 shapely>=1.7.1

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ INSTALL_REQUIRES = [
     "packaging",
     "pandas",
     "Pillow>=6.2",
-    "plotly>=4.14,<5",
+    "plotly>=4.14",
     "pprintpp",
     "psutil",
     "pymongo>=3.11,<4",


### PR DESCRIPTION
Resolves #1099
Resolves #1319

This PR removes the `plotly<5` restriction that exists in FiftyOne's current dependencies (currently we require `plotly>=4.14,<5`).

After doing some digging, it turns out [this small regression](https://github.com/plotly/plotly.py/issues/3292) introduced in `plotly==5.0.0` was breaking the selection callbacks of our [interactive plots](https://voxel51.com/docs/fiftyone/user_guide/plots.html).

The plotly maintainers patched this regression in [plotly==5.2.1](https://github.com/plotly/plotly.py/releases/tag/v5.2.1), so this PR could have just updated our dependency to `plotly>=5.2.1`. However, it was simple to patch the regression and thus support `plotly>=4.14`.

I also added a `jupyterlab>=3` requirement to the recommended JupyterLab setup instructions in the docs, which simplifies the install process.

This PR was tested by manually running these two examples in Jupyter notebooks and JupyterLab:
- https://voxel51.com/docs/fiftyone/user_guide/plots.html#id5
- https://voxel51.com/docs/fiftyone/user_guide/plots.html#id8