### PR TITLE
Upgrading AnnotationAPI reuse to interface level

### DIFF
--- a/docs/source/integrations/cvat.rst
+++ b/docs/source/integrations/cvat.rst
@@ -2366,18 +2366,19 @@ Using the CVAT API
 ------------------
 
 You can use the
-:meth:`connect_to_api() <fiftyone.utils.cvat.CVATAnnotationResults.connect_to_api>`
+:func:`connect_to_api() <fiftyone.utils.annotations.connect_to_api>`
 to retrive a :class:`CVATAnnotationAPI <fiftyone.utils.cvat.CVATAnnotationAPI>`
 instance, which is a wrapper around the
 `CVAT REST API <https://openvinotoolkit.github.io/cvat/docs/administration/basics/rest_api_guide/>`_
 that provides convenient methods for performing common actions on your CVAT
-tasks.
+tasks:
 
 .. code:: python
     :linenos:
 
     import fiftyone as fo
     import fiftyone.zoo as foz
+    import fiftyone.utils.annotations as foua
 
     dataset = foz.load_zoo_dataset("quickstart")
     view = dataset.take(1)
@@ -2386,12 +2387,11 @@ tasks.
 
     view.annotate(anno_key, label_field="ground_truth")
 
-    results = dataset.load_annotation_results(anno_key)
+    api = foua.connect_to_api()
 
-    # A context manager that closes TCP connections on exit
-    with results:
-        api = results.connect_to_api()
-
+    # The context manager is optional and simply ensures that TCP connections
+    # are always closed
+    with api:
         # Launch CVAT in your browser
         api.launch_editor(api.base_url)
 
@@ -2455,27 +2455,24 @@ for that annotation run:
 
 .. note::
 
-    **Pro tip**: Various methods available on the
-    :class:`results <fiftyone.utils.cvat.CVATAnnotationResults>` object, like
-    those shown above, can be performed more efficiently with the
-    :meth:`use_api() <fiftyone.utils.cvat.CVATAnnotationResults.use_api>`
-    method. This allows you to provide a
-    :class:`CVATAnnotationAPI <fiftyone.utils.cvat.CVATAnnotationAPI>` object as
-    defined in the previous section. The benefit is that this allows you to
-    avoid authentication in each
-    method and significantly speeds up these calls if there are
-    multiple being performed at a time.
+    **Pro tip**: If you are iterating over many annotation runs, you can use
+    :func:`connect_to_api() <fiftyone.utils.annotations.connect_to_api>` and
+    :meth:`use_api() <fiftyone.utils.cvat.CVATAnnotationResults.use_api>` as
+    shown below to reuse a single
+    :class:`CVATAnnotationAPI <fiftyone.utils.cvat.CVATAnnotationAPI>` instance
+    and avoid reauthenticating with CVAT for each run:
 
     .. code-block:: python
         :linenos:
 
-        api = results.connect_to_api()
+        import fiftyone.utils.annotations as foua
+
+        api = foua.connect_to_api()
 
         for anno_key in dataset.list_annotation_runs():
             results = dataset.load_annotation_results(anno_key)
             results.use_api(api)
             results.print_status()
-
 
 Deleting tasks
 --------------

--- a/fiftyone/utils/annotations.py
+++ b/fiftyone/utils/annotations.py
@@ -33,6 +33,34 @@ import fiftyone.utils.eta as foue
 logger = logging.getLogger(__name__)
 
 
+def connect_to_api(backend=None, **kwargs):
+    """Returns an API instance connected to the annotation backend.
+
+    Some annotation backends may not expose this functionality.
+
+    Args:
+        backend (None): the annotation backend to use. The supported values are
+            ``fiftyone.annotation_config.backends.keys()`` and the default
+            is ``fiftyone.annotation_config.default_backend``
+        **kwargs: keyword arguments for the :class:`AnnotationBackendConfig`
+            subclass of the backend being used
+
+    Returns:
+        an :class:`AnnotationAPI`
+    """
+    if backend is None:
+        backend = fo.annotation_config.default_backend
+
+    config = _parse_config(backend, None, **kwargs)
+    anno_backend = config.build()
+
+    api = anno_backend.connect_to_api()
+    if api is None:
+        raise ValueError("The '%s' backend does not expose an API" % backend)
+
+    return api
+
+
 def annotate(
     samples,
     anno_key,
@@ -1744,6 +1772,21 @@ class AnnotationBackend(foa.AnnotationMethod):
         config: an :class:`AnnotationBackendConfig`
     """
 
+    def __init__(self, *args, **kwargs):
+        self._api = None
+        super().__init__(*args, **kwargs)
+
+    def __enter__(self):
+        api = self.connect_to_api()
+        if api is not None:
+            api.__enter__()
+
+        return self
+
+    def __exit__(self, *args):
+        if self._api is not None:
+            self._api.__exit__(*args)
+
     @property
     def supported_label_types(self):
         """The list of label types supported by the backend.
@@ -1860,6 +1903,31 @@ class AnnotationBackend(foa.AnnotationMethod):
         raise NotImplementedError(
             "subclass must implement requires_attr_values()"
         )
+
+    def connect_to_api(self):
+        """Returns an API instance connected to the annotation server.
+
+        Some annotation backends may not expose this functionality.
+
+        Returns:
+            an :class:`AnnotationAPI`, or ``None``
+        """
+        if self._api is None:
+            # pylint: disable=assignment-from-none
+            self._api = self._connect_to_api()
+
+        return self._api
+
+    def _connect_to_api(self):
+        return None
+
+    def use_api(self, api):
+        """Registers an API instance to use for subsequent operations.
+
+        Args:
+            api: an :class:`AnnotationAPI`
+        """
+        self._api = api
 
     def upload_annotations(self, samples, launch_editor=False):
         """Uploads the samples and relevant existing labels from the label
@@ -1991,6 +2059,13 @@ class AnnotationResults(foa.AnnotationResults):
         self.id_map = id_map
         self._backend = backend
 
+    def __enter__(self):
+        self._backend.__enter__()
+        return self
+
+    def __exit__(self, *args):
+        self._backend.__exit__(*args)
+
     @property
     def config(self):
         """The :class:`AnnotationBackendConfig` for these results."""
@@ -2009,6 +2084,26 @@ class AnnotationResults(foa.AnnotationResults):
             **kwargs: subclass-specific credentials
         """
         raise NotImplementedError("subclass must implement load_credentials()")
+
+    def connect_to_api(self):
+        """Returns an API instance connected to the annotation server.
+
+        Existing instances are reused, if available.
+
+        Some annotation backends may not expose this functionality.
+
+        Returns:
+            a :class:`AnnotationAPI`, or ``None``
+        """
+        return self._backend.connect_to_api()
+
+    def use_api(self, api):
+        """Registers an API instance to use for subsequent operations.
+
+        Args:
+            api: an :class:`AnnotationAPI`
+        """
+        self._backend.use_api(api)
 
     def launch_editor(self):
         """Launches the annotation backend's editor for these results."""
@@ -2097,7 +2192,7 @@ class AnnotationResults(foa.AnnotationResults):
 
 
 class AnnotationAPI(object):
-    """Base class for APIs that connect to annotation backend."""
+    """Base class for APIs that connect to annotation backends."""
 
     def _prompt_username_password(self, backend, username=None, password=None):
         prefix = "FIFTYONE_%s_" % backend.upper()

--- a/fiftyone/utils/annotations.py
+++ b/fiftyone/utils/annotations.py
@@ -1905,12 +1905,15 @@ class AnnotationBackend(foa.AnnotationMethod):
         )
 
     def connect_to_api(self):
-        """Returns an API instance connected to the annotation server.
+        """Returns an API instance connected to the annotation backend.
+
+        Existing API instances are reused, if available.
 
         Some annotation backends may not expose this functionality.
 
         Returns:
-            an :class:`AnnotationAPI`, or ``None``
+            an :class:`AnnotationAPI`, or ``None`` if the backend does not
+            expose an API
         """
         if self._api is None:
             # pylint: disable=assignment-from-none
@@ -1919,6 +1922,12 @@ class AnnotationBackend(foa.AnnotationMethod):
         return self._api
 
     def _connect_to_api(self):
+        """Returns a new API instance connected to the annotation backend.
+
+        Returns:
+            an :class:`AnnotationAPI`, or ``None`` if the backend does not
+            expose an API
+        """
         return None
 
     def use_api(self, api):
@@ -2086,14 +2095,15 @@ class AnnotationResults(foa.AnnotationResults):
         raise NotImplementedError("subclass must implement load_credentials()")
 
     def connect_to_api(self):
-        """Returns an API instance connected to the annotation server.
+        """Returns an API instance connected to the annotation backend.
 
-        Existing instances are reused, if available.
+        Existing API instances are reused, if available.
 
         Some annotation backends may not expose this functionality.
 
         Returns:
-            a :class:`AnnotationAPI`, or ``None``
+            an :class:`AnnotationAPI`, or ``None`` if the backend does not
+            expose an API
         """
         return self._backend.connect_to_api()
 

--- a/fiftyone/utils/cvat.py
+++ b/fiftyone/utils/cvat.py
@@ -3609,7 +3609,7 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
         self._session = requests.Session()
 
         if self._headers:
-            # pylint: disable=E1121
+            # pylint: disable=too-many-function-args
             self._session.headers.update(self._headers)
 
         self._server_version = 2

--- a/fiftyone/utils/cvat.py
+++ b/fiftyone/utils/cvat.py
@@ -3118,27 +3118,6 @@ class CVATBackendConfig(foua.AnnotationBackendConfig):
 class CVATBackend(foua.AnnotationBackend):
     """Class for interacting with the CVAT annotation backend."""
 
-    def __init__(self, *args, **kwargs):
-        self._api = None
-        super().__init__(*args, **kwargs)
-
-    def __enter__(self):
-        self.get_api().__enter__()
-        return self
-
-    def __exit__(self, *args):
-        if self._api is not None:
-            self._api.__exit__(*args)
-
-    def get_api(self):
-        if self._api is None:
-            self._api = self.connect_to_api()
-
-        return self._api
-
-    def use_api(self, api):
-        self._api = api
-
     @property
     def supported_label_types(self):
         return [
@@ -3206,7 +3185,7 @@ class CVATBackend(foua.AnnotationBackend):
     def requires_attr_values(self, attr_type):
         return attr_type in ("select", "radio")
 
-    def connect_to_api(self):
+    def _connect_to_api(self):
         return CVATAnnotationAPI(
             self.config.name,
             self.config.url,
@@ -3261,16 +3240,6 @@ class CVATAnnotationResults(foua.AnnotationResults):
         self.frame_id_map = frame_id_map
         self.labels_task_map = labels_task_map
 
-    def __enter__(self):
-        self._backend.__enter__()
-        return self
-
-    def __exit__(self, *args):
-        self._backend.__exit__(*args)
-
-    def use_api(self, api):
-        self._backend.use_api(api)
-
     def load_credentials(
         self, url=None, username=None, password=None, headers=None
     ):
@@ -3287,14 +3256,6 @@ class CVATAnnotationResults(foua.AnnotationResults):
         self._load_config_parameters(
             url=url, username=username, password=password, headers=headers
         )
-
-    def connect_to_api(self):
-        """Returns an API instance connected to the CVAT server.
-
-        Returns:
-            a :class:`CVATAnnotationAPI`
-        """
-        return self._backend.get_api()
 
     def launch_editor(self):
         """Launches the CVAT editor and loads the first task for this
@@ -3648,6 +3609,7 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
         self._session = requests.Session()
 
         if self._headers:
+            # pylint: disable=E1121
             self._session.headers.update(self._headers)
 
         self._server_version = 2

--- a/fiftyone/utils/labelbox.py
+++ b/fiftyone/utils/labelbox.py
@@ -155,7 +155,7 @@ class LabelboxBackend(foua.AnnotationBackend):
     def requires_attr_values(self, attr_type):
         return attr_type != "text"
 
-    def connect_to_api(self):
+    def _connect_to_api(self):
         return LabelboxAnnotationAPI(
             self.config.name,
             self.config.url,
@@ -1259,14 +1259,6 @@ class LabelboxAnnotationResults(foua.AnnotationResults):
             api_key (None): the Labelbox API key
         """
         self._load_config_parameters(url=url, api_key=api_key)
-
-    def connect_to_api(self):
-        """Returns an API instance connected to the Labelbox server.
-
-        Returns:
-            a :class:`LabelboxAnnotationAPI`
-        """
-        return self._backend.connect_to_api()
 
     def launch_editor(self):
         """Launches the Labelbox editor and loads the project for this


### PR DESCRIPTION
@ehofesmann I upgraded the `connect_to_api()` notion to an interface-level thing. So, for example, now the Labelbox backend can use the same API-sharing features "for free". The updated docs show the idea.

LMK what you think about this proposed upgrade to add to #1944 before merging it 😄 