### PR TITLE
Switching to list-based storage of saved views

### DIFF
--- a/fiftyone/__public__.py
+++ b/fiftyone/__public__.py
@@ -49,6 +49,7 @@ from .core.fields import (
     ArrayField,
     BooleanField,
     ClassesField,
+    ColorField,
     DateField,
     DateTimeField,
     DictField,

--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -6,7 +6,6 @@ FiftyOne datasets.
 |
 """
 from collections import defaultdict
-from copy import deepcopy
 from datetime import datetime
 import fnmatch
 import itertools
@@ -26,13 +25,9 @@ import eta.core.serial as etas
 import eta.core.utils as etau
 
 import fiftyone as fo
-import fiftyone.core.aggregations as foa
-import fiftyone.core.annotation as foan
-import fiftyone.core.brain as fob
 import fiftyone.constants as focn
 import fiftyone.core.collections as foc
-import fiftyone.core.expressions as foex
-import fiftyone.core.evaluation as foe
+import fiftyone.core.expressions as foe
 import fiftyone.core.fields as fof
 import fiftyone.core.frame as fofr
 import fiftyone.core.labels as fol
@@ -268,7 +263,7 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
         if isinstance(id_filepath_slice, slice):
             return self.view()[id_filepath_slice]
 
-        if isinstance(id_filepath_slice, foex.ViewExpression):
+        if isinstance(id_filepath_slice, foe.ViewExpression):
             return self.view()[id_filepath_slice]
 
         if etau.is_container(id_filepath_slice):
@@ -2264,9 +2259,16 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
         Returns:
             a list of saved view names
         """
-        return sorted(self._doc.views.keys())
+        return [view_doc.name for view_doc in self._doc.views]
 
-    def save_view(self, name, view, overwrite=False):
+    def save_view(
+        self,
+        name,
+        view,
+        description=None,
+        color=None,
+        overwrite=False,
+    ):
         """Saves the given view into this dataset under the given name so it
         can be loaded later via :meth:`load_view`.
 
@@ -2293,26 +2295,89 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
         if view._root_dataset is not self:
             raise ValueError("Cannot save view into a different dataset")
 
-        if name in self._doc.views:
+        if self.has_view(name):
             if not overwrite:
                 raise ValueError(
                     "Saved view with name '%s' already exists" % name
                 )
 
-            _view_doc = self._doc.views.pop(name)
+            _view_doc = self._get_view_doc(name, pop=True)
             _view_doc.delete()
 
+        now = datetime.utcnow()
         view_doc = foo.ViewDocument(
             dataset_id=self._doc.id,
+            name=name,
+            url_name=fou.to_url_name(name),
+            description=description,
+            color=color,
             view_stages=[
                 json_util.dumps(s)
                 for s in view._serialize(include_uuids=False)
             ],
+            created_at=now,
+            last_modified_at=now,
         )
         view_doc.save()
 
-        self._doc.views[name] = view_doc
+        self._doc.views.append(view_doc)
         self._doc.save()
+
+    def get_view_info(self, name):
+        """Loads the editable information about the saved view with the given
+        name.
+
+        Args:
+            name: the name of a saved view
+
+        Returns:
+            a dict of editable info
+        """
+        view_doc = self._get_view_doc(name)
+        return {f: view_doc[f] for f in view_doc._EDITABLE_FIELDS}
+
+    def update_view_info(self, name, info):
+        """Updates the editable information for the saved view with the given
+        name.
+
+        Examples::
+
+            import fiftyone as fo
+            import fiftyone.zoo as foz
+
+            dataset = foz.load_zoo_dataset("quickstart")
+            view = dataset.limit(10)
+
+            dataset.save_view("test", view)
+
+            info = dataset.get_view_info("test")
+            info["name"] = "a new name"
+
+            dataset.update_view_info("test", info)
+
+        Args:
+            name: the name of a saved view
+            info: a dict whose keys are a subset of the keys returned by
+                :meth:`get_view_info`
+        """
+        view_doc = self._get_view_doc(name)
+
+        invalid_fields = set(info.keys()) - set(view_doc._EDITABLE_FIELDS)
+        if invalid_fields:
+            raise ValueError("Cannot edit fields %s" % invalid_fields)
+
+        edited = False
+        for key, value in info.items():
+            if value != view_doc[key]:
+                view_doc[key] = value
+
+                edited = True
+                if key == "name":
+                    view_doc.url_name = fou.to_url_name(value)
+
+        if edited:
+            view_doc.last_modified_at = datetime.utcnow()
+            view_doc.save()
 
     def load_view(self, name):
         """Loads the saved view with the given name.
@@ -2337,12 +2402,30 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
         Returns:
             a :class:`fiftyone.core.view.DatasetView`
         """
-        if name not in self._doc.views:
+        view_doc = self._get_view_doc(name)
+
+        stage_dicts = [json_util.loads(s) for s in view_doc.view_stages]
+        view = fov.DatasetView._build(self, stage_dicts)
+
+        view_doc.last_loaded_at = datetime.utcnow()
+        view_doc.save()
+
+        return view
+
+    def _get_view_doc(self, name, pop=False):
+        idx = None
+        for i, view_doc in enumerate(self._doc.views):
+            if name == view_doc.name:
+                idx = i
+                break
+
+        if idx is None:
             raise ValueError("Dataset has no saved view '%s'" % name)
 
-        view_doc = self._doc.views[name]
-        stage_dicts = [json_util.loads(s) for s in view_doc.view_stages]
-        return fov.DatasetView._build(self, stage_dicts)
+        if pop:
+            return self._doc.views.pop(idx)
+
+        return self._doc.views[idx]
 
     def delete_view(self, name):
         """Deletes the saved view with the given name.
@@ -2350,10 +2433,7 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
         Args:
             name: the name of a saved view
         """
-        if name not in self._doc.views:
-            raise ValueError("Dataset has no saved view '%s'" % name)
-
-        view_doc = self._doc.views.pop(name)
+        view_doc = self._get_view_doc(name, pop=True)
         view_doc.delete()
         self._doc.save()
 
@@ -5085,7 +5165,7 @@ def _load_dataset(name, virtual=False):
 
 
 def _delete_dataset_doc(dataset_doc):
-    for view_doc in dataset_doc.views.values():
+    for view_doc in dataset_doc.views:
         view_doc.delete()
 
     for run_doc in dataset_doc.annotation_runs.values():
@@ -5482,11 +5562,11 @@ def _clone_extras(dst_dataset, src_doc):
     dst_doc = dst_dataset._doc
 
     # Clone saved views
-    for name, _view_doc in src_doc.views.items():
+    for _view_doc in src_doc.views:
         view_doc = _clone_view_doc(_view_doc)
         view_doc.save()
 
-        dst_doc.views[name] = view_doc
+        dst_doc.views.append(view_doc)
 
     # Clone annotation runs
     for anno_key, _run_doc in src_doc.annotation_runs.items():

--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -2421,8 +2421,11 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
 
     def delete_views(self):
         """Deletes all saved views from this dataset."""
-        for name in self.list_views():
-            self.delete_view(name)
+        for view_doc in self._doc.views:
+            view_doc.delete()
+
+        self._doc.views = []
+        self._doc.save()
 
     def _get_view_doc(self, name, pop=False):
         idx = None
@@ -2472,8 +2475,7 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
                         "Saved view with name '%s' already exists" % dup_name
                     )
 
-                _view_doc = self._get_view_doc(dup_name, pop=True)
-                _view_doc.delete()
+                self.delete_view(dup_name)
 
         return url_name
 

--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -2440,7 +2440,7 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
 
         return self._doc.views[idx]
 
-    def _ordered_views(self):
+    def _views(self):
         return self._doc.views
 
     def _reorder_views(self, new_order):

--- a/fiftyone/core/fields.py
+++ b/fiftyone/core/fields.py
@@ -7,6 +7,7 @@ Dataset sample fields.
 """
 from datetime import date, datetime
 import numbers
+import re
 
 from bson import ObjectId, SON
 from bson.binary import Binary
@@ -157,6 +158,16 @@ class StringField(mongoengine.fields.StringField, Field):
     """A unicode string field."""
 
     pass
+
+
+class ColorField(StringField):
+    """A string field that holds a hex color string like '#FF6D04'."""
+
+    def validate(self, value):
+        try:
+            fou.validate_hex_color(value)
+        except ValueError as e:
+            self.error(str(e))
 
 
 class ListField(mongoengine.fields.ListField, Field):

--- a/fiftyone/core/odm/dataset.py
+++ b/fiftyone/core/odm/dataset.py
@@ -388,7 +388,7 @@ class DatasetDocument(Document):
     annotation_runs = DictField(ReferenceField(RunDocument))
     brain_methods = DictField(ReferenceField(RunDocument))
     evaluations = DictField(ReferenceField(RunDocument))
-    views = DictField(ReferenceField(ViewDocument))
+    views = ListField(ReferenceField(ViewDocument))
     app_sidebar_groups = ListField(
         EmbeddedDocumentField(document_type=SidebarGroupDocument), default=None
     )

--- a/fiftyone/core/odm/views.py
+++ b/fiftyone/core/odm/views.py
@@ -5,7 +5,9 @@ Dataset view documents.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
-from mongoengine import (
+from fiftyone.core.fields import (
+    ColorField,
+    DateTimeField,
     ListField,
     ObjectIdField,
     StringField,
@@ -18,6 +20,14 @@ class ViewDocument(Document):
     """Backing document for dataset views."""
 
     meta = {"collection": "views"}
+    _EDITABLE_FIELDS = ("name", "color", "description")
 
     dataset_id = ObjectIdField()
+    name = StringField()
+    url_name = StringField()
+    description = StringField()
+    color = ColorField()
     view_stages = ListField(StringField())
+    created_at = DateTimeField()
+    last_modified_at = DateTimeField()
+    last_loaded_at = DateTimeField()

--- a/fiftyone/core/odm/views.py
+++ b/fiftyone/core/odm/views.py
@@ -8,7 +8,6 @@ Dataset view documents.
 from fiftyone.core.fields import (
     ColorField,
     DateTimeField,
-    IntField,
     ListField,
     ObjectIdField,
     StringField,
@@ -29,7 +28,6 @@ class ViewDocument(Document):
     description = StringField()
     color = ColorField()
     view_stages = ListField(StringField())
-    index = IntField()
     created_at = DateTimeField()
     last_modified_at = DateTimeField()
     last_loaded_at = DateTimeField()

--- a/fiftyone/core/odm/views.py
+++ b/fiftyone/core/odm/views.py
@@ -8,6 +8,7 @@ Dataset view documents.
 from fiftyone.core.fields import (
     ColorField,
     DateTimeField,
+    IntField,
     ListField,
     ObjectIdField,
     StringField,
@@ -28,6 +29,7 @@ class ViewDocument(Document):
     description = StringField()
     color = ColorField()
     view_stages = ListField(StringField())
+    index = IntField()
     created_at = DateTimeField()
     last_modified_at = DateTimeField()
     last_loaded_at = DateTimeField()

--- a/fiftyone/core/utils.py
+++ b/fiftyone/core/utils.py
@@ -1496,15 +1496,32 @@ def to_url_name(name):
         -   Whitespace and ``+`` are converted to ``-``
         -   All other characters are omitted
         -   All consecutive ``-`` characters are reduced to a single ``-``
-        -   All leading a trailing ``-`` are stripped
+        -   All leading and trailing ``-`` are stripped
         -   The resulting string must be ``[1, 100]`` characters in length
+
+    Examples::
+
+        Input name                       | URL-friendly name
+        ---------------------------------+-----------------------
+        coco_2017                        | coco_2017
+        c+o+c+o 2-0-1-7                  | c-o-c-o-2-0-1-7
+        cat.DOG                          | cat.DOG
+        ---name----                      | name
+        Brian's #$&@ (Awesome?) Dataset! | Brians-Awesome-Dataset
+        sPaM     aNd  EgGs               | sPaM-aNd-EgGs
 
     Args:
         name: a string
 
     Returns:
         a URL-friendly string
+
+    Raises:
+        ValueError: if the name cannot be made URL-friendly
     """
+    if not etau.is_str(name):
+        raise ValueError("Expected string; found %s: %s" % (type(name), name))
+
     safe = []
     last = ""
     for c in name:

--- a/fiftyone/migrations/revisions/v0_16_6.py
+++ b/fiftyone/migrations/revisions/v0_16_6.py
@@ -17,7 +17,7 @@ def up(db, dataset_name):
     _up_runs(db, dataset_dict, "evaluations")
 
     if "views" not in dataset_dict:
-        dataset_dict["views"] = {}
+        dataset_dict["views"] = []
 
     db.datasets.replace_one(match_d, dataset_dict)
 
@@ -30,7 +30,7 @@ def down(db, dataset_name):
     _down_runs(db, dataset_dict, "brain_methods")
     _down_runs(db, dataset_dict, "evaluations")
 
-    views = dataset_dict.pop("views", {})
+    views = dataset_dict.pop("views", [])
 
     _delete_views(dataset_dict, views)
 
@@ -77,4 +77,4 @@ def _delete_views(db, views):
     if not views:
         return
 
-    db.views.delete_many({"_id": {"$in": list(views.values())}})
+    db.views.delete_many({"_id": {"$in": views}})

--- a/fiftyone/utils/data/exporters.py
+++ b/fiftyone/utils/data/exporters.py
@@ -1591,10 +1591,9 @@ class LegacyFiftyOneDatasetExporter(GenericSampleDatasetExporter):
         # entire dataset
 
         if dataset.has_views:
-            self._metadata["views"] = {
-                k: json_util.dumps(v.to_dict())
-                for k, v in dataset._doc.views.items()
-            }
+            self._metadata["views"] = [
+                json_util.dumps(v.to_dict()) for v in dataset._doc.views
+            ]
 
         if dataset.has_annotation_runs:
             self._metadata["annotation_runs"] = {
@@ -1775,9 +1774,7 @@ class FiftyOneDatasetExporter(BatchDatasetExporter):
         full_dataset = sample_collection == sample_collection._root_dataset
 
         if full_dataset and dataset.has_views:
-            dataset_dict["views"] = {
-                k: v.to_dict() for k, v in dataset._doc.views.items()
-            }
+            dataset_dict["views"] = [v.to_dict() for v in dataset._doc.views]
 
         if full_dataset and dataset.has_annotation_runs:
             dataset_dict["annotation_runs"] = {

--- a/fiftyone/utils/data/importers.py
+++ b/fiftyone/utils/data/importers.py
@@ -1329,11 +1329,6 @@ class LegacyFiftyOneDatasetImporter(GenericSampleDatasetImporter):
         # Import views
         views = self._metadata.get("views", None)
         if views:
-            for name in views.keys():
-                if dataset.has_view(name):
-                    logger.warning("Overwriting existing view '%s'", name)
-                    dataset.delete_view(name)
-
             _import_views(dataset, views)
 
         # Import annotation runs
@@ -1673,15 +1668,20 @@ class FiftyOneDatasetImporter(BatchDatasetImporter):
 
 
 def _import_views(dataset, views):
-    for name, d in views.items():
+    for d in views:
         if etau.is_str(d):
             d = json_util.loads(d)
+
+        name = d["name"]
+        if dataset.has_view(name):
+            logger.warning("Overwriting existing view '%s'", name)
+            dataset.delete_view(name)
 
         d.pop("_id", None)
         view_doc = foo.ViewDocument.from_dict(d)
         view_doc.save()
 
-        dataset._doc.views[name] = view_doc
+        dataset._doc.views.append(view_doc)
 
     dataset._doc.save()
 

--- a/tests/unittests/dataset_tests.py
+++ b/tests/unittests/dataset_tests.py
@@ -1560,7 +1560,7 @@ class DatasetExtrasTests(unittest.TestCase):
         # Verify that saved views are deleted when a dataset is deleted
         #
 
-        view_id = dataset2._doc.views["test"].id
+        view_id = dataset2._doc.views[0].id
 
         db = foo.get_db_conn()
 

--- a/tests/unittests/dataset_tests.py
+++ b/tests/unittests/dataset_tests.py
@@ -1615,7 +1615,7 @@ class DatasetExtrasTests(unittest.TestCase):
         with self.assertRaises(ValueError):
             dataset.update_view_info("my-view1", {"name": "my_view2!"})
 
-        view_docs = dataset._ordered_views()
+        view_docs = dataset._views()
 
         self.assertListEqual([v.name for v in view_docs], names)
         self.assertListEqual([v.url_name for v in view_docs], url_names)
@@ -1626,22 +1626,21 @@ class DatasetExtrasTests(unittest.TestCase):
 
         dataset._reorder_views([2, 1, 0])
 
-        view_docs = dataset._ordered_views()
-
         self.assertListEqual(
-            [v.name for v in view_docs],
+            [v.name for v in dataset._views()],
             list(reversed(names)),
         )
 
         dataset.delete_view("my_view2")
 
-        view_docs = dataset._ordered_views()
-
-        self.assertListEqual([v.name for v in view_docs], [names[2], names[0]])
+        self.assertListEqual(
+            [v.name for v in dataset._views()],
+            [names[2], names[0]],
+        )
 
         dataset.delete_views()
 
-        self.assertListEqual(dataset._ordered_views(), [])
+        self.assertListEqual(dataset._views(), [])
 
     def test_runs(self):
         dataset = self.dataset

--- a/tests/unittests/dataset_tests.py
+++ b/tests/unittests/dataset_tests.py
@@ -1619,7 +1619,10 @@ class DatasetExtrasTests(unittest.TestCase):
 
         self.assertListEqual([v.name for v in view_docs], names)
         self.assertListEqual([v.url_name for v in view_docs], url_names)
-        self.assertListEqual([v.index for v in view_docs], [0, 1, 2])
+
+        # Wrong list of indexes
+        with self.assertRaises(ValueError):
+            dataset._reorder_views([3, 2, 1, 0])
 
         dataset._reorder_views([2, 1, 0])
 
@@ -1629,13 +1632,16 @@ class DatasetExtrasTests(unittest.TestCase):
             [v.name for v in view_docs],
             list(reversed(names)),
         )
-        self.assertListEqual([v.index for v in view_docs], [0, 1, 2])
 
         dataset.delete_view("my_view2")
 
         view_docs = dataset._ordered_views()
 
-        self.assertListEqual([v.index for v in view_docs], [0, 2])
+        self.assertListEqual([v.name for v in view_docs], [names[2], names[0]])
+
+        dataset.delete_views()
+
+        self.assertListEqual(dataset._ordered_views(), [])
 
     def test_runs(self):
         dataset = self.dataset

--- a/tests/unittests/utils_tests.py
+++ b/tests/unittests/utils_tests.py
@@ -14,10 +14,53 @@ import numpy as np
 import fiftyone as fo
 import fiftyone.constants as foc
 import fiftyone.core.media as fom
-import fiftyone.core.uid as fou
+import fiftyone.core.utils as fou
+import fiftyone.core.uid as foui
 from fiftyone.migrations.runner import MigrationRunner
 
 from decorators import drop_datasets
+
+
+class CoreUtilsTests(unittest.TestCase):
+    def test_validate_hex_color(self):
+        # Valid colors
+        fou.validate_hex_color("#FF6D04")
+        fou.validate_hex_color("#ff6d04")
+        fou.validate_hex_color("#000")
+        fou.validate_hex_color("#eee")
+
+        # Invalid colors
+        with self.assertRaises(ValueError):
+            fou.validate_hex_color("aaaaaa")
+
+        with self.assertRaises(ValueError):
+            fou.validate_hex_color("#bcedfg")
+
+        with self.assertRaises(ValueError):
+            fou.validate_hex_color("#ggg")
+
+        with self.assertRaises(ValueError):
+            fou.validate_hex_color("#FFFF")
+
+    def test_to_url_name(self):
+        self.assertEqual(fou.to_url_name("coco_2017"), "coco_2017")
+        self.assertEqual(fou.to_url_name("c+o+c+o 2-0-1-7"), "c-o-c-o-2-0-1-7")
+        self.assertEqual(fou.to_url_name("cat.DOG"), "cat.DOG")
+        self.assertEqual(fou.to_url_name("---z----"), "z")
+        self.assertEqual(
+            fou.to_url_name("Brian's #$&@ [awesome?] dataset!"),
+            "Brians-awesome-dataset",
+        )
+        self.assertEqual(
+            fou.to_url_name("     sPaM     aNd  EgGs    "),
+            "sPaM-aNd-EgGs",
+        )
+
+        with self.assertRaises(ValueError):
+            fou.to_url_name("------")  # too short
+
+        with self.assertRaises(ValueError):
+            fou.to_url_name("a" * 101)  # too long
 
 
 class LabelsTests(unittest.TestCase):
@@ -241,9 +284,9 @@ class UIDTests(unittest.TestCase):
         fo.config.do_not_track = False
         foc.UA_ID = foc.UA_DEV
 
-        fou.log_import_if_allowed(test=True)
+        foui.log_import_if_allowed(test=True)
         time.sleep(2)
-        self.assertTrue(fou._import_logged)
+        self.assertTrue(foui._import_logged)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Makes some changes to the saved view dataset model that will be necessary to implement the frontend design we'd like to have for this feature:
- Switches to list-based storage of saved views on `DatasetDocument` so that views can be ordered and reordered in the frontend
- Adds `created_at`, `last_modified_at`, and `last_loaded_at` fields
- Adds `color` (with validation) and `description` fields
- Adds a `url_name` field that contains a `url-friendly-name` for view names `URL Friendly Name!`
- Adds a `get_view_info()` method to retrieve the editable info about a saved view
- Adds an `update_view_info()` method to edit a saved view's info

Relevant private methods that the App backend can use:
- `_reorder_views()`: change the order of the saved views on a dataset
- `_validate_view_name()`: validate that a new saved view name is available (both name and URL name)

## URL-friendly names discussion

Here's how `to_url_name()` is currently defined:

```py
def to_url_name(name):
    """Returns a URL-friendly version of the given string.

    The following strategy is used to generate URL-friendly strings:

        -   The characters ``A-Za-z0-9-_.`` are left unchanged
        -   Whitespace and ``+`` are converted to ``-``
        -   All other characters are omitted
        -   All consecutive ``-`` characters are reduced to a single ``-``
        -   All leading and trailing ``-`` are stripped
        -   The resulting string must be ``[1, 100]`` characters in length

    Examples::

        Input name                       | URL-friendly name
        ---------------------------------+-----------------------
        coco_2017                        | coco_2017
        c+o+c+o 2-0-1-7                  | c-o-c-o-2-0-1-7
        cat.DOG                          | cat.DOG
        ---name----                      | name
        Brian's #$&@ (Awesome?) Dataset! | Brians-Awesome-Dataset
        sPaM     aNd  EgGs               | sPaM-aNd-EgGs
    """
```

Below are my notes that led me to propose the above behavior as our default:

#### Github repository names
Github allows `[A-Za-z0-9_.-]` and transforms all other characters to `"-"`
https://stackoverflow.com/a/59082561/16823653

#### Github branches and tags
Github allows `A-Za-z0-9_.-/`
https://docs.github.com/en/get-started/using-git/dealing-with-special-characters-in-branch-and-tag-names

#### Our use case
We'll use URL-friendly dataset and saved view names like so:

```
https://fiftyone.ai/my-dataset?view=my-view
```

Considerations
- If we wanted to allow `.` in names, we can't use them as document keys in MongoDB collections (currently we're not using names as keys)
- We can't allow `/` in dataset names (without escaping) because it will interfere with routing `fiftyone.ai/bad/dataset/name`
