### PR TITLE
Adding support for writing transformed images/videos to new location/field

### DIFF
--- a/docs/source/cli/index.rst
+++ b/docs/source/cli/index.rst
@@ -841,9 +841,11 @@ Transforms the images in a dataset per the specified parameters.
 
 .. code-block:: text
 
-    fiftyone utils transform-images [-h] [--size SIZE]
-                                    [--min-size MIN_SIZE]
+    fiftyone utils transform-images [-h] [--size SIZE] [--min-size MIN_SIZE]
                                     [--max-size MAX_SIZE] [-e EXT] [-f]
+                                    [--media-field MEDIA_FIELD]
+                                    [--output-field OUTPUT_FIELD]
+                                    [-o OUTPUT_DIR] [-r REL_DIR]
                                     [-d] [-n NUM_WORKERS] [-s]
                                     DATASET_NAME
 
@@ -865,6 +867,22 @@ Transforms the images in a dataset per the specified parameters.
       -e EXT, --ext EXT     an image format to convert to (e.g., '.png' or '.jpg')
       -f, --force-reencode  whether to re-encode images whose parameters already
                             meet the specified values
+      --media-field MEDIA_FIELD
+                            the input field containing the image paths to
+                            transform
+      --output-field OUTPUT_FIELD
+                            an optional field in which to store the paths to
+                            the transformed images. By default, `media_field`
+                            is updated in-place
+      -o OUTPUT_DIR, --output-dir OUTPUT_DIR
+                            an optional output directory in which to write the
+                            transformed images. If none is provided, the images
+                            are updated in-place
+      -r REL_DIR, --rel-dir REL_DIR
+                            an optional relative directory to strip from each
+                            input filepath to generate a unique identifier that
+                            is joined with `output_dir` to generate an output
+                            path for each image
       -d, --delete-originals
                             whether to delete the original images after transforming
       -n NUM_WORKERS, --num-workers NUM_WORKERS
@@ -894,11 +912,16 @@ Transforms the videos in a dataset per the specified parameters.
 
 .. code-block:: text
 
+
     fiftyone utils transform-videos [-h] [--fps FPS] [--min-fps MIN_FPS]
                                     [--max-fps MAX_FPS] [--size SIZE]
-                                    [--min-size MIN_SIZE]
-                                    [--max-size MAX_SIZE] [-r] [-f] [-d]
-                                    [-s] [-v]
+                                    [--min-size MIN_SIZE] [--max-size MAX_SIZE]
+                                    [-r] [-f]
+                                    [--media-field MEDIA_FIELD]
+                                    [--output-field OUTPUT_FIELD]
+                                    [--output-dir OUTPUT_DIR]
+                                    [--rel-dir REL_DIR]
+                                    [-d] [-s] [-v]
                                     DATASET_NAME
 
 **Arguments**
@@ -924,6 +947,21 @@ Transforms the videos in a dataset per the specified parameters.
       -r, --reencode        whether to re-encode the videos as H.264 MP4s
       -f, --force-reencode  whether to re-encode videos whose parameters already
                             meet the specified values
+      --media-field MEDIA_FIELD
+                            the input field containing the video paths to
+                            transform
+      --output-field OUTPUT_FIELD
+                            an optional field in which to store the paths to
+                            the transformed videos. By default, `media_field`
+                            is updated in-place
+      --output-dir OUTPUT_DIR
+                            an optional output directory in which to write the
+                            transformed videos. If none is provided, the videos
+                            are updated in-place
+      --rel-dir REL_DIR     an optional relative directory to strip from each
+                            input filepath to generate a unique identifier that
+                            is joined with `output_dir` to generate an output
+                            path for each video
       -d, --delete-originals
                             whether to delete the original videos after transforming
       -s, --skip-failures   whether to gracefully continue without raising an

--- a/fiftyone/core/cli.py
+++ b/fiftyone/core/cli.py
@@ -2732,6 +2732,39 @@ class TransformImagesCommand(Command):
             ),
         )
         parser.add_argument(
+            "--media-field",
+            metavar="MEDIA_FIELD",
+            default="filepath",
+            help="the input field containing the image paths to transform",
+        )
+        parser.add_argument(
+            "--output-field",
+            metavar="OUTPUT_FIELD",
+            help=(
+                "an optional field in which to store the paths to the "
+                "transformed images. By default, `media_field` is updated "
+                "in-place"
+            ),
+        )
+        parser.add_argument(
+            "--output-dir",
+            metavar="OUTPUT_DIR",
+            help=(
+                "an optional output directory in which to write the "
+                "transformed images. If none is provided, the images are "
+                "updated in-place"
+            ),
+        )
+        parser.add_argument(
+            "--rel-dir",
+            metavar="REL_DIR",
+            help=(
+                "an optional relative directory to strip from each input "
+                "filepath to generate a unique identifier that is joined with "
+                "`output_dir` to generate an output path for each image"
+            ),
+        )
+        parser.add_argument(
             "-d",
             "--delete-originals",
             action="store_true",
@@ -2767,6 +2800,10 @@ class TransformImagesCommand(Command):
             max_size=args.max_size,
             ext=args.ext,
             force_reencode=args.force_reencode,
+            media_field=args.media_field,
+            output_field=args.output_field,
+            output_dir=args.output_dir,
+            rel_dir=args.rel_dir,
             delete_originals=args.delete_originals,
             num_workers=args.num_workers,
             skip_failures=args.skip_failures,
@@ -2861,6 +2898,39 @@ class TransformVideosCommand(Command):
             ),
         )
         parser.add_argument(
+            "--media-field",
+            metavar="MEDIA_FIELD",
+            default="filepath",
+            help="the input field containing the video paths to transform",
+        )
+        parser.add_argument(
+            "--output-field",
+            metavar="OUTPUT_FIELD",
+            help=(
+                "an optional field in which to store the paths to the "
+                "transformed videos. By default, `media_field` is updated "
+                "in-place"
+            ),
+        )
+        parser.add_argument(
+            "--output-dir",
+            metavar="OUTPUT_DIR",
+            help=(
+                "an optional output directory in which to write the "
+                "transformed videos. If none is provided, the videos are "
+                "updated in-place"
+            ),
+        )
+        parser.add_argument(
+            "--rel-dir",
+            metavar="REL_DIR",
+            help=(
+                "an optional relative directory to strip from each input "
+                "filepath to generate a unique identifier that is joined with "
+                "`output_dir` to generate an output path for each video"
+            ),
+        )
+        parser.add_argument(
             "-d",
             "--delete-originals",
             action="store_true",
@@ -2895,6 +2965,10 @@ class TransformVideosCommand(Command):
             max_size=args.max_size,
             reencode=args.reencode,
             force_reencode=args.force_reencode,
+            media_field=args.media_field,
+            output_field=args.output_field,
+            output_dir=args.output_dir,
+            rel_dir=args.rel_dir,
             delete_originals=args.delete_originals,
             skip_failures=args.skip_failures,
             verbose=args.verbose,

--- a/fiftyone/utils/image.py
+++ b/fiftyone/utils/image.py
@@ -23,14 +23,23 @@ def reencode_images(
     sample_collection,
     ext=".png",
     force_reencode=True,
+    media_field="filepath",
+    output_field=None,
+    output_dir=None,
+    rel_dir=None,
     delete_originals=False,
     num_workers=None,
     skip_failures=False,
 ):
     """Re-encodes the images in the sample collection to the given format.
 
-    The ``filepath`` of the samples are updated to point to the re-encoded
-    images.
+    .. note::
+
+        This method will not update the ``metadata`` field of the collection
+        after transforming. You can repopulate the ``metadata` field if needed
+        by calling::
+
+            sample_collection.compute_metadata(overwrite=True)
 
     Args:
         sample_collection: a
@@ -38,8 +47,22 @@ def reencode_images(
         ext (".png"): the image format to use (e.g., ".png" or ".jpg")
         force_reencode (True): whether to re-encode images whose extension
             already matches ``ext``
+        media_field ("filepath"): the input field containing the image paths to
+            transform
+        output_field (None): an optional field in which to store the paths to
+            the transformed images. By default, ``media_field`` is updated
+            in-place
+        output_dir (None): an optional output directory in which to write the
+            transformed images. If none is provided, the images are updated
+            in-place
+        rel_dir (None): an optional relative directory to strip from each input
+            filepath to generate a unique identifier that is joined with
+            ``output_dir`` to generate an output path for each image. This
+            argument allows for populating nested subdirectories in
+            ``output_dir`` that match the shape of the input paths
         delete_originals (False): whether to delete the original images after
-            re-encoding
+            re-encoding. This parameter has no effect if the images are being
+            updated in-place
         num_workers (None): the number of worker processes to use. By default,
             ``multiprocessing.cpu_count()`` is used
         skip_failures (False): whether to gracefully continue without raising
@@ -51,6 +74,10 @@ def reencode_images(
         sample_collection,
         ext=ext,
         force_reencode=force_reencode,
+        media_field=media_field,
+        output_field=output_field,
+        output_dir=output_dir,
+        rel_dir=rel_dir,
         delete_originals=delete_originals,
         num_workers=num_workers,
         skip_failures=skip_failures,
@@ -64,15 +91,16 @@ def transform_images(
     max_size=None,
     ext=None,
     force_reencode=False,
+    media_field="filepath",
+    output_field=None,
+    output_dir=None,
+    rel_dir=None,
     delete_originals=False,
     num_workers=None,
     skip_failures=False,
 ):
     """Transforms the images in the sample collection according to the provided
     parameters.
-
-    The ``filepath`` of the samples are updated to point to the transformed
-    images.
 
     .. note::
 
@@ -99,8 +127,22 @@ def transform_images(
             into (e.g., ".png" or ".jpg")
         force_reencode (False): whether to re-encode images whose parameters
             already match the specified values
+        media_field ("filepath"): the input field containing the image paths to
+            transform
+        output_field (None): an optional field in which to store the paths to
+            the transformed images. By default, ``media_field`` is updated
+            in-place
+        output_dir (None): an optional output directory in which to write the
+            transformed images. If none is provided, the images are updated
+            in-place
+        rel_dir (None): an optional relative directory to strip from each input
+            filepath to generate a unique identifier that is joined with
+            ``output_dir`` to generate an output path for each image. This
+            argument allows for populating nested subdirectories in
+            ``output_dir`` that match the shape of the input paths
         delete_originals (False): whether to delete the original images if any
-            transformation was applied
+            transformation was applied. This parameter has no effect if the
+            images are being updated in-place
         num_workers (None): the number of worker processes to use. By default,
             ``multiprocessing.cpu_count()`` is used
         skip_failures (False): whether to gracefully continue without raising
@@ -115,6 +157,10 @@ def transform_images(
         max_size=max_size,
         ext=ext,
         force_reencode=force_reencode,
+        media_field=media_field,
+        output_field=output_field,
+        output_dir=output_dir,
+        rel_dir=rel_dir,
         delete_originals=delete_originals,
         num_workers=num_workers,
         skip_failures=skip_failures,
@@ -164,6 +210,10 @@ def _transform_images(
     max_size=None,
     ext=None,
     force_reencode=False,
+    media_field="filepath",
+    output_field=None,
+    output_dir=None,
+    rel_dir=None,
     delete_originals=False,
     num_workers=None,
     skip_failures=False,
@@ -181,6 +231,10 @@ def _transform_images(
             max_size=max_size,
             ext=ext,
             force_reencode=force_reencode,
+            media_field=media_field,
+            output_field=output_field,
+            output_dir=output_dir,
+            rel_dir=rel_dir,
             delete_originals=delete_originals,
             skip_failures=skip_failures,
         )
@@ -193,6 +247,10 @@ def _transform_images(
             max_size=max_size,
             ext=ext,
             force_reencode=force_reencode,
+            media_field=media_field,
+            output_field=output_field,
+            output_dir=output_dir,
+            rel_dir=rel_dir,
             delete_originals=delete_originals,
             skip_failures=skip_failures,
         )
@@ -205,19 +263,30 @@ def _transform_images_single(
     max_size=None,
     ext=None,
     force_reencode=False,
+    media_field="filepath",
+    output_field=None,
+    output_dir=None,
+    rel_dir=None,
     delete_originals=False,
     skip_failures=False,
 ):
-    view = sample_collection.select_fields()
+    if output_field is None:
+        output_field = media_field
+
+    diff_field = output_field != media_field
+
+    view = sample_collection.select_fields(media_field)
 
     with fou.ProgressBar() as pb:
         for sample in pb(view):
-            inpath = sample.filepath
+            inpath = sample[media_field]
+
+            outpath = _get_outpath(
+                inpath, output_dir=output_dir, rel_dir=rel_dir
+            )
 
             if ext is not None:
-                outpath = os.path.splitext(inpath)[0] + ext
-            else:
-                outpath = inpath
+                outpath = os.path.splitext(outpath)[0] + ext
 
             _transform_image(
                 inpath,
@@ -230,8 +299,8 @@ def _transform_images_single(
                 skip_failures=skip_failures,
             )
 
-            if outpath != inpath:
-                sample.filepath = outpath
+            if diff_field or outpath != inpath:
+                sample[output_field] = outpath
                 sample.save()
 
 
@@ -243,17 +312,26 @@ def _transform_images_multi(
     max_size=None,
     ext=None,
     force_reencode=False,
+    media_field="filepath",
+    output_field=None,
+    output_dir=None,
+    rel_dir=None,
     delete_originals=False,
     skip_failures=False,
 ):
-    sample_ids, filepaths = sample_collection.values(["id", "filepath"])
+    if output_field is None:
+        output_field = media_field
+
+    diff_field = output_field != media_field
+
+    sample_ids, inpaths = sample_collection.values(["id", media_field])
 
     inputs = []
-    for sample_id, inpath in zip(sample_ids, filepaths):
+    for sample_id, inpath in zip(sample_ids, inpaths):
+        outpath = _get_outpath(inpath, output_dir=output_dir, rel_dir=rel_dir)
+
         if ext is not None:
-            outpath = os.path.splitext(inpath)[0] + ext
-        else:
-            outpath = inpath
+            outpath = os.path.splitext(outpath)[0] + ext
 
         inputs.append(
             (
@@ -269,19 +347,20 @@ def _transform_images_multi(
             )
         )
 
-    view = sample_collection.select_fields()
+    outpaths = {}
 
-    with fou.ProgressBar(inputs) as pb:
-        with fou.get_multiprocessing_context().Pool(
-            processes=num_workers
-        ) as pool:
-            for sample_id, inpath, outpath, _ in pb(
-                pool.imap_unordered(_do_transform, inputs)
-            ):
-                if outpath != inpath:
-                    sample = view[sample_id]
-                    sample.filepath = outpath
-                    sample.save()
+    try:
+        with fou.ProgressBar(inputs) as pb:
+            with fou.get_multiprocessing_context().Pool(
+                processes=num_workers
+            ) as pool:
+                for sample_id, inpath, outpath, _ in pb(
+                    pool.imap_unordered(_do_transform, inputs)
+                ):
+                    if diff_field or outpath != inpath:
+                        outpaths[sample_id] = outpath
+    finally:
+        sample_collection.set_values(output_field, outpaths, key_field="id")
 
 
 def _do_transform(args):
@@ -318,27 +397,17 @@ def _transform_image(
             img = etai.read(inpath)
             size = _parse_parameters(img, size, min_size, max_size)
 
-        diff_params = size is not None
-        should_reencode = diff_params or force_reencode
-
-        if (inpath == outpath) and should_reencode and not delete_original:
-            _inpath = inpath
-            inpath = etau.make_unique_path(inpath, suffix="-original")
-            etau.move_file(_inpath, inpath)
-
-        diff_path = inpath != outpath
-
-        if diff_params:
+        if size is not None:
             img = etai.resize(img, width=size[0], height=size[1])
             etai.write(img, outpath)
             did_transform = True
         elif force_reencode or (in_ext != out_ext):
             etai.write(img, outpath)
             did_transform = True
-        elif diff_path:
+        elif inpath != outpath:
             etau.copy_file(inpath, outpath)
 
-        if delete_original and diff_path:
+        if delete_original and inpath != outpath:
             etau.delete_file(inpath)
     except Exception as e:
         if not skip_failures:
@@ -370,3 +439,16 @@ def _parse_ext(ext):
         ext = "." + ext
 
     return ext.lower()
+
+
+def _get_outpath(inpath, output_dir=None, rel_dir=None):
+    if output_dir is None:
+        return inpath
+
+    if rel_dir is not None:
+        rel_dir = fou.normalize_path(rel_dir)
+        filename = os.path.relpath(inpath, rel_dir)
+    else:
+        filename = os.path.basename(inpath)
+
+    return os.path.join(output_dir, filename)


### PR DESCRIPTION
Small enhancement that adds support for optionally writing transformed images/videos to a new output location, and storing the resulting filepaths in a new field.

This new syntax is useful, for example, for quickly generating thumbnail images for a dataset.

### Python examples

```py
import shutil

import fiftyone as fo
import fiftyone.zoo as foz
import fiftyone.utils.image as foui
import fiftyone.utils.video as fouv

# Image example
dataset = foz.load_zoo_dataset("quickstart")

foui.transform_images(
    dataset,
    size=(-1, 64),
    output_field="thumbnail_path",
    output_dir="/tmp/thumbnails",
    rel_dir=fo.config.dataset_zoo_dir,
)

print(dataset.select_fields("thumbnail_path").first())

# Video example
dataset = foz.load_zoo_dataset("quickstart-video")

fouv.transform_videos(
    dataset,
    size=(-1, 128),
    output_field="thumbnail_path",
    output_dir="/tmp/thumbnails",
    rel_dir=fo.config.dataset_zoo_dir,
)

print(dataset.select_fields("thumbnail_path").first())

# Cleanup
shutil.rmtree("/tmp/thumbnails")
```

### CLI examples

```shell
ZOO_DIR=$(fiftyone config dataset_zoo_dir)

# Image example
fiftyone zoo datasets load quickstart

fiftyone utils transform-images quickstart \
    --max-size='-1,64' \
    --output-field thumbnail_path \
    --output-dir /tmp/thumbnails \
    --rel-dir $ZOO_DIR

ls -lah $ZOO_DIR/quickstart/data | head

# Video example
fiftyone zoo datasets load quickstart-video

fiftyone utils transform-videos quickstart-video \
    --max-size='-1,128' \
    --output-field thumbnail_path \
    --output-dir /tmp/thumbnails \
    --rel-dir $ZOO_DIR

ls -lah $ZOO_DIR/quickstart-video/data | head

# Cleanup
fiftyone datasets delete quickstart
fiftyone datasets delete quickstart-video
rm -rf /tmp/thumbnails
```
