### PR TITLE
Package-wide logging config

### DIFF
--- a/docs/source/user_guide/config.rst
+++ b/docs/source/user_guide/config.rst
@@ -76,6 +76,9 @@ FiftyOne supports the configuration options described below:
 +-------------------------------+-------------------------------------+-------------------------------+----------------------------------------------------------------------------------------+
 | `do_not_track`                | `FIFTYONE_DO_NOT_TRACK`             | `False`                       | Controls whether UUID based import and App usage events are tracked.                   |
 +-------------------------------+-------------------------------------+-------------------------------+----------------------------------------------------------------------------------------+
+| `logging_level`               | `FIFTYONE_LOGGING_LEVEL`            | `INFO`                        | Controls FiftyOne's package-wide logging level. Can be any valid ``logging`` level,    |
+|                               |                                     |                               | such as ``logging.INFO``.                                                              |
++-------------------------------+-------------------------------------+-------------------------------+----------------------------------------------------------------------------------------+
 | `model_zoo_dir`               | `FIFTYONE_MODEL_ZOO_DIR`            | `~/fiftyone/__models__`       | The default directory in which to store models that are downloaded from the            |
 |                               |                                     |                               | :ref:`FiftyOne Model Zoo <model-zoo>`.                                                 |
 +-------------------------------+-------------------------------------+-------------------------------+----------------------------------------------------------------------------------------+
@@ -138,6 +141,7 @@ and the CLI:
             "default_video_ext": ".mp4",
             "desktop_app": false,
             "do_not_track": false,
+            "logging_level": "INFO",
             "model_zoo_dir": "~/fiftyone/__models__",
             "model_zoo_manifest_paths": null,
             "module_path": null,
@@ -179,6 +183,7 @@ and the CLI:
             "default_video_ext": ".mp4",
             "desktop_app": false,
             "do_not_track": false,
+            "logging_level": "INFO",
             "model_zoo_dir": "~/fiftyone/__models__",
             "model_zoo_manifest_paths": null,
             "module_path": null,

--- a/fiftyone/__init__.py
+++ b/fiftyone/__init__.py
@@ -25,7 +25,10 @@ __version__ = _foc.VERSION
 from fiftyone.__public__ import *
 
 import fiftyone.core.uid as _fou
+import fiftyone.core.logging as _fol
 import fiftyone.migrations as _fom
+
+_fol.init_logging()
 
 if _os.environ.get("FIFTYONE_DISABLE_SERVICES", "0") != "1":
     _fom.migrate_database_if_necessary()

--- a/fiftyone/__public__.py
+++ b/fiftyone/__public__.py
@@ -98,6 +98,10 @@ from .core.labels import (
     GeoLocation,
     GeoLocations,
 )
+from .core.logging import (
+    get_logging_level,
+    set_logging_level,
+)
 from .core.metadata import (
     Metadata,
     ImageMetadata,

--- a/fiftyone/core/config.py
+++ b/fiftyone/core/config.py
@@ -175,6 +175,12 @@ class FiftyOneConfig(EnvConfig):
             env_var="FIFTYONE_DESKTOP_APP",
             default=False,
         )
+        self.logging_level = self.parse_string(
+            d,
+            "logging_level",
+            env_var="FIFTYONE_LOGGING_LEVEL",
+            default="INFO",
+        )
         self._show_progress_bars = None  # declare
         self.show_progress_bars = self.parse_bool(
             d,

--- a/fiftyone/core/logging.py
+++ b/fiftyone/core/logging.py
@@ -21,15 +21,16 @@ def init_logging():
     The logging level is set to ``fo.config.logging_level``.
     """
     global handler
+
     if handler is None:
         handler = logging.StreamHandler(stream=sys.stdout)
+        handler.setFormatter(logging.Formatter(fmt="%(message)s"))
 
-    handler.setFormatter(logging.Formatter(fmt="%(message)s"))
-    logging.getLogger("fiftyone").addHandler(handler)
-    logging.getLogger("eta").addHandler(handler)
+        for logger in _get_loggers():
+            logger.addHandler(handler)
 
     level = _parse_logging_level()
-    handler.setLevel(level)
+    set_logging_level(level)
 
 
 def get_logging_level():
@@ -38,7 +39,7 @@ def get_logging_level():
     Returns:
         a ``logging`` level, such as ``logging.INFO``
     """
-    return handler.level
+    return _get_loggers()[0].level
 
 
 def set_logging_level(level):
@@ -47,7 +48,15 @@ def set_logging_level(level):
     Args:
         level: a ``logging`` level, such as ``logging.INFO``
     """
-    handler.setLevel(level)
+    for logger in _get_loggers():
+        logger.setLevel(level)
+
+
+def _get_loggers():
+    return [
+        logging.getLogger("fiftyone"),
+        logging.getLogger("eta"),
+    ]
 
 
 def _parse_logging_level():

--- a/fiftyone/core/logging.py
+++ b/fiftyone/core/logging.py
@@ -1,0 +1,60 @@
+"""
+Logging utilities.
+
+| Copyright 2017-2022, Voxel51, Inc.
+| `voxel51.com <https://voxel51.com/>`_
+|
+"""
+import logging
+import sys
+
+import fiftyone as fo
+
+
+logger = logging.getLogger(__name__)
+handler = None
+
+
+def init_logging():
+    """Initializes FiftyOne's package-wide logging.
+
+    The logging level is set to ``fo.config.logging_level``.
+    """
+    global handler
+    if handler is None:
+        handler = logging.StreamHandler(stream=sys.stdout)
+
+    handler.setFormatter(logging.Formatter(fmt="%(message)s"))
+    logging.getLogger("fiftyone").addHandler(handler)
+    logging.getLogger("eta").addHandler(handler)
+
+    level = _parse_logging_level()
+    handler.setLevel(level)
+
+
+def get_logging_level():
+    """Gets FiftyOne's package-wide logging level.
+
+    Returns:
+        a ``logging`` level, such as ``logging.INFO``
+    """
+    return handler.level
+
+
+def set_logging_level(level):
+    """Sets FiftyOne's package-wide logging level.
+
+    Args:
+        level: a ``logging`` level, such as ``logging.INFO``
+    """
+    handler.setLevel(level)
+
+
+def _parse_logging_level():
+    try:
+        level = getattr(logging, fo.config.logging_level)
+    except AttributeError:
+        logger.warning("Invalid logging level '%s'", fo.config.logging_level)
+        level = logging.INFO
+
+    return level


### PR DESCRIPTION
https://github.com/voxel51/eta/pull/567 removed ETA's configuration of the root logger, which was a good change because the root logger shouldn't have been touched.

However, FiftyOne was implicitly built assuming all of its `logging.INFO` messages would be printed, which is no longer true:

```py
import fiftyone.zoo as foz

# This used to print some persistent output, but with latest `eta`, it will not
dataset = foz.load_zoo_dataset("quickstart")
```

This PR re-introduces package-wide logging at `INFO` level by default, and exposes a `fo.config.logging_level` setting that can be used to customize this behavior if desired:

```shell
export FIFTYONE_LOGGING_LEVEL=WARNING
```
