### PR TITLE
Adding ipywidgets<8 requirement

### DIFF
--- a/docs/source/user_guide/plots.rst
+++ b/docs/source/user_guide/plots.rst
@@ -145,7 +145,7 @@ below for your environment:
 
     .. code-block:: shell
 
-        pip install "notebook>=5.3" "ipywidgets>=7.5"
+        pip install "notebook>=5.3" "ipywidgets>=7.5,<8"
 
   .. group-tab:: JupyterLab
 
@@ -154,7 +154,7 @@ below for your environment:
 
     .. code-block:: shell
 
-        pip install "jupyterlab>=3" "ipywidgets>=7.6"
+        pip install "jupyterlab>=3" "ipywidgets>=7.6,<8"
 
     If you run into any issues in JupyterLab, especially if you are trying to
     use JupyterLab 2.X rather than 3.0+, you may need to manually install the

--- a/fiftyone/core/plots/plotly.py
+++ b/fiftyone/core/plots/plotly.py
@@ -1881,7 +1881,7 @@ def _check_plotly_jupyter_environment():
     # JupyterLab is different and I don't know how to distinguish Jupyter
     # notebooks from JupyterLab right now...
     #
-    fou.ensure_package("ipywidgets>=7.5")
+    fou.ensure_package("ipywidgets>=7.5,<8")
 
 
 class PlotlyNotebookPlot(PlotlyWidgetMixin, Plot):


### PR DESCRIPTION
`ipywidgets==8.0.0` was [released August 18th](https://pypi.org/project/ipywidgets/#history), but unfortunately [it looks like](https://pythontechworld.com/issue/plotly/plotly.py/3686) it is not compatible with `plotly<=5.9.0`, as the following error is raised (confirmed locally):

```
AttributeError: type object 'DOMWidget' has no attribute '_ipython_display_'
```

Therefore, this PR adds an `ipywidgets<8` requirement to FiftyOne.
