### PR TITLE
Save context tweaks

### DIFF
--- a/docs/source/user_guide/using_datasets.rst
+++ b/docs/source/user_guide/using_datasets.rst
@@ -657,7 +657,7 @@ or in batches via
     # equivalent to above
     del dataset[sample_id]
 
-    dataset.delete_samples([sample_id2, sample_id3])
+    dataset.delete_samples([sample_id1, sample_id2])
 
 Samples can also be removed from a |Dataset| by passing |Sample| instance(s)
 or |DatasetView| instances:
@@ -914,6 +914,45 @@ You can make any edits you wish to the fields of an existing |Sample|:
     You must call :meth:`sample.save() <fiftyone.core.sample.Sample.save>` in
     order to persist changes to the database when editing samples that are in
     datasets.
+
+A common workflow is to iterate over a dataset
+:ref:`or view <editing-view-fields>` and edit each sample:
+
+.. code-block:: python
+    :linenos:
+
+    for sample in dataset:
+        sample["new_field"] = ...
+        sample.save()
+
+The :meth:`iter_samples() <fiftyone.core.dataset.Dataset.iter_samples>` method
+is an equivalent way to iterate over a dataset that provides a
+``progress=True`` option that prints a progress bar tracking the status of the
+iteration:
+
+.. code-block:: python
+    :linenos:
+
+    # Prints a progress bar tracking the status of the iteration
+    for sample in dataset.iter_samples(progress=True):
+        sample["new_field"] = ...
+        sample.save()
+
+The :meth:`iter_samples() <fiftyone.core.dataset.Dataset.iter_samples>` method
+also provides an ``autosave=True`` option that causes all changes to samples
+emitted by the iterator to be automatically saved using efficient batch
+updates:
+
+.. code-block:: python
+    :linenos:
+
+    # Automatically saves sample edits in efficient batches
+    for sample in dataset.iter_samples(autosave=True):
+        sample["new_field"] = ...
+
+Using ``autosave=True`` can significantly improve performance when editing
+large datasets. See :ref:`this section <batch-updates>` for more information
+on batch update patterns.
 
 .. _removing-sample-fields:
 
@@ -3292,7 +3331,56 @@ its contents and editing the samples directly:
     print(dataset.count("random"))  # 200
     print(dataset.bounds("random")) # (0.0007, 0.9987)
 
-Alternatively, you can use
+However, the above pattern can be inefficient for large datasets because each
+:meth:`sample.save() <fiftyone.core.sample.Sample.save>` call makes a new
+connection to the database.
+
+The :meth:`iter_samples() <fiftyone.core.dataset.Dataset.iter_samples>` method
+provides an ``autosave=True`` option that causes all changes to samples
+emitted by the iterator to be automatically saved using an efficient batch
+update strategy:
+
+.. code-block:: python
+    :linenos:
+
+    # Automatically saves sample edits in efficient batches
+    for sample in dataset.select_fields().iter_samples(autosave=True):
+        sample["random"] = random.random()
+
+.. note::
+
+    As the above snippet shows, you should also optimize your iteration by
+    :ref:`selecting only <efficient-iteration-views>` the required fields.
+
+By default, updates are batched and submitted every 0.2 seconds, but you can
+configure the batching strategy by passing the optional ``batch_size`` argument
+to :meth:`iter_samples() <fiftyone.core.dataset.Dataset.iter_samples>`.
+
+You can also use the
+:meth:`save_context() <fiftyone.core.collections.SampleCollection.save_context>`
+method to perform batched edits using the pattern below:
+
+.. code-block:: python
+    :linenos:
+
+    # Automatically saves sample edits in efficient batches
+    with dataset.save_context() as context:
+        for sample in dataset.select_fields():
+            sample["random"] = random.random()
+            context.save(sample)
+
+The benefit of the above approach versus passing ``autosave=True`` to
+:meth:`iter_samples() <fiftyone.core.dataset.Dataset.iter_samples>` is that
+:meth:`context.save() <fiftyone.core.collections.SaveContext.save>` allows you
+to be explicit about which samples you are editing, which avoids unnecessary
+computations if your loop only edits certain samples.
+
+.. _set-values:
+
+Setting values
+--------------
+
+Another strategy for performing efficient batch edits is to use
 :meth:`set_values() <fiftyone.core.collections.SampleCollection.set_values>` to
 set a field (or embedded field) on each sample in the dataset in a single
 batch operation:
@@ -3300,10 +3388,10 @@ batch operation:
 .. code-block:: python
     :linenos:
 
-    # Delete the field we added in the previous variation
+    # Delete the field we added earlier
     dataset.delete_sample_field("random")
 
-    # Equivalent way to populate a new field on each sample in a view
+    # Equivalent way to populate the field on each sample in the dataset
     values = [random.random() for _ in range(len(dataset))]
     dataset.set_values("random", values)
 
@@ -3316,7 +3404,7 @@ batch operation:
     :meth:`set_values() <fiftyone.core.collections.SampleCollection.set_values>`
     is often more efficient than performing the equivalent operation via an
     explicit iteration over the |Dataset| because it avoids the need to read
-    the entire |Sample| instances into memory and then save them.
+    |Sample| instances into memory and sequentially save them.
 
 Similarly, you can edit nested sample fields of a |Dataset| by iterating over
 the dataset and editing the necessary data:

--- a/docs/source/user_guide/using_views.rst
+++ b/docs/source/user_guide/using_views.rst
@@ -1830,7 +1830,51 @@ contents and editing the samples directly:
     print(dataset.count("random"))  # 50
     print(dataset.bounds("random")) # (0.0005, 0.9928)
 
-Alternatively, you can use
+However, the above pattern can be inefficient for large views because each
+:meth:`sample.save() <fiftyone.core.sample.SampleView.save>` call makes a new
+connection to the database.
+
+The :meth:`iter_samples() <fiftyone.core.view.DatasetView.iter_samples>` method
+provides an ``autosave=True`` option that causes all changes to samples
+emitted by the iterator to be automatically saved using an efficient batch
+update strategy:
+
+.. code-block:: python
+    :linenos:
+
+    # Automatically saves sample edits in efficient batches
+    for sample in view.select_fields().iter_samples(autosave=True):
+        sample["random"] = random.random()
+
+.. note::
+
+    As the above snippet shows, you should also optimize your iteration by
+    :ref:`selecting only <efficient-iteration-views>` the required fields.
+
+By default, updates are batched and submitted every 0.2 seconds, but you can
+configure the batching strategy by passing the optional ``batch_size`` argument
+to :meth:`iter_samples() <fiftyone.core.view.DatasetView.iter_samples>`.
+
+You can also use the
+:meth:`save_context() <fiftyone.core.collections.SampleCollection.save_context>`
+method to perform batched edits using the pattern below:
+
+.. code-block:: python
+    :linenos:
+
+    # Automatically saves sample edits in efficient batches
+    with view.save_context() as context:
+        for sample in view.select_fields():
+            sample["random"] = random.random()
+            context.save(sample)
+
+The benefit of the above approach versus passing ``autosave=True`` to
+:meth:`iter_samples() <fiftyone.core.view.DatasetView.iter_samples>` is that
+:meth:`context.save() <fiftyone.core.collections.SaveContext.save>` allows you
+to be explicit about which samples you are editing, which avoids unnecessary
+computations if your loop only edits certain samples.
+
+Another strategy for performing efficient batch edits is to use
 :meth:`set_values() <fiftyone.core.collections.SampleCollection.set_values>` to
 set a field (or embedded field) on each sample in the collection in a single
 batch operation:
@@ -1838,7 +1882,7 @@ batch operation:
 .. code-block:: python
     :linenos:
 
-    # Delete the field we added in the previous variation
+    # Delete the field we added earlier
     dataset.delete_sample_field("random")
 
     # Equivalent way to populate a new field on each sample in a view
@@ -1854,7 +1898,7 @@ batch operation:
     :meth:`set_values() <fiftyone.core.collections.SampleCollection.set_values>`
     is often more efficient than performing the equivalent operation via an
     explicit iteration over the |DatasetView| because it avoids the need to
-    read the entire |SampleView| instances into memory and then save them.
+    read |SampleView| instances into memory and sequentially save them.
 
 Naturally, you can edit nested sample fields of a |DatasetView| by iterating
 over the view and editing the necessary data:
@@ -2202,6 +2246,8 @@ dataset as follows:
 
     dataset.delete_samples(unlucky_samples)
 
+.. _efficient-iteration-views:
+
 Efficiently iterating samples
 -----------------------------
 
@@ -2245,11 +2291,17 @@ to load only the ``open_images_id`` field speeds up the operation below by
     import time
 
     start = time.time()
-    oiids = [s.open_images_id for s in dataset]
+    oids = []
+    for sample in dataset:
+        oids.append(sample.open_images_id)
+
     print(time.time() - start)
     # 38.212332010269165
 
     start = time.time()
-    oiids = [s.open_images_id for s in dataset.select_fields("open_images_id")]
+    oids = []
+    for sample in dataset.select_fields("open_images_id"):
+        oids.append(sample.open_images_id)
+
     print(time.time() - start)
     # 0.20824909210205078

--- a/fiftyone/__public__.py
+++ b/fiftyone/__public__.py
@@ -27,6 +27,7 @@ from .core.aggregations import (
     Sum,
     Values,
 )
+from .core.collections import SaveContext
 from .core.config import AppConfig
 from .core.dataset import (
     Dataset,

--- a/fiftyone/core/clips.py
+++ b/fiftyone/core/clips.py
@@ -49,6 +49,9 @@ class ClipView(fos.SampleView):
         super().save()
         self._view._sync_source_sample(self)
 
+    def _deferred_save(self):
+        raise NotImplementedError("Clips views do not support save contexts")
+
 
 class ClipsView(fov.DatasetView):
     """A :class:`fiftyone.core.view.DatasetView` of clips from a video

--- a/fiftyone/core/clips.py
+++ b/fiftyone/core/clips.py
@@ -44,13 +44,14 @@ class ClipView(fos.SampleView):
     def _sample_id(self):
         return ObjectId(self._doc.sample_id)
 
-    def save(self):
-        """Saves the clip to the database."""
-        super().save()
-        self._view._sync_source_sample(self)
+    def _save(self, deferred=False):
+        if deferred:
+            raise NotImplementedError(
+                "Clips views do not support save contexts"
+            )
 
-    def _deferred_save(self):
-        raise NotImplementedError("Clips views do not support save contexts")
+        super()._save(deferred=deferred)
+        self._view._sync_source_sample(self)
 
 
 class ClipsView(fov.DatasetView):

--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -91,12 +91,13 @@ class SaveContext(object):
         self._sample_coll = sample_collection._dataset._sample_collection
         self._frame_coll = sample_collection._dataset._frame_collection
 
-        self._curr_batch_size = None
-        self._dynamic_batches = not isinstance(batch_size, numbers.Integral)
-        self._last_time = None
         self._sample_ops = []
         self._frame_ops = []
         self._reload_parents = []
+
+        self._curr_batch_size = None
+        self._dynamic_batches = not isinstance(batch_size, numbers.Integral)
+        self._last_time = None
 
     def __enter__(self):
         if self._dynamic_batches:

--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -749,6 +749,44 @@ class SampleCollection(object):
         """
         raise NotImplementedError("Subclass must implement iter_samples()")
 
+    def save_context(self, batch_size=1):
+        """Returns a context that can be used to save samples from this
+        collection according to a configurable batching strategy.
+
+        Examples::
+
+            import fiftyone as fo
+            import fiftyone.zoo as foz
+
+            dataset = foz.load_zoo_dataset("quickstart")
+
+            # No save context
+            for sample in dataset.iter_samples(progress=True):
+                sample["num_objects"] = len(sample.ground_truth.detections)
+                sample.save()
+
+            # Save in batches of 10
+            with dataset.save_context(batch_size=10) as context:
+                for sample in dataset.iter_samples(progress=True):
+                    sample["num_objects"] = len(sample.ground_truth.detections)
+                    context.save(sample)
+
+            # Save every 0.5 seconds
+            with dataset.save_context(batch_size=0.5) as context:
+                for sample in dataset.iter_samples(progress=True):
+                    sample["num_objects"] = len(sample.ground_truth.detections)
+                    context.save(sample)
+
+        Args:
+            batch_size (1): the batching strategy to use. Can either be an
+                integer specifying the number of samples to save in a batch, or
+                a float number of seconds between batched saves
+
+        Returns:
+            a :class:`SaveContext`
+        """
+        return SaveContext(self, batch_size=batch_size)
+
     def _get_default_sample_fields(
         self, include_private=False, use_db_fields=False
     ):

--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -1433,9 +1433,6 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
         Returns:
             an iterator over :class:`fiftyone.core.sample.Sample` instances
         """
-        if autosave and batch_size is None:
-            batch_size = 0.2
-
         pipeline = self._pipeline(detach_frames=True)
 
         with contextlib.ExitStack() as exit_context:

--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -1388,48 +1388,43 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
 
         self._reload()
 
-    def iter_samples(
-        self, progress=False, autosave=False, autosave_batch_size=10
-    ):
-        """Returns an iterator over the samples in the collection.
+    def iter_samples(self, progress=False, autosave=False, batch_size=None):
+        """Returns an iterator over the samples in the dataset.
 
-         Args:
+        Args:
             progress (False): whether to render a progress bar tracking the
                 iterator's progress
-
-            autosave (False): whether to automatically save :class:`fiftyone.core.sample.Sample` or
-            :class:`fiftyone.core.sample.SampleView` during iteration
-
-            autosave_batch_size (int, optional): Btachsize of samples for autosaving. Defaults to 10
+            autosave (False): whether to automatically save changes to samples
+                emitted by this iterator
+            batch_size (None): a batch size to use when autosaving samples. Can
+                either be an integer specifying the number of samples to save
+                in a batch, or a float number of seconds between batched saves
 
         Returns:
-            an iterator over :class:`fiftyone.core.sample.Sample`
+            an iterator over :class:`fiftyone.core.sample.Sample` instances
         """
+        if autosave and batch_size is None:
+            batch_size = 0.5
+
         pipeline = self._pipeline(detach_frames=True)
 
-        with contextlib.ExitStack() as iter_ctx:
+        with contextlib.ExitStack() as exit_context:
             samples = self._iter_samples(pipeline)
 
             if progress:
-                pbar = fou.ProgressBar(total=len(self))
-                iter_ctx.enter_context(pbar)
-                samples = pbar(samples)
+                pb = fou.ProgressBar(total=len(self))
+                exit_context.enter_context(pb)
+                samples = pb(samples)
 
             if autosave:
-                autosave_batch = foc._AutosaveSampleBatch(
-                    self._sample_collection,
-                    self._frame_collection,
-                    batch_size=autosave_batch_size,
-                )
-                iter_ctx.enter_context(autosave_batch)
+                save_context = foc.SaveContext(self, batch_size=batch_size)
+                exit_context.enter_context(save_context)
 
             for sample in samples:
-                with contextlib.ExitStack() as sample_ctx:
-                    if autosave:
-                        sample_ctx.enter_context(
-                            foc._AutosaveSample(autosave_batch, sample)
-                        )
-                    yield sample
+                yield sample
+
+                if autosave:
+                    save_context.save(sample)
 
     def _iter_samples(self, pipeline):
         index = 0

--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -1391,6 +1391,36 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
     def iter_samples(self, progress=False, autosave=False, batch_size=None):
         """Returns an iterator over the samples in the dataset.
 
+        Examples::
+
+            import random as r
+            import string as s
+
+            import fiftyone as fo
+            import fiftyone.zoo as foz
+
+            dataset = foz.load_zoo_dataset("cifar10", split="test")
+
+            def make_label():
+                return "".join(r.choice(s.ascii_letters) for i in range(10))
+
+            # No save context
+            for sample in dataset.iter_samples(progress=True):
+                sample.ground_truth.label = make_label()
+                sample.save()
+
+            # Save in batches of 10
+            for sample in dataset.iter_samples(
+                progress=True, autosave=True, batch_size=10
+            ):
+                sample.ground_truth.label = make_label()
+
+            # Save every 0.5 seconds
+            for sample in dataset.iter_samples(
+                progress=True, autosave=True, batch_size=0.5
+            ):
+                sample.ground_truth.label = make_label()
+
         Args:
             progress (False): whether to render a progress bar tracking the
                 iterator's progress

--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -1404,7 +1404,7 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
             an iterator over :class:`fiftyone.core.sample.Sample` instances
         """
         if autosave and batch_size is None:
-            batch_size = 0.5
+            batch_size = 0.2
 
         pipeline = self._pipeline(detach_frames=True)
 

--- a/fiftyone/core/document.py
+++ b/fiftyone/core/document.py
@@ -388,12 +388,15 @@ class _Document(object):
 
     def save(self):
         """Saves the document to the database."""
+        self._save()
+
+    def _save(self, deferred=False):
         if not self._in_db:
             raise ValueError(
                 "Cannot save a document that has not been added to a dataset"
             )
 
-        self._doc.save()
+        return self._doc._save(deferred=deferred)
 
     def _parse_fields(self, fields=None, omit_fields=None):
         if fields is None:
@@ -757,8 +760,16 @@ class DocumentView(_Document):
 
     def save(self):
         """Saves the document view to the database."""
-        self._doc.save(filtered_fields=self._filtered_fields)
+        self._save()
+        self._reload_parents()
 
+    def _save(self, deferred=False):
+        return self._doc._save(
+            deferred=deferred,
+            filtered_fields=self._filtered_fields,
+        )
+
+    def _reload_parents(self):
         if issubclass(type(self._DOCUMENT_CLS), DocumentSingleton):
             self._DOCUMENT_CLS._reload_instance(self)
 

--- a/fiftyone/core/frame.py
+++ b/fiftyone/core/frame.py
@@ -454,7 +454,7 @@ class Frames(object):
         Frame._sync_docs_for_sample(
             self._frame_collection_name,
             self._sample.id,
-            self._get_frame_numbers(),
+            self._get_frame_numbers,  # pass fcn so it can be lazily called
             hard=hard,
         )
 
@@ -926,7 +926,7 @@ class FramesView(Frames):
         Frame._sync_docs_for_sample(
             self._frame_collection_name,
             self._sample.id,
-            self._get_frame_numbers(),
+            self._get_frame_numbers,  # pass fcn so it can be lazily called
         )
 
 

--- a/fiftyone/core/odm/document.py
+++ b/fiftyone/core/odm/document.py
@@ -524,7 +524,7 @@ class Document(BaseDocument, mongoengine.Document):
     meta = {"abstract": True}
 
     def save(self, validate=True, clean=True, **kwargs):
-        """Save the document to the database.
+        """Saves the document to the database.
 
         If the document already exists, it will be updated, otherwise it will
         be created.

--- a/fiftyone/core/odm/document.py
+++ b/fiftyone/core/odm/document.py
@@ -654,14 +654,19 @@ class Document(BaseDocument, mongoengine.Document):
             sets, unsets = self._delta()
 
             update_doc = {}
+
             if sets:
                 update_doc["$set"] = sets
+
             if unsets:
                 update_doc["$unset"] = unsets
+
             if update_doc:
                 save_op = pymongo.UpdateOne(
                     {"_id": object_id}, update_doc, upsert=True
                 )
+            else:
+                save_op = None
 
         # Make sure we store the PK on this document now that it's saved
         id_field = self._meta["id_field"]

--- a/fiftyone/core/odm/document.py
+++ b/fiftyone/core/odm/document.py
@@ -12,6 +12,7 @@ import re
 from bson import json_util, ObjectId
 import mongoengine
 import pymongo
+from pymongo import UpdateOne
 
 import eta.core.serial as etas
 
@@ -523,24 +524,31 @@ class Document(BaseDocument, mongoengine.Document):
     meta = {"abstract": True}
 
     def save(self, validate=True, clean=True, **kwargs):
-        """Save the :class:`Document` to the database.
+        """Save the document to the database.
 
         If the document already exists, it will be updated, otherwise it will
         be created.
 
         Args:
-            validate (True): validates the document
-            clean (True): call the document's clean method; requires
-                ``validate`` to be True
+            validate (True): whether to validate the document
+            clean (True): whether to call the document's ``clean()`` method.
+                Only applicable when ``validate`` is True
 
         Returns:
             self
         """
+        self._save(deferred=False, validate=validate, clean=clean, **kwargs)
+        return self
+
+    def _save(self, deferred=False, validate=True, clean=True, **kwargs):
         # pylint: disable=no-member
         if self._meta.get("abstract"):
             raise mongoengine.InvalidDocumentError(
                 "Cannot save an abstract document."
             )
+
+        if self._meta.get("auto_create_index", True):
+            self.ensure_indexes()
 
         if validate:
             self.validate(clean=clean)
@@ -548,144 +556,76 @@ class Document(BaseDocument, mongoengine.Document):
         doc_id = self.to_mongo(fields=[self._meta["id_field"]])
         created = "_id" not in doc_id or self._created
 
-        # It might be refreshed by the pre_save_post_validation hook, e.g., for
-        # etag generation
         doc = self.to_mongo()
 
-        if self._meta.get("auto_create_index", True):
-            self.ensure_indexes()
+        _id = None
+        op = None
 
         try:
-            # Save a new document or update an existing one
             if created:
                 # Save new document
+                if deferred:
+                    _id = doc.get("_id", None) or ObjectId()
+                    op = UpdateOne({"_id": _id}, doc, upsert=True)
+                else:
+                    collection = self._get_collection()
 
-                # insert_one will provoke UniqueError alongside save does not
-                # therefore, it need to catch and call replace_one.
-                collection = self._get_collection()
+                    if "_id" in doc:
+                        raw_object = collection.find_one_and_replace(
+                            {"_id": doc["_id"]}, doc
+                        )
+                        if raw_object:
+                            _id = doc["_id"]
 
-                object_id = None
-
-                if "_id" in doc:
-                    raw_object = collection.find_one_and_replace(
-                        {"_id": doc["_id"]}, doc
-                    )
-                    if raw_object:
-                        object_id = doc["_id"]
-
-                if not object_id:
-                    object_id = collection.insert_one(doc).inserted_id
+                    if not _id:
+                        _id = collection.insert_one(doc).inserted_id
             else:
                 # Update existing document
-                object_id = doc["_id"]
+                _id = doc["_id"]
                 created = False
 
-                updates, removals = self._delta()
+                updates = {}
+                sets, unsets = self._delta()
 
-                update_doc = {}
+                if sets:
+                    updates["$set"] = sets
+
+                if unsets:
+                    updates["$unset"] = unsets
 
                 if updates:
-                    update_doc["$set"] = updates
-
-                if removals:
-                    update_doc["$unset"] = removals
-
-                if update_doc:
-                    updated_existing = self._update(
-                        object_id, update_doc, **kwargs
-                    )
-
-                    if updated_existing is False:
-                        created = True
-                        # !!! This is bad, means we accidentally created a
-                        # new, potentially corrupted document. See
-                        # https://github.com/MongoEngine/mongoengine/issues/564
-
-        except pymongo.errors.DuplicateKeyError as err:
+                    if deferred:
+                        op = UpdateOne({"_id": _id}, updates, upsert=True)
+                    else:
+                        updated_existing = self._update(_id, updates, **kwargs)
+                        if updated_existing is False:
+                            created = True
+        except pymongo.errors.DuplicateKeyError as e:
             message = "Tried to save duplicate unique keys (%s)"
-            raise mongoengine.NotUniqueError(message % err)
-
-        except pymongo.errors.OperationFailure as err:
+            raise mongoengine.NotUniqueError(message % e)
+        except pymongo.errors.OperationFailure as e:
             message = "Could not save document (%s)"
-            if re.match("^E1100[01] duplicate key", str(err)):
-                # E11000 - duplicate key error index
-                # E11001 - duplicate key on update
+            if re.match("^E1100[01] duplicate key", str(e)):
                 message = "Tried to save duplicate unique keys (%s)"
-                raise mongoengine.NotUniqueError(message % err)
+                raise mongoengine.NotUniqueError(message % e)
 
-            raise mongoengine.OperationError(message % err)
-
-        # Make sure we store the PK on this document now that it's saved
-        id_field = self._meta["id_field"]
-        if created or id_field not in self._meta.get("shard_key", []):
-            self[id_field] = self._fields[id_field].to_python(object_id)
-
-        self._clear_changed_fields()
-        self._created = False
-
-        return self
-
-    def _deferred_save(self):
-        # pylint: disable=no-member
-        if self._meta.get("abstract"):
-            raise mongoengine.InvalidDocumentError(
-                "Cannot save an abstract document."
-            )
-
-        self.validate(clean=True)
-
-        doc_id = self.to_mongo(fields=[self._meta["id_field"]])
-        created = "_id" not in doc_id or self._created
-
-        # It might be refreshed by the pre_save_post_validation hook, e.g., for
-        # etag generation
-        doc = self.to_mongo()
-
-        if self._meta.get("auto_create_index", True):
-            self.ensure_indexes()
-
-        if created:
-            object_id = doc.get("_id") or ObjectId()
-            save_op = pymongo.UpdateOne({"_id": object_id}, doc, upsert=True)
-        else:
-            object_id = doc.get("_id")
-            created = False
-
-            sets, unsets = self._delta()
-
-            update_doc = {}
-
-            if sets:
-                update_doc["$set"] = sets
-
-            if unsets:
-                update_doc["$unset"] = unsets
-
-            if update_doc:
-                save_op = pymongo.UpdateOne(
-                    {"_id": object_id}, update_doc, upsert=True
-                )
-            else:
-                save_op = None
+            raise mongoengine.OperationError(message % e)
 
         # Make sure we store the PK on this document now that it's saved
         id_field = self._meta["id_field"]
         if created or id_field not in self._meta.get("shard_key", []):
-            self[id_field] = self._fields[id_field].to_python(object_id)
+            self[id_field] = self._fields[id_field].to_python(_id)
 
         self._clear_changed_fields()
         self._created = False
 
-        return save_op
+        return op
 
-    def _update(self, object_id, update_doc, **kwargs):
-        """Updates an existing document.
-
-        Helper method; should only be used by :meth:`Document.save`.
-        """
+    def _update(self, _id, updates, **kwargs):
+        """Updates an existing document."""
         result = (
             self._get_collection()
-            .update_one({"_id": object_id}, update_doc, upsert=True)
+            .update_one({"_id": _id}, updates, upsert=True)
             .raw_result
         )
 

--- a/fiftyone/core/odm/mixins.py
+++ b/fiftyone/core/odm/mixins.py
@@ -1156,6 +1156,9 @@ class NoDatasetMixin(object):
     def save(self):
         pass
 
+    def _save(self, deferred=False):
+        pass
+
     def reload(self):
         pass
 

--- a/fiftyone/core/patches.py
+++ b/fiftyone/core/patches.py
@@ -41,6 +41,9 @@ class _PatchView(fos.SampleView):
         super().save()
         self._view._sync_source_sample(self)
 
+    def _deferred_save(self):
+        raise NotImplementedError("Patches views do not support save contexts")
+
 
 class PatchView(_PatchView):
     """A patch in a :class:`PatchesView`.

--- a/fiftyone/core/patches.py
+++ b/fiftyone/core/patches.py
@@ -37,12 +37,14 @@ class _PatchView(fos.SampleView):
     def _frame_id(self):
         return ObjectId(self._doc.frame_id)
 
-    def save(self):
-        super().save()
-        self._view._sync_source_sample(self)
+    def _save(self, deferred=False):
+        if deferred:
+            raise NotImplementedError(
+                "Patches views do not support save contexts"
+            )
 
-    def _deferred_save(self):
-        raise NotImplementedError("Patches views do not support save contexts")
+        super()._save(deferred=deferred)
+        self._view._sync_source_sample(self)
 
 
 class PatchView(_PatchView):

--- a/fiftyone/core/sample.py
+++ b/fiftyone/core/sample.py
@@ -489,28 +489,20 @@ class Sample(_SampleMixin, Document, metaclass=SampleSingleton):
 
     def save(self):
         """Saves the sample to the database."""
-        if not self._in_db:
-            raise ValueError(
-                "Cannot save a sample that has not been added to a dataset"
-            )
-
-        if self.media_type == fomm.VIDEO:
-            self.frames.save()
-
         super().save()
 
-    def _deferred_save(self):
+    def _save(self, deferred=False):
         if not self._in_db:
             raise ValueError(
                 "Cannot save a sample that has not been added to a dataset"
             )
 
         if self.media_type == fomm.VIDEO:
-            frame_ops = self.frames._deferred_save()
+            frame_ops = self.frames._save(deferred=deferred)
         else:
-            frame_ops = None
+            frame_ops = []
 
-        sample_op = self._doc._deferred_save()
+        sample_op = super()._save(deferred=deferred)
 
         return sample_op, frame_ops
 
@@ -689,20 +681,23 @@ class SampleView(_SampleMixin, DocumentView):
             This will permanently delete any omitted or filtered contents from
             the source dataset.
         """
-        if self.media_type == fomm.VIDEO:
-            self.frames.save()
-
         super().save()
 
-    def _deferred_save(self):
+    def _save(self, deferred=False):
         if self.media_type == fomm.VIDEO:
-            frame_ops = self.frames._deferred_save()
+            frame_ops = self.frames._save(deferred=deferred)
         else:
-            frame_ops = None
+            frame_ops = []
 
-        sample_op = self._doc._deferred_save()
+        sample_op = super()._save(deferred=deferred)
 
         return sample_op, frame_ops
+
+    def _reload_parents(self):
+        if self.media_type == fomm.VIDEO:
+            self.frames._reload_parents()
+
+        super()._reload_parents()
 
 
 def _apply_confidence_thresh(label, confidence_thresh):

--- a/fiftyone/core/sample.py
+++ b/fiftyone/core/sample.py
@@ -500,15 +500,15 @@ class Sample(_SampleMixin, Document, metaclass=SampleSingleton):
         super().save()
 
     def _deferred_save(self):
-        """Saves the sample to the database."""
         if not self._in_db:
             raise ValueError(
                 "Cannot save a sample that has not been added to a dataset"
             )
 
-        frame_ops = []
         if self.media_type == fomm.VIDEO:
             frame_ops = self.frames._deferred_save()
+        else:
+            frame_ops = None
 
         sample_op = self._doc._deferred_save()
 
@@ -695,11 +695,10 @@ class SampleView(_SampleMixin, DocumentView):
         super().save()
 
     def _deferred_save(self):
-        """Saves the sample view to the database."""
-
-        frame_ops = []
         if self.media_type == fomm.VIDEO:
             frame_ops = self.frames._deferred_save()
+        else:
+            frame_ops = None
 
         sample_op = self._doc._deferred_save()
 

--- a/fiftyone/core/sample.py
+++ b/fiftyone/core/sample.py
@@ -693,12 +693,6 @@ class SampleView(_SampleMixin, DocumentView):
 
         return sample_op, frame_ops
 
-    def _reload_parents(self):
-        if self.media_type == fomm.VIDEO:
-            self.frames._reload_parents()
-
-        super()._reload_parents()
-
 
 def _apply_confidence_thresh(label, confidence_thresh):
     if _is_frames_dict(label):

--- a/fiftyone/core/singletons.py
+++ b/fiftyone/core/singletons.py
@@ -320,8 +320,15 @@ class FrameSingleton(DocumentSingleton):
         samples = cls._instances[collection_name]
         frames = samples.get(sample_id, {})
 
+        if not frames:
+            return
+
+        if callable(frame_numbers):
+            frame_numbers = frame_numbers()
+
         frame_numbers = set(frame_numbers)
         reset_fns = set()
+
         for frame_number, frame in frames.items():
             if frame_number in frame_numbers:
                 frame.reload(hard=hard)
@@ -418,6 +425,12 @@ class FrameSingleton(DocumentSingleton):
 
         samples = cls._instances[collection_name]
         frames = samples.get(sample_id, {})
+
+        if not frames:
+            return
+
+        if callable(frame_numbers):
+            frame_numbers = frame_numbers()
 
         frame_numbers = set(frame_numbers)
         reset_fns = set()

--- a/fiftyone/core/video.py
+++ b/fiftyone/core/video.py
@@ -58,6 +58,9 @@ class FrameView(fos.SampleView):
         super().save()
         self._view._sync_source_sample(self)
 
+    def _deferred_save(self):
+        raise NotImplementedError("Frames views do not support save contexts")
+
 
 class FramesView(fov.DatasetView):
     """A :class:`fiftyone.core.view.DatasetView` of frames from a video

--- a/fiftyone/core/video.py
+++ b/fiftyone/core/video.py
@@ -53,13 +53,14 @@ class FrameView(fos.SampleView):
     def _sample_id(self):
         return ObjectId(self._doc.sample_id)
 
-    def save(self):
-        """Saves the frame to the database."""
-        super().save()
-        self._view._sync_source_sample(self)
+    def _save(self, deferred=False):
+        if deferred:
+            raise NotImplementedError(
+                "Frames views do not support save contexts"
+            )
 
-    def _deferred_save(self):
-        raise NotImplementedError("Frames views do not support save contexts")
+        super()._save(deferred=deferred)
+        self._view._sync_source_sample(self)
 
 
 class FramesView(fov.DatasetView):

--- a/fiftyone/core/view.py
+++ b/fiftyone/core/view.py
@@ -279,6 +279,37 @@ class DatasetView(foc.SampleCollection):
     def iter_samples(self, progress=False, autosave=False, batch_size=None):
         """Returns an iterator over the samples in the view.
 
+        Examples::
+
+            import random as r
+            import string as s
+
+            import fiftyone as fo
+            import fiftyone.zoo as foz
+
+            dataset = foz.load_zoo_dataset("cifar10", split="test")
+            view = dataset.shuffle().limit(5000)
+
+            def make_label():
+                return "".join(r.choice(s.ascii_letters) for i in range(10))
+
+            # No save context
+            for sample in view.iter_samples(progress=True):
+                sample.ground_truth.label = make_label()
+                sample.save()
+
+            # Save in batches of 10
+            for sample in view.iter_samples(
+                progress=True, autosave=True, batch_size=10
+            ):
+                sample.ground_truth.label = make_label()
+
+            # Save every 0.5 seconds
+            for sample in view.iter_samples(
+                progress=True, autosave=True, batch_size=0.5
+            ):
+                sample.ground_truth.label = make_label()
+
         Args:
             progress (False): whether to render a progress bar tracking the
                 iterator's progress
@@ -291,9 +322,6 @@ class DatasetView(foc.SampleCollection):
         Returns:
             an iterator over :class:`fiftyone.core.sample.SampleView` instances
         """
-        if autosave and batch_size is None:
-            batch_size = 0.2
-
         with contextlib.ExitStack() as exit_context:
             samples = self._iter_samples()
 

--- a/fiftyone/core/view.py
+++ b/fiftyone/core/view.py
@@ -276,46 +276,41 @@ class DatasetView(foc.SampleCollection):
         """
         return copy(self)
 
-    def iter_samples(
-        self, progress=False, autosave=False, autosave_batch_size=10
-    ):
+    def iter_samples(self, progress=False, autosave=False, batch_size=None):
         """Returns an iterator over the samples in the view.
 
         Args:
             progress (False): whether to render a progress bar tracking the
                 iterator's progress
-
-            autosave (False): whether to automatically save :class:`fiftyone.core.sample.SampleView` during iteration
-
-            autosave_batch_size (int, optional): Btachsize of samples for autosaving. Defaults to 10
+            autosave (False): whether to automatically save changes to samples
+                emitted by this iterator
+            batch_size (None): a batch size to use when autosaving samples. Can
+                either be an integer specifying the number of samples to save
+                in a batch, or a float number of seconds between batched saves
 
         Returns:
             an iterator over :class:`fiftyone.core.sample.SampleView` instances
         """
+        if autosave and batch_size is None:
+            batch_size = 0.5
 
-        with contextlib.ExitStack() as iter_ctx:
+        with contextlib.ExitStack() as exit_context:
             samples = self._iter_samples()
 
             if progress:
-                pbar = fou.ProgressBar(total=len(self))
-                iter_ctx.enter_context(pbar)
-                samples = pbar(samples)
+                pb = fou.ProgressBar(total=len(self))
+                exit_context.enter_context(pb)
+                samples = pb(samples)
 
             if autosave:
-                autosave_batch = foc._AutosaveSampleBatch(
-                    self._dataset._sample_collection,
-                    self._dataset._frame_collection,
-                    batch_size=autosave_batch_size,
-                )
-                iter_ctx.enter_context(autosave_batch)
+                save_context = foc.SaveContext(self, batch_size=batch_size)
+                exit_context.enter_context(save_context)
 
             for sample in samples:
-                with contextlib.ExitStack() as sample_ctx:
-                    if autosave:
-                        sample_ctx.enter_context(
-                            foc._AutosaveSample(autosave_batch, sample)
-                        )
-                    yield sample
+                yield sample
+
+                if autosave:
+                    save_context.save(sample)
 
     def _iter_samples(self):
         sample_cls = self._sample_cls

--- a/fiftyone/core/view.py
+++ b/fiftyone/core/view.py
@@ -292,7 +292,7 @@ class DatasetView(foc.SampleCollection):
             an iterator over :class:`fiftyone.core.sample.SampleView` instances
         """
         if autosave and batch_size is None:
-            batch_size = 0.5
+            batch_size = 0.2
 
         with contextlib.ExitStack() as exit_context:
             samples = self._iter_samples()

--- a/tests/unittests/dataset_tests.py
+++ b/tests/unittests/dataset_tests.py
@@ -220,11 +220,29 @@ class DatasetTests(unittest.TestCase):
             [fo.Sample(filepath="image%d.jpg" % i) for i in range(50)]
         )
 
-        for sample in dataset:
-            pass
+        for idx, sample in enumerate(dataset):
+            sample["int"] = idx + 1
+            sample.save()
 
-        for sample in dataset.iter_samples(progress=True):
-            pass
+        self.assertTupleEqual(dataset.bounds("int"), (1, 50))
+
+        for idx, sample in enumerate(dataset.iter_samples(progress=True)):
+            sample["int"] = idx + 2
+            sample.save()
+
+        self.assertTupleEqual(dataset.bounds("int"), (2, 51))
+
+        for idx, sample in enumerate(dataset.iter_samples(autosave=True)):
+            sample["int"] = idx + 3
+
+        self.assertTupleEqual(dataset.bounds("int"), (3, 52))
+
+        with dataset.save_context() as context:
+            for idx, sample in enumerate(dataset):
+                sample["int"] = idx + 4
+                context.save(sample)
+
+        self.assertTupleEqual(dataset.bounds("int"), (4, 53))
 
     @drop_datasets
     def test_date_fields(self):

--- a/tests/unittests/view_tests.py
+++ b/tests/unittests/view_tests.py
@@ -26,18 +26,39 @@ class DatasetViewTests(unittest.TestCase):
     def test_iter_samples(self):
         dataset = fo.Dataset()
         dataset.add_samples(
-            [fo.Sample(filepath="image%d.jpg" % i) for i in range(50)]
+            [fo.Sample(filepath="image%d.jpg" % i) for i in range(51)]
         )
 
-        view = dataset.view()
+        first_sample = dataset.first()
+        view = dataset.limit(50)
 
-        self.assertEqual(len(dataset), len(view))
+        for idx, sample in enumerate(view):
+            sample["int"] = idx + 1
+            sample.save()
 
-        for sample in view:
-            pass
+        self.assertTupleEqual(dataset.bounds("int"), (1, 50))
+        self.assertEqual(first_sample.int, 1)
 
-        for sample in view.iter_samples(progress=True):
-            pass
+        for idx, sample in enumerate(view.iter_samples(progress=True)):
+            sample["int"] = idx + 2
+            sample.save()
+
+        self.assertTupleEqual(dataset.bounds("int"), (2, 51))
+        self.assertEqual(first_sample.int, 2)
+
+        for idx, sample in enumerate(view.iter_samples(autosave=True)):
+            sample["int"] = idx + 3
+
+        self.assertTupleEqual(dataset.bounds("int"), (3, 52))
+        self.assertEqual(first_sample.int, 3)
+
+        with view.save_context() as context:
+            for idx, sample in enumerate(view):
+                sample["int"] = idx + 4
+                context.save(sample)
+
+        self.assertTupleEqual(dataset.bounds("int"), (4, 53))
+        self.assertEqual(first_sample.int, 4)
 
     @drop_datasets
     def test_view(self):


### PR DESCRIPTION
Completes the implementation of the dataset save context started in https://github.com/voxel51/fiftyone/pull/1727.

### Change log

- Added support for dynamically batching samples to achieve a target number of database connections per second
- Updated the default batching strategy to save batches every 0.2 seconds (this is the same strategy used by `add_samples()`)
- Added a `save_context()` syntax
- Added proper reloading of `Sample`/`Frame` singletons when applying save contexts to dataset *views*
- Added documentation
- Added unit tests

### Example usage

The `iter_samples(autosave=True)` syntax is the same:

```py
import random as r
import string as s

import fiftyone as fo
import fiftyone.zoo as foz

dataset = foz.load_zoo_dataset("cifar10", split="test")

def make_label():
    return "".join(r.choice(s.ascii_letters) for i in range(10))

# No save context
for sample in dataset.iter_samples(progress=True):
    sample.ground_truth.label = make_label()
    sample.save()

# Save in batches of 10
for sample in dataset.iter_samples(progress=True, autosave=True, batch_size=10):
    sample.ground_truth.label = make_label()

# Save every 0.5 seconds
for sample in dataset.iter_samples(progress=True, autosave=True, batch_size=0.5):
    sample.ground_truth.label = make_label()
```

And here's how the new `save_context()` syntax looks:

```py
# No save context
for sample in dataset.iter_samples(progress=True):
    sample.ground_truth.label = label()
    sample.save()

# Save in batches of 10
with dataset.save_context(batch_size=10) as context:
    for sample in dataset.iter_samples(progress=True):
        sample.ground_truth.label = make_label()
        context.save(sample)

# Save every 0.5 seconds
with dataset.save_context(batch_size=0.5) as context:
    for sample in dataset.iter_samples(progress=True):
        sample.ground_truth.label = make_label()
        context.save(sample)
```
