### PR TITLE
Adding client compatibility versions

### DIFF
--- a/docs/source/cli/index.rst
+++ b/docs/source/cli/index.rst
@@ -749,7 +749,7 @@ FiftyOne deployments.
 
 .. code-block:: shell
 
-    # Migrate the database and all datasets to the current package version
+    # Migrate the database and all datasets to the current client version
     fiftyone migrate --all
 
 .. code-block:: shell

--- a/fiftyone/constants.py
+++ b/fiftyone/constants.py
@@ -29,11 +29,22 @@ BASE_DIR = os.path.dirname(FIFTYONE_DIR)
 TEAMS_PATH = os.path.join(FIFTYONE_CONFIG_DIR, "var", "teams.json")
 RESOURCES_DIR = os.path.join(FIFTYONE_DIR, "resources")
 
+#
+# The compatible versions for this client
+#
+# RULES: Datasets from all compatible versions must be...
+#   - Loadable by this client without error
+#   - Editable by this client without causing any database edits that would
+#     break the original client's ability to work with the dataset
+#
+# This setting may be ``None`` if this client has no compatibility
+#
+COMPATIBLE_VERSIONS = ">=0.16.3,<0.17"
+
 # Package metadata
 _META = metadata("fiftyone")
 NAME = _META["name"]
 VERSION = _META["version"]
-COMPATIBLE_VERSIONS = ">=0.16.3,<0.17"  # compatible versions
 DESCRIPTION = _META["summary"]
 AUTHOR = _META["author"]
 AUTHOR_EMAIL = _META["author-email"]

--- a/fiftyone/constants.py
+++ b/fiftyone/constants.py
@@ -33,7 +33,7 @@ RESOURCES_DIR = os.path.join(FIFTYONE_DIR, "resources")
 _META = metadata("fiftyone")
 NAME = _META["name"]
 VERSION = _META["version"]
-COMPATIBLE_VERSIONS = ">=0.16.1,<0.17"  # compatible DB versions
+COMPATIBLE_VERSIONS = ">=0.16.1,<0.17"  # compatible versions
 DESCRIPTION = _META["summary"]
 AUTHOR = _META["author"]
 AUTHOR_EMAIL = _META["author-email"]

--- a/fiftyone/constants.py
+++ b/fiftyone/constants.py
@@ -33,6 +33,7 @@ RESOURCES_DIR = os.path.join(FIFTYONE_DIR, "resources")
 _META = metadata("fiftyone")
 NAME = _META["name"]
 VERSION = _META["version"]
+COMPATIBLE_VERSIONS = ">=0.16.1,<0.17"  # compatible DB versions
 DESCRIPTION = _META["summary"]
 AUTHOR = _META["author"]
 AUTHOR_EMAIL = _META["author-email"]

--- a/fiftyone/constants.py
+++ b/fiftyone/constants.py
@@ -33,7 +33,7 @@ RESOURCES_DIR = os.path.join(FIFTYONE_DIR, "resources")
 _META = metadata("fiftyone")
 NAME = _META["name"]
 VERSION = _META["version"]
-COMPATIBLE_VERSIONS = ">=0.16.1,<0.17"  # compatible versions
+COMPATIBLE_VERSIONS = ">=0.16.3,<0.17"  # compatible versions
 DESCRIPTION = _META["summary"]
 AUTHOR = _META["author"]
 AUTHOR_EMAIL = _META["author-email"]

--- a/fiftyone/core/cli.py
+++ b/fiftyone/core/cli.py
@@ -2590,7 +2590,8 @@ class MigrateCommand(Command):
 
 
 def _print_migration_table(db_ver, dataset_vers):
-    print("FiftyOne version: %s" % foc.VERSION)
+    print("Client version: %s" % foc.VERSION)
+    print("Compatible database versions: %s" % foc.COMPATIBLE_VERSIONS)
     print("Database version: %s" % db_ver)
 
     if dataset_vers:

--- a/fiftyone/core/cli.py
+++ b/fiftyone/core/cli.py
@@ -2591,7 +2591,9 @@ class MigrateCommand(Command):
 
 def _print_migration_table(db_ver, dataset_vers):
     print("Client version: %s" % foc.VERSION)
-    print("Compatible database versions: %s" % foc.COMPATIBLE_VERSIONS)
+    print("Compatible versions: %s" % foc.COMPATIBLE_VERSIONS)
+    print("")
+
     print("Database version: %s" % db_ver)
 
     if dataset_vers:

--- a/fiftyone/core/cli.py
+++ b/fiftyone/core/cli.py
@@ -2509,7 +2509,7 @@ class MigrateCommand(Command):
         # Print information about the current revisions of all datasets
         fiftyone migrate --info
 
-        # Migrate the database and all datasets to the current package version
+        # Migrate the database and all datasets to the current client version
         fiftyone migrate --all
 
         # Migrate to a specific revision

--- a/fiftyone/core/cli.py
+++ b/fiftyone/core/cli.py
@@ -2591,8 +2591,10 @@ class MigrateCommand(Command):
 
 def _print_migration_table(db_ver, dataset_vers):
     print("Client version: %s" % foc.VERSION)
-    print("Compatible versions: %s" % foc.COMPATIBLE_VERSIONS)
-    print("")
+
+    if foc.COMPATIBLE_VERSIONS:
+        print("Compatible versions: %s" % foc.COMPATIBLE_VERSIONS)
+        print("")
 
     print("Database version: %s" % db_ver)
 

--- a/fiftyone/core/odm/database.py
+++ b/fiftyone/core/odm/database.py
@@ -32,7 +32,7 @@ import fiftyone.core.fields as fof
 import fiftyone.core.service as fos
 import fiftyone.core.utils as fou
 
-from .document import DynamicDocument
+from .document import Document
 
 fod = fou.lazy_import("fiftyone.core.dataset")
 
@@ -54,17 +54,18 @@ _db_service = None
 # wrong version or type of client.
 #
 # This is currently guaranteed because:
-#   - `DatabaseConfigDocument` is a dynamic document, so any future fields that
-#     are added will not cause an error
+#   - `DatabaseConfigDocument` is declared as non-strict, so any past or future
+#     fields that are not currently defined will not cause an error
 #   - All declared fields are optional and we have promised ourselves that
 #     their type and meaning will never change
 #
 
 
-class DatabaseConfigDocument(DynamicDocument):
+class DatabaseConfigDocument(Document):
     """Backing document for the database config."""
 
-    meta = {"collection": "config"}
+    # strict=False lets this class ignore unknown fields from other versions
+    meta = {"collection": "config", "strict": False}
 
     version = fof.StringField()
     type = fof.StringField()

--- a/fiftyone/core/odm/dataset.py
+++ b/fiftyone/core/odm/dataset.py
@@ -138,6 +138,9 @@ def create_field(
 class SampleFieldDocument(EmbeddedDocument):
     """Description of a sample field."""
 
+    # strict=False lets this class ignore unknown fields from other versions
+    meta = {"strict": False}
+
     name = StringField()
     ftype = StringField()
     subfield = StringField(null=True)
@@ -313,6 +316,9 @@ class SampleFieldDocument(EmbeddedDocument):
 class SidebarGroupDocument(EmbeddedDocument):
     """Description of a Sidebar Group in the App."""
 
+    # strict=False lets this class ignore unknown fields from other versions
+    meta = {"strict": False}
+
     name = StringField(required=True)
     paths = ListField(StringField(), default=[])
 
@@ -354,6 +360,9 @@ class KeypointSkeleton(EmbeddedDocument):
         edges: a list of lists of integer indexes defining the connectivity
             between nodes
     """
+
+    # strict=False lets this class ignore unknown fields from other versions
+    meta = {"strict": False}
 
     labels = ListField(StringField(), null=True)
     edges = ListField(ListField(IntField()))

--- a/fiftyone/core/odm/dataset.py
+++ b/fiftyone/core/odm/dataset.py
@@ -362,7 +362,8 @@ class KeypointSkeleton(EmbeddedDocument):
 class DatasetDocument(Document):
     """Backing document for datasets."""
 
-    meta = {"collection": "datasets"}
+    # strict=False lets this class ignore unknown fields from other versions
+    meta = {"collection": "datasets", "strict": False}
 
     name = StringField(unique=True, required=True)
     version = StringField(required=True, null=True)

--- a/fiftyone/core/odm/dataset.py
+++ b/fiftyone/core/odm/dataset.py
@@ -26,7 +26,7 @@ from fiftyone.core.fields import (
     TargetsField,
 )
 
-from .document import Document, DynamicDocument
+from .document import Document
 from .embedded_document import EmbeddedDocument, BaseEmbeddedDocument
 from .runs import RunDocument
 
@@ -359,7 +359,7 @@ class KeypointSkeleton(EmbeddedDocument):
     edges = ListField(ListField(IntField()))
 
 
-class DatasetDocument(DynamicDocument):
+class DatasetDocument(Document):
     """Backing document for datasets."""
 
     meta = {"collection": "datasets"}

--- a/fiftyone/core/odm/dataset.py
+++ b/fiftyone/core/odm/dataset.py
@@ -26,7 +26,7 @@ from fiftyone.core.fields import (
     TargetsField,
 )
 
-from .document import Document
+from .document import Document, DynamicDocument
 from .embedded_document import EmbeddedDocument, BaseEmbeddedDocument
 from .runs import RunDocument
 
@@ -359,7 +359,7 @@ class KeypointSkeleton(EmbeddedDocument):
     edges = ListField(ListField(IntField()))
 
 
-class DatasetDocument(Document):
+class DatasetDocument(DynamicDocument):
     """Backing document for datasets."""
 
     meta = {"collection": "datasets"}

--- a/fiftyone/core/odm/document.py
+++ b/fiftyone/core/odm/document.py
@@ -384,6 +384,31 @@ class MongoEngineBaseDocument(SerializableDocument):
         # @todo can we optimize this?
         return json.loads(json_util.dumps(d))
 
+    @classmethod
+    def from_dict(cls, d, extended=False):
+        if not extended:
+            try:
+                # Attempt to load the document directly, assuming it is in
+                # extended form
+
+                # pylint: disable=no-member
+                return cls._from_son(d)
+            except Exception:
+                pass
+
+        # Construct any necessary extended JSON components like ObjectIds
+        # @todo can we optimize this?
+        d = json_util.loads(json_util.dumps(d))
+
+        # pylint: disable=no-member
+        return cls._from_son(d)
+
+
+class DynamicMixin(object):
+    """Mixin for :class:`MongoEngineBaseDocument` classes that can have
+    arbitrary dynamic fields added to them.
+    """
+
     def to_mongo(self, *args, **kwargs):
         # pylint: disable=no-member
         d = super().to_mongo(*args, **kwargs)
@@ -412,25 +437,6 @@ class MongoEngineBaseDocument(SerializableDocument):
             d[new] = d.pop(old)
 
         return d
-
-    @classmethod
-    def from_dict(cls, d, extended=False):
-        if not extended:
-            try:
-                # Attempt to load the document directly, assuming it is in
-                # extended form
-
-                # pylint: disable=no-member
-                return cls._from_son(d)
-            except Exception:
-                pass
-
-        # Construct any necessary extended JSON components like ObjectIds
-        # @todo can we optimize this?
-        d = json_util.loads(json_util.dumps(d))
-
-        # pylint: disable=no-member
-        return cls._from_son(d)
 
     @classmethod
     def _from_son(cls, d, *args, **kwargs):
@@ -493,13 +499,16 @@ class BaseDocument(MongoEngineBaseDocument):
         return self.id is not None
 
 
-class DynamicDocument(BaseDocument, mongoengine.DynamicDocument):
+class DynamicDocument(DynamicMixin, BaseDocument, mongoengine.DynamicDocument):
     """Base class for dynamic documents that are stored in a MongoDB
     collection.
+
     Dynamic documents can have arbitrary fields added to them.
+
     The ID of a document is automatically populated when it is added to the
     database, and the ID of a document is ``None`` if it has not been added to
     the database.
+
     Attributes:
         id: the ID of the document, or ``None`` if it has not been added to the
             database

--- a/fiftyone/core/odm/embedded_document.py
+++ b/fiftyone/core/odm/embedded_document.py
@@ -9,7 +9,7 @@ import mongoengine
 
 import fiftyone.core.utils as fou
 
-from .document import MongoEngineBaseDocument
+from .document import DynamicMixin, MongoEngineBaseDocument
 
 
 food = fou.lazy_import("fiftyone.core.odm.dataset")
@@ -19,6 +19,8 @@ class BaseEmbeddedDocument(MongoEngineBaseDocument):
     """Base class for documents that are embedded within other documents and
     therefore are not stored in their own collection in the database.
     """
+
+    pass
 
 
 class EmbeddedDocument(BaseEmbeddedDocument, mongoengine.EmbeddedDocument):
@@ -34,6 +36,7 @@ class EmbeddedDocument(BaseEmbeddedDocument, mongoengine.EmbeddedDocument):
 
 
 class DynamicEmbeddedDocument(
+    DynamicMixin,
     BaseEmbeddedDocument,
     mongoengine.DynamicEmbeddedDocument,
 ):

--- a/fiftyone/core/odm/runs.py
+++ b/fiftyone/core/odm/runs.py
@@ -19,6 +19,9 @@ from .embedded_document import EmbeddedDocument
 class RunDocument(EmbeddedDocument):
     """Description of a run on a dataset."""
 
+    # strict=False lets this class ignore unknown fields from other versions
+    meta = {"strict": False}
+
     key = StringField()
     version = StringField()
     timestamp = DateTimeField()

--- a/fiftyone/migrations/runner.py
+++ b/fiftyone/migrations/runner.py
@@ -55,7 +55,7 @@ def get_dataset_revision(name):
         the dataset revision string
     """
     conn = foo.get_db_conn()
-    dataset_doc = conn.datasets.find_one({"name": name})
+    dataset_doc = conn.datasets.find_one({"name": name}, {"version": 1})
     if dataset_doc is None:
         raise ValueError("Dataset '%s' not found" % name)
 

--- a/fiftyone/migrations/runner.py
+++ b/fiftyone/migrations/runner.py
@@ -103,9 +103,10 @@ def migrate_database_if_necessary(destination=None, verbose=False):
     use_client_version = destination is None
 
     if use_client_version:
-        destination = foc.VERSION
-        if _is_compatible_version(destination):
+        if _is_compatible_version(head):
             return
+
+        destination = foc.VERSION
 
     if head == destination:
         return
@@ -203,13 +204,14 @@ def migrate_dataset_if_necessary(name, destination=None, verbose=False):
     if head is None:
         head = "0.0"
 
-    if Version(head) > Version(foc.VERSION):
-        if not _is_compatible_version(head):
-            raise EnvironmentError(
-                "Cannot access dataset '%s' with v%s from client v%s "
-                "(compatibility %s)"
-                % (name, head, foc.VERSION, foc.COMPATIBLE_VERSIONS)
-            )
+    if Version(head) > Version(foc.VERSION) and not _is_compatible_version(
+        head
+    ):
+        raise EnvironmentError(
+            "Cannot access dataset '%s' with v%s from client v%s "
+            "(compatibility %s)"
+            % (name, head, foc.VERSION, foc.COMPATIBLE_VERSIONS)
+        )
 
     if destination is None:
         if _is_compatible_version(head):

--- a/fiftyone/migrations/runner.py
+++ b/fiftyone/migrations/runner.py
@@ -11,7 +11,6 @@ import os
 from packaging.requirements import Requirement
 from packaging.version import Version as V
 
-import eta.core.serial as etas
 import eta.core.utils as etau
 
 import fiftyone as fo
@@ -353,22 +352,6 @@ class MigrationRunner(object):
 
             fcn = etau.get_function(self.direction, module)
             fcn(client)
-
-
-class DatabaseConfig(etas.Serializable):
-    """Config for the database's state.
-
-    Args:
-        version (None): the ``fiftyone`` package version for which the database
-            is configured
-    """
-
-    def __init__(self, version=None):
-        self.version = version
-
-    @classmethod
-    def from_dict(cls, d):
-        return cls(**d)
 
 
 def _database_exists():

--- a/fiftyone/migrations/runner.py
+++ b/fiftyone/migrations/runner.py
@@ -8,6 +8,7 @@ FiftyOne migrations runner.
 import bisect
 import logging
 import os
+from packaging.requirements import Requirement
 from packaging.version import Version as V
 
 import eta.core.serial as etas
@@ -65,14 +66,15 @@ def migrate_all(destination=None, verbose=False):
     """Migrates the database and all datasets to the specified destination
     revision.
 
+    If no ``destination`` is provided, the database and each dataset will only
+    be migrated if their current versions are not compatible with the client's
+    version.
+
     Args:
         destination (None): the destination revision. By default, the
-            ``fiftyone`` package version is used
+            ``fiftyone`` client version is used
         verbose (False): whether to log incremental migrations that are run
     """
-    if destination is None:
-        destination = foc.VERSION
-
     migrate_database_if_necessary(destination=destination, verbose=verbose)
 
     for name in fo.list_datasets():
@@ -82,24 +84,28 @@ def migrate_all(destination=None, verbose=False):
 
 
 def migrate_database_if_necessary(destination=None, verbose=False):
-    """Migrates the database to the current revision of the ``fiftyone``
-    package, if necessary.
+    """Migrates the database to the specified revision, if necessary.
+
+    If no ``destination`` is provided, the database will only be migrated if
+    its current version is not compatible with the client's version.
 
     Args:
         destination (None): the destination revision. By default, the
-            ``fiftyone`` package version is used
+            ``fiftyone`` client version is used
         verbose (False): whether to log incremental migrations that are run
     """
     if _migrations_disabled():
         return
 
+    config = foo.get_db_config()
+    head = config.version
+
     use_client_version = destination is None
+
     if use_client_version:
         destination = foc.VERSION
-
-    config = foo.get_db_config()
-
-    head = config.version
+        if _is_compatible_version(destination):
+            return
 
     if head == destination:
         return
@@ -107,10 +113,16 @@ def migrate_database_if_necessary(destination=None, verbose=False):
     if not fo.config.database_admin:
         if use_client_version:
             raise EnvironmentError(
-                "Cannot connect to database v%s with client v%s when database_admin=%s. "
+                "Cannot connect to database v%s with client v%s "
+                "(compatibility v%s) when database_admin=%s. "
                 "See https://voxel51.com/docs/fiftyone/user_guide/config.html#database-migrations "
                 "for more information"
-                % (head, destination, fo.config.database_admin)
+                % (
+                    head,
+                    destination,
+                    foc.COMPATIBLE_VERSIONS,
+                    fo.config.database_admin,
+                )
             )
         else:
             raise EnvironmentError(
@@ -121,7 +133,7 @@ def migrate_database_if_necessary(destination=None, verbose=False):
             )
 
     if _database_exists():
-        runner = MigrationRunner(head=head, destination=destination)
+        runner = MigrationRunner(head, destination)
         if runner.has_admin_revisions:
             logger.info("Migrating database to v%s", destination)
             runner.run_admin(verbose=verbose)
@@ -137,11 +149,15 @@ def needs_migration(name=None, head=None, destination=None):
     To use this method, specify either the ``name`` of an existing dataset or
     provide the ``head`` revision of the dataset.
 
+    If no ``destination`` is provided, a dataset will always be deemed to
+    require no migration if its current version if compatible with the client's
+    version.
+
     Args:
         name (None): the name of the dataset
         head (None): the current revision of the dataset
-        destination (None): the destination revision. By default, the
-            ``fiftyone`` package version is used
+        destination (None): the destination revision. By default, the current
+            database version is used
 
     Returns:
         True/False
@@ -153,12 +169,15 @@ def needs_migration(name=None, head=None, destination=None):
         head = "0.0"
 
     if destination is None:
-        destination = foc.VERSION
+        if _is_compatible_version(head):
+            return False
+
+        destination = get_database_revision()
 
     if head == destination:
         return False
 
-    runner = MigrationRunner(head=head, destination=destination)
+    runner = MigrationRunner(head, destination)
     return runner.has_revisions
 
 
@@ -166,36 +185,51 @@ def migrate_dataset_if_necessary(name, destination=None, verbose=False):
     """Migrates the dataset from its current revision to the specified
     destination revision.
 
+    If no ``destination`` is provided, the dataset will only be migrated if
+    its current version is not compatible with the client's version.
+
     Args:
         name: the name of the dataset
-        destination (None): the destination revision. By default, the
-            ``fiftyone`` package version is used
+        destination (None): the destination revision. By default, the current
+            database version is used
         verbose (False): whether to log incremental migrations that are run
     """
     if _migrations_disabled():
         return
 
-    if destination is None:
-        destination = foc.VERSION
-
     head = get_dataset_revision(name)
+    db_version = get_database_revision()
 
     if head is None:
         head = "0.0"
 
+    if Version(head) > Version(foc.VERSION):
+        if not _is_compatible_version(head):
+            raise EnvironmentError(
+                "Cannot access dataset '%s' with v%s from client v%s "
+                "(compatibility %s)"
+                % (name, head, foc.VERSION, foc.COMPATIBLE_VERSIONS)
+            )
+
+    if destination is None:
+        if _is_compatible_version(head):
+            return
+
+        destination = db_version
+
     if head == destination:
         return
 
-    if not fo.config.database_admin and destination != foc.VERSION:
+    if not fo.config.database_admin and destination != db_version:
         raise EnvironmentError(
             "Cannot migrate dataset '%s' from v%s to v%s. Datasets can only "
             "be migrated to the current revision (v%s) when database_admin=%s."
             "See https://voxel51.com/docs/fiftyone/user_guide/config.html#database-migrations "
             "for more information"
-            % (name, head, destination, foc.VERSION, fo.config.database_admin)
+            % (name, head, destination, db_version, fo.config.database_admin)
         )
 
-    runner = MigrationRunner(head=head, destination=destination)
+    runner = MigrationRunner(head, destination)
     if runner.has_revisions:
         logger.info("Migrating dataset '%s' to v%s", name, destination)
         runner.run(name, verbose=verbose)
@@ -214,23 +248,17 @@ class MigrationRunner(object):
     """Class for running FiftyOne migrations.
 
     Args:
-        head (None): the current revision
-        destination (None): the destination revision
+        head: the current revision
+        destination: the destination revision
     """
 
     def __init__(
         self,
-        head=None,
-        destination=None,
+        head,
+        destination,
         _revisions=None,
         _admin_revisions=None,
     ):
-        if head is None:
-            head = foc.VERSION
-
-        if destination is None:
-            destination = foc.VERSION
-
         pkg_ver = Version(foc.VERSION)
         head_ver = Version(head)
         dest_ver = Version(destination)
@@ -344,6 +372,11 @@ class DatabaseConfig(etas.Serializable):
 def _database_exists():
     client = foo.get_db_client()
     return fo.config.database_name in client.list_database_names()
+
+
+def _is_compatible_version(version):
+    req = Requirement("fiftyone" + foc.COMPATIBLE_VERSIONS)
+    return req.specifier.contains(version)
 
 
 def _get_revisions_to_run(head, dest, revisions):

--- a/tests/unittests/utils_tests.py
+++ b/tests/unittests/utils_tests.py
@@ -188,29 +188,29 @@ class MigrationTests(unittest.TestCase):
             return [(v, v + ".py") for v in versions]
 
         runner = MigrationRunner(
-            head="0.0.1",
-            destination="0.3",
+            "0.0.1",
+            "0.3",
             _revisions=revs(["0.1", "0.2", "0.3"]),
         )
         self.assertEqual(runner.revisions, ["0.1", "0.2", "0.3"])
 
         runner = MigrationRunner(
-            head="0.1",
-            destination="0.3",
+            "0.1",
+            "0.3",
             _revisions=revs(["0.1", "0.2", "0.3"]),
         )
         self.assertEqual(runner.revisions, ["0.2", "0.3"])
 
         runner = MigrationRunner(
-            head="0.3",
-            destination="0.1",
+            "0.3",
+            "0.1",
             _revisions=revs(["0.1", "0.2", "0.3"]),
         )
         self.assertEqual(runner.revisions, ["0.3", "0.2"])
 
         runner = MigrationRunner(
-            head="0.3",
-            destination="0.0.1",
+            "0.3",
+            "0.0.1",
             _revisions=revs(["0.1", "0.2", "0.3"]),
         )
         self.assertEqual(runner.revisions, ["0.3", "0.2", "0.1"])
@@ -222,18 +222,18 @@ class MigrationTests(unittest.TestCase):
         # Uprading to a future version is not allowed
 
         with self.assertRaises(EnvironmentError):
-            MigrationRunner(destination=future_ver)
+            MigrationRunner(pkg_ver, future_ver)
 
         with self.assertRaises(EnvironmentError):
-            MigrationRunner(head="0.1", destination=future_ver)
+            MigrationRunner("0.1", future_ver)
 
         # Downgrading from a future version is not allowed
 
         with self.assertRaises(EnvironmentError):
-            MigrationRunner(head=future_ver)
+            MigrationRunner(future_ver, pkg_ver)
 
         with self.assertRaises(EnvironmentError):
-            MigrationRunner(head=future_ver, destination="0.1")
+            MigrationRunner(future_ver, "0.1")
 
 
 class UIDTests(unittest.TestCase):


### PR DESCRIPTION
This PR introduces a `fiftyone.constants.COMPATIBLE_VERSIONS` constant that allows a given FiftyOne version to declare that it is compatible with a range of other versions.

When clients running this patch encounter a dataset with a compatible version, they will not migrate the dataset (unless a migration was specifically requested via `fiftyone migrate`); instead the dataset will be loaded and used as-is.

For example, since this patch declares its compatibility as `>=0.16.3,<0.17`, you can connect to a database at version `0.16.3` without causing anything to be migrated.

This PR also converts all of the classes used in `DatasetDocument` to be non-strict, meaning that they will no longer raise a `ValidationError` if unknown fields are encountered when loading dataset docs from the database. This is a future-proofing change that will allow for wider compatibility between versions. For example, with this change, this branch could be compatible with a future client version that adds new fields to its dataset's `DatasetDocument` instances.