### PR TITLE
Fixing match_frames() bug

### DIFF
--- a/fiftyone/core/stages.py
+++ b/fiftyone/core/stages.py
@@ -6609,8 +6609,9 @@ _STAGES = [
 # Registry of stages that promise to only reorder/select documents
 _STAGES_THAT_SELECT_OR_REORDER = {
     # View stages that only reorder documents
-    SortBy,
     GroupBy,
+    SortBy,
+    SortBySimilarity,
     Shuffle,
     # View stages that only select documents
     Exclude,
@@ -6620,12 +6621,10 @@ _STAGES_THAT_SELECT_OR_REORDER = {
     GeoWithin,
     Limit,
     Match,
-    MatchFrames,
     MatchLabels,
     MatchTags,
     Select,
     SelectBy,
     Skip,
-    SortBySimilarity,
     Take,
 }

--- a/tests/unittests/view_tests.py
+++ b/tests/unittests/view_tests.py
@@ -1203,9 +1203,11 @@ class ViewSaveTest(unittest.TestCase):
         dataset.add_samples([sample1, sample2])
 
         view = dataset.limit(1).match_frames(F("frame_number") == 1)
+        sample = view.first()
 
         self.assertEqual(dataset.count("frames"), 4)
         self.assertEqual(view.count("frames"), 1)
+        self.assertEqual(len(sample.frames), 1)
 
         view.keep_frames()
 


### PR DESCRIPTION
Fixes a bug in `match_frames()` that was causing `sample.frames` to lookup all frames, even if the view filters the frames:

```py
import fiftyone as fo
import fiftyone.zoo as foz
from fiftyone import ViewField as F

dataset = foz.load_zoo_dataset("quickstart-video")

num_objects = F("detections.detections").length()
view = dataset.match_frames(num_objects == 28)
sample = view.first()

assert len(view) == 1

# Used to fail because all frames were being attached; now succeeds
assert len(sample.frames) == view.count("frames")
```
