### PR TITLE
Don't include runs when merging collections

### DIFF
--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -5348,28 +5348,6 @@ def _merge_dataset_doc(
 
     curr_doc.save()
 
-    if dataset:
-        if doc.annotation_runs:
-            logger.warning(
-                "Annotation runs cannot be merged into a non-empty dataset"
-            )
-
-        if doc.brain_methods:
-            logger.warning(
-                "Brain runs cannot be merged into a non-empty dataset"
-            )
-
-        if doc.evaluations:
-            logger.warning(
-                "Evaluations cannot be merged into a non-empty dataset"
-            )
-    else:
-        dataset.delete_annotation_runs()
-        dataset.delete_brain_runs()
-        dataset.delete_evaluations()
-
-        _clone_runs(dataset, doc)
-
 
 def _update_no_overwrite(d, dnew):
     d.update({k: v for k, v in dnew.items() if k not in d})

--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -4518,19 +4518,19 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
         return [k["key"][0][0] for k in index_info.values()]
 
     def _apply_field_schema(self, new_fields):
-        curr_fields = self.get_field_schema()
-        add_field_fcn = self.add_sample_field
-        self._apply_schema(curr_fields, new_fields, add_field_fcn)
-
-    def _apply_frame_field_schema(self, new_fields):
-        curr_fields = self.get_frame_field_schema()
-        add_field_fcn = self.add_frame_field
-        self._apply_schema(curr_fields, new_fields, add_field_fcn)
-
-    def _apply_schema(self, curr_fields, new_fields, add_field_fcn):
         for field_name, field_str in new_fields.items():
             ftype, embedded_doc_type, subfield = fof.parse_field_str(field_str)
-            add_field_fcn(
+            self.add_sample_field(
+                field_name,
+                ftype,
+                embedded_doc_type=embedded_doc_type,
+                subfield=subfield,
+            )
+
+    def _apply_frame_field_schema(self, new_fields):
+        for field_name, field_str in new_fields.items():
+            ftype, embedded_doc_type, subfield = fof.parse_field_str(field_str)
+            self.add_frame_field(
                 field_name,
                 ftype,
                 embedded_doc_type=embedded_doc_type,


### PR DESCRIPTION
For some reason, `add_samples()` and `add_collection()` had logic in-place to merge annotation/brain/evaluation runs into the destination dataset, but that doesn't make sense as runs are only valid for the particular `view` on which they were applied, which will not be the same (in general) when merging datasets.

There was already logic in-place to prevent merges when the destination dataset was non-empty, but there wasn't any logic to prevent runs from being merged when the source collection was a view, not a full dataset, which was definitely a bug. So the only valid use case is:

```py
new_dataset = fo.Dataset()
new_dataset.add_collection(dataset)
```

but that is better expressed as:

```py
new_dataset = dataset.clone()
```

So, I just removed this code :)
