### PR TITLE
Groups zoo fixes

### DIFF
--- a/fiftyone/utils/coco.py
+++ b/fiftyone/utils/coco.py
@@ -1317,7 +1317,7 @@ def parse_coco_categories(categories):
 
     classes = []
     supercategory_map = {}
-    for cat_id in range(max(cat_map) + 1):
+    for cat_id in range(max(cat_map, default=-1) + 1):
         category = cat_map.get(cat_id, None)
         try:
             name = category["name"]

--- a/fiftyone/utils/kitti.py
+++ b/fiftyone/utils/kitti.py
@@ -828,7 +828,7 @@ def _prepare_kitti_split(split_dir, overwrite=False):
         },
         "overlay": {
             "rotation": [-90, 0, 0],
-            "itemRotation": [0, 90, 0],
+            "itemRotation": [0, 90, 90],
         },
     }
     dataset.save()

--- a/fiftyone/utils/kitti.py
+++ b/fiftyone/utils/kitti.py
@@ -618,32 +618,32 @@ _LABELS = {
 _LEFT_IMAGES = {
     "url": "https://s3.eu-central-1.amazonaws.com/avg-kitti/data_object_image_2.zip",
     "contents": {
-        "train": ["data_object_image_2", "training", "image_2"],
-        "test": ["data_object_image_2", "testing", "image_2"],
+        "train": ["training", "image_2"],
+        "test": ["testing", "image_2"],
     },
 }
 
 _RIGHT_IMAGES = {
     "url": "https://s3.eu-central-1.amazonaws.com/avg-kitti/data_object_image_3.zip",
     "contents": {
-        "train": ["data_object_image_3", "training", "image_3"],
-        "test": ["data_object_image_3", "testing", "image_3"],
+        "train": ["training", "image_3"],
+        "test": ["testing", "image_3"],
     },
 }
 
 _VELODYNE = {
     "url": "https://s3.eu-central-1.amazonaws.com/avg-kitti/data_object_velodyne.zip",
     "contents": {
-        "train": ["data_object_velodyne", "training", "velodyne"],
-        "test": ["data_object_velodyne", "testing", "velodyne"],
+        "train": ["training", "velodyne"],
+        "test": ["testing", "velodyne"],
     },
 }
 
 _CALIB = {
     "url": "https://s3.eu-central-1.amazonaws.com/avg-kitti/data_object_calib.zip",
     "contents": {
-        "train": ["data_object_calib", "training", "calib"],
-        "test": ["data_object_calib", "testing", "calib"],
+        "train": ["training", "calib"],
+        "test": ["testing", "calib"],
     },
 }
 

--- a/fiftyone/utils/yolo.py
+++ b/fiftyone/utils/yolo.py
@@ -1121,7 +1121,7 @@ def _to_classes(labels_map_rev):
     targets_to_labels = {v: k for k, v in labels_map_rev.items()}
 
     classes = []
-    for target in range(max(targets_to_labels.keys()) + 1):
+    for target in range(max(targets_to_labels.keys(), default=-1) + 1):
         if target in targets_to_labels:
             classes.append(targets_to_labels[target])
         else:

--- a/fiftyone/zoo/datasets/__init__.py
+++ b/fiftyone/zoo/datasets/__init__.py
@@ -176,7 +176,7 @@ def load_zoo_dataset(
             with the same name if it exists
         overwrite (False): whether to overwrite any existing files if the
             dataset is to be downloaded
-        cleanup (None): whether to cleanup any temporary files generated during
+        cleanup (True): whether to cleanup any temporary files generated during
             download
         **kwargs: optional arguments to pass to the
             :class:`fiftyone.utils.data.importers.DatasetImporter` constructor.


### PR DESCRIPTION
- Fixes a bug that prevented `load_zoo_dataset("kitti-multiview", split="train")` from working properly
- Fixes the `itemRotation` setting for both `kitti-multiview` and `quickstart-groups` (the latter was achieved by uploading a new zip to Google Drive

