### PR TITLE
Adding support for linking directly to imported subpackage contents

### DIFF
--- a/docs/source/_includes/substitutions.rst
+++ b/docs/source/_includes/substitutions.rst
@@ -81,11 +81,11 @@
 .. |UnlabeledVideoSampleParser| replace:: :class:`UnlabeledVideoSampleParser <fiftyone.utils.data.parsers.UnlabeledVideoSampleParser>`
 .. |LabeledVideoSampleParser| replace:: :class:`LabeledVideoSampleParser <fiftyone.utils.data.parsers.LabeledVideoSampleParser>`
 
-.. |DatasetType| replace:: :class:`Dataset <fiftyone.types.dataset_types.Dataset>`
-.. |UnlabeledImageDatasetType| replace:: :class:`UnlabeledImageDataset <fiftyone.types.dataset_types.UnlabeledImageDataset>`
-.. |LabeledImageDatasetType| replace:: :class:`LabeledImageDataset <fiftyone.types.dataset_types.LabeledImageDataset>`
-.. |UnlabeledVideoDatasetType| replace:: :class:`UnlabeledVideoDataset <fiftyone.types.dataset_types.UnlabeledVideoDataset>`
-.. |LabeledVideoDatasetType| replace:: :class:`LabeledVideoDataset <fiftyone.types.dataset_types.LabeledVideoDataset>`
+.. |DatasetType| replace:: :class:`Dataset <fiftyone.types.Dataset>`
+.. |UnlabeledImageDatasetType| replace:: :class:`UnlabeledImageDataset <fiftyone.types.UnlabeledImageDataset>`
+.. |LabeledImageDatasetType| replace:: :class:`LabeledImageDataset <fiftyone.types.LabeledImageDataset>`
+.. |UnlabeledVideoDatasetType| replace:: :class:`UnlabeledVideoDataset <fiftyone.types.UnlabeledVideoDataset>`
+.. |LabeledVideoDatasetType| replace:: :class:`LabeledVideoDataset <fiftyone.types.LabeledVideoDataset>`
 
 .. |Metadata| replace:: :class:`Metadata <fiftyone.core.metadata.Metadata>`
 .. |ImageMetadata| replace:: :class:`ImageMetadata <fiftyone.core.metadata.ImageMetadata>`

--- a/docs/source/release-notes.rst
+++ b/docs/source/release-notes.rst
@@ -397,10 +397,9 @@ Core
 - Added a :meth:`keep_fields() <fiftyone.core.view.DatasetView.keep_fields>`
   method to |DatasetView| and its subclasses
   `#1616 <https://github.com/voxel51/fiftyone/pull/1616>`_
-- Added a :func:`fiftyone.core.plots.base.lines()` method that allows for
-  plotting lines whose scatter points can be interactively selected via the
-  typical
-  `interactive plotting workflows <https://voxel51.com/docs/fiftyone/user_guide/plots.html>`_
+- Added a :func:`lines() <fiftyone.core.plots.base.lines>` method that allows
+  for plotting lines whose scatter points can be interactively selected via the
+  typical `interactive plotting workflows <https://voxel51.com/docs/fiftyone/user_guide/plots.html>`_
   `#1614 <https://github.com/voxel51/fiftyone/pull/1614>`_
 - Added an optional `force_rgb=True` syntax when importing/exporting/creating
   TF records using all relevant methods in :mod:`fiftyone.utils.tf`
@@ -708,8 +707,7 @@ Core
   parent dataset that has brain runs
 - Fixed sampling frames when using
   :meth:`to_frames() <fiftyone.core.collections.SampleCollection.to_frames>`
-- Fixed importing of
-  :class:`FiftyOneDataset <fiftyone.types.dataset_types.FiftyOneDataset>`
+- Fixed importing of :class:`FiftyOneDataset <fiftyone.types.FiftyOneDataset>`
   with run results
 - Added a :class:`Regression <fiftyone.core.labels.Regression>` label type
 - Added a :func:`random_split() <fiftyone.utils.random.random_split>` method
@@ -725,9 +723,8 @@ Core
   :meth:`compute_max_ious() <fiftyone.utils.eval.detection.compute_max_ious>`
   utility
 - Added support for labels-only exports when working with
-  :class:`YOLOv4Dataset <fiftyone.types.dataset_types.YOLOv4Dataset>` and
-  :class:`YOLOv5Dataset <fiftyone.types.dataset_types.YOLOv5Dataset>`
-  formats
+  :class:`YOLOv4Dataset <fiftyone.types.YOLOv4Dataset>` and
+  :class:`YOLOv5Dataset <fiftyone.types.YOLOv5Dataset>` formats
 - Added :mod:`fiftyone.utils.beam` for parallel import, merge, and export
   operations with `Apache Beam <https://beam.apache.org>`_
 - Added an  :func:`add_yolo_labels() <fiftyone.utils.yolo.add_yolo_labels>`
@@ -1241,8 +1238,8 @@ Core
 - Added support for :ref:`importing <YOLOv5Dataset-import>` and
   :ref:`exporting <YOLOv5Dataset-export>` datasets in
   `YOLOv5 format <https://github.com/ultralytics/yolov5>`_
-- Updated the :class:`GeoJSONDataset <fiftyone.types.dataset_types.GeoJSONDataset>`
-  dataset type to support both image and video datasets
+- Updated the :class:`GeoJSONDataset <fiftyone.types.GeoJSONDataset>` dataset
+  type to support both image and video datasets
 - Added support for :class:`importing <fiftyone.utils.coco.COCODetectionDatasetImporter>`
   and :class:`exporting <fiftyone.utils.coco.COCODetectionDatasetExporter>` extra
   attributes in COCO format via a new ``extra_attrs`` parameter
@@ -1585,8 +1582,8 @@ Core
       an interacive scatterplot of a dataset via its |GeoLocation| coordinates
     - Added |GeoLocation| and |GeoLocations| label types that can be used to store
       arbitrary GeoJSON location data on samples
-    - Added the :class:`GeoJSONDataset <fiftyone.types.dataset_types.GeoJSONDataset>`
-      dataset type for importing and exporting datasets in GeoJSON format
+    - Added the :class:`GeoJSONDataset <fiftyone.types.GeoJSONDataset>` dataset
+      type for importing and exporting datasets in GeoJSON format
     - Added :meth:`SampleCollection.geo_near() <fiftyone.core.collections.SampleCollection.geo_near>`
       and
       :meth:`SampleCollection.geo_within() <fiftyone.core.collections.SampleCollection.geo_within>`
@@ -2302,8 +2299,7 @@ Core
   `CVAT video format <https://github.com/openvinotoolkit/cvat/blob/develop/cvat/apps/documentation/xml_format.md>`_
 - Added support for :ref:`importing <FiftyOneDataset-import>` and
   :ref:`exporting <FiftyOneDataset-export>` video datasets in
-  :class:`FiftyOneDataset <fiftyone.types.dataset_types.FiftyOneDataset>`
-  format
+  :class:`FiftyOneDataset <fiftyone.types.FiftyOneDataset>` format
 - Added frame field schemas to string representations for video datasets/views
 
 CLI
@@ -2581,7 +2577,7 @@ Core
 
 - Added support for :ref:`importing <FiftyOneDataset-import>` and
   :ref:`exporting <FiftyOneDataset-export>` FiftyOne datasets via the
-  :class:`FiftyOneDataset <fiftyone.types.dataset_types.FiftyOneDataset>` type
+  :class:`FiftyOneDataset <fiftyone.types.FiftyOneDataset>` type
 - Added a :meth:`Dataset.info <fiftyone.core.dataset.Dataset.info>` field that
   can be used to store dataset-level info in FiftyOne datasets
 - Added a :meth:`shuffle() <fiftyone.core.collections.SampleCollection.shuffle>`
@@ -2677,15 +2673,15 @@ App
 Core
 
 - Added support for importing and exporting datasets in several common formats:
-    - COCO: :class:`COCODetectionDataset <fiftyone.types.dataset_types.COCODetectionDataset>`
-    - VOC: :class:`VOCDetectionDataset <fiftyone.types.dataset_types.VOCDetectionDataset>`
-    - KITTI: :class:`KITTIDetectionDataset <fiftyone.types.dataset_types.KITTIDetectionDataset>`
+    - COCO: :class:`COCODetectionDataset <fiftyone.types.COCODetectionDataset>`
+    - VOC: :class:`VOCDetectionDataset <fiftyone.types.VOCDetectionDataset>`
+    - KITTI: :class:`KITTIDetectionDataset <fiftyone.types.KITTIDetectionDataset>`
     - Image classification TFRecords:
-      :class:`TFImageClassificationDataset <fiftyone.types.dataset_types.TFImageClassificationDataset>`
+      :class:`TFImageClassificationDataset <fiftyone.types.TFImageClassificationDataset>`
     - TF Object Detection API TFRecords:
-      :class:`TFObjectDetectionDataset <fiftyone.types.dataset_types.TFObjectDetectionDataset>`
-    - CVAT image: :class:`CVATImageDataset <fiftyone.types.dataset_types.CVATImageDataset>`
-    - Berkeley DeepDrive: :class:`BDDDataset <fiftyone.types.dataset_types.BDDDataset>`
+      :class:`TFObjectDetectionDataset <fiftyone.types.TFObjectDetectionDataset>`
+    - CVAT image: :class:`CVATImageDataset <fiftyone.types.CVATImageDataset>`
+    - Berkeley DeepDrive: :class:`BDDDataset <fiftyone.types.BDDDataset>`
 - Added :meth:`Dataset.add_dir() <fiftyone.core.dataset.Dataset.add_dir>` and
   :meth:`Dataset.from_dir() <fiftyone.core.dataset.Dataset.from_dir>` to allow
   for importing datasets on disk in any supported format

--- a/docs/source/user_guide/dataset_creation/datasets.rst
+++ b/docs/source/user_guide/dataset_creation/datasets.rst
@@ -164,9 +164,8 @@ Supported formats
 -----------------
 
 Each supported dataset type is represented by a subclass of
-:class:`fiftyone.types.Dataset <fiftyone.types.dataset_types.Dataset>`, which
-is used by the Python library and CLI to refer to the corresponding dataset
-format when reading the dataset from disk.
+:class:`fiftyone.types.Dataset`, which is used by the Python library and CLI to
+refer to the corresponding dataset format when reading the dataset from disk.
 
 .. table::
     :widths: 40 60
@@ -260,8 +259,8 @@ format when reading the dataset from disk.
 ImageDirectory
 --------------
 
-The :class:`fiftyone.types.ImageDirectory <fiftyone.types.dataset_types.ImageDirectory>`
-type represents a directory of images.
+The :class:`fiftyone.types.ImageDirectory` type represents a directory of
+images.
 
 Datasets of this type are read in the following format:
 
@@ -346,8 +345,8 @@ You can create a FiftyOne dataset from a directory of images as follows:
 VideoDirectory
 --------------
 
-The :class:`fiftyone.types.VideoDirectory <fiftyone.types.dataset_types.VideoDirectory>`
-type represents a directory of videos.
+The :class:`fiftyone.types.VideoDirectory` type represents a directory of
+videos.
 
 Datasets of this type are read in the following format:
 
@@ -432,9 +431,9 @@ You can create a FiftyOne dataset from a directory of videos as follows:
 FiftyOneImageClassificationDataset
 ----------------------------------
 
-The :class:`fiftyone.types.FiftyOneImageClassificationDataset <fiftyone.types.dataset_types.FiftyOneImageClassificationDataset>`
-type represents a labeled dataset consisting of images and their associated
-classification label(s) stored in a simple JSON format.
+The :class:`fiftyone.types.FiftyOneImageClassificationDataset` type represents
+a labeled dataset consisting of images and their associated classification
+label(s) stored in a simple JSON format.
 
 Datasets of this type are read in the following format:
 
@@ -640,9 +639,8 @@ directory containing the corresponding media files by providing the
 ImageClassificationDirectoryTree
 --------------------------------
 
-The :class:`fiftyone.types.ImageClassificationDirectoryTree <fiftyone.types.dataset_types.ImageClassificationDirectoryTree>`
-type represents a directory tree whose subfolders define an image
-classification dataset.
+The :class:`fiftyone.types.ImageClassificationDirectoryTree` type represents a
+directory tree whose subfolders define an image classification dataset.
 
 Datasets of this type are read in the following format:
 
@@ -734,9 +732,8 @@ stored in the above format as follows:
 VideoClassificationDirectoryTree
 --------------------------------
 
-The :class:`fiftyone.types.VideoClassificationDirectoryTree <fiftyone.types.dataset_types.VideoClassificationDirectoryTree>`
-type represents a directory tree whose subfolders define a video classification
-dataset.
+The :class:`fiftyone.types.VideoClassificationDirectoryTree` type represents a
+directory tree whose subfolders define a video classification dataset.
 
 Datasets of this type are read in the following format:
 
@@ -828,9 +825,9 @@ stored in the above format as follows:
 TFImageClassificationDataset
 ----------------------------
 
-The :class:`fiftyone.types.TFImageClassificationDataset <fiftyone.types.dataset_types.TFImageClassificationDataset>`
-type represents a labeled dataset consisting of images and their associated
-classification labels stored as
+The :class:`fiftyone.types.TFImageClassificationDataset` type represents a
+labeled dataset consisting of images and their associated classification labels
+stored as
 `TFRecords <https://www.tensorflow.org/tutorials/load_data/tfrecord>`_.
 
 Datasets of this type are read in the following format:
@@ -953,9 +950,9 @@ as a directory of TFRecords in the above format as follows:
 FiftyOneImageDetectionDataset
 -----------------------------
 
-The :class:`fiftyone.types.FiftyOneImageDetectionDataset <fiftyone.types.dataset_types.FiftyOneImageDetectionDataset>`
-type represents a labeled dataset consisting of images and their associated
-object detections stored in a simple JSON format.
+The :class:`fiftyone.types.FiftyOneImageDetectionDataset` type represents a
+labeled dataset consisting of images and their associated object detections
+stored in a simple JSON format.
 
 Datasets of this type are read in the following format:
 
@@ -1126,9 +1123,9 @@ directory containing the corresponding media files by providing the
 FiftyOneTemporalDetectionDataset
 --------------------------------
 
-The :class:`fiftyone.types.FiftyOneTemporalDetectionDataset <fiftyone.types.dataset_types.FiftyOneTemporalDetectionDataset>`
-type represents a labeled dataset consisting of videos and their associated
-temporal detections stored in a simple JSON format.
+The :class:`fiftyone.types.FiftyOneTemporalDetectionDataset` type represents a
+labeled dataset consisting of videos and their associated temporal detections
+stored in a simple JSON format.
 
 Datasets of this type are read in the following format:
 
@@ -1324,9 +1321,8 @@ directory containing the corresponding media files by providing the
 COCODetectionDataset
 --------------------
 
-The :class:`fiftyone.types.COCODetectionDataset <fiftyone.types.dataset_types.COCODetectionDataset>`
-type represents a labeled dataset consisting of images and their associated
-object detections saved in
+The :class:`fiftyone.types.COCODetectionDataset` type represents a labeled
+dataset consisting of images and their associated object detections saved in
 `COCO Object Detection Format <https://cocodataset.org/#format-data>`_.
 
 Datasets of this type are read in the following format:
@@ -1597,9 +1593,8 @@ COCO format:
 VOCDetectionDataset
 -------------------
 
-The :class:`fiftyone.types.VOCDetectionDataset <fiftyone.types.dataset_types.VOCDetectionDataset>`
-type represents a labeled dataset consisting of images and their associated
-object detections saved in
+The :class:`fiftyone.types.VOCDetectionDataset` type represents a labeled
+dataset consisting of images and their associated object detections saved in
 `VOC format <http://host.robots.ox.ac.uk/pascal/VOC>`_.
 
 Datasets of this type are read in the following format:
@@ -1782,9 +1777,8 @@ directory containing the corresponding media files by providing the
 KITTIDetectionDataset
 ---------------------
 
-The :class:`fiftyone.types.KITTIDetectionDataset <fiftyone.types.dataset_types.KITTIDetectionDataset>`
-type represents a labeled dataset consisting of images and their associated
-object detections saved in
+The :class:`fiftyone.types.KITTIDetectionDataset` type represents a labeled
+dataset consisting of images and their associated object detections saved in
 `KITTI format <http://www.cvlibs.net/datasets/kitti/eval_object.php>`_.
 
 Datasets of this type are read in the following format:
@@ -1957,9 +1951,8 @@ directory containing the corresponding media files by providing the
 YOLOv4Dataset
 -------------
 
-The :class:`fiftyone.types.YOLOv4Dataset <fiftyone.types.dataset_types.YOLOv4Dataset>`
-type represents a labeled dataset consisting of images and their associated
-object detections saved in
+The :class:`fiftyone.types.YOLOv4Dataset` type represents a labeled dataset
+consisting of images and their associated object detections saved in
 `YOLOv4 format <https://github.com/AlexeyAB/darknet>`_.
 
 Datasets of this type are read in the following format:
@@ -2191,9 +2184,8 @@ images-and-labels and labels-only data in YOLO format:
 YOLOv5Dataset
 -------------
 
-The :class:`fiftyone.types.YOLOv5Dataset <fiftyone.types.dataset_types.YOLOv5Dataset>`
-type represents a labeled dataset consisting of images and their associated
-object detections saved in
+The :class:`fiftyone.types.YOLOv5Dataset` type represents a labeled dataset
+consisting of images and their associated object detections saved in
 `YOLOv5 format <https://github.com/ultralytics/yolov5>`_.
 
 Datasets of this type are read in the following format:
@@ -2377,9 +2369,8 @@ images-and-labels and labels-only data in YOLO format:
 TFObjectDetectionDataset
 ------------------------
 
-The :class:`fiftyone.types.TFObjectDetectionDataset <fiftyone.types.dataset_types.TFObjectDetectionDataset>`
-type represents a labeled dataset consisting of images and their associated
-object detections stored as
+The :class:`fiftyone.types.TFObjectDetectionDataset` type represents a labeled
+dataset consisting of images and their associated object detections stored as
 `TFRecords <https://www.tensorflow.org/tutorials/load_data/tfrecord>`_ in
 `TF Object Detection API format <https://github.com/tensorflow/models/blob/master/research/object_detection>`_.
 
@@ -2528,9 +2519,9 @@ directory of TFRecords in the above format as follows:
 ImageSegmentationDirectory
 --------------------------
 
-The :class:`fiftyone.types.ImageSegmentationDirectory <fiftyone.types.dataset_types.ImageSegmentationDirectory>`
-type represents a labeled dataset consisting of images and their associated
-semantic segmentations stored as images on disk.
+The :class:`fiftyone.types.ImageSegmentationDirectory` type represents a
+labeled dataset consisting of images and their associated semantic
+segmentations stored as images on disk.
 
 Datasets of this type are read in the following format:
 
@@ -2666,9 +2657,8 @@ directory containing the corresponding media files by providing the
 CVATImageDataset
 ----------------
 
-The :class:`fiftyone.types.CVATImageDataset <fiftyone.types.dataset_types.CVATImageDataset>`
-type represents a labeled dataset consisting of images and their associated
-tags and object detections stored in
+The :class:`fiftyone.types.CVATImageDataset` type represents a labeled dataset
+consisting of images and their associated tags and object detections stored in
 `CVAT image format <https://github.com/opencv/cvat>`_.
 
 Datasets of this type are read in the following format:
@@ -2890,9 +2880,8 @@ directory containing the corresponding media files by providing the
 CVATVideoDataset
 ----------------
 
-The :class:`fiftyone.types.CVATVideoDataset <fiftyone.types.dataset_types.CVATVideoDataset>`
-type represents a labeled dataset consisting of videos and their associated
-object detections stored in
+The :class:`fiftyone.types.CVATVideoDataset` type represents a labeled dataset
+consisting of videos and their associated object detections stored in
 `CVAT video format <https://github.com/opencv/cvat>`_.
 
 Datasets of this type are read in the following format:
@@ -3118,10 +3107,9 @@ directory containing the corresponding media files by providing the
 OpenLABELImageDataset
 ---------------------
 
-The :class:`fiftyone.types.OpenLABELImageDataset <fiftyone.types.dataset_types.OpenLABELImageDataset>`
-type represents a labeled dataset consisting of images and their associated
-multitask predictions stored in
-`OpenLABEL format <https://www.asam.net/index.php?eID=dumpFile&t=f&f=3876&token=413e8c85031ae64cc35cf42d0768627514868b2f>`_.
+The :class:`fiftyone.types.OpenLABELImageDataset` type represents a labeled
+dataset consisting of images and their associated multitask predictions stored =
+in `OpenLABEL format <https://www.asam.net/index.php?eID=dumpFile&t=f&f=3876&token=413e8c85031ae64cc35cf42d0768627514868b2f>`_.
 
 OpenLABEL is a flexible format which allows labels to be stored in a variety of
 different ways with respect to the corresponding media files. The following
@@ -3412,10 +3400,9 @@ directory containing the corresponding media files by providing the
 OpenLABELVideoDataset
 ---------------------
 
-The :class:`fiftyone.types.OpenLABELVideoDataset <fiftyone.types.dataset_types.OpenLABELVideoDataset>`
-type represents a labeled dataset consisting of videos and their associated
-multitask predictions stored in
-`OpenLABEL format <https://www.asam.net/index.php?eID=dumpFile&t=f&f=3876&token=413e8c85031ae64cc35cf42d0768627514868b2f>`_.
+The :class:`fiftyone.types.OpenLABELVideoDataset` type represents a labeled
+dataset consisting of videos and their associated multitask predictions stored
+in `OpenLABEL format <https://www.asam.net/index.php?eID=dumpFile&t=f&f=3876&token=413e8c85031ae64cc35cf42d0768627514868b2f>`_.
 
 OpenLABEL is a flexible format which allows labels to be stored in a variety of
 different ways with respect to the corresponding media files. The following
@@ -3702,9 +3689,9 @@ directory containing the corresponding media files by providing the
 FiftyOneImageLabelsDataset
 --------------------------
 
-The :class:`fiftyone.types.FiftyOneImageLabelsDataset <fiftyone.types.dataset_types.FiftyOneImageLabelsDataset>`
-type represents a labeled dataset consisting of images and their associated
-multitask predictions stored in
+The :class:`fiftyone.types.FiftyOneImageLabelsDataset` type represents a
+labeled dataset consisting of images and their associated multitask predictions
+stored in
 `ETA ImageLabels format <https://github.com/voxel51/eta/blob/develop/docs/image_labels_guide.md>`_.
 
 Datasets of this type are read in the following format:
@@ -3818,9 +3805,8 @@ above format as follows:
 FiftyOneVideoLabelsDataset
 --------------------------
 
-The :class:`fiftyone.types.FiftyOneVideoLabelsDataset <fiftyone.types.dataset_types.FiftyOneVideoLabelsDataset>`
-type represents a labeled dataset consisting of videos and their associated
-labels stored in
+The :class:`fiftyone.types.FiftyOneVideoLabelsDataset` type represents a
+labeled dataset consisting of videos and their associated labels stored in
 `ETA VideoLabels format <https://github.com/voxel51/eta/blob/develop/docs/video_labels_guide.md>`_.
 
 Datasets of this type are read in the following format:
@@ -3934,9 +3920,8 @@ above format as follows:
 BDDDataset
 ----------
 
-The :class:`fiftyone.types.BDDDataset <fiftyone.types.dataset_types.BDDDataset>`
-type represents a labeled dataset consisting of images and their associated
-multitask predictions saved in
+The :class:`fiftyone.types.BDDDataset` type represents a labeled dataset
+consisting of images and their associated multitask predictions saved in
 `Berkeley DeepDrive (BDD) format <https://bdd-data.berkeley.edu>`_.
 
 Datasets of this type are read in the following format:
@@ -4160,9 +4145,9 @@ directory containing the corresponding media files by providing the
 DICOMDataset
 ------------
 
-The :class:`fiftyone.types.DICOMDataset <fiftyone.types.dataset_types.DICOMDataset>`
-type represents a dataset consisting of images and their associated properties
-stored in `DICOM format <https://en.wikipedia.org/wiki/DICOM>`_.
+The :class:`fiftyone.types.DICOMDataset` type represents a dataset consisting
+of images and their associated properties stored in
+`DICOM format <https://en.wikipedia.org/wiki/DICOM>`_.
 
 .. note::
 
@@ -4318,10 +4303,9 @@ path to a DICOMDIR file as follows:
 GeoJSONDataset
 --------------
 
-The :class:`fiftyone.types.GeoJSONDataset <fiftyone.types.dataset_types.GeoJSONDataset>`
-type represents a dataset consisting of images or videos and their associated
-geolocation data and optional properties stored in
-`GeoJSON format <https://en.wikipedia.org/wiki/GeoJSON>`_.
+The :class:`fiftyone.types.GeoJSONDataset` type represents a dataset consisting
+of images or videos and their associated geolocation data and optional
+properties stored in `GeoJSON format <https://en.wikipedia.org/wiki/GeoJSON>`_.
 
 Datasets of this type are read in the following format:
 
@@ -4501,9 +4485,9 @@ directory containing the corresponding media files by providing the
 GeoTIFFDataset
 --------------
 
-The :class:`fiftyone.types.GeoTIFFDataset <fiftyone.types.dataset_types.GeoTIFFDataset>`
-type represents a dataset consisting of images and their associated geolocation
-data stored in `GeoTIFF format <https://en.wikipedia.org/wiki/GeoTIFF>`_.
+The :class:`fiftyone.types.GeoTIFFDataset` type represents a dataset consisting
+of images and their associated geolocation data stored in
+`GeoTIFF format <https://en.wikipedia.org/wiki/GeoTIFF>`_.
 
 .. note::
 
@@ -4645,9 +4629,8 @@ as follows:
 FiftyOneDataset
 ---------------
 
-The :class:`fiftyone.types.FiftyOneDataset <fiftyone.types.dataset_types.FiftyOneDataset>`
-provides a disk representation of an entire |Dataset| in a serialized JSON
-format along with its source media.
+The :class:`fiftyone.types.FiftyOneDataset` provides a disk representation of
+an entire |Dataset| in a serialized JSON format along with its source media.
 
 Datasets of this type are read in the following format:
 

--- a/docs/source/user_guide/dataset_creation/samples.rst
+++ b/docs/source/user_guide/dataset_creation/samples.rst
@@ -665,20 +665,17 @@ You can use a |SampleParser| to
 | <fiftyone.utils.data.parsers.ImageLabelsSampleParser>`                 | `ETA ImageLabels format <https://github.com/voxel51/eta/blob/develop/docs/image_labels_guide.md>`_.             |
 +------------------------------------------------------------------------+-----------------------------------------------------------------------------------------------------------------+
 | :class:`FiftyOneImageClassificationSampleParser                        | Parser for samples in FiftyOne image classification datasets. See                                               |
-| <fiftyone.utils.data.parsers.FiftyOneImageClassificationSampleParser>` | :class:`FiftyOneImageClassificationDataset <fiftyone.types.dataset_types.FiftyOneImageClassificationDataset>`   |
-|                                                                        | for format details.                                                                                             |
+| <fiftyone.utils.data.parsers.FiftyOneImageClassificationSampleParser>` | :class:`FiftyOneImageClassificationDataset <fiftyone.types.FiftyOneImageClassificationDataset>` for format      |
+|                                                                        | details.                                                                                                        |
 +------------------------------------------------------------------------+-----------------------------------------------------------------------------------------------------------------+
 | :class:`FiftyOneImageDetectionSampleParser                             | Parser for samples in FiftyOne image detection datasets. See                                                    |
-| <fiftyone.utils.data.parsers.FiftyOneImageDetectionSampleParser>`      | :class:`FiftyOneImageDetectionDataset <fiftyone.types.dataset_types.FiftyOneImageDetectionDataset>` for format  |
-|                                                                        | details.                                                                                                        |
+| <fiftyone.utils.data.parsers.FiftyOneImageDetectionSampleParser>`      | :class:`FiftyOneImageDetectionDataset <fiftyone.types.FiftyOneImageDetectionDataset>` for format details.       |
 +------------------------------------------------------------------------+-----------------------------------------------------------------------------------------------------------------+
 | :class:`FiftyOneImageLabelsSampleParser                                | Parser for samples in FiftyOne image labels datasets. See                                                       |
-| <fiftyone.utils.data.parsers.FiftyOneImageLabelsSampleParser>`         | :class:`FiftyOneImageLabelsDataset <fiftyone.types.dataset_types.FiftyOneImageLabelsDataset>` for format        |
-|                                                                        | details.                                                                                                        |
+| <fiftyone.utils.data.parsers.FiftyOneImageLabelsSampleParser>`         | :class:`FiftyOneImageLabelsDataset <fiftyone.types.FiftyOneImageLabelsDataset>` for format details.             |
 +------------------------------------------------------------------------+-----------------------------------------------------------------------------------------------------------------+
 | :class:`FiftyOneVideoLabelsSampleParser                                | Parser for samples in FiftyOne video labels datasets. See                                                       |
-| <fiftyone.utils.data.parsers.FiftyOneVideoLabelsSampleParser>`         | :class:`FiftyOneVideoLabelsDataset <fiftyone.types.dataset_types.FiftyOneVideoLabelsDataset>` for format        |
-|                                                                        | details.                                                                                                        |
+| <fiftyone.utils.data.parsers.FiftyOneVideoLabelsSampleParser>`         | :class:`FiftyOneVideoLabelsDataset <fiftyone.types.FiftyOneVideoLabelsDataset>` for format details.             |
 +------------------------------------------------------------------------+-----------------------------------------------------------------------------------------------------------------+
 | :class:`TFImageClassificationSampleParser                              | Parser for image classification samples stored as                                                               |
 | <fiftyone.utils.tf.TFImageClassificationSampleParser>`                 | `TFRecords <https://www.tensorflow.org/tutorials/load_data/tfrecord>`_.                                         |

--- a/docs/source/user_guide/export_datasets.rst
+++ b/docs/source/user_guide/export_datasets.rst
@@ -406,9 +406,8 @@ Supported formats
 -----------------
 
 Each supported dataset type is represented by a subclass of
-:class:`fiftyone.types.Dataset <fiftyone.types.dataset_types.Dataset>`, which
-is used by the Python library and CLI to refer to the corresponding dataset
-format when writing the dataset to disk.
+:class:`fiftyone.types.Dataset`, which is used by the Python library and CLI to
+refer to the corresponding dataset format when writing the dataset to disk.
 
 .. table::
     :widths: 40 60
@@ -492,8 +491,8 @@ format when writing the dataset to disk.
 ImageDirectory
 --------------
 
-The :class:`fiftyone.types.ImageDirectory <fiftyone.types.dataset_types.ImageDirectory>`
-type represents a directory of images.
+The :class:`fiftyone.types.ImageDirectory` type represents a directory of
+images.
 
 Datasets of this type are exported in the following format:
 
@@ -550,8 +549,8 @@ disk as follows:
 VideoDirectory
 --------------
 
-The :class:`fiftyone.types.VideoDirectory <fiftyone.types.dataset_types.VideoDirectory>`
-type represents a directory of videos.
+The :class:`fiftyone.types.VideoDirectory` type represents a directory of
+videos.
 
 Datasets of this type are exported in the following format:
 
@@ -613,9 +612,9 @@ FiftyOneImageClassificationDataset
 
     |Classification|, |Classifications|
 
-The :class:`fiftyone.types.FiftyOneImageClassificationDataset <fiftyone.types.dataset_types.FiftyOneImageClassificationDataset>`
-type represents a labeled dataset consisting of images and their associated
-classification label(s) stored in a simple JSON format.
+The :class:`fiftyone.types.FiftyOneImageClassificationDataset` type represents
+a labeled dataset consisting of images and their associated classification
+label(s) stored in a simple JSON format.
 
 Datasets of this type are exported in the following format:
 
@@ -839,9 +838,8 @@ ImageClassificationDirectoryTree
 
     |Classification|
 
-The :class:`fiftyone.types.ImageClassificationDirectoryTree <fiftyone.types.dataset_types.ImageClassificationDirectoryTree>`
-type represents a directory tree whose subfolders define an image
-classification dataset.
+The :class:`fiftyone.types.ImageClassificationDirectoryTree` type represents a
+directory tree whose subfolders define an image classification dataset.
 
 Datasets of this type are exported in the following format:
 
@@ -916,9 +914,8 @@ VideoClassificationDirectoryTree
 
     |Classification|
 
-The :class:`fiftyone.types.VideoClassificationDirectoryTree <fiftyone.types.dataset_types.VideoClassificationDirectoryTree>`
-type represents a directory tree whose subfolders define a video classification
-dataset.
+The :class:`fiftyone.types.VideoClassificationDirectoryTree` type represents a
+directory tree whose subfolders define a video classification dataset.
 
 Datasets of this type are exported in the following format:
 
@@ -993,9 +990,9 @@ TFImageClassificationDataset
 
     |Classification|
 
-The :class:`fiftyone.types.TFImageClassificationDataset <fiftyone.types.dataset_types.TFImageClassificationDataset>`
-type represents a labeled dataset consisting of images and their associated
-classification labels stored as
+The :class:`fiftyone.types.TFImageClassificationDataset` type represents a
+labeled dataset consisting of images and their associated classification labels
+stored as
 `TFRecords <https://www.tensorflow.org/tutorials/load_data/tfrecord>`_.
 
 Datasets of this type are exported in the following format:
@@ -1091,9 +1088,9 @@ FiftyOneImageDetectionDataset
 
     |Detections|
 
-The :class:`fiftyone.types.FiftyOneImageDetectionDataset <fiftyone.types.dataset_types.FiftyOneImageDetectionDataset>`
-type represents a labeled dataset consisting of images and their associated
-object detections stored in a simple JSON format.
+The :class:`fiftyone.types.FiftyOneImageDetectionDataset` type represents a
+labeled dataset consisting of images and their associated object detections
+stored in a simple JSON format.
 
 Datasets of this type are exported in the following format:
 
@@ -1283,9 +1280,9 @@ FiftyOneTemporalDetectionDataset
 
     |TemporalDetections|
 
-The :class:`fiftyone.types.FiftyOneTemporalDetectionDataset <fiftyone.types.dataset_types.FiftyOneTemporalDetectionDataset>`
-type represents a labeled dataset consisting of videos and their associated
-temporal detections stored in a simple JSON format.
+The :class:`fiftyone.types.FiftyOneTemporalDetectionDataset` type represents a
+labeled dataset consisting of videos and their associated temporal detections
+stored in a simple JSON format.
 
 Datasets of this type are exported in the following format:
 
@@ -1501,9 +1498,8 @@ COCODetectionDataset
 
     |Detections|, |Polylines|
 
-The :class:`fiftyone.types.COCODetectionDataset <fiftyone.types.dataset_types.COCODetectionDataset>`
-type represents a labeled dataset consisting of images and their associated
-object detections saved in
+The :class:`fiftyone.types.COCODetectionDataset` type represents a labeled
+dataset consisting of images and their associated object detections saved in
 `COCO Object Detection Format <https://cocodataset.org/#format-data>`_.
 
 Datasets of this type are exported in the following format:
@@ -1683,9 +1679,8 @@ VOCDetectionDataset
 
     |Detections|
 
-The :class:`fiftyone.types.VOCDetectionDataset <fiftyone.types.dataset_types.VOCDetectionDataset>`
-type represents a labeled dataset consisting of images and their associated
-object detections saved in
+The :class:`fiftyone.types.VOCDetectionDataset` type represents a labeled
+dataset consisting of images and their associated object detections saved in
 `VOC format <http://host.robots.ox.ac.uk/pascal/VOC>`_.
 
 Datasets of this type are exported in the following format:
@@ -1848,9 +1843,8 @@ KITTIDetectionDataset
 
     |Detections|
 
-The :class:`fiftyone.types.KITTIDetectionDataset <fiftyone.types.dataset_types.KITTIDetectionDataset>`
-type represents a labeled dataset consisting of images and their associated
-object detections saved in
+The :class:`fiftyone.types.KITTIDetectionDataset` type represents a labeled
+dataset consisting of images and their associated object detections saved in
 `KITTI format <http://www.cvlibs.net/datasets/kitti/eval_object.php>`_.
 
 Datasets of this type are exported in the following format:
@@ -2003,9 +1997,8 @@ YOLOv4Dataset
 
     |Detections|
 
-The :class:`fiftyone.types.YOLOv4Dataset <fiftyone.types.dataset_types.YOLOv4Dataset>`
-type represents a labeled dataset consisting of images and their associated
-object detections saved in
+The :class:`fiftyone.types.YOLOv4Dataset` type represents a labeled dataset
+consisting of images and their associated object detections saved in
 `YOLOv4 format <https://github.com/AlexeyAB/darknet>`_.
 
 Datasets of this type are exported in the following format:
@@ -2158,9 +2151,8 @@ YOLOv5Dataset
 
     |Detections|
 
-The :class:`fiftyone.types.YOLOv5Dataset <fiftyone.types.dataset_types.YOLOv5Dataset>`
-type represents a labeled dataset consisting of images and their associated
-object detections saved in
+The :class:`fiftyone.types.YOLOv5Dataset` type represents a labeled dataset
+consisting of images and their associated object detections saved in
 `YOLOv5 format <https://github.com/ultralytics/yolov5>`_.
 
 Datasets of this type are exported in the following format:
@@ -2306,9 +2298,8 @@ TFObjectDetectionDataset
 
     |Detections|
 
-The :class:`fiftyone.types.TFObjectDetectionDataset <fiftyone.types.dataset_types.TFObjectDetectionDataset>`
-type represents a labeled dataset consisting of images and their associated
-object detections stored as
+The :class:`fiftyone.types.TFObjectDetectionDataset` type represents a labeled
+dataset consisting of images and their associated object detections stored as
 `TFRecords <https://www.tensorflow.org/tutorials/load_data/tfrecord>`_ in
 `TF Object Detection API format <https://github.com/tensorflow/models/blob/master/research/object_detection>`_.
 
@@ -2438,9 +2429,9 @@ ImageSegmentationDirectory
 
     |Segmentation|, |Detections|, |Polylines|
 
-The :class:`fiftyone.types.ImageSegmentationDirectory <fiftyone.types.dataset_types.ImageSegmentationDirectory>`
-type represents a labeled dataset consisting of images and their associated
-semantic segmentations stored as images on disk.
+The :class:`fiftyone.types.ImageSegmentationDirectory` type represents a
+labeled dataset consisting of images and their associated semantic
+segmentations stored as images on disk.
 
 Datasets of this type are exported in the following format:
 
@@ -2559,9 +2550,8 @@ CVATImageDataset
 
     |Classifications|, |Detections|, |Polylines|, |Keypoints|
 
-The :class:`fiftyone.types.CVATImageDataset <fiftyone.types.dataset_types.CVATImageDataset>`
-type represents a labeled dataset consisting of images and their associated
-tags and object detections stored in
+The :class:`fiftyone.types.CVATImageDataset` type represents a labeled dataset
+consisting of images and their associated tags and object detections stored in
 `CVAT image format <https://github.com/opencv/cvat>`_.
 
 Datasets of this type are exported in the following format:
@@ -2766,9 +2756,8 @@ CVATVideoDataset
 
     |Detections|, |Polylines|, |Keypoints|
 
-The :class:`fiftyone.types.CVATVideoDataset <fiftyone.types.dataset_types.CVATVideoDataset>`
-type represents a labeled dataset consisting of videos and their associated
-object detections stored in
+The :class:`fiftyone.types.CVATVideoDataset` type represents a labeled dataset
+consisting of videos and their associated object detections stored in
 `CVAT video format <https://github.com/opencv/cvat>`_.
 
 Datasets of this type are exported in the following format:
@@ -2974,9 +2963,9 @@ FiftyOneImageLabelsDataset
 
     |Classifications|, |Detections|, |Polylines|, |Keypoints|
 
-The :class:`fiftyone.types.FiftyOneImageLabelsDataset <fiftyone.types.dataset_types.FiftyOneImageLabelsDataset>`
-type represents a labeled dataset consisting of images and their associated
-multitask predictions stored in
+The :class:`fiftyone.types.FiftyOneImageLabelsDataset` type represents a
+labeled dataset consisting of images and their associated multitask predictions
+stored in
 `ETA ImageLabels format <https://github.com/voxel51/eta/blob/develop/docs/image_labels_guide.md>`_.
 
 Datasets of this type are exported in the following format:
@@ -3075,9 +3064,8 @@ FiftyOneVideoLabelsDataset
 
     |Classifications|, |Detections|, |TemporalDetections|, |Polylines|, |Keypoints|
 
-The :class:`fiftyone.types.FiftyOneVideoLabelsDataset <fiftyone.types.dataset_types.FiftyOneVideoLabelsDataset>`
-type represents a labeled dataset consisting of videos and their associated
-labels stored in
+The :class:`fiftyone.types.FiftyOneVideoLabelsDataset` type represents a
+labeled dataset consisting of videos and their associated labels stored in
 `ETA VideoLabels format <https://github.com/voxel51/eta/blob/develop/docs/video_labels_guide.md>`_.
 
 Datasets of this type are exported in the following format:
@@ -3176,9 +3164,8 @@ BDDDataset
 
     |Classifications|, |Detections|, |Polylines|
 
-The :class:`fiftyone.types.BDDDataset <fiftyone.types.dataset_types.BDDDataset>`
-type represents a labeled dataset consisting of images and their associated
-multitask predictions saved in
+The :class:`fiftyone.types.BDDDataset` type represents a labeled dataset
+consisting of images and their associated multitask predictions saved in
 `Berkeley DeepDrive (BDD) format <https://bdd-data.berkeley.edu>`_.
 
 Datasets of this type are exported in the following format:
@@ -3375,10 +3362,9 @@ the `labels_path` parameter instead of `export_dir`:
 GeoJSONDataset
 --------------
 
-The :class:`fiftyone.types.GeoJSONDataset <fiftyone.types.dataset_types.GeoJSONDataset>`
-type represents a dataset consisting of images or videos and their associated
-geolocation data and optional properties stored in
-`GeoJSON format <https://en.wikipedia.org/wiki/GeoJSON>`_.
+The :class:`fiftyone.types.GeoJSONDataset` type represents a dataset consisting
+of images or videos and their associated geolocation data and optional
+properties stored in `GeoJSON format <https://en.wikipedia.org/wiki/GeoJSON>`_.
 
 Datasets of this type are exported in the following format:
 
@@ -3527,9 +3513,8 @@ providing the `labels_path` parameter instead of `export_dir`:
 FiftyOneDataset
 ---------------
 
-The :class:`fiftyone.types.FiftyOneDataset <fiftyone.types.dataset_types.FiftyOneDataset>`
-provides a disk representation of an entire |Dataset| in a serialized JSON
-format along with its source media.
+The :class:`fiftyone.types.FiftyOneDataset` provides a disk representation of
+an entire |Dataset| in a serialized JSON format along with its source media.
 
 Datasets of this type are exported in the following format:
 
@@ -3675,14 +3660,13 @@ image's filepath, and then provide the new `rel_dir` when
 
 .. note::
 
-    Exporting in
-    :class:`fiftyone.types.FiftyOneDataset <fiftyone.types.dataset_types.FiftyOneDataset>`
-    format as shown above using the `export_media=False` and `rel_dir`
-    parameters is a convenient way to transfer datasets between work
-    environments, since this enables you to store the media files wherever you
-    wish in each environment and then simply provide the appropriate `rel_dir`
-    value when :ref:`importing <FiftyOneDataset-import>` the dataset into
-    FiftyOne in a new environment.
+    Exporting in :class:`fiftyone.types.FiftyOneDataset` format as shown above
+    using the `export_media=False` and `rel_dir` parameters is a convenient way
+    to transfer datasets between work environments, since this enables you to
+    store the media files wherever you wish in each environment and then simply
+    provide the appropriate `rel_dir` value when
+    :ref:`importing <FiftyOneDataset-import>` the dataset into FiftyOne in a
+    new environment.
 
 .. _custom-dataset-exporter:
 

--- a/docs/source/user_guide/plots.rst
+++ b/docs/source/user_guide/plots.rst
@@ -5,8 +5,7 @@ Interactive Plots
 
 .. default-role:: code
 
-FiftyOne provides a powerful
-:mod:`fiftyone.core.plots <fiftyone.core.plots.base>` framework that contains
+FiftyOne provides a powerful :mod:`fiftyone.core.plots` framework that contains
 a variety of interactive plotting methods that enable you to visualize your
 datasets and uncover patterns that are not apparent from inspecting either the
 :ref:`raw media files <fiftyone-app>` or
@@ -1230,8 +1229,7 @@ property of the plot:
 Plotting backend
 ----------------
 
-Most plotting methods in the
-:meth:`fiftyone.core.plots <fiftyone.core.plots.base>` module provide an
+Most plotting methods in the :meth:`fiftyone.core.plots` module provide an
 optional ``backend`` parameter that you can use to control the plotting backend
 used to render plots.
 

--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -6605,9 +6605,9 @@ class SampleCollection(object):
                 If an archive path is specified, the export is performed in a
                 directory of same name (minus extension) and then automatically
                 archived and the directory then deleted
-            dataset_type (None): the
-                :class:`fiftyone.types.dataset_types.Dataset` type to write. If
-                not specified, the default type for ``label_field`` is used
+            dataset_type (None): the :class:`fiftyone.types.Dataset` type to
+                write. If not specified, the default type for ``label_field``
+                is used
             data_path (None): an optional parameter that enables explicit
                 control over the location of the exported media for certain
                 export formats. Can be any of the following:

--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -2555,9 +2555,8 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
             dataset_dir (None): the dataset directory. This can be omitted for
                 certain dataset formats if you provide arguments such as
                 ``data_path`` and ``labels_path``
-            dataset_type (None): the
-                :class:`fiftyone.types.dataset_types.Dataset` type of the
-                dataset
+            dataset_type (None): the :class:`fiftyone.types.Dataset` type of
+                the dataset
             data_path (None): an optional parameter that enables explicit
                 control over the location of the media for certain dataset
                 types. Can be any of the following:
@@ -2713,9 +2712,8 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
             dataset_dir (None): the dataset directory. This can be omitted for
                 certain dataset formats if you provide arguments such as
                 ``data_path`` and ``labels_path``
-            dataset_type (None): the
-                :class:`fiftyone.types.dataset_types.Dataset` type of the
-                dataset
+            dataset_type (None): the :class:`fiftyone.types.Dataset` type of
+                the dataset
             data_path (None): an optional parameter that enables explicit
                 control over the location of the media for certain dataset
                 types. Can be any of the following:
@@ -2867,9 +2865,8 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
 
         Args:
             archive_path: the path to an archive of a dataset directory
-            dataset_type (None): the
-                :class:`fiftyone.types.dataset_types.Dataset` type of the
-                dataset in ``archive_path``
+            dataset_type (None): the :class:`fiftyone.types.Dataset` type of
+                the dataset in ``archive_path``
             data_path (None): an optional parameter that enables explicit
                 control over the location of the media for certain dataset
                 types. Can be any of the following:
@@ -3018,9 +3015,8 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
 
         Args:
             archive_path: the path to an archive of a dataset directory
-            dataset_type (None): the
-                :class:`fiftyone.types.dataset_types.Dataset` type of the
-                dataset in ``archive_path``
+            dataset_type (None): the :class:`fiftyone.types.Dataset` type of
+                the dataset in ``archive_path``
             data_path (None): an optional parameter that enables explicit
                 control over the location of the media for certain dataset
                 types. Can be any of the following:
@@ -3395,9 +3391,8 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
     def add_images_dir(self, images_dir, tags=None, recursive=True):
         """Adds the given directory of images to the dataset.
 
-        See :class:`fiftyone.types.dataset_types.ImageDirectory` for format
-        details. In particular, note that files with non-image MIME types are
-        omitted.
+        See :class:`fiftyone.types.ImageDirectory` for format details. In
+        particular, note that files with non-image MIME types are omitted.
 
         This operation does not read the images.
 
@@ -3629,9 +3624,8 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
     def add_videos_dir(self, videos_dir, tags=None, recursive=True):
         """Adds the given directory of videos to the dataset.
 
-        See :class:`fiftyone.types.dataset_types.VideoDirectory` for format
-        details. In particular, note that files with non-video MIME types are
-        omitted.
+        See :class:`fiftyone.types.VideoDirectory` for format details. In
+        particular, note that files with non-video MIME types are omitted.
 
         This operation does not read/decode the videos.
 
@@ -3786,9 +3780,8 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
         Args:
             dataset_dir (None): the dataset directory. This can be omitted if
                 you provide arguments such as ``data_path`` and ``labels_path``
-            dataset_type (None): the
-                :class:`fiftyone.types.dataset_types.Dataset` type of the
-                dataset
+            dataset_type (None): the :class:`fiftyone.types.Dataset` type of
+                the dataset
             data_path (None): an optional parameter that enables explicit
                 control over the location of the media for certain dataset
                 types. Can be any of the following:
@@ -3895,9 +3888,8 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
 
         Args:
             archive_path: the path to an archive of a dataset directory
-            dataset_type (None): the
-                :class:`fiftyone.types.dataset_types.Dataset` type of the
-                dataset in ``archive_path``
+            dataset_type (None): the :class:`fiftyone.types.Dataset` type of
+                the dataset in ``archive_path``
             data_path (None): an optional parameter that enables explicit
                 control over the location of the media for certain dataset
                 types. Can be any of the following:

--- a/fiftyone/core/odm/__init__.py
+++ b/fiftyone/core/odm/__init__.py
@@ -5,6 +5,8 @@ ODM package declaration.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+import types
+
 from .database import (
     aggregate,
     get_db_config,
@@ -65,3 +67,10 @@ from .utils import (
     get_field_kwargs,
     get_implied_field_kwargs,
 )
+
+# This enables Sphinx refs to directly use paths imported here
+__all__ = [
+    k
+    for k, v in globals().items()
+    if not k.startswith("_") and not isinstance(v, types.ModuleType)
+]

--- a/fiftyone/core/plots/__init__.py
+++ b/fiftyone/core/plots/__init__.py
@@ -5,6 +5,7 @@ Plotting framework.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+import types
 
 from .base import (
     plot_confusion_matrix,
@@ -26,3 +27,10 @@ from .views import (
     CategoricalHistogram,
     NumericalHistogram,
 )
+
+# This enables Sphinx refs to directly use paths imported here
+__all__ = [
+    k
+    for k, v in globals().items()
+    if not k.startswith("_") and not isinstance(v, types.ModuleType)
+]

--- a/fiftyone/core/plots/manager.py
+++ b/fiftyone/core/plots/manager.py
@@ -28,7 +28,7 @@ logger = logging.getLogger(__name__)
 class PlotManager(object):
     """Class that manages communication between a
     :class:`fiftyone.core.session.Session` and one or more
-    :class:`ResponsivePlot` instances.
+    :class:`fiftyone.core.plots.base.ResponsivePlot` instances.
 
     Each plot can be linked to either the view, samples, frames, or labels of a
     session:
@@ -291,7 +291,7 @@ class PlotManager(object):
             name: the name of a plot
 
         Returns:
-            the :class:`ResponsivePlot`
+            the :class:`fiftyone.core.plots.base.ResponsivePlot`
         """
         if name not in self._plots:
             raise ValueError("No plot with name '%s'" % name)

--- a/fiftyone/core/plots/manager.py
+++ b/fiftyone/core/plots/manager.py
@@ -168,7 +168,8 @@ class PlotManager(object):
         """Returns an iterator over the plots in this manager.
 
         Returns:
-            an iterator that emits :class:`ResponsivePlot` instances
+            an iterator that emits
+            :class:`fiftyone.core.plots.base.ResponsivePlot` instances
         """
         return self._plots.values()
 

--- a/fiftyone/core/session/__init__.py
+++ b/fiftyone/core/session/__init__.py
@@ -5,6 +5,13 @@ Session definitions for interacting with the FiftyOne App.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+import types
+
 from .session import close_app, launch_app, Session
 
-__all__ = ["close_app", "launch_app", "Session"]
+# This enables Sphinx refs to directly use paths imported here
+__all__ = [
+    k
+    for k, v in globals().items()
+    if not k.startswith("_") and not isinstance(v, types.ModuleType)
+]

--- a/fiftyone/core/session/client.py
+++ b/fiftyone/core/session/client.py
@@ -1,5 +1,5 @@
 """
-Session server-sent events client
+Session server-sent events client.
 
 | Copyright 2017-2022, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_

--- a/fiftyone/core/session/events.py
+++ b/fiftyone/core/session/events.py
@@ -1,5 +1,5 @@
 """
-Session events
+Session events.
 
 | Copyright 2017-2022, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_

--- a/fiftyone/core/session/notebooks.py
+++ b/fiftyone/core/session/notebooks.py
@@ -1,5 +1,5 @@
 """
-Session notebook handling
+Session notebook handling.
 
 | Copyright 2017-2022, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_

--- a/fiftyone/core/session/session.py
+++ b/fiftyone/core/session/session.py
@@ -1,5 +1,5 @@
 """
-Session class for interacting with the FiftyOne App
+Session class for interacting with the FiftyOne App.
 
 | Copyright 2017-2022, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
@@ -194,8 +194,8 @@ def update_state(auto_show: bool = False) -> t.Callable:
     """:class:`Session` method decorator for triggering state update events
 
     Args:
-        auto_show (False): whether the method should show a new notebook App cell as
-            well, if ``auto`` is ``True``
+        auto_show (False): whether the method should show a new notebook App
+            cell as well, if ``auto`` is ``True``
 
     Returns:
         the decorated method

--- a/fiftyone/migrations/__init__.py
+++ b/fiftyone/migrations/__init__.py
@@ -5,6 +5,8 @@ FiftyOne's migration interface.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+import types
+
 from .runner import (
     get_database_revision,
     get_dataset_revision,
@@ -13,3 +15,10 @@ from .runner import (
     migrate_dataset_if_necessary,
     needs_migration,
 )
+
+# This enables Sphinx refs to directly use paths imported here
+__all__ = [
+    k
+    for k, v in globals().items()
+    if not k.startswith("_") and not isinstance(v, types.ModuleType)
+]

--- a/fiftyone/types/__init__.py
+++ b/fiftyone/types/__init__.py
@@ -5,5 +5,13 @@ FiftyOne types.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
-# pylint: disable=wildcard-import,unused-wildcard-import
+import types
+
 from .dataset_types import *
+
+# This enables Sphinx refs to directly use paths imported here
+__all__ = [
+    k
+    for k, v in globals().items()
+    if not k.startswith("_") and not isinstance(v, types.ModuleType)
+]

--- a/fiftyone/utils/cityscapes.py
+++ b/fiftyone/utils/cityscapes.py
@@ -42,7 +42,7 @@ def parse_cityscapes_dataset(
 ):
     """Parses the Cityscapes archive(s) in the specified directory and writes
     the requested splits in subdirectories of ``dataset_dir`` in
-    :class:`fiftyone.types.dataset_types.FiftyOneDataset` format.
+    :class:`fiftyone.types.FiftyOneDataset` format.
 
     The archives must have been manually downloaded into the directory before
     this method is called.

--- a/fiftyone/utils/data/__init__.py
+++ b/fiftyone/utils/data/__init__.py
@@ -5,9 +5,18 @@ Data utilities.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+import types
+
 from .base import *
 from .converters import *
 from .exporters import *
 from .importers import *
 from .ingestors import *
 from .parsers import *
+
+# This enables Sphinx refs to directly use paths imported here
+__all__ = [
+    k
+    for k, v in globals().items()
+    if not k.startswith("_") and not isinstance(v, types.ModuleType)
+]

--- a/fiftyone/utils/data/base.py
+++ b/fiftyone/utils/data/base.py
@@ -111,8 +111,7 @@ def download_image_classification_dataset(
     unique.
 
     The dataset is written to disk in
-    :class:`fiftyone.types.dataset_types.FiftyOneImageClassificationDataset`
-    format.
+    :class:`fiftyone.types.FiftyOneImageClassificationDataset` format.
 
     Args:
         csv_path: a CSV file containing the labels and image URLs

--- a/fiftyone/utils/data/converters.py
+++ b/fiftyone/utils/data/converters.py
@@ -42,8 +42,8 @@ def convert_dataset(
 
     Args:
         input_dir (None): the input dataset directory
-        input_type (None): the :class:`fiftyone.types.dataset_types.Dataset`
-            type of the dataset in ``input_dir``
+        input_type (None): the :class:`fiftyone.types.Dataset` type of the
+            dataset in ``input_dir``
         input_kwargs (None): optional kwargs dict to pass to the constructor of
             the :class:`fiftyone.utils.data.importers.DatasetImporter` for the
             ``input_type`` you specify
@@ -51,8 +51,8 @@ def convert_dataset(
             :class:`fiftyone.utils.data.importers.DatasetImporter` to use to
             import the input dataset
         output_dir (None): the directory to which to write the output dataset
-        output_type (None): the :class:`fiftyone.types.dataset_types.Dataset`
-            type to write to ``output_dir``
+        output_type (None): the :class:`fiftyone.types.Dataset` type to write
+            to ``output_dir``
         output_kwargs (None): optional kwargs dict to pass to the constructor
             of the :class:`fiftyone.utils.data.exporters.DatasetExporter` for
             the ``output_type`` you specify

--- a/fiftyone/utils/data/exporters.py
+++ b/fiftyone/utils/data/exporters.py
@@ -115,8 +115,7 @@ def export_samples(
         samples: a :class:`fiftyone.core.collections.SampleCollection`
         export_dir (None): the directory to which to export the samples in
             format ``dataset_type``
-        dataset_type (None): the :class:`fiftyone.types.dataset_types.Dataset`
-            type to write
+        dataset_type (None): the :class:`fiftyone.types.Dataset` type to write
         data_path (None): an optional parameter that enables explicit control
             over the location of the exported media for certain export formats.
             Can be any of the following:
@@ -419,7 +418,7 @@ def build_dataset_exporter(
     """Builds the :class:`DatasetExporter` instance for the given parameters.
 
     Args:
-        dataset_type: the :class:`fiftyone.types.dataset_types.Dataset` type
+        dataset_type: the :class:`fiftyone.types.Dataset` type
         strip_none (True): whether to exclude None-valued items from ``kwargs``
         warn_unused (True): whether to issue warnings for any non-None unused
             parameters encountered
@@ -1481,9 +1480,9 @@ class LegacyFiftyOneDatasetExporter(GenericSampleDatasetExporter):
 
     .. warning::
 
-        The :class:`fiftyone.types.dataset_types.FiftyOneDataset` format was
-        upgraded in ``fiftyone==0.8`` and this exporter is now deprecated.
-        The new exporter is :class:`FiftyOneDatasetExporter`.
+        The :class:`fiftyone.types.FiftyOneDataset` format was upgraded in
+        ``fiftyone==0.8`` and this exporter is now deprecated. The new exporter
+        is :class:`FiftyOneDatasetExporter`.
 
     Args:
         export_dir: the directory to write the export

--- a/fiftyone/utils/data/importers.py
+++ b/fiftyone/utils/data/importers.py
@@ -486,7 +486,7 @@ def build_dataset_importer(
     """Builds the :class:`DatasetImporter` instance for the given parameters.
 
     Args:
-        dataset_type: the :class:`fiftyone.types.dataset_types.Dataset` type
+        dataset_type: the :class:`fiftyone.types.Dataset` type
         strip_none (True): whether to exclude None-valued items from ``kwargs``
         warn_unused (True): whether to issue warnings for any non-None unused
             parameters encountered
@@ -1239,8 +1239,8 @@ class LegacyFiftyOneDatasetImporter(GenericSampleDatasetImporter):
 
     .. warning::
 
-        The :class:`fiftyone.types.dataset_types.FiftyOneDataset` format was
-        upgraded in ``fiftyone==0.8`` and this importer is now deprecated.
+        The :class:`fiftyone.types.FiftyOneDataset` format was upgraded in
+        ``fiftyone==0.8`` and this importer is now deprecated.
 
         However, to maintain backwards compatibility,
         :class:`FiftyOneDatasetImporter` will check for instances of datasets

--- a/fiftyone/utils/eval/__init__.py
+++ b/fiftyone/utils/eval/__init__.py
@@ -5,6 +5,8 @@ Evaluation utilities.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+import types
+
 from .classification import (
     evaluate_classifications,
     ClassificationResults,
@@ -22,3 +24,11 @@ from .segmentation import (
     evaluate_segmentations,
     SegmentationResults,
 )
+
+# This tells Sphinx to allow refs to imported objects in this module
+# https://stackoverflow.com/a/31594545/16823653
+__all__ = [
+    k
+    for k, v in globals().items()
+    if not k.startswith("_") and not isinstance(v, types.ModuleType)
+]

--- a/fiftyone/utils/openimages.py
+++ b/fiftyone/utils/openimages.py
@@ -34,8 +34,7 @@ logger = logging.getLogger(__name__)
 class OpenImagesV6DatasetImporter(foud.LabeledImageDatasetImporter):
     """Base class for importing datasets in Open Images V6 format.
 
-    See :class:`fiftyone.types.dataset_types.OpenImagesV6Dataset` for format
-    details.
+    See :class:`fiftyone.types.OpenImagesV6Dataset` for format details.
 
     Args:
         dataset_dir: the dataset directory
@@ -462,8 +461,8 @@ def download_open_images_split(
     """Utility that downloads full or partial splits of the
     `Open Images dataset <https://storage.googleapis.com/openimages/web/index.html>`_.
 
-    See :class:`fiftyone.types.dataset_types.OpenImagesV6Dataset` for the
-    format in which ``dataset_dir`` will be arranged.
+    See :class:`fiftyone.types.OpenImagesV6Dataset` for the format in which
+    ``dataset_dir`` will be arranged.
 
     Any existing files are not re-downloaded.
 

--- a/fiftyone/zoo/__init__.py
+++ b/fiftyone/zoo/__init__.py
@@ -4,5 +4,14 @@ The FiftyOne Zoo.
 Copyright 2017-2022, Voxel51, Inc.
 voxel51.com
 """
+import types
+
 from .datasets import *
 from .models import *
+
+# This enables Sphinx refs to directly use paths imported here
+__all__ = [
+    k
+    for k, v in globals().items()
+    if not k.startswith("_") and not isinstance(v, types.ModuleType)
+]

--- a/fiftyone/zoo/datasets/__init__.py
+++ b/fiftyone/zoo/datasets/__init__.py
@@ -535,8 +535,7 @@ class ZooDatasetInfo(etas.Serializable):
 
     Args:
         zoo_dataset: the :class:`ZooDataset` instance for the dataset
-        dataset_type: the :class:`fiftyone.types.dataset_types.Dataset` type of
-            the dataset
+        dataset_type: the :class:`fiftyone.types.Dataset` type of the dataset
         num_samples: the total number of samples in all downloaded splits of
             the dataset
         downloaded_splits (None): a dict of :class:`ZooDatasetSplitInfo`
@@ -583,7 +582,7 @@ class ZooDatasetInfo(etas.Serializable):
     @property
     def dataset_type(self):
         """The fully-qualified class string of the
-        :class:`fiftyone.types.dataset_types.Dataset` type.
+        :class:`fiftyone.types.Dataset` type.
         """
         return etau.get_class_name(self._dataset_type)
 
@@ -603,11 +602,11 @@ class ZooDatasetInfo(etas.Serializable):
         return self._zoo_dataset
 
     def get_dataset_type(self):
-        """Returns the :class:`fiftyone.types.dataset_types.Dataset` type
-        instance for the dataset.
+        """Returns the :class:`fiftyone.types.Dataset` type instance for the
+        dataset.
 
         Returns:
-            a :class:`fiftyone.types.dataset_types.Dataset` instance
+            a :class:`fiftyone.types.Dataset` instance
         """
         return self._dataset_type
 
@@ -1078,8 +1077,8 @@ class ZooDataset(object):
         Returns:
             tuple of
 
-            -   dataset_type: the :class:`fiftyone.types.dataset_types.Dataset`
-                type of the dataset
+            -   dataset_type: the :class:`fiftyone.types.Dataset` type of the
+                dataset
             -   num_samples: the number of samples in the split. For datasets
                 that support partial downloads, this can be ``None``, which
                 indicates that all content was already downloaded
@@ -1199,7 +1198,7 @@ def _migrate_zoo_dataset_info(d):
         migrated = True
 
     # @legacy dataset type names
-    _dt = "fiftyone.types.dataset_types"
+    _dt = "fiftyone.types"
     if dataset_type.endswith(".ImageClassificationDataset"):
         dataset_type = _dt + ".FiftyOneImageClassificationDataset"
         migrated = True


### PR DESCRIPTION
This PR adds the following block of code to all `__init__.py` files that import symbols that are intended to be exposed in FiftyOne's public namespace using `path.to.package.symbol` rather than `path.to.package.module.symbol`:

```py
# This enables Sphinx refs to directly use paths imported here
__all__ = [
    k
    for k, v in globals().items()
    if not k.startswith("_") and not isinstance(v, types.ModuleType)
]
```

The reason I'm adding this code is to allow Sphinx to understand references to imported symbols. For example, we allow users to use `fiftyone.types.Dataset` rather than the full `fiftyone.types.dataset_types.Dataset`. But, prior to this PR, docstrings had to use the full `:class:fiftyone.types.dataset_types.Dataset`. Now docstrings may choose to use the abbreviated `:class:fiftyone.types.Dataset` (and I updated all such references in the docs to use the abbreviated form as a proof of concept).

I believe @benjaminpkane was thinking along similar lines when he manually added `__all__` to `fiftyone/core/session.__init__.py` when he split `fiftyone.core.session` into submodules, because that was required to avoid breaking (or having to manually change) all `:class:fiftyone.core.session.Session` references in the code/docs. This PR effectively future-proofs all other such cases.

### Implementation detail

The funny `globals()` syntax is because it would be tedious (although, tbh, more proper) to update certain imports like this:

```py
from .base import *
from .converters import *
from .exporters import *
from .importers import *
from .ingestors import *
from .parsers import *
```

into explicit imports and corresponding `__all__` statements.