### PR TITLE
Improving groups migration

### DIFF
--- a/fiftyone/core/cli.py
+++ b/fiftyone/core/cli.py
@@ -2592,11 +2592,6 @@ class MigrateCommand(Command):
             )
             return
 
-        fom.migrate_database_if_necessary(
-            destination=args.version,
-            verbose=args.verbose,
-        )
-
         if args.dataset_name:
             for name in args.dataset_name:
                 fom.migrate_dataset_if_necessary(
@@ -2605,6 +2600,11 @@ class MigrateCommand(Command):
                     error_level=args.error_level,
                     verbose=args.verbose,
                 )
+        else:
+            fom.migrate_database_if_necessary(
+                destination=args.version,
+                verbose=args.verbose,
+            )
 
 
 def _print_migration_table(db_ver, dataset_vers):

--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -5745,15 +5745,11 @@ def _do_load_dataset(name, virtual=False):
         raise ValueError("Dataset '%s' not found" % name)
 
     sample_collection_name = dataset_doc.sample_collection_name
+    frame_collection_name = dataset_doc.frame_collection_name
+
     sample_doc_cls = _create_sample_document_cls(
         sample_collection_name, field_docs=dataset_doc.sample_fields
     )
-
-    for sample_field in dataset_doc.sample_fields:
-        if sample_field.name not in sample_doc_cls._fields:
-            sample_doc_cls._declare_field(sample_field)
-
-    frame_collection_name = dataset_doc.frame_collection_name
 
     if sample_collection_name.startswith("clips."):
         # Clips datasets directly inherit frames from source dataset
@@ -5768,29 +5764,11 @@ def _do_load_dataset(name, virtual=False):
             frame_collection_name, field_docs=dataset_doc.frame_fields
         )
 
-        if _contains_videos(dataset_doc):
-            for frame_field in dataset_doc.frame_fields:
-                if frame_field.name not in frame_doc_cls._fields:
-                    frame_doc_cls._declare_field(frame_field)
-
     if not virtual:
         dataset_doc.last_loaded_at = datetime.utcnow()
         dataset_doc.save()
 
     return dataset_doc, sample_doc_cls, frame_doc_cls
-
-
-def _contains_videos(dataset_doc):
-    if dataset_doc.media_type == fom.VIDEO:
-        return True
-
-    if (dataset_doc.media_type == fom.GROUP) and any(
-        slice_media_type == fom.VIDEO
-        for slice_media_type in dataset_doc.group_media_types.values()
-    ):
-        return True
-
-    return False
 
 
 def _delete_dataset_doc(dataset_doc):

--- a/fiftyone/core/odm/dataset.py
+++ b/fiftyone/core/odm/dataset.py
@@ -498,10 +498,7 @@ class DatasetDocument(Document):
     default_group_slice = StringField()
     tags = ListField(StringField())
     info = DictField()
-    app_config = EmbeddedDocumentField(
-        document_type=DatasetAppConfig,
-        default=lambda: DatasetAppConfig(),
-    )
+    app_config = EmbeddedDocumentField(document_type=DatasetAppConfig)
     classes = DictField(ClassesField())
     default_classes = ClassesField()
     mask_targets = DictField(TargetsField())

--- a/fiftyone/migrations/revisions/v0_17_0.py
+++ b/fiftyone/migrations/revisions/v0_17_0.py
@@ -21,7 +21,13 @@ def up(db, dataset_name):
         dataset_dict["default_group_slice"] = None
 
     if "app_config" not in dataset_dict:
-        dataset_dict["app_config"] = {}
+        dataset_dict["app_config"] = {
+            "media_fields": ["filepath"],
+            "grid_media_field": "filepath",
+            "modal_media_field": "filepath",
+            "sidebar_groups": None,
+            "plugins": {},
+        }
 
     if "app_sidebar_groups" in dataset_dict:
         dataset_dict["app_config"]["sidebar_groups"] = dataset_dict.pop(


### PR DESCRIPTION
The original impetus for this PR was to update the v0.17.0 migration so that a valid `DatasetAppConfig` is inserted by the migration itself. Previously `app_config == {}` was being inserted, which led to default values being populated by `load_dataset()` but *not* getting persisted to the database because `doc.save()` wasn't detecting any changes. This is bad because anything (eg GraphQL) that tries to pull directly from the DB wouldn't have the correct data available to it.

Along the way, I removed some unnecessary code from `_load_dataset()` that was redeclaring `sample_fields` and `frame_fields` and then immediately re-saving the dataset doc, even though this data was already properly defined. The implementation of `_load_dataset()` now has the property that the only field that may be changed is `last_loaded_at`, which makes sense. I verified that this change is valid like so:

```shell
fiftyone zoo datasets load quickstart
fiftyone migrate -n quickstart -v 0.8
```

```py
import fiftyone as fo
dataset = fo.load_dataset("quickstart")
session = fo.launch_app(dataset)
```
