### PR TITLE
Adding rel_dir to export() and draw_labels()

### DIFF
--- a/docs/source/getting_started/install.rst
+++ b/docs/source/getting_started/install.rst
@@ -272,11 +272,11 @@ Here's the workflow for downgrading to an older version of FiftyOne:
     # Migrate the database
     fiftyone migrate --all -v $VERSION
 
-    # Optional: verify that your datasets were migrated
-    fiftyone migrate --info
-
     # Now install the older version of `fiftyone`
     pip install fiftyone==$VERSION
+
+    # Optional: verify that your datasets were migrated
+    fiftyone migrate --info
 
 If you are reading this after encountering an error resulting from downgrading
 your ``fiftyone`` package without first running

--- a/docs/source/user_guide/dataset_creation/datasets.rst
+++ b/docs/source/user_guide/dataset_creation/datasets.rst
@@ -76,6 +76,22 @@ that you're loading.
             labels_path=labels_path,
         )
 
+    Many formats like :ref:`COCO <COCODetectionDataset-import>` also support
+    storing absolute filepaths to the source media directly in the labels, in
+    which case you can provide only the `labels_path` parameter:
+
+    .. code-block:: python
+        :linenos:
+
+        # The path to a COCO labels JSON file containing absolute image paths
+        labels_path = "/path/to/coco-labels.json"
+
+        # Import the dataset
+        dataset = fo.Dataset.from_dir(
+            dataset_type=fo.types.COCODetectionDataset,
+            labels_path=labels_path,
+        )
+
     In general, you can pass any parameter for the |DatasetImporter| of the
     format you're importing to
     :meth:`Dataset.from_dir() <fiftyone.core.dataset.Dataset.from_dir>`. For
@@ -140,6 +156,20 @@ that you're loading.
             --kwargs \
                 data_path=$DATA_PATH \
                 labels_path=$LABELS_PATH
+
+    Many formats like :ref:`COCO <COCODetectionDataset-import>` also support
+    storing absolute filepaths to the source media directly in the labels, in
+    which case you can provide only the `labels_path` parameter:
+
+    .. code-block:: shell
+
+        # The path to a COCO labels JSON file containing absolute image paths
+        LABELS_PATH=/path/to/coco-labels.json
+
+        # Import the dataset
+        fiftyone datasets create --name my-dataset \
+            --type fiftyone.types.COCODetectionDataset \
+            --kwargs labels_path=$LABELS_PATH
 
     In general, you can pass any parameter for the |DatasetImporter| of the
     format you're importing via the
@@ -471,7 +501,8 @@ The target value in `labels` for unlabeled images is `None` (or missing).
 
 The UUIDs can also be relative paths like `path/to/uuid`, in which case the
 images in `data/` should be arranged in nested subfolders with the
-corresponding names.
+corresponding names, or they can be absolute paths, in which case the images
+may or may not be in `data/`.
 
 Alternatively, `labels.json` can contain predictions with associated
 confidences and additional attributes in the following format:
@@ -633,6 +664,11 @@ directory containing the corresponding media files by providing the
             --kwargs \
                 data_path=$DATA_PATH \
                 labels_path=$LABELS_PATH
+
+.. note::
+
+    If the UUIDs in your labels are absolute paths to the source media, then
+    you can omit the `data_path` parameter from the example above.
 
 .. _ImageClassificationDirectoryTree-import:
 
@@ -1008,7 +1044,8 @@ The target value in `labels` for unlabeled images is `None` (or missing).
 
 The UUIDs can also be relative paths like `path/to/uuid`, in which case the
 images in `data/` should be arranged in nested subfolders with the
-corresponding names.
+corresponding names, or they can be absolute paths, in which case the images
+may or may not be in `data/`.
 
 .. note::
 
@@ -1118,6 +1155,11 @@ directory containing the corresponding media files by providing the
                 data_path=$DATA_PATH \
                 labels_path=$LABELS_PATH
 
+.. note::
+
+    If the UUIDs in your labels are absolute paths to the source media, then
+    you can omit the `data_path` parameter from the example above.
+
 .. _FiftyOneTemporalDetectionDataset-import:
 
 FiftyOneTemporalDetectionDataset
@@ -1207,7 +1249,8 @@ Unlabeled videos can have a `None` (or missing) key in `labels`.
 
 The UUIDs can also be relative paths like `path/to/uuid`, in which case the
 images in `data/` should be arranged in nested subfolders with the
-corresponding names.
+corresponding names, or they can be absolute paths, in which case the images
+may or may not be in `data/`.
 
 .. note::
 
@@ -1315,6 +1358,11 @@ directory containing the corresponding media files by providing the
             --kwargs \
                 data_path=$DATA_PATH \
                 labels_path=$LABELS_PATH
+
+.. note::
+
+    If the UUIDs in your labels are absolute paths to the source media, then
+    you can omit the `data_path` parameter from the example above.
 
 .. _COCODetectionDataset-import:
 
@@ -1527,6 +1575,11 @@ directory containing the corresponding media files by providing the
             --kwargs \
                 data_path=$DATA_PATH \
                 labels_path=$LABELS_PATH
+
+.. note::
+
+    If the `file_name` key of your labels contains absolute paths to the source
+    media, then you can omit the `data_path` parameter from the example above.
 
 If you have an existing dataset and corresponding model predictions stored in
 COCO format, then you can use
@@ -1771,6 +1824,12 @@ directory containing the corresponding media files by providing the
             --kwargs \
                 data_path=$DATA_PATH \
                 labels_path=$LABELS_PATH
+
+.. note::
+
+    If the `<path>` field of your labels are populated with the absolute paths
+    to the source media, then you can omit the `data_path` parameter from the
+    example above.
 
 .. _KITTIDetectionDataset-import:
 
@@ -2874,6 +2933,11 @@ directory containing the corresponding media files by providing the
             --kwargs \
                 data_path=$DATA_PATH \
                 labels_path=$LABELS_PATH
+
+.. note::
+
+    If the `name` key of your labels contains absolute paths to the source
+    media, then you can omit the `data_path` parameter from the example above.
 
 .. _CVATVideoDataset-import:
 
@@ -4138,7 +4202,7 @@ directory containing the corresponding media files by providing the
 .. note::
 
     If the `name` key of your labels contains absolute paths to the source
-    media, then you can omit `data_path` parameter from the example above.
+    media, then you can omit the `data_path` parameter from the example above.
 
 .. _DICOMDataset-import:
 

--- a/docs/source/user_guide/dataset_creation/datasets.rst
+++ b/docs/source/user_guide/dataset_creation/datasets.rst
@@ -95,7 +95,7 @@ that you're loading.
     In general, you can pass any parameter for the |DatasetImporter| of the
     format you're importing to
     :meth:`Dataset.from_dir() <fiftyone.core.dataset.Dataset.from_dir>`. For
-    example, all importers should support optional `max_samples`, `shuffle`,
+    example, most builtin importers support optional `max_samples`, `shuffle`,
     and `seed` parameters, which provide support for importing a small subset
     of a potentially large dataset:
 
@@ -173,8 +173,8 @@ that you're loading.
 
     In general, you can pass any parameter for the |DatasetImporter| of the
     format you're importing via the
-    :ref:`kwargs option <cli-fiftyone-datasets-create>`. For example, all
-    importers should support optional `max_samples`, `shuffle`, and `seed`
+    :ref:`kwargs option <cli-fiftyone-datasets-create>`. For example, most
+    builtin importers support optional `max_samples`, `shuffle`, and `seed`
     parameters, which provide support for importing a small subset of a
     potentially large dataset:
 

--- a/docs/source/user_guide/export_datasets.rst
+++ b/docs/source/user_guide/export_datasets.rst
@@ -650,6 +650,10 @@ IDs that are mapped to class label strings via `classes[target]`. If no
 `classes` are included, then the `target` values directly store the label
 strings.
 
+If you provide the optional `abs_paths=True` argument when exporting datasets
+of this type, the keys of the `labels` dict will be absolute filepaths to the
+images.
+
 The target value in `labels` for unlabeled images is `None`.
 
 If you wish to export classifications with associated confidences and/or
@@ -762,15 +766,24 @@ disk in the above format as follows:
     the strategy outlined in :ref:`this section <export-class-lists>` will be
     used to populate the class list.
 
-You can also perform labels-only exports in this format. If the filenames of
-the images of your dataset are unique, then you can simply provide the
-`labels_path` parameter instead of `export_dir` when calling
-:meth:`export() <fiftyone.core.collections.SampleCollection.export>` and the
-labels JSON will be populated using the basenames of the exported samples'
-image filepaths as keys. You can also include the `data_path` parameter to
-specify a common prefix to strip from each image's filepath to generate keys,
-in which case you must explicitly pass `export_media=False` to declare that you
-would only like to export labels.
+You can also perform labels-only exports in this format by providing the
+`labels_path` parameter instead of `export_dir` to
+:meth:`export() <fiftyone.core.collections.SampleCollection.export>` to specify
+a location to write (only) the labels.
+
+.. note::
+
+    You can optionally include the `export_media=False` option to
+    :meth:`export() <fiftyone.core.collections.SampleCollection.export>` to
+    make it explicit that you only wish to export labels, although this will be
+    inferred if you do not provide an `export_dir` or `data_path`.
+
+By default, the filenames of your images will be used as keys in the exported
+labels. However, you can also provide the optional `rel_dir` parameter to
+:meth:`export() <fiftyone.core.collections.SampleCollection.export>` to specify
+a prefix to strip from each image path to generate a key for the image. This
+argument allows for populating nested subdirectories that match the shape of
+the input paths.
 
 .. tabs::
 
@@ -795,13 +808,12 @@ would only like to export labels.
         )
 
         # Export labels using the relative path of each image with respect to
-        # the given `data_path` as keys
+        # the given `rel_dir` as keys
         dataset_or_view.export(
             dataset_type=fo.types.FiftyOneImageClassificationDataset,
-            data_path="/common/images/dir",
             labels_path=labels_path,
             label_field=label_field,
-            export_media=False,
+            rel_dir="/common/images/dir",
         )
 
   .. group-tab:: CLI
@@ -819,14 +831,13 @@ would only like to export labels.
             --kwargs labels_path=$LABELS_PATH
 
         # Export labels using the relative path of each image with respect to
-        # the given `data_path` as keys
+        # the given `rel_dir` as keys
         fiftyone datasets export $NAME \
             --label-field $LABEL_FIELD \
             --type fiftyone.types.FiftyOneImageClassificationDataset \
             --kwargs \
-                data_path="/common/images/dir" \
                 labels_path=$LABELS_PATH \
-                export_media=False
+                rel_dir="/common/images/dir"
 
 .. _ImageClassificationDirectoryTree-export:
 
@@ -1572,8 +1583,8 @@ The `file_name` attribute of the labels file encodes the location of the
 corresponding images, which can be any of the following:
 
 -   The filename of an image in the `data/` folder
--   A relative path like `data/sub/folder/filename.ext` specifying the relative
-    path to the image in a nested subfolder of `data/`
+-   A relative path like `path/to/filename.ext` specifying the relative path to
+    the image in a nested subfolder of `data/`
 -   An absolute path to an image, which may or may not be in the `data/` folder
 
 .. note::
@@ -2657,8 +2668,8 @@ The `name` field of the `<image>` tags in the labels file encodes the location
 of the corresponding images, which can be any of the following:
 
 -   The filename of an image in the `data/` folder
--   A relative path like `data/sub/folder/filename.ext` specifying the relative
-    path to the image in a nested subfolder of `data/`
+-   A relative path like `path/to/filename.ext` specifying the relative path to
+    the image in a nested subfolder of `data/`
 -   An absolute path to an image, which may or may not be in the `data/` folder
 
 .. note::
@@ -3268,8 +3279,8 @@ The `name` attribute of the labels file encodes the location of the
 corresponding images, which can be any of the following:
 
 -   The filename of an image in the `data/` folder
--   A relative path like `data/sub/folder/filename.ext` specifying the relative
-    path to the image in a nested subfolder of `data/`
+-   A relative path like `path/to/filename.ext` specifying the relative path to
+    the image in a nested subfolder of `data/`
 -   An absolute path to an image, which may or may not be in the `data/` folder
 
 .. note::

--- a/docs/source/user_guide/export_datasets.rst
+++ b/docs/source/user_guide/export_datasets.rst
@@ -650,10 +650,6 @@ IDs that are mapped to class label strings via `classes[target]`. If no
 `classes` are included, then the `target` values directly store the label
 strings.
 
-If you provide the optional `abs_paths=True` argument when exporting datasets
-of this type, the keys of the `labels` dict will be absolute filepaths to the
-images.
-
 The target value in `labels` for unlabeled images is `None`.
 
 If you wish to export classifications with associated confidences and/or
@@ -837,7 +833,7 @@ the input paths.
             --type fiftyone.types.FiftyOneImageClassificationDataset \
             --kwargs \
                 labels_path=$LABELS_PATH \
-                rel_dir="/common/images/dir"
+                rel_dir=/common/images/dir
 
 .. _ImageClassificationDirectoryTree-export:
 
@@ -1215,15 +1211,24 @@ format as follows:
     the strategy outlined in :ref:`this section <export-class-lists>` will be
     used to populate the class list.
 
-You can also perform labels-only exports in this format. If the filenames of
-the images of your dataset are unique, then you can simply provide the
-`labels_path` parameter instead of `export_dir` when calling
-:meth:`export() <fiftyone.core.collections.SampleCollection.export>` and the
-labels JSON will be populated using the basenames of the exported samples'
-image filepaths as keys. You can also include the `data_path` parameter to
-specify a common prefix to strip from each image's filepath to generate keys,
-in which case you must explicitly pass `export_media=False` to declare that you
-would only like to export labels.
+You can also perform labels-only exports in this format by providing the
+`labels_path` parameter instead of `export_dir` to
+:meth:`export() <fiftyone.core.collections.SampleCollection.export>` to specify
+a location to write (only) the labels.
+
+.. note::
+
+    You can optionally include the `export_media=False` option to
+    :meth:`export() <fiftyone.core.collections.SampleCollection.export>` to
+    make it explicit that you only wish to export labels, although this will be
+    inferred if you do not provide an `export_dir` or `data_path`.
+
+By default, the filenames of your images will be used as keys in the exported
+labels. However, you can also provide the optional `rel_dir` parameter to
+:meth:`export() <fiftyone.core.collections.SampleCollection.export>` to specify
+a prefix to strip from each image path to generate a key for the image. This
+argument allows for populating nested subdirectories that match the shape of
+the input paths.
 
 .. tabs::
 
@@ -1248,13 +1253,12 @@ would only like to export labels.
         )
 
         # Export labels using the relative path of each image with respect to
-        # the given `data_path` as keys
+        # the given `rel_dir` as keys
         dataset_or_view.export(
             dataset_type=fo.types.FiftyOneImageDetectionDataset,
-            data_path="/common/images/dir",
             labels_path=labels_path,
             label_field=label_field,
-            export_media=False,
+            rel_dir="/common/images/dir",
         )
 
   .. group-tab:: CLI
@@ -1272,14 +1276,13 @@ would only like to export labels.
             --kwargs labels_path=$LABELS_PATH
 
         # Export labels using the relative path of each image with respect to
-        # the given `data_path` as keys
+        # the given `rel_dir` as keys
         fiftyone datasets export $NAME \
             --label-field $LABEL_FIELD \
             --type fiftyone.types.FiftyOneImageDetectionDataset \
             --kwargs \
-                data_path=/common/images/dir \
                 labels_path=$LABELS_PATH \
-                export_media=False
+                rel_dir=/common/images/dir
 
 .. _FiftyOneTemporalDetectionDataset-export:
 
@@ -1433,15 +1436,24 @@ disk in the above format as follows:
     the strategy outlined in :ref:`this section <export-class-lists>` will be
     used to populate the class list.
 
-You can also perform labels-only exports in this format. If the filenames of
-the images of your dataset are unique, then you can simply provide the
-`labels_path` parameter instead of `export_dir` when calling
-:meth:`export() <fiftyone.core.collections.SampleCollection.export>` and the
-labels JSON will be populated using the basenames of the exported samples'
-image filepaths as keys. You can also include the `data_path` parameter to
-specify a common prefix to strip from each image's filepath to generate keys,
-in which case you must explicitly pass `export_media=False` to declare that you
-would only like to export labels.
+You can also perform labels-only exports in this format by providing the
+`labels_path` parameter instead of `export_dir` to
+:meth:`export() <fiftyone.core.collections.SampleCollection.export>` to specify
+a location to write (only) the labels.
+
+.. note::
+
+    You can optionally include the `export_media=False` option to
+    :meth:`export() <fiftyone.core.collections.SampleCollection.export>` to
+    make it explicit that you only wish to export labels, although this will be
+    inferred if you do not provide an `export_dir` or `data_path`.
+
+By default, the filenames of your images will be used as keys in the exported
+labels. However, you can also provide the optional `rel_dir` parameter to
+:meth:`export() <fiftyone.core.collections.SampleCollection.export>` to specify
+a prefix to strip from each image path to generate a key for the image. This
+argument allows for populating nested subdirectories that match the shape of
+the input paths.
 
 .. tabs::
 
@@ -1466,13 +1478,12 @@ would only like to export labels.
         )
 
         # Export labels using the relative path of each image with respect to
-        # the given `data_path` as keys
+        # the given `rel_dir` as keys
         dataset_or_view.export(
             dataset_type=fo.types.FiftyOneTemporalDetectionDataset,
-            data_path="/common/images/dir",
             labels_path=labels_path,
             label_field=label_field,
-            export_media=False,
+            rel_dir="/common/images/dir",
         )
 
   .. group-tab:: CLI
@@ -1490,14 +1501,13 @@ would only like to export labels.
             --kwargs labels_path=$LABELS_PATH
 
         # Export labels using the relative path of each image with respect to
-        # the given `data_path` as keys
+        # the given `rel_dir` as keys
         fiftyone datasets export $NAME \
             --label-field $LABEL_FIELD \
             --type fiftyone.types.FiftyOneTemporalDetectionDataset \
             --kwargs \
-                data_path=/common/images/dir \
                 labels_path=$LABELS_PATH \
-                export_media=False
+                rel_dir=/common/images/dir
 
 .. _COCODetectionDataset-export:
 
@@ -3667,7 +3677,7 @@ image's filepath, and then provide the new `rel_dir` when
             --type fiftyone.types.FiftyOneDataset \
             --kwargs \
                 export_media=False \
-                rel_dir="/common/images/dir"
+                rel_dir=/common/images/dir
 
 .. note::
 

--- a/docs/source/user_guide/export_datasets.rst
+++ b/docs/source/user_guide/export_datasets.rst
@@ -66,10 +66,12 @@ a |DatasetView| into any format of your choice via the basic recipe below.
         :linenos:
 
         # Export **only** labels in the `ground_truth` field in COCO format
+        # with absolute image filepaths in the labels
         dataset_or_view.export(
             dataset_type=fo.types.COCODetectionDataset,
             labels_path="/path/for/export.json",
             label_field="ground_truth",
+            abs_paths=True,
         )
 
     Or you can use the `export_media` parameter to configure whether to copy,
@@ -131,10 +133,13 @@ a |DatasetView| into any format of your choice via the basic recipe below.
     .. code-block:: shell
 
         # Export **only** labels in the `ground_truth` field in COCO format
+        # with absolute image filepaths in the labels
         fiftyone datasets export $NAME \
             --type fiftyone.types.COCODetectionDataset \
             --label-field ground_truth \
-            --kwargs labels_path=/path/for/labels.json
+            --kwargs \
+                labels_path=/path/for/labels.json \
+                abs_paths=True
 
     Or you can use the `export_media` parameter to configure whether to copy,
     move, symlink, or omit the media files from the export:

--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -6487,7 +6487,8 @@ class SampleCollection(object):
                 with ``output_dir`` to generate an output path for each
                 annotated media. This argument allows for populating nested
                 subdirectories in ``output_dir`` that match the shape of the
-                input paths
+                input paths. The path is converted to an absolute path (if
+                necessary) via :func:`fiftyone.core.utils.normalize_path`
             label_fields (None): a label field or list of label fields to
                 render. By default, all :class:`fiftyone.core.labels.Label`
                 fields are drawn
@@ -6542,6 +6543,7 @@ class SampleCollection(object):
         data_path=None,
         labels_path=None,
         export_media=None,
+        rel_dir=None,
         dataset_exporter=None,
         label_field=None,
         frame_labels_field=None,
@@ -6674,6 +6676,14 @@ class SampleCollection(object):
                 that some dataset formats may not support certain values for
                 this parameter (e.g., when exporting in binary formats such as
                 TF records, "symlink" is not an option)
+            rel_dir (None): an optional relative directory to strip from each
+                input filepath to generate a unique identifier for each media.
+                When exporting media, this identifier is joined with
+                ``data_path`` to generate an output path for each exported
+                media. This argument allows for populating nested
+                subdirectories that match the shape of the input paths. The
+                path is converted to an absolute path (if necessary) via
+                :func:`fiftyone.core.utils.normalize_path`
             dataset_exporter (None): a
                 :class:`fiftyone.utils.data.exporters.DatasetExporter` to use
                 to export the samples. When provided, parameters such as
@@ -6730,6 +6740,7 @@ class SampleCollection(object):
             data_path=data_path,
             labels_path=labels_path,
             export_media=export_media,
+            rel_dir=rel_dir,
             dataset_exporter=dataset_exporter,
             label_field=label_field,
             frame_labels_field=frame_labels_field,
@@ -8745,6 +8756,7 @@ def _export(
     data_path=None,
     labels_path=None,
     export_media=None,
+    rel_dir=None,
     dataset_exporter=None,
     label_field=None,
     frame_labels_field=None,
@@ -8775,6 +8787,7 @@ def _export(
             data_path=data_path,
             labels_path=labels_path,
             export_media=export_media,
+            rel_dir=rel_dir,
             **kwargs,
         )
 

--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -6464,6 +6464,7 @@ class SampleCollection(object):
     def draw_labels(
         self,
         output_dir,
+        rel_dir=None,
         label_fields=None,
         overwrite=False,
         config=None,
@@ -6481,6 +6482,12 @@ class SampleCollection(object):
 
         Args:
             output_dir: the directory to write the annotated media
+            rel_dir (None): an optional relative directory to strip from each
+                input filepath to generate a unique identifier that is joined
+                with ``output_dir`` to generate an output path for each
+                annotated media. This argument allows for populating nested
+                subdirectories in ``output_dir`` that match the shape of the
+                input paths
             label_fields (None): a label field or list of label fields to
                 render. By default, all :class:`fiftyone.core.labels.Label`
                 fields are drawn
@@ -6513,6 +6520,7 @@ class SampleCollection(object):
             return foua.draw_labeled_videos(
                 self,
                 output_dir,
+                rel_dir=rel_dir,
                 label_fields=label_fields,
                 config=config,
                 **kwargs,
@@ -6521,6 +6529,7 @@ class SampleCollection(object):
         return foua.draw_labeled_images(
             self,
             output_dir,
+            rel_dir=rel_dir,
             label_fields=label_fields,
             config=config,
             **kwargs,

--- a/fiftyone/core/utils.py
+++ b/fiftyone/core/utils.py
@@ -1065,7 +1065,7 @@ class UniqueFilenameMaker(object):
         ignore_existing (False): whether to ignore existing files in
             ``output_dir`` for output filename generation purposes
         idempotent (True): whether to return the same output path when the same
-            input path is provided multiple times (True) or to regenerate new
+            input path is provided multiple times (True) or to generate new
             output paths (False)
     """
 
@@ -1182,8 +1182,9 @@ class UniqueFilenameMaker(object):
 
 
 def safe_relpath(path, start=None, default=None):
-    """A safe version of ``os.path.relpath`` that returns the basename of the
-    given path if it does not lie within the given relative start.
+    """A safe version of ``os.path.relpath`` that returns a configurable
+    default value if the given path if it does not lie within the given
+    relative start.
 
     Args:
         path: a path

--- a/fiftyone/core/utils.py
+++ b/fiftyone/core/utils.py
@@ -1181,19 +1181,24 @@ class UniqueFilenameMaker(object):
         return output_path
 
 
-def safe_relpath(path, start=None):
+def safe_relpath(path, start=None, default=None):
     """A safe version of ``os.path.relpath`` that returns the basename of the
     given path if it does not lie within the given relative start.
 
     Args:
         path: a path
         start (None): the relative prefix to strip from ``path``
+        default (None): a default value to return if ``path`` does not lie
+            within ``start``. By default, the basename of the path is returned
 
     Returns:
         the relative path
     """
     relpath = os.path.relpath(path, start)
     if relpath.startswith(".."):
+        if default is not None:
+            return default
+
         logger.warning(
             "Path '%s' is not in '%s'. Using filename as unique identifier",
             path,

--- a/fiftyone/core/utils.py
+++ b/fiftyone/core/utils.py
@@ -1062,6 +1062,9 @@ class UniqueFilenameMaker(object):
             duplicate filenames
         ignore_existing (False): whether to ignore existing files in
             ``output_dir`` for output filename generation purposes
+        idempotent (True): whether to return the same output path when the same
+            input path is provided multiple times (True) or to regenerate new
+            output paths (False)
     """
 
     def __init__(
@@ -1071,12 +1074,14 @@ class UniqueFilenameMaker(object):
         default_ext=None,
         ignore_exts=False,
         ignore_existing=False,
+        idempotent=True,
     ):
         self.output_dir = output_dir
         self.rel_dir = rel_dir
         self.default_ext = default_ext
         self.ignore_exts = ignore_exts
         self.ignore_existing = ignore_existing
+        self.idempotent = idempotent
 
         self._filepath_map = {}
         self._filename_counts = defaultdict(int)
@@ -1126,7 +1131,11 @@ class UniqueFilenameMaker(object):
         """
         found_input = bool(input_path)
 
-        if found_input and input_path in self._filepath_map:
+        if (
+            found_input
+            and self.idempotent
+            and input_path in self._filepath_map
+        ):
             return self._filepath_map[input_path]
 
         self._idx += 1

--- a/fiftyone/utils/annotations.py
+++ b/fiftyone/utils/annotations.py
@@ -2300,7 +2300,7 @@ class DrawConfig(etaa.AnnotationConfig):
 
 
 def draw_labeled_images(
-    samples, output_dir, label_fields=None, config=None, **kwargs
+    samples, output_dir, rel_dir=None, label_fields=None, config=None, **kwargs
 ):
     """Renders annotated versions of the images in the collection with the
     specified label data overlaid to the given directory.
@@ -2314,6 +2314,11 @@ def draw_labeled_images(
     Args:
         samples: a :class:`fiftyone.core.collections.SampleCollection`
         output_dir: the directory to write the annotated images
+        rel_dir (None): an optional relative directory to strip from each input
+            filepath to generate a unique identifier that is joined with
+            ``output_dir`` to generate an output path for each annotated image.
+            This argument allows for populating nested subdirectories in
+            ``output_dir`` that match the shape of the input paths
         label_fields (None): a label field or list of label fields to render.
             If omitted, all compatiable fields are rendered
         config (None): an optional :class:`DrawConfig` configuring how to draw
@@ -2328,7 +2333,9 @@ def draw_labeled_images(
         config, kwargs, samples=samples, label_fields=label_fields
     )
 
-    filename_maker = fou.UniqueFilenameMaker(output_dir=output_dir)
+    filename_maker = fou.UniqueFilenameMaker(
+        output_dir=output_dir, rel_dir=rel_dir, idempotent=False
+    )
     output_ext = fo.config.default_image_ext
 
     outpaths = []
@@ -2372,7 +2379,7 @@ def draw_labeled_image(
 
 
 def draw_labeled_videos(
-    samples, output_dir, label_fields=None, config=None, **kwargs
+    samples, output_dir, rel_dir=None, label_fields=None, config=None, **kwargs
 ):
     """Renders annotated versions of the videos in the collection with the
     specified label data overlaid to the given directory.
@@ -2386,6 +2393,11 @@ def draw_labeled_videos(
     Args:
         samples: a :class:`fiftyone.core.collections.SampleCollection`
         output_dir: the directory to write the annotated videos
+        rel_dir (None): an optional relative directory to strip from each input
+            filepath to generate a unique identifier that is joined with
+            ``output_dir`` to generate an output path for each annotated video.
+            This argument allows for populating nested subdirectories in
+            ``output_dir`` that match the shape of the input paths
         label_fields (None): a label field or list of label fields to render.
             If omitted, all compatiable fields are rendered
         config (None): an optional :class:`DrawConfig` configuring how to draw
@@ -2400,7 +2412,9 @@ def draw_labeled_videos(
         config, kwargs, samples=samples, label_fields=label_fields
     )
 
-    filename_maker = fou.UniqueFilenameMaker(output_dir=output_dir)
+    filename_maker = fou.UniqueFilenameMaker(
+        output_dir=output_dir, rel_dir=rel_dir, idempotent=False
+    )
     output_ext = fo.config.default_video_ext
 
     is_clips = samples._dataset._is_clips

--- a/fiftyone/utils/annotations.py
+++ b/fiftyone/utils/annotations.py
@@ -2318,7 +2318,9 @@ def draw_labeled_images(
             filepath to generate a unique identifier that is joined with
             ``output_dir`` to generate an output path for each annotated image.
             This argument allows for populating nested subdirectories in
-            ``output_dir`` that match the shape of the input paths
+            ``output_dir`` that match the shape of the input paths. The path is
+            converted to an absolute path (if necessary) via
+            :func:`fiftyone.core.utils.normalize_path`
         label_fields (None): a label field or list of label fields to render.
             If omitted, all compatiable fields are rendered
         config (None): an optional :class:`DrawConfig` configuring how to draw
@@ -2397,7 +2399,9 @@ def draw_labeled_videos(
             filepath to generate a unique identifier that is joined with
             ``output_dir`` to generate an output path for each annotated video.
             This argument allows for populating nested subdirectories in
-            ``output_dir`` that match the shape of the input paths
+            ``output_dir`` that match the shape of the input paths. The path is
+            converted to an absolute path (if necessary) via
+            :func:`fiftyone.core.utils.normalize_path`
         label_fields (None): a label field or list of label fields to render.
             If omitted, all compatiable fields are rendered
         config (None): an optional :class:`DrawConfig` configuring how to draw

--- a/fiftyone/utils/bdd.py
+++ b/fiftyone/utils/bdd.py
@@ -259,6 +259,8 @@ class BDDDatasetExporter(
             allows for populating nested subdirectories that match the shape of
             the input paths. The path is converted to an absolute path (if
             necessary) via :func:`fiftyone.core.utils.normalize_path`
+        abs_paths (False): whether to store absolute paths to the images in the
+            exported labels
         image_format (None): the image format to use when writing in-memory
             images to disk. By default, ``fiftyone.config.default_image_ext``
             is used
@@ -277,6 +279,7 @@ class BDDDatasetExporter(
         labels_path=None,
         export_media=None,
         rel_dir=None,
+        abs_paths=False,
         image_format=None,
         extra_attrs=True,
     ):
@@ -299,6 +302,7 @@ class BDDDatasetExporter(
         self.labels_path = labels_path
         self.export_media = export_media
         self.rel_dir = rel_dir
+        self.abs_paths = abs_paths
         self.image_format = image_format
         self.extra_attrs = extra_attrs
 
@@ -328,7 +332,7 @@ class BDDDatasetExporter(
         self._media_exporter.setup()
 
     def export_sample(self, image_or_path, labels, metadata=None):
-        _, uuid = self._media_exporter.export(image_or_path)
+        out_image_path, uuid = self._media_exporter.export(image_or_path)
 
         if labels is None:
             return  # unlabeled
@@ -342,8 +346,13 @@ class BDDDatasetExporter(
         if metadata is None:
             metadata = fom.ImageMetadata.build_for(image_or_path)
 
+        if self.abs_paths:
+            name = out_image_path
+        else:
+            name = uuid
+
         annotation = _make_bdd_annotation(
-            labels, metadata, uuid, self.extra_attrs
+            labels, metadata, name, self.extra_attrs
         )
         self._annotations.append(annotation)
 

--- a/fiftyone/utils/bdd.py
+++ b/fiftyone/utils/bdd.py
@@ -252,6 +252,13 @@ class BDDDatasetExporter(
 
             If None, the default value of this parameter will be chosen based
             on the value of the ``data_path`` parameter
+        rel_dir (None): an optional relative directory to strip from each input
+            filepath to generate a unique identifier for each image. When
+            exporting media, this identifier is joined with ``data_path`` to
+            generate an output path for each exported image. This argument
+            allows for populating nested subdirectories that match the shape of
+            the input paths. The path is converted to an absolute path (if
+            necessary) via :func:`fiftyone.core.utils.normalize_path`
         image_format (None): the image format to use when writing in-memory
             images to disk. By default, ``fiftyone.config.default_image_ext``
             is used
@@ -269,6 +276,7 @@ class BDDDatasetExporter(
         data_path=None,
         labels_path=None,
         export_media=None,
+        rel_dir=None,
         image_format=None,
         extra_attrs=True,
     ):
@@ -290,6 +298,7 @@ class BDDDatasetExporter(
         self.data_path = data_path
         self.labels_path = labels_path
         self.export_media = export_media
+        self.rel_dir = rel_dir
         self.image_format = image_format
         self.extra_attrs = extra_attrs
 
@@ -313,6 +322,7 @@ class BDDDatasetExporter(
         self._media_exporter = foud.ImageExporter(
             self.export_media,
             export_path=self.data_path,
+            rel_dir=self.rel_dir,
             default_ext=self.image_format,
         )
         self._media_exporter.setup()

--- a/fiftyone/utils/coco.py
+++ b/fiftyone/utils/coco.py
@@ -640,6 +640,8 @@ class COCODetectionDatasetExporter(
             allows for populating nested subdirectories that match the shape of
             the input paths. The path is converted to an absolute path (if
             necessary) via :func:`fiftyone.core.utils.normalize_path`
+        abs_paths (False): whether to store absolute paths to the images in the
+            exported labels
         image_format (None): the image format to use when writing in-memory
             images to disk. By default, ``fiftyone.config.default_image_ext``
             is used
@@ -671,6 +673,7 @@ class COCODetectionDatasetExporter(
         labels_path=None,
         export_media=None,
         rel_dir=None,
+        abs_paths=False,
         image_format=None,
         classes=None,
         info=None,
@@ -698,6 +701,7 @@ class COCODetectionDatasetExporter(
         self.labels_path = labels_path
         self.export_media = export_media
         self.rel_dir = rel_dir
+        self.abs_paths = abs_paths
         self.image_format = image_format
         self.classes = classes
         self.info = info
@@ -746,16 +750,21 @@ class COCODetectionDatasetExporter(
             self.info = sample_collection.info
 
     def export_sample(self, image_or_path, label, metadata=None):
-        _, uuid = self._media_exporter.export(image_or_path)
+        out_image_path, uuid = self._media_exporter.export(image_or_path)
 
         if metadata is None:
             metadata = fom.ImageMetadata.build_for(image_or_path)
+
+        if self.abs_paths:
+            file_name = out_image_path
+        else:
+            file_name = uuid
 
         self._image_id += 1
         self._images.append(
             {
                 "id": self._image_id,
-                "file_name": uuid,
+                "file_name": file_name,
                 "height": metadata.height,
                 "width": metadata.width,
                 "license": None,

--- a/fiftyone/utils/coco.py
+++ b/fiftyone/utils/coco.py
@@ -633,6 +633,13 @@ class COCODetectionDatasetExporter(
 
             If None, the default value of this parameter will be chosen based
             on the value of the ``data_path`` parameter
+        rel_dir (None): an optional relative directory to strip from each input
+            filepath to generate a unique identifier for each image. When
+            exporting media, this identifier is joined with ``data_path`` to
+            generate an output path for each exported image. This argument
+            allows for populating nested subdirectories that match the shape of
+            the input paths. The path is converted to an absolute path (if
+            necessary) via :func:`fiftyone.core.utils.normalize_path`
         image_format (None): the image format to use when writing in-memory
             images to disk. By default, ``fiftyone.config.default_image_ext``
             is used
@@ -663,6 +670,7 @@ class COCODetectionDatasetExporter(
         data_path=None,
         labels_path=None,
         export_media=None,
+        rel_dir=None,
         image_format=None,
         classes=None,
         info=None,
@@ -689,6 +697,7 @@ class COCODetectionDatasetExporter(
         self.data_path = data_path
         self.labels_path = labels_path
         self.export_media = export_media
+        self.rel_dir = rel_dir
         self.image_format = image_format
         self.classes = classes
         self.info = info
@@ -727,6 +736,7 @@ class COCODetectionDatasetExporter(
         self._media_exporter = foud.ImageExporter(
             self.export_media,
             export_path=self.data_path,
+            rel_dir=self.rel_dir,
             default_ext=self.image_format,
         )
         self._media_exporter.setup()

--- a/fiftyone/utils/cvat.py
+++ b/fiftyone/utils/cvat.py
@@ -854,6 +854,13 @@ class CVATImageDatasetExporter(
 
             If None, the default value of this parameter will be chosen based
             on the value of the ``data_path`` parameter
+        rel_dir (None): an optional relative directory to strip from each input
+            filepath to generate a unique identifier for each image. When
+            exporting media, this identifier is joined with ``data_path`` to
+            generate an output path for each exported image. This argument
+            allows for populating nested subdirectories that match the shape of
+            the input paths. The path is converted to an absolute path (if
+            necessary) via :func:`fiftyone.core.utils.normalize_path`
         image_format (None): the image format to use when writing in-memory
             images to disk. By default, ``fiftyone.config.default_image_ext``
             is used
@@ -865,6 +872,7 @@ class CVATImageDatasetExporter(
         data_path=None,
         labels_path=None,
         export_media=None,
+        rel_dir=None,
         image_format=None,
     ):
         data_path, export_media = self._parse_data_path(
@@ -885,6 +893,7 @@ class CVATImageDatasetExporter(
         self.data_path = data_path
         self.labels_path = labels_path
         self.export_media = export_media
+        self.rel_dir = rel_dir
         self.image_format = image_format
 
         self._name = None
@@ -910,6 +919,7 @@ class CVATImageDatasetExporter(
         self._media_exporter = foud.ImageExporter(
             self.export_media,
             export_path=self.data_path,
+            rel_dir=self.rel_dir,
             default_ext=self.image_format,
         )
         self._media_exporter.setup()
@@ -1018,6 +1028,13 @@ class CVATVideoDatasetExporter(
 
             If None, the default value of this parameter will be chosen based
             on the value of the ``data_path`` parameter
+        rel_dir (None): an optional relative directory to strip from each input
+            filepath to generate a unique identifier for each video. When
+            exporting media, this identifier is joined with ``data_path`` to
+            generate an output path for each exported video. This argument
+            allows for populating nested subdirectories that match the shape of
+            the input paths. The path is converted to an absolute path (if
+            necessary) via :func:`fiftyone.core.utils.normalize_path`
     """
 
     def __init__(
@@ -1026,6 +1043,7 @@ class CVATVideoDatasetExporter(
         data_path=None,
         labels_path=None,
         export_media=None,
+        rel_dir=None,
     ):
         data_path, export_media = self._parse_data_path(
             export_dir=export_dir,
@@ -1045,6 +1063,7 @@ class CVATVideoDatasetExporter(
         self.data_path = data_path
         self.labels_path = labels_path
         self.export_media = export_media
+        self.rel_dir = rel_dir
 
         self._task_labels = None
         self._num_samples = 0
@@ -1069,9 +1088,10 @@ class CVATVideoDatasetExporter(
 
     def setup(self):
         self._writer = CVATVideoAnnotationWriter()
-        self._media_exporter = foud.ImageExporter(
+        self._media_exporter = foud.VideoExporter(
             self.export_media,
             export_path=self.data_path,
+            rel_dir=self.rel_dir,
         )
         self._media_exporter.setup()
 

--- a/fiftyone/utils/data/exporters.py
+++ b/fiftyone/utils/data/exporters.py
@@ -2674,7 +2674,7 @@ class FiftyOneTemporalDetectionDatasetExporter(
             allows for populating nested subdirectories that match the shape of
             the input paths. The path is converted to an absolute path (if
             necessary) via :func:`fiftyone.core.utils.normalize_path`
-        abs_paths (False): whether to store absolute paths to the images in the
+        abs_paths (False): whether to store absolute paths to the videos in the
             exported labels
         use_timestamps (False): whether to export the support of each temporal
             detection in seconds rather than frame numbers

--- a/fiftyone/utils/data/exporters.py
+++ b/fiftyone/utils/data/exporters.py
@@ -978,10 +978,7 @@ class MediaExporter(object):
                 directory in which to export the media
             -   When ``export_mode`` is "manifest", the path to write a JSON
                 file mapping UUIDs to input filepaths
-            -   When ``export_media`` is False, this parameter can optionally
-                be a root directory to strip from each exported image's path to
-                yield a UUID for each image. If no path is provided, only the
-                filename of each image is used for UUID generation
+            -   When ``export_media`` is False, this parameter has no effect
         rel_dir (None): an optional relative directory to strip from each input
             filepath to generate a unique identifier for each media. When
             exporting media, this identifier is joined with ``export_path`` to

--- a/fiftyone/utils/data/exporters.py
+++ b/fiftyone/utils/data/exporters.py
@@ -1045,6 +1045,7 @@ class MediaExporter(object):
             output_dir=output_dir,
             default_ext=self.default_ext,
             ignore_exts=self.ignore_exts,
+            ignore_existing=True,
         )
         self._manifest_path = manifest_path
         self._manifest = manifest

--- a/fiftyone/utils/data/exporters.py
+++ b/fiftyone/utils/data/exporters.py
@@ -52,6 +52,7 @@ def export_samples(
     data_path=None,
     labels_path=None,
     export_media=None,
+    rel_dir=None,
     dataset_exporter=None,
     label_field=None,
     frame_labels_field=None,
@@ -171,6 +172,13 @@ def export_samples(
             some dataset formats may not support certain values for this
             parameter (e.g., when exporting in binary formats such as TF
             records, "symlink" is not an option)
+        rel_dir (None): an optional relative directory to strip from each input
+            filepath to generate a unique identifier for each media. When
+            exporting media, this identifier is joined with ``data_path`` to
+            generate an output path for each exported media. This argument
+            allows for populating nested subdirectories that match the shape of
+            the input paths. The path is converted to an absolute path (if
+            necessary) via :func:`fiftyone.core.utils.normalize_path`
         dataset_exporter (None): a :class:`DatasetExporter` to use to write the
             dataset
         label_field (None): the name of the label field to export, or a
@@ -204,6 +212,7 @@ def export_samples(
             data_path=data_path,
             labels_path=labels_path,
             export_media=export_media,
+            rel_dir=rel_dir,
             **kwargs,
         )
     else:
@@ -213,6 +222,7 @@ def export_samples(
                 data_path=data_path,
                 labels_path=labels_path,
                 export_media=export_media,
+                rel_dir=rel_dir,
             )
         )
 
@@ -972,6 +982,13 @@ class MediaExporter(object):
                 be a root directory to strip from each exported image's path to
                 yield a UUID for each image. If no path is provided, only the
                 filename of each image is used for UUID generation
+        rel_dir (None): an optional relative directory to strip from each input
+            filepath to generate a unique identifier for each media. When
+            exporting media, this identifier is joined with ``export_path`` to
+            generate an output path for each exported media. This argument
+            allows for populating nested subdirectories that match the shape of
+            the input paths. The path is converted to an absolute path (if
+            necessary) via :func:`fiftyone.core.utils.normalize_path`
         supported_modes (None): an optional tuple specifying a subset of the
             ``export_mode`` values that are allowed
         default_ext (None): the file extension to use when generating default
@@ -984,6 +1001,7 @@ class MediaExporter(object):
         self,
         export_mode,
         export_path=None,
+        rel_dir=None,
         supported_modes=None,
         default_ext=None,
         ignore_exts=False,
@@ -1000,8 +1018,12 @@ class MediaExporter(object):
         if export_path is not None:
             export_path = fou.normalize_path(export_path)
 
+        if rel_dir is not None:
+            rel_dir = fou.normalize_path(rel_dir)
+
         self.export_mode = export_mode
         self.export_path = export_path
+        self.rel_dir = rel_dir
         self.supported_modes = supported_modes
         self.default_ext = default_ext
         self.ignore_exts = ignore_exts
@@ -1013,15 +1035,21 @@ class MediaExporter(object):
     def _write_media(self, media, outpath):
         raise NotImplementedError("subclass must implement _write_media()")
 
-    def _get_uuid(self, media_path):
-        if self.export_mode == False and self.export_path is not None:
-            media_path = fou.normalize_path(media_path)
-            uuid = os.path.relpath(media_path, self.export_path)
+    def _get_uuid(self, path):
+        if self.export_mode in (False, "manifest"):
+            # `path` should be an input path
+            rel_dir = self.rel_dir
         else:
-            uuid = os.path.basename(media_path)
+            # `path` should be an output path
+            rel_dir = self.export_path
+
+        if rel_dir is not None:
+            uuid = fou.safe_relpath(path, rel_dir)
+        else:
+            uuid = os.path.basename(path)
 
         if self.ignore_exts:
-            return os.path.splitext(uuid)[0]
+            uuid = os.path.splitext(uuid)[0]
 
         return uuid
 
@@ -1043,6 +1071,7 @@ class MediaExporter(object):
 
         self._filename_maker = fou.UniqueFilenameMaker(
             output_dir=output_dir,
+            rel_dir=self.rel_dir,
             default_ext=self.default_ext,
             ignore_exts=self.ignore_exts,
             ignore_existing=True,
@@ -1065,17 +1094,20 @@ class MediaExporter(object):
             -   the path to the exported media
             -   the UUID of the exported media
         """
+        if outpath is not None:
+            outpath = fou.normalize_path(outpath)
+
         if etau.is_str(media_or_path):
-            media_path = media_or_path
+            media_path = fou.normalize_path(media_or_path)
 
             if outpath is not None:
                 uuid = self._get_uuid(outpath)
-            elif self.export_mode != False:
-                outpath = self._filename_maker.get_output_path(media_path)
-                uuid = self._get_uuid(outpath)
-            else:
+            elif self.export_mode in (False, "manifest"):
                 outpath = None
                 uuid = self._get_uuid(media_path)
+            else:
+                outpath = self._filename_maker.get_output_path(media_path)
+                uuid = self._get_uuid(outpath)
 
             if self.export_mode == True:
                 etau.copy_file(media_path, outpath)
@@ -1084,15 +1116,15 @@ class MediaExporter(object):
             elif self.export_mode == "symlink":
                 etau.symlink_file(media_path, outpath)
             elif self.export_mode == "manifest":
-                outpath = None
                 self._manifest[uuid] = media_path
         else:
             media = media_or_path
 
-            if outpath is None:
+            if outpath is not None:
+                uuid = self._get_uuid(outpath)
+            else:
                 outpath = self._filename_maker.get_output_path()
-
-            uuid = self._get_uuid(outpath)
+                uuid = self._get_uuid(outpath)
 
             if self.export_mode == True:
                 self._write_media(media, outpath)
@@ -1496,6 +1528,13 @@ class LegacyFiftyOneDatasetExporter(GenericSampleDatasetExporter):
             -   ``"move"``: move media files into the export directory
             -   ``"symlink"``: create symlinks to each media file in the export
                 directory
+        rel_dir (None): an optional relative directory to strip from each input
+            filepath to generate a unique identifier for each media. When
+            exporting media, this identifier is joined with ``export_dir`` to
+            generate an output path for each exported media. This argument
+            allows for populating nested subdirectories that match the shape of
+            the input paths. The path is converted to an absolute path (if
+            necessary) via :func:`fiftyone.core.utils.normalize_path`
         relative_filepaths (True): whether to store relative (True) or absolute
             (False) filepaths to media files on disk in the output dataset
         pretty_print (False): whether to render the JSON in human readable
@@ -1506,6 +1545,7 @@ class LegacyFiftyOneDatasetExporter(GenericSampleDatasetExporter):
         self,
         export_dir,
         export_media=None,
+        rel_dir=None,
         relative_filepaths=True,
         pretty_print=False,
     ):
@@ -1515,6 +1555,7 @@ class LegacyFiftyOneDatasetExporter(GenericSampleDatasetExporter):
         super().__init__(export_dir=export_dir)
 
         self.export_media = export_media
+        self.rel_dir = rel_dir
         self.relative_filepaths = relative_filepaths
         self.pretty_print = pretty_print
 
@@ -1543,8 +1584,9 @@ class LegacyFiftyOneDatasetExporter(GenericSampleDatasetExporter):
 
         self._media_exporter = MediaExporter(
             self.export_media,
-            supported_modes=(True, False, "move", "symlink"),
             export_path=self._data_dir,
+            rel_dir=self.rel_dir,
+            supported_modes=(True, False, "move", "symlink"),
         )
         self._media_exporter.setup()
 
@@ -1670,13 +1712,13 @@ class FiftyOneDatasetExporter(BatchDatasetExporter):
             -   ``"move"``: move media files into the export directory
             -   ``"symlink"``: create symlinks to each media file in the export
                 directory
-        rel_dir (None): a relative directory to remove from the ``filepath`` of
-            each sample, if possible. The path is converted to an absolute path
-            (if necessary) via :func:`fiftyone.core.utils.normalize_path`.
-            The typical use case for this argument is that your source data
-            lives in a single directory and you wish to serialize relative,
-            rather than absolute, paths to the data within that directory.
-            Only applicable when ``export_media`` is False
+        rel_dir (None): an optional relative directory to strip from each input
+            filepath to generate a unique identifier for each media. When
+            exporting media, this identifier is joined with ``export_dir`` to
+            generate an output path for each exported media. This argument
+            allows for populating nested subdirectories that match the shape of
+            the input paths. The path is converted to an absolute path (if
+            necessary) via :func:`fiftyone.core.utils.normalize_path`
         export_runs (True): whether to include annotation/brain/evaluation
             runs in the export. Only applicable when exporting full datasets
         use_dirs (False): whether to export metadata into directories of per
@@ -1731,6 +1773,7 @@ class FiftyOneDatasetExporter(BatchDatasetExporter):
         self._media_exporter = MediaExporter(
             self.export_media,
             export_path=self._data_dir,
+            rel_dir=self.rel_dir,
             supported_modes=(True, False, "move", "symlink"),
         )
         self._media_exporter.setup()
@@ -1741,15 +1784,10 @@ class FiftyOneDatasetExporter(BatchDatasetExporter):
         inpaths = sample_collection.values("filepath")
 
         if self.export_media != False:
-            if self.rel_dir is not None:
-                logger.warning(
-                    "Ignoring `rel_dir` since `export_media` is True"
-                )
-
-            outpaths = [self._media_exporter.export(p)[0] for p in inpaths]
-
-            # Replace filepath prefixes with `data/` for samples export
-            _outpaths = ["data/" + os.path.basename(p) for p in outpaths]
+            _outpaths = []
+            for inpath in inpaths:
+                _, uuid = self._media_exporter.export(inpath)
+                _outpaths.append(os.path.join("data", uuid))
         elif self.rel_dir is not None:
             # Remove `rel_dir` prefix from filepaths
             rel_dir = fou.normalize_path(self.rel_dir) + os.path.sep
@@ -1874,18 +1912,28 @@ class ImageDirectoryExporter(UnlabeledImageDatasetExporter):
             -   ``"move"``: move media files into the export directory
             -   ``"symlink"``: create symlinks to each media file in the export
                 directory
+        rel_dir (None): an optional relative directory to strip from each input
+            filepath to generate a unique identifier for each image. When
+            exporting media, this identifier is joined with ``export_dir`` to
+            generate an output path for each exported image. This argument
+            allows for populating nested subdirectories that match the shape of
+            the input paths. The path is converted to an absolute path (if
+            necessary) via :func:`fiftyone.core.utils.normalize_path`
         image_format (None): the image format to use when writing in-memory
             images to disk. By default, ``fiftyone.config.default_image_ext``
             is used
     """
 
-    def __init__(self, export_dir, export_media=None, image_format=None):
+    def __init__(
+        self, export_dir, export_media=None, rel_dir=None, image_format=None
+    ):
         if export_media is None:
             export_media = True
 
         super().__init__(export_dir=export_dir)
 
         self.export_media = export_media
+        self.rel_dir = rel_dir
         self.image_format = image_format
 
         self._media_exporter = None
@@ -1898,6 +1946,7 @@ class ImageDirectoryExporter(UnlabeledImageDatasetExporter):
         self._media_exporter = ImageExporter(
             self.export_media,
             export_path=self.export_dir,
+            rel_dir=self.rel_dir,
             supported_modes=(True, "move", "symlink"),
             default_ext=self.image_format,
         )
@@ -1929,15 +1978,23 @@ class VideoDirectoryExporter(UnlabeledVideoDatasetExporter):
             -   ``"move"``: move media files into the export directory
             -   ``"symlink"``: create symlinks to each media file in the export
                 directory
+        rel_dir (None): an optional relative directory to strip from each input
+            filepath to generate a unique identifier for each video. When
+            exporting media, this identifier is joined with ``export_dir`` to
+            generate an output path for each exported video. This argument
+            allows for populating nested subdirectories that match the shape of
+            the input paths. The path is converted to an absolute path (if
+            necessary) via :func:`fiftyone.core.utils.normalize_path`
     """
 
-    def __init__(self, export_dir, export_media=None):
+    def __init__(self, export_dir, export_media=None, rel_dir=None):
         if export_media is None:
             export_media = True
 
         super().__init__(export_dir=export_dir)
 
         self.export_media = export_media
+        self.rel_dir = rel_dir
 
         self._media_exporter = None
 
@@ -1949,6 +2006,7 @@ class VideoDirectoryExporter(UnlabeledVideoDatasetExporter):
         self._media_exporter = VideoExporter(
             self.export_media,
             export_path=self.export_dir,
+            rel_dir=self.rel_dir,
             supported_modes=(True, "move", "symlink"),
         )
         self._media_exporter.setup()
@@ -2021,6 +2079,13 @@ class FiftyOneImageClassificationDatasetExporter(
 
             If None, the default value of this parameter will be chosen based
             on the value of the ``data_path`` parameter
+        rel_dir (None): an optional relative directory to strip from each input
+            filepath to generate a unique identifier for each image. When
+            exporting media, this identifier is joined with ``data_path`` to
+            generate an output path for each exported image. This argument
+            allows for populating nested subdirectories that match the shape of
+            the input paths. The path is converted to an absolute path (if
+            necessary) via :func:`fiftyone.core.utils.normalize_path`
         include_confidence (False): whether to include classification
             confidences in the export. The supported values are:
 
@@ -2048,6 +2113,7 @@ class FiftyOneImageClassificationDatasetExporter(
         data_path=None,
         labels_path=None,
         export_media=None,
+        rel_dir=None,
         include_confidence=False,
         include_attributes=False,
         classes=None,
@@ -2072,6 +2138,7 @@ class FiftyOneImageClassificationDatasetExporter(
         self.data_path = data_path
         self.labels_path = labels_path
         self.export_media = export_media
+        self.rel_dir = rel_dir
         self.include_confidence = include_confidence
         self.include_attributes = include_attributes
         self.classes = classes
@@ -2097,6 +2164,7 @@ class FiftyOneImageClassificationDatasetExporter(
         self._media_exporter = ImageExporter(
             self.export_media,
             export_path=self.data_path,
+            rel_dir=self.rel_dir,
             default_ext=self.image_format,
             ignore_exts=True,
         )
@@ -2146,14 +2214,26 @@ class ImageClassificationDirectoryTreeExporter(LabeledImageDatasetExporter):
             -   ``"move"``: move all media files into the output directory
             -   ``"symlink"``: create symlinks to the media files in the output
                 directory
+        rel_dir (None): an optional relative directory to strip from each input
+            filepath to generate a unique identifier for each image. When
+            exporting media, this identifier is joined with ``export_dir`` to
+            generate an output path for each exported image. This argument
+            allows for populating nested subdirectories that match the shape of
+            the input paths. The path is converted to an absolute path (if
+            necessary) via :func:`fiftyone.core.utils.normalize_path`
         image_format (None): the image format to use when writing in-memory
             images to disk. By default, ``fiftyone.config.default_image_ext``
             is used
     """
 
-    def __init__(self, export_dir, export_media=None, image_format=None):
+    def __init__(
+        self, export_dir, export_media=None, rel_dir=None, image_format=None
+    ):
         if export_media is None:
             export_media = True
+
+        if rel_dir is not None:
+            rel_dir = fou.normalize_path(rel_dir)
 
         if image_format is None:
             image_format = fo.config.default_image_ext
@@ -2161,6 +2241,7 @@ class ImageClassificationDirectoryTreeExporter(LabeledImageDatasetExporter):
         super().__init__(export_dir=export_dir)
 
         self.export_media = export_media
+        self.rel_dir = rel_dir
         self.image_format = image_format
 
         self._class_counts = None
@@ -2200,14 +2281,18 @@ class ImageClassificationDirectoryTreeExporter(LabeledImageDatasetExporter):
         self._class_counts[_label] += 1
 
         if etau.is_str(image_or_path):
-            image_path = image_or_path
+            image_path = fou.normalize_path(image_or_path)
         else:
             img = image_or_path
             image_path = self._default_filename_patt % (
                 self._class_counts[_label]
             )
 
-        filename = os.path.basename(image_path)
+        if self.rel_dir is not None:
+            filename = fou.safe_relpath(image_path, self.rel_dir)
+        else:
+            filename = os.path.basename(image_path)
+
         name, ext = os.path.splitext(filename)
 
         key = (_label, filename)
@@ -2245,15 +2330,26 @@ class VideoClassificationDirectoryTreeExporter(LabeledVideoDatasetExporter):
             -   ``"move"``: move all media files into the output directory
             -   ``"symlink"``: create symlinks to the media files in the output
                 directory
+        rel_dir (None): an optional relative directory to strip from each input
+            filepath to generate a unique identifier for each video. When
+            exporting media, this identifier is joined with ``export_dir`` to
+            generate an output path for each exported video. This argument
+            allows for populating nested subdirectories that match the shape of
+            the input paths. The path is converted to an absolute path (if
+            necessary) via :func:`fiftyone.core.utils.normalize_path`
     """
 
-    def __init__(self, export_dir, export_media=None):
+    def __init__(self, export_dir, export_media=None, rel_dir=None):
         if export_media is None:
             export_media = True
+
+        if rel_dir is not None:
+            rel_dir = fou.normalize_path(rel_dir)
 
         super().__init__(export_dir=export_dir)
 
         self.export_media = export_media
+        self.rel_dir = rel_dir
 
         self._class_counts = None
         self._filename_counts = None
@@ -2292,7 +2388,11 @@ class VideoClassificationDirectoryTreeExporter(LabeledVideoDatasetExporter):
 
         self._class_counts[_label] += 1
 
-        filename = os.path.basename(video_path)
+        if self.rel_dir is not None:
+            filename = fou.safe_relpath(video_path, self.rel_dir)
+        else:
+            filename = os.path.basename(video_path)
+
         name, ext = os.path.splitext(filename)
 
         key = (_label, filename)
@@ -2370,6 +2470,13 @@ class FiftyOneImageDetectionDatasetExporter(
 
             If None, the default value of this parameter will be chosen based
             on the value of the ``data_path`` parameter
+        rel_dir (None): an optional relative directory to strip from each input
+            filepath to generate a unique identifier for each image. When
+            exporting media, this identifier is joined with ``data_path`` to
+            generate an output path for each exported image. This argument
+            allows for populating nested subdirectories that match the shape of
+            the input paths. The path is converted to an absolute path (if
+            necessary) via :func:`fiftyone.core.utils.normalize_path`
         classes (None): the list of possible class labels
         include_confidence (None): whether to include detection confidences in
             the export. The supported values are:
@@ -2397,6 +2504,7 @@ class FiftyOneImageDetectionDatasetExporter(
         data_path=None,
         labels_path=None,
         export_media=None,
+        rel_dir=None,
         classes=None,
         include_confidence=None,
         include_attributes=None,
@@ -2421,6 +2529,7 @@ class FiftyOneImageDetectionDatasetExporter(
         self.data_path = data_path
         self.labels_path = labels_path
         self.export_media = export_media
+        self.rel_dir = rel_dir
         self.classes = classes
         self.include_confidence = include_confidence
         self.include_attributes = include_attributes
@@ -2446,6 +2555,7 @@ class FiftyOneImageDetectionDatasetExporter(
         self._media_exporter = ImageExporter(
             self.export_media,
             export_path=self.data_path,
+            rel_dir=self.rel_dir,
             default_ext=self.image_format,
             ignore_exts=True,
         )
@@ -2535,6 +2645,13 @@ class FiftyOneTemporalDetectionDatasetExporter(
 
             If None, the default value of this parameter will be chosen based
             on the value of the ``data_path`` parameter
+        rel_dir (None): an optional relative directory to strip from each input
+            filepath to generate a unique identifier for each video. When
+            exporting media, this identifier is joined with ``data_path`` to
+            generate an output path for each exported video. This argument
+            allows for populating nested subdirectories that match the shape of
+            the input paths. The path is converted to an absolute path (if
+            necessary) via :func:`fiftyone.core.utils.normalize_path`
         use_timestamps (False): whether to export the support of each temporal
             detection in seconds rather than frame numbers
         classes (None): the list of possible class labels
@@ -2561,6 +2678,7 @@ class FiftyOneTemporalDetectionDatasetExporter(
         data_path=None,
         labels_path=None,
         export_media=None,
+        rel_dir=None,
         use_timestamps=False,
         classes=None,
         include_confidence=None,
@@ -2585,6 +2703,7 @@ class FiftyOneTemporalDetectionDatasetExporter(
         self.data_path = data_path
         self.labels_path = labels_path
         self.export_media = export_media
+        self.rel_dir = rel_dir
         self.use_timestamps = use_timestamps
         self.classes = classes
         self.include_confidence = include_confidence
@@ -2614,6 +2733,7 @@ class FiftyOneTemporalDetectionDatasetExporter(
         self._media_exporter = VideoExporter(
             self.export_media,
             export_path=self.data_path,
+            rel_dir=self.rel_dir,
             ignore_exts=True,
         )
         self._media_exporter.setup()
@@ -2704,6 +2824,14 @@ class ImageSegmentationDirectoryExporter(
 
             If None, the default value of this parameter will be chosen based
             on the value of the ``data_path`` parameter
+        rel_dir (None): an optional relative directory to strip from each input
+            filepath to generate a unique identifier for each image. When
+            exporting media, this identifier is joined with ``data_path`` and
+            ``labels_path`` to generate output paths for each exported image
+            and mask. This argument allows for populating nested subdirectories
+            that match the shape of the input paths. The path is converted to
+            an absolute path (if necessary) via
+            :func:`fiftyone.core.utils.normalize_path`
         image_format (None): the image format to use when writing in-memory
             images to disk. By default, ``fiftyone.config.default_image_ext``
             is used
@@ -2727,6 +2855,7 @@ class ImageSegmentationDirectoryExporter(
         data_path=None,
         labels_path=None,
         export_media=None,
+        rel_dir=None,
         image_format=None,
         mask_format=".png",
         mask_size=None,
@@ -2751,6 +2880,7 @@ class ImageSegmentationDirectoryExporter(
         self.data_path = data_path
         self.labels_path = labels_path
         self.export_media = export_media
+        self.rel_dir = rel_dir
         self.image_format = image_format
         self.mask_format = mask_format
         self.mask_size = mask_size
@@ -2771,6 +2901,7 @@ class ImageSegmentationDirectoryExporter(
         self._media_exporter = ImageExporter(
             self.export_media,
             export_path=self.data_path,
+            rel_dir=self.rel_dir,
             default_ext=self.image_format,
             ignore_exts=True,
         )
@@ -2847,6 +2978,13 @@ class FiftyOneImageLabelsDatasetExporter(LabeledImageDatasetExporter):
             -   ``"move"``: move all media files into the output directory
             -   ``"symlink"``: create symlinks to the media files in the output
                 directory
+        rel_dir (None): an optional relative directory to strip from each input
+            filepath to generate a unique identifier for each image. When
+            exporting media, this identifier is joined with ``export_dir`` to
+            generate an output path for each exported image. This argument
+            allows for populating nested subdirectories that match the shape of
+            the input paths. The path is converted to an absolute path (if
+            necessary) via :func:`fiftyone.core.utils.normalize_path`
         image_format (None): the image format to use when writing in-memory
             images to disk. By default, ``fiftyone.config.default_image_ext``
             is used
@@ -2858,6 +2996,7 @@ class FiftyOneImageLabelsDatasetExporter(LabeledImageDatasetExporter):
         self,
         export_dir,
         export_media=None,
+        rel_dir=None,
         image_format=None,
         pretty_print=False,
     ):
@@ -2867,6 +3006,7 @@ class FiftyOneImageLabelsDatasetExporter(LabeledImageDatasetExporter):
         super().__init__(export_dir=export_dir)
 
         self.export_media = export_media
+        self.rel_dir = rel_dir
         self.image_format = image_format
         self.pretty_print = pretty_print
 
@@ -2901,6 +3041,7 @@ class FiftyOneImageLabelsDatasetExporter(LabeledImageDatasetExporter):
         self._media_exporter = ImageExporter(
             self.export_media,
             export_path=self._data_dir,
+            rel_dir=self.rel_dir,
             supported_modes=(True, "move", "symlink"),
             default_ext=self.image_format,
             ignore_exts=True,
@@ -2920,8 +3061,8 @@ class FiftyOneImageLabelsDatasetExporter(LabeledImageDatasetExporter):
 
         self._dataset_index.append(
             etad.LabeledDataRecord(
-                "data/" + os.path.basename(out_image_path),
-                "labels/" + os.path.basename(out_labels_path),
+                "data/" + uuid + os.path.splitext(out_image_path)[1],
+                "labels/" + uuid + ".json",
             )
         )
 
@@ -2956,17 +3097,27 @@ class FiftyOneVideoLabelsDatasetExporter(LabeledVideoDatasetExporter):
             -   ``"move"``: move all media files into the output directory
             -   ``"symlink"``: create symlinks to the media files in the output
                 directory
+        rel_dir (None): an optional relative directory to strip from each input
+            filepath to generate a unique identifier for each video. When
+            exporting media, this identifier is joined with ``export_dir`` to
+            generate an output path for each exported video. This argument
+            allows for populating nested subdirectories that match the shape of
+            the input paths. The path is converted to an absolute path (if
+            necessary) via :func:`fiftyone.core.utils.normalize_path`
         pretty_print (False): whether to render the JSON in human readable
             format with newlines and indentations
     """
 
-    def __init__(self, export_dir, export_media=None, pretty_print=False):
+    def __init__(
+        self, export_dir, export_media=None, rel_dir=None, pretty_print=False
+    ):
         if export_media is None:
             export_media = True
 
         super().__init__(export_dir=export_dir)
 
         self.export_media = export_media
+        self.rel_dir = rel_dir
         self.pretty_print = pretty_print
 
         self._dataset_index = None
@@ -3004,6 +3155,7 @@ class FiftyOneVideoLabelsDatasetExporter(LabeledVideoDatasetExporter):
         self._media_exporter = VideoExporter(
             self.export_media,
             export_path=self._data_dir,
+            rel_dir=self.rel_dir,
             supported_modes=(True, "move", "symlink"),
             ignore_exts=True,
         )
@@ -3022,8 +3174,8 @@ class FiftyOneVideoLabelsDatasetExporter(LabeledVideoDatasetExporter):
 
         self._dataset_index.append(
             etad.LabeledDataRecord(
-                "data/" + os.path.basename(out_video_path),
-                "labels/" + os.path.basename(out_labels_path),
+                "data/" + uuid + os.path.splitext(out_video_path)[1],
+                "labels/" + uuid + ".json",
             )
         )
 

--- a/fiftyone/utils/data/importers.py
+++ b/fiftyone/utils/data/importers.py
@@ -2012,7 +2012,11 @@ class FiftyOneImageClassificationDatasetImporter(
     def __next__(self):
         uuid = next(self._iter_uuids)
 
-        image_path = self._image_paths_map[uuid]
+        if os.path.isabs(uuid):
+            image_path = uuid
+        else:
+            image_path = self._image_paths_map[uuid]
+
         target = self._labels_map[uuid]
 
         if self.compute_metadata:
@@ -2464,7 +2468,11 @@ class FiftyOneImageDetectionDatasetImporter(
     def __next__(self):
         uuid = next(self._iter_uuids)
 
-        image_path = self._image_paths_map[uuid]
+        if os.path.isabs(uuid):
+            image_path = uuid
+        else:
+            image_path = self._image_paths_map[uuid]
+
         target = self._labels_map[uuid]
 
         if self.compute_metadata:
@@ -2644,7 +2652,11 @@ class FiftyOneTemporalDetectionDatasetImporter(
     def __next__(self):
         uuid = next(self._iter_uuids)
 
-        video_path = self._video_paths_map[uuid]
+        if os.path.isabs(uuid):
+            video_path = uuid
+        else:
+            video_path = self._video_paths_map[uuid]
+
         labels = self._labels_map[uuid]
 
         if self.compute_metadata:

--- a/fiftyone/utils/geojson.py
+++ b/fiftyone/utils/geojson.py
@@ -547,6 +547,13 @@ class GeoJSONDatasetExporter(
 
             If None, the default value of this parameter will be chosen based
             on the value of the ``data_path`` parameter
+        rel_dir (None): an optional relative directory to strip from each input
+            filepath to generate a unique identifier for each media. When
+            exporting media, this identifier is joined with ``data_path`` to
+            generate an output path for each exported media. This argument
+            allows for populating nested subdirectories that match the shape of
+            the input paths. The path is converted to an absolute path (if
+            necessary) via :func:`fiftyone.core.utils.normalize_path`
         image_format (None): the image format to use when writing in-memory
             images to disk. By default, ``fiftyone.config.default_image_ext``
             is used
@@ -575,6 +582,7 @@ class GeoJSONDatasetExporter(
         data_path=None,
         labels_path=None,
         export_media=None,
+        rel_dir=None,
         image_format=None,
         location_field=None,
         property_makers=None,
@@ -599,6 +607,7 @@ class GeoJSONDatasetExporter(
         self.data_path = data_path
         self.labels_path = labels_path
         self.export_media = export_media
+        self.rel_dir = rel_dir
         self.image_format = image_format
         self.location_field = location_field
         self.property_makers = property_makers
@@ -613,6 +622,7 @@ class GeoJSONDatasetExporter(
         self._media_exporter = foud.ImageExporter(
             self.export_media,
             export_path=self.data_path,
+            rel_dir=self.rel_dir,
             default_ext=self.image_format,
         )
         self._media_exporter.setup()

--- a/fiftyone/utils/geojson.py
+++ b/fiftyone/utils/geojson.py
@@ -554,6 +554,8 @@ class GeoJSONDatasetExporter(
             allows for populating nested subdirectories that match the shape of
             the input paths. The path is converted to an absolute path (if
             necessary) via :func:`fiftyone.core.utils.normalize_path`
+        abs_paths (False): whether to store absolute paths to the images in the
+            exported labels
         image_format (None): the image format to use when writing in-memory
             images to disk. By default, ``fiftyone.config.default_image_ext``
             is used
@@ -583,6 +585,7 @@ class GeoJSONDatasetExporter(
         labels_path=None,
         export_media=None,
         rel_dir=None,
+        abs_paths=False,
         image_format=None,
         location_field=None,
         property_makers=None,
@@ -608,6 +611,7 @@ class GeoJSONDatasetExporter(
         self.labels_path = labels_path
         self.export_media = export_media
         self.rel_dir = rel_dir
+        self.abs_paths = abs_paths
         self.image_format = image_format
         self.location_field = location_field
         self.property_makers = property_makers
@@ -640,9 +644,12 @@ class GeoJSONDatasetExporter(
                 if value is not None or not self.omit_none_fields:
                     properties[key] = fn(value)
 
-        _, uuid = self._media_exporter.export(sample.filepath)
+        out_media_path, uuid = self._media_exporter.export(sample.filepath)
 
-        properties["filename"] = uuid
+        if self.abs_paths:
+            properties["filename"] = out_media_path
+        else:
+            properties["filename"] = uuid
 
         location = sample[self.location_field]
         if location is not None:

--- a/fiftyone/utils/kitti.py
+++ b/fiftyone/utils/kitti.py
@@ -309,6 +309,7 @@ class KITTIDetectionDatasetExporter(
         self._media_exporter = foud.ImageExporter(
             self.export_media,
             export_path=self.data_path,
+            rel_dir=self.rel_dir,
             default_ext=self.image_format,
             ignore_exts=True,
         )

--- a/fiftyone/utils/kitti.py
+++ b/fiftyone/utils/kitti.py
@@ -250,6 +250,14 @@ class KITTIDetectionDatasetExporter(
 
             If None, the default value of this parameter will be chosen based
             on the value of the ``data_path`` parameter
+        rel_dir (None): an optional relative directory to strip from each input
+            filepath to generate a unique identifier for each image. When
+            exporting media, this identifier is joined with ``data_path`` and
+            ``labels_path`` to generate output paths for each exported image
+            and labels file. This argument allows for populating nested
+            subdirectories that match the shape of the input paths. The path is
+            converted to an absolute path (if necessary) via
+            :func:`fiftyone.core.utils.normalize_path`
         image_format (None): the image format to use when writing in-memory
             images to disk. By default, ``fiftyone.config.default_image_ext``
             is used
@@ -261,6 +269,7 @@ class KITTIDetectionDatasetExporter(
         data_path=None,
         labels_path=None,
         export_media=None,
+        rel_dir=None,
         image_format=None,
     ):
         data_path, export_media = self._parse_data_path(
@@ -281,6 +290,7 @@ class KITTIDetectionDatasetExporter(
         self.data_path = data_path
         self.labels_path = labels_path
         self.export_media = export_media
+        self.rel_dir = rel_dir
         self.image_format = image_format
 
         self._writer = None

--- a/fiftyone/utils/voc.py
+++ b/fiftyone/utils/voc.py
@@ -353,12 +353,10 @@ class VOCDetectionDatasetExporter(
         if metadata is None:
             metadata = fom.ImageMetadata.build_for(image_or_path)
 
-        path = None
         if self.include_paths:
-            if out_image_path is not None:
-                path = out_image_path
-            elif etau.is_str(image_or_path):
-                path = image_or_path
+            path = out_image_path
+        else:
+            path = None
 
         annotation = VOCAnnotation.from_labeled_image(
             metadata,

--- a/fiftyone/utils/voc.py
+++ b/fiftyone/utils/voc.py
@@ -262,6 +262,14 @@ class VOCDetectionDatasetExporter(
 
             If None, the default value of this parameter will be chosen based
             on the value of the ``data_path`` parameter
+        rel_dir (None): an optional relative directory to strip from each input
+            filepath to generate a unique identifier for each image. When
+            exporting media, this identifier is joined with ``data_path`` and
+            ``labels_path`` to generate output paths for each exported image
+            and labels file. This argument allows for populating nested
+            subdirectories that match the shape of the input paths. The path is
+            converted to an absolute path (if necessary) via
+            :func:`fiftyone.core.utils.normalize_path`
         include_paths (True): whether to include the absolute paths to the
             images in the ``<path>`` elements of the exported XML
         image_format (None): the image format to use when writing in-memory
@@ -281,6 +289,7 @@ class VOCDetectionDatasetExporter(
         data_path=None,
         labels_path=None,
         export_media=None,
+        rel_dir=None,
         include_paths=True,
         image_format=None,
         extra_attrs=True,
@@ -303,6 +312,7 @@ class VOCDetectionDatasetExporter(
         self.data_path = data_path
         self.labels_path = labels_path
         self.export_media = export_media
+        self.rel_dir = rel_dir
         self.include_paths = include_paths
         self.image_format = image_format
         self.extra_attrs = extra_attrs
@@ -323,6 +333,7 @@ class VOCDetectionDatasetExporter(
         self._media_exporter = foud.ImageExporter(
             self.export_media,
             export_path=self.data_path,
+            rel_dir=self.rel_dir,
             default_ext=self.image_format,
         )
         self._media_exporter.setup()
@@ -330,13 +341,13 @@ class VOCDetectionDatasetExporter(
         etau.ensure_dir(self.labels_path)
 
     def export_sample(self, image_or_path, detections, metadata=None):
-        out_image_path, filename = self._media_exporter.export(image_or_path)
+        out_image_path, uuid = self._media_exporter.export(image_or_path)
 
         if detections is None:
             return
 
         out_labels_path = os.path.join(
-            self.labels_path, os.path.splitext(filename)[0] + ".xml"
+            self.labels_path, os.path.splitext(uuid)[0] + ".xml"
         )
 
         if metadata is None:
@@ -353,7 +364,7 @@ class VOCDetectionDatasetExporter(
             metadata,
             detections,
             path=path,
-            filename=filename,
+            filename=uuid,
             extra_attrs=self.extra_attrs,
         )
         self._writer.write(annotation, out_labels_path)

--- a/fiftyone/utils/yolo.py
+++ b/fiftyone/utils/yolo.py
@@ -601,6 +601,14 @@ class YOLOv4DatasetExporter(
 
             If None, the default value of this parameter will be chosen based
             on the value of the ``data_path`` parameter
+        rel_dir (None): an optional relative directory to strip from each input
+            filepath to generate a unique identifier for each image. When
+            exporting media, this identifier is joined with ``data_path`` and
+            ``labels_path`` to generate output paths for each exported image
+            and labels file. This argument allows for populating nested
+            subdirectories that match the shape of the input paths. The path is
+            converted to an absolute path (if necessary) via
+            :func:`fiftyone.core.utils.normalize_path`
         classes (None): the list of possible class labels
         include_confidence (False): whether to include detection confidences in
             the export, if they exist
@@ -617,6 +625,7 @@ class YOLOv4DatasetExporter(
         objects_path=None,
         images_path=None,
         export_media=None,
+        rel_dir=None,
         classes=None,
         include_confidence=False,
         image_format=None,
@@ -651,6 +660,7 @@ class YOLOv4DatasetExporter(
         self.objects_path = objects_path
         self.images_path = images_path
         self.export_media = export_media
+        self.rel_dir = rel_dir
         self.classes = classes
         self.include_confidence = include_confidence
         self.image_format = image_format
@@ -673,11 +683,9 @@ class YOLOv4DatasetExporter(
 
     def setup(self):
         if self.export_dir is None:
-            rel_dir = self.data_path
+            self._rel_dir = self.data_path
         else:
-            rel_dir = self.export_dir
-
-        self._rel_dir = rel_dir
+            self._rel_dir = self.export_dir
 
         self._classes = {}
         self._labels_map_rev = {}
@@ -690,6 +698,7 @@ class YOLOv4DatasetExporter(
         self._media_exporter = foud.ImageExporter(
             self.export_media,
             export_path=export_path,
+            rel_dir=self.rel_dir,
             supported_modes=(True, False, "move", "symlink"),
             default_ext=self.image_format,
             ignore_exts=True,
@@ -795,6 +804,14 @@ class YOLOv5DatasetExporter(
 
             If None, the default value of this parameter will be chosen based
             on the value of the ``data_path`` parameter
+        rel_dir (None): an optional relative directory to strip from each input
+            filepath to generate a unique identifier for each image. When
+            exporting media, this identifier is joined with ``data_path`` and
+            ``labels_path`` to generate output paths for each exported image
+            and labels file. This argument allows for populating nested
+            subdirectories that match the shape of the input paths. The path is
+            converted to an absolute path (if necessary) via
+            :func:`fiftyone.core.utils.normalize_path`
         classes (None): the list of possible class labels
         include_confidence (False): whether to include detection confidences in
             the export, if they exist
@@ -811,6 +828,7 @@ class YOLOv5DatasetExporter(
         labels_path=None,
         yaml_path=None,
         export_media=None,
+        rel_dir=None,
         classes=None,
         include_confidence=False,
         image_format=None,
@@ -841,6 +859,7 @@ class YOLOv5DatasetExporter(
         self.labels_path = labels_path
         self.yaml_path = yaml_path
         self.export_media = export_media
+        self.rel_dir = rel_dir
         self.classes = classes
         self.include_confidence = include_confidence
         self.image_format = image_format
@@ -872,6 +891,7 @@ class YOLOv5DatasetExporter(
         self._media_exporter = foud.ImageExporter(
             self.export_media,
             export_path=self.data_path,
+            rel_dir=self.rel_dir,
             supported_modes=(True, False, "move", "symlink"),
             default_ext=self.image_format,
             ignore_exts=True,

--- a/fiftyone/utils/yolo.py
+++ b/fiftyone/utils/yolo.py
@@ -682,13 +682,9 @@ class YOLOv4DatasetExporter(
         return fol.Detections
 
     def setup(self):
-        if self.export_dir is None:
-            self._rel_dir = self.data_path
-        else:
-            self._rel_dir = self.export_dir
-
         self._classes = {}
         self._labels_map_rev = {}
+        self._rel_dir = os.path.dirname(self.images_path)
         self._images = []
         self._writer = YOLOAnnotationWriter()
 

--- a/tests/unittests/import_export_tests.py
+++ b/tests/unittests/import_export_tests.py
@@ -460,6 +460,32 @@ class ImageClassificationDatasetTests(ImageDatasetTests):
             dataset2.count("predictions"),
         )
 
+        # Labels-only (absolute paths)
+
+        labels_path = os.path.join(self._new_dir(), "labels.json")
+
+        dataset.export(
+            dataset_type=fo.types.FiftyOneImageClassificationDataset,
+            labels_path=labels_path,
+            abs_paths=True,
+        )
+
+        dataset2 = fo.Dataset.from_dir(
+            dataset_type=fo.types.FiftyOneImageClassificationDataset,
+            labels_path=labels_path,
+            label_field="predictions",
+        )
+
+        self.assertEqual(len(dataset), len(dataset2))
+        self.assertSetEqual(
+            set(dataset.values("filepath")),
+            set(dataset2.values("filepath")),
+        )
+        self.assertEqual(
+            dataset.count("predictions"),
+            dataset2.count("predictions"),
+        )
+
     @drop_datasets
     def test_image_classification_directory_tree(self):
         dataset = self._make_dataset()
@@ -826,6 +852,32 @@ class ImageDetectionDatasetTests(ImageDatasetTests):
             dataset2.count("predictions.detections"),
         )
 
+        # Labels-only (absolute paths)
+
+        labels_path = os.path.join(self._new_dir(), "labels.json")
+
+        dataset.export(
+            dataset_type=fo.types.FiftyOneImageDetectionDataset,
+            labels_path=labels_path,
+            abs_paths=True,
+        )
+
+        dataset2 = fo.Dataset.from_dir(
+            dataset_type=fo.types.FiftyOneImageDetectionDataset,
+            labels_path=labels_path,
+            label_field="predictions",
+        )
+
+        self.assertEqual(len(dataset), len(dataset2))
+        self.assertSetEqual(
+            set(dataset.values("filepath")),
+            set(dataset2.values("filepath")),
+        )
+        self.assertEqual(
+            dataset.count("predictions.detections"),
+            dataset2.count("predictions.detections"),
+        )
+
     @drop_datasets
     def test_tf_object_detection_dataset(self):
         dataset = self._make_dataset()
@@ -952,6 +1004,32 @@ class ImageDetectionDatasetTests(ImageDatasetTests):
         dataset2 = fo.Dataset.from_dir(
             dataset_type=fo.types.COCODetectionDataset,
             data_path=data_path,
+            labels_path=labels_path,
+            label_field="predictions",
+        )
+
+        self.assertEqual(len(dataset), len(dataset2))
+        self.assertSetEqual(
+            set(dataset.values("filepath")),
+            set(dataset2.values("filepath")),
+        )
+        self.assertEqual(
+            dataset.count("predictions.detections"),
+            dataset2.count("predictions.detections"),
+        )
+
+        # Labels-only (absolute paths)
+
+        labels_path = os.path.join(self._new_dir(), "labels.json")
+
+        dataset.export(
+            dataset_type=fo.types.COCODetectionDataset,
+            labels_path=labels_path,
+            abs_paths=True,
+        )
+
+        dataset2 = fo.Dataset.from_dir(
+            dataset_type=fo.types.COCODetectionDataset,
             labels_path=labels_path,
             label_field="predictions",
         )
@@ -1654,6 +1732,31 @@ class GeoLocationDatasetTests(ImageDatasetTests):
             dataset.count("coordinates"), dataset2.count("coordinates")
         )
 
+        # Labels-only (absolute paths)
+
+        labels_path = os.path.join(self._new_dir(), "labels.json")
+
+        dataset.export(
+            labels_path=labels_path,
+            dataset_type=fo.types.GeoJSONDataset,
+            abs_paths=True,
+        )
+
+        dataset2 = fo.Dataset.from_dir(
+            labels_path=labels_path,
+            dataset_type=fo.types.GeoJSONDataset,
+            location_field="coordinates",
+        )
+
+        self.assertEqual(len(dataset), len(dataset2))
+        self.assertSetEqual(
+            set(dataset.values("filepath")),
+            set(dataset2.values("filepath")),
+        )
+        self.assertEqual(
+            dataset.count("coordinates"), dataset2.count("coordinates")
+        )
+
 
 class MultitaskImageDatasetTests(ImageDatasetTests):
     def _make_dataset(self):
@@ -1815,6 +1918,30 @@ class MultitaskImageDatasetTests(ImageDatasetTests):
             dataset2.count("detections.detections"),
         )
 
+        # Labels-only (absolute paths)
+
+        labels_path = os.path.join(self._new_dir(), "labels.json")
+
+        dataset.export(
+            labels_path=labels_path,
+            dataset_type=fo.types.BDDDataset,
+            abs_paths=True,
+        )
+
+        dataset2 = fo.Dataset.from_dir(
+            labels_path=labels_path,
+            dataset_type=fo.types.BDDDataset,
+        )
+
+        self.assertEqual(
+            dataset.count("weather"),
+            dataset2.count("attributes"),
+        )
+        self.assertEqual(
+            dataset.count("predictions.detections"),
+            dataset2.count("detections.detections"),
+        )
+
     @drop_datasets
     def test_cvat_image_dataset(self):
         dataset = self._make_dataset()
@@ -1875,6 +2002,26 @@ class MultitaskImageDatasetTests(ImageDatasetTests):
         )
 
         self.assertEqual(len(dataset), len(dataset2))
+        self.assertEqual(
+            dataset.count("predictions.detections"),
+            dataset2.count("detections.detections"),
+        )
+
+        # Labels-only (absolute paths)
+
+        labels_path = os.path.join(self._new_dir(), "labels.xml")
+
+        dataset.export(
+            labels_path=labels_path,
+            dataset_type=fo.types.CVATImageDataset,
+            abs_paths=True,
+        )
+
+        dataset2 = fo.Dataset.from_dir(
+            labels_path=labels_path,
+            dataset_type=fo.types.CVATImageDataset,
+        )
+
         self.assertEqual(
             dataset.count("predictions.detections"),
             dataset2.count("detections.detections"),
@@ -2545,6 +2692,59 @@ class TemporalDetectionDatasetTests(VideoDatasetTests):
         self.assertListEqual(
             sorted(supports, key=lambda k: (k is None, k)),
             sorted(supports2, key=lambda k: (k is None, k)),
+        )
+
+        # Labels-only
+
+        data_path = self.videos_dir
+        labels_path = os.path.join(self._new_dir(), "labels.json")
+
+        dataset.export(
+            dataset_type=fo.types.FiftyOneTemporalDetectionDataset,
+            labels_path=labels_path,
+        )
+
+        dataset2 = fo.Dataset.from_dir(
+            dataset_type=fo.types.FiftyOneTemporalDetectionDataset,
+            data_path=data_path,
+            labels_path=labels_path,
+            label_field="predictions",
+        )
+
+        self.assertEqual(len(dataset), len(dataset2))
+        self.assertSetEqual(
+            set(dataset.values("filepath")),
+            set(dataset2.values("filepath")),
+        )
+        self.assertEqual(
+            dataset.count("predictions.detections"),
+            dataset2.count("predictions.detections"),
+        )
+
+        # Labels-only (absolute paths)
+
+        labels_path = os.path.join(self._new_dir(), "labels.json")
+
+        dataset.export(
+            dataset_type=fo.types.FiftyOneTemporalDetectionDataset,
+            labels_path=labels_path,
+            abs_paths=True,
+        )
+
+        dataset2 = fo.Dataset.from_dir(
+            dataset_type=fo.types.FiftyOneTemporalDetectionDataset,
+            labels_path=labels_path,
+            label_field="predictions",
+        )
+
+        self.assertEqual(len(dataset), len(dataset2))
+        self.assertSetEqual(
+            set(dataset.values("filepath")),
+            set(dataset2.values("filepath")),
+        )
+        self.assertEqual(
+            dataset.count("predictions.detections"),
+            dataset2.count("predictions.detections"),
         )
 
 

--- a/tests/unittests/import_export_tests.py
+++ b/tests/unittests/import_export_tests.py
@@ -375,8 +375,8 @@ class UnlabeledImageDatasetTests(ImageDatasetTests):
         rel_dir = self.root_dir
 
         dataset.export(
-            dataset_type=fo.types.ImageDirectory,
             export_dir=export_dir,
+            dataset_type=fo.types.ImageDirectory,
             rel_dir=rel_dir,
         )
 
@@ -387,11 +387,9 @@ class UnlabeledImageDatasetTests(ImageDatasetTests):
 
         self.assertEqual(len(dataset), len(dataset2))
 
-        relpath = os.path.relpath(
-            dataset2.first().filepath,
-            os.path.realpath(export_dir),
-        )
+        relpath = _relpath(dataset2.first().filepath, export_dir)
 
+        # _images/<filename>
         self.assertEqual(len(relpath.split(os.path.sep)), 2)
 
 
@@ -522,9 +520,9 @@ class ImageClassificationDatasetTests(ImageDatasetTests):
         rel_dir = self.root_dir
 
         dataset.export(
-            dataset_type=fo.types.FiftyOneImageClassificationDataset,
             export_dir=export_dir,
             data_path=data_path,
+            dataset_type=fo.types.FiftyOneImageClassificationDataset,
             rel_dir=rel_dir,
         )
 
@@ -540,12 +538,10 @@ class ImageClassificationDatasetTests(ImageDatasetTests):
             dataset.count("predictions"), dataset2.count("predictions")
         )
 
-        relpath = os.path.relpath(
-            dataset2.first().filepath,
-            os.path.join(export_dir, data_path),
-        )
+        relpath = _relpath(dataset2.first().filepath, export_dir)
 
-        self.assertEqual(len(relpath.split(os.path.sep)), 2)
+        # data/_images/<filename>
+        self.assertEqual(len(relpath.split(os.path.sep)), 3)
 
         # Labels-only (with rel dir)
 
@@ -553,13 +549,13 @@ class ImageClassificationDatasetTests(ImageDatasetTests):
         rel_dir = self.root_dir
 
         dataset.export(
-            dataset_type=fo.types.FiftyOneImageClassificationDataset,
             labels_path=labels_path,
+            dataset_type=fo.types.FiftyOneImageClassificationDataset,
             rel_dir=rel_dir,
         )
 
         dataset2 = fo.Dataset.from_dir(
-            data_path=self.root_dir,
+            data_path=rel_dir,
             labels_path=labels_path,
             dataset_type=fo.types.FiftyOneImageClassificationDataset,
             label_field="predictions",
@@ -570,8 +566,9 @@ class ImageClassificationDatasetTests(ImageDatasetTests):
             dataset.count("predictions"), dataset2.count("predictions")
         )
 
-        relpath = os.path.relpath(dataset2.first().filepath, rel_dir)
+        relpath = _relpath(dataset2.first().filepath, rel_dir)
 
+        # _images/<filename>
         self.assertEqual(len(relpath.split(os.path.sep)), 2)
 
     @drop_datasets
@@ -597,6 +594,33 @@ class ImageClassificationDatasetTests(ImageDatasetTests):
         self.assertEqual(
             dataset.count("predictions"), dataset2.count("predictions")
         )
+
+        # Standard format (with rel dir)
+
+        export_dir = self._new_dir()
+        rel_dir = self.root_dir
+
+        dataset.export(
+            export_dir=export_dir,
+            dataset_type=fo.types.ImageClassificationDirectoryTree,
+            rel_dir=rel_dir,
+        )
+
+        dataset2 = fo.Dataset.from_dir(
+            dataset_dir=export_dir,
+            dataset_type=fo.types.ImageClassificationDirectoryTree,
+            label_field="predictions",
+        )
+
+        self.assertEqual(len(dataset), len(dataset2))
+        self.assertEqual(
+            dataset.count("predictions"), dataset2.count("predictions")
+        )
+
+        relpath = _relpath(dataset2.first().filepath, export_dir)
+
+        # <class>/_images/<filename>
+        self.assertEqual(len(relpath.split(os.path.sep)), 3)
 
     @drop_datasets
     def test_tf_image_classification_dataset(self):
@@ -888,9 +912,9 @@ class ImageDetectionDatasetTests(ImageDatasetTests):
         rel_dir = self.root_dir
 
         dataset.export(
-            dataset_type=fo.types.FiftyOneImageDetectionDataset,
             export_dir=export_dir,
             data_path=data_path,
+            dataset_type=fo.types.FiftyOneImageDetectionDataset,
             rel_dir=rel_dir,
         )
 
@@ -907,12 +931,10 @@ class ImageDetectionDatasetTests(ImageDatasetTests):
             dataset2.count("predictions.detections"),
         )
 
-        relpath = os.path.relpath(
-            dataset2.first().filepath,
-            os.path.join(export_dir, data_path),
-        )
+        relpath = _relpath(dataset2.first().filepath, export_dir)
 
-        self.assertEqual(len(relpath.split(os.path.sep)), 2)
+        # data/_images/<filename>
+        self.assertEqual(len(relpath.split(os.path.sep)), 3)
 
         # Labels-only (with rel dir)
 
@@ -920,13 +942,13 @@ class ImageDetectionDatasetTests(ImageDatasetTests):
         rel_dir = self.root_dir
 
         dataset.export(
-            dataset_type=fo.types.FiftyOneImageDetectionDataset,
             labels_path=labels_path,
+            dataset_type=fo.types.FiftyOneImageDetectionDataset,
             rel_dir=rel_dir,
         )
 
         dataset2 = fo.Dataset.from_dir(
-            data_path=self.root_dir,
+            data_path=rel_dir,
             labels_path=labels_path,
             dataset_type=fo.types.FiftyOneImageDetectionDataset,
             label_field="predictions",
@@ -938,8 +960,9 @@ class ImageDetectionDatasetTests(ImageDatasetTests):
             dataset2.count("predictions.detections"),
         )
 
-        relpath = os.path.relpath(dataset2.first().filepath, rel_dir)
+        relpath = _relpath(dataset2.first().filepath, rel_dir)
 
+        # _images/<filename>
         self.assertEqual(len(relpath.split(os.path.sep)), 2)
 
     @drop_datasets
@@ -1108,6 +1131,34 @@ class ImageDetectionDatasetTests(ImageDatasetTests):
             dataset2.count("predictions.detections"),
         )
 
+        # Standard format (with rel dir)
+
+        export_dir = self._new_dir()
+        rel_dir = self.root_dir
+
+        dataset.export(
+            export_dir=export_dir,
+            dataset_type=fo.types.COCODetectionDataset,
+            rel_dir=rel_dir,
+        )
+
+        dataset2 = fo.Dataset.from_dir(
+            dataset_dir=export_dir,
+            dataset_type=fo.types.COCODetectionDataset,
+            label_field="predictions",
+        )
+
+        self.assertEqual(len(dataset), len(dataset2))
+        self.assertEqual(
+            dataset.count("predictions.detections"),
+            dataset2.count("predictions.detections"),
+        )
+
+        relpath = _relpath(dataset2.first().filepath, export_dir)
+
+        # data/_images/<filename>
+        self.assertEqual(len(relpath.split(os.path.sep)), 3)
+
     @drop_datasets
     def test_voc_detection_dataset(self):
         dataset = self._make_dataset()
@@ -1192,6 +1243,35 @@ class ImageDetectionDatasetTests(ImageDatasetTests):
             dataset2.count("predictions.detections"),
         )
 
+        # Standard format (with rel dir)
+
+        export_dir = self._new_dir()
+        rel_dir = self.root_dir
+
+        dataset.export(
+            export_dir=export_dir,
+            dataset_type=fo.types.VOCDetectionDataset,
+            rel_dir=rel_dir,
+        )
+
+        dataset2 = fo.Dataset.from_dir(
+            dataset_dir=export_dir,
+            dataset_type=fo.types.VOCDetectionDataset,
+            label_field="predictions",
+            include_all_data=True,
+        )
+
+        self.assertEqual(len(dataset), len(dataset2))
+        self.assertEqual(
+            dataset.count("predictions.detections"),
+            dataset2.count("predictions.detections"),
+        )
+
+        relpath = _relpath(dataset2.first().filepath, export_dir)
+
+        # data/_images/<filename>
+        self.assertEqual(len(relpath.split(os.path.sep)), 3)
+
     @drop_datasets
     def test_kitti_detection_dataset(self):
         dataset = self._make_dataset()
@@ -1246,14 +1326,14 @@ class ImageDetectionDatasetTests(ImageDatasetTests):
         labels_path = os.path.join(self._new_dir(), "labels/")
 
         dataset.export(
-            dataset_type=fo.types.KITTIDetectionDataset,
             labels_path=labels_path,
+            dataset_type=fo.types.KITTIDetectionDataset,
         )
 
         dataset2 = fo.Dataset.from_dir(
-            dataset_type=fo.types.KITTIDetectionDataset,
             data_path=data_path,
             labels_path=labels_path,
+            dataset_type=fo.types.KITTIDetectionDataset,
             label_field="predictions",
             include_all_data=True,
         )
@@ -1267,6 +1347,35 @@ class ImageDetectionDatasetTests(ImageDatasetTests):
             dataset.count("predictions.detections"),
             dataset2.count("predictions.detections"),
         )
+
+        # Standard format (with rel dir)
+
+        export_dir = self._new_dir()
+        rel_dir = self.root_dir
+
+        dataset.export(
+            export_dir=export_dir,
+            dataset_type=fo.types.KITTIDetectionDataset,
+            rel_dir=rel_dir,
+        )
+
+        dataset2 = fo.Dataset.from_dir(
+            dataset_dir=export_dir,
+            dataset_type=fo.types.KITTIDetectionDataset,
+            label_field="predictions",
+            include_all_data=True,
+        )
+
+        self.assertEqual(len(dataset), len(dataset2))
+        self.assertEqual(
+            dataset.count("predictions.detections"),
+            dataset2.count("predictions.detections"),
+        )
+
+        relpath = _relpath(dataset2.first().filepath, export_dir)
+
+        # data/_images/<filename>
+        self.assertEqual(len(relpath.split(os.path.sep)), 3)
 
     @drop_datasets
     def test_yolov4_dataset(self):
@@ -1341,8 +1450,39 @@ class ImageDetectionDatasetTests(ImageDatasetTests):
             dataset.count("predictions.detections"),
             dataset2.count("predictions.detections"),
         )
+
         for sample in dataset2:
             self.assertTrue(os.path.isfile(sample.filepath))
+
+        # Standard format
+
+        export_dir = self._new_dir()
+        rel_dir = self.root_dir
+
+        dataset.export(
+            export_dir=export_dir,
+            dataset_type=fo.types.YOLOv4Dataset,
+            rel_dir=rel_dir,
+            label_field="predictions",
+        )
+
+        dataset2 = fo.Dataset.from_dir(
+            dataset_dir=export_dir,
+            dataset_type=fo.types.YOLOv4Dataset,
+            label_field="predictions",
+            include_all_data=True,
+        )
+
+        self.assertEqual(len(dataset), len(dataset2))
+        self.assertEqual(
+            dataset.count("predictions.detections"),
+            dataset2.count("predictions.detections"),
+        )
+
+        relpath = _relpath(dataset2.first().filepath, export_dir)
+
+        # images/_images/<filename>
+        self.assertEqual(len(relpath.split(os.path.sep)), 3)
 
     @drop_datasets
     def test_yolov5_dataset(self):
@@ -1390,6 +1530,35 @@ class ImageDetectionDatasetTests(ImageDatasetTests):
         bounds2 = dataset2.bounds("predictions.detections.confidence")
         self.assertAlmostEqual(bounds[0], bounds2[0])
         self.assertAlmostEqual(bounds[1], bounds2[1])
+
+        # Standard format (with rel dir)
+
+        export_dir = self._new_dir()
+        rel_dir = self.root_dir
+
+        dataset.export(
+            export_dir=export_dir,
+            dataset_type=fo.types.YOLOv5Dataset,
+            rel_dir=rel_dir,
+        )
+
+        dataset2 = fo.Dataset.from_dir(
+            dataset_dir=export_dir,
+            dataset_type=fo.types.YOLOv5Dataset,
+            label_field="predictions",
+            include_all_data=True,
+        )
+
+        self.assertEqual(len(dataset), len(dataset2))
+        self.assertEqual(
+            dataset.count("predictions.detections"),
+            dataset2.count("predictions.detections"),
+        )
+
+        relpath = _relpath(dataset2.first().filepath, export_dir)
+
+        # images/<split>/_images/<filename>
+        self.assertEqual(len(relpath.split(os.path.sep)), 4)
 
     @drop_datasets
     def test_add_yolo_labels(self):
@@ -1665,6 +1834,36 @@ class ImageSegmentationDatasetTests(ImageDatasetTests):
             dataset2.count("segmentations.mask"),
         )
 
+        # Segmentations (with rel dir)
+
+        export_dir = self._new_dir()
+        rel_dir = self.root_dir
+
+        dataset.export(
+            export_dir=export_dir,
+            dataset_type=fo.types.ImageSegmentationDirectory,
+            rel_dir=rel_dir,
+            label_field="segmentations",
+        )
+
+        dataset2 = fo.Dataset.from_dir(
+            dataset_dir=export_dir,
+            dataset_type=fo.types.ImageSegmentationDirectory,
+            label_field="segmentations",
+            include_all_data=True,
+        )
+
+        self.assertEqual(len(dataset), len(dataset2))
+        self.assertEqual(
+            dataset.count("segmentations.mask"),
+            dataset2.count("segmentations.mask"),
+        )
+
+        relpath = _relpath(dataset2.first().filepath, export_dir)
+
+        # data/_images/<filename>
+        self.assertEqual(len(relpath.split(os.path.sep)), 3)
+
 
 class DICOMDatasetTests(ImageDatasetTests):
     def _get_dcm_path(self):
@@ -1821,6 +2020,33 @@ class GeoLocationDatasetTests(ImageDatasetTests):
             dataset.count("coordinates"), dataset2.count("coordinates")
         )
 
+        # Standard format (with rel dir)
+
+        export_dir = self._new_dir()
+        rel_dir = self.root_dir
+
+        dataset.export(
+            export_dir=export_dir,
+            dataset_type=fo.types.GeoJSONDataset,
+            rel_dir=rel_dir,
+        )
+
+        dataset2 = fo.Dataset.from_dir(
+            dataset_dir=export_dir,
+            dataset_type=fo.types.GeoJSONDataset,
+            location_field="coordinates",
+        )
+
+        self.assertEqual(len(dataset), len(dataset2))
+        self.assertEqual(
+            dataset.count("coordinates"), dataset2.count("coordinates")
+        )
+
+        relpath = _relpath(dataset2.first().filepath, export_dir)
+
+        # data/_images/<filename>
+        self.assertEqual(len(relpath.split(os.path.sep)), 3)
+
 
 class MultitaskImageDatasetTests(ImageDatasetTests):
     def _make_dataset(self):
@@ -1908,6 +2134,33 @@ class MultitaskImageDatasetTests(ImageDatasetTests):
             dataset.distinct("predictions.detections.confidence"),
             dataset2.distinct("detections.detections.confidence"),
         )
+
+        # Standard format (with rel dir)
+
+        export_dir = self._new_dir()
+        rel_dir = self.root_dir
+
+        dataset.export(
+            export_dir=export_dir,
+            dataset_type=fo.types.FiftyOneImageLabelsDataset,
+            rel_dir=rel_dir,
+        )
+
+        dataset2 = fo.Dataset.from_dir(
+            dataset_dir=export_dir,
+            dataset_type=fo.types.FiftyOneImageLabelsDataset,
+        )
+
+        self.assertEqual(len(dataset), len(dataset2))
+        self.assertEqual(
+            dataset.count("predictions.detections"),
+            dataset2.count("detections.detections"),
+        )
+
+        relpath = _relpath(dataset2.first().filepath, export_dir)
+
+        # data/_images/<filename>
+        self.assertEqual(len(relpath.split(os.path.sep)), 3)
 
     @drop_datasets
     def test_bdd_dataset(self):
@@ -2006,6 +2259,38 @@ class MultitaskImageDatasetTests(ImageDatasetTests):
             dataset2.count("detections.detections"),
         )
 
+        # Standard format (with rel dir)
+
+        export_dir = self._new_dir()
+        rel_dir = self.root_dir
+
+        dataset.export(
+            export_dir=export_dir,
+            dataset_type=fo.types.BDDDataset,
+            rel_dir=rel_dir,
+        )
+
+        dataset2 = fo.Dataset.from_dir(
+            dataset_dir=export_dir,
+            dataset_type=fo.types.BDDDataset,
+            include_all_data=True,
+        )
+
+        self.assertEqual(len(dataset), len(dataset2))
+        self.assertEqual(
+            dataset.count("weather"),
+            dataset2.count("attributes"),
+        )
+        self.assertEqual(
+            dataset.count("predictions.detections"),
+            dataset2.count("detections.detections"),
+        )
+
+        relpath = _relpath(dataset2.first().filepath, export_dir)
+
+        # data/_images/<filename>
+        self.assertEqual(len(relpath.split(os.path.sep)), 3)
+
     @drop_datasets
     def test_cvat_image_dataset(self):
         dataset = self._make_dataset()
@@ -2090,6 +2375,34 @@ class MultitaskImageDatasetTests(ImageDatasetTests):
             dataset.count("predictions.detections"),
             dataset2.count("detections.detections"),
         )
+
+        # Standard format (with rel dir)
+
+        export_dir = self._new_dir()
+        rel_dir = self.root_dir
+
+        dataset.export(
+            export_dir=export_dir,
+            dataset_type=fo.types.CVATImageDataset,
+            rel_dir=rel_dir,
+        )
+
+        dataset2 = fo.Dataset.from_dir(
+            dataset_dir=export_dir,
+            dataset_type=fo.types.CVATImageDataset,
+            include_all_data=True,
+        )
+
+        self.assertEqual(len(dataset), len(dataset2))
+        self.assertEqual(
+            dataset.count("predictions.detections"),
+            dataset2.count("detections.detections"),
+        )
+
+        relpath = _relpath(dataset2.first().filepath, export_dir)
+
+        # data/_images/<filename>
+        self.assertEqual(len(relpath.split(os.path.sep)), 3)
 
     @skipwindows
     @drop_datasets
@@ -2182,6 +2495,82 @@ class MultitaskImageDatasetTests(ImageDatasetTests):
             dataset3.count("predictions.detections"),
         )
 
+        # Labels-only (absolute paths)
+
+        export_dir = self._new_dir()
+
+        dataset.export(
+            dataset_type=fo.types.FiftyOneDataset,
+            export_dir=export_dir,
+            export_media=False,
+        )
+
+        self.assertFalse(os.path.isdir(os.path.join(export_dir, "data")))
+
+        dataset2 = fo.Dataset.from_dir(
+            dataset_dir=export_dir,
+            dataset_type=fo.types.FiftyOneDataset,
+        )
+
+        self.assertEqual(len(dataset), len(dataset2))
+        self.assertListEqual(
+            dataset.values("filepath"),
+            dataset2.values("filepath"),
+        )
+
+        # Labels-only (with rel dir)
+
+        export_dir = self._new_dir()
+        rel_dir = self.root_dir
+
+        dataset.export(
+            export_dir=export_dir,
+            dataset_type=fo.types.FiftyOneDataset,
+            export_media=False,
+            rel_dir=rel_dir,
+        )
+
+        self.assertFalse(os.path.isdir(os.path.join(export_dir, "data")))
+
+        dataset2 = fo.Dataset.from_dir(
+            dataset_dir=export_dir,
+            dataset_type=fo.types.FiftyOneDataset,
+            rel_dir=rel_dir,
+        )
+
+        self.assertEqual(len(dataset), len(dataset2))
+        self.assertListEqual(
+            dataset.values("filepath"),
+            dataset2.values("filepath"),
+        )
+
+        # Standard format (with rel dir)
+
+        export_dir = self._new_dir()
+        rel_dir = self.root_dir
+
+        dataset.export(
+            export_dir=export_dir,
+            dataset_type=fo.types.FiftyOneDataset,
+            rel_dir=rel_dir,
+        )
+
+        dataset2 = fo.Dataset.from_dir(
+            dataset_dir=export_dir,
+            dataset_type=fo.types.FiftyOneDataset,
+        )
+
+        self.assertEqual(len(dataset), len(dataset2))
+        self.assertEqual(
+            dataset.count("predictions.detections"),
+            dataset2.count("predictions.detections"),
+        )
+
+        relpath = _relpath(dataset2.first().filepath, export_dir)
+
+        # data/_images/<filename>
+        self.assertEqual(len(relpath.split(os.path.sep)), 3)
+
     @skipwindows
     @drop_datasets
     def test_legacy_fiftyone_dataset(self):
@@ -2244,6 +2633,83 @@ class MultitaskImageDatasetTests(ImageDatasetTests):
         info = dataset.get_evaluation_info("test")
         info2 = dataset2.get_evaluation_info("test")
         self.assertEqual(info.key, info2.key)
+
+        # Labels-only (absolute paths)
+
+        export_dir = self._new_dir()
+
+        dataset.export(
+            dataset_type=fo.types.LegacyFiftyOneDataset,
+            export_dir=export_dir,
+            export_media=False,
+            abs_paths=True,
+        )
+
+        self.assertFalse(os.path.isdir(os.path.join(export_dir, "data")))
+
+        dataset2 = fo.Dataset.from_dir(
+            dataset_type=fo.types.LegacyFiftyOneDataset,
+            dataset_dir=export_dir,
+        )
+
+        self.assertEqual(len(dataset), len(dataset2))
+        self.assertListEqual(
+            dataset.values("filepath"),
+            dataset2.values("filepath"),
+        )
+
+        # Labels-only (with rel dir)
+
+        export_dir = self._new_dir()
+        rel_dir = self.root_dir
+
+        dataset.export(
+            export_dir=export_dir,
+            dataset_type=fo.types.LegacyFiftyOneDataset,
+            export_media=False,
+            rel_dir=rel_dir,
+        )
+
+        self.assertFalse(os.path.isdir(os.path.join(export_dir, "data")))
+
+        dataset2 = fo.Dataset.from_dir(
+            dataset_type=fo.types.LegacyFiftyOneDataset,
+            dataset_dir=export_dir,
+            rel_dir=rel_dir,
+        )
+
+        self.assertEqual(len(dataset), len(dataset2))
+        self.assertListEqual(
+            dataset.values("filepath"),
+            dataset2.values("filepath"),
+        )
+
+        # Standard format (with rel dir)
+
+        export_dir = self._new_dir()
+        rel_dir = self.root_dir
+
+        dataset.export(
+            export_dir=export_dir,
+            dataset_type=fo.types.LegacyFiftyOneDataset,
+            rel_dir=rel_dir,
+        )
+
+        dataset2 = fo.Dataset.from_dir(
+            dataset_dir=export_dir,
+            dataset_type=fo.types.LegacyFiftyOneDataset,
+        )
+
+        self.assertEqual(len(dataset), len(dataset2))
+        self.assertEqual(
+            dataset.count("predictions.detections"),
+            dataset2.count("predictions.detections"),
+        )
+
+        relpath = _relpath(dataset2.first().filepath, export_dir)
+
+        # data/_images/<filename>
+        self.assertEqual(len(relpath.split(os.path.sep)), 3)
 
 
 class OpenLABELImageDatasetTests(ImageDatasetTests):
@@ -2628,8 +3094,8 @@ class UnlabeledVideoDatasetTests(VideoDatasetTests):
         rel_dir = self.root_dir
 
         dataset.export(
-            dataset_type=fo.types.VideoDirectory,
             export_dir=export_dir,
+            dataset_type=fo.types.VideoDirectory,
             rel_dir=rel_dir,
         )
 
@@ -2640,11 +3106,9 @@ class UnlabeledVideoDatasetTests(VideoDatasetTests):
 
         self.assertEqual(len(dataset), len(dataset2))
 
-        relpath = os.path.relpath(
-            dataset2.first().filepath,
-            os.path.realpath(export_dir),
-        )
+        relpath = _relpath(dataset2.first().filepath, export_dir)
 
+        # _videos/<filename>
         self.assertEqual(len(relpath.split(os.path.sep)), 2)
 
 
@@ -2690,6 +3154,33 @@ class VideoClassificationDatasetTests(VideoDatasetTests):
         self.assertEqual(
             dataset.count("predictions"), dataset2.count("predictions")
         )
+
+        # Standard format (with rel dir)
+
+        export_dir = self._new_dir()
+        rel_dir = self.root_dir
+
+        dataset.export(
+            export_dir=export_dir,
+            dataset_type=fo.types.VideoClassificationDirectoryTree,
+            rel_dir=rel_dir,
+        )
+
+        dataset2 = fo.Dataset.from_dir(
+            dataset_dir=export_dir,
+            dataset_type=fo.types.VideoClassificationDirectoryTree,
+            label_field="predictions",
+        )
+
+        self.assertEqual(len(dataset), len(dataset2))
+        self.assertEqual(
+            dataset.count("predictions"), dataset2.count("predictions")
+        )
+
+        relpath = _relpath(dataset2.first().filepath, export_dir)
+
+        # <class>/_videos/<filename>
+        self.assertEqual(len(relpath.split(os.path.sep)), 3)
 
 
 class TemporalDetectionDatasetTests(VideoDatasetTests):
@@ -2847,9 +3338,9 @@ class TemporalDetectionDatasetTests(VideoDatasetTests):
         rel_dir = self.root_dir
 
         dataset.export(
-            dataset_type=fo.types.FiftyOneTemporalDetectionDataset,
             export_dir=export_dir,
             data_path=data_path,
+            dataset_type=fo.types.FiftyOneTemporalDetectionDataset,
             rel_dir=rel_dir,
         )
 
@@ -2866,12 +3357,10 @@ class TemporalDetectionDatasetTests(VideoDatasetTests):
             dataset2.count("predictions.detections"),
         )
 
-        relpath = os.path.relpath(
-            dataset2.first().filepath,
-            os.path.join(export_dir, data_path),
-        )
+        relpath = _relpath(dataset2.first().filepath, export_dir)
 
-        self.assertEqual(len(relpath.split(os.path.sep)), 2)
+        # data/_videos/<filename>
+        self.assertEqual(len(relpath.split(os.path.sep)), 3)
 
         # Labels-only (with rel dir)
 
@@ -2879,13 +3368,13 @@ class TemporalDetectionDatasetTests(VideoDatasetTests):
         rel_dir = self.root_dir
 
         dataset.export(
-            dataset_type=fo.types.FiftyOneTemporalDetectionDataset,
             labels_path=labels_path,
+            dataset_type=fo.types.FiftyOneTemporalDetectionDataset,
             rel_dir=rel_dir,
         )
 
         dataset2 = fo.Dataset.from_dir(
-            data_path=self.root_dir,
+            data_path=rel_dir,
             labels_path=labels_path,
             dataset_type=fo.types.FiftyOneTemporalDetectionDataset,
             label_field="predictions",
@@ -2897,7 +3386,8 @@ class TemporalDetectionDatasetTests(VideoDatasetTests):
             dataset2.count("predictions.detections"),
         )
 
-        relpath = os.path.relpath(dataset2.first().filepath, rel_dir)
+        # _videos/<filename>
+        relpath = _relpath(dataset2.first().filepath, rel_dir)
 
         self.assertEqual(len(relpath.split(os.path.sep)), 2)
 
@@ -2990,6 +3480,33 @@ class MultitaskVideoDatasetTests(VideoDatasetTests):
             dataset2.distinct("frames.detections.detections.confidence"),
         )
 
+        # Standard format (with rel dir)
+
+        export_dir = self._new_dir()
+        rel_dir = self.root_dir
+
+        dataset.export(
+            export_dir=export_dir,
+            dataset_type=fo.types.FiftyOneVideoLabelsDataset,
+            rel_dir=rel_dir,
+        )
+
+        dataset2 = fo.Dataset.from_dir(
+            dataset_dir=export_dir,
+            dataset_type=fo.types.FiftyOneVideoLabelsDataset,
+        )
+
+        self.assertEqual(len(dataset), len(dataset2))
+        self.assertEqual(
+            dataset.count("frames.predictions.detections"),
+            dataset2.count("frames.detections.detections"),
+        )
+
+        relpath = _relpath(dataset2.first().filepath, export_dir)
+
+        # data/_videos/<filename>
+        self.assertEqual(len(relpath.split(os.path.sep)), 3)
+
     @drop_datasets
     def test_cvat_video_dataset(self):
         dataset = self._make_dataset()
@@ -3054,6 +3571,39 @@ class MultitaskVideoDatasetTests(VideoDatasetTests):
             dataset.count("frames.predictions.detections"),
             dataset2.count("frames.detections.detections"),
         )
+
+        # Standard format (with rel dir)
+
+        export_dir = self._new_dir()
+        rel_dir = self.root_dir
+
+        dataset.export(
+            export_dir=export_dir,
+            dataset_type=fo.types.CVATVideoDataset,
+            rel_dir=rel_dir,
+        )
+
+        dataset2 = fo.Dataset.from_dir(
+            dataset_dir=export_dir,
+            dataset_type=fo.types.CVATVideoDataset,
+            include_all_data=True,
+        )
+
+        self.assertEqual(len(dataset), len(dataset2))
+        self.assertEqual(
+            dataset.count("frames.predictions.detections"),
+            dataset2.count("frames.detections.detections"),
+        )
+
+        relpath = _relpath(dataset2.first().filepath, export_dir)
+
+        # data/_videos/<filename>
+        self.assertEqual(len(relpath.split(os.path.sep)), 3)
+
+
+def _relpath(path, start):
+    # Avoids errors related to symlinks in `/tmp` directories
+    return os.path.relpath(os.path.realpath(path), os.path.realpath(start))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Resolves https://github.com/voxel51/fiftyone/issues/2000

Other goodies:
- Added a `rel_dir` parameter on `draw_labels()` and `export()`---as well as all builtin exporters---which allows for the possibility of preserving nested subdirectory structure of the input dataset's media
- Adds an optional `abs_paths` parameter to all relevant exporters that allows for storing absolute paths to media in the exported labels
