### PR TITLE
Adding plugins docs/env var

### DIFF
--- a/app/packages/plugins/README.md
+++ b/app/packages/plugins/README.md
@@ -36,14 +36,18 @@ NOTE: your plugins directory must be readable by the FiftyOne server.
 Once you have a plugins directory setup, you must create a shell package to
 version your plugins:
 
-```
+```shell
 cd $FIFTYONE_PLUGINS_DIR
-yarn init # or npm init
+
+yarn init
+
+# or with npm
+npm init
 ```
 
 Now you can install a node package that contains a plugin:
 
-```
+```shell
 # if it is avaialable on plubic/private npm registry
 yarn add my-fiftyone-plugin
 
@@ -55,7 +59,7 @@ If your plugin is only available in a git repository, you can still install via
 git, although the environment must be configured to allow reading from that git
 repository:
 
-```
+```shell
 # install via a github http url
 yarn add my-plugin@https://github.com/user/my-plugin.git#my-branch-name
 
@@ -99,17 +103,19 @@ First ensure your plugin's `package.json` includes the path to the plugin
 script:
 
 ```json
+{
   "fiftyone": {
     "script": "dist/index.umd.js"
   }
+}
 ```
 
 Then follow the steps below, in separate terminal sessions as needed.
 
-```sh
+```shell
 # tell FiftyOne where you want to load plugins from
-# this should be a parent directory to all your plugins
-FIFTYONE_PLUGINS_DIR=$MY_PLUGINS_DIR
+# this should be the parent directory to all your plugins
+FIFTYONE_PLUGINS_DIR=/path/to/your/plugins
 
 # start the FiftyOne App in dev mode
 cd $FIFTYONE/app/packaages/app
@@ -154,10 +160,11 @@ Before publishing make sure you do the following:
 
 Then to publish your latest plugin to an npm registry:
 
-```
-# using yarn
+```shell
 yarn publish
-# using npm
+
+# or with npm
+npm publish
 ```
 
 If you are using a git repository to publish your plugins, you must ensure that

--- a/app/packages/plugins/README.md
+++ b/app/packages/plugins/README.md
@@ -1,35 +1,59 @@
-# Plugins
+# FiftyOne Plugins
 
-Develop plugins for fiftyone.
+FiftyOne provides a plugin system that you can use to customize and extend its
+behavior!
+
+This document describes how to develop, publish, and install custom plugins.
 
 ## Installing plugins
 
-In order to install a plugin you must have one of the two tools available in the environment you are running fiftyone.
+In order to install plugins you must have one of the following tools available
+in the environment you are running FiftyOne:
 
-- npm
-- yarn
+- `npm`
+- `yarn`
 
-Create a directory where you want to store your plugins. Note: this directory must be readable by the fiftyone server.
+First, create a directory where you want to store your plugins.
 
-When running fiftyone, you must specify the location of the plugin directory using the `FIFTYONE_PLUGINS_DIR`.
+Subsequently, when running FiftyOne, you must specify the location of this
+directory by setting the `FIFTYONE_PLUGINS_DIR` environment variable:
 
-Once you have a plugins directory setup, you must create a shell package to version your plugins.
+```shell
+export FIFTYONE_PLUGINS_DIR=/path/to/your/plugins
+```
+
+You can also permanently configure this directory by adding it to your
+[FiftyOne config](https://voxel51.com/docs/fiftyone/user_guide/config.html):
+
+```json
+{
+  "plugins_dir": "/path/to/your/plugins"
+}
+```
+
+NOTE: your plugins directory must be readable by the FiftyOne server.
+
+Once you have a plugins directory setup, you must create a shell package to
+version your plugins:
 
 ```
 cd $FIFTYONE_PLUGINS_DIR
 yarn init # or npm init
 ```
 
-Now you can install a node package that contains a plugin.
+Now you can install a node package that contains a plugin:
 
 ```
 # if it is avaialable on plubic/private npm registry
 yarn add my-fiftyone-plugin
+
 # or with npm
 npm install my-fiftyone-plugin --save
 ```
 
-If your plugin is only available in a git repository, you can still install via git, although the environment must be configured to allow reading from that git repository.
+If your plugin is only available in a git repository, you can still install via
+git, although the environment must be configured to allow reading from that git
+repository:
 
 ```
 # install via a github http url
@@ -41,13 +65,14 @@ yarn add ssh://github.com/user/my-plugin#my-branch
 
 ## Configuring plugins
 
-In your `FIFTYONE_PLUGINS_DIR`, create a file named `settings.json`. Each top level property in this file corresponds to the
-name (package.json "name") of one of your installed plugins.
+In your `FIFTYONE_PLUGINS_DIR`, create a file named `settings.json`. Each top
+level property in this file corresponds to the name (package.json "name") of
+one of your installed plugins.
 
-Each plugin should describe what settings it supports. All plugins share the "enabled" setting. If set to `false` the
-plugin will not be loaded.
+Each plugin should describe what settings it supports. All plugins share the
+"enabled" setting. If set to `false` the plugin will not be loaded.
 
-Below is an example `settings.json` file.
+Below is an example `settings.json` file:
 
 ```json
 {
@@ -58,19 +83,20 @@ Below is an example `settings.json` file.
 }
 ```
 
-## Developing your Plugin
+## Developing plugins
 
 In order to develop and test your plugin you will need the following:
 
-- a development install of fiftyone
-- the fiftyone app setup for development
-- a plugin skeleton (start with one of the plugins in voxel51/fiftyone-plugins)
+- A development install of FiftyOne
+- The FiftyOne App setup for development
+- A plugin skeleton (start with one of the plugins in voxel51/fiftyone-plugins)
 - npm link / symlink to the `@fiftyone/plugins` package
 - npm link / symlink to the `@fiftyone/aggregations` package (optional)
 
 For local testing, follow these basic steps:
 
-First ensure your plugin's `package.json` includes the path to the plugin script:
+First ensure your plugin's `package.json` includes the path to the plugin
+script:
 
 ```json
   "fiftyone": {
@@ -81,15 +107,15 @@ First ensure your plugin's `package.json` includes the path to the plugin script
 Then follow the steps below, in separate terminal sessions as needed.
 
 ```sh
-# tell fiftyone where you want to load plugins from
+# tell FiftyOne where you want to load plugins from
 # this should be a parent directory to all your plugins
 FIFTYONE_PLUGINS_DIR=$MY_PLUGINS_DIR
 
-# start the fiftyone app in dev mode
+# start the FiftyOne App in dev mode
 cd $FIFTYONE/app/packaages/app
 yarn dev
 
-# start the fiftyone python server (in a separate session)
+# start the FiftyOne python server (in a separate session)
 cd $FIFTYONE
 python fiftyone/server/main.py
 
@@ -106,22 +132,25 @@ npm link @fiftyone/plugins
 yarn build
 ```
 
-You should now have a running fiftyone server and app, including your plugin.
+You should now have a running FiftyOne server and App, including your plugin.
 
-NOTE: each time you change you plugin's source you must rebuild using `yarn build`. You can setup a watcher to do this automatically (see: [nodemon](https://www.npmjs.com/package/nodemon)).
+NOTE: each time you change you plugin's source you must rebuild using
+`yarn build`. You can setup a watcher to do this automatically
+(see: [nodemon](https://www.npmjs.com/package/nodemon)).
 
 ## Publishing your plugin
 
-You can publish your plugin to either a public/private npm registry,
-or a git repository. Including your package.json and built (dist) files is required for both. No other files are required to be published with your plugin.
+You can publish your plugin to either a public/private npm registry or a git
+repository. Including your package.json and built (dist) files is required for
+both. No other files are required to be published with your plugin.
 
 Before publishing make sure you do the following:
 
-- login to the registry you are trying to publish to
-- OR use a .npmrc to include private registry credentials
-- have the correct name, version, etc in your package.json
-- have a built plugin `dist` directory
-- your package.json points to the plugin entry point
+- Login to the registry you are trying to publish to
+- OR use a `.npmrc` to include private registry credentials
+- Have the correct name, version, etc in your package.json
+- Have a built plugin `dist` directory
+- Your `package.json` points to the plugin entry point
 
 Then to publish your latest plugin to an npm registry:
 
@@ -131,17 +160,17 @@ yarn publish
 # using npm
 ```
 
-If you are using a git repository to publish your plugins,
-you must ensure that you include the `dist` directory when
-pushing to the remote repo.
+If you are using a git repository to publish your plugins, you must ensure that
+you include the `dist` directory when pushing to the remote repo.
 
-## How to write Plugins
+## How to write plugins
 
-Below are introductory examples to the fiftyone plugin api.
+Below are introductory examples to the FiftyOne plugin API.
 
-### Hello World
+### Hello world
 
-A simple hello world plugin, that renders "hello world" in place of the plots main content area, would look like this:
+A simple hello world plugin, that renders "hello world" in place of the plots
+main content area, would look like this:
 
 ```jsx
 import { registerComponent, PluginComponentTypes } from "@fiftyone/plugins";
@@ -156,11 +185,13 @@ registerComponent({
 });
 ```
 
-Installing the plugin above would require building a bundle JS file and placing in a directory with a `package.json` file.
+Installing the plugin above would require building a bundle JS file and placing
+in a directory with a `package.json` file.
 
-The fiftyone python server will then detect this as an installed plugin and the app will load it and render it.
+The FiftyOne python server will then detect this as an installed plugin and the
+App will load it and render it.
 
-### Adding a custom Fiftyone Visualizer
+### Adding a custom FiftyOne Visualizer
 
 ```jsx
 import * as fop from "@fiftyone/plugins";
@@ -170,20 +201,20 @@ function PointCloud({ src }) {
   // TODO: implement your visualizer using React
 }
 
-// this separate components shows where the fiftyone plugin
+// this separate components shows where the FiftyOne plugin
 // dependent code ends and the pure react code begins
 function CustomVisualizer({ sample }) {
   const src = fos.getSampleSrc(sample.filepath);
   // now that we have all the data we need
   // we can delegate to code that doesn't depend
-  // on the fiftyone plugin api
+  // on the FiftyOne plugin API
   return <PointCloud src={src} />;
 }
 
 fop.registerComponent({
   // component to delegate to
   copmponent: CustomVisualizer,
-  // tell fiftyone you want to provide a Visualizer
+  // tell FiftyOne you want to provide a Visualizer
   type: PluginComponentTypes.Visualizer,
   // activate this plugin when the mediaType is PointCloud
   activator: ({ dataset }) => dataset.mediaType === "PointCloud",
@@ -230,7 +261,7 @@ function CustomPlot() {
 fop.registerComponent({
   // component to delegate to
   copmponent: CustomPlot,
-  // tell fiftyone you want to provide a custom Plot
+  // tell FiftyOne you want to provide a custom Plot
   type: PluginComponentTypes.Plot,
   // used for the plot selector button
   label: "Map",
@@ -239,7 +270,7 @@ fop.registerComponent({
 });
 ```
 
-### Reacting to State Changes
+### Reacting to state changes
 
 ```tsx
 import * as fos from '@fiftyone/state'
@@ -255,11 +286,15 @@ function MyPlugin() {
 }
 ```
 
-### Interactivity and State
+### Interactivity and state
 
-If your plugin only has internal state, you can use existing state management to achieve your desired ux. Eg. in a 3d Visualizer, you might want to use Thee.js and its object model, events, and state management. Or just use your own React hooks to maintain your plugin components internal state.
+If your plugin only has internal state, you can use existing state management
+to achieve your desired ux. For example, in a 3D visualizer, you might want to
+use Thee.js and its object model, events, and state management. Or just use
+your own React hooks to maintain your plugin components internal state.
 
-If you want to allow users to interact with other aspects of fiftyone through your plugin, you can use the `@fiftyone/state` package.
+If you want to allow users to interact with other aspects of FiftyOne through
+your plugin, you can use the `@fiftyone/state` package:
 
 ```jsx
 // note: similar to react hooks, these must be used in the context
@@ -272,13 +307,16 @@ const selectLabel = fos.useOnSelectLabel();
 selectLabel({ id: "labelId", field: "fieldName" });
 ```
 
-## Reading Settings in Your Plugin
+## Reading settings in your plugin
 
-Somme plugins use libraries or tools that require credentials such as API keys or tokens. Below is an example for how to provide and read these credentials.
+Somme plugins use libraries or tools that require credentials such as API keys
+or tokens. Below is an example for how to provide and read these credentials.
 
-The same mechanism can be used to expose configuration to plugin users, such as color choices, and default values.
+The same mechanism can be used to expose configuration to plugin users, such as
+color choices, and default values.
 
-You can store your credentials in your plugin settings located at `FIFTYONE_PLUGINS_DIR/settings.json`:
+You can store your credentials in your plugin settings located at
+`${FIFTYONE_PLUGINS_DIR}/settings.json`:
 
 ```json
 {
@@ -288,17 +326,22 @@ You can store your credentials in your plugin settings located at `FIFTYONE_PLUG
 }
 ```
 
-Then in your plugin implementation, you can read settings with the `useSettings` hook:
+Then in your plugin implementation, you can read settings with the
+`useSettings` hook:
 
 ```js
 const { mapboxAPIKey } = fop.useSettings("my-map-box-plugin");
 ```
 
-## Querying Fiftyone
+## Querying FiftyOne
 
-The typical use case for a plugin is to provide a unique way of visualizing fiftyone data. However some plugins may need to also fetch data in a unique way to efficiently visualize it.
+The typical use case for a plugin is to provide a unique way of visualizing
+FiftyOne data. However some plugins may need to also fetch data in a unique way
+to efficiently visualize it.
 
-For example, a `PluginComponentType.Plot` plugin rendering a map of geo points may need to fetch data relative to where the user is currently viewing. In mongodb, such a query would look like this:
+For example, a `PluginComponentType.Plot` plugin rendering a map of geo points
+may need to fetch data relative to where the user is currently viewing. In
+MongoDB, such a query would look like this:
 
 ```js
 {
@@ -310,7 +353,8 @@ For example, a `PluginComponentType.Plot` plugin rendering a map of geo points m
 }
 ```
 
-In a fiftyone plugin this same query can be performed using the `useAggregation()` method of the plugin sdk.
+In a FiftyOne plugin this same query can be performed using the
+`useAggregation()` method of the plugin SDK:
 
 ```js
 import * as fop from "@fiftyone/plugins";

--- a/docs/source/user_guide/app.rst
+++ b/docs/source/user_guide/app.rst
@@ -1194,5 +1194,5 @@ FiftyOne provides a plugin system that you can use to customize and extend its
 behavior!
 
 Check out
-`this page <https://github.com/voxel51/fiftyone/blob/groups/app/packages/plugins/README.md>`_
+`this page <https://github.com/voxel51/fiftyone/blob/develop/app/packages/plugins/README.md>`_
 for documentation on developing and installing custom plugins.

--- a/docs/source/user_guide/app.rst
+++ b/docs/source/user_guide/app.rst
@@ -1184,3 +1184,15 @@ you can use to customize the behavior of the App for that particular dataset:
     :meth:`app_config <fiftyone.core.dataset.Dataset.app_config>` will override
     the corresponding settings from your
     :ref:`global App config <configuring-fiftyone-app>`.
+
+.. _app-plugins:
+
+Custom App plugins
+__________________
+
+FiftyOne provides a plugin system that you can use to customize and extend its
+behavior!
+
+Check out
+`this page <https://github.com/voxel51/fiftyone/blob/groups/app/packages/plugins/README.md>`_
+for documentation on developing and installing custom plugins.

--- a/docs/source/user_guide/config.rst
+++ b/docs/source/user_guide/config.rst
@@ -88,6 +88,9 @@ FiftyOne supports the configuration options described below:
 | `module_path`                 | `FIFTYONE_MODULE_PATH`              | `None`                        | A list of modules that should be automatically imported whenever FiftyOne is imported. |
 |                               |                                     |                               | See :ref:`this page <custom-embedded-documents>` for an example usage.                 |
 +-------------------------------+-------------------------------------+-------------------------------+----------------------------------------------------------------------------------------+
+| `plugins_dir`                 | `FIFTYONE_PLUGINS_DIR`              | `None`                        | A directory containing custom App plugins. See :ref:`this page <app-plugins>` for more |
+|                               |                                     |                               | information.                                                                           |
++-------------------------------+-------------------------------------+-------------------------------+----------------------------------------------------------------------------------------+
 | `requirement_error_level`     | `FIFTYONE_REQUIREMENT_ERROR_LEVEL`  | `0`                           | A default error level to use when ensuring/installing requirements such as third-party |
 |                               |                                     |                               | packages. See :ref:`loading zoo models <model-zoo-load>` for an example usage.         |
 +-------------------------------+-------------------------------------+-------------------------------+----------------------------------------------------------------------------------------+
@@ -145,6 +148,7 @@ and the CLI:
             "model_zoo_dir": "~/fiftyone/__models__",
             "model_zoo_manifest_paths": null,
             "module_path": null,
+            "plugins_dir": null,
             "requirement_error_level": 0,
             "show_progress_bars": true,
             "timezone": null
@@ -187,6 +191,7 @@ and the CLI:
             "model_zoo_dir": "~/fiftyone/__models__",
             "model_zoo_manifest_paths": null,
             "module_path": null,
+            "plugins_dir": null,
             "requirement_error_level": 0,
             "show_progress_bars": true,
             "timezone": null

--- a/fiftyone/core/config.py
+++ b/fiftyone/core/config.py
@@ -109,6 +109,9 @@ class FiftyOneConfig(EnvConfig):
             env_var="FIFTYONE_MODULE_PATH",
             default=None,
         )
+        self.plugins_dir = self.parse_string(
+            d, "plugins_dir", env_var="FIFTYONE_PLUGINS_DIR", default=None
+        )
         self.dataset_zoo_manifest_paths = self.parse_path_array(
             d,
             "dataset_zoo_manifest_paths",

--- a/fiftyone/server/app.py
+++ b/fiftyone/server/app.py
@@ -1,19 +1,12 @@
 """
-FiftyOne Server app
+FiftyOne Server app.
 
-| Copyright 2017-2021, Voxel51, Inc.
+| Copyright 2017-2022, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
 import os
 
-import fiftyone.constants as foc
-import strawberry as gql
-from fiftyone.server.context import GraphQL
-from fiftyone.server.extensions import EndSession
-from fiftyone.server.mutation import Mutation
-from fiftyone.server.query import Query
-from fiftyone.server.routes import routes
 from starlette.applications import Starlette
 from starlette.middleware import Middleware
 from starlette.middleware.base import (
@@ -26,6 +19,15 @@ from starlette.responses import Response
 from starlette.routing import Mount, Route
 from starlette.staticfiles import StaticFiles
 from starlette.types import Scope
+import strawberry as gql
+
+import fiftyone as fo
+import fiftyone.constants as foc
+from fiftyone.server.context import GraphQL
+from fiftyone.server.extensions import EndSession
+from fiftyone.server.mutation import Mutation
+from fiftyone.server.query import Query
+from fiftyone.server.routes import routes
 
 
 class Static(StaticFiles):
@@ -72,7 +74,7 @@ app = Starlette(
         Mount(
             "/plugins",
             app=Static(
-                directory=os.environ.get('FIFTYONE_PLUGINS_DIR'),
+                directory=fo.config.plugins_dir,
                 html=True,
             ),
             name="plugins",

--- a/fiftyone/server/routes/plugins.py
+++ b/fiftyone/server/routes/plugins.py
@@ -1,38 +1,42 @@
 """
-FiftyOne Server /plugins route
+FiftyOne Server ``/plugins`` route.
 
 | Copyright 2017-2022, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
-import json
-import os
 import glob
+import os
 
 from starlette.endpoints import HTTPEndpoint
 from starlette.requests import Request
 
+import eta.core.serial as etas
 
+import fiftyone as fo
 from fiftyone.server.decorators import route
 
 
 class Plugins(HTTPEndpoint):
     @route
     async def get(self, request: Request, data: dict):
-        dir = os.environ.get("FIFTYONE_PLUGINS_DIR")
+        plugins_dir = fo.config.plugins_dir
 
-        settingsFilepath = os.path.join(dir, "settings.json")
-        settings = load_json_file(settingsFilepath)
+        if not plugins_dir:
+            return {"plugins": [], "settings": None}
 
-        pkgs = glob.glob(os.path.join(dir, "*", "package.json"))
+        settings_path = os.path.join(plugins_dir, "settings.json")
+        settings = load_json_or_none(settings_path)
+
+        pkgs = glob.glob(os.path.join(plugins_dir, "*", "package.json"))
         pkgs += glob.glob(
-            os.path.join(dir, "node_modules", "*", "package.json")
+            os.path.join(plugins_dir, "node_modules", "*", "package.json")
         )
         plugin_packages = []
 
         for filepath in pkgs:
-            f = open(filepath, "r")
-            pkg = json.loads(f.read())
+            pkg = etas.read_json(filepath)
+
             plugin_definition = {
                 "name": pkg["name"],
                 "version": pkg["version"],
@@ -40,16 +44,16 @@ class Plugins(HTTPEndpoint):
             plugin_definition.update(pkg["fiftyone"])
             plugin_definition["scriptPath"] = "/" + os.path.join(
                 "plugins",
-                os.path.dirname(os.path.relpath(filepath, dir)),
+                os.path.dirname(os.path.relpath(filepath, plugins_dir)),
                 plugin_definition["script"],
             )
             plugin_packages.append(plugin_definition)
+
         return {"plugins": plugin_packages, "settings": settings}
 
 
-def load_json_file(path_to_file):
-    if os.path.isfile(path_to_file) and os.access(path_to_file, os.R_OK):
-        f = open(path_to_file, "r")
-        return json.loads(f.read())
-    else:
+def load_json_or_none(filepath):
+    try:
+        return etas.read_json(filepath)
+    except FileNotFoundError:
         return None


### PR DESCRIPTION
Change log
- Adds `plugins_dir` to the FiftyOne config (env var `FIFTYONE_PLUGINS_DIR`)
- Adds a pointer to the plugin README to the App User Guide page
- Editorial pass over plugin README 🤓 