### PR TITLE
Bugfix: task_map expected string got int

### DIFF
--- a/fiftyone/utils/labelstudio.py
+++ b/fiftyone/utils/labelstudio.py
@@ -368,7 +368,7 @@ class LabelStudioAnnotationAPI(foua.AnnotationAPI):
                     if not isinstance(labels[0], fol.Regression)
                     else labels[0]
                 )
-                sample_id = task_map[t["id"]]
+                sample_id = task_map[str(t["id"])]
                 results[sample_id] = label_ids
 
         return results


### PR DESCRIPTION
## What changes are proposed in this pull request?

load_annotations from label studio do not brake

## How is this patch tested? If it is not, please explain why.

Tested on develop branch

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other

### To reproduce:
```python
# pip install label-studio-sdk label-studio

import fiftyone as fo

d: fo.Dataset = fo.load_dataset(name="2022.09.07.10.41.35")
print(d.name, len(d))
anno_key = "asd123456"
# d.annotate(
#     anno_key=anno_key,
#     label_schema={"gt_b_box": {"type": "detections", "classes": ["something"]}},
#     launch_editor=True,
# )

# do the annotation

d.load_annotations(anno_key=anno_key)

"""
Downloading labels from Label Studio...
Traceback (most recent call last):
  File "/Users/oe/code/fiftyone/asd/asd_1.py", line 13, in <module>
    d.load_annotations(anno_key=anno_key)
  File "/Users/oe/code/fiftyone/fiftyone/core/collections.py", line 6998, in load_annotations
    return foua.load_annotations(
  File "/Users/oe/code/fiftyone/fiftyone/utils/annotations.py", line 1033, in load_annotations
    annotations = results.backend.download_annotations(results)
  File "/Users/oe/code/fiftyone/fiftyone/utils/labelstudio.py", line 142, in download_annotations
    annotations = api.download_annotations(results)
  File "/Users/oe/code/fiftyone/fiftyone/utils/labelstudio.py", line 432, in download_annotations
    labels = self._import_annotations(
  File "/Users/oe/code/fiftyone/fiftyone/utils/labelstudio.py", line 373, in _import_annotations
    sample_id = task_map[t["id"]]
KeyError: 3
"""

```
