### PR TITLE
Fix CVAT bug when checking if a task exists

### DIFF
--- a/fiftyone/utils/cvat.py
+++ b/fiftyone/utils/cvat.py
@@ -5350,7 +5350,11 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
 
         # For non-outside tracked objects, the last track goes to the end of
         # the video, so fill remaining frames with copies of the last instance
-        if prev_frame is not None and not prev_outside:
+        if (
+            anno_type == "track"
+            and prev_frame is not None
+            and not prev_outside
+        ):
             for frame in range(prev_frame + 1, max(frame_id_map) + 1):
                 anno = deepcopy(prev_anno)
                 anno["frame"] = frame

--- a/fiftyone/utils/cvat.py
+++ b/fiftyone/utils/cvat.py
@@ -3512,6 +3512,9 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
     def task_url(self, task_id):
         return "%s/%d" % (self.tasks_url, task_id)
 
+    def task_status_url(self, task_id):
+        return "%s/status" % self.task_url(task_id)
+
     def task_data_url(self, task_id):
         return "%s/data" % self.task_url(task_id)
 
@@ -3971,15 +3974,17 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
         Returns:
             True/False
         """
-        return (
-            self._get_value_from_search(
-                self.task_id_search_url,
-                task_id,
-                "id",
-                "id",
+        try:
+            response = self.get(
+                self.task_status_url(task_id), print_error_info=False
             )
-            is not None
-        )
+        except requests.exceptions.HTTPError as e:
+            if e.response.status_code == 404:
+                return False
+            else:
+                raise e
+
+        return True
 
     def delete_task(self, task_id):
         """Deletes the given task from the CVAT server.

--- a/tests/intensive/cvat_tests.py
+++ b/tests/intensive/cvat_tests.py
@@ -1187,6 +1187,48 @@ class CVATTests(unittest.TestCase):
             any([gid == test_group_id for gid in id_group_map.values()])
         )
 
+    def test_task_exists(self):
+        dataset = (
+            foz.load_zoo_dataset("quickstart", max_samples=20)
+            .select_fields("ground_truth")
+            .clone()
+        )
+
+        anno_key = "task_exists"
+        results = dataset.annotate(
+            anno_key,
+            label_field="ground_truth",
+            backend="cvat",
+            task_size=1,
+        )
+
+        tasks_exist = []
+        with results:
+            api = results.connect_to_api()
+            for task_id in results.task_ids:
+                tasks_exist.append(api.task_exists(task_id))
+
+        dataset.load_annotations(anno_key, cleanup=True)
+
+        self.assertNotIn(False, tasks_exist)
+
+        view = dataset.take(1)
+
+        anno_key = "task_not_exists"
+        results = view.annotate(
+            anno_key,
+            label_field="ground_truth",
+            backend="cvat",
+        )
+
+        task_id = results.task_ids[0]
+        with results:
+            api = results.connect_to_api()
+            api.delete_task(task_id)
+            self.assertFalse(api.task_exists(task_id))
+
+        dataset.load_annotations(anno_key, cleanup=True)
+
 
 if __name__ == "__main__":
     fo.config.show_progress_bars = False


### PR DESCRIPTION
On CVAT > v2.0 servers, when checking if a task exists, the existing method would fail if there are too many tasks. 
Previously, this was accomplished by searching for a task id by `cvat_url/api/task?id=XXX` which would return the query task for CVATv1 servers, but may not for CVATv2 servers. This error would result in annotation runs unable to be loaded

After this PR, the `task_exists()` method now attempts to get the status of a task and returns `False` if it encounters a 404 error. 

A test was added to capture this issue on CVATv2 servers.



Note: This also fixes a bug where annotations were being duplicated to other images in a task due to the fact that images also contain an `outside` property now in CVATv2 servers.