### PR TITLE
Resolve Labelstudio task_map key error

### DIFF
--- a/fiftyone/utils/labelstudio.py
+++ b/fiftyone/utils/labelstudio.py
@@ -520,12 +520,16 @@ class LabelStudioAnnotationResults(foua.AnnotationResults):
 
     @classmethod
     def _from_dict(cls, d, samples, config):
+        uploaded_tasks = {
+            int(task_id): source_id
+            for task_id, source_id in d["uploaded_tasks"].items()
+        }
         return cls(
             samples,
             config,
             d["id_map"],
             d["project_id"],
-            d["uploaded_tasks"],
+            uploaded_tasks,
         )
 
 

--- a/fiftyone/utils/labelstudio.py
+++ b/fiftyone/utils/labelstudio.py
@@ -520,10 +520,12 @@ class LabelStudioAnnotationResults(foua.AnnotationResults):
 
     @classmethod
     def _from_dict(cls, d, samples, config):
+        # int keys were serialized as strings...
         uploaded_tasks = {
             int(task_id): source_id
             for task_id, source_id in d["uploaded_tasks"].items()
         }
+
         return cls(
             samples,
             config,


### PR DESCRIPTION
Alternative to #2066 

When deserializing the `uploaded_tasks` dict that maps labelstudio task ids to FiftyOne sample ids, the keys were previously not converted back from strings to integers.

```
KeyError                                  Traceback (most recent call last)
<ipython-input-1-b67eda7559a6> in <module>
      2
      3 dataset = fo.load_dataset("ls_test")
----> 4 dataset.load_annotations("anno_key", cleanup=True)
      5 dataset.delete()

~/work/fiftyone/fiftyone/fiftyone/core/collections.py in load_annotations(self, anno_key, dest_field, unexpected, cleanup, **kwargs)
   7016             found, in which case a dict containing the extra labels is returned
   7017         """
-> 7018         return foua.load_annotations(
   7019             self,
   7020             anno_key,

~/work/fiftyone/fiftyone/fiftyone/utils/annotations.py in load_annotations(samples, anno_key, dest_field, unexpected, cleanup, **kwargs)
   1031     """
   1032     results = samples.load_annotation_results(anno_key, **kwargs)
-> 1033     annotations = results.backend.download_annotations(results)
   1034     label_schema = results.config.label_schema
   1035

~/work/fiftyone/fiftyone/fiftyone/utils/labelstudio.py in download_annotations(self, results)
    140
    141         logger.info("Downloading labels from Label Studio...")
--> 142         annotations = api.download_annotations(results)
    143         logger.info("Download complete")
    144

~/work/fiftyone/fiftyone/fiftyone/utils/labelstudio.py in download_annotations(self, results)
    428         for label_field, label_info in results.config.label_schema.items():
    429             return_type = foua._RETURN_TYPES_MAP[label_info["type"]]
--> 430             labels = self._import_annotations(
    431                 labeled_tasks, results.uploaded_tasks, return_type
    432             )

~/work/fiftyone/fiftyone/fiftyone/utils/labelstudio.py in _import_annotations(self, tasks, task_map, label_type)
    369                     else labels[0]
    370                 )
--> 371                 sample_id = task_map[t["id"]]
    372                 results[sample_id] = label_ids
    373

KeyError: 309

```

 This PR fixes that. 



## Example
The following example now works:

```
pip install label-studio label-studio-sdk
```

Launch label studio and create an account, registering it in FiftyOne:https://voxel51.com/docs/fiftyone/integrations/labelstudio.html#authentication
```
label-studio
```

```python
import fiftyone.zoo as foz

dataset = foz.load_zoo_dataset("quickstart", max_samples=2).clone()
dataset.name = "ls_test"
dataset.persistent = True

dataset.annotate("anno_key", label_field="ground_truth", backend="labelstudio")
```
**Close and relaunch your Python session**

```python
import fiftyone as fo

dataset = fo.load_dataset("ls_test")
dataset.load_annotations("anno_key", cleanup=True)
dataset.delete()
```