### PR TITLE
fix pinned sample not clearing

### DIFF
--- a/app/packages/app/src/components/Modal/Group.tsx
+++ b/app/packages/app/src/components/Modal/Group.tsx
@@ -9,6 +9,7 @@ import {
 import { PluginComponentType, usePlugin } from "@fiftyone/plugins";
 import * as fos from "@fiftyone/state";
 import {
+  dataset,
   groupField,
   groupId,
   hasPinnedSlice,
@@ -28,6 +29,7 @@ import React, {
   useCallback,
   useRef,
   useState,
+  useEffect,
 } from "react";
 
 import { useRecoilState, useRecoilValue, useResetRecoilState } from "recoil";
@@ -192,6 +194,8 @@ const PinnedSample: React.FC = () => {
   const [pinned, setPinned] = useRecoilState(sidebarOverride);
   const slice = useRecoilValue(pinnedSlice) as string;
   const hover = fos.useHoveredSample(sample.sample);
+
+  useEffect(() => () => setPinned(null), []);
 
   return (
     <GroupSample


### PR DESCRIPTION
In a group modal, selecting the point cloud sample would not be cleared. This would cause a graphql query to execute in an unexpected state (non-groups). This patch clears out the selected sample when the modal is closed.