### PR TITLE
fix L3D hotkey targeting

### DIFF
--- a/app/packages/looker-3d/src/Looker3d.tsx
+++ b/app/packages/looker-3d/src/Looker3d.tsx
@@ -826,7 +826,8 @@ function useHotkey(code, fn, deps) {
   const EVENT_NAME = "keydown";
   const cb = recoil.useRecoilTransaction_UNSTABLE((ctx) => () => fn(ctx), deps);
   function handle(e) {
-    if (e.code === code) {
+    const shouldIgnore = e.target.tagName.toLowerCase() === "input";
+    if (!shouldIgnore && e.code === code) {
       cb();
     }
   }


### PR DESCRIPTION
Fixes case where "keyboard shortcuts shouldn’t have “focus” when using the tagging menu (eg as I type the tag “test”, the E and T shortcuts take effect behind)"