### PR TITLE
Don't regenerate IDs when copying Group instances

### DIFF
--- a/fiftyone/core/groups.py
+++ b/fiftyone/core/groups.py
@@ -5,6 +5,8 @@ Sample groups.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+from copy import deepcopy
+
 from bson import ObjectId
 
 import fiftyone.core.fields as fof
@@ -21,6 +23,17 @@ class Group(foo.EmbeddedDocument):
 
     id = fof.ObjectIdField(default=lambda: str(ObjectId()), db_field="_id")
     name = fof.StringField()
+
+    def __deepcopy__(self, memo):
+        # Custom implementation that does NOT exclude `id` field, since `Group`
+        # instances often do need to share the same IDs
+        # pylint: disable=no-member, unsubscriptable-object
+        return self.__class__(
+            **{
+                f: deepcopy(self.get_field(f), memo)
+                for f in self._fields_ordered
+            }
+        )
 
     @property
     def _id(self):


### PR DESCRIPTION
Alternative to https://github.com/voxel51/fiftyone/pull/2085 that makes it so that *only* `Group` instances don't have their IDs changed when they are copied.

Why is this change needed? Because it is normal to have multiple `Group` instances with a shared `id`, and regenerating this ID in a `sample.copy()` operation would break the group association.