### PR TITLE
Fix CVAT task id bug and add task download progress bar

### DIFF
--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -6957,7 +6957,9 @@ class SampleCollection(object):
         Returns:
             a :class:`fiftyone.utils.annotations.AnnotationResults`
         """
-        results = foan.AnnotationMethod.load_run_results(self, anno_key)
+        results = foan.AnnotationMethod.load_run_results(
+            self, anno_key, load_view=False
+        )
         results.load_credentials(**kwargs)
         return results
 

--- a/fiftyone/utils/annotations.py
+++ b/fiftyone/utils/annotations.py
@@ -185,7 +185,7 @@ def annotate(
             subclass of the backend being used
 
     Returns:
-        an :class:`AnnnotationResults`
+        an :class:`AnnotationResults`
     """
     # @todo support this?
     if samples._dataset._is_frames:
@@ -1029,7 +1029,8 @@ def load_annotations(
         ``None``, unless ``unexpected=="return"`` and unexpected labels are
         found, in which case a dict containing the extra labels is returned
     """
-    results = samples.load_annotation_results(anno_key, **kwargs)
+    dataset = samples._root_dataset
+    results = dataset.load_annotation_results(anno_key, **kwargs)
     annotations = results.backend.download_annotations(results)
     label_schema = results.config.label_schema
 
@@ -1064,7 +1065,7 @@ def load_annotations(
                 # Expected labels
                 if label_type == "scalar":
                     _merge_scalars(
-                        samples,
+                        dataset,
                         annos,
                         results,
                         label_field,
@@ -1072,7 +1073,7 @@ def load_annotations(
                     )
                 else:
                     _merge_labels(
-                        samples,
+                        dataset,
                         annos,
                         results,
                         label_field,
@@ -1087,7 +1088,7 @@ def load_annotations(
                     new_field = None
                 elif unexpected == "prompt":
                     new_field = _prompt_field(
-                        samples, anno_type, label_field, label_schema
+                        dataset, anno_type, label_field, label_schema
                     )
                 elif unexpected == "return":
                     new_field = None
@@ -1104,14 +1105,14 @@ def load_annotations(
 
                 if new_field:
                     new_field = _handle_frame_fields(
-                        new_field, samples, label_field
+                        dataset, new_field, label_field
                     )
 
                     if anno_type == "scalar":
-                        _merge_scalars(samples, annos, results, new_field)
+                        _merge_scalars(dataset, annos, results, new_field)
                     else:
                         _merge_labels(
-                            samples, annos, results, new_field, anno_type
+                            dataset, annos, results, new_field, anno_type
                         )
                 else:
                     if label_field:
@@ -1127,7 +1128,7 @@ def load_annotations(
                     if unexpected == "return":
                         unexpected_annos[label_field][anno_type] = annos
 
-    results.backend.save_run_results(samples, anno_key, results)
+    results.backend.save_run_results(dataset, anno_key, results)
 
     if cleanup:
         results.cleanup()
@@ -1136,14 +1137,14 @@ def load_annotations(
         return dict(unexpected_annos) if unexpected_annos else None
 
 
-def _handle_frame_fields(field, samples, ref_field):
-    if samples.media_type != fomm.VIDEO:
+def _handle_frame_fields(dataset, field, ref_field):
+    if dataset.media_type != fomm.VIDEO:
         return field
 
     if (
-        ref_field is None or samples._is_frame_field(ref_field)
-    ) and not samples._is_frame_field(field):
-        field = samples._FRAMES_PREFIX + field
+        ref_field is None or dataset._is_frame_field(ref_field)
+    ) and not dataset._is_frame_field(field):
+        field = dataset._FRAMES_PREFIX + field
 
     return field
 
@@ -1173,7 +1174,7 @@ def _get_writeable_attributes(attributes):
     return [k for k, v in attributes.items() if not v.get("read_only", False)]
 
 
-def _prompt_field(samples, label_type, label_field, label_schema):
+def _prompt_field(dataset, label_type, label_field, label_schema):
     if label_field:
         new_field = input(
             "Found unexpected labels of type '%s' when loading annotations "
@@ -1195,24 +1196,24 @@ def _prompt_field(samples, label_type, label_field, label_schema):
         fo_label_type = _LABEL_TYPES_MAP[label_type]
 
     if label_field is not None:
-        _, is_frame_field = samples._handle_frame_field(label_field)
+        _, is_frame_field = dataset._handle_frame_field(label_field)
     else:
-        is_frame_field = samples.media_type == fomm.VIDEO
+        is_frame_field = dataset.media_type == fomm.VIDEO
 
     if is_frame_field:
-        schema = samples.get_frame_field_schema()
+        schema = dataset.get_frame_field_schema()
     else:
-        schema = samples.get_field_schema()
+        schema = dataset.get_field_schema()
 
     while True:
         is_good_field = new_field not in label_schema
 
         if is_good_field:
             if is_frame_field:
-                if not samples._is_frame_field(new_field):
-                    new_field = samples._FRAMES_PREFIX + new_field
+                if not dataset._is_frame_field(new_field):
+                    new_field = dataset._FRAMES_PREFIX + new_field
 
-                field, _ = samples._handle_frame_field(new_field)
+                field, _ = dataset._handle_frame_field(new_field)
             else:
                 field = new_field
 
@@ -1257,20 +1258,20 @@ def _prompt_field(samples, label_type, label_field, label_schema):
     return new_field
 
 
-def _merge_scalars(samples, anno_dict, results, label_field, label_info=None):
+def _merge_scalars(dataset, anno_dict, results, label_field, label_info=None):
     if label_info is None:
         label_info = {}
 
     allow_additions = label_info.get("allow_additions", True)
     allow_deletions = label_info.get("allow_deletions", True)
 
-    is_video = samples._is_frame_field(label_field)
+    is_video = dataset._is_frame_field(label_field)
 
     # Retrieve a view that contains all samples involved in the annotation run
     id_map = results.id_map.get(label_field, {})
     uploaded_ids = set(k for k, v in id_map.items() if v is not None)
     sample_ids = list(uploaded_ids | set(anno_dict.keys()))
-    view = samples._dataset.select(sample_ids)
+    view = dataset.select(sample_ids)
 
     if is_video:
         field, _ = view._handle_frame_field(label_field)
@@ -1342,7 +1343,7 @@ def _merge_scalars(samples, anno_dict, results, label_field, label_info=None):
 
 
 def _merge_labels(
-    samples,
+    dataset,
     anno_dict,
     results,
     label_field,
@@ -1369,21 +1370,21 @@ def _merge_labels(
     else:
         is_list = False
 
-    _ensure_label_field(samples, label_field, fo_label_type)
+    _ensure_label_field(dataset, label_field, fo_label_type)
 
-    is_video = samples.media_type == fomm.VIDEO
+    is_video = dataset.media_type == fomm.VIDEO
 
     if is_video and label_type in _TRACKABLE_TYPES:
         if not existing_field:
             # Always include keyframe info when importing new video tracks
             only_keyframes = True
 
-        _update_tracks(samples, label_field, anno_dict, only_keyframes)
+        _update_tracks(dataset, label_field, anno_dict, only_keyframes)
 
     id_map = results.id_map.get(label_field, {})
 
     if is_video:
-        field, _ = samples._handle_frame_field(label_field)
+        field, _ = dataset._handle_frame_field(label_field)
         added_id_map = defaultdict(lambda: defaultdict(list))
     else:
         field = label_field
@@ -1457,11 +1458,11 @@ def _merge_labels(
     # Delete labels that were deleted in the annotation task
     if delete_ids and allow_deletions:
         _del_ids = [key[-1] for key in delete_ids]
-        samples._dataset.delete_labels(ids=_del_ids, fields=label_field)
+        dataset.delete_labels(ids=_del_ids, fields=label_field)
 
     # Add/merge labels from the annotation task
     sample_ids = list(anno_dict.keys())
-    view = samples._dataset.select(sample_ids).select_fields(label_field)
+    view = dataset.select(sample_ids).select_fields(label_field)
     for sample in view.iter_samples(progress=True):
         sample_id = sample.id
         sample_annos = anno_dict[sample_id]
@@ -1571,22 +1572,20 @@ def _merge_labels(
     results._update_id_map(label_field, added_id_map)
 
 
-def _ensure_label_field(samples, label_field, fo_label_type):
-    field, is_frame_field = samples._handle_frame_field(label_field)
+def _ensure_label_field(dataset, label_field, fo_label_type):
+    field, is_frame_field = dataset._handle_frame_field(label_field)
     if is_frame_field:
-        if not samples.has_frame_field(field):
-            samples._dataset.add_frame_field(
-                field,
-                fof.EmbeddedDocumentField,
-                embedded_doc_type=fo_label_type,
-            )
+        dataset.add_frame_field(
+            field,
+            fof.EmbeddedDocumentField,
+            embedded_doc_type=fo_label_type,
+        )
     else:
-        if not samples.has_sample_field(field):
-            samples._dataset.add_sample_field(
-                field,
-                fof.EmbeddedDocumentField,
-                embedded_doc_type=fo_label_type,
-            )
+        dataset.add_sample_field(
+            field,
+            fof.EmbeddedDocumentField,
+            embedded_doc_type=fo_label_type,
+        )
 
 
 def _merge_label(
@@ -1628,13 +1627,13 @@ def _merge_label(
             label.set_attribute_value(name, value)
 
 
-def _update_tracks(samples, label_field, anno_dict, only_keyframes):
-    # Using unfiltered samples is important here because we need to ensure
+def _update_tracks(dataset, label_field, anno_dict, only_keyframes):
+    # Using the full dataset here is important here because we need to ensure
     # that any new indexes never clash with *any* existing tracks
-    view = samples._dataset.select(list(anno_dict.keys()))
+    view = dataset.select(list(anno_dict.keys()))
 
-    _, id_path = samples._get_label_field_path(label_field, "id")
-    _, index_path = samples._get_label_field_path(label_field, "index")
+    _, id_path = dataset._get_label_field_path(label_field, "id")
+    _, index_path = dataset._get_label_field_path(label_field, "index")
 
     sample_ids, frame_ids, label_ids, indexes = view.values(
         ["id", "frames.id", id_path, index_path]

--- a/fiftyone/utils/cvat.py
+++ b/fiftyone/utils/cvat.py
@@ -3903,7 +3903,13 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
             the list of task IDs
         """
         resp = self.get(self.project_url(project_id)).json()
-        return [task["id"] for task in resp.get("tasks", [])]
+        tasks = []
+        for task in resp.get("tasks", []):
+            if isinstance(task, int):
+                tasks.append(task)
+            else:
+                tasks.append(task["id"])
+        return tasks
 
     def create_task(
         self,

--- a/fiftyone/utils/cvat.py
+++ b/fiftyone/utils/cvat.py
@@ -3906,8 +3906,12 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
         tasks = []
         for task in resp.get("tasks", []):
             if isinstance(task, int):
+                # For CVATv2 servers, task ids are stored directly as an array
+                # of integers
                 tasks.append(task)
             else:
+                # For CVATv1 servers, project tasks are dictionaries we need to
+                # exctract "id" from
                 tasks.append(task["id"])
         return tasks
 

--- a/fiftyone/utils/cvat.py
+++ b/fiftyone/utils/cvat.py
@@ -4378,152 +4378,163 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
         annotations = {}
         deleted_tasks = []
 
-        for task_id in task_ids:
-            if not self.task_exists(task_id):
-                deleted_tasks.append(task_id)
-                logger.warning(
-                    "Skipping task %d, which no longer exists", task_id
+        with fou.ProgressBar(
+            total=len(task_ids),
+            iters_str="tasks",
+            quiet=len(task_ids) == 1,
+        ) as pb:
+            for task_id in pb(task_ids):
+                if not self.task_exists(task_id):
+                    deleted_tasks.append(task_id)
+                    logger.warning(
+                        "Skipping task %d, which no longer exists", task_id
+                    )
+                    continue
+
+                # Download task data
+                attr_id_map, _class_map_rev = self._get_attr_class_maps(
+                    task_id
                 )
-                continue
+                task_resp = self.get(self.task_annotation_url(task_id)).json()
+                all_shapes = task_resp["shapes"]
+                all_tags = task_resp["tags"]
+                all_tracks = task_resp["tracks"]
 
-            # Download task data
-            attr_id_map, _class_map_rev = self._get_attr_class_maps(task_id)
-            task_resp = self.get(self.task_annotation_url(task_id)).json()
-            all_shapes = task_resp["shapes"]
-            all_tags = task_resp["tags"]
-            all_tracks = task_resp["tracks"]
+                data_resp = self.get(self.task_data_meta_url(task_id)).json()
+                frames = data_resp["frames"]
 
-            data_resp = self.get(self.task_data_meta_url(task_id)).json()
-            frames = data_resp["frames"]
-
-            label_fields = labels_task_map_rev[task_id]
-            label_types = self._get_return_label_types(
-                label_schema, label_fields
-            )
-
-            for lf_ind, label_field in enumerate(label_fields):
-                label_info = label_schema[label_field]
-                label_type = label_info.get("type", None)
-                scalar_attrs = assigned_scalar_attrs.get(label_field, False)
-                _occluded_attrs = occluded_attrs.get(label_field, {})
-                _group_id_attrs = group_id_attrs.get(label_field, {})
-                _id_map = id_map.get(label_field, {})
-
-                label_field_results = {}
-
-                # Dict mapping class labels to the classes used in CVAT.
-                # These are equal unless a class appears in multiple fields
-                _classes = label_field_classes[label_field]
-
-                # Maps CVAT IDs to FiftyOne labels
-                class_map = {
-                    _class_map_rev[name_lf]: name
-                    for name, name_lf in _classes.items()
-                }
-
-                _cvat_classes = class_map.keys()
-                tags, shapes, tracks = self._filter_field_classes(
-                    all_tags,
-                    all_shapes,
-                    all_tracks,
-                    _cvat_classes,
+                label_fields = labels_task_map_rev[task_id]
+                label_types = self._get_return_label_types(
+                    label_schema, label_fields
                 )
 
-                is_last_field = lf_ind == len(label_fields) - 1
-                ignore_types = self._get_ignored_types(
-                    project_id, label_types, label_type, is_last_field
-                )
+                for lf_ind, label_field in enumerate(label_fields):
+                    label_info = label_schema[label_field]
+                    label_type = label_info.get("type", None)
+                    scalar_attrs = assigned_scalar_attrs.get(
+                        label_field, False
+                    )
+                    _occluded_attrs = occluded_attrs.get(label_field, {})
+                    _group_id_attrs = group_id_attrs.get(label_field, {})
+                    _id_map = id_map.get(label_field, {})
 
-                tag_results = self._parse_shapes_tags(
-                    "tags",
-                    tags,
-                    frame_id_map[task_id],
-                    label_type,
-                    _id_map,
-                    server_id_map.get("tags", {}),
-                    class_map,
-                    attr_id_map,
-                    frames,
-                    ignore_types,
-                    assigned_scalar_attrs=scalar_attrs,
-                )
-                label_field_results = self._merge_results(
-                    label_field_results, tag_results
-                )
+                    label_field_results = {}
 
-                shape_results = self._parse_shapes_tags(
-                    "shapes",
-                    shapes,
-                    frame_id_map[task_id],
-                    label_type,
-                    _id_map,
-                    server_id_map.get("shapes", {}),
-                    class_map,
-                    attr_id_map,
-                    frames,
-                    ignore_types,
-                    assigned_scalar_attrs=scalar_attrs,
-                    occluded_attrs=_occluded_attrs,
-                    group_id_attrs=_group_id_attrs,
-                )
-                label_field_results = self._merge_results(
-                    label_field_results, shape_results
-                )
+                    # Dict mapping class labels to the classes used in CVAT.
+                    # These are equal unless a class appears in multiple fields
+                    _classes = label_field_classes[label_field]
 
-                for track_index, track in enumerate(tracks, 1):
-                    label_id = track["label_id"]
-                    shapes = track["shapes"]
-                    track_group_id = track.get("group", None)
-                    for shape in shapes:
-                        shape["label_id"] = label_id
+                    # Maps CVAT IDs to FiftyOne labels
+                    class_map = {
+                        _class_map_rev[name_lf]: name
+                        for name, name_lf in _classes.items()
+                    }
 
-                    immutable_attrs = track["attributes"]
+                    _cvat_classes = class_map.keys()
+                    tags, shapes, tracks = self._filter_field_classes(
+                        all_tags,
+                        all_shapes,
+                        all_tracks,
+                        _cvat_classes,
+                    )
 
-                    track_shape_results = self._parse_shapes_tags(
-                        "track",
-                        shapes,
+                    is_last_field = lf_ind == len(label_fields) - 1
+                    ignore_types = self._get_ignored_types(
+                        project_id, label_types, label_type, is_last_field
+                    )
+
+                    tag_results = self._parse_shapes_tags(
+                        "tags",
+                        tags,
                         frame_id_map[task_id],
                         label_type,
                         _id_map,
-                        server_id_map.get("tracks", {}),
+                        server_id_map.get("tags", {}),
                         class_map,
                         attr_id_map,
                         frames,
                         ignore_types,
                         assigned_scalar_attrs=scalar_attrs,
-                        track_index=track_index,
-                        track_group_id=track_group_id,
-                        immutable_attrs=immutable_attrs,
+                    )
+                    label_field_results = self._merge_results(
+                        label_field_results, tag_results
+                    )
+
+                    shape_results = self._parse_shapes_tags(
+                        "shapes",
+                        shapes,
+                        frame_id_map[task_id],
+                        label_type,
+                        _id_map,
+                        server_id_map.get("shapes", {}),
+                        class_map,
+                        attr_id_map,
+                        frames,
+                        ignore_types,
+                        assigned_scalar_attrs=scalar_attrs,
                         occluded_attrs=_occluded_attrs,
                         group_id_attrs=_group_id_attrs,
                     )
                     label_field_results = self._merge_results(
-                        label_field_results, track_shape_results
+                        label_field_results, shape_results
                     )
 
-                frames_metadata = {}
-                for cvat_frame_id, frame_data in frame_id_map[task_id].items():
-                    sample_id = frame_data["sample_id"]
-                    if "frame_id" in frame_data and len(frames) == 1:
-                        frames_metadata[sample_id] = frames[0]
-                        break
+                    for track_index, track in enumerate(tracks, 1):
+                        label_id = track["label_id"]
+                        shapes = track["shapes"]
+                        track_group_id = track.get("group", None)
+                        for shape in shapes:
+                            shape["label_id"] = label_id
 
-                    if len(frames) > cvat_frame_id:
-                        frame_metadata = frames[cvat_frame_id]
-                    else:
-                        frame_metadata = None
+                        immutable_attrs = track["attributes"]
 
-                    frames_metadata[sample_id] = frame_metadata
+                        track_shape_results = self._parse_shapes_tags(
+                            "track",
+                            shapes,
+                            frame_id_map[task_id],
+                            label_type,
+                            _id_map,
+                            server_id_map.get("tracks", {}),
+                            class_map,
+                            attr_id_map,
+                            frames,
+                            ignore_types,
+                            assigned_scalar_attrs=scalar_attrs,
+                            track_index=track_index,
+                            track_group_id=track_group_id,
+                            immutable_attrs=immutable_attrs,
+                            occluded_attrs=_occluded_attrs,
+                            group_id_attrs=_group_id_attrs,
+                        )
+                        label_field_results = self._merge_results(
+                            label_field_results, track_shape_results
+                        )
 
-                # Polyline(s) corresponding to instance/semantic masks need to
-                # be converted to their final format
-                self._convert_polylines_to_masks(
-                    label_field_results, label_info, frames_metadata
-                )
+                    frames_metadata = {}
+                    for cvat_frame_id, frame_data in frame_id_map[
+                        task_id
+                    ].items():
+                        sample_id = frame_data["sample_id"]
+                        if "frame_id" in frame_data and len(frames) == 1:
+                            frames_metadata[sample_id] = frames[0]
+                            break
 
-                annotations = self._merge_results(
-                    annotations, {label_field: label_field_results}
-                )
+                        if len(frames) > cvat_frame_id:
+                            frame_metadata = frames[cvat_frame_id]
+                        else:
+                            frame_metadata = None
+
+                        frames_metadata[sample_id] = frame_metadata
+
+                    # Polyline(s) corresponding to instance/semantic masks need to
+                    # be converted to their final format
+                    self._convert_polylines_to_masks(
+                        label_field_results, label_info, frames_metadata
+                    )
+
+                    annotations = self._merge_results(
+                        annotations, {label_field: label_field_results}
+                    )
 
         if deleted_tasks:
             results._forget_tasks(deleted_tasks)

--- a/fiftyone/utils/cvat.py
+++ b/fiftyone/utils/cvat.py
@@ -4228,12 +4228,11 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
 
         logger.info("Uploading samples to CVAT...")
 
-        with fou.ProgressBar(
-            total=num_samples,
-            iters_str="samples",
-            quiet=num_samples <= batch_size,
-        ) as pb:
+        pb_kwargs = {"total": num_samples, "iters_str": "samples"}
+        if num_samples <= batch_size:
+            pb_kwargs["quiet"] = True
 
+        with fou.ProgressBar(**pb_kwargs) as pb:
             for idx, offset in enumerate(range(0, num_samples, batch_size)):
                 samples_batch = samples[offset : (offset + batch_size)]
                 anno_tags = []
@@ -4378,11 +4377,11 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
         annotations = {}
         deleted_tasks = []
 
-        with fou.ProgressBar(
-            total=len(task_ids),
-            iters_str="tasks",
-            quiet=len(task_ids) == 1,
-        ) as pb:
+        pb_kwargs = {"total": len(task_ids), "iters_str": "tasks"}
+        if len(task_ids) == 1:
+            pb_kwargs["quiet"] = True
+
+        with fou.ProgressBar(**pb_kwargs) as pb:
             for task_id in pb(task_ids):
                 if not self.task_exists(task_id):
                     deleted_tasks.append(task_id)

--- a/tests/intensive/cvat_tests.py
+++ b/tests/intensive/cvat_tests.py
@@ -535,7 +535,12 @@ class CVATTests(unittest.TestCase):
                 )
 
             dataset.load_annotations(anno_key, cleanup=True)
-            self.assertIsNotNone(api.get_project_id(project_name))
+            project_id = api.get_project_id(project_name)
+            self.assertIsNotNone(project_id)
+
+            project_tasks = api.get_project_tasks(project_id)
+            task_ids = results.task_ids + results2.task_ids + results3.task_ids
+            self.assertListEqual(sorted(project_tasks), sorted(task_ids))
 
             dataset.load_annotations(anno_key2, cleanup=True)
             self.assertIsNotNone(api.get_project_id(project_name))

--- a/tests/intensive/cvat_tests.py
+++ b/tests/intensive/cvat_tests.py
@@ -229,6 +229,7 @@ class CVATTests(unittest.TestCase):
             ]["sample_id"]
             self.assertEqual(sample_id, dataset.first().id)
 
+        dataset.reload()
         dataset.load_annotations(anno_key, cleanup=True)
 
         self.assertListEqual(
@@ -262,6 +263,7 @@ class CVATTests(unittest.TestCase):
             ]["sample_id"]
             self.assertEqual(sample_id, dataset.first().id)
 
+        dataset.reload()
         dataset.load_annotations(anno_key, cleanup=True)
 
         self.assertListEqual(
@@ -1231,6 +1233,39 @@ class CVATTests(unittest.TestCase):
             api = results.connect_to_api()
             api.delete_task(task_id)
             self.assertFalse(api.task_exists(task_id))
+
+        dataset.load_annotations(anno_key, cleanup=True)
+
+    def test_deleted_label_field(self):
+        dataset = foz.load_zoo_dataset("quickstart", max_samples=1).clone()
+        view = dataset.select_fields("ground_truth")
+        prev_ids = dataset.values("ground_truth.detections.id", unwind=True)
+
+        anno_key = "anno_key"
+        results = view.annotate(
+            anno_key,
+            backend="cvat",
+            label_field="ground_truth",
+        )
+        dataset.delete_sample_field("ground_truth")
+        dataset.reload()
+
+        dataset.load_annotations(anno_key, cleanup=True)
+        self.assertListEqual(
+            sorted(dataset.values("ground_truth.detections.id", unwind=True)),
+            sorted(prev_ids),
+        )
+
+        # Test scalar
+        view = dataset.select_fields("uniqueness")
+        anno_key = "anno_key2"
+        results = view.annotate(
+            anno_key,
+            backend="cvat",
+            label_field="uniqueness",
+        )
+        dataset.delete_sample_field("uniqueness")
+        dataset.reload()
 
         dataset.load_annotations(anno_key, cleanup=True)
 


### PR DESCRIPTION
This PR resolves an issue with CVAT >v2.0 servers where `import_annotations()` can fail to list tasks for existing projects due to a change in the CVAT API. Previously, the tasks for a project were listed as a dictionary of tasks that we needed to access the `id` of, now they are stored as a list of integer ids directly.

This PR fixes that bug as well as adds a progress bar when downloading annotations from CVAT for more than one task. 