### PR TITLE
Add the option to load a view or dataset for run results

### DIFF
--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -6957,7 +6957,9 @@ class SampleCollection(object):
         Returns:
             a :class:`fiftyone.utils.annotations.AnnotationResults`
         """
-        results = foan.AnnotationMethod.load_run_results(self, anno_key)
+        results = foan.AnnotationMethod.load_run_results(
+            self, anno_key, load_view=False
+        )
         results.load_credentials(**kwargs)
         return results
 

--- a/fiftyone/core/runs.py
+++ b/fiftyone/core/runs.py
@@ -440,13 +440,15 @@ class Run(Configurable):
         dataset._doc.save()
 
     @classmethod
-    def load_run_results(cls, samples, key, cache=True):
+    def load_run_results(cls, samples, key, cache=True, load_view=True):
         """Loads the :class:`RunResults` for the given key on the collection.
 
         Args:
             samples: a :class:`fiftyone.core.collections.SampleCollection`
             key: a run key
             cache (True): whether to cache the results on the collection
+            load_view (True): whether to load the run view in the results
+                (True) or the run dataset (False)
 
         Returns:
             a :class:`RunResults`, or None if the run did not save results
@@ -469,12 +471,15 @@ class Run(Configurable):
         config = run_info.config
 
         # Load run result from GridFS
-        view = cls.load_run_view(samples, key)
+        if load_view:
+            run_samples = cls.load_run_view(samples, key)
+        else:
+            run_samples = dataset
         run_doc.results.seek(0)
         d = json_util.loads(run_doc.results.read().decode())
 
         try:
-            run_results = RunResults.from_dict(d, view, config)
+            run_results = RunResults.from_dict(d, run_samples, config)
         except Exception as e:
             if run_doc.version == foc.VERSION:
                 raise e

--- a/fiftyone/core/runs.py
+++ b/fiftyone/core/runs.py
@@ -448,7 +448,7 @@ class Run(Configurable):
             key: a run key
             cache (True): whether to cache the results on the collection
             load_view (True): whether to load the run view in the results
-                (True) or the run dataset (False)
+                (True) or the full dataset (False)
 
         Returns:
             a :class:`RunResults`, or None if the run did not save results
@@ -470,11 +470,12 @@ class Run(Configurable):
         run_info = cls.get_run_info(samples, key)
         config = run_info.config
 
-        # Load run result from GridFS
         if load_view:
             run_samples = cls.load_run_view(samples, key)
         else:
             run_samples = dataset
+
+        # Load run result from GridFS
         run_doc.results.seek(0)
         d = json_util.loads(run_doc.results.read().decode())
 

--- a/fiftyone/utils/annotations.py
+++ b/fiftyone/utils/annotations.py
@@ -185,7 +185,7 @@ def annotate(
             subclass of the backend being used
 
     Returns:
-        an :class:`AnnnotationResults`
+        an :class:`AnnotationResults`
     """
     # @todo support this?
     if samples._dataset._is_frames:

--- a/fiftyone/utils/annotations.py
+++ b/fiftyone/utils/annotations.py
@@ -1029,7 +1029,8 @@ def load_annotations(
         ``None``, unless ``unexpected=="return"`` and unexpected labels are
         found, in which case a dict containing the extra labels is returned
     """
-    results = samples.load_annotation_results(anno_key, **kwargs)
+    dataset = samples._root_dataset
+    results = dataset.load_annotation_results(anno_key, **kwargs)
     annotations = results.backend.download_annotations(results)
     label_schema = results.config.label_schema
 
@@ -1064,7 +1065,7 @@ def load_annotations(
                 # Expected labels
                 if label_type == "scalar":
                     _merge_scalars(
-                        samples,
+                        dataset,
                         annos,
                         results,
                         label_field,
@@ -1072,7 +1073,7 @@ def load_annotations(
                     )
                 else:
                     _merge_labels(
-                        samples,
+                        dataset,
                         annos,
                         results,
                         label_field,
@@ -1087,7 +1088,7 @@ def load_annotations(
                     new_field = None
                 elif unexpected == "prompt":
                     new_field = _prompt_field(
-                        samples, anno_type, label_field, label_schema
+                        dataset, anno_type, label_field, label_schema
                     )
                 elif unexpected == "return":
                     new_field = None
@@ -1104,14 +1105,14 @@ def load_annotations(
 
                 if new_field:
                     new_field = _handle_frame_fields(
-                        new_field, samples, label_field
+                        dataset, new_field, label_field
                     )
 
                     if anno_type == "scalar":
-                        _merge_scalars(samples, annos, results, new_field)
+                        _merge_scalars(dataset, annos, results, new_field)
                     else:
                         _merge_labels(
-                            samples, annos, results, new_field, anno_type
+                            dataset, annos, results, new_field, anno_type
                         )
                 else:
                     if label_field:
@@ -1127,7 +1128,7 @@ def load_annotations(
                     if unexpected == "return":
                         unexpected_annos[label_field][anno_type] = annos
 
-    results.backend.save_run_results(samples, anno_key, results)
+    results.backend.save_run_results(dataset, anno_key, results)
 
     if cleanup:
         results.cleanup()
@@ -1136,14 +1137,14 @@ def load_annotations(
         return dict(unexpected_annos) if unexpected_annos else None
 
 
-def _handle_frame_fields(field, samples, ref_field):
-    if samples.media_type != fomm.VIDEO:
+def _handle_frame_fields(dataset, field, ref_field):
+    if dataset.media_type != fomm.VIDEO:
         return field
 
     if (
-        ref_field is None or samples._is_frame_field(ref_field)
-    ) and not samples._is_frame_field(field):
-        field = samples._FRAMES_PREFIX + field
+        ref_field is None or dataset._is_frame_field(ref_field)
+    ) and not dataset._is_frame_field(field):
+        field = dataset._FRAMES_PREFIX + field
 
     return field
 
@@ -1173,7 +1174,7 @@ def _get_writeable_attributes(attributes):
     return [k for k, v in attributes.items() if not v.get("read_only", False)]
 
 
-def _prompt_field(samples, label_type, label_field, label_schema):
+def _prompt_field(dataset, label_type, label_field, label_schema):
     if label_field:
         new_field = input(
             "Found unexpected labels of type '%s' when loading annotations "
@@ -1195,24 +1196,24 @@ def _prompt_field(samples, label_type, label_field, label_schema):
         fo_label_type = _LABEL_TYPES_MAP[label_type]
 
     if label_field is not None:
-        _, is_frame_field = samples._handle_frame_field(label_field)
+        _, is_frame_field = dataset._handle_frame_field(label_field)
     else:
-        is_frame_field = samples.media_type == fomm.VIDEO
+        is_frame_field = dataset.media_type == fomm.VIDEO
 
     if is_frame_field:
-        schema = samples.get_frame_field_schema()
+        schema = dataset.get_frame_field_schema()
     else:
-        schema = samples.get_field_schema()
+        schema = dataset.get_field_schema()
 
     while True:
         is_good_field = new_field not in label_schema
 
         if is_good_field:
             if is_frame_field:
-                if not samples._is_frame_field(new_field):
-                    new_field = samples._FRAMES_PREFIX + new_field
+                if not dataset._is_frame_field(new_field):
+                    new_field = dataset._FRAMES_PREFIX + new_field
 
-                field, _ = samples._handle_frame_field(new_field)
+                field, _ = dataset._handle_frame_field(new_field)
             else:
                 field = new_field
 
@@ -1257,20 +1258,20 @@ def _prompt_field(samples, label_type, label_field, label_schema):
     return new_field
 
 
-def _merge_scalars(samples, anno_dict, results, label_field, label_info=None):
+def _merge_scalars(dataset, anno_dict, results, label_field, label_info=None):
     if label_info is None:
         label_info = {}
 
     allow_additions = label_info.get("allow_additions", True)
     allow_deletions = label_info.get("allow_deletions", True)
 
-    is_video = samples._is_frame_field(label_field)
+    is_video = dataset._is_frame_field(label_field)
 
     # Retrieve a view that contains all samples involved in the annotation run
     id_map = results.id_map.get(label_field, {})
     uploaded_ids = set(k for k, v in id_map.items() if v is not None)
     sample_ids = list(uploaded_ids | set(anno_dict.keys()))
-    view = samples._dataset.select(sample_ids)
+    view = dataset.select(sample_ids)
 
     if is_video:
         field, _ = view._handle_frame_field(label_field)
@@ -1342,7 +1343,7 @@ def _merge_scalars(samples, anno_dict, results, label_field, label_info=None):
 
 
 def _merge_labels(
-    samples,
+    dataset,
     anno_dict,
     results,
     label_field,
@@ -1369,21 +1370,21 @@ def _merge_labels(
     else:
         is_list = False
 
-    _ensure_label_field(samples, label_field, fo_label_type)
+    _ensure_label_field(dataset, label_field, fo_label_type)
 
-    is_video = samples.media_type == fomm.VIDEO
+    is_video = dataset.media_type == fomm.VIDEO
 
     if is_video and label_type in _TRACKABLE_TYPES:
         if not existing_field:
             # Always include keyframe info when importing new video tracks
             only_keyframes = True
 
-        _update_tracks(samples, label_field, anno_dict, only_keyframes)
+        _update_tracks(dataset, label_field, anno_dict, only_keyframes)
 
     id_map = results.id_map.get(label_field, {})
 
     if is_video:
-        field, _ = samples._handle_frame_field(label_field)
+        field, _ = dataset._handle_frame_field(label_field)
         added_id_map = defaultdict(lambda: defaultdict(list))
     else:
         field = label_field
@@ -1457,11 +1458,11 @@ def _merge_labels(
     # Delete labels that were deleted in the annotation task
     if delete_ids and allow_deletions:
         _del_ids = [key[-1] for key in delete_ids]
-        samples._dataset.delete_labels(ids=_del_ids, fields=label_field)
+        dataset.delete_labels(ids=_del_ids, fields=label_field)
 
     # Add/merge labels from the annotation task
     sample_ids = list(anno_dict.keys())
-    view = samples._dataset.select(sample_ids).select_fields(label_field)
+    view = dataset.select(sample_ids).select_fields(label_field)
     for sample in view.iter_samples(progress=True):
         sample_id = sample.id
         sample_annos = anno_dict[sample_id]
@@ -1571,22 +1572,20 @@ def _merge_labels(
     results._update_id_map(label_field, added_id_map)
 
 
-def _ensure_label_field(samples, label_field, fo_label_type):
-    field, is_frame_field = samples._handle_frame_field(label_field)
+def _ensure_label_field(dataset, label_field, fo_label_type):
+    field, is_frame_field = dataset._handle_frame_field(label_field)
     if is_frame_field:
-        if not samples.has_frame_field(field):
-            samples._dataset.add_frame_field(
-                field,
-                fof.EmbeddedDocumentField,
-                embedded_doc_type=fo_label_type,
-            )
+        dataset.add_frame_field(
+            field,
+            fof.EmbeddedDocumentField,
+            embedded_doc_type=fo_label_type,
+        )
     else:
-        if not samples.has_sample_field(field):
-            samples._dataset.add_sample_field(
-                field,
-                fof.EmbeddedDocumentField,
-                embedded_doc_type=fo_label_type,
-            )
+        dataset.add_sample_field(
+            field,
+            fof.EmbeddedDocumentField,
+            embedded_doc_type=fo_label_type,
+        )
 
 
 def _merge_label(
@@ -1628,13 +1627,13 @@ def _merge_label(
             label.set_attribute_value(name, value)
 
 
-def _update_tracks(samples, label_field, anno_dict, only_keyframes):
-    # Using unfiltered samples is important here because we need to ensure
+def _update_tracks(dataset, label_field, anno_dict, only_keyframes):
+    # Using the full dataset here is important here because we need to ensure
     # that any new indexes never clash with *any* existing tracks
-    view = samples._dataset.select(list(anno_dict.keys()))
+    view = dataset.select(list(anno_dict.keys()))
 
-    _, id_path = samples._get_label_field_path(label_field, "id")
-    _, index_path = samples._get_label_field_path(label_field, "index")
+    _, id_path = dataset._get_label_field_path(label_field, "id")
+    _, index_path = dataset._get_label_field_path(label_field, "index")
 
     sample_ids, frame_ids, label_ids, indexes = view.values(
         ["id", "frames.id", id_path, index_path]

--- a/tests/intensive/cvat_tests.py
+++ b/tests/intensive/cvat_tests.py
@@ -1242,7 +1242,7 @@ class CVATTests(unittest.TestCase):
         prev_ids = dataset.values("ground_truth.detections.id", unwind=True)
 
         anno_key = "anno_key"
-        results = dataset.annotate(
+        results = view.annotate(
             anno_key,
             backend="cvat",
             label_field="ground_truth",
@@ -1255,6 +1255,19 @@ class CVATTests(unittest.TestCase):
             sorted(dataset.values("ground_truth.detections.id", unwind=True)),
             sorted(prev_ids),
         )
+
+        # Test scalar
+        view = dataset.select_fields("uniqueness")
+        anno_key = "anno_key2"
+        results = view.annotate(
+            anno_key,
+            backend="cvat",
+            label_field="uniqueness",
+        )
+        dataset.delete_sample_field("uniqueness")
+        dataset.reload()
+
+        dataset.load_annotations(anno_key, cleanup=True)
 
 
 if __name__ == "__main__":

--- a/tests/intensive/cvat_tests.py
+++ b/tests/intensive/cvat_tests.py
@@ -1252,8 +1252,8 @@ class CVATTests(unittest.TestCase):
 
         dataset.load_annotations(anno_key, cleanup=True)
         self.assertListEqual(
-            dataset.values("ground_truth.detections.id", unwind=True),
-            prev_ids,
+            sorted(dataset.values("ground_truth.detections.id", unwind=True)),
+            sorted(prev_ids),
         )
 
 


### PR DESCRIPTION
Currently, a bug can arise when load annotation results through the following:
* Create a view that adds a stage referencing a field being annotated
* Create an annotation run with this view
* Delete the field
* Load the annotation run
* ERROR: The annotation results cannot be loaded since the run view needs to be constructed [here](https://github.com/voxel51/fiftyone/blob/e94ccf26703bde87be16cd5143bd54014001ef2b/fiftyone/core/runs.py#L472) in order to load the run results, but one of the fields doesn't exist.

The workaround is for the user to manually add the sample/frame field back on the dataset and rerun `load_annotations()`, however, this seemingly should not be necessary since we allow brand new fields to be annotated in the same manner.

Since the annotation run view is never actually used when loading annotations for an annotation run, loading the dataset directly should suffice. This PR adds the option to `load_run_results()` to load the dataset directly rather than loading a view, which `load_annotation_results()` then uses.

My only concern with this change is that a future annotation backend may require the results to contain the annotation view rather than dataset for some unforseen reason.