### PR TITLE
Update Qdrant tutorial

### DIFF
--- a/docs/source/tutorials/qdrant.ipynb
+++ b/docs/source/tutorials/qdrant.ipynb
@@ -891,9 +891,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import fiftyone.utils.splits as fous\n",
+    "import fiftyone.utils.random as four\n",
     "\n",
-    "fous.random_split(dataset, {\"train\": 0.7, \"test\": 0.3})\n",
+    "four.random_split(dataset, {\"train\": 0.7, \"test\": 0.3})\n",
     "\n",
     "train_view = dataset.match_tags(\"train\")\n",
     "test_view = dataset.match_tags(\"test\")\n",


### PR DESCRIPTION
Updates Qdrant tutorial to use `fiftyone.utils.random` instead of `fiftyone.utils.splits`. 