### PR TITLE
YOLOv5DatasetExporter: Add flag to use export_dir for path value

### DIFF
--- a/fiftyone/utils/yolo.py
+++ b/fiftyone/utils/yolo.py
@@ -814,6 +814,8 @@ class YOLOv5DatasetExporter(
         image_format (None): the image format to use when writing in-memory
             images to disk. By default, ``fiftyone.config.default_image_ext``
             is used
+        include_path (True): whether to add export_dir as value to 'path'.
+            export_dir must have been set.
     """
 
     def __init__(
@@ -828,6 +830,7 @@ class YOLOv5DatasetExporter(
         classes=None,
         include_confidence=False,
         image_format=None,
+        include_path=True
     ):
         data_path, export_media = self._parse_data_path(
             export_dir=export_dir,
@@ -859,6 +862,7 @@ class YOLOv5DatasetExporter(
         self.classes = classes
         self.include_confidence = include_confidence
         self.image_format = image_format
+        self.include_path = include_path
 
         self._classes = None
         self._dynamic_classes = classes is None
@@ -938,6 +942,9 @@ class YOLOv5DatasetExporter(
         d[self.split] = _make_yolo_v5_path(self.data_path, self.yaml_path)
         d["nc"] = len(classes)
         d["names"] = classes
+        
+        if self.export_dir and self.include_path:
+            d["path"] = self.export_dir
 
         _write_yaml_file(d, self.yaml_path, default_flow_style=False)
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

Discussed in #2106 and implemented as such. `YOLOv5DatasetExporter` is now able to add append the `export_dir` value (i.e. an absolute path) to the the `path` key in the resulting `dataset.yaml`. This behavior is active by default and can be deactivated by passing `include_path=False`.

## How is this patch tested? If it is not, please explain why.

Tested locally

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [ ] No. You can skip the rest of this section.
-   [X] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

When exporting a YOLOv5 dataset, the passed `export_dir` parameter is added to the resulting `dataset.yaml` as value to the `path` key. This can be deactivated by passing `include_path=False`.

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [X] Core: Core `fiftyone` Python library changes
-   [X] Documentation: FiftyOne documentation changes
-   [ ] Other
