### PR TITLE
Dataset Reloading on Click

### DIFF
--- a/app/packages/state/src/hooks/useHelpPanel.ts
+++ b/app/packages/state/src/hooks/useHelpPanel.ts
@@ -24,23 +24,9 @@ export default function useHelpPanel() {
     setState((s) => ({ ...s, isOpen: false }));
   }
 
-  function handleEscape(e) {
-    if (e.key === "Escape") close();
-  }
   function handleClick() {
     close();
   }
-
-  useEffect(() => {
-    if (isOpen) {
-      window.addEventListener("keydown", handleEscape);
-      window.addEventListener("click", handleClick);
-    }
-    return () => {
-      window.removeEventListener("keydown", handleEscape);
-      window.removeEventListener("click", handleClick);
-    };
-  }, [isOpen]);
 
   return {
     open(items) {

--- a/app/packages/state/src/hooks/useJSONPanel.ts
+++ b/app/packages/state/src/hooks/useJSONPanel.ts
@@ -36,19 +36,14 @@ export default function useJSONPanel() {
     [json]
   );
   function close() {
-    setState((s) => ({ ...s, isOpen: false }));
+    setState((s) => {
+      ({ ...s, isOpen: false });
+    });
   }
 
   function handleClick() {
     close();
   }
-
-  useEffect(() => {
-    window.addEventListener("click", handleClick);
-    return () => {
-      window.removeEventListener("click", handleClick);
-    };
-  }, []);
 
   return {
     open(sample) {


### PR DESCRIPTION
When embeded, the `Dataset` component will refresh on all clicks, since this window handler causes a perceived state change.

 