### PR TITLE
avoid using router context

### DIFF
--- a/app/packages/dataset/src/Dataset.tsx
+++ b/app/packages/dataset/src/Dataset.tsx
@@ -24,6 +24,8 @@ enum Events {
   STATE_UPDATE = "state_update",
 }
 
+const ViewBarWrapper = ({ children }) => <div>{children}</div>;
+
 export function Dataset({ datasetName, environment, theme }) {
   theme = theme || darkTheme;
 
@@ -64,7 +66,9 @@ export function Dataset({ datasetName, environment, theme }) {
             datasetQueryRef={datasetQueryRef}
             initialState={initialState}
           >
-            <ViewBar />
+            <ViewBarWrapper>
+              <ViewBar />
+            </ViewBarWrapper>
             <CoreDataset />
           </DatasetLoader>
         </Suspense>

--- a/app/packages/state/src/hooks/useSetView.ts
+++ b/app/packages/state/src/hooks/useSetView.ts
@@ -8,10 +8,10 @@ import { RouterContext } from "../routing";
 import { getDatasetName, transformDataset } from "../utils";
 import useSendEvent from "./useSendEvent";
 import useStateUpdate from "./useStateUpdate";
+import * as fos from "../";
 
 const useSetView = () => {
   const send = useSendEvent(true);
-  const context = useContext(RouterContext);
   const updateState = useStateUpdate();
   const subscription = useRecoilValue(stateSubscription);
   const [commit] = useMutation<setViewMutation>(setView);
@@ -25,6 +25,7 @@ const useSetView = () => {
           | State.Stage[]
           | ((current: State.Stage[]) => State.Stage[])
       ) => {
+        const dataset = get(fos.dataset);
         send((session) => {
           const value =
             viewOrUpdater instanceof Function
@@ -35,7 +36,7 @@ const useSetView = () => {
               subscription,
               session,
               view: value,
-              dataset: getDatasetName(context),
+              dataset: dataset.name,
             },
             onError,
             onCompleted: ({ setView: { dataset, view: value } }) => {


### PR DESCRIPTION
Since the embed version does not use a router, any deep usage of the router will cause issues. In this case the viewbar was referring to a router context that did not exist.