### PR TITLE
Fixing select_by() ID bug

### DIFF
--- a/fiftyone/core/stages.py
+++ b/fiftyone/core/stages.py
@@ -566,9 +566,9 @@ class ExcludeBy(ViewStage):
         return self._values
 
     def to_mongo(self, sample_collection):
-        path, field, _ = sample_collection._handle_id_fields(self._field)
+        path, is_id_field, _ = sample_collection._handle_id_fields(self._field)
 
-        if isinstance(field, fof.ObjectIdField):
+        if is_id_field:
             values = [
                 value if isinstance(value, ObjectId) else ObjectId(value)
                 for value in self._values
@@ -4914,9 +4914,9 @@ class SelectBy(ViewStage):
         return self._ordered
 
     def to_mongo(self, sample_collection):
-        path, field, _ = sample_collection._handle_id_fields(self._field)
+        path, is_id_field, _ = sample_collection._handle_id_fields(self._field)
 
-        if isinstance(field, fof.ObjectIdField):
+        if is_id_field:
             values = [
                 value if isinstance(value, ObjectId) else ObjectId(value)
                 for value in self._values

--- a/tests/unittests/view_tests.py
+++ b/tests/unittests/view_tests.py
@@ -2296,6 +2296,16 @@ class ViewStageTests(unittest.TestCase):
         self.assertEqual(len(result), 2)
         self.assertEqual(result.values("filepath"), unordered_values)
 
+        ids = self.dataset.values("id")
+
+        values = [ids[1], ids[0]]
+        unordered_values = [ids[0], ids[1]]
+
+        result = self.dataset.select_by("id", values)
+
+        self.assertEqual(len(result), 2)
+        self.assertEqual(result.values("id"), unordered_values)
+
     def test_select_by_ordered(self):
         filepaths = self.dataset.values("filepath")
 
@@ -2305,6 +2315,15 @@ class ViewStageTests(unittest.TestCase):
 
         self.assertEqual(len(result), 2)
         self.assertEqual(result.values("filepath"), values)
+
+        ids = self.dataset.values("id")
+
+        values = [ids[1], ids[0]]
+
+        result = self.dataset.select_by("id", values, ordered=True)
+
+        self.assertEqual(len(result), 2)
+        self.assertEqual(result.values("id"), values)
 
     def test_select_fields(self):
         self.dataset.add_sample_field("select_fields_field", fo.IntField)


### PR DESCRIPTION
Fixes a bug when using `select_by()` with `ObjectIdField`s.