### PR TITLE
Automatic Docker address + moving instructions to the docs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -97,6 +97,9 @@ RUN pip --no-cache-dir install --upgrade pip setuptools wheel ipython
 COPY dist dist
 RUN pip --no-cache-dir install dist/*.whl && rm -rf dist
 
+# Use this instead if you want the latest FiftyOne release
+RUN pip --no-cache-dir install fiftyone
+
 #
 # Configure shared storage
 #

--- a/Dockerfile
+++ b/Dockerfile
@@ -98,7 +98,7 @@ COPY dist dist
 RUN pip --no-cache-dir install dist/*.whl && rm -rf dist
 
 # Use this instead if you want the latest FiftyOne release
-RUN pip --no-cache-dir install fiftyone
+# RUN pip --no-cache-dir install fiftyone
 
 #
 # Configure shared storage

--- a/README.md
+++ b/README.md
@@ -216,8 +216,8 @@ bash install.bash
 
 Refer to
 [these instructions](https://voxel51.com/docs/fiftyone/environments/index.html#docker)
-to see how to build and run a Docker image containing a source (or release)
-build of FiftyOne.
+to see how to build and run Docker images containing source or release builds
+of FiftyOne.
 
 ### Generating documentation
 

--- a/README.md
+++ b/README.md
@@ -212,109 +212,18 @@ cd fiftyone
 bash install.bash
 ```
 
+### Docker installs
+
+Refer to
+[these instructions](https://voxel51.com/docs/fiftyone/environments/index.html#docker)
+to see how to build and run a Docker image containing a source (or release)
+build of FiftyOne.
+
 ### Generating documentation
 
 See the
 [docs guide](https://github.com/voxel51/fiftyone/blob/develop/docs/docs_guide.md)
 for information on building and contributing to the documentation.
-
-## Docker installs
-
-Follow the instructions below to build and run a Docker image containing a
-source build of FiftyOne.
-
-### Building an image
-
-First, clone the repository:
-
-```shell
-git clone https://github.com/voxel51/fiftyone
-cd fiftyone
-```
-
-Then build a FiftyOne wheel:
-
-```shell
-make python
-```
-
-and then build the image:
-
-```shell
-docker build -t voxel51/fiftyone .
-```
-
-The default image uses Ubuntu 20.04 and Python 3.8, but you can customize these
-via optional build arguments:
-
-```shell
-docker build \
-    --build-arg BASE_IMAGE=ubuntu:18.04 \
-    --build-arg PYTHON_VERSION=3.9 \
-    -t voxel51/fiftyone .
-```
-
-Refer to the `Dockerfile` itself for additional Python packages that you may
-wish to include in your build.
-
-### Running an image
-
-The image is designed to persist all data in a single `/fiftyone` directory with
-the following organization:
-
-```
-/fiftyone/
-    db/             # FIFTYONE_DATABASE_DIR
-    default/        # FIFTYONE_DEFAULT_DATASET_DIR
-    zoo/
-        datasets/   # FIFTYONE_DATASET_ZOO_DIR
-        models/     # FIFTYONE_MODEL_ZOO_DIR
-```
-
-Therefore, to run a container, you should mount `/fiftyone` as a local volume
-via `--mount` or `-v`, as shown below:
-
-```shell
-SHARED_DIR=/path/to/shared/dir
-
-docker run -v ${SHARED_DIR}:/fiftyone -p 5151:5151 -it voxel51/fiftyone
-```
-
-The `-p 5151:5151` option is required so that when you
-[launch the App](https://voxel51.com/docs/fiftyone/user_guide/app.html#sessions)
-from within the container you can connect to it at http://localhost:5151 in
-your browser.
-
-You can also include the `-e` or `--env-file` options if you need to further
-[configure FiftyOne](https://voxel51.com/docs/fiftyone/user_guide/config.html).
-
-By default, running the image launches an IPython shell, which you can use as
-normal:
-
-```py
-import fiftyone as fo
-import fiftyone.zoo as foz
-
-dataset = foz.load_zoo_dataset("quickstart")
-session = fo.launch_app(dataset)
-```
-
-Note that any datasets you create inside the Docker image must refer to media
-files within `SHARED_DIR` or another mounted volume if you intend to work with
-datasets between sessions.
-
-### Connecting to a localhost database
-
-If you are using a
-[self-managed database](https://voxel51.com/docs/fiftyone/user_guide/config.html#configuring-a-mongodb-connection)
-that you ordinarily connect to via a URI like `mongodb://localhost`, then you
-will need to tweak this slightly when working in Docker. See
-[this question](https://stackoverflow.com/q/24319662) for details.
-
-On Linux, include `--network="host"` in your `docker run` command and use
-`mongodb://127.0.0.1` for your URI.
-
-On Mac or Windows, use `mongodb://host.docker.internal` for your URI.
 
 ## Uninstallation
 

--- a/docs/source/environments/index.rst
+++ b/docs/source/environments/index.rst
@@ -395,8 +395,8 @@ ______
 
 The FiftyOne repository contains a
 `Dockerfile <https://github.com/voxel51/fiftyone/blob/develop/Dockerfile>`_
-that you can use/customize to build and run Docker images containing release
-(or source) builds of FiftyOne.
+that you can use/customize to build and run Docker images containing source
+or release builds of FiftyOne.
 
 Building an image
 ~~~~~~~~~~~~~~~~~

--- a/docs/source/environments/index.rst
+++ b/docs/source/environments/index.rst
@@ -478,19 +478,24 @@ normal:
     import fiftyone.zoo as foz
 
     dataset = foz.load_zoo_dataset("quickstart")
-    session = fo.launch_app(dataset, address="0.0.0.0")
-
-.. note::
-
-    When working inside a Docker container, you must manually
-    :ref:`set the App address <restricting-app-address>` to `0.0.0.0` in order
-    to access the App from outside the container.
+    session = fo.launch_app(dataset)
 
 .. note::
 
     Any datasets you create inside the Docker image must refer to media
     files within `SHARED_DIR` or another mounted volume if you intend to work
     with datasets between sessions.
+
+.. note::
+
+    FiftyOne should automatically detect that it is running inside a Docker
+    container. However, if you are unable to load the App in your browser, you
+    may need to manually :ref:`set the App address <restricting-app-address>`
+    to `0.0.0.0`:
+
+    .. code:: python
+
+        session = fo.launch_app(..., address="0.0.0.0")
 
 Connecting to a localhost database
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/source/environments/index.rst
+++ b/docs/source/environments/index.rst
@@ -388,6 +388,124 @@ Note that you can also open the App
     session = fo.launch_app(dataset, auto=False)  # port=YYYY
     session.open_tab()
 
+.. _docker:
+
+Docker
+______
+
+The FiftyOne repository contains a
+`Dockerfile <https://github.com/voxel51/fiftyone/blob/develop/Dockerfile>`_
+that you can use/customize to build and run Docker images containing release
+(or source) builds of FiftyOne.
+
+Building an image
+~~~~~~~~~~~~~~~~~
+
+First, clone the repository:
+
+.. code:: shell
+
+    git clone https://github.com/voxel51/fiftyone
+    cd fiftyone
+
+If you want a source install of FiftyOne, then build a wheel:
+
+.. code:: shell
+
+    make python
+
+If you want to install a FiftyOne release, then make the suggested modification
+in the
+`Dockerfile <https://github.com/voxel51/fiftyone/blob/develop/Dockerfile>`_.
+
+Next, build the image:
+
+.. code:: shell
+
+    docker build -t voxel51/fiftyone .
+
+The default image uses Ubuntu 20.04 and Python 3.8, but you can customize these
+via optional build arguments:
+
+.. code:: shell
+
+    docker build \
+        --build-arg BASE_IMAGE=ubuntu:18.04 \
+        --build-arg PYTHON_VERSION=3.9 \
+        -t voxel51/fiftyone .
+
+Refer to the
+`Dockerfile <https://github.com/voxel51/fiftyone/blob/develop/Dockerfile>`_ for
+additional Python packages that you may wish to include in your build.
+
+Running an image
+~~~~~~~~~~~~~~~~
+
+The image is designed to persist all data in a single `/fiftyone` directory
+with the following organization:
+
+.. code:: text
+
+    /fiftyone/
+        db/             # FIFTYONE_DATABASE_DIR
+        default/        # FIFTYONE_DEFAULT_DATASET_DIR
+        zoo/
+            datasets/   # FIFTYONE_DATASET_ZOO_DIR
+            models/     # FIFTYONE_MODEL_ZOO_DIR
+
+Therefore, to run a container, you should mount `/fiftyone` as a local volume
+via `--mount` or `-v`, as shown below:
+
+.. code:: shell
+
+    SHARED_DIR=/path/to/shared/dir
+
+    docker run -v ${SHARED_DIR}:/fiftyone -p 5151:5151 -it voxel51/fiftyone
+
+The `-p 5151:5151` option is required so that when you
+:ref:`launch the App <creating-an-app-session>` from within the container you
+can connect to it at http://localhost:5151 in your browser.
+
+You can also include the `-e` or `--env-file` options if you need to further
+:ref:`configure FiftyOne <configuring-fiftyone>`.
+
+By default, running the image launches an IPython shell, which you can use as
+normal:
+
+.. code:: python
+
+    import fiftyone as fo
+    import fiftyone.zoo as foz
+
+    dataset = foz.load_zoo_dataset("quickstart")
+    session = fo.launch_app(dataset, address="0.0.0.0")
+
+.. note::
+
+    When working inside a Docker container, you must manually
+    :ref:`set the App address <restricting-app-address>` to `0.0.0.0` in order
+    to access the App from outside the container.
+
+.. note::
+
+    Any datasets you create inside the Docker image must refer to media
+    files within `SHARED_DIR` or another mounted volume if you intend to work
+    with datasets between sessions.
+
+Connecting to a localhost database
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If you are using a
+:ref:`self-managed database <configuring-mongodb-connection>` that you
+ordinarily connect to via a URI like `mongodb://localhost`, then you will need
+to tweak this slightly when working in Docker. See
+`this question <https://stackoverflow.com/q/24319662>`_ for details.
+
+On Linux, include `--network="host"` in your `docker run` command and use
+`mongodb://127.0.0.1` for your URI.
+
+On Mac or Windows, use `mongodb://host.docker.internal` for your URI.
+
 .. _cloud-storage:
 
 Cloud storage

--- a/docs/source/user_guide/app.rst
+++ b/docs/source/user_guide/app.rst
@@ -78,6 +78,19 @@ install if you would like to run the App as a desktop application.
 
 .. note::
 
+    When working inside a Docker container, you must manually
+    :ref:`set the App address <restricting-app-address>` to `0.0.0.0` in order
+    to access the App from outside the container:
+
+    .. code-block:: python
+
+        session = fo.launch_app(..., address="0.0.0.0")
+
+    See :ref:`this page <docker>` for more information about working with
+    FiftyOne inside Docker.
+
+.. note::
+
     If you are a Windows user launching the App from a script, you should use
     the pattern below to avoid
     `multiprocessing issues <https://stackoverflow.com/q/20360686>`_, since the

--- a/docs/source/user_guide/app.rst
+++ b/docs/source/user_guide/app.rst
@@ -78,11 +78,12 @@ install if you would like to run the App as a desktop application.
 
 .. note::
 
-    When working inside a Docker container, you must manually
-    :ref:`set the App address <restricting-app-address>` to `0.0.0.0` in order
-    to access the App from outside the container:
+    When working inside a Docker container, FiftyOne should automatically
+    detect and appropriately configure networking. However, if you are unable
+    to load the App in your browser, you many need to manually
+    :ref:`set the App address <restricting-app-address>` to `0.0.0.0`:
 
-    .. code-block:: python
+    .. code:: python
 
         session = fo.launch_app(..., address="0.0.0.0")
 

--- a/fiftyone/core/session/session.py
+++ b/fiftyone/core/session/session.py
@@ -307,7 +307,10 @@ class Session(object):
             port = fo.config.default_app_port
 
         if address is None:
-            address = fo.config.default_app_address
+            if fou.is_docker():
+                address = "0.0.0.0"
+            else:
+                address = fo.config.default_app_address
 
         if config is None:
             config = fo.app_config.copy()

--- a/fiftyone/core/utils.py
+++ b/fiftyone/core/utils.py
@@ -1465,6 +1465,20 @@ def is_32_bit():
     return struct.calcsize("P") * 8 == 32
 
 
+def is_docker():
+    """Determines if we're currently running in a Docker image.
+
+    Returns:
+        True/False
+    """
+    path = "/proc/self/cgroup"
+    return (
+        os.path.exists("/.dockerenv")
+        or os.path.isfile(path)
+        and any("docker" in line for line in open(path))
+    )
+
+
 def get_multiprocessing_context():
     """Returns the preferred ``multiprocessing`` context for the current OS.
 

--- a/fiftyone/core/utils.py
+++ b/fiftyone/core/utils.py
@@ -1466,7 +1466,7 @@ def is_32_bit():
 
 
 def is_docker():
-    """Determines if we're currently running in a Docker image.
+    """Determines if we're currently running in a Docker container.
 
     Returns:
         True/False


### PR DESCRIPTION
## Change log

- Automatically sets `address="0.0.0.0"` when running in Docker. Thanks @ritch for the idea!
- Moves the Docker instructions from the GitHub README to the docs
- Explicitly documents that `session = fo.launch_app(..., address="0.0.0.0")` is required when working inside Docker (in case `is_docker()` doesn't work for any reason)
- Adds a note + pointer to the Docker documentation under the App docs where `launch_app()` is introduced

## New Docker section of the environments page

<img width="1149" alt="Screen Shot 2022-10-06 at 3 30 44 PM" src="https://user-images.githubusercontent.com/25985824/194402882-1f5d93ca-6e9e-46ff-a664-0a55c35a3007.png">

## New pointer in the launch App docs

<img width="707" alt="Screen Shot 2022-10-06 at 4 35 30 PM" src="https://user-images.githubusercontent.com/25985824/194414785-b731d0ad-c1e0-44a1-964b-4a713905b836.png">
