### PR TITLE
Handling grouped collections when sampling frames

### DIFF
--- a/fiftyone/core/clips.py
+++ b/fiftyone/core/clips.py
@@ -742,14 +742,14 @@ def _write_manual_clips(dataset, src_collection, clips, other_fields=None):
     if other_fields:
         project.update({f: True for f in other_fields})
 
-    pipeline = [
-        {"$project": project},
-        {"$unwind": "$support"},
-        {"$set": {"_rand": {"$rand": {}}}},
-        {"$out": dataset._sample_collection_name},
-    ]
-
-    src_collection._aggregate(post_pipeline=pipeline)
+    src_collection._aggregate(
+        post_pipeline=[
+            {"$project": project},
+            {"$unwind": "$support"},
+            {"$set": {"_rand": {"$rand": {}}}},
+            {"$out": dataset._sample_collection_name},
+        ]
+    )
 
     cleanup_op = {"$unset": {_tmp_field: ""}}
     src_dataset._sample_collection.update_many({}, cleanup_op)

--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -7894,6 +7894,7 @@ class SampleCollection(object):
         groups_only=False,
         detach_groups=False,
         manual_group_select=False,
+        post_pipeline=None,
     ):
         """Returns the MongoDB aggregation pipeline for the collection.
 
@@ -7925,6 +7926,9 @@ class SampleCollection(object):
             manual_group_select (False): whether the pipeline has manually
                 handled the initial group selection. Only applicable to grouped
                 collections
+            post_pipeline (None): a MongoDB aggregation pipeline (list of
+                dicts) to append to the very end of the pipeline, after all
+                other arguments are applied
 
         Returns:
             the aggregation pipeline
@@ -7944,6 +7948,7 @@ class SampleCollection(object):
         groups_only=False,
         detach_groups=False,
         manual_group_select=False,
+        post_pipeline=None,
     ):
         """Runs the MongoDB aggregation pipeline on the collection and returns
         the result.
@@ -7976,6 +7981,9 @@ class SampleCollection(object):
             manual_group_select (False): whether the pipeline has manually
                 handled the initial group selection. Only applicable to grouped
                 collections
+            post_pipeline (None): a MongoDB aggregation pipeline (list of
+                dicts) to append to the very end of the pipeline, after all
+                other arguments are applied
 
         Returns:
             the aggregation result dict

--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -3025,10 +3025,8 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
             )
 
         sample_collection.compute_metadata()
-
-        pipeline = sample_collection._pipeline()
-        pipeline.extend(
-            [
+        sample_collection._aggregate(
+            post_pipeline=[
                 {
                     "$project": {
                         "_id": False,
@@ -3052,8 +3050,6 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
                 },
             ]
         )
-
-        self._aggregate(pipeline=pipeline, manual_group_select=True)
 
     def delete(self):
         """Deletes the dataset.
@@ -4969,6 +4965,7 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
         groups_only=False,
         detach_groups=False,
         manual_group_select=False,
+        post_pipeline=None,
     ):
         if media_type is None:
             media_type = self.media_type
@@ -5032,6 +5029,9 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
             _pipeline.append({"$project": {"groups": False}})
         elif groups_only:
             _pipeline.extend(self._groups_only_pipeline())
+
+        if post_pipeline is not None:
+            _pipeline.extend(post_pipeline)
 
         return _pipeline
 
@@ -5200,6 +5200,7 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
         groups_only=False,
         detach_groups=False,
         manual_group_select=False,
+        post_pipeline=None,
     ):
         _pipeline = self._pipeline(
             pipeline=pipeline,
@@ -5213,6 +5214,7 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
             groups_only=groups_only,
             detach_groups=detach_groups,
             manual_group_select=manual_group_select,
+            post_pipeline=post_pipeline,
         )
 
         return foo.aggregate(self._sample_collection, _pipeline)
@@ -6328,20 +6330,20 @@ def _add_collection_with_new_ids(
     else:
         src_samples = sample_collection
 
-    src_dataset = sample_collection._dataset
-
     if not contains_videos:
-        pipeline = src_samples._pipeline(detach_groups=True) + [
-            {"$unset": "_id"},
-            {
-                "$merge": {
-                    "into": dataset._sample_collection_name,
-                    "whenMatched": "keepExisting",
-                    "whenNotMatched": "insert",
-                }
-            },
-        ]
-        src_dataset._aggregate(pipeline=pipeline, manual_group_select=True)
+        src_samples._aggregate(
+            detach_groups=True,
+            post_pipeline=[
+                {"$unset": "_id"},
+                {
+                    "$merge": {
+                        "into": dataset._sample_collection_name,
+                        "whenMatched": "keepExisting",
+                        "whenNotMatched": "insert",
+                    }
+                },
+            ],
+        )
 
         return
 
@@ -6359,32 +6361,35 @@ def _add_collection_with_new_ids(
 
     old_ids = src_samples.values("_id")
 
-    sample_pipeline = src_samples._pipeline(
-        detach_frames=True, detach_groups=True
-    ) + [
-        {"$unset": "_id"},
-        {
-            "$merge": {
-                "into": dataset._sample_collection_name,
-                "whenMatched": "keepExisting",
-                "whenNotMatched": "insert",
-            }
-        },
-    ]
-    src_dataset._aggregate(pipeline=sample_pipeline, manual_group_select=True)
+    src_samples._aggregate(
+        detach_frames=True,
+        detach_groups=True,
+        post_pipeline=[
+            {"$unset": "_id"},
+            {
+                "$merge": {
+                    "into": dataset._sample_collection_name,
+                    "whenMatched": "keepExisting",
+                    "whenNotMatched": "insert",
+                }
+            },
+        ],
+    )
 
-    frame_pipeline = src_videos._pipeline(frames_only=True) + [
-        {"$set": {"_tmp": "$_sample_id", "_sample_id": {"$rand": {}}}},
-        {"$unset": "_id"},
-        {
-            "$merge": {
-                "into": dataset._frame_collection_name,
-                "whenMatched": "keepExisting",
-                "whenNotMatched": "insert",
-            }
-        },
-    ]
-    src_dataset._aggregate(pipeline=frame_pipeline, manual_group_select=True)
+    src_videos._aggregate(
+        frames_only=True,
+        post_pipeline=[
+            {"$set": {"_tmp": "$_sample_id", "_sample_id": {"$rand": {}}}},
+            {"$unset": "_id"},
+            {
+                "$merge": {
+                    "into": dataset._frame_collection_name,
+                    "whenMatched": "keepExisting",
+                    "whenNotMatched": "insert",
+                }
+            },
+        ],
+    )
 
     new_ids = dataset[-len(old_ids) :].values("_id")
 
@@ -6637,9 +6642,7 @@ def _merge_samples_pipeline(
     )
     default_fields.discard("id")
 
-    sample_pipeline = src_samples._pipeline(
-        detach_frames=True, detach_groups=True
-    )
+    sample_pipeline = []
 
     if fields is not None:
         project = {key_field: True}
@@ -6726,7 +6729,9 @@ def _merge_samples_pipeline(
     )
 
     # Merge samples
-    src_dataset._aggregate(pipeline=sample_pipeline, manual_group_select=True)
+    src_samples._aggregate(
+        detach_frames=True, detach_groups=True, post_pipeline=sample_pipeline
+    )
 
     # Cleanup indexes
     _cleanup_index(src_dataset, key_field, new_src_index, dropped_src_index)
@@ -6745,7 +6750,7 @@ def _merge_samples_pipeline(
 
         db_fields_map = src_collection._get_db_fields_map(frames=True)
 
-        frame_pipeline = _src_videos._pipeline(frames_only=True)
+        frame_pipeline = []
 
         if frame_fields is not None:
             project = {}
@@ -6797,9 +6802,7 @@ def _merge_samples_pipeline(
         )
 
         # Merge frames
-        src_dataset._aggregate(
-            pipeline=frame_pipeline, manual_group_select=True
-        )
+        _src_videos._aggregate(frames_only=True, post_pipeline=frame_pipeline)
 
         # Drop indexes
         dst_dataset._frame_collection.drop_index(dst_frame_index)

--- a/fiftyone/core/frame.py
+++ b/fiftyone/core/frame.py
@@ -829,7 +829,7 @@ class FramesView(Frames):
         ]
 
         try:
-            d = next(self._dataset._aggregate(pipeline))
+            d = next(foo.aggregate(self._sample_collection, pipeline))
             return set(d["frame_numbers"])
         except StopIteration:
             return set()
@@ -838,18 +838,19 @@ class FramesView(Frames):
         if not self._needs_frames:
             return super()._get_frame_db(frame_number)
 
-        pipeline = self._view._pipeline(frames_only=True)
-        pipeline.append(
-            {
-                "$match": {
-                    "_sample_id": self._sample_id,
-                    "frame_number": frame_number,
-                }
-            }
-        )
-
         try:
-            return next(self._dataset._aggregate(pipeline))
+            result = self._view._aggregate(
+                frames_only=True,
+                post_pipeline=[
+                    {
+                        "$match": {
+                            "_sample_id": self._sample_id,
+                            "frame_number": frame_number,
+                        }
+                    }
+                ],
+            )
+            return next(result)
         except StopIteration:
             return None
 

--- a/fiftyone/core/video.py
+++ b/fiftyone/core/video.py
@@ -589,7 +589,7 @@ def make_frames_dataset(
     _make_pretty_summary(dataset)
 
     # Initialize frames dataset
-    ids_to_sample, frames_to_sample = _init_frames(
+    sample_view, frames_to_sample = _init_frames(
         dataset,
         sample_collection,
         sample_frames,
@@ -604,14 +604,10 @@ def make_frames_dataset(
     )
 
     # Sample frames, if necessary
-    if ids_to_sample:
+    if sample_view is not None:
         logger.info("Sampling video frames...")
-        to_sample_view = sample_collection._root_dataset.select(
-            ids_to_sample, ordered=True
-        )
-
         fouv.sample_videos(
-            to_sample_view,
+            sample_view,
             output_dir=output_dir,
             rel_dir=rel_dir,
             frames_patt=frames_patt,
@@ -854,6 +850,8 @@ def _init_frames(
     # We first populate `sample_map` and then convert to `ids_to_sample` and
     # `frames_to_sample` here to avoid resampling frames when working with clip
     # views with multiple overlapping clips into the same video
+    #
+
     ids_to_sample = []
     frames_to_sample = []
     for video_path, sample_frame_numbers in sample_map.items():
@@ -863,7 +861,17 @@ def _init_frames(
 
         frames_to_sample.append(sample_frame_numbers)
 
-    return ids_to_sample, frames_to_sample
+    if ids_to_sample:
+        if src_dataset.media_type == fom.GROUP:
+            sample_view = src_dataset.select_group_slices(media_type=fom.VIDEO)
+        else:
+            sample_view = src_dataset
+
+        sample_view = sample_view.select(ids_to_sample, ordered=True)
+    else:
+        sample_view = None
+
+    return sample_view, frames_to_sample
 
 
 def _insert_docs(docs, src_docs, src_inds, dataset, src_dataset):

--- a/fiftyone/core/view.py
+++ b/fiftyone/core/view.py
@@ -1100,6 +1100,7 @@ class DatasetView(foc.SampleCollection):
         groups_only=False,
         detach_groups=False,
         manual_group_select=False,
+        post_pipeline=None,
     ):
         _pipelines = []
         _view = self._base_view
@@ -1233,6 +1234,7 @@ class DatasetView(foc.SampleCollection):
             groups_only=groups_only,
             detach_groups=detach_groups,
             manual_group_select=manual_group_select,
+            post_pipeline=post_pipeline,
         )
 
     def _aggregate(
@@ -1248,6 +1250,7 @@ class DatasetView(foc.SampleCollection):
         groups_only=False,
         detach_groups=False,
         manual_group_select=False,
+        post_pipeline=None,
     ):
         _pipeline = self._pipeline(
             pipeline=pipeline,
@@ -1261,7 +1264,9 @@ class DatasetView(foc.SampleCollection):
             groups_only=groups_only,
             detach_groups=detach_groups,
             manual_group_select=manual_group_select,
+            post_pipeline=post_pipeline,
         )
+
         return foo.aggregate(self._dataset._sample_collection, _pipeline)
 
     def _serialize(self, include_uuids=True):


### PR DESCRIPTION
This PR fixes some group-related bugs that were identified originally in the context of running `to_frames()`.

```py
import fiftyone as fo
import fiftyone.zoo as foz

img_data = foz.load_zoo_dataset("quickstart")
vid_data = foz.load_zoo_dataset("quickstart-video")

keys = ["video"] + ["image%d" % i for i in range(9)]
datasets = [vid_data] + [img_data.shuffle().limit(10) for i in range(9)]
sample_dicts = [dict(zip(keys, s)) for s in zip(*datasets)]

dataset = fo.Dataset()
dataset.add_group_field("group", default="image0")

samples = []
for sample_dict in sample_dicts:
    group = fo.Group()
    for name, sample in sample_dict.items():
        sample = sample.copy()
        sample["group"] = group.element(name)
        samples.append(sample)

dataset.add_samples(samples)

videos = dataset.select_group_slices("video")

# Would previously fail if frames needed to be sampled; but now succeeds
view1 = videos.to_frames(sample_frames=True)

# Would previously not include frame filepaths; but now does
view2 = videos.to_frames()
```
