### PR TITLE
fix:  create annotation run crashes if some but not all samples are labeled

### DIFF
--- a/fiftyone/utils/labelstudio.py
+++ b/fiftyone/utils/labelstudio.py
@@ -257,12 +257,10 @@ class LabelStudioAnnotationAPI(foua.AnnotationAPI):
                         },
                     )
                     for smp in samples.select_fields(label_field)
-                    if smp[label_field]
                 }
                 id_map[label_field] = {
                     smp.id: _get_label_ids(smp[label_field])
                     for smp in samples.select_fields(label_field)
-                    if smp[label_field]
                 }
 
         return tasks, predictions, id_map
@@ -638,7 +636,11 @@ def export_label_to_label_studio(label, full_result=None):
         a dictionary or a list in Label Studio format
     """
     # TODO model version and model score
-    if _check_type(label, fol.Classification, fol.Classifications):
+    if label is None:
+        result_value = {}
+        ls_type = ""
+        ids = [0]
+    elif _check_type(label, fol.Classification, fol.Classifications):
         result_value, ls_type, ids = _to_classification(label)
     elif _check_type(label, fol.Detection, fol.Detections):
         result_value, ls_type, ids = _to_detection(label)
@@ -904,6 +906,8 @@ def _denormalize_values(values):
 
 
 def _get_label_ids(label):
+    if label is None:
+        return []
     if isinstance(
         label, (fol.Classification, fol.Segmentation, fol.Regression)
     ):

--- a/fiftyone/utils/labelstudio.py
+++ b/fiftyone/utils/labelstudio.py
@@ -638,8 +638,8 @@ def export_label_to_label_studio(label, full_result=None):
     # TODO model version and model score
     if label is None:
         result_value = {}
-        ls_type = ""
-        ids = [0]
+        ls_type = None
+        ids = []
     elif _check_type(label, fol.Classification, fol.Classifications):
         result_value, ls_type, ids = _to_classification(label)
     elif _check_type(label, fol.Detection, fol.Detections):

--- a/fiftyone/utils/labelstudio.py
+++ b/fiftyone/utils/labelstudio.py
@@ -257,10 +257,12 @@ class LabelStudioAnnotationAPI(foua.AnnotationAPI):
                         },
                     )
                     for smp in samples.select_fields(label_field)
+                    if smp[label_field]
                 }
                 id_map[label_field] = {
                     smp.id: _get_label_ids(smp[label_field])
                     for smp in samples.select_fields(label_field)
+                    if smp[label_field]
                 }
 
         return tasks, predictions, id_map


### PR DESCRIPTION
## What changes are proposed in this pull request?

Creating an annotation run works fine, but when you add new images to the dataset and want to create a new annotation run with all the images, both the new and old, labelstudio crashes. This PR fixes this since labels are only imported from samples that have labels. 

## How is this patch tested? If it is not, please explain why.

Versions:

fiftyone version: 0.17.2
Tested with both label-studio-sdk 0.0.14 and 0.0.15 

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other

## To reproduce:
```
d.annotate(
    anno_key=annotation_key,
    label_schema={
        gt_field: {
            "type": "keypoints",
            "classes": classes,
        }
    },
)
```
Where d is a fiftyone dataset and some of the samples in d have values in `gt_field` and some do not.