### PR TITLE
only warn when plugin re-registered

### DIFF
--- a/app/packages/plugins/src/index.ts
+++ b/app/packages/plugins/src/index.ts
@@ -22,8 +22,9 @@ window.recoil = recoil;
 window.__fos__ = fos;
 
 function usingRegistry() {
-  if (!window.__fo_plugin_registry__)
+  if (!window.__fo_plugin_registry__) {
     window.__fo_plugin_registry__ = new PluginComponentRegistry();
+  }
   return window.__fo_plugin_registry__;
 }
 
@@ -147,8 +148,13 @@ interface PluginComponentRegistration<T extends {} = {}> {
 
 const DEFAULT_ACTIVATOR = () => true;
 
-function assert(ok, msg) {
-  if (ok === false || ok === null || ok === undefined) throw new Error(msg);
+function assert(ok, msg, printWarningOnly = false) {
+  const failed = ok === false || ok === null || ok === undefined;
+  if (failed && printWarningOnly) console.warn(msg);
+  else if (failed) throw new Error(msg);
+}
+function warn(ok, msg) {
+  assert(ok, msg, true);
 }
 const REQUIRED = ["name", "type", "component"];
 class PluginComponentRegistry {
@@ -166,7 +172,7 @@ class PluginComponentRegistry {
         `${fieldName} is required to register a Plugin Component`
       );
     }
-    assert(
+    warn(
       !this.data.has(name),
       `${name} is already a registered Plugin Component`
     );
@@ -184,6 +190,9 @@ class PluginComponentRegistry {
     }
 
     return results;
+  }
+  clear() {
+    this.data.clear();
   }
 }
 


### PR DESCRIPTION
Originally a plugin registered with the same name would cause an assertion to throw. This relaxes that to a warning, since in some environments HMR causes plugins to re-register without issue.

The original intent was to prevent multiple plugins from sharing the same name. The warning will replace the assertion/error.