### PR TITLE
use 5151 local address instead of localhost

### DIFF
--- a/app/packages/app/vite.config.ts
+++ b/app/packages/app/vite.config.ts
@@ -16,13 +16,13 @@ export default defineConfig(({ mode }) => {
     server: {
       proxy: {
         "/plugins": {
-          target: "http://localhost:5151",
+          target: "http://127.0.0.1:5151",
           changeOrigin: false,
           secure: false,
           ws: false,
         },
         "/aggregate": {
-          target: "http://localhost:5151",
+          target: "http://127.0.0.1:5151",
           changeOrigin: false,
           secure: false,
           ws: false,


### PR DESCRIPTION
Local proxy has recently failed to connect on localhost. Switching to `127.0.0.1` fixes the issue. This is only for the `/aggregate` and `/plugin` routes. Eventually I'd like to move these to the other local development env vars we use else where. Until then this will unblock plugin development.

For google searches:

```
[dev] 9:20:23 AM [vite] http proxy error:
[dev] Error: connect ECONNREFUSED ::1:5151
[dev]   at TCPConnectWrap.afterConnect [as oncomplete] (node:net:1237:16)
```

and

```
Error: connect ECONNREFUSED ::1:5151
```