### PR TITLE
Update to MongoDb v 6.0.2 for m1 Macs

### DIFF
--- a/.github/workflows/build-db.yml
+++ b/.github/workflows/build-db.yml
@@ -44,6 +44,11 @@ jobs:
         run: |
           cd package/db
           python setup.py bdist_wheel --plat-name ${{ matrix.platform }}
+      - name: Build wheel (macOS Arm64)
+        if: ${{ matrix.platform == 'mac-arm64' }}
+        run: |
+          cd package/db
+          python setup.py bdist_wheel --plat-name mac-arm64
       - name: Build wheel (Ubuntu 20.04 x86_64)
         if: ${{ matrix.platform == 'linux-x86_64' }}
         env:

--- a/install.bash
+++ b/install.bash
@@ -47,6 +47,7 @@ done
 set -e
 NODE_VERSION=17.9.0
 OS=$(uname -s)
+ARCH=$(uname -m)
 
 if [ ${SCRATCH_MONGODB_INSTALL} = true ]; then
     echo "***** INSTALLING MONGODB *****"
@@ -57,18 +58,31 @@ if [ ${SCRATCH_MONGODB_INSTALL} = true ]; then
     if [ -x bin/mongod ]; then
         VERSION_FULL=$(bin/mongod --version | grep 'db version')
         VERSION="${VERSION_FULL:12}"
-        if [ ${VERSION} != "5.0.4" ]; then
-            echo "Upgrading MongoDB v${VERSION} to v5.0.4"
+        if [ "${OS}" == "Darwin" ] && [ "${ARCH}" == "arm64" ]; then
+            if [ ${VERSION} != "6.0.2" ]; then
+                echo "Upgrading MongoDB v${VERSION} to v6.0.2"
+            else
+                echo "MongoDB v6.0.2 already installed"
+                INSTALL_MONGODB=false
+            fi
         else
-            echo "MongoDB v5.0.4 already installed"
-            INSTALL_MONGODB=false
+            if [ ${VERSION} != "5.0.4" ]; then
+                echo "Upgrading MongoDB v${VERSION} to v5.0.4"
+            else
+                echo "MongoDB v5.0.4 already installed"
+                INSTALL_MONGODB=false
+            fi
         fi
     else
         echo "Installing MongoDB v5.0.4"
     fi
     if [ ${INSTALL_MONGODB} = true ]; then
-        if [ "${OS}" == "Darwin" ]; then
-            MONGODB_BUILD=mongodb-macos-x86_64-5.0.4
+        MONGODB_VERSION=5.0.4
+            if [ "${OS}" == "Darwin" ]; then
+                if ["${ARCH}" == "arm64"]; then
+                    MONGODB_VERSION=6.0.2
+                fi
+                MONGODB_BUILD=mongodb-macos-x86_64-${MONGODB_VERSION}
 
             curl https://fastdl.mongodb.org/osx/${MONGODB_BUILD}.tgz --output mongodb.tgz
             tar -zxvf mongodb.tgz
@@ -76,7 +90,7 @@ if [ ${SCRATCH_MONGODB_INSTALL} = true ]; then
             rm mongodb.tgz
             rm -rf ${MONGODB_BUILD}
         elif [ "${OS}" == "Linux" ]; then
-            MONGODB_BUILD=mongodb-linux-x86_64-ubuntu2004-5.0.4
+            MONGODB_BUILD=mongodb-linux-x86_64-ubuntu2004-${MONGODB_VERSION}
 
             curl https://fastdl.mongodb.org/linux/${MONGODB_BUILD}.tgz --output mongodb.tgz
             tar -zxvf mongodb.tgz

--- a/package/db/setup.py
+++ b/package/db/setup.py
@@ -27,7 +27,7 @@ MONGODB_DOWNLOAD_URLS = {
     "linux-aarch64": "https://fastdl.mongodb.org/linux/mongodb-linux-aarch64-ubuntu1804-5.0.4.tgz",
     "linux-i686": None,
     "linux-x86_64": "https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-ubuntu1804-5.0.4.tgz",
-    "mac-arm64": None,
+    "mac-arm64": "https://fastdl.mongodb.org/osx/mongodb-macos-x86_64-6.0.2.tgz",
     "mac-x86_64": "https://fastdl.mongodb.org/osx/mongodb-macos-x86_64-5.0.4.tgz",
     "win-32": None,
     "win-amd64": "https://fastdl.mongodb.org/windows/mongodb-windows-x86_64-5.0.4.zip",


### PR DESCRIPTION
Addresses https://github.com/voxel51/fiftyone/issues/2151

## What changes are proposed in this pull request?

(Please fill in changes proposed in this fix)

## How is this patch tested? If it is not, please explain why.

- run `install.bash` with `SCRATCH_MONGODB_INSTALL=true` on a m1 Mac
- verify that mongodb version 6.0.2 is downloaded if version != 6.0.2

## Release Notes

- For M1 Macs: Update mongoDb to v6.0.2, which supports the arm64 architecture

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [x ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ x] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
