### PR TITLE
add support for readOnly mode

### DIFF
--- a/app/packages/core/src/components/Actions/ActionsRow.tsx
+++ b/app/packages/core/src/components/Actions/ActionsRow.tsx
@@ -361,12 +361,13 @@ const ActionsRowDiv = styled.div`
 
 export const GridActionsRow = () => {
   const isVideo = useRecoilValue(fos.isVideoDataset);
+  const hideTagging = useRecoilValue(fos.readOnly);
 
   return (
     <ActionsRowDiv>
       <ToggleSidebar modal={false} />
       <Options modal={false} />
-      <Tag modal={false} />
+      {hideTagging ? null : <Tag modal={false} />}
       <Patches />
       {!isVideo && <Similarity modal={false} />}
       <SaveFilters />

--- a/app/packages/dataset/src/Dataset.tsx
+++ b/app/packages/dataset/src/Dataset.tsx
@@ -8,7 +8,7 @@ import {
   usePreLoadedDataset,
   ViewBar,
 } from "@fiftyone/core";
-import { useRecoilValue } from "recoil";
+import { useRecoilValue, useSetRecoilState } from "recoil";
 import * as fos from "@fiftyone/state";
 import { darkTheme, getEventSource, toCamelCase } from "@fiftyone/utilities";
 import { useEffect, useState, Suspense } from "react";
@@ -26,15 +26,17 @@ enum Events {
 
 const ViewBarWrapper = ({ children }) => <div>{children}</div>;
 
-export function Dataset({ datasetName, environment, theme }) {
+export function Dataset({ datasetName, environment, theme, readOnly }) {
   theme = theme || darkTheme;
 
   const [initialState, setInitialState] = useState();
   const [datasetQueryRef, loadDataset] = useDatasetLoader(environment);
+  const setReadOnly = useSetRecoilState(fos.readOnly);
 
   useEffect(() => {
+    setReadOnly(readOnly);
     loadDataset(datasetName);
-  }, [datasetName]);
+  }, [datasetName, readOnly]);
   const subscription = useRecoilValue(fos.stateSubscription);
   useEventSource(datasetName, subscription, setInitialState);
   const plugins = usePlugins();

--- a/app/packages/dataset/src/index.tsx
+++ b/app/packages/dataset/src/index.tsx
@@ -28,28 +28,42 @@ const DatasetWrapper = () => {
 };
 
 function LoadableDataset() {
-  const [datasetName, setDatasetName] = React.useState("quickstart");
+  const [settings, setSettings] = React.useState({
+    dataset: "quickstart",
+    readOnly: false,
+  });
   return (
     <Fragment>
-      <DatasetSelector current={datasetName} onChange={setDatasetName} />
+      <DatasetSettings current={settings} onChange={setSettings} />
       <div style={{ height: "100vh", overflow: "hidden" }}>
-        <Dataset datasetName={datasetName} />
+        <Dataset datasetName={settings.dataset} readOnly={settings.readOnly} />
       </div>
     </Fragment>
   );
 }
 
-function DatasetSelector({ current, onChange }) {
-  const ref = useRef();
+function DatasetSettings({ current, onChange }) {
+  const datasetInputRef = useRef();
+  const readOnlyInputRef = useRef();
   function load(e) {
     e.preventDefault();
-    if (ref.current && ref.current.value) {
-      onChange(ref.current.value);
-    }
+    const dataset = datasetInputRef.current
+      ? datasetInputRef.current.value
+      : null;
+    const readOnly = readOnlyInputRef.current
+      ? readOnlyInputRef.current.checked
+      : false;
+    onChange((s) => ({ ...s, dataset, readOnly }));
   }
   return (
     <form onSubmit={load}>
-      <input ref={ref} type="text" defaultValue={current} />
+      <input
+        ref={readOnlyInputRef}
+        type="checkbox"
+        defaultChecked={current.readOnly}
+      />{" "}
+      Read Only
+      <input ref={datasetInputRef} type="text" defaultValue={current.dataset} />
       <button type="submit">load</button>
     </form>
   );

--- a/app/packages/state/src/recoil/atoms.ts
+++ b/app/packages/state/src/recoil/atoms.ts
@@ -238,3 +238,8 @@ export const lookerPanels = atom({
     help: { isOpen: false },
   },
 });
+
+export const readOnly = atom({
+  key: "readOnly",
+  default: false,
+});


### PR DESCRIPTION
In order to support cases where the app should not display actions that write to mongodb, this PR adds the ability to load the app in a "readOnly" mode. For now this only applies to the Tagging functionality, but any new or other features which behave similarly should be hidden in this mode.