### PR TITLE
Fix relay compilation and ensure future compilations in builds

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,2 +1,3 @@
 *.html
 voxel51-website.js
+**/__generated__

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,18 +1,18 @@
 {
-    "overrides": [
-        {
-            "files": "*.md",
-            "options": {
-                "printWidth": 79,
-                "proseWrap": "always",
-                "tabWidth": 4
-            }
-        },
-        {
-            "files": "*.json",
-            "options": {
-                "tabWidth": 4
-            }
-        }
-    ]
+  "overrides": [
+    {
+      "files": "*.md",
+      "options": {
+        "printWidth": 79,
+        "proseWrap": "always",
+        "tabWidth": 4
+      }
+    },
+    {
+      "files": "*.json",
+      "options": {
+        "tabWidth": 4
+      }
+    }
+  ]
 }

--- a/app/packages/aggregations/package.json
+++ b/app/packages/aggregations/package.json
@@ -1,34 +1,33 @@
 {
-  "name": "@fiftyone/aggregations",
-  "author": "Voxel51, Inc.",
-  "version": "0.0.0",
-  "description": "Query fiftyone from a browser",
-  "homepage": "https://github.com/voxel51/fiftyone/app/packages/plugins",
-  "license": "Apache-2.0",
-  "bugs": {
-    "url": "https://github.com/voxel51/fiftyone/"
-  },
-  "main": "./src/index.ts",
-  "scripts": {
-    "dev": "vite",
-    "test": "jest",
-    "gen:aggs": "node scripts/generateAggregationClasses.js"
-  },
-  "prettier": "@fiftyone/prettier-config",
-  "private": true,
-  "files": [
-    "dist",
-    "README.md"
-  ],
-  "devDependencies": {
-    "@babel/preset-typescript": "^7.17.12",
-    "@fiftyone/prettier-config": "*",
-    "@types/react": "^18.0.12",
-    "fs-extra": "^10.1.0",
-    "jest": "^28.1.1",
-    "lodash": "^4.17.21",
-    "prettier": "2.2.1",
-    "typescript": "4.2.4",
-    "vite": "2.4.2"
-  }
+    "name": "@fiftyone/aggregations",
+    "author": "Voxel51, Inc.",
+    "version": "0.0.0",
+    "description": "Query fiftyone from a browser",
+    "homepage": "https://github.com/voxel51/fiftyone/app/packages/plugins",
+    "license": "Apache-2.0",
+    "bugs": {
+        "url": "https://github.com/voxel51/fiftyone/"
+    },
+    "main": "./src/index.ts",
+    "scripts": {
+        "dev": "vite",
+        "test": "jest",
+        "gen:aggs": "node scripts/generateAggregationClasses.js"
+    },
+    "private": true,
+    "files": [
+        "dist",
+        "README.md"
+    ],
+    "devDependencies": {
+        "@babel/preset-typescript": "^7.17.12",
+        "@fiftyone/prettier-config": "*",
+        "@types/react": "^18.0.12",
+        "fs-extra": "^10.1.0",
+        "jest": "^28.1.1",
+        "lodash": "^4.17.21",
+        "prettier": "2.2.1",
+        "typescript": "4.2.4",
+        "vite": "2.4.2"
+    }
 }

--- a/app/packages/aggregations/package.json
+++ b/app/packages/aggregations/package.json
@@ -21,7 +21,6 @@
     ],
     "devDependencies": {
         "@babel/preset-typescript": "^7.17.12",
-        "@fiftyone/prettier-config": "*",
         "@types/react": "^18.0.12",
         "fs-extra": "^10.1.0",
         "jest": "^28.1.1",

--- a/app/packages/app/package.json
+++ b/app/packages/app/package.json
@@ -55,7 +55,6 @@
         "xstate": "^4.14.0"
     },
     "devDependencies": {
-        "@fiftyone/prettier-config": "*",
         "@types/lodash": "^4.14.182",
         "@types/mime": "^2.0.3",
         "@types/react": "^18.0.9",

--- a/app/packages/app/package.json
+++ b/app/packages/app/package.json
@@ -5,11 +5,11 @@
     "private": true,
     "main": "./src/index.tsx",
     "scripts": {
+        "compile": "yarn workspace @fiftyone/core compile && yarn workspace @fiftyone/relay compile",
         "dev": "vite",
-        "build": "yarn build-bare && yarn copy-to-python",
+        "build": "yarn compile && yarn build-bare && yarn copy-to-python",
         "build-bare": "tsc && vite build",
         "build-desktop": "tsc && vite build --mode desktop",
-        "compile": "relay-compiler",
         "copy-to-python": "rm -rf ../../../fiftyone/server/static && cp -r ./dist ../../../fiftyone/server/static",
         "copy-to-desktop": "rm -rf ../desktop/dist/ && cp -r ./dist ../desktop/dist"
     },

--- a/app/packages/components/package.json
+++ b/app/packages/components/package.json
@@ -1,48 +1,47 @@
 {
-  "name": "@fiftyone/components",
-  "author": "Voxel51, Inc.",
-  "version": "0.0.0",
-  "description": "FiftyOne component library.",
-  "homepage": "https://github.com/voxel51/fiftyone/app/packages/componentsr",
-  "license": "Apache-2.0",
-  "bugs": {
-    "url": "https://github.com/voxel51/fiftyone/"
-  },
-  "main": "./src/index.ts",
-  "scripts": {
-    "dev": "vite"
-  },
-  "prettier": "@fiftyone/prettier-config",
-  "private": true,
-  "files": [
-    "dist",
-    "package.json",
-    "README.md"
-  ],
-  "devDependencies": {
-    "@fiftyone/prettier-config": "*",
-    "@types/react-input-autosize": "^2.2.1",
-    "prettier": "^2.7.1",
-    "typescript": "^4.7.4",
-    "typescript-plugin-css-modules": "^3.4.0",
-    "vite": "^3.0.0"
-  },
-  "peerDependencies": {
-    "@material-ui/core": "*",
-    "@material-ui/icons": "*",
-    "@react-spring/web": "*",
-    "react": "*",
-    "react-relay": "*",
-    "recoil": "*",
-    "styled-components": "*"
-  },
-  "dependencies": {
-    "@fiftyone/state": "*",
-    "classnames": "^2.3.1",
-    "framer-motion": "^6.2.7",
-    "path-to-regexp": "^6.2.0",
-    "react-input-autosize": "^3.0.0",
-    "react-laag": "^2.0.3",
-    "react-use": "^17.3.2"
-  }
+    "name": "@fiftyone/components",
+    "author": "Voxel51, Inc.",
+    "version": "0.0.0",
+    "description": "FiftyOne component library.",
+    "homepage": "https://github.com/voxel51/fiftyone/app/packages/componentsr",
+    "license": "Apache-2.0",
+    "bugs": {
+        "url": "https://github.com/voxel51/fiftyone/"
+    },
+    "main": "./src/index.ts",
+    "scripts": {
+        "dev": "vite"
+    },
+    "private": true,
+    "files": [
+        "dist",
+        "package.json",
+        "README.md"
+    ],
+    "devDependencies": {
+        "@fiftyone/prettier-config": "*",
+        "@types/react-input-autosize": "^2.2.1",
+        "prettier": "^2.7.1",
+        "typescript": "^4.7.4",
+        "typescript-plugin-css-modules": "^3.4.0",
+        "vite": "^3.0.0"
+    },
+    "peerDependencies": {
+        "@material-ui/core": "*",
+        "@material-ui/icons": "*",
+        "@react-spring/web": "*",
+        "react": "*",
+        "react-relay": "*",
+        "recoil": "*",
+        "styled-components": "*"
+    },
+    "dependencies": {
+        "@fiftyone/state": "*",
+        "classnames": "^2.3.1",
+        "framer-motion": "^6.2.7",
+        "path-to-regexp": "^6.2.0",
+        "react-input-autosize": "^3.0.0",
+        "react-laag": "^2.0.3",
+        "react-use": "^17.3.2"
+    }
 }

--- a/app/packages/components/package.json
+++ b/app/packages/components/package.json
@@ -19,7 +19,6 @@
         "README.md"
     ],
     "devDependencies": {
-        "@fiftyone/prettier-config": "*",
         "@types/react-input-autosize": "^2.2.1",
         "prettier": "^2.7.1",
         "typescript": "^4.7.4",

--- a/app/packages/core/package.json
+++ b/app/packages/core/package.json
@@ -49,7 +49,6 @@
         "xstate": "^4.14.0"
     },
     "devDependencies": {
-        "@fiftyone/prettier-config": "*",
         "@types/lodash": "^4.14.182",
         "@types/mime": "^2.0.3",
         "@types/react": "^18.0.9",

--- a/app/packages/core/src/Dataset.ts
+++ b/app/packages/core/src/Dataset.ts
@@ -1,9 +1,9 @@
 import * as fos from "@fiftyone/state";
-import { dataset } from "@fiftyone/state";
-import { Resource, toCamelCase } from "@fiftyone/utilities";
+import { toCamelCase } from "@fiftyone/utilities";
 import { useEffect, useState } from "react";
-import { loadQuery, usePreloadedQuery, useQueryLoader } from "react-relay";
-import { useRecoilValue } from "recoil";
+import { usePreloadedQuery, useQueryLoader } from "react-relay";
+
+import { DatasetQuery } from "./__generated__/DatasetQuery.graphql";
 
 const DatasetQueryNode = graphql`
   query DatasetQuery($name: String!, $view: BSONArray = null) {
@@ -124,11 +124,14 @@ export function usePreLoadedDataset(
   { colorscale, config, state } = {}
 ) {
   const [ready, setReady] = useState(false);
-  const { dataset } = usePreloadedQuery(DatasetQueryNode, queryRef);
+  const { dataset } = usePreloadedQuery<DatasetQuery>(
+    DatasetQueryNode,
+    queryRef
+  );
   usePrepareDataset(dataset, { colorscale, config, state }, setReady);
   return [dataset, ready];
 }
-export function useDatasetLoader(environment) {
+export function useDatasetLoader() {
   const [queryRef, loadQuery] = useQueryLoader(DatasetQueryNode);
   return [
     queryRef,

--- a/app/packages/core/src/Dataset.ts
+++ b/app/packages/core/src/Dataset.ts
@@ -3,7 +3,10 @@ import { toCamelCase } from "@fiftyone/utilities";
 import { useEffect, useState } from "react";
 import { usePreloadedQuery, useQueryLoader } from "react-relay";
 
-import { DatasetQuery } from "./__generated__/DatasetQuery.graphql";
+import {
+  DatasetQuery,
+  DatasetQuery$data,
+} from "./__generated__/DatasetQuery.graphql";
 
 const DatasetQueryNode = graphql`
   query DatasetQuery($name: String!, $view: BSONArray = null) {
@@ -122,7 +125,7 @@ export function usePrepareDataset(
 export function usePreLoadedDataset(
   queryRef,
   { colorscale, config, state } = {}
-) {
+): [DatasetQuery$data["dataset"], boolean] {
   const [ready, setReady] = useState(false);
   const { dataset } = usePreloadedQuery<DatasetQuery>(
     DatasetQueryNode,

--- a/app/packages/core/src/Root/Datasets/Dataset.tsx
+++ b/app/packages/core/src/Root/Datasets/Dataset.tsx
@@ -1,21 +1,21 @@
-import { NotFoundError, toCamelCase } from "@fiftyone/utilities";
-import React, { useContext, useEffect } from "react";
-import { graphql, usePreloadedQuery } from "react-relay";
+import { NotFoundError } from "@fiftyone/utilities";
+import React, { useContext } from "react";
 import { useRecoilValue } from "recoil";
 
 import DatasetComponent from "../../components/Dataset";
 
 import * as fos from "@fiftyone/state";
-import { refresher, Route, RouterContext } from "@fiftyone/state";
+import { Route, RouterContext } from "@fiftyone/state";
 import { getDatasetName } from "@fiftyone/state";
-import { usePreLoadedDataset, DatasetQuery } from "../../loaders";
+import { usePreLoadedDataset } from "../../Dataset";
+import { DatasetQuery } from "../../__generated__/DatasetQuery.graphql";
 
 export const Dataset: Route<DatasetQuery> = ({ prepared }) => {
   const router = useContext(RouterContext);
   const [dataset, ready] = usePreLoadedDataset(prepared, router?.state);
   const name = useRecoilValue(fos.datasetName);
   if (!ready) return null;
-  if (!dataset) {
+  if (dataset === null) {
     throw new NotFoundError(`/datasets/${getDatasetName(router)}`);
   }
   if (!name || name !== dataset.name) {

--- a/app/packages/core/src/Root/__generated__/DatasetsPaginationQuery.graphql.ts
+++ b/app/packages/core/src/Root/__generated__/DatasetsPaginationQuery.graphql.ts
@@ -8,7 +8,7 @@
 /* eslint-disable */
 // @ts-nocheck
 
-import { ConcreteRequest, Query } from "relay-runtime";
+import { ConcreteRequest, Query } from 'relay-runtime';
 import { FragmentRefs } from "relay-runtime";
 export type DatasetsPaginationQuery$variables = {
   count?: number | null;
@@ -23,176 +23,178 @@ export type DatasetsPaginationQuery = {
   variables: DatasetsPaginationQuery$variables;
 };
 
-const node: ConcreteRequest = (function () {
-  var v0 = [
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "count"
+  },
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "cursor"
+  },
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "search"
+  }
+],
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "after",
+    "variableName": "cursor"
+  },
+  {
+    "kind": "Variable",
+    "name": "first",
+    "variableName": "count"
+  },
+  {
+    "kind": "Variable",
+    "name": "search",
+    "variableName": "search"
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "DatasetsPaginationQuery",
+    "selections": [
       {
-        defaultValue: null,
-        kind: "LocalArgument",
-        name: "count",
-      },
-      {
-        defaultValue: null,
-        kind: "LocalArgument",
-        name: "cursor",
-      },
-      {
-        defaultValue: null,
-        kind: "LocalArgument",
-        name: "search",
-      },
+        "args": null,
+        "kind": "FragmentSpread",
+        "name": "RootDatasets_query"
+      }
     ],
-    v1 = [
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "DatasetsPaginationQuery",
+    "selections": [
       {
-        kind: "Variable",
-        name: "after",
-        variableName: "cursor",
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": "DatasetStrConnection",
+        "kind": "LinkedField",
+        "name": "datasets",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "total",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "DatasetStrEdge",
+            "kind": "LinkedField",
+            "name": "edges",
+            "plural": true,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "cursor",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "Dataset",
+                "kind": "LinkedField",
+                "name": "node",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "name",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "id",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "__typename",
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "DatasetStrPageInfo",
+            "kind": "LinkedField",
+            "name": "pageInfo",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "endCursor",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "hasNextPage",
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
       },
       {
-        kind: "Variable",
-        name: "first",
-        variableName: "count",
-      },
-      {
-        kind: "Variable",
-        name: "search",
-        variableName: "search",
-      },
-    ];
-  return {
-    fragment: {
-      argumentDefinitions: v0 /*: any*/,
-      kind: "Fragment",
-      metadata: null,
-      name: "DatasetsPaginationQuery",
-      selections: [
-        {
-          args: null,
-          kind: "FragmentSpread",
-          name: "RootDatasets_query",
-        },
-      ],
-      type: "Query",
-      abstractKey: null,
-    },
-    kind: "Request",
-    operation: {
-      argumentDefinitions: v0 /*: any*/,
-      kind: "Operation",
-      name: "DatasetsPaginationQuery",
-      selections: [
-        {
-          alias: null,
-          args: v1 /*: any*/,
-          concreteType: "DatasetStrConnection",
-          kind: "LinkedField",
-          name: "datasets",
-          plural: false,
-          selections: [
-            {
-              alias: null,
-              args: null,
-              kind: "ScalarField",
-              name: "total",
-              storageKey: null,
-            },
-            {
-              alias: null,
-              args: null,
-              concreteType: "DatasetStrEdge",
-              kind: "LinkedField",
-              name: "edges",
-              plural: true,
-              selections: [
-                {
-                  alias: null,
-                  args: null,
-                  kind: "ScalarField",
-                  name: "cursor",
-                  storageKey: null,
-                },
-                {
-                  alias: null,
-                  args: null,
-                  concreteType: "Dataset",
-                  kind: "LinkedField",
-                  name: "node",
-                  plural: false,
-                  selections: [
-                    {
-                      alias: null,
-                      args: null,
-                      kind: "ScalarField",
-                      name: "name",
-                      storageKey: null,
-                    },
-                    {
-                      alias: null,
-                      args: null,
-                      kind: "ScalarField",
-                      name: "id",
-                      storageKey: null,
-                    },
-                    {
-                      alias: null,
-                      args: null,
-                      kind: "ScalarField",
-                      name: "__typename",
-                      storageKey: null,
-                    },
-                  ],
-                  storageKey: null,
-                },
-              ],
-              storageKey: null,
-            },
-            {
-              alias: null,
-              args: null,
-              concreteType: "DatasetStrPageInfo",
-              kind: "LinkedField",
-              name: "pageInfo",
-              plural: false,
-              selections: [
-                {
-                  alias: null,
-                  args: null,
-                  kind: "ScalarField",
-                  name: "endCursor",
-                  storageKey: null,
-                },
-                {
-                  alias: null,
-                  args: null,
-                  kind: "ScalarField",
-                  name: "hasNextPage",
-                  storageKey: null,
-                },
-              ],
-              storageKey: null,
-            },
-          ],
-          storageKey: null,
-        },
-        {
-          alias: null,
-          args: v1 /*: any*/,
-          filters: ["search"],
-          handle: "connection",
-          key: "DatasetsList_query_datasets",
-          kind: "LinkedHandle",
-          name: "datasets",
-        },
-      ],
-    },
-    params: {
-      cacheID: "1e0b621671e78c21b0947dcfa72dd51e",
-      id: null,
-      metadata: {},
-      name: "DatasetsPaginationQuery",
-      operationKind: "query",
-      text: "query DatasetsPaginationQuery(\n  $count: Int\n  $cursor: String\n  $search: String\n) {\n  ...RootDatasets_query\n}\n\nfragment RootDatasets_query on Query {\n  datasets(search: $search, first: $count, after: $cursor) {\n    total\n    edges {\n      cursor\n      node {\n        name\n        id\n        __typename\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n",
-    },
-  };
+        "alias": null,
+        "args": (v1/*: any*/),
+        "filters": [
+          "search"
+        ],
+        "handle": "connection",
+        "key": "DatasetsList_query_datasets",
+        "kind": "LinkedHandle",
+        "name": "datasets"
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "1e0b621671e78c21b0947dcfa72dd51e",
+    "id": null,
+    "metadata": {},
+    "name": "DatasetsPaginationQuery",
+    "operationKind": "query",
+    "text": "query DatasetsPaginationQuery(\n  $count: Int\n  $cursor: String\n  $search: String\n) {\n  ...RootDatasets_query\n}\n\nfragment RootDatasets_query on Query {\n  datasets(search: $search, first: $count, after: $cursor) {\n    total\n    edges {\n      cursor\n      node {\n        name\n        id\n        __typename\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
+  }
+};
 })();
 
 (node as any).hash = "280afc557752c2245a140c58ccb00248";

--- a/app/packages/core/src/Root/__generated__/RootConfig_query.graphql.ts
+++ b/app/packages/core/src/Root/__generated__/RootConfig_query.graphql.ts
@@ -8,7 +8,7 @@
 /* eslint-disable */
 // @ts-nocheck
 
-import { Fragment, ReaderFragment } from "relay-runtime";
+import { Fragment, ReaderFragment } from 'relay-runtime';
 export type ColorBy = "field" | "instance" | "label" | "%future added value";
 import { FragmentRefs } from "relay-runtime";
 export type RootConfig_query$data = {
@@ -36,128 +36,128 @@ export type RootConfig_query$key = {
   readonly " $fragmentSpreads": FragmentRefs<"RootConfig_query">;
 };
 
-const node: ReaderFragment = (function () {
-  var v0 = {
-    alias: null,
-    args: null,
-    kind: "ScalarField",
-    name: "colorscale",
-    storageKey: null,
-  };
-  return {
-    argumentDefinitions: [],
-    kind: "Fragment",
-    metadata: null,
-    name: "RootConfig_query",
-    selections: [
-      {
-        alias: null,
-        args: null,
-        concreteType: "AppConfig",
-        kind: "LinkedField",
-        name: "config",
-        plural: false,
-        selections: [
-          {
-            alias: null,
-            args: null,
-            kind: "ScalarField",
-            name: "colorBy",
-            storageKey: null,
-          },
-          {
-            alias: null,
-            args: null,
-            kind: "ScalarField",
-            name: "colorPool",
-            storageKey: null,
-          },
-          v0 /*: any*/,
-          {
-            alias: null,
-            args: null,
-            kind: "ScalarField",
-            name: "gridZoom",
-            storageKey: null,
-          },
-          {
-            alias: null,
-            args: null,
-            kind: "ScalarField",
-            name: "loopVideos",
-            storageKey: null,
-          },
-          {
-            alias: null,
-            args: null,
-            kind: "ScalarField",
-            name: "notebookHeight",
-            storageKey: null,
-          },
-          {
-            alias: null,
-            args: null,
-            kind: "ScalarField",
-            name: "plugins",
-            storageKey: null,
-          },
-          {
-            alias: null,
-            args: null,
-            kind: "ScalarField",
-            name: "showConfidence",
-            storageKey: null,
-          },
-          {
-            alias: null,
-            args: null,
-            kind: "ScalarField",
-            name: "showIndex",
-            storageKey: null,
-          },
-          {
-            alias: null,
-            args: null,
-            kind: "ScalarField",
-            name: "showLabel",
-            storageKey: null,
-          },
-          {
-            alias: null,
-            args: null,
-            kind: "ScalarField",
-            name: "showSkeletons",
-            storageKey: null,
-          },
-          {
-            alias: null,
-            args: null,
-            kind: "ScalarField",
-            name: "showTooltip",
-            storageKey: null,
-          },
-          {
-            alias: null,
-            args: null,
-            kind: "ScalarField",
-            name: "timezone",
-            storageKey: null,
-          },
-          {
-            alias: null,
-            args: null,
-            kind: "ScalarField",
-            name: "useFrameNumber",
-            storageKey: null,
-          },
-        ],
-        storageKey: null,
-      },
-      v0 /*: any*/,
-    ],
-    type: "Query",
-    abstractKey: null,
-  };
+const node: ReaderFragment = (function(){
+var v0 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "colorscale",
+  "storageKey": null
+};
+return {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": null,
+  "name": "RootConfig_query",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "AppConfig",
+      "kind": "LinkedField",
+      "name": "config",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "colorBy",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "colorPool",
+          "storageKey": null
+        },
+        (v0/*: any*/),
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "gridZoom",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "loopVideos",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "notebookHeight",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "plugins",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "showConfidence",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "showIndex",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "showLabel",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "showSkeletons",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "showTooltip",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "timezone",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "useFrameNumber",
+          "storageKey": null
+        }
+      ],
+      "storageKey": null
+    },
+    (v0/*: any*/)
+  ],
+  "type": "Query",
+  "abstractKey": null
+};
 })();
 
 (node as any).hash = "84d84de0717c65bc7a17e0afd6384e08";

--- a/app/packages/core/src/Root/__generated__/RootDatasets_query.graphql.ts
+++ b/app/packages/core/src/Root/__generated__/RootDatasets_query.graphql.ts
@@ -8,7 +8,7 @@
 /* eslint-disable */
 // @ts-nocheck
 
-import { ReaderFragment, RefetchableFragment } from "relay-runtime";
+import { ReaderFragment, RefetchableFragment } from 'relay-runtime';
 import { FragmentRefs } from "relay-runtime";
 export type RootDatasets_query$data = {
   readonly datasets: {
@@ -27,146 +27,148 @@ export type RootDatasets_query$key = {
   readonly " $fragmentSpreads": FragmentRefs<"RootDatasets_query">;
 };
 
-import DatasetsPaginationQuery_graphql from "./DatasetsPaginationQuery.graphql";
+import DatasetsPaginationQuery_graphql from './DatasetsPaginationQuery.graphql';
 
-const node: ReaderFragment = (function () {
-  var v0 = ["datasets"];
-  return {
-    argumentDefinitions: [
-      {
-        kind: "RootArgument",
-        name: "count",
-      },
-      {
-        kind: "RootArgument",
-        name: "cursor",
-      },
-      {
-        kind: "RootArgument",
-        name: "search",
-      },
-    ],
-    kind: "Fragment",
-    metadata: {
-      connection: [
-        {
-          count: "count",
-          cursor: "cursor",
-          direction: "forward",
-          path: v0 /*: any*/,
-        },
-      ],
-      refetch: {
-        connection: {
-          forward: {
-            count: "count",
-            cursor: "cursor",
-          },
-          backward: null,
-          path: v0 /*: any*/,
-        },
-        fragmentPathInResult: [],
-        operation: DatasetsPaginationQuery_graphql,
-      },
+const node: ReaderFragment = (function(){
+var v0 = [
+  "datasets"
+];
+return {
+  "argumentDefinitions": [
+    {
+      "kind": "RootArgument",
+      "name": "count"
     },
-    name: "RootDatasets_query",
-    selections: [
+    {
+      "kind": "RootArgument",
+      "name": "cursor"
+    },
+    {
+      "kind": "RootArgument",
+      "name": "search"
+    }
+  ],
+  "kind": "Fragment",
+  "metadata": {
+    "connection": [
       {
-        alias: "datasets",
-        args: [
-          {
-            kind: "Variable",
-            name: "search",
-            variableName: "search",
-          },
-        ],
-        concreteType: "DatasetStrConnection",
-        kind: "LinkedField",
-        name: "__DatasetsList_query_datasets_connection",
-        plural: false,
-        selections: [
-          {
-            alias: null,
-            args: null,
-            kind: "ScalarField",
-            name: "total",
-            storageKey: null,
-          },
-          {
-            alias: null,
-            args: null,
-            concreteType: "DatasetStrEdge",
-            kind: "LinkedField",
-            name: "edges",
-            plural: true,
-            selections: [
-              {
-                alias: null,
-                args: null,
-                kind: "ScalarField",
-                name: "cursor",
-                storageKey: null,
-              },
-              {
-                alias: null,
-                args: null,
-                concreteType: "Dataset",
-                kind: "LinkedField",
-                name: "node",
-                plural: false,
-                selections: [
-                  {
-                    alias: null,
-                    args: null,
-                    kind: "ScalarField",
-                    name: "name",
-                    storageKey: null,
-                  },
-                  {
-                    alias: null,
-                    args: null,
-                    kind: "ScalarField",
-                    name: "__typename",
-                    storageKey: null,
-                  },
-                ],
-                storageKey: null,
-              },
-            ],
-            storageKey: null,
-          },
-          {
-            alias: null,
-            args: null,
-            concreteType: "DatasetStrPageInfo",
-            kind: "LinkedField",
-            name: "pageInfo",
-            plural: false,
-            selections: [
-              {
-                alias: null,
-                args: null,
-                kind: "ScalarField",
-                name: "endCursor",
-                storageKey: null,
-              },
-              {
-                alias: null,
-                args: null,
-                kind: "ScalarField",
-                name: "hasNextPage",
-                storageKey: null,
-              },
-            ],
-            storageKey: null,
-          },
-        ],
-        storageKey: null,
-      },
+        "count": "count",
+        "cursor": "cursor",
+        "direction": "forward",
+        "path": (v0/*: any*/)
+      }
     ],
-    type: "Query",
-    abstractKey: null,
-  };
+    "refetch": {
+      "connection": {
+        "forward": {
+          "count": "count",
+          "cursor": "cursor"
+        },
+        "backward": null,
+        "path": (v0/*: any*/)
+      },
+      "fragmentPathInResult": [],
+      "operation": DatasetsPaginationQuery_graphql
+    }
+  },
+  "name": "RootDatasets_query",
+  "selections": [
+    {
+      "alias": "datasets",
+      "args": [
+        {
+          "kind": "Variable",
+          "name": "search",
+          "variableName": "search"
+        }
+      ],
+      "concreteType": "DatasetStrConnection",
+      "kind": "LinkedField",
+      "name": "__DatasetsList_query_datasets_connection",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "total",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "concreteType": "DatasetStrEdge",
+          "kind": "LinkedField",
+          "name": "edges",
+          "plural": true,
+          "selections": [
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "cursor",
+              "storageKey": null
+            },
+            {
+              "alias": null,
+              "args": null,
+              "concreteType": "Dataset",
+              "kind": "LinkedField",
+              "name": "node",
+              "plural": false,
+              "selections": [
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "name",
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "__typename",
+                  "storageKey": null
+                }
+              ],
+              "storageKey": null
+            }
+          ],
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "concreteType": "DatasetStrPageInfo",
+          "kind": "LinkedField",
+          "name": "pageInfo",
+          "plural": false,
+          "selections": [
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "endCursor",
+              "storageKey": null
+            },
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "hasNextPage",
+              "storageKey": null
+            }
+          ],
+          "storageKey": null
+        }
+      ],
+      "storageKey": null
+    }
+  ],
+  "type": "Query",
+  "abstractKey": null
+};
 })();
 
 (node as any).hash = "280afc557752c2245a140c58ccb00248";

--- a/app/packages/core/src/Root/__generated__/RootGA_query.graphql.ts
+++ b/app/packages/core/src/Root/__generated__/RootGA_query.graphql.ts
@@ -8,7 +8,7 @@
 /* eslint-disable */
 // @ts-nocheck
 
-import { Fragment, ReaderFragment } from "relay-runtime";
+import { Fragment, ReaderFragment } from 'relay-runtime';
 import { FragmentRefs } from "relay-runtime";
 export type RootGA_query$data = {
   readonly context: string;
@@ -24,49 +24,49 @@ export type RootGA_query$key = {
 };
 
 const node: ReaderFragment = {
-  argumentDefinitions: [],
-  kind: "Fragment",
-  metadata: null,
-  name: "RootGA_query",
-  selections: [
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": null,
+  "name": "RootGA_query",
+  "selections": [
     {
-      alias: null,
-      args: null,
-      kind: "ScalarField",
-      name: "context",
-      storageKey: null,
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "context",
+      "storageKey": null
     },
     {
-      alias: null,
-      args: null,
-      kind: "ScalarField",
-      name: "dev",
-      storageKey: null,
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "dev",
+      "storageKey": null
     },
     {
-      alias: null,
-      args: null,
-      kind: "ScalarField",
-      name: "doNotTrack",
-      storageKey: null,
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "doNotTrack",
+      "storageKey": null
     },
     {
-      alias: null,
-      args: null,
-      kind: "ScalarField",
-      name: "uid",
-      storageKey: null,
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "uid",
+      "storageKey": null
     },
     {
-      alias: null,
-      args: null,
-      kind: "ScalarField",
-      name: "version",
-      storageKey: null,
-    },
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "version",
+      "storageKey": null
+    }
   ],
-  type: "Query",
-  abstractKey: null,
+  "type": "Query",
+  "abstractKey": null
 };
 
 (node as any).hash = "40d5fec94e7227a5e638ff2fec41458e";

--- a/app/packages/core/src/Root/__generated__/RootNav_query.graphql.ts
+++ b/app/packages/core/src/Root/__generated__/RootNav_query.graphql.ts
@@ -8,7 +8,7 @@
 /* eslint-disable */
 // @ts-nocheck
 
-import { Fragment, ReaderFragment } from "relay-runtime";
+import { Fragment, ReaderFragment } from 'relay-runtime';
 import { FragmentRefs } from "relay-runtime";
 export type RootNav_query$data = {
   readonly teamsSubmission: boolean;
@@ -20,21 +20,21 @@ export type RootNav_query$key = {
 };
 
 const node: ReaderFragment = {
-  argumentDefinitions: [],
-  kind: "Fragment",
-  metadata: null,
-  name: "RootNav_query",
-  selections: [
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": null,
+  "name": "RootNav_query",
+  "selections": [
     {
-      alias: null,
-      args: null,
-      kind: "ScalarField",
-      name: "teamsSubmission",
-      storageKey: null,
-    },
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "teamsSubmission",
+      "storageKey": null
+    }
   ],
-  type: "Query",
-  abstractKey: null,
+  "type": "Query",
+  "abstractKey": null
 };
 
 (node as any).hash = "24cca3fbea15640c1527e86151f3899e";

--- a/app/packages/core/src/Root/__generated__/RootQuery.graphql.ts
+++ b/app/packages/core/src/Root/__generated__/RootQuery.graphql.ts
@@ -8,7 +8,7 @@
 /* eslint-disable */
 // @ts-nocheck
 
-import { ConcreteRequest, Query } from "relay-runtime";
+import { ConcreteRequest, Query } from 'relay-runtime';
 import { FragmentRefs } from "relay-runtime";
 export type RootQuery$variables = {
   count?: number | null;
@@ -16,351 +16,359 @@ export type RootQuery$variables = {
   search?: string | null;
 };
 export type RootQuery$data = {
-  readonly " $fragmentSpreads": FragmentRefs<
-    "RootConfig_query" | "RootDatasets_query" | "RootGA_query" | "RootNav_query"
-  >;
+  readonly " $fragmentSpreads": FragmentRefs<"RootConfig_query" | "RootDatasets_query" | "RootGA_query" | "RootNav_query">;
 };
 export type RootQuery = {
   response: RootQuery$data;
   variables: RootQuery$variables;
 };
 
-const node: ConcreteRequest = (function () {
-  var v0 = {
-      defaultValue: null,
-      kind: "LocalArgument",
-      name: "count",
-    },
-    v1 = {
-      defaultValue: null,
-      kind: "LocalArgument",
-      name: "cursor",
-    },
-    v2 = {
-      defaultValue: "",
-      kind: "LocalArgument",
-      name: "search",
-    },
-    v3 = {
-      alias: null,
-      args: null,
-      kind: "ScalarField",
-      name: "colorscale",
-      storageKey: null,
-    },
-    v4 = [
+const node: ConcreteRequest = (function(){
+var v0 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "count"
+},
+v1 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "cursor"
+},
+v2 = {
+  "defaultValue": "",
+  "kind": "LocalArgument",
+  "name": "search"
+},
+v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "colorscale",
+  "storageKey": null
+},
+v4 = [
+  {
+    "kind": "Variable",
+    "name": "after",
+    "variableName": "cursor"
+  },
+  {
+    "kind": "Variable",
+    "name": "first",
+    "variableName": "count"
+  },
+  {
+    "kind": "Variable",
+    "name": "search",
+    "variableName": "search"
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": [
+      (v0/*: any*/),
+      (v1/*: any*/),
+      (v2/*: any*/)
+    ],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "RootQuery",
+    "selections": [
       {
-        kind: "Variable",
-        name: "after",
-        variableName: "cursor",
+        "args": null,
+        "kind": "FragmentSpread",
+        "name": "RootConfig_query"
       },
       {
-        kind: "Variable",
-        name: "first",
-        variableName: "count",
+        "args": null,
+        "kind": "FragmentSpread",
+        "name": "RootDatasets_query"
       },
       {
-        kind: "Variable",
-        name: "search",
-        variableName: "search",
+        "args": null,
+        "kind": "FragmentSpread",
+        "name": "RootGA_query"
       },
-    ];
-  return {
-    fragment: {
-      argumentDefinitions: [v0 /*: any*/, v1 /*: any*/, v2 /*: any*/],
-      kind: "Fragment",
-      metadata: null,
-      name: "RootQuery",
-      selections: [
-        {
-          args: null,
-          kind: "FragmentSpread",
-          name: "RootConfig_query",
-        },
-        {
-          args: null,
-          kind: "FragmentSpread",
-          name: "RootDatasets_query",
-        },
-        {
-          args: null,
-          kind: "FragmentSpread",
-          name: "RootGA_query",
-        },
-        {
-          args: null,
-          kind: "FragmentSpread",
-          name: "RootNav_query",
-        },
-      ],
-      type: "Query",
-      abstractKey: null,
-    },
-    kind: "Request",
-    operation: {
-      argumentDefinitions: [v2 /*: any*/, v0 /*: any*/, v1 /*: any*/],
-      kind: "Operation",
-      name: "RootQuery",
-      selections: [
-        {
-          alias: null,
-          args: null,
-          concreteType: "AppConfig",
-          kind: "LinkedField",
-          name: "config",
-          plural: false,
-          selections: [
-            {
-              alias: null,
-              args: null,
-              kind: "ScalarField",
-              name: "colorBy",
-              storageKey: null,
-            },
-            {
-              alias: null,
-              args: null,
-              kind: "ScalarField",
-              name: "colorPool",
-              storageKey: null,
-            },
-            v3 /*: any*/,
-            {
-              alias: null,
-              args: null,
-              kind: "ScalarField",
-              name: "gridZoom",
-              storageKey: null,
-            },
-            {
-              alias: null,
-              args: null,
-              kind: "ScalarField",
-              name: "loopVideos",
-              storageKey: null,
-            },
-            {
-              alias: null,
-              args: null,
-              kind: "ScalarField",
-              name: "notebookHeight",
-              storageKey: null,
-            },
-            {
-              alias: null,
-              args: null,
-              kind: "ScalarField",
-              name: "plugins",
-              storageKey: null,
-            },
-            {
-              alias: null,
-              args: null,
-              kind: "ScalarField",
-              name: "showConfidence",
-              storageKey: null,
-            },
-            {
-              alias: null,
-              args: null,
-              kind: "ScalarField",
-              name: "showIndex",
-              storageKey: null,
-            },
-            {
-              alias: null,
-              args: null,
-              kind: "ScalarField",
-              name: "showLabel",
-              storageKey: null,
-            },
-            {
-              alias: null,
-              args: null,
-              kind: "ScalarField",
-              name: "showSkeletons",
-              storageKey: null,
-            },
-            {
-              alias: null,
-              args: null,
-              kind: "ScalarField",
-              name: "showTooltip",
-              storageKey: null,
-            },
-            {
-              alias: null,
-              args: null,
-              kind: "ScalarField",
-              name: "timezone",
-              storageKey: null,
-            },
-            {
-              alias: null,
-              args: null,
-              kind: "ScalarField",
-              name: "useFrameNumber",
-              storageKey: null,
-            },
-          ],
-          storageKey: null,
-        },
-        v3 /*: any*/,
-        {
-          alias: null,
-          args: v4 /*: any*/,
-          concreteType: "DatasetStrConnection",
-          kind: "LinkedField",
-          name: "datasets",
-          plural: false,
-          selections: [
-            {
-              alias: null,
-              args: null,
-              kind: "ScalarField",
-              name: "total",
-              storageKey: null,
-            },
-            {
-              alias: null,
-              args: null,
-              concreteType: "DatasetStrEdge",
-              kind: "LinkedField",
-              name: "edges",
-              plural: true,
-              selections: [
-                {
-                  alias: null,
-                  args: null,
-                  kind: "ScalarField",
-                  name: "cursor",
-                  storageKey: null,
-                },
-                {
-                  alias: null,
-                  args: null,
-                  concreteType: "Dataset",
-                  kind: "LinkedField",
-                  name: "node",
-                  plural: false,
-                  selections: [
-                    {
-                      alias: null,
-                      args: null,
-                      kind: "ScalarField",
-                      name: "name",
-                      storageKey: null,
-                    },
-                    {
-                      alias: null,
-                      args: null,
-                      kind: "ScalarField",
-                      name: "id",
-                      storageKey: null,
-                    },
-                    {
-                      alias: null,
-                      args: null,
-                      kind: "ScalarField",
-                      name: "__typename",
-                      storageKey: null,
-                    },
-                  ],
-                  storageKey: null,
-                },
-              ],
-              storageKey: null,
-            },
-            {
-              alias: null,
-              args: null,
-              concreteType: "DatasetStrPageInfo",
-              kind: "LinkedField",
-              name: "pageInfo",
-              plural: false,
-              selections: [
-                {
-                  alias: null,
-                  args: null,
-                  kind: "ScalarField",
-                  name: "endCursor",
-                  storageKey: null,
-                },
-                {
-                  alias: null,
-                  args: null,
-                  kind: "ScalarField",
-                  name: "hasNextPage",
-                  storageKey: null,
-                },
-              ],
-              storageKey: null,
-            },
-          ],
-          storageKey: null,
-        },
-        {
-          alias: null,
-          args: v4 /*: any*/,
-          filters: ["search"],
-          handle: "connection",
-          key: "DatasetsList_query_datasets",
-          kind: "LinkedHandle",
-          name: "datasets",
-        },
-        {
-          alias: null,
-          args: null,
-          kind: "ScalarField",
-          name: "context",
-          storageKey: null,
-        },
-        {
-          alias: null,
-          args: null,
-          kind: "ScalarField",
-          name: "dev",
-          storageKey: null,
-        },
-        {
-          alias: null,
-          args: null,
-          kind: "ScalarField",
-          name: "doNotTrack",
-          storageKey: null,
-        },
-        {
-          alias: null,
-          args: null,
-          kind: "ScalarField",
-          name: "uid",
-          storageKey: null,
-        },
-        {
-          alias: null,
-          args: null,
-          kind: "ScalarField",
-          name: "version",
-          storageKey: null,
-        },
-        {
-          alias: null,
-          args: null,
-          kind: "ScalarField",
-          name: "teamsSubmission",
-          storageKey: null,
-        },
-      ],
-    },
-    params: {
-      cacheID: "42eabc83fdab1de44494830c776ea037",
-      id: null,
-      metadata: {},
-      name: "RootQuery",
-      operationKind: "query",
-      text: 'query RootQuery(\n  $search: String = ""\n  $count: Int\n  $cursor: String\n) {\n  ...RootConfig_query\n  ...RootDatasets_query\n  ...RootGA_query\n  ...RootNav_query\n}\n\nfragment RootConfig_query on Query {\n  config {\n    colorBy\n    colorPool\n    colorscale\n    gridZoom\n    loopVideos\n    notebookHeight\n    plugins\n    showConfidence\n    showIndex\n    showLabel\n    showSkeletons\n    showTooltip\n    timezone\n    useFrameNumber\n  }\n  colorscale\n}\n\nfragment RootDatasets_query on Query {\n  datasets(search: $search, first: $count, after: $cursor) {\n    total\n    edges {\n      cursor\n      node {\n        name\n        id\n        __typename\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n\nfragment RootGA_query on Query {\n  context\n  dev\n  doNotTrack\n  uid\n  version\n}\n\nfragment RootNav_query on Query {\n  teamsSubmission\n}\n',
-    },
-  };
+      {
+        "args": null,
+        "kind": "FragmentSpread",
+        "name": "RootNav_query"
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [
+      (v2/*: any*/),
+      (v0/*: any*/),
+      (v1/*: any*/)
+    ],
+    "kind": "Operation",
+    "name": "RootQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "AppConfig",
+        "kind": "LinkedField",
+        "name": "config",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "colorBy",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "colorPool",
+            "storageKey": null
+          },
+          (v3/*: any*/),
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "gridZoom",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "loopVideos",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "notebookHeight",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "plugins",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "showConfidence",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "showIndex",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "showLabel",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "showSkeletons",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "showTooltip",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "timezone",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "useFrameNumber",
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      },
+      (v3/*: any*/),
+      {
+        "alias": null,
+        "args": (v4/*: any*/),
+        "concreteType": "DatasetStrConnection",
+        "kind": "LinkedField",
+        "name": "datasets",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "total",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "DatasetStrEdge",
+            "kind": "LinkedField",
+            "name": "edges",
+            "plural": true,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "cursor",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "Dataset",
+                "kind": "LinkedField",
+                "name": "node",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "name",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "id",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "__typename",
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "DatasetStrPageInfo",
+            "kind": "LinkedField",
+            "name": "pageInfo",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "endCursor",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "hasNextPage",
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      },
+      {
+        "alias": null,
+        "args": (v4/*: any*/),
+        "filters": [
+          "search"
+        ],
+        "handle": "connection",
+        "key": "DatasetsList_query_datasets",
+        "kind": "LinkedHandle",
+        "name": "datasets"
+      },
+      {
+        "alias": null,
+        "args": null,
+        "kind": "ScalarField",
+        "name": "context",
+        "storageKey": null
+      },
+      {
+        "alias": null,
+        "args": null,
+        "kind": "ScalarField",
+        "name": "dev",
+        "storageKey": null
+      },
+      {
+        "alias": null,
+        "args": null,
+        "kind": "ScalarField",
+        "name": "doNotTrack",
+        "storageKey": null
+      },
+      {
+        "alias": null,
+        "args": null,
+        "kind": "ScalarField",
+        "name": "uid",
+        "storageKey": null
+      },
+      {
+        "alias": null,
+        "args": null,
+        "kind": "ScalarField",
+        "name": "version",
+        "storageKey": null
+      },
+      {
+        "alias": null,
+        "args": null,
+        "kind": "ScalarField",
+        "name": "teamsSubmission",
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "42eabc83fdab1de44494830c776ea037",
+    "id": null,
+    "metadata": {},
+    "name": "RootQuery",
+    "operationKind": "query",
+    "text": "query RootQuery(\n  $search: String = \"\"\n  $count: Int\n  $cursor: String\n) {\n  ...RootConfig_query\n  ...RootDatasets_query\n  ...RootGA_query\n  ...RootNav_query\n}\n\nfragment RootConfig_query on Query {\n  config {\n    colorBy\n    colorPool\n    colorscale\n    gridZoom\n    loopVideos\n    notebookHeight\n    plugins\n    showConfidence\n    showIndex\n    showLabel\n    showSkeletons\n    showTooltip\n    timezone\n    useFrameNumber\n  }\n  colorscale\n}\n\nfragment RootDatasets_query on Query {\n  datasets(search: $search, first: $count, after: $cursor) {\n    total\n    edges {\n      cursor\n      node {\n        name\n        id\n        __typename\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n\nfragment RootGA_query on Query {\n  context\n  dev\n  doNotTrack\n  uid\n  version\n}\n\nfragment RootNav_query on Query {\n  teamsSubmission\n}\n"
+  }
+};
 })();
 
 (node as any).hash = "ad38dfd0504d23894ee801a4ba0ba91e";

--- a/app/packages/core/src/__generated__/DatasetQuery.graphql.ts
+++ b/app/packages/core/src/__generated__/DatasetQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<ea5365736f1bd446454e5e87bc24c7ff>>
+ * @generated SignedSource<<c4b17cb450e9f84cc8e6797f8a2aeedb>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -8,13 +8,8 @@
 /* eslint-disable */
 // @ts-nocheck
 
-import { ConcreteRequest, Query } from "relay-runtime";
-export type MediaType =
-  | "group"
-  | "image"
-  | "point_cloud"
-  | "video"
-  | "%future added value";
+import { ConcreteRequest, Query } from 'relay-runtime';
+export type MediaType = "group" | "image" | "point_cloud" | "video" | "%future added value";
 export type DatasetQuery$variables = {
   name: string;
   view?: Array | null;
@@ -75,7 +70,6 @@ export type DatasetQuery$data = {
       readonly mediaType: MediaType;
       readonly name: string;
     }> | null;
-    readonly groupSlice: string | null;
     readonly id: string;
     readonly lastLoadedAt: string | null;
     readonly maskTargets: ReadonlyArray<{
@@ -108,461 +102,464 @@ export type DatasetQuery = {
   variables: DatasetQuery$variables;
 };
 
-const node: ConcreteRequest = (function () {
-  var v0 = [
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "name"
+  },
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "view"
+  }
+],
+v1 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
+},
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "mediaType",
+  "storageKey": null
+},
+v3 = [
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "ftype",
+    "storageKey": null
+  },
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "subfield",
+    "storageKey": null
+  },
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "embeddedDocType",
+    "storageKey": null
+  },
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "path",
+    "storageKey": null
+  },
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "dbField",
+    "storageKey": null
+  }
+],
+v4 = [
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "target",
+    "storageKey": null
+  },
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "value",
+    "storageKey": null
+  }
+],
+v5 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "key",
+  "storageKey": null
+},
+v6 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "version",
+  "storageKey": null
+},
+v7 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "timestamp",
+  "storageKey": null
+},
+v8 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "viewStages",
+  "storageKey": null
+},
+v9 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "cls",
+  "storageKey": null
+},
+v10 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "labels",
+  "storageKey": null
+},
+v11 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "edges",
+  "storageKey": null
+},
+v12 = [
+  {
+    "alias": null,
+    "args": [
       {
-        defaultValue: null,
-        kind: "LocalArgument",
-        name: "name",
+        "kind": "Variable",
+        "name": "name",
+        "variableName": "name"
       },
       {
-        defaultValue: null,
-        kind: "LocalArgument",
-        name: "view",
-      },
+        "kind": "Variable",
+        "name": "view",
+        "variableName": "view"
+      }
     ],
-    v1 = {
-      alias: null,
-      args: null,
-      kind: "ScalarField",
-      name: "name",
-      storageKey: null,
-    },
-    v2 = {
-      alias: null,
-      args: null,
-      kind: "ScalarField",
-      name: "mediaType",
-      storageKey: null,
-    },
-    v3 = [
+    "concreteType": "Dataset",
+    "kind": "LinkedField",
+    "name": "dataset",
+    "plural": false,
+    "selections": [
       {
-        alias: null,
-        args: null,
-        kind: "ScalarField",
-        name: "ftype",
-        storageKey: null,
+        "alias": null,
+        "args": null,
+        "kind": "ScalarField",
+        "name": "id",
+        "storageKey": null
+      },
+      (v1/*: any*/),
+      (v2/*: any*/),
+      {
+        "alias": null,
+        "args": null,
+        "kind": "ScalarField",
+        "name": "defaultGroupSlice",
+        "storageKey": null
       },
       {
-        alias: null,
-        args: null,
-        kind: "ScalarField",
-        name: "subfield",
-        storageKey: null,
+        "alias": null,
+        "args": null,
+        "kind": "ScalarField",
+        "name": "groupField",
+        "storageKey": null
       },
       {
-        alias: null,
-        args: null,
-        kind: "ScalarField",
-        name: "embeddedDocType",
-        storageKey: null,
-      },
-      {
-        alias: null,
-        args: null,
-        kind: "ScalarField",
-        name: "path",
-        storageKey: null,
-      },
-      {
-        alias: null,
-        args: null,
-        kind: "ScalarField",
-        name: "dbField",
-        storageKey: null,
-      },
-    ],
-    v4 = [
-      {
-        alias: null,
-        args: null,
-        kind: "ScalarField",
-        name: "target",
-        storageKey: null,
-      },
-      {
-        alias: null,
-        args: null,
-        kind: "ScalarField",
-        name: "value",
-        storageKey: null,
-      },
-    ],
-    v5 = {
-      alias: null,
-      args: null,
-      kind: "ScalarField",
-      name: "key",
-      storageKey: null,
-    },
-    v6 = {
-      alias: null,
-      args: null,
-      kind: "ScalarField",
-      name: "version",
-      storageKey: null,
-    },
-    v7 = {
-      alias: null,
-      args: null,
-      kind: "ScalarField",
-      name: "timestamp",
-      storageKey: null,
-    },
-    v8 = {
-      alias: null,
-      args: null,
-      kind: "ScalarField",
-      name: "viewStages",
-      storageKey: null,
-    },
-    v9 = {
-      alias: null,
-      args: null,
-      kind: "ScalarField",
-      name: "cls",
-      storageKey: null,
-    },
-    v10 = {
-      alias: null,
-      args: null,
-      kind: "ScalarField",
-      name: "labels",
-      storageKey: null,
-    },
-    v11 = {
-      alias: null,
-      args: null,
-      kind: "ScalarField",
-      name: "edges",
-      storageKey: null,
-    },
-    v12 = [
-      {
-        alias: null,
-        args: [
-          {
-            kind: "Variable",
-            name: "name",
-            variableName: "name",
-          },
-          {
-            kind: "Variable",
-            name: "view",
-            variableName: "view",
-          },
+        "alias": null,
+        "args": null,
+        "concreteType": "Group",
+        "kind": "LinkedField",
+        "name": "groupMediaTypes",
+        "plural": true,
+        "selections": [
+          (v1/*: any*/),
+          (v2/*: any*/)
         ],
-        concreteType: "Dataset",
-        kind: "LinkedField",
-        name: "dataset",
-        plural: false,
-        selections: [
-          {
-            alias: null,
-            args: null,
-            kind: "ScalarField",
-            name: "id",
-            storageKey: null,
-          },
-          v1 /*: any*/,
-          v2 /*: any*/,
-          {
-            alias: null,
-            args: null,
-            kind: "ScalarField",
-            name: "defaultGroupSlice",
-            storageKey: null,
-          },
-          {
-            alias: null,
-            args: null,
-            kind: "ScalarField",
-            name: "groupField",
-            storageKey: null,
-          },
-          {
-            alias: null,
-            args: null,
-            kind: "ScalarField",
-            name: "groupSlice",
-            storageKey: null,
-          },
-          {
-            alias: null,
-            args: null,
-            concreteType: "Group",
-            kind: "LinkedField",
-            name: "groupMediaTypes",
-            plural: true,
-            selections: [v1 /*: any*/, v2 /*: any*/],
-            storageKey: null,
-          },
-          {
-            alias: null,
-            args: null,
-            concreteType: "DatasetAppConfig",
-            kind: "LinkedField",
-            name: "appConfig",
-            plural: false,
-            selections: [
-              {
-                alias: null,
-                args: null,
-                kind: "ScalarField",
-                name: "gridMediaField",
-                storageKey: null,
-              },
-              {
-                alias: null,
-                args: null,
-                kind: "ScalarField",
-                name: "mediaFields",
-                storageKey: null,
-              },
-              {
-                alias: null,
-                args: null,
-                kind: "ScalarField",
-                name: "plugins",
-                storageKey: null,
-              },
-              {
-                alias: null,
-                args: null,
-                concreteType: "SidebarGroup",
-                kind: "LinkedField",
-                name: "sidebarGroups",
-                plural: true,
-                selections: [
-                  v1 /*: any*/,
-                  {
-                    alias: null,
-                    args: null,
-                    kind: "ScalarField",
-                    name: "paths",
-                    storageKey: null,
-                  },
-                ],
-                storageKey: null,
-              },
-            ],
-            storageKey: null,
-          },
-          {
-            alias: null,
-            args: null,
-            concreteType: "SampleField",
-            kind: "LinkedField",
-            name: "sampleFields",
-            plural: true,
-            selections: v3 /*: any*/,
-            storageKey: null,
-          },
-          {
-            alias: null,
-            args: null,
-            concreteType: "SampleField",
-            kind: "LinkedField",
-            name: "frameFields",
-            plural: true,
-            selections: v3 /*: any*/,
-            storageKey: null,
-          },
-          {
-            alias: null,
-            args: null,
-            concreteType: "NamedTargets",
-            kind: "LinkedField",
-            name: "maskTargets",
-            plural: true,
-            selections: [
-              v1 /*: any*/,
-              {
-                alias: null,
-                args: null,
-                concreteType: "Target",
-                kind: "LinkedField",
-                name: "targets",
-                plural: true,
-                selections: v4 /*: any*/,
-                storageKey: null,
-              },
-            ],
-            storageKey: null,
-          },
-          {
-            alias: null,
-            args: null,
-            concreteType: "Target",
-            kind: "LinkedField",
-            name: "defaultMaskTargets",
-            plural: true,
-            selections: v4 /*: any*/,
-            storageKey: null,
-          },
-          {
-            alias: null,
-            args: null,
-            concreteType: "EvaluationRun",
-            kind: "LinkedField",
-            name: "evaluations",
-            plural: true,
-            selections: [
-              v5 /*: any*/,
-              v6 /*: any*/,
-              v7 /*: any*/,
-              v8 /*: any*/,
-              {
-                alias: null,
-                args: null,
-                concreteType: "EvaluationRunConfig",
-                kind: "LinkedField",
-                name: "config",
-                plural: false,
-                selections: [
-                  v9 /*: any*/,
-                  {
-                    alias: null,
-                    args: null,
-                    kind: "ScalarField",
-                    name: "predField",
-                    storageKey: null,
-                  },
-                  {
-                    alias: null,
-                    args: null,
-                    kind: "ScalarField",
-                    name: "gtField",
-                    storageKey: null,
-                  },
-                ],
-                storageKey: null,
-              },
-            ],
-            storageKey: null,
-          },
-          {
-            alias: null,
-            args: null,
-            concreteType: "BrainRun",
-            kind: "LinkedField",
-            name: "brainMethods",
-            plural: true,
-            selections: [
-              v5 /*: any*/,
-              v6 /*: any*/,
-              v7 /*: any*/,
-              v8 /*: any*/,
-              {
-                alias: null,
-                args: null,
-                concreteType: "BrainRunConfig",
-                kind: "LinkedField",
-                name: "config",
-                plural: false,
-                selections: [
-                  v9 /*: any*/,
-                  {
-                    alias: null,
-                    args: null,
-                    kind: "ScalarField",
-                    name: "embeddingsField",
-                    storageKey: null,
-                  },
-                  {
-                    alias: null,
-                    args: null,
-                    kind: "ScalarField",
-                    name: "method",
-                    storageKey: null,
-                  },
-                  {
-                    alias: null,
-                    args: null,
-                    kind: "ScalarField",
-                    name: "patchesField",
-                    storageKey: null,
-                  },
-                ],
-                storageKey: null,
-              },
-            ],
-            storageKey: null,
-          },
-          {
-            alias: null,
-            args: null,
-            kind: "ScalarField",
-            name: "lastLoadedAt",
-            storageKey: null,
-          },
-          {
-            alias: null,
-            args: null,
-            kind: "ScalarField",
-            name: "createdAt",
-            storageKey: null,
-          },
-          {
-            alias: null,
-            args: null,
-            concreteType: "NamedKeypointSkeleton",
-            kind: "LinkedField",
-            name: "skeletons",
-            plural: true,
-            selections: [v1 /*: any*/, v10 /*: any*/, v11 /*: any*/],
-            storageKey: null,
-          },
-          {
-            alias: null,
-            args: null,
-            concreteType: "KeypointSkeleton",
-            kind: "LinkedField",
-            name: "defaultSkeleton",
-            plural: false,
-            selections: [v10 /*: any*/, v11 /*: any*/],
-            storageKey: null,
-          },
-          v6 /*: any*/,
-          {
-            alias: null,
-            args: null,
-            kind: "ScalarField",
-            name: "viewCls",
-            storageKey: null,
-          },
-        ],
-        storageKey: null,
+        "storageKey": null
       },
-    ];
-  return {
-    fragment: {
-      argumentDefinitions: v0 /*: any*/,
-      kind: "Fragment",
-      metadata: null,
-      name: "DatasetQuery",
-      selections: v12 /*: any*/,
-      type: "Query",
-      abstractKey: null,
-    },
-    kind: "Request",
-    operation: {
-      argumentDefinitions: v0 /*: any*/,
-      kind: "Operation",
-      name: "DatasetQuery",
-      selections: v12 /*: any*/,
-    },
-    params: {
-      cacheID: "5ba0dc4897f8e5b5025ab9a233490365",
-      id: null,
-      metadata: {},
-      name: "DatasetQuery",
-      operationKind: "query",
-      text: "query DatasetQuery(\n  $name: String!\n  $view: BSONArray = null\n) {\n  dataset(name: $name, view: $view) {\n    id\n    name\n    mediaType\n    defaultGroupSlice\n    groupField\n    groupSlice\n    groupMediaTypes {\n      name\n      mediaType\n    }\n    appConfig {\n      gridMediaField\n      mediaFields\n      plugins\n      sidebarGroups {\n        name\n        paths\n      }\n    }\n    sampleFields {\n      ftype\n      subfield\n      embeddedDocType\n      path\n      dbField\n    }\n    frameFields {\n      ftype\n      subfield\n      embeddedDocType\n      path\n      dbField\n    }\n    maskTargets {\n      name\n      targets {\n        target\n        value\n      }\n    }\n    defaultMaskTargets {\n      target\n      value\n    }\n    evaluations {\n      key\n      version\n      timestamp\n      viewStages\n      config {\n        cls\n        predField\n        gtField\n      }\n    }\n    brainMethods {\n      key\n      version\n      timestamp\n      viewStages\n      config {\n        cls\n        embeddingsField\n        method\n        patchesField\n      }\n    }\n    lastLoadedAt\n    createdAt\n    skeletons {\n      name\n      labels\n      edges\n    }\n    defaultSkeleton {\n      labels\n      edges\n    }\n    version\n    viewCls\n  }\n}\n",
-    },
-  };
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "DatasetAppConfig",
+        "kind": "LinkedField",
+        "name": "appConfig",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "gridMediaField",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "mediaFields",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "plugins",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "SidebarGroup",
+            "kind": "LinkedField",
+            "name": "sidebarGroups",
+            "plural": true,
+            "selections": [
+              (v1/*: any*/),
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "paths",
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      },
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "SampleField",
+        "kind": "LinkedField",
+        "name": "sampleFields",
+        "plural": true,
+        "selections": (v3/*: any*/),
+        "storageKey": null
+      },
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "SampleField",
+        "kind": "LinkedField",
+        "name": "frameFields",
+        "plural": true,
+        "selections": (v3/*: any*/),
+        "storageKey": null
+      },
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "NamedTargets",
+        "kind": "LinkedField",
+        "name": "maskTargets",
+        "plural": true,
+        "selections": [
+          (v1/*: any*/),
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "Target",
+            "kind": "LinkedField",
+            "name": "targets",
+            "plural": true,
+            "selections": (v4/*: any*/),
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      },
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "Target",
+        "kind": "LinkedField",
+        "name": "defaultMaskTargets",
+        "plural": true,
+        "selections": (v4/*: any*/),
+        "storageKey": null
+      },
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "EvaluationRun",
+        "kind": "LinkedField",
+        "name": "evaluations",
+        "plural": true,
+        "selections": [
+          (v5/*: any*/),
+          (v6/*: any*/),
+          (v7/*: any*/),
+          (v8/*: any*/),
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "EvaluationRunConfig",
+            "kind": "LinkedField",
+            "name": "config",
+            "plural": false,
+            "selections": [
+              (v9/*: any*/),
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "predField",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "gtField",
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      },
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "BrainRun",
+        "kind": "LinkedField",
+        "name": "brainMethods",
+        "plural": true,
+        "selections": [
+          (v5/*: any*/),
+          (v6/*: any*/),
+          (v7/*: any*/),
+          (v8/*: any*/),
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "BrainRunConfig",
+            "kind": "LinkedField",
+            "name": "config",
+            "plural": false,
+            "selections": [
+              (v9/*: any*/),
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "embeddingsField",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "method",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "patchesField",
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      },
+      {
+        "alias": null,
+        "args": null,
+        "kind": "ScalarField",
+        "name": "lastLoadedAt",
+        "storageKey": null
+      },
+      {
+        "alias": null,
+        "args": null,
+        "kind": "ScalarField",
+        "name": "createdAt",
+        "storageKey": null
+      },
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "NamedKeypointSkeleton",
+        "kind": "LinkedField",
+        "name": "skeletons",
+        "plural": true,
+        "selections": [
+          (v1/*: any*/),
+          (v10/*: any*/),
+          (v11/*: any*/)
+        ],
+        "storageKey": null
+      },
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "KeypointSkeleton",
+        "kind": "LinkedField",
+        "name": "defaultSkeleton",
+        "plural": false,
+        "selections": [
+          (v10/*: any*/),
+          (v11/*: any*/)
+        ],
+        "storageKey": null
+      },
+      (v6/*: any*/),
+      {
+        "alias": null,
+        "args": null,
+        "kind": "ScalarField",
+        "name": "viewCls",
+        "storageKey": null
+      }
+    ],
+    "storageKey": null
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "DatasetQuery",
+    "selections": (v12/*: any*/),
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "DatasetQuery",
+    "selections": (v12/*: any*/)
+  },
+  "params": {
+    "cacheID": "e5b28d650f56482fe3a4e90ce3dde09b",
+    "id": null,
+    "metadata": {},
+    "name": "DatasetQuery",
+    "operationKind": "query",
+    "text": "query DatasetQuery(\n  $name: String!\n  $view: BSONArray = null\n) {\n  dataset(name: $name, view: $view) {\n    id\n    name\n    mediaType\n    defaultGroupSlice\n    groupField\n    groupMediaTypes {\n      name\n      mediaType\n    }\n    appConfig {\n      gridMediaField\n      mediaFields\n      plugins\n      sidebarGroups {\n        name\n        paths\n      }\n    }\n    sampleFields {\n      ftype\n      subfield\n      embeddedDocType\n      path\n      dbField\n    }\n    frameFields {\n      ftype\n      subfield\n      embeddedDocType\n      path\n      dbField\n    }\n    maskTargets {\n      name\n      targets {\n        target\n        value\n      }\n    }\n    defaultMaskTargets {\n      target\n      value\n    }\n    evaluations {\n      key\n      version\n      timestamp\n      viewStages\n      config {\n        cls\n        predField\n        gtField\n      }\n    }\n    brainMethods {\n      key\n      version\n      timestamp\n      viewStages\n      config {\n        cls\n        embeddingsField\n        method\n        patchesField\n      }\n    }\n    lastLoadedAt\n    createdAt\n    skeletons {\n      name\n      labels\n      edges\n    }\n    defaultSkeleton {\n      labels\n      edges\n    }\n    version\n    viewCls\n  }\n}\n"
+  }
+};
 })();
 
-(node as any).hash = "447724e7d4d6ce2853d339b3bd3ae577";
+(node as any).hash = "393e9a77be7b019383e437812359086e";
 
 export default node;

--- a/app/packages/core/src/components/Teams/__generated__/TeamsStoreTeamsSubmissionMutation.graphql.ts
+++ b/app/packages/core/src/components/Teams/__generated__/TeamsStoreTeamsSubmissionMutation.graphql.ts
@@ -8,7 +8,7 @@
 /* eslint-disable */
 // @ts-nocheck
 
-import { ConcreteRequest, Mutation } from "relay-runtime";
+import { ConcreteRequest, Mutation } from 'relay-runtime';
 export type TeamsStoreTeamsSubmissionMutation$variables = {};
 export type TeamsStoreTeamsSubmissionMutation$data = {
   readonly storeTeamsSubmission: boolean;
@@ -18,42 +18,42 @@ export type TeamsStoreTeamsSubmissionMutation = {
   variables: TeamsStoreTeamsSubmissionMutation$variables;
 };
 
-const node: ConcreteRequest = (function () {
-  var v0 = [
-    {
-      alias: null,
-      args: null,
-      kind: "ScalarField",
-      name: "storeTeamsSubmission",
-      storageKey: null,
-    },
-  ];
-  return {
-    fragment: {
-      argumentDefinitions: [],
-      kind: "Fragment",
-      metadata: null,
-      name: "TeamsStoreTeamsSubmissionMutation",
-      selections: v0 /*: any*/,
-      type: "Mutation",
-      abstractKey: null,
-    },
-    kind: "Request",
-    operation: {
-      argumentDefinitions: [],
-      kind: "Operation",
-      name: "TeamsStoreTeamsSubmissionMutation",
-      selections: v0 /*: any*/,
-    },
-    params: {
-      cacheID: "65a385a73975d2daf14d156ff5b7ed6a",
-      id: null,
-      metadata: {},
-      name: "TeamsStoreTeamsSubmissionMutation",
-      operationKind: "mutation",
-      text: "mutation TeamsStoreTeamsSubmissionMutation {\n  storeTeamsSubmission\n}\n",
-    },
-  };
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "storeTeamsSubmission",
+    "storageKey": null
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": [],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "TeamsStoreTeamsSubmissionMutation",
+    "selections": (v0/*: any*/),
+    "type": "Mutation",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [],
+    "kind": "Operation",
+    "name": "TeamsStoreTeamsSubmissionMutation",
+    "selections": (v0/*: any*/)
+  },
+  "params": {
+    "cacheID": "65a385a73975d2daf14d156ff5b7ed6a",
+    "id": null,
+    "metadata": {},
+    "name": "TeamsStoreTeamsSubmissionMutation",
+    "operationKind": "mutation",
+    "text": "mutation TeamsStoreTeamsSubmissionMutation {\n  storeTeamsSubmission\n}\n"
+  }
+};
 })();
 
 (node as any).hash = "75deb5f0c490b3073749a77128b435e4";

--- a/app/packages/core/src/index.ts
+++ b/app/packages/core/src/index.ts
@@ -1,3 +1,3 @@
 export * from "./components";
 export { default as makeRoutes } from "./makeRoutes";
-export * from "./loaders";
+export * from "./Dataset";

--- a/app/packages/dataset/package.json
+++ b/app/packages/dataset/package.json
@@ -22,7 +22,6 @@
         "@fiftyone/core": "*"
     },
     "devDependencies": {
-        "@fiftyone/prettier-config": "*",
         "prettier": "^2.7.1",
         "typescript": "^4.7.4",
         "typescript-plugin-css-modules": "^3.4.0",

--- a/app/packages/dataset/package.json
+++ b/app/packages/dataset/package.json
@@ -1,41 +1,40 @@
 {
-  "name": "@fiftyone/dataset",
-  "author": "Voxel51, Inc.",
-  "version": "0.0.0",
-  "description": "Media viewer that can render label overlays.",
-  "homepage": "https://github.com/voxel51/fiftyone/app/packages/looker",
-  "license": "Apache-2.0",
-  "bugs": {
-    "url": "https://github.com/voxel51/fiftyone/"
-  },
-  "main": "./src/index.tsx",
-  "scripts": {
-    "build": "NODE_OPTIONS='--max-old-space-size=9728' vite build",
-    "dev": "vite dev"
-  },
-  "prettier": "@fiftyone/prettier-config",
-  "private": true,
-  "files": [
-    "dist",
-    "README.md"
-  ],
-  "dependencies": {
-    "@fiftyone/core": "*"
-  },
-  "devDependencies": {
-    "@fiftyone/prettier-config": "*",
-    "prettier": "^2.7.1",
-    "typescript": "^4.7.4",
-    "typescript-plugin-css-modules": "^3.4.0",
-    "vite": "^3.0.0"
-  },
-  "exports": {
-    ".": {
-      "import": "./dist/dataset.js",
-      "require": "./dist/dataset.js"
+    "name": "@fiftyone/dataset",
+    "author": "Voxel51, Inc.",
+    "version": "0.0.0",
+    "description": "Media viewer that can render label overlays.",
+    "homepage": "https://github.com/voxel51/fiftyone/app/packages/looker",
+    "license": "Apache-2.0",
+    "bugs": {
+        "url": "https://github.com/voxel51/fiftyone/"
     },
-    "./style.css": {
-      "import": "./dist/style.css"
+    "main": "./src/index.tsx",
+    "scripts": {
+        "build": "NODE_OPTIONS='--max-old-space-size=9728' vite build",
+        "dev": "vite dev"
+    },
+    "private": true,
+    "files": [
+        "dist",
+        "README.md"
+    ],
+    "dependencies": {
+        "@fiftyone/core": "*"
+    },
+    "devDependencies": {
+        "@fiftyone/prettier-config": "*",
+        "prettier": "^2.7.1",
+        "typescript": "^4.7.4",
+        "typescript-plugin-css-modules": "^3.4.0",
+        "vite": "^3.0.0"
+    },
+    "exports": {
+        ".": {
+            "import": "./dist/dataset.js",
+            "require": "./dist/dataset.js"
+        },
+        "./style.css": {
+            "import": "./dist/style.css"
+        }
     }
-  }
 }

--- a/app/packages/desktop/package.json
+++ b/app/packages/desktop/package.json
@@ -1,101 +1,100 @@
 {
-  "name": "FiftyOne",
-  "description": "Explore, Analyze, Curate",
-  "author": "Voxel51, Inc.",
-  "version": "0.0.0",
-  "main": "./dist/main.js",
-  "license": "Apache-2.0",
-  "private": true,
-  "prettier": "@fiftyone/prettier-config",
-  "scripts": {
-    "build": "yarn build-source && yarn build-desktop",
-    "build-desktop": "yarn build-source && yarn pull-source && tsc -p tsconfig.json",
-    "build-source": "yarn workspace @fiftyone/app build-desktop",
-    "pull-source": "yarn workspace @fiftyone/app copy-to-desktop",
-    "start-desktop": "yarn build-desktop && cross-env DEBUG_APP=true electron ./dist/main.js",
-    "package-linux-aarch64": "yarn build && electron-builder build --linux --arm64",
-    "package-linux-x86_64": "yarn build && electron-builder build --linux --x64",
-    "package-mac-arm64": "yarn build && electron-builder build --mac --arm64",
-    "package-mac-x86_64": "yarn build && electron-builder build --mac --x64",
-    "package-win-amd64": "yarn build && electron-builder build --win --x64"
-  },
-  "build": {
-    "productName": "FiftyOne",
-    "appId": "com.voxel51.FiftyOne",
-    "files": [
-      "dist/",
-      "package.json",
-      "resources/**/*"
-    ],
-    "dmg": {
-      "contents": [
-        {
-          "x": 130,
-          "y": 220
+    "name": "FiftyOne",
+    "description": "Explore, Analyze, Curate",
+    "author": "Voxel51, Inc.",
+    "version": "0.0.0",
+    "main": "./dist/main.js",
+    "license": "Apache-2.0",
+    "private": true,
+    "scripts": {
+        "build": "yarn build-source && yarn build-desktop",
+        "build-desktop": "yarn build-source && yarn pull-source && tsc -p tsconfig.json",
+        "build-source": "yarn workspace @fiftyone/app build-desktop",
+        "pull-source": "yarn workspace @fiftyone/app copy-to-desktop",
+        "start-desktop": "yarn build-desktop && cross-env DEBUG_APP=true electron ./dist/main.js",
+        "package-linux-aarch64": "yarn build && electron-builder build --linux --arm64",
+        "package-linux-x86_64": "yarn build && electron-builder build --linux --x64",
+        "package-mac-arm64": "yarn build && electron-builder build --mac --arm64",
+        "package-mac-x86_64": "yarn build && electron-builder build --mac --x64",
+        "package-win-amd64": "yarn build && electron-builder build --win --x64"
+    },
+    "build": {
+        "productName": "FiftyOne",
+        "appId": "com.voxel51.FiftyOne",
+        "files": [
+            "dist/",
+            "package.json",
+            "resources/**/*"
+        ],
+        "dmg": {
+            "contents": [
+                {
+                    "x": 130,
+                    "y": 220
+                },
+                {
+                    "x": 410,
+                    "y": 220,
+                    "type": "link",
+                    "path": "/Applications"
+                }
+            ]
         },
-        {
-          "x": 410,
-          "y": 220,
-          "type": "link",
-          "path": "/Applications"
+        "mac": {
+            "target": [
+                "dir"
+            ]
+        },
+        "win": {
+            "target": [
+                "portable"
+            ]
+        },
+        "linux": {
+            "target": [
+                "AppImage"
+            ],
+            "category": "Tool"
+        },
+        "directories": {
+            "buildResources": "resources",
+            "output": "release"
+        },
+        "publish": {
+            "provider": "github",
+            "owner": "voxel51",
+            "repo": "fiftyone",
+            "private": true
         }
-      ]
     },
-    "mac": {
-      "target": [
-        "dir"
-      ]
-    },
-    "win": {
-      "target": [
-        "portable"
-      ]
-    },
-    "linux": {
-      "target": [
-        "AppImage"
-      ],
-      "category": "Tool"
-    },
-    "directories": {
-      "buildResources": "resources",
-      "output": "release"
-    },
-    "publish": {
-      "provider": "github",
-      "owner": "voxel51",
-      "repo": "fiftyone",
-      "private": true
+    "devDependencies": {
+        "@babel/core": "^7.9.0",
+        "@babel/plugin-proposal-class-properties": "^7.8.3",
+        "@babel/plugin-proposal-decorators": "^7.8.3",
+        "@babel/plugin-proposal-do-expressions": "^7.8.3",
+        "@babel/plugin-proposal-export-default-from": "^7.8.3",
+        "@babel/plugin-proposal-export-namespace-from": "^7.8.3",
+        "@babel/plugin-proposal-function-bind": "^7.8.3",
+        "@babel/plugin-proposal-function-sent": "^7.8.3",
+        "@babel/plugin-proposal-json-strings": "^7.8.3",
+        "@babel/plugin-proposal-logical-assignment-operators": "^7.8.3",
+        "@babel/plugin-proposal-nullish-coalescing-operator": "^7.8.3",
+        "@babel/plugin-proposal-numeric-separator": "^7.8.3",
+        "@babel/plugin-proposal-optional-chaining": "^7.9.0",
+        "@babel/plugin-proposal-pipeline-operator": "^7.8.3",
+        "@babel/plugin-proposal-throw-expressions": "^7.8.3",
+        "@babel/plugin-syntax-dynamic-import": "^7.8.3",
+        "@babel/plugin-syntax-import-meta": "^7.8.3",
+        "@babel/plugin-transform-react-constant-elements": "^7.9.0",
+        "@babel/plugin-transform-react-inline-elements": "^7.9.0",
+        "@babel/preset-env": "^7.9.0",
+        "@babel/preset-react": "^7.9.4",
+        "@babel/preset-typescript": "^7.9.0",
+        "@babel/register": "^7.9.0",
+        "cross-env": "^7.0.3",
+        "electron": "18.2.3",
+        "electron-builder": "^23.0.3",
+        "electron-devtools-installer": "^3.2.0",
+        "typescript": "^4.7.4"
     }
-  },
-  "devDependencies": {
-    "@babel/core": "^7.9.0",
-    "@babel/plugin-proposal-class-properties": "^7.8.3",
-    "@babel/plugin-proposal-decorators": "^7.8.3",
-    "@babel/plugin-proposal-do-expressions": "^7.8.3",
-    "@babel/plugin-proposal-export-default-from": "^7.8.3",
-    "@babel/plugin-proposal-export-namespace-from": "^7.8.3",
-    "@babel/plugin-proposal-function-bind": "^7.8.3",
-    "@babel/plugin-proposal-function-sent": "^7.8.3",
-    "@babel/plugin-proposal-json-strings": "^7.8.3",
-    "@babel/plugin-proposal-logical-assignment-operators": "^7.8.3",
-    "@babel/plugin-proposal-nullish-coalescing-operator": "^7.8.3",
-    "@babel/plugin-proposal-numeric-separator": "^7.8.3",
-    "@babel/plugin-proposal-optional-chaining": "^7.9.0",
-    "@babel/plugin-proposal-pipeline-operator": "^7.8.3",
-    "@babel/plugin-proposal-throw-expressions": "^7.8.3",
-    "@babel/plugin-syntax-dynamic-import": "^7.8.3",
-    "@babel/plugin-syntax-import-meta": "^7.8.3",
-    "@babel/plugin-transform-react-constant-elements": "^7.9.0",
-    "@babel/plugin-transform-react-inline-elements": "^7.9.0",
-    "@babel/preset-env": "^7.9.0",
-    "@babel/preset-react": "^7.9.4",
-    "@babel/preset-typescript": "^7.9.0",
-    "@babel/register": "^7.9.0",
-    "cross-env": "^7.0.3",
-    "electron": "18.2.3",
-    "electron-builder": "^23.0.3",
-    "electron-devtools-installer": "^3.2.0",
-    "typescript": "^4.7.4"
-  }
 }

--- a/app/packages/flashlight/package.json
+++ b/app/packages/flashlight/package.json
@@ -18,7 +18,6 @@
         "README.md"
     ],
     "devDependencies": {
-        "@fiftyone/prettier-config": "*",
         "prettier": "^2.7.1",
         "typescript": "^4.7.4",
         "typescript-plugin-css-modules": "^3.4.0",

--- a/app/packages/flashlight/package.json
+++ b/app/packages/flashlight/package.json
@@ -1,28 +1,27 @@
 {
-  "name": "@fiftyone/flashlight",
-  "version": "0.2.0",
-  "author": "Voxel51, Inc.",
-  "description": "Justified, scrubbable, and virtualized looker grid",
-  "homepage": "https://github.com/voxel51/fiftyone/app/packages/flashlight",
-  "license": "Apache-2.0",
-  "bugs": {
-    "url": "https://github.com/voxel51/fiftyone"
-  },
-  "main": "./src/index.ts",
-  "scripts": {
-    "dev": "vite"
-  },
-  "prettier": "@fiftyone/prettier-config",
-  "private": true,
-  "files": [
-    "dist",
-    "README.md"
-  ],
-  "devDependencies": {
-    "@fiftyone/prettier-config": "*",
-    "prettier": "^2.7.1",
-    "typescript": "^4.7.4",
-    "typescript-plugin-css-modules": "^3.4.0",
-    "vite": "^3.0.0"
-  }
+    "name": "@fiftyone/flashlight",
+    "version": "0.2.0",
+    "author": "Voxel51, Inc.",
+    "description": "Justified, scrubbable, and virtualized looker grid",
+    "homepage": "https://github.com/voxel51/fiftyone/app/packages/flashlight",
+    "license": "Apache-2.0",
+    "bugs": {
+        "url": "https://github.com/voxel51/fiftyone"
+    },
+    "main": "./src/index.ts",
+    "scripts": {
+        "dev": "vite"
+    },
+    "private": true,
+    "files": [
+        "dist",
+        "README.md"
+    ],
+    "devDependencies": {
+        "@fiftyone/prettier-config": "*",
+        "prettier": "^2.7.1",
+        "typescript": "^4.7.4",
+        "typescript-plugin-css-modules": "^3.4.0",
+        "vite": "^3.0.0"
+    }
 }

--- a/app/packages/looker/package.json
+++ b/app/packages/looker/package.json
@@ -1,40 +1,39 @@
 {
-  "name": "@fiftyone/looker",
-  "author": "Voxel51, Inc.",
-  "version": "0.0.0",
-  "description": "Media viewer that can render label overlays.",
-  "homepage": "https://github.com/voxel51/fiftyone/app/packages/looker",
-  "license": "Apache-2.0",
-  "bugs": {
-    "url": "https://github.com/voxel51/fiftyone/"
-  },
-  "main": "./src/index.ts",
-  "scripts": {
-    "dev": "vite"
-  },
-  "prettier": "@fiftyone/prettier-config",
-  "private": true,
-  "files": [
-    "dist",
-    "README.md"
-  ],
-  "dependencies": {
-    "@ungap/event-target": "^0.2.2",
-    "copy-to-clipboard": "^3.3.1",
-    "immutable": "^4.0.0-rc.12",
-    "json-format-highlight": "^1.0.4",
-    "lru-cache": "^6.0.0",
-    "mime": "^2.5.2",
-    "uuid": "^8.3.2"
-  },
-  "devDependencies": {
-    "@fiftyone/prettier-config": "*",
-    "@types/color-string": "^1.5.0",
-    "@types/lru-cache": "^5.1.0",
-    "@types/uuid": "^8.3.0",
-    "prettier": "^2.7.1",
-    "typescript": "^4.7.4",
-    "typescript-plugin-css-modules": "^3.4.0",
-    "vite": "^3.0.0"
-  }
+    "name": "@fiftyone/looker",
+    "author": "Voxel51, Inc.",
+    "version": "0.0.0",
+    "description": "Media viewer that can render label overlays.",
+    "homepage": "https://github.com/voxel51/fiftyone/app/packages/looker",
+    "license": "Apache-2.0",
+    "bugs": {
+        "url": "https://github.com/voxel51/fiftyone/"
+    },
+    "main": "./src/index.ts",
+    "scripts": {
+        "dev": "vite"
+    },
+    "private": true,
+    "files": [
+        "dist",
+        "README.md"
+    ],
+    "dependencies": {
+        "@ungap/event-target": "^0.2.2",
+        "copy-to-clipboard": "^3.3.1",
+        "immutable": "^4.0.0-rc.12",
+        "json-format-highlight": "^1.0.4",
+        "lru-cache": "^6.0.0",
+        "mime": "^2.5.2",
+        "uuid": "^8.3.2"
+    },
+    "devDependencies": {
+        "@fiftyone/prettier-config": "*",
+        "@types/color-string": "^1.5.0",
+        "@types/lru-cache": "^5.1.0",
+        "@types/uuid": "^8.3.0",
+        "prettier": "^2.7.1",
+        "typescript": "^4.7.4",
+        "typescript-plugin-css-modules": "^3.4.0",
+        "vite": "^3.0.0"
+    }
 }

--- a/app/packages/looker/package.json
+++ b/app/packages/looker/package.json
@@ -27,7 +27,6 @@
         "uuid": "^8.3.2"
     },
     "devDependencies": {
-        "@fiftyone/prettier-config": "*",
         "@types/color-string": "^1.5.0",
         "@types/lru-cache": "^5.1.0",
         "@types/uuid": "^8.3.0",

--- a/app/packages/plugins/package.json
+++ b/app/packages/plugins/package.json
@@ -1,32 +1,31 @@
 {
-  "name": "@fiftyone/plugins",
-  "author": "Voxel51, Inc.",
-  "version": "0.0.0",
-  "description": "Develop fiftyone plugins",
-  "homepage": "https://github.com/voxel51/fiftyone/app/packages/plugins",
-  "license": "Apache-2.0",
-  "bugs": {
-    "url": "https://github.com/voxel51/fiftyone/"
-  },
-  "main": "./src/index.ts",
-  "scripts": {
-    "dev": "vite",
-    "test": "jest"
-  },
-  "prettier": "@fiftyone/prettier-config",
-  "private": true,
-  "files": [
-    "dist",
-    "README.md"
-  ],
-  "devDependencies": {
-    "@babel/preset-typescript": "^7.17.12",
-    "@fiftyone/prettier-config": "*",
-    "@fiftyone/utilities": "workspace:^",
-    "@types/react": "^18.0.12",
-    "jest": "^28.1.1",
-    "prettier": "2.2.1",
-    "typescript": "4.2.4",
-    "vite": "2.4.2"
-  }
+    "name": "@fiftyone/plugins",
+    "author": "Voxel51, Inc.",
+    "version": "0.0.0",
+    "description": "Develop fiftyone plugins",
+    "homepage": "https://github.com/voxel51/fiftyone/app/packages/plugins",
+    "license": "Apache-2.0",
+    "bugs": {
+        "url": "https://github.com/voxel51/fiftyone/"
+    },
+    "main": "./src/index.ts",
+    "scripts": {
+        "dev": "vite",
+        "test": "jest"
+    },
+    "private": true,
+    "files": [
+        "dist",
+        "README.md"
+    ],
+    "devDependencies": {
+        "@babel/preset-typescript": "^7.17.12",
+        "@fiftyone/prettier-config": "*",
+        "@fiftyone/utilities": "workspace:^",
+        "@types/react": "^18.0.12",
+        "jest": "^28.1.1",
+        "prettier": "2.2.1",
+        "typescript": "4.2.4",
+        "vite": "2.4.2"
+    }
 }

--- a/app/packages/plugins/package.json
+++ b/app/packages/plugins/package.json
@@ -20,7 +20,6 @@
     ],
     "devDependencies": {
         "@babel/preset-typescript": "^7.17.12",
-        "@fiftyone/prettier-config": "*",
         "@fiftyone/utilities": "workspace:^",
         "@types/react": "^18.0.12",
         "jest": "^28.1.1",

--- a/app/packages/prettier-config/index.js
+++ b/app/packages/prettier-config/index.js
@@ -1,6 +1,0 @@
-module.exports = {
-  trailingComma: "es5",
-  tabWidth: 2,
-  semi: true,
-  singleQuote: false,
-};

--- a/app/packages/prettier-config/package.json
+++ b/app/packages/prettier-config/package.json
@@ -1,7 +1,0 @@
-{
-    "name": "@fiftyone/prettier-config",
-    "version": "0.0.0",
-    "main": "index.js",
-    "license": "Apache-2.0",
-    "private": true
-}

--- a/app/packages/relay/package.json
+++ b/app/packages/relay/package.json
@@ -1,34 +1,33 @@
 {
-  "name": "@fiftyone/relay",
-  "author": "Voxel51, Inc.",
-  "version": "0.0.0",
-  "description": "FiftyOne App Relay GraphQL queries, mutations, and subscriptions",
-  "homepage": "https://github.com/voxel51/fiftyone/app/packages/state",
-  "license": "Apache-2.0",
-  "bugs": {
-    "url": "https://github.com/voxel51/fiftyone/"
-  },
-  "main": "./src/index.ts",
-  "scripts": {
-    "compile": "relay-compiler",
-    "dev": "vite"
-  },
-  "prettier": "@fiftyone/prettier-config",
-  "private": true,
-  "files": [
-    "dist",
-    "README.md"
-  ],
-  "devDependencies": {
-    "@fiftyone/prettier-config": "*",
-    "prettier": "^2.7.1",
-    "relay-compiler": "^14.0.0",
-    "relay-compiler-language-typescript": "^15.0.1",
-    "relay-config": "^12.0.1",
-    "typescript": "^4.7.4",
-    "vite": "^3.0.0"
-  },
-  "dependencies": {
-    "react-relay": "^14.0.0"
-  }
+    "name": "@fiftyone/relay",
+    "author": "Voxel51, Inc.",
+    "version": "0.0.0",
+    "description": "FiftyOne App Relay GraphQL queries, mutations, and subscriptions",
+    "homepage": "https://github.com/voxel51/fiftyone/app/packages/state",
+    "license": "Apache-2.0",
+    "bugs": {
+        "url": "https://github.com/voxel51/fiftyone/"
+    },
+    "main": "./src/index.ts",
+    "scripts": {
+        "compile": "relay-compiler",
+        "dev": "vite"
+    },
+    "private": true,
+    "files": [
+        "dist",
+        "README.md"
+    ],
+    "devDependencies": {
+        "@fiftyone/prettier-config": "*",
+        "prettier": "^2.7.1",
+        "relay-compiler": "^14.0.0",
+        "relay-compiler-language-typescript": "^15.0.1",
+        "relay-config": "^12.0.1",
+        "typescript": "^4.7.4",
+        "vite": "^3.0.0"
+    },
+    "dependencies": {
+        "react-relay": "^14.0.0"
+    }
 }

--- a/app/packages/relay/package.json
+++ b/app/packages/relay/package.json
@@ -19,7 +19,6 @@
         "README.md"
     ],
     "devDependencies": {
-        "@fiftyone/prettier-config": "*",
         "prettier": "^2.7.1",
         "relay-compiler": "^14.0.0",
         "relay-compiler-language-typescript": "^15.0.1",

--- a/app/packages/relay/src/mutations/__generated__/setGroupSliceMutation.graphql.ts
+++ b/app/packages/relay/src/mutations/__generated__/setGroupSliceMutation.graphql.ts
@@ -8,7 +8,7 @@
 /* eslint-disable */
 // @ts-nocheck
 
-import { ConcreteRequest, Mutation } from "relay-runtime";
+import { ConcreteRequest, Mutation } from 'relay-runtime';
 export type setGroupSliceMutation$variables = {
   session?: string | null;
   slice: string;
@@ -25,104 +25,104 @@ export type setGroupSliceMutation = {
   variables: setGroupSliceMutation$variables;
 };
 
-const node: ConcreteRequest = (function () {
-  var v0 = {
-      defaultValue: null,
-      kind: "LocalArgument",
-      name: "session",
-    },
-    v1 = {
-      defaultValue: null,
-      kind: "LocalArgument",
-      name: "slice",
-    },
-    v2 = {
-      defaultValue: null,
-      kind: "LocalArgument",
-      name: "subscription",
-    },
-    v3 = {
-      defaultValue: null,
-      kind: "LocalArgument",
-      name: "view",
-    },
-    v4 = [
+const node: ConcreteRequest = (function(){
+var v0 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "session"
+},
+v1 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "slice"
+},
+v2 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "subscription"
+},
+v3 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "view"
+},
+v4 = [
+  {
+    "alias": null,
+    "args": [
       {
-        alias: null,
-        args: [
-          {
-            kind: "Variable",
-            name: "session",
-            variableName: "session",
-          },
-          {
-            kind: "Variable",
-            name: "slice",
-            variableName: "slice",
-          },
-          {
-            kind: "Variable",
-            name: "subscription",
-            variableName: "subscription",
-          },
-          {
-            kind: "Variable",
-            name: "view",
-            variableName: "view",
-          },
-        ],
-        concreteType: "Dataset",
-        kind: "LinkedField",
-        name: "setGroupSlice",
-        plural: false,
-        selections: [
-          {
-            alias: null,
-            args: null,
-            kind: "ScalarField",
-            name: "id",
-            storageKey: null,
-          },
-        ],
-        storageKey: null,
+        "kind": "Variable",
+        "name": "session",
+        "variableName": "session"
       },
-    ];
-  return {
-    fragment: {
-      argumentDefinitions: [
-        v0 /*: any*/,
-        v1 /*: any*/,
-        v2 /*: any*/,
-        v3 /*: any*/,
-      ],
-      kind: "Fragment",
-      metadata: null,
-      name: "setGroupSliceMutation",
-      selections: v4 /*: any*/,
-      type: "Mutation",
-      abstractKey: null,
-    },
-    kind: "Request",
-    operation: {
-      argumentDefinitions: [
-        v2 /*: any*/,
-        v0 /*: any*/,
-        v3 /*: any*/,
-        v1 /*: any*/,
-      ],
-      kind: "Operation",
-      name: "setGroupSliceMutation",
-      selections: v4 /*: any*/,
-    },
-    params: {
-      cacheID: "bf10fdcc9a9e3441643c157812f905a2",
-      id: null,
-      metadata: {},
-      name: "setGroupSliceMutation",
-      operationKind: "mutation",
-      text: "mutation setGroupSliceMutation(\n  $subscription: String!\n  $session: String\n  $view: BSONArray!\n  $slice: String!\n) {\n  setGroupSlice(subscription: $subscription, session: $session, view: $view, slice: $slice) {\n    id\n  }\n}\n",
-    },
-  };
+      {
+        "kind": "Variable",
+        "name": "slice",
+        "variableName": "slice"
+      },
+      {
+        "kind": "Variable",
+        "name": "subscription",
+        "variableName": "subscription"
+      },
+      {
+        "kind": "Variable",
+        "name": "view",
+        "variableName": "view"
+      }
+    ],
+    "concreteType": "Dataset",
+    "kind": "LinkedField",
+    "name": "setGroupSlice",
+    "plural": false,
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "kind": "ScalarField",
+        "name": "id",
+        "storageKey": null
+      }
+    ],
+    "storageKey": null
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": [
+      (v0/*: any*/),
+      (v1/*: any*/),
+      (v2/*: any*/),
+      (v3/*: any*/)
+    ],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "setGroupSliceMutation",
+    "selections": (v4/*: any*/),
+    "type": "Mutation",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [
+      (v2/*: any*/),
+      (v0/*: any*/),
+      (v3/*: any*/),
+      (v1/*: any*/)
+    ],
+    "kind": "Operation",
+    "name": "setGroupSliceMutation",
+    "selections": (v4/*: any*/)
+  },
+  "params": {
+    "cacheID": "bf10fdcc9a9e3441643c157812f905a2",
+    "id": null,
+    "metadata": {},
+    "name": "setGroupSliceMutation",
+    "operationKind": "mutation",
+    "text": "mutation setGroupSliceMutation(\n  $subscription: String!\n  $session: String\n  $view: BSONArray!\n  $slice: String!\n) {\n  setGroupSlice(subscription: $subscription, session: $session, view: $view, slice: $slice) {\n    id\n  }\n}\n"
+  }
+};
 })();
 
 (node as any).hash = "88072c125d8981795598ed623e1609eb";

--- a/app/packages/relay/src/mutations/__generated__/setViewMutation.graphql.ts
+++ b/app/packages/relay/src/mutations/__generated__/setViewMutation.graphql.ts
@@ -8,13 +8,8 @@
 /* eslint-disable */
 // @ts-nocheck
 
-import { ConcreteRequest, Mutation } from "relay-runtime";
-export type MediaType =
-  | "group"
-  | "image"
-  | "point_cloud"
-  | "video"
-  | "%future added value";
+import { ConcreteRequest, Mutation } from 'relay-runtime';
+export type MediaType = "group" | "image" | "point_cloud" | "video" | "%future added value";
 export type setViewMutation$variables = {
   dataset: string;
   session?: string | null;
@@ -113,505 +108,515 @@ export type setViewMutation = {
   variables: setViewMutation$variables;
 };
 
-const node: ConcreteRequest = (function () {
-  var v0 = {
-      defaultValue: null,
-      kind: "LocalArgument",
-      name: "dataset",
-    },
-    v1 = {
-      defaultValue: null,
-      kind: "LocalArgument",
-      name: "session",
-    },
-    v2 = {
-      defaultValue: null,
-      kind: "LocalArgument",
-      name: "subscription",
-    },
-    v3 = {
-      defaultValue: null,
-      kind: "LocalArgument",
-      name: "view",
-    },
-    v4 = {
-      alias: null,
-      args: null,
-      kind: "ScalarField",
-      name: "name",
-      storageKey: null,
-    },
-    v5 = {
-      alias: null,
-      args: null,
-      kind: "ScalarField",
-      name: "mediaType",
-      storageKey: null,
-    },
-    v6 = [
+const node: ConcreteRequest = (function(){
+var v0 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "dataset"
+},
+v1 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "session"
+},
+v2 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "subscription"
+},
+v3 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "view"
+},
+v4 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
+},
+v5 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "mediaType",
+  "storageKey": null
+},
+v6 = [
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "ftype",
+    "storageKey": null
+  },
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "subfield",
+    "storageKey": null
+  },
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "embeddedDocType",
+    "storageKey": null
+  },
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "path",
+    "storageKey": null
+  },
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "dbField",
+    "storageKey": null
+  }
+],
+v7 = [
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "target",
+    "storageKey": null
+  },
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "value",
+    "storageKey": null
+  }
+],
+v8 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "key",
+  "storageKey": null
+},
+v9 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "version",
+  "storageKey": null
+},
+v10 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "timestamp",
+  "storageKey": null
+},
+v11 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "viewStages",
+  "storageKey": null
+},
+v12 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "cls",
+  "storageKey": null
+},
+v13 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "labels",
+  "storageKey": null
+},
+v14 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "edges",
+  "storageKey": null
+},
+v15 = [
+  {
+    "alias": null,
+    "args": [
       {
-        alias: null,
-        args: null,
-        kind: "ScalarField",
-        name: "ftype",
-        storageKey: null,
+        "kind": "Variable",
+        "name": "dataset",
+        "variableName": "dataset"
       },
       {
-        alias: null,
-        args: null,
-        kind: "ScalarField",
-        name: "subfield",
-        storageKey: null,
+        "kind": "Variable",
+        "name": "session",
+        "variableName": "session"
       },
       {
-        alias: null,
-        args: null,
-        kind: "ScalarField",
-        name: "embeddedDocType",
-        storageKey: null,
+        "kind": "Variable",
+        "name": "subscription",
+        "variableName": "subscription"
       },
       {
-        alias: null,
-        args: null,
-        kind: "ScalarField",
-        name: "path",
-        storageKey: null,
-      },
-      {
-        alias: null,
-        args: null,
-        kind: "ScalarField",
-        name: "dbField",
-        storageKey: null,
-      },
+        "kind": "Variable",
+        "name": "view",
+        "variableName": "view"
+      }
     ],
-    v7 = [
+    "concreteType": "ViewResponse",
+    "kind": "LinkedField",
+    "name": "setView",
+    "plural": false,
+    "selections": [
       {
-        alias: null,
-        args: null,
-        kind: "ScalarField",
-        name: "target",
-        storageKey: null,
-      },
-      {
-        alias: null,
-        args: null,
-        kind: "ScalarField",
-        name: "value",
-        storageKey: null,
-      },
-    ],
-    v8 = {
-      alias: null,
-      args: null,
-      kind: "ScalarField",
-      name: "key",
-      storageKey: null,
-    },
-    v9 = {
-      alias: null,
-      args: null,
-      kind: "ScalarField",
-      name: "version",
-      storageKey: null,
-    },
-    v10 = {
-      alias: null,
-      args: null,
-      kind: "ScalarField",
-      name: "timestamp",
-      storageKey: null,
-    },
-    v11 = {
-      alias: null,
-      args: null,
-      kind: "ScalarField",
-      name: "viewStages",
-      storageKey: null,
-    },
-    v12 = {
-      alias: null,
-      args: null,
-      kind: "ScalarField",
-      name: "cls",
-      storageKey: null,
-    },
-    v13 = {
-      alias: null,
-      args: null,
-      kind: "ScalarField",
-      name: "labels",
-      storageKey: null,
-    },
-    v14 = {
-      alias: null,
-      args: null,
-      kind: "ScalarField",
-      name: "edges",
-      storageKey: null,
-    },
-    v15 = [
-      {
-        alias: null,
-        args: [
+        "alias": null,
+        "args": null,
+        "concreteType": "Dataset",
+        "kind": "LinkedField",
+        "name": "dataset",
+        "plural": false,
+        "selections": [
           {
-            kind: "Variable",
-            name: "dataset",
-            variableName: "dataset",
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "id",
+            "storageKey": null
+          },
+          (v4/*: any*/),
+          (v5/*: any*/),
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "groupSlice",
+            "storageKey": null
           },
           {
-            kind: "Variable",
-            name: "session",
-            variableName: "session",
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "defaultGroupSlice",
+            "storageKey": null
           },
           {
-            kind: "Variable",
-            name: "subscription",
-            variableName: "subscription",
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "groupField",
+            "storageKey": null
           },
           {
-            kind: "Variable",
-            name: "view",
-            variableName: "view",
-          },
-        ],
-        concreteType: "ViewResponse",
-        kind: "LinkedField",
-        name: "setView",
-        plural: false,
-        selections: [
-          {
-            alias: null,
-            args: null,
-            concreteType: "Dataset",
-            kind: "LinkedField",
-            name: "dataset",
-            plural: false,
-            selections: [
-              {
-                alias: null,
-                args: null,
-                kind: "ScalarField",
-                name: "id",
-                storageKey: null,
-              },
-              v4 /*: any*/,
-              v5 /*: any*/,
-              {
-                alias: null,
-                args: null,
-                kind: "ScalarField",
-                name: "groupSlice",
-                storageKey: null,
-              },
-              {
-                alias: null,
-                args: null,
-                kind: "ScalarField",
-                name: "defaultGroupSlice",
-                storageKey: null,
-              },
-              {
-                alias: null,
-                args: null,
-                kind: "ScalarField",
-                name: "groupField",
-                storageKey: null,
-              },
-              {
-                alias: null,
-                args: null,
-                concreteType: "Group",
-                kind: "LinkedField",
-                name: "groupMediaTypes",
-                plural: true,
-                selections: [v4 /*: any*/, v5 /*: any*/],
-                storageKey: null,
-              },
-              {
-                alias: null,
-                args: null,
-                concreteType: "SampleField",
-                kind: "LinkedField",
-                name: "sampleFields",
-                plural: true,
-                selections: v6 /*: any*/,
-                storageKey: null,
-              },
-              {
-                alias: null,
-                args: null,
-                concreteType: "SampleField",
-                kind: "LinkedField",
-                name: "frameFields",
-                plural: true,
-                selections: v6 /*: any*/,
-                storageKey: null,
-              },
-              {
-                alias: null,
-                args: null,
-                concreteType: "NamedTargets",
-                kind: "LinkedField",
-                name: "maskTargets",
-                plural: true,
-                selections: [
-                  v4 /*: any*/,
-                  {
-                    alias: null,
-                    args: null,
-                    concreteType: "Target",
-                    kind: "LinkedField",
-                    name: "targets",
-                    plural: true,
-                    selections: v7 /*: any*/,
-                    storageKey: null,
-                  },
-                ],
-                storageKey: null,
-              },
-              {
-                alias: null,
-                args: null,
-                concreteType: "Target",
-                kind: "LinkedField",
-                name: "defaultMaskTargets",
-                plural: true,
-                selections: v7 /*: any*/,
-                storageKey: null,
-              },
-              {
-                alias: null,
-                args: null,
-                concreteType: "EvaluationRun",
-                kind: "LinkedField",
-                name: "evaluations",
-                plural: true,
-                selections: [
-                  v8 /*: any*/,
-                  v9 /*: any*/,
-                  v10 /*: any*/,
-                  v11 /*: any*/,
-                  {
-                    alias: null,
-                    args: null,
-                    concreteType: "EvaluationRunConfig",
-                    kind: "LinkedField",
-                    name: "config",
-                    plural: false,
-                    selections: [
-                      v12 /*: any*/,
-                      {
-                        alias: null,
-                        args: null,
-                        kind: "ScalarField",
-                        name: "predField",
-                        storageKey: null,
-                      },
-                      {
-                        alias: null,
-                        args: null,
-                        kind: "ScalarField",
-                        name: "gtField",
-                        storageKey: null,
-                      },
-                    ],
-                    storageKey: null,
-                  },
-                ],
-                storageKey: null,
-              },
-              {
-                alias: null,
-                args: null,
-                concreteType: "BrainRun",
-                kind: "LinkedField",
-                name: "brainMethods",
-                plural: true,
-                selections: [
-                  v8 /*: any*/,
-                  v9 /*: any*/,
-                  v10 /*: any*/,
-                  v11 /*: any*/,
-                  {
-                    alias: null,
-                    args: null,
-                    concreteType: "BrainRunConfig",
-                    kind: "LinkedField",
-                    name: "config",
-                    plural: false,
-                    selections: [
-                      v12 /*: any*/,
-                      {
-                        alias: null,
-                        args: null,
-                        kind: "ScalarField",
-                        name: "embeddingsField",
-                        storageKey: null,
-                      },
-                      {
-                        alias: null,
-                        args: null,
-                        kind: "ScalarField",
-                        name: "method",
-                        storageKey: null,
-                      },
-                      {
-                        alias: null,
-                        args: null,
-                        kind: "ScalarField",
-                        name: "patchesField",
-                        storageKey: null,
-                      },
-                    ],
-                    storageKey: null,
-                  },
-                ],
-                storageKey: null,
-              },
-              {
-                alias: null,
-                args: null,
-                kind: "ScalarField",
-                name: "lastLoadedAt",
-                storageKey: null,
-              },
-              {
-                alias: null,
-                args: null,
-                kind: "ScalarField",
-                name: "createdAt",
-                storageKey: null,
-              },
-              v9 /*: any*/,
-              {
-                alias: null,
-                args: null,
-                kind: "ScalarField",
-                name: "viewCls",
-                storageKey: null,
-              },
-              {
-                alias: null,
-                args: null,
-                concreteType: "NamedKeypointSkeleton",
-                kind: "LinkedField",
-                name: "skeletons",
-                plural: true,
-                selections: [v4 /*: any*/, v13 /*: any*/, v14 /*: any*/],
-                storageKey: null,
-              },
-              {
-                alias: null,
-                args: null,
-                concreteType: "KeypointSkeleton",
-                kind: "LinkedField",
-                name: "defaultSkeleton",
-                plural: false,
-                selections: [v13 /*: any*/, v14 /*: any*/],
-                storageKey: null,
-              },
-              {
-                alias: null,
-                args: null,
-                concreteType: "DatasetAppConfig",
-                kind: "LinkedField",
-                name: "appConfig",
-                plural: false,
-                selections: [
-                  {
-                    alias: null,
-                    args: null,
-                    kind: "ScalarField",
-                    name: "gridMediaField",
-                    storageKey: null,
-                  },
-                  {
-                    alias: null,
-                    args: null,
-                    kind: "ScalarField",
-                    name: "mediaFields",
-                    storageKey: null,
-                  },
-                  {
-                    alias: null,
-                    args: null,
-                    kind: "ScalarField",
-                    name: "plugins",
-                    storageKey: null,
-                  },
-                  {
-                    alias: null,
-                    args: null,
-                    concreteType: "SidebarGroup",
-                    kind: "LinkedField",
-                    name: "sidebarGroups",
-                    plural: true,
-                    selections: [
-                      v4 /*: any*/,
-                      {
-                        alias: null,
-                        args: null,
-                        kind: "ScalarField",
-                        name: "paths",
-                        storageKey: null,
-                      },
-                    ],
-                    storageKey: null,
-                  },
-                ],
-                storageKey: null,
-              },
+            "alias": null,
+            "args": null,
+            "concreteType": "Group",
+            "kind": "LinkedField",
+            "name": "groupMediaTypes",
+            "plural": true,
+            "selections": [
+              (v4/*: any*/),
+              (v5/*: any*/)
             ],
-            storageKey: null,
+            "storageKey": null
           },
           {
-            alias: null,
-            args: null,
-            kind: "ScalarField",
-            name: "view",
-            storageKey: null,
+            "alias": null,
+            "args": null,
+            "concreteType": "SampleField",
+            "kind": "LinkedField",
+            "name": "sampleFields",
+            "plural": true,
+            "selections": (v6/*: any*/),
+            "storageKey": null
           },
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "SampleField",
+            "kind": "LinkedField",
+            "name": "frameFields",
+            "plural": true,
+            "selections": (v6/*: any*/),
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "NamedTargets",
+            "kind": "LinkedField",
+            "name": "maskTargets",
+            "plural": true,
+            "selections": [
+              (v4/*: any*/),
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "Target",
+                "kind": "LinkedField",
+                "name": "targets",
+                "plural": true,
+                "selections": (v7/*: any*/),
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "Target",
+            "kind": "LinkedField",
+            "name": "defaultMaskTargets",
+            "plural": true,
+            "selections": (v7/*: any*/),
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "EvaluationRun",
+            "kind": "LinkedField",
+            "name": "evaluations",
+            "plural": true,
+            "selections": [
+              (v8/*: any*/),
+              (v9/*: any*/),
+              (v10/*: any*/),
+              (v11/*: any*/),
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "EvaluationRunConfig",
+                "kind": "LinkedField",
+                "name": "config",
+                "plural": false,
+                "selections": [
+                  (v12/*: any*/),
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "predField",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "gtField",
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "BrainRun",
+            "kind": "LinkedField",
+            "name": "brainMethods",
+            "plural": true,
+            "selections": [
+              (v8/*: any*/),
+              (v9/*: any*/),
+              (v10/*: any*/),
+              (v11/*: any*/),
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "BrainRunConfig",
+                "kind": "LinkedField",
+                "name": "config",
+                "plural": false,
+                "selections": [
+                  (v12/*: any*/),
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "embeddingsField",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "method",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "patchesField",
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "lastLoadedAt",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "createdAt",
+            "storageKey": null
+          },
+          (v9/*: any*/),
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "viewCls",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "NamedKeypointSkeleton",
+            "kind": "LinkedField",
+            "name": "skeletons",
+            "plural": true,
+            "selections": [
+              (v4/*: any*/),
+              (v13/*: any*/),
+              (v14/*: any*/)
+            ],
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "KeypointSkeleton",
+            "kind": "LinkedField",
+            "name": "defaultSkeleton",
+            "plural": false,
+            "selections": [
+              (v13/*: any*/),
+              (v14/*: any*/)
+            ],
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "DatasetAppConfig",
+            "kind": "LinkedField",
+            "name": "appConfig",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "gridMediaField",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "mediaFields",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "plugins",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "SidebarGroup",
+                "kind": "LinkedField",
+                "name": "sidebarGroups",
+                "plural": true,
+                "selections": [
+                  (v4/*: any*/),
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "paths",
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          }
         ],
-        storageKey: null,
+        "storageKey": null
       },
-    ];
-  return {
-    fragment: {
-      argumentDefinitions: [
-        v0 /*: any*/,
-        v1 /*: any*/,
-        v2 /*: any*/,
-        v3 /*: any*/,
-      ],
-      kind: "Fragment",
-      metadata: null,
-      name: "setViewMutation",
-      selections: v15 /*: any*/,
-      type: "Mutation",
-      abstractKey: null,
-    },
-    kind: "Request",
-    operation: {
-      argumentDefinitions: [
-        v2 /*: any*/,
-        v1 /*: any*/,
-        v3 /*: any*/,
-        v0 /*: any*/,
-      ],
-      kind: "Operation",
-      name: "setViewMutation",
-      selections: v15 /*: any*/,
-    },
-    params: {
-      cacheID: "b69edbfcc1b37d21ad4713a4b2aeaa5a",
-      id: null,
-      metadata: {},
-      name: "setViewMutation",
-      operationKind: "mutation",
-      text: "mutation setViewMutation(\n  $subscription: String!\n  $session: String\n  $view: BSONArray!\n  $dataset: String!\n) {\n  setView(subscription: $subscription, session: $session, view: $view, dataset: $dataset) {\n    dataset {\n      id\n      name\n      mediaType\n      groupSlice\n      defaultGroupSlice\n      groupField\n      groupMediaTypes {\n        name\n        mediaType\n      }\n      sampleFields {\n        ftype\n        subfield\n        embeddedDocType\n        path\n        dbField\n      }\n      frameFields {\n        ftype\n        subfield\n        embeddedDocType\n        path\n        dbField\n      }\n      maskTargets {\n        name\n        targets {\n          target\n          value\n        }\n      }\n      defaultMaskTargets {\n        target\n        value\n      }\n      evaluations {\n        key\n        version\n        timestamp\n        viewStages\n        config {\n          cls\n          predField\n          gtField\n        }\n      }\n      brainMethods {\n        key\n        version\n        timestamp\n        viewStages\n        config {\n          cls\n          embeddingsField\n          method\n          patchesField\n        }\n      }\n      lastLoadedAt\n      createdAt\n      version\n      viewCls\n      skeletons {\n        name\n        labels\n        edges\n      }\n      defaultSkeleton {\n        labels\n        edges\n      }\n      appConfig {\n        gridMediaField\n        mediaFields\n        plugins\n        sidebarGroups {\n          name\n          paths\n        }\n      }\n    }\n    view\n  }\n}\n",
-    },
-  };
+      {
+        "alias": null,
+        "args": null,
+        "kind": "ScalarField",
+        "name": "view",
+        "storageKey": null
+      }
+    ],
+    "storageKey": null
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": [
+      (v0/*: any*/),
+      (v1/*: any*/),
+      (v2/*: any*/),
+      (v3/*: any*/)
+    ],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "setViewMutation",
+    "selections": (v15/*: any*/),
+    "type": "Mutation",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [
+      (v2/*: any*/),
+      (v1/*: any*/),
+      (v3/*: any*/),
+      (v0/*: any*/)
+    ],
+    "kind": "Operation",
+    "name": "setViewMutation",
+    "selections": (v15/*: any*/)
+  },
+  "params": {
+    "cacheID": "b69edbfcc1b37d21ad4713a4b2aeaa5a",
+    "id": null,
+    "metadata": {},
+    "name": "setViewMutation",
+    "operationKind": "mutation",
+    "text": "mutation setViewMutation(\n  $subscription: String!\n  $session: String\n  $view: BSONArray!\n  $dataset: String!\n) {\n  setView(subscription: $subscription, session: $session, view: $view, dataset: $dataset) {\n    dataset {\n      id\n      name\n      mediaType\n      groupSlice\n      defaultGroupSlice\n      groupField\n      groupMediaTypes {\n        name\n        mediaType\n      }\n      sampleFields {\n        ftype\n        subfield\n        embeddedDocType\n        path\n        dbField\n      }\n      frameFields {\n        ftype\n        subfield\n        embeddedDocType\n        path\n        dbField\n      }\n      maskTargets {\n        name\n        targets {\n          target\n          value\n        }\n      }\n      defaultMaskTargets {\n        target\n        value\n      }\n      evaluations {\n        key\n        version\n        timestamp\n        viewStages\n        config {\n          cls\n          predField\n          gtField\n        }\n      }\n      brainMethods {\n        key\n        version\n        timestamp\n        viewStages\n        config {\n          cls\n          embeddingsField\n          method\n          patchesField\n        }\n      }\n      lastLoadedAt\n      createdAt\n      version\n      viewCls\n      skeletons {\n        name\n        labels\n        edges\n      }\n      defaultSkeleton {\n        labels\n        edges\n      }\n      appConfig {\n        gridMediaField\n        mediaFields\n        plugins\n        sidebarGroups {\n          name\n          paths\n        }\n      }\n    }\n    view\n  }\n}\n"
+  }
+};
 })();
 
 (node as any).hash = "42eb6fbca8fb3eec644d4b0bdbe13b76";

--- a/app/packages/relay/src/queries/__generated__/mainSampleQuery.graphql.ts
+++ b/app/packages/relay/src/queries/__generated__/mainSampleQuery.graphql.ts
@@ -8,7 +8,7 @@
 /* eslint-disable */
 // @ts-nocheck
 
-import { ConcreteRequest, Query } from "relay-runtime";
+import { ConcreteRequest, Query } from 'relay-runtime';
 export type SampleFilter = {
   group?: GroupElementFilter | null;
   id?: string | null;
@@ -38,165 +38,182 @@ export type mainSampleQuery = {
   variables: mainSampleQuery$variables;
 };
 
-const node: ConcreteRequest = (function () {
-  var v0 = {
-      defaultValue: null,
-      kind: "LocalArgument",
-      name: "dataset",
+const node: ConcreteRequest = (function(){
+var v0 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "dataset"
+},
+v1 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "filter"
+},
+v2 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "view"
+},
+v3 = [
+  {
+    "kind": "Variable",
+    "name": "dataset",
+    "variableName": "dataset"
+  },
+  {
+    "kind": "Variable",
+    "name": "filter",
+    "variableName": "filter"
+  },
+  {
+    "kind": "Variable",
+    "name": "view",
+    "variableName": "view"
+  }
+],
+v4 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v5 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "sample",
+  "storageKey": null
+},
+v6 = {
+  "alias": null,
+  "args": null,
+  "concreteType": "MediaURL",
+  "kind": "LinkedField",
+  "name": "urls",
+  "plural": true,
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "field",
+      "storageKey": null
     },
-    v1 = {
-      defaultValue: null,
-      kind: "LocalArgument",
-      name: "filter",
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "url",
+      "storageKey": null
+    }
+  ],
+  "storageKey": null
+},
+v7 = {
+  "kind": "InlineFragment",
+  "selections": [
+    (v4/*: any*/),
+    (v5/*: any*/),
+    (v6/*: any*/)
+  ],
+  "type": "ImageSample",
+  "abstractKey": null
+},
+v8 = {
+  "kind": "InlineFragment",
+  "selections": [
+    (v4/*: any*/),
+    (v5/*: any*/),
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "frameRate",
+      "storageKey": null
     },
-    v2 = {
-      defaultValue: null,
-      kind: "LocalArgument",
-      name: "view",
-    },
-    v3 = [
-      {
-        kind: "Variable",
-        name: "dataset",
-        variableName: "dataset",
-      },
-      {
-        kind: "Variable",
-        name: "filter",
-        variableName: "filter",
-      },
-      {
-        kind: "Variable",
-        name: "view",
-        variableName: "view",
-      },
+    (v6/*: any*/)
+  ],
+  "type": "VideoSample",
+  "abstractKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": [
+      (v0/*: any*/),
+      (v1/*: any*/),
+      (v2/*: any*/)
     ],
-    v4 = {
-      alias: null,
-      args: null,
-      kind: "ScalarField",
-      name: "id",
-      storageKey: null,
-    },
-    v5 = {
-      alias: null,
-      args: null,
-      kind: "ScalarField",
-      name: "sample",
-      storageKey: null,
-    },
-    v6 = {
-      alias: null,
-      args: null,
-      concreteType: "MediaURL",
-      kind: "LinkedField",
-      name: "urls",
-      plural: true,
-      selections: [
-        {
-          alias: null,
-          args: null,
-          kind: "ScalarField",
-          name: "field",
-          storageKey: null,
-        },
-        {
-          alias: null,
-          args: null,
-          kind: "ScalarField",
-          name: "url",
-          storageKey: null,
-        },
-      ],
-      storageKey: null,
-    },
-    v7 = {
-      kind: "InlineFragment",
-      selections: [v4 /*: any*/, v5 /*: any*/, v6 /*: any*/],
-      type: "ImageSample",
-      abstractKey: null,
-    },
-    v8 = {
-      kind: "InlineFragment",
-      selections: [
-        v4 /*: any*/,
-        v5 /*: any*/,
-        {
-          alias: null,
-          args: null,
-          kind: "ScalarField",
-          name: "frameRate",
-          storageKey: null,
-        },
-        v6 /*: any*/,
-      ],
-      type: "VideoSample",
-      abstractKey: null,
-    };
-  return {
-    fragment: {
-      argumentDefinitions: [v0 /*: any*/, v1 /*: any*/, v2 /*: any*/],
-      kind: "Fragment",
-      metadata: null,
-      name: "mainSampleQuery",
-      selections: [
-        {
-          alias: null,
-          args: v3 /*: any*/,
-          concreteType: null,
-          kind: "LinkedField",
-          name: "sample",
-          plural: false,
-          selections: [v7 /*: any*/, v8 /*: any*/],
-          storageKey: null,
-        },
-      ],
-      type: "Query",
-      abstractKey: null,
-    },
-    kind: "Request",
-    operation: {
-      argumentDefinitions: [v0 /*: any*/, v2 /*: any*/, v1 /*: any*/],
-      kind: "Operation",
-      name: "mainSampleQuery",
-      selections: [
-        {
-          alias: null,
-          args: v3 /*: any*/,
-          concreteType: null,
-          kind: "LinkedField",
-          name: "sample",
-          plural: false,
-          selections: [
-            {
-              alias: null,
-              args: null,
-              kind: "ScalarField",
-              name: "__typename",
-              storageKey: null,
-            },
-            v7 /*: any*/,
-            v8 /*: any*/,
-            {
-              kind: "InlineFragment",
-              selections: [v4 /*: any*/],
-              type: "PointCloudSample",
-              abstractKey: null,
-            },
-          ],
-          storageKey: null,
-        },
-      ],
-    },
-    params: {
-      cacheID: "8288bef45852588e173f7ad9366b1cbc",
-      id: null,
-      metadata: {},
-      name: "mainSampleQuery",
-      operationKind: "query",
-      text: "query mainSampleQuery(\n  $dataset: String!\n  $view: BSONArray!\n  $filter: SampleFilter!\n) {\n  sample(dataset: $dataset, view: $view, filter: $filter) {\n    __typename\n    ... on ImageSample {\n      id\n      sample\n      urls {\n        field\n        url\n      }\n    }\n    ... on VideoSample {\n      id\n      sample\n      frameRate\n      urls {\n        field\n        url\n      }\n    }\n    ... on PointCloudSample {\n      id\n    }\n  }\n}\n",
-    },
-  };
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "mainSampleQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v3/*: any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "sample",
+        "plural": false,
+        "selections": [
+          (v7/*: any*/),
+          (v8/*: any*/)
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [
+      (v0/*: any*/),
+      (v2/*: any*/),
+      (v1/*: any*/)
+    ],
+    "kind": "Operation",
+    "name": "mainSampleQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v3/*: any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "sample",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "__typename",
+            "storageKey": null
+          },
+          (v7/*: any*/),
+          (v8/*: any*/),
+          {
+            "kind": "InlineFragment",
+            "selections": [
+              (v4/*: any*/)
+            ],
+            "type": "PointCloudSample",
+            "abstractKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "8288bef45852588e173f7ad9366b1cbc",
+    "id": null,
+    "metadata": {},
+    "name": "mainSampleQuery",
+    "operationKind": "query",
+    "text": "query mainSampleQuery(\n  $dataset: String!\n  $view: BSONArray!\n  $filter: SampleFilter!\n) {\n  sample(dataset: $dataset, view: $view, filter: $filter) {\n    __typename\n    ... on ImageSample {\n      id\n      sample\n      urls {\n        field\n        url\n      }\n    }\n    ... on VideoSample {\n      id\n      sample\n      frameRate\n      urls {\n        field\n        url\n      }\n    }\n    ... on PointCloudSample {\n      id\n    }\n  }\n}\n"
+  }
+};
 })();
 
 (node as any).hash = "20386ac4db1c242b8eda0747ef22faa1";

--- a/app/packages/relay/src/queries/__generated__/paginateGroupPageQuery.graphql.ts
+++ b/app/packages/relay/src/queries/__generated__/paginateGroupPageQuery.graphql.ts
@@ -8,7 +8,7 @@
 /* eslint-disable */
 // @ts-nocheck
 
-import { ConcreteRequest, Query } from "relay-runtime";
+import { ConcreteRequest, Query } from 'relay-runtime';
 import { FragmentRefs } from "relay-runtime";
 export type SampleFilter = {
   group?: GroupElementFilter | null;
@@ -33,263 +33,271 @@ export type paginateGroupPageQuery = {
   variables: paginateGroupPageQuery$variables;
 };
 
-const node: ConcreteRequest = (function () {
-  var v0 = [
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "count"
+  },
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "cursor"
+  },
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "dataset"
+  },
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "filter"
+  },
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "view"
+  }
+],
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "after",
+    "variableName": "cursor"
+  },
+  {
+    "kind": "Variable",
+    "name": "dataset",
+    "variableName": "dataset"
+  },
+  {
+    "kind": "Variable",
+    "name": "filter",
+    "variableName": "filter"
+  },
+  {
+    "kind": "Variable",
+    "name": "first",
+    "variableName": "count"
+  },
+  {
+    "kind": "Variable",
+    "name": "view",
+    "variableName": "view"
+  }
+],
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "aspectRatio",
+  "storageKey": null
+},
+v4 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "sample",
+  "storageKey": null
+},
+v5 = {
+  "alias": null,
+  "args": null,
+  "concreteType": "MediaURL",
+  "kind": "LinkedField",
+  "name": "urls",
+  "plural": true,
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "field",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "url",
+      "storageKey": null
+    }
+  ],
+  "storageKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "paginateGroupPageQuery",
+    "selections": [
       {
-        defaultValue: null,
-        kind: "LocalArgument",
-        name: "count",
-      },
-      {
-        defaultValue: null,
-        kind: "LocalArgument",
-        name: "cursor",
-      },
-      {
-        defaultValue: null,
-        kind: "LocalArgument",
-        name: "dataset",
-      },
-      {
-        defaultValue: null,
-        kind: "LocalArgument",
-        name: "filter",
-      },
-      {
-        defaultValue: null,
-        kind: "LocalArgument",
-        name: "view",
-      },
+        "args": null,
+        "kind": "FragmentSpread",
+        "name": "paginateGroup_query"
+      }
     ],
-    v1 = [
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "paginateGroupPageQuery",
+    "selections": [
       {
-        kind: "Variable",
-        name: "after",
-        variableName: "cursor",
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": "SampleItemStrConnection",
+        "kind": "LinkedField",
+        "name": "samples",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "total",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "SampleItemStrEdge",
+            "kind": "LinkedField",
+            "name": "edges",
+            "plural": true,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "cursor",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": null,
+                "kind": "LinkedField",
+                "name": "node",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "__typename",
+                    "storageKey": null
+                  },
+                  {
+                    "kind": "InlineFragment",
+                    "selections": [
+                      (v2/*: any*/),
+                      (v3/*: any*/),
+                      (v4/*: any*/),
+                      (v5/*: any*/)
+                    ],
+                    "type": "ImageSample",
+                    "abstractKey": null
+                  },
+                  {
+                    "kind": "InlineFragment",
+                    "selections": [
+                      (v2/*: any*/),
+                      (v4/*: any*/),
+                      (v5/*: any*/)
+                    ],
+                    "type": "PointCloudSample",
+                    "abstractKey": null
+                  },
+                  {
+                    "kind": "InlineFragment",
+                    "selections": [
+                      (v2/*: any*/),
+                      (v3/*: any*/),
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "frameRate",
+                        "storageKey": null
+                      },
+                      (v4/*: any*/),
+                      (v5/*: any*/)
+                    ],
+                    "type": "VideoSample",
+                    "abstractKey": null
+                  }
+                ],
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "SampleItemStrPageInfo",
+            "kind": "LinkedField",
+            "name": "pageInfo",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "endCursor",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "hasNextPage",
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
       },
       {
-        kind: "Variable",
-        name: "dataset",
-        variableName: "dataset",
-      },
-      {
-        kind: "Variable",
-        name: "filter",
-        variableName: "filter",
-      },
-      {
-        kind: "Variable",
-        name: "first",
-        variableName: "count",
-      },
-      {
-        kind: "Variable",
-        name: "view",
-        variableName: "view",
-      },
-    ],
-    v2 = {
-      alias: null,
-      args: null,
-      kind: "ScalarField",
-      name: "id",
-      storageKey: null,
-    },
-    v3 = {
-      alias: null,
-      args: null,
-      kind: "ScalarField",
-      name: "aspectRatio",
-      storageKey: null,
-    },
-    v4 = {
-      alias: null,
-      args: null,
-      kind: "ScalarField",
-      name: "sample",
-      storageKey: null,
-    },
-    v5 = {
-      alias: null,
-      args: null,
-      concreteType: "MediaURL",
-      kind: "LinkedField",
-      name: "urls",
-      plural: true,
-      selections: [
-        {
-          alias: null,
-          args: null,
-          kind: "ScalarField",
-          name: "field",
-          storageKey: null,
-        },
-        {
-          alias: null,
-          args: null,
-          kind: "ScalarField",
-          name: "url",
-          storageKey: null,
-        },
-      ],
-      storageKey: null,
-    };
-  return {
-    fragment: {
-      argumentDefinitions: v0 /*: any*/,
-      kind: "Fragment",
-      metadata: null,
-      name: "paginateGroupPageQuery",
-      selections: [
-        {
-          args: null,
-          kind: "FragmentSpread",
-          name: "paginateGroup_query",
-        },
-      ],
-      type: "Query",
-      abstractKey: null,
-    },
-    kind: "Request",
-    operation: {
-      argumentDefinitions: v0 /*: any*/,
-      kind: "Operation",
-      name: "paginateGroupPageQuery",
-      selections: [
-        {
-          alias: null,
-          args: v1 /*: any*/,
-          concreteType: "SampleItemStrConnection",
-          kind: "LinkedField",
-          name: "samples",
-          plural: false,
-          selections: [
-            {
-              alias: null,
-              args: null,
-              kind: "ScalarField",
-              name: "total",
-              storageKey: null,
-            },
-            {
-              alias: null,
-              args: null,
-              concreteType: "SampleItemStrEdge",
-              kind: "LinkedField",
-              name: "edges",
-              plural: true,
-              selections: [
-                {
-                  alias: null,
-                  args: null,
-                  kind: "ScalarField",
-                  name: "cursor",
-                  storageKey: null,
-                },
-                {
-                  alias: null,
-                  args: null,
-                  concreteType: null,
-                  kind: "LinkedField",
-                  name: "node",
-                  plural: false,
-                  selections: [
-                    {
-                      alias: null,
-                      args: null,
-                      kind: "ScalarField",
-                      name: "__typename",
-                      storageKey: null,
-                    },
-                    {
-                      kind: "InlineFragment",
-                      selections: [
-                        v2 /*: any*/,
-                        v3 /*: any*/,
-                        v4 /*: any*/,
-                        v5 /*: any*/,
-                      ],
-                      type: "ImageSample",
-                      abstractKey: null,
-                    },
-                    {
-                      kind: "InlineFragment",
-                      selections: [v2 /*: any*/, v4 /*: any*/, v5 /*: any*/],
-                      type: "PointCloudSample",
-                      abstractKey: null,
-                    },
-                    {
-                      kind: "InlineFragment",
-                      selections: [
-                        v2 /*: any*/,
-                        v3 /*: any*/,
-                        {
-                          alias: null,
-                          args: null,
-                          kind: "ScalarField",
-                          name: "frameRate",
-                          storageKey: null,
-                        },
-                        v4 /*: any*/,
-                        v5 /*: any*/,
-                      ],
-                      type: "VideoSample",
-                      abstractKey: null,
-                    },
-                  ],
-                  storageKey: null,
-                },
-              ],
-              storageKey: null,
-            },
-            {
-              alias: null,
-              args: null,
-              concreteType: "SampleItemStrPageInfo",
-              kind: "LinkedField",
-              name: "pageInfo",
-              plural: false,
-              selections: [
-                {
-                  alias: null,
-                  args: null,
-                  kind: "ScalarField",
-                  name: "endCursor",
-                  storageKey: null,
-                },
-                {
-                  alias: null,
-                  args: null,
-                  kind: "ScalarField",
-                  name: "hasNextPage",
-                  storageKey: null,
-                },
-              ],
-              storageKey: null,
-            },
-          ],
-          storageKey: null,
-        },
-        {
-          alias: null,
-          args: v1 /*: any*/,
-          filters: ["dataset", "view", "filter"],
-          handle: "connection",
-          key: "paginateGroup_query_samples",
-          kind: "LinkedHandle",
-          name: "samples",
-        },
-      ],
-    },
-    params: {
-      cacheID: "1e5b70e8bf7e81c7574e5701cfc30db6",
-      id: null,
-      metadata: {},
-      name: "paginateGroupPageQuery",
-      operationKind: "query",
-      text: "query paginateGroupPageQuery(\n  $count: Int\n  $cursor: String\n  $dataset: String!\n  $filter: SampleFilter\n  $view: BSONArray!\n) {\n  ...paginateGroup_query\n}\n\nfragment paginateGroup_query on Query {\n  samples(dataset: $dataset, view: $view, first: $count, after: $cursor, filter: $filter) {\n    total\n    edges {\n      cursor\n      node {\n        __typename\n        ... on ImageSample {\n          id\n          aspectRatio\n          sample\n          urls {\n            field\n            url\n          }\n        }\n        ... on PointCloudSample {\n          id\n          sample\n          urls {\n            field\n            url\n          }\n        }\n        ... on VideoSample {\n          id\n          aspectRatio\n          frameRate\n          sample\n          urls {\n            field\n            url\n          }\n        }\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n",
-    },
-  };
+        "alias": null,
+        "args": (v1/*: any*/),
+        "filters": [
+          "dataset",
+          "view",
+          "filter"
+        ],
+        "handle": "connection",
+        "key": "paginateGroup_query_samples",
+        "kind": "LinkedHandle",
+        "name": "samples"
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "1e5b70e8bf7e81c7574e5701cfc30db6",
+    "id": null,
+    "metadata": {},
+    "name": "paginateGroupPageQuery",
+    "operationKind": "query",
+    "text": "query paginateGroupPageQuery(\n  $count: Int\n  $cursor: String\n  $dataset: String!\n  $filter: SampleFilter\n  $view: BSONArray!\n) {\n  ...paginateGroup_query\n}\n\nfragment paginateGroup_query on Query {\n  samples(dataset: $dataset, view: $view, first: $count, after: $cursor, filter: $filter) {\n    total\n    edges {\n      cursor\n      node {\n        __typename\n        ... on ImageSample {\n          id\n          aspectRatio\n          sample\n          urls {\n            field\n            url\n          }\n        }\n        ... on PointCloudSample {\n          id\n          sample\n          urls {\n            field\n            url\n          }\n        }\n        ... on VideoSample {\n          id\n          aspectRatio\n          frameRate\n          sample\n          urls {\n            field\n            url\n          }\n        }\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
+  }
+};
 })();
 
 (node as any).hash = "20891cc18082d493738d44781ff64148";

--- a/app/packages/relay/src/queries/__generated__/paginateGroupPinnedSample_query.graphql.ts
+++ b/app/packages/relay/src/queries/__generated__/paginateGroupPinnedSample_query.graphql.ts
@@ -8,46 +8,41 @@
 /* eslint-disable */
 // @ts-nocheck
 
-import { InlineFragment, ReaderInlineDataFragment } from "relay-runtime";
+import { InlineFragment, ReaderInlineDataFragment } from 'relay-runtime';
 import { FragmentRefs } from "relay-runtime";
 export type paginateGroupPinnedSample_query$data = {
-  readonly sample:
-    | {
-        readonly __typename: "ImageSample";
-        readonly aspectRatio: number;
-        readonly id: string;
-        readonly sample: object;
-        readonly urls: ReadonlyArray<{
-          readonly field: string;
-          readonly url: string;
-        }>;
-      }
-    | {
-        readonly __typename: "PointCloudSample";
-        readonly id: string;
-        readonly sample: object;
-        readonly urls: ReadonlyArray<{
-          readonly field: string;
-          readonly url: string;
-        }>;
-      }
-    | {
-        readonly __typename: "VideoSample";
-        readonly aspectRatio: number;
-        readonly frameRate: number;
-        readonly id: string;
-        readonly sample: object;
-        readonly urls: ReadonlyArray<{
-          readonly field: string;
-          readonly url: string;
-        }>;
-      }
-    | {
-        // This will never be '%other', but we need some
-        // value in case none of the concrete values match.
-        readonly __typename: "%other";
-      }
-    | null;
+  readonly sample: {
+    readonly __typename: "ImageSample";
+    readonly aspectRatio: number;
+    readonly id: string;
+    readonly sample: object;
+    readonly urls: ReadonlyArray<{
+      readonly field: string;
+      readonly url: string;
+    }>;
+  } | {
+    readonly __typename: "PointCloudSample";
+    readonly id: string;
+    readonly sample: object;
+    readonly urls: ReadonlyArray<{
+      readonly field: string;
+      readonly url: string;
+    }>;
+  } | {
+    readonly __typename: "VideoSample";
+    readonly aspectRatio: number;
+    readonly frameRate: number;
+    readonly id: string;
+    readonly sample: object;
+    readonly urls: ReadonlyArray<{
+      readonly field: string;
+      readonly url: string;
+    }>;
+  } | {
+    // This will never be '%other', but we need some
+    // value in case none of the concrete values match.
+    readonly __typename: "%other";
+  } | null;
   readonly " $fragmentType": "paginateGroupPinnedSample_query";
 };
 export type paginateGroupPinnedSample_query$key = {
@@ -56,8 +51,8 @@ export type paginateGroupPinnedSample_query$key = {
 };
 
 const node: ReaderInlineDataFragment = {
-  kind: "InlineDataFragment",
-  name: "paginateGroupPinnedSample_query",
+  "kind": "InlineDataFragment",
+  "name": "paginateGroupPinnedSample_query"
 };
 
 (node as any).hash = "1d6bafdc772cdec18ce0362791e8d869";

--- a/app/packages/relay/src/queries/__generated__/paginateGroupQuery.graphql.ts
+++ b/app/packages/relay/src/queries/__generated__/paginateGroupQuery.graphql.ts
@@ -8,7 +8,7 @@
 /* eslint-disable */
 // @ts-nocheck
 
-import { ConcreteRequest, Query } from "relay-runtime";
+import { ConcreteRequest, Query } from 'relay-runtime';
 import { FragmentRefs } from "relay-runtime";
 export type SampleFilter = {
   group?: GroupElementFilter | null;
@@ -27,311 +27,324 @@ export type paginateGroupQuery$variables = {
   view: Array;
 };
 export type paginateGroupQuery$data = {
-  readonly " $fragmentSpreads": FragmentRefs<
-    "paginateGroupPinnedSample_query" | "paginateGroup_query"
-  >;
+  readonly " $fragmentSpreads": FragmentRefs<"paginateGroupPinnedSample_query" | "paginateGroup_query">;
 };
 export type paginateGroupQuery = {
   response: paginateGroupQuery$data;
   variables: paginateGroupQuery$variables;
 };
 
-const node: ConcreteRequest = (function () {
-  var v0 = {
-      defaultValue: 20,
-      kind: "LocalArgument",
-      name: "count",
+const node: ConcreteRequest = (function(){
+var v0 = {
+  "defaultValue": 20,
+  "kind": "LocalArgument",
+  "name": "count"
+},
+v1 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "cursor"
+},
+v2 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "dataset"
+},
+v3 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "filter"
+},
+v4 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "pinnedSampleFilter"
+},
+v5 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "view"
+},
+v6 = {
+  "kind": "Variable",
+  "name": "dataset",
+  "variableName": "dataset"
+},
+v7 = {
+  "kind": "Variable",
+  "name": "view",
+  "variableName": "view"
+},
+v8 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v9 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "aspectRatio",
+  "storageKey": null
+},
+v10 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "sample",
+  "storageKey": null
+},
+v11 = {
+  "alias": null,
+  "args": null,
+  "concreteType": "MediaURL",
+  "kind": "LinkedField",
+  "name": "urls",
+  "plural": true,
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "field",
+      "storageKey": null
     },
-    v1 = {
-      defaultValue: null,
-      kind: "LocalArgument",
-      name: "cursor",
-    },
-    v2 = {
-      defaultValue: null,
-      kind: "LocalArgument",
-      name: "dataset",
-    },
-    v3 = {
-      defaultValue: null,
-      kind: "LocalArgument",
-      name: "filter",
-    },
-    v4 = {
-      defaultValue: null,
-      kind: "LocalArgument",
-      name: "pinnedSampleFilter",
-    },
-    v5 = {
-      defaultValue: null,
-      kind: "LocalArgument",
-      name: "view",
-    },
-    v6 = {
-      kind: "Variable",
-      name: "dataset",
-      variableName: "dataset",
-    },
-    v7 = {
-      kind: "Variable",
-      name: "view",
-      variableName: "view",
-    },
-    v8 = {
-      alias: null,
-      args: null,
-      kind: "ScalarField",
-      name: "id",
-      storageKey: null,
-    },
-    v9 = {
-      alias: null,
-      args: null,
-      kind: "ScalarField",
-      name: "aspectRatio",
-      storageKey: null,
-    },
-    v10 = {
-      alias: null,
-      args: null,
-      kind: "ScalarField",
-      name: "sample",
-      storageKey: null,
-    },
-    v11 = {
-      alias: null,
-      args: null,
-      concreteType: "MediaURL",
-      kind: "LinkedField",
-      name: "urls",
-      plural: true,
-      selections: [
-        {
-          alias: null,
-          args: null,
-          kind: "ScalarField",
-          name: "field",
-          storageKey: null,
-        },
-        {
-          alias: null,
-          args: null,
-          kind: "ScalarField",
-          name: "url",
-          storageKey: null,
-        },
-      ],
-      storageKey: null,
-    },
-    v12 = [
-      {
-        alias: null,
-        args: null,
-        kind: "ScalarField",
-        name: "__typename",
-        storageKey: null,
-      },
-      {
-        kind: "InlineFragment",
-        selections: [v8 /*: any*/, v9 /*: any*/, v10 /*: any*/, v11 /*: any*/],
-        type: "ImageSample",
-        abstractKey: null,
-      },
-      {
-        kind: "InlineFragment",
-        selections: [v8 /*: any*/, v10 /*: any*/, v11 /*: any*/],
-        type: "PointCloudSample",
-        abstractKey: null,
-      },
-      {
-        kind: "InlineFragment",
-        selections: [
-          v8 /*: any*/,
-          v9 /*: any*/,
-          {
-            alias: null,
-            args: null,
-            kind: "ScalarField",
-            name: "frameRate",
-            storageKey: null,
-          },
-          v10 /*: any*/,
-          v11 /*: any*/,
-        ],
-        type: "VideoSample",
-        abstractKey: null,
-      },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "url",
+      "storageKey": null
+    }
+  ],
+  "storageKey": null
+},
+v12 = [
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "__typename",
+    "storageKey": null
+  },
+  {
+    "kind": "InlineFragment",
+    "selections": [
+      (v8/*: any*/),
+      (v9/*: any*/),
+      (v10/*: any*/),
+      (v11/*: any*/)
     ],
-    v13 = {
-      alias: null,
-      args: [
-        v6 /*: any*/,
-        {
-          kind: "Variable",
-          name: "filter",
-          variableName: "pinnedSampleFilter",
-        },
-        v7 /*: any*/,
-      ],
-      concreteType: null,
-      kind: "LinkedField",
-      name: "sample",
-      plural: false,
-      selections: v12 /*: any*/,
-      storageKey: null,
-    },
-    v14 = [
+    "type": "ImageSample",
+    "abstractKey": null
+  },
+  {
+    "kind": "InlineFragment",
+    "selections": [
+      (v8/*: any*/),
+      (v10/*: any*/),
+      (v11/*: any*/)
+    ],
+    "type": "PointCloudSample",
+    "abstractKey": null
+  },
+  {
+    "kind": "InlineFragment",
+    "selections": [
+      (v8/*: any*/),
+      (v9/*: any*/),
       {
-        kind: "Variable",
-        name: "after",
-        variableName: "cursor",
+        "alias": null,
+        "args": null,
+        "kind": "ScalarField",
+        "name": "frameRate",
+        "storageKey": null
       },
-      v6 /*: any*/,
+      (v10/*: any*/),
+      (v11/*: any*/)
+    ],
+    "type": "VideoSample",
+    "abstractKey": null
+  }
+],
+v13 = {
+  "alias": null,
+  "args": [
+    (v6/*: any*/),
+    {
+      "kind": "Variable",
+      "name": "filter",
+      "variableName": "pinnedSampleFilter"
+    },
+    (v7/*: any*/)
+  ],
+  "concreteType": null,
+  "kind": "LinkedField",
+  "name": "sample",
+  "plural": false,
+  "selections": (v12/*: any*/),
+  "storageKey": null
+},
+v14 = [
+  {
+    "kind": "Variable",
+    "name": "after",
+    "variableName": "cursor"
+  },
+  (v6/*: any*/),
+  {
+    "kind": "Variable",
+    "name": "filter",
+    "variableName": "filter"
+  },
+  {
+    "kind": "Variable",
+    "name": "first",
+    "variableName": "count"
+  },
+  (v7/*: any*/)
+];
+return {
+  "fragment": {
+    "argumentDefinitions": [
+      (v0/*: any*/),
+      (v1/*: any*/),
+      (v2/*: any*/),
+      (v3/*: any*/),
+      (v4/*: any*/),
+      (v5/*: any*/)
+    ],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "paginateGroupQuery",
+    "selections": [
       {
-        kind: "Variable",
-        name: "filter",
-        variableName: "filter",
+        "args": null,
+        "kind": "FragmentSpread",
+        "name": "paginateGroup_query"
       },
       {
-        kind: "Variable",
-        name: "first",
-        variableName: "count",
+        "kind": "InlineDataFragmentSpread",
+        "name": "paginateGroupPinnedSample_query",
+        "selections": [
+          (v13/*: any*/)
+        ]
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [
+      (v0/*: any*/),
+      (v1/*: any*/),
+      (v2/*: any*/),
+      (v5/*: any*/),
+      (v3/*: any*/),
+      (v4/*: any*/)
+    ],
+    "kind": "Operation",
+    "name": "paginateGroupQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v14/*: any*/),
+        "concreteType": "SampleItemStrConnection",
+        "kind": "LinkedField",
+        "name": "samples",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "total",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "SampleItemStrEdge",
+            "kind": "LinkedField",
+            "name": "edges",
+            "plural": true,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "cursor",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": null,
+                "kind": "LinkedField",
+                "name": "node",
+                "plural": false,
+                "selections": (v12/*: any*/),
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "SampleItemStrPageInfo",
+            "kind": "LinkedField",
+            "name": "pageInfo",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "endCursor",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "hasNextPage",
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
       },
-      v7 /*: any*/,
-    ];
-  return {
-    fragment: {
-      argumentDefinitions: [
-        v0 /*: any*/,
-        v1 /*: any*/,
-        v2 /*: any*/,
-        v3 /*: any*/,
-        v4 /*: any*/,
-        v5 /*: any*/,
-      ],
-      kind: "Fragment",
-      metadata: null,
-      name: "paginateGroupQuery",
-      selections: [
-        {
-          args: null,
-          kind: "FragmentSpread",
-          name: "paginateGroup_query",
-        },
-        {
-          kind: "InlineDataFragmentSpread",
-          name: "paginateGroupPinnedSample_query",
-          selections: [v13 /*: any*/],
-        },
-      ],
-      type: "Query",
-      abstractKey: null,
-    },
-    kind: "Request",
-    operation: {
-      argumentDefinitions: [
-        v0 /*: any*/,
-        v1 /*: any*/,
-        v2 /*: any*/,
-        v5 /*: any*/,
-        v3 /*: any*/,
-        v4 /*: any*/,
-      ],
-      kind: "Operation",
-      name: "paginateGroupQuery",
-      selections: [
-        {
-          alias: null,
-          args: v14 /*: any*/,
-          concreteType: "SampleItemStrConnection",
-          kind: "LinkedField",
-          name: "samples",
-          plural: false,
-          selections: [
-            {
-              alias: null,
-              args: null,
-              kind: "ScalarField",
-              name: "total",
-              storageKey: null,
-            },
-            {
-              alias: null,
-              args: null,
-              concreteType: "SampleItemStrEdge",
-              kind: "LinkedField",
-              name: "edges",
-              plural: true,
-              selections: [
-                {
-                  alias: null,
-                  args: null,
-                  kind: "ScalarField",
-                  name: "cursor",
-                  storageKey: null,
-                },
-                {
-                  alias: null,
-                  args: null,
-                  concreteType: null,
-                  kind: "LinkedField",
-                  name: "node",
-                  plural: false,
-                  selections: v12 /*: any*/,
-                  storageKey: null,
-                },
-              ],
-              storageKey: null,
-            },
-            {
-              alias: null,
-              args: null,
-              concreteType: "SampleItemStrPageInfo",
-              kind: "LinkedField",
-              name: "pageInfo",
-              plural: false,
-              selections: [
-                {
-                  alias: null,
-                  args: null,
-                  kind: "ScalarField",
-                  name: "endCursor",
-                  storageKey: null,
-                },
-                {
-                  alias: null,
-                  args: null,
-                  kind: "ScalarField",
-                  name: "hasNextPage",
-                  storageKey: null,
-                },
-              ],
-              storageKey: null,
-            },
-          ],
-          storageKey: null,
-        },
-        {
-          alias: null,
-          args: v14 /*: any*/,
-          filters: ["dataset", "view", "filter"],
-          handle: "connection",
-          key: "paginateGroup_query_samples",
-          kind: "LinkedHandle",
-          name: "samples",
-        },
-        v13 /*: any*/,
-      ],
-    },
-    params: {
-      cacheID: "a9e21aaa8639bf48b9a5a8a2042d3541",
-      id: null,
-      metadata: {},
-      name: "paginateGroupQuery",
-      operationKind: "query",
-      text: "query paginateGroupQuery(\n  $count: Int = 20\n  $cursor: String = null\n  $dataset: String!\n  $view: BSONArray!\n  $filter: SampleFilter!\n  $pinnedSampleFilter: SampleFilter!\n) {\n  ...paginateGroup_query\n  ...paginateGroupPinnedSample_query\n}\n\nfragment paginateGroupPinnedSample_query on Query {\n  sample(dataset: $dataset, view: $view, filter: $pinnedSampleFilter) {\n    __typename\n    ... on ImageSample {\n      id\n      aspectRatio\n      sample\n      urls {\n        field\n        url\n      }\n    }\n    ... on PointCloudSample {\n      id\n      sample\n      urls {\n        field\n        url\n      }\n    }\n    ... on VideoSample {\n      id\n      aspectRatio\n      frameRate\n      sample\n      urls {\n        field\n        url\n      }\n    }\n  }\n}\n\nfragment paginateGroup_query on Query {\n  samples(dataset: $dataset, view: $view, first: $count, after: $cursor, filter: $filter) {\n    total\n    edges {\n      cursor\n      node {\n        __typename\n        ... on ImageSample {\n          id\n          aspectRatio\n          sample\n          urls {\n            field\n            url\n          }\n        }\n        ... on PointCloudSample {\n          id\n          sample\n          urls {\n            field\n            url\n          }\n        }\n        ... on VideoSample {\n          id\n          aspectRatio\n          frameRate\n          sample\n          urls {\n            field\n            url\n          }\n        }\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n",
-    },
-  };
+      {
+        "alias": null,
+        "args": (v14/*: any*/),
+        "filters": [
+          "dataset",
+          "view",
+          "filter"
+        ],
+        "handle": "connection",
+        "key": "paginateGroup_query_samples",
+        "kind": "LinkedHandle",
+        "name": "samples"
+      },
+      (v13/*: any*/)
+    ]
+  },
+  "params": {
+    "cacheID": "a9e21aaa8639bf48b9a5a8a2042d3541",
+    "id": null,
+    "metadata": {},
+    "name": "paginateGroupQuery",
+    "operationKind": "query",
+    "text": "query paginateGroupQuery(\n  $count: Int = 20\n  $cursor: String = null\n  $dataset: String!\n  $view: BSONArray!\n  $filter: SampleFilter!\n  $pinnedSampleFilter: SampleFilter!\n) {\n  ...paginateGroup_query\n  ...paginateGroupPinnedSample_query\n}\n\nfragment paginateGroupPinnedSample_query on Query {\n  sample(dataset: $dataset, view: $view, filter: $pinnedSampleFilter) {\n    __typename\n    ... on ImageSample {\n      id\n      aspectRatio\n      sample\n      urls {\n        field\n        url\n      }\n    }\n    ... on PointCloudSample {\n      id\n      sample\n      urls {\n        field\n        url\n      }\n    }\n    ... on VideoSample {\n      id\n      aspectRatio\n      frameRate\n      sample\n      urls {\n        field\n        url\n      }\n    }\n  }\n}\n\nfragment paginateGroup_query on Query {\n  samples(dataset: $dataset, view: $view, first: $count, after: $cursor, filter: $filter) {\n    total\n    edges {\n      cursor\n      node {\n        __typename\n        ... on ImageSample {\n          id\n          aspectRatio\n          sample\n          urls {\n            field\n            url\n          }\n        }\n        ... on PointCloudSample {\n          id\n          sample\n          urls {\n            field\n            url\n          }\n        }\n        ... on VideoSample {\n          id\n          aspectRatio\n          frameRate\n          sample\n          urls {\n            field\n            url\n          }\n        }\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
+  }
+};
 })();
 
 (node as any).hash = "e04660582e3fd8867f7144bee2881f52";

--- a/app/packages/relay/src/queries/__generated__/paginateGroup_query.graphql.ts
+++ b/app/packages/relay/src/queries/__generated__/paginateGroup_query.graphql.ts
@@ -8,48 +8,44 @@
 /* eslint-disable */
 // @ts-nocheck
 
-import { ReaderFragment, RefetchableFragment } from "relay-runtime";
+import { ReaderFragment, RefetchableFragment } from 'relay-runtime';
 import { FragmentRefs } from "relay-runtime";
 export type paginateGroup_query$data = {
   readonly samples: {
     readonly edges: ReadonlyArray<{
       readonly cursor: string;
-      readonly node:
-        | {
-            readonly __typename: "ImageSample";
-            readonly aspectRatio: number;
-            readonly id: string;
-            readonly sample: object;
-            readonly urls: ReadonlyArray<{
-              readonly field: string;
-              readonly url: string;
-            }>;
-          }
-        | {
-            readonly __typename: "PointCloudSample";
-            readonly id: string;
-            readonly sample: object;
-            readonly urls: ReadonlyArray<{
-              readonly field: string;
-              readonly url: string;
-            }>;
-          }
-        | {
-            readonly __typename: "VideoSample";
-            readonly aspectRatio: number;
-            readonly frameRate: number;
-            readonly id: string;
-            readonly sample: object;
-            readonly urls: ReadonlyArray<{
-              readonly field: string;
-              readonly url: string;
-            }>;
-          }
-        | {
-            // This will never be '%other', but we need some
-            // value in case none of the concrete values match.
-            readonly __typename: "%other";
-          };
+      readonly node: {
+        readonly __typename: "ImageSample";
+        readonly aspectRatio: number;
+        readonly id: string;
+        readonly sample: object;
+        readonly urls: ReadonlyArray<{
+          readonly field: string;
+          readonly url: string;
+        }>;
+      } | {
+        readonly __typename: "PointCloudSample";
+        readonly id: string;
+        readonly sample: object;
+        readonly urls: ReadonlyArray<{
+          readonly field: string;
+          readonly url: string;
+        }>;
+      } | {
+        readonly __typename: "VideoSample";
+        readonly aspectRatio: number;
+        readonly frameRate: number;
+        readonly id: string;
+        readonly sample: object;
+        readonly urls: ReadonlyArray<{
+          readonly field: string;
+          readonly url: string;
+        }>;
+      } | {
+        // This will never be '%other', but we need some
+        // value in case none of the concrete values match.
+        readonly __typename: "%other";
+      };
     }>;
     readonly total: number | null;
   };
@@ -60,238 +56,244 @@ export type paginateGroup_query$key = {
   readonly " $fragmentSpreads": FragmentRefs<"paginateGroup_query">;
 };
 
-import paginateGroupPageQuery_graphql from "./paginateGroupPageQuery.graphql";
+import paginateGroupPageQuery_graphql from './paginateGroupPageQuery.graphql';
 
-const node: ReaderFragment = (function () {
-  var v0 = ["samples"],
-    v1 = {
-      alias: null,
-      args: null,
-      kind: "ScalarField",
-      name: "id",
-      storageKey: null,
+const node: ReaderFragment = (function(){
+var v0 = [
+  "samples"
+],
+v1 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "aspectRatio",
+  "storageKey": null
+},
+v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "sample",
+  "storageKey": null
+},
+v4 = {
+  "alias": null,
+  "args": null,
+  "concreteType": "MediaURL",
+  "kind": "LinkedField",
+  "name": "urls",
+  "plural": true,
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "field",
+      "storageKey": null
     },
-    v2 = {
-      alias: null,
-      args: null,
-      kind: "ScalarField",
-      name: "aspectRatio",
-      storageKey: null,
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "url",
+      "storageKey": null
+    }
+  ],
+  "storageKey": null
+};
+return {
+  "argumentDefinitions": [
+    {
+      "kind": "RootArgument",
+      "name": "count"
     },
-    v3 = {
-      alias: null,
-      args: null,
-      kind: "ScalarField",
-      name: "sample",
-      storageKey: null,
+    {
+      "kind": "RootArgument",
+      "name": "cursor"
     },
-    v4 = {
-      alias: null,
-      args: null,
-      concreteType: "MediaURL",
-      kind: "LinkedField",
-      name: "urls",
-      plural: true,
-      selections: [
-        {
-          alias: null,
-          args: null,
-          kind: "ScalarField",
-          name: "field",
-          storageKey: null,
-        },
-        {
-          alias: null,
-          args: null,
-          kind: "ScalarField",
-          name: "url",
-          storageKey: null,
-        },
-      ],
-      storageKey: null,
-    };
-  return {
-    argumentDefinitions: [
+    {
+      "kind": "RootArgument",
+      "name": "dataset"
+    },
+    {
+      "kind": "RootArgument",
+      "name": "filter"
+    },
+    {
+      "kind": "RootArgument",
+      "name": "view"
+    }
+  ],
+  "kind": "Fragment",
+  "metadata": {
+    "connection": [
       {
-        kind: "RootArgument",
-        name: "count",
-      },
-      {
-        kind: "RootArgument",
-        name: "cursor",
-      },
-      {
-        kind: "RootArgument",
-        name: "dataset",
-      },
-      {
-        kind: "RootArgument",
-        name: "filter",
-      },
-      {
-        kind: "RootArgument",
-        name: "view",
-      },
+        "count": "count",
+        "cursor": "cursor",
+        "direction": "forward",
+        "path": (v0/*: any*/)
+      }
     ],
-    kind: "Fragment",
-    metadata: {
-      connection: [
+    "refetch": {
+      "connection": {
+        "forward": {
+          "count": "count",
+          "cursor": "cursor"
+        },
+        "backward": null,
+        "path": (v0/*: any*/)
+      },
+      "fragmentPathInResult": [],
+      "operation": paginateGroupPageQuery_graphql
+    }
+  },
+  "name": "paginateGroup_query",
+  "selections": [
+    {
+      "alias": "samples",
+      "args": [
         {
-          count: "count",
-          cursor: "cursor",
-          direction: "forward",
-          path: v0 /*: any*/,
+          "kind": "Variable",
+          "name": "dataset",
+          "variableName": "dataset"
         },
+        {
+          "kind": "Variable",
+          "name": "filter",
+          "variableName": "filter"
+        },
+        {
+          "kind": "Variable",
+          "name": "view",
+          "variableName": "view"
+        }
       ],
-      refetch: {
-        connection: {
-          forward: {
-            count: "count",
-            cursor: "cursor",
-          },
-          backward: null,
-          path: v0 /*: any*/,
+      "concreteType": "SampleItemStrConnection",
+      "kind": "LinkedField",
+      "name": "__paginateGroup_query_samples_connection",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "total",
+          "storageKey": null
         },
-        fragmentPathInResult: [],
-        operation: paginateGroupPageQuery_graphql,
-      },
-    },
-    name: "paginateGroup_query",
-    selections: [
-      {
-        alias: "samples",
-        args: [
-          {
-            kind: "Variable",
-            name: "dataset",
-            variableName: "dataset",
-          },
-          {
-            kind: "Variable",
-            name: "filter",
-            variableName: "filter",
-          },
-          {
-            kind: "Variable",
-            name: "view",
-            variableName: "view",
-          },
-        ],
-        concreteType: "SampleItemStrConnection",
-        kind: "LinkedField",
-        name: "__paginateGroup_query_samples_connection",
-        plural: false,
-        selections: [
-          {
-            alias: null,
-            args: null,
-            kind: "ScalarField",
-            name: "total",
-            storageKey: null,
-          },
-          {
-            alias: null,
-            args: null,
-            concreteType: "SampleItemStrEdge",
-            kind: "LinkedField",
-            name: "edges",
-            plural: true,
-            selections: [
-              {
-                alias: null,
-                args: null,
-                kind: "ScalarField",
-                name: "cursor",
-                storageKey: null,
-              },
-              {
-                alias: null,
-                args: null,
-                concreteType: null,
-                kind: "LinkedField",
-                name: "node",
-                plural: false,
-                selections: [
-                  {
-                    alias: null,
-                    args: null,
-                    kind: "ScalarField",
-                    name: "__typename",
-                    storageKey: null,
-                  },
-                  {
-                    kind: "InlineFragment",
-                    selections: [
-                      v1 /*: any*/,
-                      v2 /*: any*/,
-                      v3 /*: any*/,
-                      v4 /*: any*/,
-                    ],
-                    type: "ImageSample",
-                    abstractKey: null,
-                  },
-                  {
-                    kind: "InlineFragment",
-                    selections: [v1 /*: any*/, v3 /*: any*/, v4 /*: any*/],
-                    type: "PointCloudSample",
-                    abstractKey: null,
-                  },
-                  {
-                    kind: "InlineFragment",
-                    selections: [
-                      v1 /*: any*/,
-                      v2 /*: any*/,
-                      {
-                        alias: null,
-                        args: null,
-                        kind: "ScalarField",
-                        name: "frameRate",
-                        storageKey: null,
-                      },
-                      v3 /*: any*/,
-                      v4 /*: any*/,
-                    ],
-                    type: "VideoSample",
-                    abstractKey: null,
-                  },
-                ],
-                storageKey: null,
-              },
-            ],
-            storageKey: null,
-          },
-          {
-            alias: null,
-            args: null,
-            concreteType: "SampleItemStrPageInfo",
-            kind: "LinkedField",
-            name: "pageInfo",
-            plural: false,
-            selections: [
-              {
-                alias: null,
-                args: null,
-                kind: "ScalarField",
-                name: "endCursor",
-                storageKey: null,
-              },
-              {
-                alias: null,
-                args: null,
-                kind: "ScalarField",
-                name: "hasNextPage",
-                storageKey: null,
-              },
-            ],
-            storageKey: null,
-          },
-        ],
-        storageKey: null,
-      },
-    ],
-    type: "Query",
-    abstractKey: null,
-  };
+        {
+          "alias": null,
+          "args": null,
+          "concreteType": "SampleItemStrEdge",
+          "kind": "LinkedField",
+          "name": "edges",
+          "plural": true,
+          "selections": [
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "cursor",
+              "storageKey": null
+            },
+            {
+              "alias": null,
+              "args": null,
+              "concreteType": null,
+              "kind": "LinkedField",
+              "name": "node",
+              "plural": false,
+              "selections": [
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "__typename",
+                  "storageKey": null
+                },
+                {
+                  "kind": "InlineFragment",
+                  "selections": [
+                    (v1/*: any*/),
+                    (v2/*: any*/),
+                    (v3/*: any*/),
+                    (v4/*: any*/)
+                  ],
+                  "type": "ImageSample",
+                  "abstractKey": null
+                },
+                {
+                  "kind": "InlineFragment",
+                  "selections": [
+                    (v1/*: any*/),
+                    (v3/*: any*/),
+                    (v4/*: any*/)
+                  ],
+                  "type": "PointCloudSample",
+                  "abstractKey": null
+                },
+                {
+                  "kind": "InlineFragment",
+                  "selections": [
+                    (v1/*: any*/),
+                    (v2/*: any*/),
+                    {
+                      "alias": null,
+                      "args": null,
+                      "kind": "ScalarField",
+                      "name": "frameRate",
+                      "storageKey": null
+                    },
+                    (v3/*: any*/),
+                    (v4/*: any*/)
+                  ],
+                  "type": "VideoSample",
+                  "abstractKey": null
+                }
+              ],
+              "storageKey": null
+            }
+          ],
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "concreteType": "SampleItemStrPageInfo",
+          "kind": "LinkedField",
+          "name": "pageInfo",
+          "plural": false,
+          "selections": [
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "endCursor",
+              "storageKey": null
+            },
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "hasNextPage",
+              "storageKey": null
+            }
+          ],
+          "storageKey": null
+        }
+      ],
+      "storageKey": null
+    }
+  ],
+  "type": "Query",
+  "abstractKey": null
+};
 })();
 
 (node as any).hash = "20891cc18082d493738d44781ff64148";

--- a/app/packages/state/package.json
+++ b/app/packages/state/package.json
@@ -25,7 +25,6 @@
         "recoil-relay": "*"
     },
     "devDependencies": {
-        "@fiftyone/prettier-config": "*",
         "prettier": "^2.7.1",
         "typescript": "^4.7.4",
         "vite": "^3.0.0"

--- a/app/packages/utilities/package.json
+++ b/app/packages/utilities/package.json
@@ -17,7 +17,6 @@
         "README.md"
     ],
     "devDependencies": {
-        "@fiftyone/prettier-config": "*",
         "prettier": "^2.7.1",
         "typescript": "^4.7.4",
         "typescript-plugin-css-modules": "^3.4.0",

--- a/app/packages/utilities/package.json
+++ b/app/packages/utilities/package.json
@@ -1,32 +1,31 @@
 {
-  "name": "@fiftyone/utilities",
-  "author": "Voxel51, Inc.",
-  "version": "0.0.0",
-  "description": "Generic JavaScript utilities for the FiftyOne monorepo",
-  "homepage": "https://github.com/voxel51/fiftyone/app/packages/utilities",
-  "license": "Apache-2.0",
-  "bugs": {
-    "url": "https://github.com/voxel51/fiftyone/"
-  },
-  "main": "./src/index.ts",
-  "scripts": {
-    "dev": "vite"
-  },
-  "prettier": "@fiftyone/prettier-config",
-  "files": [
-    "dist",
-    "README.md"
-  ],
-  "devDependencies": {
-    "@fiftyone/prettier-config": "*",
-    "prettier": "^2.7.1",
-    "typescript": "^4.7.4",
-    "typescript-plugin-css-modules": "^3.4.0",
-    "vite": "^3.0.0"
-  },
-  "dependencies": {
-    "@microsoft/fetch-event-source": "^2.0.1",
-    "lodash": "^4.17.21",
-    "mime": "^2.5.2"
-  }
+    "name": "@fiftyone/utilities",
+    "author": "Voxel51, Inc.",
+    "version": "0.0.0",
+    "description": "Generic JavaScript utilities for the FiftyOne monorepo",
+    "homepage": "https://github.com/voxel51/fiftyone/app/packages/utilities",
+    "license": "Apache-2.0",
+    "bugs": {
+        "url": "https://github.com/voxel51/fiftyone/"
+    },
+    "main": "./src/index.ts",
+    "scripts": {
+        "dev": "vite"
+    },
+    "files": [
+        "dist",
+        "README.md"
+    ],
+    "devDependencies": {
+        "@fiftyone/prettier-config": "*",
+        "prettier": "^2.7.1",
+        "typescript": "^4.7.4",
+        "typescript-plugin-css-modules": "^3.4.0",
+        "vite": "^3.0.0"
+    },
+    "dependencies": {
+        "@microsoft/fetch-event-source": "^2.0.1",
+        "lodash": "^4.17.21",
+        "mime": "^2.5.2"
+    }
 }

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -2356,7 +2356,6 @@ __metadata:
   resolution: "@fiftyone/aggregations@workspace:packages/aggregations"
   dependencies:
     "@babel/preset-typescript": ^7.17.12
-    "@fiftyone/prettier-config": "*"
     "@types/react": ^18.0.12
     fs-extra: ^10.1.0
     jest: ^28.1.1
@@ -2376,7 +2375,6 @@ __metadata:
     "@fiftyone/flashlight": "*"
     "@fiftyone/looker": "*"
     "@fiftyone/map": "*"
-    "@fiftyone/prettier-config": "*"
     "@fiftyone/state": "*"
     "@fiftyone/utilities": "*"
     "@material-ui/core": 4.11.4
@@ -2435,7 +2433,6 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@fiftyone/components@workspace:packages/components"
   dependencies:
-    "@fiftyone/prettier-config": "*"
     "@fiftyone/state": "*"
     "@types/react-input-autosize": ^2.2.1
     classnames: ^2.3.1
@@ -2467,7 +2464,6 @@ __metadata:
     "@fiftyone/flashlight": "*"
     "@fiftyone/looker": "*"
     "@fiftyone/map": "*"
-    "@fiftyone/prettier-config": "*"
     "@fiftyone/state": "*"
     "@fiftyone/utilities": "*"
     "@material-ui/core": 4.11.4
@@ -2527,7 +2523,6 @@ __metadata:
   resolution: "@fiftyone/dataset@workspace:packages/dataset"
   dependencies:
     "@fiftyone/core": "*"
-    "@fiftyone/prettier-config": "*"
     prettier: ^2.7.1
     typescript: ^4.7.4
     typescript-plugin-css-modules: ^3.4.0
@@ -2550,7 +2545,6 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@fiftyone/flashlight@workspace:packages/flashlight"
   dependencies:
-    "@fiftyone/prettier-config": "*"
     prettier: ^2.7.1
     typescript: ^4.7.4
     typescript-plugin-css-modules: ^3.4.0
@@ -2587,7 +2581,6 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@fiftyone/looker@workspace:packages/looker"
   dependencies:
-    "@fiftyone/prettier-config": "*"
     "@types/color-string": ^1.5.0
     "@types/lru-cache": ^5.1.0
     "@types/uuid": ^8.3.0
@@ -2638,7 +2631,6 @@ __metadata:
   resolution: "@fiftyone/plugins@workspace:packages/plugins"
   dependencies:
     "@babel/preset-typescript": ^7.17.12
-    "@fiftyone/prettier-config": "*"
     "@fiftyone/utilities": "workspace:^"
     "@types/react": ^18.0.12
     jest: ^28.1.1
@@ -2648,17 +2640,10 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@fiftyone/prettier-config@*, @fiftyone/prettier-config@workspace:packages/prettier-config":
-  version: 0.0.0-use.local
-  resolution: "@fiftyone/prettier-config@workspace:packages/prettier-config"
-  languageName: unknown
-  linkType: soft
-
 "@fiftyone/relay@*, @fiftyone/relay@workspace:packages/relay":
   version: 0.0.0-use.local
   resolution: "@fiftyone/relay@workspace:packages/relay"
   dependencies:
-    "@fiftyone/prettier-config": "*"
     prettier: ^2.7.1
     react-relay: ^14.0.0
     relay-compiler: ^14.0.0
@@ -2673,7 +2658,6 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@fiftyone/state@workspace:packages/state"
   dependencies:
-    "@fiftyone/prettier-config": "*"
     "@fiftyone/relay": "*"
     "@fiftyone/utilities": "*"
     "@microsoft/fetch-event-source": ^2.0.1
@@ -2694,7 +2678,6 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@fiftyone/utilities@workspace:packages/utilities"
   dependencies:
-    "@fiftyone/prettier-config": "*"
     "@microsoft/fetch-event-source": ^2.0.1
     lodash: ^4.17.21
     mime: ^2.5.2


### PR DESCRIPTION
Fixes relay compilation in @fiftyone/core and ensures future breaking changes will be caught in workflows via the `yarn build` script in @fiftyone/app.

Also removes unused prettier code in the app and adds __generated__ files created by relay to the .prettierignore which I find more convenient than compiling and reformatting every time via pre-commit.