### PR TITLE
Adding support for field descriptions (option 1)

### DIFF
--- a/docs/source/user_guide/using_datasets.rst
+++ b/docs/source/user_guide/using_datasets.rst
@@ -334,11 +334,6 @@ to update a field's metadata at any time:
     field = dataset.get_field("ground_truth.detections.area")
     print(field.description)  # Area of the box, in pixels^2
 
-.. note::
-
-    Did you know? You can view/edit field metadata directly
-    :ref:`in the App <fiftyone-app>`!
-
 .. _custom-app-config:
 
 Custom App config

--- a/docs/source/user_guide/using_datasets.rst
+++ b/docs/source/user_guide/using_datasets.rst
@@ -280,6 +280,65 @@ Datasets can also store more specific types of ancillary information such as
     the dataset's :meth:`info <fiftyone.core.dataset.Dataset.info>` property
     in-place to save the changes to the database.
 
+.. _storing-field-metadata:
+
+Storing field metadata
+----------------------
+
+You can store metadata such as descriptions on the :ref:`fields <using-fields>`
+of your dataset.
+
+One approach is to manually declare the field with
+:ref:`add_sample_field() <fiftyone.core.dataset.Dataset.add_sample_field>` with
+the appropriate metadata provided:
+
+.. code-block:: python
+    :linenos:
+
+    import fiftyone as fo
+
+    dataset = fo.Dataset()
+    dataset.add_sample_field(
+        "int_field", fo.IntField, description="An integer field"
+    )
+
+    field = dataset.get_field("int_field")
+    print(field.description)  # An integer field
+
+You can also use
+:ref:`set_field_metadata() <fiftyone.core.dataset.Dataset.set_field_metadata>`
+to update a field's metadata at any time:
+
+.. code-block:: python
+    :linenos:
+
+    import fiftyone as fo
+    import fiftyone.zoo as foz
+
+    dataset = foz.load_zoo_dataset("quickstart")
+    dataset.add_dynamic_sample_fields()
+
+    dataset.set_field_metadata(
+        "ground_truth",
+        description="Ground truth annotations",
+    )
+
+    dataset.set_field_metadata(
+        "ground_truth.detections.area",
+        description="Area of the box, in pixels^2",
+    )
+
+    field = dataset.get_field("ground_truth")
+    print(field.description)  # Ground truth annotations
+
+    field = dataset.get_field("ground_truth.detections.area")
+    print(field.description)  # Area of the box, in pixels^2
+
+.. note::
+
+    Did you know? You can view/edit field metadata directly
+    :ref:`in the App <fiftyone-app>`!
+
 .. _custom-app-config:
 
 Custom App config

--- a/docs/source/user_guide/using_datasets.rst
+++ b/docs/source/user_guide/using_datasets.rst
@@ -289,8 +289,8 @@ You can store metadata such as descriptions on the :ref:`fields <using-fields>`
 of your dataset.
 
 One approach is to manually declare the field with
-:ref:`add_sample_field() <fiftyone.core.dataset.Dataset.add_sample_field>` with
-the appropriate metadata provided:
+:meth:`add_sample_field() <fiftyone.core.dataset.Dataset.add_sample_field>`
+with the appropriate metadata provided:
 
 .. code-block:: python
     :linenos:
@@ -306,7 +306,7 @@ the appropriate metadata provided:
     print(field.description)  # An integer field
 
 You can also use
-:ref:`set_field_metadata() <fiftyone.core.dataset.Dataset.set_field_metadata>`
+:meth:`set_field_metadata() <fiftyone.core.dataset.Dataset.set_field_metadata>`
 to update a field's metadata at any time:
 
 .. code-block:: python

--- a/docs/source/user_guide/using_datasets.rst
+++ b/docs/source/user_guide/using_datasets.rst
@@ -929,6 +929,11 @@ printing it:
         tags:       fiftyone.core.fields.ListField(fiftyone.core.fields.StringField)
         metadata:   fiftyone.core.fields.EmbeddedDocumentField(fiftyone.core.metadata.ImageMetadata)
 
+.. note::
+
+    Did you know? You can :ref:`store metadata <storing-field-metadata>` such
+    as descriptions on your dataset's fields!
+
 .. _adding-sample-fields:
 
 Adding fields to a sample

--- a/fiftyone/constants.py
+++ b/fiftyone/constants.py
@@ -40,7 +40,7 @@ RESOURCES_DIR = os.path.join(FIFTYONE_DIR, "resources")
 # This setting may be ``None`` if this client has no compatibility with other
 # versions
 #
-COMPATIBLE_VERSIONS = ">=0.16.6,<0.18"
+COMPATIBLE_VERSIONS = ">=0.16.6,<0.19"
 
 # Package metadata
 _META = metadata("fiftyone")

--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -578,12 +578,8 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
         if name in list_datasets():
             raise ValueError("A dataset with name '%s' already exists" % name)
 
-        try:
-            self._doc.name = name
-            self._doc.save()
-        except:
-            self._doc.name = _name
-            raise
+        self._doc.name = name
+        self._doc.save(safe=True)
 
         # Update singleton
         self._instances.pop(_name, None)
@@ -608,13 +604,8 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
 
     @persistent.setter
     def persistent(self, value):
-        _value = self._doc.persistent
-        try:
-            self._doc.persistent = value
-            self._doc.save()
-        except:
-            self._doc.persistent = _value
-            raise
+        self._doc.persistent = value
+        self._doc.save(safe=True)
 
     @property
     def tags(self):
@@ -638,13 +629,8 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
 
     @tags.setter
     def tags(self, value):
-        _value = self._doc.tags
-        try:
-            self._doc.tags = value
-            self._doc.save()
-        except:
-            self._doc.tags = _value
-            raise
+        self._doc.tags = value
+        self._doc.save(safe=True)
 
     @property
     def info(self):
@@ -668,7 +654,7 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
     @info.setter
     def info(self, info):
         self._doc.info = info
-        self._doc.save()
+        self._doc.save(safe=True)
 
     @property
     def app_config(self):
@@ -707,6 +693,7 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
     @app_config.setter
     def app_config(self, config):
         self._doc.app_config = config
+        self._doc.save(safe=True)
 
     @property
     def classes(self):
@@ -734,7 +721,7 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
     @classes.setter
     def classes(self, classes):
         self._doc.classes = classes
-        self.save()
+        self._doc.save(safe=True)
 
     @property
     def default_classes(self):
@@ -760,7 +747,7 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
     @default_classes.setter
     def default_classes(self, classes):
         self._doc.default_classes = classes
-        self.save()
+        self._doc.save(safe=True)
 
     @property
     def mask_targets(self):
@@ -794,7 +781,7 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
     @mask_targets.setter
     def mask_targets(self, targets):
         self._doc.mask_targets = targets
-        self.save()
+        self._doc.save(safe=True)
 
     @property
     def default_mask_targets(self):
@@ -826,7 +813,7 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
     @default_mask_targets.setter
     def default_mask_targets(self, targets):
         self._doc.default_mask_targets = targets
-        self.save()
+        self._doc.save(safe=True)
 
     @property
     def skeletons(self):
@@ -862,7 +849,7 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
     @skeletons.setter
     def skeletons(self, skeletons):
         self._doc.skeletons = skeletons
-        self.save()
+        self._doc.save(safe=True)
 
     @property
     def default_skeleton(self):
@@ -895,7 +882,7 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
     @default_skeleton.setter
     def default_skeleton(self, skeleton):
         self._doc.default_skeleton = skeleton
-        self.save()
+        self._doc.save(safe=True)
 
     @property
     def deleted(self):

--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -674,7 +674,7 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
 
             dataset.set_field_metadata(
                 "ground_truth.detections.area",
-                description="The area of the box, in pixels^2",
+                description="Area of the box, in pixels^2",
             )
 
             field = dataset.get_field("ground_truth")

--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -1153,6 +1153,7 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
         embedded_doc_type=None,
         subfield=None,
         fields=None,
+        description=None,
         **kwargs,
     ):
         """Adds a new sample field or embedded field to the dataset, if
@@ -1174,6 +1175,7 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
                 instances defining embedded document attributes. Only
                 applicable when ``ftype`` is
                 :class:`fiftyone.core.fields.EmbeddedDocumentField`
+            description (None): an optional description
 
         Raises:
             ValueError: if a field of the same name already exists and it is
@@ -1182,7 +1184,9 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
         if embedded_doc_type is not None and issubclass(
             embedded_doc_type, fog.Group
         ):
-            expanded = self._add_group_field(field_name)
+            expanded = self._add_group_field(
+                field_name, description=description
+            )
         else:
             expanded = self._sample_doc_cls.add_field(
                 field_name,
@@ -1190,6 +1194,7 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
                 embedded_doc_type=embedded_doc_type,
                 subfield=subfield,
                 fields=fields,
+                description=description,
                 dataset_doc=self._doc,
                 **kwargs,
             )
@@ -1254,6 +1259,7 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
         embedded_doc_type=None,
         subfield=None,
         fields=None,
+        description=None,
         **kwargs,
     ):
         """Adds a new frame-level field or embedded field to the dataset, if
@@ -1277,6 +1283,7 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
                 instances defining embedded document attributes. Only
                 applicable when ``ftype`` is
                 :class:`fiftyone.core.fields.EmbeddedDocumentField`
+            description (None): an optional description
 
         Raises:
             ValueError: if a field of the same name already exists and it is
@@ -1293,6 +1300,7 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
             embedded_doc_type=embedded_doc_type,
             subfield=subfield,
             fields=fields,
+            description=description,
             dataset_doc=self._doc,
             **kwargs,
         )
@@ -1357,26 +1365,30 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
         if expanded:
             self._reload()
 
-    def add_group_field(self, field_name, default=None):
+    def add_group_field(self, field_name, default=None, description=None):
         """Adds a group field to the dataset, if necessary.
 
         Args:
             field_name: the field name
             default (None): a default group slice for the field
+            description (None): an optional description
 
         Raises:
             ValueError: if a group field with another name already exists
         """
-        expanded = self._add_group_field(field_name, default=default)
+        expanded = self._add_group_field(
+            field_name, default=default, description=description
+        )
 
         if expanded:
             self._reload()
 
-    def _add_group_field(self, field_name, default=None):
+    def _add_group_field(self, field_name, default=None, description=None):
         expanded = self._sample_doc_cls.add_field(
             field_name,
             fof.EmbeddedDocumentField,
             embedded_doc_type=fog.Group,
+            description=description,
             dataset_doc=self._doc,
         )
 

--- a/fiftyone/core/fields.py
+++ b/fiftyone/core/fields.py
@@ -967,7 +967,7 @@ class EmbeddedDocumentField(mongoengine.fields.EmbeddedDocumentField, Field):
 
     def __init__(self, document_type, description=None, **kwargs):
         super().__init__(document_type, **kwargs)
-        self.description = None
+        self.description = description
         self.fields = kwargs.get("fields", [])
 
         self._selected_fields = None

--- a/fiftyone/core/fields.py
+++ b/fiftyone/core/fields.py
@@ -225,7 +225,15 @@ def _flatten(
 
 
 class Field(mongoengine.fields.BaseField):
-    """Base class for :class:`fiftyone.core.sample.Sample` fields."""
+    """Base class for :class:`fiftyone.core.sample.Sample` fields.
+
+    Args:
+        description (None): an optional description
+    """
+
+    def __init__(self, description=None, **kwargs):
+        super().__init__(**kwargs)
+        self.description = description
 
     def __str__(self):
         return etau.get_class_name(self)
@@ -235,7 +243,15 @@ class Field(mongoengine.fields.BaseField):
 
 
 class IntField(mongoengine.fields.IntField, Field):
-    """A 32 bit integer field."""
+    """A 32 bit integer field.
+
+    Args:
+        description (None): an optional description
+    """
+
+    def __init__(self, description=None, **kwargs):
+        super().__init__(**kwargs)
+        self.description = description
 
     def to_mongo(self, value):
         if value is None:
@@ -245,7 +261,15 @@ class IntField(mongoengine.fields.IntField, Field):
 
 
 class ObjectIdField(mongoengine.fields.ObjectIdField, Field):
-    """An Object ID field."""
+    """An Object ID field.
+
+    Args:
+        description (None): an optional description
+    """
+
+    def __init__(self, description=None, **kwargs):
+        super().__init__(**kwargs)
+        self.description = description
 
     def to_mongo(self, value):
         if value is None:
@@ -261,13 +285,27 @@ class ObjectIdField(mongoengine.fields.ObjectIdField, Field):
 
 
 class UUIDField(mongoengine.fields.UUIDField, Field):
-    """A UUID field."""
+    """A UUID field.
 
-    pass
+    Args:
+        description (None): an optional description
+    """
+
+    def __init__(self, description=None, **kwargs):
+        super().__init__(**kwargs)
+        self.description = description
 
 
 class BooleanField(mongoengine.fields.BooleanField, Field):
-    """A boolean field."""
+    """A boolean field.
+
+    Args:
+        description (None): an optional description
+    """
+
+    def __init__(self, description=None, **kwargs):
+        super().__init__(**kwargs)
+        self.description = description
 
     def validate(self, value):
         if not isinstance(value, (bool, np.bool_)):
@@ -275,7 +313,15 @@ class BooleanField(mongoengine.fields.BooleanField, Field):
 
 
 class DateField(mongoengine.fields.DateField, Field):
-    """A date field."""
+    """A date field.
+
+    Args:
+        description (None): an optional description
+    """
+
+    def __init__(self, description=None, **kwargs):
+        super().__init__(**kwargs)
+        self.description = description
 
     def to_mongo(self, value):
         if value is None:
@@ -298,7 +344,15 @@ class DateField(mongoengine.fields.DateField, Field):
 
 
 class DateTimeField(mongoengine.fields.DateTimeField, Field):
-    """A datetime field."""
+    """A datetime field.
+
+    Args:
+        description (None): an optional description
+    """
+
+    def __init__(self, description=None, **kwargs):
+        super().__init__(**kwargs)
+        self.description = description
 
     def validate(self, value):
         if not isinstance(value, datetime):
@@ -306,7 +360,15 @@ class DateTimeField(mongoengine.fields.DateTimeField, Field):
 
 
 class FloatField(mongoengine.fields.FloatField, Field):
-    """A floating point number field."""
+    """A floating point number field.
+
+    Args:
+        description (None): an optional description
+    """
+
+    def __init__(self, description=None, **kwargs):
+        super().__init__(**kwargs)
+        self.description = description
 
     def to_mongo(self, value):
         if value is None:
@@ -330,9 +392,15 @@ class FloatField(mongoengine.fields.FloatField, Field):
 
 
 class StringField(mongoengine.fields.StringField, Field):
-    """A unicode string field."""
+    """A unicode string field.
 
-    pass
+    Args:
+        description (None): an optional description
+    """
+
+    def __init__(self, description=None, **kwargs):
+        super().__init__(**kwargs)
+        self.description = description
 
 
 class ListField(mongoengine.fields.ListField, Field):
@@ -344,9 +412,10 @@ class ListField(mongoengine.fields.ListField, Field):
     Args:
         field (None): an optional :class:`Field` instance describing the
             type of the list elements
+        description (None): an optional description
     """
 
-    def __init__(self, field=None, **kwargs):
+    def __init__(self, field=None, description=None, **kwargs):
         if field is not None:
             if not isinstance(field, Field):
                 raise ValueError(
@@ -355,6 +424,7 @@ class ListField(mongoengine.fields.ListField, Field):
                 )
 
         super().__init__(field=field, **kwargs)
+        self.description = description
 
     def __str__(self):
         if self.field is not None:
@@ -369,9 +439,12 @@ class ListField(mongoengine.fields.ListField, Field):
 class HeatmapRangeField(ListField):
     """A ``[min, max]`` range of the values in a
     :class:`fiftyone.core.labels.Heatmap`.
+
+    Args:
+        description (None): an optional description
     """
 
-    def __init__(self, **kwargs):
+    def __init__(self, description=None, **kwargs):
         if "null" not in kwargs:
             kwargs["null"] = True
 
@@ -379,6 +452,7 @@ class HeatmapRangeField(ListField):
             kwargs["field"] = FloatField()
 
         super().__init__(**kwargs)
+        self.description = description
 
     def __str__(self):
         return etau.get_class_name(self)
@@ -400,9 +474,10 @@ class DictField(mongoengine.fields.DictField, Field):
     Args:
         field (None): an optional :class:`Field` instance describing the type
             of the values in the dict
+        description (None): an optional description
     """
 
-    def __init__(self, field=None, **kwargs):
+    def __init__(self, field=None, description=None, **kwargs):
         if field is not None:
             if not isinstance(field, Field):
                 raise ValueError(
@@ -411,6 +486,7 @@ class DictField(mongoengine.fields.DictField, Field):
                 )
 
         super().__init__(field=field, **kwargs)
+        self.description = description
 
     def __str__(self):
         if self.field is not None:
@@ -441,6 +517,7 @@ class IntDictField(DictField):
     Args:
         field (None): an optional :class:`Field` instance describing the type
             of the values in the dict
+        description (None): an optional description
     """
 
     def to_mongo(self, value):
@@ -472,10 +549,14 @@ class KeypointsField(ListField):
     """A list of ``(x, y)`` coordinate pairs.
 
     If this field is not set, its default value is ``[]``.
+
+    Args:
+        description (None): an optional description
     """
 
-    def __init__(self, **kwargs):
+    def __init__(self, description=None, **kwargs):
         super().__init__(field=None, **kwargs)
+        self.description = description
 
     def __str__(self):
         return etau.get_class_name(self)
@@ -493,10 +574,14 @@ class PolylinePointsField(ListField):
     """A list of lists of ``(x, y)`` coordinate pairs.
 
     If this field is not set, its default value is ``[]``.
+
+    Args:
+        description (None): an optional description
     """
 
-    def __init__(self, **kwargs):
+    def __init__(self, description=None, **kwargs):
         super().__init__(field=None, **kwargs)
+        self.description = description
 
     def __str__(self):
         return etau.get_class_name(self)
@@ -522,10 +607,18 @@ class PolylinePointsField(ListField):
 
 
 class _GeoField(Field):
-    """Base class for GeoJSON fields."""
+    """Base class for GeoJSON fields.
+
+    Args:
+        description (None): an optional description
+    """
 
     # The GeoJSON type of the field. Subclasses must implement this
     _TYPE = None
+
+    def __init__(self, description=None, **kwargs):
+        super().__init__(**kwargs)
+        self.description = description
 
     def to_mongo(self, value):
         if isinstance(value, dict):
@@ -544,9 +637,16 @@ class GeoPointField(_GeoField, mongoengine.fields.PointField):
     """A GeoJSON field storing a longitude and latitude coordinate point.
 
     The data is stored as ``[longitude, latitude]``.
+
+    Args:
+        description (None): an optional description
     """
 
     _TYPE = "Point"
+
+    def __init__(self, description=None, **kwargs):
+        super().__init__(**kwargs)
+        self.description = description
 
     def validate(self, value):
         if isinstance(value, dict):
@@ -558,12 +658,19 @@ class GeoPointField(_GeoField, mongoengine.fields.PointField):
 class GeoLineStringField(_GeoField, mongoengine.fields.LineStringField):
     """A GeoJSON field storing a line of longitude and latitude coordinates.
 
-    The data is stored as follow::
+    The data is stored as follows::
 
         [[lon1, lat1], [lon2, lat2], ...]
+
+    Args:
+        description (None): an optional description
     """
 
     _TYPE = "LineString"
+
+    def __init__(self, description=None, **kwargs):
+        super().__init__(**kwargs)
+        self.description = description
 
     def validate(self, value):
         if isinstance(value, dict):
@@ -585,9 +692,16 @@ class GeoPolygonField(_GeoField, mongoengine.fields.PolygonField):
 
     where the first element describes the boundary of the polygon and any
     remaining entries describe holes.
+
+    Args:
+        description (None): an optional description
     """
 
     _TYPE = "Polygon"
+
+    def __init__(self, description=None, **kwargs):
+        super().__init__(**kwargs)
+        self.description = description
 
     def validate(self, value):
         if isinstance(value, dict):
@@ -602,9 +716,16 @@ class GeoMultiPointField(_GeoField, mongoengine.fields.MultiPointField):
     The data is stored as follows::
 
         [[lon1, lat1], [lon2, lat2], ...]
+
+    Args:
+        description (None): an optional description
     """
 
     _TYPE = "MultiPoint"
+
+    def __init__(self, description=None, **kwargs):
+        super().__init__(**kwargs)
+        self.description = description
 
     def validate(self, value):
         if isinstance(value, dict):
@@ -625,9 +746,16 @@ class GeoMultiLineStringField(
             [[lon1, lat1], [lon2, lat2], ...],
             ...
         ]
+
+    Args:
+        description (None): an optional description
     """
 
     _TYPE = "MultiLineString"
+
+    def __init__(self, description=None, **kwargs):
+        super().__init__(**kwargs)
+        self.description = description
 
     def validate(self, value):
         if isinstance(value, dict):
@@ -654,9 +782,16 @@ class GeoMultiPolygonField(_GeoField, mongoengine.fields.MultiPolygonField):
             ],
             ...
         ]
+
+    Args:
+        description (None): an optional description
     """
 
     _TYPE = "MultiPolygon"
+
+    def __init__(self, description=None, **kwargs):
+        super().__init__(**kwargs)
+        self.description = description
 
     def validate(self, value):
         if isinstance(value, dict):
@@ -672,7 +807,14 @@ class VectorField(mongoengine.fields.BinaryField, Field):
     array values. The underlying data is serialized and stored in the database
     as zlib-compressed bytes generated by ``numpy.save`` and always retrieved
     as a numpy array.
+
+    Args:
+        description (None): an optional description
     """
+
+    def __init__(self, description=None, **kwargs):
+        super().__init__(**kwargs)
+        self.description = description
 
     def to_mongo(self, value):
         if value is None:
@@ -704,7 +846,14 @@ class ArrayField(mongoengine.fields.BinaryField, Field):
     :class:`ArrayField` instances accept numpy array values. The underlying
     data is serialized and stored in the database as zlib-compressed bytes
     generated by ``numpy.save`` and always retrieved as a numpy array.
+
+    Args:
+        description (None): an optional description
     """
+
+    def __init__(self, description=None, **kwargs):
+        super().__init__(**kwargs)
+        self.description = description
 
     def to_mongo(self, value):
         if value is None:
@@ -725,7 +874,15 @@ class ArrayField(mongoengine.fields.BinaryField, Field):
 
 
 class FrameNumberField(IntField):
-    """A video frame number field."""
+    """A video frame number field.
+
+    Args:
+        description (None): an optional description
+    """
+
+    def __init__(self, description=None, **kwargs):
+        super().__init__(**kwargs)
+        self.description = description
 
     def validate(self, value):
         try:
@@ -735,13 +892,18 @@ class FrameNumberField(IntField):
 
 
 class FrameSupportField(ListField):
-    """A ``[first, last]`` frame support in a video."""
+    """A ``[first, last]`` frame support in a video.
 
-    def __init__(self, **kwargs):
+    Args:
+        description (None): an optional description
+    """
+
+    def __init__(self, description=None, **kwargs):
         if "field" not in kwargs:
             kwargs["field"] = IntField()
 
         super().__init__(**kwargs)
+        self.description = description
 
     def __str__(self):
         return etau.get_class_name(self)
@@ -762,10 +924,14 @@ class ClassesField(ListField):
     """A :class:`ListField` that stores class label strings.
 
     If this field is not set, its default value is ``[]``.
+
+    Args:
+        description (None): an optional description
     """
 
-    def __init__(self, **kwargs):
+    def __init__(self, description=None, **kwargs):
         super().__init__(field=StringField(), **kwargs)
+        self.description = description
 
     def __str__(self):
         return etau.get_class_name(self)
@@ -776,10 +942,14 @@ class TargetsField(IntDictField):
     targets.
 
     If this field is not set, its default value is ``{}``.
+
+    Args:
+        description (None): an optional description
     """
 
-    def __init__(self, **kwargs):
+    def __init__(self, description=None, **kwargs):
         super().__init__(field=StringField(), **kwargs)
+        self.description = description
 
     def __str__(self):
         return etau.get_class_name(self)
@@ -792,11 +962,14 @@ class EmbeddedDocumentField(mongoengine.fields.EmbeddedDocumentField, Field):
     Args:
         document_type: the :class:`fiftyone.core.odm.BaseEmbeddedDocument` type
             stored in this field
+        description (None): an optional description
     """
 
-    def __init__(self, document_type, **kwargs):
+    def __init__(self, document_type, description=None, **kwargs):
         super().__init__(document_type, **kwargs)
+        self.description = None
         self.fields = kwargs.get("fields", [])
+
         self._selected_fields = None
         self._excluded_fields = None
         self.__fields = None
@@ -990,7 +1163,12 @@ class EmbeddedDocumentListField(
     Args:
         document_type: the :class:`fiftyone.core.odm.BaseEmbeddedDocument` type
             stored in this field
+        description (None): an optional description
     """
+
+    def __init__(self, description=None, **kwargs):
+        super().__init__(**kwargs)
+        self.description = description
 
     def __str__(self):
         # pylint: disable=no-member

--- a/fiftyone/core/fields.py
+++ b/fiftyone/core/fields.py
@@ -225,7 +225,7 @@ def _flatten(
 
 
 class Field(mongoengine.fields.BaseField):
-    """Base class for :class:`fiftyone.core.sample.Sample` fields.
+    """A generic field.
 
     Args:
         description (None): an optional description
@@ -233,10 +233,14 @@ class Field(mongoengine.fields.BaseField):
 
     def __init__(self, description=None, **kwargs):
         super().__init__(**kwargs)
-        self.description = description
+        self._description = description
 
     def __str__(self):
         return etau.get_class_name(self)
+
+    @property
+    def description(self):
+        return self._description
 
     def copy(self):
         return deepcopy(self)
@@ -251,7 +255,7 @@ class IntField(mongoengine.fields.IntField, Field):
 
     def __init__(self, description=None, **kwargs):
         super().__init__(**kwargs)
-        self.description = description
+        self._description = description
 
     def to_mongo(self, value):
         if value is None:
@@ -269,7 +273,7 @@ class ObjectIdField(mongoengine.fields.ObjectIdField, Field):
 
     def __init__(self, description=None, **kwargs):
         super().__init__(**kwargs)
-        self.description = description
+        self._description = description
 
     def to_mongo(self, value):
         if value is None:
@@ -293,7 +297,7 @@ class UUIDField(mongoengine.fields.UUIDField, Field):
 
     def __init__(self, description=None, **kwargs):
         super().__init__(**kwargs)
-        self.description = description
+        self._description = description
 
 
 class BooleanField(mongoengine.fields.BooleanField, Field):
@@ -305,7 +309,7 @@ class BooleanField(mongoengine.fields.BooleanField, Field):
 
     def __init__(self, description=None, **kwargs):
         super().__init__(**kwargs)
-        self.description = description
+        self._description = description
 
     def validate(self, value):
         if not isinstance(value, (bool, np.bool_)):
@@ -321,7 +325,7 @@ class DateField(mongoengine.fields.DateField, Field):
 
     def __init__(self, description=None, **kwargs):
         super().__init__(**kwargs)
-        self.description = description
+        self._description = description
 
     def to_mongo(self, value):
         if value is None:
@@ -352,7 +356,7 @@ class DateTimeField(mongoengine.fields.DateTimeField, Field):
 
     def __init__(self, description=None, **kwargs):
         super().__init__(**kwargs)
-        self.description = description
+        self._description = description
 
     def validate(self, value):
         if not isinstance(value, datetime):
@@ -368,7 +372,7 @@ class FloatField(mongoengine.fields.FloatField, Field):
 
     def __init__(self, description=None, **kwargs):
         super().__init__(**kwargs)
-        self.description = description
+        self._description = description
 
     def to_mongo(self, value):
         if value is None:
@@ -400,7 +404,7 @@ class StringField(mongoengine.fields.StringField, Field):
 
     def __init__(self, description=None, **kwargs):
         super().__init__(**kwargs)
-        self.description = description
+        self._description = description
 
 
 class ListField(mongoengine.fields.ListField, Field):
@@ -424,7 +428,7 @@ class ListField(mongoengine.fields.ListField, Field):
                 )
 
         super().__init__(field=field, **kwargs)
-        self.description = description
+        self._description = description
 
     def __str__(self):
         if self.field is not None:
@@ -452,7 +456,7 @@ class HeatmapRangeField(ListField):
             kwargs["field"] = FloatField()
 
         super().__init__(**kwargs)
-        self.description = description
+        self._description = description
 
     def __str__(self):
         return etau.get_class_name(self)
@@ -486,7 +490,7 @@ class DictField(mongoengine.fields.DictField, Field):
                 )
 
         super().__init__(field=field, **kwargs)
-        self.description = description
+        self._description = description
 
     def __str__(self):
         if self.field is not None:
@@ -556,7 +560,7 @@ class KeypointsField(ListField):
 
     def __init__(self, description=None, **kwargs):
         super().__init__(field=None, **kwargs)
-        self.description = description
+        self._description = description
 
     def __str__(self):
         return etau.get_class_name(self)
@@ -581,7 +585,7 @@ class PolylinePointsField(ListField):
 
     def __init__(self, description=None, **kwargs):
         super().__init__(field=None, **kwargs)
-        self.description = description
+        self._description = description
 
     def __str__(self):
         return etau.get_class_name(self)
@@ -618,7 +622,7 @@ class _GeoField(Field):
 
     def __init__(self, description=None, **kwargs):
         super().__init__(**kwargs)
-        self.description = description
+        self._description = description
 
     def to_mongo(self, value):
         if isinstance(value, dict):
@@ -646,7 +650,7 @@ class GeoPointField(_GeoField, mongoengine.fields.PointField):
 
     def __init__(self, description=None, **kwargs):
         super().__init__(**kwargs)
-        self.description = description
+        self._description = description
 
     def validate(self, value):
         if isinstance(value, dict):
@@ -670,7 +674,7 @@ class GeoLineStringField(_GeoField, mongoengine.fields.LineStringField):
 
     def __init__(self, description=None, **kwargs):
         super().__init__(**kwargs)
-        self.description = description
+        self._description = description
 
     def validate(self, value):
         if isinstance(value, dict):
@@ -701,7 +705,7 @@ class GeoPolygonField(_GeoField, mongoengine.fields.PolygonField):
 
     def __init__(self, description=None, **kwargs):
         super().__init__(**kwargs)
-        self.description = description
+        self._description = description
 
     def validate(self, value):
         if isinstance(value, dict):
@@ -725,7 +729,7 @@ class GeoMultiPointField(_GeoField, mongoengine.fields.MultiPointField):
 
     def __init__(self, description=None, **kwargs):
         super().__init__(**kwargs)
-        self.description = description
+        self._description = description
 
     def validate(self, value):
         if isinstance(value, dict):
@@ -755,7 +759,7 @@ class GeoMultiLineStringField(
 
     def __init__(self, description=None, **kwargs):
         super().__init__(**kwargs)
-        self.description = description
+        self._description = description
 
     def validate(self, value):
         if isinstance(value, dict):
@@ -791,7 +795,7 @@ class GeoMultiPolygonField(_GeoField, mongoengine.fields.MultiPolygonField):
 
     def __init__(self, description=None, **kwargs):
         super().__init__(**kwargs)
-        self.description = description
+        self._description = description
 
     def validate(self, value):
         if isinstance(value, dict):
@@ -814,7 +818,7 @@ class VectorField(mongoengine.fields.BinaryField, Field):
 
     def __init__(self, description=None, **kwargs):
         super().__init__(**kwargs)
-        self.description = description
+        self._description = description
 
     def to_mongo(self, value):
         if value is None:
@@ -853,7 +857,7 @@ class ArrayField(mongoengine.fields.BinaryField, Field):
 
     def __init__(self, description=None, **kwargs):
         super().__init__(**kwargs)
-        self.description = description
+        self._description = description
 
     def to_mongo(self, value):
         if value is None:
@@ -882,7 +886,7 @@ class FrameNumberField(IntField):
 
     def __init__(self, description=None, **kwargs):
         super().__init__(**kwargs)
-        self.description = description
+        self._description = description
 
     def validate(self, value):
         try:
@@ -903,7 +907,7 @@ class FrameSupportField(ListField):
             kwargs["field"] = IntField()
 
         super().__init__(**kwargs)
-        self.description = description
+        self._description = description
 
     def __str__(self):
         return etau.get_class_name(self)
@@ -931,7 +935,7 @@ class ClassesField(ListField):
 
     def __init__(self, description=None, **kwargs):
         super().__init__(field=StringField(), **kwargs)
-        self.description = description
+        self._description = description
 
     def __str__(self):
         return etau.get_class_name(self)
@@ -949,7 +953,7 @@ class TargetsField(IntDictField):
 
     def __init__(self, description=None, **kwargs):
         super().__init__(field=StringField(), **kwargs)
-        self.description = description
+        self._description = description
 
     def __str__(self):
         return etau.get_class_name(self)
@@ -967,9 +971,9 @@ class EmbeddedDocumentField(mongoengine.fields.EmbeddedDocumentField, Field):
 
     def __init__(self, document_type, description=None, **kwargs):
         super().__init__(document_type, **kwargs)
-        self.description = description
         self.fields = kwargs.get("fields", [])
 
+        self._description = description
         self._selected_fields = None
         self._excluded_fields = None
         self.__fields = None
@@ -1166,9 +1170,9 @@ class EmbeddedDocumentListField(
         description (None): an optional description
     """
 
-    def __init__(self, description=None, **kwargs):
-        super().__init__(**kwargs)
-        self.description = description
+    def __init__(self, document_type, description=None, **kwargs):
+        super().__init__(document_type, **kwargs)
+        self._description = description
 
     def __str__(self):
         # pylint: disable=no-member

--- a/fiftyone/core/odm/dataset.py
+++ b/fiftyone/core/odm/dataset.py
@@ -37,6 +37,7 @@ def create_field(
     subfield=None,
     fields=None,
     db_field=None,
+    description=None,
     **kwargs,
 ):
     """Creates the field defined by the given specification.
@@ -65,6 +66,7 @@ def create_field(
             ``ftype`` is :class:`fiftyone.core.fields.EmbeddedDocumentField`
         db_field (None): the database field to store this field in. By default,
             ``name`` is used
+        description (None): an optional description
 
     Returns:
         a :class:`fiftyone.core.fields.Field`
@@ -76,7 +78,7 @@ def create_field(
             db_field = name
 
     # All user-defined fields are nullable
-    field_kwargs = dict(null=True, db_field=db_field)
+    field_kwargs = dict(null=True, db_field=db_field, description=description)
     field_kwargs.update(kwargs)
 
     if fields is not None:
@@ -138,6 +140,7 @@ class SampleFieldDocument(EmbeddedDocument):
         EmbeddedDocumentField(document_type="SampleFieldDocument")
     )
     db_field = StringField(null=True)
+    description = StringField(null=True)
 
     def to_field(self):
         """Creates the :class:`fiftyone.core.fields.Field` specified by this
@@ -167,6 +170,7 @@ class SampleFieldDocument(EmbeddedDocument):
             subfield=subfield,
             fields=fields,
             db_field=self.db_field,
+            description=self.description,
         )
 
     @classmethod
@@ -192,6 +196,7 @@ class SampleFieldDocument(EmbeddedDocument):
             subfield=cls._get_attr_repr(field, "field"),
             fields=cls._get_field_documents(field),
             db_field=field.db_field,
+            description=field.description,
         )
 
     @staticmethod

--- a/fiftyone/core/odm/dataset.py
+++ b/fiftyone/core/odm/dataset.py
@@ -91,7 +91,7 @@ def create_field(
         if subfield is not None:
             if inspect.isclass(subfield):
                 if issubclass(subfield, EmbeddedDocumentField):
-                    subfield = subfield(document_type=embedded_doc_type)
+                    subfield = subfield(embedded_doc_type)
                 else:
                     subfield = subfield()
 
@@ -136,9 +136,7 @@ class SampleFieldDocument(EmbeddedDocument):
     ftype = StringField()
     embedded_doc_type = StringField(null=True)
     subfield = StringField(null=True)
-    fields = ListField(
-        EmbeddedDocumentField(document_type="SampleFieldDocument")
-    )
+    fields = ListField(EmbeddedDocumentField("SampleFieldDocument"))
     db_field = StringField(null=True)
     description = StringField(null=True)
 
@@ -308,7 +306,7 @@ class DatasetAppConfig(EmbeddedDocument):
     grid_media_field = StringField(default="filepath")
     modal_media_field = StringField(default="filepath")
     sidebar_groups = ListField(
-        EmbeddedDocumentField(document_type=SidebarGroupDocument), default=None
+        EmbeddedDocumentField(SidebarGroupDocument), default=None
     )
     plugins = DictField()
 
@@ -402,21 +400,15 @@ class DatasetDocument(Document):
     default_group_slice = StringField()
     tags = ListField(StringField())
     info = DictField()
-    app_config = EmbeddedDocumentField(document_type=DatasetAppConfig)
+    app_config = EmbeddedDocumentField(DatasetAppConfig)
     classes = DictField(ClassesField())
     default_classes = ClassesField()
     mask_targets = DictField(TargetsField())
     default_mask_targets = TargetsField()
-    skeletons = DictField(
-        EmbeddedDocumentField(document_type=KeypointSkeleton)
-    )
-    default_skeleton = EmbeddedDocumentField(document_type=KeypointSkeleton)
-    sample_fields = EmbeddedDocumentListField(
-        document_type=SampleFieldDocument
-    )
-    frame_fields = EmbeddedDocumentListField(document_type=SampleFieldDocument)
-    annotation_runs = DictField(
-        EmbeddedDocumentField(document_type=RunDocument)
-    )
-    brain_methods = DictField(EmbeddedDocumentField(document_type=RunDocument))
-    evaluations = DictField(EmbeddedDocumentField(document_type=RunDocument))
+    skeletons = DictField(EmbeddedDocumentField(KeypointSkeleton))
+    default_skeleton = EmbeddedDocumentField(KeypointSkeleton)
+    sample_fields = EmbeddedDocumentListField(SampleFieldDocument)
+    frame_fields = EmbeddedDocumentListField(SampleFieldDocument)
+    annotation_runs = DictField(EmbeddedDocumentField(RunDocument))
+    brain_methods = DictField(EmbeddedDocumentField(RunDocument))
+    evaluations = DictField(EmbeddedDocumentField(RunDocument))

--- a/fiftyone/core/odm/document.py
+++ b/fiftyone/core/odm/document.py
@@ -539,7 +539,7 @@ class Document(BaseDocument, mongoengine.Document):
 
     meta = {"abstract": True}
 
-    def save(self, validate=True, clean=True, **kwargs):
+    def save(self, validate=True, clean=True, safe=False, **kwargs):
         """Saves the document to the database.
 
         If the document already exists, it will be updated, otherwise it will
@@ -549,11 +549,22 @@ class Document(BaseDocument, mongoengine.Document):
             validate (True): whether to validate the document
             clean (True): whether to call the document's ``clean()`` method.
                 Only applicable when ``validate`` is True
+            safe (False): whether to ``reload()`` the document before raising
+                any validation errors
 
         Returns:
             self
         """
-        self._save(deferred=False, validate=validate, clean=clean, **kwargs)
+        try:
+            self._save(
+                deferred=False, validate=validate, clean=clean, **kwargs
+            )
+        except:
+            if safe:
+                self.reload()
+
+            raise
+
         return self
 
     def _save(self, deferred=False, validate=True, clean=True, **kwargs):

--- a/fiftyone/core/odm/mixins.py
+++ b/fiftyone/core/odm/mixins.py
@@ -1122,6 +1122,32 @@ class DatasetMixin(object):
         return field, is_default
 
     @classmethod
+    def _get_field_doc(cls, path, dataset_doc, allow_missing=False):
+        chunks = path.split(".")
+        field_docs = dataset_doc[cls._fields_attr()]
+
+        field_doc = None
+        for chunk in chunks:
+            found = False
+            for _field_doc in field_docs:
+                if _field_doc.name == chunk:
+                    field_doc = _field_doc
+                    field_docs = _field_doc.fields
+                    found = True
+                    break
+
+            if not found:
+                if not allow_missing:
+                    raise ValueError(
+                        "%s field '%s' does not exist"
+                        % (cls._doc_name(), path)
+                    )
+
+                return None
+
+        return field_doc
+
+    @classmethod
     def _parse_path(cls, path, dataset_doc, allow_missing=False):
         chunks = path.split(".")
 

--- a/fiftyone/core/odm/mixins.py
+++ b/fiftyone/core/odm/mixins.py
@@ -279,6 +279,7 @@ class DatasetMixin(object):
         embedded_doc_type=None,
         subfield=None,
         fields=None,
+        description=None,
         expand_schema=True,
         recursive=True,
         validate=True,
@@ -303,6 +304,7 @@ class DatasetMixin(object):
                 instances defining embedded document attributes. Only
                 applicable when ``ftype`` is
                 :class:`fiftyone.core.fields.EmbeddedDocumentField`
+            description (None): an optional description
             expand_schema (True): whether to add new fields to the schema
                 (True) or simply validate that the field already exists with a
                 consistent type (False)
@@ -327,6 +329,7 @@ class DatasetMixin(object):
             embedded_doc_type=embedded_doc_type,
             subfield=subfield,
             fields=fields,
+            description=description,
             **kwargs,
         )
 
@@ -393,6 +396,7 @@ class DatasetMixin(object):
         embedded_doc_type=None,
         subfield=None,
         fields=None,
+        description=None,
         **kwargs,
     ):
         field_name = path.rsplit(".", 1)[-1]
@@ -402,6 +406,7 @@ class DatasetMixin(object):
             embedded_doc_type=embedded_doc_type,
             subfield=subfield,
             fields=fields,
+            description=description,
             **kwargs,
         )
 

--- a/fiftyone/core/odm/utils.py
+++ b/fiftyone/core/odm/utils.py
@@ -191,6 +191,7 @@ def get_field_kwargs(field):
         "ftype": type(field),
         "fields": fields,
         "db_field": field.db_field,
+        "description": field.description,
     }
 
     if isinstance(field, (fof.ListField, fof.DictField)):
@@ -287,6 +288,7 @@ def _get_field_kwargs(value, field, dynamic):
     kwargs = {
         "ftype": type(field),
         "db_field": field.db_field,
+        "description": field.description,
     }
 
     if isinstance(field, (fof.ListField, fof.DictField)):

--- a/fiftyone/migrations/revisions/v0_18_0.py
+++ b/fiftyone/migrations/revisions/v0_18_0.py
@@ -1,0 +1,48 @@
+"""
+FiftyOne v0.18.0 revision.
+
+| Copyright 2017-2022, Voxel51, Inc.
+| `voxel51.com <https://voxel51.com/>`_
+|
+"""
+
+
+def up(db, dataset_name):
+    match_d = {"name": dataset_name}
+    dataset_dict = db.datasets.find_one(match_d)
+
+    for field in dataset_dict.get("sample_fields", []):
+        _add_description(field)
+
+    for field in dataset_dict.get("frame_fields", []):
+        _add_description(field)
+
+    db.datasets.replace_one(match_d, dataset_dict)
+
+
+def down(db, dataset_name):
+    match_d = {"name": dataset_name}
+    dataset_dict = db.datasets.find_one(match_d)
+
+    for field in dataset_dict.get("sample_fields", []):
+        _remove_description(field)
+
+    for field in dataset_dict.get("frame_fields", []):
+        _remove_description(field)
+
+    db.datasets.replace_one(match_d, dataset_dict)
+
+
+def _add_description(field):
+    if "description" not in field:
+        field["description"] = None
+
+    for field in field.get("fields", []):
+        _add_description(field)
+
+
+def _remove_description(field):
+    field.pop("description", None)
+
+    for field in field.get("fields", []):
+        _remove_description(field)

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ import re
 from setuptools import setup, find_packages
 
 
-VERSION = "0.17.2"
+VERSION = "0.18.0"
 
 
 def get_version():


### PR DESCRIPTION
Resolves https://github.com/voxel51/fiftyone/issues/2163

Adds support for storing field-level descriptions on datasets.

## Notes

I vote for https://github.com/voxel51/fiftyone/pull/2216 instead of this implementation 🤗 

## Example usage

```py
import fiftyone as fo
import fiftyone.zoo as foz

dataset = foz.load_zoo_dataset("quickstart")
dataset.add_dynamic_sample_fields()

dataset.set_field_metadata(
    "ground_truth",
    description="Ground truth annotations",
)

dataset.set_field_metadata(
    "ground_truth.detections.area",
    description="Area of the box, in pixels^2",
)

field = dataset.get_field("ground_truth")
print(field.description)  # Ground truth annotations

field = dataset.get_field("ground_truth.detections.area")
print(field.description)  # Area of the box, in pixels^2
```

Appropriate validation is in-place:

```py
# None of these are allowed
dataset.set_field_metadata("foo", description="bar")  # bad field
dataset.set_field_metadata("ground_truth.detections.foo", description="bar")  # bad attribute
dataset.set_field_metadata("ground_truth", foo="bar")  # bad metadata key
dataset.set_field_metadata("ground_truth", description=False)  # bad metadata value
```

Field descriptions may also be provided when the field is declared, if desired:

```py
import fiftyone as fo

dataset = fo.Dataset()
dataset.add_sample_field(
    "int_field", fo.IntField, description="An integer field"
)

field = dataset.get_field("int_field")
print(field.description)  # An integer field
```
