### PR TITLE
Fix qdrant tutorial

### DIFF
--- a/docs/source/tutorials/qdrant.ipynb
+++ b/docs/source/tutorials/qdrant.ipynb
@@ -91,7 +91,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!docker run -p \"6333:6333\" -p \"6334:6334\" -d qdrant/qdrant"
+    "!docker run -p \"6333:6333\" -p \"6334:6334\" -d qdrant / qdrant"
    ]
   },
   {
@@ -333,15 +333,16 @@
    "outputs": [],
    "source": [
     "import qdrant_client as qc\n",
-    "from qdrant_client.http.models import Distance\n",
+    "from qdrant_client.http.models import Distance, VectorParams\n",
+    "\n",
     "\n",
     "# Load the train embeddings into Qdrant\n",
     "def create_and_upload_collection(embeddings, payload, collection_name=\"mnist\"):\n",
     "    client = qc.QdrantClient(host=\"localhost\")\n",
     "    client.recreate_collection(\n",
     "        collection_name=collection_name,\n",
-    "        vector_size=embeddings.shape[1],\n",
-    "        distance=Distance.COSINE,\n",
+    "        vectors_config=VectorParams(size=embeddings.shape[1],\n",
+    "                                    distance=Distance.COSINE),\n",
     "    )\n",
     "    client.upload_collection(\n",
     "        collection_name=collection_name,\n",
@@ -433,6 +434,7 @@
    "outputs": [],
    "source": [
     "import collections\n",
+    "\n",
     "\n",
     "def generate_fiftyone_classification(embedding, collection_name=\"mnist\"):\n",
     "    search_results = client.search(\n",

--- a/docs/source/tutorials/qdrant.ipynb
+++ b/docs/source/tutorials/qdrant.ipynb
@@ -91,7 +91,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!docker run -p \"6333:6333\" -p \"6334:6334\" -d qdrant / qdrant"
+    "!docker run -p \"6333:6333\" -p \"6334:6334\" -d qdrant/qdrant"
    ]
   },
   {
@@ -434,7 +434,6 @@
    "outputs": [],
    "source": [
     "import collections\n",
-    "\n",
     "\n",
     "def generate_fiftyone_classification(embedding, collection_name=\"mnist\"):\n",
     "    search_results = client.search(\n",


### PR DESCRIPTION
## What changes are proposed in this pull request?

- Fix the qdrant tutorial. Since it's writing, the qdrant_client api has changed and the args for `recreate_collection` have changed. (See https://github.com/qdrant/qdrant_client/blob/master/tests/test_qdrant_client.py#L78)

## How is this patch tested? If it is not, please explain why.

- Run the notebook and verify everything runs without error.

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [x] Documentation: FiftyOne documentation changes
-   [ ] Other
