### PR TITLE
Allow frame views to edit source frame filepaths

### DIFF
--- a/fiftyone/core/patches.py
+++ b/fiftyone/core/patches.py
@@ -205,8 +205,7 @@ class _PatchesView(fov.DatasetView):
 
         super().set_values(field_name, *args, **kwargs)
 
-        if must_sync:
-            self._sync_source_field(field, ids=ids)
+        self._sync_source_field(field, ids=ids)
 
     def save(self, fields=None):
         """Saves the patches in this view to the underlying dataset.
@@ -307,6 +306,9 @@ class _PatchesView(fov.DatasetView):
         self._source_collection._set_labels(field, [sample_id], [doc])
 
     def _sync_source_field(self, field, ids=None):
+        if field not in self._label_fields:
+            return
+
         _, label_path = self._patches_dataset._get_label_field_path(field)
 
         if ids is not None:
@@ -327,6 +329,9 @@ class _PatchesView(fov.DatasetView):
             self._sync_source_root_field(field, update=update, delete=delete)
 
     def _sync_source_root_field(self, field, update=True, delete=False):
+        if field not in self._label_fields:
+            return
+
         _, label_id_path = self._get_label_field_path(field, "id")
         label_path = label_id_path.rsplit(".", 1)[0]
 

--- a/fiftyone/core/video.py
+++ b/fiftyone/core/video.py
@@ -142,6 +142,21 @@ class FramesView(fov.DatasetView):
     def media_type(self):
         return fom.IMAGE
 
+    def _get_sample_only_fields(
+        self, include_private=False, use_db_fields=False
+    ):
+        sample_only_fields = set(
+            self._get_default_sample_fields(
+                include_private=include_private, use_db_fields=use_db_fields
+            )
+        )
+
+        # If sample_frames != dynamic, `filepath` can be synced
+        if self._frames_stage.config.get("sample_frames", None) != "dynamic":
+            sample_only_fields.discard("filepath")
+
+        return sample_only_fields
+
     def _get_default_sample_fields(
         self, include_private=False, use_db_fields=False
     ):

--- a/fiftyone/core/video.py
+++ b/fiftyone/core/video.py
@@ -152,7 +152,8 @@ class FramesView(fov.DatasetView):
         )
 
         # If sample_frames != dynamic, `filepath` can be synced
-        if self._frames_stage.config.get("sample_frames", None) != "dynamic":
+        config = self._frames_stage.config or {}
+        if config.get("sample_frames", None) != "dynamic":
             sample_only_fields.discard("filepath")
 
         return sample_only_fields

--- a/fiftyone/core/video.py
+++ b/fiftyone/core/video.py
@@ -288,16 +288,14 @@ class FramesView(fov.DatasetView):
         self._sync_source_schema()
 
         dst_dataset = self._source_collection._root_dataset
-        default_fields = set(
-            self._get_default_sample_fields(
-                include_private=True, use_db_fields=True
-            )
+        sample_only_fields = self._get_sample_only_fields(
+            include_private=True, use_db_fields=True
         )
 
         updates = {
             k: v
             for k, v in sample.to_mongo_dict().items()
-            if k not in default_fields
+            if k not in sample_only_fields
         }
 
         if not updates:
@@ -312,14 +310,12 @@ class FramesView(fov.DatasetView):
 
     def _sync_source(self, fields=None, ids=None, update=True, delete=False):
         dst_dataset = self._source_collection._root_dataset
-        default_fields = set(
-            self._get_default_sample_fields(
-                include_private=True, use_db_fields=True
-            )
+        sample_only_fields = self._get_sample_only_fields(
+            include_private=True, use_db_fields=True
         )
 
         if fields is not None:
-            fields = [f for f in fields if f not in default_fields]
+            fields = [f for f in fields if f not in sample_only_fields]
             if not fields:
                 return
 
@@ -338,10 +334,10 @@ class FramesView(fov.DatasetView):
                 )
 
             if fields is None:
-                default_fields.discard("_sample_id")
-                default_fields.discard("frame_number")
+                sample_only_fields.discard("_sample_id")
+                sample_only_fields.discard("frame_number")
 
-                pipeline.append({"$unset": list(default_fields)})
+                pipeline.append({"$unset": list(sample_only_fields)})
             else:
                 project = {f: True for f in fields}
                 project["_id"] = True

--- a/tests/unittests/video_tests.py
+++ b/tests/unittests/video_tests.py
@@ -2033,6 +2033,33 @@ class VideoTests(unittest.TestCase):
         self.assertEqual(len(frames), 2)
 
     @drop_datasets
+    def test_to_frames_filepaths(self):
+        sample = fo.Sample(filepath="video.mp4")
+        sample.frames[1] = fo.Frame(filepath="image.jpg")
+
+        dataset = fo.Dataset()
+        dataset.add_sample(sample)
+
+        frames = dataset.to_frames()
+
+        sample = frames.first()
+        sample.filepath = "foo.jpg"
+        sample.save()
+
+        self.assertEqual(frames.first().filepath, "foo.jpg")
+        self.assertEqual(dataset.first().frames.first().filepath, "foo.jpg")
+
+        frames.set_values("filepath", ["bar.jpg"])
+
+        self.assertEqual(frames.first().filepath, "bar.jpg")
+        self.assertEqual(dataset.first().frames.first().filepath, "bar.jpg")
+
+        frames.set_field("filepath", F("filepath").upper()).save()
+
+        self.assertEqual(frames.first().filepath, "BAR.JPG")
+        self.assertEqual(dataset.first().frames.first().filepath, "BAR.JPG")
+
+    @drop_datasets
     def test_to_clip_frames(self):
         dataset = fo.Dataset()
 


### PR DESCRIPTION
Previously, editing the `filepath` of a frame view would not sync to the source dataset's frame `filepath`, but this should be allowed, since frame views were intended to sync all relevant frame fields of the source dataset. This PR resolves the bug.

```py
import fiftyone as fo
import fiftyone.zoo as foz
from fiftyone import ViewField as F

dataset = foz.load_zoo_dataset("quickstart-video", max_samples=1)
frames = dataset.to_frames(sample_frames=True)

sample = frames.first()
sample.filepath = sample.filepath.upper()
sample.save()

# Previously wasn't changed; now is
print(dataset.first().frames.first().filepath)

upper_view = frames.set_field("filepath", F("filepath").upper())
frames.set_values("filepath", upper_view.values("filepath"))

# Previously wasn't changed; now is
print(dataset.values("frames.filepath", unwind=True)[:5])

frames.set_field("filepath", F("filepath").upper().concat(".bak")).save()

# Previously wasn't changed; now is
print(dataset.values("frames.filepath", unwind=True)[:5])
```
