### PR TITLE
add info to dataset

### DIFF
--- a/app/packages/core/src/Dataset.ts
+++ b/app/packages/core/src/Dataset.ts
@@ -95,6 +95,7 @@ const DatasetQueryNode = graphql`
           paths
         }
       }
+      info
     }
   }
 `;

--- a/app/packages/core/src/__generated__/DatasetQuery.graphql.ts
+++ b/app/packages/core/src/__generated__/DatasetQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<c4b17cb450e9f84cc8e6797f8a2aeedb>>
+ * @generated SignedSource<<0b2970abf6649f5c311edb3e2ad6445c>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -71,6 +71,7 @@ export type DatasetQuery$data = {
       readonly name: string;
     }> | null;
     readonly id: string;
+    readonly info: object | null;
     readonly lastLoadedAt: string | null;
     readonly maskTargets: ReadonlyArray<{
       readonly name: string;
@@ -527,6 +528,13 @@ v12 = [
         "kind": "ScalarField",
         "name": "viewCls",
         "storageKey": null
+      },
+      {
+        "alias": null,
+        "args": null,
+        "kind": "ScalarField",
+        "name": "info",
+        "storageKey": null
       }
     ],
     "storageKey": null
@@ -550,16 +558,16 @@ return {
     "selections": (v12/*: any*/)
   },
   "params": {
-    "cacheID": "e5b28d650f56482fe3a4e90ce3dde09b",
+    "cacheID": "8d3f81596498c437a322670d5b776032",
     "id": null,
     "metadata": {},
     "name": "DatasetQuery",
     "operationKind": "query",
-    "text": "query DatasetQuery(\n  $name: String!\n  $view: BSONArray = null\n) {\n  dataset(name: $name, view: $view) {\n    id\n    name\n    mediaType\n    defaultGroupSlice\n    groupField\n    groupMediaTypes {\n      name\n      mediaType\n    }\n    appConfig {\n      gridMediaField\n      mediaFields\n      plugins\n      sidebarGroups {\n        name\n        paths\n      }\n    }\n    sampleFields {\n      ftype\n      subfield\n      embeddedDocType\n      path\n      dbField\n    }\n    frameFields {\n      ftype\n      subfield\n      embeddedDocType\n      path\n      dbField\n    }\n    maskTargets {\n      name\n      targets {\n        target\n        value\n      }\n    }\n    defaultMaskTargets {\n      target\n      value\n    }\n    evaluations {\n      key\n      version\n      timestamp\n      viewStages\n      config {\n        cls\n        predField\n        gtField\n      }\n    }\n    brainMethods {\n      key\n      version\n      timestamp\n      viewStages\n      config {\n        cls\n        embeddingsField\n        method\n        patchesField\n      }\n    }\n    lastLoadedAt\n    createdAt\n    skeletons {\n      name\n      labels\n      edges\n    }\n    defaultSkeleton {\n      labels\n      edges\n    }\n    version\n    viewCls\n  }\n}\n"
+    "text": "query DatasetQuery(\n  $name: String!\n  $view: BSONArray = null\n) {\n  dataset(name: $name, view: $view) {\n    id\n    name\n    mediaType\n    defaultGroupSlice\n    groupField\n    groupMediaTypes {\n      name\n      mediaType\n    }\n    appConfig {\n      gridMediaField\n      mediaFields\n      plugins\n      sidebarGroups {\n        name\n        paths\n      }\n    }\n    sampleFields {\n      ftype\n      subfield\n      embeddedDocType\n      path\n      dbField\n    }\n    frameFields {\n      ftype\n      subfield\n      embeddedDocType\n      path\n      dbField\n    }\n    maskTargets {\n      name\n      targets {\n        target\n        value\n      }\n    }\n    defaultMaskTargets {\n      target\n      value\n    }\n    evaluations {\n      key\n      version\n      timestamp\n      viewStages\n      config {\n        cls\n        predField\n        gtField\n      }\n    }\n    brainMethods {\n      key\n      version\n      timestamp\n      viewStages\n      config {\n        cls\n        embeddingsField\n        method\n        patchesField\n      }\n    }\n    lastLoadedAt\n    createdAt\n    skeletons {\n      name\n      labels\n      edges\n    }\n    defaultSkeleton {\n      labels\n      edges\n    }\n    version\n    viewCls\n    info\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "393e9a77be7b019383e437812359086e";
+(node as any).hash = "61947167292f19ada5da19e777a06877";
 
 export default node;

--- a/app/packages/state/src/recoil/types.ts
+++ b/app/packages/state/src/recoil/types.ts
@@ -109,6 +109,7 @@ export namespace State {
     defaultGroupSlice: string;
     groupField: string;
     appConfig: DatasetAppConfig;
+    info: { [key: string]: string };
   }
 
   export interface Filter {}

--- a/app/schema.graphql
+++ b/app/schema.graphql
@@ -60,6 +60,7 @@ type Dataset {
   defaultSkeleton: KeypointSkeleton
   skeletons: [NamedKeypointSkeleton!]!
   appConfig: DatasetAppConfig
+  info: JSON
 }
 
 type DatasetAppConfig {

--- a/fiftyone/server/query.py
+++ b/fiftyone/server/query.py
@@ -161,6 +161,7 @@ class Dataset:
     default_skeleton: t.Optional[KeypointSkeleton]
     skeletons: t.List[NamedKeypointSkeleton]
     app_config: t.Optional[DatasetAppConfig]
+    info: t.Optional[JSON]
 
     @staticmethod
     def modifier(doc: dict) -> dict:


### PR DESCRIPTION
## What changes are proposed in this pull request?

Adds info from python lib dataset into the frontend so that metadata about a dataset can be used for plugins

## How is this patch tested? If it is not, please explain why.

Tested with our custom plugins

## Release Notes


### What areas of FiftyOne does this PR affect?

-   [X] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
