### PR TITLE
Support cuda devices for CLIP zoo model

### DIFF
--- a/fiftyone/utils/clip/zoo.py
+++ b/fiftyone/utils/clip/zoo.py
@@ -121,7 +121,10 @@ class TorchCLIPModel(fout.TorchImageModel):
             dtype = torch.int
 
         text_features = torch.zeros(
-            len(all_tokens), self.config.context_length, dtype=dtype
+            len(all_tokens),
+            self.config.context_length,
+            dtype=dtype,
+            device=self.device,
         )
 
         for i, (prompt, tokens) in enumerate(zip(prompts, all_tokens)):


### PR DESCRIPTION
When running the CLIP zoo model on a cuda device, it would currently fail due to the `text_features` not being properly placed on the cuda device as well causing a device mismatch when running a forward pass.

This PR places the `text_features` tensor on the same device as the model itself to resolve this issue. Tested both on a cuda device and cpu device.