### PR TITLE
use theme based color for action row tooltip text

### DIFF
--- a/app/packages/components/src/components/Tooltip/Tooltip.module.css
+++ b/app/packages/components/src/components/Tooltip/Tooltip.module.css
@@ -7,4 +7,5 @@
   z-index: 1000;
   font-family: var(--joy-fontFamily-body);
   font-size: 14px;
+  color: var(--joy-palette-text-secondary);
 }


### PR DESCRIPTION
## What changes are proposed in this pull request?

PR fixes action row item's tooltip text color bug shown in the image below

![image](https://user-images.githubusercontent.com/25350704/198406973-b9d298ec-6aea-4365-b4b1-d7197d076603.png)

## How is this patch tested? If it is not, please explain why.

Tested manually by hovering action row items visually inspecting tooltip text color in both light and dark theme

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
