### PR TITLE
More tagging optimization

### DIFF
--- a/fiftyone/core/clips.py
+++ b/fiftyone/core/clips.py
@@ -648,7 +648,10 @@ def _write_temporal_detection_clips(
     if other_fields:
         project.update({f: True for f in other_fields})
 
-    pipeline = [{"$project": project}]
+    pipeline = [
+        {"$project": project},
+        {"$match": {"$expr": {"$gt": ["$" + field, None]}}},
+    ]
 
     if label_type is fol.TemporalDetections:
         list_path = field + "." + label_type._LABEL_LIST_FIELD

--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -1162,7 +1162,6 @@ class SampleCollection(object):
 
         # We only need to process samples that are missing a tag of interest
         view = self.match_tags(tags, bool=False, all=True)
-
         view._edit_sample_tags(update)
 
     def untag_samples(self, tags):
@@ -1179,7 +1178,6 @@ class SampleCollection(object):
 
         # We only need to process samples that have a tag of interest
         view = self.match_tags(tags)
-
         view._edit_sample_tags(update)
 
     def _edit_sample_tags(self, update):
@@ -1218,7 +1216,6 @@ class SampleCollection(object):
         for label_field in label_fields:
             # We only need to process labels that are missing a tag of interest
             view = self.filter_labels(label_field, match_expr)
-
             view._tag_labels(tags, label_field)
 
     def _tag_labels(self, tags, label_field, ids=None, label_ids=None):

--- a/fiftyone/core/patches.py
+++ b/fiftyone/core/patches.py
@@ -5,6 +5,7 @@ Patches views.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+from collections import defaultdict
 from copy import deepcopy
 
 from bson import ObjectId
@@ -192,32 +193,52 @@ class _PatchesView(fov.DatasetView):
 
         return names
 
-    def tag_labels(self, tags, label_fields=None):
-        for field in self._parse_label_fields(label_fields=label_fields):
-            view = self._get_source_labels_view(field)
-            view.tag_labels(tags, label_fields=[field])
+    def _tag_labels(self, tags, label_field, ids=None, label_ids=None):
+        if label_field in self._label_fields:
+            _ids = self.values("_" + self._id_field)
 
-        super().tag_labels(tags, label_fields=label_fields)
+        _, label_ids = super()._tag_labels(
+            tags, label_field, ids=ids, label_ids=label_ids
+        )
 
-    def untag_labels(self, tags, label_fields=None):
-        for field in self._parse_label_fields(label_fields=label_fields):
-            view = self._get_source_labels_view(field)
-            view.untag_labels(tags, label_fields=[field])
+        if label_field in self._label_fields:
+            ids, label_ids = self._to_source_ids(label_field, _ids, label_ids)
+            self._source_collection._tag_labels(
+                tags, label_field, ids=ids, label_ids=label_ids
+            )
 
-        super().untag_labels(tags, label_fields=label_fields)
+    def _untag_labels(self, tags, label_field, ids=None, label_ids=None):
+        if label_field in self._label_fields:
+            _ids = self.values("_" + self._id_field)
 
-    def _parse_label_fields(self, label_fields=None):
-        if label_fields is None:
-            label_fields = self._label_fields
-        elif etau.is_str(label_fields):
-            label_fields = [label_fields]
+        _, label_ids = super()._untag_labels(
+            tags, label_field, ids=ids, label_ids=label_ids
+        )
 
-        return list(set(label_fields) & set(self._label_fields))
+        if label_field in self._label_fields:
+            ids, label_ids = self._to_source_ids(label_field, _ids, label_ids)
+            self._source_collection._untag_labels(
+                tags, label_field, ids=ids, label_ids=label_ids
+            )
 
-    def _get_source_labels_view(self, field):
-        _, id_path = self._get_label_field_path(field, "id")
-        ids = self.values(id_path, unwind=True)
-        return self._source_collection.select_labels(ids=ids, fields=[field])
+    def _to_source_ids(self, label_field, ids, label_ids):
+        label_type = self._source_collection._get_label_field_type(label_field)
+        is_list_field = issubclass(label_type, fol._LABEL_LIST_FIELDS)
+
+        if not is_list_field:
+            return ids, label_ids
+
+        id_map = defaultdict(list)
+        for _id, _label_id in zip(ids, label_ids):
+            if etau.is_container(_label_id):
+                id_map[_id].extend(_label_id)
+            else:
+                id_map[_id].append(_label_id)
+
+        if not id_map:
+            return [], []
+
+        return zip(*id_map.items())
 
     def set_values(self, field_name, *args, **kwargs):
         field = field_name.split(".", 1)[0]

--- a/fiftyone/core/patches.py
+++ b/fiftyone/core/patches.py
@@ -192,6 +192,33 @@ class _PatchesView(fov.DatasetView):
 
         return names
 
+    def tag_labels(self, tags, label_fields=None):
+        for field in self._parse_label_fields(label_fields=label_fields):
+            view = self._get_source_labels_view(field)
+            view.tag_labels(tags, label_fields=[field])
+
+        super().tag_labels(tags, label_fields=label_fields)
+
+    def untag_labels(self, tags, label_fields=None):
+        for field in self._parse_label_fields(label_fields=label_fields):
+            view = self._get_source_labels_view(field)
+            view.untag_labels(tags, label_fields=[field])
+
+        super().untag_labels(tags, label_fields=label_fields)
+
+    def _parse_label_fields(self, label_fields=None):
+        if label_fields is None:
+            label_fields = self._label_fields
+        elif etau.is_str(label_fields):
+            label_fields = [label_fields]
+
+        return list(set(label_fields) & set(self._label_fields))
+
+    def _get_source_labels_view(self, field):
+        _, id_path = self._get_label_field_path(field, "id")
+        ids = self.values(id_path, unwind=True)
+        return self._source_collection.select_labels(ids=ids, fields=[field])
+
     def set_values(self, field_name, *args, **kwargs):
         field = field_name.split(".", 1)[0]
         must_sync = field in self._label_fields

--- a/fiftyone/core/video.py
+++ b/fiftyone/core/video.py
@@ -160,38 +160,25 @@ class FramesView(fov.DatasetView):
 
         return ["id", "filepath", "sample_id", "_sample_id_1_frame_number_1"]
 
-    def tag_labels(self, tags, label_fields=None):
-        for field in self._parse_label_fields(label_fields=label_fields):
-            view, frame_field = self._get_source_labels_view(field)
-            view.tag_labels(tags, label_fields=[frame_field])
-
-        super().tag_labels(tags, label_fields=label_fields)
-
-    def untag_labels(self, tags, label_fields=None):
-        for field in self._parse_label_fields(label_fields=label_fields):
-            view, frame_field = self._get_source_labels_view(field)
-            view.untag_labels(tags, label_fields=[frame_field])
-
-        super().untag_labels(tags, label_fields=label_fields)
-
-    def _parse_label_fields(self, label_fields=None):
-        if label_fields is None:
-            label_fields = self._get_label_fields()
-        elif etau.is_str(label_fields):
-            label_fields = [label_fields]
-        else:
-            label_fields = list(label_fields)
-
-        return label_fields
-
-    def _get_source_labels_view(self, field):
-        _, id_path = self._get_label_field_path(field, "id")
-        ids = self.values(id_path, unwind=True)
-        frame_field = self._source_collection._FRAMES_PREFIX + field
-        view = self._source_collection.select_labels(
-            ids=ids, fields=[frame_field]
+    def _tag_labels(self, tags, label_field, ids=None, label_ids=None):
+        ids, label_ids = super()._tag_labels(
+            tags, label_field, ids=ids, label_ids=label_ids
         )
-        return view, frame_field
+
+        frame_field = self._source_collection._FRAMES_PREFIX + label_field
+        self._source_collection._tag_labels(
+            tags, frame_field, ids=ids, label_ids=label_ids
+        )
+
+    def _untag_labels(self, tags, label_field, ids=None, label_ids=None):
+        ids, label_ids = super()._untag_labels(
+            tags, label_field, ids=ids, label_ids=label_ids
+        )
+
+        frame_field = self._source_collection._FRAMES_PREFIX + label_field
+        self._source_collection._untag_labels(
+            tags, frame_field, ids=ids, label_ids=label_ids
+        )
 
     def set_values(self, field_name, *args, **kwargs):
         # The `set_values()` operation could change the contents of this view,

--- a/fiftyone/core/video.py
+++ b/fiftyone/core/video.py
@@ -160,6 +160,39 @@ class FramesView(fov.DatasetView):
 
         return ["id", "filepath", "sample_id", "_sample_id_1_frame_number_1"]
 
+    def tag_labels(self, tags, label_fields=None):
+        for field in self._parse_label_fields(label_fields=label_fields):
+            view, frame_field = self._get_source_labels_view(field)
+            view.tag_labels(tags, label_fields=[frame_field])
+
+        super().tag_labels(tags, label_fields=label_fields)
+
+    def untag_labels(self, tags, label_fields=None):
+        for field in self._parse_label_fields(label_fields=label_fields):
+            view, frame_field = self._get_source_labels_view(field)
+            view.untag_labels(tags, label_fields=[frame_field])
+
+        super().untag_labels(tags, label_fields=label_fields)
+
+    def _parse_label_fields(self, label_fields=None):
+        if label_fields is None:
+            label_fields = self._get_label_fields()
+        elif etau.is_str(label_fields):
+            label_fields = [label_fields]
+        else:
+            label_fields = list(label_fields)
+
+        return label_fields
+
+    def _get_source_labels_view(self, field):
+        _, id_path = self._get_label_field_path(field, "id")
+        ids = self.values(id_path, unwind=True)
+        frame_field = self._source_collection._FRAMES_PREFIX + field
+        view = self._source_collection.select_labels(
+            ids=ids, fields=[frame_field]
+        )
+        return view, frame_field
+
     def set_values(self, field_name, *args, **kwargs):
         # The `set_values()` operation could change the contents of this view,
         # so we first record the sample IDs that need to be synced

--- a/tests/unittests/video_tests.py
+++ b/tests/unittests/video_tests.py
@@ -2797,6 +2797,121 @@ class VideoTests(unittest.TestCase):
         with self.assertRaises(KeyError):
             frame["ground_truth"]
 
+    @drop_datasets
+    def test_detection_frames(self):
+        dataset = fo.Dataset()
+
+        sample1 = fo.Sample(
+            filepath="video1.mp4",
+            metadata=fo.VideoMetadata(total_frame_count=4),
+        )
+        sample1.frames[1] = fo.Frame(
+            filepath="frame11.jpg", detection=fo.Detection(label="cat")
+        )
+        sample1.frames[2] = fo.Frame(filepath="frame12.jpg")
+        sample1.frames[3] = fo.Frame(
+            filepath="frame13.jpg", detection=fo.Detection(label="dog")
+        )
+
+        sample2 = fo.Sample(
+            filepath="video2.mp4",
+            metadata=fo.VideoMetadata(total_frame_count=5),
+        )
+        sample2.frames[1] = fo.Frame(
+            filepath="frame21.jpg", detection=fo.Detection(label="dog")
+        )
+        sample2.frames[3] = fo.Frame(filepath="frame23.jpg")
+        sample2.frames[5] = fo.Frame(
+            filepath="frame25.jpg", detection=fo.Detection(label="rabbit")
+        )
+
+        dataset.add_samples([sample1, sample2])
+
+        frames = dataset.to_frames()
+        view = frames.filter_labels("detection", F("label") == "dog")
+
+        view.tag_samples("test")
+
+        self.assertEqual(view.count_sample_tags(), {"test": 2})
+        self.assertEqual(dataset.count_sample_tags(), {})
+
+        view.untag_samples("test")
+
+        self.assertEqual(frames.count_sample_tags(), {})
+        self.assertEqual(dataset.count_sample_tags(), {})
+
+        view.tag_labels("test")
+
+        self.assertEqual(view.count_label_tags(), {"test": 2})
+        self.assertEqual(dataset.count_label_tags(), {"test": 2})
+
+        view.untag_labels("test")
+
+        self.assertEqual(view.count_label_tags(), {})
+        self.assertEqual(dataset.count_label_tags(), {})
+
+        view.tag_labels("test")
+
+        self.assertEqual(view.count_label_tags(), {"test": 2})
+        self.assertEqual(dataset.count_label_tags(), {"test": 2})
+
+        view.select_labels(tags="test").untag_labels("test")
+
+        self.assertEqual(view.count_label_tags(), {})
+        self.assertEqual(dataset.count_label_tags(), {})
+
+    @drop_datasets
+    def test_temporal_detection_clips(self):
+        dataset = fo.Dataset()
+
+        sample1 = fo.Sample(
+            filepath="video1.mp4",
+            metadata=fo.VideoMetadata(total_frame_count=4),
+            event=fo.TemporalDetection(label="meeting", support=[1, 3]),
+        )
+        sample2 = fo.Sample(filepath="video2.mp4")
+        sample3 = fo.Sample(
+            filepath="video3.mp4",
+            metadata=fo.VideoMetadata(total_frame_count=5),
+            event=fo.TemporalDetection(label="party", support=[3, 5]),
+        )
+
+        dataset.add_samples([sample1, sample2, sample3])
+
+        clips = dataset.to_clips("event")
+
+        self.assertEqual(len(clips), 2)
+
+        clips.tag_samples("test")
+
+        self.assertEqual(clips.count_sample_tags(), {"test": 2})
+        self.assertEqual(dataset.count_sample_tags(), {})
+
+        clips.untag_samples("test")
+
+        self.assertEqual(clips.count_sample_tags(), {})
+        self.assertEqual(dataset.count_sample_tags(), {})
+
+        clips.tag_labels("test")
+
+        self.assertEqual(clips.count_label_tags(), {"test": 2})
+        self.assertEqual(dataset.count_label_tags(), {"test": 2})
+
+        clips.untag_labels("test")
+
+        self.assertEqual(clips.count_label_tags(), {})
+        self.assertEqual(dataset.count_label_tags(), {})
+
+        clips.tag_labels("test")
+
+        self.assertEqual(clips.count_label_tags(), {"test": 2})
+        self.assertEqual(dataset.count_label_tags(), {"test": 2})
+
+        clips.select_labels(tags="test").untag_labels("test")
+
+        self.assertEqual(clips.count_label_tags(), {})
+        self.assertEqual(dataset.count_label_tags(), {})
+
 
 if __name__ == "__main__":
     fo.config.show_progress_bars = False


### PR DESCRIPTION
Implements my idea from https://github.com/voxel51/fiftyone/pull/2203: all tagging operations are now done via update operations!

```py
{"$addToSet": {"tags": {"$each": tags}}}  # add tags
{"$pullAll": {"tags": tags}}  # remove tags
```

This is a much better implementation than the current one because:
- The tag edits are no longer applied in-memory; `values()` and `set_values()` are no longer used
- When tagging labels in generated views (patches/frames/clips), the relevant changes are applied to the source collection only on the affected labels by ID, whereas previously the entire field was synced to the source collection via a `$merge` aggregation
