### PR TITLE
Handling exists("frames")

### DIFF
--- a/fiftyone/core/stages.py
+++ b/fiftyone/core/stages.py
@@ -1261,6 +1261,22 @@ class Exists(ViewStage):
             self._field
         )
 
+        # Option 1: treat frames like any other array field
+        if is_frame_field and not field_name:
+            field_name = self._field
+            is_frame_field = False
+
+        # Option 2: special behavior for "frames"
+        """
+        if is_frame_field not field_name:
+            if self._bool:
+                expr = F("frames").length() > 0
+            else:
+                expr = F("frames").length() == 0
+
+            return [{"$match": {"$expr": expr.to_mongo()}}]
+        """
+
         if not is_frame_field:
             expr = F(field_name).exists(self._bool)
             return [{"$match": {"$expr": expr.to_mongo()}}]


### PR DESCRIPTION
We have two options for how `exists("frames")` should work for video datasets:

**Option 1**
Always return all samples, since, as an implementation detail, `frames == []` if no frames have been added, and `exists()` is only supposed to exclude `None`/missing

**Option 2**
Only return samples with at least one frame declared, similar to how `exists("frames.field")` works

**Example usage**

```py
import fiftyone as fo

sample1 = fo.Sample(filepath="video1.mp4")
sample1.frames[1] = fo.Frame()

sample2 = fo.Sample(filepath="video2.mp4")

dataset = fo.Dataset()
dataset.add_samples([sample1, sample2])

view1 = dataset.exists("frames")
print(view1)

view2 = dataset.exists("frames", bool=False)
print(view2)
```
