### PR TITLE
fix flashlight clipping from height overflow

### DIFF
--- a/app/packages/dataset/src/Dataset.tsx
+++ b/app/packages/dataset/src/Dataset.tsx
@@ -58,6 +58,9 @@ const ViewBarWrapper = styled.div`
   background: var(--joy-palette-background-header);
   display: flex;
 `;
+const CoreDatasetContainer = styled.div`
+  height: calc(100% - 84px);
+`;
 
 export function Dataset({
   datasetName,
@@ -109,7 +112,9 @@ export function Dataset({
                 />
               )}
             </ViewBarWrapper>
-            <CoreDataset />
+            <CoreDatasetContainer>
+              <CoreDataset />
+            </CoreDatasetContainer>
           </DatasetLoader>
         </Suspense>
         <div id="modal" />


### PR DESCRIPTION
## What changes are proposed in this pull request?

Fix an issue where bottom row of flashlight images were getting clipped from height overflow

## How is this patch tested? If it is not, please explain why.

Tested visually by ensuring images are no longer clipped and there is no excess space below last row of images once it's fully scrolled

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
