### PR TITLE
Export state from dataset module

### DIFF
--- a/app/packages/dataset/src/index.ts
+++ b/app/packages/dataset/src/index.ts
@@ -1,6 +1,8 @@
-export {Dataset} from './Dataset'
-import {getEnvironment, RelayEnvironmentKey} from '@fiftyone/state'
+export { Dataset } from "./Dataset";
+import { getEnvironment, RelayEnvironmentKey } from "@fiftyone/state";
 
 export function getEnvProps() {
-  return {environment: getEnvironment(), environmentKey: RelayEnvironmentKey}
+  return { environment: getEnvironment(), environmentKey: RelayEnvironmentKey };
 }
+
+export * as fos from "@fiftyone/state";

--- a/app/packages/dataset/src/index.tsx
+++ b/app/packages/dataset/src/index.tsx
@@ -1,8 +1,8 @@
 import React, { useRef } from "react";
 import { createRoot } from "react-dom/client";
-import { RecoilRoot } from "recoil";
+import { RecoilRoot, useRecoilState } from "recoil";
 import { RecoilRelayEnvironmentProvider } from "recoil-relay";
-import { Dataset, getEnvProps } from "./";
+import { Dataset, getEnvProps, fos } from "./";
 
 // import "./index.css";
 
@@ -25,14 +25,39 @@ const DatasetWrapper = () => {
   );
 };
 
+const EXAMPLE_VIEW = [
+  {
+    _cls: "fiftyone.core.stages.Limit",
+    kwargs: [["limit", 10]],
+    _uuid: "020b33dd-775a-4b4a-a865-4901e2e6ee43",
+  },
+];
+
 function LoadableDataset() {
   const [settings, setSettings] = React.useState({
     dataset: "quickstart",
     readOnly: false,
   });
+  const [view, setView] = useRecoilState(fos.view);
+
+  function printView() {
+    console.log(JSON.stringify(view, null, 2));
+  }
+
+  function changeView() {
+    setView(EXAMPLE_VIEW);
+  }
+
+  function clearView() {
+    setView([]);
+  }
+
   return (
     <>
       <DatasetSettings current={settings} onChange={setSettings} />
+      <button onClick={() => printView()}>Print View</button>
+      <button onClick={() => changeView()}>Set View</button>
+      <button onClick={() => clearView()}>Clear View</button>
       <div style={{ height: "100vh", overflow: "hidden" }}>
         <Dataset datasetName={settings.dataset} readOnly={settings.readOnly} />
       </div>

--- a/app/packages/state/README.md
+++ b/app/packages/state/README.md
@@ -1,3 +1,34 @@
 # State
 
 FiftyOne App state APIs
+
+## Usage
+
+This package can be used in the following contexts
+
+- internal - for interacting with the app state within the core app modules
+- external - for interacting with the state of an embeded app aka the `<Dataset />` component
+- plugin - for interacting with app state in your plugin
+
+## Types
+
+The API assumes you are running in one of the contexts listed above, which requires the ability to interact with the following types of objects.
+
+### Recoil
+
+- `Atom`
+- `Selector`
+- `SelectorFamily`
+
+### React Hooks
+
+Custom hooks following similar patterns to the following:
+
+- `useEffect`
+- `useState`
+- `useCallback`
+- etc.
+
+## API Reference
+
+Coming soon. This will describe each of the exported objects and functions.


### PR DESCRIPTION
Allows for managing state externally.

See [here](https://github.com/voxel51/fiftyone/pull/2214/files#diff-df67c1016008538fab6072e014adc3a196aeb28234134be32382edf99f41c043R41) for example usage.