### PR TITLE
Fix unset media field

### DIFF
--- a/app/packages/core/src/components/Modal/Group.tsx
+++ b/app/packages/core/src/components/Modal/Group.tsx
@@ -164,6 +164,8 @@ const withVisualizerPlugin = <
       onSelectLabel,
       useState: useRecoilValue,
       state: fos,
+      mediaFieldValue: urls[mediaField],
+      mediaField,
       src: getSampleSrc(urls[mediaField]),
     };
 

--- a/app/packages/looker-3d/src/Looker3d.tsx
+++ b/app/packages/looker-3d/src/Looker3d.tsx
@@ -269,6 +269,11 @@ export const usePathFilter = (): Partial => {
 };
 
 export function Looker3d(props) {
+  const mediaFieldValue = props?.api?.mediaFieldValue;
+  const mediaField = props?.api?.mediaField;
+  if (!mediaFieldValue) {
+    return <Loading>No value provided for "{mediaField}".</Loading>;
+  }
   return (
     <ErrorBoundary>
       <Looker3dCore {...props} />
@@ -276,7 +281,7 @@ export function Looker3d(props) {
   );
 }
 
-function Looker3dCore({ api: { sample, src } }) {
+function Looker3dCore({ api: { sample, src, mediaFieldValue } }) {
   const settings = fop.usePluginSettings("3d");
 
   const modal = true;

--- a/fiftyone/server/samples.py
+++ b/fiftyone/server/samples.py
@@ -27,7 +27,7 @@ from fiftyone.server.scalars import BSON, JSON, BSONArray
 @gql.type
 class MediaURL:
     field: str
-    url: str
+    url: t.Optional[str]
 
 
 @gql.interface


### PR DESCRIPTION
Fixes [this](https://github.com/voxel51/fiftyone/issues/2164) issue by allowing mediaFields to be null.

Also adds improved error messages when a mediaField is null in Looker3D.