### PR TITLE
fix json panel styles in light theme

### DIFF
--- a/app/packages/components/src/components/Icons/Icons.tsx
+++ b/app/packages/components/src/components/Icons/Icons.tsx
@@ -1,4 +1,4 @@
-import { SvgIcon } from "@mui/material";
+import { SvgIcon, SvgIconProps } from "@mui/material";
 import { GitHub, MenuBook } from "@mui/icons-material";
 import React from "react";
 
@@ -57,6 +57,21 @@ export const DocsLink = () => {
     </ExternalLink>
   );
 };
+
+export function Copy(props: SvgIconProps) {
+  return (
+    <SvgIcon {...props}>
+      <path d="M19,3H14.82C14.4,1.84 13.3,1 12,1C10.7,1 9.6,1.84 9.18,3H5A2,2 0 0,0 3,5V19A2,2 0 0,0 5,21H19A2,2 0 0,0 21,19V5A2,2 0 0,0 19,3M12,3A1,1 0 0,1 13,4A1,1 0 0,1 12,5A1,1 0 0,1 11,4A1,1 0 0,1 12,3M7,7H17V5H19V19H5V5H7V7Z" />
+    </SvgIcon>
+  );
+}
+export function Close(props: SvgIconProps) {
+  return (
+    <SvgIcon {...props}>
+      <path d="M19,3H5A2,2 0 0,0 3,5V19A2,2 0 0,0 5,21H19A2,2 0 0,0 21,19V5A2,2 0 0,0 19,3M19,19H5V5H19V19M17,8.4L13.4,12L17,15.6L15.6,17L12,13.4L8.4,17L7,15.6L10.6,12L7,8.4L8.4,7L12,10.6L15.6,7L17,8.4Z" />
+    </SvgIcon>
+  );
+}
 
 export { KeyboardArrowDown, KeyboardArrowUp } from "@mui/icons-material";
 export { IconButton } from "@mui/material";

--- a/app/packages/components/src/components/Icons/index.ts
+++ b/app/packages/components/src/components/Icons/index.ts
@@ -6,4 +6,6 @@ export {
   KeyboardArrowDown,
   KeyboardArrowUp,
   IconButton,
+  Close,
+  Copy,
 } from "./Icons";

--- a/app/packages/components/src/components/JSONPanel/JSONPanel.tsx
+++ b/app/packages/components/src/components/JSONPanel/JSONPanel.tsx
@@ -1,6 +1,7 @@
 /**
  * Copyright 2017-2022, Voxel51, Inc.
  */
+import { Copy as CopyIcon, Close as CloseIcon } from "@fiftyone/components";
 import {
   lookerPanel,
   lookerPanelContainer,
@@ -11,30 +12,6 @@ import {
   lookerCloseJSON,
   lookerJSONPanel,
 } from "./json.module.css";
-import closeIcon from "../../icons/close.svg";
-import clipboardIcon from "../../icons/clipboard.svg";
-
-function Close({ onClick }) {
-  return (
-    <img
-      src={closeIcon}
-      className={lookerCloseJSON}
-      title="Close JSON"
-      onClick={onClick}
-    />
-  );
-}
-
-function Copy({ onClick }) {
-  return (
-    <img
-      src={clipboardIcon}
-      className={lookerCopyJSON}
-      title="Copy JSON to clipboard"
-      onClick={onClick}
-    />
-  );
-}
 
 export default function JSONPanel({ containerRef, jsonHTML, onClose, onCopy }) {
   return (
@@ -47,8 +24,22 @@ export default function JSONPanel({ containerRef, jsonHTML, onClose, onCopy }) {
         <div className={lookerPanel}>
           {jsonHTML && <pre dangerouslySetInnerHTML={jsonHTML} />}
         </div>
-        <Close onClick={onClose} />
-        <Copy onClick={onCopy} />
+        <CloseIcon
+          className={lookerCloseJSON}
+          titleAccess="Close JSON"
+          onClick={onClose}
+          sx={{
+            fontSize: "1.75rem",
+          }}
+        />
+        <CopyIcon
+          className={lookerCopyJSON}
+          titleAccess="Copy JSON to clipboard"
+          onClick={onCopy}
+          sx={{
+            fontSize: "1.75rem",
+          }}
+        />
       </div>
     </div>
   );

--- a/app/packages/components/src/components/JSONPanel/json.module.css
+++ b/app/packages/components/src/components/JSONPanel/json.module.css
@@ -38,5 +38,6 @@
 .lookerCloseJSON:hover,
 .lookerCopyJSON:hover {
   background-color: var(--joy-palette-primary-plainColor);
+  color: var(--joy-palette-text-buttonHighlight);
   transform: translate(0, -1px);
 }

--- a/app/packages/state/src/hooks/useJSONPanel.ts
+++ b/app/packages/state/src/hooks/useJSONPanel.ts
@@ -1,19 +1,13 @@
-import { Sample } from "@fiftyone/looker/src/state";
 import { useMemo } from "react";
 import copyToClipboard from "copy-to-clipboard";
 import highlightJSON from "json-format-highlight";
 import * as fos from "../../";
 import usePanel from "./usePanel";
 
-type JSONPanelState = {
-  sample?: Sample;
-  isOpen: boolean;
-};
-
 export const JSON_COLORS = {
-  keyColor: "rgb(138, 138, 138)",
+  keyColor: "var(--joy-palette-text-tertiary)",
   numberColor: "rgb(225, 100, 40)",
-  stringColor: "rgb(238, 238, 238)",
+  stringColor: "var(--joy-palette-text-secondary)",
   nullColor: "rgb(225, 100, 40)",
   trueColor: "rgb(225, 100, 40)",
   falseColor: "rgb(225, 100, 40)",


### PR DESCRIPTION
## What changes are proposed in this pull request?

Fix JSON panel syntax highlighting colors and copy/close icon colors in light theme.

## How is this patch tested? If it is not, please explain why.

Tested visually in both light and dark theme.

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
