### PR TITLE
fix range slider value label style

### DIFF
--- a/app/packages/core/src/components/Common/RangeSlider.tsx
+++ b/app/packages/core/src/components/Common/RangeSlider.tsx
@@ -55,6 +55,7 @@ const SliderStyled = styled(SliderUnstyled)`
   .thumb:focus,
   .thumb.active {
     box-shadow: none;
+    z-index: 1;
   }
 
   .valueLabel::before {
@@ -68,7 +69,7 @@ const SliderStyled = styled(SliderUnstyled)`
     margin-top: -100%;
     padding: 0 0.25rem;
     color: transparent;
-    transform: none !important;
+    top: 100%;
     color: ${({ theme }) => theme.palette.text.primary};
     background: ${({ theme }) => theme.palette.background.level2};
     border: 1px solid ${({ theme }) => theme.palette.primary.plainBorder};
@@ -192,9 +193,10 @@ const BaseSlider = <T extends Range | number>({
           step={step}
           theme={{
             palette: {
-            ...theme,
-            color,
-            primary: { ...theme.primary, plainColor: color } }
+              ...theme,
+              color,
+              primary: { ...theme.primary, plainColor: color },
+            },
           }}
         />
         {showBounds && formatter(bounds[1])}


### PR DESCRIPTION
## What changes are proposed in this pull request?

Fix an issue where multi-line range slider label covers range slider thumb. Also adds an enhancement to show lower range label on hover when two labels are near and the higher range label covers lower range label.

## How is this patch tested? If it is not, please explain why.

Visually tested to ensure label for various types of range slider renders correctly.

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
