### PR TITLE
fix typo in colorscale route

### DIFF
--- a/fiftyone/server/routes/__init__.py
+++ b/fiftyone/server/routes/__init__.py
@@ -29,7 +29,7 @@ from .values import Values
 routes = [
     ("/aggregate", Aggregate),
     ("/aggregations", Aggregations),
-    ("/coloscales", Colorscales),
+    ("/colorscales", Colorscales),
     ("/distributions", Distributions),
     ("/event", Event),
     ("/events", Events),


### PR DESCRIPTION
## What changes are proposed in this pull request?

- fix typo: `coloscales` -> `colorscales` so that the get request will work (https://github.com/voxel51/fiftyone/blob/develop/fiftyone/server/routes/colorscales.py#L19)

## How is this patch tested? If it is not, please explain why.

(Details)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
