### PR TITLE
Optimizing ordered select implementation

### DIFF
--- a/fiftyone/core/stages.py
+++ b/fiftyone/core/stages.py
@@ -4850,16 +4850,18 @@ class Select(ViewStage):
 
         pipeline = [{"$match": {"_id": {"$in": ids}}}]
 
-        if not self._ordered:
-            return pipeline
-
-        pipeline.extend(
-            [
-                {"$set": {"_select_order": {"$indexOfArray": [ids, "$_id"]}}},
-                {"$sort": {"_select_order": 1}},
-                {"$unset": "_select_order"},
-            ]
-        )
+        if self._ordered:
+            pipeline.extend(
+                [
+                    {
+                        "$set": {
+                            "_select_order": {"$indexOfArray": [ids, "$_id"]}
+                        }
+                    },
+                    {"$sort": {"_select_order": 1}},
+                    {"$unset": "_select_order"},
+                ]
+            )
 
         return pipeline
 
@@ -4972,19 +4974,24 @@ class SelectBy(ViewStage):
         else:
             values = self._values
 
-        if not self._ordered:
-            return [{"$match": {path: {"$in": values}}}]
+        pipeline = [{"$match": {path: {"$in": values}}}]
 
-        return [
-            {
-                "$set": {
-                    "_select_order": {"$indexOfArray": [values, "$" + path]}
-                }
-            },
-            {"$match": {"_select_order": {"$gt": -1}}},
-            {"$sort": {"_select_order": 1}},
-            {"$unset": "_select_order"},
-        ]
+        if self._ordered:
+            pipeline.extend(
+                [
+                    {
+                        "$set": {
+                            "_select_order": {
+                                "$indexOfArray": [values, "$" + path]
+                            }
+                        }
+                    },
+                    {"$sort": {"_select_order": 1}},
+                    {"$unset": "_select_order"},
+                ]
+            )
+
+        return pipeline
 
     def _kwargs(self):
         return [
@@ -5338,19 +5345,24 @@ class SelectGroups(ViewStage):
         id_path = sample_collection.group_field + "._id"
         ids = [ObjectId(_id) for _id in self._group_ids]
 
-        if not self._ordered:
-            return [{"$match": {id_path: {"$in": ids}}}]
+        pipeline = [{"$match": {id_path: {"$in": ids}}}]
 
-        return [
-            {
-                "$set": {
-                    "_select_order": {"$indexOfArray": [ids, "$" + id_path]}
-                }
-            },
-            {"$match": {"_select_order": {"$gt": -1}}},
-            {"$sort": {"_select_order": 1}},
-            {"$unset": "_select_order"},
-        ]
+        if self._ordered:
+            pipeline.extend(
+                [
+                    {
+                        "$set": {
+                            "_select_order": {
+                                "$indexOfArray": [ids, "$" + id_path]
+                            }
+                        }
+                    },
+                    {"$sort": {"_select_order": 1}},
+                    {"$unset": "_select_order"},
+                ]
+            )
+
+        return pipeline
 
     def _kwargs(self):
         return [["group_ids", self._group_ids], ["ordered", self._ordered]]

--- a/fiftyone/core/stages.py
+++ b/fiftyone/core/stages.py
@@ -4848,15 +4848,20 @@ class Select(ViewStage):
 
         ids = [ObjectId(_id) for _id in self._sample_ids]
 
-        if not self._ordered:
-            return [{"$match": {"_id": {"$in": ids}}}]
+        pipeline = [{"$match": {"_id": {"$in": ids}}}]
 
-        return [
-            {"$set": {"_select_order": {"$indexOfArray": [ids, "$_id"]}}},
-            {"$match": {"_select_order": {"$gt": -1}}},
-            {"$sort": {"_select_order": 1}},
-            {"$unset": "_select_order"},
-        ]
+        if not self._ordered:
+            return pipeline
+
+        pipeline.extend(
+            [
+                {"$set": {"_select_order": {"$indexOfArray": [ids, "$_id"]}}},
+                {"$sort": {"_select_order": 1}},
+                {"$unset": "_select_order"},
+            ]
+        )
+
+        return pipeline
 
     def _kwargs(self):
         return [["sample_ids", self._sample_ids], ["ordered", self._ordered]]


### PR DESCRIPTION
In the typical case where the number of selected IDs is small compared to the number of total documents, this implementation of ordered `select()`, `select_by()` and `select_groups()` should be more efficient. `$match` first, then `$set`.