### PR TITLE
Update CVAT integration and docs to point to app.cvat.ai

### DIFF
--- a/docs/source/integrations/cvat.rst
+++ b/docs/source/integrations/cvat.rst
@@ -9,8 +9,8 @@ CVAT Integration
 open-source image and video annotation tools available, and we've made it easy
 to upload your data directly from FiftyOne to CVAT to add or edit labels.
 
-You can use CVAT either through the demo server at
-`cvat.org <https://cvat.org>`_ or through a
+You can use CVAT either through the hosted server at
+`app.cvat.ai <https://app.cvat.ai>`_ or through a
 `self-hosted server <https://openvinotoolkit.github.io/cvat/docs/administration/basics/installation/>`_.
 In either case, FiftyOne provides :ref:`simple setup <cvat-setup>` instructions
 that you can use to specify the necessary account credentials and server
@@ -78,7 +78,7 @@ The example below demonstrates this workflow.
 
 .. note::
 
-    You must create an account at `cvat.org <https://cvat.org>`_ in order to
+    You must create an account at `app.cvat.ai <https://app.cvat.ai>`_ in order to
     run this example.
 
     Note that you can store your credentials as described in
@@ -173,11 +173,11 @@ FiftyOne:
 Setup
 _____
 
-FiftyOne supports both `cvat.org <https://cvat.org>`_ and
+FiftyOne supports both `app.cvat.ai <https://app.cvat.ai>`_ and
 `self-hosted servers <https://openvinotoolkit.github.io/cvat/docs/administration/basics/installation/>`_.
 
 The easiest way to get started is to use the default server
-`cvat.org <https://cvat.org>`_, which simply requires creating an account and
+`app.cvat.ai <https://app.cvat.ai>`_, which simply requires creating an account and
 then providing your authentication credentials as shown below.
 
 .. note::

--- a/docs/source/user_guide/annotation.rst
+++ b/docs/source/user_guide/annotation.rst
@@ -10,7 +10,7 @@ labels on your :ref:`datasets <using-datasets>` or specific
 :ref:`views <using-views>` into them.
 
 By default, all annotation is performend via a native
-:ref:`CVAT integration <cvat-integration>` that uses `cvat.org <https://cvat.org>`_, but
+:ref:`CVAT integration <cvat-integration>` that uses `app.cvat.ai <https://app.cvat.ai>`_, but
 you can use a :ref:`self-hosted CVAT server <cvat-setup>`, switch to the
 :ref:`Labelbox backend <labelbox-integration>`, or even use a
 :ref:`custom annotation backend <custom-annotation-backend>`.
@@ -55,7 +55,7 @@ The example below demonstrates this workflow using the default
 
 .. note::
 
-    You must create an account at `cvat.org <https://cvat.org>`_ in order to
+    You must create an account at `app.cvat.ai <https://app.cvat.ai>`_ in order to
     run this example.
 
     Note that you can store your credentials as described in
@@ -150,7 +150,7 @@ FiftyOne:
 Setup
 _____
 
-By default, all annotation is performed via `cvat.org <https://cvat.org>`_,
+By default, all annotation is performed via `app.cvat.ai <https://app.cvat.ai>`_,
 which simply requires that you create an account and then configure your
 username and password credentials.
 
@@ -260,7 +260,7 @@ and the CLI:
             "backends": {
                 "cvat": {
                     "config_cls": "fiftyone.utils.cvat.CVATBackendConfig",
-                    "url": "https://cvat.org"
+                    "url": "https://app.cvat.ai"
                 }
             }
         }
@@ -279,7 +279,7 @@ and the CLI:
             "backends": {
                 "cvat": {
                     "config_cls": "fiftyone.utils.cvat.CVATBackendConfig",
-                    "url": "https://cvat.org"
+                    "url": "https://app.cvat.ai"
                 }
             }
         }

--- a/fiftyone/core/config.py
+++ b/fiftyone/core/config.py
@@ -445,7 +445,7 @@ class AnnotationConfig(EnvConfig):
     _BUILTIN_BACKENDS = {
         "cvat": {
             "config_cls": "fiftyone.utils.cvat.CVATBackendConfig",
-            "url": "https://cvat.org",
+            "url": "https://app.cvat.ai",
         },
         "labelbox": {
             "config_cls": "fiftyone.utils.labelbox.LabelboxBackendConfig",


### PR DESCRIPTION
CVAT has recently moved from hosting their server from cvat.org to app.cvat.ai. This PR updates the integration to point to app.cvat.ai by default and updates corresponding the references in the docs and tutorials.