### PR TITLE
Downgrade starlette

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -27,7 +27,7 @@ scikit-image>=0.16.2
 setuptools==45.2.0
 sseclient-py>=1.7.2
 sse-starlette>=0.10.3
-starlette==0.21.0
+starlette==0.20.4
 strawberry-graphql==0.138.1
 tabulate==0.8.10
 universal-analytics-python3==1.0.1

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ INSTALL_REQUIRES = [
     "setuptools",
     "sseclient-py>=1.7.2,<2",
     "sse-starlette>=0.10.3,<1",
-    "starlette==0.21.0",
+    "starlette==0.20.4",
     "strawberry-graphql==0.138.1",
     "tabulate",
     "xmltodict",


### PR DESCRIPTION
I didn't notice this got bumped in the previous PR. The version was too high for FastAPI and VoxelHub to be able to use it. Dropping it back down.