### PR TITLE
update view bar colors on theme change

### DIFF
--- a/app/packages/core/src/components/ViewBar/ViewStage/ViewStage.tsx
+++ b/app/packages/core/src/components/ViewBar/ViewStage/ViewStage.tsx
@@ -12,6 +12,8 @@ import SearchResults from "./SearchResults";
 import ViewStageParameter from "./ViewStageParameter";
 import { getMatch } from "./utils";
 import { useTheme } from "@fiftyone/components";
+import { theme as themeState } from "@fiftyone/state";
+import { useRecoilValue } from "recoil";
 
 const ViewStageContainer = animated(styled.div`
   margin: 0.5rem;
@@ -80,6 +82,7 @@ const ViewStageButton = styled.div`
 
 export const AddViewStage = React.memo(({ send, index, active }) => {
   const theme = useTheme();
+  const themeMode = useRecoilValue(themeState);
   const [hovering, setHovering] = useState(false);
   const [props, set] = useSpring(() => ({
     background: theme.background,
@@ -100,7 +103,7 @@ export const AddViewStage = React.memo(({ send, index, active }) => {
       borderColor: active ? theme.primary.plainColor : theme.text.tertiary,
     });
     active ? setEnterProps() : setLeaveProps();
-  }, [active]);
+  }, [active, themeMode]);
 
   const [addProps, setAdd] = useSpring(() => ({
     marginTop: active ? 0 : 31,
@@ -332,7 +335,7 @@ const ViewStage = React.memo(({ barRef, stageRef }) => {
               style={{
                 width: "1rem",
                 height: "1rem",
-                margin: "0.4rem 0.5rem 0.5rem 0",
+                margin: "0.4rem 0.5rem 0.75rem 0",
               }}
             >
               <ExternalLink
@@ -343,6 +346,7 @@ const ViewStage = React.memo(({ barRef, stageRef }) => {
                   style={{
                     width: "1rem",
                     height: "1rem",
+                    color: theme.text.secondary,
                   }}
                 />
               </ExternalLink>

--- a/app/packages/core/src/components/ViewBar/ViewStage/ViewStageParameter.tsx
+++ b/app/packages/core/src/components/ViewBar/ViewStage/ViewStageParameter.tsx
@@ -11,6 +11,8 @@ import { useEventHandler, useObserve, useOutsideClick } from "@fiftyone/state";
 import ErrorMessage from "./ErrorMessage";
 import SearchResults from "./SearchResults";
 import { useTheme } from "@fiftyone/components";
+import { theme as themeState } from "@fiftyone/state";
+import { useRecoilValue } from "recoil";
 
 const ViewStageParameterContainer = styled.div`
   display: flex;
@@ -150,6 +152,7 @@ const ObjectEditor = ({
   const [stageState] = useService(stageRef);
   const theme = useContext(ThemeContext);
   const containerRef = useRef(null);
+  const themeMode = useRecoilValue(themeState);
 
   const { active, value } = state.context;
 
@@ -199,6 +202,7 @@ const ObjectEditor = ({
     state.matches("editing"),
     active,
     stageState.matches("focusedViewBar.yes"),
+    themeMode,
   ]);
 
   const attach = () => {


### PR DESCRIPTION
## What changes are proposed in this pull request?

Fix view bar colors not updating when toggling between light and dark theme. React spring library resolves css variable to it's corresponding color codes resulting in static colors which are staled when theme mode is switched. Changes in this PR forces re-resolution of color on theme change. 

## How is this patch tested? If it is not, please explain why.

Visually tested by toggling between theme to ensure colors updates as intended.

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
