### PR TITLE
remove redundant font family styles

### DIFF
--- a/app/packages/components/src/components/Tooltip/Tooltip.module.css
+++ b/app/packages/components/src/components/Tooltip/Tooltip.module.css
@@ -5,7 +5,6 @@
   padding: 0.25rem;
   border-radius: 3px;
   z-index: 1000;
-  font-family: var(--joy-fontFamily-body);
   font-size: 14px;
   color: var(--joy-palette-text-secondary);
 }

--- a/app/packages/dataset/src/Dataset.tsx
+++ b/app/packages/dataset/src/Dataset.tsx
@@ -44,14 +44,10 @@ const Container = styled.div`
   padding: 0;
   font-family: "Palanquin", sans-serif;
   font-size: 14px;
-
   color: var(--joy-palette-text-primary);
   display: flex;
   flex-direction: column;
   min-width: 660px;
-  & * {
-    font-family: var(--joy-fontFamily-body);
-  }
 `;
 const ViewBarWrapper = styled.div`
   padding: 16px;


### PR DESCRIPTION
## What changes are proposed in this pull request?

Removes redundant font family styles

## How is this patch tested? If it is not, please explain why.

Visually inspected affected components to ensure font family remains the same

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
