### PR TITLE
fix toggling field not capturing click some times

### DIFF
--- a/app/packages/core/src/components/Sidebar/Entries/Draggable.tsx
+++ b/app/packages/core/src/components/Sidebar/Entries/Draggable.tsx
@@ -29,6 +29,9 @@ const Draggable: React.FC<
   return (
     <>
       <animated.div
+        onClick={(event) => {
+          event.stopPropagation();
+        }}
         onMouseDown={
           trigger
             ? (event) => {

--- a/app/packages/core/src/components/Sidebar/Entries/RegularEntry.tsx
+++ b/app/packages/core/src/components/Sidebar/Entries/RegularEntry.tsx
@@ -52,20 +52,10 @@ const RegularEntry = React.forwardRef(
     }: RegularEntryProps,
     ref
   ) => {
-    const canCommit = useRef(false);
-
     return (
       <Container
         ref={ref}
-        onMouseDown={() => {
-          canCommit.current = true;
-        }}
-        onMouseMove={() => {
-          canCommit.current && (canCommit.current = false);
-        }}
-        onMouseUp={(event) => {
-          canCommit.current && onClick && onClick(event);
-        }}
+        onClick={onClick}
         style={{
           backgroundColor,
           cursor: clickable ? "pointer" : "unset",


### PR DESCRIPTION
## What changes are proposed in this pull request?

Fixes an issue where toggle field does not register click sometime if you move cursor right after click a field or checkbox.

## How is this patch tested? If it is not, please explain why.

Visually inspected to ensure clicking and moving the cursor away is registered as toggle but drag or selection is not.

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
