### PR TITLE
fix label tag text color in light theme

### DIFF
--- a/app/packages/components/src/components/ThemeProvider/index.tsx
+++ b/app/packages/components/src/components/ThemeProvider/index.tsx
@@ -53,6 +53,7 @@ let theme = extendJoyTheme({
           primary: "hsl(200, 0%, 0%)",
           secondary: "hsl(200, 0%, 30%)",
           tertiary: "hsl(200, 0%, 50%)",
+          lookerTag: "hsl(200, 0%, 100%)",
         },
         custom: {
           shadow: "hsl(200, 0%, 90%)",
@@ -102,6 +103,7 @@ let theme = extendJoyTheme({
           secondary: "hsl(200, 0%, 70%)",
           tertiary: "hsl(200, 0%, 50%)",
           buttonHighlight: "hsl(200, 0%, 100%)",
+          lookerTag: "hsl(200, 0%, 100%)",
         },
         custom: {
           shadow: "hsl(200, 0%, 10%)",

--- a/app/packages/looker/src/elements/common/tags.module.css
+++ b/app/packages/looker/src/elements/common/tags.module.css
@@ -30,7 +30,7 @@
   height: 1em;
   margin: 0 2px 0;
   padding: 3px;
-  color: var(--joy-palette-text-primary);
+  color: var(--joy-palette-text-lookerTag);
   font-size: 14px;
   line-height: 12px;
   border-radius: 3px;
@@ -46,5 +46,5 @@
 }
 
 .lookerTags > div > a {
-  color: var(--joy-palette-text-primary);
+  color: var(--joy-palette-text-lookerTag);
 }


### PR DESCRIPTION
## What changes are proposed in this pull request?

Fixes a style issue where label tag text color becomes lighter shade of black. 

## How is this patch tested? If it is not, please explain why.

Tested by visually inspecting label tag text color in both dark and light theme

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
