### PR TITLE
action row popover content color enhancements

### DIFF
--- a/app/packages/components/src/components/TabOption/TabOption.tsx
+++ b/app/packages/components/src/components/TabOption/TabOption.tsx
@@ -50,7 +50,8 @@ export default ({ active, options, color }: TabOptionProps) => {
           : hovering[i]
           ? theme.background.body
           : theme.background.level1,
-      color: hovering ? theme.text.primary : theme.text.secondary,
+      color:
+        o.text === active ? theme.text.buttonHighlight : theme.text.secondary,
     }))
   );
 

--- a/app/packages/core/src/components/Actions/Checker.tsx
+++ b/app/packages/core/src/components/Actions/Checker.tsx
@@ -78,7 +78,7 @@ const Check = ({
         onChange={() => !disabled && onCheck()}
         checked={checkmark === CheckState.ADD || checkmark === null}
         style={{
-          color: edited ? theme.primary.plainColor : theme.text.secondary,
+          color: theme.primary.plainColor,
           padding: "0 0.5rem 0 0",
         }}
       />

--- a/app/packages/core/src/components/utils.tsx
+++ b/app/packages/core/src/components/utils.tsx
@@ -306,7 +306,7 @@ export const Button = ({
   color = color ?? theme.primary.plainColor;
   const props = useSpring({
     backgroundColor: hover ? color : theme.background.body,
-    color: hover ? theme.text.primary : theme.text.secondary,
+    color: hover ? theme.text.buttonHighlight : theme.text.secondary,
     config: {
       duration: 150,
     },


### PR DESCRIPTION
## What changes are proposed in this pull request?

Improve action row popover items background and text color

## How is this patch tested? If it is not, please explain why.

Tested visually in both light and dark theme

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
