### PR TITLE
Build 404 for SPA intex.html handling

### DIFF
--- a/app/packages/app/public/404.html
+++ b/app/packages/app/public/404.html
@@ -1,0 +1,1 @@
+<!-- don't delete me -->

--- a/fiftyone/server/.gitignore
+++ b/fiftyone/server/.gitignore
@@ -1,2 +1,1 @@
 static/*
-!static/404.html


### PR DESCRIPTION
A change in starlette default 404 handling now requires a 404.html to be present in the static directory for the Static file route to resolve on app routes, e.g. `dataset/my-dataset`. Adding a dummy 404.html to the public folder in `@fiftyone/app` accommodates the peculiar behavior.