### PR TITLE
toggle sidebar entry only on clicking header

### DIFF
--- a/app/packages/core/src/components/Sidebar/Entries/FilterablePathEntry.tsx
+++ b/app/packages/core/src/components/Sidebar/Entries/FilterablePathEntry.tsx
@@ -341,7 +341,7 @@ const FilterableEntry = React.memo(
             </NameAndCountContainer>
           </>
         }
-        onClick={!disabled ? () => setActive(!active) : null}
+        onHeaderClick={!disabled ? () => setActive(!active) : undefined}
         title={`${path} (${
           field.embeddedDocType
             ? field.embeddedDocType

--- a/app/packages/core/src/components/Sidebar/Entries/FilterableTagEntry.tsx
+++ b/app/packages/core/src/components/Sidebar/Entries/FilterableTagEntry.tsx
@@ -153,7 +153,7 @@ const FilterableTagEntry = ({
           </NameAndCountContainer>
         </>
       }
-      onClick={() => setActive(!active)}
+      onHeaderClick={() => setActive(!active)}
       title={tag}
     />
   );

--- a/app/packages/core/src/components/Sidebar/Entries/RegularEntry.tsx
+++ b/app/packages/core/src/components/Sidebar/Entries/RegularEntry.tsx
@@ -28,6 +28,7 @@ type RegularEntryProps = React.PropsWithChildren<{
   heading: ReactNode;
   left?: boolean;
   onClick?: MouseEventHandler;
+  onHeaderClick?: MouseEventHandler;
   title: string;
   trigger?: (
     event: React.MouseEvent<HTMLDivElement>,
@@ -47,11 +48,15 @@ const RegularEntry = React.forwardRef(
       heading,
       left = false,
       onClick,
+      onHeaderClick,
       title,
       trigger,
     }: RegularEntryProps,
     ref
   ) => {
+    const tolerance = 5;
+    const headerClickStart = useRef<MouseEvent>();
+
     return (
       <Container
         ref={ref}
@@ -63,7 +68,24 @@ const RegularEntry = React.forwardRef(
         title={title}
       >
         <Draggable color={color} entryKey={entryKey} trigger={trigger}>
-          <Header style={{ justifyContent: left ? "left" : "space-between" }}>
+          <Header
+            onMouseDown={(event: MouseEvent) => {
+              headerClickStart.current = event;
+            }}
+            onMouseUp={(event: MouseEvent) => {
+              if (!onHeaderClick) return;
+              const startX = headerClickStart.current.pageX;
+              const startY = headerClickStart.current.pageY;
+              const endX = event.pageX;
+              const endY = event.pageY;
+              const deltaX = Math.abs(endX - startX);
+              const deltaY = Math.abs(endY - startY);
+              if (deltaX <= tolerance && deltaY <= tolerance) {
+                onHeaderClick(event);
+              }
+            }}
+            style={{ justifyContent: left ? "left" : "space-between" }}
+          >
             {heading}
           </Header>
           {children}


### PR DESCRIPTION
## What changes are proposed in this pull request?

Improve sidebar toggle entry to only toggle when header of entry is clicked and prevent toggle on click and drag to avoid unexpected toggle on selection of entry text.  

### Demo
![Kapture 2022-11-05 at 18 57 13](https://user-images.githubusercontent.com/25350704/200144472-f48905c9-da62-406c-8cd1-300f4e77d3e6.gif)


## How is this patch tested? If it is not, please explain why.

Tested visually by interacting with field to ensure entry is toggled only when expected. 

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
