### PR TITLE
fix toggle error when click start event is unset

### DIFF
--- a/app/packages/core/src/components/Sidebar/Entries/RegularEntry.tsx
+++ b/app/packages/core/src/components/Sidebar/Entries/RegularEntry.tsx
@@ -74,8 +74,8 @@ const RegularEntry = React.forwardRef(
             }}
             onMouseUp={(event: MouseEvent) => {
               if (!onHeaderClick) return;
-              const startX = headerClickStart.current.pageX;
-              const startY = headerClickStart.current.pageY;
+              const startX = headerClickStart?.current?.pageX;
+              const startY = headerClickStart?.current?.pageY;
               const endX = event.pageX;
               const endY = event.pageY;
               const deltaX = Math.abs(endX - startX);


### PR DESCRIPTION
## What changes are proposed in this pull request?

PR fixes error in console when click start event is not set on toggling sidebar entry. Not really sure why `onMouseUp` handler would be called without click start event being set in `onMouseDown` handler.

## How is this patch tested? If it is not, please explain why.

Tested manually to verify console error is no longer logged.

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
