### PR TITLE
Add support for configuring the default App theme

### DIFF
--- a/app/packages/core/src/Root/Root.tsx
+++ b/app/packages/core/src/Root/Root.tsx
@@ -240,6 +240,7 @@ const Root: Route<RootQuery> = ({ children, prepared }) => {
           showLabel
           showSkeletons
           showTooltip
+          theme
           timezone
           useFrameNumber
         }

--- a/app/packages/core/src/Root/__generated__/RootConfig_query.graphql.ts
+++ b/app/packages/core/src/Root/__generated__/RootConfig_query.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<e5feb27d43e7b28b2b4e4d25d8e7abb0>>
+ * @generated SignedSource<<5089c0d3f4431db72a359dc138237c4c>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -10,6 +10,7 @@
 
 import { Fragment, ReaderFragment } from 'relay-runtime';
 export type ColorBy = "field" | "instance" | "label" | "%future added value";
+export type Theme = "browser" | "dark" | "light" | "%future added value";
 import { FragmentRefs } from "relay-runtime";
 export type RootConfig_query$data = {
   readonly colorscale: ReadonlyArray<ReadonlyArray<number>> | null;
@@ -26,6 +27,7 @@ export type RootConfig_query$data = {
     readonly showLabel: boolean;
     readonly showSkeletons: boolean;
     readonly showTooltip: boolean;
+    readonly theme: Theme;
     readonly timezone: string | null;
     readonly useFrameNumber: boolean;
   };
@@ -140,6 +142,13 @@ return {
           "alias": null,
           "args": null,
           "kind": "ScalarField",
+          "name": "theme",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
           "name": "timezone",
           "storageKey": null
         },
@@ -160,6 +169,6 @@ return {
 };
 })();
 
-(node as any).hash = "84d84de0717c65bc7a17e0afd6384e08";
+(node as any).hash = "56d74eee88eef2b223ccb488bdfae184";
 
 export default node;

--- a/app/packages/core/src/Root/__generated__/RootQuery.graphql.ts
+++ b/app/packages/core/src/Root/__generated__/RootQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<edeb0f17372be5e7bb09675c4f0dd89b>>
+ * @generated SignedSource<<bf87b92d90990a318a1e7f8a95dfa1d6>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -198,6 +198,13 @@ return {
             "alias": null,
             "args": null,
             "kind": "ScalarField",
+            "name": "theme",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
             "name": "timezone",
             "storageKey": null
           },
@@ -361,12 +368,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "42eabc83fdab1de44494830c776ea037",
+    "cacheID": "ede5db567f24de274fb056a298c0ec23",
     "id": null,
     "metadata": {},
     "name": "RootQuery",
     "operationKind": "query",
-    "text": "query RootQuery(\n  $search: String = \"\"\n  $count: Int\n  $cursor: String\n) {\n  ...RootConfig_query\n  ...RootDatasets_query\n  ...RootGA_query\n  ...RootNav_query\n}\n\nfragment RootConfig_query on Query {\n  config {\n    colorBy\n    colorPool\n    colorscale\n    gridZoom\n    loopVideos\n    notebookHeight\n    plugins\n    showConfidence\n    showIndex\n    showLabel\n    showSkeletons\n    showTooltip\n    timezone\n    useFrameNumber\n  }\n  colorscale\n}\n\nfragment RootDatasets_query on Query {\n  datasets(search: $search, first: $count, after: $cursor) {\n    total\n    edges {\n      cursor\n      node {\n        name\n        id\n        __typename\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n\nfragment RootGA_query on Query {\n  context\n  dev\n  doNotTrack\n  uid\n  version\n}\n\nfragment RootNav_query on Query {\n  teamsSubmission\n}\n"
+    "text": "query RootQuery(\n  $search: String = \"\"\n  $count: Int\n  $cursor: String\n) {\n  ...RootConfig_query\n  ...RootDatasets_query\n  ...RootGA_query\n  ...RootNav_query\n}\n\nfragment RootConfig_query on Query {\n  config {\n    colorBy\n    colorPool\n    colorscale\n    gridZoom\n    loopVideos\n    notebookHeight\n    plugins\n    showConfidence\n    showIndex\n    showLabel\n    showSkeletons\n    showTooltip\n    theme\n    timezone\n    useFrameNumber\n  }\n  colorscale\n}\n\nfragment RootDatasets_query on Query {\n  datasets(search: $search, first: $count, after: $cursor) {\n    total\n    edges {\n      cursor\n      node {\n        name\n        id\n        __typename\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n\nfragment RootGA_query on Query {\n  context\n  dev\n  doNotTrack\n  uid\n  version\n}\n\nfragment RootNav_query on Query {\n  teamsSubmission\n}\n"
   }
 };
 })();

--- a/app/packages/core/src/__generated__/DatasetQuery.graphql.ts
+++ b/app/packages/core/src/__generated__/DatasetQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<680473ddf5f30935f62e7f6c225c4ad6>>
+ * @generated SignedSource<<1b071ab867c7e3787c8a8086a9e9169f>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -33,11 +33,11 @@ export type DatasetQuery$data = {
         readonly patchesField: string | null;
       } | null;
       readonly key: string;
-      readonly timestamp: number | null;
+      readonly timestamp: any | null;
       readonly version: string | null;
       readonly viewStages: ReadonlyArray<string> | null;
     }>;
-    readonly createdAt: number | null;
+    readonly createdAt: any | null;
     readonly defaultGroupSlice: string | null;
     readonly defaultMaskTargets: ReadonlyArray<{
       readonly target: number;
@@ -54,7 +54,7 @@ export type DatasetQuery$data = {
         readonly predField: string | null;
       } | null;
       readonly key: string;
-      readonly timestamp: number | null;
+      readonly timestamp: any | null;
       readonly version: string | null;
       readonly viewStages: ReadonlyArray<string> | null;
     }>;
@@ -72,7 +72,7 @@ export type DatasetQuery$data = {
     }> | null;
     readonly id: string;
     readonly info: object | null;
-    readonly lastLoadedAt: number | null;
+    readonly lastLoadedAt: any | null;
     readonly maskTargets: ReadonlyArray<{
       readonly name: string;
       readonly targets: ReadonlyArray<{

--- a/app/packages/relay/src/mutations/__generated__/setViewMutation.graphql.ts
+++ b/app/packages/relay/src/mutations/__generated__/setViewMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<7b2eab9ca89ecf66fb5c391886a976eb>>
+ * @generated SignedSource<<e1be8359c7383c395a06123931816a55>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -36,11 +36,11 @@ export type setViewMutation$data = {
           readonly patchesField: string | null;
         } | null;
         readonly key: string;
-        readonly timestamp: number | null;
+        readonly timestamp: any | null;
         readonly version: string | null;
         readonly viewStages: ReadonlyArray<string> | null;
       }>;
-      readonly createdAt: number | null;
+      readonly createdAt: any | null;
       readonly defaultGroupSlice: string | null;
       readonly defaultMaskTargets: ReadonlyArray<{
         readonly target: number;
@@ -57,7 +57,7 @@ export type setViewMutation$data = {
           readonly predField: string | null;
         } | null;
         readonly key: string;
-        readonly timestamp: number | null;
+        readonly timestamp: any | null;
         readonly version: string | null;
         readonly viewStages: ReadonlyArray<string> | null;
       }>;
@@ -75,7 +75,7 @@ export type setViewMutation$data = {
       }> | null;
       readonly groupSlice: string | null;
       readonly id: string;
-      readonly lastLoadedAt: number | null;
+      readonly lastLoadedAt: any | null;
       readonly maskTargets: ReadonlyArray<{
         readonly name: string;
         readonly targets: ReadonlyArray<{

--- a/app/packages/relay/src/queries/__generated__/histogramValuesQuery.graphql.ts
+++ b/app/packages/relay/src/queries/__generated__/histogramValuesQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<6b433dd77a9be2a5d641bf2f73e84d9c>>
+ * @generated SignedSource<<0befd93c5e70e9594b9caff983ca6e23>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -18,7 +18,7 @@ export type histogramValuesQuery$data = {
   readonly aggregate: ReadonlyArray<{
     readonly __typename: "DatetimeHistogramValuesResponse";
     readonly counts: ReadonlyArray<number>;
-    readonly datetimes: ReadonlyArray<number>;
+    readonly datetimes: ReadonlyArray<any>;
     readonly other: number;
   } | {
     readonly __typename: "FloatHistogramValuesResponse";

--- a/app/packages/state/src/hooks/useStateUpdate.ts
+++ b/app/packages/state/src/hooks/useStateUpdate.ts
@@ -25,6 +25,7 @@ import {
   similarityParameters,
   extendedSelection,
   selectedMediaField,
+  theme,
 } from "../recoil";
 
 import * as viewAtoms from "../recoil/view";
@@ -77,6 +78,7 @@ const useStateUpdate = () => {
           )
         );
 
+      config && config.theme !== "browser" && set(theme, config.theme);
       const colorPool = get(colorPoolAtom);
       if (
         config &&

--- a/app/packages/state/src/recoil/types.ts
+++ b/app/packages/state/src/recoil/types.ts
@@ -23,7 +23,7 @@ export namespace State {
     showLabel: boolean;
     showTooltip: boolean;
     timezone: string | null;
-    theme: "dark" | "light";
+    theme: "browser" | "dark" | "light";
     useFrameNumber: boolean;
     mediaFields?: string[];
   }

--- a/app/packages/state/src/recoil/types.ts
+++ b/app/packages/state/src/recoil/types.ts
@@ -23,8 +23,9 @@ export namespace State {
     showLabel: boolean;
     showTooltip: boolean;
     timezone: string | null;
+    theme: "dark" | "light";
     useFrameNumber: boolean;
-    mediaFields: string[];
+    mediaFields?: string[];
   }
 
   export interface ID {

--- a/app/schema.graphql
+++ b/app/schema.graphql
@@ -24,6 +24,7 @@ type AppConfig {
   showLabel: Boolean!
   showSkeletons: Boolean!
   showTooltip: Boolean!
+  theme: Theme!
   timezone: String
   useFrameNumber: Boolean!
 }
@@ -35,14 +36,14 @@ type BoolCountValuesResponse {
 }
 
 type BoolValueCount {
-  value: Int!
   key: Boolean
+  value: Int!
 }
 
 type BrainRun implements Run {
   key: String!
   version: String
-  timestamp: DateTime
+  timestamp: datetime
   config: BrainRunConfig
   viewStages: [String!]
 }
@@ -67,8 +68,8 @@ input CountValues {
 type Dataset {
   id: ID!
   name: String!
-  createdAt: Date
-  lastLoadedAt: DateTime
+  createdAt: date
+  lastLoadedAt: datetime
   persistent: Boolean!
   groupMediaTypes: [Group!]
   groupField: String
@@ -115,26 +116,16 @@ type DatasetStrPageInfo {
   endCursor: String
 }
 
-"""
-Date (isoformat)
-"""
-scalar Date
-
-"""
-Date with time (isoformat)
-"""
-scalar DateTime
-
 type DatetimeHistogramValuesResponse {
   counts: [Int!]!
-  edges: [DateTime!]!
+  edges: [datetime!]!
   other: Int!
 }
 
 type EvaluationRun implements Run {
   key: String!
   version: String
-  timestamp: DateTime
+  timestamp: datetime
   config: EvaluationRunConfig
   viewStages: [String!]
 }
@@ -184,8 +175,8 @@ type IntHistogramValuesResponse {
 }
 
 type IntValueCount {
-  value: Int!
   key: Int
+  value: Int!
 }
 
 scalar JSON
@@ -284,7 +275,7 @@ type Query {
 interface Run {
   key: String!
   version: String
-  timestamp: DateTime
+  timestamp: datetime
   config: RunConfig
   viewStages: [String!]
 }
@@ -351,13 +342,18 @@ type StrCountValuesResponse {
 }
 
 type StrValueCount {
-  value: Int!
   key: String
+  value: Int!
 }
 
 type Target {
   target: Int!
   value: String!
+}
+
+enum Theme {
+  dark
+  light
 }
 
 type VideoSample implements Sample {
@@ -372,3 +368,7 @@ type ViewResponse {
   view: BSONArray!
   dataset: Dataset!
 }
+
+scalar date
+
+scalar datetime

--- a/app/schema.graphql
+++ b/app/schema.graphql
@@ -352,6 +352,7 @@ type Target {
 }
 
 enum Theme {
+  browser
   dark
   light
 }

--- a/docs/source/user_guide/config.rst
+++ b/docs/source/user_guide/config.rst
@@ -649,6 +649,8 @@ The FiftyOne App can be configured in the ways described below:
 +---------------------------+----------------------------------------+-----------------------------+------------------------------------------------------------------------------------------+
 | `show_tooltip`            | `FIFTYONE_APP_SHOW_TOOLTIP`            | `True`                      | Whether to show the tooltip when hovering over labels in the App's expanded sample view. |
 +---------------------------+----------------------------------------+-----------------------------+------------------------------------------------------------------------------------------+
+| `theme`                   | `FIFTYONE_APP_THEME`                   | `"dark"`                    | The default theme to use in the App. Supported values are `{'dark', 'light'}`.           |
++---------------------------+----------------------------------------+-----------------------------+------------------------------------------------------------------------------------------+
 | `use_frame_number`        | `FIFTYONE_APP_USE_FRAME_NUMBER`        | `False`                     | Whether to use the frame number instead of a timestamp in the expanded sample view. Only |
 |                           |                                        |                             | applicable to video samples.                                                             |
 +---------------------------+----------------------------------------+-----------------------------+------------------------------------------------------------------------------------------+
@@ -704,6 +706,7 @@ You can print your App config at any time via the Python library and the CLI:
             "show_label": true,
             "show_skeletons": true,
             "show_tooltip": true,
+            "theme": "dark",
             "use_frame_number": false,
             "plugins": {}
         }
@@ -749,6 +752,7 @@ You can print your App config at any time via the Python library and the CLI:
             "show_label": true,
             "show_skeletons": true,
             "show_tooltip": true,
+            "theme": "dark",
             "use_frame_number": false,
             "plugins": {}
         }

--- a/docs/source/user_guide/config.rst
+++ b/docs/source/user_guide/config.rst
@@ -649,7 +649,8 @@ The FiftyOne App can be configured in the ways described below:
 +---------------------------+----------------------------------------+-----------------------------+------------------------------------------------------------------------------------------+
 | `show_tooltip`            | `FIFTYONE_APP_SHOW_TOOLTIP`            | `True`                      | Whether to show the tooltip when hovering over labels in the App's expanded sample view. |
 +---------------------------+----------------------------------------+-----------------------------+------------------------------------------------------------------------------------------+
-| `theme`                   | `FIFTYONE_APP_THEME`                   | `"dark"`                    | The default theme to use in the App. Supported values are `{'dark', 'light'}`.           |
+| `theme`                   | `FIFTYONE_APP_THEME`                   | `"browser"`                 | The default theme to use in the App. Supported values are `{'browser', 'dark', 'light'}`.|
+|                           |                                        |                             | If `browser`, browser storage will be used, defaulting to `dark`.                        |
 +---------------------------+----------------------------------------+-----------------------------+------------------------------------------------------------------------------------------+
 | `use_frame_number`        | `FIFTYONE_APP_USE_FRAME_NUMBER`        | `False`                     | Whether to use the frame number instead of a timestamp in the expanded sample view. Only |
 |                           |                                        |                             | applicable to video samples.                                                             |
@@ -706,7 +707,7 @@ You can print your App config at any time via the Python library and the CLI:
             "show_label": true,
             "show_skeletons": true,
             "show_tooltip": true,
-            "theme": "dark",
+            "theme": "browser",
             "use_frame_number": false,
             "plugins": {}
         }
@@ -752,7 +753,7 @@ You can print your App config at any time via the Python library and the CLI:
             "show_label": true,
             "show_skeletons": true,
             "show_tooltip": true,
-            "theme": "dark",
+            "theme": "browser",
             "use_frame_number": false,
             "plugins": {}
         }

--- a/fiftyone/core/config.py
+++ b/fiftyone/core/config.py
@@ -356,7 +356,7 @@ class AppConfig(EnvConfig):
             d,
             "theme",
             env_var="FIFTYONE_APP_THEME",
-            default="dark",
+            default="browser",
         )
         self.use_frame_number = self.parse_bool(
             d,
@@ -423,8 +423,8 @@ class AppConfig(EnvConfig):
             )
             self.color_by = default_color_by
 
-        supported_themes = {"dark", "light"}
-        default_theme = "dark"
+        supported_themes = {"browser", "dark", "light"}
+        default_theme = "browser"
         if self.theme not in supported_themes:
             logger.warning(
                 "Invalid theme=%s. Must be one of %s. Defaulting to '%s'",

--- a/fiftyone/core/config.py
+++ b/fiftyone/core/config.py
@@ -352,6 +352,12 @@ class AppConfig(EnvConfig):
             env_var="FIFTYONE_APP_SHOW_TOOLTIP",
             default=True,
         )
+        self.theme = self.parse_string(
+            d,
+            "theme",
+            env_var="FIFTYONE_APP_THEME",
+            default="dark",
+        )
         self.use_frame_number = self.parse_bool(
             d,
             "use_frame_number",
@@ -406,13 +412,27 @@ class AppConfig(EnvConfig):
         return fop.get_colormap(colorscale, n=n, hex_strs=hex_strs)
 
     def _init(self):
-        if self.color_by not in {"field", "instance", "label"}:
+        supported_color_bys = {"field", "instance", "label"}
+        default_color_by = "field"
+        if self.color_by not in supported_color_bys:
             logger.warning(
-                "Invalid `color_by` option '%s'. Must be one of 'field', "
-                "'instance' or 'label'. Defaulting to 'field'",
+                "Invalid color_by=%s. Must be one of %s. Defaulting to '%s'",
+                supported_color_bys,
                 self.color_by,
+                default_color_by,
             )
-            self.color_by = "field"
+            self.color_by = default_color_by
+
+        supported_themes = {"dark", "light"}
+        default_theme = "dark"
+        if self.theme not in supported_themes:
+            logger.warning(
+                "Invalid theme=%s. Must be one of %s. Defaulting to '%s'",
+                supported_themes,
+                self.theme,
+                default_theme,
+            )
+            self.theme = default_theme
 
         if self.grid_zoom < 0 or self.grid_zoom > 10:
             logger.warning(

--- a/fiftyone/core/config.py
+++ b/fiftyone/core/config.py
@@ -417,8 +417,8 @@ class AppConfig(EnvConfig):
         if self.color_by not in supported_color_bys:
             logger.warning(
                 "Invalid color_by=%s. Must be one of %s. Defaulting to '%s'",
-                supported_color_bys,
                 self.color_by,
+                supported_color_bys,
                 default_color_by,
             )
             self.color_by = default_color_by
@@ -428,8 +428,8 @@ class AppConfig(EnvConfig):
         if self.theme not in supported_themes:
             logger.warning(
                 "Invalid theme=%s. Must be one of %s. Defaulting to '%s'",
-                supported_themes,
                 self.theme,
+                supported_themes,
                 default_theme,
             )
             self.theme = default_theme

--- a/fiftyone/server/query.py
+++ b/fiftyone/server/query.py
@@ -215,6 +215,7 @@ class AppConfig:
     show_label: bool
     show_skeletons: bool
     show_tooltip: bool
+    theme: bool
     timezone: t.Optional[str]
     use_frame_number: bool
 

--- a/fiftyone/server/query.py
+++ b/fiftyone/server/query.py
@@ -203,6 +203,7 @@ class ColorBy(Enum):
 
 @gql.enum
 class Theme(Enum):
+    browser = "browser"
     dark = "dark"
     light = "light"
 

--- a/fiftyone/server/query.py
+++ b/fiftyone/server/query.py
@@ -215,7 +215,7 @@ class AppConfig:
     show_label: bool
     show_skeletons: bool
     show_tooltip: bool
-    theme: bool
+    theme: str
     timezone: t.Optional[str]
     use_frame_number: bool
 

--- a/fiftyone/server/query.py
+++ b/fiftyone/server/query.py
@@ -201,6 +201,12 @@ class ColorBy(Enum):
     label = "label"
 
 
+@gql.enum
+class Theme(Enum):
+    dark = "dark"
+    light = "light"
+
+
 @gql.type
 class AppConfig:
     color_by: ColorBy
@@ -215,7 +221,7 @@ class AppConfig:
     show_label: bool
     show_skeletons: bool
     show_tooltip: bool
-    theme: str
+    theme: Theme
     timezone: t.Optional[str]
     use_frame_number: bool
 


### PR DESCRIPTION
Adds support for configuring the default App theme via your [App config](https://voxel51.com/docs/fiftyone/user_guide/config.html#configuring-the-app).

```shell
export FIFTYONE_APP_THEME=light
```

```py
import fiftyone as fo
import fiftyone.zoo as foz

print(fo.app_config.theme)  # 'light'

dataset = foz.load_zoo_dataset("quickstart")
session = fo.launch_app(dataset)

print(session.config.theme)  # 'light'

# Programmatically switch to dark theme
session.config.theme = "dark"
session.refresh()
```
