### PR TITLE
re-enable field text selection

### DIFF
--- a/app/packages/core/src/components/FieldLabelAndInfo/index.tsx
+++ b/app/packages/core/src/components/FieldLabelAndInfo/index.tsx
@@ -73,10 +73,6 @@ function useFieldInfo(field, nested, { expandedPath, color }) {
     setOpen(selectedField === instanceId);
   }, [selectedField]);
 
-  useEffect(() => {
-    if (hoverTarget.current) hoverTarget.current.style["user-select"] = "none";
-  }, [hoverTarget.current]);
-
   return {
     open,
     hoverTarget,


### PR DESCRIPTION
## What changes are proposed in this pull request?

Re-enable field label selection even when field label info tooltip is available

## How is this patch tested? If it is not, please explain why.

Manually by interacting with field label to ensure selection works both by drag and by double clicking field label

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
