### PR TITLE
Fix typo in get_dataloader 

### DIFF
--- a/fiftyone/server/dataloader.py
+++ b/fiftyone/server/dataloader.py
@@ -36,7 +36,7 @@ def get_dataloader(
     ) -> t.List[t.Optional[T]]:
         results = {}
         if config.key == "id":
-            config.key == "_id"
+            config.key = "_id"
         async for doc in db[config.collection].find(
             {"$and": [{config.key: {"$in": keys}}] + config.filters}
         ):


### PR DESCRIPTION
## What changes are proposed in this pull request?

Replace `==` with `=` so `id` key becomes `_id`

## How is this patch tested? If it is not, please explain why.

(Details)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
