### PR TITLE
Fix 0.18.0rc0 install 

### DIFF
--- a/fiftyone/core/odm/database.py
+++ b/fiftyone/core/odm/database.py
@@ -147,7 +147,7 @@ def establish_db_conn(config):
         _connection_kwargs["port"] = int(established_port)
     if config.database_uri is not None:
         _connection_kwargs["host"] = config.database_uri
-    elif _db_service is None:
+    if _db_service is None:
         if os.environ.get("FIFTYONE_DISABLE_SERVICES", False):
             return
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

Start the database server if it has not been started yet

## How is this patch tested? If it is not, please explain why.
after running ` pip install fiftyone==0.18.0rc0`, importing fiftyone always throws an error if mongod is not started in the background already:
```
>>> import fiftyone as fo
Traceback (most recent call last):
  File "/Users/kacey/PycharmProjects/temp/venv/lib/python3.9/site-packages/fiftyone/core/odm/database.py", line 246, in _validate_db_version
    version = Version(client.server_info()["version"])
  File "/Users/kacey/PycharmProjects/temp/venv/lib/python3.9/site-packages/pymongo/mongo_client.py", line 1805, in server_info
    self.admin.command(
  File "/Users/kacey/PycharmProjects/temp/venv/lib/python3.9/site-packages/pymongo/_csot.py", line 105, in csot_wrapper
    return func(self, *args, **kwargs)
  File "/Users/kacey/PycharmProjects/temp/venv/lib/python3.9/site-packages/pymongo/database.py", line 805, in command
    with self.__client._socket_for_reads(read_preference, session) as (
  File "/Users/kacey/PycharmProjects/temp/venv/lib/python3.9/site-packages/pymongo/mongo_client.py", line 1296, in _socket_for_reads
    server = self._select_server(read_preference, session)
  File "/Users/kacey/PycharmProjects/temp/venv/lib/python3.9/site-packages/pymongo/mongo_client.py", line 1257, in _select_server
    server = topology.select_server(server_selector)
  File "/Users/kacey/PycharmProjects/temp/venv/lib/python3.9/site-packages/pymongo/topology.py", line 272, in select_server
    server = self._select_server(selector, server_selection_timeout, address)
  File "/Users/kacey/PycharmProjects/temp/venv/lib/python3.9/site-packages/pymongo/topology.py", line 261, in _select_server
    servers = self.select_servers(selector, server_selection_timeout, address)
  File "/Users/kacey/PycharmProjects/temp/venv/lib/python3.9/site-packages/pymongo/topology.py", line 223, in select_servers
    server_descriptions = self._select_servers_loop(selector, server_timeout, address)
  File "/Users/kacey/PycharmProjects/temp/venv/lib/python3.9/site-packages/pymongo/topology.py", line 238, in _select_servers_loop
    raise ServerSelectionTimeoutError(
pymongo.errors.ServerSelectionTimeoutError: localhost:27017: [Errno 61] Connection refused, Timeout: 30s, Topology Description: <TopologyDescription id: 636b1cbe4f58d6f9492a7d70, topology_type: Unknown, servers: [<ServerDescription ('localhost', 27017) server_type: Unknown, rtt: None, error=AutoReconnect('localhost:27017: [Errno 61] Connection refused')>]>

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/kacey/PycharmProjects/temp/venv/lib/python3.9/site-packages/fiftyone/__init__.py", line 25, in <module>
    from fiftyone.__public__ import *
  File "/Users/kacey/PycharmProjects/temp/venv/lib/python3.9/site-packages/fiftyone/__public__.py", line 15, in <module>
    _foo.establish_db_conn(config)
  File "/Users/kacey/PycharmProjects/temp/venv/lib/python3.9/site-packages/fiftyone/core/odm/database.py", line 174, in establish_db_conn
    _validate_db_version(config, _client)
  File "/Users/kacey/PycharmProjects/temp/venv/lib/python3.9/site-packages/fiftyone/core/odm/database.py", line 249, in _validate_db_version
    raise ConnectionError("Could not connect to `mongod`") from e
ConnectionError: Could not connect to `mongod`
>>> 
```

importing fiftyone now works without separately starting mongod beforehand:
<img width="639" alt="image" src="https://user-images.githubusercontent.com/30936736/200749357-aa3f676b-6b26-40f6-977a-4a872ec34861.png">

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [x] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
