### PR TITLE
Patch v0.16.6 compatibility

### DIFF
--- a/app/packages/core/src/__generated__/DatasetQuery.graphql.ts
+++ b/app/packages/core/src/__generated__/DatasetQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<a2f8d4a86d8e3c6654edba23aa04eab9>>
+ * @generated SignedSource<<ada5cd8e34cacf34f90035e5f89a5932>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -19,7 +19,7 @@ export type DatasetQuery$data = {
   readonly dataset: {
     readonly appConfig: {
       readonly gridMediaField: string | null;
-      readonly mediaFields: ReadonlyArray<string>;
+      readonly mediaFields: ReadonlyArray<string> | null;
       readonly plugins: object | null;
       readonly sidebarGroups: ReadonlyArray<{
         readonly expanded: boolean | null;

--- a/app/packages/relay/src/mutations/__generated__/setViewMutation.graphql.ts
+++ b/app/packages/relay/src/mutations/__generated__/setViewMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<7b0143980c8a872dedfc4f766a9d161b>>
+ * @generated SignedSource<<56be5c6fe96ae9ae34e5cddab797ee07>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -37,7 +37,7 @@ export type setViewMutation$data = {
     readonly dataset: {
       readonly appConfig: {
         readonly gridMediaField: string | null;
-        readonly mediaFields: ReadonlyArray<string>;
+        readonly mediaFields: ReadonlyArray<string> | null;
         readonly plugins: object | null;
         readonly sidebarGroups: ReadonlyArray<{
           readonly expanded: boolean | null;

--- a/app/schema.graphql
+++ b/app/schema.graphql
@@ -136,7 +136,7 @@ type Dataset {
 }
 
 type DatasetAppConfig {
-  mediaFields: [String!]!
+  mediaFields: [String!]
   plugins: JSON
   sidebarGroups: [SidebarGroup!]
   sidebarMode: SidebarMode

--- a/fiftyone/core/odm/dataset.py
+++ b/fiftyone/core/odm/dataset.py
@@ -546,7 +546,9 @@ class DatasetDocument(Document):
     default_group_slice = StringField()
     tags = ListField(StringField())
     info = DictField()
-    app_config = EmbeddedDocumentField(DatasetAppConfig)
+    app_config = EmbeddedDocumentField(
+        DatasetAppConfig, default=DatasetAppConfig
+    )
     classes = DictField(ClassesField())
     default_classes = ClassesField()
     mask_targets = DictField(TargetsField())

--- a/fiftyone/server/metadata.py
+++ b/fiftyone/server/metadata.py
@@ -358,11 +358,7 @@ class FFmpegNotFoundException(RuntimeError):
 def _create_media_urls(
     collection: SampleCollection, sample: t.Dict, cache: t.Dict
 ) -> t.Dict[str, str]:
-    media_fields = (
-        collection.app_config.media_fields
-        if collection.app_config
-        else ["filepath"]
-    )
+    media_fields = collection.app_config.media_fields
     media_urls = []
 
     for field in media_fields:

--- a/fiftyone/server/query.py
+++ b/fiftyone/server/query.py
@@ -134,7 +134,7 @@ class SidebarMode(Enum):
 
 @gql.type
 class DatasetAppConfig:
-    media_fields: t.List[str]
+    media_fields: t.Optional[t.List[str]]
     plugins: t.Optional[JSON]
     sidebar_groups: t.Optional[t.List[SidebarGroup]]
     sidebar_mode: t.Optional[SidebarMode]


### PR DESCRIPTION
v0.18 purports to be backwards-compatible with v0.16.6 datasets. However, this is not currently the case because it does not appropriately handle missing `app_config`s.

```shell
fiftyone zoo datasets load quickstart
fiftyone migrate -v 0.16.6 -n quickstart
export FIFTYONE_DATABASE_ADMIN=false
```

```py
import fiftyone as fo
import fiftyone.core.odm as foo

dataset = fo.load_dataset("quickstart")
db = foo.get_db_conn()

# Scenario 1: entire `app_config` is missing

assert "app_config" not in db.datasets.find_one({"name": "quickstart"})
assert dataset.version == "0.16.6"
assert dataset.app_config is not None  # previously failed; now doesn't

session = fo.launch_app(dataset)  # TODO: fix this

# Scenario 2: any part(s) of `app_config` are missing

dataset.app_config.grid_media_field = "foo"  # force mongoengine to detect a change
dataset.app_config.grid_media_field = "filepath"
dataset.save()

print(db.datasets.find_one({"name": "quickstart"})["app_config"])  # None
# {'grid_media_field': 'filepath'}

session = fo.launch_app(dataset)  # TODO: fix this
```

```shell
unset FIFTYONE_DATABASE_ADMIN
```
