### PR TITLE
hide bookmark icon when no filters are applied

### DIFF
--- a/app/packages/core/src/components/Actions/ActionsRow.tsx
+++ b/app/packages/core/src/components/Actions/ActionsRow.tsx
@@ -280,7 +280,6 @@ const Hidden = () => {
 
 const SaveFilters = () => {
   const hasFiltersValue = useRecoilValue(fos.hasFilters(false));
-  const extended = Object.keys(useRecoilValue(fos.extendedStages)).length > 0;
   const loading = useRecoilValue(fos.savingFilters);
   const onComplete = useRecoilCallback(({ set, reset }) => () => {
     set(fos.savingFilters, false);
@@ -302,7 +301,7 @@ const SaveFilters = () => {
     []
   );
 
-  return hasFiltersValue || extended ? (
+  return hasFiltersValue ? (
     <ActionDiv>
       <PillButton
         open={false}

--- a/app/packages/core/src/components/Actions/Common.tsx
+++ b/app/packages/core/src/components/Actions/Common.tsx
@@ -4,6 +4,8 @@ import { Launch } from "@mui/icons-material";
 import { useHighlightHover } from "./utils";
 import { ItemAction } from "./ItemAction";
 import { useExternalLink } from "@fiftyone/utilities";
+import ExternalLink from "@fiftyone/components/src/components/ExternalLink";
+import { useTheme } from "@fiftyone/components";
 
 type ActionOptionProps = {
   onClick?: (event?: Event) => void;
@@ -25,9 +27,10 @@ export const ActionOption = React.memo(
     disabled = false,
     hidden = false,
     style,
-    svgStyles = { height: "1rem", marginTop: 4.5 },
+    svgStyles = { height: "1rem", marginTop: 4.5, marginLeft: 1 },
   }: ActionOptionProps) => {
     const { style: animationStyles, ...rest } = useHighlightHover(disabled);
+    const theme = useTheme();
     onClick = href ? useExternalLink(href) : onClick;
     if (hidden) {
       return null;
@@ -38,12 +41,16 @@ export const ActionOption = React.memo(
         onClick={disabled ? null : onClick}
         {...rest}
         style={style ?? animationStyles}
-        href={href}
-        target={href ? "_blank" : null}
       >
         <span style={href ? { textDecoration: "underline" } : {}}>
-          {text}
-          {href && <Launch style={svgStyles} />}
+          {href ? (
+            <ExternalLink style={{ color: theme.text.primary }} href={href}>
+              {text}
+              <Launch style={svgStyles} />
+            </ExternalLink>
+          ) : (
+            `${text}`
+          )}
         </span>
       </ItemAction>
     );


### PR DESCRIPTION
## What changes are proposed in this pull request?

Fixes #2281

### Changelog
- Hide bookmark icon when no filters are applied
- Render anchor element instead of div in `ItemAction` when there's a href

## How is this patch tested? If it is not, please explain why.

On a dev build

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
