### PR TITLE
[BUG FIX] Enable selecting datasets with spaces in the name

### DIFF
--- a/app/packages/state/src/hooks/useSetDataset.ts
+++ b/app/packages/state/src/hooks/useSetDataset.ts
@@ -17,7 +17,7 @@ const useSetDataset = () => {
   const onError = useErrorHandler();
 
   return (name?: string) => {
-    to(name ? `/datasets/${encodeURI(name)}` : "/");
+    to(name ? `/datasets/${encodeURIComponent(name)}` : "/");
 
     send((session) =>
       commit({

--- a/app/packages/state/src/routing/matchPath.ts
+++ b/app/packages/state/src/routing/matchPath.ts
@@ -87,7 +87,7 @@ export const matchPath = <T extends OperationType | undefined>(
   };
   keys.forEach((key, i) => {
     // @ts-ignore
-    allVariables[key.name] = values[i];
+    allVariables[key.name] = decodeURIComponent(values[i]);
   });
 
   return {

--- a/app/packages/state/src/utils.ts
+++ b/app/packages/state/src/utils.ts
@@ -106,7 +106,7 @@ export const getDatasetName = (context: RoutingContext<any>): string => {
   );
 
   if (result) {
-    return result.variables.name;
+    return decodeURIComponent(result.variables.name);
   }
 
   return null;


### PR DESCRIPTION
## What changes are proposed in this pull request?

- Currently, if a dataset name has spaces or other encodable symbols, it is not possible to interact with the dataset in the app because the name will be uri encoded and thus not resolve properly. 
- This change enables using the app for datasets with names like "dataset with name" without requiring a change in the database schema
- This issue will be fully resolved once slugs are merged (https://voxel51.atlassian.net/browse/TEAMS-386)
<img width="1430" alt="image" src="https://user-images.githubusercontent.com/30936736/202018109-da921fce-faf4-459d-8a87-b40a04972785.png">


## How is this patch tested? If it is not, please explain why.

1. Create a dataset with spaces in the name:
```import fiftyone as fo
import fiftyone.zoo as foz

dataset = foz.load_zoo_dataset("quickstart", dataset_name="quickstart with  spaces")
dataset.persistent = True
```

2. Start the dev server and open the app in the browser.
3. From the `Select dataset` dropdown, select a dataset with spaces in the name
4. Observe that the dataset loads without error.

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
