### PR TITLE
[HOLD] Loading spatial label field 'rotation'

### DIFF
--- a/fiftyone/utils/annotations.py
+++ b/fiftyone/utils/annotations.py
@@ -344,7 +344,7 @@ _DEFAULT_LABEL_FIELDS_MAP = {
 
 # Label fields that are overwritten when spatial changes are allowed
 _SPATIAL_LABEL_FIELDS_MAP = {
-    fol.Detection: ["bounding_box", "mask"],
+    fol.Detection: ["bounding_box", "mask", "rotation"],
     fol.Polyline: ["points", "closed", "filled"],
     fol.Keypoint: ["points"],
     fol.Segmentation: ["mask"],


### PR DESCRIPTION
## What changes are proposed in this pull request?

Relevant issue #1821 

Annotation backend (label-studio) will return an updated rotation field for Detection (bbox) labels. Although fiftyone does not yet support previewing rotated bounding boxes, it is able to receive and store it. This fix makes fiftyone able to update the rotation field. 

The current behaviour is that if a bbox is rotated in label-studio, then loaded back into fiftyone, the bbox is drawn without rotation, and the rotation information is lost. While this pr does not solve everything, it will retain the rotation in fiftyone for future use.

Rotation from label-studio is in degrees clockwise from _up_ ("north") direction, aka. azimuth. When previewing, Fiftyone should then rotate it counter-clockwise around the bbox coordinate by `360-rotation`. Evaluations (such as IoU), and export/import should also make the necessary adaptations.

Questions:
- It should possibly only do this if `label["rotation"]` exists in the label already.
- Is 'rotation' a standard name for the other annotation backends?
- Is clockwise rotation from up ("north") standard for the other backends?

## How is this patch tested? If it is not, please explain why.

It is tested towards label-studio, but no other annotation backend.
