### PR TITLE
Documenting how to use custom torch models with builtin FiftyOne methods

### DIFF
--- a/fiftyone/utils/torch.py
+++ b/fiftyone/utils/torch.py
@@ -203,9 +203,7 @@ class TorchImageModel(
     :class:`torch:torch.nn.Module` whose ``__call__()`` method directly accepts
     Torch tensors (NCHW) as input.
 
-    .. note::
-
-        See :ref:`this page <model-zoo-custom-models>` for example usage.
+    See :ref:`this page <model-zoo-custom-models>` for example usage.
 
     Args:
         config: an :class:`TorchImageModelConfig`

--- a/fiftyone/utils/torch.py
+++ b/fiftyone/utils/torch.py
@@ -203,6 +203,10 @@ class TorchImageModel(
     :class:`torch:torch.nn.Module` whose ``__call__()`` method directly accepts
     Torch tensors (NCHW) as input.
 
+    .. note::
+
+        See :ref:`this page <model-zoo-custom-models>` for example usage.
+
     Args:
         config: an :class:`TorchImageModelConfig`
     """


### PR DESCRIPTION
Adds my tip from https://github.com/voxel51/fiftyone/issues/2343#issuecomment-1324524198 formally to the docs.

<img width="1309" alt="Screen Shot 2022-11-23 at 12 10 36 PM" src="https://user-images.githubusercontent.com/25985824/203607787-6802e76a-853e-46c0-9086-31d4aa76bef2.png">
