### PR TITLE
Adding support for importing annotations on grouped datasets

### DIFF
--- a/fiftyone/utils/annotations.py
+++ b/fiftyone/utils/annotations.py
@@ -415,7 +415,7 @@ def _build_label_schema(
 
     _label_schema = {}
 
-    is_video = samples.media_type == fomm.VIDEO
+    contains_videos = samples._contains_videos(any_slice=True)
 
     for _label_field, _label_info in label_schema.items():
         (
@@ -443,23 +443,21 @@ def _build_label_schema(
         _return_type = _RETURN_TYPES_MAP[_label_type]
         _is_trackable = _is_frame_field and _return_type in _TRACKABLE_TYPES
 
-        if is_video:
-            if not _is_frame_field:
-                if _return_type in _SPATIAL_TYPES:
-                    raise ValueError(
-                        "Invalid label field '%s'. Spatial labels of type "
-                        "'%s' being annotated on a video must be stored in a "
-                        "frame-level field, i.e., one that starts with "
-                        "'frames.'" % (_label_field, _label_type)
-                    )
-                elif not backend.supports_video_sample_fields:
-                    raise ValueError(
-                        "Invalid label field '%s'. Backend '%s' does not "
-                        "support annotating video fields at a sample-level. "
-                        "Labels must be stored in a frame-level field, i.e., "
-                        "one that starts with 'frames.'"
-                        % (_label_field, backend.config.name)
-                    )
+        if contains_videos and not _is_frame_field:
+            if _return_type in _SPATIAL_TYPES:
+                raise ValueError(
+                    "Invalid label field '%s'. Spatial labels of type '%s' "
+                    "being annotated on a video must be stored in a "
+                    "frame-level field, i.e., one that starts with 'frames.'"
+                    % (_label_field, _label_type)
+                )
+            elif not backend.supports_video_sample_fields:
+                raise ValueError(
+                    "Invalid label field '%s'. Backend '%s' does not support "
+                    "annotating video fields at a sample-level. Labels must "
+                    "be stored in a frame-level field, i.e., one that starts "
+                    "with 'frames.'" % (_label_field, backend.config.name)
+                )
 
         # We found an existing field with multiple label types, so we must
         # select only the relevant labels
@@ -628,14 +626,14 @@ def _get_label_type(samples, backend, label_type, label_field, label_info):
     if "type" in label_info:
         label_type = label_info["type"]
 
-    field, is_frame_field = samples._handle_frame_field(label_field)
+    field_name, is_frame_field = samples._handle_frame_field(label_field)
 
     if is_frame_field:
         schema = samples.get_frame_field_schema()
     else:
         schema = samples.get_field_schema()
 
-    if field not in schema:
+    if field_name not in schema:
         if label_type is None:
             raise ValueError(
                 "You must specify a type for new label field '%s'"
@@ -644,9 +642,7 @@ def _get_label_type(samples, backend, label_type, label_field, label_info):
 
         return label_type, is_frame_field, False, False
 
-    _existing_type = _get_existing_label_type(
-        samples, backend, label_field, schema[field]
-    )
+    _existing_type = _get_backend_field_type(backend, schema[field_name])
     _multiple_types = isinstance(_existing_type, list)
 
     if label_type is not None:
@@ -722,15 +718,15 @@ def _unwrap(value):
     return value
 
 
-def _get_existing_label_type(samples, backend, label_field, field_type):
-    if not isinstance(field_type, fof.EmbeddedDocumentField):
-        if not isinstance(field_type, tuple(backend.supported_scalar_types)):
+def _get_backend_field_type(backend, field):
+    if not isinstance(field, fof.EmbeddedDocumentField):
+        if not isinstance(field, tuple(backend.supported_scalar_types)):
             raise ValueError(
                 "Field '%s' has unsupported scalar type %s. The '%s' backend "
                 "supports %s"
                 % (
-                    label_field,
-                    field_type,
+                    field.path,
+                    type(field),
                     backend.config.name,
                     backend.supported_scalar_types,
                 )
@@ -738,7 +734,7 @@ def _get_existing_label_type(samples, backend, label_field, field_type):
 
         return "scalar"
 
-    fo_label_type = field_type.document_type
+    fo_label_type = field.document_type
 
     if issubclass(fo_label_type, fol.Detection):
         return ["detection", "instance"]
@@ -768,7 +764,7 @@ def _get_existing_label_type(samples, backend, label_field, field_type):
         return "segmentation"
 
     raise ValueError(
-        "Field '%s' has unsupported type %s" % (label_field, fo_label_type)
+        "Field '%s' has unsupported type %s" % (field.path, fo_label_type)
     )
 
 
@@ -1141,7 +1137,7 @@ def load_annotations(
 
 
 def _handle_frame_fields(dataset, field, ref_field):
-    if dataset.media_type != fomm.VIDEO:
+    if not dataset._has_frame_fields():
         return field
 
     if (
@@ -1201,7 +1197,7 @@ def _prompt_field(dataset, label_type, label_field, label_schema):
     if label_field is not None:
         _, is_frame_field = dataset._handle_frame_field(label_field)
     else:
-        is_frame_field = dataset.media_type == fomm.VIDEO
+        _, is_frame_field = dataset._handle_frame_field(new_field)
 
     if is_frame_field:
         schema = dataset.get_frame_field_schema()
@@ -1268,15 +1264,21 @@ def _merge_scalars(dataset, anno_dict, results, label_field, label_info=None):
     allow_additions = label_info.get("allow_additions", True)
     allow_deletions = label_info.get("allow_deletions", True)
 
-    is_video = dataset._is_frame_field(label_field)
+    is_frame_field = dataset._is_frame_field(label_field)
 
     # Retrieve a view that contains all samples involved in the annotation run
     id_map = results.id_map.get(label_field, {})
     uploaded_ids = set(k for k, v in id_map.items() if v is not None)
     sample_ids = list(uploaded_ids | set(anno_dict.keys()))
+
+    if dataset.media_type == fomm.GROUP:
+        view = dataset.select_group_slices(_allow_mixed=True)
+    else:
+        view = dataset.view()
+
     view = dataset.select(sample_ids)
 
-    if is_video:
+    if is_frame_field:
         field, _ = view._handle_frame_field(label_field)
         if view.has_frame_field(field):
             view = view.select_fields(label_field)
@@ -1292,13 +1294,13 @@ def _merge_scalars(dataset, anno_dict, results, label_field, label_info=None):
     for sample in view.iter_samples(progress=True):
         sample_annos = anno_dict.get(sample.id, None)
 
-        if is_video:
+        if is_frame_field:
             images = sample.frames.values()
         else:
             images = [sample]
 
         for image in images:
-            if is_video:
+            if is_frame_field:
                 if sample_annos is None:
                     new_value = None
                 else:
@@ -1375,9 +1377,9 @@ def _merge_labels(
 
     _ensure_label_field(dataset, label_field, fo_label_type)
 
-    is_video = dataset.media_type == fomm.VIDEO
+    is_frame_field = dataset._is_frame_field(label_field)
 
-    if is_video and label_type in _TRACKABLE_TYPES:
+    if is_frame_field and label_type in _TRACKABLE_TYPES:
         if not existing_field:
             # Always include keyframe info when importing new video tracks
             only_keyframes = True
@@ -1386,7 +1388,7 @@ def _merge_labels(
 
     id_map = results.id_map.get(label_field, {})
 
-    if is_video:
+    if is_frame_field:
         field, _ = dataset._handle_frame_field(label_field)
         added_id_map = defaultdict(lambda: defaultdict(list))
     else:
@@ -1396,7 +1398,7 @@ def _merge_labels(
     # Record existing label IDs
     existing_ids = set()
     for sample_id, sample_labels in id_map.items():
-        if is_video:
+        if is_frame_field:
             for frame_id, frame_labels in sample_labels.items():
                 for label_id in _to_list(frame_labels):
                     existing_ids.add((sample_id, frame_id, label_id))
@@ -1408,7 +1410,7 @@ def _merge_labels(
     anno_ids = set()
     anno_id_counts = defaultdict(int)
     for sample_id, sample_labels in anno_dict.items():
-        if is_video:
+        if is_frame_field:
             for frame_id, frame_labels in sample_labels.items():
                 for label_id in frame_labels.keys():
                     anno_ids.add((sample_id, frame_id, label_id))
@@ -1433,7 +1435,7 @@ def _merge_labels(
     #
     dup_ids = set(_id for _id, count in anno_id_counts.items() if count > 1)
     if dup_ids:
-        if is_video:
+        if is_frame_field:
             for sample_id, frame_id, label_id in list(new_ids):
                 if label_id in dup_ids:
                     # Regenerate duplicate label ID
@@ -1463,20 +1465,25 @@ def _merge_labels(
         _del_ids = [key[-1] for key in delete_ids]
         dataset.delete_labels(ids=_del_ids, fields=label_field)
 
+    if dataset.media_type == fomm.GROUP:
+        view = dataset.select_group_slices(_allow_mixed=True)
+    else:
+        view = dataset.view()
+
     # Add/merge labels from the annotation task
     sample_ids = list(anno_dict.keys())
-    view = dataset.select(sample_ids).select_fields(label_field)
+    view = view.select(sample_ids).select_fields(label_field)
     for sample in view.iter_samples(progress=True):
         sample_id = sample.id
         sample_annos = anno_dict[sample_id]
 
-        if is_video:
+        if is_frame_field:
             images = sample.frames.values()
         else:
             images = [sample]
 
         for image in images:
-            if is_video:
+            if is_frame_field:
                 frame_id = image.id
                 image_annos = sample_annos.get(frame_id, None)
                 if not image_annos:
@@ -1494,7 +1501,7 @@ def _merge_labels(
                         **{list_field: list(image_annos.values())}
                     )
 
-                    if is_video:
+                    if is_frame_field:
                         added_id_map[sample_id][frame_id].extend(label_ids)
                     else:
                         added_id_map[sample_id].extend(label_ids)
@@ -1502,7 +1509,7 @@ def _merge_labels(
                     label_id, anno_label = next(iter(image_annos.items()))
                     image[field] = anno_label
 
-                    if is_video:
+                    if is_frame_field:
                         added_id_map[sample_id][frame_id] = label_id
                     else:
                         added_id_map[sample_id] = label_id
@@ -1515,7 +1522,7 @@ def _merge_labels(
                 # Merge labels that existed before and after annotation
                 for label in labels:
                     label_id = label.id
-                    if is_video:
+                    if is_frame_field:
                         key = (sample_id, frame_id, label_id)
                     else:
                         key = (sample_id, label_id)
@@ -1537,7 +1544,7 @@ def _merge_labels(
                 # Add new labels to label list fields
                 if is_list and allow_additions:
                     for label_id, anno_label in image_annos.items():
-                        if is_video:
+                        if is_frame_field:
                             key = (sample_id, frame_id, label_id)
                         else:
                             key = (sample_id, label_id)
@@ -1547,7 +1554,7 @@ def _merge_labels(
 
                         labels.append(anno_label)
 
-                        if is_video:
+                        if is_frame_field:
                             added_id_map[sample_id][frame_id].append(label_id)
                         else:
                             added_id_map[sample_id].append(label_id)
@@ -1631,9 +1638,14 @@ def _merge_label(
 
 
 def _update_tracks(dataset, label_field, anno_dict, only_keyframes):
+    if dataset.media_type == fomm.GROUP:
+        view = dataset.select_group_slices(_allow_mixed=True)
+    else:
+        view = dataset.view()
+
     # Using the full dataset here is important here because we need to ensure
     # that any new indexes never clash with *any* existing tracks
-    view = dataset.select(list(anno_dict.keys()))
+    view = view.select(list(anno_dict.keys()))
 
     _, id_path = dataset._get_label_field_path(label_field, "id")
     _, index_path = dataset._get_label_field_path(label_field, "index")


### PR DESCRIPTION
Previously annotations on grouped datasets would only be loaded for the active slice, whereas the consist thing to do would be for annotations for all slices to be loaded.

```py
import fiftyone as fo
import fiftyone.zoo as foz

dataset = foz.load_zoo_dataset("quickstart-groups", max_samples=3)
view = dataset.select_group_slices(media_type="image")

view.annotate("test", label_field="ground_truth", launch_editor=True)

# Previously would only load annotations for the current `group_slice`
# Now all annotations are loaded
dataset.load_annotations("test")
```
