### PR TITLE
Provide custom task name for CVAT

### DIFF
--- a/docs/source/integrations/cvat.rst
+++ b/docs/source/integrations/cvat.rst
@@ -492,6 +492,7 @@ provided:
     otherwise a new project is created. By default, no project is used
 -   **project_id** (*None*): an optional ID of an existing CVAT project to
     which to upload the annotation tasks. By default, no project is used
+-   **task_name** (None): an optional task name to use for the created CVAT task
 -   **occluded_attr** (*None*): an optional attribute name containing existing
     occluded values and/or in which to store downloaded occluded values for all
     objects in the annotation run

--- a/fiftyone/utils/cvat.py
+++ b/fiftyone/utils/cvat.py
@@ -3060,6 +3060,7 @@ class CVATBackendConfig(foua.AnnotationBackendConfig):
             default, no project is used
         project_id (None): an optional ID of an existing CVAT project to which
             to upload the annotation tasks. By default, no project is used
+        task_name (None): an optional task name to use for the created CVAT task
         occluded_attr (None): an optional attribute name containing existing
             occluded values and/or in which to store downloaded occluded values
             for all objects in the annotation run
@@ -3091,6 +3092,7 @@ class CVATBackendConfig(foua.AnnotationBackendConfig):
         job_reviewers=None,
         project_name=None,
         project_id=None,
+        task_name=None,
         occluded_attr=None,
         group_id_attr=None,
         issue_tracker=None,
@@ -3109,6 +3111,7 @@ class CVATBackendConfig(foua.AnnotationBackendConfig):
         self.job_reviewers = job_reviewers
         self.project_name = project_name
         self.project_id = project_id
+        self.task_name = task_name
         self.occluded_attr = occluded_attr
         self.group_id_attr = group_id_attr
         self.issue_tracker = issue_tracker
@@ -4290,8 +4293,11 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
                     project_id = self.create_project(project_name, cvat_schema)
                     project_ids.append(project_id)
 
-                _dataset_name = samples_batch._dataset.name.replace(" ", "_")
-                task_name = "FiftyOne_%s" % _dataset_name
+                if config.task_name is None:
+                    _dataset_name = samples_batch._dataset.name.replace(" ", "_")
+                    task_name = "FiftyOne_%s" % _dataset_name
+                else:
+                    task_name = config.task_name
 
                 (
                     task_id,

--- a/fiftyone/utils/cvat.py
+++ b/fiftyone/utils/cvat.py
@@ -6,6 +6,7 @@ Utilities for working with datasets in
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+import math
 from collections import defaultdict
 from copy import copy, deepcopy
 from datetime import datetime
@@ -4229,6 +4230,7 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
 
         num_samples = len(samples)
         batch_size = self._get_batch_size(samples, task_size)
+        num_batches = math.ceil(num_samples / batch_size)
 
         samples.compute_metadata()
 
@@ -4294,10 +4296,15 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
                     project_ids.append(project_id)
 
                 if config.task_name is None:
-                    _dataset_name = samples_batch._dataset.name.replace(" ", "_")
-                    task_name = "FiftyOne_%s" % _dataset_name
+                    _dataset_name = samples_batch._dataset.name.replace(
+                        " ", "_"
+                    )
+                    task_name = f"FiftyOne_{_dataset_name}"
                 else:
                     task_name = config.task_name
+                # append task number when multiple tasks are created
+                if num_batches > 1:
+                    task_name += f"_{idx + 1}"
 
                 (
                     task_id,

--- a/tests/intensive/cvat_tests.py
+++ b/tests/intensive/cvat_tests.py
@@ -434,11 +434,11 @@ class CVATTests(unittest.TestCase):
         with results:
             api = results.connect_to_api()
             self.assertEqual(len(task_ids), 2)
-            for task_id in task_ids:
+            for idx, task_id in enumerate(task_ids):
                 task_json = api.get(api.task_url(task_id)).json()
                 self.assertEqual(task_json["bug_tracker"], bug_tracker)
                 self.assertEqual(task_json["segment_size"], 1)
-                self.assertEqual(task_json["name"], task_name)
+                self.assertEqual(task_json["name"], f"{task_name}_{idx + 1}")
                 if user is not None:
                     self.assertEqual(task_json["assignee"]["username"], user)
                 for job in api.get(api.jobs_url(task_id)).json():

--- a/tests/intensive/cvat_tests.py
+++ b/tests/intensive/cvat_tests.py
@@ -417,6 +417,7 @@ class CVATTests(unittest.TestCase):
 
         anno_key = "anno_key"
         bug_tracker = "test_tracker"
+        task_name = "test_task"
         results = dataset.annotate(
             anno_key,
             backend="cvat",
@@ -427,6 +428,7 @@ class CVATTests(unittest.TestCase):
             job_assignees=users,
             job_reviewers=users,
             issue_tracker=bug_tracker,
+            task_name=task_name,
         )
         task_ids = results.task_ids
         with results:
@@ -436,6 +438,7 @@ class CVATTests(unittest.TestCase):
                 task_json = api.get(api.task_url(task_id)).json()
                 self.assertEqual(task_json["bug_tracker"], bug_tracker)
                 self.assertEqual(task_json["segment_size"], 1)
+                self.assertEqual(task_json["name"], task_name)
                 if user is not None:
                     self.assertEqual(task_json["assignee"]["username"], user)
                 for job in api.get(api.jobs_url(task_id)).json():


### PR DESCRIPTION
## What changes are proposed in this pull request?

Closes #1753 

1. Custom task name can be passed for labelling data in CVAT such as `dataset.annotate("anno_key", backend="cvat", task_name="Custom task name", ...)`
2. Default task name for CVAT to include an annotation key such as `FiftyOne_{dataset_name}_{annotation_key}`

## How is this patch tested? If it is not, please explain why.

added few lines to existing cvat unit-tests.

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

A custom task name can be provided with CVAT annotation backend. Default CVAT task name now includes an annotation key.

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [x] Documentation: FiftyOne documentation changes
-   [ ] Other
