### PR TITLE
Fix bug when loading dataset in VOCDetectionDataset format with CVAT attributes

### DIFF
--- a/fiftyone/utils/voc.py
+++ b/fiftyone/utils/voc.py
@@ -554,6 +554,7 @@ class VOCObject(object):
         # Handles CVAT exported attributes
         if "attributes" in d:
             cvat_attrs = d.pop("attributes", {}).pop("attribute", {})
+            cvat_attrs = _ensure_list(cvat_attrs)
             cvat_attrs = {a["name"]: a["value"] for a in cvat_attrs}
             d.update(cvat_attrs)
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

When a dataset in VOCDetectionDataset format with CVAT attributes but the `attributes` tag has only one child, it will raise `TypeError: string indices must be integers`. This PR will fix the error.

## How is this patch tested? If it is not, please explain why.

We first construct a dataset looks like:
```
my-dataset/
  data/
    000000.jpg
  labels/
    000000.xml
```

To reproduce this error, we put the following text to `000000.xml`:
```
<annotation>
  <folder></folder>
  <filename>000000.jpg</filename>
  <source>
    <database>Unknown</database>
    <annotation>Unknown</annotation>
    <image>Unknown</image>
  </source>
  <size>
    <width>4096</width>
    <height>3000</height>
    <depth></depth>
  </size>
  <segmented>0</segmented>
  <object>
    <name>car</name>
    <truncated>0</truncated>
    <occluded>0</occluded>
    <difficult>0</difficult>
    <bndbox>
      <xmin>2538.0</xmin>
      <ymin>1801.0</ymin>
      <xmax>2679.0</xmax>
      <ymax>1836.0</ymax>
    </bndbox>
    <attributes>
      <attribute>
        <name>rotation</name>
        <value>0.0</value>
      </attribute>
    </attributes>
  </object>
</annotation>
```

Run the following script:
```python
import fiftyone as fo
dataset = fo.Dataset.from_dir(name='example', dataset_dir='my-dataset', dataset_type=fo.types.VOCDetectionDataset)
```

We will get the `TypeError`:
```
Traceback (most recent call last):
  File "demo.py", line 3, in <module>
    dataset = fo.Dataset.from_dir(name='demo', dataset_dir='my-dataset', dataset_type=fo.types.VOCDetectionDataset)
  File "/home/john/code/fiftyone/fiftyone/core/dataset.py", line 4686, in from_dir
    dataset.add_dir(
  File "/home/john/code/fiftyone/fiftyone/core/dataset.py", line 3426, in add_dir
    return self.add_importer(
  File "/home/john/code/fiftyone/fiftyone/core/dataset.py", line 3986, in add_importer
    return foud.import_samples(
  File "/home/john/code/fiftyone/fiftyone/utils/data/importers.py", line 142, in import_samples
    sample_ids = dataset.add_samples(
  File "/home/john/code/fiftyone/fiftyone/core/dataset.py", line 2209, in add_samples
    for batch in batcher:
  File "/home/john/code/fiftyone/fiftyone/core/utils.py", line 987, in __next__
    batch.append(next(self._iter))
  File "/home/john/code/fiftyone/fiftyone/utils/voc.py", line 138, in __next__
    annotation = load_voc_detection_annotations(labels_path)
  File "/home/john/code/fiftyone/fiftyone/utils/voc.py", line 758, in load_voc_detection_annotations
    return VOCAnnotation.from_xml(xml_path)
  File "/home/john/code/fiftyone/fiftyone/utils/voc.py", line 480, in from_xml
    return cls.from_dict(d)
  File "/home/john/code/fiftyone/fiftyone/utils/voc.py", line 515, in from_dict
    objects = [VOCObject.from_annotation_dict(do) for do in _objects]
  File "/home/john/code/fiftyone/fiftyone/utils/voc.py", line 515, in <listcomp>
    objects = [VOCObject.from_annotation_dict(do) for do in _objects]
  File "/home/john/code/fiftyone/fiftyone/utils/voc.py", line 557, in from_annotation_dict
    cvat_attrs = {a["name"]: a["value"] for a in cvat_attrs}
  File "/home/john/code/fiftyone/fiftyone/utils/voc.py", line 557, in <dictcomp>
    cvat_attrs = {a["name"]: a["value"] for a in cvat_attrs}
TypeError: string indices must be integers
```

Because, at `cvat_attrs = d.pop("attributes", {}).pop("attribute", {})`, we will get the element instead of list of elements if `attributes` only has one child. Therefore, we need to ensure the `cvat_attrs` is a list by adding the following line:
```python
cvat_attrs = _ensure_list(cvat_attrs)
```

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [X] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [X] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
