### PR TITLE
Using dataset as source of truth for existing frames when sampling frames with to_frames()

### DIFF
--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -5840,10 +5840,11 @@ class SampleCollection(object):
         populated will be omitted from the returned view.
 
         When ``sample_frames`` is True, this method samples each video in the
-        collection into a directory of per-frame images with filenames
-        specified by ``frames_patt``. By default, each folder of images is
-        written using the same basename as the input video. For example, if
-        ``frames_patt = "%%06d.jpg"``, then videos with the following paths::
+        collection into a directory of per-frame images and stores the
+        filepaths in the ``filepath`` frame field of the source dataset. By
+        default, each folder of images is written using the same basename as
+        the input video. For example, if ``frames_patt = "%%06d.jpg"``, then
+        videos with the following paths::
 
             /path/to/video1.mp4
             /path/to/video2.mp4

--- a/fiftyone/core/stages.py
+++ b/fiftyone/core/stages.py
@@ -6925,10 +6925,11 @@ class ToFrames(ViewStage):
     omitted from the returned view.
 
     When ``sample_frames`` is True, this method samples each video in the
-    collection into a directory of per-frame images with filenames specified by
-    ``frames_patt``. By default, each folder of images is written using the
-    same basename as the input video. For example, if
-    ``frames_patt = "%%06d.jpg"``, then videos with the following paths::
+    collection into a directory of per-frame images and stores the filepaths in
+    the ``filepath`` frame field of the source dataset. By default, each folder
+    of images is written using the same basename as the input video. For
+    example, if ``frames_patt = "%%06d.jpg"``, then videos with the following
+    paths::
 
         /path/to/video1.mp4
         /path/to/video2.mp4

--- a/fiftyone/core/video.py
+++ b/fiftyone/core/video.py
@@ -635,7 +635,10 @@ def make_frames_dataset(
             skip_failures=skip_failures,
         )
 
+    #
     # Merge frame data
+    #
+
     pipeline = []
 
     if sample_frames == "dynamic":
@@ -653,10 +656,6 @@ def make_frames_dataset(
     )
 
     sample_collection._aggregate(frames_only=True, post_pipeline=pipeline)
-
-    # Delete samples for frames without filepaths
-    if sample_frames == True:
-        dataset._sample_collection.delete_many({"filepath": None})
 
     if sample_frames == False and not dataset:
         logger.warning(
@@ -833,6 +832,7 @@ def _init_frames(
 
             _id = frame_ids_map.get(fn, None)
             _filepath = images_patt % fn
+            _rand = foos._generate_rand(_filepath)
 
             if missing_fps is not None and fn in missing_fps:
                 missing_filepaths.append((_sample_id, fn, _filepath))
@@ -840,7 +840,9 @@ def _init_frames(
             if sample_frames == "dynamic":
                 filepath = video_path
             else:
-                filepath = None  # will be populated later
+                # This will be overwritten in the final merge if the actual
+                # filepath is different
+                filepath = _filepath
 
             doc = {
                 "filepath": filepath,
@@ -848,7 +850,7 @@ def _init_frames(
                 "metadata": None,
                 "frame_number": fn,
                 "_media_type": "image",
-                "_rand": foos._generate_rand(_filepath),
+                "_rand": _rand,
                 "_sample_id": _sample_id,
             }
 

--- a/fiftyone/core/video.py
+++ b/fiftyone/core/video.py
@@ -454,10 +454,11 @@ def make_frames_dataset(
     omitted from the frames dataset.
 
     When ``sample_frames`` is True, this method samples each video in the
-    collection into a directory of per-frame images with filenames specified by
-    ``frames_patt``. By default, each folder of images is written using the
-    same basename as the input video. For example, if
-    ``frames_patt = "%%06d.jpg"``, then videos with the following paths::
+    collection into a directory of per-frame images and stores the filepaths in
+    the ``filepath`` frame field of the source dataset. By default, each folder
+    of images is written using the same basename as the input video. For
+    example, if ``frames_patt = "%%06d.jpg"``, then videos with the following
+    paths::
 
         /path/to/video1.mp4
         /path/to/video2.mp4

--- a/fiftyone/core/video.py
+++ b/fiftyone/core/video.py
@@ -740,7 +740,7 @@ def _init_frames(
 
         if src_dataset.has_frame_field("filepath"):
             ids, fns = _view.match_frames(
-                fo.ViewField("filepath") is not None,
+                fo.ViewField("filepath") != None,
                 omit_empty=False,
             ).values(["_id", "frames.frame_number"])
             has_filepaths_map = {_id: set(_fns) for _id, _fns in zip(ids, fns)}
@@ -754,6 +754,7 @@ def _init_frames(
         frames = sample.get("frames", [])
 
         frame_ids_map = {}
+        frames_with_docs = set()
         frames_with_filepaths = set()
         for frame in frames:
             _frame_id = frame["_id"]
@@ -763,8 +764,10 @@ def _init_frames(
             if sample_frames != False or filepath is not None:
                 frame_ids_map[fn] = _frame_id
 
-            if sample_frames == True and filepath is not None:
-                frames_with_filepaths.add(fn)
+            if sample_frames == True:
+                frames_with_docs.add(fn)
+                if filepath is not None:
+                    frames_with_filepaths.add(fn)
 
         if is_clips:
             _sample_id = sample["_sample_id"]
@@ -807,13 +810,11 @@ def _init_frames(
 
         # Determine if any docs/filepaths are missing from the source dataset
         if sample_frames == True:
-            if has_filepaths_map is not None:
-                frames_with_filepaths = has_filepaths_map[_sample_id]
-
             if has_docs_map is not None:
                 frames_with_docs = has_docs_map[_sample_id]
-            else:
-                frames_with_docs = frames_with_filepaths
+
+            if has_filepaths_map is not None:
+                frames_with_filepaths = has_filepaths_map[_sample_id]
 
             target_frames = set(doc_frame_numbers)
             missing_docs = target_frames - frames_with_docs

--- a/tests/unittests/video_tests.py
+++ b/tests/unittests/video_tests.py
@@ -1995,42 +1995,41 @@ class VideoTests(unittest.TestCase):
             filepath="video1.mp4",
             metadata=fo.VideoMetadata(total_frame_count=4),
         )
-        sample1.frames[1] = fo.Frame()
+        sample1.frames[1] = fo.Frame(filepath="image11.jpg")
         sample1.frames[2] = fo.Frame(
+            filepath="image12.jpg",
             ground_truth=fo.Detections(
                 detections=[
                     fo.Detection(label="cat"),
                     fo.Detection(label="dog"),
                 ]
-            )
+            ),
         )
-        sample1.frames[3] = fo.Frame(hello="goodbye")
+        sample1.frames[3] = fo.Frame(filepath="image13.jpg", hello="goodbye")
 
         sample2 = fo.Sample(
             filepath="video2.mp4",
             metadata=fo.VideoMetadata(total_frame_count=5),
         )
         sample2.frames[1] = fo.Frame(
+            filepath="image21.jpg",
             ground_truth=fo.Detections(
-                detections=[
-                    fo.Detection(label="dog"),
-                    fo.Detection(label="rabbit"),
-                ]
+                detections=[fo.Detection(label="rabbit")]
             ),
         )
-        sample2.frames[3] = fo.Frame()
-        sample2.frames[5] = fo.Frame(hello="there")
+        sample2.frames[3] = fo.Frame(filepath="image23.jpg")
+        sample2.frames[5] = fo.Frame(filepath="image25.jpg", hello="there")
 
         dataset.add_samples([sample1, sample2])
 
-        frames = dataset.to_frames(sample_frames="dynamic", sparse=True)
-
+        # `sparse=True` would only be needed here if `sample_frames=True`
+        frames = dataset.to_frames()
         self.assertEqual(len(frames), 6)
 
-        view = dataset.match_frames(F("ground_truth.detections").length() > 0)
-        frames = view.to_frames(sample_frames="dynamic", sparse=True)
-
-        self.assertEqual(len(frames), 2)
+        # `sparse=True` would only be needed here if `sample_frames=True`
+        view = dataset.match_frames(F("ground_truth.detections").length() > 1)
+        frames = view.to_frames()
+        self.assertEqual(len(frames), 1)
 
     @drop_datasets
     def test_to_frames_filepaths(self):


### PR DESCRIPTION
Fixes a bug when calling `to_frames(sample_frames=True)` on a view that filters the frames of the input dataset. The following would previously raise an error but now does not:

```py
import fiftyone as fo
import fiftyone.zoo as foz
from fiftyone import ViewField as F

dataset = foz.load_zoo_dataset("quickstart-video")

view = dataset.match_frames(F("frame_number") == 51)

frames1 = view.to_frames(sample_frames=True, sparse=True)
assert len(frames1) == 10
assert dataset.count("frames.filepath") == 10

frames2 = view.to_frames(sample_frames=True)
assert len(frames2) == 1279
assert dataset.count("frames.filepath") == 1279
```
