### PR TITLE
Fix bookmark icon bug

### DIFF
--- a/app/packages/core/src/components/Actions/ActionsRow.tsx
+++ b/app/packages/core/src/components/Actions/ActionsRow.tsx
@@ -1,10 +1,3 @@
-import React, {
-  MutableRefObject,
-  useLayoutEffect,
-  useRef,
-  useState,
-} from "react";
-import { CircularProgress } from "@mui/material";
 import {
   Bookmark,
   Check,
@@ -16,6 +9,13 @@ import {
   VisibilityOff,
   Wallpaper,
 } from "@mui/icons-material";
+import { CircularProgress } from "@mui/material";
+import React, {
+  MutableRefObject,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from "react";
 import useMeasure from "react-use-measure";
 import {
   selectorFamily,
@@ -27,15 +27,15 @@ import styled from "styled-components";
 
 import { FrameLooker, ImageLooker, VideoLooker } from "@fiftyone/looker";
 
+import { useTheme } from "@fiftyone/components";
+import * as fos from "@fiftyone/state";
+import { useEventHandler, useOutsideClick, useSetView } from "@fiftyone/state";
+import { PillButton } from "../utils";
 import OptionsActions from "./Options";
 import Patcher, { patchesFields } from "./Patcher";
 import Selector from "./Selected";
-import Tagger from "./Tagger";
-import { PillButton } from "../utils";
-import { useEventHandler, useOutsideClick, useSetView } from "@fiftyone/state";
 import Similar from "./Similar";
-import { useTheme } from "@fiftyone/components";
-import * as fos from "@fiftyone/state";
+import Tagger from "./Tagger";
 
 const Loading = () => {
   const theme = useTheme();
@@ -279,7 +279,6 @@ const Hidden = () => {
 };
 
 const SaveFilters = () => {
-  const hasFiltersValue = useRecoilValue(fos.hasFilters(false));
   const loading = useRecoilValue(fos.savingFilters);
   const onComplete = useRecoilCallback(({ set, reset }) => () => {
     set(fos.savingFilters, false);
@@ -301,7 +300,18 @@ const SaveFilters = () => {
     []
   );
 
-  return hasFiltersValue ? (
+  const hasFiltersValue = useRecoilValue(fos.hasFilters(false));
+
+  const extendedSelectionList = useRecoilValue(fos.extendedSelection);
+  const isExtendedSelectionOn =
+    extendedSelectionList && extendedSelectionList.length > 0;
+
+  const selectedSampleSet = useRecoilValue(fos.selectedSamples);
+
+  const shouldToggleBookMarkIconOn =
+    hasFiltersValue || isExtendedSelectionOn || selectedSampleSet.size > 0;
+
+  return shouldToggleBookMarkIconOn ? (
     <ActionDiv>
       <PillButton
         open={false}

--- a/app/packages/core/src/components/Actions/ActionsRow.tsx
+++ b/app/packages/core/src/components/Actions/ActionsRow.tsx
@@ -18,6 +18,7 @@ import React, {
 } from "react";
 import useMeasure from "react-use-measure";
 import {
+  selector,
   selectorFamily,
   useRecoilCallback,
   useRecoilState,
@@ -36,6 +37,22 @@ import Patcher, { patchesFields } from "./Patcher";
 import Selector from "./Selected";
 import Similar from "./Similar";
 import Tagger from "./Tagger";
+
+const shouldToggleBookMarkIconOnSelector = selector<boolean>({
+  key: "shouldToggleBookMarkIconOn",
+  get: ({ get }) => {
+    const hasFiltersValue = get(fos.hasFilters(false));
+    const extendedSelectionList = get(fos.extendedSelection);
+    const selectedSampleSet = get(fos.selectedSamples);
+
+    const isExtendedSelectionOn =
+      extendedSelectionList && extendedSelectionList.length > 0;
+
+    return (
+      isExtendedSelectionOn || hasFiltersValue || selectedSampleSet.size > 0
+    );
+  },
+});
 
 const Loading = () => {
   const theme = useTheme();
@@ -300,16 +317,9 @@ const SaveFilters = () => {
     []
   );
 
-  const hasFiltersValue = useRecoilValue(fos.hasFilters(false));
-
-  const extendedSelectionList = useRecoilValue(fos.extendedSelection);
-  const isExtendedSelectionOn =
-    extendedSelectionList && extendedSelectionList.length > 0;
-
-  const selectedSampleSet = useRecoilValue(fos.selectedSamples);
-
-  const shouldToggleBookMarkIconOn =
-    hasFiltersValue || isExtendedSelectionOn || selectedSampleSet.size > 0;
+  const shouldToggleBookMarkIconOn = useRecoilValue(
+    shouldToggleBookMarkIconOnSelector
+  );
 
   return shouldToggleBookMarkIconOn ? (
     <ActionDiv>


### PR DESCRIPTION
## What changes are proposed in this pull request?

Show bookmark icon also when extended selection is on or samples are selected using checkbox. Fixes https://github.com/voxel51/fiftyone/issues/2306

## How is this patch tested? If it is not, please explain why.

Locally

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
