### PR TITLE
Compute sample and label tags counts seperately in tag UI

### DIFF
--- a/app/packages/core/src/components/Actions/Tagger.tsx
+++ b/app/packages/core/src/components/Actions/Tagger.tsx
@@ -525,7 +525,7 @@ const Tagger = ({ modal, bounds, close, lookerRef }: TaggerProps) => {
 
   const submit = useTagCallback(modal, labels, lookerRef);
   const labelPlaceholder = useLabelPlaceHolder(modal, elementNames);
-  const nonLabelPlaceholder = useNonLabelPlaceHolder(modal, elementNames);
+  const samplePlaceholder = useSamplePlaceHolder(modal, elementNames);
   return (
     <Popout style={{ width: "12rem" }} modal={modal} bounds={bounds}>
       <SwitcherDiv>

--- a/app/packages/core/src/components/Actions/Tagger.tsx
+++ b/app/packages/core/src/components/Actions/Tagger.tsx
@@ -431,26 +431,19 @@ const useLabelPlaceHolder = (
 ) => {
   return (): [number, string] => {
     const selectedSamples = useRecoilValue(fos.selectedSamples).size;
-    const totalSamples = useRecoilValue(
-      fos.count({ path: "", extended: false, modal })
-    );
-    const filteredSamples = useRecoilValue(
-      fos.count({ path: "", extended: true, modal })
-    );
-    const count = filteredSamples ?? totalSamples;
     const selectedLabels = useRecoilValue(fos.selectedLabelIds).size;
     const selectedLabelCount = useRecoilValue(numItemsInSelection(true));
     const totalLabelCount = useRecoilValue(
       fos.labelCount({ modal, extended: true })
     );
-    if (modal && (!selectedSamples || selectedLabels)) {
+    if (modal && selectedLabels) {
       const labelCount = selectedLabels > 0 ? selectedLabels : totalLabelCount;
       return [labelCount, labelsModalPlaceholder(selectedLabels, labelCount)];
     } else {
       const labelCount = selectedSamples ? selectedLabelCount : totalLabelCount;
       return [
         labelCount,
-        labelsPlaceholder(selectedSamples, labelCount, count, elementNames),
+        labelsPlaceholder(selectedSamples, labelCount, null, elementNames),
       ];
     }
   };

--- a/app/packages/core/src/components/Actions/Tagger.tsx
+++ b/app/packages/core/src/components/Actions/Tagger.tsx
@@ -557,7 +557,7 @@ const Tagger = ({ modal, bounds, close, lookerRef }: TaggerProps) => {
       {!labels && (
         <Suspense fallback={<SuspenseLoading />} key={elementNames.plural}>
           <Section
-            countAndPlaceholder={nonLabelPlaceholder}
+            countAndPlaceholder={samplePlaceholder}
             submit={submit}
             taggingAtom={fos.tagging({ modal, labels })}
             itemsAtom={tagStats({ modal, labels })}

--- a/app/packages/core/src/components/Actions/Tagger.tsx
+++ b/app/packages/core/src/components/Actions/Tagger.tsx
@@ -456,7 +456,7 @@ const useLabelPlaceHolder = (
   };
 };
 
-const useNonLabelPlaceHolder = (
+const useSamplePlaceHolder = (
   modal: boolean,
   elementNames: { plural: string; singular: string }
 ) => {


### PR DESCRIPTION
## What changes are proposed in this pull request?

#2278 
Compute Sample and Label tags count seperately in tag UI

## How is this patch tested? If it is not, please explain why.

locally


## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other

https://user-images.githubusercontent.com/17770824/204662476-d12fe69d-3b99-4c82-9577-09338ebdd1b9.mov

