### PR TITLE
Initialize current relay environment

### DIFF
--- a/app/packages/state/src/hooks/useRouter.ts
+++ b/app/packages/state/src/hooks/useRouter.ts
@@ -8,7 +8,7 @@ import {
   getEnvironment,
 } from "../routing";
 
-let currentEnvironment: Environment = null;
+let currentEnvironment: Environment = getEnvironment();
 
 export const getCurrentEnvironment = () => {
   return currentEnvironment;


### PR DESCRIPTION
Initializes the a current relay environment for situations in which `useRouter` is not called.