### PR TITLE
count exact number of frames with ffprbe -count_frames

### DIFF
--- a/fiftyone/utils/video.py
+++ b/fiftyone/utils/video.py
@@ -6,6 +6,7 @@ Video utilities.
 |
 """
 import itertools
+import json
 import logging
 import os
 
@@ -656,6 +657,33 @@ def concat_videos(input_paths, output_path, verbose=False):
 
         with etav.FFmpeg(in_opts=in_opts, out_opts=out_opts) as ffmpeg:
             ffmpeg.run(input_list_path, output_path, verbose=verbose)
+
+
+def exact_frame_count(input_path):
+    """Returns the exact number of frames in the video.
+
+    This method uses -count_frames argument of ffprobe
+    which decodes the entire video to count the frames
+    and can be very slow.
+
+    Args:
+        input_path: the path to the video
+
+    Returns:
+        the number of frames in the video
+    """
+    opts = [
+        "-count_frames",
+        "-select_streams",
+        "v:0",
+        "-print_format",
+        "json",
+        "-show_streams",
+    ]
+    ffprobe = etav.FFprobe(opts=opts)
+    output = ffprobe.run(input_path)
+    output = json.loads(output.decode())
+    return int(output["streams"][0]["nb_read_frames"])
 
 
 def _transform_videos(

--- a/tests/intensive/video_tests.py
+++ b/tests/intensive/video_tests.py
@@ -15,6 +15,7 @@ import unittest
 import fiftyone as fo
 import fiftyone.zoo as foz
 from fiftyone import ViewField as F
+import fiftyone.utils.video as fouv
 
 
 def test_to_clips():
@@ -456,6 +457,15 @@ def test_to_frame_eval_patches():
     print(patches)
     print(patches.first())
     print(patches.count_values("type"))
+
+
+def test_exact_frame_count():
+    dataset = foz.load_zoo_dataset("quickstart-video").clone()
+    dataset.limit(2).save()
+
+    for smp in dataset:
+        frame_count = fouv.exact_frame_count(smp.filepath)
+        assert frame_count == len(smp.frames)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What changes are proposed in this pull request?

Count exact number of frames in a video.

## How is this patch tested? If it is not, please explain why.

added a unit-test to the intensive group.

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

Exact number of frames can be counted with `fiftyone.utils.video.exact_frame_count()`.
This method uses `-count_frames` argument of `ffprobe` which decodes the entire video to count the frames and can be very slow.

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
