### PR TITLE
Updating last_loaded_at whenever Dataset is accessed

### DIFF
--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -5807,6 +5807,10 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
     def _serialize(self):
         return self._doc.to_dict(extended=True)
 
+    def _update_last_loaded_at(self):
+        self._doc.last_loaded_at = datetime.utcnow()
+        self._doc.save()
+
 
 def _get_random_characters(n):
     return "".join(

--- a/fiftyone/core/singletons.py
+++ b/fiftyone/core/singletons.py
@@ -33,8 +33,11 @@ class DatasetSingleton(type):
             instance.__init__(name=name, _create=_create, *args, **kwargs)
             name = instance.name  # `__init__` may have changed `name`
             cls._instances[name] = instance
+        else:
+            instance = cls._instances[name]
+            instance._update_last_loaded_at()
 
-        return cls._instances[name]
+        return instance
 
 
 class DocumentSingleton(type):

--- a/tests/unittests/dataset_tests.py
+++ b/tests/unittests/dataset_tests.py
@@ -100,6 +100,11 @@ class DatasetTests(unittest.TestCase):
         self.assertIs(also_dataset, dataset)
         self.assertTrue(last_loaded_at2 > last_loaded_at1)
 
+        dataset.reload()
+        last_loaded_at3 = dataset.last_loaded_at
+
+        self.assertTrue(last_loaded_at3 > last_loaded_at2)
+
     @drop_datasets
     def test_dataset_tags(self):
         dataset_name = self.test_dataset_tags.__name__

--- a/tests/unittests/dataset_tests.py
+++ b/tests/unittests/dataset_tests.py
@@ -88,6 +88,19 @@ class DatasetTests(unittest.TestCase):
         self.assertIs(dataset1, dataset4)
 
     @drop_datasets
+    def test_last_loaded_at(self):
+        dataset_name = self.test_dataset_info.__name__
+
+        dataset = fo.Dataset(dataset_name)
+        last_loaded_at1 = dataset.last_loaded_at
+
+        also_dataset = fo.load_dataset(dataset_name)
+        last_loaded_at2 = dataset.last_loaded_at
+
+        self.assertIs(also_dataset, dataset)
+        self.assertTrue(last_loaded_at2 > last_loaded_at1)
+
+    @drop_datasets
     def test_dataset_tags(self):
         dataset_name = self.test_dataset_tags.__name__
 


### PR DESCRIPTION
```py
import fiftyone as fo
import fiftyone.zoo as foz

dataset = foz.load_zoo_dataset("quickstart")
last_loaded_at1 = dataset.last_loaded_at

dataset = fo.load_dataset("quickstart")
last_loaded_at2 = dataset.last_loaded_at  # previously didn't update; now does

assert last_loaded_at2 > last_loaded_at1

dataset.reload()
last_loaded_at3 = dataset.last_loaded_at  # previously didn't update; now does

assert last_loaded_at3 > last_loaded_at2
```
