### PR TITLE
Override gridMeidaField and ModalMediaField to filepath 

### DIFF
--- a/app/packages/state/src/hooks/useStateUpdate.ts
+++ b/app/packages/state/src/hooks/useStateUpdate.ts
@@ -27,6 +27,8 @@ import {
   sidebarMode,
   groupStatistics,
   theme,
+  schemaReduce,
+  field,
 } from "../recoil";
 import { useColorScheme } from "@mui/material";
 
@@ -109,13 +111,21 @@ const useStateUpdate = () => {
           reset(groupStatistics(false));
 
           reset(similarityParameters);
+
+          const getMediaPathWithOverride = (f: string) =>
+            dataset.sampleFields.map((field) => field.name).includes(f)
+              ? f
+              : "filepath";
+
           set(
             selectedMediaField(false),
-            dataset?.appConfig?.gridMediaField || "filepath"
+            getMediaPathWithOverride(dataset?.appConfig?.gridMediaField) ||
+              "filepath"
           );
           set(
             selectedMediaField(true),
-            dataset?.appConfig?.modalMediaField || "filepath"
+            getMediaPathWithOverride(dataset?.appConfig?.modalMediaField) ||
+              "filepath"
           );
           reset(extendedSelection);
           reset(filters);

--- a/app/packages/state/src/hooks/useStateUpdate.ts
+++ b/app/packages/state/src/hooks/useStateUpdate.ts
@@ -27,8 +27,6 @@ import {
   sidebarMode,
   groupStatistics,
   theme,
-  schemaReduce,
-  field,
 } from "../recoil";
 import { useColorScheme } from "@mui/material";
 


### PR DESCRIPTION
#2303 

## What changes are proposed in this pull request?

When gridMediaField and modalMediaField are set to a field that’s not in the current view’s schema, the App will override to `filepath` (which must always exist). This makes sure the grid always default render on the right path. 

## How is this patch tested? If it is not, please explain why.

Locally

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne doe
![Screenshot 2022-11-30 at 11 53 15 AM](https://user-images.githubusercontent.com/17770824/204871960-0e9fd232-0967-4a67-9faf-02a48b17e701.png)
s this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
