### PR TITLE
Add modalMediaField to graphQL query and type 

### DIFF
--- a/app/packages/core/src/Dataset.ts
+++ b/app/packages/core/src/Dataset.ts
@@ -21,6 +21,7 @@ export const DatasetNodeQuery = graphql`
       }
       appConfig {
         gridMediaField
+        modalMediaField
         mediaFields
         plugins
         sidebarGroups {
@@ -95,6 +96,7 @@ export const DatasetNodeQuery = graphql`
       appConfig {
         mediaFields
         gridMediaField
+        modalMediaField
         plugins
         sidebarGroups {
           name

--- a/app/packages/core/src/__generated__/DatasetQuery.graphql.ts
+++ b/app/packages/core/src/__generated__/DatasetQuery.graphql.ts
@@ -19,7 +19,8 @@ export type DatasetQuery$data = {
   readonly dataset: {
     readonly appConfig: {
       readonly gridMediaField: string | null;
-      readonly mediaFields: ReadonlyArray<string> | null;
+      readonly modalMediaField: string | null;
+      readonly mediaFields: ReadonlyArray<string>;
       readonly plugins: object | null;
       readonly sidebarGroups: ReadonlyArray<{
         readonly expanded: boolean | null;
@@ -317,6 +318,13 @@ v17 = [
             "alias": null,
             "args": null,
             "kind": "ScalarField",
+            "name": "modalMediaField",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
             "name": "mediaFields",
             "storageKey": null
           },
@@ -601,7 +609,7 @@ return {
     "metadata": {},
     "name": "DatasetQuery",
     "operationKind": "query",
-    "text": "query DatasetQuery(\n  $name: String!\n  $view: BSONArray = null\n) {\n  dataset(name: $name, view: $view) {\n    id\n    name\n    mediaType\n    defaultGroupSlice\n    groupField\n    groupMediaTypes {\n      name\n      mediaType\n    }\n    appConfig {\n      gridMediaField\n      mediaFields\n      plugins\n      sidebarGroups {\n        expanded\n        paths\n        name\n      }\n      sidebarMode\n    }\n    sampleFields {\n      ftype\n      subfield\n      embeddedDocType\n      path\n      dbField\n      description\n      info\n    }\n    frameFields {\n      ftype\n      subfield\n      embeddedDocType\n      path\n      dbField\n    }\n    maskTargets {\n      name\n      targets {\n        target\n        value\n      }\n    }\n    defaultMaskTargets {\n      target\n      value\n    }\n    evaluations {\n      key\n      version\n      timestamp\n      viewStages\n      config {\n        cls\n        predField\n        gtField\n      }\n    }\n    brainMethods {\n      key\n      version\n      timestamp\n      viewStages\n      config {\n        cls\n        embeddingsField\n        method\n        patchesField\n      }\n    }\n    lastLoadedAt\n    createdAt\n    skeletons {\n      name\n      labels\n      edges\n    }\n    defaultSkeleton {\n      labels\n      edges\n    }\n    version\n    viewCls\n    info\n  }\n}\n"
+    "text": "query DatasetQuery(\n  $name: String!\n  $view: BSONArray = null\n) {\n  dataset(name: $name, view: $view) {\n    id\n    name\n    mediaType\n    defaultGroupSlice\n    groupField\n    groupMediaTypes {\n      name\n      mediaType\n    }\n    appConfig {\n      gridMediaField\n      modalMediaField\n      mediaFields\n      plugins\n      sidebarGroups {\n        expanded\n        paths\n        name\n      }\n      sidebarMode\n    }\n    sampleFields {\n      ftype\n      subfield\n      embeddedDocType\n      path\n      dbField\n      description\n      info\n    }\n    frameFields {\n      ftype\n      subfield\n      embeddedDocType\n      path\n      dbField\n    }\n    maskTargets {\n      name\n      targets {\n        target\n        value\n      }\n    }\n    defaultMaskTargets {\n      target\n      value\n    }\n    evaluations {\n      key\n      version\n      timestamp\n      viewStages\n      config {\n        cls\n        predField\n        gtField\n      }\n    }\n    brainMethods {\n      key\n      version\n      timestamp\n      viewStages\n      config {\n        cls\n        embeddingsField\n        method\n        patchesField\n      }\n    }\n    lastLoadedAt\n    createdAt\n    skeletons {\n      name\n      labels\n      edges\n    }\n    defaultSkeleton {\n      labels\n      edges\n    }\n    version\n    viewCls\n    info\n  }\n}\n"
   }
 };
 })();

--- a/app/packages/core/src/__generated__/DatasetQuery.graphql.ts
+++ b/app/packages/core/src/__generated__/DatasetQuery.graphql.ts
@@ -20,7 +20,7 @@ export type DatasetQuery$data = {
     readonly appConfig: {
       readonly gridMediaField: string | null;
       readonly modalMediaField: string | null;
-      readonly mediaFields: ReadonlyArray<string>;
+      readonly mediaFields: ReadonlyArray<string> | null;
       readonly plugins: object | null;
       readonly sidebarGroups: ReadonlyArray<{
         readonly expanded: boolean | null;

--- a/app/packages/relay/src/mutations/__generated__/setViewMutation.graphql.ts
+++ b/app/packages/relay/src/mutations/__generated__/setViewMutation.graphql.ts
@@ -37,7 +37,8 @@ export type setViewMutation$data = {
     readonly dataset: {
       readonly appConfig: {
         readonly gridMediaField: string | null;
-        readonly mediaFields: ReadonlyArray<string> | null;
+        readonly modalMediaField: string | null;
+        readonly mediaFields: ReadonlyArray<string>;
         readonly plugins: object | null;
         readonly sidebarGroups: ReadonlyArray<{
           readonly expanded: boolean | null;

--- a/app/packages/relay/src/mutations/__generated__/setViewMutation.graphql.ts
+++ b/app/packages/relay/src/mutations/__generated__/setViewMutation.graphql.ts
@@ -38,7 +38,7 @@ export type setViewMutation$data = {
       readonly appConfig: {
         readonly gridMediaField: string | null;
         readonly modalMediaField: string | null;
-        readonly mediaFields: ReadonlyArray<string>;
+        readonly mediaFields: ReadonlyArray<string> | null;
         readonly plugins: object | null;
         readonly sidebarGroups: ReadonlyArray<{
           readonly expanded: boolean | null;

--- a/app/packages/relay/src/mutations/setView.ts
+++ b/app/packages/relay/src/mutations/setView.ts
@@ -89,6 +89,7 @@ export default graphql`
         }
         appConfig {
           gridMediaField
+          modalMediaField
           mediaFields
           plugins
           sidebarGroups {


### PR DESCRIPTION
## What changes are proposed in this pull request?

appConfig graphQL did not have modalMediaField, so we are loading the saved modal_media_field in the FE. This fixes that. 

## How is this patch tested? If it is not, please explain why.
Locally

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
