### PR TITLE
Fix Flashlight resets

### DIFF
--- a/app/packages/core/src/components/Grid/Grid.tsx
+++ b/app/packages/core/src/components/Grid/Grid.tsx
@@ -85,6 +85,30 @@ const Grid: React.FC<{}> = () => {
     return flashlight;
   });
 
+  useLayoutEffect(
+    deferred(() => {
+      if (isTagging || !flashlight.isAttached()) {
+        return;
+      }
+
+      next.current = 0;
+      flashlight.reset();
+      store.reset();
+      freeVideos();
+    }),
+    [
+      stringifyObj(useRecoilValue(fos.filters)),
+      useRecoilValue(fos.datasetName),
+      useRecoilValue(fos.cropToContent(false)),
+      fos.filterView(useRecoilValue(fos.view)),
+      useRecoilValue(fos.groupSlice(false)),
+      useRecoilValue(fos.refresher),
+      useRecoilValue(fos.similarityParameters),
+      useRecoilValue(fos.selectedMediaField(false)),
+      useRecoilValue(fos.extendedStagesUnsorted),
+    ]
+  );
+
   const select = fos.useSelectFlashlightSample();
   const selectSample = useRef(select);
   selectSample.current = select;
@@ -121,44 +145,19 @@ const Grid: React.FC<{}> = () => {
   );
   const isTagging = taggingLabels || taggingSamples;
 
-  useLayoutEffect(
-    deferred(() => {
-      if (isTagging || !flashlight.isAttached()) {
-        return;
-      }
-
-      next.current = 0;
-      flashlight.reset();
-      store.reset();
-      freeVideos();
-    }),
-    [
-      stringifyObj(useRecoilValue(fos.filters)),
-      useRecoilValue(fos.datasetName),
-      useRecoilValue(fos.cropToContent(false)),
-      fos.filterView(useRecoilValue(fos.view)),
-      useRecoilValue(fos.groupSlice(false)),
-      useRecoilValue(fos.refresher),
-      useRecoilValue(fos.similarityParameters),
-      useRecoilValue(fos.selectedMediaField(false)),
-      useRecoilValue(fos.extendedStagesUnsorted),
-    ]
-  );
-
   useEventHandler(
     document,
     "keydown",
     useRecoilCallback(
-      ({ snapshot, set }) =>
-        async (event: KeyboardEvent) => {
-          if (event.key !== "Escape") {
-            return;
-          }
+      ({ snapshot, set }) => async (event: KeyboardEvent) => {
+        if (event.key !== "Escape") {
+          return;
+        }
 
-          if (!(await snapshot.getPromise(fos.modal))) {
-            set(fos.selectedSamples, new Set());
-          }
-        },
+        if (!(await snapshot.getPromise(fos.modal))) {
+          set(fos.selectedSamples, new Set());
+        }
+      },
       []
     )
   );

--- a/app/packages/flashlight/src/index.ts
+++ b/app/packages/flashlight/src/index.ts
@@ -146,13 +146,11 @@ export default class Flashlight<K> {
     return Boolean(this.element.parentElement);
   }
   private showPixels() {
-    !this.pixelsSet && this.container.classList.add(flashlightPixels);
-    this.pixelsSet = true;
+    this.container.classList.add(flashlightPixels);
   }
 
   private hidePixels() {
-    this.pixelsSet && this.container.classList.remove(flashlightPixels);
-    this.pixelsSet = false;
+    this.container.classList.remove(flashlightPixels);
   }
 
   attach(element: HTMLElement | string): void {


### PR DESCRIPTION
Fixes situations in which the schema changes when the view changes and flashlight must reset before other effects are run. Also ensures loading pixels are shown during a loading state.