### PR TITLE
show message for bad token error in map plugin

### DIFF
--- a/app/packages/map/src/Map.tsx
+++ b/app/packages/map/src/Map.tsx
@@ -216,8 +216,8 @@ const Plot: React.FC<{}> = () => {
                 draw.changeMode("draw_polygon");
               }
             } catch (error) {
-              console.error(error);
               setMapError(true);
+              throw error;
             }
           }}
         >

--- a/app/packages/map/src/Map.tsx
+++ b/app/packages/map/src/Map.tsx
@@ -117,6 +117,7 @@ const Plot: React.FC<{}> = () => {
         defaultMode: "draw_polygon",
       })
   );
+  const [mapError, setMapError] = React.useState(false);
 
   const onLoad = React.useCallback(() => {
     const map = mapRef.current?.getMap();
@@ -170,6 +171,8 @@ const Plot: React.FC<{}> = () => {
     <div className={container} ref={ref}>
       {loading && !length ? (
         <foc.Loading style={{ opacity: 0.5 }}>Pixelating...</foc.Loading>
+      ) : mapError ? (
+        <foc.Loading> Bad token </foc.Loading>
       ) : (
         <Map
           ref={mapRef}
@@ -190,7 +193,10 @@ const Plot: React.FC<{}> = () => {
               if (draw.getMode() !== "draw_polygon") {
                 draw.changeMode("draw_polygon");
               }
-            } catch {}
+            } catch (error) {
+              console.error(error);
+              setMapError(true);
+            }
           }}
         >
           <Source

--- a/app/packages/map/src/Map.tsx
+++ b/app/packages/map/src/Map.tsx
@@ -183,7 +183,18 @@ const Plot: React.FC<{}> = () => {
       {loading && !length ? (
         <foc.Loading style={{ opacity: 0.5 }}>Pixelating...</foc.Loading>
       ) : mapError ? (
-        <foc.Loading> Bad token </foc.Loading>
+        <foc.Loading>
+          Something went wrong... is your&nbsp;
+          <ExternalLink
+            style={{ color: theme.text.primary }}
+            href={
+              "https://voxel51.com/docs/fiftyone/user_guide/app.html#map-tab"
+            }
+          >
+            Mapbox token
+          </ExternalLink>
+          &nbsp;valid?
+        </foc.Loading>
       ) : (
         <Map
           ref={mapRef}


### PR DESCRIPTION
## What changes are proposed in this pull request?
fixes #2363 

Handle the map token error when rendering the map
![Screenshot 2022-12-02 at 11 37 56 AM](https://user-images.githubusercontent.com/17770824/205352602-0b3405d3-5ff8-4db1-863d-bb0ce2d11f06.png)


## How is this patch tested? If it is not, please explain why.

Local

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
