### PR TITLE
Ensure sample is present when rendering an unloaded looker (Fix groups modal)

### DIFF
--- a/app/packages/looker/src/index.ts
+++ b/app/packages/looker/src/index.ts
@@ -265,8 +265,8 @@ export abstract class Looker<
 
         this.previousState = this.state;
         this.state = mergeUpdates(this.state, updates);
-        if (!this.state.loaded) {
-          this.lookerElement.render(this.state, undefined);
+        if (!this.state.loaded && this.sample) {
+          this.lookerElement.render(this.state, this.sample);
           return;
         }
 


### PR DESCRIPTION
Ensures the sample is loaded before rendering an unloaded state. Fixes expanding the group modal.

```py
import fiftyone.zoo as foz

dataset = foz.load_zoo_dataset("quickstart-groups")
session = fo.Session(dataset) # open the modal
```