### PR TITLE
Remove `none` as an option from other value options

### DIFF
--- a/app/packages/core/src/components/Filters/CategoricalFilter.tsx
+++ b/app/packages/core/src/components/Filters/CategoricalFilter.tsx
@@ -132,7 +132,7 @@ const Wrapper = ({
     );
   }
 
-  allValues = [...new Set(allValues)];
+  allValues = [...new Set(allValues)].filter((v) => Boolean(v.value));
 
   return (
     <>


### PR DESCRIPTION
fixes #2277 

## What changes are proposed in this pull request?

None/Null should not be treated equally as the other value options. There will be a separate ticket tracking how to allow user to select the empty value samples. 
![Screenshot 2022-12-06 at 1 33 09 PM](https://user-images.githubusercontent.com/17770824/206005231-943a399f-15c5-4912-bf26-f05fcf80f684.png)

## How is this patch tested? If it is not, please explain why.

(Details)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
