### PR TITLE
Resolve custom embedded list field in App filters

### DIFF
--- a/fiftyone/server/view.py
+++ b/fiftyone/server/view.py
@@ -355,6 +355,12 @@ def _is_label(field):
 
 def _make_scalar_expression(f, args, field):
     expr = None
+    if isinstance(field, fof.ListField):
+        return (
+            f.filter(_make_scalar_expression(F(), args, field.field)).length()
+            > 0
+        )
+
     if isinstance(field, fof.BooleanField):
         true, false = args["true"], args["false"]
         if true and false:


### PR DESCRIPTION
Resolves filtering in the sidebar for custom embedded list fields, e.g.
```py
import fiftyone as fo
import fiftyone.zoo as foz

dataset = foz.load_zoo_dataset("quickstart").clone()
dataset.add_sample_field("ground_truth.detections.custom_tags", ftype=fo.ListField, subfield=fo.StringField)
sample = dataset.first()
sample.ground_truth.detections[0]["custom_tags"] = ["person", "standing", "resident"]
sample.save()

session = fo.launch_app(dataset)
```