### PR TITLE
Never show expanded list for ID fields

### DIFF
--- a/app/packages/core/src/components/Filters/CategoricalFilter.tsx
+++ b/app/packages/core/src/components/Filters/CategoricalFilter.tsx
@@ -109,12 +109,9 @@ const Wrapper = ({
     count: counts[String(value)] ?? 0,
   }));
   const skeleton = useRecoilValue(isKeypointLabel(path));
+  const neverShowExpansion = NEVEREXPAND_FIELDS.includes(name.toLowerCase());
 
-  if (
-    (results.length <= CHECKBOX_LIMIT &&
-      !NEVEREXPAND_FIELDS.includes(name.toLowerCase())) ||
-    skeleton
-  ) {
+  if ((results.length <= CHECKBOX_LIMIT && !neverShowExpansion) || skeleton) {
     allValues = [
       ...allValues,
       ...results
@@ -366,6 +363,7 @@ const CategoricalFilter = <T extends V = V>({
   const theme = useTheme();
   const field = useRecoilValue(fos.field(path));
   const countsLoadable = useRecoilValueLoadable(countsAtom);
+  const neverShowExpansion = NEVEREXPAND_FIELDS.includes(name.toLowerCase());
 
   if (countsLoadable.state !== "hasValue") return null;
 
@@ -404,8 +402,7 @@ const CategoricalFilter = <T extends V = V>({
       >
         {results === null && <LoadingDots text="" />}
         {results !== null &&
-          (results.length > CHECKBOX_LIMIT ||
-            NEVEREXPAND_FIELDS.includes(name.toLowerCase())) &&
+          (results.length > CHECKBOX_LIMIT || neverShowExpansion) &&
           !skeleton && (
             <Selector
               useSearch={useSearch}

--- a/app/packages/core/src/components/Filters/CategoricalFilter.tsx
+++ b/app/packages/core/src/components/Filters/CategoricalFilter.tsx
@@ -111,7 +111,8 @@ const Wrapper = ({
   const skeleton = useRecoilValue(isKeypointLabel(path));
 
   if (
-    (results.length <= CHECKBOX_LIMIT && !NEVEREXPAND_FIELDS.includes(name)) ||
+    (results.length <= CHECKBOX_LIMIT &&
+      !NEVEREXPAND_FIELDS.includes(name.toLowerCase())) ||
     skeleton
   ) {
     allValues = [
@@ -404,7 +405,7 @@ const CategoricalFilter = <T extends V = V>({
         {results === null && <LoadingDots text="" />}
         {results !== null &&
           (results.length > CHECKBOX_LIMIT ||
-            NEVEREXPAND_FIELDS.includes(name.toLocaleLowerCase())) &&
+            NEVEREXPAND_FIELDS.includes(name.toLowerCase())) &&
           !skeleton && (
             <Selector
               useSearch={useSearch}

--- a/app/packages/core/src/components/Filters/CategoricalFilter.tsx
+++ b/app/packages/core/src/components/Filters/CategoricalFilter.tsx
@@ -47,7 +47,6 @@ const NamedCategoricalFilterHeader = styled.div`
 `;
 
 const CHECKBOX_LIMIT = 20;
-const NEVEREXPAND_FIELDS = ["id"];
 
 type V = { value: string | number | null | boolean; count: number };
 
@@ -109,9 +108,7 @@ const Wrapper = ({
     count: counts[String(value)] ?? 0,
   }));
   const skeleton = useRecoilValue(isKeypointLabel(path));
-  const neverShowExpansion =
-    NEVEREXPAND_FIELDS.includes(name.toLowerCase()) &&
-    schema?.ftype.includes("ObjectIdField");
+  const neverShowExpansion = schema?.ftype.includes("ObjectIdField");
 
   if ((results.length <= CHECKBOX_LIMIT && !neverShowExpansion) || skeleton) {
     allValues = [

--- a/app/packages/core/src/components/Filters/CategoricalFilter.tsx
+++ b/app/packages/core/src/components/Filters/CategoricalFilter.tsx
@@ -362,7 +362,8 @@ const CategoricalFilter = <T extends V = V>({
   const theme = useTheme();
   const field = useRecoilValue(fos.field(path));
   const countsLoadable = useRecoilValueLoadable(countsAtom);
-  const neverShowExpansion = NEVEREXPAND_FIELDS.includes(name.toLowerCase());
+  const schema = useRecoilValue(fos.field(path));
+  const neverShowExpansion = schema?.ftype.includes("ObjectIdField");
 
   if (countsLoadable.state !== "hasValue") return null;
 

--- a/app/packages/core/src/components/Filters/CategoricalFilter.tsx
+++ b/app/packages/core/src/components/Filters/CategoricalFilter.tsx
@@ -98,8 +98,8 @@ const Wrapper = ({
   selectedCounts,
 }: WrapperProps) => {
   const name = path.split(".").slice(-1)[0];
+  const schema = useRecoilValue(fos.field(path));
   const [selected, setSelected] = useRecoilState(selectedValuesAtom);
-
   const selectedSet = new Set(selected);
   const setExcluded = excludeAtom ? useSetRecoilState(excludeAtom) : null;
   const sorting = useRecoilValue(fos.sortFilterResults(modal));
@@ -109,7 +109,9 @@ const Wrapper = ({
     count: counts[String(value)] ?? 0,
   }));
   const skeleton = useRecoilValue(isKeypointLabel(path));
-  const neverShowExpansion = NEVEREXPAND_FIELDS.includes(name.toLowerCase());
+  const neverShowExpansion =
+    NEVEREXPAND_FIELDS.includes(name.toLowerCase()) &&
+    schema?.ftype.includes("ObjectIdField");
 
   if ((results.length <= CHECKBOX_LIMIT && !neverShowExpansion) || skeleton) {
     allValues = [

--- a/app/packages/core/src/components/Filters/CategoricalFilter.tsx
+++ b/app/packages/core/src/components/Filters/CategoricalFilter.tsx
@@ -47,6 +47,7 @@ const NamedCategoricalFilterHeader = styled.div`
 `;
 
 const CHECKBOX_LIMIT = 20;
+const NEVEREXPAND_FIELDS = ["id"];
 
 type V = { value: string | number | null | boolean; count: number };
 
@@ -109,7 +110,10 @@ const Wrapper = ({
   }));
   const skeleton = useRecoilValue(isKeypointLabel(path));
 
-  if (results.length <= CHECKBOX_LIMIT || skeleton) {
+  if (
+    (results.length <= CHECKBOX_LIMIT && !NEVEREXPAND_FIELDS.includes(name)) ||
+    skeleton
+  ) {
     allValues = [
       ...allValues,
       ...results
@@ -398,21 +402,24 @@ const CategoricalFilter = <T extends V = V>({
         onMouseDown={(event) => event.stopPropagation()}
       >
         {results === null && <LoadingDots text="" />}
-        {results !== null && results.length > CHECKBOX_LIMIT && !skeleton && (
-          <Selector
-            useSearch={useSearch}
-            placeholder={`+ filter by ${name}`}
-            component={ResultComponent}
-            onSelect={onSelect}
-            inputStyle={{
-              color: theme.text.secondary,
-              fontSize: "1rem",
-              width: "100%",
-            }}
-            containerStyle={{ borderBottomColor: color, zIndex: 1000 }}
-            toKey={({ value }) => String(value)}
-          />
-        )}
+        {results !== null &&
+          (results.length > CHECKBOX_LIMIT ||
+            NEVEREXPAND_FIELDS.includes(name.toLocaleLowerCase())) &&
+          !skeleton && (
+            <Selector
+              useSearch={useSearch}
+              placeholder={`+ filter by ${name}`}
+              component={ResultComponent}
+              onSelect={onSelect}
+              inputStyle={{
+                color: theme.text.secondary,
+                fontSize: "1rem",
+                width: "100%",
+              }}
+              containerStyle={{ borderBottomColor: color, zIndex: 1000 }}
+              toKey={({ value }) => String(value)}
+            />
+          )}
         <Wrapper
           path={path}
           color={color}


### PR DESCRIPTION
fixes #2308 

## What changes are proposed in this pull request?
ID list should always be displayed as a filter search, instead of expanded selection options.

## How is this patch tested? If it is not, please explain why.

Locally

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
