### PR TITLE
Remove none count option (remove null count in recoil)

### DIFF
--- a/app/packages/state/src/recoil/aggregations.ts
+++ b/app/packages/state/src/recoil/aggregations.ts
@@ -274,12 +274,6 @@ export const stringCountResults = selectorFamily<
       const results: [string | null, number][] = values.map(
         ({ count, value }) => [value, count]
       );
-      const none: number = get(noneCount(params));
-
-      if (none) {
-        results.push([null, none]);
-        count++;
-      }
 
       return {
         count,
@@ -305,7 +299,6 @@ export const booleanCountResults = selectorFamily<
         results: [
           [false, data.false],
           [true, data.true],
-          [null, get(noneCount(params))],
         ],
       };
     },
@@ -334,6 +327,7 @@ export const labelCount = selectorFamily<
     eviction: "most-recent",
   },
 });
+
 export const values = selectorFamily<
   string[],
   { extended: boolean; path: string; modal: boolean }


### PR DESCRIPTION
fixes #2277 

## What changes are proposed in this pull request?

Here I removed none count from `[count, results]` in `stringCountResults` and `booleanCountResults` in recoil. 

## How is this patch tested? If it is not, please explain why.
Locally

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
