### PR TITLE
Fix grid sync from event source

### DIFF
--- a/app/packages/core/src/components/Grid/Grid.tsx
+++ b/app/packages/core/src/components/Grid/Grid.tsx
@@ -85,7 +85,7 @@ const Grid: React.FC<{}> = () => {
     return flashlight;
   });
 
-  useLayoutEffect(
+  useEffect(
     deferred(() => {
       if (isTagging || !flashlight.isAttached()) {
         return;

--- a/app/packages/state/src/hooks/useStateUpdate.ts
+++ b/app/packages/state/src/hooks/useStateUpdate.ts
@@ -93,7 +93,7 @@ const useStateUpdate = () => {
         if (
           !previousDataset ||
           previousDataset.id !== dataset.id ||
-          dataset.groupSlice !== previousDataset.groupSlice
+          dataset.groupSlice != previousDataset.groupSlice
         ) {
           if (dataset?.name !== previousDataset?.name) {
             reset(sidebarMode(false));


### PR DESCRIPTION
Sometimes state updates that are pushed to the App are not handled correctly by the grid. This should fix the issue.