### PR TITLE
Allow frame-level fields to be passed via export(label_field=)

### DIFF
--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -7232,8 +7232,7 @@ class SampleCollection(object):
                 ``export_dir``, ``dataset_type``, ``data_path``, and
                 ``labels_path`` have no effect
             label_field (None): controls the label field(s) to export. Only
-                applicable to labeled image datasets or labeled video datasets
-                with sample-level labels. Can be any of the following:
+                applicable to labeled datasets. Can be any of the following:
 
                 -   the name of a label field to export
                 -   a glob pattern of label field(s) to export
@@ -7243,10 +7242,12 @@ class SampleCollection(object):
 
                 Note that multiple fields can only be specified when the
                 exporter used can handle dictionaries of labels. By default,
-                the first field of compatible type for the exporter is used
+                the first field of compatible type for the exporter is used.
+                When exporting labeled video datasets, this argument may
+                contain frame fields prefixed by ``"frames."``
             frame_labels_field (None): controls the frame label field(s) to
-                export. Only applicable to labeled video datasets. Can be any
-                of the following:
+                export. The ``"frames."`` prefix is optional. Only applicable
+                to labeled video datasets. Can be any of the following:
 
                 -   the name of a frame label field to export
                 -   a glob pattern of frame label field(s) to export
@@ -9606,6 +9607,10 @@ def _export(
         frame_labels_field = None
     elif isinstance(dataset_exporter, foud.LabeledVideoDatasetExporter):
         # Labeled videos
+        label_field, frame_labels_field = _parse_frame_label_fields(
+            sample_collection, label_field, frame_labels_field
+        )
+
         label_field = sample_collection._parse_label_field(
             label_field,
             dataset_exporter=dataset_exporter,
@@ -9633,6 +9638,67 @@ def _export(
         frame_labels_field=frame_labels_field,
         **kwargs,
     )
+
+
+def _parse_frame_label_fields(samples, label_field, frame_labels_field):
+    if not samples._has_frame_fields():
+        return label_field, frame_labels_field
+
+    force_dict, label_fields_dict = _to_label_fields_dict(label_field)
+    _force_dict, frame_labels_field_dict = _to_label_fields_dict(
+        frame_labels_field
+    )
+    force_dict &= _force_dict
+
+    updated = False
+
+    # Move frame fields to `frame_labels_field`
+    for k, v in list(label_fields_dict.items()):
+        _v, is_frame_field = samples._handle_frame_field(v)
+        if is_frame_field:
+            updated = True
+            frame_labels_field_dict[k] = _v
+            del label_fields_dict[k]
+
+    # Remove "frames." prefix from frame fields
+    for k, v in list(frame_labels_field_dict.items()):
+        _v, is_frame_field = samples._handle_frame_field(v)
+        if is_frame_field:
+            updated = True
+            frame_labels_field_dict[k] = _v
+            del frame_labels_field_dict[k]
+
+    if not updated:
+        return label_field, frame_labels_field
+
+    label_field = _finalize_label_fields(label_fields_dict, force_dict)
+    frame_labels_field = _finalize_label_fields(
+        frame_labels_field_dict, force_dict
+    )
+
+    return label_field, frame_labels_field
+
+
+def _to_label_fields_dict(label_field):
+    force_dict = isinstance(label_field, dict)
+
+    if label_field is None:
+        label_field = {}
+
+    if not isinstance(label_field, dict):
+        label_field = {label_field: label_field}
+
+    return force_dict, label_field
+
+
+def _finalize_label_fields(label_fields_dict, force_dict):
+    if not label_fields_dict:
+        return None
+
+    if len(label_fields_dict) == 1 and not force_dict:
+        return next(iter(label_fields_dict.values()))
+
+    return label_fields_dict
 
 
 def _handle_existing_dirs(

--- a/fiftyone/utils/data/exporters.py
+++ b/fiftyone/utils/data/exporters.py
@@ -526,8 +526,10 @@ def _check_for_patches_export(samples, dataset_exporter, label_field, kwargs):
             export_types = list(label_cls.values())
         elif isinstance(label_cls, (list, tuple)):
             export_types = list(label_cls)
-        else:
+        elif label_cls is not None:
             export_types = [label_cls]
+        else:
+            export_types = None
 
         try:
             label_type = samples._get_label_field_type(label_field)
@@ -536,6 +538,7 @@ def _check_for_patches_export(samples, dataset_exporter, label_field, kwargs):
 
         if (
             label_type is not None
+            and export_types is not None
             and not issubclass(label_type, tuple(export_types))
             and fol.Classification in export_types
         ):
@@ -598,8 +601,10 @@ def _check_for_clips_export(samples, dataset_exporter, label_field, kwargs):
             export_types = list(label_cls.values())
         elif isinstance(label_cls, (list, tuple)):
             export_types = list(label_cls)
-        else:
+        elif label_cls is not None:
             export_types = [label_cls]
+        else:
+            export_types = None
 
         try:
             label_type = samples._get_label_field_type(label_field)
@@ -608,6 +613,7 @@ def _check_for_clips_export(samples, dataset_exporter, label_field, kwargs):
 
         if (
             label_type is not None
+            and export_types is not None
             and not issubclass(label_type, tuple(export_types))
             and fol.Classification in export_types
         ):

--- a/tests/unittests/import_export_tests.py
+++ b/tests/unittests/import_export_tests.py
@@ -2931,9 +2931,7 @@ class OpenLABELVideoDatasetTests(VideoDatasetTests):
 
 
 class VideoExportCoersionTests(VideoDatasetTests):
-    @skipwindows
-    @drop_datasets
-    def test_clip_exports(self):
+    def _make_dataset(self):
         sample1 = fo.Sample(
             filepath=self._new_video(),
             predictions=fo.TemporalDetections(
@@ -3003,6 +3001,132 @@ class VideoExportCoersionTests(VideoDatasetTests):
 
         dataset = fo.Dataset()
         dataset.add_samples([sample1, sample2])
+
+        return dataset
+
+    @drop_datasets
+    def test_frame_label_fields(self):
+        dataset = self._make_dataset()
+
+        #
+        # `label_field` scalar syntax
+        #
+
+        export_dir = self._new_dir()
+
+        dataset.export(
+            export_dir=export_dir,
+            dataset_type=fo.types.CVATVideoDataset,
+            label_field="frames.predictions",
+        )
+
+        dataset2 = fo.Dataset.from_dir(
+            dataset_dir=export_dir,
+            dataset_type=fo.types.CVATVideoDataset,
+            label_field={"detections": "predictions"},
+        )
+
+        self.assertEqual(
+            dataset.count("frames.predictions.detections"),
+            dataset2.count("frames.predictions.detections"),
+        )
+
+        #
+        # `label_field` dict syntax
+        #
+
+        export_dir = self._new_dir()
+
+        dataset.export(
+            export_dir=export_dir,
+            dataset_type=fo.types.CVATVideoDataset,
+            label_field={"dets": "frames.predictions"},
+        )
+
+        dataset2 = fo.Dataset.from_dir(
+            dataset_dir=export_dir,
+            dataset_type=fo.types.CVATVideoDataset,
+            label_field={"detections": "predictions"},
+        )
+
+        self.assertEqual(
+            dataset.count("frames.predictions.detections"),
+            dataset2.count("frames.predictions.detections"),
+        )
+
+        #
+        # `frame_labels_field`
+        #
+
+        export_dir = self._new_dir()
+
+        dataset.export(
+            export_dir=export_dir,
+            dataset_type=fo.types.CVATVideoDataset,
+            frame_labels_field="predictions",
+        )
+
+        dataset2 = fo.Dataset.from_dir(
+            dataset_dir=export_dir,
+            dataset_type=fo.types.CVATVideoDataset,
+            label_field={"detections": "predictions"},
+        )
+
+        self.assertEqual(
+            dataset.count("frames.predictions.detections"),
+            dataset2.count("frames.predictions.detections"),
+        )
+
+        #
+        # `frame_labels_field` with "frames." prefix
+        #
+
+        export_dir = self._new_dir()
+
+        dataset.export(
+            export_dir=export_dir,
+            dataset_type=fo.types.CVATVideoDataset,
+            frame_labels_field="frames.predictions",
+        )
+
+        dataset2 = fo.Dataset.from_dir(
+            dataset_dir=export_dir,
+            dataset_type=fo.types.CVATVideoDataset,
+            label_field={"detections": "predictions"},
+        )
+
+        self.assertEqual(
+            dataset.count("frames.predictions.detections"),
+            dataset2.count("frames.predictions.detections"),
+        )
+
+        #
+        # `frame_labels_field` with dict syntax
+        #
+
+        export_dir = self._new_dir()
+
+        dataset.export(
+            export_dir=export_dir,
+            dataset_type=fo.types.CVATVideoDataset,
+            frame_labels_field={"dets": "frames.predictions"},
+        )
+
+        dataset2 = fo.Dataset.from_dir(
+            dataset_dir=export_dir,
+            dataset_type=fo.types.CVATVideoDataset,
+            label_field={"detections": "predictions"},
+        )
+
+        self.assertEqual(
+            dataset.count("frames.predictions.detections"),
+            dataset2.count("frames.predictions.detections"),
+        )
+
+    @skipwindows
+    @drop_datasets
+    def test_clip_exports(self):
+        dataset = self._make_dataset()
 
         #
         # Export unlabeled video clips


### PR DESCRIPTION
Adds more flexibility for specifying frame field exports via `export()`.

Previously only this was allowed:

```py
dataset.export(..., frame_labels_field="XXX")
```

Now any of these are allowed:

```py
dataset.export(..., label_field="frames.XXX")
dataset.export(..., frame_labels_field="XXX")
dataset.export(..., frame_labels_field="frames.XXX")
```

Example usage:

```py
import fiftyone as fo
import fiftyone.zoo as foz

dataset = foz.load_zoo_dataset("quickstart-video")

dataset.export(
    export_dir="/tmp/quickstart-video",
    dataset_type=fo.types.CVATVideoDataset,
    label_field="frames.detections",
    overwrite=True,
)
```
