### PR TITLE
Undo reformat of label

### DIFF
--- a/app/packages/core/src/components/FieldLabelAndInfo/index.tsx
+++ b/app/packages/core/src/components/FieldLabelAndInfo/index.tsx
@@ -90,8 +90,7 @@ function useFieldInfo(field, nested, { expandedPath, color }) {
 }
 
 function toLabel(path, nested) {
-  let label = !nested ? path : path.split(".").pop();
-  return label;
+  return !nested ? path : path.split(".").pop();
 }
 
 const FieldInfoIcon = (props) => <InfoIcon {...props} style={{ opacity: 1 }} />;

--- a/app/packages/core/src/components/FieldLabelAndInfo/index.tsx
+++ b/app/packages/core/src/components/FieldLabelAndInfo/index.tsx
@@ -91,7 +91,7 @@ function useFieldInfo(field, nested, { expandedPath, color }) {
 
 function toLabel(path, nested) {
   let label = !nested ? path : path.split(".").pop();
-  return label.replaceAll("_", " ");
+  return label;
 }
 
 const FieldInfoIcon = (props) => <InfoIcon {...props} style={{ opacity: 1 }} />;


### PR DESCRIPTION
fixes #2409 
## What changes are proposed in this pull request?

Do not re-format label attributes (convert _ to spaces)

## How is this patch tested? If it is not, please explain why.

![Screenshot 2022-12-08 at 6 23 53 PM](https://user-images.githubusercontent.com/17770824/206594497-597697d2-a146-423f-a881-f7f3ef0c9310.png)


## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
