### PR TITLE
Only show supported eval keys

### DIFF
--- a/app/packages/core/src/components/Actions/Patcher.tsx
+++ b/app/packages/core/src/components/Actions/Patcher.tsx
@@ -69,7 +69,24 @@ export const clipsFields = selector<string[]>({
 const evaluationKeys = selector<string[]>({
   key: "evaluationKeys",
   get: ({ get }) => {
-    return get(fos.dataset).evaluations.map(({ key }) => key);
+    const paths = get(fos.labelFields({}));
+    const valid = paths.filter((p) =>
+      get(
+        fos.meetsType({
+          path: p,
+          ftype: EMBEDDED_DOCUMENT_FIELD,
+          embeddedDocType: PATCHES_FIELDS,
+        })
+      )
+    );
+    
+    const evals = get(fos.dataset).evaluations.filter(
+      e => valid.includes(e.config.predField) || valid.includes(e.config.gtField)
+    )
+
+    const keys = evals.map(({key}) => key);
+
+    return keys;
   },
 });
 


### PR DESCRIPTION
## What changes are proposed in this pull request?
Resolves #2275. The current application will display any evaluation key in the Evaluations dropdown in the app's patches menu UI. This is problematic because evaluation types that are not supported will throw an error and cause the app to hang, yet showing them in the dropdown enables the user to pass the evaluation into to_evaluation_patches(). In this PR, rather than showing every key in the active session in the dropdown, I am filtering the keys based on whether or not the type of their corresponding evaluation is supported by the to_evaluation_patches() function. I did so by consulting the dataset schema, as performed in various other places in the Patcher.tsx file to extract the necessary field types.

## How is this patch tested? If it is not, please explain why.
This patch does not currently include an explicit test suite. I was unable to locate a test suite for the App's core components action directory, but can add a few cases asserting that only certain types get added to the dropdown. That being said, the logic to check the types in the test would be the exact same logic used to populate the dropdown. Circle back on this if possible.

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [X] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

All evaluation keys present in the patches UI now support patch views. Previously, certain evaluation keys were erroneously left as options.

### What areas of FiftyOne does this PR affect?

-   [X] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
