### PR TITLE
Remove label query from sample tagger data flow

### DIFF
--- a/app/packages/core/src/components/Actions/Tagger.tsx
+++ b/app/packages/core/src/components/Actions/Tagger.tsx
@@ -42,20 +42,6 @@ import {
   tagStats,
 } from "./utils";
 
-const IconDiv = styled.div`
-  position: absolute;
-  top: 0.25rem;
-  right: -0.75rem;
-  height: 2rem;
-  width: 2rem;
-
-  & > svg {
-    margin-top: 0.5rem;
-    margin-right: 0.25rem;
-    color: ${({ theme }) => theme.text.primary};
-  }
-`;
-
 const TaggingContainerInput = styled.div`
   font-size: 14px;
   border-bottom: 1px ${({ theme }) => theme.primary.plainColor} solid;
@@ -325,7 +311,7 @@ const useTagCallback = (
   targetLabels,
   lookerRef?: React.MutableRefObject<Lookers | undefined>
 ) => {
-  const setAggs = useSetRecoilState(fos.aggregationsTick);
+  const setAggs = useSetRecoilState(fos.refresher);
   const setLabels = fos.useSetSelectedLabels();
   const setSamples = fos.useSetSelected();
   const updateSample = fos.useUpdateSample();

--- a/app/packages/core/src/components/Actions/utils.tsx
+++ b/app/packages/core/src/components/Actions/utils.tsx
@@ -1,6 +1,6 @@
 import { animated, useSpring } from "@react-spring/web";
 import { useState } from "react";
-import { selector, selectorFamily } from "recoil";
+import { selectorFamily } from "recoil";
 import styled from "styled-components";
 
 import { useTheme } from "@fiftyone/components";
@@ -59,24 +59,6 @@ export const useHighlightHover = (disabled, override = null, color = null) => {
     onMouseLeave,
   };
 };
-
-export const allTags = selector<{ sample: string[]; label: string[] } | null>({
-  key: "tagAggs",
-  get: async ({ get }) => {
-    const labels = get(fos.labelTagCounts({ modal: false, extended: false }));
-
-    const sample = get(fos.sampleTagCounts({ modal: false, extended: false }));
-
-    if (!labels || !sample) {
-      return null;
-    }
-
-    return {
-      label: Object.keys(labels).sort(),
-      sample: Object.keys(sample).sort(),
-    };
-  },
-});
 
 export const tagStatistics = selectorFamily<
   {
@@ -149,13 +131,14 @@ export const tagStats = selectorFamily<
   get:
     ({ modal, labels }) =>
     ({ get }) => {
-      const tags = get(allTags);
-      const results = Object.fromEntries(
-        tags[labels ? "label" : "sample"].map((t) => [t, 0])
+      const data = get(
+        labels
+          ? fos.labelTagCounts({ modal: false, extended: false })
+          : fos.sampleTagCounts({ modal: false, extended: false })
       );
 
       return {
-        ...results,
+        ...data,
         ...get(tagStatistics({ modal, labels })).tags,
       };
     },

--- a/app/packages/core/tests/components/Actions/utils.test.ts
+++ b/app/packages/core/tests/components/Actions/utils.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("recoil");
+vi.mock("recoil-relay");
+import * as utils from "../../../src/components/Actions/utils";
+
+import {
+  setMockAtoms,
+  TestSelector,
+  TestSelectorFamily,
+} from "../../../../../__mocks__/recoil";
+
+describe("Resolves tag counts", () => {
+  it("resolves all", () => {
+    setMockAtoms({
+      labelTagCounts: (params) => ({ one: 1, two: 1 }),
+      sampleTagCounts: (params) => ({ one: 1, two: 1 }),
+      tagStatistics: (modal) => ({
+        count: 2,
+        items: 1,
+        tags: { one: 1, two: 1 },
+      }),
+    });
+
+    const samples = <TestSelectorFamily<typeof utils.tagStats>>(
+      (<unknown>utils.tagStats({ modal: false, labels: false }))
+    );
+    expect(samples()).toStrictEqual({ one: 1, two: 1 });
+
+    const labels = <TestSelectorFamily<typeof utils.tagStats>>(
+      (<unknown>utils.tagStats({ modal: false, labels: true }))
+    );
+    expect(labels()).toStrictEqual({ one: 1, two: 1 });
+  });
+});


### PR DESCRIPTION
Resolves #2433

Previously the `allTags` selector would query for both label and sample tags via a aggregation graphql call. Now they have separate dataflow.