### PR TITLE
groups expansion should be defaulted to none

### DIFF
--- a/app/packages/state/src/recoil/sidebar.ts
+++ b/app/packages/state/src/recoil/sidebar.ts
@@ -212,28 +212,34 @@ const DEFAULT_VIDEO_GROUPS = [
   { name: "other", paths: [] },
 ];
 
+const NONE = [null, undefined];
+
 export const resolveGroups = (
   dataset: State.Dataset,
   current?: State.SidebarGroup[]
 ): State.SidebarGroup[] => {
   // when expanded is null in sidebarGroups, use default settings
-  const sidebarGroups = dataset?.appConfig?.sidebarGroups.map((group) => {
-    if (group.expanded === null) {
-      group.expanded = [
-        "label tags",
-        "tags",
-        "labels",
-        "primitives",
-        "metadata",
-      ].includes(group.name)
-        ? true
-        : undefined;
-      return group;
-    }
-    return group;
-  });
+  const sidebarGroups = dataset?.appConfig?.sidebarGroups
+    ? dataset?.appConfig?.sidebarGroups.map((group) => {
+        if (group.expanded === null) {
+          group.expanded = [
+            "label tags",
+            "tags",
+            "labels",
+            "primitives",
+            "metadata",
+          ].includes(group.name)
+            ? true
+            : undefined;
+          return group;
+        }
+        return group;
+      })
+    : dataset?.appConfig?.sidebarGroups;
 
-  let groups = JSON.parse(JSON.stringify(sidebarGroups));
+  let groups = sidebarGroups
+    ? JSON.parse(JSON.stringify(sidebarGroups))
+    : undefined;
 
   const expanded = current
     ? current.reduce((map, { name, expanded }) => {
@@ -383,16 +389,16 @@ export const sidebarGroups = selectorFamily<
         if (
           video &&
           groups[framesIndex] &&
-          groups[framesIndex].expanded === undefined
+          NONE.includes(groups[framesIndex].expanded)
         ) {
           groups[framesIndex].expanded = !largeVideo;
         }
 
-        if (groups[tagsIndex].expanded === undefined) {
+        if (NONE.includes(groups[tagsIndex].expanded)) {
           groups[tagsIndex].expanded =
             get(resolvedSidebarMode(false)) === "all";
         }
-        if (groups[labelTagsIndex].expanded === undefined) {
+        if (NONE.includes(groups[labelTagsIndex].expanded)) {
           groups[labelTagsIndex].expanded =
             get(resolvedSidebarMode(false)) === "all" ? !largeVideo : false;
         }
@@ -416,19 +422,19 @@ export const sidebarGroups = selectorFamily<
             .filter((tag) => !filtered || tag.includes(f))
             .map((tag) => `_label_tags.${tag}`));
       } else {
-        if (groups[labelTagsIndex].expanded === undefined) {
+        if (NONE.includes(groups[labelTagsIndex].expanded)) {
           groups[labelTagsIndex].expanded = false;
         }
 
         if (
           video &&
           groups[framesIndex] &&
-          groups[framesIndex].expanded === undefined
+          NONE.includes(groups[framesIndex].expanded)
         ) {
           groups[framesIndex].expanded = false;
         }
 
-        if (groups[tagsIndex].expanded === undefined) {
+        if (NONE.includes(groups[tagsIndex].expanded)) {
           groups[tagsIndex].expanded = false;
         }
       }

--- a/app/packages/state/src/recoil/sidebar.ts
+++ b/app/packages/state/src/recoil/sidebar.ts
@@ -216,7 +216,24 @@ export const resolveGroups = (
   dataset: State.Dataset,
   current?: State.SidebarGroup[]
 ): State.SidebarGroup[] => {
-  let groups = JSON.parse(JSON.stringify(dataset?.appConfig?.sidebarGroups));
+  // when expanded is null in sidebarGroups, use default settings
+  const sidebarGroups = dataset?.appConfig?.sidebarGroups.map((group) => {
+    if (group.expanded === null) {
+      group.expanded = [
+        "label tags",
+        "tags",
+        "labels",
+        "primitives",
+        "metadata",
+      ].includes(group.name)
+        ? true
+        : undefined;
+      return group;
+    }
+    return group;
+  });
+
+  let groups = JSON.parse(JSON.stringify(sidebarGroups));
 
   const expanded = current
     ? current.reduce((map, { name, expanded }) => {

--- a/app/packages/state/src/recoil/sidebar.ts
+++ b/app/packages/state/src/recoil/sidebar.ts
@@ -502,7 +502,7 @@ export const sidebarGroups = selectorFamily<
       !modal &&
         persist &&
         persistSidebarGroups({
-          subscription: useRecoilValue(stateSubscription),
+          subscription: get(stateSubscription),
           dataset: get(datasetName),
           stages: get(viewAtoms.view),
           sidebarGroups: groups,

--- a/app/packages/state/src/recoil/sidebar.ts
+++ b/app/packages/state/src/recoil/sidebar.ts
@@ -716,10 +716,13 @@ export const groupShown = selectorFamily<
       const data = get(sidebarGroupMapping({ modal, loading }))[group];
 
       if ([null, undefined].includes(data.expanded)) {
-        if (!["tags", "label tags"].includes(group)) {
-          return true;
+        if (["tags", "label tags"].includes(group)) {
+          return null;
         }
-        return null;
+        return (
+          !data.paths.length ||
+          !data.paths.every((path) => get(disabledPaths).has(path))
+        );
       }
 
       return data.expanded;

--- a/app/packages/state/src/recoil/sidebar.ts
+++ b/app/packages/state/src/recoil/sidebar.ts
@@ -219,23 +219,20 @@ export const resolveGroups = (
   current?: State.SidebarGroup[]
 ): State.SidebarGroup[] => {
   // when expanded is null in sidebarGroups, use default settings
-  const sidebarGroups = dataset?.appConfig?.sidebarGroups
-    ? dataset?.appConfig?.sidebarGroups.map((group) => {
-        if (group.expanded === null) {
-          group.expanded = [
-            "label tags",
-            "tags",
-            "labels",
-            "primitives",
-            "metadata",
-          ].includes(group.name)
-            ? true
-            : undefined;
-          return group;
-        }
+  let sidebarGroups = dataset?.appConfig?.sidebarGroups;
+  if (dataset?.appConfig?.sidebarGroups) {
+    sidebarGroups = dataset?.appConfig?.sidebarGroups.map((group) => {
+      if (group.expanded === null) {
+        const openFields =
+          dataset?.appConfig?.sidebarMode === "all"
+            ? ["labels", "primitives", "metadata", "sample tags", "label tags"]
+            : ["labels", "primitives", "metadata"];
+        group.expanded = openFields.includes(group.name) ? true : undefined;
         return group;
-      })
-    : dataset?.appConfig?.sidebarGroups;
+      }
+      return group;
+    });
+  }
 
   let groups = sidebarGroups
     ? JSON.parse(JSON.stringify(sidebarGroups))

--- a/app/packages/state/src/recoil/sidebar.ts
+++ b/app/packages/state/src/recoil/sidebar.ts
@@ -218,21 +218,7 @@ export const resolveGroups = (
   dataset: State.Dataset,
   current?: State.SidebarGroup[]
 ): State.SidebarGroup[] => {
-  // when expanded is null in sidebarGroups, use default settings
-  let sidebarGroups = dataset?.appConfig?.sidebarGroups;
-  if (dataset?.appConfig?.sidebarGroups) {
-    sidebarGroups = dataset?.appConfig?.sidebarGroups.map((group) => {
-      if (group.expanded === null) {
-        const openFields =
-          dataset?.appConfig?.sidebarMode === "all"
-            ? ["labels", "primitives", "metadata", "sample tags", "label tags"]
-            : ["labels", "primitives", "metadata"];
-        group.expanded = openFields.includes(group.name) ? true : undefined;
-        return group;
-      }
-      return group;
-    });
-  }
+  const sidebarGroups = dataset?.appConfig?.sidebarGroups;
 
   let groups = sidebarGroups
     ? JSON.parse(JSON.stringify(sidebarGroups))
@@ -729,12 +715,14 @@ export const groupShown = selectorFamily<
     ({ get }) => {
       const data = get(sidebarGroupMapping({ modal, loading }))[group];
 
-      return data.expanded === undefined
-        ? !["tags", "label tags"].includes(group)
-          ? !data.paths.length ||
-            !data.paths.every((path) => get(disabledPaths).has(path))
-          : true
-        : data.expanded;
+      if ([null, undefined].includes(data.expanded)) {
+        if (!["tags", "label tags"].includes(group)) {
+          return true;
+        }
+        return null;
+      }
+
+      return data.expanded;
     },
   set:
     ({ modal, group }) =>

--- a/app/packages/state/src/recoil/types.ts
+++ b/app/packages/state/src/recoil/types.ts
@@ -122,12 +122,12 @@ export namespace State {
     sampleFields: StrictField[];
     version: string;
     skeletons: StrictKeypointSkeleton[];
-    defaultSkeleton: KeypointSkeleton;
+    defaultSkeleton?: KeypointSkeleton;
     groupMediaTypes?: {
       name: string;
       mediaType: MediaType;
     }[];
-    defaultGroupSlice: string;
+    defaultGroupSlice?: string;
     groupField: string;
     appConfig: DatasetAppConfig;
     info: { [key: string]: string };

--- a/app/packages/state/tests/recoil/sidebar.test.ts
+++ b/app/packages/state/tests/recoil/sidebar.test.ts
@@ -1,0 +1,271 @@
+import { describe, expect, it, vi } from "vitest";
+import * as sidebar from "../../src/recoil/sidebar";
+import { State } from "../../src/recoil/types";
+
+const mockDataset: State.Dataset = {
+  id: "mockQuickStart",
+  appConfig: {
+    gridMediaField: "filepath",
+    mediaFields: ["filepath"],
+    modalMediaField: "filepath",
+    plugins: {},
+  },
+  brainMethods: [],
+  createdAt: { $date: new Date().getTime() },
+  defaultMaskTargets: {},
+  evaluations: [],
+  frameFields: [],
+  lastLoadedAt: { $date: new Date().getTime() },
+  maskTargets: {},
+  mediaType: "image",
+  name: "quickstart-test",
+  sampleFields: [
+    {
+      dbField: "_id",
+      description: null,
+      embeddedDocType: null,
+      fields: [],
+      ftype: "fiftyone.core.fields.ObjectIdField",
+      info: null,
+      name: "id",
+      path: "id",
+      subfield: null,
+    },
+    {
+      dbField: "filepath",
+      description: null,
+      embeddedDocType: null,
+      fields: [],
+      ftype: "fiftyone.core.fields.StringField",
+      info: null,
+      name: "filepath",
+      path: "filepath",
+      subfield: null,
+    },
+    {
+      dbField: "tags",
+      description: null,
+      embeddedDocType: null,
+      fields: [],
+      ftype: "fiftyone.core.fields.ListField",
+      info: null,
+      name: "tags",
+      path: "tags",
+      subfield: "fiftyone.core.fields.StringField",
+    },
+    {
+      dbField: "metadata",
+      description: null,
+      embeddedDocType: "fiftyone.core.metadata.Metadata",
+      fields: [
+        {
+          dbField: "size_types",
+          description: null,
+          embeddedDocType: null,
+          fields: [],
+          ftype: "fiftyone.core.fields.IntField",
+          info: null,
+          name: "size_types",
+          subfield: null,
+          path: "metadata.size_types",
+        },
+        {
+          dbField: "mime_type",
+          description: null,
+          embeddedDocType: null,
+          fields: [],
+          ftype: "fiftyone.core.fields.StringField",
+          info: null,
+          name: "mime_type",
+          subfield: null,
+          path: "metadata.mime_type",
+        },
+        {
+          dbField: "width",
+          description: null,
+          embeddedDocType: null,
+          fields: [],
+          ftype: "fiftyone.core.fields.IntField",
+          info: null,
+          name: "width",
+          subfield: null,
+          path: "metadata.width",
+        },
+        {
+          dbField: "height",
+          description: null,
+          embeddedDocType: null,
+          fields: [],
+          ftype: "fiftyone.core.fields.IntField",
+          info: null,
+          name: "height",
+          subfield: null,
+          path: "metadata.height",
+        },
+        {
+          dbField: "num_channels",
+          description: null,
+          embeddedDocType: null,
+          fields: [],
+          ftype: "fiftyone.core.fields.IntField",
+          info: null,
+          name: "num_channels",
+          subfield: null,
+          path: "metadata.num_channels",
+        },
+      ],
+      ftype: "fiftyone.core.fields.EmbeddedDocumentField",
+      info: null,
+      name: "metadata",
+      path: "metadata",
+      subfield: null,
+    },
+    {
+      dbField: "ground_truth",
+      description: null,
+      embeddedDocType: "fiftyone.core.labels.Detection",
+      fields: [
+        {
+          dbField: "detections",
+          description: null,
+          embeddedDocType: null,
+          fields: [],
+          ftype: "fiftyone.core.fields.ListField",
+          info: null,
+          name: "detections",
+          subfield: "fiftyone.core.fields.EmbeddedDocumentField",
+          path: "ground_truth.detections",
+        },
+      ],
+      ftype: "fiftyone.core.fields.EmbeddedDocumentField",
+      info: null,
+      name: "ground_truth",
+      path: "ground_truth",
+      subfield: null,
+    },
+    {
+      dbField: "uniqueness",
+      description: null,
+      embeddedDocType: null,
+      fields: [],
+      ftype: "fiftyone.core.fields.FloatField",
+      info: null,
+      name: "uniqueness",
+      subfield: null,
+      path: "uniqueness",
+    },
+    {
+      dbField: "predictions",
+      description: null,
+      embeddedDocType: "fiftyone.core.labels.Detection",
+      fields: [
+        {
+          dbField: "detections",
+          description: null,
+          embeddedDocType: null,
+          fields: [],
+          ftype: "fiftyone.core.fields.ListField",
+          info: null,
+          name: "detections",
+          subfield: "fiftyone.core.fields.EmbeddedDocumentField",
+          path: "ground_truth.detections",
+        },
+      ],
+      ftype: "fiftyone.core.fields.EmbeddedDocumentField",
+      info: null,
+      name: "predictions",
+      subfield: null,
+      path: "predictions",
+    },
+    {
+      dbField: "dict_field",
+      description: null,
+      embeddedDocType: null,
+      fields: [],
+      ftype: "fiftyone.core.fields.DictField",
+      info: null,
+      name: "dict_field",
+      subfield: null,
+      path: "dict_field",
+    },
+    {
+      dbField: "list_field",
+      description: null,
+      embeddedDocType: null,
+      fields: [],
+      ftype: "fiftyone.core.fields.ListField",
+      info: null,
+      name: "list_field",
+      subfield: null,
+      path: "list_field",
+    },
+  ],
+  version: "test",
+  skeletons: [],
+  groupMediaTypes: [],
+  groupField: "",
+  info: {},
+};
+
+describe("ResolveGroups works", () => {
+  it("dataset groups should resolve when curent is undefined", () => {
+    const test = sidebar.resolveGroups(mockDataset, undefined);
+
+    expect(test.length).toBe(6);
+    expect(test[0].name).toBe("tags");
+    expect(test[0].paths.length).toBe(0);
+    expect(test[1].name).toBe("label tags");
+    expect(test[1].paths.length).toBe(0);
+    expect(test[2].name).toBe("metadata");
+    expect(test[2].paths.length).toBe(5);
+    expect(test[3].name).toBe("labels");
+    expect(test[3].paths.length).toBe(2);
+    expect(test[4].name).toBe("primitives");
+    expect(test[4].paths.length).toBe(3);
+    expect(test[5].name).toBe("other");
+    expect(test[5].paths.length).toBe(2);
+  });
+
+  it("when dataset appconfig does not have sidebarGroups settings, use default settings", () => {
+    const mockSidebarGroups = [
+      { name: "tags", paths: [], expanded: true },
+      { name: "label tags", paths: [], expanded: true },
+      {
+        name: "metadata",
+        paths: [
+          "metadata.size_types",
+          "metadata.mime_type",
+          "metadata.width",
+          "metadata.height",
+          "metadata.num_channels",
+        ],
+        expanded: true,
+      },
+      {
+        name: "labels",
+        paths: ["ground_truth", "predictions"],
+        expanded: true,
+      },
+      {
+        name: "primitives",
+        paths: ["id", "filepath", "uniqueness"],
+        expanded: true,
+      },
+      { name: "other", paths: ["dict_field", "list_field"] },
+      { name: "test group a", paths: [] },
+      { name: "test group b", paths: [] },
+    ];
+    const dataSetWithNewGroups = { ...mockDataset };
+    dataSetWithNewGroups.appConfig.sidebarGroups = mockSidebarGroups;
+
+    const test = sidebar.resolveGroups(mockDataset, mockSidebarGroups);
+
+    expect(test.length).toBe(8);
+    expect(test[5].name).toBe("other");
+    expect(test[5].expanded).toBeFalsy();
+    expect(test[6].name).toBe("test group a");
+    expect(test[6].expanded).toBeFalsy();
+    expect(test[7].name).toBe("test group b");
+    expect(test[7].expanded).toBeFalsy();
+  });
+});

--- a/app/packages/utilities/src/index.ts
+++ b/app/packages/utilities/src/index.ts
@@ -92,6 +92,7 @@ interface BaseField {
   name: string;
   embeddedDocType: string | null;
   subfield: string | null;
+  path: string | null;
 }
 
 export interface StrictField extends BaseField {

--- a/fiftyone/server/query.py
+++ b/fiftyone/server/query.py
@@ -142,7 +142,7 @@ class SavedView:
 class SidebarGroup:
     name: str
     paths: t.Optional[t.List[str]]
-    expanded: t.Optional[bool] = True
+    expanded: t.Optional[bool] = None
 
 
 @gql.type


### PR DESCRIPTION
fixes #2284 

## What changes are proposed in this pull request?

- set the groups expansion default to none in the BE 
- in the FE, let `resolveGroup` would expand the defaulted open fields

![Screenshot 2022-12-15 at 6 26 51 PM](https://user-images.githubusercontent.com/17770824/207994777-bea58263-7e9b-4038-aa49-7d859fa4a3a5.png)


## How is this patch tested? If it is not, please explain why.

(Details)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
