### PR TITLE
added exclude_groups() to mirror select_groups()

### DIFF
--- a/docs/source/user_guide/groups.rst
+++ b/docs/source/user_guide/groups.rst
@@ -813,6 +813,33 @@ to create a view that contains certain group(s) of interest by their IDs:
     same_order = dataset.select_groups(group_ids, ordered=True)
     assert view.values("id") == same_order.values("id")
 
+.. _groups-excluding-groups:
+
+Excluding groups
+----------------
+
+You can use
+:meth:`exclude_groups() <fiftyone.core.collections.SampleCollection.exclude_groups>`
+to create a view that excludes certain group(s) of interest by their IDs:
+
+.. code-block:: python
+    :linenos:
+
+    # Exclude two groups at random
+    view = dataset.take(2)
+
+    group_ids = view.values("group.id")
+    all_other_groups = dataset.exclude_groups(group_ids)
+
+    ## Verify set complements:
+    
+    excluded_group_ids = set(group_ids)
+    all_other_group_ids = set(all_other_groups.values("group.id"))
+    dataset_group_ids = set(dataset.values("group.id"))
+
+    assert set() == all_other_group_ids.intersection(excluded_group_ids)
+    assert dataset_group_ids == all_other_group_ids.union(excluded_group_ids)
+
 .. _groups-selecting-slices:
 
 Selecting slices

--- a/fiftyone/__public__.py
+++ b/fiftyone/__public__.py
@@ -152,6 +152,7 @@ from .core.stages import (
     ExcludeBy,
     ExcludeFields,
     ExcludeFrames,
+    ExcludeGroups,
     ExcludeLabels,
     Exists,
     FilterField,

--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -3250,21 +3250,26 @@ class SampleCollection(object):
             dataset = foz.load_zoo_dataset("quickstart-groups")
 
             #
-            # Select some specific groups by ID
+            # Exclude some specific groups by ID
             #
 
-            group_ids = dataset.take(10).values("group.id")
+            view = dataset.take(2)
+            group_ids = view.values("group.id")
+            all_other_groups = dataset.exclude_groups(group_ids)
 
-            view = dataset.exclude_groups(group_ids)
+            #
+            # Verify set complements
+            #
 
-            view_group_ids = set(view.values("group.id"))
+            excluded_group_ids = set(group_ids)
+            all_other_group_ids = set(all_other_groups.values("group.id"))
             dataset_group_ids = set(dataset.values("group.id"))
 
-            assert view_group_ids == set(group_ids)
-            assert set() = view_group_ids.intersection(dataset_group_ids)
+            assert set() == all_other_group_ids.intersection(excluded_group_ids)
+            assert dataset_group_ids == all_other_group_ids.union(excluded_group_ids)
 
         Args:
-            groups_ids: the groups to select. Can be any of the following:
+            groups_ids: the groups to exclude. Can be any of the following:
 
                 -   a group ID
                 -   an iterable of group IDs

--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -3239,6 +3239,51 @@ class SampleCollection(object):
         )
 
     @view_stage
+    def exclude_groups(self, group_ids):
+        """Excludes the groups with the given IDs from the grouped collection.
+
+        Examples::
+
+            import fiftyone as fo
+            import fiftyone.zoo as foz
+
+            dataset = foz.load_zoo_dataset("quickstart-groups")
+
+            #
+            # Select some specific groups by ID
+            #
+
+            group_ids = dataset.take(10).values("group.id")
+
+            view = dataset.exclude_groups(group_ids)
+
+            view_group_ids = set(view.values("group.id"))
+            dataset_group_ids = set(dataset.values("group.id"))
+
+            assert view_group_ids == set(group_ids)
+            assert set() = view_group_ids.intersection(dataset_group_ids)
+
+        Args:
+            groups_ids: the groups to select. Can be any of the following:
+
+                -   a group ID
+                -   an iterable of group IDs
+                -   a :class:`fiftyone.core.sample.Sample` or
+                    :class:`fiftyone.core.sample.SampleView`
+                -   a group dict returned by
+                    :meth:`get_group() <fiftyone.core.collections.SampleCollection.get_group>`
+                -   an iterable of :class:`fiftyone.core.sample.Sample` or
+                    :class:`fiftyone.core.sample.SampleView` instances
+                -   an iterable of group dicts returned by
+                    :meth:`get_group() <fiftyone.core.collections.SampleCollection.get_group>`
+                -   a :class:`fiftyone.core.collections.SampleCollection`
+
+        Returns:
+            a :class:`fiftyone.core.view.DatasetView`
+        """
+        return self._add_view_stage(fos.ExcludeGroups(group_ids))
+
+    @view_stage
     def exclude_labels(
         self, labels=None, ids=None, tags=None, fields=None, omit_empty=True
     ):

--- a/fiftyone/core/stages.py
+++ b/fiftyone/core/stages.py
@@ -908,21 +908,20 @@ class ExcludeGroups(ViewStage):
         dataset = foz.load_zoo_dataset("quickstart-groups")
 
         #
-        # Select some specific groups by ID
+        # Exclude some specific groups by ID
         #
 
         group_ids = dataset.take(10).values("group.id")
 
         stage = fo.ExcludeGroups(group_ids)
-        view = dataset.add_stage(stage)
+        all_other_groups_view = dataset.add_stage(stage)
 
-
-        view_group_ids = set(view.values("group.id"))
+        excluded_group_ids = set(group_ids)
+        all_other_group_ids = set(all_other_groups_view.values("group.id"))
         dataset_group_ids = set(dataset.values("group.id"))
 
-
-        assert view_group_ids == set(group_ids)
-        assert set() = view_group_ids.intersection(dataset_group_ids)
+        assert set() == all_other_group_ids.intersection(excluded_group_ids)
+        assert dataset_group_ids == all_other_group_ids.union(excluded_group_ids)
 
 
     Args:
@@ -967,6 +966,10 @@ class ExcludeGroups(ViewStage):
                 "placeholder": "list,of,group,ids",
             }
         ]
+
+    def validate(self, sample_collection):
+        if sample_collection.media_type != fom.GROUP:
+            raise ValueError("%s has no groups" % type(sample_collection))
 
 
 class ExcludeLabels(ViewStage):

--- a/fiftyone/core/stages.py
+++ b/fiftyone/core/stages.py
@@ -897,6 +897,78 @@ class ExcludeFrames(ViewStage):
         fova.validate_video_collection(sample_collection)
 
 
+class ExcludeGroups(ViewStage):
+    """Excludes the groups with the given IDs from a grouped collection.
+
+    Examples::
+
+        import fiftyone as fo
+        import fiftyone.zoo as foz
+
+        dataset = foz.load_zoo_dataset("quickstart-groups")
+
+        #
+        # Select some specific groups by ID
+        #
+
+        group_ids = dataset.take(10).values("group.id")
+
+        stage = fo.ExcludeGroups(group_ids)
+        view = dataset.add_stage(stage)
+
+
+        view_group_ids = set(view.values("group.id"))
+        dataset_group_ids = set(dataset.values("group.id"))
+
+
+        assert view_group_ids == set(group_ids)
+        assert set() = view_group_ids.intersection(dataset_group_ids)
+
+
+    Args:
+        groups_ids: the groups to select. Can be any of the following:
+
+            -   a group ID
+            -   an iterable of group IDs
+            -   a :class:`fiftyone.core.sample.Sample` or
+                :class:`fiftyone.core.sample.SampleView`
+            -   a group dict returned by
+                :meth:`get_group() <fiftyone.core.collections.SampleCollection.get_group>`
+            -   an iterable of :class:`fiftyone.core.sample.Sample` or
+                :class:`fiftyone.core.sample.SampleView` instances
+            -   an iterable of group dicts returned by
+                :meth:`get_group() <fiftyone.core.collections.SampleCollection.get_group>`
+            -   a :class:`fiftyone.core.collections.SampleCollection`
+    """
+
+    def __init__(self, group_ids, ordered=False):
+        self._group_ids = _parse_group_ids(group_ids)
+
+    @property
+    def group_ids(self):
+        """The list of group IDs to exclude."""
+        return self._group_ids
+
+    def to_mongo(self, sample_collection):
+        id_path = sample_collection.group_field + "._id"
+        ids = [ObjectId(_id) for _id in self._group_ids]
+
+        return [{"$match": {id_path: {"$not": {"$in": ids}}}}]
+
+    def _kwargs(self):
+        return [["group_ids", self._group_ids]]
+
+    @classmethod
+    def _params(cls):
+        return [
+            {
+                "name": "group_ids",
+                "type": "list<id>|id",
+                "placeholder": "list,of,group,ids",
+            }
+        ]
+
+
 class ExcludeLabels(ViewStage):
     """Excludes the specified labels from a collection.
 
@@ -7385,6 +7457,7 @@ _STAGES = [
     ExcludeBy,
     ExcludeFields,
     ExcludeFrames,
+    ExcludeGroups,
     ExcludeLabels,
     Exists,
     FilterField,

--- a/tests/unittests/group_tests.py
+++ b/tests/unittests/group_tests.py
@@ -303,6 +303,14 @@ class GroupTests(unittest.TestCase):
         self.assertEqual(sample.group_field.name, "ego")
         self.assertEqual(sample.media_type, "video")
 
+        group_ids_to_keep = dataset.take(2).values("group_field.id")
+        keep_view = dataset.select_groups(group_ids_to_keep)
+        self.assertEqual(len(keep_view), 2)
+
+        group_ids_to_exclude = dataset.take(2).values("group_field.id")
+        exclude_view = dataset.exclude_groups(group_ids_to_exclude)
+        self.assertEqual(len(exclude_view), len(dataset) - 2)
+
         group_id = sample.group_field.id
         group = view.get_group(group_id)
 


### PR DESCRIPTION
`dataset.exclude_groups()`, and the associated `ExcludeGroups()` stage. Syntax is as you'd expect:

```py
import fiftyone as fo
import fiftyone.zoo as foz

dataset = foz.load_zoo_dataset("quickstart-groups")

group_ids = dataset.take(10).values("group.id")

view = dataset.exclude_groups(group_ids)
view_group_ids = set(view.values("group.id"))
dataset_group_ids = set(dataset.values("group.id"))

assert view_group_ids == set(group_ids)
assert set() = view_group_ids.intersection(dataset_group_ids)
```

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [x] Documentation: FiftyOne documentation changes
-   [ ] Other
