### PR TITLE
[BUG] Fix missing view_name error

### DIFF
--- a/app/packages/relay/src/mutations/__generated__/setGroupSliceMutation.graphql.ts
+++ b/app/packages/relay/src/mutations/__generated__/setGroupSliceMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<74d626b47db10bf8fe56d811cad7e41f>>
+ * @generated SignedSource<<d65841e678cc9636391bee909d50f98c>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -14,6 +14,7 @@ export type setGroupSliceMutation$variables = {
   slice: string;
   subscription: string;
   view: Array;
+  viewName?: string | null;
 };
 export type setGroupSliceMutation$data = {
   readonly setGroupSlice: {
@@ -46,7 +47,12 @@ v3 = {
   "kind": "LocalArgument",
   "name": "view"
 },
-v4 = [
+v4 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "viewName"
+},
+v5 = [
   {
     "alias": null,
     "args": [
@@ -69,6 +75,11 @@ v4 = [
         "kind": "Variable",
         "name": "view",
         "variableName": "view"
+      },
+      {
+        "kind": "Variable",
+        "name": "viewName",
+        "variableName": "viewName"
       }
     ],
     "concreteType": "Dataset",
@@ -93,12 +104,13 @@ return {
       (v0/*: any*/),
       (v1/*: any*/),
       (v2/*: any*/),
-      (v3/*: any*/)
+      (v3/*: any*/),
+      (v4/*: any*/)
     ],
     "kind": "Fragment",
     "metadata": null,
     "name": "setGroupSliceMutation",
-    "selections": (v4/*: any*/),
+    "selections": (v5/*: any*/),
     "type": "Mutation",
     "abstractKey": null
   },
@@ -108,23 +120,24 @@ return {
       (v2/*: any*/),
       (v0/*: any*/),
       (v3/*: any*/),
-      (v1/*: any*/)
+      (v1/*: any*/),
+      (v4/*: any*/)
     ],
     "kind": "Operation",
     "name": "setGroupSliceMutation",
-    "selections": (v4/*: any*/)
+    "selections": (v5/*: any*/)
   },
   "params": {
-    "cacheID": "bf10fdcc9a9e3441643c157812f905a2",
+    "cacheID": "a8129fbfe516833d7d5c233d2adddd97",
     "id": null,
     "metadata": {},
     "name": "setGroupSliceMutation",
     "operationKind": "mutation",
-    "text": "mutation setGroupSliceMutation(\n  $subscription: String!\n  $session: String\n  $view: BSONArray!\n  $slice: String!\n) {\n  setGroupSlice(subscription: $subscription, session: $session, view: $view, slice: $slice) {\n    id\n  }\n}\n"
+    "text": "mutation setGroupSliceMutation(\n  $subscription: String!\n  $session: String\n  $view: BSONArray!\n  $slice: String!\n  $viewName: String\n) {\n  setGroupSlice(subscription: $subscription, session: $session, view: $view, slice: $slice, viewName: $viewName) {\n    id\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "88072c125d8981795598ed623e1609eb";
+(node as any).hash = "c240e69e37d0f3986af1569e5abd985f";
 
 export default node;

--- a/app/packages/relay/src/mutations/setGroupSlice.ts
+++ b/app/packages/relay/src/mutations/setGroupSlice.ts
@@ -6,12 +6,14 @@ export default graphql`
     $session: String
     $view: BSONArray!
     $slice: String!
+    $viewName: String
   ) {
     setGroupSlice(
       subscription: $subscription
       session: $session
       view: $view
       slice: $slice
+      viewName: $viewName
     ) {
       id
     }

--- a/app/schema.graphql
+++ b/app/schema.graphql
@@ -305,8 +305,8 @@ type Mutation {
     subscription: String!
     session: String
     view: BSONArray!
-    viewName: String
     slice: String!
+    viewName: String = null
   ): Dataset!
   createSavedView(
     subscription: String!

--- a/fiftyone/server/aggregate.py
+++ b/fiftyone/server/aggregate.py
@@ -121,7 +121,7 @@ class AggregateQuery:
         dataset_name: str,
         view: t.Optional[BSONArray],
         aggregations: t.List[Aggregate],
-        view_name: t.Optional[str],
+        view_name: t.Optional[str] = None,
     ) -> t.List[
         gql.union(
             "AggregationResponses",

--- a/fiftyone/server/aggregations.py
+++ b/fiftyone/server/aggregations.py
@@ -124,7 +124,7 @@ async def aggregate_resolver(
 
     view = fosv.get_dataset_view(
         form.dataset,
-        view_name=form.view_name,
+        view_name=form.view_name if form.view_name else None,
         stages=form.view,
         filters=form.filters,
         extended_stages=form.extended_stages,

--- a/fiftyone/server/mutation.py
+++ b/fiftyone/server/mutation.py
@@ -246,9 +246,9 @@ class Mutation:
         subscription: str,
         session: t.Optional[str],
         view: BSONArray,
-        view_name: t.Optional[str],
         slice: str,
         info: Info,
+        view_name: t.Optional[str] = None,
     ) -> Dataset:
         state = get_state()
         state.dataset.group_slice = slice
@@ -256,7 +256,11 @@ class Mutation:
         return await Dataset.resolver(
             name=state.dataset.name,
             view=view,
-            view_name=view_name if view_name else state.view.name,
+            view_name=view_name
+            if view_name
+            else state.view.name
+            if state.view
+            else None,
             info=info,
         )
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

- Add a default value when view_name isn't provided
- Addresses https://voxel51.atlassian.net/browse/TEAMS-684

## How is this patch tested? If it is not, please explain why.

- Run app and verify no error thrown when clicking on Sample tags, Label tags, Labels, and Other fields
- 
<img width="900" alt="image" src="https://user-images.githubusercontent.com/30936736/209726069-df85df2e-c590-4a6b-a01a-ac9a0048540d.png">

- Run app and view `quickstart-groups` dataset. Toggle between left and right group selectors:
- 
<img width="1494" alt="image" src="https://user-images.githubusercontent.com/30936736/209729743-efa2ceb3-ea8e-439f-af2a-35b287807a07.png">
- <img width="885" alt="image" src="https://user-images.githubusercontent.com/30936736/209729851-07d09065-1d46-4e63-9883-0743a44b3a0d.png">

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
