### PR TITLE
Separate method for clearing a dataset's run cache

### DIFF
--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -6077,6 +6077,8 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
         self._reload(hard=True)
         self._reload_docs(hard=True)
 
+    def clear_cache(self):
+        """Clears the dataset's in-memory cache."""
         self._annotation_cache.clear()
         self._brain_cache.clear()
         self._evaluation_cache.clear()


### PR DESCRIPTION
Refactors clearing of a dataset's run cache into a dedicated `clear_cache()` method. Previously, calling `SampleCollection.reload()` would cause a dataset's cache of run results to be cleared, which is really a separate operation.

`reload()` is required when another process has edited a dataset's field schema, while `clear_cache()` is only required if one is concerned about memory issues due to loading too many large run results into memory in a single session.
