### PR TITLE
Fix CVAT bug when checking if a project exists

### DIFF
--- a/fiftyone/utils/cvat.py
+++ b/fiftyone/utils/cvat.py
@@ -3821,6 +3821,9 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
         return [pid for pid in project_ids if self._is_empty_project(pid)]
 
     def _is_empty_project(self, project_id):
+        if not self.project_exists(project_id):
+            return True
+
         resp = self.get(self.project_url(project_id)).json()
         return not resp["tasks"]
 
@@ -3869,15 +3872,17 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
         Returns:
             True/False
         """
-        return (
-            self._get_value_from_search(
-                self.project_id_search_url,
-                project_id,
-                "id",
-                "id",
+        try:
+            response = self.get(
+                self.project_url(project_id), print_error_info=False
             )
-            is not None
-        )
+        except requests.exceptions.HTTPError as e:
+            if e.response.status_code == 404:
+                return False
+            else:
+                raise e
+
+        return True
 
     def delete_project(self, project_id):
         """Deletes the given project from the CVAT server.

--- a/tests/intensive/cvat_tests.py
+++ b/tests/intensive/cvat_tests.py
@@ -1239,6 +1239,53 @@ class CVATTests(unittest.TestCase):
 
         dataset.load_annotations(anno_key, cleanup=True)
 
+    def test_project_exists(self):
+        dataset = (
+            foz.load_zoo_dataset("quickstart", max_samples=1)
+            .select_fields("ground_truth")
+            .clone()
+        )
+
+        all_results = []
+        for i in range(20):
+            anno_key = "project_exists"
+            results = dataset.annotate(
+                anno_key + str(i),
+                label_field="ground_truth",
+                backend="cvat",
+                project_name="fo_cvat_test_" + str(i),
+            )
+            all_results.append(results)
+
+        projects_exist = []
+        for i, results in enumerate(all_results):
+            with results:
+                api = results.connect_to_api()
+                for project_id in results.project_ids:
+                    projects_exist.append(api.project_exists(project_id))
+
+            dataset.load_annotations(anno_key + str(i), cleanup=True)
+
+        self.assertNotIn(False, projects_exist)
+
+        view = dataset.take(1)
+
+        anno_key = "project_not_exists"
+        results = view.annotate(
+            anno_key,
+            label_field="ground_truth",
+            backend="cvat",
+            project_name="fo_cvat_project_test",
+        )
+
+        project_id = results.project_ids[0]
+        with results:
+            api = results.connect_to_api()
+            api.delete_project(project_id)
+            self.assertFalse(api.project_exists(project_id))
+
+        dataset.load_annotations(anno_key, cleanup=True)
+
     def test_deleted_label_field(self):
         dataset = foz.load_zoo_dataset("quickstart", max_samples=1).clone()
         view = dataset.select_fields("ground_truth")


### PR DESCRIPTION
There was a similar issue when checking if projects exists that we ran into for tasks in https://github.com/voxel51/fiftyone/pull/2070. The issue arises when too many projects exist in once CVAT organizaton.

This is also a similar solution in that it attempts to access the URL for the project and assumes it does not exist on a 404 error. This PR also adds a test for this issue that now passes.