### PR TITLE
bugfix: CSVDatasetExporter - Dont pre-quote list values

### DIFF
--- a/fiftyone/utils/csv.py
+++ b/fiftyone/utils/csv.py
@@ -144,7 +144,9 @@ class CSVDatasetExporter(foud.BatchDatasetExporter, foud.ExportPathsMixin):
         etau.ensure_basedir(self.labels_path)
         f = open(self.labels_path, "w")
 
-        csv_writer = csv.writer(f)
+        # QUOTE_MINIMAL is default, but pass it anyways to make sure
+        #   list fields we try to write are handled properly
+        csv_writer = csv.writer(f, quoting=csv.QUOTE_MINIMAL)
         csv_writer.writerow(header)
 
         self._f = f
@@ -211,4 +213,4 @@ def _parse_value(value):
         return str(value)
 
     # Render lists as "list,of,values"
-    return '"' + ",".join(str(v) for v in value) + '"'
+    return ",".join(str(v) for v in value)


### PR DESCRIPTION
## What changes are proposed in this pull request?

Closes https://github.com/voxel51/fiftyone/issues/2493

`csv` module quotes the delimiter and double-quotes already with the default `dialect`.
So we do not need to add the literal quotes surrounding the stringified list, as `csv` 
will then quote it again (with 2 double quotes) so we end up with 3 total.
Even though it's the default, I've passed in `quoting=csv.QUOTE_MINIMAL` just to make
sure it's done anyways.

## How is this patch tested? If it is not, please explain why.

```
import fiftyone as fo
import fiftyone.zoo as foz

dataset = foz.load_zoo_dataset("quickstart")
view = dataset.limit(2)
view.export(
  dataset_type=fo.types.CSVDataset,
  export_dir="/tmp/csv_export_test",
  fields=[
    "filepath",
    "tags",
    "ground_truth.detections.tags",
    "ground_truth.detections.label"
  ]
)
```
Checked export output which now looks like this:
```
filepath,tags,ground_truth.detections.tags,ground_truth.detections.label
000880.jpg,validation,"[],[],[]","bird,bird,bird"
001599.jpg,validation,"[],[]","horse,person"
```

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
