### PR TITLE
ViewSelection and its subcomponents capable of rendering readonly or editable versions

### DIFF
--- a/app/packages/core/src/components/Sidebar/ViewSelection/ViewDialog.tsx
+++ b/app/packages/core/src/components/Sidebar/ViewSelection/ViewDialog.tsx
@@ -39,10 +39,10 @@ import {
 import { shouldToggleBookMarkIconOnSelector } from "../../Actions/ActionsRow";
 
 interface Props {
-  canEdit?: boolean;
   savedViews: fos.State.SavedView[];
   onEditSuccess: (saveView: fos.State.SavedView, reload?: boolean) => void;
   onDeleteSuccess: (slug: string) => void;
+  canEdit?: boolean;
 }
 
 export const viewDialogContent = atom({

--- a/app/packages/core/src/components/Sidebar/ViewSelection/ViewDialog.tsx
+++ b/app/packages/core/src/components/Sidebar/ViewSelection/ViewDialog.tsx
@@ -39,6 +39,7 @@ import {
 import { shouldToggleBookMarkIconOnSelector } from "../../Actions/ActionsRow";
 
 interface Props {
+  canEdit?: boolean;
   savedViews: fos.State.SavedView[];
   onEditSuccess: (saveView: fos.State.SavedView, reload?: boolean) => void;
   onDeleteSuccess: (slug: string) => void;
@@ -55,7 +56,7 @@ export const viewDialogContent = atom({
 });
 
 export default function ViewDialog(props: Props) {
-  const { onEditSuccess, onDeleteSuccess, savedViews = [] } = props;
+  const { onEditSuccess, onDeleteSuccess, savedViews = [], canEdit } = props;
   const theme = useTheme();
   const [isOpen, setIsOpen] = useRecoilState<boolean>(viewDialogOpen);
   const viewContent = useRecoilValue(viewDialogContent);
@@ -239,7 +240,7 @@ export default function ViewDialog(props: Props) {
               justifyContent: "start",
             }}
           >
-            {!isCreating && (
+            {!isCreating && canEdit && (
               <Button
                 onClick={onDeleteView}
                 sx={{

--- a/app/packages/core/src/components/Sidebar/ViewSelection/index.tsx
+++ b/app/packages/core/src/components/Sidebar/ViewSelection/index.tsx
@@ -67,7 +67,7 @@ export default function ViewSelection(props: Props) {
   const [selected, setSelected] = useRecoilState<DatasetViewOption | null>(
     selectedSavedViewState
   );
-
+  const canEditSavedViews = useRecoilValue<boolean>(fos.canEditSavedViews);
   const existingQueries = qs.parse(location.search, {
     ignoreQueryPrefix: true,
   });
@@ -206,6 +206,9 @@ export default function ViewSelection(props: Props) {
 
   useEffect(() => {
     const callback = (event: KeyboardEvent) => {
+      if (!canEditSavedViews) {
+        return;
+      }
       if ((event.metaKey || event.ctrlKey) && event.code === "KeyS") {
         event.preventDefault();
         if (!isEmptyView) {
@@ -218,12 +221,13 @@ export default function ViewSelection(props: Props) {
     return () => {
       document.removeEventListener("keydown", callback);
     };
-  }, [isEmptyView]);
+  }, [isEmptyView, canEditSavedViews]);
 
   return (
     <Suspense fallback="Loading saved views...">
       <Box>
         <ViewDialog
+          canEdit={canEditSavedViews}
           savedViews={items}
           onEditSuccess={(
             createSavedView: fos.State.SavedView,
@@ -265,6 +269,7 @@ export default function ViewSelection(props: Props) {
           }}
         />
         <Selection
+          readonly={!canEditSavedViews}
           selected={selected}
           setSelected={(item: DatasetViewOption) => {
             setSelected(item);
@@ -289,8 +294,10 @@ export default function ViewSelection(props: Props) {
           }}
           lastFixedOption={
             <LastOption
-              onClick={() => !isEmptyView && setIsOpen(true)}
-              disabled={isEmptyView}
+              onClick={() =>
+                canEditSavedViews && !isEmptyView && setIsOpen(true)
+              }
+              disabled={isEmptyView || !canEditSavedViews}
             >
               <Box style={{ width: "12%" }}>
                 <AddIcon fontSize="small" disabled={isEmptyView} />

--- a/app/packages/dataset/src/Dataset.tsx
+++ b/app/packages/dataset/src/Dataset.tsx
@@ -59,6 +59,7 @@ export interface DatasetProps {
   readOnly?: boolean;
   theme?: "dark" | "light";
   toggleHeaders?: () => void;
+  canEditSavedViews?: boolean;
 }
 
 export const Dataset: React.FC<DatasetProps> = (props) => {
@@ -87,9 +88,11 @@ export const DatasetRenderer: React.FC<DatasetProps> = ({
   readOnly = false,
   theme = "dark",
   toggleHeaders,
+  canEditSavedViews = true,
 }) => {
   const [queryRef, loadQuery] = useQueryLoader<DatasetQuery>(DatasetNodeQuery);
   const setTheme = useSetRecoilState(fos.theme);
+  const setCanChangeSavedViews = useSetRecoilState(fos.canEditSavedViews);
   const setCompactLayout = useSetRecoilState(fos.compactLayout);
   const setReadOnly = useSetRecoilState(fos.readOnly);
 
@@ -99,6 +102,9 @@ export const DatasetRenderer: React.FC<DatasetProps> = ({
   React.useEffect(() => {
     loadQuery({ name: dataset });
   }, [dataset]);
+  React.useEffect(() => {
+    setCanChangeSavedViews(canEditSavedViews);
+  }, [canEditSavedViews]);
   React.useLayoutEffect(() => {
     setReadOnly(readOnly);
   }, [readOnly]);

--- a/app/packages/state/src/recoil/atoms.ts
+++ b/app/packages/state/src/recoil/atoms.ts
@@ -240,6 +240,11 @@ export const theme = atom<"dark" | "light">({
   ],
 });
 
+export const canEditSavedViews = atom({
+  key: "canEditSavedViews",
+  default: true,
+});
+
 export const compactLayout = atom({
   key: "compactLayout",
   default: false,


### PR DESCRIPTION
This pr enables passing a canEdit property to ViewSelection. if true, this property would make ViewSelection an editable component. if false, disables the "save new view" and hides edit/delete options.

the changes for teams are in kacey's branch

## What changes are proposed in this pull request?

(Please fill in changes proposed in this fix)

## How is this patch tested? If it is not, please explain why.

(Details)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
