### PR TITLE
Adding support for declaring dynamic fields on generated views via set_values()

### DIFF
--- a/fiftyone/core/clips.py
+++ b/fiftyone/core/clips.py
@@ -378,7 +378,7 @@ class ClipsView(fov.DatasetView):
         _, label_root = self._get_label_field_path(root)
         leaf = path[len(label_root) + 1 :]
 
-        dst_dataset = self._source_collection._root_dataset
+        dst_dataset = self._source_collection._dataset
         _, dst_path = dst_dataset._get_label_field_path(root)
         dst_path += "." + leaf
 

--- a/fiftyone/core/clips.py
+++ b/fiftyone/core/clips.py
@@ -367,20 +367,22 @@ class ClipsView(fov.DatasetView):
             self._source_collection._delete_labels(del_ids, fields=[field])
 
     def _sync_source_field_schema(self, path):
-        field = path.split(".", 1)[0]
-        if field != self._classification_field:
+        root = path.split(".", 1)[0]
+        if root != self._classification_field:
             return
 
-        _, label_path = self._get_label_field_path(field)
-        leaf = path[len(label_path) + 1 :]
+        field = self.get_field(path)
+        if field is None:
+            return
+
+        _, label_root = self._get_label_field_path(root)
+        leaf = path[len(label_root) + 1 :]
 
         dst_dataset = self._source_collection._root_dataset
-        _, dst_path = dst_dataset._get_label_field_path(field)
+        _, dst_path = dst_dataset._get_label_field_path(root)
         dst_path += "." + leaf
 
-        dst_dataset._merge_sample_field_schema(
-            {dst_path: self.get_field(path)}
-        )
+        dst_dataset._merge_sample_field_schema({dst_path: field})
 
     def _sync_source_keep_fields(self):
         # If the source TemporalDetection field is excluded, delete it from

--- a/fiftyone/core/clips.py
+++ b/fiftyone/core/clips.py
@@ -384,6 +384,9 @@ class ClipsView(fov.DatasetView):
 
         dst_dataset._merge_sample_field_schema({dst_path: field})
 
+        if self._source_collection._is_generated:
+            self._source_collection._sync_source_field_schema(dst_path)
+
     def _sync_source_keep_fields(self):
         # If the source TemporalDetection field is excluded, delete it from
         # this collection and the source collection

--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -1262,6 +1262,23 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
         if expanded:
             self._reload()
 
+    def _merge_sample_field_schema(
+        self,
+        schema,
+        expand_schema=True,
+        recursive=True,
+        validate=True,
+    ):
+        expanded = self._sample_doc_cls.merge_field_schema(
+            schema,
+            expand_schema=expand_schema,
+            recursive=recursive,
+            validate=validate,
+        )
+
+        if expanded:
+            self._reload()
+
     def add_dynamic_sample_fields(self, fields=None, add_mixed=False):
         """Adds all dynamic sample fields to the dataset's schema.
 
@@ -1291,10 +1308,7 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
             elif field is not None:
                 schema[path] = field
 
-        expanded = self._sample_doc_cls.merge_field_schema(schema)
-
-        if expanded:
-            self._reload()
+        self._merge_sample_field_schema(schema)
 
     def add_frame_field(
         self,
@@ -1369,6 +1383,23 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
         if expanded:
             self._reload()
 
+    def _merge_frame_field_schema(
+        self,
+        schema,
+        expand_schema=True,
+        recursive=True,
+        validate=True,
+    ):
+        expanded = self._frame_doc_cls.merge_field_schema(
+            schema,
+            expand_schema=expand_schema,
+            recursive=recursive,
+            validate=validate,
+        )
+
+        if expanded:
+            self._reload()
+
     def add_dynamic_frame_fields(self, fields=None, add_mixed=False):
         """Adds all dynamic frame fields to the dataset's schema.
 
@@ -1403,10 +1434,7 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
             elif field is not None:
                 schema[path] = field
 
-        expanded = self._frame_doc_cls.merge_field_schema(schema)
-
-        if expanded:
-            self._reload()
+        self._merge_frame_field_schema(schema)
 
     def add_group_field(
         self, field_name, default=None, description=None, info=None

--- a/fiftyone/core/patches.py
+++ b/fiftyone/core/patches.py
@@ -363,7 +363,7 @@ class _PatchesView(fov.DatasetView):
         _, label_root = self._get_label_field_path(root)
         leaf = path[len(label_root) + 1 :]
 
-        dst_dataset = self._source_collection._root_dataset
+        dst_dataset = self._source_collection._dataset
         _, dst_path = dst_dataset._get_label_field_path(root)
         dst_path += "." + leaf
 

--- a/fiftyone/core/patches.py
+++ b/fiftyone/core/patches.py
@@ -217,6 +217,7 @@ class _PatchesView(fov.DatasetView):
         super().set_values(field_name, *args, **kwargs)
 
         self._sync_source_field(field, ids=ids)
+        self._sync_source_field_schema(field_name)
 
     def set_label_values(self, field_name, *args, **kwargs):
         field = field_name.split(".", 1)[0]
@@ -335,7 +336,7 @@ class _PatchesView(fov.DatasetView):
         if field not in self._label_fields:
             return
 
-        _, label_path = self._patches_dataset._get_label_field_path(field)
+        _, label_path = self._get_label_field_path(field)
 
         if ids is not None:
             view = self._patches_dataset.mongo(
@@ -349,6 +350,22 @@ class _PatchesView(fov.DatasetView):
         )
 
         self._source_collection._set_labels(field, sample_ids, docs)
+
+    def _sync_source_field_schema(self, path):
+        field = path.split(".", 1)[0]
+        if field not in self._label_fields:
+            return
+
+        _, label_path = self._get_label_field_path(field)
+        leaf = path[len(label_path) + 1 :]
+
+        dst_dataset = self._source_collection._root_dataset
+        _, dst_path = dst_dataset._get_label_field_path(field)
+        dst_path += "." + leaf
+
+        dst_dataset._merge_sample_field_schema(
+            {dst_path: self.get_field(path)}
+        )
 
     def _sync_source_root(self, fields, update=True, delete=False):
         for field in fields:

--- a/fiftyone/core/patches.py
+++ b/fiftyone/core/patches.py
@@ -352,20 +352,22 @@ class _PatchesView(fov.DatasetView):
         self._source_collection._set_labels(field, sample_ids, docs)
 
     def _sync_source_field_schema(self, path):
-        field = path.split(".", 1)[0]
-        if field not in self._label_fields:
+        root = path.split(".", 1)[0]
+        if root not in self._label_fields:
             return
 
-        _, label_path = self._get_label_field_path(field)
-        leaf = path[len(label_path) + 1 :]
+        field = self.get_field(path)
+        if field is None:
+            return
+
+        _, label_root = self._get_label_field_path(root)
+        leaf = path[len(label_root) + 1 :]
 
         dst_dataset = self._source_collection._root_dataset
-        _, dst_path = dst_dataset._get_label_field_path(field)
+        _, dst_path = dst_dataset._get_label_field_path(root)
         dst_path += "." + leaf
 
-        dst_dataset._merge_sample_field_schema(
-            {dst_path: self.get_field(path)}
-        )
+        dst_dataset._merge_sample_field_schema({dst_path: field})
 
     def _sync_source_root(self, fields, update=True, delete=False):
         for field in fields:

--- a/fiftyone/core/patches.py
+++ b/fiftyone/core/patches.py
@@ -369,6 +369,9 @@ class _PatchesView(fov.DatasetView):
 
         dst_dataset._merge_sample_field_schema({dst_path: field})
 
+        if self._source_collection._is_generated:
+            self._source_collection._sync_source_field_schema(dst_path)
+
     def _sync_source_root(self, fields, update=True, delete=False):
         for field in fields:
             self._sync_source_root_field(field, update=update, delete=delete)

--- a/fiftyone/core/video.py
+++ b/fiftyone/core/video.py
@@ -383,6 +383,9 @@ class FramesView(fov.DatasetView):
         dst_dataset = self._source_collection._dataset
         dst_dataset._merge_frame_field_schema({path: field})
 
+        if self._source_collection._is_generated:
+            self._source_collection._sync_source_field_schema(path)
+
     def _sync_source_schema(self, fields=None, delete=False):
         if delete:
             schema = self.get_field_schema()

--- a/fiftyone/core/video.py
+++ b/fiftyone/core/video.py
@@ -376,8 +376,12 @@ class FramesView(fov.DatasetView):
             dst_dataset._clear_frames(frame_ids=frame_ids)
 
     def _sync_source_field_schema(self, path):
+        field = self.get_field(path)
+        if field is None:
+            return
+
         dst_dataset = self._source_collection._root_dataset
-        dst_dataset._merge_frame_field_schema({path: self.get_field(path)})
+        dst_dataset._merge_frame_field_schema({path: field})
 
     def _sync_source_schema(self, fields=None, delete=False):
         if delete:

--- a/fiftyone/core/video.py
+++ b/fiftyone/core/video.py
@@ -193,6 +193,7 @@ class FramesView(fov.DatasetView):
 
         field = field_name.split(".", 1)[0]
         self._sync_source(fields=[field], ids=ids)
+        self._sync_source_field_schema(field_name)
 
     def set_label_values(self, field_name, *args, **kwargs):
         super().set_label_values(field_name, *args, **kwargs)
@@ -373,6 +374,10 @@ class FramesView(fov.DatasetView):
         if delete:
             frame_ids = self._frames_dataset.exclude(self).values("id")
             dst_dataset._clear_frames(frame_ids=frame_ids)
+
+    def _sync_source_field_schema(self, path):
+        dst_dataset = self._source_collection._root_dataset
+        dst_dataset._merge_frame_field_schema({path: self.get_field(path)})
 
     def _sync_source_schema(self, fields=None, delete=False):
         if delete:

--- a/fiftyone/core/video.py
+++ b/fiftyone/core/video.py
@@ -380,7 +380,7 @@ class FramesView(fov.DatasetView):
         if field is None:
             return
 
-        dst_dataset = self._source_collection._root_dataset
+        dst_dataset = self._source_collection._dataset
         dst_dataset._merge_frame_field_schema({path: field})
 
     def _sync_source_schema(self, fields=None, delete=False):

--- a/tests/unittests/patches_tests.py
+++ b/tests/unittests/patches_tests.py
@@ -186,6 +186,16 @@ class PatchesTests(unittest.TestCase):
             dataset.count_values("ground_truth.detections.label_upper")["CAT"],
             1,
         )
+        self.assertIsNone(view.get_field("ground_truth.label_upper"))
+        self.assertIsNone(
+            dataset.get_field("ground_truth.detections.label_upper")
+        )
+
+        view2.set_values("ground_truth.label_dynamic", values, dynamic=True)
+        self.assertIsNotNone(view.get_field("ground_truth.label_dynamic"))
+        self.assertIsNotNone(
+            dataset.get_field("ground_truth.detections.label_dynamic")
+        )
 
         values = {
             _id: v
@@ -481,6 +491,20 @@ class PatchesTests(unittest.TestCase):
         self.assertEqual(
             dataset.count_values("predictions.detections.label_upper")["CAT"],
             2,
+        )
+        self.assertIsNone(view.get_field("predictions.detections.label_upper"))
+        self.assertIsNone(
+            dataset.get_field("predictions.detections.label_upper")
+        )
+
+        view2.set_values(
+            "predictions.detections.label_dynamic", values, dynamic=True
+        )
+        self.assertIsNotNone(
+            view.get_field("predictions.detections.label_dynamic")
+        )
+        self.assertIsNotNone(
+            dataset.get_field("predictions.detections.label_dynamic")
         )
 
         values = {

--- a/tests/unittests/video_tests.py
+++ b/tests/unittests/video_tests.py
@@ -2581,6 +2581,22 @@ class VideoTests(unittest.TestCase):
         )
         self.assertEqual(patches.count("ground_truth.label_upper"), 2)
         self.assertEqual(view2.count("ground_truth.label_upper"), 2)
+        self.assertIsNone(patches.get_field("ground_truth.label_upper"))
+        self.assertIsNone(
+            frames.get_field("ground_truth.detections.label_upper")
+        )
+        self.assertIsNone(
+            dataset.get_field("frames.ground_truth.detections.label_upper")
+        )
+
+        view2.set_values("ground_truth.label_dynamic", values, dynamic=True)
+        self.assertIsNotNone(patches.get_field("ground_truth.label_dynamic"))
+        self.assertIsNotNone(
+            frames.get_field("ground_truth.detections.label_dynamic")
+        )
+        self.assertIsNotNone(
+            dataset.get_field("frames.ground_truth.detections.label_dynamic")
+        )
 
         values = {
             _id: v
@@ -2823,6 +2839,16 @@ class VideoTests(unittest.TestCase):
         )
         self.assertEqual(patches.count("ground_truth.label_upper"), 2)
         self.assertEqual(view2.count("ground_truth.label_upper"), 2)
+        self.assertIsNone(patches.get_field("ground_truth.label_upper"))
+        self.assertIsNone(
+            dataset.get_field("frames.ground_truth.detections.label_upper")
+        )
+
+        view2.set_values("ground_truth.label_dynamic", values, dynamic=True)
+        self.assertIsNotNone(patches.get_field("ground_truth.label_dynamic"))
+        self.assertIsNotNone(
+            dataset.get_field("frames.ground_truth.detections.label_dynamic")
+        )
 
         view3 = patches.skip(2).set_field(
             "ground_truth.label", F("label").upper()


### PR DESCRIPTION
It should ideally possible to declare a new dynamic label attribute by applying `set_values()` to a generated view (eg patches). Previously the values themselves would be added, but the field wouldn't be added to the underlying dataset's schema. This PR adds the schema piece.

```py
import fiftyone as fo
import fiftyone.zoo as foz

dataset = foz.load_zoo_dataset("quickstart")

patches = dataset.to_patches("ground_truth")
patches.set_values("ground_truth.foo", ["bar"] * len(patches), dynamic=True)

# previously False, now True
assert "ground_truth.detections.foo" in dataset.get_field_schema(flat=True)
```
