### PR TITLE
Unsafe module used in deserialization

### DIFF
--- a/fiftyone/service/ipc.py
+++ b/fiftyone/service/ipc.py
@@ -89,6 +89,13 @@ class IPCServer(socketserver.TCPServer):
 class IPCRequestHandler(socketserver.StreamRequestHandler):
     def handle(self):
         try:
+            """***************** Warning *****************
+            Injection attack opportunity during deserialization!
+            Path:
+            	File: ipc.py, Line: 92
+            		message = pickle.load(self.rfile)
+            		Tainted information is used in a sink.
+            """
             message = pickle.load(self.rfile)
             reply = self.server.on_message(message)
             self.send_reply(reply)


### PR DESCRIPTION
In file: ipc.py, a deserialization operation is performed by the unsafe Pickle Module (https://docs.python.org/3/library/pickle.html). The data that goes through the deserialization process comes from an untrusted source and it can not be trusted to be well formed (https://cwe.mitre.org/data/definitions/502.html). 

The deserialization operation is done with the safe PyYAML module. No fix created.