### PR TITLE
expand tab drop zone in spaces

### DIFF
--- a/app/packages/spaces/src/components/Space.tsx
+++ b/app/packages/spaces/src/components/Space.tsx
@@ -2,7 +2,7 @@ import { Allotment } from "allotment";
 import "allotment/dist/style.css";
 import { ReactSortable } from "react-sortablejs";
 import { Layout } from "../enums";
-import { useSpaces } from "../hooks";
+import { useSpaces, usePanelTabAutoPosition } from "../hooks";
 import SpaceNode from "../SpaceNode";
 import { SpaceProps } from "../types";
 import AddPanelButton from "./AddPanelButton";
@@ -13,6 +13,7 @@ import { PanelContainer, PanelTabs, SpaceContainer } from "./StyledElements";
 
 export default function Space({ node, id }: SpaceProps) {
   const { spaces } = useSpaces(id);
+  const autoPosition = usePanelTabAutoPosition();
 
   if (node.layout) {
     return (
@@ -39,6 +40,7 @@ export default function Space({ node, id }: SpaceProps) {
           <ReactSortable
             group="panel-tabs"
             list={node.children}
+            filter=".sortable-ignore"
             setList={(children, _, dragging) => {
               if (dragging?.dragging !== null) {
                 node.children = children;
@@ -53,7 +55,9 @@ export default function Space({ node, id }: SpaceProps) {
                 spaces.updateTree(node);
               }
             }}
-            style={{ display: "flex" }}
+            onChange={autoPosition}
+            onEnd={autoPosition}
+            style={{ display: "flex", width: "100%" }}
           >
             {node.children.map((child) => (
               <PanelTab
@@ -63,22 +67,24 @@ export default function Space({ node, id }: SpaceProps) {
                 spaceId={id}
               />
             ))}
+            <div className="sortable-ignore" style={{ display: "flex" }}>
+              <AddPanelButton node={node} spaceId={id} />
+              {canSpaceSplit && (
+                <>
+                  <SplitPanelButton
+                    node={node}
+                    layout={Layout.Horizontal}
+                    spaceId={id}
+                  />
+                  <SplitPanelButton
+                    node={node}
+                    layout={Layout.Vertical}
+                    spaceId={id}
+                  />
+                </>
+              )}
+            </div>
           </ReactSortable>
-          <AddPanelButton node={node} spaceId={id} />
-          {canSpaceSplit && (
-            <>
-              <SplitPanelButton
-                node={node}
-                layout={Layout.Horizontal}
-                spaceId={id}
-              />
-              <SplitPanelButton
-                node={node}
-                layout={Layout.Vertical}
-                spaceId={id}
-              />
-            </>
-          )}
         </PanelTabs>
         {node.hasActiveChild() ? (
           <Panel node={activeChild as SpaceNode} spaceId={id} />

--- a/app/packages/spaces/src/state.ts
+++ b/app/packages/spaces/src/state.ts
@@ -82,6 +82,11 @@ export const panelStatePartialSelector = selectorFamily({
     },
 });
 
+export const previousTabsGroupAtom = atom<HTMLElement | null>({
+  key: "previousTabsGroupAtom",
+  default: null,
+});
+
 function getStateAtom(local?: boolean) {
   return local ? panelsLocalStateAtom : panelsStateAtom;
 }


### PR DESCRIPTION
## What changes are proposed in this pull request?

PR expands spaces panel tabs dropzone area

## How is this patch tested? If it is not, please explain why.

Interactively within the app as it involves dragging and dropping a tab from one space to another

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
