### PR TITLE
[WIP] add panel state hook to get panel recoil state ref

### DIFF
--- a/app/packages/spaces/src/hooks.ts
+++ b/app/packages/spaces/src/hooks.ts
@@ -129,6 +129,22 @@ export function usePanelState<T>(
 }
 
 /**
+ * Get reference to recoil state of a panel which can be used with any recoil
+ *  state hooks
+ *
+ * **Note: `id` is required if the hook is used outside of a panel component.**
+ */
+export function usePanelStateRecoil(
+  defaultState?: unknown,
+  id?: string,
+  local?: boolean
+) {
+  const panelContext = usePanelContext();
+  const panelId = id || (panelContext?.node?.id as string);
+  return panelStateSelector({ panelId, local, defaultState });
+}
+
+/**
  * Can only be used within a panel component
  */
 export function usePanelStateCallback<T>(

--- a/app/packages/spaces/src/state.ts
+++ b/app/packages/spaces/src/state.ts
@@ -49,9 +49,12 @@ export const panelStateSelector = selectorFamily({
   get:
     (params: PanelStateParameter) =>
     ({ get }) => {
-      const { panelId, local } = params;
+      const { panelId, local, defaultState } = params;
       const stateAtom = getStateAtom(local);
-      return get(stateAtom).get(panelId);
+      const state = get(stateAtom).get(panelId);
+      // todo: need better way to check if state was initialized to also allow
+      //  `undefined` value for a state
+      return state === undefined ? defaultState : state;
     },
   set:
     (params: PanelStateParameter) =>

--- a/app/packages/spaces/src/types.ts
+++ b/app/packages/spaces/src/types.ts
@@ -61,6 +61,7 @@ export type SpaceProps = {
 export type PanelStateParameter = {
   panelId: string;
   local?: boolean;
+  defaultState?: any;
 };
 
 export type PanelStatePartialParameter = PanelStateParameter & {


### PR DESCRIPTION
## What changes are proposed in this pull request?

Add a hook to the spaces package which can be used to get a reference to the recoil state holding the state of a panel

## How is this patch tested? If it is not, please explain why.

(Details)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
