### PR TITLE
Maintain Starlette route list

### DIFF
--- a/fiftyone/server/app.py
+++ b/fiftyone/server/app.py
@@ -33,8 +33,6 @@ from fiftyone.server.query import Query
 from fiftyone.server.routes import routes
 from fiftyone.server.scalars import Date, DateTime
 
-from fiftyone.server.routes.embeddings import Embeddings
-
 
 etau.ensure_dir(os.path.join(os.path.dirname(__file__), "static"))
 
@@ -91,7 +89,6 @@ app = Starlette(
     ],
     debug=foc.DEV_INSTALL,
     routes=[Route(route, endpoint) for route, endpoint in routes]
-    + Embeddings
     + [
         Route(
             "/graphql",

--- a/fiftyone/server/routes/__init__.py
+++ b/fiftyone/server/routes/__init__.py
@@ -22,6 +22,7 @@ from .tag import Tag
 from .tagging import Tagging
 from .values import Values
 
+# Starlette routes should not be created here. Please leave as tuple definitions
 routes = EmbeddingsRoutes + [
     ("/aggregate", Aggregate),
     ("/event", Event),

--- a/fiftyone/server/routes/__init__.py
+++ b/fiftyone/server/routes/__init__.py
@@ -6,7 +6,7 @@ FiftyOne Server routes
 |
 """
 from .aggregate import Aggregate
-from .embeddings import Embeddings
+from .embeddings import EmbeddingsRoutes
 from .event import Event
 from .events import Events
 from .fiftyone import FiftyOne
@@ -22,9 +22,8 @@ from .tag import Tag
 from .tagging import Tagging
 from .values import Values
 
-routes = [
+routes = EmbeddingsRoutes + [
     ("/aggregate", Aggregate),
-    ("/embeddings", Embeddings),
     ("/event", Event),
     ("/events", Events),
     ("/fiftyone", FiftyOne),

--- a/fiftyone/server/routes/embeddings.py
+++ b/fiftyone/server/routes/embeddings.py
@@ -9,7 +9,6 @@ import itertools
 
 from starlette.endpoints import HTTPEndpoint
 from starlette.requests import Request
-from starlette.routing import Route
 
 import fiftyone as fo
 from fiftyone.server.decorators import route
@@ -245,11 +244,11 @@ class ColorByChoices(HTTPEndpoint):
         return {"fields": fields}
 
 
-Embeddings = [
-    Route("/embeddings/plot", OnPlotLoad),
-    Route("/embeddings/selection", EmbeddingsSelection),
-    Route("/embeddings/extended-stage", EmbeddingsExtendedStage),
-    Route("/embeddings/color-by-choices", ColorByChoices),
+EmbeddingsRoutes = [
+    ("/embeddings/plot", OnPlotLoad),
+    ("/embeddings/selection", EmbeddingsSelection),
+    ("/embeddings/extended-stage", EmbeddingsExtendedStage),
+    ("/embeddings/color-by-choices", ColorByChoices),
 ]
 
 


### PR DESCRIPTION
For Teams routing, the OSS routes must be represented as a flat list of tuple definitions for proper construction.