### PR TITLE
update select sample with select label under condition

### DIFF
--- a/app/packages/core/src/components/Actions/ActionsRow.tsx
+++ b/app/packages/core/src/components/Actions/ActionsRow.tsx
@@ -196,7 +196,7 @@ const Selected = ({
 }) => {
   const [open, setOpen] = useState(false);
   const [loading, setLoading] = useState(false);
-  const [samples, setSamples] = useRecoilState(fos.selectedSamples);
+  const samples = useRecoilValue(fos.selectedSamples);
   const labels = useRecoilValue(fos.selectedLabelIds);
   const ref = useRef();
   useOutsideClick(ref, () => open && setOpen(false));
@@ -209,14 +209,6 @@ const Selected = ({
 
   if (samples.size < 1 && !modal) {
     return null;
-  }
-
-  // when the user selects labels in sample modal, but no samples are selected, we add the current sample to selected samples
-  if (modal && labels.size > 0 && samples.size < 1) {
-    const currentSample = lookerRef?.current?.sample?.id;
-    if (currentSample) {
-      setSamples(new Set([currentSample]));
-    }
   }
 
   let text = samples.size.toLocaleString();

--- a/app/packages/core/src/components/Actions/ActionsRow.tsx
+++ b/app/packages/core/src/components/Actions/ActionsRow.tsx
@@ -196,7 +196,7 @@ const Selected = ({
 }) => {
   const [open, setOpen] = useState(false);
   const [loading, setLoading] = useState(false);
-  const samples = useRecoilValue(fos.selectedSamples);
+  const [samples, setSamples] = useRecoilState(fos.selectedSamples);
   const labels = useRecoilValue(fos.selectedLabelIds);
   const ref = useRef();
   useOutsideClick(ref, () => open && setOpen(false));
@@ -209,6 +209,14 @@ const Selected = ({
 
   if (samples.size < 1 && !modal) {
     return null;
+  }
+
+  // when the user selects labels in sample modal, but no samples are selected, we add the current sample to selected samples
+  if (modal && labels.size > 0 && samples.size < 1) {
+    const currentSample = lookerRef?.current?.sample?.id;
+    if (currentSample) {
+      setSamples(new Set([currentSample]));
+    }
   }
 
   let text = samples.size.toLocaleString();

--- a/app/packages/core/src/components/Actions/utils.tsx
+++ b/app/packages/core/src/components/Actions/utils.tsx
@@ -12,7 +12,11 @@ import {
   isGroup,
   State,
 } from "@fiftyone/state";
-import { getFetchFunction, toSnakeCase } from "@fiftyone/utilities";
+import {
+  CLIPS_SAMPLE_FIELDS,
+  getFetchFunction,
+  toSnakeCase,
+} from "@fiftyone/utilities";
 
 export const SwitcherDiv = styled.div`
   border-bottom: 1px solid ${({ theme }) => theme.background.body};
@@ -170,21 +174,25 @@ export const tagParameters = ({
   targetLabels: boolean;
   sampleId: string | null;
 }) => {
-  const hasSelected =
-    selectedSamples.size || selectedLabels.length || hiddenLabels.length;
+  const shouldShowCurrentSample =
+    params.modal && selectedSamples.size == 0 && hiddenLabels.length == 0;
   const groups = groupData?.mode === "group";
+
+  const getSampleIds = () => {
+    if (shouldShowCurrentSample && !groups) {
+      return [sampleId];
+    } else if (selectedSamples.size) {
+      return [...selectedSamples];
+    }
+    return null;
+  };
 
   return {
     ...params,
     label_fields: activeFields,
     target_labels: targetLabels,
     slice: !params.modal && !groups ? groupData?.slice : null,
-    sample_ids:
-      params.modal && !hasSelected && !groups
-        ? [sampleId]
-        : selectedSamples.size
-        ? [...selectedSamples]
-        : null,
+    sample_ids: getSampleIds(),
     labels:
       params.modal && targetLabels && selectedLabels && selectedLabels.length
         ? toSnakeCase(selectedLabels)

--- a/app/packages/core/src/components/Actions/utils.tsx
+++ b/app/packages/core/src/components/Actions/utils.tsx
@@ -12,11 +12,7 @@ import {
   isGroup,
   State,
 } from "@fiftyone/state";
-import {
-  CLIPS_SAMPLE_FIELDS,
-  getFetchFunction,
-  toSnakeCase,
-} from "@fiftyone/utilities";
+import { getFetchFunction, toSnakeCase } from "@fiftyone/utilities";
 
 export const SwitcherDiv = styled.div`
   border-bottom: 1px solid ${({ theme }) => theme.background.body};

--- a/app/packages/state/src/recoil/atoms.ts
+++ b/app/packages/state/src/recoil/atoms.ts
@@ -111,6 +111,7 @@ export const loading = atom<boolean>({
   default: false,
 });
 
+// labels: whether label tag or sample tag
 export const tagging = atomFamily<boolean, { modal: boolean; labels: boolean }>(
   {
     key: "tagging",


### PR DESCRIPTION
fixes #2541 

## What changes are proposed in this pull request?

As a user, if I did not select any sample and I go into the sample modal view, then when I select labels on the sample, this sample will be added to the selected samples. This way, when I click add sample tag, the tag applies to the current sample, instead of all the samples in the dataset. 

Note: Select labels will not add current sample to selected sample, if the user already selected some samples. It only applies if selectedsample is a empty set. 

https://user-images.githubusercontent.com/17770824/213489763-fd8b088b-c39c-4e7a-bc55-9dd1605d9292.mov


## How is this patch tested? If it is not, please explain why.

See video.

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
