### PR TITLE
Updating copyrights

### DIFF
--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -97,7 +97,7 @@ For example, an import block might look like this:
 """
 Module docstring.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
@@ -184,7 +184,7 @@ Short module description here (generally one sentence max).
 
 A longer section can also be added here as appropriate.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/app/CONTRIBUTING.md
+++ b/app/CONTRIBUTING.md
@@ -18,4 +18,4 @@ See the App's [README.md](README.md) for installation instructions.
 
 ## Copyright
 
-Copyright 2017-2022, Voxel51, Inc.<br> voxel51.com
+Copyright 2017-2023, Voxel51, Inc.<br> voxel51.com

--- a/app/packages/components/src/components/HelpPanel/HelpPanel.tsx
+++ b/app/packages/components/src/components/HelpPanel/HelpPanel.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017-2022, Voxel51, Inc.
+ * Copyright 2017-2023, Voxel51, Inc.
  */
 import {
   lookerPanel,

--- a/app/packages/components/src/components/JSONPanel/JSONPanel.tsx
+++ b/app/packages/components/src/components/JSONPanel/JSONPanel.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017-2022, Voxel51, Inc.
+ * Copyright 2017-2023, Voxel51, Inc.
  */
 import { Copy as CopyIcon, Close as CloseIcon } from "@fiftyone/components";
 import {

--- a/app/packages/dataset/src/Dataset.tsx
+++ b/app/packages/dataset/src/Dataset.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017-2022, Voxel51, Inc.
+ * Copyright 2017-2023, Voxel51, Inc.
  */
 import {
   IconButton,

--- a/app/packages/flashlight/src/constants.ts
+++ b/app/packages/flashlight/src/constants.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017-2022, Voxel51, Inc.
+ * Copyright 2017-2023, Voxel51, Inc.
  */
 
 export const NUM_ROWS_PER_SECTION = 1;

--- a/app/packages/flashlight/src/index.ts
+++ b/app/packages/flashlight/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017-2022, Voxel51, Inc.
+ * Copyright 2017-2023, Voxel51, Inc.
  */
 import { MARGIN, NUM_ROWS_PER_SECTION } from "./constants";
 import SectionElement from "./section";

--- a/app/packages/flashlight/src/section.ts
+++ b/app/packages/flashlight/src/section.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017-2022, Voxel51, Inc.
+ * Copyright 2017-2023, Voxel51, Inc.
  */
 
 import { MARGIN } from "./constants";

--- a/app/packages/flashlight/src/state.ts
+++ b/app/packages/flashlight/src/state.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017-2022, Voxel51, Inc.
+ * Copyright 2017-2023, Voxel51, Inc.
  */
 
 export type Optional<T> = {

--- a/app/packages/flashlight/src/util.ts
+++ b/app/packages/flashlight/src/util.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017-2022, Voxel51, Inc.
+ * Copyright 2017-2023, Voxel51, Inc.
  */
 
 export function argMin<T>(array: T[]): number {

--- a/app/packages/flashlight/src/zooming.ts
+++ b/app/packages/flashlight/src/zooming.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017-2022, Voxel51, Inc.
+ * Copyright 2017-2023, Voxel51, Inc.
  */
 
 export const createScrollReader = (

--- a/app/packages/looker/src/constants.ts
+++ b/app/packages/looker/src/constants.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017-2022, Voxel51, Inc.
+ * Copyright 2017-2023, Voxel51, Inc.
  */
 
 import {

--- a/app/packages/looker/src/elements/base.ts
+++ b/app/packages/looker/src/elements/base.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017-2022, Voxel51, Inc.
+ * Copyright 2017-2023, Voxel51, Inc.
  */
 
 import { BaseState, DispatchEvent, Sample, StateUpdate } from "../state";

--- a/app/packages/looker/src/elements/common/actions.ts
+++ b/app/packages/looker/src/elements/common/actions.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017-2022, Voxel51, Inc.
+ * Copyright 2017-2023, Voxel51, Inc.
  */
 
 import { SCALE_FACTOR } from "../../constants";

--- a/app/packages/looker/src/elements/common/canvas.ts
+++ b/app/packages/looker/src/elements/common/canvas.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017-2022, Voxel51, Inc.
+ * Copyright 2017-2023, Voxel51, Inc.
  */
 
 import { SCALE_FACTOR } from "../../constants";

--- a/app/packages/looker/src/elements/common/controls.ts
+++ b/app/packages/looker/src/elements/common/controls.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017-2022, Voxel51, Inc.
+ * Copyright 2017-2023, Voxel51, Inc.
  */
 
 import { BaseState } from "../../state";

--- a/app/packages/looker/src/elements/common/error.ts
+++ b/app/packages/looker/src/elements/common/error.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017-2022, Voxel51, Inc.
+ * Copyright 2017-2023, Voxel51, Inc.
  */
 import copy from "copy-to-clipboard";
 

--- a/app/packages/looker/src/elements/common/index.ts
+++ b/app/packages/looker/src/elements/common/index.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017-2022, Voxel51, Inc.
+ * Copyright 2017-2023, Voxel51, Inc.
  */
 
 export { CanvasElement } from "./canvas";

--- a/app/packages/looker/src/elements/common/looker.ts
+++ b/app/packages/looker/src/elements/common/looker.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017-2022, Voxel51, Inc.
+ * Copyright 2017-2023, Voxel51, Inc.
  */
 
 import { SELECTION_TEXT } from "../../constants";

--- a/app/packages/looker/src/elements/common/options.ts
+++ b/app/packages/looker/src/elements/common/options.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017-2022, Voxel51, Inc.
+ * Copyright 2017-2023, Voxel51, Inc.
  */
 
 import { BaseState, VideoState } from "../../state";

--- a/app/packages/looker/src/elements/common/tags.ts
+++ b/app/packages/looker/src/elements/common/tags.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017-2022, Voxel51, Inc.
+ * Copyright 2017-2023, Voxel51, Inc.
  */
 
 import {

--- a/app/packages/looker/src/elements/common/thumbnail.ts
+++ b/app/packages/looker/src/elements/common/thumbnail.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017-2022, Voxel51, Inc.
+ * Copyright 2017-2023, Voxel51, Inc.
  */
 
 import { SELECTION_TEXT } from "../../constants";

--- a/app/packages/looker/src/elements/common/util.ts
+++ b/app/packages/looker/src/elements/common/util.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017-2022, Voxel51, Inc.
+ * Copyright 2017-2023, Voxel51, Inc.
  */
 
 import { prettify as pretty, useExternalLink } from "@fiftyone/utilities";

--- a/app/packages/looker/src/elements/frame.ts
+++ b/app/packages/looker/src/elements/frame.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017-2022, Voxel51, Inc.
+ * Copyright 2017-2023, Voxel51, Inc.
  */
 
 import { FrameState, StateUpdate } from "../state";

--- a/app/packages/looker/src/elements/image.ts
+++ b/app/packages/looker/src/elements/image.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017-2022, Voxel51, Inc.
+ * Copyright 2017-2023, Voxel51, Inc.
  */
 
 import { update } from "immutable";

--- a/app/packages/looker/src/elements/index.ts
+++ b/app/packages/looker/src/elements/index.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017-2022, Voxel51, Inc.
+ * Copyright 2017-2023, Voxel51, Inc.
  */
 import * as common from "./common";
 import * as frame from "./frame";

--- a/app/packages/looker/src/elements/util.ts
+++ b/app/packages/looker/src/elements/util.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017-2022, Voxel51, Inc.
+ * Copyright 2017-2023, Voxel51, Inc.
  */
 
 import { BaseState, StateUpdate } from "../state";

--- a/app/packages/looker/src/elements/video.ts
+++ b/app/packages/looker/src/elements/video.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017-2022, Voxel51, Inc.
+ * Copyright 2017-2023, Voxel51, Inc.
  */
 
 import { Optional, StateUpdate, VideoState } from "../state";

--- a/app/packages/looker/src/index.ts
+++ b/app/packages/looker/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017-2022, Voxel51, Inc.
+ * Copyright 2017-2023, Voxel51, Inc.
  */
 import {
   AppError,

--- a/app/packages/looker/src/numpy.ts
+++ b/app/packages/looker/src/numpy.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017-2022, Voxel51, Inc.
+ * Copyright 2017-2023, Voxel51, Inc.
  */
 
 import { Buffer } from "buffer";

--- a/app/packages/looker/src/overlays/base.ts
+++ b/app/packages/looker/src/overlays/base.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017-2022, Voxel51, Inc.
+ * Copyright 2017-2023, Voxel51, Inc.
  */
 
 import { getColor } from "@fiftyone/utilities";

--- a/app/packages/looker/src/overlays/classifications.ts
+++ b/app/packages/looker/src/overlays/classifications.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017-2022, Voxel51, Inc.
+ * Copyright 2017-2023, Voxel51, Inc.
  */
 
 import { REGRESSION, TEMPORAL_DETECTION } from "@fiftyone/utilities";

--- a/app/packages/looker/src/overlays/detection.ts
+++ b/app/packages/looker/src/overlays/detection.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017-2022, Voxel51, Inc.
+ * Copyright 2017-2023, Voxel51, Inc.
  */
 import { NONFINITES } from "@fiftyone/utilities";
 

--- a/app/packages/looker/src/overlays/heatmap.ts
+++ b/app/packages/looker/src/overlays/heatmap.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017-2022, Voxel51, Inc.
+ * Copyright 2017-2023, Voxel51, Inc.
  */
 import {
   get32BitColor,

--- a/app/packages/looker/src/overlays/index.ts
+++ b/app/packages/looker/src/overlays/index.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017-2022, Voxel51, Inc.
+ * Copyright 2017-2023, Voxel51, Inc.
  */
 import { LABEL_LISTS_MAP } from "@fiftyone/utilities";
 import { LABEL_TAGS_CLASSES } from "../constants";

--- a/app/packages/looker/src/overlays/keypoint.ts
+++ b/app/packages/looker/src/overlays/keypoint.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017-2022, Voxel51, Inc.
+ * Copyright 2017-2023, Voxel51, Inc.
  */
 
 import { getColor } from "@fiftyone/utilities";

--- a/app/packages/looker/src/overlays/polyline.ts
+++ b/app/packages/looker/src/overlays/polyline.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017-2022, Voxel51, Inc.
+ * Copyright 2017-2023, Voxel51, Inc.
  */
 
 import { INFO_COLOR, TOLERANCE } from "../constants";

--- a/app/packages/looker/src/overlays/segmentation.ts
+++ b/app/packages/looker/src/overlays/segmentation.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017-2022, Voxel51, Inc.
+ * Copyright 2017-2023, Voxel51, Inc.
  */
 
 import { getColor } from "@fiftyone/utilities";

--- a/app/packages/looker/src/overlays/util.ts
+++ b/app/packages/looker/src/overlays/util.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017-2022, Voxel51, Inc.
+ * Copyright 2017-2023, Voxel51, Inc.
  */
 
 import { INFO_COLOR } from "../constants";

--- a/app/packages/looker/src/processOverlays.ts
+++ b/app/packages/looker/src/processOverlays.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017-2022, Voxel51, Inc.
+ * Copyright 2017-2023, Voxel51, Inc.
  */
 
 import { CONTAINS, Overlay } from "./overlays/base";

--- a/app/packages/looker/src/state.ts
+++ b/app/packages/looker/src/state.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017-2022, Voxel51, Inc.
+ * Copyright 2017-2023, Voxel51, Inc.
  */
 
 import { Overlay } from "./overlays/base";

--- a/app/packages/looker/src/util.ts
+++ b/app/packages/looker/src/util.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017-2022, Voxel51, Inc.
+ * Copyright 2017-2023, Voxel51, Inc.
  */
 import { mergeWith } from "immutable";
 import mime from "mime";

--- a/app/packages/looker/src/worker.ts
+++ b/app/packages/looker/src/worker.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017-2022, Voxel51, Inc.
+ * Copyright 2017-2023, Voxel51, Inc.
  */
 
 import { getSampleSrc } from "@fiftyone/state/src/recoil/utils";

--- a/app/packages/utilities/src/color.ts
+++ b/app/packages/utilities/src/color.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017-2022, Voxel51, Inc.
+ * Copyright 2017-2023, Voxel51, Inc.
  */
 
 export type RGB = [number, number, number];

--- a/docs/generate_docs.bash
+++ b/docs/generate_docs.bash
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Generates documentation for FiftyOne.
 #
-# Copyright 2017-2022, Voxel51, Inc.
+# Copyright 2017-2023, Voxel51, Inc.
 # voxel51.com
 #
 

--- a/docs/scripts/make_model_zoo_docs.py
+++ b/docs/scripts/make_model_zoo_docs.py
@@ -2,7 +2,7 @@
 Script for generating the model zoo docs page contents
 ``docs/source/user_guide/model_zoo/models.rst``.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/docs/source/_templates/layout.html
+++ b/docs/source/_templates/layout.html
@@ -196,7 +196,7 @@ endblock %} {% block custom_footer %}
 
     <div class="footer__copyright">
       <ul class="list-inline">
-        <li>&copy; 2022 Voxel51 Inc.</li>
+        <li>&copy; 2023 Voxel51 Inc.</li>
         <li>
           <a href="{{link_privacypolicy}}">Privacy Policy</a>
         </li>

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -4,7 +4,7 @@ Sphinx configuration file.
 For a full list of available options, see:
 https://www.sphinx-doc.org/en/master/usage/configuration.html
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/docs/source/custom_directives.py
+++ b/docs/source/custom_directives.py
@@ -1,7 +1,7 @@
 """
 Sphinx custom directives.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/docs/source/recipes/image_deduplication_helpers.py
+++ b/docs/source/recipes/image_deduplication_helpers.py
@@ -15,7 +15,7 @@ Downloads a subset of CIFAR-100 and stores it to disk as follows::
 
 A random 5% of the samples are duplicates, instead of the original samples.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/docs/source/redirects.py
+++ b/docs/source/redirects.py
@@ -4,7 +4,7 @@ Sphinx utility that generates HTML page redirects specified in the
 
 Inspired by https://github.com/sphinx-contrib/redirects.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/docs/source/tutorials/query_flickr.py
+++ b/docs/source/tutorials/query_flickr.py
@@ -4,7 +4,7 @@ Simple utility to download images from Flickr based on a text query.
 Requires a user-specified API key, which can be obtained for free at
 https://www.flickr.com/services/apps/create.
 
-Copyright 2017-2022, Voxel51, Inc.
+Copyright 2017-2023, Voxel51, Inc.
 voxel51.com
 """
 import argparse

--- a/fiftyone/__init__.py
+++ b/fiftyone/__init__.py
@@ -3,7 +3,7 @@ FiftyOne: a powerful package for dataset curation, analysis, and visualization.
 
 See https://voxel51.com/fiftyone for more information.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/__public__.py
+++ b/fiftyone/__public__.py
@@ -1,7 +1,7 @@
 """
 FiftyOne's public interface.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/constants.py
+++ b/fiftyone/constants.py
@@ -1,7 +1,7 @@
 """
 Package-wide constants.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/core/__init__.py
+++ b/fiftyone/core/__init__.py
@@ -1,5 +1,5 @@
 """
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/core/aggregations.py
+++ b/fiftyone/core/aggregations.py
@@ -1,7 +1,7 @@
 """
 Aggregations.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/core/annotation.py
+++ b/fiftyone/core/annotation.py
@@ -1,7 +1,7 @@
 """
 Annotation runs framework.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/core/brain.py
+++ b/fiftyone/core/brain.py
@@ -1,7 +1,7 @@
 """
 Brain method runs framework.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/core/cli.py
+++ b/fiftyone/core/cli.py
@@ -1,7 +1,7 @@
 """
 Definition of the `fiftyone` command-line interface (CLI).
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/core/clips.py
+++ b/fiftyone/core/clips.py
@@ -1,7 +1,7 @@
 """
 Clips views.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -1,7 +1,7 @@
 """
 Interface for sample collections.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/core/config.py
+++ b/fiftyone/core/config.py
@@ -1,7 +1,7 @@
 """
 FiftyOne config.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/core/context.py
+++ b/fiftyone/core/context.py
@@ -1,7 +1,7 @@
 """
 Context utilities.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -1,7 +1,7 @@
 """
 FiftyOne datasets.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/core/document.py
+++ b/fiftyone/core/document.py
@@ -1,7 +1,7 @@
 """
 Base classes for objects that are backed by database documents.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/core/evaluation.py
+++ b/fiftyone/core/evaluation.py
@@ -1,7 +1,7 @@
 """
 Evaluation runs framework.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/core/expressions.py
+++ b/fiftyone/core/expressions.py
@@ -1,7 +1,7 @@
 """
 Expressions for :class:`fiftyone.core.stages.ViewStage` definitions.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/core/fields.py
+++ b/fiftyone/core/fields.py
@@ -1,7 +1,7 @@
 """
 Dataset sample fields.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/core/frame.py
+++ b/fiftyone/core/frame.py
@@ -1,7 +1,7 @@
 """
 Video frames.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/core/frame_utils.py
+++ b/fiftyone/core/frame_utils.py
@@ -1,7 +1,7 @@
 """
 Frame utilites.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/core/groups.py
+++ b/fiftyone/core/groups.py
@@ -1,7 +1,7 @@
 """
 Sample groups.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/core/json.py
+++ b/fiftyone/core/json.py
@@ -1,7 +1,7 @@
 """
 FiftyOne JSON handling
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/core/labels.py
+++ b/fiftyone/core/labels.py
@@ -1,7 +1,7 @@
 """
 Labels stored in dataset samples.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/core/logging.py
+++ b/fiftyone/core/logging.py
@@ -1,7 +1,7 @@
 """
 Logging utilities.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/core/media.py
+++ b/fiftyone/core/media.py
@@ -1,7 +1,7 @@
 """
 Sample media utilities.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/core/metadata.py
+++ b/fiftyone/core/metadata.py
@@ -1,7 +1,7 @@
 """
 Metadata stored in dataset samples.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/core/models.py
+++ b/fiftyone/core/models.py
@@ -1,7 +1,7 @@
 """
 FiftyOne models.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/core/odm/__init__.py
+++ b/fiftyone/core/odm/__init__.py
@@ -1,7 +1,7 @@
 """
 ODM package declaration.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/core/odm/database.py
+++ b/fiftyone/core/odm/database.py
@@ -1,7 +1,7 @@
 """
 Database utilities.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/core/odm/dataset.py
+++ b/fiftyone/core/odm/dataset.py
@@ -1,7 +1,7 @@
 """
 Documents that track datasets and their sample schemas in the database.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/core/odm/document.py
+++ b/fiftyone/core/odm/document.py
@@ -1,7 +1,7 @@
 """
 Base classes for documents that back dataset contents.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/core/odm/embedded_document.py
+++ b/fiftyone/core/odm/embedded_document.py
@@ -1,7 +1,7 @@
 """
 Base classes for documents that back dataset contents.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/core/odm/frame.py
+++ b/fiftyone/core/odm/frame.py
@@ -1,7 +1,7 @@
 """
 Backing document classes for :class:`fiftyone.core.frame.Frame` instances.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/core/odm/mixins.py
+++ b/fiftyone/core/odm/mixins.py
@@ -1,7 +1,7 @@
 """
 Mixins and helpers for dataset backing documents.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/core/odm/runs.py
+++ b/fiftyone/core/odm/runs.py
@@ -1,7 +1,7 @@
 """
 Dataset run documents.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/core/odm/sample.py
+++ b/fiftyone/core/odm/sample.py
@@ -42,7 +42,7 @@ type :class:`NoDatasetSampleDocument` to type ``dataset._sample_doc_cls``::
     dataset.add_sample(sample)
     sample._doc  # my_dataset(DatasetSampleDocument)
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/core/odm/utils.py
+++ b/fiftyone/core/odm/utils.py
@@ -1,7 +1,7 @@
 """
 Utilities for documents.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/core/odm/views.py
+++ b/fiftyone/core/odm/views.py
@@ -1,7 +1,7 @@
 """
 Saved view documents.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/core/patches.py
+++ b/fiftyone/core/patches.py
@@ -1,7 +1,7 @@
 """
 Patches views.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/core/plots/__init__.py
+++ b/fiftyone/core/plots/__init__.py
@@ -1,7 +1,7 @@
 """
 Plotting framework.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/core/plots/base.py
+++ b/fiftyone/core/plots/base.py
@@ -1,7 +1,7 @@
 """
 Base plotting definitions.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/core/plots/manager.py
+++ b/fiftyone/core/plots/manager.py
@@ -1,7 +1,7 @@
 """
 Session plot manager.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/core/plots/matplotlib.py
+++ b/fiftyone/core/plots/matplotlib.py
@@ -1,7 +1,7 @@
 """
 Matplotlib plots.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/core/plots/plotly.py
+++ b/fiftyone/core/plots/plotly.py
@@ -1,7 +1,7 @@
 """
 Plotly plots.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/core/plots/utils.py
+++ b/fiftyone/core/plots/utils.py
@@ -1,7 +1,7 @@
 """
 Plotting utils.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/core/plots/views.py
+++ b/fiftyone/core/plots/views.py
@@ -1,7 +1,7 @@
 """
 Plotly-powered view plots.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/core/runs.py
+++ b/fiftyone/core/runs.py
@@ -1,7 +1,7 @@
 """
 Dataset runs framework.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/core/sample.py
+++ b/fiftyone/core/sample.py
@@ -1,7 +1,7 @@
 """
 Dataset samples.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/core/service.py
+++ b/fiftyone/core/service.py
@@ -1,7 +1,7 @@
 """
 FiftyOne Services.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/core/session/__init__.py
+++ b/fiftyone/core/session/__init__.py
@@ -1,7 +1,7 @@
 """
 Session definitions for interacting with the FiftyOne App.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/core/session/client.py
+++ b/fiftyone/core/session/client.py
@@ -1,7 +1,7 @@
 """
 Session server-sent events client.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/core/session/events.py
+++ b/fiftyone/core/session/events.py
@@ -1,7 +1,7 @@
 """
 Session events.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/core/session/notebooks.py
+++ b/fiftyone/core/session/notebooks.py
@@ -1,7 +1,7 @@
 """
 Session notebook handling.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/core/session/session.py
+++ b/fiftyone/core/session/session.py
@@ -1,7 +1,7 @@
 """
 Session class for interacting with the FiftyOne App.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/core/session/templates.py
+++ b/fiftyone/core/session/templates.py
@@ -1,7 +1,7 @@
 """
 Notebook Session HTML templates
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/core/singletons.py
+++ b/fiftyone/core/singletons.py
@@ -1,7 +1,7 @@
 """
 FiftyOne singleton implementations.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/core/spaces.py
+++ b/fiftyone/core/spaces.py
@@ -1,7 +1,7 @@
 """
 App Space configuration.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/core/stages.py
+++ b/fiftyone/core/stages.py
@@ -1,7 +1,7 @@
 """
 View stages.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/core/state.py
+++ b/fiftyone/core/state.py
@@ -1,7 +1,7 @@
 """
 Defines the shared state between the FiftyOne App and backend.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/core/uid.py
+++ b/fiftyone/core/uid.py
@@ -1,7 +1,7 @@
 """
 Utilities for usage analytics.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/core/utils.py
+++ b/fiftyone/core/utils.py
@@ -1,7 +1,7 @@
 """
 Core utilities.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/core/validation.py
+++ b/fiftyone/core/validation.py
@@ -1,7 +1,7 @@
 """
 Validation utilities.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/core/video.py
+++ b/fiftyone/core/video.py
@@ -1,7 +1,7 @@
 """
 Video frame views.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/core/view.py
+++ b/fiftyone/core/view.py
@@ -1,7 +1,7 @@
 """
 Dataset views.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/migrations/__init__.py
+++ b/fiftyone/migrations/__init__.py
@@ -1,7 +1,7 @@
 """
 FiftyOne's migration interface.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/migrations/revisions/admin/v0_15_0.py
+++ b/fiftyone/migrations/revisions/admin/v0_15_0.py
@@ -1,7 +1,7 @@
 """
 FiftyOne v0.15.0 admin revision.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/migrations/revisions/admin/v0_15_1.py
+++ b/fiftyone/migrations/revisions/admin/v0_15_1.py
@@ -1,7 +1,7 @@
 """
 FiftyOne v0.15.1 admin revision.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/migrations/revisions/v0_11_2.py
+++ b/fiftyone/migrations/revisions/v0_11_2.py
@@ -1,7 +1,7 @@
 """
 FiftyOne v0.11.2 revision.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/migrations/revisions/v0_13_0.py
+++ b/fiftyone/migrations/revisions/v0_13_0.py
@@ -1,7 +1,7 @@
 """
 FiftyOne v0.13.0 revision.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/migrations/revisions/v0_14_0.py
+++ b/fiftyone/migrations/revisions/v0_14_0.py
@@ -1,7 +1,7 @@
 """
 FiftyOne v0.14.0 revision.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/migrations/revisions/v0_15_1.py
+++ b/fiftyone/migrations/revisions/v0_15_1.py
@@ -1,7 +1,7 @@
 """
 FiftyOne v0.15.1 revision.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/migrations/revisions/v0_16_0.py
+++ b/fiftyone/migrations/revisions/v0_16_0.py
@@ -1,7 +1,7 @@
 """
 FiftyOne v0.16.0 revision.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/migrations/revisions/v0_16_1.py
+++ b/fiftyone/migrations/revisions/v0_16_1.py
@@ -5,7 +5,7 @@ This revision is identical to v0.16.0 except it does not affect
 app sidebar groups and it fixes label list fields, e.g. Detections,
 which were skipped in v0.16.0
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/migrations/revisions/v0_16_3.py
+++ b/fiftyone/migrations/revisions/v0_16_3.py
@@ -1,7 +1,7 @@
 """
 FiftyOne v0.16.3 revision.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/migrations/revisions/v0_17_0.py
+++ b/fiftyone/migrations/revisions/v0_17_0.py
@@ -1,7 +1,7 @@
 """
 FiftyOne v0.17.0 revision.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/migrations/revisions/v0_18_0.py
+++ b/fiftyone/migrations/revisions/v0_18_0.py
@@ -1,7 +1,7 @@
 """
 FiftyOne v0.18.0 revision.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/migrations/revisions/v0_19_0.py
+++ b/fiftyone/migrations/revisions/v0_19_0.py
@@ -1,7 +1,7 @@
 """
 FiftyOne v0.19.0 revision.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/migrations/revisions/v0_6_2.py
+++ b/fiftyone/migrations/revisions/v0_6_2.py
@@ -1,7 +1,7 @@
 """
 FiftyOne v0.6.2 revision.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/migrations/revisions/v0_6_5.py
+++ b/fiftyone/migrations/revisions/v0_6_5.py
@@ -1,7 +1,7 @@
 """
 FiftyOne v0.6.5 revision.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/migrations/revisions/v0_7_2.py
+++ b/fiftyone/migrations/revisions/v0_7_2.py
@@ -1,7 +1,7 @@
 """
 FiftyOne v0.7.2 revision.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/migrations/revisions/v0_7_3.py
+++ b/fiftyone/migrations/revisions/v0_7_3.py
@@ -1,7 +1,7 @@
 """
 FiftyOne v0.7.3 revision.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/migrations/revisions/v0_7_4.py
+++ b/fiftyone/migrations/revisions/v0_7_4.py
@@ -1,7 +1,7 @@
 """
 FiftyOne v0.7.4 revision.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/migrations/revisions/v0_8_0.py
+++ b/fiftyone/migrations/revisions/v0_8_0.py
@@ -1,7 +1,7 @@
 """
 FiftyOne v0.8.0 revision.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/migrations/revisions/v0_9_4.py
+++ b/fiftyone/migrations/revisions/v0_9_4.py
@@ -1,7 +1,7 @@
 """
 FiftyOne v0.9.4 revision.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/migrations/runner.py
+++ b/fiftyone/migrations/runner.py
@@ -1,7 +1,7 @@
 """
 FiftyOne migrations runner.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/server/__init__.py
+++ b/fiftyone/server/__init__.py
@@ -1,7 +1,7 @@
 """
 FiftyOne Server
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/server/aggregate.py
+++ b/fiftyone/server/aggregate.py
@@ -1,7 +1,7 @@
 """
 FiftyOne Server aggregations
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/server/app.py
+++ b/fiftyone/server/app.py
@@ -1,7 +1,7 @@
 """
 FiftyOne Server app.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/server/context.py
+++ b/fiftyone/server/context.py
@@ -1,7 +1,7 @@
 """
 FiftyOne Server context
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/server/data.py
+++ b/fiftyone/server/data.py
@@ -1,7 +1,7 @@
 """
 FiftyOne Server data
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/server/dataloader.py
+++ b/fiftyone/server/dataloader.py
@@ -1,7 +1,7 @@
 """
 FiftyOne Server dataloader
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/server/decorators.py
+++ b/fiftyone/server/decorators.py
@@ -1,7 +1,7 @@
 """
 FiftyOne Server decorators
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/server/events.py
+++ b/fiftyone/server/events.py
@@ -1,7 +1,7 @@
 """
 FiftyOne Server events
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/server/extensions.py
+++ b/fiftyone/server/extensions.py
@@ -1,7 +1,7 @@
 """
 FiftyOne Server extensions
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/server/filters.py
+++ b/fiftyone/server/filters.py
@@ -1,7 +1,7 @@
 """
 FiftyOne Server filter inputs
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/server/interfaces.py
+++ b/fiftyone/server/interfaces.py
@@ -1,7 +1,7 @@
 """
 FiftyOne Server interfaces
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/server/main.py
+++ b/fiftyone/server/main.py
@@ -1,7 +1,7 @@
 """
 FiftyOne Server main
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/server/metadata.py
+++ b/fiftyone/server/metadata.py
@@ -1,7 +1,7 @@
 """
 FiftyOne Server JIT metadata utilities
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/server/mutation.py
+++ b/fiftyone/server/mutation.py
@@ -1,7 +1,7 @@
 """
 FiftyOne Server mutations
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/server/paginator.py
+++ b/fiftyone/server/paginator.py
@@ -1,7 +1,7 @@
 """
 FiftyOne Server paginator
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/server/query.py
+++ b/fiftyone/server/query.py
@@ -1,7 +1,7 @@
 """
 FiftyOne Server queries
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/server/routes/__init__.py
+++ b/fiftyone/server/routes/__init__.py
@@ -1,7 +1,7 @@
 """
 FiftyOne Server routes
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/server/routes/aggregate.py
+++ b/fiftyone/server/routes/aggregate.py
@@ -1,7 +1,7 @@
 """
 FiftyOne Server /aggregation and /tagging routes
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/server/routes/embeddings.py
+++ b/fiftyone/server/routes/embeddings.py
@@ -1,7 +1,7 @@
 """
 FiftyOne Server ``/embeddings`` route.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/server/routes/event.py
+++ b/fiftyone/server/routes/event.py
@@ -1,7 +1,7 @@
 """
 FiftyOne Server /event route
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/server/routes/events.py
+++ b/fiftyone/server/routes/events.py
@@ -1,7 +1,7 @@
 """
 FiftyOne Server /events route
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/server/routes/fiftyone.py
+++ b/fiftyone/server/routes/fiftyone.py
@@ -1,7 +1,7 @@
 """
 FiftyOne Server /fiftyone route
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/server/routes/frames.py
+++ b/fiftyone/server/routes/frames.py
@@ -1,7 +1,7 @@
 """
 FiftyOne Server /frames route
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/server/routes/media.py
+++ b/fiftyone/server/routes/media.py
@@ -1,7 +1,7 @@
 """
 FiftyOne Server /media route
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/server/routes/plugins.py
+++ b/fiftyone/server/routes/plugins.py
@@ -1,7 +1,7 @@
 """
 FiftyOne Server ``/plugins`` route.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/server/routes/samples.py
+++ b/fiftyone/server/routes/samples.py
@@ -1,7 +1,7 @@
 """
 FiftyOne Server /samples route
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/server/routes/screenshot.py
+++ b/fiftyone/server/routes/screenshot.py
@@ -1,7 +1,7 @@
 """
 FiftyOne Server /screenshot route
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/server/routes/select.py
+++ b/fiftyone/server/routes/select.py
@@ -1,7 +1,7 @@
 """
 FiftyOne Server /select route
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/server/routes/sort.py
+++ b/fiftyone/server/routes/sort.py
@@ -1,7 +1,7 @@
 """
 FiftyOne Server /sort route
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/server/routes/stages.py
+++ b/fiftyone/server/routes/stages.py
@@ -1,7 +1,7 @@
 """
 FiftyOne Server /stages route
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/server/routes/tag.py
+++ b/fiftyone/server/routes/tag.py
@@ -1,7 +1,7 @@
 """
 FiftyOne Server /tag route
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/server/routes/tagging.py
+++ b/fiftyone/server/routes/tagging.py
@@ -1,7 +1,7 @@
 """
 FiftyOne Server /tagging route
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/server/routes/values.py
+++ b/fiftyone/server/routes/values.py
@@ -1,7 +1,7 @@
 """
 FiftyOne Server /values route
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/server/samples.py
+++ b/fiftyone/server/samples.py
@@ -1,7 +1,7 @@
 """
 FiftyOne Server samples pagination
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/server/scalars.py
+++ b/fiftyone/server/scalars.py
@@ -1,7 +1,7 @@
 """
 FiftyOne Server GraphQL scalars
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/server/tags.py
+++ b/fiftyone/server/tags.py
@@ -1,7 +1,7 @@
 """
 FiftyOne Server tags and tagging
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/server/utils.py
+++ b/fiftyone/server/utils.py
@@ -1,7 +1,7 @@
 """
 FiftyOne Server utils
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/server/view.py
+++ b/fiftyone/server/view.py
@@ -1,7 +1,7 @@
 """
 FiftyOne Server view
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/service/__init__.py
+++ b/fiftyone/service/__init__.py
@@ -1,7 +1,7 @@
 """
 FiftyOne service support.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/service/ipc.py
+++ b/fiftyone/service/ipc.py
@@ -1,7 +1,7 @@
 """
 Inter-process communication handling.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/service/main.py
+++ b/fiftyone/service/main.py
@@ -23,7 +23,7 @@ script will continue running in the background and keep the child process alive
 until all registered clients, including the original parent process, have
 exited.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/service/util.py
+++ b/fiftyone/service/util.py
@@ -1,7 +1,7 @@
 """
 FiftyOne service utilities.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/types/__init__.py
+++ b/fiftyone/types/__init__.py
@@ -1,7 +1,7 @@
 """
 FiftyOne types.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/types/dataset_types.py
+++ b/fiftyone/types/dataset_types.py
@@ -1,7 +1,7 @@
 """
 FiftyOne dataset types.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/utils/__init__.py
+++ b/fiftyone/utils/__init__.py
@@ -1,5 +1,5 @@
 """
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/utils/activitynet.py
+++ b/fiftyone/utils/activitynet.py
@@ -2,7 +2,7 @@
 Utilities for working with the
 `ActivityNet dataset <http://activity-net.org/index.html>`.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/utils/annotations.py
+++ b/fiftyone/utils/annotations.py
@@ -1,7 +1,7 @@
 """
 Annotation utilities.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/utils/aws.py
+++ b/fiftyone/utils/aws.py
@@ -1,7 +1,7 @@
 """
 Utilities for working with `Amazon Web Services <https://aws.amazon.com>`.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/utils/bdd.py
+++ b/fiftyone/utils/bdd.py
@@ -2,7 +2,7 @@
 Utilities for working with datasets in
 `Berkeley DeepDrive (BDD) format <https://bdd-data.berkeley.edu>`_.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/utils/beam.py
+++ b/fiftyone/utils/beam.py
@@ -1,7 +1,7 @@
 """
 `Apache Beam <https://beam.apache.org>`_ utilities.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/utils/cityscapes.py
+++ b/fiftyone/utils/cityscapes.py
@@ -2,7 +2,7 @@
 Utilities for working with the
 `Cityscapes dataset <https://www.cityscapes-dataset.com>`_.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/utils/clip/__init__.py
+++ b/fiftyone/utils/clip/__init__.py
@@ -1,6 +1,6 @@
 """CLIP model utils.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/utils/clip/model.py
+++ b/fiftyone/utils/clip/model.py
@@ -1,7 +1,7 @@
 """
 CLIP model from https://github.com/openai/CLIP.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/utils/clip/tokenizer.py
+++ b/fiftyone/utils/clip/tokenizer.py
@@ -1,7 +1,7 @@
 """
 CLIP text tokenizer from https://github.com/openai/CLIP.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/utils/clip/zoo.py
+++ b/fiftyone/utils/clip/zoo.py
@@ -1,7 +1,7 @@
 """
 CLIP model wrapper for the FiftyOne Model Zoo.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/utils/coco.py
+++ b/fiftyone/utils/coco.py
@@ -2,7 +2,7 @@
 Utilities for working with datasets in
 `COCO format <https://cocodataset.org/#format-data>`_.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/utils/csv.py
+++ b/fiftyone/utils/csv.py
@@ -1,7 +1,7 @@
 """
 CSV utilities.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/utils/cvat.py
+++ b/fiftyone/utils/cvat.py
@@ -2,7 +2,7 @@
 Utilities for working with datasets in
 `CVAT format <https://github.com/opencv/cvat>`_.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/utils/data/__init__.py
+++ b/fiftyone/utils/data/__init__.py
@@ -1,7 +1,7 @@
 """
 Data utilities.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/utils/data/base.py
+++ b/fiftyone/utils/data/base.py
@@ -1,7 +1,7 @@
 """
 Data utilities.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/utils/data/converters.py
+++ b/fiftyone/utils/data/converters.py
@@ -1,7 +1,7 @@
 """
 Dataset format conversion utilities.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/utils/data/exporters.py
+++ b/fiftyone/utils/data/exporters.py
@@ -1,7 +1,7 @@
 """
 Dataset exporters.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/utils/data/importers.py
+++ b/fiftyone/utils/data/importers.py
@@ -1,7 +1,7 @@
 """
 Dataset importers.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/utils/data/ingestors.py
+++ b/fiftyone/utils/data/ingestors.py
@@ -1,7 +1,7 @@
 """
 Dataset ingestors.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/utils/data/parsers.py
+++ b/fiftyone/utils/data/parsers.py
@@ -1,7 +1,7 @@
 """
 Sample parsers.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/utils/dicom.py
+++ b/fiftyone/utils/dicom.py
@@ -1,7 +1,7 @@
 """
 DICOM utilities.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/utils/eta.py
+++ b/fiftyone/utils/eta.py
@@ -2,7 +2,7 @@
 Utilities for interfacing with the
 `ETA library <https://github.com/voxel51/eta>`_.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/utils/eval/__init__.py
+++ b/fiftyone/utils/eval/__init__.py
@@ -1,7 +1,7 @@
 """
 Evaluation utilities.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/utils/eval/activitynet.py
+++ b/fiftyone/utils/eval/activitynet.py
@@ -1,7 +1,7 @@
 """
 ActivityNet-style temporal detection evaluation.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/utils/eval/base.py
+++ b/fiftyone/utils/eval/base.py
@@ -1,7 +1,7 @@
 """
 Base evaluation methods.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/utils/eval/classification.py
+++ b/fiftyone/utils/eval/classification.py
@@ -1,7 +1,7 @@
 """
 Classification evaluation.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/utils/eval/coco.py
+++ b/fiftyone/utils/eval/coco.py
@@ -1,7 +1,7 @@
 """
 COCO-style detection evaluation.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/utils/eval/detection.py
+++ b/fiftyone/utils/eval/detection.py
@@ -1,7 +1,7 @@
 """
 Detection evaluation.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/utils/eval/openimages.py
+++ b/fiftyone/utils/eval/openimages.py
@@ -1,7 +1,7 @@
 """
 Open Images-style detection evaluation.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/utils/eval/regression.py
+++ b/fiftyone/utils/eval/regression.py
@@ -1,7 +1,7 @@
 """
 Regression evaluation.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/utils/eval/segmentation.py
+++ b/fiftyone/utils/eval/segmentation.py
@@ -1,7 +1,7 @@
 """
 Segmentation evaluation.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/utils/fiw.py
+++ b/fiftyone/utils/fiw.py
@@ -2,7 +2,7 @@
 Utilities for working with the
 `Families in the Wild dataset <https://web.northeastern.edu/smilelab/fiw/>`_.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/utils/flash.py
+++ b/fiftyone/utils/flash.py
@@ -2,7 +2,7 @@
 Utilities for working with
 `Lightning Flash <https://github.com/PyTorchLightning/lightning-flash>`_.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/utils/geojson.py
+++ b/fiftyone/utils/geojson.py
@@ -1,7 +1,7 @@
 """
 GeoJSON utilities.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/utils/geotiff.py
+++ b/fiftyone/utils/geotiff.py
@@ -1,7 +1,7 @@
 """
 GeoTIFF utilities.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/utils/groups.py
+++ b/fiftyone/utils/groups.py
@@ -1,7 +1,7 @@
 """
 Grouped dataset utilities.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/utils/hmdb51.py
+++ b/fiftyone/utils/hmdb51.py
@@ -2,7 +2,7 @@
 Utilities for working with the
 `HMDB51 dataset <https://serre-lab.clps.brown.edu/resource/hmdb-a-large-human-motion-database>`_.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/utils/image.py
+++ b/fiftyone/utils/image.py
@@ -1,7 +1,7 @@
 """
 Image utilities.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/utils/imagenet.py
+++ b/fiftyone/utils/imagenet.py
@@ -1,7 +1,7 @@
 """
 Utilities for working with the `ImageNet dataset <http://www.image-net.org>`_.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/utils/iou.py
+++ b/fiftyone/utils/iou.py
@@ -1,7 +1,7 @@
 """
 Intersection over union (IoU) utilities.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/utils/kinetics.py
+++ b/fiftyone/utils/kinetics.py
@@ -2,7 +2,7 @@
 Utilities for working with the
 `Kinetics dataset <https://deepmind.com/research/open-source/kinetics>`.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/utils/kitti.py
+++ b/fiftyone/utils/kitti.py
@@ -2,7 +2,7 @@
 Utilities for working with datasets in
 `KITTI format <http://www.cvlibs.net/datasets/kitti/eval_object.php>`_.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/utils/labelbox.py
+++ b/fiftyone/utils/labelbox.py
@@ -2,7 +2,7 @@
 Utilities for working with annotations in
 `Labelbox format <https://labelbox.com/docs/exporting-data/export-format-detail>`_.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/utils/labels.py
+++ b/fiftyone/utils/labels.py
@@ -1,7 +1,7 @@
 """
 Label utilities.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/utils/labelstudio.py
+++ b/fiftyone/utils/labelstudio.py
@@ -2,7 +2,7 @@
 Utilities for working with annotations in
 `Label Studio <https://labelstud.io>`_.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/utils/lfw.py
+++ b/fiftyone/utils/lfw.py
@@ -2,7 +2,7 @@
 Utilities for working with the
 `Labeled Faces in the Wild dataset <http://vis-www.cs.umass.edu/lfw>`_.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/utils/openimages.py
+++ b/fiftyone/utils/openimages.py
@@ -3,7 +3,7 @@ Utilities for working with the
 `Open Images <https://storage.googleapis.com/openimages/web/index.html>`
 dataset.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/utils/openlabel.py
+++ b/fiftyone/utils/openlabel.py
@@ -2,7 +2,7 @@
 Utilities for working with datasets in
 `OpenLABEL format <https://www.asam.net/index.php?eID=dumpFile&t=f&f=3876&token=413e8c85031ae64cc35cf42d0768627514868b2f>`_.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/utils/patches.py
+++ b/fiftyone/utils/patches.py
@@ -1,7 +1,7 @@
 """
 Image patch utilities.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/utils/quickstart.py
+++ b/fiftyone/utils/quickstart.py
@@ -1,7 +1,7 @@
 """
 FiftyOne quickstart.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/utils/random.py
+++ b/fiftyone/utils/random.py
@@ -1,7 +1,7 @@
 """
 Random sampling utilities.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/utils/scale.py
+++ b/fiftyone/utils/scale.py
@@ -2,7 +2,7 @@
 Utilities for working with annotations in
 `Scale AI format <https://docs.scale.com/reference#annotation>`_.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/utils/tf.py
+++ b/fiftyone/utils/tf.py
@@ -1,7 +1,7 @@
 """
 TensorFlow utilities.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/utils/torch.py
+++ b/fiftyone/utils/torch.py
@@ -1,7 +1,7 @@
 """
 PyTorch utilities.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/utils/ucf101.py
+++ b/fiftyone/utils/ucf101.py
@@ -2,7 +2,7 @@
 Utilities for working with the
 `UCF101 dataset <https://www.crcv.ucf.edu/research/data-sets/ucf101>`_.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/utils/video.py
+++ b/fiftyone/utils/video.py
@@ -1,7 +1,7 @@
 """
 Video utilities.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/utils/voc.py
+++ b/fiftyone/utils/voc.py
@@ -2,7 +2,7 @@
 Utilities for working with datasets in
 `VOC format <http://host.robots.ox.ac.uk/pascal/VOC>`_.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/utils/yolo.py
+++ b/fiftyone/utils/yolo.py
@@ -1,7 +1,7 @@
 """
 Utilities for working with datasets in YOLO format.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/utils/youtube.py
+++ b/fiftyone/utils/youtube.py
@@ -1,7 +1,7 @@
 """
 Utilities for working with `YouTube <https://youtube.com>`.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/zoo/__init__.py
+++ b/fiftyone/zoo/__init__.py
@@ -1,7 +1,7 @@
 """
 The FiftyOne Zoo.
 
-Copyright 2017-2022, Voxel51, Inc.
+Copyright 2017-2023, Voxel51, Inc.
 voxel51.com
 """
 import types

--- a/fiftyone/zoo/datasets/__init__.py
+++ b/fiftyone/zoo/datasets/__init__.py
@@ -4,7 +4,7 @@ The FiftyOne Dataset Zoo.
 This package defines a collection of open source datasets made available for
 download via FiftyOne.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/zoo/datasets/base.py
+++ b/fiftyone/zoo/datasets/base.py
@@ -1,7 +1,7 @@
 """
 FiftyOne Zoo Datasets provided natively by the library.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/zoo/datasets/tf.py
+++ b/fiftyone/zoo/datasets/tf.py
@@ -1,7 +1,7 @@
 """
 FiftyOne Zoo Datasets provided by ``tensorflow_datasets``.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/zoo/datasets/torch.py
+++ b/fiftyone/zoo/datasets/torch.py
@@ -1,7 +1,7 @@
 """
 FiftyOne Zoo Datasets provided by :mod:`torchvision:torchvision.datasets`.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/zoo/models/__init__.py
+++ b/fiftyone/zoo/models/__init__.py
@@ -1,7 +1,7 @@
 """
 The FiftyOne Model Zoo.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/fiftyone/zoo/models/torch.py
+++ b/fiftyone/zoo/models/torch.py
@@ -1,7 +1,7 @@
 """
 FiftyOne Zoo models provided by :mod:`torchvision:torchvision.models`.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/install.bash
+++ b/install.bash
@@ -4,7 +4,7 @@
 # Usage:
 #   bash install.bash
 #
-# Copyright 2017-2022, Voxel51, Inc.
+# Copyright 2017-2023, Voxel51, Inc.
 # voxel51.com
 #
 

--- a/package/db/setup.py
+++ b/package/db/setup.py
@@ -2,7 +2,7 @@
 """
 Installs the ``fiftyone-db`` package.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/package/desktop/setup.py
+++ b/package/desktop/setup.py
@@ -2,7 +2,7 @@
 """
 Installs the ``fiftyone-desktop`` package.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 """
 Installs FiftyOne.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/tests/benchmarking/add_samples_benchmark.py
+++ b/tests/benchmarking/add_samples_benchmark.py
@@ -3,7 +3,7 @@ Benchmarking for :func:`fiftyone.core.dataset.Dataset.add_samples`.
 
 Results are written to `add_samples_benchmark.log`.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/tests/benchmarking/cifar10_benchmark.py
+++ b/tests/benchmarking/cifar10_benchmark.py
@@ -3,7 +3,7 @@ Benchmarking CRUD operations on CIFAR10.
 
 Results are appended to `cifar10_benchmark.log`.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/tests/intensive/collections_tests.py
+++ b/tests/intensive/collections_tests.py
@@ -5,7 +5,7 @@ All of these tests are designed to be run manually via::
 
     pytest tests/intensive/collections_tests.py -s -k test_<name>
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/tests/intensive/cvat_tests.py
+++ b/tests/intensive/cvat_tests.py
@@ -5,7 +5,7 @@ You must run these tests interactively as follows::
 
     python tests/intensive/cvat_tests.py
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/tests/intensive/dataset_zoo_tests.py
+++ b/tests/intensive/dataset_zoo_tests.py
@@ -5,7 +5,7 @@ You must run these tests interactively as follows::
 
     pytest tests/intensive/dataset_zoo_tests.py -s -k <test_case>
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/tests/intensive/evaluation_tests.py
+++ b/tests/intensive/evaluation_tests.py
@@ -5,7 +5,7 @@ You must run these tests interactively as follows::
 
     pytest tests/intensive/evaluation_tests.py -s -k <test_case>
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/tests/intensive/import_export_tests.py
+++ b/tests/intensive/import_export_tests.py
@@ -5,7 +5,7 @@ You must run these tests interactively as follows::
 
     pytest tests/intensive/import_export_tests.py -s -k <test_case>
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/tests/intensive/labelbox_tests.py
+++ b/tests/intensive/labelbox_tests.py
@@ -5,7 +5,7 @@ You must run these tests interactively as follows::
 
     pytest tests/intensive/labelbox_tests.py -s -k <test_case>
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/tests/intensive/labelstudio_tests.py
+++ b/tests/intensive/labelstudio_tests.py
@@ -1,7 +1,7 @@
 """
 Tests for the :mod:`fiftyone.utils.labelstudio` module.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 =======

--- a/tests/intensive/lightning_flash_tests.py
+++ b/tests/intensive/lightning_flash_tests.py
@@ -5,7 +5,7 @@ You must run these tests interactively as follows::
 
     python tests/intensive/lightning_flash_tests.py
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/tests/intensive/merge_tests.py
+++ b/tests/intensive/merge_tests.py
@@ -5,7 +5,7 @@ All of these tests are designed to be run manually via::
 
     pytest tests/intensive/merge_tests.py -s -k test_<name>
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/tests/intensive/model_tests.py
+++ b/tests/intensive/model_tests.py
@@ -5,7 +5,7 @@ All of these tests are designed to be run manually via::
 
     pytest tests/intensive/model_tests.py -s -k test_<name>
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/tests/intensive/model_zoo_tests.py
+++ b/tests/intensive/model_zoo_tests.py
@@ -5,7 +5,7 @@ All of these tests are designed to be run manually via::
 
     pytest tests/intensive/model_zoo_tests.py -s -k test_<name>
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/tests/intensive/patches_tests.py
+++ b/tests/intensive/patches_tests.py
@@ -5,7 +5,7 @@ You must run these tests interactively as follows::
 
     pytest tests/intensive/patches_tests.py -s -k <test_case>
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/tests/intensive/scale_tests.py
+++ b/tests/intensive/scale_tests.py
@@ -5,7 +5,7 @@ You must run these tests interactively as follows::
 
     pytest tests/intensive/scale_tests.py -s -k <test_case>
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/tests/intensive/session_tests.py
+++ b/tests/intensive/session_tests.py
@@ -5,7 +5,7 @@ You must run these tests interactively as follows::
 
     pytest tests/intensive/session_tests.py -s -k <test_case>
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/tests/intensive/similarity_tests.py
+++ b/tests/intensive/similarity_tests.py
@@ -5,7 +5,7 @@ You must run these tests interactively as follows::
 
     pytest tests/intensive/similarity_tests.py -s -k <test_case>
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/tests/intensive/utils_tests.py
+++ b/tests/intensive/utils_tests.py
@@ -1,7 +1,7 @@
 """
 Utils tests.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/tests/intensive/video_tests.py
+++ b/tests/intensive/video_tests.py
@@ -5,7 +5,7 @@ You must run these tests interactively as follows::
 
     pytest tests/intensive/video_tests.py -s -k <test_case>
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/tests/intensive/view_tests.py
+++ b/tests/intensive/view_tests.py
@@ -5,7 +5,7 @@ All of these tests are designed to be run manually via::
 
     pytest tests/intensive/view_tests.py -s -k test_<name>
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/tests/ipc_tests.py
+++ b/tests/ipc_tests.py
@@ -1,7 +1,7 @@
 """
 Tests related to inter-process communication (for services).
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/tests/isolated/import_deps_test.py
+++ b/tests/isolated/import_deps_test.py
@@ -2,7 +2,7 @@
 Test that the fiftyone core package does not depend on any extra packages that
 are intended to be manually installed by users.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/tests/isolated/import_time_test.py
+++ b/tests/isolated/import_time_test.py
@@ -1,7 +1,7 @@
 """
 Test that fiftyone can be imported in a reasonable amount of time.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/tests/isolated/service_tests.py
+++ b/tests/isolated/service_tests.py
@@ -1,7 +1,7 @@
 """
 Service tests.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/tests/misc/selection_tests.py
+++ b/tests/misc/selection_tests.py
@@ -2,7 +2,7 @@
 Unit tests for :class:`fiftyone.core.stages.SelectObjects` and
 :class:`fiftyone.core.stages.ExcludeObjects`.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/tests/misc/torch_tests.py
+++ b/tests/misc/torch_tests.py
@@ -1,7 +1,7 @@
 """
 Tests for the :mod:`fiftyone.utils.torch` module.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/tests/no_wrapper/multiprocess_tests.py
+++ b/tests/no_wrapper/multiprocess_tests.py
@@ -1,7 +1,7 @@
 """
-Multiprocess tests.
+Multiprocess tests.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/tests/session_tests.py
+++ b/tests/session_tests.py
@@ -1,7 +1,7 @@
 """
 Tests related to Session behavior.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/tests/unittests/aggregation_tests.py
+++ b/tests/unittests/aggregation_tests.py
@@ -1,7 +1,7 @@
 """
 FiftyOne aggregation-related unit tests.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/tests/unittests/dataset_tests.py
+++ b/tests/unittests/dataset_tests.py
@@ -1,7 +1,7 @@
 """
 FiftyOne dataset-related unit tests.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/tests/unittests/decorators.py
+++ b/tests/unittests/decorators.py
@@ -1,7 +1,7 @@
 """
 Decorator utils for unit tests.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/tests/unittests/evaluation_tests.py
+++ b/tests/unittests/evaluation_tests.py
@@ -1,7 +1,7 @@
 """
 FiftyOne evaluation-related unit tests.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/tests/unittests/group_tests.py
+++ b/tests/unittests/group_tests.py
@@ -1,7 +1,7 @@
 """
 FiftyOne group-related unit tests.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/tests/unittests/import_export_tests.py
+++ b/tests/unittests/import_export_tests.py
@@ -1,7 +1,7 @@
 """
 FiftyOne import/export-related unit tests.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/tests/unittests/label_tests.py
+++ b/tests/unittests/label_tests.py
@@ -1,7 +1,7 @@
 """
 FiftyOne Label-related unit tests.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/tests/unittests/patches_tests.py
+++ b/tests/unittests/patches_tests.py
@@ -1,7 +1,7 @@
 """
 FiftyOne patches-related unit tests.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/tests/unittests/sample_tests.py
+++ b/tests/unittests/sample_tests.py
@@ -1,7 +1,7 @@
 """
 FiftyOne sample-related unit tests.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/tests/unittests/server_tests.py
+++ b/tests/unittests/server_tests.py
@@ -1,7 +1,7 @@
 """
 FiftyOne server-related unit tests.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/tests/unittests/similarity_tests.py
+++ b/tests/unittests/similarity_tests.py
@@ -1,7 +1,7 @@
 """
 FiftyOne visual similarity-related unit tests.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/tests/unittests/synchronization_tests.py
+++ b/tests/unittests/synchronization_tests.py
@@ -1,7 +1,7 @@
 """
 FiftyOne synchronization-related unit tests.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/tests/unittests/utils_tests.py
+++ b/tests/unittests/utils_tests.py
@@ -1,7 +1,7 @@
 """
 FiftyOne utilities unit tests.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/tests/unittests/video_tests.py
+++ b/tests/unittests/video_tests.py
@@ -1,7 +1,7 @@
 """
 FiftyOne video-related unit tests.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/tests/unittests/view_tests.py
+++ b/tests/unittests/view_tests.py
@@ -1,7 +1,7 @@
 """
 FiftyOne view-related unit tests.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/tests/utils/command_wrapper.py
+++ b/tests/utils/command_wrapper.py
@@ -1,7 +1,7 @@
 """
 Wrapper around an arbitrary command that cleans up subprocesses.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/tests/utils/github_actions_flags.py
+++ b/tests/utils/github_actions_flags.py
@@ -1,7 +1,7 @@
 """
 Sets up flags used by GitHub Actions to determine which tests to run.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/tests/utils/interactive_python.py
+++ b/tests/utils/interactive_python.py
@@ -2,7 +2,7 @@
 A script that simulates a Python shell and accepts arbitrary commands to
 execute. For use by service tests.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/tests/utils/pytest_wrapper.py
+++ b/tests/utils/pytest_wrapper.py
@@ -1,7 +1,7 @@
 """
 Wrapper around pytest that cleans up subprocesses.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/tests/utils/session_helper.py
+++ b/tests/utils/session_helper.py
@@ -1,7 +1,7 @@
 """
 A script that sets up and tears down a session. For use by session tests.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """

--- a/tests/utils/setup_config.py
+++ b/tests/utils/setup_config.py
@@ -1,7 +1,7 @@
 """
 Sets up configuration for tests.
 
-| Copyright 2017-2022, Voxel51, Inc.
+| Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """


### PR DESCRIPTION
Leaving this for mac users in 2024 😄 

Update copyrights:

```shell
find . \
    -type d \( \
        -path '**/.*' -o \
        -path './eta' -o \
        -path './docs/build' -o \
        -path '**/node_modules' \
    \) -prune -o \
    -type f \( \
        -name "*.py" -o \
        -name "*.md" -o \
        -name '*.bash' -o \
        -name '*.ts' -o \
        -name '*.tsx' -o \
        -name '*.rst' -o \
        -name '*.txt' \
    \) \
    -exec sed -i '' 's/Copyright 2017-2022/Copyright 2017-2023/g' {} +
```

Check work:

```shell
find . \
    -type d \( \
        -path '**/.*' -o \
        -path './eta' -o \
        -path './docs/build' -o \
        -path '**/node_modules' \
    \) -prune -o \
    -type f \( \
        -name "*.py" -o \
        -name "*.md" -o \
        -name '*.bash' -o \
        -name '*.ts' -o \
        -name '*.tsx' -o \
        -name '*.rst' -o \
        -name '*.txt' \
    \) \
    -print | xargs grep 2022
```
