### PR TITLE
Fix import path

### DIFF
--- a/app/packages/dataset/index.html
+++ b/app/packages/dataset/index.html
@@ -18,6 +18,6 @@
     <div id="root"></div>
     <div id="teams"></div>
     <div id="modal"></div>
-    <script type="module" src="/src/index.tsx"></script>
+    <script type="module" src="/src/index.ts"></script>
   </body>
 </html>


### PR DESCRIPTION
## What changes are proposed in this pull request?

- `dataset/index.html` references `./src/index.tsx` which doesn't exist. The existing file is `./src/index.ts`
- without fixing the reference, the dataset package will fail to build 
- 
<img width="814" alt="image" src="https://user-images.githubusercontent.com/30936736/213659516-69d8d616-8da5-4da6-a731-c9bda33d4c8f.png">

## How is this patch tested? If it is not, please explain why.

(Details)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
