### PR TITLE
Throw GraphQL errors correctly

### DIFF
--- a/app/packages/state/src/routing/RouterContext.ts
+++ b/app/packages/state/src/routing/RouterContext.ts
@@ -13,6 +13,7 @@ import {
 
 import {
   getFetchFunction,
+  GQLError,
   GraphQLError,
   isElectron,
   isNotebook,
@@ -261,13 +262,10 @@ async function fetchGraphQL(
   );
 
   if ("errors" in data && data.errors) {
-    // TODO: figure out how why the aggregationQuery is getting
-    //  triggered for non-existent datasets and handle this upstream, but
-    //  silence the error for now since the no data from the failed query
-    //  is required/expected
-    console.error("GraphQLResponse data returned errors:", data.errors, data);
-    return null;
-    // throw new GraphQLError(data.errors as unknown as GraphQLError[]);
+    throw new GraphQLError({
+      errors: data.errors as GQLError[],
+      variables,
+    });
   }
   return data;
 }


### PR DESCRIPTION
Related #2290 

Fixes handling of GraphQL errors so an informative error is shown.

```py
import fiftyone as fo
import fiftyone.zoo as foz

dataset = foz.load_zoo_dataset("quickstart-groups")
session = fo.launch_app(dataset)

session.view = dataset.select_group_slices(media_type="image").to_patches("ground_truth")

# remove select_group_slices(media_type="image") in view bar
```

<img width="1470" alt="Screen Shot 2023-01-20 at 11 01 44 AM" src="https://user-images.githubusercontent.com/19821840/213759355-83a99e4c-417c-48bf-8011-35d6c185bfee.png">
