### PR TITLE
update local sessionSpaces atom on space changes

### DIFF
--- a/app/packages/state/src/hooks/useSessionSpaces.ts
+++ b/app/packages/state/src/hooks/useSessionSpaces.ts
@@ -2,7 +2,7 @@ import * as foq from "@fiftyone/relay";
 import { useMemo } from "react";
 import { useErrorHandler } from "react-error-boundary";
 import { useMutation } from "react-relay";
-import { useRecoilValue } from "recoil";
+import { useRecoilState, useRecoilValue } from "recoil";
 import { stateSubscription, sessionSpaces } from "../recoil";
 import useSendEvent from "./useSendEvent";
 import { size } from "lodash";
@@ -10,7 +10,8 @@ import { size } from "lodash";
 const useSessionSpaces = () => {
   const send = useSendEvent();
   const subscription = useRecoilValue(stateSubscription);
-  const sessionSpacesState = useRecoilValue(sessionSpaces);
+  const [sessionSpacesState, setSessionSpacesState] =
+    useRecoilState(sessionSpaces);
   const [commit] = useMutation<foq.setSpacesMutation>(foq.setSpaces);
   const onError = useErrorHandler();
 
@@ -26,6 +27,7 @@ const useSessionSpaces = () => {
 
   function setSessionSpaces(spaces: object, panelsState?: object) {
     const formattedSpaces = toAPIFormat(spaces, panelsState);
+    setSessionSpacesState(formattedSpaces);
     return send((session) =>
       commit({
         onError,


### PR DESCRIPTION
## What changes are proposed in this pull request?

Update local sessionSpaces atom when space layout or panel state is updated

## How is this patch tested? If it is not, please explain why.

PR is an enhancement to sessionSpaces atom update and was tested manually to ensure space session continues to work as before

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
