### PR TITLE
bugfix: update filter labels for listfield

### DIFF
--- a/app/packages/core/src/components/Filters/categoricalFilter/Wrapper.tsx
+++ b/app/packages/core/src/components/Filters/categoricalFilter/Wrapper.tsx
@@ -136,7 +136,7 @@ const Wrapper = ({
       ))}
       {Boolean(selectedSet.size) && (
         <>
-          {totalCount > 3 && (
+          {(
             <FilterOption
               nestedField={nestedField}
               shouldNotShowExclude={shouldNotShowExclude}

--- a/app/packages/core/src/components/Filters/utils.ts
+++ b/app/packages/core/src/components/Filters/utils.ts
@@ -31,7 +31,7 @@ export const joinStringArray = (arr: string[]) => {
   } else if (arr.length === 1) {
     return arr[0];
   } else if (arr.length === 2) {
-    return `${arr[0]} and ${arr[1]}`;
+    return `${arr[0]}, ${arr[1]}`;
   } else {
     let result = "";
     for (let i = 0; i < arr.length - 1; i++) {

--- a/app/packages/core/src/components/Modal/TooltipInfo.tsx
+++ b/app/packages/core/src/components/Modal/TooltipInfo.tsx
@@ -20,7 +20,7 @@ const TooltipDiv = animated(styled(ContentDiv)`
 const ContentItemDiv = styled.div`
   margin: 0;
   padding: 0;
-  max-width: 10rem;
+  max-width: 12rem;
 `;
 
 const ContentValue = styled.div`

--- a/app/packages/core/src/components/Modal/TooltipInfo.tsx
+++ b/app/packages/core/src/components/Modal/TooltipInfo.tsx
@@ -20,14 +20,16 @@ const TooltipDiv = animated(styled(ContentDiv)`
 const ContentItemDiv = styled.div`
   margin: 0;
   padding: 0;
-  max-width: 12rem;
-  word-wrap: break-word;
+  max-width: 10rem;
 `;
 
 const ContentValue = styled.div`
   font-size: 0.8rem;
   font-weight: bold;
   color: ${({ theme }) => theme.text.primary};
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
 `;
 
 const ContentName = styled.div`

--- a/app/packages/core/src/components/Modal/TooltipInfo.tsx
+++ b/app/packages/core/src/components/Modal/TooltipInfo.tsx
@@ -6,6 +6,7 @@ import styled from "styled-components";
 import * as fos from "@fiftyone/state";
 import { useRecoilValue } from "recoil";
 import { ContentDiv, ContentHeader } from "../utils";
+import { joinStringArray } from '../Filters/utils';
 
 const TooltipDiv = animated(styled(ContentDiv)`
   position: absolute;
@@ -19,7 +20,7 @@ const TooltipDiv = animated(styled(ContentDiv)`
 const ContentItemDiv = styled.div`
   margin: 0;
   padding: 0;
-  max-width: 10rem;
+  max-width: 12rem;
   word-wrap: break-word;
 `;
 
@@ -42,13 +43,14 @@ const ContentItem = ({
   style,
 }: {
   name: string;
-  value?: number | string;
+  value?: number | string | string[];
   style?: object;
 }) => {
-  if (typeof value === "object") {
+  debugger
+  if (typeof value === "object" && !value.length) {
     return null;
   }
-
+  
   return (
     <ContentItemDiv style={style}>
       <ContentValue>
@@ -60,6 +62,8 @@ const ContentItem = ({
               return value.length ? value : '""';
             case "boolean":
               return value ? "True" : "False";
+            case "object":
+              return joinStringArray(value);
             default:
               return "None";
           }
@@ -170,7 +174,7 @@ const AttrInfo = ({ label, children = null }) => {
   );
 
   const other = entries.filter(
-    ([name]) => !["label", "confidence"].includes(name)
+    ([name]) => !["label", "confidence", "bounding_box"].includes(name)
   );
   const mapper = ([name, value]) => (
     <ContentItem key={name} name={name} value={value} />

--- a/app/packages/core/src/components/Modal/TooltipInfo.tsx
+++ b/app/packages/core/src/components/Modal/TooltipInfo.tsx
@@ -169,11 +169,11 @@ const AttrInfo = ({ label, infoType, children = null }) => {
   if (!entries || !entries.length) {
     return null;
   }
-  const defaultLabels = ["label", "confidence"]
+  const defaultLabels = infoType === "Keypoint" ? ["label"] : ["label", "confidence"]
   const defaults = entries.filter(([name]) =>
     defaultLabels.includes(name)
   );
-  
+
   const other = entries.filter(
     ([name]) => !([...defaultLabels, ...HIDDENLABELS[infoType], "attributes"].includes(name))
   );
@@ -233,8 +233,8 @@ const KeypointInfo = ({ detail }) => {
       {detail.point && (
         <AttrInfo
           label={Object.fromEntries(
-            detail.point.attributes.map(([k, v]) => [
-              `points[${detail.point.index}].${k}`,
+            detail.point.attributes.filter(([x, y]) => x !== "points").map(([k, v]) => [
+              `${k === "label" ? "skeleton" : k}[${detail.point.index}]`,
               v,
             ])
           )}
@@ -300,7 +300,7 @@ const HIDDENLABELS = {
   Classification: ["logtis"],
   Detection: ["bounding_box", "mask"],
   Heatmap: ["map"],
-  Keypoint: ["points"],
+  Keypoint: ["points", "occluded", "confidence"],
   Polyline: ["points"],
   Regression: [],
   Segmentation: ["mask"],

--- a/app/packages/core/src/components/Modal/TooltipInfo.tsx
+++ b/app/packages/core/src/components/Modal/TooltipInfo.tsx
@@ -46,7 +46,6 @@ const ContentItem = ({
   value?: number | string | string[];
   style?: object;
 }) => {
-  debugger
   if (typeof value === "object" && !value.length) {
     return null;
   }
@@ -161,20 +160,20 @@ const useTarget = (field, target) => {
   return getTarget(field, target);
 };
 
-const AttrInfo = ({ label, children = null }) => {
+const AttrInfo = ({ label, infoType, children = null }) => {
   let entries = Object.entries(label).filter(
     ([k, v]) => "tags" !== k && !k.startsWith("_")
   );
   if (!entries || !entries.length) {
     return null;
   }
-
+  const defaultLabels = ["label", "confidence"]
   const defaults = entries.filter(([name]) =>
-    ["label", "confidence"].includes(name)
+    defaultLabels.includes(name)
   );
-
+  
   const other = entries.filter(
-    ([name]) => !["label", "confidence", "bounding_box"].includes(name)
+    ([name]) => !([...defaultLabels, ...HIDDENLABELS[infoType], "attributes"].includes(name))
   );
   const mapper = ([name, value]) => (
     <ContentItem key={name} name={name} value={value} />
@@ -203,7 +202,7 @@ const AttrInfo = ({ label, children = null }) => {
 const ClassificationInfo = ({ detail }) => {
   return (
     <AttrBlock style={{ borderColor: detail.color }}>
-      <AttrInfo label={detail.label} />
+      <AttrInfo label={detail.label} infoType={detail.type} />
     </AttrBlock>
   );
 };
@@ -211,7 +210,7 @@ const ClassificationInfo = ({ detail }) => {
 const DetectionInfo = ({ detail }) => {
   return (
     <AttrBlock style={{ borderColor: detail.color }}>
-      <AttrInfo label={detail.label} />
+      <AttrInfo label={detail.label} infoType={detail.type} />
     </AttrBlock>
   );
 };
@@ -220,7 +219,7 @@ const HeatmapInfo = ({ detail }) => {
   return (
     <AttrBlock style={{ borderColor: detail.color }}>
       <ContentItem key={"pixel-value"} name={"pixel"} value={detail.target} />
-      <AttrInfo label={detail.label} />
+      <AttrInfo label={detail.label} infoType={detail.type} />
     </AttrBlock>
   );
 };
@@ -228,7 +227,7 @@ const HeatmapInfo = ({ detail }) => {
 const KeypointInfo = ({ detail }) => {
   return (
     <AttrBlock style={{ borderColor: detail.color }}>
-      <AttrInfo label={detail.label} />
+      <AttrInfo label={detail.label} infoType={detail.type} />
       {detail.point && (
         <AttrInfo
           label={Object.fromEntries(
@@ -237,6 +236,7 @@ const KeypointInfo = ({ detail }) => {
               v,
             ])
           )}
+          infoType={detail.type} 
         />
       )}
     </AttrBlock>
@@ -246,7 +246,7 @@ const KeypointInfo = ({ detail }) => {
 const RegressionInfo = ({ detail }) => {
   return (
     <AttrBlock style={{ borderColor: detail.color }}>
-      <AttrInfo label={detail.label} />
+      <AttrInfo label={detail.label} infoType={detail.type} />
     </AttrBlock>
   );
 };
@@ -271,7 +271,7 @@ const SegmentationInfo = ({ detail }) => {
             value={detail.target}
           />
         ))}
-      <AttrInfo label={detail.label} />
+      <AttrInfo label={detail.label} infoType={detail.type} />
     </AttrBlock>
   );
 };
@@ -279,7 +279,7 @@ const SegmentationInfo = ({ detail }) => {
 const PolylineInfo = ({ detail }) => {
   return (
     <AttrBlock style={{ borderColor: detail.color }}>
-      <AttrInfo label={detail.label} />
+      <AttrInfo label={detail.label} infoType={detail.type} />
     </AttrBlock>
   );
 };
@@ -292,4 +292,14 @@ const OVERLAY_INFO = {
   Polyline: PolylineInfo,
   Regression: RegressionInfo,
   Segmentation: SegmentationInfo,
+};
+
+const HIDDENLABELS = {
+  Classification: ["logtis"],
+  Detection: ["bounding_box", "mask"],
+  Heatmap: ["map"],
+  Keypoint: ["points"],
+  Polyline: ["points"],
+  Regression: [],
+  Segmentation: ["mask"],
 };

--- a/app/packages/core/src/components/Modal/TooltipInfo.tsx
+++ b/app/packages/core/src/components/Modal/TooltipInfo.tsx
@@ -48,7 +48,7 @@ const ContentItem = ({
   value?: number | string | string[];
   style?: object;
 }) => {
-  if (typeof value === "object" && !value.length) {
+  if (typeof value === "object" && !value?.length) {
     return null;
   }
   

--- a/app/packages/core/src/components/Modal/TooltipInfo.tsx
+++ b/app/packages/core/src/components/Modal/TooltipInfo.tsx
@@ -162,20 +162,20 @@ const useTarget = (field, target) => {
   return getTarget(field, target);
 };
 
-const AttrInfo = ({ label, infoType, children = null }) => {
+const AttrInfo = ({ label, labelType, children = null }) => {
   let entries = Object.entries(label).filter(
     ([k, v]) => "tags" !== k && !k.startsWith("_")
   );
   if (!entries || !entries.length) {
     return null;
   }
-  const defaultLabels = infoType === "Keypoint" ? ["label"] : ["label", "confidence"]
+  const defaultLabels = labelType === "Keypoint" ? ["label"] : ["label", "confidence"]
   const defaults = entries.filter(([name]) =>
     defaultLabels.includes(name)
   );
 
   const other = entries.filter(
-    ([name]) => !([...defaultLabels, ...HIDDENLABELS[infoType], "attributes"].includes(name))
+    ([name]) => !([...defaultLabels, ...HIDDEN_LABELS[labelType], "attributes"].includes(name))
   );
   const mapper = ([name, value]) => (
     <ContentItem key={name} name={name} value={value} />
@@ -204,7 +204,7 @@ const AttrInfo = ({ label, infoType, children = null }) => {
 const ClassificationInfo = ({ detail }) => {
   return (
     <AttrBlock style={{ borderColor: detail.color }}>
-      <AttrInfo label={detail.label} infoType={detail.type} />
+      <AttrInfo label={detail.label} labelType={detail.type} />
     </AttrBlock>
   );
 };
@@ -212,7 +212,7 @@ const ClassificationInfo = ({ detail }) => {
 const DetectionInfo = ({ detail }) => {
   return (
     <AttrBlock style={{ borderColor: detail.color }}>
-      <AttrInfo label={detail.label} infoType={detail.type} />
+      <AttrInfo label={detail.label} labelType={detail.type} />
     </AttrBlock>
   );
 };
@@ -221,7 +221,7 @@ const HeatmapInfo = ({ detail }) => {
   return (
     <AttrBlock style={{ borderColor: detail.color }}>
       <ContentItem key={"pixel-value"} name={"pixel"} value={detail.target} />
-      <AttrInfo label={detail.label} infoType={detail.type} />
+      <AttrInfo label={detail.label} labelType={detail.type} />
     </AttrBlock>
   );
 };
@@ -229,7 +229,7 @@ const HeatmapInfo = ({ detail }) => {
 const KeypointInfo = ({ detail }) => {
   return (
     <AttrBlock style={{ borderColor: detail.color }}>
-      <AttrInfo label={detail.label} infoType={detail.type} />
+      <AttrInfo label={detail.label} labelType={detail.type} />
       {detail.point && (
         <AttrInfo
           label={Object.fromEntries(
@@ -238,7 +238,7 @@ const KeypointInfo = ({ detail }) => {
               v,
             ])
           )}
-          infoType={detail.type} 
+          labelType={detail.type} 
         />
       )}
     </AttrBlock>
@@ -248,7 +248,7 @@ const KeypointInfo = ({ detail }) => {
 const RegressionInfo = ({ detail }) => {
   return (
     <AttrBlock style={{ borderColor: detail.color }}>
-      <AttrInfo label={detail.label} infoType={detail.type} />
+      <AttrInfo label={detail.label} labelType={detail.type} />
     </AttrBlock>
   );
 };
@@ -273,7 +273,7 @@ const SegmentationInfo = ({ detail }) => {
             value={detail.target}
           />
         ))}
-      <AttrInfo label={detail.label} infoType={detail.type} />
+      <AttrInfo label={detail.label} labelType={detail.type} />
     </AttrBlock>
   );
 };
@@ -281,7 +281,7 @@ const SegmentationInfo = ({ detail }) => {
 const PolylineInfo = ({ detail }) => {
   return (
     <AttrBlock style={{ borderColor: detail.color }}>
-      <AttrInfo label={detail.label} infoType={detail.type} />
+      <AttrInfo label={detail.label} labelType={detail.type} />
     </AttrBlock>
   );
 };
@@ -296,7 +296,7 @@ const OVERLAY_INFO = {
   Segmentation: SegmentationInfo,
 };
 
-const HIDDENLABELS = {
+const HIDDEN_LABELS = {
   Classification: ["logtis"],
   Detection: ["bounding_box", "mask"],
   Heatmap: ["map"],

--- a/app/packages/state/src/recoil/pathFilters/index.ts
+++ b/app/packages/state/src/recoil/pathFilters/index.ts
@@ -5,6 +5,7 @@ import {
   FRAME_SUPPORT_FIELD,
   INT_FIELD,
   LABELS,
+  LIST_FIELD,
   OBJECT_ID_FIELD,
   STRING_FIELD,
   VALID_PRIMITIVE_TYPES,
@@ -17,7 +18,7 @@ import * as selectors from "../selectors";
 import { State } from "../types";
 import { boolean } from "./boolean";
 import { numeric } from "./numeric";
-import { string } from "./string";
+import { string, listString } from "./string";
 
 export * from "./boolean";
 export * from "./numeric";
@@ -49,6 +50,10 @@ const primitiveFilter = selectorFamily<
 
       if ([OBJECT_ID_FIELD, STRING_FIELD].includes(ftype)) {
         return get(string({ modal, path }));
+      }
+
+      if ([LIST_FIELD].includes(ftype)) {
+        return get(listString({ modal, path}));
       }
 
       return (value) => true;

--- a/app/packages/state/src/recoil/pathFilters/string.ts
+++ b/app/packages/state/src/recoil/pathFilters/string.ts
@@ -153,3 +153,33 @@ export const string = selectorFamily<
       };
     },
 });
+
+export const listString = selectorFamily<
+(value: string | null) => boolean,
+{ modal: boolean; path: string }
+>({
+key: "stringFilterForListField",
+get:
+  (params) =>
+  ({ get }) => {
+    if (!get(filterAtoms.filter(params))) {
+      return (value) => true;
+    }
+    const isMatching = get(isMatchingAtom(params));
+    if (isMatching) {
+      return (value) => true;
+    }
+
+    const exclude = get(stringExcludeAtom(params));
+    const values = get(stringSelectedValuesAtom({ ...params }));
+    const none = values.includes(null);
+
+    return (value) => {
+      const c1 = values.every(v => value?.includes(v));
+      const c2 = (none && NONE.has(value));
+      const c3 = value;
+      const r = (c1 || c2) && c3;
+      return exclude ? !r : r;
+    };
+  },
+});


### PR DESCRIPTION
fix  #2508 

## What changes are proposed in this pull request?

1. filter dropdown should always show as long as totalcount is more than 0. 
2. added filter labels for listfields
3. tooltip will display listfields (except for bounding box) in modal view
![Screen Shot 2023-01-30 at 11 08 40 PM](https://user-images.githubusercontent.com/17770824/215671078-2c278916-dc93-410e-80a3-99c8036b940e.png)

## How is this patch tested? If it is not, please explain why.

locally

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
