### PR TITLE
fix warning on setting default space state

### DIFF
--- a/app/packages/spaces/src/hooks.ts
+++ b/app/packages/spaces/src/hooks.ts
@@ -1,6 +1,6 @@
 import { PluginComponentType, useActivePlugins } from "@fiftyone/plugins";
 import * as fos from "@fiftyone/state";
-import { useContext, useMemo, useRef } from "react";
+import { useContext, useEffect, useMemo, useRef } from "react";
 import { SortableEvent } from "react-sortablejs";
 import {
   useRecoilCallback,
@@ -25,14 +25,17 @@ import { getNodes } from "./utils";
 export function useSpaces(id: string, defaultState?: SpaceNodeJSON) {
   const [state, setState] = useRecoilState(spaceSelector(id));
 
-  if (!state) {
-    const baseState = new SpaceNode("root").toJSON();
-    setState(defaultState || baseState);
-  }
+  useEffect(() => {
+    if (!state) {
+      const baseState = new SpaceNode("root").toJSON();
+      setState(defaultState || baseState);
+    }
+  }, []);
 
   const spaces = new SpaceTree(state, (spaces: SpaceNodeJSON) => {
     setState(spaces);
   });
+
   return {
     spaces,
     updateSpaces: (


### PR DESCRIPTION
## What changes are proposed in this pull request?

Fixes React warning when initializing space state

## How is this patch tested? If it is not, please explain why.

(Details)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
