### PR TITLE
[Bug Fix] Fix gql saved view field

### DIFF
--- a/fiftyone/server/query.py
+++ b/fiftyone/server/query.py
@@ -109,7 +109,7 @@ class EvaluationRun(Run):
 
 @gql.type
 class SavedView:
-    id: t.Optional[str]
+    _id: gql.Private[t.Optional[ObjectId]]
     dataset_id: t.Optional[str]
     name: t.Optional[str]
     description: t.Optional[str]
@@ -119,6 +119,10 @@ class SavedView:
     created_at: t.Optional[datetime]
     last_modified_at: t.Optional[datetime]
     last_loaded_at: t.Optional[datetime]
+
+    @gql.field
+    def id(self) -> t.Optional[str]:
+        return str(self._id)
 
     @gql.field
     def view_name(self) -> t.Optional[str]:


### PR DESCRIPTION
## What changes are proposed in this pull request?

Fix error: 
`ERROR:strawberry.execution:unhashable type: 'StrawberryAnnotation'`

with traceback: 
```Traceback (most recent call last):
  File "/Users/kacey/Dev/voxel-hub/fiftyone-teams/teams/lib/python3.9/site-packages/graphql/execution/execute.py", line 528, in await_result
    return_type, field_nodes, info, path, await result
  File "/Users/kacey/Dev/voxel-hub/fiftyone-teams/teams/lib/python3.9/site-packages/strawberry/schema/schema_converter.py", line 513, in _async_resolver
    return await await_maybe(_get_result(_source, strawberry_info, **kwargs))
  File "/Users/kacey/Dev/voxel-hub/fiftyone-teams/teams/lib/python3.9/site-packages/strawberry/schema/schema_converter.py", line 499, in _get_result
    return field.get_result(
  File "/Users/kacey/Dev/voxel-hub/fiftyone-teams/teams/lib/python3.9/site-packages/strawberry/field.py", line 161, in get_result
    return self.base_resolver(*args, **kwargs)
  File "/Users/kacey/Dev/voxel-hub/fiftyone-teams/teams/lib/python3.9/site-packages/strawberry/types/fields/resolver.py", line 187, in __call__
    return self.wrapped_func(*args, **kwargs)
  File "/Users/kacey/Dev/voxel-hub/fiftyone-teams/fiftyone/server/query.py", line 393, in saved_views
    return [
  File "/Users/kacey/Dev/voxel-hub/fiftyone-teams/fiftyone/server/query.py", line 394, in <listcomp>
    SavedView.from_doc(view_doc) for view_doc in ds._doc.saved_views
  File "/Users/kacey/Dev/voxel-hub/fiftyone-teams/fiftyone/server/query.py", line 142, in from_doc
    saved_view = from_dict(data_class=cls, data=doc.to_dict())
```

## How is this patch tested? If it is not, please explain why.

(Details)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
