### PR TITLE
bugfix: Sort by similarity is broken

### DIFF
--- a/app/packages/state/src/hooks/useStateUpdate.ts
+++ b/app/packages/state/src/hooks/useStateUpdate.ts
@@ -53,7 +53,7 @@ const useStateUpdate = () => {
       const { get, reset, set } = t;
       if (state) {
         const view = get(viewAtoms.view);
-        if (dataset.stages && !state.view) {
+        if (dataset?.stages && !state.view) {
           state.view = dataset.stages;
         }
 

--- a/fiftyone/server/routes/sort.py
+++ b/fiftyone/server/routes/sort.py
@@ -26,11 +26,8 @@ class Sort(HTTPEndpoint):
         filters = data.get("filters", {})
         stages = data.get("view", None)
         dist_field = data.get("dist_field", None)
-        similarity = data.get("extended", None)
-
-        similarity_stage = None if similarity is None else fos.SortBySimilarity(**similarity)._serialize()
-        stages = data.get("view", []).append(similarity_stage)
-
+        stages = data.get("view", [])
+        
         dataset = fod.load_dataset(dataset_name)
 
         changed = False

--- a/fiftyone/server/routes/sort.py
+++ b/fiftyone/server/routes/sort.py
@@ -26,8 +26,6 @@ class Sort(HTTPEndpoint):
         filters = data.get("filters", {})
         stages = data.get("view", None)
         dist_field = data.get("dist_field", None)
-        stages = data.get("view", [])
-        
         dataset = fod.load_dataset(dataset_name)
 
         changed = False

--- a/fiftyone/server/routes/sort.py
+++ b/fiftyone/server/routes/sort.py
@@ -11,6 +11,7 @@ from starlette.requests import Request
 import fiftyone.core.dataset as fod
 import fiftyone.core.fields as fof
 import fiftyone.core.view as fov
+import fiftyone.core.stages as fos
 
 from fiftyone.server.decorators import route
 import fiftyone.server.events as fose
@@ -24,8 +25,11 @@ class Sort(HTTPEndpoint):
         dataset_name = data.get("dataset", None)
         filters = data.get("filters", {})
         stages = data.get("view", None)
-        extended = data.get("extended", None)
         dist_field = data.get("dist_field", None)
+        similarity = data.get("extended", None)
+
+        similarity_stage = None if similarity is None else fos.SortBySimilarity(**similarity)
+        stages = data.get("view", []).append(similarity_stage)
 
         dataset = fod.load_dataset(dataset_name)
 

--- a/fiftyone/server/routes/sort.py
+++ b/fiftyone/server/routes/sort.py
@@ -28,7 +28,7 @@ class Sort(HTTPEndpoint):
         dist_field = data.get("dist_field", None)
         similarity = data.get("extended", None)
 
-        similarity_stage = None if similarity is None else fos.SortBySimilarity(**similarity)
+        similarity_stage = None if similarity is None else fos.SortBySimilarity(**similarity)._serialize()
         stages = data.get("view", []).append(similarity_stage)
 
         dataset = fod.load_dataset(dataset_name)

--- a/fiftyone/server/routes/sort.py
+++ b/fiftyone/server/routes/sort.py
@@ -11,7 +11,6 @@ from starlette.requests import Request
 import fiftyone.core.dataset as fod
 import fiftyone.core.fields as fof
 import fiftyone.core.view as fov
-import fiftyone.core.stages as fos
 
 from fiftyone.server.decorators import route
 import fiftyone.server.events as fose


### PR DESCRIPTION
fixes #2576 

fixed the issue of extended stage not being updated by `useStateUpdate` when sort by similarity on UI

## What changes are proposed in this pull request?

https://user-images.githubusercontent.com/17770824/215925402-791fc25f-2af5-4705-bca4-db3152b558c6.mov

## How is this patch tested? If it is not, please explain why.

Locally

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
