### PR TITLE
extensible state proxy for dataset

### DIFF
--- a/app/packages/core/src/Dataset.ts
+++ b/app/packages/core/src/Dataset.ts
@@ -177,10 +177,6 @@ export const usePreLoadedDataset = (
       );
     }
 
-    if (stateProxyValue) {
-      view = stateProxyValue.view;
-      viewName = stateProxyValue.viewName;
-    }
     if (
       !router.state &&
       typeof window !== "undefined" &&
@@ -199,7 +195,7 @@ export const usePreLoadedDataset = (
             ? (toCamelCase(config) as fos.State.Config)
             : undefined,
           dataset: fos.transformDataset(rest),
-          state: { view, viewName, ...state },
+          state: { view, viewName, ...state, ...(stateProxyValue || {}) },
         };
       });
       setReady(true);


### PR DESCRIPTION
## What changes are proposed in this pull request?

PR enhances consuming of state proxy in the dataset to be extensible. It now supports providing additional app states beyond view and viewName.

## How is this patch tested? If it is not, please explain why.

Only an enhancement to the current implementation and was tested in app to ensure state sync works as before

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
