### PR TITLE
Restrict dacite

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,7 @@ INSTALL_REQUIRES = [
     "argcomplete",
     "boto3",
     "dacite>=1.6.0",
+    "dacite>=1.6.0,<1.8.0",
     "Deprecated",
     "eventlet",
     "future",


### PR DESCRIPTION
Dacite 1.8.0 breaks Strawberry. Specifically, fields with resolvers like `Dataset.stages` that result in a `StrawberryAnnotation` type in the parent `__annotations__`.

```
[2023-02-01 09:16:42 -0600] [57577] [INFO] Running on http://0.0.0.0:5151 (CTRL + C to quit)
unhashable type: 'StrawberryAnnotation'

GraphQL request:7:3
6 |   ...DatasetSavedViewsFragment
7 |   dataset(name: $name, view: $view, savedViewSlug: $savedViewSlug) {
  |   ^
8 |     stages(slug: $savedViewSlug)
Traceback (most recent call last):
  File "/Users/benjaminkane/venvs/fo/lib/python3.10/site-packages/graphql/execution/execute.py", line 528, in await_result
    return_type, field_nodes, info, path, await result
  File "/Users/benjaminkane/venvs/fo/lib/python3.10/site-packages/strawberry/schema/schema_converter.py", line 513, in _async_resolver
    return await await_maybe(_get_result(_source, strawberry_info, **kwargs))
  File "/Users/benjaminkane/venvs/fo/lib/python3.10/site-packages/strawberry/utils/await_maybe.py", line 12, in await_maybe
    return await value
  File "/Users/benjaminkane/code/teams/fiftyone-teams/fiftyone/server/query.py", line 252, in resolver
    return await serialize_dataset(
  File "/Users/benjaminkane/code/teams/fiftyone-teams/fiftyone/server/query.py", line 465, in serialize_dataset
    return await loop.run_in_executor(None, run)
  File "/opt/homebrew/Cellar/python@3.10/3.10.9/Frameworks/Python.framework/Versions/3.10/lib/python3.10/concurrent/futures/thread.py", line 58, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/Users/benjaminkane/code/teams/fiftyone-teams/fiftyone/server/query.py", line 431, in run
    data = from_dict(Dataset, doc, config=Config(check_types=False))
  File "/Users/benjaminkane/venvs/fo/lib/python3.10/site-packages/dacite/core.py", line 64, in from_dict
    value = _build_value(type_=field_type, data=field_data, config=config)
  File "/Users/benjaminkane/venvs/fo/lib/python3.10/site-packages/dacite/core.py", line 95, in _build_value
    data = _build_value_for_union(union=type_, data=data, config=config)
  File "/Users/benjaminkane/venvs/fo/lib/python3.10/site-packages/dacite/core.py", line 113, in _build_value_for_union
    return _build_value(type_=types[0], data=data, config=config)
  File "/Users/benjaminkane/venvs/fo/lib/python3.10/site-packages/dacite/core.py", line 97, in _build_value
    data = _build_value_for_collection(collection=type_, data=data, config=config)
  File "/Users/benjaminkane/venvs/fo/lib/python3.10/site-packages/dacite/core.py", line 154, in _build_value_for_collection
    return data_type(_build_value(type_=item_type, data=item, config=config) for item in data)
  File "/Users/benjaminkane/venvs/fo/lib/python3.10/site-packages/dacite/core.py", line 154, in <genexpr>
    return data_type(_build_value(type_=item_type, data=item, config=config) for item in data)
  File "/Users/benjaminkane/venvs/fo/lib/python3.10/site-packages/dacite/core.py", line 99, in _build_value
    data = from_dict(data_class=type_, data=data, config=config)
  File "/Users/benjaminkane/venvs/fo/lib/python3.10/site-packages/dacite/core.py", line 72, in from_dict
    value = get_default_value_for_field(field, field_type)
TypeError: unhashable type: 'StrawberryAnnotation'
```

```py
import strawberry as gql
from dacite import from_dict


@gql.type
class Example:
    @gql.field
    def will_break(self) -> str:
        return "example"


from_dict(Example, {})
```