### PR TITLE
bugfix: keypoints count fails without skeleton & type issues

### DIFF
--- a/app/packages/core/src/components/Common/Checkbox.tsx
+++ b/app/packages/core/src/components/Common/Checkbox.tsx
@@ -21,7 +21,7 @@ interface CheckboxProps<T> {
   subcountAtom?: RecoilValueReadOnly<number>;
   disabled?: boolean;
   forceColor?: boolean;
-  formatter?: (value: T) => string;
+  formatter?: (value: T | undefined) => string | null | undefined;
 }
 
 const StyledCheckboxContainer = styled.div`

--- a/app/packages/core/src/components/FieldLabelAndInfo/index.tsx
+++ b/app/packages/core/src/components/FieldLabelAndInfo/index.tsx
@@ -1,4 +1,3 @@
-import { InfoIcon, useTheme } from "@fiftyone/components";
 import React, {
   MutableRefObject,
   useEffect,
@@ -9,6 +8,8 @@ import React, {
 import { atom, useRecoilState } from "recoil";
 import styled from "styled-components";
 import { ExternalLink } from "../../utils/generic";
+import { InfoIcon, useTheme } from "@fiftyone/components";
+import { Field } from "@fiftyone/utilities";
 
 const selectedFieldInfo = atom<string | null>({
   key: "selectedFieldInfo",
@@ -93,13 +94,22 @@ function toLabel(path, nested) {
 }
 
 const FieldInfoIcon = (props) => <InfoIcon {...props} style={{ opacity: 1 }} />;
-export default function FieldLabelAndInfo({
+
+type FieldLabelAndInfo = {
+  nested?: boolean 
+  field: Field
+  color: string
+  expandedPath?: string 
+  template: (unknown) => JSX.Element
+}
+
+const FieldLabelAndInfo = ({
   nested,
   field,
   color,
   expandedPath,
   template,
-}) {
+}: FieldLabelAndInfo) => {
   const fieldInfo = useFieldInfo(field, nested, { expandedPath, color });
   return (
     <>
@@ -108,6 +118,8 @@ export default function FieldLabelAndInfo({
     </>
   );
 }
+
+export default FieldLabelAndInfo
 
 const FieldInfoExpandedContainer = styled.div`
   background: ${({ theme }) => {

--- a/app/packages/core/src/components/Filters/NumericFieldFilter.tsx
+++ b/app/packages/core/src/components/Filters/NumericFieldFilter.tsx
@@ -210,7 +210,7 @@ const NumericFieldFilter = ({
     setIsMatching && setIsMatching(!nestedField);
   };
 
-  if (!hasNonfinites && !hasBounds && named) {
+  if (!(hasBounds || hasNonfinites) || !field) {
     return null;
   }
 
@@ -223,14 +223,11 @@ const NumericFieldFilter = ({
       {named && name && (
         <FieldLabelAndInfo
           nested
-          field={field}
+          field={field!}
           color={color}
           template={({
             label,
-            hoverHanlders,
-            FieldInfoIcon,
             hoverTarget,
-            container,
           }) => (
             <NamedRangeSliderHeader>
               <span ref={hoverTarget}>{label}</span>
@@ -284,8 +281,8 @@ const NumericFieldFilter = ({
             })}
             formatter={
               [DATE_TIME_FIELD, DATE_FIELD].includes(ftype)
-                ? (v) => formatDateTime(v, timeZone)
-                : null
+                ? (v) => v ? formatDateTime(v, timeZone) : null
+                : (v) => null
             }
             value={false}
           />

--- a/app/packages/core/src/components/Filters/StringFieldFilter.tsx
+++ b/app/packages/core/src/components/Filters/StringFieldFilter.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-
 import * as fos from "@fiftyone/state";
 
 import {

--- a/app/packages/core/src/components/Filters/categoricalFilter/CategoricalFilter.tsx
+++ b/app/packages/core/src/components/Filters/categoricalFilter/CategoricalFilter.tsx
@@ -148,7 +148,8 @@ export const isKeypointLabel = selectorFamily<boolean, string>({
           parent = `frames.${keys[1]}`;
         }
 
-        if (VALID_KEYPOINTS.includes(get(fos.field(parent)).embeddedDocType)) {
+        const p = get(fos.field(parent))?.embeddedDocType
+        if (p && VALID_KEYPOINTS.includes(p)) {
           return true;
         }
       }
@@ -198,7 +199,6 @@ const CategoricalFilter = <T extends V = V>({
   const neverShowExpansion = field?.ftype.includes("ObjectIdField");
 
   if (countsLoadable.state !== "hasValue") return null;
-
   const { count, results } = countsLoadable.contents;
 
   if (named && !results.length) {
@@ -214,7 +214,7 @@ const CategoricalFilter = <T extends V = V>({
       {named && (
         <FieldLabelAndInfo
           nested
-          field={field}
+          field={field!}
           color={color}
           template={({ label, hoverTarget }) => (
             <NamedCategoricalFilterHeader>

--- a/app/packages/core/src/components/Filters/index.tsx
+++ b/app/packages/core/src/components/Filters/index.tsx
@@ -1,17 +1,4 @@
 import "react";
-import { selectorFamily } from "recoil";
-
-import {
-  BOOLEAN_FIELD,
-  FLOAT_FIELD,
-  FRAME_NUMBER_FIELD,
-  FRAME_SUPPORT_FIELD,
-  INT_FIELD,
-  LABELS,
-  OBJECT_ID_FIELD,
-  STRING_FIELD,
-  VALID_PRIMITIVE_TYPES,
-} from "@fiftyone/utilities";
 
 export { default as BooleanFieldFilter } from "./BooleanFieldFilter";
 export { default as NumericFieldFilter } from "./NumericFieldFilter";

--- a/app/packages/state/src/recoil/aggregations.ts
+++ b/app/packages/state/src/recoil/aggregations.ts
@@ -173,6 +173,7 @@ export const stringCountResults = selectorFamily({
       const keys = params.path.split(".");
       let parent = keys[0];
       let field = get(schemaAtoms.field(parent));
+
       if (!field && parent === "frames") {
         parent = `frames.${keys[1]}`;
       }
@@ -181,11 +182,12 @@ export const stringCountResults = selectorFamily({
         VALID_KEYPOINTS.includes(get(schemaAtoms.field(parent)).embeddedDocType)
       ) {
         const skeleton = get(selectors.skeleton(parent));
-
-        return {
-          count: skeleton.labels.length,
-          results: skeleton.labels.map((label) => [label as string | null, -1]),
-        };
+        if (skeleton && skeleton.labels) {
+          return {
+            count: skeleton.labels.length,
+            results: skeleton.labels.map((label) => [label as string | null, -1]),
+          };
+        }
       }
 
       let { values, count } = get(aggregation(params));


### PR DESCRIPTION
Fix bug that prevents keypoints filter tray from opening in
 https://github.com/voxel51/fiftyone/pull/2582#pullrequestreview-1276544240

## What changes are proposed in this pull request?

1. skeleton filter tray cannot open because keypoints count fails when skeleton is null;
2. addressed type issues

## How is this patch tested? If it is not, please explain why.
Locally

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
