### PR TITLE
Do not refresh grid when modal is open

### DIFF
--- a/app/packages/core/src/components/Grid/Grid.tsx
+++ b/app/packages/core/src/components/Grid/Grid.tsx
@@ -99,7 +99,6 @@ const Grid: React.FC<{}> = () => {
       freeVideos();
     }),
     [
-      isModalOpen,
       stringifyObj(useRecoilValue(fos.filters)),
       useRecoilValue(fos.datasetName),
       useRecoilValue(fos.cropToContent(false)),

--- a/app/packages/core/src/components/Grid/Grid.tsx
+++ b/app/packages/core/src/components/Grid/Grid.tsx
@@ -32,6 +32,8 @@ const Grid: React.FC<{}> = () => {
   const threshold = useRecoilValue(rowAspectRatioThreshold);
   const resize = useResize();
 
+  const isModalOpen = Boolean(useRecoilValue(fos.modal));
+
   const [flashlight] = useState(() => {
     const flashlight = new Flashlight<number>({
       horizontal: false,
@@ -87,7 +89,7 @@ const Grid: React.FC<{}> = () => {
 
   useEffect(
     deferred(() => {
-      if (isTagging || !flashlight.isAttached()) {
+      if (isModalOpen || isTagging || !flashlight.isAttached()) {
         return;
       }
 
@@ -97,6 +99,7 @@ const Grid: React.FC<{}> = () => {
       freeVideos();
     }),
     [
+      isModalOpen,
       stringifyObj(useRecoilValue(fos.filters)),
       useRecoilValue(fos.datasetName),
       useRecoilValue(fos.cropToContent(false)),


### PR DESCRIPTION
## What changes are proposed in this pull request?

The fix is to disable the background grid refresh every-time a tagging happens when the sample modal is open which prevents the extra refresh and also prevents the modal closing unexpectedly.

https://user-images.githubusercontent.com/109545780/216155993-9d17db6a-4758-46f2-a03b-32933bd79a08.mov


(Please fill in changes proposed in this fix)

## How is this patch tested? If it is not, please explain why.

(Details)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
