### PR TITLE
Automatically clear sample selection after sort by similarity is applied

### DIFF
--- a/app/packages/core/src/components/Actions/ActionsRow.tsx
+++ b/app/packages/core/src/components/Actions/ActionsRow.tsx
@@ -43,9 +43,11 @@ export const shouldToggleBookMarkIconOnSelector = selector<boolean>({
     const hasFiltersValue = get(fos.hasFilters(false));
     const extendedSelectionList = get(fos.extendedSelection);
     const selectedSampleSet = get(fos.selectedSamples);
+    const isSimilarityOn = get(fos.similarityParameters);
 
     const isExtendedSelectionOn =
-      extendedSelectionList && extendedSelectionList.length > 0;
+      (extendedSelectionList && extendedSelectionList.length > 0) ||
+      isSimilarityOn;
 
     return (
       isExtendedSelectionOn || hasFiltersValue || selectedSampleSet.size > 0

--- a/app/packages/core/src/components/Actions/Similar.tsx
+++ b/app/packages/core/src/components/Actions/Similar.tsx
@@ -64,6 +64,7 @@ const getQueryIds = async (snapshot: Snapshot, brainKey?: string) => {
 const useSortBySimilarity = (close) => {
   const update = useUnprocessedStateUpdate();
   const handleError = useErrorHandler();
+
   return useRecoilCallback(
     ({ snapshot, set }) =>
       async (parameters: fos.State.SortBySimilarityParameters) => {
@@ -81,6 +82,10 @@ const useSortBySimilarity = (close) => {
               queryIds,
             }),
           });
+
+          // update selectedSamples atom to new set.
+          // modifying data, otherwise useStateUpdate will set the selectedSamples again
+          data.state.selected = [];
 
           update(({ set }) => {
             set(fos.similarityParameters, {


### PR DESCRIPTION
## What changes are proposed in this pull request?

https://user-images.githubusercontent.com/17770824/216185385-72c22ea4-5963-4cde-9114-1861cd6a64b6.mov


(Please fill in changes proposed in this fix)

## How is this patch tested? If it is not, please explain why.

(Details)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
