### PR TITLE
bookmark icon always appears when there is an active similarity sort in extended_stages

### DIFF
--- a/app/packages/core/src/components/Actions/ActionsRow.tsx
+++ b/app/packages/core/src/components/Actions/ActionsRow.tsx
@@ -43,9 +43,11 @@ export const shouldToggleBookMarkIconOnSelector = selector<boolean>({
     const hasFiltersValue = get(fos.hasFilters(false));
     const extendedSelectionList = get(fos.extendedSelection);
     const selectedSampleSet = get(fos.selectedSamples);
+    const isSimilarityOn = get(fos.similarityParameters);
 
     const isExtendedSelectionOn =
-      extendedSelectionList && extendedSelectionList.length > 0;
+      (extendedSelectionList && extendedSelectionList.length > 0) ||
+      isSimilarityOn;
 
     return (
       isExtendedSelectionOn || hasFiltersValue || selectedSampleSet.size > 0


### PR DESCRIPTION
bookmark icon always appears when there is an active similarity sort in extended_stages
## What changes are proposed in this pull request?
![Screenshot 2023-02-01 at 5 08 26 PM](https://user-images.githubusercontent.com/17770824/216187014-a7dc70ad-35eb-4551-acad-07cc008b7220.png)
(Please fill in changes proposed in this fix)

## How is this patch tested? If it is not, please explain why.

(Details)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
