### PR TITLE
Add support for CVAT v2.4

### DIFF
--- a/fiftyone/utils/cvat.py
+++ b/fiftyone/utils/cvat.py
@@ -4139,7 +4139,11 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
         job_ids = []
         while not job_ids:
             job_resp = self.get(self.jobs_url(task_id))
-            job_ids = [j["id"] for j in job_resp.json()]
+            job_resp_json = job_resp.json()
+            if "results" in job_resp_json:
+                job_resp_json = job_resp_json["results"]
+
+            job_ids = [j["id"] for j in job_resp_json]
 
         if job_assignees is not None:
             num_assignees = len(job_assignees)

--- a/tests/intensive/cvat_tests.py
+++ b/tests/intensive/cvat_tests.py
@@ -441,7 +441,10 @@ class CVATTests(unittest.TestCase):
                 self.assertEqual(task_json["name"], f"{task_name}_{idx + 1}")
                 if user is not None:
                     self.assertEqual(task_json["assignee"]["username"], user)
-                for job in api.get(api.jobs_url(task_id)).json():
+                jobs_json = api.get(api.jobs_url(task_id)).json()
+                if "results" in jobs_json:
+                    jobs_json = jobs_json["results"]
+                for job in jobs_json:
                     job_json = api.get(job["url"]).json()
                     if user is not None:
                         self.assertEqual(


### PR DESCRIPTION
Resolves #2572
Resolves #2567
Resolves #2565 

Thanks to @tjaeuth for the recommendation!

The CVAT API response for the jobs query has been modified slightly which broke our integration for v2.4 servers. This PR adds support for v2.4 servers and updates our tests. All tests pass on both v2.3 and v2.4 now.