### PR TITLE
Label choices in filter tray of Keypoints field incorrectly show skeleton labels

### DIFF
--- a/app/packages/state/src/recoil/aggregations.ts
+++ b/app/packages/state/src/recoil/aggregations.ts
@@ -178,14 +178,20 @@ export const stringCountResults = selectorFamily({
         parent = `frames.${keys[1]}`;
       }
 
-      if (
-        VALID_KEYPOINTS.includes(get(schemaAtoms.field(parent)).embeddedDocType)
-      ) {
+      const isSkeletonPoints =
+        VALID_KEYPOINTS.includes(
+          get(schemaAtoms.field(parent)).embeddedDocType
+        ) && keys[2] === "points";
+
+      if (isSkeletonPoints) {
         const skeleton = get(selectors.skeleton(parent));
         if (skeleton && skeleton.labels) {
           return {
             count: skeleton.labels.length,
-            results: skeleton.labels.map((label) => [label as string | null, -1]),
+            results: skeleton.labels.map((label) => [
+              label as string | null,
+              -1,
+            ]),
           };
         }
       }


### PR DESCRIPTION
Fix bug where label choices in the filter tray of a Keypoint field incorrectly show the skeleton points labels as keypoints labels

## What changes are proposed in this pull request?
![Screenshot 2023-02-01 at 9 44 33 PM](https://user-images.githubusercontent.com/17770824/216233263-ae7a49c5-694b-4805-b175-344c4b3a1d60.png)

## How is this patch tested? If it is not, please explain why.

(Details)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
