### PR TITLE
Sample tag count in extended view is broken

### DIFF
--- a/app/packages/core/src/components/Common/CountSubcount.tsx
+++ b/app/packages/core/src/components/Common/CountSubcount.tsx
@@ -21,7 +21,7 @@ const EntryCounts = ({
   if (!["number", "undefined"].includes(typeof subcount)) {
     return (
       <span style={{ whiteSpace: "nowrap" }}>
-        <LoadingDots text="" /> {count!.toLocaleString()}
+        <LoadingDots text="" /> {count.toLocaleString()}
       </span>
     );
   }
@@ -32,7 +32,7 @@ const EntryCounts = ({
 
   return (
     <span style={{ whiteSpace: "nowrap" }}>
-      {subcount?.toLocaleString() ?? "0"} of {count?.toLocaleString()}
+      {subcount?.toLocaleString() ?? "0"} of {count.toLocaleString()}
     </span>
   );
 };

--- a/app/packages/core/src/components/Common/CountSubcount.tsx
+++ b/app/packages/core/src/components/Common/CountSubcount.tsx
@@ -18,21 +18,21 @@ const EntryCounts = ({
     return <LoadingDots text="" />;
   }
 
-  if (count === subcount || count === 0) {
-    return <span>{count.toLocaleString()}</span>;
-  }
-
-  if (typeof subcount !== "number") {
+  if (!["number", "undefined"].includes(typeof subcount)) {
     return (
       <span style={{ whiteSpace: "nowrap" }}>
-        <LoadingDots text="" /> {count.toLocaleString()}
+        <LoadingDots text="" /> {count!.toLocaleString()}
       </span>
     );
   }
 
+  if (count === subcount || count === 0) {
+    return <span>{count!.toLocaleString()}</span>;
+  }
+
   return (
     <span style={{ whiteSpace: "nowrap" }}>
-      {subcount.toLocaleString()} of {count.toLocaleString()}
+      {subcount?.toLocaleString() ?? "0"} of {count?.toLocaleString()}
     </span>
   );
 };


### PR DESCRIPTION
fix #2443 


![Screenshot 2023-02-02 at 1 02 58 PM](https://user-images.githubusercontent.com/17770824/216424912-de51ee3f-bb97-413d-8072-6cdf7ee56f05.png)

## What changes are proposed in this pull request?

In the extended view, if the `subcount` is `0`, it will return`undefined` and render loading dots.
Added the fallback to 0 when subcount is `undefined`. 

## How is this patch tested? If it is not, please explain why.

(Details)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
