### PR TITLE
[bug fix] update grid to cropped items after clicking patches button

### DIFF
--- a/app/packages/state/src/hooks/useSetView.ts
+++ b/app/packages/state/src/hooks/useSetView.ts
@@ -107,20 +107,19 @@ const useSetView = (
                 });
                 window.history.replaceState(window.history.state, "", newRoute);
               }
-              if (patch) {
-                updateState({
-                  dataset: fos.transformDataset(dataset),
-                  state: {
-                    view: value,
-                    viewCls: dataset.viewCls,
-                    selected: [],
-                    selectedLabels: [],
-                    viewName,
-                    savedViews,
-                    savedViewSlug,
-                  },
-                });
-              }
+              updateState({
+                dataset: fos.transformDataset(dataset),
+                state: {
+                  view: value,
+                  viewCls: dataset.viewCls,
+                  selected: [],
+                  selectedLabels: [],
+                  viewName,
+                  savedViews,
+                  savedViewSlug,
+                },
+              });
+
               onComplete && onComplete();
             },
           });

--- a/app/packages/state/src/hooks/useSetView.ts
+++ b/app/packages/state/src/hooks/useSetView.ts
@@ -12,6 +12,7 @@ import { State, stateSubscription, view, viewStateForm } from "../recoil";
 import { RouterContext } from "../routing";
 import useSendEvent from "./useSendEvent";
 import * as fos from "../";
+import { transformDataset } from "../";
 
 export const stateProxy = atom({
   key: "stateProxy",
@@ -29,6 +30,7 @@ const useSetView = (
   const [commit] = useMutation<setViewMutation>(setView);
   const onError = useErrorHandler();
   const setStateProxy = useSetRecoilState(stateProxy);
+  const updateState = fos.useStateUpdate();
 
   return useRecoilCallback(
     ({ snapshot }) =>
@@ -107,7 +109,20 @@ const useSetView = (
                 });
                 window.history.replaceState(window.history.state, "", newRoute);
               }
-
+              if (patch) {
+                updateState({
+                  dataset: transformDataset(dataset),
+                  state: {
+                    view: value,
+                    viewCls: dataset.viewCls,
+                    selected: [],
+                    selectedLabels: [],
+                    viewName,
+                    savedViews,
+                    savedViewSlug,
+                  },
+                });
+              }
               onComplete && onComplete();
             },
           });

--- a/app/packages/state/src/hooks/useSetView.ts
+++ b/app/packages/state/src/hooks/useSetView.ts
@@ -10,9 +10,7 @@ import {
 } from "recoil";
 import { State, stateSubscription, view, viewStateForm } from "../recoil";
 import { RouterContext } from "../routing";
-import useSendEvent from "./useSendEvent";
 import * as fos from "../";
-import { transformDataset } from "../";
 
 export const stateProxy = atom({
   key: "stateProxy",
@@ -24,7 +22,7 @@ const useSetView = (
   selectSlice = false,
   onComplete?: () => void
 ) => {
-  const send = useSendEvent(true);
+  const send = fos.useSendEvent(true);
   const subscription = useRecoilValue(stateSubscription);
   const router = useContext(RouterContext);
   const [commit] = useMutation<setViewMutation>(setView);
@@ -111,7 +109,7 @@ const useSetView = (
               }
               if (patch) {
                 updateState({
-                  dataset: transformDataset(dataset),
+                  dataset: fos.transformDataset(dataset),
                   state: {
                     view: value,
                     viewCls: dataset.viewCls,


### PR DESCRIPTION
## What changes are proposed in this pull request?

- Currently, patches views don't crop to the bounding box: 
<img width="2101" alt="image" src="https://user-images.githubusercontent.com/30936736/216454825-c41687d1-b92e-4060-b012-ace5b20b613f.png">

- with this change:
<img width="991" alt="image" src="https://user-images.githubusercontent.com/30936736/216454968-3cb84a0d-e2d2-41e1-b43c-4fdfaa4515f8.png">



## How is this patch tested? If it is not, please explain why.

(Details)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
