### PR TITLE
Adding support for importing/exporting generic media

### DIFF
--- a/docs/source/user_guide/dataset_creation/datasets.rst
+++ b/docs/source/user_guide/dataset_creation/datasets.rst
@@ -207,6 +207,8 @@ refer to the corresponding dataset format when reading the dataset from disk.
     +---------------------------------------------------------------------------------------+------------------------------------------------------------------------------------+
     | :ref:`VideoDirectory <VideoDirectory-import>`                                         | A directory of videos.                                                             |
     +---------------------------------------------------------------------------------------+------------------------------------------------------------------------------------+
+    | :ref:`MediaDirectory <MediaDirectory-import>`                                         | A directory of media files.                                                        |
+    +---------------------------------------------------------------------------------------+------------------------------------------------------------------------------------+
     | :ref:`FiftyOneImageClassificationDataset <FiftyOneImageClassificationDataset-import>` | A labeled dataset consisting of images and their associated classification labels  |
     |                                                                                       | in a simple JSON format.                                                           |
     +---------------------------------------------------------------------------------------+------------------------------------------------------------------------------------+
@@ -455,6 +457,94 @@ You can create a FiftyOne dataset from a directory of videos as follows:
         fiftyone app view \
             --dataset-dir $DATASET_DIR \
             --type fiftyone.types.VideoDirectory
+
+.. _MediaDirectory-import:
+
+MediaDirectory
+--------------
+
+The :class:`fiftyone.types.MediaDirectory` type represents a directory of media
+files.
+
+Datasets of this type are read in the following format:
+
+.. code-block:: text
+
+    <dataset_dir>/
+        <filename1>.<ext>
+        <filename2>.<ext>
+
+.. note::
+
+    All files must have the same media type (image, video, point cloud, etc.)
+
+By default, the dataset may contain nested subfolders of media files, which are
+recursively listed.
+
+.. note::
+
+    See :class:`MediaDirectoryImporter <fiftyone.utils.data.importers.MediaDirectoryImporter>`
+    for parameters that can be passed to methods like
+    :meth:`Dataset.from_dir() <fiftyone.core.dataset.Dataset.from_dir>` to
+    customize the import of datasets of this type.
+
+You can create a FiftyOne dataset from a directory of media files as follows:
+
+.. tabs::
+
+  .. group-tab:: Python
+
+    .. code-block:: python
+        :linenos:
+
+        import fiftyone as fo
+
+        name = "my-dataset"
+        dataset_dir = "/path/to/media-dir"
+
+        # Create the dataset
+        dataset = fo.Dataset.from_dir(
+            dataset_dir=dataset_dir,
+            dataset_type=fo.types.MediaDirectory,
+            name=name,
+        )
+
+        # View summary info about the dataset
+        print(dataset)
+
+        # Print the first few samples in the dataset
+        print(dataset.head())
+
+  .. group-tab:: CLI
+
+    .. code:: shell
+
+      NAME=my-dataset
+      DATASET_DIR=/path/to/media-dir
+
+      # Create the dataset
+      fiftyone datasets create \
+          --name $NAME \
+          --dataset-dir $DATASET_DIR \
+          --type fiftyone.types.MediaDirectory
+
+      # View summary info about the dataset
+      fiftyone datasets info $NAME
+
+      # Print the first few samples in the dataset
+      fiftyone datasets head $NAME
+
+    To view a directory of media in the FiftyOne App without creating
+    a persistent FiftyOne dataset, you can execute:
+
+    .. code-block:: shell
+
+        DATASET_DIR=/path/to/media-dir
+
+        # View the dataset in the App
+        fiftyone app view \
+            --dataset-dir $DATASET_DIR \
+            --type fiftyone.types.MediaDirectory
 
 .. _FiftyOneImageClassificationDataset-import:
 

--- a/docs/source/user_guide/export_datasets.rst
+++ b/docs/source/user_guide/export_datasets.rst
@@ -424,6 +424,8 @@ refer to the corresponding dataset format when writing the dataset to disk.
     +--------------------------------------------------------------------+------------------------------------------------------------------------------------+
     | :ref:`VideoDirectory <VideoDirectory-export>`                      | A directory of videos.                                                             |
     +--------------------------------------------------------------------+------------------------------------------------------------------------------------+
+    | :ref:`MediaDirectory <MediaDirectory-export>`                      | A directory of media files.                                                        |
+    +--------------------------------------------------------------------+------------------------------------------------------------------------------------+
     | :ref:`FiftyOneImageClassificationDataset                           | A labeled dataset consisting of images and their associated classification labels  |
     | <FiftyOneImageClassificationDataset-export>`                       | in a simple JSON format.                                                           |
     +--------------------------------------------------------------------+------------------------------------------------------------------------------------+
@@ -609,6 +611,64 @@ disk as follows:
         fiftyone datasets export $NAME \
             --export-dir $EXPORT_DIR \
             --type fiftyone.types.VideoDirectory
+
+.. _MediaDirectory-export:
+
+MediaDirectory
+--------------
+
+The :class:`fiftyone.types.MediaDirectory` type represents a directory of
+media files.
+
+Datasets of this type are exported in the following format:
+
+.. code-block:: text
+
+    <dataset_dir>/
+        <filename1>.<ext>
+        <filename2>.<ext>
+        ...
+
+.. note::
+
+    See :class:`MediaDirectoryExporter <fiftyone.utils.data.exporters.MediaDirectoryExporter>`
+    for parameters that can be passed to methods like
+    :meth:`export() <fiftyone.core.collections.SampleCollection.export>`
+    to customize the export of datasets of this type.
+
+You can export the media in a FiftyOne dataset as a directory of media files on
+disk as follows:
+
+.. tabs::
+
+  .. group-tab:: Python
+
+    .. code-block:: python
+        :linenos:
+
+        import fiftyone as fo
+
+        export_dir = "/path/for/media-dir"
+
+        # The dataset or view to export
+        dataset_or_view = fo.Dataset(...)
+
+        # Export the dataset
+        dataset_or_view.export(
+            export_dir=export_dir, dataset_type=fo.types.MediaDirectory
+        )
+
+  .. group-tab:: CLI
+
+    .. code-block:: shell
+
+        NAME=my-dataset
+        EXPORT_DIR=/path/to/media-dir
+
+        # Export the dataset
+        fiftyone datasets export $NAME \
+            --export-dir $EXPORT_DIR \
+            --type fiftyone.types.MediaDirectory
 
 .. _FiftyOneImageClassificationDataset-export:
 

--- a/fiftyone/types/dataset_types.py
+++ b/fiftyone/types/dataset_types.py
@@ -278,6 +278,25 @@ class VideoDirectory(UnlabeledImageDataset):
         return foud.VideoDirectoryExporter
 
 
+class MediaDirectory(UnlabeledDataset):
+    """A directory of media files.
+
+    See :ref:`this page <MediaDirectory-import>` for importing datasets of this
+    type, and see :ref:`this page <MediaDirectory-export>` for exporting
+    datasets of this type.
+    """
+
+    def get_dataset_importer_cls(self):
+        import fiftyone.utils.data as foud
+
+        return foud.MediaDirectoryImporter
+
+    def get_dataset_exporter_cls(self):
+        import fiftyone.utils.data as foud
+
+        return foud.MediaDirectoryExporter
+
+
 class FiftyOneImageClassificationDataset(ImageClassificationDataset):
     """A labeled dataset consisting of images and their associated
     classification labels stored in a simple JSON format.

--- a/fiftyone/utils/data/exporters.py
+++ b/fiftyone/utils/data/exporters.py
@@ -35,6 +35,7 @@ import fiftyone.utils.patches as foup
 from .parsers import (
     FiftyOneLabeledImageSampleParser,
     FiftyOneUnlabeledImageSampleParser,
+    FiftyOneUnlabeledMediaSampleParser,
     FiftyOneLabeledVideoSampleParser,
     FiftyOneUnlabeledVideoSampleParser,
     ImageSampleParser,
@@ -282,6 +283,11 @@ def export_samples(
             compute_metadata=True, export_media=_export_media, **clips_kwargs
         )
 
+    elif isinstance(dataset_exporter, UnlabeledMediaDatasetExporter):
+        sample_parser = FiftyOneUnlabeledMediaSampleParser(
+            compute_metadata=True
+        )
+
     elif isinstance(dataset_exporter, LabeledImageDatasetExporter):
         if found_patches:
             # Export labeled image patches
@@ -420,6 +426,14 @@ def write_dataset(
         (UnlabeledVideoDatasetExporter, LabeledVideoDatasetExporter),
     ):
         _write_video_dataset(
+            dataset_exporter,
+            samples,
+            sample_parser,
+            num_samples=num_samples,
+            sample_collection=sample_collection,
+        )
+    elif isinstance(dataset_exporter, UnlabeledMediaDatasetExporter):
+        _write_unlabeled_dataset(
             dataset_exporter,
             samples,
             sample_parser,
@@ -938,6 +952,40 @@ def _write_video_dataset(
                     )
 
 
+def _write_unlabeled_dataset(
+    dataset_exporter,
+    samples,
+    sample_parser,
+    num_samples=None,
+    sample_collection=None,
+):
+    with fou.ProgressBar(total=num_samples) as pb:
+        with dataset_exporter:
+            if sample_collection is not None:
+                dataset_exporter.log_collection(sample_collection)
+
+            for sample in pb(samples):
+                sample_parser.with_sample(sample)
+
+                # Parse media
+                filepath = sample_parser.get_media_path()
+
+                # Parse metadata
+                if dataset_exporter.requires_metadata:
+                    if sample_parser.has_metadata:
+                        metadata = sample_parser.get_metadata()
+                    else:
+                        metadata = None
+
+                    if metadata is None:
+                        metadata = fom.Metadata.build_for(filepath)
+                else:
+                    metadata = None
+
+                # Export sample
+                dataset_exporter.export_sample(filepath, metadata=metadata)
+
+
 class ExportPathsMixin(object):
     """Mixin for :class:`DatasetExporter` classes that provides convenience
     methods for parsing the ``data_path``, ``labels_path``, and
@@ -1438,6 +1486,37 @@ class UnlabeledVideoDatasetExporter(DatasetExporter):
             metadata (None): a :class:`fiftyone.core.metadata.VideoMetadata`
                 instance for the sample. Only required when
                 :meth:`requires_video_metadata` is ``True``
+        """
+        raise NotImplementedError("subclass must implement export_sample()")
+
+
+class UnlabeledMediaDatasetExporter(DatasetExporter):
+    """Interface for exporting datasets of unlabeled samples.
+
+    See :ref:`this page <writing-a-custom-dataset-exporter>` for information
+    about implementing/using dataset exporters.
+
+    Args:
+        export_dir (None): the directory to write the export. This may be
+            optional for some exporters
+    """
+
+    @property
+    def requires_metadata(self):
+        """Whether this exporter requires
+        :class:`fiftyone.core.metadata.Metadata` instances for each sample
+        being exported.
+        """
+        raise NotImplementedError("subclass must implement requires_metadata")
+
+    def export_sample(self, filepath, metadata=None):
+        """Exports the given sample to the dataset.
+
+        Args:
+            filepath: a media path
+            metadata (None): a :class:`fiftyone.core.metadata.Metadata`
+                instance for the sample. Only required when
+                :meth:`requires_metadata` is ``True``
         """
         raise NotImplementedError("subclass must implement export_sample()")
 
@@ -2269,6 +2348,62 @@ class VideoDirectoryExporter(UnlabeledVideoDatasetExporter):
 
     def export_sample(self, video_path, metadata=None):
         self._media_exporter.export(video_path)
+
+    def close(self, *args):
+        self._media_exporter.close()
+
+
+class MediaDirectoryExporter(UnlabeledMediaDatasetExporter):
+    """Exporter that writes a directory of media files of arbitrary type to
+    disk.
+
+    See :ref:`this page <MediaDirectory-export>` for format details.
+
+    The filenames of the input media files will be maintained in the export
+    directory, unless a name conflict would occur, in which case an index of
+    the form ``"-%d" % count`` is appended to the base filename.
+
+    Args:
+        export_dir: the directory to write the export
+        export_media (None): defines how to export the raw media contained
+            in the dataset. The supported values are:
+
+            -   ``True`` (default): copy all media files into the export
+                directory
+            -   ``"move"``: move media files into the export directory
+            -   ``"symlink"``: create symlinks to each media file in the export
+                directory
+        rel_dir (None): an optional relative directory to strip from each input
+            filepath to generate a unique identifier for each output file. This
+            identifier is joined with ``export_dir`` to generate an output path
+            for each exported media. This argument allows for populating nested
+            subdirectories that match the shape of the input paths. The path is
+            converted to an absolute path (if necessary) via
+            :func:`fiftyone.core.utils.normalize_path`
+    """
+
+    def __init__(self, export_dir, export_media=None, rel_dir=None):
+        if export_media is None:
+            export_media = True
+
+        super().__init__(export_dir=export_dir)
+
+        self.export_media = export_media
+        self.rel_dir = rel_dir
+
+        self._media_exporter = None
+
+    def setup(self):
+        self._media_exporter = MediaExporter(
+            self.export_media,
+            export_path=self.export_dir,
+            rel_dir=self.rel_dir,
+            supported_modes=(True, "move", "symlink"),
+        )
+        self._media_exporter.setup()
+
+    def export_sample(self, filepath, metadata=None):
+        self._media_exporter.export(filepath)
 
     def close(self, *args):
         self._media_exporter.close()

--- a/fiftyone/utils/data/exporters.py
+++ b/fiftyone/utils/data/exporters.py
@@ -2393,6 +2393,10 @@ class MediaDirectoryExporter(UnlabeledMediaDatasetExporter):
 
         self._media_exporter = None
 
+    @property
+    def requires_metadata(self):
+        return False
+
     def setup(self):
         self._media_exporter = MediaExporter(
             self.export_media,

--- a/fiftyone/utils/data/importers.py
+++ b/fiftyone/utils/data/importers.py
@@ -434,6 +434,16 @@ def _build_parse_sample_fcn(
                 tags=tags,
             )
 
+    elif isinstance(dataset_importer, UnlabeledMediaDatasetImporter):
+        # Unlabeled media dataset
+
+        # The schema never needs expanding when importing unlabeled samples
+        expand_schema = False
+
+        def parse_sample(sample):
+            filepath, metadata = sample
+            return Sample(filepath=filepath, metadata=metadata, tags=tags)
+
     elif isinstance(dataset_importer, LabeledImageDatasetImporter):
         # Labeled image dataset
 
@@ -1189,6 +1199,52 @@ class UnlabeledVideoDatasetImporter(DatasetImporter):
         :class:`fiftyone.core.metadata.VideoMetadata` instances for each video.
         """
         raise NotImplementedError("subclass must implement has_video_metadata")
+
+
+class UnlabeledMediaDatasetImporter(DatasetImporter):
+    """Interface for importing datasets of unlabeled media samples.
+
+    Typically, dataset importers should implement the parameters documented on
+    this class, although this is not mandatory.
+
+    See :ref:`this page <writing-a-custom-dataset-importer>` for information
+    about implementing/using dataset importers.
+
+    .. automethod:: __len__
+    .. automethod:: __next__
+
+    Args:
+        dataset_dir (None): the dataset directory. This may be optional for
+            some importers
+        shuffle (False): whether to randomly shuffle the order in which the
+            samples are imported
+        seed (None): a random seed to use when shuffling
+        max_samples (None): a maximum number of samples to import. By default,
+            all samples are imported
+    """
+
+    def __next__(self):
+        """Returns information about the next sample in the dataset.
+
+        Returns:
+            an ``(filepath, metadata)`` tuple, where
+
+            -   ``filepath``: the path to the media on disk
+            -   ``metadata``: a
+                :class:`fiftyone.core.metadata.Metadata` instance for the
+                media, or ``None`` if :meth:`has_metadata` is ``False``
+
+        Raises:
+            StopIteration: if there are no more samples to import
+        """
+        raise NotImplementedError("subclass must implement __next__()")
+
+    @property
+    def has_metadata(self):
+        """Whether this importer produces
+        :class:`fiftyone.core.metadata.Metadata` instances for each sample.
+        """
+        raise NotImplementedError("subclass must implement has_metadata")
 
 
 class LabeledImageDatasetImporter(DatasetImporter):
@@ -2131,6 +2187,87 @@ class VideoDirectoryImporter(UnlabeledVideoDatasetImporter):
         filepaths = etau.list_files(dataset_dir, recursive=True)
         filepaths = [p for p in filepaths if etav.is_video_mime_type(p)]
         return len(filepaths)
+
+
+class MediaDirectoryImporter(UnlabeledMediaDatasetImporter):
+    """Importer for a directory of media files stored on disk.
+
+    See :ref:`this page <MediaDirectory-import>` for format details.
+
+    Args:
+        dataset_dir: the dataset directory
+        recursive (True): whether to recursively traverse subdirectories
+        compute_metadata (False): whether to produce
+            :class:`fiftyone.core.metadata.Metadata` instances for each media
+            file when importing
+        shuffle (False): whether to randomly shuffle the order in which the
+            samples are imported
+        seed (None): a random seed to use when shuffling
+        max_samples (None): a maximum number of samples to import. By default,
+            all samples are imported
+    """
+
+    def __init__(
+        self,
+        dataset_dir,
+        recursive=True,
+        compute_metadata=False,
+        shuffle=False,
+        seed=None,
+        max_samples=None,
+    ):
+        super().__init__(
+            dataset_dir=dataset_dir,
+            shuffle=shuffle,
+            seed=seed,
+            max_samples=max_samples,
+        )
+
+        self.recursive = recursive
+        self.compute_metadata = compute_metadata
+
+        self._filepaths = None
+        self._iter_filepaths = None
+        self._num_samples = None
+
+    def __iter__(self):
+        self._iter_filepaths = iter(self._filepaths)
+        return self
+
+    def __len__(self):
+        return self._num_samples
+
+    def __next__(self):
+        filepath = next(self._iter_filepaths)
+
+        if self.compute_metadata:
+            metadata = fom.Metadata.build_for(filepath)
+        else:
+            metadata = None
+
+        return filepath, metadata
+
+    @property
+    def has_dataset_info(self):
+        return False
+
+    @property
+    def has_metadata(self):
+        return self.compute_metadata
+
+    def setup(self):
+        filepaths = etau.list_files(
+            self.dataset_dir, abs_paths=True, recursive=self.recursive
+        )
+        filepaths = self._preprocess_list(filepaths)
+
+        self._filepaths = filepaths
+        self._num_samples = len(filepaths)
+
+    @staticmethod
+    def _get_num_samples(dataset_dir):
+        # Used only by dataset zoo
+        return len(etau.list_files(dataset_dir, recursive=True))
 
 
 class FiftyOneImageClassificationDatasetImporter(

--- a/fiftyone/utils/data/parsers.py
+++ b/fiftyone/utils/data/parsers.py
@@ -561,6 +561,52 @@ class UnlabeledVideoSampleParser(SampleParser):
         )
 
 
+class UnlabeledMediaSampleParser(SampleParser):
+    """Interface for :class:`SampleParser` instances that parse unlabeled
+    media samples.
+
+    The general recipe for using :class:`UnlabeledMediaSampleParser` instances
+    is as follows::
+
+        sample_parser = UnlabeledMediaSampleParser(...)
+
+        for sample in samples:
+            sample_parser.with_sample(sample)
+            filepath = sample_parser.get_media_path()
+            metadata = sample_parser.get_metadata()
+    """
+
+    @property
+    def has_metadata(self):
+        """Whether this parser produces
+        :class:`fiftyone.core.metadata.Metadata` instances for samples that it
+        parses.
+        """
+        raise NotImplementedError("subclass must implement has_metadata")
+
+    def get_media_path(self):
+        """Returns the media path for the current sample.
+
+        Returns:
+            the path to the media on disk
+        """
+        raise NotImplementedError("subclass must implement get_media_path()")
+
+    def get_metadata(self):
+        """Returns the metadata for the current sample.
+
+        Returns:
+            a :class:`fiftyone.core.metadata.Metadata` instance
+        """
+        if not self.has_metadata:
+            raise ValueError(
+                "This '%s' does not provide metadata"
+                % etau.get_class_name(self)
+            )
+
+        raise NotImplementedError("subclass must implement get_metadata()")
+
+
 class ImageSampleParser(UnlabeledImageSampleParser):
     """Sample parser that parses unlabeled image samples.
 
@@ -606,6 +652,21 @@ class VideoSampleParser(UnlabeledVideoSampleParser):
         return False
 
     def get_video_path(self):
+        return self.current_sample
+
+
+class MediaSampleParser(UnlabeledMediaSampleParser):
+    """Sample parser that parses unlabeled media samples.
+
+    This implementation assumes that the provided sample is a path to a media
+    file on disk.
+    """
+
+    @property
+    def has_metadata(self):
+        return False
+
+    def get_media_path(self):
         return self.current_sample
 
 
@@ -1913,3 +1974,32 @@ class FiftyOneLabeledVideoSampleParser(
             frame_fcn_dict = frame_labels_fcn
 
         return frame_labels_dict, frame_fcn_dict
+
+
+class FiftyOneUnlabeledMediaSampleParser(MediaSampleParser):
+    """Parser for :class:`fiftyone.core.sample.Sample` instances that contain
+    unlabeled media.
+
+    Args:
+        compute_metadata (False): whether to compute
+            :class:`fiftyone.core.metadata.Metadata` instances on-the-fly if
+            :meth:`get_metadata` is called and no metadata is available
+    """
+
+    def __init__(self, compute_metadata=False):
+        super().__init__()
+        self.compute_metadata = compute_metadata
+
+    @property
+    def has_metadata(self):
+        return True
+
+    def get_media_path(self):
+        return self.current_sample.filepath
+
+    def get_metadata(self):
+        metadata = self.current_sample.metadata
+        if metadata is None and self.compute_metadata:
+            metadata = fom.Metadata.build_for(self.current_sample.filepath)
+
+        return metadata

--- a/tests/unittests/import_export_tests.py
+++ b/tests/unittests/import_export_tests.py
@@ -4267,6 +4267,59 @@ class MultitaskVideoDatasetTests(VideoDatasetTests):
         self.assertEqual(len(relpath.split(os.path.sep)), 3)
 
 
+class UnlabeledMediaDatasetTests(ImageDatasetTests):
+    def _make_dataset(self):
+        samples = [fo.Sample(filepath=self._new_image()) for _ in range(5)]
+
+        dataset = fo.Dataset()
+        dataset.add_samples(samples)
+
+        return dataset
+
+    @drop_datasets
+    def test_media_directory(self):
+        dataset = self._make_dataset()
+
+        # Standard format
+
+        export_dir = self._new_dir()
+
+        dataset.export(
+            export_dir=export_dir,
+            dataset_type=fo.types.MediaDirectory,
+        )
+
+        dataset2 = fo.Dataset.from_dir(
+            dataset_dir=export_dir,
+            dataset_type=fo.types.MediaDirectory,
+        )
+
+        self.assertEqual(len(dataset), len(dataset2))
+
+        # Standard format (with rel dir)
+
+        export_dir = self._new_dir()
+        rel_dir = self.root_dir
+
+        dataset.export(
+            export_dir=export_dir,
+            dataset_type=fo.types.MediaDirectory,
+            rel_dir=rel_dir,
+        )
+
+        dataset2 = fo.Dataset.from_dir(
+            dataset_dir=export_dir,
+            dataset_type=fo.types.MediaDirectory,
+        )
+
+        self.assertEqual(len(dataset), len(dataset2))
+
+        relpath = _relpath(dataset2.first().filepath, export_dir)
+
+        # _images/<filename>
+        self.assertEqual(len(relpath.split(os.path.sep)), 2)
+
+
 def _relpath(path, start):
     # Avoids errors related to symlinks in `/tmp` directories
     return os.path.relpath(os.path.realpath(path), os.path.realpath(start))


### PR DESCRIPTION
Adds a `MediaDirectory` type for importing/exporting arbitrary (homogeneous) directories of media (images, videos, point clouds, etc).

```py
import fiftyone as fo
import fiftyone.zoo as foz

dataset = foz.load_zoo_dataset("quickstart")
# dataset = foz.load_zoo_dataset("quickstart-video")  # also works

dataset.export(
    export_dir="/tmp/media",
    dataset_type=fo.types.MediaDirectory,
)

dataset2 = fo.Dataset.from_dir(
    dataset_dir="/tmp/media",
    dataset_type=fo.types.MediaDirectory,
)
```
