### PR TITLE
Add support filtering by dynamic properties in keypoints

### DIFF
--- a/app/packages/core/src/components/Filters/categoricalFilter/Wrapper.tsx
+++ b/app/packages/core/src/components/Filters/categoricalFilter/Wrapper.tsx
@@ -76,8 +76,10 @@ const Wrapper = ({
     ? fieldSchema?.dbField?.toLowerCase()
     : undefined;
 
-  // if the field is a BooleanField, there is no need to show the exclude option
-  const shouldNotShowExclude = Boolean(schema?.ftype.includes("BooleanField"));
+  // if the field is a BooleanField or ListField(BooleanField), there is no need to show the exclude option
+  const shouldNotShowExclude =
+    schema?.ftype.includes("BooleanField") ||
+    schema?.subfield?.includes("BooleanField");
 
   // if the field is a keypoint label, there is no need to show match options
   const isKeyPoints = fieldSchema?.dbField === "keypoints";
@@ -136,7 +138,7 @@ const Wrapper = ({
       ))}
       {Boolean(selectedSet.size) && (
         <>
-          {(
+          {
             <FilterOption
               nestedField={nestedField}
               shouldNotShowExclude={shouldNotShowExclude}
@@ -148,7 +150,7 @@ const Wrapper = ({
               modal={modal}
               isKeyPointLabel={isKeyPoints}
             />
-          )}
+          }
           <Button
             text={"Reset"}
             color={color}

--- a/app/packages/core/src/components/Filters/categoricalFilter/filterOption/FilterOption.tsx
+++ b/app/packages/core/src/components/Filters/categoricalFilter/filterOption/FilterOption.tsx
@@ -54,7 +54,9 @@ const generateOptions = (
       icon: "FilterAltIcon",
       key: "filter",
       value: `Select ${nestedField} with ${valueName}`,
-      tooltip: "dataset.filter_labels(field, expr, only_matches=True)",
+      tooltip: isKeyPointLabel
+        ? "dataset.filter_keypoints(field, expr, only_matches=True)"
+        : "dataset.filter_labels(field, expr, only_matches=True)",
     });
   }
   if (nestedField && !shouldNotShowExclude) {
@@ -62,7 +64,9 @@ const generateOptions = (
       icon: "FilterAltOffIcon",
       key: "negativeFilter",
       value: `Exclude ${nestedField} with ${valueName}`,
-      tooltip: "dataset.filter_labels(field, ~expr, only_matches=False)",
+      tooltip: isKeyPointLabel
+        ? "dataset.filter_keypoints(field, ~expr, only_matches=False)"
+        : "dataset.filter_labels(field, ~expr, only_matches=False)",
     });
   }
   if (!modal && !isKeyPointLabel) {

--- a/app/packages/looker/src/overlays/keypoint.ts
+++ b/app/packages/looker/src/overlays/keypoint.ts
@@ -45,9 +45,7 @@ export default class KeypointOverlay<
     ctx.lineWidth = 0;
 
     const skeleton = getSkeleton(this.field, state);
-    console.info(skeleton);
     const points = this.getFilteredPoints(state, skeleton);
-    // console.info(points)
     if (skeleton && state.options.showSkeletons) {
       for (let i = 0; i < skeleton.edges.length; i++) {
         const path = skeleton.edges[i].map((index) => points[index]);

--- a/app/packages/looker/src/overlays/keypoint.ts
+++ b/app/packages/looker/src/overlays/keypoint.ts
@@ -4,7 +4,13 @@
 
 import { getColor } from "@fiftyone/utilities";
 import { INFO_COLOR, TOLERANCE } from "../constants";
-import { BaseState, Coordinates, KeypointSkeleton, NONFINITE } from "../state";
+import {
+  BaseState,
+  Coordinates,
+  KeypointSkeleton,
+  NONFINITE,
+  Point,
+} from "../state";
 import { distance, distanceFromLineSegment, multiply } from "../util";
 import { CONTAINS, CoordinateOverlay, PointInfo, RegularLabel } from "./base";
 import { t } from "./util";
@@ -39,8 +45,9 @@ export default class KeypointOverlay<
     ctx.lineWidth = 0;
 
     const skeleton = getSkeleton(this.field, state);
+    console.info(skeleton);
     const points = this.getFilteredPoints(state, skeleton);
-
+    // console.info(points)
     if (skeleton && state.options.showSkeletons) {
       for (let i = 0; i < skeleton.edges.length; i++) {
         const path = skeleton.edges[i].map((index) => points[index]);
@@ -185,7 +192,9 @@ export default class KeypointOverlay<
       return p.every((c) => typeof c === "number") &&
         state.options.pointFilter(
           this.field,
-          Object.fromEntries(getAttributes(skeleton, this.label, i))
+          Object.fromEntries(
+            getAttributes(skeleton, this.label, i)
+          ) as unknown as Point
         )
         ? p
         : null;

--- a/app/packages/state/src/recoil/pathFilters/boolean.ts
+++ b/app/packages/state/src/recoil/pathFilters/boolean.ts
@@ -6,7 +6,7 @@ import {
 } from "recoil";
 import * as filterAtoms from "../filters";
 
-interface BooleanFilter {
+export interface BooleanFilter {
   false: boolean;
   true: boolean;
   none: boolean;

--- a/app/packages/state/src/recoil/pathFilters/index.ts
+++ b/app/packages/state/src/recoil/pathFilters/index.ts
@@ -53,7 +53,7 @@ const primitiveFilter = selectorFamily<
       }
 
       if ([LIST_FIELD].includes(ftype)) {
-        return get(listString({ modal, path}));
+        return get(listString({ modal, path }));
       }
 
       return (value) => true;
@@ -79,6 +79,7 @@ export const pathFilter = selectorFamily<PathFilterSelector, boolean>({
         if (path.startsWith("_")) return f;
 
         const field = get(schemaAtoms.field(path));
+        const isKeypoints = path.includes("keypoints");
 
         if (field && LABELS.includes(field.embeddedDocType)) {
           const expandedPath = get(schemaAtoms.expandPath(path));
@@ -95,7 +96,9 @@ export const pathFilter = selectorFamily<PathFilterSelector, boolean>({
             );
 
             return (value: unknown) =>
-              filter(value[name === "id" ? "id" : dbField || name]);
+              isKeypoints && typeof value[name] === "object" // keypoints ListFields
+                ? () => true
+                : filter(value[name === "id" ? "id" : dbField || name]);
           });
 
           f[path] = (value: unknown) => {

--- a/app/packages/state/src/recoil/skeletonFilter.ts
+++ b/app/packages/state/src/recoil/skeletonFilter.ts
@@ -2,7 +2,7 @@ import { Point } from "@fiftyone/looker";
 import { selectorFamily } from "recoil";
 import { filters, modalFilters } from "./filters";
 import { NumericFilter } from "./pathFilters/numeric";
-import { StringFilter } from "./pathFilters/string";
+import { string, StringFilter } from "./pathFilters/string";
 import { expandPath } from "./schema";
 
 export default selectorFamily<(path: string, value: Point) => boolean, boolean>(
@@ -14,56 +14,92 @@ export default selectorFamily<(path: string, value: Point) => boolean, boolean>(
         const f = get(modal ? modalFilters : filters);
         return getCallback(({ snapshot }) => (path: string, value: Point) => {
           path = snapshot.getLoadable(expandPath(path)).contents;
-          const labels = f[`${path}.points`] as StringFilter;
+          let result: boolean = true;
 
+          const stringListFilters: string[] = [];
+          const numberListFilters: string[] = [];
+
+          Object.entries(value).forEach(([k, v]) => {
+            if (typeof v === "string" && !["label"].includes(k)) {
+              stringListFilters.push(k);
+            }
+            if (typeof v === "number") {
+              numberListFilters.push(k);
+            }
+          });
+
+          // skeleton points is a special case:
+          const labels = f[`${path}.points`] as StringFilter;
           if (labels && labels.values.length && value.label) {
             const included = labels.values.includes(value.label);
             if (labels.exclude) {
               if (included) {
-                return false;
+                result = false;
               }
             } else if (!labels.exclude) {
               if (!included) {
-                return false;
+                result = false;
               }
             }
           }
 
-          const confidence = f[`${path}.confidence`] as NumericFilter;
-          if (confidence) {
-            if (typeof value.confidence !== "number") {
-              switch (value.confidence) {
-                case "inf":
-                  return confidence.inf
-                    ? !confidence.exclude
-                    : confidence.exclude;
-                case "ninf":
-                  return confidence.ninf
-                    ? !confidence.exclude
-                    : confidence.exclude;
-                case "nan":
-                  return confidence.nan
-                    ? !confidence.exclude
-                    : confidence.exclude;
-                case null:
-                  return confidence.none
-                    ? !confidence.exclude
-                    : confidence.exclude;
-                case undefined:
-                  return confidence.none
-                    ? !confidence.exclude
-                    : confidence.exclude;
+          stringListFilters.forEach((key) => {
+            const strFilter = f[`${path}.${key}`] as StringFilter;
+            if (strFilter && strFilter.values.length && value[key]) {
+              const included = strFilter.values.includes(value[key]);
+              if (strFilter.exclude) {
+                if (included) {
+                  result = false;
+                }
+              } else if (!strFilter.exclude) {
+                if (!included) {
+                  result = false;
+                }
               }
             }
+          });
 
-            const includes =
-              value.confidence >= confidence.range[0] &&
-              value.confidence <= confidence.range[1];
+          numberListFilters.forEach((key) => {
+            const numFilter = f[`${path}.${key}`] as NumericFilter;
+            if (numFilter) {
+              if (typeof value[key] !== "number") {
+                switch (value[key]) {
+                  case "inf":
+                    return numFilter.inf
+                      ? !numFilter.exclude
+                      : numFilter.exclude;
+                  case "ninf":
+                    return numFilter.ninf
+                      ? !numFilter.exclude
+                      : numFilter.exclude;
+                  case "nan":
+                    return numFilter.nan
+                      ? !numFilter.exclude
+                      : numFilter.exclude;
+                  case null:
+                    return numFilter.none
+                      ? !numFilter.exclude
+                      : numFilter.exclude;
+                  case undefined:
+                    return numFilter.none
+                      ? !numFilter.exclude
+                      : numFilter.exclude;
+                }
+              }
 
-            return includes ? !confidence.exclude : confidence.exclude;
-          }
+              const includes =
+                value[key] >= numFilter.range[0] &&
+                value[key] <= numFilter.range[1];
+              const r = numFilter.exclude ? !includes : includes;
 
-          return true;
+              if (!r) {
+                console.log("5");
+                result = false;
+              }
+            }
+          });
+          console.info("result", result);
+          return result;
         });
       },
   }

--- a/app/packages/state/src/recoil/skeletonFilter.ts
+++ b/app/packages/state/src/recoil/skeletonFilter.ts
@@ -12,12 +12,10 @@ export default selectorFamily<(path: string, value: Point) => boolean, boolean>(
       (modal) =>
       ({ get, getCallback }) => {
         const f = get(modal ? modalFilters : filters);
-        console.info("line1");
         return getCallback(({ snapshot }) => (path: string, value: Point) => {
-          console.info("line2");
           path = snapshot.getLoadable(expandPath(path)).contents;
-
           const labels = f[`${path}.points`] as StringFilter;
+
           if (labels && labels.values.length && value.label) {
             const included = labels.values.includes(value.label);
             if (labels.exclude) {
@@ -32,7 +30,6 @@ export default selectorFamily<(path: string, value: Point) => boolean, boolean>(
           }
 
           const confidence = f[`${path}.confidence`] as NumericFilter;
-
           if (confidence) {
             if (typeof value.confidence !== "number") {
               switch (value.confidence) {

--- a/app/packages/state/src/recoil/skeletonFilter.ts
+++ b/app/packages/state/src/recoil/skeletonFilter.ts
@@ -2,7 +2,7 @@ import { Point } from "@fiftyone/looker";
 import { selectorFamily } from "recoil";
 import { filters, modalFilters } from "./filters";
 import { NumericFilter } from "./pathFilters/numeric";
-import { string, StringFilter } from "./pathFilters/string";
+import { StringFilter } from "./pathFilters/string";
 import { expandPath } from "./schema";
 
 export default selectorFamily<(path: string, value: Point) => boolean, boolean>(
@@ -93,12 +93,10 @@ export default selectorFamily<(path: string, value: Point) => boolean, boolean>(
               const r = numFilter.exclude ? !includes : includes;
 
               if (!r) {
-                console.log("5");
                 result = false;
               }
             }
           });
-          console.info("result", result);
           return result;
         });
       },

--- a/app/packages/state/src/recoil/skeletonFilter.ts
+++ b/app/packages/state/src/recoil/skeletonFilter.ts
@@ -12,10 +12,12 @@ export default selectorFamily<(path: string, value: Point) => boolean, boolean>(
       (modal) =>
       ({ get, getCallback }) => {
         const f = get(modal ? modalFilters : filters);
+        console.info("line1");
         return getCallback(({ snapshot }) => (path: string, value: Point) => {
+          console.info("line2");
           path = snapshot.getLoadable(expandPath(path)).contents;
-          const labels = f[`${path}.points`] as StringFilter;
 
+          const labels = f[`${path}.points`] as StringFilter;
           if (labels && labels.values.length && value.label) {
             const included = labels.values.includes(value.label);
             if (labels.exclude) {


### PR DESCRIPTION
## What changes are proposed in this pull request?

We used to filter keypoints by only confidence and points(label). 
Updated the FE and BE to support other properties and fixed some issues. 

https://user-images.githubusercontent.com/17770824/216675550-ddaef8b9-fd40-4e14-af47-b6cf93cb36af.mov



## How is this patch tested? If it is not, please explain why.



## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
