### PR TITLE
Handling manual unwinds in aggregations

### DIFF
--- a/fiftyone/core/aggregations.py
+++ b/fiftyone/core/aggregations.py
@@ -1129,7 +1129,11 @@ class FacetAggregations(Aggregation):
 
     @staticmethod
     def _get_key(agg):
-        return agg.field_name.replace(".", "_") + "_" + agg.__class__.__name__
+        return (
+            agg.field_name.replace(".", "_").replace("[]", "")
+            + "_"
+            + agg.__class__.__name__
+        )
 
     @staticmethod
     def _parse_aggregations(field_name, aggregations):

--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -8591,21 +8591,27 @@ class SampleCollection(object):
                 compiled[idx] = aggregation
                 continue
 
-            keys = aggregation.field_name.split(".")
-            path = ""
-            subfield_name = keys[-1]
-            for num in range(len(keys), 0, -1):
-                path = ".".join(keys[:num])
-                subfield_name = ".".join(keys[num:])
-                field = self.get_field(path)
-                if isinstance(field, fof.ListField) and isinstance(
-                    field.field, fof.EmbeddedDocumentField
-                ):
-                    break
+            # @todo optimize this
+            field_name = aggregation.field_name
+            if "[]" in field_name:
+                root = field_name
+                leaf = ""
+            else:
+                keys = field_name.split(".")
+                root = ""
+                leaf = keys[-1]
+                for num in range(len(keys), 0, -1):
+                    root = ".".join(keys[:num])
+                    leaf = ".".join(keys[num:])
+                    field = self.get_field(root)
+                    if isinstance(field, fof.ListField) and isinstance(
+                        field.field, fof.EmbeddedDocumentField
+                    ):
+                        break
 
             aggregation = copy(aggregation)
-            aggregation._field_name = subfield_name
-            compiled[path][idx] = aggregation
+            aggregation._field_name = leaf
+            compiled[root][idx] = aggregation
 
         for field_name, aggregations in compiled.items():
             if isinstance(aggregations, foa.Aggregation):

--- a/tests/unittests/aggregation_tests.py
+++ b/tests/unittests/aggregation_tests.py
@@ -147,6 +147,33 @@ class DatasetTests(unittest.TestCase):
             d.count_values("frames.classifications.classifications.label"),
             {"one": 1, "two": 2},
         )
+        self.assertEqual(
+            d.count_values(
+                F("frames.classifications.classifications.label").upper()
+            ),
+            {"ONE": 1, "TWO": 2},
+        )
+
+        self.assertEqual(
+            d.count_values("classifications.classifications[].label"),
+            {"one": 1, "two": 2},
+        )
+        self.assertEqual(
+            d.count_values(
+                F("classifications.classifications[].label").upper()
+            ),
+            {"ONE": 1, "TWO": 2},
+        )
+        self.assertEqual(
+            d.count_values("frames[].classifications.classifications[].label"),
+            {"one": 1, "two": 2},
+        )
+        self.assertEqual(
+            d.count_values(
+                F("frames[].classifications.classifications[].label").upper()
+            ),
+            {"ONE": 1, "TWO": 2},
+        )
 
     @drop_datasets
     def test_distinct(self):


### PR DESCRIPTION
Fixes a bug identified by @allenleetc:

```py
import fiftyone as fo
import fiftyone.zoo as foz

dataset = foz.load_zoo_dataset("quickstart-video")

dataset.count_values('frames[].detections.detections[].label')
# develop: {}
# this branch: {'person': 1108, 'vehicle': 7511, 'road sign': 2726}
```
