### PR TITLE
Always use IDs in plots and brain results

### DIFF
--- a/docs/source/user_guide/plots.rst
+++ b/docs/source/user_guide/plots.rst
@@ -567,7 +567,6 @@ notebook:
     :linenos:
 
     import fiftyone as fo
-    import fiftyone.core.plots as fop
     import fiftyone.zoo as foz
     from fiftyone import ViewField as F
 
@@ -584,7 +583,7 @@ notebook:
     view = dataset.filter_labels("frames.detections", F("label") == "vehicle")
 
     # Plot the number of vehicles in each frame of a video dataset
-    plot = fop.lines(
+    plot = fo.lines(
         x="frames.frame_number",
         y=F("frames.detections.detections").length(),
         labels="id",
@@ -742,7 +741,7 @@ notebook:
 
     # Define some interesting plots
     plot1 = fo.NumericalHistogram(F("metadata.size_bytes") / 1024, bins=50, xlabel="image size (KB)")
-    plot2 = fo.NumericalHistogram("predictions.detections.confidence", bins=50)
+    plot2 = fo.NumericalHistogram("predictions.detections.confidence", bins=50, range=[0, 1])
     plot3 = fo.CategoricalHistogram("ground_truth.detections.label", order="frequency")
     plot4 = fo.CategoricalHistogram("predictions.detections.label", order="frequency")
 

--- a/docs/source/user_guide/plots.rst
+++ b/docs/source/user_guide/plots.rst
@@ -361,9 +361,6 @@ contains |GeoLocation| data in its ``location`` field:
     dataset = foz.load_zoo_dataset("quickstart-geo")
     fob.compute_uniqueness(dataset)
 
-    # Index the dataset by visual uniqueness
-    fob.compute_uniqueness(dataset)
-
     # A list of ``[longitude, latitude]`` coordinates
     locations = dataset.values("location.point.coordinates")
 

--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -9263,6 +9263,25 @@ class SampleCollection(object):
             new_field=new_field,
         )
 
+    def _get_values_by_id(self, path_or_expr, ids, link_field=None):
+        if link_field == "frames":
+            if self._is_frames:
+                id_path = "id"
+            else:
+                id_path = "frames.id"
+        elif link_field is not None:
+            _, id_path = self._get_label_field_path(link_field, "id")
+        elif self._is_patches:
+            id_path = "sample_id"
+        else:
+            id_path = "id"
+
+        values_map = {
+            i: v
+            for i, v in zip(*self.values([id_path, path_or_expr], unwind=True))
+        }
+        return [values_map.get(i, None) for i in ids]
+
 
 def _unwind_values(values, level=0):
     if not values:

--- a/fiftyone/core/plots/matplotlib.py
+++ b/fiftyone/core/plots/matplotlib.py
@@ -1400,9 +1400,11 @@ def _plot_scatter(
     figsize=None,
     **kwargs,
 ):
-    if labels is not None:
+    if labels is not None and classes is not None:
         values_map = {c: i for i, c in enumerate(classes)}
         values = np.array([values_map.get(l, -1) for l in labels])
+    else:
+        values = labels
 
     scatter_3d = points.shape[1] == 3
 

--- a/fiftyone/core/plots/matplotlib.py
+++ b/fiftyone/core/plots/matplotlib.py
@@ -542,6 +542,11 @@ def lines(
     else:
         show_legend = labels[0] is not None
 
+    if ids[0] is not None:
+        ids = list(itertools.chain.from_iterable(ids))
+    else:
+        ids = None
+
     with plt.style.context(style):
         collection = _plot_lines(
             x,
@@ -1339,12 +1344,6 @@ def _plot_lines(
         num_points = sum(len(xi) for xi in x)
         marker_size = 2.0 * (10 ** (4 - np.log10(num_points)))
         marker_size = max(1, min(marker_size, 50))
-
-    if sizes is None:
-        sizes = itertools.repeat(None)
-
-    if labels is None:
-        labels = itertools.repeat(None)
 
     colors = _get_qualitative_colors(len(y), colors=colors)
 

--- a/fiftyone/core/plots/matplotlib.py
+++ b/fiftyone/core/plots/matplotlib.py
@@ -7,7 +7,6 @@ Matplotlib plots.
 """
 import itertools
 import logging
-import warnings
 
 import numpy as np
 import matplotlib as mpl
@@ -17,22 +16,22 @@ import matplotlib.pyplot as plt
 from mpl_toolkits.axes_grid1 import make_axes_locatable
 from mpl_toolkits.axes_grid1.inset_locator import InsetPosition
 from mpl_toolkits.mplot3d import Axes3D  # pylint: disable=unused-import
-import sklearn.linear_model as skl
 import sklearn.metrics.pairwise as skp
 import sklearn.metrics as skm
 
 import eta.core.utils as etau
 
 import fiftyone.core.context as foc
-import fiftyone.core.expressions as foe
-import fiftyone.core.fields as fof
-import fiftyone.core.labels as fol
-import fiftyone.core.patches as fop
 import fiftyone.core.utils as fou
-import fiftyone.core.video as fov
 
 from .base import InteractivePlot
-from .utils import load_button_icon
+from .utils import (
+    best_fit_line,
+    load_button_icon,
+    parse_lines_inputs,
+    parse_locations,
+    parse_scatter_inputs,
+)
 
 
 logger = logging.getLogger(__name__)
@@ -206,43 +205,6 @@ def plot_regressions(
     Returns:
         a matplotlib figure
     """
-    if ax is None:
-        _, ax = plt.subplots()
-
-    points = np.stack([ytrue, ypred], axis=-1)
-
-    points, labels, sizes, _, inds, _ = _parse_scatter_inputs(
-        points, labels, sizes, classes
-    )
-
-    if ids is not None and inds is not None:
-        ids = np.asarray(ids)[inds]
-
-    ytrue = points[:, 0]
-    ypred = points[:, 1]
-
-    if best_fit_label is None:
-        r2_score = skm.r2_score(ytrue, ypred, sample_weight=None)
-        best_fit_label = "r^2: %0.3f" % r2_score
-
-    model = skl.LinearRegression()
-    model.fit(ytrue[:, np.newaxis], ypred)
-
-    xline = np.array([ytrue.min(), ytrue.max()])
-    yline = model.predict(xline[:, np.newaxis])
-
-    xlabel = gt_field if gt_field is not None else "Ground truth"
-    ylabel = pred_field if pred_field is not None else "Predictions"
-
-    if style is None:
-        style = _DEFAULT_STYLE
-
-    with plt.style.context(style):
-        ax.plot(xline, yline, color="k", label=best_fit_label)
-        ax.set(xlabel=xlabel, ylabel=ylabel)
-        ax.legend()
-        ax.axis("equal")
-
     if (
         samples is not None
         and gt_field is not None
@@ -251,6 +213,35 @@ def plot_regressions(
         link_field = "frames"
     else:
         link_field = None
+
+    points = np.stack([ytrue, ypred], axis=-1)
+
+    points, ids, labels, sizes, _, _, _ = parse_scatter_inputs(
+        points,
+        samples=samples,
+        ids=ids,
+        link_field=link_field,
+        labels=labels,
+        sizes=sizes,
+        classes=classes,
+    )
+
+    xline, yline, best_fit_label = best_fit_line(points, label=best_fit_label)
+
+    xlabel = gt_field if gt_field is not None else "Ground truth"
+    ylabel = pred_field if pred_field is not None else "Predictions"
+
+    if style is None:
+        style = _DEFAULT_STYLE
+
+    if ax is None:
+        _, ax = plt.subplots()
+
+    with plt.style.context(style):
+        ax.plot(xline, yline, color="k", label=best_fit_label)
+        ax.set(xlabel=xlabel, ylabel=ylabel)
+        ax.legend()
+        ax.axis("equal")
 
     return scatterplot(
         points,
@@ -533,60 +524,23 @@ def lines(
         -   an :class:`InteractiveCollection`, when IDs are available
         -   a matplotlib figure, otherwise
     """
-    if y is None:
-        raise ValueError("You must provide 'y' values")
-
-    if etau.is_str(y) or isinstance(y, foe.ViewExpression):
-        if samples is not None and samples._contains_videos():
-            is_frames = foe.is_frames_expr(y)
-        else:
-            is_frames = False
-    else:
-        is_frames = y and etau.is_container(y[0])
-
-    if is_frames and link_field is None:
-        link_field = "frames"
-
-    y = _parse_values(y, "y", samples=samples, is_frames=is_frames)
-
-    if x is None:
-        if is_frames:
-            x = [np.arange(1, len(yi) + 1) for yi in y]
-        else:
-            x = np.arange(1, len(y) + 1)
-    else:
-        x = _parse_values(x, "x", samples=samples, ref=y, is_frames=is_frames)
-
-    if is_frames and x and not etau.is_container(x[0]):
-        x = [x] * len(y)
-
-    sizes = _parse_values(
-        sizes, "sizes", samples=samples, ref=y, is_frames=is_frames
+    x, y, ids, link_field, labels, sizes, is_frames = parse_lines_inputs(
+        x=x,
+        y=y,
+        samples=samples,
+        ids=ids,
+        link_field=link_field,
+        labels=labels,
+        sizes=sizes,
     )
-
-    if is_frames:
-        if sizes is None:
-            sizes = itertools.repeat(None)
-
-        if labels is None:
-            labels = [str(i) for i in range(1, len(y) + 1)]
-        elif etau.is_str(labels):
-            labels = _parse_values(labels, "labels", samples=samples)
-
-        show_legend = True
-    else:
-        x = [x]
-        y = [y]
-        sizes = [sizes]
-        labels = [labels]
-        show_legend = labels[0] is not None
-
-    if ids is None and samples is not None:
-        ref = list(itertools.chain.from_iterable(y))
-        ids = _get_ids(samples, link_field=link_field, ref=ref)
 
     if style is None:
         style = _DEFAULT_STYLE
+
+    if is_frames:
+        show_legend = True
+    else:
+        show_legend = labels[0] is not None
 
     with plt.style.context(style):
         collection = _plot_lines(
@@ -732,27 +686,34 @@ def scatterplot(
     if num_dims not in {2, 3}:
         raise ValueError("This method only supports 2D or 3D points")
 
-    labels = _parse_values(labels, "labels", samples=samples, ref=points)
-    sizes = _parse_values(sizes, "sizes", samples=samples, ref=points)
-
-    if ids is not None:
-        ids = np.asarray(ids)
-    elif samples is not None:
-        if num_dims != 2:
-            msg = "Interactive selection is only supported in 2D"
-            warnings.warn(msg)
-        else:
-            ids = _get_ids(samples, link_field=link_field, ref=points)
+    (
+        points,
+        ids,
+        labels,
+        sizes,
+        _,
+        classes,
+        categorical,
+    ) = parse_scatter_inputs(
+        points,
+        samples=samples,
+        ids=ids,
+        link_field=link_field,
+        labels=labels,
+        sizes=sizes,
+        classes=classes,
+    )
 
     if style is None:
         style = _DEFAULT_STYLE
 
     with plt.style.context(style):
-        collection, inds = _plot_scatter(
+        collection = _plot_scatter(
             points,
             labels=labels,
             sizes=sizes,
             classes=classes,
+            categorical=categorical,
             marker_size=marker_size,
             cmap=cmap,
             ax=ax,
@@ -768,9 +729,6 @@ def scatterplot(
             fig = collection.axes.figure
             plt.tight_layout()
             return fig
-
-        if ids is not None and inds is not None:
-            ids = ids[inds]
 
         (
             link_type,
@@ -792,88 +750,6 @@ def scatterplot(
             selection_mode=selection_mode,
             init_fcn=init_fcn,
         )
-
-
-def _parse_values(values, parameter, samples=None, ref=None, is_frames=False):
-    if values is None:
-        return None
-
-    if etau.is_str(values) or isinstance(values, foe.ViewExpression):
-        if samples is None:
-            raise ValueError(
-                "You must provide `samples` in order to extract field values "
-                "for the `%s` parameter" % parameter
-            )
-
-        values = samples.values(values)
-
-    if is_frames:
-        values = [_unwind_values(v) for v in values]
-    else:
-        values = _unwind_values(values)
-
-    if ref is not None:
-        _validate_values(values, ref, parameter, is_frames=is_frames)
-
-    return values
-
-
-def _get_ids(samples, link_field=None, ref=None, is_frames=False):
-    if link_field is None:
-        ids = samples.values("id")
-        ptype = "sample"
-    elif link_field == "frames":
-        ids = samples.values("frames.id")
-        ptype = "frame"
-    else:
-        _, id_path = samples._get_label_field_path(link_field, "id")
-        ids = samples.values(id_path)
-        ptype = "label"
-
-    if is_frames:
-        ids = [_unwind_values(_ids) for _ids in ids]
-    else:
-        ids = _unwind_values(ids)
-
-    if ref is not None:
-        values_type = "%s IDs" % ptype
-        _validate_values(ids, ref, values_type, is_frames=is_frames)
-
-    return ids
-
-
-def _unwind_values(values):
-    while any(isinstance(v, (list, tuple)) for v in values):
-        values = list(itertools.chain.from_iterable(v for v in values if v))
-
-    return values
-
-
-def _validate_values(values, ref, values_type, is_frames=False):
-    if not is_frames:
-        if len(values) != len(ref):
-            raise ValueError(
-                "Inconsistent number of %s (%d != %d). You may have missing "
-                "data/labels that you need to omit from your view"
-                % (values_type, len(values), len(ref))
-            )
-
-        return
-
-    if len(values) != len(ref):
-        raise ValueError(
-            "Inconsistent number of %s traces (%d != %d). You may have "
-            "missing data/labels that you need to omit from your view"
-            % (values_type, len(values), len(ref))
-        )
-
-    for idx, (_values, _ref) in enumerate(zip(values, ref), 1):
-        if len(_values) != len(_ref):
-            raise ValueError(
-                "Inconsistent number of %s (%d != %d) in trace %d/%d. You may "
-                "have missing data/labels that you need to omit from your view"
-                % (values_type, len(_values), len(_ref), idx, len(values))
-            )
 
 
 def location_scatterplot(
@@ -969,7 +845,7 @@ def location_scatterplot(
         -   an :class:`InteractiveCollection`, if IDs are available
         -   a matplotlib figure, otherwise
     """
-    locations = _parse_locations(locations, samples)
+    locations = parse_locations(locations, samples, ids=ids)
 
     if ax is None:
         fig = plt.figure()
@@ -1011,28 +887,6 @@ def location_scatterplot(
         buttons=buttons,
         **kwargs,
     )
-
-
-def _parse_locations(locations, samples):
-    if locations is not None and not etau.is_str(locations):
-        return np.asarray(locations)
-
-    if samples is None:
-        raise ValueError(
-            "You must provide `samples` in order to extract `locations` from "
-            "your dataset"
-        )
-
-    if locations is None:
-        location_field = samples._get_geo_location_field()
-    else:
-        location_field = locations
-        samples.validate_field_type(
-            location_field, embedded_doc_type=fol.GeoLocation
-        )
-
-    locations = samples.values(location_field + ".point.coordinates")
-    return np.asarray(locations)
 
 
 class InteractiveMatplotlibPlot(InteractivePlot):
@@ -1538,6 +1392,7 @@ def _plot_scatter(
     labels=None,
     sizes=None,
     classes=None,
+    categorical=False,
     marker_size=None,
     cmap=None,
     ax=None,
@@ -1545,9 +1400,9 @@ def _plot_scatter(
     figsize=None,
     **kwargs,
 ):
-    points, values, sizes, classes, inds, categorical = _parse_scatter_inputs(
-        points, labels, sizes, classes
-    )
+    if labels is not None:
+        values_map = {c: i for i, c in enumerate(classes)}
+        values = np.array([values_map.get(l, -1) for l in labels])
 
     scatter_3d = points.shape[1] == 3
 
@@ -1626,7 +1481,7 @@ def _plot_scatter(
     if ax_equal:
         collection.axes.axis("equal")
 
-    return collection, inds
+    return collection
 
 
 def _get_qualitative_colors(num_classes, colors=None):
@@ -1641,36 +1496,6 @@ def _get_qualitative_colors(num_classes, colors=None):
     # @todo can we blend when there are more classes than colors?
     colors = list(colors)
     return [colors[i % len(colors)] for i in range(num_classes)]
-
-
-def _parse_scatter_inputs(points, labels, sizes, classes):
-    if sizes is not None:
-        sizes = np.asarray(sizes)
-
-    if labels is None:
-        return points, None, sizes, None, None, False
-
-    labels = np.asarray(labels)
-
-    if not etau.is_str(labels[0]):
-        return points, labels, sizes, None, None, False
-
-    if classes is None:
-        classes = sorted(set(labels))
-
-    values_map = {c: i for i, c in enumerate(classes)}
-    values = np.array([values_map.get(l, -1) for l in labels])
-
-    found = values >= 0
-    if not np.all(found):
-        points = points[found, :]
-        values = values[found]
-        if sizes is not None:
-            sizes = sizes[found]
-    else:
-        found = None
-
-    return points, values, sizes, classes, found, True
 
 
 def _plot_map_background(ax, locations, api_key, map_type, show_scale_bar):

--- a/fiftyone/core/plots/plotly.py
+++ b/fiftyone/core/plots/plotly.py
@@ -801,6 +801,12 @@ def lines(
             notebook but the above conditions aren't met
         -   a plotly figure, otherwise
     """
+    if sizes is not None and sizes_title is None:
+        if etau.is_str(sizes):
+            sizes_title = sizes.rsplit(".", 1)[-1]
+        else:
+            sizes_title = "size"
+
     x, y, ids, link_field, labels, sizes, is_frames = parse_lines_inputs(
         x=x,
         y=y,
@@ -826,31 +832,20 @@ def lines(
     else:
         ytitle = "y"
 
-    if sizes is not None and sizes_title is None:
-        if etau.is_str(sizes):
-            sizes_title = sizes.rsplit(".", 1)[-1]
-        else:
-            sizes_title = "size"
-
     hover_lines = ["%s: %%{x}" % xtitle, "%s: %%{y}" % ytitle]
 
-    if sizes is not None:
+    if sizes[0] is not None:
         hover_lines.append("%s: %%{marker.size}" % sizes_title)
 
         if marker_size is None:
             marker_size = 15  # max marker size
 
-        if is_frames:
-            _sizes = list(itertools.chain(*sizes))
-        else:
-            _sizes = sizes
-
         try:
-            sizeref = 0.5 * max(_sizes) / marker_size
+            sizeref = 0.5 * max(itertools.chain(*sizes)) / marker_size
         except ValueError:
             sizeref = 1
 
-    if ids is not None or samples is not None:
+    if ids[0] is not None:
         hover_lines.append("ID: %{customdata}")
 
     hovertemplate = "<br>".join(hover_lines) + "<extra></extra>"

--- a/fiftyone/core/plots/plotly.py
+++ b/fiftyone/core/plots/plotly.py
@@ -16,20 +16,20 @@ from PIL import ImageColor
 import plotly.colors as pc
 import plotly.express as px
 import plotly.graph_objects as go
-import sklearn.linear_model as skl
-import sklearn.metrics as skm
 
 import eta.core.utils as etau
 
 import fiftyone.core.context as foc
-import fiftyone.core.expressions as foe
-import fiftyone.core.fields as fof
 import fiftyone.core.labels as fol
-import fiftyone.core.patches as fop
 import fiftyone.core.utils as fou
-import fiftyone.core.video as fov
 
 from .base import Plot, InteractivePlot, ResponsivePlot
+from .utils import (
+    best_fit_line,
+    parse_lines_inputs,
+    parse_locations,
+    parse_scatter_inputs,
+)
 
 
 logger = logging.getLogger(__name__)
@@ -363,22 +363,17 @@ def plot_regressions(
         _,
         classes,
         categorical,
-    ) = _parse_scatter_inputs(
-        points, samples, ids, link_field, labels, sizes, None, classes
+    ) = parse_scatter_inputs(
+        points,
+        samples=samples,
+        ids=ids,
+        link_field=link_field,
+        labels=labels,
+        sizes=sizes,
+        classes=classes,
     )
 
-    ytrue = points[:, 0]
-    ypred = points[:, 1]
-
-    if best_fit_label is None:
-        r2_score = skm.r2_score(ytrue, ypred, sample_weight=None)
-        best_fit_label = "r^2: %0.3f" % r2_score
-
-    model = skl.LinearRegression()
-    model.fit(ytrue[:, np.newaxis], ypred)
-
-    xline = np.array([ytrue.min(), ytrue.max()])
-    yline = model.predict(xline[:, np.newaxis])
+    xline, yline, best_fit_label = best_fit_line(points, label=best_fit_label)
 
     xlabel = gt_field if gt_field is not None else "Ground truth"
     ylabel = pred_field if pred_field is not None else "Predictions"
@@ -806,18 +801,30 @@ def lines(
             notebook but the above conditions aren't met
         -   a plotly figure, otherwise
     """
-    if y is None:
-        raise ValueError("You must provide 'y' values")
+    x, y, ids, link_field, labels, sizes, is_frames = parse_lines_inputs(
+        x=x,
+        y=y,
+        samples=samples,
+        ids=ids,
+        link_field=link_field,
+        labels=labels,
+        sizes=sizes,
+    )
+
+    if is_frames:
+        showlegend = True
+    else:
+        showlegend = labels[0] is not None
 
     if xaxis_title is not None:
-        x_title = xaxis_title.rsplit(".", 1)[-1]
+        xtitle = xaxis_title.rsplit(".", 1)[-1]
     else:
-        x_title = "x"
+        xtitle = "x"
 
     if yaxis_title is not None:
-        y_title = yaxis_title.rsplit(".", 1)[-1]
+        ytitle = yaxis_title.rsplit(".", 1)[-1]
     else:
-        y_title = "y"
+        ytitle = "y"
 
     if sizes is not None and sizes_title is None:
         if etau.is_str(sizes):
@@ -825,45 +832,11 @@ def lines(
         else:
             sizes_title = "size"
 
-    hover_lines = ["%s: %%{x}" % x_title, "%s: %%{y}" % y_title]
+    hover_lines = ["%s: %%{x}" % xtitle, "%s: %%{y}" % ytitle]
 
     if sizes is not None:
         hover_lines.append("%s: %%{marker.size}" % sizes_title)
 
-    if ids is not None or samples is not None:
-        hover_lines.append("ID: %{customdata}")
-
-    hovertemplate = "<br>".join(hover_lines) + "<extra></extra>"
-
-    if etau.is_str(y) or isinstance(y, foe.ViewExpression):
-        if samples is not None and samples._contains_videos():
-            is_frames = foe.is_frames_expr(y)
-        else:
-            is_frames = False
-    else:
-        is_frames = y and etau.is_container(y[0])
-
-    if is_frames and link_field is None:
-        link_field = "frames"
-
-    y = _parse_values(y, "y", samples=samples, is_frames=is_frames)
-
-    if x is None:
-        if is_frames:
-            x = [np.arange(1, len(yi) + 1) for yi in y]
-        else:
-            x = np.arange(1, len(y) + 1)
-    else:
-        x = _parse_values(x, "x", samples=samples, ref=y, is_frames=is_frames)
-
-    if is_frames and x and not etau.is_container(x[0]):
-        x = [x] * len(y)
-
-    sizes = _parse_values(
-        sizes, "sizes", samples=samples, ref=y, is_frames=is_frames
-    )
-
-    if sizes is not None:
         if marker_size is None:
             marker_size = 15  # max marker size
 
@@ -877,31 +850,10 @@ def lines(
         except ValueError:
             sizeref = 1
 
-    if ids is None and samples is not None:
-        ids = _get_ids(
-            samples, link_field=link_field, ref=y, is_frames=is_frames
-        )
+    if ids is not None or samples is not None:
+        hover_lines.append("ID: %{customdata}")
 
-    if is_frames:
-        if sizes is None:
-            sizes = itertools.repeat(None)
-
-        if ids is None:
-            ids = itertools.repeat(None)
-
-        if labels is None:
-            labels = [str(i) for i in range(1, len(y) + 1)]
-        elif etau.is_str(labels):
-            labels = _parse_values(labels, "labels", samples=samples)
-
-        showlegend = True
-    else:
-        x = [x]
-        y = [y]
-        ids = [ids]
-        sizes = [sizes]
-        labels = [labels]
-        showlegend = labels[0] is not None
+    hovertemplate = "<br>".join(hover_lines) + "<extra></extra>"
 
     colors = _get_qualitative_colors(len(y), colors=colors)
 
@@ -1114,8 +1066,15 @@ def scatterplot(
         edges,
         classes,
         categorical,
-    ) = _parse_scatter_inputs(
-        points, samples, ids, link_field, labels, sizes, edges, classes
+    ) = parse_scatter_inputs(
+        points,
+        samples=samples,
+        ids=ids,
+        link_field=link_field,
+        labels=labels,
+        sizes=sizes,
+        edges=edges,
+        classes=classes,
     )
 
     if categorical:
@@ -1234,149 +1193,6 @@ def _parse_titles(
     colorbar_title = labels_title if show_colorbar_title else None
 
     return labels_title, sizes_title, colorbar_title
-
-
-def _parse_scatter_inputs(
-    points, samples, ids, link_field, labels, sizes, edges, classes
-):
-    num_dims = points.shape[1]
-
-    labels = _parse_values(labels, "labels", samples=samples, ref=points)
-    sizes = _parse_values(sizes, "sizes", samples=samples, ref=points)
-
-    if ids is None and samples is not None:
-        if num_dims != 2:
-            msg = "Interactive selection is only supported in 2D"
-            warnings.warn(msg)
-        else:
-            ids = _get_ids(samples, link_field=link_field, ref=points)
-
-    return _parse_scatter_data(points, ids, labels, sizes, edges, classes)
-
-
-def _parse_values(values, parameter, samples=None, ref=None, is_frames=False):
-    if values is None:
-        return None
-
-    if etau.is_str(values) or isinstance(values, foe.ViewExpression):
-        if samples is None:
-            raise ValueError(
-                "You must provide `samples` in order to extract field values "
-                "for the `%s` parameter" % parameter
-            )
-
-        values = samples.values(values)
-
-    if is_frames:
-        values = [_unwind_values(v) for v in values]
-    else:
-        values = _unwind_values(values)
-
-    if ref is not None:
-        _validate_values(values, ref, parameter, is_frames=is_frames)
-
-    return values
-
-
-def _get_ids(samples, link_field=None, ref=None, is_frames=False):
-    if link_field is None:
-        ids = samples.values("id")
-        ptype = "sample"
-    elif link_field == "frames":
-        ids = samples.values("frames.id")
-        ptype = "frame"
-    else:
-        _, id_path = samples._get_label_field_path(link_field, "id")
-        ids = samples.values(id_path)
-        ptype = "label"
-
-    if is_frames:
-        ids = [_unwind_values(_ids) for _ids in ids]
-    else:
-        ids = _unwind_values(ids)
-
-    if ref is not None:
-        values_type = "%s IDs" % ptype
-        _validate_values(ids, ref, values_type, is_frames=is_frames)
-
-    return ids
-
-
-def _unwind_values(values):
-    if values is None:
-        return None
-
-    while any(etau.is_container(v) for v in values):
-        values = list(itertools.chain.from_iterable(v for v in values if v))
-
-    return np.array(values)
-
-
-def _validate_values(values, ref, values_type, is_frames=False):
-    if not is_frames:
-        if len(values) != len(ref):
-            raise ValueError(
-                "Inconsistent number of %s (%d != %d). You may have missing "
-                "data/labels that you need to omit from your view"
-                % (values_type, len(values), len(ref))
-            )
-
-        return
-
-    if len(values) != len(ref):
-        raise ValueError(
-            "Inconsistent number of %s traces (%d != %d). You may have "
-            "missing data/labels that you need to omit from your view"
-            % (values_type, len(values), len(ref))
-        )
-
-    for idx, (_values, _ref) in enumerate(zip(values, ref), 1):
-        if len(_values) != len(_ref):
-            raise ValueError(
-                "Inconsistent number of %s (%d != %d) in trace %d/%d. You may "
-                "have missing data/labels that you need to omit from your view"
-                % (values_type, len(_values), len(_ref), idx, len(values))
-            )
-
-
-def _parse_scatter_data(points, ids, labels, sizes, edges, classes):
-    if ids is not None:
-        ids = np.asarray(ids)
-
-    if sizes is not None:
-        sizes = np.asarray(sizes)
-
-    if edges is not None:
-        edges = np.asarray(edges)
-
-    if labels is None:
-        return points, ids, None, sizes, edges, None, False
-
-    labels = np.asarray(labels)
-
-    if not etau.is_str(labels[0]):
-        return points, ids, labels, sizes, edges, None, False
-
-    if classes is None:
-        classes = sorted(set(labels))
-        return points, ids, labels, sizes, edges, classes, True
-
-    found = np.array([l in classes for l in labels])
-    if not np.all(found):
-        points = points[found, :]
-        labels = labels[found]
-
-        if sizes is not None:
-            sizes = sizes[found]
-
-        if ids is not None:
-            ids = ids[found]
-
-        if edges is not None:
-            i = set(np.nonzero(found)[0])
-            edges = np.array([e for e in edges if e[0] in i and e[1] in i])
-
-    return points, ids, labels, sizes, edges, classes, True
 
 
 def location_scatterplot(
@@ -1504,11 +1320,11 @@ def location_scatterplot(
             working in a Jupyter notebook
         -   a plotly figure, otherwise
     """
-    locations = _parse_locations(locations, samples)
-
     labels_title, sizes_title, colorbar_title = _parse_titles(
         labels, labels_title, sizes, sizes_title, show_colorbar_title
     )
+
+    locations = parse_locations(locations, samples, ids=ids)
 
     (
         locations,
@@ -1518,8 +1334,14 @@ def location_scatterplot(
         edges,
         classes,
         categorical,
-    ) = _parse_scatter_inputs(
-        locations, samples, ids, None, labels, sizes, edges, classes
+    ) = parse_scatter_inputs(
+        locations,
+        samples=samples,
+        ids=ids,
+        labels=labels,
+        sizes=sizes,
+        edges=edges,
+        classes=classes,
     )
 
     if style not in (None, "scatter", "density"):
@@ -1616,28 +1438,6 @@ def location_scatterplot(
         return figure
 
     return InteractiveScatter(figure, init_view=samples)
-
-
-def _parse_locations(locations, samples):
-    if locations is not None and not etau.is_str(locations):
-        return np.asarray(locations)
-
-    if samples is None:
-        raise ValueError(
-            "You must provide `samples` in order to extract `locations` from "
-            "your dataset"
-        )
-
-    if locations is None:
-        location_field = samples._get_geo_location_field()
-    else:
-        location_field = locations
-        samples.validate_field_type(
-            location_field, embedded_doc_type=fol.GeoLocation
-        )
-
-    locations = samples.values(location_field + ".point.coordinates")
-    return np.asarray(locations)
 
 
 def get_colormap(colorscale, n=256, hex_strs=False):

--- a/fiftyone/core/plots/utils.py
+++ b/fiftyone/core/plots/utils.py
@@ -5,46 +5,339 @@ Plotting utils.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
-import os
+import itertools
+import warnings
 
 import numpy as np
+import sklearn.linear_model as skl
+import sklearn.metrics as skm
 
-import eta.core.image as etai
 import eta.core.serial as etas
 import eta.core.utils as etau
 
+import fiftyone.core.expressions as foe
+import fiftyone.core.labels as fol
 
-# Original images from https://www.iconfinder.com
-BUTTON_ICONS = {
-    "map": "eJztk79LG2Ech9+jcgdddFKaLDcYTiWNuCTQVeymyWCGTiXEJEdbGklMl7aT4FKERAeJk/4Dpd1bx3avm0bQrFl00Io/+nr33q/3vfu+74VS6PI+w4V88+QZPiHbS8XFwgsFvUPvjZVKs9wwnunGh9ackdaNar2x1ii9fVlvrFTs+/PSm2bFujfN0mrFej+Vy6b1XHY6rX/U/5LHSCL5LxQ3ng7lZQoTMUbqBGN8+iS2lPqK8eWCyBjbvMM2v9vi2tjmja0d8Y0Rc4A9rjuJITyuMn+Iabg1yuOU7AFCgDXGA0vuALG1kCccAF+R5xlcowfltIIB7rtl8qpWqdpWEvBegS1qgINZtOw6aq0fqsEeZ4BeXkGUw9ZmuJ6HUvUHuGhq9oV26BoWeA7r/gA7486FdbRwjePZnLvKN//vHHbYGt9DyDGOlxTEdzTTq4k9cvihUhfo99FMctwTe+SwjITOsJ5syZZsyZZsyZZsyRZB3ScnU4tpqT/jWkr+GDv02RrP4zuZ7ziAqXG8c15rvHuPGfo1NcZbh1ta6wJH8GugN6gqUEsp9Dzj5tPM1rVfO3NqoDeKENCaPfC//GXSOifDNY4Xbb3e/eMZv+bdDxIdpkZey4AXbvkMao+Cj5gaeV6BHtiKDEDXRF60FR0ArkEe24IGgGo8L2jBA7i1dlATeehINEC4div2Fi6tAVLCEql9tlK9OG+ikIkt2aQ3ikN5Esk/5wFTASSi",
-    "sync": "eJztll9IU1Ecx28u7zWVCp1BS2tPbtP1UISDIIIeon8zJ/2hBwnJifRHZTezKImQ2V5FEgwpIoIKzTR76yGSWAZFT6EvZS77o840N/8s9XbVc86uu+fcc67tKfZ92u73y+ee39nvd86aCo87i06t4S5xVy1lbvGMx7LbbLlWs8NiN1vKqzwXPaWVp6s8Ze7F5/tLz4tu+blYUVrtlr9bHQV2s6PAZjfXmVepVC6hhBKKkcEhtvYMBCML4UDv/Zo9PDLyusOhLis7iC9un5BWKPTkpLCMWjLGWWFGb1DCKNiwSTa7l790MpHSfGEcaVFhbzoHzEkWlCtAIi0q4ISf6KSU21okpaio7A+sKCrL+oUZRWNZh5Xheb/XlZ/BJ623FTX0LuhkZStXNVhrUno5dd/1sFIUezVSnqyyxXF2Vks09yADF9j8nJXlQqmIW2XKM6hjv9JRi4YPqlETsSRNlg+t6oDa7FajNFhZqAZ1gRyHG1Ayy4u2HeeG1CjybPPwkBnG/oJdalYHkVUMI+VY2zoeixrLJbLaQWRQ1aIA1jm5osAOMmrtbxCqJUaY5QCoeRM9S5MIWP5/R3GtgOWNA6sHsFxxYA0AVn4cWLBTsY2qUxHA4unR+LN2vpgOP8vDWnprtC1NwYQN5+ndezBybTgP9kQxG0qYBgOOM2GvNrCx9oH4DM70APMNG6sJxPtxJprtLSwoHl7v93CuAd4zl1lYJfAYO4G124AbYOiwpI/wREzH+uiiraCz3DDbivf5UeCPZtJQWXC3FuyERD182UMaC26H9JSUyERXIKXKKpibIw8Jumz/HNZCOedgrpkcSkV/5KY0YIemYGpoo8YbCyW0srOkTFkEhY5orZ5rRjnpkREX2HA3mmjURHHC+2g0eE6ItQ0l36L+a8L9jmT6HA1LQ1dylF7mhT6F2ZdFQXFc7k9FXpp/e/PYdqMgGG2u668iSiewlYqSYcqVEdW/jQEll/mOjuqlF7gs4RYN1ajj4nMOaJG+HmUnyUqtnySRZn1pulCyMm6M4EhjPqYjPFbJhY9/rQSF2kt0rwnJsKu65eWnkdmZH/3+O5V7160alFBC/63+Asl9Dog=",
-    "disconnect": "eJztmG9IE2Ecx28ribQ/qGQUledGTHFSYWpYRilYUYqCRoYh1i6tLG2rREosaC8Mk2gQlI2cK6NQ8nUJ0ZtSiBaCEigpkdpfnTqkctu16e+5u9nzPHc4e7fvu/t+v8/n7rk9z90xS25hTl6RirnEXNYZONMJoy6d1V25uE2nZ3UnK40XjKXnSiqNBs7vZ5dWmDifbyovreJ8x/FpqXo2LTVBz9ayC1Q4E1JIIf1vxZjs9vNrFgV1dIr3afLwIqAOeflZebKDRqk/8qAPqmBZKbygLcGyCkVWXrCsIyKrYAHDUzumXG0aMkvb7ppxHFSEOubxD/wWR2Jpv8/+rEUKUAfccyOfkljtc0d/smRRm50wcorEcsHhWJwMKuwdGumUY/HdS+msq8LIFhLrmWDUUFGaX6g3up7ESvYgY3ojjfUY1b4mMCQWwwmOjYKKR6ecTkYWbq3WI8etwXP8uoNKnGDh9tCSN8i6RUSFT0DluehtF1lJgpk4A9bPZSQWugZPouipBxCqT9K8h8wcEssOhTapuQ/uoTtTYmrRjb1PYo1AITPALZyd+Xh+gNkJ1SECKhbyUXWgH11htZ6JCvTK0CTX4Vm5EDeTrlsiLWLtx+cmiMsUsJgfUD6Ljxsh3qWE9RrK9fjYBjGrhNUG5SZ8/ATiaCWsB1B+iI9bIY5RwkJrkbC970JM2bCiOqBswcc3IN6thPUWymZ8fBpigwKUaoJezoLYqoClR2s1A5/HQDyogFUJXW8kodALhR3yrC6oOkgFCxSIDxJBwhQbSI09UPi9QY71CLHSSQ3VEDRaZFAp6FHYT+7UotPRvxXC0OLiq8mlyEnojFD30U2EGltJaZlRqzuCXBLftXW0M674jGovV5E6JW7UGVxOYzEFwjkd+E8idZ3Q4HOpKIZpEZrOYkzMvhBRssswok8sv5q/2aKvT4tpD32Gfmm+iHW+69RaIQjba3VJouFNsiiG2erkpeq115YXH6+63ekKsMeT5El+2Cgvq2FlKN80e+VQPbEKUb6Pp2Y6qkn+tkuU/4lMGpJbV/MVcc2JJ43VLeD/pNU1A/+S+quJe0tGOxvfe0WO19FAfPQpUlQGZ7bYbBazIYP0mggppJAWSX8Bi5hqdQ==",
-}
+
+def parse_scatter_inputs(
+    points,
+    samples=None,
+    ids=None,
+    link_field=None,
+    labels=None,
+    sizes=None,
+    edges=None,
+    classes=None,
+):
+    points = np.asarray(points)
+    num_dims = points.shape[1]
+
+    if ids is None and samples is not None:
+        if num_dims != 2:
+            msg = "Interactive selection is only supported in 2D"
+            warnings.warn(msg)
+        else:
+            ids = _get_ids(samples, link_field=link_field, ref=points)
+
+    labels = _parse_values(
+        labels,
+        "labels",
+        samples=samples,
+        ids=ids,
+        link_field=link_field,
+        ref=points,
+    )
+
+    sizes = _parse_values(
+        sizes,
+        "sizes",
+        samples=samples,
+        ids=ids,
+        link_field=link_field,
+        ref=points,
+    )
+
+    if ids is not None:
+        ids = np.asarray(ids)
+
+    if sizes is not None:
+        sizes = np.asarray(sizes)
+
+    if edges is not None:
+        edges = np.asarray(edges)
+
+    if labels is None:
+        return points, ids, None, sizes, edges, None, False
+
+    labels = np.asarray(labels)
+
+    if not etau.is_str(labels[0]):
+        return points, ids, labels, sizes, edges, None, False
+
+    if classes is None:
+        classes = sorted(set(labels))
+        return points, ids, labels, sizes, edges, classes, True
+
+    found = np.array([l in classes for l in labels])
+    if not np.all(found):
+        points = points[found, :]
+        labels = labels[found]
+
+        if sizes is not None:
+            sizes = sizes[found]
+
+        if ids is not None:
+            ids = ids[found]
+
+        if edges is not None:
+            i = set(np.nonzero(found)[0])
+            edges = np.array([e for e in edges if e[0] in i and e[1] in i])
+
+    return points, ids, labels, sizes, edges, classes, True
+
+
+def parse_locations(locations, samples, ids=None):
+    if locations is not None and not etau.is_str(locations):
+        return np.asarray(locations)
+
+    if samples is None:
+        raise ValueError(
+            "You must provide `samples` in order to extract `locations` from "
+            "your dataset"
+        )
+
+    if locations is None:
+        location_field = samples._get_geo_location_field()
+    else:
+        location_field = locations
+        samples.validate_field_type(
+            location_field, embedded_doc_type=fol.GeoLocation
+        )
+
+    path = location_field + ".point.coordinates"
+    if ids is not None:
+        locations = samples._get_values_by_id(path, ids)
+    else:
+        locations = samples.values(path)
+
+    return np.asarray(locations)
+
+
+def parse_lines_inputs(
+    x=None,
+    y=None,
+    samples=None,
+    ids=None,
+    link_field=None,
+    labels=None,
+    sizes=None,
+):
+    if y is None:
+        raise ValueError("You must provide 'y' values")
+
+    if etau.is_str(y) or isinstance(y, foe.ViewExpression):
+        if samples is not None and samples._contains_videos():
+            is_frames = foe.is_frames_expr(y)
+        else:
+            is_frames = False
+    else:
+        is_frames = y and etau.is_container(y[0])
+
+    if is_frames and link_field is None:
+        link_field = "frames"
+
+    if ids is None and samples is not None:
+        ref = y if etau.is_container(y) else None
+        ids = _get_ids(
+            samples, link_field=link_field, ref=ref, is_frames=is_frames
+        )
+
+    x = _parse_values(
+        x,
+        "x",
+        samples=samples,
+        ids=ids,
+        link_field=link_field,
+        is_frames=is_frames,
+    )
+
+    y = _parse_values(
+        y,
+        "y",
+        samples=samples,
+        ids=ids,
+        link_field=link_field,
+        is_frames=is_frames,
+    )
+
+    labels = _parse_values(
+        labels,
+        "labels",
+        samples=samples,
+        ids=ids,
+        link_field=link_field,
+        ref=y,
+        is_frames=is_frames,
+    )
+
+    sizes = _parse_values(
+        sizes,
+        "sizes",
+        samples=samples,
+        ids=ids,
+        link_field=link_field,
+        ref=y,
+        is_frames=is_frames,
+    )
+
+    if x is None:
+        if is_frames:
+            x = [np.arange(1, len(yi) + 1) for yi in y]
+        else:
+            x = np.arange(1, len(y) + 1)
+
+    if is_frames and x and not etau.is_container(x[0]):
+        x = [x] * len(y)
+
+    if is_frames:
+        if sizes is None:
+            sizes = itertools.repeat(None)
+
+        if ids is None:
+            ids = itertools.repeat(None)
+
+        if labels is None:
+            labels = [str(i) for i in range(1, len(y) + 1)]
+    else:
+        x = [x]
+        y = [y]
+        ids = [ids]
+        sizes = [sizes]
+        labels = [labels]
+
+    return x, y, ids, link_field, labels, sizes, is_frames
+
+
+def best_fit_line(points, label=None):
+    x = points[:, 0]
+    y = points[:, 1]
+
+    model = skl.LinearRegression()
+    model.fit(x[:, np.newaxis], y)
+
+    xline = np.array([x.min(), x.max()])
+    yline = model.predict(xline[:, np.newaxis])
+
+    if label is None:
+        r2_score = skm.r2_score(x, y, sample_weight=None)
+        label = "r^2: %0.3f" % r2_score
+
+    return xline, yline, label
+
+
+def _parse_values(
+    values,
+    parameter,
+    samples=None,
+    ids=None,
+    link_field=None,
+    ref=None,
+    is_frames=False,
+):
+    if values is None:
+        return None
+
+    if etau.is_str(values) or isinstance(values, foe.ViewExpression):
+        if samples is None:
+            raise ValueError(
+                "You must provide `samples` in order to extract field values "
+                "for the `%s` parameter" % parameter
+            )
+
+        if ids is not None and not is_frames:
+            values = samples._get_values_by_id(
+                values, ids, link_field=link_field
+            )
+        else:
+            values = samples.values(values)
+
+    if is_frames:
+        values = [_unwind_values(v) for v in values]
+    else:
+        values = _unwind_values(values)
+
+    if ref is not None:
+        _validate_values(values, ref, parameter, is_frames=is_frames)
+
+    return values
+
+
+def _get_ids(samples, link_field=None, ref=None, is_frames=False):
+    if link_field is None:
+        ids = samples.values("id")
+        ptype = "sample"
+    elif link_field == "frames":
+        ids = samples.values("frames.id")
+        ptype = "frame"
+    else:
+        _, id_path = samples._get_label_field_path(link_field, "id")
+        ids = samples.values(id_path)
+        ptype = "label"
+
+    if is_frames:
+        ids = [_unwind_values(_ids) for _ids in ids]
+    else:
+        ids = _unwind_values(ids)
+
+    if ref is not None:
+        values_type = "%s IDs" % ptype
+        _validate_values(ids, ref, values_type, is_frames=is_frames)
+
+    return ids
+
+
+def _unwind_values(values):
+    if values is None:
+        return None
+
+    while any(etau.is_container(v) for v in values):
+        values = list(itertools.chain.from_iterable(v for v in values if v))
+
+    return np.array(values)
+
+
+def _validate_values(values, ref, values_type, is_frames=False):
+    if not is_frames:
+        if len(values) != len(ref):
+            raise ValueError(
+                "Inconsistent number of %s (%d != %d). You may have missing "
+                "data/labels that you need to omit from your view"
+                % (values_type, len(values), len(ref))
+            )
+
+        return
+
+    if len(values) != len(ref):
+        raise ValueError(
+            "Inconsistent number of %s traces (%d != %d). You may have "
+            "missing data/labels that you need to omit from your view"
+            % (values_type, len(values), len(ref))
+        )
+
+    for idx, (_values, _ref) in enumerate(zip(values, ref), 1):
+        if len(_values) != len(_ref):
+            raise ValueError(
+                "Inconsistent number of %s (%d != %d) in trace %d/%d. You may "
+                "have missing data/labels that you need to omit from your view"
+                % (values_type, len(_values), len(_ref), idx, len(values))
+            )
 
 
 def load_button_icon(name):
-    """Loads the button icon with the given name.
-
-    The available buttons are :const:`BUTTON_ICONS`.
-
-    Args:
-        name: the button name
-
-    Returns:
-        the numpy image
-    """
-    return load_icon(BUTTON_ICONS[name])
+    return load_icon(_BUTTON_ICONS[name])
 
 
 def load_icon(icon_bytes):
-    """Loads the icon image from bytes.
-
-    Args:
-        icon_bytes:
-
-    Returns:
-        the numpy image
-    """
     alpha = etas.deserialize_numpy_array(icon_bytes)
     h, w = alpha.shape
     img = np.zeros((h, w, 4), dtype=alpha.dtype)
@@ -53,16 +346,6 @@ def load_icon(icon_bytes):
 
 
 def serialize_icon(img):
-    """Serializes the icon image into a compressed bytes representation.
-
-    The icon must be defined purely by alpha-channel values.
-
-    Args:
-        img: a numpy image
-
-    Returns:
-        a bytes string
-    """
     if img.shape[2] < 4 or np.any(img[:, :, :-1] > 0):
         raise ValueError("Image must be alpha-only")
 
@@ -71,17 +354,15 @@ def serialize_icon(img):
 
 
 def pad_icon(img, pad, fill=0):
-    """Pads the icon by the
-
-    Args:
-        img: a numpy image
-        pad: the number of pixels of padding
-        fill (0): the fill value
-
-    Returns:
-         a numpy image
-    """
     h, w, c = img.shape[:3]
     img_pad = np.full((h + 2 * pad, w + 2 * pad, c), fill, dtype=img.dtype)
     img_pad[pad : (pad + h), pad : (pad + w), :] = img
     return img_pad
+
+
+# Original images from https://www.iconfinder.com
+_BUTTON_ICONS = {
+    "map": "eJztk79LG2Ech9+jcgdddFKaLDcYTiWNuCTQVeymyWCGTiXEJEdbGklMl7aT4FKERAeJk/4Dpd1bx3avm0bQrFl00Io/+nr33q/3vfu+74VS6PI+w4V88+QZPiHbS8XFwgsFvUPvjZVKs9wwnunGh9ackdaNar2x1ii9fVlvrFTs+/PSm2bFujfN0mrFej+Vy6b1XHY6rX/U/5LHSCL5LxQ3ng7lZQoTMUbqBGN8+iS2lPqK8eWCyBjbvMM2v9vi2tjmja0d8Y0Rc4A9rjuJITyuMn+Iabg1yuOU7AFCgDXGA0vuALG1kCccAF+R5xlcowfltIIB7rtl8qpWqdpWEvBegS1qgINZtOw6aq0fqsEeZ4BeXkGUw9ZmuJ6HUvUHuGhq9oV26BoWeA7r/gA7486FdbRwjePZnLvKN//vHHbYGt9DyDGOlxTEdzTTq4k9cvihUhfo99FMctwTe+SwjITOsJ5syZZsyZZsyZZsyRZB3ScnU4tpqT/jWkr+GDv02RrP4zuZ7ziAqXG8c15rvHuPGfo1NcZbh1ta6wJH8GugN6gqUEsp9Dzj5tPM1rVfO3NqoDeKENCaPfC//GXSOifDNY4Xbb3e/eMZv+bdDxIdpkZey4AXbvkMao+Cj5gaeV6BHtiKDEDXRF60FR0ArkEe24IGgGo8L2jBA7i1dlATeehINEC4div2Fi6tAVLCEql9tlK9OG+ikIkt2aQ3ikN5Esk/5wFTASSi",
+    "sync": "eJztll9IU1Ecx28u7zWVCp1BS2tPbtP1UISDIIIeon8zJ/2hBwnJifRHZTezKImQ2V5FEgwpIoIKzTR76yGSWAZFT6EvZS77o840N/8s9XbVc86uu+fcc67tKfZ92u73y+ee39nvd86aCo87i06t4S5xVy1lbvGMx7LbbLlWs8NiN1vKqzwXPaWVp6s8Ze7F5/tLz4tu+blYUVrtlr9bHQV2s6PAZjfXmVepVC6hhBKKkcEhtvYMBCML4UDv/Zo9PDLyusOhLis7iC9un5BWKPTkpLCMWjLGWWFGb1DCKNiwSTa7l790MpHSfGEcaVFhbzoHzEkWlCtAIi0q4ISf6KSU21okpaio7A+sKCrL+oUZRWNZh5Xheb/XlZ/BJ623FTX0LuhkZStXNVhrUno5dd/1sFIUezVSnqyyxXF2Vks09yADF9j8nJXlQqmIW2XKM6hjv9JRi4YPqlETsSRNlg+t6oDa7FajNFhZqAZ1gRyHG1Ayy4u2HeeG1CjybPPwkBnG/oJdalYHkVUMI+VY2zoeixrLJbLaQWRQ1aIA1jm5osAOMmrtbxCqJUaY5QCoeRM9S5MIWP5/R3GtgOWNA6sHsFxxYA0AVn4cWLBTsY2qUxHA4unR+LN2vpgOP8vDWnprtC1NwYQN5+ndezBybTgP9kQxG0qYBgOOM2GvNrCx9oH4DM70APMNG6sJxPtxJprtLSwoHl7v93CuAd4zl1lYJfAYO4G124AbYOiwpI/wREzH+uiiraCz3DDbivf5UeCPZtJQWXC3FuyERD182UMaC26H9JSUyERXIKXKKpibIw8Jumz/HNZCOedgrpkcSkV/5KY0YIemYGpoo8YbCyW0srOkTFkEhY5orZ5rRjnpkREX2HA3mmjURHHC+2g0eE6ItQ0l36L+a8L9jmT6HA1LQ1dylF7mhT6F2ZdFQXFc7k9FXpp/e/PYdqMgGG2u668iSiewlYqSYcqVEdW/jQEll/mOjuqlF7gs4RYN1ajj4nMOaJG+HmUnyUqtnySRZn1pulCyMm6M4EhjPqYjPFbJhY9/rQSF2kt0rwnJsKu65eWnkdmZH/3+O5V7160alFBC/63+Asl9Dog=",
+    "disconnect": "eJztmG9IE2Ecx28ribQ/qGQUledGTHFSYWpYRilYUYqCRoYh1i6tLG2rREosaC8Mk2gQlI2cK6NQ8nUJ0ZtSiBaCEigpkdpfnTqkctu16e+5u9nzPHc4e7fvu/t+v8/n7rk9z90xS25hTl6RirnEXNYZONMJoy6d1V25uE2nZ3UnK40XjKXnSiqNBs7vZ5dWmDifbyovreJ8x/FpqXo2LTVBz9ayC1Q4E1JIIf1vxZjs9vNrFgV1dIr3afLwIqAOeflZebKDRqk/8qAPqmBZKbygLcGyCkVWXrCsIyKrYAHDUzumXG0aMkvb7ppxHFSEOubxD/wWR2Jpv8/+rEUKUAfccyOfkljtc0d/smRRm50wcorEcsHhWJwMKuwdGumUY/HdS+msq8LIFhLrmWDUUFGaX6g3up7ESvYgY3ojjfUY1b4mMCQWwwmOjYKKR6ecTkYWbq3WI8etwXP8uoNKnGDh9tCSN8i6RUSFT0DluehtF1lJgpk4A9bPZSQWugZPouipBxCqT9K8h8wcEssOhTapuQ/uoTtTYmrRjb1PYo1AITPALZyd+Xh+gNkJ1SECKhbyUXWgH11htZ6JCvTK0CTX4Vm5EDeTrlsiLWLtx+cmiMsUsJgfUD6Ljxsh3qWE9RrK9fjYBjGrhNUG5SZ8/ATiaCWsB1B+iI9bIY5RwkJrkbC970JM2bCiOqBswcc3IN6thPUWymZ8fBpigwKUaoJezoLYqoClR2s1A5/HQDyogFUJXW8kodALhR3yrC6oOkgFCxSIDxJBwhQbSI09UPi9QY71CLHSSQ3VEDRaZFAp6FHYT+7UotPRvxXC0OLiq8mlyEnojFD30U2EGltJaZlRqzuCXBLftXW0M674jGovV5E6JW7UGVxOYzEFwjkd+E8idZ3Q4HOpKIZpEZrOYkzMvhBRssswok8sv5q/2aKvT4tpD32Gfmm+iHW+69RaIQjba3VJouFNsiiG2erkpeq115YXH6+63ekKsMeT5El+2Cgvq2FlKN80e+VQPbEKUb6Pp2Y6qkn+tkuU/4lMGpJbV/MVcc2JJ43VLeD/pNU1A/+S+quJe0tGOxvfe0WO19FAfPQpUlQGZ7bYbBazIYP0mggppJAWSX8Bi5hqdQ==",
+}

--- a/fiftyone/core/plots/utils.py
+++ b/fiftyone/core/plots/utils.py
@@ -135,19 +135,20 @@ def parse_lines_inputs(
     if y is None:
         raise ValueError("You must provide 'y' values")
 
-    if etau.is_str(y) or isinstance(y, foe.ViewExpression):
-        if samples is not None and samples._contains_videos():
-            is_frames = foe.is_frames_expr(y)
-        else:
-            is_frames = False
-    else:
+    raw_y_values = not (etau.is_str(y) or _is_expr(y))
+
+    if raw_y_values:
         is_frames = y and etau.is_container(y[0])
+    elif samples is not None and samples._contains_videos():
+        is_frames = foe.is_frames_expr(y)
+    else:
+        is_frames = False
 
     if is_frames and link_field is None:
         link_field = "frames"
 
     if ids is None and samples is not None:
-        ref = y if etau.is_container(y) else None
+        ref = y if raw_y_values else None
         ids = _get_ids(
             samples, link_field=link_field, ref=ref, is_frames=is_frames
         )
@@ -233,6 +234,10 @@ def best_fit_line(points, label=None):
         label = "r^2: %0.3f" % r2_score
 
     return xline, yline, label
+
+
+def _is_expr(arg):
+    return isinstance(arg, (foe.ViewExpression, dict))
 
 
 def _parse_values(

--- a/fiftyone/core/plots/utils.py
+++ b/fiftyone/core/plots/utils.py
@@ -171,16 +171,6 @@ def parse_lines_inputs(
         is_frames=is_frames,
     )
 
-    labels = _parse_values(
-        labels,
-        "labels",
-        samples=samples,
-        ids=ids,
-        link_field=link_field,
-        ref=y,
-        is_frames=is_frames,
-    )
-
     sizes = _parse_values(
         sizes,
         "sizes",
@@ -209,6 +199,8 @@ def parse_lines_inputs(
 
         if labels is None:
             labels = [str(i) for i in range(1, len(y) + 1)]
+        else:
+            labels = _parse_values(labels, "labels", samples=samples)
     else:
         x = [x]
         y = [y]

--- a/fiftyone/core/plots/utils.py
+++ b/fiftyone/core/plots/utils.py
@@ -192,10 +192,10 @@ def parse_lines_inputs(
 
     if is_frames:
         if sizes is None:
-            sizes = itertools.repeat(None)
+            sizes = [None] * len(y)
 
         if ids is None:
-            ids = itertools.repeat(None)
+            ids = [None] * len(y)
 
         if labels is None:
             labels = [str(i) for i in range(1, len(y) + 1)]

--- a/fiftyone/core/runs.py
+++ b/fiftyone/core/runs.py
@@ -462,11 +462,12 @@ class Run(Configurable):
         """
         dataset = samples._root_dataset
 
-        results_cache = getattr(dataset, cls._results_cache_field())
+        if cache:
+            results_cache = getattr(dataset, cls._results_cache_field())
 
-        # Returned cached results if available
-        if key in results_cache:
-            return results_cache[key]
+            # Returned cached results if available
+            if key in results_cache:
+                return results_cache[key]
 
         run_doc = cls._get_run_doc(samples, key)
 

--- a/fiftyone/server/routes/embeddings.py
+++ b/fiftyone/server/routes/embeddings.py
@@ -265,9 +265,9 @@ def _add_to_trace(traces, style, points, id, sample_id, label, selected):
 
     traces[key].append(
         {
+            "points": points,
             "id": id,
             "sample_id": sample_id or id,
-            "points": points,
             "label": label,
             "selected": selected,
         }

--- a/tests/intensive/plot_tests.py
+++ b/tests/intensive/plot_tests.py
@@ -1,0 +1,349 @@
+"""
+Plot tests.
+
+You must run these tests interactively as follows::
+
+    pytest tests/intensive/plot_tests.py -s -k <test_case>
+
+| Copyright 2017-2023, Voxel51, Inc.
+| `voxel51.com <https://voxel51.com/>`_
+|
+"""
+import random
+import unittest
+
+import numpy as np
+
+import fiftyone as fo
+import fiftyone.brain as fob
+import fiftyone.zoo as foz
+from fiftyone import ViewField as F
+
+
+###############################################################################
+# scatterplot()
+###############################################################################
+
+
+def test_scatterplot():
+    _test_scatterplot("plotly")
+
+
+def test_scatterplot_mpl():
+    _test_scatterplot("matplotlib")
+
+
+def _test_scatterplot(backend):
+    dataset = foz.load_zoo_dataset("quickstart")
+
+    points = np.random.randn(len(dataset), 2)
+    labels = dataset.values("uniqueness")
+    sizes = dataset.values(F("ground_truth.detections").length())
+
+    plot = fo.scatterplot(
+        points=points,
+        labels=labels,
+        sizes=sizes,
+        backend=backend,
+    )
+    plot.show()
+
+    input("Press enter to continue...")
+
+
+def test_scatterplot_interactive():
+    _test_scatterplot_interactive("plotly")
+
+
+def test_scatterplot_interactive_mpl():
+    _test_scatterplot_interactive("matplotlib")
+
+
+def _test_scatterplot_interactive(backend):
+    dataset = foz.load_zoo_dataset("quickstart")
+
+    points = np.random.randn(len(dataset), 2)
+
+    plot = fo.scatterplot(
+        points=points,
+        samples=dataset,
+        labels="uniqueness",
+        sizes=F("ground_truth.detections").length(),
+        backend=backend,
+    )
+    plot.show()
+
+    input("Press enter to continue...")
+
+
+def test_scatterplot_by_ids():
+    _test_scatterplot_by_ids("plotly")
+
+
+def test_scatterplot_by_ids_mpl():
+    _test_scatterplot_by_ids("matplotlib")
+
+
+def _test_scatterplot_by_ids(backend):
+    dataset = foz.load_zoo_dataset("quickstart")
+
+    view = dataset.take(51, seed=51)
+    points = np.random.randn(len(view), 2)
+    ids = view.values("id")
+
+    plot = fo.scatterplot(
+        points=points,
+        samples=dataset,
+        ids=ids,
+        labels="uniqueness",
+        sizes=F("ground_truth.detections").length(),
+        backend=backend,
+    )
+    plot.show()
+
+    input("Press enter to continue...")
+
+
+###############################################################################
+# location_scatterplot()
+###############################################################################
+
+
+def test_location_scatterplot():
+    _test_location_scatterplot("plotly")
+
+
+def test_location_scatterplot_mpl():
+    _test_location_scatterplot("matplotlib")
+
+
+def _test_location_scatterplot(backend):
+    dataset = foz.load_zoo_dataset("quickstart-geo")
+    fob.compute_uniqueness(dataset)
+
+    locations = dataset.values("location.point.coordinates")
+    labels = dataset.values("uniqueness")
+    sizes = dataset.values(F("ground_truth.detections").length())
+
+    plot = fo.location_scatterplot(
+        locations=locations,
+        labels=labels,
+        sizes=sizes,
+        backend=backend,
+    )
+    plot.show()
+
+    input("Press enter to continue...")
+
+
+def test_location_scatterplot_interactive():
+    _test_location_scatterplot_interactive("plotly")
+
+
+def test_location_scatterplot_interactive_mpl():
+    _test_location_scatterplot_interactive("matplotlib")
+
+
+def _test_location_scatterplot_interactive(backend):
+    dataset = foz.load_zoo_dataset("quickstart-geo")
+    fob.compute_uniqueness(dataset)
+
+    plot = fo.location_scatterplot(
+        locations="location",
+        samples=dataset,
+        labels="uniqueness",
+        sizes=F("ground_truth.detections").length(),
+        backend=backend,
+    )
+    plot.show()
+
+    input("Press enter to continue...")
+
+
+def test_location_scatterplot_by_ids():
+    _test_location_scatterplot_by_ids("plotly")
+
+
+def test_location_scatterplot_by_ids_mpl():
+    _test_location_scatterplot_by_ids("matplotlib")
+
+
+def _test_location_scatterplot_by_ids(backend):
+    dataset = foz.load_zoo_dataset("quickstart-geo")
+
+    view = dataset.take(51, seed=51)
+    ids = view.values("id")
+
+    plot = fo.location_scatterplot(
+        samples=dataset,
+        ids=ids,
+        labels="uniqueness",
+        sizes=F("ground_truth.detections").length(),
+        backend=backend,
+    )
+    plot.show()
+
+    input("Press enter to continue...")
+
+
+###############################################################################
+# plot_regressions()
+###############################################################################
+
+
+def test_plot_regressions():
+    _test_plot_regressions("plotly")
+
+
+def test_plot_regressions_mpl():
+    _test_plot_regressions("matplotlib")
+
+
+def _test_plot_regressions(backend):
+    dataset = foz.load_zoo_dataset("quickstart").select_fields().clone()
+
+    # Populate some fake regression + weather data
+    for idx, sample in enumerate(dataset, 1):
+        ytrue = random.random() * idx
+        ypred = ytrue + np.random.randn() * np.sqrt(ytrue)
+        sample["ground_truth"] = fo.Regression(value=ytrue)
+        sample["predictions"] = fo.Regression(
+            value=ypred, confidence=random.random()
+        )
+        sample["weather"] = random.choice(["sunny", "cloudy", "rainy"])
+        sample.save()
+
+    # Evaluate the predictions in the `predictions` field with respect to the
+    # values in the `ground_truth` field
+    results = dataset.evaluate_regressions(
+        "predictions",
+        gt_field="ground_truth",
+        eval_key="eval",
+    )
+
+    plot = results.plot_results(
+        labels="weather",
+        sizes="predictions.confidence",
+        backend=backend,
+    )
+    plot.show()
+
+    input("Press enter to continue...")
+
+
+###############################################################################
+# lines()
+###############################################################################
+
+
+def test_lines():
+    _test_lines("plotly")
+
+
+def test_lines_mpl():
+    _test_lines("matplotlib")
+
+
+def _test_lines(backend):
+    dataset = foz.load_zoo_dataset("quickstart-video")
+    view = dataset.filter_labels("frames.detections", F("label") == "vehicle")
+
+    plot = fo.lines(
+        x="frames.frame_number",
+        y=F("frames.detections.detections").length(),
+        labels="id",
+        samples=view,
+        backend=backend,
+    )
+    plot.show()
+
+    input("Press enter to continue...")
+
+
+###############################################################################
+# plot_confusion_matrix()
+###############################################################################
+
+
+def test_plot_confusion_matrix():
+    _test_plot_confusion_matrix("plotly")
+
+
+def test_plot_confusion_matrix_mpl():
+    _test_plot_confusion_matrix("matplotlib")
+
+
+def _test_plot_confusion_matrix(backend):
+    dataset = foz.load_zoo_dataset("quickstart")
+    results = dataset.evaluate_detections(
+        "predictions",
+        gt_field="ground_truth",
+        classwise=False,
+        eval_key="eval",
+    )
+
+    counts = dataset.count_values("ground_truth.detections.label")
+    classes = sorted(counts, key=counts.get, reverse=True)[:10]
+
+    plot = results.plot_confusion_matrix(classes=classes, backend=backend)
+    plot.show()
+
+    input("Press enter to continue...")
+
+
+###############################################################################
+# ViewPlot
+###############################################################################
+
+
+def test_view_plot():
+    dataset = foz.load_zoo_dataset("quickstart")
+    dataset.compute_metadata()
+
+    plot1 = fo.NumericalHistogram(
+        F("metadata.size_bytes") / 1024,
+        bins=50,
+        xlabel="image size (KB)",
+        init_view=dataset,
+    )
+    plot1.show()
+
+    plot2 = fo.NumericalHistogram(
+        "predictions.detections.confidence",
+        bins=50,
+        range=[0, 1],
+        init_view=dataset,
+    )
+    plot2.show()
+
+    plot3 = fo.CategoricalHistogram(
+        "ground_truth.detections.label",
+        order="frequency",
+        init_view=dataset,
+    )
+    plot3.show()
+
+    plot4 = fo.CategoricalHistogram(
+        "predictions.detections.label",
+        order="frequency",
+        init_view=dataset,
+    )
+    plot4.show()
+
+    input("Press enter to continue...")
+
+    plot = fo.ViewGrid([plot1, plot2, plot3, plot4], init_view=dataset)
+    plot.show()
+
+    input("Press enter to continue...")
+
+    view = dataset.take(51)
+    plot.update_view(view)
+    plot.show()
+
+    input("Press enter to continue...")
+
+
+if __name__ == "__main__":
+    fo.config.show_progress_bars = True
+    unittest.main(verbosity=2)


### PR DESCRIPTION
Updates methods like `scatterplot()` and the in-App embeddings backend to always rely on sample/label IDs when pulling data for plots.

Previously, these implementations assumed that the `view` on which embeddings/etc were computed has not changed in any way. Now, these methods will gracefully handle added/deleted data.

New tests are added to `tests/intensive/plot_tests.py` to verify that the plotting methods function as expected.