### PR TITLE
Use TTL caches when accessing datasets in App server

### DIFF
--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -17,6 +17,7 @@ import random
 import string
 
 from bson import json_util, ObjectId
+import cachetools
 from deprecated import deprecated
 import mongoengine.errors as moe
 from pymongo import DeleteMany, InsertOne, ReplaceOne, UpdateMany, UpdateOne
@@ -278,9 +279,9 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
 
         self._group_slice = doc.default_group_slice
 
-        self._annotation_cache = {}
-        self._brain_cache = {}
-        self._evaluation_cache = {}
+        self._annotation_cache = cachetools.LRUCache(10)
+        self._brain_cache = cachetools.LRUCache(10)
+        self._evaluation_cache = cachetools.LRUCache(10)
 
         self._deleted = False
 

--- a/fiftyone/server/events.py
+++ b/fiftyone/server/events.py
@@ -1,5 +1,5 @@
 """
-FiftyOne Server events
+FiftyOne Server events.
 
 | Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
@@ -14,7 +14,6 @@ import asyncio
 from sse_starlette import ServerSentEvent
 from starlette.requests import Request
 
-import fiftyone as fo
 import fiftyone.core.context as focx
 from fiftyone.core.json import FiftyOneJSONEncoder
 from fiftyone.core.session.events import (
@@ -30,7 +29,9 @@ from fiftyone.core.session.events import (
 )
 import fiftyone.core.state as fos
 import fiftyone.core.utils as fou
+
 from fiftyone.server.query import serialize_dataset
+import fiftyone.server.utils as fosu
 
 
 @dataclass(frozen=True)
@@ -275,7 +276,7 @@ async def _initialize_listener(payload: ListenPayload) -> InitializedListener:
         ):
             update = True
             try:
-                state.dataset = fo.load_dataset(payload.initializer.dataset)
+                state.dataset = fosu.load_dataset(payload.initializer.dataset)
                 state.selected = []
                 state.selected_labels = []
                 state.view = None

--- a/fiftyone/server/mutation.py
+++ b/fiftyone/server/mutation.py
@@ -1,5 +1,5 @@
 """
-FiftyOne Server mutations
+FiftyOne Server mutations.
 
 | Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
@@ -11,20 +11,19 @@ import typing as t
 
 import eta.core.serial as etas
 
-import fiftyone as fo
 import fiftyone.constants as foc
 import fiftyone.core.odm as foo
 from fiftyone.core.session.events import StateUpdate
-import fiftyone.core.stages as fos
-import fiftyone.core.view as fov
-import fiftyone.core.dataset as fod
 from fiftyone.core.spaces import default_spaces, Space
+import fiftyone.core.stages as fos
 import fiftyone.core.utils as fou
+import fiftyone.core.view as fov
 
 from fiftyone.server.data import Info
 from fiftyone.server.events import get_state, dispatch_event
 from fiftyone.server.query import Dataset, SidebarGroup, SavedView
 from fiftyone.server.scalars import BSON, BSONArray, JSON
+import fiftyone.server.utils as fosu
 from fiftyone.server.view import get_view, extend_view
 
 
@@ -92,7 +91,7 @@ class Mutation:
         info: Info,
     ) -> bool:
         state = get_state()
-        state.dataset = fo.load_dataset(name) if name is not None else None
+        state.dataset = fosu.load_dataset(name) if name is not None else None
         state.selected = []
         state.selected_labels = []
         state.view = None
@@ -182,7 +181,7 @@ class Mutation:
         # Load saved views
         if saved_view_slug is not None:
             try:
-                ds = fod.load_dataset(dataset_name)
+                ds = fosu.load_dataset(dataset_name)
                 doc = ds._get_saved_view_doc(saved_view_slug, slug=True)
                 result_view = ds._load_saved_view_from_doc(doc)
             except:
@@ -271,8 +270,7 @@ class Mutation:
         dataset = state.dataset
         use_state = dataset is not None
         if dataset is None:
-            # teams is stateless so dataset will be null
-            dataset = fo.load_dataset(dataset_name)
+            dataset = fosu.load_dataset(dataset_name)
 
         if dataset is None:
             raise ValueError(
@@ -322,7 +320,7 @@ class Mutation:
                 view_name,
             )
 
-        dataset = fo.load_dataset(dataset_name)
+        dataset = fosu.load_dataset(dataset_name)
         if not dataset:
             raise ValueError(f"No dataset found with name {dataset_name}")
 
@@ -366,7 +364,7 @@ class Mutation:
         """
         state = get_state()
         if state is None or state.dataset is None:
-            dataset = fo.load_dataset(dataset_name)
+            dataset = fosu.load_dataset(dataset_name)
         else:
             dataset = state.dataset
 

--- a/fiftyone/server/query.py
+++ b/fiftyone/server/query.py
@@ -1,5 +1,5 @@
 """
-FiftyOne Server queries
+FiftyOne Server queries.
 
 | Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
@@ -39,8 +39,9 @@ from fiftyone.server.samples import (
     SampleItem,
     paginate_samples,
 )
-
 from fiftyone.server.scalars import BSONArray, JSON
+import fiftyone.server.utils as fosu
+
 
 ID = gql.scalar(
     t.NewType("ID", str),
@@ -393,7 +394,7 @@ class Query(fosa.AggregateQuery):
 
     @gql.field
     def saved_views(self, dataset_name: str) -> t.Optional[t.List[SavedView]]:
-        ds = fo.load_dataset(dataset_name)
+        ds = fosu.load_dataset(dataset_name)
         return [
             SavedView.from_doc(view_doc) for view_doc in ds._doc.saved_views
         ]
@@ -426,7 +427,7 @@ async def serialize_dataset(
     saved_view_slug: t.Optional[str],
 ) -> Dataset:
     def run():
-        dataset = fo.load_dataset(dataset_name)
+        dataset = fosu.load_dataset(dataset_name)
         dataset.reload()
         view_name = None
         try:

--- a/fiftyone/server/routes/sort.py
+++ b/fiftyone/server/routes/sort.py
@@ -1,5 +1,5 @@
 """
-FiftyOne Server /sort route
+FiftyOne Server ``/sort`` route.
 
 | Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
@@ -8,13 +8,14 @@ FiftyOne Server /sort route
 from starlette.endpoints import HTTPEndpoint
 from starlette.requests import Request
 
-import fiftyone.core.dataset as fod
 import fiftyone.core.fields as fof
+import fiftyone.core.utils as fou
 import fiftyone.core.view as fov
 
 from fiftyone.server.decorators import route
 import fiftyone.server.events as fose
 from fiftyone.server.query import serialize_dataset
+import fiftyone.server.utils as fosu
 import fiftyone.server.view as fosv
 
 
@@ -25,31 +26,22 @@ class Sort(HTTPEndpoint):
         filters = data.get("filters", {})
         stages = data.get("view", None)
         dist_field = data.get("dist_field", None)
-        dataset = fod.load_dataset(dataset_name)
 
-        changed = False
-        if dist_field and not dataset.get_field(dist_field):
-            dataset.add_sample_field(dist_field, fof.FloatField)
-            changed = True
-
-        fosv.get_view(dataset_name, stages=stages, filters=filters)
+        view = fosv.get_view(dataset_name, stages=stages, filters=filters)
+        dataset = view._dataset
 
         state = fose.get_state().copy()
-        view = fosv.get_view(dataset_name, stages=stages, filters=filters)
-        state.dataset = view._dataset
+        state.dataset = dataset
+        state.view = view
 
-        if isinstance(view, fov.DatasetView):
-            state.view = view
-        else:
-            view = None
-
-        return {
-            "dataset": await serialize_dataset(
+        if dist_field and not dataset.has_field(dist_field):
+            dataset.add_sample_field(dist_field, fof.FloatField)
+            _dataset = await serialize_dataset(
                 dataset_name=dataset_name,
-                serialized_view=stages,
-                view_name=view.name,
+                serialized_view=view._serialize(),
+                saved_view_slug=fou.to_slug(view.name) if view.name else None,
             )
-            if changed
-            else None,
-            "state": state.serialize(),
-        }
+        else:
+            _dataset = None
+
+        return {"dataset": _dataset, "state": state.serialize()}

--- a/fiftyone/server/utils.py
+++ b/fiftyone/server/utils.py
@@ -18,9 +18,10 @@ import fiftyone.core.media as fom
 def load_dataset(name):
     """Loads the dataset with the given name.
 
-    Dataset objects are singletons, but we use a TTL + LRU cache here to ensure
-    that references to recently used datasets exist in memory so that dataset
-    objects aren't garbage collected between async calls.
+    Dataset objects are singletons and may have objects (eg brain results) that
+    are expensive to load cached on them, so we use a TTL + LRU cache here to
+    ensure that references to recently used datasets exist in memory so that
+    dataset objects aren't garbage collected between async calls.
 
     Args:
         name: the dataset name

--- a/fiftyone/server/utils.py
+++ b/fiftyone/server/utils.py
@@ -1,14 +1,34 @@
 """
-FiftyOne Server utils
+FiftyOne Server utils.
 
 | Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+import cachetools.func
+
 import fiftyone.core.collections as foc
+import fiftyone.core.dataset as fod
 import fiftyone.core.fields as fof
 import fiftyone.core.labels as fol
 import fiftyone.core.media as fom
+
+
+@cachetools.func.ttl_cache(maxsize=10, ttl=900)  # ttl in seconds
+def load_dataset(name):
+    """Loads the dataset with the given name.
+
+    Dataset objects are singletons, but we use a TTL + LRU cache here to ensure
+    that references to recently used datasets exist in memory so that dataset
+    objects aren't garbage collected between async calls.
+
+    Args:
+        name: the dataset name
+
+    Returns:
+        a :class:`fiftyone.core.dataset.Dataset`
+    """
+    return fod.load_dataset(name)
 
 
 def change_sample_tags(sample_collection, changes):

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -1,6 +1,7 @@
 aiofiles==0.7.0
 argcomplete==1.11.0
 boto3==1.17.36
+cachetools==5.2.0
 dacite==1.6.0
 Deprecated==1.2.11
 eventlet==0.31.0

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ INSTALL_REQUIRES = [
     "aiofiles",
     "argcomplete",
     "boto3",
+    "cachetools",
     "dacite>=1.6.0",
     "dacite>=1.6.0,<1.8.0",
     "Deprecated",


### PR DESCRIPTION
Updates all usages of `load_dataset()` in the App server to use a TTL cache so that recently used dataset objects will not be garbage collected between async calls.

```py
@cachetools.func.ttl_cache(maxsize=10, ttl=900)  # ttl in seconds
def load_dataset(name):
    """Loads the dataset with the given name.

    Dataset objects are singletons, but we use a TTL + LRU cache here to ensure
    that references to recently used datasets exist in memory so that dataset
    objects aren't garbage collected between async calls.

    Args:
        name: the dataset name

    Returns:
        a :class:`fiftyone.core.dataset.Dataset`
    """
    return fod.load_dataset(name)
```
