### PR TITLE
Add support for importing CSV datasets

### DIFF
--- a/docs/source/user_guide/dataset_creation/datasets.rst
+++ b/docs/source/user_guide/dataset_creation/datasets.rst
@@ -264,6 +264,9 @@ refer to the corresponding dataset format when reading the dataset from disk.
     | :ref:`BDDDataset <BDDDataset-import>`                                                 | A labeled dataset consisting of images and their associated multitask predictions  |
     |                                                                                       | saved in `Berkeley DeepDrive (BDD) format <https://bdd-data.berkeley.edu>`_.       |
     +---------------------------------------------------------------------------------------+------------------------------------------------------------------------------------+
+    | :ref:`CSVDataset <CSVDataset-import>`                                                 | A labeled dataset consisting of images or videos and their associated field values |
+    |                                                                                       | stored as columns of a CSV file.                                                   |
+    +---------------------------------------------------------------------------------------+------------------------------------------------------------------------------------+
     | :ref:`DICOMDataset <DICOMDataset-import>`                                             | An image dataset whose image data and optional properties are stored in            |
     |                                                                                       | `DICOM format <https://en.wikipedia.org/wiki/DICOM>`_.                             |
     +---------------------------------------------------------------------------------------+------------------------------------------------------------------------------------+
@@ -4203,6 +4206,163 @@ directory containing the corresponding media files by providing the
 
     If the `name` key of your labels contains absolute paths to the source
     media, then you can omit the `data_path` parameter from the example above.
+
+.. _CSVDataset-import:
+
+CSVDataset
+----------
+
+The :class:`fiftyone.types.CSVDataset` type represents a dataset consisting
+of images or videos and their associated field values stored as columns of a
+CSV file.
+
+Datasets of this type are read in the following format:
+
+.. code-block:: text
+
+    <dataset_dir>/
+        data/
+            <filename1>.<ext>
+            <filename2>.<ext>
+            ...
+        labels.csv
+
+where `labels.csv` is a CSV file in the following format:
+
+.. code-block:: text
+
+    field1,field2,field3,...
+    value1,value2,value3,...
+    value1,value2,value3,...
+    ...
+
+One sample will be generated per row in the CSV file (excluding the header
+row).
+
+One column of the CSV file must contain media paths, which may be either:
+
+-   filenames or relative paths to media files in ``data/``
+-   absolute paths to media files
+
+By default it is assumed that a ``filepath`` column exists and contains the
+media paths, but you can customize this via the optional ``media_field``
+parameter.
+
+By default all columns are loaded as string fields, but you can provide the
+optional ``fields`` parameter to select a subset of columns to load or provide
+custom parsing functions for each field, as demonstrated below.
+
+.. note::
+
+    See :class:`CSVDatasetImporter <fiftyone.utils.csv.CSVDatasetImporter>`
+    for parameters that can be passed to methods like
+    :meth:`Dataset.from_dir() <fiftyone.core.dataset.Dataset.from_dir>` to
+    customize the import of datasets of this type.
+
+You can create a FiftyOne dataset from a CSV dataset stored in the above
+format as follows:
+
+.. tabs::
+
+  .. group-tab:: Python
+
+    .. code-block:: python
+        :linenos:
+
+        import fiftyone as fo
+
+        name = "my-dataset"
+        dataset_dir = "/path/to/csv-dataset"
+
+        # Create the dataset
+        dataset = fo.Dataset.from_dir(
+            dataset_dir=dataset_dir,
+            dataset_type=fo.types.CSVDataset,
+            name=name,
+        )
+
+        # View summary info about the dataset
+        print(dataset)
+
+        # Print the first few samples in the dataset
+        print(dataset.head())
+
+  .. group-tab:: CLI
+
+    .. code-block:: shell
+
+        NAME=my-dataset
+        DATASET_DIR=/path/to/csv-dataset
+
+        # Create the dataset
+        fiftyone datasets create \
+            --name $NAME \
+            --dataset-dir $DATASET_DIR \
+            --type fiftyone.types.CSVDataset
+
+        # View summary info about the dataset
+        fiftyone datasets info $NAME
+
+        # Print the first few samples in the dataset
+        fiftyone datasets head $NAME
+
+    To view a CSV dataset stored in the above format in the FiftyOne App
+    without creating a persistent FiftyOne dataset, you can execute:
+
+    .. code-block:: shell
+
+        DATASET_DIR=/path/to/csv-dataset
+
+        # View the dataset in the App
+        fiftyone app view \
+            --dataset-dir $DATASET_DIR \
+            --type fiftyone.types.CSVDataset
+
+If your CSV file contains absolute media paths, then you can directly specify
+the path to the CSV file itself by providing the `labels_path` parameter.
+
+Additionally, you can use the `fields` parameter to customize how each field is
+parsed, as demonstrated below:
+
+.. tabs::
+
+  .. group-tab:: Python
+
+    .. code-block:: python
+        :linenos:
+
+        import fiftyone as fo
+
+        name = "my-dataset"
+        labels_path = "/path/to/labels.csv"
+
+        fields = {
+            "filepath": None,  # load as strings
+            "tags": lambda v: v.strip("").split(","),
+            "float_field": lambda v: float(v),
+            "weather": lambda v: fo.Classification(label=v) if v else None,
+        }
+
+        # Import CSV file with absolute media paths and custom field parsers
+        dataset = fo.Dataset.from_dir(
+            dataset_type=fo.types.CSVDataset,
+            labels_path=labels_path,
+            fields=fields,
+            name=name,
+        )
+
+  .. group-tab:: CLI
+
+    .. code-block:: shell
+
+        NAME=my-dataset
+        LABELS_PATH=/path/to/labels.csv
+
+        # Import CSV file with absolute media paths
+        fiftyone datasets create \
+            --name $NAME \
+            --type fiftyone.types.CSVDataset \
+            --kwargs labels_path=$LABELS_PATH
 
 .. _DICOMDataset-import:
 

--- a/docs/source/user_guide/export_datasets.rst
+++ b/docs/source/user_guide/export_datasets.rst
@@ -3465,8 +3465,9 @@ follows:
             --type fiftyone.types.CSVDataset \
             --kwargs fields=list,of,fields
 
-You can also directly export a CSV of field values with no media by providing
-the `labels_path` parameter instead of `export_dir`:
+You can also directly export a CSV files of field values and absolute media
+paths without exporting the actual media files by providing the `labels_path`
+parameter instead of `export_dir`:
 
 .. tabs::
 
@@ -3482,11 +3483,12 @@ the `labels_path` parameter instead of `export_dir`:
         # The dataset or view to export
         dataset_or_view = fo.Dataset(...)
 
-        # Export labels
+        # Export labels with absolute media paths
         dataset_or_view.export(
             dataset_type=fo.types.CSVDataset,
             labels_path=labels_path,
             fields=["list", "of", "fields"],
+            abs_paths=True,
         )
 
   .. group-tab:: CLI
@@ -3496,12 +3498,13 @@ the `labels_path` parameter instead of `export_dir`:
         NAME=my-dataset
         LABELS_PATH=/path/for/labels.csv
 
-        # Export labels
+        # Export labels with absolute media paths
         fiftyone datasets export $NAME \
             --type fiftyone.types.CSVDataset \
             --kwargs \
                 labels_path=$LABELS_PATH \
-                fields=list,of,fields
+                fields=list,of,fields \
+                abs_paths=True
 
 .. _GeoJSONDataset-export:
 

--- a/docs/source/user_guide/export_datasets.rst
+++ b/docs/source/user_guide/export_datasets.rst
@@ -3465,7 +3465,7 @@ follows:
             --type fiftyone.types.CSVDataset \
             --kwargs fields=list,of,fields
 
-You can also directly export a CSV files of field values and absolute media
+You can also directly export a CSV file of field values and absolute media
 paths without exporting the actual media files by providing the `labels_path`
 parameter instead of `export_dir`:
 

--- a/fiftyone/types/dataset_types.py
+++ b/fiftyone/types/dataset_types.py
@@ -768,19 +768,20 @@ class CSVDataset(Dataset):
     """A flexible CSV format that represents slice(s) of field values of a
     dataset as columns of a CSV file.
 
-    See :ref:`this page <CSVDataset-export>` for exporting datasets of this
-    type.
+    See :ref:`this page <CSVDataset-import>` for importing datasets of this
+    type, and see :ref:`this page <CSVDataset-export>` for exporting
+    datasets of this type.
     """
-
-    def get_dataset_exporter_cls(self):
-        import fiftyone.utils.csv as fouc
-
-        return fouc.CSVDatasetExporter
 
     def get_dataset_importer_cls(self):
         import fiftyone.utils.csv as fouc
 
         return fouc.CSVDatasetImporter
+
+    def get_dataset_exporter_cls(self):
+        import fiftyone.utils.csv as fouc
+
+        return fouc.CSVDatasetExporter
 
 
 class FiftyOneDataset(Dataset):

--- a/fiftyone/types/dataset_types.py
+++ b/fiftyone/types/dataset_types.py
@@ -777,6 +777,11 @@ class CSVDataset(Dataset):
 
         return fouc.CSVDatasetExporter
 
+    def get_dataset_importer_cls(self):
+        import fiftyone.utils.csv as fouc
+
+        return fouc.CSVDatasetImporter
+
 
 class FiftyOneDataset(Dataset):
     """A disk representation of an entire

--- a/fiftyone/utils/csv.py
+++ b/fiftyone/utils/csv.py
@@ -53,13 +53,17 @@ class CSVDatasetImporter(
 
             If None, the parameter will default to ``labels.csv``
         media_field ("filepath"): the name of the column containing the media
-            path for each sample
+            path for each sample. The media paths in this column may be:
+
+            -   filenames or relative paths to media files in ``data_path``
+            -   absolute media paths, in which case ``data_path`` has no effect
         fields (None): an optional parameter that specifies the columns to read
             and parse from the CSV file. Can be any of the following:
 
             -   an iterable of column names to parse as strings
             -   a dict mapping column names to functions that parse the column
-                values into the appropriate type
+                values into the appropriate type. Any keys with ``None`` values
+                in this case are directly loaded as strings
 
             If not provided, all columns are parsed as strings
         skip_missing_media (False): whether to skip (True) or raise an error
@@ -93,15 +97,6 @@ class CSVDatasetImporter(
                 "`labels_path` must be provided"
             )
 
-        if isinstance(fields, dict):
-            fields.pop(media_field, None)
-            fields = {k: v or str for k, v in fields.items()}
-        elif fields is not None:
-            if etau.is_str(fields):
-                fields = [fields]
-
-            fields = [f for f in fields if f != media_field]
-
         data_path = self._parse_data_path(
             dataset_dir=dataset_dir,
             data_path=data_path,
@@ -130,6 +125,7 @@ class CSVDatasetImporter(
 
         self._media_paths_map = None
         self._rows_map = None
+        self._fields = None
         self._filepaths = None
         self._iter_filepaths = None
         self._num_samples = None
@@ -149,13 +145,13 @@ class CSVDatasetImporter(
             return fos.Sample(filepath=filepath)
 
         kwargs = {}
-        if isinstance(self.fields, dict):
-            for key, parser in self.fields.items():
+        if isinstance(self._fields, dict):
+            for key, parser in self._fields.items():
                 value = row.get(key, "")
                 if value:
                     kwargs[key] = parser(value)
-        elif self.fields is not None:
-            for key in self.fields:
+        elif self._fields is not None:
+            for key in self._fields:
                 value = row.get(key, "")
                 if value:
                     kwargs[key] = value
@@ -178,6 +174,7 @@ class CSVDatasetImporter(
         media_paths_map = self._load_data_map(self.data_path, recursive=True)
 
         rows_map = {}
+        fields = _parse_import_fields(self.fields, self.media_field)
 
         media_field = self.media_field
         if self.labels_path is not None and os.path.isfile(self.labels_path):
@@ -215,8 +212,22 @@ class CSVDatasetImporter(
 
         self._media_paths_map = media_paths_map
         self._rows_map = rows_map
+        self._fields = fields
         self._filepaths = filepaths
         self._num_samples = len(filepaths)
+
+
+def _parse_import_fields(fields, media_field):
+    if isinstance(fields, dict):
+        fields.pop(media_field, None)
+        fields = {k: v or str for k, v in fields.items()}
+    elif fields is not None:
+        if etau.is_str(fields):
+            fields = [fields]
+
+        fields = [f for f in fields if f != media_field]
+
+    return fields
 
 
 class CSVDatasetExporter(foud.BatchDatasetExporter, foud.ExportPathsMixin):
@@ -284,8 +295,14 @@ class CSVDatasetExporter(foud.BatchDatasetExporter, foud.ExportPathsMixin):
             exported labels
         media_field ("filepath"): the name of the field containing the media to
             export for each sample
-        fields (None): a field or iterable of fields to include as columns in
-            the exported CSV file. By default, only the ``media_field`` is used
+        fields (None): an optional argument specifying the fields or
+            ``embedding.field.names`` to include as columns in the exported
+            CSV. Can be:
+
+            -   a field or iterable of fields
+            -   a dict mapping field names to column names
+
+            By default, only the ``media_field`` is exported
     """
 
     def __init__(
@@ -325,7 +342,7 @@ class CSVDatasetExporter(foud.BatchDatasetExporter, foud.ExportPathsMixin):
         self._media_exporter = None
         self._f = None
         self._csv_writer = None
-        self._fields = None
+        self._paths = None
         self._media_idx = None
         self._include_media = None
         self._needs_metadata = None
@@ -338,26 +355,26 @@ class CSVDatasetExporter(foud.BatchDatasetExporter, foud.ExportPathsMixin):
         )
         self._media_exporter.setup()
 
-        fields, media_idx, include_media = _parse_fields(
+        (
+            paths,
+            header,
+            media_idx,
+            include_media,
+            needs_metadata,
+        ) = _parse_export_fields(
             self.fields, self.media_field, self.export_media
         )
-        needs_metadata = any(p.startswith("metadata.") for p in fields)
-
-        header = fields.copy()
-        if not include_media and media_idx is not None:
-            header.pop(media_idx)
 
         etau.ensure_basedir(self.labels_path)
         f = open(self.labels_path, "w")
 
-        # QUOTE_MINIMAL is default, but pass it anyway to make sure list
-        # fields we try to write are handled properly
+        # QUOTE_MINIMAL ensures that list fields are handled properly
         csv_writer = csv.writer(f, quoting=csv.QUOTE_MINIMAL)
         csv_writer.writerow(header)
 
         self._f = f
         self._csv_writer = csv_writer
-        self._fields = fields
+        self._paths = paths
         self._media_idx = media_idx
         self._include_media = include_media
         self._needs_metadata = needs_metadata
@@ -368,7 +385,7 @@ class CSVDatasetExporter(foud.BatchDatasetExporter, foud.ExportPathsMixin):
 
         idx = self._media_idx
         with fou.ProgressBar(total=len(sample_collection)) as pb:
-            for data in pb(zip(*sample_collection.values(self._fields))):
+            for data in pb(zip(*sample_collection.values(self._paths))):
                 data = [_parse_value(d) for d in data]
 
                 if idx is not None:
@@ -387,28 +404,33 @@ class CSVDatasetExporter(foud.BatchDatasetExporter, foud.ExportPathsMixin):
         self._f.close()
 
 
-def _parse_fields(fields, media_field, export_media):
+def _parse_export_fields(fields, media_field, export_media):
     if not fields:
         fields = media_field
 
-    if etau.is_str(fields):
-        fields = [fields]
+    if isinstance(fields, dict):
+        paths, header = zip(*fields.items())
+    elif etau.is_str(fields):
+        paths = [fields]
+        header = [fields]
     else:
-        fields = list(fields)
+        paths = list(fields)
+        header = list(fields)
 
     try:
-        media_idx = fields.index(media_field)
+        media_idx = paths.index(media_field)
         include_media = True
     except ValueError:
+        include_media = False
         if export_media:
-            fields.append(media_field)
-            media_idx = len(fields) - 1
-            include_media = False
+            paths.append(media_field)
+            media_idx = len(paths) - 1
         else:
             media_idx = None
-            include_media = False
 
-    return fields, media_idx, include_media
+    needs_metadata = any(p.startswith("metadata.") for p in paths)
+
+    return paths, header, media_idx, include_media, needs_metadata
 
 
 def _parse_value(value):

--- a/fiftyone/utils/csv.py
+++ b/fiftyone/utils/csv.py
@@ -18,7 +18,7 @@ import fiftyone.utils.data as foud
 class CSVDatasetImporter(
     foud.GenericSampleDatasetImporter, foud.ImportPathsMixin
 ):
-    """A flexible CSV exporter that represents slice(s) of field values of a
+    """A flexible CSV importer that represents slice(s) of field values of a
     dataset as columns of a CSV file.
 
     See :ref:`this page <CSVDataset-import>` for format details.

--- a/fiftyone/utils/csv.py
+++ b/fiftyone/utils/csv.py
@@ -7,15 +7,216 @@ CSV utilities.
 """
 import csv
 import os
-import random
-import re
 
 import eta.core.utils as etau
 
-import fiftyone.core.labels as fol
 import fiftyone.core.utils as fou
 import fiftyone.core.sample as fos
 import fiftyone.utils.data as foud
+
+
+class CSVDatasetImporter(
+    foud.GenericSampleDatasetImporter, foud.ImportPathsMixin
+):
+    """A flexible CSV exporter that represents slice(s) of field values of a
+    dataset as columns of a CSV file.
+
+    See :ref:`this page <CSVDataset-import>` for format details.
+
+    Args:
+        dataset_dir (None): the dataset directory. If omitted, ``data_path``
+            and/or ``labels_path`` must be provided
+        data_path (None): an optional parameter that enables explicit control
+            over the location of the media. Can be any of the following:
+
+            -   a folder name like ``"data"`` or ``"data/"`` specifying a
+                subfolder of ``dataset_dir`` where the media files reside
+            -   an absolute directory path where the media files reside. In
+                this case, the ``dataset_dir`` has no effect on the location of
+                the data
+            -   a filename like ``"data.json"`` specifying the filename of the
+                JSON data manifest file in ``dataset_dir``
+            -   an absolute filepath specifying the location of the JSON data
+                manifest. In this case, ``dataset_dir`` has no effect on the
+                location of the data
+            -   a dict mapping filenames to absolute filepaths
+
+            If None, this parameter will default to whichever of ``data/`` or
+            ``data.json`` exists in the dataset directory
+        labels_path (None): an optional parameter that enables explicit control
+            over the location of the labels. Can be any of the following:
+
+            -   a filename like ``"labels.csv"`` specifying the location of
+                the labels in ``dataset_dir``
+            -   an absolute filepath to the labels. In this case,
+                ``dataset_dir`` has no effect on the location of the labels
+
+            If None, the parameter will default to ``labels.csv``
+        media_field ("filepath"): the name of the column containing the media
+            path for each sample
+        fields (None): an optional parameter that specifies the columns to read
+            and parse from the CSV file. Can be any of the following:
+
+            -   an iterable of column names to parse as strings
+            -   a dict mapping column names to functions that parse the column
+                values into the appropriate type
+
+            If not provided, all columns are parsed as strings
+        skip_missing_media (False): whether to skip (True) or raise an error
+            (False) when rows with no ``media_field`` are encountered
+        include_all_data (False): whether to generate samples for all media in
+            the data directory (True) rather than only creating samples for
+            media with label entries (False)
+        shuffle (False): whether to randomly shuffle the order in which the
+            samples are imported
+        seed (None): a random seed to use when shuffling
+        max_samples (None): a maximum number of samples to import. By default,
+            all samples are imported
+    """
+
+    def __init__(
+        self,
+        dataset_dir=None,
+        data_path=None,
+        labels_path=None,
+        media_field="filepath",
+        fields=None,
+        skip_missing_media=False,
+        include_all_data=False,
+        shuffle=False,
+        seed=None,
+        max_samples=None,
+    ):
+        if dataset_dir is None and data_path is None and labels_path is None:
+            raise ValueError(
+                "At least one of `dataset_dir`, `data_path`, and "
+                "`labels_path` must be provided"
+            )
+
+        if isinstance(fields, dict):
+            fields.pop(media_field, None)
+            fields = {k: v or str for k, v in fields.items()}
+        elif fields is not None:
+            if etau.is_str(fields):
+                fields = [fields]
+
+            fields = [f for f in fields if f != media_field]
+
+        data_path = self._parse_data_path(
+            dataset_dir=dataset_dir,
+            data_path=data_path,
+            default="data/",
+        )
+
+        labels_path = self._parse_labels_path(
+            dataset_dir=dataset_dir,
+            labels_path=labels_path,
+            default="labels.csv",
+        )
+
+        super().__init__(
+            dataset_dir=dataset_dir,
+            shuffle=shuffle,
+            seed=seed,
+            max_samples=max_samples,
+        )
+
+        self.data_path = data_path
+        self.labels_path = labels_path
+        self.media_field = media_field
+        self.fields = fields
+        self.skip_missing_media = skip_missing_media
+        self.include_all_data = include_all_data
+
+        self._media_paths_map = None
+        self._rows_map = None
+        self._filepaths = None
+        self._iter_filepaths = None
+        self._num_samples = None
+
+    def __iter__(self):
+        self._iter_filepaths = iter(self._filepaths)
+        return self
+
+    def __len__(self):
+        return self._num_samples
+
+    def __next__(self):
+        filepath = next(self._iter_filepaths)
+
+        row = self._rows_map.get(filepath, None)
+        if row is None:
+            return fos.Sample(filepath=filepath)
+
+        kwargs = {}
+        if isinstance(self.fields, dict):
+            for key, parser in self.fields.items():
+                value = row.get(key, "")
+                if value:
+                    kwargs[key] = parser(value)
+        elif self.fields is not None:
+            for key in self.fields:
+                value = row.get(key, "")
+                if value:
+                    kwargs[key] = value
+        else:
+            for key, value in row.items():
+                if value:
+                    kwargs[key] = value
+
+        return fos.Sample(filepath=filepath, **kwargs)
+
+    @property
+    def has_sample_field_schema(self):
+        return False
+
+    @property
+    def has_dataset_info(self):
+        return False
+
+    def setup(self):
+        media_paths_map = self._load_data_map(self.data_path, recursive=True)
+
+        rows_map = {}
+
+        media_field = self.media_field
+        if self.labels_path is not None and os.path.isfile(self.labels_path):
+            with open(self.labels_path, "r") as f:
+                reader = csv.DictReader(f)
+                if media_field not in reader.fieldnames:
+                    raise ValueError(
+                        "Media field '%s' not found in '%s'"
+                        % (media_field, self.labels_path)
+                    )
+
+                for row in reader:
+                    filename = row.pop(media_field, None)
+                    if filename is None or os.path.isabs(filename):
+                        filepath = filename
+                    else:
+                        filepath = media_paths_map.get(filename, None)
+
+                    if filepath is None:
+                        if self.skip_missing_media:
+                            continue
+                        else:
+                            raise ValueError(
+                                "Found row with no '%s' value" % media_field
+                            )
+
+                    rows_map[filepath] = row
+
+        filepaths = set(rows_map.keys())
+
+        if self.include_all_data:
+            filepaths.update(media_paths_map.values())
+
+        filepaths = self._preprocess_list(sorted(filepaths))
+
+        self._media_paths_map = media_paths_map
+        self._rows_map = rows_map
+        self._filepaths = filepaths
+        self._num_samples = len(filepaths)
 
 
 class CSVDatasetExporter(foud.BatchDatasetExporter, foud.ExportPathsMixin):
@@ -149,8 +350,8 @@ class CSVDatasetExporter(foud.BatchDatasetExporter, foud.ExportPathsMixin):
         etau.ensure_basedir(self.labels_path)
         f = open(self.labels_path, "w")
 
-        # QUOTE_MINIMAL is default, but pass it anyway to make sure
-        #   list fields we try to write are handled properly
+        # QUOTE_MINIMAL is default, but pass it anyway to make sure list
+        # fields we try to write are handled properly
         csv_writer = csv.writer(f, quoting=csv.QUOTE_MINIMAL)
         csv_writer.writerow(header)
 
@@ -219,246 +420,3 @@ def _parse_value(value):
 
     # Render lists as "list,of,values"
     return ",".join(str(v) for v in value)
-
-
-class Parsers:
-    @staticmethod
-    def StringParser(value):
-        return None if value == "" else str(value)
-
-    DefaultParser = StringParser
-
-    @staticmethod
-    def IntParser(value):
-        return int(value) if value else 0
-
-    @staticmethod
-    def FloatParser(value):
-        return float(value) if value else None
-
-    @staticmethod
-    def ListParser(subparser=DefaultParser):
-        def _ListParser(value):
-            return (
-                []
-                if value == ""
-                else [subparser(sv) for sv in value.split(",")]
-            )
-
-        return _ListParser
-
-    @staticmethod
-    def ClassificationParser(value):
-        return fol.Classification(label=value) if value else None
-
-
-class CSVDatasetImporter(foud.BatchDatasetImporter, foud.ImportPathsMixin):
-    """Importer for COCO detection datasets stored on disk.
-
-    See :ref:`this page <COCODetectionDataset-import>` for format details.
-
-    Args:
-        dataset_dir (None): the dataset directory. If omitted, ``data_path``
-            and/or ``labels_path`` must be provided
-        data_path (None): an optional parameter that enables explicit control
-            over the location of the media. Can be any of the following:
-
-            -   a folder name like ``"data"`` or ``"data/"`` specifying a
-                subfolder of ``dataset_dir`` where the media files reside
-            -   an absolute directory path where the media files reside. In
-                this case, the ``dataset_dir`` has no effect on the location of
-                the data
-            -   a filename like ``"data.json"`` specifying the filename of the
-                JSON data manifest file in ``dataset_dir``
-            -   an absolute filepath specifying the location of the JSON data
-                manifest. In this case, ``dataset_dir`` has no effect on the
-                location of the data
-            -   a dict mapping filenames to absolute filepaths
-
-            If None, this parameter will default to whichever of ``data/`` or
-            ``data.json`` exists in the dataset directory
-        labels_path (None): an optional parameter that enables explicit control
-            over the location of the labels. Can be any of the following:
-
-            -   a filename like ``"labels.csv"`` specifying the location of
-                the labels in ``dataset_dir``
-            -   an absolute filepath to the labels. In this case,
-                ``dataset_dir`` has no effect on the location of the labels
-
-            If None, the parameter will default to ``labels.csv``
-        media_field ("filepath"): the name of the field containing the media path
-            for each sample
-        fields (None): An optional parameter that specifies fields to read and parse
-            from the CSV file. Can be any of the following:
-            -   `None`. Will use all fields in the CSV and parse with default
-                string parser.
-            -   `List[str]` which are the field names to be read from
-                the CSV. All data will be parsed with default string parser.
-            -   `Dict[str, Optional[fiftyone.utils.csv.Parsers]]` where the key
-                specifies the field name to be read and the value specifies the
-                parser to be used, e.g., `StringParser` or `IntParser`. If `None`,
-                default string parser will be used. `ListParser` can be uniquely
-                used by passing in sub parser type to use for each data field.
-                For example:
-                {
-                    "float_field": Parsers.FloatParser,
-                    "list_field": Parsers.ListParser(Parsers.StringParser),
-                    "classification_field": Parsers.ClassificationParser,
-                    "string_field": None # uses DefaultParser
-                }
-        seed (None): a random seed to use when shuffling
-        max_samples (None): a maximum number of samples to load. If
-            ``label_types`` and/or ``classes`` are also specified, first
-            priority will be given to samples that contain all of the specified
-            label types and/or classes, followed by samples that contain at
-            least one of the specified labels types or classes. The actual
-            number of samples loaded may be less than this maximum value if the
-            dataset does not contain sufficient samples matching your
-            requirements. By default, all matching samples are loaded
-    """
-
-    TAGS_FIELD = "tags"
-
-    def __init__(
-        self,
-        dataset_dir=None,
-        data_path=None,
-        labels_path=None,
-        media_field="filepath",
-        fields=None,
-        shuffle=False,
-        seed=None,
-        max_samples=None,
-    ):
-        if dataset_dir is None and data_path is None and labels_path is None:
-            raise ValueError(
-                "At least one of `dataset_dir`, `data_path`, and "
-                "`labels_path` must be provided"
-            )
-
-        data_path = self._parse_data_path(
-            dataset_dir=dataset_dir,
-            data_path=data_path,
-            default="data/",
-        )
-
-        labels_path = self._parse_labels_path(
-            dataset_dir=dataset_dir,
-            labels_path=labels_path,
-            default="labels.csv",
-        )
-
-        super().__init__(
-            dataset_dir=dataset_dir,
-            shuffle=shuffle,
-            seed=seed,
-            max_samples=max_samples,
-        )
-
-        self.data_path = data_path
-        self.labels_path = labels_path
-        self.media_field = media_field
-
-        if fields is not None:
-            if not isinstance(fields, list) and not isinstance(fields, dict):
-                raise ValueError(
-                    f"Unsupported fields parameter of type {type(fields)}"
-                )
-            if any("." in f for f in fields):
-                raise ValueError(
-                    "Embedded fields not supported in fields parameter"
-                )
-
-        self.field_parsers = fields
-
-    def import_samples(self, dataset, tags=None):
-        """Imports samples and labels stored on disk in CSV format.
-
-        Args:
-            dataset: a :class:`fiftyone.core.dataset.Dataset`
-            tags (None): an optional list of tags to attach to each sample
-
-        Returns:
-            a list of IDs of the samples that were added to the dataset
-        """
-
-        with open(self.labels_path, "r") as labels_file:
-            labels_csv = csv.DictReader(labels_file)
-            if self.media_field not in labels_csv.fieldnames:
-                raise ValueError(
-                    f"No media field '{self.media_field}'"
-                    f" found in '{self.labels_path}'"
-                )
-
-            # Sane defaults
-            #   None: all columns as strings
-            #   List: All columns in list as strings
-            #   Dict: Column name -> Parser or function
-            if self.field_parsers is None:
-                _field_parsers = {
-                    field: Parsers.DefaultParser
-                    for field in labels_csv.fieldnames
-                }
-            elif isinstance(self.field_parsers, list):
-                _field_parsers = {
-                    field: Parsers.DefaultParser
-                    for field in self.field_parsers
-                }
-            elif isinstance(self.field_parsers, dict):
-                _field_parsers = {
-                    f: p or Parsers.DefaultParser
-                    for f, p in self.field_parsers.items()
-                }
-            else:
-                raise ValueError(
-                    f"Unsupported fields parameter of type {type(self.field_parsers)}"
-                )
-
-            embedded_fields = [
-                f.split(".")[0] for f in labels_csv.fieldnames if "." in f
-            ]
-            if len(embedded_fields) != len(set(embedded_fields)):
-                raise ValueError(
-                    "Cannot import embedded document type with multiple fields"
-                )
-
-            has_tags = self.TAGS_FIELD in labels_csv.fieldnames
-            samples = []
-            with fou.ProgressBar(total=self.max_samples) as pb:
-                # Rip through csv rows
-                for csv_row in pb(labels_csv):
-                    media_loc = csv_row.pop(self.media_field)
-                    # Not absolute path (either local or remote)
-                    if not os.path.isabs(media_loc) and not re.match(
-                        r"^\w+://", media_loc
-                    ):
-                        media_loc = os.path.join(self.data_path, media_loc)
-
-                    # Get tags if we have them plus add global tags
-                    _tags = None
-                    if has_tags:
-                        _tags = Parsers.ListParser(Parsers.DefaultParser)(
-                            csv_row[self.TAGS_FIELD]
-                        )
-                        _tags += tags or []
-                        csv_row.pop(self.TAGS_FIELD)
-
-                    # Make sample, parse&add all wanted fields
-                    sample = fos.Sample(filepath=media_loc, tags=_tags)
-                    for field, value in csv_row.items():
-                        field = field.split(".")[0]
-                        if field in _field_parsers:
-                            sample[field] = _field_parsers[field](value)
-                    samples.append(sample)
-
-                    if (
-                        self.max_samples is not None
-                        and labels_csv.line_num > self.max_samples
-                    ):
-                        break
-
-        if self.shuffle:
-            shuffler = random.Random(self.seed)
-            shuffler.shuffle(samples)
-
-        return dataset.add_samples(samples)

--- a/fiftyone/utils/csv.py
+++ b/fiftyone/utils/csv.py
@@ -8,6 +8,7 @@ CSV utilities.
 import csv
 import os
 import random
+import re
 
 import eta.core.utils as etau
 
@@ -427,7 +428,10 @@ class CSVDatasetImporter(foud.BatchDatasetImporter, foud.ImportPathsMixin):
                 # Rip through csv rows
                 for csv_row in pb(labels_csv):
                     media_loc = csv_row.pop(self.media_field)
-                    if not os.path.isabs(media_loc):
+                    # Not absolute path (either local or remote)
+                    if not os.path.isabs(media_loc) and not re.match(
+                        r"^\w+://", media_loc
+                    ):
                         media_loc = os.path.join(self.data_path, media_loc)
 
                     # Get tags if we have them plus add global tags

--- a/fiftyone/utils/csv.py
+++ b/fiftyone/utils/csv.py
@@ -70,7 +70,7 @@ class CSVDatasetImporter(
             (False) when rows with no ``media_field`` are encountered
         include_all_data (False): whether to generate samples for all media in
             the data directory (True) rather than only creating samples for
-            media with label entries (False)
+            media with CSV rows (False)
         shuffle (False): whether to randomly shuffle the order in which the
             samples are imported
         seed (None): a random seed to use when shuffling

--- a/fiftyone/utils/csv.py
+++ b/fiftyone/utils/csv.py
@@ -6,10 +6,14 @@ CSV utilities.
 |
 """
 import csv
+import os
+import random
 
 import eta.core.utils as etau
 
+import fiftyone.core.labels as fol
 import fiftyone.core.utils as fou
+import fiftyone.core.sample as fos
 import fiftyone.utils.data as foud
 
 
@@ -144,7 +148,7 @@ class CSVDatasetExporter(foud.BatchDatasetExporter, foud.ExportPathsMixin):
         etau.ensure_basedir(self.labels_path)
         f = open(self.labels_path, "w")
 
-        # QUOTE_MINIMAL is default, but pass it anyways to make sure
+        # QUOTE_MINIMAL is default, but pass it anyway to make sure
         #   list fields we try to write are handled properly
         csv_writer = csv.writer(f, quoting=csv.QUOTE_MINIMAL)
         csv_writer.writerow(header)
@@ -214,3 +218,235 @@ def _parse_value(value):
 
     # Render lists as "list,of,values"
     return ",".join(str(v) for v in value)
+
+
+class Parsers:
+    @staticmethod
+    def StringParser(value):
+        return None if value == "" else str(value)
+
+    DefaultParser = StringParser
+
+    @staticmethod
+    def IntParser(value):
+        return int(value) if value else 0
+
+    @staticmethod
+    def FloatParser(value):
+        return float(value) if value else None
+
+    @staticmethod
+    def ListParser(subparser=DefaultParser):
+        def _ListParser(value):
+            return (
+                []
+                if value == ""
+                else [subparser(sv) for sv in value.split(",")]
+            )
+
+        return _ListParser
+
+    @staticmethod
+    def ClassificationParser(value):
+        return fol.Classification(label=value) if value else None
+
+
+class CSVDatasetImporter(foud.BatchDatasetImporter, foud.ImportPathsMixin):
+    """Importer for COCO detection datasets stored on disk.
+
+    See :ref:`this page <COCODetectionDataset-import>` for format details.
+
+    Args:
+        dataset_dir (None): the dataset directory. If omitted, ``data_path``
+            and/or ``labels_path`` must be provided
+        data_path (None): an optional parameter that enables explicit control
+            over the location of the media. Can be any of the following:
+
+            -   a folder name like ``"data"`` or ``"data/"`` specifying a
+                subfolder of ``dataset_dir`` where the media files reside
+            -   an absolute directory path where the media files reside. In
+                this case, the ``dataset_dir`` has no effect on the location of
+                the data
+            -   a filename like ``"data.json"`` specifying the filename of the
+                JSON data manifest file in ``dataset_dir``
+            -   an absolute filepath specifying the location of the JSON data
+                manifest. In this case, ``dataset_dir`` has no effect on the
+                location of the data
+            -   a dict mapping filenames to absolute filepaths
+
+            If None, this parameter will default to whichever of ``data/`` or
+            ``data.json`` exists in the dataset directory
+        labels_path (None): an optional parameter that enables explicit control
+            over the location of the labels. Can be any of the following:
+
+            -   a filename like ``"labels.csv"`` specifying the location of
+                the labels in ``dataset_dir``
+            -   an absolute filepath to the labels. In this case,
+                ``dataset_dir`` has no effect on the location of the labels
+
+            If None, the parameter will default to ``labels.csv``
+        media_field ("filepath"): the name of the field containing the media path
+            for each sample
+        fields (None): An optional parameter that specifies fields to read and parse
+            from the CSV file. Can be any of the following:
+            -   `None`. Will use all fields in the CSV and parse with default
+                string parser.
+            -   `List[str]` which are the field names to be read from
+                the CSV. All data will be parsed with default string parser.
+            -   `Dict[str, Optional[fiftyone.utils.csv.Parsers]]` where the key
+                specifies the field name to be read and the value specifies the
+                parser to be used, e.g., `StringParser` or `IntParser`. If `None`,
+                default string parser will be used. `ListParser` can be uniquely
+                used by passing in sub parser type to use for each data field.
+                For example:
+                {
+                    "float_field": Parsers.FloatParser,
+                    "list_field": Parsers.ListParser(Parsers.StringParser),
+                    "classification_field": Parsers.ClassificationParser,
+                    "string_field": None # uses DefaultParser
+                }
+        seed (None): a random seed to use when shuffling
+        max_samples (None): a maximum number of samples to load. If
+            ``label_types`` and/or ``classes`` are also specified, first
+            priority will be given to samples that contain all of the specified
+            label types and/or classes, followed by samples that contain at
+            least one of the specified labels types or classes. The actual
+            number of samples loaded may be less than this maximum value if the
+            dataset does not contain sufficient samples matching your
+            requirements. By default, all matching samples are loaded
+    """
+
+    TAGS_FIELD = "tags"
+
+    def __init__(
+        self,
+        dataset_dir=None,
+        data_path=None,
+        labels_path=None,
+        media_field="filepath",
+        fields=None,
+        shuffle=False,
+        seed=None,
+        max_samples=None,
+    ):
+        if dataset_dir is None and data_path is None and labels_path is None:
+            raise ValueError(
+                "At least one of `dataset_dir`, `data_path`, and "
+                "`labels_path` must be provided"
+            )
+
+        data_path = self._parse_data_path(
+            dataset_dir=dataset_dir,
+            data_path=data_path,
+            default="data/",
+        )
+
+        labels_path = self._parse_labels_path(
+            dataset_dir=dataset_dir,
+            labels_path=labels_path,
+            default="labels.csv",
+        )
+
+        super().__init__(
+            dataset_dir=dataset_dir,
+            shuffle=shuffle,
+            seed=seed,
+            max_samples=max_samples,
+        )
+
+        self.data_path = data_path
+        self.labels_path = labels_path
+        self.media_field = media_field
+
+        if fields is not None:
+            if not isinstance(fields, list) and not isinstance(fields, dict):
+                raise ValueError(
+                    f"Unsupported fields parameter of type {type(fields)}"
+                )
+            if any("." in f for f in fields):
+                raise ValueError(
+                    "Embedded fields not supported in fields parameter"
+                )
+
+        self.field_parsers = fields
+
+    def import_samples(self, dataset, tags=None):
+        """Imports samples and labels stored on disk in CSV format.
+
+        Args:
+            dataset: a :class:`fiftyone.core.dataset.Dataset`
+            tags (None): an optional list of tags to attach to each sample
+
+        Returns:
+            a list of IDs of the samples that were added to the dataset
+        """
+
+        with open(self.labels_path, "r") as labels_file:
+            labels_csv = csv.DictReader(labels_file)
+            if self.media_field not in labels_csv.fieldnames:
+                raise ValueError(
+                    f"No media field '{self.media_field}'"
+                    f" found in '{self.labels_path}'"
+                )
+            if self.field_parsers is None:
+                _field_parsers = {
+                    field: Parsers.DefaultParser
+                    for field in labels_csv.fieldnames
+                }
+            elif isinstance(self.field_parsers, list):
+                _field_parsers = {
+                    field: Parsers.DefaultParser
+                    for field in self.field_parsers
+                }
+            elif isinstance(self.field_parsers, dict):
+                _field_parsers = {
+                    f: p or Parsers.DefaultParser
+                    for f, p in self.field_parsers.items()
+                }
+            else:
+                raise ValueError(
+                    f"Unsupported fields parameter of type {type(self.field_parsers)}"
+                )
+
+            embedded_fields = [
+                f.split(".")[0] for f in labels_csv.fieldnames if "." in f
+            ]
+            if len(embedded_fields) != len(set(embedded_fields)):
+                raise ValueError(
+                    "Cannot import embedded document type with multiple fields"
+                )
+
+            has_tags = self.TAGS_FIELD in labels_csv.fieldnames
+            samples = []
+            with fou.ProgressBar(total=self.max_samples) as pb:
+                for csv_row in pb(labels_csv):
+                    media_loc = csv_row.pop(self.media_field)
+                    if not os.path.isabs(media_loc):
+                        media_loc = os.path.join(self.data_path, media_loc)
+
+                    _tags = None
+                    if has_tags:
+                        _tags = Parsers.ListParser(Parsers.DefaultParser)(
+                            csv_row[self.TAGS_FIELD]
+                        )
+                        _tags += tags or []
+                        csv_row.pop(self.TAGS_FIELD)
+
+                    sample = fos.Sample(filepath=media_loc, tags=_tags)
+                    for field, value in csv_row.items():
+                        field = field.split(".")[0]
+                        if field in _field_parsers:
+                            sample[field] = _field_parsers[field](value)
+                    samples.append(sample)
+
+                    if (
+                        self.max_samples is not None
+                        and labels_csv.line_num > self.max_samples
+                    ):
+                        break
+
+            if self.shuffle:
+                shuffler = random.Random(self.seed)
+                shuffler.shuffle(samples)
+
+            return dataset.add_samples(samples)

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,3 +1,3 @@
-pytest==7.2.1
+pytest==5.4.3
 pytest-cov==4.0.0
 twine>=3

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,3 +1,3 @@
-pytest==5.4.3
+pytest==7.2.1
 pytest-cov==4.0.0
 twine>=3

--- a/tests/unittests/import_export_tests.py
+++ b/tests/unittests/import_export_tests.py
@@ -2104,13 +2104,18 @@ class CSVDatasetTests(ImageDatasetTests):
     def test_csv_dataset(self):
         dataset = self._make_dataset()
 
-        field_parsers = {
-            "weather": lambda value: (
-                fo.Classification(label=value) if value is not None else None
-            ),
-            "filepath": None,  # default parser
-            "tags": lambda value: value.strip("").split(","),
-            "float_field": lambda value: float(value),
+        export_fields = {
+            "filepath": "filepath",
+            "tags": "tags",
+            "float_field": "float_field",
+            "weather.label": "weather",
+        }
+
+        import_fields = {
+            "filepath": None,  # load as strings
+            "tags": lambda v: v.strip("").split(","),
+            "float_field": lambda v: float(v),
+            "weather": lambda v: fo.Classification(label=v) if v else None,
         }
 
         # Standard format
@@ -2120,13 +2125,13 @@ class CSVDatasetTests(ImageDatasetTests):
         dataset.export(
             export_dir=export_dir,
             dataset_type=fo.types.CSVDataset,
-            fields=["filepath", "tags", "float_field", "weather.label"],
+            fields=export_fields,
         )
 
         dataset2 = fo.Dataset.from_dir(
             dataset_dir=export_dir,
             dataset_type=fo.types.CSVDataset,
-            fields=field_parsers,
+            fields=import_fields,
         )
 
         self.assertEqual(len(dataset), len(dataset2))
@@ -2157,14 +2162,14 @@ class CSVDatasetTests(ImageDatasetTests):
         dataset.export(
             labels_path=labels_path,
             dataset_type=fo.types.CSVDataset,
-            fields=["filepath", "tags", "float_field", "weather.label"],
+            fields=export_fields,
         )
 
         dataset2 = fo.Dataset.from_dir(
             data_path=data_path,
             labels_path=labels_path,
             dataset_type=fo.types.CSVDataset,
-            fields=field_parsers,
+            fields=import_fields,
         )
 
         self.assertEqual(len(dataset), len(dataset2))
@@ -2194,14 +2199,14 @@ class CSVDatasetTests(ImageDatasetTests):
         dataset.export(
             labels_path=labels_path,
             dataset_type=fo.types.CSVDataset,
-            fields=["filepath", "tags", "float_field", "weather.label"],
+            fields=export_fields,
             abs_paths=True,
         )
 
         dataset2 = fo.Dataset.from_dir(
             labels_path=labels_path,
             dataset_type=fo.types.CSVDataset,
-            fields=field_parsers,
+            fields=import_fields,
         )
 
         self.assertEqual(len(dataset), len(dataset2))
@@ -2232,13 +2237,13 @@ class CSVDatasetTests(ImageDatasetTests):
             export_dir=export_dir,
             dataset_type=fo.types.CSVDataset,
             rel_dir=rel_dir,
-            fields=["filepath", "tags", "float_field", "weather.label"],
+            fields=export_fields,
         )
 
         dataset2 = fo.Dataset.from_dir(
             dataset_dir=export_dir,
             dataset_type=fo.types.CSVDataset,
-            fields=field_parsers,
+            fields=import_fields,
         )
 
         self.assertEqual(len(dataset), len(dataset2))


### PR DESCRIPTION
Adds support for importing datasets stored as CSV files.

## Example usage:

```py
import fiftyone as fo
import fiftyone.zoo as foz

dataset = foz.load_zoo_dataset("cifar10")

dataset.export(
    labels_path="/tmp/cifar10.csv",
    dataset_type=fo.types.CSVDataset,
    fields={
        "filepath": "filepath",
        "tags": "tags",
        "ground_truth.label": "ground_truth",
    },
    abs_paths=True,
)

dataset2 = fo.Dataset.from_dir(
    labels_path="/tmp/cifar10.csv",
    dataset_type=fo.types.CSVDataset,
    fields={
        "filepath": None,  # load as strings
        "tags": lambda v: v.strip("").split(","),
        "ground_truth": lambda v: fo.Classification(label=v) if v else None,
    },
)

assert set(dataset.values("filepath")) == set(dataset2.values("filepath"))
assert dataset.count_sample_tags() == dataset2.count_sample_tags()
assert dataset.count_values("ground_truth.label") == dataset2.count_values("ground_truth.label")
```
