### PR TITLE
Tweak Similarity Menu

### DIFF
--- a/app/packages/core/src/components/Actions/Similar.tsx
+++ b/app/packages/core/src/components/Actions/Similar.tsx
@@ -200,6 +200,7 @@ interface SortBySimilarityProps {
 const SortBySimilarity = React.memo(
   ({ modal, bounds, close }: SortBySimilarityProps) => {
     const current = useRecoilValue(fos.similarityParameters);
+    const selectedSamples = useRecoilValue(fos.selectedSamples);
     const [state, setState] = useState<fos.State.SortBySimilarityParameters>(
       () =>
         current
@@ -224,6 +225,7 @@ const SortBySimilarity = React.memo(
 
     const choices = useRecoilValue(currentSimilarityKeys(modal));
     const sortBySimilarity = useSortBySimilarity(close);
+    const hasSelectedSamples = [...selectedSamples].length > 0;
     const type = useRecoilValue(sortType(modal));
     const theme = useTheme();
 
@@ -252,7 +254,7 @@ const SortBySimilarity = React.memo(
             svgStyles={{ height: "1rem", marginTop: 7.5 }}
           />
         </PopoutSectionTitle>
-        {hasSimilarityKeys && (
+        {hasSimilarityKeys && hasSelectedSamples && (
           <>
             <Input
               placeholder={"k (default = None)"}


### PR DESCRIPTION
As a user, if I submitted a similarity, but no samples are currently selected, 
when I open the similarity menu, 
I should see doc_link and reset button only. 



## What changes are proposed in this pull request?

https://user-images.githubusercontent.com/17770824/216999066-fe6e969c-f568-475b-bc1d-20ad0d717c59.mov




## How is this patch tested? If it is not, please explain why.

(Details)