### PR TITLE
Correct schema updates with respect to views

### DIFF
--- a/app/packages/app/src/index.tsx
+++ b/app/packages/app/src/index.tsx
@@ -16,7 +16,6 @@ import {
   useRefresh,
   getSavedViewName,
 } from "@fiftyone/state";
-import { isElectron } from "@fiftyone/utilities";
 import { getEventSource, toCamelCase } from "@fiftyone/utilities";
 import React, { useEffect, useRef, useState } from "react";
 import { createRoot } from "react-dom/client";
@@ -126,6 +125,7 @@ const App: React.FC = ({}) => {
                 colorscale,
                 config,
                 refresh: payload.refresh,
+                // REQUIRED: here we define DatasetQuery GraphQL variables
                 variables: state.dataset
                   ? { view: state.view || null }
                   : undefined,

--- a/app/packages/core/src/Dataset.ts
+++ b/app/packages/core/src/Dataset.ts
@@ -194,7 +194,9 @@ export const usePreLoadedDataset = (
           config: config
             ? (toCamelCase(config) as fos.State.Config)
             : undefined,
-          dataset: fos.transformDataset(rest),
+          dataset: fos.transformDataset(
+            stateProxyValue ? stateProxyValue.dataset : rest
+          ),
           state: { view, viewName, ...state, ...(stateProxyValue || {}) },
         };
       });

--- a/app/packages/state/src/hooks/useSetView.ts
+++ b/app/packages/state/src/hooks/useSetView.ts
@@ -84,6 +84,7 @@ const useSetView = (
                 const newRoute = `${router.history.location.pathname}${
                   search.length ? "?" : ""
                 }${search}`;
+
                 router.history.push(newRoute, {
                   ...router.history.location.state,
                   state: {
@@ -94,6 +95,10 @@ const useSetView = (
                     selectedLabels: [],
                     viewName,
                     savedViews: savedViews,
+                  },
+                  variables: {
+                    view: savedViewSlug ? value : viewResponse,
+                    dataset: dataset.name,
                   },
                 });
               } else {

--- a/app/packages/state/src/hooks/useSetView.ts
+++ b/app/packages/state/src/hooks/useSetView.ts
@@ -96,6 +96,7 @@ const useSetView = (
                     viewName,
                     savedViews: savedViews,
                   },
+                  // REQUIRED: here we define DatasetQuery GraphQL variables
                   variables: {
                     view: savedViewSlug ? value : viewResponse,
                     dataset: dataset.name,

--- a/app/packages/state/src/hooks/useSetView.ts
+++ b/app/packages/state/src/hooks/useSetView.ts
@@ -13,7 +13,7 @@ import { RouterContext } from "../routing";
 import useSendEvent from "./useSendEvent";
 import * as fos from "../";
 
-export const stateProxy = atom({
+export const stateProxy = atom<object>({
   key: "stateProxy",
   default: null,
 });
@@ -41,6 +41,9 @@ const useSetView = (
       ) => {
         const dataset = snapshot.getLoadable(fos.dataset).contents;
         const savedViews = dataset.savedViews || [];
+        // temporary workaround to prevent spaces reset on view update
+        const spaces = snapshot.getLoadable(fos.sessionSpaces).contents;
+        const stateProxyValue = snapshot.getLoadable(fos.stateProxy).contents;
         send((session) => {
           const value =
             viewOrUpdater instanceof Function
@@ -64,12 +67,8 @@ const useSetView = (
               savedViewSlug,
             },
             onError,
-            onCompleted: ({
-              setView: {
-                view: viewResponse,
-                dataset: { stages: value, viewName, ...dataset },
-              },
-            }) => {
+            onCompleted: ({ setView: { view: viewResponse, dataset } }) => {
+              const { stages: value, viewName } = dataset;
               const searchParamsString =
                 router.history.location.search || window.location.search;
               const searchParams = new URLSearchParams(searchParamsString);
@@ -95,8 +94,8 @@ const useSetView = (
                     selectedLabels: [],
                     viewName,
                     savedViews: savedViews,
+                    spaces,
                   },
-                  // REQUIRED: here we define DatasetQuery GraphQL variables
                   variables: {
                     view: savedViewSlug ? value : viewResponse,
                     dataset: dataset.name,
@@ -108,12 +107,13 @@ const useSetView = (
                 }${search}`;
 
                 setStateProxy({
+                  ...(stateProxyValue || {}),
                   view: savedViewSlug ? value : viewResponse,
                   viewName,
+                  dataset,
                 });
                 window.history.replaceState(window.history.state, "", newRoute);
               }
-
               onComplete && onComplete();
             },
           });

--- a/app/packages/state/src/routing/RouterContext.ts
+++ b/app/packages/state/src/routing/RouterContext.ts
@@ -92,8 +92,9 @@ export const createRouter = (
       location.pathname,
       errors,
       location.state?.variables as Partial<VariablesOf<any>>,
-      history.location.search
+      location.search
     );
+
     const entries = prepareMatches(environment, matches);
     const nextEntry: Entry<any> = {
       pathname: location.pathname,
@@ -107,7 +108,6 @@ export const createRouter = (
   const context: RoutingContext = {
     history,
     get() {
-      const location = window.location;
       if (!currentEntry) {
         currentEntry = {
           pathname: history.location.pathname,
@@ -120,7 +120,7 @@ export const createRouter = (
               history.location.pathname,
               errors,
               history.location.state?.variables as Partial<VariablesOf<any>>,
-              history.location.search || location.search
+              history.location.search
             )
           ),
         };


### PR DESCRIPTION
Adds the previously missing `variables` state update in `useSetView`. This is required for the dataset query routing variable `view` to be kept in sync and correctly resolve dataset schemas based on the current view. See [here](https://github.com/voxel51/fiftyone/blob/b691096b1537ea1e5e4b6e5ab446967caa7b4a9d/app/packages/state/src/routing/RouterContext.ts#L94).