### PR TITLE
Relay invariant comment on scalar hydration

### DIFF
--- a/app/packages/state/src/hooks/useUpdateSample.ts
+++ b/app/packages/state/src/hooks/useUpdateSample.ts
@@ -22,6 +22,8 @@ export const useUpdateSample = () => {
       commitLocalUpdate(environment, (store) => {
         const record = store.get(id);
 
+        // Relay will not allow objects when hydrating a scalar value
+        // https://github.com/facebook/relay/issues/91
         record?.setValue(JSON.stringify(sample), "sample");
       });
     },

--- a/app/packages/state/src/hooks/useUpdateSample.ts
+++ b/app/packages/state/src/hooks/useUpdateSample.ts
@@ -23,7 +23,8 @@ export const useUpdateSample = () => {
         const record = store.get(id);
 
         // Relay will not allow objects when hydrating a scalar value
-        // https://github.com/facebook/relay/issues/91
+        // - https://github.com/voxel51/fiftyone/pull/2622
+        // - https://github.com/facebook/relay/issues/91
         record?.setValue(JSON.stringify(sample), "sample");
       });
     },

--- a/app/packages/state/src/recoil/groups.ts
+++ b/app/packages/state/src/recoil/groups.ts
@@ -170,6 +170,8 @@ export const pinnedSliceSample = graphQLSelector<
   mapResponse: (response) => {
     const actualRawSample = response?.sample?.sample;
 
+    // This value may be a string that needs to be deserialized
+    // Only occurs after calling useUpdateSample for pinned sample
     if (actualRawSample && typeof actualRawSample === "string") {
       return {
         ...response.sample,

--- a/app/packages/state/src/recoil/groups.ts
+++ b/app/packages/state/src/recoil/groups.ts
@@ -172,6 +172,8 @@ export const pinnedSliceSample = graphQLSelector<
 
     // This value may be a string that needs to be deserialized
     // Only occurs after calling useUpdateSample for pinned sample
+    // - https://github.com/voxel51/fiftyone/pull/2622
+    // - https://github.com/facebook/relay/issues/91
     if (actualRawSample && typeof actualRawSample === "string") {
       return {
         ...response.sample,


### PR DESCRIPTION
I hope this PR will start a larger discussion on "JSON" scalars in FiftyOne, which is essentially schema-less data used largely for sample data and some inputs. Admittedly, this is a shortcoming of the Relay implementation that I did not anticipate.

The issue at hand can be found [here](https://github.com/facebook/relay/issues/91) and it seems unlikely a proper fix will be provided. A practical solution would be to always serialize "JSON" scalars so edge cases don't have to be accounted for.