### PR TITLE
fix plugins require fiftyone key

### DIFF
--- a/fiftyone/server/routes/plugins.py
+++ b/fiftyone/server/routes/plugins.py
@@ -37,6 +37,9 @@ class Plugins(HTTPEndpoint):
         for filepath in pkgs:
             pkg = etas.read_json(filepath)
 
+            if "fiftyone" not in pkg:
+                continue
+
             plugin_definition = {
                 "name": pkg["name"],
                 "version": pkg["version"],


### PR DESCRIPTION
Before this patch, if you added a plugin without a `fiftyone` key in its package.json, all plugin loading would fail.