### PR TITLE
Ensure viewCls for state proxy

### DIFF
--- a/app/packages/state/src/hooks/useSetView.ts
+++ b/app/packages/state/src/hooks/useSetView.ts
@@ -109,6 +109,7 @@ const useSetView = (
                 setStateProxy({
                   ...(stateProxyValue || {}),
                   view: savedViewSlug ? value : viewResponse,
+                  viewCls: dataset.viewCls,
                   viewName,
                   dataset,
                 });


### PR DESCRIPTION
In a stateless context, `viewCls` must be set in the state proxy in `useSetView` to ensure default behavior like crop to content in patches views work correctly. 