### PR TITLE
[Bug fix] Disable saved views with non-unique slugs

### DIFF
--- a/app/packages/core/src/components/Actions/Patcher.tsx
+++ b/app/packages/core/src/components/Actions/Patcher.tsx
@@ -177,6 +177,7 @@ const EvaluationPatches = ({ close }) => {
 };
 
 type PatcherProps = {
+  bounds: any;
   close: () => void;
 };
 

--- a/app/packages/core/src/components/Actions/Patcher.tsx
+++ b/app/packages/core/src/components/Actions/Patcher.tsx
@@ -1,5 +1,5 @@
-import React, { useContext, useState } from "react";
-import { selector, Snapshot, useRecoilCallback, useRecoilValue } from "recoil";
+import React, { useState } from "react";
+import { selector, useRecoilValue } from "recoil";
 import { useSpring } from "@react-spring/web";
 import {
   useToClips,
@@ -11,16 +11,9 @@ import {
   CLIPS_FRAME_FIELDS,
   CLIPS_SAMPLE_FIELDS,
   EMBEDDED_DOCUMENT_FIELD,
-  getFetchFunction,
   PATCHES_FIELDS,
-  toSnakeCase,
 } from "@fiftyone/utilities";
 
-import {
-  RouterContext,
-  useSetView,
-  useUnprocessedStateUpdate,
-} from "@fiftyone/state";
 import {
   OBJECT_PATCHES,
   EVALUATION_PATCHES,

--- a/app/packages/core/src/components/Sidebar/ViewSelection/ViewDialog.tsx
+++ b/app/packages/core/src/components/Sidebar/ViewSelection/ViewDialog.tsx
@@ -37,7 +37,7 @@ import {
   DEFAULT_COLOR_OPTION,
 } from "@fiftyone/components/src/components/Selection/SelectionColors";
 import { shouldToggleBookMarkIconOnSelector } from "../../Actions/ActionsRow";
-import { getFetchFunction, toSnakeCase } from "@fiftyone/utilities";
+import { getFetchFunction } from "@fiftyone/utilities";
 
 interface Props {
   savedViews: fos.State.SavedView[];

--- a/fiftyone/server/routes/__init__.py
+++ b/fiftyone/server/routes/__init__.py
@@ -14,9 +14,10 @@ from .frames import Frames
 from .media import Media
 from .plugins import Plugins
 from .samples import Samples
-from .select import Select
-from .sort import Sort
 from .screenshot import Screenshot
+from .select import Select
+from .slugify import Slugify
+from .sort import Sort
 from .stages import Stages
 from .tag import Tag
 from .tagging import Tagging
@@ -33,6 +34,7 @@ routes = EmbeddingsRoutes + [
     ("/plugins", Plugins),
     ("/samples", Samples),
     ("/select", Select),
+    ("/slugify", Slugify),
     ("/sort", Sort),
     ("/stages", Stages),
     ("/screenshot/{img:str}", Screenshot),

--- a/fiftyone/server/routes/slugify.py
+++ b/fiftyone/server/routes/slugify.py
@@ -1,5 +1,5 @@
 """
-FiftyOne Server /stages route
+FiftyOne Server /slugify route
 
 | Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_

--- a/fiftyone/server/routes/slugify.py
+++ b/fiftyone/server/routes/slugify.py
@@ -1,0 +1,23 @@
+"""
+FiftyOne Server /stages route
+
+| Copyright 2017-2023, Voxel51, Inc.
+| `voxel51.com <https://voxel51.com/>`_
+|
+"""
+from starlette.endpoints import HTTPEndpoint
+from starlette.requests import Request
+
+import typing as t
+
+from fiftyone.core.utils import to_slug
+from fiftyone.server.decorators import route
+
+
+class Slugify(HTTPEndpoint):
+    @route
+    async def post(self, request: Request, data: dict) -> t.Dict[str, str]:
+        print(request)
+        name = data.get("name")
+        if name:
+            return {"slug": to_slug(name)}


### PR DESCRIPTION
## What changes are proposed in this pull request?

- cleanup imports
- add rest endpoint to use serverside to_slug function for checking unique saved view slugs

## How is this patch tested? If it is not, please explain why.

(Details)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
