### PR TITLE
Store patch embeddings directly on label objects

### DIFF
--- a/fiftyone/core/aggregations.py
+++ b/fiftyone/core/aggregations.py
@@ -2312,6 +2312,7 @@ class Values(Aggregation):
         _allow_missing=False,
         _big_result=True,
         _raw=False,
+        _field=None,
     ):
         super().__init__(field_or_expr, expr=expr)
         self._missing_value = missing_value
@@ -2320,8 +2321,9 @@ class Values(Aggregation):
         self._big_result = _big_result
         self._raw = _raw
 
-        self._field_type = None
+        self._field = None
         self._big_field = None
+        self._manual_field = _field
         self._num_list_fields = None
 
     def _kwargs(self):
@@ -2398,8 +2400,8 @@ class Values(Aggregation):
             context=context,
         )
 
+        self._field = self._manual_field or field
         self._big_field = big_field
-        self._field = field
         self._num_list_fields = len(list_fields)
 
         pipeline.extend(

--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -7246,6 +7246,7 @@ class SampleCollection(object):
         _allow_missing=False,
         _big_result=True,
         _raw=False,
+        _field=None,
     ):
         """Extracts the values of a field from all samples in the collection.
 
@@ -7361,6 +7362,7 @@ class SampleCollection(object):
             _allow_missing=_allow_missing,
             _big_result=_big_result,
             _raw=_raw,
+            _field=_field,
         )
         return self._make_and_aggregate(make, field_or_expr)
 

--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -2703,9 +2703,8 @@ class SampleCollection(object):
                 :class:`fiftyone.core.labels.Polyline`, or
                 :class:`fiftyone.core.labels.Polylines`. When computing video
                 frame embeddings, the "frames." prefix is optional
-            embeddings_field (None): the name of a field in which to store the
-                embeddings. When computing video frame embeddings, the
-                "frames." prefix is optional
+            embeddings_field (None): the name of a label attribute in which to
+                store the embeddings
             force_square (False): whether to minimally manipulate the patch
                 bounding boxes into squares prior to extraction
             alpha (None): an optional expansion/contraction to apply to the

--- a/fiftyone/core/models.py
+++ b/fiftyone/core/models.py
@@ -1280,19 +1280,20 @@ def compute_patch_embeddings(
     batch_size = _parse_batch_size(batch_size, model, use_data_loader)
 
     if embeddings_field is not None:
-        if samples.media_type == fom.VIDEO:
-            _, embeddings_path = samples._get_label_field_path(
-                samples._FRAMES_PREFIX + patches_field, embeddings_field
+        dataset = samples._root_dataset
+        if dataset.media_type == fom.VIDEO:
+            _, embeddings_path = dataset._get_label_field_path(
+                dataset._FRAMES_PREFIX + patches_field, embeddings_field
             )
-            embeddings_path, _ = samples._handle_frame_field(embeddings_path)
-            if not samples.has_frame_field(embeddings_path):
-                samples.add_frame_field(embeddings_path, fof.VectorField)
+            embeddings_path, _ = dataset._handle_frame_field(embeddings_path)
+            if not dataset.has_frame_field(embeddings_path):
+                dataset.add_frame_field(embeddings_path, fof.VectorField)
         else:
-            _, embeddings_path = samples._get_label_field_path(
+            _, embeddings_path = dataset._get_label_field_path(
                 patches_field, embeddings_field
             )
-            if not samples.has_sample_field(embeddings_path):
-                samples.add_sample_field(embeddings_path, fof.VectorField)
+            if not dataset.has_sample_field(embeddings_path):
+                dataset.add_sample_field(embeddings_path, fof.VectorField)
 
     with contextlib.ExitStack() as context:
         if use_data_loader:

--- a/fiftyone/core/models.py
+++ b/fiftyone/core/models.py
@@ -20,6 +20,7 @@ import eta.core.video as etav
 import eta.core.web as etaw
 
 import fiftyone as fo
+import fiftyone.core.fields as fof
 import fiftyone.core.labels as fol
 import fiftyone.core.media as fom
 import fiftyone.core.utils as fou
@@ -1277,6 +1278,21 @@ def compute_patch_embeddings(
         )
 
     batch_size = _parse_batch_size(batch_size, model, use_data_loader)
+
+    if embeddings_field is not None:
+        if samples.media_type == fom.VIDEO:
+            _, embeddings_path = samples._get_label_field_path(
+                samples._FRAMES_PREFIX + patches_field, embeddings_field
+            )
+            embeddings_path, _ = samples._handle_frame_field(embeddings_path)
+            if not samples.has_frame_field(embeddings_path):
+                samples.add_frame_field(embeddings_path, fof.VectorField)
+        else:
+            _, embeddings_path = samples._get_label_field_path(
+                patches_field, embeddings_field
+            )
+            if not samples.has_sample_field(embeddings_path):
+                samples.add_sample_field(embeddings_path, fof.VectorField)
 
     with contextlib.ExitStack() as context:
         if use_data_loader:

--- a/fiftyone/core/models.py
+++ b/fiftyone/core/models.py
@@ -1418,7 +1418,7 @@ def _embed_patches_single(model, img, detections, force_square, alpha):
         embedding = model.embed(patch)
         embeddings.append(embedding)
 
-    return np.concatenate(embeddings)
+    return np.stack(embeddings)
 
 
 def _embed_patches_batch(

--- a/fiftyone/core/stages.py
+++ b/fiftyone/core/stages.py
@@ -7416,7 +7416,12 @@ def _get_default_similarity_run(sample_collection):
                 % (sample_collection.dataset_name, gt_field, pred_field)
             )
     else:
+        # Try sample indexes first
         brain_keys = sample_collection._get_similarity_keys(patches_field=None)
+
+        # It's allowable to use a patches index too
+        if not brain_keys:
+            brain_keys = sample_collection._get_similarity_keys()
 
         if not brain_keys:
             raise ValueError(

--- a/tests/intensive/model_tests.py
+++ b/tests/intensive/model_tests.py
@@ -143,7 +143,7 @@ def _load_frame_embeddings(samples, path):
 
 def test_compute_patch_embeddings_frames():
     dataset = foz.load_zoo_dataset("quickstart-video")
-    view = dataset.take(2)
+    view = dataset.take(1)
 
     model = foz.load_zoo_model("inception-v3-imagenet-torch")
 
@@ -151,7 +151,7 @@ def test_compute_patch_embeddings_frames():
         model, "frames.detections"
     )
     view.compute_patch_embeddings(
-        model, "detections", embeddings_field="patch_embeddings1"
+        model, "frames.detections", embeddings_field="patch_embeddings1"
     )
     patch_embeddings1b = _load_frame_patch_embeddings(
         view, "frames.detections.detections.patch_embeddings1"
@@ -159,10 +159,10 @@ def test_compute_patch_embeddings_frames():
     _assert_frame_embedding_dicts_equal(patch_embeddings1a, patch_embeddings1b)
 
     patch_embeddings2a = view.compute_patch_embeddings(
-        model, "detections", batch_size=8
+        model, "frames.detections", batch_size=8
     )
     view.compute_patch_embeddings(
-        model, "detections", embeddings_field="patch_embeddings2"
+        model, "frames.detections", embeddings_field="patch_embeddings2"
     )
     patch_embeddings2b = _load_frame_patch_embeddings(
         view, "frames.detections.detections.patch_embeddings2"
@@ -287,19 +287,19 @@ def test_apply_model_frames_skip_failures():
 
     # torch, data loader, single batches
     model = foz.load_zoo_model("inception-v3-imagenet-torch")
-    dataset.apply_model(model, "predictions1")
+    dataset.apply_model(model, "frames.predictions1")
 
     # torch, data loader, batches
     model = foz.load_zoo_model("inception-v3-imagenet-torch")
-    dataset.apply_model(model, "predictions2", batch_size=2)
+    dataset.apply_model(model, "frames.predictions2", batch_size=2)
 
     # TF, single inference
     model = foz.load_zoo_model("ssd-mobilenet-v1-coco-tf")
-    dataset.apply_model(model, "predictions3")
+    dataset.apply_model(model, "frames.predictions3")
 
     # TF, batch inference
     model = foz.load_zoo_model("resnet-v2-50-imagenet-tf1")
-    dataset.apply_model(model, "predictions4", batch_size=2)
+    dataset.apply_model(model, "frames.predictions4", batch_size=2)
 
 
 def test_compute_embeddings_frames_skip_failures():
@@ -346,15 +346,19 @@ def test_compute_patch_embeddings_frames_skip_failures():
 
     # torch, data loader, single batches
     model = foz.load_zoo_model("inception-v3-imagenet-torch")
-    dataset.compute_patch_embeddings(model, "ground_truth")
+    dataset.compute_patch_embeddings(model, "frames.ground_truth")
 
     # torch, data loader, batches
     model = foz.load_zoo_model("inception-v3-imagenet-torch")
-    dataset.compute_patch_embeddings(model, "ground_truth", batch_size=2)
+    dataset.compute_patch_embeddings(
+        model, "frames.ground_truth", batch_size=2
+    )
 
     # TF, batch inference
     model = foz.load_zoo_model("resnet-v2-50-imagenet-tf1")
-    dataset.compute_patch_embeddings(model, "ground_truth", batch_size=2)
+    dataset.compute_patch_embeddings(
+        model, "frames.ground_truth", batch_size=2
+    )
 
 
 if __name__ == "__main__":

--- a/tests/unittests/similarity_tests.py
+++ b/tests/unittests/similarity_tests.py
@@ -38,7 +38,7 @@ class SimilarityTests(unittest.TestCase):
         fob.compute_similarity(
             dataset,
             embeddings=embeddings,
-            brain_key="image_similarity",
+            brain_key="img_sim",
         )
 
         query_id = dataset.first().id
@@ -54,9 +54,7 @@ class SimilarityTests(unittest.TestCase):
 
         self.assertEqual(len(view3), 4)
 
-        view4 = dataset.sort_by_similarity(
-            query_id, brain_key="image_similarity"
-        )
+        view4 = dataset.sort_by_similarity(query_id, brain_key="img_sim")
 
         self.assertEqual(view1.values("id"), view4.values("id"))
 
@@ -98,14 +96,12 @@ class SimilarityTests(unittest.TestCase):
             dataset,
             patches_field="ground_truth",
             embeddings=embeddings,
-            brain_key="object_similarity",
+            brain_key="obj_sim",
         )
 
         query_id = dataset.first().ground_truth.detections[0].id
 
-        view = dataset.sort_by_similarity(
-            query_id, k=3, brain_key="object_similarity"
-        )
+        view = dataset.sort_by_similarity(query_id, k=3, brain_key="obj_sim")
 
         self.assertEqual(view.count("ground_truth.detections"), 3)
 
@@ -122,9 +118,7 @@ class SimilarityTests(unittest.TestCase):
 
         self.assertEqual(len(view3), 4)
 
-        view4 = patches.sort_by_similarity(
-            query_id, brain_key="object_similarity"
-        )
+        view4 = patches.sort_by_similarity(query_id, brain_key="obj_sim")
 
         self.assertEqual(view1.values("id"), view4.values("id"))
 


### PR DESCRIPTION
Updates the `compute_patch_embeddings()` method to store patch embeddings directly on `Label` objects when the `embeddings_field` argument is provided.

Previously a `num_objects x num_dims` array would be stored as a top-level sample/frame field, which is less desirable because in that case there's no simple way to, for example, use `filter_labels()` + `values()` to extract the patch embeddings for a particular class.