### PR TITLE
use state proxy dataset only if it's set

### DIFF
--- a/app/packages/core/src/Dataset.ts
+++ b/app/packages/core/src/Dataset.ts
@@ -186,7 +186,7 @@ export const usePreLoadedDataset = (
             ? (toCamelCase(config) as fos.State.Config)
             : undefined,
           dataset: fos.transformDataset(
-            stateProxyValue ? stateProxyValue.dataset : rest
+            stateProxyValue?.dataset ? stateProxyValue.dataset : rest
           ),
           state: { view, viewName, ...state, ...(stateProxyValue || {}) },
         };


### PR DESCRIPTION
## What changes are proposed in this pull request?

PR fixes an error when stateProxy is set but the dataset property of state proxy is not set

## How is this patch tested? If it is not, please explain why.

Tested in the app by setting state proxy to non-null value and not setting the dataset property

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
