### PR TITLE
Fix matching single label fields

### DIFF
--- a/fiftyone/server/view.py
+++ b/fiftyone/server/view.py
@@ -378,7 +378,7 @@ def _make_filter_stages(
                     _field = cache.get(_field, _field)
 
                     stage = fosg.MatchLabels(
-                        fields=_field[0],
+                        fields=_field,
                         filter=expr,
                         bool=(not args["exclude"]),
                     )


### PR DESCRIPTION
On `develop`, fixes matching via the sidebar in the App for categorical values on single label fields like `ground_truth` in `cifar100`

```py
import fiftyone.zoo as foz

dataset = foz.load_zoo_dataset("cifar100")
session = fo.Session(dataset)
```

Filter `ground_truth.label`  in sidebar