### PR TITLE
Fix pinned sample sidebar

### DIFF
--- a/app/packages/state/src/recoil/groups.ts
+++ b/app/packages/state/src/recoil/groups.ts
@@ -195,7 +195,7 @@ export const activeModalSample = selector<
   key: "activeModalSample",
   get: ({ get }) => {
     if (get(sidebarOverride)) {
-      return get(pinnedSliceSample);
+      return get(pinnedSliceSample).sample;
     }
 
     return get(modal)?.sample;


### PR DESCRIPTION
Fixes sample data state in the sidebar, etc. when the pinned sample is active in group datasets, e.g. `quickstart-groups`