### PR TITLE
Only update dataset entry if name exists

### DIFF
--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -285,8 +285,7 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
         self._deleted = False
 
         if not _virtual:
-            if name:
-                self._update_last_loaded_at()
+            self._update_last_loaded_at()
 
     def __eq__(self, other):
         return type(other) == type(self) and self.name == other.name
@@ -6205,6 +6204,11 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
         return self._doc.to_dict(extended=True)
 
     def _update_last_loaded_at(self):
+        if self.name is None:
+            # It's possible that the dataset being accessed has been deleted.
+            # In this case, the name will be null and  we don't want to
+            # update the `last_loaded_at`
+            return
         self._doc.last_loaded_at = datetime.utcnow()
         self._doc.save()
 

--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -285,7 +285,8 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
         self._deleted = False
 
         if not _virtual:
-            self._update_last_loaded_at()
+            if name:
+                self._update_last_loaded_at()
 
     def __eq__(self, other):
         return type(other) == type(self) and self.name == other.name


### PR DESCRIPTION
## What changes are proposed in this pull request?

- when loading a dataset, only update the last loaded at for datasets with non null names, otherwise will trigger an error for saving documents with duplicate keys (equal to none)

## How is this patch tested? If it is not, please explain why.

(Details)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
