### PR TITLE
Include all group slices in media size stat

### DIFF
--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -1065,8 +1065,13 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
             total_bytes += frames_bytes
 
         if include_media:
-            self.compute_metadata()
-            media_bytes = self.sum("metadata.size_bytes")
+            if self.media_type == fom.GROUP:
+                samples = self.select_group_slices(_allow_mixed=True)
+            else:
+                samples = self
+
+            samples.compute_metadata()
+            media_bytes = samples.sum("metadata.size_bytes")
             stats["media_bytes"] = media_bytes
             stats["media_size"] = etau.to_human_bytes_str(media_bytes)
             total_bytes += media_bytes


### PR DESCRIPTION
Previously the media size computation in `Dataset.stats()` only accounted for the current slice of a grouped dataset. Now it includes all slices, as expected.

```py
import fiftyone as fo
import fiftyone.zoo as foz

dataset = foz.load_zoo_dataset("quickstart-groups")

stats1 = dataset.stats(include_media=True)
stats2 = dataset.select_group_slices(_allow_mixed=True).stats(include_media=True)

# previously failed; now succeeds
assert stats1["total_bytes"] == stats2["total_bytes"]
```
