### PR TITLE
select all groups in unlabeled media dataset exporter

### DIFF
--- a/fiftyone/utils/data/exporters.py
+++ b/fiftyone/utils/data/exporters.py
@@ -964,6 +964,12 @@ def _write_unlabeled_dataset(
             if sample_collection is not None:
                 dataset_exporter.log_collection(sample_collection)
 
+            if (
+                isinstance(samples, foc.SampleCollection)
+                and samples.media_type == fomm.GROUP
+            ):
+                samples = samples.select_group_slices(_allow_mixed=True)
+
             for sample in pb(samples):
                 sample_parser.with_sample(sample)
 


### PR DESCRIPTION
fixes media directory export in a group type dataset by selecting all slices first

Tested - before only get 200 images, after get 400 images plus pcd files
```
dataset=fo.load_dataset('quickstart-groups')
dataset.export(dataset_type=fo.types.MediaDirectory)
```