### PR TITLE
sidebar re-size enhancements

### DIFF
--- a/app/packages/core/src/components/Sidebar/Sidebar.module.css
+++ b/app/packages/core/src/components/Sidebar/Sidebar.module.css
@@ -1,0 +1,9 @@
+.resizeHandle:hover,
+.resizeHandle:active {
+  background: #007fd4;
+  width: 4px !important;
+  z-index: 1;
+  right: 0px !important;
+  transition: background-color 0.25s ease;
+  transition-delay: 0.25s;
+}

--- a/app/packages/core/src/components/Sidebar/Sidebar.tsx
+++ b/app/packages/core/src/components/Sidebar/Sidebar.tsx
@@ -13,7 +13,7 @@ import { move } from "@fiftyone/utilities";
 import { useEventHandler } from "@fiftyone/state";
 import { scrollbarStyles } from "../utils";
 import { Resizable } from "re-resizable";
-import { useRecoilState, useRecoilValue } from "recoil";
+import { useRecoilState, useRecoilValue, useResetRecoilState } from "recoil";
 import { replace } from "./Entries/GroupEntries";
 import { useTheme } from "@fiftyone/components";
 import * as fos from "@fiftyone/state";
@@ -21,6 +21,8 @@ import { Box } from "@mui/material";
 import ViewSelection from "./ViewSelection";
 import { DatasetSavedViewsQuery } from "../../Root/Root";
 import { useQueryLoader } from "react-relay";
+import { resizeHandle } from "./Sidebar.module.css";
+
 const MARGIN = 3;
 
 const fn = (
@@ -434,6 +436,7 @@ const InteractiveSidebar = ({
   const scroll = useRef<number>(0);
   const maxScrollHeight = useRef<number>();
   const [width, setWidth] = useRecoilState(fos.sidebarWidth(modal));
+  const resetWidth = useResetRecoilState(fos.sidebarWidth(modal));
   const shown = useRecoilValue(fos.sidebarVisible(modal));
   const [entries, setEntries] = fos.useEntries(modal);
   const disabled = useRecoilValue(fos.disabledPaths);
@@ -706,6 +709,8 @@ const InteractiveSidebar = ({
       }}
       onResizeStop={(e, direction, ref, { width: delta }) => {
         setWidth(width + delta);
+        // reset sidebar to default width on double click
+        if (e.detail === 2) resetWidth();
       }}
       style={{
         borderLeft: modal
@@ -715,6 +720,10 @@ const InteractiveSidebar = ({
           ? `1px solid ${theme.primary.plainBorder}`
           : undefined,
         borderTopRightRadius: 8,
+      }}
+      handleClasses={{
+        left: modal ? resizeHandle : "",
+        right: !modal ? resizeHandle : "",
       }}
     >
       {!modal && (


### PR DESCRIPTION
## What changes are proposed in this pull request?

PR adds hover/active state to the sidebar resize rule (bolder blue border) and adds an ability to resize sidebar to default width when resize rule is double-clicked:

Preview:
![Kapture 2023-02-09 at 10 31 49](https://user-images.githubusercontent.com/25350704/217858152-2af89c44-d714-4f0d-bb4c-3d2fac716bfa.gif)


## How is this patch tested? If it is not, please explain why.

Tested interactive in-app for both modal and non-modal sidebar

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
