### PR TITLE
Associate shortcut to all event keys

### DIFF
--- a/app/packages/looker/src/elements/common/actions.ts
+++ b/app/packages/looker/src/elements/common/actions.ts
@@ -21,7 +21,7 @@ const readActions = <State extends BaseState>(
   return Object.fromEntries(
     Object.entries(actions).reduce((acc, [_, v]) => {
       if (Array.isArray(v.eventKeys)) {
-        return [...acc, [v.eventKeys[0], v]];
+        return [...acc, ...v.eventKeys.map((key) => [key, v])];
       }
 
       return [...acc, [v.eventKeys || v.shortcut, v]];


### PR DESCRIPTION
## What changes are proposed in this pull request?

Associate shortcut to all event keys when `eventkeys` is an array. 

@benjaminpkane PR undoes [this change ](https://github.com/voxel51/fiftyone/pull/2093/files#diff-b731314c70a8bd373561bb299112b8ac883762eafe407026fe915a8ad12b9d91R24). Do you expect this change to re-introduce issue the change in  PR #2093 fixed?

## How is this patch tested? If it is not, please explain why.

Interactively in app with a video player to ensure all items in array of event keys are associated to its respective action

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
