### PR TITLE
Fix Python client session initialization

### DIFF
--- a/app/packages/core/src/components/Actions/Similar.tsx
+++ b/app/packages/core/src/components/Actions/Similar.tsx
@@ -98,7 +98,6 @@ const useSortBySimilarity = (close) => {
           set(fos.modal, null);
           close();
 
-          console.log(data);
           return data;
         });
       },

--- a/fiftyone/core/session/events.py
+++ b/fiftyone/core/session/events.py
@@ -114,8 +114,8 @@ class ListenPayload:
     def from_dict(cls, d: dict) -> "ListenPayload":
         init = d["initializer"]
 
-        if isinstance(init, dict) and "_cls" in init:
-            d["initializer"] = fos.StateDescription.from_dict(d["initializer"])
+        if isinstance(init, dict) and "_CLS" in init:
+            d["initializer"] = fos.StateDescription.from_dict(init)
 
         return from_dict(cls, d)
 

--- a/fiftyone/core/state.py
+++ b/fiftyone/core/state.py
@@ -62,7 +62,7 @@ class StateDescription(etas.Serializable):
         self.saved_view_slug = saved_view_slug
         self.spaces = spaces
 
-    def serialize(self, reflective=False):
+    def serialize(self, reflective=True):
         with fou.disable_progress_bars():
             d = super().serialize(reflective=reflective)
 


### PR DESCRIPTION
Currently, Python client's cannot connect properly because the initializer payload is malformed.
```py
import fiftyone as fo
import fiftyone.zoo as foz

dataset = foz.load_zoo_dataset("quickstart")
view = dataset.limit(10)

session = fo.launch_app(view)
```