### PR TITLE
SaveFilters bug 

### DIFF
--- a/app/packages/core/src/components/Actions/ActionsRow.tsx
+++ b/app/packages/core/src/components/Actions/ActionsRow.tsx
@@ -312,18 +312,22 @@ const SaveFilters = () => {
         }
 
         set(fos.savingFilters, true);
-        setView(
-          (v) => [
-            ...v,
-            {
-              _cls: "fiftyone.core.stages.Select",
-              kwargs: [["sample_ids", [...selected]]],
-            },
-          ],
-          undefined,
-          undefined,
-          true
-        );
+        if (selected.size > 0) {
+          setView(
+            (v) => [
+              ...v,
+              {
+                _cls: "fiftyone.core.stages.Select",
+                kwargs: [["sample_ids", [...selected]]],
+              },
+            ],
+            undefined,
+            undefined,
+            true
+          );
+        } else {
+          setView((v) => v);
+        }
       },
     []
   );


### PR DESCRIPTION
When no sample is selected, saveFilter is not working properly. For instance, sort by similarity, and then save filters fail. 

This PR fixes this issue. 

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
