### PR TITLE
[HOLD] Index sample tags by default

### DIFF
--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -8162,7 +8162,7 @@ class SampleCollection(object):
             return []
 
         if self._is_patches:
-            names = ["id", "filepath", "sample_id"]
+            names = ["id", "filepath", "tags", "sample_id"]
             if self._is_frames:
                 names.extend(["frame_id", "_sample_id_1_frame_number_1"])
 
@@ -8172,14 +8172,15 @@ class SampleCollection(object):
             return [
                 "id",
                 "filepath",
+                "tags",
                 "sample_id",
                 "_sample_id_1_frame_number_1",
             ]
 
         if self._is_clips:
-            return ["id", "filepath", "sample_id"]
+            return ["id", "filepath", "tags", "sample_id"]
 
-        return ["id", "filepath"]
+        return ["id", "filepath", "tags"]
 
     def reload(self):
         """Reloads the collection from the database."""

--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -6339,6 +6339,7 @@ def _create_indexes(sample_collection_name, frame_collection_name):
 
     collection = conn[sample_collection_name]
     collection.create_index("filepath")
+    collection.create_index("tags")
 
     if frame_collection_name is not None:
         frame_collection = conn[frame_collection_name]

--- a/tests/unittests/dataset_tests.py
+++ b/tests/unittests/dataset_tests.py
@@ -441,7 +441,7 @@ class DatasetTests(unittest.TestCase):
         info = dataset.get_index_information()
         indexes = dataset.list_indexes()
 
-        default_indexes = {"id", "filepath"}
+        default_indexes = {"id", "filepath", "tags"}
         self.assertSetEqual(set(info.keys()), default_indexes)
         self.assertSetEqual(set(indexes), default_indexes)
 
@@ -451,13 +451,21 @@ class DatasetTests(unittest.TestCase):
             dataset.drop_index("id")  # can't drop default
 
         dataset.create_index("filepath")  # already exists
+        dataset.create_index("tags")  # already exists
 
         with self.assertRaises(ValueError):
             # can't upgrade default index to unique
             dataset.create_index("filepath", unique=True)
 
         with self.assertRaises(ValueError):
+            # can't upgrade default index to unique
+            dataset.create_index("tags", unique=True)
+
+        with self.assertRaises(ValueError):
             dataset.drop_index("filepath")  # can't drop default index
+
+        with self.assertRaises(ValueError):
+            dataset.drop_index("tags")  # can't drop default index
 
         name = dataset.create_index("field")
         self.assertEqual(name, "field")

--- a/tests/unittests/patches_tests.py
+++ b/tests/unittests/patches_tests.py
@@ -91,7 +91,7 @@ class PatchesTests(unittest.TestCase):
         index_info = view.get_index_information()
         indexes = view.list_indexes()
 
-        default_indexes = {"id", "filepath", "sample_id"}
+        default_indexes = {"id", "filepath", "tags", "sample_id"}
         self.assertSetEqual(set(index_info.keys()), default_indexes)
         self.assertSetEqual(set(indexes), default_indexes)
 
@@ -388,7 +388,7 @@ class PatchesTests(unittest.TestCase):
         index_info = view.get_index_information()
         indexes = view.list_indexes()
 
-        default_indexes = {"id", "filepath", "sample_id"}
+        default_indexes = {"id", "filepath", "tags", "sample_id"}
         self.assertSetEqual(set(index_info.keys()), default_indexes)
         self.assertSetEqual(set(indexes), default_indexes)
 

--- a/tests/unittests/video_tests.py
+++ b/tests/unittests/video_tests.py
@@ -110,6 +110,7 @@ class VideoTests(unittest.TestCase):
         default_indexes = {
             "id",
             "filepath",
+            "tags",
             "frames.id",
             "frames._sample_id_1_frame_number_1",
         }

--- a/tests/unittests/video_tests.py
+++ b/tests/unittests/video_tests.py
@@ -1449,6 +1449,7 @@ class VideoTests(unittest.TestCase):
         default_indexes = {
             "id",
             "filepath",
+            "tags",
             "sample_id",
             "frames.id",
             "frames._sample_id_1_frame_number_1",
@@ -1838,6 +1839,7 @@ class VideoTests(unittest.TestCase):
         default_indexes = {
             "id",
             "filepath",
+            "tags",
             "sample_id",
             "_sample_id_1_frame_number_1",
         }
@@ -2230,6 +2232,7 @@ class VideoTests(unittest.TestCase):
         default_indexes = {
             "id",
             "filepath",
+            "tags",
             "sample_id",
             "_sample_id_1_frame_number_1",
         }
@@ -2476,6 +2479,7 @@ class VideoTests(unittest.TestCase):
         default_indexes = {
             "id",
             "filepath",
+            "tags",
             "sample_id",
             "frame_id",
             "_sample_id_1_frame_number_1",


### PR DESCRIPTION
Indexes the sample `tags` field by default.

This is probably long overdue, considering the prominent real estate in the App we give to tags and the builtin methods like `match_tags()`, `count_sample_tags()`, etc.

## UPDATE

Hmmm, so apparently indexed list fields may no longer guarantee that samples in a `[{"$match": ...}]` pipeline will maintain insertion order, which is something that I imagine users are implicitly assuming today... 🤔 

```py
import fiftyone as fo

dataset = fo.Dataset()
dataset.add_samples(
    [
        fo.Sample(filepath="image1.png", tags=["train"], i=1),
        fo.Sample(filepath="image2.png", tags=["test"], i=2),
        fo.Sample(filepath="image3.png", tags=["train", "test"], i=3),
        fo.Sample(filepath="image4.png", i=4),
    ]
)

# This is true with and without an index
view = dataset.match_tags("test")
assert view.values("i") == [2, 3]

# This is true with no index, but the order is [4, 1] with an index :(
view = dataset.match_tags("test", bool=False)
assert view.values("i") == [1, 4]
```

## Benchmarking

Benchmarks on `develop` verify that `match_tags()` views are ~3.7x faster with indexed `tags` field on a dataset with 60K samples and 10 tags per sample:

```py
import string
import random

import fiftyone as fo
import fiftyone.zoo as foz

dataset = foz.load_zoo_dataset("cifar10")

all_tags = list(string.ascii_lowercase)
tags = [random.sample(all_tags, 10) for _ in range(len(dataset))]
dataset.set_values("tags", tags)
print(dataset.count_sample_tags())  # yep, lots of tags

counts1 = []
with fo.ProgressBar(iters_str="ops") as pb:
    for tag in pb(all_tags):
        counts1.append(len(dataset.match_tags(tag)))

dataset.create_index("tags")

counts2 = []
with fo.ProgressBar(iters_str="ops") as pb:
    for tag in pb(all_tags):
        counts2.append(len(dataset.match_tags(tag)))
```

```
100% |██████████████████████| 26/26 [1.4s elapsed, 0s remaining, 18.9 ops/s]
100% |██████████████████████| 26/26 [371.9ms elapsed, 0s remaining, 69.9 ops/s]
```
