### PR TITLE
Present error message for embeddings plot if no results

### DIFF
--- a/app/packages/embeddings/src/useViewChangeEffect.tsx
+++ b/app/packages/embeddings/src/useViewChangeEffect.tsx
@@ -39,6 +39,12 @@ export function useViewChangeEffect() {
     fetchPlot({ datasetName, brainKey, view, labelField })
       .catch((err) => setLoadingPlotError(err))
       .then((res) => {
+        if (!res || !res.index_size) {
+          warnings.add(
+            `The current view does not have any corresponding embeddings.`
+          );
+          return;
+        }
         const notUsed = res.index_size - res.available_count;
         const missing = res.missing_count;
         const total = res.index_size;

--- a/app/packages/embeddings/src/useViewChangeEffect.tsx
+++ b/app/packages/embeddings/src/useViewChangeEffect.tsx
@@ -40,9 +40,14 @@ export function useViewChangeEffect() {
       .catch((err) => setLoadingPlotError(err))
       .then((res) => {
         if (!res || !res.index_size) {
-          warnings.add(`Failed to fetch embeddings for the current view.`);
+          if (res?.index_size === 0) {
+            warnings.add(`No samples in the current view.`);
+          } else {
+            warnings.add(`Failed to fetch embeddings for the current view.`);
+          }
           return;
         }
+
         const notUsed = res.index_size - res.available_count;
         const missing = res.missing_count;
         const total = res.index_size;

--- a/app/packages/embeddings/src/useViewChangeEffect.tsx
+++ b/app/packages/embeddings/src/useViewChangeEffect.tsx
@@ -41,7 +41,7 @@ export function useViewChangeEffect() {
       .then((res) => {
         if (!res || !res.index_size) {
           warnings.add(
-            `The current view does not have any corresponding embeddings.`
+            `Error fetching embeddings corresponding to the current view.`
           );
           return;
         }

--- a/app/packages/embeddings/src/useViewChangeEffect.tsx
+++ b/app/packages/embeddings/src/useViewChangeEffect.tsx
@@ -40,9 +40,7 @@ export function useViewChangeEffect() {
       .catch((err) => setLoadingPlotError(err))
       .then((res) => {
         if (!res || !res.index_size) {
-          warnings.add(
-            `Error fetching embeddings corresponding to the current view.`
-          );
+          warnings.add(`Failed to fetch embeddings for the current view.`);
           return;
         }
         const notUsed = res.index_size - res.available_count;


### PR DESCRIPTION
## What changes are proposed in this pull request?

Currently throws an error: 
<img width="1211" alt="image" src="https://user-images.githubusercontent.com/30936736/218332676-f9d7bed6-267e-40d3-9430-99f98d953aea.png">

Proposal:
Handle fetch failure:
<img width="1360" alt="image" src="https://user-images.githubusercontent.com/30936736/218333174-4a6292bc-8836-40f7-8238-b0e984034e6d.png">


## How is this patch tested? If it is not, please explain why.

(Details)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
