### PR TITLE
fix sidebar resize border flash on click

### DIFF
--- a/app/packages/core/src/components/Sidebar/Sidebar.module.css
+++ b/app/packages/core/src/components/Sidebar/Sidebar.module.css
@@ -1,9 +1,11 @@
 .resizeHandle:hover,
-.resizeHandle:active {
+.resizeHandle:active,
+.resizeHandle:focus {
   background: #007fd4;
-  width: 4px !important;
   z-index: 1;
-  right: 0px !important;
-  transition: background-color 0.25s ease;
   transition-delay: 0.25s;
+}
+
+.resizeHandle {
+  transition: background-color 0.1s ease;
 }

--- a/app/packages/core/src/components/Sidebar/Sidebar.tsx
+++ b/app/packages/core/src/components/Sidebar/Sidebar.tsx
@@ -683,6 +683,7 @@ const InteractiveSidebar = ({
     () => new ResizeObserver(placeItems)
   );
   const theme = useTheme();
+  const resizableSide = modal ? "left" : "right";
 
   return shown ? (
     <Resizable
@@ -715,9 +716,11 @@ const InteractiveSidebar = ({
         display: "flex",
         flexDirection: "column",
       }}
+      handleStyles={{
+        [resizableSide]: { right: 0, width: 4 },
+      }}
       handleClasses={{
-        left: modal ? resizeHandle : "",
-        right: !modal ? resizeHandle : "",
+        [resizableSide]: resizeHandle,
       }}
     >
       {!modal && (


### PR DESCRIPTION
## What changes are proposed in this pull request?

PR fixes sidebar resize active blue border flashing on clicking

## How is this patch tested? If it is not, please explain why.

Interactively in-app for both modal and non-modal sidebar

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
