### PR TITLE
Allows space in list of strings in viewbar stages

### DIFF
--- a/app/packages/core/src/components/ViewBar/ViewStage/viewStageParameterMachine.ts
+++ b/app/packages/core/src/components/ViewBar/ViewStage/viewStageParameterMachine.ts
@@ -143,7 +143,14 @@ export const PARSER = {
   "list<str>": {
     castFrom: (value) => value.join(","),
     castTo: (value) => value.split(","),
-    parse: (value) => value.replace(/[\s\'\"\[\]]/g, ""),
+    parse: (value) =>
+      value
+        // replace spaces with a single space (to allow search by words with spaces)
+        .replace(/[\s\'\"\[\]]+/g, " ")
+        // replace comma followed by trailing spaces with a single comma
+        .replace(/,\s*/g, ",")
+        // remove trailing spaces
+        .replace(/[ \t]+$/, ""),
     validate: (value) => {
       const stripped = value.replace(/[\s]/g, "");
       let array = null;


### PR DESCRIPTION
## What changes are proposed in this pull request?

problem
Trying to matchTags with spaces is impossible

Reason
The parser is removing all spaces when entered in MatchTags expression

Solution
Allow single spaces in parser for list of strings
- Replace all spaces with single space
- Replace ", " with single comma
- Remove trailing spaces

https://user-images.githubusercontent.com/109545780/218838504-bfbe49c4-2936-4a6c-977b-a57457276740.mov


## How is this patch tested? If it is not, please explain why.

Manually - see video

@benjaminpkane can this cause regression elsewhere as far as you know? 

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
