### PR TITLE
add ability to open a panel directly in split mode

### DIFF
--- a/app/packages/spaces/src/components/AddPanelItem.tsx
+++ b/app/packages/spaces/src/components/AddPanelItem.tsx
@@ -1,3 +1,4 @@
+import { Layout } from "../enums";
 import { useSpaces } from "../hooks";
 import SpaceNode from "../SpaceNode";
 import { AddPanelItemProps } from "../types";
@@ -14,10 +15,15 @@ export default function AddPanelItem({
   const { spaces } = useSpaces(spaceId);
   return (
     <StyledPanelItem
-      onClick={() => {
+      onClick={(e) => {
         const newNode = new SpaceNode();
         newNode.type = name;
         spaces.addNodeAfter(node, newNode);
+        if (e.altKey) {
+          spaces.splitLayout(node, Layout.Horizontal);
+        } else if (e.shiftKey) {
+          spaces.splitLayout(node, Layout.Vertical);
+        }
         if (onClick) onClick();
       }}
     >


### PR DESCRIPTION
## What changes are proposed in this pull request?

PR adds the ability to open a panel directly in split mode:
 - Selecting a new panel to add while holding `Option` (`Alt` in linux/windows) key will open a new panel in side-by-side panel split mode
- Selecting a new panel to add while holding `Shift` key will open a new panel in top-and-bottom panel split mode

## How is this patch tested? If it is not, please explain why.

Interactively within the app

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

- Selecting a new panel to add while holding `Option` (`Alt` in linux/windows) key will open a new panel in side-by-side panel split mode
- Selecting a new panel to add while holding `Shift` key will open a new panel in top-and-bottom panel split mode

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
