### PR TITLE
Fix open_images tutorial

### DIFF
--- a/fiftyone/core/session/session.py
+++ b/fiftyone/core/session/session.py
@@ -933,7 +933,6 @@ class Session(object):
         """
         if not focx.is_notebook_context() or self.desktop:
             return
-
         self.freeze()
         if self.dataset is not None:
             self.dataset._reload()

--- a/fiftyone/core/session/session.py
+++ b/fiftyone/core/session/session.py
@@ -933,6 +933,7 @@ class Session(object):
         """
         if not focx.is_notebook_context() or self.desktop:
             return
+
         self.freeze()
         if self.dataset is not None:
             self.dataset._reload()

--- a/fiftyone/zoo/models/manifest-tf.json
+++ b/fiftyone/zoo/models/manifest-tf.json
@@ -1134,7 +1134,7 @@
             "requirements": {
                 "cpu": {
                     "support": true,
-                    "packages": ["tensorflow"]
+                    "packages": ["tensorflow|tensorflow-macos"]
                 },
                 "gpu": {
                     "support": true,


### PR DESCRIPTION
## What changes are proposed in this pull request?

- current version of the tutorial: https://docs.voxel51.com/tutorials/open_images.html
- rerun notebook, fix functions, and cleanup outputs 
- change model requirements to `tensorflow|tensorflow-macos`

## How is this patch tested? If it is not, please explain why.

(Details)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [x] Documentation: FiftyOne documentation changes
-   [ ] Other
