### PR TITLE
Check slug instead of the entire dataset before saving views

### DIFF
--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -3226,7 +3226,7 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
             overwrite (False): whether to overwrite an existing saved view with
                 the same name
         """
-        if view._root_dataset.slug != self.slug:
+        if view._root_dataset._doc.id != self._doc.id:
             raise ValueError("Cannot save view into a different dataset")
 
         view._set_name(name)

--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -3226,7 +3226,7 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
             overwrite (False): whether to overwrite an existing saved view with
                 the same name
         """
-        if view._root_dataset is not self:
+        if view._root_dataset.slug != self.slug:
             raise ValueError("Cannot save view into a different dataset")
 
         view._set_name(name)


### PR DESCRIPTION
## What changes are proposed in this pull request?

@lanzhenw recently noticed that saving views fails (intermittently) raising `raise ValueError("Cannot save view into a different dataset")`

Digging into it, It fails every other time or so after trying to save a view (whatever the view be). For some reason (ideas are welcomed) the `view._root_dataset is not self:` condition started passing/failing depending on how many times you try to save a view. 

Fix: making the condition check based on slug is more efficient and seems to fix the issue.



https://user-images.githubusercontent.com/109545780/219476413-f7375aab-221d-4149-b69f-2678b10b961c.mov




(Please fill in changes proposed in this fix)

## How is this patch tested? If it is not, please explain why.

(Details)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
