### PR TITLE
Fix make_optimized_select_view for group datasets

### DIFF
--- a/fiftyone/core/view.py
+++ b/fiftyone/core/view.py
@@ -1587,11 +1587,6 @@ def make_optimized_select_view(
             sample_ids, ordered=ordered
         )
     else:
-        if view.media_type == fom.GROUP and not select_groups:
-            optimized_view = optimized_view.select_group_slices(
-                _allow_mixed=True
-            )
-
         optimized_view = optimized_view.select(sample_ids, ordered=ordered)
         if view.media_type == fom.GROUP and select_groups:
             optimized_view = optimized_view.select_group_slices(

--- a/tests/unittests/view_tests.py
+++ b/tests/unittests/view_tests.py
@@ -15,8 +15,10 @@ import numpy as np
 
 import fiftyone as fo
 from fiftyone import ViewField as F, VALUE
+import fiftyone.core.media as fom
 import fiftyone.core.sample as fos
 import fiftyone.core.stages as fosg
+import fiftyone.core.view as fov
 
 from decorators import drop_datasets, skip_windows
 
@@ -3000,6 +3002,57 @@ class ViewStageTests(unittest.TestCase):
 
         field = F("$ground_truth")
         self.assertEqual(str(field), str(deepcopy(field)))
+
+    def test_make_optimized_select_view_group_media_type_select_samples(self):
+        samples = self._create_group_samples()
+        dataset = self._create_group_dataset()
+        sample_ids = dataset.add_samples(samples)
+        self.assertEqual(len(sample_ids), len(samples))
+
+        # Default call should have select_groups = False
+        optimized_view = fov.make_optimized_select_view(dataset, sample_ids[0])
+
+        expected_stages = [fosg.Select(sample_ids[0])]
+        self.assertEqual(optimized_view._all_stages, expected_stages)
+
+    def test_make_optimized_select_view_group_media_type_select_groups(self):
+        samples = self._create_group_samples()
+        dataset = self._create_group_dataset()
+        sample_ids = dataset.add_samples(samples)
+        self.assertEqual(len(sample_ids), len(samples))
+
+        optimized_view = fov.make_optimized_select_view(
+            dataset, sample_ids[0], select_groups=True
+        )
+        expected_stages = [
+            fosg.Select(sample_ids[0]),
+            fosg.SelectGroupSlices(),
+        ]
+        self.assertEqual(optimized_view._all_stages, expected_stages)
+
+    def _create_group_dataset(self):
+        dataset = fo.Dataset()
+        dataset.add_group_field("group", default="center")
+        self.assertEqual(dataset.media_type, fom.GROUP)
+        self.assertEqual(dataset.default_group_slice, "center")
+        return dataset
+
+    def _create_group_samples(self):
+        groups = ["left", "center", "right"]
+        filepaths = [
+            [str(i) + str(j) + ".jpg" for i in groups] for j in range(3)
+        ]
+        filepaths = [dict(zip(groups, fps)) for fps in zip(*filepaths)]
+        group = fo.Group()
+        samples = []
+        for fps in filepaths:
+            for name, filepath in fps.items():
+                sample = fo.Sample(
+                    filepath=filepath, group=group.element(name)
+                )
+                samples.append(sample)
+        assert all([s.group is not None for s in samples])
+        return samples
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What changes are proposed in this pull request?

- Currently, select_group_slices is being called when it's not supposed to be in make_optimized_select_view, leading to the select group slice stage getting appended to the list of view stages always, leading to errors when creating a saved view

## How is this patch tested? If it is not, please explain why.

(Details)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
