### PR TITLE
bugfix: file already exist when exporting with media

### DIFF
--- a/fiftyone/utils/data/exporters.py
+++ b/fiftyone/utils/data/exporters.py
@@ -1204,7 +1204,8 @@ class MediaExporter(object):
                 uuid = self._get_uuid(outpath)
 
             if self.export_mode == True:
-                etau.copy_file(media_path, outpath)
+                if not os.path.exists(outpath):
+                    etau.copy_file(media_path, outpath)
             elif self.export_mode == "move":
                 etau.move_file(media_path, outpath)
             elif self.export_mode == "symlink":


### PR DESCRIPTION
## What changes are proposed in this pull request?

When exporting a dataset with export_media=True, it fails if you have exported the dataset earlier. The copy file method does not handle if the file already exists.   

## How is this patch tested? If it is not, please explain why.

A local run with version 0.18.0. Added some new images to the dataset, and tried to export, but failed on the images already exported.

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
