### PR TITLE
[BUG FIX] Add id to saved views

### DIFF
--- a/fiftyone/core/odm/views.py
+++ b/fiftyone/core/odm/views.py
@@ -25,6 +25,7 @@ class SavedViewDocument(Document):
 
     _EDITABLE_FIELDS = ("name", "color", "description")
 
+    id = ObjectIdField(db_field="_id", primary_key=True)
     dataset_id = ObjectIdField(db_field="_dataset_id")
     name = StringField()
     description = StringField()

--- a/fiftyone/core/odm/views.py
+++ b/fiftyone/core/odm/views.py
@@ -25,7 +25,7 @@ class SavedViewDocument(Document):
 
     _EDITABLE_FIELDS = ("name", "color", "description")
 
-    id = ObjectIdField(db_field="_id", primary_key=True)
+    id = ObjectIdField(db_field="_id", primary_key=True, default=ObjectId())
     dataset_id = ObjectIdField(db_field="_dataset_id")
     name = StringField()
     description = StringField()


### PR DESCRIPTION
## What changes are proposed in this pull request?

Saving a view produces an error:
```

In [10]: dataset.save_view('all', dataset.view())
---------------------------------------------------------------------------
ValidationError                           Traceback (most recent call last)
<ipython-input-10-4521ab1a57e7> in <module>
----> 1 dataset.save_view('all', dataset.view())

~/Dev/voxel51/fiftyone/fiftyone/core/dataset.py in save_view(self, name, view, description, color, overwrite)
   3248             last_modified_at=now,
   3249         )
-> 3250         view_doc.save()
   3251 
   3252         self._doc.saved_views.append(view_doc)

~/Dev/voxel51/fiftyone/fiftyone/core/odm/document.py in save(self, validate, clean, safe, **kwargs)
    557         """
    558         try:
--> 559             self._save(
    560                 deferred=False, validate=validate, clean=clean, **kwargs
    561             )

~/Dev/voxel51/fiftyone/fiftyone/core/odm/document.py in _save(self, deferred, validate, clean, **kwargs)
    579 
    580         if validate:
--> 581             self.validate(clean=clean)
    582 
    583         doc_id = self.to_mongo(fields=[self._meta["id_field"]])

~/.pyenv/versions/3.9.14/envs/fo/lib/python3.9/site-packages/mongoengine/base/document.py in validate(self, clean)
    437                 pk = self._instance.pk
    438             message = f"ValidationError ({self._class_name}:{pk}) "
--> 439             raise ValidationError(message, errors=errors)
    440 
    441     def to_json(self, *args, **kwargs):

ValidationError: ValidationError (SavedViewDocument:None) (Field is required: ['id'])

```

## How is this patch tested? If it is not, please explain why.

(Details)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
