### PR TITLE
from_dict wrapper for server dataclasses

### DIFF
--- a/fiftyone/server/aggregations.py
+++ b/fiftyone/server/aggregations.py
@@ -5,12 +5,9 @@ FiftyOne Server aggregations
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
-import logging
-from dataclasses import asdict
 from datetime import date, datetime
 import typing as t
 
-from dacite import Config, from_dict
 import strawberry as gql
 
 import fiftyone.core.aggregations as foa
@@ -24,7 +21,7 @@ import fiftyone.core.view as fov
 from fiftyone.server.constants import LIST_LIMIT
 from fiftyone.server.filters import GroupElementFilter, SampleFilter
 from fiftyone.server.scalars import BSON, BSONArray
-from fiftyone.server.utils import meets_type
+from fiftyone.server.utils import from_dict, meets_type
 import fiftyone.server.view as fosv
 
 
@@ -289,7 +286,7 @@ def _resolve_path_aggregation(
                         embedded_doc_type=fol.Label
                     )
                 )
-        return from_dict(cls, data, config=Config(check_types=False))
+        return from_dict(cls, data)
 
     return aggregations, from_results
 

--- a/fiftyone/server/dataloader.py
+++ b/fiftyone/server/dataloader.py
@@ -8,13 +8,11 @@ FiftyOne Server dataloader
 from dataclasses import dataclass
 import typing as t
 
-from dacite import Config, from_dict
 import motor.motor_asyncio as mtr
 from strawberry.dataloader import DataLoader
 
 from fiftyone.server.data import Info, T
-
-# from fiftyone.server.query import SavedView
+from fiftyone.server.utils import from_dict
 
 
 @dataclass
@@ -54,7 +52,7 @@ def get_dataloader(
                 return None
 
             doc = cls.modifier(doc)
-            return from_dict(cls, doc, config=Config(check_types=False))
+            return from_dict(cls, doc)
 
         return [build(results.get(k, None)) for k in keys]
 

--- a/fiftyone/server/paginator.py
+++ b/fiftyone/server/paginator.py
@@ -6,7 +6,6 @@ FiftyOne Server paginator
 |
 """
 from bson import ObjectId
-from dacite import Config, from_dict
 import motor.motor_asyncio as mtr
 import typing as t
 
@@ -17,6 +16,7 @@ import fiftyone.core.odm as foo
 
 from fiftyone.server.constants import LIST_LIMIT
 from fiftyone.server.data import Info, T
+from fiftyone.server.utils import from_dict
 
 C = t.TypeVar("C")
 
@@ -103,7 +103,7 @@ def get_paginator_resolver(
     ):
         def from_db(doc: dict) -> t.Optional[T]:
             doc = cls.modifier(doc)
-            return from_dict(cls, doc, config=Config(check_types=False))
+            return from_dict(cls, doc)
 
         return await get_items(
             info.context.db[collection],

--- a/fiftyone/server/samples.py
+++ b/fiftyone/server/samples.py
@@ -6,12 +6,10 @@ FiftyOne Server samples pagination
 |
 """
 import asyncio
-from dacite import Config, from_dict
 import strawberry as gql
 import typing as t
 
 
-import fiftyone.core.clips as focl
 from fiftyone.core.collections import SampleCollection
 from fiftyone.core.expressions import ViewField as F
 import fiftyone.core.media as fom
@@ -20,8 +18,9 @@ from fiftyone.server.filters import SampleFilter
 
 import fiftyone.server.metadata as fosm
 from fiftyone.server.paginator import Connection, Edge, PageInfo
-import fiftyone.server.view as fosv
 from fiftyone.server.scalars import BSON, JSON, BSONArray
+from fiftyone.server.utils import from_dict
+import fiftyone.server.view as fosv
 
 
 @gql.type
@@ -164,8 +163,4 @@ async def _create_sample_item(
         dataset, sample, media_type, metadata_cache, url_cache
     )
 
-    return from_dict(
-        cls,
-        {"id": sample["_id"], "sample": sample, **metadata},
-        Config(check_types=False),
-    )
+    return from_dict(cls, {"id": sample["_id"], "sample": sample, **metadata})

--- a/fiftyone/server/utils.py
+++ b/fiftyone/server/utils.py
@@ -5,7 +5,12 @@ FiftyOne Server utils.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+import typing as t
 import cachetools
+
+from dacite import Config, from_dict as _from_dict
+from dacite.core import T
+from dacite.data import Data
 
 import fiftyone.core.collections as foc
 import fiftyone.core.dataset as fod
@@ -15,6 +20,7 @@ import fiftyone.core.media as fom
 
 
 _cache = cachetools.TTLCache(maxsize=10, ttl=900)  # ttl in seconds
+_dacite_config = Config(check_types=False)
 
 
 def load_and_cache_dataset(name):
@@ -86,6 +92,21 @@ def change_label_tags(sample_collection, changes, label_fields=None):
 
     if del_tags:
         sample_collection.untag_labels(del_tags, label_fields=label_fields)
+
+
+def from_dict(data_class: t.Type[T], data: Data) -> T:
+    """
+    Wrapping function for :func:`dacite.from_dict` to ensure a common configuration
+    is used
+
+    Args:
+        data_class: a dataclass
+        data: the data with which to instantiate the dataclass instance
+
+    Returns:
+        a dataclass instance
+    """
+    return _from_dict(data_class, data, config=_dacite_config)
 
 
 def iter_label_fields(view: foc.SampleCollection):

--- a/fiftyone/server/utils.py
+++ b/fiftyone/server/utils.py
@@ -6,8 +6,8 @@ FiftyOne Server utils.
 |
 """
 import typing as t
-import cachetools
 
+import cachetools
 from dacite import Config, from_dict as _from_dict
 from dacite.core import T
 from dacite.data import Data
@@ -95,9 +95,8 @@ def change_label_tags(sample_collection, changes, label_fields=None):
 
 
 def from_dict(data_class: t.Type[T], data: Data) -> T:
-    """
-    Wrapping function for :func:`dacite.from_dict` to ensure a common configuration
-    is used
+    """Wrapping function for ``dacite.from_dict`` that ensures a common
+    configuration is used.
 
     Args:
         data_class: a dataclass


### PR DESCRIPTION
Adds a `from_dict` wrapper for `dacite` in server utils for ensuring a common configuration and removes all direct usage of dacite's `from_dict`


### Issues
* Resolves #2672 