### PR TITLE
Fix samples request

### DIFF
--- a/fiftyone/server/samples.py
+++ b/fiftyone/server/samples.py
@@ -96,6 +96,7 @@ async def paginate_samples(
 
     if int(after) > -1:
         view = view.skip(int(after) + 1)
+
     pipeline = view._pipeline(
         attach_frames=True,
         detach_frames=False,
@@ -103,9 +104,10 @@ async def paginate_samples(
         and sample_filter.group
         and (sample_filter.group.id and not sample_filter.group.slice),
     )
-    # Only return the first frame of each video sample
+    # Only return the first frame of each video sample for the samples grid
     if media == fom.VIDEO:
         pipeline.append({"$set": {"frames": {"$slice": ["$frames", 1]}}})
+
     samples = await foo.aggregate(
         foo.get_async_db_conn()[view._dataset._sample_collection_name],
         pipeline,

--- a/fiftyone/server/samples.py
+++ b/fiftyone/server/samples.py
@@ -104,7 +104,7 @@ async def paginate_samples(
         and sample_filter.group
         and (sample_filter.group.id and not sample_filter.group.slice),
     )
-    # Only return the first frame of each video sample for the samples grid
+    # Only return the first frame of each video sample for the grid thumbnail
     if media == fom.VIDEO:
         pipeline.append({"$set": {"frames": {"$slice": ["$frames", 1]}}})
 

--- a/fiftyone/server/samples.py
+++ b/fiftyone/server/samples.py
@@ -94,7 +94,8 @@ async def paginate_samples(
     if after is None:
         after = "-1"
 
-    view = view.skip(int(after) + 1)
+    if int(after) > -1:
+        view = view.skip(int(after) + 1)
 
     samples = await foo.aggregate(
         foo.get_async_db_conn()[view._dataset._sample_collection_name],

--- a/fiftyone/server/samples.py
+++ b/fiftyone/server/samples.py
@@ -104,7 +104,6 @@ async def paginate_samples(
             manual_group_select=sample_filter
             and sample_filter.group
             and (sample_filter.group.id and not sample_filter.group.slice),
-            support=[1, 1],
         ),
     ).to_list(first + 1)
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

- Fixes https://github.com/voxel51/fiftyone/issues/2681

https://user-images.githubusercontent.com/30936736/221044147-e8eec4b4-8cd6-48d3-904b-29db4ded8bc7.mov

To create the demo views:
```
import fiftyone as fo
import fiftyone.zoo as foz
from fiftyone import ViewField as F

dataset = foz.load_zoo_dataset('quickstart-video', dataset_name = 'video')
dataset.persistent = True
v1=dataset.limit(1).filter_labels("frames.detections", F("label") == "road sign")
dataset.save_view('limit1 road sign',v1)
v1=dataset.limit(1).filter_labels("frames.detections", F("index") == 9)
dataset.save_view('limit1 index 9',v1)
v1 = dataset.skip(3).limit(1).match_frames(F("detections.detections.label").contains('vehicle'))
dataset.save_view('skip3 limit1 vehicle',v1)
v1 = dataset.skip(3).limit(1).match_frames(F("detections.detections.label").contains('person'))
dataset.save_view('skip3 limit1 person',v1)
v1 = dataset.skip(3).limit(1).match_frames(F(
        "detections.detections.label").contains('dog'))
dataset.save_view('skip3 limit1 dog',v1)
```

## How is this patch tested? If it is not, please explain why.

(Details)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
