### PR TITLE
Add support for negative integer mask targets

### DIFF
--- a/fiftyone/core/fields.py
+++ b/fiftyone/core/fields.py
@@ -1153,10 +1153,14 @@ def is_integer_mask_targets(mask_targets):
     return all(
         map(
             lambda k: isinstance(k, numbers.Integral)
-            or (isinstance(k, str) and k.isdigit()),
+            or (isinstance(k, str) and _is_valid_int_string(k)),
             mask_targets.keys(),
         )
     )
+
+
+def _is_valid_int_string(s):
+    return s.replace("-", "", 1).isdigit()
 
 
 def is_rgb_mask_targets(mask_targets):


### PR DESCRIPTION
Previous versions of FiftyOne technically allowed negative integer mask targets (although the docs recommend only using non-negative integers), but [this update](https://github.com/voxel51/fiftyone/commit/171071da26e432b6ea2d831b589d09f6fe79b7e1) changed the implementation in such a way that existing datasets that *do* happen to contain mask targets with negative integers would no longer be loadable.

