### PR TITLE
[WIP] Change look and feel of selected label tags

### DIFF
--- a/app/packages/looker/src/elements/common/tags.ts
+++ b/app/packages/looker/src/elements/common/tags.ts
@@ -60,7 +60,7 @@ export class TagsElement<State extends BaseState> extends BaseElement<State> {
   renderSelf(
     {
       config: { fieldSchema },
-      options: { activePaths, coloring, timeZone },
+      options: { activePaths, coloring, timeZone, selectedLabelTags, ...props },
       playing,
     }: Readonly<State>,
     sample: Readonly<Sample>
@@ -209,26 +209,34 @@ export class TagsElement<State extends BaseState> extends BaseElement<State> {
     } = {
       [withPath(LABELS_PATH, CLASSIFICATION)]: (
         path,
-        { label }: Classification
+        { label, tags }: Classification
       ) => ({
         value: label,
         title: `${path}: ${label}`,
         color: getColor(
           coloring.pool,
           coloring.seed,
-          coloring.by === "label" ? label : path
+          selectedLabelTags?.some((tag) => tags.includes(tag))
+            ? "_label_tag"
+            : coloring.by === "label"
+            ? label
+            : path
         ),
       }),
       [withPath(LABELS_PATH, CLASSIFICATIONS)]: (
         path,
-        { label }: Classification
+        { label, tags }: Classification
       ) => ({
         value: label,
         title: `${path}: ${label}`,
         color: getColor(
           coloring.pool,
           coloring.seed,
-          coloring.by === "label" ? label : path
+          selectedLabelTags?.some((tag) => tags.includes(tag))
+            ? "_label_tag"
+            : coloring.by === "label"
+            ? label
+            : path
         ),
       }),
       [withPath(LABELS_PATH, REGRESSION)]: (path, { value }: Regression) => {

--- a/app/packages/looker/src/elements/common/tags.ts
+++ b/app/packages/looker/src/elements/common/tags.ts
@@ -251,7 +251,7 @@ export class TagsElement<State extends BaseState> extends BaseElement<State> {
         if (Array.isArray(sample.tags)) {
           sample.tags.forEach((tag) => {
             elements.push({
-              color: getColor(coloring.pool, coloring.seed, tag),
+              color: getColor(coloring.pool, coloring.seed, "tags"),
               title: tag,
               value: tag,
             });
@@ -261,7 +261,7 @@ export class TagsElement<State extends BaseState> extends BaseElement<State> {
         Object.entries(sample._label_tags).forEach(([tag, count]) => {
           const value = `${tag}: ${count}`;
           elements.push({
-            color: getColor(coloring.pool, coloring.seed, path),
+            color: getColor(coloring.pool, coloring.seed, "_label_tags"),
             title: value,
             value,
           });

--- a/app/packages/looker/src/overlays/base.ts
+++ b/app/packages/looker/src/overlays/base.ts
@@ -93,6 +93,12 @@ export abstract class CoordinateOverlay<
     return state.options.selectedLabels.includes(this.label.id);
   }
 
+  isTagFiltered(state: Readonly<State>): boolean {
+    return state.options.selectedLabelTags?.some((tag) =>
+      this.label.tags.includes(tag)
+    );
+  }
+
   getColor({ options: { coloring } }: Readonly<State>): string {
     let key;
 

--- a/app/packages/looker/src/overlays/base.ts
+++ b/app/packages/looker/src/overlays/base.ts
@@ -99,20 +99,30 @@ export abstract class CoordinateOverlay<
     );
   }
 
-  getColor({ options: { coloring } }: Readonly<State>): string {
+  getColor(state: Readonly<State>): string {
     let key;
 
-    switch (coloring.by) {
+    switch (state.options.coloring.by) {
       case "field":
-        return getColor(coloring.pool, coloring.seed, this.field);
+        return getColor(
+          state.options.coloring.pool,
+          state.options.coloring.seed,
+          this.field
+        );
       case "instance":
         key = this.label.index !== undefined ? "index" : "id";
         break;
       default:
         key = "label";
     }
-
-    return getColor(coloring.pool, coloring.seed, this.label[key]);
+    const labelKey = this.isTagFiltered(state)
+      ? "_label_tags"
+      : this.label[key];
+    return getColor(
+      state.options.coloring.pool,
+      state.options.coloring.seed,
+      labelKey
+    );
   }
 
   abstract containsPoint(state: Readonly<State>): CONTAINS;

--- a/app/packages/looker/src/overlays/classifications.ts
+++ b/app/packages/looker/src/overlays/classifications.ts
@@ -222,7 +222,7 @@ export class ClassificationsOverlay<
   }
 
   isTagFiltered(state: Readonly<State>, label: Label): boolean {
-    return state.options.selectedLabelTags.some((tag) =>
+    return state.options.selectedLabelTags?.some((tag) =>
       label.tags.includes(tag)
     );
   }

--- a/app/packages/looker/src/overlays/classifications.ts
+++ b/app/packages/looker/src/overlays/classifications.ts
@@ -221,6 +221,12 @@ export class ClassificationsOverlay<
     return state.options.selectedLabels.includes(label.id);
   }
 
+  isTagFiltered(state: Readonly<State>, label: Label): boolean {
+    return state.options.selectedLabelTags.some((tag) =>
+      label.tags.includes(tag)
+    );
+  }
+
   private strokeClassification(
     ctx: CanvasRenderingContext2D,
     state: Readonly<State>,
@@ -259,6 +265,16 @@ export class ClassificationsOverlay<
     ctx.fillText(text, tlx + state.textPad, tly + h - state.textPad);
 
     this.strokeBorder(ctx, state, [tlx, tly, w, h], color);
+
+    if (this.isTagFiltered(state, label)) {
+      const coloring = state.options.coloring;
+      this.strokeBorder(
+        ctx,
+        state,
+        [tlx, tly, w, h],
+        getColor(coloring.pool, coloring.seed, "_label_tags")
+      );
+    }
 
     if (this.isSelected(state, label)) {
       this.strokeBorder(

--- a/app/packages/looker/src/overlays/detection.ts
+++ b/app/packages/looker/src/overlays/detection.ts
@@ -140,7 +140,6 @@ export default class DetectionOverlay<
       this.labelBoundingBox = null;
       return;
     }
-
     const color = this.getColor(state);
 
     const [tlx, tly, _, __] = this.label.bounding_box;

--- a/app/packages/looker/src/overlays/detection.ts
+++ b/app/packages/looker/src/overlays/detection.ts
@@ -1,7 +1,7 @@
 /**
  * Copyright 2017-2023, Voxel51, Inc.
  */
-import { NONFINITES } from "@fiftyone/utilities";
+import { getColor, NONFINITES } from "@fiftyone/utilities";
 
 import { INFO_COLOR } from "../constants";
 import { OverlayMask } from "../numpy";
@@ -87,6 +87,15 @@ export default class DetectionOverlay<
       this.fillRectFor3d(ctx, state, this.getColor(state));
     } else {
       this.strokeRect(ctx, state, this.getColor(state));
+    }
+
+    if (this.isTagFiltered(state)) {
+      const coloring = state.options.coloring;
+      this.strokeRect(
+        ctx,
+        state,
+        getColor(coloring.pool, coloring.seed, "_label_tags")
+      );
     }
 
     if (this.isSelected(state)) {

--- a/app/packages/looker/src/overlays/heatmap.ts
+++ b/app/packages/looker/src/overlays/heatmap.ts
@@ -179,7 +179,7 @@ export default class HeatmapOverlay<State extends BaseState>
   }
 
   isTagFiltered(state: Readonly<State>): boolean {
-    return state.options.selectedLabelTags.some((tag) =>
+    return state.options.selectedLabelTags?.some((tag) =>
       this.label.tags.includes(tag)
     );
   }

--- a/app/packages/looker/src/overlays/heatmap.ts
+++ b/app/packages/looker/src/overlays/heatmap.ts
@@ -119,6 +119,18 @@ export default class HeatmapOverlay<State extends BaseState>
       ctx.globalAlpha = tmp;
     }
 
+    if (this.isTagFiltered(state)) {
+      strokeCanvasRect(
+        ctx,
+        state,
+        getColor(
+          state.options.coloring.pool,
+          state.options.coloring.seed,
+          "_label_tags"
+        )
+      );
+    }
+
     if (this.isSelected(state)) {
       strokeCanvasRect(
         ctx,
@@ -164,6 +176,12 @@ export default class HeatmapOverlay<State extends BaseState>
 
   isSelected(state: Readonly<State>): boolean {
     return state.options.selectedLabels.includes(this.label.id);
+  }
+
+  isTagFiltered(state: Readonly<State>): boolean {
+    return state.options.selectedLabelTags.some((tag) =>
+      this.label.tags.includes(tag)
+    );
   }
 
   isShown(state: Readonly<State>): boolean {

--- a/app/packages/looker/src/overlays/keypoint.ts
+++ b/app/packages/looker/src/overlays/keypoint.ts
@@ -42,6 +42,8 @@ export default class KeypointOverlay<
   draw(ctx: CanvasRenderingContext2D, state: Readonly<State>): void {
     const color = this.getColor(state);
     const selected = this.isSelected(state);
+    const isTagFiltered = this.isTagFiltered(state);
+
     ctx.lineWidth = 0;
 
     const skeleton = getSkeleton(this.field, state);
@@ -50,6 +52,19 @@ export default class KeypointOverlay<
       for (let i = 0; i < skeleton.edges.length; i++) {
         const path = skeleton.edges[i].map((index) => points[index]);
         this.strokePath(ctx, state, path, color);
+
+        if (isTagFiltered) {
+          this.strokePath(
+            ctx,
+            state,
+            path,
+            getColor(
+              state.options.coloring.pool,
+              state.options.coloring.seed,
+              "label_tags"
+            )
+          );
+        }
 
         if (selected) {
           this.strokePath(ctx, state, path, INFO_COLOR, state.dashLength);

--- a/app/packages/looker/src/overlays/polyline.ts
+++ b/app/packages/looker/src/overlays/polyline.ts
@@ -2,6 +2,7 @@
  * Copyright 2017-2023, Voxel51, Inc.
  */
 
+import { getColor } from "@fiftyone/utilities";
 import { INFO_COLOR, TOLERANCE } from "../constants";
 import { BaseState, Coordinates } from "../state";
 import { distanceFromLineSegment, getRenderedScale } from "../util";
@@ -49,6 +50,17 @@ export default class PolylineOverlay<
       }
 
       this.strokePath(ctx, state, path, color, this.label.filled);
+
+      if (this.isTagFiltered(state)) {
+        const coloring = state.options.coloring;
+        this.strokePath(
+          ctx,
+          state,
+          path,
+          getColor(coloring.pool, coloring.seed, "_label_tags"),
+          this.label.filled
+        );
+      }
 
       if (selected) {
         this.strokePath(ctx, state, path, INFO_COLOR, false, state.dashLength);

--- a/app/packages/looker/src/overlays/segmentation.ts
+++ b/app/packages/looker/src/overlays/segmentation.ts
@@ -113,6 +113,18 @@ export default class SegmentationOverlay<State extends BaseState>
       ctx.globalAlpha = tmp;
     }
 
+    if (this.isTagFiltered(state)) {
+      strokeCanvasRect(
+        ctx,
+        state,
+        getColor(
+          state.options.coloring.pool,
+          state.options.coloring.seed,
+          "_label_tags"
+        )
+      );
+    }
+
     if (this.isSelected(state)) {
       strokeCanvasRect(
         ctx,
@@ -247,6 +259,12 @@ export default class SegmentationOverlay<State extends BaseState>
 
   isSelected(state: Readonly<State>): boolean {
     return state.options.selectedLabels.includes(this.label.id);
+  }
+
+  isTagFiltered(state: Readonly<State>): boolean {
+    return state.options.selectedLabelTags.some((tag) =>
+      this.label.tags.includes(tag)
+    );
   }
 
   isShown(state: Readonly<State>): boolean {

--- a/app/packages/looker/src/overlays/segmentation.ts
+++ b/app/packages/looker/src/overlays/segmentation.ts
@@ -262,7 +262,7 @@ export default class SegmentationOverlay<State extends BaseState>
   }
 
   isTagFiltered(state: Readonly<State>): boolean {
-    return state.options.selectedLabelTags.some((tag) =>
+    return state.options.selectedLabelTags?.some((tag) =>
       this.label.tags.includes(tag)
     );
   }

--- a/app/packages/looker/src/state.ts
+++ b/app/packages/looker/src/state.ts
@@ -121,6 +121,7 @@ interface BaseOptions {
   filter: (path: string, value: unknown) => boolean;
   coloring: Coloring;
   selectedLabels: string[];
+  selectedLabelTags: string[];
   showConfidence: boolean;
   showControls: boolean;
   showIndex: boolean;

--- a/app/packages/state/src/recoil/looker.ts
+++ b/app/packages/state/src/recoil/looker.ts
@@ -10,6 +10,7 @@ import { selectorFamily, useRecoilValue, useRecoilValueLoadable } from "recoil";
 
 import * as atoms from "./atoms";
 import * as colorAtoms from "./color";
+import { filters, modalFilters } from "./filters";
 import { pathFilter } from "./pathFilters";
 import * as schemaAtoms from "./schema";
 import * as selectors from "./selectors";
@@ -53,6 +54,14 @@ export const lookerOptions = selectorFamily<
           }
         : {};
 
+      const filter = withFilter
+        ? modal
+          ? get(modalFilters)
+          : get(filters)
+        : {};
+
+      const selectedLabelTags = filter["_label_tags"]?.values ?? [];
+
       return {
         showJSON: panels.json.isOpen,
         showHelp: panels.help.isOpen,
@@ -67,6 +76,7 @@ export const lookerOptions = selectorFamily<
         coloring: get(colorAtoms.coloring(modal)),
         ...get(atoms.savedLookerOptions),
         selectedLabels: [...get(selectors.selectedLabelIds)],
+        selectedLabelTags,
         fullscreen: get(atoms.fullscreen),
         filter: withFilter ? get(pathFilter(modal)) : undefined,
         activePaths: get(schemaAtoms.activeFields({ modal })),


### PR DESCRIPTION
fix #2445 

label tag color is applied to filtered detections:

![Screenshot 2023-02-27 at 11 03 19 AM](https://user-images.githubusercontent.com/17770824/221631296-040b0cd1-67e7-46cf-8ec3-5fc486a3e4d4.png)

## What changes are proposed in this pull request?

When label tags are selected in filter (filter/match mode), change their box color to match the color of the field assigned to that label tag. 

## How is this patch tested? If it is not, please explain why.

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->
Highlight the label box color if they are tagged and the tags are active in the filter. 

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
