### PR TITLE
Add CODECOV_TOKEN to coverage upload

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,6 +24,7 @@ jobs:
       - name: Upload
         uses: codecov/codecov-action@v3
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage-final.json
           flags: app
 
@@ -91,6 +92,7 @@ jobs:
         if: ${{ !startsWith(matrix.os, 'windows') && matrix.python == '3.9' }}
         uses: codecov/codecov-action@v3
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage.xml
           flags: python
       - name: Run no wrapper tests


### PR DESCRIPTION
Adds an upload token to the codecov action to better ensure successful reports and correct coverage deltas in PRs