### PR TITLE
Fix tagging selection

### DIFF
--- a/app/packages/core/src/components/Actions/utils.tsx
+++ b/app/packages/core/src/components/Actions/utils.tsx
@@ -131,14 +131,16 @@ export const tagStats = selectorFamily<
   get:
     ({ modal, labels }) =>
     ({ get }) => {
-      const data = get(
-        labels
-          ? fos.labelTagCounts({ modal: false, extended: false })
-          : fos.sampleTagCounts({ modal: false, extended: false })
-      );
+      const data = Object.keys(
+        get(
+          labels
+            ? fos.labelTagCounts({ modal: false, extended: false })
+            : fos.sampleTagCounts({ modal: false, extended: false })
+        )
+      ).map((t) => [t, 0]);
 
       return {
-        ...data,
+        ...Object.fromEntries(data),
         ...get(tagStatistics({ modal, labels })).tags,
       };
     },

--- a/app/packages/state/src/recoil/aggregations.ts
+++ b/app/packages/state/src/recoil/aggregations.ts
@@ -21,7 +21,12 @@ import { field } from "./schema";
  */
 export const aggregationQuery = graphQLSelectorFamily<
   VariablesOf<foq.aggregationsQuery>,
-  { extended: boolean; modal: boolean; paths: string[]; root?: boolean },
+  {
+    extended: boolean;
+    modal: boolean;
+    paths: string[];
+    root?: boolean;
+  },
   ResponseFrom<foq.aggregationsQuery>
 >({
   key: "aggregationQuery",
@@ -32,7 +37,6 @@ export const aggregationQuery = graphQLSelectorFamily<
     ({ extended, modal, paths, root = false }) =>
     ({ get }) => {
       const mixed = get(groupStatistics(modal)) === "group";
-      //TODO: refactor to reuse viewStateForm here?
       const aggForm = {
         index: get(refresher),
         dataset: get(selectors.datasetName),
@@ -85,19 +89,9 @@ export const aggregation = selectorFamily({
       path: string;
     }) =>
     ({ get }) => {
-      const result = get(
+      return get(
         aggregations({ ...params, paths: get(schemaAtoms.filterFields(path)) })
-      ).filter((data) => data.path === path);
-      // Avoid downstream errors due to undefined.map by returning an
-      // object for failed graphQL aggregations
-      return result?.length
-        ? result[0]
-        : {
-            path: path,
-            count: 0,
-            exists: 0,
-            values: [],
-          };
+      ).filter((data) => data.path === path)[0];
     },
 });
 
@@ -172,7 +166,7 @@ export const stringCountResults = selectorFamily({
     ({ get }): { count: number; results: [string | null, number][] } => {
       const keys = params.path.split(".");
       let parent = keys[0];
-      let field = get(schemaAtoms.field(parent));
+      const field = get(schemaAtoms.field(parent));
 
       if (!field && parent === "frames") {
         parent = `frames.${keys[1]}`;
@@ -225,12 +219,13 @@ export const booleanCountResults = selectorFamily<
     ({ get }) => {
       const data = get(aggregation(params));
       const none = get(noneCount(params));
+
       const result = {
         count: data.false + data.true,
         results: [
           [false, data.false],
           [true, data.true],
-        ],
+        ] as [boolean, number][],
       };
       if (none) {
         result.results.push([null, none]);
@@ -311,7 +306,7 @@ export const count = selectorFamily({
           // this will never resolve, which allows for incoming schema changes
           // this shouldn't be necessary, but there is a mismatch between
           // aggs and schema when there is a field change
-          throw new Promise(() => {});
+          throw new Promise(() => undefined);
         }
 
         const parent = split.slice(0, split.length - 1).join(".");


### PR DESCRIPTION
Resolves #2692 

Fixes tagging selection data by adding the new `selected` flag for the aggregations selector family which can be subscribed to downstream by the label tag and sample tag count selectors for the Tagger component