### PR TITLE
Adding ability to pass CVAT organization for annotations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+
 **/*.DS_store
 .vscode
 
@@ -26,4 +27,3 @@ dist/
 coverage.xml
 .coverage.*
 pyvenv.cfg
-.venv

--- a/docs/source/integrations/cvat.rst
+++ b/docs/source/integrations/cvat.rst
@@ -502,6 +502,8 @@ provided:
 -   **issue_tracker** (*None*): URL(s) of an issue tracker to link to the
     created task(s). This argument can be a list of URLs when annotating videos
     or when using `task_size` and generating multiple tasks
+-   **organization** (*None*): the name of the organization to use when sending
+    requests to CVAT
 
 .. _cvat-label-schema:
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

Resolves #1712

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

possibly

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

Gives the ability to pass along your organization for CVAT

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
