### PR TITLE
No unnecessary upserts or frames collections

### DIFF
--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -1946,7 +1946,7 @@ class SampleCollection(object):
         finally:
             if new_group_field:
                 self._dataset._doc.media_type = fom.GROUP
-                self._dataset._doc.save()
+                self._dataset.save()
 
     def set_label_values(
         self,

--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -124,13 +124,13 @@ class SaveContext(object):
                 % (self._dataset.name, sample._dataset.name)
             )
 
-        sample_op, frame_ops = sample._save(deferred=True)
-        updated = sample_op is not None or frame_ops
+        sample_ops, frame_ops = sample._save(deferred=True)
+        updated = sample_ops or frame_ops
 
         self._curr_batch_size += 1
 
-        if sample_op is not None:
-            self._sample_ops.append(sample_op)
+        if sample_ops:
+            self._sample_ops.extend(sample_ops)
 
         if frame_ops:
             self._frame_ops.extend(frame_ops)

--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -3199,7 +3199,12 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
         if view is not None:
             _save_view(view, fields=fields)
 
-        self._doc.save(safe=True)
+        try:
+            self._doc.save(safe=True)
+        except moe.DoesNotExist:
+            name = self.name
+            self._deleted = True
+            raise ValueError("Dataset '%s' is deleted" % name)
 
     def _save_field(self, field):
         if self._is_generated:

--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -412,11 +412,11 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
         if media_type == fom.GROUP:
             # The `metadata` field of group datasets always stays as the
             # generic `Metadata` type because slices may have different types
-            self._save()
+            self.save()
         else:
             self._update_metadata_field(media_type)
 
-            self._save()
+            self.save()
             self.reload()
 
     def _update_metadata_field(self, media_type):
@@ -591,7 +591,7 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
             raise ValueError("Dataset has no group slice '%s'" % slice_name)
 
         self._doc.default_group_slice = slice_name
-        self._save()
+        self.save()
 
         if self._group_slice is None:
             self._group_slice = slice_name
@@ -619,7 +619,7 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
 
         self._doc.name = name
         self._doc.slug = slug
-        self._save()
+        self.save()
 
         # Update singleton
         self._instances.pop(_name, None)
@@ -650,7 +650,7 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
     @persistent.setter
     def persistent(self, value):
         self._doc.persistent = value
-        self._save()
+        self.save()
 
     @property
     def tags(self):
@@ -675,7 +675,7 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
     @tags.setter
     def tags(self, value):
         self._doc.tags = value
-        self._save()
+        self.save()
 
     @property
     def description(self):
@@ -695,7 +695,7 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
     @description.setter
     def description(self, description):
         self._doc.description = description
-        self._save()
+        self.save()
 
     @property
     def info(self):
@@ -719,7 +719,7 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
     @info.setter
     def info(self, info):
         self._doc.info = info
-        self._save()
+        self.save()
 
     @property
     def app_config(self):
@@ -761,7 +761,7 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
             config = DatasetAppConfig()
 
         self._doc.app_config = config
-        self._save()
+        self.save()
 
     @property
     def classes(self):
@@ -789,7 +789,7 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
     @classes.setter
     def classes(self, classes):
         self._doc.classes = classes
-        self._save()
+        self.save()
 
     @property
     def default_classes(self):
@@ -815,7 +815,7 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
     @default_classes.setter
     def default_classes(self, classes):
         self._doc.default_classes = classes
-        self._save()
+        self.save()
 
     @property
     def mask_targets(self):
@@ -872,7 +872,7 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
     @mask_targets.setter
     def mask_targets(self, targets):
         self._doc.mask_targets = targets
-        self._save()
+        self.save()
 
     @property
     def default_mask_targets(self):
@@ -920,7 +920,7 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
     @default_mask_targets.setter
     def default_mask_targets(self, targets):
         self._doc.default_mask_targets = targets
-        self._save()
+        self.save()
 
     @property
     def skeletons(self):
@@ -956,7 +956,7 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
     @skeletons.setter
     def skeletons(self, skeletons):
         self._doc.skeletons = skeletons
-        self._save()
+        self.save()
 
     @property
     def default_skeleton(self):
@@ -989,7 +989,7 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
     @default_skeleton.setter
     def default_skeleton(self, skeleton):
         self._doc.default_skeleton = skeleton
-        self._save()
+        self.save()
 
     @property
     def deleted(self):
@@ -1533,7 +1533,7 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
             self._doc.default_group_slice = default
 
         self._doc.group_field = field_name
-        self._save()
+        self.save()
 
         self._group_slice = self._doc.default_group_slice
 
@@ -2000,7 +2000,7 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
         if self.group_slice == name:
             self.group_slice = new_name
 
-        self._save()
+        self.save()
 
     def delete_group_slice(self, name):
         """Deletes all samples in the given group slice from the dataset.
@@ -2026,7 +2026,7 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
         if self._group_slice == name:
             self._group_slice = new_default
 
-        self._save()
+        self.save()
 
     def iter_samples(self, progress=False, autosave=False, batch_size=None):
         """Returns an iterator over the samples in the dataset.
@@ -3178,9 +3178,9 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
         field_doc.info = field.info
 
         try:
-            self._doc.save(safe=True)
+            self.save()
         except:
-            self._reload(hard=True)
+            self.reload()
             raise
 
     @property
@@ -3262,7 +3262,7 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
         view_doc.save(upsert=True)
 
         self._doc.saved_views.append(view_doc)
-        self._save()
+        self.save()
 
     def get_saved_view_info(self, name):
         """Loads the editable information about the saved view with the given
@@ -3379,7 +3379,7 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
         deleted_id = view_doc.id
 
         view_doc.delete()
-        self._save()
+        self.save()
 
         return str(deleted_id)
 
@@ -3389,7 +3389,7 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
             view_doc.delete()
 
         self._doc.saved_views = []
-        self._save()
+        self.save()
 
     def _get_saved_view_doc(self, name, pop=False, slug=False):
         idx = None
@@ -6056,7 +6056,7 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
                 self._doc.default_group_slice = slice_name
                 self._group_slice = slice_name
 
-            self._save()
+            self.save()
 
     def _expand_frame_schema(self, frames, dynamic):
         if not dynamic:
@@ -6230,7 +6230,7 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
 
     def _update_last_loaded_at(self):
         self._doc.last_loaded_at = datetime.utcnow()
-        self._save()
+        self.save()
 
 
 def _get_random_characters(n):

--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -406,18 +406,18 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
     def _set_media_type(self, media_type):
         self._doc.media_type = media_type
 
-        if media_type == fom.VIDEO:
-            self._declare_frame_fields()
+        if self._contains_videos(any_slice=True):
+            self._init_frames()
 
-        if media_type != fom.GROUP:
-            self._update_metadata_field(media_type)
-
-            self._doc.save()
-            self.reload()
-        else:
+        if media_type == fom.GROUP:
             # The `metadata` field of group datasets always stays as the
             # generic `Metadata` type because slices may have different types
-            self._doc.save()
+            self._save()
+        else:
+            self._update_metadata_field(media_type)
+
+            self._save()
+            self.reload()
 
     def _update_metadata_field(self, media_type):
         idx = None
@@ -441,8 +441,20 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
             field_doc = foo.SampleFieldDocument.from_field(field)
             self._doc.sample_fields[idx] = field_doc
 
-    def _declare_frame_fields(self):
-        # pylint: disable=no-member
+    def _init_frames(self):
+        if not self._is_clips:
+            frame_collection_name = _make_frame_collection_name(
+                self._sample_collection_name
+            )
+            frame_doc_cls = _create_frame_document_cls(
+                self, frame_collection_name, field_docs=self._doc.frame_fields
+            )
+
+            _create_indexes(None, frame_collection_name)
+
+            self._doc.frame_collection_name = frame_collection_name
+            self._frame_doc_cls = frame_doc_cls
+
         self._doc.frame_fields = [
             foo.SampleFieldDocument.from_field(field)
             for field in self._frame_doc_cls._fields.values()
@@ -579,7 +591,7 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
             raise ValueError("Dataset has no group slice '%s'" % slice_name)
 
         self._doc.default_group_slice = slice_name
-        self._doc.save()
+        self._save()
 
         if self._group_slice is None:
             self._group_slice = slice_name
@@ -607,7 +619,7 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
 
         self._doc.name = name
         self._doc.slug = slug
-        self._doc.save(safe=True)
+        self._save()
 
         # Update singleton
         self._instances.pop(_name, None)
@@ -638,7 +650,7 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
     @persistent.setter
     def persistent(self, value):
         self._doc.persistent = value
-        self._doc.save(safe=True)
+        self._save()
 
     @property
     def tags(self):
@@ -663,7 +675,7 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
     @tags.setter
     def tags(self, value):
         self._doc.tags = value
-        self._doc.save(safe=True)
+        self._save()
 
     @property
     def description(self):
@@ -683,7 +695,7 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
     @description.setter
     def description(self, description):
         self._doc.description = description
-        self._doc.save()
+        self._save()
 
     @property
     def info(self):
@@ -707,7 +719,7 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
     @info.setter
     def info(self, info):
         self._doc.info = info
-        self._doc.save(safe=True)
+        self._save()
 
     @property
     def app_config(self):
@@ -749,7 +761,7 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
             config = DatasetAppConfig()
 
         self._doc.app_config = config
-        self._doc.save(safe=True)
+        self._save()
 
     @property
     def classes(self):
@@ -777,7 +789,7 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
     @classes.setter
     def classes(self, classes):
         self._doc.classes = classes
-        self._doc.save(safe=True)
+        self._save()
 
     @property
     def default_classes(self):
@@ -803,7 +815,7 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
     @default_classes.setter
     def default_classes(self, classes):
         self._doc.default_classes = classes
-        self._doc.save(safe=True)
+        self._save()
 
     @property
     def mask_targets(self):
@@ -860,7 +872,7 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
     @mask_targets.setter
     def mask_targets(self, targets):
         self._doc.mask_targets = targets
-        self._doc.save(safe=True)
+        self._save()
 
     @property
     def default_mask_targets(self):
@@ -908,7 +920,7 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
     @default_mask_targets.setter
     def default_mask_targets(self, targets):
         self._doc.default_mask_targets = targets
-        self._doc.save(safe=True)
+        self._save()
 
     @property
     def skeletons(self):
@@ -944,7 +956,7 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
     @skeletons.setter
     def skeletons(self, skeletons):
         self._doc.skeletons = skeletons
-        self._doc.save(safe=True)
+        self._save()
 
     @property
     def default_skeleton(self):
@@ -977,7 +989,7 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
     @default_skeleton.setter
     def default_skeleton(self, skeleton):
         self._doc.default_skeleton = skeleton
-        self._doc.save(safe=True)
+        self._save()
 
     @property
     def deleted(self):
@@ -1521,7 +1533,7 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
             self._doc.default_group_slice = default
 
         self._doc.group_field = field_name
-        self._doc.save()
+        self._save()
 
         self._group_slice = self._doc.default_group_slice
 
@@ -1988,7 +2000,7 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
         if self.group_slice == name:
             self.group_slice = new_name
 
-        self._doc.save()
+        self._save()
 
     def delete_group_slice(self, name):
         """Deletes all samples in the given group slice from the dataset.
@@ -2014,7 +2026,7 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
         if self._group_slice == name:
             self._group_slice = new_default
 
-        self._doc.save()
+        self._save()
 
     def iter_samples(self, progress=False, autosave=False, batch_size=None):
         """Returns an iterator over the samples in the dataset.
@@ -3147,7 +3159,7 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
         if view is not None:
             _save_view(view, fields=fields)
 
-        self._doc.save()
+        self._doc.save(safe=True)
 
     def _save_field(self, field):
         if self._is_generated:
@@ -3247,10 +3259,10 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
             created_at=now,
             last_modified_at=now,
         )
-        view_doc.save()
+        view_doc.save(upsert=True)
 
         self._doc.saved_views.append(view_doc)
-        self._doc.save()
+        self._save()
 
     def get_saved_view_info(self, name):
         """Loads the editable information about the saved view with the given
@@ -3367,7 +3379,8 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
         deleted_id = view_doc.id
 
         view_doc.delete()
-        self._doc.save()
+        self._save()
+
         return str(deleted_id)
 
     def delete_saved_views(self):
@@ -3376,7 +3389,7 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
             view_doc.delete()
 
         self._doc.saved_views = []
-        self._doc.save()
+        self._save()
 
     def _get_saved_view_doc(self, name, pop=False, slug=False):
         idx = None
@@ -3699,7 +3712,7 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
         fos.Sample._reset_docs(self._sample_collection_name)
 
         # Clips datasets directly inherit frames from source dataset
-        if not self._is_clips:
+        if self._frame_collection_name is not None and not self._is_clips:
             self._frame_collection.drop()
             fofr.Frame._reset_docs(self._frame_collection_name)
 
@@ -5562,24 +5575,18 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
         dataset = cls(name)
 
         media_type = d.get("media_type", None)
-        if media_type is not None:
-            dataset.media_type = media_type
 
         if media_type == fom.GROUP:
-            # group_field and group_slice are inferred when adding samples
             dataset._doc.group_media_types = d.get("group_media_types", {})
             dataset._doc.default_group_slice = d.get(
                 "default_group_slice", None
             )
-            dataset.save()
+
+        if media_type is not None:
+            dataset.media_type = media_type
 
         dataset._apply_field_schema(d.get("sample_fields", {}))
-
-        if "frame_fields" in d:
-            if media_type == fom.GROUP:
-                dataset._declare_frame_fields()
-
-            dataset._apply_frame_field_schema(d["frame_fields"])
+        dataset._apply_frame_field_schema(d.get("frame_fields", {}))
 
         dataset._doc.info = d.get("info", {})
 
@@ -5945,11 +5952,18 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
 
     @property
     def _frame_collection(self):
+        if self._frame_collection_name is None:
+            return None
+
         return foo.get_db_conn()[self._frame_collection_name]
 
     @property
     def _frame_indexes(self):
-        index_info = self._frame_collection.index_information()
+        frame_collection = self._frame_collection
+        if frame_collection is None:
+            return None
+
+        index_info = frame_collection.index_information()
         return [k["key"][0][0] for k in index_info.values()]
 
     def _apply_field_schema(self, new_fields):
@@ -6027,13 +6041,12 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
             raise ValueError("Dataset has no group field '%s'" % field_name)
 
         if slice_name not in self._doc.group_media_types:
-            # If this is the first video slice, we need to initialize the frame
-            # field schema
+            # If this is the first video slice, we need to initialize frames
             if media_type == fom.VIDEO and not any(
                 slice_media_type == fom.VIDEO
                 for slice_media_type in self._doc.group_media_types.values()
             ):
-                self._declare_frame_fields()
+                self._init_frames()
 
             self._doc.group_media_types[slice_name] = media_type
 
@@ -6043,7 +6056,7 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
                 self._doc.default_group_slice = slice_name
                 self._group_slice = slice_name
 
-            self._doc.save()
+            self._save()
 
     def _expand_frame_schema(self, frames, dynamic):
         if not dynamic:
@@ -6190,9 +6203,14 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
             self, self.name, virtual=True
         )
 
+        new_media_type = doc.media_type != self.media_type
+
         self._doc = doc
         self._sample_doc_cls = sample_doc_cls
         self._frame_doc_cls = frame_doc_cls
+
+        if new_media_type:
+            self._set_media_type(doc.media_type)
 
         if self._group_slice is None:
             self._group_slice = doc.default_group_slice
@@ -6212,7 +6230,7 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
 
     def _update_last_loaded_at(self):
         self._doc.last_loaded_at = datetime.utcnow()
-        self._doc.save()
+        self._save()
 
 
 def _get_random_characters(n):
@@ -6303,12 +6321,9 @@ def _create_dataset(
         frame_doc_cls = src_dataset._frame_doc_cls
         frame_fields = src_dataset._doc.frame_fields
     else:
-        # @todo don't create frame collection until media type is VIDEO?
-        frame_collection_name = _make_frame_collection_name(
-            sample_collection_name
-        )
-        frame_doc_cls = _create_frame_document_cls(obj, frame_collection_name)
-        frame_fields = []
+        frame_collection_name = None
+        frame_doc_cls = None
+        frame_fields = None
 
     dataset_doc = foo.DatasetDocument(
         id=_id,
@@ -6324,7 +6339,7 @@ def _create_dataset(
         frame_fields=frame_fields,
         app_config=DatasetAppConfig(),
     )
-    dataset_doc.save()
+    dataset_doc.save(upsert=True)
 
     if _clips:
         _create_indexes(sample_collection_name, None)
@@ -6337,8 +6352,9 @@ def _create_dataset(
 def _create_indexes(sample_collection_name, frame_collection_name):
     conn = foo.get_db_conn()
 
-    collection = conn[sample_collection_name]
-    collection.create_index("filepath")
+    if sample_collection_name is not None:
+        sample_collection = conn[sample_collection_name]
+        sample_collection.create_index("filepath")
 
     if frame_collection_name is not None:
         frame_collection = conn[frame_collection_name]
@@ -6464,10 +6480,12 @@ def _do_load_dataset(obj, name):
 
     if _src_dataset is not None:
         frame_doc_cls = _src_dataset._frame_doc_cls
-    else:
+    elif frame_collection_name is not None:
         frame_doc_cls = _create_frame_document_cls(
             obj, frame_collection_name, field_docs=dataset_doc.frame_fields
         )
+    else:
+        frame_doc_cls = None
 
     return dataset_doc, sample_doc_cls, frame_doc_cls
 
@@ -6514,7 +6532,13 @@ def _clone_dataset_or_view(dataset_or_view, name, persistent):
     _id = ObjectId()
 
     sample_collection_name = _make_sample_collection_name(_id)
-    frame_collection_name = _make_frame_collection_name(sample_collection_name)
+
+    if contains_videos:
+        frame_collection_name = _make_frame_collection_name(
+            sample_collection_name
+        )
+    else:
+        frame_collection_name = None
 
     #
     # Clone dataset document
@@ -6561,7 +6585,7 @@ def _clone_dataset_or_view(dataset_or_view, name, persistent):
                 if f.name in set(frame_schema.keys())
             ]
 
-    dataset_doc.save()
+    dataset_doc.save(upsert=True)
 
     # Create indexes
     _create_indexes(sample_collection_name, frame_collection_name)
@@ -6765,19 +6789,16 @@ def _merge_dataset_doc(
             dataset.media_type = src_media_type
 
     curr_doc = dataset._doc
-    has_frame_fields = dataset._has_frame_fields()
 
     if isinstance(collection_or_doc, foc.SampleCollection):
         # Respects filtered schemas, if any
         doc = collection_or_doc._root_dataset._doc
         schema = collection_or_doc.get_field_schema()
-        if has_frame_fields:
-            frame_schema = collection_or_doc.get_frame_field_schema()
+        frame_schema = collection_or_doc.get_frame_field_schema() or {}
     else:
         doc = collection_or_doc
         schema = {f.name: f.to_field() for f in doc.sample_fields}
-        if has_frame_fields:
-            frame_schema = {f.name: f.to_field() for f in doc.frame_fields}
+        frame_schema = {f.name: f.to_field() for f in doc.frame_fields or []}
 
     if curr_doc.media_type == fom.GROUP:
         # Get the group field this way because a view might omit the field
@@ -6819,6 +6840,12 @@ def _merge_dataset_doc(
                         "type '%s'" % (name, media_type, name, curr_media_type)
                     )
 
+        if dataset._frame_collection is None and any(
+            media_type == fom.VIDEO
+            for media_type in src_group_media_types.values()
+        ):
+            dataset._init_frames()
+
         if curr_doc.default_group_slice is None:
             curr_doc.default_group_slice = src_default_group_slice
 
@@ -6829,6 +6856,8 @@ def _merge_dataset_doc(
             "Cannot merge a collection with media_type='%s' into a dataset "
             "with media_type='%s'" % (src_media_type, dataset.media_type)
         )
+
+    has_frame_fields = dataset._has_frame_fields()
 
     # Omit fields first in case `fields` is a dict that changes field names
     if omit_fields is not None:
@@ -6863,7 +6892,7 @@ def _merge_dataset_doc(
         schema, expand_schema=expand_schema
     )
 
-    if has_frame_fields and frame_schema is not None:
+    if has_frame_fields and frame_schema:
         dataset._frame_doc_cls.merge_field_schema(
             frame_schema, expand_schema=expand_schema
         )
@@ -6919,7 +6948,7 @@ def _clone_extras(dst_dataset, src_doc):
     for _view_doc in src_doc.saved_views:
         view_doc = _clone_view_doc(_view_doc)
         view_doc.dataset_id = dst_doc.id
-        view_doc.save()
+        view_doc.save(upsert=True)
 
         dst_doc.saved_views.append(view_doc)
 
@@ -6927,7 +6956,7 @@ def _clone_extras(dst_dataset, src_doc):
     for anno_key, _run_doc in src_doc.annotation_runs.items():
         run_doc = _clone_run(_run_doc)
         run_doc.dataset_id = dst_doc.id
-        run_doc.save()
+        run_doc.save(upsert=True)
 
         dst_doc.annotation_runs[anno_key] = run_doc
 
@@ -6935,7 +6964,7 @@ def _clone_extras(dst_dataset, src_doc):
     for brain_key, _run_doc in src_doc.brain_methods.items():
         run_doc = _clone_run(_run_doc)
         run_doc.dataset_id = dst_doc.id
-        run_doc.save()
+        run_doc.save(upsert=True)
 
         dst_doc.brain_methods[brain_key] = run_doc
 
@@ -6943,7 +6972,7 @@ def _clone_extras(dst_dataset, src_doc):
     for eval_key, _run_doc in src_doc.evaluations.items():
         run_doc = _clone_run(_run_doc)
         run_doc.dataset_id = dst_doc.id
-        run_doc.save()
+        run_doc.save(upsert=True)
 
         dst_doc.evaluations[eval_key] = run_doc
 

--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -3209,8 +3209,8 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
 
     def save_view(
         self,
-        name=name,
-        view=view,
+        name,
+        view,
         description=None,
         color=None,
         overwrite=False,
@@ -3235,6 +3235,8 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
         Args:
             name: a name for the saved view
             view: a :class:`fiftyone.core.view.DatasetView`
+            description (None): an optional string description
+            color (None): an optional RGB hex string like ``'#FF6D04'``
             overwrite (False): whether to overwrite an existing saved view with
                 the same name
         """
@@ -3335,10 +3337,7 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
             view_doc.last_modified_at = datetime.utcnow()
             view_doc.save()
 
-    def load_saved_view(
-        self,
-        name,
-    ):
+    def load_saved_view(self, name):
         """Loads the saved view with the given name.
 
         Examples::

--- a/fiftyone/core/frame.py
+++ b/fiftyone/core/frame.py
@@ -10,7 +10,6 @@ import itertools
 from bson import ObjectId
 from pymongo import ReplaceOne, UpdateOne, DeleteOne, DeleteMany
 
-
 from fiftyone.core.document import Document, DocumentView
 import fiftyone.core.frame_utils as fofu
 import fiftyone.core.odm as foo

--- a/fiftyone/core/odm/document.py
+++ b/fiftyone/core/odm/document.py
@@ -537,6 +537,10 @@ class Document(BaseDocument, mongoengine.Document):
 
     meta = {"abstract": True}
 
+    @classmethod
+    def _doc_name(cls):
+        return "Document"
+
     def save(
         self,
         upsert=False,
@@ -637,7 +641,8 @@ class Document(BaseDocument, mongoengine.Document):
 
                 if not deferred and not upsert and not updated_existing:
                     raise ValueError(
-                        "Failed to update document with ID '%s'" % str(_id)
+                        "Failed to update %s with ID '%s'"
+                        % (self._doc_name().lower(), str(_id))
                     )
 
         # Make sure we store the PK on this document now that it's saved

--- a/fiftyone/core/odm/document.py
+++ b/fiftyone/core/odm/document.py
@@ -7,12 +7,10 @@ Base classes for documents that back dataset contents.
 """
 from copy import deepcopy
 import json
-import re
 
 from bson import json_util, ObjectId
 import mongoengine
-import pymongo
-from pymongo import UpdateOne
+from pymongo import InsertOne, UpdateOne
 
 import eta.core.serial as etas
 
@@ -46,7 +44,7 @@ class SerializableDocument(object):
         class_name=None,
         select_fields=None,
         exclude_fields=None,
-        **kwargs
+        **kwargs,
     ):
         """Generates a customizable string representation of the document.
 
@@ -539,25 +537,38 @@ class Document(BaseDocument, mongoengine.Document):
 
     meta = {"abstract": True}
 
-    def save(self, validate=True, clean=True, safe=False, **kwargs):
+    def save(
+        self,
+        upsert=False,
+        validate=True,
+        clean=True,
+        safe=False,
+        **kwargs,
+    ):
         """Saves the document to the database.
 
         If the document already exists, it will be updated, otherwise it will
         be created.
 
         Args:
+            upsert (False): whether to insert the document if it has an ``id``
+                populated but no document with that ID exists in the database
             validate (True): whether to validate the document
             clean (True): whether to call the document's ``clean()`` method.
                 Only applicable when ``validate`` is True
             safe (False): whether to ``reload()`` the document before raising
-                any validation errors
+                any errors
 
         Returns:
             self
         """
         try:
             self._save(
-                deferred=False, validate=validate, clean=clean, **kwargs
+                deferred=False,
+                upsert=upsert,
+                validate=validate,
+                clean=clean,
+                **kwargs,
             )
         except:
             if safe:
@@ -567,11 +578,18 @@ class Document(BaseDocument, mongoengine.Document):
 
         return self
 
-    def _save(self, deferred=False, validate=True, clean=True, **kwargs):
+    def _save(
+        self,
+        deferred=False,
+        upsert=False,
+        validate=True,
+        clean=True,
+        **kwargs,
+    ):
         # pylint: disable=no-member
         if self._meta.get("abstract"):
             raise mongoengine.InvalidDocumentError(
-                "Cannot save an abstract document."
+                "Cannot save an abstract document"
             )
 
         if self._meta.get("auto_create_index", True):
@@ -580,88 +598,85 @@ class Document(BaseDocument, mongoengine.Document):
         if validate:
             self.validate(clean=clean)
 
-        doc_id = self.to_mongo(fields=[self._meta["id_field"]])
-        created = "_id" not in doc_id or self._created
+        id_field = self._meta["id_field"]
+
+        created = self._created
+        if not created:
+            created = "_id" not in self.to_mongo(fields=[id_field])
 
         doc = self.to_mongo()
+        _id = doc.get("_id", None)
 
-        _id = None
-        op = None
+        ops = None
 
-        try:
-            if created:
-                # Save new document
-                if deferred:
-                    _id = doc.get("_id", None) or ObjectId()
-                    op = UpdateOne({"_id": _id}, doc, upsert=True)
-                else:
-                    collection = self._get_collection()
+        if created:
+            # Save new document
+            if _id is None:
+                _id = ObjectId()
+                doc["_id"] = _id
 
-                    if "_id" in doc:
-                        raw_object = collection.find_one_and_replace(
-                            {"_id": doc["_id"]}, doc
-                        )
-                        if raw_object:
-                            _id = doc["_id"]
-
-                    if not _id:
-                        _id = collection.insert_one(doc).inserted_id
+            if deferred:
+                ops = [InsertOne(doc)]
             else:
-                # Update existing document
-                _id = doc["_id"]
-                created = False
+                self._get_collection().insert_one(doc)
+        else:
+            # Update existing document
+            updates = {}
+            sets, unsets = self._delta()
 
-                updates = {}
-                sets, unsets = self._delta()
+            if sets:
+                updates["$set"] = sets
 
-                if sets:
-                    updates["$set"] = sets
+            if unsets:
+                updates["$unset"] = unsets
 
-                if unsets:
-                    updates["$unset"] = unsets
+            if updates:
+                ops, updated_existing = self._update(
+                    _id, updates, deferred=deferred, upsert=upsert, **kwargs
+                )
 
-                if updates:
-                    if deferred:
-                        op = UpdateOne({"_id": _id}, updates, upsert=True)
-                    else:
-                        updated_existing = self._update(_id, updates, **kwargs)
-                        if updated_existing is False:
-                            created = True
-        except pymongo.errors.DuplicateKeyError as e:
-            message = "Tried to save duplicate unique keys (%s)"
-            raise mongoengine.NotUniqueError(message % e)
-        except pymongo.errors.OperationFailure as e:
-            message = "Could not save document (%s)"
-            if re.match("^E1100[01] duplicate key", str(e)):
-                message = "Tried to save duplicate unique keys (%s)"
-                raise mongoengine.NotUniqueError(message % e)
-
-            raise mongoengine.OperationError(message % e)
+                if not deferred and not upsert and not updated_existing:
+                    raise ValueError(
+                        "Failed to update document with ID '%s'" % str(_id)
+                    )
 
         # Make sure we store the PK on this document now that it's saved
-        id_field = self._meta["id_field"]
         if created or id_field not in self._meta.get("shard_key", []):
             self[id_field] = self._fields[id_field].to_python(_id)
 
         self._clear_changed_fields()
         self._created = False
 
-        return op
+        return ops
 
-    def _update(self, _id, updates, **kwargs):
+    def _update(self, _id, updates, deferred=False, upsert=False, **kwargs):
         """Updates an existing document."""
+        if deferred:
+            ops = self._deferred_updates(_id, updates, upsert)
+            updated_existing = None
+        else:
+            ops = None
+            updated_existing = self._do_updates(_id, updates, upsert)
+
+        return ops, updated_existing
+
+    def _do_updates(self, _id, updates, upsert):
+        updated_existing = True
+
         result = (
             self._get_collection()
-            .update_one({"_id": _id}, updates, upsert=True)
+            .update_one({"_id": _id}, updates, upsert=upsert)
             .raw_result
         )
 
         if result is not None:
-            updated_existing = result.get("updatedExisting")
-        else:
-            updated_existing = None
+            updated_existing = result.get("updatedExisting", None)
 
         return updated_existing
+
+    def _deferred_updates(self, _id, updates, upsert):
+        op = UpdateOne({"_id": _id}, updates, upsert=upsert)
+        return [op]
 
 
 def _merge_lists(dst, src, overwrite=False):

--- a/fiftyone/core/odm/mixins.py
+++ b/fiftyone/core/odm/mixins.py
@@ -486,7 +486,7 @@ class DatasetMixin(object):
             dataset_doc.group_field = new_group_field
 
         dataset_doc.app_config._rename_paths(paths, new_paths)
-        dataset_doc.save()
+        dataset.save()
 
     @classmethod
     def _clone_fields(cls, sample_collection, paths, new_paths):
@@ -556,7 +556,7 @@ class DatasetMixin(object):
         for path, new_path in schema_paths:
             cls._clone_field_schema(path, new_path)
 
-        dataset_doc.save()
+        dataset.save()
 
     @classmethod
     def _clear_fields(cls, sample_collection, paths):
@@ -675,7 +675,7 @@ class DatasetMixin(object):
 
         if del_paths:
             dataset_doc.app_config._delete_paths(del_paths)
-            dataset_doc.save()
+            dataset.save()
 
     @classmethod
     def _remove_dynamic_fields(cls, paths, error_level=0):
@@ -734,9 +734,9 @@ class DatasetMixin(object):
             cls._delete_field_schema(del_path)
 
         if del_paths:
-            dataset_doc = cls._dataset._doc
-            dataset_doc.app_config._delete_paths(del_paths)
-            dataset_doc.save()
+            dataset = cls._dataset
+            dataset._doc.app_config._delete_paths(del_paths)
+            dataset.save()
 
     @classmethod
     def _rename_fields_simple(cls, paths, new_paths):

--- a/fiftyone/core/runs.py
+++ b/fiftyone/core/runs.py
@@ -361,7 +361,8 @@ class Run(Configurable):
                     % (cls._run_str().capitalize(), key)
                 )
 
-        dataset_doc = samples._root_dataset._doc
+        dataset = samples._root_dataset
+        dataset_doc = dataset._doc
         run_docs = getattr(dataset_doc, cls._runs_field())
         view_stages = [
             json_util.dumps(s)
@@ -377,10 +378,10 @@ class Run(Configurable):
             view_stages=view_stages,
             results=None,
         )
-        run_doc.save()
+        run_doc.save(upsert=True)
 
         run_docs[key] = run_doc
-        dataset_doc.save()
+        dataset.save()
 
     @classmethod
     def update_run_config(cls, samples, key, config):
@@ -599,7 +600,7 @@ class Run(Configurable):
             run_doc.results.delete()
 
         run_doc.delete()
-        dataset._doc.save()
+        dataset.save()
 
     @classmethod
     def delete_runs(cls, samples):

--- a/fiftyone/core/sample.py
+++ b/fiftyone/core/sample.py
@@ -543,9 +543,9 @@ class Sample(_SampleMixin, Document, metaclass=SampleSingleton):
         else:
             frame_ops = []
 
-        sample_op = super()._save(deferred=deferred)
+        sample_ops = super()._save(deferred=deferred)
 
-        return sample_op, frame_ops
+        return sample_ops, frame_ops
 
     @classmethod
     def from_frame(cls, frame, filepath=None):
@@ -730,9 +730,9 @@ class SampleView(_SampleMixin, DocumentView):
         else:
             frame_ops = []
 
-        sample_op = super()._save(deferred=deferred)
+        sample_ops = super()._save(deferred=deferred)
 
-        return sample_op, frame_ops
+        return sample_ops, frame_ops
 
 
 def _apply_confidence_thresh(label, confidence_thresh):

--- a/fiftyone/server/mutation.py
+++ b/fiftyone/server/mutation.py
@@ -133,8 +133,8 @@ class Mutation:
             )
             for group in sidebar_groups
         ]
+        view._dataset.save()
 
-        view._dataset._doc.save()
         state.view = view
         await dispatch_event(subscription, StateUpdate(state=state))
         return True

--- a/fiftyone/utils/data/importers.py
+++ b/fiftyone/utils/data/importers.py
@@ -1949,8 +1949,6 @@ class FiftyOneDatasetImporter(BatchDatasetImporter):
 
 
 def _import_saved_views(dataset, views):
-    dataset_doc = dataset._doc
-
     for d in views:
         if etau.is_str(d):
             d = json_util.loads(d)
@@ -1962,17 +1960,15 @@ def _import_saved_views(dataset, views):
 
         d.pop("_id", None)
         view_doc = foo.SavedViewDocument.from_dict(d)
-        view_doc.dataset_id = str(dataset_doc.id)
-        view_doc.save()
+        view_doc.dataset_id = str(dataset._doc.id)
+        view_doc.save(upsert=True)
 
-        dataset_doc.saved_views.append(view_doc)
+        dataset._doc.saved_views.append(view_doc)
 
-    dataset_doc.save()
+    dataset.save()
 
 
 def _import_runs(dataset, runs, results_dir, run_cls):
-    dataset_doc = dataset._doc
-
     # Import run documents
     for key, d in runs.items():
         if etau.is_str(d):
@@ -1980,14 +1976,14 @@ def _import_runs(dataset, runs, results_dir, run_cls):
 
         d.pop("_id", None)
         run_doc = foo.RunDocument.from_dict(d)
-        run_doc.dataset_id = str(dataset_doc.id)
+        run_doc.dataset_id = str(dataset._doc.id)
         run_doc.results = None
-        run_doc.save()
+        run_doc.save(upsert=True)
 
-        runs = getattr(dataset_doc, run_cls._runs_field())
+        runs = getattr(dataset._doc, run_cls._runs_field())
         runs[key] = run_doc
 
-    dataset_doc.save()
+    dataset.save()
 
     # Import run results
     for key in runs.keys():

--- a/tests/unittests/dataset_tests.py
+++ b/tests/unittests/dataset_tests.py
@@ -2287,7 +2287,6 @@ class DatasetTests(unittest.TestCase):
             dataset.default_classes.append(1)
             dataset.save()  # error
 
-        dataset.default_classes.pop()
         dataset.save()  # success
 
         classes = {"ground_truth": ["cat", "dog"]}
@@ -2301,13 +2300,11 @@ class DatasetTests(unittest.TestCase):
             dataset.classes["other"] = {"hi": "there"}
             dataset.save()  # error
 
-        dataset.classes.pop("other")
+        dataset.save()  # success
 
         with self.assertRaises(Exception):
             dataset.classes["ground_truth"].append(1)
             dataset.save()  # error
-
-        dataset.classes["ground_truth"].pop()
 
         dataset.save()  # success
 
@@ -2350,7 +2347,6 @@ class DatasetTests(unittest.TestCase):
             dataset.default_mask_targets["hi"] = "there"
             dataset.save()  # error
 
-        dataset.default_mask_targets.pop("hi")
         dataset.save()  # success
 
         mask_targets = {"ground_truth": {1: "cat", 2: "dog"}}
@@ -2363,28 +2359,24 @@ class DatasetTests(unittest.TestCase):
             dataset.mask_targets["hi"] = "there"
             dataset.save()  # error
 
-        dataset.mask_targets.pop("hi")
         dataset.save()  # success
 
         with self.assertRaises(ValidationError):
             dataset.mask_targets[1] = {1: "cat", 2: "dog"}
             dataset.save()  # error
 
-        dataset.mask_targets.pop(1)
         dataset.save()  # success
 
         with self.assertRaises(ValidationError):
             dataset.mask_targets["ground_truth"]["hi"] = "there"
             dataset.save()  # error
 
-        dataset.mask_targets["ground_truth"].pop("hi")
         dataset.save()  # success
 
         with self.assertRaises(ValidationError):
             dataset.mask_targets["predictions"] = {1: {"too": "many"}}
             dataset.save()  # error
 
-        dataset.mask_targets.pop("predictions")
         dataset.save()  # success
 
     @drop_datasets
@@ -2403,12 +2395,13 @@ class DatasetTests(unittest.TestCase):
             dataset.default_skeleton.labels = [1]
             dataset.save()  # error
 
-        dataset.default_skeleton.labels = ["left eye", "right eye"]
         dataset.save()  # success
 
         with self.assertRaises(Exception):
             dataset.default_skeleton.edges = "hello"
             dataset.save()  # error
+
+        dataset.save()  # success
 
         dataset.default_skeleton.edges = [[0, 1]]
         dataset.save()  # success
@@ -2430,7 +2423,6 @@ class DatasetTests(unittest.TestCase):
             dataset.skeletons["hi"] = "there"
             dataset.save()  # error
 
-        dataset.skeletons.pop("hi")
         dataset.save()  # success
 
         with self.assertRaises(Exception):
@@ -2439,21 +2431,18 @@ class DatasetTests(unittest.TestCase):
             )
             dataset.save()  # error
 
-        dataset.skeletons.pop(1)
         dataset.save()  # success
 
         with self.assertRaises(Exception):
             dataset.skeletons["ground_truth"].labels = [1]
             dataset.save()  # error
 
-        dataset.skeletons["ground_truth"].labels = ["left eye", "right eye"]
         dataset.save()  # success
 
         with self.assertRaises(Exception):
             dataset.skeletons["ground_truth"].edges = "hello"
             dataset.save()  # error
 
-        dataset.skeletons["ground_truth"].edges = [[0, 1]]
         dataset.save()  # success
 
         dataset.skeletons["ground_truth"].labels = None

--- a/tests/unittests/group_tests.py
+++ b/tests/unittests/group_tests.py
@@ -14,6 +14,7 @@ import unittest
 import eta.core.utils as etau
 
 import fiftyone as fo
+import fiftyone.core.odm as foo
 import fiftyone.utils.data as foud
 import fiftyone.utils.groups as foug
 from fiftyone import ViewField as F
@@ -69,6 +70,66 @@ class GroupTests(unittest.TestCase):
             dataset.group_media_types,
             {"left": "image", "ego": "video", "right": "image"},
         )
+
+    @drop_datasets
+    def test_group_dataset_frames_init(self):
+        conn = foo.get_db_conn()
+
+        dataset = fo.Dataset()
+        dataset.media_type = "group"
+
+        self.assertIsNone(dataset._frame_collection)
+        self.assertIsNone(dataset._frame_collection_name)
+        self.assertTrue(len(dataset._doc.frame_fields) == 0)
+
+        dataset.add_group_slice("pcd", "point-cloud")
+
+        self.assertIsNone(dataset._frame_collection)
+        self.assertIsNone(dataset._frame_collection_name)
+        self.assertTrue(len(dataset._doc.frame_fields) == 0)
+
+        dataset.add_group_slice("camera", "video")
+
+        self.assertIsNotNone(dataset._frame_collection)
+        self.assertIsNotNone(dataset._frame_collection_name)
+        self.assertTrue(len(dataset._doc.frame_fields) > 0)
+
+        collections = conn.list_collection_names()
+        self.assertIn(dataset._frame_collection_name, collections)
+
+        dataset = fo.Dataset()
+        group = fo.Group()
+
+        dataset.add_samples(
+            [
+                fo.Sample(
+                    filepath="left-image.jpg",
+                    group_field=group.element("left"),
+                ),
+                fo.Sample(
+                    filepath="right-image.jpg",
+                    group_field=group.element("right"),
+                ),
+            ]
+        )
+
+        self.assertIsNone(dataset._frame_collection)
+        self.assertIsNone(dataset._frame_collection_name)
+        self.assertTrue(len(dataset._doc.frame_fields) == 0)
+
+        dataset.add_sample(
+            fo.Sample(
+                filepath="ego-video.mp4",
+                group_field=group.element("ego"),
+            )
+        )
+
+        self.assertIsNotNone(dataset._frame_collection)
+        self.assertIsNotNone(dataset._frame_collection_name)
+        self.assertTrue(len(dataset._doc.frame_fields) > 0)
+
+        collections = conn.list_collection_names()
+        self.assertIn(dataset._frame_collection_name, collections)
 
     @drop_datasets
     def test_basics(self):

--- a/tests/unittests/utils3d_tests.py
+++ b/tests/unittests/utils3d_tests.py
@@ -82,17 +82,7 @@ class OrthographicProjectionTests(BaseOrthographicProjectionTests):
     def test_params_validation(self):
         dataset = fo.Dataset()
 
-        group = fo.Group()
-        group_samples = [
-            fo.Sample(
-                filepath="image.jpg", group_field=group.element("image")
-            ),
-            fo.Sample(
-                filepath=self.test_pcd_path, group_field=group.element("pcd")
-            ),
-        ]
         non_group_samples = [fo.Sample(filepath="test.jpg")]
-
         dataset.add_samples(non_group_samples)
 
         # if media type is not group, usage of group params should throw an
@@ -113,10 +103,21 @@ class OrthographicProjectionTests(BaseOrthographicProjectionTests):
                 output_dir=self.temp_dir.name,
             )
 
+        dataset = fo.Dataset()
+
+        group = fo.Group()
+        group_samples = [
+            fo.Sample(
+                filepath="image.jpg", group_field=group.element("image")
+            ),
+            fo.Sample(
+                filepath=self.test_pcd_path, group_field=group.element("pcd")
+            ),
+        ]
+        dataset.add_samples(group_samples)
+
         # if media type is group, in_group_slice should be valid, or omitted to
         # be implicitly derived
-        dataset.clear()
-        dataset.add_samples(group_samples)
 
         # throws with wrong slice
         with self.assertRaisesRegex(ValueError, ".*media type.*"):

--- a/tests/unittests/video_tests.py
+++ b/tests/unittests/video_tests.py
@@ -13,6 +13,7 @@ import numpy as np
 import unittest
 
 import fiftyone as fo
+import fiftyone.core.odm as foo
 from fiftyone import ViewField as F
 
 from decorators import drop_datasets
@@ -92,6 +93,27 @@ class VideoTests(unittest.TestCase):
             self.assertEqual(frame_number, frame.frame_number)
 
         self.assertTrue(frame_numbers, [1, 5])
+
+    @drop_datasets
+    def test_video_dataset_frames_init(self):
+        dataset = fo.Dataset()
+        conn = foo.get_db_conn()
+
+        collections = conn.list_collection_names()
+        self.assertIn(dataset._sample_collection_name, collections)
+
+        self.assertIsNone(dataset._frame_collection)
+        self.assertIsNone(dataset._frame_collection_name)
+        self.assertTrue(len(dataset._doc.frame_fields) == 0)
+
+        dataset.media_type = "video"
+
+        self.assertIsNotNone(dataset._frame_collection)
+        self.assertIsNotNone(dataset._frame_collection_name)
+        self.assertTrue(len(dataset._doc.frame_fields) > 0)
+
+        collections = conn.list_collection_names()
+        self.assertIn(dataset._frame_collection_name, collections)
 
     @drop_datasets
     def test_video_indexes(self):


### PR DESCRIPTION
## Change log

- Frame collections are now lazily created only when necessary. Previously an empty frames collection would always be created when a dataset is created, even if the dataset doesn't contain videos
- Added an `add_group_slice()` method to declare new slices on grouped datasetes
- Updated the `_save()` implementation to only use `upsert=True` when explicitly requested by the caller
- Updated the codebase to use `Dataset.save()` rather than `DatasetDocument.save()`, for consistency and so that the last valid dataset doc is automatically reloaded from the database if a bad save occurs. Previously, the user must manually correct any bad data on their `_doc` or manually reload the dataset in order to continue using the `Dataset` object if an error occurred due to invalid data during a `save()`
- Fixed a bug in `_save(deferred=True)` where filtered list updates were not being applied
