### PR TITLE
Fix session usage for schema changes

### DIFF
--- a/fiftyone/core/state.py
+++ b/fiftyone/core/state.py
@@ -125,7 +125,11 @@ class StateDescription(etas.Serializable):
 
         stages = d.get("view", None)
         if dataset is not None and stages:
-            view = fov.DatasetView._build(dataset, stages)
+            try:
+                view = fov.DatasetView._build(dataset, stages)
+            except:
+                dataset.reload()
+                view = fov.DatasetView._build(dataset, stages)
         else:
             view = None
 

--- a/fiftyone/server/routes/event.py
+++ b/fiftyone/server/routes/event.py
@@ -21,7 +21,7 @@ class Event(HTTPEndpoint):
     async def post(self, request: Request, data: t.Dict) -> t.Dict:
         await dispatch_event(
             data["subscription"],
-            fose.Event.from_data(data["event"], data["data"]),
+            await fose.Event.from_data_async(data["event"], data["data"]),
         )
 
         return {}

--- a/fiftyone/server/routes/events.py
+++ b/fiftyone/server/routes/events.py
@@ -25,7 +25,7 @@ class Events(HTTPEndpoint):
         self, request: Request, data: dict
     ) -> t.Union[t.Dict, EventSourceResponse]:
         polling = data.pop("polling", False)
-        payload = ListenPayload.from_dict(data)
+        payload = await ListenPayload.from_dict(data)
         if polling:
             return await dispatch_polling_event_listener(request, payload)
 


### PR DESCRIPTION
Resolves #2700 

Resolves session updates by reloading the dataset singleton on the server when building a view that raises an exception