### PR TITLE
Fix bug in looker video

### DIFF
--- a/app/packages/looker/src/lookers/video.ts
+++ b/app/packages/looker/src/lookers/video.ts
@@ -335,7 +335,7 @@ export class VideoLooker extends AbstractLooker<VideoState, VideoSample> {
       true
     );
 
-    const providedFrames = sample.frames.length
+    const providedFrames = sample.frames?.length
       ? sample.frames
       : [{ frame_number: 1 }];
     const providedFrameOverlays = providedFrames.map((frameSample) =>
@@ -359,6 +359,7 @@ export class VideoLooker extends AbstractLooker<VideoState, VideoSample> {
       this.frames.set(frame.sample.frame_number, new WeakRef(frame));
       addToBuffers([frameNumber, frameNumber], this.state.buffers);
     });
+    debugger;
   }
 
   pluckOverlays(state: VideoState) {
@@ -450,7 +451,7 @@ export class VideoLooker extends AbstractLooker<VideoState, VideoSample> {
             frames: [
               {
                 frame_number: this.frameNumber,
-                ...f({
+                ...{
                   filter: this.state.options.filter,
                   value: {
                     ...this.frames.get(this.frameNumber).deref().sample,
@@ -458,7 +459,7 @@ export class VideoLooker extends AbstractLooker<VideoState, VideoSample> {
                   schema: this.state.config.fieldSchema.frames.fields,
                   keys: ["frames"],
                   active: this.state.options.activePaths,
-                }),
+                },
               },
             ],
           });

--- a/app/packages/looker/src/lookers/video.ts
+++ b/app/packages/looker/src/lookers/video.ts
@@ -359,7 +359,6 @@ export class VideoLooker extends AbstractLooker<VideoState, VideoSample> {
       this.frames.set(frame.sample.frame_number, new WeakRef(frame));
       addToBuffers([frameNumber, frameNumber], this.state.buffers);
     });
-    debugger;
   }
 
   pluckOverlays(state: VideoState) {

--- a/app/packages/looker/src/lookers/video.ts
+++ b/app/packages/looker/src/lookers/video.ts
@@ -359,6 +359,7 @@ export class VideoLooker extends AbstractLooker<VideoState, VideoSample> {
       this.frames.set(frame.sample.frame_number, new WeakRef(frame));
       addToBuffers([frameNumber, frameNumber], this.state.buffers);
     });
+    debugger;
   }
 
   pluckOverlays(state: VideoState) {

--- a/docs/source/recipes/custom_exporter.ipynb
+++ b/docs/source/recipes/custom_exporter.ipynb
@@ -390,9 +390,9 @@
      "output_type": "stream",
      "text": [
       "total 168\r\n",
-      "drwxr-xr-x     4 voxel51  wheel   128B Jul 14 22:46 \u001b[34m.\u001b[m\u001b[m\r\n",
-      "drwxr-xr-x     3 voxel51  wheel    96B Jul 14 22:46 \u001b[34m..\u001b[m\u001b[m\r\n",
-      "drwxr-xr-x  1002 voxel51  wheel    31K Jul 14 22:46 \u001b[34mdata\u001b[m\u001b[m\r\n",
+      "drwxr-xr-x     4 voxel51  wheel   128B Jul 14 22:46 \u001B[34m.\u001B[m\u001B[m\r\n",
+      "drwxr-xr-x     3 voxel51  wheel    96B Jul 14 22:46 \u001B[34m..\u001B[m\u001B[m\r\n",
+      "drwxr-xr-x  1002 voxel51  wheel    31K Jul 14 22:46 \u001B[34mdata\u001B[m\u001B[m\r\n",
       "-rw-r--r--     1 voxel51  wheel    83K Jul 14 22:46 labels.csv\r\n"
      ]
     }

--- a/docs/source/recipes/custom_exporter.ipynb
+++ b/docs/source/recipes/custom_exporter.ipynb
@@ -390,9 +390,9 @@
      "output_type": "stream",
      "text": [
       "total 168\r\n",
-      "drwxr-xr-x     4 voxel51  wheel   128B Jul 14 22:46 \u001B[34m.\u001B[m\u001B[m\r\n",
-      "drwxr-xr-x     3 voxel51  wheel    96B Jul 14 22:46 \u001B[34m..\u001B[m\u001B[m\r\n",
-      "drwxr-xr-x  1002 voxel51  wheel    31K Jul 14 22:46 \u001B[34mdata\u001B[m\u001B[m\r\n",
+      "drwxr-xr-x     4 voxel51  wheel   128B Jul 14 22:46 \u001b[34m.\u001b[m\u001b[m\r\n",
+      "drwxr-xr-x     3 voxel51  wheel    96B Jul 14 22:46 \u001b[34m..\u001b[m\u001b[m\r\n",
+      "drwxr-xr-x  1002 voxel51  wheel    31K Jul 14 22:46 \u001b[34mdata\u001b[m\u001b[m\r\n",
       "-rw-r--r--     1 voxel51  wheel    83K Jul 14 22:46 labels.csv\r\n"
      ]
     }


### PR DESCRIPTION
## What changes are proposed in this pull request?

- ensure frames exist before checking length, otherwise filtering may throw errors in the app
- remove `f` so that calls of `getSample()` complete as expected

## How is this patch tested? If it is not, please explain why.

(Details)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
