### PR TITLE
Empty samples page with reset button

### DIFF
--- a/app/packages/core/src/Root/Root.tsx
+++ b/app/packages/core/src/Root/Root.tsx
@@ -35,7 +35,7 @@ import { RootQuery } from "./__generated__/RootQuery.graphql";
 import { RootDatasets_query$key } from "./__generated__/RootDatasets_query.graphql";
 import { RootGA_query$key } from "./__generated__/RootGA_query.graphql";
 import { RootNav_query$key } from "./__generated__/RootNav_query.graphql";
-import { clone, isElectron } from "@fiftyone/utilities";
+import { isElectron } from "@fiftyone/utilities";
 import * as fos from "@fiftyone/state";
 import { getDatasetName, Route, RouterContext } from "@fiftyone/state";
 

--- a/app/packages/core/src/components/Dataset.tsx
+++ b/app/packages/core/src/components/Dataset.tsx
@@ -3,7 +3,6 @@ import React from "react";
 import { useRecoilValue } from "recoil";
 import styled from "styled-components";
 
-import HorizontalNav from "../components/HorizontalNav";
 import Modal from "./Modal";
 import SamplesContainer from "./SamplesContainer";
 

--- a/app/packages/core/src/components/EmptySamples.tsx
+++ b/app/packages/core/src/components/EmptySamples.tsx
@@ -5,21 +5,24 @@ import * as fos from "@fiftyone/state";
 import { SamplesHeader } from "./ImageContainerHeader";
 import { Typography } from "@mui/material";
 import ClearAll from "@mui/icons-material/ClearAll";
-import { Button } from "@fiftyone/components";
+import { Button, useTheme } from "@fiftyone/components";
+import ErrorImg from "../images/error.svg";
+import { ExternalLink } from "../utils/generic";
 
 const BaseContainer = styled.div`
   display: flex;
   align-items: center;
   justify-content: center;
-  flex-direction: row;
+  height: 100%;
 `;
 
 const Container = styled(SamplesHeader)`
-  height: 30vh;
+  height: auto;
   display: flex;
   align-items: center;
   justify-content: center;
   flex-direction: column;
+  min-width: 300px;
 `;
 
 const TextContainer = styled(Container)`
@@ -40,33 +43,68 @@ function EmptySamples() {
   const totalSamples = useRecoilValue(
     fos.count({ path: "", extended: false, modal: false })
   );
+  const theme = useTheme();
   const setView = fos.useSetView();
 
-  const showEmptySamples = useMemo(
+  const showEmptyDataset = useMemo(
+    () => !loadedView?.length && !totalSamples,
+    [totalSamples, loadedView]
+  );
+
+  const showEmptyView = useMemo(
     () => loadedView?.length && !totalSamples,
     [totalSamples, loadedView]
   );
 
-  if (!showEmptySamples) return null;
+  if (!showEmptyView && !showEmptyDataset) {
+    return null;
+  }
+
   return (
-    <Container>
-      <TextContainer>
-        <Typography variant="h6" component="span">
-          Your view is empty :-|
-        </Typography>
-      </TextContainer>
-      <ActionContainer>
-        <Button aria-label="clear-filters" onClick={() => setView([], [])}>
-          <BaseContainer style={{ padding: "0.25rem" }}>
-            <BaseContainer>
-              <Typography variant="body1" component="span">
-                Clear view
-              </Typography>
-            </BaseContainer>
-            <ClearAll sx={{ ml: ".5rem" }} />
-          </BaseContainer>
-        </Button>
-      </ActionContainer>
+    <Container style={{ padding: "6rem 1rem" }}>
+      <BaseContainer style={{ flexDirection: "column" }}>
+        <TextContainer>
+          <Typography variant="h6" component="span">
+            {!!showEmptyView && "Your view is empty"}
+            {!!showEmptyDataset && "Your dataset is empty"}
+          </Typography>
+        </TextContainer>
+      </BaseContainer>
+      {!!showEmptyDataset && (
+        <BaseContainer style={{ padding: "1rem 0 2rem 0" }}>
+          <ExternalLink
+            href="https://docs.voxel51.com/user_guide/dataset_creation/index.html"
+            style={{ display: "flex", color: theme.text.secondary }}
+          >
+            <Typography
+              variant="subtitle1"
+              component="span"
+              sx={{ color: theme.text.secondary }}
+            >
+              Add samples to your dataset
+            </Typography>
+          </ExternalLink>
+        </BaseContainer>
+      )}
+      {!!showEmptyView && (
+        <BaseContainer style={{ paddingBottom: "1rem" }}>
+          <ActionContainer>
+            <Button aria-label="clear-filters" onClick={() => setView([], [])}>
+              <BaseContainer style={{ padding: "0.25rem" }}>
+                <BaseContainer>
+                  <Typography variant="body1" component="span">
+                    Clear view
+                  </Typography>
+                </BaseContainer>
+                <ClearAll sx={{ ml: ".5rem" }} />
+              </BaseContainer>
+            </Button>
+          </ActionContainer>
+        </BaseContainer>
+      )}
+      <BaseContainer>
+        <img src={ErrorImg} height={402} width={296} />
+      </BaseContainer>
     </Container>
   );
 }

--- a/app/packages/core/src/components/EmptySamples.tsx
+++ b/app/packages/core/src/components/EmptySamples.tsx
@@ -1,0 +1,74 @@
+import React, { useMemo } from "react";
+import { useRecoilValue } from "recoil";
+import styled from "styled-components";
+import * as fos from "@fiftyone/state";
+import { SamplesHeader } from "./ImageContainerHeader";
+import { Typography } from "@mui/material";
+import ClearAll from "@mui/icons-material/ClearAll";
+import { Button } from "@fiftyone/components";
+
+const BaseContainer = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-direction: row;
+`;
+
+const Container = styled(SamplesHeader)`
+  height: 30vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-direction: column;
+`;
+
+const TextContainer = styled(Container)`
+  height: 100%;
+  width: 100%;
+  position: relative;
+  justify-content: end;
+`;
+
+const ActionContainer = styled(TextContainer)`
+  justify-content: start;
+  display: flex;
+  position: relative;
+`;
+
+function EmptySamples() {
+  const loadedView = useRecoilValue<fos.State.Stage[]>(fos.view);
+  const totalSamples = useRecoilValue(
+    fos.count({ path: "", extended: false, modal: false })
+  );
+  const setView = fos.useSetView();
+
+  const showEmptySamples = useMemo(
+    () => loadedView?.length && !totalSamples,
+    [totalSamples, loadedView]
+  );
+
+  if (!showEmptySamples) return null;
+  return (
+    <Container>
+      <TextContainer>
+        <Typography variant="h6" component="span">
+          Your view is empty :-|
+        </Typography>
+      </TextContainer>
+      <ActionContainer>
+        <Button aria-label="clear-filters" onClick={() => setView([], [])}>
+          <BaseContainer style={{ padding: "0.25rem" }}>
+            <BaseContainer>
+              <Typography variant="body1" component="span">
+                Clear view
+              </Typography>
+            </BaseContainer>
+            <ClearAll sx={{ ml: ".5rem" }} />
+          </BaseContainer>
+        </Button>
+      </ActionContainer>
+    </Container>
+  );
+}
+
+export default React.memo(EmptySamples);

--- a/app/packages/core/src/components/ImageContainerHeader.tsx
+++ b/app/packages/core/src/components/ImageContainerHeader.tsx
@@ -15,7 +15,7 @@ import * as fos from "@fiftyone/state";
 import { groupStatistics, isGroup } from "@fiftyone/state";
 import LoadingDots from "../../../components/src/components/Loading/LoadingDots";
 
-const SamplesHeader = styled.div`
+export const SamplesHeader = styled.div`
   position: absolute;
   top: 0;
   display: flex;

--- a/app/packages/core/src/components/index.ts
+++ b/app/packages/core/src/components/index.ts
@@ -2,5 +2,6 @@ export * from "./Actions";
 export { default as Loading } from "./Loading";
 export { default as Setup } from "./Setup";
 export { default as Dataset } from "./Dataset";
+export { default as EmptySamples } from "./EmptySamples";
 export { default as ViewBar } from "./ViewBar/ViewBar";
 export { default as FieldLabelAndInfo } from "./FieldLabelAndInfo";

--- a/app/packages/core/src/plugins/samples.tsx
+++ b/app/packages/core/src/plugins/samples.tsx
@@ -7,6 +7,7 @@ import Grid from "../components/Grid";
 import ContainerHeader from "../components/ImageContainerHeader";
 import * as fos from "@fiftyone/state";
 import { FilterAndSelectionIndicator } from "@fiftyone/components";
+import { EmptySamples } from "../components";
 
 const FlashlightContainer = styled.div`
   position: relative;
@@ -20,6 +21,7 @@ registerComponent({
   component: () => (
     <FlashlightContainer>
       <Grid key={"grid"} />
+      <EmptySamples />
       <ContainerHeader key={"header"} />
     </FlashlightContainer>
   ),


### PR DESCRIPTION

<img width="1137" alt="Screen Shot 2023-03-08 at 3 55 09 PM" src="https://user-images.githubusercontent.com/109545780/223880046-cc2e9022-eb64-469d-9940-0e992412b62a.png">
<img width="1138" alt="Screen Shot 2023-03-08 at 3 55 15 PM" src="https://user-images.githubusercontent.com/109545780/223880050-d8221ea6-3f56-4000-83aa-b77057d793c6.png">
## What changes are proposed in this pull request?

Shows an Empty component for when there are no samples in a dataset or there are no samples in the given view.


<img width="1138" alt="Screen Shot 2023-03-08 at 3 54 52 PM" src="https://user-images.githubusercontent.com/109545780/223880031-289559d8-3d59-4148-82f2-4ae37eaad300.png">
<img width="1141" alt="Screen Shot 2023-03-08 at 3 54 57 PM" src="https://user-images.githubusercontent.com/109545780/223880044-a80c2662-663d-4d5f-af73-bbe8c2882583.png">

(Please fill in changes proposed in this fix)

## How is this patch tested? If it is not, please explain why.

(Details)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
