### PR TITLE
Bugfix: url is rendered in wrong type in sidebar

### DIFF
--- a/app/packages/core/src/components/Sidebar/Entries/PathValueEntry.tsx
+++ b/app/packages/core/src/components/Sidebar/Entries/PathValueEntry.tsx
@@ -218,7 +218,7 @@ const Loadable = ({ path }: { path: string }) => {
   const { ftype } = useRecoilValue(fos.field(path));
   const color = useRecoilValue(fos.pathColor({ path, modal: true }));
   const timeZone = useRecoilValue(fos.timeZone);
-  const formatted = format({ ftype, value, timeZone })?.toString();
+  const formatted = format({ ftype, value, timeZone });
 
   return <div style={none ? { color } : {}}>{none ? "None" : formatted}</div>;
 };


### PR DESCRIPTION
`format` method creates a link with the url and should not be rendered as a string

## What changes are proposed in this pull request?

![Screenshot 2023-03-06 at 4 46 24 PM](https://user-images.githubusercontent.com/17770824/223271405-3800135b-a52c-4c0f-8c92-512a351a0edc.png)


## How is this patch tested? If it is not, please explain why.

(Details)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
