### PR TITLE
bugfix: use wildcard pattern matching in app

### DIFF
--- a/fiftyone/server/routes/values.py
+++ b/fiftyone/server/routes/values.py
@@ -5,14 +5,14 @@ FiftyOne Server /values route
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+import regex as re
 from starlette.endpoints import HTTPEndpoint
 from starlette.requests import Request
 
 import fiftyone.core.aggregations as foa
-
 import fiftyone.server.constants as foc
-from fiftyone.server.decorators import route
 import fiftyone.server.view as fosv
+from fiftyone.server.decorators import route
 
 
 class Values(HTTPEndpoint):
@@ -36,13 +36,20 @@ class Values(HTTPEndpoint):
 
         sort_by = "count" if count else "_id"
 
+        # escape special characters, add support for wilcard pattern matching
+        regex_safe_search = (
+            re.escape(search).replace(r"\*", ".*").replace(r"\?", ".")
+            if search
+            else None
+        )
+
         count, first = await view._async_aggregate(
             foa.CountValues(
                 path,
                 _first=limit,
                 _asc=asc,
                 _sort_by=sort_by,
-                _search=search,
+                _search=regex_safe_search,
                 _selected=selected,
             )
         )


### PR DESCRIPTION
## What changes are proposed in this pull request?

Currently we use regex matching for string fields (like `id`, `filepath`, etc.). It breaks the app when the user enters invalid regex, example: `*`. This PR includes a fix such that we use wildcard matching instead of regex matching.

## How is this patch tested? If it is not, please explain why.

Tested locally. No automated tests.

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
