### PR TITLE
Apply extended stages before filters in extended view

### DIFF
--- a/fiftyone/server/mutation.py
+++ b/fiftyone/server/mutation.py
@@ -36,9 +36,6 @@ def _build_result_view(result_view, form):
             result_view, form.sample_ids
         )
 
-    if form.extended:
-        result_view = extend_view(result_view, form.extended, True)
-
     if form.add_stages:
         for d in form.add_stages:
             stage = fos.ViewStage._from_dict(d)
@@ -197,10 +194,13 @@ class Mutation:
                 dataset_name,
                 stages=view if view else None,
                 filters=form.filters if form else None,
+                extended_stages=form.extended if form else None,
+                sort=True,
             )
 
-        # Set view state
         result_view = _build_result_view(result_view, form)
+
+        # Set view state
         slug = (
             fou.to_slug(result_view.name)
             if result_view.name
@@ -287,10 +287,12 @@ class Mutation:
             dataset_name,
             stages=view_stages if view_stages else None,
             filters=form.filters if form else None,
+            extended_stages=form.extended if form else None,
+            sort=True,
         )
-        # view arg required to be an instance of
-        # `fiftyone.core.view.DatasetView`
+
         result_view = _build_result_view(dataset_view, form)
+
         dataset.save_view(
             view_name, result_view, description=description, color=color
         )

--- a/fiftyone/server/view.py
+++ b/fiftyone/server/view.py
@@ -151,13 +151,17 @@ def get_extended_view(
         extended_stages (None): extended view stages
         sort (False): wheter to include sort extended stages
 
-    The function returns a fiftyone.core.collections.SampleCollection
+    Returns:
+        a :class:`fiftyone.core.view.DatasetView`
     """
     cleanup_fields = set()
     filtered_labels = set()
-
     label_tags = None
-    if filters is not None and len(filters):
+
+    if extended_stages:
+        view = extend_view(view, extended_stages, sort)
+
+    if filters:
         if "tags" in filters:
             tags = filters.get("tags")
             if "label" in tags:
@@ -178,9 +182,6 @@ def get_extended_view(
 
         for stage in stages:
             view = view.add_stage(stage)
-
-    if extended_stages:
-        view = extend_view(view, extended_stages, sort)
 
     if count_label_tags:
         view = _add_labels_tags_counts(view, filtered_labels, label_tags)


### PR DESCRIPTION
Resolves https://github.com/voxel51/fiftyone/issues/2710.

Applies extended stages (panel selections, similarity sorts) before sidebar filters when constructing the extended view.

In general, since view stages are applied serially in a pipeline, we may have to update the extended view logic to remember the order in which the user's operations were performed in order to produce exactly the view they are looking at.

HOWEVER, the only extended view stages that we currently use operate solely based on _selecting_ sample/label IDs, so, for now, it's true that putting them first and then applying filters will always match what the user is looking at in the grid.