### PR TITLE
[Bugfix] Error when pressing enter twice

### DIFF
--- a/app/packages/core/src/components/Actions/Checker.tsx
+++ b/app/packages/core/src/components/Actions/Checker.tsx
@@ -194,7 +194,7 @@ const Checker = ({
       setActive(names[index]);
     }
 
-    if (e.key === "Enter" && active.length) {
+    if (e.key === "Enter" && active?.length) {
       createSubmit({
         name: active,
         changes,

--- a/docs/source/recipes/custom_exporter.ipynb
+++ b/docs/source/recipes/custom_exporter.ipynb
@@ -390,9 +390,9 @@
      "output_type": "stream",
      "text": [
       "total 168\r\n",
-      "drwxr-xr-x     4 voxel51  wheel   128B Jul 14 22:46 \u001b[34m.\u001b[m\u001b[m\r\n",
-      "drwxr-xr-x     3 voxel51  wheel    96B Jul 14 22:46 \u001b[34m..\u001b[m\u001b[m\r\n",
-      "drwxr-xr-x  1002 voxel51  wheel    31K Jul 14 22:46 \u001b[34mdata\u001b[m\u001b[m\r\n",
+      "drwxr-xr-x     4 voxel51  wheel   128B Jul 14 22:46 \u001B[34m.\u001B[m\u001B[m\r\n",
+      "drwxr-xr-x     3 voxel51  wheel    96B Jul 14 22:46 \u001B[34m..\u001B[m\u001B[m\r\n",
+      "drwxr-xr-x  1002 voxel51  wheel    31K Jul 14 22:46 \u001B[34mdata\u001B[m\u001B[m\r\n",
       "-rw-r--r--     1 voxel51  wheel    83K Jul 14 22:46 labels.csv\r\n"
      ]
     }

--- a/docs/source/recipes/custom_exporter.ipynb
+++ b/docs/source/recipes/custom_exporter.ipynb
@@ -390,9 +390,9 @@
      "output_type": "stream",
      "text": [
       "total 168\r\n",
-      "drwxr-xr-x     4 voxel51  wheel   128B Jul 14 22:46 \u001B[34m.\u001B[m\u001B[m\r\n",
-      "drwxr-xr-x     3 voxel51  wheel    96B Jul 14 22:46 \u001B[34m..\u001B[m\u001B[m\r\n",
-      "drwxr-xr-x  1002 voxel51  wheel    31K Jul 14 22:46 \u001B[34mdata\u001B[m\u001B[m\r\n",
+      "drwxr-xr-x     4 voxel51  wheel   128B Jul 14 22:46 \u001b[34m.\u001b[m\u001b[m\r\n",
+      "drwxr-xr-x     3 voxel51  wheel    96B Jul 14 22:46 \u001b[34m..\u001b[m\u001b[m\r\n",
+      "drwxr-xr-x  1002 voxel51  wheel    31K Jul 14 22:46 \u001b[34mdata\u001b[m\u001b[m\r\n",
       "-rw-r--r--     1 voxel51  wheel    83K Jul 14 22:46 labels.csv\r\n"
      ]
     }


### PR DESCRIPTION
## What changes are proposed in this pull request?

Throws error when tapping enter a second time in add label tag popover

<img width="961" alt="Pasted Graphic" src="https://user-images.githubusercontent.com/30936736/224181274-5a7abb2a-fa5e-459f-893e-228eaa74c2bf.png">

## How is this patch tested? If it is not, please explain why.

(Details)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
