### PR TITLE
Group modal  and orthographic projection improvements

### DIFF
--- a/app/packages/core/src/components/Group/Group.tsx
+++ b/app/packages/core/src/components/Group/Group.tsx
@@ -205,7 +205,7 @@ const Column: React.FC = () => {
           ...opts,
           selected: snapshot.getLoadable(fos.selectedSamples).contents.has(id),
           highlight:
-            (await snapshot.getPromise(fos.mainGroupSample))?._id === id,
+            (await snapshot.getPromise(fos.groupSample(null)))?._id === id,
         });
       },
     [opts]

--- a/app/packages/core/src/components/GroupSliceSelector.tsx
+++ b/app/packages/core/src/components/GroupSliceSelector.tsx
@@ -20,6 +20,7 @@ const GroupSlice: React.FC = () => {
 
   /**
    * this effect syncs the session slice with the default slice on component load
+   * (todo: rm network side effect and move to session subscription initialization)
    */
   useEffect(() => {
     setSlice(defaultSlice);

--- a/app/packages/core/src/components/GroupSliceSelector.tsx
+++ b/app/packages/core/src/components/GroupSliceSelector.tsx
@@ -5,7 +5,7 @@ import {
   groupSlices,
   useSetGroupSlice,
 } from "@fiftyone/state";
-import React, { useCallback } from "react";
+import React, { useCallback, useEffect } from "react";
 import { useRecoilValue } from "recoil";
 
 const Slice: React.FC<{ value: string; className: string }> = ({ value }) => {
@@ -17,6 +17,15 @@ const GroupSlice: React.FC = () => {
   const defaultSlice = useRecoilValue(defaultGroupSlice);
   const setSlice = useSetGroupSlice();
   const groupSlicesValue = useRecoilValue(groupSlices);
+
+  /**
+   * this effect syncs the session slice with the default slice on component load
+   */
+  useEffect(() => {
+    setSlice(defaultSlice);
+    // only run on mount, setSlice dependency should be stable but somehow changes on every render (todo: fix)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [defaultSlice]);
 
   const useSearch = useCallback(
     (search: string) => {

--- a/app/packages/core/src/components/Sidebar/Sidebar.tsx
+++ b/app/packages/core/src/components/Sidebar/Sidebar.tsx
@@ -436,7 +436,6 @@ const InteractiveSidebar = ({
   const [containerController] = useState(
     () => new Controller({ minHeight: 0 })
   );
-  const loadedDatasetName = useRecoilValue<string>(fos.datasetName);
 
   if (entries instanceof Error) {
     throw entries;

--- a/app/packages/state/src/hooks/useCreateLooker.ts
+++ b/app/packages/state/src/hooks/useCreateLooker.ts
@@ -12,7 +12,7 @@ import {
 import { useCallback, useRef } from "react";
 import { useErrorHandler } from "react-error-boundary";
 import { useRecoilValue } from "recoil";
-import { mainGroupSample, selectedMediaField } from "../recoil";
+import { groupSample, selectedMediaField } from "../recoil";
 
 import { SampleData, selectedSamples } from "../recoil/atoms";
 import * as schemaAtoms from "../recoil/schema";
@@ -32,7 +32,7 @@ export default <T extends FrameLooker | ImageLooker | VideoLooker>(
   const isFrame = useRecoilValue(viewAtoms.isFramesView);
   const isPatch = useRecoilValue(viewAtoms.isPatchesView);
   const handleError = useErrorHandler();
-  const activeId = isModal ? useRecoilValue(mainGroupSample)._id : null;
+  const activeId = isModal ? useRecoilValue(groupSample(null))._id : null;
 
   const view = useRecoilValue(viewAtoms.view);
   const dataset = useRecoilValue(datasetName);

--- a/app/packages/state/src/recoil/atoms.ts
+++ b/app/packages/state/src/recoil/atoms.ts
@@ -213,7 +213,7 @@ export const alpha = atomFamily<number, boolean>({
 
 export const colorSeed = atomFamily<number, boolean>({
   key: "colorSeed",
-  default: 1,
+  default: 0,
 });
 
 export const appTeamsIsOpen = atom({

--- a/app/packages/state/src/recoil/groups.ts
+++ b/app/packages/state/src/recoil/groups.ts
@@ -8,10 +8,11 @@ import {
   pinnedSampleQuery,
 } from "@fiftyone/relay";
 
-import { atom, atomFamily, selector, selectorFamily } from "recoil";
 import { VariablesOf } from "react-relay";
+import { atom, atomFamily, selector, selectorFamily } from "recoil";
 
-import { graphQLSelector } from "recoil-relay";
+import { graphQLSelector, graphQLSelectorFamily } from "recoil-relay";
+import type { ResponseFrom } from "../utils";
 import {
   AppSample,
   dataset,
@@ -23,7 +24,8 @@ import {
 import { RelayEnvironmentKey } from "./relay";
 import { datasetName } from "./selectors";
 import { view } from "./view";
-import type { ResponseFrom } from "../utils";
+
+type SliceName = string | undefined | null;
 
 export const isGroup = selector<boolean>({
   key: "isGroup",
@@ -62,9 +64,6 @@ export const groupSlices = selector<string[]>({
   key: "groupSlices",
   get: ({ get }) => {
     return get(groupMediaTypes)
-      .filter(
-        ({ mediaType }) => !["point_cloud", "point-cloud"].includes(mediaType)
-      )
       .map(({ name }) => name)
       .sort();
   },
@@ -210,44 +209,53 @@ export const activeModalSample = selector<
   },
 });
 
-const mainSampleQuery = graphQLSelector<
+const groupSampleQuery = graphQLSelectorFamily<
   VariablesOf<mainSampleQueryGraphQL>,
+  SliceName,
   ResponseFrom<mainSampleQueryGraphQL>
 >({
   environment: RelayEnvironmentKey,
   key: "mainSampleQuery",
   mapResponse: (response) => response,
   query: mainSample,
-  variables: ({ get }) => {
-    return {
-      view: get(view),
-      dataset: get(dataset).name,
-      filter: {
-        group: {
-          slice: get(groupSlice(true)),
-          id: get(modal).sample[get(groupField)]._id,
+  variables:
+    (slice) =>
+    ({ get }) => {
+      return {
+        view: get(view),
+        dataset: get(dataset).name,
+        filter: {
+          group: {
+            slice: slice ?? get(groupSlice(true)),
+            id: get(modal).sample[get(groupField)]._id,
+          },
         },
-      },
-    };
-  },
+      };
+    },
 });
 
-export const mainGroupSample = selector<AppSample>({
+export const groupSample = selectorFamily<AppSample, SliceName>({
   key: "mainGroupSample",
-  get: ({ get }) => {
-    const field = get(groupField);
-    const group = get(isGroup);
+  get:
+    (sliceName) =>
+    ({ get }) => {
+      if (sliceName) {
+        return get(groupSampleQuery(sliceName)).sample.sample as AppSample;
+      }
 
-    const sample = get(modal).sample;
+      const field = get(groupField);
+      const group = get(isGroup);
 
-    if (!field || !group) return sample;
+      const sample = get(modal).sample;
 
-    if (sample[field].name === get(groupSlice(true))) {
-      return sample;
-    }
+      if (!field || !group) return sample;
 
-    return get(mainSampleQuery).sample.sample as AppSample;
-  },
+      if (sample[field].name === get(groupSlice(true))) {
+        return sample;
+      }
+
+      return get(groupSampleQuery(sliceName)).sample.sample as AppSample;
+    },
 });
 
 export const groupStatistics = atomFamily<"group" | "slice", boolean>({

--- a/app/packages/state/src/recoil/modal.ts
+++ b/app/packages/state/src/recoil/modal.ts
@@ -1,12 +1,12 @@
 import { selector } from "recoil";
 import { sidebarOverride } from "./atoms";
-import { mainGroupSample } from "./groups";
+import { groupSample } from "./groups";
 
 export const sidebarSampleId = selector({
   key: "sidebarSampleId",
   get: ({ get }) => {
     const override = get(sidebarOverride);
 
-    return override ? override : get(mainGroupSample)._id;
+    return override ? override : get(groupSample(null))._id;
   },
 });

--- a/fiftyone/utils/utils3d.py
+++ b/fiftyone/utils/utils3d.py
@@ -531,8 +531,8 @@ def compute_orthographic_projection_images(
 
     if out_group_slice is not None:
         out_samples = []
-    else:
-        all_metadata = []
+
+    all_metadata = []
 
     with fou.ProgressBar(total=len(filepaths)) as pb:
         for filepath, group in pb(zip(filepaths, groups)):
@@ -557,15 +557,14 @@ def compute_orthographic_projection_images(
                 sample = fos.Sample(filepath=image_path)
                 sample[group_field] = group.element(out_group_slice)
                 sample[metadata_field] = metadata
-
                 out_samples.append(sample)
-            else:
-                all_metadata.append(metadata)
+
+            all_metadata.append(metadata)
 
     if out_group_slice is not None:
         samples.add_samples(out_samples)
-    else:
-        point_cloud_view.set_values(metadata_field, all_metadata)
+
+    point_cloud_view.set_values(metadata_field, all_metadata)
 
 
 def compute_orthographic_projection_image(


### PR DESCRIPTION
## What changes are proposed in this pull request?
- Show pointcloud slice selector in group datasets (also resolves #2722)
- Address a number of bugs in grouped datasets

### Known issues
- Pinned slice persists in the looker when switching samples, but not in the sidebar. Not a regression.
  - It didn't use to persist in the looker as well, but that has been fixed.
- Orthographic projection metadata, if calculated, is only available in the pointcloud slice. However, the sidebar shows this field for all slices. This can create a confusing experience. Not a regression.
- Projected bounding boxes are painted off the center once in a blue moon-ly. I haven't been able to reproduce this but I'll dive deeper in next iteration. Not a regression.
- Nit: Group dataset primitives and state management need some rethinking and refactoring. Atoms and selectors are scattered across multiple places and it's usually not clear how different states are related, or when certain state updates take place.

### Regression Testing
- Test with `quickstart` dataset.
- Test with `quickstart-groups` dataset.
  - Without calculating orthographic projection, for each slice, expand a sample and navigate prev/next. Change pinned sample and navigate prev/next.
  - Repeat above but calculate orthographic projection first.


## How is this patch tested? If it is not, please explain why.

Locally. No automated testing.

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

Refer to #2660

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
