### PR TITLE
move tooltip from looker2D to modal

### DIFF
--- a/app/packages/components/src/components/Tooltip/Tooltip.tsx
+++ b/app/packages/components/src/components/Tooltip/Tooltip.tsx
@@ -1,10 +1,10 @@
+import { AnimatePresence, motion } from "framer-motion";
 import * as React from "react";
-import { useLayer, useHover, Arrow } from "react-laag";
-import { motion, AnimatePresence } from "framer-motion";
+import { Arrow, useHover, useLayer } from "react-laag";
 import { PlacementType } from "react-laag/dist/PlacementType";
 
-import style from "./Tooltip.module.css";
 import { useTheme } from "../..";
+import style from "./Tooltip.module.css";
 
 const Tooltip: React.FC<{
   children: React.ReactElement;

--- a/app/packages/core/src/components/Modal/Bars.tsx
+++ b/app/packages/core/src/components/Modal/Bars.tsx
@@ -1,5 +1,5 @@
 import { Bar, useTheme } from "@fiftyone/components";
-import { VideoLooker } from "@fiftyone/looker";
+import { AbstractLooker, VideoLooker } from "@fiftyone/looker";
 import * as fos from "@fiftyone/state";
 import { currentSlice, hasPinnedSlice } from "@fiftyone/state";
 import { Checkbox } from "@mui/material";
@@ -46,7 +46,7 @@ const SelectableBar: React.FC<
 
 export const SampleBar: React.FC<{
   sampleId: string;
-  lookerRef: React.MutableRefObject<VideoLooker | undefined>;
+  lookerRef: React.MutableRefObject<AbstractLooker | undefined>;
   visible?: boolean;
   hoveringRef: MutableRefObject<boolean>;
 }> = ({ hoveringRef, lookerRef, sampleId, visible }) => {

--- a/app/packages/core/src/components/Modal/Group.tsx
+++ b/app/packages/core/src/components/Modal/Group.tsx
@@ -125,7 +125,8 @@ const useSlice = (sample: any): string => {
 
 const DefaultGroupSample: React.FC<{
   lookerRef: MutableRefObject<VideoLooker | undefined>;
-}> = ({ lookerRef }) => {
+  lookerRefCallback?: (looker) => void;
+}> = ({ lookerRef, lookerRefCallback }) => {
   const defaultSlice = useRecoilValue(defaultGroupSlice);
   const sample = useRecoilValue(groupSampleSelectorFamily(defaultSlice));
   const clearModal = useClearModal();
@@ -145,6 +146,7 @@ const DefaultGroupSample: React.FC<{
         key={sample._id}
         sample={sample}
         lookerRef={lookerRef}
+        lookerRefCallback={lookerRefCallback}
         onClose={clearModal}
       />
     </GroupSample>
@@ -153,7 +155,8 @@ const DefaultGroupSample: React.FC<{
 
 const MainSample: React.FC<{
   lookerRef: MutableRefObject<VideoLooker | undefined>;
-}> = ({ lookerRef }) => {
+  lookerRefCallback?: (looker) => void;
+}> = ({ lookerRef, lookerRefCallback }) => {
   const sample = useRecoilValue(groupSampleSelectorFamily(null));
   const currentModalSlice = useRecoilValue(currentSlice(true));
   const clearModal = useClearModal();
@@ -181,6 +184,7 @@ const MainSample: React.FC<{
         sample={sample}
         key={sample._id}
         lookerRef={lookerRef}
+        lookerRefCallback={lookerRefCallback}
         onClose={clearModal}
       />
     </GroupSample>
@@ -248,7 +252,9 @@ const PinnedSample: React.FC = () => {
   );
 };
 
-const DualView: React.FC = () => {
+const DualView: React.FC<{ lookerRefCallback?: (looker) => void }> = ({
+  lookerRefCallback,
+}) => {
   const lookerRef = useRef<VideoLooker>();
   const theme = useTheme();
   const key = useRecoilValue(groupId);
@@ -318,7 +324,10 @@ const DualView: React.FC = () => {
 
             {isImageVisible ? (
               <PixelatingSuspense>
-                <MainSample lookerRef={lookerRef} />
+                <MainSample
+                  lookerRef={lookerRef}
+                  lookerRefCallback={lookerRefCallback}
+                />
               </PixelatingSuspense>
             ) : is3DVisible ? (
               <PixelatingSuspense>
@@ -344,21 +353,23 @@ const DualView: React.FC = () => {
   );
 };
 
-const Group: React.FC = () => {
+const Group: React.FC<{ lookerRefCallback: (looker) => void }> = ({
+  lookerRefCallback,
+}) => {
   const hasPinned = useRecoilValue(hasPinnedSlice);
   const key = useRecoilValue(groupId);
 
   if (!hasPinned) {
     return (
       <>
-        <GroupList key={key} /> <Sample />
+        <GroupList key={key} /> <Sample lookerRefCallback={lookerRefCallback} />
       </>
     );
   }
 
   return (
     <Suspense>
-      <DualView />
+      <DualView lookerRefCallback={lookerRefCallback} />
     </Suspense>
   );
 };

--- a/app/packages/core/src/components/Modal/Sample.tsx
+++ b/app/packages/core/src/components/Modal/Sample.tsx
@@ -1,11 +1,13 @@
-import { VideoLooker } from "@fiftyone/looker";
+import { AbstractLooker, VideoLooker } from "@fiftyone/looker";
 import { modal, useClearModal, useHoveredSample } from "@fiftyone/state";
 import React, { MutableRefObject, useCallback, useRef, useState } from "react";
 import { useRecoilValue } from "recoil";
 import { SampleBar } from "./Bars";
 import Looker from "./Looker";
 
-const Sample: React.FC = () => {
+const Sample: React.FC<{
+  lookerRefCallback: (looker: AbstractLooker) => void;
+}> = ({ lookerRefCallback }) => {
   const data = useRecoilValue(modal);
 
   if (!data) {
@@ -50,7 +52,12 @@ const Sample: React.FC = () => {
         visible={hovering}
         hoveringRef={hoveringRef}
       />
-      <Looker key={_id} lookerRef={lookerRef} onClose={clearModal} />
+      <Looker
+        key={_id}
+        lookerRef={lookerRef}
+        lookerRefCallback={lookerRefCallback}
+        onClose={clearModal}
+      />
     </div>
   );
 };


### PR DESCRIPTION
## What changes are proposed in this pull request?

Currently the tooltip doesn't show for 3D labels if looker2D is not in context. This PR fixes that. Also closes #2723.

![2023-03-10 09 37 40](https://user-images.githubusercontent.com/66688606/224358760-42f7e2e4-6d87-4fdd-bd67-265f867c068e.gif)

Note to the reviewer: `lookerRefCallback` is a callback prop that, when invoked, sets the ref. More on it: https://github.com/voxel51/fiftyone/pull/2766/files#diff-59872f6c92cd7fab33aaf4419234215cac6c621914dc9a321c36980e87a62917R253

## How is this patch tested? If it is not, please explain why.

Locally. No automated tests.

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
