### PR TITLE
Fix sidebar metadata inconsistency in group modal 

### DIFF
--- a/app/packages/core/src/components/Modal/Group.tsx
+++ b/app/packages/core/src/components/Modal/Group.tsx
@@ -169,7 +169,12 @@ const MainSample: React.FC<{
     sample._media_type === "point-cloud" &&
     currentModalSlice === sample.group.name
   ) {
-    return <DefaultGroupSample lookerRef={lookerRef} />;
+    return (
+      <DefaultGroupSample
+        lookerRef={lookerRef}
+        lookerRefCallback={lookerRefCallback}
+      />
+    );
   }
 
   return (

--- a/app/packages/core/src/components/Modal/Modal.tsx
+++ b/app/packages/core/src/components/Modal/Modal.tsx
@@ -219,13 +219,10 @@ const SampleModal = () => {
   const keyboardHandler = useCallback(
     (e: KeyboardEvent) => {
       if (e.key === "ArrowLeft") {
-        e.preventDefault();
         navigatePrevious();
       } else if (e.key === "ArrowRight") {
-        e.preventDefault();
         navigateNext();
       } else if (e.key === "c") {
-        e.preventDefault();
         setIsNavigationHidden((prev) => !prev);
       }
       // note: don't stop event propagation here

--- a/app/packages/core/src/components/Sidebar/Entries/PathValueEntry.tsx
+++ b/app/packages/core/src/components/Sidebar/Entries/PathValueEntry.tsx
@@ -206,8 +206,9 @@ const LengthLoadable = ({ path }: { path: string }) => {
 const ListLoadable = ({ path }: { path: string }) => {
   const data = useData<any[]>(path);
   const values = useMemo(() => {
-    let d = Array.from(data);
-    return data ? d.map((value) => prettify(value as string)) : [];
+    return data
+      ? Array.from(data).map((value) => prettify(value as string))
+      : [];
   }, [data]);
 
   return (

--- a/app/packages/core/src/components/Sidebar/Entries/PathValueEntry.tsx
+++ b/app/packages/core/src/components/Sidebar/Entries/PathValueEntry.tsx
@@ -2,7 +2,6 @@ import { useTheme } from "@fiftyone/components";
 import {
   DATE_FIELD,
   DATE_TIME_FIELD,
-  Field,
   formatDate,
   formatDateTime,
   FRAME_SUPPORT_FIELD,
@@ -21,11 +20,10 @@ import { prettify } from "../../../utils/generic";
 import * as fos from "@fiftyone/state";
 import { NameAndCountContainer } from "../../utils";
 
-import RegularEntry from "./RegularEntry";
-import FieldLabelAndInfo from "../../FieldLabelAndInfo";
 import LoadingDots from "../../../../../components/src/components/Loading/LoadingDots";
+import FieldLabelAndInfo from "../../FieldLabelAndInfo";
+import RegularEntry from "./RegularEntry";
 import { makePseudoField } from "./utils";
-import Checkbox from "../../Common/Checkbox";
 
 const ScalarDiv = styled.div`
   & > div {
@@ -235,7 +233,9 @@ const Loadable = ({ path }: { path: string }) => {
 
 const useData = <T extends unknown>(path: string): T => {
   const keys = path.split(".");
-  let data = useRecoilValue(fos.activeModalSample);
+  const activeSlice = useRecoilValue(fos.currentSlice(true));
+
+  let data = useRecoilValue(fos.activeModalSample(activeSlice));
 
   let field = useRecoilValue(fos.field(keys[0]));
 

--- a/app/packages/looker-3d/src/state.ts
+++ b/app/packages/looker-3d/src/state.ts
@@ -50,7 +50,7 @@ export const currentActionAtom = atom<Actions>({
 
 export const currentPointSizeAtom = atom<string>({
   key: "pointSize",
-  default: "1",
+  default: "2",
   effects: [getBrowserStorageEffectForKey("pointSize")],
 });
 

--- a/app/packages/state/src/recoil/groups.ts
+++ b/app/packages/state/src/recoil/groups.ts
@@ -196,17 +196,20 @@ export const groupPaginationFragment = selector<paginateGroup_query$key>({
   get: ({ get }) => get(groupQuery),
 });
 
-export const activeModalSample = selector<
-  AppSample | ResponseFrom<pinnedSampleQuery>["sample"]
+export const activeModalSample = selectorFamily<
+  AppSample | ResponseFrom<pinnedSampleQuery>["sample"],
+  SliceName
 >({
   key: "activeModalSample",
-  get: ({ get }) => {
-    if (get(sidebarOverride)) {
-      return get(pinnedSliceSample).sample;
-    }
+  get:
+    (sliceName) =>
+    ({ get }) => {
+      if (get(sidebarOverride) || get(pinnedSlice) === sliceName) {
+        return get(pinnedSliceSample).sample;
+      }
 
-    return get(modal)?.sample;
-  },
+      return get(groupSample(sliceName));
+    },
 });
 
 const groupSampleQuery = graphQLSelectorFamily<

--- a/app/packages/state/src/recoil/groups.ts
+++ b/app/packages/state/src/recoil/groups.ts
@@ -204,6 +204,10 @@ export const activeModalSample = selectorFamily<
   get:
     (sliceName) =>
     ({ get }) => {
+      if (!sliceName || !get(isGroup)) {
+        return get(modalAtom).sample;
+      }
+
       if (get(sidebarOverride) || get(pinnedSlice) === sliceName) {
         return get(pinnedSliceSample).sample;
       }

--- a/app/packages/state/src/recoil/sidebar.ts
+++ b/app/packages/state/src/recoil/sidebar.ts
@@ -33,7 +33,7 @@ import {
 import { State } from "./types";
 import * as viewAtoms from "./view";
 import { datasetName, isVideoDataset, stateSubscription } from "./selectors";
-import { isLargeVideo, resolvedSidebarMode } from "./options";
+import { isLargeVideo } from "./options";
 import { commitMutation, VariablesOf } from "react-relay";
 import { setSidebarGroups, setSidebarGroupsMutation } from "@fiftyone/relay";
 import { getCurrentEnvironment } from "../hooks/useRouter";


### PR DESCRIPTION
## What changes are proposed in this pull request?

Ensure the integrity of group metadata in the sidebar as you navigate between different samples with different pinned slices.

Additional small changes not directly related to this PR:
1. Update point size default to 2 in looker 3d.
2. Don't "prevent default" when `c` is pressed.
3. Fix minor bugs introduced in #2766

## How is this patch tested? If it is not, please explain why.

Locally. 

1. Load quickstart dataset. Open a sample. Make sure everything looks normal in the sidebar. Navigate next/previous.
4. Load quickstart-groups dataset. For each slice, load a sample on the modal and see if filename + metadata + group metadata are correct. Group metadata is in the bottom of the modal sidebar.
5. Additionally, for each sample modal, alter between different slices from within the modal and make sure filename + metadata + group metadata are correct. 

Known issues:
- Sidebar labels (or any "filterables") reflect the dataset level slice and don't update correctly when different slices are chosen from within the modal. This is a prior bug I'm working on fixing and not a regression.

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
