### PR TITLE
fixes app crashing while filtering keypoints labels (view.py) & keypoints missing metrics

### DIFF
--- a/fiftyone/core/patches.py
+++ b/fiftyone/core/patches.py
@@ -23,7 +23,7 @@ import fiftyone.core.validation as fova
 import fiftyone.core.view as fov
 
 
-_PATCHES_TYPES = (fol.Detections, fol.Polylines)
+_PATCHES_TYPES = (fol.Detections, fol.Polylines, fol.Keypoints)
 _NO_MATCH_ID = ""
 
 

--- a/fiftyone/server/view.py
+++ b/fiftyone/server/view.py
@@ -626,12 +626,19 @@ def _make_keypoint_list_filter(args, view, path, field):
 
     if isinstance(field.field, (fof.FloatField, fof.IntField)):
         f = F(name)
-        mn, mx = args["range"]
-        expr = (f >= mn) & (f <= mx)
-        if args["exclude"]:
-            expr = ~expr
+        #adding support if filter will applied on categorical variable i.e. 'labels' 
+        k = F('labels')
+        if 'values' in args:
+            val = args["values"]
 
-        return {"filter": expr}
+            return {"filter": (k == val)}
+        else:
+            mn, mx = args["range"]
+            expr = (f >= mn) & (f <= mx)
+            if args["exclude"]:
+                expr = ~expr
+
+            return {"filter": expr}
 
 
 def _apply_others(expr, f, args, is_label):

--- a/fiftyone/utils/eval/detection.py
+++ b/fiftyone/utils/eval/detection.py
@@ -130,7 +130,7 @@ def evaluate_detections(
     fov.validate_collection_label_fields(
         samples,
         (pred_field, gt_field),
-        (fol.Detections, fol.Polylines, fol.TemporalDetections),
+        (fol.Detections, fol.Polylines, fol.TemporalDetections, fol.Keypoints),
         same_type=True,
     )
 

--- a/fiftyone/utils/iou.py
+++ b/fiftyone/utils/iou.py
@@ -17,6 +17,8 @@ import fiftyone.core.labels as fol
 import fiftyone.core.utils as fou
 import fiftyone.core.validation as fov
 
+from scipy.spatial import distance
+
 from .utils3d import compute_cuboid_iou as _compute_cuboid_iou
 
 sg = fou.lazy_import("shapely.geometry")
@@ -88,6 +90,11 @@ def compute_ious(
         return _compute_polyline_ious(
             preds, gts, error_level, iscrowd=iscrowd, classwise=classwise
         )
+
+    if isinstance(preds[0], fol.Keypoints):
+            return _compute_keypoint_similarity(
+                preds, gts, iscrowd=iscrowd, classwise=classwise
+            )
 
     if use_masks:
         # @todo when tolerance is None, consider using dense masks rather than
@@ -554,6 +561,28 @@ def _compute_polyline_ious(
                 ious[i, j] = iou
 
         return ious
+
+
+def _compute_keypoint_similarity(preds, gts, error_level, iscrowd=None, classwise=False, gt_crowds=None):
+    #calculate euclidean distance of each keypoint
+    sim_score = np.zeros((len(preds), len(gts)))
+
+    for j, gt in enumerate(gts):
+        for i, pt in enumerate(preds):
+            gt_points=[]
+            pt_points=[]
+            for x in gt['points']:
+                gt_points.append(x)
+            for y in pt['points']:
+                pt_points.append(y)
+
+            gt_points=sum(gt_points, [])
+
+            pt_points=sum(pt_points, [])
+
+            sim_score[i, j] = 1/(1 + distance.euclidean(tuple(gt_points),tuple(pt_points)))
+
+    return sim_score
 
 
 def _compute_mask_ious(


### PR DESCRIPTION

## What changes are proposed in this pull request?
1. Changes in fiftyone/server/view.py --> As the previous code looks only for numeric classes so when the user is filtering wrt. labels the app was crashing . Made the changes in func "_make_keypoint_list_filter" now code will able to handle those cases.
2. Added keypoints support where it was missing.
3. Created test metrics for keypoints.

## How is this patch tested? If it is not, please explain why.
its thoroughly tested on thousands of images.

## Release Notes
Keypoints filter bug fix and extended keypoints support.

### Is this a user-facing change that should be mentioned in the release notes?
Yes
<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)
Fixes app crashing while filtering keypoints labels & extended keypoints missing metrics. This change is specific to keypoints function only. The changes are made only on keypoints functions it is not interfering other functions. 

### What areas of FiftyOne does this PR affect?

-   [x ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x ] Core: Core `fiftyone` Python library changes
-   [ x] Documentation: FiftyOne documentation changes
-   [ ] Other
