### PR TITLE
Keypoints filter app crash fix

### DIFF
--- a/fiftyone/server/view.py
+++ b/fiftyone/server/view.py
@@ -640,6 +640,15 @@ def _make_keypoint_list_filter(args, view, path, field):
 
             return {"filter": expr}
 
+    if isinstance(field.field, (fof.StringField)):
+        f = F(name)
+        if 'values' in args:
+            val = args["values"]
+            expr = f.is_in(val)
+            if args["exclude"]:
+                expr = ~expr
+            return {"filter": expr}
+
 
 def _apply_others(expr, f, args, is_label):
     is_matching = args.get("isMatching", False)

--- a/fiftyone/server/view.py
+++ b/fiftyone/server/view.py
@@ -626,12 +626,19 @@ def _make_keypoint_list_filter(args, view, path, field):
 
     if isinstance(field.field, (fof.FloatField, fof.IntField)):
         f = F(name)
-        mn, mx = args["range"]
-        expr = (f >= mn) & (f <= mx)
-        if args["exclude"]:
-            expr = ~expr
+        #adding support if filter will applied on categorical variable i.e. 'labels' 
+        k = F('labels')
+        if 'values' in args:
+            val = args["values"]
 
-        return {"filter": expr}
+            return {"filter": (k == val)}
+        else:
+            mn, mx = args["range"]
+            expr = (f >= mn) & (f <= mx)
+            if args["exclude"]:
+                expr = ~expr
+
+            return {"filter": expr}
 
 
 def _apply_others(expr, f, args, is_label):

--- a/fiftyone/server/view.py
+++ b/fiftyone/server/view.py
@@ -626,19 +626,12 @@ def _make_keypoint_list_filter(args, view, path, field):
 
     if isinstance(field.field, (fof.FloatField, fof.IntField)):
         f = F(name)
-        #adding support if filter will applied on categorical variable i.e. 'label' 
-        k = F('labels')
-        if 'values' in args:
-            val = args["values"]
+        mn, mx = args["range"]
+        expr = (f >= mn) & (f <= mx)
+        if args["exclude"]:
+            expr = ~expr
 
-            return {"filter": (k == val)}
-        else:
-            mn, mx = args["range"]
-            expr = (f >= mn) & (f <= mx)
-            if args["exclude"]:
-                expr = ~expr
-
-            return {"filter": expr}
+        return {"filter": expr}
 
     if isinstance(field.field, (fof.StringField)):
         f = F(name)
@@ -647,6 +640,7 @@ def _make_keypoint_list_filter(args, view, path, field):
             expr = f.is_in(val)
             if args["exclude"]:
                 expr = ~expr
+                
             return {"filter": expr}
 
 

--- a/fiftyone/server/view.py
+++ b/fiftyone/server/view.py
@@ -626,7 +626,7 @@ def _make_keypoint_list_filter(args, view, path, field):
 
     if isinstance(field.field, (fof.FloatField, fof.IntField)):
         f = F(name)
-        #adding support if filter will applied on categorical variable i.e. 'labels' 
+        #adding support if filter will applied on categorical variable i.e. 'label' 
         k = F('labels')
         if 'values' in args:
             val = args["values"]


### PR DESCRIPTION
## What changes are proposed in this pull request?
Changes in fiftyone/server/view.py , added the case where filter is on categorical variable i.e. labels


## How is this patch tested? If it is not, please explain why.
Tested on thousand image.

## Release Notes
Keypoints apps filtering bug fix

### Is this a user-facing change that should be mentioned in the release notes?
No
<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)
Initially code was looking for Boolean as well as Numerical class only. Now added support for categorical variables i.e. labels. The code changes are done only on keypoints function. This change is not interfering with other applications.

### What areas of FiftyOne does this PR affect?

-   [x ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
