### PR TITLE
add optional dice score computation for evaluate_segmentations

### DIFF
--- a/fiftyone/utils/eval/segmentation.py
+++ b/fiftyone/utils/eval/segmentation.py
@@ -32,6 +32,7 @@ def evaluate_segmentations(
     eval_key=None,
     mask_targets=None,
     method="simple",
+    compute_dice=False,
     **kwargs,
 ):
     """Evaluates the specified semantic segmentation masks in the given
@@ -80,6 +81,8 @@ def evaluate_segmentations(
             labels. If not provided, the observed values are used as labels
         method ("simple"): a string specifying the evaluation method to use.
             Supported values are ``("simple")``
+        compute_dice (False): whether to compute the Dice coefficient for each
+            sample
         **kwargs: optional keyword arguments for the constructor of the
             :class:`SegmentationEvaluationConfig` being used
 
@@ -90,7 +93,9 @@ def evaluate_segmentations(
         samples, (pred_field, gt_field), fol.Segmentation, same_type=True
     )
 
-    config = _parse_config(pred_field, gt_field, method, **kwargs)
+    config = _parse_config(
+        pred_field, gt_field, method, compute_dice=compute_dice, **kwargs
+    )
     eval_method = config.build()
     eval_method.ensure_requirements()
 
@@ -256,11 +261,18 @@ class SimpleEvaluationConfig(SegmentationEvaluationConfig):
         return "simple"
 
     def __init__(
-        self, pred_field, gt_field, bandwidth=None, average="micro", **kwargs
+        self,
+        pred_field,
+        gt_field,
+        bandwidth=None,
+        average="micro",
+        compute_dice=False,
+        **kwargs,
     ):
         super().__init__(pred_field, gt_field, **kwargs)
         self.bandwidth = bandwidth
         self.average = average
+        self.compute_dice = compute_dice
 
 
 class SimpleEvaluation(SegmentationEvaluation):
@@ -297,11 +309,14 @@ class SimpleEvaluation(SegmentationEvaluation):
 
         bandwidth = self.config.bandwidth
         average = self.config.average
+        compute_dice = self.config.compute_dice
 
         if eval_key is not None:
             acc_field = "%s_accuracy" % eval_key
             pre_field = "%s_precision" % eval_key
             rec_field = "%s_recall" % eval_key
+            if compute_dice:
+                dice_field = "%s_dice" % eval_key
 
         logger.info("Evaluating segmentations...")
         for sample in _samples.iter_samples(progress=True):
@@ -340,6 +355,8 @@ class SimpleEvaluation(SegmentationEvaluation):
                     image[acc_field] = facc
                     image[pre_field] = fpre
                     image[rec_field] = frec
+                    if compute_dice:
+                        image[dice_field] = _dice_score(image_conf_mat)
 
             confusion_matrix += sample_conf_mat
 
@@ -351,6 +368,8 @@ class SimpleEvaluation(SegmentationEvaluation):
                 sample[acc_field] = sacc
                 sample[pre_field] = spre
                 sample[rec_field] = srec
+                if compute_dice:
+                    sample[dice_field] = _dice_score(confusion_matrix)
                 sample.save()
 
         if nc > 0:
@@ -437,13 +456,23 @@ class SegmentationResults(BaseEvaluationResults):
 
         return ytrue, ypred, weights
 
+    def dice_score(self):
+        """Returns the Dice score for all samples.
 
-def _parse_config(pred_field, gt_field, method, **kwargs):
+        Returns:
+            an overall Dice score
+        """
+        return _dice_score(self.pixel_confusion_matrix)
+
+
+def _parse_config(pred_field, gt_field, method, compute_dice, **kwargs):
     if method is None:
         method = "simple"
 
     if method == "simple":
-        return SimpleEvaluationConfig(pred_field, gt_field, **kwargs)
+        return SimpleEvaluationConfig(
+            pred_field, gt_field, compute_dice=compute_dice, **kwargs
+        )
 
     raise ValueError("Unsupported evaluation method '%s'" % method)
 
@@ -480,6 +509,22 @@ def _compute_pixel_confusion_matrix(
         # `skm.confusion_matrix` to raise an error
         num_classes = len(values)
         return np.zeros((num_classes, num_classes), dtype=int)
+
+
+def _dice_score(confusion_matrix):
+    """Computes the Dice score from a pixel confusion matrix.
+
+    Args:
+        confusion_matrix: a pixel value confusion matrix
+
+    Returns:
+        the Dice score
+    """
+    confusion_matrix = np.asarray(confusion_matrix)
+    tp = np.diag(confusion_matrix).sum()
+    fp = confusion_matrix.sum() - tp
+    fn = fp
+    return 2 * tp / (2 * tp + fp + fn)
 
 
 def _extract_contour_band_values(pred_mask, gt_mask, bandwidth):


### PR DESCRIPTION
## What changes are proposed in this pull request?

Dice score computation in `evaluate_segmentations`

## How is this patch tested? If it is not, please explain why.

Existing unit-test parametrized to `compute_dice=True/False`.

NOTE: I had to disable `pylint` for both `test_classification_results` tests as it was not kept up-to-date with the recent `ClassificationResults` changes. I can help with the fix as well if required. 

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

Dice score can be computed per sample when evaluating semantic segmentations.
Specify `evaluate_segmentation(..., compute_dice=True)` in order to add a sample field
with `{eval_key}_dice` to each sample or run calculation on a segmentation results object: `results.dice_score()` .

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [x] Documentation: FiftyOne documentation changes
-   [ ] Other
