### PR TITLE
Fix empty state loading

### DIFF
--- a/app/packages/core/src/components/EmptySamples.tsx
+++ b/app/packages/core/src/components/EmptySamples.tsx
@@ -43,6 +43,9 @@ export default function EmptySamples() {
   const totalSamples = useRecoilValue(
     fos.count({ path: "", extended: true, modal: false })
   );
+
+  console.log({ totalSamples });
+
   const theme = useTheme();
   const setView = fos.useSetView();
 

--- a/app/packages/core/src/components/EmptySamples.tsx
+++ b/app/packages/core/src/components/EmptySamples.tsx
@@ -38,10 +38,10 @@ const ActionContainer = styled(TextContainer)`
   position: relative;
 `;
 
-function EmptySamples() {
+export default function EmptySamples() {
   const loadedView = useRecoilValue<fos.State.Stage[]>(fos.view);
   const totalSamples = useRecoilValue(
-    fos.count({ path: "", extended: false, modal: false })
+    fos.count({ path: "", extended: true, modal: false })
   );
   const theme = useTheme();
   const setView = fos.useSetView();
@@ -109,4 +109,4 @@ function EmptySamples() {
   );
 }
 
-export default React.memo(EmptySamples);
+// export default React.memo(EmptySamples);

--- a/app/packages/core/src/components/Grid/Grid.tsx
+++ b/app/packages/core/src/components/Grid/Grid.tsx
@@ -1,4 +1,10 @@
-import React, { useEffect, useLayoutEffect, useMemo, useRef } from "react";
+import React, {
+  Suspense,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+} from "react";
 import { useRecoilCallback, useRecoilValue } from "recoil";
 import { v4 as uuid } from "uuid";
 
@@ -14,6 +20,7 @@ import useResize from "./useResize";
 
 import * as fos from "@fiftyone/state";
 import { deferrer, stringifyObj } from "@fiftyone/state";
+import EmptySamples from "../EmptySamples";
 
 const Grid: React.FC<{}> = () => {
   const [id] = React.useState(() => uuid());
@@ -170,7 +177,14 @@ const Grid: React.FC<{}> = () => {
     initialized.current = true;
   }, []);
 
-  return <div id={id} className={flashlightLooker}></div>;
+  return (
+    <>
+      <div id={id} className={flashlightLooker}></div>
+      <Suspense>
+        <EmptySamples />
+      </Suspense>
+    </>
+  );
 };
 
 export default Grid;

--- a/app/packages/core/src/components/Grid/Grid.tsx
+++ b/app/packages/core/src/components/Grid/Grid.tsx
@@ -177,14 +177,7 @@ const Grid: React.FC<{}> = () => {
     initialized.current = true;
   }, []);
 
-  return (
-    <>
-      <div id={id} className={flashlightLooker}></div>
-      <Suspense>
-        <EmptySamples />
-      </Suspense>
-    </>
-  );
+  return <div id={id} className={flashlightLooker}></div>;
 };
 
 export default Grid;

--- a/app/packages/core/src/plugins/samples.tsx
+++ b/app/packages/core/src/plugins/samples.tsx
@@ -1,6 +1,6 @@
 import { PluginComponentType, registerComponent } from "@fiftyone/plugins";
 import AppsIcon from "@mui/icons-material/Apps";
-import React from "react";
+import React, { Suspense } from "react";
 import { useRecoilValue, useResetRecoilState } from "recoil";
 import styled from "styled-components";
 import Grid from "../components/Grid";
@@ -21,7 +21,9 @@ registerComponent({
   component: () => (
     <FlashlightContainer>
       <Grid key={"grid"} />
-      <EmptySamples />
+      <Suspense>
+        <EmptySamples />
+      </Suspense>
       <ContainerHeader key={"header"} />
     </FlashlightContainer>
   ),

--- a/app/packages/core/src/plugins/samples.tsx
+++ b/app/packages/core/src/plugins/samples.tsx
@@ -21,9 +21,6 @@ registerComponent({
   component: () => (
     <FlashlightContainer>
       <Grid key={"grid"} />
-      <Suspense>
-        <EmptySamples />
-      </Suspense>
       <ContainerHeader key={"header"} />
     </FlashlightContainer>
   ),


### PR DESCRIPTION
Empty state was reloading and returning null even while loading. This caused several issues. 

 - empty state would not update/display when filters caused 0 results
 - when selecting samples in embeddings empty state would re-render in the loading state and cause issues with spaces (closing the embeddings tab)