### PR TITLE
Use dedicated media field for orthographic projection filepath

### DIFF
--- a/app/packages/state/src/hooks/useCreateLooker.ts
+++ b/app/packages/state/src/hooks/useCreateLooker.ts
@@ -82,8 +82,8 @@ export default <T extends FrameLooker | ImageLooker | VideoLooker>(
           )
           ?.at(0) as string | undefined;
         if (orthographicProjectionField) {
-          sampleMediaFilePath = sample[orthographicProjectionField][
-            "filepath"
+          sampleMediaFilePath = urls[
+            `${orthographicProjectionField}.filepath`
           ] as string;
         }
       }

--- a/fiftyone/server/metadata.py
+++ b/fiftyone/server/metadata.py
@@ -11,6 +11,8 @@ import shutil
 import struct
 import typing as t
 
+from functools import reduce
+
 import asyncio
 import aiofiles
 import strawberry as gql
@@ -55,23 +57,21 @@ async def get_metadata(
     """
     filepath = sample["filepath"]
     metadata = sample.get("metadata", None)
-    urls = _create_media_urls(collection, sample, url_cache)
 
-    has_orthographic_projection_metadata = False
-    orthographic_projection_field = collection.get_field_schema(
-        embedded_doc_type=OrthographicProjectionMetadata
+    orthographic_projection_metadata_field_name = (
+        _get_orthographic_projection_metadata_field_name(collection)
     )
 
-    if len(orthographic_projection_field) > 0 and (
-        media_type == fom.POINT_CLOUD or media_type == fom.GROUP
-    ):
-        has_orthographic_projection_metadata = True
-        orthographic_projection_metadata_field_name = next(
-            iter(orthographic_projection_field)
-        )
-        orthographic_projection_image_path = sample[
-            orthographic_projection_metadata_field_name
-        ]["filepath"]
+    urls = _create_media_urls(
+        collection,
+        sample,
+        url_cache,
+        additional_fields=[
+            f"{orthographic_projection_metadata_field_name}.filepath"
+        ]
+        if orthographic_projection_metadata_field_name
+        else None,
+    )
 
     is_video = media_type == fom.VIDEO
 
@@ -87,10 +87,6 @@ async def get_metadata(
                     aspect_ratio=width / height,
                     frame_rate=frame_rate,
                 )
-        elif has_orthographic_projection_metadata:
-            metadata_cache[filepath] = await read_metadata(
-                orthographic_projection_image_path, False
-            )
         else:
             width = metadata.get("width", None)
             height = metadata.get("height", None)
@@ -377,16 +373,54 @@ class FFmpegNotFoundException(RuntimeError):
 
 
 def _create_media_urls(
-    collection: SampleCollection, sample: t.Dict, cache: t.Dict
+    collection: SampleCollection,
+    sample: t.Dict,
+    cache: t.Dict,
+    additional_fields: t.Optional[t.List[str]] = None,
 ) -> t.Dict[str, str]:
     media_fields = collection.app_config.media_fields
+
+    if additional_fields is not None:
+        media_fields.extend(additional_fields)
+
     media_urls = []
 
     for field in media_fields:
-        path = sample.get(field, None)
+        path = _deep_get(sample, field)
+
         if path not in cache:
             cache[path] = path
 
         media_urls.append(dict(field=field, url=path))
 
     return media_urls
+
+
+def _get_orthographic_projection_metadata_field_name(
+    collection: SampleCollection,
+) -> t.Optional[str]:
+    orthographic_projection_field = collection.get_field_schema(
+        embedded_doc_type=OrthographicProjectionMetadata
+    )
+    media_type = collection.media_type
+
+    has_projection_metadata = len(orthographic_projection_field) > 0 and (
+        media_type == fom.POINT_CLOUD or media_type == fom.GROUP
+    )
+
+    if has_projection_metadata:
+        return next(iter(orthographic_projection_field))
+
+    return None
+
+
+def _deep_get(sample, keys, default=None):
+    """
+    Get a value from a nested dictionary by specifying keys delimited by '.',
+    similar to lodash's ``_.get()``.
+    """
+    return reduce(
+        lambda d, key: d.get(key, default) if isinstance(d, dict) else default,
+        keys.split("."),
+        sample,
+    )

--- a/fiftyone/server/metadata.py
+++ b/fiftyone/server/metadata.py
@@ -85,6 +85,10 @@ async def get_metadata(
                     aspect_ratio=width / height,
                     frame_rate=frame_rate,
                 )
+        elif opm_field:
+            metadata_cache[filepath] = await read_metadata(
+                sample[opm_field]["filepath"], False
+            )
         else:
             width = metadata.get("width", None)
             height = metadata.get("height", None)

--- a/fiftyone/server/metadata.py
+++ b/fiftyone/server/metadata.py
@@ -58,19 +58,17 @@ async def get_metadata(
     filepath = sample["filepath"]
     metadata = sample.get("metadata", None)
 
-    orthographic_projection_metadata_field_name = (
-        _get_orthographic_projection_metadata_field_name(collection)
-    )
+    opm_field = _get_orthographic_projection_metadata_field_name(collection)
+    if opm_field:
+        additional_fields = [opm_field + ".filepath"]
+    else:
+        additional_fields = None
 
     urls = _create_media_urls(
         collection,
         sample,
         url_cache,
-        additional_fields=[
-            f"{orthographic_projection_metadata_field_name}.filepath"
-        ]
-        if orthographic_projection_metadata_field_name
-        else None,
+        additional_fields=additional_fields,
     )
 
     is_video = media_type == fom.VIDEO
@@ -105,8 +103,8 @@ async def get_metadata(
             if isinstance(exc, FFmpegNotFoundException):
                 raise exc
 
-            # Something went wrong (ie non-existent file), so we gracefully return
-            # some placeholder metadata so the App grid can be rendered
+            # Something went wrong (ie non-existent file), so we gracefully
+            # return some placeholder metadata so the App grid can be rendered
             if is_video:
                 metadata_cache[filepath] = dict(aspect_ratio=1, frame_rate=30)
             else:


### PR DESCRIPTION
## What changes are proposed in this pull request?

Use dedicated media field for orthographic projection filepath

## How is this patch tested? If it is not, please explain why.

Locally, with quickstart-groups dataset, both with and without projections computed.

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
