### PR TITLE
refactor/default port

### DIFF
--- a/app/packages/app/vite.config.ts
+++ b/app/packages/app/vite.config.ts
@@ -20,13 +20,17 @@ export default defineConfig({
   server: {
     proxy: {
       "/plugins": {
-        target: "http://127.0.0.1:5151",
+        target: `http://127.0.0.1:${
+          process.env.FIFTYONE_DEFAULT_APP_PORT ?? "5151"
+        }`,
         changeOrigin: false,
         secure: false,
         ws: false,
       },
       "/aggregate": {
-        target: "http://127.0.0.1:5151",
+        target: `http://127.0.0.1:${
+          process.env.FIFTYONE_DEFAULT_APP_PORT ?? "5151"
+        }`,
         changeOrigin: false,
         secure: false,
         ws: false,

--- a/app/packages/core/src/components/Setup.tsx
+++ b/app/packages/core/src/components/Setup.tsx
@@ -47,7 +47,7 @@ const Code = styled.pre`
 
 const port = (() => {
   if (isElectron()) {
-    return parseInt(process.env.FIFTYONE_SERVER_PORT) || 5151;
+    return parseInt(process.env.FIFTYONE_DEFAULT_APP_PORT) || 5151;
   }
 
   if (typeof window !== "undefined" && window.location.port !== undefined) {

--- a/app/packages/core/vite.config.ts
+++ b/app/packages/core/vite.config.ts
@@ -16,13 +16,17 @@ export default defineConfig(({ mode }) => {
     server: {
       proxy: {
         "/plugins": {
-          target: "http://localhost:5151",
+          target: `http://localhost:${
+            process.env.FIFTYONE_DEFAULT_APP_PORT ?? "5151"
+          }`,
           changeOrigin: false,
           secure: false,
           ws: false,
         },
         "/aggregate": {
-          target: "http://localhost:5151",
+          target: `http://localhost:${
+            process.env.FIFTYONE_DEFAULT_APP_PORT ?? "5151"
+          }`,
           changeOrigin: false,
           secure: false,
           ws: false,

--- a/app/packages/utilities/src/fetch.ts
+++ b/app/packages/utilities/src/fetch.ts
@@ -178,7 +178,7 @@ export const getAPI = () => {
   }
   return isElectron()
     ? `http://${process.env.FIFTYONE_SERVER_ADDRESS || "localhost"}:${
-        process.env.FIFTYONE_SERVER_PORT || 5151
+        process.env.FIFTYONE_DEFAULT_APP_PORT || 5151
       }`
     : window.location.origin;
 };

--- a/fiftyone/server/metadata.py
+++ b/fiftyone/server/metadata.py
@@ -86,9 +86,11 @@ async def get_metadata(
                     frame_rate=frame_rate,
                 )
         elif opm_field:
-            metadata_cache[filepath] = await read_metadata(
-                sample[opm_field]["filepath"], False
-            )
+            opm_img_path = _deep_get(sample, opm_field + ".filepath")
+            if opm_img_path:
+                metadata_cache[filepath] = await read_metadata(
+                    opm_img_path, False
+                )
         else:
             width = metadata.get("width", None)
             height = metadata.get("height", None)


### PR DESCRIPTION
- use deep get to get opm image path
- respect FIFTYONE_DEFAULT_APP_PORT env var

## What changes are proposed in this pull request?

(Please fill in changes proposed in this fix)

## How is this patch tested? If it is not, please explain why.

(Details)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
