### PR TITLE
fix toPatches modal view regression for similarity search

### DIFF
--- a/app/packages/core/src/components/Actions/ActionsRow.tsx
+++ b/app/packages/core/src/components/Actions/ActionsRow.tsx
@@ -85,13 +85,16 @@ const Similarity = ({ modal }: { modal: boolean }) => {
   const [open, setOpen] = useState(false);
   const [isImageSearch, setIsImageSearch] = useState(false);
   const hasSelectedSamples = useRecoilValue(fos.hasSelectedSamples);
+  const hasSelectedLabels = useRecoilValue(fos.hasSelectedLabels);
   const hasSorting = Boolean(useRecoilValue(fos.similarityParameters));
   const [mRef, bounds] = useMeasure();
   const ref = useRef<HTMLDivElement>(null);
   useOutsideClick(ref, () => open && setOpen(false));
 
   const showImageSimilarityIcon =
-    hasSelectedSamples || (isImageSearch && hasSorting);
+    hasSelectedSamples ||
+    (isImageSearch && hasSorting) ||
+    (modal && hasSelectedLabels);
 
   const toggleSimilarity = useCallback(() => {
     setOpen((open) => !open);

--- a/app/packages/core/src/components/Actions/similar/utils.ts
+++ b/app/packages/core/src/components/Actions/similar/utils.ts
@@ -24,15 +24,15 @@ export const getQueryIds = async (
   const selectedLabels = await snapshot.getPromise(fos.selectedLabels);
   const methods = await snapshot.getPromise(fos.similarityMethods);
 
+  const labels_field = methods.patches
+    .filter(([method]) => method.key === brainKey)
+    .map(([_, value]) => value)[0];
+
   if (selectedLabelIds.size) {
     return [...selectedLabelIds].filter(
       (id) => selectedLabels[id].field === labels_field
     );
   }
-
-  const labels_field = methods.patches
-    .filter(([method]) => method.key === brainKey)
-    .map(([_, value]) => value)[0];
 
   const selectedSamples = await snapshot.getPromise(fos.selectedSamples);
   const isPatches = await snapshot.getPromise(fos.isPatchesView);
@@ -184,7 +184,9 @@ const availablePatchesSimilarityKeys = selectorFamily<
             Object.values(get(selectedLabels)).map(({ field }) => field)
           );
 
-          return patches.filter(([_, field]) => fields.has(field));
+          return patches
+            .filter(([_, field]) => fields.has(field))
+            .map(([key]) => key);
         } else {
           const { sample } = get(fos.modal) as ModalSample;
 


### PR DESCRIPTION
As a user, I can select a bounding box in the sample modal and then execute a similarity search against any brain_key that corresponds to a similarity run with that matches that label's patches_field.

https://user-images.githubusercontent.com/17770824/225401265-b37123ca-da46-4d29-a043-bbf6172fcd4d.mov

## What changes are proposed in this pull request?



## How is this patch tested? If it is not, please explain why.


## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
