### PR TITLE
bugfix: reset selected labels after submission

### DIFF
--- a/app/packages/core/src/components/Actions/similar/utils.ts
+++ b/app/packages/core/src/components/Actions/similar/utils.ts
@@ -115,7 +115,6 @@ export const useSortBySimilarity = (close) => {
             set(fos.modal, null);
             set(fos.similaritySorting, false);
             set(fos.savedLookerOptions, (cur) => ({ ...cur, showJSON: false }));
-            set(fos.selectedLabels, {});
             set(fos.hiddenLabels, {});
             set(fos.modal, null);
             close();

--- a/fiftyone/server/routes/sort.py
+++ b/fiftyone/server/routes/sort.py
@@ -33,6 +33,7 @@ class Sort(HTTPEndpoint):
         )
         state = fose.get_state()
         state.selected = []
+        state.selected_labels = []
 
         await fose.dispatch_event(subscription, fose.StateUpdate(state))
         return {


### PR DESCRIPTION
https://user-images.githubusercontent.com/17770824/225449700-499a266e-571a-41ca-a347-dd6c11fde91f.mov

## What changes are proposed in this pull request?

reset selected labels after sort by similarity submission

## How is this patch tested? If it is not, please explain why.

yes

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
