### PR TITLE
fix delete saved view crash

### DIFF
--- a/fiftyone/server/mutation.py
+++ b/fiftyone/server/mutation.py
@@ -322,7 +322,11 @@ class Mutation:
         # If the current view is deleted, set the view state to the full
         # dataset view
         state = get_state()
-        if view_name and state.view and state.view.name == view_name:
+        if (
+            view_name
+            and state.view is not None
+            and state.view.name == view_name
+        ):
             state.view = dataset.view()
             state.view_name = None
 

--- a/fiftyone/server/mutation.py
+++ b/fiftyone/server/mutation.py
@@ -322,7 +322,7 @@ class Mutation:
         # If the current view is deleted, set the view state to the full
         # dataset view
         state = get_state()
-        if view_name and state.view_name == view_name:
+        if view_name and state.view and state.view.name == view_name:
             state.view = dataset.view()
             state.view_name = None
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

deleting saved views crashes since the property does not exist in state
https://voxel51.atlassian.net/browse/TEAMS-1029

## How is this patch tested? If it is not, please explain why.

(Details)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
