### PR TITLE
more explicit font declaration for point cloud size input

### DIFF
--- a/app/packages/looker-3d/src/action-bar/PointSize.tsx
+++ b/app/packages/looker-3d/src/action-bar/PointSize.tsx
@@ -87,8 +87,8 @@ export const PointSizeSlider = () => {
               onChange={handlePointSizeAttenuationChange}
             />
           }
+          classes={{ label: style.pointSizeAttenuationLabel }}
           label="Point Size Attenuation"
-          className="pointSizeAttenuationCheckbox"
         />
 
         <div className={style.pointSizeContainer}>

--- a/app/packages/looker-3d/src/action-bar/style.module.css
+++ b/app/packages/looker-3d/src/action-bar/style.module.css
@@ -40,5 +40,6 @@
 }
 
 .pointSizeAttenuationLabel {
+  /* mui should override label styles with these, but doesn't */
   font-family: inherit !important;
 }

--- a/app/packages/looker-3d/src/action-bar/style.module.css
+++ b/app/packages/looker-3d/src/action-bar/style.module.css
@@ -13,6 +13,7 @@
   background: transparent;
   outline-width: 0;
   width: 2.5em;
+  color: var(--joy-palette-text-primary);
 }
 
 .pointSizeTextField:focus {
@@ -38,6 +39,6 @@
   margin: 1em;
 }
 
-.pointSizeAttenuationCheckbox {
-  font: unset;
+.pointSizeAttenuationLabel {
+  font-family: inherit !important;
 }


### PR DESCRIPTION
## What changes are proposed in this pull request?

- Set color of point cloud size textbox to theme text primary color
- Override MUI's font for point cloud size label

<img width="817" alt="Screenshot 2023-03-21 at 9 51 08 AM" src="https://user-images.githubusercontent.com/66688606/226645079-a8e95128-8b11-446d-81fb-ffa83946f724.png">
<img width="825" alt="Screenshot 2023-03-21 at 9 50 49 AM" src="https://user-images.githubusercontent.com/66688606/226645093-0e016670-213f-446f-bc13-3b06a0ecf70c.png">

## How is this patch tested? If it is not, please explain why.

Locally

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
