### PR TITLE
[HOLD] check for reserved keywords on sample, raise ValueError on reserved keyword

### DIFF
--- a/tests/unittests/sample_tests.py
+++ b/tests/unittests/sample_tests.py
@@ -858,6 +858,24 @@ class SampleFieldTests(unittest.TestCase):
             self.assertIsInstance(fields["vector_field"], fo.VectorField)
             self.assertIsInstance(fields["array_field"], fo.ArrayField)
 
+    @drop_datasets
+    def test_reserved_keywords_fields(self):
+        with self.assertRaises(ValueError):
+            fo.Sample(filepath="img.png", pk=321)
+
+        sample1 = fo.Sample(
+            filepath="img.png",
+        )
+
+        with self.assertRaises(ValueError):
+            sample1.pk = 321
+
+        with self.assertRaises(ValueError):
+            sample1["pk"] = 321
+
+        with self.assertRaises(ValueError):
+            sample1["pk"]
+
 
 if __name__ == "__main__":
     fo.config.show_progress_bars = False


### PR DESCRIPTION
## What changes are proposed in this pull request?

Checking supplied fields against a list of reserved keywords, currently the list contains a single keyword: `'pk'`, which is an alias for the `_id` field. We may want to add more of these reserved keywords in the future, so created this as a list.

Also, support for checking all the supplied fields on sample instantiation, and returning a comprehensive error message if multiple reserved keywords are attempting to be used (`'pk' is a reserved keyword` vs `'pk', 'foo' are reserved keywords`)



## How is this patch tested? If it is not, please explain why.

added a test in the existing `unittests/sample.py`

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

original issue here: https://github.com/voxel51/fiftyone/issues/2192


### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
