### PR TITLE
workaround mongodb bug in _get_samples_bytes()

### DIFF
--- a/tests/unittests/view_tests.py
+++ b/tests/unittests/view_tests.py
@@ -2082,7 +2082,7 @@ class ViewStageTests(unittest.TestCase):
         self.assertIs(len(result), 1)
         self.assertEqual(result[0].id, self.sample2.id)
 
-    def test_exclude_fields(self):
+    def _exclude_fields_setup(self):
         self.dataset.add_sample_field("exclude_fields_field1", fo.IntField)
         self.dataset.add_sample_field("exclude_fields_field2", fo.IntField)
         self.dataset.set_values(
@@ -2092,6 +2092,13 @@ class ViewStageTests(unittest.TestCase):
             "exclude_fields_field2", [1] * len(self.dataset)
         )
 
+    def _exclude_fields_teardown(self):
+        self.dataset.delete_sample_fields(
+            ["exclude_fields_field1", "exclude_fields_field2"]
+        )
+
+    def test_exclude_fields(self):
+        self._exclude_fields_setup()
         for default_field in ("id", "filepath", "tags", "metadata"):
             with self.assertRaises(ValueError):
                 self.dataset.exclude_fields(default_field)
@@ -2105,7 +2112,10 @@ class ViewStageTests(unittest.TestCase):
                 sample.exclude_fields_field1
 
             self.assertEqual(sample.exclude_fields_field2, 1)
+        self._exclude_fields_teardown()
 
+    def test_exclude_fields_stats(self):
+        self._exclude_fields_setup()
         base_size = self.dataset.exclude_fields(
             ["exclude_fields_field1", "exclude_fields_field2"]
         ).stats()["samples_bytes"]
@@ -2115,10 +2125,7 @@ class ViewStageTests(unittest.TestCase):
         total_size = self.dataset.stats()["samples_bytes"]
         self.assertLess(base_size, excl1_size)
         self.assertLess(excl1_size, total_size)
-
-        self.dataset.delete_sample_fields(
-            ["exclude_fields_field1", "exclude_fields_field2"]
-        )
+        self._exclude_fields_teardown()
 
     def test_exclude_frame_fields(self):
         sample = fo.Sample(filepath="video.mp4")
@@ -2136,11 +2143,18 @@ class ViewStageTests(unittest.TestCase):
                 with self.assertRaises(AttributeError):
                     frame.int_field
 
+    def test_exclude_frame_fields_stats(self):
+        sample = fo.Sample(filepath="video.mp4")
+        sample.frames[1] = fo.Frame(int_field=1)
+
+        dataset = fo.Dataset()
+        dataset.add_sample(sample)
+
         excl_size = dataset.exclude_fields(["frames.int_field"]).stats()[
             "frames_bytes"
         ]
         total_size = dataset.stats()["frames_bytes"]
-        assert excl_size < total_size
+        self.assertLess(excl_size, total_size)
 
     def test_exists(self):
         sample1 = fo.Sample(filepath="video1.mp4", index=1)
@@ -3098,10 +3112,15 @@ class ViewStageTests(unittest.TestCase):
         self.assertEqual(len(result), 2)
         self.assertEqual(result.values("id"), values)
 
-    def test_select_fields(self):
+    def _select_field_setup(self):
         self.dataset.add_sample_field("select_fields_field", fo.IntField)
         self.dataset.set_values("select_fields_field", [1] * len(self.dataset))
 
+    def _select_field_teardown(self):
+        self.dataset.delete_sample_field("select_fields_field")
+
+    def test_select_fields(self):
+        self._select_field_setup()
         for sample in self.dataset.select_fields():
             self.assertSetEqual(
                 sample.selected_field_names,
@@ -3113,10 +3132,15 @@ class ViewStageTests(unittest.TestCase):
             sample.tags
             with self.assertRaises(AttributeError):
                 sample.select_fields_field
+        self._select_field_teardown()
+
+    def test_select_fields_stats(self):
+        self._select_field_setup()
 
         base_size = self.dataset.select_fields().stats()["samples_bytes"]
         total_size = self.dataset.stats()["samples_bytes"]
         self.assertLess(base_size, total_size)
+        self._select_field_teardown()
 
     def test_skip(self):
         result = list(self.dataset.sort_by("filepath").skip(1))


### PR DESCRIPTION
## What changes are proposed in this pull request?
Closes https://github.com/voxel51/fiftyone/issues/2836 where `SampleCollection.stats()` was being reported as the full document size total even if a SelectField stage was present.

This bug was due to a change in behavior of $bsonSize within a $group stage after MongoDB ~ 5.2. It's believed because of the usage of the Slot Based Execution query engine for $group stage in 5.2.
A [MongoDB bug ticket has been filed](https://jira.mongodb.org/browse/SERVER-75267) but that's about all we can do since there appears to be no way to turn off the SDE engine selectively.

The workaround is to grab document sizes first then sum them, in 2 stages instead of 1. This may be slightly more inefficient but likely not by much.

## How is this patch tested? If it is not, please explain why.

Added unit test exposing bug in MongoDB >= 5.2. Passes now.


```python
# connect to MongoDB 6.0.X ...
import fiftyone.zoo as foz
dataset=foz.load_zoo_dataset('quickstart')

def get_stats(collection):
    return collection.stats()["total_bytes"]

select_view = dataset.select_fields()
select_view2 = dataset.select_fields("uniqueness")
select_view3 = dataset.select_fields(["uniqueness", "ground_truth"])
assert get_stats(select_view) < get_stats(select_view2) < get_stats(select_view3) < get_stats(dataset)
```

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
