### PR TITLE
adding the ability to use any device trough parameter + apple's MPS automatic check

### DIFF
--- a/fiftyone/utils/torch.py
+++ b/fiftyone/utils/torch.py
@@ -142,6 +142,8 @@ class TorchImageModelConfig(foc.Config):
         cudnn_benchmark (None): a value to use for
             :attr:`torch:torch.backends.cudnn.benchmark` while the model is
             running
+        device (None): a string specifying the device to use
+            (e.g., ``"cuda:0"``, ``"cpu"``, ``"mps"``, etc.)
     """
 
     def __init__(self, d):
@@ -192,6 +194,7 @@ class TorchImageModelConfig(foc.Config):
         self.cudnn_benchmark = self.parse_bool(
             d, "cudnn_benchmark", default=None
         )
+        self.device = self.parse_string(d, "device", default=None)
 
 
 class TorchImageModel(
@@ -211,7 +214,6 @@ class TorchImageModel(
 
     def __init__(self, config):
         self.config = config
-
         # Parse model details
         self._classes = self._parse_classes(config)
         self._mask_targets = self._parse_mask_targets(config)
@@ -227,18 +229,22 @@ class TorchImageModel(
         self._cuda_available = torch.cuda.is_available()
         self._mps_available = torch.backends.mps.is_available()
         self._using_gpu = self._cuda_available or self._mps_available
-        self._device = torch.device(
-            "cuda:0"
-            if self._cuda_available
-            else "mps"
-            if self._mps_available
-            else "cpu"
-        )
+        if self.config.device is None:
+            self._device = torch.device(
+                "cuda:0"
+                if self._cuda_available
+                else "mps"
+                if self._mps_available
+                else "cpu"
+            )
+        else:
+            self._device = torch.device(self.config.device)
         print("Using device:", self._device)
         self._using_half_precision = (
             self.config.use_half_precision is True
         ) and self._cuda_available
         self._model = self._load_model(config)
+        self._model.eval()
         self._no_grad = None
         self._benchmark_orig = None
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

added the functionality to do inference on the GPU on apple devices with the [metal backend in pytorch](https://pytorch.org/blog/introducing-accelerated-pytorch-training-on-mac/)

(Please fill in changes proposed in this fix)

changed up the `_using_gpu` so it also checks for cuda and mps and then after also make the images go to `self._device` instead of going to `cuda()` directly

## How is this patch tested? If it is not, please explain why.

tested on some models in the zoo, I can not test if it conflicts on other devices 

(Details)

## Release Notes

for Mac users have the ability to utilise more of their available hardware by utilising the MPS backend

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
