### PR TITLE
Avoid errors during failed merge cleanup

### DIFF
--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -7081,7 +7081,8 @@ def _cleanup_index(dataset, db_field, new_index, dropped_index):
         index_map = _get_single_index_map(coll)
 
         name = index_map[db_field][0]
-        coll.drop_index(name)
+        if name in coll.index_information():
+            coll.drop_index(name)
 
     if dropped_index:
         coll.create_index(db_field)
@@ -7090,7 +7091,7 @@ def _cleanup_index(dataset, db_field, new_index, dropped_index):
 def _cleanup_frame_index(dataset, index):
     coll = dataset._frame_collection
 
-    if index:
+    if index in coll.index_information():
         coll.drop_index(index)
 
 


### PR DESCRIPTION
If a `merge_samples()` operation fails, some indexes must be cleaned up which may not exist. Previously, in the case of a failed merge, another "index does not exist" error message could be raised, which may distract the user from the *initial* error that caused the failed merge, which likely requires them to change something about their `merge_samples()` syntax.

Now only the initial error will be raised.