### PR TITLE
Pulling correct data when viewing patches with a sample embeddings plot

### DIFF
--- a/fiftyone/server/routes/embeddings.py
+++ b/fiftyone/server/routes/embeddings.py
@@ -49,6 +49,7 @@ class OnPlotLoad(HTTPEndpoint):
             return {"error": msg}
 
         view = fosv.get_view(dataset_name, stages=stages)
+        is_patches_view = view._is_patches
 
         patches_field = results.config.patches_field
         is_patches_plot = patches_field is not None
@@ -78,7 +79,12 @@ class OnPlotLoad(HTTPEndpoint):
 
         # Color by data
         if label_field:
-            if view._is_patches:
+            if is_patches_view and not is_patches_plot:
+                # Must use the root dataset in order to retrieve colors for the
+                # plot, which is linked to samples, not patches
+                view = view._root_dataset
+
+            if is_patches_view and is_patches_plot:
                 # `label_field` is always provided with respect to root
                 # dataset, so we must translate for patches views
                 _, root = dataset._get_label_field_path(patches_field)


### PR DESCRIPTION
The embeddings panel backend previously did not correctly handle the case of pulling color-by data for a sample embeddings plot when the current view is a patches view.

I tested all four combinations of sample/patches views/embeddings on the dataset below and now colors work in all cases:

```py
import fiftyone as fo
import fiftyone.brain as fob
import fiftyone.zoo as foz

dataset = foz.load_zoo_dataset("quickstart")

fob.compute_visualization(
    dataset,
    model="clip-vit-base32-torch",
    brain_key="img_viz",
)

fob.compute_visualization(
    dataset,
    patches_field="ground_truth",
    model="clip-vit-base32-torch",
    brain_key="gt_viz",
)

session = fo.launch_app(dataset)
```
