### PR TITLE
Hidden results and server MatchLabels fix 

### DIFF
--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -9291,7 +9291,14 @@ class SampleCollection(object):
         field_name, _ = self._handle_group_field(field_name)
         field_name, is_frame_field = self._handle_frame_field(field_name)
 
-        if field_name.startswith("__"):
+        if field_name.startswith(
+            "___"
+        ):  # for fiftyone.server.view hidden results
+            field_name = field_name[3:]
+
+        if field_name.startswith(
+            "__"
+        ):  # for fiftyone.core.stages hidden results
             field_name = field_name[2:]
 
         if is_frame_field:

--- a/fiftyone/server/view.py
+++ b/fiftyone/server/view.py
@@ -22,7 +22,6 @@ import fiftyone.core.view as fov
 from fiftyone.server.aggregations import GroupElementFilter, SampleFilter
 from fiftyone.server.scalars import BSONArray, JSON
 import fiftyone.server.utils as fosu
-from fiftyone.core.utils import pprint
 
 
 _LABEL_TAGS = "_label_tags"
@@ -404,7 +403,7 @@ def _make_filter_stages(
 
             if expr is not None:
                 if hide_result:
-                    new_field = "__%s" % path.split(".")[1 if frames else 0]
+                    new_field = "___%s" % path.split(".")[1 if frames else 0]
                     if frames:
                         new_field = "%s%s" % (
                             view._FRAMES_PREFIX,
@@ -434,7 +433,6 @@ def _make_filter_stages(
                 elif is_matching:
                     _field = prefix + parent.name
                     _field = cache.get(_field, _field)
-
                     stage = fosg.MatchLabels(
                         fields=_field,
                         filter=expr,
@@ -453,8 +451,7 @@ def _make_filter_stages(
 
                 stages.append(stage)
                 filtered_labels.add(path)
-
-                if new_field:
+                if new_field and (not is_matching or is_keypoints):
                     cache[prefix + parent.name] = new_field
                     cleanup.add(new_field)
         else:
@@ -699,9 +696,9 @@ def _get_filtered_path(view, path, filtered_fields, label_tags):
         return path
 
     if path.startswith(view._FRAMES_PREFIX):
-        return "%s__%s" % (view._FRAMES_PREFIX, path.split(".")[1])
+        return "%s___%s" % (view._FRAMES_PREFIX, path.split(".")[1])
 
-    return "__%s" % path
+    return "___%s" % path
 
 
 def _add_frame_labels_tags(path, field, view):

--- a/tests/unittests/server_tests.py
+++ b/tests/unittests/server_tests.py
@@ -49,7 +49,7 @@ class ServerViewTests(unittest.TestCase):
         expected = [
             {
                 "$set": {
-                    "__predictions.detections": {
+                    "___predictions.detections": {
                         "$filter": {
                             "input": "$predictions.detections",
                             "cond": {
@@ -84,7 +84,7 @@ class ServerViewTests(unittest.TestCase):
                             {
                                 "$size": {
                                     "$ifNull": [
-                                        "$__predictions.detections",
+                                        "$___predictions.detections",
                                         [],
                                     ]
                                 }
@@ -96,9 +96,9 @@ class ServerViewTests(unittest.TestCase):
             },
             {
                 "$set": {
-                    "__predictions.detections": {
+                    "___predictions.detections": {
                         "$filter": {
-                            "input": "$__predictions.detections",
+                            "input": "$___predictions.detections",
                             "cond": {"$in": ["$$this.label", ["carrot"]]},
                         }
                     }
@@ -111,7 +111,7 @@ class ServerViewTests(unittest.TestCase):
                             {
                                 "$size": {
                                     "$ifNull": [
-                                        "$__predictions.detections",
+                                        "$___predictions.detections",
                                         [],
                                     ]
                                 }
@@ -154,7 +154,7 @@ class ServerViewTests(unittest.TestCase):
                     }
                 }
             },
-            {"$unset": "__predictions"},
+            {"$unset": "___predictions"},
         ]
 
         self.assertEqual(expected, returned)
@@ -302,7 +302,7 @@ class ServerViewTests(unittest.TestCase):
                                 "$mergeObjects": [
                                     "$$frame",
                                     {
-                                        "__detections": {
+                                        "___detections": {
                                             "$mergeObjects": [
                                                 "$$frame.detections",
                                                 {
@@ -361,7 +361,7 @@ class ServerViewTests(unittest.TestCase):
                                             {
                                                 "$size": {
                                                     "$ifNull": [
-                                                        "$$this.__detections.detections",
+                                                        "$$this.___detections.detections",
                                                         [],
                                                     ]
                                                 }
@@ -385,13 +385,13 @@ class ServerViewTests(unittest.TestCase):
                                 "$mergeObjects": [
                                     "$$frame",
                                     {
-                                        "__detections": {
+                                        "___detections": {
                                             "$mergeObjects": [
-                                                "$$frame.__detections",
+                                                "$$frame.___detections",
                                                 {
                                                     "detections": {
                                                         "$filter": {
-                                                            "input": "$$frame.__detections.detections",
+                                                            "input": "$$frame.___detections.detections",
                                                             "cond": {
                                                                 "$in": [
                                                                     "$$this.label",
@@ -426,7 +426,7 @@ class ServerViewTests(unittest.TestCase):
                                             {
                                                 "$size": {
                                                     "$ifNull": [
-                                                        "$$this.__detections.detections",
+                                                        "$$this.___detections.detections",
                                                         [],
                                                     ]
                                                 }
@@ -484,7 +484,7 @@ class ServerViewTests(unittest.TestCase):
                     }
                 }
             },
-            {"$unset": "frames.__detections"},
+            {"$unset": "frames.___detections"},
         ]
 
         self.assertEqual(expected, returned)
@@ -702,7 +702,7 @@ class ServerViewTests(unittest.TestCase):
                                 "$mergeObjects": [
                                     "$$frame",
                                     {
-                                        "__detections": {
+                                        "___detections": {
                                             "$mergeObjects": [
                                                 "$$frame.detections",
                                                 {
@@ -752,7 +752,7 @@ class ServerViewTests(unittest.TestCase):
                                             {
                                                 "$size": {
                                                     "$ifNull": [
-                                                        "$$this.__detections.detections",
+                                                        "$$this.___detections.detections",
                                                         [],
                                                     ]
                                                 }
@@ -781,7 +781,7 @@ class ServerViewTests(unittest.TestCase):
                                             "$$value",
                                             {
                                                 "$reduce": {
-                                                    "input": "$$this.__detections.detections",
+                                                    "input": "$$this.___detections.detections",
                                                     "initialValue": [],
                                                     "in": {
                                                         "$concatArrays": [
@@ -810,7 +810,7 @@ class ServerViewTests(unittest.TestCase):
                     }
                 }
             },
-            {"$unset": "frames.__detections"},
+            {"$unset": "frames.___detections"},
         ]
 
         self.assertEqual(expected, returned)


### PR DESCRIPTION
When "Showing samples with ..." in the sidebar, `new_field` changes are not included. Also fixes a clash of hidden `__` field processing between `MatchLabels` and `fiftyone.server.view.get_view`