### PR TITLE
Prevent loading a dataset without a name in the sdk

### DIFF
--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -124,6 +124,8 @@ def load_dataset(name):
     Returns:
         a :class:`Dataset`
     """
+    if not name:
+        raise ValueError("Cannot load a dataset with no name")
     return Dataset(name, _create=False)
 
 

--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -124,7 +124,7 @@ def load_dataset(name):
     Returns:
         a :class:`Dataset`
     """
-    if not name:
+    if not (name and isinstance(name, str)):
         raise ValueError("Cannot load a dataset with no name")
     return Dataset(name, _create=False)
 

--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -119,13 +119,16 @@ def load_dataset(name):
         return the same object.
 
     Args:
-        name: the name of the dataset
+        name (str): the name of the dataset
 
     Returns:
         a :class:`Dataset`
     """
     if not (name and isinstance(name, str)):
-        raise ValueError("Cannot load a dataset with no name")
+        raise ValueError(
+            f"Cannot load dataset with name {name}. "
+            f"Dataset `name` must be a non-empty string."
+        )
     return Dataset(name, _create=False)
 
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

- Check that `load_dataset` was called with a non-empty name before returning a `Dataset` since all valid datasets should have names

## How is this patch tested? If it is not, please explain why.

(Details)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
