### PR TITLE
[Bugfix] Serialize datetime for sample info field

### DIFF
--- a/fiftyone/core/state.py
+++ b/fiftyone/core/state.py
@@ -216,7 +216,7 @@ def serialize_fields(schema: t.Dict, dicts=False) -> t.List[SampleField]:
 
             if field.info is not None:
                 # Converts mongoengine types to primitives
-                info = json.loads(json.dumps(field.info))
+                info = json.loads(json_util.dumps(field.info))
             else:
                 info = None
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

- use json_util rather than json for serialization

## How is this patch tested? If it is not, please explain why.

Running the following no longer throws an error:

```
import fiftyone as fo
import fiftyone.zoo as foz
from datetime import datetime

dataset = foz.load_zoo_dataset("quickstart")

field = dataset.get_field("ground_truth")
field.info = {"author": "Brian", "created_at": datetime.utcnow()}

session = fo.launch_app(dataset)
```

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
