### PR TITLE
Bugfix: a user can save a float/datetime object in field.info and see that in the tootlip

### DIFF
--- a/app/packages/core/src/components/FieldLabelAndInfo/index.tsx
+++ b/app/packages/core/src/components/FieldLabelAndInfo/index.tsx
@@ -73,8 +73,6 @@ function useFieldInfo(field, nested, { expandedPath, color }) {
     setOpen(selectedField === instanceId);
   }, [selectedField]);
 
-  console.info("field", field);
-
   return {
     open,
     hoverTarget,
@@ -509,8 +507,9 @@ function keyValueIsRenderable([key, value]) {
     case "number":
     case "boolean":
       return true;
+    case "object":
+      if (value._cls === "DateTime") return true;
     default:
-      console.info(typeof value);
       return false;
   }
 }
@@ -518,6 +517,12 @@ function toRenderValue([key, value]): [string, string] {
   switch (typeof value) {
     case "boolean":
       return [key, value ? "True" : "False"];
+    case "object":
+      if (value._cls === "DateTime" && value.datetime) {
+        return [key, new Date(value.datetime).toUTCString()];
+      } else {
+        return [key, ""];
+      }
     default:
       return [key, value];
   }

--- a/app/packages/core/src/components/FieldLabelAndInfo/index.tsx
+++ b/app/packages/core/src/components/FieldLabelAndInfo/index.tsx
@@ -1,3 +1,6 @@
+import { InfoIcon, useTheme } from "@fiftyone/components";
+import * as fos from "@fiftyone/state";
+import { Field, formatDate, formatDateTime } from "@fiftyone/utilities";
 import React, {
   MutableRefObject,
   useEffect,
@@ -5,11 +8,9 @@ import React, {
   useRef,
   useState,
 } from "react";
-import { atom, useRecoilState } from "recoil";
+import { atom, useRecoilState, useRecoilValue } from "recoil";
 import styled from "styled-components";
 import { ExternalLink } from "../../utils/generic";
-import { InfoIcon, useTheme } from "@fiftyone/components";
-import { Field } from "@fiftyone/utilities";
 
 const selectedFieldInfo = atom<string | null>({
   key: "selectedFieldInfo",
@@ -260,6 +261,7 @@ function FieldInfoExpanded({
   };
 
   useEffect(updatePosition, [field, isCollapsed]);
+  const timeZone = useRecoilValue(fos.timeZone);
 
   return ReactDOM.createPortal(
     <FieldInfoHoverTarget
@@ -284,6 +286,7 @@ function FieldInfoExpanded({
           collapsed={tooManyInfoKeys && isCollapsed}
           type={field.embeddedDocType || field.ftype}
           expandedPath={expandedPath}
+          timeZone={timeZone}
         />
         {isCollapsed && (
           <ShowMoreLink
@@ -448,12 +451,19 @@ function entryKeyToLabel(key) {
 // a react componont that renders a table
 // given an object where the keys are the first column
 // and the values are the second column
-function FieldInfoTable({ info, type, collapsed, subfield, description }) {
+function FieldInfoTable({
+  info,
+  type,
+  collapsed,
+  subfield,
+  description,
+  timeZone,
+}) {
   info = info || {};
   const tableData = info;
   let items = Object.entries<any>(tableData)
     .filter(keyValueIsRenderable)
-    .map(toRenderValue);
+    .map((v) => toRenderValue(v, timeZone));
 
   if (collapsed) {
     items = items.slice(0, 2);
@@ -507,20 +517,20 @@ function keyValueIsRenderable([key, value]) {
     case "boolean":
       return true;
     case "object":
-      if (value.$date || value.$numberDouble) return true;
+      return ["Date", "DateTime"].includes(value._cls);
     default:
       return false;
   }
 }
-function toRenderValue([key, value]): [string, string] {
+function toRenderValue([key, value], timeZone: string): [string, string] {
   switch (typeof value) {
     case "boolean":
       return [key, value ? "True" : "False"];
     case "object":
-      if (value.$date) {
-        return [key, new Date(value.$date).toUTCString()];
-      } else if (value.$numberDouble) {
-        return [key, value.$numberDouble];
+      if (value._cls === "Date") {
+        return [key, formatDate(value._timestamp)];
+      } else if (value._cls === "DateTime") {
+        return [key, formatDateTime(value._timestamp, timeZone)];
       } else {
         return [key, ""];
       }

--- a/app/packages/core/src/components/FieldLabelAndInfo/index.tsx
+++ b/app/packages/core/src/components/FieldLabelAndInfo/index.tsx
@@ -507,7 +507,7 @@ function keyValueIsRenderable([key, value]) {
     case "boolean":
       return true;
     case "object":
-      if (value.$date) return true;
+      if (value.$date || value.$numberDouble) return true;
     default:
       return false;
   }
@@ -519,6 +519,8 @@ function toRenderValue([key, value]): [string, string] {
     case "object":
       if (value.$date) {
         return [key, new Date(value.$date).toUTCString()];
+      } else if (value.$numberDouble) {
+        return [key, value.$numberDouble];
       } else {
         return [key, ""];
       }

--- a/app/packages/core/src/components/FieldLabelAndInfo/index.tsx
+++ b/app/packages/core/src/components/FieldLabelAndInfo/index.tsx
@@ -458,7 +458,7 @@ function FieldInfoTable({ info, type, collapsed, subfield, description }) {
   if (collapsed) {
     items = items.slice(0, 2);
   }
-  console.info("info", info);
+
   return (
     <FieldInfoTableContainer>
       <tbody>
@@ -501,14 +501,13 @@ function FieldInfoTable({ info, type, collapsed, subfield, description }) {
 
 function keyValueIsRenderable([key, value]) {
   if (value === undefined || value === null) return true;
-  console.log("abc", value, key);
   switch (typeof value) {
     case "string":
     case "number":
     case "boolean":
       return true;
     case "object":
-      if (value._cls === "DateTime") return true;
+      if (value.$date) return true;
     default:
       return false;
   }
@@ -518,8 +517,8 @@ function toRenderValue([key, value]): [string, string] {
     case "boolean":
       return [key, value ? "True" : "False"];
     case "object":
-      if (value._cls === "DateTime" && value.datetime) {
-        return [key, new Date(value.datetime).toUTCString()];
+      if (value.$date) {
+        return [key, new Date(value.$date).toUTCString()];
       } else {
         return [key, ""];
       }

--- a/app/packages/core/src/components/FieldLabelAndInfo/index.tsx
+++ b/app/packages/core/src/components/FieldLabelAndInfo/index.tsx
@@ -528,9 +528,9 @@ function toRenderValue([key, value], timeZone: string): [string, string] {
       return [key, value ? "True" : "False"];
     case "object":
       if (value._cls === "Date") {
-        return [key, formatDate(value._timestamp)];
+        return [key, formatDate(value.datetime)];
       } else if (value._cls === "DateTime") {
-        return [key, formatDateTime(value._timestamp, timeZone)];
+        return [key, formatDateTime(value.datetime, timeZone)];
       } else {
         return [key, ""];
       }

--- a/app/packages/core/src/components/FieldLabelAndInfo/index.tsx
+++ b/app/packages/core/src/components/FieldLabelAndInfo/index.tsx
@@ -73,6 +73,8 @@ function useFieldInfo(field, nested, { expandedPath, color }) {
     setOpen(selectedField === instanceId);
   }, [selectedField]);
 
+  console.info("field", field);
+
   return {
     open,
     hoverTarget,
@@ -458,6 +460,7 @@ function FieldInfoTable({ info, type, collapsed, subfield, description }) {
   if (collapsed) {
     items = items.slice(0, 2);
   }
+  console.info("info", info);
   return (
     <FieldInfoTableContainer>
       <tbody>
@@ -500,13 +503,14 @@ function FieldInfoTable({ info, type, collapsed, subfield, description }) {
 
 function keyValueIsRenderable([key, value]) {
   if (value === undefined || value === null) return true;
-
+  console.log("abc", value, key);
   switch (typeof value) {
     case "string":
     case "number":
     case "boolean":
       return true;
     default:
+      console.info(typeof value);
       return false;
   }
 }

--- a/fiftyone/core/session/client.py
+++ b/fiftyone/core/session/client.py
@@ -20,7 +20,7 @@ from uuid import uuid4
 import fiftyone.constants as foc
 import fiftyone.core.state as fos
 
-from fiftyone.core.json import stringify
+from fiftyone.core.json import FiftyOneJSONEncoder, stringify
 from fiftyone.core.session.events import (
     Event,
     EventType,
@@ -157,11 +157,15 @@ class Client:
         response = requests.post(
             f"{self.origin}/event",
             headers={"Content-type": "application/json"},
-            json={
-                "event": event.get_event_name(),
-                "data": stringify(asdict(event, dict_factory=dict_factory)),
-                "subscription": self._subscription,
-            },
+            data=FiftyOneJSONEncoder.dumps(
+                {
+                    "event": event.get_event_name(),
+                    "data": stringify(
+                        asdict(event, dict_factory=dict_factory)
+                    ),
+                    "subscription": self._subscription,
+                }
+            ),
         )
 
         if response.status_code != 200:

--- a/fiftyone/core/state.py
+++ b/fiftyone/core/state.py
@@ -216,7 +216,7 @@ def serialize_fields(schema: t.Dict, dicts=False) -> t.List[SampleField]:
 
             if field.info is not None:
                 # Converts mongoengine types to primitives
-                info = json.loads(json.dumps(field.info))
+                info = json.loads(json_util.dumps(field.info))
             else:
                 info = None
 

--- a/fiftyone/core/state.py
+++ b/fiftyone/core/state.py
@@ -6,7 +6,6 @@ Defines the shared state between the FiftyOne App and backend.
 |
 """
 from bson import json_util
-from dataclasses import asdict
 import json
 import logging
 import typing as t
@@ -91,10 +90,10 @@ class StateDescription(etas.Serializable):
                         d["saved_view_slug"] = fou.to_slug(self.view.name)
 
                 d["sample_fields"] = serialize_fields(
-                    collection.get_field_schema(flat=True), dicts=True
+                    collection.get_field_schema(flat=True)
                 )
                 d["frame_fields"] = serialize_fields(
-                    collection.get_frame_field_schema(flat=True), dicts=True
+                    collection.get_frame_field_schema(flat=True)
                 )
 
                 view = self.view if self.view is not None else self.dataset
@@ -188,7 +187,7 @@ class SampleField:
     info: t.Optional[JSON]
 
 
-def serialize_fields(schema: t.Dict, dicts=False) -> t.List[SampleField]:
+def serialize_fields(schema: t.Dict) -> t.List[SampleField]:
     data = []
 
     if schema:
@@ -214,12 +213,6 @@ def serialize_fields(schema: t.Dict, dicts=False) -> t.List[SampleField]:
             else:
                 subfield = None
 
-            if field.info is not None:
-                # Converts mongoengine types to primitives
-                info = json.loads(json_util.dumps(field.info))
-            else:
-                info = None
-
             data.append(
                 SampleField(
                     path=path,
@@ -228,11 +221,8 @@ def serialize_fields(schema: t.Dict, dicts=False) -> t.List[SampleField]:
                     embedded_doc_type=embedded_doc_type,
                     subfield=subfield,
                     description=field.description,
-                    info=info,
+                    info=field.info,
                 )
             )
-
-    if dicts:
-        return [asdict(f) for f in data]
 
     return data


### PR DESCRIPTION
## What changes are proposed in this pull request?

- update json dump to be able to save a date object in field
- display datetime and float type in field.info table in the tooltip
To test this change, you can run the following SDK code: 
```
In [1]: import fiftyone as fo
    ...: import fiftyone.zoo as foz
    ...: from datetime import datetime
    ...:
    ...: dataset = foz.load_zoo_dataset("quickstart")
    ...:
    ...: field = dataset.get_field("ground_truth")
    ...: field.info = {"created_at": datetime.utcnow(), "sample": float(InF)}
    ...: field.save()
    ...: dataset.save()
    ...: session = fo.launch_app(dataset)
```

![Screenshot 2023-03-28 at 7 17 30 PM](https://user-images.githubusercontent.com/17770824/228395154-81078b42-918b-49da-93b4-f4cacbd1ecc7.png)
![Screenshot 2023-03-28 at 7 14 56 PM](https://user-images.githubusercontent.com/17770824/228395174-21b3a623-1247-4124-8a54-1643f6fa78e7.png)
![Screenshot 2023-03-28 at 7 15 15 PM](https://user-images.githubusercontent.com/17770824/228395165-38c4a573-67fd-4f54-9828-5dca345216d9.png)



## How is this patch tested? If it is not, please explain why.

(Details)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
