### PR TITLE
Adding support for dynamically inferring fields on embedded lists and documents

### DIFF
--- a/fiftyone/core/aggregations.py
+++ b/fiftyone/core/aggregations.py
@@ -1841,12 +1841,13 @@ class Schema(Aggregation):
         field_or_expr,
         expr=None,
         dynamic_only=False,
+        _doc_type=None,
         _include_private=False,
     ):
         super().__init__(field_or_expr, expr=expr)
         self._dynamic_only = dynamic_only
         self._include_private = _include_private
-        self._doc_type = None
+        self._doc_type = _doc_type
 
     def _kwargs(self):
         return [
@@ -1919,16 +1920,17 @@ class Schema(Aggregation):
 
     def to_mongo(self, sample_collection, context=None):
         field_name = self._field_name
-        doc_type = None
 
-        if self._expr is None:
-            field_type = _get_field_type(
-                sample_collection, field_name, unwind=True
-            )
-            if isinstance(field_type, fof.EmbeddedDocumentField):
-                doc_type = field_type
+        if self._doc_type is None:
+            doc_type = None
+            if self._expr is None:
+                field_type = _get_field_type(
+                    sample_collection, field_name, unwind=True
+                )
+                if isinstance(field_type, fof.EmbeddedDocumentField):
+                    doc_type = field_type
 
-        self._doc_type = doc_type
+            self._doc_type = doc_type
 
         path, pipeline, _, _, _ = _parse_field_and_expr(
             sample_collection,

--- a/fiftyone/core/aggregations.py
+++ b/fiftyone/core/aggregations.py
@@ -1921,16 +1921,12 @@ class Schema(Aggregation):
     def to_mongo(self, sample_collection, context=None):
         field_name = self._field_name
 
-        if self._doc_type is None:
-            doc_type = None
-            if self._expr is None:
-                field_type = _get_field_type(
-                    sample_collection, field_name, unwind=True
-                )
-                if isinstance(field_type, fof.EmbeddedDocumentField):
-                    doc_type = field_type
-
-            self._doc_type = doc_type
+        if self._doc_type is None and self._expr is None:
+            field_type = _get_field_type(
+                sample_collection, field_name, unwind=True
+            )
+            if isinstance(field_type, fof.EmbeddedDocumentField):
+                self._doc_type = field_type
 
         path, pipeline, _, _, _ = _parse_field_and_expr(
             sample_collection,

--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -1184,7 +1184,6 @@ class SampleCollection(object):
 
         schema = self.get_frame_field_schema()
         prefix = self._FRAMES_PREFIX
-
         return self._get_dynamic_field_schema(
             schema, prefix=prefix, fields=fields
         )

--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -1075,7 +1075,7 @@ class SampleCollection(object):
             if last_key and not leaf:
                 continue
 
-            if isinstance(field, fof.ListField):
+            while isinstance(field, fof.ListField):
                 field = field.field
 
             if isinstance(field, fof.EmbeddedDocumentField) and not last_key:
@@ -1162,7 +1162,7 @@ class SampleCollection(object):
             types
         """
         schema = self.get_field_schema()
-        return self._get_dynamic_field_schema(schema, "", fields=fields)
+        return self._get_dynamic_field_schema(schema, fields=fields)
 
     def get_dynamic_frame_field_schema(self, fields=None):
         """Returns a schema dictionary describing the dynamic fields of the
@@ -1184,32 +1184,69 @@ class SampleCollection(object):
 
         schema = self.get_frame_field_schema()
         prefix = self._FRAMES_PREFIX
-        return self._get_dynamic_field_schema(schema, prefix, fields=fields)
 
-    def _get_dynamic_field_schema(self, schema, prefix, fields=None):
+        return self._get_dynamic_field_schema(
+            schema, prefix=prefix, fields=fields
+        )
+
+    def _get_dynamic_field_schema(self, schema, prefix=None, fields=None):
+        if prefix is None:
+            prefix = ""
+
         if fields is not None:
             if etau.is_str(fields):
-                fields = {fields}
+                fields = [fields]
             else:
-                fields = set(fields)
+                fields = list(fields)
 
-            schema = {k: v for k, v in schema.items() if k in fields}
+            schema = {
+                k: v
+                for k, v in schema.items()
+                if any(f == k or f.startswith(k + ".") for f in fields)
+            }
+
+        dynamic_schema = self._do_get_dynamic_field_schema(schema, prefix)
+
+        # Recursively add dynamic fields for any new embedded documents
+        if dynamic_schema:
+            s = dynamic_schema
+            while True:
+                s = self._do_get_dynamic_field_schema(s, prefix, new=True)
+                if s:
+                    dynamic_schema.update(s)
+                else:
+                    break
+
+        return dynamic_schema
+
+    def _do_get_dynamic_field_schema(self, schema, prefix, new=False):
+        schema = fof.flatten_schema(schema)
 
         aggs = []
         paths = []
-        for name, field in schema.items():
-            if isinstance(field, fof.ListField):
+        for path, field in schema.items():
+            is_list_field = False
+            while isinstance(field, fof.ListField):
                 field = field.field
+                is_list_field = True
 
             if isinstance(field, fof.EmbeddedDocumentField):
-                path = name
-                aggs.append(foa.Schema(prefix + path, dynamic_only=True))
-                paths.append(path)
+                _path = prefix + path
+                if is_list_field:
+                    _path += "[]"
 
-                if issubclass(field.document_type, fol._LABEL_LIST_FIELDS):
-                    path = name + "." + field.document_type._LABEL_LIST_FIELD
-                    aggs.append(foa.Schema(prefix + path, dynamic_only=True))
-                    paths.append(path)
+                if new:
+                    # This field hasn't been declared yet, so we must provide
+                    # it's document type so that `Schema()` can distinguish
+                    # dynamic fields from builtin fields
+                    _doc_type = field.document_type
+                else:
+                    _doc_type = None
+
+                agg = foa.Schema(_path, dynamic_only=True, _doc_type=_doc_type)
+
+                aggs.append(agg)
+                paths.append(path)
 
         fields = {}
 
@@ -7111,6 +7148,7 @@ class SampleCollection(object):
         field_or_expr,
         expr=None,
         dynamic_only=False,
+        _doc_type=None,
         _include_private=False,
     ):
         """Extracts the names and types of the attributes of a specified
@@ -7194,6 +7232,7 @@ class SampleCollection(object):
             field_or_expr,
             expr=expr,
             dynamic_only=dynamic_only,
+            _doc_type=_doc_type,
             _include_private=_include_private,
         )
         return self._make_and_aggregate(make, field_or_expr)

--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -1198,6 +1198,9 @@ class SampleCollection(object):
         aggs = []
         paths = []
         for name, field in schema.items():
+            if isinstance(field, fof.ListField):
+                field = field.field
+
             if isinstance(field, fof.EmbeddedDocumentField):
                 path = name
                 aggs.append(foa.Schema(prefix + path, dynamic_only=True))

--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -1372,7 +1372,8 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
             elif field is not None:
                 schema[path] = field
 
-        self._merge_sample_field_schema(schema)
+        for _schema in _handle_nested_fields(schema):
+            self._merge_sample_field_schema(_schema)
 
     def add_frame_field(
         self,
@@ -1498,7 +1499,8 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
             elif field is not None:
                 schema[path] = field
 
-        self._merge_frame_field_schema(schema)
+        for _schema in _handle_nested_fields(schema):
+            self._merge_frame_field_schema(_schema)
 
     def add_group_field(
         self, field_name, default=None, description=None, info=None
@@ -8090,6 +8092,28 @@ def _parse_field_mapping(field_mapping):
             new_fields.append(new_field)
 
     return fields, new_fields, embedded_fields, embedded_new_fields
+
+
+def _handle_nested_fields(schema):
+    safe_schemas = []
+
+    while True:
+        _now = {}
+        _later = {}
+        for path, field in schema.items():
+            if any(path.startswith(p + ".") for p in schema.keys()):
+                _later[path] = field
+            else:
+                _now[path] = field
+
+        safe_schemas.append(_now)
+
+        if _later:
+            schema = _later
+        else:
+            break
+
+    return safe_schemas
 
 
 def _extract_archive_if_necessary(archive_path, cleanup):

--- a/fiftyone/core/fields.py
+++ b/fiftyone/core/fields.py
@@ -242,7 +242,7 @@ def _flatten(
     ):
         schema[prefix] = field
 
-    if isinstance(field, (ListField, DictField)):
+    while isinstance(field, (ListField, DictField)):
         field = field.field
 
     if isinstance(field, EmbeddedDocumentField):
@@ -1361,7 +1361,7 @@ class EmbeddedDocumentField(mongoengine.fields.EmbeddedDocumentField, Field):
                     foo.validate_fields_match(_path, _field, _existing_field)
 
                 if recursive:
-                    if isinstance(_existing_field, ListField):
+                    while isinstance(_existing_field, ListField):
                         _existing_field = _existing_field.field
                         if isinstance(_field, ListField):
                             _field = _field.field

--- a/fiftyone/core/labels.py
+++ b/fiftyone/core/labels.py
@@ -370,6 +370,7 @@ class Classifications(_HasLabelList, Label):
 
     Args:
         classifications (None): a list of :class:`Classification` instances
+        logits (None): logits associated with the labels
     """
 
     _LABEL_LIST_FIELD = "classifications"

--- a/tests/unittests/dataset_tests.py
+++ b/tests/unittests/dataset_tests.py
@@ -4139,6 +4139,72 @@ class DynamicFieldTests(unittest.TestCase):
         self.assertEqual(detection.mixed, [1, 2, 3])
 
     @drop_datasets
+    def test_dynamic_fields_nested(self):
+        sample = fo.Sample(
+            filepath="image.jpg",
+            tasks=[
+                fo.DynamicEmbeddedDocument(
+                    annotator="alice",
+                    labels=fo.Classifications(
+                        classifications=[
+                            fo.Classification(label="cat", mood="surly"),
+                            fo.Classification(label="dog"),
+                        ]
+                    ),
+                ),
+                fo.DynamicEmbeddedDocument(
+                    annotator="bob",
+                    labels=fo.Classifications(
+                        classifications=[
+                            fo.Classification(label="rabbit"),
+                            fo.Classification(label="squirrel", age=51),
+                        ]
+                    ),
+                ),
+            ],
+        )
+
+        dataset = fo.Dataset()
+        dataset.add_sample(sample)
+
+        dynamic_schema = dataset.get_dynamic_field_schema()
+        self.assertSetEqual(
+            set(dynamic_schema.keys()),
+            {
+                "tasks.annotator",
+                "tasks.labels",
+                "tasks.labels.classifications.age",
+                "tasks.labels.classifications.mood",
+            },
+        )
+
+        dataset.add_dynamic_sample_fields()
+
+        new_paths = [
+            "tasks",
+            "tasks.labels",
+            "tasks.labels.classifications",
+            "tasks.labels.classifications.id",
+            "tasks.labels.classifications.tags",
+            "tasks.labels.classifications.label",
+            "tasks.labels.classifications.logits",
+            "tasks.labels.classifications.confidence",
+            "tasks.labels.classifications.age",
+            "tasks.labels.classifications.mood",
+            "tasks.labels.logits",
+            "tasks.annotator",
+        ]
+        schema = dataset.get_field_schema(flat=True)
+        for path in new_paths:
+            self.assertIn(path, schema)
+
+        dynamic_schema = dataset.get_dynamic_field_schema()
+
+        self.assertDictEqual(dynamic_schema, {})
+
+        dataset.add_dynamic_sample_fields()
+
+    @drop_datasets
     def test_rename_dynamic_embedded_fields(self):
         sample = fo.Sample(
             filepath="image.jpg",


### PR DESCRIPTION
The `get_dynamic_field_schema()` and `add_dynamic_sample_fields()` methods did not previously handle either of these cases:
- fields that contain lists of embedded documents 
- dynamic embedded documents (eg `Label` fields)

Now it does!

```py
import fiftyone as fo

sample = fo.Sample(
    filepath="/Users/Brian/Desktop/test.png",
    tasks=[
        fo.DynamicEmbeddedDocument(
            annotator="eric",
            labels=fo.Classifications(
                classifications=[
                    fo.Classification(label="cat", mood="surly"),
                    fo.Classification(label="dog"),
                ]
            ),
        ),
        fo.DynamicEmbeddedDocument(
            annotator="mani",
            labels=fo.Classifications(
                classifications=[
                    fo.Classification(label="rabbit"),
                    fo.Classification(label="squirrel", age=51),
                ]
            ),
        ),
    ]
)

dataset = fo.Dataset()
dataset.add_sample(sample)

fo.pprint(dataset.get_field_schema(flat=True))
fo.pprint(dataset.get_dynamic_field_schema())

dataset.add_dynamic_sample_fields()

fo.pprint(dataset.get_field_schema(flat=True))
fo.pprint(dataset.get_dynamic_field_schema())
```
