### PR TITLE
Replace ndjson and patool packages with non-GPL code

### DIFF
--- a/fiftyone/utils/labelbox.py
+++ b/fiftyone/utils/labelbox.py
@@ -14,7 +14,7 @@ from uuid import uuid4
 import warnings
 import webbrowser
 
-import ndjson
+# import jsonlines
 import numpy as np
 
 import eta.core.image as etai
@@ -688,7 +688,9 @@ class LabelboxAnnotationAPI(foua.AnnotationAPI):
     def _setup_project(
         self, project_name, dataset, label_schema, classes_as_attrs
     ):
-        project = self._client.create_project(name=project_name)
+        project = self._client.create_project(
+            name=project_name, queue_mode=lb.QueueMode.Dataset
+        )
         project.datasets.connect(dataset)
 
         self._setup_editor(project, label_schema, classes_as_attrs)
@@ -931,7 +933,7 @@ class LabelboxAnnotationAPI(foua.AnnotationAPI):
         url = label_dict["frames"]
         headers = {"Authorization": "Bearer %s" % self._api_key}
         response = requests.get(url, headers=headers)
-        return ndjson.loads(response.text)
+        return etas.load_ndjson(response.text)
 
     def _download_project_labels(self, project_id=None, project=None):
         if project is None:

--- a/fiftyone/utils/labelbox.py
+++ b/fiftyone/utils/labelbox.py
@@ -14,7 +14,6 @@ from uuid import uuid4
 import warnings
 import webbrowser
 
-# import jsonlines
 import numpy as np
 
 import eta.core.image as etai

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -9,12 +9,12 @@ Flask==1.1.2
 ftfy==6.1.1
 httpx==0.23.0
 hypercorn==0.13.2
+jsonlines==3.1.0
 Jinja2==3.0.3
 kaleido==0.2.1
 matplotlib==3.5.2
 mongoengine==0.24.2
 motor>=2.5
-ndjson==0.3.1
 packaging==20.3
 pandas>=1.3
 plotly==5.9.0

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -9,7 +9,6 @@ Flask==1.1.2
 ftfy==6.1.1
 httpx==0.23.0
 hypercorn==0.13.2
-jsonlines==3.1.0
 Jinja2==3.0.3
 kaleido==0.2.1
 matplotlib==3.5.2


### PR DESCRIPTION
relies on: https://github.com/voxel51/eta/pull/590

## What changes are proposed in this pull request?

removed ndjson & patool, removed ndjson from this repo as well and pointed the one call to ndjson directly to the eta lib functionality. 

Also added the missing parameter to the labelbox `create_project` call which may have been caused by a breaking change in a recent update. This was necessary to get the labelbox tests working so I could test the ndjson -> jsonlines changes via the `tests/intensive/labelbox_tests`, not a robust fix for the [existing labelbox issue](https://voxel51.atlassian.net/browse/TEAMS-1065).  

## How is this patch tested? If it is not, please explain why.

manually tested & ran through existing labelbox tests (which covered the ndjson -> jsonlines changes in eta, PR [here](https://github.com/voxel51/eta/pull/590/files))

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

ETA PR - https://github.com/voxel51/eta/pull/590

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [x] Other
