### PR TITLE
Adding support for listing datasets matching a glob pattern

### DIFF
--- a/docs/source/cli/index.rst
+++ b/docs/source/cli/index.rst
@@ -321,14 +321,16 @@ List FiftyOne datasets.
 
 .. code-block:: text
 
-    fiftyone datasets list [-h]
+    fiftyone datasets list [-h] [-p PATT]
 
 **Arguments**
 
 .. code-block:: text
 
     optional arguments:
-      -h, --help  show this help message and exit
+      -h, --help        show this help message and exit
+      -p PATT, --glob-patt PATT
+                        an optional glob pattern of names to return
 
 **Examples**
 
@@ -336,6 +338,9 @@ List FiftyOne datasets.
 
     # List available datasets
     fiftyone datasets list
+
+    # List datasets matching a given pattern
+    fiftyone datasets list --glob-patt quick*
 
 .. _cli-fiftyone-datasets-info:
 
@@ -346,7 +351,7 @@ Print information about FiftyOne datasets.
 
 .. code-block:: text
 
-    fiftyone datasets info [-h] [-s FIELD] [-r] [NAME]
+    fiftyone datasets info [-h] [-p PATT] [-s FIELD] [-r] [NAME]
 
 **Arguments**
 
@@ -357,6 +362,8 @@ Print information about FiftyOne datasets.
 
     optional arguments:
       -h, --help            show this help message and exit
+      -p PATT, --glob-patt PATT
+                            an optional glob pattern of names to return
       -s FIELD, --sort-by FIELD
                             a field to sort the dataset rows by
       -r, --reverse         whether to print the results in reverse order
@@ -367,6 +374,7 @@ Print information about FiftyOne datasets.
 
     # Print basic information about all datasets
     fiftyone datasets info
+    fiftyone datasets info --glob-patt quick*
     fiftyone datasets info --sort-by created_at
     fiftyone datasets info --sort-by name --reverse
 

--- a/fiftyone/core/cli.py
+++ b/fiftyone/core/cli.py
@@ -413,15 +413,23 @@ class DatasetsListCommand(Command):
 
         # List available datasets
         fiftyone datasets list
+
+        # List datasets matching a given pattern
+        fiftyone datasets list --glob-patt quick*
     """
 
     @staticmethod
     def setup(parser):
-        pass
+        parser.add_argument(
+            "-p",
+            "--glob-patt",
+            metavar="PATT",
+            help="an optional glob pattern of names to return",
+        )
 
     @staticmethod
     def execute(parser, args):
-        datasets = fod.list_datasets()
+        datasets = fod.list_datasets(glob_patt=args.glob_patt)
 
         if datasets:
             for dataset in datasets:
@@ -437,6 +445,7 @@ class DatasetsInfoCommand(Command):
 
         # Print basic information about all datasets
         fiftyone datasets info
+        fiftyone datasets info --glob-patt quick*
         fiftyone datasets info --sort-by created_at
         fiftyone datasets info --sort-by name --reverse
 
@@ -451,6 +460,12 @@ class DatasetsInfoCommand(Command):
             nargs="?",
             metavar="NAME",
             help="the name of a dataset",
+        )
+        parser.add_argument(
+            "-p",
+            "--glob-patt",
+            metavar="PATT",
+            help="an optional glob pattern of names to return",
         )
         parser.add_argument(
             "-s",
@@ -471,7 +486,7 @@ class DatasetsInfoCommand(Command):
         if args.name:
             _print_dataset_info(args.name)
         else:
-            _print_all_dataset_info(args.sort_by, args.reverse)
+            _print_all_dataset_info(args.glob_patt, args.sort_by, args.reverse)
 
 
 def _print_dataset_info(name):
@@ -479,8 +494,8 @@ def _print_dataset_info(name):
     print(dataset)
 
 
-def _print_all_dataset_info(sort_by, reverse):
-    info = fod.list_datasets(info=True)
+def _print_all_dataset_info(glob_patt, sort_by, reverse):
+    info = fod.list_datasets(glob_patt=glob_patt, info=True)
 
     headers = [
         "name",

--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -52,10 +52,11 @@ foud = fou.lazy_import("fiftyone.utils.data")
 logger = logging.getLogger(__name__)
 
 
-def list_datasets(info=False):
+def list_datasets(glob_patt=None, info=False):
     """Lists the available FiftyOne datasets.
 
     Args:
+        glob_patt (None): an optional glob pattern of names to return
         info (False): whether to return info dicts describing each dataset
             rather than just their names
 
@@ -63,9 +64,9 @@ def list_datasets(info=False):
         a list of dataset names or info dicts
     """
     if info:
-        return _list_dataset_info()
+        return _list_dataset_info(glob_patt=glob_patt)
 
-    return _list_datasets()
+    return _list_datasets(glob_patt=glob_patt)
 
 
 def dataset_exists(name):
@@ -198,8 +199,7 @@ def delete_datasets(glob_patt, verbose=False):
         glob_patt: a glob pattern of datasets to delete
         verbose (False): whether to log the names of deleted datasets
     """
-    all_datasets = _list_datasets()
-    for name in fnmatch.filter(all_datasets, glob_patt):
+    for name in _list_datasets(glob_patt=glob_patt):
         delete_dataset(name, verbose=verbose)
 
 
@@ -6280,7 +6280,7 @@ def _get_random_characters(n):
     )
 
 
-def _list_datasets(include_private=False):
+def _list_datasets(include_private=False, glob_patt=None):
     conn = foo.get_db_conn()
 
     if include_private:
@@ -6290,15 +6290,20 @@ def _list_datasets(include_private=False):
         # private e.g., patches or frames datasets
         query = {"sample_collection_name": {"$regex": "^samples\\."}}
 
+    if glob_patt is not None:
+        query["name"] = {"$regex": fnmatch.translate(glob_patt)}
+
     # We don't want an error here if `name == None`
     _sort = lambda l: sorted(l, key=lambda x: (x is None, x))
 
     return _sort(conn.datasets.find(query).distinct("name"))
 
 
-def _list_dataset_info():
+def _list_dataset_info(include_private=False, glob_patt=None):
     info = []
-    for name in _list_datasets():
+    for name in _list_datasets(
+        include_private=include_private, glob_patt=glob_patt
+    ):
         try:
             dataset = Dataset(name, _create=False, _virtual=True)
             num_samples = dataset._sample_collection.estimated_document_count()

--- a/tests/unittests/dataset_tests.py
+++ b/tests/unittests/dataset_tests.py
@@ -9,6 +9,8 @@ from copy import deepcopy, copy
 from datetime import date, datetime
 import gc
 import os
+import random
+import string
 import unittest
 
 from bson import ObjectId
@@ -30,7 +32,20 @@ from decorators import drop_datasets, skip_windows
 class DatasetTests(unittest.TestCase):
     @drop_datasets
     def test_list_datasets(self):
-        self.assertIsInstance(fo.list_datasets(), list)
+        names = fo.list_datasets()
+        self.assertIsInstance(names, list)
+
+        root = "".join(random.choice(string.ascii_letters) for _ in range(64))
+
+        fo.Dataset(root[:-1])
+        fo.Dataset(root)
+        fo.Dataset(root + "-foo")
+
+        names = fo.list_datasets(root + "-*")
+        self.assertEqual(len(names), 1)
+
+        names = fo.list_datasets(root + "*")
+        self.assertEqual(len(names), 2)
 
     @drop_datasets
     def test_dataset_names(self):


### PR DESCRIPTION
```py
import fiftyone as fo

fo.list_datasets()
# ['foo', 'bar', 'quickstart-groups', 'quickstart-video', ...]

fo.list_datasets("quickstart-*")
# 'quickstart-groups', 'quickstart-video']
```
