### PR TITLE
add support for jpg segmentations / heatmaps

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -47,5 +47,8 @@
     "workspaces": [
         "packages/*"
     ],
-    "packageManager": "yarn@3.2.1"
+    "packageManager": "yarn@3.2.1",
+    "dependencies": {
+        "jpeg-js": "^0.4.4"
+    }
 }

--- a/app/packages/looker/src/worker/index.ts
+++ b/app/packages/looker/src/worker/index.ts
@@ -14,6 +14,7 @@ import {
   VALID_LABEL_TYPES,
 } from "@fiftyone/utilities";
 import { decode as decodePng } from "fast-png";
+import { decode as decodeJpg } from "jpeg-js";
 import { CHUNK_SIZE } from "../constants";
 import { OverlayMask } from "../numpy";
 import { Coloring, FrameChunk, FrameSample, Sample } from "../state";
@@ -114,18 +115,24 @@ const imputeOverlayFromPath = async (
   }
 
   // convert absolute file path to a URL that we can "fetch" from
-  const overlayPngImageUrl = getSampleSrc(
+  const overlayImageUrl = getSampleSrc(
     sources[`${field}.${overlayPathField}`] || label[overlayPathField]
   );
 
-  const pngArrayBuffer: ArrayBuffer = await getFetchFunction()(
+  const overlayImageBuffer: ArrayBuffer = await getFetchFunction()(
     "GET",
-    overlayPngImageUrl,
+    overlayImageUrl,
     null,
     "arrayBuffer"
   );
 
-  const overlayData = decodePng(pngArrayBuffer);
+  let overlayData;
+
+  if (overlayImageUrl.endsWith(".png")) {
+    overlayData = decodePng(overlayImageBuffer);
+  } else {
+    overlayData = decodeJpg(overlayImageBuffer, { useTArray: true });
+  }
 
   const width = overlayData.width;
   const height = overlayData.height;

--- a/app/packages/looker/src/worker/index.ts
+++ b/app/packages/looker/src/worker/index.ts
@@ -128,10 +128,10 @@ const imputeOverlayFromPath = async (
 
   let overlayData;
 
-  if (overlayImageUrl.endsWith(".png")) {
-    overlayData = decodePng(overlayImageBuffer);
-  } else {
+  if (overlayImageUrl.endsWith(".jpg")) {
     overlayData = decodeJpg(overlayImageBuffer, { useTArray: true });
+  } else {
+    overlayData = decodePng(overlayImageBuffer);
   }
 
   const width = overlayData.width;

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -4453,6 +4453,7 @@ __metadata:
     eslint-plugin-prettier: ^4.2.1
     eslint-plugin-react: ^7.31.11
     eslint-plugin-react-hooks: ^4.6.0
+    jpeg-js: ^0.4.4
     jsdom: ^20.0.2
     patch-package: ^6.4.7
     prettier: ^2.8.0
@@ -18558,6 +18559,13 @@ __metadata:
   bin:
     jest: bin/jest.js
   checksum: 398a143d9ef1a78e2ba516a09b6343cb926bf20e29ad400141dd3bd57e964195b82817a60eb8745ba9006fcd7c028ceda5108e3c426fa4e29877f28d87cf88a3
+  languageName: node
+  linkType: hard
+
+"jpeg-js@npm:^0.4.4":
+  version: 0.4.4
+  resolution: "jpeg-js@npm:0.4.4"
+  checksum: bd7cb61aa8df40a9ee2c2106839c3df6054891e56cfc22c0ac581402e06c6295f962a4754b0b2ac50a401789131b1c6dc9df8d24400f1352168be1894833c590
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

Only png images were supported for `mask_path` / `map_path` for on-disk segmentations / heatmaps, this PR adds support for jpg as well.

## How is this patch tested? If it is not, please explain why.

Locally

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
