### PR TITLE
use FiftyOneJSONEncoder if datetime type exists in info field

### DIFF
--- a/app/packages/core/src/components/FieldLabelAndInfo/index.tsx
+++ b/app/packages/core/src/components/FieldLabelAndInfo/index.tsx
@@ -527,6 +527,7 @@ function toRenderValue([key, value], timeZone: string): [string, string] {
     case "boolean":
       return [key, value ? "True" : "False"];
     case "object":
+      console.log("here", key, ":", value);
       if (value._cls === "Date") {
         return [key, formatDate(value.datetime)];
       } else if (value._cls === "DateTime") {

--- a/fiftyone/core/state.py
+++ b/fiftyone/core/state.py
@@ -21,6 +21,7 @@ import fiftyone.core.dataset as fod
 import fiftyone.core.media as fom
 import fiftyone.core.utils as fou
 import fiftyone.core.view as fov
+from fiftyone.core.json import FiftyOneJSONEncoder
 from fiftyone.core.spaces import Space
 from fiftyone.server.scalars import JSON
 
@@ -221,7 +222,9 @@ def serialize_fields(schema: t.Dict) -> t.List[SampleField]:
                     embedded_doc_type=embedded_doc_type,
                     subfield=subfield,
                     description=field.description,
-                    info=field.info,
+                    info=json.loads(
+                        FiftyOneJSONEncoder.dumps(field.info or {})
+                    ),
                 )
             )
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

@benjaminpkane after running 
```
import fiftyone as fo
import fiftyone.zoo as foz
from datetime import datetime

dataset = foz.load_zoo_dataset("quickstart")

field = dataset.get_field("ground_truth")
field.info = {"created_at": datetime.utcnow(), "sample": float("inf")}
field.save()

session = fo.launch_app(dataset)
```
does not throw the error anymore but I can't see the date when hovering over the ground_truth field so maybe it needs a FE handle too?

Error before fix
```
App launched. Point your web browser to http://localhost:5151

Traceback (most recent call last):
  File "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/threading.py", line 980, in _bootstrap_inner
    self.run()
  File "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/threading.py", line 917, in run
    self._target(*self._args, **self._kwargs)
  File "/Users/Brian/dev/fiftyone/fiftyone/core/session/client.py", line 98, in run_client
    raise e
  File "/Users/Brian/dev/fiftyone/fiftyone/core/session/client.py", line 95, in run_client
    subscribe()
  File "/Users/Brian/dev/fiftyone/fiftyone/core/session/client.py", line 65, in subscribe
    response = requests.post(
  File "/Users/Brian/dev/env/fo/lib/python3.9/site-packages/requests/api.py", line 117, in post
    return request('post', url, data=data, json=json, **kwargs)
  File "/Users/Brian/dev/env/fo/lib/python3.9/site-packages/requests/api.py", line 61, in request
    return session.request(method=method, url=url, **kwargs)
  File "/Users/Brian/dev/env/fo/lib/python3.9/site-packages/requests/sessions.py", line 515, in request
    prep = self.prepare_request(req)
  File "/Users/Brian/dev/env/fo/lib/python3.9/site-packages/requests/sessions.py", line 443, in prepare_request
    p.prepare(
  File "/Users/Brian/dev/env/fo/lib/python3.9/site-packages/requests/models.py", line 321, in prepare
    self.prepare_body(data, files, json)
  File "/Users/Brian/dev/env/fo/lib/python3.9/site-packages/requests/models.py", line 473, in prepare_body
    body = complexjson.dumps(json, allow_nan=False)
  File "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/json/__init__.py", line 234, in dumps
    return cls(
  File "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/json/encoder.py", line 199, in encode
    chunks = self.iterencode(o, _one_shot=True)
  File "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/json/encoder.py", line 257, in iterencode
    return _iterencode(o, 0)
  File "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/json/encoder.py", line 179, in default
    raise TypeError(f'Object of type {o.__class__.__name__} '
TypeError: Object of type datetime is not JSON serializable
```

I would expect the UI to show the date when hovering over the field with new info data - but not seeing creation date

![Screen Shot 2023-04-03 at 12 10 56 PM](https://user-images.githubusercontent.com/109545780/229604317-b2962dcf-51a8-4671-91a4-c3830af37964.png)



(Please fill in changes proposed in this fix)

## How is this patch tested? If it is not, please explain why.

(Details)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
