### PR TITLE
Fix client serialization initialization

### DIFF
--- a/fiftyone/core/session/client.py
+++ b/fiftyone/core/session/client.py
@@ -69,17 +69,22 @@ class Client:
                         "Accept": "text/event-stream",
                         "Content-type": "application/json",
                     },
-                    json=asdict(
-                        ListenPayload(
-                            events=[
-                                "capture_notebook_cell",
-                                "close_session",
-                                "reactivate_notebook_cell",
-                                "reload_session",
-                                "state_update",
-                            ],
-                            initializer=state.serialize(),
-                            subscription=self._subscription,
+                    data=FiftyOneJSONEncoder.dumps(
+                        stringify(
+                            asdict(
+                                ListenPayload(
+                                    events=[
+                                        "capture_notebook_cell",
+                                        "close_session",
+                                        "reactivate_notebook_cell",
+                                        "reload_session",
+                                        "state_update",
+                                    ],
+                                    initializer=state.serialize(),
+                                    subscription=self._subscription,
+                                ),
+                                dict_factory=dict_factory,
+                            )
                         )
                     ),
                 )

--- a/fiftyone/core/session/client.py
+++ b/fiftyone/core/session/client.py
@@ -80,7 +80,7 @@ class Client:
                                         "reload_session",
                                         "state_update",
                                     ],
-                                    initializer=state.serialize(),
+                                    initializer=state,
                                     subscription=self._subscription,
                                 ),
                                 dict_factory=dict_factory,


### PR DESCRIPTION
Post data in `fiftyone.core.session.client.Client.run` initialization  the same way `post_event` does to fix `datetime` serialization when initializing a`Session` with a non-`None` dataset value

```py
import fiftyone as fo
import fiftyone.zoo as foz
from datetime import datetime

dataset = foz.load_zoo_dataset("quickstart")

field = dataset.get_field("ground_truth")
field.info = {"created_at": datetime.utcnow(), "sample": float("inf")}
field.save()

session = fo.launch_app(dataset) # previously would fail
```