### PR TITLE
Removes supports prompts warning from server

### DIFF
--- a/fiftyone/server/query.py
+++ b/fiftyone/server/query.py
@@ -126,7 +126,6 @@ class BrainRunConfig(RunConfig):
             return cls(
                 embeddings_field=self.embeddings_field,
                 patches_field=self.patches_field,
-                supports_prompts=self.supports_prompts,
             )
         except:
             return None


### PR DESCRIPTION
Creating a brain config does not require the `kwarg`