### PR TITLE
Fix field mask targets for RGB

### DIFF
--- a/app/packages/looker/src/worker/index.ts
+++ b/app/packages/looker/src/worker/index.ts
@@ -191,7 +191,11 @@ const processLabels = async (
 
     if (painterFactory[label._cls]) {
       promises.push(
-        painterFactory[label._cls](prefix + field, label, coloring)
+        painterFactory[label._cls](
+          prefix ? prefix + field : field,
+          label,
+          coloring
+        )
       );
     }
   }


### PR DESCRIPTION
Fixes field mask targets for RGB segmentations:

```py
import fiftyone as fo
import fiftyone.zoo as foz
import fiftyone.utils.labels as foul

dataset = foz.load_zoo_dataset(
    "coco-2017",
    split="validation",
    label_types="segmentations",
    classes=["chair", "couch"],
    max_samples=3,
)

labels = dataset.distinct("ground_truth.detections.label")

color_pool = [
    "#ee0000", "#ee6600", "#993300", "#996633", "#999900", "#009900",
    "#003300", "#009999", "#000099", "#0066ff", "#6600ff", "#cc33cc", "#777799"
]

cmap2d = {idx: lbl for idx, lbl in enumerate(labels)}
print(cmap2d)

cmap3d = {color_pool[idx]: lbl for idx, lbl in enumerate(labels)}
print(cmap3d)

foul.objects_to_segmentations(dataset, "ground_truth", "seg2d_binary")

foul.objects_to_segmentations(
    dataset,
    "ground_truth",
    "seg2d",
    mask_targets=cmap2d,
    save_mask_targets=True,
)

foul.objects_to_segmentations(
    dataset,
    "ground_truth",
    "seg3d",
    mask_targets=cmap3d,
    save_mask_targets=True,
)

dataset.default_mask_targets = None
dataset.mask_targets = {"seg2d": cmap2d, "seg3d": cmap3d}
dataset.save()

session = fo.launch_app(dataset)
```
