### PR TITLE
on-disk heatmap bug part 2

### DIFF
--- a/app/packages/looker/src/overlays/heatmap.ts
+++ b/app/packages/looker/src/overlays/heatmap.ts
@@ -230,6 +230,11 @@ export default class HeatmapOverlay<State extends BaseState>
     if (index < 0) {
       return null;
     }
+
+    if (this.label.map.data.channels > 1) {
+      return this.targets[index * this.label.map.data.channels];
+    }
+
     return this.targets[index];
   }
 }

--- a/app/packages/looker/src/overlays/util.ts
+++ b/app/packages/looker/src/overlays/util.ts
@@ -85,3 +85,15 @@ export function isRgbMaskTargets(
 
   return Object.keys(maskTargets)[0]?.startsWith("#") === true;
 }
+
+export function normalizeMaskTargetsCase(maskTargets: MaskTargets) {
+  if (!maskTargets || !isRgbMaskTargets(maskTargets)) {
+    return maskTargets;
+  }
+
+  const normalizedMaskTargets: RgbMaskTargets = {};
+  Object.entries(maskTargets).forEach(([key, value]) => {
+    normalizedMaskTargets[key.toLocaleUpperCase()] = value;
+  });
+  return normalizedMaskTargets;
+}

--- a/app/packages/looker/src/worker/index.ts
+++ b/app/packages/looker/src/worker/index.ts
@@ -137,9 +137,12 @@ const imputeOverlayFromPath = async (
   const width = overlayData.width;
   const height = overlayData.height;
 
+  const numChannels =
+    overlayData.channels ?? overlayData.data.length / (width * height);
+
   const overlayMask: OverlayMask = {
     buffer: overlayData.data.buffer,
-    channels: overlayData.channels,
+    channels: numChannels,
     arrayType: overlayData.data.constructor.name as OverlayMask["arrayType"],
     shape: [height, width],
   };

--- a/app/packages/looker/src/worker/painter.ts
+++ b/app/packages/looker/src/worker/painter.ts
@@ -52,47 +52,56 @@ export const PainterFactory = (requestColor) => ({
       label.map.data.buffer
     );
 
-    if (mapData.channels > 2) {
-      // rgb map
-      for (let i = 0; i < overlay.length; i++) {
-        overlay[i] = get32BitColor(
-          getRgbFromMaskData(targets, mapData.channels, i)
-        );
-      }
-    } else {
-      const [start, stop] = label.range
-        ? label.range
-        : isFloatArray(targets)
-        ? [0, 1]
-        : [0, 255];
-      const max = Math.max(Math.abs(start), Math.abs(stop));
+    const [start, stop] = label.range
+      ? label.range
+      : isFloatArray(targets)
+      ? [0, 1]
+      : [0, 255];
+    const color = await requestColor(coloring.pool, coloring.seed, field);
 
-      const color = await requestColor(coloring.pool, coloring.seed, field);
+    const getColor =
+      coloring.by === "label"
+        ? (value) => {
+            if (value === 0) {
+              return 0;
+            }
 
-      const getColor =
-        coloring.by === "label"
-          ? (value) => {
-              if (value === 0) {
-                return 0;
-              }
+            const index = Math.round(
+              (Math.max(value - start, 0) / (stop - start)) *
+                (coloring.scale.length - 1)
+            );
 
-              const index = Math.round(
-                (Math.max(value - start, 0) / (stop - start)) *
-                  (coloring.scale.length - 1)
+            return get32BitColor(coloring.scale[index]);
+          }
+        : (value) => {
+            if (value === 0) {
+              return 0;
+            }
+
+            const rangeMidPoint = (start + stop) / 2;
+            const maxDeviationFromMidpoint = Math.max(
+              stop - rangeMidPoint,
+              rangeMidPoint - start
+            );
+            // alpha is 1 when value is at midpoint, 0 when value is at start or stop
+            const alpha =
+              1 -
+              Math.min(
+                Math.abs(value - rangeMidPoint) / maxDeviationFromMidpoint,
+                1
               );
 
-              return get32BitColor(coloring.scale[index]);
-            }
-          : (value) => {
-              if (value === 0) {
-                return 0;
-              }
+            return get32BitColor(color, alpha);
+          };
 
-              return get32BitColor(color, Math.min(max, Math.abs(value)) / max);
-            };
-      // these for loops must be fast. no "in" or "of" syntax
-      for (let i = 0; i < overlay.length; i++) {
-        if (targets[i] !== 0) {
+    // these for loops must be fast. no "in" or "of" syntax
+    for (let i = 0; i < overlay.length; i++) {
+      if (targets[i] !== 0) {
+        if (mapData.channels > 2) {
+          overlay[i] = getColor(
+            getRgbFromMaskData(targets, mapData.channels, i)[0]
+          );
+        } else {
           overlay[i] = getColor(targets[i]);
         }
       }

--- a/app/packages/looker/src/worker/painter.ts
+++ b/app/packages/looker/src/worker/painter.ts
@@ -74,22 +74,17 @@ export const PainterFactory = (requestColor) => ({
             return get32BitColor(coloring.scale[index]);
           }
         : (value) => {
-            if (value === 0) {
-              return 0;
+            // render in field’s color with opacity proportional to the magnitude of the heatmap’s value
+            const absMax = Math.max(Math.abs(start), Math.abs(stop));
+
+            // clip value
+            if (value < start) {
+              value = start;
+            } else if (value > stop) {
+              value = stop;
             }
 
-            const rangeMidPoint = (start + stop) / 2;
-            const maxDeviationFromMidpoint = Math.max(
-              stop - rangeMidPoint,
-              rangeMidPoint - start
-            );
-            // alpha is 1 when value is at midpoint, 0 when value is at start or stop
-            const alpha =
-              1 -
-              Math.min(
-                Math.abs(value - rangeMidPoint) / maxDeviationFromMidpoint,
-                1
-              );
+            const alpha = 1 - Math.abs(value) / absMax;
 
             return get32BitColor(color, alpha);
           };


### PR DESCRIPTION
## What changes are proposed in this pull request?

Fixes bug in RGB heatmaps. 

## How is this patch tested? If it is not, please explain why.

Locally.

```py
import os
import numpy as np

import fiftyone as fo
import fiftyone.zoo as foz

def random_kernel(metadata):
    h = metadata.height // 2
    w = metadata.width // 2
    sign = np.sign(np.random.randn())
    x, y = np.meshgrid(np.linspace(-1, 1, w), np.linspace(-1, 1, h))
    x0, y0 = np.random.random(2) - 0.5
    kernel = sign * np.exp(-np.sqrt((x - x0) ** 2 + (y - y0) ** 2))
    return fo.Heatmap(map=kernel, range=[-1, 1])

dataset = foz.load_zoo_dataset("quickstart").select_fields().clone()
dataset.compute_metadata()

for sample in dataset:
    heatmap = random_kernel(sample.metadata)

    # Convert to on-disk
    map_path = os.path.join("/tmp/heatmaps", os.path.basename(sample.filepath))
    heatmap.export_map(map_path, update=True)

    sample["heatmap"] = heatmap
    sample.save()

session = fo.launch_app(dataset)
```

![2023-04-04 13 38 16](https://user-images.githubusercontent.com/66688606/229887920-2a41d469-bd3c-438c-893b-a6a6ab89fe75.gif)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
