### PR TITLE
Adding support for list fields to dynamic schema methods

### DIFF
--- a/docs/source/user_guide/using_datasets.rst
+++ b/docs/source/user_guide/using_datasets.rst
@@ -1159,6 +1159,10 @@ on all samples in the dataset with the value `None`:
 .. code-block:: python
     :linenos:
 
+    print(sample)
+
+.. code-block:: text
+
     <Sample: {
         'id': '642d8848f291652133df8d3a',
         'media_type': 'image',
@@ -1213,7 +1217,7 @@ to recursively inspect its nested fields:
     # Directly retrieve a nested field
     field = dataset.get_field("predictions.breed")
     print(type(field))
-    # fiftyone.core.fields.StringField
+    # <class 'fiftyone.core.fields.StringField'>
 
 If your dataset contains a |ListField| with no value type declared, you can add
 the type later by appending `[]` to the field path:
@@ -1237,7 +1241,7 @@ the type later by appending `[]` to the field path:
         embedded_doc_type=fo.DynamicEmbeddedDocument,
     )
 
-    field = dataset.get_field("more_tags")
+    field = dataset.get_field("info")
     print(field.field)  # EmbeddedDocumentField
     print(field.field.document_type)  # DynamicEmbeddedDocument
 

--- a/docs/source/user_guide/using_datasets.rst
+++ b/docs/source/user_guide/using_datasets.rst
@@ -1094,6 +1094,158 @@ Setting a field to an inappropriate type raises an error:
     order to persist changes to the database when editing samples that are in
     datasets.
 
+.. _adding-dataset-fields:
+
+Adding fields to a dataset
+--------------------------
+
+You can also use
+:meth:`add_sample_field() <fiftyone.core.dataset.Dataset.add_sample_field>` to
+declare new sample fields directly on datasets without explicitly populating
+any values on its samples:
+
+.. code-block:: python
+    :linenos:
+
+    import fiftyone as fo
+
+    sample = fo.Sample(
+        filepath="image.jpg",
+        ground_truth=fo.Classification(label="cat"),
+    )
+
+    dataset = fo.Dataset()
+    dataset.add_sample(sample)
+
+    # Declare new primitive fields
+    dataset.add_sample_field("scene_id", fo.StringField)
+    dataset.add_sample_field("quality", fo.FloatField)
+
+    # Declare untyped list fields
+    dataset.add_sample_field("more_tags", fo.ListField)
+    dataset.add_sample_field("info", fo.ListField)
+
+    # Declare a typed list field
+    dataset.add_sample_field("also_tags", fo.ListField, subfield=fo.StringField)
+
+    # Declare a new Label field
+    dataset.add_sample_field(
+        "predictions",
+        fo.EmbeddedDocumentField,
+        embedded_doc_type=fo.Classification,
+    )
+
+    print(dataset.get_field_schema())
+
+.. code-block:: text
+
+    {
+        'id': <fiftyone.core.fields.ObjectIdField object at 0x7f9280803910>,
+        'filepath': <fiftyone.core.fields.StringField object at 0x7f92d273e0d0>,
+        'tags': <fiftyone.core.fields.ListField object at 0x7f92d2654f70>,
+        'metadata': <fiftyone.core.fields.EmbeddedDocumentField object at 0x7f9280803d90>,
+        'ground_truth': <fiftyone.core.fields.EmbeddedDocumentField object at 0x7f92d2605190>,
+        'scene_id': <fiftyone.core.fields.StringField object at 0x7f9280803490>,
+        'quality': <fiftyone.core.fields.FloatField object at 0x7f92d2605bb0>,
+        'more_tags': <fiftyone.core.fields.ListField object at 0x7f92d08e4550>,
+        'info': <fiftyone.core.fields.ListField object at 0x7f92d264f9a0>,
+        'also_tags': <fiftyone.core.fields.ListField object at 0x7f92d264ff70>,
+        'predictions': <fiftyone.core.fields.EmbeddedDocumentField object at 0x7f92d2605640>,
+    }
+
+Whenever a new field is added to a dataset, the field is immediately available
+on all samples in the dataset with the value `None`:
+
+.. code-block:: python
+    :linenos:
+
+    <Sample: {
+        'id': '642d8848f291652133df8d3a',
+        'media_type': 'image',
+        'filepath': '/Users/Brian/dev/fiftyone/image.jpg',
+        'tags': [],
+        'metadata': None,
+        'ground_truth': <Classification: {
+            'id': '642d8848f291652133df8d38',
+            'tags': [],
+            'label': 'cat',
+            'confidence': None,
+            'logits': None,
+        }>,
+        'scene_id': None,
+        'quality': None,
+        'more_tags': None,
+        'info': None,
+        'also_tags': None,
+        'predictions': None,
+    }>
+
+You can also declare nested fields on existing embedded documents using dot
+notation:
+
+.. code-block:: python
+    :linenos:
+
+    # Declare a new attribute on a `Classification` field
+    dataset.add_sample_field("predictions.breed", fo.StringField)
+
+.. note::
+
+    See :ref:`this section <dynamic-attributes>` for more options for
+    dynamically expanding the schema of nested lists and embedded documents.
+
+You can use :meth:`get_field() <fiftyone.core.dataset.Dataset.get_field>` to
+retrieve a |Field| instance by its name or ``embedded.field.name``. And, if the
+field contains an embedded document, you can call
+:meth:`get_field_schema() <fiftyone.core.fields.EmbeddedDocumentField.get_field_schema>`
+to recursively inspect its nested fields:
+
+.. code-block:: python
+    :linenos:
+
+    field = dataset.get_field("predictions")
+    print(field.document_type)
+    # <class 'fiftyone.core.labels.Classification'>
+
+    print(set(field.get_field_schema().keys()))
+    # {'logits', 'confidence', 'breed', 'tags', 'label', 'id'}
+
+    # Directly retrieve a nested field
+    field = dataset.get_field("predictions.breed")
+    print(type(field))
+    # fiftyone.core.fields.StringField
+
+If your dataset contains a |ListField| with no value type declared, you can add
+the type later by appending `[]` to the field path:
+
+.. code-block:: python
+    :linenos:
+
+    field = dataset.get_field("more_tags")
+    print(field.field)  # None
+
+    # Declare the subfield types of an existing untyped list field
+    dataset.add_sample_field("more_tags[]", fo.StringField)
+
+    field = dataset.get_field("more_tags")
+    print(field.field)  # StringField
+
+    # List fields can also contain embedded documents
+    dataset.add_sample_field(
+        "info[]",
+        fo.EmbeddedDocumentField,
+        embedded_doc_type=fo.DynamicEmbeddedDocument,
+    )
+
+    field = dataset.get_field("more_tags")
+    print(field.field)  # EmbeddedDocumentField
+    print(field.field.document_type)  # DynamicEmbeddedDocument
+
+.. note::
+
+    Declaring the value type of list fields is required if you want to filter
+    by the list's values :ref:`in the App <app-filtering>`.
+
 .. _editing-sample-fields:
 
 Editing sample fields

--- a/fiftyone/__public__.py
+++ b/fiftyone/__public__.py
@@ -25,6 +25,7 @@ from .core.aggregations import (
     Mean,
     Quantiles,
     Schema,
+    ListSchema,
     Std,
     Sum,
     Values,

--- a/fiftyone/core/aggregations.py
+++ b/fiftyone/core/aggregations.py
@@ -1913,8 +1913,7 @@ class Schema(Aggregation):
 
         schema = {}
         for name, raw_types in raw_schema.items():
-            types = _resolve_types(raw_types)
-            schema[name] = types[0] if len(types) == 1 else types
+            schema[name] = _resolve_types(raw_types)
 
         return schema
 
@@ -1989,6 +1988,198 @@ class Schema(Aggregation):
         return pipeline
 
 
+class ListSchema(Aggregation):
+    """Extracts the value type(s) in a specified list field across all samples
+    in a collection.
+
+    Examples::
+
+        from datetime import datetime
+        import fiftyone as fo
+
+        dataset = fo.Dataset()
+
+        sample1 = fo.Sample(
+            filepath="image1.png",
+            ground_truth=fo.Classification(
+                label="cat",
+                info=[
+                    fo.DynamicEmbeddedDocument(
+                        task="initial_annotation",
+                        author="Alice",
+                        timestamp=datetime(1970, 1, 1),
+                        notes=["foo", "bar"],
+                    ),
+                    fo.DynamicEmbeddedDocument(
+                        task="editing_pass",
+                        author="Bob",
+                        timestamp=datetime.utcnow(),
+                    ),
+                ],
+            ),
+        )
+
+        sample2 = fo.Sample(
+            filepath="image2.png",
+            ground_truth=fo.Classification(
+                label="dog",
+                info=[
+                    fo.DynamicEmbeddedDocument(
+                        task="initial_annotation",
+                        author="Bob",
+                        timestamp=datetime(2018, 10, 18),
+                        notes=["spam", "eggs"],
+                    ),
+                ],
+            ),
+        )
+
+        dataset.add_samples([sample1, sample2])
+
+        # Determine that `ground_truth.info` contains embedded documents
+        aggregation = fo.ListSchema("ground_truth.info")
+        print(dataset.aggregate(aggregation))
+        # fo.EmbeddedDocumentField
+
+        # Determine the fields of the embedded documents in the list
+        aggregation = fo.Schema("ground_truth.info[]")
+        print(dataset.aggregate(aggregation))
+        # {'task': StringField, ..., 'notes': ListField}
+
+        # Determine the type of the values in the nested `notes` list field
+        # Since `ground_truth.info` is not yet declared on the dataset's
+        # schema, we must manually include `[]` to unwind the info lists
+        aggregation = fo.ListSchema("ground_truth.info[].notes")
+        print(dataset.aggregate(aggregation))
+        # fo.StringField
+
+        # Declare the `ground_truth.info` field
+        dataset.add_sample_field(
+            "ground_truth.info",
+            fo.ListField,
+            subfield=fo.EmbeddedDocumentField,
+            embedded_doc_type=fo.DynamicEmbeddedDocument,
+        )
+
+        # Now we can inspect the nested `notes` field without unwinding
+        aggregation = fo.ListSchema("ground_truth.info.notes")
+        print(dataset.aggregate(aggregation))
+        # fo.StringField
+
+    Args:
+        field_or_expr: a field name, ``embedded.field.name``,
+            :class:`fiftyone.core.expressions.ViewExpression`, or
+            `MongoDB expression <https://docs.mongodb.com/manual/meta/aggregation-quick-reference/#aggregation-expressions>`_
+            defining the field or expression to aggregate
+        expr (None): a :class:`fiftyone.core.expressions.ViewExpression` or
+            `MongoDB expression <https://docs.mongodb.com/manual/meta/aggregation-quick-reference/#aggregation-expressions>`_
+            to apply to ``field_or_expr`` (which must be a field) before
+            aggregating
+    """
+
+    def __init__(self, field_or_expr, expr=None):
+        super().__init__(field_or_expr, expr=expr)
+
+    def _kwargs(self):
+        return [["field_or_expr", self._field_name], ["expr", self._expr]]
+
+    def default_result(self):
+        """Returns the default result for this aggregation.
+
+        Returns:
+            ``[]``
+        """
+        return []
+
+    def parse_result(self, d):
+        """Parses the output of :meth:`to_mongo`.
+
+        Args:
+            d: the result dict
+
+        Returns:
+            a :class:`fiftyone.core.fields.Field` or list of
+            :class:`fiftyone.core.fields.Field` instances describing the value
+            type(s) in the list
+        """
+        raw_types = set()
+        for _type in d["schema"]:
+            if "." in _type:
+                _type, _cls = _type.split(".", 1)
+                try:
+                    document_type = get_document(_cls)
+                    field = fof.EmbeddedDocumentField(document_type)
+                except Exception as e:
+                    field = None
+                    logger.warning(
+                        "Unable to load document class '%s': %s", _cls, e
+                    )
+            else:
+                field = _MONGO_TO_FIFTYONE_TYPES.get(_type, None)
+
+            raw_types.add(field)
+
+        return _resolve_types(raw_types)
+
+    def to_mongo(self, sample_collection, context=None):
+        field_name = self._field_name
+
+        path, pipeline, _, _, _ = _parse_field_and_expr(
+            sample_collection,
+            field_name,
+            expr=self._expr,
+            context=context,
+        )
+
+        field_type_expr = {
+            "$let": {
+                "vars": {"ftype": {"$type": "$" + path}},
+                "in": {
+                    "$cond": {
+                        "if": {
+                            "$and": [
+                                {
+                                    "$eq": [
+                                        "$$ftype",
+                                        "object",
+                                    ]
+                                },
+                                {
+                                    "$gt": [
+                                        "$" + path + "._cls",
+                                        None,
+                                    ]
+                                },
+                            ],
+                        },
+                        "then": {
+                            "$concat": [
+                                "$$ftype",
+                                ".",
+                                "$" + path + "._cls",
+                            ]
+                        },
+                        "else": "$$ftype",
+                    }
+                },
+            }
+        }
+
+        pipeline.extend(
+            [
+                {"$unwind": "$" + path},
+                {
+                    "$group": {
+                        "_id": None,
+                        "schema": {"$addToSet": field_type_expr},
+                    }
+                },
+            ]
+        )
+
+        return pipeline
+
+
 def _resolve_types(raw_types):
     types = []
     for t in raw_types:
@@ -2006,7 +2197,7 @@ def _resolve_types(raw_types):
         ):
             types = [fof.FloatField()]
 
-    return types
+    return types[0] if len(types) == 1 else types
 
 
 class Std(Aggregation):

--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -1214,7 +1214,7 @@ class SampleCollection(object):
 
         dynamic_schema = self._do_get_dynamic_field_schema(schema, prefix)
 
-        # Recursive into new dynamic fields
+        # Recurse into new dynamic fields
         if recursive:
             s = dynamic_schema
             while True:

--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -1375,7 +1375,7 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
                     logger.warning(
                         "Skipping dynamic list field '%s' with mixed types %s",
                         path,
-                        field.field,
+                        [type(f) for f in field.field],
                     )
                     field = None
             elif etau.is_container(field):
@@ -1385,7 +1385,7 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
                     logger.warning(
                         "Skipping dynamic field '%s' with mixed types %s",
                         path,
-                        field,
+                        [type(f) for f in field],
                     )
                     field = None
 
@@ -1523,7 +1523,7 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
                         "Skipping dynamic list frame field '%s' with mixed "
                         "types %s",
                         path,
-                        field.field,
+                        [type(f) for f in field.field],
                     )
                     field = None
             elif etau.is_container(field):
@@ -1533,7 +1533,7 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
                     logger.warning(
                         "Skipping dynamic fra,e field '%s' with mixed types %s",
                         path,
-                        field,
+                        [type(f) for f in field],
                     )
                     field = None
 

--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -1531,7 +1531,7 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
                     field = fof.Field()
                 else:
                     logger.warning(
-                        "Skipping dynamic fra,e field '%s' with mixed types %s",
+                        "Skipping dynamic frame field '%s' with mixed types %s",
                         path,
                         [type(f) for f in field],
                     )

--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -1370,7 +1370,7 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
                 field.field
             ):
                 if add_mixed:
-                    field.field = None
+                    field.field = fof.Field()
                 else:
                     logger.warning(
                         "Skipping dynamic list field '%s' with mixed types %s",
@@ -1517,7 +1517,7 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
                 field.field
             ):
                 if add_mixed:
-                    field.field = None
+                    field.field = fof.Field()
                 else:
                     logger.warning(
                         "Skipping dynamic list frame field '%s' with mixed "

--- a/tests/unittests/aggregation_tests.py
+++ b/tests/unittests/aggregation_tests.py
@@ -330,6 +330,92 @@ class DatasetTests(unittest.TestCase):
                 self.assertEqual(type(schema[key]), ftype)
 
     @drop_datasets
+    def test_list_schema(self):
+        d = fo.Dataset()
+        d.add_samples(
+            [
+                fo.Sample(
+                    filepath="image1.png",
+                    ground_truth=fo.Classification(
+                        label="cat",
+                        info=[
+                            fo.DynamicEmbeddedDocument(
+                                task="initial_annotation",
+                                author="Alice",
+                                timestamp=datetime(1970, 1, 1),
+                                notes=["foo", "bar"],
+                                ints=[1],
+                                floats=[1.0],
+                                mixed=[1, "foo"],
+                            ),
+                            fo.DynamicEmbeddedDocument(
+                                task="editing_pass",
+                                author="Bob",
+                                timestamp=datetime.utcnow(),
+                            ),
+                        ],
+                    ),
+                ),
+                fo.Sample(
+                    filepath="image2.png",
+                    ground_truth=fo.Classification(
+                        label="dog",
+                        info=[
+                            fo.DynamicEmbeddedDocument(
+                                task="initial_annotation",
+                                author="Bob",
+                                timestamp=datetime(2018, 10, 18),
+                                notes=["spam", "eggs"],
+                                ints=[2],
+                                floats=[2],
+                                mixed=[2.0],
+                            ),
+                        ],
+                    ),
+                ),
+            ]
+        )
+
+        field = d.list_schema("ground_truth.info")
+        self.assertIsInstance(field, fo.EmbeddedDocumentField)
+        self.assertEqual(field.document_type, fo.DynamicEmbeddedDocument)
+
+        schema = d.schema("ground_truth.info[]")
+        self.assertIsInstance(schema["task"], fo.StringField)
+        self.assertIsInstance(schema["author"], fo.StringField)
+        self.assertIsInstance(schema["timestamp"], fo.DateTimeField)
+        self.assertIsInstance(schema["notes"], fo.ListField)
+        self.assertIsInstance(schema["ints"], fo.ListField)
+        self.assertIsInstance(schema["floats"], fo.ListField)
+        self.assertIsInstance(schema["mixed"], fo.ListField)
+
+        field = d.list_schema("ground_truth.info[].notes")
+        self.assertIsInstance(field, fo.StringField)
+
+        field = d.list_schema("ground_truth.info[].ints")
+        self.assertIsInstance(field, fo.IntField)
+
+        field = d.list_schema("ground_truth.info[].floats")
+        self.assertIsInstance(field, fo.FloatField)
+
+        fields = d.list_schema("ground_truth.info[].mixed")
+        self.assertIsInstance(fields, list)
+        self.assertEqual(len(fields), 3)
+
+        d.add_sample_field(
+            "ground_truth.info",
+            fo.ListField,
+            subfield=fo.EmbeddedDocumentField,
+            embedded_doc_type=fo.DynamicEmbeddedDocument,
+        )
+
+        field = d.list_schema("ground_truth.info.notes")
+        self.assertIsInstance(field, fo.StringField)
+
+        schema = d.schema("ground_truth.info")
+        self.assertEqual(len(schema), 7)
+
+    @drop_datasets
     def test_quantiles(self):
         d = fo.Dataset()
         d.add_sample_field("numeric_field", fo.IntField)

--- a/tests/unittests/aggregation_tests.py
+++ b/tests/unittests/aggregation_tests.py
@@ -1131,6 +1131,7 @@ class DatasetTests(unittest.TestCase):
             ),
             fo.Mean("predictions.detections[]", expr=bbox_area),
             fo.Schema("predictions.detections"),
+            fo.ListSchema("predictions.detections[]"),
             fo.Std("predictions.detections[]", expr=bbox_area),
             fo.Sum("predictions.detections", expr=F().length()),
             fo.Values("id"),

--- a/tests/unittests/dataset_tests.py
+++ b/tests/unittests/dataset_tests.py
@@ -1085,6 +1085,41 @@ class DatasetTests(unittest.TestCase):
             )
 
     @drop_datasets
+    def test_add_list_subfield(self):
+        sample = fo.Sample(
+            filepath="image.jpg",
+            ground_truth=fo.Classification(
+                label="cat",
+                info=[
+                    fo.DynamicEmbeddedDocument(
+                        author="Alice",
+                        notes=["foo", "bar"],
+                    ),
+                    fo.DynamicEmbeddedDocument(author="Bob"),
+                ],
+            ),
+        )
+
+        dataset = fo.Dataset()
+        dataset.add_sample(sample)
+
+        dataset.add_sample_field("ground_truth.info", fo.ListField)
+
+        field = dataset.get_field("ground_truth.info")
+        self.assertIsNone(field.field)
+
+        # Syntax for declaring the subfield type of an existing list field
+        dataset.add_sample_field(
+            "ground_truth.info[]",
+            fo.EmbeddedDocumentField,
+            embedded_doc_type=fo.DynamicEmbeddedDocument,
+        )
+
+        field = dataset.get_field("ground_truth.info")
+        self.assertIsInstance(field.field, fo.EmbeddedDocumentField)
+        self.assertEqual(field.field.document_type, fo.DynamicEmbeddedDocument)
+
+    @drop_datasets
     def test_merge_samples1(self):
         # Windows compatibility
         def expand_path(path):

--- a/tests/unittests/dataset_tests.py
+++ b/tests/unittests/dataset_tests.py
@@ -4382,7 +4382,7 @@ class DynamicFieldTests(unittest.TestCase):
 
         field = schema["ground_truth.info.mixed"]
         self.assertIsInstance(field, fo.ListField)
-        self.assertIsNone(field.field)
+        self.assertIsInstance(field.field, fo.Field)
 
     @drop_datasets
     def test_dynamic_frame_fields_nested(self):


### PR DESCRIPTION
The `get_dynamic_field_schema()` and `add_dynamic_sample_fields()` methods now support nested list fields.

In order to implement this, we needed a method to inspect the value type(s) of list fields across a collection, which is now exposed publicly as a new `list_schema()` aggregation.

## List schema usage

```py
from datetime import datetime
import fiftyone as fo

dataset = fo.Dataset()

sample1 = fo.Sample(
    filepath="image1.png",
    ground_truth=fo.Classification(
        label="cat",
        info=[
            fo.DynamicEmbeddedDocument(
                task="initial_annotation",
                author="Alice",
                timestamp=datetime(1970, 1, 1),
                notes=["foo", "bar"],
            ),
            fo.DynamicEmbeddedDocument(
                task="editing_pass",
                author="Bob",
                timestamp=datetime.utcnow(),
            ),
        ],
    ),
)

sample2 = fo.Sample(
    filepath="image2.png",
    ground_truth=fo.Classification(
        label="dog",
        info=[
            fo.DynamicEmbeddedDocument(
                task="initial_annotation",
                author="Bob",
                timestamp=datetime(2018, 10, 18),
                notes=["spam", "eggs"],
            ),
        ],
    ),
)

dataset.add_samples([sample1, sample2])

# Determine that `ground_truth.info` contains embedded documents
print(dataset.list_schema("ground_truth.info"))
# fo.EmbeddedDocumentField

# Determine the fields of the embedded documents in the list
print(dataset.schema("ground_truth.info[]"))
# {'task': StringField, ..., 'notes': ListField}

# Determine the type of the values in the nested `notes` list field
# Since `ground_truth.info` is not yet declared on the dataset's
# schema, we must manually include `[]` to unwind the info lists
print(dataset.list_schema("ground_truth.info[].notes"))
# fo.StringField

# Declare the `ground_truth.info` field
dataset.add_sample_field(
    "ground_truth.info",
    fo.ListField,
    subfield=fo.EmbeddedDocumentField,
    embedded_doc_type=fo.DynamicEmbeddedDocument,
)

# Now we can inspect the nested `notes` field without unwinding
print(dataset.list_schema("ground_truth.info.notes"))
# fo.StringField
```

## Dynamic sample usage

```py
from datetime import datetime
import fiftyone as fo

dataset = fo.Dataset()
dataset.add_samples(
    [
        fo.Sample(
            filepath="image1.png",
            ground_truth=fo.Classification(
                label="cat",
                info=[
                    fo.DynamicEmbeddedDocument(
                        task="initial_annotation",
                        author="Alice",
                        timestamp=datetime(1970, 1, 1),
                        notes=["foo", "bar"],
                        ints=[1],
                        floats=[1.0],
                        mixed=[1, "foo"],
                    ),
                    fo.DynamicEmbeddedDocument(
                        task="editing_pass",
                        author="Bob",
                        timestamp=datetime.utcnow(),
                    ),
                ],
            ),
        ),
        fo.Sample(
            filepath="image2.png",
            ground_truth=fo.Classification(
                label="dog",
                info=[
                    fo.DynamicEmbeddedDocument(
                        task="initial_annotation",
                        author="Bob",
                        timestamp=datetime(2018, 10, 18),
                        notes=["spam", "eggs"],
                        ints=[2],
                        floats=[2],
                        mixed=[2.0],
                    ),
                ],
            ),
        )
    ]
)

fo.pprint(dataset.get_dynamic_field_schema())
```

```
{
    'ground_truth.info': <fiftyone.core.fields.ListField at 0x7fca8a4ec460>,
    'ground_truth.info.mixed': <fiftyone.core.fields.ListField at 0x7fca8a4fa430>,
    'ground_truth.info.author': <fiftyone.core.fields.StringField at 0x7fca48b858b0>,
    'ground_truth.info.task': <fiftyone.core.fields.StringField at 0x7fca48b858e0>,
    'ground_truth.info.ints': <fiftyone.core.fields.ListField at 0x7fca48b85640>,
    'ground_truth.info.floats': <fiftyone.core.fields.ListField at 0x7fca48b85ca0>,
    'ground_truth.info.notes': <fiftyone.core.fields.ListField at 0x7fca48b85b80>,
    'ground_truth.info.timestamp': <fiftyone.core.fields.DateTimeField at 0x7fca48b85bb0>,
}
```

```py
dataset.add_dynamic_sample_fields()
# Skipping dynamic list field 'ground_truth.info.mixed' with mixed types [IntField, FloatField, StringField]

fo.pprint(dataset.get_field_schema(flat=True))
```

```
{
    'id': <fiftyone.core.fields.ObjectIdField object at 0x7fca48b85e80>,
    'filepath': <fiftyone.core.fields.StringField object at 0x7fca8a4ecbe0>,
    'tags': <fiftyone.core.fields.ListField object at 0x7fca8a4ecaf0>,
    'metadata': <fiftyone.core.fields.EmbeddedDocumentField object at 0x7fca8a4ecac0>,
    'metadata.size_bytes': <fiftyone.core.fields.IntField object at 0x7fca8a4ecd60>,
    'metadata.mime_type': <fiftyone.core.fields.StringField object at 0x7fca8a4ecd90>,
    'metadata.width': <fiftyone.core.fields.IntField object at 0x7fca8a4ec9d0>,
    'metadata.height': <fiftyone.core.fields.IntField object at 0x7fca8a4ecb20>,
    'metadata.num_channels': <fiftyone.core.fields.IntField object at 0x7fca8a4ecbb0>,
    'ground_truth': <fiftyone.core.fields.EmbeddedDocumentField object at 0x7fca8a4ecf70>,
    'ground_truth.id': <fiftyone.core.fields.ObjectIdField object at 0x7fca8a4fa220>,
    'ground_truth.tags': <fiftyone.core.fields.ListField object at 0x7fca8a4fa310>,
    'ground_truth.label': <fiftyone.core.fields.StringField object at 0x7fca8a4fa340>,
    'ground_truth.confidence': <fiftyone.core.fields.FloatField object at 0x7fca8a4fa190>,
    'ground_truth.logits': <fiftyone.core.fields.VectorField object at 0x7fca8a4fa070>,
    'ground_truth.info': <fiftyone.core.fields.ListField object at 0x7fca6842e6a0>,
    'ground_truth.info.author': <fiftyone.core.fields.StringField object at 0x7fca8a4ec880>,
    'ground_truth.info.ints': <fiftyone.core.fields.ListField object at 0x7fca48b85550>,
    'ground_truth.info.task': <fiftyone.core.fields.StringField object at 0x7fca88ae7e80>,
    'ground_truth.info.notes': <fiftyone.core.fields.ListField object at 0x7fca88ae79d0>,
    'ground_truth.info.floats': <fiftyone.core.fields.ListField object at 0x7fca88ae7130>,
    'ground_truth.info.timestamp': <fiftyone.core.fields.DateTimeField object at 0x7fca88ae7ee0>,
}
```

The `mixed` list was not declared because it contains multiple value types:

```py
fo.pprint(dataset.get_dynamic_field_schema())
```

```
{
    'ground_truth.info.mixed': <fiftyone.core.fields.ListField object at 0x7fca501ed5e0>,
}
```

but, if desired, we can pass `add_mixed=True` to declare that its value types are generic `Field` instances:

```py
dataset.add_dynamic_sample_fields(add_mixed=True)

fo.pprint(dataset.get_dynamic_field_schema())
# {}
```
