### PR TITLE
Show embedded documents and list of documents in sidebar as filterable fields

### DIFF
--- a/app/packages/state/src/recoil/sidebar.ts
+++ b/app/packages/state/src/recoil/sidebar.ts
@@ -277,7 +277,14 @@ export const resolveGroups = (
     .reduce(fieldsReducer([EMBEDDED_DOCUMENT_FIELD]), [])
     .forEach((name) => {
       const fieldPaths = (fields[name].fields || [])
-        .reduce(fieldsReducer(VALID_PRIMITIVE_TYPES), [])
+        .reduce(
+          fieldsReducer([
+            ...VALID_PRIMITIVE_TYPES,
+            EMBEDDED_DOCUMENT_FIELD,
+            LIST_FIELD,
+          ]),
+          []
+        )
         .map((subfield) => `${name}.${subfield}`)
         .filter((path) => !present.has(path));
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

After some backend PRs to enable expanding nested lists into top level ones, we can show these in the sidebar now - filterability for free.

### **test cases** 

No way one line change enables this haha 

The videos show the results in UI sidebar after following commands. New fields can be visualized and filtered just like any other fields


image dataset
https://user-images.githubusercontent.com/109545780/230228235-2163216e-15d1-4372-bcb3-ecd070d9044b.mp4


video dataset

https://user-images.githubusercontent.com/109545780/230228466-62e7b7b6-d4f8-4804-8e6d-7161f1a2666e.mov



**Case 1** Simple dynamic embedded document 

```
sm[“custom_document”] = fo.DynamicEmbeddedDocument(
  a=1,
  b="a_string",
  c=1.1,
  d=False,
   e=["custom_tag_1", "custom_tag_11"]
)

fo.pprint(ds.get_field_schema(flat=True))

{
    …
    'tasks.labels.logits': <fiftyone.core.fields.VectorField object at 0x7fce49eb10d0>,
    'custom_document': <fiftyone.core.fields.EmbeddedDocumentField object at 0x7fce49eb8e50>,
    'custom_document.c': <fiftyone.core.fields.FloatField object at 0x7fce3bee7df0>,
    'custom_document.b': <fiftyone.core.fields.StringField object at 0x7fce3bee7d90>,
    'custom_document.e': <fiftyone.core.fields.ListField object at 0x7fce49eb1370>,
    'custom_document.d': <fiftyone.core.fields.BooleanField object at 0x7fce49eb1160>,
    'custom_document.a': <fiftyone.core.fields.IntField object at 0x7fce49eb12e0>,
}

view = ds.skip(1)
sm = view.head()[0]
sm["custom_document"] = fo.DynamicEmbeddedDocument(
	a=2,
	b="b_string",
	c=2.2,
	d=True,
	e=["custom_tag_1", "custom_tag_2"]
)
sm.save()
ds.add_dynamic_sample_fields()
```

**Case 2**  A Dynamic document with a list of dynamic documents and detections.
```
sm["list_of_embed_and_detections"] = fo.DynamicEmbeddedDocument(
        a_list_of_embedded=[fo.DynamicEmbeddedDocument(age=1), fo.DynamicEmbeddedDocument(age=11)],
        detections=fo.Detections(
            fo.Detection(
                label="cat",
                bounding_box=[0.5, 0.5, 0.4, 0.3],
                age=1
            ),
            fo.Detection(
                label="dog",
                bounding_box=[0.5, 0.6, 0.7, 0.3],
                age=2
            ),
        )
    )
```

**Case 3** video basic

```
sm = ds.head()[0]
sm["custom_document"] = fo.DynamicEmbeddedDocument(
         a=2,
         b="b_string",
         c=2.2,
         d=True,
         e=["custom_tag_1", "custom_tag_2"]
)
sm.save()
ds.add_dynamic_sample_fields()
fo.pprint(ds.get_field_schema(flat=True))
{
    'id': <fiftyone.core.fields.ObjectIdField object at 0x7fd8f97c7a00>,
    'filepath': <fiftyone.core.fields.StringField object at 0x7fd9013157c0>,
    'tags': <fiftyone.core.fields.ListField object at 0x7fd8f97b6490>,
    'metadata': <fiftyone.core.fields.EmbeddedDocumentField object at 0x7fd8f97b6250>,
    'metadata.size_bytes': <fiftyone.core.fields.IntField object at 0x7fd8f97b6610>,
    'metadata.mime_type': <fiftyone.core.fields.StringField object at 0x7fd8f97b6640>,
    'metadata.frame_width': <fiftyone.core.fields.IntField object at 0x7fd8f97b6460>,
    'metadata.frame_height': <fiftyone.core.fields.IntField object at 0x7fd8f97b6100>,
    'metadata.frame_rate': <fiftyone.core.fields.FloatField object at 0x7fd8f97b6430>,
    'metadata.total_frame_count': <fiftyone.core.fields.IntField object at 0x7fd8f97b6400>,
    'metadata.duration': <fiftyone.core.fields.FloatField object at 0x7fd8f97b6580>,
    'metadata.encoding_str': <fiftyone.core.fields.StringField object at 0x7fd8f97b6670>,
    'custom_document': <fiftyone.core.fields.EmbeddedDocumentField object at 0x7fd8e9db46d0>,
    'custom_document.d': <fiftyone.core.fields.BooleanField object at 0x7fd8f99da3a0>,
    'custom_document.e': <fiftyone.core.fields.ListField object at 0x7fd8f99daee0>,
    'custom_document.b': <fiftyone.core.fields.StringField object at 0x7fd8f99da6a0>,
    'custom_document.c': <fiftyone.core.fields.FloatField object at 0x7fd8f99dac40>,
    'custom_document.a': <fiftyone.core.fields.IntField object at 0x7fd8f99dad90>,
}
```

**Case 4** List of embedded documents with primitive and label fields
```
ds = foz.load_zoo_dataset("quickstart", dataset_name="embed-2")
ds.persistent = True
sm = ds.head()[0]
sm[“tasks”] = [
        fo.DynamicEmbeddedDocument(
            annotator="alice",
            labels=fo.Classifications(
                classifications=[
                    fo.Classification(label="cat"),
                    fo.Classification(label="dog"),
                ]
            ),
        ),
        fo.DynamicEmbeddedDocument(
            annotator="bob",
            labels=fo.Classifications(
                classifications=[
                    fo.Classification(label="rabbit"),
                    fo.Classification(label="squirrel"),
                ]
            ),
        ),
]
sm.save()
ds.add_dynamic_sample_fields()
fo.pprint(ds.get_field_schema(flat=True))
{
    'id': <fiftyone.core.fields.ObjectIdField object at 0x7fce3c0d3430>,
    …
    'predictions.detections.index': <fiftyone.core.fields.IntField object at 0x7fce3c1161f0>,
    'tasks': <fiftyone.core.fields.ListField object at 0x7fce3c116790>,
    'tasks.annotator': <fiftyone.core.fields.StringField object at 0x7fce49eb8c70>,
    'tasks.labels': <fiftyone.core.fields.EmbeddedDocumentField object at 0x7fce49ea97f0>,
    'tasks.labels.classifications': <fiftyone.core.fields.ListField object at 0x7fce49ea9c40>,
    'tasks.labels.classifications.id': <fiftyone.core.fields.ObjectIdField object at 0x7fce49eb1940>,
    'tasks.labels.classifications.tags': <fiftyone.core.fields.ListField object at 0x7fce49eb1b80>,
    'tasks.labels.classifications.label': <fiftyone.core.fields.StringField object at 0x7fce49eb19d0>,
    'tasks.labels.classifications.confidence': <fiftyone.core.fields.FloatField object at 0x7fce49eb1400>,
    'tasks.labels.classifications.logits': <fiftyone.core.fields.VectorField object at 0x7fce49eb1310>,
    'tasks.labels.logits': <fiftyone.core.fields.VectorField object at 0x7fce49eb10d0>,
}
```

## How is this patch tested? If it is not, please explain why.

(Details)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
