### PR TITLE
permission for custom color settings

### DIFF
--- a/app/packages/dataset/src/Dataset.tsx
+++ b/app/packages/dataset/src/Dataset.tsx
@@ -58,6 +58,7 @@ export interface DatasetProps {
   theme?: "dark" | "light";
   toggleHeaders?: () => void;
   canEditSavedViews?: boolean;
+  canEditCustomColors?: boolean;
 }
 
 export const Dataset: React.FC<DatasetProps> = ({
@@ -68,10 +69,12 @@ export const Dataset: React.FC<DatasetProps> = ({
   theme = "dark",
   toggleHeaders,
   canEditSavedViews = true,
+  canEditCustomColors = true,
 }) => {
   const [queryRef, loadQuery] = useQueryLoader<DatasetQuery>(DatasetNodeQuery);
   const setTheme = useSetRecoilState(fos.theme);
   const setCanChangeSavedViews = useSetRecoilState(fos.canEditSavedViews);
+  const setCanChangeCustomColors = useSetRecoilState(fos.canEditCustomColors);
   const setCompactLayout = useSetRecoilState(fos.compactLayout);
   const setReadOnly = useSetRecoilState(fos.readOnly);
 
@@ -96,6 +99,9 @@ export const Dataset: React.FC<DatasetProps> = ({
   React.useEffect(() => {
     setCanChangeSavedViews(canEditSavedViews);
   }, [canEditSavedViews]);
+  React.useEffect(() => {
+    setCanChangeCustomColors(canEditCustomColors);
+  }, [canEditCustomColors]);
 
   const plugins = usePlugins();
   const loadingElement = <Loading>Pixelating...</Loading>;

--- a/app/packages/state/src/recoil/atoms.ts
+++ b/app/packages/state/src/recoil/atoms.ts
@@ -322,6 +322,11 @@ export const canEditSavedViews = atom({
   default: true,
 });
 
+export const canEditCustomColors = atom({
+  key: "canEditCustomColors",
+  default: true,
+});
+
 export const compactLayout = atom({
   key: "compactLayout",
   default: false,


### PR DESCRIPTION
## What changes are proposed in this pull request?

pass canEditCustomColors for permission in teams usage

## How is this patch tested? If it is not, please explain why.

(Details)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
