### PR TITLE
Revalidate stages upon view reload

### DIFF
--- a/fiftyone/core/clips.py
+++ b/fiftyone/core/clips.py
@@ -302,9 +302,9 @@ class ClipsView(fov.DatasetView):
         _view = self._clips_stage.load_view(self._source_collection)
         self._clips_dataset = _view._clips_dataset
 
-        view = self._base_view
+        _view = self._base_view
         for stage in self._stages:
-            view = view.add_stage(stage)
+            _view = _view.add_stage(stage)
 
     def _sync_source_sample(self, sample):
         if not self._classification_field:

--- a/fiftyone/core/clips.py
+++ b/fiftyone/core/clips.py
@@ -284,7 +284,7 @@ class ClipsView(fov.DatasetView):
         super().keep_fields()
 
     def reload(self):
-        """Reloads this view from the source collection in the database.
+        """Reloads the view.
 
         Note that :class:`ClipView` instances are not singletons, so any
         in-memory clips extracted from this view will not be updated by calling
@@ -298,10 +298,13 @@ class ClipsView(fov.DatasetView):
         # This assumes that calling `load_view()` when the current clips
         # dataset has been deleted will cause a new one to be generated
         #
-
         self._clips_dataset.delete()
         _view = self._clips_stage.load_view(self._source_collection)
         self._clips_dataset = _view._clips_dataset
+
+        view = self._base_view
+        for stage in self._stages:
+            view = view.add_stage(stage)
 
     def _sync_source_sample(self, sample):
         if not self._classification_field:

--- a/fiftyone/core/patches.py
+++ b/fiftyone/core/patches.py
@@ -315,9 +315,9 @@ class _PatchesView(fov.DatasetView):
         _view = self._patches_stage.load_view(self._source_collection)
         self._patches_dataset = _view._patches_dataset
 
-        view = self._base_view
+        _view = self._base_view
         for stage in self._stages:
-            view = view.add_stage(stage)
+            _view = _view.add_stage(stage)
 
     def _sync_source_sample(self, sample):
         for field in self._label_fields:

--- a/fiftyone/core/patches.py
+++ b/fiftyone/core/patches.py
@@ -297,7 +297,7 @@ class _PatchesView(fov.DatasetView):
         super().keep_fields()
 
     def reload(self):
-        """Reloads this view from the source collection in the database.
+        """Reloads the view.
 
         Note that :class:`PatchView` instances are not singletons, so any
         in-memory patches extracted from this view will not be updated by
@@ -311,10 +311,13 @@ class _PatchesView(fov.DatasetView):
         # This assumes that calling `load_view()` when the current patches
         # dataset has been deleted will cause a new one to be generated
         #
-
         self._patches_dataset.delete()
         _view = self._patches_stage.load_view(self._source_collection)
         self._patches_dataset = _view._patches_dataset
+
+        view = self._base_view
+        for stage in self._stages:
+            view = view.add_stage(stage)
 
     def _sync_source_sample(self, sample):
         for field in self._label_fields:

--- a/fiftyone/core/video.py
+++ b/fiftyone/core/video.py
@@ -276,9 +276,9 @@ class FramesView(fov.DatasetView):
         _view = self._frames_stage.load_view(self._source_collection)
         self._frames_dataset = _view._frames_dataset
 
-        view = self._base_view
+        _view = self._base_view
         for stage in self._stages:
-            view = view.add_stage(stage)
+            _view = _view.add_stage(stage)
 
     def _set_labels(self, field_name, sample_ids, label_docs):
         super()._set_labels(field_name, sample_ids, label_docs)

--- a/fiftyone/core/video.py
+++ b/fiftyone/core/video.py
@@ -258,7 +258,7 @@ class FramesView(fov.DatasetView):
         super().keep_fields()
 
     def reload(self):
-        """Reloads this view from the source collection in the database.
+        """Reloads the view.
 
         Note that :class:`FrameView` instances are not singletons, so any
         in-memory frames extracted from this view will not be updated by
@@ -272,10 +272,13 @@ class FramesView(fov.DatasetView):
         # This assumes that calling `load_view()` when the current patches
         # dataset has been deleted will cause a new one to be generated
         #
-
         self._frames_dataset.delete()
         _view = self._frames_stage.load_view(self._source_collection)
         self._frames_dataset = _view._frames_dataset
+
+        view = self._base_view
+        for stage in self._stages:
+            view = view.add_stage(stage)
 
     def _set_labels(self, field_name, sample_ids, label_docs):
         super()._set_labels(field_name, sample_ids, label_docs)

--- a/fiftyone/core/view.py
+++ b/fiftyone/core/view.py
@@ -1100,13 +1100,17 @@ class DatasetView(foc.SampleCollection):
         )
 
     def reload(self):
-        """Reloads the underlying dataset from the database.
+        """Reloads the view.
 
         Note that :class:`fiftyone.core.sample.SampleView` instances are not
         singletons, so any in-memory samples extracted from this view will not
         be updated by calling this method.
         """
         self._dataset.reload()
+
+        view = self._base_view
+        for stage in self._stages:
+            view = view.add_stage(stage)
 
     def to_dict(
         self,

--- a/fiftyone/core/view.py
+++ b/fiftyone/core/view.py
@@ -1108,9 +1108,9 @@ class DatasetView(foc.SampleCollection):
         """
         self._dataset.reload()
 
-        view = self._base_view
+        _view = self._base_view
         for stage in self._stages:
-            view = view.add_stage(stage)
+            _view = _view.add_stage(stage)
 
     def to_dict(
         self,

--- a/tests/unittests/similarity_tests.py
+++ b/tests/unittests/similarity_tests.py
@@ -99,19 +99,32 @@ class SimilarityTests(unittest.TestCase):
         query_id = dataset.first().id
 
         view1 = dataset.sort_by_similarity(query_id)
-        view2 = dataset.sort_by_similarity(query_id, reverse=True)
+        values1 = view1.values("id")
 
-        self.assertEqual(
-            view1.values("id"), list(reversed(view2.values("id")))
-        )
+        view2 = dataset.sort_by_similarity(query_id, reverse=True)
+        values2 = view2.values("id")
+
+        self.assertListEqual(values2, values1[::-1])
 
         view3 = dataset.sort_by_similarity(query_id, k=4)
+        values3 = view3.values("id")
 
-        self.assertEqual(len(view3), 4)
+        self.assertListEqual(values3, values1[:4])
 
         view4 = dataset.sort_by_similarity(query_id, brain_key="img_sim")
+        values4 = view4.values("id")
 
-        self.assertEqual(view1.values("id"), view4.values("id"))
+        self.assertListEqual(values4, values1)
+
+        view5 = view4.limit(2)
+        values5 = view5.values("id")
+
+        self.assertListEqual(values5, values1[:2])
+
+        view5.reload()
+        values5 = view5.values("id")
+
+        self.assertListEqual(values5, values1[:2])
 
     @drop_datasets
     def test_object_similarity(self):
@@ -163,19 +176,32 @@ class SimilarityTests(unittest.TestCase):
         patches = dataset.to_patches("ground_truth")
 
         view1 = patches.sort_by_similarity(query_id)
-        view2 = patches.sort_by_similarity(query_id, reverse=True)
+        values1 = view1.values("id")
 
-        self.assertEqual(
-            view1.values("id"), list(reversed(view2.values("id")))
-        )
+        view2 = patches.sort_by_similarity(query_id, reverse=True)
+        values2 = view2.values("id")
+
+        self.assertListEqual(values2, values1[::-1])
 
         view3 = patches.sort_by_similarity(query_id, k=4)
+        values3 = view3.values("id")
 
-        self.assertEqual(len(view3), 4)
+        self.assertListEqual(values3, values1[:4])
 
         view4 = patches.sort_by_similarity(query_id, brain_key="obj_sim")
+        values4 = view4.values("id")
 
-        self.assertEqual(view1.values("id"), view4.values("id"))
+        self.assertEqual(values4, values1)
+
+        view5 = view4.limit(2)
+        values5 = view5.values("id")
+
+        self.assertListEqual(values5, values1[:2])
+
+        view5.reload()
+        values5 = view5.values("id")
+
+        self.assertListEqual(values5, values1[:2])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Calling `reload()` now causes view stages to be re-validated, which allows for views to take into account any changes to the underlying dataset that occurred after the view is created.

In general, one can always reconstruct views from scratch, but `reload()` is now more a more viable option in cases where it is desired to continue using an existing `DatasetView` instance while a dataset may be changing underneath.

Example use case:

```py
import fiftyone as fo
import fiftyone.zoo as foz

dataset = foz.load_zoo_dataset("quickstart")
view = dataset.select_fields("uniqueness")

dataset.delete_sample_field("uniqueness")

# Immediately raises an error, since `uniqueness` field was deleted
view.reload()
# ValueError: Field 'uniqueness' does not exist
```
