### PR TITLE
Handling missing label fields when deleting labels

### DIFF
--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -2999,11 +2999,12 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
             ops = []
             if issubclass(label_type, fol._LABEL_LIST_FIELDS):
                 array_field = field + "." + label_type._LABEL_LIST_FIELD
+                query = {array_field: {"$exists": True}}
 
                 if view_ids is not None:
                     ops.append(
                         UpdateMany(
-                            {},
+                            query,
                             {
                                 "$pull": {
                                     array_field: {"_id": {"$in": view_ids}}
@@ -3015,14 +3016,15 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
                 if ids is not None:
                     ops.append(
                         UpdateMany(
-                            {}, {"$pull": {array_field: {"_id": {"$in": ids}}}}
+                            query,
+                            {"$pull": {array_field: {"_id": {"$in": ids}}}},
                         )
                     )
 
                 if tags is not None:
                     ops.append(
                         UpdateMany(
-                            {},
+                            query,
                             {
                                 "$pull": {
                                     array_field: {

--- a/tests/unittests/dataset_tests.py
+++ b/tests/unittests/dataset_tests.py
@@ -3178,10 +3178,13 @@ class DatasetDeletionTests(unittest.TestCase):
         sample2 = sample1.copy()
         sample2.filepath = "image2.png"
 
-        sample3 = sample1.copy()
-        sample3.filepath = "image3.png"
+        # Test missing labels
+        sample3 = fo.Sample(filepath="image3.png")
 
-        self.dataset.add_samples([sample1, sample2, sample3])
+        sample4 = sample1.copy()
+        sample4.filepath = "image4.png"
+
+        self.dataset.add_samples([sample1, sample2, sample3, sample4])
 
     def _setUp_video_classification(self):
         sample1 = fo.Sample(filepath="video1.mp4")
@@ -3195,10 +3198,14 @@ class DatasetDeletionTests(unittest.TestCase):
             frame_number=3, ground_truth=fo.Classification(label="rabbit")
         )
 
-        sample2 = sample1.copy()
-        sample2.filepath = "video2.mp4"
+        # Test missing labels
+        sample2 = fo.Sample(filepath="video2.mp4")
+        sample2.frames[1] = fo.Frame()
 
-        self.dataset.add_samples([sample1, sample2])
+        sample3 = sample1.copy()
+        sample3.filepath = "video3.mp4"
+
+        self.dataset.add_samples([sample1, sample2, sample3])
 
     def _setUp_detections(self):
         sample1 = fo.Sample(
@@ -3225,10 +3232,13 @@ class DatasetDeletionTests(unittest.TestCase):
         sample2 = sample1.copy()
         sample2.filepath = "image2.png"
 
-        sample3 = sample1.copy()
-        sample3.filepath = "image3.png"
+        # Test missing labels
+        sample3 = fo.Sample(filepath="image3.png")
 
-        self.dataset.add_samples([sample1, sample2, sample3])
+        sample4 = sample1.copy()
+        sample4.filepath = "image4.png"
+
+        self.dataset.add_samples([sample1, sample2, sample3, sample4])
 
     def _setUp_video_detections(self):
         sample1 = fo.Sample(filepath="video1.mp4")
@@ -3263,10 +3273,14 @@ class DatasetDeletionTests(unittest.TestCase):
         frame3.frame_number = 3
         sample1.frames[3] = frame3
 
-        sample2 = sample1.copy()
-        sample2.filepath = "video2.mp4"
+        # Test missing labels
+        sample2 = fo.Sample(filepath="video2.mp4")
+        sample2.frames[1] = fo.Frame()
 
-        self.dataset.add_samples([sample1, sample2])
+        sample3 = sample1.copy()
+        sample3.filepath = "video3.mp4"
+
+        self.dataset.add_samples([sample1, sample2, sample3])
 
     def test_delete_samples_ids(self):
         self._setUp_classification()


### PR DESCRIPTION
`delete_labels()` did not previously handle the case where a sample with `None`-valued field was involved.

```py
import fiftyone as fo
import fiftyone.zoo as foz

dataset = foz.load_zoo_dataset("quickstart", max_samples=25)
dataset.take(10, seed=51).set_field("ground_truth", None).save()

label_id = dataset.exists("ground_truth").first().ground_truth.detections[0].id
view = dataset.select_labels(ids=label_id, fields="ground_truth")

assert len(view) == 1

# Previously would fail; now succeeds
dataset.delete_labels(ids=label_id, fields="ground_truth")

assert len(view) == 0
```
