### PR TITLE
add support for indexed encoding in pngs

### DIFF
--- a/app/packages/looker/src/worker/benchmarking/benchmark-indexed-png-decoder.ts
+++ b/app/packages/looker/src/worker/benchmarking/benchmark-indexed-png-decoder.ts
@@ -1,0 +1,37 @@
+import { ValidPngBitDepth } from "../indexed-png-decoder";
+import { indexedPngBufferToRgb } from "../indexed-png-decoder";
+
+const generateSampleData = (size: number) => {
+  const inputData = new Uint8Array(size);
+  const colorPalette = [
+    [0, 0, 0],
+    [255, 255, 255],
+    [128, 128, 128],
+    [192, 192, 192],
+  ];
+
+  for (let i = 0; i < size; i++) {
+    inputData[i] = Math.floor(Math.random() * 256);
+  }
+
+  return { inputData, colorPalette };
+};
+
+export const benchmarkIndexedPngDecode = () => {
+  // realistic bit depth that supports four colors
+  // bit depth 4 and 8 are significantly faster
+  const bitDepth: ValidPngBitDepth = 2;
+  const sampleSizes = [1e4, 1e5, 1e6, 1e7];
+
+  for (const size of sampleSizes) {
+    const { inputData, colorPalette } = generateSampleData(size);
+    const startTime = performance.now();
+    indexedPngBufferToRgb(inputData, bitDepth, colorPalette);
+    const endTime = performance.now();
+    const elapsedTime = endTime - startTime;
+
+    console.log(
+      `Sample size: ${size}, elapsed time: ${elapsedTime.toFixed(2)} ms`
+    );
+  }
+};

--- a/app/packages/looker/src/worker/index.ts
+++ b/app/packages/looker/src/worker/index.ts
@@ -19,6 +19,7 @@ import { CHUNK_SIZE } from "../constants";
 import { OverlayMask } from "../numpy";
 import { Coloring, FrameChunk, FrameSample, Sample } from "../state";
 import { DeserializerFactory } from "./deserializer";
+import { indexedPngBufferToRgb } from "./indexed-png-decoder";
 import { PainterFactory } from "./painter";
 import { mapId } from "./shared";
 import { process3DLabels } from "./threed-label-processor";
@@ -132,6 +133,15 @@ const imputeOverlayFromPath = async (
     overlayData = decodeJpg(overlayImageBuffer, { useTArray: true });
   } else {
     overlayData = decodePng(overlayImageBuffer);
+  }
+
+  if (overlayData.palette?.length) {
+    overlayData.data = indexedPngBufferToRgb(
+      overlayData.data,
+      overlayData.depth,
+      overlayData.palette
+    );
+    overlayData.channels = 3;
   }
 
   const width = overlayData.width;

--- a/app/packages/looker/src/worker/indexed-png-decoder.ts
+++ b/app/packages/looker/src/worker/indexed-png-decoder.ts
@@ -6,8 +6,9 @@ export const indexedPngBufferToRgb = (
   bitDepth: ValidPngBitDepth,
   colorPalette: ColorPalette
 ) => {
+  const inputDataLength = inputData.length;
   const indicesPerByte = 8 / bitDepth;
-  const numIndices = inputData.length * indicesPerByte;
+  const numIndices = inputDataLength * indicesPerByte;
   const resultSize = numIndices * 3;
   const newRgbArray = new Uint8Array(resultSize);
 
@@ -17,7 +18,8 @@ export const indexedPngBufferToRgb = (
   const initialBitMask = ((1 << bitDepth) - 1) << (8 - bitDepth);
 
   // extract color indexes from data based on bit depth
-  for (const byte of inputData) {
+  for (let i = 0; i < inputDataLength; i++) {
+    const byte = inputData[i];
     let currentBitMask = initialBitMask;
     let remainingBits = 8;
 

--- a/app/packages/looker/src/worker/indexed-png-decoder.ts
+++ b/app/packages/looker/src/worker/indexed-png-decoder.ts
@@ -1,0 +1,43 @@
+export const indexedPngBufferToRgb = (
+  data: Uint8Array,
+  bitDepth: 1 | 2 | 4 | 8,
+  colorPalette: number[][]
+) => {
+  const indicesPerByte = 8 / bitDepth;
+  const numIndexes = data.length * indicesPerByte;
+  const resultSize = numIndexes * 3;
+
+  const rgbArray = new Uint8Array(resultSize);
+
+  let rgbIdx = 0;
+  let paletteIdx = 0;
+
+  const colorIndices = new Uint8Array(numIndexes);
+
+  // Determine the initial bit mask based on the bit depth:
+  const initialBitMask = ((1 << bitDepth) - 1) << (8 - bitDepth);
+
+  // extract color indexes from data based on bit depth
+  for (const byte of data) {
+    let currentBitMask = initialBitMask;
+    let bitsToShift = 8 - bitDepth;
+
+    while (currentBitMask) {
+      colorIndices[paletteIdx++] = (byte & currentBitMask) >> bitsToShift;
+      currentBitMask >>= bitDepth;
+      bitsToShift -= bitDepth;
+    }
+  }
+
+  // map color indices to rgb values
+  for (const index of colorIndices) {
+    const color = colorPalette[index];
+    if (!color) {
+      throw new Error("incorrect index of palette color");
+    }
+    rgbArray.set(color, rgbIdx);
+    rgbIdx += 3;
+  }
+
+  return rgbArray;
+};

--- a/app/packages/looker/src/worker/tests/indexed-png-decoder.test.ts
+++ b/app/packages/looker/src/worker/tests/indexed-png-decoder.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import {
+  ColorPalette,
+  ValidPngBitDepth,
+  indexedPngBufferToRgb,
+} from "../indexed-png-decoder";
+
+describe("convertIndexedPngToRgb", () => {
+  const palette: ColorPalette = [
+    [0, 0, 0],
+    [1, 1, 1],
+    [2, 2, 2],
+    [3, 3, 3],
+  ];
+
+  it("works with 1-bit depth", () => {
+    const inputData = new Uint8Array([0b10000000]);
+    const bitDepth: ValidPngBitDepth = 1;
+    // only two colors possible with 1 bit depth
+    // for 0b10000000, only first bit has value, so the first index color (0, 0, 0) is chosen
+    const expectedResult = new Uint8Array([
+      1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    ]);
+
+    const result = indexedPngBufferToRgb(inputData, bitDepth, palette);
+    expect(result).toEqual(expectedResult);
+  });
+
+  it("works with 2-bit depth", () => {
+    const inputData = new Uint8Array([0b11100000]);
+    const bitDepth: ValidPngBitDepth = 2;
+    // four colors possible with 2 bit depth
+    // first two bits = 11 = 3, so the third index color (3, 3, 3) is chosen
+    // second two bits = 10 = 2, so the second color is chosen
+    const expectedResult = new Uint8Array([3, 3, 3, 2, 2, 2, 0, 0, 0, 0, 0, 0]);
+
+    const result = indexedPngBufferToRgb(inputData, bitDepth, palette);
+    expect(result).toEqual(expectedResult);
+  });
+
+  it("works with 4-bit depth", () => {
+    const inputData = new Uint8Array([0b00110010]);
+    const bitDepth: ValidPngBitDepth = 4;
+    const expectedResult = new Uint8Array([3, 3, 3, 2, 2, 2]);
+
+    const result = indexedPngBufferToRgb(inputData, bitDepth, palette);
+    expect(result).toEqual(expectedResult);
+  });
+
+  it("works with 8-bit depth", () => {
+    const inputData = new Uint8Array([0b00000010, 0b00000011]);
+    const bitDepth: ValidPngBitDepth = 8;
+    const expectedResult = new Uint8Array([2, 2, 2, 3, 3, 3]);
+
+    const result = indexedPngBufferToRgb(inputData, bitDepth, palette);
+    expect(result).toEqual(expectedResult);
+  });
+});

--- a/app/packages/looker/src/worker/tests/indexed-png-decoder.test.ts
+++ b/app/packages/looker/src/worker/tests/indexed-png-decoder.test.ts
@@ -17,7 +17,8 @@ describe("convertIndexedPngToRgb", () => {
     const inputData = new Uint8Array([0b10000000]);
     const bitDepth: ValidPngBitDepth = 1;
     // only two colors possible with 1 bit depth
-    // for 0b10000000, only first bit has value, so the first index color (0, 0, 0) is chosen
+    // for 0b10000000, only first bit has value, so the first index color (1, 1, 1) is chosen
+    // other bits get 0 indexed color (0, 0, 0)
     const expectedResult = new Uint8Array([
       1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     ]);
@@ -32,6 +33,7 @@ describe("convertIndexedPngToRgb", () => {
     // four colors possible with 2 bit depth
     // first two bits = 11 = 3, so the third index color (3, 3, 3) is chosen
     // second two bits = 10 = 2, so the second color is chosen
+    // other two-two bits (00, 00) translate to (0,0,0), (0,0,0)
     const expectedResult = new Uint8Array([3, 3, 3, 2, 2, 2, 0, 0, 0, 0, 0, 0]);
 
     const result = indexedPngBufferToRgb(inputData, bitDepth, palette);
@@ -41,6 +43,8 @@ describe("convertIndexedPngToRgb", () => {
   it("works with 4-bit depth", () => {
     const inputData = new Uint8Array([0b00110010]);
     const bitDepth: ValidPngBitDepth = 4;
+    // 0011 = 3, so the third index color (3, 3, 3) is chosen
+    // 0010 = 2, so the second index color is chosen
     const expectedResult = new Uint8Array([3, 3, 3, 2, 2, 2]);
 
     const result = indexedPngBufferToRgb(inputData, bitDepth, palette);
@@ -50,6 +54,8 @@ describe("convertIndexedPngToRgb", () => {
   it("works with 8-bit depth", () => {
     const inputData = new Uint8Array([0b00000010, 0b00000011]);
     const bitDepth: ValidPngBitDepth = 8;
+    // 00000010 = 2, so the second index color (2, 2, 2) is chosen
+    // 00000011 = 3, so the third index color (3, 3, 3) is chosen
     const expectedResult = new Uint8Array([2, 2, 2, 3, 3, 3]);
 
     const result = indexedPngBufferToRgb(inputData, bitDepth, palette);


### PR DESCRIPTION
## What changes are proposed in this pull request?

fixes #2920, essentially adding support for color type 3 PNGs (https://www.w3.org/TR/PNG-Chunks.html)
<img width="565" alt="Screenshot 2023-04-25 at 11 34 06 AM" src="https://user-images.githubusercontent.com/66688606/234344164-bd63efc7-04ad-40d3-94dc-b87b2de3867e.png">
<img width="1503" alt="Screenshot 2023-04-25 at 11 33 56 AM" src="https://user-images.githubusercontent.com/66688606/234344170-96beb379-8711-44f6-87df-e49dac2de543.png">


## How is this patch tested? If it is not, please explain why.

Locally.

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
