### PR TITLE
Adding keypoint evaluation

### DIFF
--- a/docs/source/user_guide/evaluation.rst
+++ b/docs/source/user_guide/evaluation.rst
@@ -666,8 +666,9 @@ __________
 You can use the
 :meth:`evaluate_detections() <fiftyone.core.collections.SampleCollection.evaluate_detections>`
 method to evaluate the predictions of an object detection model stored in a
-|Detections| or |Polylines| field of your dataset or of a temporal detection
-model stored in a |TemporalDetections| field of your dataset.
+|Detections|, |Polylines|, or |Keypoints| field of your dataset or of a
+temporal detection model stored in a |TemporalDetections| field of your
+dataset.
 
 Invoking
 :meth:`evaluate_detections() <fiftyone.core.collections.SampleCollection.evaluate_detections>`
@@ -698,14 +699,23 @@ method supports all of the following task types:
 -   :ref:`Object detection <object-detection>`
 -   :ref:`Instance segmentations <instance-segmentation>`
 -   :ref:`Polygon detection <polylines>`
+-   :ref:`Keypoints <keypoints>`
 -   :ref:`Temporal detections <temporal-detection>`
 -   :ref:`3D detections <3d-detections>`
 
 The only difference between each task type is in how the IoU between objects is
-calculated. Specifically, for instance segmentations and polygons, IoUs are
-computed between the polgyonal shapes rather than their rectangular bounding
-boxes. For temporal detections, IoU is computed between the 1D support of two
-temporal segments.
+calculated:
+
+-   For object detections, IoUs are computed between each pair of bounding boxes
+-   For instance segmentations and polygons, IoUs are computed between the
+    polgyonal shapes rather than their rectangular bounding boxes
+-   For keypoint tasks,
+    `object keypoint similarity (OKS) <https://cocodataset.org/#keypoints-eval>`_
+    is computed for each pair of objects, using the extent of the ground truth
+    keypoints as a proxy for the area of the object's bounding box, and
+    assuming uniform falloff (:math:`\kappa`)
+-   For temporal detections, IoU is computed between the 1D support of two
+    temporal segments
 
 For object detection tasks, the ground truth and predicted objects should be
 stored in |Detections| format.
@@ -732,6 +742,15 @@ polylines).
     than the actual polygonal geometries for IoU calculations, you can pass
     ``use_boxes=True`` to
     :meth:`evaluate_detections() <fiftyone.core.collections.SampleCollection.evaluate_detections>`.
+
+For keypoint tasks, each |Keypoint| instance must contain point arrays of equal
+length and semantic ordering.
+
+.. note::
+
+    If a particular point is missing or not visible for a |Keypoint| instance,
+    use nan values for its coordinates. :ref:`See here <keypoints>` for more
+    information about structuring keypoints.
 
 For temporal detection tasks, the ground truth and predicted objects should be
 stored in |TemporalDetections| format.

--- a/docs/source/user_guide/evaluation.rst
+++ b/docs/source/user_guide/evaluation.rst
@@ -710,7 +710,7 @@ calculated:
 -   For instance segmentations and polygons, IoUs are computed between the
     polgyonal shapes rather than their rectangular bounding boxes
 -   For keypoint tasks,
-    `object keypoint similarity (OKS) <https://cocodataset.org/#keypoints-eval>`_
+    `object keypoint similarity <https://cocodataset.org/#keypoints-eval>`_
     is computed for each pair of objects, using the extent of the ground truth
     keypoints as a proxy for the area of the object's bounding box, and
     assuming uniform falloff (:math:`\kappa`)

--- a/docs/source/user_guide/using_datasets.rst
+++ b/docs/source/user_guide/using_datasets.rst
@@ -2532,13 +2532,31 @@ attributes and rendered as such in the App:
         'occluded': [False, False, True, False],
     }>
 
+If your keypoints have semantic meanings, you can
+:ref:`store keypoint skeletons <storing-keypoint-skeletons>` on your dataset to
+encode the meanings.
+
+If you are working with keypoint skeletons and a particular point is missing or
+not visible for an instance, use nan values for its coordinates:
+
+.. code-block:: python
+    :linenos:
+
+    keypoint = fo.Keypoint(
+        label="rectangle",
+        points=[
+            (0.3, 0.3),
+            (float("nan"), float("nan")),  # use nan to encode missing points
+            (0.7, 0.7),
+            (0.3, 0.7),
+        ],
+    )
+
 .. note::
 
-    Did you know? You can
-    :ref:`store keypoint skeletons <storing-keypoint-skeletons>` for your
-    keypoint fields on your dataset. Then, when you view the dataset in the
-    App, label strings and edges will be drawn when you visualize these fields
-    in the App.
+    Did you know? When you view datasets with
+    :ref:`keypoint skeletons <storing-keypoint-skeletons>` in the App, label
+    strings and edges will be drawn when you visualize the keypoint fields.
 
 .. _semantic-segmentation:
 

--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -3042,6 +3042,9 @@ class SampleCollection(object):
         For spatial object detection evaluation, this method uses COCO-style
         evaluation by default.
 
+        When evaluating keypoints, "IoUs" are computed via
+        `object keypoint similarity <https://cocodataset.org/#keypoints-eval>`_.
+
         For temporal segment detection, this method uses ActivityNet-style
         evaluation by default.
 

--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -3035,6 +3035,7 @@ class SampleCollection(object):
         -   Instance segmentations in :class:`fiftyone.core.labels.Detections`
             format with their ``mask`` attributes populated
         -   Polygons in :class:`fiftyone.core.labels.Polylines` format
+        -   Keypoints in :class:`fiftyone.core.labels.Keypoints` format
         -   Temporal detections in
             :class:`fiftyone.core.labels.TemporalDetections` format
 
@@ -3084,10 +3085,12 @@ class SampleCollection(object):
             pred_field: the name of the field containing the predicted
                 :class:`fiftyone.core.labels.Detections`,
                 :class:`fiftyone.core.labels.Polylines`,
+                :class:`fiftyone.core.labels.Keypoints`,
                 or :class:`fiftyone.core.labels.TemporalDetections`
             gt_field ("ground_truth"): the name of the field containing the
                 ground truth :class:`fiftyone.core.labels.Detections`,
                 :class:`fiftyone.core.labels.Polylines`,
+                :class:`fiftyone.core.labels.Keypoints`,
                 or :class:`fiftyone.core.labels.TemporalDetections`
             eval_key (None): a string key to use to refer to this evaluation
             classes (None): the list of possible classes. If not provided,
@@ -6127,8 +6130,9 @@ class SampleCollection(object):
 
         Args:
             field: the patches field, which must be of type
-                :class:`fiftyone.core.labels.Detections` or
-                :class:`fiftyone.core.labels.Polylines`
+                :class:`fiftyone.core.labels.Detections`,
+                :class:`fiftyone.core.labels.Polylines`, or
+                :class:`fiftyone.core.labels.Keypoints`
             other_fields (None): controls whether fields other than ``field``
                 and the default sample fields are included. Can be any of the
                 following:
@@ -6200,8 +6204,9 @@ class SampleCollection(object):
         Args:
             eval_key: an evaluation key that corresponds to the evaluation of
                 ground truth/predicted fields that are of type
-                :class:`fiftyone.core.labels.Detections` or
-                :class:`fiftyone.core.labels.Polylines`
+                :class:`fiftyone.core.labels.Detections`,
+                :class:`fiftyone.core.labels.Polylines`, or
+                :class:`fiftyone.core.labels.Keypoints`
             other_fields (None): controls whether fields other than the
                 ground truth/predicted fields and the default sample fields are
                 included. Can be any of the following:

--- a/fiftyone/core/patches.py
+++ b/fiftyone/core/patches.py
@@ -549,8 +549,9 @@ def make_patches_dataset(
         sample_collection: a
             :class:`fiftyone.core.collections.SampleCollection`
         field: the patches field, which must be of type
-            :class:`fiftyone.core.labels.Detections` or
-            :class:`fiftyone.core.labels.Polylines`
+            :class:`fiftyone.core.labels.Detections`,
+            :class:`fiftyone.core.labels.Polylines`, or
+            :class:`fiftyone.core.labels.Keypoints`
         other_fields (None): controls whether fields other than ``field`` and
             the default sample fields are included. Can be any of the
             following:
@@ -666,8 +667,9 @@ def make_evaluation_patches_dataset(
             :class:`fiftyone.core.collections.SampleCollection`
         eval_key: an evaluation key that corresponds to the evaluation of
             ground truth/predicted fields that are of type
-            :class:`fiftyone.core.labels.Detections` or
-            :class:`fiftyone.core.labels.Polylines`
+            :class:`fiftyone.core.labels.Detections`,
+            :class:`fiftyone.core.labels.Polylines`, or
+            :class:`fiftyone.core.labels.Keypoints`
         other_fields (None): controls whether fields other than the
             ground truth/predicted fields and the default sample fields are
             included. Can be any of the following:

--- a/fiftyone/core/stages.py
+++ b/fiftyone/core/stages.py
@@ -6649,8 +6649,9 @@ class ToPatches(ViewStage):
 
     Args:
         field: the patches field, which must be of type
-            :class:`fiftyone.core.labels.Detections` or
-            :class:`fiftyone.core.labels.Polylines`
+            :class:`fiftyone.core.labels.Detections`,
+            :class:`fiftyone.core.labels.Polylines`, or
+            :class:`fiftyone.core.labels.Keypoints`
         config (None): an optional dict of keyword arguments for
             :meth:`fiftyone.core.patches.make_patches_dataset` specifying how
             to perform the conversion
@@ -6792,8 +6793,9 @@ class ToEvaluationPatches(ViewStage):
     Args:
         eval_key: an evaluation key that corresponds to the evaluation of
             ground truth/predicted fields that are of type
-            :class:`fiftyone.core.labels.Detections` or
-            :class:`fiftyone.core.labels.Polylines`
+            :class:`fiftyone.core.labels.Detections`,
+            :class:`fiftyone.core.labels.Polylines, or
+            :class:`fiftyone.core.labels.Keypoints`
         config (None): an optional dict of keyword arguments for
             :meth:`fiftyone.core.patches.make_evaluation_patches_dataset`
             specifying how to perform the conversion

--- a/fiftyone/utils/eval/coco.py
+++ b/fiftyone/utils/eval/coco.py
@@ -30,11 +30,13 @@ class COCOEvaluationConfig(DetectionEvaluationConfig):
 
     Args:
         pred_field: the name of the field containing the predicted
-            :class:`fiftyone.core.labels.Detections` or
-            :class:`fiftyone.core.labels.Polylines`
+            :class:`fiftyone.core.labels.Detections`,
+            :class:`fiftyone.core.labels.Polylines`, or
+            :class:`fiftyone.core.labels.Keypoints`
         gt_field: the name of the field containing the ground truth
-            :class:`fiftyone.core.labels.Detections` or
-            :class:`fiftyone.core.labels.Polylines`
+            :class:`fiftyone.core.labels.Detections`,
+            :class:`fiftyone.core.labels.Polylines`, or
+            :class:`fiftyone.core.labels.Keypoints`
         iou (None): the IoU threshold to use to determine matches
         classwise (None): whether to only match objects with the same class
             label (True) or allow matches between classes (False)

--- a/fiftyone/utils/eval/detection.py
+++ b/fiftyone/utils/eval/detection.py
@@ -46,6 +46,7 @@ def evaluate_detections(
     -   Instance segmentations in :class:`fiftyone.core.labels.Detections`
         format with their ``mask`` attributes populated
     -   Polygons in :class:`fiftyone.core.labels.Polylines` format
+    -   Keypoints in :class:`fiftyone.core.labels.Keypoints` format
     -   Temporal detections in :class:`fiftyone.core.labels.TemporalDetections`
         format
 
@@ -95,10 +96,12 @@ def evaluate_detections(
         pred_field: the name of the field containing the predicted
             :class:`fiftyone.core.labels.Detections`,
             :class:`fiftyone.core.labels.Polylines`,
+            :class:`fiftyone.core.labels.Keypoints`,
             or :class:`fiftyone.core.labels.TemporalDetections`
         gt_field ("ground_truth"): the name of the field containing the ground
             truth :class:`fiftyone.core.labels.Detections`,
             :class:`fiftyone.core.labels.Polylines`,
+            :class:`fiftyone.core.labels.Keypoints`,
             or :class:`fiftyone.core.labels.TemporalDetections`
         eval_key (None): an evaluation key to use to refer to this evaluation
         classes (None): the list of possible classes. If not provided, the
@@ -130,7 +133,7 @@ def evaluate_detections(
     fov.validate_collection_label_fields(
         samples,
         (pred_field, gt_field),
-        (fol.Detections, fol.Polylines, fol.TemporalDetections, fol.Keypoints),
+        (fol.Detections, fol.Polylines, fol.Keypoints, fol.TemporalDetections),
         same_type=True,
     )
 
@@ -213,11 +216,13 @@ class DetectionEvaluationConfig(foe.EvaluationMethodConfig):
 
     Args:
         pred_field: the name of the field containing the predicted
-            :class:`fiftyone.core.labels.Detections` or
-            :class:`fiftyone.core.labels.Polylines`
+            :class:`fiftyone.core.labels.Detections`,
+            :class:`fiftyone.core.labels.Polylines`, or
+            :class:`fiftyone.core.labels.Keypoints`
         gt_field: the name of the field containing the ground truth
-            :class:`fiftyone.core.labels.Detections` or
-            :class:`fiftyone.core.labels.Polylines`
+            :class:`fiftyone.core.labels.Detections`,
+            :class:`fiftyone.core.labels.Polylines`, or
+            :class:`fiftyone.core.labels.Keypoints`
         iou (None): the IoU threshold to use to determine matches
         classwise (None): whether to only match objects with the same class
             label (True) or allow matches between classes (False)

--- a/fiftyone/utils/eval/detection.py
+++ b/fiftyone/utils/eval/detection.py
@@ -53,6 +53,9 @@ def evaluate_detections(
     For spatial object detection evaluation, this method uses COCO-style
     evaluation by default.
 
+    When evaluating keypoints, "IoUs" are computed via
+    `object keypoint similarity <https://cocodataset.org/#keypoints-eval>`_.
+
     For temporal segment detection, this method uses ActivityNet-style
     evaluation by default.
 

--- a/fiftyone/utils/eval/openimages.py
+++ b/fiftyone/utils/eval/openimages.py
@@ -25,11 +25,13 @@ class OpenImagesEvaluationConfig(DetectionEvaluationConfig):
 
     Args:
         pred_field: the name of the field containing the predicted
-            :class:`fiftyone.core.labels.Detections` or
-            :class:`fiftyone.core.labels.Polylines`
+            :class:`fiftyone.core.labels.Detections`,
+            :class:`fiftyone.core.labels.Polylines`, or
+            :class:`fiftyone.core.labels.Keypoints`
         gt_field: the name of the field containing the ground truth
-            :class:`fiftyone.core.labels.Detections` or
-            :class:`fiftyone.core.labels.Polylines`
+            :class:`fiftyone.core.labels.Detections`,
+            :class:`fiftyone.core.labels.Polylines`, or
+            :class:`fiftyone.core.labels.Keypoints`
         iou (None): the IoU threshold to use to determine matches
         classwise (None): whether to only match objects with the same class
             label (True) or allow matches between classes (False)

--- a/fiftyone/utils/iou.py
+++ b/fiftyone/utils/iou.py
@@ -9,6 +9,7 @@ import contextlib
 import logging
 
 import numpy as np
+import scipy.spatial as sp
 
 import eta.core.numutils as etan
 import eta.core.utils as etau
@@ -16,8 +17,6 @@ import eta.core.utils as etau
 import fiftyone.core.labels as fol
 import fiftyone.core.utils as fou
 import fiftyone.core.validation as fov
-
-import scipy.spatial as sp
 
 from .utils3d import compute_cuboid_iou as _compute_cuboid_iou
 

--- a/fiftyone/utils/iou.py
+++ b/fiftyone/utils/iou.py
@@ -45,10 +45,14 @@ def compute_ious(
     https://cocodataset.org/#keypoints-eval.
 
     Args:
-        preds: a list of predicted :class:`fiftyone.core.labels.Detection` or
-            :class:`fiftyone.core.labels.Polyline` instances
-        gts: a list of ground truth :class:`fiftyone.core.labels.Detection` or
-            :class:`fiftyone.core.labels.Polyline` instances
+        preds: a list of predicted
+            :class:`fiftyone.core.labels.Detection`,
+            :class:`fiftyone.core.labels.Polyline`, or
+            :class:`fiftyone.core.labels.Keypoints` instances
+        gts: a list of ground truth
+            :class:`fiftyone.core.labels.Detection`,
+            :class:`fiftyone.core.labels.Polyline`, or
+            :class:`fiftyone.core.labels.Keypoints` instances
         iscrowd (None): an optional name of a boolean attribute or boolean
             function to apply to each label that determines whether a ground
             truth object is a crowd. If provided, the area of the predicted
@@ -158,11 +162,13 @@ def compute_max_ious(
         sample_collection: a
             :class:`fiftyone.core.collections.SampleCollection`
         label_field: a label field of type
-            :class:`fiftyone.core.labels.Detections` or
-            :class:`fiftyone.core.labels.Polylines`
+            :class:`fiftyone.core.labels.Detections`,
+            :class:`fiftyone.core.labels.Polylines`, or
+            :class:`fiftyone.core.labels.Keypoints`
         other_field (None): another label field of type
-            :class:`fiftyone.core.labels.Detections` or
-            :class:`fiftyone.core.labels.Polylines`
+            :class:`fiftyone.core.labels.Detections`,
+            :class:`fiftyone.core.labels.Polylines`, or
+            :class:`fiftyone.core.labels.Keypoints`
         iou_attr ("max_iou"): the label attribute in which to store the max IoU
         id_attr (None): an optional attribute in which to store the label ID of
             the maximum overlapping label
@@ -271,8 +277,9 @@ def find_duplicates(
         sample_collection: a
             :class:`fiftyone.core.collections.SampleCollection`
         label_field: a label field of type
-            :class:`fiftyone.core.labels.Detections` or
-            :class:`fiftyone.core.labels.Polylines`
+            :class:`fiftyone.core.labels.Detections`,
+            :class:`fiftyone.core.labels.Polylines`, or
+            :class:`fiftyone.core.labels.Keypoints`
         iou_thresh (0.999): the IoU threshold to use to determine whether
             labels are duplicates
         method ("simple"): the duplicate removal method to use. The supported


### PR DESCRIPTION
Finishes the work started in https://github.com/voxel51/fiftyone/pull/2776 to add keypoint evaluation to FO.

Matching is done via [object keypoint similarity](https://cocodataset.org/#keypoints-eval).

## Example usage

```py
import numpy as np

import fiftyone as fo
import fiftyone.zoo as foz
from fiftyone import ViewField as F

dataset = foz.load_zoo_dataset(
    "coco-2017",
    split="validation",
    label_types="detections",
    classes=["person"],
    max_samples=5,
    only_matching=True,
)

model = foz.load_zoo_model("keypoint-rcnn-resnet50-fpn-coco-torch")
dataset.default_skeleton = model.skeleton

dataset.apply_model(model, label_field="gt")
dataset.clone_sample_field("gt_keypoints", "pred_keypoints")

for sample in dataset.iter_samples(autosave=True):
    for keypoint in sample.pred_keypoints.keypoints:
        points = np.array(keypoint.points)
        points += 0.02 * np.random.randn(*points.shape)
        keypoint.points = points.tolist()

results = dataset.evaluate_detections(
    "pred_keypoints",
    gt_field="gt_keypoints",
    eval_key="eval",
)

results.print_report()
print(dataset.bounds("pred_keypoints.keypoints.eval_iou"))

session = fo.launch_app(dataset)
```
