### PR TITLE
Reencode updates

### DIFF
--- a/docs/source/cli/index.rst
+++ b/docs/source/cli/index.rst
@@ -860,6 +860,7 @@ Transforms the images in a dataset per the specified parameters.
                                     [-e EXT] [-f] [--media-field MEDIA_FIELD]
                                     [--output-field OUTPUT_FIELD]
                                     [-o OUTPUT_DIR] [-r REL_DIR]
+                                    [--no-update-filepaths]
                                     [-d] [-n NUM_WORKERS] [-s]
                                     DATASET_NAME
 
@@ -899,6 +900,9 @@ Transforms the images in a dataset per the specified parameters.
                             input filepath to generate a unique identifier that
                             is joined with `output_dir` to generate an output
                             path for each image
+      --no-update-filepaths
+                            whether to store the output filepaths on the sample
+                            collection
       -d, --delete-originals
                             whether to delete the original images after transforming
       -n NUM_WORKERS, --num-workers NUM_WORKERS
@@ -928,7 +932,6 @@ Transforms the videos in a dataset per the specified parameters.
 
 .. code-block:: text
 
-
     fiftyone utils transform-videos [-h] [--fps FPS] [--min-fps MIN_FPS]
                                     [--max-fps MAX_FPS] [--size SIZE]
                                     [--min-size MIN_SIZE] [--max-size MAX_SIZE]
@@ -937,6 +940,7 @@ Transforms the videos in a dataset per the specified parameters.
                                     [--output-field OUTPUT_FIELD]
                                     [--output-dir OUTPUT_DIR]
                                     [--rel-dir REL_DIR]
+                                    [--no-update-filepaths]
                                     [-d] [-s] [-v]
                                     DATASET_NAME
 
@@ -978,6 +982,9 @@ Transforms the videos in a dataset per the specified parameters.
                             input filepath to generate a unique identifier that
                             is joined with `output_dir` to generate an output
                             path for each video
+      --no-update-filepaths
+                            whether to store the output filepaths on the sample
+                            collection
       -d, --delete-originals
                             whether to delete the original videos after transforming
       -s, --skip-failures   whether to gracefully continue without raising an

--- a/fiftyone/core/cli.py
+++ b/fiftyone/core/cli.py
@@ -2879,6 +2879,16 @@ class TransformImagesCommand(Command):
             ),
         )
         parser.add_argument(
+            "--no-update-filepaths",
+            dest="update_filepaths",
+            action="store_false",
+            default=True,
+            help=(
+                "whether to store the output filepaths on the sample "
+                "collection"
+            ),
+        )
+        parser.add_argument(
             "-d",
             "--delete-originals",
             action="store_true",
@@ -2919,6 +2929,7 @@ class TransformImagesCommand(Command):
             output_field=args.output_field,
             output_dir=args.output_dir,
             rel_dir=args.rel_dir,
+            update_filepaths=args.update_filepaths,
             delete_originals=args.delete_originals,
             num_workers=args.num_workers,
             skip_failures=args.skip_failures,
@@ -3046,6 +3057,16 @@ class TransformVideosCommand(Command):
             ),
         )
         parser.add_argument(
+            "--no-update-filepaths",
+            dest="update_filepaths",
+            action="store_false",
+            default=True,
+            help=(
+                "whether to store the output filepaths on the sample "
+                "collection"
+            ),
+        )
+        parser.add_argument(
             "-d",
             "--delete-originals",
             action="store_true",
@@ -3084,6 +3105,7 @@ class TransformVideosCommand(Command):
             output_field=args.output_field,
             output_dir=args.output_dir,
             rel_dir=args.rel_dir,
+            update_filepaths=args.update_filepaths,
             delete_originals=args.delete_originals,
             skip_failures=args.skip_failures,
             verbose=args.verbose,

--- a/fiftyone/utils/image.py
+++ b/fiftyone/utils/image.py
@@ -432,7 +432,6 @@ def _transform_image(
     moves = []
 
     try:
-        same_path = inpath == outpath
         should_reencode = (
             force_reencode
             or size is not None
@@ -445,7 +444,7 @@ def _transform_image(
             img = etai.read(inpath)
             size = _parse_parameters(img, size, min_size, max_size)
 
-        if same_path and should_reencode and not delete_original:
+        if should_reencode and inpath == outpath and not delete_original:
             orig_path = etau.make_unique_path(inpath, suffix="-original")
             etau.move_file(inpath, orig_path)
             moves.append((inpath, orig_path))
@@ -463,10 +462,10 @@ def _transform_image(
         elif should_reencode:
             etai.write(img, outpath)
             did_transform = True
-        elif not same_path:
+        elif inpath != outpath:
             etau.copy_file(inpath, outpath)
 
-        if delete_original and not same_path:
+        if delete_original and inpath != outpath:
             etau.delete_file(inpath)
     except Exception as e:
         try:

--- a/fiftyone/utils/image.py
+++ b/fiftyone/utils/image.py
@@ -469,9 +469,12 @@ def _transform_image(
         if delete_original and not same_path:
             etau.delete_file(inpath)
     except Exception as e:
-        # Undo any moves
-        for from_path, to_path in moves:
-            etau.move_file(to_path, from_path)
+        try:
+            # Undo any moves
+            for from_path, to_path in moves:
+                etau.move_file(to_path, from_path)
+        except:
+            pass
 
         if not skip_failures:
             raise

--- a/fiftyone/utils/image.py
+++ b/fiftyone/utils/image.py
@@ -68,8 +68,7 @@ def reencode_images(
         update_filepaths (True): whether to store the output paths on the
             sample collection
         delete_originals (False): whether to delete the original images after
-            re-encoding. This parameter has no effect if the images are being
-            updated in-place
+            re-encoding
         num_workers (None): the number of worker processes to use. By default,
             ``multiprocessing.cpu_count()`` is used
         skip_failures (False): whether to gracefully continue without raising
@@ -159,8 +158,7 @@ def transform_images(
         update_filepaths (True): whether to store the output paths on the
             sample collection
         delete_originals (False): whether to delete the original images if any
-            transformation was applied. This parameter has no effect if the
-            images are being updated in-place
+            transformation was applied
         num_workers (None): the number of worker processes to use. By default,
             ``multiprocessing.cpu_count()`` is used
         skip_failures (False): whether to gracefully continue without raising

--- a/fiftyone/utils/image.py
+++ b/fiftyone/utils/image.py
@@ -467,7 +467,7 @@ def _transform_image(
 
         if delete_original and inpath != outpath:
             etau.delete_file(inpath)
-    except Exception as e:
+    except BaseException as e:
         try:
             # Undo any moves
             for from_path, to_path in moves:

--- a/fiftyone/utils/video.py
+++ b/fiftyone/utils/video.py
@@ -931,9 +931,12 @@ def _transform_video(
         if delete_original and not same_path:
             etau.delete_file(inpath)
     except Exception as e:
-        # Undo any moves
-        for from_path, to_path in moves:
-            etau.move_file(to_path, from_path)
+        try:
+            # Undo any moves
+            for from_path, to_path in moves:
+                etau.move_file(to_path, from_path)
+        except:
+            pass
 
         if not skip_failures:
             raise

--- a/fiftyone/utils/video.py
+++ b/fiftyone/utils/video.py
@@ -799,7 +799,7 @@ def _transform_videos(
                         _frames = range(
                             1, sample.metadata.total_frame_count + 1
                         )
-                    except Exception as e:
+                    except BaseException as e:
                         if not skip_failures:
                             raise
 
@@ -929,7 +929,7 @@ def _transform_video(
 
         if delete_original and inpath != outpath:
             etau.delete_file(inpath)
-    except Exception as e:
+    except BaseException as e:
         try:
             # Undo any moves
             for from_path, to_path in moves:

--- a/fiftyone/utils/video.py
+++ b/fiftyone/utils/video.py
@@ -933,7 +933,7 @@ def _transform_video(
     except Exception as e:
         # Undo any moves
         for from_path, to_path in moves:
-            etau.move_file(from_path, to_path)
+            etau.move_file(to_path, from_path)
 
         if not skip_failures:
             raise

--- a/fiftyone/utils/video.py
+++ b/fiftyone/utils/video.py
@@ -146,8 +146,7 @@ def reencode_videos(
         update_filepaths (True): whether to store the output paths on the
             sample collection
         delete_originals (False): whether to delete the original videos after
-            re-encoding. This parameter has no effect if the videos are being
-            updated in-place
+            re-encoding
         skip_failures (False): whether to gracefully continue without raising
             an error if a video cannot be re-encoded
         verbose (False): whether to log the ``ffmpeg`` commands that are

--- a/fiftyone/utils/video.py
+++ b/fiftyone/utils/video.py
@@ -92,6 +92,7 @@ def reencode_videos(
     output_field=None,
     output_dir=None,
     rel_dir=None,
+    update_filepaths=True,
     delete_originals=False,
     skip_failures=False,
     verbose=False,
@@ -142,6 +143,8 @@ def reencode_videos(
             ``output_dir`` to generate an output path for each video. This
             argument allows for populating nested subdirectories in
             ``output_dir`` that match the shape of the input paths
+        update_filepaths (True): whether to store the output paths on the
+            sample collection
         delete_originals (False): whether to delete the original videos after
             re-encoding. This parameter has no effect if the videos are being
             updated in-place
@@ -161,6 +164,7 @@ def reencode_videos(
         output_field=output_field,
         output_dir=output_dir,
         rel_dir=rel_dir,
+        update_filepaths=update_filepaths,
         delete_originals=delete_originals,
         skip_failures=skip_failures,
         verbose=verbose,
@@ -182,6 +186,7 @@ def transform_videos(
     output_field=None,
     output_dir=None,
     rel_dir=None,
+    update_filepaths=True,
     delete_originals=False,
     skip_failures=False,
     verbose=False,
@@ -245,6 +250,8 @@ def transform_videos(
             ``output_dir`` to generate an output path for each video. This
             argument allows for populating nested subdirectories in
             ``output_dir`` that match the shape of the input paths
+        update_filepaths (True): whether to store the output paths on the
+            sample collection
         delete_originals (False): whether to delete the original videos after
             re-encoding
         skip_failures (False): whether to gracefully continue without raising
@@ -269,6 +276,7 @@ def transform_videos(
         output_field=output_field,
         output_dir=output_dir,
         rel_dir=rel_dir,
+        update_filepaths=update_filepaths,
         delete_originals=delete_originals,
         skip_failures=skip_failures,
         verbose=verbose,
@@ -287,11 +295,11 @@ def sample_videos(
     max_size=None,
     original_frame_numbers=True,
     force_sample=False,
-    save_filepaths=False,
     media_field="filepath",
     output_field=None,
     output_dir=None,
     rel_dir=None,
+    save_filepaths=False,
     delete_originals=False,
     skip_failures=False,
     verbose=False,
@@ -374,8 +382,6 @@ def sample_videos(
             the frames as 1, 2, ... (False)
         force_sample (False): whether to resample videos whose sampled frames
             already exist
-        save_filepaths (False): whether to save the sampled frame paths in the
-            ``output_field`` field of each frame of the input collection
         media_field ("filepath"): the input field containing the video paths to
             sample
         output_field (None): an optional frame field in which to store the
@@ -390,6 +396,8 @@ def sample_videos(
             the sampled frames to be written in a nested directory structure
             within ``output_dir`` matching the shape of the input video's
             folder structure
+        save_filepaths (False): whether to save the sampled frame paths in the
+            ``output_field`` field of each frame of the input collection
         delete_originals (False): whether to delete the original videos after
             sampling
         skip_failures (False): whether to gracefully continue without raising
@@ -708,11 +716,12 @@ def _transform_videos(
     original_frame_numbers=True,
     reencode=False,
     force_reencode=False,
-    save_filepaths=False,
     media_field="filepath",
     output_field=None,
     output_dir=None,
     rel_dir=None,
+    save_filepaths=False,
+    update_filepaths=True,
     delete_originals=False,
     skip_failures=False,
     verbose=False,
@@ -804,7 +813,11 @@ def _transform_videos(
 
                 sample.save()
 
-            if (diff_field or outpath != inpath) and not sample_frames:
+            if (
+                update_filepaths
+                and not sample_frames
+                and (diff_field or outpath != inpath)
+            ):
                 sample[output_field] = outpath
                 sample.save()
 

--- a/fiftyone/utils/video.py
+++ b/fiftyone/utils/video.py
@@ -881,10 +881,13 @@ def _transform_video(
             or in_ext.lower() != out_ext.lower()
         )
 
+        move = []
+
         if (inpath == outpath) and should_reencode:
-            _inpath = inpath
-            inpath = etau.make_unique_path(inpath, suffix="-original")
-            etau.move_file(_inpath, inpath)
+            tmp_path = etau.make_unique_path(inpath, suffix="-tmp")
+            orig_path = etau.make_unique_path(inpath, suffix="-original")
+            move = [(inpath, orig_path), (tmp_path, outpath)]
+            outpath = tmp_path
 
         diff_path = inpath != outpath
 
@@ -908,6 +911,9 @@ def _transform_video(
 
         if delete_original and diff_path:
             etau.delete_file(inpath)
+
+        for from_path, to_path in move:
+            etau.move_file(from_path, to_path)
     except Exception as e:
         if not skip_failures:
             raise

--- a/fiftyone/utils/video.py
+++ b/fiftyone/utils/video.py
@@ -896,7 +896,6 @@ def _transform_video(
             if "out_opts" not in kwargs:
                 kwargs["out_opts"] = []
 
-        same_path = inpath == outpath
         should_reencode = (
             force_reencode
             or fps is not None
@@ -904,7 +903,7 @@ def _transform_video(
             or in_ext.lower() != out_ext.lower()
         )
 
-        if same_path and should_reencode and not delete_original:
+        if should_reencode and inpath == outpath:
             orig_path = etau.make_unique_path(inpath, suffix="-original")
             etau.move_file(inpath, orig_path)
             moves.append((inpath, orig_path))
@@ -925,10 +924,10 @@ def _transform_video(
                 ffmpeg.run(inpath, outpath, verbose=verbose)
 
             did_transform = True
-        elif not same_path:
+        elif inpath != outpath:
             etau.copy_file(inpath, outpath)
 
-        if delete_original and not same_path:
+        if delete_original and inpath != outpath:
             etau.delete_file(inpath)
     except Exception as e:
         try:


### PR DESCRIPTION
Resolves https://github.com/voxel51/fiftyone/issues/2909.

Two changes were made when updating images/videos in-place:
- Docstrings are updated to clarify that existing files will be moved to `-original` when `delete_originals=False`
- If an error occurs while transforming, the original file is moved back into place

Additionally, users can now opt *not* to update their dataset's filepaths by passing `update_filepaths=False`.

## Image example

```py
import fiftyone as fo
import fiftyone.zoo as foz
import fiftyone.utils.image as foui

images_dir1 = "/tmp/images1"
images_dir2 = "/tmp/images2"

foz.load_zoo_dataset("quickstart").export(
    export_dir=images_dir1,
    dataset_type=fo.types.ImageDirectory,
    overwrite=True,
)

dataset = fo.Dataset.from_images_dir(images_dir1)

# Updates images in-place. But if an error occurs, the original will still be in its original place
foui.transform_images(dataset, size=(32, -1), delete_originals=True)

# Transforms the images (written to a new dir) but doesn't update the dataset's filepaths
foui.transform_images(
    dataset,
    force_reencode=True,
    output_dir=images_dir2,
    update_filepaths=False,
)
```

## Video example

```py
import fiftyone as fo
import fiftyone.zoo as foz
import fiftyone.utils.video as fouv

videos_dir1 = "/tmp/videos1"
videos_dir2 = "/tmp/videos2"

foz.load_zoo_dataset("quickstart-video").export(
    export_dir=videos_dir1,
    dataset_type=fo.types.VideoDirectory,
    overwrite=True,
)

dataset = fo.Dataset.from_videos_dir(videos_dir1)

# Updates videos in-place. But if an error occurs, the original will still be in its original place
fouv.transform_videos(dataset, size=(32, -1), delete_originals=True)

# Transforms the videos (written to a new dir) but doesn't update the dataset's filepaths
fouv.transform_videos(
    dataset,
    force_reencode=True,
    output_dir=videos_dir2,
    update_filepaths=False,
)
```