### PR TITLE
add run_doc check before results check

### DIFF
--- a/fiftyone/core/runs.py
+++ b/fiftyone/core/runs.py
@@ -582,7 +582,7 @@ class Run(Configurable):
 
         run_doc = cls._get_run_doc(samples, key)
 
-        if not run_doc.results:
+        if not run_doc or not run_doc.results:
             return None
 
         # Load run config


### PR DESCRIPTION
prevent throwing an error that prevents loading a dataset when run doc doesn't exist