### PR TITLE
Log warnings that hint how to patch broken saved views and runs

### DIFF
--- a/fiftyone/core/annotation.py
+++ b/fiftyone/core/annotation.py
@@ -6,6 +6,7 @@ Annotation runs framework.
 |
 """
 from fiftyone.core.runs import Run, RunConfig, RunInfo, RunResults
+from fiftyone.core.odm import patch_annotation_runs
 
 
 class AnnotationInfo(RunInfo):
@@ -56,6 +57,10 @@ class AnnotationMethod(Run):
     @classmethod
     def _results_cache_field(cls):
         return "_annotation_cache"
+
+    @classmethod
+    def _patch_function(cls):
+        return patch_annotation_runs
 
 
 class AnnotationResults(RunResults):

--- a/fiftyone/core/brain.py
+++ b/fiftyone/core/brain.py
@@ -6,6 +6,7 @@ Brain method runs framework.
 |
 """
 from fiftyone.core.runs import Run, RunConfig, RunInfo, RunResults
+from fiftyone.core.odm import patch_brain_runs
 
 
 class BrainInfo(RunInfo):
@@ -55,6 +56,10 @@ class BrainMethod(Run):
     @classmethod
     def _results_cache_field(cls):
         return "_brain_cache"
+
+    @classmethod
+    def _patch_function(cls):
+        return patch_brain_runs
 
 
 class BrainResults(RunResults):

--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -6589,19 +6589,19 @@ def _delete_dataset_doc(dataset_doc):
     for view_doc in dataset_doc.get_saved_views():
         view_doc.delete()
 
-    for run_doc in dataset_doc.get_annotation_runs.values():
+    for run_doc in dataset_doc.get_annotation_runs().values():
         if run_doc.results is not None:
             run_doc.results.delete()
 
         run_doc.delete()
 
-    for run_doc in dataset_doc.get_brain_methods.values():
+    for run_doc in dataset_doc.get_brain_methods().values():
         if run_doc.results is not None:
             run_doc.results.delete()
 
         run_doc.delete()
 
-    for run_doc in dataset_doc.get_evaluations.values():
+    for run_doc in dataset_doc.get_evaluations().values():
         if run_doc.results is not None:
             run_doc.results.delete()
 
@@ -7052,7 +7052,7 @@ def _clone_extras(src_dataset, dst_dataset):
         dst_doc.saved_views.append(view_doc)
 
     # Clone annotation runs
-    for anno_key, _run_doc in src_doc.get_annotation_runs.items():
+    for anno_key, _run_doc in src_doc.get_annotation_runs().items():
         run_doc = _clone_run(_run_doc)
         run_doc.dataset_id = dst_doc.id
         run_doc.save(upsert=True)
@@ -7060,7 +7060,7 @@ def _clone_extras(src_dataset, dst_dataset):
         dst_doc.annotation_runs[anno_key] = run_doc
 
     # Clone brain method runs
-    for brain_key, _run_doc in src_doc.get_brain_methods.items():
+    for brain_key, _run_doc in src_doc.get_brain_methods().items():
         run_doc = _clone_run(_run_doc)
         run_doc.dataset_id = dst_doc.id
         run_doc.save(upsert=True)
@@ -7068,7 +7068,7 @@ def _clone_extras(src_dataset, dst_dataset):
         dst_doc.brain_methods[brain_key] = run_doc
 
     # Clone evaluation runs
-    for eval_key, _run_doc in src_doc.get_evaluations.items():
+    for eval_key, _run_doc in src_doc.get_evaluations().items():
         run_doc = _clone_run(_run_doc)
         run_doc.dataset_id = dst_doc.id
         run_doc.save(upsert=True)

--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -3305,7 +3305,7 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
         Returns:
             a list of saved view names
         """
-        return [view_doc.name for view_doc in self._doc.saved_views]
+        return [view_doc.name for view_doc in self._doc.get_saved_views()]
 
     def save_view(
         self,
@@ -3478,7 +3478,7 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
 
     def delete_saved_views(self):
         """Deletes all saved views from this dataset."""
-        for view_doc in self._doc.saved_views:
+        for view_doc in self._doc.get_saved_views():
             view_doc.delete()
 
         self._doc.saved_views = []
@@ -3500,7 +3500,7 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
         idx = None
         key = "slug" if slug else "name"
 
-        for i, view_doc in enumerate(self._doc.saved_views):
+        for i, view_doc in enumerate(self._doc.get_saved_views()):
             if name == getattr(view_doc, key):
                 idx = i
                 break
@@ -3522,7 +3522,7 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
 
     def _validate_saved_view_name(self, name, skip=None, overwrite=False):
         slug = fou.to_slug(name)
-        for view_doc in self._doc.saved_views:
+        for view_doc in self._doc.get_saved_views():
             if view_doc is skip:
                 continue
 
@@ -6586,22 +6586,22 @@ def _do_load_dataset(obj, name):
 
 
 def _delete_dataset_doc(dataset_doc):
-    for view_doc in dataset_doc.saved_views:
+    for view_doc in dataset_doc.get_saved_views():
         view_doc.delete()
 
-    for run_doc in dataset_doc.annotation_runs.values():
+    for run_doc in dataset_doc.get_annotation_runs.values():
         if run_doc.results is not None:
             run_doc.results.delete()
 
         run_doc.delete()
 
-    for run_doc in dataset_doc.brain_methods.values():
+    for run_doc in dataset_doc.get_brain_methods.values():
         if run_doc.results is not None:
             run_doc.results.delete()
 
         run_doc.delete()
 
-    for run_doc in dataset_doc.evaluations.values():
+    for run_doc in dataset_doc.get_evaluations.values():
         if run_doc.results is not None:
             run_doc.results.delete()
 
@@ -6707,7 +6707,7 @@ def _clone_dataset_or_view(dataset_or_view, name, persistent):
         or dataset.has_brain_runs
         or dataset.has_evaluations
     ):
-        _clone_extras(clone_dataset, dataset._doc)
+        _clone_extras(dataset, clone_dataset)
 
     return clone_dataset
 
@@ -7039,11 +7039,12 @@ def _update_no_overwrite(d, dnew):
     d.update({k: v for k, v in dnew.items() if k not in d})
 
 
-def _clone_extras(dst_dataset, src_doc):
+def _clone_extras(src_dataset, dst_dataset):
+    src_doc = src_dataset._doc
     dst_doc = dst_dataset._doc
 
     # Clone saved views
-    for _view_doc in src_doc.saved_views:
+    for _view_doc in src_doc.get_saved_views():
         view_doc = _clone_view_doc(_view_doc)
         view_doc.dataset_id = dst_doc.id
         view_doc.save(upsert=True)
@@ -7051,7 +7052,7 @@ def _clone_extras(dst_dataset, src_doc):
         dst_doc.saved_views.append(view_doc)
 
     # Clone annotation runs
-    for anno_key, _run_doc in src_doc.annotation_runs.items():
+    for anno_key, _run_doc in src_doc.get_annotation_runs.items():
         run_doc = _clone_run(_run_doc)
         run_doc.dataset_id = dst_doc.id
         run_doc.save(upsert=True)
@@ -7059,7 +7060,7 @@ def _clone_extras(dst_dataset, src_doc):
         dst_doc.annotation_runs[anno_key] = run_doc
 
     # Clone brain method runs
-    for brain_key, _run_doc in src_doc.brain_methods.items():
+    for brain_key, _run_doc in src_doc.get_brain_methods.items():
         run_doc = _clone_run(_run_doc)
         run_doc.dataset_id = dst_doc.id
         run_doc.save(upsert=True)
@@ -7067,7 +7068,7 @@ def _clone_extras(dst_dataset, src_doc):
         dst_doc.brain_methods[brain_key] = run_doc
 
     # Clone evaluation runs
-    for eval_key, _run_doc in src_doc.evaluations.items():
+    for eval_key, _run_doc in src_doc.get_evaluations.items():
         run_doc = _clone_run(_run_doc)
         run_doc.dataset_id = dst_doc.id
         run_doc.save(upsert=True)

--- a/fiftyone/core/evaluation.py
+++ b/fiftyone/core/evaluation.py
@@ -6,6 +6,7 @@ Evaluation runs framework.
 |
 """
 from fiftyone.core.runs import Run, RunInfo, RunConfig, RunResults
+from fiftyone.core.odm import patch_evaluations
 
 
 class EvaluationInfo(RunInfo):
@@ -58,6 +59,10 @@ class EvaluationMethod(Run):
     @classmethod
     def _results_cache_field(cls):
         return "_evaluation_cache"
+
+    @classmethod
+    def _patch_function(cls):
+        return patch_evaluations
 
 
 class EvaluationResults(RunResults):

--- a/fiftyone/core/odm/dataset.py
+++ b/fiftyone/core/odm/dataset.py
@@ -494,54 +494,62 @@ class DatasetDocument(Document):
     evaluations = DictField(ReferenceField(RunDocument))
 
     def get_saved_views(self):
-        saved_views = self.saved_views
-
-        if any(isinstance(doc, DBRef) for doc in saved_views):
-            logger.warning(
-                "This dataset's saved view references are corrupted. Run "
-                "%s('%s') and dataset.reload() to resolve",
-                etau.get_function_name(patch_saved_views),
-                self.name,
-            )
+        saved_views = []
+        for view_doc in self.saved_views:
+            if not isinstance(view_doc, DBRef):
+                saved_views.append(view_doc)
+            else:
+                logger.warning(
+                    "This dataset's saved view references are corrupted. "
+                    "Run %s('%s') and dataset.reload() to resolve",
+                    etau.get_function_name(patch_saved_views),
+                    self.name,
+                )
 
         return saved_views
 
     def get_annotation_runs(self):
-        annotation_runs = self.annotation_runs
-
-        if any(isinstance(doc, DBRef) for doc in annotation_runs.values()):
-            logger.warning(
-                "This dataset's annotation run references are corrupted. Run "
-                "%s('%s') and dataset.reload() to resolve",
-                etau.get_function_name(patch_annotation_runs),
-                self.name,
-            )
+        annotation_runs = {}
+        for key, run_doc in self.annotation_runs.items():
+            if not isinstance(run_doc, DBRef):
+                annotation_runs[key] = run_doc
+            else:
+                logger.warning(
+                    "This dataset's annotation run references are corrupted. "
+                    "Run %s('%s') and dataset.reload() to resolve",
+                    etau.get_function_name(patch_annotation_runs),
+                    self.name,
+                )
 
         return annotation_runs
 
     def get_brain_methods(self):
-        brain_methods = self.brain_methods
-
-        if any(isinstance(doc, DBRef) for doc in brain_methods.values()):
-            logger.warning(
-                "This dataset's brain run references are corrupted. Run "
-                "%s('%s') and dataset.reload() to resolve",
-                etau.get_function_name(patch_brain_runs),
-                self.name,
-            )
+        brain_methods = {}
+        for key, run_doc in self.brain_methods.items():
+            if not isinstance(run_doc, DBRef):
+                brain_methods[key] = run_doc
+            else:
+                logger.warning(
+                    "This dataset's brain method run references are corrupted. "
+                    "Run %s('%s') and dataset.reload() to resolve",
+                    etau.get_function_name(patch_brain_runs),
+                    self.name,
+                )
 
         return brain_methods
 
     def get_evaluations(self):
-        evaluations = self.evaluations
-
-        if any(isinstance(doc, DBRef) for doc in evaluations.values()):
-            logger.warning(
-                "This dataset's evaluations are corrupted. Run %s('%s') to "
-                "resolve",
-                etau.get_function_name(patch_evaluations),
-                self.name,
-            )
+        evaluations = {}
+        for key, run_doc in self.evaluations.items():
+            if not isinstance(run_doc, DBRef):
+                evaluations[key] = run_doc
+            else:
+                logger.warning(
+                    "This dataset's evaluation runs references are corrupted. "
+                    "Run %s('%s') and dataset.reload() to resolve",
+                    etau.get_function_name(patch_evaluations),
+                    self.name,
+                )
 
         return evaluations
 

--- a/fiftyone/core/odm/dataset.py
+++ b/fiftyone/core/odm/dataset.py
@@ -545,7 +545,7 @@ class DatasetDocument(Document):
                 evaluations[key] = run_doc
             else:
                 logger.warning(
-                    "This dataset's evaluation runs references are corrupted. "
+                    "This dataset's evaluation run references are corrupted. "
                     "Run %s('%s') and dataset.reload() to resolve",
                     etau.get_function_name(patch_evaluations),
                     self.name,

--- a/fiftyone/core/odm/dataset.py
+++ b/fiftyone/core/odm/dataset.py
@@ -498,8 +498,8 @@ class DatasetDocument(Document):
 
         if any(isinstance(doc, DBRef) for doc in saved_views):
             logger.warning(
-                "This dataset's saved views are corrupted. Run %s('%s') to "
-                "resolve",
+                "This dataset's saved view references are corrupted. Run "
+                "%s('%s') and dataset.reload() to resolve",
                 etau.get_function_name(patch_saved_views),
                 self.name,
             )
@@ -511,8 +511,8 @@ class DatasetDocument(Document):
 
         if any(isinstance(doc, DBRef) for doc in annotation_runs.values()):
             logger.warning(
-                "This dataset's annotation runs are corrupted. Run %s('%s') "
-                "to resolve",
+                "This dataset's annotation run references are corrupted. Run "
+                "%s('%s') and dataset.reload() to resolve",
                 etau.get_function_name(patch_annotation_runs),
                 self.name,
             )
@@ -524,8 +524,8 @@ class DatasetDocument(Document):
 
         if any(isinstance(doc, DBRef) for doc in brain_methods.values()):
             logger.warning(
-                "This dataset's brain runs are corrupted. Run %s('%s') to "
-                "resolve",
+                "This dataset's brain run references are corrupted. Run "
+                "%s('%s') and dataset.reload() to resolve",
                 etau.get_function_name(patch_brain_runs),
                 self.name,
             )

--- a/fiftyone/core/odm/dataset.py
+++ b/fiftyone/core/odm/dataset.py
@@ -496,88 +496,52 @@ class DatasetDocument(Document):
     def get_saved_views(self):
         saved_views = self.saved_views
 
-        #
-        # When mongoengine encounters a ReferenceField that contains an
-        # ObjectId with no matching document, the doc is a falsey DBRef.
-        #
-        # We're not currently sure why this happens... but we've observed that
-        # ObjectIDs in DatasetDocument can somehow get out of sync with their
-        # corresponding view documents. This attempts to patch on-the-fly.
-        #
         if any(isinstance(doc, DBRef) for doc in saved_views):
-            try:
-                patch_saved_views(self.name)
-            except Exception as e:
-                logger.warning("Failed to patch saved views: %s", e)
-
-            self.reload()
-            saved_views = self.saved_views
+            logger.warning(
+                "This dataset's saved views are corrupted. Run %s('%s') to "
+                "resolve",
+                etau.get_function_name(patch_saved_views),
+                self.name,
+            )
 
         return saved_views
 
     def get_annotation_runs(self):
         annotation_runs = self.annotation_runs
 
-        #
-        # When mongoengine encounters a ReferenceField that contains an
-        # ObjectId with no matching document, the doc will be a falsey DBRef.
-        #
-        # We're not currently sure why this happens... but we've observed that
-        # ObjectIDs in DatasetDocument can somehow get out of sync with their
-        # corresponding run documents. This attempts to patch on-the-fly.
-        #
         if any(isinstance(doc, DBRef) for doc in annotation_runs.values()):
-            try:
-                patch_annotation_runs(self.name)
-            except Exception as e:
-                logger.warning("Failed to patch annotation runs: %s", e)
-
-            self.reload()
-            annotation_runs = self.annotation_runs
+            logger.warning(
+                "This dataset's annotation runs are corrupted. Run %s('%s') "
+                "to resolve",
+                etau.get_function_name(patch_annotation_runs),
+                self.name,
+            )
 
         return annotation_runs
 
     def get_brain_methods(self):
         brain_methods = self.brain_methods
 
-        #
-        # When mongoengine encounters a ReferenceField that contains an
-        # ObjectId with no matching document, the doc will be a falsey DBRef.
-        #
-        # We're not currently sure why this happens... but we've observed that
-        # ObjectIDs in DatasetDocument can somehow get out of sync with their
-        # corresponding run documents. This attempts to patch on-the-fly.
-        #
         if any(isinstance(doc, DBRef) for doc in brain_methods.values()):
-            try:
-                patch_brain_runs(self.name)
-            except Exception as e:
-                logger.warning("Failed to patch brain method runs: %s", e)
-
-            self.reload()
-            brain_methods = self.brain_methods
+            logger.warning(
+                "This dataset's brain runs are corrupted. Run %s('%s') to "
+                "resolve",
+                etau.get_function_name(patch_brain_runs),
+                self.name,
+            )
 
         return brain_methods
 
     def get_evaluations(self):
         evaluations = self.evaluations
 
-        #
-        # When mongoengine encounters a ReferenceField that contains an
-        # ObjectId with no matching document, the doc will be a falsey DBRef.
-        #
-        # We're not currently sure why this happens... but we've observed that
-        # ObjectIDs in `dataset_doc` can somehow get out of sync with their
-        # corresponding run documents. This attempts to patch on-the-fly.
-        #
         if any(isinstance(doc, DBRef) for doc in evaluations.values()):
-            try:
-                patch_evaluations(self.name)
-            except Exception as e:
-                logger.warning("Failed to patch evaluations: %s", e)
-
-            self.reload()
-            evaluations = self.evaluations
+            logger.warning(
+                "This dataset's evaluations are corrupted. Run %s('%s') to "
+                "resolve",
+                etau.get_function_name(patch_evaluations),
+                self.name,
+            )
 
         return evaluations
 

--- a/fiftyone/core/runs.py
+++ b/fiftyone/core/runs.py
@@ -754,7 +754,7 @@ class Run(Configurable):
         if any(isinstance(doc, DBRef) for doc in run_docs.values()):
             logger.warning(
                 "This dataset's %s references are corrupted. Run %s('%s') and "
-                "dataset.reload() to resolve the issue",
+                "dataset.reload() to resolve",
                 cls._run_str(),
                 etau.get_function_name(cls._patch_function()),
                 dataset_doc.name,

--- a/fiftyone/core/runs.py
+++ b/fiftyone/core/runs.py
@@ -753,7 +753,8 @@ class Run(Configurable):
 
         if any(isinstance(doc, DBRef) for doc in run_docs.values()):
             logger.warning(
-                "This dataset's %ss are corrupted. Run %s('%s') to resolve",
+                "This dataset's %s references are corrupted. Run %s('%s') and "
+                "dataset.reload() to resolve the issue",
                 cls._run_str(),
                 etau.get_function_name(cls._patch_function()),
                 dataset_doc.name,

--- a/fiftyone/server/mutation.py
+++ b/fiftyone/server/mutation.py
@@ -296,7 +296,7 @@ class Mutation:
         return next(
             (
                 SavedView.from_doc(view_doc)
-                for view_doc in dataset._doc.saved_views
+                for view_doc in dataset._doc.get_saved_views()
                 if view_doc.name == view_name
             ),
             None,
@@ -390,7 +390,7 @@ class Mutation:
         return next(
             (
                 SavedView.from_doc(view_doc)
-                for view_doc in dataset._doc.saved_views
+                for view_doc in dataset._doc.get_saved_views()
                 if view_doc.name == current_name
             ),
             None,

--- a/fiftyone/server/query.py
+++ b/fiftyone/server/query.py
@@ -454,7 +454,8 @@ class Query(fosa.AggregateQuery):
     def saved_views(self, dataset_name: str) -> t.Optional[t.List[SavedView]]:
         ds = fod.load_dataset(dataset_name)
         return [
-            SavedView.from_doc(view_doc) for view_doc in ds._doc.saved_views
+            SavedView.from_doc(view_doc)
+            for view_doc in ds._doc.get_saved_views()
         ]
 
 

--- a/fiftyone/utils/data/exporters.py
+++ b/fiftyone/utils/data/exporters.py
@@ -1823,21 +1823,21 @@ class LegacyFiftyOneDatasetExporter(GenericSampleDatasetExporter):
         if dataset.has_annotation_runs and self.export_runs:
             self._metadata["annotation_runs"] = {
                 k: json_util.dumps(v.to_dict())
-                for k, v in dataset._doc.get_annotation_runs.items()
+                for k, v in dataset._doc.get_annotation_runs().items()
             }
             _export_annotation_results(dataset, self._anno_dir)
 
         if dataset.has_brain_runs and self.export_runs:
             self._metadata["brain_methods"] = {
                 k: json_util.dumps(v.to_dict())
-                for k, v in dataset._doc.get_brain_methods.items()
+                for k, v in dataset._doc.get_brain_methods().items()
             }
             _export_brain_results(dataset, self._brain_dir)
 
         if dataset.has_evaluations and self.export_runs:
             self._metadata["evaluations"] = {
                 k: json_util.dumps(v.to_dict())
-                for k, v in dataset._doc.get_evaluations.items()
+                for k, v in dataset._doc.get_evaluations().items()
             }
             _export_evaluation_results(dataset, self._eval_dir)
 
@@ -2139,20 +2139,21 @@ class FiftyOneDatasetExporter(BatchDatasetExporter):
         if _export_runs and dataset.has_annotation_runs:
             dataset_dict["annotation_runs"] = {
                 k: v.to_dict()
-                for k, v in dataset._doc.get_annotation_runs.items()
+                for k, v in dataset._doc.get_annotation_runs().items()
             }
             _export_annotation_results(dataset, self._anno_dir)
 
         if _export_runs and dataset.has_brain_runs:
             dataset_dict["brain_methods"] = {
                 k: v.to_dict()
-                for k, v in dataset._doc.get_brain_methods.items()
+                for k, v in dataset._doc.get_brain_methods().items()
             }
             _export_brain_results(dataset, self._brain_dir)
 
         if _export_runs and dataset.has_evaluations:
             dataset_dict["evaluations"] = {
-                k: v.to_dict() for k, v in dataset._doc.get_evaluations.items()
+                k: v.to_dict()
+                for k, v in dataset._doc.get_evaluations().items()
             }
             _export_evaluation_results(dataset, self._eval_dir)
 

--- a/fiftyone/utils/data/exporters.py
+++ b/fiftyone/utils/data/exporters.py
@@ -1816,27 +1816,28 @@ class LegacyFiftyOneDatasetExporter(GenericSampleDatasetExporter):
 
         if dataset.has_saved_views and self.export_saved_views:
             self._metadata["saved_views"] = [
-                json_util.dumps(v.to_dict()) for v in dataset._doc.saved_views
+                json_util.dumps(v.to_dict())
+                for v in dataset._doc.get_saved_views()
             ]
 
         if dataset.has_annotation_runs and self.export_runs:
             self._metadata["annotation_runs"] = {
                 k: json_util.dumps(v.to_dict())
-                for k, v in dataset._doc.annotation_runs.items()
+                for k, v in dataset._doc.get_annotation_runs.items()
             }
             _export_annotation_results(dataset, self._anno_dir)
 
         if dataset.has_brain_runs and self.export_runs:
             self._metadata["brain_methods"] = {
                 k: json_util.dumps(v.to_dict())
-                for k, v in dataset._doc.brain_methods.items()
+                for k, v in dataset._doc.get_brain_methods.items()
             }
             _export_brain_results(dataset, self._brain_dir)
 
         if dataset.has_evaluations and self.export_runs:
             self._metadata["evaluations"] = {
                 k: json_util.dumps(v.to_dict())
-                for k, v in dataset._doc.evaluations.items()
+                for k, v in dataset._doc.get_evaluations.items()
             }
             _export_evaluation_results(dataset, self._eval_dir)
 
@@ -2132,24 +2133,26 @@ class FiftyOneDatasetExporter(BatchDatasetExporter):
 
         if _export_saved_views and dataset.has_saved_views:
             dataset_dict["saved_views"] = [
-                v.to_dict() for v in dataset._doc.saved_views
+                v.to_dict() for v in dataset._doc.get_saved_views()
             ]
 
         if _export_runs and dataset.has_annotation_runs:
             dataset_dict["annotation_runs"] = {
-                k: v.to_dict() for k, v in dataset._doc.annotation_runs.items()
+                k: v.to_dict()
+                for k, v in dataset._doc.get_annotation_runs.items()
             }
             _export_annotation_results(dataset, self._anno_dir)
 
         if _export_runs and dataset.has_brain_runs:
             dataset_dict["brain_methods"] = {
-                k: v.to_dict() for k, v in dataset._doc.brain_methods.items()
+                k: v.to_dict()
+                for k, v in dataset._doc.get_brain_methods.items()
             }
             _export_brain_results(dataset, self._brain_dir)
 
         if _export_runs and dataset.has_evaluations:
             dataset_dict["evaluations"] = {
-                k: v.to_dict() for k, v in dataset._doc.evaluations.items()
+                k: v.to_dict() for k, v in dataset._doc.get_evaluations.items()
             }
             _export_evaluation_results(dataset, self._eval_dir)
 


### PR DESCRIPTION
If broken saved view/run references are encountered, log warnings that describe how to run the utils introduced in https://github.com/voxel51/fiftyone/pull/2970 to patch the issue *and* omit the broken references from all operations that would raise an error when encountering broken refs.

Example usage:

```py
from bson import ObjectId, DBRef

import fiftyone as fo
import fiftyone.zoo as foz
import fiftyone.core.odm as foo

db = foo.get_db_conn()

dataset = foz.load_zoo_dataset("quickstart", max_samples=10, dataset_name="zzz")
dataset.evaluate_detections("predictions", gt_field="ground_truth", eval_key="eval")
dataset.save_view("test", dataset.limit(10))

# Break some references
dataset_dict = db.datasets.find_one({"name": dataset.name})
dataset_dict["saved_views"] = [ObjectId()]
dataset_dict["evaluations"] = {"eval": ObjectId()}
db.datasets.replace_one({"name": dataset.name}, dataset_dict)

dataset.reload()
dataset.list_saved_views()  # []
# This dataset's saved view references are corrupted. Run fiftyone.core.odm.database.patch_saved_views('zzz') and dataset.reload() to resolve
dataset.list_evaluations()  # []
# This dataset's evaluation references are corrupted. Run fiftyone.core.odm.database.patch_evaluations('zzz') and dataset.reload() to resolve

foo.patch_saved_views(dataset.name)
# Purging 1 bad saved view ID(s) {ObjectId('6458f353efee59d28b1cefde')} from dataset
# Adding 1 misplaced saved view(s) [(ObjectId('6458f346efee59d28b1cefdd'), 'test')] back to dataset

foo.patch_evaluations(dataset.name)
# Purging 1 evaluation(s) {('eval', ObjectId('6458f353efee59d28b1cefdf'))} from dataset
# Adding 1 misplaced evaluation(s) {('eval', ObjectId('6458f346efee59d28b1cefda'))} to dataset

# Now things are fixed
dataset.reload()
dataset.list_saved_views()  # ['test']
dataset.list_evaluations()  # ['eval']
```
