### PR TITLE
fix heatmap alpha bug

### DIFF
--- a/app/packages/looker/src/worker/painter.ts
+++ b/app/packages/looker/src/worker/painter.ts
@@ -84,7 +84,7 @@ export const PainterFactory = (requestColor) => ({
               value = stop;
             }
 
-            const alpha = 1 - Math.abs(value) / absMax;
+            const alpha = Math.abs(value) / absMax;
 
             return get32BitColor(color, alpha);
           };


### PR DESCRIPTION
## What changes are proposed in this pull request?

Correct inverted alpha value calculation in heatmap.

## How is this patch tested? If it is not, please explain why.

Locally.

![2023-05-08 10 30 18](https://user-images.githubusercontent.com/66688606/236865701-ad21fed5-7890-4849-87ff-bf1ecd9d5b77.gif)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
