### PR TITLE
fix a bug with search and space replacement

### DIFF
--- a/app/packages/core/src/components/Schema/SchemaSearch.tsx
+++ b/app/packages/core/src/components/Schema/SchemaSearch.tsx
@@ -52,8 +52,8 @@ export const SchemaSearch = (props: Props) => {
                 let finalSearchTerm = checkValue
                   ? searchTerm.substring(0, searchTerm.indexOf(":"))
                   : searchTerm;
-                finalSearchTerm = finalSearchTerm.replace(/\s/g, "");
-                checkValue = checkValue.replace(/\s/g, "");
+                finalSearchTerm = finalSearchTerm.trim();
+                checkValue = checkValue.trim();
 
                 let props = finalSearchTerm.split(".");
                 const last = props[props.length - 1];


### PR DESCRIPTION
## What changes are proposed in this pull request?

noticed that all spaces should **not** be removed so we can support multi-word search ex: "description:bad annotations"
solution is to trim() instead

## How is this patch tested? If it is not, please explain why.

(Details)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
