### PR TITLE
fix null error

### DIFF
--- a/app/packages/state/src/recoil/groups.ts
+++ b/app/packages/state/src/recoil/groups.ts
@@ -155,7 +155,10 @@ export const currentSlices = selectorFamily<string[] | null, boolean>({
         return get(activePcdSlices);
       }
 
-      return [get(groupSlice(modal)) || get(defaultGroupSlice)];
+      const defaultCurrentSlice =
+        get(groupSlice(modal)) || get(defaultGroupSlice);
+
+      return defaultCurrentSlice ? [defaultCurrentSlice] : null;
     },
 });
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

Account for dynamic groups edge case and return null if neither modal slice or default slice are defined


## How is this patch tested? If it is not, please explain why.

Locally

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?


-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
