### PR TITLE
improve listing perf of plugins

### DIFF
--- a/fiftyone/plugins/definitions.py
+++ b/fiftyone/plugins/definitions.py
@@ -10,70 +10,13 @@ import eta.core.serial as etas
 
 import fiftyone as fo
 import os
-import yaml  # BEFORE PR: add to requirements.txt
+import yaml
 import traceback
 
 import fiftyone.plugins.core as fopc
 import fiftyone.constants as foc
 
-
-# BEFORE PR: where should this go?
-def find_files(root_dir, filename, extensions, max_depth):
-    """Returns all files matching the given pattern, up to the given depth.
-
-    Args:
-        pattern: a glob pattern
-        max_depth: the maximum depth to search
-
-    Returns:
-        a list of paths
-    """
-    if max_depth == 0:
-        return []
-
-    paths = []
-    for i in range(1, max_depth):
-        pattern_parts = [root_dir]
-        pattern_parts += list("*" * i)
-        pattern_parts += [filename]
-        pattern = os.path.join(*pattern_parts)
-        for extension in extensions:
-            paths += glob.glob(pattern + "." + extension)
-
-    return paths
-
-
-MAX_PLUGIN_SEARCH_DEPTH = 3
-PLUGIN_METADATA_FILENAME = "fiftyone"
-PLUGIN_METADATA_EXTENSIONS = ["yml", "yaml"]
 REQUIRED_PLUGIN_METADATA_KEYS = ["name"]
-
-
-def find_plugin_metadata_files():
-    plugins_dir = fo.config.plugins_dir
-
-    if not plugins_dir:
-        return []
-
-    normal_locations = find_files(
-        plugins_dir,
-        PLUGIN_METADATA_FILENAME,
-        PLUGIN_METADATA_EXTENSIONS,
-        MAX_PLUGIN_SEARCH_DEPTH,
-    )
-    node_modules_locations = find_files(
-        os.path.join(plugins_dir, "node_modules", "*"),
-        PLUGIN_METADATA_FILENAME,
-        PLUGIN_METADATA_EXTENSIONS,
-        1,
-    )
-    yarn_packages_locations = find_files(
-        os.path.join(plugins_dir, "packages", "*"),
-        PLUGIN_METADATA_FILENAME,
-        PLUGIN_METADATA_EXTENSIONS,
-        1,
-    )
-    return normal_locations + node_modules_locations + yarn_packages_locations
 
 
 class PluginDefinition:
@@ -232,9 +175,7 @@ def list_plugins():
     plugins = [
         pd
         for pd in [
-            load_plugin_definition(
-                os.path.join(p.path, PLUGIN_METADATA_FILENAME + ".yml")
-            )
+            load_plugin_definition(p.metadata_filepath)
             for p in fopc._list_plugins(enabled_only=True)
         ]
         if pd

--- a/tests/unittests/plugins/core_tests.py
+++ b/tests/unittests/plugins/core_tests.py
@@ -118,12 +118,18 @@ def test_find_plugin_error_not_found(mocker, fiftyone_plugins_dir):
 
 
 @pytest.fixture(scope="function")
-def mock_plugin_package_name(plugin_name, plugin_path):
+def mock_plugin_package_name(
+    plugin_name, plugin_path, plugin_metadata_filepath
+):
     if not plugin_name:
         plugin_name = "test-plugin1-name"
     if not plugin_path:
         plugin_path = "path/to/plugin"
-    return fop.core.plugin_package(plugin_name, plugin_path)
+    if not plugin_metadata_filepath:
+        plugin_metadata_filepath = "path/to/plugin/fiftyone.yml"
+    return fop.core.plugin_package(
+        plugin_name, plugin_path, plugin_metadata_filepath
+    )
 
 
 def test_find_plugin_error_duplicate_name(
@@ -133,7 +139,11 @@ def test_find_plugin_error_duplicate_name(
     plugin_name = "test-plugin1"
     dup_plugin_dir = fiftyone_plugins_dir / "test-plugin2"
     mocker.patch("fiftyone.plugins.core._PLUGIN_DIRS", [fiftyone_plugins_dir])
-    m = mock.Mock(spec=fop.core.plugin_package(plugin_name, "path/to/plugin"))
+    m = mock.Mock(
+        spec=fop.core.plugin_package(
+            plugin_name, "path/to/plugin", "path/to/plugin/fiftyone.yml"
+        )
+    )
     with open(os.path.join(dup_plugin_dir, "fiftyone.yml"), "w") as f:
         pd = {k: plugin_name + "-" + k for k in _REQUIRED_YML_KEYS}
         f.write(yaml.dump(pd))


### PR DESCRIPTION
Before:

```
Time to run test_core_list_plugins: 47.207579135894775 seconds
```

```
Time to run test_core_list_plugins: 0.10054922103881836 seconds
```

The output is the same for all values of `FIFTYONE_PLUGINS_DIR` I've used. The numbers above are for my `~/Project/voxel51` dir, which includes all of fiftyone and other voxel51 source.