### PR TITLE
add missing app support for nested fields in dynamic groups

### DIFF
--- a/app/packages/core/src/components/Modal/Group/GroupContextProvider.tsx
+++ b/app/packages/core/src/components/Modal/Group/GroupContextProvider.tsx
@@ -1,5 +1,6 @@
 import { AbstractLooker } from "@fiftyone/looker";
 import * as fos from "@fiftyone/state";
+import { get } from "lodash";
 import React, { useContext, useMemo } from "react";
 import { useRecoilValue } from "recoil";
 
@@ -32,9 +33,10 @@ export const GroupContextProvider = ({
   const groupByFieldValue = useMemo(() => {
     if (modal && dynamicGroupParameters?.groupBy) {
       return String(
-        modal.sample[
+        get(
+          modal.sample,
           fos.getSanitizedGroupByExpression(dynamicGroupParameters.groupBy)
-        ] as unknown
+        )
       );
     }
     return null;


### PR DESCRIPTION
## What changes are proposed in this pull request?

Add missing app support for nested fields in dynamic groups (#2475).

## How is this patch tested? If it is not, please explain why.

Locally.
![dyanamic-groups-value-bug](https://github.com/voxel51/fiftyone/assets/66688606/40be1321-760b-480a-adf3-069616683f4f)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
