### PR TITLE
Adding fiftyone-db build for Ubuntu 22.04

### DIFF
--- a/.github/workflows/build-db.yml
+++ b/.github/workflows/build-db.yml
@@ -49,6 +49,13 @@ jobs:
         run: |
           cd package/db
           python setup.py bdist_wheel --plat-name mac-arm64
+      - name: Build wheel (Ubuntu 22.04 x86_64)
+        if: ${{ matrix.platform == 'linux-x86_64' }}
+        env:
+          FIFTYONE_DB_BUILD_LINUX_DISTRO: ubuntu2204
+        run: |
+          cd package/db
+          python setup.py bdist_wheel --plat-name linux-x86_64
       - name: Build wheel (Ubuntu 20.04 x86_64)
         if: ${{ matrix.platform == 'linux-x86_64' }}
         env:

--- a/docs/source/getting_started/troubleshooting.rst
+++ b/docs/source/getting_started/troubleshooting.rst
@@ -254,7 +254,6 @@ installation by adding `--force-reinstall` to the commands below.
 
     .. code-block:: shell
 
-      # installs MongoDB v6.0.5
       pip install fiftyone-db-ubuntu2204 
 
   .. tab:: Ubuntu 20.04

--- a/docs/source/getting_started/troubleshooting.rst
+++ b/docs/source/getting_started/troubleshooting.rst
@@ -250,7 +250,14 @@ installation by adding `--force-reinstall` to the commands below.
 
 .. tabs::
 
-  .. tab:: Ubuntu 16.04
+  .. tab:: Ubuntu 22.04
+
+    .. code-block:: shell
+
+      # installs MongoDB v6.0.5
+      pip install fiftyone-db-ubuntu2204 
+
+  .. tab:: Ubuntu 20.04
 
     .. code-block:: shell
 

--- a/install.bash
+++ b/install.bash
@@ -59,29 +59,26 @@ if [ ${SCRATCH_MONGODB_INSTALL} = true ]; then
         VERSION_FULL=$(bin/mongod --version | grep 'db version')
         VERSION="${VERSION_FULL:12}"
         if [ "${OS}" == "Darwin" ] && [ "${ARCH}" == "arm64" ]; then
-            if [ ${VERSION} != "6.0.2" ]; then
-                echo "Upgrading MongoDB v${VERSION} to v6.0.2"
+            if [ ${VERSION} != "6.0.5" ]; then
+                echo "Upgrading MongoDB v${VERSION} to v6.0.5"
             else
                 echo "MongoDB v6.0.2 already installed"
                 INSTALL_MONGODB=false
             fi
         else
-            if [ ${VERSION} != "5.0.4" ]; then
-                echo "Upgrading MongoDB v${VERSION} to v5.0.4"
+            if [ ${VERSION} != "6.0.5" ]; then
+                echo "Upgrading MongoDB v${VERSION} to v6.0.5"
             else
-                echo "MongoDB v5.0.4 already installed"
+                echo "MongoDB v6.0.5 already installed"
                 INSTALL_MONGODB=false
             fi
         fi
     else
-        echo "Installing MongoDB v5.0.4"
+        echo "Installing MongoDB v6.0.5"
     fi
     if [ ${INSTALL_MONGODB} = true ]; then
-        MONGODB_VERSION=5.0.4
+        MONGODB_VERSION=6.0.5
         if [ "${OS}" == "Darwin" ]; then
-            if [ "${ARCH}" == "arm64" ]; then
-                MONGODB_VERSION=6.0.2
-            fi
             MONGODB_BUILD=mongodb-macos-x86_64-${MONGODB_VERSION}
 
             curl https://fastdl.mongodb.org/osx/${MONGODB_BUILD}.tgz --output mongodb.tgz
@@ -90,7 +87,7 @@ if [ ${SCRATCH_MONGODB_INSTALL} = true ]; then
             rm mongodb.tgz
             rm -rf ${MONGODB_BUILD}
         elif [ "${OS}" == "Linux" ]; then
-            MONGODB_BUILD=mongodb-linux-x86_64-ubuntu2004-${MONGODB_VERSION}
+            MONGODB_BUILD=mongodb-linux-x86_64-ubuntu2204-${MONGODB_VERSION}
 
             curl https://fastdl.mongodb.org/linux/${MONGODB_BUILD}.tgz --output mongodb.tgz
             tar -zxvf mongodb.tgz

--- a/install.bash
+++ b/install.bash
@@ -50,37 +50,28 @@ OS=$(uname -s)
 ARCH=$(uname -m)
 
 if [ ${SCRATCH_MONGODB_INSTALL} = true ]; then
-    echo "***** INSTALLING MONGODB *****"
+    echo "***** INSTALLING MONGODB FROM SCRATCH *****"
+    MONGODB_VERSION=6.0.5
+    INSTALL_MONGODB=true
+
     mkdir -p ~/.fiftyone/bin
     cd ~/.fiftyone
     mkdir -p var/lib/mongo
-    INSTALL_MONGODB=true
     if [ -x bin/mongod ]; then
         VERSION_FULL=$(bin/mongod --version | grep 'db version')
-        VERSION="${VERSION_FULL:12}"
-        if [ "${OS}" == "Darwin" ] && [ "${ARCH}" == "arm64" ]; then
-            if [ ${VERSION} != "6.0.5" ]; then
-                echo "Upgrading MongoDB v${VERSION} to v6.0.5"
-            else
-                echo "MongoDB v6.0.2 already installed"
-                INSTALL_MONGODB=false
-            fi
+        CURRENT_VERSION="${VERSION_FULL:12}"
+        if [ ${CURRENT_VERSION} != ${MONGODB_VERSION} ]; then
+            echo "Upgrading MongoDB v${CURRENT_VERSION} to v${MONGODB_VERSION}"
         else
-            if [ ${VERSION} != "6.0.5" ]; then
-                echo "Upgrading MongoDB v${VERSION} to v6.0.5"
-            else
-                echo "MongoDB v6.0.5 already installed"
-                INSTALL_MONGODB=false
-            fi
+            echo "MongoDB v${MONGODB_VERSION} already installed"
+            INSTALL_MONGODB=false
         fi
-    else
-        echo "Installing MongoDB v6.0.5"
     fi
+
     if [ ${INSTALL_MONGODB} = true ]; then
-        MONGODB_VERSION=6.0.5
+        echo "Installing MongoDB v${MONGODB_VERSION}"
         if [ "${OS}" == "Darwin" ]; then
             MONGODB_BUILD=mongodb-macos-x86_64-${MONGODB_VERSION}
-
             curl https://fastdl.mongodb.org/osx/${MONGODB_BUILD}.tgz --output mongodb.tgz
             tar -zxvf mongodb.tgz
             mv ${MONGODB_BUILD}/bin/* ./bin/
@@ -88,7 +79,6 @@ if [ ${SCRATCH_MONGODB_INSTALL} = true ]; then
             rm -rf ${MONGODB_BUILD}
         elif [ "${OS}" == "Linux" ]; then
             MONGODB_BUILD=mongodb-linux-x86_64-ubuntu2204-${MONGODB_VERSION}
-
             curl https://fastdl.mongodb.org/linux/${MONGODB_BUILD}.tgz --output mongodb.tgz
             tar -zxvf mongodb.tgz
             mv ${MONGODB_BUILD}/bin/* ./bin/

--- a/package/db/setup.py
+++ b/package/db/setup.py
@@ -40,6 +40,9 @@ MONGODB_DOWNLOAD_URLS = {
     "ubuntu2004": {
         "manylinux1_x86_64": "https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-ubuntu2004-5.0.4.tgz",
     },
+    "ubuntu2204": {
+        "manylinux1_x86_64": "https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-ubuntu2204-6.0.5.tgz",
+    },
 }
 
 # mongodb binaries to distribute


### PR DESCRIPTION
Partially addresses https://github.com/voxel51/fiftyone/issues/1803 and  https://github.com/voxel51/fiftyone/issues/2737

According to the [platform support matrix](https://www.mongodb.com/docs/manual/administration/production-notes/#platform-support-matrix), MongoDB 6.0.4+ now supports Ubuntu 22.04.

This PR adds a `fiftyone-db-ubuntu2204` build with MongoDB 6.0.5 for Ubuntu 22.04.