### PR TITLE
Teams search fields mutation fix and cleanup for video dataset

### DIFF
--- a/app/packages/core/src/components/Schema/SchemaSearch.tsx
+++ b/app/packages/core/src/components/Schema/SchemaSearch.tsx
@@ -19,7 +19,7 @@ export const SchemaSearch = (props: Props) => {
     useMutation<foq.searchSelectFieldsMutation>(foq.searchSelectFields);
   const [error, setError] = useState<string>("");
 
-  const { setSearchResults } = useSchemaSettings();
+  const { setSearchResults, dataset } = useSchemaSettings();
 
   return (
     <Box
@@ -44,7 +44,7 @@ export const SchemaSearch = (props: Props) => {
           }}
           onChange={(e) => setSearchTerm(e.target.value)}
           onKeyDown={(e) => {
-            if (e.key === "Enter") {
+            if (e.key === "Enter" && dataset) {
               if (searchTerm) {
                 // convert dot notation to object
                 const split = searchTerm.split(":");
@@ -75,7 +75,7 @@ export const SchemaSearch = (props: Props) => {
                 }
 
                 searchSchemaFields({
-                  variables: { metaFilter: object },
+                  variables: { datasetName: dataset.name, metaFilter: object },
                   onCompleted: (data, err) => {
                     if (data) {
                       const { searchSelectFields = [] } = data;

--- a/app/packages/core/src/components/Schema/SchemaSettings.tsx
+++ b/app/packages/core/src/components/Schema/SchemaSettings.tsx
@@ -182,12 +182,6 @@ const SchemaSettings = () => {
                   ? searchResults.filter((pp) => selectedPaths.has(pp))
                   : [...selectedPaths];
 
-                if (mediatType === "video") {
-                  initialFieldNames = initialFieldNames.map(
-                    (pp) => `frames.${pp}`
-                  );
-                }
-
                 const stageKwargs = {
                   field_names: initialFieldNames.filter((pp) => !!pp),
                   _allow_missing: true,

--- a/app/packages/core/src/components/Sidebar/Entries/FilterEntry.tsx
+++ b/app/packages/core/src/components/Sidebar/Entries/FilterEntry.tsx
@@ -13,7 +13,6 @@ import { Settings, VisibilityOff } from "@mui/icons-material";
 import { Box, Typography } from "@mui/material";
 import {
   affectedPathCountState,
-  revertSelectedPathsState,
   selectedFieldsStageState,
   selectedPathsState,
 } from "@fiftyone/state/src/hooks/useSchemaSettings";
@@ -30,9 +29,6 @@ const Filter = ({ modal }: { modal: boolean }) => {
   );
   const resetSelectedPaths = useResetRecoilState(
     selectedPathsState({ allPaths: [] })
-  );
-  const [revertSelectedPaths, setRevertSelectedPaths] = useRecoilState(
-    revertSelectedPathsState
   );
   const affectedPathCount = useRecoilValue(affectedPathCountState);
 
@@ -71,7 +67,6 @@ const Filter = ({ modal }: { modal: boolean }) => {
                 }}
                 onClick={() => {
                   resetSelectedFieldStages();
-                  setRevertSelectedPaths(!revertSelectedPaths);
                   resetSelectedPaths();
                 }}
               >

--- a/app/packages/relay/src/mutations/__generated__/searchSelectFieldsMutation.graphql.ts
+++ b/app/packages/relay/src/mutations/__generated__/searchSelectFieldsMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<6aeac381594064ae7f8e58c8a3972720>>
+ * @generated SignedSource<<fc74ac51debe0ebc4fda5c7da7e8d743>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -10,6 +10,7 @@
 
 import { ConcreteRequest, Mutation } from 'relay-runtime';
 export type searchSelectFieldsMutation$variables = {
+  datasetName: string;
   metaFilter?: object | null;
 };
 export type searchSelectFieldsMutation$data = {
@@ -27,6 +28,11 @@ var v0 = [
   {
     "defaultValue": null,
     "kind": "LocalArgument",
+    "name": "datasetName"
+  },
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
     "name": "metaFilter"
   }
 ],
@@ -34,6 +40,11 @@ v1 = [
   {
     "alias": null,
     "args": [
+      {
+        "kind": "Variable",
+        "name": "datasetName",
+        "variableName": "datasetName"
+      },
       {
         "kind": "Variable",
         "name": "metaFilter",
@@ -74,16 +85,16 @@ return {
     "selections": (v1/*: any*/)
   },
   "params": {
-    "cacheID": "05ffc3bc35bab390474fc9a2190d0b88",
+    "cacheID": "1eaeda342a4af68822fa0cf50597efbe",
     "id": null,
     "metadata": {},
     "name": "searchSelectFieldsMutation",
     "operationKind": "mutation",
-    "text": "mutation searchSelectFieldsMutation(\n  $metaFilter: JSON = null\n) {\n  searchSelectFields(metaFilter: $metaFilter) {\n    path\n  }\n}\n"
+    "text": "mutation searchSelectFieldsMutation(\n  $datasetName: String!\n  $metaFilter: JSON = null\n) {\n  searchSelectFields(datasetName: $datasetName, metaFilter: $metaFilter) {\n    path\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "81e6b8da8399868f5d70bd599e40ac5f";
+(node as any).hash = "7509f7695fcde68a5b04b389f16164a6";
 
 export default node;

--- a/app/packages/relay/src/mutations/searchSelectFields.ts
+++ b/app/packages/relay/src/mutations/searchSelectFields.ts
@@ -1,8 +1,11 @@
 import { graphql } from "react-relay";
 
 export default graphql`
-  mutation searchSelectFieldsMutation($metaFilter: JSON = null) {
-    searchSelectFields(metaFilter: $metaFilter) {
+  mutation searchSelectFieldsMutation(
+    $datasetName: String!
+    $metaFilter: JSON = null
+  ) {
+    searchSelectFields(datasetName: $datasetName, metaFilter: $metaFilter) {
       path
     }
   }

--- a/app/packages/state/src/hooks/useSchemaSettings.ts
+++ b/app/packages/state/src/hooks/useSchemaSettings.ts
@@ -445,5 +445,6 @@ export default function useSchemaSettings() {
     setSelectedFieldsStage,
     affectedPathCount,
     mediatType: dataset.mediaType,
+    dataset,
   };
 }

--- a/app/packages/state/src/hooks/useSchemaSettings.ts
+++ b/app/packages/state/src/hooks/useSchemaSettings.ts
@@ -42,7 +42,6 @@ const disabledField = (path: string, ftype: string, subfield: string) => {
     path.startsWith("metadata") ||
     path.endsWith("frames.frame_number") ||
     ftype === FRAME_NUMBER_FIELD
-    // (ftype === LIST_FIELD && subfield === EMBEDDED_DOCUMENT_FIELD)
   );
 };
 export const schemaSearchTerm = atom<string>({
@@ -114,7 +113,6 @@ export const selectedPathsState = atomFamily({
           .filter(
             (path) =>
               !!path &&
-              // (viewSchema?.[path]?.ftype || schema?.[path]?.ftype) &&
               !skipFiled(
                 path,
                 viewSchema?.[path]?.ftype || schema?.[path]?.ftype

--- a/app/schema.graphql
+++ b/app/schema.graphql
@@ -377,7 +377,7 @@ type Mutation {
     saveToApp: Boolean!
     colorSchemeSaveFormat: ColorSchemeSaveFormat!
   ): Boolean!
-  searchSelectFields(metaFilter: JSON): [SampleField]!
+  searchSelectFields(datasetName: String, metaFilter: JSON): [SampleField]!
 }
 
 type NamedKeypointSkeleton {

--- a/fiftyone/server/mutation.py
+++ b/fiftyone/server/mutation.py
@@ -441,13 +441,16 @@ class Mutation:
 
     @gql.mutation
     async def search_select_fields(
-        self, meta_filter: t.Optional[JSON]
+        self, dataset_name: str, meta_filter: t.Optional[JSON]
     ) -> t.List[SampleField]:
         if not meta_filter:
             return []
 
         state = get_state()
         dataset = state.dataset
+        if dataset is None:
+            dataset = fod.load_dataset(dataset_name)
+
         try:
             view = dataset.select_fields(meta_filter=meta_filter)
         except Exception as e:

--- a/fiftyone/server/query.py
+++ b/fiftyone/server/query.py
@@ -478,12 +478,11 @@ class Query(fosa.AggregateQuery):
 
                 return base_schema
 
-            base_schema = serialize_fields(ds.get_field_schema(flat=True))
             if ds.media_type == fom.VIDEO:
                 # return base_schema + serialize_fields(ds.get_frame_field_schema(flat=True))
                 return serialize_fields(ds.get_frame_field_schema(flat=True))
 
-            return base_schema
+            return serialize_fields(ds.get_field_schema(flat=True))
         except Exception as e:
             print("failed to get schema for view stages", str(e))
             return []

--- a/fiftyone/server/query.py
+++ b/fiftyone/server/query.py
@@ -467,9 +467,6 @@ class Query(fosa.AggregateQuery):
             if view_stages:
                 view = fov.DatasetView._build(ds, view_stages or [])
 
-                for stage in view_stages:
-                    view.add_stage(fosg.ViewStage._from_dict(stage))
-
                 base_schema = serialize_fields(
                     view.get_field_schema(flat=True)
                 )


### PR DESCRIPTION
## What changes are proposed in this pull request?

- Fixes teams where dataset is null
- adds datasetName to seearchFields mutation
- Cleans up unused code
- merge frame fields and sample fields schemas to make better selection decision

## How is this patch tested? If it is not, please explain why.

(Details)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
