### PR TITLE
[HOLD] Fix CVAT 'import annotations()'

### DIFF
--- a/fiftyone/core/runs.py
+++ b/fiftyone/core/runs.py
@@ -241,7 +241,7 @@ class Run(Configurable):
         run_info = run_info_cls(
             key, version=version, timestamp=timestamp, config=self.config
         )
-        self.save_run_info(samples, run_info)
+        self.save_run_info(samples, run_info, overwrite)
 
     def validate_run(self, samples, key, overwrite=True):
         """Validates that the collection can accept this run.


### PR DESCRIPTION
## What changes are proposed in this pull request?

- don't delete annotation key when download succeeds
- throw an error if there is an error while downloading for project_id, but enable attempting to download all tasks and cleanup failed ones at the end in case the problem is with a specific task

## How is this patch tested? If it is not, please explain why.

(Details)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
