### PR TITLE
video dataset should have access to similarity run

### DIFF
--- a/app/packages/core/src/components/Actions/ActionsRow.tsx
+++ b/app/packages/core/src/components/Actions/ActionsRow.tsx
@@ -478,7 +478,7 @@ export const GridActionsRow = () => {
       <Colors />
       {hideTagging ? null : <Tag modal={false} />}
       <Patches />
-      {!isVideo && <Similarity modal={false} />}
+      <Similarity modal={false} />
       <SaveFilters />
       <Selected modal={false} />
       <DynamicGroupAction />
@@ -508,7 +508,7 @@ export const ModalActionsRow = ({
     >
       <Hidden />
       <Selected modal={true} lookerRef={lookerRef} />
-      {!isVideo && <Similarity modal={true} />}
+      <Similarity modal={true} />
       {!hideTagging && <Tag modal={true} lookerRef={lookerRef} />}
       <Options modal={true} />
       {isGroup && <GroupMediaVisibilityContainer modal={true} />}


### PR DESCRIPTION
```py
import numpy as np

import fiftyone as fo
import fiftyone.brain as fob
import fiftyone.zoo as foz

dataset = foz.load_zoo_dataset("quickstart-video")
embeddings = np.random.randn(len(dataset), 512)

fob.compute_similarity(
    dataset,
    embeddings=embeddings,
    model="clip-vit-base32-torch",  # hack so we can test text similarity
    brain_key="sim",
)

session = fo.launch_app(dataset)
```
