### PR TITLE
Restrict patching to correct Run class

### DIFF
--- a/fiftyone/core/odm/database.py
+++ b/fiftyone/core/odm/database.py
@@ -34,7 +34,11 @@ import fiftyone.core.utils as fou
 
 from .document import Document
 
+foa = fou.lazy_import("fiftyone.core.annotation")
+fob = fou.lazy_import("fiftyone.core.brain")
 fod = fou.lazy_import("fiftyone.core.dataset")
+foe = fou.lazy_import("fiftyone.core.evaluation")
+
 
 logger = logging.getLogger(__name__)
 
@@ -870,6 +874,7 @@ def patch_annotation_runs(dataset_name, dry_run=False):
     _patch_runs(
         dataset_name,
         "annotation_runs",
+        foa.AnnotationMethod,
         "annotation run",
         dry_run=dry_run,
     )
@@ -887,6 +892,7 @@ def patch_brain_runs(dataset_name, dry_run=False):
     _patch_runs(
         dataset_name,
         "brain_methods",
+        fob.BrainMethod,
         "brain method run",
         dry_run=dry_run,
     )
@@ -901,10 +907,16 @@ def patch_evaluations(dataset_name, dry_run=False):
         dry_run (False): whether to log the actions that would be taken but not
             perform them
     """
-    _patch_runs(dataset_name, "evaluations", "evaluation", dry_run=dry_run)
+    _patch_runs(
+        dataset_name,
+        "evaluations",
+        foe.EvaluationMethod,
+        "evaluation",
+        dry_run=dry_run,
+    )
 
 
-def _patch_runs(dataset_name, runs_field, run_str, dry_run=False):
+def _patch_runs(dataset_name, runs_field, run_cls, run_str, dry_run=False):
     conn = get_db_conn()
     _logger = _get_logger(dry_run=dry_run)
 
@@ -922,7 +934,9 @@ def _patch_runs(dataset_name, runs_field, run_str, dry_run=False):
     rd = {}
     for run_dict in conn.runs.find({"_dataset_id": dataset_id}):
         try:
-            rd[run_dict["key"]] = run_dict["_id"]
+            cls = etau.get_class(run_dict["config"]["cls"][: -len("Config")])
+            if issubclass(cls, run_cls):
+                rd[run_dict["key"]] = run_dict["_id"]
         except:
             pass
 


### PR DESCRIPTION
The `patch_XXX()` utils needed to restrict to the appropriate `Run` class.

```py
from bson import ObjectId, DBRef
import numpy as np

import fiftyone as fo
import fiftyone.brain as fob
import fiftyone.zoo as foz
import fiftyone.core.odm as foo

db = foo.get_db_conn()

dataset = foz.load_zoo_dataset("quickstart", max_samples=10)

dataset.evaluate_detections(
    "predictions",
    gt_field="ground_truth",
    eval_key="eval",
)

fob.compute_similarity(
    dataset,
    embeddings=np.random.randn(len(dataset), 12),
    brain_key="sim",
)

dataset.save_view("test", dataset.limit(10))

# Break some references
dataset_dict = db.datasets.find_one({"name": dataset.name})
dataset_dict["saved_views"] = [ObjectId()]
dataset_dict["evaluations"] = {"eval": ObjectId()}
dataset_dict["brain_methods"] = {"sim": ObjectId()}
db.datasets.replace_one({"name": dataset.name}, dataset_dict)

# Bad IDs present as DBRefs
dataset.reload()
assert isinstance(dataset._doc.saved_views[0], DBRef)
assert isinstance(dataset._doc.evaluations["eval"], DBRef)
assert isinstance(dataset._doc.brain_methods["sim"], DBRef)

foo.patch_saved_views(dataset.name)
# Purging 1 bad saved view ID(s) {ObjectId('645d8f018fdea805437ee4b3')} from dataset
# Adding 1 misplaced saved view(s) [(ObjectId('645d8f018fdea805437ee4b2'), 'test')] back to dataset

foo.patch_evaluations(dataset.name)
# Purging 1 evaluation(s) {('eval', ObjectId('645d8f018fdea805437ee4b4'))} from dataset
# Adding 1 misplaced evaluation(s) {('eval', ObjectId('645d8f018fdea805437ee4ac'))} to dataset

foo.patch_brain_runs(dataset.name)
# Purging 1 brain method run(s) {('sim', ObjectId('645d8f018fdea805437ee4b5'))} from dataset
# Adding 1 misplaced brain method run(s) {('sim', ObjectId('645d8f018fdea805437ee4af'))} to dataset

dataset.reload()
assert len(dataset.list_saved_views()) == 1
assert len(dataset.list_evaluations()) == 1
assert len(dataset.list_brain_runs()) == 1
```
