### PR TITLE
Add segment-anything models (SAM) to model zoo 

### DIFF
--- a/fiftyone/core/models.py
+++ b/fiftyone/core/models.py
@@ -363,13 +363,9 @@ def _apply_image_model_data_loader(
 
     samples = samples.select_fields(extra_fields)
     # we need to make sure classes are available in the samples
-    if (
-        extra_fields
-        and model.field_type == "detections"
-        and not samples.classes
-    ):
+    if extra_fields:
         class_labels = samples.values(
-            f"{model.needs_fields[0]}.detections.label"
+            f"{model.needs_fields[0]}.{model.field_type}.label"
         )
         class_labels = list(
             set(one for labels in class_labels for one in labels)

--- a/fiftyone/core/models.py
+++ b/fiftyone/core/models.py
@@ -234,6 +234,7 @@ def apply_model(
                 num_workers,
                 skip_failures,
                 filename_maker,
+                **kwargs,
             )
 
         if batch_size is not None:
@@ -352,8 +353,29 @@ def _apply_image_model_data_loader(
     num_workers,
     skip_failures,
     filename_maker,
+    **kwargs,
 ):
-    samples = samples.select_fields()
+    if isinstance(model, SamplesMixin):
+        model.needs_fields = kwargs
+        extra_fields = model.needs_fields
+    else:
+        extra_fields = None
+
+    samples = samples.select_fields(extra_fields)
+    # we need to make sure classes are available in the samples
+    if (
+        extra_fields
+        and model.field_type == "detections"
+        and not samples.classes
+    ):
+        class_labels = samples.values(
+            f"{model.needs_fields[0]}.detections.label"
+        )
+        class_labels = list(
+            set(one for labels in class_labels for one in labels)
+        )
+        samples.classes.update({model.needs_fields[0]: class_labels})
+
     samples_loader = fou.iter_batches(samples, batch_size)
     data_loader = _make_data_loader(
         samples, model, batch_size, num_workers, skip_failures
@@ -365,7 +387,10 @@ def _apply_image_model_data_loader(
                 if isinstance(imgs, Exception):
                     raise imgs
 
-                labels_batch = model.predict_all(imgs)
+                if extra_fields is not None:
+                    labels_batch = model.predict_all(imgs, sample_batch[0])
+                else:
+                    labels_batch = model.predict_all(imgs)
 
                 for sample, labels in zip(sample_batch, labels_batch):
                     if filename_maker is not None:
@@ -1998,6 +2023,73 @@ class PromptMixin(object):
             a numpy array containing the embeddings stacked along axis 0
         """
         return np.stack([self.embed_prompt(arg) for arg in args])
+
+
+class SamplesMixin(object):
+    """Mixin for :class:`Model` classes that need extra sample fields for prediction."""
+
+    @property
+    def needs_fields(self):
+        """Which sample fields are required for this model to run."""
+        if self.keypoint_field is not None:
+            return [self.keypoint_field]
+        elif self.detection_field is not None:
+            return [self.detection_field]
+        else:
+            return None
+
+    @property
+    def field_type(self):
+        """Which sample fields are required for this model to run."""
+        if self.keypoint_field is not None:
+            return "keypoints"
+        elif self.detection_field is not None:
+            return "detections"
+        else:
+            return None
+
+    @needs_fields.setter
+    def needs_fields(self, kwargs):
+        """Find whether points or boxes are requested and set required fields as one of them if any.
+
+        Args:
+            kwargs: keyword arguments that may contain fields to extract
+
+        """
+        self.keypoint_field = kwargs.get("points_from", None)
+        self.detection_field = kwargs.get("boxes_from", None)
+
+    @property
+    def keypoint_field(self):
+        return getattr(self, "_keypoint_field")
+
+    @property
+    def detection_field(self):
+        return getattr(self, "_detection_field")
+
+    @keypoint_field.setter
+    def keypoint_field(self, field_name):
+        self._keypoint_field = field_name
+
+    @detection_field.setter
+    def detection_field(self, field_name):
+        self._detection_field = field_name
+
+    def get_labels(self, samples):
+        field_name = self._get_field_name(samples)
+        return samples.get_field(field_name)
+
+    def get_classes(self, samples):
+        field_name = self._get_field_name(samples)
+        return samples.dataset.get_classes(field_name)
+
+    def _get_field_name(self, samples):
+        if not self.needs_fields:
+            raise ValueError("Set needs_fields before calling get_labels")
+        field_name = self.needs_fields[0]
+        if not samples.has_field(field_name):
+            raise ValueError(f"Samples must have {field_name}.label field")
+        return field_name
 
 
 class TorchModelMixin(object):

--- a/fiftyone/utils/sam.py
+++ b/fiftyone/utils/sam.py
@@ -18,9 +18,16 @@ class SegmentAnythingModelConfig(fout.TorchImageModelConfig, fozm.HasZooModel):
 
     See :class:`fiftyone.utils.torch.TorchImageModelConfig` for additional
     arguments.
+
+    Args:
+        amg_kwargs: a dictionary of keyword arguments to pass to
+            ``SamAutomaticMaskGenerator``
     """
 
-    pass
+    def __init__(self, d):
+        d = self.init(d)
+        super().__init__(d)
+        self.amg_kwargs = self.parse_dict(d, "amg_kwargs", default={})
 
 
 class SegmentAnythingModel(fout.TorchImageModel):
@@ -67,12 +74,7 @@ class SegmentAnythingModel(fout.TorchImageModel):
     def _forward_pass(self, inputs):
         mask_generator = SamAutomaticMaskGenerator(
             self._model,
-            points_per_side=32,
-            pred_iou_thresh=0.9,
-            stability_score_thresh=0.92,
-            crop_n_layers=1,
-            crop_n_points_downscale_factor=2,
-            min_mask_region_area=400,
+            **self.config.amg_kwargs,
         )
         masks = [
             mask_generator.generate(

--- a/fiftyone/utils/sam.py
+++ b/fiftyone/utils/sam.py
@@ -212,10 +212,10 @@ class SegmentAnythingModel(fout.TorchImageModel, fom.SamplesMixin):
         return self._predict_all(imgs)
 
 
-def generate_sam_points(points, w, h):
+def generate_sam_points(points, w, h, negative=False):
     # Written by Jacob Marks, modified by me
     scaled_points = np.array(points) * np.array([w, h])
-    labels = np.ones(len(points))
+    labels = np.zeros(len(points)) if negative else np.ones(len(points))
     return scaled_points, labels
 
 

--- a/fiftyone/utils/sam.py
+++ b/fiftyone/utils/sam.py
@@ -5,12 +5,13 @@ import numpy as np
 import torch
 
 import fiftyone.core.utils as fou
+import fiftyone.core.models as fom
 import fiftyone.utils.torch as fout
 import fiftyone.zoo.models as fozm
 
 fou.ensure_torch()
 
-from segment_anything import SamAutomaticMaskGenerator
+from segment_anything import SamAutomaticMaskGenerator, SamPredictor
 
 
 class SegmentAnythingModelConfig(fout.TorchImageModelConfig, fozm.HasZooModel):
@@ -30,7 +31,7 @@ class SegmentAnythingModelConfig(fout.TorchImageModelConfig, fozm.HasZooModel):
         self.amg_kwargs = self.parse_dict(d, "amg_kwargs", default={})
 
 
-class SegmentAnythingModel(fout.TorchImageModel):
+class SegmentAnythingModel(fout.TorchImageModel, fom.SamplesMixin):
     """Wrapper for running 'segment-anything-model' from https://segment-anything.com/."""
 
     def _download_model(self, config):
@@ -72,6 +73,15 @@ class SegmentAnythingModel(fout.TorchImageModel):
         return torch.from_numpy(full_mask)
 
     def _forward_pass(self, inputs):
+        mode = self.field_type
+        if mode == "keypoints":
+            return self._forward_pass_points(inputs)
+        elif mode == "detections":
+            return self._forward_pass_boxes(inputs)
+        else:
+            return self._forward_pass_amg(inputs)
+
+    def _forward_pass_amg(self, inputs):
         mask_generator = SamAutomaticMaskGenerator(
             self._model,
             **self.config.amg_kwargs,
@@ -84,3 +94,90 @@ class SegmentAnythingModel(fout.TorchImageModel):
         ]
         masks = torch.stack([self._to_torch_output(m) for m in masks])
         return dict(out=masks)
+
+    def _forward_pass_points(self, inputs):
+        sam_predictor = SamPredictor(self._model)
+        for inp in inputs:
+            sam_predictor.set_image(self._to_numpy_input(inp))
+
+    def predict_all(self, imgs, samples=None):
+        if samples is not None:
+            self.prompts = [
+                self.get_labels(samples)
+            ]  # tolist because ragged_batches=True
+            self.class_labels = self.get_classes(samples)
+
+        return self._predict_all(imgs)
+
+    def _forward_pass_boxes(self, inputs):
+        # we have to change it to instance segmentations
+        self._output_processor = fout.InstanceSegmenterOutputProcessor(
+            self.class_labels
+        )
+
+        sam_predictor = SamPredictor(self._model)
+        outputs = []
+        for inp, detections in zip(inputs, self.prompts):
+            sam_predictor.set_image(self._to_numpy_input(inp))
+            h, w = inp.size(1), inp.size(2)
+            boxes = [d.bounding_box for d in detections.detections]
+            sam_boxes = np.array([fo_to_sam(box, w, h) for box in boxes])
+            input_boxes = torch.tensor(sam_boxes, device=sam_predictor.device)
+            transformed_boxes = sam_predictor.transform.apply_boxes_torch(
+                input_boxes, (h, w)
+            )
+
+            mask, _, _ = sam_predictor.predict_torch(
+                point_coords=None,
+                point_labels=None,
+                boxes=transformed_boxes,
+                multimask_output=False,
+            )
+            outputs.append(
+                {
+                    "boxes": input_boxes,
+                    "labels": torch.tensor(
+                        [
+                            self.class_labels.index(d.label)
+                            for d in detections.detections
+                        ],
+                        device=sam_predictor.device,
+                    ),
+                    "scores": torch.tensor(
+                        [
+                            d.confidence if d.confidence else 1.0
+                            for d in detections.detections
+                        ],
+                        device=sam_predictor.device,
+                    ),
+                    "masks": mask,
+                }
+            )
+
+        return outputs
+
+
+def generate_sam_points(keypoints, label, w, h):
+    # Written by Jacob Marks
+    def scale_keypoint(p):
+        return [p[0] * w, p[1] * h]
+
+    sam_points, sam_labels = [], []
+    for kp in keypoints:
+        if kp.label == label and kp.estimated_yes_no != "unsure":
+            sam_points.append(scale_keypoint(kp.points[0]))
+            sam_labels.append(bool(kp.estimated_yes_no == "yes"))
+
+    return np.array(sam_points), np.array(sam_labels)
+
+
+def fo_to_sam(box, img_width, img_height):
+    # Written by Jacob Marks
+    new_box = np.copy(np.array(box))
+    new_box[0] *= img_width
+    new_box[2] *= img_width
+    new_box[1] *= img_height
+    new_box[3] *= img_height
+    new_box[2] += new_box[0]
+    new_box[3] += new_box[1]
+    return np.round(new_box).astype(int)

--- a/fiftyone/utils/sam.py
+++ b/fiftyone/utils/sam.py
@@ -1,0 +1,84 @@
+"""Segment-anything model integration.
+"""
+import eta.core.utils as etau
+import numpy as np
+import torch
+
+import fiftyone.core.utils as fou
+import fiftyone.utils.torch as fout
+import fiftyone.zoo.models as fozm
+
+fou.ensure_torch()
+
+from segment_anything import SamAutomaticMaskGenerator
+
+
+class SegmentAnythingModelConfig(fout.TorchImageModelConfig, fozm.HasZooModel):
+    """Configuration for running a :class:`SegmentAnythingModel`.
+
+    See :class:`fiftyone.utils.torch.TorchImageModelConfig` for additional
+    arguments.
+    """
+
+    pass
+
+
+class SegmentAnythingModel(fout.TorchImageModel):
+    """Wrapper for running 'segment-anything-model' from https://segment-anything.com/."""
+
+    def _download_model(self, config):
+        config.download_model_if_necessary()
+
+    def _load_network(self, config):
+        entrypoint = etau.get_function(config.entrypoint_fcn)
+        model = entrypoint(checkpoint=config.model_path)
+        self.preprocess = False
+        return model
+
+    @staticmethod
+    def _to_numpy_input(tensor):
+        """Converts a float32 torch tensor to a uint8 numpy array.
+
+        Args:
+            tensor: a float32 torch tensor
+
+        Returns:
+            a uint8 numpy array
+        """
+        return (tensor.cpu().numpy() * 255).astype("uint8").transpose(1, 2, 0)
+
+    @staticmethod
+    def _to_torch_output(model_output):
+        """Convert SAM's automatic mask output to a single mask torch tensor.
+
+        Args:
+            model_output: a list of masks from SAM's automatic mask generator
+
+        Returns:
+            a torch tensor of shape (num_masks, height, width)
+        """
+        masks = [one["segmentation"].astype(int) for one in model_output]
+        masks.insert(
+            0, np.zeros_like(model_output[0]["segmentation"])
+        )  # background
+        full_mask = np.stack(masks)
+        return torch.from_numpy(full_mask)
+
+    def _forward_pass(self, inputs):
+        mask_generator = SamAutomaticMaskGenerator(
+            self._model,
+            points_per_side=32,
+            pred_iou_thresh=0.9,
+            stability_score_thresh=0.92,
+            crop_n_layers=1,
+            crop_n_points_downscale_factor=2,
+            min_mask_region_area=400,
+        )
+        masks = [
+            mask_generator.generate(
+                self._to_numpy_input(inp),
+            )
+            for inp in inputs
+        ]
+        masks = torch.stack([self._to_torch_output(m) for m in masks])
+        return dict(out=masks)

--- a/fiftyone/utils/torch.py
+++ b/fiftyone/utils/torch.py
@@ -389,7 +389,7 @@ class TorchImageModel(
         if self._using_half_precision:
             imgs = imgs.half()
 
-        output = self._model(imgs)
+        output = self._forward_pass(imgs)
 
         if self.has_logits:
             self._output_processor.store_logits = self.store_logits
@@ -397,6 +397,9 @@ class TorchImageModel(
         return self._output_processor(
             output, frame_size, confidence_thresh=self.config.confidence_thresh
         )
+
+    def _forward_pass(self, inputs):
+        return self._model(inputs)
 
     def _parse_classes(self, config):
         if config.labels_string is not None:

--- a/fiftyone/zoo/models/manifest-torch.json
+++ b/fiftyone/zoo/models/manifest-torch.json
@@ -83,6 +83,42 @@
             "date_added": "2020-12-11 13:45:51"
         },
         {
+            "base_name": "segment-anything-vit_b-torch",
+            "base_filename": "sam_vit_b_01ec64.pth",
+            "version": null,
+            "description": "Segment Anything Model (SAM) from `Segment Anything <https://arxiv.org/abs/2304.02643>` with ViT-B/16 backbone trained on SA-1B",
+            "source": "https://segment-anything.com/",
+            "size_bytes": 732512,
+            "manager": {
+                "type": "fiftyone.core.models.ModelManager",
+                "config": {
+                    "url": "https://dl.fbaipublicfiles.com/segment_anything/sam_vit_b_01ec64.pth"
+                }
+            },
+            "default_deployment_config_dict": {
+                "type": "fiftyone.utils.sam.SegmentAnythingModel",
+                "config": {
+                    "entrypoint_fcn": "segment_anything.build_sam.build_sam_vit_b",
+                    "entrypoint_args": {},
+                    "output_processor_cls": "fiftyone.utils.torch.SemanticSegmenterOutputProcessor",
+                    "image_dim": 1024,
+                    "image_mean": [123.675, 116.28, 103.53],
+                    "image_std": [58.395, 57.12, 57.375]
+                }
+            },
+            "requirements": {
+                "packages": ["torch", "torchvision", "segment-anything"],
+                "cpu": {
+                    "support": true
+                },
+                "gpu": {
+                    "support": true
+                }
+            },
+            "tags": ["segmentation", "sa-1b", "zero-shot", "torch"],
+            "date_added": "2023-05-12 11:40:51"
+        },
+        {
             "base_name": "deeplabv3-resnet50-coco-torch",
             "base_filename": "deeplabv3_resnet50_coco-cd0a2569.pth",
             "version": null,

--- a/fiftyone/zoo/models/manifest-torch.json
+++ b/fiftyone/zoo/models/manifest-torch.json
@@ -119,6 +119,78 @@
             "date_added": "2023-05-12 11:40:51"
         },
         {
+            "base_name": "segment-anything-vit_h-torch",
+            "base_filename": "sam_vit_h_4b8939.pth",
+            "version": null,
+            "description": "Segment Anything Model (SAM) from `Segment Anything <https://arxiv.org/abs/2304.02643>` with ViT-H/16 backbone trained on SA-1B",
+            "source": "https://segment-anything.com/",
+            "size_bytes": 5008896,
+            "manager": {
+                "type": "fiftyone.core.models.ModelManager",
+                "config": {
+                    "url": "https://dl.fbaipublicfiles.com/segment_anything/sam_vit_h_4b8939.pth"
+                }
+            },
+            "default_deployment_config_dict": {
+                "type": "fiftyone.utils.sam.SegmentAnythingModel",
+                "config": {
+                    "entrypoint_fcn": "segment_anything.build_sam.build_sam_vit_h",
+                    "entrypoint_args": {},
+                    "output_processor_cls": "fiftyone.utils.torch.SemanticSegmenterOutputProcessor",
+                    "image_dim": 1024,
+                    "image_mean": [123.675, 116.28, 103.53],
+                    "image_std": [58.395, 57.12, 57.375]
+                }
+            },
+            "requirements": {
+                "packages": ["torch", "torchvision", "segment-anything"],
+                "cpu": {
+                    "support": true
+                },
+                "gpu": {
+                    "support": true
+                }
+            },
+            "tags": ["segmentation", "sa-1b", "zero-shot", "torch"],
+            "date_added": "2023-05-12 11:40:51"
+        },
+        {
+            "base_name": "segment-anything-vit_l-torch",
+            "base_filename": "sam_vit_l_0b3195.pth",
+            "version": null,
+            "description": "Segment Anything Model (SAM) from `Segment Anything <https://arxiv.org/abs/2304.02643>` with ViT-L/16 backbone trained on SA-1B",
+            "source": "https://segment-anything.com/",
+            "size_bytes": 2440480,
+            "manager": {
+                "type": "fiftyone.core.models.ModelManager",
+                "config": {
+                    "url": "https://dl.fbaipublicfiles.com/segment_anything/sam_vit_l_0b3195.pth"
+                }
+            },
+            "default_deployment_config_dict": {
+                "type": "fiftyone.utils.sam.SegmentAnythingModel",
+                "config": {
+                    "entrypoint_fcn": "segment_anything.build_sam.build_sam_vit_l",
+                    "entrypoint_args": {},
+                    "output_processor_cls": "fiftyone.utils.torch.SemanticSegmenterOutputProcessor",
+                    "image_dim": 1024,
+                    "image_mean": [123.675, 116.28, 103.53],
+                    "image_std": [58.395, 57.12, 57.375]
+                }
+            },
+            "requirements": {
+                "packages": ["torch", "torchvision", "segment-anything"],
+                "cpu": {
+                    "support": true
+                },
+                "gpu": {
+                    "support": true
+                }
+            },
+            "tags": ["segmentation", "sa-1b", "zero-shot", "torch"],
+            "date_added": "2023-05-12 11:40:51"
+        },
+        {
             "base_name": "deeplabv3-resnet50-coco-torch",
             "base_filename": "deeplabv3_resnet50_coco-cd0a2569.pth",
             "version": null,

--- a/fiftyone/zoo/models/manifest-torch.json
+++ b/fiftyone/zoo/models/manifest-torch.json
@@ -100,10 +100,7 @@
                 "config": {
                     "entrypoint_fcn": "segment_anything.build_sam.build_sam_vit_b",
                     "entrypoint_args": {},
-                    "output_processor_cls": "fiftyone.utils.torch.SemanticSegmenterOutputProcessor",
-                    "image_dim": 1024,
-                    "image_mean": [123.675, 116.28, 103.53],
-                    "image_std": [58.395, 57.12, 57.375]
+                    "output_processor_cls": "fiftyone.utils.torch.SemanticSegmenterOutputProcessor"
                 }
             },
             "requirements": {
@@ -136,10 +133,7 @@
                 "config": {
                     "entrypoint_fcn": "segment_anything.build_sam.build_sam_vit_h",
                     "entrypoint_args": {},
-                    "output_processor_cls": "fiftyone.utils.torch.SemanticSegmenterOutputProcessor",
-                    "image_dim": 1024,
-                    "image_mean": [123.675, 116.28, 103.53],
-                    "image_std": [58.395, 57.12, 57.375]
+                    "output_processor_cls": "fiftyone.utils.torch.SemanticSegmenterOutputProcessor"
                 }
             },
             "requirements": {
@@ -172,10 +166,7 @@
                 "config": {
                     "entrypoint_fcn": "segment_anything.build_sam.build_sam_vit_l",
                     "entrypoint_args": {},
-                    "output_processor_cls": "fiftyone.utils.torch.SemanticSegmenterOutputProcessor",
-                    "image_dim": 1024,
-                    "image_mean": [123.675, 116.28, 103.53],
-                    "image_std": [58.395, 57.12, 57.375]
+                    "output_processor_cls": "fiftyone.utils.torch.SemanticSegmenterOutputProcessor"
                 }
             },
             "requirements": {

--- a/tests/intensive/model_zoo_tests.py
+++ b/tests/intensive/model_zoo_tests.py
@@ -41,6 +41,11 @@ def test_semantic_segmentation_models():
     _apply_models(models)
 
 
+def test_sam():
+    models = ["segment-anything-vit_b-torch"]
+    _apply_models(models, max_samples=1)
+
+
 def test_keypoint_models():
     models = _get_models_with_tag("keypoints")
     _apply_person_keypoint_models(models)
@@ -49,7 +54,7 @@ def test_keypoint_models():
 def test_embedding_models():
     all_models = foz.list_zoo_models()
     _apply_embedding_models(all_models)
-    
+
 
 def test_logits_models():
     models = _get_models_with_tag("logits")
@@ -100,6 +105,7 @@ def _apply_models(
     batch_size=None,
     confidence_thresh=None,
     pass_confidence_thresh=False,
+    max_samples=10,
 ):
     if pass_confidence_thresh:
         kwargs = {"confidence_thresh": confidence_thresh}
@@ -111,7 +117,7 @@ def _apply_models(
         split="validation",
         dataset_name=fo.get_default_dataset_name(),
         shuffle=True,
-        max_samples=10,
+        max_samples=max_samples,
     )
 
     for idx, model_name in enumerate(model_names, 1):
@@ -213,7 +219,12 @@ def _apply_zero_shot_models(model_names):
         dataset.apply_model(model, label_field=label_field, batch_size=4)
 
         assert len(dataset.exists(label_field)) == len(dataset)
-        assert all([label in custom_labels for label in dataset.distinct(f"{label_field}.label")])
+        assert all(
+            [
+                label in custom_labels
+                for label in dataset.distinct(f"{label_field}.label")
+            ]
+        )
 
 
 def _apply_person_keypoint_models(model_names):

--- a/tests/intensive/model_zoo_tests.py
+++ b/tests/intensive/model_zoo_tests.py
@@ -43,9 +43,17 @@ def test_semantic_segmentation_models():
 
 def test_sam():
     models = ["segment-anything-vit_b-torch"]
+    # box prompts
     _apply_models(
         models,
-        max_samples=1,
+        max_samples=3,
+        batch_size=2,
+        apply_kwargs=dict(boxes_from="ground_truth"),
+    )
+    # auto mask generation
+    _apply_models(
+        models,
+        max_samples=2,
         model_kwargs=dict(pred_iou_thresh=0.9, min_mask_region_area=200),
     )
 
@@ -111,11 +119,14 @@ def _apply_models(
     pass_confidence_thresh=False,
     max_samples=10,
     model_kwargs=None,
+    apply_kwargs=None,
 ):
     if pass_confidence_thresh:
         kwargs = {"confidence_thresh": confidence_thresh}
     else:
         kwargs = {}
+    if apply_kwargs:
+        kwargs.update(apply_kwargs)
 
     dataset = foz.load_zoo_dataset(
         "coco-2017",

--- a/tests/intensive/model_zoo_tests.py
+++ b/tests/intensive/model_zoo_tests.py
@@ -43,7 +43,11 @@ def test_semantic_segmentation_models():
 
 def test_sam():
     models = ["segment-anything-vit_b-torch"]
-    _apply_models(models, max_samples=1)
+    _apply_models(
+        models,
+        max_samples=1,
+        model_kwargs=dict(pred_iou_thresh=0.9, min_mask_region_area=200),
+    )
 
 
 def test_keypoint_models():
@@ -106,6 +110,7 @@ def _apply_models(
     confidence_thresh=None,
     pass_confidence_thresh=False,
     max_samples=10,
+    model_kwargs=None,
 ):
     if pass_confidence_thresh:
         kwargs = {"confidence_thresh": confidence_thresh}
@@ -125,7 +130,7 @@ def _apply_models(
             "Running model %d/%d: '%s'" % (idx, len(model_names), model_name)
         )
 
-        model = foz.load_zoo_model(model_name)
+        model = foz.load_zoo_model(model_name, **(model_kwargs or {}))
 
         label_field = model_name.lower().replace("-", "_").replace(".", "_")
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

Add three [segment-anything](https://segment-anything.com/) models to the model zoo.

## How is this patch tested? If it is not, please explain why.

Added an extra intensive model test for sam backbone.

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

Segment-anything model is now available in the model zoo. It can perform automatic mask generation and guided mask generation with prompts.

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [x] Documentation: FiftyOne documentation changes
-   [ ] Other
