### PR TITLE
bugfix: sidebar filter color inconsistency

### DIFF
--- a/app/packages/state/src/recoil/color.ts
+++ b/app/packages/state/src/recoil/color.ts
@@ -82,9 +82,15 @@ export const pathColor = selectorFamily<
     ({ modal, path }) =>
     ({ get }) => {
       // video path tweak
-      const adjustedPath = path.startsWith("frames.")
-        ? path.slice("frames.".length)
-        : path;
+      const video = get(selectors.mediaTypeSelector) !== "image";
+      const parentPath =
+        video && path.startsWith("frames.")
+          ? path.split(".").slice(0, 2).join(".")
+          : path.split(".")[0];
+      const adjustedPath = parentPath.startsWith("frames.")
+        ? parentPath.slice("frames.".length)
+        : parentPath;
+
       const setting = get(
         atoms.sessionColorScheme
       )?.customizedColorSettings?.find((x) => x.field === adjustedPath);
@@ -94,12 +100,6 @@ export const pathColor = selectorFamily<
       }
 
       const map = get(colorMap(modal));
-      const video = get(selectors.mediaTypeSelector) !== "image";
-
-      const parentPath =
-        video && path.startsWith("frames.")
-          ? path.split(".").slice(0, 2).join(".")
-          : path.split(".")[0];
 
       if (get(schemaAtoms.labelFields({})).includes(parentPath)) {
         return map(parentPath);


### PR DESCRIPTION
Bug: Embedded doc filters did not use the custom color in the sidebar
![Screenshot 2023-05-12 at 9 57 08 AM](https://github.com/voxel51/fiftyone/assets/17770824/de519986-2af0-48a4-9cde-07b0bd758bdd)

Fixed this issue

## What changes are proposed in this pull request?

(Please fill in changes proposed in this fix)

## How is this patch tested? If it is not, please explain why.

(Details)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
