### PR TITLE
ColorModal UI improvements + fix reset

### DIFF
--- a/app/packages/core/src/components/ColorModal/ColorFooter.tsx
+++ b/app/packages/core/src/components/ColorModal/ColorFooter.tsx
@@ -1,7 +1,6 @@
 import * as fos from "@fiftyone/state";
 import React, { useMemo } from "react";
 import { useRecoilState, useRecoilValue } from "recoil";
-import { Field } from "@fiftyone/utilities";
 
 import { Button } from "../utils";
 import {

--- a/app/packages/core/src/components/ColorModal/ColorModal.tsx
+++ b/app/packages/core/src/components/ColorModal/ColorModal.tsx
@@ -2,7 +2,7 @@ import * as fos from "@fiftyone/state";
 import { useOutsideClick } from "@fiftyone/state";
 import { Field } from "@fiftyone/utilities";
 import CloseIcon from "@mui/icons-material/Close";
-import React, { Fragment, useRef } from "react";
+import React, { Fragment, useCallback, useRef } from "react";
 import ReactDOM from "react-dom";
 import Draggable from "react-draggable";
 import { useRecoilState, useRecoilValue } from "recoil";
@@ -31,6 +31,23 @@ const ColorModal = () => {
   const [activeColorModalField, setActiveColorModalField] = useRecoilState(
     fos.activeColorField
   );
+
+  const keyboardHandler = useCallback(
+    (e: KeyboardEvent) => {
+      const active = document.activeElement;
+      if (active?.tagName === "INPUT") {
+        if ((active as HTMLInputElement).type === "text") {
+          return;
+        }
+      }
+      if (e.key === "Escape") {
+        setActiveColorModalField(null);
+      }
+    },
+    [setActiveColorModalField]
+  );
+
+  fos.useEventHandler(document, "keydown", keyboardHandler);
 
   if (targetContainer) {
     return ReactDOM.createPortal(

--- a/app/packages/core/src/components/ColorModal/ColorModal.tsx
+++ b/app/packages/core/src/components/ColorModal/ColorModal.tsx
@@ -103,7 +103,6 @@ const ColorModal = () => {
                 ["top"]: resizeHandle,
                 ["bottom"]: resizeHandle,
               }}
-              style={{ overflow: "auto" }}
             >
               <Container height={height} width={width}>
                 <DraggableModalTitle className="draggable-colorModal-handle">
@@ -116,7 +115,7 @@ const ColorModal = () => {
                       margin: "4px",
                     }}
                   >
-                    Color Scheme
+                    Color scheme
                   </Typography>
                   <CloseIcon
                     onClick={() => setActiveColorModalField(null)}

--- a/app/packages/core/src/components/ColorModal/ColorModal.tsx
+++ b/app/packages/core/src/components/ColorModal/ColorModal.tsx
@@ -23,10 +23,7 @@ import { ACTIVE_FIELD } from "./utils";
 import Typography from "@mui/material/Typography";
 import { useTheme } from "@fiftyone/components";
 import { Resizable } from "re-resizable";
-import {
-  resizeHandle,
-  resizeLeftHandle,
-} from "./../Sidebar/Sidebar.module.css";
+import { resizeHandle } from "./../Sidebar/Sidebar.module.css";
 
 const ColorModal = () => {
   const ref = React.useRef<HTMLDivElement>();

--- a/app/packages/core/src/components/ColorModal/ColorModal.tsx
+++ b/app/packages/core/src/components/ColorModal/ColorModal.tsx
@@ -2,7 +2,7 @@ import * as fos from "@fiftyone/state";
 import { useOutsideClick } from "@fiftyone/state";
 import { Field } from "@fiftyone/utilities";
 import CloseIcon from "@mui/icons-material/Close";
-import React, { Fragment, useCallback, useRef } from "react";
+import React, { Fragment, useCallback, useRef, useState } from "react";
 import ReactDOM from "react-dom";
 import Draggable from "react-draggable";
 import { useRecoilState, useRecoilValue } from "recoil";
@@ -20,9 +20,17 @@ import {
 
 import SidebarList from "./SidebarList";
 import { ACTIVE_FIELD } from "./utils";
+import Typography from "@mui/material/Typography";
+import { useTheme } from "@fiftyone/components";
+import { Resizable } from "re-resizable";
+import {
+  resizeHandle,
+  resizeLeftHandle,
+} from "./../Sidebar/Sidebar.module.css";
 
 const ColorModal = () => {
   const ref = React.useRef<HTMLDivElement>();
+  const theme = useTheme();
   const [open, setOpen] = React.useState(false);
   useOutsideClick(ref, () => open && setOpen(false));
   const field = useRecoilValue(fos.activeColorField);
@@ -31,6 +39,8 @@ const ColorModal = () => {
   const [activeColorModalField, setActiveColorModalField] = useRecoilState(
     fos.activeColorField
   );
+  const [width, setWidth] = useState(860);
+  const [height, setHeight] = useState(680);
 
   const keyboardHandler = useCallback(
     (e: KeyboardEvent) => {
@@ -58,27 +68,75 @@ const ColorModal = () => {
           aria-labelledby="draggable-color-modal"
         >
           <Draggable bounds="parent" handle=".draggable-colorModal-handle">
-            <Container>
-              <DraggableModalTitle className="draggable-colorModal-handle">
-                <div style={{ margin: "4px" }}>Edit color scheme</div>
-                <CloseIcon
-                  onClick={() => setActiveColorModalField(null)}
-                  onMouseDown={(e) => e.stopPropagation()}
-                  style={{ margin: "4px", cursor: "pointer" }}
-                />
-              </DraggableModalTitle>
-              <DraggableContent>
-                <SidebarList />
-                <Display>
-                  {field === ACTIVE_FIELD.global && <GlobalSetting />}
-                  {field === ACTIVE_FIELD.json && <JSONViewer />}
-                  {typeof field !== "string" && field && (
-                    <FieldSetting field={activeColorModalField as Field} />
-                  )}
-                </Display>
-              </DraggableContent>
-              <ColorFooter />
-            </Container>
+            <Resizable
+              size={{ height, width }}
+              minWidth={600}
+              minHeight={500}
+              enable={{
+                top: true,
+                right: true,
+                left: true,
+                bottom: true,
+                topRight: true,
+                bottomRight: true,
+                bottomLeft: true,
+                topLeft: true,
+              }}
+              onResizeStop={(e, direction, ref, { width: dw, height: dh }) => {
+                setWidth(width + dw);
+                setHeight(height + dh);
+                // reset sidebar width on double click
+                if (e.detail === 2) {
+                  setWidth(860);
+                  setHeight(680);
+                }
+              }}
+              handleStyles={{
+                ["right"]: { right: 0, width: 4 },
+                ["left"]: { left: 0, width: 4 },
+                ["top"]: { top: 0, height: 4 },
+                ["bottom"]: { bottom: 0, height: 4 },
+              }}
+              handleClasses={{
+                ["right"]: resizeHandle,
+                ["left"]: resizeHandle,
+                ["top"]: resizeHandle,
+                ["bottom"]: resizeHandle,
+              }}
+              style={{ overflow: "auto" }}
+            >
+              <Container height={height} width={width}>
+                <DraggableModalTitle className="draggable-colorModal-handle">
+                  <Typography
+                    component="h1"
+                    color={theme.text.primary}
+                    fontSize="1.5rem"
+                    style={{
+                      width: "100%",
+                      margin: "4px",
+                    }}
+                  >
+                    Color Scheme
+                  </Typography>
+                  <CloseIcon
+                    onClick={() => setActiveColorModalField(null)}
+                    onMouseDown={(e) => e.stopPropagation()}
+                    style={{ margin: "4px", cursor: "pointer" }}
+                  />
+                </DraggableModalTitle>
+                <DraggableContent height={height} width={width}>
+                  <SidebarList />
+                  <Display>
+                    {field === ACTIVE_FIELD.global && <GlobalSetting />}
+                    {field === ACTIVE_FIELD.json && <JSONViewer />}
+                    {typeof field !== "string" && field && (
+                      <FieldSetting field={activeColorModalField as Field} />
+                    )}
+                  </Display>
+                </DraggableContent>
+                <ColorFooter />
+              </Container>
+            </Resizable>
           </Draggable>
         </ModalWrapper>
       </Fragment>,

--- a/app/packages/core/src/components/ColorModal/FieldSetting.tsx
+++ b/app/packages/core/src/components/ColorModal/FieldSetting.tsx
@@ -97,11 +97,7 @@ const FieldSetting: React.FC<Prop> = ({ field }) => {
         field: path,
         useFieldColor: false,
         fieldColor: color,
-        attributeForColor: colorFields.some(
-          (f) => f.path?.includes("label") || f.name == "label"
-        )
-          ? "label"
-          : undefined,
+        attributeForColor: undefined,
         labelColors: [],
       } as fos.CustomizeColor;
       const newSetting = [...copy, defaultSetting];

--- a/app/packages/core/src/components/ColorModal/FieldSetting.tsx
+++ b/app/packages/core/src/components/ColorModal/FieldSetting.tsx
@@ -187,19 +187,21 @@ const FieldSetting: React.FC<Prop> = ({ field }) => {
           <form
             style={{ display: "flex", flexDirection: "column", margin: "1rem" }}
           >
-            <Checkbox
-              name={`Use custom attribute for label`}
-              value={state.useCustomAttribute}
-              setValue={(v: boolean) => {
-                if (!v) {
-                  const newSetting = cloneDeep(customizedColorSettings ?? []);
-                  const index = newSetting.findIndex((x) => x.field === path);
-                  newSetting[index].attributeForColor = undefined;
-                  setColorScheme(colorPool, newSetting, false);
-                }
-                setState((s) => ({ ...s, useCustomAttribute: v }));
-              }}
-            />
+            {path && field.embeddedDocType && (
+              <Checkbox
+                name={`Use custom attribute for label`}
+                value={state.useCustomAttribute}
+                setValue={(v: boolean) => {
+                  if (!v) {
+                    const newSetting = cloneDeep(customizedColorSettings ?? []);
+                    const index = newSetting.findIndex((x) => x.field === path);
+                    newSetting[index].attributeForColor = undefined;
+                    setColorScheme(colorPool, newSetting, false);
+                  }
+                  setState((s) => ({ ...s, useCustomAttribute: v }));
+                }}
+              />
+            )}
             {/* set the attribute used for color */}
             {path && field.embeddedDocType && state.useCustomAttribute && (
               <ColorAttribute fields={colorFields} />

--- a/app/packages/core/src/components/ColorModal/FieldSetting.tsx
+++ b/app/packages/core/src/components/ColorModal/FieldSetting.tsx
@@ -202,8 +202,18 @@ const FieldSetting: React.FC<Prop> = ({ field }) => {
             {/* set the attribute used for color */}
             <SectionWrapper>
               {path && field.embeddedDocType && state.useLabelColors && (
-                <ColorAttribute fields={colorFields} style={FieldCHILD_STYLE} />
+                <>
+                  <ColorAttribute
+                    fields={colorFields}
+                    style={FieldCHILD_STYLE}
+                  />
+                  <br />
+                  <div style={FieldCHILD_STYLE}>
+                    Use specific colors for the following values
+                  </div>
+                </>
               )}
+
               <AttributeColorSetting style={FieldCHILD_STYLE} />
             </SectionWrapper>
           </form>

--- a/app/packages/core/src/components/ColorModal/GlobalSetting.tsx
+++ b/app/packages/core/src/components/ColorModal/GlobalSetting.tsx
@@ -23,7 +23,7 @@ const GlobalSetting: React.FC = ({}) => {
 
   return (
     <div>
-      <Divider>Color Setting</Divider>
+      <Divider>General</Divider>
       <ControlGroupWrapper>
         <LabelTitle>Color annotations by</LabelTitle>
         <SectionWrapper>
@@ -58,12 +58,13 @@ const GlobalSetting: React.FC = ({}) => {
           min={0}
           max={1}
           step={0.01}
+          style={{ width: "50%" }}
         />
       </ControlGroupWrapper>
-      <Divider>Keypoints Setting</Divider>
+      <Divider>Keypoints</Divider>
       <ControlGroupWrapper>
         <Checkbox
-          name={"Show keypoints in multicolor"}
+          name={"Multicolor keypoints"}
           value={Boolean(props.useMulticolorKeypoints)}
           setValue={(v) => props.setUseMultiplecolorKeypoints(v)}
         />

--- a/app/packages/core/src/components/ColorModal/JSONViewer.tsx
+++ b/app/packages/core/src/components/ColorModal/JSONViewer.tsx
@@ -85,7 +85,7 @@ const JSONViewer: React.FC = ({}) => {
           onClick={onApply}
           style={{
             margin: "0.25rem",
-            backgroundColor: theme.voxel["500"],
+            backgroundColor: theme.primary.main,
             color: "#fff",
             position: "absolute",
             top: "calc(100% - 90px)",

--- a/app/packages/core/src/components/ColorModal/JSONViewer.tsx
+++ b/app/packages/core/src/components/ColorModal/JSONViewer.tsx
@@ -48,7 +48,7 @@ const JSONViewer: React.FC = ({}) => {
   }, [setting]);
 
   const haveChanges = JSON.stringify(setting) !== JSON.stringify(data);
-
+  console.info(theme);
   return (
     <div style={{ width: "100%", height: "100%", overflow: "hidden" }}>
       <SectionWrapper>
@@ -65,25 +65,33 @@ const JSONViewer: React.FC = ({}) => {
           }}
           svgStyles={{ height: "1rem", marginTop: 7.5 }}
         />
-        {haveChanges && (
-          <Button
-            onClick={onApply}
-            style={{ margin: "0.25rem" }}
-            text="Save Changes"
-            title="Validate color scheme JSON and apply to session color scheme setting"
-          />
-        )}
       </SectionWrapper>
       <Editor
         defaultLanguage="json"
         theme={themeMode == "dark" ? "vs-dark" : "vs-light"}
         value={JSON.stringify(data, null, 4)}
         width={"100%"}
-        height={"calc(100% - 110px)"}
+        height={"calc(100% - 90px)"}
         wrapperProps={{ padding: 0 }}
         onMount={handleEditorDidMount}
         onChange={handleEditorChange}
       />
+      {haveChanges && (
+        <Button
+          onClick={onApply}
+          style={{
+            margin: "0.25rem",
+            backgroundColor: theme.voxel["500"],
+            color: "#fff",
+            position: "absolute",
+            top: "calc(100% - 90px)",
+            left: "calc(100% - 150px)",
+            textAlign: "center",
+          }}
+          text="Apply Changes"
+          title="Validate color scheme JSON and apply to session color scheme setting"
+        />
+      )}
     </div>
   );
 };

--- a/app/packages/core/src/components/ColorModal/JSONViewer.tsx
+++ b/app/packages/core/src/components/ColorModal/JSONViewer.tsx
@@ -48,11 +48,12 @@ const JSONViewer: React.FC = ({}) => {
   }, [setting]);
 
   const haveChanges = JSON.stringify(setting) !== JSON.stringify(data);
-  console.info(theme);
+
   return (
     <div style={{ width: "100%", height: "100%", overflow: "hidden" }}>
       <SectionWrapper>
-        You can use the JSON editor to customize the color settings.
+        You can use the JSON editor below to copy/edit your current color
+        scheme, or you can paste in a pre-built color scheme to apply.
         <ActionOption
           href={COLOR_SCHEME}
           text={"Read more"}
@@ -62,9 +63,12 @@ const JSONViewer: React.FC = ({}) => {
             color: theme.text.primary,
             paddingTop: 0,
             paddingBottom: 0,
+            marginLeft: 5,
+            display: "inline-block",
           }}
           svgStyles={{ height: "1rem", marginTop: 7.5 }}
-        />
+        />{" "}
+        about custom color schemes.
       </SectionWrapper>
       <Editor
         defaultLanguage="json"

--- a/app/packages/core/src/components/ColorModal/ShareStyledDiv.ts
+++ b/app/packages/core/src/components/ColorModal/ShareStyledDiv.ts
@@ -13,7 +13,12 @@ export const ModalWrapper = styled.div`
   background-color: ${({ theme }) => theme.neutral.softBg};
 `;
 
-export const Container = styled.div`
+type Props = {
+  height: number;
+  width: number;
+};
+
+export const Container = styled.div<Props>`
   background-color: ${({ theme }) => theme.background.level2};
   border: 1px solid ${({ theme }) => theme.primary.plainBorder};
   position: relative;
@@ -22,12 +27,12 @@ export const Container = styled.div`
   justify-content: start;
   overflow: hidden;
   box-shadow: ${({ theme }) => `0 20px 25px -20px ${theme.background.level1}`};
-  width: 80vw;
-  height: 80vh;
+  width: ${(props) => props.width};
+  height: ${(props) => props.height};
 `;
 
-export const DraggableContent = styled.div`
-  height: calc(80vh - 6rem);
+export const DraggableContent = styled.div<Props>`
+  height: ${(props) => `calc(${props.height}px - 6.5rem)`};
   width: 100%;
   display: flex;
   flex-direction: row;
@@ -45,9 +50,8 @@ export const DraggableModalTitle = styled.div`
   display: flex;
   justify-content: space-between;
   width: 100%;
-  height: 2.5rem;
+  height: 3rem;
   background-color: ${({ theme }) => theme.background.level1};
-  padding: 2px;
   cursor: move;
   font-weight: 600;
 `;
@@ -166,7 +170,7 @@ export const Slider = styled.span`
     width: 26px;
     left: 4px;
     bottom: 4px;
-    background-color: ${({ theme }) => theme.background.level1}};
+    background-color: ${({ theme }) => theme.background.level1};
     transition: 0.4s;
     border-radius: 50%;
   }

--- a/app/packages/core/src/components/ColorModal/SidebarList.tsx
+++ b/app/packages/core/src/components/ColorModal/SidebarList.tsx
@@ -104,7 +104,13 @@ const SidebarList: React.FC = () => {
                 <List component="div" disablePadding>
                   {group.paths.map((path, pathIdx) => (
                     <ListItemButton
-                      sx={{ pl: 4, margin: "-0.25rem" }}
+                      sx={{
+                        pl: 4,
+                        margin: "-0.25rem",
+                        "&.Mui-selected": {
+                          backgroundColor: theme.primary.main,
+                        },
+                      }}
                       key={`menu-${pathIdx}`}
                       selected={path === getCurrentField(activeField)}
                       disableRipple

--- a/app/packages/core/src/components/ColorModal/colorPalette/AttributeColorSetting.tsx
+++ b/app/packages/core/src/components/ColorModal/colorPalette/AttributeColorSetting.tsx
@@ -129,7 +129,8 @@ const AttributeColorSetting: React.FC<ColorPickerRowProps> = ({ style }) => {
     }
   }, [values]);
 
-  if (!values || values.length == 0) return null;
+  if (!values) return null;
+
   return (
     <div style={style}>
       {values.map((value, index) => (
@@ -180,13 +181,18 @@ const AttributeColorSetting: React.FC<ColorPickerRowProps> = ({ style }) => {
           />
         </RowContainer>
       ))}
-      <AddContainer>
-        <Button
-          onClick={handleAdd}
-          text="Add a new pair"
-          title="add a new pair"
-        />
-      </AddContainer>
+      {Boolean(
+        setting?.attributeForColor ||
+          (setting?.labelColors && setting.labelColors.length > 0)
+      ) && (
+        <AddContainer>
+          <Button
+            onClick={handleAdd}
+            text="Add a new pair"
+            title="add a new pair"
+          />
+        </AddContainer>
+      )}
     </div>
   );
 };

--- a/app/packages/core/src/components/ColorModal/colorPalette/AttributeColorSetting.tsx
+++ b/app/packages/core/src/components/ColorModal/colorPalette/AttributeColorSetting.tsx
@@ -129,7 +129,7 @@ const AttributeColorSetting: React.FC<ColorPickerRowProps> = ({ style }) => {
     }
   }, [values]);
 
-  if (!values) return null;
+  if (!values || values.length == 0) return null;
   return (
     <div style={style}>
       {values.map((value, index) => (

--- a/app/packages/core/src/components/ColorModal/controls/ColorAttribute.tsx
+++ b/app/packages/core/src/components/ColorModal/controls/ColorAttribute.tsx
@@ -70,7 +70,7 @@ const ColorAttribute: React.FC<Prop> = ({ fields }) => {
 
   return (
     <div>
-      Select an attribute for annotation's color
+      Select an attribute to color by
       <ActionDiv ref={ref}>
         <Tooltip
           text={

--- a/app/packages/core/src/components/ColorModal/controls/ColorAttribute.tsx
+++ b/app/packages/core/src/components/ColorModal/controls/ColorAttribute.tsx
@@ -58,7 +58,7 @@ const ColorAttribute: React.FC<Prop> = ({ fields, style }) => {
       e.preventDefault();
       const copy = cloneDeep(customizedColorSettings);
       if (index > -1) {
-        copy[index].attributeForColor = field.path?.split(".").slice(-1);
+        copy[index].attributeForColor = field.path?.split(".").slice(-1)[0];
         setColorScheme(colorPool, copy, false);
         setOpen(false);
       }

--- a/app/packages/core/src/components/ColorModal/controls/ColorAttribute.tsx
+++ b/app/packages/core/src/components/ColorModal/controls/ColorAttribute.tsx
@@ -28,6 +28,7 @@ const SelectButton = styled.div`
 
 type Prop = {
   fields: Field[];
+  style: React.CSSProperties;
 };
 
 type Option = {
@@ -35,7 +36,7 @@ type Option = {
   onClick: () => void;
 };
 
-const ColorAttribute: React.FC<Prop> = ({ fields }) => {
+const ColorAttribute: React.FC<Prop> = ({ fields, style }) => {
   const theme = useTheme();
   const ref = React.useRef<HTMLDivElement>();
   const [open, setOpen] = React.useState(false);
@@ -69,7 +70,7 @@ const ColorAttribute: React.FC<Prop> = ({ fields }) => {
     "Please select an attribute";
 
   return (
-    <div>
+    <div style={style}>
       Select an attribute to color by
       <ActionDiv ref={ref}>
         <Tooltip

--- a/app/packages/core/src/components/ColorModal/controls/RefreshColor.tsx
+++ b/app/packages/core/src/components/ColorModal/controls/RefreshColor.tsx
@@ -25,7 +25,6 @@ const ShuffleColor: React.FC = () => {
         style={{
           margin: "0.25rem -0.5rem",
           height: "2rem",
-          borderRadius: 0,
           textAlign: "center",
           flex: 1,
           width: "200px",

--- a/app/packages/core/src/components/Sidebar/Sidebar.module.css
+++ b/app/packages/core/src/components/Sidebar/Sidebar.module.css
@@ -1,7 +1,7 @@
 .resizeHandle:hover,
 .resizeHandle:active,
 .resizeHandle:focus {
-  background: #ff6d05;
+  background: var(--fo-palette-primary-brand);
   z-index: 1;
   transition-delay: 0.25s;
 }

--- a/app/packages/core/src/components/Sidebar/Sidebar.module.css
+++ b/app/packages/core/src/components/Sidebar/Sidebar.module.css
@@ -1,7 +1,7 @@
 .resizeHandle:hover,
 .resizeHandle:active,
 .resizeHandle:focus {
-  background: #007fd4;
+  background: #ff6d05;
   z-index: 1;
   transition-delay: 0.25s;
 }

--- a/app/packages/core/src/components/Sidebar/ViewSelection/ViewDialog.tsx
+++ b/app/packages/core/src/components/Sidebar/ViewSelection/ViewDialog.tsx
@@ -301,7 +301,7 @@ export default function ViewDialog(props: Props) {
                   colorOption?.color === initialColor)
               }
               sx={{
-                background: theme.voxel[500],
+                background: theme.primary.main,
                 color: theme.common.white,
                 textTransform: "inherit",
                 padding: "0.5rem 1.25rem",
@@ -309,7 +309,7 @@ export default function ViewDialog(props: Props) {
                 marginLeft: "1rem",
 
                 "&:hover": {
-                  background: theme.voxel[600],
+                  background: theme.primary.main,
                   color: theme.common.white,
                 },
 

--- a/app/packages/looker-3d/src/Looker3d.tsx
+++ b/app/packages/looker-3d/src/Looker3d.tsx
@@ -48,6 +48,7 @@ import {
   isPointSizeAttenuatedAtom,
   shadeByAtom,
 } from "./state";
+import { isValidColor } from "@fiftyone/looker/src/overlays/util";
 
 type View = "pov" | "top";
 
@@ -67,6 +68,10 @@ export const Looker3d = () => {
   const cameraRef = React.useRef<Camera>();
   const controlsRef = React.useRef();
   const getColor = useRecoilValue(fos.colorMap(true));
+  const colorScheme = useRecoilValue(
+    fos.sessionColorScheme
+  ).customizedColorSettings;
+
   const [pointCloudBounds, setPointCloudBounds] = React.useState<Box3>();
   const { coloring } = useRecoilValue(
     fos.lookerOptions({ withFilter: true, modal: MODAL_TRUE })
@@ -89,10 +94,6 @@ export const Looker3d = () => {
   const mediaField = useRecoilValue(fos.selectedMediaField(true));
 
   const sampleMap = useRecoilValue(fos.activePcdSliceToSampleMap);
-
-  // const sampleMapJson = useMemo(() => {
-  //   r
-  // }, [sampleMap])
 
   useEffect(() => {
     Object3D.DefaultUp = new Vector3(...settings.defaultUp).normalize();
@@ -378,17 +379,44 @@ export const Looker3d = () => {
         .map((l) => {
           const path = l.path.join(".");
           let color: string;
-          switch (coloring.by) {
-            case "field":
+          const setting = colorScheme?.find((s) => s.field === path);
+          if (coloring.by === "field") {
+            if (
+              setting &&
+              setting.useFieldColor &&
+              setting.fieldColor &&
+              isValidColor(setting.fieldColor)
+            ) {
+              color = setting.fieldColor;
+            } else {
               color = getColor(path);
-              break;
-            case "instance":
-              color = getColor(l._id);
-              break;
-            default:
-              color = getColor(l.label);
-              break;
+            }
           }
+          if (coloring.by === "value") {
+            const key =
+              setting.attributeForColor === "index"
+                ? l._id
+                : setting.attributeForColor === "label"
+                ? l.label
+                : l.attributes[setting.attributeForColor] ?? l.label;
+            if (
+              setting &&
+              setting.labelColors &&
+              setting.labelColors.length > 0
+            ) {
+              const labelColor = setting.labelColors.find(
+                (s) => s.name === key
+              )?.color;
+              if (isValidColor(labelColor)) {
+                color = labelColor;
+              } else {
+                color = getColor(key);
+              }
+            } else {
+              color = getColor(key);
+            }
+          }
+
           return { ...l, color, id: l._id };
         })
         .filter((l) => pathFilter(l.path.join("."), l)),

--- a/app/packages/looker/src/overlays/base.ts
+++ b/app/packages/looker/src/overlays/base.ts
@@ -114,14 +114,19 @@ export abstract class CoordinateOverlay<
     }
     if (coloring.by === "value") {
       if (field) {
-        key = field.attributeForColor ?? "label";
+        key = field.attributeForColor
+          ? field.attributeForColor === "index"
+            ? "id"
+            : field.attributeForColor
+          : "label";
         // check if this label has a assigned color, use it if it is a valid color
         const labelColor = field.labelColors?.find(
           (l) => l.name == this.label[key]?.toString()
         )?.color;
+
         return isValidColor(labelColor)
           ? labelColor
-          : getColor(coloring.pool, coloring.seed, this.label["label"]);
+          : getColor(coloring.pool, coloring.seed, this.label[key]);
       } else {
         return getColor(coloring.pool, coloring.seed, this.label["label"]);
       }

--- a/app/packages/spaces/src/App.css
+++ b/app/packages/spaces/src/App.css
@@ -6,6 +6,7 @@ body {
   --fo-palette-text-primary: hsl(200, 0%, 100%);
   --fo-palette-text-secondary: hsl(200, 0%, 70%);
   --fo-palette-background-level3: hsl(200, 0%, 5%);
+  --fo-palette-primary-brand: hsl(25, 100%, 51%);
 
   padding: 0;
   margin: 0;

--- a/app/packages/state/src/hooks/useClearSessionColorScheme.ts
+++ b/app/packages/state/src/hooks/useClearSessionColorScheme.ts
@@ -11,6 +11,7 @@ import {
 } from "../recoil";
 import useSendEvent from "./useSendEvent";
 import { DEFAULT_APP_COLOR_SCHEME } from "../utils";
+import useSetDataset from "./useSetDataset";
 
 const useClearSessionColorScheme = () => {
   const send = useSendEvent(true);
@@ -18,6 +19,7 @@ const useClearSessionColorScheme = () => {
   const [commit] = useMutation<foq.setColorSchemeMutation>(foq.setColorScheme);
   const onError = useErrorHandler();
   const setSessionColorSchemeState = useSetRecoilState(sessionColorScheme);
+  const setDataset = useSetDataset();
   const dataset = useRecoilValue(datasetName);
   const stages = useRecoilValue(view);
   const defaultSetting = useRecoilValue(datasetAppConfig).colorScheme;
@@ -45,11 +47,16 @@ const useClearSessionColorScheme = () => {
           ? defaultSetting.customizedColorSettings
           : null,
     };
-    setSessionColorSchemeState(combined);
 
     return send((session) =>
       commit({
         onError,
+        onCompleted: () => {
+          setSessionColorSchemeState(combined);
+          if (saveToApp) {
+            setDataset(dataset);
+          }
+        },
         variables: {
           subscription,
           session,
@@ -62,6 +69,7 @@ const useClearSessionColorScheme = () => {
       })
     );
   }
+
   return onClear;
 };
 

--- a/app/packages/state/src/hooks/useClearSessionColorScheme.ts
+++ b/app/packages/state/src/hooks/useClearSessionColorScheme.ts
@@ -23,21 +23,27 @@ const useClearSessionColorScheme = () => {
   const defaultSetting = useRecoilValue(datasetAppConfig).colorScheme;
 
   function onClear(saveToApp: boolean) {
+    // when clear default, we reset to app default;
+    // when reset, we reset to appConfig default (if exisits) or app default.
     const combined = {
-      colorPool: defaultSetting
-        ? defaultSetting.colorPool
-        : DEFAULT_APP_COLOR_SCHEME.colorPool,
-      customizedColorSettings: defaultSetting?.customizedColorSettings
-        ? JSON.parse(defaultSetting.customizedColorSettings)
-        : DEFAULT_APP_COLOR_SCHEME.customizedColorSettings,
+      colorPool:
+        defaultSetting && !saveToApp
+          ? defaultSetting.colorPool
+          : DEFAULT_APP_COLOR_SCHEME.colorPool,
+      customizedColorSettings:
+        defaultSetting?.customizedColorSettings && !saveToApp
+          ? JSON.parse(defaultSetting.customizedColorSettings)
+          : DEFAULT_APP_COLOR_SCHEME.customizedColorSettings,
     };
     const api = {
-      colorPool: defaultSetting
-        ? defaultSetting.colorPool
-        : DEFAULT_APP_COLOR_SCHEME.colorPool,
-      customizedColorSettings: defaultSetting?.customizedColorSettings
-        ? defaultSetting.customizedColorSettings
-        : null,
+      colorPool:
+        defaultSetting && !saveToApp
+          ? defaultSetting.colorPool
+          : DEFAULT_APP_COLOR_SCHEME.colorPool,
+      customizedColorSettings:
+        defaultSetting?.customizedColorSettings && !saveToApp
+          ? defaultSetting.customizedColorSettings
+          : null,
     };
     setSessionColorSchemeState(combined);
 

--- a/app/packages/state/src/hooks/useClearSessionColorScheme.ts
+++ b/app/packages/state/src/hooks/useClearSessionColorScheme.ts
@@ -7,6 +7,7 @@ import {
   sessionColorScheme,
   datasetName,
   view,
+  datasetAppConfig,
 } from "../recoil";
 import useSendEvent from "./useSendEvent";
 import { DEFAULT_APP_COLOR_SCHEME } from "../utils";
@@ -19,17 +20,25 @@ const useClearSessionColorScheme = () => {
   const setSessionColorSchemeState = useSetRecoilState(sessionColorScheme);
   const dataset = useRecoilValue(datasetName);
   const stages = useRecoilValue(view);
+  const defaultSetting = useRecoilValue(datasetAppConfig).colorScheme;
 
   function onClear(saveToApp: boolean) {
     const combined = {
-      colorPool: DEFAULT_APP_COLOR_SCHEME.colorPool,
-      customizedColorSettings: DEFAULT_APP_COLOR_SCHEME.customizedColorSettings,
+      colorPool: defaultSetting
+        ? defaultSetting.colorPool
+        : DEFAULT_APP_COLOR_SCHEME.colorPool,
+      customizedColorSettings: defaultSetting?.customizedColorSettings
+        ? JSON.parse(defaultSetting.customizedColorSettings)
+        : DEFAULT_APP_COLOR_SCHEME.customizedColorSettings,
     };
     const api = {
-      colorPool: DEFAULT_APP_COLOR_SCHEME.colorPool,
-      customizedColorSettings: null,
+      colorPool: defaultSetting
+        ? defaultSetting.colorPool
+        : DEFAULT_APP_COLOR_SCHEME.colorPool,
+      customizedColorSettings: defaultSetting?.customizedColorSettings
+        ? defaultSetting.customizedColorSettings
+        : null,
     };
-
     setSessionColorSchemeState(combined);
 
     return send((session) =>

--- a/app/packages/state/src/hooks/useSendEvent.ts
+++ b/app/packages/state/src/hooks/useSendEvent.ts
@@ -1,10 +1,10 @@
 import { useContext } from "react";
 import { EventsContext } from "../contexts";
 
-export default (force: boolean = false) => {
+export default (force = false) => {
   const { session } = useContext(EventsContext);
 
-  return (send: (session: string | null) => void) => {
+  return (send: (session: string | null) => void | Promise<void>) => {
     if (session === undefined && !force) {
       return;
     }

--- a/app/packages/state/src/hooks/useSessionColorScheme.ts
+++ b/app/packages/state/src/hooks/useSessionColorScheme.ts
@@ -20,6 +20,7 @@ const useSessionColorScheme = () => {
   const [computedSessionColorScheme, setSessionColorSchemeState] =
     useRecoilState(sessionColorScheme);
   const dataset = useRecoilValue(datasetName);
+  const setDataset = fos.useSetDataset();
   const stages = useRecoilValue(view);
 
   function setColorScheme(
@@ -37,10 +38,14 @@ const useSessionColorScheme = () => {
       customizedColorSettings: JSON.stringify(customizedColorSettings),
     };
 
-    setSessionColorSchemeState(combined);
-
     return send((session) =>
       commit({
+        onCompleted: () => {
+          setSessionColorSchemeState(combined);
+          if (saveToApp) {
+            setDataset(dataset);
+          }
+        },
         onError,
         variables: {
           subscription,

--- a/app/packages/state/src/recoil/color.ts
+++ b/app/packages/state/src/recoil/color.ts
@@ -1,23 +1,19 @@
-import { DefaultValue, selector, selectorFamily } from "recoil";
+import { selector, selectorFamily } from "recoil";
 
 import { Coloring } from "@fiftyone/looker";
 import {
   createColorGenerator,
-  EMBEDDED_DOCUMENT_FIELD,
-  Field,
   getColor,
   hexToRgb,
   RGB,
-  VALID_LABEL_TYPES,
 } from "@fiftyone/utilities";
 
+import { isValidColor } from "@fiftyone/looker/src/overlays/util";
+import { DEFAULT_APP_COLOR_SCHEME } from "../utils";
 import * as atoms from "./atoms";
 import { colorPalette, colorscale } from "./config";
 import * as schemaAtoms from "./schema";
 import * as selectors from "./selectors";
-import { isValidColor } from "@fiftyone/looker/src/overlays/util";
-import { DEFAULT_APP_COLOR_SCHEME } from "../utils";
-import { State } from "./types";
 import { PathEntry, sidebarEntries } from "./sidebar";
 
 export const coloring = selectorFamily<Coloring, boolean>({
@@ -52,8 +48,7 @@ export const colorMap = selectorFamily<(val) => string, boolean>({
   get:
     (modal) =>
     ({ get }) => {
-      get(selectors.appConfigOption({ key: "colorBy", modal }));
-      let pool = get(colorPalette) ?? DEFAULT_APP_COLOR_SCHEME.colorPool;
+      const pool = get(colorPalette) ?? DEFAULT_APP_COLOR_SCHEME.colorPool;
       const seed = get(atoms.colorSeed(modal));
       return createColorGenerator(pool, seed);
     },


### PR DESCRIPTION
- [x] If dataset has default setting, reset session color should reset to dataset default. 
- [x] Make color modal resizable. 
- [x] Menu list selected item highlighted
- [x] Update texts
- [x] Improve UI in field settings
- [x] Fix a bug with rendering color by index
- [x] Update on overlay on looker3d

https://github.com/voxel51/fiftyone/assets/17770824/ab659f53-a6e5-4535-81e0-70846af851c0


## What changes are proposed in this pull request?

(Please fill in changes proposed in this fix)

## How is this patch tested? If it is not, please explain why.

(Details)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
