### PR TITLE
additional operator prompt/types enhancements

### DIFF
--- a/app/packages/components/src/components/Button/Button.module.css
+++ b/app/packages/components/src/components/Button/Button.module.css
@@ -11,14 +11,15 @@
   color: var(--fo-palette-text-secondary);
 }
 
-.button:hover {
+.button:hover:enabled {
   background: var(--fo-palette-primary-plainColor);
   color: var(--fo-palette-text-buttonHighlight);
   border-color: var(--fo-palette-primary-plainColor);
 }
 
 .button:disabled {
-  border: 1px solid var(--fo-palette-primary-plainColor);
-  cursor: default;
-  background: var(--fo-palette-background-level2);
+  border-color: var(--fo-palette-dividerDisabled);
+  cursor: not-allowed;
+  color: var(--fo-palette-text-tertiary);
+  background: var(--fo-palette-background-level3);
 }

--- a/app/packages/components/src/components/ThemeProvider/index.tsx
+++ b/app/packages/components/src/components/ThemeProvider/index.tsx
@@ -37,6 +37,7 @@ let theme = extendMuiTheme({
           inactiveTab: "hsl(200, 0%, 90%)",
         },
         divider: "hsl(200, 0%, 80%)",
+        dividerDisabled: "hsl(200, 0%, 85%)",
         danger: {
           plainColor: "hsl(0, 87%, 47%)",
         },
@@ -102,6 +103,7 @@ let theme = extendMuiTheme({
           paper: "hsl(200, 0%, 10%)",
         },
         divider: "hsl(200, 0%, 20%)",
+        dividerDisabled: "hsl(200, 0%, 15%)",
         danger: {
           plainColor: "hsl(0, 87%, 53%)",
         },

--- a/app/packages/core/src/plugins/OperatorIO/examples/Panel.tsx
+++ b/app/packages/core/src/plugins/OperatorIO/examples/Panel.tsx
@@ -1,11 +1,13 @@
 import { types } from "@fiftyone/operators";
 import { PluginComponentType, registerComponent } from "@fiftyone/plugins";
-import { Box } from "@mui/material";
+import { usePanelStatePartial } from "@fiftyone/spaces";
+import { Box, Button } from "@mui/material";
 import React, { useEffect, useState } from "react";
 import { SchemaIOComponent } from "../../SchemaIO";
 import { TabsView } from "../../SchemaIO/components";
 import { log, operatorToIOSchema } from "../utils";
 import {
+  basic as basicSchema,
   errors as inputErrors,
   schema as inputSchema,
   simpleSchema,
@@ -24,13 +26,16 @@ if (import.meta.env?.MODE === "development") {
 }
 
 function OperatorIO() {
-  const [mode, setMode] = useState("input");
+  const [mode, setMode] = usePanelStatePartial("mode", "input");
+  const [basicData, setBasicData] = useState({});
   const input = types.Property.fromJSON(inputSchema);
   const ioSchema = operatorToIOSchema(input);
   const output = types.Property.fromJSON(outputSchema);
   const oSchema = operatorToIOSchema(output, { isOutput: true });
   const simple = types.Property.fromJSON(simpleSchema);
   const sSchema = operatorToIOSchema(simple);
+  const basic = types.Property.fromJSON(basicSchema);
+  const bSchema = operatorToIOSchema(basic);
   const [state, setState] = useState(data);
 
   useEffect(() => {
@@ -57,12 +62,13 @@ function OperatorIO() {
             setState({ ...state, linear: 0, circular: 0 });
           }}
           schema={{
-            default: "input",
+            default: mode,
             view: {
               choices: [
                 { value: "input", label: "Input" },
                 { value: "output", label: "Output" },
                 { value: "inferred-input", label: "Inferred Input" },
+                { value: "basic-input", label: "Basic Input" },
               ],
             },
           }}
@@ -80,6 +86,18 @@ function OperatorIO() {
       )}
       {mode === "inferred-input" && (
         <SchemaIOComponent schema={sSchema} onChange={log} />
+      )}
+      {mode === "basic-input" && (
+        <Box>
+          <Button
+            onClick={() => {
+              setBasicData({ list: ["Hi", "Bye"] });
+            }}
+          >
+            Set data
+          </Button>
+          <SchemaIOComponent schema={bSchema} onChange={log} data={basicData} />
+        </Box>
       )}
     </Box>
   );

--- a/app/packages/core/src/plugins/OperatorIO/examples/input.json
+++ b/app/packages/core/src/plugins/OperatorIO/examples/input.json
@@ -1,4 +1,165 @@
 {
+    "basic": {
+        "type": {
+            "name": "Object",
+            "properties": {
+                "autocomplete": {
+                    "type": { "name": "String" },
+                    "view": {
+                        "label": "Autocomplete Field",
+                        "name": "AutocompleteView",
+                        "choices": [
+                            {
+                                "name": "Choice",
+                                "label": "First",
+                                "value": "1"
+                            },
+                            {
+                                "name": "Choice",
+                                "label": "Second",
+                                "value": "2"
+                            },
+                            {
+                                "name": "Choice",
+                                "label": "Third",
+                                "value": "3"
+                            }
+                        ]
+                    }
+                },
+                "checkbox": {
+                    "type": { "name": "Boolean" },
+                    "view": { "label": "Checkbox field" }
+                },
+                "code": {
+                    "type": { "name": "String" },
+                    "view": {
+                        "label": "Code field",
+                        "name": "CodeView",
+                        "language": "javascript"
+                    }
+                },
+                "color": {
+                    "type": { "name": "String" },
+                    "view": { "label": "Color field", "name": "ColorView" }
+                },
+                "dropdown": {
+                    "type": { "name": "Number" },
+                    "view": {
+                        "label": "Dropdown Field",
+                        "name": "Dropdown",
+                        "choices": [
+                            {
+                                "name": "Choice",
+                                "label": "First",
+                                "value": "1"
+                            },
+                            {
+                                "name": "Choice",
+                                "label": "Second",
+                                "value": "2"
+                            },
+                            {
+                                "name": "Choice",
+                                "label": "Third",
+                                "value": "3"
+                            }
+                        ]
+                    }
+                },
+                "number": {
+                    "type": { "name": "Number" },
+                    "view": { "label": "Number Field" }
+                },
+                "string": {
+                    "type": { "name": "String" },
+                    "view": { "label": "String Field" }
+                },
+                "file": {
+                    "type": { "name": "String" },
+                    "view": { "label": "File Field", "name": "FileView" }
+                },
+                "list": {
+                    "type": {
+                        "name": "List",
+                        "element_type": { "name": "String" }
+                    },
+                    "view": { "label": "List Field" }
+                },
+                "map": {
+                    "type": {
+                        "name": "Map",
+                        "key_type": { "name": "String" },
+                        "value_type": { "name": "String" }
+                    },
+                    "view": {
+                        "name": "MapView",
+                        "label": "Map Field",
+                        "key": { "label": "Key" },
+                        "value": { "label": "Value" }
+                    }
+                },
+                "object": {
+                    "type": {
+                        "name": "Object",
+                        "properties": {
+                            "nestedString": {
+                                "type": { "name": "String" },
+                                "view": { "label": "Nested String Field" }
+                            }
+                        }
+                    },
+                    "view": { "label": "Object Field" }
+                },
+                "oneof": {
+                    "type": {
+                        "name": "OneOf",
+                        "types": [{ "name": "String" }, { "name": "Number" }]
+                    },
+                    "view": {
+                        "name": "OneOfView",
+                        "label": "Number or String",
+                        "oneof": [
+                            { "name": "View", "label": "String Field" },
+                            { "name": "View", "label": "Number Field" }
+                        ]
+                    }
+                },
+                "radio": {
+                    "type": {
+                        "name": "Enum",
+                        "values": ["first", "second", "third"]
+                    },
+                    "view": { "label": "Radio Field", "name": "RadioGroup" }
+                },
+                "slider": {
+                    "type": { "name": "Number" },
+                    "view": { "name": "SliderView", "label": "Slider Field" }
+                },
+                "switch": {
+                    "type": { "name": "Boolean" },
+                    "view": { "name": "SwitchView", "label": "Switch Field" }
+                },
+                "tuple": {
+                    "type": {
+                        "name": "Tuple",
+                        "items": [{ "name": "String" }, { "name": "Number" }]
+                    },
+                    "defaultValue": null,
+                    "required": false,
+                    "choices": null,
+                    "view": {
+                        "name": "TupleView",
+                        "label": "Tuple Field",
+                        "items": [
+                            { "label": "String Field" },
+                            { "label": "Number Field" }
+                        ]
+                    }
+                }
+            }
+        }
+    },
     "simpleSchema": {
         "type": { "name": "Object", "properties": {} },
         "default": {

--- a/app/packages/core/src/plugins/OperatorIO/utils/index.ts
+++ b/app/packages/core/src/plugins/OperatorIO/utils/index.ts
@@ -152,6 +152,7 @@ function getViewSchema(property) {
     }
     view = { ...view, choices };
   }
+  view = { ...(view?.options || {}), ...view };
   return view;
 }
 

--- a/app/packages/core/src/plugins/SchemaIO/components/AutocompleteView.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/AutocompleteView.tsx
@@ -28,7 +28,11 @@ export default function AutocompleteView(props) {
           <TextField
             autoFocus={autoFocus(props)}
             {...params}
-            placeholder="Type and press enter to add an item"
+            placeholder={
+              multiple
+                ? "Type and press enter to add a value"
+                : "Type or select a value"
+            }
           />
         )}
         onInputChange={(e) => {

--- a/app/packages/core/src/plugins/SchemaIO/components/ListView.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/ListView.tsx
@@ -25,7 +25,7 @@ export default function ListView(props) {
     view: { ...(items?.view || {}), ...itemsView },
   };
   const label = view.label;
-  const lowerCaseLabel = label.toLowerCase();
+  const lowerCaseLabel = label?.toLowerCase();
 
   return (
     <Box>

--- a/app/packages/operators/src/OperatorPalette.tsx
+++ b/app/packages/operators/src/OperatorPalette.tsx
@@ -33,6 +33,7 @@ export default function OperatorPalette(props: OperatorPaletteProps) {
     allowPropagation,
     submitOnControlEnter,
     title,
+    disableSubmit,
   } = props;
   const hideActions = !onSubmit && !onCancel;
   const scroll = "paper";
@@ -61,6 +62,11 @@ export default function OperatorPalette(props: OperatorPaletteProps) {
     },
     [onClose, onCancel, onSubmit, allowPropagation, submitOnControlEnter]
   );
+
+  const handleSubmit = useCallback(() => {
+    if (disableSubmit) return;
+    onSubmit();
+  }, [disableSubmit, onSubmit]);
 
   useEffect(() => {
     document.addEventListener("keydown", keyDownHandler);
@@ -109,7 +115,11 @@ export default function OperatorPalette(props: OperatorPaletteProps) {
               </Button>
             )}
             {onSubmit && (
-              <Button onClick={onSubmit} onKeyDown={onEnter(onSubmit)}>
+              <Button
+                onClick={handleSubmit}
+                onKeyDown={onEnter(handleSubmit)}
+                disabled={disableSubmit}
+              >
                 {submitButtonText}
               </Button>
             )}
@@ -131,4 +141,5 @@ export type OperatorPaletteProps = PropsWithChildren & {
   allowPropagation?: boolean;
   submitOnControlEnter?: boolean;
   title?: ReactElement;
+  disableSubmit?: boolean;
 };

--- a/app/packages/operators/src/OperatorPlacements.tsx
+++ b/app/packages/operators/src/OperatorPlacements.tsx
@@ -7,6 +7,8 @@ import { types } from ".";
 import { Operator } from "./operators";
 import { withSuspense } from "@fiftyone/state";
 import { usePluginDefinition } from "@fiftyone/plugins";
+import { resolveServerPath } from "./utils";
+import { useColorScheme } from "@mui/material";
 
 function OperatorPlacements(props: OperatorPlacementsProps) {
   const { place } = props;
@@ -38,16 +40,19 @@ function OperatorPlacement(props: OperatorPlacementProps) {
 }
 
 function ButtonPlacement(props: OperatorPlacementProps) {
+  const { mode } = useColorScheme();
   const promptForInput = usePromptOperatorInput();
   const { operator, placement, place } = props;
   const { uri, pluginName } = operator;
   const { view = {} } = placement;
   const { label } = view;
-  const { icon } = view?.options || {};
-  const { serverPath } = usePluginDefinition(pluginName);
+  const { icon, darkIcon, lightIcon } = view?.options || {};
+  const plugin = usePluginDefinition(pluginName);
+  const serverPath = resolveServerPath(plugin);
+  const iconPath = mode === "dark" && darkIcon ? darkIcon : lightIcon || icon;
 
   const IconComponent = icon && (
-    <img src={`${serverPath}/${icon}`} width={21} height={21} />
+    <img src={`${serverPath}/${iconPath}`} width={21} height={21} />
   );
 
   const handleClick = () => {

--- a/app/packages/operators/src/OperatorPrompt.tsx
+++ b/app/packages/operators/src/OperatorPrompt.tsx
@@ -58,6 +58,7 @@ function ActualOperatorPrompt() {
       {...paletteProps}
       onClose={paletteProps.onCancel || operatorPrompt.close}
       submitOnControlEnter
+      disableSubmit={operatorPrompt.validationErrors?.length > 0}
     >
       <PaletteContentContainer>
         {operatorPrompt.showPrompt && (

--- a/app/packages/operators/src/constants.ts
+++ b/app/packages/operators/src/constants.ts
@@ -2,3 +2,4 @@ export const BROWSER_CONTROL_KEYS = ["ArrowDown", "ArrowUp", "`"];
 export const PALETTE_CONTROL_KEYS = ["`", "Enter", "Escape"];
 export const RESOLVE_PLACEMENTS_TTL = 2500;
 export const RESOLVE_TYPE_TTL = 1000;
+export const RESOLVE_INPUT_VALIDATION_TTL = 1500;

--- a/app/packages/operators/src/types.ts
+++ b/app/packages/operators/src/types.ts
@@ -254,7 +254,8 @@ export class View {
     this.description = options.description;
     this.caption = options.caption;
     this.space = options.space;
-    this.name = this.constructor.name;
+    this.name = "View";
+    this.options = options;
   }
   label?: string;
   description?: string;
@@ -268,6 +269,7 @@ export class View {
 export class InferredView extends View {
   constructor(options?: ViewProps) {
     super(options);
+    this.name = "InferredView";
   }
 }
 export class Form extends View {
@@ -278,6 +280,7 @@ export class Form extends View {
     options: ViewProps
   ) {
     super(options);
+    this.name = "Form";
   }
   static fromJSON(json: ViewProps) {
     return new Form(
@@ -293,6 +296,7 @@ export class ReadonlyView extends View {
   constructor(options: ViewProps) {
     super(options);
     this.readOnly = true;
+    this.name = "ReadonlyView";
   }
 }
 export class Choice extends View {
@@ -300,6 +304,7 @@ export class Choice extends View {
   constructor(value: string, options: ViewProps = {}) {
     super(options);
     this.value = value;
+    this.name = "Choice";
   }
   static fromJSON(json) {
     return new Choice(json.value, json);
@@ -311,6 +316,7 @@ export class Choices extends View {
     options = options || { choices: [] };
     super(options);
     this.choices = options.choices;
+    this.name = "Choices";
   }
   values() {
     return this.choices.map((c) => c.value);
@@ -330,6 +336,7 @@ export class RadioGroup extends Choices {
   constructor(options?: ChoicesOptions) {
     super(options);
     this.orientation = options.orientation as ViewOrientation;
+    this.name = "RadioGroup";
   }
   static fromJSON(json) {
     return new RadioGroup({
@@ -341,6 +348,7 @@ export class RadioGroup extends Choices {
 export class Dropdown extends Choices {
   constructor(options?: ChoicesOptions) {
     super(options);
+    this.name = "Dropdown";
   }
   static fromJSON(json) {
     return new Dropdown({
@@ -352,6 +360,7 @@ export class Dropdown extends Choices {
 export class Notice extends View {
   constructor(options: ViewProps = {}) {
     super(options);
+    this.name = "Notice";
   }
   static fromJSON(json) {
     return new Notice(json);
@@ -360,6 +369,7 @@ export class Notice extends View {
 export class Header extends View {
   constructor(options: ViewProps = {}) {
     super(options);
+    this.name = "Header";
   }
   static fromJSON(json) {
     return new Header(json);
@@ -368,6 +378,7 @@ export class Header extends View {
 export class Warning extends View {
   constructor(options: ViewProps = {}) {
     super(options);
+    this.name = "Warning";
   }
   static fromJSON(json) {
     return new Warning(json);
@@ -391,6 +402,7 @@ export class Button extends View {
     super(options);
     this.operator = options.operator as string;
     this.params = options.operator as object;
+    this.name = "Button";
   }
   static fromJSON(json) {
     return new Button(json);
@@ -401,6 +413,7 @@ export class OneOfView extends View {
   constructor(options: ViewProps) {
     super(options);
     this.oneof = options.oneof as Array<View>;
+    this.name = "OneOfView";
   }
   static fromJSON(json) {
     return new OneOfView({ ...json, oneof: json.oneof.map(viewFromJSON) });
@@ -411,6 +424,7 @@ export class ListView extends View {
   constructor(options: ViewProps) {
     super(options);
     this.items = options.items as View;
+    this.name = "ListView";
   }
   static fromJSON(json) {
     return new ListView({ ...json, items: viewFromJSON(json.items) });
@@ -421,6 +435,7 @@ export class TupleView extends View {
   constructor(options: ViewProps) {
     super(options);
     this.items = options.items as Array<View>;
+    this.name = "TupleView";
   }
   static fromJSON(json) {
     return new TupleView({ ...json, items: json.items.map(viewFromJSON) });
@@ -431,6 +446,7 @@ export class CodeView extends View {
   constructor(options: ViewProps) {
     super(options);
     this.language = options.language as string;
+    this.name = "CodeView";
   }
   static fromJSON(json) {
     return new CodeView(json);
@@ -443,6 +459,7 @@ export class ColorView extends View {
     super(options);
     this.compact = options.compact as boolean;
     this.variant = options.variant as string;
+    this.name = "ColorView";
   }
   static fromJSON(json) {
     return new ColorView(json);
@@ -453,6 +470,7 @@ export class TabsView extends View {
   constructor(options: ViewProps) {
     super(options);
     this.variant = options.variant as string;
+    this.name = "TabsView";
   }
   static fromJSON(json) {
     return new TabsView(json);
@@ -461,6 +479,7 @@ export class TabsView extends View {
 export class JSONView extends View {
   constructor(options: ViewProps) {
     super(options);
+    this.name = "JSONView";
   }
   static fromJSON(json) {
     return new JSONView(json);
@@ -469,6 +488,7 @@ export class JSONView extends View {
 export class AutocompleteView extends Choices {
   constructor(options?: ChoicesOptions) {
     super(options);
+    this.name = "AutocompleteView";
   }
   static fromJSON(json) {
     return new AutocompleteView(json);
@@ -477,6 +497,7 @@ export class AutocompleteView extends Choices {
 export class FileView extends View {
   constructor(options: ViewProps) {
     super(options);
+    this.name = "FileView";
   }
   static fromJSON(json) {
     return new FileView(json);
@@ -487,6 +508,7 @@ export class LinkView extends View {
   constructor(options: ViewProps) {
     super(options);
     this.href = options.href as string;
+    this.name = "LinkView";
   }
   static fromJSON(json) {
     return new LinkView(json);
@@ -495,6 +517,7 @@ export class LinkView extends View {
 export class HiddenView extends View {
   constructor(options: ViewProps) {
     super(options);
+    this.name = "HiddenView";
   }
   static fromJSON(json) {
     return new HiddenView(json);
@@ -503,6 +526,7 @@ export class HiddenView extends View {
 export class LoadingView extends View {
   constructor(options: ViewProps) {
     super(options);
+    this.name = "LoadingView";
   }
   static fromJSON(json) {
     return new LoadingView(json);
@@ -518,6 +542,7 @@ export class PlotlyView extends View {
     this.data = options.href as object;
     this.config = options.config as object;
     this.layout = options.layout as object;
+    this.name = "PlotlyView";
   }
   static fromJSON(json) {
     return new PlotlyView(json);
@@ -526,6 +551,7 @@ export class PlotlyView extends View {
 export class KeyValueView extends View {
   constructor(options: ViewProps) {
     super(options);
+    this.name = "KeyValueView";
   }
   static fromJSON(json) {
     return new KeyValueView(json);
@@ -534,6 +560,7 @@ export class KeyValueView extends View {
 export class Column extends View {
   constructor(public key: string, options: ViewProps) {
     super(options);
+    this.name = "Column";
   }
   clone() {
     return new Column(this.key, this.options);
@@ -547,6 +574,7 @@ export class TableView extends View {
   constructor(options: ViewProps) {
     super(options);
     this.columns = options.columns as Array<Column>;
+    this.name = "TableView";
   }
   keys() {
     return this.columns.map((column) => column.key);
@@ -571,6 +599,7 @@ export class MapView extends View {
     super(options);
     this.key = options.key as string;
     this.value = options.value;
+    this.name = "MapView";
   }
   static fromJSON(json) {
     return new MapView(json);
@@ -581,6 +610,7 @@ export class ProgressView extends View {
   constructor(options: ViewProps) {
     super(options);
     this.variant = options.variant as string;
+    this.name = "ProgressView";
   }
   static fromJSON(json) {
     return new ProgressView(json);

--- a/app/packages/operators/src/types.ts
+++ b/app/packages/operators/src/types.ts
@@ -254,6 +254,7 @@ export class View {
     this.description = options.description;
     this.caption = options.caption;
     this.space = options.space;
+    this.componentsProps = options.componentsProps;
     this.name = "View";
     this.options = options;
   }
@@ -262,6 +263,7 @@ export class View {
   caption?: string;
   space?: number;
   name?: string;
+  componentsProps?: unknown;
   static fromJSON(json: ViewProps) {
     return new View(json);
   }

--- a/app/packages/operators/src/utils.ts
+++ b/app/packages/operators/src/utils.ts
@@ -21,3 +21,7 @@ export function onEnter(
     if (e.key === "Enter") handler(e);
   };
 }
+
+export function resolveServerPath(plugin) {
+  return plugin.serverPath;
+}

--- a/fiftyone/operators/types.py
+++ b/fiftyone/operators/types.py
@@ -450,6 +450,7 @@ class View:
         placeholder (None): string to display placeholder text
         read_only (False): whether the :class:`View` is read-only
         component (None): specifying custom component to use as the view
+        componentProps (None): dict for providing props to components rendered by a :class:`View`
     """
 
     def __init__(self, **kwargs):
@@ -460,6 +461,7 @@ class View:
         self.placeholder = kwargs.get("placeholder", None)
         self.read_only = kwargs.get("read_only", None)
         self.component = kwargs.get("component", None)
+        self.componentProps = kwargs.get("componentProps", None)
         self._kwargs = kwargs
 
     def clone(self):
@@ -475,6 +477,7 @@ class View:
             "placeholder": self.placeholder,
             "read_only": self.read_only,
             "component": self.component,
+            "componentProps": self.componentProps,
             **self._kwargs,
         }
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

- Adds hard-coded view name to all view classes
- Passes additional view options from JS operators
- Adds validate for operator input prompt
- Disables execute button if there are validation errors

## How is this patch tested? If it is not, please explain why.

(Details)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
