### PR TITLE
Plugin updates

### DIFF
--- a/docs/source/cli/index.rst
+++ b/docs/source/cli/index.rst
@@ -791,7 +791,7 @@ Tools for working with FiftyOne plugins.
 
 .. code-block:: text
 
-    fiftyone plugins [-h] [--all-help] {list,download,enable,disable,delete} ...
+    fiftyone plugins [-h] [--all-help] {list,download,create,enable,disable,delete} ...
 
 **Arguments**
 
@@ -802,12 +802,13 @@ Tools for working with FiftyOne plugins.
       --all-help            show help recursively and exit
 
     available commands:
-      {list,download,enable,disable,delete}
+      {list,download,create,enable,disable,delete}
         list                List plugins that you've downloaded or created locally.
         download            Download plugins from the web.
+        create              Creates or initializes a plugin.
         enable              Enables the given plugin(s).
         disable             Disables the given plugin(s).
-        delete              Deletes the local copy of the plugin on disk.
+        delete              Delete plugins from your local machine.
 
 .. _cli-fiftyone-plugins-list:
 
@@ -852,7 +853,11 @@ Download plugins from the web.
 
 .. code-block:: text
 
-    fiftyone plugins download [-h] [-n PLUGIN_NAMES] [-d MAX_DEPTH] [-o] URL_OR_GH_REPO
+    fiftyone plugins download [-h]
+                              [-n [PLUGIN_NAMES ...]]
+                              [-d MAX_DEPTH]
+                              [-o]
+                              URL_OR_GH_REPO
 
 **Arguments**
 
@@ -863,8 +868,8 @@ Download plugins from the web.
 
     optional arguments:
       -h, --help            show this help message and exit
-      -n PLUGIN_NAMES, --plugin-names PLUGIN_NAMES
-                            a comma-separated list of plugin names to download
+      -n [PLUGIN_NAMES ...], --plugin-names [PLUGIN_NAMES ...]
+                            a plugin name or list of plugin names to download
       -d MAX_DEPTH, --max-depth MAX_DEPTH
                             a maximum depth to search for plugins
       -o, --overwrite       whether to overwrite existing plugins
@@ -878,6 +883,64 @@ Download plugins from the web.
 
     # Download plugins by specifying the GitHub repository details
     fiftyone plugins download <user>/<repo>[/<ref>]
+
+    # Download specific plugins from a URL with a custom search depth
+    fiftyone plugins download \
+        <url> \
+        --plugin-names <name1> <name2> <name3> \
+        --max-depth 2  # search nested directories for plugins
+
+.. _cli-fiftyone-plugins-create:
+
+Create plugins
+~~~~~~~~~~~~~~
+
+Creates or initializes a plugin.
+
+.. code-block:: text
+
+    fiftyone plugins create [-h]
+                            [-f [FILES ...]]
+                            [-d OUTDIR]
+                            [--label LABEL]
+                            [--description DESCRIPTION]
+                            [--version VERSION]
+                            [-o]
+                            [--kwargs KEY=VAL [KEY=VAL ...]]
+                            [NAME ...]
+
+**Arguments**
+
+.. code-block:: text
+
+    positional arguments:
+      NAME                  the plugin name(s)
+
+    optional arguments:
+      -h, --help            show this help message and exit
+      -f [FILES ...], --from-files [FILES ...]
+                            a directory or list of explicit filepaths to include in the plugin
+      -d OUTDIR, --outdir OUTDIR
+                            a directory in which to create the plugin
+      --label LABEL         a display name for the plugin
+      --description DESCRIPTION
+                            a description for the plugin
+      --version VERSION     an optional FiftyOne version requirement for the plugin
+      -o, --overwrite       whether to overwrite existing plugins
+      --kwargs KEY=VAL [KEY=VAL ...]
+                            additional keyword arguments to include in the plugin definition
+
+**Examples**
+
+    # Initialize a new plugin
+    fiftyone plugins create <name>
+
+    # Create a plugin from existing files
+    fiftyone plugins create \
+        <name> \
+        --from-files /path/to/dir \
+        --label <label> \
+        --description <description>
 
 .. _cli-fiftyone-plugins-enable:
 

--- a/docs/source/cli/index.rst
+++ b/docs/source/cli/index.rst
@@ -87,6 +87,7 @@ The FiftyOne command-line interface.
         convert             Convert datasets on disk between supported formats.
         datasets            Tools for working with FiftyOne datasets.
         migrate             Tools for migrating the FiftyOne database.
+        plugins             Tools for working with FiftyOne plugins.
         utils               FiftyOne utilities.
         zoo                 Tools for working with the FiftyOne Zoo.
 
@@ -780,6 +781,196 @@ FiftyOne deployments.
 
     # Update the database version without migrating any existing datasets
     fiftyone migrate
+
+.. _cli-fiftyone-plugins:
+
+FiftyOne plugins
+----------------
+
+Tools for working with FiftyOne plugins.
+
+.. code-block:: text
+
+    fiftyone plugins [-h] [--all-help] {list,download,enable,disable,delete} ...
+
+**Arguments**
+
+.. code-block:: text
+
+    optional arguments:
+      -h, --help            show this help message and exit
+      --all-help            show help recursively and exit
+
+    available commands:
+      {list,download,enable,disable,delete}
+        list                List plugins that you've downloaded or created locally.
+        download            Download plugins from the web.
+        enable              Enables the given plugin(s).
+        disable             Disables the given plugin(s).
+        delete              Deletes the local copy of the plugin on disk.
+
+.. _cli-fiftyone-plugins-list:
+
+List plugins
+~~~~~~~~~~~~
+
+List plugins that you've downloaded or created locally.
+
+.. code-block:: text
+
+    fiftyone plugins list [-h] [-e] [-d] [-n]
+
+**Arguments**
+
+.. code-block:: text
+
+    optional arguments:
+      -h, --help        show this help message and exit
+      -e, --enabled     only show enabled plugins
+      -d, --disabled    only show disabled plugins
+      -n, --names-only  only show plugin names
+
+**Examples**
+
+.. code-block:: shell
+
+    # List all locally available plugins
+    fiftyone plugins list
+
+    # List enabled plugins
+    fiftyone plugins list --enabled
+
+    # List disabled plugins
+    fiftyone plugins list --disabled
+
+.. _cli-fiftyone-plugins-download:
+
+Download plugins
+~~~~~~~~~~~~~~~~
+
+Download plugins from the web.
+
+.. code-block:: text
+
+    fiftyone plugins download [-h] [-n PLUGIN_NAMES] [-d MAX_DEPTH] [-o] URL_OR_GH_REPO
+
+**Arguments**
+
+.. code-block:: text
+
+    positional arguments:
+      URL_OR_GH_REPO        A URL or <user>/<repo>[/<ref>] of a GitHub repository
+
+    optional arguments:
+      -h, --help            show this help message and exit
+      -n PLUGIN_NAMES, --plugin-names PLUGIN_NAMES
+                            a comma-separated list of plugin names to download
+      -d MAX_DEPTH, --max-depth MAX_DEPTH
+                            a maximum depth to search for plugins
+      -o, --overwrite       whether to overwrite existing plugins
+
+**Examples**
+
+.. code-block:: shell
+
+    # Download plugins from a GitHub repository URL
+    fiftyone plugins download <github-repo-url>
+
+    # Download plugins by specifying the GitHub repository details
+    fiftyone plugins download <user>/<repo>[/<ref>]
+
+.. _cli-fiftyone-plugins-enable:
+
+Enable plugins
+~~~~~~~~~~~~~~
+
+Enables the given plugin(s).
+
+.. code-block:: text
+
+    fiftyone plugins enable [-h] [NAME ...]
+
+**Arguments**
+
+.. code-block:: text
+
+    positional arguments:
+      NAME        the plugin name(s)
+
+    optional arguments:
+      -h, --help  show this help message and exit
+
+**Examples**
+
+.. code-block:: shell
+
+    # Enable a plugin
+    fiftyone plugins enable <name>
+
+    # Enable multiple plugins
+    fiftyone plugins enable <name1> <name2> ...
+
+.. _cli-fiftyone-plugins-disable:
+
+Disable plugins
+~~~~~~~~~~~~~~~
+
+Disables the given plugin(s).
+
+.. code-block:: text
+
+    fiftyone plugins disable [-h] [NAME ...]
+
+**Arguments**
+
+.. code-block:: text
+
+    positional arguments:
+      NAME        the plugin name(s)
+
+    optional arguments:
+      -h, --help  show this help message and exit
+
+**Examples**
+
+.. code-block:: shell
+
+    # Disable a plugin
+    fiftyone plugins disable <name>
+
+    # Disable multiple plugins
+    fiftyone plugins disable <name1> <name2> ...
+
+.. _cli-fiftyone-plugins-delete:
+
+Delete plugins
+~~~~~~~~~~~~~~
+
+Delete plugins from your local machine.
+
+.. code-block:: text
+
+    fiftyone plugins delete [-h] [NAME ...]
+
+**Arguments**
+
+.. code-block:: text
+
+    positional arguments:
+      NAME        the plugin name(s)
+
+    optional arguments:
+      -h, --help  show this help message and exit
+
+**Examples**
+
+.. code-block:: shell
+
+    # Delete a plugin from local disk
+    fiftyone plugins delete <name>
+
+    # Delete multiple plugins from local disk
+    fiftyone plugins delete <name1> <name2> ...
 
 .. _cli-fiftyone-utils:
 

--- a/docs/source/cli/index.rst
+++ b/docs/source/cli/index.rst
@@ -851,6 +851,12 @@ Download plugins
 
 Download plugins from the web.
 
+.. note::
+
+    To download a plugin from a private GitHub repository that you have
+    access to, provide your GitHub personal access token by setting the
+    ``GITHUB_TOKEN`` environment variable.
+
 .. code-block:: text
 
     fiftyone plugins download [-h]

--- a/fiftyone/core/cli.py
+++ b/fiftyone/core/cli.py
@@ -2739,8 +2739,7 @@ class PluginCreateCommand(Command):
         parser.add_argument(
             "name",
             metavar="NAME",
-            nargs="*",
-            help="the plugin name(s)",
+            help="the plugin name",
         )
         parser.add_argument(
             "-f",
@@ -2796,7 +2795,7 @@ class PluginCreateCommand(Command):
             description=args.description,
             version=args.version,
             overwrite=args.overwrite,
-            **args.kwargs,
+            **args.kwargs or {},
         )
 
 

--- a/fiftyone/core/cli.py
+++ b/fiftyone/core/cli.py
@@ -2750,10 +2750,10 @@ class PluginDisableCommand(Command):
 
     Examples::
 
-        # Enable a plugin
+        # Disable a plugin
         fiftyone plugins disable <name>
 
-        # Enable multiple plugins
+        # Disable multiple plugins
         fiftyone plugins disable <name1> <name2> ...
     """
 
@@ -2773,14 +2773,14 @@ class PluginDisableCommand(Command):
 
 
 class PluginDeleteCommand(Command):
-    """Deletes the local copy of the plugin on disk.
+    """Delete plugins from your local machine.
 
     Examples::
 
-        # Delete a plugin from your local machine
-        fiftyone zoo datasets delete <name>
+        # Delete a plugin from local disk
+        fiftyone plugins delete <name>
 
-        # Delete multiple plugins from your local machine
+        # Delete multiple plugins from local disk
         fiftyone plugins delete <name1> <name2> ...
     """
 

--- a/fiftyone/core/cli.py
+++ b/fiftyone/core/cli.py
@@ -2600,12 +2600,6 @@ class PluginListCommand(Command):
     @staticmethod
     def setup(parser):
         parser.add_argument(
-            "-n",
-            "--names-only",
-            action="store_true",
-            help="only show plugin names",
-        )
-        parser.add_argument(
             "-e",
             "--enabled",
             action="store_true",
@@ -2619,6 +2613,12 @@ class PluginListCommand(Command):
             default=None,
             help="only show disabled plugins",
         )
+        parser.add_argument(
+            "-n",
+            "--names-only",
+            action="store_true",
+            help="only show plugin names",
+        )
 
     @staticmethod
     def execute(parser, args):
@@ -2627,17 +2627,29 @@ class PluginListCommand(Command):
         elif args.disabled:
             enabled = False
         else:
-            enabled = None
+            enabled = "all"
 
-        plugin_defintions = fop.list_plugins(enabled=enabled)
-        _print_plugins_info(plugin_defintions)
+        _print_plugins_info(enabled, args.names_only)
 
 
-def _print_plugins_info(plugin_defintions):
-    # @todo implement enabled
+def _print_plugins_info(enabled, names_only):
+    plugin_defintions = fop.list_plugins(enabled=enabled)
+
+    if names_only:
+        for pd in plugin_defintions:
+            print(pd.name)
+
+        return
+
+    enabled = set(fop.list_enabled_plugins())
+
     headers = ["name", "directory", "enabled"]
     rows = [
-        {"name": pd.name, "directory": pd.directory, "enabled": "?"}
+        {
+            "name": pd.name,
+            "directory": pd.directory,
+            "enabled": pd.name in enabled,
+        }
         for pd in plugin_defintions
     ]
 

--- a/fiftyone/core/cli.py
+++ b/fiftyone/core/cli.py
@@ -2731,7 +2731,6 @@ class PluginCreateCommand(Command):
         fiftyone plugins create \\
             <name> \\
             --from-files /path/to/dir \\
-            --label <label> \\
             --description <description>
     """
 
@@ -2760,11 +2759,6 @@ class PluginCreateCommand(Command):
             "--outdir",
             metavar="OUTDIR",
             help="a directory in which to create the plugin",
-        )
-        parser.add_argument(
-            "--label",
-            metavar="LABEL",
-            help="a display name for the plugin",
         )
         parser.add_argument(
             "--description",
@@ -2799,7 +2793,6 @@ class PluginCreateCommand(Command):
             args.name,
             from_files=args.from_files,
             outdir=args.outdir,
-            label=args.label,
             description=args.description,
             version=args.version,
             overwrite=args.overwrite,

--- a/fiftyone/core/cli.py
+++ b/fiftyone/core/cli.py
@@ -2663,6 +2663,12 @@ def _print_plugins_info(enabled, names_only):
 class PluginDownloadCommand(Command):
     """Download plugins from the web.
 
+    .. note::
+
+        To download a plugin from a private GitHub repository that you have
+        access to, provide your GitHub personal access token by setting the
+        ``GITHUB_TOKEN`` environment variable.
+
     Examples::
 
         # Download plugins from a GitHub repository URL

--- a/fiftyone/core/config.py
+++ b/fiftyone/core/config.py
@@ -246,6 +246,12 @@ class FiftyOneConfig(EnvConfig):
                 self.default_dataset_dir, "__models__"
             )
 
+        if self.plugins_dir is None:
+            self.plugins_dir = os.path.join(
+                self.default_dataset_dir,
+                "__plugins__",
+            )
+
         if self.default_ml_backend is None:
             installed_packages = _get_installed_packages()
 

--- a/fiftyone/core/utils.py
+++ b/fiftyone/core/utils.py
@@ -316,14 +316,16 @@ def find_files(root_dir, patt, max_depth=1):
 
     Exammples::
 
+        import fiftyone.core.utils as fou
+
         # Find .txt files in `/tmp`
-        find_files("/tmp", "*.txt")
+        fou.find_files("/tmp", "*.txt")
 
         # Find .txt files in subdirectories of `/tmp` that begin with `foo-`
-        find_files("/tmp/foo-*", "*.txt")
+        fou.find_files("/tmp/foo-*", "*.txt")
 
         # Find .txt files in `/tmp` or its subdirectories
-        find_files("/tmp", "*.txt", max_depth=2)
+        fou.find_files("/tmp", "*.txt", max_depth=2)
 
     Args:
         root_dir: the root directory

--- a/fiftyone/core/utils.py
+++ b/fiftyone/core/utils.py
@@ -11,6 +11,7 @@ from collections import defaultdict
 from contextlib import contextmanager
 from copy import deepcopy
 from datetime import date, datetime
+import glob
 import hashlib
 import importlib
 import inspect
@@ -305,6 +306,44 @@ def fill_patterns(string):
         a copy of string with any patterns replaced
     """
     return etau.fill_patterns(string, available_patterns())
+
+
+def find_files(root_dir, patt, max_depth=1):
+    """Finds all files in the given root directory whose filename matches the
+    given glob pattern(s).
+
+    Both ``root_dir`` and ``patt`` may contain glob patterns.
+
+    Exammples::
+
+        # Find .txt files in `/tmp`
+        find_files("/tmp", "*.txt")
+
+        # Find .txt files in subdirectories of `/tmp` that begin with `foo-`
+        find_files("/tmp/foo-*", "*.txt")
+
+        # Find .txt files in `/tmp` or its subdirectories
+        find_files("/tmp", "*.txt", max_depth=2)
+
+    Args:
+        root_dir: the root directory
+        patt: a glob pattern or list of patterns
+        max_depth (1): a maximum depth to search. 1 means ``root_dir`` only,
+            2 means ``root_dir`` and its immediate subdirectories, etc
+
+    Returns:
+        a list of matching paths
+    """
+    if etau.is_str(patt):
+        patt = [patt]
+
+    paths = []
+    for i in range(max_depth):
+        root = os.path.join(root_dir, *list("*" * i))
+        for p in patt:
+            paths += glob.glob(os.path.join(root, p))
+
+    return paths
 
 
 def normpath(path):

--- a/fiftyone/core/utils.py
+++ b/fiftyone/core/utils.py
@@ -1529,6 +1529,23 @@ class SuppressLogging(object):
         logging.disable(logging.NOTSET)
 
 
+class add_sys_path(object):
+    """Context manager that temporarily inserts a path to ``sys.path``."""
+
+    def __init__(self, path, index=0):
+        self.path = path
+        self.index = index
+
+    def __enter__(self):
+        sys.path.insert(self.index, self.path)
+
+    def __exit__(self, *args):
+        try:
+            sys.path.remove(self.path)
+        except:
+            pass
+
+
 def is_arm_mac():
     """Determines whether the system is an ARM-based Mac (Apple Silicon).
 

--- a/fiftyone/plugins/__init__.py
+++ b/fiftyone/plugins/__init__.py
@@ -19,6 +19,7 @@ from .core import (
     download_plugin,
     create_plugin,
 )
+from .definitions import PluginDefinition
 
 # This enables Sphinx refs to directly use paths imported here
 __all__ = [

--- a/fiftyone/plugins/__init__.py
+++ b/fiftyone/plugins/__init__.py
@@ -1,16 +1,17 @@
 """
+FiftyOne plugins.
+
 | Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
 import types
-import deprecated
-import wrapt
 
 from .core import (
     enable_plugin,
     disable_plugin,
     delete_plugin,
+    list_plugins,
     list_disabled_plugins,
     list_downloaded_plugins,
     list_enabled_plugins,
@@ -18,28 +19,10 @@ from .core import (
     download_plugin,
     create_plugin,
 )
-from .definitions import list_plugins
-
-
-@deprecated.deprecated(reason="Use list_plugins() instead")
-def list_all_plugins():
-    """Wrapper for backwards compatibility. Returns a list of all plugins
-    that have not explicitly been disabled.
-
-    .. warning::
-
-            This method is deprecated and will be removed in a future release.
-            Use the drop-in replacement :meth:`list_plugins()` instead.
-    """
-
-    return list_plugins()
-
 
 # This enables Sphinx refs to directly use paths imported here
-# and ignore functions marked as depreciated
 __all__ = [
     k
     for k, v in globals().items()
-    if not k.startswith("_")
-    and not (type(v) in [wrapt.decorators.AdapterWrapper, types.ModuleType])
+    if not k.startswith("_") and not isinstance(v, types.ModuleType)
 ]

--- a/fiftyone/plugins/core.py
+++ b/fiftyone/plugins/core.py
@@ -65,7 +65,9 @@ def list_plugins(enabled=True):
         try:
             pd = PluginDefinition.from_disk(metadata_path)
         except:
-            logger.debug(f"Failed to load metadata from '{metadata_path}'")
+            logger.debug(
+                f"Failed to load plugin metadata from '{metadata_path}'"
+            )
             continue
 
         plugins.append(pd)
@@ -234,7 +236,7 @@ def _download_plugin(url, plugin_names=None, max_depth=3, overwrite=False):
             existing_dir = existing_plugin_dirs.get(plugin.name, None)
             if existing_dir is not None:
                 if not overwrite:
-                    logger.debug(f"Skipping existing plugin '{plugin.name}'")
+                    logger.info(f"Skipping existing plugin '{plugin.name}'")
                     continue
 
                 logger.debug(f"Overwriting existing plugin '{plugin.name}'")
@@ -245,7 +247,7 @@ def _download_plugin(url, plugin_names=None, max_depth=3, overwrite=False):
                     plugin.name, src_dir=plugin.path
                 )
 
-            logger.debug(f"Copying plugin '{plugin.name}' to '{plugin_dir}'")
+            logger.info(f"Copying plugin '{plugin.name}' to '{plugin_dir}'")
             etau.copy_dir(plugin.path, plugin_dir)
             downloaded_plugins[plugin.name] = plugin_dir
 
@@ -254,7 +256,6 @@ def _download_plugin(url, plugin_names=None, max_depth=3, overwrite=False):
 
 def create_plugin(
     plugin_name,
-    from_dir=None,
     from_files=None,
     outdir=None,
     label=None,
@@ -265,7 +266,7 @@ def create_plugin(
 ):
     """Creates a plugin with the given name.
 
-    If no input files are provided, a directory containing only the plugin's
+    If no ``from_files`` are provided, a directory containing only the plugin's
     metadata file will be created.
 
     If no ``outdir`` is specified, the plugin is created within your local
@@ -273,9 +274,8 @@ def create_plugin(
 
     Args:
         plugin_name: the name of the plugin
-        from_dir (None): the path to the directory containing the plugin
-        from_files (None): an explicit list of filepaths and/or directories to
-            include in the plugin
+        from_files (None): a directory or list of explicit filepaths to include
+            in the plugin
         outdir (None): the path at which to create the plugin directory. If
             not provided, the plugin is created within your
             ``fo_config.plugins_dir``
@@ -284,7 +284,7 @@ def create_plugin(
         version (None): an optional FiftyOne version requirement string
         overwrite (False): whether to overwrite a local plugin with the same
             name if one exists
-        **kwargs: optional keyword arguments to include in the plugin
+        **kwargs: additional keyword arguments to include in the plugin
             definition
 
     Returns:
@@ -296,26 +296,26 @@ def create_plugin(
             if not overwrite:
                 raise ValueError(f"Plugin '{plugin_name}' already exists")
 
-            logger.debug(f"Overwriting existing plugin '{plugin_name}'")
             plugin_dir = existing_plugin_dirs[plugin_name]
+            logger.info(f"Overwriting existing plugin '{plugin_name}'")
         else:
             plugin_dir = os.path.join(fo.config.plugins_dir, plugin_name)
     elif os.path.isdir(outdir):
         if not overwrite:
             raise ValueError(f"Directory '{outdir}' already exists")
 
-        logger.debug(f"Overwriting existing plugin directory '{outdir}'")
         plugin_dir = outdir
+        logger.debug(f"Overwriting existing plugin at '{plugin_dir}'")
     else:
         plugin_dir = _recommend_plugin_dir(plugin_name)
-        logger.debug(f"Creating plugin in '{plugin_dir}'")
+        logger.info(f"Creating plugin at '{plugin_dir}'")
 
     etau.ensure_empty_dir(plugin_dir, cleanup=True)
 
-    if from_dir:
-        from_files = [os.path.join(from_dir, f) for f in os.listdir(from_dir)]
+    if from_files is not None:
+        if etau.is_str(from_files):
+            from_files = [from_files]
 
-    if from_files:
         for from_path in from_files:
             if os.path.isfile(from_path):
                 shutil.copy(from_path, plugin_dir)

--- a/fiftyone/plugins/core.py
+++ b/fiftyone/plugins/core.py
@@ -181,7 +181,7 @@ def download_plugin(
     """
     if etaw.is_url(url_or_gh_repo):
         if "github" in url_or_gh_repo:
-            repo = GitHubRepository(url)
+            repo = GitHubRepository(url_or_gh_repo)
             url = repo.download_url
         else:
             url = url_or_gh_repo

--- a/fiftyone/plugins/core.py
+++ b/fiftyone/plugins/core.py
@@ -409,7 +409,7 @@ def _find_plugin(name, check_for_duplicates=False):
             if check_for_duplicates and plugin_dir is not None:
                 raise ValueError(f"Multiple plugins found with name '{name}'")
 
-            plugin_dir = os.path.dirname(plugin.path)
+            plugin_dir = plugin.path
 
     if plugin_dir is None:
         raise ValueError(f"Plugin '${name}' not found")

--- a/fiftyone/plugins/core.py
+++ b/fiftyone/plugins/core.py
@@ -328,7 +328,10 @@ def create_plugin(
     if yaml_path is None:
         yaml_path = os.path.join(plugin_dir, _PLUGIN_METADATA_FILENAMES[0])
 
-    pd = dict(name=plugin_name, description=description)
+    pd = {"name": plugin_name}
+    if description:
+        pd[description] = description
+
     pd.update(kwargs)
 
     if version is not None:

--- a/fiftyone/plugins/core.py
+++ b/fiftyone/plugins/core.py
@@ -234,6 +234,10 @@ def _download_plugin(
             os.path.join(tmpdir, "*"),
             max_depth=max_depth + 1,
         )
+        if not metadata_paths:
+            logger.info(
+                f"No {_PLUGIN_METADATA_FILENAMES} files found in {url} (max_depth={max_depth})"
+            )
 
         for metadata_path in metadata_paths:
             try:

--- a/fiftyone/plugins/core.py
+++ b/fiftyone/plugins/core.py
@@ -274,6 +274,8 @@ def _download_plugin(
                 etau.delete_dir(existing_dir)
                 plugin_dir = existing_dir
             else:
+                # @todo maintain `<org>/<user>/<plugin_name>` structure for
+                # plugins downloaded from github?
                 plugin_dir = _recommend_plugin_dir(
                     plugin.name, src_dir=plugin.path
                 )

--- a/fiftyone/plugins/core.py
+++ b/fiftyone/plugins/core.py
@@ -65,7 +65,8 @@ def list_plugins(enabled=True):
     for p in _list_plugins(enabled=enabled):
         metadata_path = _find_plugin_metadata_file(p.path)
         pd = fopd.load_plugin_definition(metadata_path)
-        plugins.append(pd)
+        if pd is not None:
+            plugins.append(pd)
 
     return fopd.validate_plugins(plugins)
 

--- a/fiftyone/plugins/core.py
+++ b/fiftyone/plugins/core.py
@@ -258,7 +258,6 @@ def create_plugin(
     plugin_name,
     from_files=None,
     outdir=None,
-    label=None,
     description=None,
     version=None,
     overwrite=False,
@@ -279,7 +278,6 @@ def create_plugin(
         outdir (None): the path at which to create the plugin directory. If
             not provided, the plugin is created within your
             ``fo_config.plugins_dir``
-        label (None): a display name for the plugin
         description (None): a description for the plugin
         version (None): an optional FiftyOne version requirement string
         overwrite (False): whether to overwrite a local plugin with the same
@@ -330,15 +328,8 @@ def create_plugin(
     if yaml_path is None:
         yaml_path = os.path.join(plugin_dir, _PLUGIN_METADATA_FILENAMES[0])
 
-    if label is None:
-        label = _recommend_plugin_label(plugin_name)
-
-    pd = {
-        "name": plugin_name,
-        "label": label,
-        "description": description,
-        **kwargs,
-    }
+    pd = dict(name=plugin_name, description=description)
+    pd.update(kwargs)
 
     if version is not None:
         if "fiftyone" not in pd:
@@ -489,7 +480,7 @@ def _recommend_plugin_dir(plugin_name, src_dir=None):
     return os.path.join(plugins_dir, unique_name)
 
 
-def _recommend_plugin_label(name):
+def _recommend_label(name):
     label = re.sub("[^A-Za-z0-9]+", " ", name)
     return " ".join([w.capitalize() for w in label.split()])
 

--- a/fiftyone/plugins/core.py
+++ b/fiftyone/plugins/core.py
@@ -76,27 +76,21 @@ def list_plugins(enabled=True):
 
 
 def enable_plugin(plugin_name):
-    """Enables the given plugin in the FiftyOne App.
+    """Enables the given plugin.
 
     Args:
         plugin_name: the plugin name
-
-    Returns:
-        the path to the enabled plugin
     """
-    return _update_plugin_settings(plugin_name, enabled=True)
+    _update_plugin_settings(plugin_name, enabled=True)
 
 
 def disable_plugin(plugin_name):
-    """Disables the given plugin in the FiftyOne App.
+    """Disables the given plugin.
 
     Args:
         plugin_name: the plugin name
-
-    Returns:
-        the path to the enabled plugin
     """
-    return _update_plugin_settings(plugin_name, enabled=False)
+    _update_plugin_settings(plugin_name, enabled=False)
 
 
 def delete_plugin(plugin_name):
@@ -106,6 +100,8 @@ def delete_plugin(plugin_name):
         plugin_name: the plugin name
     """
     plugin_dir = _find_plugin(plugin_name)
+
+    _update_plugin_settings(plugin_name, delete=True)
     etau.delete_dir(plugin_dir)
 
 
@@ -488,7 +484,7 @@ def _recommend_label(name):
     return " ".join([w.capitalize() for w in label.split()])
 
 
-def _update_plugin_settings(plugin_name, enabled=None, **kwargs):
+def _update_plugin_settings(plugin_name, enabled=None, delete=False, **kwargs):
     # This would ensure that the plugin actually exists
     # _find_plugin(plugin_name)
 
@@ -519,20 +515,25 @@ def _update_plugin_settings(plugin_name, enabled=None, **kwargs):
 
     plugins = app_config["plugins"]
 
-    if not plugins.get(plugin_name):
-        plugins[plugin_name] = {}
-
-    plugin_settings = plugins[plugin_name]
-
-    if enabled in (True, None):
-        # Plugins are enabled by default, so just remove the entry altogether
-        plugin_settings.pop("enabled", None)
-        if not plugin_settings:
-            plugins.pop(plugin_name)
+    if delete:
+        # Delete entire plugin entry
+        plugins.pop(plugin_name, None)
     else:
-        plugin_settings["enabled"] = False
+        # Update plugin settings
+        if not plugins.get(plugin_name):
+            plugins[plugin_name] = {}
 
-    plugin_settings.update(kwargs)
+        plugin_settings = plugins[plugin_name]
+
+        if enabled in (True, None):
+            # Plugins are enabled by default, so just remove the entry altogether
+            plugin_settings.pop("enabled", None)
+            if not plugin_settings:
+                plugins.pop(plugin_name)
+        else:
+            plugin_settings["enabled"] = False
+
+        plugin_settings.update(kwargs)
 
     with open(app_config_path, "wt") as f:
         json.dump(app_config, f, indent=4)

--- a/fiftyone/plugins/core.py
+++ b/fiftyone/plugins/core.py
@@ -1,36 +1,35 @@
 """
+Core plugin methods.
+
 | Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
-
-import glob
+from collections import Counter
+from dataclasses import dataclass
 import json
 import logging
 import os
-import pprint
 import re
 import shutil
-from collections import defaultdict
-from dataclasses import dataclass
-from io import BytesIO
-from time import time
-from typing import List, Optional
-from urllib.error import HTTPError
-from urllib.request import urlopen
-from zipfile import ZipFile
 
-import eta.core.web as etaw
 import yaml
+
+import eta.core.utils as etau
+import eta.core.web as etaw
 
 import fiftyone as fo
 import fiftyone.constants as foc
 import fiftyone.core.config as focc
-import fiftyone.zoo.utils.github as fozug
+import fiftyone.core.utils as fou
+import fiftyone.plugins.definitions as fopd
+from fiftyone.utils.github import GitHubRepository
+
+
+_PLUGIN_METADATA_FILENAMES = ["fiftyone.yaml", "fiftyone.yml"]
+_PLUGIN_DIRS = [fo.config.plugins_dir]
 
 logger = logging.getLogger(__name__)
-_PLUGIN_DEFINITION_FILE_PATTERN = r"/?fiftyone\.ya?ml$"
-_PLUGIN_DIRS = [fo.config.plugins_dir]
 
 
 @dataclass
@@ -49,498 +48,466 @@ class plugin_package:
         return f"Plugin(name={self.name}, path={self.path})"
 
 
-def enable_plugin(plugin_name: str):
+def list_plugins(enabled=True):
+    """Returns the list of enabled plugins.
+
+    Args:
+        enabled (True): whether to include only enabled (True) or only disabled
+            (False) plugins. By default, all downloaded plugins are returned
+
+    Returns:
+        a list of :class:`PluginDefinition` instances
+    """
+    plugins = []
+    for p in _list_plugins(enabled=enabled):
+        metadata_path = _find_plugin_metadata_file(p.path)
+        pd = fopd.load_plugin_definition(metadata_path)
+        plugins.append(pd)
+
+    return fopd.validate_plugins(plugins)
+
+
+def enable_plugin(plugin_name):
     """Enable the plugin in the app.
 
     Args:
-        plugin_name: the name of the  plugin
+        plugin_name: the plugin name
 
     Returns:
         the path to the enabled plugin
     """
-
-    return _update_app_config(plugin_name, enabled=True)
+    return _update_plugin_settings(plugin_name, enabled=True)
 
 
 def disable_plugin(plugin_name):
     """Disables the plugin in the app.
 
     Args:
-        plugin_name: the name of the  plugin
+        plugin_name: the plugin name
 
     Returns:
         the path to the enabled plugin
     """
-
-    return _update_app_config(plugin_name, enabled=False)
-
-
-def _update_app_config(plugin_name, **kwargs):
-    """Updates the app config settings for a plugin using a dict."""
-    try:
-        app_config_path = focc.locate_app_config()
-        with open(app_config_path, "r") as f:
-            app_config = json.load(f)
-    except OSError as e:
-        # app config file doesn't exist at specified location so create an empty dict and continue
-        app_config = {}
-    except json.decoder.JSONDecodeError as e:
-        if (
-            os.path.exists(app_config_path)
-            and os.path.getsize(app_config_path) > 0
-        ):
-            # app config file exists but is invalid json so fail silently
-            if "enabled" in kwargs and kwargs["enabled"] == True:
-                # if the user is trying to enable a plugin and the app config file is invalid
-                # then we can assume that the plugin is already enabled
-                return
-            # TODO: Just log for now, but figure out how to handle if the user is trying to disable a plugin and the app config file is invalid...
-            logging.debug(
-                "Could not parse app config file. Please ensure that the `FIFTYONE_APP_CONFIG_PATH` is pointing to a valid json file and try again."
-            )
-            return
-        else:
-            # app config file doesn't exist or is empty so create an empty dict and continue
-            app_config = {}
-    except Exception as e:
-        # shouldn't get here, but log and fail silently
-        logging.debug(f"Uncaught error when loading app config file: {e}.")
-        return
-
-    if app_config.get("plugins") is None:
-        app_config["plugins"] = {}
-    if not app_config["plugins"].get(plugin_name):
-        app_config["plugins"][plugin_name] = {}
-    for k, v in kwargs.items():
-        app_config["plugins"][plugin_name][k] = v
-
-    logging.debug(
-        f"Updated app config settings for `{plugin_name}:\n{app_config['plugins'][plugin_name]}"
-    )
-    with open(app_config_path, "w+") as f:
-        json.dump(app_config, f, indent=4)
-    return
+    return _update_plugin_settings(plugin_name, enabled=False)
 
 
-def _list_disabled_plugins():
-    """Returns the list of plugins with `enabled == False` in the app_config settings."""
-    try:
-        with open(focc.locate_app_config(), "r") as f:
-            app_config = json.load(f)
-    except:
-        # no plugins have been disabled if the app config file doesn't exist or is invalid
-        return []
-
-    if len(app_config.get("plugins", {})) > 0:
-        plugins = app_config["plugins"]
-        return list(
-            filter(lambda x: plugins[x].get("enabled", None) == False, plugins)
-        )
-
-
-def delete_plugin(plugin_name, dry_run=False, cleanup=True, limit=None):
-    """Deletes all plugins with the name matching <plugin_name> from the local filesystem.
+def delete_plugin(plugin_name):
+    """Deletes the plugin with the given name from local disk.
 
     Args:
-        plugin_name: the name of the downloaded plugin
-        dry_run: if True, will print the files that will be deleted without actually deleting them
-        cleanup: if True, will delete the plugin directory if it is empty after deleting the plugin
+        plugin_name: the plugin name
     """
-    deleted = []
-    for plugin_dir in _find_plugin_paths(plugin_name):
-        if limit is not None and len(deleted) >= limit:
-            break
-        if plugin_dir:
-            if dry_run:
-                to_delete = glob.glob(
-                    os.path.join(plugin_dir, "**"), recursive=True
-                )
-                logging.info(
-                    f"Deleting `{plugin_name}` will permanently remove the following items from the filesystem:\n {to_delete}"
-                )
-                return
-            shutil.rmtree(plugin_dir)
-            logging.debug(f"Deleted plugin at {plugin_dir}")
-            if cleanup:
-                _cleanup_plugin_dir(plugin_dir)
-        deleted.append(plugin_dir)
-    if len(deleted) > 0:
-        logging.info(
-            f"Deleted {len(deleted)} plugins with name `{plugin_name}`:{deleted}"
-        )
-        return deleted
-    logging.info(
-        f"Nothing to delete. Plugin directory '{plugin_dir}' does not exist."
-    )
-
-
-def _cleanup_plugin_dir(plugin_dir: str, recursive: bool = True):
-    """Deletes any empty plugin parent directories if empty after deleting the plugin."""
-    if plugin_dir in _PLUGIN_DIRS:
-        return
-    plugin_parent_dir = os.path.dirname(plugin_dir)
-    if len(glob.glob(os.path.join(plugin_parent_dir, "*"))) == 0:
-        if plugin_parent_dir not in _PLUGIN_DIRS:
-            shutil.rmtree(plugin_parent_dir)
-        logging.debug(f"Deleted empty directory {plugin_parent_dir}")
-    if recursive:
-        return _cleanup_plugin_dir(plugin_parent_dir, recursive=recursive)
+    plugin_dir = _find_plugin(plugin_name)
+    etau.delete_dir(plugin_dir)
 
 
 def list_downloaded_plugins():
-    """Returns a list of all downloaded plugins by name."""
+    """Returns a list of all downloaded plugins.
+
+    Returns:
+        a list of plugin names
+    """
     return _list_plugins_by_name()
 
 
 def list_enabled_plugins():
-    """Returns a list of all enabled plugins by name."""
-    return _list_plugins_by_name(enabled_only=True)
+    """Returns a list of all enabled plugins.
+
+    Returns:
+        a list of plugin names
+    """
+    return _list_plugins_by_name(enabled=True)
 
 
 def list_disabled_plugins():
-    """Returns a list of all downloaded but disabled plugins by name."""
-    return _list_plugins_by_name(enabled_only=False)
+    """Returns a list of all disabled plugins.
+
+    Returns:
+        a list of plugin names
+    """
+    return _list_plugins_by_name(enabled=False)
+
+
+def find_plugin(name, check_for_duplicates=True):
+    """Returns the path to the plugin's directory.
+
+    Args:
+        name: the plugin name
+        check_for_duplicates (True): whether to ensure that multiple plugins
+            with the given name do not exist
+
+    Returns:
+        the path to the plugin directory
+
+    Raises:
+        ValueError: if the plugin is not found or there are multiple plugins
+        with the same name
+    """
+    return _find_plugin(name, check_for_duplicates=check_for_duplicates)
+
+
+def download_plugin(
+    url_or_gh_repo,
+    plugin_names=None,
+    max_depth=3,
+    overwrite=False,
+):
+    """Downloads the given plugin(s) to your local plugins directory
+    (``fo.config.plugins_dir``).
+
+    Args:
+        url_or_gh_repo: the location to download the plugin from, which can be:
+
+            -   a publicly accessible URL of an archive (eg zip) file
+            -   a GitHub repository like ``https://github.com/<org>/<repo>``
+            -   a string with format ``<user>/<repo>[/<ref>]`` specifying the
+                GitHub repository to use
+
+        plugin_names (None): a plugin name or iterable of plugin names to
+            download. By default, all found plugins are downloaded
+        max_depth (3): the maximum depth within the downloaded archive to
+            search for plugins:
+
+            - ``max_depth=1``: only search the top-level downloaded directory
+            - ``max_depth=2``: also search immediate subdirectories
+            - ``max_depth=3``: search two levels deep
+            - etc
+
+        overwrite (False): whether to overwrite an existing plugin with the
+            same name if it already exists
+
+    Returns:
+        the path to the downloaded plugin
+    """
+    if etaw.is_url(url_or_gh_repo):
+        if "github" in url_or_gh_repo:
+            repo = GitHubRepository(url)
+            url = repo.download_url
+        else:
+            url = url_or_gh_repo
+    else:
+        repo = GitHubRepository(url_or_gh_repo)
+        url = repo.download_url
+
+    return _download_plugin(
+        url,
+        plugin_names=plugin_names,
+        max_depth=max_depth,
+        overwrite=overwrite,
+    )
+
+
+def _download_plugin(url, plugin_names=None, max_depth=3, overwrite=False):
+    if etau.is_str(plugin_names):
+        plugin_names = {plugin_names}
+    elif plugin_names is not None:
+        plugin_names = set(plugin_names)
+
+    existing_plugin_dirs = {p.name: p.path for p in _list_plugins()}
+
+    with etau.TempDir() as tmpdir:
+        path = os.path.join(tmpdir, os.path.basename(url))
+        etaw.download_file(url, path=path)
+        etau.extract_archive(path)
+
+        metadata_paths = _find_plugin_metadata_files(
+            os.path.join(tmpdir, "*"),
+            max_depth=max_depth + 1,
+        )
+
+        for metadata_path in metadata_paths:
+            try:
+                plugin = _parse_plugin_metadata(metadata_path)
+            except AttributeError:
+                logging.debug(f"Failed to parse '{metadata_path}'")
+                continue
+
+            if plugin_names is not None and plugin.name not in plugin_names:
+                logger.debug(f"Skipping unwanted plugin '{plugin.name}'")
+                continue
+
+            existing_dir = existing_plugin_dirs.get(plugin.name, None)
+            if existing_dir is not None:
+                if not overwrite:
+                    logger.debug(f"Skipping existing plugin '{plugin.name}'")
+                    continue
+
+                logger.debug(f"Overwriting existing plugin '{plugin.name}'")
+                etau.delete_dir(existing_dir)
+                plugin_dir = existing_dir
+            else:
+                plugin_dir = _recommend_plugin_dir(plugin)
+
+            logger.debug(f"Copying plugin '{plugin.name}' to '${plugin_dir}'")
+            etau.copy_dir(plugin.path, plugin_dir)
+
+
+def create_plugin(
+    plugin_name,
+    label=None,
+    description=None,
+    from_dir=None,
+    from_files=None,
+    outdir=None,
+    overwrite=False,
+    **kwargs,
+):
+    """Creates a plugin with the given name.
+
+    If no input files are provided, a directory containing only the plugin's
+    metadata file will be created.
+
+    If no ``outdir`` is specified, the plugin is created within your
+    ``fo.config.plugins_dir``.
+
+    Args:
+        plugin_name: the name of the plugin
+        label (None): a display name for the plugin
+        description (None): a description for the plugin
+        from_dir (None): the path to the directory containing the plugin
+        from_files (None): an explicit list of filepaths and/or directories to
+            include in the plugin
+        outdir (None): the path at which to create the plugin directory. If
+            not provided, the plugin is created within your
+            ``fo_config.plugins_dir``
+        overwrite (False): whether to overwrite a local plugin with the same
+            name if one exists
+        **kwargs: optional keyword arguments to include in the plugin
+            definition
+
+    Returns:
+        the directory containging the plugin
+    """
+    if outdir is None:
+        existing_plugin_dirs = {p.name: p.path for p in _list_plugins()}
+        if plugin_name in existing_plugin_dirs:
+            if not overwrite:
+                raise ValueError(f"Plugin '${plugin_name}' already exists")
+
+            logger.debug(f"Overwriting existing plugin {plugin_name}")
+            outdir = existing_plugin_dirs[plugin_name]
+        else:
+            outdir = os.path.join(fo.config.plugins_dir, plugin_name)
+    elif os.path.isdir(outdir):
+        if not overwrite:
+            raise ValueError(f"Plugin directory '${outdir}' already exists")
+
+        logger.debug(f"Overwriting existing plugin directory '${outdir}'")
+
+    etau.ensure_empty_dir(outdir, cleanup=True)
+
+    if from_dir:
+        from_files = [os.path.join(from_dir, f) for f in os.listdir(from_dir)]
+
+    if from_files:
+        for from_path in from_files:
+            shutil.copytree(from_path, outdir)
+
+    yaml_path = _find_plugin_metadata_file(outdir)
+    if yaml_path is None:
+        yaml_path = os.path.join(outdir, _PLUGIN_METADATA_FILENAMES[0])
+
+    pd = {
+        "name": plugin_name,
+        "label": label,
+        "description": description,
+        "fiftyone": {"version": foc.VERSION},
+        **kwargs,
+    }
+
+    # Merge with existing YAML file, if necessary
+    if os.path.isfile(yaml_path):
+        with open(yaml_path, "r") as f:
+            pd = yaml.safe_load(f) | pd
+
+    with open(yaml_path, "w") as f:
+        yaml.dump(pd, f)
 
 
 def _is_plugin_definition_file(path):
-    """Returns whether the given path is a plugin."""
-    return re.search(_PLUGIN_DEFINITION_FILE_PATTERN, path) is not None
+    return os.path.basename(path) in _PLUGIN_METADATA_FILENAMES
 
 
-def _list_plugins_by_name(
-    enabled_only: bool = None, check_for_duplicates=True
-) -> List[Optional[str]]:
-    """Returns a list of plugins.
+def _find_plugin_metadata_file(dirpath):
+    for filename in _PLUGIN_METADATA_FILENAMES:
+        metadata_path = os.path.join(dirpath, filename)
+        if os.path.isfile(metadata_path):
+            return metadata_path
 
-    Args:
-        enabled_only: If enabled_only == True, only returns enabled plugins.
-            If enabled_only == False, only returns disabled plugins.
-            If enabled_only == None, all downloaded plugins will be listed
-        check_for_duplicates (True): raises an error if duplicate plugin names are found
-    """
-    if not fo.config.plugins_dir or not os.path.exists(fo.config.plugins_dir):
-        logging.debug("No plugins directory found.")
-        return []
-
-    plugins = _list_plugins(enabled_only=enabled_only)
-    if check_for_duplicates:
-        dupes = []
-        plugin_map = defaultdict(list)
-        for plugin in plugins:
-            if len(plugin_map[plugin.name]) > 0:
-                dupes.append(plugin.name)
-            plugin_map[plugin.name].append(plugin.path)
-
-        if len(dupes) > 0:
-            pprint.pprint(
-                ({k: v for k, v in plugin_map.items() if k in dupes})
-            )
-            raise ValueError(
-                f"Plugin names not unique. Please rename or delete the duplicates."
-            )
-
-    return [p.name for p in plugins]
+    return None
 
 
-def _list_plugins(enabled_only: bool = None) -> List[Optional[plugin_package]]:
-    """Returns a list of plugins.
-    If enabled_only == True, only returns enabled plugins.
-    If enabled_only == False, only returns disabled plugins.
-    If enabled_only == None, all downloaded plugins will be listed
-    """
-    if not fo.config.plugins_dir or not os.path.exists(fo.config.plugins_dir):
-        logging.debug("No plugins directory found.")
-        return []
+def _parse_plugin_metadata(metadata_path):
+    with open(metadata_path, "r") as f:
+        plugin_name = yaml.safe_load(f).get("name")
+
+    plugin_path = os.path.dirname(metadata_path)
+    return plugin_package(plugin_name, plugin_path)
+
+
+def _list_plugins(enabled=None):
     plugins = []
-    disabled = _list_disabled_plugins()
-    # plugin directory must have a fiftyone.yml file defining the plugin
-    for fpath in _iter_plugin_definition_files():
+    for metadata_path in _iter_plugin_definition_files():
         try:
-            # get plugin name from yml
-            with open(fpath, "r") as f:
-                plugin_name = yaml.safe_load(f).get("name")
+            plugin = _parse_plugin_metadata(metadata_path)
+            plugins.append(plugin)
         except AttributeError:
-            logging.debug(
-                f"error parsing plugin_name from yml file and filepath: {fpath}"
-            )
+            logging.debug(f"Failed to parse {metadata_path}")
             continue
 
-        if plugin_name:
-            logging.debug(f"Found plugin {plugin_name} at {fpath}")
-            plugin = plugin_package(plugin_name, os.path.dirname(fpath))
-            plugins.append(plugin)
+    disabled = set(_list_disabled_plugins())
 
-    if enabled_only and (disabled is not None):
+    if enabled is True:
         return [p for p in plugins if p.name not in disabled]
-    elif enabled_only is False:
+
+    if enabled is False:
         return [p for p in plugins if p.name in disabled]
+
     return plugins
 
 
-def find_plugin(name: str, check_for_duplicates: bool = True) -> Optional[str]:
-    """Returns the path to the plugin directory if it exists, None otherwise.
-    Raises an error if multiple paths are found.
-    Args:
-        name: the name of the plugin as it appears in the .yml file
-    Returns:
-        the path to the plugin directory or error if not found or multiple found
-    """
+def _list_plugins_by_name(enabled=None, check_for_duplicates=True):
+    plugin_names = [p.name for p in _list_plugins(enabled=enabled)]
 
-    plugin_dir = list(_find_plugin_paths(name))
-    if len(plugin_dir) == 1:
-        logging.debug(f"Found plugin at {plugin_dir}")
-        return plugin_dir[0]
-    elif (len(plugin_dir) > 1) and check_for_duplicates:
-        raise ValueError(
-            f"Multiple plugins found with name '{name}': {plugin_dir}."
-        )
+    if check_for_duplicates:
+        dups = [n for n, c in Counter(plugin_names).items() if c > 1]
+        if dups:
+            raise ValueError(f"Plugin names ${dups} are not unique")
 
-    raise ValueError(f"Plugin '{name}' not found in {_PLUGIN_DIRS[0]}.")
+    return plugin_names
 
 
-def _iter_plugin_definition_files(filepaths: Optional[List[str]] = None):
-    """Returns an iterator that finds all plugin definition files in filepaths.
-    If filepaths is not provided, the default plugin directory is searched.
+def _find_plugin_metadata_files(root_dir, max_depth=1):
+    return fou.find_files(
+        root_dir,
+        _PLUGIN_METADATA_FILENAMES,
+        max_depth=max_depth,
+    )
 
-    """
 
-    if filepaths and len(filepaths) > 0:
+def _iter_plugin_definition_files(filepaths=None):
+    if filepaths is not None:
         for fpath in filter(
             lambda x: _is_plugin_definition_file(x), filepaths
         ):
             yield fpath
-    else:
-        for root, dirs, files in os.walk(_PLUGIN_DIRS[0]):
-            # ignore hidden directories
-            dirs[:] = [d for d in dirs if not re.search(r"^[._]", d)]
-            for file in files:
-                if _is_plugin_definition_file(file):
-                    yield os.path.join(root, file)
-                    files[:] = []
+
+        return
+
+    if not fo.config.plugins_dir or not os.path.isdir(fo.config.plugins_dir):
+        return
+
+    for root, dirs, files in os.walk(fo.config.plugins_dir):
+        # ignore hidden directories
+        dirs[:] = [d for d in dirs if not re.search(r"^[._]", d)]
+        for file in files:
+            if _is_plugin_definition_file(file):
+                yield os.path.join(root, file)
+                files[:] = []
 
 
-def _find_plugin_paths(name: str = None) -> Optional[str]:
-    for fpath in _iter_plugin_definition_files():
-        try:
-            # get plugin name from yml
-            with open(fpath, "r") as f:
-                plugin_name = yaml.safe_load(f).get("name")
-                if not plugin_name:
-                    continue
-                if not name:
-                    name = plugin_name
-                if name == plugin_name:
-                    yield os.path.dirname(fpath)
-        except AttributeError:
-            logging.debug(
-                f"error parsing plugin_name from yml file and filepath: {fpath}"
-            )
-            continue
+def _find_plugin(name, check_for_duplicates=False):
+    plugin_dir = None
+    for plugin in _list_plugins():
+        if name == plugin.name:
+            if check_for_duplicates and plugin_dir is not None:
+                raise ValueError(f"Multiple plugins found with name '{name}'")
+
+            plugin_dir = os.path.dirname(plugin.path)
+
+    if plugin_dir is None:
+        raise ValueError(f"Plugin '${name}' not found")
+
+    return plugin_dir
 
 
-def download_plugin(
-    name: str = None,
-    url: str = None,
-    gh_repo: str = None,
-    overwrite: bool = False,
-    **kwargs,
-) -> Optional[str]:
-    """Downloads a plugin into the directory specified by FIFTYONE_PLUGINS_DIR.
-    Currently only supports downloading zip archives directly via URL or from public GitHub repos.
-
-    Args:
-        name: the name of the plugin as it appears in the .yml file
-        url: the URL to the plugin zip archive
-        gh_repo: URL or '<user>/<repo>[/<ref>]' of the GitHub repo containing the plugin
-        overwrite: whether to force re-download and overwrite the plugin if it already exists
-        **kwargs: optional keyword arguments to pass to the plugin's `install()` method
-    Returns:
-        the path to the downloaded plugin
-    """
-    plugins_dir = _PLUGIN_DIRS[0]
-    if not plugins_dir:
-        raise ValueError("Plugins directory not set.")
-    elif not os.path.isdir(plugins_dir):
-        try:
-            # create plugins directory at set path if it doesn't exist
-            os.makedirs(plugins_dir)
-        except:
-            raise ValueError(
-                f"Plugins directory '{plugins_dir}' does not exist."
-            )
-    download_ref = next(ref for ref in [name, url, gh_repo] if ref is not None)
-    if not download_ref:
-        raise ValueError("Must provide name, url, or github_repo.")
-    if etaw.is_url(download_ref) and "github" not in download_ref:
-        logging.debug("Downloading from URL")
-        zip_url = download_ref
-    else:
-        logging.debug("Downloading from GitHub")
-        zip_url = _get_gh_download_url(download_ref)
-    if not zip_url:
-        raise ValueError("Could not determine zip download URL.")
-    extracted_dir_path = _download_and_extract_zip(
-        zip_url, overwrite=overwrite
-    )
-
-    return extracted_dir_path
-
-
-def _get_gh_download_url(gh_repo: str) -> str:
-    """Returns the URL to the plugin zip archive on GitHub."""
-    repo = fozug.GitHubRepo(gh_repo)
-    return repo.download_url
-
-
-def _download_and_extract_zip(
-    zip_url: str,
-    plugin_names: Optional[List[str]] = None,
-    overwrite: Optional[bool] = False,
-) -> Optional[str]:
-    """Downloads and extracts a zip archive to the plugin directory.
-
-    Args:
-        zip_url: the URL of the zip archive
-        plugin_names: an optional list of plugin names to extract.
-            If not provided, all plugins in the archive will be extracted
-        overwrite: whether to force re-download and overwrite the plugin if it already exists
-    """
-
-    # TODO: add support for specifying plugin names to extract
-
-    extracted_dir_name = "-".join(re.findall(r"\w+", zip_url))
-
-    extracted_dir_path = os.path.join(
-        fo.config.plugins_dir, extracted_dir_name
-    )
-    if not overwrite:
-        print("overwrite=", overwrite)
-        if os.path.isdir(extracted_dir_path):
-            print(
-                f"Plugin from {zip_url} already downloaded at {extracted_dir_path}. Skipping download."
-            )
-            return extracted_dir_path
-
+def _list_disabled_plugins():
     try:
-        with urlopen(zip_url) as zipresp:
-            if zipresp.info().get("Content-Type") != "application/zip":
-                raise ValueError(
-                    f"File at {zip_url} is not a zip archive. Aborting download."
-                )
-            logging.info(f"Attempting to download plugin from {zip_url}...")
-            with ZipFile(BytesIO(zipresp.read())) as zfile:
-                logging.debug(f"Files in archive: {zfile.namelist()}")
-                plugin_defs = list(
-                    _iter_plugin_definition_files(zfile.namelist())
-                )
-                if len(plugin_defs) < 1:
-                    logging.warning(
-                        f"Aborting download. Archive missing `fiftyone.yml` file."
-                    )
-                    return
-                # TODO (followup): Extracting entire archive for now, but may need to
-                #  limit to extracting only plugin directories (with .yml files at their root)
-                zfile.extractall(extracted_dir_path)
-                print(f"Downloaded plugin to {extracted_dir_path}")
-                return extracted_dir_path
+        with open(focc.locate_app_config(), "r") as f:
+            app_config = json.load(f)
+    except:
+        return {}
 
-    except HTTPError as e:
-        raise ValueError(f"Error downloading archive at {zip_url}: \n{e}")
+    plugins = app_config.get("plugins", {})
+    return [name for name, d in plugins.items() if d.get("enabled") == False]
 
 
-def _has_plugin_definition(plugin_files: list) -> bool:
-    """Checks whether the plugin directory contains a valid plugin definition.
-
-    Args:
-        plugin_dir: the path to the plugin directory
-
-    Returns:
-        True if the plugin is valid, False otherwise
-    """
-    return any(
-        filter(
-            lambda x: _is_plugin_definition_file(x),
-            plugin_files,
-        )
-    )
-
-
-def create_plugin(
-    plugin_name: str,
-    from_dir: Optional[str] = None,
-    from_files: Optional[list] = None,
-    label: Optional[str] = None,
-    description: Optional[str] = None,
-    overwrite=False,
-    **kwargs,
-) -> None:
-    """Creates a local plugin with the given name and places it in the `<FIFTYONE_PLUGINS_DIR>/local` directory.
-    If no files are specified, only a directory with a plugin definition file will be created.
-
-    Args:
-        plugin_name: the name of the plugin. An error will be raised if a plugin with this name already exists unless overwrite=True
-        from_dir: the path to the directory containing the plugin files
-        from_files: a list of filepaths to include in the plugin
-        overwrite: whether to overwrite the plugin directory if it already exists
-        label: the display name of the plugin
-        description: a description of the plugin
-        **kwargs: optional keyword arguments to include in the plugin definition
-    """
-    if from_dir and from_files:
-        raise ValueError("Cannot specify both from_dir and from_files.")
-    if plugin_name in _list_plugins_by_name(check_for_duplicates=False):
-        if not overwrite:
-            raise ValueError(
-                f"Plugin '{plugin_name}' already exists. Rerun `create` with overwrite=True to overwrite it."
-            )
-        else:
-            deleted_dir = delete_plugin(plugin_name)
-            print(
-                f'Deleted existing plugin with name "{plugin_name}" at {deleted_dir}'
-            )
-
-    plugin_dir = os.path.join(
-        fo.config.plugins_dir,
-        "local",
-        "-".join([plugin_name, str(round(time()))]),
-    )
-    os.makedirs(plugin_dir)
-    if from_dir:
-        if not (os.path.isdir(from_dir) and os.path.exists(from_dir)):
-            raise ValueError(f"'{from_dir}' is not a directory.")
-        from_files = [os.path.join(from_dir, f) for f in os.listdir(from_dir)]
-    if from_files:
-        for fpath in from_files:
-            if not (os.path.isfile(fpath) and os.path.exists(fpath)):
-                raise ValueError(f"'{fpath}' is not a file.")
-            shutil.copytree(fpath, plugin_dir)
-    yml_path = next(
-        _iter_plugin_definition_files(os.listdir(plugin_dir)), None
-    )
-    plugin_definition = {
-        "name": plugin_name,
-        "description": description,
-        "label": label,
-        "fiftyone": {"version": foc.VERSION},
-        **kwargs,
-    }
-    if not yml_path:
-        yml_path = os.path.join(plugin_dir, "fiftyone.yml")
+def _recommend_plugin_dir(plugin):
+    plugins_dir = fo.config.plugins_dir
+    if os.path.isdir(plugins_dir):
+        existing_dirs = set(os.listdir(plugins_dir))
     else:
-        with open(yml_path, "r") as yml_file:
-            old_yml = yaml.safe_load(yml_file)
-            # add any missing and overwrite existing fields with the values
-            # from the new plugin definition
-            plugin_definition = old_yml | plugin_definition
+        existing_dirs = {}
 
-    with open(yml_path, "w") as yml_file:
-        yaml.dump(plugin_definition, yml_file)
-    print(f"Created plugin with name `{plugin_name}` at {plugin_dir}")
-    return
+    dirname = os.path.basename(plugin.path)
+    if dirname not in existing_dirs:
+        return os.path.join(plugins_dir, dirname)
+
+    name = plugin.name
+    if name not in existing_dirs:
+        return os.path.join(plugins_dir, name)
+
+    unique_name = None
+    i = 2
+    while True:
+        unique_name = name + str(i)
+        if unique_name in existing_dirs:
+            i += 1
+        else:
+            break
+
+    return os.path.join(plugins_dir, unique_name)
 
 
-def _label_from_name(name: str) -> str:
+def _recommend_plugin_label(name):
     # replace non-alphanumeric characters with spaces
     label = re.sub("[^A-Za-z0-9]+", " ", name)
     # capitalize each word
-    return " ".join([w.capitalize() for w in label.split(" ")])
+    return " ".join([w.capitalize() for w in label.split()])
+
+
+def _update_plugin_settings(plugin_name, enabled=None, **kwargs):
+    app_config_path = focc.locate_app_config()
+
+    # Plugins are enabled by default, so if we can't read the App config or it
+    # doesn't exist, don't do anything
+    okay_missing = enabled in (True, None) and not kwargs
+
+    if os.path.isfile(app_config_path):
+        try:
+            with open(app_config_path, "rt") as f:
+                app_config = json.load(f)
+        except Exception as e:
+            if okay_missing:
+                return
+
+            raise ValueError(
+                "Failed to parse App config at '%s'" % app_config_path
+            ) from e
+    elif okay_missing:
+        return
+    else:
+        app_config = {}
+
+    if app_config.get("plugins") is None:
+        app_config["plugins"] = {}
+
+    plugins = app_config["plugins"]
+
+    if not plugins.get(plugin_name):
+        plugins[plugin_name] = {}
+
+    plugin_settings = plugins[plugin_name]
+
+    if enabled in (True, None):
+        # Plugins are enabled by default, so just remove the entry altogether
+        plugin_settings.pop("enabled", None)
+        if not plugin_settings:
+            plugins.pop(plugin_name)
+    else:
+        plugin_settings["enabled"] = False
+
+    plugin_settings.update(kwargs)
+
+    with open(app_config_path, "wt") as f:
+        json.dump(app_config, f, indent=4)

--- a/fiftyone/plugins/core.py
+++ b/fiftyone/plugins/core.py
@@ -260,8 +260,8 @@ def create_plugin(
     If no input files are provided, a directory containing only the plugin's
     metadata file will be created.
 
-    If no ``outdir`` is specified, the plugin is created within your
-    ``fo.config.plugins_dir``.
+    If no ``outdir`` is specified, the plugin is created within your local
+    plugins directory (``fo.config.plugins_dir``).
 
     Args:
         plugin_name: the name of the plugin
@@ -279,7 +279,7 @@ def create_plugin(
             definition
 
     Returns:
-        the directory containging the plugin
+        the directory containing the plugin
     """
     if outdir is None:
         existing_plugin_dirs = {p.name: p.path for p in _list_plugins()}
@@ -389,10 +389,11 @@ def _find_plugin_metadata_files(root_dir, max_depth=1):
 
 
 def _iter_plugin_metadata_files():
-    if not fo.config.plugins_dir or not os.path.isdir(fo.config.plugins_dir):
+    plugins_dir = fo.config.plugins_dir
+    if not plugins_dir or not os.path.isdir(plugins_dir):
         return
 
-    for root, dirs, files in os.walk(fo.config.plugins_dir):
+    for root, dirs, files in os.walk(plugins_dir, followlinks=True):
         # ignore hidden directories
         dirs[:] = [d for d in dirs if not re.search(r"^[._]", d)]
         for file in files:

--- a/fiftyone/plugins/core.py
+++ b/fiftyone/plugins/core.py
@@ -155,6 +155,12 @@ def download_plugin(
     """Downloads the plugin(s) from the given location to your local plugins
     directory (``fo.config.plugins_dir``).
 
+    .. note::
+
+        To download a plugin from a private GitHub repo that you have access
+        to, provide your GitHub personal access token by setting the
+        ``GITHUB_TOKEN`` environment variable.
+
     Args:
         url_or_gh_repo: the location to download from, which can be:
 
@@ -227,7 +233,13 @@ def _download_plugin(
     downloaded_plugins = {}
     with etau.TempDir() as tmpdir:
         archive_path = os.path.join(tmpdir, archive_name)
-        etaw.download_file(url, path=archive_path)
+        session = etaw.WebSession()
+        token = os.environ.get("GITHUB_TOKEN", None)
+        if token:
+            logger.debug("Using GitHub token as authorization for download")
+            session.sess.headers.update({"Authorization": "token " + token})
+
+        session.write(archive_path, url)
         etau.extract_archive(archive_path)
 
         metadata_paths = _find_plugin_metadata_files(

--- a/fiftyone/plugins/core.py
+++ b/fiftyone/plugins/core.py
@@ -52,12 +52,15 @@ def list_plugins(enabled=True):
     """Returns the list of enabled plugins.
 
     Args:
-        enabled (True): whether to include only enabled (True) or only disabled
-            (False) plugins. By default, all downloaded plugins are returned
+        enabled (True): whether to show only enabled plugins (True) or only
+            disabled plugins (False) or all plugins ("all")
 
     Returns:
         a list of :class:`PluginDefinition` instances
     """
+    if enabled == "all":
+        enabled = None
+
     plugins = []
     for p in _list_plugins(enabled=enabled):
         metadata_path = _find_plugin_metadata_file(p.path)
@@ -467,12 +470,15 @@ def _recommend_plugin_label(name):
 
 
 def _update_plugin_settings(plugin_name, enabled=None, **kwargs):
-    app_config_path = focc.locate_app_config()
+    # Ensure plugin actually exists
+    _find_plugin(plugin_name)
 
     # Plugins are enabled by default, so if we can't read the App config or it
     # doesn't exist, don't do anything
     okay_missing = enabled in (True, None) and not kwargs
 
+    # Load existin App config, if any
+    app_config_path = focc.locate_app_config()
     if os.path.isfile(app_config_path):
         try:
             with open(app_config_path, "rt") as f:

--- a/fiftyone/plugins/core.py
+++ b/fiftyone/plugins/core.py
@@ -157,8 +157,8 @@ def download_plugin(
 
     .. note::
 
-        To download a plugin from a private GitHub repo that you have access
-        to, provide your GitHub personal access token by setting the
+        To download a plugin from a private GitHub repository that you have
+        access to, provide your GitHub personal access token by setting the
         ``GITHUB_TOKEN`` environment variable.
 
     Args:

--- a/fiftyone/plugins/definitions.py
+++ b/fiftyone/plugins/definitions.py
@@ -1,82 +1,78 @@
 """
-FiftyOne Plugin Definitions.
+Plugin definitions.
 
 | Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
-import glob
+import logging
+import os
+
+import yaml
+
 import eta.core.serial as etas
 
 import fiftyone as fo
-import os
-import yaml  # BEFORE PR: add to requirements.txt
-import traceback
-
-import fiftyone.plugins.core as fopc
 import fiftyone.constants as foc
+import fiftyone.core.utils as fou
 
 
-# BEFORE PR: where should this go?
-def find_files(root_dir, filename, extensions, max_depth):
-    """Returns all files matching the given pattern, up to the given depth.
-
-    Args:
-        pattern: a glob pattern
-        max_depth: the maximum depth to search
-
-    Returns:
-        a list of paths
-    """
-    if max_depth == 0:
-        return []
-
-    paths = []
-    for i in range(1, max_depth):
-        pattern_parts = [root_dir]
-        pattern_parts += list("*" * i)
-        pattern_parts += [filename]
-        pattern = os.path.join(*pattern_parts)
-        for extension in extensions:
-            paths += glob.glob(pattern + "." + extension)
-
-    return paths
-
-
-MAX_PLUGIN_SEARCH_DEPTH = 3
-PLUGIN_METADATA_FILENAME = "fiftyone"
-PLUGIN_METADATA_EXTENSIONS = ["yml", "yaml"]
 REQUIRED_PLUGIN_METADATA_KEYS = ["name"]
 
 
-def find_plugin_metadata_files():
-    plugins_dir = fo.config.plugins_dir
-
-    if not plugins_dir:
-        return []
-
-    normal_locations = find_files(
-        plugins_dir,
-        PLUGIN_METADATA_FILENAME,
-        PLUGIN_METADATA_EXTENSIONS,
-        MAX_PLUGIN_SEARCH_DEPTH,
-    )
-    node_modules_locations = find_files(
-        os.path.join(plugins_dir, "node_modules", "*"),
-        PLUGIN_METADATA_FILENAME,
-        PLUGIN_METADATA_EXTENSIONS,
-        1,
-    )
-    yarn_packages_locations = find_files(
-        os.path.join(plugins_dir, "packages", "*"),
-        PLUGIN_METADATA_FILENAME,
-        PLUGIN_METADATA_EXTENSIONS,
-        1,
-    )
-    return normal_locations + node_modules_locations + yarn_packages_locations
+logger = logging.getLogger(__name__)
 
 
-class PluginDefinition:
+def load_plugin_definition(metadata_path):
+    """Loads the plugin definition from the given metadata file.
+
+    Args:
+        metadata_path: path to the plugin metadata
+
+    Returns:
+        a :class:`PluginDefinition`
+    """
+    try:
+        module_dir = os.path.dirname(metadata_path)
+        with open(metadata_path, "r") as f:
+            metadata_dict = yaml.safe_load(f)
+            return PluginDefinition(module_dir, metadata_dict)
+    except Exception as e:
+        logger.warning(
+            "Failed to load plugin metadata from '%s': %s", metadata_path, e
+        )
+        return None
+
+
+def validate_plugins(plugins):
+    """Validates the given plugin definitions, checking for things like missing
+    or duplicate names.
+
+    Args:
+        plugins: a list of :class:`PluginDefinition` instances
+
+    Returns:
+        a list of valid :class:`PluginDefinition` instances
+    """
+    results = []
+    names = set()
+    for plugin in plugins:
+        if not plugin.name:
+            raise InvalidPluginDefinition(
+                "Plugin definition in %s is missing a name" % plugin.directory
+            )
+        if plugin.name in names:
+            raise DuplicatePluginNameError(
+                "Plugin name %s is not unique" % plugin.name
+            )
+        else:
+            results.append(plugin)
+        names.add(plugin.name)
+
+    return results
+
+
+class PluginDefinition(object):
     """A plugin definition.
 
     Args:
@@ -234,62 +230,9 @@ class PluginDefinition:
         }
 
 
-def load_plugin_definition(metadata_file):
-    """Loads the plugin definition from the given metadata_file."""
-    try:
-        with open(metadata_file, "r") as f:
-            metadata_dict = yaml.safe_load(f)
-            module_dir = os.path.dirname(metadata_file)
-            definition = PluginDefinition(module_dir, metadata_dict)
-            return definition
-    except:
-        traceback.print_exc()
-        return None
-
-
-def list_plugins():
-    """
-    List all PluginDefinitions for enabled plugins.
-    """
-    plugins = [
-        pd
-        for pd in [
-            load_plugin_definition(
-                os.path.join(p.path, PLUGIN_METADATA_FILENAME + ".yml")
-            )
-            for p in fopc._list_plugins(enabled_only=True)
-        ]
-        if pd
-    ]
-
-    return validate_plugins(plugins)
-
-
 class DuplicatePluginNameError(ValueError):
     pass
 
 
 class InvalidPluginDefinition(ValueError):
     pass
-
-
-def validate_plugins(plugins):
-    """
-    Validates the given list of PluginDefinitions.
-    Returns a list of valid PluginDefinitions.
-    """
-    results = []
-    names = set()
-    for plugin in plugins:
-        if not plugin.name:
-            raise InvalidPluginDefinition(
-                "Plugin definition in %s is missing a name" % plugin.directory
-            )
-        if plugin.name in names:
-            raise DuplicatePluginNameError(
-                "Plugin name %s is not unique" % plugin.name
-            )
-        else:
-            results.append(plugin)
-        names.add(plugin.name)
-    return results

--- a/fiftyone/plugins/definitions.py
+++ b/fiftyone/plugins/definitions.py
@@ -12,7 +12,6 @@ import yaml
 import eta.core.serial as etas
 
 import fiftyone as fo
-import fiftyone.constants as foc
 
 
 class PluginDefinition(object):
@@ -78,7 +77,7 @@ class PluginDefinition(object):
     @property
     def fiftyone_compatibility(self):
         """The FiftyOne compatible version as a semver string."""
-        return self._metadata.get("fiftyone", {}).get("version", foc.Version)
+        return self._metadata.get("fiftyone", {}).get("version", None)
 
     @property
     def operators(self):
@@ -121,9 +120,8 @@ class PluginDefinition(object):
     @property
     def server_path(self):
         """The default server path to the plugin."""
-        return "/" + os.path.join(
-            "plugins", os.path.relpath(self.directory, fo.config.plugins_dir)
-        )
+        relpath = os.path.relpath(self.directory, fo.config.plugins_dir)
+        return "/" + os.path.join("plugins", relpath)
 
     @property
     def js_bundle_server_path(self):

--- a/fiftyone/server/routes/plugins.py
+++ b/fiftyone/server/routes/plugins.py
@@ -5,15 +5,9 @@ FiftyOne Server ``/plugins`` route.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
-import glob
-import os
-
 from starlette.endpoints import HTTPEndpoint
 from starlette.requests import Request
 
-import eta.core.serial as etas
-
-import fiftyone as fo
 from fiftyone.server.decorators import route
 from fiftyone.plugins import list_plugins
 
@@ -21,14 +15,4 @@ from fiftyone.plugins import list_plugins
 class Plugins(HTTPEndpoint):
     @route
     async def get(self, request: Request, data: dict):
-        plugin_packages = [
-            plugin_definition.to_json() for plugin_definition in list_plugins()
-        ]
-        return {"plugins": plugin_packages}
-
-
-def load_json_or_none(filepath):
-    try:
-        return etas.read_json(filepath)
-    except FileNotFoundError:
-        return None
+        return {"plugins": pd.to_dict() for pd in list_plugins()}

--- a/fiftyone/utils/github.py
+++ b/fiftyone/utils/github.py
@@ -1,57 +1,57 @@
-import json
-import logging
+"""
+GitHub utilities.
+
+| Copyright 2017-2023, Voxel51, Inc.
+| `voxel51.com <https://voxel51.com/>`_
+|
+"""
 import os
 import re
-from typing import Optional
-
-import eta.core.web as etaw
 import requests
 
+import eta.core.web as etaw
 
-class GitHubRepo:
-    """A GitHub repo containing a FiftyOne zoo package"""
 
-    def __init__(self, repo: str):
-        """
-        Args:
-            repo: URL or '<user>/<repo>[/<ref>]' of the GitHub repo containing the plugin
-        """
+class GitHubRepository(object):
+    """Utility class for interacting with a GitHub repository.
+
+    Args:
+        repo: a URL like ``https://github.com/<user>/<repo>`` or an identifier
+            like ``<user>/<repo>[/<ref>]``
+    """
+
+    def __init__(self, repo):
         if not etaw.is_url(repo):
             params = self.from_str(repo)
         else:
             params = self.from_url(repo)
+
         self._user = params.get("user")
         self._name = params.get("repo")
         self._ref = params.get("ref")
 
     @property
-    def user(self) -> str:
-        """The GitHub username of the repo owner"""
+    def user(self):
+        """The username of the repo."""
         return self._user
 
     @property
-    def name(self) -> str:
-        """The name of the repo"""
+    def name(self):
+        """The name of the repo."""
         return self._name
 
     @property
-    def ref(self) -> Optional[str]:
-        """The ref of the repo (e.g. branch, tag, commit hash)"""
+    def ref(self):
+        """The ref of the repo (e.g. branch, tag, commit hash)."""
         return self._ref
 
     @ref.setter
-    def ref(self, ref: str):
-        """Sets the ref of the repo (e.g. branch, tag, commit hash)"""
+    def ref(self, ref):
         self._ref = ref
 
     @property
-    def download_url(self) -> str:
-        """The URL to download the repo as a zip archive"""
-        """
-         Returns the URL to download a GitHub repo as a zip archive
-         Args:
-             github_repo: URL or '<username>/<repo>' of the GitHub repo containing the plugin
-         """
+    def download_url(self):
+        """The URL to download the repo as a zip archive."""
         zip_url = (
             f"https://api.github.com/repos/{self.user}/{self.name}/zipball"
         )
@@ -63,7 +63,6 @@ class GitHubRepo:
     @classmethod
     def from_url(cls, url):
         """Parses a GitHub URL into its components."""
-        logging.debug(f"Parsing url: {url}")
         params = re.search(
             "github.com/(?P<user>[A-Za-z0-9_-]+)/((?P<repo>["
             "A-Za-z0-9_-]+)((/.+?)?/(?P<ref>[A-Za-z0-9_-]+)?(?P<path>.*)?)?)",
@@ -72,19 +71,17 @@ class GitHubRepo:
         params["is_gist"] = False
         params["ref"] = params["ref"] or "main"
         params["path"] = params["path"] or ""
-        logging.debug(f"params = {params}")
         return params
 
     @classmethod
     def from_str(cls, repo):
         """Parses a GitHub repo string into its components."""
-        logging.debug(f"Parsing repo: {repo}")
         params = repo.split("/")
         if len(params) < 2:
             raise ValueError(
                 "Invalid repo format. Must be in the form of user/repo/<ref>"
             )
-        logging.debug(f"params = {params}")
+
         return {
             "user": params[0],
             "repo": params[1],
@@ -93,20 +90,21 @@ class GitHubRepo:
             "path": "",
         }
 
-    def list_path_contents(self, path: Optional[str] = None) -> Optional[list]:
-        """Returns the contents of the repo at the given path"""
-
+    def list_path_contents(self, path=None):
+        """Returns the contents of the repo at the given path."""
         content_url = (
             f"https://api.github.com/repos/{self.user}/{self.name}/contents"
         )
         if path:
             content_url = os.path.join(content_url, path)
+
         if self.ref:
             content_url = f"{content_url}?ref={self.ref}"
+
         return requests.get(content_url).json()
 
-    def list_repo_contents(self, recursive: bool = True) -> Optional[list]:
-        """Returns a flatlist of the contents of the repo."""
+    def list_repo_contents(self, recursive=True):
+        """Returns a flat list of the contents of the repo."""
         content_url = f"https://api.github.com/repos/{self.user}/{self.name}/git/trees/{self.ref}?recursive={int(recursive)}"
         resp = requests.get(content_url).json()
         if "message" in resp:

--- a/tests/unittests/plugins/core_tests.py
+++ b/tests/unittests/plugins/core_tests.py
@@ -119,7 +119,7 @@ def mock_plugin_package_name(plugin_name, plugin_path):
         plugin_name = "test-plugin1-name"
     if not plugin_path:
         plugin_path = "path/to/plugin"
-    return fop.core.plugin_package(plugin_name, plugin_path)
+    return fop.core.PluginPackage(plugin_name, plugin_path)
 
 
 def test_find_plugin_error_duplicate_name(mocker, fiftyone_plugins_dir):
@@ -127,7 +127,7 @@ def test_find_plugin_error_duplicate_name(mocker, fiftyone_plugins_dir):
 
     plugin_name = "test-plugin1"
     dup_plugin_dir = fiftyone_plugins_dir / "test-plugin2"
-    m = mock.Mock(spec=fop.core.plugin_package(plugin_name, "path/to/plugin"))
+    m = mock.Mock(spec=fop.core.PluginPackage(plugin_name, "path/to/plugin"))
     with open(os.path.join(dup_plugin_dir, "fiftyone.yml"), "w") as f:
         pd = {k: plugin_name + "-" + k for k in _REQUIRED_YML_KEYS}
         f.write(yaml.dump(pd))

--- a/tests/unittests/plugins/core_tests.py
+++ b/tests/unittests/plugins/core_tests.py
@@ -38,7 +38,8 @@ def test_enable_plugin(mocker, app_config_path):
     fop.enable_plugin("my-plugin")
     with open(app_config_path, "r") as f:
         config = json.load(f)
-    assert config["plugins"]["my-plugin"]["enabled"] == True
+
+    assert config["plugins"].get("my-plugin", {}).get("enabled", True) == True
 
 
 def test_disable_plugin(mocker, app_config_path):
@@ -53,13 +54,12 @@ def test_disable_plugin(mocker, app_config_path):
 
 def test_delete_plugin_success(mocker, fiftyone_plugins_dir):
     mocker.patch("fiftyone.config.plugins_dir", fiftyone_plugins_dir)
-    print(os.listdir(fiftyone_plugins_dir))
     assert fo.config.plugins_dir == fiftyone_plugins_dir
+    print(os.listdir(fiftyone_plugins_dir))
 
 
 def test_list_downloaded_plugins(mocker, fiftyone_plugins_dir):
     mocker.patch("fiftyone.config.plugins_dir", fiftyone_plugins_dir)
-    mocker.patch("fiftyone.plugins.core._PLUGIN_DIRS", [fiftyone_plugins_dir])
     assert fo.config.plugins_dir == fiftyone_plugins_dir
 
     actual = fop.list_downloaded_plugins()
@@ -70,10 +70,8 @@ def test_list_downloaded_plugins(mocker, fiftyone_plugins_dir):
     assert set(actual) == set(expected)
 
 
-#
 def test_list_enabled_plugins(mocker, fiftyone_plugins_dir):
     mocker.patch("fiftyone.config.plugins_dir", fiftyone_plugins_dir)
-    mocker.patch("fiftyone.plugins.core._PLUGIN_DIRS", [fiftyone_plugins_dir])
     assert fo.config.plugins_dir == fiftyone_plugins_dir
 
     # enable all
@@ -99,7 +97,7 @@ def test_list_enabled_plugins(mocker, fiftyone_plugins_dir):
 
 
 def test_find_plugin_success(mocker, fiftyone_plugins_dir):
-    mocker.patch("fiftyone.plugins.core._PLUGIN_DIRS", [fiftyone_plugins_dir])
+    mocker.patch("fiftyone.config.plugins_dir", fiftyone_plugins_dir)
     plugin_name = _DEFAULT_TEST_PLUGINS[0] + "-name"
     actual_path = fop.find_plugin(plugin_name)
     expected_path = os.path.join(
@@ -108,9 +106,8 @@ def test_find_plugin_success(mocker, fiftyone_plugins_dir):
     assert actual_path == expected_path
 
 
-#
 def test_find_plugin_error_not_found(mocker, fiftyone_plugins_dir):
-    mocker.patch("fiftyone.plugins.core._PLUGIN_DIRS", [fiftyone_plugins_dir])
+    mocker.patch("fiftyone.config.plugins_dir", fiftyone_plugins_dir)
     plugin_dir_name = _DEFAULT_TEST_PLUGINS[0]
     with pytest.raises(ValueError):
         _ = fop.find_plugin(plugin_dir_name)
@@ -125,13 +122,11 @@ def mock_plugin_package_name(plugin_name, plugin_path):
     return fop.core.plugin_package(plugin_name, plugin_path)
 
 
-def test_find_plugin_error_duplicate_name(
-    mocker,
-    fiftyone_plugins_dir,
-):
+def test_find_plugin_error_duplicate_name(mocker, fiftyone_plugins_dir):
+    mocker.patch("fiftyone.config.plugins_dir", fiftyone_plugins_dir)
+
     plugin_name = "test-plugin1"
     dup_plugin_dir = fiftyone_plugins_dir / "test-plugin2"
-    mocker.patch("fiftyone.plugins.core._PLUGIN_DIRS", [fiftyone_plugins_dir])
     m = mock.Mock(spec=fop.core.plugin_package(plugin_name, "path/to/plugin"))
     with open(os.path.join(dup_plugin_dir, "fiftyone.yml"), "w") as f:
         pd = {k: plugin_name + "-" + k for k in _REQUIRED_YML_KEYS}


### PR DESCRIPTION
## Change log

Main updates
- Added `fiftyone plugins create` command to CLI
- Show plugin enabled status in `fiftyone plugins list`
- Adds optional `outdir` parameter to `creeate_plugin()` to create plugins in custom directories, if desired
- Adds a `plugin_names` parameter to `download_plugin()` to download specific plugins by name
- Entire interface now allows for `fiftyone.yaml` or `fiftyone.yml`
- Move `GitHubRepository` to `fiftyone.utils.github` as it is a general purpose utility
- Exposed all relevant function parameters in CLI
- Added CLI documentation for all new methods

Other things I encountered while making above changes:
- Fixed bugs
- Remove deprecated/unused/duplicate methods
- General implementation cleanup

## Example usages

```shell
fiftyone plugins list

# Create a plugin
fiftyone plugins create test
fiftyone plugins list

# Disable a plugin
fiftyone plugins disable test
fiftyone app config
fiftyone plugins list

# Enable a plugin
fiftyone plugins enable test
fiftyone app config
fiftyone plugins list

# Delete a plugin
fiftyone plugins delete test
fiftyone app config
fiftyone plugins list

# Download a plugin from a private repo
export GITHUB_TOKEN=XXXXXXXX
fiftyone plugins download https://github.com/voxel51/fiftyone-gpt
fiftyone plugins list

# Download specific plugins from a GitHub repository
fiftyone plugins download \
    https://github.com/voxel51/fiftyone-plugins \
    -n '@voxel51/examples'
fiftyone plugins list
```
