### PR TITLE
Fix sort by similarity for datasets with field info

### DIFF
--- a/fiftyone/core/state.py
+++ b/fiftyone/core/state.py
@@ -10,6 +10,7 @@ import json
 import logging
 import typing as t
 
+from mongoengine.base import BaseDict
 import strawberry as gql
 
 import eta.core.serial as etas
@@ -233,7 +234,9 @@ def serialize_fields(schema: t.Dict) -> t.List[SampleField]:
                     embedded_doc_type=embedded_doc_type,
                     subfield=subfield,
                     description=field.description,
-                    info=field.info,
+                    info=dict(**field.info)
+                    if isinstance(field.info, BaseDict)
+                    else field.info,
                 )
             )
 


### PR DESCRIPTION
Currently, sort by similarity fails to serialize the dataset when field info is defined.

```py
import fiftyone as fo
import fiftyone.brain as fob
import fiftyone.zoo as foz

dataset = foz.load_zoo_dataset("quickstart")

# Index images by similarity
image_index = fob.compute_similarity(
    dataset,
    model="clip-vit-base32-torch",
    brain_key="img_sim",
)

field = dataset.get_field("ground_truth")
field.info = {"test": 51}
field.save() 
```