### PR TITLE
fix a side effect from fixing video frames issue on the metadata fiel…

### DIFF
--- a/app/packages/state/src/recoil/color.ts
+++ b/app/packages/state/src/recoil/color.ts
@@ -76,14 +76,17 @@ export const pathColor = selectorFamily<
     ({ modal, path }) =>
     ({ get }) => {
       // video path tweak
+      const field = get(schemaAtoms.field(path));
       const video = get(selectors.mediaTypeSelector) !== "image";
       const parentPath =
         video && path.startsWith("frames.")
           ? path.split(".").slice(0, 2).join(".")
           : path.split(".")[0];
-      const adjustedPath = parentPath.startsWith("frames.")
-        ? parentPath.slice("frames.".length)
-        : parentPath;
+      const adjustedPath = field?.embeddedDocType
+        ? parentPath.startsWith("frames.")
+          ? parentPath.slice("frames.".length)
+          : parentPath
+        : path;
 
       const setting = get(
         atoms.sessionColorScheme


### PR DESCRIPTION
Earlier the tweak to fix a bug related to `frames.detections` field in color setting had a side effect on `meta` fields display in the sidebar. This fix the sidebar drag bar color issue of meta fields. 

<img width="612" alt="Screenshot 2023-05-15 at 5 56 25 PM" src="https://github.com/voxel51/fiftyone/assets/17770824/f331ec7a-5a78-4dd1-9712-df51961ad240">

## What changes are proposed in this pull request?

(Please fill in changes proposed in this fix)

## How is this patch tested? If it is not, please explain why.

(Details)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
