### PR TITLE
Fix plugin route

### DIFF
--- a/fiftyone/server/routes/plugins.py
+++ b/fiftyone/server/routes/plugins.py
@@ -15,4 +15,4 @@ from fiftyone.plugins import list_plugins
 class Plugins(HTTPEndpoint):
     @route
     async def get(self, request: Request, data: dict):
-        return {"plugins": pd.to_dict() for pd in list_plugins()}
+        return {"plugins": [pd.to_dict() for pd in list_plugins()]}


### PR DESCRIPTION
Fixes recent refactor regressed the contract for `GET /plugins` which should return `{plugins: []}`.

Note: this is not an issue in other form factors (teams).