### PR TITLE
add initial jsdocs to operator types

### DIFF
--- a/app/gen-docs.js
+++ b/app/gen-docs.js
@@ -972,6 +972,17 @@ class DocCommentTag extends DocFragment {
   }
 }
 
+class DocCommentLink extends DocFragment {
+  link() {
+    const text = this.get("text");
+    const [ref, label] = text.split("|");
+    return `:js:class:\`${label || ref} <${ref}>\``;
+  }
+  static isInlineLink(raw) {
+    return raw.kind === "inline-tag" && raw.tag === "@link";
+  }
+}
+
 class DocComment extends DocFragment {
   static kind = () => "Comment";
   summary() {
@@ -982,7 +993,13 @@ class DocComment extends DocFragment {
         new DocCommentBlock(
           {
             kind: "text",
-            text: raw.map((r) => r.text).join(""),
+            text: raw
+              .map((r) => {
+                if (DocCommentLink.isInlineLink(r))
+                  return new DocCommentLink(r, this).link();
+                return r.text;
+              })
+              .join(""),
           },
           this
         ),

--- a/app/typedoc.js
+++ b/app/typedoc.js
@@ -1,4 +1,11 @@
-const packages = ["plugins", "state", "aggregations", "utilities", "relay"];
+const packages = [
+  "plugins",
+  "state",
+  "aggregations",
+  "utilities",
+  "relay",
+  "operators",
+];
 
 /**
  * @type {import('typedoc').TypeDocOptions}

--- a/docs/source/plugins/ts-api.rst
+++ b/docs/source/plugins/ts-api.rst
@@ -4,6 +4,7 @@
    Typescript API <self>
       @fiftyone/state <api/fiftyone.state>
       @fiftyone/plugins <api/fiftyone.plugins>
+      @fiftyone/operators <api/fiftyone.operators>
       @fiftyone/aggregations <api/fiftyone.aggregations>
       @fiftyone/relay <api/fiftyone.relay>
       @fiftyone/utils <api/fiftyone.utils>


### PR DESCRIPTION
## What changes are proposed in this pull request?

(Please fill in changes proposed in this fix)

## How is this patch tested? If it is not, please explain why.

(Details)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
