### PR TITLE
[HOLD] Raise error for no dataset name

### DIFF
--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -257,8 +257,11 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
         _virtual=False,
         **kwargs,
     ):
-        if name is None and _create:
-            name = get_default_dataset_name()
+        if name is None:
+            if _create:
+                name = get_default_dataset_name()
+            else:
+                raise ValueError("Dataset `name` is required")
 
         if overwrite and dataset_exists(name):
             delete_dataset(name)


### PR DESCRIPTION
## What changes are proposed in this pull request?

Raise an error for attempts to load a Dataset without providing a name to prevent any further operations that may lead to upserting a dataset document with no name.