### PR TITLE
Plugins support symlinks

### DIFF
--- a/fiftyone/server/app.py
+++ b/fiftyone/server/app.py
@@ -100,7 +100,10 @@ app = Starlette(
         Mount(
             "/plugins",
             app=Static(
-                directory=fo.config.plugins_dir, html=True, check_dir=False
+                directory=fo.config.plugins_dir,
+                html=True,
+                check_dir=False,
+                follow_symlink=True,
             ),
             name="plugins",
         ),

--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ INSTALL_REQUIRES = [
     "setuptools",
     "sseclient-py>=1.7.2,<2",
     "sse-starlette>=0.10.3,<1",
-    "starlette>=0.20.4,<0.27",
+    "starlette>=0.24.0,<0.27",
     "strawberry-graphql==0.138.1",
     "tabulate",
     "xmltodict",


### PR DESCRIPTION
This is needed to fully support symlinks for plugin directories. Note: this also requires min version of 0.24.0 of starlette.