### PR TITLE
view modal width and palette base style fixes

### DIFF
--- a/app/packages/operators/src/OperatorPalette.tsx
+++ b/app/packages/operators/src/OperatorPalette.tsx
@@ -28,7 +28,6 @@ export default function OperatorPalette(props: OperatorPaletteProps) {
     onClose,
     submitButtonText = "Execute",
     cancelButtonText = "Cancel",
-    maxWidth = "lg",
     onOutsideClick,
     allowPropagation,
     submitOnControlEnter,
@@ -76,39 +75,39 @@ export default function OperatorPalette(props: OperatorPaletteProps) {
   }, [paletteElem, keyDownHandler]);
 
   return (
-    <BaseStylesProvider>
-      <Dialog
-        open
-        onClose={onClose || onOutsideClick}
-        scroll={scroll}
-        maxWidth={false}
-        aria-labelledby=""
-        aria-describedby="scroll-dialog-description"
-        PaperProps={{ sx: { backgroundImage: "none" } }}
+    <Dialog
+      open
+      onClose={onClose || onOutsideClick}
+      scroll={scroll}
+      maxWidth={false}
+      aria-labelledby=""
+      aria-describedby="scroll-dialog-description"
+      PaperProps={{ sx: { backgroundImage: "none" } }}
+      sx={{
+        "& .MuiDialog-container": {
+          alignItems: "flex-start",
+        },
+      }}
+    >
+      {title && (
+        <DialogTitle component="div" sx={{ p: 1 }}>
+          <BaseStylesProvider>{title}</BaseStylesProvider>
+        </DialogTitle>
+      )}
+      <DialogContent
+        dividers={scroll === "paper"}
+        className={scrollable}
         sx={{
-          "& .MuiDialog-container": {
-            alignItems: "flex-start",
-          },
+          p: 1,
+          ...(hideActions ? { borderBottom: "none" } : {}),
+          ...(title ? {} : { borderTop: "none" }),
         }}
       >
-        {title && (
-          <DialogTitle component="div" sx={{ p: 1 }}>
-            {title}
-          </DialogTitle>
-        )}
-        <DialogContent
-          dividers={scroll === "paper"}
-          className={scrollable}
-          sx={{
-            p: 1,
-            ...(hideActions ? { borderBottom: "none" } : {}),
-            ...(title ? {} : { borderTop: "none" }),
-          }}
-        >
-          {children}
-        </DialogContent>
-        {!hideActions && (
-          <DialogActions sx={{ p: 1 }}>
+        <BaseStylesProvider>{children}</BaseStylesProvider>
+      </DialogContent>
+      {!hideActions && (
+        <DialogActions sx={{ p: 1 }}>
+          <BaseStylesProvider>
             {onCancel && (
               <Button onClick={onCancel} onKeyDown={onEnter(onCancel)}>
                 {cancelButtonText}
@@ -123,10 +122,10 @@ export default function OperatorPalette(props: OperatorPaletteProps) {
                 {submitButtonText}
               </Button>
             )}
-          </DialogActions>
-        )}
-      </Dialog>
-    </BaseStylesProvider>
+          </BaseStylesProvider>
+        </DialogActions>
+      )}
+    </Dialog>
   );
 }
 

--- a/app/packages/operators/src/OperatorPrompt.tsx
+++ b/app/packages/operators/src/OperatorPrompt.tsx
@@ -103,7 +103,9 @@ export function OperatorViewModal() {
 
   return createPortal(
     <OperatorPalette onSubmit={io.hide} submitButtonText="Done">
-      <OperatorIO schema={io.schema} data={io.data || {}} type={io.type} />
+      <PaletteContentContainer>
+        <OperatorIO schema={io.schema} data={io.data || {}} type={io.type} />
+      </PaletteContentContainer>
     </OperatorPalette>,
     document.body
   );


### PR DESCRIPTION
## What changes are proposed in this pull request?

Fixes view modal width and style for the operator palette

## How is this patch tested? If it is not, please explain why.

(Details)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
