### PR TITLE
Remove redundant dataset serialization in server events

### DIFF
--- a/fiftyone/server/events.py
+++ b/fiftyone/server/events.py
@@ -95,16 +95,6 @@ async def add_event_listener(
                 StateUpdate(state=data.state),
                 dict_factory=dict_factory,
             )
-            if data.state.dataset is not None:
-                d["dataset"] = await serialize_dataset(
-                    dataset_name=data.state.dataset.name,
-                    serialized_view=data.state.view._serialize()
-                    if data.state.view is not None
-                    else [],
-                    saved_view_slug=fou.to_slug(data.state.view.name)
-                    if data.state.view is not None and data.state.view.name
-                    else None,
-                )
 
             yield ServerSentEvent(
                 event=StateUpdate.get_event_name(),
@@ -127,24 +117,8 @@ async def add_event_listener(
 
             events = sorted(events, key=lambda event: event[0])
 
-            for (_, event) in events:
+            for _, event in events:
                 d = asdict(event, dict_factory=dict_factory)
-
-                if (
-                    data.is_app
-                    and isinstance(event, StateUpdate)
-                    and event.state.dataset is not None
-                ):
-                    d["dataset"] = await serialize_dataset(
-                        dataset_name=event.state.dataset.name,
-                        serialized_view=event.state.view._serialize()
-                        if event.state.view is not None
-                        else [],
-                        saved_view_slug=fou.to_slug(event.state.view.name)
-                        if event.state.view is not None
-                        and event.state.view.name
-                        else None,
-                    )
 
                 yield ServerSentEvent(
                     event=event.get_event_name(),

--- a/fiftyone/server/events.py
+++ b/fiftyone/server/events.py
@@ -91,14 +91,14 @@ async def add_event_listener(
     data = await _initialize_listener(payload)
     try:
         if data.is_app:
-            d = asdict(
-                StateUpdate(state=data.state),
-                dict_factory=dict_factory,
-            )
-
             yield ServerSentEvent(
                 event=StateUpdate.get_event_name(),
-                data=FiftyOneJSONEncoder.dumps(d),
+                data=FiftyOneJSONEncoder.dumps(
+                    asdict(
+                        StateUpdate(state=data.state),
+                        dict_factory=dict_factory,
+                    )
+                ),
             )
 
         while True:
@@ -118,11 +118,11 @@ async def add_event_listener(
             events = sorted(events, key=lambda event: event[0])
 
             for _, event in events:
-                d = asdict(event, dict_factory=dict_factory)
-
                 yield ServerSentEvent(
                     event=event.get_event_name(),
-                    data=FiftyOneJSONEncoder.dumps(d),
+                    data=FiftyOneJSONEncoder.dumps(
+                        asdict(event, dict_factory=dict_factory)
+                    ),
                 )
 
             await asyncio.sleep(0.2)


### PR DESCRIPTION
Dataset serialization is already handled by state description serialization in the[ `dict_factory`'s](https://github.com/voxel51/fiftyone/blob/4bc4cf46bd3ccbe435cb8de3305573e8bf2a8d5c/fiftyone/core/session/events.py#L134) call to `StateDescription.serialize()`