### PR TITLE
add guards for invalid location or dimension in cuboid.tsx

### DIFF
--- a/app/packages/looker-3d/src/overlays/cuboid.tsx
+++ b/app/packages/looker-3d/src/overlays/cuboid.tsx
@@ -21,6 +21,13 @@ export const Cuboid = ({
   color,
   useLegacyCoordinates,
 }: CuboidProps) => {
+  const geo = React.useMemo(
+    () => dimensions && new THREE.BoxGeometry(...dimensions),
+    [dimensions]
+  );
+
+  if (!location || !dimensions) return null;
+
   const [x, y, z] = location;
 
   // @todo: add comment to add more context on what legacy coordinates means
@@ -31,11 +38,6 @@ export const Cuboid = ({
   const itemRotationVec = new THREE.Vector3(...itemRotation);
   const resolvedRotation = new THREE.Vector3(...rotation);
   const actualRotation = resolvedRotation.add(itemRotationVec).toArray();
-
-  const geo = React.useMemo(
-    () => new THREE.BoxGeometry(...dimensions),
-    [dimensions]
-  );
 
   return (
     <>


### PR DESCRIPTION
## What changes are proposed in this pull request?

add guards for invalid location or dimension in cuboid.tsx

## How is this patch tested? If it is not, please explain why.

Locally

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
