### PR TITLE
bugfix: fix a frames related issue

### DIFF
--- a/app/packages/core/src/components/ColorModal/ColorModal.tsx
+++ b/app/packages/core/src/components/ColorModal/ColorModal.tsx
@@ -1,5 +1,4 @@
 import * as fos from "@fiftyone/state";
-import { useOutsideClick } from "@fiftyone/state";
 import { Field } from "@fiftyone/utilities";
 import CloseIcon from "@mui/icons-material/Close";
 import React, { Fragment, useCallback, useRef, useState } from "react";
@@ -82,7 +81,6 @@ const ColorModal = () => {
               onResizeStop={(e, direction, ref, { width: dw, height: dh }) => {
                 setWidth(width + dw);
                 setHeight(height + dh);
-                // reset sidebar width on double click
                 if (e.detail === 2) {
                   setWidth(860);
                   setHeight(680);
@@ -126,7 +124,7 @@ const ColorModal = () => {
                     {field === ACTIVE_FIELD.global && <GlobalSetting />}
                     {field === ACTIVE_FIELD.json && <JSONViewer />}
                     {typeof field !== "string" && field && (
-                      <FieldSetting field={activeColorModalField as Field} />
+                      <FieldSetting prop={activeColorModalField} />
                     )}
                   </Display>
                 </DraggableContent>

--- a/app/packages/core/src/components/ColorModal/FieldSetting.tsx
+++ b/app/packages/core/src/components/ColorModal/FieldSetting.tsx
@@ -31,7 +31,7 @@ import ModeControl from "./controls/ModeControl";
 import { resetColor } from "./ColorFooter";
 
 type Prop = {
-  field: Field;
+  prop: { field: Field; expandedPath: string };
 };
 
 type State = {
@@ -39,9 +39,10 @@ type State = {
   useFieldColor: boolean;
 };
 
-const FieldSetting: React.FC<Prop> = ({ field }) => {
+const FieldSetting: React.FC<Prop> = ({ prop }) => {
   const colorContainer: React.RefObject<HTMLDivElement> = React.createRef();
-  const path = field.path;
+  const { field, expandedPath } = prop;
+  const path = field?.path;
   const { colorPool, fields } = useRecoilValue(fos.sessionColorScheme);
   const setting = (fields ?? []).find((x) => x.path == path!);
   const setColorScheme = fos.useSetSessionColorScheme();
@@ -59,7 +60,6 @@ const FieldSetting: React.FC<Prop> = ({ field }) => {
 
   const defaultColor =
     coloring.pool[Math.floor(Math.random() * coloring.pool.length)];
-  const expandedPath = useRecoilValue(fos.expandPath(path!));
   const VALID_COLOR_ATTRIBUTE_TYPES = [BOOLEAN_FIELD, INT_FIELD, STRING_FIELD];
 
   const isMaskType =
@@ -69,10 +69,14 @@ const FieldSetting: React.FC<Prop> = ({ field }) => {
   const isTypeValueSupported =
     !isMaskType && !isNoShowType && !(field.ftype == FLOAT_FIELD);
   const isTypeFieldSupported = !isNoShowType;
+  // non video frames. field expanded path
+  const commonExpandedPath = useRecoilValue(
+    fos.expandPath(expandedPath.startsWith("frames.") ? expandedPath : path)
+  );
 
   const colorFields = useRecoilValue(
     fos.fields({
-      path: expandedPath,
+      path: commonExpandedPath,
       ftype: VALID_COLOR_ATTRIBUTE_TYPES,
     })
   ).filter((field) => field.dbField !== "tags");
@@ -264,7 +268,10 @@ const FieldSetting: React.FC<Prop> = ({ field }) => {
                 </>
               )}
 
-              <AttributeColorSetting style={FieldCHILD_STYLE} />
+              <AttributeColorSetting
+                style={FieldCHILD_STYLE}
+                useLabelColors={state.useLabelColors}
+              />
             </SectionWrapper>
           </form>
         </div>

--- a/app/packages/core/src/components/ColorModal/JSONViewer.tsx
+++ b/app/packages/core/src/components/ColorModal/JSONViewer.tsx
@@ -9,6 +9,7 @@ import { ActionOption } from "../Actions/Common";
 import { Button } from "../utils";
 import { SectionWrapper } from "./ShareStyledDiv";
 import { validateJSONSetting } from "./utils";
+import colorString from "color-string";
 
 const JSONViewer: React.FC = () => {
   const themeMode = useRecoilValue(fos.theme);
@@ -41,7 +42,9 @@ const JSONViewer: React.FC = () => {
     )
       return;
     const { colorPool, fields } = data;
-    const validColors = colorPool?.filter((c) => isValidColor(c));
+    const validColors = colorPool
+      ?.filter((c) => isValidColor(c))
+      .map((c) => colorString.to.hex(colorString.get(c).value));
     const validatedSetting = validateJSONSetting(fields);
     setData({
       colorPool: validColors,

--- a/app/packages/core/src/components/ColorModal/SidebarList.tsx
+++ b/app/packages/core/src/components/ColorModal/SidebarList.tsx
@@ -35,10 +35,10 @@ const SidebarList: React.FC = () => {
     ({ set, snapshot }) =>
       async (path: string) => {
         if ([ACTIVE_FIELD.global, ACTIVE_FIELD.json].includes(path)) {
-          set(fos.activeColorField, path);
+          set(fos.activeColorField, path as "global" | "json");
         } else {
           const field = await snapshot.getPromise(fos.field(path));
-          set(fos.activeColorField, field);
+          set(fos.activeColorField, { field, expandedPath: path });
         }
       },
     []
@@ -47,7 +47,7 @@ const SidebarList: React.FC = () => {
   const getCurrentField = (activeField) => {
     if (activeField === ACTIVE_FIELD.global) return ACTIVE_FIELD.global;
     if (activeField === ACTIVE_FIELD.json) return ACTIVE_FIELD.json;
-    return activeField?.path;
+    return activeField?.expandedPath;
   };
   return (
     <Resizable

--- a/app/packages/core/src/components/ColorModal/colorPalette/AttributeColorSetting.tsx
+++ b/app/packages/core/src/components/ColorModal/colorPalette/AttributeColorSetting.tsx
@@ -70,14 +70,15 @@ const AttributeColorSetting: React.FC<ColorPickerRowProps> = ({
 }) => {
   const pickerRef = useRef<HTMLDivElement>(null);
   const activeField = useRecoilValue(fos.activeColorField);
+  const activePath = useMemo(() => activeField.field.path, [activeField]);
   const { colorPool, fields } = useRecoilValue(fos.sessionColorScheme);
   const setColorScheme = fos.useSetSessionColorScheme();
   const setting = useMemo(
-    () => fields.find((s) => s.path == activeField.field.path),
+    () => fields.find((s) => s.path == activePath),
     [activeField, fields]
   );
   const index = useMemo(
-    () => fields.findIndex((s) => s.path == activeField.field.path),
+    () => fields.findIndex((s) => s.path == activePath),
     [activeField, fields]
   );
 
@@ -169,7 +170,7 @@ const AttributeColorSetting: React.FC<ColorPickerRowProps> = ({
   useEffect(() => {
     if (!values) {
       const copy = cloneDeep(fields);
-      const idx = fields.findIndex((s) => s.path == activeField.field.path);
+      const idx = fields.findIndex((s) => s.path == activePath);
       if (idx > -1) {
         copy[idx].valueColors = [defaultValue];
         setColorScheme(false, { colorPool, fields: copy });
@@ -182,7 +183,7 @@ const AttributeColorSetting: React.FC<ColorPickerRowProps> = ({
   useEffect(() => {
     setInput(values ?? []);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [useRecoilValue(resetColor), activeField.field.path]);
+  }, [useRecoilValue(resetColor), activePath]);
 
   useEffect(() => {
     if (!useLabelColors) setInput([]);

--- a/app/packages/core/src/components/ColorModal/colorPalette/AttributeColorSetting.tsx
+++ b/app/packages/core/src/components/ColorModal/colorPalette/AttributeColorSetting.tsx
@@ -56,6 +56,7 @@ const ChromePickerWrapper = styled.div`
 
 type ColorPickerRowProps = {
   style?: React.CSSProperties;
+  useLabelColors?: boolean;
 };
 
 type Input = {
@@ -63,17 +64,20 @@ type Input = {
   color: string;
 };
 
-const AttributeColorSetting: React.FC<ColorPickerRowProps> = ({ style }) => {
+const AttributeColorSetting: React.FC<ColorPickerRowProps> = ({
+  style,
+  useLabelColors,
+}) => {
   const pickerRef = useRef<HTMLDivElement>(null);
   const activeField = useRecoilValue(fos.activeColorField);
   const { colorPool, fields } = useRecoilValue(fos.sessionColorScheme);
   const setColorScheme = fos.useSetSessionColorScheme();
   const setting = useMemo(
-    () => fields.find((s) => s.path == (activeField as Field).path),
+    () => fields.find((s) => s.path == activeField.field.path),
     [activeField, fields]
   );
   const index = useMemo(
-    () => fields.findIndex((s) => s.path == (activeField as Field).path),
+    () => fields.findIndex((s) => s.path == activeField.field.path),
     [activeField, fields]
   );
 
@@ -165,9 +169,7 @@ const AttributeColorSetting: React.FC<ColorPickerRowProps> = ({ style }) => {
   useEffect(() => {
     if (!values) {
       const copy = cloneDeep(fields);
-      const idx = fields.findIndex(
-        (s) => s.path == (activeField as Field).path
-      );
+      const idx = fields.findIndex((s) => s.path == activeField.field.path);
       if (idx > -1) {
         copy[idx].valueColors = [defaultValue];
         setColorScheme(false, { colorPool, fields: copy });
@@ -178,15 +180,19 @@ const AttributeColorSetting: React.FC<ColorPickerRowProps> = ({ style }) => {
 
   // on reset, sync local state with new session values
   useEffect(() => {
-    setInput(values);
+    setInput(values ?? []);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [useRecoilValue(resetColor)]);
+  }, [useRecoilValue(resetColor), activeField.field.path]);
+
+  useEffect(() => {
+    if (!useLabelColors) setInput([]);
+  }, [useLabelColors]);
 
   if (!values) return null;
 
   return (
     <div style={style}>
-      {input.map((v, index) => (
+      {input?.map((v, index) => (
         <RowContainer key={index}>
           <Input
             placeholder="Value (e.g. 'car')"

--- a/app/packages/core/src/components/ColorModal/controls/ColorAttribute.tsx
+++ b/app/packages/core/src/components/ColorModal/controls/ColorAttribute.tsx
@@ -44,7 +44,7 @@ const ColorAttribute: React.FC<Prop> = ({ eligibleFields, style }) => {
   const [mRef, bounds] = useMeasure();
 
   const setColorScheme = fos.useSetSessionColorScheme();
-  const activeField = useRecoilValue(fos.activeColorField) as Field;
+  const activeField = useRecoilValue(fos.activeColorField).field as Field;
   const { colorPool, fields } = useRecoilValue(fos.sessionColorScheme);
   const index = fields.findIndex((s) => s.path == activeField.path);
 

--- a/app/packages/core/src/components/ColorModal/controls/OpacityAttribute.tsx
+++ b/app/packages/core/src/components/ColorModal/controls/OpacityAttribute.tsx
@@ -39,7 +39,7 @@ const OpacityAttribute: React.FC<Prop> = ({ fields }) => {
   const [open, setOpen] = React.useState(false);
   useOutsideClick(ref, () => open && setOpen(false));
   const [mRef, bounds] = useMeasure();
-  const field = useRecoilValue(fos.activeColorField) as Field;
+  const field = useRecoilValue(fos.activeColorField).field as Field;
   const setting = useRecoilValue(fos.sessionColorScheme)?.fields?.find(
     (f) => f.path === field.path
   );

--- a/app/packages/core/src/components/FieldLabelAndInfo/index.tsx
+++ b/app/packages/core/src/components/FieldLabelAndInfo/index.tsx
@@ -263,7 +263,7 @@ function FieldInfoExpanded({
   const colorBy = colorSettings.by;
   const onClickCustomizeColor = () => {
     // open the color customization modal based on colorBy status
-    setIsCustomizingColor(field);
+    setIsCustomizingColor({ field, expandedPath });
   };
 
   const isNotTag = field.path !== "tags";

--- a/app/packages/core/src/components/Sidebar/Entries/FilterablePathEntry.tsx
+++ b/app/packages/core/src/components/Sidebar/Entries/FilterablePathEntry.tsx
@@ -48,11 +48,11 @@ import { KeypointSkeleton } from "@fiftyone/looker/src/state";
 import * as fos from "@fiftyone/state";
 
 import FieldLabelAndInfo from "../../FieldLabelAndInfo";
+import LabelFieldFilter from "../../Filters/LabelFieldFilter";
 import { NameAndCountContainer } from "../../utils";
 import { PathEntryCounts } from "./EntryCounts";
 import RegularEntry from "./RegularEntry";
 import { makePseudoField, pathIsExpanded } from "./utils";
-import LabelFieldFilter from "../../Filters/LabelFieldFilter";
 
 const FILTERS = {
   [BOOLEAN_FIELD]: BooleanFieldFilter,
@@ -281,9 +281,8 @@ const FilterableEntry = ({
     pathIsExpanded({ modal, path: expandedPath })
   );
   const Arrow = expanded ? KeyboardArrowUp : KeyboardArrowDown;
-  const color = disabled
-    ? theme.background.level2
-    : useRecoilValue(fos.pathColor({ path, modal }));
+  const activeColor = useRecoilValue(fos.pathColor({ path, modal }));
+  const color = disabled ? theme.background.level2 : activeColor;
   const fields = useRecoilValue(
     fos.fields({
       path: expandedPath,

--- a/app/packages/state/src/recoil/atoms.ts
+++ b/app/packages/state/src/recoil/atoms.ts
@@ -396,7 +396,9 @@ export const sessionSpaces = atom<SpaceNodeJSON>({
 });
 
 // the active field for customize color modal
-export const activeColorField = atom<Field | "global" | "json" | null>({
+export const activeColorField = atom<
+  { field: Field; expandedPath: string } | "global" | "json" | null
+>({
   key: "activeColorField",
   default: null,
 });


### PR DESCRIPTION

![Screenshot 2023-05-19 at 3 23 35 PM](https://github.com/voxel51/fiftyone/assets/17770824/ca588456-addf-4253-933b-ad4dd49afe43)

Fix a bug: previously colorbyattribute options failed to read frames.X fields attributes

## What changes are proposed in this pull request?

(Please fill in changes proposed in this fix)

## How is this patch tested? If it is not, please explain why.

(Details)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
