### PR TITLE
Schema field visibility bug fixes for datasets with frames and more

### DIFF
--- a/app/packages/core/src/components/Schema/SchemaSettings.tsx
+++ b/app/packages/core/src/components/Schema/SchemaSettings.tsx
@@ -1,5 +1,7 @@
-import React, { Fragment, useRef } from "react";
+import React, { Fragment, useCallback, useRef } from "react";
 import styled from "styled-components";
+
+import * as fos from "@fiftyone/state";
 
 import CloseIcon from "@mui/icons-material/Close";
 import { Box, Typography } from "@mui/material";
@@ -75,6 +77,22 @@ const SchemaSettings = () => {
   useOutsideClick(schemaModalRef, (_) => {
     close();
   });
+
+  const keyboardHandler = useCallback(
+    (e: KeyboardEvent) => {
+      const active = document.activeElement;
+      if (active?.tagName === "INPUT") {
+        if ((active as HTMLInputElement).type === "text") {
+          return;
+        }
+      }
+      if (e.key === "Escape") {
+        setSettingsModal({ open: false });
+      }
+    },
+    [setSettingsModal]
+  );
+  fos.useEventHandler(document, "keydown", keyboardHandler);
 
   const { open: isSettingsModalOpen } = settingModal || {};
   if (!isSettingsModalOpen) {

--- a/app/packages/core/src/components/Schema/SchemaSettings.tsx
+++ b/app/packages/core/src/components/Schema/SchemaSettings.tsx
@@ -84,7 +84,7 @@ const SchemaSettings = () => {
   const close = () => {
     setSearchTerm("");
     setSearchResults([]);
-    setSettingsModal({ ...settingModal, open: false });
+    setSettingsModal({ open: false });
     setSelectedPaths({ [datasetName]: new Set(lastAppliedPaths.selected) });
     setExcludedPaths({ [datasetName]: new Set(lastAppliedPaths.excluded) });
   };

--- a/app/packages/relay/src/queries/__generated__/viewSchemaFragment.graphql.ts
+++ b/app/packages/relay/src/queries/__generated__/viewSchemaFragment.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<e82807cf666ed1de0d6560ab526a0a33>>
+ * @generated SignedSource<<7ef0138316d531c3ab955081d6692334>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -11,14 +11,24 @@
 import { ReaderFragment, RefetchableFragment } from 'relay-runtime';
 import { FragmentRefs } from "relay-runtime";
 export type viewSchemaFragment$data = {
-  readonly schemaForViewStages: ReadonlyArray<{
-    readonly description: string | null;
-    readonly embeddedDocType: string | null;
-    readonly ftype: string;
-    readonly info: object | null;
-    readonly path: string;
-    readonly subfield: string | null;
-  }>;
+  readonly schemaForViewStages: {
+    readonly fieldSchema: ReadonlyArray<{
+      readonly description: string | null;
+      readonly embeddedDocType: string | null;
+      readonly ftype: string;
+      readonly info: object | null;
+      readonly path: string;
+      readonly subfield: string | null;
+    } | null>;
+    readonly frameFieldSchema: ReadonlyArray<{
+      readonly description: string | null;
+      readonly embeddedDocType: string | null;
+      readonly ftype: string;
+      readonly info: object | null;
+      readonly path: string;
+      readonly subfield: string | null;
+    } | null>;
+  } | null;
   readonly " $fragmentType": "viewSchemaFragment";
 };
 export type viewSchemaFragment$key = {
@@ -28,7 +38,52 @@ export type viewSchemaFragment$key = {
 
 import viewSchemaFragmentQuery_graphql from './viewSchemaFragmentQuery.graphql';
 
-const node: ReaderFragment = {
+const node: ReaderFragment = (function(){
+var v0 = [
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "path",
+    "storageKey": null
+  },
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "ftype",
+    "storageKey": null
+  },
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "subfield",
+    "storageKey": null
+  },
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "embeddedDocType",
+    "storageKey": null
+  },
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "info",
+    "storageKey": null
+  },
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "description",
+    "storageKey": null
+  }
+];
+return {
   "argumentDefinitions": [
     {
       "kind": "RootArgument",
@@ -63,51 +118,29 @@ const node: ReaderFragment = {
           "variableName": "viewStages"
         }
       ],
-      "concreteType": "SampleField",
+      "concreteType": "SchemaResult",
       "kind": "LinkedField",
       "name": "schemaForViewStages",
-      "plural": true,
+      "plural": false,
       "selections": [
         {
           "alias": null,
           "args": null,
-          "kind": "ScalarField",
-          "name": "path",
+          "concreteType": "SampleField",
+          "kind": "LinkedField",
+          "name": "fieldSchema",
+          "plural": true,
+          "selections": (v0/*: any*/),
           "storageKey": null
         },
         {
           "alias": null,
           "args": null,
-          "kind": "ScalarField",
-          "name": "ftype",
-          "storageKey": null
-        },
-        {
-          "alias": null,
-          "args": null,
-          "kind": "ScalarField",
-          "name": "subfield",
-          "storageKey": null
-        },
-        {
-          "alias": null,
-          "args": null,
-          "kind": "ScalarField",
-          "name": "embeddedDocType",
-          "storageKey": null
-        },
-        {
-          "alias": null,
-          "args": null,
-          "kind": "ScalarField",
-          "name": "info",
-          "storageKey": null
-        },
-        {
-          "alias": null,
-          "args": null,
-          "kind": "ScalarField",
-          "name": "description",
+          "concreteType": "SampleField",
+          "kind": "LinkedField",
+          "name": "frameFieldSchema",
+          "plural": true,
+          "selections": (v0/*: any*/),
           "storageKey": null
         }
       ],
@@ -117,7 +150,8 @@ const node: ReaderFragment = {
   "type": "Query",
   "abstractKey": null
 };
+})();
 
-(node as any).hash = "f0d986e992cfda1ea89e036a79e55e81";
+(node as any).hash = "b744bc5d77c4fb64ec357da7669d4f0f";
 
 export default node;

--- a/app/packages/relay/src/queries/__generated__/viewSchemaFragmentQuery.graphql.ts
+++ b/app/packages/relay/src/queries/__generated__/viewSchemaFragmentQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<53e1f2a36751db81d104e98860cb0ca7>>
+ * @generated SignedSource<<f83a98aea83bea88b16c38877616891c>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -33,6 +33,50 @@ var v0 = [
     "defaultValue": null,
     "kind": "LocalArgument",
     "name": "viewStages"
+  }
+],
+v1 = [
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "path",
+    "storageKey": null
+  },
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "ftype",
+    "storageKey": null
+  },
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "subfield",
+    "storageKey": null
+  },
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "embeddedDocType",
+    "storageKey": null
+  },
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "info",
+    "storageKey": null
+  },
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "description",
+    "storageKey": null
   }
 ];
 return {
@@ -71,51 +115,29 @@ return {
             "variableName": "viewStages"
           }
         ],
-        "concreteType": "SampleField",
+        "concreteType": "SchemaResult",
         "kind": "LinkedField",
         "name": "schemaForViewStages",
-        "plural": true,
+        "plural": false,
         "selections": [
           {
             "alias": null,
             "args": null,
-            "kind": "ScalarField",
-            "name": "path",
+            "concreteType": "SampleField",
+            "kind": "LinkedField",
+            "name": "fieldSchema",
+            "plural": true,
+            "selections": (v1/*: any*/),
             "storageKey": null
           },
           {
             "alias": null,
             "args": null,
-            "kind": "ScalarField",
-            "name": "ftype",
-            "storageKey": null
-          },
-          {
-            "alias": null,
-            "args": null,
-            "kind": "ScalarField",
-            "name": "subfield",
-            "storageKey": null
-          },
-          {
-            "alias": null,
-            "args": null,
-            "kind": "ScalarField",
-            "name": "embeddedDocType",
-            "storageKey": null
-          },
-          {
-            "alias": null,
-            "args": null,
-            "kind": "ScalarField",
-            "name": "info",
-            "storageKey": null
-          },
-          {
-            "alias": null,
-            "args": null,
-            "kind": "ScalarField",
-            "name": "description",
+            "concreteType": "SampleField",
+            "kind": "LinkedField",
+            "name": "frameFieldSchema",
+            "plural": true,
+            "selections": (v1/*: any*/),
             "storageKey": null
           }
         ],
@@ -124,16 +146,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "e977c7f98e83df0f47b63b26a056de21",
+    "cacheID": "7118f2ee6bf3a2a13e29bd0bc61b4bf0",
     "id": null,
     "metadata": {},
     "name": "viewSchemaFragmentQuery",
     "operationKind": "query",
-    "text": "query viewSchemaFragmentQuery(\n  $name: String!\n  $viewStages: BSONArray!\n) {\n  ...viewSchemaFragment\n}\n\nfragment viewSchemaFragment on Query {\n  schemaForViewStages(datasetName: $name, viewStages: $viewStages) {\n    path\n    ftype\n    subfield\n    embeddedDocType\n    info\n    description\n  }\n}\n"
+    "text": "query viewSchemaFragmentQuery(\n  $name: String!\n  $viewStages: BSONArray!\n) {\n  ...viewSchemaFragment\n}\n\nfragment viewSchemaFragment on Query {\n  schemaForViewStages(datasetName: $name, viewStages: $viewStages) {\n    fieldSchema {\n      path\n      ftype\n      subfield\n      embeddedDocType\n      info\n      description\n    }\n    frameFieldSchema {\n      path\n      ftype\n      subfield\n      embeddedDocType\n      info\n      description\n    }\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "f0d986e992cfda1ea89e036a79e55e81";
+(node as any).hash = "b744bc5d77c4fb64ec357da7669d4f0f";
 
 export default node;

--- a/app/packages/relay/src/queries/viewSchema.ts
+++ b/app/packages/relay/src/queries/viewSchema.ts
@@ -6,13 +6,24 @@ export default r(graphql`
   fragment viewSchemaFragment on Query
   @refetchable(queryName: "viewSchemaFragmentQuery") {
     schemaForViewStages(datasetName: $name, viewStages: $viewStages) {
-      path
-      ftype
-      subfield
-      embeddedDocType
-      info
-      description
-      subfield
+      fieldSchema {
+        path
+        ftype
+        subfield
+        embeddedDocType
+        info
+        description
+        subfield
+      }
+      frameFieldSchema {
+        path
+        ftype
+        subfield
+        embeddedDocType
+        info
+        description
+        subfield
+      }
     }
   }
 `);

--- a/app/packages/state/src/hooks/useSchemaSettings.ts
+++ b/app/packages/state/src/hooks/useSchemaSettings.ts
@@ -133,17 +133,17 @@ export const schemaSearchRestuls = atom<string[]>({
     ({ onSet, getPromise, setSelf }) => {
       onSet(async (newPaths = []) => {
         const viewSchema = await getPromise(viewSchemaState);
-        const schema = await getPromise(schemaState);
+        const fieldSchema = await getPromise(fieldSchemaState);
+        const combinedSchema = { ...fieldSchema, ...viewSchema };
 
         const greenPaths = [...newPaths]
           .filter(
             (path) =>
               path &&
-              (viewSchema?.[
+              combinedSchema?.[
                 path.startsWith("frames.") ? path.replace("frames.", "") : path
-              ]?.ftype ||
-                schema?.[path]?.ftype) &&
-              !skipField(path, viewSchema?.[path]?.ftype, viewSchema)
+              ]?.ftype &&
+              !skipField(path, combinedSchema?.[path]?.ftype, combinedSchema)
           )
           .map((path) =>
             path.startsWith("frames.") ? path.replace("frames.", "") : path
@@ -522,7 +522,7 @@ export default function useSchemaSettings() {
     let finalSchemaKeyByPath = {};
     if (dataset.mediaType === "video") {
       Object.keys(viewSchema).forEach((fieldPath) => {
-        finalSchemaKeyByPath[`frames.${fieldPath}`] = viewSchema[fieldPath];
+        finalSchemaKeyByPath[fieldPath] = viewSchema[fieldPath];
       });
       Object.keys(fieldSchema).forEach((fieldPath) => {
         finalSchemaKeyByPath[fieldPath] = fieldSchema[fieldPath];
@@ -649,9 +649,9 @@ export default function useSchemaSettings() {
         onCompleted: (data) => {
           if (data) {
             const { searchSelectFields = [] } = data;
-            const res = (searchSelectFields as string[]).map((p) =>
-              p.replace("._cls", "")
-            );
+            const res = (searchSelectFields as string[])
+              .map((p) => p.replace("._cls", ""))
+              .filter((pp) => !pp.startsWith("_"));
             setSearchResults(res);
             setSearchMetaFilter(object);
 

--- a/app/packages/state/src/hooks/useSchemaSettings.ts
+++ b/app/packages/state/src/hooks/useSchemaSettings.ts
@@ -618,7 +618,9 @@ export default function useSchemaSettings() {
         onCompleted: (data) => {
           if (data) {
             const { searchSelectFields = [] } = data;
-            const res = searchSelectFields as string[];
+            const res = (searchSelectFields as string[]).map((p) =>
+              p.replace("._cls", "")
+            );
             setSearchResults(res);
             setSearchMetaFilter(object);
 

--- a/app/packages/state/src/hooks/useSchemaSettings.ts
+++ b/app/packages/state/src/hooks/useSchemaSettings.ts
@@ -8,6 +8,7 @@ import {
   DETECTION_FIELD,
   DETECTION_FILED,
   DYNAMIC_EMBEDDED_DOCUMENT_FIELD,
+  DYNAMIC_EMBEDDED_DOCUMENT_FIELD_V2,
   EMBEDDED_DOCUMENT_FIELD,
   FRAME_SUPPORT_FIELD,
   Field,
@@ -266,11 +267,13 @@ export const excludedPathsState = atomFamily({
           ? finalGreenPaths.filter(
               (path) =>
                 !(
-                  // a top-level embedded document with dynamic embed type which
+                  // a top-level embedded document with dynamic embed type
                   (
                     combinedSchema[path]?.ftype === EMBEDDED_DOCUMENT_FIELD &&
-                    combinedSchema[path]?.embeddedDocType ===
-                      DYNAMIC_EMBEDDED_DOCUMENT_FIELD &&
+                    [
+                      DYNAMIC_EMBEDDED_DOCUMENT_FIELD,
+                      DYNAMIC_EMBEDDED_DOCUMENT_FIELD_V2,
+                    ].includes(combinedSchema[path]?.embeddedDocType) &&
                     (isVideo
                       ? !(
                           path.split(".").length === 2 &&

--- a/app/packages/utilities/src/index.ts
+++ b/app/packages/utilities/src/index.ts
@@ -296,6 +296,8 @@ export const EMBEDDED_DOCUMENT_FIELD =
   "fiftyone.core.fields.EmbeddedDocumentField";
 export const DYNAMIC_EMBEDDED_DOCUMENT_FIELD =
   "fiftyone.core.fields.DynamicEmbeddedDocumentField";
+export const DYNAMIC_EMBEDDED_DOCUMENT_FIELD_V2 =
+  "fiftyone.core.odm.embedded_document.DynamicEmbeddedDocument";
 export const FLOAT_FIELD = "fiftyone.core.fields.FloatField";
 export const FRAME_NUMBER_FIELD = "fiftyone.core.fields.FrameNumberField";
 export const FRAME_SUPPORT_FIELD = "fiftyone.core.fields.FrameSupportField";

--- a/app/schema.graphql
+++ b/app/schema.graphql
@@ -454,7 +454,7 @@ type Query {
   schemaForViewStages(
     datasetName: String!
     viewStages: BSONArray!
-  ): [SampleField!]!
+  ): SchemaResult
 }
 
 type RootAggregation implements Aggregation {
@@ -493,6 +493,11 @@ type SampleField {
   dbField: String
   description: String
   info: JSON
+}
+
+type SchemaResult {
+  fieldSchema: [SampleField]!
+  frameFieldSchema: [SampleField]!
 }
 
 input SampleFilter {

--- a/fiftyone/server/mutation.py
+++ b/fiftyone/server/mutation.py
@@ -440,11 +440,13 @@ class Mutation:
 
         state = get_state()
         dataset = state.dataset
+        isVideo = dataset.media_type == "video"
         if dataset is None:
             dataset = fod.load_dataset(dataset_name)
 
         try:
             view = dataset.select_fields(meta_filter=meta_filter)
+            print("\nmeta_filter\n", meta_filter)
         except Exception as e:
             try:
                 view = dataset.select_fields(meta_filter)
@@ -457,9 +459,7 @@ class Mutation:
             for stage in view._stages:
                 res += [
                     st
-                    for st in stage.get_selected_fields(
-                        view, frames=dataset.media_type == "video"
-                    )
+                    for st in stage.get_selected_fields(view, frames=isVideo)
                 ]
         except Exception as e:
             print("failed to get_selected_fields", e)

--- a/fiftyone/server/query.py
+++ b/fiftyone/server/query.py
@@ -363,6 +363,12 @@ class AppConfig:
 
 
 @gql.type
+class SchemaResult:
+    field_schema: t.List[SampleField]
+    frame_field_schema: t.List[SampleField]
+
+
+@gql.type
 class Query(fosa.AggregateQuery):
     aggregations = gql.field(resolver=aggregate_resolver)
 
@@ -457,27 +463,53 @@ class Query(fosa.AggregateQuery):
 
     @gql.field
     def schema_for_view_stages(
-        self, dataset_name: str, view_stages: BSONArray
-    ) -> t.List[SampleField]:
+        self,
+        dataset_name: str,
+        view_stages: BSONArray,
+    ) -> SchemaResult:
         try:
             ds = fod.load_dataset(dataset_name)
             if view_stages:
                 view = fov.DatasetView._build(ds, view_stages or [])
 
                 if ds.media_type == fom.VIDEO:
-                    return serialize_fields(
+                    frame_schema = serialize_fields(
                         view.get_frame_field_schema(flat=True)
                     )
+                    field_schema = serialize_fields(
+                        view.get_field_schema(flat=True)
+                    )
+                    return SchemaResult(
+                        field_schema=field_schema,
+                        frame_field_schema=frame_schema,
+                    )
 
-                return serialize_fields(view.get_field_schema(flat=True))
-
+                return SchemaResult(
+                    field_schema=serialize_fields(
+                        view.get_field_schema(flat=True)
+                    ),
+                    frame_field_schema=[],
+                )
             if ds.media_type == fom.VIDEO:
-                return serialize_fields(ds.get_frame_field_schema(flat=True))
+                frames_field_schema = serialize_fields(
+                    ds.get_frame_field_schema(flat=True)
+                )
+                field_schema = serialize_fields(ds.get_field_schema(flat=True))
+                return SchemaResult(
+                    field_schema=field_schema,
+                    frame_field_schema=frames_field_schema,
+                )
 
-            return serialize_fields(ds.get_field_schema(flat=True))
+            return SchemaResult(
+                field_schema=serialize_fields(ds.get_field_schema(flat=True)),
+                frame_field_schema=[],
+            )
         except Exception as e:
             print("failed to get schema for view stages", str(e))
-            return []
+            return SchemaResult(
+                field_schema=[],
+                frame_field_schema=[],
+            )
 
 
 def _flatten_fields(


### PR DESCRIPTION
## What changes are proposed in this pull request?

- [x] Fixes when you enable show-nested-fields toggle and (un)check top level fields. before it was not unselecting - now is
- [x] Fixes when you try to re-select a `frames.ANYTHING` field for datasets that have frames - before clicking on it would not select it
- [x] Fixes search for frame fields that result in field path suffixed with `._cls` for some reason
- [x] embeddedDocument types that are top level and have dynamic embedDocType are disappearing when unselected and applied.  
- [x] fix search for frames



## How is this patch tested? If it is not, please explain why.

(Details)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
