### PR TITLE
Fixing color scheme bugs

### DIFF
--- a/fiftyone/core/odm/dataset.py
+++ b/fiftyone/core/odm/dataset.py
@@ -172,7 +172,14 @@ class ColorScheme(EmbeddedDocument):
         # Store a custom color scheme for a dataset
         dataset.app_config.color_scheme = fo.ColorScheme(
             color_pool=["#ff0000", "#00ff00", "#0000ff", "pink", "yellowgreen"],
-            fields=[{'path': 'ground_truth', 'fieldColor': '#ff00ff', 'colorByAttribute': 'label' : [{'value': 'dog', 'color': 'yellow'}]}]
+            fields=[
+                {
+                    "path": "ground_truth",
+                    "fieldColor": "#ff00ff",
+                    "colorByAttribute": "label",
+                    "valueColors": [{"value": "dog", "color": "yellow"}],
+                }
+            ]
         )
         dataset.save()
 

--- a/fiftyone/core/session/session.py
+++ b/fiftyone/core/session/session.py
@@ -285,7 +285,7 @@ class Session(object):
             load
         spaces (None): an optional :class:`fiftyone.core.spaces.Space` instance
             defining a space configuration to load
-        color_scheme (None): an optional :class:`fiftyone.core.odm.dataset`
+        color_scheme (None): an optional :class:`fiftyone.core.odm.dataset.ColorScheme`
             defining a custom color scheme to use
         plots (None): an optional
             :class:`fiftyone.core.plots.manager.PlotManager` to connect to this

--- a/fiftyone/core/session/session.py
+++ b/fiftyone/core/session/session.py
@@ -285,7 +285,7 @@ class Session(object):
             load
         spaces (None): an optional :class:`fiftyone.core.spaces.Space` instance
             defining a space configuration to load
-        color_scheme (None): an optional :class:`fiftyone.core.ColorScheme`
+        color_scheme (None): an optional :class:`fiftyone.core.odm.dataset`
             defining a custom color scheme to use
         plots (None): an optional
             :class:`fiftyone.core.plots.manager.PlotManager` to connect to this

--- a/fiftyone/core/state.py
+++ b/fiftyone/core/state.py
@@ -20,7 +20,7 @@ import fiftyone as fo
 import fiftyone.core.clips as foc
 
 import fiftyone.core.dataset as fod
-import fiftyone.core.odm.dataset as food
+from fiftyone.core.odm.dataset import ColorScheme
 import fiftyone.core.media as fom
 import fiftyone.core.utils as fou
 import fiftyone.core.view as fov
@@ -40,7 +40,8 @@ class StateDescription(etas.Serializable):
         dataset (None): the current :class:`fiftyone.core.dataset.Dataset`
         selected (None): the list of currently selected samples
         selected_labels (None): the list of currently selected labels
-        spaces (None): spaces config
+        spaces (None): a :class:`fiftyone.core.spaces.Space`
+        color_scheme (None): a :class:`fiftyone.core.odm.dataset.ColorScheme`
         view (None): the current :class:`fiftyone.core.view.DatasetView`
         view_name (None): the name of the view if the current view is a
             saved view
@@ -52,8 +53,8 @@ class StateDescription(etas.Serializable):
         dataset=None,
         selected=None,
         selected_labels=None,
-        color_scheme=None,
         spaces=None,
+        color_scheme=None,
         view=None,
         view_name=None,
     ):
@@ -113,7 +114,7 @@ class StateDescription(etas.Serializable):
             if isinstance(self.spaces, Space):
                 d["spaces"] = self.spaces.to_json()
 
-            if isinstance(self.color_scheme, food.ColorScheme):
+            if isinstance(self.color_scheme, ColorScheme):
                 d["color_scheme"] = self.color_scheme.to_json()
 
             return d
@@ -170,13 +171,12 @@ class StateDescription(etas.Serializable):
         fo.config.timezone = d.get("config", {}).get("timezone", None)
 
         spaces = d.get("spaces", None)
-        color_scheme = d.get("color_scheme", None)
-
-        if color_scheme:
-            color_scheme = json_util.dumps(color_scheme)
-
         if spaces is not None:
             spaces = Space.from_dict(json_util.loads(spaces))
+
+        color_scheme = d.get("color_scheme", None)
+        if color_scheme:
+            color_scheme = ColorScheme.from_dict(json_util.loads(color_scheme))
 
         return cls(
             config=config,


### PR DESCRIPTION
Change log
- `launch_app()` with no `dataset` was previously raising an error due to color scheme parsing, but should be allowed
- `session.color_scheme` should always be presented as a `ColorScheme` object. Previously it was presented as a string when updates were made in the App
- By convention, `session.color_scheme = None` should be allowed as shorthand for reverting to the default color scheme
- `session.color_scheme` was not updating when `session.dataset` is modified

```py
import fiftyone as fo
import fiftyone.zoo as foz

session = fo.launch_app()
print(session.color_scheme)  # default

dataset = foz.load_zoo_dataset("quickstart")

dataset.app_config.color_scheme = fo.ColorScheme(
    color_pool=["#ff0000", "#00ff00", "#0000ff", "pink", "yellowgreen"],
    fields=[
        {
            "path": "ground_truth",
            "fieldColor": "#ff00ff",
            "colorByAttribute": "label",
            "valueColors": [{"value": "dog", "color": "yellow"}],
        }
    ]
)
dataset.save()

session.dataset = dataset
print(session.color_scheme)  # now is custom scheme above

session.dataset = fo.Dataset()
print(session.color_scheme)  # default again

session.view = dataset.limit(10)
print(session.color_scheme)  # custom scheme above once again

session.dataset = None
print(session.color_scheme)  # default again
```
