### PR TITLE
Add persistent and overwrite arguments to dataset factory functions

### DIFF
--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -5109,11 +5109,11 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
         data_path=None,
         labels_path=None,
         name=None,
+        persistent=False,
+        overwrite=False,
         label_field=None,
         tags=None,
         dynamic=False,
-        persistent=False,
-        overwrite=False,
         **kwargs,
     ):
         """Creates a :class:`Dataset` from the contents of the given directory.
@@ -5181,6 +5181,10 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
                 dataset type being imported
             name (None): a name for the dataset. By default,
                 :func:`get_default_dataset_name` is used
+            persistent (False): whether the dataset should persist in the
+                database after the session terminates
+            overwrite (False): whether to overwrite an existing dataset of
+                the same name
             label_field (None): controls the field(s) in which imported labels
                 are stored. Only applicable if ``dataset_importer`` is a
                 :class:`fiftyone.utils.data.importers.LabeledImageDatasetImporter` or
@@ -5198,10 +5202,6 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
                 sample
             dynamic (False): whether to declare dynamic attributes of embedded
                 document fields that are encountered
-            persistent (False): whether the dataset should persist in the
-                database after the session terminates
-            overwrite (False): whether to overwrite an existing dataset of
-                the same name
             **kwargs: optional keyword arguments to pass to the constructor of
                 the :class:`fiftyone.utils.data.importers.DatasetImporter` for
                 the specified ``dataset_type``
@@ -5230,12 +5230,12 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
         data_path=None,
         labels_path=None,
         name=None,
+        persistent=False,
+        overwrite=False,
         label_field=None,
         tags=None,
         dynamic=False,
         cleanup=True,
-        persistent=False,
-        overwrite=False,
         **kwargs,
     ):
         """Creates a :class:`Dataset` from the contents of the given archive.
@@ -5299,6 +5299,10 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
                 dataset type being imported
             name (None): a name for the dataset. By default,
                 :func:`get_default_dataset_name` is used
+            persistent (False): whether the dataset should persist in the
+                database after the session terminates
+            overwrite (False): whether to overwrite an existing dataset of
+                the same name
             label_field (None): controls the field(s) in which imported labels
                 are stored. Only applicable if ``dataset_importer`` is a
                 :class:`fiftyone.utils.data.importers.LabeledImageDatasetImporter` or
@@ -5317,10 +5321,6 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
             dynamic (False): whether to declare dynamic attributes of embedded
                 document fields that are encountered
             cleanup (True): whether to delete the archive after extracting it
-            persistent (False): whether the dataset should persist in the
-                database after the session terminates
-            overwrite (False): whether to overwrite an existing dataset of
-                the same name
             **kwargs: optional keyword arguments to pass to the constructor of
                 the :class:`fiftyone.utils.data.importers.DatasetImporter` for
                 the specified ``dataset_type``
@@ -5347,11 +5347,11 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
         cls,
         dataset_importer,
         name=None,
+        persistent=False,
+        overwrite=False,
         label_field=None,
         tags=None,
         dynamic=False,
-        persistent=False,
-        overwrite=False,
     ):
         """Creates a :class:`Dataset` by importing the samples in the given
         :class:`fiftyone.utils.data.importers.DatasetImporter`.
@@ -5366,6 +5366,10 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
                 :class:`fiftyone.utils.data.importers.DatasetImporter`
             name (None): a name for the dataset. By default,
                 :func:`get_default_dataset_name` is used
+            persistent (False): whether the dataset should persist in the
+                database after the session terminates
+            overwrite (False): whether to overwrite an existing dataset of
+                the same name
             label_field (None): controls the field(s) in which imported labels
                 are stored. Only applicable if ``dataset_importer`` is a
                 :class:`fiftyone.utils.data.importers.LabeledImageDatasetImporter` or
@@ -5383,10 +5387,6 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
                 sample
             dynamic (False): whether to declare dynamic attributes of embedded
                 document fields that are encountered
-            persistent (False): whether the dataset should persist in the
-                database after the session terminates
-            overwrite (False): whether to overwrite an existing dataset of
-                the same name
 
         Returns:
             a :class:`Dataset`
@@ -5406,9 +5406,9 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
         paths_or_samples,
         sample_parser=None,
         name=None,
-        tags=None,
         persistent=False,
         overwrite=False,
+        tags=None,
     ):
         """Creates a :class:`Dataset` from the given images.
 
@@ -5429,12 +5429,12 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
                 instance to use to parse the samples
             name (None): a name for the dataset. By default,
                 :func:`get_default_dataset_name` is used
-            tags (None): an optional tag or iterable of tags to attach to each
-                sample
             persistent (False): whether the dataset should persist in the
                 database after the session terminates
             overwrite (False): whether to overwrite an existing dataset of
                 the same name
+            tags (None): an optional tag or iterable of tags to attach to each
+                sample
 
         Returns:
             a :class:`Dataset`
@@ -5451,11 +5451,11 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
         samples,
         sample_parser,
         name=None,
+        persistent=False,
+        overwrite=False,
         label_field=None,
         tags=None,
         dynamic=False,
-        persistent=False,
-        overwrite=False,
     ):
         """Creates a :class:`Dataset` from the given labeled images.
 
@@ -5474,6 +5474,10 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
                 instance to use to parse the samples
             name (None): a name for the dataset. By default,
                 :func:`get_default_dataset_name` is used
+            persistent (False): whether the dataset should persist in the
+                database after the session terminates
+            overwrite (False): whether to overwrite an existing dataset of
+                the same name
             label_field (None): controls the field(s) in which imported labels
                 are stored. If the parser produces a single
                 :class:`fiftyone.core.labels.Label` instance per sample, this
@@ -5487,10 +5491,6 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
                 sample
             dynamic (False): whether to declare dynamic attributes of embedded
                 document fields that are encountered
-            persistent (False): whether the dataset should persist in the
-                database after the session terminates
-            overwrite (False): whether to overwrite an existing dataset of
-                the same name
 
         Returns:
             a :class:`Dataset`
@@ -5510,10 +5510,10 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
         cls,
         images_dir,
         name=None,
-        tags=None,
-        recursive=True,
         persistent=False,
         overwrite=False,
+        tags=None,
+        recursive=True,
     ):
         """Creates a :class:`Dataset` from the given directory of images.
 
@@ -5523,13 +5523,13 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
             images_dir: a directory of images
             name (None): a name for the dataset. By default,
                 :func:`get_default_dataset_name` is used
-            tags (None): an optional tag or iterable of tags to attach to each
-                sample
-            recursive (True): whether to recursively traverse subdirectories
             persistent (False): whether the dataset should persist in the
                 database after the session terminates
             overwrite (False): whether to overwrite an existing dataset of
                 the same name
+            tags (None): an optional tag or iterable of tags to attach to each
+                sample
+            recursive (True): whether to recursively traverse subdirectories
 
         Returns:
             a :class:`Dataset`
@@ -5543,9 +5543,9 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
         cls,
         images_patt,
         name=None,
-        tags=None,
         persistent=False,
         overwrite=False,
+        tags=None,
     ):
         """Creates a :class:`Dataset` from the given glob pattern of images.
 
@@ -5556,12 +5556,12 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
                 ``/path/to/images/*.jpg``
             name (None): a name for the dataset. By default,
                 :func:`get_default_dataset_name` is used
-            tags (None): an optional tag or iterable of tags to attach to each
-                sample
             persistent (False): whether the dataset should persist in the
                 database after the session terminates
             overwrite (False): whether to overwrite an existing dataset of
                 the same name
+            tags (None): an optional tag or iterable of tags to attach to each
+                sample
 
         Returns:
             a :class:`Dataset`
@@ -5576,9 +5576,9 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
         paths_or_samples,
         sample_parser=None,
         name=None,
-        tags=None,
         persistent=False,
         overwrite=False,
+        tags=None,
     ):
         """Creates a :class:`Dataset` from the given videos.
 
@@ -5599,12 +5599,12 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
                 instance to use to parse the samples
             name (None): a name for the dataset. By default,
                 :func:`get_default_dataset_name` is used
-            tags (None): an optional tag or iterable of tags to attach to each
-                sample
             persistent (False): whether the dataset should persist in the
                 database after the session terminates
             overwrite (False): whether to overwrite an existing dataset of
                 the same name
+            tags (None): an optional tag or iterable of tags to attach to each
+                sample
 
         Returns:
             a :class:`Dataset`
@@ -5621,11 +5621,11 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
         samples,
         sample_parser,
         name=None,
+        persistent=False,
+        overwrite=False,
         label_field=None,
         tags=None,
         dynamic=False,
-        persistent=False,
-        overwrite=False,
     ):
         """Creates a :class:`Dataset` from the given labeled videos.
 
@@ -5644,6 +5644,10 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
                 instance to use to parse the samples
             name (None): a name for the dataset. By default,
                 :func:`get_default_dataset_name` is used
+            persistent (False): whether the dataset should persist in the
+                database after the session terminates
+            overwrite (False): whether to overwrite an existing dataset of
+                the same name
             label_field (None): controls the field(s) in which imported labels
                 are stored. If the parser produces a single
                 :class:`fiftyone.core.labels.Label` instance per sample/frame,
@@ -5658,10 +5662,6 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
                 sample
             dynamic (False): whether to declare dynamic attributes of embedded
                 document fields that are encountered
-            persistent (False): whether the dataset should persist in the
-                database after the session terminates
-            overwrite (False): whether to overwrite an existing dataset of
-                the same name
 
         Returns:
             a :class:`Dataset`
@@ -5681,10 +5681,10 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
         cls,
         videos_dir,
         name=None,
-        tags=None,
-        recursive=True,
         persistent=False,
         overwrite=False,
+        tags=None,
+        recursive=True,
     ):
         """Creates a :class:`Dataset` from the given directory of videos.
 
@@ -5694,13 +5694,13 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
             videos_dir: a directory of videos
             name (None): a name for the dataset. By default,
                 :func:`get_default_dataset_name` is used
-            tags (None): an optional tag or iterable of tags to attach to each
-                sample
-            recursive (True): whether to recursively traverse subdirectories
             persistent (False): whether the dataset should persist in the
                 database after the session terminates
             overwrite (False): whether to overwrite an existing dataset of
                 the same name
+            tags (None): an optional tag or iterable of tags to attach to each
+                sample
+            recursive (True): whether to recursively traverse subdirectories
 
         Returns:
             a :class:`Dataset`
@@ -5710,7 +5710,14 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
         return dataset
 
     @classmethod
-    def from_videos_patt(cls, videos_patt, name=None, tags=None):
+    def from_videos_patt(
+        cls,
+        videos_patt,
+        name=None,
+        persistent=False,
+        overwrite=False,
+        tags=None,
+    ):
         """Creates a :class:`Dataset` from the given glob pattern of videos.
 
         This operation does not read/decode the videos.
@@ -5720,17 +5727,17 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
                 ``/path/to/videos/*.mp4``
             name (None): a name for the dataset. By default,
                 :func:`get_default_dataset_name` is used
-            tags (None): an optional tag or iterable of tags to attach to each
-                sample
             persistent (False): whether the dataset should persist in the
                 database after the session terminates
             overwrite (False): whether to overwrite an existing dataset of
                 the same name
+            tags (None): an optional tag or iterable of tags to attach to each
+                sample
 
         Returns:
             a :class:`Dataset`
         """
-        dataset = cls(name)
+        dataset = cls(name, persistent=persistent, overwrite=overwrite)
         dataset.add_videos_patt(videos_patt, tags=tags)
         return dataset
 
@@ -5739,9 +5746,10 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
         cls,
         d,
         name=None,
+        persistent=False,
+        overwrite=False,
         rel_dir=None,
         frame_labels_dir=None,
-        persistent=False,
     ):
         """Loads a :class:`Dataset` from a JSON dictionary generated by
         :meth:`fiftyone.core.collections.SampleCollection.to_dict`.
@@ -5753,6 +5761,10 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
         Args:
             d: a JSON dictionary
             name (None): a name for the new dataset
+            persistent (False): whether the dataset should persist in the
+                database after the session terminates
+            overwrite (False): whether to overwrite an existing dataset of
+                the same name
             rel_dir (None): a relative directory to prepend to the ``filepath``
                 of each sample if the filepath is not absolute (begins with a
                 path separator). The path is converted to an absolute path
@@ -5762,8 +5774,6 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
                 is assumed that the frame labels are included directly in the
                 provided JSON dict. Only applicable to datasets that contain
                 videos
-            persistent (False): whether the dataset should persist in the
-                database after the session terminates
 
         Returns:
             a :class:`Dataset`
@@ -5777,7 +5787,7 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
             rel_dir = fou.normalize_path(rel_dir)
 
         name = make_unique_dataset_name(name)
-        dataset = cls(name, persistent=persistent)
+        dataset = cls(name, persistent=persistent, overwrite=overwrite)
 
         media_type = d.get("media_type", None)
 
@@ -5853,9 +5863,10 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
         cls,
         path_or_str,
         name=None,
+        persistent=False,
+        overwrite=False,
         rel_dir=None,
         frame_labels_dir=None,
-        persistent=False,
     ):
         """Loads a :class:`Dataset` from JSON generated by
         :func:`fiftyone.core.collections.SampleCollection.write_json` or
@@ -5868,12 +5879,14 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
         Args:
             path_or_str: the path to a JSON file on disk or a JSON string
             name (None): a name for the new dataset
+            persistent (False): whether the dataset should persist in the
+                database after the session terminates
+            overwrite (False): whether to overwrite an existing dataset of
+                the same name
             rel_dir (None): a relative directory to prepend to the ``filepath``
                 of each sample, if the filepath is not absolute (begins with a
                 path separator). The path is converted to an absolute path
                 (if necessary) via :func:`fiftyone.core.utils.normalize_path`
-            persistent (False): whether the dataset should persist in the
-                database after the session terminates
 
         Returns:
             a :class:`Dataset`
@@ -5882,9 +5895,10 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
         return cls.from_dict(
             d,
             name=name,
+            persistent=persistent,
+            overwrite=overwrite,
             rel_dir=rel_dir,
             frame_labels_dir=frame_labels_dir,
-            persistent=persistent,
         )
 
     def _add_view_stage(self, stage):

--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -5112,6 +5112,8 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
         label_field=None,
         tags=None,
         dynamic=False,
+        persistent=False,
+        overwrite=False,
         **kwargs,
     ):
         """Creates a :class:`Dataset` from the contents of the given directory.
@@ -5196,6 +5198,10 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
                 sample
             dynamic (False): whether to declare dynamic attributes of embedded
                 document fields that are encountered
+            persistent (False): whether the dataset should persist in the
+                database after the session terminates
+            overwrite (False): whether to overwrite an existing dataset of
+                the same name
             **kwargs: optional keyword arguments to pass to the constructor of
                 the :class:`fiftyone.utils.data.importers.DatasetImporter` for
                 the specified ``dataset_type``
@@ -5203,7 +5209,7 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
         Returns:
             a :class:`Dataset`
         """
-        dataset = cls(name)
+        dataset = cls(name, persistent=persistent, overwrite=overwrite)
         dataset.add_dir(
             dataset_dir=dataset_dir,
             dataset_type=dataset_type,
@@ -5228,6 +5234,8 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
         tags=None,
         dynamic=False,
         cleanup=True,
+        persistent=False,
+        overwrite=False,
         **kwargs,
     ):
         """Creates a :class:`Dataset` from the contents of the given archive.
@@ -5309,6 +5317,10 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
             dynamic (False): whether to declare dynamic attributes of embedded
                 document fields that are encountered
             cleanup (True): whether to delete the archive after extracting it
+            persistent (False): whether the dataset should persist in the
+                database after the session terminates
+            overwrite (False): whether to overwrite an existing dataset of
+                the same name
             **kwargs: optional keyword arguments to pass to the constructor of
                 the :class:`fiftyone.utils.data.importers.DatasetImporter` for
                 the specified ``dataset_type``
@@ -5316,7 +5328,7 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
         Returns:
             a :class:`Dataset`
         """
-        dataset = cls(name)
+        dataset = cls(name, persistent=persistent, overwrite=overwrite)
         dataset.add_archive(
             archive_path,
             dataset_type=dataset_type,
@@ -5338,6 +5350,8 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
         label_field=None,
         tags=None,
         dynamic=False,
+        persistent=False,
+        overwrite=False,
     ):
         """Creates a :class:`Dataset` by importing the samples in the given
         :class:`fiftyone.utils.data.importers.DatasetImporter`.
@@ -5369,11 +5383,15 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
                 sample
             dynamic (False): whether to declare dynamic attributes of embedded
                 document fields that are encountered
+            persistent (False): whether the dataset should persist in the
+                database after the session terminates
+            overwrite (False): whether to overwrite an existing dataset of
+                the same name
 
         Returns:
             a :class:`Dataset`
         """
-        dataset = cls(name)
+        dataset = cls(name, persistent=persistent, overwrite=overwrite)
         dataset.add_importer(
             dataset_importer,
             label_field=label_field,
@@ -5384,7 +5402,13 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
 
     @classmethod
     def from_images(
-        cls, paths_or_samples, sample_parser=None, name=None, tags=None
+        cls,
+        paths_or_samples,
+        sample_parser=None,
+        name=None,
+        tags=None,
+        persistent=False,
+        overwrite=False,
     ):
         """Creates a :class:`Dataset` from the given images.
 
@@ -5407,11 +5431,15 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
                 :func:`get_default_dataset_name` is used
             tags (None): an optional tag or iterable of tags to attach to each
                 sample
+            persistent (False): whether the dataset should persist in the
+                database after the session terminates
+            overwrite (False): whether to overwrite an existing dataset of
+                the same name
 
         Returns:
             a :class:`Dataset`
         """
-        dataset = cls(name)
+        dataset = cls(name, persistent=persistent, overwrite=overwrite)
         dataset.add_images(
             paths_or_samples, sample_parser=sample_parser, tags=tags
         )
@@ -5426,6 +5454,8 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
         label_field=None,
         tags=None,
         dynamic=False,
+        persistent=False,
+        overwrite=False,
     ):
         """Creates a :class:`Dataset` from the given labeled images.
 
@@ -5457,11 +5487,15 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
                 sample
             dynamic (False): whether to declare dynamic attributes of embedded
                 document fields that are encountered
+            persistent (False): whether the dataset should persist in the
+                database after the session terminates
+            overwrite (False): whether to overwrite an existing dataset of
+                the same name
 
         Returns:
             a :class:`Dataset`
         """
-        dataset = cls(name)
+        dataset = cls(name, persistent=persistent, overwrite=overwrite)
         dataset.add_labeled_images(
             samples,
             sample_parser,
@@ -5472,7 +5506,15 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
         return dataset
 
     @classmethod
-    def from_images_dir(cls, images_dir, name=None, tags=None, recursive=True):
+    def from_images_dir(
+        cls,
+        images_dir,
+        name=None,
+        tags=None,
+        recursive=True,
+        persistent=False,
+        overwrite=False,
+    ):
         """Creates a :class:`Dataset` from the given directory of images.
 
         This operation does not read the images.
@@ -5484,16 +5526,27 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
             tags (None): an optional tag or iterable of tags to attach to each
                 sample
             recursive (True): whether to recursively traverse subdirectories
+            persistent (False): whether the dataset should persist in the
+                database after the session terminates
+            overwrite (False): whether to overwrite an existing dataset of
+                the same name
 
         Returns:
             a :class:`Dataset`
         """
-        dataset = cls(name)
+        dataset = cls(name, persistent=persistent, overwrite=overwrite)
         dataset.add_images_dir(images_dir, tags=tags, recursive=recursive)
         return dataset
 
     @classmethod
-    def from_images_patt(cls, images_patt, name=None, tags=None):
+    def from_images_patt(
+        cls,
+        images_patt,
+        name=None,
+        tags=None,
+        persistent=False,
+        overwrite=False,
+    ):
         """Creates a :class:`Dataset` from the given glob pattern of images.
 
         This operation does not read the images.
@@ -5505,17 +5558,27 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
                 :func:`get_default_dataset_name` is used
             tags (None): an optional tag or iterable of tags to attach to each
                 sample
+            persistent (False): whether the dataset should persist in the
+                database after the session terminates
+            overwrite (False): whether to overwrite an existing dataset of
+                the same name
 
         Returns:
             a :class:`Dataset`
         """
-        dataset = cls(name)
+        dataset = cls(name, persistent=persistent, overwrite=overwrite)
         dataset.add_images_patt(images_patt, tags=tags)
         return dataset
 
     @classmethod
     def from_videos(
-        cls, paths_or_samples, sample_parser=None, name=None, tags=None
+        cls,
+        paths_or_samples,
+        sample_parser=None,
+        name=None,
+        tags=None,
+        persistent=False,
+        overwrite=False,
     ):
         """Creates a :class:`Dataset` from the given videos.
 
@@ -5538,11 +5601,15 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
                 :func:`get_default_dataset_name` is used
             tags (None): an optional tag or iterable of tags to attach to each
                 sample
+            persistent (False): whether the dataset should persist in the
+                database after the session terminates
+            overwrite (False): whether to overwrite an existing dataset of
+                the same name
 
         Returns:
             a :class:`Dataset`
         """
-        dataset = cls(name)
+        dataset = cls(name, persistent=persistent, overwrite=overwrite)
         dataset.add_videos(
             paths_or_samples, sample_parser=sample_parser, tags=tags
         )
@@ -5557,6 +5624,8 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
         label_field=None,
         tags=None,
         dynamic=False,
+        persistent=False,
+        overwrite=False,
     ):
         """Creates a :class:`Dataset` from the given labeled videos.
 
@@ -5589,11 +5658,15 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
                 sample
             dynamic (False): whether to declare dynamic attributes of embedded
                 document fields that are encountered
+            persistent (False): whether the dataset should persist in the
+                database after the session terminates
+            overwrite (False): whether to overwrite an existing dataset of
+                the same name
 
         Returns:
             a :class:`Dataset`
         """
-        dataset = cls(name)
+        dataset = cls(name, persistent=persistent, overwrite=overwrite)
         dataset.add_labeled_videos(
             samples,
             sample_parser,
@@ -5604,7 +5677,15 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
         return dataset
 
     @classmethod
-    def from_videos_dir(cls, videos_dir, name=None, tags=None, recursive=True):
+    def from_videos_dir(
+        cls,
+        videos_dir,
+        name=None,
+        tags=None,
+        recursive=True,
+        persistent=False,
+        overwrite=False,
+    ):
         """Creates a :class:`Dataset` from the given directory of videos.
 
         This operation does not read/decode the videos.
@@ -5616,11 +5697,15 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
             tags (None): an optional tag or iterable of tags to attach to each
                 sample
             recursive (True): whether to recursively traverse subdirectories
+            persistent (False): whether the dataset should persist in the
+                database after the session terminates
+            overwrite (False): whether to overwrite an existing dataset of
+                the same name
 
         Returns:
             a :class:`Dataset`
         """
-        dataset = cls(name)
+        dataset = cls(name, persistent=persistent, overwrite=overwrite)
         dataset.add_videos_dir(videos_dir, tags=tags, recursive=recursive)
         return dataset
 
@@ -5637,6 +5722,10 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
                 :func:`get_default_dataset_name` is used
             tags (None): an optional tag or iterable of tags to attach to each
                 sample
+            persistent (False): whether the dataset should persist in the
+                database after the session terminates
+            overwrite (False): whether to overwrite an existing dataset of
+                the same name
 
         Returns:
             a :class:`Dataset`
@@ -5646,7 +5735,14 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
         return dataset
 
     @classmethod
-    def from_dict(cls, d, name=None, rel_dir=None, frame_labels_dir=None):
+    def from_dict(
+        cls,
+        d,
+        name=None,
+        rel_dir=None,
+        frame_labels_dir=None,
+        persistent=False,
+    ):
         """Loads a :class:`Dataset` from a JSON dictionary generated by
         :meth:`fiftyone.core.collections.SampleCollection.to_dict`.
 
@@ -5666,6 +5762,8 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
                 is assumed that the frame labels are included directly in the
                 provided JSON dict. Only applicable to datasets that contain
                 videos
+            persistent (False): whether the dataset should persist in the
+                database after the session terminates
 
         Returns:
             a :class:`Dataset`
@@ -5679,7 +5777,7 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
             rel_dir = fou.normalize_path(rel_dir)
 
         name = make_unique_dataset_name(name)
-        dataset = cls(name)
+        dataset = cls(name, persistent=persistent)
 
         media_type = d.get("media_type", None)
 
@@ -5752,7 +5850,12 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
 
     @classmethod
     def from_json(
-        cls, path_or_str, name=None, rel_dir=None, frame_labels_dir=None
+        cls,
+        path_or_str,
+        name=None,
+        rel_dir=None,
+        frame_labels_dir=None,
+        persistent=False,
     ):
         """Loads a :class:`Dataset` from JSON generated by
         :func:`fiftyone.core.collections.SampleCollection.write_json` or
@@ -5769,13 +5872,19 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
                 of each sample, if the filepath is not absolute (begins with a
                 path separator). The path is converted to an absolute path
                 (if necessary) via :func:`fiftyone.core.utils.normalize_path`
+            persistent (False): whether the dataset should persist in the
+                database after the session terminates
 
         Returns:
             a :class:`Dataset`
         """
         d = etas.load_json(path_or_str)
         return cls.from_dict(
-            d, name=name, rel_dir=rel_dir, frame_labels_dir=frame_labels_dir
+            d,
+            name=name,
+            rel_dir=rel_dir,
+            frame_labels_dir=frame_labels_dir,
+            persistent=persistent,
         )
 
     def _add_view_stage(self, stage):

--- a/tests/unittests/dataset_tests.py
+++ b/tests/unittests/dataset_tests.py
@@ -4991,11 +4991,41 @@ class DatasetFactoryTests(unittest.TestCase):
 
         self.assertEqual(len(dataset), 1)
 
+        self.assertRaises(
+            ValueError, fo.Dataset.from_images, filepaths, name=dataset.name
+        )
+
+        dataset2 = fo.Dataset.from_images(
+            filepaths, name=dataset.name, overwrite=True, persistent=True
+        )
+        self.assertEqual(len(dataset2), 1)
+        self.assertTrue(dataset2.persistent)
+        dataset2.delete()
+
         samples = [{"filepath": "image.jpg"}]
         sample_parser = _ImageSampleParser()
         dataset = fo.Dataset.from_images(samples, sample_parser=sample_parser)
 
         self.assertEqual(len(dataset), 1)
+
+        self.assertRaises(
+            ValueError,
+            fo.Dataset.from_images,
+            samples,
+            sample_parser=sample_parser,
+            name=dataset.name,
+        )
+
+        dataset2 = fo.Dataset.from_images(
+            samples,
+            sample_parser=sample_parser,
+            name=dataset.name,
+            overwrite=True,
+            persistent=True,
+        )
+        self.assertEqual(len(dataset2), 1)
+        self.assertTrue(dataset2.persistent)
+        dataset2.delete()
 
     @drop_datasets
     def test_from_videos(self):
@@ -5004,11 +5034,39 @@ class DatasetFactoryTests(unittest.TestCase):
 
         self.assertEqual(len(dataset), 1)
 
+        self.assertRaises(
+            ValueError, fo.Dataset.from_videos, filepaths, name=dataset.name
+        )
+        dataset2 = fo.Dataset.from_videos(
+            filepaths, name=dataset.name, overwrite=True, persistent=True
+        )
+        self.assertEqual(len(dataset2), 1)
+        self.assertTrue(dataset2.persistent)
+        dataset2.delete()
+
         samples = [{"filepath": "video.mp4"}]
         sample_parser = _VideoSampleParser()
         dataset = fo.Dataset.from_videos(samples, sample_parser=sample_parser)
 
         self.assertEqual(len(dataset), 1)
+
+        self.assertRaises(
+            ValueError,
+            fo.Dataset.from_videos,
+            samples,
+            sample_parser=sample_parser,
+            name=dataset.name,
+        )
+        dataset2 = fo.Dataset.from_videos(
+            samples,
+            sample_parser=sample_parser,
+            name=dataset.name,
+            overwrite=True,
+            persistent=True,
+        )
+        self.assertEqual(len(dataset2), 1)
+        self.assertTrue(dataset2.persistent)
+        dataset2.delete()
 
     @drop_datasets
     def test_from_labeled_images(self):
@@ -5020,6 +5078,26 @@ class DatasetFactoryTests(unittest.TestCase):
 
         self.assertEqual(dataset.values("ground_truth.label"), ["label"])
 
+        self.assertRaises(
+            ValueError,
+            fo.Dataset.from_labeled_images,
+            samples,
+            sample_parser,
+            label_field="ground_truth",
+            name=dataset.name,
+        )
+        dataset2 = fo.Dataset.from_labeled_images(
+            samples,
+            sample_parser,
+            label_field="ground_truth",
+            name=dataset.name,
+            overwrite=True,
+            persistent=True,
+        )
+        self.assertEqual(dataset2.values("ground_truth.label"), ["label"])
+        self.assertTrue(dataset2.persistent)
+        dataset2.delete()
+
     @drop_datasets
     def test_from_labeled_videos(self):
         samples = [{"filepath": "video.mp4", "label": "label"}]
@@ -5029,6 +5107,26 @@ class DatasetFactoryTests(unittest.TestCase):
         )
 
         self.assertEqual(dataset.values("ground_truth.label"), ["label"])
+
+        self.assertRaises(
+            ValueError,
+            fo.Dataset.from_labeled_videos,
+            samples,
+            sample_parser,
+            label_field="ground_truth",
+            name=dataset.name,
+        )
+        dataset2 = fo.Dataset.from_labeled_videos(
+            samples,
+            sample_parser,
+            label_field="ground_truth",
+            name=dataset.name,
+            overwrite=True,
+            persistent=True,
+        )
+        self.assertEqual(dataset2.values("ground_truth.label"), ["label"])
+        self.assertTrue(dataset2.persistent)
+        dataset2.delete()
 
 
 class _ImageSampleParser(foud.ImageSampleParser):

--- a/tests/unittests/dataset_tests.py
+++ b/tests/unittests/dataset_tests.py
@@ -4991,16 +4991,15 @@ class DatasetFactoryTests(unittest.TestCase):
 
         self.assertEqual(len(dataset), 1)
 
-        self.assertRaises(
-            ValueError, fo.Dataset.from_images, filepaths, name=dataset.name
-        )
+        with self.assertRaises(ValueError):
+            fo.Dataset.from_images(filepaths, name=dataset.name)
 
         dataset2 = fo.Dataset.from_images(
             filepaths, name=dataset.name, overwrite=True, persistent=True
         )
+
         self.assertEqual(len(dataset2), 1)
         self.assertTrue(dataset2.persistent)
-        dataset2.delete()
 
         samples = [{"filepath": "image.jpg"}]
         sample_parser = _ImageSampleParser()
@@ -5008,13 +5007,12 @@ class DatasetFactoryTests(unittest.TestCase):
 
         self.assertEqual(len(dataset), 1)
 
-        self.assertRaises(
-            ValueError,
-            fo.Dataset.from_images,
-            samples,
-            sample_parser=sample_parser,
-            name=dataset.name,
-        )
+        with self.assertRaises(ValueError):
+            fo.Dataset.from_images(
+                samples,
+                sample_parser=sample_parser,
+                name=dataset.name,
+            )
 
         dataset2 = fo.Dataset.from_images(
             samples,
@@ -5023,9 +5021,9 @@ class DatasetFactoryTests(unittest.TestCase):
             overwrite=True,
             persistent=True,
         )
+
         self.assertEqual(len(dataset2), 1)
         self.assertTrue(dataset2.persistent)
-        dataset2.delete()
 
     @drop_datasets
     def test_from_videos(self):
@@ -5034,15 +5032,15 @@ class DatasetFactoryTests(unittest.TestCase):
 
         self.assertEqual(len(dataset), 1)
 
-        self.assertRaises(
-            ValueError, fo.Dataset.from_videos, filepaths, name=dataset.name
-        )
+        with self.assertRaises(ValueError):
+            fo.Dataset.from_videos(filepaths, name=dataset.name)
+
         dataset2 = fo.Dataset.from_videos(
             filepaths, name=dataset.name, overwrite=True, persistent=True
         )
+
         self.assertEqual(len(dataset2), 1)
         self.assertTrue(dataset2.persistent)
-        dataset2.delete()
 
         samples = [{"filepath": "video.mp4"}]
         sample_parser = _VideoSampleParser()
@@ -5050,13 +5048,13 @@ class DatasetFactoryTests(unittest.TestCase):
 
         self.assertEqual(len(dataset), 1)
 
-        self.assertRaises(
-            ValueError,
-            fo.Dataset.from_videos,
-            samples,
-            sample_parser=sample_parser,
-            name=dataset.name,
-        )
+        with self.assertRaises(ValueError):
+            fo.Dataset.from_videos(
+                samples,
+                sample_parser=sample_parser,
+                name=dataset.name,
+            )
+
         dataset2 = fo.Dataset.from_videos(
             samples,
             sample_parser=sample_parser,
@@ -5064,9 +5062,9 @@ class DatasetFactoryTests(unittest.TestCase):
             overwrite=True,
             persistent=True,
         )
+
         self.assertEqual(len(dataset2), 1)
         self.assertTrue(dataset2.persistent)
-        dataset2.delete()
 
     @drop_datasets
     def test_from_labeled_images(self):
@@ -5078,14 +5076,14 @@ class DatasetFactoryTests(unittest.TestCase):
 
         self.assertEqual(dataset.values("ground_truth.label"), ["label"])
 
-        self.assertRaises(
-            ValueError,
-            fo.Dataset.from_labeled_images,
-            samples,
-            sample_parser,
-            label_field="ground_truth",
-            name=dataset.name,
-        )
+        with self.assertRaises(ValueError):
+            fo.Dataset.from_labeled_images(
+                samples,
+                sample_parser,
+                label_field="ground_truth",
+                name=dataset.name,
+            )
+
         dataset2 = fo.Dataset.from_labeled_images(
             samples,
             sample_parser,
@@ -5094,9 +5092,9 @@ class DatasetFactoryTests(unittest.TestCase):
             overwrite=True,
             persistent=True,
         )
+
         self.assertEqual(dataset2.values("ground_truth.label"), ["label"])
         self.assertTrue(dataset2.persistent)
-        dataset2.delete()
 
     @drop_datasets
     def test_from_labeled_videos(self):
@@ -5108,14 +5106,14 @@ class DatasetFactoryTests(unittest.TestCase):
 
         self.assertEqual(dataset.values("ground_truth.label"), ["label"])
 
-        self.assertRaises(
-            ValueError,
-            fo.Dataset.from_labeled_videos,
-            samples,
-            sample_parser,
-            label_field="ground_truth",
-            name=dataset.name,
-        )
+        with self.assertRaises(ValueError):
+            fo.Dataset.from_labeled_videos(
+                samples,
+                sample_parser,
+                label_field="ground_truth",
+                name=dataset.name,
+            )
+
         dataset2 = fo.Dataset.from_labeled_videos(
             samples,
             sample_parser,
@@ -5124,9 +5122,9 @@ class DatasetFactoryTests(unittest.TestCase):
             overwrite=True,
             persistent=True,
         )
+
         self.assertEqual(dataset2.values("ground_truth.label"), ["label"])
         self.assertTrue(dataset2.persistent)
-        dataset2.delete()
 
 
 class _ImageSampleParser(foud.ImageSampleParser):


### PR DESCRIPTION
## What changes are proposed in this pull request?

I propose adding `persistent (default False)` and `overwrite (default False)` arguments to each of the Dataset factory functions (`fo.Dataset.from_*`), to mirror the parameters available in the `fo.Dataset` constructor.

Makes the solution for https://github.com/voxel51/fiftyone/issues/3016 a little more elegant

For reference, here is the args docstring for `class Dataset`
```
    Args:
        name (None): the name of the dataset. By default,
            :func:`get_default_dataset_name` is used
        persistent (False): whether the dataset should persist in the database
            after the session terminates
        overwrite (False): whether to overwrite an existing dataset of the same
            name
```

## How is this patch tested? If it is not, please explain why.

- added to `DatasetFactoryTests`

```py
import fiftyone as fo
datadir = "/path/to/images"
dataset_name = "dataset"

dataset = fo.Dataset.from_dir(
    datadir,
    dataset_type=fo.types.ImageDirectory,
    name=dataset_name,
    persistent=True
)
assert dataset.persistent

# raises ValueError because name "dataset" already taken
fo.Dataset.from_dir(
    datadir,
    dataset_type=fo.types.ImageDirectory,
    name=dataset_name,
    persistent=True
)

# Succeeds
dataset2 = fo.Dataset.from_dir(
    datadir,
    dataset_type=fo.types.ImageDirectory,
    name=dataset_name,
    persistent=True,
    overwrite=True,
)
assert dataset.persistent
assert dataset2.name == dataset_name
```

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
