### PR TITLE
Bugfix:sample tag color does not respect field color

### DIFF
--- a/app/packages/core/src/components/Filters/BooleanFieldFilter.tsx
+++ b/app/packages/core/src/components/Filters/BooleanFieldFilter.tsx
@@ -12,6 +12,7 @@ import CategoricalFilter from "./categoricalFilter/CategoricalFilter";
 const BooleanFieldFilter = ({
   path,
   modal,
+  color,
   ...rest
 }: {
   path: string;

--- a/app/packages/core/src/components/Filters/LabelFieldFilter.tsx
+++ b/app/packages/core/src/components/Filters/LabelFieldFilter.tsx
@@ -32,6 +32,7 @@ const LabelTagFieldFilter = ({
       countsAtom={labelTagsCount({ modal, extended: false })}
       path={path}
       modal={modal}
+      color={color}
       {...rest}
     />
   );

--- a/app/packages/core/src/components/Filters/StringFieldFilter.tsx
+++ b/app/packages/core/src/components/Filters/StringFieldFilter.tsx
@@ -18,6 +18,7 @@ const StringFieldFilter = ({
   path: string;
   modal: boolean;
   name?: boolean;
+  color: string;
   onFocus?: () => void;
   onBlur?: () => void;
   title: string;

--- a/app/packages/looker/src/elements/common/tags.ts
+++ b/app/packages/looker/src/elements/common/tags.ts
@@ -262,7 +262,7 @@ export class TagsElement<State extends BaseState> extends BaseElement<State> {
         if (Array.isArray(sample.tags)) {
           sample.tags.forEach((tag) => {
             elements.push({
-              color: getColor(coloring.pool, coloring.seed, tag),
+              color: getColor(coloring.pool, coloring.seed, "tags"),
               title: tag,
               value: tag,
             });

--- a/app/packages/looker/src/elements/common/tags.ts
+++ b/app/packages/looker/src/elements/common/tags.ts
@@ -261,8 +261,9 @@ export class TagsElement<State extends BaseState> extends BaseElement<State> {
       if (path === "tags") {
         if (Array.isArray(sample.tags)) {
           sample.tags.forEach((tag) => {
+            const v = coloring.by === "value" ? tag : "tags";
             elements.push({
-              color: getColor(coloring.pool, coloring.seed, "tags"),
+              color: getColor(coloring.pool, coloring.seed, v),
               title: tag,
               value: tag,
             });
@@ -271,8 +272,9 @@ export class TagsElement<State extends BaseState> extends BaseElement<State> {
       } else if (path === "_label_tags") {
         Object.entries(sample._label_tags).forEach(([tag, count]) => {
           const value = `${tag}: ${count}`;
+          const v = coloring.by === "value" ? tag : path;
           elements.push({
-            color: getColor(coloring.pool, coloring.seed, path),
+            color: getColor(coloring.pool, coloring.seed, v),
             title: value,
             value,
           });


### PR DESCRIPTION
Fix sample tags do not respect field color issue.

https://github.com/voxel51/fiftyone/assets/17770824/c2044f71-b8f0-4cca-a41d-011642df69f4

# What changes are proposed in this pull request?

(Please fill in changes proposed in this fix)

## How is this patch tested? If it is not, please explain why.

(Details)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
