### PR TITLE
Filter out flattened and redundant sub fields to avoid overcounting label paths, failed tagging, etc.

### DIFF
--- a/app/packages/core/src/components/Sidebar/Entries/FilterablePathEntry.tsx
+++ b/app/packages/core/src/components/Sidebar/Entries/FilterablePathEntry.tsx
@@ -318,7 +318,7 @@ const FilterableEntry = ({
       entryKey={entryKey}
       heading={
         <>
-          {!disabled && !isLabelTag && (
+          {!disabled && !(modal && isLabelTag) && (
             <Checkbox
               checked={active}
               title={`Show ${path}`}

--- a/app/packages/looker/src/elements/common/tags.ts
+++ b/app/packages/looker/src/elements/common/tags.ts
@@ -328,6 +328,13 @@ export class TagsElement<State extends BaseState> extends BaseElement<State> {
                 value?.classifications
               );
           } else {
+            // remove undefined classifications - can show up as None
+            if (
+              "_cls" in (value as Object) &&
+              typeof value._cls === "undefined"
+            ) {
+              continue;
+            }
             elements.push(LABEL_RENDERERS[field.embeddedDocType](path, value));
           }
           continue;

--- a/app/packages/looker/src/elements/common/util.ts
+++ b/app/packages/looker/src/elements/common/util.ts
@@ -124,7 +124,9 @@ export const getColorFromOptions = ({
       // check if this label has a assigned color, use it if it is a valid color
       const valueColor = setting?.valueColors?.find((l) => {
         if (["none", "null", "undefined"].includes(l.value?.toLowerCase())) {
-          return !param[key];
+          return typeof param[key] === "string"
+            ? l.value?.toLowerCase === param[key]
+            : !param[key];
         }
         if (["True", "False"].includes(l.value?.toString())) {
           return (
@@ -171,7 +173,9 @@ export const getColorFromOptionsPrimitives = ({
       // check if this label has a assigned color, use it if it is a valid color
       const valueColor = setting.valueColors?.find((l) => {
         if (["none", "null", "undefined"].includes(l.value?.toLowerCase())) {
-          return !value;
+          return typeof value === "string"
+            ? l.value?.toLowerCase === value
+            : !value;
         }
         if (["True", "False"].includes(l.value?.toString())) {
           return (

--- a/app/packages/looker/src/overlays/base.ts
+++ b/app/packages/looker/src/overlays/base.ts
@@ -119,7 +119,9 @@ export abstract class CoordinateOverlay<
         // check if this label has a assigned color, use it if it is a valid color
         const valueColor = field?.valueColors?.find((l) => {
           if (["none", "null", "undefined"].includes(l.value?.toLowerCase())) {
-            return !this.label[key];
+            return typeof this.label[key] === "string"
+              ? l.value?.toLowerCase === this.label[key]
+              : !this.label[key];
           }
           if (["True", "False"].includes(l.value?.toString())) {
             return (

--- a/app/packages/looker/src/overlays/classifications.ts
+++ b/app/packages/looker/src/overlays/classifications.ts
@@ -76,7 +76,9 @@ export class ClassificationsOverlay<
       // check if this label has a assigned color, use it if it is a valid color
       const valueColor = setting?.valueColors?.find((l) => {
         if (["none", "null", "undefined"].includes(l.value?.toLowerCase())) {
-          return !label[key];
+          return typeof label[key] === "string"
+            ? l.value?.toLowerCase === label[key]
+            : !label[key];
         }
         if (["True", "False"].includes(l.value?.toString())) {
           return (

--- a/app/packages/looker/src/overlays/index.ts
+++ b/app/packages/looker/src/overlays/index.ts
@@ -14,6 +14,7 @@ import HeatmapOverlay, { getHeatmapPoints } from "./heatmap";
 import KeypointOverlay, { getKeypointPoints } from "./keypoint";
 import PolylineOverlay, { getPolylinePoints } from "./polyline";
 import SegmentationOverlay, { getSegmentationPoints } from "./segmentation";
+import { convertId } from "./util";
 
 const fromLabel = (overlayType) => (field, label) =>
   [new overlayType(field, label)];
@@ -63,7 +64,7 @@ export const loadOverlays = <State extends BaseState>(
 
     const dynamicLabel =
       label._cls === "DynamicEmbeddedDocument"
-        ? Object.entries(label)[1][1]
+        ? convertId(Object.entries(label)[1][1])
         : label;
     const dynamicField =
       label._cls === "DynamicEmbeddedDocument"

--- a/app/packages/looker/src/overlays/util.ts
+++ b/app/packages/looker/src/overlays/util.ts
@@ -102,3 +102,14 @@ export function normalizeMaskTargetsCase(maskTargets: MaskTargets) {
   });
   return normalizedMaskTargets;
 }
+
+export const convertId = (obj: Record<string, any>): Record<string, any> => {
+  return Object.fromEntries(
+    Object.entries(obj).map(([key, value]) => {
+      if (Array.isArray(value)) {
+        return [key, value.map((item) => ({ ...item, id: item["_id"] }))];
+      }
+      return [key, value];
+    })
+  );
+};

--- a/app/packages/looker/src/worker/painter.ts
+++ b/app/packages/looker/src/worker/painter.ts
@@ -37,7 +37,9 @@ export const PainterFactory = (requestColor) => ({
           : "label";
         const valueColor = setting?.valueColors?.find((l) => {
           if (["none", "null", "undefined"].includes(l.value?.toLowerCase())) {
-            return !label[key];
+            return typeof label[key] === "string"
+              ? l.value?.toLowerCase === label[key]
+              : !label[key];
           }
           if (["True", "False"].includes(l.value?.toString())) {
             return (

--- a/app/packages/state/src/hooks/useUpdateSamples.ts
+++ b/app/packages/state/src/hooks/useUpdateSamples.ts
@@ -17,7 +17,7 @@ export const useUpdateSamples = () => {
                 sampleStore.samples.set(id, { ...record, sample });
 
                 // @ts-ignore
-                store.lookers.get(id)?.updateSample(sample);
+                sampleStore.lookers.get(id)?.updateSample(sample);
               }
             });
           const record = store.get(id);

--- a/app/packages/state/src/recoil/aggregations.ts
+++ b/app/packages/state/src/recoil/aggregations.ts
@@ -448,17 +448,20 @@ export const cumulativeCounts = selectorFamily<
   get:
     ({ extended, path: key, modal, ftype, embeddedDocType }) =>
     ({ get }) => {
-      return gatherPaths(get, ftype, embeddedDocType).reduce((result, path) => {
-        const data = get(counts({ extended, modal, path: `${path}.${key}` }));
-        for (const value in data) {
-          if (!result[value]) {
-            result[value] = 0;
-          }
+      return [...new Set(gatherPaths(get, ftype, embeddedDocType))].reduce(
+        (result, path) => {
+          const data = get(counts({ extended, modal, path: `${path}.${key}` }));
+          for (const value in data) {
+            if (!result[value]) {
+              result[value] = 0;
+            }
 
-          result[value] += data[value];
-        }
-        return result;
-      }, {});
+            result[value] += data[value];
+          }
+          return result;
+        },
+        {}
+      );
     },
 });
 

--- a/app/packages/state/src/recoil/schema.ts
+++ b/app/packages/state/src/recoil/schema.ts
@@ -212,6 +212,7 @@ export const fieldPaths = selectorFamily<
         throw new Error("path and space provided");
       }
 
+      // use { flat: true } to get schema's dynamic fields included
       const sampleFields = get(
         fieldSchema({ space: State.SPACE.SAMPLE, flat: true })
       );

--- a/app/packages/state/src/recoil/schema.ts
+++ b/app/packages/state/src/recoil/schema.ts
@@ -349,10 +349,7 @@ export const labelFields = selectorFamily<string[], { space?: State.SPACE }>({
       const allSet = new Set(flatLabelFieldsBase);
       const flatLabelFields = flatLabelFieldsBase.filter((pp) => {
         const parentPath = pp.substring(0, pp.lastIndexOf("."));
-        if (parentPath && parentPath !== pp && allSet.has(parentPath)) {
-          return false;
-        }
-        return true;
+        return !(parentPath && parentPath !== pp && allSet.has(parentPath));
       });
 
       const dynamicLabelFields = paths

--- a/app/packages/state/src/recoil/schema.ts
+++ b/app/packages/state/src/recoil/schema.ts
@@ -335,7 +335,7 @@ export const labelFields = selectorFamily<string[], { space?: State.SPACE }>({
     ({ get }) => {
       const paths = get(fieldPaths(params));
 
-      const flatLabelFields1 = paths.filter((path) =>
+      const flatLabelFieldsBase = paths.filter((path) =>
         LABELS.includes(get(field(path)).embeddedDocType)
       );
 
@@ -346,8 +346,8 @@ export const labelFields = selectorFamily<string[], { space?: State.SPACE }>({
           - duplicate count of labels
           - unwanted filtering causing some operations that depend on labelPaths
             (such as tagging) to fail. */
-      const allSet = new Set(flatLabelFields1);
-      const flatLabelFields = flatLabelFields1.filter((pp) => {
+      const allSet = new Set(flatLabelFieldsBase);
+      const flatLabelFields = flatLabelFieldsBase.filter((pp) => {
         const parentPath = pp.substring(0, pp.lastIndexOf("."));
         if (parentPath && parentPath !== pp && allSet.has(parentPath)) {
           return false;

--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -9559,7 +9559,8 @@ class SampleCollection(object):
     def _get_sample_label_fields(self):
         return list(
             self.get_field_schema(
-                ftype=fof.EmbeddedDocumentField, embedded_doc_type=fol.Label
+                ftype=fof.EmbeddedDocumentField,
+                embedded_doc_type=fol.Label,
             ).keys()
         )
 
@@ -9570,7 +9571,8 @@ class SampleCollection(object):
         return [
             self._FRAMES_PREFIX + field
             for field in self.get_frame_field_schema(
-                ftype=fof.EmbeddedDocumentField, embedded_doc_type=fol.Label
+                ftype=fof.EmbeddedDocumentField,
+                embedded_doc_type=fol.Label,
             ).keys()
         ]
 
@@ -9658,7 +9660,12 @@ class SampleCollection(object):
         label_type = self._get_label_field_type(field_name)
 
         if issubclass(label_type, fol._LABEL_LIST_FIELDS):
-            field_name += "." + label_type._LABEL_LIST_FIELD
+            # some fields (including dynamic fields) with labels might
+            # come daisy.chained already. ex: custom_document.detections
+            if not "." in field_name:
+                field_name += "." + label_type._LABEL_LIST_FIELD
+            else:
+                field_name = field_name[0 : field_name.index(".")]
 
         if subfield:
             field_path = field_name + "." + subfield

--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -9660,12 +9660,7 @@ class SampleCollection(object):
         label_type = self._get_label_field_type(field_name)
 
         if issubclass(label_type, fol._LABEL_LIST_FIELDS):
-            # some fields (including dynamic fields) with labels might
-            # come daisy.chained already. ex: custom_document.detections
-            if not "." in field_name:
-                field_name += "." + label_type._LABEL_LIST_FIELD
-            else:
-                field_name = field_name[0 : field_name.index(".")]
+            field_name += "." + label_type._LABEL_LIST_FIELD
 
         if subfield:
             field_path = field_name + "." + subfield

--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -9519,10 +9519,10 @@ class SampleCollection(object):
         media_fields = {}
 
         if frames:
-            schema = self.get_frame_field_schema()
+            schema = self.get_frame_field_schema(flat=True)
             app_media_fields = set()
         else:
-            schema = self.get_field_schema()
+            schema = self.get_field_schema(flat=True)
             app_media_fields = set(self._dataset.app_config.media_fields)
 
         if not include_filepath:
@@ -9631,9 +9631,9 @@ class SampleCollection(object):
             field_name = field_name[2:]
 
         if is_frame_field:
-            schema = self.get_frame_field_schema()
+            schema = self.get_frame_field_schema(flat=True)
         else:
-            schema = self.get_field_schema()
+            schema = self.get_field_schema(flat=True)
 
         if field_name not in schema:
             ftype = "frame field" if is_frame_field else "field"

--- a/fiftyone/server/routes/tag.py
+++ b/fiftyone/server/routes/tag.py
@@ -69,7 +69,7 @@ class Tag(HTTPEndpoint):
             hidden_labels=hidden_labels,
             sample_ids=sample_ids,
             sample_filter=SampleFilter(
-                group=GroupElementFilter(id=group_id, slice=slice)
+                group=GroupElementFilter(id=group_id, slices=slices)
             ),
             target_labels=False,
         )


### PR DESCRIPTION
Fix 1
The sample modal was not successfully tagging - unrelated to this work - @sashankaryal fixed that!

Fix 2
small backend tweak where dynamic fields with labels were coming in as `custom_document.detections` and getting suffixed with another detections causing DB filed error

Fix 3
With the recent introduction of allowing labels in embedded fields to be visualized/filtered, some redundant paths were added to the count and tagging paths. the schema is now flattened so that these dynamic fields can be recognized and visualized, etc. 

the flat schema is now bringing some unwanted/redundant label fields into labelPaths which eventually powers the tag label count and gets sent to /tag route when submitting a tag, causing a crash.

ex: labelPaths = [custom_document.detections, custom_document.detections.detections]
is wrong and will cause unwanted issues with anything dependent on the labelPaths.

where,
labelPaths = [custom_document.detections]
works as expected with label count (when Tagger is open) and submitting any tags for labels now success - before crashing if embedded document type exists

![Screenshot 2023-05-23 at 10 45 10 AM](https://github.com/voxel51/fiftyone/assets/17770824/1540ad94-8a2f-4556-8530-8928b4c3c1c7)

![Screenshot 2023-05-23 at 10 45 26 AM](https://github.com/voxel51/fiftyone/assets/17770824/3af3bd93-f76d-4bad-9ab9-683d256f1094)

## What changes are proposed in this pull request?

Label tag counts are 2x reality

## How is this patch tested? If it is not, please explain why.

(Details)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
