### PR TITLE
hide empty classification list as tags in looker

### DIFF
--- a/app/packages/looker/src/elements/common/tags.ts
+++ b/app/packages/looker/src/elements/common/tags.ts
@@ -320,6 +320,8 @@ export class TagsElement<State extends BaseState> extends BaseElement<State> {
           if (path.startsWith("frames.")) continue;
           const classifications = LABEL_LISTS.includes(field.embeddedDocType);
 
+          if (!value.classifications?.length) continue;
+
           if (classifications) {
             pushList(
               LABEL_RENDERERS[field.embeddedDocType],


### PR DESCRIPTION
## What changes are proposed in this pull request?

- Filters out empty list of classifications if any

problem
in `open-images-v7-validation-100` and other datasets, we saw `None` label/tags showing up in the Grid.

<img width="1054" alt="Screen Shot 2023-05-23 at 9 26 05 AM" src="https://github.com/voxel51/fiftyone/assets/109545780/0fb254b8-1fb3-443d-9324-be2b61e9188e">


solution
filter empty lists of classifications
<img width="1206" alt="Screen Shot 2023-05-23 at 9 24 51 AM" src="https://github.com/voxel51/fiftyone/assets/109545780/85436226-c518-47a8-ad8b-ef6cc6a3348a">



## How is this patch tested? If it is not, please explain why.

(Details)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
