### PR TITLE
fix setGroupSlice mutation bug when refreshing page after clearing views

### DIFF
--- a/fiftyone/server/mutation.py
+++ b/fiftyone/server/mutation.py
@@ -244,7 +244,7 @@ class Mutation:
             saved_view_slug=fou.to_slug(view_name)
             if view_name
             else fou.to_slug(state.view.name)
-            if state.view
+            if state.view and state.view.name
             else None,
             info=info,
         )


### PR DESCRIPTION
## What changes are proposed in this pull request?

fixes a bug associated with `set_group_slice` mutation; the symptom on the app looking like:
<img width="1092" alt="Screenshot 2023-05-23 at 5 27 55 PM" src="https://github.com/voxel51/fiftyone/assets/66688606/e9057150-4840-45d7-bc5f-e07980824eda">


## How is this patch tested? If it is not, please explain why.

Locally. To reproduce:
1. Open a dataset.
2. Add view stages / select a saved view.
3. Clear view stages.
4. Refresh the page.

There's also an e2e regression test that's part of dynamic groups e2e PR that checks for this.

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
