### PR TITLE
Bugfix: fix overlay rendering issue for dynamic embeddedDoc fields

### DIFF
--- a/app/packages/core/src/components/Sidebar/Entries/GroupEntries.tsx
+++ b/app/packages/core/src/components/Sidebar/Entries/GroupEntries.tsx
@@ -181,16 +181,6 @@ const useClearActive = (modal: boolean, group: string) => {
         );
         const active = await snapshot.getPromise(fos.activeFields({ modal }));
 
-        if (group === "tags") {
-          set(fos.activeTags(modal), []);
-          return;
-        }
-
-        if (group === "label tags") {
-          set(fos.activeLabelTags(modal), []);
-          return;
-        }
-
         set(
           fos.activeFields({ modal }),
           active.filter((p) => !paths.includes(p))

--- a/app/packages/embeddings/src/tracesToData.tsx
+++ b/app/packages/embeddings/src/tracesToData.tsx
@@ -79,11 +79,11 @@ export function tracesToData(
 }
 
 const getLabelColor = (key: string, setting: CustomizeColor): Color | null => {
-  if (!setting || !setting.labelColors) {
+  if (!setting || !setting.valueColors) {
     return null;
   }
 
-  const color = setting.labelColors.find((x) => x.name === key)?.color;
+  const color = setting.valueColors.find((x) => x.value === key)?.color;
   return getConvertedColor(color);
 };
 

--- a/app/packages/looker/src/elements/common/tags.ts
+++ b/app/packages/looker/src/elements/common/tags.ts
@@ -118,7 +118,7 @@ export class TagsElement<State extends BaseState> extends BaseElement<State> {
           color: getColorFromOptionsPrimitives({
             coloring,
             path,
-            value,
+            value: v,
             customizeColorSetting,
           }),
         };
@@ -132,7 +132,7 @@ export class TagsElement<State extends BaseState> extends BaseElement<State> {
           color: getColorFromOptionsPrimitives({
             coloring,
             path,
-            value,
+            value: v,
             customizeColorSetting,
           }),
         };
@@ -146,7 +146,7 @@ export class TagsElement<State extends BaseState> extends BaseElement<State> {
           color: getColorFromOptionsPrimitives({
             coloring,
             path,
-            value,
+            value: v,
             customizeColorSetting,
           }),
         };
@@ -160,7 +160,7 @@ export class TagsElement<State extends BaseState> extends BaseElement<State> {
           color: getColorFromOptionsPrimitives({
             coloring,
             path,
-            value,
+            value: v,
             customizeColorSetting,
           }),
         };
@@ -174,7 +174,7 @@ export class TagsElement<State extends BaseState> extends BaseElement<State> {
           color: getColorFromOptionsPrimitives({
             coloring,
             path,
-            value,
+            value: v,
             customizeColorSetting,
           }),
         };
@@ -187,7 +187,7 @@ export class TagsElement<State extends BaseState> extends BaseElement<State> {
           color: getColorFromOptionsPrimitives({
             coloring,
             path,
-            value,
+            value: v,
             customizeColorSetting,
           }),
         };
@@ -276,7 +276,7 @@ export class TagsElement<State extends BaseState> extends BaseElement<State> {
           elements.push({
             color: getColor(coloring.pool, coloring.seed, v),
             title: value,
-            value,
+            value: tag,
           });
         });
       } else {
@@ -321,14 +321,12 @@ export class TagsElement<State extends BaseState> extends BaseElement<State> {
         if (field && LABEL_RENDERERS[field.embeddedDocType]) {
           if (path.startsWith("frames.")) continue;
           const classifications = LABEL_LISTS.includes(field.embeddedDocType);
-
-          if (!value.classifications?.length) continue;
-
           if (classifications) {
-            pushList(
-              LABEL_RENDERERS[field.embeddedDocType],
-              value.classifications
-            );
+            !value?.classifications?.length &&
+              pushList(
+                LABEL_RENDERERS[field.embeddedDocType],
+                value?.classifications
+              );
           } else {
             elements.push(LABEL_RENDERERS[field.embeddedDocType](path, value));
           }

--- a/app/packages/looker/src/elements/common/util.ts
+++ b/app/packages/looker/src/elements/common/util.ts
@@ -118,8 +118,10 @@ export const getColorFromOptions = ({
     if (setting) {
       key = setting.colorByAttribute ?? labelDefault ? "label" : "value";
       // check if this label has a assigned color, use it if it is a valid color
-      const labelColor = setting.valueColors?.find(
-        (l) => l.value?.toString() == param[key]?.toString()
+      const labelColor = setting.valueColors?.find((l) =>
+        ["none", "null", "undefined"].includes(l.value?.toLowerCase())
+          ? !param[key]
+          : l.value?.toString() == param[key]?.toString()
       )?.color;
       if (isValidColor(labelColor)) {
         return labelColor;

--- a/app/packages/looker/src/elements/common/util.ts
+++ b/app/packages/looker/src/elements/common/util.ts
@@ -11,8 +11,12 @@ import {
 import { Overlay } from "../../overlays/base";
 import { Classification, Regression } from "../../overlays/classifications";
 import { isValidColor } from "../../overlays/util";
-import { BaseState, Coloring, CustomizeColor } from "../../state";
-import { DispatchEvent } from "../../state";
+import {
+  BaseState,
+  Coloring,
+  CustomizeColor,
+  DispatchEvent,
+} from "../../state";
 
 import { lookerCheckbox, lookerLabel } from "./util.module.css";
 
@@ -31,7 +35,7 @@ export const dispatchTooltipEvent = <State extends BaseState>(
       return;
     }
 
-    let detail =
+    const detail =
       overlays.length && overlays[0].containsPoint(state) && !nullify
         ? overlays[0].getPointInfo(state)
         : null;
@@ -118,13 +122,21 @@ export const getColorFromOptions = ({
     if (setting) {
       key = setting.colorByAttribute ?? labelDefault ? "label" : "value";
       // check if this label has a assigned color, use it if it is a valid color
-      const labelColor = setting.valueColors?.find((l) =>
-        ["none", "null", "undefined"].includes(l.value?.toLowerCase())
-          ? !param[key]
-          : l.value?.toString() == param[key]?.toString()
-      )?.color;
-      if (isValidColor(labelColor)) {
-        return labelColor;
+      const valueColor = setting?.valueColors?.find((l) => {
+        if (["none", "null", "undefined"].includes(l.value?.toLowerCase())) {
+          return !param[key];
+        }
+        if (["True", "False"].includes(l.value?.toString())) {
+          return (
+            l.value?.toString().toLowerCase() ==
+            param[key]?.toString().toLowerCase()
+          );
+        }
+        return l.value?.toString() == param[key]?.toString();
+      })?.color;
+
+      if (isValidColor(valueColor)) {
+        return valueColor;
       }
     } else {
       key = labelDefault ? "label" : "value";
@@ -157,11 +169,19 @@ export const getColorFromOptionsPrimitives = ({
   if (coloring.by === "value") {
     if (setting) {
       // check if this label has a assigned color, use it if it is a valid color
-      const labelColor = setting.valueColors?.find(
-        (l) => l.value?.toString() == value?.toString()
-      )?.color;
-      if (isValidColor(labelColor)) {
-        return labelColor;
+      const valueColor = setting.valueColors?.find((l) => {
+        if (["none", "null", "undefined"].includes(l.value?.toLowerCase())) {
+          return !value;
+        }
+        if (["True", "False"].includes(l.value?.toString())) {
+          return (
+            l.value?.toString().toLowerCase() == value.toString().toLowerCase()
+          );
+        }
+        return l.value?.toString() == value.toString();
+      })?.color;
+      if (isValidColor(valueColor)) {
+        return valueColor;
       }
     }
     return getColor(coloring.pool, coloring.seed, path);

--- a/app/packages/looker/src/overlays/base.ts
+++ b/app/packages/looker/src/overlays/base.ts
@@ -116,8 +116,10 @@ export abstract class CoordinateOverlay<
             : field.colorByAttribute
           : "label";
         // check if this label has a assigned color, use it if it is a valid color
-        const labelColor = field.valueColors?.find(
-          (l) => l.value?.toString() == this.label[key]?.toString()
+        const labelColor = field.valueColors?.find((l) =>
+          ["none", "null", "undefined"].includes(l.value?.toLowerCase())
+            ? !this.label[key]
+            : l.value?.toString() == this.label[key]?.toString()
         )?.color;
 
         return isValidColor(labelColor)

--- a/app/packages/looker/src/overlays/base.ts
+++ b/app/packages/looker/src/overlays/base.ts
@@ -115,15 +115,22 @@ export abstract class CoordinateOverlay<
             ? "id"
             : field.colorByAttribute
           : "label";
-        // check if this label has a assigned color, use it if it is a valid color
-        const labelColor = field.valueColors?.find((l) =>
-          ["none", "null", "undefined"].includes(l.value?.toLowerCase())
-            ? !this.label[key]
-            : l.value?.toString() == this.label[key]?.toString()
-        )?.color;
 
-        return isValidColor(labelColor)
-          ? labelColor
+        // check if this label has a assigned color, use it if it is a valid color
+        const valueColor = field?.valueColors?.find((l) => {
+          if (["none", "null", "undefined"].includes(l.value?.toLowerCase())) {
+            return !this.label[key];
+          }
+          if (["True", "False"].includes(l.value?.toString())) {
+            return (
+              l.value?.toString().toLowerCase() ==
+              this.label[key]?.toString().toLowerCase()
+            );
+          }
+          return l.value?.toString() == this.label[key]?.toString();
+        })?.color;
+        return isValidColor(valueColor)
+          ? valueColor
           : getColor(coloring.pool, coloring.seed, this.label[key]);
       } else {
         return getColor(coloring.pool, coloring.seed, this.label["label"]);

--- a/app/packages/looker/src/overlays/classifications.ts
+++ b/app/packages/looker/src/overlays/classifications.ts
@@ -201,11 +201,13 @@ export class ClassificationsOverlay<
   protected getFiltered(state: Readonly<State>): Labels<Label> {
     return this.labels.map(([field, labels]) => [
       field,
-      labels.filter(
-        (label) =>
-          MOMENT_CLASSIFICATIONS.includes(label._cls) &&
-          isShown(state, field, label)
-      ),
+      Array.isArray(labels)
+        ? labels.filter(
+            (label) =>
+              MOMENT_CLASSIFICATIONS.includes(label._cls) &&
+              isShown(state, field, label)
+          )
+        : [],
     ]);
   }
 

--- a/app/packages/looker/src/overlays/classifications.ts
+++ b/app/packages/looker/src/overlays/classifications.ts
@@ -72,8 +72,10 @@ export class ClassificationsOverlay<
     if (coloring.by !== "field") {
       key = setting?.colorByAttribute ?? key;
       // check if this label has a assigned color, use it if it is a valid color
-      const labelColor = setting?.valueColors?.find(
-        (l) => l.value?.toString() == label[key]?.toString()
+      const labelColor = setting?.valueColors?.find((l) =>
+        ["none", "null", "undefined"].includes(l.value?.toLowerCase())
+          ? !label[key]
+          : l.value?.toString() == label[key]?.toString()
       )?.color;
       if (isValidColor(labelColor)) {
         return labelColor;

--- a/app/packages/looker/src/overlays/classifications.ts
+++ b/app/packages/looker/src/overlays/classifications.ts
@@ -60,6 +60,7 @@ export class ClassificationsOverlay<
       ? field.slice("frames.".length)
       : field;
     const setting = customizeColorSetting.find((s) => s.path === f);
+
     // check if the field has a customized color, use it if it is a valid color
     if (
       coloring.by === "field" &&
@@ -71,14 +72,23 @@ export class ClassificationsOverlay<
 
     if (coloring.by !== "field") {
       key = setting?.colorByAttribute ?? key;
+
       // check if this label has a assigned color, use it if it is a valid color
-      const labelColor = setting?.valueColors?.find((l) =>
-        ["none", "null", "undefined"].includes(l.value?.toLowerCase())
-          ? !label[key]
-          : l.value?.toString() == label[key]?.toString()
-      )?.color;
-      if (isValidColor(labelColor)) {
-        return labelColor;
+      const valueColor = setting?.valueColors?.find((l) => {
+        if (["none", "null", "undefined"].includes(l.value?.toLowerCase())) {
+          return !label[key];
+        }
+        if (["True", "False"].includes(l.value?.toString())) {
+          return (
+            l.value?.toString().toLowerCase() ==
+            label[key]?.toString().toLowerCase()
+          );
+        }
+        return l.value?.toString() == label[key]?.toString();
+      })?.color;
+
+      if (isValidColor(valueColor)) {
+        return valueColor;
       }
 
       // fallback to use label as default attribute

--- a/app/packages/looker/src/overlays/index.ts
+++ b/app/packages/looker/src/overlays/index.ts
@@ -59,16 +59,38 @@ export const loadOverlays = <State extends BaseState>(
       continue;
     }
 
-    if (label._cls in FROM_FO) {
-      const labelOverlays = FROM_FO[label._cls](field, label, this);
-      overlays = [...overlays, ...labelOverlays];
-    } else if (LABEL_TAGS_CLASSES.includes(label._cls)) {
-      classifications.push([
-        field,
-        label._cls in LABEL_LISTS_MAP
-          ? label[LABEL_LISTS_MAP[label._cls]]
-          : [label],
-      ]);
+    if (label._cls === "DynamicEmbeddedDocument") {
+      const [key, element] = Object.entries(label)[1];
+      const dynamicField = [field, key].join(".");
+      const dynamicLabel = element;
+
+      if (dynamicLabel["_cls"] in FROM_FO) {
+        const labelOverlays = FROM_FO[dynamicLabel["_cls"]](
+          dynamicField,
+          dynamicLabel,
+          this
+        );
+        overlays = [...overlays, ...labelOverlays];
+      } else if (LABEL_TAGS_CLASSES.includes(dynamicLabel["_cls"])) {
+        classifications.push([
+          field,
+          dynamicLabel["_cls"] in LABEL_LISTS_MAP
+            ? label[LABEL_LISTS_MAP[dynamicLabel["_cls"]]]
+            : [label],
+        ]);
+      }
+    } else {
+      if (label._cls in FROM_FO) {
+        const labelOverlays = FROM_FO[label._cls](field, label, this);
+        overlays = [...overlays, ...labelOverlays];
+      } else if (LABEL_TAGS_CLASSES.includes(label._cls)) {
+        classifications.push([
+          field,
+          label._cls in LABEL_LISTS_MAP
+            ? label[LABEL_LISTS_MAP[label._cls]]
+            : [label],
+        ]);
+      }
     }
   }
 

--- a/app/packages/looker/src/overlays/index.ts
+++ b/app/packages/looker/src/overlays/index.ts
@@ -52,45 +52,38 @@ export const loadOverlays = <State extends BaseState>(
   video = false
 ): Overlay<State>[] => {
   const classifications = [];
-  let overlays = [];
+  const overlays = [];
+
   for (const field in sample) {
     const label = sample[field];
+
     if (!label) {
       continue;
     }
 
-    if (label._cls === "DynamicEmbeddedDocument") {
-      const [key, element] = Object.entries(label)[1];
-      const dynamicField = [field, key].join(".");
-      const dynamicLabel = element;
+    const dynamicLabel =
+      label._cls === "DynamicEmbeddedDocument"
+        ? Object.entries(label)[1][1]
+        : label;
+    const dynamicField =
+      label._cls === "DynamicEmbeddedDocument"
+        ? [field, Object.entries(label)[1][0]].join(".")
+        : field;
 
-      if (dynamicLabel["_cls"] in FROM_FO) {
-        const labelOverlays = FROM_FO[dynamicLabel["_cls"]](
-          dynamicField,
-          dynamicLabel,
-          this
-        );
-        overlays = [...overlays, ...labelOverlays];
-      } else if (LABEL_TAGS_CLASSES.includes(dynamicLabel["_cls"])) {
-        classifications.push([
-          field,
-          dynamicLabel["_cls"] in LABEL_LISTS_MAP
-            ? label[LABEL_LISTS_MAP[dynamicLabel["_cls"]]]
-            : [label],
-        ]);
-      }
-    } else {
-      if (label._cls in FROM_FO) {
-        const labelOverlays = FROM_FO[label._cls](field, label, this);
-        overlays = [...overlays, ...labelOverlays];
-      } else if (LABEL_TAGS_CLASSES.includes(label._cls)) {
-        classifications.push([
-          field,
-          label._cls in LABEL_LISTS_MAP
-            ? label[LABEL_LISTS_MAP[label._cls]]
-            : [label],
-        ]);
-      }
+    if (dynamicLabel._cls in FROM_FO) {
+      const labelOverlays = FROM_FO[dynamicLabel._cls](
+        dynamicField,
+        dynamicLabel,
+        this
+      );
+      overlays.push(...labelOverlays);
+    } else if (LABEL_TAGS_CLASSES.includes(dynamicLabel._cls)) {
+      classifications.push([
+        dynamicField,
+        dynamicLabel._cls in LABEL_LISTS_MAP
+          ? label[LABEL_LISTS_MAP[dynamicLabel._cls]]
+          : [label],
+      ]);
     }
   }
 

--- a/app/packages/looker/src/worker/painter.ts
+++ b/app/packages/looker/src/worker/painter.ts
@@ -35,8 +35,10 @@ export const PainterFactory = (requestColor) => ({
             ? "id"
             : setting.colorByAttribute
           : "label";
-        const labelColor = setting.valueColors?.find(
-          (l) => l.value?.toString() === label[key]?.toString()
+        const labelColor = setting.valueColors?.find((l) =>
+          ["none", "null", "undefined"].includes(l.value?.toLowerCase())
+            ? !label[key]
+            : l.value?.toString() == label[key]?.toString()
         )?.color;
 
         color = labelColor

--- a/app/packages/looker/src/worker/painter.ts
+++ b/app/packages/looker/src/worker/painter.ts
@@ -35,14 +35,20 @@ export const PainterFactory = (requestColor) => ({
             ? "id"
             : setting.colorByAttribute
           : "label";
-        const labelColor = setting.valueColors?.find((l) =>
-          ["none", "null", "undefined"].includes(l.value?.toLowerCase())
-            ? !label[key]
-            : l.value?.toString() == label[key]?.toString()
-        )?.color;
-
-        color = labelColor
-          ? labelColor
+        const valueColor = setting?.valueColors?.find((l) => {
+          if (["none", "null", "undefined"].includes(l.value?.toLowerCase())) {
+            return !label[key];
+          }
+          if (["True", "False"].includes(l.value?.toString())) {
+            return (
+              l.value?.toString().toLowerCase() ==
+              label[key]?.toString().toLowerCase()
+            );
+          }
+          return l.value?.toString() == label[key]?.toString();
+        })?.color;
+        color = valueColor
+          ? valueColor
           : await requestColor(coloring.pool, coloring.seed, label[key]);
       } else {
         color = await requestColor(coloring.pool, coloring.seed, label.label);

--- a/app/packages/state/src/recoil/color.ts
+++ b/app/packages/state/src/recoil/color.ts
@@ -3,6 +3,8 @@ import { selector, selectorFamily } from "recoil";
 import { Coloring } from "@fiftyone/looker";
 import {
   createColorGenerator,
+  DYNAMIC_EMBEDDED_DOCUMENT_FIELD,
+  DYNAMIC_EMBEDDED_DOCUMENT_FIELD_V2,
   getColor,
   hexToRgb,
   RGB,
@@ -78,22 +80,33 @@ export const pathColor = selectorFamily<
       // video path tweak
       const field = get(schemaAtoms.field(path));
       const video = get(selectors.mediaTypeSelector) !== "image";
+
       const parentPath =
         video && path.startsWith("frames.")
           ? path.split(".").slice(0, 2).join(".")
           : path.split(".")[0];
-      const adjustedPath = field?.embeddedDocType
+
+      let adjustedPath = field?.embeddedDocType
         ? parentPath.startsWith("frames.")
           ? parentPath.slice("frames.".length)
           : parentPath
         : path;
 
+      if (
+        [
+          DYNAMIC_EMBEDDED_DOCUMENT_FIELD,
+          DYNAMIC_EMBEDDED_DOCUMENT_FIELD_V2,
+        ].includes(get(schemaAtoms.field(adjustedPath))?.embeddedDocType ?? "")
+      ) {
+        adjustedPath = path;
+      }
+
       const setting = get(atoms.sessionColorScheme)?.fields?.find(
         (x) => x.path === adjustedPath
       );
 
-      if (isValidColor(setting?.fieldColor)) {
-        return setting.fieldColor;
+      if (isValidColor(setting?.fieldColor ?? "")) {
+        return setting!.fieldColor;
       }
 
       const map = get(colorMap(modal));

--- a/app/packages/state/src/recoil/color.ts
+++ b/app/packages/state/src/recoil/color.ts
@@ -3,7 +3,6 @@ import { selector, selectorFamily } from "recoil";
 import { Coloring } from "@fiftyone/looker";
 import {
   createColorGenerator,
-  DYNAMIC_EMBEDDED_DOCUMENT_FIELD,
   DYNAMIC_EMBEDDED_DOCUMENT_FIELD_V2,
   getColor,
   hexToRgb,
@@ -93,10 +92,8 @@ export const pathColor = selectorFamily<
         : path;
 
       if (
-        [
-          DYNAMIC_EMBEDDED_DOCUMENT_FIELD,
-          DYNAMIC_EMBEDDED_DOCUMENT_FIELD_V2,
-        ].includes(get(schemaAtoms.field(adjustedPath))?.embeddedDocType ?? "")
+        get(schemaAtoms.field(adjustedPath))?.embeddedDocType ===
+        DYNAMIC_EMBEDDED_DOCUMENT_FIELD_V2
       ) {
         adjustedPath = path;
       }


### PR DESCRIPTION
-Fixed overlay rendering issues of dynamic embeddedDoc fields
-Fixed a regression with rendering classification labels
-Fixed an issue that user cannot set color value for None/Undefined attribute values in color by value mode

Main change: updated the path and label to create overlay for dynamic embeddedDoc fields in this directory 
`app/packages/looker/src/overlays/index.ts`

How to test `DynamicEmbeddedDocument`: 
```
import fiftyone as fo
dataset = foz.load_zoo_dataset("quickstart")
sample = dataset.first()
detections = fo.Detections(
                detections=[
                  fo.Detection(
                        label="cat",
                        bounding_box=[0.018094074726104737, 0.5562847137451172, 0.17362892627716064, 0.15742950439453124],
                        foo="bar",
                        hello=True,
                    ),
                    fo.Detection(
                        label="dog",
                        bounding_box=[0.217216157913208, 0.05954849322636922, 0.4945165634155273, 0.8721434275309244],
                       hello=None,
                    )
                ]
            )

sample["task"] = fo.DynamicEmbeddedDocument(detections=detections)

sample.save()
dataset.add_dynamic_sample_fields()
dataset.save()
session = fo.launch_app(dataset)
```

![Screenshot 2023-05-23 at 5 44 32 PM](https://github.com/voxel51/fiftyone/assets/17770824/dd5d0a0c-7684-4bae-97d5-d654ac8fc646)
![Screenshot 2023-05-23 at 5 44 41 PM](https://github.com/voxel51/fiftyone/assets/17770824/364f1a5c-13cf-4a12-b26b-58acc81b2159)

## What changes are proposed in this pull request?

(Please fill in changes proposed in this fix)

## How is this patch tested? If it is not, please explain why.

(Details)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
