### PR TITLE
Bugfix: fix label tag regression in modal view

### DIFF
--- a/app/packages/core/src/components/Modal/Modal.tsx
+++ b/app/packages/core/src/components/Modal/Modal.tsx
@@ -133,7 +133,7 @@ const SampleModal = () => {
                     onBlur={() => {
                       controller.set({ zIndex: "0" });
                     }}
-                    disabled={isOther || isLabelTag || isTag}
+                    disabled={isOther}
                     key={key}
                     trigger={trigger}
                   />
@@ -148,7 +148,7 @@ const SampleModal = () => {
                 )}
               </>
             ),
-            disabled: isTag || isLabelTag || isOther,
+            disabled: isTag || isOther,
           };
 
         case fos.EntryKind.GROUP: {

--- a/app/packages/core/src/components/Sidebar/Entries/EntryCounts.tsx
+++ b/app/packages/core/src/components/Sidebar/Entries/EntryCounts.tsx
@@ -56,14 +56,12 @@ export const PathEntryCounts = ({
 
   return shown.state === "loading" ? (
     <LoadingDots text="" />
-  ) : (
-    shown.contents && (
-      <SuspenseEntryCounts
-        countAtom={getAtom(false)}
-        subcountAtom={getAtom(true)}
-      />
-    )
-  );
+  ) : shown.contents ? (
+    <SuspenseEntryCounts
+      countAtom={getAtom(false)}
+      subcountAtom={getAtom(true)}
+    />
+  ) : null;
 };
 
 const labelTagCount = selectorFamily<

--- a/app/packages/core/src/components/Sidebar/Entries/FilterablePathEntry.tsx
+++ b/app/packages/core/src/components/Sidebar/Entries/FilterablePathEntry.tsx
@@ -305,6 +305,7 @@ const FilterableEntry = ({
   const hidden = modal ? useHidden(path) : null;
 
   const onClick = useOnClick({ disabled, modal, path });
+  const isLabelTag = path === "_label_tags";
 
   return (
     <RegularEntry
@@ -317,7 +318,7 @@ const FilterableEntry = ({
       entryKey={entryKey}
       heading={
         <>
-          {!disabled && (
+          {!disabled && !isLabelTag && (
             <Checkbox
               checked={active}
               title={`Show ${path}`}


### PR DESCRIPTION
Fix a regression of label tag not displaying in sample modal view.

https://github.com/voxel51/fiftyone/assets/17770824/ad049282-7f76-4759-80a2-498faed41467


## What changes are proposed in this pull request?

(Please fill in changes proposed in this fix)

## How is this patch tested? If it is not, please explain why.

(Details)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
