### PR TITLE
fix urls transformation bug

### DIFF
--- a/app/packages/core/src/components/Modal/Looker.tsx
+++ b/app/packages/core/src/components/Modal/Looker.tsx
@@ -85,32 +85,15 @@ const Looker = ({
   }
 
   const sampleData = useMemo(() => {
-    let transformedUrls = modalSampleData?.urls
-      ? { ...modalSampleData.urls }
-      : {};
-    if (urls) {
-      if (Array.isArray(urls)) {
-        for (const { field, url } of urls) {
-          transformedUrls[field] = url;
-        }
-      } else {
-        transformedUrls = urls;
-      }
-    }
-
     if (propsSampleData) {
       return {
         ...modalSampleData,
         sample: propsSampleData,
-        urls: transformedUrls,
       };
     }
 
-    return {
-      ...modalSampleData,
-      urls: transformedUrls,
-    };
-  }, [propsSampleData, modalSampleData, urls]);
+    return modalSampleData;
+  }, [propsSampleData, modalSampleData]);
 
   const { sample } = sampleData;
 

--- a/app/packages/state/src/hooks/useCreateLooker.ts
+++ b/app/packages/state/src/hooks/useCreateLooker.ts
@@ -47,7 +47,7 @@ export default <T extends FrameLooker | ImageLooker | VideoLooker>(
   );
 
   const create = useCallback(
-    ({ frameNumber, frameRate, sample, urls }: SampleData): T => {
+    ({ frameNumber, frameRate, sample, urls: rawUrls }: SampleData): T => {
       let constructor:
         | typeof FrameLooker
         | typeof ImageLooker
@@ -55,6 +55,19 @@ export default <T extends FrameLooker | ImageLooker | VideoLooker>(
         | typeof VideoLooker = ImageLooker;
 
       const mimeType = getMimeType(sample);
+
+      let urls = {};
+
+      // sometimes the urls are an array of objects, sometimes they are just an object
+      // this is a workaround to make sure we can handle both cases
+      // todo: investigate why this is the case
+      if (Array.isArray(rawUrls)) {
+        for (const { field, url } of rawUrls) {
+          urls[field] = url;
+        }
+      } else {
+        urls = rawUrls;
+      }
 
       // checking for pcd extension instead of media_type because this also applies for group slices
       if (urls.filepath?.endsWith(".pcd")) {


### PR DESCRIPTION
## What changes are proposed in this pull request?

`useCreateLooker()` expects `urls` as an object. But because of erroneous upstream transformation, it's sometimes received as an array of objects. This PR adds a guard so that urls passed as arrays are transformed into objects. This was previously done in `Looker.tsx` but there're other modules that also invoke `useCreateLooker()`, like `Grid.tsx` or flashlight, and it makes more sense for this transformation logic to be in `useCreateLooker()`.

## How is this patch tested? If it is not, please explain why.

Locally.

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
