### PR TITLE
replace set with addFields in aggregations py

### DIFF
--- a/fiftyone/core/aggregations.py
+++ b/fiftyone/core/aggregations.py
@@ -808,7 +808,7 @@ class CountValues(Aggregation):
         if self._include is not None:
             limit = max(limit, len(self._include))
             pipeline += [
-                {"$set": {"included": {"$in": ["$_id", self._include]}}},
+                {"$addFields": {"included": {"$in": ["$_id", self._include]}}},
             ]
             sort["included"] = -1
 
@@ -2920,7 +2920,9 @@ def _handle_reduce_unwinds(path, unwind_list_fields, other_list_fields):
                 (F(leaf) != None).if_else(VALUE.extend(F(leaf)), VALUE),
                 init_val=[],
             )
-            pipeline.append({"$set": {prev_list: reduce_expr.to_mongo()}})
+            pipeline.append(
+                {"$addFields": {prev_list: reduce_expr.to_mongo()}}
+            )
             path, list_fields = _replace_list(
                 path, list_fields, list_field, prev_list
             )


### PR DESCRIPTION
## What changes are proposed in this pull request?

This PR replaces the aggregation stage `$set` operator with the `$addFields` operator in `aggregations.py`. These two operators [are alias](https://www.mongodb.com/docs/manual/reference/operator/aggregation/addFields/) to each other in MongoDB. The reason for the change is `$addFields` is [supported by AWS DocumentDB](https://docs.aws.amazon.com/documentdb/latest/developerguide/mongo-apis.html) while `$set` is not. 

Note the $set operator is overloaded in MongoDB, and the one under change is the [aggregation stage $set operator](https://www.mongodb.com/docs/manual/reference/operator/aggregation/set/#mongodb-pipeline-pipe.-set) as opposed to the [update operator $set](https://www.mongodb.com/docs/manual/reference/operator/update/set/).

PRs will follow up to replace all the `$set` operators to `$addFields`

## How is this patch tested? If it is not, please explain why.

(Details)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
