### PR TITLE
view expression and count of hidden fields improved

### DIFF
--- a/app/packages/core/src/components/ViewBar/ViewStage/viewStageParameterMachine.ts
+++ b/app/packages/core/src/components/ViewBar/ViewStage/viewStageParameterMachine.ts
@@ -162,10 +162,11 @@ export const PARSER = {
       try {
         array = JSON.parse(stripped);
       } catch {
+        // ex: exclude_fields('a, b'). 'a,b' => ['a', 'b']
         array = stripped.split(",");
       }
       return (
-        typeof value !== "string" &&
+        typeof array !== "string" &&
         Array.isArray(array) &&
         array.every((e) => PARSER.str.validate(e))
       );

--- a/app/packages/looker/src/overlays/index.ts
+++ b/app/packages/looker/src/overlays/index.ts
@@ -82,8 +82,8 @@ export const loadOverlays = <State extends BaseState>(
       classifications.push([
         dynamicField,
         dynamicLabel._cls in LABEL_LISTS_MAP
-          ? label[LABEL_LISTS_MAP[dynamicLabel._cls]]
-          : [label],
+          ? dynamicLabel[LABEL_LISTS_MAP[dynamicLabel._cls]]
+          : [dynamicLabel],
       ]);
     }
   }

--- a/app/packages/state/src/hooks/useSchemaSettings.ts
+++ b/app/packages/state/src/hooks/useSchemaSettings.ts
@@ -822,6 +822,19 @@ export default function useSchemaSettings() {
     [finalSchema, allPaths, vPaths, datasetName]
   );
 
+  const bareFinalSchema = useMemo(
+    () =>
+      mergedSchema
+        ? finalSchema.filter((field) => {
+            return (
+              !disabledField(field.path, mergedSchema, dataset?.groupField) &&
+              !skipField(field.path, mergedSchema?.[field.path], mergedSchema)
+            );
+          })
+        : finalSchema,
+    [mergedSchema, finalSchema]
+  );
+
   // updates the affected fields count
   useEffect(() => {
     if (finalSchema?.length && excludedPaths?.[datasetName]) {
@@ -830,7 +843,7 @@ export default function useSchemaSettings() {
         searchResults?.length
       ) {
         setAffectedPathCount(
-          Object.keys(schema)?.length - searchResults.length
+          Object.keys(bareFinalSchema)?.length - searchResults.length
         );
       } else {
         setAffectedPathCount(excludedPaths[datasetName].size);


### PR DESCRIPTION
## What changes are proposed in this pull request?

fixes 
- removes disabled/skipped fields for better hidden field count report.
- fixes the view stage to show the fields selected/excluded
<img width="900" alt="Screen Shot 2023-05-25 at 5 19 10 AM" src="https://github.com/voxel51/fiftyone/assets/109545780/4913f49e-f69d-4977-8e39-419c0eaf7b66">


## How is this patch tested? If it is not, please explain why.

(Details)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
