### PR TITLE
allow multi class classifications from scale.com labelling

### DIFF
--- a/fiftyone/utils/scale.py
+++ b/fiftyone/utils/scale.py
@@ -1031,7 +1031,14 @@ def _parse_image_labels(anno_dict, frame_size):
 
 
 def _parse_classifications(attrs):
-    return {k: fol.Classification(label=v) for k, v in attrs.items()}
+    classifications = {}
+    for k, v in attrs.items():
+        if isinstance(v, list):
+            classes = [fol.Classification(label=label) for label in v]
+            classifications[k] = fol.Classifications(classifications=classes)
+        else:
+            classifications[k] = fol.Classification(label=v)
+    return classifications
 
 
 def _parse_objects(anno_dict, frame_size):


### PR DESCRIPTION
## What changes are proposed in this pull request?

I am working with labels from scale. In the following format.

```
  "global_attributes": {
      "traffic_density": "low",
      "weather": [
          "fog",
          "rain"
      ]
  },
```
While the string-based attribute "traffic_density" can be loaded with the fo dev branch, the list-based attribute "weather" throws an error as the list type is not compatible with `fol.Classification()`

The proposed changes support also the list type.

## How is this patch tested? If it is not, please explain why.

Import of private data into the database.

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

- Support for multi attribute labels for scale integration.

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
