### PR TITLE
undefined dataset error fix for stateless app

### DIFF
--- a/fiftyone/server/mutation.py
+++ b/fiftyone/server/mutation.py
@@ -444,7 +444,6 @@ class Mutation:
 
         state = get_state()
         dataset = state.dataset
-        isVideo = dataset.media_type == "video"
         if dataset is None:
             dataset = fod.load_dataset(dataset_name)
 
@@ -460,6 +459,7 @@ class Mutation:
 
         res = []
         try:
+            isVideo = dataset.media_type == "video"
             for stage in view._stages:
                 res += [
                     st

--- a/fiftyone/server/mutation.py
+++ b/fiftyone/server/mutation.py
@@ -459,11 +459,11 @@ class Mutation:
 
         res = []
         try:
-            isVideo = dataset.media_type == "video"
+            is_video = dataset.media_type == "video"
             for stage in view._stages:
                 res += [
                     st
-                    for st in stage.get_selected_fields(view, frames=isVideo)
+                    for st in stage.get_selected_fields(view, frames=is_video)
                 ]
         except Exception as e:
             print("failed to get_selected_fields", e)


### PR DESCRIPTION
## What changes are proposed in this pull request?

teams stateless check before grabbing media_typ

## How is this patch tested? If it is not, please explain why.

(Details)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
