### PR TITLE
Only match .txt files when reading YOLO labels

### DIFF
--- a/fiftyone/utils/yolo.py
+++ b/fiftyone/utils/yolo.py
@@ -72,6 +72,7 @@ def add_yolo_labels(
         txt_map = {
             os.path.splitext(p)[0]: os.path.join(labels_path, p)
             for p in etau.list_files(labels_path, recursive=True)
+            if p.endswith(".txt")
         }
         match_type = "uuid"
     elif isinstance(labels_path, dict):


### PR DESCRIPTION
## What changes are proposed in this pull request?

Only load files if they end in `.txt`. This will ensure non-text files that are in the directory will not get loaded by accident.

Related to #1975, but takes changes from suggestion here: https://github.com/voxel51/fiftyone/pull/1975#issuecomment-1219818368.

## How is this patch tested? If it is not, please explain why.

Pass a folder with both `.txt` and non-text files like `.png` into `add_yolo_labels()`.

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
