### PR TITLE
Fix label list ids

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -5,6 +5,7 @@ on:
     types: [opened, synchronize]
     branches:
       - develop
+      - release/v[0-9]+.[0-9]+.[0-9]+
 
 jobs:
   build:

--- a/fiftyone/core/labels.py
+++ b/fiftyone/core/labels.py
@@ -327,6 +327,10 @@ class _HasID(Label):
     def _id(self):
         return ObjectId(self.id)
 
+    @_id.setter
+    def _id(self, value):
+        self.id = str(value)
+
 
 class _HasLabelList(object):
     """Mixin for :class:`Label` classes that contain a list of :class:`Label`

--- a/tests/unittests/sample_tests.py
+++ b/tests/unittests/sample_tests.py
@@ -874,7 +874,7 @@ class SampleFieldTests(unittest.TestCase):
         sample = dataset.first()
         self.assertEqual(sample.custom_field.single.label, "single")
         self.assertEqual(len(sample.custom_field.list), 1)
-        self.assertEqual(len(sample.custom_field.list[0].label), "list")
+        self.assertEqual(sample.custom_field.list[0].label, "list")
 
 
 if __name__ == "__main__":

--- a/tests/unittests/sample_tests.py
+++ b/tests/unittests/sample_tests.py
@@ -864,17 +864,17 @@ class SampleFieldTests(unittest.TestCase):
         sample = fo.Sample(
             filepath="img.png",
             custom_field=fo.DynamicEmbeddedDocument(
-                label=fo.Classification(label="label"),
-                labels=[fo.Classification(label="labels")],
+                single=fo.Classification(label="single"),
+                list=[fo.Classification(label="list")],
             ),
         )
         dataset.add_sample(sample)
         dataset.add_dynamic_sample_fields()
 
         sample = dataset.first()
-        self.assertEqual(sample.custom_field.label, "label")
-        self.assertEqual(len(sample.custom_field.labels), 1)
-        self.assertEqual(len(sample.custom_field.labels[0].label), "labels")
+        self.assertEqual(sample.custom_field.single.label, "single")
+        self.assertEqual(len(sample.custom_field.list), 1)
+        self.assertEqual(len(sample.custom_field.list[0].label), "list")
 
 
 if __name__ == "__main__":

--- a/tests/unittests/sample_tests.py
+++ b/tests/unittests/sample_tests.py
@@ -858,6 +858,24 @@ class SampleFieldTests(unittest.TestCase):
             self.assertIsInstance(fields["vector_field"], fo.VectorField)
             self.assertIsInstance(fields["array_field"], fo.ArrayField)
 
+    @drop_datasets
+    def test_dynamic_fields(self):
+        dataset = fo.Dataset()
+        sample = fo.Sample(
+            filepath="img.png",
+            custom_field=fo.DynamicEmbeddedDocument(
+                label=fo.Classification(label="label"),
+                labels=[fo.Classification(label="labels")],
+            ),
+        )
+        dataset.add_sample(sample)
+        dataset.add_dynamic_sample_fields()
+
+        sample = dataset.first()
+        self.assertEqual(sample.custom_field.label, "label")
+        self.assertEqual(len(sample.custom_field.labels), 1)
+        self.assertEqual(len(sample.custom_field.labels[0].label), "labels")
+
 
 if __name__ == "__main__":
     fo.config.show_progress_bars = False


### PR DESCRIPTION
The below is currently broken (may never have worked) on `release/v0.21.0`. Adding a `setter` for `_id` for labels with an id solves the issue, although I can't explain why it is only needed for raw label lists.

```py
import fiftyone as fo

dataset = fo.Dataset("tmp")
sample = fo.Sample(
    filepath="/tmp/image.png",
)
dataset.add_sample(sample)
sample = dataset.first()
sample["custom"] = fo.DynamicEmbeddedDocument(
    classifications=[fo.Classification(label="x")]
)
sample.save()
dataset.first()
```