### PR TITLE
Bug: add label count back to the bubble grid view

### DIFF
--- a/app/packages/looker/src/elements/common/tags.ts
+++ b/app/packages/looker/src/elements/common/tags.ts
@@ -276,7 +276,7 @@ export class TagsElement<State extends BaseState> extends BaseElement<State> {
           elements.push({
             color: getColor(coloring.pool, coloring.seed, v),
             title: value,
-            value: tag,
+            value: value,
           });
         });
       } else {


### PR DESCRIPTION

![Screenshot 2023-05-30 at 11 26 34 AM](https://github.com/voxel51/fiftyone/assets/17770824/54acc943-a74e-4164-8bd2-c040dc579fb2)

## What changes are proposed in this pull request?

(Please fill in changes proposed in this fix)

## How is this patch tested? If it is not, please explain why.

(Details)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
