### PR TITLE
Serialization cleanup

### DIFF
--- a/fiftyone/core/session/client.py
+++ b/fiftyone/core/session/client.py
@@ -13,6 +13,7 @@ from threading import Thread
 import time
 import typing as t
 
+from bson import json_util
 import requests
 import sseclient
 from uuid import uuid4
@@ -20,14 +21,12 @@ from uuid import uuid4
 import fiftyone.constants as foc
 import fiftyone.core.state as fos
 
-from fiftyone.core.json import FiftyOneJSONEncoder, stringify
 from fiftyone.core.session.events import (
     Event,
     EventType,
     ListenPayload,
     dict_factory,
 )
-from fiftyone.core.utils import pprint
 
 
 logger = logging.getLogger(__name__)
@@ -70,22 +69,20 @@ class Client:
                         "Accept": "text/event-stream",
                         "Content-type": "application/json",
                     },
-                    data=FiftyOneJSONEncoder.dumps(
-                        stringify(
-                            asdict(
-                                ListenPayload(
-                                    events=[
-                                        "capture_notebook_cell",
-                                        "close_session",
-                                        "reactivate_notebook_cell",
-                                        "reload_session",
-                                        "state_update",
-                                    ],
-                                    initializer=state,
-                                    subscription=self._subscription,
-                                ),
-                                dict_factory=dict_factory,
-                            )
+                    data=json_util.dumps(
+                        asdict(
+                            ListenPayload(
+                                events=[
+                                    "capture_notebook_cell",
+                                    "close_session",
+                                    "reactivate_notebook_cell",
+                                    "reload_session",
+                                    "state_update",
+                                ],
+                                initializer=state,
+                                subscription=self._subscription,
+                            ),
+                            dict_factory=dict_factory,
                         )
                     ),
                 )
@@ -162,12 +159,10 @@ class Client:
         response = requests.post(
             f"{self.origin}/event",
             headers={"Content-type": "application/json"},
-            data=FiftyOneJSONEncoder.dumps(
+            data=json_util.dumps(
                 {
                     "event": event.get_event_name(),
-                    "data": stringify(
-                        asdict(event, dict_factory=dict_factory)
-                    ),
+                    "data": asdict(event, dict_factory=dict_factory),
                     "subscription": self._subscription,
                 }
             ),

--- a/fiftyone/core/session/events.py
+++ b/fiftyone/core/session/events.py
@@ -11,11 +11,11 @@ import re
 import typing as t
 
 import asyncio
+from bson import json_util
 from dacite import from_dict
 
 import eta.core.utils as etau
 
-import fiftyone.core.json as foj
 import fiftyone.core.state as fos
 from fiftyone.core.utils import run_sync_task
 
@@ -45,7 +45,7 @@ class Event:
             return Ping()
 
         if isinstance(data, str):
-            data = foj.FiftyOneJSONEncoder.loads(data)
+            data = json_util.loads(data)
 
         event_cls = etau.get_class(
             "".join(word.title() for word in event_name.split("_")),

--- a/fiftyone/core/state.py
+++ b/fiftyone/core/state.py
@@ -5,11 +5,12 @@ Defines the shared state between the FiftyOne App and backend.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
-from bson import json_util
 import json
 import logging
 import typing as t
 
+from bson import json_util
+from dataclasses import asdict
 from mongoengine.base import BaseDict
 import strawberry as gql
 
@@ -86,21 +87,25 @@ class StateDescription(etas.Serializable):
                     else:
                         _view_cls = etau.get_class_name(self.view)
 
-                    d["view"] = json.loads(
-                        json_util.dumps(self.view._serialize())
-                    )
+                    d["view"] = self.view._serialize()
                     d["view_cls"] = _view_cls
 
                     d["view_name"] = self.view.name  # None for unsaved views
                     if d.get("view_name") is not None:
                         d["saved_view_slug"] = fou.to_slug(self.view.name)
 
-                d["sample_fields"] = serialize_fields(
-                    collection.get_field_schema(flat=True)
-                )
-                d["frame_fields"] = serialize_fields(
-                    collection.get_frame_field_schema(flat=True)
-                )
+                d["sample_fields"] = [
+                    asdict(field)
+                    for field in serialize_fields(
+                        collection.get_field_schema(flat=True)
+                    )
+                ]
+                d["frame_fields"] = [
+                    asdict(field)
+                    for field in serialize_fields(
+                        collection.get_frame_field_schema(flat=True)
+                    )
+                ]
 
                 view = self.view if self.view is not None else self.dataset
                 if view.media_type == fom.GROUP:

--- a/fiftyone/operators/server.py
+++ b/fiftyone/operators/server.py
@@ -9,9 +9,9 @@ import types
 from starlette.endpoints import HTTPEndpoint
 from starlette.exceptions import HTTPException
 from starlette.requests import Request
-from starlette.responses import StreamingResponse
+from starlette.responses import JSONResponse, StreamingResponse
 
-from fiftyone.server.decorators import route, FiftyOneResponse
+from fiftyone.server.decorators import route
 
 from .executor import (
     execute_operator,
@@ -108,7 +108,7 @@ async def create_response_async_generator(generator):
 
 def create_permission_error(uri):
     message = "User does not have permission to execute operator '%s'" % uri
-    return FiftyOneResponse(
+    return JSONResponse(
         {"error": {"message": message}},
         status_code=403,
     )

--- a/fiftyone/server/events.py
+++ b/fiftyone/server/events.py
@@ -11,12 +11,12 @@ import typing as t
 from datetime import datetime
 
 import asyncio
+from bson import json_util
 from sse_starlette import ServerSentEvent
 from starlette.requests import Request
 
 import fiftyone.core.context as focx
 import fiftyone.core.dataset as fod
-from fiftyone.core.json import FiftyOneJSONEncoder
 from fiftyone.core.session.events import (
     add_screenshot,
     CaptureNotebookCell,
@@ -30,8 +30,6 @@ from fiftyone.core.session.events import (
 )
 import fiftyone.core.state as fos
 import fiftyone.core.utils as fou
-
-from fiftyone.server.query import serialize_dataset
 
 
 @dataclass(frozen=True)
@@ -91,24 +89,14 @@ async def add_event_listener(
     data = await _initialize_listener(payload)
     try:
         if data.is_app:
-            d = asdict(
-                StateUpdate(state=data.state),
-                dict_factory=dict_factory,
-            )
-            if data.state.dataset is not None:
-                d["dataset"] = await serialize_dataset(
-                    dataset_name=data.state.dataset.name,
-                    serialized_view=data.state.view._serialize()
-                    if data.state.view is not None
-                    else [],
-                    saved_view_slug=fou.to_slug(data.state.view.name)
-                    if data.state.view is not None and data.state.view.name
-                    else None,
-                )
-
             yield ServerSentEvent(
                 event=StateUpdate.get_event_name(),
-                data=FiftyOneJSONEncoder.dumps(d),
+                data=json_util.dumps(
+                    asdict(
+                        StateUpdate(state=data.state.serialize()),
+                        dict_factory=dict_factory,
+                    )
+                ),
             )
 
         while True:
@@ -127,28 +115,15 @@ async def add_event_listener(
 
             events = sorted(events, key=lambda event: event[0])
 
-            for (_, event) in events:
-                d = asdict(event, dict_factory=dict_factory)
-
-                if (
-                    data.is_app
-                    and isinstance(event, StateUpdate)
-                    and event.state.dataset is not None
-                ):
-                    d["dataset"] = await serialize_dataset(
-                        dataset_name=event.state.dataset.name,
-                        serialized_view=event.state.view._serialize()
-                        if event.state.view is not None
-                        else [],
-                        saved_view_slug=fou.to_slug(event.state.view.name)
-                        if event.state.view is not None
-                        and event.state.view.name
-                        else None,
-                    )
+            for _, event in events:
+                if isinstance(event, StateUpdate):
+                    event.state = event.state.serialize()
 
                 yield ServerSentEvent(
                     event=event.get_event_name(),
-                    data=FiftyOneJSONEncoder.dumps(d),
+                    data=json_util.dumps(
+                        asdict(event, dict_factory=dict_factory)
+                    ),
                 )
 
             await asyncio.sleep(0.2)

--- a/fiftyone/server/mutation.py
+++ b/fiftyone/server/mutation.py
@@ -244,7 +244,7 @@ class Mutation:
             saved_view_slug=fou.to_slug(view_name)
             if view_name
             else fou.to_slug(state.view.name)
-            if state.view and state.view.name
+            if state.view is not None and state.view.name
             else None,
             info=info,
         )

--- a/fiftyone/server/routes/samples.py
+++ b/fiftyone/server/routes/samples.py
@@ -5,10 +5,12 @@ FiftyOne Server /samples route
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
-from dataclasses import asdict
 from starlette.endpoints import HTTPEndpoint
 from starlette.requests import Request
+from starlette.responses import JSONResponse
 
+from fiftyone.core.json import stringify
+from fiftyone.core.utils import run_sync_task
 
 from fiftyone.server.decorators import route
 from fiftyone.server.filters import GroupElementFilter, SampleFilter
@@ -25,7 +27,6 @@ class Samples(HTTPEndpoint):
         page_length = data.get("page_length", 20)
         slice = data.get("slice", None)
         extended = data.get("extended", None)
-
         results = await paginate_samples(
             dataset,
             stages,
@@ -38,7 +39,11 @@ class Samples(HTTPEndpoint):
             extended_stages=extended,
         )
 
-        return {
-            "results": [asdict(edge.node) for edge in results.edges],
-            "more": results.page_info.has_next_page,
-        }
+        return JSONResponse(
+            {
+                "results": await run_sync_task(
+                    lambda: [stringify(edge.node) for edge in results.edges]
+                ),
+                "more": results.page_info.has_next_page,
+            }
+        )

--- a/fiftyone/server/routes/sort.py
+++ b/fiftyone/server/routes/sort.py
@@ -10,6 +10,9 @@ from dataclasses import asdict
 from starlette.endpoints import HTTPEndpoint
 from starlette.requests import Request
 
+from fiftyone.core.json import stringify
+from fiftyone.core.utils import run_sync_task
+
 from fiftyone.server.decorators import route
 import fiftyone.server.events as fose
 from fiftyone.server.query import serialize_dataset
@@ -23,24 +26,32 @@ class Sort(HTTPEndpoint):
         filters = data.get("filters", {})
         stages = data.get("view", None)
         subscription = data.get("subscription", None)
-        fosv.get_view(
-            dataset_name,
-            stages=stages,
-            filters=filters,
-            extended_stages={
-                "fiftyone.core.stages.SortBySimilarity": data["extended"]
-            },
+
+        await run_sync_task(
+            lambda: fosv.get_view(
+                dataset_name,
+                stages=stages,
+                filters=filters,
+                extended_stages={
+                    "fiftyone.core.stages.SortBySimilarity": data["extended"]
+                },
+            )
         )
+
         state = fose.get_state()
         state.selected = []
         state.selected_labels = []
 
         await fose.dispatch_event(subscription, fose.StateUpdate(state))
-        return {
-            "dataset": asdict(
+
+        dataset = stringify(
+            asdict(
                 await serialize_dataset(
                     dataset_name=dataset_name,
                     serialized_view=stages,
                 )
             )
-        }
+        )
+
+        dataset["stages"] = None
+        return {"dataset": dataset}


### PR DESCRIPTION
### Changes
* Removes excess calls to `bson.json_util.dumps` and `bson.json_utils.loads`
* Removes `FiftyOneResponse` in favor of simplified`JSONResponse`usage
* Small fixes to prevent `len()` calls on sample collections
* `fiftyone.core.json` enhancements to prevent excess object creation
* `run_sync_tasks` additions where possible
* events serialization cleanup