### PR TITLE
remove None classifications from showing in Grid

### DIFF
--- a/app/packages/looker/src/elements/common/tags.ts
+++ b/app/packages/looker/src/elements/common/tags.ts
@@ -322,16 +322,16 @@ export class TagsElement<State extends BaseState> extends BaseElement<State> {
           if (path.startsWith("frames.")) continue;
           const classifications = LABEL_LISTS.includes(field.embeddedDocType);
           if (classifications) {
-            !value?.classifications?.length &&
-              pushList(
-                LABEL_RENDERERS[field.embeddedDocType],
-                value?.classifications
-              );
+            pushList(
+              LABEL_RENDERERS[field.embeddedDocType],
+              value?.classifications
+            );
           } else {
             // remove undefined classifications - can show up as None
+            const objVal = value as Object;
             if (
-              "_cls" in (value as Object) &&
-              typeof value._cls === "undefined"
+              ("_cls" in objVal && typeof objVal._cls === "undefined") ||
+              (objVal._cls === CLASSIFICATION && !objVal?.label)
             ) {
               continue;
             }


### PR DESCRIPTION
## What changes are proposed in this pull request?

classification that is None should not show in Grid

With valid Classification shows `Right`

<img width="680" alt="Screen Shot 2023-05-30 at 12 04 23 PM" src="https://github.com/voxel51/fiftyone/assets/109545780/751cef95-56f0-4c75-ae62-8997b1b714ec">

With None Classification shows nothing
<img width="598" alt="Screen Shot 2023-05-30 at 12 04 35 PM" src="https://github.com/voxel51/fiftyone/assets/109545780/91c03d97-7dcd-4c67-9c2b-f24ae255d57f">


## How is this patch tested? If it is not, please explain why.

(Details)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
