### PR TITLE
Convert color names to hex code for consistency when loading from session

### DIFF
--- a/app/packages/looker/src/overlays/util.ts
+++ b/app/packages/looker/src/overlays/util.ts
@@ -5,6 +5,7 @@
 import { INFO_COLOR } from "../constants";
 import { BaseState, Coordinates, MaskTargets, RgbMaskTargets } from "../state";
 import { BaseLabel } from "./base";
+import colorString from "color-string";
 
 export const t = (state: BaseState, x: number, y: number): Coordinates => {
   const [ctlx, ctly, cw, ch] = state.canvasBBox;
@@ -89,6 +90,16 @@ export function isRgbMaskTargets(
 // Return true is string is a valid color
 export function isValidColor(color: string): boolean {
   return CSS.supports("color", color);
+}
+
+// Convert any valid css color to the hex color
+export function convertToHex(color: string) {
+  if (!isValidColor(color)) return null;
+  const formatted = colorString.get(color);
+  if (formatted) {
+    return colorString.to.hex(formatted?.value);
+  }
+  return null;
 }
 
 export function normalizeMaskTargetsCase(maskTargets: MaskTargets) {

--- a/app/packages/state/src/hooks/useStateUpdate.ts
+++ b/app/packages/state/src/hooks/useStateUpdate.ts
@@ -41,7 +41,7 @@ import {
 } from "../utils";
 
 import { selectedFieldsStageState } from "./useSchemaSettings";
-import { isValidColor } from "@fiftyone/looker/src/overlays/util";
+import { convertToHex, isValidColor } from "@fiftyone/looker/src/overlays/util";
 
 export interface StateUpdate {
   colorscale?: RGB[];
@@ -120,7 +120,9 @@ const useStateUpdate = (ignoreSpaces = false) => {
             : DEFAULT_APP_COLOR_SCHEME.colorPool;
         colorPool =
           colorPool.filter((c) => isValidColor(c)).length > 0
-            ? colorPool.filter((c) => isValidColor(c))
+            ? colorPool
+                .filter((c) => isValidColor(c))
+                .map((c) => convertToHex(c))
             : DEFAULT_APP_COLOR_SCHEME.colorPool;
         colorSetting = {
           colorPool,


### PR DESCRIPTION
Convert backend color palette settings into hex colors on load. 

## What changes are proposed in this pull request?

Convert backend color palette settings into hex colors on load. 
With the twitter style color selector, using color name could cause issue when selecting

## How is this patch tested? If it is not, please explain why.
(Details)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
