### PR TITLE
Plugins cache tweaks

### DIFF
--- a/fiftyone/operators/decorators.py
+++ b/fiftyone/operators/decorators.py
@@ -83,6 +83,8 @@ def plugins_cache(func):
 
 
 def dir_state(dirpath):
+    if not os.path.isdir(dirpath):
+        return None
     return max(
         os.path.getmtime(os.path.join(dirpath, f)) for f in os.listdir(dirpath)
     )


### PR DESCRIPTION
## What changes are proposed in this pull request?

Check that a path is a directory in the case a plugins cache is enabled by env var, but plugins dir doesn't exist for whatever reason.

## How is this patch tested? If it is not, please explain why.

(Details)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
