### PR TITLE
Dynamic label field upgrades

### DIFF
--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -931,11 +931,8 @@ class SampleCollection(object):
         use_db_fields=False,
     ):
         if path is not None:
-            field = self.get_field(
-                path, ftype=fof.EmbeddedDocumentField, leaf=True
-            )
-
-            if field is None:
+            field = self.get_field(path, leaf=True)
+            if not isinstance(field, fof.EmbeddedDocumentField):
                 return tuple()
 
             field_names = field._get_default_fields(
@@ -980,13 +977,8 @@ class SampleCollection(object):
         use_db_fields=False,
     ):
         if path is not None:
-            field = self.get_field(
-                self._FRAMES_PREFIX + path,
-                ftype=fof.EmbeddedDocumentField,
-                leaf=True,
-            )
-
-            if field is None:
+            field = self.get_field(self._FRAMES_PREFIX + path, leaf=True)
+            if not isinstance(field, fof.EmbeddedDocumentField):
                 return tuple()
 
             field_names = field._get_default_fields(
@@ -1315,7 +1307,7 @@ class SampleCollection(object):
 
                 agg = foa.Schema(_path, dynamic_only=True, _doc_type=_doc_type)
             elif is_list_field:
-                # Inferring subfields of default list fields is not allowed
+                # Processing untyped default list fields is not allowed
                 if field is None and not self._is_default_field(_path):
                     agg = foa.ListSchema(_path)
                 else:

--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -9626,7 +9626,7 @@ class SampleCollection(object):
 
         field = schema[field_name]
 
-        while isinstance(field, fof.ListField):
+        if isinstance(field, fof.ListField):
             field = field.field
 
         if not isinstance(field, fof.EmbeddedDocumentField) or not issubclass(

--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -9549,31 +9549,25 @@ class SampleCollection(object):
         return media_fields
 
     def _get_label_fields(self):
-        fields = self._get_sample_label_fields()
-
-        if self._has_frame_fields():
-            fields.extend(self._get_frame_label_fields())
-
-        return fields
+        return [path for path, _ in _iter_label_fields(self)]
 
     def _get_sample_label_fields(self):
-        return list(
-            self.get_field_schema(
-                ftype=fof.EmbeddedDocumentField,
-                embedded_doc_type=fol.Label,
-            ).keys()
-        )
+        return [
+            path
+            for path, _ in _iter_schema_label_fields(
+                self.get_field_schema(flat=True)
+            )
+        ]
 
     def _get_frame_label_fields(self):
         if not self._has_frame_fields():
             return None
 
         return [
-            self._FRAMES_PREFIX + field
-            for field in self.get_frame_field_schema(
-                ftype=fof.EmbeddedDocumentField,
-                embedded_doc_type=fol.Label,
-            ).keys()
+            self._FRAMES_PREFIX + path
+            for path, _ in _iter_schema_label_fields(
+                self.get_frame_field_schema(flat=True)
+            )
         ]
 
     def _get_root_fields(self, fields):
@@ -9771,6 +9765,42 @@ class SampleCollection(object):
             for i, v in zip(*self.values([id_path, path_or_expr], unwind=True))
         }
         return [values_map.get(i, None) for i in ids]
+
+
+def _iter_label_fields(view: SampleCollection):
+    for path, field in _iter_schema_label_fields(
+        view.get_field_schema(flat=True)
+    ):
+        yield path, field
+
+    if not view._has_frame_fields():
+        return
+
+    for path, field in _iter_schema_label_fields(
+        view.get_frame_field_schema(flat=True)
+    ):
+        yield f"frames.{path}", field
+
+
+def _iter_schema_label_fields(schema):
+    for path, field in schema.items():
+        field_to_check = field
+        if isinstance(field, fof.ListField):
+            field_to_check = field.field
+        if (
+            isinstance(field_to_check, fof.EmbeddedDocumentField)
+            and issubclass(field_to_check.document_type, fol.Label)
+            and not issubclass(field_to_check.document_type, fol._HasLabelList)
+        ):
+            parent_path = ".".join(path.split(".")[:-1])
+            parent_field = schema.get(parent_path, None)
+            if isinstance(
+                parent_field, fof.EmbeddedDocumentField
+            ) and issubclass(parent_field.document_type, fol._HasLabelList):
+                yield parent_path, parent_field
+                continue
+
+            yield path, field
 
 
 def _serialize_value(field_name, field, value, validate=True):

--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -1308,7 +1308,8 @@ class SampleCollection(object):
                 agg = foa.Schema(_path, dynamic_only=True, _doc_type=_doc_type)
             elif is_list_field:
                 # Processing untyped default list fields is not allowed
-                if field is None and not self._is_default_field(_path):
+                _clean_path = _path.replace("[]", "")
+                if field is None and not self._is_default_field(_clean_path):
                     agg = foa.ListSchema(_path)
                 else:
                     agg = None

--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -1316,7 +1316,7 @@ class SampleCollection(object):
                 agg = foa.Schema(_path, dynamic_only=True, _doc_type=_doc_type)
             elif is_list_field:
                 # Inferring subfields of default list fields is not allowed
-                if field is not None and not self._is_default_field(_path):
+                if field is None and not self._is_default_field(_path):
                     agg = foa.ListSchema(_path)
                 else:
                     agg = None

--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -9767,19 +9767,20 @@ class SampleCollection(object):
         return [values_map.get(i, None) for i in ids]
 
 
-def _iter_label_fields(view: SampleCollection):
+def _iter_label_fields(sample_collection):
     for path, field in _iter_schema_label_fields(
-        view.get_field_schema(flat=True)
+        sample_collection.get_field_schema(flat=True)
     ):
         yield path, field
 
-    if not view._has_frame_fields():
+    if not sample_collection._has_frame_fields():
         return
 
+    prefix = sample_collection._FRAMES_PREFIX
     for path, field in _iter_schema_label_fields(
-        view.get_frame_field_schema(flat=True)
+        sample_collection.get_frame_field_schema(flat=True)
     ):
-        yield f"frames.{path}", field
+        yield prefix + path, field
 
 
 def _iter_schema_label_fields(schema):
@@ -9800,7 +9801,7 @@ def _iter_schema_label_fields(schema):
             leaf = keys[-1]
             parent_field = schema.get(parent_path, None)
 
-            # we skip _HasLabelList label list fields
+            # Don't report leaf for `_HasLabelList` fields
             if (
                 isinstance(parent_field, fof.EmbeddedDocumentField)
                 and issubclass(parent_field.document_type, fol._HasLabelList)

--- a/fiftyone/core/document.py
+++ b/fiftyone/core/document.py
@@ -13,6 +13,7 @@ import eta.core.serial as etas
 import eta.core.utils as etau
 
 import fiftyone.core.labels as fol
+import fiftyone.core.odm as foo
 from fiftyone.core.singletons import DocumentSingleton
 
 
@@ -255,6 +256,15 @@ class _Document(object):
                 continue
 
             yield field_name, self.get_field(field_name)
+
+    def _iter_label_fields(self):
+        for name, value in self.iter_fields():
+            if isinstance(value, fol.Label):
+                yield name, value
+            elif isinstance(value, foo.BaseEmbeddedDocument):
+                for _name, _value in value.iter_fields():
+                    if isinstance(_value, fol.Label):
+                        yield name + "." + _name, _value
 
     def merge(
         self,

--- a/fiftyone/core/fields.py
+++ b/fiftyone/core/fields.py
@@ -1281,6 +1281,36 @@ class EmbeddedDocumentField(mongoengine.fields.EmbeddedDocumentField, Field):
     def _to_db_fields(self, field_names):
         return tuple(self._fields[f].db_field or f for f in field_names)
 
+    def has_field(self, path):
+        """Determines whether this field has the given embedded field.
+
+        Args:
+            path: the field name or ``embedded.field.name``
+
+        Returns:
+            True/False
+        """
+        return self.get_field(path) is not None
+
+    def get_field(self, path):
+        """Returns the field for the provided path, or ``None``.
+
+        Args:
+            path: a field name or ``embedded.field.name``
+
+        Returns:
+            a :class:`Field` instance or ``None``
+        """
+        chunks = path.split(".", 1)
+        if len(chunks) > 1:
+            field = self._fields.get(chunks[0], None)
+            if not isinstance(field, EmbeddedDocumentField):
+                return None
+
+            return field.get_field(chunks[1])
+
+        return self._fields.get(path, None)
+
     def get_field_schema(
         self,
         ftype=None,

--- a/fiftyone/core/labels.py
+++ b/fiftyone/core/labels.py
@@ -1420,6 +1420,15 @@ _PATCHES_FIELDS = (
     Polylines,
 )
 
+_INDEX_FIEDS = (
+    Detection,
+    Detections,
+    Polyline,
+    Polylines,
+    Keypoint,
+    Keypoints,
+)
+
 _SINGLE_LABEL_TO_LIST_MAP = {
     Classification: Classifications,
     Detection: Detections,

--- a/fiftyone/core/models.py
+++ b/fiftyone/core/models.py
@@ -1651,14 +1651,20 @@ def _parse_batch_size(batch_size, model, use_data_loader):
 
 def _make_label_parser(samples, patches_field):
     patches_attr, _ = samples._handle_frame_field(patches_field)
-    label_type, _ = samples._get_label_field_path(patches_field)
+    label_type = samples._get_label_field_type(patches_field)
     is_list_field = issubclass(label_type, fol._LABEL_LIST_FIELDS)
 
     if not is_list_field:
 
         def parse_label(sample):
             label = sample[patches_attr]
-            return [label] if label is not None else []
+            if label is None:
+                return []
+
+            if isinstance(label, list):
+                return label
+
+            return [label]
 
         return parse_label
 

--- a/fiftyone/core/odm/mixins.py
+++ b/fiftyone/core/odm/mixins.py
@@ -113,18 +113,6 @@ class DatasetMixin(object):
         # pylint: disable=no-member
         return tuple(cls._fields[f].db_field or f for f in field_names)
 
-    def has_field(self, field_name):
-        # pylint: disable=no-member
-        return field_name in self._fields
-
-    def get_field(self, field_name):
-        if not self.has_field(field_name):
-            raise AttributeError(
-                "%s has no field '%s'" % (self._doc_name(), field_name)
-            )
-
-        return super().get_field(field_name)
-
     def set_field(
         self,
         field_name,
@@ -1493,15 +1481,29 @@ class NoDatasetMixin(object):
 
     def has_field(self, field_name):
         try:
-            return field_name in self._data
+            data = self._data
         except AttributeError:
-            # If `_data` is not initialized
+            # `_data` is not initialized
             return False
 
+        chunks = field_name.split(".", 1)
+        if len(chunks) > 1:
+            value = data.get(chunks[0], None)
+            try:
+                return value.has_field(chunks[1])
+            except AttributeError:
+                return False
+
+        return field_name in data
+
     def get_field(self, field_name):
+        chunks = field_name.split(".", 1)
         try:
-            return self._data[field_name]
-        except KeyError:
+            if len(chunks) > 1:
+                return self._data[chunks[0]].get_field(chunks[1])
+            else:
+                return self._data[field_name]
+        except (KeyError, AttributeError):
             raise AttributeError(
                 "%s has no field '%s'" % (self._doc_name(), field_name)
             )
@@ -1514,6 +1516,11 @@ class NoDatasetMixin(object):
         validate=True,
         dynamic=False,
     ):
+        chunks = field_name.split(".", 1)
+        if len(chunks) > 1:
+            doc = self.get_field(chunks[0])
+            return doc.set_field(chunks[1], value, create=create)
+
         if not create and not self.has_field(field_name):
             raise ValueError(
                 "%s has no field '%s'" % (self._doc_name(), field_name)
@@ -1523,17 +1530,30 @@ class NoDatasetMixin(object):
         self._data[field_name] = value
 
     def clear_field(self, field_name):
+        chunks = field_name.split(".", 1)
+        if len(chunks) > 1:
+            value = self.get_field(chunks[0])
+            if value is not None:
+                return value.clear_field(chunks[1])
+
+            if self.has_field(field_name):
+                return
+
+            raise AttributeError(
+                "%s has no field '%s'" % (self._doc_name(), field_name)
+            )
+
         if field_name in self.default_fields:
             default_value = self._get_default(self.default_fields[field_name])
             self.set_field(field_name, default_value, create=False)
             return
 
-        if not self.has_field(field_name):
-            raise ValueError(
+        try:
+            self._data.pop(field_name)
+        except KeyError:
+            raise AttributeError(
                 "%s has no field '%s'" % (self._doc_name(), field_name)
             )
-
-        self._data.pop(field_name)
 
     def to_dict(self, extended=False):
         d = {}

--- a/fiftyone/core/odm/utils.py
+++ b/fiftyone/core/odm/utils.py
@@ -468,8 +468,9 @@ def _parse_embedded_doc_list_fields(values, dynamic):
 
 def _merge_embedded_doc_fields(fields_dict, fields):
     for field in fields:
-        ftype = field["ftype"]
         name = field["name"]
+        ftype = field["ftype"]
+        subfield = field.get("subfield", None)
 
         if name not in fields_dict:
             fields_dict[name] = field
@@ -482,6 +483,11 @@ def _merge_embedded_doc_fields(fields_dict, fields):
                 # @todo could provide an `add_mixed=True` option to declare
                 # mixed fields like this as a generic `Field`
                 fields_dict[name] = None
+            elif etype in (fof.ListField, fof.DictField):
+                if "subfield" in efield and efield["subfield"] != subfield:
+                    efield["subfield"] = None
+                elif subfield is not None:
+                    efield["subfield"] = subfield
             elif ftype == fof.EmbeddedDocumentField:
                 _merge_embedded_doc_fields(efield["fields"], field["fields"])
 

--- a/fiftyone/core/stages.py
+++ b/fiftyone/core/stages.py
@@ -8074,23 +8074,29 @@ def _parse_labels_field(sample_collection, field_path):
     else:
         path = field_path
 
-    real_path = path
     prefix = ""
+    real_path = path
     if is_frame_field:
-        real_path = real_path[len(sample_collection._FRAMES_PREFIX) :]
         prefix = sample_collection._FRAMES_PREFIX
+        real_path = real_path[len(prefix) :]
 
-    if real_path.startswith("___"):  # for fiftyone.server.view hidden results
+    hidden = False
+
+    # for fiftyone.server.view hidden results
+    if real_path.startswith("___"):
+        hidden = True
         real_path = real_path[3:]
 
-    if real_path.startswith("__"):  # for fiftyone.core.stages hidden results
+    # for fiftyone.core.stages hidden results
+    if real_path.startswith("__"):
+        hidden = True
         real_path = real_path[2:]
 
-    return (
-        path,
-        isinstance(sample_collection.get_field(prefix + real_path), ListField),
-        is_frame_field,
-    )
+    if hidden:
+        real_field = sample_collection.get_field(prefix + real_path)
+        is_list_field = isinstance(real_field, ListField)
+
+    return path, is_list_field, is_frame_field
 
 
 def _parse_labels_list_field(sample_collection, field_path):

--- a/fiftyone/core/stages.py
+++ b/fiftyone/core/stages.py
@@ -8074,9 +8074,21 @@ def _parse_labels_field(sample_collection, field_path):
     else:
         path = field_path
 
+    real_path = path
+    prefix = ""
+    if is_frame_field:
+        real_path = real_path[len(sample_collection._FRAMES_PREFIX) :]
+        prefix = sample_collection._FRAMES_PREFIX
+
+    if real_path.startswith("___"):  # for fiftyone.server.view hidden results
+        real_path = real_path[3:]
+
+    if real_path.startswith("__"):  # for fiftyone.core.stages hidden results
+        real_path = real_path[2:]
+
     return (
         path,
-        isinstance(sample_collection.get_field(path), ListField),
+        isinstance(sample_collection.get_field(prefix + real_path), ListField),
         is_frame_field,
     )
 

--- a/fiftyone/core/stages.py
+++ b/fiftyone/core/stages.py
@@ -2515,36 +2515,37 @@ def _get_frames_list_field_only_matches_expr(field):
 
 
 def _get_trajectories_filter(sample_collection, field, filter_arg):
+    root, is_list_field = sample_collection._get_label_field_root(field)
+    root, is_frame_field = sample_collection._handle_frame_field(root)
     label_type = sample_collection._get_label_field_type(field)
-    path, is_frame_field = sample_collection._handle_frame_field(field)
 
     if not is_frame_field:
         raise ValueError(
             "Filtering trajectories is only supported for frame fields"
         )
 
-    if issubclass(label_type, (fol.Detections, fol.Polylines, fol.Keypoints)):
-        path += "." + label_type._LABEL_LIST_FIELD
+    if label_type not in fol._INDEX_FIEDS:
+        raise ValueError(
+            "Cannot filter trajectories for field '%s' of type %s"
+            % (field, fol._INDEX_FIEDS)
+        )
+
+    if is_list_field:
         cond = _get_list_trajectory_mongo_filter(filter_arg)
         filter_expr = (F("index") != None) & foe.ViewExpression(cond)
         reduce_expr = VALUE.extend(
-            (F(path) != None).if_else(
-                F(path).filter(filter_expr).map(F("index")),
+            (F(root) != None).if_else(
+                F(root).filter(filter_expr).map(F("index")),
                 [],
             )
         )
-    elif issubclass(label_type, (fol.Detection, fol.Polyline, fol.Keypoint)):
+    else:
         cond = _get_trajectory_mongo_filter(filter_arg)
         filter_expr = (F("index") != None) & foe.ViewExpression(cond)
         reduce_expr = (
-            F(path)
+            F(root)
             .apply(filter_expr)
-            .if_else(VALUE.append(F(path + ".index")), VALUE)
-        )
-    else:
-        raise ValueError(
-            "Cannot filter trajectories for field '%s' of type %s"
-            % (field, label_type)
+            .if_else(VALUE.append(F(root + ".index")), VALUE)
         )
 
     # union() removes duplicates
@@ -3867,9 +3868,15 @@ class LimitLabels(ViewStage):
         ]
 
     def validate(self, sample_collection):
-        list_field, is_frame_field = _parse_labels_list_field(
+        list_field, is_list_field, is_frame_field = _parse_labels_field(
             sample_collection, self._field
         )
+
+        if not is_list_field:
+            raise ValueError(
+                "Field '%s' does not contain a list of labels" % self._field
+            )
+
         self._labels_list_field = list_field
         self._is_frame_field = is_frame_field
 
@@ -8066,13 +8073,8 @@ def _get_rng(seed):
 
 
 def _parse_labels_field(sample_collection, field_path):
-    label_type = sample_collection._get_label_field_type(field_path)
+    path, is_list_field = sample_collection._get_label_field_root(field_path)
     is_frame_field = sample_collection._is_frame_field(field_path)
-    is_list_field = issubclass(label_type, fol._LABEL_LIST_FIELDS)
-    if is_list_field:
-        path = field_path + "." + label_type._LABEL_LIST_FIELD
-    else:
-        path = field_path
 
     prefix = ""
     real_path = path
@@ -8097,21 +8099,6 @@ def _parse_labels_field(sample_collection, field_path):
         is_list_field = isinstance(real_field, ListField)
 
     return path, is_list_field, is_frame_field
-
-
-def _parse_labels_list_field(sample_collection, field_path):
-    label_type = sample_collection._get_label_field_type(field_path)
-    is_frame_field = sample_collection._is_frame_field(field_path)
-
-    if not issubclass(label_type, fol._LABEL_LIST_FIELDS):
-        raise ValueError(
-            "Field '%s' must be a labels list type %s; found %s"
-            % (field_path, fol._LABEL_LIST_FIELDS, label_type)
-        )
-
-    path = field_path + "." + label_type._LABEL_LIST_FIELD
-
-    return path, is_frame_field
 
 
 def _remove_path_collisions(paths):
@@ -8152,29 +8139,25 @@ def _parse_labels(labels):
 def _get_label_field_only_matches_expr(
     sample_collection, field, new_field=None, prefix=""
 ):
-    label_type = sample_collection._get_label_field_type(field)
-    is_label_list_field = issubclass(label_type, fol._LABEL_LIST_FIELDS)
+    path, is_list_field = sample_collection._get_label_field_root(field)
 
     if new_field is not None:
-        field = new_field
+        path = new_field + path[len(field) :]
 
-    field, is_frame_field = sample_collection._handle_frame_field(field)
-
-    if is_label_list_field:
-        field += "." + label_type._LABEL_LIST_FIELD
+    path, is_frame_field = sample_collection._handle_frame_field(path)
 
     if is_frame_field:
-        if is_label_list_field:
+        if is_list_field:
             match_fcn = _get_frames_list_field_only_matches_expr
         else:
             match_fcn = _get_frames_field_only_matches_expr
     else:
-        if is_label_list_field:
+        if is_list_field:
             match_fcn = _get_list_field_only_matches_expr
         else:
             match_fcn = _get_field_only_matches_expr
 
-    return match_fcn(prefix + field)
+    return match_fcn(prefix + path)
 
 
 def _make_omit_empty_labels_pipeline(sample_collection, fields):

--- a/fiftyone/core/stages.py
+++ b/fiftyone/core/stages.py
@@ -30,7 +30,7 @@ from fiftyone.core.odm.document import MongoEngineBaseDocument
 import fiftyone.core.sample as fos
 import fiftyone.core.utils as fou
 import fiftyone.core.validation as fova
-from fiftyone.core.fields import EmbeddedDocumentField
+from fiftyone.core.fields import EmbeddedDocumentField, ListField
 
 fob = fou.lazy_import("fiftyone.brain")
 focl = fou.lazy_import("fiftyone.core.clips")
@@ -8074,7 +8074,11 @@ def _parse_labels_field(sample_collection, field_path):
     else:
         path = field_path
 
-    return path, is_list_field, is_frame_field
+    return (
+        path,
+        isinstance(sample_collection.get_field(path), ListField),
+        is_frame_field,
+    )
 
 
 def _parse_labels_list_field(sample_collection, field_path):

--- a/fiftyone/server/utils.py
+++ b/fiftyone/server/utils.py
@@ -108,26 +108,6 @@ def from_dict(data_class: t.Type[T], data: Data) -> T:
     return _from_dict(data_class, data, config=_dacite_config)
 
 
-def iter_label_fields(view: foc.SampleCollection):
-    """
-    Yields the labels of the
-    :class:`fiftyone.core.collections.SampleCollection`
-
-    Args:
-        view: a :class:`fiftyone.core.collections.SampleCollection`
-    """
-    for path, field in _iter_label_fields(view.get_field_schema(flat=True)):
-        yield path, field
-
-    if view.media_type != fom.VIDEO:
-        return
-
-    for path, field in _iter_label_fields(
-        view.get_frame_field_schema(flat=True)
-    ):
-        yield f"frames.{path}", field
-
-
 def meets_type(field: fof.Field, type_or_types):
     """
     Determines whether the field meets type or types, or the field
@@ -141,27 +121,6 @@ def meets_type(field: fof.Field, type_or_types):
         isinstance(field, fof.ListField)
         and isinstance(field.field, type_or_types)
     )
-
-
-def _iter_label_fields(schema):
-    for path, field in schema.items():
-        field_to_check = field
-        if isinstance(field, fof.ListField):
-            field_to_check = field.field
-        if (
-            isinstance(field_to_check, fof.EmbeddedDocumentField)
-            and issubclass(field_to_check.document_type, fol.Label)
-            and not issubclass(field_to_check.document_type, fol._HasLabelList)
-        ):
-            parent_path = ".".join(path.split(".")[:-1])
-            parent_field = schema.get(parent_path, None)
-            if isinstance(
-                parent_field, fof.EmbeddedDocumentField
-            ) and issubclass(parent_field.document_type, fol._HasLabelList):
-                yield parent_path, parent_field
-                continue
-
-            yield path, field
 
 
 def _parse_changes(changes):

--- a/fiftyone/server/view.py
+++ b/fiftyone/server/view.py
@@ -172,7 +172,7 @@ def get_extended_view(
 
         if _LABEL_TAGS in filters:
             label_tags = filters.get(_LABEL_TAGS)
-            label_fields = [path for path in view._get_label_fields()]
+            label_fields = view._get_label_fields()
 
             if (
                 not count_label_tags

--- a/fiftyone/server/view.py
+++ b/fiftyone/server/view.py
@@ -172,7 +172,7 @@ def get_extended_view(
 
         if _LABEL_TAGS in filters:
             label_tags = filters.get(_LABEL_TAGS)
-            label_fields = [path for path, _ in fosu.iter_label_fields(view)]
+            label_fields = [path for path in view.get_label_fields()]
 
             if (
                 not count_label_tags
@@ -270,7 +270,7 @@ def _add_labels_tags_counts(view, filtered_fields, label_tags):
     """
     view = view.set_field(_LABEL_TAGS, [], _allow_missing=True)
 
-    for path, field in fosu.iter_label_fields(view):
+    for path, field in foc._iter_label_fields(view):
         path = _get_filtered_path(view, path, filtered_fields, label_tags)
         if isinstance(field, fof.ListField) or (
             isinstance(field, fof.EmbeddedDocumentField)
@@ -477,7 +477,7 @@ def _make_filter_stages(
         is_matching = label_tags.get("isMatching", False)
         exclude = label_tags.get("exclude", False)
 
-        for path, _ in fosu.iter_label_fields(view):
+        for path in view._get_label_fields():
             if hide_result:
                 new_field = _get_filtered_path(
                     view, path, filtered_labels, label_tags
@@ -498,7 +498,7 @@ def _make_filter_stages(
                 cleanup.add(new_field)
 
         match_exprs = []
-        for path, _ in fosu.iter_label_fields(view):
+        for path in view.get_label_fields():
             expr = fosg._get_label_field_only_matches_expr(
                 view,
                 cache.get(path, path),

--- a/fiftyone/server/view.py
+++ b/fiftyone/server/view.py
@@ -172,7 +172,7 @@ def get_extended_view(
 
         if _LABEL_TAGS in filters:
             label_tags = filters.get(_LABEL_TAGS)
-            label_fields = [path for path in view.get_label_fields()]
+            label_fields = [path for path in view._get_label_fields()]
 
             if (
                 not count_label_tags
@@ -498,7 +498,7 @@ def _make_filter_stages(
                 cleanup.add(new_field)
 
         match_exprs = []
-        for path in view.get_label_fields():
+        for path in view._get_label_fields():
             expr = fosg._get_label_field_only_matches_expr(
                 view,
                 cache.get(path, path),

--- a/fiftyone/utils/annotations.py
+++ b/fiftyone/utils/annotations.py
@@ -2538,11 +2538,7 @@ def _to_video_labels(sample, label_fields=None):
 
 def _get_sample_labels(sample, label_fields):
     if label_fields is None:
-        return {
-            name: value
-            for name, value in sample.iter_fields()
-            if isinstance(value, fol.Label)
-        }
+        return dict(sample._iter_label_fields())
 
     if label_fields:
         return {name: sample[name] for name in label_fields}
@@ -2557,11 +2553,7 @@ def _get_frame_labels(sample, frame_label_fields):
     frames = {}
     for frame_number, frame in sample.frames.items():
         if frame_label_fields is None:
-            frames[frame_number] = {
-                name: value
-                for name, value in frame.iter_fields()
-                if isinstance(value, fol.Label)
-            }
+            frames[frame_number] = dict(frame._iter_label_fields())
         else:
             frames[frame_number] = {
                 name: frame[name] for name in frame_label_fields

--- a/tests/unittests/dataset_tests.py
+++ b/tests/unittests/dataset_tests.py
@@ -4465,6 +4465,50 @@ class DynamicFieldTests(unittest.TestCase):
         dataset.add_dynamic_frame_fields()
 
     @drop_datasets
+    def test_dynamic_fields_defaults(self):
+        sample = fo.Sample(
+            filepath="video.mp4",
+            shapes=fo.Polylines(
+                polylines=[
+                    fo.Polyline(
+                        tags=["tag1", "tag2"],
+                        label="square",
+                        points=[[(0, 0), (0, 1), (1, 1), (1, 0), (0, 0)]],
+                    ),
+                ]
+            ),
+        )
+        sample.frames[1] = fo.Frame(
+            shapes=fo.Polylines(
+                polylines=[
+                    fo.Polyline(
+                        tags=["tag1", "tag2"],
+                        label="square",
+                        points=[[(0, 0), (0, 1), (1, 1), (1, 0), (0, 0)]],
+                    ),
+                ]
+            )
+        )
+
+        dataset = fo.Dataset()
+        dataset.add_sample(sample)
+
+        dynamic_schema = dataset.get_dynamic_field_schema()
+        self.assertDictEqual(dynamic_schema, {})
+
+        dynamic_schema = dataset.get_dynamic_frame_field_schema()
+        self.assertDictEqual(dynamic_schema, {})
+
+        dataset.add_dynamic_sample_fields()
+        dataset.add_dynamic_frame_fields()
+
+        field = dataset.get_field("shapes.polylines.points")
+        self.assertIsInstance(field, fof.PolylinePointsField)
+
+        field = dataset.get_field("frames.shapes.polylines.points")
+        self.assertIsInstance(field, fof.PolylinePointsField)
+
+    @drop_datasets
     def test_rename_dynamic_embedded_fields(self):
         sample = fo.Sample(
             filepath="image.jpg",

--- a/tests/unittests/label_tests.py
+++ b/tests/unittests/label_tests.py
@@ -89,20 +89,20 @@ class LabelTests(unittest.TestCase):
 
     @drop_datasets
     def test_dynamic_label_fields(self):
-        dynamic_data = fo.DynamicEmbeddedDocument(
+        dynamic_doc = fo.DynamicEmbeddedDocument(
             classification=fo.Classification(label="label"),
             classifications=[fo.Classification(label="label")],
             more_classifications=fo.Classifications(
                 classifications=[fo.Classification(label="label")]
             ),
         )
-        sample = fo.Sample(filepath="image.jpg", dynamic=dynamic_data)
+        sample = fo.Sample(filepath="image.jpg", dynamic=dynamic_doc)
 
         dataset = fo.Dataset()
         dataset.add_sample(sample)
         dataset.add_dynamic_sample_fields()
 
-        label_id = dynamic_data["classification"].id
+        label_id = dynamic_doc["classification"].id
         view = dataset.select_labels(
             [
                 {
@@ -117,7 +117,7 @@ class LabelTests(unittest.TestCase):
         self.assertFalse("classifications" in dynamic)
         self.assertFalse("more_classifications" in dynamic)
 
-        label_id = dynamic_data["classifications"][0].id
+        label_id = dynamic_doc["classifications"][0].id
         view = dataset.select_labels(
             [
                 {
@@ -133,7 +133,7 @@ class LabelTests(unittest.TestCase):
         self.assertFalse("classification" in dynamic)
         self.assertFalse("more_classifications" in dynamic)
 
-        label_id = dynamic_data["more_classifications"].classifications[0].id
+        label_id = dynamic_doc["more_classifications"].classifications[0].id
         view = dataset.select_labels(
             [
                 {

--- a/tests/unittests/sample_tests.py
+++ b/tests/unittests/sample_tests.py
@@ -139,6 +139,56 @@ class SampleTests(unittest.TestCase):
         self.assertIsInstance(sample2["sample_id"], str)
         self.assertIsInstance(sample2["embedding"], np.ndarray)
 
+    @drop_datasets
+    def test_nested_fields(self):
+        sample = fo.Sample(
+            filepath="image1.jpg",
+            dynamic=fo.DynamicEmbeddedDocument(
+                classification=fo.Classification(label="hi"),
+                classification_list=[
+                    fo.Classification(label="foo"),
+                    fo.Classification(label="bar"),
+                ],
+                classifications=fo.Classifications(
+                    classifications=[
+                        fo.Classification(label="spam"),
+                        fo.Classification(label="eggs"),
+                    ]
+                ),
+            ),
+        )
+
+        self.assertIsInstance(sample["dynamic"], fo.DynamicEmbeddedDocument)
+        self.assertIsInstance(
+            sample["dynamic.classification"], fo.Classification
+        )
+        self.assertIsInstance(sample["dynamic.classification_list"], list)
+        self.assertIsInstance(
+            sample["dynamic.classifications"], fo.Classifications
+        )
+        self.assertIsInstance(
+            sample["dynamic.classifications.classifications"], list
+        )
+        self.assertIsInstance(
+            sample["dynamic.classifications.classifications"][0],
+            fo.Classification,
+        )
+
+        with self.assertRaises(KeyError):
+            sample["foo"]
+
+        with self.assertRaises(KeyError):
+            sample["dynamic.foo"]
+
+        with self.assertRaises(KeyError):
+            sample["dynamic.classification.foo"]
+
+        with self.assertRaises(KeyError):
+            sample["dynamic.classifications.foo"]
+
+        with self.assertRaises(KeyError):
+            sample["dynamic.classifications.classifications.foo"]
+
 
 class SampleInDatasetTests(unittest.TestCase):
     @drop_datasets
@@ -393,6 +443,82 @@ class SampleInDatasetTests(unittest.TestCase):
 
         self.assertIsNone(s1.new_field)
         self.assertEqual(s2.new_field, "fiftyone")
+
+    @drop_datasets
+    def test_nested_fields(self):
+        sample1 = fo.Sample(
+            filepath="image1.jpg",
+            dynamic=fo.DynamicEmbeddedDocument(
+                classification=fo.Classification(label="hi"),
+                classification_list=[
+                    fo.Classification(label="foo"),
+                    fo.Classification(label="bar"),
+                ],
+                classifications=fo.Classifications(
+                    classifications=[
+                        fo.Classification(label="spam"),
+                        fo.Classification(label="eggs"),
+                    ]
+                ),
+            ),
+        )
+
+        sample2 = fo.Sample(filepath="image2.jpg")
+
+        dataset = fo.Dataset()
+        dataset.add_samples([sample1, sample2], dynamic=True)
+
+        self.assertIsInstance(sample1["dynamic"], fo.DynamicEmbeddedDocument)
+        self.assertIsInstance(
+            sample1["dynamic.classification"], fo.Classification
+        )
+        self.assertIsInstance(sample1["dynamic.classification_list"], list)
+        self.assertIsInstance(
+            sample1["dynamic.classifications"], fo.Classifications
+        )
+        self.assertIsInstance(
+            sample1["dynamic.classifications.classifications"], list
+        )
+        self.assertIsInstance(
+            sample1["dynamic.classifications.classifications"][0],
+            fo.Classification,
+        )
+
+        self.assertIsNone(sample2["dynamic"])
+        self.assertIsNone(sample2["dynamic.classification"])
+        self.assertIsNone(sample2["dynamic.classification_list"])
+        self.assertIsNone(sample2["dynamic.classifications"])
+        self.assertIsNone(sample2["dynamic.classifications.classifications"])
+
+        with self.assertRaises(KeyError):
+            sample1["foo"]
+
+        with self.assertRaises(KeyError):
+            sample2["foo"]
+
+        with self.assertRaises(KeyError):
+            sample1["dynamic.foo"]
+
+        with self.assertRaises(KeyError):
+            sample2["dynamic.foo"]
+
+        with self.assertRaises(KeyError):
+            sample1["dynamic.classification.foo"]
+
+        with self.assertRaises(KeyError):
+            sample2["dynamic.classification.foo"]
+
+        with self.assertRaises(KeyError):
+            sample1["dynamic.classifications.foo"]
+
+        with self.assertRaises(KeyError):
+            sample2["dynamic.classifications.foo"]
+
+        with self.assertRaises(KeyError):
+            sample1["dynamic.classifications.classifications.foo"]
+
+        with self.assertRaises(KeyError):
+            sample2["dynamic.classifications.classifications.foo"]
 
 
 class SampleCollectionTests(unittest.TestCase):


### PR DESCRIPTION
Resolves https://github.com/voxel51/fiftyone/issues/3157
Resolves https://github.com/voxel51/fiftyone/issues/3183

Upgrades the SDK to fully support label fields stored as embedded document fields.

## Change log

- Methods like `tag_labels()`, `select_labels()`, `export()`, and `draw_labels()` automatically detect and properly handle label fields stored within embedded documents
- All `Document` objects now support `doc["nested.field"]` key access, which ensures that methods that accept label fields as parameters will gracefully support nested label fields
- Fixes some bugs related to dynamic field expansion:
    - https://github.com/voxel51/fiftyone/issues/3157
    - https://github.com/voxel51/fiftyone/issues/3183

## Example usage

```py
import fiftyone as fo
import fiftyone.zoo as foz
import fiftyone.utils.annotations as foua

dataset = (
    foz.load_zoo_dataset("quickstart", max_samples=10)
    .select_fields("ground_truth")
    .limit(10)
    .clone()
)

# Move labels to an embedded document field
dataset.add_sample_field(
    "dynamic",
    fo.EmbeddedDocumentField,
    embedded_doc_type=fo.DynamicEmbeddedDocument,
)
dataset.rename_sample_field("ground_truth", "dynamic.ground_truth")

# Automatically locates labels in `dynamic.ground_truth` field
dataset.export(
    export_dir="/tmp/coco",
    dataset_type=fo.types.COCODetectionDataset,
)

# Automatically locates labels in `dynamic.ground_truth` field
dataset.draw_labels("/tmp/anno")
```
