### PR TITLE
[1.3.1 Bug fixes]  Field visibility improvements

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -15,7 +15,8 @@
         "postinstall": "patch-package",
         "start": "yarn workspace @fiftyone/app start",
         "start-desktop": "yarn workspace FiftyOne start-desktop",
-        "test": "yarn vitest run",
+        "test": "yarn vitest run --coverage",
+        "test-ui": "yarn vitest --ui",
         "gen:schema": "strawberry export-schema fiftyone.server.app:schema > schema.graphql"
     },
     "devDependencies": {
@@ -23,7 +24,8 @@
         "@testing-library/react-hooks": "latest",
         "@typescript-eslint/eslint-plugin": "^5.44.0",
         "@typescript-eslint/parser": "^5.44.0",
-        "@vitest/coverage-c8": "^0.25.2",
+        "@vitest/coverage-v8": "^0.32.0",
+        "@vitest/ui": "^0.32.0",
         "concurrently": "^7.2.1",
         "eslint": "^8.28.0",
         "eslint-config-prettier": "^8.5.0",
@@ -42,7 +44,7 @@
         "vite": "^3.0.0",
         "vite-plugin-eslint": "^1.8.1",
         "vite-plugin-relay": "^2.0.0",
-        "vitest": "^0.25.2"
+        "vitest": "^0.32.0"
     },
     "workspaces": [
         "packages/*"

--- a/app/package.json
+++ b/app/package.json
@@ -15,7 +15,7 @@
         "postinstall": "patch-package",
         "start": "yarn workspace @fiftyone/app start",
         "start-desktop": "yarn workspace FiftyOne start-desktop",
-        "test": "yarn vitest run --coverage",
+        "test": "yarn vitest run",
         "test-ui": "yarn vitest --ui",
         "gen:schema": "strawberry export-schema fiftyone.server.app:schema > schema.graphql"
     },

--- a/app/packages/core/src/components/ColorModal/ColorModal.tsx
+++ b/app/packages/core/src/components/ColorModal/ColorModal.tsx
@@ -121,6 +121,7 @@ const ColorModal = () => {
                       height: "30px",
                       display: "flex",
                       alignItems: "center",
+                      margin: "auto 4px",
                     }}
                     title="Documentation"
                     href={CUSTOM_COLOR_DOCUMENTATION_LINK}
@@ -130,7 +131,7 @@ const ColorModal = () => {
                   <CloseIcon
                     onClick={() => setActiveColorModalField(null)}
                     onMouseDown={(e) => e.stopPropagation()}
-                    style={{ margin: "4px", cursor: "pointer" }}
+                    style={{ margin: "auto 4px", cursor: "pointer" }}
                   />
                 </DraggableModalTitle>
                 <DraggableContent height={height} width={width}>

--- a/app/packages/core/src/components/ColorModal/ColorModal.tsx
+++ b/app/packages/core/src/components/ColorModal/ColorModal.tsx
@@ -17,12 +17,15 @@ import {
   ModalWrapper,
 } from "./ShareStyledDiv";
 
-import { useTheme } from "@fiftyone/components";
+import { ExternalLink, InfoIcon, useTheme } from "@fiftyone/components";
 import Typography from "@mui/material/Typography";
 import { Resizable } from "re-resizable";
 import { resizeHandle } from "./../Sidebar/Sidebar.module.css";
 import SidebarList from "./SidebarList";
 import { ACTIVE_FIELD } from "./utils";
+
+const CUSTOM_COLOR_DOCUMENTATION_LINK =
+  "https://docs.voxel51.com/user_guide/app.html#app-color-schemes";
 
 const ColorModal = () => {
   const theme = useTheme();
@@ -112,6 +115,18 @@ const ColorModal = () => {
                   >
                     Color scheme
                   </Typography>
+                  <ExternalLink
+                    style={{
+                      color: theme.text.secondary,
+                      height: "30px",
+                      display: "flex",
+                      alignItems: "center",
+                    }}
+                    title="Documentation"
+                    href={CUSTOM_COLOR_DOCUMENTATION_LINK}
+                  >
+                    <InfoIcon />
+                  </ExternalLink>
                   <CloseIcon
                     onClick={() => setActiveColorModalField(null)}
                     onMouseDown={(e) => e.stopPropagation()}

--- a/app/packages/core/src/components/ColorModal/ShareStyledDiv.ts
+++ b/app/packages/core/src/components/ColorModal/ShareStyledDiv.ts
@@ -33,6 +33,7 @@ export const Container = styled.div<Props>`
 
 export const DraggableContent = styled.div<Props>`
   height: ${(props) => `calc(${props.height}px - 6.5rem)`};
+  border-top: 1px solid ${({ theme }) => theme.primary.plainBorder};
   width: 100%;
   display: flex;
   flex-direction: row;
@@ -51,7 +52,8 @@ export const DraggableModalTitle = styled.div`
   justify-content: space-between;
   width: 100%;
   height: 3rem;
-  padding: 0.75rem;
+  padding-left: 0.75rem;
+  padding-right: 0.75rem;
   background-color: ${({ theme }) => theme.background.level2};
   cursor: move;
   font-weight: 600;

--- a/app/packages/core/src/components/Schema/SchemaSearchHelp.tsx
+++ b/app/packages/core/src/components/Schema/SchemaSearchHelp.tsx
@@ -17,15 +17,15 @@ const EXAMPLES = [
   },
   {
     title:
-      '# Search across name, description, and all info.* keys for string "foo"',
+      'Search across name, description, and all info.* keys for string "foo"',
     code: "foo",
   },
   {
-    title: '# Match fields whose name contains "ground_truth"',
+    title: 'Match fields whose name contains "ground_truth"',
     code: "name:ground_truth",
   },
   {
-    title: "# Match fields whose owner contains “foo”",
+    title: "Match fields whose owner contains “foo”",
     code: "info.owner:foo",
   },
   {
@@ -42,7 +42,7 @@ export const SchemaSearchHelp = (props: Props) => {
   const theme = useTheme();
 
   return (
-    <Box display="flex" flexDirection="column" padding="1rem">
+    <Box display="flex" flexDirection="column">
       {EXAMPLES.map(({ title, primaryTextColor, code }: Example) => (
         <Box
           key={title}
@@ -64,7 +64,11 @@ export const SchemaSearchHelp = (props: Props) => {
           </Typography>
           {code && (
             <Box paddingTop="0.25rem">
-              <CodeBlock text={code} language="python" />
+              <CodeBlock
+                text={code}
+                language="python"
+                showLineNumbers={false}
+              />
             </Box>
           )}
         </Box>

--- a/app/packages/core/src/components/Schema/SchemaSelectControls.tsx
+++ b/app/packages/core/src/components/Schema/SchemaSelectControls.tsx
@@ -2,7 +2,6 @@ import React, { useMemo } from "react";
 import { Box, FormControlLabel, FormGroup, Switch } from "@mui/material";
 
 import { useSchemaSettings } from "@fiftyone/state";
-import { TAB_OPTIONS_MAP } from "@fiftyone/state/src/hooks/useSchemaSettings";
 import styled from "styled-components";
 
 const ContainerBox = styled(Box)`
@@ -19,22 +18,21 @@ export const SchemaSelectionControls = () => {
     setShowNestedFields,
     allFieldsChecked,
     setAllFieldsChecked,
-    selectedTab,
+    isFilterRuleActive,
     showMetadata,
     setShowMetadata,
     searchResults,
     includeNestedFields,
     setIncludeNestedFields,
   } = useSchemaSettings();
-  const isFilterRuleMode = selectedTab === TAB_OPTIONS_MAP.FILTER_RULE;
-  const showMetadataVisibile = !!!(isFilterRuleMode && !searchResults.length);
-  const includeNestedVisible = !!(isFilterRuleMode && searchResults.length);
+  const showMetadataVisible = !!!(isFilterRuleActive && !searchResults.length);
+  const includeNestedVisible = !!(isFilterRuleActive && searchResults.length);
 
   const controlList = useMemo(() => {
     return [
       {
         label: "Show metadata",
-        isVisible: showMetadataVisibile,
+        isVisible: showMetadataVisible,
         value: showMetadata,
         checked: showMetadata,
         onChange: () => setShowMetadata(!showMetadata),
@@ -49,14 +47,14 @@ export const SchemaSelectionControls = () => {
       },
       {
         label: "Show nested fields",
-        isVisible: !isFilterRuleMode,
+        isVisible: !isFilterRuleActive,
         value: showNestedFields,
         checked: showNestedFields,
         onChange: () => setShowNestedFields(!showNestedFields),
       },
       {
         label: "Select all",
-        isVisible: !isFilterRuleMode,
+        isVisible: !isFilterRuleActive,
         value: allFieldsChecked,
         checked: allFieldsChecked,
         onChange: () => setAllFieldsChecked(!allFieldsChecked),
@@ -64,7 +62,7 @@ export const SchemaSelectionControls = () => {
     ];
   }, [
     showMetadata,
-    showMetadataVisibile,
+    showMetadataVisible,
     includeNestedFields,
     showNestedFields,
     allFieldsChecked,

--- a/app/packages/core/src/components/Schema/SchemaSelectControls.tsx
+++ b/app/packages/core/src/components/Schema/SchemaSelectControls.tsx
@@ -1,8 +1,6 @@
 import React, { useMemo } from "react";
 import { Box, FormControlLabel, FormGroup, Switch } from "@mui/material";
 
-import Checkbox from "@mui/material/Checkbox";
-import { useTheme } from "@fiftyone/components";
 import { useSchemaSettings } from "@fiftyone/state";
 import { TAB_OPTIONS_MAP } from "@fiftyone/state/src/hooks/useSchemaSettings";
 import styled from "styled-components";
@@ -15,10 +13,7 @@ const ContainerBox = styled(Box)`
   padding: 0.35rem 1rem;
 `;
 
-interface Props {}
-
-export const SchemaSelectionControls = (props: Props) => {
-  const theme = useTheme();
+export const SchemaSelectionControls = () => {
   const {
     showNestedFields,
     setShowNestedFields,
@@ -85,7 +80,7 @@ export const SchemaSelectionControls = (props: Props) => {
         {controlList
           .filter(({ isVisible }) => isVisible)
           .map(({ label, value, checked, onChange, disabled = false }) => (
-            <ContainerBox key={label}>
+            <ContainerBox key={label} flex="1">
               <FormGroup>
                 <FormControlLabel
                   control={

--- a/app/packages/core/src/components/Schema/SchemaSelectControls.tsx
+++ b/app/packages/core/src/components/Schema/SchemaSelectControls.tsx
@@ -25,7 +25,7 @@ export const SchemaSelectionControls = () => {
     includeNestedFields,
     setIncludeNestedFields,
   } = useSchemaSettings();
-  const showMetadataVisible = !!!(isFilterRuleActive && !searchResults.length);
+  const showMetadataVisible = !(isFilterRuleActive && !searchResults.length);
   const includeNestedVisible = !!(isFilterRuleActive && searchResults.length);
 
   const controlList = useMemo(() => {
@@ -61,11 +61,18 @@ export const SchemaSelectionControls = () => {
       },
     ];
   }, [
-    showMetadata,
     showMetadataVisible,
+    showMetadata,
+    includeNestedVisible,
     includeNestedFields,
+    searchResults.length,
+    isFilterRuleActive,
     showNestedFields,
     allFieldsChecked,
+    setShowMetadata,
+    setIncludeNestedFields,
+    setShowNestedFields,
+    setAllFieldsChecked,
   ]);
 
   return (

--- a/app/packages/core/src/components/Schema/SchemaSelectControls.tsx
+++ b/app/packages/core/src/components/Schema/SchemaSelectControls.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useMemo } from "react";
 import { Box, FormControlLabel, FormGroup, Switch } from "@mui/material";
 
 import Checkbox from "@mui/material/Checkbox";
@@ -32,6 +32,48 @@ export const SchemaSelectionControls = (props: Props) => {
     setIncludeNestedFields,
   } = useSchemaSettings();
   const isFilterRuleMode = selectedTab === TAB_OPTIONS_MAP.FILTER_RULE;
+  const showMetadataVisibile = !!!(isFilterRuleMode && !searchResults.length);
+  const includeNestedVisible = !!(isFilterRuleMode && searchResults.length);
+
+  const controlList = useMemo(() => {
+    return [
+      {
+        label: "Show metadata",
+        isVisible: showMetadataVisibile,
+        value: showMetadata,
+        checked: showMetadata,
+        onChange: () => setShowMetadata(!showMetadata),
+      },
+      {
+        label: "Include nested fields",
+        isVisible: includeNestedVisible,
+        value: includeNestedFields,
+        checked: includeNestedFields,
+        onChange: () => setIncludeNestedFields(!includeNestedFields),
+        disabled: !searchResults.length,
+      },
+      {
+        label: "Show nested fields",
+        isVisible: !isFilterRuleMode,
+        value: showNestedFields,
+        checked: showNestedFields,
+        onChange: () => setShowNestedFields(!showNestedFields),
+      },
+      {
+        label: "Select all",
+        isVisible: !isFilterRuleMode,
+        value: allFieldsChecked,
+        checked: allFieldsChecked,
+        onChange: () => setAllFieldsChecked(!allFieldsChecked),
+      },
+    ];
+  }, [
+    showMetadata,
+    showMetadataVisibile,
+    includeNestedFields,
+    showNestedFields,
+    allFieldsChecked,
+  ]);
 
   return (
     <Box
@@ -40,73 +82,26 @@ export const SchemaSelectionControls = (props: Props) => {
       sx={{ position: "relative !important" }}
     >
       <Box display="flex" width="100%" flexDirection="row" marginTop="1rem">
-        {!!!(isFilterRuleMode && !searchResults.length) && (
-          <ContainerBox>
-            <FormGroup>
-              <FormControlLabel
-                control={
-                  <Switch
-                    value={showMetadata}
-                    checked={showMetadata}
-                    onChange={() => setShowMetadata(!showMetadata)}
-                  />
-                }
-                label="Show metadata"
-              />
-            </FormGroup>
-          </ContainerBox>
-        )}
-        {!!(isFilterRuleMode && searchResults.length) && (
-          <ContainerBox>
-            <FormGroup>
-              <FormControlLabel
-                control={
-                  <Switch
-                    value={includeNestedFields}
-                    checked={includeNestedFields}
-                    onChange={() =>
-                      setIncludeNestedFields(!includeNestedFields)
-                    }
-                    disabled={!searchResults.length}
-                  />
-                }
-                label="Include nested fields"
-              />
-            </FormGroup>
-          </ContainerBox>
-        )}
-        {!isFilterRuleMode && (
-          <ContainerBox>
-            <FormGroup>
-              <FormControlLabel
-                control={
-                  <Switch
-                    value={showNestedFields}
-                    checked={showNestedFields}
-                    onChange={() => setShowNestedFields(!showNestedFields)}
-                  />
-                }
-                label="Show nested fields"
-              />
-            </FormGroup>
-          </ContainerBox>
-        )}
-        {!isFilterRuleMode && (
-          <ContainerBox>
-            <FormGroup>
-              <FormControlLabel
-                control={
-                  <Switch
-                    value={allFieldsChecked}
-                    checked={allFieldsChecked}
-                    onChange={() => setAllFieldsChecked(!allFieldsChecked)}
-                  />
-                }
-                label="Select all"
-              />
-            </FormGroup>
-          </ContainerBox>
-        )}
+        {controlList
+          .filter(({ isVisible }) => isVisible)
+          .map(({ label, value, checked, onChange, disabled = false }) => (
+            <ContainerBox key={label}>
+              <FormGroup>
+                <FormControlLabel
+                  control={
+                    <Switch
+                      value={value}
+                      checked={checked}
+                      onChange={onChange}
+                      disabled={disabled}
+                    />
+                  }
+                  label={label}
+                  sx={{ letterSpacing: "0.05rem" }}
+                />
+              </FormGroup>
+            </ContainerBox>
+          ))}
       </Box>
     </Box>
   );

--- a/app/packages/core/src/components/Schema/SchemaSelection.tsx
+++ b/app/packages/core/src/components/Schema/SchemaSelection.tsx
@@ -142,7 +142,6 @@ export const SchemaSelection = () => {
           marginTop: "1rem",
           overflow: "auto",
           color: "#232323",
-          border: `1px solid ${theme.primary.plainBorder}`,
         }}
       >
         {showSearchHelp && <SchemaSearchHelp />}

--- a/app/packages/core/src/components/Schema/SchemaSelection.tsx
+++ b/app/packages/core/src/components/Schema/SchemaSelection.tsx
@@ -215,7 +215,7 @@ export const SchemaSelection = () => {
                             paddingLeft: "0.5rem",
                             color: disabled
                               ? theme.text.tertiary
-                              : theme.text.secondary,
+                              : theme.text.tertiary,
                             fontSize: "0.8rem",
                             alignItems: "center",
                           }}

--- a/app/packages/core/src/components/Schema/SchemaSelection.tsx
+++ b/app/packages/core/src/components/Schema/SchemaSelection.tsx
@@ -1,125 +1,38 @@
-import React, { useCallback, useEffect, useState } from "react";
-import { Box, Typography } from "@mui/material";
+import React, { useEffect, useState } from "react";
+import { Box } from "@mui/material";
 
-import Checkbox from "@mui/material/Checkbox";
-import { CodeBlock, JSONIcon, useTheme } from "@fiftyone/components";
 import { useSchemaSettings } from "@fiftyone/state";
 import { SchemaSelectionControls } from "./SchemaSelectControls";
 import { SchemaSearchHelp } from "./SchemaSearchHelp";
-import { ExpandMore } from "@mui/icons-material";
-import styled from "styled-components";
 import { EMBEDDED_DOCUMENT_FIELD } from "@fiftyone/utilities";
-
-const InfoCell = styled(Box)`
-  display: flex;
-  padding: 0 0.25rem;
-`;
-
-const MetaInfoBlock = styled(Box)`
-  display: flex;
-  padding-left: 2rem;
-  font-size: 0.9rem;
-  color: ${({ theme }) => theme.text.secondary};
-`;
-const MetaInfoKey = styled(Typography)`
-  color: ${({ theme }) => theme.text.secondary};
-  padding-right: 0.25rem;
-  font-weight: bold !important;
-  font-size: 1rem;
-`;
+import { SchemaSelectionRow } from "./SchemaSelectionRow";
 
 export const SchemaSelection = () => {
-  const theme = useTheme();
   const {
-    toggleSelection,
     finalSchema,
     searchResults,
     isFilterRuleActive,
     showMetadata,
     finalSchemaKeyByPath,
+    setExpandedPaths,
+    expandedPaths,
   } = useSchemaSettings();
-  const [expandedPaths, setExpandedPaths] = useState({});
   const showSearchHelp = isFilterRuleActive && !searchResults?.length;
   const showSelection = !showSearchHelp;
-  const expandedPathsKeys = new Set(Object.keys(expandedPaths));
-  const [JSONifiedPaths, setJSONifiedPaths] = useState(new Set());
 
   useEffect(() => {
-    if (showMetadata) {
+    if (showMetadata && finalSchema && !expandedPaths) {
       const res = {};
-      finalSchema?.forEach((entry) => {
+      finalSchema.forEach((entry) => {
         if (entry?.info || entry?.description) {
           res[entry.path] = entry;
         }
       });
       setExpandedPaths(res);
-    } else {
-      setExpandedPaths({});
+    } else if (!showMetadata && !!expandedPaths) {
+      setExpandedPaths(null);
     }
-  }, [showMetadata]);
-
-  const renderInfo = useCallback(
-    (fInfo, path: string) => {
-      if (fInfo) {
-        switch (typeof fInfo) {
-          case "number":
-            const value = Number.isInteger(fInfo) ? fInfo : fInfo.toFixed(3);
-            return <MetaInfoBlock key={path + value}>{value}</MetaInfoBlock>;
-          case "string":
-            return (
-              <MetaInfoBlock key={fInfo}>
-                {fInfo.length ? fInfo : '""'}
-              </MetaInfoBlock>
-            );
-          case "boolean":
-            const boolLabel: string = fInfo ? "True" : "False";
-            <MetaInfoBlock key={path + boolLabel}>{boolLabel}</MetaInfoBlock>;
-          case "object":
-            try {
-              const obj = fInfo;
-              if (Array.isArray(obj)) {
-                return obj.map((key) => {
-                  return <InfoCell key={key}>{key}</InfoCell>;
-                });
-              } else {
-                return Object.keys(obj).map((key) => {
-                  const val = obj[key] || "";
-                  return (
-                    <MetaInfoBlock key={path + key}>
-                      <MetaInfoKey>
-                        {`${key}:`}
-                        {` `}
-                      </MetaInfoKey>
-                      {JSONifiedPaths.has(path)
-                        ? JSON.stringify(val, null, 1)
-                        : JSON.stringify(val)}
-                    </MetaInfoBlock>
-                  );
-                });
-              }
-            } catch (e) {
-              return <InfoCell>{fInfo}</InfoCell>;
-            }
-          default:
-            return <InfoCell>None</InfoCell>;
-        }
-      }
-    },
-    [JSONifiedPaths]
-  );
-
-  const handleJSONify = useCallback(
-    (path: string) => {
-      const newJSONifiedPaths = new Set([...JSONifiedPaths]);
-      if (JSONifiedPaths.has(path)) {
-        newJSONifiedPaths.delete(path);
-      } else {
-        newJSONifiedPaths.add(path);
-      }
-      setJSONifiedPaths(newJSONifiedPaths);
-    },
-    [JSONifiedPaths]
-  );
+  }, [expandedPaths, finalSchema, setExpandedPaths, showMetadata]);
 
   return (
     <Box
@@ -140,7 +53,7 @@ export const SchemaSelection = () => {
         {showSearchHelp && <SchemaSearchHelp />}
         {showSelection &&
           finalSchema?.map(
-            ({ path, count, isSelected, pathLabelFinal, skip, disabled }) => {
+            ({ path, count, pathLabelFinal, skip, disabled, isSelected }) => {
               if (skip) return null;
 
               const field = finalSchemaKeyByPath[path];
@@ -159,135 +72,20 @@ export const SchemaSelection = () => {
                       embedDocType.length
                     )
                   : docTypeLabel;
-              const isExpandable = fInfo || fDesc;
 
               return (
-                <Box
-                  style={{
-                    padding: "0.25rem 0.25rem",
-                    borderBottom: `1px solid ${theme.primary.plainBorder}`,
-                    display: "flex",
-                    flexDirection: "column",
-                    position: "relative",
-                    background:
-                      theme.mode === "light"
-                        ? theme.background.level2
-                        : theme.background.body,
-                  }}
+                <SchemaSelectionRow
                   key={path}
-                >
-                  <Box display="flex" justifyContent="space-between">
-                    <Box display="flex" flexDirection="row" width="100%">
-                      <Box>
-                        <Checkbox
-                          name={"Carousel"}
-                          value={path}
-                          checked={isSelected}
-                          onChange={() => {
-                            toggleSelection(path, isSelected);
-                          }}
-                          style={{
-                            padding: 0,
-                          }}
-                          disabled={disabled}
-                        />
-                      </Box>
-                      <Box display="flex">
-                        <Box
-                          style={{
-                            paddingLeft: `${
-                              isFilterRuleActive
-                                ? "0.5rem"
-                                : `${(count - 1) * 15 + 5}px`
-                            }`,
-                            color: disabled
-                              ? theme.text.tertiary
-                              : theme.text.primary,
-                            fontSize: "1rem",
-                          }}
-                          display="flex"
-                        >
-                          {pathLabelFinal}
-                        </Box>
-                        <Box
-                          display="flex"
-                          style={{
-                            paddingLeft: "0.5rem",
-                            color: disabled
-                              ? theme.text.tertiary
-                              : theme.text.tertiary,
-                            fontSize: "0.8rem",
-                            alignItems: "center",
-                          }}
-                        >
-                          ({docTypeLabel})
-                        </Box>
-                      </Box>
-                    </Box>
-                    {isExpandable && (
-                      <Box
-                        display="flex"
-                        position="relative"
-                        alignItems="center"
-                        sx={{ cursor: "pointer" }}
-                        onClick={() => {
-                          if (expandedPathsKeys.has(path)) {
-                            const newPaths = Object.assign({}, expandedPaths);
-                            delete newPaths[path];
-                            setExpandedPaths(newPaths);
-                          } else {
-                            const newPaths = Object.assign({}, expandedPaths);
-                            const element = finalSchema.filter(
-                              (sc) => sc.path === path
-                            )?.[0];
-
-                            newPaths[path] = {
-                              info: element?.info || "None",
-                              description: element?.description || "None",
-                              name: element?.name || "None",
-                            };
-                            setExpandedPaths(newPaths);
-                          }
-                        }}
-                      >
-                        <ExpandMore />
-                      </Box>
-                    )}
-                  </Box>
-                  <Box>
-                    {expandedPathsKeys.has(path) && (
-                      <Box
-                        maxHeight="200px"
-                        overflow="auto"
-                        position="relative"
-                      >
-                        {renderInfo(fInfo, path)}
-                        {fDesc && (
-                          <MetaInfoBlock key={fDesc}>
-                            <MetaInfoKey>Description: </MetaInfoKey>
-                            {fDesc}
-                          </MetaInfoBlock>
-                        )}
-                        <Box
-                          sx={{
-                            position: "absolute",
-                            right: "0.5rem",
-                            bottom: "20%",
-                            cursor: "pointer",
-                          }}
-                          onClick={() => handleJSONify(path)}
-                        >
-                          <JSONIcon
-                            sx={{
-                              color: (theme) => theme.typography.body2,
-                              fontSize: "1rem",
-                            }}
-                          />
-                        </Box>
-                      </Box>
-                    )}
-                  </Box>
-                </Box>
+                  path={path}
+                  isSelected={isSelected}
+                  count={count}
+                  disabled={disabled}
+                  pathLabelFinal={pathLabelFinal}
+                  docTypeLabel={docTypeLabel}
+                  isExpandable={fInfo || fDesc}
+                  info={fInfo}
+                  description={fDesc}
+                />
               );
             }
           )}

--- a/app/packages/core/src/components/Schema/SchemaSelection.tsx
+++ b/app/packages/core/src/components/Schema/SchemaSelection.tsx
@@ -7,7 +7,6 @@ import { useSchemaSettings } from "@fiftyone/state";
 import { SchemaSelectionControls } from "./SchemaSelectControls";
 import { SchemaSearchHelp } from "./SchemaSearchHelp";
 import { ExpandMore } from "@mui/icons-material";
-import { TAB_OPTIONS_MAP } from "@fiftyone/state/src/hooks/useSchemaSettings";
 import styled from "styled-components";
 
 interface Props {}
@@ -23,13 +22,12 @@ export const SchemaSelection = () => {
     toggleSelection,
     finalSchema,
     searchResults,
-    selectedTab,
+    isFilterRuleActive,
     showMetadata,
     finalSchemaKeyByPath,
   } = useSchemaSettings();
-  const isFilterRuleMode = selectedTab === TAB_OPTIONS_MAP.FILTER_RULE;
   const [expandedPaths, setExpandedPaths] = useState({});
-  const showSearchHelp = isFilterRuleMode && !searchResults?.length;
+  const showSearchHelp = isFilterRuleActive && !searchResults?.length;
   const showSelection = !showSearchHelp;
   const expandedPathsKeys = new Set(Object.keys(expandedPaths));
   const [JSONifiedPaths, setJSONifiedPaths] = useState(new Set());
@@ -191,7 +189,7 @@ export const SchemaSelection = () => {
                     <Box
                       style={{
                         paddingLeft: `${
-                          isFilterRuleMode
+                          isFilterRuleActive
                             ? "0.5rem"
                             : `${(count - 1) * 15 + 5}px`
                         }`,

--- a/app/packages/core/src/components/Schema/SchemaSelectionRow.tsx
+++ b/app/packages/core/src/components/Schema/SchemaSelectionRow.tsx
@@ -1,0 +1,214 @@
+import React, { useCallback } from "react";
+import { Box, Typography } from "@mui/material";
+
+import Checkbox from "@mui/material/Checkbox";
+import { useTheme } from "@fiftyone/components";
+import { useSchemaSettings } from "@fiftyone/state";
+import { ExpandMore } from "@mui/icons-material";
+import styled from "styled-components";
+
+const InfoCell = styled(Box)`
+  display: flex;
+  padding: 0 0.25rem;
+`;
+
+const MetaInfoBlock = styled(Box)`
+  display: flex;
+  padding-left: 2rem;
+  font-size: 0.9rem;
+  color: ${({ theme }) => theme.text.secondary};
+`;
+
+const MetaInfoKey = styled(Typography)`
+  color: ${({ theme }) => theme.text.secondary};
+  padding-right: 0.25rem;
+  font-weight: bold !important;
+  font-size: 1rem;
+`;
+
+const MAX_ROW_HEIGHT = "200px";
+
+interface Props {
+  path: string;
+  isSelected: boolean;
+  count: number;
+  disabled: boolean;
+  pathLabelFinal: string;
+  docTypeLabel: string;
+  isExpandable: boolean;
+  info: any;
+  description: string;
+}
+
+export const SchemaSelectionRow = (props: Props) => {
+  const {
+    path,
+    isSelected,
+    count,
+    disabled,
+    pathLabelFinal,
+    docTypeLabel,
+    isExpandable,
+    info,
+    description,
+  } = props;
+  const theme = useTheme();
+  const {
+    toggleSelection,
+    finalSchema,
+    isFilterRuleActive,
+    expandedPaths = {},
+    setExpandedPaths,
+  } = useSchemaSettings();
+  const expandedPathsKeys = new Set(Object.keys(expandedPaths || {}));
+
+  const renderInfo = useCallback(() => {
+    if (info) {
+      const infoType = typeof info;
+      if (infoType === "number") {
+        const value = Number.isInteger(info) ? info : info.toFixed(3);
+        return <MetaInfoBlock key={path + value}>{value}</MetaInfoBlock>;
+      }
+      if (infoType === "string") {
+        return (
+          <MetaInfoBlock key={info}>{info.length ? info : '""'}</MetaInfoBlock>
+        );
+      }
+      if (infoType === "boolean") {
+        const boolLabel: string = info ? "True" : "False";
+        return (
+          <MetaInfoBlock key={path + boolLabel}>{boolLabel}</MetaInfoBlock>
+        );
+      }
+      if (infoType === "object") {
+        try {
+          const obj = info;
+          if (Array.isArray(obj)) {
+            return obj.map((key) => {
+              return <InfoCell key={key}>{key}</InfoCell>;
+            });
+          } else {
+            return Object.keys(obj).map((key) => {
+              const val = obj[key] || "";
+              return (
+                <MetaInfoBlock key={path + key}>
+                  <MetaInfoKey>
+                    {`${key}:`}
+                    {` `}
+                  </MetaInfoKey>
+                  {JSON.stringify(val)}
+                </MetaInfoBlock>
+              );
+            });
+          }
+        } catch (e) {
+          return <InfoCell>{info}</InfoCell>;
+        }
+      }
+      return <InfoCell>None</InfoCell>;
+    }
+  }, [info, path]);
+
+  return (
+    <Box
+      style={{
+        padding: "0.25rem 0.25rem",
+        borderBottom: `1px solid ${theme.primary.plainBorder}`,
+        display: "flex",
+        flexDirection: "column",
+        position: "relative",
+        background:
+          theme.mode === "light"
+            ? theme.background.level2
+            : theme.background.body,
+      }}
+      key={path}
+    >
+      <Box display="flex" justifyContent="space-between">
+        <Box display="flex" flexDirection="row" width="100%">
+          <Box>
+            <Checkbox
+              name={"Carousel"}
+              value={path}
+              checked={isSelected}
+              onChange={() => {
+                toggleSelection(path, isSelected);
+              }}
+              style={{
+                padding: 0,
+              }}
+              disabled={disabled}
+            />
+          </Box>
+          <Box display="flex">
+            <Box
+              style={{
+                paddingLeft: `${
+                  isFilterRuleActive ? "0.5rem" : `${(count - 1) * 15 + 5}px`
+                }`,
+                color: disabled ? theme.text.tertiary : theme.text.primary,
+                fontSize: "1rem",
+              }}
+              display="flex"
+            >
+              {pathLabelFinal}
+            </Box>
+            <Box
+              display="flex"
+              style={{
+                paddingLeft: "0.5rem",
+                color: disabled ? theme.text.tertiary : theme.text.tertiary,
+                fontSize: "0.8rem",
+                alignItems: "center",
+              }}
+            >
+              ({docTypeLabel})
+            </Box>
+          </Box>
+        </Box>
+        {isExpandable && (
+          <Box
+            display="flex"
+            position="relative"
+            alignItems="center"
+            sx={{ cursor: "pointer" }}
+            onClick={() => {
+              if (expandedPathsKeys && expandedPathsKeys.has(path)) {
+                const newPaths = Object.assign({}, expandedPaths);
+                delete newPaths[path];
+                setExpandedPaths(newPaths);
+              } else {
+                const newPaths = Object.assign({}, expandedPaths);
+                const element = finalSchema.filter(
+                  (sc) => sc.path === path
+                )?.[0];
+
+                newPaths[path] = {
+                  info: element?.info || "None",
+                  description: element?.description || "None",
+                  name: element?.name || "None",
+                };
+                setExpandedPaths(newPaths);
+              }
+            }}
+          >
+            <ExpandMore />
+          </Box>
+        )}
+      </Box>
+      <Box>
+        {expandedPathsKeys.has(path) && (
+          <Box maxHeight={MAX_ROW_HEIGHT} overflow="auto" position="relative">
+            {renderInfo(info, path)}
+            {description && (
+              <MetaInfoBlock key={description}>
+                <MetaInfoKey>Description: </MetaInfoKey>
+                {description}
+              </MetaInfoBlock>
+            )}
+          </Box>
+        )}
+      </Box>
+    </Box>
+  );
+};

--- a/app/packages/core/src/components/Schema/SchemaSettings.tsx
+++ b/app/packages/core/src/components/Schema/SchemaSettings.tsx
@@ -11,7 +11,6 @@ import { TabOption } from "../utils";
 
 import useSchemaSettings, {
   TAB_OPTIONS,
-  TAB_OPTIONS_MAP,
 } from "@fiftyone/state/src/hooks/useSchemaSettings";
 
 import { SchemaSearch } from "./SchemaSearch";
@@ -69,7 +68,6 @@ const SchemaSettings = () => {
     setSelectedFieldsStage,
     datasetName,
     excludedPaths,
-    selectedPaths,
     resetExcludedPaths,
     setSelectedPaths,
     setLastAppliedPaths,
@@ -77,6 +75,7 @@ const SchemaSettings = () => {
     setExcludedPaths,
     isFilterRuleActive,
     searchMetaFilter,
+    enabledSelectedPaths,
   } = useSchemaSettings();
 
   useOutsideClick(schemaModalRef, (_) => {
@@ -189,13 +188,13 @@ const SchemaSettings = () => {
               })}
             />
           </Box>
-          {selectedTab === TAB_OPTIONS_MAP.FILTER_RULE && (
+          {isFilterRuleActive && (
             <SchemaSearch
               setSearchTerm={setSearchTerm}
               searchTerm={searchTerm}
             />
           )}
-          {selectedTab === TAB_OPTIONS_MAP.SELECTION && <SchemaSelection />}
+          {!isFilterRuleActive && <SchemaSelection />}
           <Box
             style={{
               position: "sticky",
@@ -244,7 +243,7 @@ const SchemaSettings = () => {
                   setSettingsModal({ open: false });
                 }
                 setLastAppliedPaths({
-                  selected: selectedPaths[datasetName],
+                  selected: enabledSelectedPaths[datasetName],
                   excluded: excludedPaths[datasetName],
                 });
               }}

--- a/app/packages/core/src/components/Schema/SchemaSettings.tsx
+++ b/app/packages/core/src/components/Schema/SchemaSettings.tsx
@@ -77,7 +77,6 @@ const SchemaSettings = () => {
     searchMetaFilter,
     enabledSelectedPaths,
     setShowNestedFields,
-    setIncludeNestedFields,
   } = useSchemaSettings();
 
   useOutsideClick(schemaModalRef, (_) => {
@@ -186,6 +185,12 @@ const SchemaSettings = () => {
                   onClick: () => {
                     setSelectedTab(value);
                     setShowNestedFields(false);
+                    setSelectedPaths({
+                      [datasetName]: new Set(lastAppliedPaths.selected),
+                    });
+                    setExcludedPaths({
+                      [datasetName]: new Set(lastAppliedPaths.excluded),
+                    });
                   },
                 };
               })}

--- a/app/packages/core/src/components/Schema/SchemaSettings.tsx
+++ b/app/packages/core/src/components/Schema/SchemaSettings.tsx
@@ -6,7 +6,7 @@ import * as fos from "@fiftyone/state";
 import CloseIcon from "@mui/icons-material/Close";
 import { Box, Typography } from "@mui/material";
 
-import { Button, useTheme } from "@fiftyone/components";
+import { Button, ExternalLink, InfoIcon, useTheme } from "@fiftyone/components";
 import { TabOption } from "../utils";
 
 import useSchemaSettings, {
@@ -48,6 +48,9 @@ const Container = styled.div`
   min-height: auto;
   background: white;
 `;
+
+const FIELD_VISIBILITY_DOCUMENTATION_LINK =
+  "https://docs.voxel51.com/user_guide/app.html#app-field-visibility";
 
 const SchemaSettings = () => {
   const theme = useTheme();
@@ -137,10 +140,24 @@ const SchemaSettings = () => {
               fontSize="1.5rem"
               style={{
                 width: "100%",
+                letterSpacing: "0.05rem",
               }}
             >
               Field visibility
             </Typography>
+            <ExternalLink
+              style={{
+                color: theme.text.secondary,
+                height: "20px",
+                display: "flex",
+                alignItems: "center",
+                marginRight: "0.5rem",
+              }}
+              title="Documentation"
+              href={FIELD_VISIBILITY_DOCUMENTATION_LINK}
+            >
+              <InfoIcon />
+            </ExternalLink>
             <CloseIcon
               sx={{
                 color: theme.text.primary,
@@ -155,6 +172,7 @@ const SchemaSettings = () => {
               overflow: "hidden",
               width: "100%",
               paddingTop: "0.5rem",
+              letterSpacing: "0.05rem",
             }}
           >
             <TabOption

--- a/app/packages/core/src/components/Schema/SchemaSettings.tsx
+++ b/app/packages/core/src/components/Schema/SchemaSettings.tsx
@@ -72,6 +72,8 @@ const SchemaSettings = () => {
     setLastAppliedPaths,
     lastAppliedPaths,
     setExcludedPaths,
+    isFilterRuleActive,
+    searchMetaFilter,
   } = useSchemaSettings();
 
   useOutsideClick(schemaModalRef, (_) => {
@@ -197,16 +199,25 @@ const SchemaSettings = () => {
               onClick={() => {
                 const initialFieldNames = [...excludedPaths[datasetName]];
 
-                const stageKwargs = {
-                  field_names: initialFieldNames,
-                  _allow_missing: true,
-                };
+                let stage;
+                if (isFilterRuleActive) {
+                  stage = {
+                    _cls: "fiftyone.core.stages.SelectFields",
+                    kwargs: {
+                      meta_filter: searchMetaFilter,
+                      _allow_missing: true,
+                    },
+                  };
+                } else {
+                  stage = {
+                    _cls: "fiftyone.core.stages.ExcludeFields",
+                    kwargs: {
+                      field_names: initialFieldNames,
+                      _allow_missing: true,
+                    },
+                  };
+                }
 
-                const stageCls = "fiftyone.core.stages.ExcludeFields";
-                const stage = {
-                  _cls: stageCls,
-                  kwargs: stageKwargs,
-                };
                 try {
                   setSelectedFieldsStage(stage);
                 } catch (e) {

--- a/app/packages/core/src/components/Schema/SchemaSettings.tsx
+++ b/app/packages/core/src/components/Schema/SchemaSettings.tsx
@@ -76,6 +76,8 @@ const SchemaSettings = () => {
     isFilterRuleActive,
     searchMetaFilter,
     enabledSelectedPaths,
+    setShowNestedFields,
+    setIncludeNestedFields,
   } = useSchemaSettings();
 
   useOutsideClick(schemaModalRef, (_) => {
@@ -131,6 +133,7 @@ const SchemaSettings = () => {
               position: "relative",
               display: "flex",
               justifyContent: "space-between",
+              alignItems: "center",
             }}
           >
             <Typography
@@ -147,7 +150,6 @@ const SchemaSettings = () => {
             <ExternalLink
               style={{
                 color: theme.text.secondary,
-                height: "20px",
                 display: "flex",
                 alignItems: "center",
                 marginRight: "0.5rem",
@@ -183,6 +185,7 @@ const SchemaSettings = () => {
                   title: `Fiele ${value}`,
                   onClick: () => {
                     setSelectedTab(value);
+                    setShowNestedFields(false);
                   },
                 };
               })}

--- a/app/packages/core/src/components/Sidebar/Entries/FilterEntry.tsx
+++ b/app/packages/core/src/components/Sidebar/Entries/FilterEntry.tsx
@@ -11,10 +11,7 @@ import { InputDiv } from "./utils";
 import * as fos from "@fiftyone/state";
 import { Settings, VisibilityOff } from "@mui/icons-material";
 import { Box, Typography } from "@mui/material";
-import {
-  affectedPathCountState,
-  selectedFieldsStageState,
-} from "@fiftyone/state/src/hooks/useSchemaSettings";
+import { selectedFieldsStageState } from "@fiftyone/state/src/hooks/useSchemaSettings";
 import { Tooltip, useTheme } from "@fiftyone/components";
 
 const Filter = ({ modal }: { modal: boolean }) => {
@@ -26,10 +23,13 @@ const Filter = ({ modal }: { modal: boolean }) => {
   const resetSelectedFieldStages = useResetRecoilState(
     selectedFieldsStageState
   );
-  const affectedPathCount = useRecoilValue(affectedPathCountState);
 
-  const { setSelectedFieldsStage, resetTextFilter, resetExcludedPaths } =
-    fos.useSchemaSettings();
+  const {
+    setSelectedFieldsStage,
+    resetTextFilter,
+    resetExcludedPaths,
+    affectedPathCount,
+  } = fos.useSchemaSettings();
 
   useDebounce(
     () => {

--- a/app/packages/core/src/components/Sidebar/Entries/FilterEntry.tsx
+++ b/app/packages/core/src/components/Sidebar/Entries/FilterEntry.tsx
@@ -29,6 +29,7 @@ const Filter = ({ modal }: { modal: boolean }) => {
     resetTextFilter,
     resetExcludedPaths,
     affectedPathCount,
+    setSearchResults,
   } = fos.useSchemaSettings();
 
   useDebounce(
@@ -69,6 +70,7 @@ const Filter = ({ modal }: { modal: boolean }) => {
                   resetSelectedFieldStages();
                   setSelectedFieldsStage(undefined);
                   resetExcludedPaths();
+                  setSearchResults([]);
                 }}
               >
                 {affectedPathCount > 0 && (

--- a/app/packages/state/src/hooks/useSchemaSettings.test.ts
+++ b/app/packages/state/src/hooks/useSchemaSettings.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { disabledField } from "./useSchemaSettings";
+import { disabledField } from "./useSchemaSettings.utils";
 import { OBJECT_ID_FIELD } from "@fiftyone/utilities";
 
 const FIELDS = {
@@ -17,6 +17,9 @@ const FIELDS = {
   },
 };
 
+const GROUP_DATASET = "group";
+const NOT_GROUP_DATASET = "";
+
 describe("Disabled schema fields", () => {
   afterEach(() => {
     vi.restoreAllMocks();
@@ -26,7 +29,7 @@ describe("Disabled schema fields", () => {
     const path = "id";
     const field_1 = FIELDS.ID_FIELD;
     const schema = { id: field_1 };
-    const isGroupDataset = "group";
-    expect(disabledField(path, schema, isGroupDataset)).toBe(true);
+
+    expect(disabledField(path, schema, NOT_GROUP_DATASET)).toBe(true);
   });
 });

--- a/app/packages/state/src/hooks/useSchemaSettings.test.ts
+++ b/app/packages/state/src/hooks/useSchemaSettings.test.ts
@@ -1,0 +1,32 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { disabledField } from "./useSchemaSettings";
+import { OBJECT_ID_FIELD } from "@fiftyone/utilities";
+
+const FIELDS = {
+  ID_FIELD: {
+    path: "id",
+    embeddedDocType: null,
+    ftype: OBJECT_ID_FIELD,
+    description: null,
+    info: null,
+    name: null,
+    fields: null,
+    dbField: null,
+    subfield: null,
+    visible: false,
+  },
+};
+
+describe("Disabled schema fields", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("id path is disabled across all fields", () => {
+    const path = "id";
+    const field_1 = FIELDS.ID_FIELD;
+    const schema = { id: field_1 };
+    const isGroupDataset = "group";
+    expect(disabledField(path, schema, isGroupDataset)).toBe(true);
+  });
+});

--- a/app/packages/state/src/hooks/useSchemaSettings.ts
+++ b/app/packages/state/src/hooks/useSchemaSettings.ts
@@ -66,11 +66,12 @@ const skipField = (path: string, ftype: string, schema: {}) => {
     path.endsWith(".index")
   );
 };
-const disabledField = (
+
+export const disabledField = (
   path: string,
-  combinedSchema: Schema,
+  combinedSchema: Record<string, Field>,
   groupField?: string
-) => {
+): boolean => {
   const currField = combinedSchema?.[path] || ({} as Field);
   const { ftype, embeddedDocType } = currField;
   const parentPath = path.substring(0, path.lastIndexOf("."));

--- a/app/packages/state/src/hooks/useSchemaSettings.ts
+++ b/app/packages/state/src/hooks/useSchemaSettings.ts
@@ -113,7 +113,7 @@ export const showNestedFieldsState = atom<boolean>({
 });
 export const schemaSelectedSettingsTab = atom<string>({
   key: "schemaSelectedSettingsTab",
-  default: TAB_OPTIONS_MAP.FILTER_RULE,
+  default: TAB_OPTIONS_MAP.SELECTION,
 });
 export const settingsModal = atom<{ open: boolean } | null>({
   key: "settingsModal",
@@ -404,7 +404,7 @@ export default function useSchemaSettings() {
   const [searchTerm, setSearchTerm] = useRecoilState<string>(schemaSearchTerm);
   const [searchResults, setSearchResults] = useRecoilState(schemaSearchRestuls);
 
-  const [schema, setSchema] = useRecoilState(schemaState);
+  const setSchema = useSetRecoilState(schemaState);
   useEffect(() => {
     if (datasetName) {
       setSchema(dataset ? buildSchema(dataset, true) : null);
@@ -476,6 +476,7 @@ export default function useSchemaSettings() {
   const [selectedTab, setSelectedTab] = useRecoilState(
     schemaSelectedSettingsTab
   );
+  const filterRuleTab = selectedTab === TAB_OPTIONS_MAP.FILTER_RULE;
 
   const selectedPathState = selectedPathsState({});
   const [selectedPaths, setSelectedPaths] = useRecoilState<{}>(
@@ -531,7 +532,6 @@ export default function useSchemaSettings() {
       finalSchemaKeyByPath = !isEmpty(viewSchema) ? viewSchema : fieldSchema;
     }
 
-    const filterRuleTab = selectedTab === TAB_OPTIONS_MAP.FILTER_RULE;
     const resSchema = Object.keys(finalSchemaKeyByPath)
       .sort()
       .filter((path) => {
@@ -838,10 +838,7 @@ export default function useSchemaSettings() {
   // updates the affected fields count
   useEffect(() => {
     if (finalSchema?.length && excludedPaths?.[datasetName]) {
-      if (
-        selectedTab === TAB_OPTIONS_MAP.FILTER_RULE &&
-        searchResults?.length
-      ) {
+      if (filterRuleTab && searchResults?.length) {
         setAffectedPathCount(
           Object.keys(bareFinalSchema)?.length - searchResults.length
         );
@@ -849,9 +846,11 @@ export default function useSchemaSettings() {
         setAffectedPathCount(excludedPaths[datasetName].size);
       }
     }
-  }, [selectedTab, searchResults, excludedPaths, datasetName]);
+  }, [filterRuleTab, searchResults, excludedPaths, datasetName]);
 
   return {
+    searchMetaFilter,
+    filterRuleTab,
     settingModal,
     setSettingsModal,
     searchTerm,
@@ -887,5 +886,6 @@ export default function useSchemaSettings() {
     searchSchemaFields,
     setLastAppliedPaths,
     lastAppliedPaths,
+    isFilterRuleActive: filterRuleTab,
   };
 }

--- a/app/packages/state/src/hooks/useSchemaSettings.ts
+++ b/app/packages/state/src/hooks/useSchemaSettings.ts
@@ -2,37 +2,15 @@ import * as foq from "@fiftyone/relay";
 import * as fos from "@fiftyone/state";
 import { buildSchema } from "@fiftyone/state";
 import {
-  CLASSIFICATIONS_FIELD,
-  CLASSIFICATION_FIELD,
-  DETECTIONS_FIELD,
-  DETECTION_FIELD,
   DETECTION_FILED,
   DYNAMIC_EMBEDDED_DOCUMENT_FIELD,
   DYNAMIC_EMBEDDED_DOCUMENT_FIELD_V2,
   EMBEDDED_DOCUMENT_FIELD,
-  FRAME_SUPPORT_FIELD,
-  Field,
-  GEO_LOCATIONS_FIELD,
-  GEO_LOCATION_FIELD,
-  HEATMAP_FIELD,
-  KEYPOINT_FILED,
   LIST_FIELD,
-  POLYLINES_FIELD,
-  POLYLINE_FIELD,
-  REGRESSION_FILED,
-  RESERVED_FIELD_KEYS,
-  SEGMENTATION_FIELD,
   Schema,
-  TEMPORAL_DETECTION_FIELD,
   UNSUPPORTED_FILTER_TYPES,
-  VALID_LABEL_TYPES,
-  VECTOR_FIELD,
 } from "@fiftyone/utilities";
-import {
-  FRAME_NUMBER_FIELD,
-  JUST_FIELD,
-  OBJECT_ID_FIELD,
-} from "@fiftyone/utilities";
+import { JUST_FIELD } from "@fiftyone/utilities";
 import { isEmpty, keyBy } from "lodash";
 import { useCallback, useContext, useEffect, useMemo } from "react";
 import { useMutation, useRefetchableFragment } from "react-relay";
@@ -45,6 +23,7 @@ import {
   useResetRecoilState,
   useSetRecoilState,
 } from "recoil";
+import { disabledField } from "./useSchemaSettings.utils";
 
 export const TAB_OPTIONS_MAP = {
   SELECTION: "Selection",
@@ -64,99 +43,6 @@ const skipField = (path: string, ftype: string, schema: {}) => {
       schema[parentPath]?.embeddedDocType === DETECTION_FILED &&
       path.endsWith(".bounding_box")) ||
     path.endsWith(".index")
-  );
-};
-
-export const disabledField = (
-  path: string,
-  combinedSchema: Record<string, Field>,
-  groupField?: string
-): boolean => {
-  const currField = combinedSchema?.[path] || ({} as Field);
-  const { ftype, embeddedDocType } = currField;
-  const parentPath = path.substring(0, path.lastIndexOf("."));
-  const parentField = combinedSchema?.[parentPath];
-  const parentEmbeddedDocType = parentField?.embeddedDocType;
-  const pathSplit = path.split(".");
-  const embeddedDocTypeSplit = embeddedDocType?.split(".");
-  const hasDynamicEmbeddedDocument = [
-    DYNAMIC_EMBEDDED_DOCUMENT_FIELD,
-    DYNAMIC_EMBEDDED_DOCUMENT_FIELD_V2,
-  ].includes(embeddedDocType);
-
-  return (
-    [
-      OBJECT_ID_FIELD,
-      FRAME_NUMBER_FIELD,
-      FRAME_SUPPORT_FIELD,
-      VECTOR_FIELD,
-    ].includes(ftype) ||
-    [path, parentPath].includes(groupField) ||
-    RESERVED_FIELD_KEYS.includes(path) ||
-    path.startsWith("metadata") ||
-    ([
-      TEMPORAL_DETECTION_FIELD,
-      DETECTION_FIELD,
-      DETECTIONS_FIELD,
-      CLASSIFICATION_FIELD,
-      CLASSIFICATIONS_FIELD,
-      KEYPOINT_FILED,
-      REGRESSION_FILED,
-      HEATMAP_FIELD,
-      SEGMENTATION_FIELD,
-      GEO_LOCATIONS_FIELD,
-      GEO_LOCATION_FIELD,
-      POLYLINE_FIELD,
-      POLYLINES_FIELD,
-    ].includes(parentEmbeddedDocType) &&
-      [
-        "id",
-        "tags",
-        "label",
-        "bounding_box",
-        "mask",
-        "confidence",
-        "index",
-        "points",
-        "closed",
-        "filled",
-        "logits",
-        "mask_path",
-        "map",
-        "map_path",
-        "Range",
-        "Confidence",
-        "support",
-        "point",
-        "line",
-        "Polygon",
-        "points",
-        "polygons",
-      ].includes(pathSplit[pathSplit.length - 1])) ||
-    [
-      TEMPORAL_DETECTION_FIELD,
-      DETECTION_FIELD,
-      DETECTIONS_FIELD,
-      CLASSIFICATION_FIELD,
-      CLASSIFICATIONS_FIELD,
-      KEYPOINT_FILED,
-      REGRESSION_FILED,
-      HEATMAP_FIELD,
-      SEGMENTATION_FIELD,
-      GEO_LOCATIONS_FIELD,
-      GEO_LOCATION_FIELD,
-      POLYLINE_FIELD,
-      POLYLINES_FIELD,
-    ].includes(ftype) ||
-    (parentPath &&
-      parentPath !== path &&
-      ftype === LIST_FIELD &&
-      (hasDynamicEmbeddedDocument ||
-        VALID_LABEL_TYPES.includes(
-          embeddedDocType?.includes(".")
-            ? embeddedDocTypeSplit[embeddedDocTypeSplit.length - 1]
-            : embeddedDocType
-        )))
   );
 };
 

--- a/app/packages/state/src/hooks/useSchemaSettings.ts
+++ b/app/packages/state/src/hooks/useSchemaSettings.ts
@@ -3,7 +3,6 @@ import * as fos from "@fiftyone/state";
 import { buildSchema } from "@fiftyone/state";
 import {
   DETECTION_FILED,
-  DYNAMIC_EMBEDDED_DOCUMENT_FIELD,
   DYNAMIC_EMBEDDED_DOCUMENT_FIELD_V2,
   EMBEDDED_DOCUMENT_FIELD,
   LIST_FIELD,
@@ -233,7 +232,6 @@ export const excludedPathsState = atomFamily({
 
               // embedded document could break an exclude_field() call causing mongo query issue.
               const hasDynamicEmbeddedDocument = [
-                DYNAMIC_EMBEDDED_DOCUMENT_FIELD,
                 DYNAMIC_EMBEDDED_DOCUMENT_FIELD_V2,
               ].includes(combinedSchema[path]?.embeddedDocType);
 

--- a/app/packages/state/src/hooks/useSchemaSettings.ts
+++ b/app/packages/state/src/hooks/useSchemaSettings.ts
@@ -846,7 +846,14 @@ export default function useSchemaSettings() {
         setAffectedPathCount(excludedPaths[datasetName].size);
       }
     }
-  }, [filterRuleTab, searchResults, excludedPaths, datasetName]);
+  }, [
+    finalSchema,
+    filterRuleTab,
+    searchResults,
+    excludedPaths,
+    datasetName,
+    selectedPaths,
+  ]);
 
   return {
     searchMetaFilter,

--- a/app/packages/state/src/hooks/useSchemaSettings.utils.ts
+++ b/app/packages/state/src/hooks/useSchemaSettings.utils.ts
@@ -1,0 +1,117 @@
+import {
+  CLASSIFICATIONS_FIELD,
+  CLASSIFICATION_FIELD,
+  DETECTIONS_FIELD,
+  DETECTION_FIELD,
+  DYNAMIC_EMBEDDED_DOCUMENT_FIELD,
+  DYNAMIC_EMBEDDED_DOCUMENT_FIELD_V2,
+  FRAME_SUPPORT_FIELD,
+  Field,
+  GEO_LOCATIONS_FIELD,
+  GEO_LOCATION_FIELD,
+  HEATMAP_FIELD,
+  KEYPOINT_FILED,
+  LIST_FIELD,
+  POLYLINES_FIELD,
+  POLYLINE_FIELD,
+  REGRESSION_FILED,
+  RESERVED_FIELD_KEYS,
+  SEGMENTATION_FIELD,
+  TEMPORAL_DETECTION_FIELD,
+  VALID_LABEL_TYPES,
+  VECTOR_FIELD,
+} from "@fiftyone/utilities";
+import { FRAME_NUMBER_FIELD, OBJECT_ID_FIELD } from "@fiftyone/utilities";
+
+export const disabledField = (
+  path: string,
+  combinedSchema: Record<string, Field>,
+  groupField?: string
+): boolean => {
+  const currField = combinedSchema?.[path] || ({} as Field);
+  const { ftype, embeddedDocType } = currField;
+  const parentPath = path.substring(0, path.lastIndexOf("."));
+  const parentField = combinedSchema?.[parentPath];
+  const parentEmbeddedDocType = parentField?.embeddedDocType;
+  const pathSplit = path.split(".");
+  const embeddedDocTypeSplit = embeddedDocType?.split(".");
+  const hasDynamicEmbeddedDocument = [
+    DYNAMIC_EMBEDDED_DOCUMENT_FIELD,
+    DYNAMIC_EMBEDDED_DOCUMENT_FIELD_V2,
+  ].includes(embeddedDocType);
+
+  return (
+    [
+      OBJECT_ID_FIELD,
+      FRAME_NUMBER_FIELD,
+      FRAME_SUPPORT_FIELD,
+      VECTOR_FIELD,
+    ].includes(ftype) ||
+    [path, parentPath].includes(groupField) ||
+    RESERVED_FIELD_KEYS.includes(path) ||
+    path.startsWith("metadata") ||
+    ([
+      TEMPORAL_DETECTION_FIELD,
+      DETECTION_FIELD,
+      DETECTIONS_FIELD,
+      CLASSIFICATION_FIELD,
+      CLASSIFICATIONS_FIELD,
+      KEYPOINT_FILED,
+      REGRESSION_FILED,
+      HEATMAP_FIELD,
+      SEGMENTATION_FIELD,
+      GEO_LOCATIONS_FIELD,
+      GEO_LOCATION_FIELD,
+      POLYLINE_FIELD,
+      POLYLINES_FIELD,
+    ].includes(parentEmbeddedDocType) &&
+      [
+        "id",
+        "tags",
+        "label",
+        "bounding_box",
+        "mask",
+        "confidence",
+        "index",
+        "points",
+        "closed",
+        "filled",
+        "logits",
+        "mask_path",
+        "map",
+        "map_path",
+        "Range",
+        "Confidence",
+        "support",
+        "point",
+        "line",
+        "Polygon",
+        "points",
+        "polygons",
+      ].includes(pathSplit[pathSplit.length - 1])) ||
+    [
+      TEMPORAL_DETECTION_FIELD,
+      DETECTION_FIELD,
+      DETECTIONS_FIELD,
+      CLASSIFICATION_FIELD,
+      CLASSIFICATIONS_FIELD,
+      KEYPOINT_FILED,
+      REGRESSION_FILED,
+      HEATMAP_FIELD,
+      SEGMENTATION_FIELD,
+      GEO_LOCATIONS_FIELD,
+      GEO_LOCATION_FIELD,
+      POLYLINE_FIELD,
+      POLYLINES_FIELD,
+    ].includes(ftype) ||
+    (parentPath &&
+      parentPath !== path &&
+      ftype === LIST_FIELD &&
+      (hasDynamicEmbeddedDocument ||
+        VALID_LABEL_TYPES.includes(
+          embeddedDocType?.includes(".")
+            ? embeddedDocTypeSplit[embeddedDocTypeSplit.length - 1]
+            : embeddedDocType
+        )))
+  );
+};

--- a/app/vite.config.ts
+++ b/app/vite.config.ts
@@ -8,6 +8,14 @@ export default defineConfig({
     coverage: {
       reporter: ["json", "lcov"],
       reportsDirectory: "./coverage",
+      enabled: true,
+      all: true,
+      exclude: [
+        "**/__generated__/**",
+        "**/__generated__",
+        "**/.yarn/**",
+        "**/.storybook/**",
+      ],
     },
   },
   plugins: [relay],

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -22,6 +22,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@ampproject/remapping@npm:^2.2.1":
+  version: 2.2.1
+  resolution: "@ampproject/remapping@npm:2.2.1"
+  dependencies:
+    "@jridgewell/gen-mapping": ^0.3.0
+    "@jridgewell/trace-mapping": ^0.3.9
+  checksum: 03c04fd526acc64a1f4df22651186f3e5ef0a9d6d6530ce4482ec9841269cf7a11dbb8af79237c282d721c5312024ff17529cd72cc4768c11e999b58e2302079
+  languageName: node
+  linkType: hard
+
 "@babel/code-frame@npm:^7.0.0, @babel/code-frame@npm:^7.12.13, @babel/code-frame@npm:^7.16.7":
   version: 7.16.7
   resolution: "@babel/code-frame@npm:7.16.7"
@@ -4454,7 +4464,8 @@ __metadata:
     "@testing-library/react-hooks": latest
     "@typescript-eslint/eslint-plugin": ^5.44.0
     "@typescript-eslint/parser": ^5.44.0
-    "@vitest/coverage-c8": ^0.25.2
+    "@vitest/coverage-v8": ^0.32.0
+    "@vitest/ui": ^0.32.0
     concurrently: ^7.2.1
     eslint: ^8.28.0
     eslint-config-prettier: ^8.5.0
@@ -4474,7 +4485,7 @@ __metadata:
     vite: ^3.0.0
     vite-plugin-eslint: ^1.8.1
     vite-plugin-relay: ^2.0.0
-    vitest: ^0.25.2
+    vitest: ^0.32.0
   languageName: unknown
   linkType: soft
 
@@ -5129,6 +5140,23 @@ __metadata:
   version: 1.4.11
   resolution: "@jridgewell/sourcemap-codec@npm:1.4.11"
   checksum: 3b2afaf8400fb07a36db60e901fcce6a746cdec587310ee9035939d89878e57b2dec8173b0b8f63176f647efa352294049a53c49739098eb907ff81fec2547c8
+  languageName: node
+  linkType: hard
+
+"@jridgewell/sourcemap-codec@npm:^1.4.13":
+  version: 1.4.15
+  resolution: "@jridgewell/sourcemap-codec@npm:1.4.15"
+  checksum: b881c7e503db3fc7f3c1f35a1dd2655a188cc51a3612d76efc8a6eb74728bef5606e6758ee77423e564092b4a518aba569bbb21c9bac5ab7a35b0c6ae7e344c8
+  languageName: node
+  linkType: hard
+
+"@jridgewell/trace-mapping@npm:^0.3.12":
+  version: 0.3.18
+  resolution: "@jridgewell/trace-mapping@npm:0.3.18"
+  dependencies:
+    "@jridgewell/resolve-uri": 3.1.0
+    "@jridgewell/sourcemap-codec": 1.4.14
+  checksum: 0572669f855260808c16fe8f78f5f1b4356463b11d3f2c7c0b5580c8ba1cbf4ae53efe9f627595830856e57dbac2325ac17eb0c3dd0ec42102e6f227cc289c02
   languageName: node
   linkType: hard
 
@@ -7934,6 +7962,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/chai@npm:^4.3.5":
+  version: 4.3.5
+  resolution: "@types/chai@npm:4.3.5"
+  checksum: c8f26a88c6b5b53a3275c7f5ff8f107028e3cbb9ff26795fff5f3d9dea07106a54ce9e2dce5e40347f7c4cc35657900aaf0c83934a25a1ae12e61e0f5516e431
+  languageName: node
+  linkType: hard
+
 "@types/color-string@npm:^1.5.0":
   version: 1.5.2
   resolution: "@types/color-string@npm:1.5.2"
@@ -8932,13 +8967,67 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vitest/coverage-c8@npm:^0.25.2":
-  version: 0.25.8
-  resolution: "@vitest/coverage-c8@npm:0.25.8"
+"@vitest/coverage-v8@npm:^0.32.0":
+  version: 0.32.0
+  resolution: "@vitest/coverage-v8@npm:0.32.0"
   dependencies:
-    c8: ^7.12.0
-    vitest: 0.25.8
-  checksum: 189a7d8df0e4185d7f016184c70a65fc40bf661294de340b7c63991ffb494acf09769ce1bc4817d879f13b5b5e462ab4052ca35fa8315ca2723b69f9fce61a28
+    "@ampproject/remapping": ^2.2.1
+    "@bcoe/v8-coverage": ^0.2.3
+    istanbul-lib-coverage: ^3.2.0
+    istanbul-lib-report: ^3.0.0
+    istanbul-lib-source-maps: ^4.0.1
+    istanbul-reports: ^3.1.5
+    magic-string: ^0.30.0
+    picocolors: ^1.0.0
+    std-env: ^3.3.2
+    test-exclude: ^6.0.0
+    v8-to-istanbul: ^9.1.0
+  peerDependencies:
+    vitest: ">=0.32.0 <1"
+  checksum: 6f025b5a74397c91bab988c58a763ad9d4e9a3ebb20c928e3732e409358be656d0f3753e114970bce1f2a53cd09f3bab0f0a947cc0c7683469fd66a5c74a337c
+  languageName: node
+  linkType: hard
+
+"@vitest/expect@npm:0.32.0":
+  version: 0.32.0
+  resolution: "@vitest/expect@npm:0.32.0"
+  dependencies:
+    "@vitest/spy": 0.32.0
+    "@vitest/utils": 0.32.0
+    chai: ^4.3.7
+  checksum: 0f5740057faf1a45be00b7e06ad8dd7e5b37d9f436e29701a8577d42bdff930ce958bc9a7732eb88fb71a3ab5009a72f2ed11c02b2095a4173fa69f69897e7b4
+  languageName: node
+  linkType: hard
+
+"@vitest/runner@npm:0.32.0":
+  version: 0.32.0
+  resolution: "@vitest/runner@npm:0.32.0"
+  dependencies:
+    "@vitest/utils": 0.32.0
+    concordance: ^5.0.4
+    p-limit: ^4.0.0
+    pathe: ^1.1.0
+  checksum: d7a63a9a80d90a48e706fcf8bc1c2171ee0395f60241c1f0bb67854d246b68a472805d6abe33ce9a7250768c0b27af882e4beb7a5ba9eea2b3e085a54ed978e0
+  languageName: node
+  linkType: hard
+
+"@vitest/snapshot@npm:0.32.0":
+  version: 0.32.0
+  resolution: "@vitest/snapshot@npm:0.32.0"
+  dependencies:
+    magic-string: ^0.30.0
+    pathe: ^1.1.0
+    pretty-format: ^27.5.1
+  checksum: 2017d461b8492ae16b15f4f3725e1e3dc7bd18e24f1db788f151f9435af620ee711114edc4bd6ad88ba047f47dc4104b7db87d7f7b29363537272c0353ceb71d
+  languageName: node
+  linkType: hard
+
+"@vitest/spy@npm:0.32.0":
+  version: 0.32.0
+  resolution: "@vitest/spy@npm:0.32.0"
+  dependencies:
+    tinyspy: ^2.1.0
+  checksum: 1c418f4064f4357e972e99d20e2b7b65b8cde3a8280a8e06a41fa81517efe335ca176c21a6644a6f490b565fb0ed6df0ed4ab8097813be3d0f4ec625b7fd3451
   languageName: node
   linkType: hard
 
@@ -8948,6 +9037,34 @@ __metadata:
   dependencies:
     sirv: ^2.0.2
   checksum: 2ef6e0e6eb95d9f857761b3a74edcf1290ac7b9d00078e752172078ee63c581f17c743e40098dabf9d4baa7f946303e9849ef45a96c50f1deba4a93f0c45890a
+  languageName: node
+  linkType: hard
+
+"@vitest/ui@npm:^0.32.0":
+  version: 0.32.0
+  resolution: "@vitest/ui@npm:0.32.0"
+  dependencies:
+    "@vitest/utils": 0.32.0
+    fast-glob: ^3.2.12
+    fflate: ^0.7.4
+    flatted: ^3.2.7
+    pathe: ^1.1.0
+    picocolors: ^1.0.0
+    sirv: ^2.0.3
+  peerDependencies:
+    vitest: ">=0.30.1 <1"
+  checksum: 0a0ac067ef667dfdd60e89c8a554cd2056cd5c39874940a0ed13cd4b27e04755aa2df56bbb19dcbf8eff7c458d84b7832ce9e817a5671319bb46019d3473c98d
+  languageName: node
+  linkType: hard
+
+"@vitest/utils@npm:0.32.0":
+  version: 0.32.0
+  resolution: "@vitest/utils@npm:0.32.0"
+  dependencies:
+    concordance: ^5.0.4
+    loupe: ^2.3.6
+    pretty-format: ^27.5.1
+  checksum: f27df1e7066a310cd43a7261f2b1f668e32b7443f9b90af4a6e49575ee2d65b019192833ddbd0f51eb5690130b5b1bd2459cb83397860941308eeb122983427a
   languageName: node
   linkType: hard
 
@@ -9485,6 +9602,15 @@ __metadata:
   bin:
     acorn: bin/acorn
   checksum: 7270ca82b242eafe5687a11fea6e088c960af712683756abf0791b68855ea9cace3057bd5e998ffcef50c944810c1e0ca1da526d02b32110e13c722aa959afdc
+  languageName: node
+  linkType: hard
+
+"acorn@npm:^8.8.2":
+  version: 8.8.2
+  resolution: "acorn@npm:8.8.2"
+  bin:
+    acorn: bin/acorn
+  checksum: f790b99a1bf63ef160c967e23c46feea7787e531292bb827126334612c234ed489a0dc2c7ba33156416f0ffa8d25bf2b0fdb7f35c2ba60eb3e960572bece4001
   languageName: node
   linkType: hard
 
@@ -10624,6 +10750,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"blueimp-md5@npm:^2.10.0":
+  version: 2.19.0
+  resolution: "blueimp-md5@npm:2.19.0"
+  checksum: 28095dcbd2c67152a2938006e8d7c74c3406ba6556071298f872505432feb2c13241b0476644160ee0a5220383ba94cb8ccdac0053b51f68d168728f9c382530
+  languageName: node
+  linkType: hard
+
 "bn.js@npm:^4.0.0, bn.js@npm:^4.1.0, bn.js@npm:^4.11.9":
   version: 4.12.0
   resolution: "bn.js@npm:4.12.0"
@@ -11015,7 +11148,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"c8@npm:^7.12.0, c8@npm:^7.6.0":
+"c8@npm:^7.6.0":
   version: 7.12.0
   resolution: "c8@npm:7.12.0"
   dependencies:
@@ -11034,6 +11167,13 @@ __metadata:
   bin:
     c8: bin/c8.js
   checksum: 3b7fa9ad7cff2cb0bb579467e6b544498fbd46e9353a809ad3b8cf749df4beadd074cde277356b0552f3c8055b1b3ec3ebaf2209e9ad4bdefed92dbf64d283ab
+  languageName: node
+  linkType: hard
+
+"cac@npm:^6.7.14":
+  version: 6.7.14
+  resolution: "cac@npm:6.7.14"
+  checksum: 45a2496a9443abbe7f52a49b22fbe51b1905eff46e03fd5e6c98e3f85077be3f8949685a1849b1a9cd2bc3e5567dfebcf64f01ce01847baf918f1b37c839791a
   languageName: node
   linkType: hard
 
@@ -11981,6 +12121,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"concordance@npm:^5.0.4":
+  version: 5.0.4
+  resolution: "concordance@npm:5.0.4"
+  dependencies:
+    date-time: ^3.1.0
+    esutils: ^2.0.3
+    fast-diff: ^1.2.0
+    js-string-escape: ^1.0.1
+    lodash: ^4.17.15
+    md5-hex: ^3.0.1
+    semver: ^7.3.2
+    well-known-symbols: ^2.0.0
+  checksum: 749153ba711492feb7c3d2f5bb04c107157440b3e39509bd5dd19ee7b3ac751d1e4cd75796d9f702e0a713312dbc661421c68aa4a2c34d5f6d91f47e3a1c64a6
+  languageName: node
+  linkType: hard
+
 "concurrently@npm:^7.2.1":
   version: 7.2.1
   resolution: "concurrently@npm:7.2.1"
@@ -12919,6 +13075,15 @@ __metadata:
   version: 2.28.0
   resolution: "date-fns@npm:2.28.0"
   checksum: a0516b2e4f99b8bffc6cc5193349f185f195398385bdcaf07f17c2c4a24473c99d933eb0018be4142a86a6d46cb0b06be6440ad874f15e795acbedd6fd727a1f
+  languageName: node
+  linkType: hard
+
+"date-time@npm:^3.1.0":
+  version: 3.1.0
+  resolution: "date-time@npm:3.1.0"
+  dependencies:
+    time-zone: ^1.0.0
+  checksum: f9cfcd1b15dfeabab15c0b9d18eb9e4e2d9d4371713564178d46a8f91ad577a290b5178b80050718d02d9c0cf646f8a875011e12d1ed05871e9f72c72c8a8fe6
   languageName: node
   linkType: hard
 
@@ -14720,7 +14885,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"esutils@npm:^2.0.2":
+"esutils@npm:^2.0.2, esutils@npm:^2.0.3":
   version: 2.0.3
   resolution: "esutils@npm:2.0.3"
   checksum: 22b5b08f74737379a840b8ed2036a5fb35826c709ab000683b092d9054e5c2a82c27818f12604bfc2a9a76b90b6834ef081edbc1c7ae30d1627012e067c6ec87
@@ -14968,6 +15133,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"fast-diff@npm:^1.2.0":
+  version: 1.3.0
+  resolution: "fast-diff@npm:1.3.0"
+  checksum: d22d371b994fdc8cce9ff510d7b8dc4da70ac327bcba20df607dd5b9cae9f908f4d1028f5fe467650f058d1e7270235ae0b8230809a262b4df587a3b3aa216c3
+  languageName: node
+  linkType: hard
+
 "fast-equals@npm:^2.0.0":
   version: 2.0.4
   resolution: "fast-equals@npm:2.0.4"
@@ -14989,7 +15161,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fast-glob@npm:^3.2.9":
+"fast-glob@npm:^3.2.12, fast-glob@npm:^3.2.9":
   version: 3.2.12
   resolution: "fast-glob@npm:3.2.12"
   dependencies:
@@ -15166,6 +15338,13 @@ __metadata:
   version: 0.6.10
   resolution: "fflate@npm:0.6.10"
   checksum: 96384bc4090987fe565c0de8204e3830f538144ec950576fea50aee1b42adbe9fc3ed5e7905dfa7979faaa20979def330dbebce548f3dcafc3e118cc9838526d
+  languageName: node
+  linkType: hard
+
+"fflate@npm:^0.7.4":
+  version: 0.7.4
+  resolution: "fflate@npm:0.7.4"
+  checksum: b812ab26047432db70ff4c73eb45ad53bd0774575b4818b9c61c2921e89ec65d1259f06ec1618f2ac55e6a2f2e29b6dc09173d213b46580bc69efae5344bf8f1
   languageName: node
   linkType: hard
 
@@ -15346,7 +15525,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"flatted@npm:^3.1.0":
+"flatted@npm:^3.1.0, flatted@npm:^3.2.7":
   version: 3.2.7
   resolution: "flatted@npm:3.2.7"
   checksum: 427633049d55bdb80201c68f7eb1cbd533e03eac541f97d3aecab8c5526f12a20ccecaeede08b57503e772c769e7f8680b37e8d482d1e5f8d7e2194687f9ea35
@@ -18100,7 +18279,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"istanbul-lib-source-maps@npm:^4.0.0":
+"istanbul-lib-source-maps@npm:^4.0.0, istanbul-lib-source-maps@npm:^4.0.1":
   version: 4.0.1
   resolution: "istanbul-lib-source-maps@npm:4.0.1"
   dependencies:
@@ -18121,7 +18300,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"istanbul-reports@npm:^3.1.4":
+"istanbul-reports@npm:^3.1.4, istanbul-reports@npm:^3.1.5":
   version: 3.1.5
   resolution: "istanbul-reports@npm:3.1.5"
   dependencies:
@@ -18891,7 +19070,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jsonc-parser@npm:^3.0.0":
+"jsonc-parser@npm:^3.0.0, jsonc-parser@npm:^3.2.0":
   version: 3.2.0
   resolution: "jsonc-parser@npm:3.2.0"
   checksum: 946dd9a5f326b745aa326d48a7257e3f4a4b62c5e98ec8e49fa2bdd8d96cef7e6febf1399f5c7016114fd1f68a1c62c6138826d5d90bc650448e3cf0951c53c7
@@ -19305,6 +19484,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"local-pkg@npm:^0.4.3":
+  version: 0.4.3
+  resolution: "local-pkg@npm:0.4.3"
+  checksum: 7825aca531dd6afa3a3712a0208697aa4a5cd009065f32e3fb732aafcc42ed11f277b5ac67229222e96f4def55197171cdf3d5522d0381b489d2e5547b407d55
+  languageName: node
+  linkType: hard
+
 "locate-path@npm:^3.0.0":
   version: 3.0.0
   resolution: "locate-path@npm:3.0.0"
@@ -19445,7 +19631,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"loupe@npm:^2.3.1":
+"loupe@npm:^2.3.1, loupe@npm:^2.3.6":
   version: 2.3.6
   resolution: "loupe@npm:2.3.6"
   dependencies:
@@ -19543,6 +19729,15 @@ __metadata:
   dependencies:
     sourcemap-codec: ^1.4.8
   checksum: 89b0d60cbb32bbf3d1e23c46ea93db082d18a8230b972027aecb10a40bba51be519ecce0674f995571e3affe917b76b09f59d8dbc9a1b2c9c4102a2b6e8a2b01
+  languageName: node
+  linkType: hard
+
+"magic-string@npm:^0.30.0":
+  version: 0.30.0
+  resolution: "magic-string@npm:0.30.0"
+  dependencies:
+    "@jridgewell/sourcemap-codec": ^1.4.13
+  checksum: 7bdf22e27334d8a393858a16f5f840af63a7c05848c000fd714da5aa5eefa09a1bc01d8469362f25cc5c4a14ec01b46557b7fff8751365522acddf21e57c488d
   languageName: node
   linkType: hard
 
@@ -19734,6 +19929,15 @@ __metadata:
   version: 1.0.1
   resolution: "math-log2@npm:1.0.1"
   checksum: b9a9c746ec0b28157865b5b9e9bdba25d04b77112f45ec65eb129b07ae42b0f017d59919d21e409fb6bb6587da28e5c40b4e49e80b917fa00a74f7ea5446932e
+  languageName: node
+  linkType: hard
+
+"md5-hex@npm:^3.0.1":
+  version: 3.0.1
+  resolution: "md5-hex@npm:3.0.1"
+  dependencies:
+    blueimp-md5: ^2.10.0
+  checksum: 6799a19e8bdd3e0c2861b94c1d4d858a89220488d7885c1fa236797e367d0c2e5f2b789e05309307083503f85be3603a9686a5915568a473137d6b4117419cc2
   languageName: node
   linkType: hard
 
@@ -20498,6 +20702,18 @@ __metadata:
   bin:
     mkdirp: bin/cmd.js
   checksum: a96865108c6c3b1b8e1d5e9f11843de1e077e57737602de1b82030815f311be11f96f09cce59bd5b903d0b29834733e5313f9301e3ed6d6f6fba2eae0df4298f
+  languageName: node
+  linkType: hard
+
+"mlly@npm:^1.2.0":
+  version: 1.3.0
+  resolution: "mlly@npm:1.3.0"
+  dependencies:
+    acorn: ^8.8.2
+    pathe: ^1.1.0
+    pkg-types: ^1.0.3
+    ufo: ^1.1.2
+  checksum: aea2a99131b1a1f02a733219317b6466156e150473e0a2f490802eaf2dc66940a21bb68e0ddd5c003360263e674e7dd0bd02da6520c740e6d16fa0edf5efa46e
   languageName: node
   linkType: hard
 
@@ -21414,6 +21630,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"p-limit@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "p-limit@npm:4.0.0"
+  dependencies:
+    yocto-queue: ^1.0.0
+  checksum: 01d9d70695187788f984226e16c903475ec6a947ee7b21948d6f597bed788e3112cc7ec2e171c1d37125057a5f45f3da21d8653e04a3a793589e12e9e80e756b
+  languageName: node
+  linkType: hard
+
 "p-locate@npm:^3.0.0":
   version: 3.0.0
   resolution: "p-locate@npm:3.0.0"
@@ -21802,6 +22027,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"pathe@npm:^1.1.0":
+  version: 1.1.1
+  resolution: "pathe@npm:1.1.1"
+  checksum: 34ab3da2e5aa832ebc6a330ffe3f73d7ba8aec6e899b53b8ec4f4018de08e40742802deb12cf5add9c73b7bf719b62c0778246bd376ca62b0fb23e0dde44b759
+  languageName: node
+  linkType: hard
+
 "pathval@npm:^1.1.1":
   version: 1.1.1
   resolution: "pathval@npm:1.1.1"
@@ -21944,6 +22176,17 @@ __metadata:
   dependencies:
     find-up: ^5.0.0
   checksum: b167bb8dac7bbf22b1d5e30ec223e6b064b84b63010c9d49384619a36734caf95ed23ad23d4f9bd975e8e8082b60a83395f43a89bb192df53a7c25a38ecb57d9
+  languageName: node
+  linkType: hard
+
+"pkg-types@npm:^1.0.3":
+  version: 1.0.3
+  resolution: "pkg-types@npm:1.0.3"
+  dependencies:
+    jsonc-parser: ^3.2.0
+    mlly: ^1.2.0
+    pathe: ^1.1.0
+  checksum: 4b305c834b912ddcc8a0fe77530c0b0321fe340396f84cbb87aecdbc126606f47f2178f23b8639e71a4870f9631c7217aef52ffed0ae17ea2dbbe7e43d116a6e
   languageName: node
   linkType: hard
 
@@ -22350,7 +22593,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"pretty-format@npm:^27.0.2":
+"pretty-format@npm:^27.0.2, pretty-format@npm:^27.5.1":
   version: 27.5.1
   resolution: "pretty-format@npm:27.5.1"
   dependencies:
@@ -24932,6 +25175,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"siginfo@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "siginfo@npm:2.0.0"
+  checksum: 8aa5a98640ca09fe00d74416eca97551b3e42991614a3d1b824b115fc1401543650914f651ab1311518177e4d297e80b953f4cd4cd7ea1eabe824e8f2091de01
+  languageName: node
+  linkType: hard
+
 "signal-exit@npm:^3.0.0, signal-exit@npm:^3.0.2, signal-exit@npm:^3.0.3, signal-exit@npm:^3.0.7":
   version: 3.0.7
   resolution: "signal-exit@npm:3.0.7"
@@ -24972,6 +25222,17 @@ __metadata:
     mrmime: ^1.0.0
     totalist: ^3.0.0
   checksum: 6982f8ecee9392d246d7eeea8144e50334fe1b46a4fa942995a844ea88c2d518b17cce781bb09926c9a5692a7002a207d18dfd67af2aa538a15e733dc2042298
+  languageName: node
+  linkType: hard
+
+"sirv@npm:^2.0.3":
+  version: 2.0.3
+  resolution: "sirv@npm:2.0.3"
+  dependencies:
+    "@polka/url": ^1.0.0-next.20
+    mrmime: ^1.0.0
+    totalist: ^3.0.0
+  checksum: e2dfd4c97735a6ad6d842d0eec2cd9e3919ff0e46f0d228248c5753ad4b70b832711e77e1259c031c439cdb08303cc54d923685c92b0e890145cc733af7c5568
   languageName: node
   linkType: hard
 
@@ -25304,6 +25565,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"stackback@npm:0.0.2":
+  version: 0.0.2
+  resolution: "stackback@npm:0.0.2"
+  checksum: 2d4dc4e64e2db796de4a3c856d5943daccdfa3dd092e452a1ce059c81e9a9c29e0b9badba91b43ef0d5ff5c04ee62feb3bcc559a804e16faf447bac2d883aa99
+  languageName: node
+  linkType: hard
+
 "stackframe@npm:^1.1.1":
   version: 1.2.1
   resolution: "stackframe@npm:1.2.1"
@@ -25383,6 +25651,13 @@ __metadata:
   version: 2.0.1
   resolution: "statuses@npm:2.0.1"
   checksum: 18c7623fdb8f646fb213ca4051be4df7efb3484d4ab662937ca6fbef7ced9b9e12842709872eb3020cc3504b93bde88935c9f6417489627a7786f24f8031cbcb
+  languageName: node
+  linkType: hard
+
+"std-env@npm:^3.3.2":
+  version: 3.3.3
+  resolution: "std-env@npm:3.3.3"
+  checksum: 6665f6d8bd63aae432d3eb9abbd7322847ad0d902603e6dce1e8051b4f42ceeb4f7f96a4faf70bb05ce65ceee2dc982502b701575c8a58b1bfad29f3dbb19f81
   languageName: node
   linkType: hard
 
@@ -25669,6 +25944,15 @@ __metadata:
   dependencies:
     acorn: ^8.8.1
   checksum: ada9b60f322ce3e3fd167b65a186ab77a8c76b8f9074dcdbad4c1a810b46f21c9dca30d4d807e98af580cbe99bfbccd6d8176f69183a454ae2868d8ddd6d4f88
+  languageName: node
+  linkType: hard
+
+"strip-literal@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "strip-literal@npm:1.0.1"
+  dependencies:
+    acorn: ^8.8.2
+  checksum: ab40496820f02220390d95cdd620a997168efb69d5bd7d180bc4ef83ca562a95447843d8c7c88b8284879a29cf4eedc89d8001d1e098c1a1e23d12a9c755dff4
   languageName: node
   linkType: hard
 
@@ -26180,6 +26464,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"time-zone@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "time-zone@npm:1.0.0"
+  checksum: e46f5a69b8c236dcd8e91e29d40d4e7a3495ed4f59888c3f84ce1d9678e20461421a6ba41233509d47dd94bc18f1a4377764838b21b584663f942b3426dcbce8
+  languageName: node
+  linkType: hard
+
 "timers-browserify@npm:^2.0.4":
   version: 2.0.12
   resolution: "timers-browserify@npm:2.0.12"
@@ -26217,6 +26508,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"tinybench@npm:^2.5.0":
+  version: 2.5.0
+  resolution: "tinybench@npm:2.5.0"
+  checksum: 284bb9428f197ec8b869c543181315e65e41ccfdad3c4b6c916bb1fdae1b5c6785661b0d90cf135b48d833b03cb84dc5357b2d33ec65a1f5971fae0ab2023821
+  languageName: node
+  linkType: hard
+
 "tinycolor2@npm:^1.4.1":
   version: 1.6.0
   resolution: "tinycolor2@npm:1.6.0"
@@ -26238,6 +26536,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"tinypool@npm:^0.5.0":
+  version: 0.5.0
+  resolution: "tinypool@npm:0.5.0"
+  checksum: 4e0dfd8f28666d541c1d92304222edc4613f05d74fe2243c8520d466a2cc6596011a7072c1c41a7de7522351b82fda07e8038198e8f43673d8d69401c5903f8c
+  languageName: node
+  linkType: hard
+
 "tinyqueue@npm:^2.0.3":
   version: 2.0.3
   resolution: "tinyqueue@npm:2.0.3"
@@ -26249,6 +26554,13 @@ __metadata:
   version: 1.0.2
   resolution: "tinyspy@npm:1.0.2"
   checksum: 32096121aa8d52bb625ad62c9314b3e4daba4ab9ac428217b12b1e1dfe9860e3c94d54a7affa279cc70dc6f10d88c6ba46b51de68896b318a06d02f05e87dcc3
+  languageName: node
+  linkType: hard
+
+"tinyspy@npm:^2.1.0":
+  version: 2.1.1
+  resolution: "tinyspy@npm:2.1.1"
+  checksum: cfe669803a7f11ca912742b84c18dcc4ceecaa7661c69bc5eb608a8a802d541c48aba220df8929f6c8cd09892ad37cb5ba5958ddbbb57940e91d04681d3cee73
   languageName: node
   linkType: hard
 
@@ -26848,6 +27160,13 @@ __metadata:
   version: 0.7.31
   resolution: "ua-parser-js@npm:0.7.31"
   checksum: e2f8324a83d1715601576af85b2b6c03890699aaa7272950fc77ea925c70c5e4f75060ae147dc92124e49f7f0e3d6dd2b0a91e7f40d267e92df8894be967ba8b
+  languageName: node
+  linkType: hard
+
+"ufo@npm:^1.1.2":
+  version: 1.1.2
+  resolution: "ufo@npm:1.1.2"
+  checksum: 83c940a6a23b6d4fc0cd116265bb5dcf88ab34a408ad9196e413270ca607a4781c09b547dc518f43caee128a096f20fe80b5a0e62b4bcc0a868619896106d048
   languageName: node
   linkType: hard
 
@@ -27563,6 +27882,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"v8-to-istanbul@npm:^9.1.0":
+  version: 9.1.0
+  resolution: "v8-to-istanbul@npm:9.1.0"
+  dependencies:
+    "@jridgewell/trace-mapping": ^0.3.12
+    "@types/istanbul-lib-coverage": ^2.0.1
+    convert-source-map: ^1.6.0
+  checksum: 2069d59ee46cf8d83b4adfd8a5c1a90834caffa9f675e4360f1157ffc8578ef0f763c8f32d128334424159bb6b01f3876acd39cd13297b2769405a9da241f8d1
+  languageName: node
+  linkType: hard
+
 "validate-npm-package-license@npm:^3.0.1":
   version: 3.0.4
   resolution: "validate-npm-package-license@npm:3.0.4"
@@ -27734,6 +28064,22 @@ __metadata:
     unist-util-stringify-position: ^3.0.0
     vfile-message: ^3.0.0
   checksum: 642cce703afc186dbe7cabf698dc954c70146e853491086f5da39e1ce850676fc96b169fcf7898aa3ff245e9313aeec40da93acd1e1fcc0c146dc4f6308b4ef9
+  languageName: node
+  linkType: hard
+
+"vite-node@npm:0.32.0":
+  version: 0.32.0
+  resolution: "vite-node@npm:0.32.0"
+  dependencies:
+    cac: ^6.7.14
+    debug: ^4.3.4
+    mlly: ^1.2.0
+    pathe: ^1.1.0
+    picocolors: ^1.0.0
+    vite: ^3.0.0 || ^4.0.0
+  bin:
+    vite-node: vite-node.mjs
+  checksum: ce1c45e7d903afc001a08b3bc3159d268e8422e28ec7ffa8e4a4f99d18c9f4e447db989a6e0a8e168d3a4f4e6eb0b954f2b51ef1a85f29cc3f7f561045ff0bbe
   languageName: node
   linkType: hard
 
@@ -27920,7 +28266,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vitest@npm:0.25.8, vitest@npm:^0.25.2":
+"vitest@npm:^0.25.2":
   version: 0.25.8
   resolution: "vitest@npm:0.25.8"
   dependencies:
@@ -27958,6 +28304,67 @@ __metadata:
   bin:
     vitest: vitest.mjs
   checksum: 2444dc04c87c261fcd43e1e240e5c62d6e96d0b52c0142f30200fde1078e97afad7cc6dd3163aa520ef4b0584f02cecfcc676300cb839e4470751403f54d2623
+  languageName: node
+  linkType: hard
+
+"vitest@npm:^0.32.0":
+  version: 0.32.0
+  resolution: "vitest@npm:0.32.0"
+  dependencies:
+    "@types/chai": ^4.3.5
+    "@types/chai-subset": ^1.3.3
+    "@types/node": "*"
+    "@vitest/expect": 0.32.0
+    "@vitest/runner": 0.32.0
+    "@vitest/snapshot": 0.32.0
+    "@vitest/spy": 0.32.0
+    "@vitest/utils": 0.32.0
+    acorn: ^8.8.2
+    acorn-walk: ^8.2.0
+    cac: ^6.7.14
+    chai: ^4.3.7
+    concordance: ^5.0.4
+    debug: ^4.3.4
+    local-pkg: ^0.4.3
+    magic-string: ^0.30.0
+    pathe: ^1.1.0
+    picocolors: ^1.0.0
+    std-env: ^3.3.2
+    strip-literal: ^1.0.1
+    tinybench: ^2.5.0
+    tinypool: ^0.5.0
+    vite: ^3.0.0 || ^4.0.0
+    vite-node: 0.32.0
+    why-is-node-running: ^2.2.2
+  peerDependencies:
+    "@edge-runtime/vm": "*"
+    "@vitest/browser": "*"
+    "@vitest/ui": "*"
+    happy-dom: "*"
+    jsdom: "*"
+    playwright: "*"
+    safaridriver: "*"
+    webdriverio: "*"
+  peerDependenciesMeta:
+    "@edge-runtime/vm":
+      optional: true
+    "@vitest/browser":
+      optional: true
+    "@vitest/ui":
+      optional: true
+    happy-dom:
+      optional: true
+    jsdom:
+      optional: true
+    playwright:
+      optional: true
+    safaridriver:
+      optional: true
+    webdriverio:
+      optional: true
+  bin:
+    vitest: vitest.mjs
+  checksum: a752f7a2290e08cc4033936b1b9e1fe6adcb156bccff6404d4950b4f913c01a8015768f8dbd35267752331311dc55e218d56c5271c56e5ca9c848a36a5dc5b55
   languageName: node
   linkType: hard
 
@@ -28244,6 +28651,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"well-known-symbols@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "well-known-symbols@npm:2.0.0"
+  checksum: 4f54bbc3012371cb4d228f436891b8e7536d34ac61a57541890257e96788608e096231e0121ac24d08ef2f908b3eb2dc0adba35023eaeb2a7df655da91415402
+  languageName: node
+  linkType: hard
+
 "wgs84@npm:0.0.0":
   version: 0.0.0
   resolution: "wgs84@npm:0.0.0"
@@ -28359,6 +28773,18 @@ __metadata:
   bin:
     node-which: ./bin/node-which
   checksum: 1a5c563d3c1b52d5f893c8b61afe11abc3bab4afac492e8da5bde69d550de701cf9806235f20a47b5c8fa8a1d6a9135841de2596535e998027a54589000e66d1
+  languageName: node
+  linkType: hard
+
+"why-is-node-running@npm:^2.2.2":
+  version: 2.2.2
+  resolution: "why-is-node-running@npm:2.2.2"
+  dependencies:
+    siginfo: ^2.0.0
+    stackback: 0.0.2
+  bin:
+    why-is-node-running: cli.js
+  checksum: 50820428f6a82dfc3cbce661570bcae9b658723217359b6037b67e495255409b4c8bc7931745f5c175df71210450464517cab32b2f7458ac9c40b4925065200a
   languageName: node
   linkType: hard
 
@@ -28661,6 +29087,13 @@ __metadata:
   version: 0.1.0
   resolution: "yocto-queue@npm:0.1.0"
   checksum: f77b3d8d00310def622123df93d4ee654fc6a0096182af8bd60679ddcdfb3474c56c6c7190817c84a2785648cdee9d721c0154eb45698c62176c322fb46fc700
+  languageName: node
+  linkType: hard
+
+"yocto-queue@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "yocto-queue@npm:1.0.0"
+  checksum: 2cac84540f65c64ccc1683c267edce396b26b1e931aa429660aefac8fbe0188167b7aee815a3c22fa59a28a58d898d1a2b1825048f834d8d629f4c2a5d443801
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

- [x] Field visibility selection mode is the default
- [x] schema search help text removing stray #s
- [x] use selectFields(metadata="foo") when in filter rule mode (continue using exclude_fields() in selection mode)
- [x] remove line number from search help text
- [x] Refactored schema controls
- [x] Add documentation icon/link to custom colors and field visibility modals
- [x] uncheck subpaths when parent path is unchecked even if the subpaths are disabled


<img width="763" alt="Screen Shot 2023-06-06 at 1 22 08 PM" src="https://github.com/voxel51/fiftyone/assets/109545780/3eac996c-d12d-4164-8c09-9884d66037ab">

<img width="776" alt="Screen Shot 2023-06-06 at 1 21 32 PM" src="https://github.com/voxel51/fiftyone/assets/109545780/e947be21-4d27-43ed-ac20-782197e7da9f">

## How is this patch tested? If it is not, please explain why.

(Details)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
