### PR TITLE
Add basic index usage to group matching

### DIFF
--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -2374,13 +2374,7 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
         group_field = self.group_field
         id_field = group_field + "._id"
 
-        pipeline = [
-            {
-                "$match": {
-                    "$expr": {"$eq": ["$" + id_field, ObjectId(group_id)]}
-                }
-            }
-        ]
+        pipeline = [{"$match": {id_field: ObjectId(group_id)}}]
 
         try:
             return next(
@@ -5942,7 +5936,7 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
             return []
 
         name_field = self.group_field + ".name"
-        return [{"$match": {"$expr": {"$eq": ["$" + name_field, slice_name]}}}]
+        return [{"$match": {name_field: slice_name}}]
 
     def _attach_groups_pipeline(self, group_slices=None):
         """A pipeline that attaches the requested group slice(s) for each

--- a/fiftyone/core/stages.py
+++ b/fiftyone/core/stages.py
@@ -4467,10 +4467,10 @@ class SelectGroupSlices(ViewStage):
         slices = self._get_slices(sample_collection)
 
         if etau.is_container(slices):
-            return [{"$match": {"$expr": {"$in": ["$" + group_path, slices]}}}]
+            return [{"$match": {group_path: {"$in": slices}}}]
 
         if slices is not None:
-            return [{"$match": {"$expr": {"$eq": ["$" + group_path, slices]}}}]
+            return [{"$match": {group_path: slices}}]
 
         return []
 
@@ -4501,7 +4501,6 @@ class SelectGroupSlices(ViewStage):
         ]
 
     def get_media_type(self, sample_collection):
-        group_field = sample_collection.group_field
         group_media_types = sample_collection.group_media_types
 
         slices = self._get_slices(sample_collection)


### PR DESCRIPTION
Adds basic index usage to group matching in `dataset._pipeline()` calls and `SelectGroupSlices`. Lookup pipelines could also be used, but `ViewExpression` use would need to be updated or replaced.