### PR TITLE
close panel on middle clicking panel tab

### DIFF
--- a/app/packages/spaces/src/components/PanelTab.tsx
+++ b/app/packages/spaces/src/components/PanelTab.tsx
@@ -1,3 +1,4 @@
+import { useCallback } from "react";
 import { IconButton } from "@fiftyone/components";
 import { Close } from "@mui/icons-material";
 import {
@@ -19,12 +20,23 @@ export default function PanelTab({ node, active, spaceId }: PanelTabProps) {
   const [title] = usePanelTitle(panelId);
   const closeEffect = usePanelCloseEffect(panelId);
 
+  const handleClose = useCallback(() => {
+    if (node.pinned) return;
+    closeEffect();
+    spaces.removeNode(node);
+  }, [node, closeEffect, spaces]);
+
   if (!panel) return warnPanelNotFound(panelName);
 
   const TabIndicator = panel?.panelOptions?.TabIndicator;
 
   return (
     <StyledTab
+      onMouseDown={(e) => {
+        if (e.button === 1) {
+          handleClose();
+        }
+      }}
       onClick={() => {
         if (!active) spaces.setNodeActive(node);
       }}
@@ -42,8 +54,7 @@ export default function PanelTab({ node, active, spaceId }: PanelTabProps) {
           onClick={(e) => {
             e.preventDefault();
             e.stopPropagation();
-            closeEffect();
-            spaces.removeNode(node);
+            handleClose();
           }}
           sx={{ pb: 0, mr: "-8px" }}
           title="Close"


### PR DESCRIPTION
## What changes are proposed in this pull request?

Add support for closing a panel by clicking panel's tab

https://github.com/voxel51/fiftyone/assets/25350704/1b51483b-1074-4bb3-bbed-964a17ade83f



## How is this patch tested? If it is not, please explain why.

Interactively within the app

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

Add support for closing a panel by clicking panel's tab

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
