### PR TITLE
move sample bar to modal from looker in dynamic groups

### DIFF
--- a/app/packages/core/src/components/Actions/ActionsRow.tsx
+++ b/app/packages/core/src/components/Actions/ActionsRow.tsx
@@ -31,7 +31,12 @@ import {
 import styled from "styled-components";
 
 import { PillButton, useTheme } from "@fiftyone/components";
-import { FrameLooker, ImageLooker, VideoLooker } from "@fiftyone/looker";
+import {
+  AbstractLooker,
+  FrameLooker,
+  ImageLooker,
+  VideoLooker,
+} from "@fiftyone/looker";
 import { OperatorPlacements, types } from "@fiftyone/operators";
 import { useOperatorBrowser } from "@fiftyone/operators/src/state";
 import * as fos from "@fiftyone/state";
@@ -498,7 +503,7 @@ export const ModalActionsRow = ({
   lookerRef,
   isGroup,
 }: {
-  lookerRef?: MutableRefObject<VideoLooker | undefined>;
+  lookerRef?: MutableRefObject<AbstractLooker | undefined>;
   isGroup?: boolean;
 }) => {
   const hideTagging = useRecoilValue(fos.readOnly);

--- a/app/packages/core/src/components/Modal/Group/DynamicGroup/UnorderedDynamicGroup.tsx
+++ b/app/packages/core/src/components/Modal/Group/DynamicGroup/UnorderedDynamicGroup.tsx
@@ -1,19 +1,71 @@
-import React from "react";
+import { Bar } from "@fiftyone/components";
+import { AbstractLooker } from "@fiftyone/looker";
+import * as fos from "@fiftyone/state";
+import React, { useRef } from "react";
+import { useRecoilValue } from "recoil";
+import styled from "styled-components";
+import { ModalActionsRow } from "../../../Actions";
 import Sample from "../../Sample";
 import { useGroupContext } from "../GroupContextProvider";
 import { DynamicGroupCarousel } from "./carousel/DynamicGroupCarousel";
 
+const RootContainer = styled.div`
+  height: 100%;
+  width: 100%;
+`;
+
+const ElementsContainer = styled.div`
+  width: 100%;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+`;
+
 export const UnorderedDynamicGroup = () => {
   const { lookerRefCallback, groupByFieldValue } = useGroupContext();
+  const lookerRef = useRef<AbstractLooker>();
+
+  const isImageVisible = useRecoilValue(fos.groupMediaIsImageVisible);
+  const isCarouselVisible = useRecoilValue(fos.groupMediaIsCarouselVisible);
 
   if (!groupByFieldValue) {
     return null;
   }
 
   return (
-    <>
-      <DynamicGroupCarousel key={groupByFieldValue} />
-      <Sample lookerRefCallback={lookerRefCallback} />
-    </>
+    <RootContainer>
+      {!isImageVisible && <UnorderedDynamicGroupBar lookerRef={lookerRef} />}
+      <ElementsContainer>
+        {isImageVisible && <UnorderedDynamicGroupBar lookerRef={lookerRef} />}
+        {isCarouselVisible && <DynamicGroupCarousel key={groupByFieldValue} />}
+        {isImageVisible && (
+          <Sample
+            lookerRefCallback={lookerRefCallback}
+            lookerRef={lookerRef}
+            hideSampleBar
+          />
+        )}
+      </ElementsContainer>
+    </RootContainer>
+  );
+};
+
+const UnorderedDynamicGroupBar = ({
+  lookerRef,
+}: {
+  lookerRef: React.MutableRefObject<AbstractLooker | undefined>;
+}) => {
+  return (
+    <Bar
+      style={{
+        position: "relative",
+        display: "flex",
+        justifyContent: "right",
+        zIndex: 10000,
+      }}
+    >
+      <ModalActionsRow isGroup lookerRef={lookerRef} />
+    </Bar>
   );
 };

--- a/app/packages/core/src/components/Modal/Group/DynamicGroup/UnorderedDynamicGroup.tsx
+++ b/app/packages/core/src/components/Modal/Group/DynamicGroup/UnorderedDynamicGroup.tsx
@@ -35,6 +35,7 @@ export const UnorderedDynamicGroup = () => {
 
   return (
     <RootContainer>
+      {/* weird conditional rendering of the bar because lookerControls messes up positioning of the bar in firefox in inexplicable ways */}
       {!isImageVisible && <UnorderedDynamicGroupBar lookerRef={lookerRef} />}
       <ElementsContainer>
         {isImageVisible && <UnorderedDynamicGroupBar lookerRef={lookerRef} />}

--- a/app/packages/core/src/components/Modal/Group/DynamicGroup/carousel/DynamicGroupCarousel.tsx
+++ b/app/packages/core/src/components/Modal/Group/DynamicGroup/carousel/DynamicGroupCarousel.tsx
@@ -1,10 +1,12 @@
 import { Loading, useTheme } from "@fiftyone/components";
+import * as fos from "@fiftyone/state";
 import { useBrowserStorage } from "@fiftyone/state";
 import { Resizable } from "re-resizable";
 import React, { Suspense, useState } from "react";
+import { useRecoilValue } from "recoil";
 import { DynamicGroupsFlashlightWrapper } from "./DynamicGroupsFlashlightWrapper";
 
-const MAX_CAROUSEL_HEIGHT = 500;
+const MAX_CAROUSEL_HEIGHT = 600;
 
 export const DynamicGroupCarousel = () => {
   const [height, setHeight] = useBrowserStorage(
@@ -15,6 +17,8 @@ export const DynamicGroupCarousel = () => {
   const theme = useTheme();
 
   const [isGroupEmpty, setIsGroupEmpty] = useState(false);
+
+  const isImageVisible = useRecoilValue(fos.groupMediaIsImageVisible);
 
   if (isGroupEmpty) {
     return null;
@@ -27,7 +31,7 @@ export const DynamicGroupCarousel = () => {
       maxHeight={MAX_CAROUSEL_HEIGHT}
       enable={{
         bottom: true,
-        top: false,
+        top: !isImageVisible,
         right: false,
         left: false,
         topRight: false,

--- a/app/packages/core/src/components/Modal/Sample.tsx
+++ b/app/packages/core/src/components/Modal/Sample.tsx
@@ -1,20 +1,37 @@
-import { AbstractLooker, VideoLooker } from "@fiftyone/looker";
+import { AbstractLooker } from "@fiftyone/looker";
 import { modal, useClearModal, useHoveredSample } from "@fiftyone/state";
-import React, { MutableRefObject, useCallback, useRef, useState } from "react";
+import React, {
+  MutableRefObject,
+  useCallback,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { useRecoilValue } from "recoil";
 import { SampleBar } from "./Bars";
 import Looker from "./Looker";
 
-const Sample: React.FC<{
+interface SampleProps {
   lookerRefCallback: (looker: AbstractLooker) => void;
-}> = ({ lookerRefCallback }) => {
+  lookerRef?: MutableRefObject<AbstractLooker | undefined>;
+  hideSampleBar?: boolean;
+}
+
+const Sample: React.FC<SampleProps> = ({
+  lookerRefCallback,
+  lookerRef: propsLookerRef,
+  hideSampleBar,
+}) => {
   const data = useRecoilValue(modal);
 
   if (!data) {
     throw new Error("no data");
   }
 
-  const lookerRef = useRef<VideoLooker>();
+  const lookerRef = useMemo(
+    () => propsLookerRef ?? React.createRef<AbstractLooker | undefined>(),
+    [propsLookerRef]
+  );
 
   const {
     sample: { _id },
@@ -46,12 +63,14 @@ const Sample: React.FC<{
       style={{ width: "100%", height: "100%", position: "relative" }}
       {...hover.handlers}
     >
-      <SampleBar
-        sampleId={_id}
-        lookerRef={lookerRef}
-        visible={hovering}
-        hoveringRef={hoveringRef}
-      />
+      {!hideSampleBar && (
+        <SampleBar
+          sampleId={_id}
+          lookerRef={lookerRef}
+          visible={hovering}
+          hoveringRef={hoveringRef}
+        />
+      )}
       <Looker
         key={_id}
         lookerRef={lookerRef}

--- a/e2e/cypress/support/e2e.ts
+++ b/e2e/cypress/support/e2e.ts
@@ -9,6 +9,12 @@ compareSnapshotCommand({
   errorThreshold: 0,
 });
 
+Cypress.on("uncaught:exception", (err, runnable) => {
+  // returning false here prevents Cypress from failing the test
+  // if there're certain exceptions we want to ignore, we can add them here
+  return true;
+});
+
 // delete all datasets before each spec runs
 // todo: investigate, this is flaky, sometimes singleton state doesn't reflect dataset deletion
 before(() => {


### PR DESCRIPTION
## What changes are proposed in this pull request?

Move sample bar to modal from looker in dynamic groups. This also makes it possible to maximize carousel / image in dynamic groups modal.

![2023-06-05 21 03 53](https://github.com/voxel51/fiftyone/assets/66688606/057ea17d-dc41-455d-854f-991db263148f)

## How is this patch tested? If it is not, please explain why.

All E2E tests green locally.

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
