### PR TITLE
Server patches

### DIFF
--- a/fiftyone/core/state.py
+++ b/fiftyone/core/state.py
@@ -5,13 +5,13 @@ Defines the shared state between the FiftyOne App and backend.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
-import json
+
 import logging
 import typing as t
 
 from bson import json_util
 from dataclasses import asdict
-from mongoengine.base import BaseDict
+from mongoengine.base import BaseDict, BaseList
 import strawberry as gql
 
 import eta.core.serial as etas
@@ -239,10 +239,20 @@ def serialize_fields(schema: t.Dict) -> t.List[SampleField]:
                     embedded_doc_type=embedded_doc_type,
                     subfield=subfield,
                     description=field.description,
-                    info=dict(**field.info)
+                    info=_convert_mongoengine_data(field.info)
                     if isinstance(field.info, BaseDict)
                     else field.info,
                 )
             )
+
+    return data
+
+
+def _convert_mongoengine_data(data):
+    if isinstance(data, BaseDict):
+        return {k: _convert_mongoengine_data(v) for k, v in data.items()}
+
+    if isinstance(data, BaseList):
+        return [_convert_mongoengine_data(v) for v in data]
 
     return data

--- a/fiftyone/server/events.py
+++ b/fiftyone/server/events.py
@@ -117,7 +117,10 @@ async def add_event_listener(
 
             for _, event in events:
                 if isinstance(event, StateUpdate):
-                    event.state = event.state.serialize()
+                    # we copy here as this is a shared object
+                    event = StateUpdate(
+                        state=event.state.serialize(), refresh=event.refresh
+                    )
 
                 yield ServerSentEvent(
                     event=event.get_event_name(),


### PR DESCRIPTION
### Changes

* In `fiftyone.server.events`, copy the `StateUpdate` event as it is a shared object. Ideally, `StateDescription` can be updated to a `dataclass` for a cleaner solution
* In `fiftyone.core.state`, recursively convert `BaseDict` and `BaseList` data as they interferes with `dataclasses.asdict`