### PR TITLE
Add sample tags to colorScheme editor

### DIFF
--- a/app/packages/core/src/components/ColorModal/SidebarList.tsx
+++ b/app/packages/core/src/components/ColorModal/SidebarList.tsx
@@ -9,9 +9,9 @@ import ListItemText from "@mui/material/ListItemText";
 import { Resizable } from "re-resizable";
 import React, { useState } from "react";
 import { useRecoilCallback, useRecoilValue } from "recoil";
-import { resizeHandle } from "./../Sidebar/Sidebar.module.css";
 import styles from "../../../../../packages/components/src/scrollable.module.css";
-import { ACTIVE_FIELD } from "./utils";
+import { resizeHandle } from "./../Sidebar/Sidebar.module.css";
+import { ACTIVE_FIELD, getDisplayName } from "./utils";
 
 const WIDTH = 230;
 
@@ -22,6 +22,7 @@ const SidebarList: React.FC = () => {
   const [width, setWidth] = useState(WIDTH);
   const stableGroup = [
     { paths: [ACTIVE_FIELD.global, ACTIVE_FIELD.json], name: "general" },
+    { paths: ["tags"], name: "tags" },
   ];
   const fieldGroups = useRecoilValue(
     fos.sidebarGroups({ modal: false, loading: false })
@@ -50,6 +51,7 @@ const SidebarList: React.FC = () => {
   const getCurrentField = (activeField) => {
     if (activeField === ACTIVE_FIELD.global) return ACTIVE_FIELD.global;
     if (activeField === ACTIVE_FIELD.json) return ACTIVE_FIELD.json;
+
     return activeField?.expandedPath;
   };
   return (
@@ -123,7 +125,7 @@ const SidebarList: React.FC = () => {
                       disableRipple
                     >
                       <ListItemText
-                        primary={path}
+                        primary={getDisplayName(path)}
                         onClick={() => onSelectField(path)}
                         sx={{ fontFamily: "palanquin, sans-serif" }}
                       />

--- a/app/packages/core/src/components/ColorModal/utils.ts
+++ b/app/packages/core/src/components/ColorModal/utils.ts
@@ -1,5 +1,5 @@
-import { isEmpty, xor } from "lodash";
 import * as fos from "@fiftyone/state";
+import { isEmpty, xor } from "lodash";
 
 // Masataka Okabe and Kei Ito have proposed a palette of 8 colors on their
 // website Color Universal Design (CUD). This palette is a “Set of colors that
@@ -35,6 +35,7 @@ export const fiftyoneDefaultColorPalette = [
 export const ACTIVE_FIELD = {
   ["json"]: "JSON editor",
   ["global"]: "Global settings",
+  ["_label_tags"]: "label tags",
 };
 
 // disregard the order
@@ -92,4 +93,11 @@ export const isDefaultSetting = (savedSetting: fos.ColorScheme) => {
     ) &&
     (savedSetting.fields?.length == 0 || !savedSetting.fields)
   );
+};
+
+export const getDisplayName = (path: string) => {
+  if (path === "tags") {
+    return "sample tags";
+  }
+  return path;
 };

--- a/app/packages/core/src/components/FieldLabelAndInfo/index.tsx
+++ b/app/packages/core/src/components/FieldLabelAndInfo/index.tsx
@@ -1,3 +1,8 @@
+import { InfoIcon, useTheme } from "@fiftyone/components";
+import * as fos from "@fiftyone/state";
+import { activeColorField, coloring } from "@fiftyone/state";
+import { Field, formatDate, formatDateTime } from "@fiftyone/utilities";
+import PaletteIcon from "@mui/icons-material/Palette";
 import React, {
   MutableRefObject,
   useEffect,
@@ -5,6 +10,7 @@ import React, {
   useRef,
   useState,
 } from "react";
+import ReactDOM from "react-dom";
 import {
   atom,
   useRecoilState,
@@ -12,13 +18,8 @@ import {
   useSetRecoilState,
 } from "recoil";
 import styled from "styled-components";
-import * as fos from "@fiftyone/state";
-import PaletteIcon from "@mui/icons-material/Palette";
 import { ExternalLink } from "../../utils/generic";
-import { InfoIcon, useTheme } from "@fiftyone/components";
-import { Field, formatDate, formatDateTime } from "@fiftyone/utilities";
-import { coloring, activeColorField } from "@fiftyone/state";
-import ReactDOM from "react-dom";
+import { ACTIVE_FIELD } from "../ColorModal/utils";
 
 const selectedFieldInfo = atom<string | null>({
   key: "selectedFieldInfo",
@@ -263,10 +264,12 @@ function FieldInfoExpanded({
   const colorBy = colorSettings.by;
   const onClickCustomizeColor = () => {
     // open the color customization modal based on colorBy status
+    if (field.path === "_label_tags") {
+      setIsCustomizingColor(ACTIVE_FIELD[field.path]);
+    }
     setIsCustomizingColor({ field, expandedPath });
   };
 
-  const isNotTag = field.path !== "tags";
   useEffect(updatePosition, [field, isCollapsed]);
   const timeZone = useRecoilValue(fos.timeZone);
 
@@ -280,7 +283,7 @@ function FieldInfoExpanded({
       onClick={(e) => e.stopPropagation()}
     >
       <FieldInfoExpandedContainer color={color}>
-        {isNotTag && !isModal && (
+        {!isModal && (
           <CustomizeColor
             onClick={onClickCustomizeColor}
             color={color}

--- a/app/packages/core/src/components/FieldLabelAndInfo/index.tsx
+++ b/app/packages/core/src/components/FieldLabelAndInfo/index.tsx
@@ -264,9 +264,6 @@ function FieldInfoExpanded({
   const colorBy = colorSettings.by;
   const onClickCustomizeColor = () => {
     // open the color customization modal based on colorBy status
-    if (field.path === "_label_tags") {
-      setIsCustomizingColor(ACTIVE_FIELD[field.path]);
-    }
     setIsCustomizingColor({ field, expandedPath });
   };
 

--- a/app/packages/looker/src/elements/common/tags.ts
+++ b/app/packages/looker/src/elements/common/tags.ts
@@ -275,9 +275,16 @@ export class TagsElement<State extends BaseState> extends BaseElement<State> {
           sample.tags.forEach((tag) => {
             const v = coloring.by === "value" ? tag : "tags";
             elements.push({
-              color: getColor(coloring.pool, coloring.seed, v),
+              color: getColorFromOptions({
+                coloring,
+                path,
+                param: tag,
+                customizeColorSetting,
+                labelDefault: false,
+              }),
               title: tag,
               value: tag,
+              path: v,
             });
           });
         }
@@ -289,6 +296,7 @@ export class TagsElement<State extends BaseState> extends BaseElement<State> {
             color: getColor(coloring.pool, coloring.seed, v),
             title: value,
             value: value,
+            path: v,
           });
         });
       } else {

--- a/app/packages/looker/src/elements/common/util.ts
+++ b/app/packages/looker/src/elements/common/util.ts
@@ -95,13 +95,13 @@ export const prettify = (
   return result;
 };
 
-// for classification types and regression types
+// for classification types and regression and sample tag types
 type Param = {
   coloring: Coloring;
   path: string;
-  param: Classification | Regression;
+  param: Classification | Regression | string;
   customizeColorSetting: CustomizeColor[];
-  labelDefault: boolean; // use .label or .value as default
+  labelDefault: boolean; // use .label for classification or .value for regression
 };
 export const getColorFromOptions = ({
   coloring,
@@ -118,7 +118,7 @@ export const getColorFromOptions = ({
     }
     return getColor(coloring.pool, coloring.seed, path);
   }
-  if (coloring.by === "value") {
+  if (coloring.by === "value" && path !== "tags") {
     if (setting) {
       key = setting.colorByAttribute ?? labelDefault ? "label" : "value";
       // check if this label has a assigned color, use it if it is a valid color
@@ -144,6 +144,16 @@ export const getColorFromOptions = ({
       key = labelDefault ? "label" : "value";
     }
     return getColor(coloring.pool, coloring.seed, param[key]);
+  }
+  if (coloring.by === "value" && path === "tags") {
+    if (setting) {
+      const valueColor = setting.valueColors?.find(
+        (v) => v.value === param
+      )?.color;
+      if (isValidColor(valueColor)) {
+        return valueColor;
+      }
+    }
   }
   return getColor(coloring.pool, coloring.seed, path);
 };


### PR DESCRIPTION
## What changes are proposed in this pull request?

Added sample tags to colorScheme editor. User can now configure sample tags like other common ListField. 

## How is this patch tested? If it is not, please explain why.
https://github.com/voxel51/fiftyone/assets/17770824/526bdc8b-da1c-4a59-9e37-6230a629e4ab

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
