### PR TITLE
use $addFields and $project in aggregation pipelines

### DIFF
--- a/fiftyone/core/aggregations.py
+++ b/fiftyone/core/aggregations.py
@@ -807,9 +807,9 @@ class CountValues(Aggregation):
 
         if self._include is not None:
             limit = max(limit, len(self._include))
-            pipeline += [
-                {"$addFields": {"included": {"$in": ["$_id", self._include]}}},
-            ]
+            pipeline.append(
+                {"$addFields": {"included": {"$in": ["$_id", self._include]}}}
+            )
             sort["included"] = -1
 
         order = 1 if self._asc else -1

--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -5415,7 +5415,7 @@ class SampleCollection(object):
                     }
                 },
                 {"$sort": {"_sort_field": -1}},
-                {"$unset": "_sort_field"}
+                {"$project": {"_sort_field": False}},
             ])
 
         Args:
@@ -10413,7 +10413,7 @@ def _make_set_field_pipeline(
     # Case 1: no list fields
     if not list_fields:
         expr_dict = _render_expr(expr, path, embedded_root)
-        pipeline = [{"$set": {path: expr_dict}}]
+        pipeline = [{"$addFields": {path: expr_dict}}]
         return pipeline, expr_dict
 
     # Case 2: one list field
@@ -10423,7 +10423,7 @@ def _make_set_field_pipeline(
         expr, expr_dict = _set_terminal_list_field(
             list_field, subfield, expr, embedded_root
         )
-        pipeline = [{"$set": {list_field: expr.to_mongo()}}]
+        pipeline = [{"$addFields": {list_field: expr.to_mongo()}}]
         return pipeline, expr_dict
 
     # Case 3: multiple list fields
@@ -10443,7 +10443,7 @@ def _make_set_field_pipeline(
 
     expr = expr.to_mongo(prefix="$" + list_fields[0])
 
-    pipeline = [{"$set": {list_fields[0]: expr}}]
+    pipeline = [{"$addFields": {list_fields[0]: expr}}]
 
     return pipeline, expr_dict
 

--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -5971,7 +5971,7 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
                 }
             },
             {
-                "$set": {
+                "$addFields": {
                     "groups": {
                         "$arrayToObject": {
                             "$map": {
@@ -6020,7 +6020,7 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
         """A pipeline that returns (only) the unwound ``groups`` documents."""
         return [
             {
-                "$set": {
+                "$addFields": {
                     "groups": {
                         "$map": {
                             "input": {"$objectToArray": "$groups"},
@@ -6721,14 +6721,14 @@ def _clone_dataset_or_view(dataset_or_view, name, persistent):
 
     # Clone samples
     coll, pipeline = _get_samples_pipeline(dataset_or_view)
-    pipeline.append({"$set": {"_dataset_id": _id}})
+    pipeline.append({"$addFields": {"_dataset_id": _id}})
     pipeline.append({"$out": sample_collection_name})
     foo.aggregate(coll, pipeline)
 
     # Clone frames
     if contains_videos:
         coll, pipeline = _get_frames_pipeline(dataset_or_view)
-        pipeline.append({"$set": {"_dataset_id": _id}})
+        pipeline.append({"$addFields": {"_dataset_id": _id}})
         pipeline.append({"$out": frame_collection_name})
         foo.aggregate(coll, pipeline)
 
@@ -6774,9 +6774,9 @@ def _get_frames_pipeline(sample_collection):
         pipeline = sample_collection._pipeline(attach_frames=True) + [
             {"$project": {"frames": True}},
             {"$unwind": "$frames"},
-            {"$set": {"frames._sample_id": "$_id"}},
+            {"$addFields": {"frames._sample_id": "$_id"}},
             {"$replaceRoot": {"newRoot": "$frames"}},
-            {"$unset": "_id"},
+            {"$project": {"_id": False}},
         ]
     elif view is not None:
         # The view may modify the frames, so we route the frames though
@@ -7218,8 +7218,8 @@ def _add_collection_with_new_ids(
         src_samples._aggregate(
             detach_groups=True,
             post_pipeline=[
-                {"$unset": "_id"},
-                {"$set": {"_dataset_id": dataset._doc.id}},
+                {"$project": {"_id": False}},
+                {"$addFields": {"_dataset_id": dataset._doc.id}},
                 {
                     "$merge": {
                         "into": dataset._sample_collection_name,
@@ -7250,8 +7250,8 @@ def _add_collection_with_new_ids(
         detach_frames=True,
         detach_groups=True,
         post_pipeline=[
-            {"$unset": "_id"},
-            {"$set": {"_dataset_id": dataset._doc.id}},
+            {"$project": {"_id": False}},
+            {"$addFields": {"_dataset_id": dataset._doc.id}},
             {
                 "$merge": {
                     "into": dataset._sample_collection_name,
@@ -7265,9 +7265,14 @@ def _add_collection_with_new_ids(
     src_videos._aggregate(
         frames_only=True,
         post_pipeline=[
-            {"$set": {"_tmp": "$_sample_id", "_sample_id": {"$rand": {}}}},
-            {"$unset": "_id"},
-            {"$set": {"_dataset_id": dataset._doc.id}},
+            {
+                "$addFields": {
+                    "_tmp": "$_sample_id",
+                    "_sample_id": {"$rand": {}},
+                }
+            },
+            {"$project": {"_id": False}},
+            {"$addFields": {"_dataset_id": dataset._doc.id}},
             {
                 "$merge": {
                     "into": dataset._frame_collection_name,
@@ -7526,7 +7531,7 @@ def _merge_samples_pipeline(
 
     if _omit_fields:
         unset_fields = [db_fields_map.get(f, f) for f in _omit_fields]
-        sample_pipeline.append({"$unset": unset_fields})
+        sample_pipeline.append({"$project": {f: False for f in unset_fields}})
 
     if skip_existing:
         when_matched = "keepExisting"
@@ -7563,7 +7568,7 @@ def _merge_samples_pipeline(
 
     sample_pipeline.extend(
         [
-            {"$set": {"_dataset_id": dst_dataset._doc.id}},
+            {"$addFields": {"_dataset_id": dst_dataset._doc.id}},
             {
                 "$merge": {
                     "into": dst_dataset._sample_collection_name,
@@ -7636,7 +7641,7 @@ def _merge_samples_pipeline(
         _omit_frame_fields.discard("frame_number")
 
         unset_fields = [db_fields_map.get(f, f) for f in _omit_frame_fields]
-        frame_pipeline.append({"$unset": unset_fields})
+        frame_pipeline.append({"$project": {f: False for f in unset_fields}})
 
         if skip_existing:
             when_frame_matched = "keepExisting"
@@ -7653,7 +7658,7 @@ def _merge_samples_pipeline(
         frame_pipeline.extend(
             [
                 {
-                    "$set": {
+                    "$addFields": {
                         "_dataset_id": dst_dataset._doc.id,
                         "_sample_id": "$" + frame_key_field,
                     }

--- a/fiftyone/core/odm/database.py
+++ b/fiftyone/core/odm/database.py
@@ -260,7 +260,7 @@ def _delete_non_persistent_datasets_if_allowed():
                 _client.admin.aggregate(
                     [
                         {"$currentOp": {"allUsers": True}},
-                        {"$project": {"appName": 1, "command": 1}},
+                        {"$project": {"appName": True, "command": True}},
                         {
                             "$match": {
                                 "appName": foc.DATABASE_APPNAME,

--- a/fiftyone/core/odm/mixins.py
+++ b/fiftyone/core/odm/mixins.py
@@ -796,7 +796,7 @@ class DatasetMixin(object):
 
             view = view.set_field(new_path, expr, _allow_missing=True)
 
-        view = view.mongo([{"$unset": _paths}])
+        view = view.mongo([{"$project": {p: False for p in _paths}}])
 
         #
         # Ideally only the embedded field would be saved, but the `$merge`

--- a/fiftyone/core/video.py
+++ b/fiftyone/core/video.py
@@ -351,7 +351,9 @@ class FramesView(fov.DatasetView):
                 sample_only_fields.discard("_sample_id")
                 sample_only_fields.discard("frame_number")
 
-                pipeline.append({"$unset": list(sample_only_fields)})
+                pipeline.append(
+                    {"$project": {f: False for f in sample_only_fields}}
+                )
             else:
                 project = {f: True for f in fields}
                 project["_id"] = True
@@ -665,11 +667,11 @@ def make_frames_dataset(
     pipeline = []
 
     if sample_frames == "dynamic":
-        pipeline.append({"$unset": "filepath"})
+        pipeline.append({"$project": {"filepath": False}})
 
     pipeline.extend(
         [
-            {"$set": {"_dataset_id": dataset._doc.id}},
+            {"$addFields": {"_dataset_id": dataset._doc.id}},
             {
                 "$merge": {
                     "into": dataset._sample_collection_name,

--- a/fiftyone/server/samples.py
+++ b/fiftyone/server/samples.py
@@ -116,7 +116,7 @@ async def paginate_samples(
 
     # Only return the first frame of each video sample for the grid thumbnail
     if media == fom.VIDEO:
-        pipeline.append({"$set": {"frames": {"$slice": ["$frames", 1]}}})
+        pipeline.append({"$addFields": {"frames": {"$slice": ["$frames", 1]}}})
 
     samples = await foo.aggregate(
         foo.get_async_db_conn()[view._dataset._sample_collection_name],

--- a/fiftyone/server/view.py
+++ b/fiftyone/server/view.py
@@ -232,7 +232,9 @@ def get_extended_view(
     if count_label_tags:
         view = _add_labels_tags_counts(view, filtered_labels, label_tags)
         if cleanup_fields:
-            view = view.mongo([{"$unset": field} for field in cleanup_fields])
+            view = view.mongo(
+                [{"$project": {f: False for f in cleanup_fields}}]
+            )
 
     return view
 

--- a/tests/unittests/server_tests.py
+++ b/tests/unittests/server_tests.py
@@ -48,7 +48,7 @@ class ServerViewTests(unittest.TestCase):
 
         expected = [
             {
-                "$set": {
+                "$addFields": {
                     "___predictions.detections": {
                         "$filter": {
                             "input": "$predictions.detections",
@@ -90,7 +90,7 @@ class ServerViewTests(unittest.TestCase):
                 },
             },
             {
-                "$set": {
+                "$addFields": {
                     "___predictions.detections": {
                         "$filter": {
                             "input": "$___predictions.detections",
@@ -116,9 +116,9 @@ class ServerViewTests(unittest.TestCase):
                     },
                 },
             },
-            {"$set": {"_label_tags": []}},
+            {"$addFields": {"_label_tags": []}},
             {
-                "$set": {
+                "$addFields": {
                     "_label_tags": {
                         "$cond": {
                             "if": {"$gt": ["$predictions", None]},
@@ -145,7 +145,7 @@ class ServerViewTests(unittest.TestCase):
                 },
             },
             {
-                "$set": {
+                "$addFields": {
                     "_label_tags": {
                         "$function": {
                             "body": "function(items) {let counts = {};items && items.forEach((i) => {counts[i] = 1 + (counts[i] || 0);});return counts;}",
@@ -155,7 +155,7 @@ class ServerViewTests(unittest.TestCase):
                     },
                 },
             },
-            {"$unset": "___predictions"},
+            {"$project": {"___predictions": False}},
         ]
 
         self.assertEqual(expected, returned)
@@ -190,7 +190,7 @@ class ServerViewTests(unittest.TestCase):
 
         expected = [
             {
-                "$set": {
+                "$addFields": {
                     "predictions.detections": {
                         "$filter": {
                             "input": "$predictions.detections",
@@ -234,7 +234,7 @@ class ServerViewTests(unittest.TestCase):
                 }
             },
             {
-                "$set": {
+                "$addFields": {
                     "predictions.detections": {
                         "$filter": {
                             "input": "$predictions.detections",
@@ -294,7 +294,7 @@ class ServerViewTests(unittest.TestCase):
 
         expected = [
             {
-                "$set": {
+                "$addFields": {
                     "frames": {
                         "$map": {
                             "input": "$frames",
@@ -377,7 +377,7 @@ class ServerViewTests(unittest.TestCase):
                 },
             },
             {
-                "$set": {
+                "$addFields": {
                     "frames": {
                         "$map": {
                             "input": "$frames",
@@ -441,9 +441,9 @@ class ServerViewTests(unittest.TestCase):
                     },
                 },
             },
-            {"$set": {"_label_tags": []}},
+            {"$addFields": {"_label_tags": []}},
             {
-                "$set": {
+                "$addFields": {
                     "_label_tags": {
                         "$concatArrays": [
                             "$_label_tags",
@@ -486,7 +486,7 @@ class ServerViewTests(unittest.TestCase):
                 },
             },
             {
-                "$set": {
+                "$addFields": {
                     "_label_tags": {
                         "$function": {
                             "body": "function(items) {let counts = {};items && items.forEach((i) => {counts[i] = 1 + (counts[i] || 0);});return counts;}",
@@ -496,7 +496,7 @@ class ServerViewTests(unittest.TestCase):
                     },
                 },
             },
-            {"$unset": "frames.___detections"},
+            {"$project": {"frames.___detections": False}},
         ]
 
         self.assertEqual(expected, returned)
@@ -532,7 +532,7 @@ class ServerViewTests(unittest.TestCase):
 
         expected = [
             {
-                "$set": {
+                "$addFields": {
                     "frames": {
                         "$map": {
                             "input": "$frames",
@@ -615,7 +615,7 @@ class ServerViewTests(unittest.TestCase):
                 }
             },
             {
-                "$set": {
+                "$addFields": {
                     "frames": {
                         "$map": {
                             "input": "$frames",
@@ -705,7 +705,7 @@ class ServerViewTests(unittest.TestCase):
 
         expected = [
             {
-                "$set": {
+                "$addFields": {
                     "frames": {
                         "$map": {
                             "input": "$frames",
@@ -778,9 +778,9 @@ class ServerViewTests(unittest.TestCase):
                     },
                 },
             },
-            {"$set": {"_label_tags": []}},
+            {"$addFields": {"_label_tags": []}},
             {
-                "$set": {
+                "$addFields": {
                     "_label_tags": {
                         "$concatArrays": [
                             "$_label_tags",
@@ -823,7 +823,7 @@ class ServerViewTests(unittest.TestCase):
                 },
             },
             {
-                "$set": {
+                "$addFields": {
                     "_label_tags": {
                         "$function": {
                             "body": "function(items) {let counts = {};items && items.forEach((i) => {counts[i] = 1 + (counts[i] || 0);});return counts;}",
@@ -833,7 +833,7 @@ class ServerViewTests(unittest.TestCase):
                     },
                 },
             },
-            {"$unset": "frames.___detections"},
+            {"$project": {"frames.___detections": False}},
         ]
 
         self.assertEqual(expected, returned)
@@ -860,7 +860,7 @@ class ServerViewTests(unittest.TestCase):
 
         expected = [
             {
-                "$set": {
+                "$addFields": {
                     "frames": {
                         "$map": {
                             "input": "$frames",


### PR DESCRIPTION
Replaces all usages of `$set` and `$unset` in aggregation pipelines with `$addFields` and `$project: {XXX: False}`, respectively.

This is being done as part of an effort to broaden the compatibility of FiftyOne with older MongoDB versions and other technologies like DocumentDB.