### PR TITLE
Add CVAT support for frame_start frame_stop and frame_step

### DIFF
--- a/docs/source/integrations/cvat.rst
+++ b/docs/source/integrations/cvat.rst
@@ -505,6 +505,48 @@ provided:
     or when using `task_size` and generating multiple tasks
 -   **organization** (*None*): the name of the organization to use when sending
     requests to CVAT
+-   **frame_start** (*None*): nonnegative integer(s) defining the first frame of
+    videos to upload when creating video tasks.
+    Supported types are:
+
+    - `integer`: the first frame to upload for each video
+    - `list`: a list of first frame integers corresponding to
+      videos in the given samples. If fewer `frame_start` values are
+      provided than there are videos in the given samples, they will be
+      reassigned with a round-robin strategy
+    - `dict`: a dictionary mapping sample filepath to the first frame
+      integer to use for the corresponding video
+
+    Note: This argument is only supported for videos.
+-   **frame_stop** (*None*): nonnegative integer(s) defining the last frame of
+    videos to upload when creating video tasks.
+    Supported types are:
+
+    - `integer`: the last frame to upload for each video
+    - `list`: a list of last frame integers corresponding to
+      videos in the given samples. If fewer `frame_stop` values are
+      provided than there are videos in the given samples, they will be
+      reassigned with a round-robin strategy
+    - `dict`: a dictionary mapping sample filepath to the last frame
+      integer to use for the corresponding video
+
+    Note: This argument is only supported for videos.
+-   **frame_step** (*None*): positive integer(s) defining which frames to sample
+    when creating video tasks.
+    For example, a frame step of 25 will include frames 1, 26, 51 and
+    so on.
+    Supported types are:
+
+    - `integer`: the frame step to apply to each video task
+    - `list`: a list of frame step integers corresponding to
+      videos in the given samples. If fewer `frame_step` values are
+      provided than there are videos in the given samples, they will be
+      reassigned with a round-robin strategy
+    - `dict`: a dictionary mapping sample filepath to the frame step
+      integer to use for the corresponding video
+
+    Note: This argument is only supported for videos and does not
+    support uploading existing tracks when provided.
 
 .. _cvat-label-schema:
 
@@ -2125,6 +2167,67 @@ destination fields.
         dest_field=dest_field,
     )
     dataset.delete_annotation_run(anno_key)
+
+
+.. _cvat-frame-args:
+
+Using frame start, stop, step
+-----------------------------
+
+When annotating videos, you can use the arguments `frame_start`, `frame_stop`,
+and `frame_step` to annotate subsampled clips of your videos rather than
+loading every frame into CVAT. These arguments are only supported for video
+tasks and accept either integer values to use for each video task that is
+created, a list of values that will be applied to video tasks in a round-robin
+strategy, or a dictionary of values mapping the video filepath to the
+corresponding integer value.
+
+Note: Uploading existing annotation tracks while using the `frame_step`
+argument is not currently supported.
+
+.. code:: python
+   :linenos:
+
+   import fiftyone as fo
+   import fiftyone.zoo as foz
+
+   dataset = foz.load_zoo_dataset("quickstart-video", max_samples=2).clone()
+   sample_fps = dataset.values("filepath")
+
+   # Start video 1 at frame 10 and video 2 at frame 5
+   frame_start = {sample_fps[0]: 10, sample_fps[1]: 5}
+
+   # For video 1, load every frame after the start
+   # For video 2, load every 10th frame
+   frame_step = [1, 10]
+
+   # Stop all videos at frame 100
+   frame_stop = 100
+
+   anno_key = "frame_args"
+   label_field = "frames.new_detections"
+   label_type = "detections"
+   classes = ["person", "vehicle"]
+
+   # Annotate a new detections field
+   dataset.annotate(
+       anno_key,
+       label_field=label_field,
+       label_type=label_type,
+       classes=classes,
+       frame_start=frame_start,
+       frame_stop=frame_stop,
+       frame_step=frame_step,
+   )
+   print(dataset.get_annotation_info(anno_key))
+
+   # Annotate in CVAT
+
+   dataset.load_annotations(
+       anno_key,
+       cleanup=True,
+   )
+   dataset.delete_annotation_run(anno_key)
 
 .. _cvat-annotating-videos:
 

--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -8363,6 +8363,8 @@ class SampleCollection(object):
                 -   ``"prompt"``: present an interactive prompt to
                     direct/discard unexpected labels
                 -   ``"ignore"``: automatically ignore any unexpected labels
+                -   ``"keep"``: automatically keep all unexpected labels in a
+                    field whose name matches the the label type
                 -   ``"return"``: return a dict containing all unexpected
                     labels, or ``None`` if there aren't any
             cleanup (False): whether to delete any informtation regarding this

--- a/fiftyone/utils/cvat.py
+++ b/fiftyone/utils/cvat.py
@@ -3177,6 +3177,21 @@ class CVATBackendConfig(foua.AnnotationBackendConfig):
                 % (type(arg), arg_name)
             )
 
+        if arg_name == "frame_step":
+            if isinstance(arg, int):
+                arg_list = [arg]
+            elif isinstance(arg, dict):
+                arg_list = arg.values()
+            else:
+                arg_list = arg
+
+            for _arg in arg_list:
+                if _arg < 1:
+                    raise ValueError(
+                        "'frame_step' must be greater than 1 but found %d."
+                        % _arg
+                    )
+
         return arg
 
 
@@ -4208,7 +4223,7 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
         if frame_step is not None:
             if frame_step < 1:
                 logger.warning(
-                    "Ignoring 'frame_step' as must be great than 1 but found %d."
+                    "Ignoring 'frame_step' as it must be greater than 1 but found %d."
                     % frame_step
                 )
             else:

--- a/fiftyone/utils/cvat.py
+++ b/fiftyone/utils/cvat.py
@@ -6166,9 +6166,9 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
             _frame_step = 1 if frame_step is None else frame_step
             return sampled_frame_id + _frame_step
 
-        sampled_frame_id = 0 if frame_start is None else frame_start
         frame_id = -1
         for sample in samples:
+            sampled_frame_id = 0 if frame_start is None else frame_start
             metadata = sample.metadata
 
             if is_video:

--- a/tests/intensive/cvat_tests.py
+++ b/tests/intensive/cvat_tests.py
@@ -1349,7 +1349,9 @@ class CVATTests(unittest.TestCase):
             results = dataset.annotate(
                 anno_key,
                 backend="cvat",
-                label_field="frames.detections",
+                label_field="frames.new_detections",
+                label_type="detections",
+                classes=["test"],
                 frame_start=10,
                 frame_stop=100,
                 frame_step=0,


### PR DESCRIPTION
CVAT has [three arguments](https://opencv.github.io/cvat/docs/manual/basics/create_an_annotation_task/) that let you define which portions of videos are uploaded: `frame_start`, `frame_stop`, and `frame_step` 

This PR adds support to these through keyword arguments when calling `dataset.annotate()` with the CVAT backend as well as docs and tests.

@brimoor I'm a bit confused why this is required: https://github.com/voxel51/fiftyone/blob/8aca7cb29cbb9ddcb12a54340dffb36f2736c5b9/fiftyone/utils/cvat.py#L3218-L3222
These args are being loaded as mongoengine versions of lists/dicts if you load this config from the DB at some future time. I'm not sure if this is the right way to handle this or if this is indicative of other issues with serialization/deserialization of these args in the config.

Docs:

- frame_start (None): nonnegative integer(s) defining the first frame of videos to upload when creating video tasks. Supported types are:
  - integer: the first frame to upload for each video
  - list: a list of first frame integers corresponding to videos in the given samples. If fewer frame_start values are provided than there are videos in the given samples, they will be reassigned with a round-robin strategy
  - dict: a dictionary mapping sample filepath to the first frame integer to use for the corresponding video

  Note: This argument is only supported for videos.

- frame_stop (None): nonnegative integer(s) defining the last frame of videos to upload when creating video tasks. Supported types are:

  - integer: the last frame to upload for each video

  - list: a list of last frame integers corresponding to videos in the given samples. If fewer frame_stop values are provided than there are videos in the given samples, they will be reassigned with a round-robin strategy

  - dict: a dictionary mapping sample filepath to the last frame integer to use for the corresponding video

  Note: This argument is only supported for videos.

- frame_step (None): positive integer(s) defining which frames to sample when creating video tasks. For example, a frame step of 25 will include frames 1, 26, 51 and so on. Supported types are:

  - integer: the frame step to apply to each video task

  - list: a list of frame step integers corresponding to videos in the given samples. If fewer frame_step values are provided than there are videos in the given samples, they will be reassigned with a round-robin strategy

  - dict: a dictionary mapping sample filepath to the frame step integer to use for the corresponding video

  Note: This argument is only supported for videos and does not support uploading existing tracks when provided.

![image](https://github.com/voxel51/fiftyone/assets/21222883/958b011a-6516-42ab-87b2-62ad1250e933)


