### PR TITLE
Bumping compatibility version

### DIFF
--- a/fiftyone/constants.py
+++ b/fiftyone/constants.py
@@ -41,7 +41,7 @@ RESOURCES_DIR = os.path.join(FIFTYONE_DIR, "resources")
 # This setting may be ``None`` if this client has no compatibility with other
 # versions
 #
-COMPATIBLE_VERSIONS = ">=0.19,<0.21"
+COMPATIBLE_VERSIONS = ">=0.19,<0.22"
 
 # Package metadata
 _META = metadata("fiftyone")


### PR DESCRIPTION
The compatibility version wasn't bumped with the 0.21 release.

This likely wasn't detected because `database_admin=True` by default in OSS, so compatibility version doesn't come into play (the compatibility version *was* bumped in Teams, where `database_admin=False` by default).