### PR TITLE
replace expr with DocDB compatible equivalent

### DIFF
--- a/fiftyone/core/aggregations.py
+++ b/fiftyone/core/aggregations.py
@@ -578,7 +578,7 @@ class Count(Aggregation):
         )
 
         if not sample_collection._contains_videos() or path != "frames":
-            pipeline.append({"$match": {"$expr": {"$gt": ["$" + path, None]}}})
+            pipeline.append({"$match": {path: {"$exists": True, "$ne": None}}})
 
         pipeline.append({"$count": "count"})
 


### PR DESCRIPTION
## What changes are proposed in this pull request?
Replace one `$expr` operation to its DocDB compatible equivalent. Specifically, replace `{"$match": {"$expr": {"$gt": ["$" + path, None]}}}` with `{"$match": {path: {"$exists": True, "$ne": None}}}`.
They are semantically equivalent as they both check the existence of the field and also making sure the field is not None.

## How is this patch tested? If it is not, please explain why.

pytest all green locally.
The `Build docs / build (pull_request)` failure seems not relevant to this PR.

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
