### PR TITLE
Unit tests for field visibility's disabling field logic

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -16,7 +16,7 @@
         "start": "yarn workspace @fiftyone/app start",
         "start-desktop": "yarn workspace FiftyOne start-desktop",
         "test": "yarn vitest run",
-        "test-ui": "yarn vitest --ui",
+        "test-ui": "yarn vitest --ui --coverage",
         "gen:schema": "strawberry export-schema fiftyone.server.app:schema > schema.graphql"
     },
     "devDependencies": {

--- a/app/packages/state/src/hooks/useSchemaSettings.test.ts
+++ b/app/packages/state/src/hooks/useSchemaSettings.test.ts
@@ -95,7 +95,7 @@ const FIELDS = {
     path: "frames.id",
     ftype: OBJECT_ID_FIELD,
   },
-  FRAME_NUMBER_FIELD: {
+  FRAMES_NUMBER_FIELD: {
     ...BASE_FIELD,
     path: "frames.number",
     ftype: FRAME_NUMBER_FIELD,
@@ -105,6 +105,11 @@ const FIELDS = {
     path: "sample_id",
     ftype: OBJECT_ID_FIELD,
   },
+  FRAME_NUMBER_FIELD: {
+    ...BASE_FIELD,
+    path: "frame_number",
+    ftype: INT_FIELD,
+  },
 };
 
 const BASE_SCHEMA = {
@@ -113,11 +118,12 @@ const BASE_SCHEMA = {
   tags: FIELDS.TAGS_FIELD,
   metadata: FIELDS.METADATA_FIELD,
   [FIELDS.SAMPLE_ID_FIELD.path]: FIELDS.SAMPLE_ID_FIELD,
+  [FIELDS.FRAME_NUMBER_FIELD.path]: FIELDS.FRAME_NUMBER_FIELD,
 };
 
 const FRAME_SCHEMA = {
   [FIELDS.FRAME_ID_FIELD.path]: FIELDS.FRAME_ID_FIELD,
-  [FIELDS.FRAME_NUMBER_FIELD.path]: FIELDS.FRAME_NUMBER_FIELD,
+  [FIELDS.FRAMES_NUMBER_FIELD.path]: FIELDS.FRAMES_NUMBER_FIELD,
 };
 
 const DISABLED_TYPES_SCHEMA = {
@@ -126,9 +132,16 @@ const DISABLED_TYPES_SCHEMA = {
   FrameNumberField: FIELDS.FRAME_NUMBER_TYPE,
   FrameSupportField: FIELDS.FRAME_SUPPORT_TYPE,
   VectorField: FIELDS.VECTOR_TYPE,
-  customEmbeddedDocumentField: FIELDS.CUSTOM_EMBEDDED_DOCUMENT_FIELD,
+  [FIELDS.CUSTOM_EMBEDDED_DOCUMENT_FIELD.path]:
+    FIELDS.CUSTOM_EMBEDDED_DOCUMENT_FIELD,
   [GROUP_DATASET]: FIELDS.GROUP_FIELD,
   [`${GROUP_DATASET}.name`]: FIELDS.GROUP_CHILD_FIELD,
+};
+
+const ALL_SCHEMAS = {
+  ...BASE_SCHEMA,
+  ...DISABLED_TYPES_SCHEMA,
+  ...FRAME_SCHEMA,
 };
 
 describe("Disabled field paths in schema fields", () => {
@@ -213,17 +226,13 @@ describe("Disabled group field in schema fields", () => {
     expect(
       disabledField(
         FIELDS.CUSTOM_EMBEDDED_DOCUMENT_FIELD.path,
-        DISABLED_TYPES_SCHEMA,
-        NOT_GROUP_DATASET
+        ALL_SCHEMAS,
+        NOT_GROUP_DATASET,
+        false
       )
     ).toBe(false);
     expect(
-      disabledField(
-        FIELDS.GROUP_FIELD.path,
-        DISABLED_TYPES_SCHEMA,
-        GROUP_DATASET,
-        false
-      )
+      disabledField(FIELDS.GROUP_FIELD.path, ALL_SCHEMAS, GROUP_DATASET, false)
     ).toBe(true);
   });
 
@@ -244,16 +253,22 @@ describe("Video dataset disabled fields", () => {
 
   it("frames.id field is disabled", () => {
     expect(
-      disabledField(FIELDS.FRAME_ID_FIELD.path, FRAME_SCHEMA, NOT_GROUP_DATASET)
+      disabledField(
+        FIELDS.FRAME_ID_FIELD.path,
+        FRAME_SCHEMA,
+        NOT_GROUP_DATASET,
+        false
+      )
     ).toBe(true);
   });
 
   it("frames.frame_number field is disabled", () => {
     expect(
       disabledField(
-        FIELDS.FRAME_NUMBER_FIELD.path,
+        FIELDS.FRAMES_NUMBER_FIELD.path,
         FRAME_SCHEMA,
-        NOT_GROUP_DATASET
+        NOT_GROUP_DATASET,
+        false
       )
     ).toBe(true);
   });
@@ -270,7 +285,63 @@ describe("Patches view disabled fields", () => {
         FIELDS.SAMPLE_ID_FIELD.path,
         BASE_SCHEMA,
         NOT_GROUP_DATASET,
+        false
+      )
+    ).toBe(true);
+  });
+});
+
+describe("Frames view disabled fields", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("sample_id field is disabled", () => {
+    expect(
+      disabledField(
+        FIELDS.SAMPLE_ID_FIELD.path,
+        BASE_SCHEMA,
+        NOT_GROUP_DATASET,
+        false
+      )
+    ).toBe(true);
+  });
+
+  it("frame_number field is disabled", () => {
+    expect(
+      disabledField(
+        FIELDS.FRAME_NUMBER_FIELD.path,
+        ALL_SCHEMAS,
+        NOT_GROUP_DATASET,
         true
+      )
+    ).toBe(true);
+  });
+});
+
+describe("Clip view disabled fields", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("sample_id field is disabled", () => {
+    expect(
+      disabledField(
+        FIELDS.SAMPLE_ID_FIELD.path,
+        BASE_SCHEMA,
+        NOT_GROUP_DATASET,
+        false
+      )
+    ).toBe(true);
+  });
+
+  it("support field is disabled", () => {
+    expect(
+      disabledField(
+        FIELDS.FRAME_SUPPORT_TYPE.path,
+        ALL_SCHEMAS,
+        NOT_GROUP_DATASET,
+        false
       )
     ).toBe(true);
   });

--- a/app/packages/state/src/hooks/useSchemaSettings.test.ts
+++ b/app/packages/state/src/hooks/useSchemaSettings.test.ts
@@ -33,6 +33,10 @@ import {
   REGRESSION_DISABLED_SUB_PATHS,
   KEYPOINT_DISABLED_SUB_PATHS,
   SEGMENTATION_DISABLED_SUB_PATHS,
+  HEATMAP_DISABLED_SUB_PATHS,
+  TEMPORAL_DETECTION_DISABLED_SUB_PATHS,
+  GEOLOCATION_DISABLED_SUB_PATHS,
+  GEOLOCATIONS_DISABLED_SUB_PATHS,
 } from "@fiftyone/utilities";
 import { FRAME_SUPPORT_FIELD } from "@fiftyone/utilities";
 import { VECTOR_FIELD } from "@fiftyone/utilities";
@@ -603,6 +607,110 @@ describe("label types are disabled fields", () => {
     });
 
     const enabledSubFields = getEnabledNestedLabelFields("segmentation", [
+      "foo",
+      "bar",
+    ]);
+    enabledSubFields.forEach((field) => {
+      SCHEMA[field.path] = field;
+    });
+    enabledSubFields.forEach((field) => {
+      expect(disabledField(field.path, SCHEMA)).toBe(false);
+    });
+  });
+
+  it("Heatmap nested fields that are disabled", () => {
+    SCHEMA = { ...ORIGINAL_SCHEMA };
+    const disabledSubFields = getDisabledNestedLabelFields(
+      "heatmap",
+      HEATMAP_DISABLED_SUB_PATHS
+    );
+    disabledSubFields.forEach((field) => {
+      SCHEMA[field.path] = field;
+    });
+
+    disabledSubFields.forEach((field) => {
+      expect(disabledField(field.path, SCHEMA)).toBe(true);
+    });
+
+    const enabledSubFields = getEnabledNestedLabelFields("heatmap", [
+      "foo",
+      "bar",
+    ]);
+    enabledSubFields.forEach((field) => {
+      SCHEMA[field.path] = field;
+    });
+    enabledSubFields.forEach((field) => {
+      expect(disabledField(field.path, SCHEMA)).toBe(false);
+    });
+  });
+
+  it("TemporalDetection nested fields that are disabled", () => {
+    SCHEMA = { ...ORIGINAL_SCHEMA };
+    const disabledSubFields = getDisabledNestedLabelFields(
+      "temporal",
+      TEMPORAL_DETECTION_DISABLED_SUB_PATHS
+    );
+    disabledSubFields.forEach((field) => {
+      SCHEMA[field.path] = field;
+    });
+
+    disabledSubFields.forEach((field) => {
+      expect(disabledField(field.path, SCHEMA)).toBe(true);
+    });
+
+    const enabledSubFields = getEnabledNestedLabelFields("temporal", [
+      "foo",
+      "bar",
+    ]);
+    enabledSubFields.forEach((field) => {
+      SCHEMA[field.path] = field;
+    });
+    enabledSubFields.forEach((field) => {
+      expect(disabledField(field.path, SCHEMA)).toBe(false);
+    });
+  });
+
+  it("GeoLocation nested fields that are disabled", () => {
+    SCHEMA = { ...ORIGINAL_SCHEMA };
+    const disabledSubFields = getDisabledNestedLabelFields(
+      "geolocation",
+      GEOLOCATION_DISABLED_SUB_PATHS
+    );
+    disabledSubFields.forEach((field) => {
+      SCHEMA[field.path] = field;
+    });
+
+    disabledSubFields.forEach((field) => {
+      expect(disabledField(field.path, SCHEMA)).toBe(true);
+    });
+
+    const enabledSubFields = getEnabledNestedLabelFields("geolocation", [
+      "foo",
+      "bar",
+    ]);
+    enabledSubFields.forEach((field) => {
+      SCHEMA[field.path] = field;
+    });
+    enabledSubFields.forEach((field) => {
+      expect(disabledField(field.path, SCHEMA)).toBe(false);
+    });
+  });
+
+  it("GeoLocations nested fields that are disabled", () => {
+    SCHEMA = { ...ORIGINAL_SCHEMA };
+    const disabledSubFields = getDisabledNestedLabelFields(
+      "geolocations",
+      GEOLOCATIONS_DISABLED_SUB_PATHS
+    );
+    disabledSubFields.forEach((field) => {
+      SCHEMA[field.path] = field;
+    });
+
+    disabledSubFields.forEach((field) => {
+      expect(disabledField(field.path, SCHEMA)).toBe(true);
+    });
+
+    const enabledSubFields = getEnabledNestedLabelFields("geolocations", [
       "foo",
       "bar",
     ]);

--- a/app/packages/state/src/hooks/useSchemaSettings.test.ts
+++ b/app/packages/state/src/hooks/useSchemaSettings.test.ts
@@ -1,34 +1,157 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { disabledField } from "./useSchemaSettings.utils";
-import { OBJECT_ID_FIELD } from "@fiftyone/utilities";
+import {
+  EMBEDDED_DOCUMENT_FIELD,
+  FRAME_NUMBER_FIELD,
+  LIST_FIELD,
+  OBJECT_ID_FIELD,
+  STRING_FIELD,
+} from "@fiftyone/utilities";
+import { FRAME_SUPPORT_FIELD } from "@fiftyone/utilities";
+import { VECTOR_FIELD } from "@fiftyone/utilities";
+
+const BASE_FIELD = {
+  path: null,
+  embeddedDocType: null,
+  ftype: null,
+  description: null,
+  info: null,
+  name: null,
+  fields: null,
+  dbField: null,
+  subfield: null,
+  visible: false,
+};
 
 const FIELDS = {
   ID_FIELD: {
+    ...BASE_FIELD,
     path: "id",
-    embeddedDocType: null,
     ftype: OBJECT_ID_FIELD,
-    description: null,
-    info: null,
-    name: null,
-    fields: null,
-    dbField: null,
-    subfield: null,
-    visible: false,
   },
+  FILEPATH_FIELD: {
+    ...BASE_FIELD,
+    path: "filepath",
+    ftype: STRING_FIELD,
+  },
+  TAGS_FIELD: {
+    ...BASE_FIELD,
+    path: "tags",
+    ftype: LIST_FIELD,
+  },
+  METADATA_FIELD: {
+    ...BASE_FIELD,
+    path: "metadata",
+    ftype: EMBEDDED_DOCUMENT_FIELD,
+  },
+  OBJECT_ID_TYPE: {
+    ...BASE_FIELD,
+    path: "ObjectIdType",
+    ftype: OBJECT_ID_FIELD,
+  },
+  FRAME_NUMBER_TYPE: {
+    ...BASE_FIELD,
+    path: "FrameNumberField",
+    ftype: FRAME_NUMBER_FIELD,
+  },
+  FRAME_SUPPORT_TYPE: {
+    ...BASE_FIELD,
+    path: "FrameSupportField",
+    ftype: FRAME_SUPPORT_FIELD,
+  },
+  VECTOR_TYPE: {
+    ...BASE_FIELD,
+    path: "VectorField",
+    ftype: VECTOR_FIELD,
+  },
+};
+
+const BASE_SCHEMA = {
+  id: FIELDS.ID_FIELD,
+  filepath: FIELDS.FILEPATH_FIELD,
+  tags: FIELDS.TAGS_FIELD,
+  metadata: FIELDS.METADATA_FIELD,
+};
+
+const DISABLED_TYPES_SCHEMA = {
+  ...BASE_SCHEMA,
+  ObjectIdType: FIELDS.OBJECT_ID_TYPE,
+  FrameNumberField: FIELDS.FRAME_NUMBER_TYPE,
+  FrameSupportField: FIELDS.FRAME_SUPPORT_TYPE,
+  VectorField: FIELDS.VECTOR_TYPE,
 };
 
 const GROUP_DATASET = "group";
 const NOT_GROUP_DATASET = "";
 
-describe("Disabled schema fields", () => {
+describe("Disabled field paths in schema fields", () => {
   afterEach(() => {
     vi.restoreAllMocks();
   });
 
   it("id path is disabled across all fields", () => {
     const path = "id";
-    const field_1 = FIELDS.ID_FIELD;
-    const schema = { id: field_1 };
+    const schema = BASE_SCHEMA;
+
+    expect(disabledField(path, schema, NOT_GROUP_DATASET)).toBe(true);
+  });
+
+  it("filepath path is disabled across all fields", () => {
+    const path = FIELDS.FILEPATH_FIELD.path;
+    const schema = BASE_SCHEMA;
+
+    expect(disabledField(path, schema, NOT_GROUP_DATASET)).toBe(true);
+  });
+
+  it("tags path is disabled across all fields", () => {
+    const path = FIELDS.TAGS_FIELD.path;
+    const schema = BASE_SCHEMA;
+
+    expect(disabledField(path, schema, NOT_GROUP_DATASET)).toBe(true);
+  });
+
+  it("metadata path is disabled across all fields", () => {
+    const path = FIELDS.METADATA_FIELD.path;
+    const schema = BASE_SCHEMA;
+
+    expect(disabledField(path, schema, NOT_GROUP_DATASET)).toBe(true);
+  });
+
+  it("all disabled paths are also disabled when prefixed with 'frames.'", () => {
+    // TODO
+    expect("TODO: double check with team wether this is needed");
+  });
+});
+
+describe("Disabled field types in schema fields", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("ObjectIdField type is disabled across all fields", () => {
+    const path = FIELDS.OBJECT_ID_TYPE.path;
+    const schema = DISABLED_TYPES_SCHEMA;
+
+    expect(disabledField(path, schema, NOT_GROUP_DATASET)).toBe(true);
+  });
+
+  it("FrameNumberField type is disabled across all fields", () => {
+    const path = FIELDS.FRAME_NUMBER_TYPE.path;
+    const schema = DISABLED_TYPES_SCHEMA;
+
+    expect(disabledField(path, schema, NOT_GROUP_DATASET)).toBe(true);
+  });
+
+  it("FrameSupportField type is disabled across all fields", () => {
+    const path = FIELDS.FRAME_SUPPORT_TYPE.path;
+    const schema = DISABLED_TYPES_SCHEMA;
+
+    expect(disabledField(path, schema, NOT_GROUP_DATASET)).toBe(true);
+  });
+
+  it("VectorField type is disabled across all fields", () => {
+    const path = FIELDS.VECTOR_TYPE.path;
+    const schema = DISABLED_TYPES_SCHEMA;
 
     expect(disabledField(path, schema, NOT_GROUP_DATASET)).toBe(true);
   });

--- a/app/packages/state/src/hooks/useSchemaSettings.test.ts
+++ b/app/packages/state/src/hooks/useSchemaSettings.test.ts
@@ -7,8 +7,6 @@ import {
   DETECTIONS_FIELD,
   DETECTION_DISABLED_SUB_PATHS,
   DETECTION_FIELD,
-  DYNAMIC_EMBEDDED_DOCUMENT_FIELD,
-  DYNAMIC_EMBEDDED_DOCUMENT_FIELD_V2,
   EMBEDDED_DOCUMENT_FIELD,
   FLOAT_FIELD,
   FRAME_NUMBER_FIELD,
@@ -25,8 +23,6 @@ import {
   REGRESSION_FIELD,
   SEGMENTATION_FIELD,
   STRING_FIELD,
-  TEMPORAL_DETECTION,
-  TEMPORAL_DETECTIONS,
   TEMPORAL_DETECTIONS_FIELD,
   TEMPORAL_DETECTION_FIELD,
   CLASSIFICATION_DISABLED_SUB_PATHS,
@@ -37,6 +33,7 @@ import {
   TEMPORAL_DETECTION_DISABLED_SUB_PATHS,
   GEOLOCATION_DISABLED_SUB_PATHS,
   GEOLOCATIONS_DISABLED_SUB_PATHS,
+  KEYPOINTS_FIELD,
 } from "@fiftyone/utilities";
 import { FRAME_SUPPORT_FIELD } from "@fiftyone/utilities";
 import { VECTOR_FIELD } from "@fiftyone/utilities";
@@ -167,6 +164,11 @@ const FIELDS = {
     ...BASE_FIELD,
     path: "keypoint",
     ftype: KEYPOINT_FIELD,
+  },
+  KEYPOINTS_FIELD: {
+    ...BASE_FIELD,
+    path: "keypoints",
+    ftype: KEYPOINTS_FIELD,
   },
   REGRESSION_FIELD: {
     ...BASE_FIELD,
@@ -446,6 +448,7 @@ describe("label types are disabled fields", () => {
     expect(disabledField(FIELDS.CLASSIFICATION_FIELD.path, SCHEMA)).toBe(true);
     expect(disabledField(FIELDS.CLASSIFICATIONS_FIELD.path, SCHEMA)).toBe(true);
     expect(disabledField(FIELDS.KEYPOINT_FIELD.path, SCHEMA)).toBe(true);
+    expect(disabledField(FIELDS.KEYPOINTS_FIELD.path, SCHEMA)).toBe(true);
     expect(disabledField(FIELDS.TEMPORAL_DETECTION_FIELD.path, SCHEMA)).toBe(
       true
     );

--- a/app/packages/state/src/hooks/useSchemaSettings.test.ts
+++ b/app/packages/state/src/hooks/useSchemaSettings.test.ts
@@ -92,13 +92,18 @@ const FIELDS = {
   },
   FRAME_ID_FIELD: {
     ...BASE_FIELD,
-    Path: "frames.id",
+    path: "frames.id",
     ftype: OBJECT_ID_FIELD,
   },
   FRAME_NUMBER_FIELD: {
     ...BASE_FIELD,
-    Path: "frames.number",
-    ftype: INT_FIELD,
+    path: "frames.number",
+    ftype: FRAME_NUMBER_FIELD,
+  },
+  SAMPLE_ID_FIELD: {
+    ...BASE_FIELD,
+    path: "sample_id",
+    ftype: OBJECT_ID_FIELD,
   },
 };
 
@@ -107,20 +112,23 @@ const BASE_SCHEMA = {
   filepath: FIELDS.FILEPATH_FIELD,
   tags: FIELDS.TAGS_FIELD,
   metadata: FIELDS.METADATA_FIELD,
+  [FIELDS.SAMPLE_ID_FIELD.path]: FIELDS.SAMPLE_ID_FIELD,
 };
 
 const FRAME_SCHEMA = {
-  id: FIELDS.ID_FIELD,
-  frame_number: FIELDS.FRAME_NUMBER_FIELD,
+  [FIELDS.FRAME_ID_FIELD.path]: FIELDS.FRAME_ID_FIELD,
+  [FIELDS.FRAME_NUMBER_FIELD.path]: FIELDS.FRAME_NUMBER_FIELD,
 };
 
 const DISABLED_TYPES_SCHEMA = {
   ...BASE_SCHEMA,
-  ObjectIdType: FIELDS.OBJECT_ID_TYPE,
+  ObjectIdType: FIELDS.ID_FIELD,
   FrameNumberField: FIELDS.FRAME_NUMBER_TYPE,
   FrameSupportField: FIELDS.FRAME_SUPPORT_TYPE,
   VectorField: FIELDS.VECTOR_TYPE,
   customEmbeddedDocumentField: FIELDS.CUSTOM_EMBEDDED_DOCUMENT_FIELD,
+  [GROUP_DATASET]: FIELDS.GROUP_FIELD,
+  [`${GROUP_DATASET}.name`]: FIELDS.GROUP_CHILD_FIELD,
 };
 
 describe("Disabled field paths in schema fields", () => {
@@ -211,9 +219,10 @@ describe("Disabled group field in schema fields", () => {
     ).toBe(false);
     expect(
       disabledField(
-        FIELDS.CUSTOM_EMBEDDED_DOCUMENT_FIELD.path,
+        FIELDS.GROUP_FIELD.path,
         DISABLED_TYPES_SCHEMA,
-        GROUP_DATASET
+        GROUP_DATASET,
+        false
       )
     ).toBe(true);
   });
@@ -245,6 +254,23 @@ describe("Video dataset disabled fields", () => {
         FIELDS.FRAME_NUMBER_FIELD.path,
         FRAME_SCHEMA,
         NOT_GROUP_DATASET
+      )
+    ).toBe(true);
+  });
+});
+
+describe("Patches view disabled fields", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("sample_id field is disabled", () => {
+    expect(
+      disabledField(
+        FIELDS.SAMPLE_ID_FIELD.path,
+        BASE_SCHEMA,
+        NOT_GROUP_DATASET,
+        true
       )
     ).toBe(true);
   });

--- a/app/packages/state/src/hooks/useSchemaSettings.test.ts
+++ b/app/packages/state/src/hooks/useSchemaSettings.test.ts
@@ -1,14 +1,31 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { disabledField } from "./useSchemaSettings.utils";
 import {
+  CLASSIFICATIONS_FIELD,
+  CLASSIFICATION_FIELD,
+  DETECTIONS_FIELD,
+  DETECTION_FIELD,
   DYNAMIC_EMBEDDED_DOCUMENT_FIELD,
   DYNAMIC_EMBEDDED_DOCUMENT_FIELD_V2,
   EMBEDDED_DOCUMENT_FIELD,
+  FLOAT_FIELD,
   FRAME_NUMBER_FIELD,
+  GEO_LOCATIONS_FIELD,
+  GEO_LOCATION_FIELD,
+  HEATMAP_FIELD,
   INT_FIELD,
+  KEYPOINT_FIELD,
   LIST_FIELD,
   OBJECT_ID_FIELD,
+  POLYLINES_FIELD,
+  POLYLINE_FIELD,
+  REGRESSION_FIELD,
+  SEGMENTATION_FIELD,
   STRING_FIELD,
+  TEMPORAL_DETECTION,
+  TEMPORAL_DETECTIONS,
+  TEMPORAL_DETECTIONS_FIELD,
+  TEMPORAL_DETECTION_FIELD,
 } from "@fiftyone/utilities";
 import { FRAME_SUPPORT_FIELD } from "@fiftyone/utilities";
 import { VECTOR_FIELD } from "@fiftyone/utilities";
@@ -110,39 +127,107 @@ const FIELDS = {
     path: "frame_number",
     ftype: INT_FIELD,
   },
+  METADATA_WIDTH_FIELD: {
+    ...BASE_FIELD,
+    path: "metadata.width",
+    ftype: FLOAT_FIELD,
+  },
+  DETECTION_FIELD: {
+    ...BASE_FIELD,
+    path: "detection",
+    ftype: DETECTION_FIELD,
+  },
+  DETECTIONS_FIELD: {
+    ...BASE_FIELD,
+    path: "detections",
+    ftype: DETECTIONS_FIELD,
+  },
+  CLASSIFICATION_FIELD: {
+    ...BASE_FIELD,
+    path: "classification",
+    ftype: CLASSIFICATION_FIELD,
+  },
+  CLASSIFICATIONS_FIELD: {
+    ...BASE_FIELD,
+    path: "classifications",
+    ftype: CLASSIFICATIONS_FIELD,
+  },
+  KEYPOINT_FIELD: {
+    ...BASE_FIELD,
+    path: "keypoint",
+    ftype: KEYPOINT_FIELD,
+  },
+  REGRESSION_FIELD: {
+    ...BASE_FIELD,
+    path: "regression",
+    ftype: REGRESSION_FIELD,
+  },
+  HEATMAP_FIELD: {
+    ...BASE_FIELD,
+    path: "heatmap",
+    ftype: HEATMAP_FIELD,
+  },
+  SEGMENTATION_FIELD: {
+    ...BASE_FIELD,
+    path: "segmentation",
+    ftype: SEGMENTATION_FIELD,
+  },
+  GEO_LOCATION_FIELD: {
+    ...BASE_FIELD,
+    path: "geolocation",
+    ftype: GEO_LOCATION_FIELD,
+  },
+  GEO_LOCATIONS_FIELD: {
+    ...BASE_FIELD,
+    path: "geolocations",
+    ftype: GEO_LOCATIONS_FIELD,
+  },
+  POLYLINE_FIELD: {
+    ...BASE_FIELD,
+    path: "polyline",
+    ftype: POLYLINE_FIELD,
+  },
+  POLYLINES_FIELD: {
+    ...BASE_FIELD,
+    path: "polylines",
+    ftype: POLYLINES_FIELD,
+  },
+  TEMPORAL_DETECTION_FIELD: {
+    ...BASE_FIELD,
+    path: "temporal",
+    ftype: TEMPORAL_DETECTION_FIELD,
+  },
+  TEMPORAL_DETECTIONS_FIELD: {
+    ...BASE_FIELD,
+    path: "temporals",
+    ftype: TEMPORAL_DETECTIONS_FIELD,
+  },
 };
 
-const BASE_SCHEMA = {
-  id: FIELDS.ID_FIELD,
-  filepath: FIELDS.FILEPATH_FIELD,
-  tags: FIELDS.TAGS_FIELD,
-  metadata: FIELDS.METADATA_FIELD,
-  [FIELDS.SAMPLE_ID_FIELD.path]: FIELDS.SAMPLE_ID_FIELD,
-  [FIELDS.FRAME_NUMBER_FIELD.path]: FIELDS.FRAME_NUMBER_FIELD,
-};
+const SCHEMA = {};
+Object.values(FIELDS).forEach((f) => {
+  SCHEMA[f.path] = f;
+});
 
-const FRAME_SCHEMA = {
-  [FIELDS.FRAME_ID_FIELD.path]: FIELDS.FRAME_ID_FIELD,
-  [FIELDS.FRAMES_NUMBER_FIELD.path]: FIELDS.FRAMES_NUMBER_FIELD,
-};
+// const SCHEMA = {
+//   id: FIELDS.ID_FIELD,
+//   filepath: FIELDS.FILEPATH_FIELD,
+//   tags: FIELDS.TAGS_FIELD,
+//   metadata: FIELDS.METADATA_FIELD,
+//   [FIELDS.SAMPLE_ID_FIELD.path]: FIELDS.SAMPLE_ID_FIELD,
+//   [FIELDS.FRAME_NUMBER_FIELD.path]: FIELDS.FRAME_NUMBER_FIELD,
+//   [FIELDS.FRAME_ID_FIELD.path]: FIELDS.FRAME_ID_FIELD,
+//   [FIELDS.FRAMES_NUMBER_FIELD.path]: FIELDS.FRAMES_NUMBER_FIELD,
+//   ObjectIdType: FIELDS.ID_FIELD,
+//   FrameNumberField: FIELDS.FRAME_NUMBER_TYPE,
+//   FrameSupportField: FIELDS.FRAME_SUPPORT_TYPE,
+//   VectorField: FIELDS.VECTOR_TYPE,
+//   [FIELDS.CUSTOM_EMBEDDED_DOCUMENT_FIELD.path]:
+//     FIELDS.CUSTOM_EMBEDDED_DOCUMENT_FIELD,
+//   [GROUP_DATASET]: FIELDS.GROUP_FIELD,
+//   [`${GROUP_DATASET}.name`]: FIELDS.GROUP_CHILD_FIELD,
 
-const DISABLED_TYPES_SCHEMA = {
-  ...BASE_SCHEMA,
-  ObjectIdType: FIELDS.ID_FIELD,
-  FrameNumberField: FIELDS.FRAME_NUMBER_TYPE,
-  FrameSupportField: FIELDS.FRAME_SUPPORT_TYPE,
-  VectorField: FIELDS.VECTOR_TYPE,
-  [FIELDS.CUSTOM_EMBEDDED_DOCUMENT_FIELD.path]:
-    FIELDS.CUSTOM_EMBEDDED_DOCUMENT_FIELD,
-  [GROUP_DATASET]: FIELDS.GROUP_FIELD,
-  [`${GROUP_DATASET}.name`]: FIELDS.GROUP_CHILD_FIELD,
-};
-
-const ALL_SCHEMAS = {
-  ...BASE_SCHEMA,
-  ...DISABLED_TYPES_SCHEMA,
-  ...FRAME_SCHEMA,
-};
+// };
 
 describe("Disabled field paths in schema fields", () => {
   afterEach(() => {
@@ -150,36 +235,19 @@ describe("Disabled field paths in schema fields", () => {
   });
 
   it("id path is disabled across all fields", () => {
-    const path = "id";
-    const schema = BASE_SCHEMA;
-
-    expect(disabledField(path, schema, NOT_GROUP_DATASET)).toBe(true);
+    expect(disabledField("id", SCHEMA, NOT_GROUP_DATASET)).toBe(true);
   });
 
   it("filepath path is disabled across all fields", () => {
-    const path = FIELDS.FILEPATH_FIELD.path;
-    const schema = BASE_SCHEMA;
-
-    expect(disabledField(path, schema, NOT_GROUP_DATASET)).toBe(true);
+    expect(disabledField(FIELDS.FILEPATH_FIELD.path, SCHEMA, "")).toBe(true);
   });
 
   it("tags path is disabled across all fields", () => {
-    const path = FIELDS.TAGS_FIELD.path;
-    const schema = BASE_SCHEMA;
-
-    expect(disabledField(path, schema, NOT_GROUP_DATASET)).toBe(true);
+    expect(disabledField(FIELDS.TAGS_FIELD.path, SCHEMA, "")).toBe(true);
   });
 
   it("metadata path is disabled across all fields", () => {
-    const path = FIELDS.METADATA_FIELD.path;
-    const schema = BASE_SCHEMA;
-
-    expect(disabledField(path, schema, NOT_GROUP_DATASET)).toBe(true);
-  });
-
-  it("all disabled paths are also disabled when prefixed with 'frames.'", () => {
-    // TODO
-    expect("TODO: double check with team wether this is needed");
+    expect(disabledField(FIELDS.METADATA_FIELD.path, SCHEMA, "")).toBe(true);
   });
 });
 
@@ -189,31 +257,25 @@ describe("Disabled field types in schema fields", () => {
   });
 
   it("ObjectIdField type is disabled across all fields", () => {
-    const path = FIELDS.OBJECT_ID_TYPE.path;
-    const schema = DISABLED_TYPES_SCHEMA;
-
-    expect(disabledField(path, schema, NOT_GROUP_DATASET)).toBe(true);
+    expect(disabledField(FIELDS.OBJECT_ID_TYPE.path, SCHEMA, "")).toBe(true);
   });
 
   it("FrameNumberField type is disabled across all fields", () => {
-    const path = FIELDS.FRAME_NUMBER_TYPE.path;
-    const schema = DISABLED_TYPES_SCHEMA;
-
-    expect(disabledField(path, schema, NOT_GROUP_DATASET)).toBe(true);
+    expect(
+      disabledField(FIELDS.FRAME_NUMBER_TYPE.path, SCHEMA, NOT_GROUP_DATASET)
+    ).toBe(true);
   });
 
   it("FrameSupportField type is disabled across all fields", () => {
-    const path = FIELDS.FRAME_SUPPORT_TYPE.path;
-    const schema = DISABLED_TYPES_SCHEMA;
-
-    expect(disabledField(path, schema, NOT_GROUP_DATASET)).toBe(true);
+    expect(
+      disabledField(FIELDS.FRAME_SUPPORT_TYPE.path, SCHEMA, NOT_GROUP_DATASET)
+    ).toBe(true);
   });
 
   it("VectorField type is disabled across all fields", () => {
-    const path = FIELDS.VECTOR_TYPE.path;
-    const schema = DISABLED_TYPES_SCHEMA;
-
-    expect(disabledField(path, schema, NOT_GROUP_DATASET)).toBe(true);
+    expect(
+      disabledField(FIELDS.VECTOR_TYPE.path, SCHEMA, NOT_GROUP_DATASET)
+    ).toBe(true);
   });
 });
 
@@ -226,23 +288,22 @@ describe("Disabled group field in schema fields", () => {
     expect(
       disabledField(
         FIELDS.CUSTOM_EMBEDDED_DOCUMENT_FIELD.path,
-        ALL_SCHEMAS,
+        SCHEMA,
         NOT_GROUP_DATASET,
         false
       )
     ).toBe(false);
     expect(
-      disabledField(FIELDS.GROUP_FIELD.path, ALL_SCHEMAS, GROUP_DATASET, false)
+      disabledField(FIELDS.GROUP_FIELD.path, SCHEMA, GROUP_DATASET, false)
     ).toBe(true);
   });
 
   it("field with parent group is disabled", () => {
     const parentPath = FIELDS.GROUP_FIELD.path;
     const path = FIELDS.GROUP_CHILD_FIELD.path;
-    const schema = DISABLED_TYPES_SCHEMA;
 
-    expect(disabledField(parentPath, schema, GROUP_DATASET)).toBe(true);
-    expect(disabledField(path, schema, GROUP_DATASET)).toBe(true);
+    expect(disabledField(parentPath, SCHEMA, GROUP_DATASET)).toBe(true);
+    expect(disabledField(path, SCHEMA, GROUP_DATASET)).toBe(true);
   });
 });
 
@@ -253,23 +314,13 @@ describe("Video dataset disabled fields", () => {
 
   it("frames.id field is disabled", () => {
     expect(
-      disabledField(
-        FIELDS.FRAME_ID_FIELD.path,
-        FRAME_SCHEMA,
-        NOT_GROUP_DATASET,
-        false
-      )
+      disabledField(FIELDS.FRAME_ID_FIELD.path, SCHEMA, NOT_GROUP_DATASET)
     ).toBe(true);
   });
 
   it("frames.frame_number field is disabled", () => {
     expect(
-      disabledField(
-        FIELDS.FRAMES_NUMBER_FIELD.path,
-        FRAME_SCHEMA,
-        NOT_GROUP_DATASET,
-        false
-      )
+      disabledField(FIELDS.FRAMES_NUMBER_FIELD.path, SCHEMA, NOT_GROUP_DATASET)
     ).toBe(true);
   });
 });
@@ -281,12 +332,7 @@ describe("Patches view disabled fields", () => {
 
   it("sample_id field is disabled", () => {
     expect(
-      disabledField(
-        FIELDS.SAMPLE_ID_FIELD.path,
-        BASE_SCHEMA,
-        NOT_GROUP_DATASET,
-        false
-      )
+      disabledField(FIELDS.SAMPLE_ID_FIELD.path, SCHEMA, NOT_GROUP_DATASET)
     ).toBe(true);
   });
 });
@@ -298,12 +344,7 @@ describe("Frames view disabled fields", () => {
 
   it("sample_id field is disabled", () => {
     expect(
-      disabledField(
-        FIELDS.SAMPLE_ID_FIELD.path,
-        BASE_SCHEMA,
-        NOT_GROUP_DATASET,
-        false
-      )
+      disabledField(FIELDS.SAMPLE_ID_FIELD.path, SCHEMA, NOT_GROUP_DATASET)
     ).toBe(true);
   });
 
@@ -311,7 +352,7 @@ describe("Frames view disabled fields", () => {
     expect(
       disabledField(
         FIELDS.FRAME_NUMBER_FIELD.path,
-        ALL_SCHEMAS,
+        SCHEMA,
         NOT_GROUP_DATASET,
         true
       )
@@ -326,23 +367,68 @@ describe("Clip view disabled fields", () => {
 
   it("sample_id field is disabled", () => {
     expect(
-      disabledField(
-        FIELDS.SAMPLE_ID_FIELD.path,
-        BASE_SCHEMA,
-        NOT_GROUP_DATASET,
-        false
-      )
+      disabledField(FIELDS.SAMPLE_ID_FIELD.path, SCHEMA, NOT_GROUP_DATASET)
     ).toBe(true);
   });
 
   it("support field is disabled", () => {
     expect(
-      disabledField(
-        FIELDS.FRAME_SUPPORT_TYPE.path,
-        ALL_SCHEMAS,
-        NOT_GROUP_DATASET,
-        false
-      )
+      disabledField(FIELDS.FRAME_SUPPORT_TYPE.path, SCHEMA, NOT_GROUP_DATASET)
     ).toBe(true);
+  });
+});
+
+describe("metadata and its children are disabled fields", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("metadata field is disabled", () => {
+    expect(
+      disabledField(FIELDS.METADATA_FIELD.path, SCHEMA, NOT_GROUP_DATASET)
+    ).toBe(true);
+  });
+
+  it("metadata's subpaths are disabled", () => {
+    expect(
+      disabledField(FIELDS.METADATA_WIDTH_FIELD.path, SCHEMA, NOT_GROUP_DATASET)
+    ).toBe(true);
+  });
+});
+
+describe("label types are disabled fields", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("LABEL fields are disabled", () => {
+    expect(disabledField(FIELDS.DETECTION_FIELD.path, SCHEMA, "")).toBe(true);
+    expect(disabledField(FIELDS.DETECTIONS_FIELD.path, SCHEMA, "")).toBe(true);
+    expect(disabledField(FIELDS.CLASSIFICATION_FIELD.path, SCHEMA, "")).toBe(
+      true
+    );
+    expect(disabledField(FIELDS.CLASSIFICATIONS_FIELD.path, SCHEMA, "")).toBe(
+      true
+    );
+    expect(disabledField(FIELDS.KEYPOINT_FIELD.path, SCHEMA, "")).toBe(true);
+    expect(
+      disabledField(FIELDS.TEMPORAL_DETECTION_FIELD.path, SCHEMA, "")
+    ).toBe(true);
+    expect(
+      disabledField(FIELDS.TEMPORAL_DETECTIONS_FIELD.path, SCHEMA, "")
+    ).toBe(true);
+    expect(disabledField(FIELDS.REGRESSION_FIELD.path, SCHEMA, "")).toBe(true);
+    expect(disabledField(FIELDS.HEATMAP_FIELD.path, SCHEMA, "")).toBe(true);
+    expect(disabledField(FIELDS.SEGMENTATION_FIELD.path, SCHEMA, "")).toBe(
+      true
+    );
+    expect(disabledField(FIELDS.GEO_LOCATION_FIELD.path, SCHEMA, "")).toBe(
+      true
+    );
+    expect(disabledField(FIELDS.GEO_LOCATIONS_FIELD.path, SCHEMA, "")).toBe(
+      true
+    );
+    expect(disabledField(FIELDS.POLYLINE_FIELD.path, SCHEMA, "")).toBe(true);
+    expect(disabledField(FIELDS.POLYLINES_FIELD.path, SCHEMA, "")).toBe(true);
   });
 });

--- a/app/packages/state/src/hooks/useSchemaSettings.test.ts
+++ b/app/packages/state/src/hooks/useSchemaSettings.test.ts
@@ -70,6 +70,11 @@ const FIELDS = {
     path: "tags",
     ftype: LIST_FIELD,
   },
+  CUSTOM_LIST_FIELD: {
+    ...BASE_FIELD,
+    path: "custom_list",
+    ftype: LIST_FIELD,
+  },
   METADATA_FIELD: {
     ...BASE_FIELD,
     path: "metadata",
@@ -164,6 +169,12 @@ const FIELDS = {
     ...BASE_FIELD,
     path: "detections",
     ftype: DETECTIONS_FIELD,
+  },
+  DETECTIONS_LIST_FIELD: {
+    ...BASE_FIELD,
+    path: "detections",
+    ftype: LIST_FIELD,
+    embeddedDocType: DETECTIONS_FIELD,
   },
   CLASSIFICATION_FIELD: {
     ...BASE_FIELD,
@@ -856,5 +867,27 @@ describe("Label fields that are disabled", () => {
     enabledSubFields.forEach((field) => {
       expect(disabledField(field.path, SCHEMA)).toBe(false);
     });
+  });
+});
+
+describe("List of labels", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("List of labels are disabled", () => {
+    expect(
+      disabledField(
+        FIELDS.DETECTIONS_LIST_FIELD.path,
+        SCHEMA,
+        NOT_GROUP_DATASET
+      )
+    ).toBe(true);
+  });
+
+  it("List of non-labels are enabled", () => {
+    expect(
+      disabledField(FIELDS.CUSTOM_LIST_FIELD.path, SCHEMA, NOT_GROUP_DATASET)
+    ).toBe(false);
   });
 });

--- a/app/packages/state/src/hooks/useSchemaSettings.test.ts
+++ b/app/packages/state/src/hooks/useSchemaSettings.test.ts
@@ -799,8 +799,6 @@ describe("Label fields that are disabled", () => {
       SCHEMA[field.path] = field;
     });
 
-    console.log("disabledSubFields", disabledSubFields);
-
     disabledSubFields.forEach((field) => {
       expect(disabledField(field.path, SCHEMA)).toBe(true);
     });

--- a/app/packages/state/src/hooks/useSchemaSettings.ts
+++ b/app/packages/state/src/hooks/useSchemaSettings.ts
@@ -173,7 +173,9 @@ export const excludedPathsState = atomFamily({
         const dataset = await getPromise(fos.dataset);
         const showNestedField = await getPromise(showNestedFieldsState);
         const searchResults = await getPromise(schemaSearchRestuls);
-        const isFrameVIew = await getPromise(fos.isFramesView);
+        const isFrameView = await getPromise(fos.isFramesView);
+        const isClipsView = await getPromise(fos.isClipsView);
+        const isPatchesView = await getPromise(fos.isPatchesView);
         const isVideo = dataset.mediaType === "video";
         const isImage = dataset.mediaType === "image";
         const isInSearchMode = !!searchResults?.length;
@@ -210,7 +212,10 @@ export const excludedPathsState = atomFamily({
                 path,
                 combinedSchema,
                 dataset?.groupField,
-                isFrameVIew
+                isFrameView,
+                isClipsView,
+                isVideo,
+                isPatchesView
               )
             );
           })
@@ -425,6 +430,7 @@ export default function useSchemaSettings() {
 
   const isPatchesView = useRecoilValue(fos.isPatchesView);
   const isFrameView = useRecoilValue(fos.isFramesView);
+  const isClipsView = useRecoilValue(fos.isClipsView);
 
   const [expandedPaths, setExpandedPaths] = useRecoilState(expandedPathsState);
 
@@ -486,7 +492,15 @@ export default function useSchemaSettings() {
       ? [...datasetSelectedPaths]?.filter(
           ({ path }) =>
             path &&
-            !disabledField(path, combinedSchema, isGroupDataset, isFrameView)
+            !disabledField(
+              path,
+              combinedSchema,
+              isGroupDataset,
+              isFrameView,
+              isClipsView,
+              isVideo,
+              isPatchesView
+            )
         )
       : [];
 
@@ -565,7 +579,10 @@ export default function useSchemaSettings() {
             path,
             finalSchemaKeyByPath,
             isGroupDataset,
-            isFrameView
+            isFrameView,
+            isClipsView,
+            isVideo,
+            isPatchesView
           ) || filterRuleTab;
 
         const fullPath =
@@ -628,6 +645,9 @@ export default function useSchemaSettings() {
     datasetName,
     fieldSchema,
     includeNestedFields,
+    isPatchesView,
+    isClipsView,
+    isVideo,
   ]);
 
   const [searchSchemaFieldsRaw] = useMutation<foq.searchSelectFieldsMutation>(
@@ -836,7 +856,15 @@ export default function useSchemaSettings() {
         }
         const res = Object.values(combinedSchema)
           .filter((f) =>
-            disabledField(f.path, combinedSchema, isGroupDataset, isFrameView)
+            disabledField(
+              f.path,
+              combinedSchema,
+              isGroupDataset,
+              isFrameView,
+              isClipsView,
+              isVideo,
+              isPatchesView
+            )
           )
           .map((f) => f.path);
 
@@ -858,6 +886,8 @@ export default function useSchemaSettings() {
     filterRuleTab,
     combinedSchema,
     isPatchesView,
+    isClipsView,
+    isVideo,
   ]);
 
   const setAllFieldsCheckedWrapper = useCallback(

--- a/app/packages/state/src/hooks/useSchemaSettings.ts
+++ b/app/packages/state/src/hooks/useSchemaSettings.ts
@@ -486,9 +486,10 @@ export default function useSchemaSettings() {
     selectedPathState
   );
   // disabled paths are filtered
-  const datasetSelectedPaths = selectedPaths[datasetName] || new Set();
-  const enabledSelectedPaths =
-    datasetSelectedPaths?.size && combinedSchema
+  const enabledSelectedPaths = useMemo(() => {
+    const datasetSelectedPaths = selectedPaths[datasetName] || new Set();
+
+    return datasetSelectedPaths?.size && combinedSchema
       ? [...datasetSelectedPaths]?.filter(
           ({ path }) =>
             path &&
@@ -503,6 +504,16 @@ export default function useSchemaSettings() {
             )
         )
       : [];
+  }, [
+    combinedSchema,
+    datasetName,
+    isClipsView,
+    isFrameView,
+    isGroupDataset,
+    isPatchesView,
+    isVideo,
+    selectedPaths,
+  ]);
 
   const excludePathsState = excludedPathsState({});
   const [excludedPaths, setExcludedPaths] = useRecoilState<{}>(

--- a/app/packages/state/src/hooks/useSchemaSettings.ts
+++ b/app/packages/state/src/hooks/useSchemaSettings.ts
@@ -173,6 +173,7 @@ export const excludedPathsState = atomFamily({
         const dataset = await getPromise(fos.dataset);
         const showNestedField = await getPromise(showNestedFieldsState);
         const searchResults = await getPromise(schemaSearchRestuls);
+        const isPatchesView = await getPromise(fos.isPatchesView);
         const isVideo = dataset.mediaType === "video";
         const isImage = dataset.mediaType === "image";
         const isInSearchMode = !!searchResults?.length;
@@ -205,7 +206,12 @@ export const excludedPathsState = atomFamily({
                 combinedSchema?.[rawPath]?.ftype,
                 combinedSchema
               ) &&
-              !disabledField(path, combinedSchema, dataset?.groupField)
+              !disabledField(
+                path,
+                combinedSchema,
+                dataset?.groupField,
+                isPatchesView
+              )
             );
           })
           .map((path) => mapping?.[path] || path);
@@ -417,6 +423,8 @@ export default function useSchemaSettings() {
     searchMetaFilterState
   );
 
+  const isPatchesView = useRecoilValue(fos.isPatchesView);
+
   const [expandedPaths, setExpandedPaths] = useRecoilState(expandedPathsState);
 
   const [lastActionToggleSelection, setLastActionToggleSelection] =
@@ -476,7 +484,8 @@ export default function useSchemaSettings() {
     datasetSelectedPaths?.size && combinedSchema
       ? [...datasetSelectedPaths]?.filter(
           ({ path }) =>
-            path && !disabledField(path, combinedSchema, isGroupDataset)
+            path &&
+            !disabledField(path, combinedSchema, isGroupDataset, isPatchesView)
         )
       : [];
 
@@ -551,8 +560,12 @@ export default function useSchemaSettings() {
         const ftype = finalSchemaKeyByPath[path].ftype;
         const skip = skipField(path, ftype, finalSchemaKeyByPath);
         const disabled =
-          disabledField(path, finalSchemaKeyByPath, isGroupDataset) ||
-          filterRuleTab;
+          disabledField(
+            path,
+            finalSchemaKeyByPath,
+            isGroupDataset,
+            isPatchesView
+          ) || filterRuleTab;
 
         const fullPath =
           isVideo && viewSchema?.[path] ? `frames.${path}` : path;
@@ -821,7 +834,9 @@ export default function useSchemaSettings() {
           setExcludedPaths({ [datasetName]: new Set(topLevelPaths) });
         }
         const res = Object.values(combinedSchema)
-          .filter((f) => disabledField(f.path, combinedSchema, isGroupDataset))
+          .filter((f) =>
+            disabledField(f.path, combinedSchema, isGroupDataset, isPatchesView)
+          )
           .map((f) => f.path);
 
         setSelectedPaths({
@@ -841,6 +856,7 @@ export default function useSchemaSettings() {
     includeNestedFields,
     filterRuleTab,
     combinedSchema,
+    isPatchesView,
   ]);
 
   const setAllFieldsCheckedWrapper = useCallback(

--- a/app/packages/state/src/hooks/useSchemaSettings.ts
+++ b/app/packages/state/src/hooks/useSchemaSettings.ts
@@ -173,7 +173,7 @@ export const excludedPathsState = atomFamily({
         const dataset = await getPromise(fos.dataset);
         const showNestedField = await getPromise(showNestedFieldsState);
         const searchResults = await getPromise(schemaSearchRestuls);
-        const isPatchesView = await getPromise(fos.isPatchesView);
+        const isFrameVIew = await getPromise(fos.isFramesView);
         const isVideo = dataset.mediaType === "video";
         const isImage = dataset.mediaType === "image";
         const isInSearchMode = !!searchResults?.length;
@@ -210,7 +210,7 @@ export const excludedPathsState = atomFamily({
                 path,
                 combinedSchema,
                 dataset?.groupField,
-                isPatchesView
+                isFrameVIew
               )
             );
           })
@@ -424,6 +424,7 @@ export default function useSchemaSettings() {
   );
 
   const isPatchesView = useRecoilValue(fos.isPatchesView);
+  const isFrameView = useRecoilValue(fos.isFramesView);
 
   const [expandedPaths, setExpandedPaths] = useRecoilState(expandedPathsState);
 
@@ -485,7 +486,7 @@ export default function useSchemaSettings() {
       ? [...datasetSelectedPaths]?.filter(
           ({ path }) =>
             path &&
-            !disabledField(path, combinedSchema, isGroupDataset, isPatchesView)
+            !disabledField(path, combinedSchema, isGroupDataset, isFrameView)
         )
       : [];
 
@@ -564,7 +565,7 @@ export default function useSchemaSettings() {
             path,
             finalSchemaKeyByPath,
             isGroupDataset,
-            isPatchesView
+            isFrameView
           ) || filterRuleTab;
 
         const fullPath =
@@ -835,7 +836,7 @@ export default function useSchemaSettings() {
         }
         const res = Object.values(combinedSchema)
           .filter((f) =>
-            disabledField(f.path, combinedSchema, isGroupDataset, isPatchesView)
+            disabledField(f.path, combinedSchema, isGroupDataset, isFrameView)
           )
           .map((f) => f.path);
 

--- a/app/packages/state/src/hooks/useSchemaSettings.utils.ts
+++ b/app/packages/state/src/hooks/useSchemaSettings.utils.ts
@@ -3,7 +3,9 @@ import {
   CLASSIFICATION_FIELD,
   DETECTIONS_FIELD,
   DETECTION_FIELD,
+  DISABLED_FIELDS_VISIBILITY,
   DISABLED_FIELD_TYPES,
+  DISABLED_LABEL_FIELDS_VISIBILITY,
   DISABLED_PATHS,
   DYNAMIC_EMBEDDED_DOCUMENT_FIELD,
   DYNAMIC_EMBEDDED_DOCUMENT_PATH,
@@ -13,18 +15,22 @@ import {
   GEO_LOCATIONS_FIELD,
   GEO_LOCATION_FIELD,
   HEATMAP_FIELD,
-  KEYPOINT_FILED,
+  KEYPOINT_FIELD,
   LIST_FIELD,
   OBJECT_ID_FIELD,
   POLYLINES_FIELD,
   POLYLINE_FIELD,
-  REGRESSION_FILED,
+  REGRESSION_FIELD,
   RESERVED_FIELD_KEYS,
   SEGMENTATION_FIELD,
   TEMPORAL_DETECTION_FIELD,
   VALID_LABEL_TYPES,
   VECTOR_FIELD,
 } from "@fiftyone/utilities";
+
+export const isMetadataField = (path: string) => {
+  return path === "metadata" || path.startsWith("metadata.");
+};
 
 export const disabledField = (
   path: string,
@@ -44,23 +50,22 @@ export const disabledField = (
     DYNAMIC_EMBEDDED_DOCUMENT_PATH,
   ].includes(embeddedDocType);
 
-  console.log("ftype", path, ftype);
   return (
     DISABLED_PATHS.includes(path) ||
     DISABLED_FIELD_TYPES.includes(ftype) ||
     [path, parentPath || path].includes(groupField) ||
-    (isFrameView && path === "frame_number")
+    (isFrameView && path === "frame_number") ||
+    isMetadataField(path) ||
+    DISABLED_LABEL_FIELDS_VISIBILITY.includes(ftype)
   );
-  // RESERVED_FIELD_KEYS.includes(path) ||
-  // path.startsWith("metadata")
   // ([
   //   TEMPORAL_DETECTION_FIELD,
   //   DETECTION_FIELD,
   //   DETECTIONS_FIELD,
   //   CLASSIFICATION_FIELD,
   //   CLASSIFICATIONS_FIELD,
-  //   KEYPOINT_FILED,
-  //   REGRESSION_FILED,
+  //   KEYPOINT_FIELD,
+  //   REGRESSION_FIELD,
   //   HEATMAP_FIELD,
   //   SEGMENTATION_FIELD,
   //   GEO_LOCATIONS_FIELD,
@@ -91,21 +96,6 @@ export const disabledField = (
   //   "points",
   //   "polygons",
   // ].includes(pathSplit[pathSplit.length - 1]) ||
-  // [
-  //   TEMPORAL_DETECTION_FIELD,
-  //   DETECTION_FIELD,
-  //   DETECTIONS_FIELD,
-  //   CLASSIFICATION_FIELD,
-  //   CLASSIFICATIONS_FIELD,
-  //   KEYPOINT_FILED,
-  //   REGRESSION_FILED,
-  //   HEATMAP_FIELD,
-  //   SEGMENTATION_FIELD,
-  //   GEO_LOCATIONS_FIELD,
-  //   GEO_LOCATION_FIELD,
-  //   POLYLINE_FIELD,
-  //   POLYLINES_FIELD,
-  // ].includes(ftype) ||
   // (parentPath &&
   //   parentPath !== path &&
   //   ftype === LIST_FIELD &&

--- a/app/packages/state/src/hooks/useSchemaSettings.utils.ts
+++ b/app/packages/state/src/hooks/useSchemaSettings.utils.ts
@@ -30,7 +30,7 @@ export const disabledField = (
   path: string,
   combinedSchema: Record<string, Field>,
   groupField?: string,
-  isPatchesView?: boolean
+  isFrameView?: boolean
 ): boolean => {
   const currField = combinedSchema?.[path] || ({} as Field);
   const { ftype, embeddedDocType } = currField;
@@ -48,7 +48,8 @@ export const disabledField = (
   return (
     DISABLED_PATHS.includes(path) ||
     DISABLED_FIELD_TYPES.includes(ftype) ||
-    [path, parentPath || path].includes(groupField)
+    [path, parentPath || path].includes(groupField) ||
+    (isFrameView && path === "frame_number")
   );
   // RESERVED_FIELD_KEYS.includes(path) ||
   // path.startsWith("metadata")

--- a/app/packages/state/src/hooks/useSchemaSettings.utils.ts
+++ b/app/packages/state/src/hooks/useSchemaSettings.utils.ts
@@ -3,6 +3,8 @@ import {
   CLASSIFICATION_FIELD,
   DETECTIONS_FIELD,
   DETECTION_FIELD,
+  DISABLED_FIELD_TYPES,
+  DISABLED_PATHS,
   DYNAMIC_EMBEDDED_DOCUMENT_FIELD,
   DYNAMIC_EMBEDDED_DOCUMENT_PATH,
   FRAME_NUMBER_FIELD,
@@ -41,78 +43,77 @@ export const disabledField = (
     DYNAMIC_EMBEDDED_DOCUMENT_PATH,
   ].includes(embeddedDocType);
 
-  return (
-    [
-      OBJECT_ID_FIELD,
-      FRAME_NUMBER_FIELD,
-      FRAME_SUPPORT_FIELD,
-      VECTOR_FIELD,
-    ].includes(ftype) ||
-    [path, parentPath].includes(groupField) ||
-    RESERVED_FIELD_KEYS.includes(path) ||
-    path.startsWith("metadata") ||
-    ([
-      TEMPORAL_DETECTION_FIELD,
-      DETECTION_FIELD,
-      DETECTIONS_FIELD,
-      CLASSIFICATION_FIELD,
-      CLASSIFICATIONS_FIELD,
-      KEYPOINT_FILED,
-      REGRESSION_FILED,
-      HEATMAP_FIELD,
-      SEGMENTATION_FIELD,
-      GEO_LOCATIONS_FIELD,
-      GEO_LOCATION_FIELD,
-      POLYLINE_FIELD,
-      POLYLINES_FIELD,
-    ].includes(parentEmbeddedDocType) &&
-      [
-        "id",
-        "tags",
-        "label",
-        "bounding_box",
-        "mask",
-        "confidence",
-        "index",
-        "points",
-        "closed",
-        "filled",
-        "logits",
-        "mask_path",
-        "map",
-        "map_path",
-        "Range",
-        "Confidence",
-        "support",
-        "point",
-        "line",
-        "Polygon",
-        "points",
-        "polygons",
-      ].includes(pathSplit[pathSplit.length - 1])) ||
-    [
-      TEMPORAL_DETECTION_FIELD,
-      DETECTION_FIELD,
-      DETECTIONS_FIELD,
-      CLASSIFICATION_FIELD,
-      CLASSIFICATIONS_FIELD,
-      KEYPOINT_FILED,
-      REGRESSION_FILED,
-      HEATMAP_FIELD,
-      SEGMENTATION_FIELD,
-      GEO_LOCATIONS_FIELD,
-      GEO_LOCATION_FIELD,
-      POLYLINE_FIELD,
-      POLYLINES_FIELD,
-    ].includes(ftype) ||
-    (parentPath &&
-      parentPath !== path &&
-      ftype === LIST_FIELD &&
-      (hasDynamicEmbeddedDocument ||
-        VALID_LABEL_TYPES.includes(
-          embeddedDocType?.includes(".")
-            ? embeddedDocTypeSplit[embeddedDocTypeSplit.length - 1]
-            : embeddedDocType
-        )))
-  );
+  console.log("ftype", path, ftype);
+  return DISABLED_PATHS.includes(path) || DISABLED_FIELD_TYPES.includes(ftype);
+  // [
+  //   // OBJECT_ID_FIELD,
+  //   FRAME_NUMBER_FIELD,
+  //   FRAME_SUPPORT_FIELD,
+  //   VECTOR_FIELD,
+  // ].includes(ftype) ||
+  // [path, parentPath].includes(groupField) ||
+  // RESERVED_FIELD_KEYS.includes(path) ||
+  // path.startsWith("metadata")
+  // ([
+  //   TEMPORAL_DETECTION_FIELD,
+  //   DETECTION_FIELD,
+  //   DETECTIONS_FIELD,
+  //   CLASSIFICATION_FIELD,
+  //   CLASSIFICATIONS_FIELD,
+  //   KEYPOINT_FILED,
+  //   REGRESSION_FILED,
+  //   HEATMAP_FIELD,
+  //   SEGMENTATION_FIELD,
+  //   GEO_LOCATIONS_FIELD,
+  //   GEO_LOCATION_FIELD,
+  //   POLYLINE_FIELD,
+  //   POLYLINES_FIELD,
+  // ].includes(parentEmbeddedDocType) &&
+  // [
+  //   "tags",
+  //   "label",
+  //   "bounding_box",
+  //   "mask",
+  //   "confidence",
+  //   "index",
+  //   "points",
+  //   "closed",
+  //   "filled",
+  //   "logits",
+  //   "mask_path",
+  //   "map",
+  //   "map_path",
+  //   "Range",
+  //   "Confidence",
+  //   "support",
+  //   "point",
+  //   "line",
+  //   "Polygon",
+  //   "points",
+  //   "polygons",
+  // ].includes(pathSplit[pathSplit.length - 1]) ||
+  // [
+  //   TEMPORAL_DETECTION_FIELD,
+  //   DETECTION_FIELD,
+  //   DETECTIONS_FIELD,
+  //   CLASSIFICATION_FIELD,
+  //   CLASSIFICATIONS_FIELD,
+  //   KEYPOINT_FILED,
+  //   REGRESSION_FILED,
+  //   HEATMAP_FIELD,
+  //   SEGMENTATION_FIELD,
+  //   GEO_LOCATIONS_FIELD,
+  //   GEO_LOCATION_FIELD,
+  //   POLYLINE_FIELD,
+  //   POLYLINES_FIELD,
+  // ].includes(ftype) ||
+  // (parentPath &&
+  //   parentPath !== path &&
+  //   ftype === LIST_FIELD &&
+  //   (hasDynamicEmbeddedDocument ||
+  //     VALID_LABEL_TYPES.includes(
+  //       embeddedDocType?.includes(".")
+  //         ? embeddedDocTypeSplit[embeddedDocTypeSplit.length - 1]
+  //         : embeddedDocType
+  //     )))
 };

--- a/app/packages/state/src/hooks/useSchemaSettings.utils.ts
+++ b/app/packages/state/src/hooks/useSchemaSettings.utils.ts
@@ -1,7 +1,9 @@
 import {
   CLASSIFICATIONS_FIELD,
+  CLASSIFICATION_DISABLED_SUB_PATHS,
   CLASSIFICATION_FIELD,
   DETECTIONS_FIELD,
+  DETECTION_DISABLED_SUB_PATHS,
   DETECTION_FIELD,
   DISABLED_FIELDS_VISIBILITY,
   DISABLED_FIELD_TYPES,
@@ -15,13 +17,17 @@ import {
   GEO_LOCATIONS_FIELD,
   GEO_LOCATION_FIELD,
   HEATMAP_FIELD,
+  KEYPOINT_DISABLED_SUB_PATHS,
   KEYPOINT_FIELD,
   LIST_FIELD,
   OBJECT_ID_FIELD,
   POLYLINES_FIELD,
+  POLYLINE_DISABLED_SUB_PATHS,
   POLYLINE_FIELD,
+  REGRESSION_DISABLED_SUB_PATHS,
   REGRESSION_FIELD,
   RESERVED_FIELD_KEYS,
+  SEGMENTATION_DISABLED_SUB_PATHS,
   SEGMENTATION_FIELD,
   TEMPORAL_DETECTION_FIELD,
   VALID_LABEL_TYPES,
@@ -42,6 +48,7 @@ export const disabledField = (
   const { ftype, embeddedDocType } = currField;
   const parentPath = path.substring(0, path.lastIndexOf("."));
   const parentField = combinedSchema?.[parentPath];
+  const parentFType = parentField?.ftype;
   const parentEmbeddedDocType = parentField?.embeddedDocType;
   const pathSplit = path.split(".");
   const embeddedDocTypeSplit = embeddedDocType?.split(".");
@@ -50,14 +57,87 @@ export const disabledField = (
     DYNAMIC_EMBEDDED_DOCUMENT_PATH,
   ].includes(embeddedDocType);
 
-  return (
-    DISABLED_PATHS.includes(path) ||
-    DISABLED_FIELD_TYPES.includes(ftype) ||
-    [path, parentPath || path].includes(groupField) ||
-    (isFrameView && path === "frame_number") ||
-    isMetadataField(path) ||
-    DISABLED_LABEL_FIELDS_VISIBILITY.includes(ftype)
-  );
+  const shortPath = pathSplit[pathSplit.length - 1];
+
+  // ex: 'id' and 'filepath' are always disabled
+  if (DISABLED_PATHS.includes(path)) {
+    return true;
+  }
+
+  // ex: ObjectIdType and VectorType are always disabled
+  if (DISABLED_FIELD_TYPES.includes(ftype)) {
+    return true;
+  }
+
+  // ex: in a dataset with 'dataset.group_field="group"'
+  //  field 'group' (and children) will be disabled.
+  if ([path, parentPath || path].includes(groupField)) {
+    return true;
+  }
+
+  if (isFrameView && path === "frame_number") {
+    return true;
+  }
+
+  // metadata and all its children are disabled
+  if (isMetadataField(path)) {
+    return true;
+  }
+
+  // All label
+  if (DISABLED_LABEL_FIELDS_VISIBILITY.includes(ftype)) {
+    return true;
+  }
+
+  // field Detection has reserved subpaths. ex: tags, id, mask
+  if (
+    parentFType === DETECTION_FIELD &&
+    DETECTION_DISABLED_SUB_PATHS.includes(pathSplit[pathSplit.length - 1])
+  ) {
+    return true;
+  }
+
+  // field Polyline has reserved subpaths. ex: "points", "closed", "filled",
+  if (
+    parentFType === POLYLINE_FIELD &&
+    POLYLINE_DISABLED_SUB_PATHS.includes(shortPath)
+  ) {
+    return true;
+  }
+
+  // field Classification has reserved subpaths. ex: "logits"
+  if (
+    parentFType === CLASSIFICATION_FIELD &&
+    CLASSIFICATION_DISABLED_SUB_PATHS.includes(shortPath)
+  ) {
+    return true;
+  }
+
+  // field Regression has reserved subpaths. ex: "value", "id"
+  if (
+    parentFType === REGRESSION_FIELD &&
+    REGRESSION_DISABLED_SUB_PATHS.includes(shortPath)
+  ) {
+    return true;
+  }
+
+  // field Keypoint has reserved subpaths. ex: "point", "index"
+  if (
+    parentFType === KEYPOINT_FIELD &&
+    KEYPOINT_DISABLED_SUB_PATHS.includes(shortPath)
+  ) {
+    return true;
+  }
+
+  // field Segmentation has reserved subpaths. ex: "mask", "mask_path"
+  if (
+    parentFType === SEGMENTATION_FIELD &&
+    SEGMENTATION_DISABLED_SUB_PATHS.includes(shortPath)
+  ) {
+    return true;
+  }
+
+  return false;
   // ([
   //   TEMPORAL_DETECTION_FIELD,
   //   DETECTION_FIELD,

--- a/app/packages/state/src/hooks/useSchemaSettings.utils.ts
+++ b/app/packages/state/src/hooks/useSchemaSettings.utils.ts
@@ -35,10 +35,10 @@ export const disabledField = (
   groupField?: string,
   isFrameView?: boolean
 ): boolean => {
-  const currField = combinedSchema?.[path] || ({} as Field);
+  const currField = combinedSchema[path] || ({} as Field);
   const { ftype } = currField;
   const parentPath = path.substring(0, path.lastIndexOf("."));
-  const parentField = combinedSchema?.[parentPath];
+  const parentField = combinedSchema[parentPath];
   const parentFType = parentField?.ftype;
   const pathSplit = path.split(".");
 

--- a/app/packages/state/src/hooks/useSchemaSettings.utils.ts
+++ b/app/packages/state/src/hooks/useSchemaSettings.utils.ts
@@ -1,18 +1,11 @@
 import {
-  CLASSIFICATIONS_FIELD,
   CLASSIFICATION_DISABLED_SUB_PATHS,
   CLASSIFICATION_FIELD,
-  DETECTIONS_FIELD,
   DETECTION_DISABLED_SUB_PATHS,
   DETECTION_FIELD,
-  DISABLED_FIELDS_VISIBILITY,
   DISABLED_FIELD_TYPES,
   DISABLED_LABEL_FIELDS_VISIBILITY,
   DISABLED_PATHS,
-  DYNAMIC_EMBEDDED_DOCUMENT_FIELD,
-  DYNAMIC_EMBEDDED_DOCUMENT_PATH,
-  FRAME_NUMBER_FIELD,
-  FRAME_SUPPORT_FIELD,
   Field,
   GEOLOCATIONS_DISABLED_SUB_PATHS,
   GEOLOCATION_DISABLED_SUB_PATHS,
@@ -22,20 +15,14 @@ import {
   HEATMAP_FIELD,
   KEYPOINT_DISABLED_SUB_PATHS,
   KEYPOINT_FIELD,
-  LIST_FIELD,
-  OBJECT_ID_FIELD,
-  POLYLINES_FIELD,
   POLYLINE_DISABLED_SUB_PATHS,
   POLYLINE_FIELD,
   REGRESSION_DISABLED_SUB_PATHS,
   REGRESSION_FIELD,
-  RESERVED_FIELD_KEYS,
   SEGMENTATION_DISABLED_SUB_PATHS,
   SEGMENTATION_FIELD,
   TEMPORAL_DETECTION_DISABLED_SUB_PATHS,
   TEMPORAL_DETECTION_FIELD,
-  VALID_LABEL_TYPES,
-  VECTOR_FIELD,
 } from "@fiftyone/utilities";
 
 export const isMetadataField = (path: string) => {
@@ -49,17 +36,11 @@ export const disabledField = (
   isFrameView?: boolean
 ): boolean => {
   const currField = combinedSchema?.[path] || ({} as Field);
-  const { ftype, embeddedDocType } = currField;
+  const { ftype } = currField;
   const parentPath = path.substring(0, path.lastIndexOf("."));
   const parentField = combinedSchema?.[parentPath];
   const parentFType = parentField?.ftype;
-  const parentEmbeddedDocType = parentField?.embeddedDocType;
   const pathSplit = path.split(".");
-  const embeddedDocTypeSplit = embeddedDocType?.split(".");
-  const hasDynamicEmbeddedDocument = [
-    DYNAMIC_EMBEDDED_DOCUMENT_FIELD,
-    DYNAMIC_EMBEDDED_DOCUMENT_PATH,
-  ].includes(embeddedDocType);
 
   const shortPath = pathSplit[pathSplit.length - 1];
 
@@ -174,13 +155,4 @@ export const disabledField = (
   }
 
   return false;
-  // (parentPath &&
-  //   parentPath !== path &&
-  //   ftype === LIST_FIELD &&
-  //   (hasDynamicEmbeddedDocument ||
-  //     VALID_LABEL_TYPES.includes(
-  //       embeddedDocType?.includes(".")
-  //         ? embeddedDocTypeSplit[embeddedDocTypeSplit.length - 1]
-  //         : embeddedDocType
-  //     )))
 };

--- a/app/packages/state/src/hooks/useSchemaSettings.utils.ts
+++ b/app/packages/state/src/hooks/useSchemaSettings.utils.ts
@@ -44,14 +44,11 @@ export const disabledField = (
   ].includes(embeddedDocType);
 
   console.log("ftype", path, ftype);
-  return DISABLED_PATHS.includes(path) || DISABLED_FIELD_TYPES.includes(ftype);
-  // [
-  //   // OBJECT_ID_FIELD,
-  //   FRAME_NUMBER_FIELD,
-  //   FRAME_SUPPORT_FIELD,
-  //   VECTOR_FIELD,
-  // ].includes(ftype) ||
-  // [path, parentPath].includes(groupField) ||
+  return (
+    DISABLED_PATHS.includes(path) ||
+    DISABLED_FIELD_TYPES.includes(ftype) ||
+    [path, parentPath || path].includes(groupField)
+  );
   // RESERVED_FIELD_KEYS.includes(path) ||
   // path.startsWith("metadata")
   // ([

--- a/app/packages/state/src/hooks/useSchemaSettings.utils.ts
+++ b/app/packages/state/src/hooks/useSchemaSettings.utils.ts
@@ -14,8 +14,11 @@ import {
   FRAME_NUMBER_FIELD,
   FRAME_SUPPORT_FIELD,
   Field,
+  GEOLOCATIONS_DISABLED_SUB_PATHS,
+  GEOLOCATION_DISABLED_SUB_PATHS,
   GEO_LOCATIONS_FIELD,
   GEO_LOCATION_FIELD,
+  HEATMAP_DISABLED_SUB_PATHS,
   HEATMAP_FIELD,
   KEYPOINT_DISABLED_SUB_PATHS,
   KEYPOINT_FIELD,
@@ -29,6 +32,7 @@ import {
   RESERVED_FIELD_KEYS,
   SEGMENTATION_DISABLED_SUB_PATHS,
   SEGMENTATION_FIELD,
+  TEMPORAL_DETECTION_DISABLED_SUB_PATHS,
   TEMPORAL_DETECTION_FIELD,
   VALID_LABEL_TYPES,
   VECTOR_FIELD,
@@ -137,45 +141,39 @@ export const disabledField = (
     return true;
   }
 
+  // field Heatmap has reserved subpaths. ex: "map_path", "Range"
+  if (
+    parentFType === HEATMAP_FIELD &&
+    HEATMAP_DISABLED_SUB_PATHS.includes(shortPath)
+  ) {
+    return true;
+  }
+
+  // field TemporalDetection has reserved subpaths. ex: "support", "tags"
+  if (
+    parentFType === TEMPORAL_DETECTION_FIELD &&
+    TEMPORAL_DETECTION_DISABLED_SUB_PATHS.includes(shortPath)
+  ) {
+    return true;
+  }
+
+  // field Geolocation has reserved subpaths. ex: "polygon", "line", "point"
+  if (
+    parentFType === GEO_LOCATION_FIELD &&
+    GEOLOCATION_DISABLED_SUB_PATHS.includes(shortPath)
+  ) {
+    return true;
+  }
+
+  // field Geolocations has reserved subpaths. ex: "polygons", "line", "point"
+  if (
+    parentFType === GEO_LOCATIONS_FIELD &&
+    GEOLOCATIONS_DISABLED_SUB_PATHS.includes(shortPath)
+  ) {
+    return true;
+  }
+
   return false;
-  // ([
-  //   TEMPORAL_DETECTION_FIELD,
-  //   DETECTION_FIELD,
-  //   DETECTIONS_FIELD,
-  //   CLASSIFICATION_FIELD,
-  //   CLASSIFICATIONS_FIELD,
-  //   KEYPOINT_FIELD,
-  //   REGRESSION_FIELD,
-  //   HEATMAP_FIELD,
-  //   SEGMENTATION_FIELD,
-  //   GEO_LOCATIONS_FIELD,
-  //   GEO_LOCATION_FIELD,
-  //   POLYLINE_FIELD,
-  //   POLYLINES_FIELD,
-  // ].includes(parentEmbeddedDocType) &&
-  // [
-  //   "tags",
-  //   "label",
-  //   "bounding_box",
-  //   "mask",
-  //   "confidence",
-  //   "index",
-  //   "points",
-  //   "closed",
-  //   "filled",
-  //   "logits",
-  //   "mask_path",
-  //   "map",
-  //   "map_path",
-  //   "Range",
-  //   "Confidence",
-  //   "support",
-  //   "point",
-  //   "line",
-  //   "Polygon",
-  //   "points",
-  //   "polygons",
-  // ].includes(pathSplit[pathSplit.length - 1]) ||
   // (parentPath &&
   //   parentPath !== path &&
   //   ftype === LIST_FIELD &&

--- a/app/packages/state/src/hooks/useSchemaSettings.utils.ts
+++ b/app/packages/state/src/hooks/useSchemaSettings.utils.ts
@@ -16,6 +16,7 @@ import {
   HEATMAP_FIELD,
   KEYPOINT_DISABLED_SUB_PATHS,
   KEYPOINT_FIELD,
+  LIST_FIELD,
   OBJECT_ID_FIELD,
   POLYLINE_DISABLED_SUB_PATHS,
   POLYLINE_FIELD,
@@ -25,6 +26,7 @@ import {
   SEGMENTATION_FIELD,
   TEMPORAL_DETECTION_DISABLED_SUB_PATHS,
   TEMPORAL_DETECTION_FIELD,
+  VALID_LABEL_TYPES,
 } from "@fiftyone/utilities";
 
 export const isMetadataField = (path: string) => {
@@ -41,7 +43,7 @@ export const disabledField = (
   isPatchesView?: boolean
 ): boolean => {
   const currField = combinedSchema[path] || ({} as Field);
-  const { ftype } = currField;
+  const { ftype, embeddedDocType } = currField;
   const parentPath = path.substring(0, path.lastIndexOf("."));
   const parentField = combinedSchema[parentPath];
   const parentFType = parentField?.ftype;
@@ -174,6 +176,17 @@ export const disabledField = (
     GEOLOCATIONS_DISABLED_SUB_PATHS.includes(shortPath)
   ) {
     return true;
+  }
+
+  // list of any valid labels
+  if (embeddedDocType && ftype === LIST_FIELD) {
+    const embeddedRoot = embeddedDocType?.substring(
+      embeddedDocType.lastIndexOf(".") + 1,
+      embeddedDocType.length
+    );
+    if (VALID_LABEL_TYPES.includes(embeddedRoot)) {
+      return true;
+    }
   }
 
   return false;

--- a/app/packages/state/src/hooks/useSchemaSettings.utils.ts
+++ b/app/packages/state/src/hooks/useSchemaSettings.utils.ts
@@ -29,7 +29,8 @@ import {
 export const disabledField = (
   path: string,
   combinedSchema: Record<string, Field>,
-  groupField?: string
+  groupField?: string,
+  isPatchesView?: boolean
 ): boolean => {
   const currField = combinedSchema?.[path] || ({} as Field);
   const { ftype, embeddedDocType } = currField;

--- a/app/packages/state/src/recoil/schemaSettings.atoms.ts
+++ b/app/packages/state/src/recoil/schemaSettings.atoms.ts
@@ -1,0 +1,311 @@
+import { DefaultValue, atom, atomFamily, selector } from "recoil";
+import { disabledField, skipField } from "../hooks/useSchemaSettings.utils";
+import * as fos from "@fiftyone/state";
+import {
+  DYNAMIC_EMBEDDED_DOCUMENT_FIELD_V2,
+  EMBEDDED_DOCUMENT_FIELD,
+  LIST_FIELD,
+} from "@fiftyone/utilities";
+
+export const TAB_OPTIONS_MAP = {
+  SELECTION: "Selection",
+  FILTER_RULE: "Filter rule",
+};
+
+export const TAB_OPTIONS = Object.values(TAB_OPTIONS_MAP);
+
+export const schemaSearchTerm = atom<string>({
+  key: "schemaSearchTerm",
+  default: "",
+});
+
+export const showNestedFieldsState = atom<boolean>({
+  key: "showNestedFieldsState",
+  default: false,
+});
+
+export const schemaSelectedSettingsTab = atom<string>({
+  key: "schemaSelectedSettingsTab",
+  default: TAB_OPTIONS_MAP.SELECTION,
+});
+
+export const settingsModal = atom<{ open: boolean } | null>({
+  key: "settingsModal",
+  default: {
+    open: false,
+  },
+});
+
+export const allFieldsCheckedState = atom<boolean>({
+  key: "allFieldsCheckedState",
+  default: true,
+});
+
+export const expandedPathsState = atom<{} | null>({
+  key: "expandedPathsState",
+  default: null,
+});
+
+export const viewSchemaState = atom({
+  key: "viewSchemaState",
+  default: null,
+});
+
+export const fieldSchemaState = atom({
+  key: "fieldSchemaState",
+  default: null,
+});
+
+export const showMetadataState = atom({
+  key: "showMetadataState",
+  default: false,
+});
+
+export const includeNestedFieldsState = atom({
+  key: "includeNestedFieldsState",
+  default: true,
+});
+
+export const affectedPathCountState = atom({
+  key: "affectedPathCountState",
+  default: 0,
+});
+
+export const searchMetaFilterState = atom({
+  key: "searchMetaFilterState",
+  default: {},
+});
+
+export const lastAppliedPathsState = atom({
+  key: "lastAppliedExcludedPathsState",
+  default: {
+    excluded: [],
+    selected: [],
+  },
+});
+
+// tracks action and value - currently used for (un)select all action
+export const lastActionToggleSelectionState = atom<Record<
+  string,
+  boolean
+> | null>({
+  key: "lastActionToggleSelectionState",
+  default: null,
+});
+
+const getRawPath = (path: string) =>
+  path.startsWith("frames.") ? path.replace("frames.", "") : path;
+
+export const schemaSearchResultList = selector<string[]>({
+  key: "schemaSearchResultsSelector",
+  get: ({ get }) => get(schemaSearchResults),
+  set: ({ set, get }, newPaths) => {
+    if (newPaths instanceof DefaultValue) {
+      newPaths = [];
+    }
+    const viewSchema = get(viewSchemaState);
+    const fieldSchema = get(fieldSchemaState);
+    const combinedSchema = { ...fieldSchema, ...viewSchema };
+
+    const greenPaths = [...newPaths]
+      .filter((path) => {
+        const cleanPath = getRawPath(path);
+
+        return (
+          cleanPath &&
+          combinedSchema?.[cleanPath]?.ftype &&
+          !skipField(cleanPath, combinedSchema)
+        );
+      })
+      .map((path) => getRawPath(path));
+    set(schemaSearchResults, greenPaths);
+  },
+  cachePolicy_UNSTABLE: {
+    eviction: "most-recent",
+  },
+});
+
+export const schemaSearchResults = atom<string[]>({
+  key: "schemaSearchResults",
+  default: [],
+});
+
+export const selectedPathsState = atomFamily({
+  key: "selectedPathsState",
+  default: (param: {}) => param,
+  effects: [
+    ({ onSet, getPromise, setSelf }) => {
+      onSet(async (newPathsMap) => {
+        const dataset = await getPromise(fos.dataset);
+        const viewSchema = await getPromise(viewSchemaState);
+        const fieldSchema = await getPromise(fieldSchemaState);
+        const combinedSchema = { ...fieldSchema, ...viewSchema };
+        const isImage = dataset.mediaType === "image";
+        const isVideo = dataset.mediaType === "video";
+
+        const mapping = {};
+        Object.keys(combinedSchema).forEach((path) => {
+          if (isImage) {
+            mapping[path] = path;
+          }
+          if (isVideo && viewSchema) {
+            Object.keys(viewSchema).forEach((path) => {
+              mapping[path] = `frames.${path}`;
+            });
+          }
+        });
+
+        const newPaths = newPathsMap?.[dataset?.name] || [];
+        const greenPaths = [...newPaths]
+          .filter((path) => {
+            const skip = skipField(path, combinedSchema);
+            return !!path && !skip;
+          })
+          .map((path) => mapping?.[path] || path);
+
+        setSelf({
+          [dataset?.name]: new Set(greenPaths),
+        });
+      });
+    },
+  ],
+});
+
+export const excludedPathsState = atomFamily({
+  key: "excludedPathsState",
+  default: (param: {}) => param,
+  effects: [
+    ({ onSet, getPromise, setSelf }) => {
+      onSet(async (newPathsMap) => {
+        const viewSchema = await getPromise(fos.viewSchemaState);
+        const fieldSchema = await getPromise(fos.fieldSchemaState);
+        const dataset = await getPromise(fos.dataset);
+        const showNestedField = await getPromise(fos.showNestedFieldsState);
+        const searchResults = await getPromise(fos.schemaSearchResults);
+        const isFrameView = await getPromise(fos.isFramesView);
+        const isClipsView = await getPromise(fos.isClipsView);
+        const isPatchesView = await getPromise(fos.isPatchesView);
+        const isVideo = dataset.mediaType === "video";
+        const isImage = dataset.mediaType === "image";
+        const isInSearchMode = !!searchResults?.length;
+
+        if (!dataset) {
+          return;
+        }
+
+        const combinedSchema = { ...fieldSchema, ...viewSchema };
+        const mapping = {};
+        Object.keys(combinedSchema).forEach((path) => {
+          if (isImage) {
+            mapping[path] = path;
+          }
+          if (isVideo && viewSchema) {
+            Object.keys(viewSchema).forEach((path) => {
+              mapping[path] = `frames.${path}`;
+            });
+          }
+        });
+
+        const newPaths = newPathsMap?.[dataset?.name] || [];
+        const greenPaths = [...newPaths]
+          .filter((path) => {
+            const rawPath = path.replace("frames.", "");
+            return (
+              !!rawPath &&
+              !skipField(rawPath, combinedSchema) &&
+              !disabledField(
+                path,
+                combinedSchema,
+                dataset?.groupField,
+                isFrameView,
+                isClipsView,
+                isVideo,
+                isPatchesView
+              )
+            );
+          })
+          .map((path) => mapping?.[path] || path);
+
+        // if top level only, count should be top-level too
+        // if nested fields are shown, exclude more granular
+        let finalGreenPaths = greenPaths;
+        if (!showNestedField && !isInSearchMode) {
+          finalGreenPaths = greenPaths.filter((path) =>
+            isVideo
+              ? (path.split(".").length === 2 && path.startsWith("frames.")) ||
+                !path.includes(".")
+              : !path.includes(".")
+          );
+        }
+
+        const shouldFilterTopLevelFields = showNestedField || isInSearchMode;
+        finalGreenPaths = shouldFilterTopLevelFields
+          ? finalGreenPaths.filter((path) => {
+              const isEmbeddedOrListType = [
+                EMBEDDED_DOCUMENT_FIELD,
+                LIST_FIELD,
+              ].includes(combinedSchema[path]?.ftype);
+
+              // embedded document could break an exclude_field() call causing mongo query issue.
+              const hasDynamicEmbeddedDocument = [
+                DYNAMIC_EMBEDDED_DOCUMENT_FIELD_V2,
+              ].includes(combinedSchema[path]?.embeddedDocType);
+
+              const isTopLevelPath = isVideo
+                ? !(
+                    path.split(".").length === 2 && path.startsWith("frames.")
+                  ) || !path.includes(".")
+                : !path.includes(".");
+
+              return !(
+                isEmbeddedOrListType &&
+                hasDynamicEmbeddedDocument &&
+                isTopLevelPath
+              );
+            })
+          : finalGreenPaths;
+
+        // filter out subpaths if a parent (or higher) path is also in the list
+        const finalGreenPathsSet = new Set(finalGreenPaths);
+        if (showNestedField) {
+          finalGreenPaths = finalGreenPaths.filter((path) => {
+            let tmp = path;
+            while (tmp.indexOf(".") > 0) {
+              const parentPath = tmp.substring(0, tmp.lastIndexOf("."));
+              if (finalGreenPathsSet.has(parentPath) || path === parentPath) {
+                return false;
+              }
+              tmp = parentPath;
+            }
+            return true;
+          });
+        }
+
+        setSelf({
+          [dataset.name]: new Set(finalGreenPaths),
+        });
+      });
+    },
+  ],
+});
+
+export const selectedFieldsStageState = atom<any>({
+  key: "selectedFieldsStageState",
+  default: undefined,
+  effects: [
+    ({ onSet }) => {
+      onSet((value) => {
+        const context = fos.getContext();
+        if (context.loaded) {
+          context.history.replace(
+            `${context.history.location.pathname}${context.history.location.search}`,
+            {
+              ...context.history.location.state,
+              selectedFieldsStage: value || null,
+            }
+          );
+        }
+      });
+    },
+  ],
+});

--- a/app/packages/utilities/src/index.ts
+++ b/app/packages/utilities/src/index.ts
@@ -286,6 +286,8 @@ export const DETECTION_FIELD = "fiftyone.core.labels.Detection";
 export const DETECTIONS_FIELD = "fiftyone.core.labels.Detections";
 export const TEMPORAL_DETECTION_FIELD =
   "fiftyone.core.labels.TemporalDetection";
+export const TEMPORAL_DETECTIONS_FIELD =
+  "fiftyone.core.labels.TemporalDetections";
 export const ARRAY_FIELD = "fiftyone.core.fields.ArrayField";
 export const BOOLEAN_FIELD = "fiftyone.core.fields.BooleanField";
 export const DATE_FIELD = "fiftyone.core.fields.DateField";
@@ -307,11 +309,28 @@ export const LIST_FIELD = "fiftyone.core.fields.ListField";
 export const JUST_FIELD = "fiftyone.core.fields.Field";
 export const VECTOR_FIELD = "fiftyone.core.fields.VectorField";
 export const DETECTION_FILED = "fiftyone.core.labels.Detection";
-export const KEYPOINT_FILED = "fiftyone.core.labels.Keypoint";
-export const REGRESSION_FILED = "fiftyone.core.labels.Regression";
+export const KEYPOINT_FIELD = "fiftyone.core.labels.Keypoint";
+export const REGRESSION_FIELD = "fiftyone.core.labels.Regression";
 export const GROUP = "fiftyone.core.groups.Group";
 
 export const VALID_LIST_FIELDS = [FRAME_SUPPORT_FIELD, LIST_FIELD];
+
+export const DISABLED_LABEL_FIELDS_VISIBILITY = [
+  DETECTION_FIELD,
+  DETECTIONS_FIELD,
+  CLASSIFICATION_FIELD,
+  CLASSIFICATIONS_FIELD,
+  KEYPOINT_FIELD,
+  TEMPORAL_DETECTION_FIELD,
+  TEMPORAL_DETECTIONS_FIELD,
+  REGRESSION_FIELD,
+  HEATMAP_FIELD,
+  SEGMENTATION_FIELD,
+  GEO_LOCATION_FIELD,
+  GEO_LOCATIONS_FIELD,
+  POLYLINE_FIELD,
+  POLYLINES_FIELD,
+];
 
 export const VALID_PRIMITIVE_TYPES = [
   BOOLEAN_FIELD,

--- a/app/packages/utilities/src/index.ts
+++ b/app/packages/utilities/src/index.ts
@@ -414,6 +414,48 @@ export const DISABLED_FIELD_TYPES = [
   VECTOR_FIELD,
 ];
 
+const BASE_DISABLED_PATHS = ["id", "tags", "label", "confidence"];
+
+export const DETECTION_DISABLED_SUB_PATHS = [
+  ...BASE_DISABLED_PATHS,
+  "bounding_box",
+  "mask",
+  "index",
+];
+
+export const POLYLINE_DISABLED_SUB_PATHS = [
+  ...BASE_DISABLED_PATHS,
+  "points",
+  "closed",
+  "filled",
+  "index",
+];
+
+export const CLASSIFICATION_DISABLED_SUB_PATHS = [
+  ...BASE_DISABLED_PATHS,
+  "logits",
+];
+
+export const REGRESSION_DISABLED_SUB_PATHS = [
+  "id",
+  "tags",
+  "value",
+  "confidence",
+];
+
+export const KEYPOINT_DISABLED_SUB_PATHS = [
+  ...BASE_DISABLED_PATHS,
+  "points",
+  "index",
+];
+
+export const SEGMENTATION_DISABLED_SUB_PATHS = [
+  "id",
+  "tags",
+  "mask",
+  "mask_path",
+];
+
 export function withPath(path: string, types: string): string;
 export function withPath(path: string, types: string[]): string[];
 export function withPath(

--- a/app/packages/utilities/src/index.ts
+++ b/app/packages/utilities/src/index.ts
@@ -387,6 +387,14 @@ export const CLIPS_FRAME_FIELDS = withPath(LABELS_PATH, [
   "Polylines",
 ]);
 
+export const DISABLED_PATHS = ["id", "filepath", "tags", "metadata"];
+export const DISABLED_FIELD_TYPES = [
+  OBJECT_ID_FIELD,
+  FRAME_NUMBER_FIELD,
+  FRAME_SUPPORT_FIELD,
+  VECTOR_FIELD,
+];
+
 export function withPath(path: string, types: string): string;
 export function withPath(path: string, types: string[]): string[];
 export function withPath(

--- a/app/packages/utilities/src/index.ts
+++ b/app/packages/utilities/src/index.ts
@@ -409,12 +409,6 @@ export const CLIPS_FRAME_FIELDS = withPath(LABELS_PATH, [
 ]);
 
 export const DISABLED_PATHS = ["id", "filepath", "tags", "metadata"];
-export const DISABLED_FIELD_TYPES = [
-  OBJECT_ID_FIELD,
-  FRAME_NUMBER_FIELD,
-  FRAME_SUPPORT_FIELD,
-  VECTOR_FIELD,
-];
 
 const BASE_DISABLED_PATHS = ["id", "tags", "label", "confidence"];
 

--- a/app/packages/utilities/src/index.ts
+++ b/app/packages/utilities/src/index.ts
@@ -310,6 +310,7 @@ export const JUST_FIELD = "fiftyone.core.fields.Field";
 export const VECTOR_FIELD = "fiftyone.core.fields.VectorField";
 export const DETECTION_FILED = "fiftyone.core.labels.Detection";
 export const KEYPOINT_FIELD = "fiftyone.core.labels.Keypoint";
+export const KEYPOINTS_FIELD = "fiftyone.core.labels.Keypoints";
 export const REGRESSION_FIELD = "fiftyone.core.labels.Regression";
 export const GROUP = "fiftyone.core.groups.Group";
 
@@ -321,6 +322,7 @@ export const DISABLED_LABEL_FIELDS_VISIBILITY = [
   CLASSIFICATION_FIELD,
   CLASSIFICATIONS_FIELD,
   KEYPOINT_FIELD,
+  KEYPOINTS_FIELD,
   TEMPORAL_DETECTION_FIELD,
   TEMPORAL_DETECTIONS_FIELD,
   REGRESSION_FIELD,
@@ -461,7 +463,7 @@ export const HEATMAP_DISABLED_SUB_PATHS = [
   "tags",
   "map",
   "map_path",
-  "Range",
+  "range",
 ];
 
 export const TEMPORAL_DETECTION_DISABLED_SUB_PATHS = [
@@ -474,7 +476,7 @@ export const GEOLOCATION_DISABLED_SUB_PATHS = [
   "tags",
   "point",
   "line",
-  "Polygon",
+  "polygon",
 ];
 
 export const GEOLOCATIONS_DISABLED_SUB_PATHS = [
@@ -482,7 +484,7 @@ export const GEOLOCATIONS_DISABLED_SUB_PATHS = [
   "tags",
   "point",
   "line",
-  "Polygons",
+  "polygons",
 ];
 
 export function withPath(path: string, types: string): string;

--- a/app/packages/utilities/src/index.ts
+++ b/app/packages/utilities/src/index.ts
@@ -456,6 +456,35 @@ export const SEGMENTATION_DISABLED_SUB_PATHS = [
   "mask_path",
 ];
 
+export const HEATMAP_DISABLED_SUB_PATHS = [
+  "id",
+  "tags",
+  "map",
+  "map_path",
+  "Range",
+];
+
+export const TEMPORAL_DETECTION_DISABLED_SUB_PATHS = [
+  ...BASE_DISABLED_PATHS,
+  "support",
+];
+
+export const GEOLOCATION_DISABLED_SUB_PATHS = [
+  "id",
+  "tags",
+  "point",
+  "line",
+  "Polygon",
+];
+
+export const GEOLOCATIONS_DISABLED_SUB_PATHS = [
+  "id",
+  "tags",
+  "point",
+  "line",
+  "Polygons",
+];
+
 export function withPath(path: string, types: string): string;
 export function withPath(path: string, types: string[]): string[];
 export function withPath(

--- a/app/vite.config.ts
+++ b/app/vite.config.ts
@@ -6,7 +6,7 @@ export default defineConfig({
   test: {
     environment: "jsdom",
     coverage: {
-      reporter: ["json", "lcov"],
+      reporter: ["json", "lcov", "text", "html"],
       reportsDirectory: "./coverage",
       enabled: true,
       all: true,


### PR DESCRIPTION
## What changes are proposed in this pull request?

Disabling logic is an important piece of field visibility because if it has a wrong value, it can cause the app to crash (most probably due to select_fields or exclude_fields view stages failing to select or exclude unwanted fields).

Currently, we select and exclude fields based on path which can cause unintended disabling. it is improved to be based on path and type of self/parent field.

unit tests more granular selection of fields to avoid unintended selection.

- [x] image
- [x] video
- [x] group
- [x] toPatches view
- [X] Frames view  
- [x] Nested Fields
  - [x] Detection
  - [x] Polyline
  - [x] Classification
  - [x] Regression
  - [x] Keypoint
  - [x] Segmentation
  - [x] TemporalDetection
  - [x] Heatmap
  - [x] Geolocation
  - [x] Geolocations

## How is this patch tested? If it is not, please explain why.

(Details)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
