### PR TITLE
fix annoying pcd selector disappearing bug

### DIFF
--- a/app/packages/looker-3d/src/Looker3d.tsx
+++ b/app/packages/looker-3d/src/Looker3d.tsx
@@ -470,7 +470,7 @@ export const Looker3d = () => {
 
   return (
     <ErrorBoundary>
-      <Container onMouseOver={update} onMouseMove={update} onMouseLeave={clear}>
+      <Container onMouseOver={update} onMouseMove={update}>
         <Canvas onClick={() => setCurrentAction(null)} data-cy="looker3d">
           <Screenshot />
           <Environment


### PR DESCRIPTION
## What changes are proposed in this pull request?

Fix selector closing inconveniently as a result of container.onmouseleave triggering when looker3d re-renders. Removing `onMouseLeave` from `Container` has no real consequence, as `onMouseOver` subsumes what it intends to do.

Before:
![before](https://github.com/voxel51/fiftyone/assets/66688606/2a88e516-acc2-47ae-bb6d-e5461dc0c71f)

After:
![after](https://github.com/voxel51/fiftyone/assets/66688606/d602be80-fdf7-4c35-8fba-624a71929aae)

## How is this patch tested? If it is not, please explain why.

Locally.

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
