### PR TITLE
Session proxy url

### DIFF
--- a/docs/source/user_guide/config.rst
+++ b/docs/source/user_guide/config.rst
@@ -650,6 +650,9 @@ The FiftyOne App can be configured in the ways described below:
 +---------------------------+----------------------------------------+-----------------------------+-------------------------------------------------------------------------------------------+
 | `notebook_height`         | `FIFTYONE_APP_NOTEBOOK_HEIGHT`         | `800`                       | The height of App instances displayed in notebook cells.                                  |
 +---------------------------+----------------------------------------+-----------------------------+-------------------------------------------------------------------------------------------+
+| `proxy_url`               | `FIFTYONE_APP_PROXY_URL`               | `None`                      | A URL string to override the default server URL. Useful for configuring the session       |
+|                           |                                        |                             | through a reverse proxy in notebook environments.                                         |
++---------------------------+----------------------------------------+-----------------------------+-------------------------------------------------------------------------------------------+
 | `show_confidence`         | `FIFTYONE_APP_SHOW_CONFIDENCE`         | `True`                      | Whether to show confidences when rendering labels in the App's expanded sample view.      |
 +---------------------------+----------------------------------------+-----------------------------+-------------------------------------------------------------------------------------------+
 | `show_index`              | `FIFTYONE_APP_SHOW_INDEX`              | `True`                      | Whether to show indexes when rendering labels in the App's expanded sample view.          |
@@ -717,6 +720,7 @@ You can print your App config at any time via the Python library and the CLI:
             "loop_videos": false,
             "multicolor_keypoints": false,
             "notebook_height": 800,
+            "proxy_url": None,
             "show_confidence": true,
             "show_index": true,
             "show_label": true,
@@ -764,6 +768,7 @@ You can print your App config at any time via the Python library and the CLI:
             "loop_videos": false,
             "multicolor_keypoints": false,
             "notebook_height": 800,
+            "proxy_url": None,
             "show_confidence": true,
             "show_index": true,
             "show_label": true,

--- a/fiftyone/core/config.py
+++ b/fiftyone/core/config.py
@@ -347,6 +347,12 @@ class AppConfig(EnvConfig):
             env_var="FIFTYONE_APP_NOTEBOOK_HEIGHT",
             default=800,
         )
+        self.proxy_url = self.parse_string(
+            d,
+            "proxy_url",
+            env_var="FIFTYONE_APP_PROXY_URL",
+            default=None,
+        )
         self.show_confidence = self.parse_bool(
             d,
             "show_confidence",

--- a/fiftyone/core/context.py
+++ b/fiftyone/core/context.py
@@ -142,9 +142,11 @@ def _get_context():
 def get_url(
     address: str,
     port: int,
+    proxy_url: str = None,
     **kwargs: t.Dict[str, str],
 ) -> str:
     context = _get_context()
+
     if context == _COLAB:
         # pylint: disable=no-name-in-module,import-error
         from google.colab.output import eval_js
@@ -154,6 +156,8 @@ def get_url(
         _url = _get_databricks_proxy_url(port)
         kwargs["proxy"] = _get_databricks_proxy(port)
         kwargs["context"] = "databricks"
+    elif proxy_url:
+        _url = proxy_url if proxy_url.endswith("/") else f"{proxy_url}/"
     else:
         _url = f"http://{address}:{port}/"
 

--- a/fiftyone/core/context.py
+++ b/fiftyone/core/context.py
@@ -8,6 +8,7 @@ Context utilities.
 import json
 import os
 import typing as t
+from urllib.parse import urlparse
 
 try:
     import IPython.display
@@ -158,6 +159,7 @@ def get_url(
         kwargs["context"] = "databricks"
     elif proxy_url:
         _url = proxy_url if proxy_url.endswith("/") else f"{proxy_url}/"
+        kwargs["proxy"] = urlparse(_url).path
     else:
         _url = f"http://{address}:{port}/"
 

--- a/fiftyone/core/session/notebooks.py
+++ b/fiftyone/core/session/notebooks.py
@@ -72,7 +72,7 @@ def display_ipython(
     iframe = IPython.display.IFrame(
         focx.get_url(
             cell.address,
-            os.environ.get("FIFTYONE_APP_CLIENT_PORT", cell.port),
+            cell.port,
             notebook=True,
             proxy_url=proxy_url,
             subscription=cell.subscription,

--- a/fiftyone/core/session/notebooks.py
+++ b/fiftyone/core/session/notebooks.py
@@ -47,7 +47,10 @@ def capture(cell: NotebookCell, data: fose.CaptureNotebookCell) -> None:
 
 
 def display(
-    client: Client, cell: NotebookCell, reactivate: bool = False
+    client: Client,
+    cell: NotebookCell,
+    proxy_url: str = None,
+    reactivate: bool = False,
 ) -> None:
     """Displays a running FiftyOne instance."""
     funcs = {
@@ -56,12 +59,13 @@ def display(
         focx._DATABRICKS: display_databricks,
     }
     fn = funcs[focx._get_context()]
-    fn(client, cell, reactivate)
+    fn(client, cell, proxy_url=proxy_url, reactivate=reactivate)
 
 
 def display_ipython(
     client: Client,
     cell: NotebookCell,
+    proxy_url: str = None,
     reactivate: bool = False,
     **kwargs: t.Dict[str, t.Union[str, bool]],
 ) -> None:
@@ -70,6 +74,7 @@ def display_ipython(
             cell.address,
             os.environ.get("FIFTYONE_APP_CLIENT_PORT", cell.port),
             notebook=True,
+            proxy_url=proxy_url,
             subscription=cell.subscription,
             **kwargs,
         ),
@@ -83,7 +88,10 @@ def display_ipython(
 
 
 def display_colab(
-    client: Client, cell: NotebookCell, reactivate: bool = False
+    client: Client,
+    cell: NotebookCell,
+    proxy_url: str = None,
+    reactivate: bool = False,
 ) -> None:
     """Display a FiftyOne instance in a Colab output frame.
 
@@ -134,7 +142,10 @@ def display_colab(
 
 
 def display_databricks(
-    client: Client, cell: NotebookCell, reactivate: bool = False
+    client: Client,
+    cell: NotebookCell,
+    proxy_url: str = None,
+    reactivate: bool = False,
 ):
     """Display a FiftyOne instance in a Databricks output frame.
 
@@ -144,6 +155,7 @@ def display_databricks(
     display_ipython(
         client,
         cell,
-        reactivate=reactivate,
         polling=True,
+        proxy_url=proxy_url,
+        reactivate=reactivate,
     )

--- a/fiftyone/core/session/session.py
+++ b/fiftyone/core/session/session.py
@@ -552,7 +552,11 @@ class Session(object):
     @property
     def url(self) -> str:
         """The URL of the session."""
-        return focx.get_url(self.server_address, self.server_port)
+        return focx.get_url(
+            self.server_address,
+            self.server_port,
+            proxy_url=self.config.proxy_url,
+        )
 
     @property
     def config(self) -> AppConfig:

--- a/fiftyone/core/session/session.py
+++ b/fiftyone/core/session/session.py
@@ -20,7 +20,6 @@ import time
 import typing as t
 import webbrowser
 from uuid import uuid4
-from bson import json_util
 
 try:
     import IPython.display
@@ -1033,7 +1032,7 @@ class Session(object):
         )
 
         self._notebook_cells[uuid] = cell
-        fosn.display(self._client, cell)
+        fosn.display(self._client, cell, self.config.proxy_url)
 
     def no_show(self) -> fou.SetAttributes:
         """Returns a context manager that temporarily prevents new App


### PR DESCRIPTION
Resolves #2995 

Adds `proxy_url` to the `AppConfig` allowing for an override of the server URL. This only affect how the session resolves `session.url` for browser interactions, e.g. opening a tab or displaying a notebook cell