### PR TITLE
Customize Label Tag Color

### DIFF
--- a/app/packages/core/src/Dataset.ts
+++ b/app/packages/core/src/Dataset.ts
@@ -60,6 +60,13 @@ export const DatasetNodeQuery = graphql`
         sidebarMode
         colorScheme {
           colorPool
+          labelTags {
+            fieldColor
+            valueColors {
+              value
+              color
+            }
+          }
           fields {
             path
             fieldColor

--- a/app/packages/core/src/__generated__/DatasetQuery.graphql.ts
+++ b/app/packages/core/src/__generated__/DatasetQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<6f404d0f9acec7eb77405902128f79dc>>
+ * @generated SignedSource<<b9975ee97ebfe4d855e6f3a407867370>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -871,16 +871,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "9a31166d9423e91d2dc255435faedb12",
+    "cacheID": "d1c18fb84a78ffeb643841b589439bd9",
     "id": null,
     "metadata": {},
     "name": "DatasetQuery",
     "operationKind": "query",
-    "text": "query DatasetQuery(\n  $name: String!\n  $view: BSONArray = null\n  $savedViewSlug: String = null\n) {\n  ...DatasetSavedViewsFragment\n  dataset(name: $name, view: $view, savedViewSlug: $savedViewSlug) {\n    stages(slug: $savedViewSlug)\n    id\n    name\n    mediaType\n    defaultGroupSlice\n    groupField\n    groupSlice\n    groupMediaTypes {\n      name\n      mediaType\n    }\n    appConfig {\n      gridMediaField\n      mediaFields\n      modalMediaField\n      plugins\n      sidebarGroups {\n        expanded\n        paths\n        name\n      }\n      sidebarMode\n      colorScheme {\n        colorPool\n        fields {\n          path\n          fieldColor\n          colorByAttribute\n          valueColors {\n            value\n            color\n          }\n        }\n      }\n    }\n    sampleFields {\n      ftype\n      subfield\n      embeddedDocType\n      path\n      dbField\n      description\n      info\n    }\n    frameFields {\n      ftype\n      subfield\n      embeddedDocType\n      path\n      dbField\n      description\n      info\n    }\n    maskTargets {\n      name\n      targets {\n        target\n        value\n      }\n    }\n    defaultMaskTargets {\n      target\n      value\n    }\n    evaluations {\n      key\n      version\n      timestamp\n      viewStages\n      config {\n        cls\n        predField\n        gtField\n      }\n    }\n    brainMethods {\n      key\n      version\n      timestamp\n      viewStages\n      config {\n        cls\n        embeddingsField\n        method\n        patchesField\n        supportsPrompts\n        type\n        maxK\n        supportsLeastSimilarity\n      }\n    }\n    savedViews {\n      id\n      datasetId\n      name\n      slug\n      description\n      color\n      viewStages\n    }\n    lastLoadedAt\n    createdAt\n    skeletons {\n      name\n      labels\n      edges\n    }\n    defaultSkeleton {\n      labels\n      edges\n    }\n    version\n    viewCls\n    viewName\n    savedViewSlug\n    info\n  }\n}\n\nfragment DatasetSavedViewsFragment on Query {\n  savedViews(datasetName: $name) {\n    id\n    datasetId\n    name\n    slug\n    description\n    color\n    viewStages\n    createdAt\n    lastModifiedAt\n    lastLoadedAt\n  }\n}\n"
+    "text": "query DatasetQuery(\n  $name: String!\n  $view: BSONArray = null\n  $savedViewSlug: String = null\n) {\n  ...DatasetSavedViewsFragment\n  dataset(name: $name, view: $view, savedViewSlug: $savedViewSlug) {\n    stages(slug: $savedViewSlug)\n    id\n    name\n    mediaType\n    defaultGroupSlice\n    groupField\n    groupSlice\n    groupMediaTypes {\n      name\n      mediaType\n    }\n    appConfig {\n      gridMediaField\n      mediaFields\n      modalMediaField\n      plugins\n      sidebarGroups {\n        expanded\n        paths\n        name\n      }\n      sidebarMode\n      colorScheme {\n        colorPool\n        labelTags {\n          fieldColor\n          valueColors {\n            value\n            color\n          }\n        }\n        fields {\n          path\n          fieldColor\n          colorByAttribute\n          valueColors {\n            value\n            color\n          }\n        }\n      }\n    }\n    sampleFields {\n      ftype\n      subfield\n      embeddedDocType\n      path\n      dbField\n      description\n      info\n    }\n    frameFields {\n      ftype\n      subfield\n      embeddedDocType\n      path\n      dbField\n      description\n      info\n    }\n    maskTargets {\n      name\n      targets {\n        target\n        value\n      }\n    }\n    defaultMaskTargets {\n      target\n      value\n    }\n    evaluations {\n      key\n      version\n      timestamp\n      viewStages\n      config {\n        cls\n        predField\n        gtField\n      }\n    }\n    brainMethods {\n      key\n      version\n      timestamp\n      viewStages\n      config {\n        cls\n        embeddingsField\n        method\n        patchesField\n        supportsPrompts\n        type\n        maxK\n        supportsLeastSimilarity\n      }\n    }\n    savedViews {\n      id\n      datasetId\n      name\n      slug\n      description\n      color\n      viewStages\n    }\n    lastLoadedAt\n    createdAt\n    skeletons {\n      name\n      labels\n      edges\n    }\n    defaultSkeleton {\n      labels\n      edges\n    }\n    version\n    viewCls\n    viewName\n    savedViewSlug\n    info\n  }\n}\n\nfragment DatasetSavedViewsFragment on Query {\n  savedViews(datasetName: $name) {\n    id\n    datasetId\n    name\n    slug\n    description\n    color\n    viewStages\n    createdAt\n    lastModifiedAt\n    lastLoadedAt\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "85b4296e073b84791ee820bbc13af6bf";
+(node as any).hash = "25bc9c3b91800a69547fe67bf6cc5378";
 
 export default node;

--- a/app/packages/core/src/__generated__/DatasetQuery.graphql.ts
+++ b/app/packages/core/src/__generated__/DatasetQuery.graphql.ts
@@ -32,6 +32,13 @@ export type DatasetQuery$data = {
             readonly value: string;
           }> | null;
         }> | null;
+        readonly labelTags: {
+          readonly fieldColor: string | null;
+          readonly valueColors: ReadonlyArray<{
+            readonly color: string;
+            readonly value: string;
+          }> | null;
+        } | null;
       } | null;
       readonly gridMediaField: string | null;
       readonly mediaFields: ReadonlyArray<string> | null;
@@ -185,7 +192,7 @@ v6 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "path",
+  "name": "fieldColor",
   "storageKey": null
 },
 v7 = {
@@ -205,18 +212,38 @@ v8 = {
 v9 = {
   "alias": null,
   "args": null,
-  "kind": "ScalarField",
-  "name": "description",
+  "concreteType": "LabelSetting",
+  "kind": "LinkedField",
+  "name": "valueColors",
+  "plural": true,
+  "selections": [
+    (v7/*: any*/),
+    (v8/*: any*/)
+  ],
   "storageKey": null
 },
 v10 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
+  "name": "path",
+  "storageKey": null
+},
+v11 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "description",
+  "storageKey": null
+},
+v12 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
   "name": "info",
   "storageKey": null
 },
-v11 = [
+v13 = [
   {
     "alias": null,
     "args": null,
@@ -238,7 +265,7 @@ v11 = [
     "name": "embeddedDocType",
     "storageKey": null
   },
-  (v6/*: any*/),
+  (v10/*: any*/),
   {
     "alias": null,
     "args": null,
@@ -246,10 +273,10 @@ v11 = [
     "name": "dbField",
     "storageKey": null
   },
-  (v9/*: any*/),
-  (v10/*: any*/)
+  (v11/*: any*/),
+  (v12/*: any*/)
 ],
-v12 = [
+v14 = [
   {
     "alias": null,
     "args": null,
@@ -259,84 +286,84 @@ v12 = [
   },
   (v7/*: any*/)
 ],
-v13 = {
+v15 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "key",
   "storageKey": null
 },
-v14 = {
+v16 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "version",
   "storageKey": null
 },
-v15 = {
+v17 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "timestamp",
   "storageKey": null
 },
-v16 = {
+v18 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "viewStages",
   "storageKey": null
 },
-v17 = {
+v19 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "cls",
   "storageKey": null
 },
-v18 = {
+v20 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "datasetId",
   "storageKey": null
 },
-v19 = {
+v21 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "slug",
   "storageKey": null
 },
-v20 = {
+v22 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "lastLoadedAt",
   "storageKey": null
 },
-v21 = {
+v23 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "createdAt",
   "storageKey": null
 },
-v22 = {
+v24 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "labels",
   "storageKey": null
 },
-v23 = {
+v25 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "edges",
   "storageKey": null
 },
-v24 = {
+v26 = {
   "alias": null,
   "args": [
     {
@@ -497,19 +524,26 @@ v24 = {
             {
               "alias": null,
               "args": null,
+              "concreteType": "LabelTagColor",
+              "kind": "LinkedField",
+              "name": "labelTags",
+              "plural": false,
+              "selections": [
+                (v6/*: any*/),
+                (v9/*: any*/)
+              ],
+              "storageKey": null
+            },
+            {
+              "alias": null,
+              "args": null,
               "concreteType": "CustomizeColor",
               "kind": "LinkedField",
               "name": "fields",
               "plural": true,
               "selections": [
+                (v10/*: any*/),
                 (v6/*: any*/),
-                {
-                  "alias": null,
-                  "args": null,
-                  "kind": "ScalarField",
-                  "name": "fieldColor",
-                  "storageKey": null
-                },
                 {
                   "alias": null,
                   "args": null,
@@ -517,19 +551,7 @@ v24 = {
                   "name": "colorByAttribute",
                   "storageKey": null
                 },
-                {
-                  "alias": null,
-                  "args": null,
-                  "concreteType": "LabelSetting",
-                  "kind": "LinkedField",
-                  "name": "valueColors",
-                  "plural": true,
-                  "selections": [
-                    (v7/*: any*/),
-                    (v8/*: any*/)
-                  ],
-                  "storageKey": null
-                }
+                (v9/*: any*/)
               ],
               "storageKey": null
             }
@@ -546,7 +568,7 @@ v24 = {
       "kind": "LinkedField",
       "name": "sampleFields",
       "plural": true,
-      "selections": (v11/*: any*/),
+      "selections": (v13/*: any*/),
       "storageKey": null
     },
     {
@@ -556,7 +578,7 @@ v24 = {
       "kind": "LinkedField",
       "name": "frameFields",
       "plural": true,
-      "selections": (v11/*: any*/),
+      "selections": (v13/*: any*/),
       "storageKey": null
     },
     {
@@ -575,7 +597,7 @@ v24 = {
           "kind": "LinkedField",
           "name": "targets",
           "plural": true,
-          "selections": (v12/*: any*/),
+          "selections": (v14/*: any*/),
           "storageKey": null
         }
       ],
@@ -588,7 +610,7 @@ v24 = {
       "kind": "LinkedField",
       "name": "defaultMaskTargets",
       "plural": true,
-      "selections": (v12/*: any*/),
+      "selections": (v14/*: any*/),
       "storageKey": null
     },
     {
@@ -599,10 +621,10 @@ v24 = {
       "name": "evaluations",
       "plural": true,
       "selections": [
-        (v13/*: any*/),
-        (v14/*: any*/),
         (v15/*: any*/),
         (v16/*: any*/),
+        (v17/*: any*/),
+        (v18/*: any*/),
         {
           "alias": null,
           "args": null,
@@ -611,7 +633,7 @@ v24 = {
           "name": "config",
           "plural": false,
           "selections": [
-            (v17/*: any*/),
+            (v19/*: any*/),
             {
               "alias": null,
               "args": null,
@@ -640,10 +662,10 @@ v24 = {
       "name": "brainMethods",
       "plural": true,
       "selections": [
-        (v13/*: any*/),
-        (v14/*: any*/),
         (v15/*: any*/),
         (v16/*: any*/),
+        (v17/*: any*/),
+        (v18/*: any*/),
         {
           "alias": null,
           "args": null,
@@ -652,7 +674,7 @@ v24 = {
           "name": "config",
           "plural": false,
           "selections": [
-            (v17/*: any*/),
+            (v19/*: any*/),
             {
               "alias": null,
               "args": null,
@@ -717,17 +739,17 @@ v24 = {
       "plural": true,
       "selections": [
         (v3/*: any*/),
-        (v18/*: any*/),
+        (v20/*: any*/),
         (v4/*: any*/),
-        (v19/*: any*/),
-        (v9/*: any*/),
+        (v21/*: any*/),
+        (v11/*: any*/),
         (v8/*: any*/),
-        (v16/*: any*/)
+        (v18/*: any*/)
       ],
       "storageKey": null
     },
-    (v20/*: any*/),
-    (v21/*: any*/),
+    (v22/*: any*/),
+    (v23/*: any*/),
     {
       "alias": null,
       "args": null,
@@ -737,8 +759,8 @@ v24 = {
       "plural": true,
       "selections": [
         (v4/*: any*/),
-        (v22/*: any*/),
-        (v23/*: any*/)
+        (v24/*: any*/),
+        (v25/*: any*/)
       ],
       "storageKey": null
     },
@@ -750,12 +772,12 @@ v24 = {
       "name": "defaultSkeleton",
       "plural": false,
       "selections": [
-        (v22/*: any*/),
-        (v23/*: any*/)
+        (v24/*: any*/),
+        (v25/*: any*/)
       ],
       "storageKey": null
     },
-    (v14/*: any*/),
+    (v16/*: any*/),
     {
       "alias": null,
       "args": null,
@@ -777,7 +799,7 @@ v24 = {
       "name": "savedViewSlug",
       "storageKey": null
     },
-    (v10/*: any*/)
+    (v12/*: any*/)
   ],
   "storageKey": null
 };
@@ -797,7 +819,7 @@ return {
         "kind": "FragmentSpread",
         "name": "DatasetSavedViewsFragment"
       },
-      (v24/*: any*/)
+      (v26/*: any*/)
     ],
     "type": "Query",
     "abstractKey": null
@@ -827,13 +849,13 @@ return {
         "plural": true,
         "selections": [
           (v3/*: any*/),
-          (v18/*: any*/),
+          (v20/*: any*/),
           (v4/*: any*/),
-          (v19/*: any*/),
-          (v9/*: any*/),
-          (v8/*: any*/),
-          (v16/*: any*/),
           (v21/*: any*/),
+          (v11/*: any*/),
+          (v8/*: any*/),
+          (v18/*: any*/),
+          (v23/*: any*/),
           {
             "alias": null,
             "args": null,
@@ -841,11 +863,11 @@ return {
             "name": "lastModifiedAt",
             "storageKey": null
           },
-          (v20/*: any*/)
+          (v22/*: any*/)
         ],
         "storageKey": null
       },
-      (v24/*: any*/)
+      (v26/*: any*/)
     ]
   },
   "params": {

--- a/app/packages/core/src/components/ColorModal/ColorModal.tsx
+++ b/app/packages/core/src/components/ColorModal/ColorModal.tsx
@@ -23,6 +23,7 @@ import { Resizable } from "re-resizable";
 import { resizeHandle } from "./../Sidebar/Sidebar.module.css";
 import SidebarList from "./SidebarList";
 import { ACTIVE_FIELD } from "./utils";
+import LabelTag from "./LabelTag";
 
 const CUSTOM_COLOR_DOCUMENTATION_LINK =
   "https://docs.voxel51.com/user_guide/app.html#app-color-schemes";
@@ -139,6 +140,7 @@ const ColorModal = () => {
                   <Display>
                     {field === ACTIVE_FIELD.global && <GlobalSetting />}
                     {field === ACTIVE_FIELD.json && <JSONViewer />}
+                    {field === ACTIVE_FIELD._label_tags && <LabelTag />}
                     {typeof field !== "string" && field && (
                       <FieldSetting prop={activeColorModalField} />
                     )}

--- a/app/packages/core/src/components/ColorModal/FieldSetting.tsx
+++ b/app/packages/core/src/components/ColorModal/FieldSetting.tsx
@@ -44,7 +44,9 @@ const FieldSetting: React.FC<Prop> = ({ prop }) => {
   const pickerRef: React.RefObject<TwitterPicker> = React.useRef();
   const { field, expandedPath } = prop;
   const path = field?.path;
-  const { colorPool, fields } = useRecoilValue(fos.sessionColorScheme);
+  const { colorPool, fields, labelTags } = useRecoilValue(
+    fos.sessionColorScheme
+  );
   const setting = (fields ?? []).find((x) => x.path == path!);
   const setColorScheme = fos.useSetSessionColorScheme();
   const coloring = useRecoilValue(fos.coloring(false));
@@ -88,9 +90,9 @@ const FieldSetting: React.FC<Prop> = ({ prop }) => {
       const newSetting = cloneDeep(fields ?? []);
       const index = newSetting.findIndex((x) => x.path == path!);
       newSetting[index].fieldColor = color;
-      setColorScheme(false, { colorPool, fields: newSetting });
+      setColorScheme(false, { colorPool, fields: newSetting, labelTags });
     },
-    [fields, path, setColorScheme, colorPool]
+    [fields, path, setColorScheme, colorPool, labelTags]
   );
 
   const onValidateColor = useCallback(
@@ -142,7 +144,7 @@ const FieldSetting: React.FC<Prop> = ({ prop }) => {
         valueColors: [],
       } as fos.CustomizeColor;
       const newSetting = [...copy, defaultSetting];
-      setColorScheme(false, { colorPool, fields: newSetting });
+      setColorScheme(false, { colorPool, fields: newSetting, labelTags });
     }
     setState({
       useLabelColors: Boolean(
@@ -183,6 +185,7 @@ const FieldSetting: React.FC<Prop> = ({ prop }) => {
                 setColorScheme(false, {
                   colorPool,
                   fields: newSetting,
+                  labelTags,
                 });
               }
               setState((s) => ({ ...s, useFieldColor: v }));
@@ -263,6 +266,7 @@ const FieldSetting: React.FC<Prop> = ({ prop }) => {
                 setColorScheme(false, {
                   colorPool,
                   fields: newSetting,
+                  labelTags,
                 });
                 setState((s) => ({ ...s, useLabelColors: v }));
               }}

--- a/app/packages/core/src/components/ColorModal/FieldSetting.tsx
+++ b/app/packages/core/src/components/ColorModal/FieldSetting.tsx
@@ -29,6 +29,7 @@ import AttributeColorSetting from "./colorPalette/AttributeColorSetting";
 import { colorPicker } from "./colorPalette/Colorpicker.module.css";
 import ColorAttribute from "./controls/ColorAttribute";
 import ModeControl from "./controls/ModeControl";
+import { useResetColor } from "./useResetColor";
 
 type Prop = {
   prop: { field: Field; expandedPath: string };
@@ -40,8 +41,8 @@ type State = {
 };
 
 const FieldSetting: React.FC<Prop> = ({ prop }) => {
-  const wrapperRef: React.RefObject<HTMLDivElement> = React.useRef();
-  const pickerRef: React.RefObject<TwitterPicker> = React.useRef();
+  const wrapperRef = React.useRef<HTMLDivElement>(null);
+  const pickerRef = React.useRef<TwitterPicker>(null);
   const { field, expandedPath } = prop;
   const path = field?.path;
   const { colorPool, fields, labelTags } = useRecoilValue(
@@ -53,7 +54,7 @@ const FieldSetting: React.FC<Prop> = ({ prop }) => {
   const color = getColor(colorPool, coloring.seed, path);
 
   const [showFieldPicker, setShowFieldPicker] = useState(false);
-  const [input, setInput] = useState(color);
+  const [input, setInput] = useResetColor(color);
   const [colors, setColors] = useState(colorPool);
   const [state, setState] = useState<State>({
     useLabelColors: Boolean(
@@ -155,12 +156,6 @@ const FieldSetting: React.FC<Prop> = ({ prop }) => {
     });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [path, fields]);
-
-  // on reset, sync local state input with session values
-  useEffect(() => {
-    setInput(color);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [useRecoilValue(resetColor)]);
 
   fos.useOutsideClick(wrapperRef, () => {
     setShowFieldPicker(false);

--- a/app/packages/core/src/components/ColorModal/JSONViewer.tsx
+++ b/app/packages/core/src/components/ColorModal/JSONViewer.tsx
@@ -2,15 +2,14 @@ import { useTheme } from "@fiftyone/components";
 import { isValidColor } from "@fiftyone/looker/src/overlays/util";
 import * as fos from "@fiftyone/state";
 import Editor from "@monaco-editor/react";
+import { Link } from "@mui/material";
+import colorString from "color-string";
 import React, { useEffect, useMemo, useRef, useState } from "react";
 import { useRecoilValue } from "recoil";
 import { COLOR_SCHEME } from "../../utils/links";
-import { ActionOption } from "../Actions/Common";
 import { Button } from "../utils";
 import { SectionWrapper } from "./ShareStyledDiv";
-import { validateJSONSetting } from "./utils";
-import colorString from "color-string";
-import { Link } from "@mui/material";
+import { validateJSONSetting, validateLabelTags } from "./utils";
 
 const JSONViewer: React.FC = () => {
   const themeMode = useRecoilValue(fos.theme);
@@ -22,6 +21,7 @@ const JSONViewer: React.FC = () => {
     return {
       colorPool: sessionColor?.colorPool ?? [],
       fields: validateJSONSetting(sessionColor?.fields ?? []),
+      labelTags: sessionColor?.labelTags ?? {},
     };
   }, [sessionColor]);
   const setColorScheme = fos.useSetSessionColorScheme();
@@ -42,18 +42,21 @@ const JSONViewer: React.FC = () => {
       !data?.fields
     )
       return;
-    const { colorPool, fields } = data;
+    const { colorPool, fields, labelTags } = data;
     const validColors = colorPool
       ?.filter((c) => isValidColor(c))
       .map((c) => colorString.to.hex(colorString.get(c).value));
     const validatedSetting = validateJSONSetting(fields);
+    const validatedLabelTags = validateLabelTags(labelTags);
     setData({
       colorPool: validColors,
       fields: validatedSetting,
+      labelTags: validatedLabelTags,
     });
     setColorScheme(false, {
       colorPool: validColors,
       fields: validatedSetting,
+      labelTags: validatedLabelTags,
     });
   };
 

--- a/app/packages/core/src/components/ColorModal/JSONViewer.tsx
+++ b/app/packages/core/src/components/ColorModal/JSONViewer.tsx
@@ -21,7 +21,7 @@ const JSONViewer: React.FC = () => {
     return {
       colorPool: sessionColor?.colorPool ?? [],
       fields: validateJSONSetting(sessionColor?.fields ?? []),
-      labelTags: sessionColor?.labelTags ?? {},
+      labelTags: validateLabelTags(sessionColor?.labelTags) ?? {},
     };
   }, [sessionColor]);
   const setColorScheme = fos.useSetSessionColorScheme();

--- a/app/packages/core/src/components/ColorModal/LabelTag.tsx
+++ b/app/packages/core/src/components/ColorModal/LabelTag.tsx
@@ -26,8 +26,8 @@ type State = {
 };
 
 const LabelTag: React.FC = () => {
-  const wrapperRef: React.RefObject<HTMLDivElement> = React.useRef();
-  const pickerRef: React.RefObject<TwitterPicker> = React.useRef();
+  const wrapperRef = React.useRef<HTMLDivElement>(null);
+  const pickerRef = React.useRef<TwitterPicker>(null);
   const { colorPool, fields, labelTags } = useRecoilValue(
     fos.sessionColorScheme
   );

--- a/app/packages/core/src/components/ColorModal/LabelTag.tsx
+++ b/app/packages/core/src/components/ColorModal/LabelTag.tsx
@@ -1,0 +1,237 @@
+import { isValidColor } from "@fiftyone/looker/src/overlays/util";
+import * as fos from "@fiftyone/state";
+import { getColor } from "@fiftyone/utilities";
+import { Divider } from "@mui/material";
+import colorString from "color-string";
+import _, { cloneDeep } from "lodash";
+import React, { useCallback, useEffect, useState } from "react";
+import { TwitterPicker } from "react-color";
+import { useRecoilValue } from "recoil";
+import Checkbox from "../Common/Checkbox";
+import Input from "../Common/Input";
+import { resetColor } from "./ColorFooter";
+import {
+  FieldCHILD_STYLE,
+  FieldColorSquare,
+  PickerWrapper,
+  SectionWrapper,
+} from "./ShareStyledDiv";
+import AttributeColorSetting from "./colorPalette/AttributeColorSetting";
+import { colorPicker } from "./colorPalette/Colorpicker.module.css";
+import ColorAttribute from "./controls/ColorAttribute";
+import ModeControl from "./controls/ModeControl";
+
+type State = {
+  useLabelColors: boolean;
+  useFieldColor: boolean;
+};
+
+const LabelTag: React.FC = () => {
+  const wrapperRef: React.RefObject<HTMLDivElement> = React.useRef();
+  const pickerRef: React.RefObject<TwitterPicker> = React.useRef();
+  const { colorPool, fields, labelTags } = useRecoilValue(
+    fos.sessionColorScheme
+  );
+
+  const setColorScheme = fos.useSetSessionColorScheme();
+  const coloring = useRecoilValue(fos.coloring(false));
+  const color = getColor(colorPool, coloring.seed, "_label_tags");
+
+  const [showFieldPicker, setShowFieldPicker] = useState(false);
+  const [input, setInput] = useState(color);
+  const [colors, setColors] = useState(colorPool);
+  const [state, setState] = useState<State>({
+    useLabelColors: Boolean(
+      labelTags?.valueColors && labelTags.valueColors.length > 0
+    ),
+    useFieldColor: Boolean(labelTags?.fieldColor),
+  });
+
+  const defaultColor =
+    coloring.pool[Math.floor(Math.random() * coloring.pool.length)];
+
+  const onChangeFieldColor = useCallback(
+    (color) => {
+      const copy = cloneDeep(labelTags) ?? {};
+      copy["fieldColor"] = color;
+      setColorScheme(false, { colorPool, fields, labelTags: copy });
+    },
+    [setColorScheme, labelTags, colorPool, fields]
+  );
+
+  const onValidateColor = useCallback(
+    (input) => {
+      if (isValidColor(input)) {
+        const hexColor = colorString.to.hex(
+          colorString.get(input)?.value ?? []
+        );
+        onChangeFieldColor(hexColor);
+        setInput(hexColor);
+        setColors([...new Set([...colors, hexColor])]);
+      } else {
+        // revert input to previous value
+        setInput("invalid");
+        setTimeout(() => {
+          setInput(labelTags?.fieldColor);
+        }, 1000);
+      }
+    },
+    [onChangeFieldColor, colors, labelTags?.fieldColor]
+  );
+
+  const toggleColorPicker = (e) => {
+    if (e.target.id == "color-square") {
+      setShowFieldPicker(!showFieldPicker);
+    }
+  };
+
+  const hideFieldColorPicker = (e) => {
+    if (
+      e.target.id != "twitter-color-container" &&
+      !e.target.id.includes("input")
+    ) {
+      setShowFieldPicker(false);
+    }
+  };
+
+  // initialize field settings
+  useEffect(() => {
+    // check setting to see if custom setting exists
+
+    const copy = cloneDeep(labelTags) ?? {};
+    if (_.isEmpty(copy)) {
+      const defaultSetting = {
+        path: "_label_tags",
+        fieldColor: undefined,
+        valueColors: [],
+      } as fos.CustomizeColor;
+      setColorScheme(false, { colorPool, fields, labelTags: defaultSetting });
+    }
+    setState({
+      useLabelColors: Boolean(
+        labelTags?.valueColors && labelTags.valueColors.length > 0
+      ),
+      useFieldColor: Boolean(labelTags?.fieldColor),
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [labelTags]);
+
+  // on reset, sync local state input with session values
+  useEffect(() => {
+    setInput(color);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [useRecoilValue(resetColor)]);
+
+  fos.useOutsideClick(wrapperRef, () => {
+    setShowFieldPicker(false);
+  });
+
+  return (
+    <div>
+      <ModeControl />
+      <Divider />
+
+      <div style={{ margin: "1rem", width: "100%" }}>
+        <Checkbox
+          name={`Use custom color for label tags field`}
+          value={state.useFieldColor}
+          setValue={(v: boolean) => {
+            const copy = cloneDeep(labelTags);
+            copy.fieldColor = v ? labelTags?.fieldColor : undefined;
+            setColorScheme(false, {
+              colorPool,
+              fields,
+              labelTags: copy,
+            });
+            setState((s) => ({ ...s, useFieldColor: v }));
+          }}
+        />
+        {state?.useFieldColor && (
+          <div
+            style={{
+              margin: "1rem",
+              display: "flex",
+              flexDirection: "row",
+              alignItems: "end",
+            }}
+          >
+            <FieldColorSquare
+              color={labelTags?.fieldColor ?? input}
+              onClick={toggleColorPicker}
+              id="color-square"
+            >
+              {showFieldPicker && (
+                <PickerWrapper
+                  id="twitter-color-container"
+                  onBlur={hideFieldColorPicker}
+                  visible={showFieldPicker}
+                  tabIndex={0}
+                  ref={wrapperRef}
+                >
+                  <TwitterPicker
+                    color={input ?? labelTags?.fieldColor}
+                    colors={colors}
+                    onChange={(color) => setInput(color.hex)}
+                    onChangeComplete={(color) => {
+                      onChangeFieldColor(color.hex);
+                      setColors([...new Set([...colors, color.hex])]);
+                    }}
+                    className={colorPicker}
+                    ref={pickerRef}
+                  />
+                </PickerWrapper>
+              )}
+            </FieldColorSquare>
+            <Input
+              value={input}
+              setter={(v) => setInput(v)}
+              onBlur={() => onValidateColor(input)}
+              onEnter={() => onValidateColor(input)}
+              style={{
+                width: 120,
+                display: "inline-block",
+                margin: 3,
+              }}
+            />
+          </div>
+        )}
+      </div>
+
+      {coloring.by == "value" && (
+        <div>
+          <form
+            style={{ display: "flex", flexDirection: "column", margin: "1rem" }}
+          >
+            {/* set attribute value - color */}
+            <Checkbox
+              name={`Use custom colors for specific field values`}
+              value={state.useLabelColors}
+              setValue={(v: boolean) => {
+                const copy = cloneDeep(labelTags);
+                copy.valueColors = v
+                  ? [{ value: "", color: defaultColor }]
+                  : [];
+
+                setColorScheme(false, {
+                  colorPool,
+                  fields,
+                  labelTags: copy,
+                });
+                setState((s) => ({ ...s, useLabelColors: v }));
+              }}
+            />
+            {/* set the attribute used for color */}
+            <SectionWrapper>
+              <AttributeColorSetting
+                style={FieldCHILD_STYLE}
+                useLabelColors={state.useLabelColors}
+              />
+            </SectionWrapper>
+          </form>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default LabelTag;

--- a/app/packages/core/src/components/ColorModal/LabelTag.tsx
+++ b/app/packages/core/src/components/ColorModal/LabelTag.tsx
@@ -18,7 +18,6 @@ import {
 } from "./ShareStyledDiv";
 import AttributeColorSetting from "./colorPalette/AttributeColorSetting";
 import { colorPicker } from "./colorPalette/Colorpicker.module.css";
-import ColorAttribute from "./controls/ColorAttribute";
 import ModeControl from "./controls/ModeControl";
 
 type State = {
@@ -97,22 +96,20 @@ const LabelTag: React.FC = () => {
   // initialize field settings
   useEffect(() => {
     // check setting to see if custom setting exists
-
-    const copy = cloneDeep(labelTags) ?? {};
-    if (_.isEmpty(copy)) {
+    const copy = cloneDeep(labelTags);
+    if (!copy || _.isEmpty(copy)) {
       const defaultSetting = {
-        path: "_label_tags",
-        fieldColor: undefined,
+        fieldColor: color,
         valueColors: [],
       } as fos.CustomizeColor;
       setColorScheme(false, { colorPool, fields, labelTags: defaultSetting });
+      setState({
+        useLabelColors: Boolean(
+          labelTags?.valueColors && labelTags.valueColors.length > 0
+        ),
+        useFieldColor: Boolean(labelTags?.fieldColor),
+      });
     }
-    setState({
-      useLabelColors: Boolean(
-        labelTags?.valueColors && labelTags.valueColors.length > 0
-      ),
-      useFieldColor: Boolean(labelTags?.fieldColor),
-    });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [labelTags]);
 
@@ -131,73 +128,75 @@ const LabelTag: React.FC = () => {
       <ModeControl />
       <Divider />
 
-      <div style={{ margin: "1rem", width: "100%" }}>
-        <Checkbox
-          name={`Use custom color for label tags field`}
-          value={state.useFieldColor}
-          setValue={(v: boolean) => {
-            const copy = cloneDeep(labelTags);
-            copy.fieldColor = v ? labelTags?.fieldColor : undefined;
-            setColorScheme(false, {
-              colorPool,
-              fields,
-              labelTags: copy,
-            });
-            setState((s) => ({ ...s, useFieldColor: v }));
-          }}
-        />
-        {state?.useFieldColor && (
-          <div
-            style={{
-              margin: "1rem",
-              display: "flex",
-              flexDirection: "row",
-              alignItems: "end",
+      {coloring.by === "field" && (
+        <div style={{ margin: "1rem", width: "100%" }}>
+          <Checkbox
+            name={`Use custom color for label tags field`}
+            value={state.useFieldColor}
+            setValue={(v: boolean) => {
+              const copy = cloneDeep(labelTags);
+              copy.fieldColor = v ? labelTags?.fieldColor : undefined;
+              setColorScheme(false, {
+                colorPool,
+                fields,
+                labelTags: copy,
+              });
+              setState((s) => ({ ...s, useFieldColor: v }));
             }}
-          >
-            <FieldColorSquare
-              color={labelTags?.fieldColor ?? input}
-              onClick={toggleColorPicker}
-              id="color-square"
-            >
-              {showFieldPicker && (
-                <PickerWrapper
-                  id="twitter-color-container"
-                  onBlur={hideFieldColorPicker}
-                  visible={showFieldPicker}
-                  tabIndex={0}
-                  ref={wrapperRef}
-                >
-                  <TwitterPicker
-                    color={input ?? labelTags?.fieldColor}
-                    colors={colors}
-                    onChange={(color) => setInput(color.hex)}
-                    onChangeComplete={(color) => {
-                      onChangeFieldColor(color.hex);
-                      setColors([...new Set([...colors, color.hex])]);
-                    }}
-                    className={colorPicker}
-                    ref={pickerRef}
-                  />
-                </PickerWrapper>
-              )}
-            </FieldColorSquare>
-            <Input
-              value={input}
-              setter={(v) => setInput(v)}
-              onBlur={() => onValidateColor(input)}
-              onEnter={() => onValidateColor(input)}
+          />
+          {state?.useFieldColor && (
+            <div
               style={{
-                width: 120,
-                display: "inline-block",
-                margin: 3,
+                margin: "1rem",
+                display: "flex",
+                flexDirection: "row",
+                alignItems: "end",
               }}
-            />
-          </div>
-        )}
-      </div>
+            >
+              <FieldColorSquare
+                color={labelTags?.fieldColor ?? input}
+                onClick={toggleColorPicker}
+                id="color-square"
+              >
+                {showFieldPicker && (
+                  <PickerWrapper
+                    id="twitter-color-container"
+                    onBlur={hideFieldColorPicker}
+                    visible={showFieldPicker}
+                    tabIndex={0}
+                    ref={wrapperRef}
+                  >
+                    <TwitterPicker
+                      color={input ?? labelTags?.fieldColor}
+                      colors={colors}
+                      onChange={(color) => setInput(color.hex)}
+                      onChangeComplete={(color) => {
+                        onChangeFieldColor(color.hex);
+                        setColors([...new Set([...colors, color.hex])]);
+                      }}
+                      className={colorPicker}
+                      ref={pickerRef}
+                    />
+                  </PickerWrapper>
+                )}
+              </FieldColorSquare>
+              <Input
+                value={input}
+                setter={(v) => setInput(v)}
+                onBlur={() => onValidateColor(input)}
+                onEnter={() => onValidateColor(input)}
+                style={{
+                  width: 120,
+                  display: "inline-block",
+                  margin: 3,
+                }}
+              />
+            </div>
+          )}
+        </div>
+      )}
 
-      {coloring.by == "value" && (
+      {coloring.by === "value" && (
         <div>
           <form
             style={{ display: "flex", flexDirection: "column", margin: "1rem" }}
@@ -220,7 +219,6 @@ const LabelTag: React.FC = () => {
                 setState((s) => ({ ...s, useLabelColors: v }));
               }}
             />
-            {/* set the attribute used for color */}
             <SectionWrapper>
               <AttributeColorSetting
                 style={FieldCHILD_STYLE}

--- a/app/packages/core/src/components/ColorModal/SidebarList.tsx
+++ b/app/packages/core/src/components/ColorModal/SidebarList.tsx
@@ -37,7 +37,6 @@ const SidebarList: React.FC = () => {
   const onSelectField = useRecoilCallback(
     ({ set, snapshot }) =>
       async (path: string) => {
-        console.info("onSelectField", path);
         if (
           [
             ACTIVE_FIELD.global,

--- a/app/packages/core/src/components/ColorModal/SidebarList.tsx
+++ b/app/packages/core/src/components/ColorModal/SidebarList.tsx
@@ -22,11 +22,10 @@ const SidebarList: React.FC = () => {
   const [width, setWidth] = useState(WIDTH);
   const stableGroup = [
     { paths: [ACTIVE_FIELD.global, ACTIVE_FIELD.json], name: "general" },
-    { paths: ["tags", ACTIVE_FIELD._label_tags], name: "tags" },
   ];
   const fieldGroups = useRecoilValue(
     fos.sidebarGroups({ modal: false, loading: false })
-  ).filter((g) => g.name !== "tags");
+  );
   const groups = [...stableGroup, ...fieldGroups];
   const [groupOpen, setGroupOpen] = React.useState(
     new Array(groups.length).fill(true)

--- a/app/packages/core/src/components/ColorModal/SidebarList.tsx
+++ b/app/packages/core/src/components/ColorModal/SidebarList.tsx
@@ -37,6 +37,7 @@ const SidebarList: React.FC = () => {
   const onSelectField = useRecoilCallback(
     ({ set, snapshot }) =>
       async (path: string) => {
+        console.info("onSelectField", path);
         if (
           [
             ACTIVE_FIELD.global,

--- a/app/packages/core/src/components/ColorModal/SidebarList.tsx
+++ b/app/packages/core/src/components/ColorModal/SidebarList.tsx
@@ -22,7 +22,7 @@ const SidebarList: React.FC = () => {
   const [width, setWidth] = useState(WIDTH);
   const stableGroup = [
     { paths: [ACTIVE_FIELD.global, ACTIVE_FIELD.json], name: "general" },
-    { paths: ["tags"], name: "tags" },
+    { paths: ["tags", ACTIVE_FIELD._label_tags], name: "tags" },
   ];
   const fieldGroups = useRecoilValue(
     fos.sidebarGroups({ modal: false, loading: false })
@@ -38,7 +38,13 @@ const SidebarList: React.FC = () => {
   const onSelectField = useRecoilCallback(
     ({ set, snapshot }) =>
       async (path: string) => {
-        if ([ACTIVE_FIELD.global, ACTIVE_FIELD.json].includes(path)) {
+        if (
+          [
+            ACTIVE_FIELD.global,
+            ACTIVE_FIELD.json,
+            ACTIVE_FIELD._label_tags,
+          ].includes(path)
+        ) {
           set(fos.activeColorField, path);
         } else {
           const field = await snapshot.getPromise(fos.field(path));
@@ -51,6 +57,8 @@ const SidebarList: React.FC = () => {
   const getCurrentField = (activeField) => {
     if (activeField === ACTIVE_FIELD.global) return ACTIVE_FIELD.global;
     if (activeField === ACTIVE_FIELD.json) return ACTIVE_FIELD.json;
+    if (activeField === ACTIVE_FIELD._label_tags)
+      return ACTIVE_FIELD._label_tags;
 
     return activeField?.expandedPath;
   };

--- a/app/packages/core/src/components/ColorModal/colorPalette/AttributeColorSetting.tsx
+++ b/app/packages/core/src/components/ColorModal/colorPalette/AttributeColorSetting.tsx
@@ -218,25 +218,37 @@ const AttributeColorSetting: React.FC<ColorPickerRowProps> = ({
   useEffect(() => {
     if (!values) {
       const copy = cloneDeep(fields);
-
       const idx = fields.findIndex((s) => s.path == activePath);
       if (idx > -1) {
         copy[idx]["valueColors"] = [defaultValue];
         setColorScheme(false, { colorPool, fields: copy, labelTags });
       }
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [values, activePath]);
+  }, [
+    values,
+    activePath,
+    fields,
+    defaultValue,
+    setColorScheme,
+    colorPool,
+    labelTags,
+  ]);
 
   useEffect(() => {
     if (!labelTags?.valueColors) {
       const copy = cloneDeep(labelTags);
-
       copy["valueColors"] = [defaultValue];
       setColorScheme(false, { colorPool, fields, labelTags: copy });
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [labelTags?.valueColors, activePath]);
+  }, [
+    labelTags?.valueColors,
+    activePath,
+    labelTags,
+    defaultValue,
+    setColorScheme,
+    colorPool,
+    fields,
+  ]);
 
   // on reset, sync local state with new session values
   useEffect(() => {

--- a/app/packages/core/src/components/ColorModal/colorPalette/ColorPalette.tsx
+++ b/app/packages/core/src/components/ColorModal/colorPalette/ColorPalette.tsx
@@ -24,18 +24,19 @@ const ColorPalette: React.FC<ColorPaletteProps> = ({
   maxColors = 20,
   style,
 }) => {
-  const computedSessionColorScheme = useRecoilValue(fos.sessionColorScheme);
+  const { colorPool, fields, labelTags } = useRecoilValue(
+    fos.sessionColorScheme
+  );
   const setColorScheme = fos.useSetSessionColorScheme();
-  const colors = computedSessionColorScheme.colorPool;
   const [pickerColor, setPickerColor] = useState<string | null>(null);
 
   const isUsingColorBlindOption = isSameArray(
-    colors,
+    colorPool,
     colorBlindFriendlyPalette
   );
 
   const isUsingFiftyoneClassic = isSameArray(
-    colors,
+    colorPool,
     fiftyoneDefaultColorPalette
   );
 
@@ -47,29 +48,32 @@ const ColorPalette: React.FC<ColorPaletteProps> = ({
 
   const handleColorChange = (color: any) => {
     if (activeIndex !== null && color) {
-      const newColors = colors ? [...colors] : [];
+      const newColors = colorPool ? [...colorPool] : [];
       newColors[activeIndex] = color.hex;
       setColorScheme(false, {
         colorPool: newColors,
-        fields: computedSessionColorScheme.fields,
+        fields,
+        labelTags,
       });
     }
   };
 
   const handleColorDelete = (index: number) => {
-    const newColors = colors ? [...colors] : [];
+    const newColors = colorPool ? [...colorPool] : [];
     newColors.splice(index, 1);
     setColorScheme(false, {
       colorPool: newColors,
-      fields: computedSessionColorScheme.fields,
+      fields,
+      labelTags,
     });
   };
 
   const handleColorAdd = () => {
-    if (colors?.length < maxColors) {
+    if (colorPool?.length < maxColors) {
       setColorScheme(false, {
-        colorPool: [...colors, "#ffffff"],
-        fields: computedSessionColorScheme.fields,
+        colorPool: [...colorPool, "#ffffff"],
+        fields,
+        labelTags,
       });
     }
   };
@@ -83,12 +87,12 @@ const ColorPalette: React.FC<ColorPaletteProps> = ({
     if (!showPicker) setPickerColor(null);
   }, [showPicker]);
 
-  if (!colors) return null;
+  if (!colorPool) return null;
 
   return (
     <div style={style} id="color-palette">
       <ColorPaletteContainer>
-        {colors.map((color, index) => (
+        {colorPool.map((color, index) => (
           <ColorSquare
             key={index}
             color={color}
@@ -130,7 +134,7 @@ const ColorPalette: React.FC<ColorPaletteProps> = ({
             )}
           </ColorSquare>
         ))}
-        {colors.length < maxColors && (
+        {colorPool.length < maxColors && (
           <AddSquare onClick={handleColorAdd}>
             <AddIcon>+</AddIcon>
           </AddSquare>
@@ -145,7 +149,8 @@ const ColorPalette: React.FC<ColorPaletteProps> = ({
               v &&
               setColorScheme(false, {
                 colorPool: fiftyoneDefaultColorPalette,
-                fields: computedSessionColorScheme.fields,
+                fields,
+                labelTags,
               })
             }
           />
@@ -158,7 +163,8 @@ const ColorPalette: React.FC<ColorPaletteProps> = ({
               v &&
               setColorScheme(false, {
                 colorPool: colorBlindFriendlyPalette,
-                fields: computedSessionColorScheme.fields,
+                fields,
+                labelTags,
               })
             }
           />

--- a/app/packages/core/src/components/ColorModal/controls/ColorAttribute.tsx
+++ b/app/packages/core/src/components/ColorModal/controls/ColorAttribute.tsx
@@ -45,7 +45,9 @@ const ColorAttribute: React.FC<Prop> = ({ eligibleFields, style }) => {
 
   const setColorScheme = fos.useSetSessionColorScheme();
   const activeField = useRecoilValue(fos.activeColorField).field as Field;
-  const { colorPool, fields } = useRecoilValue(fos.sessionColorScheme);
+  const { colorPool, fields, labelTags } = useRecoilValue(
+    fos.sessionColorScheme
+  );
   const index = fields.findIndex((s) => s.path == activeField.path);
 
   const options = eligibleFields.map((field) => ({
@@ -55,7 +57,7 @@ const ColorAttribute: React.FC<Prop> = ({ eligibleFields, style }) => {
       const copy = cloneDeep(fields);
       if (index > -1) {
         copy[index].colorByAttribute = field.path?.split(".").slice(-1)[0];
-        setColorScheme(false, { colorPool, fields: copy });
+        setColorScheme(false, { colorPool, labelTags, fields: copy });
         setOpen(false);
       }
     },

--- a/app/packages/core/src/components/ColorModal/useResetColor.ts
+++ b/app/packages/core/src/components/ColorModal/useResetColor.ts
@@ -1,0 +1,16 @@
+import { Dispatch, SetStateAction, useEffect, useState } from "react";
+import { useRecoilValue } from "recoil";
+import { resetColor } from "./ColorFooter";
+
+type UseResetColorReturnType = [string, Dispatch<SetStateAction<string>>];
+
+export function useResetColor(initialColor: string): UseResetColorReturnType {
+  const [color, setColor] = useState(initialColor);
+  const resetCounter = useRecoilValue(resetColor);
+
+  useEffect(() => {
+    setColor(initialColor);
+  }, [resetCounter, initialColor]);
+
+  return [color, setColor];
+}

--- a/app/packages/core/src/components/ColorModal/utils.ts
+++ b/app/packages/core/src/components/ColorModal/utils.ts
@@ -85,6 +85,15 @@ export const validateJSONSetting = (json: unknown[]) => {
   }) as fos.CustomizeColor[];
 };
 
+export const validateLabelTags = (json: unknown) => {
+  if (!json || !isObject(json)) return {};
+  const fieldColor = json["fieldColor"] ?? null;
+  const valueColors = Array.isArray(json["valueColors"])
+    ? getValidLabelColors(json["valueColors"])
+    : null;
+  return { fieldColor, valueColors } as fos.TagColor;
+};
+
 export const isDefaultSetting = (savedSetting: fos.ColorScheme) => {
   return (
     isSameArray(

--- a/app/packages/core/src/components/ColorModal/utils.ts
+++ b/app/packages/core/src/components/ColorModal/utils.ts
@@ -35,7 +35,7 @@ export const fiftyoneDefaultColorPalette = [
 export const ACTIVE_FIELD = {
   ["json"]: "JSON editor",
   ["global"]: "Global settings",
-  ["_label_tags"]: "label tags",
+  ["_label_tags"]: "_label_tags",
 };
 
 // disregard the order
@@ -91,7 +91,11 @@ export const validateLabelTags = (json: unknown) => {
   const valueColors = Array.isArray(json["valueColors"])
     ? getValidLabelColors(json["valueColors"])
     : null;
-  return { fieldColor, valueColors } as fos.TagColor;
+  if (fieldColor || (valueColors && valueColors?.length > 0)) {
+    return { fieldColor, valueColors } as fos.TagColor;
+  } else {
+    return {};
+  }
 };
 
 export const isDefaultSetting = (savedSetting: fos.ColorScheme) => {

--- a/app/packages/core/src/components/ColorModal/utils.ts
+++ b/app/packages/core/src/components/ColorModal/utils.ts
@@ -96,8 +96,12 @@ export const isDefaultSetting = (savedSetting: fos.ColorScheme) => {
 };
 
 export const getDisplayName = (path: string) => {
-  if (path === "tags") {
-    return "sample tags";
+  switch (path) {
+    case "tags":
+      return "sample tags";
+    case "_label_tags":
+      return "label tags";
+    default:
+      return path;
   }
-  return path;
 };

--- a/app/packages/core/src/components/FieldLabelAndInfo/index.tsx
+++ b/app/packages/core/src/components/FieldLabelAndInfo/index.tsx
@@ -261,7 +261,11 @@ function FieldInfoExpanded({
   const colorBy = colorSettings.by;
   const onClickCustomizeColor = () => {
     // open the color customization modal based on colorBy status
-    setIsCustomizingColor({ field, expandedPath });
+    if (field.path === ACTIVE_FIELD["_label_tags"]) {
+      setIsCustomizingColor(ACTIVE_FIELD[field.path]);
+    } else {
+      setIsCustomizingColor({ field, expandedPath });
+    }
   };
 
   useEffect(updatePosition, [field, isCollapsed]);

--- a/app/packages/core/src/components/FieldLabelAndInfo/index.tsx
+++ b/app/packages/core/src/components/FieldLabelAndInfo/index.tsx
@@ -124,9 +124,7 @@ const FieldLabelAndInfo = ({
   return (
     <>
       {template({ ...fieldInfo, FieldInfoIcon })}
-      {field.path !== "_label_tags" && fieldInfo.open && (
-        <FieldInfoExpanded {...fieldInfo} />
-      )}
+      {fieldInfo.open && <FieldInfoExpanded {...fieldInfo} />}
     </>
   );
 };

--- a/app/packages/core/src/components/FieldLabelAndInfo/index.tsx
+++ b/app/packages/core/src/components/FieldLabelAndInfo/index.tsx
@@ -19,6 +19,7 @@ import {
 } from "recoil";
 import styled from "styled-components";
 import { ExternalLink } from "../../utils/generic";
+import { ACTIVE_FIELD } from "../ColorModal/utils";
 
 const selectedFieldInfo = atom<string | null>({
   key: "selectedFieldInfo",

--- a/app/packages/looker/src/elements/common/tags.ts
+++ b/app/packages/looker/src/elements/common/tags.ts
@@ -35,6 +35,9 @@ import {
   prettify,
 } from "./util";
 
+import { lookerTags } from "./tags.module.css";
+import _ from "lodash";
+
 interface TagData {
   color: string;
   title: string;
@@ -45,6 +48,7 @@ interface TagData {
 export class TagsElement<State extends BaseState> extends BaseElement<State> {
   private activePaths: string[] = [];
   private customizedColors: CustomizeColor[] = [];
+  private labelTagColors: CustomizeColor = {};
   private colorPool: string[];
   private colorByValue: boolean;
   private colorSeed: number;
@@ -63,7 +67,13 @@ export class TagsElement<State extends BaseState> extends BaseElement<State> {
   renderSelf(
     {
       config: { fieldSchema, ...r },
-      options: { activePaths, coloring, timeZone, customizeColorSetting },
+      options: {
+        activePaths,
+        coloring,
+        timeZone,
+        customizeColorSetting,
+        labelTagColors,
+      },
       playing,
     }: Readonly<State>,
     sample: Readonly<Sample>
@@ -79,6 +89,7 @@ export class TagsElement<State extends BaseState> extends BaseElement<State> {
         this.colorByValue === (coloring.by === "value") &&
         arraysAreEqual(this.colorPool, coloring.pool as string[]) &&
         compareObjectArrays(this.customizedColors, customizeColorSetting) &&
+        _.isEqual(this.labelTagColors, labelTagColors) &&
         this.colorSeed === coloring.seed) ||
       !sample
     ) {
@@ -282,7 +293,13 @@ export class TagsElement<State extends BaseState> extends BaseElement<State> {
           const value = `${tag}: ${count}`;
           const v = coloring.by === "value" ? tag : path;
           elements.push({
-            color: getColor(coloring.pool, coloring.seed, v),
+            color: getColorFromOptions({
+              coloring,
+              path,
+              param: tag,
+              labelTagColors,
+              labelDefault: false,
+            }),
             title: value,
             value: value,
             path: v,
@@ -356,6 +373,7 @@ export class TagsElement<State extends BaseState> extends BaseElement<State> {
     this.activePaths = [...activePaths];
     this.element.innerHTML = "";
     this.customizedColors = customizeColorSetting;
+    this.labelTagColors = labelTagColors;
     this.colorPool = coloring.pool as string[];
 
     elements

--- a/app/packages/looker/src/state.ts
+++ b/app/packages/looker/src/state.ts
@@ -131,6 +131,7 @@ interface BaseOptions {
   filter: (path: string, value: unknown) => boolean;
   coloring: Coloring;
   customizeColorSetting: CustomizeColor[];
+  labelTagColors: CustomizeColor;
   selectedLabels: string[];
   showConfidence: boolean;
   showControls: boolean;

--- a/app/packages/looker/src/worker/painter.ts
+++ b/app/packages/looker/src/worker/painter.ts
@@ -23,7 +23,7 @@ export const PainterFactory = (requestColor) => ({
     let color;
     if (coloring.by === "field") {
       if (setting?.fieldColor) {
-        color = setting.fieldColor;
+        color = field === setting.fieldColor;
       } else {
         color = await requestColor(coloring.pool, coloring.seed, field);
       }

--- a/app/packages/relay/src/mutations/__generated__/setColorSchemeMutation.graphql.ts
+++ b/app/packages/relay/src/mutations/__generated__/setColorSchemeMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<98eab1035b9a3cd4474a2cda909c13c0>>
+ * @generated SignedSource<<db0fc00d6735058b89f2d344c9583004>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -12,6 +12,7 @@ import { ConcreteRequest, Mutation } from 'relay-runtime';
 export type ColorSchemeInput = {
   colorPool?: ReadonlyArray<string> | null;
   fields?: Array | null;
+  labelTags?: object | null;
 };
 export type setColorSchemeMutation$variables = {
   colorScheme: ColorSchemeInput;

--- a/app/packages/relay/src/mutations/__generated__/setViewMutation.graphql.ts
+++ b/app/packages/relay/src/mutations/__generated__/setViewMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<9a5243b073307efa634a4c9acfb36b4f>>
+ * @generated SignedSource<<cf7ede8b82b1b3cad559d3b091be8235>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -49,6 +49,13 @@ export type setViewMutation$data = {
               readonly value: string;
             }> | null;
           }> | null;
+          readonly labelTags: {
+            readonly fieldColor: string | null;
+            readonly valueColors: ReadonlyArray<{
+              readonly color: string;
+              readonly value: string;
+            }> | null;
+          } | null;
         } | null;
         readonly gridMediaField: string | null;
         readonly mediaFields: ReadonlyArray<string> | null;
@@ -352,7 +359,27 @@ v23 = {
   "name": "edges",
   "storageKey": null
 },
-v24 = [
+v24 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "fieldColor",
+  "storageKey": null
+},
+v25 = {
+  "alias": null,
+  "args": null,
+  "concreteType": "LabelSetting",
+  "kind": "LinkedField",
+  "name": "valueColors",
+  "plural": true,
+  "selections": [
+    (v12/*: any*/),
+    (v14/*: any*/)
+  ],
+  "storageKey": null
+},
+v26 = [
   {
     "alias": null,
     "args": [
@@ -768,19 +795,26 @@ v24 = [
                   {
                     "alias": null,
                     "args": null,
+                    "concreteType": "LabelTagColor",
+                    "kind": "LinkedField",
+                    "name": "labelTags",
+                    "plural": false,
+                    "selections": [
+                      (v24/*: any*/),
+                      (v25/*: any*/)
+                    ],
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
                     "concreteType": "CustomizeColor",
                     "kind": "LinkedField",
                     "name": "fields",
                     "plural": true,
                     "selections": [
                       (v9/*: any*/),
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "fieldColor",
-                        "storageKey": null
-                      },
+                      (v24/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -788,19 +822,7 @@ v24 = [
                         "name": "colorByAttribute",
                         "storageKey": null
                       },
-                      {
-                        "alias": null,
-                        "args": null,
-                        "concreteType": "LabelSetting",
-                        "kind": "LinkedField",
-                        "name": "valueColors",
-                        "plural": true,
-                        "selections": [
-                          (v12/*: any*/),
-                          (v14/*: any*/)
-                        ],
-                        "storageKey": null
-                      }
+                      (v25/*: any*/)
                     ],
                     "storageKey": null
                   }
@@ -837,7 +859,7 @@ return {
     "kind": "Fragment",
     "metadata": null,
     "name": "setViewMutation",
-    "selections": (v24/*: any*/),
+    "selections": (v26/*: any*/),
     "type": "Mutation",
     "abstractKey": null
   },
@@ -853,19 +875,19 @@ return {
     ],
     "kind": "Operation",
     "name": "setViewMutation",
-    "selections": (v24/*: any*/)
+    "selections": (v26/*: any*/)
   },
   "params": {
-    "cacheID": "2b8857ad8836b170cef260a3b4de211b",
+    "cacheID": "99507229e94a0296813e8addd6bd16cb",
     "id": null,
     "metadata": {},
     "name": "setViewMutation",
     "operationKind": "mutation",
-    "text": "mutation setViewMutation(\n  $subscription: String!\n  $session: String\n  $view: BSONArray!\n  $savedViewSlug: String\n  $datasetName: String!\n  $form: StateForm!\n) {\n  setView(subscription: $subscription, session: $session, view: $view, savedViewSlug: $savedViewSlug, datasetName: $datasetName, form: $form) {\n    dataset {\n      id\n      name\n      mediaType\n      groupSlice\n      defaultGroupSlice\n      groupField\n      groupMediaTypes {\n        name\n        mediaType\n      }\n      stages(slug: $savedViewSlug)\n      sampleFields {\n        ftype\n        subfield\n        embeddedDocType\n        path\n        dbField\n        description\n        info\n      }\n      frameFields {\n        ftype\n        subfield\n        embeddedDocType\n        path\n        dbField\n        description\n        info\n      }\n      maskTargets {\n        name\n        targets {\n          target\n          value\n        }\n      }\n      defaultMaskTargets {\n        target\n        value\n      }\n      savedViews {\n        id\n        name\n        description\n        color\n        viewStages\n        slug\n        createdAt\n        lastModifiedAt\n        lastLoadedAt\n      }\n      evaluations {\n        key\n        version\n        timestamp\n        viewStages\n        config {\n          cls\n          predField\n          gtField\n        }\n      }\n      brainMethods {\n        key\n        version\n        timestamp\n        viewStages\n        config {\n          cls\n          embeddingsField\n          method\n          patchesField\n          supportsPrompts\n          type\n        }\n      }\n      lastLoadedAt\n      createdAt\n      version\n      viewCls\n      viewName\n      skeletons {\n        name\n        labels\n        edges\n      }\n      defaultSkeleton {\n        labels\n        edges\n      }\n      appConfig {\n        gridMediaField\n        mediaFields\n        modalMediaField\n        plugins\n        sidebarGroups {\n          expanded\n          name\n          paths\n        }\n        sidebarMode\n        colorScheme {\n          colorPool\n          fields {\n            path\n            fieldColor\n            colorByAttribute\n            valueColors {\n              value\n              color\n            }\n          }\n        }\n      }\n    }\n    view\n  }\n}\n"
+    "text": "mutation setViewMutation(\n  $subscription: String!\n  $session: String\n  $view: BSONArray!\n  $savedViewSlug: String\n  $datasetName: String!\n  $form: StateForm!\n) {\n  setView(subscription: $subscription, session: $session, view: $view, savedViewSlug: $savedViewSlug, datasetName: $datasetName, form: $form) {\n    dataset {\n      id\n      name\n      mediaType\n      groupSlice\n      defaultGroupSlice\n      groupField\n      groupMediaTypes {\n        name\n        mediaType\n      }\n      stages(slug: $savedViewSlug)\n      sampleFields {\n        ftype\n        subfield\n        embeddedDocType\n        path\n        dbField\n        description\n        info\n      }\n      frameFields {\n        ftype\n        subfield\n        embeddedDocType\n        path\n        dbField\n        description\n        info\n      }\n      maskTargets {\n        name\n        targets {\n          target\n          value\n        }\n      }\n      defaultMaskTargets {\n        target\n        value\n      }\n      savedViews {\n        id\n        name\n        description\n        color\n        viewStages\n        slug\n        createdAt\n        lastModifiedAt\n        lastLoadedAt\n      }\n      evaluations {\n        key\n        version\n        timestamp\n        viewStages\n        config {\n          cls\n          predField\n          gtField\n        }\n      }\n      brainMethods {\n        key\n        version\n        timestamp\n        viewStages\n        config {\n          cls\n          embeddingsField\n          method\n          patchesField\n          supportsPrompts\n          type\n        }\n      }\n      lastLoadedAt\n      createdAt\n      version\n      viewCls\n      viewName\n      skeletons {\n        name\n        labels\n        edges\n      }\n      defaultSkeleton {\n        labels\n        edges\n      }\n      appConfig {\n        gridMediaField\n        mediaFields\n        modalMediaField\n        plugins\n        sidebarGroups {\n          expanded\n          name\n          paths\n        }\n        sidebarMode\n        colorScheme {\n          colorPool\n          labelTags {\n            fieldColor\n            valueColors {\n              value\n              color\n            }\n          }\n          fields {\n            path\n            fieldColor\n            colorByAttribute\n            valueColors {\n              value\n              color\n            }\n          }\n        }\n      }\n    }\n    view\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "c7e809b8883323c8f0b80af440a0d830";
+(node as any).hash = "8857da23e7e07d6599c0ef50ba834454";
 
 export default node;

--- a/app/packages/relay/src/mutations/setView.ts
+++ b/app/packages/relay/src/mutations/setView.ts
@@ -123,6 +123,13 @@ export default r(graphql`
           sidebarMode
           colorScheme {
             colorPool
+            labelTags {
+              fieldColor
+              valueColors {
+                value
+                color
+              }
+            }
             fields {
               path
               fieldColor

--- a/app/packages/relay/src/queries/__generated__/viewSchemaFragment.graphql.ts
+++ b/app/packages/relay/src/queries/__generated__/viewSchemaFragment.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<7ef0138316d531c3ab955081d6692334>>
+ * @generated SignedSource<<add70884bae39830061041624d34323e>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -19,7 +19,7 @@ export type viewSchemaFragment$data = {
       readonly info: object | null;
       readonly path: string;
       readonly subfield: string | null;
-    } | null>;
+    }>;
     readonly frameFieldSchema: ReadonlyArray<{
       readonly description: string | null;
       readonly embeddedDocType: string | null;
@@ -27,8 +27,8 @@ export type viewSchemaFragment$data = {
       readonly info: object | null;
       readonly path: string;
       readonly subfield: string | null;
-    } | null>;
-  } | null;
+    }>;
+  };
   readonly " $fragmentType": "viewSchemaFragment";
 };
 export type viewSchemaFragment$key = {

--- a/app/packages/state/src/hooks/useSetSessionColorScheme.ts
+++ b/app/packages/state/src/hooks/useSetSessionColorScheme.ts
@@ -31,6 +31,7 @@ const useSetSessionColorScheme = () => {
                 colorScheme: {
                   colorPool: setting.colorPool,
                   fields: setting.fields,
+                  labelTags: setting.labelTags,
                 },
               },
             };
@@ -57,6 +58,10 @@ const useSetSessionColorScheme = () => {
             defaultSetting?.fields && !saveToApp
               ? defaultSetting.fields
               : DEFAULT_APP_COLOR_SCHEME.fields,
+          labelTags:
+            defaultSetting?.labelTags && !saveToApp
+              ? defaultSetting.labelTags
+              : DEFAULT_APP_COLOR_SCHEME.labelTags,
         };
 
         if (colorScheme == null) {

--- a/app/packages/state/src/hooks/useStateUpdate.ts
+++ b/app/packages/state/src/hooks/useStateUpdate.ts
@@ -128,6 +128,7 @@ const useStateUpdate = (ignoreSpaces = false) => {
             parsedSetting["fields"] ?? parsedSetting?.fields?.length > 0
               ? parsedSetting.fields
               : [],
+          labelTags: parsedSetting["label_tags"] ?? {},
         } as ColorScheme;
         set(sessionColorScheme, colorSetting);
         set(isUsingSessionColorScheme, true);

--- a/app/packages/state/src/recoil/atoms.ts
+++ b/app/packages/state/src/recoil/atoms.ts
@@ -378,6 +378,7 @@ export const sessionColorScheme = atom<ColorSchemeSetting>({
   default: {
     colorPool: [],
     fields: [],
+    labelTags: {},
   },
 });
 

--- a/app/packages/state/src/recoil/color.ts
+++ b/app/packages/state/src/recoil/color.ts
@@ -96,9 +96,12 @@ export const pathColor = selectorFamily<
         adjustedPath = path;
       }
 
-      const setting = get(atoms.sessionColorScheme)?.fields?.find(
-        (x) => x.path === adjustedPath
-      );
+      const setting =
+        path === "_label_tags"
+          ? get(atoms.sessionColorScheme).labelTags
+          : get(atoms.sessionColorScheme)?.fields?.find(
+              (x) => x.path === adjustedPath
+            );
 
       if (isValidColor(setting?.fieldColor ?? "")) {
         return setting!.fieldColor;

--- a/app/packages/state/src/recoil/looker.ts
+++ b/app/packages/state/src/recoil/looker.ts
@@ -66,6 +66,7 @@ export const lookerOptions = selectorFamily<
         isPointcloudDataset: get(selectors.isPointcloudDataset),
         coloring: get(colorAtoms.coloring(modal)),
         customizeColorSetting: get(atoms.sessionColorScheme).fields ?? [],
+        labelTagColors: get(atoms.sessionColorScheme).labelTags ?? {},
         ...get(atoms.savedLookerOptions),
         selectedLabels: [...get(selectors.selectedLabelIds)],
         fullscreen: get(atoms.fullscreen),

--- a/app/packages/state/src/recoil/types.ts
+++ b/app/packages/state/src/recoil/types.ts
@@ -232,6 +232,7 @@ export interface CustomizeColor {
 export interface ColorScheme {
   colorPool: string[];
   fields: CustomizeColor[];
+  labelTags: CustomizeColor;
 }
 
 export interface ColorSchemeSetting extends ColorScheme {

--- a/app/packages/state/src/recoil/types.ts
+++ b/app/packages/state/src/recoil/types.ts
@@ -18,7 +18,6 @@ export namespace State {
   export interface Config {
     colorPool: string[];
     customizedColors: CustomizeColor[];
-    // labelTags: CustomizeColor;
     colorscale: string;
     gridZoom: number;
     loopVideos: boolean;

--- a/app/packages/state/src/recoil/types.ts
+++ b/app/packages/state/src/recoil/types.ts
@@ -18,6 +18,7 @@ export namespace State {
   export interface Config {
     colorPool: string[];
     customizedColors: CustomizeColor[];
+    // labelTags: CustomizeColor;
     colorscale: string;
     gridZoom: number;
     loopVideos: boolean;
@@ -219,20 +220,23 @@ export namespace State {
   }
 }
 
-export interface CustomizeColor {
-  path: string;
+export interface ColorScheme {
+  colorPool: string[];
+  fields: CustomizeColor[];
+  labelTags: TagColor;
+}
+
+export interface TagColor {
   fieldColor?: string;
-  colorByAttribute?: string; // must be string field, int field, or boolean field
   valueColors?: {
     value: string;
     color: string;
   }[];
 }
 
-export interface ColorScheme {
-  colorPool: string[];
-  fields: CustomizeColor[];
-  labelTags: CustomizeColor;
+export interface CustomizeColor extends TagColor {
+  path: string;
+  colorByAttribute?: string; // must be string field, int field, or boolean field
 }
 
 export interface ColorSchemeSetting extends ColorScheme {

--- a/app/packages/state/src/utils.ts
+++ b/app/packages/state/src/utils.ts
@@ -158,4 +158,5 @@ export const DEFAULT_APP_COLOR_SCHEME = {
     "#777799",
   ],
   fields: [],
+  labelTags: {},
 };

--- a/app/schema.graphql
+++ b/app/schema.graphql
@@ -116,11 +116,13 @@ enum ColorBy {
 type ColorScheme {
   colorPool: [String!]
   fields: [CustomizeColor!]
+  labelTags: LabelTagColor
 }
 
 input ColorSchemeInput {
   colorPool: [String!] = null
   fields: JSONArray = null
+  labelTags: JSON = null
 }
 
 input Count {
@@ -309,6 +311,11 @@ type LabelSetting {
   color: String!
 }
 
+type LabelTagColor {
+  fieldColor: String
+  valueColors: [LabelSetting!]
+}
+
 enum MediaType {
   image
   group
@@ -455,7 +462,7 @@ type Query {
   schemaForViewStages(
     datasetName: String!
     viewStages: BSONArray!
-  ): SchemaResult
+  ): SchemaResult!
 }
 
 type RootAggregation implements Aggregation {
@@ -494,11 +501,6 @@ type SampleField {
   dbField: String
   description: String
   info: JSON
-}
-
-type SchemaResult {
-  fieldSchema: [SampleField]!
-  frameFieldSchema: [SampleField]!
 }
 
 input SampleFilter {
@@ -545,6 +547,11 @@ input SavedViewInfo {
   name: String = null
   description: String = null
   color: String = null
+}
+
+type SchemaResult {
+  fieldSchema: [SampleField!]!
+  frameFieldSchema: [SampleField!]!
 }
 
 input SelectedLabel {

--- a/fiftyone/core/odm/dataset.py
+++ b/fiftyone/core/odm/dataset.py
@@ -179,7 +179,14 @@ class ColorScheme(EmbeddedDocument):
                     "colorByAttribute": "label",
                     "valueColors": [{"value": "dog", "color": "yellow"}],
                 }
-            ]
+            ],
+            label_tags={
+                "fieldColor": "#00ffff",
+                "valueColors": [
+                    {"value": "correct", "color": "#ff00ff"},
+                    {"value": "mistake", "color": "#00ff00"},
+                ]
+            }
         )
         dataset.save()
 
@@ -198,6 +205,11 @@ class ColorScheme(EmbeddedDocument):
                 document
             -   `valueColors` (optional): a list of dicts specifying colors to
                 use for individual values of this field
+        label_tags (None): an optional dict specifying custom colors for label tags
+            with the following keys:
+            -    `fieldColor` (optional): a color to assign to all label tags
+            -    `valueColors` (optional): a list of dicts specifying colors to
+            specific label tags
     """
 
     # strict=False lets this class ignore unknown fields from other versions
@@ -205,6 +217,7 @@ class ColorScheme(EmbeddedDocument):
 
     color_pool = ListField(ColorField(), null=True)
     fields = ListField(DictField(), null=True)
+    label_tags = DictField(null=True)
 
 
 class KeypointSkeleton(EmbeddedDocument):

--- a/fiftyone/server/mutation.py
+++ b/fiftyone/server/mutation.py
@@ -67,6 +67,7 @@ class SavedViewInfo:
 class ColorSchemeInput:
     color_pool: t.Optional[t.List[str]] = None
     fields: t.Optional[JSONArray] = None
+    label_tags: t.Optional[JSON] = None
 
 
 @gql.type
@@ -422,12 +423,14 @@ class Mutation:
         state.color_scheme = foo.ColorScheme(
             color_pool=color_scheme.color_pool,
             fields=color_scheme.fields,
+            label_tags=color_scheme.label_tags,
         )
 
         if save_to_app:
             view._dataset.app_config.color_scheme = foo.ColorScheme(
                 color_pool=color_scheme.color_pool,
                 fields=color_scheme.fields,
+                label_tags=color_scheme.label_tags,
             )
             view._dataset.save()
             state.view = view

--- a/fiftyone/server/query.py
+++ b/fiftyone/server/query.py
@@ -207,9 +207,16 @@ class CustomizeColor:
 
 
 @gql.type
+class LabelTagColor:
+    fieldColor: t.Optional[str]
+    valueColors: t.Optional[t.List[LabelSetting]]
+
+
+@gql.type
 class ColorScheme:
     color_pool: t.Optional[t.List[str]] = None
     fields: t.Optional[t.List[CustomizeColor]] = None
+    label_tags: t.Optional[LabelTagColor] = None
 
 
 @gql.type

--- a/fiftyone/server/query.py
+++ b/fiftyone/server/query.py
@@ -208,8 +208,8 @@ class CustomizeColor:
 
 @gql.type
 class LabelTagColor:
-    fieldColor: t.Optional[str]
-    valueColors: t.Optional[t.List[LabelSetting]]
+    field_color: t.Optional[str]
+    value_colors: t.Optional[t.List[LabelSetting]]
 
 
 @gql.type


### PR DESCRIPTION
User can now customize label tag colors, which modifies the 
  - sidebar display color
  - grid view label tag bubble color

## What changes are proposed in this pull request?

- User can now customize label tag colors in the UI and through the session, and save it along with other settings

## How is this patch tested? If it is not, please explain why.
https://github.com/voxel51/fiftyone/assets/17770824/aa7a68b9-16cb-42ba-b8b1-de52dbf2709c

![Screenshot 2023-06-26 at 11 11 00 AM](https://github.com/voxel51/fiftyone/assets/17770824/3a2f8447-48c3-40fd-ae0e-0f511d04df90)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
