### PR TITLE
Resolve saved views when serializing datasets

### DIFF
--- a/app/packages/core/src/components/Actions/similar/utils.ts
+++ b/app/packages/core/src/components/Actions/similar/utils.ts
@@ -35,28 +35,28 @@ export const getQueryIds = async (
 
   const selectedSamples = await snapshot.getPromise(fos.selectedSamples);
   const isPatches = await snapshot.getPromise(fos.isPatchesView);
-  const modal = await snapshot.getPromise(fos.modalSample);
 
   if (isPatches) {
     if (selectedSamples.size) {
       return [...selectedSamples].map((id) => {
         const sample = fos.getSample(id);
         if (sample) {
-          return sample.sample[labels_field]._id;
+          return sample.sample[labels_field]._id as string;
         }
 
         throw new Error("sample not found");
       });
     }
 
-    return modal.sample[labels_field]._id;
+    return (await snapshot.getPromise(fos.modalSample)).sample[labels_field]
+      ._id as string;
   }
 
   if (selectedSamples.size) {
     return [...selectedSamples];
   }
 
-  return modal.id;
+  return await snapshot.getPromise(fos.modalSampleId);
 };
 
 export const useSortBySimilarity = (close) => {
@@ -77,6 +77,7 @@ export const useSortBySimilarity = (close) => {
         const queryIds = parameters.query
           ? null
           : await getQueryIds(snapshot, parameters.brainKey);
+
         const view = await snapshot.getPromise(fos.view);
         const subscription = await snapshot.getPromise(fos.stateSubscription);
 

--- a/fiftyone/server/query.py
+++ b/fiftyone/server/query.py
@@ -5,10 +5,11 @@ FiftyOne Server queries.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
-import typing as t
+from dataclasses import asdict
 from datetime import date, datetime
 from enum import Enum
 import os
+import typing as t
 
 import eta.core.serial as etas
 import eta.core.utils as etau
@@ -319,6 +320,7 @@ class Dataset:
             dataset_name=name,
             serialized_view=view,
             saved_view_slug=saved_view_slug,
+            dicts=False,
         )
 
 
@@ -542,6 +544,7 @@ async def serialize_dataset(
     dataset_name: str,
     serialized_view: BSONArray,
     saved_view_slug: t.Optional[str] = None,
+    dicts=True,
 ) -> Dataset:
     def run():
         dataset = fod.load_dataset(dataset_name)
@@ -587,9 +590,15 @@ async def serialize_dataset(
         if dataset.media_type == fom.GROUP:
             data.group_slice = collection.group_slice
 
-        for view in data.saved_views:
-            setattr(view, "view_name", view.view_name())
-            setattr(view, "stage_dicts", view.stage_dicts())
+        if dicts:
+            saved_views = []
+            for view in data.saved_views:
+                view_dict = asdict(view)
+                view_dict["view_name"] = view.view_name()
+                view_dict["stage_dicts"] = view.stage_dicts()
+                saved_views.append(view_dict)
+
+            data.saved_views = saved_views
 
         for brain_method in data.brain_methods:
             try:

--- a/fiftyone/server/query.py
+++ b/fiftyone/server/query.py
@@ -587,6 +587,10 @@ async def serialize_dataset(
         if dataset.media_type == fom.GROUP:
             data.group_slice = collection.group_slice
 
+        for view in data.saved_views:
+            setattr(view, "view_name", view.view_name())
+            setattr(view, "stage_dicts", view.stage_dicts())
+
         for brain_method in data.brain_methods:
             try:
                 type = brain_method.config.type().value


### PR DESCRIPTION
Fixes the `/sort` route and other occurrences of serializing a dataset outside of graphql 