### PR TITLE
Fix reset color

### DIFF
--- a/app/packages/core/src/components/ColorModal/ColorFooter.tsx
+++ b/app/packages/core/src/components/ColorModal/ColorFooter.tsx
@@ -38,6 +38,11 @@ const ColorFooter: React.FC = () => {
     return true;
   }, [savedSettings]);
 
+  // set to be true only for teams
+  const isTeams = useRecoilValue(fos.compactLayout);
+  const datasetDefault =
+    useRecoilValue(fos.datasetAppConfig)?.colorScheme ?? null;
+
   if (!activeColorModalField) return null;
 
   return (
@@ -47,7 +52,7 @@ const ColorFooter: React.FC = () => {
           text={"Reset"}
           title={`Clear session settings and revert to default settings`}
           onClick={() => {
-            setColorScheme(false, null);
+            setColorScheme(false, isTeams ? datasetDefault : null);
             setReset((prev) => prev + 1);
           }}
           style={BUTTON_STYLE}

--- a/app/packages/core/src/components/ColorModal/ShareStyledDiv.ts
+++ b/app/packages/core/src/components/ColorModal/ShareStyledDiv.ts
@@ -40,9 +40,10 @@ export const DraggableContent = styled.div<Props>`
 `;
 
 export const Display = styled.div`
-  overflow: auto;
+  overflow-y: auto;
+  overflow-x: hidden;
   height: 100%;
-  margin: 1rem;
+  padding: 1rem;
   flex: 1;
 `;
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

- Bugfix: `reset` button failed to set `can view` permission user setting back to dataset app_config setting on TEAMS. 
- Previously x-direction scroller shows up unnecessarily on color modal. 

## How is this patch tested? If it is not, please explain why.

(Details)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
