### PR TITLE
Fix numeric fields display bug

### DIFF
--- a/app/packages/core/src/components/Filters/NumericFieldFilter.tsx
+++ b/app/packages/core/src/components/Filters/NumericFieldFilter.tsx
@@ -283,7 +283,7 @@ const NumericFieldFilter = ({
             formatter={
               [DATE_TIME_FIELD, DATE_FIELD].includes(ftype)
                 ? (v) => (v ? formatDateTime(v, timeZone) : null)
-                : (v) => null
+                : (v) => (v ? v.toString() : null)
             }
             value={false}
           />
@@ -307,6 +307,7 @@ const NumericFieldFilter = ({
             onlyMatchAtom={onlyMatchAtom}
             isMatchingAtom={isMatchingAtom}
             valueName={field?.name ?? ""}
+            path={path}
             color={color}
             modal={modal}
             isKeyPointLabel={isKeyPoints}

--- a/app/packages/core/src/components/Filters/NumericFieldFilter.tsx
+++ b/app/packages/core/src/components/Filters/NumericFieldFilter.tsx
@@ -283,7 +283,7 @@ const NumericFieldFilter = ({
             formatter={
               [DATE_TIME_FIELD, DATE_FIELD].includes(ftype)
                 ? (v) => (v ? formatDateTime(v, timeZone) : null)
-                : (v) => (v ? v.toString() : null)
+                : (v) => (typeof v === "number" ? v.toString() : null)
             }
             value={false}
           />


### PR DESCRIPTION
Fix a display bug for numeric field
Previously after I assign one value to float field, the value is shown as `none`. 
![Screenshot 2023-06-29 at 4 06 10 PM](https://github.com/voxel51/fiftyone/assets/17770824/fc89393e-22c1-43e7-b88f-41a22352cb7a)

Fix: 
![Screenshot 2023-06-29 at 10 28 59 PM](https://github.com/voxel51/fiftyone/assets/17770824/7c7a4dcb-fa51-4c61-aa26-6d1b762b323c)
![Screenshot 2023-06-29 at 10 22 05 PM](https://github.com/voxel51/fiftyone/assets/17770824/86ace902-71ca-461b-a4fb-0dbd67eec019)

## What changes are proposed in this pull request?

(Please fill in changes proposed in this fix)

## How is this patch tested? If it is not, please explain why.

(Details)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
