### PR TITLE
Update sidebar unit tests

### DIFF
--- a/app/packages/state/src/recoil/sidebar.ts
+++ b/app/packages/state/src/recoil/sidebar.ts
@@ -170,7 +170,7 @@ const NONE = [null, undefined];
 export const resolveGroups = (
   sampleFields: StrictField[],
   frameFields: StrictField[],
-  sidebarGroups: State.SidebarGroup[],
+  sidebarGroups?: State.SidebarGroup[],
   current?: State.SidebarGroup[]
 ): State.SidebarGroup[] => {
   let groups = sidebarGroups
@@ -262,6 +262,7 @@ const groupUpdater = (
     const index = groupNames.indexOf(name);
     if (index < 0) {
       groups.push({ name, paths, expanded: false });
+      groupNames.push(name);
       return;
     }
 

--- a/app/packages/state/src/recoil/utils.ts
+++ b/app/packages/state/src/recoil/utils.ts
@@ -128,6 +128,13 @@ export const unsupportedMatcher = (field: StrictField) => {
 
   if (
     field.ftype === LIST_FIELD &&
+    (UNSUPPORTED_FILTER_TYPES.includes(field.subfield) || !field.subfield)
+  ) {
+    return true;
+  }
+
+  if (
+    field.ftype === LIST_FIELD &&
     field.subfield === EMBEDDED_DOCUMENT_FIELD &&
     LABELS.includes(field.embeddedDocType)
   ) {

--- a/app/packages/state/tests/recoil/sidebar.test.ts
+++ b/app/packages/state/tests/recoil/sidebar.test.ts
@@ -187,11 +187,7 @@ const mockFields = {
 
 describe("ResolveGroups works", () => {
   it("dataset groups should resolve when curent is undefined", () => {
-    const test = sidebar.resolveGroups(
-      mockFields.sampleFields,
-      mockFields.sampleFields,
-      []
-    );
+    const test = sidebar.resolveGroups(mockFields.sampleFields, []);
 
     expect(test.length).toBe(5);
     expect(test[0].name).toBe("tags");


### PR DESCRIPTION
Fixes sidebar tests and some small regressions related to them (grouping unsupported/untyped list fields) and removing redundant group name updates