### PR TITLE
Updating `Session.close()`

### DIFF
--- a/fiftyone/core/session/client.py
+++ b/fiftyone/core/session/client.py
@@ -58,6 +58,11 @@ class Client:
         """The origin of the server"""
         return f"http://{self.address}:{self.port}"
 
+    @property
+    def is_open(self) -> str:
+        """Whether the client is connected"""
+        return not self._closed.is_set()
+
     def open(self, state: fos.StateDescription) -> None:
         """Open the client connection
 

--- a/fiftyone/core/session/session.py
+++ b/fiftyone/core/session/session.py
@@ -972,7 +972,9 @@ class Session(object):
         -   Other (non-remote): opens the App in a new browser tab
         """
         _register_session(self)
-        self._client.open(self._state)
+
+        if not self._client.is_open:
+            self._client.open(self._state)
 
         if self.remote:
             logger.warning("Remote sessions cannot open new App windows")

--- a/fiftyone/core/session/session.py
+++ b/fiftyone/core/session/session.py
@@ -1114,11 +1114,8 @@ class Session(object):
         if self.remote:
             return
 
-        if self._client._connected:
-            if focx._get_context() == focx._NONE:
-                pass  # Close Desktop App
-            elif focx.is_notebook_context():
-                self.freeze()
+        if self._client._connected and focx.is_notebook_context():
+            self.freeze()
 
         self.plots.disconnect()
         self.__del__()

--- a/fiftyone/core/session/session.py
+++ b/fiftyone/core/session/session.py
@@ -1103,6 +1103,9 @@ class Session(object):
 
     def close(self) -> None:
         """Closes the session and terminates the App, if necessary."""
+        if self.desktop:
+            self._app_service.stop()
+
         if self.remote:
             return
 

--- a/fiftyone/core/session/session.py
+++ b/fiftyone/core/session/session.py
@@ -515,6 +515,7 @@ class Session(object):
                 # logger may already have been garbage-collected
                 print(_WAIT_INSTRUCTIONS)
 
+            self._client.close()
             _unregister_session(self)
         except:
             # e.g. globals were already garbage-collected
@@ -1105,10 +1106,14 @@ class Session(object):
         if self.remote:
             return
 
-        if self._client._connected and focx._get_context() == focx._NONE:
-            self._client.send_event(CloseSession())
+        if self._client._connected:
+            if focx._get_context() == focx._NONE:
+                pass  # Close Desktop App
+            elif focx.is_notebook_context():
+                self.freeze()
 
         self.plots.disconnect()
+        self.__del__()
 
     def freeze(self) -> None:
         """Screenshots the active App cell, replacing it with a static image.

--- a/fiftyone/core/session/session.py
+++ b/fiftyone/core/session/session.py
@@ -976,10 +976,6 @@ class Session(object):
         if not self._client.is_open:
             self._client.open(self._state)
 
-        if self.remote:
-            logger.warning("Remote sessions cannot open new App windows")
-            return
-
         if self.plots:
             self.plots.connect()
 
@@ -1110,9 +1106,6 @@ class Session(object):
         """Closes the session and terminates the App, if necessary."""
         if self.desktop:
             self._app_service.stop()
-
-        if self.remote:
-            return
 
         if self._client.is_open and focx.is_notebook_context():
             self.freeze()

--- a/fiftyone/core/session/session.py
+++ b/fiftyone/core/session/session.py
@@ -422,7 +422,7 @@ class Session(object):
             remote=remote,
             start_time=self._get_time(),
         )
-        self._client.run(self._state)
+        self._client.open(self._state)
         _attach_listeners(self)
         _register_session(self)
 
@@ -971,6 +971,9 @@ class Session(object):
         -   Desktop: opens the desktop App, if necessary
         -   Other (non-remote): opens the App in a new browser tab
         """
+        _register_session(self)
+        self._client.open(self._state)
+
         if self.remote:
             logger.warning("Remote sessions cannot open new App windows")
             return

--- a/fiftyone/core/session/session.py
+++ b/fiftyone/core/session/session.py
@@ -1114,7 +1114,7 @@ class Session(object):
         if self.remote:
             return
 
-        if self._client._connected and focx.is_notebook_context():
+        if self._client.is_open and focx.is_notebook_context():
             self.freeze()
 
         self.plots.disconnect()


### PR DESCRIPTION
Closes #3190 

Updates `Session.close()` to always kill the `ServerService` (and `AppService`, i.e. the Desktop App) and accordingly adds service restarts when calling `session.open()`


```py
import fiftyone as fo

# start server, open tab
session = fo.launch_app()

# stop server
session.close()

# start server, open tab
session.open()

# start server, open desktop app
session = fo.launch_app(desktop=True)

# stop server, close desktop app
session.close()

# start server, open desktop app
session.open()
```