### PR TITLE
Embedded frame label fixes

### DIFF
--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -1620,7 +1620,20 @@ class SampleCollection(object):
                     label_ids = self.values(id_path)
 
             for _label_ids in fou.iter_batches(label_ids, 100000):
-                ops.append(UpdateMany({_id_path: {"$in": _label_ids}}, update))
+                ops.append(
+                    UpdateMany(
+                        {
+                            _id_path: {
+                                "$in": [
+                                    _id
+                                    for _id in _label_ids
+                                    if _id is not None
+                                ]
+                            }
+                        },
+                        update,
+                    )
+                )
 
         if ops:
             self._dataset._bulk_write(ops, frames=is_frame_field)

--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -1620,17 +1620,10 @@ class SampleCollection(object):
                     label_ids = self.values(id_path)
 
             for _label_ids in fou.iter_batches(label_ids, 100000):
+                _label_ids = [_id for _id in _label_ids if _id is not None]
                 ops.append(
                     UpdateMany(
-                        {
-                            _id_path: {
-                                "$in": [
-                                    _id
-                                    for _id in _label_ids
-                                    if _id is not None
-                                ]
-                            }
-                        },
+                        {_id_path: {"$in": _label_ids}},
                         update,
                     )
                 )

--- a/fiftyone/core/stages.py
+++ b/fiftyone/core/stages.py
@@ -1920,7 +1920,7 @@ def _get_filter_frames_field_pipeline(
     cond = _get_field_mongo_filter(filter_arg, prefix="$frame." + filter_field)
 
     if "." in new_field:
-        parent, child = new_field.split(".")
+        parent, child = new_field.split(".", 1)
         obj = {
             "$cond": {
                 "if": {"$gt": ["$$frame." + filter_field, None]},


### PR DESCRIPTION
Fixes tagging and label filtering for embedded frame label fields. Also ensures `new_field` is properly assigned for frame label lists when using the `MatchLabels` stage.


```py
import fiftyone as fo
import fiftyone.zoo as foz

dataset = foz.load_zoo_dataset("quickstart-video")
for sample in dataset:
    sample.frames[1]["dynamic"] = fo.DynamicEmbeddedDocument(
        classification=fo.Classification(label="single")
    )
    sample.save()

dataset.add_dynamic_frame_fields()
dataset.tag_labels("classification", label_fields="frames.dynamic.classification")

# Only 10 tags should be present, i.e. the first frame of each sample
assert dataset.count_label_tags()["classification"] == 10
```