### PR TITLE
Fix expanding samples in patches views for group datasets

### DIFF
--- a/app/packages/state/src/recoil/groups.ts
+++ b/app/packages/state/src/recoil/groups.ts
@@ -71,7 +71,7 @@ export const groupSlices = selector<string[]>({
 
 export const hasGroupSlices = selector<boolean>({
   key: "hasGroupSlices",
-  get: ({ get }) => Boolean(get(groupSlices).length),
+  get: ({ get }) => get(isGroup) && Boolean(get(groupSlices).length),
 });
 
 export const defaultPcdSlice = selector<string | null>({


### PR DESCRIPTION
In `0.21.1` and `0.21.2`, samples cannot be expanded (opened) when views a patches view in group datasets. Ensuring the `hasGroupSlices` is true for `group` media types resolves the issue

```py
import fiftyone.zoo as foz

dataset = foz.load_zoo_dataset("quickstart-groups")
view = dataset.select_group_slices("left").to_patches("ground_truth")
session = fo.Session(view)
```