### PR TITLE
[Plugins] use basename for module name

### DIFF
--- a/fiftyone/operators/loader.py
+++ b/fiftyone/operators/loader.py
@@ -116,7 +116,7 @@ class PluginContext(object):
             if not os.path.isfile(module_path):
                 return
 
-            parent_dir = os.path.dirname(module_dir)
+            parent_dir = os.path.basename(module_dir)
             spec = importlib.util.spec_from_file_location(
                 parent_dir, module_path
             )


### PR DESCRIPTION
## What changes are proposed in this pull request?
fix imported module name. `importlib.util.spec_from_file_location` takes a module name and it's path. Currently this means that the name of a module used in imports is the parent directory. For example: 
```
module_dir = '...fiftyone-plugins/packages/examples'
module_path = os.path.join(module_dir, "__init__.py")
parent_dir = os.path.dirname(module_dir)
importlib.util.spec_from_file_location(
    ...:     ...:                 parent_dir, module_path
    ...:     ...:             )
    ...: 
ModuleSpec(name='...fiftyone-plugins/packages', loader=<_frozen_importlib_external.SourceFileLoader object at 0x2a5157640>, origin='...fiftyone-plugins/packages/examples/__init__.py', submodule_search_locations=['...fiftyone-plugins/packages/examples'])
``` 
Consequently, any subsequent loading of a plugin in the packages directory would just overwrite the previous

however, using basename:
```
 parent_dir = os.path.basename(module_dir)
importlib.util.spec_from_file_location(
    ...:                 parent_dir, module_path
    ...:             )
ModuleSpec(name='examples', loader=<_frozen_importlib_external.SourceFileLoader object at 0x2a525b870>, origin='...fiftyone-plugins/packages/examples/__init__.py', submodule_search_locations=['...fiftyone-plugins/packages/examples'])


