### PR TITLE
Fix label tags counts for filterless view

### DIFF
--- a/fiftyone/server/view.py
+++ b/fiftyone/server/view.py
@@ -134,7 +134,7 @@ def get_view(
         # omit all dict field values for performance, not needed by grid
         view = _project_pagination_paths(view)
 
-    if filters or extended_stages:
+    if filters or extended_stages or count_label_tags:
         view = get_extended_view(
             view,
             filters,


### PR DESCRIPTION
Since `0.21.1`, no label tag bubble counts are not shown when `label tags` is checked if sidebar filters are not present.