### PR TITLE
Fix sidebar matching on label fields

### DIFF
--- a/fiftyone/server/view.py
+++ b/fiftyone/server/view.py
@@ -320,7 +320,7 @@ def _make_filter_stages(
                     fosg.FilterLabels(
                         prefix + parent.name,
                         expr,
-                        only_matches=False,
+                        only_matches=only_matches,
                     )
                 )
 


### PR DESCRIPTION
Ensures `only_matches` flag is set when creating the extended view from sidebar filters. This ensures a second matching is done **after** a label field list has been filtered. Also fixes `id` filtering by translating the path to `_id`