### PR TITLE
Adding merge_sample() method

### DIFF
--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -788,6 +788,10 @@ class SampleCollection(object):
             exact (False): whether to raise an error if multiple samples match
                 the expression
 
+        Raises:
+            ValueError: if no samples match the expression or if ``exact=True``
+            and multiple samples match the expression
+
         Returns:
             a :class:`fiftyone.core.sample.SampleView`
         """

--- a/fiftyone/core/odm/mixins.py
+++ b/fiftyone/core/odm/mixins.py
@@ -993,6 +993,19 @@ class DatasetMixin(object):
                 ):
                     return {path: field}
 
+            #
+            # In principle, merging an untyped list field into a typed list
+            # field --- eg ListField(StringField) --- should not be allowed, as
+            # the untyped list may contain incompatible values.
+            #
+            # However, we are intentionally skipping validation here so that
+            # the following will work::
+            #
+            #   doc.set_field("tags", [], validate=True)
+            #
+            if is_list_field and field is None:
+                return
+
             if validate:
                 validate_fields_match(path, field, existing_field)
 

--- a/tests/unittests/dataset_tests.py
+++ b/tests/unittests/dataset_tests.py
@@ -1120,6 +1120,59 @@ class DatasetTests(unittest.TestCase):
         self.assertEqual(field.field.document_type, fo.DynamicEmbeddedDocument)
 
     @drop_datasets
+    def test_merge_sample22(self):
+        sample1 = fo.Sample(filepath="image.jpg", foo="bar", tags=["a"])
+        sample2 = fo.Sample(filepath="image.jpg", spam="eggs", tags=["b"])
+        sample3 = fo.Sample(filepath="image.jpg", tags=[])
+
+        # No dataset
+
+        s1 = sample1.copy()
+        s2 = sample2.copy()
+        s3 = sample3.copy()
+
+        s1.merge(s2)
+        s1.merge(s3)
+
+        self.assertListEqual(s1["tags"], ["a", "b"])
+        self.assertEqual(s1["foo"], "bar")
+        self.assertEqual(s1["spam"], "eggs")
+
+        # In dataset
+
+        s1 = sample1.copy()
+        s2 = sample2.copy()
+        s3 = sample3.copy()
+
+        dataset = fo.Dataset()
+        dataset.add_sample(s1)
+
+        dataset.merge_sample(s2)
+        dataset.merge_sample(s3)
+
+        self.assertListEqual(s1["tags"], ["a", "b"])
+        self.assertEqual(s1["foo"], "bar")
+        self.assertEqual(s1["spam"], "eggs")
+
+        # List merging variations
+
+        s1 = sample1.copy()
+        s2 = sample2.copy()
+        s3 = sample3.copy()
+
+        dataset = fo.Dataset()
+        dataset.add_sample(s1)
+
+        dataset.merge_sample(s2, merge_lists=False)
+
+        self.assertListEqual(s1["tags"], ["b"])
+
+        # Tests an edge case when setting a typed list field to an empty list
+        dataset.merge_sample(s3, merge_lists=False, dynamic=True)
+
+        self.assertListEqual(s1["tags"], [])
+
+    @drop_datasets
     def test_merge_samples1(self):
         # Windows compatibility
         def expand_path(path):

--- a/tests/unittests/dataset_tests.py
+++ b/tests/unittests/dataset_tests.py
@@ -1120,7 +1120,34 @@ class DatasetTests(unittest.TestCase):
         self.assertEqual(field.field.document_type, fo.DynamicEmbeddedDocument)
 
     @drop_datasets
-    def test_merge_sample22(self):
+    def test_one(self):
+        samples = [
+            fo.Sample(filepath="image1.jpg"),
+            fo.Sample(filepath="image2.png"),
+            fo.Sample(filepath="image3.jpg"),
+        ]
+
+        dataset = fo.Dataset()
+        dataset.add_samples(samples)
+
+        filepath = dataset.first().filepath
+
+        sample = dataset.one(F("filepath") == filepath)
+
+        self.assertEqual(sample.filepath, filepath)
+
+        with self.assertRaises(ValueError):
+            _ = dataset.one(F("filepath") == "bad")
+
+        sample = dataset.one(F("filepath").ends_with(".jpg"))
+
+        self.assertTrue(sample.filepath.endswith(".jpg"))
+
+        with self.assertRaises(ValueError):
+            _ = dataset.one(F("filepath").ends_with(".jpg"), exact=True)
+
+    @drop_datasets
+    def test_merge_sample(self):
         sample1 = fo.Sample(filepath="image.jpg", foo="bar", tags=["a"])
         sample2 = fo.Sample(filepath="image.jpg", spam="eggs", tags=["b"])
         sample3 = fo.Sample(filepath="image.jpg", tags=[])


### PR DESCRIPTION
Resolves https://github.com/voxel51/fiftyone/issues/3273

Adds a `merge_sample()` method for merging a single sample into a dataset via the same basic interface as `merge_samples()`.

This method is useful for workflows that process one sample at a time, eg a cloud function that processes one sample at a time. It is *not* intended for use in a loop:

```py
# Don't do this
for sample in samples:
   dataset.merge_sample(sample, ...)

# Use this instead
dataset.merge_samples(samples, ...)
```
