### PR TITLE
Suppress errors due to none fields

### DIFF
--- a/fiftyone/server/query.py
+++ b/fiftyone/server/query.py
@@ -5,6 +5,7 @@ FiftyOne Server queries.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+import logging
 from dataclasses import asdict
 from datetime import date, datetime
 from enum import Enum
@@ -529,6 +530,7 @@ def _flatten_fields(
             # Issues with concurrency can cause this to happen.
             # Until it's fixed, just ignore these fields to avoid throwing hard
             # errors when loading in the app.
+            logging.debug("Skipping field with no name: %s", field)
             continue
         field_path = path + [key]
         field["path"] = ".".join(field_path)

--- a/fiftyone/server/query.py
+++ b/fiftyone/server/query.py
@@ -524,7 +524,12 @@ def _flatten_fields(
 ) -> t.List[t.Dict]:
     result = []
     for field in fields:
-        key = field.pop("name")
+        key = field.pop("name", None)
+        if key is None:
+            # Issues with concurrency can cause this to happen.
+            # Until it's fixed, just ignore these fields to avoid throwing hard
+            # errors when loading in the app.
+            continue
         field_path = path + [key]
         field["path"] = ".".join(field_path)
         result.append(field)


### PR DESCRIPTION
## What changes are proposed in this pull request?
Avoid throwing hard errors that prevent loading a dataset in the app due to a missing field name