### PR TITLE
E2E for saved views

### DIFF
--- a/app/packages/components/src/components/Selection/Option.tsx
+++ b/app/packages/components/src/components/Selection/Option.tsx
@@ -78,6 +78,7 @@ export default function SelectionOption(props: Props) {
             <Box>
               {isHovered && item.id !== "1" && (
                 <Edit
+                  data-cy="btn-edit-selection"
                   fontSize="small"
                   sx={{
                     color: theme.neutral[400],

--- a/app/packages/components/src/components/Selection/SearchBox.tsx
+++ b/app/packages/components/src/components/Selection/SearchBox.tsx
@@ -29,6 +29,7 @@ const SearchInput = styled.input`
 `;
 
 export const SearchBox = ({
+  id,
   searchTerm,
   searchPlaceholder,
   setSearchTerm,
@@ -36,6 +37,7 @@ export const SearchBox = ({
   searchValue,
   disabled = false,
 }: {
+  id: string;
   searchTerm: string;
   searchPlaceholder?: string;
   setSearchTerm: (term: string) => void;
@@ -51,6 +53,7 @@ export const SearchBox = ({
   } = theme;
   return (
     <Box
+      data-cy={`${id}-selection-search-container`}
       style={{
         position: "sticky",
         top: 0,
@@ -60,6 +63,7 @@ export const SearchBox = ({
       }}
     >
       <SearchInput
+        data-cy={`${id}-selection-search-input`}
         disabled={disabled}
         value={searchTerm}
         placeholder={searchPlaceholder}

--- a/app/packages/components/src/components/Selection/Selection.tsx
+++ b/app/packages/components/src/components/Selection/Selection.tsx
@@ -45,6 +45,7 @@ const ColoredDot = styled(Box)<{ color: string }>`
 `;
 
 type SelectionProps = {
+  id: string;
   items: Array<DatasetViewOption>;
   headerComponent?: React.ReactNode;
   search?: {
@@ -69,6 +70,7 @@ const VIEW_LIST_MAX_COMPACT_HEIGHT = "200px";
 
 function Selection(props: SelectionProps) {
   const {
+    id,
     items = [],
     headerComponent = null,
     lastFixedOption = null,
@@ -80,9 +82,6 @@ function Selection(props: SelectionProps) {
     onEdit,
     onClear,
   } = props;
-  if (!selected) {
-    return null;
-  }
 
   const theme = useTheme();
   const [isOpen, setIsOpen] = useState<boolean>(false);
@@ -116,9 +115,20 @@ function Selection(props: SelectionProps) {
     [onSearch]
   );
 
+  if (!selected) {
+    return null;
+  }
+
+  const selectionId = id;
+
   return (
-    <div ref={ref} style={{ width: "100%" }}>
+    <div
+      ref={ref}
+      style={{ width: "100%" }}
+      data-cy={`${id}-selection-container`}
+    >
       <Select
+        data-cy={`${id}-selection`}
         value={selectedId}
         defaultValue={selectedId}
         listboxOpen={isOpen}
@@ -172,12 +182,16 @@ function Selection(props: SelectionProps) {
           },
         }}
         startDecorator={
-          <ColoredDot color={selectedColor || DEFAULT_COLOR_OPTION.color} />
+          <ColoredDot
+            color={selectedColor || DEFAULT_COLOR_OPTION.color}
+            data-cy="selection-color-dot"
+          />
         }
         {...(selectedId !== DEFAULT_SELECTED.id &&
           onClear && {
             endDecorator: (
               <IconButton
+                data-cy={`${id}-btn-selection-clear`}
                 size="small"
                 onMouseDown={(e) => {
                   e.stopPropagation();
@@ -198,12 +212,12 @@ function Selection(props: SelectionProps) {
       >
         {onSearch && (
           <SearchBox
+            id="saved-views"
             debouncedSearch={debouncedSearch}
             searchTerm={searchTerm}
             setSearchTerm={setSearchTerm}
             searchPlaceholder={searchPlaceholder}
             searchValue={searchValue}
-            disabled={items?.length <= 1}
           />
         )}
         {!onSearch && headerComponent}
@@ -214,9 +228,10 @@ function Selection(props: SelectionProps) {
           }}
         >
           {items.map((itemProps) => {
-            const { id, color, label } = itemProps;
+            const { id, color, label, slug } = itemProps;
             return (
               <Option
+                data-cy={`${selectionId}-${slug}-selection-option`}
                 key={id + label}
                 value={id}
                 label={label}
@@ -247,7 +262,10 @@ function Selection(props: SelectionProps) {
                         display: "inline-block",
                       }}
                     >
-                      <ColoredDot color={color || DEFAULT_COLOR_OPTION.color} />
+                      <ColoredDot
+                        color={color || DEFAULT_COLOR_OPTION.color}
+                        data-cy="testme"
+                      />
                     </Box>
                   }
                   compact={compact}

--- a/app/packages/core/src/components/Sidebar/Sidebar.tsx
+++ b/app/packages/core/src/components/Sidebar/Sidebar.tsx
@@ -742,7 +742,7 @@ const InteractiveSidebar = ({
               borderTopRightRadius: 8,
             }}
           >
-            <ViewSelection />
+            <ViewSelection id="saved-views" />
           </Box>
         </Suspense>
       )}

--- a/app/packages/core/src/components/Sidebar/ViewSelection/ViewDialog.tsx
+++ b/app/packages/core/src/components/Sidebar/ViewSelection/ViewDialog.tsx
@@ -41,6 +41,7 @@ import { toSlug } from "@fiftyone/utilities";
 import { extendedStages } from "@fiftyone/state";
 
 interface Props {
+  id: string;
   savedViews: fos.State.SavedView[];
   onEditSuccess: (saveView: fos.State.SavedView, reload?: boolean) => void;
   onDeleteSuccess: (slug: string) => void;
@@ -58,7 +59,13 @@ export const viewDialogContent = atom({
 });
 
 export default function ViewDialog(props: Props) {
-  const { onEditSuccess, onDeleteSuccess, savedViews = [], canEdit } = props;
+  const {
+    onEditSuccess,
+    onDeleteSuccess,
+    savedViews = [],
+    canEdit,
+    id,
+  } = props;
   const theme = useTheme();
   const [isOpen, setIsOpen] = useRecoilState<boolean>(viewDialogOpen);
   const viewContent = useRecoilValue(viewDialogContent);
@@ -133,7 +140,7 @@ export default function ViewDialog(props: Props) {
     setNameValue("");
     setDescriptionValue("");
     setColorOption(DEFAULT_COLOR_OPTION);
-  }, []);
+  }, [resetViewContent]);
 
   const onDeleteView = useCallback(() => {
     handleDeleteView(nameValue, () => {
@@ -141,7 +148,7 @@ export default function ViewDialog(props: Props) {
       setIsOpen(false);
       onDeleteSuccess(nameValue);
     });
-  }, [nameValue]);
+  }, [handleDeleteView, nameValue, onDeleteSuccess, resetValues, setIsOpen]);
 
   const onSaveView = useCallback(() => {
     if (isCreating) {
@@ -169,7 +176,19 @@ export default function ViewDialog(props: Props) {
         }
       );
     }
-  }, [view, nameValue, descriptionValue, colorOption?.color]);
+  }, [
+    isCreating,
+    handleCreateSavedView,
+    nameValue,
+    descriptionValue,
+    colorOption.color,
+    view,
+    resetValues,
+    onEditSuccess,
+    setIsOpen,
+    handleUpdateSavedView,
+    initialName,
+  ]);
 
   return (
     <Dialog
@@ -183,6 +202,7 @@ export default function ViewDialog(props: Props) {
         style={{
           background: theme.background.level1,
         }}
+        data-cy={`${id}-modal-body-container`}
       >
         <DialogTitle
           alignItems="flex-start"
@@ -192,6 +212,7 @@ export default function ViewDialog(props: Props) {
           {title}
           <IconButton
             aria-label="close"
+            data-cy={`${id}-btn-close`}
             onClick={() => {
               setIsOpen(false);
               resetValues();
@@ -210,6 +231,8 @@ export default function ViewDialog(props: Props) {
           <InputContainer>
             <Label>Name</Label>
             <NameInput
+              data-cy={`${id}-input-name`}
+              autoFocus
               placeholder="Your view name"
               value={nameValue}
               onChange={(e) => setNameValue(e.target.value)}
@@ -220,6 +243,7 @@ export default function ViewDialog(props: Props) {
           <InputContainer>
             <Label>Description</Label>
             <DescriptionInput
+              data-cy={`${id}-input-description`}
               rows={5}
               placeholder="Enter a description"
               value={descriptionValue}
@@ -229,6 +253,7 @@ export default function ViewDialog(props: Props) {
           <InputContainer>
             <Label>Color</Label>
             <Selection
+              id={`${id}-input-color-selection`}
               selected={colorOption}
               setSelected={(item) => setColorOption(item)}
               items={COLOR_OPTIONS}
@@ -250,6 +275,7 @@ export default function ViewDialog(props: Props) {
           >
             {!isCreating && canEdit && (
               <Button
+                data-cy={`${id}-btn-delete`}
                 onClick={onDeleteView}
                 sx={{
                   background: theme.background.level1,
@@ -271,7 +297,10 @@ export default function ViewDialog(props: Props) {
             }}
           >
             <Button
-              onClick={() => setIsOpen(false)}
+              onClick={() => {
+                resetValues();
+                setIsOpen(false);
+              }}
               sx={{
                 background: theme.background.level1,
                 color: theme.text.primary,
@@ -287,6 +316,7 @@ export default function ViewDialog(props: Props) {
               Cancel
             </Button>
             <Button
+              data-cy={`${id}-btn-save`}
               onClick={onSaveView}
               disabled={
                 isUpdatingSavedView ||

--- a/app/packages/core/src/components/Sidebar/ViewSelection/index.tsx
+++ b/app/packages/core/src/components/Sidebar/ViewSelection/index.tsx
@@ -180,6 +180,7 @@ export default function ViewSelection() {
       <Box>
         <ViewDialog
           canEdit={canEdit}
+          id="saved-views"
           savedViews={items}
           onEditSuccess={(
             createSavedView: fos.State.SavedView,
@@ -189,7 +190,7 @@ export default function ViewSelection() {
               { name: datasetName },
               {
                 fetchPolicy: "network-only",
-                onComplete: (newOptions) => {
+                onComplete: () => {
                   if (createSavedView && reload) {
                     setView([], undefined, createSavedView.slug);
                     setSelected({
@@ -217,6 +218,7 @@ export default function ViewSelection() {
         />
         <Selection
           readonly={!canEdit}
+          id="saved-views"
           selected={selected}
           setSelected={(item: fos.DatasetViewOption) => {
             setSelected(item);
@@ -245,6 +247,7 @@ export default function ViewSelection() {
           }}
           lastFixedOption={
             <LastOption
+              data-cy={`saved-views-create-new`}
               onClick={() => canEdit && !isEmptyView && setIsOpen(true)}
               disabled={isEmptyView || !canEdit}
             >

--- a/e2e-pw/package.json
+++ b/e2e-pw/package.json
@@ -28,6 +28,6 @@
         "build-linux-screenshot-docker-image": "./scripts/generate-screenshots-docker-image/build-docker-image.sh",
         "e2e:ui": "npx playwright test --ui -c playwright.config.ts",
         "e2e": "playwright test -c playwright.config.ts",
-        "devserver": "export VITE_API=http://localhost:8787 VITE_NO_STATE=true && export FIFTYONE_DEFAULT_APP_PORT=5193 && (cd ../app && yarn dev --host 0.0.0.0)"
+        "devserver": "export VITE_API=http://localhost:8787 && export FIFTYONE_DEFAULT_APP_PORT=5193 && (cd ../app && yarn dev --host 0.0.0.0)"
     }
 }

--- a/e2e-pw/src/oss/fixtures/index.ts
+++ b/e2e-pw/src/oss/fixtures/index.ts
@@ -71,4 +71,4 @@ export const test = customFixtures.extend<CustomFixturesWithPage>({
   },
 });
 
-export { Locator, Page, expect } from "@playwright/test";
+export { Locator, Page, expect, Browser } from "@playwright/test";

--- a/e2e-pw/src/oss/poms/saved-views.ts
+++ b/e2e-pw/src/oss/poms/saved-views.ts
@@ -158,12 +158,6 @@ export class SavedViewsPom {
     return this.dialogLocator.getByRole("option", { name: c });
   }
 
-  // saveButton() {
-  //   return this.dialogLocator.getByRole("button", {
-  //     name: "Save view",
-  //     exact: true,
-  //   });
-  // }
   saveButton() {
     return this.dialogLocator.getByTestId("saved-views-btn-save");
   }
@@ -247,7 +241,6 @@ class SavedViewAsserter {
   }
 
   async verifySavedView(slug: string = "test") {
-    // await this.svp.page.waitForURL(`*view=${slug}`, { timeout: 5000 });
     await expect(this.svp.page).toHaveURL(new RegExp(`view=${slug}`));
   }
 

--- a/e2e-pw/src/oss/poms/saved-views.ts
+++ b/e2e-pw/src/oss/poms/saved-views.ts
@@ -1,0 +1,383 @@
+import { expect, Locator, Page } from "src/oss/fixtures";
+import {
+  Color,
+  ColorList,
+  updatedView,
+  updatedView2,
+} from "../specs/smoke-tests/saved-views.spec";
+
+export class SavedViewsPom {
+  readonly page: Page;
+  readonly assert: SavedViewAsserter;
+
+  readonly locator: Locator;
+  readonly dialogLocator: Locator;
+
+  constructor(page: Page) {
+    this.page = page;
+    this.assert = new SavedViewAsserter(this);
+
+    this.locator = page.getByTestId("saved-views-selection-container");
+    this.dialogLocator = page.getByTestId("saved-views-modal-body-container");
+  }
+
+  async clickEditRaw(slug: string) {
+    await this.locator.click();
+    await this.clickOptionEdit(slug);
+  }
+
+  async clickOptionEdit(slug: string) {
+    await this.savedViewOption(slug).hover();
+    await this.optionEdit(slug).click();
+  }
+
+  async clickEdit(slug: string) {
+    await this.clearView();
+    await this.clickEditRaw(slug);
+  }
+
+  optionEdit(slug: string) {
+    return this.savedViewOption(slug).getByTestId("btn-edit-selection");
+  }
+
+  async saveViewInputs({ name, description, color, newColor }) {
+    await this.nameInput().type(name);
+    await this.descriptionInput().type(description);
+    await this.colorInput(color).click();
+    await this.colorOption(newColor).click();
+  }
+
+  async saveView(view) {
+    await this.openCreateModal();
+    await this.saveViewInputs(view);
+    await this.saveButton().click();
+  }
+
+  async saveView2() {
+    await this.saveButton().click();
+  }
+
+  async deleteView(name: string) {
+    await this.savedViewOption(name).hover();
+    await this.optionEdit(name).click();
+    await this.clickDeleteBtn();
+  }
+
+  async deleteViewClick() {
+    await this.clickDeleteBtn();
+  }
+
+  async editView(
+    name: string,
+    description: string,
+    color: Color,
+    newColor: Color
+  ) {
+    await this.nameInput().clear();
+    await this.nameInput().type(name);
+    await this.descriptionInput().clear();
+    await this.descriptionInput().type(description);
+    await this.colorInput(color).click();
+    await this.colorOption(newColor).click();
+
+    await this.saveButton().click();
+  }
+
+  async clickColor(color: Color = "Gray") {
+    await this.colorInput(color).click();
+  }
+
+  async clearView() {
+    await this.clearViewBtn().click();
+  }
+
+  async clickCloseModal() {
+    await this.closeModalBtn().click();
+  }
+
+  selectorContainer() {
+    return this.locator.getByTestId("saved-views-selection-container");
+  }
+
+  selector() {
+    return this.locator.getByTestId("saved-views-selection");
+  }
+
+  clearViewBtn() {
+    return this.selector()
+      .getByTestId("saved-views-btn-selection-clear")
+      .first();
+  }
+
+  closeModalBtn() {
+    return this.dialogLocator.getByTestId("saved-views-btn-close");
+  }
+
+  saveNewViewBtn() {
+    return this.locator.getByTestId("saved-views-create-new");
+  }
+
+  canClearView() {
+    return this.clearViewBtn().isVisible();
+  }
+
+  async openSelect() {
+    await this.selector().click();
+  }
+
+  async openCreateModal() {
+    await this.openSelect();
+    await this.saveNewViewBtn().click();
+  }
+
+  async savedViewCount(name: string) {
+    return await this.locator.getByRole("button", { name }).count();
+  }
+
+  savedViewOption(slug: string) {
+    return this.locator.getByTestId(`saved-views-${slug}-selection-option`);
+  }
+
+  async savedViewOptionCount(slug: string) {
+    return await this.savedViewOption(slug).count();
+  }
+
+  nameInput() {
+    return this.dialogLocator.getByTestId("saved-views-input-name");
+  }
+
+  descriptionInput() {
+    return this.dialogLocator.getByTestId("saved-views-input-description");
+  }
+
+  colorInput(c: Color = "Gray") {
+    return this.dialogLocator.getByRole("button", { name: c });
+  }
+
+  colorOption(c: Color = "Purple") {
+    return this.dialogLocator.getByRole("option", { name: c });
+  }
+
+  // saveButton() {
+  //   return this.dialogLocator.getByRole("button", {
+  //     name: "Save view",
+  //     exact: true,
+  //   });
+  // }
+  saveButton() {
+    return this.dialogLocator.getByTestId("saved-views-btn-save");
+  }
+
+  cancelButton() {
+    return this.dialogLocator.getByRole("button", {
+      name: "Cancel",
+      exact: true,
+    });
+  }
+
+  colorListContainer() {
+    return this.dialogLocator.getByRole("listbox");
+  }
+
+  nameError() {
+    return this.dialogLocator.getByText("Name already exists");
+  }
+
+  searchInput() {
+    return this.locator
+      .getByTestId("saved-views-selection-search-container")
+      .getByTestId("saved-views-selection-search-input");
+  }
+
+  deleteBtn() {
+    return this.dialogLocator.getByRole("button", { name: "Delete" }).first();
+  }
+
+  async clickDeleteBtn() {
+    return this.deleteBtn().click();
+  }
+}
+
+class SavedViewAsserter {
+  constructor(private readonly svp: SavedViewsPom) {}
+
+  async verifyNameIsEmpty() {
+    await this.svp.nameInput().waitFor({ state: "visible" });
+    const name = this.svp.nameInput();
+    await expect(name).toBeVisible();
+    await expect(name).toBeEmpty();
+  }
+
+  async verifyDescriptionIsEmpty() {
+    const desc = this.svp.descriptionInput();
+    await expect(desc).toBeEmpty();
+  }
+
+  async verifyDefaultColor(color: Color = "Gray") {
+    await expect(this.svp.colorInput(color).first()).toBeInViewport();
+  }
+
+  async verifyInputIsDefault() {
+    await this.verifyNameIsEmpty();
+    await this.verifyDescriptionIsEmpty();
+    await this.verifyDefaultColor();
+  }
+
+  async verifySaveBtnIsDisabled() {
+    const saveBtn = this.svp.saveButton();
+    await expect(saveBtn).toBeDisabled();
+  }
+
+  async verifySaveBtnIsEnabled() {
+    const saveBtn = this.svp.saveButton();
+    await expect(saveBtn).toBeEnabled();
+  }
+
+  async verifyAllInputClear() {
+    await expect(this.svp.nameInput()).toBeEmpty();
+    await expect(this.svp.descriptionInput()).toBeEmpty();
+    await expect(this.svp.colorInput("Gray")).toBeVisible();
+  }
+
+  async verifyCancelBtnClearsAll() {
+    const cancelBtn = this.svp.cancelButton();
+    await cancelBtn.click();
+
+    await this.verifyAllInputClear();
+  }
+
+  async verifySavedView(slug: string = "test") {
+    // await this.svp.page.waitForURL(`*view=${slug}`, { timeout: 5000 });
+    await expect(this.svp.page).toHaveURL(new RegExp(`view=${slug}`));
+  }
+
+  async verifyUnsavedView(name: string = "test") {
+    await expect(this.svp.page).not.toHaveURL(new RegExp(`view=${name}`));
+    await expect(this.svp.selector()).toBeVisible();
+  }
+
+  async verifyModalClosed() {
+    await expect(this.svp.closeModalBtn()).toBeHidden();
+  }
+
+  async verifyDefaultColors() {
+    const colorListBox = this.svp.colorListContainer();
+    await expect(colorListBox).toBeVisible();
+    // verify default
+    await expect(
+      colorListBox.getByRole("option", { name: "Gray" })
+    ).toBeInViewport();
+
+    ColorList.forEach(async (color: string) => {
+      await expect(
+        colorListBox.getByRole("option", { name: color })
+      ).toBeVisible();
+    });
+  }
+
+  async verifyColorNotExists(color: string = "white") {
+    await expect(this.svp.colorOption(color as Color)).toBeHidden();
+  }
+
+  async verifySelectionHasNewOption(name: string = "test") {
+    await this.svp.clearView();
+    await this.svp.selector().click();
+    await expect(this.svp.savedViewOption(name)).toBeVisible();
+  }
+
+  async verifySaveViewFails(name: string = "test") {
+    await expect(this.svp.saveButton()).toBeDisabled();
+    expect(this.svp.nameError()).toBeDefined();
+    await this.svp.clickCloseModal();
+  }
+
+  async verifyModalTitle(name: string) {
+    await expect(
+      this.svp.dialogLocator.getByRole("heading", {
+        name,
+      })
+    ).toBeVisible();
+  }
+
+  async verifySearchExists() {
+    await expect(this.svp.searchInput()).toBeVisible();
+  }
+
+  async verifySearch(
+    term: string,
+    expectedResult: string[],
+    excluded: string[]
+  ) {
+    await this.svp.searchInput().clear();
+    await this.svp.searchInput().type(term);
+
+    if (expectedResult.length) {
+      await this.svp
+        .savedViewOption(expectedResult[0])
+        .waitFor({ state: "visible", timeout: 1000 });
+
+      expectedResult.forEach(async (slug: string) => {
+        await expect(this.svp.savedViewOption(slug)).toBeVisible();
+      });
+    }
+
+    if (excluded.length) {
+      await this.svp
+        .savedViewOption(excluded[1])
+        .waitFor({ state: "hidden", timeout: 1000 });
+
+      excluded.forEach(async (slug: string) => {
+        await expect(this.svp.savedViewOption(slug).first()).toBeHidden();
+      });
+    }
+  }
+
+  async verifyDeleteBtnHidden() {
+    await expect(this.svp.deleteBtn()).toBeHidden();
+  }
+
+  async verifyDeleteBtn() {
+    await expect(this.svp.deleteBtn()).toBeVisible();
+  }
+
+  async verifyViewOption(name: string = "test") {
+    await expect(this.svp.savedViewOption(name)).toBeVisible();
+  }
+
+  async verifyViewOptionHidden(name: string = "test") {
+    await expect(this.svp.savedViewOption(name)).toBeHidden();
+  }
+
+  async verifyInput({
+    name,
+    description,
+    color,
+  }: {
+    name: string;
+    description: string;
+    color: Color;
+  }) {
+    await expect(this.svp.nameInput()).toHaveValue(name);
+    await expect(this.svp.descriptionInput()).toHaveValue(description);
+    await expect(this.svp.colorInput(color)).toBeVisible();
+  }
+
+  async verifyInputUpdated(
+    name: string = updatedView.name,
+    description: string = updatedView.description,
+    color: Color = updatedView.color
+  ) {
+    await this.svp.clickEdit("test");
+    this.verifyInputUpdated(name, description, color);
+  }
+
+  async verifyInputUpdatedRaw(
+    name: string = updatedView2.name,
+    description: string = updatedView2.description,
+    color: Color = updatedView2.color
+  ) {
+    await expect(this.svp.nameInput()).toHaveValue(name);
+    await expect(this.svp.descriptionInput()).toHaveValue(description);
+    await expect(this.svp.colorInput(color)).toBeVisible();
+  }
+}

--- a/e2e-pw/src/oss/poms/saved-views.ts
+++ b/e2e-pw/src/oss/poms/saved-views.ts
@@ -1,10 +1,15 @@
 import { expect, Locator, Page } from "src/oss/fixtures";
-import {
-  Color,
-  ColorList,
-  updatedView,
-  updatedView2,
-} from "../specs/smoke-tests/saved-views.spec";
+
+export type Color =
+  | "Gray"
+  | "Blue"
+  | "Purple"
+  | "Red"
+  | "Yellow"
+  | "Green"
+  | "Pink"
+  | "Orange"
+  | "Purple";
 
 export class SavedViewsPom {
   readonly page: Page;
@@ -253,7 +258,7 @@ class SavedViewAsserter {
     await expect(this.svp.closeModalBtn()).toBeHidden();
   }
 
-  async verifyDefaultColors() {
+  async verifyDefaultColors(ColorList: string[]) {
     const colorListBox = this.svp.colorListContainer();
     await expect(colorListBox).toBeVisible();
     // verify default
@@ -355,20 +360,15 @@ class SavedViewAsserter {
     await expect(this.svp.colorInput(color)).toBeVisible();
   }
 
-  async verifyInputUpdated(
-    name: string = updatedView.name,
-    description: string = updatedView.description,
-    color: Color = updatedView.color
-  ) {
-    await this.svp.clickEdit("test");
-    this.verifyInputUpdated(name, description, color);
-  }
-
-  async verifyInputUpdatedRaw(
-    name: string = updatedView2.name,
-    description: string = updatedView2.description,
-    color: Color = updatedView2.color
-  ) {
+  async verifyInputUpdated({
+    name,
+    description,
+    color,
+  }: {
+    name: string;
+    description: string;
+    color: Color;
+  }) {
     await expect(this.svp.nameInput()).toHaveValue(name);
     await expect(this.svp.descriptionInput()).toHaveValue(description);
     await expect(this.svp.colorInput(color)).toBeVisible();

--- a/e2e-pw/src/oss/poms/saved-views.ts
+++ b/e2e-pw/src/oss/poms/saved-views.ts
@@ -258,7 +258,7 @@ class SavedViewAsserter {
     await expect(this.svp.closeModalBtn()).toBeHidden();
   }
 
-  async verifyDefaultColors(ColorList: string[]) {
+  async verifyDefaultColors(colorList: string[]) {
     const colorListBox = this.svp.colorListContainer();
     await expect(colorListBox).toBeVisible();
     // verify default
@@ -266,7 +266,7 @@ class SavedViewAsserter {
       colorListBox.getByRole("option", { name: "Gray" })
     ).toBeInViewport();
 
-    ColorList.forEach(async (color: string) => {
+    colorList.forEach(async (color: string) => {
       await expect(
         colorListBox.getByRole("option", { name: color })
       ).toBeVisible();

--- a/e2e-pw/src/oss/specs/smoke-tests/saved-views.spec.ts
+++ b/e2e-pw/src/oss/specs/smoke-tests/saved-views.spec.ts
@@ -1,0 +1,320 @@
+import { test as base, expect } from "src/oss/fixtures";
+import { SavedViewsPom } from "src/oss/poms/saved-views";
+import { getUniqueDatasetNameWithPrefix } from "src/oss/utils";
+
+export const ColorList = [
+  "Gray",
+  "Blue",
+  "Purple",
+  "Red",
+  "Yellow",
+  "Green",
+  "Pink",
+  "Orange",
+  "Purple",
+];
+
+export type Color =
+  | "Gray"
+  | "Blue"
+  | "Purple"
+  | "Red"
+  | "Yellow"
+  | "Green"
+  | "Pink"
+  | "Orange"
+  | "Purple";
+
+export const updatedView = {
+  name: "test updated",
+  description: "test updated",
+  color: "Yellow" as Color,
+};
+
+export const updatedView2 = {
+  name: "test updated 2",
+  description: "test updated 2",
+  color: "Orange" as Color,
+  slug: "test-updated-2",
+};
+
+const testView = {
+  id: 0,
+  name: "test",
+  description: "description",
+  color: "Gray" as Color,
+  newColor: "Blue" as Color,
+  slug: "test",
+};
+
+const testView1 = {
+  id: 1,
+  name: "test 1",
+  description: "description ",
+  color: "Gray",
+  newColor: "Orange",
+  slug: "test-1",
+};
+
+const testView2 = {
+  id: 2,
+  name: "test 2",
+  description: "description 2",
+  color: "Gray",
+  newColor: "Yellow",
+  slug: "test-2",
+};
+
+const datasetName = getUniqueDatasetNameWithPrefix("smoke-quickstart");
+
+const test = base.extend<{ savedViews: SavedViewsPom }>({
+  savedViews: async ({ page }, use) => {
+    await use(new SavedViewsPom(page));
+  },
+});
+
+test.describe("saved views", () => {
+  test.beforeAll(async ({ fiftyoneLoader }) => {
+    await fiftyoneLoader.loadZooDataset("quickstart", datasetName, {
+      max_samples: 5,
+    });
+  });
+
+  test.beforeEach(async ({ page, fiftyoneLoader, savedViews }) => {
+    await fiftyoneLoader.waitUntilLoad(page, datasetName);
+    await delete_saved_view(savedViews, testView.name);
+    await delete_saved_view(savedViews, updatedView2.slug);
+  });
+
+  async function delete_saved_view(savedViews, slug: string) {
+    const hasUnsaved = savedViews.canClearView();
+    if (!hasUnsaved) {
+      await savedViews.clearView();
+    }
+
+    await savedViews.openSelect();
+    const count = await savedViews.savedViewOptionCount(slug);
+
+    if (count) {
+      await savedViews.clickOptionEdit(slug);
+      await savedViews.clickDeleteBtn();
+    } else {
+      await savedViews.openSelect();
+    }
+  }
+
+  test("page has the correct title", async ({ page }) => {
+    await expect(page).toHaveTitle(/FiftyOne/);
+  });
+
+  test("saved views selector exists", async ({ savedViews }) => {
+    await expect(savedViews.selector()).toBeVisible();
+  });
+
+  test("clicking on the selector opens the view dialog with default values.", async ({
+    savedViews,
+  }) => {
+    await savedViews.openCreateModal();
+    await savedViews.assert.verifyInputIsDefault();
+  });
+
+  test("saving a view is disabled if the name input is empty", async ({
+    savedViews,
+  }) => {
+    await savedViews.openCreateModal();
+    await savedViews.assert.verifySaveBtnIsDisabled();
+  });
+
+  test("saving a view is enabled if the name input has value", async ({
+    savedViews,
+  }) => {
+    await savedViews.openCreateModal();
+    await savedViews.assert.verifySaveBtnIsDisabled();
+    await savedViews.nameInput().type("test");
+    await savedViews.assert.verifySaveBtnIsEnabled();
+  });
+
+  test("cancel button clears the inputs", async ({ savedViews }) => {
+    await savedViews.openCreateModal();
+
+    await savedViews.nameInput().type("test");
+    await savedViews.descriptionInput().type("test");
+    await savedViews.colorInput().click();
+    await savedViews.colorOption().click();
+
+    await savedViews.assert.verifyCancelBtnClearsAll();
+  });
+
+  test("saving a valid view succeeds with view=view-slug as query parameter in the URL", async ({
+    savedViews,
+  }) => {
+    await savedViews.saveView(testView);
+    await savedViews.assert.verifySavedView();
+  });
+
+  test("clearing a saved view clears the url and view selection", async ({
+    savedViews,
+  }) => {
+    await savedViews.saveView(testView);
+    await savedViews.assert.verifySavedView();
+
+    await savedViews.clearView();
+    await savedViews.assert.verifyUnsavedView();
+  });
+
+  test("clicking on the close icon closes the save view modal", async ({
+    savedViews,
+  }) => {
+    await savedViews.openCreateModal();
+    await savedViews.clickCloseModal();
+    await savedViews.assert.verifyModalClosed();
+  });
+
+  test("directly linking to a non-existing view clears view parameter", async ({
+    page,
+    savedViews,
+  }) => {
+    const nonExistingName = "test-name-non-existing";
+    await page.goto(`/datasets/${datasetName}?view=${nonExistingName}`);
+    await savedViews.assert.verifyUnsavedView(nonExistingName);
+  });
+
+  test("color selection has nine specific color choices", async ({
+    savedViews,
+  }) => {
+    await savedViews.openCreateModal();
+    await savedViews.clickColor();
+    await savedViews.assert.verifyDefaultColors();
+    await savedViews.assert.verifyColorNotExists();
+  });
+
+  test("saving a view adds a new option to the saved views selector", async ({
+    savedViews,
+  }) => {
+    await savedViews.saveView(testView);
+    await savedViews.assert.verifySelectionHasNewOption();
+  });
+
+  test("saving a view with an already existing name fails", async ({
+    savedViews,
+  }) => {
+    await savedViews.saveView(testView);
+    await savedViews.clearView();
+
+    await savedViews.openCreateModal();
+    await savedViews.saveViewInputs(testView);
+
+    await savedViews.assert.verifySaveViewFails();
+  });
+
+  test("create and edit modals have the correct titles", async ({
+    savedViews,
+  }) => {
+    await savedViews.openCreateModal();
+    await savedViews.assert.verifyModalTitle("Create view close");
+    await savedViews.closeModalBtn().click();
+
+    await savedViews.saveView(testView);
+    await savedViews.clickEdit("test");
+    await savedViews.assert.verifyModalTitle("Edit view close");
+    await savedViews.clickCloseModal();
+  });
+
+  test("searching through saved views works", async ({ savedViews }) => {
+    await savedViews.saveView(testView1);
+    await savedViews.clearViewBtn().click();
+
+    await savedViews.saveView(testView2);
+    await savedViews.clearView();
+
+    await savedViews.selector().click();
+    await savedViews.assert.verifySearchExists();
+
+    await savedViews.assert.verifySearch("test 2", ["test-2"], ["test-1"]);
+    await savedViews.assert.verifySearch("test 3", [], ["test-1", "test-2"]);
+    await savedViews.assert.verifySearch("test", ["test-1", "test-2"], []);
+
+    await savedViews.deleteView("test-1");
+    await savedViews.selector().click();
+    await savedViews.deleteView("test-2");
+  });
+
+  test("edit modal has a delete button but a create modal does not", async ({
+    savedViews,
+  }) => {
+    await savedViews.openCreateModal();
+    await savedViews.assert.verifyDeleteBtnHidden();
+
+    await savedViews.closeModalBtn().click();
+    await savedViews.saveView(testView);
+
+    await savedViews.clickEdit("test");
+    await savedViews.assert.verifyDeleteBtn();
+
+    await savedViews.deleteViewClick();
+  });
+
+  test("deleting a saved view clears the URL view parameter and view selection", async ({
+    savedViews,
+  }) => {
+    await savedViews.saveView(testView);
+    await savedViews.clearView();
+
+    await savedViews.openSelect();
+    await savedViews.assert.verifyViewOption();
+
+    await savedViews.clickOptionEdit(testView.name);
+    await savedViews.clickDeleteBtn();
+
+    await savedViews.assert.verifyUnsavedView();
+    await savedViews.openCreateModal();
+    await savedViews.assert.verifyViewOptionHidden();
+  });
+
+  test("editing a saved view updates the view's name and description", async ({
+    savedViews,
+  }) => {
+    await savedViews.saveView(testView);
+    await savedViews.clearView();
+
+    await savedViews.openSelect();
+    await savedViews.clickOptionEdit(testView.name);
+    await savedViews.assert.verifyInput({
+      name: testView.name,
+      description: testView.description,
+      color: testView.newColor,
+    });
+
+    await savedViews.editView(
+      updatedView2.name,
+      updatedView2.description,
+      "Blue",
+      updatedView2.color
+    );
+
+    await savedViews.clickEdit(updatedView2.slug);
+    await savedViews.assert.verifyInputUpdatedRaw();
+  });
+
+  test("editing a saved view should update the view URL parameter and selection", async ({
+    savedViews,
+  }) => {
+    await savedViews.assert.verifyUnsavedView();
+
+    await savedViews.saveView(testView);
+    await savedViews.assert.verifySavedView();
+
+    await savedViews.clearView();
+
+    await savedViews.openSelect();
+    await savedViews.clickOptionEdit(testView.name);
+    await savedViews.editView(
+      updatedView2.name,
+      updatedView2.description,
+      "Blue",
+      updatedView2.color
+    );
+
+    await savedViews.assert.verifySavedView("test-updated");
+  });
+});

--- a/e2e-pw/src/oss/specs/smoke-tests/saved-views.spec.ts
+++ b/e2e-pw/src/oss/specs/smoke-tests/saved-views.spec.ts
@@ -1,8 +1,8 @@
 import { test as base, expect } from "src/oss/fixtures";
-import { SavedViewsPom } from "src/oss/poms/saved-views";
+import { SavedViewsPom, Color } from "src/oss/poms/saved-views";
 import { getUniqueDatasetNameWithPrefix } from "src/oss/utils";
 
-export const ColorList = [
+const ColorList = [
   "Gray",
   "Blue",
   "Purple",
@@ -13,17 +13,6 @@ export const ColorList = [
   "Orange",
   "Purple",
 ];
-
-export type Color =
-  | "Gray"
-  | "Blue"
-  | "Purple"
-  | "Red"
-  | "Yellow"
-  | "Green"
-  | "Pink"
-  | "Orange"
-  | "Purple";
 
 export const updatedView = {
   name: "test updated",
@@ -82,11 +71,11 @@ test.describe("saved views", () => {
 
   test.beforeEach(async ({ page, fiftyoneLoader, savedViews }) => {
     await fiftyoneLoader.waitUntilLoad(page, datasetName);
-    await delete_saved_view(savedViews, testView.name);
-    await delete_saved_view(savedViews, updatedView2.slug);
+    await deleteSavedView(savedViews, testView.name);
+    await deleteSavedView(savedViews, updatedView2.slug);
   });
 
-  async function delete_saved_view(savedViews, slug: string) {
+  async function deleteSavedView(savedViews, slug: string) {
     const hasUnsaved = savedViews.canClearView();
     if (!hasUnsaved) {
       await savedViews.clearView();
@@ -111,7 +100,7 @@ test.describe("saved views", () => {
     await expect(savedViews.selector()).toBeVisible();
   });
 
-  test("clicking on the selector opens the view dialog with default values.", async ({
+  test("clicking on the selector opens the view dialog with default values", async ({
     savedViews,
   }) => {
     await savedViews.openCreateModal();
@@ -184,7 +173,7 @@ test.describe("saved views", () => {
   }) => {
     await savedViews.openCreateModal();
     await savedViews.clickColor();
-    await savedViews.assert.verifyDefaultColors();
+    await savedViews.assert.verifyDefaultColors(ColorList);
     await savedViews.assert.verifyColorNotExists();
   });
 
@@ -293,7 +282,7 @@ test.describe("saved views", () => {
     );
 
     await savedViews.clickEdit(updatedView2.slug);
-    await savedViews.assert.verifyInputUpdatedRaw();
+    await savedViews.assert.verifyInputUpdated(updatedView2);
   });
 
   test("editing a saved view should update the view URL parameter and selection", async ({


### PR DESCRIPTION
## What changes are proposed in this pull request?

- Note: I still see intermittent failures when run locally.
- I have tried not used waitForTimeout as much as possible, but currently I have couple to wait for dialogs to close etc. I had a hard time use the locator.wait({ state: 'visible'}). 

## How is this patch tested? If it is not, please explain why.

(Details)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
