### PR TITLE
Display label tag per field in sidebar

### DIFF
--- a/app/packages/core/src/components/Sidebar/Entries/FilterablePathEntry.tsx
+++ b/app/packages/core/src/components/Sidebar/Entries/FilterablePathEntry.tsx
@@ -147,9 +147,7 @@ const getFilterData = (
 
       return (
         !label ||
-        (name !== "tags" &&
-          !excluded.includes(name) &&
-          VALID_PRIMITIVE_TYPES.includes(ftype))
+        (!excluded.includes(name) && VALID_PRIMITIVE_TYPES.includes(ftype))
       );
     })
     .map<FilterItem>(({ ftype, subfield, name }) => {


### PR DESCRIPTION
Display label tags on per field level. User can use label tag to filter and select on the field level. 

https://github.com/voxel51/fiftyone/assets/17770824/77435082-aa9e-485b-a5a6-1a896a615c7e

## What changes are proposed in this pull request?

(Please fill in changes proposed in this fix)

## How is this patch tested? If it is not, please explain why.

(Details)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
