### PR TITLE
improve operator form validation debounce

### DIFF
--- a/app/packages/operators/src/OperatorBrowser.tsx
+++ b/app/packages/operators/src/OperatorBrowser.tsx
@@ -54,11 +54,25 @@ const ChoiceIcon = styled.div`
 `;
 
 const Choice = (props: ChoicePropsType) => {
+  const containerRef = useRef<HTMLDivElement>(null);
   const { onClick, choice, selected } = props;
   const { label, name, canExecute } = choice;
   const disabled = canExecute === false;
+
+  useEffect(() => {
+    const containerElem = containerRef.current;
+    if (selected && containerElem) {
+      containerElem.scrollIntoView({ block: "nearest" });
+    }
+  }, [selected]);
+
   return (
-    <ChoiceContainer disabled={disabled} onClick={onClick} selected={selected}>
+    <ChoiceContainer
+      disabled={disabled}
+      onClick={onClick}
+      selected={selected}
+      ref={containerRef}
+    >
       <ChoiceIcon>
         <OperatorIcon {...choice} Fallback={disabled ? Lock : Extension} />
       </ChoiceIcon>

--- a/app/packages/operators/src/OperatorPalette.tsx
+++ b/app/packages/operators/src/OperatorPalette.tsx
@@ -11,6 +11,7 @@ import { PALETTE_CONTROL_KEYS } from "./constants";
 
 import { scrollable } from "@fiftyone/components";
 import {
+  CircularProgress,
   Dialog,
   DialogActions,
   DialogContent,
@@ -34,6 +35,7 @@ export default function OperatorPalette(props: OperatorPaletteProps) {
     title,
     disableSubmit,
     disabledReason,
+    loading,
   } = props;
   const hideActions = !onSubmit && !onCancel;
   const scroll = "paper";
@@ -108,6 +110,12 @@ export default function OperatorPalette(props: OperatorPaletteProps) {
       </DialogContent>
       {!hideActions && (
         <DialogActions sx={{ p: 1 }}>
+          {loading && (
+            <CircularProgress
+              size={20}
+              sx={{ mr: 1, color: (theme) => theme.palette.text.secondary }}
+            />
+          )}
           {onCancel && (
             <BaseStylesProvider>
               <Button onClick={onCancel} onKeyDown={onEnter(onCancel)}>
@@ -146,4 +154,5 @@ export type OperatorPaletteProps = PropsWithChildren & {
   title?: ReactElement;
   disableSubmit?: boolean;
   disabledReason?: string;
+  loading?: boolean;
 };

--- a/app/packages/operators/src/OperatorPrompt.tsx
+++ b/app/packages/operators/src/OperatorPrompt.tsx
@@ -1,4 +1,4 @@
-import { Box } from "@mui/material";
+import { Box, LinearProgress, Typography } from "@mui/material";
 import { useCallback } from "react";
 import { createPortal } from "react-dom";
 import { useRecoilValue } from "recoil";
@@ -52,6 +52,7 @@ function ActualOperatorPrompt() {
 
   const title = getPromptTitle(operatorPrompt);
   const hasValidationErrors = operatorPrompt.validationErrors?.length > 0;
+  const { resolving, pendingResolve } = operatorPrompt;
 
   return createPortal(
     <OperatorPalette
@@ -59,14 +60,19 @@ function ActualOperatorPrompt() {
       {...paletteProps}
       onClose={paletteProps.onCancel || operatorPrompt.close}
       submitOnControlEnter
-      disableSubmit={hasValidationErrors}
-      disabledReason="Cannot execute operator with validation errors"
+      disableSubmit={hasValidationErrors || resolving || pendingResolve}
+      disabledReason={
+        hasValidationErrors
+          ? "Cannot execute operator with validation errors"
+          : "Cannot execute operator while validating form"
+      }
+      loading={resolving || pendingResolve}
     >
       <PaletteContentContainer>
         {operatorPrompt.showPrompt && (
           <Prompting operatorPrompt={operatorPrompt} />
         )}
-        {operatorPrompt.isExecuting && <div>Executing...</div>}
+        {operatorPrompt.isExecuting && <Executing />}
         {showResultOrError && (
           <ResultsOrError
             operatorPrompt={operatorPrompt}
@@ -76,6 +82,15 @@ function ActualOperatorPrompt() {
       </PaletteContentContainer>
     </OperatorPalette>,
     document.body
+  );
+}
+
+function Executing() {
+  return (
+    <Box>
+      <LinearProgress />
+      <Typography sx={{ pt: 1, textAlign: "center" }}>Executing...</Typography>
+    </Box>
   );
 }
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

- Add loading indicator when resolving input is in progress
- Disable execute button if resolving or there is unresolved changes or if it's resolving
- Immediately validate form on prompt
- Improve "Executing..." UI

## How is this patch tested? If it is not, please explain why.

(Details)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
