### PR TITLE
Remove starlette ceiling

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ INSTALL_REQUIRES = [
     "setuptools",
     "sseclient-py>=1.7.2,<2",
     "sse-starlette>=0.10.3,<1",
-    "starlette>=0.24.0,<0.27",
+    "starlette>=0.24.0",
     "strawberry-graphql==0.138.1",
     "tabulate",
     "xmltodict",


### PR DESCRIPTION
Resolves #2210 

Removes the `starlette<0.27`. I am personally ok with removing this dependency, `starlette` seems stable now