### PR TITLE
add support for custom operator icon

### DIFF
--- a/app/packages/operators/src/OperatorBrowser.tsx
+++ b/app/packages/operators/src/OperatorBrowser.tsx
@@ -9,6 +9,7 @@ import { useOperatorBrowser } from "./state";
 // todo: use plugin component
 import { useEffect, useRef } from "react";
 import ErrorView from "../../core/src/plugins/SchemaIO/components/ErrorView";
+import OperatorIcon, { CustomIconPropsType } from "./OperatorIcon";
 import OperatorPalette from "./OperatorPalette";
 import { PaletteContentContainer } from "./styled-components";
 
@@ -52,13 +53,17 @@ const ChoiceIcon = styled.div`
   line-height: 45px;
 `;
 
-const Choice = ({ onClick, choice, selected }) => {
-  const disabled = choice.canExecute === false;
+const Choice = (props: ChoicePropsType) => {
+  const { onClick, choice, selected } = props;
+  const { label, name, canExecute } = choice;
+  const disabled = canExecute === false;
   return (
     <ChoiceContainer disabled={disabled} onClick={onClick} selected={selected}>
-      <ChoiceIcon>{disabled ? <Lock /> : <Extension />}</ChoiceIcon>
-      <ChoiceDescription>{choice.label}</ChoiceDescription>
-      {choice.label && <ChoiceLabel>{choice.name}</ChoiceLabel>}
+      <ChoiceIcon>
+        <OperatorIcon {...choice} Fallback={disabled ? Lock : Extension} />
+      </ChoiceIcon>
+      <ChoiceDescription>{label}</ChoiceDescription>
+      {label && <ChoiceLabel>{name}</ChoiceLabel>}
     </ChoiceContainer>
   );
 };
@@ -165,7 +170,9 @@ export default function OperatorBrowser() {
         ))}
         {browser.choices.length === 0 && (
           <Choice
-            onClick={() => {}}
+            onClick={() => {
+              // noop
+            }}
             key={"no-operator"}
             choice={{ label: "No matching operators" }}
             selected={false}
@@ -176,3 +183,15 @@ export default function OperatorBrowser() {
     document.body
   );
 }
+
+type ChoiceType = CustomIconPropsType & {
+  label: string;
+  name?: string;
+  canExecute?: boolean;
+};
+
+type ChoicePropsType = {
+  onClick: () => void;
+  choice: ChoiceType;
+  selected?: boolean;
+};

--- a/app/packages/operators/src/OperatorIcon.tsx
+++ b/app/packages/operators/src/OperatorIcon.tsx
@@ -1,0 +1,44 @@
+import { usePluginDefinition } from "@fiftyone/plugins";
+import { useColorScheme } from "@mui/material";
+import { resolveServerPath } from "./utils";
+
+export default function OperatorIcon(props: CustomIconPropsType) {
+  const { pluginName, icon, lightIcon, darkIcon, _builtIn, Fallback } = props;
+  const { mode } = useColorScheme();
+  const iconPath = mode === "dark" && darkIcon ? darkIcon : lightIcon || icon;
+
+  if (!iconPath) return Fallback ? <Fallback /> : null;
+  if (_builtIn) return <ImageIcon src={iconPath} />;
+  return <CustomOperatorIcon pluginName={pluginName} iconPath={iconPath} />;
+}
+
+function CustomOperatorIcon(props: CustomOperatorIconPropsType) {
+  const { pluginName, iconPath } = props;
+  const plugin = usePluginDefinition(pluginName);
+  const assetPath = resolveServerPath(plugin);
+  const resolvedIconPath = assetPath + iconPath;
+  return <ImageIcon src={resolvedIconPath} />;
+}
+
+function ImageIcon(props: ImageIconPropsType) {
+  const { src } = props;
+  return <img src={src} height={21} width={21} />;
+}
+
+export type CustomIconPropsType = {
+  pluginName?: string;
+  icon?: string;
+  lightIcon?: string;
+  darkIcon?: string;
+  _builtIn?: boolean;
+  Fallback?: React.ComponentType;
+};
+
+type CustomOperatorIconPropsType = {
+  pluginName?: string;
+  iconPath?: string;
+};
+
+type ImageIconPropsType = {
+  src: string;
+};

--- a/app/packages/operators/src/OperatorPlacements.tsx
+++ b/app/packages/operators/src/OperatorPlacements.tsx
@@ -1,18 +1,16 @@
-import { ErrorBoundary, PillButton } from "@fiftyone/components";
+import { ErrorBoundary, Link, PillButton } from "@fiftyone/components";
+import { withSuspense } from "@fiftyone/state";
+import { Extension } from "@mui/icons-material";
+import styled from "styled-components";
+import { types } from ".";
+import OperatorIcon from "./OperatorIcon";
+import { Operator } from "./operators";
 import {
   useOperatorExecutor,
   useOperatorPlacements,
   usePromptOperatorInput,
 } from "./state";
 import { Placement, Places } from "./types";
-import { Link } from "@fiftyone/components";
-import styled from "styled-components";
-import { types } from ".";
-import { Operator } from "./operators";
-import { withSuspense } from "@fiftyone/state";
-import { usePluginDefinition } from "@fiftyone/plugins";
-import { resolveServerPath } from "./utils";
-import { useColorScheme } from "@mui/material";
 
 function OperatorPlacements(props: OperatorPlacementsProps) {
   const { place } = props;
@@ -44,20 +42,22 @@ function OperatorPlacement(props: OperatorPlacementProps) {
 }
 
 function ButtonPlacement(props: OperatorPlacementProps) {
-  const { mode } = useColorScheme();
   const promptForInput = usePromptOperatorInput();
   const { operator, placement, place } = props;
-  const { uri, pluginName } = operator;
+  const { uri } = operator;
   const { view = {} } = placement;
   const { label } = view;
   const { icon, darkIcon, lightIcon, prompt = true } = view?.options || {};
-  const plugin = usePluginDefinition(pluginName);
-  const serverPath = resolveServerPath(plugin);
-  const iconPath = mode === "dark" && darkIcon ? darkIcon : lightIcon || icon;
   const { execute } = useOperatorExecutor(uri);
 
-  const IconComponent = icon && (
-    <img src={`${serverPath}/${iconPath}`} width={21} height={21} />
+  const IconComponent = (
+    <OperatorIcon
+      {...operator}
+      icon={icon}
+      darkIcon={darkIcon}
+      lightIcon={lightIcon}
+      Fallback={Extension}
+    />
   );
 
   const handleClick = () => {
@@ -86,7 +86,7 @@ function ButtonPlacement(props: OperatorPlacementProps) {
 
   return (
     <SquareButton to={handleClick} title={label}>
-      {IconComponent || label}
+      {IconComponent}
     </SquareButton>
   );
 }

--- a/app/packages/operators/src/built-in-operators.ts
+++ b/app/packages/operators/src/built-in-operators.ts
@@ -25,6 +25,7 @@ import { useShowOperatorIO } from "./state";
 // BUILT-IN OPERATORS
 //
 class ReloadSamples extends Operator {
+  _builtIn = true;
   get config(): OperatorConfig {
     return new OperatorConfig({
       name: "reload_samples",
@@ -37,6 +38,7 @@ class ReloadSamples extends Operator {
   }
 }
 class ReloadDataset extends Operator {
+  _builtIn = true;
   get config(): OperatorConfig {
     return new OperatorConfig({
       name: "reload_dataset",
@@ -50,6 +52,7 @@ class ReloadDataset extends Operator {
   }
 }
 class ClearSelectedSamples extends Operator {
+  _builtIn = true;
   get config(): OperatorConfig {
     return new OperatorConfig({
       name: "clear_selected_samples",
@@ -69,6 +72,7 @@ class ClearSelectedSamples extends Operator {
 }
 
 class CopyViewAsJSON extends Operator {
+  _builtIn = true;
   get config(): OperatorConfig {
     return new OperatorConfig({
       name: "copy_view_as_json",
@@ -83,6 +87,7 @@ class CopyViewAsJSON extends Operator {
 }
 
 class ViewFromJSON extends Operator {
+  _builtIn = true;
   get config(): OperatorConfig {
     return new OperatorConfig({
       name: "view_from_clipboard",
@@ -101,6 +106,7 @@ class ViewFromJSON extends Operator {
 }
 
 class OpenPanel extends Operator {
+  _builtIn = true;
   get config(): OperatorConfig {
     return new OperatorConfig({
       name: "open_panel",
@@ -172,6 +178,7 @@ class OpenPanel extends Operator {
 }
 
 class OpenAllPanels extends Operator {
+  _builtIn = true;
   get config(): OperatorConfig {
     return new OperatorConfig({
       name: "open_all_panel",
@@ -197,6 +204,7 @@ class OpenAllPanels extends Operator {
 }
 
 class ClosePanel extends Operator {
+  _builtIn = true;
   get config(): OperatorConfig {
     return new OperatorConfig({
       name: "close_panel",
@@ -243,6 +251,7 @@ class ClosePanel extends Operator {
 }
 
 class CloseAllPanels extends Operator {
+  _builtIn = true;
   get config(): OperatorConfig {
     return new OperatorConfig({
       name: "close_all_panel",
@@ -266,6 +275,7 @@ class CloseAllPanels extends Operator {
 }
 
 class SplitPanel extends Operator {
+  _builtIn = true;
   get config(): OperatorConfig {
     return new OperatorConfig({
       name: "split_panel",
@@ -297,6 +307,7 @@ class SplitPanel extends Operator {
 }
 
 class OpenDataset extends Operator {
+  _builtIn = true;
   get config(): OperatorConfig {
     return new OperatorConfig({
       name: "open_dataset",
@@ -320,6 +331,7 @@ class OpenDataset extends Operator {
 }
 
 class ClearView extends Operator {
+  _builtIn = true;
   get config(): OperatorConfig {
     return new OperatorConfig({
       name: "clear_view",
@@ -331,6 +343,7 @@ class ClearView extends Operator {
   }
 }
 class ClearSidebarFilters extends Operator {
+  _builtIn = true;
   get config(): OperatorConfig {
     return new OperatorConfig({
       name: "clear_sidebar_filters",
@@ -343,6 +356,7 @@ class ClearSidebarFilters extends Operator {
 }
 
 class ClearAllStages extends Operator {
+  _builtIn = true;
   get config(): OperatorConfig {
     return new OperatorConfig({
       name: "clear_all_stages",
@@ -365,6 +379,7 @@ class ClearAllStages extends Operator {
 }
 
 class RefreshColors extends Operator {
+  _builtIn = true;
   get config(): OperatorConfig {
     return new OperatorConfig({
       name: "refresh_colors",
@@ -379,6 +394,7 @@ class RefreshColors extends Operator {
 }
 
 class ShowSelectedSamples extends Operator {
+  _builtIn = true;
   get config(): OperatorConfig {
     return new OperatorConfig({
       name: "show_selected_samples",
@@ -402,6 +418,7 @@ class ShowSelectedSamples extends Operator {
 }
 
 class ConvertExtendedSelectionToSelectedSamples extends Operator {
+  _builtIn = true;
   get config(): OperatorConfig {
     return new OperatorConfig({
       name: "convert_extended_selection_to_selected_samples",
@@ -427,6 +444,7 @@ class ConvertExtendedSelectionToSelectedSamples extends Operator {
 
 // an operator that sets selected samples based on ctx.params
 class SetSelectedSamples extends Operator {
+  _builtIn = true;
   get config(): OperatorConfig {
     return new OperatorConfig({
       name: "set_selected_samples",
@@ -445,6 +463,7 @@ class SetSelectedSamples extends Operator {
 }
 
 class SetView extends Operator {
+  _builtIn = true;
   get config(): OperatorConfig {
     return new OperatorConfig({
       name: "set_view",
@@ -473,6 +492,7 @@ class SetView extends Operator {
 const SHOW_SAMPLES_STAGE_ID = "show_samples_stage_id";
 
 class ShowSamples extends Operator {
+  _builtIn = true;
   get config(): OperatorConfig {
     return new OperatorConfig({
       name: "show_samples",
@@ -538,6 +558,7 @@ class ShowSamples extends Operator {
 // }
 
 class ConsoleLog extends Operator {
+  _builtIn = true;
   get config(): OperatorConfig {
     return new OperatorConfig({
       name: "console_log",
@@ -559,6 +580,7 @@ class ConsoleLog extends Operator {
 }
 
 class ShowOutput extends Operator {
+  _builtIn = true;
   get config(): OperatorConfig {
     return new OperatorConfig({
       name: "show_output",
@@ -593,6 +615,7 @@ class ShowOutput extends Operator {
 }
 
 class TestOperator extends Operator {
+  _builtIn = true;
   get config(): OperatorConfig {
     return new OperatorConfig({
       name: "test_operator",

--- a/app/packages/operators/src/operators.ts
+++ b/app/packages/operators/src/operators.ts
@@ -109,6 +109,9 @@ export type OperatorConfigOptions = {
   onStartup?: boolean;
   canExecute?: boolean;
   disableSchemaValidation?: boolean;
+  icon?: string;
+  darkIcon?: string;
+  lightIcon?: string;
 };
 export class OperatorConfig {
   public name: string;
@@ -120,6 +123,9 @@ export class OperatorConfig {
   public onStartup: boolean;
   public canExecute = true;
   public disableSchemaValidation = false;
+  public icon = null;
+  public darkIcon = null;
+  public lightIcon = null;
   constructor(options: OperatorConfigOptions) {
     this.name = options.name;
     this.label = options.label || options.name;
@@ -131,6 +137,9 @@ export class OperatorConfig {
     this.canExecute = options.canExecute === false ? false : true;
     this.disableSchemaValidation =
       options.disableSchemaValidation === true ? true : false;
+    this.icon = options.icon;
+    this.darkIcon = options.darkIcon;
+    this.lightIcon = options.lightIcon;
   }
   static fromJSON(json) {
     return new OperatorConfig({
@@ -143,6 +152,9 @@ export class OperatorConfig {
       onStartup: json.on_startup,
       canExecute: json.can_execute,
       disableSchemaValidation: json.disable_schema_validation,
+      icon: json.icon,
+      darkIcon: json.dark_icon,
+      lightIcon: json.light_icon,
     });
   }
 }

--- a/app/packages/operators/src/state.ts
+++ b/app/packages/operators/src/state.ts
@@ -367,9 +367,14 @@ export const availableOperators = selector({
         label: operator.label,
         name: operator.name,
         value: operator.uri,
-        description: operator.description,
+        description: operator.config.description,
         unlisted: operator.unlisted,
         canExecute: operator.config.canExecute,
+        pluginName: operator.pluginName,
+        _builtIn: operator._builtIn,
+        icon: operator.config.icon,
+        darkIcon: operator.config.darkIcon,
+        lightIcon: operator.config.lightIcon,
       };
     });
   },

--- a/fiftyone/operators/operator.py
+++ b/fiftyone/operators/operator.py
@@ -39,6 +39,9 @@ class OperatorConfig(object):
         unlisted=False,
         on_startup=False,
         disable_schema_validation=False,
+        icon=None,
+        light_icon=None,
+        dark_icon=None,
     ):
         self.name = name
         self.label = label or name
@@ -48,6 +51,9 @@ class OperatorConfig(object):
         self.unlisted = unlisted
         self.on_startup = on_startup
         self.disable_schema_validation = disable_schema_validation
+        self.icon = icon
+        self.dark_icon = dark_icon
+        self.light_icon = light_icon
 
     def to_json(self):
         return {
@@ -59,6 +65,9 @@ class OperatorConfig(object):
             "dynamic": self.dynamic,
             "on_startup": self.on_startup,
             "disable_schema_validation": self.disable_schema_validation,
+            "icon": self.icon,
+            "dark_icon": self.dark_icon,
+            "light_icon": self.light_icon,
         }
 
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

Add support for custom operator icon

### Preview:
![image](https://github.com/voxel51/fiftyone/assets/25350704/b71a25e2-016e-4e0c-91c1-9e0d6e109395)

### Usage:

**Python:**
```py
class MyPyOperator(foo.Operator):
    @property
    def config(self):
        return foo.OperatorConfig(
            name="my_py_operator",
            label="My Python Operator",
            icon='/assets/icon.svg', # icon to use when dark_icon or light_icon is not provided
            dark_icon='/assets/dark_icon.svg', # icon to use for when app is in the dark mode
            light_icon='/assets/light_icon.svg', # icon to use for when app is in the light mode
        )
    # ...rest of operator implementation
```
**JavaScript**
```js
class MyJSOperator extends Operator {
  get config() {
    return new OperatorConfig({
      name: 'my_js_operator',
      label: 'My JavaScript Operator',
      icon: '/assets/icon.svg', // icon to use when dark_icon or light_icon is not provided
      darkIcon:'/assets/dark_icon.svg', // icon to use for when app is in the dark mode
      lightIcon:'/assets/light_icon.svg', // icon to use for when app is in the light mode
    })
  }
  // ...rest of operator implementation
```

## How is this patch tested? If it is not, please explain why.

(Details)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
