### PR TITLE
Fix state updates from `Session`

### DIFF
--- a/fiftyone/core/session/client.py
+++ b/fiftyone/core/session/client.py
@@ -123,6 +123,7 @@ class Client:
                 time.sleep(10)
 
         self._thread = Thread(target=run_client, daemon=True)
+        self._closed.clear()
         self._thread.start()
 
     def close(self):


### PR DESCRIPTION
In `0.21.3` a bug was introduced that prevents event emission due to changes in `Session.close()` (#3253 )

```py
import fiftyone as fo

dataset, session = fo.quickstart()

# In 0.21.3, this update will not be sent to the App
session.view = dataset.limit(1)
```