### PR TITLE
Improved robustness of concurrent schema updates

### DIFF
--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -3370,9 +3370,9 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
 
         path, is_frame_field = self._handle_frame_field(field.path)
         if is_frame_field:
-            field_doc = self._frame_doc_cls._get_field_doc(path)
+            field_doc = self._frame_doc_cls._get_field_doc(path, reload=True)
         else:
-            field_doc = self._sample_doc_cls._get_field_doc(path)
+            field_doc = self._sample_doc_cls._get_field_doc(path, reload=True)
 
         field_doc.description = field.description
         field_doc.info = field.info

--- a/fiftyone/core/odm/document.py
+++ b/fiftyone/core/odm/document.py
@@ -583,6 +583,14 @@ class Document(BaseDocument, mongoengine.Document):
     def _doc_name(cls):
         return "Document"
 
+    def reload(self, *fields, **kwargs):
+        """Reloads the document from the database.
+
+        Args:
+            *fields: an optional args list of specific fields to reload
+        """
+        super().reload(*fields, **kwargs)
+
     def save(
         self,
         upsert=False,

--- a/fiftyone/core/odm/mixins.py
+++ b/fiftyone/core/odm/mixins.py
@@ -250,7 +250,7 @@ class DatasetMixin(object):
 
         # This fixes https://github.com/voxel51/fiftyone/issues/3185
         # @todo improve list field updates in general so this isn't necessary
-        dataset_doc.reload(cls._fields_attr())
+        cls._reload_fields()
 
         for path, field in new_schema.items():
             # Special syntax for declaring the subfield of a ListField
@@ -472,7 +472,7 @@ class DatasetMixin(object):
         # This fixes https://github.com/voxel51/fiftyone/issues/3185
         # @todo improve list field updates in general so this isn't necessary
         if schema_paths:
-            dataset_doc.reload(cls._fields_attr())
+            cls._reload_fields()
 
         if simple_paths:
             _paths, _new_paths = zip(*simple_paths)
@@ -557,7 +557,7 @@ class DatasetMixin(object):
         # This fixes https://github.com/voxel51/fiftyone/issues/3185
         # @todo improve list field updates in general so this isn't necessary
         if schema_paths:
-            dataset_doc.reload(cls._fields_attr())
+            cls._reload_fields()
 
         if simple_paths:
             _paths, _new_paths = zip(*simple_paths)
@@ -687,7 +687,7 @@ class DatasetMixin(object):
         # This fixes https://github.com/voxel51/fiftyone/issues/3185
         # @todo improve list field updates in general so this isn't necessary
         if del_schema_paths:
-            dataset_doc.reload(cls._fields_attr())
+            cls._reload_fields()
 
         cls._delete_fields_simple(del_paths)
 
@@ -761,7 +761,7 @@ class DatasetMixin(object):
 
         # This fixes https://github.com/voxel51/fiftyone/issues/3185
         # @todo improve list field updates in general so this isn't necessary
-        dataset_doc.reload(cls._fields_attr())
+        cls._reload_fields()
 
         for del_path in del_paths:
             cls._delete_field_schema(del_path)
@@ -1119,6 +1119,11 @@ class DatasetMixin(object):
         _delete_field_doc(field_docs, field_name)
 
     @classmethod
+    def _reload_fields(cls):
+        dataset_doc = cls._dataset._doc
+        dataset_doc.reload(cls._fields_attr())
+
+    @classmethod
     def _get_field(cls, path, allow_missing=False, check_default=False):
         chunks = path.split(".")
         field_name = chunks[-1]
@@ -1147,7 +1152,12 @@ class DatasetMixin(object):
         return field, is_default
 
     @classmethod
-    def _get_field_doc(cls, path, allow_missing=False):
+    def _get_field_doc(cls, path, allow_missing=False, reload=True):
+        # This fixes https://github.com/voxel51/fiftyone/issues/3185
+        # @todo improve list field updates in general so this isn't necessary
+        if reload:
+            cls._reload_fields()
+
         chunks = path.split(".")
         field_docs = cls._dataset._doc[cls._fields_attr()]
 

--- a/fiftyone/core/odm/mixins.py
+++ b/fiftyone/core/odm/mixins.py
@@ -1152,7 +1152,7 @@ class DatasetMixin(object):
         return field, is_default
 
     @classmethod
-    def _get_field_doc(cls, path, allow_missing=False, reload=True):
+    def _get_field_doc(cls, path, allow_missing=False, reload=False):
         # This fixes https://github.com/voxel51/fiftyone/issues/3185
         # @todo improve list field updates in general so this isn't necessary
         if reload:

--- a/fiftyone/core/odm/mixins.py
+++ b/fiftyone/core/odm/mixins.py
@@ -224,6 +224,9 @@ class DatasetMixin(object):
                 existing field of the same name or a new field is found but
                 ``expand_schema == False``
         """
+        dataset = cls._dataset
+        dataset_doc = dataset._doc
+
         new_schema = {}
 
         for path, field in schema.items():
@@ -245,6 +248,10 @@ class DatasetMixin(object):
         if not new_schema:
             return False
 
+        # This fixes https://github.com/voxel51/fiftyone/issues/3185
+        # @todo improve list field updates in general so this isn't necessary
+        dataset_doc.reload(cls._fields_attr())
+
         for path, field in new_schema.items():
             # Special syntax for declaring the subfield of a ListField
             if path.endswith("[]"):
@@ -253,7 +260,7 @@ class DatasetMixin(object):
 
             cls._add_field_schema(path, field)
 
-        cls._dataset.save()
+        dataset_doc.save()
 
         return True
 
@@ -462,6 +469,11 @@ class DatasetMixin(object):
             if field is not None:
                 schema_paths.append((path, new_path))
 
+        # This fixes https://github.com/voxel51/fiftyone/issues/3185
+        # @todo improve list field updates in general so this isn't necessary
+        if schema_paths:
+            dataset_doc.reload(cls._fields_attr())
+
         if simple_paths:
             _paths, _new_paths = zip(*simple_paths)
             cls._rename_fields_simple(_paths, _new_paths)
@@ -483,7 +495,7 @@ class DatasetMixin(object):
             new_paths = [dataset._FRAMES_PREFIX + p for p in new_paths]
 
         dataset_doc.app_config._rename_paths(paths, new_paths)
-        dataset.save()
+        dataset_doc.save()
 
     @classmethod
     def _clone_fields(cls, sample_collection, paths, new_paths):
@@ -542,6 +554,11 @@ class DatasetMixin(object):
             if field is not None:
                 schema_paths.append((path, new_path))
 
+        # This fixes https://github.com/voxel51/fiftyone/issues/3185
+        # @todo improve list field updates in general so this isn't necessary
+        if schema_paths:
+            dataset_doc.reload(cls._fields_attr())
+
         if simple_paths:
             _paths, _new_paths = zip(*simple_paths)
             cls._clone_fields_simple(_paths, _new_paths)
@@ -553,7 +570,7 @@ class DatasetMixin(object):
         for path, new_path in schema_paths:
             cls._clone_field_schema(path, new_path)
 
-        dataset.save()
+        dataset_doc.save()
 
     @classmethod
     def _clear_fields(cls, sample_collection, paths):
@@ -664,18 +681,24 @@ class DatasetMixin(object):
             del_paths.append(path)
             del_schema_paths.append(path)
 
-        if del_paths:
-            cls._delete_fields_simple(del_paths)
+        if not del_paths:
+            return
+
+        # This fixes https://github.com/voxel51/fiftyone/issues/3185
+        # @todo improve list field updates in general so this isn't necessary
+        if del_schema_paths:
+            dataset_doc.reload(cls._fields_attr())
+
+        cls._delete_fields_simple(del_paths)
 
         for del_path in del_schema_paths:
             cls._delete_field_schema(del_path)
 
-        if del_paths:
-            if is_frame_field:
-                del_paths = [dataset._FRAMES_PREFIX + p for p in del_paths]
+        if is_frame_field:
+            del_paths = [dataset._FRAMES_PREFIX + p for p in del_paths]
 
-            dataset_doc.app_config._delete_paths(del_paths)
-            dataset.save()
+        dataset_doc.app_config._delete_paths(del_paths)
+        dataset_doc.save()
 
     @classmethod
     def _remove_dynamic_fields(cls, paths, error_level=0):
@@ -691,6 +714,9 @@ class DatasetMixin(object):
             -   1: log warning if a field cannot be removed
             -   2: ignore fields that cannot be removed
         """
+        dataset = cls._dataset
+        dataset_doc = dataset._doc
+
         del_paths = []
 
         for path in paths:
@@ -730,16 +756,21 @@ class DatasetMixin(object):
 
             del_paths.append(path)
 
+        if not del_paths:
+            return
+
+        # This fixes https://github.com/voxel51/fiftyone/issues/3185
+        # @todo improve list field updates in general so this isn't necessary
+        dataset_doc.reload(cls._fields_attr())
+
         for del_path in del_paths:
             cls._delete_field_schema(del_path)
 
-        if del_paths:
-            dataset = cls._dataset
-            if cls._is_frames_doc:
-                del_paths = [dataset._FRAMES_PREFIX + p for p in del_paths]
+        if cls._is_frames_doc:
+            del_paths = [dataset._FRAMES_PREFIX + p for p in del_paths]
 
-            dataset._doc.app_config._delete_paths(del_paths)
-            dataset.save()
+        dataset_doc.app_config._delete_paths(del_paths)
+        dataset_doc.save()
 
     @classmethod
     def _rename_fields_simple(cls, paths, new_paths):


### PR DESCRIPTION
Resolves https://github.com/voxel51/fiftyone/issues/3185

As explained in the `@todo`, this is a bit of a hack to specifically avoid issues when concurrently modifying a dataset's schema. However, the underlying problem still exists whenever list fields other than `DatasetDocument.sample_fields` and `DatasetDocument.frame_fields` are concurrently edited without first reloading.

I think it makes sense to go ahead and merge this particular patch because schema updates are by far the most likely case where concurrent list edits may arise, since in many workflows `dataset` objects may be held in-memory for long periods of time without reloading them. Unlike samples, which are generally only loaded + modified on-demand.