### PR TITLE
Support to custom color by ListField with boolean, string, and int subfields 

### DIFF
--- a/app/packages/core/src/components/ColorModal/FieldSetting.tsx
+++ b/app/packages/core/src/components/ColorModal/FieldSetting.tsx
@@ -5,6 +5,7 @@ import {
   FLOAT_FIELD,
   Field,
   INT_FIELD,
+  LIST_FIELD,
   NOT_VISIBLE_LIST,
   STRING_FIELD,
   VALID_MASK_TYPES,
@@ -79,9 +80,11 @@ const FieldSetting: React.FC<Prop> = ({ prop }) => {
   const colorFields = useRecoilValue(
     fos.fields({
       path: commonExpandedPath,
-      ftype: VALID_COLOR_ATTRIBUTE_TYPES,
+      ftype: [...VALID_COLOR_ATTRIBUTE_TYPES, LIST_FIELD],
     })
-  ).filter((field) => field.dbField !== "tags");
+  ).filter((field) =>
+    [...VALID_COLOR_ATTRIBUTE_TYPES, null].includes(field.subfield)
+  );
 
   const onChangeFieldColor = useCallback(
     (color) => {

--- a/app/packages/looker-3d/src/Looker3d.tsx
+++ b/app/packages/looker-3d/src/Looker3d.tsx
@@ -391,12 +391,22 @@ export const Looker3d = () => {
             }
           }
           if (coloring.by === "value") {
-            const key =
-              setting.colorByAttribute === "index"
-                ? l._id
-                : setting.colorByAttribute === "label"
-                ? l.label
-                : l.attributes[setting.colorByAttribute] ?? l.label;
+            let key;
+            if (setting?.colorByAttribute) {
+              if (setting.colorByAttribute === "index") {
+                key = l._id;
+              } else if (setting.colorByAttribute === "label") {
+                key = l.label;
+              } else if (l.attributes[setting.colorByAttribute]) {
+                key = l.attributes[setting.colorByAttribute];
+              } else {
+                key = l.label;
+              }
+            } else {
+              // fallback to label if colorByAttribute is not set
+              key = l.label;
+            }
+
             if (
               setting &&
               setting.valueColors &&
@@ -418,7 +428,7 @@ export const Looker3d = () => {
           return { ...l, color, id: l._id };
         })
         .filter((l) => pathFilter(l.path.join("."), l)),
-    [coloring, getColor, pathFilter, sampleMap, selectedLabels]
+    [coloring, getColor, pathFilter, sampleMap, selectedLabels, colorScheme]
   );
 
   const [cuboidOverlays, polylineOverlays] = useMemo(() => {

--- a/app/packages/looker/src/elements/common/tags.ts
+++ b/app/packages/looker/src/elements/common/tags.ts
@@ -30,6 +30,7 @@ import { BaseState, CustomizeColor, NONFINITE, Sample } from "../../state";
 import { BaseElement } from "../base";
 import { lookerTags } from "./tags.module.css";
 import { getAssignedColor, prettify } from "./util";
+import { isValidColor } from "../../overlays/util";
 
 interface TagData {
   color: string;
@@ -110,6 +111,7 @@ export class TagsElement<State extends BaseState> extends BaseElement<State> {
             path,
             value,
             customizeColorSetting,
+            isValidColor,
           }),
         };
       },
@@ -124,6 +126,7 @@ export class TagsElement<State extends BaseState> extends BaseElement<State> {
             path,
             value: v,
             customizeColorSetting,
+            isValidColor,
           }),
         };
       },
@@ -139,6 +142,7 @@ export class TagsElement<State extends BaseState> extends BaseElement<State> {
             path,
             value: v,
             customizeColorSetting,
+            isValidColor,
           }),
         };
       },
@@ -154,6 +158,7 @@ export class TagsElement<State extends BaseState> extends BaseElement<State> {
             path,
             value: v,
             customizeColorSetting,
+            isValidColor,
           }),
         };
       },
@@ -168,6 +173,7 @@ export class TagsElement<State extends BaseState> extends BaseElement<State> {
             path,
             value: v,
             customizeColorSetting,
+            isValidColor,
           }),
         };
       },
@@ -183,6 +189,7 @@ export class TagsElement<State extends BaseState> extends BaseElement<State> {
             path,
             value: v,
             customizeColorSetting,
+            isValidColor,
           }),
         };
       },
@@ -197,6 +204,7 @@ export class TagsElement<State extends BaseState> extends BaseElement<State> {
             path,
             value: v,
             customizeColorSetting,
+            isValidColor,
           }),
         };
       },
@@ -210,6 +218,7 @@ export class TagsElement<State extends BaseState> extends BaseElement<State> {
             path,
             value,
             customizeColorSetting,
+            isValidColor,
           }),
         };
       },
@@ -229,6 +238,7 @@ export class TagsElement<State extends BaseState> extends BaseElement<State> {
             path,
             value: v,
             customizeColorSetting,
+            isValidColor,
           }),
         };
       },
@@ -247,6 +257,7 @@ export class TagsElement<State extends BaseState> extends BaseElement<State> {
           path,
           param,
           customizeColorSetting,
+          isValidColor,
         }),
       };
     };
@@ -266,6 +277,7 @@ export class TagsElement<State extends BaseState> extends BaseElement<State> {
             param,
             customizeColorSetting,
             fallbackLabel: "value",
+            isValidColor,
           }),
         };
       },
@@ -284,6 +296,7 @@ export class TagsElement<State extends BaseState> extends BaseElement<State> {
                 param: tag,
                 customizeColorSetting,
                 fallbackLabel: "value",
+                isValidColor,
               }),
               title: tag,
               value: tag,

--- a/app/packages/looker/src/elements/common/tags.ts
+++ b/app/packages/looker/src/elements/common/tags.ts
@@ -100,7 +100,13 @@ export class TagsElement<State extends BaseState> extends BaseElement<State> {
 
     const PRIMITIVE_RENDERERS = {
       [BOOLEAN_FIELD]: (path, value: boolean) => {
-        const v = value ? "True" : "False";
+        let v;
+        if (Array.isArray(value)) {
+          v = value.map((v) => (v ? "True" : "False")).join(", ");
+        } else {
+          v = value ? "True" : "False";
+        }
+
         return {
           path,
           value: v,
@@ -214,14 +220,20 @@ export class TagsElement<State extends BaseState> extends BaseElement<State> {
         };
       },
       [STRING_FIELD]: (path, value: string) => {
+        let v;
+        if (Array.isArray(value)) {
+          v = value.join(", ");
+        } else {
+          v = value;
+        }
         return {
           path,
-          value,
-          title: `${path}: ${value}`,
+          value: v,
+          title: `${path}: ${v}`,
           color: getColorFromOptionsPrimitives({
             coloring,
             path,
-            value,
+            value: v,
             customizeColorSetting,
           }),
         };
@@ -418,16 +430,21 @@ const prettyNumber = (value: number | NONFINITE): string => {
   if (typeof value === "string") {
     return value;
   }
-
   let string = null;
-  if (value % 1 === 0) {
-    string = value.toFixed(0);
-  } else if (value < 0.001) {
-    string = value.toFixed(6);
+
+  if (Array.isArray(value)) {
+    string = value.map((v) => prettyNumber(v)).join(", ");
+    return string;
   } else {
-    string = value.toFixed(3);
+    if (value % 1 === 0) {
+      string = value.toFixed(0);
+    } else if (value < 0.001) {
+      string = value.toFixed(6);
+    } else {
+      string = value.toFixed(3);
+    }
+    return Number(string).toLocaleString();
   }
-  return Number(string).toLocaleString();
 };
 
 const unwind = (

--- a/app/packages/looker/src/elements/common/tags.ts
+++ b/app/packages/looker/src/elements/common/tags.ts
@@ -29,13 +29,7 @@ import { Classification, Regression } from "../../overlays/classifications";
 import { BaseState, CustomizeColor, NONFINITE, Sample } from "../../state";
 import { BaseElement } from "../base";
 import { lookerTags } from "./tags.module.css";
-import {
-  getColorFromOptions,
-  getColorFromOptionsPrimitives,
-  prettify,
-} from "./util";
-
-import _ from "lodash";
+import { getAssignedColor, prettify } from "./util";
 
 interface TagData {
   color: string;
@@ -111,7 +105,7 @@ export class TagsElement<State extends BaseState> extends BaseElement<State> {
           path,
           value: v,
           title: `${path}: ${v}`,
-          color: getColorFromOptionsPrimitives({
+          color: getAssignedColor({
             coloring,
             path,
             value,
@@ -125,7 +119,7 @@ export class TagsElement<State extends BaseState> extends BaseElement<State> {
           path,
           value: v,
           title: `${path}: ${v}`,
-          color: getColorFromOptionsPrimitives({
+          color: getAssignedColor({
             coloring,
             path,
             value: v,
@@ -140,7 +134,7 @@ export class TagsElement<State extends BaseState> extends BaseElement<State> {
           path,
           value: v,
           title: `${path}: ${v}`,
-          color: getColorFromOptionsPrimitives({
+          color: getAssignedColor({
             coloring,
             path,
             value: v,
@@ -155,7 +149,7 @@ export class TagsElement<State extends BaseState> extends BaseElement<State> {
           path,
           value: v,
           title: `${path}: ${v}`,
-          color: getColorFromOptionsPrimitives({
+          color: getAssignedColor({
             coloring,
             path,
             value: v,
@@ -169,7 +163,7 @@ export class TagsElement<State extends BaseState> extends BaseElement<State> {
           path,
           value: v,
           title: `${path}: ${value}`,
-          color: getColorFromOptionsPrimitives({
+          color: getAssignedColor({
             coloring,
             path,
             value: v,
@@ -184,7 +178,7 @@ export class TagsElement<State extends BaseState> extends BaseElement<State> {
           path,
           value: v,
           title: `${path}: ${v}`,
-          color: getColorFromOptionsPrimitives({
+          color: getAssignedColor({
             coloring,
             path,
             value: v,
@@ -198,7 +192,7 @@ export class TagsElement<State extends BaseState> extends BaseElement<State> {
           path,
           value: v,
           title: `${path}: ${v}`,
-          color: getColorFromOptionsPrimitives({
+          color: getAssignedColor({
             coloring,
             path,
             value: v,
@@ -211,7 +205,7 @@ export class TagsElement<State extends BaseState> extends BaseElement<State> {
           path,
           value,
           title: `${path}: ${value}`,
-          color: getColorFromOptionsPrimitives({
+          color: getAssignedColor({
             coloring,
             path,
             value,
@@ -230,7 +224,7 @@ export class TagsElement<State extends BaseState> extends BaseElement<State> {
           path,
           value: v,
           title: `${path}: ${v}`,
-          color: getColorFromOptionsPrimitives({
+          color: getAssignedColor({
             coloring,
             path,
             value: v,
@@ -248,12 +242,11 @@ export class TagsElement<State extends BaseState> extends BaseElement<State> {
         path,
         value: param.label,
         title: `${path}: ${param.label}`,
-        color: getColorFromOptions({
+        color: getAssignedColor({
           coloring,
           path,
           param,
           customizeColorSetting,
-          labelDefault: true,
         }),
       };
     };
@@ -267,12 +260,12 @@ export class TagsElement<State extends BaseState> extends BaseElement<State> {
           path,
           value: v,
           title: `${path}: ${v}`,
-          color: getColorFromOptions({
+          color: getAssignedColor({
             coloring,
             path,
             param,
             customizeColorSetting,
-            labelDefault: false,
+            fallbackLabel: "value",
           }),
         };
       },
@@ -283,21 +276,19 @@ export class TagsElement<State extends BaseState> extends BaseElement<State> {
       if (path === "tags") {
         if (Array.isArray(sample.tags)) {
           sample.tags.forEach((tag) => {
-            if (filter(path, tag)) {
-              const v = coloring.by === "value" ? tag : "tags";
-              elements.push({
-                color: getColorFromOptions({
-                  coloring,
-                  path,
-                  param: tag,
-                  customizeColorSetting,
-                  labelDefault: false,
-                }),
-                title: tag,
-                value: tag,
-                path: v,
-              });
-            }
+            const v = coloring.by === "value" ? tag : "tags";
+            elements.push({
+              color: getAssignedColor({
+                coloring,
+                path,
+                param: tag,
+                customizeColorSetting,
+                fallbackLabel: "value",
+              }),
+              title: tag,
+              value: tag,
+              path: v,
+            });
           });
         }
       } else if (path === "_label_tags") {

--- a/app/packages/looker/src/elements/common/tags.ts
+++ b/app/packages/looker/src/elements/common/tags.ts
@@ -31,6 +31,7 @@ import { BaseElement } from "../base";
 import { lookerTags } from "./tags.module.css";
 import { getAssignedColor, prettify } from "./util";
 import { isValidColor } from "../../overlays/util";
+import _ from "lodash";
 
 interface TagData {
   color: string;

--- a/app/packages/looker/src/elements/common/util.test.ts
+++ b/app/packages/looker/src/elements/common/util.test.ts
@@ -55,101 +55,25 @@ describe("EmbeddedDocumentField and tags bubbles get correct color", () => {
     "ground_truth"
   );
 
-  const sampleSetting1 = [];
-  const sampleSetting2 = [
+  const emptySetting = [];
+  const emptySettingWithPath = [
     {
       path: "ground_truth",
-    },
-  ];
-  const sampleSetting5 = [
-    {
-      path: "ground_truth",
-      fieldColor: color1,
-      colorByAttribute: "label",
-      valueColors: [
-        {
-          value: "telephone",
-          color: color2,
-        },
-      ],
-    },
-  ];
-  const sampleSetting8 = [
-    {
-      path: "ground_truth",
-      colorByAttribute: "tags",
-      valueColors: [
-        {
-          value: "non-worm",
-          color: color3,
-        },
-      ],
     },
   ];
 
   it("Color by field mode, color can get resolved correctly in field mode with proper fallback", () => {
-    const sampleSetting3 = [
+    const sampleSettingNullFieldColor = [
       {
         path: "ground_truth",
         fieldColor: null,
       },
     ];
-
-    // when there is setting of selected path, use the field level color setting
-    expect(
-      getAssignedColor({
-        ...sampleInput1,
-        customizeColorSetting: sampleSetting5,
-        isValidColor: isValidColorMock,
-      })
-    ).toBe(color1);
-
-    // Edge cases: fallback to default color
-    expect(
-      getAssignedColor({
-        ...sampleInput1,
-        customizeColorSetting: sampleSetting1,
-        isValidColor: isValidColorMock,
-      })
-    ).toBe(defaultColor);
-    expect(
-      getAssignedColor({
-        ...sampleInput1,
-        customizeColorSetting: sampleSetting2,
-        isValidColor: isValidColorMock,
-      })
-    ).toBe(defaultColor);
-    expect(
-      getAssignedColor({
-        ...sampleInput1,
-        customizeColorSetting: sampleSetting3,
-        isValidColor: isValidColorMock,
-      })
-    ).toBe(defaultColor);
-  });
-
-  it("Color by value mode, when set properly, assigned color gets resolved correctly", () => {
-    // Classification:
-    expect(
-      getAssignedColor({
-        ...sampleInput2,
-        customizeColorSetting: sampleSetting5,
-        isValidColor: isValidColorMock,
-      })
-    ).toBe(color2);
-    expect(
-      getAssignedColor({
-        ...sampleInput2,
-        customizeColorSetting: sampleSetting8,
-        isValidColor: isValidColorMock,
-      })
-    ).toBe(color3);
-  });
-
-  it("Color by value mode, when colorByAttribute is null or not valid, use 'label' as default attribute", () => {
-    const sampleSetting6 = [
+    const sampleSettingClassificationDefaultAttribute = [
       {
         path: "ground_truth",
+        fieldColor: color1,
+        colorByAttribute: "label",
         valueColors: [
           {
             value: "telephone",
@@ -158,7 +82,85 @@ describe("EmbeddedDocumentField and tags bubbles get correct color", () => {
         ],
       },
     ];
-    const sampleSetting7 = [
+
+    // when there is setting of selected path, use the field level color setting
+    expect(
+      getAssignedColor({
+        ...sampleInput1,
+        customizeColorSetting: sampleSettingClassificationDefaultAttribute,
+        isValidColor: isValidColorMock,
+      })
+    ).toBe(color1);
+
+    // Edge cases: fallback to default color
+    expect(
+      getAssignedColor({
+        ...sampleInput1,
+        customizeColorSetting: emptySetting,
+        isValidColor: isValidColorMock,
+      })
+    ).toBe(defaultColor);
+    expect(
+      getAssignedColor({
+        ...sampleInput1,
+        customizeColorSetting: emptySettingWithPath,
+        isValidColor: isValidColorMock,
+      })
+    ).toBe(defaultColor);
+    expect(
+      getAssignedColor({
+        ...sampleInput1,
+        customizeColorSetting: sampleSettingNullFieldColor,
+        isValidColor: isValidColorMock,
+      })
+    ).toBe(defaultColor);
+  });
+
+  it("Color by value mode, when set properly, assigned color gets resolved correctly", () => {
+    // Classification:
+    const sampleSettingClassificationDefaultAttribute = [
+      {
+        path: "ground_truth",
+        fieldColor: color1,
+        colorByAttribute: "label",
+        valueColors: [
+          {
+            value: "telephone",
+            color: color2,
+          },
+        ],
+      },
+    ];
+    const sampleSettingClassificationTagAsAttribute = [
+      {
+        path: "ground_truth",
+        colorByAttribute: "tags",
+        valueColors: [
+          {
+            value: "non-worm",
+            color: color3,
+          },
+        ],
+      },
+    ];
+    expect(
+      getAssignedColor({
+        ...sampleInput2,
+        customizeColorSetting: sampleSettingClassificationDefaultAttribute,
+        isValidColor: isValidColorMock,
+      })
+    ).toBe(color2);
+    expect(
+      getAssignedColor({
+        ...sampleInput2,
+        customizeColorSetting: sampleSettingClassificationTagAsAttribute,
+        isValidColor: isValidColorMock,
+      })
+    ).toBe(color3);
+  });
+
+  it("Color by value mode, when colorByAttribute is null or not valid, use 'label' as default attribute", () => {
+    const sampleSettingInvaidAttribute = [
       {
         path: "ground_truth",
         colorByAttribute: "ramdomString",
@@ -170,7 +172,7 @@ describe("EmbeddedDocumentField and tags bubbles get correct color", () => {
         ],
       },
     ];
-    const sampleSetting9 = [
+    const sampleSettingNullAttribute = [
       {
         path: "ground_truth",
         colorByAttribute: null,
@@ -182,7 +184,7 @@ describe("EmbeddedDocumentField and tags bubbles get correct color", () => {
         ],
       },
     ];
-    const sampleSetting10 = [
+    const sampleSettingNoAttribute = [
       {
         path: "ground_truth",
         valueColors: [
@@ -197,42 +199,36 @@ describe("EmbeddedDocumentField and tags bubbles get correct color", () => {
     expect(
       getAssignedColor({
         ...sampleInput2,
-        customizeColorSetting: sampleSetting6,
+        customizeColorSetting: sampleSettingInvaidAttribute,
         isValidColor: isValidColorMock,
       })
     ).toBe(color2);
     expect(
       getAssignedColor({
         ...sampleInput2,
-        customizeColorSetting: sampleSetting7,
+        customizeColorSetting: sampleSettingNullAttribute,
         isValidColor: isValidColorMock,
       })
     ).toBe(color2);
     expect(
       getAssignedColor({
         ...sampleInput2,
-        customizeColorSetting: sampleSetting9,
-        isValidColor: isValidColorMock,
-      })
-    ).toBe(color2);
-    expect(
-      getAssignedColor({
-        ...sampleInput2,
-        customizeColorSetting: sampleSetting10,
+        customizeColorSetting: sampleSettingNoAttribute,
         isValidColor: isValidColorMock,
       })
     ).toBe(color2);
   });
 
   it("Color by value mode, when no valid valueColors is available, fallback to default color", () => {
-    const sampleSetting12 = [
+    const sampleSettingIncomplete = [];
+    const sampleSettingEmptyValueColor = [
       {
         path: "ground_truth",
         colorByAttribute: "label",
         valueColors: [],
       },
     ];
-    const sampleSetting13 = [
+    const sampleSettingNoValueColor = [
       {
         path: "ground_truth",
         colorByAttribute: "label",
@@ -241,21 +237,21 @@ describe("EmbeddedDocumentField and tags bubbles get correct color", () => {
     expect(
       getAssignedColor({
         ...sampleInput2,
-        customizeColorSetting: sampleSetting12,
+        customizeColorSetting: sampleSettingEmptyValueColor,
         isValidColor: isValidColorMock,
       })
     ).toBe(pool2);
     expect(
       getAssignedColor({
         ...sampleInput2,
-        customizeColorSetting: sampleSetting13,
+        customizeColorSetting: sampleSettingNoValueColor,
         isValidColor: isValidColorMock,
       })
     ).toBe(pool2);
     expect(
       getAssignedColor({
         ...sampleInput2,
-        customizeColorSetting: sampleSetting1,
+        customizeColorSetting: sampleSettingIncomplete,
         isValidColor: isValidColorMock,
       })
     ).toBe("#EE6600");
@@ -264,19 +260,19 @@ describe("EmbeddedDocumentField and tags bubbles get correct color", () => {
 
 describe("Primitive fields bubbles get correct color", () => {
   const sampleValue = "apple";
-  const edgeSetting1 = [];
-  const edgeSetting2 = [
+  const emptySetting = [];
+  const emptySettingWithPath = [
     {
       path: "str_field",
     },
   ];
-  const edgeSetting3 = [
+  const emptySettingNullFieldcolor = [
     {
       path: "str_field",
       fieldColor: null,
     },
   ];
-  const edgeSetting4 = [
+  const sampleSettingNullValuecolors = [
     {
       path: "str_field",
       fieldColor: color1,
@@ -290,7 +286,7 @@ describe("Primitive fields bubbles get correct color", () => {
       path: "str_field",
       value: sampleValue,
     };
-    const sampleSetting = [
+    const validFieldColorSetting = [
       {
         path: "str_field",
         fieldColor: color1,
@@ -301,7 +297,7 @@ describe("Primitive fields bubbles get correct color", () => {
     expect(
       getAssignedColor({
         ...sampleInput,
-        customizeColorSetting: sampleSetting,
+        customizeColorSetting: validFieldColorSetting,
         isValidColor: isValidColorMock,
       })
     ).toBe(color1);
@@ -315,21 +311,21 @@ describe("Primitive fields bubbles get correct color", () => {
     expect(
       getAssignedColor({
         ...sampleInput,
-        customizeColorSetting: edgeSetting1,
+        customizeColorSetting: emptySetting,
         isValidColor: isValidColorMock,
       })
     ).toBe(defaultColor);
     expect(
       getAssignedColor({
         ...sampleInput,
-        customizeColorSetting: edgeSetting2,
+        customizeColorSetting: emptySettingWithPath,
         isValidColor: isValidColorMock,
       })
     ).toBe(defaultColor);
     expect(
       getAssignedColor({
         ...sampleInput,
-        customizeColorSetting: edgeSetting3,
+        customizeColorSetting: emptySettingNullFieldcolor,
         isValidColor: isValidColorMock,
       })
     ).toBe(defaultColor);
@@ -346,42 +342,42 @@ describe("Primitive fields bubbles get correct color", () => {
     expect(
       getAssignedColor({
         ...sampleInput,
-        customizeColorSetting: edgeSetting1,
+        customizeColorSetting: emptySetting,
         isValidColor: isValidColorMock,
       })
     ).toBe(pool2);
     expect(
       getAssignedColor({
         ...sampleInput,
-        customizeColorSetting: edgeSetting2,
+        customizeColorSetting: emptySettingWithPath,
         isValidColor: isValidColorMock,
       })
     ).toBe(pool2);
     expect(
       getAssignedColor({
         ...sampleInput,
-        customizeColorSetting: edgeSetting2,
+        customizeColorSetting: emptySettingWithPath,
         isValidColor: isValidColorMock,
       })
     ).toBe(pool2);
     expect(
       getAssignedColor({
         ...sampleInput,
-        customizeColorSetting: edgeSetting2,
+        customizeColorSetting: emptySettingWithPath,
         isValidColor: isValidColorMock,
       })
     ).toBe(pool2);
     expect(
       getAssignedColor({
         ...sampleInput,
-        customizeColorSetting: edgeSetting3,
+        customizeColorSetting: emptySettingNullFieldcolor,
         isValidColor: isValidColorMock,
       })
     ).toBe(pool2);
     expect(
       getAssignedColor({
         ...sampleInput,
-        customizeColorSetting: edgeSetting4,
+        customizeColorSetting: sampleSettingNullValuecolors,
         isValidColor: isValidColorMock,
       })
     ).toBe(pool2);
@@ -441,7 +437,7 @@ describe("Primitive fields bubbles get correct color", () => {
       path: "int_field",
       value: value1,
     };
-    const sampleSetting1 = [
+    const intValueSettingString = [
       {
         path: "int_field",
         valueColors: [
@@ -452,7 +448,7 @@ describe("Primitive fields bubbles get correct color", () => {
         ],
       },
     ];
-    const sampleSetting2 = [
+    const intValueSettingNumber = [
       {
         path: "int_field",
         valueColors: [
@@ -467,14 +463,14 @@ describe("Primitive fields bubbles get correct color", () => {
     expect(
       getAssignedColor({
         ...sampleInputInt,
-        customizeColorSetting: sampleSetting1,
+        customizeColorSetting: intValueSettingString,
         isValidColor: isValidColorMock,
       })
     ).toBe(color2);
     expect(
       getAssignedColor({
         ...sampleInputList,
-        customizeColorSetting: sampleSetting2,
+        customizeColorSetting: intValueSettingNumber,
         isValidColor: isValidColorMock,
       })
     ).toBe(color3);
@@ -493,7 +489,7 @@ describe("Primitive fields bubbles get correct color", () => {
       path: "bool_field",
       value: value2,
     };
-    const sampleSetting1 = [
+    const booleanValue = [
       {
         path: "bool_field",
         valueColors: [
@@ -512,14 +508,14 @@ describe("Primitive fields bubbles get correct color", () => {
     expect(
       getAssignedColor({
         ...sampleInputTrue,
-        customizeColorSetting: sampleSetting1,
+        customizeColorSetting: booleanValue,
         isValidColor: isValidColorMock,
       })
     ).toBe(color2);
     expect(
       getAssignedColor({
         ...sampleInputFalse,
-        customizeColorSetting: sampleSetting1,
+        customizeColorSetting: booleanValue,
         isValidColor: isValidColorMock,
       })
     ).toBe(color3);

--- a/app/packages/looker/src/elements/common/util.test.ts
+++ b/app/packages/looker/src/elements/common/util.test.ts
@@ -1,0 +1,525 @@
+import { getColor } from "@fiftyone/utilities/src/color";
+import { describe, expect, it } from "vitest";
+import { Coloring, CustomizeColor } from "../../state";
+import { getAssignedColor } from "./util";
+
+const coloringByValue = {
+  seed: 0,
+  pool: ["#EE0000", "#EE6600", "#EEBB00", "#00EE00", "#00EEBB", "#0000EE"],
+  by: "value",
+  scale: [],
+  maskTargets: {},
+  points: false,
+  targets: [],
+} as Coloring;
+
+const coloringByField = {
+  seed: 1,
+  pool: ["#EEBB00", "#00EE00", "#00EEBB", "#0000EE"],
+  by: "field",
+  scale: [],
+  maskTargets: {},
+  points: false,
+  targets: [],
+} as Coloring;
+
+const color1 = "#900000"; // assigned color for field level setting
+const color2 = "#000090"; // assigned color for attribute value level setting (label)
+const color3 = "#009000"; // assigned color for attribute value level setting (tag)
+
+const isValidColorMock = (color: string | undefined | null) => Boolean(color);
+
+describe("EmbeddedDocumentField and tags bubbles get correct color", () => {
+  const param1 = {
+    id: "1",
+    label: "telephone",
+    tags: ["non-worm", "mistake"],
+    _cls: "Classification",
+  };
+
+  const sampleInput1 = {
+    coloring: coloringByField,
+    path: "ground_truth",
+    param: param1,
+  };
+  const sampleInput2 = {
+    coloring: coloringByValue,
+    path: "ground_truth",
+    param: param1,
+  };
+  const defaultColor = getColor(
+    coloringByField.pool,
+    coloringByField.seed,
+    "ground_truth"
+  );
+
+  const sampleSetting1 = [];
+  const sampleSetting2 = [
+    {
+      path: "ground_truth",
+    },
+  ];
+  const sampleSetting5 = [
+    {
+      path: "ground_truth",
+      fieldColor: color1,
+      colorByAttribute: "label",
+      valueColors: [
+        {
+          value: "telephone",
+          color: color2,
+        },
+      ],
+    },
+  ];
+  const sampleSetting8 = [
+    {
+      path: "ground_truth",
+      colorByAttribute: "tags",
+      valueColors: [
+        {
+          value: "non-worm",
+          color: color3,
+        },
+      ],
+    },
+  ];
+
+  it("Color by field mode, color can get resolved correctly in field mode with proper fallback", () => {
+    const sampleSetting3 = [
+      {
+        path: "ground_truth",
+        fieldColor: null,
+      },
+    ];
+
+    // when there is setting of selected path, use the field level color setting
+    expect(
+      getAssignedColor({
+        ...sampleInput1,
+        customizeColorSetting: sampleSetting5,
+        isValidColor: isValidColorMock,
+      })
+    ).toBe(color1);
+
+    // Edge cases: fallback to default color
+    expect(
+      getAssignedColor({
+        ...sampleInput1,
+        customizeColorSetting: sampleSetting1,
+        isValidColor: isValidColorMock,
+      })
+    ).toBe(defaultColor);
+    expect(
+      getAssignedColor({
+        ...sampleInput1,
+        customizeColorSetting: sampleSetting2,
+        isValidColor: isValidColorMock,
+      })
+    ).toBe(defaultColor);
+    expect(
+      getAssignedColor({
+        ...sampleInput1,
+        customizeColorSetting: sampleSetting3,
+        isValidColor: isValidColorMock,
+      })
+    ).toBe(defaultColor);
+  });
+
+  it("Color by value mode, when set properly, assigned color gets resolved correctly", () => {
+    // Classification:
+    expect(
+      getAssignedColor({
+        ...sampleInput2,
+        customizeColorSetting: sampleSetting5,
+        isValidColor: isValidColorMock,
+      })
+    ).toBe(color2);
+    expect(
+      getAssignedColor({
+        ...sampleInput2,
+        customizeColorSetting: sampleSetting8,
+        isValidColor: isValidColorMock,
+      })
+    ).toBe(color3);
+  });
+
+  it("Color by value mode, when colorByAttribute is null or not valid, use 'label' as default attribute", () => {
+    const sampleSetting6 = [
+      {
+        path: "ground_truth",
+        valueColors: [
+          {
+            value: "telephone",
+            color: color2,
+          },
+        ],
+      },
+    ];
+    const sampleSetting7 = [
+      {
+        path: "ground_truth",
+        colorByAttribute: "ramdomString",
+        valueColors: [
+          {
+            value: "telephone",
+            color: color2,
+          },
+        ],
+      },
+    ];
+    const sampleSetting9 = [
+      {
+        path: "ground_truth",
+        colorByAttribute: null,
+        valueColors: [
+          {
+            value: "telephone",
+            color: color2,
+          },
+        ],
+      },
+    ];
+    const sampleSetting10 = [
+      {
+        path: "ground_truth",
+        valueColors: [
+          {
+            value: "telephone",
+            color: color2,
+          },
+        ],
+      },
+    ];
+
+    expect(
+      getAssignedColor({
+        ...sampleInput2,
+        customizeColorSetting: sampleSetting6,
+        isValidColor: isValidColorMock,
+      })
+    ).toBe(color2);
+    expect(
+      getAssignedColor({
+        ...sampleInput2,
+        customizeColorSetting: sampleSetting7,
+        isValidColor: isValidColorMock,
+      })
+    ).toBe(color2);
+    expect(
+      getAssignedColor({
+        ...sampleInput2,
+        customizeColorSetting: sampleSetting9,
+        isValidColor: isValidColorMock,
+      })
+    ).toBe(color2);
+    expect(
+      getAssignedColor({
+        ...sampleInput2,
+        customizeColorSetting: sampleSetting10,
+        isValidColor: isValidColorMock,
+      })
+    ).toBe(color2);
+  });
+
+  it("Color by value mode, when no valid valueColors is available, fallback to default color", () => {
+    const sampleSetting12 = [
+      {
+        path: "ground_truth",
+        colorByAttribute: "label",
+        valueColors: [],
+      },
+    ];
+    const sampleSetting13 = [
+      {
+        path: "ground_truth",
+        colorByAttribute: "label",
+      },
+    ];
+    expect(
+      getAssignedColor({
+        ...sampleInput2,
+        customizeColorSetting: sampleSetting12,
+        isValidColor: isValidColorMock,
+      })
+    ).toBe("#EE6600");
+    expect(
+      getAssignedColor({
+        ...sampleInput2,
+        customizeColorSetting: sampleSetting13,
+        isValidColor: isValidColorMock,
+      })
+    ).toBe("#EE6600");
+    expect(
+      getAssignedColor({
+        ...sampleInput2,
+        customizeColorSetting: sampleSetting1,
+        isValidColor: isValidColorMock,
+      })
+    ).toBe("#EEBB00");
+  });
+});
+
+describe("Primitive fields bubbles get correct color", () => {
+  const sampleValue = "apple";
+  const edgeSetting1 = [];
+  const edgeSetting2 = [
+    {
+      path: "str_field",
+    },
+  ];
+  const edgeSetting3 = [
+    {
+      path: "str_field",
+      fieldColor: null,
+    },
+  ];
+  const edgeSetting4 = [
+    {
+      path: "str_field",
+      fieldColor: color1,
+      valueColors: null,
+    },
+  ];
+
+  it("Color by field mode, color can get resolved correctly in field mode with proper fallback", () => {
+    const sampleInput = {
+      coloring: coloringByField,
+      path: "str_field",
+      value: sampleValue,
+    };
+    const sampleSetting = [
+      {
+        path: "str_field",
+        fieldColor: color1,
+      },
+    ];
+
+    // Correct case:
+    expect(
+      getAssignedColor({
+        ...sampleInput,
+        customizeColorSetting: sampleSetting,
+        isValidColor: isValidColorMock,
+      })
+    ).toBe(color1);
+
+    // Edge cases: fallback to default color of the field
+    const defaultColor = getColor(
+      coloringByField.pool,
+      coloringByField.seed,
+      "str_field"
+    );
+    expect(
+      getAssignedColor({
+        ...sampleInput,
+        customizeColorSetting: edgeSetting1,
+        isValidColor: isValidColorMock,
+      })
+    ).toBe(defaultColor);
+    expect(
+      getAssignedColor({
+        ...sampleInput,
+        customizeColorSetting: edgeSetting2,
+        isValidColor: isValidColorMock,
+      })
+    ).toBe(defaultColor);
+    expect(
+      getAssignedColor({
+        ...sampleInput,
+        customizeColorSetting: edgeSetting3,
+        isValidColor: isValidColorMock,
+      })
+    ).toBe(defaultColor);
+  });
+
+  it("Color by value mode, edge cases fallback correctly", () => {
+    const sampleInput = {
+      coloring: coloringByValue,
+      path: "str_field",
+      value: sampleValue,
+    };
+
+    // Edge cases: fallback to default color of the field
+    expect(
+      getAssignedColor({
+        ...sampleInput,
+        customizeColorSetting: edgeSetting1,
+        isValidColor: isValidColorMock,
+      })
+    ).toBe("#EE6600");
+    expect(
+      getAssignedColor({
+        ...sampleInput,
+        customizeColorSetting: edgeSetting2,
+        isValidColor: isValidColorMock,
+      })
+    ).toBe("#EE0000");
+    expect(
+      getAssignedColor({
+        ...sampleInput,
+        customizeColorSetting: edgeSetting2,
+        isValidColor: isValidColorMock,
+      })
+    ).toBe("#EE0000");
+    expect(
+      getAssignedColor({
+        ...sampleInput,
+        customizeColorSetting: edgeSetting2,
+        isValidColor: isValidColorMock,
+      })
+    ).toBe("#EE0000");
+    expect(
+      getAssignedColor({
+        ...sampleInput,
+        customizeColorSetting: edgeSetting3,
+        isValidColor: isValidColorMock,
+      })
+    ).toBe("#EE0000");
+    expect(
+      getAssignedColor({
+        ...sampleInput,
+        customizeColorSetting: edgeSetting4,
+        isValidColor: isValidColorMock,
+      })
+    ).toBe("#EE0000");
+  });
+
+  it("Color by value mode, stringField and list of stringField get assigned value color correctly", () => {
+    const value1 = "orange, pear, apple, banana";
+    const value2 = "apple";
+    const sampleInputStr = {
+      coloring: coloringByValue,
+      path: "str_field",
+      value: value1,
+    };
+    const sampleInputList = {
+      coloring: coloringByValue,
+      path: "str_field",
+      value: value2,
+    };
+    const sampleSetting = [
+      {
+        path: "str_field",
+        valueColors: [
+          {
+            value: "apple",
+            color: color2,
+          },
+        ],
+      },
+    ];
+
+    expect(
+      getAssignedColor({
+        ...sampleInputStr,
+        customizeColorSetting: sampleSetting,
+        isValidColor: isValidColorMock,
+      })
+    ).toBe(color2);
+    expect(
+      getAssignedColor({
+        ...sampleInputList,
+        customizeColorSetting: sampleSetting,
+        isValidColor: isValidColorMock,
+      })
+    ).toBe(color2);
+  });
+
+  it("Color by value mode, intField and list of intField get assigned value color correctly", () => {
+    const value1 = "3. 5, 8";
+    const value2 = "8";
+    const sampleInputInt = {
+      coloring: coloringByValue,
+      path: "int_field",
+      value: value2,
+    };
+    const sampleInputList = {
+      coloring: coloringByValue,
+      path: "int_field",
+      value: value1,
+    };
+    const sampleSetting1 = [
+      {
+        path: "int_field",
+        valueColors: [
+          {
+            value: "8",
+            color: color2,
+          },
+        ],
+      },
+    ];
+    const sampleSetting2 = [
+      {
+        path: "int_field",
+        valueColors: [
+          {
+            value: 8,
+            color: color3,
+          },
+        ],
+      },
+    ] as unknown as CustomizeColor[];
+
+    expect(
+      getAssignedColor({
+        ...sampleInputInt,
+        customizeColorSetting: sampleSetting1,
+        isValidColor: isValidColorMock,
+      })
+    ).toBe(color2);
+    expect(
+      getAssignedColor({
+        ...sampleInputList,
+        customizeColorSetting: sampleSetting2,
+        isValidColor: isValidColorMock,
+      })
+    ).toBe(color3);
+  });
+
+  it("Color by value mode, booleanField get assigned value color correctly", () => {
+    const value1 = "True";
+    const value2 = "False";
+    const sampleInputTrue = {
+      coloring: coloringByValue,
+      path: "bool_field",
+      value: value1,
+    };
+    const sampleInputFalse = {
+      coloring: coloringByValue,
+      path: "bool_field",
+      value: value2,
+    };
+    const sampleSetting1 = [
+      {
+        path: "bool_field",
+        valueColors: [
+          {
+            value: "True",
+            color: color2,
+          },
+          {
+            value: "False",
+            color: color3,
+          },
+        ],
+      },
+    ];
+
+    expect(
+      getAssignedColor({
+        ...sampleInputTrue,
+        customizeColorSetting: sampleSetting1,
+        isValidColor: isValidColorMock,
+      })
+    ).toBe(color2);
+    expect(
+      getAssignedColor({
+        ...sampleInputFalse,
+        customizeColorSetting: sampleSetting1,
+        isValidColor: isValidColorMock,
+      })
+    ).toBe(color3);
+  });
+});

--- a/app/packages/looker/src/elements/common/util.test.ts
+++ b/app/packages/looker/src/elements/common/util.test.ts
@@ -3,9 +3,11 @@ import { describe, expect, it } from "vitest";
 import { Coloring, CustomizeColor } from "../../state";
 import { getAssignedColor } from "./util";
 
+const pool1 = "#EE0000";
+const pool2 = "#EE6600";
 const coloringByValue = {
   seed: 0,
-  pool: ["#EE0000", "#EE6600", "#EEBB00", "#00EE00", "#00EEBB", "#0000EE"],
+  pool: [pool1, pool2, "#EEBB00", "#00EE00", "#00EEBB", "#0000EE"],
   by: "value",
   scale: [],
   maskTargets: {},
@@ -242,21 +244,21 @@ describe("EmbeddedDocumentField and tags bubbles get correct color", () => {
         customizeColorSetting: sampleSetting12,
         isValidColor: isValidColorMock,
       })
-    ).toBe("#EE6600");
+    ).toBe(pool2);
     expect(
       getAssignedColor({
         ...sampleInput2,
         customizeColorSetting: sampleSetting13,
         isValidColor: isValidColorMock,
       })
-    ).toBe("#EE6600");
+    ).toBe(pool2);
     expect(
       getAssignedColor({
         ...sampleInput2,
         customizeColorSetting: sampleSetting1,
         isValidColor: isValidColorMock,
       })
-    ).toBe("#EEBB00");
+    ).toBe("#EE6600");
   });
 });
 
@@ -347,42 +349,42 @@ describe("Primitive fields bubbles get correct color", () => {
         customizeColorSetting: edgeSetting1,
         isValidColor: isValidColorMock,
       })
-    ).toBe("#EE6600");
+    ).toBe(pool2);
     expect(
       getAssignedColor({
         ...sampleInput,
         customizeColorSetting: edgeSetting2,
         isValidColor: isValidColorMock,
       })
-    ).toBe("#EE0000");
+    ).toBe(pool2);
     expect(
       getAssignedColor({
         ...sampleInput,
         customizeColorSetting: edgeSetting2,
         isValidColor: isValidColorMock,
       })
-    ).toBe("#EE0000");
+    ).toBe(pool2);
     expect(
       getAssignedColor({
         ...sampleInput,
         customizeColorSetting: edgeSetting2,
         isValidColor: isValidColorMock,
       })
-    ).toBe("#EE0000");
+    ).toBe(pool2);
     expect(
       getAssignedColor({
         ...sampleInput,
         customizeColorSetting: edgeSetting3,
         isValidColor: isValidColorMock,
       })
-    ).toBe("#EE0000");
+    ).toBe(pool2);
     expect(
       getAssignedColor({
         ...sampleInput,
         customizeColorSetting: edgeSetting4,
         isValidColor: isValidColorMock,
       })
-    ).toBe("#EE0000");
+    ).toBe(pool2);
   });
 
   it("Color by value mode, stringField and list of stringField get assigned value color correctly", () => {

--- a/app/packages/looker/src/elements/common/util.ts
+++ b/app/packages/looker/src/elements/common/util.ts
@@ -163,13 +163,12 @@ function getTagColor(
   const valueColor = setting.valueColors?.find(
     (v) => v.value === (param as string)
   )?.color;
-  console.info("param", param);
 
   if (isValidColor(valueColor)) {
     return valueColor;
-  } else {
-    return getColor(pool, seed, param as string);
   }
+
+  return getColor(pool, seed, param as string);
 }
 
 function getTargetColor(
@@ -209,18 +208,17 @@ function getTargetColor(
     if (!isPrimitive) {
       if (Array.isArray(param[key])) {
         return param[key].map((el) => el.toString()).includes(stringifiedValue);
-      } else {
-        return stringifiedValue === currentValue?.toString();
       }
+      return stringifiedValue === currentValue?.toString();
     } else {
       if (typeof value === "string" && value.includes(", ")) {
         return value
           .split(", ")
           .map((el) => el.toString())
           .includes(stringifiedValue);
-      } else {
-        return stringifiedValue === value.toString();
       }
+
+      return stringifiedValue === value.toString();
     }
   })?.color;
 }
@@ -259,7 +257,7 @@ export function getAssignedColor({
     value,
     by === "value"
   );
-  debugger;
+
   if (by === "field") {
     return getColorByField(setting, pool, seed, path, isValidColor);
   }

--- a/app/packages/looker/src/overlays/base.ts
+++ b/app/packages/looker/src/overlays/base.ts
@@ -116,6 +116,10 @@ export abstract class CoordinateOverlay<
             : field.colorByAttribute
           : "label";
 
+        // use the first value as the fallback default if it's a listField
+        const currentValue = Array.isArray(this.label[key])
+          ? this.label[key][0]
+          : this.label[key];
         // check if this label has a assigned color, use it if it is a valid color
         const valueColor = field?.valueColors?.find((l) => {
           if (["none", "null", "undefined"].includes(l.value?.toLowerCase())) {
@@ -129,11 +133,15 @@ export abstract class CoordinateOverlay<
               this.label[key]?.toString().toLowerCase()
             );
           }
-          return l.value?.toString() == this.label[key]?.toString();
+          return Array.isArray(this.label[key])
+            ? this.label[key]
+                .map((list) => list.toString())
+                .includes(l.value?.toString())
+            : l.value?.toString() == this.label[key]?.toString();
         })?.color;
         return isValidColor(valueColor)
           ? valueColor
-          : getColor(coloring.pool, coloring.seed, this.label[key]);
+          : getColor(coloring.pool, coloring.seed, currentValue);
       } else {
         return getColor(coloring.pool, coloring.seed, this.label["label"]);
       }

--- a/app/packages/looker/src/overlays/util.ts
+++ b/app/packages/looker/src/overlays/util.ts
@@ -2,10 +2,10 @@
  * Copyright 2017-2023, Voxel51, Inc.
  */
 
+import colorString from "color-string";
 import { INFO_COLOR } from "../constants";
 import { BaseState, Coordinates, MaskTargets, RgbMaskTargets } from "../state";
 import { BaseLabel } from "./base";
-import colorString from "color-string";
 
 export const t = (state: BaseState, x: number, y: number): Coordinates => {
   const [ctlx, ctly, cw, ch] = state.canvasBBox;
@@ -31,7 +31,7 @@ export const sizeBytes = (label: BaseLabel) => {
         case "object":
           var objClass = Object.prototype.toString.call(obj).slice(8, -1);
           if (objClass === "Object" || objClass === "Array") {
-            for (var key in obj) {
+            for (const key in obj) {
               if (!obj.hasOwnProperty(key)) continue;
               sizer(obj[key]);
             }


### PR DESCRIPTION
Support to customize color by ListFields (both embeddedDoc type and primitive type) in color modal.

## What changes are proposed in this pull request?

Users should be allowed to configure custom Color by value rules for ListField, just like they can for other “primitive” fields like ints, strs, floats, etc.

For list fields, when a custom (value, color) pair is defined, simply apply the color if the list contains the value, rather than if the list equals the value.

Of course, the list field may contain multiple values with custom color pairs defined. No worries, any one of the colors is valid. 

Tip: If the list meets multiple color rules, looker will use the first applicable `valueColors` match in `ColorScheme` to render. 

## How is this patch tested? If it is not, please explain why.

Primitive List of StringField example: 

https://github.com/voxel51/fiftyone/assets/17770824/d4a96b8f-5293-4f54-869c-fcc7b19b4a58

Primitive List of IntField example: 

![primitive_int](https://github.com/voxel51/fiftyone/assets/17770824/38a3a9e6-a91e-48fa-bcf8-fb143e1f745e)

EmbeddedDocField List of StringField example:

Color Setting: 
![Screenshot 2023-07-19 at 11 23 19 PM](https://github.com/voxel51/fiftyone/assets/17770824/058ebe5a-c323-4214-811b-f46deaf2cbb0)

detection 1: 

![Screenshot 2023-07-19 at 11 36 01 PM](https://github.com/voxel51/fiftyone/assets/17770824/bfaaefad-7da5-4947-b1fe-fe1b4040b44d)

detection 2: 
![Screenshot 2023-07-19 at 11 36 06 PM](https://github.com/voxel51/fiftyone/assets/17770824/52724102-9d9b-401c-9a35-9945df018ad4)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
