### PR TITLE
Fixed warn condition plugin component registration

### DIFF
--- a/app/packages/plugins/src/index.ts
+++ b/app/packages/plugins/src/index.ts
@@ -318,7 +318,7 @@ class PluginComponentRegistry {
       `${name} is already a registered Plugin Component`
     );
     warn(
-      registration.type === PluginComponentType.Plot,
+      registration.type !== PluginComponentType.Plot,
       `${name} is a Plot Plugin Component. This is deprecated. Please use "Panel" instead.`
     );
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

Changed the ok-condition from equal to not equal. As `warn()` prints the message if the ok-condition is false and we want the ok-condition to be false if `registration.type` equals `PluginComponentType.Plot`.

## How is this patch tested? If it is not, please explain why.

Compiled from source and warning `_______ is a Plot Plugin Component. This is deprecated. Please use "Panel" instead.`
Is gone for plugins which are not a Plot Plugin Component.

### Is this a user-facing change that should be mentioned in the release notes?
-   [ x ] No. 

### What areas of FiftyOne does this PR affect?

-   [ x ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
