### PR TITLE
Resolve errors with Labelbox integration

### DIFF
--- a/fiftyone/utils/labelbox.py
+++ b/fiftyone/utils/labelbox.py
@@ -610,8 +610,8 @@ class LabelboxAnnotationAPI(foua.AnnotationAPI):
             metadata = self._get_sample_metadata(project, sample_id)
             if metadata is None:
                 logger.warning(
-                    "Skipping sample '%s' with no metadata, likely due to no "
-                    "with a matching Global Key being found",
+                    "Skipping sample '%s' with no metadata, likely due to not "
+                    "finding a DataRow with a matching Global Key",
                     sample_id,
                 )
                 continue


### PR DESCRIPTION
Labelbox has now fully deprecated "Queue mode" in favor of "batch mode". Previously, attempting to use the Labelbox integration would result in an error, this PR updates the integration to use batch mode and brings the integration back to its previous state.

Resolves #2654 