### PR TITLE
[WIP] Update the Labelbox integration to support uploading labels

### DIFF
--- a/fiftyone/utils/labelbox.py
+++ b/fiftyone/utils/labelbox.py
@@ -501,8 +501,13 @@ class LabelboxAnnotationAPI(foua.AnnotationAPI):
 
         upload_info = []
 
-        with fou.ProgressBar(iters_str="samples") as pb:
-            for media_path, sample_id in pb(zip(media_paths, sample_ids)):
+        data_row_id_map = self.get_data_row_ids(sample_ids)
+        existing_ids = [
+            sid for sid, drid in data_row_id_map.items() if drid != ""
+        ]
+        ids_to_upload = list(set(sample_ids) - set(existing_ids))
+        for media_path, sample_id in zip(media_paths, sample_ids):
+            if sample_id in ids_to_upload:
                 item_url = self._client.upload_file(media_path)
                 upload_info.append(
                     {
@@ -534,14 +539,6 @@ class LabelboxAnnotationAPI(foua.AnnotationAPI):
         classes_as_attrs = config.classes_as_attrs
         is_video = samples.media_type == fomm.VIDEO
 
-        for label_field, label_info in label_schema.items():
-            if label_info["existing_field"]:
-                raise ValueError(
-                    "Cannot use existing field '%s'; the Labelbox backend "
-                    "does not yet support uploading existing labels"
-                    % label_field
-                )
-
         if project_name is None:
             _dataset_name = samples._root_dataset.name.replace(" ", "_")
             project_name = "FiftyOne_%s" % _dataset_name
@@ -550,7 +547,15 @@ class LabelboxAnnotationAPI(foua.AnnotationAPI):
         self.upload_data(samples, dataset, media_field=media_field)
 
         project = self._setup_project(
-            project_name, dataset, label_schema, classes_as_attrs, is_video
+            project_name,
+            samples.values("id"),
+            label_schema,
+            classes_as_attrs,
+            is_video,
+        )
+
+        id_map = self._upload_annotations(
+            samples, label_schema, project, classes_as_attrs, is_video
         )
 
         if members:
@@ -558,7 +563,6 @@ class LabelboxAnnotationAPI(foua.AnnotationAPI):
                 self.add_member(project, email, role)
 
         project_id = project.uid
-        id_map = {}
         frame_id_map = self._build_frame_id_map(samples)
 
         return LabelboxAnnotationResults(
@@ -570,6 +574,88 @@ class LabelboxAnnotationAPI(foua.AnnotationAPI):
             frame_id_map,
             backend=backend,
         )
+
+    def get_data_row_ids(self, sample_ids):
+        try:
+            data_row_id_response = (
+                self._client.get_data_row_ids_for_global_keys(sample_ids)
+            )
+            data_row_ids = data_row_id_response["results"]
+        except lb.exceptions.TimeoutError:
+            logger.warning("Request to get data row ids timed out")
+            data_row_ids = [""] * len(sample_ids)
+
+        return dict(zip(*[sample_ids, data_row_ids]))
+
+    def _upload_annotations(
+        self, samples, label_schema, project, classes_as_attrs, is_video
+    ):
+        labels, id_map = self._build_labels(
+            samples, label_schema, classes_as_attrs, is_video
+        )
+        if labels:
+            logger.info("Uploading annotations...")
+            upload_job = lb.LabelImport.create_from_objects(
+                client=self._client,
+                project_id=project.uid,
+                name="label_import_job_" + str(project.uid),
+                labels=labels,
+            )
+            upload_job.wait_until_done()
+
+        return id_map
+
+    def _build_labels(self, samples, label_schema, classes_as_attrs, is_video):
+        id_map = {}
+        labels = []
+        label_fields = {}
+        converters = {}
+        for label_field, label_info in label_schema.items():
+            if label_info["existing_field"]:
+                converters[label_field] = _FiftyOneToLabelboxInstanceConverter(
+                    label_field,
+                    label_schema=label_schema,
+                    classes_as_attrs=classes_as_attrs,
+                )
+            id_map[label_field] = {}
+
+        if not converters:
+            return labels
+
+        samples.compute_metadata()
+        logger.info("Formatting annotations...")
+        for sample in samples:
+            sample_id = sample.id
+
+            # Get frame size
+            if is_video:
+                frame_size = (
+                    sample.metadata.frame_width,
+                    sample.metadata.frame_height,
+                )
+            else:
+                frame_size = (sample.metadata.width, sample.metadata.height)
+
+            # Export sample-level labels
+            for label_field, converter in converters.items():
+                label = sample[label_field]
+                annos, label_ids = converter.convert_image_label(
+                    label, frame_size
+                )
+                id_map[label_field][sample_id] = label_ids
+                for anno in annos:
+                    anno.update(
+                        {
+                            "dataRow": {
+                                "globalKey": sample_id,
+                            }
+                        }
+                    )
+                labels.extend(annos)
+
+            # @todo Export frame-level labels to support videos
+
+        return labels, id_map
 
     def download_annotations(self, results):
         """Downloads the annotations from the Labelbox server for the given
@@ -624,7 +710,7 @@ class LabelboxAnnotationAPI(foua.AnnotationAPI):
                 for label_d in video_d_list:
                     frame_number = label_d["frameNumber"]
                     frame_id = frame_id_map[sample_id][frame_number]
-                    labels_dict = _parse_image_labels(
+                    labels_dict = _LabelboxExportToFiftyOneConverterV1._parse_image_labels(
                         label_d, frame_size, class_attr=class_attr
                     )
                     if not classes_as_attrs:
@@ -641,8 +727,10 @@ class LabelboxAnnotationAPI(foua.AnnotationAPI):
                 )
 
             else:
-                labels_dict = _parse_image_labels(
-                    d["Label"], frame_size, class_attr=class_attr
+                labels_dict = (
+                    _LabelboxExportToFiftyOneConverterV1._parse_image_labels(
+                        d["Label"], frame_size, class_attr=class_attr
+                    )
                 )
                 if not classes_as_attrs:
                     labels_dict = self._process_label_fields(
@@ -703,7 +791,12 @@ class LabelboxAnnotationAPI(foua.AnnotationAPI):
         return frame_id_map
 
     def _setup_project(
-        self, project_name, dataset, label_schema, classes_as_attrs, is_video
+        self,
+        project_name,
+        sample_ids,
+        label_schema,
+        classes_as_attrs,
+        is_video,
     ):
         media_type = lb.MediaType.Video if is_video else lb.MediaType.Image
         project = self._client.create_project(
@@ -713,7 +806,7 @@ class LabelboxAnnotationAPI(foua.AnnotationAPI):
         )
         project.create_batch(
             name=str(uuid4()),
-            data_rows=dataset.data_rows(),
+            global_keys=sample_ids,
         )
 
         self._setup_editor(project, label_schema, classes_as_attrs)
@@ -1553,7 +1646,11 @@ def import_from_labelbox(
                     sample.metadata.frame_width,
                     sample.metadata.frame_height,
                 )
-                frames = _parse_video_labels(d["Label"], frame_size)
+                frames = (
+                    _LabelboxExportToFiftyOneConverterV1._parse_video_labels(
+                        d["Label"], frame_size
+                    )
+                )
                 sample.frames.merge(
                     {
                         frame_number: {
@@ -1565,7 +1662,11 @@ def import_from_labelbox(
                 )
             else:
                 frame_size = (sample.metadata.width, sample.metadata.height)
-                labels_dict = _parse_image_labels(d["Label"], frame_size)
+                labels_dict = (
+                    _LabelboxExportToFiftyOneConverterV1._parse_image_labels(
+                        d["Label"], frame_size
+                    )
+                )
                 sample.update_fields(
                     {label_key(k): v for k, v in labels_dict.items()}
                 )
@@ -1668,6 +1769,7 @@ def export_to_labelbox(
     sample_collection.compute_metadata()
 
     etau.ensure_empty_file(ndjson_path)
+    converter = _FiftyOneToLabelboxExportConverterV1()
 
     # Export the labels
     with fou.ProgressBar() as pb:
@@ -1693,7 +1795,7 @@ def export_to_labelbox(
             # Export sample-level labels
             if label_fields:
                 labels_dict = _get_labels(sample, label_fields)
-                annos = _to_labelbox_image_labels(
+                annos = converter._to_labelbox_image_labels(
                     labels_dict, frame_size, labelbox_id
                 )
                 etas.write_ndjson(annos, ndjson_path, append=True)
@@ -1701,7 +1803,7 @@ def export_to_labelbox(
             # Export frame-level labels
             if is_video and frame_label_fields:
                 frames = _get_frame_labels(sample, frame_label_fields)
-                video_annos = _to_labelbox_video_labels(
+                video_annos = converter._to_labelbox_video_labels(
                     frames, frame_size, labelbox_id
                 )
 
@@ -1935,172 +2037,708 @@ def _get_frame_labels(sample, frame_label_fields):
     return frames
 
 
-def _to_labelbox_image_labels(labels_dict, frame_size, data_row_id):
-    annotations = []
-    for name, label in labels_dict.items():
+class _FiftyOneToLabelboxConverterBase:
+
+    # https://labelbox.com/docs/exporting-data/export-format-detail#classification
+    @classmethod
+    def _to_global_classification(cls, name, label, data_row_id=None):
+        if isinstance(label, fol.Classification):
+            label_ids = [label.id]
+        elif isinstance(label, fol.Classifications):
+            label_ids = [l.id for l in label.classifications]
+        else:
+            label_ids = []
+
+        anno = cls._make_base_anno(name, data_row_id=data_row_id)
+        anno.update(cls._make_classification_answer(label))
+        return anno, label_ids
+
+    @classmethod
+    def _validate_label_class(cls, label):
+        return True
+
+    # https://labelbox.com/docs/exporting-data/export-format-detail#nested_classification
+    def _get_nested_classifications(self, label):
+        classifications = []
+        for name, value in label.iter_attributes():
+            if etau.is_str(value) or isinstance(value, (list, tuple)):
+                anno = self._make_base_anno(name)
+                anno.update(self._make_classification_answer(value))
+                classifications.append(anno)
+            else:
+                msg = "Ignoring unsupported attribute type '%s'" % type(value)
+                warnings.warn(msg)
+                continue
+
+        return classifications
+
+    # https://labelbox.com/docs/automation/model-assisted-labeling#mask_annotations
+    @classmethod
+    def _to_mask(cls, name, label, data_row_id=None):
+        mask = np.asarray(label.get_mask())
+        if mask.ndim < 3 or mask.dtype != np.uint8:
+            raise ValueError(
+                "Segmentation masks must be stored as RGB color uint8 images"
+            )
+
+        try:
+            instance_uri = label.instance_uri
+        except:
+            raise ValueError(
+                "You must populate the `instance_uri` field of segmentation masks"
+            )
+
+        # Get unique colors
+        colors = np.unique(np.reshape(mask, (-1, 3)), axis=0).tolist()
+
+        annos = []
+        base_anno = cls._make_base_anno(name, data_row_id=data_row_id)
+        for color in colors:
+            anno = copy(base_anno)
+            anno["mask"] = cls._make_mask(instance_uri, color)
+            annos.append(anno)
+
+        return annos
+
+    @classmethod
+    def _get_base_anno_name(cls, label):
+        return label.label
+
+    # https://labelbox.com/docs/exporting-data/export-format-detail#bounding_boxes
+    def _to_detections(self, label, frame_size, data_row_id=None):
+        if isinstance(label, fol.Detections):
+            detections = label.detections
+        else:
+            detections = [label]
+
+        annos = []
+        label_ids = []
+        for detection in detections:
+            if not self._validate_label_class(detection):
+                continue
+
+            anno_name = self._get_base_anno_name(detection)
+            anno = self._make_base_anno(anno_name, data_row_id=data_row_id)
+            anno["bbox"] = self._make_bbox(detection.bounding_box, frame_size)
+
+            classifications = self._get_nested_classifications(detection)
+            if classifications:
+                anno["classifications"] = classifications
+
+            annos.append(anno)
+            label_ids.append(detection.id)
+
+        return annos, label_ids
+
+    # https://labelbox.com/docs/exporting-data/export-format-detail#polygons
+    # https://labelbox.com/docs/exporting-data/export-format-detail#polylines
+    def _to_polylines(self, label, frame_size, data_row_id=None):
+        if isinstance(label, fol.Polylines):
+            polylines = label.polylines
+        else:
+            polylines = [label]
+
+        annos = []
+        label_ids = []
+        for polyline in polylines:
+            if not self._validate_label_class(polyline):
+                continue
+            field = "polygon" if polyline.filled else "line"
+            classifications = self._get_nested_classifications(polyline)
+            for points in polyline.points:
+                anno_name = self._get_base_anno_name(polyline)
+                anno = self._make_base_anno(anno_name, data_row_id=data_row_id)
+                anno[field] = [
+                    self._make_point(point, frame_size) for point in points
+                ]
+                if classifications:
+                    anno["classifications"] = classifications
+
+                annos.append(anno)
+            label_ids.append(polyline.id)
+
+        return annos, label_ids
+
+    # https://labelbox.com/docs/exporting-data/export-format-detail#points
+    def _to_points(self, label, frame_size, data_row_id=None):
+        if isinstance(label, fol.Keypoints):
+            keypoints = label.keypoints
+        else:
+            keypoints = [keypoints]
+
+        annos = []
+        label_ids = []
+        for keypoint in keypoints:
+            if not self._validate_label_class(keypoint):
+                continue
+            classifications = self._get_nested_classifications(keypoint)
+            for point in keypoint.points:
+                anno_name = self._get_base_anno_name(keypoint)
+                anno = self._make_base_anno(anno_name, data_row_id=data_row_id)
+                anno["point"] = self._make_point(point, frame_size)
+                if classifications:
+                    anno["classifications"] = classifications
+
+                annos.append(anno)
+            label_ids.append(keypoint.id)
+
+        return annos, label_ids
+
+    @classmethod
+    def _make_base_anno(cls, value, data_row_id=None):
+        anno = {
+            "uuid": str(uuid4()),
+            "schemaId": None,
+            "title": value,
+            "value": value,
+        }
+
+        if data_row_id:
+            anno["dataRow"] = {"id": data_row_id}
+
+        return anno
+
+    @classmethod
+    def _make_classification_answer(cls, label):
+        if isinstance(label, fol.Classification):
+            # Assume free text
+            return {"answer": label.label}
+
+        if isinstance(label, fol.Classifications):
+            # Assume checklist
+            return {
+                "answers": [{"value": c.label} for c in label.classifications]
+            }
+
+        if etau.is_str(label):
+            # Assume free text
+            return {"answer": label}
+
+        if isinstance(label, (list, tuple)):
+            # Assume checklist
+            return {"answers": [{"value": value} for value in label]}
+
+        raise ValueError(
+            "Cannot convert %s to a classification" % label.__class__
+        )
+
+    @classmethod
+    def _make_bbox(cls, bounding_box, frame_size):
+        x, y, w, h = bounding_box
+        width, height = frame_size
+        return {
+            "left": round(x * width, 1),
+            "top": round(y * height, 1),
+            "width": round(w * width, 1),
+            "height": round(h * height, 1),
+        }
+
+    @classmethod
+    def _make_point(cls, point, frame_size):
+        x, y = point
+        width, height = frame_size
+        return {"x": round(x * width, 1), "y": round(y * height, 1)}
+
+    @classmethod
+    def _make_mask(cls, instance_uri, color):
+        return {
+            "instanceURI": instance_uri,
+            "colorRGB": list(color),
+        }
+
+
+class _FiftyOneToLabelboxInstanceConverter(_FiftyOneToLabelboxConverterBase):
+    def __init__(self, label_field, label_schema=None, classes_as_attrs=True):
+        self.label_schema = label_schema
+        self.label_field = label_field
+        self.classes_as_attrs = classes_as_attrs
+
+        self._available_classes = self._get_available_classes()
+        self._attrs_per_class = self._get_attrs_per_class()
+
+    def _get_attrs_per_class(self):
+        attrs_per_class = {}
+        label_info = self.label_schema.get(self.label_field, {})
+        global_attrs = label_info.get("attributes", {})
+        for c in label_info.get("classes", []):
+            _classes = []
+            if isinstance(c, dict):
+                subclasses = c.get("classes", [])
+                if isinstance(subclasses, str):
+                    subclasses = [subclasses]
+                for sc in subclasses:
+                    class_attrs = c.get("attributes", {})
+                    attrs_per_class[sc] = {**global_attrs, **class_attrs}
+
+            elif isinstance(c, str):
+                c = [c]
+
+            if isinstance(c, list):
+                for sc in c:
+                    attrs_per_class[sc] = global_attrs
+
+        return attrs_per_class
+
+    def _get_available_classes(self):
+        available_classes = []
+        label_info = self.label_schema.get(self.label_field, {})
+        for c in label_info.get("classes", []):
+            if isinstance(c, dict):
+                for sc in c.get("classes", []):
+                    if isinstance(sc, str):
+                        sc = [sc]
+                    available_classes.extend(sc)
+
+            elif isinstance(c, str):
+                c = [c]
+
+            available_classes.extend(c)
+
+        return available_classes
+
+    def convert_image_label(self, label, frame_size):
+        annotations = []
+        name = self.label_field
+
         if isinstance(label, (fol.Classification, fol.Classifications)):
-            anno = _to_global_classification(name, label, data_row_id)
+            anno, label_ids = self._to_global_classification(name, label)
             annotations.append(anno)
         elif isinstance(label, (fol.Detection, fol.Detections)):
-            annos = _to_detections(label, frame_size, data_row_id)
+            annos, label_ids = self._to_detections(label, frame_size)
             annotations.extend(annos)
         elif isinstance(label, (fol.Polyline, fol.Polylines)):
-            annos = _to_polylines(label, frame_size, data_row_id)
+            annos, label_ids = self._to_polylines(label, frame_size)
             annotations.extend(annos)
         elif isinstance(label, (fol.Keypoint, fol.Keypoints)):
-            annos = _to_points(label, frame_size, data_row_id)
+            annos, label_ids = self._to_points(label, frame_size)
             annotations.extend(annos)
         elif isinstance(label, fol.Segmentation):
-            annos = _to_mask(name, label, data_row_id)
+            label_ids = [label.id]
+            annos = self._to_mask(name, label)
             annotations.extend(annos)
         elif label is not None:
             msg = "Ignoring unsupported label type '%s'" % label.__class__
             warnings.warn(msg)
 
-    return annotations
+        return annotations, label_ids
 
+    @classmethod
+    def _make_attribute_answer(cls, attr_name, attr_value, class_attrs):
+        if class_attrs["type"] == "text":
+            return {"answer": attr_value}
 
-def _to_labelbox_video_labels(frames, frame_size, data_row_id):
-    annotations = []
-    for frame_number, labels_dict in frames.items():
-        frame_annos = _to_labelbox_image_labels(
-            labels_dict, frame_size, data_row_id
-        )
-        for anno in frame_annos:
-            anno["frameNumber"] = frame_number
-            annotations.append(anno)
+        if class_attrs["type"] == "checkbox":
+            if isinstance(attr_value, (list, tuple)):
+                return {"answer": [{"name": value} for value in attr_value]}
 
-    return annotations
+            if isinstance(attr_value, fol.Classifications):
+                return {
+                    "answer": [
+                        {"name": c.label} for c in attr_value.classifications
+                    ]
+                }
 
+        if class_attrs["type"] in ["select", "radio"]:
+            if isinstance(attr_value, fol.Classification):
+                return {"answer": {"name": attr_value.label}}
 
-# https://labelbox.com/docs/exporting-data/export-format-detail#classification
-def _to_global_classification(name, label, data_row_id):
-    anno = _make_base_anno(name, data_row_id=data_row_id)
-    anno.update(_make_classification_answer(label))
-    return anno
+            if isinstance(attr_value, str):
+                return {"answer": {"name": attr_value}}
 
-
-# https://labelbox.com/docs/exporting-data/export-format-detail#nested_classification
-def _get_nested_classifications(label):
-    classifications = []
-    for name, value in label.iter_attributes():
-        if etau.is_str(value) or isinstance(value, (list, tuple)):
-            anno = _make_base_anno(name)
-            anno.update(_make_classification_answer(value))
-            classifications.append(anno)
-        else:
-            msg = "Ignoring unsupported attribute type '%s'" % type(value)
-            warnings.warn(msg)
-            continue
-
-    return classifications
-
-
-# https://labelbox.com/docs/automation/model-assisted-labeling#mask_annotations
-def _to_mask(name, label, data_row_id):
-    mask = np.asarray(label.get_mask())
-    if mask.ndim < 3 or mask.dtype != np.uint8:
         raise ValueError(
-            "Segmentation masks must be stored as RGB color uint8 images"
+            "Cannot convert %s to a classification" % attr_value.__class__
         )
 
-    try:
-        instance_uri = label.instance_uri
-    except:
-        raise ValueError(
-            "You must populate the `instance_uri` field of segmentation masks"
+    def _get_base_anno_name(self, label):
+        if self.classes_as_attrs:
+            return self.label_field
+
+        return label.label
+
+    @classmethod
+    def _make_base_anno(cls, value, data_row_id=None):
+        return {"name": value}
+
+    # https://docs.labelbox.com/reference/import-image-annotations#bounding-box-with-nested-classification
+    def _get_nested_classifications(self, label):
+        classifications = []
+        class_attrs = self._attrs_per_class.get(label.label, {})
+        for name, value in label.iter_attributes():
+            if class_attrs and name not in class_attrs:
+                continue
+
+            class_attr = class_attrs[name]
+
+            if etau.is_str(value) or isinstance(value, (list, tuple)):
+                anno = self._make_base_anno(name)
+                anno.update(
+                    self._make_attribute_answer(name, value, class_attr)
+                )
+                classifications.append(anno)
+            else:
+                msg = "Ignoring unsupported attribute type '%s'" % type(value)
+                warnings.warn(msg)
+                continue
+
+        if self.classes_as_attrs:
+            class_as_attr = {
+                "name": "class_name",
+                "answer": {"name": label.label},
+            }
+            classifications.append(class_as_attr)
+
+        return classifications
+
+    def _validate_label_class(self, label):
+        if self._available_classes and label.label in self._available_classes:
+            return True
+
+        return False
+
+
+class _FiftyOneToLabelboxExportConverterV1(_FiftyOneToLabelboxConverterBase):
+    # Converts FiftyOne labels to Labelbox export format v1:
+    # https://docs.labelbox.com/reference/export-image-annotations
+    def _to_labelbox_image_labels(self, labels_dict, frame_size, data_row_id):
+        annotations = []
+        for name, label in labels_dict.items():
+            if isinstance(label, (fol.Classification, fol.Classifications)):
+                anno, label_ids = self._to_global_classification(
+                    name, label, data_row_id=data_row_id
+                )
+                annotations.append(anno)
+            elif isinstance(label, (fol.Detection, fol.Detections)):
+                annos, label_ids = self._to_detections(
+                    label, frame_size, data_row_id=data_row_id
+                )
+                annotations.extend(annos)
+            elif isinstance(label, (fol.Polyline, fol.Polylines)):
+                annos, label_ids = self._to_polylines(
+                    label, frame_size, data_row_id=data_row_id
+                )
+                annotations.extend(annos)
+            elif isinstance(label, (fol.Keypoint, fol.Keypoints)):
+                annos, label_ids = self._to_points(
+                    label, frame_size, data_row_id=data_row_id
+                )
+                annotations.extend(annos)
+            elif isinstance(label, fol.Segmentation):
+                label_ids = [label.id]
+                annos = self._to_mask(name, label, data_row_id=data_row_id)
+                annotations.extend(annos)
+            elif label is not None:
+                msg = "Ignoring unsupported label type '%s'" % label.__class__
+                warnings.warn(msg)
+
+        return annotations
+
+    def _to_labelbox_video_labels(self, frames, frame_size, data_row_id):
+        annotations = []
+        for frame_number, labels_dict in frames.items():
+            frame_annos = self._to_labelbox_image_labels(
+                labels_dict, frame_size, data_row_id
+            )
+            for anno in frame_annos:
+                anno["frameNumber"] = frame_number
+                annotations.append(anno)
+
+        return annotations
+
+
+class _LabelboxExportToFiftyOneConverterV1:
+    # Parse Labelbox export format v1 to FiftyOne labels:
+
+    # Parse v1 export format
+    # https://docs.labelbox.com/reference/export-video-annotations
+    @classmethod
+    def _parse_video_labels(cls, video_label_d, frame_size):
+        url_or_filepath = video_label_d["frames"]
+        label_d_list = _download_or_load_ndjson(url_or_filepath)
+
+        frames = {}
+        for label_d in label_d_list:
+            frame_number = label_d["frameNumber"]
+            frames[frame_number] = cls._parse_image_labels(label_d, frame_size)
+
+        return frames
+
+    # Parse v1 export format
+    # https://docs.labelbox.com/reference/export-image-annotations#annotation-export-formats
+    @classmethod
+    def _parse_image_labels(cls, label_d, frame_size, class_attr=None):
+        labels = {}
+
+        # Parse classifications
+        cd_list = label_d.get("classifications", [])
+
+        classifications = cls._parse_classifications(cd_list)
+        labels.update(classifications)
+
+        # Parse objects
+        # @todo what if `objects.keys()` conflicts with `classifications.keys()`?
+        od_list = label_d.get("objects", [])
+        objects = cls._parse_objects(
+            od_list, frame_size, class_attr=class_attr
         )
+        labels.update(objects)
 
-    # Get unique colors
-    colors = np.unique(np.reshape(mask, (-1, 3)), axis=0).tolist()
+        return labels
 
-    annos = []
-    base_anno = _make_base_anno(name, data_row_id=data_row_id)
-    for color in colors:
-        anno = copy(base_anno)
-        anno["mask"] = _make_mask(instance_uri, color)
-        annos.append(anno)
+    @classmethod
+    def _get_answer_value(cls, answer):
+        return answer["value"]
 
-    return annos
+    @classmethod
+    def _parse_classifications(cls, cd_list):
+        labels = {}
+
+        for cd in cd_list:
+            name = cd["value"]
+            if "answer" in cd:
+                answer = cd["answer"]
+                if isinstance(answer, list):
+                    cd["answers"] = answer
+                else:
+                    if isinstance(answer, list):
+                        # Dropdown
+                        labels[name] = fol.Classifications(
+                            classifications=[
+                                fol.Classification(
+                                    label=cls._get_answer_value(a)
+                                )
+                                for a in answer
+                            ]
+                        )
+                    elif isinstance(answer, dict):
+                        # Radio question
+                        labels[name] = fol.Classification(
+                            label=cls._get_answer_value(answer)
+                        )
+                    else:
+                        # Free text
+                        labels[name] = fol.Classification(label=answer)
+
+            if "answers" in cd:
+                # Checklist
+                answers = cd["answers"]
+                labels[name] = fol.Classifications(
+                    classifications=[
+                        fol.Classification(label=cls._get_answer_value(a))
+                        for a in answers
+                    ]
+                )
+
+        return labels
+
+    @classmethod
+    def _parse_attributes(cls, cd_list):
+        attributes = {}
+
+        for cd in cd_list:
+            name = cls._get_answer_value(cd)
+            if "answer" in cd:
+                answer = cd["answer"]
+                if isinstance(answer, list):
+                    # Dropdown
+                    answers = [
+                        _parse_attribute(cls._get_answer_value(a))
+                        for a in answer
+                    ]
+                    if len(answers) == 1:
+                        answers = answers[0]
+
+                    attributes[name] = answers
+
+                elif isinstance(answer, dict):
+                    # Radio question
+                    attributes[name] = _parse_attribute(
+                        cls._get_answer_value(answer)
+                    )
+                else:
+                    # Free text
+                    attributes[name] = _parse_attribute(answer)
+
+            if "answers" in cd:
+                # Checklist
+                answer = cd["answers"]
+                attributes[name] = [
+                    _parse_attribute(cls._get_answer_value(a)) for a in answer
+                ]
+
+        return attributes
+
+    @classmethod
+    def _parse_objects(cls, od_list, frame_size, class_attr=None):
+        detections = []
+        polylines = []
+        keypoints = []
+        segmentations = []
+        mask = None
+        mask_instance_uri = None
+        label_fields = {}
+        for od in od_list:
+            attributes = cls._parse_attributes(od.get("classifications", []))
+            load_fo_seg = class_attr is not None
+            if class_attr and class_attr in attributes:
+                label_field = od["title"]
+                label = attributes.pop(class_attr)
+                if label_field not in label_fields:
+                    label_fields[label_field] = {}
+            else:
+                label = od["value"]
+                label_field = None
+
+            if "bbox" in od:
+                # Detection
+                bounding_box = cls._parse_bbox(od["bbox"], frame_size)
+                det = fol.Detection(
+                    label=label, bounding_box=bounding_box, **attributes
+                )
+                if label_field is None:
+                    detections.append(det)
+                else:
+                    if "detections" not in label_fields[label_field]:
+                        label_fields[label_field]["detections"] = []
+
+                    label_fields[label_field]["detections"].append(det)
+
+            elif "polygon" in od:
+                # Polyline
+                points = cls._parse_points(od["polygon"], frame_size)
+                polyline = fol.Polyline(
+                    label=label,
+                    points=[points],
+                    closed=True,
+                    filled=True,
+                    **attributes,
+                )
+                if label_field is None:
+                    polylines.append(polyline)
+                else:
+                    if "polylines" not in label_fields[label_field]:
+                        label_fields[label_field]["polylines"] = []
+
+                    label_fields[label_field]["polylines"].append(polyline)
+
+            elif "line" in od:
+                # Polyline
+                points = cls._parse_points(od["line"], frame_size)
+                polyline = fol.Polyline(
+                    label=label,
+                    points=[points],
+                    closed=True,
+                    filled=False,
+                    **attributes,
+                )
+                if label_field is None:
+                    polylines.append(polyline)
+                else:
+                    if "polylines" not in label_fields[label_field]:
+                        label_fields[label_field]["polylines"] = []
+
+                    label_fields[label_field]["polylines"].append(polyline)
+
+            elif "point" in od:
+                # Keypoint
+                point = cls._parse_point(od["point"], frame_size)
+                keypoint = fol.Keypoint(
+                    label=label, points=[point], **attributes
+                )
+                if label_field is None:
+                    keypoints.append(keypoint)
+                else:
+                    if "keypoints" not in label_fields[label_field]:
+                        label_fields[label_field]["keypoints"] = []
+
+                    label_fields[label_field]["keypoints"].append(keypoint)
+
+            elif "instanceURI" in od:
+                # Segmentation mask
+                if not load_fo_seg:
+                    if mask is None:
+                        mask_instance_uri = od["instanceURI"]
+                        mask = cls._parse_mask(mask_instance_uri)
+                        segmentation = {
+                            "mask": current_mask,
+                            "label": label,
+                            "attributes": attributes,
+                        }
+                    elif od["instanceURI"] != mask_instance_uri:
+                        msg = (
+                            "Only one segmentation mask per image/frame is "
+                            "allowed; skipping additional mask(s)"
+                        )
+                        warnings.warn(msg)
+                else:
+                    current_mask_instance_uri = od["instanceURI"]
+                    current_mask = cls._parse_mask(current_mask_instance_uri)
+                    segmentation = {
+                        "mask": current_mask,
+                        "label": label,
+                        "attributes": attributes,
+                    }
+                    if label_field is not None:
+                        if "segmentation" not in label_fields[label_field]:
+                            label_fields[label_field]["segmentation"] = []
+
+                        label_fields[label_field]["segmentation"].append(
+                            segmentation
+                        )
+                    else:
+                        segmentations.append(segmentation)
+            else:
+                msg = "Ignoring unsupported label"
+                warnings.warn(msg)
+
+        labels = {}
+
+        if detections:
+            labels["detections"] = fol.Detections(detections=detections)
+
+        if polylines:
+            labels["polylines"] = fol.Polylines(polylines=polylines)
+
+        if keypoints:
+            labels["keypoints"] = fol.Keypoints(keypoints=keypoints)
+
+        if mask is not None:
+            labels["segmentation"] = mask
+        elif segmentations:
+            labels["segmentation"] = segmentations
+
+        labels.update(label_fields)
+
+        return labels
+
+    @classmethod
+    def _parse_bbox(cls, bd, frame_size):
+        width, height = frame_size
+        x = bd["left"] / width
+        y = bd["top"] / height
+        w = bd["width"] / width
+        h = bd["height"] / height
+        return [x, y, w, h]
+
+    @classmethod
+    def _parse_points(cls, pd_list, frame_size):
+        return [cls._parse_point(pd, frame_size) for pd in pd_list]
+
+    @classmethod
+    def _parse_point(cls, pd, frame_size):
+        width, height = frame_size
+        return (pd["x"] / width, pd["y"] / height)
+
+    @classmethod
+    def _parse_mask(cls, instance_uri):
+        img_bytes = etaw.download_file(instance_uri, quiet=True)
+        return etai.decode(img_bytes)
 
 
-# https://labelbox.com/docs/exporting-data/export-format-detail#bounding_boxes
-def _to_detections(label, frame_size, data_row_id):
-    if isinstance(label, fol.Detections):
-        detections = label.detections
-    else:
-        detections = [label]
-
-    annos = []
-    for detection in detections:
-        anno = _make_base_anno(detection.label, data_row_id=data_row_id)
-        anno["bbox"] = _make_bbox(detection.bounding_box, frame_size)
-
-        classifications = _get_nested_classifications(detection)
-        if classifications:
-            anno["classifications"] = classifications
-
-        annos.append(anno)
-
-    return annos
-
-
-# https://labelbox.com/docs/exporting-data/export-format-detail#polygons
-# https://labelbox.com/docs/exporting-data/export-format-detail#polylines
-def _to_polylines(label, frame_size, data_row_id):
-    if isinstance(label, fol.Polylines):
-        polylines = label.polylines
-    else:
-        polylines = [label]
-
-    annos = []
-    for polyline in polylines:
-        field = "polygon" if polyline.filled else "line"
-        classifications = _get_nested_classifications(polyline)
-        for points in polyline.points:
-            anno = _make_base_anno(polyline.label, data_row_id=data_row_id)
-            anno[field] = [_make_point(point, frame_size) for point in points]
-            if classifications:
-                anno["classifications"] = classifications
-
-            annos.append(anno)
-
-    return annos
-
-
-# https://labelbox.com/docs/exporting-data/export-format-detail#points
-def _to_points(label, frame_size, data_row_id):
-    if isinstance(label, fol.Keypoints):
-        keypoints = label.keypoints
-    else:
-        keypoints = [keypoints]
-
-    annos = []
-    for keypoint in keypoints:
-        classifications = _get_nested_classifications(keypoint)
-        for point in keypoint.points:
-            anno = _make_base_anno(keypoint.label, data_row_id=data_row_id)
-            anno["point"] = _make_point(point, frame_size)
-            if classifications:
-                anno["classifications"] = classifications
-
-            annos.append(anno)
-
-    return annos
-
-
-def _make_base_anno(value, data_row_id=None):
-    anno = {
-        "uuid": str(uuid4()),
-        "schemaId": None,
-        "title": value,
-        "value": value,
-    }
-
-    if data_row_id:
-        anno["dataRow"] = {"id": data_row_id}
-
-    return anno
+class _LabelboxExportToFiftyOneConverter(_LabelboxExportToFiftyOneConverterV1):
+    # Parse Labelbox export format v2 to FiftyOne labels:
+    @classmethod
+    def _get_answer_value(cls, answer):
+        return answer["name"]
 
 
 def _make_video_anno(labels_path, data_row_id=None):
@@ -2113,311 +2751,6 @@ def _make_video_anno(labels_path, data_row_id=None):
         anno["dataRow"] = {"id": data_row_id}
 
     return anno
-
-
-def _make_classification_answer(label):
-    if isinstance(label, fol.Classification):
-        # Assume free text
-        return {"answer": label.label}
-
-    if isinstance(label, fol.Classifications):
-        # Assume checklist
-        return {"answers": [{"value": c.label} for c in label.classifications]}
-
-    if etau.is_str(label):
-        # Assume free text
-        return {"answer": label}
-
-    if isinstance(label, (list, tuple)):
-        # Assume checklist
-        return {"answers": [{"value": value} for value in label]}
-
-    raise ValueError("Cannot convert %s to a classification" % label.__class__)
-
-
-def _make_bbox(bounding_box, frame_size):
-    x, y, w, h = bounding_box
-    width, height = frame_size
-    return {
-        "left": round(x * width, 1),
-        "top": round(y * height, 1),
-        "width": round(w * width, 1),
-        "height": round(h * height, 1),
-    }
-
-
-def _make_point(point, frame_size):
-    x, y = point
-    width, height = frame_size
-    return {"x": round(x * width, 1), "y": round(y * height, 1)}
-
-
-def _make_mask(instance_uri, color):
-    return {
-        "instanceURI": instance_uri,
-        "colorRGB": list(color),
-    }
-
-
-# Parse v1 export format
-# https://docs.labelbox.com/reference/export-video-annotations
-def _parse_video_labels(video_label_d, frame_size):
-    url_or_filepath = video_label_d["frames"]
-    label_d_list = _download_or_load_ndjson(url_or_filepath)
-
-    frames = {}
-    for label_d in label_d_list:
-        frame_number = label_d["frameNumber"]
-        frames[frame_number] = _parse_image_labels(label_d, frame_size)
-
-    return frames
-
-
-# Parse v1 export format
-# https://docs.labelbox.com/reference/export-image-annotations#annotation-export-formats
-def _parse_image_labels(label_d, frame_size, class_attr=None):
-    labels = {}
-
-    # Parse classifications
-    cd_list = label_d.get("classifications", [])
-
-    classifications = _parse_classifications(cd_list)
-    labels.update(classifications)
-
-    # Parse objects
-    # @todo what if `objects.keys()` conflicts with `classifications.keys()`?
-    od_list = label_d.get("objects", [])
-    objects = _parse_objects(od_list, frame_size, class_attr=class_attr)
-    labels.update(objects)
-
-    return labels
-
-
-def _parse_classifications(cd_list):
-    labels = {}
-
-    for cd in cd_list:
-        name = cd["value"]
-        if "answer" in cd:
-            answer = cd["answer"]
-            if isinstance(answer, list):
-                # Dropdown
-                labels[name] = fol.Classifications(
-                    classifications=[
-                        fol.Classification(label=a["value"]) for a in answer
-                    ]
-                )
-            elif isinstance(answer, dict):
-                # Radio question
-                labels[name] = fol.Classification(label=answer["value"])
-            else:
-                # Free text
-                labels[name] = fol.Classification(label=answer)
-
-        if "answers" in cd:
-            # Checklist
-            answers = cd["answers"]
-            labels[name] = fol.Classifications(
-                classifications=[
-                    fol.Classification(label=a["value"]) for a in answers
-                ]
-            )
-
-    return labels
-
-
-def _parse_attributes(cd_list):
-    attributes = {}
-
-    for cd in cd_list:
-        name = cd["value"]
-        if "answer" in cd:
-            answer = cd["answer"]
-            if isinstance(answer, list):
-                # Dropdown
-                answers = [_parse_attribute(a["value"]) for a in answer]
-                if len(answers) == 1:
-                    answers = answers[0]
-
-                attributes[name] = answers
-
-            elif isinstance(answer, dict):
-                # Radio question
-                attributes[name] = _parse_attribute(answer["value"])
-            else:
-                # Free text
-                attributes[name] = _parse_attribute(answer)
-
-        if "answers" in cd:
-            # Checklist
-            answer = cd["answers"]
-            attributes[name] = [_parse_attribute(a["value"]) for a in answer]
-
-    return attributes
-
-
-def _parse_objects(od_list, frame_size, class_attr=None):
-    detections = []
-    polylines = []
-    keypoints = []
-    segmentations = []
-    mask = None
-    mask_instance_uri = None
-    label_fields = {}
-    for od in od_list:
-        attributes = _parse_attributes(od.get("classifications", []))
-        load_fo_seg = class_attr is not None
-        if class_attr and class_attr in attributes:
-            label_field = od["title"]
-            label = attributes.pop(class_attr)
-            if label_field not in label_fields:
-                label_fields[label_field] = {}
-        else:
-            label = od["value"]
-            label_field = None
-
-        if "bbox" in od:
-            # Detection
-            bounding_box = _parse_bbox(od["bbox"], frame_size)
-            det = fol.Detection(
-                label=label, bounding_box=bounding_box, **attributes
-            )
-            if label_field is None:
-                detections.append(det)
-            else:
-                if "detections" not in label_fields[label_field]:
-                    label_fields[label_field]["detections"] = []
-
-                label_fields[label_field]["detections"].append(det)
-
-        elif "polygon" in od:
-            # Polyline
-            points = _parse_points(od["polygon"], frame_size)
-            polyline = fol.Polyline(
-                label=label,
-                points=[points],
-                closed=True,
-                filled=True,
-                **attributes,
-            )
-            if label_field is None:
-                polylines.append(polyline)
-            else:
-                if "polylines" not in label_fields[label_field]:
-                    label_fields[label_field]["polylines"] = []
-
-                label_fields[label_field]["polylines"].append(polyline)
-
-        elif "line" in od:
-            # Polyline
-            points = _parse_points(od["line"], frame_size)
-            polyline = fol.Polyline(
-                label=label,
-                points=[points],
-                closed=True,
-                filled=False,
-                **attributes,
-            )
-            if label_field is None:
-                polylines.append(polyline)
-            else:
-                if "polylines" not in label_fields[label_field]:
-                    label_fields[label_field]["polylines"] = []
-
-                label_fields[label_field]["polylines"].append(polyline)
-
-        elif "point" in od:
-            # Keypoint
-            point = _parse_point(od["point"], frame_size)
-            keypoint = fol.Keypoint(label=label, points=[point], **attributes)
-            if label_field is None:
-                keypoints.append(keypoint)
-            else:
-                if "keypoints" not in label_fields[label_field]:
-                    label_fields[label_field]["keypoints"] = []
-
-                label_fields[label_field]["keypoints"].append(keypoint)
-
-        elif "instanceURI" in od:
-            # Segmentation mask
-            if not load_fo_seg:
-                if mask is None:
-                    mask_instance_uri = od["instanceURI"]
-                    mask = _parse_mask(mask_instance_uri)
-                    segmentation = {
-                        "mask": current_mask,
-                        "label": label,
-                        "attributes": attributes,
-                    }
-                elif od["instanceURI"] != mask_instance_uri:
-                    msg = (
-                        "Only one segmentation mask per image/frame is "
-                        "allowed; skipping additional mask(s)"
-                    )
-                    warnings.warn(msg)
-            else:
-                current_mask_instance_uri = od["instanceURI"]
-                current_mask = _parse_mask(current_mask_instance_uri)
-                segmentation = {
-                    "mask": current_mask,
-                    "label": label,
-                    "attributes": attributes,
-                }
-                if label_field is not None:
-                    if "segmentation" not in label_fields[label_field]:
-                        label_fields[label_field]["segmentation"] = []
-
-                    label_fields[label_field]["segmentation"].append(
-                        segmentation
-                    )
-                else:
-                    segmentations.append(segmentation)
-        else:
-            msg = "Ignoring unsupported label"
-            warnings.warn(msg)
-
-    labels = {}
-
-    if detections:
-        labels["detections"] = fol.Detections(detections=detections)
-
-    if polylines:
-        labels["polylines"] = fol.Polylines(polylines=polylines)
-
-    if keypoints:
-        labels["keypoints"] = fol.Keypoints(keypoints=keypoints)
-
-    if mask is not None:
-        labels["segmentation"] = mask
-    elif segmentations:
-        labels["segmentation"] = segmentations
-
-    labels.update(label_fields)
-
-    return labels
-
-
-def _parse_bbox(bd, frame_size):
-    width, height = frame_size
-    x = bd["left"] / width
-    y = bd["top"] / height
-    w = bd["width"] / width
-    h = bd["height"] / height
-    return [x, y, w, h]
-
-
-def _parse_points(pd_list, frame_size):
-    return [_parse_point(pd, frame_size) for pd in pd_list]
-
-
-def _parse_point(pd, frame_size):
-    width, height = frame_size
-    return (pd["x"] / width, pd["y"] / height)
-
-
-def _parse_mask(instance_uri):
-    img_bytes = etaw.download_file(instance_uri, quiet=True)
-    return etai.decode(img_bytes)
 
 
 def _download_or_load_ndjson(url_or_filepath):

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ import re
 from setuptools import setup, find_packages
 
 
-VERSION = "0.21.4"
+VERSION = "0.21.5"
 
 
 def get_version():


### PR DESCRIPTION
Bring the Labelbox integration to the level of CVAT, where you can now upload existing annotations to Labelbox when creating projects.

TODO:
* Figure out fix or workaround for `get_data_row_ids()` timeout error
* Update `id_map` tracking to support merging labels even if a data row was deleted in labelbox
  * Like CVAT, there is no great way to get the IDs of specific labels in Labelbox and map them to FiftyOne label UUIDs. This primarily comes up when annotating subsets of attributes on objects. If this mapping doesn't exist, then labels are deleted and added rather than merged, so any attributes not part of the annotation schema would be removed. Options to resolve this:
    * Use the CVAT approach of uploading label ids as text attributes. The downside being that these could be changed by annotators
    * Disallow annotating only subsets of attributes on existing labels
* Update classification parsing logic to support numerical and boolean values
* Add support for uploading video labels
* Add support for uploading to existing projects
* Add tests

* Future TODO: Move from v1 label exports to v2 before the end of 2023 when v1 annotation exports are deprecated