### PR TITLE
Embeddings only color-by supported list fields

### DIFF
--- a/fiftyone/server/routes/embeddings.py
+++ b/fiftyone/server/routes/embeddings.py
@@ -25,7 +25,6 @@ COLOR_BY_TYPES = (
     fof.BooleanField,
     fof.IntField,
     fof.FloatField,
-    fof.ListField,
 )
 
 
@@ -266,9 +265,18 @@ class ColorByChoices(HTTPEndpoint):
         )
 
         fields = [
-            k
-            for k, v in schema.items()
-            if isinstance(v, COLOR_BY_TYPES) and not k.startswith(bad_roots)
+            path
+            for path, field in schema.items()
+            if (
+                (
+                    isinstance(field, COLOR_BY_TYPES)
+                    or (
+                        isinstance(field, fof.ListField)
+                        and isinstance(field.field, COLOR_BY_TYPES)
+                    )
+                )
+                and not path.startswith(bad_roots)
+            )
         ]
 
         return {"fields": fields}


### PR DESCRIPTION
## Before

`ground_truth.detections` shouldn't be shown as a choice:

<img width="420" alt="Screen Shot 2023-07-20 at 9 37 05 PM" src="https://github.com/voxel51/fiftyone/assets/25985824/15a24092-27c4-4593-9bf7-05b320c3d066">


## After

Now the only allowed list field is `tags`, which is valid:

<img width="411" alt="Screen Shot 2023-07-20 at 9 36 27 PM" src="https://github.com/voxel51/fiftyone/assets/25985824/1b209774-3ddd-47e4-a819-387b31586016">


