### PR TITLE
Adding Segment Anything to the model zoo!

### DIFF
--- a/docs/scripts/make_model_zoo_docs.py
+++ b/docs/scripts/make_model_zoo_docs.py
@@ -113,7 +113,7 @@ _MODEL_TEMPLATE = """
     dataset.apply_model(
         model,
         label_field="segmentations",
-        prompt_field="ground_truth",
+        prompt_field="ground_truth",  # can contain Detections or Keypoints
     )
 
     # Full automatic segmentations

--- a/docs/scripts/make_model_zoo_docs.py
+++ b/docs/scripts/make_model_zoo_docs.py
@@ -108,11 +108,19 @@ _MODEL_TEMPLATE = """
 
     model = foz.load_zoo_model("{{ name }}")
 
+{% if 'segment-anything' in tags %}
+    dataset.apply_model(
+        model,
+        label_field="predictions",
+        prompt_field="ground_truth",
+    )
+{% else %}
     dataset.apply_model(model, label_field="predictions")
+{% endif %}
 
     session = fo.launch_app(dataset)
 
-{% if 'zero-shot' in tags %}
+{% if 'clip' in tags %}
     #
     # Make zero-shot predictions with custom classes
     #

--- a/docs/scripts/make_model_zoo_docs.py
+++ b/docs/scripts/make_model_zoo_docs.py
@@ -109,11 +109,15 @@ _MODEL_TEMPLATE = """
     model = foz.load_zoo_model("{{ name }}")
 
 {% if 'segment-anything' in tags %}
+    # Segment inside boxes
     dataset.apply_model(
         model,
-        label_field="predictions",
+        label_field="segmentations",
         prompt_field="ground_truth",
     )
+
+    # Full automatic segmentations
+    dataset.apply_model(model, label_field="auto")
 {% else %}
     dataset.apply_model(model, label_field="predictions")
 {% endif %}

--- a/fiftyone/core/models.py
+++ b/fiftyone/core/models.py
@@ -297,7 +297,7 @@ def _apply_image_model_single(
                 img = etai.read(sample.filepath)
 
                 if needs_samples:
-                    labels = model.predict(img, sample)
+                    labels = model.predict(img, sample=sample)
                 else:
                     labels = model.predict(img)
 
@@ -335,7 +335,9 @@ def _apply_image_model_batch(
                 imgs = [etai.read(sample.filepath) for sample in sample_batch]
 
                 if needs_samples:
-                    labels_batch = model.predict_all(imgs, sample_batch)
+                    labels_batch = model.predict_all(
+                        imgs, samples=sample_batch
+                    )
                 else:
                     labels_batch = model.predict_all(imgs)
 
@@ -387,7 +389,9 @@ def _apply_image_model_data_loader(
                     raise imgs
 
                 if needs_samples:
-                    labels_batch = model.predict_all(imgs, sample_batch)
+                    labels_batch = model.predict_all(
+                        imgs, samples=sample_batch
+                    )
                 else:
                     labels_batch = model.predict_all(imgs)
 
@@ -442,7 +446,7 @@ def _apply_image_model_to_frames_single(
                     for img in video_reader:
                         if needs_samples:
                             frame = sample.frames[video_reader.frame_number]
-                            labels = model.predict(img, frame)
+                            labels = model.predict(img, sample=frame)
                         else:
                             labels = model.predict(img)
 
@@ -497,7 +501,9 @@ def _apply_image_model_to_frames_batch(
                     for fns, imgs in _iter_batches(video_reader, batch_size):
                         if needs_samples:
                             _frames = [sample.frames[fn] for fn in fns]
-                            labels_batch = model.predict_all(imgs, _frames)
+                            labels_batch = model.predict_all(
+                                imgs, samples=_frames
+                            )
                         else:
                             labels_batch = model.predict_all(imgs)
 
@@ -552,7 +558,7 @@ def _apply_video_model(
                     sample.filepath, frames=frames
                 ) as video_reader:
                     if needs_samples:
-                        labels = model.predict(video_reader, sample)
+                        labels = model.predict(video_reader, sample=sample)
                     else:
                         labels = model.predict(video_reader)
 

--- a/fiftyone/core/models.py
+++ b/fiftyone/core/models.py
@@ -363,13 +363,9 @@ def _apply_image_model_data_loader(
 
     samples = samples.select_fields(extra_fields)
     # we need to make sure classes are available in the samples
-    if (
-        extra_fields
-        and model.field_type == "detections"
-        and not samples.classes
-    ):
+    if extra_fields:
         class_labels = samples.values(
-            f"{model.needs_fields[0]}.detections.label"
+            f"{model.needs_fields[0]}.{model.field_type}.label"
         )
         class_labels = list(
             set(one for labels in class_labels for one in labels)

--- a/fiftyone/core/models.py
+++ b/fiftyone/core/models.py
@@ -2120,7 +2120,8 @@ class SamplesMixin(object):
             return [self.predict(arg) for arg in args]
 
         return [
-            self.predict(arg, sample) for arg, sample in zip(args, samples)
+            self.predict(arg, sample=sample)
+            for arg, sample in zip(args, samples)
         ]
 
 

--- a/fiftyone/utils/sam.py
+++ b/fiftyone/utils/sam.py
@@ -18,9 +18,16 @@ class SegmentAnythingModelConfig(fout.TorchImageModelConfig, fozm.HasZooModel):
 
     See :class:`fiftyone.utils.torch.TorchImageModelConfig` for additional
     arguments.
+
+    Args:
+        amg_kwargs: a dictionary of keyword arguments to pass to
+            ``SamAutomaticMaskGenerator``
     """
 
-    pass
+    def __init__(self, d):
+        d = self.init(d)
+        super().__init__(d)
+        self.amg_kwargs = self.parse_dict(d, "amg_kwargs", default={})
 
 
 class SegmentAnythingModel(fout.TorchImageModel):
@@ -67,12 +74,7 @@ class SegmentAnythingModel(fout.TorchImageModel):
     def _forward_pass(self, inputs):
         mask_generator = SamAutomaticMaskGenerator(
             self._model,
-            points_per_side=32,
-            pred_iou_thresh=0.9,
-            stability_score_thresh=0.92,
-            crop_n_layers=1,
-            crop_n_points_downscale_factor=2,
-            min_mask_region_area=400,
+            **self.config.amg_kwargs,
         )
         masks = [
             mask_generator.generate(

--- a/fiftyone/utils/sam.py
+++ b/fiftyone/utils/sam.py
@@ -212,10 +212,10 @@ class SegmentAnythingModel(fout.TorchImageModel, fom.SamplesMixin):
         return self._predict_all(imgs)
 
 
-def generate_sam_points(points, w, h):
+def generate_sam_points(points, w, h, negative=False):
     # Written by Jacob Marks, modified by me
     scaled_points = np.array(points) * np.array([w, h])
-    labels = np.ones(len(points))
+    labels = np.zeros(len(points)) if negative else np.ones(len(points))
     return scaled_points, labels
 
 

--- a/fiftyone/utils/sam.py
+++ b/fiftyone/utils/sam.py
@@ -50,6 +50,72 @@ class SegmentAnythingModel(fout.TorchImageModel, fout.TorchSamplesMixin):
     """Wrapper for running `Segment Anything <https://segment-anything.com>`_
     inference.
 
+    Box prompt example::
+
+        import fiftyone as fo
+        import fiftyone.zoo as foz
+
+        dataset = foz.load_zoo_dataset(
+            "quickstart", max_samples=5, shuffle=True, seed=51
+        )
+
+        model = foz.load_zoo_model("segment-anything-vitb-torch")
+
+        # Prompt with boxes
+        dataset.apply_model(
+            model,
+            label_field="segmentations",
+            prompt_field="ground_truth",
+        )
+
+        session = fo.launch_app(dataset)
+
+    Keypoint prompt example::
+
+        import fiftyone as fo
+        import fiftyone.zoo as foz
+
+        dataset = foz.load_zoo_dataset(
+            "coco-2017",
+            split="validation",
+            label_types="detections",
+            classes=["person"],
+            max_samples=3,
+            only_matching=True,
+        )
+
+        # Generate some keypoints
+        model = foz.load_zoo_model("keypoint-rcnn-resnet50-fpn-coco-torch")
+        dataset.default_skeleton = model.skeleton
+        dataset.apply_model(model, label_field="gt")
+
+        model = foz.load_zoo_model("segment-anything-vitb-torch")
+
+        # Prompt with keypoints
+        dataset.apply_model(
+            model,
+            label_field="segmentations",
+            prompt_field="gt_keypoints",
+        )
+
+        session = fo.launch_app(dataset)
+
+    Automatic segmentation::
+
+        import fiftyone as fo
+        import fiftyone.zoo as foz
+
+        dataset = foz.load_zoo_dataset(
+            "quickstart", max_samples=5, shuffle=True, seed=51
+        )
+
+        model = foz.load_zoo_model("segment-anything-vitb-torch")
+
+        # Automatic segmentation
+        dataset.apply_model(model, label_field="auto", output_dir="/tmp/auto")
+
+        session = fo.launch_app(dataset)
+
     Args:
         config: a :class:`SegmentAnythingModelConfig`
     """

--- a/fiftyone/utils/sam.py
+++ b/fiftyone/utils/sam.py
@@ -100,7 +100,7 @@ class SegmentAnythingModel(fout.TorchImageModel, fout.TorchSamplesMixin):
 
         session = fo.launch_app(dataset)
 
-    Automatic segmentation::
+    Automatic segmentation example::
 
         import fiftyone as fo
         import fiftyone.zoo as foz

--- a/fiftyone/utils/sam.py
+++ b/fiftyone/utils/sam.py
@@ -5,12 +5,13 @@ import numpy as np
 import torch
 
 import fiftyone.core.utils as fou
+import fiftyone.core.models as fom
 import fiftyone.utils.torch as fout
 import fiftyone.zoo.models as fozm
 
 fou.ensure_torch()
 
-from segment_anything import SamAutomaticMaskGenerator
+from segment_anything import SamAutomaticMaskGenerator, SamPredictor
 
 
 class SegmentAnythingModelConfig(fout.TorchImageModelConfig, fozm.HasZooModel):
@@ -30,7 +31,7 @@ class SegmentAnythingModelConfig(fout.TorchImageModelConfig, fozm.HasZooModel):
         self.amg_kwargs = self.parse_dict(d, "amg_kwargs", default={})
 
 
-class SegmentAnythingModel(fout.TorchImageModel):
+class SegmentAnythingModel(fout.TorchImageModel, fom.SamplesMixin):
     """Wrapper for running 'segment-anything-model' from https://segment-anything.com/."""
 
     def _download_model(self, config):
@@ -72,6 +73,15 @@ class SegmentAnythingModel(fout.TorchImageModel):
         return torch.from_numpy(full_mask)
 
     def _forward_pass(self, inputs):
+        mode = self.field_type
+        if mode == "keypoints":
+            return self._forward_pass_points(inputs)
+        elif mode == "detections":
+            return self._forward_pass_boxes(inputs)
+        else:
+            return self._forward_pass_amg(inputs)
+
+    def _forward_pass_amg(self, inputs):
         mask_generator = SamAutomaticMaskGenerator(
             self._model,
             **self.config.amg_kwargs,
@@ -84,3 +94,90 @@ class SegmentAnythingModel(fout.TorchImageModel):
         ]
         masks = torch.stack([self._to_torch_output(m) for m in masks])
         return dict(out=masks)
+
+    def _forward_pass_points(self, inputs):
+        sam_predictor = SamPredictor(self._model)
+        for inp in inputs:
+            sam_predictor.set_image(self._to_numpy_input(inp))
+
+    def predict_all(self, imgs, samples=None):
+        if samples is not None:
+            self.prompts = [
+                self.get_labels(samples)
+            ]  # tolist because ragged_batches=True
+            self.class_labels = self.get_classes(samples)
+
+        return self._predict_all(imgs)
+
+    def _forward_pass_boxes(self, inputs):
+        # we have to change it to instance segmentations
+        self._output_processor = fout.InstanceSegmenterOutputProcessor(
+            self.class_labels
+        )
+
+        sam_predictor = SamPredictor(self._model)
+        outputs = []
+        for inp, detections in zip(inputs, self.prompts):
+            sam_predictor.set_image(self._to_numpy_input(inp))
+            h, w = inp.size(1), inp.size(2)
+            boxes = [d.bounding_box for d in detections.detections]
+            sam_boxes = np.array([fo_to_sam(box, w, h) for box in boxes])
+            input_boxes = torch.tensor(sam_boxes, device=sam_predictor.device)
+            transformed_boxes = sam_predictor.transform.apply_boxes_torch(
+                input_boxes, (h, w)
+            )
+
+            mask, _, _ = sam_predictor.predict_torch(
+                point_coords=None,
+                point_labels=None,
+                boxes=transformed_boxes,
+                multimask_output=False,
+            )
+            outputs.append(
+                {
+                    "boxes": input_boxes,
+                    "labels": torch.tensor(
+                        [
+                            self.class_labels.index(d.label)
+                            for d in detections.detections
+                        ],
+                        device=sam_predictor.device,
+                    ),
+                    "scores": torch.tensor(
+                        [
+                            d.confidence if d.confidence else 1.0
+                            for d in detections.detections
+                        ],
+                        device=sam_predictor.device,
+                    ),
+                    "masks": mask,
+                }
+            )
+
+        return outputs
+
+
+def generate_sam_points(keypoints, label, w, h):
+    # Written by Jacob Marks
+    def scale_keypoint(p):
+        return [p[0] * w, p[1] * h]
+
+    sam_points, sam_labels = [], []
+    for kp in keypoints:
+        if kp.label == label and kp.estimated_yes_no != "unsure":
+            sam_points.append(scale_keypoint(kp.points[0]))
+            sam_labels.append(bool(kp.estimated_yes_no == "yes"))
+
+    return np.array(sam_points), np.array(sam_labels)
+
+
+def fo_to_sam(box, img_width, img_height):
+    # Written by Jacob Marks
+    new_box = np.copy(np.array(box))
+    new_box[0] *= img_width
+    new_box[2] *= img_width
+    new_box[1] *= img_height
+    new_box[3] *= img_height
+    new_box[2] += new_box[0]
+    new_box[3] += new_box[1]
+    return np.round(new_box).astype(int)

--- a/fiftyone/utils/sam.py
+++ b/fiftyone/utils/sam.py
@@ -56,7 +56,7 @@ class SegmentAnythingModel(fout.TorchImageModel, fout.TorchSamplesMixin):
         import fiftyone.zoo as foz
 
         dataset = foz.load_zoo_dataset(
-            "quickstart", max_samples=5, shuffle=True, seed=51
+            "quickstart", max_samples=25, shuffle=True, seed=51
         )
 
         model = foz.load_zoo_model("segment-anything-vitb-torch")
@@ -80,7 +80,7 @@ class SegmentAnythingModel(fout.TorchImageModel, fout.TorchSamplesMixin):
             split="validation",
             label_types="detections",
             classes=["person"],
-            max_samples=3,
+            max_samples=25,
             only_matching=True,
         )
 
@@ -112,7 +112,7 @@ class SegmentAnythingModel(fout.TorchImageModel, fout.TorchSamplesMixin):
         model = foz.load_zoo_model("segment-anything-vitb-torch")
 
         # Automatic segmentation
-        dataset.apply_model(model, label_field="auto", output_dir="/tmp/auto")
+        dataset.apply_model(model, label_field="auto")
 
         session = fo.launch_app(dataset)
 

--- a/fiftyone/utils/sam.py
+++ b/fiftyone/utils/sam.py
@@ -1,17 +1,24 @@
-"""Segment-anything model integration.
 """
-import eta.core.utils as etau
-import numpy as np
-import torch
+`Segment Anything <https://segment-anything.com>`_ wrapper for the FiftyOne
+Model Zoo.
 
-import fiftyone.core.utils as fou
+| Copyright 2017-2023, Voxel51, Inc.
+| `voxel51.com <https://voxel51.com/>`_
+|
+"""
+import numpy as np
+
+import eta.core.utils as etau
+
 import fiftyone.core.models as fom
+import fiftyone.core.utils as fou
 import fiftyone.utils.torch as fout
 import fiftyone.zoo.models as fozm
 
 fou.ensure_torch()
+import torch
 
-from segment_anything import SamAutomaticMaskGenerator, SamPredictor
+sam = fou.lazy_import("segment_anything")
 
 
 class SegmentAnythingModelConfig(fout.TorchImageModelConfig, fozm.HasZooModel):
@@ -21,15 +28,17 @@ class SegmentAnythingModelConfig(fout.TorchImageModelConfig, fozm.HasZooModel):
     arguments.
 
     Args:
-        amg_kwargs: a dictionary of keyword arguments to pass to
-            ``SamAutomaticMaskGenerator``
-        points_mask_index: an optional index of the mask to use for each Keypoint output
+        amg_kwargs (None): a dictionary of keyword arguments to pass to
+            ``segment_anything.SamAutomaticMaskGenerator``
+        points_mask_index (None): an optional mask index to use for each
+            keypoint output
     """
 
     def __init__(self, d):
         d = self.init(d)
         super().__init__(d)
-        self.amg_kwargs = self.parse_dict(d, "amg_kwargs", default={})
+
+        self.amg_kwargs = self.parse_dict(d, "amg_kwargs", default=None)
         self.points_mask_index = self.parse_int(
             d, "points_mask_index", default=None
         )
@@ -38,7 +47,9 @@ class SegmentAnythingModelConfig(fout.TorchImageModelConfig, fozm.HasZooModel):
 
 
 class SegmentAnythingModel(fout.TorchImageModel, fom.SamplesMixin):
-    """Wrapper for running 'segment-anything-model' from https://segment-anything.com/."""
+    """Wrapper for running `Segment Anything <https://segment-anything.com>`_
+    inference.
+    """
 
     def _download_model(self, config):
         config.download_model_if_necessary()
@@ -49,65 +60,42 @@ class SegmentAnythingModel(fout.TorchImageModel, fom.SamplesMixin):
         self.preprocess = False
         return model
 
-    @staticmethod
-    def _to_numpy_input(tensor):
-        """Converts a float32 torch tensor to a uint8 numpy array.
+    def predict_all(self, imgs, samples=None):
+        if samples is not None:
+            self.prompts = [self.get_labels(samples)]
+            self.class_labels = self.get_classes(samples)
 
-        Args:
-            tensor: a float32 torch tensor
-
-        Returns:
-            a uint8 numpy array
-        """
-        return (tensor.cpu().numpy() * 255).astype("uint8").transpose(1, 2, 0)
-
-    @staticmethod
-    def _to_torch_output(model_output):
-        """Convert SAM's automatic mask output to a single mask torch tensor.
-
-        Args:
-            model_output: a list of masks from SAM's automatic mask generator
-
-        Returns:
-            a torch tensor of shape (num_masks, height, width)
-        """
-        masks = [one["segmentation"].astype(int) for one in model_output]
-        masks.insert(
-            0, np.zeros_like(model_output[0]["segmentation"])
-        )  # background
-        full_mask = np.stack(masks)
-        return torch.from_numpy(full_mask)
+        return self._predict_all(imgs)
 
     def _forward_pass(self, inputs):
         mode = self.field_type
+
         if mode == "keypoints":
             return self._forward_pass_points(inputs)
-        elif mode == "detections":
+
+        if mode == "detections":
             return self._forward_pass_boxes(inputs)
-        else:
-            return self._forward_pass_amg(inputs)
+
+        return self._forward_pass_amg(inputs)
 
     def _forward_pass_amg(self, inputs):
-        mask_generator = SamAutomaticMaskGenerator(
+        mask_generator = sam.SamAutomaticMaskGenerator(
             self._model,
-            **self.config.amg_kwargs,
+            **(self.config.amg_kwargs or {}),
         )
         masks = [
-            mask_generator.generate(
-                self._to_numpy_input(inp),
-            )
+            mask_generator.generate(self._to_numpy_input(inp))
             for inp in inputs
         ]
         masks = torch.stack([self._to_torch_output(m) for m in masks])
         return dict(out=masks)
 
     def _forward_pass_points(self, inputs):
-        # we will change to instance segmentations
         self._output_processor = fout.InstanceSegmenterOutputProcessor(
             self.class_labels
         )
 
-        sam_predictor = SamPredictor(self._model)
+        sam_predictor = sam.SamPredictor(self._model)
         outputs = []
         for inp, keypoints in zip(inputs, self.prompts):
             sam_predictor.set_image(self._to_numpy_input(inp))
@@ -117,7 +105,7 @@ class SegmentAnythingModel(fout.TorchImageModel, fom.SamplesMixin):
 
             # each keypoints object will generate its own instance segmentation
             for kp in keypoints.keypoints:
-                sam_points, sam_labels = generate_sam_points(kp.points, w, h)
+                sam_points, sam_labels = _to_sam_points(kp.points, w, h)
 
                 multi_mask, mask_scores, _ = sam_predictor.predict(
                     point_coords=sam_points,
@@ -156,18 +144,17 @@ class SegmentAnythingModel(fout.TorchImageModel, fom.SamplesMixin):
         return outputs
 
     def _forward_pass_boxes(self, inputs):
-        # we have to change it to instance segmentations
         self._output_processor = fout.InstanceSegmenterOutputProcessor(
             self.class_labels
         )
 
-        sam_predictor = SamPredictor(self._model)
+        sam_predictor = sam.SamPredictor(self._model)
         outputs = []
         for inp, detections in zip(inputs, self.prompts):
             sam_predictor.set_image(self._to_numpy_input(inp))
             h, w = inp.size(1), inp.size(2)
             boxes = [d.bounding_box for d in detections.detections]
-            sam_boxes = np.array([fo_to_sam(box, w, h) for box in boxes])
+            sam_boxes = np.array([_to_sam_box(box, w, h) for box in boxes])
             input_boxes = torch.tensor(sam_boxes, device=sam_predictor.device)
             transformed_boxes = sam_predictor.transform.apply_boxes_torch(
                 input_boxes, (h, w)
@@ -202,25 +189,27 @@ class SegmentAnythingModel(fout.TorchImageModel, fom.SamplesMixin):
 
         return outputs
 
-    def predict_all(self, imgs, samples=None):
-        if samples is not None:
-            self.prompts = [
-                self.get_labels(samples)
-            ]  # tolist because ragged_batches=True
-            self.class_labels = self.get_classes(samples)
+    @staticmethod
+    def _to_numpy_input(tensor):
+        return (tensor.cpu().numpy() * 255).astype("uint8").transpose(1, 2, 0)
 
-        return self._predict_all(imgs)
+    @staticmethod
+    def _to_torch_output(model_output):
+        masks = [one["segmentation"].astype(int) for one in model_output]
+
+        # background
+        masks.insert(0, np.zeros_like(model_output[0]["segmentation"]))
+
+        return torch.from_numpy(np.stack(masks))
 
 
-def generate_sam_points(points, w, h, negative=False):
-    # Written by Jacob Marks, modified by me
+def _to_sam_points(points, w, h, negative=False):
     scaled_points = np.array(points) * np.array([w, h])
     labels = np.zeros(len(points)) if negative else np.ones(len(points))
     return scaled_points, labels
 
 
-def fo_to_sam(box, img_width, img_height):
-    # Written by Jacob Marks
+def _to_sam_box(box, img_width, img_height):
     new_box = np.copy(np.array(box))
     new_box[0] *= img_width
     new_box[2] *= img_width

--- a/fiftyone/utils/sam.py
+++ b/fiftyone/utils/sam.py
@@ -259,7 +259,7 @@ class SegmentAnythingModel(fout.TorchImageModel, fout.TorchSamplesMixin):
 
 
 def _to_sam_input(tensor):
-    return (tensor.cpu().numpy() * 255).astype("uint8").transpose(1, 2, 0)
+    return (255 * tensor.cpu().numpy()).astype("uint8").transpose(1, 2, 0)
 
 
 def _to_sam_points(points, w, h, negative=False):
@@ -268,12 +268,12 @@ def _to_sam_points(points, w, h, negative=False):
     return scaled_points, labels
 
 
-def _to_sam_box(box, img_width, img_height):
+def _to_sam_box(box, w, h):
     new_box = np.copy(np.array(box))
-    new_box[0] *= img_width
-    new_box[2] *= img_width
-    new_box[1] *= img_height
-    new_box[3] *= img_height
+    new_box[0] *= w
+    new_box[2] *= w
+    new_box[1] *= h
+    new_box[3] *= h
     new_box[2] += new_box[0]
     new_box[3] += new_box[1]
     return np.round(new_box).astype(int)

--- a/fiftyone/utils/sam.py
+++ b/fiftyone/utils/sam.py
@@ -1,0 +1,84 @@
+"""Segment-anything model integration.
+"""
+import eta.core.utils as etau
+import numpy as np
+import torch
+
+import fiftyone.core.utils as fou
+import fiftyone.utils.torch as fout
+import fiftyone.zoo.models as fozm
+
+fou.ensure_torch()
+
+from segment_anything import SamAutomaticMaskGenerator
+
+
+class SegmentAnythingModelConfig(fout.TorchImageModelConfig, fozm.HasZooModel):
+    """Configuration for running a :class:`SegmentAnythingModel`.
+
+    See :class:`fiftyone.utils.torch.TorchImageModelConfig` for additional
+    arguments.
+    """
+
+    pass
+
+
+class SegmentAnythingModel(fout.TorchImageModel):
+    """Wrapper for running 'segment-anything-model' from https://segment-anything.com/."""
+
+    def _download_model(self, config):
+        config.download_model_if_necessary()
+
+    def _load_network(self, config):
+        entrypoint = etau.get_function(config.entrypoint_fcn)
+        model = entrypoint(checkpoint=config.model_path)
+        self.preprocess = False
+        return model
+
+    @staticmethod
+    def _to_numpy_input(tensor):
+        """Converts a float32 torch tensor to a uint8 numpy array.
+
+        Args:
+            tensor: a float32 torch tensor
+
+        Returns:
+            a uint8 numpy array
+        """
+        return (tensor.cpu().numpy() * 255).astype("uint8").transpose(1, 2, 0)
+
+    @staticmethod
+    def _to_torch_output(model_output):
+        """Convert SAM's automatic mask output to a single mask torch tensor.
+
+        Args:
+            model_output: a list of masks from SAM's automatic mask generator
+
+        Returns:
+            a torch tensor of shape (num_masks, height, width)
+        """
+        masks = [one["segmentation"].astype(int) for one in model_output]
+        masks.insert(
+            0, np.zeros_like(model_output[0]["segmentation"])
+        )  # background
+        full_mask = np.stack(masks)
+        return torch.from_numpy(full_mask)
+
+    def _forward_pass(self, inputs):
+        mask_generator = SamAutomaticMaskGenerator(
+            self._model,
+            points_per_side=32,
+            pred_iou_thresh=0.9,
+            stability_score_thresh=0.92,
+            crop_n_layers=1,
+            crop_n_points_downscale_factor=2,
+            min_mask_region_area=400,
+        )
+        masks = [
+            mask_generator.generate(
+                self._to_numpy_input(inp),
+            )
+            for inp in inputs
+        ]
+        masks = torch.stack([self._to_torch_output(m) for m in masks])
+        return dict(out=masks)

--- a/fiftyone/utils/torch.py
+++ b/fiftyone/utils/torch.py
@@ -402,8 +402,8 @@ class TorchImageModel(
             output, frame_size, confidence_thresh=self.config.confidence_thresh
         )
 
-    def _forward_pass(self, inputs):
-        return self._model(inputs)
+    def _forward_pass(self, imgs):
+        return self._model(imgs)
 
     def _parse_classes(self, config):
         if config.labels_string is not None:
@@ -504,6 +504,21 @@ class TorchImageModel(
         output_processor_cls = etau.get_class(config.output_processor_cls)
         kwargs = config.output_processor_args or {}
         return output_processor_cls(classes=self._classes, **kwargs)
+
+
+class TorchSamplesMixin(fom.SamplesMixin):
+    def predict(self, img, sample=None):
+        if isinstance(img, torch.Tensor):
+            imgs = img.unsqueeze(0)
+        else:
+            imgs = [img]
+
+        if sample is not None:
+            samples = [sample]
+        else:
+            samples = None
+
+        return self.predict_all(imgs, samples=samples)[0]
 
 
 class ToPILImage(object):

--- a/fiftyone/utils/torch.py
+++ b/fiftyone/utils/torch.py
@@ -880,7 +880,9 @@ class InstanceSegmenterOutputProcessor(OutputProcessor):
                 int(round(y1)) : int(round(y2)),
                 int(round(x1)) : int(round(x2)),
             ]
-            mask = mask > self.mask_thresh
+
+            if mask.dtype != bool:
+                mask = mask > self.mask_thresh
 
             detections.append(
                 fol.Detection(

--- a/fiftyone/utils/torch.py
+++ b/fiftyone/utils/torch.py
@@ -345,7 +345,7 @@ class TorchImageModel(
 
                 - A PIL image
                 - A uint8 numpy array (HWC)
-                - A Torch tensor (CWH)
+                - A Torch tensor (CHW)
 
         Returns:
             a :class:`fiftyone.core.labels.Label` instance or dict of

--- a/fiftyone/utils/torch.py
+++ b/fiftyone/utils/torch.py
@@ -395,6 +395,9 @@ class TorchImageModel(
 
         output = self._forward_pass(imgs)
 
+        if self._output_processor is None:
+            return output
+
         if self.has_logits:
             self._output_processor.store_logits = self.store_logits
 

--- a/fiftyone/utils/torch.py
+++ b/fiftyone/utils/torch.py
@@ -393,7 +393,7 @@ class TorchImageModel(
         if self._using_half_precision:
             imgs = imgs.half()
 
-        output = self._model(imgs)
+        output = self._forward_pass(imgs)
 
         if self.has_logits:
             self._output_processor.store_logits = self.store_logits
@@ -401,6 +401,9 @@ class TorchImageModel(
         return self._output_processor(
             output, frame_size, confidence_thresh=self.config.confidence_thresh
         )
+
+    def _forward_pass(self, inputs):
+        return self._model(inputs)
 
     def _parse_classes(self, config):
         if config.labels_string is not None:

--- a/fiftyone/zoo/models/manifest-torch.json
+++ b/fiftyone/zoo/models/manifest-torch.json
@@ -83,6 +83,42 @@
             "date_added": "2020-12-11 13:45:51"
         },
         {
+            "base_name": "segment-anything-vit_b-torch",
+            "base_filename": "sam_vit_b_01ec64.pth",
+            "version": null,
+            "description": "Segment Anything Model (SAM) from `Segment Anything <https://arxiv.org/abs/2304.02643>` with ViT-B/16 backbone trained on SA-1B",
+            "source": "https://segment-anything.com/",
+            "size_bytes": 732512,
+            "manager": {
+                "type": "fiftyone.core.models.ModelManager",
+                "config": {
+                    "url": "https://dl.fbaipublicfiles.com/segment_anything/sam_vit_b_01ec64.pth"
+                }
+            },
+            "default_deployment_config_dict": {
+                "type": "fiftyone.utils.sam.SegmentAnythingModel",
+                "config": {
+                    "entrypoint_fcn": "segment_anything.build_sam.build_sam_vit_b",
+                    "entrypoint_args": {},
+                    "output_processor_cls": "fiftyone.utils.torch.SemanticSegmenterOutputProcessor",
+                    "image_dim": 1024,
+                    "image_mean": [123.675, 116.28, 103.53],
+                    "image_std": [58.395, 57.12, 57.375]
+                }
+            },
+            "requirements": {
+                "packages": ["torch", "torchvision", "segment-anything"],
+                "cpu": {
+                    "support": true
+                },
+                "gpu": {
+                    "support": true
+                }
+            },
+            "tags": ["segmentation", "sa-1b", "zero-shot", "torch"],
+            "date_added": "2023-05-12 11:40:51"
+        },
+        {
             "base_name": "deeplabv3-resnet50-coco-torch",
             "base_filename": "deeplabv3_resnet50_coco-cd0a2569.pth",
             "version": null,

--- a/fiftyone/zoo/models/manifest-torch.json
+++ b/fiftyone/zoo/models/manifest-torch.json
@@ -86,7 +86,7 @@
             "base_name": "segment-anything-vitb-torch",
             "base_filename": "sam_vit_b_01ec64.pth",
             "version": null,
-            "description": "Segment Anything Model (SAM) from `Segment Anything <https://arxiv.org/abs/2304.02643>` with ViT-B/16 backbone trained on SA-1B",
+            "description": "Segment Anything Model (SAM) from `Segment Anything <https://arxiv.org/abs/2304.02643>`_ with ViT-B/16 backbone trained on SA-1B",
             "source": "https://segment-anything.com",
             "size_bytes": 732512,
             "manager": {
@@ -112,14 +112,14 @@
                     "support": true
                 }
             },
-            "tags": ["segmentation", "sa-1b", "zero-shot", "torch"],
+            "tags": ["segment-anything", "sa-1b", "torch", "zero-shot"],
             "date_added": "2023-05-12 11:40:51"
         },
         {
             "base_name": "segment-anything-vith-torch",
             "base_filename": "sam_vit_h_4b8939.pth",
             "version": null,
-            "description": "Segment Anything Model (SAM) from `Segment Anything <https://arxiv.org/abs/2304.02643>` with ViT-H/16 backbone trained on SA-1B",
+            "description": "Segment Anything Model (SAM) from `Segment Anything <https://arxiv.org/abs/2304.02643>`_ with ViT-H/16 backbone trained on SA-1B",
             "source": "https://segment-anything.com",
             "size_bytes": 5008896,
             "manager": {
@@ -145,14 +145,14 @@
                     "support": true
                 }
             },
-            "tags": ["segmentation", "sa-1b", "zero-shot", "torch"],
+            "tags": ["segment-anything", "sa-1b", "torch", "zero-shot"],
             "date_added": "2023-05-12 11:40:51"
         },
         {
             "base_name": "segment-anything-vitl-torch",
             "base_filename": "sam_vit_l_0b3195.pth",
             "version": null,
-            "description": "Segment Anything Model (SAM) from `Segment Anything <https://arxiv.org/abs/2304.02643>` with ViT-L/16 backbone trained on SA-1B",
+            "description": "Segment Anything Model (SAM) from `Segment Anything <https://arxiv.org/abs/2304.02643>`_ with ViT-L/16 backbone trained on SA-1B",
             "source": "https://segment-anything.com",
             "size_bytes": 2440480,
             "manager": {
@@ -178,7 +178,7 @@
                     "support": true
                 }
             },
-            "tags": ["segmentation", "sa-1b", "zero-shot", "torch"],
+            "tags": ["segment-anything", "sa-1b", "torch", "zero-shot"],
             "date_added": "2023-05-12 11:40:51"
         },
         {
@@ -1835,6 +1835,7 @@
                 "logits",
                 "embeddings",
                 "torch",
+                "clip",
                 "zero-shot"
             ],
             "date_added": "2022-04-12 17:49:51"

--- a/fiftyone/zoo/models/manifest-torch.json
+++ b/fiftyone/zoo/models/manifest-torch.json
@@ -83,11 +83,11 @@
             "date_added": "2020-12-11 13:45:51"
         },
         {
-            "base_name": "segment-anything-vit_b-torch",
+            "base_name": "segment-anything-vitb-torch",
             "base_filename": "sam_vit_b_01ec64.pth",
             "version": null,
             "description": "Segment Anything Model (SAM) from `Segment Anything <https://arxiv.org/abs/2304.02643>` with ViT-B/16 backbone trained on SA-1B",
-            "source": "https://segment-anything.com/",
+            "source": "https://segment-anything.com",
             "size_bytes": 732512,
             "manager": {
                 "type": "fiftyone.core.models.ModelManager",
@@ -116,11 +116,11 @@
             "date_added": "2023-05-12 11:40:51"
         },
         {
-            "base_name": "segment-anything-vit_h-torch",
+            "base_name": "segment-anything-vith-torch",
             "base_filename": "sam_vit_h_4b8939.pth",
             "version": null,
             "description": "Segment Anything Model (SAM) from `Segment Anything <https://arxiv.org/abs/2304.02643>` with ViT-H/16 backbone trained on SA-1B",
-            "source": "https://segment-anything.com/",
+            "source": "https://segment-anything.com",
             "size_bytes": 5008896,
             "manager": {
                 "type": "fiftyone.core.models.ModelManager",
@@ -149,11 +149,11 @@
             "date_added": "2023-05-12 11:40:51"
         },
         {
-            "base_name": "segment-anything-vit_l-torch",
+            "base_name": "segment-anything-vitl-torch",
             "base_filename": "sam_vit_l_0b3195.pth",
             "version": null,
             "description": "Segment Anything Model (SAM) from `Segment Anything <https://arxiv.org/abs/2304.02643>` with ViT-L/16 backbone trained on SA-1B",
-            "source": "https://segment-anything.com/",
+            "source": "https://segment-anything.com",
             "size_bytes": 2440480,
             "manager": {
                 "type": "fiftyone.core.models.ModelManager",

--- a/fiftyone/zoo/models/manifest-torch.json
+++ b/fiftyone/zoo/models/manifest-torch.json
@@ -119,6 +119,78 @@
             "date_added": "2023-05-12 11:40:51"
         },
         {
+            "base_name": "segment-anything-vit_h-torch",
+            "base_filename": "sam_vit_h_4b8939.pth",
+            "version": null,
+            "description": "Segment Anything Model (SAM) from `Segment Anything <https://arxiv.org/abs/2304.02643>` with ViT-H/16 backbone trained on SA-1B",
+            "source": "https://segment-anything.com/",
+            "size_bytes": 5008896,
+            "manager": {
+                "type": "fiftyone.core.models.ModelManager",
+                "config": {
+                    "url": "https://dl.fbaipublicfiles.com/segment_anything/sam_vit_h_4b8939.pth"
+                }
+            },
+            "default_deployment_config_dict": {
+                "type": "fiftyone.utils.sam.SegmentAnythingModel",
+                "config": {
+                    "entrypoint_fcn": "segment_anything.build_sam.build_sam_vit_h",
+                    "entrypoint_args": {},
+                    "output_processor_cls": "fiftyone.utils.torch.SemanticSegmenterOutputProcessor",
+                    "image_dim": 1024,
+                    "image_mean": [123.675, 116.28, 103.53],
+                    "image_std": [58.395, 57.12, 57.375]
+                }
+            },
+            "requirements": {
+                "packages": ["torch", "torchvision", "segment-anything"],
+                "cpu": {
+                    "support": true
+                },
+                "gpu": {
+                    "support": true
+                }
+            },
+            "tags": ["segmentation", "sa-1b", "zero-shot", "torch"],
+            "date_added": "2023-05-12 11:40:51"
+        },
+        {
+            "base_name": "segment-anything-vit_l-torch",
+            "base_filename": "sam_vit_l_0b3195.pth",
+            "version": null,
+            "description": "Segment Anything Model (SAM) from `Segment Anything <https://arxiv.org/abs/2304.02643>` with ViT-L/16 backbone trained on SA-1B",
+            "source": "https://segment-anything.com/",
+            "size_bytes": 2440480,
+            "manager": {
+                "type": "fiftyone.core.models.ModelManager",
+                "config": {
+                    "url": "https://dl.fbaipublicfiles.com/segment_anything/sam_vit_l_0b3195.pth"
+                }
+            },
+            "default_deployment_config_dict": {
+                "type": "fiftyone.utils.sam.SegmentAnythingModel",
+                "config": {
+                    "entrypoint_fcn": "segment_anything.build_sam.build_sam_vit_l",
+                    "entrypoint_args": {},
+                    "output_processor_cls": "fiftyone.utils.torch.SemanticSegmenterOutputProcessor",
+                    "image_dim": 1024,
+                    "image_mean": [123.675, 116.28, 103.53],
+                    "image_std": [58.395, 57.12, 57.375]
+                }
+            },
+            "requirements": {
+                "packages": ["torch", "torchvision", "segment-anything"],
+                "cpu": {
+                    "support": true
+                },
+                "gpu": {
+                    "support": true
+                }
+            },
+            "tags": ["segmentation", "sa-1b", "zero-shot", "torch"],
+            "date_added": "2023-05-12 11:40:51"
+        },
+        {
             "base_name": "deeplabv3-resnet50-coco-torch",
             "base_filename": "deeplabv3_resnet50_coco-cd0a2569.pth",
             "version": null,

--- a/fiftyone/zoo/models/manifest-torch.json
+++ b/fiftyone/zoo/models/manifest-torch.json
@@ -100,10 +100,7 @@
                 "config": {
                     "entrypoint_fcn": "segment_anything.build_sam.build_sam_vit_b",
                     "entrypoint_args": {},
-                    "output_processor_cls": "fiftyone.utils.torch.SemanticSegmenterOutputProcessor",
-                    "image_dim": 1024,
-                    "image_mean": [123.675, 116.28, 103.53],
-                    "image_std": [58.395, 57.12, 57.375]
+                    "output_processor_cls": "fiftyone.utils.torch.SemanticSegmenterOutputProcessor"
                 }
             },
             "requirements": {
@@ -136,10 +133,7 @@
                 "config": {
                     "entrypoint_fcn": "segment_anything.build_sam.build_sam_vit_h",
                     "entrypoint_args": {},
-                    "output_processor_cls": "fiftyone.utils.torch.SemanticSegmenterOutputProcessor",
-                    "image_dim": 1024,
-                    "image_mean": [123.675, 116.28, 103.53],
-                    "image_std": [58.395, 57.12, 57.375]
+                    "output_processor_cls": "fiftyone.utils.torch.SemanticSegmenterOutputProcessor"
                 }
             },
             "requirements": {
@@ -172,10 +166,7 @@
                 "config": {
                     "entrypoint_fcn": "segment_anything.build_sam.build_sam_vit_l",
                     "entrypoint_args": {},
-                    "output_processor_cls": "fiftyone.utils.torch.SemanticSegmenterOutputProcessor",
-                    "image_dim": 1024,
-                    "image_mean": [123.675, 116.28, 103.53],
-                    "image_std": [58.395, 57.12, 57.375]
+                    "output_processor_cls": "fiftyone.utils.torch.SemanticSegmenterOutputProcessor"
                 }
             },
             "requirements": {

--- a/tests/intensive/model_zoo_tests.py
+++ b/tests/intensive/model_zoo_tests.py
@@ -41,6 +41,11 @@ def test_semantic_segmentation_models():
     _apply_models(models)
 
 
+def test_sam():
+    models = ["segment-anything-vit_b-torch"]
+    _apply_models(models, max_samples=1)
+
+
 def test_keypoint_models():
     models = _get_models_with_tag("keypoints")
     _apply_person_keypoint_models(models)
@@ -49,7 +54,7 @@ def test_keypoint_models():
 def test_embedding_models():
     all_models = foz.list_zoo_models()
     _apply_embedding_models(all_models)
-    
+
 
 def test_logits_models():
     models = _get_models_with_tag("logits")
@@ -100,6 +105,7 @@ def _apply_models(
     batch_size=None,
     confidence_thresh=None,
     pass_confidence_thresh=False,
+    max_samples=10,
 ):
     if pass_confidence_thresh:
         kwargs = {"confidence_thresh": confidence_thresh}
@@ -111,7 +117,7 @@ def _apply_models(
         split="validation",
         dataset_name=fo.get_default_dataset_name(),
         shuffle=True,
-        max_samples=10,
+        max_samples=max_samples,
     )
 
     for idx, model_name in enumerate(model_names, 1):
@@ -213,7 +219,12 @@ def _apply_zero_shot_models(model_names):
         dataset.apply_model(model, label_field=label_field, batch_size=4)
 
         assert len(dataset.exists(label_field)) == len(dataset)
-        assert all([label in custom_labels for label in dataset.distinct(f"{label_field}.label")])
+        assert all(
+            [
+                label in custom_labels
+                for label in dataset.distinct(f"{label_field}.label")
+            ]
+        )
 
 
 def _apply_person_keypoint_models(model_names):

--- a/tests/intensive/model_zoo_tests.py
+++ b/tests/intensive/model_zoo_tests.py
@@ -43,9 +43,17 @@ def test_semantic_segmentation_models():
 
 def test_sam():
     models = ["segment-anything-vit_b-torch"]
+    # box prompts
     _apply_models(
         models,
-        max_samples=1,
+        max_samples=3,
+        batch_size=2,
+        apply_kwargs=dict(boxes_from="ground_truth"),
+    )
+    # auto mask generation
+    _apply_models(
+        models,
+        max_samples=2,
         model_kwargs=dict(pred_iou_thresh=0.9, min_mask_region_area=200),
     )
 
@@ -111,11 +119,14 @@ def _apply_models(
     pass_confidence_thresh=False,
     max_samples=10,
     model_kwargs=None,
+    apply_kwargs=None,
 ):
     if pass_confidence_thresh:
         kwargs = {"confidence_thresh": confidence_thresh}
     else:
         kwargs = {}
+    if apply_kwargs:
+        kwargs.update(apply_kwargs)
 
     dataset = foz.load_zoo_dataset(
         "coco-2017",

--- a/tests/intensive/model_zoo_tests.py
+++ b/tests/intensive/model_zoo_tests.py
@@ -129,9 +129,8 @@ def _get_models_with_tag(tag):
     return model_names
 
 
-def _detections_to_keypoint(detection_list):
-    """Create random points for each detection object and return Keypoints"""
-    results = []
+def _detections_to_keypoints(detection_list):
+    keypoints = []
     for detection in detection_list:
         n_points = random.randint(1, 5)
         x1, y1, w, h = detection.bounding_box
@@ -141,8 +140,9 @@ def _detections_to_keypoint(detection_list):
         )
         points = [rand_point() for _ in range(n_points)]
         keypoint = fo.Keypoint(points=points, label=detection.label)
-        results.append(keypoint)
-    return fo.Keypoints(keypoints=results)
+        keypoints.append(keypoint)
+
+    return fo.Keypoints(keypoints=keypoints)
 
 
 def _apply_models(
@@ -175,7 +175,7 @@ def _apply_models(
         field_name = kwargs[_SAM_PROMPT_FIELD]
         kp_field_name = field_name + "_points"
         detections = dataset.values(field_name + ".detections")
-        keypoints = [_detections_to_keypoint(d) for d in detections]
+        keypoints = [_detections_to_keypoints(d) for d in detections]
         dataset.set_values(kp_field_name, keypoints)
         kwargs[_SAM_PROMPT_FIELD] = kp_field_name
 

--- a/tests/intensive/model_zoo_tests.py
+++ b/tests/intensive/model_zoo_tests.py
@@ -43,7 +43,11 @@ def test_semantic_segmentation_models():
 
 def test_sam():
     models = ["segment-anything-vit_b-torch"]
-    _apply_models(models, max_samples=1)
+    _apply_models(
+        models,
+        max_samples=1,
+        model_kwargs=dict(pred_iou_thresh=0.9, min_mask_region_area=200),
+    )
 
 
 def test_keypoint_models():
@@ -106,6 +110,7 @@ def _apply_models(
     confidence_thresh=None,
     pass_confidence_thresh=False,
     max_samples=10,
+    model_kwargs=None,
 ):
     if pass_confidence_thresh:
         kwargs = {"confidence_thresh": confidence_thresh}
@@ -125,7 +130,7 @@ def _apply_models(
             "Running model %d/%d: '%s'" % (idx, len(model_names), model_name)
         )
 
-        model = foz.load_zoo_model(model_name)
+        model = foz.load_zoo_model(model_name, **(model_kwargs or {}))
 
         label_field = model_name.lower().replace("-", "_").replace(".", "_")
 


### PR DESCRIPTION
Polishes up @Rusteam's work from https://github.com/voxel51/fiftyone/pull/3019.

[Segment Anything](https://segment-anything.com/) is now officially available in the [FiftyOne Model Zoo](https://docs.voxel51.com/user_guide/model_zoo/index.html)! 📈 

## Box prompt example

```py
import fiftyone as fo
import fiftyone.zoo as foz

dataset = foz.load_zoo_dataset(
    "quickstart", max_samples=25, shuffle=True, seed=51
)

model = foz.load_zoo_model("segment-anything-vitb-torch")

# Prompt with boxes
dataset.apply_model(
    model,
    label_field="segmentations",
    prompt_field="ground_truth",
)

session = fo.launch_app(dataset)
```

## Keypoint prompt example

```py
import fiftyone as fo
import fiftyone.zoo as foz

dataset = foz.load_zoo_dataset(
    "coco-2017",
    split="validation",
    label_types="detections",
    classes=["person"],
    max_samples=25,
    only_matching=True,
)

# Generate some keypoints
model = foz.load_zoo_model("keypoint-rcnn-resnet50-fpn-coco-torch")
dataset.default_skeleton = model.skeleton
dataset.apply_model(model, label_field="gt")

model = foz.load_zoo_model("segment-anything-vitb-torch")

# Prompt with keypoints
dataset.apply_model(
    model,
    label_field="segmentations",
    prompt_field="gt_keypoints",
)

session = fo.launch_app(dataset)
```

## Automatic segmentation example

```py
import fiftyone as fo
import fiftyone.zoo as foz

dataset = foz.load_zoo_dataset(
    "quickstart", max_samples=5, shuffle=True, seed=51
)

model = foz.load_zoo_model("segment-anything-vitb-torch")

# Automatic segmentation
dataset.apply_model(model, label_field="auto")

session = fo.launch_app(dataset)
```
