### PR TITLE
Reapply schema changes after selecting group slices

### DIFF
--- a/fiftyone/core/view.py
+++ b/fiftyone/core/view.py
@@ -1435,21 +1435,22 @@ class DatasetView(foc.SampleCollection):
             # @note(SelectGroupSlices)
             # Special case: when selecting group slices of a video dataset that
             # modifies the dataset's schema, frame lookups must be injected in
-            # the middle of the stage's pipeline, after the group slice lookup
-            # but *before* the $project stages that reapply the schema change
-            if _contains_videos and isinstance(stage, fost.SelectGroupSlices):
+            # the middle of the stage's pipeline, after the group slice $lookup
+            # but *before* the $project stage(s) that reapply schema changes
+            if (
+                isinstance(stage, fost.SelectGroupSlices)
+                and _contains_videos
+                and _pipeline
+                and "$project" in _pipeline[-1]
+            ):
                 _pipeline0 = _pipeline
                 _pipeline = []
-                while "$project" in _pipeline0[-1]:
+                while _pipeline0 and "$project" in _pipeline0[-1]:
                     _pipeline.insert(0, _pipeline0.pop())
 
-                if _pipeline:
-                    _pipelines.append(_pipeline0)
-                    idx += 1
-
-                    _attach_frames_idx1 = idx
-                else:
-                    _pipeline = _pipeline0
+                idx += 1
+                _attach_frames_idx1 = idx
+                _pipelines.append(_pipeline0)
 
             _pipelines.append(_pipeline)
             _view = _view._add_view_stage(stage, validate=False)

--- a/fiftyone/core/view.py
+++ b/fiftyone/core/view.py
@@ -1391,12 +1391,14 @@ class DatasetView(foc.SampleCollection):
         _found_select_group_slice = False
         _attach_frames_idx = None
         _attach_frames_idx0 = None
+        _attach_frames_idx1 = None
 
         _contains_groups = self._dataset.media_type == fom.GROUP
         _group_slices = set()
         _attach_groups_idx = None
 
-        for idx, stage in enumerate(self._stages):
+        idx = 0
+        for stage in self._stages:
             if isinstance(stage, fost.SelectGroupSlices):
                 # We might need to reattach frames after `SelectGroupSlices`,
                 # since it involves a `$lookup` that resets the samples
@@ -1428,9 +1430,30 @@ class DatasetView(foc.SampleCollection):
 
                     _group_slices.update(_stage_group_slices)
 
-            # Generate stage's pipeline
-            _pipelines.append(stage.to_mongo(_view))
+            _pipeline = stage.to_mongo(_view)
+
+            # @note(SelectGroupSlices)
+            # Special case: when selecting group slices of a video dataset that
+            # modifies the dataset's schema, frame lookups must be injected in
+            # the middle of the stage's pipeline, after the group slice lookup
+            # but *before* the $project stages that reapply the schema change
+            if _contains_videos and isinstance(stage, fost.SelectGroupSlices):
+                _pipeline0 = _pipeline
+                _pipeline = []
+                while "$project" in _pipeline0[-1]:
+                    _pipeline.insert(0, _pipeline0.pop())
+
+                if _pipeline:
+                    _pipelines.append(_pipeline0)
+                    idx += 1
+
+                    _attach_frames_idx1 = idx
+                else:
+                    _pipeline = _pipeline0
+
+            _pipelines.append(_pipeline)
             _view = _view._add_view_stage(stage, validate=False)
+            idx += 1
 
         if _attach_frames_idx is None and (attach_frames or frames_only):
             _attach_frames_idx = len(_pipelines)
@@ -1438,6 +1461,9 @@ class DatasetView(foc.SampleCollection):
         #######################################################################
         # Insert frame lookup pipeline(s) if needed
         #######################################################################
+
+        if _attach_frames_idx1 is not None and _attach_frames_idx is not None:
+            _attach_frames_idx = _attach_frames_idx1
 
         if _attach_frames_idx0 is not None and _attach_frames_idx is not None:
             # Two lookups are required; manually do the **last** one and rely

--- a/tests/unittests/group_tests.py
+++ b/tests/unittests/group_tests.py
@@ -565,6 +565,39 @@ class GroupTests(unittest.TestCase):
         self.assertIn("field", mixed_view.get_field_schema())
         self.assertIn("field", mixed_view.get_frame_field_schema())
 
+        view = dataset.select_fields()
+
+        image_view = view.select_group_slices(media_type="image")
+
+        self.assertNotIn("field", image_view.get_field_schema())
+        for sample in image_view:
+            self.assertFalse(sample.has_field("field"))
+
+        image_dataset = image_view.clone()
+
+        self.assertNotIn("field", image_dataset.get_field_schema())
+        for sample in image_dataset:
+            self.assertFalse(sample.has_field("field"))
+
+        # @note(SelectGroupSlices)
+        video_view = view.select_group_slices(media_type="video")
+
+        self.assertNotIn("field", video_view.get_field_schema())
+        self.assertNotIn("field", video_view.get_frame_field_schema())
+        for sample in video_view:
+            self.assertFalse(sample.has_field("field"))
+            for frame in sample.frames.values():
+                self.assertFalse(frame.has_field("field"))
+
+        video_dataset = video_view.clone()
+
+        self.assertNotIn("field", video_dataset.get_field_schema())
+        self.assertNotIn("field", video_dataset.get_frame_field_schema())
+        for sample in video_dataset:
+            self.assertFalse(sample.has_field("field"))
+            for frame in sample.frames.values():
+                self.assertFalse(frame.has_field("field"))
+
     @drop_datasets
     def test_attached_groups(self):
         dataset = _make_group_dataset()

--- a/tests/unittests/group_tests.py
+++ b/tests/unittests/group_tests.py
@@ -567,6 +567,17 @@ class GroupTests(unittest.TestCase):
 
         view = dataset.select_fields()
 
+        # Cloning a grouped dataset maintains schema changes
+        group_dataset = view.clone()
+
+        self.assertNotIn("field", group_dataset.get_field_schema())
+        self.assertNotIn("field", group_dataset.get_frame_field_schema())
+        for sample in group_dataset:
+            self.assertFalse(sample.has_field("field"))
+            for frame in sample.frames.values():
+                self.assertFalse(frame.has_field("field"))
+
+        # Selecting group slices maintains schema changes
         image_view = view.select_group_slices(media_type="image")
 
         self.assertNotIn("field", image_view.get_field_schema())
@@ -580,6 +591,7 @@ class GroupTests(unittest.TestCase):
             self.assertFalse(sample.has_field("field"))
 
         # @note(SelectGroupSlices)
+        # Selecting group slices maintains frame schema changes
         video_view = view.select_group_slices(media_type="video")
 
         self.assertNotIn("field", video_view.get_field_schema())


### PR DESCRIPTION
Resolves https://github.com/voxel51/fiftyone/issues/3334.

`select_group_slices()` emits unfiltered samples, since it applies a fresh `$lookup` to retrieve slice data. However, the current implementation does *intend* maintain any schema changes (select/exclude fields) that were applied prior to the `select_group_slices()` stage. https://github.com/voxel51/fiftyone/issues/3334 identified a gap in the enforcement of this convention, which this PR patches.

## Notes

This PR is pretty ugly... which is a symptom of the tension between the inconsistency of *maintaining* schema changes while *not maintaining* field filters when selecting group slices.

Here's what it would look like to enforce a convention that `select_group_slices()` does *not* maintain schema changes (for consistency with how it does *not* maintain any field filters):

```py
view = dataset.select_fields()

### Case 1

# Presumably this should *not* contain fields that were selected above
dataset2 = view.clone()

### Case 2

# If flat_view does *not* maintain the schema change...
flat_view = view.select_group_slices()

# ... then this dataset *would* contain all original fields
dataset3 = flat_view.clone()
```

The trouble with this is that Case 1 and Case 2 have different behaviors, but `view.select_group_slices(_allow_mixed=True)` is used internally to implement Case 1...

An alternative attempt was made in https://github.com/voxel51/fiftyone/pull/3337, but it was closed because it was going to take more work to implement and was not necessarily what users would want anyway.