### PR TITLE
[WIP] Revert to dataset schema when selecting group slices

### DIFF
--- a/fiftyone/core/view.py
+++ b/fiftyone/core/view.py
@@ -1643,6 +1643,10 @@ class DatasetView(foc.SampleCollection):
 
         _view = self._base_view
         for stage in self._stages:
+            if isinstance(stage, fost.SelectGroupSlices):
+                selected_fields = None
+                excluded_fields = None
+
             sf = stage.get_selected_fields(_view, frames=frames)
             if sf:
                 if roots_only:

--- a/tests/unittests/group_tests.py
+++ b/tests/unittests/group_tests.py
@@ -565,6 +565,38 @@ class GroupTests(unittest.TestCase):
         self.assertIn("field", mixed_view.get_field_schema())
         self.assertIn("field", mixed_view.get_frame_field_schema())
 
+        view = dataset.select_fields()
+
+        image_view = view.select_group_slices(media_type="image")
+
+        self.assertIn("field", image_view.get_field_schema())
+        for sample in image_view:
+            self.assertTrue(sample.has_field("field"))
+
+        image_dataset = image_view.clone()
+
+        self.assertIn("field", image_dataset.get_field_schema())
+        for sample in image_dataset:
+            self.assertTrue(sample.has_field("field"))
+
+        video_view = view.select_group_slices(media_type="video")
+
+        self.assertIn("field", video_view.get_field_schema())
+        self.assertIn("field", video_view.get_frame_field_schema())
+        for sample in video_view:
+            self.assertTrue(sample.has_field("field"))
+            for frame in sample.frames.values():
+                self.assertTrue(frame.has_field("field"))
+
+        video_dataset = video_view.clone()
+
+        self.assertIn("field", video_dataset.get_field_schema())
+        self.assertIn("field", video_dataset.get_frame_field_schema())
+        for sample in video_dataset:
+            self.assertTrue(sample.has_field("field"))
+            for frame in sample.frames.values():
+                self.assertTrue(frame.has_field("field"))
+
     @drop_datasets
     def test_attached_groups(self):
         dataset = _make_group_dataset()

--- a/tests/unittests/group_tests.py
+++ b/tests/unittests/group_tests.py
@@ -567,6 +567,17 @@ class GroupTests(unittest.TestCase):
 
         view = dataset.select_fields()
 
+        # Cloning a grouped dataset maintains schema changes
+        group_dataset = view.clone()
+
+        self.assertNotIn("field", group_dataset.get_field_schema())
+        self.assertNotIn("field", group_dataset.get_frame_field_schema())
+        for sample in group_dataset:
+            self.assertFalse(sample.has_field("field"))
+            for frame in sample.frames.values():
+                self.assertFalse(frame.has_field("field"))
+
+        # Selecting group slices does *not* maintain schema changes
         image_view = view.select_group_slices(media_type="image")
 
         self.assertIn("field", image_view.get_field_schema())
@@ -579,6 +590,7 @@ class GroupTests(unittest.TestCase):
         for sample in image_dataset:
             self.assertTrue(sample.has_field("field"))
 
+        # Selecting group slices does *not* maintain frame schema changes
         video_view = view.select_group_slices(media_type="video")
 
         self.assertIn("field", video_view.get_field_schema())


### PR DESCRIPTION
`select_group_slices()` emits unfiltered samples, since it applies a fresh `$lookup` to retrieve slice data. However, the current implementation *does* maintain any schema changes (select/exclude fields) that were applied prior to the `select_group_slices()` stage.

One could argue that the inconsistent treatment of field and schema changes is bad; this PR attempts to make the behavior consistent: `select_group_slices()` will reset schema changes similar to how any field filters are no longer in effect.

Note that tests currently do not pass on this branch due to the tension described in https://github.com/voxel51/fiftyone/pull/3336. More work would need to be done here in order to fully adopt this approach.