### PR TITLE
Make stringify work for non np arrays

### DIFF
--- a/fiftyone/core/json.py
+++ b/fiftyone/core/json.py
@@ -81,13 +81,13 @@ def stringify(d, _cls=None):
         return d
 
     if isinstance(d, bytes):
-        if isinstance(d, bytes):
-            try:
-                # historically, bytes were used for numpy arrays
-                return _handle_numpy_array(d, _cls)
-            except:
-                # however, with plugins, bytes can represent other data
-                return str(d)
+        try:
+            # historically, bytes were used for numpy arrays
+            return _handle_numpy_array(d, _cls)
+        except:
+            # with plugins, bytes can represent other data, omit for non
+            return None
+
     elif isinstance(d, (date, datetime)):
         return _handle_date(d)
     elif isinstance(d, ObjectId):

--- a/fiftyone/core/json.py
+++ b/fiftyone/core/json.py
@@ -86,7 +86,7 @@ def stringify(d, _cls=None):
             return _handle_numpy_array(d, _cls)
         except:
             # with plugins, bytes can represent other data, omit for non
-            return None
+            return str(d)
 
     elif isinstance(d, (date, datetime)):
         return _handle_date(d)

--- a/fiftyone/core/json.py
+++ b/fiftyone/core/json.py
@@ -81,7 +81,13 @@ def stringify(d, _cls=None):
         return d
 
     if isinstance(d, bytes):
-        return _handle_numpy_array(d, _cls)
+        if isinstance(d, bytes):
+            try:
+                # historically, bytes were used for numpy arrays
+                return _handle_numpy_array(d, _cls)
+            except:
+                # however, with plugins, bytes can represent other data
+                return str(d)
     elif isinstance(d, (date, datetime)):
         return _handle_date(d)
     elif isinstance(d, ObjectId):


### PR DESCRIPTION
Add try/except around bytes conversion 
I think some of the plugins are sending non-numpy arrays as bytes in the response object, causing an error that prevents other plugins from getting loaded/executed

For example:
```
ERROR:root:cannot import name 'StringIO' from 'io' (/Users/kacey/Dev/voxel51/fiftyone-plugins/plugins/io/__init__.py)
Traceback (most recent call last):
  File "./fiftyone/server/decorators.py", line 29, in wrapper
    response = await func(endpoint, request, data, *args)
  File "./fiftyone/server/routes/samples.py", line 45, in post
    "results": await run_sync_task(
  File "./fiftyone/core/utils.py", line 1913, in run_sync_task
    return await loop.run_in_executor(get_sync_task_executor(), func, *args)
  File "/Users/kacey/.pyenv/versions/3.9.15/lib/python3.9/concurrent/futures/thread.py", line 58, in run
    result = self.fn(*self.args, **self.kwargs)
  File "./fiftyone/server/routes/samples.py", line 46, in <lambda>
    lambda: [stringify(edge.node) for edge in results.edges]
  File "./fiftyone/server/routes/samples.py", line 46, in <listcomp>
    lambda: [stringify(edge.node) for edge in results.edges]
  File "./fiftyone/core/json.py", line 71, in stringify
    d[k] = stringify(d[k], d.get("_cls", None))
  File "./fiftyone/core/json.py", line 71, in stringify
    d[k] = stringify(d[k], d.get("_cls", None))
  File "./fiftyone/core/json.py", line 71, in stringify
    d[k] = stringify(d[k], d.get("_cls", None))
  File "./fiftyone/core/json.py", line 79, in stringify
    d[i] = stringify(v)
  File "./fiftyone/core/json.py", line 71, in stringify
    d[k] = stringify(d[k], d.get("_cls", None))
  File "./fiftyone/core/json.py", line 84, in stringify
    return _handle_numpy_array(d, _cls)
  File "./fiftyone/core/json.py", line 35, in _handle_numpy_array
    array = fou.deserialize_numpy_array(raw)
  File "./fiftyone/core/utils.py", line 1454, in deserialize_numpy_array
    return np.load(f)
  File "./env/lib/python3.9/site-packages/numpy/lib/npyio.py", line 432, in load
    return format.read_array(fid, allow_pickle=allow_pickle,
  File "./env/lib/python3.9/site-packages/numpy/lib/format.py", line 776, in read_array
    shape, fortran_order, dtype = _read_array_header(
  File "./env/lib/python3.9/site-packages/numpy/lib/format.py", line 627, in _read_array_header
    header = _filter_header(header)
  File "./env/lib/python3.9/site-packages/numpy/lib/format.py", line 576, in _filter_header
    from io import StringIO
ImportError: cannot import name 'StringIO' from 'io' (/Users/kacey/Dev/voxel51/fiftyone-plugins/plugins/io/__init__.py)
```