### PR TITLE
Convert to mixed view for group datasets when making optimized sample collection

### DIFF
--- a/fiftyone/core/view.py
+++ b/fiftyone/core/view.py
@@ -1761,6 +1761,9 @@ def make_optimized_select_view(
     if groups:
         view = view.select_groups(sample_ids, ordered=ordered)
     else:
+        if view.media_type == fom.GROUP and view.group_slices:
+            view = view.select_group_slices(_allow_mixed=True)
+
         view = view.select(sample_ids, ordered=ordered)
 
     #

--- a/fiftyone/server/aggregations.py
+++ b/fiftyone/server/aggregations.py
@@ -120,6 +120,8 @@ async def aggregate_resolver(
         extended_stages=form.extended_stages,
         sample_filter=SampleFilter(
             group=GroupElementFilter(id=form.group_id, slices=form.slices)
+            if not form.sample_ids
+            else None
         ),
     )
 

--- a/fiftyone/server/routes/tag.py
+++ b/fiftyone/server/routes/tag.py
@@ -72,6 +72,8 @@ class Tag(HTTPEndpoint):
             sample_ids=sample_ids,
             sample_filter=SampleFilter(
                 group=GroupElementFilter(id=group_id, slices=slices)
+                if not sample_ids
+                else None
             ),
             target_labels=False,
         )

--- a/fiftyone/server/routes/tag.py
+++ b/fiftyone/server/routes/tag.py
@@ -47,6 +47,8 @@ class Tag(HTTPEndpoint):
             hidden_labels=hidden_labels,
             sample_filter=SampleFilter(
                 group=GroupElementFilter(id=group_id, slices=slices)
+                if not sample_ids
+                else None
             ),
             target_labels=target_labels,
             sample_ids=sample_ids,

--- a/fiftyone/server/routes/tagging.py
+++ b/fiftyone/server/routes/tagging.py
@@ -42,6 +42,8 @@ class Tagging(HTTPEndpoint):
             hidden_labels=hidden_labels,
             sample_filter=SampleFilter(
                 group=GroupElementFilter(id=group_id, slices=slices)
+                if not sample_ids
+                else None
             ),
             sample_ids=sample_ids,
             target_labels=target_labels,

--- a/fiftyone/server/tags.py
+++ b/fiftyone/server/tags.py
@@ -38,9 +38,6 @@ def get_tag_view(
     if sample_ids:
         view = fov.make_optimized_select_view(view, sample_ids)
 
-    if view.media_type == fom.GROUP and view.group_slices:
-        view = view.select_group_slices(_allow_mixed=True)
-
     if target_labels:
         if labels:
             view = view.select_labels(labels)

--- a/tests/unittests/view_tests.py
+++ b/tests/unittests/view_tests.py
@@ -3905,6 +3905,74 @@ class ViewStageTests(unittest.TestCase):
         ]
         self.assertEqual(optimized_view._all_stages, expected_stages)
 
+    def test_selected_samples_in_group_slices(self):
+        (dataset, selected_ids) = self._make_group_by_group_dataset()
+        view = dataset.view()
+        self.assertEqual(view.media_type, "group")
+
+        # treating sample_ids as groups will yield no sample
+        optimized_view = fov.make_optimized_select_view(
+            dataset, selected_ids[0], groups=True
+        )
+        self.assertEqual(len(optimized_view), 0)
+
+        # selects one sample from all group_slices
+        optimized_view = fov.make_optimized_select_view(
+            dataset, selected_ids[0], groups=False
+        )
+        self.assertEqual(len(optimized_view), 1)
+
+        # selects two sample from all group_slices
+        optimized_view = fov.make_optimized_select_view(
+            dataset, selected_ids[:2], groups=False
+        )
+        self.assertEqual(len(optimized_view), 2)
+
+    def _make_group_by_group_dataset(self):
+        dataset = fo.Dataset()
+        dataset.add_group_field("group_field", default="left")
+
+        group1 = fo.Group()
+        group2 = fo.Group()
+        group3 = fo.Group()
+
+        samples = [
+            fo.Sample(
+                filepath="left-image1.jpg",
+                group_field=group1.element("left"),
+                scene="foo",
+            ),
+            fo.Sample(
+                filepath="right-image1.jpg",
+                group_field=group1.element("right"),
+                scene="foo",
+            ),
+            fo.Sample(
+                filepath="left-image2.jpg",
+                group_field=group2.element("left"),
+                scene="foo",
+            ),
+            fo.Sample(
+                filepath="right-image2.jpg",
+                group_field=group2.element("right"),
+                scene="foo",
+            ),
+            fo.Sample(
+                filepath="left-image3.jpg",
+                group_field=group3.element("left"),
+                scene="bar",
+            ),
+            fo.Sample(
+                filepath="right-image3.jpg",
+                group_field=group3.element("right"),
+                scene="bar",
+            ),
+        ]
+
+        dataset.add_samples(samples)
+
+        return (dataset, [s.id for s in samples])
+
 
 if __name__ == "__main__":
     fo.config.show_progress_bars = False

--- a/tests/unittests/view_tests.py
+++ b/tests/unittests/view_tests.py
@@ -3899,7 +3899,10 @@ class ViewStageTests(unittest.TestCase):
         sample_ids = dataset.add_samples(samples)
 
         optimized_view = fov.make_optimized_select_view(dataset, sample_ids[0])
-        expected_stages = [fosg.Select(sample_ids[0])]
+        expected_stages = [
+            fosg.SelectGroupSlices(),
+            fosg.Select(sample_ids[0]),
+        ]
         self.assertEqual(optimized_view._all_stages, expected_stages)
 
 


### PR DESCRIPTION
When selecting multiple samples across slices in a group dataset in the modal, converting to a flat view ensures all samples are matched and no lookup occurs after the selection.

Supporting e2e and unit tests for `make_optimized_select_view` from @manivoxel51 and I will validate this change