### PR TITLE
Delegated operators CLI

### DIFF
--- a/docs/source/cli/index.rst
+++ b/docs/source/cli/index.rst
@@ -64,7 +64,7 @@ The FiftyOne command-line interface.
 .. code-block:: text
 
     fiftyone [-h] [-v] [--all-help]
-             {quickstart,annotation,app,config,constants,convert,datasets,migrate,utils,zoo}
+             {quickstart,annotation,brain,app,config,constants,convert,datasets,migrate,operators,delegated,plugins,utils,zoo}
              ...
 
 **Arguments**
@@ -77,17 +77,18 @@ The FiftyOne command-line interface.
       --all-help            show help recursively and exit
 
     available commands:
-      {quickstart,annotation,app,config,constants,convert,datasets,migrate,utils,zoo}
+      {quickstart,annotation,brain,app,config,constants,convert,datasets,migrate,operators,delegated,plugins,utils,zoo}
         quickstart          Launch a FiftyOne quickstart.
         annotation          Tools for working with the FiftyOne annotation API.
-        app                 Tools for working with the FiftyOne App.
         brain               Tools for working with the FiftyOne Brain.
+        app                 Tools for working with the FiftyOne App.
         config              Tools for working with your FiftyOne config.
         constants           Print constants from `fiftyone.constants`.
         convert             Convert datasets on disk between supported formats.
         datasets            Tools for working with FiftyOne datasets.
         migrate             Tools for migrating the FiftyOne database.
         operators           Tools for working with FiftyOne operators.
+        delegated           Tools for working with FiftyOne delegated operations.
         plugins             Tools for working with FiftyOne plugins.
         utils               FiftyOne utilities.
         zoo                 Tools for working with the FiftyOne Zoo.
@@ -868,6 +869,184 @@ Prints information about operators that you've downloaded or created locally.
 
     # Prints information about an operator
     fiftyone operators info <uri>
+
+.. _cli-fiftyone-delegated:
+
+FiftyOne delegated operations
+-----------------------------
+
+Tools for working with FiftyOne delegated operations.
+
+.. code-block:: text
+
+    fiftyone delegated [-h] [--all-help] {launch,list,info,cleanup} ...
+
+**Arguments**
+
+.. code-block:: text
+
+    optional arguments:
+      -h, --help   show this help message and exit
+      --all-help   show help recursively and exit
+
+    available commands:
+      {launch,list,info,cleanup}
+        launch              Launches a service for running delegated operations.
+        list                List delegated operations that you've run.
+        info                Prints information about a delegated operation that you've run.
+        cleanup             Cleanup delegated operations.
+
+.. _cli-fiftyone-delegated-launch:
+
+Launch delegated service
+------------------------
+
+Launches a service for running delegated operations.
+
+.. code-block:: text
+
+    fiftyone delegated launch [-h] [-t TYPE]
+
+**Arguments**
+
+.. code-block:: text
+
+    optional arguments:
+      -h, --help            show this help message and exit
+      -t TYPE, --type TYPE  the type of service to launch. The default is 'local'
+
+**Examples**
+
+.. code-block:: shell
+
+    # Launch a local service
+    fiftyone delegated launch
+
+.. _cli-fiftyone-delegated-list:
+
+List delegated operations
+-------------------------
+
+List delegated operations.
+
+.. code-block:: text
+
+    fiftyone delegated list [-h]
+                            [-o OPERATOR]
+                            [-d DATASET]
+                            [-s STATE]
+                            [--sort-by SORT_BY]
+                            [--reverse]
+                            [-l LIMIT]
+
+**Arguments**
+
+.. code-block:: text
+
+    optional arguments:
+      -h, --help            show this help message and exit
+      -o OPERATOR, --operator OPERATOR
+                            only list operations for this operator
+      -d DATASET, --dataset DATASET
+                            only list operations for this dataset
+      -s STATE, --state STATE
+                            only list operations with this state. Supported
+                            values are ('QUEUED', 'RUNNING', 'COMPLETED', 'FAILED')
+      --sort-by SORT_BY     how to sort the operations. Supported values are
+                            ('QUEUED_AT', 'STARTED_AT', COMPLETED_AT', 'FAILED_AT', 'OPERATOR')
+      --reverse             whether to sort in reverse order
+      -l LIMIT, --limit LIMIT
+                            a maximum number of operations to show
+
+**Examples**
+
+.. code-block:: shell
+
+    # List all delegated operations
+    fiftyone delegated list
+
+    # List some specific delegated operations
+    fiftyone delegated list \
+        --dataset quickstart \
+        --operator @voxel51/io/export_samples \
+        --state COMPLETED \
+        --sort-by COMPLETED_AT \
+        --limit 10
+
+.. _cli-fiftyone-delegated-info:
+
+Delegated operation info
+------------------------
+
+Prints information about a delegated operation.
+
+.. code-block:: text
+
+    fiftyone delegated info [-h] ID
+
+**Arguments**
+
+.. code-block:: text
+
+    positional arguments:
+      ID          the operation ID
+
+    optional arguments:
+      -h, --help  show this help message and exit
+
+**Examples**
+
+.. code-block:: shell
+
+    # Print information about a delegated operation
+    fiftyone delegated info <id>
+
+.. _cli-fiftyone-delegated-cleanup:
+
+Cleanup delegated operations
+----------------------------
+
+Cleanup delegated operations.
+
+.. code-block:: text
+
+    fiftyone delegated cleanup [-h]
+                               [-o OPERATOR]
+                               [-d DATASET]
+                               [-s STATE]
+                               [--orphan]
+                               [--dry-run]
+
+**Arguments**
+
+.. code-block:: text
+
+    optional arguments:
+      -h, --help            show this help message and exit
+      -o OPERATOR, --operator OPERATOR
+                            cleanup operations for this operator
+      -d DATASET, --dataset DATASET
+                            cleanup operations for this dataset
+      -s STATE, --state STATE
+                            delete operations in this state. Supported values
+                            are ('QUEUED', 'COMPLETED', 'FAILED')
+      --orphan              delete all operations associated with non-existent
+                            datasets
+      --dry-run             whether to print information rather than actually
+                            deleting operations
+
+**Examples**
+
+.. code-block:: shell
+
+    # Delete all failed operations associated with a given dataset
+    fiftyone delegated cleanup --dataset quickstart --state FAILED
+
+    # Delete all delegated operations associated with non-existent datasets
+    fiftyone delegated cleanup --orphan
+
+    # Print information about operations rather than actually deleting them
+    fiftyone delegated cleanup --orphan --dry-run
 
 .. _cli-fiftyone-plugins:
 

--- a/docs/source/cli/index.rst
+++ b/docs/source/cli/index.rst
@@ -892,14 +892,14 @@ Tools for working with FiftyOne delegated operations.
     available commands:
       {launch,list,info,cleanup}
         launch              Launches a service for running delegated operations.
-        list                List delegated operations that you've run.
-        info                Prints information about a delegated operation that you've run.
+        list                List delegated operations.
+        info                Prints information about a delegated operation.
         cleanup             Cleanup delegated operations.
 
 .. _cli-fiftyone-delegated-launch:
 
 Launch delegated service
-------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~
 
 Launches a service for running delegated operations.
 
@@ -925,7 +925,7 @@ Launches a service for running delegated operations.
 .. _cli-fiftyone-delegated-list:
 
 List delegated operations
--------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~
 
 List delegated operations.
 
@@ -976,7 +976,7 @@ List delegated operations.
 .. _cli-fiftyone-delegated-info:
 
 Delegated operation info
-------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~
 
 Prints information about a delegated operation.
 
@@ -1004,7 +1004,7 @@ Prints information about a delegated operation.
 .. _cli-fiftyone-delegated-cleanup:
 
 Cleanup delegated operations
-----------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Cleanup delegated operations.
 

--- a/fiftyone/core/cli.py
+++ b/fiftyone/core/cli.py
@@ -2777,7 +2777,8 @@ class DelegatedListCommand(Command):
         fiftyone delegated list \\
             --dataset quickstart \\
             --operator @voxel51/io/export_samples \\
-            --status COMPLETED \\
+            --state COMPLETED \\
+            --sort-by COMPLETED_AT \\
             --limit 10
     """
 

--- a/fiftyone/core/cli.py
+++ b/fiftyone/core/cli.py
@@ -2903,15 +2903,14 @@ def _print_delegated_list(ops):
 
     rows = []
     for op in ops:
-        state = _parse_state(op.run_state)
         rows.append(
             {
                 "id": op.id,
                 "operator": op.operator,
                 "dataset": op.context.request_params.get("dataset_name", None),
                 "queued_at": op.queued_at,
-                "state": op.run_state,
-                "completed": state == ExecutionRunState.COMPLETED,
+                "state": op.run_state.value,
+                "completed": op.run_state == ExecutionRunState.COMPLETED,
             }
         )
 
@@ -3058,8 +3057,7 @@ def _cleanup_delegated(operator=None, dataset=None, state=None, dry_run=False):
 
     del_ids = set()
     for op in ops:
-        state = _parse_state(op.run_state)
-        if state != ExecutionRunState.RUNNING:
+        if op.run_state != ExecutionRunState.RUNNING:
             del_ids.add(op.id)
 
     num_del = len(del_ids)

--- a/fiftyone/core/cli.py
+++ b/fiftyone/core/cli.py
@@ -30,6 +30,7 @@ import fiftyone.core.session as fos
 import fiftyone.core.utils as fou
 import fiftyone.migrations as fom
 import fiftyone.operators as foo
+import fiftyone.operators.delegated as food
 import fiftyone.plugins as fop
 import fiftyone.utils.data as foud
 import fiftyone.utils.image as foui
@@ -92,6 +93,7 @@ class FiftyOneCommand(Command):
         _register_command(subparsers, "datasets", DatasetsCommand)
         _register_command(subparsers, "migrate", MigrateCommand)
         _register_command(subparsers, "operators", OperatorsCommand)
+        _register_command(subparsers, "delegated", DelegatedCommand)
         _register_command(subparsers, "plugins", PluginsCommand)
         _register_command(subparsers, "utils", UtilsCommand)
         _register_command(subparsers, "zoo", ZooCommand)
@@ -2700,6 +2702,371 @@ def _print_operator_info(operator_uri):
 
     d = operator.config.to_json()
     _print_dict_as_table(d)
+
+
+class DelegatedCommand(Command):
+    """Tools for working with FiftyOne delegated operations."""
+
+    @staticmethod
+    def setup(parser):
+        subparsers = parser.add_subparsers(title="available commands")
+        _register_command(subparsers, "launch", DelegatedLaunchCommand)
+        _register_command(subparsers, "list", DelegatedListCommand)
+        _register_command(subparsers, "info", DelegatedInfoCommand)
+        _register_command(subparsers, "cleanup", DelegatedCleanupCommand)
+
+    @staticmethod
+    def execute(parser, args):
+        parser.print_help()
+
+
+class DelegatedLaunchCommand(Command):
+    """Launches a service for running delegated operations.
+
+    Examples::
+
+        # Launch a local service
+        fiftyone delegated launch --type local
+    """
+
+    @staticmethod
+    def setup(parser):
+        parser.add_argument(
+            "-t",
+            "--type",
+            default="local",
+            metavar="TYPE",
+            help="the type of service to launch. The default is 'local'",
+        )
+
+    @staticmethod
+    def execute(parser, args):
+        supported_types = ("local",)
+        if args.type not in supported_types:
+            raise ValueError(
+                "Unsupported service type '%s'. Supported values are %s"
+                % (args.type, supported_types)
+            )
+
+        if args.type == "local":
+            _launch_delegated_local()
+
+
+def _launch_delegated_local():
+    try:
+        dos = food.DelegatedOperation()
+
+        print("Delegated operation server running")
+        print("\nTo exit, press ctrl + c")
+        while True:
+            dos.execute_queued_operations(log=True)
+            time.sleep(1)
+    except KeyboardInterrupt:
+        pass
+
+
+class DelegatedListCommand(Command):
+    """List delegated operations that you've run.
+
+    Examples::
+
+        # List all delegated operations
+        fiftyone delegated list
+
+        # List some specific delegated operations
+        fiftyone delegated list \\
+            --dataset quickstart \\
+            --operator @voxel51/io/export_samples \\
+            --status COMPLETED \\
+            --limit 10
+    """
+
+    @staticmethod
+    def setup(parser):
+        parser.add_argument(
+            "-o",
+            "--operator",
+            default=None,
+            metavar="OPERATOR",
+            help="only list operations for this operator",
+        )
+        parser.add_argument(
+            "-d",
+            "--dataset",
+            default=None,
+            metavar="DATASET",
+            help="only list operations for this dataset",
+        )
+        parser.add_argument(
+            "-s",
+            "--state",
+            default=None,
+            help=(
+                "only list operations with this state. Supported values are: "
+                "('QUEUED', 'RUNNING', 'COMPLETED', 'FAILED')"
+            ),
+        )
+        parser.add_argument(
+            "--sort-by",
+            default="queued_at",
+            help=(
+                "how to sort the operations. Supported values are: "
+                "('QUEUED_AT', 'STARTED_AT', COMPLETED_AT', 'FAILED_AT', 'OPERATOR')"
+            ),
+        )
+        parser.add_argument(
+            "--reverse",
+            action="store_true",
+            default=None,
+            help="whether to sort in reverse order",
+        )
+        parser.add_argument(
+            "-l",
+            "--limit",
+            type=int,
+            default=None,
+            help="a maximum number of operations to show",
+        )
+
+    @staticmethod
+    def execute(parser, args):
+        dos = food.DelegatedOperation()
+
+        state = _parse_state(args.state)
+        paging = _parse_paging(
+            sort_by=args.sort_by, reverse=args.reverse, limit=args.limit
+        )
+
+        ops = dos.list_operations(
+            operator=args.operator,
+            dataset_name=args.dataset,
+            run_state=state,
+            paging=paging,
+        )
+
+        _print_delegated_list(ops)
+
+
+def _parse_state(state):
+    from fiftyone.operators.executor import ExecutionRunState
+
+    if state is not None:
+        try:
+            state = ExecutionRunState[state.upper()]
+        except:
+            raise ValueError("Invalid run state '%s'" % state)
+
+    return state
+
+
+def _parse_paging(sort_by=None, reverse=None, limit=None):
+    from fiftyone.factory import DelegatedOpPagingParams
+
+    sort_by = _parse_sort_by(sort_by)
+    sort_direction = _parse_reverse(reverse)
+    return DelegatedOpPagingParams(
+        sort_by=sort_by, sort_direction=sort_direction, limit=limit
+    )
+
+
+def _parse_sort_by(sort_by):
+    from fiftyone.factory import SortByField
+
+    if sort_by is not None:
+        try:
+            sort_by = SortByField[sort_by.upper()]
+        except:
+            raise ValueError("Invalid sort by '%s'" % sort_by)
+
+    return sort_by
+
+
+def _parse_reverse(reverse):
+    from fiftyone.factory import SortDirection
+
+    return SortDirection.ASCENDING if reverse else SortDirection.DESCENDING
+
+
+def _print_delegated_list(ops):
+    from fiftyone.operators.executor import ExecutionRunState
+
+    headers = [
+        "id",
+        "operator",
+        "dataset",
+        "queued_at",
+        "state",
+        "completed",
+    ]
+
+    rows = []
+    for op in ops:
+        state = _parse_state(op.run_state)
+        rows.append(
+            {
+                "id": op.id,
+                "operator": op.operator,
+                # @todo lookup by ID
+                "dataset": op.context.request_params.get("dataset_name", None),
+                "queued_at": op.queued_at,
+                "state": op.run_state,
+                "completed": state == ExecutionRunState.COMPLETED,
+            }
+        )
+
+    records = [tuple(_format_cell(r[key]) for key in headers) for r in rows]
+
+    table_str = tabulate(records, headers=headers, tablefmt=_TABLE_FORMAT)
+    print(table_str)
+
+
+class DelegatedInfoCommand(Command):
+    """Prints information about a delegated operation that you've run.
+
+    Examples::
+
+        # Print information about a delegated operation
+        fiftyone delegated info <id>
+    """
+
+    @staticmethod
+    def setup(parser):
+        parser.add_argument("id", metavar="ID", help="the operation ID")
+
+    @staticmethod
+    def execute(parser, args):
+        dos = food.DelegatedOperation()
+        op = dos.get(args.id)
+
+        _print_delegated_info(op)
+
+
+def _print_delegated_info(op):
+    d = op.config.to_dict()
+    _print_dict_as_json(d)
+
+
+class DelegatedCleanupCommand(Command):
+    """Cleanup delegated operations.
+
+    Examples::
+
+        # Delete all failed operations associated with a given dataset
+        fiftyone delegated cleanup --dataset quickstart --state FAILED
+
+        # Delete all delegated operations associated with non-existent datasets
+        fiftyone delegated cleanup --orphan
+
+        # Print information about operations rather than actually deleting them
+        fiftyone delegated cleanup --orphan --dry-run
+    """
+
+    @staticmethod
+    def setup(parser):
+        parser.add_argument(
+            "-o",
+            "--operator",
+            default=None,
+            metavar="OPERATOR",
+            help="cleanup operations for this operator",
+        )
+        parser.add_argument(
+            "-d",
+            "--dataset",
+            default=None,
+            metavar="DATASET",
+            help="cleanup operations for this dataset",
+        )
+        parser.add_argument(
+            "-s",
+            "--state",
+            default=None,
+            help=(
+                "delete operations in this state. Supported values are "
+                "('QUEUED', 'COMPLETED', 'FAILED')"
+            ),
+        )
+        parser.add_argument(
+            "--orphan",
+            action="store_true",
+            default=None,
+            help="delete all operations associated with non-existent datasets",
+        )
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            default=None,
+            help=(
+                "whether to print information rather than actually deleting "
+                "operations"
+            ),
+        )
+
+    @staticmethod
+    def execute(parser, args):
+        if args.orphan:
+            _cleanup_orphan_delegated(dry_run=args.dry_run)
+        elif args.operator or args.dataset or args.state:
+            state = _parse_state(args.state)
+            _cleanup_delegated(
+                operator=args.operator,
+                dataset=args.dataset,
+                state=state,
+                dry_run=args.dry_run,
+            )
+        else:
+            print("No cleanup options specified")
+
+
+def _cleanup_orphan_delegated(dry_run=False):
+    from fiftyone.core.odm import get_db_conn
+
+    db = get_db_conn()
+    dataset_ids = set(d["_id"] for d in db.datasets.find({}, {"_id": 1}))
+
+    dos = food.DelegatedOperation()
+    ops = dos.list_operations()
+
+    del_ids = set(op.id for op in ops if op.dataset_id not in dataset_ids)
+
+    num_del = len(del_ids)
+    if num_del == 0:
+        return
+
+    if dry_run:
+        print("Found %d orphan operation(s)" % num_del)
+    else:
+        print("Deleting %d orphan operation(s)" % num_del)
+        for del_id in del_ids:
+            dos.delete_operation(del_id)
+
+
+def _cleanup_delegated(operator=None, dataset=None, state=None, dry_run=False):
+    from fiftyone.operators.executor import ExecutionRunState
+
+    if state == ExecutionRunState.RUNNING:
+        raise ValueError(
+            "Deleting operations that are currently running is not allowed"
+        )
+
+    dos = food.DelegatedOperation()
+    ops = dos.list_operations(
+        operator=operator,
+        dataset_name=dataset,
+        run_state=state,
+    )
+    del_ids = set(op.id for op in ops)
+
+    num_del = len(del_ids)
+    if num_del == 0:
+        return
+
+    if dry_run:
+        print("Found %d operation(s) to delete" % num_del)
+    else:
+        print("Deleting %d operation(s)" % num_del)
+        for del_id in del_ids:
+            dos.delete_operation(del_id)
 
 
 class PluginsCommand(Command):

--- a/fiftyone/core/cli.py
+++ b/fiftyone/core/cli.py
@@ -2937,12 +2937,7 @@ class DelegatedInfoCommand(Command):
     def execute(parser, args):
         dos = food.DelegatedOperation()
         op = dos.get(ObjectId(args.id))
-
-        _print_delegated_info(op)
-
-
-def _print_delegated_info(op):
-    fo.pprint(op.to_pymongo())
+        fo.pprint(op._doc)
 
 
 class DelegatedCleanupCommand(Command):

--- a/fiftyone/core/cli.py
+++ b/fiftyone/core/cli.py
@@ -16,6 +16,7 @@ import time
 import textwrap
 
 import argcomplete
+from bson import ObjectId
 from tabulate import tabulate
 import webbrowser
 
@@ -2936,14 +2937,13 @@ class DelegatedInfoCommand(Command):
     @staticmethod
     def execute(parser, args):
         dos = food.DelegatedOperation()
-        op = dos.get(args.id)
+        op = dos.get(ObjectId(args.id))
 
         _print_delegated_info(op)
 
 
 def _print_delegated_info(op):
-    d = op.config.to_dict()
-    _print_dict_as_json(d)
+    fo.pprint(op.to_pymongo())
 
 
 class DelegatedCleanupCommand(Command):

--- a/fiftyone/core/cli.py
+++ b/fiftyone/core/cli.py
@@ -2756,7 +2756,7 @@ def _launch_delegated_local():
     try:
         dos = food.DelegatedOperation()
 
-        print("Delegated operation server running")
+        print("Delegated operation service running")
         print("\nTo exit, press ctrl + c")
         while True:
             dos.execute_queued_operations(log=True)
@@ -2907,7 +2907,6 @@ def _print_delegated_list(ops):
             {
                 "id": op.id,
                 "operator": op.operator,
-                # @todo lookup by ID
                 "dataset": op.context.request_params.get("dataset_name", None),
                 "queued_at": op.queued_at,
                 "state": op.run_state,
@@ -3056,7 +3055,12 @@ def _cleanup_delegated(operator=None, dataset=None, state=None, dry_run=False):
         dataset_name=dataset,
         run_state=state,
     )
-    del_ids = set(op.id for op in ops)
+
+    del_ids = set()
+    for op in ops:
+        state = _parse_state(op.run_state)
+        if state != ExecutionRunState.RUNNING:
+            del_ids.add(op.id)
 
     num_del = len(del_ids)
     if num_del == 0:

--- a/fiftyone/core/cli.py
+++ b/fiftyone/core/cli.py
@@ -2726,7 +2726,7 @@ class DelegatedLaunchCommand(Command):
     Examples::
 
         # Launch a local service
-        fiftyone delegated launch --type local
+        fiftyone delegated launch
     """
 
     @staticmethod
@@ -2766,7 +2766,7 @@ def _launch_delegated_local():
 
 
 class DelegatedListCommand(Command):
-    """List delegated operations that you've run.
+    """List delegated operations.
 
     Examples::
 
@@ -2803,7 +2803,7 @@ class DelegatedListCommand(Command):
             "--state",
             default=None,
             help=(
-                "only list operations with this state. Supported values are: "
+                "only list operations with this state. Supported values are "
                 "('QUEUED', 'RUNNING', 'COMPLETED', 'FAILED')"
             ),
         )
@@ -2811,7 +2811,7 @@ class DelegatedListCommand(Command):
             "--sort-by",
             default="queued_at",
             help=(
-                "how to sort the operations. Supported values are: "
+                "how to sort the operations. Supported values are "
                 "('QUEUED_AT', 'STARTED_AT', COMPLETED_AT', 'FAILED_AT', 'OPERATOR')"
             ),
         )
@@ -2921,7 +2921,7 @@ def _print_delegated_list(ops):
 
 
 class DelegatedInfoCommand(Command):
-    """Prints information about a delegated operation that you've run.
+    """Prints information about a delegated operation.
 
     Examples::
 

--- a/fiftyone/factory/__init__.py
+++ b/fiftyone/factory/__init__.py
@@ -12,8 +12,8 @@ class SortByField(Enum):
     QUEUED_AT = "queued_at"
     COMPLETED_AT = "completed_at"
     STARTED_AT = "started_at"
-    FAILED_At = "failed_at"
-    OPERATOR_NAME = "operator"
+    FAILED_AT = "failed_at"
+    OPERATOR = "operator"
 
 
 class SortDirection(Enum):

--- a/fiftyone/factory/__init__.py
+++ b/fiftyone/factory/__init__.py
@@ -8,26 +8,28 @@ FiftyOne Repository Factory
 from enum import Enum
 
 
+class SortByField(Enum):
+    QUEUED_AT = "queued_at"
+    COMPLETED_AT = "completed_at"
+    STARTED_AT = "started_at"
+    FAILED_At = "failed_at"
+    OPERATOR_NAME = "operator"
+
+
+class SortDirection(Enum):
+    ASCENDING = 1
+    DESCENDING = -1
+
+
 class DelegatedOpPagingParams(object):
-    class SortByField(Enum):
-        QUEUED_AT = "queued_at"
-        COMPLETED_AT = "completed_at"
-        STARTED_AT = "started_at"
-        FAILED_At = "failed_at"
-        OPERATOR_NAME = "operator"
-
-    class SortDirection(Enum):
-        ASCENDING = 1
-        DESCENDING = -1
-
     def __init__(
         self,
-        skip: int = 0,
-        limit: int = 10,
         sort_by: SortByField = SortByField.QUEUED_AT,
         sort_direction: SortDirection = SortDirection.DESCENDING,
+        skip: int = 0,
+        limit: int = 10,
     ):
-        self.skip = skip
-        self.limit = limit
         self.sort_by = sort_by
         self.sort_direction = sort_direction
+        self.skip = skip
+        self.limit = limit

--- a/fiftyone/factory/repos/delegated_operation.py
+++ b/fiftyone/factory/repos/delegated_operation.py
@@ -82,7 +82,6 @@ class MongoDelegatedOperationRepo(DelegatedOperationRepo):
         return database[self.COLLECTION_NAME]
 
     def queue_operation(self, **kwargs: Any) -> DelegatedOperationDocument:
-
         op = DelegatedOperationDocument()
         for prop in self.required_props:
             if prop not in kwargs:
@@ -181,12 +180,15 @@ class MongoDelegatedOperationRepo(DelegatedOperationRepo):
             query[arg] = kwargs[arg]
 
         if paging:
-            docs = (
-                self._collection.find(query)
-                .skip(paging.skip)
-                .limit(paging.limit)
-                .sort(paging.sort_by.value, paging.sort_direction.value)
-            )
+            docs = self._collection.find(query)
+            if paging.sort_by.value:
+                docs = docs.sort(
+                    paging.sort_by.value, paging.sort_direction.value
+                )
+            if paging.skip:
+                docs = docs.skip(paging.skip)
+            if paging.limit:
+                docs = docs.limit(paging.limit)
         else:
             docs = self._collection.find(query)
         return [DelegatedOperationDocument().from_pymongo(doc) for doc in docs]

--- a/fiftyone/factory/repos/delegated_operation_doc.py
+++ b/fiftyone/factory/repos/delegated_operation_doc.py
@@ -47,7 +47,7 @@ class DelegatedOperationDocument(object):
         # required fields
         self.operator = doc["operator"]
         self.queued_at = doc["queued_at"]
-        self.run_state = ExecutionRunState(doc["run_state"]).value
+        self.run_state = ExecutionRunState(doc["run_state"])
 
         # optional fields
         self.delegation_target = (

--- a/fiftyone/operators/__init__.py
+++ b/fiftyone/operators/__init__.py
@@ -7,7 +7,7 @@ FiftyOne operators.
 """
 from .operator import Operator, OperatorConfig
 from .registry import OperatorRegistry, get_operator, list_operators
-from .executor import execute_or_delegate_operator
+from .executor import execute_operator, execute_or_delegate_operator
 from .loader import PluginContext
 
 # This enables Sphinx refs to directly use paths imported here

--- a/fiftyone/operators/delegated.py
+++ b/fiftyone/operators/delegated.py
@@ -172,6 +172,6 @@ class DelegatedOperation(object):
         if isinstance(prepared, ExecutionResult):
             self.set_failed(doc_id=doc.id, result=prepared)
         else:
-            (operator, _, ctx) = prepared
+            operator, _, ctx = prepared
             self.set_running(doc_id=doc.id)
             return operator.execute(ctx)

--- a/fiftyone/operators/executor.py
+++ b/fiftyone/operators/executor.py
@@ -113,6 +113,7 @@ def execute_operator(operator_uri, ctx, params):
 
 
 def _parse_ctx(ctx):
+    # @todo add selected_labels
     dataset = ctx.get("dataset", None)
     view = ctx.get("view", None)
     selected = ctx.get("selected", None)

--- a/fiftyone/operators/executor.py
+++ b/fiftyone/operators/executor.py
@@ -10,7 +10,8 @@ import types as python_types
 import traceback
 from enum import Enum
 
-import fiftyone as fo
+import fiftyone.core.dataset as fod
+import fiftyone.core.view as fov
 import fiftyone.server.view as fosv
 import fiftyone.operators.types as types
 
@@ -90,22 +91,18 @@ def execute_operator(operator_uri, ctx, params):
 
     Args:
         operator_uri: the URI of the operator
-        ctx: a dictionary of parameters to define the execution context
+        ctx: a dictionary of parameters defining the execution context
         params: a dictionary of parameters for the operator
 
     Returns:
-        the result of the operator as a dictionary or ``None``
+        an :class:`ExecutionResult`
     """
-    dataset_name = ctx["dataset"].name
-    view = ctx.get("view", None)
-    if view is not None:
-        view = view._serialize()
-    selected = ctx.get("selected", None)
+    dataset_name, view_stages, selected = _parse_ctx(ctx)
 
     request_params = dict(
         operator_uri=operator_uri,
         dataset_name=dataset_name,
-        view=view,
+        view=view_stages,
         selected=selected,
         params=params,
     )
@@ -113,6 +110,30 @@ def execute_operator(operator_uri, ctx, params):
     return asyncio.run(
         execute_or_delegate_operator(operator_uri, request_params)
     )
+
+
+def _parse_ctx(ctx):
+    dataset = ctx.get("dataset", None)
+    view = ctx.get("view", None)
+    selected = ctx.get("selected", None)
+
+    if dataset is None and isinstance(view, fov.DatasetView):
+        dataset = view._root_dataset
+
+    if view is None:
+        if isinstance(dataset, str):
+            dataset = fod.load_dataset(dataset)
+
+        view = dataset.view()
+
+    view_stages = view._serialize()
+
+    if isinstance(dataset, fod.Dataset):
+        dataset_name = dataset.name
+    else:
+        dataset_name = dataset
+
+    return dataset_name, view_stages, selected
 
 
 async def execute_or_delegate_operator(operator_uri, request_params):
@@ -123,11 +144,13 @@ async def execute_or_delegate_operator(operator_uri, request_params):
         request_params: a dictionary of parameters for the operator
 
     Returns:
-        the result of the operator as a dictionary or ``None``
+        an :class:`ExecutionResult`
     """
-    operator, executor, ctx = prepare_operator_executor(
-        operator_uri, request_params
-    )
+    prepared = prepare_operator_executor(operator_uri, request_params)
+    if isinstance(prepared, ExecutionResult):
+        raise prepared.to_exception()
+    else:
+        operator, executor, ctx = prepared
 
     if operator.resolve_delegation(ctx):
         try:
@@ -178,7 +201,7 @@ def prepare_operator_executor(operator_uri, request_params):
     validation_ctx = ValidationContext(ctx, inputs, operator)
     if validation_ctx.invalid:
         return ExecutionResult(
-            error="Validation Error", validation_ctx=validation_ctx
+            error="Validation error", validation_ctx=validation_ctx
         )
 
     return operator, executor, ctx
@@ -275,7 +298,7 @@ class ExecutionContext(object):
     def dataset(self):
         """The :class:`fiftyone.core.dataset.Dataset` to operate on."""
         dataset_name = self.request_params.get("dataset_name", None)
-        d = fo.load_dataset(dataset_name)
+        d = fod.load_dataset(dataset_name)
         return d
 
     @property
@@ -349,6 +372,23 @@ class ExecutionResult(object):
         """Whether the result is a generator or an async generator."""
         return _is_generator(self.result)
 
+    def to_exception(self):
+        """Returns an :class:`ExecutionError` representing a failed execution
+        result.
+
+        Returns:
+            a :class:`ExecutionError`
+        """
+        msg = self.error
+
+        if self.validation_ctx.invalid:
+            val_error = self.validation_ctx.errors[0]
+            path = val_error.path.lstrip(".")
+            reason = val_error.reason
+            msg += f". Path: {path}. Reason: {reason}"
+
+        return ExecutionError(msg)
+
     def to_json(self):
         """Returns a JSON dict representation of the result.
 
@@ -363,6 +403,10 @@ class ExecutionResult(object):
             if self.validation_ctx
             else None,
         }
+
+
+class ExecutionError(Exception):
+    """An error that occurs while executing an operator."""
 
 
 class ValidationError(object):
@@ -407,13 +451,12 @@ class ValidationContext(object):
         self.ctx = ctx
         self.params = ctx.params
         self.inputs_property = inputs_property
-        self._errors = []
+        self.errors = []
         self.disable_schema_validation = (
             operator.config.disable_schema_validation
         )
         if self.inputs_property is None:
             self.invalid = False
-            self.errors = []
         else:
             self.errors = self._validate()
             self.invalid = len(self.errors) > 0
@@ -437,7 +480,7 @@ class ValidationContext(object):
         """
         if self.disable_schema_validation and error.custom != True:
             return
-        self._errors.append(error)
+        self.errors.append(error)
 
     def _validate(self):
         params = self.params
@@ -447,7 +490,7 @@ class ValidationContext(object):
         if validation_error:
             self.add_error(validation_error)
 
-        return self._errors
+        return self.errors
 
     def validate_enum(self, path, property, value):
         """Validates an enum value.


### PR DESCRIPTION
## Change log

- Adds a `fiftyone delegated` CLI command that supports a variety of useful actions related to delegated operators
- Adds a `foo.execute_operator()` method that supports programmatically execution of operators

## CLI examples

Launch a local service that will run all delegated operations:

```shell
fiftyone delegated launch
```

List delegated operations:

```shell
# List all operations
fiftyone delegated list

# List specific operations
fiftyone delegated list \
    --dataset quickstart \
    --operator @voxel51/io/export_samples \
    --state COMPLETED \
    --sort-by COMPLETED_AT \
    --limit 2
```

Cleanup delegated operations that you no longer want to keep records for:

```shell
# Delete all failed operations associated with a given dataset
fiftyone delegated cleanup --dataset quickstart --state FAILED

# Delete all delegated operations associated with non-existent datasets
fiftyone delegated cleanup --orphan

# Print information about operations rather than actually deleting them
fiftyone delegated cleanup --orphan --dry-run        
```

## Programmatically run an operation

```py
import fiftyone as fo
import fiftyone.zoo as foz
import fiftyone.operators as foo

dataset = foz.load_zoo_dataset("quickstart")

ctx = dict(dataset=dataset)

params = dict(
    target="DATASET",
    export_dir="/tmp/coco",
    export_type="LABELS_ONLY",
    dataset_type="COCO",
    label_field="ground_truth",
)

foo.execute_operator("@voxel51/io/export_samples", ctx, params)
```
