### PR TITLE
Add support for viewing group slices within embedding panel

### DIFF
--- a/app/packages/embeddings/src/fetch.tsx
+++ b/app/packages/embeddings/src/fetch.tsx
@@ -18,12 +18,19 @@ export async function fetchColorByChoices(params) {
   );
 }
 
-export async function fetchPlot({ datasetName, brainKey, view, labelField }) {
+export async function fetchPlot({
+  datasetName,
+  brainKey,
+  view,
+  labelField,
+  slices,
+}) {
   const res = await getFetchFunction()("POST", "/embeddings/plot", {
     datasetName,
     brainKey,
     view,
     labelField,
+    slices,
   });
   return handleErrors(res);
 }

--- a/app/packages/embeddings/src/useExtendedStageEffect.tsx
+++ b/app/packages/embeddings/src/useExtendedStageEffect.tsx
@@ -15,6 +15,7 @@ export default function useExtendedStageEffect() {
   const getCurrentDataset = useRecoilCallback(({ snapshot }) => async () => {
     return snapshot.getPromise(fos.datasetName);
   });
+  const slices = fos.currentSlices(false);
 
   useEffect(() => {
     if (loadedPlot && Array.isArray(selection)) {
@@ -23,6 +24,7 @@ export default function useExtendedStageEffect() {
         view,
         patchesField: loadedPlot.patches_field,
         selection,
+        slices,
       }).then(async (res) => {
         const currentDataset = await getCurrentDataset();
         if (currentDataset !== datasetName) return;

--- a/app/packages/embeddings/src/useSelectionEffect.tsx
+++ b/app/packages/embeddings/src/useSelectionEffect.tsx
@@ -16,6 +16,7 @@ export function useSelectionEffect() {
   const filters = useRecoilValue(fos.filters);
   const extended = useRecoilValue(fos.extendedStagesUnsorted);
   const { selection } = useRecoilValue(fos.extendedSelection);
+  const slices = fos.currentSlices(false);
 
   // updated the selection when the extended view updates
   useEffect(() => {
@@ -28,6 +29,7 @@ export function useSelectionEffect() {
         filters,
         extended: resolvedExtended,
         extendedSelection: selection,
+        slices,
       }).then((res) => {
         let resolved = null;
         if (res.selected) {

--- a/app/packages/embeddings/src/useViewChangeEffect.tsx
+++ b/app/packages/embeddings/src/useViewChangeEffect.tsx
@@ -13,6 +13,8 @@ export function useViewChangeEffect() {
   const [brainKey, setBrainKey] = useBrainResult();
   const [labelField] = useColorByField();
   const view = useRecoilValue(fos.view);
+  const slices = useRecoilValue(fos.currentSlices(false));
+  const filters = useRecoilValue(fos.filters);
   const [loadedPlot, setLoadedPlot] = usePanelStatePartial(
     "loadedPlot",
     null,
@@ -36,7 +38,7 @@ export function useViewChangeEffect() {
   useEffect(() => {
     setOverrideStage(null);
     setLoadingPlot(true);
-    fetchPlot({ datasetName, brainKey, view, labelField })
+    fetchPlot({ datasetName, filters, brainKey, view, labelField, slices })
       .catch((err) => {
         setLoadingPlotError(err);
         // setBrainKey(null);
@@ -72,5 +74,5 @@ export function useViewChangeEffect() {
         setLoadedPlot(res);
       })
       .finally(() => setLoadingPlot(false));
-  }, [datasetName, brainKey, labelField, view, colorSeed]);
+  }, [datasetName, brainKey, labelField, view, colorSeed, slices, filters]);
 }

--- a/fiftyone/server/routes/embeddings.py
+++ b/fiftyone/server/routes/embeddings.py
@@ -60,8 +60,6 @@ class OnPlotLoad(HTTPEndpoint):
             ) % brain_key
             return {"error": msg}
 
-        print(stages)
-
         view = fosv.get_view(
             dataset_name,
             stages=stages,

--- a/fiftyone/server/routes/embeddings.py
+++ b/fiftyone/server/routes/embeddings.py
@@ -17,6 +17,7 @@ from fiftyone.core.utils import run_sync_task
 from fiftyone.server.decorators import route
 import fiftyone.server.utils as fosu
 import fiftyone.server.view as fosv
+from fiftyone.server.filters import GroupElementFilter, SampleFilter
 
 
 MAX_CATEGORIES = 100
@@ -29,6 +30,11 @@ COLOR_BY_TYPES = (
 )
 
 
+def get_sample_filter(slices):
+    if slices:
+        return SampleFilter(group=GroupElementFilter(id=None, slices=slices))
+
+
 class OnPlotLoad(HTTPEndpoint):
     @route
     async def post(self, request: Request, data: dict) -> dict:
@@ -39,7 +45,9 @@ class OnPlotLoad(HTTPEndpoint):
         dataset_name = data["datasetName"]
         brain_key = data["brainKey"]
         stages = data["view"]
+        filters = data.get("filters", None)
         label_field = data["labelField"]
+        slices = data["slices"]
         dataset = fosu.load_and_cache_dataset(dataset_name)
 
         try:
@@ -52,7 +60,15 @@ class OnPlotLoad(HTTPEndpoint):
             ) % brain_key
             return {"error": msg}
 
-        view = fosv.get_view(dataset_name, stages=stages)
+        print(stages)
+
+        view = fosv.get_view(
+            dataset_name,
+            stages=stages,
+            filters=filters,
+            sample_filter=get_sample_filter(slices),
+        )
+
         is_patches_view = view._is_patches
 
         patches_field = results.config.patches_field
@@ -147,6 +163,7 @@ class EmbeddingsSelection(HTTPEndpoint):
         brain_key = data["brainKey"]
         stages = data["view"]
         filters = data["filters"]
+        slices = data["slices"]
         extended_stages = data["extended"]
         extended_selection = data["extendedSelection"]
 
@@ -156,7 +173,11 @@ class EmbeddingsSelection(HTTPEndpoint):
         dataset = fosu.load_and_cache_dataset(dataset_name)
         results = dataset.load_brain_results(brain_key)
 
-        view = fosv.get_view(dataset_name, stages=stages)
+        view = fosv.get_view(
+            dataset_name,
+            stages=stages,
+            sample_filter=get_sample_filter(slices),
+        )
         if results.view != view:
             results.use_view(view, allow_missing=True)
 
@@ -174,6 +195,7 @@ class EmbeddingsSelection(HTTPEndpoint):
                 stages=stages,
                 filters=filters,
                 extended_stages=extended_stages,
+                sample_filter=get_sample_filter(slices),
             )
             is_patches_view = extended_view._is_patches
 
@@ -213,8 +235,13 @@ class EmbeddingsExtendedStage(HTTPEndpoint):
         stages = data["view"]
         patches_field = data["patchesField"]  # patches field of plot, or None
         selected_ids = data["selection"]  # selected IDs in plot
+        slices = data["slices"]
 
-        view = fosv.get_view(dataset_name, stages=stages)
+        view = fosv.get_view(
+            dataset_name,
+            stages=stages,
+            sample_filter=get_sample_filter(slices),
+        )
 
         is_patches_view = view._is_patches
         is_patches_plot = patches_field is not None


### PR DESCRIPTION
Uses the current group slice to properly build a view for loading plot data for the embeddings panel. With this change you will now see corresponding samples that match the following:

1. the currently selected group slice
2. exist within the currently selected brain key (visualization)

Note: even with this change there is no simple "1 click" ux for showing multiple slices, even if they meet criteria 2.