### PR TITLE
Fixes activator, overwriting Visualizer and doc typos

### DIFF
--- a/app/packages/core/src/components/Modal/Sample3d.tsx
+++ b/app/packages/core/src/components/Modal/Sample3d.tsx
@@ -1,4 +1,4 @@
-import { PluginComponentType, usePlugin } from "@fiftyone/plugins";
+import { PluginComponentType, useActivePlugins } from "@fiftyone/plugins";
 import * as fos from "@fiftyone/state";
 import React, { Suspense, useMemo } from "react";
 
@@ -9,8 +9,10 @@ const PluginWrapper = () => {
   const groupId = useRecoilValue(fos.groupId);
   const { sample } = useRecoilValue(fos.modalSample);
 
-  const [plugin] = usePlugin(PluginComponentType.Visualizer);
   const dataset = useRecoilValue(fos.dataset);
+  const plugin = useActivePlugins(PluginComponentType.Visualizer, {
+    dataset,
+  }).pop();
 
   const pluginAPI = useMemo(
     () => ({

--- a/app/packages/looker-3d/src/Looker3dPlugin.tsx
+++ b/app/packages/looker-3d/src/Looker3dPlugin.tsx
@@ -18,6 +18,7 @@ typeof window !== "undefined" &&
     component: Looker3d,
     type: PluginComponentType.Visualizer,
     activator: ({ dataset }) =>
+      dataset.mediaType ??
       dataset.groupMediaTypes.find((g) => g.mediaType === "point_cloud") !==
-      undefined,
+        undefined,
   });

--- a/docs/source/plugins/index.rst
+++ b/docs/source/plugins/index.rst
@@ -722,7 +722,7 @@ Adding a custom FiftyOne Visualizer
 .. code-block:: jsx
 
     import * as fop from "@fiftyone/plugins";
-    import * as fos from "@fiftyone/visualizer";
+    import * as fos from "@fiftyone/state";
 
     function PointCloud({ src }) {
         // TODO: implement your visualizer using React
@@ -738,13 +738,19 @@ Adding a custom FiftyOne Visualizer
         return <PointCloud src={src} />;
     }
 
+    function myActivator({ dataset }) {
+        return dataset.mediaType ??
+            dataset.groupMediaTypes.find((g) => g.mediaType === "point_cloud") !==
+            undefined
+    }   
+
     fop.registerComponent({
         // component to delegate to
         component: CustomVisualizer,
         // tell FiftyOne you want to provide a Visualizer
-        type: PluginComponentTypes.Visualizer,
+        type: PluginComponentType.Visualizer,
         // activate this plugin when the mediaType is PointCloud
-        activator: ({ dataset }) => dataset.mediaType === "PointCloud",
+        activator: myActivator,
     });
 
 Adding a custom Plot


### PR DESCRIPTION
## What changes are proposed in this pull request?

Related to #3356 and PR from fiftyone-plugins  [#44](https://github.com/voxel51/fiftyone-plugins/pull/44). 

Call `useActivePlugins` instead of `usePlugin` for `Sample3d` components.
Use `pop()` to use the newest added Visualizer plugin.

Changed activator function of `Looker3d` to also work with non-group datasets. This worked before my fix, because the activator function was not used.

## How is this patch tested? If it is not, please explain why.

Tested with minimal plugin example in #3356 and PR from fiftyone-plugins  [#44](https://github.com/voxel51/fiftyone-plugins/pull/44).

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] No.


### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [x] Documentation: FiftyOne documentation changes
-   [ ] Other
