### PR TITLE
improve readonly mode in the app

### DIFF
--- a/app/packages/core/src/components/Actions/similar/Similar.tsx
+++ b/app/packages/core/src/components/Actions/similar/Similar.tsx
@@ -50,8 +50,7 @@ const SortBySimilarity = ({
 }: SortBySimilarityProps) => {
   const current = useRecoilValue(fos.similarityParameters);
   const datasetId = useRecoilValue(fos.dataset).id;
-  const [lastUsedBrainKeys, setLastUsedBrainKeys] =
-    useBrowserStorage("lastUsedBrainKeys");
+  const [lastUsedBrainKeys] = useBrowserStorage("lastUsedBrainKeys");
 
   const lastUsedBrainkey = useMemo(() => {
     return lastUsedBrainKeys ? JSON.parse(lastUsedBrainKeys)[datasetId] : null;
@@ -94,6 +93,7 @@ const SortBySimilarity = ({
     []
   );
   const isLoading = useRecoilValue(fos.similaritySorting);
+  const isReadOnly = useRecoilValue(fos.readOnly);
 
   useLayoutEffect(() => {
     if (!choices.choices.includes(state.brainKey)) {
@@ -277,16 +277,20 @@ const SortBySimilarity = ({
               setValue={(brainKey) => onChangeBrainKey(brainKey)}
             />
           </div>
-          Optional: store the distance between each sample and the query in this
-          field
-          <Input
-            placeholder={"dist_field (default = None)"}
-            validator={(value) => !value.startsWith("_")}
-            value={state.distField ?? ""}
-            setter={(value) =>
-              updateState({ distField: !value.length ? undefined : value })
-            }
-          />
+          {!isReadOnly && (
+            <>
+              Optional: store the distance between each sample and the query in
+              this field
+              <Input
+                placeholder={"dist_field (default = None)"}
+                validator={(value) => !value.startsWith("_")}
+                value={state.distField ?? ""}
+                setter={(value) =>
+                  updateState({ distField: !value.length ? undefined : value })
+                }
+              />
+            </>
+          )}
         </div>
       )}
     </Popout>

--- a/app/packages/core/src/components/ColorModal/ColorFooter.tsx
+++ b/app/packages/core/src/components/ColorModal/ColorFooter.tsx
@@ -23,7 +23,12 @@ export const resetColor = atom<number>({
 });
 
 const ColorFooter: React.FC = () => {
-  const canEdit = useRecoilValue(fos.canEditCustomColors);
+  const isReadOnly = useRecoilValue(fos.readOnly);
+  const canEditCustomColors = useRecoilValue(fos.canEditCustomColors);
+  const canEdit = useMemo(
+    () => !isReadOnly && canEditCustomColors,
+    [canEditCustomColors, isReadOnly]
+  );
   const setColorScheme = fos.useSetSessionColorScheme();
   const [activeColorModalField, setActiveColorModalField] = useRecoilState(
     fos.activeColorField

--- a/app/packages/core/src/components/Sidebar/Entries/Draggable.tsx
+++ b/app/packages/core/src/components/Sidebar/Entries/Draggable.tsx
@@ -1,8 +1,9 @@
 import { useTheme } from "@fiftyone/components";
-import { disabledPaths } from "@fiftyone/state";
+import { readOnly } from "@fiftyone/state";
 import { DragIndicator } from "@mui/icons-material";
 import { animated, useSpring } from "@react-spring/web";
 import React, { useState } from "react";
+import { useRecoilValue } from "recoil";
 
 const Draggable: React.FC<
   React.PropsWithChildren<{
@@ -18,11 +19,12 @@ const Draggable: React.FC<
   const theme = useTheme();
   const [hovering, setHovering] = useState(false);
   const [dragging, setDragging] = useState(false);
-
+  const isReadOnly = useRecoilValue(readOnly);
   const disableDrag =
     !entryKey ||
     entryKey.split(",")[1]?.includes("tags") ||
-    entryKey.split(",")[1]?.includes("_label_tags");
+    entryKey.split(",")[1]?.includes("_label_tags") ||
+    isReadOnly;
   const active = trigger && (dragging || hovering) && !disableDrag;
 
   const style = useSpring({
@@ -44,19 +46,20 @@ const Draggable: React.FC<
           event.stopPropagation();
         }}
         onMouseDown={
-          trigger
+          trigger && !isReadOnly
             ? (event) => {
                 setDragging(true);
                 trigger(event, entryKey, () => setDragging(false));
               }
-            : null
+            : undefined
         }
-        onMouseEnter={() => trigger && setHovering(true)}
-        onMouseLeave={() => setHovering(false)}
+        onMouseEnter={
+          isReadOnly ? undefined : () => trigger && setHovering(true)
+        }
+        onMouseLeave={isReadOnly ? undefined : () => setHovering(false)}
         style={{
           backgroundColor: color,
           position: "absolute",
-          left: 0,
           top: 0,
           zIndex: active ? 100 : 0,
           borderRadius: 2,

--- a/app/packages/core/src/components/Sidebar/ViewSelection/index.tsx
+++ b/app/packages/core/src/components/Sidebar/ViewSelection/index.tsx
@@ -46,6 +46,11 @@ export default function ViewSelection() {
   const setEditView = useSetRecoilState(viewDialogContent);
   const setView = fos.useSetView();
   const [viewSearch, setViewSearch] = useRecoilState<string>(viewSearchTerm);
+  const isReadOnly = useRecoilValue(fos.readOnly);
+  const canEdit = useMemo(
+    () => canEditSavedViews && !isReadOnly,
+    [canEditSavedViews, isReadOnly]
+  );
 
   const { savedViews: savedViewsV2 = [] } = fos.useSavedViews();
 
@@ -153,7 +158,7 @@ export default function ViewSelection() {
 
   useEffect(() => {
     const callback = (event: KeyboardEvent) => {
-      if (!canEditSavedViews) {
+      if (!canEdit) {
         return;
       }
       if ((event.metaKey || event.ctrlKey) && event.code === "KeyS") {
@@ -168,13 +173,13 @@ export default function ViewSelection() {
     return () => {
       document.removeEventListener("keydown", callback);
     };
-  }, [isEmptyView, canEditSavedViews]);
+  }, [isEmptyView, canEdit]);
 
   return (
     <Suspense fallback="Loading saved views...">
       <Box>
         <ViewDialog
-          canEdit={canEditSavedViews}
+          canEdit={canEdit}
           savedViews={items}
           onEditSuccess={(
             createSavedView: fos.State.SavedView,
@@ -211,7 +216,7 @@ export default function ViewSelection() {
           }}
         />
         <Selection
-          readonly={!canEditSavedViews}
+          readonly={!canEdit}
           selected={selected}
           setSelected={(item: fos.DatasetViewOption) => {
             setSelected(item);
@@ -240,15 +245,13 @@ export default function ViewSelection() {
           }}
           lastFixedOption={
             <LastOption
-              onClick={() =>
-                canEditSavedViews && !isEmptyView && setIsOpen(true)
-              }
-              disabled={isEmptyView || !canEditSavedViews}
+              onClick={() => canEdit && !isEmptyView && setIsOpen(true)}
+              disabled={isEmptyView || !canEdit}
             >
               <Box style={{ width: "12%" }}>
-                <AddIcon fontSize="small" disabled={isEmptyView} />
+                <AddIcon fontSize="small" disabled={isEmptyView || !canEdit} />
               </Box>
-              <TextContainer disabled={isEmptyView}>
+              <TextContainer disabled={isEmptyView || !canEdit}>
                 Save current filters as view
               </TextContainer>
             </LastOption>


### PR DESCRIPTION
## What changes are proposed in this pull request?

Improve the read-only mode in the app by extending it to actions below:
- Use the global read-only state for colour modal
- Use the global read-only state for saved views
- Disable the ability to similarity distance in a field
- Disable sidebar re-ordering

## How is this patch tested? If it is not, please explain why.

In the app with the global read-only mode enabled

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
