### PR TITLE
improve default value control for OperatorIO

### DIFF
--- a/app/packages/core/src/plugins/SchemaIO/components/AutocompleteView.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/AutocompleteView.tsx
@@ -4,6 +4,7 @@ import FieldWrapper from "./FieldWrapper";
 import autoFocus from "../utils/auto-focus";
 import { getComponentProps } from "../utils";
 import ChoiceMenuItemBody from "./ChoiceMenuItemBody";
+import { useKey } from "../hooks";
 
 export default function AutocompleteView(props) {
   const { onChange, path, schema, data } = props;
@@ -11,17 +12,22 @@ export default function AutocompleteView(props) {
   const { choices = [], readOnly } = view;
 
   const multiple = schema.type === "array";
+  const [key, setUserChanged] = useKey(path, schema);
 
   return (
     <FieldWrapper {...props}>
       <Autocomplete
+        key={key}
         disabled={readOnly}
         autoHighlight
         clearOnBlur={multiple}
         defaultValue={getDefaultValue(data ?? schema?.default, choices)}
         freeSolo
         size="small"
-        onChange={(e, choice) => onChange(path, choice?.value || choice)}
+        onChange={(e, choice) => {
+          onChange(path, choice?.value || choice);
+          setUserChanged();
+        }}
         options={choices.map((choice) => ({
           id: choice.value,
           label: choice.label || choice.value,

--- a/app/packages/core/src/plugins/SchemaIO/components/AutocompleteView.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/AutocompleteView.tsx
@@ -12,7 +12,7 @@ export default function AutocompleteView(props) {
   const { choices = [], readOnly } = view;
 
   const multiple = schema.type === "array";
-  const [key, setUserChanged] = useKey(path, schema);
+  const [key, setUserChanged] = useKey(path, schema, data, true);
 
   return (
     <FieldWrapper {...props}>
@@ -21,7 +21,7 @@ export default function AutocompleteView(props) {
         disabled={readOnly}
         autoHighlight
         clearOnBlur={multiple}
-        defaultValue={getDefaultValue(data ?? schema?.default, choices)}
+        defaultValue={getDefaultValue(data, choices)}
         freeSolo
         size="small"
         onChange={(e, choice) => {

--- a/app/packages/core/src/plugins/SchemaIO/components/CheckboxView.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/CheckboxView.tsx
@@ -3,18 +3,24 @@ import React from "react";
 import HeaderView from "./HeaderView";
 import autoFocus from "../utils/auto-focus";
 import { getComponentProps } from "../utils";
+import { useKey } from "../hooks";
 
 export default function CheckboxView(props) {
   const { onChange, path, schema, data } = props;
+  const [key, setUserChanged] = useKey(path, schema);
 
   return (
     <FormControlLabel
       control={
         <Checkbox
+          key={key}
           disabled={schema.view?.readOnly}
           autoFocus={autoFocus(props)}
           defaultChecked={data === true || schema.default === true}
-          onChange={(e, value) => onChange(path, value)}
+          onChange={(e, value) => {
+            onChange(path, value);
+            setUserChanged();
+          }}
           {...getComponentProps(props, "checkbox")}
         />
       }

--- a/app/packages/core/src/plugins/SchemaIO/components/CheckboxView.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/CheckboxView.tsx
@@ -7,7 +7,7 @@ import { useKey } from "../hooks";
 
 export default function CheckboxView(props) {
   const { onChange, path, schema, data } = props;
-  const [key, setUserChanged] = useKey(path, schema);
+  const [key, setUserChanged] = useKey(path, schema, data, true);
 
   return (
     <FormControlLabel
@@ -16,7 +16,7 @@ export default function CheckboxView(props) {
           key={key}
           disabled={schema.view?.readOnly}
           autoFocus={autoFocus(props)}
-          defaultChecked={data === true || schema.default === true}
+          defaultChecked={data === true}
           onChange={(e, value) => {
             onChange(path, value);
             setUserChanged();

--- a/app/packages/core/src/plugins/SchemaIO/components/CodeView.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/CodeView.tsx
@@ -9,9 +9,9 @@ import { useKey } from "../hooks";
 export default function CodeView(props) {
   const { mode } = useColorScheme();
   const { onChange, path, schema, data } = props;
-  const { default: defaultValue, view = {} } = schema;
+  const { view = {} } = schema;
   const { language, readOnly } = view;
-  const src = data ?? defaultValue;
+  const src = data;
   let height = view.height ?? 250;
   if (view.height === "auto") {
     const lineHeight = 19;
@@ -19,7 +19,7 @@ export default function CodeView(props) {
     height = lineHeight * numLines;
   }
 
-  const [key, setUserChanged] = useKey(path, schema);
+  const [key, setUserChanged] = useKey(path, schema, data, true);
 
   return (
     <Box
@@ -39,7 +39,7 @@ export default function CodeView(props) {
         key={key}
         height={height}
         theme={mode === "dark" ? "vs-dark" : "light"}
-        value={readOnly ? data : undefined}
+        value={data}
         defaultValue={src}
         onChange={(value) => {
           onChange(path, value);

--- a/app/packages/core/src/plugins/SchemaIO/components/CodeView.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/CodeView.tsx
@@ -4,6 +4,7 @@ import React from "react";
 import HeaderView from "./HeaderView";
 import autoFocus from "../utils/auto-focus";
 import { getComponentProps } from "../utils";
+import { useKey } from "../hooks";
 
 export default function CodeView(props) {
   const { mode } = useColorScheme();
@@ -17,6 +18,8 @@ export default function CodeView(props) {
     const numLines = src.split("\n").length;
     height = lineHeight * numLines;
   }
+
+  const [key, setUserChanged] = useKey(path, schema);
 
   return (
     <Box
@@ -33,11 +36,15 @@ export default function CodeView(props) {
     >
       <HeaderView {...props} nested />
       <Editor
+        key={key}
         height={height}
         theme={mode === "dark" ? "vs-dark" : "light"}
         value={readOnly ? data : undefined}
         defaultValue={src}
-        onChange={(value) => onChange(path, value)}
+        onChange={(value) => {
+          onChange(path, value);
+          setUserChanged();
+        }}
         language={language}
         options={{ readOnly }}
         onMount={(editor) => {

--- a/app/packages/core/src/plugins/SchemaIO/components/ColorView.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/ColorView.tsx
@@ -12,12 +12,12 @@ export default function ColorView(props) {
   const { view = {} } = schema;
   const { compact, variant, readOnly } = view;
   const [open, setOpen] = useState(false);
-  const [color, setColor] = useState(schema.default ?? data ?? fallbackColor);
+  const [color, setColor] = useState(data ?? fallbackColor);
   const [anchor, setAnchor] = React.useState<null | HTMLElement>(null);
   const Component = ColorPickers[variant] || ColorPickers.ChromePicker;
 
   const { bgColor, hexColor } = formatColor(color);
-  const [key, setUserChanged] = useKey(path, schema);
+  const [key, setUserChanged] = useKey(path, schema, data, true);
 
   const handleChange = useCallback(
     (color) => {
@@ -29,7 +29,7 @@ export default function ColorView(props) {
   );
 
   useEffect(() => {
-    setColor(schema.default ?? data ?? fallbackColor);
+    setColor(data ?? fallbackColor);
   }, [key]);
 
   return (

--- a/app/packages/core/src/plugins/SchemaIO/components/ColorView.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/ColorView.tsx
@@ -1,25 +1,36 @@
 import { Box, Popper, Stack, TextField } from "@mui/material";
-import React, { useEffect, useState } from "react";
+import React, { useCallback, useEffect, useState } from "react";
 import * as ColorPickers from "react-color";
 import { colorPicker } from "./ColorView.module.css";
 import HeaderView from "./HeaderView";
 import autoFocus from "../utils/auto-focus";
 import { getComponentProps } from "../utils";
+import { useKey } from "../hooks";
 
 export default function ColorView(props) {
   const { onChange, path, schema, data } = props;
   const { view = {} } = schema;
   const { compact, variant, readOnly } = view;
   const [open, setOpen] = useState(false);
-  const [color, setColor] = useState(data ?? defaultColor);
+  const [color, setColor] = useState(schema.default ?? data ?? fallbackColor);
   const [anchor, setAnchor] = React.useState<null | HTMLElement>(null);
   const Component = ColorPickers[variant] || ColorPickers.ChromePicker;
 
   const { bgColor, hexColor } = formatColor(color);
+  const [key, setUserChanged] = useKey(path, schema);
+
+  const handleChange = useCallback(
+    (color) => {
+      setColor(color);
+      onChange(path, color);
+      setUserChanged();
+    },
+    [onChange, path, setUserChanged]
+  );
 
   useEffect(() => {
-    onChange(path, color);
-  }, [color]);
+    setColor(schema.default ?? data ?? fallbackColor);
+  }, [key]);
 
   return (
     <Box {...getComponentProps(props, "container")}>
@@ -47,11 +58,12 @@ export default function ColorView(props) {
         />
         {!compact && (
           <TextField
+            key={key}
             autoFocus={autoFocus(props)}
             size="small"
             value={hexColor}
             onChange={(e) => {
-              setColor({ hex: e.target.value });
+              handleChange({ hex: e.target.value });
             }}
             disabled={readOnly}
             {...getComponentProps(props, "field")}
@@ -62,13 +74,12 @@ export default function ColorView(props) {
         open={open}
         anchorEl={anchor}
         placement="bottom-start"
+        sx={{ zIndex: (theme) => theme.zIndex.modal + 1 }}
         {...getComponentProps(props, "popper")}
       >
         <Component
           color={color.hsl || color.hex}
-          onChange={(color) => {
-            setColor(color);
-          }}
+          onChange={handleChange}
           className={colorPicker}
           {...getComponentProps(props, "picker")}
         />
@@ -77,19 +88,17 @@ export default function ColorView(props) {
   );
 }
 
-function formatColor(color) {
+function formatColor(color: ColorType) {
   const { hsl = {}, hex } = color;
   const { h, s, l, a } = hsl;
-  const bgColor = color.hsl
-    ? `hsla(${h},${s * 100}%,${l * 100}%,${a})`
-    : color.hex;
+  const bgColor = hsl ? `hsla(${h},${s * 100}%,${l * 100}%,${a})` : color.hex;
   const hexColor = (hex.startsWith("#") ? hex : `#${hex}`).toLowerCase();
   return { ...color, bgColor, hexColor };
 }
 
-const defaultColor: defaultColorType = { hex: "#FF6D05" };
+const fallbackColor: ColorType = { hex: "#FF6D05" };
 
-type defaultColorType = {
+type ColorType = {
   hex: string;
   hsl?: {
     h: number;

--- a/app/packages/core/src/plugins/SchemaIO/components/DropdownView.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/DropdownView.tsx
@@ -5,6 +5,7 @@ import autoFocus from "../utils/auto-focus";
 import AlertView from "./AlertView";
 import FieldWrapper from "./FieldWrapper";
 import ChoiceMenuItemBody from "./ChoiceMenuItemBody";
+import { useKey } from "../hooks";
 
 const MULTI_SELECT_TYPES = ["string", "array"];
 
@@ -48,9 +49,12 @@ export default function DropdownView(props) {
     return labels;
   }, {});
 
+  const [key, setUserChanged] = useKey(path, schema);
+
   return (
     <FieldWrapper {...props}>
       <Select
+        key={key}
         disabled={readOnly}
         autoFocus={autoFocus(props)}
         defaultValue={computedDefaultValue}
@@ -73,6 +77,7 @@ export default function DropdownView(props) {
               ? value.join(separator)
               : value;
           onChange(path, computedValue);
+          setUserChanged();
         }}
         multiple={multiple}
         {...getComponentProps(props, "select")}

--- a/app/packages/core/src/plugins/SchemaIO/components/DropdownView.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/DropdownView.tsx
@@ -11,7 +11,7 @@ const MULTI_SELECT_TYPES = ["string", "array"];
 
 export default function DropdownView(props) {
   const { onChange, schema, path, data } = props;
-  const { default: defaultValue, view = {}, type } = schema;
+  const { view = {}, type } = schema;
   const {
     choices,
     multiple: multiSelect,
@@ -19,6 +19,7 @@ export default function DropdownView(props) {
     separator = ",",
     readOnly,
   } = view;
+  const [key, setUserChanged] = useKey(path, schema, data, true);
 
   if (multiSelect && !MULTI_SELECT_TYPES.includes(type))
     return (
@@ -38,7 +39,7 @@ export default function DropdownView(props) {
   const isArrayType = type === "array";
   const multiple = multiSelect || isArrayType;
   const fallbackDefaultValue = multiple ? [] : "";
-  const rawDefaultValue = data ?? defaultValue ?? fallbackDefaultValue;
+  const rawDefaultValue = data ?? fallbackDefaultValue;
   const computedDefaultValue =
     multiple && !Array.isArray(rawDefaultValue)
       ? rawDefaultValue.toString().split(separator)
@@ -48,8 +49,6 @@ export default function DropdownView(props) {
     labels[choice.value] = choice.label;
     return labels;
   }, {});
-
-  const [key, setUserChanged] = useKey(path, schema);
 
   return (
     <FieldWrapper {...props}>

--- a/app/packages/core/src/plugins/SchemaIO/components/DynamicIO.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/DynamicIO.tsx
@@ -1,8 +1,9 @@
 import { PluginComponentType, useActivePlugins } from "@fiftyone/plugins";
+import { isPrimitiveType } from "@fiftyone/utilities";
 import { get } from "lodash";
 import React, { useEffect } from "react";
 import { getComponent, getErrorsForView } from "../utils";
-import { isNullish } from "@fiftyone/utilities";
+import { isPathUserChanged } from "../hooks";
 
 export default function DynamicIO(props) {
   const { data, schema, onChange, path, parentSchema, relativePath } = props;
@@ -17,10 +18,14 @@ export default function DynamicIO(props) {
 
   // todo: need to improve initializing default value in state
   useEffect(() => {
-    if (!isNullish(data)) return;
-    if (schema.default) onChange(path, defaultValue);
-    else if (type === "boolean") onChange(path, false);
-  }, []);
+    if (
+      isPrimitiveType(type) &&
+      data !== defaultValue &&
+      !isPathUserChanged(path)
+    ) {
+      onChange(path, defaultValue);
+    }
+  }, [defaultValue]);
 
   return (
     <Component

--- a/app/packages/core/src/plugins/SchemaIO/components/DynamicIO.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/DynamicIO.tsx
@@ -1,21 +1,34 @@
 import { PluginComponentType, useActivePlugins } from "@fiftyone/plugins";
+import { get } from "lodash";
 import React, { useEffect } from "react";
 import { getComponent, getErrorsForView } from "../utils";
 import { isNullish } from "@fiftyone/utilities";
 
 export default function DynamicIO(props) {
-  const { data, schema, onChange, path } = props;
+  const { data, schema, onChange, path, parentSchema, relativePath } = props;
   const customComponents = useCustomComponents();
   const Component = getComponent(schema, customComponents);
+  const computedSchema = schemaWithInheritedDefault(
+    schema,
+    parentSchema,
+    relativePath
+  );
+  const { default: defaultValue, type } = computedSchema;
 
   // todo: need to improve initializing default value in state
   useEffect(() => {
     if (!isNullish(data)) return;
-    if (schema.default) onChange(path, schema.default);
-    else if (schema.type === "boolean") onChange(path, false);
+    if (schema.default) onChange(path, defaultValue);
+    else if (type === "boolean") onChange(path, false);
   }, []);
 
-  return <Component {...props} validationErrors={getErrorsForView(props)} />;
+  return (
+    <Component
+      {...props}
+      schema={computedSchema}
+      validationErrors={getErrorsForView(props)}
+    />
+  );
 }
 
 function useCustomComponents() {
@@ -26,4 +39,11 @@ function useCustomComponents() {
     componentsByName[component.name] = component.component;
     return componentsByName;
   }, {});
+}
+
+function schemaWithInheritedDefault(schema, parentSchema, path) {
+  const providedDefault = get(schema, "default");
+  const inheritedDefault = get(parentSchema, `default.${path}`);
+  const computedDefault = providedDefault ?? inheritedDefault;
+  return { ...schema, default: computedDefault };
 }

--- a/app/packages/core/src/plugins/SchemaIO/components/Header.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/Header.tsx
@@ -29,7 +29,8 @@ export default function Header(props: HeaderProps) {
     !label &&
     !description &&
     (!caption || omitCaption) &&
-    (errors.length === 0 || omitErrors)
+    (errors.length === 0 || omitErrors) &&
+    !Actions
   ) {
     return null;
   }

--- a/app/packages/core/src/plugins/SchemaIO/components/ImageView.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/ImageView.tsx
@@ -5,7 +5,6 @@ import { getComponentProps } from "../utils";
 
 export default function ImageView(props) {
   const { schema, data } = props;
-  const { view = {} } = schema;
   const imageURI = data ?? schema?.default;
 
   return (

--- a/app/packages/core/src/plugins/SchemaIO/components/JSONView.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/JSONView.tsx
@@ -8,7 +8,7 @@ import { HeaderView } from ".";
 import { getComponentProps } from "../utils";
 
 export default function JSONView(props) {
-  const { data, schema } = props;
+  const { data } = props;
   const { mode } = useColorScheme();
   const isDarkMode = mode === "dark";
 
@@ -17,7 +17,7 @@ export default function JSONView(props) {
       <HeaderView {...props} nested />
       <ReactJSONContainer {...getComponentProps(props, "jsonContainer")}>
         <ReactJSON
-          src={data ?? schema?.default}
+          src={data}
           theme={`ashes${!isDarkMode ? ":inverted" : ""}`}
           style={{
             padding: "1rem",

--- a/app/packages/core/src/plugins/SchemaIO/components/ListView.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/ListView.tsx
@@ -2,12 +2,13 @@ import { Add, Delete } from "@mui/icons-material";
 import { Avatar, Box, Grid, IconButton } from "@mui/material";
 import { set } from "lodash";
 import React, { useEffect, useState } from "react";
-import { getComponentProps, getEmptyValue } from "../utils";
+import { getComponentProps, getEmptyValue, log } from "../utils";
 import Accordion from "./Accordion";
 import Button from "./Button";
 import DynamicIO from "./DynamicIO";
 import EmptyState from "./EmptyState";
 import HeaderView from "./HeaderView";
+import { NumberKeyObjectType } from "@fiftyone/utilities";
 
 export default function ListView(props) {
   const { schema, onChange, path, data, errors } = props;
@@ -52,6 +53,8 @@ export default function ListView(props) {
           </Grid>
         )}
         {Object.keys(state).map((id, index) => {
+          const fullPath = `${path}.${index}`;
+          const subPath = id.toString();
           const value = state[id];
           const ItemComponent = collapsible
             ? CollapsibleListItem
@@ -62,10 +65,13 @@ export default function ListView(props) {
               {...props}
               key={`${path}.${id}`}
               id={id}
-              path={id.toString()}
+              path={fullPath}
               index={index}
               data={value}
-              onChange={updateItem}
+              onChange={(path: string, value: unknown) => {
+                const relativePath = subPath + path.replace(fullPath, "");
+                updateItem(relativePath, value);
+              }}
               onDelete={deleteItem}
               errors={errors}
               schema={itemsSchema}
@@ -156,27 +162,29 @@ function DeleteButton(props) {
 
 function useListState(initialState: Array<unknown>) {
   let initialNextId = 0;
-  const initialStateById = initialState.reduce((stateById, item) => {
-    stateById[initialNextId++] = item;
-    return stateById;
-  }, {});
 
-  const [state, setState] = useState(initialStateById);
+  const [state, setState] = useState<NumberKeyObjectType>(() => {
+    const initialStateById: NumberKeyObjectType = {};
+    for (const item of initialState) {
+      initialStateById[initialNextId++] = item;
+    }
+    return initialStateById;
+  });
   const [nextId, setNextId] = useState(initialNextId);
 
-  function addItem(item) {
+  function addItem(item: unknown) {
     setState((state) => ({ ...state, [nextId]: item }));
     setNextId((nextId) => nextId + 1);
   }
 
-  function deleteItem(id) {
+  function deleteItem(id: number) {
     setState((state) => {
       const updatedState = { ...state };
       delete updatedState[id];
       return updatedState;
     });
   }
-  function updateItem(path, value) {
+  function updateItem(path: string, value: unknown) {
     setState((state) => {
       const updatedState = { ...state };
       set(updatedState, path, value);

--- a/app/packages/core/src/plugins/SchemaIO/components/ListView.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/ListView.tsx
@@ -71,6 +71,8 @@ export default function ListView(props) {
               schema={itemsSchema}
               readOnly={readOnly}
               hideIndexLabel={schema?.view?.hideIndexLabel}
+              parentSchema={schema}
+              relativePath={id}
             />
           );
         })}

--- a/app/packages/core/src/plugins/SchemaIO/components/ListView.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/ListView.tsx
@@ -2,7 +2,7 @@ import { Add, Delete } from "@mui/icons-material";
 import { Avatar, Box, Grid, IconButton } from "@mui/material";
 import { set } from "lodash";
 import React, { useEffect, useState } from "react";
-import { getComponentProps, getEmptyValue, log } from "../utils";
+import { getComponentProps, getEmptyValue } from "../utils";
 import Accordion from "./Accordion";
 import Button from "./Button";
 import DynamicIO from "./DynamicIO";

--- a/app/packages/core/src/plugins/SchemaIO/components/MapView.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/MapView.tsx
@@ -3,7 +3,7 @@ import ListView from "./ListView";
 import { getComponentProps } from "../utils";
 
 export default function MapView(props) {
-  const { id, schema, onChange, path, data, errors } = props;
+  const { id, schema, onChange, data } = props;
   const { additionalProperties, view = {} } = schema;
   const keyLabel = schema?.view?.key?.label || "Key";
 

--- a/app/packages/core/src/plugins/SchemaIO/components/MarkdownView.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/MarkdownView.tsx
@@ -122,7 +122,7 @@ const componentsMap = {
 };
 
 export default function MarkdownView(props) {
-  const { schema, data } = props;
+  const { data } = props;
 
   return (
     <Box {...getComponentProps(props, "container")}>
@@ -132,7 +132,7 @@ export default function MarkdownView(props) {
         remarkPlugins={[remarkGfm]}
         {...getComponentProps(props, "markdown")}
       >
-        {data || schema?.default}
+        {data}
       </ReactMarkdown>
     </Box>
   );

--- a/app/packages/core/src/plugins/SchemaIO/components/ObjectView.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/ObjectView.tsx
@@ -25,9 +25,10 @@ export default function ObjectView(props) {
       >
         {propertiesAsArray.map((property, i) => {
           const space = property?.view?.space || 12;
+          const { id } = property;
           return (
             <Grid
-              key={property.id}
+              key={id}
               item
               xs={space}
               {...getComponentProps(props, "gridItem")}
@@ -35,8 +36,10 @@ export default function ObjectView(props) {
               <DynamicIO
                 {...props}
                 schema={property}
-                path={getPath(path, property.id)}
-                data={data?.[property.id]}
+                path={getPath(path, id)}
+                data={data?.[id]}
+                parentSchema={schema}
+                relativePath={id}
               />
             </Grid>
           );

--- a/app/packages/core/src/plugins/SchemaIO/components/PlotlyView.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/PlotlyView.tsx
@@ -7,24 +7,22 @@ import { getComponentProps } from "../utils";
 
 export default function PlotlyView(props) {
   const { data, schema } = props;
-  const { default: defaultData, view = {} } = schema;
-  const { config = {}, layout = {}, onSelectionChange } = view;
+  const { view = {} } = schema;
+  const { config = {}, layout = {} } = view;
   const theme = useTheme();
 
-  // todo: ...
-  function handleSelectionChange(selection) {
-    // invoke operator in onSelectionChange
-    // onSelectionChange.execute(selection)
+  function handleSelectionChange() {
+    // invoke operator name in view.onSelectionChange
   }
 
   return (
     <Box {...getComponentProps(props, "container")}>
       <HeaderView {...props} nested />
       <Plot
-        data={data || defaultData}
+        data={data}
         style={{ zIndex: 1 }}
         onSelected={handleSelectionChange}
-        onDeselect={() => handleSelectionChange(null)}
+        onDeselect={() => handleSelectionChange()}
         config={{
           scrollZoom: true,
           displaylogo: false,

--- a/app/packages/core/src/plugins/SchemaIO/components/PopoutButton.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/PopoutButton.tsx
@@ -1,6 +1,6 @@
 import { IconButton, Popout } from "@fiftyone/components";
 import { useOutsideClick } from "@fiftyone/state";
-import { Box, Typography } from "@mui/material";
+import { Box } from "@mui/material";
 import React, { useRef, useState } from "react";
 
 // todo: convert to a view

--- a/app/packages/core/src/plugins/SchemaIO/components/RadioView.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/RadioView.tsx
@@ -8,11 +8,15 @@ import {
 import React from "react";
 import { HeaderView } from ".";
 import { autoFocus, getComponentProps } from "../utils";
+import { useKey } from "../hooks";
 
 export default function RadioView(props: RadioGroupProps) {
   const { schema, onChange, path, data } = props;
   const { view = {} } = schema;
   const { choices, label, description, orientation, readOnly } = view;
+
+  const [key, setUserChanged] = useKey(path, schema);
+
   return (
     <FormControl {...getComponentProps(props, "container")}>
       {(label || description) && (
@@ -24,9 +28,11 @@ export default function RadioView(props: RadioGroupProps) {
         </FormLabel>
       )}
       <MUIRadioGroup
-        defaultValue={data ?? schema.default}
+        key={key}
+        defaultValue={schema.default}
         onChange={(e, value) => {
           onChange(path, value);
+          setUserChanged();
         }}
         sx={{ alignItems: "flex-start" }}
         row={orientation !== "vertical"}
@@ -81,5 +87,5 @@ export type RadioGroupProps = {
   label?: string;
   description?: string;
   choices: Array<Choice>;
-  onChange: (selected: string) => void;
+  onChange: (path: string, value: string) => void;
 };

--- a/app/packages/core/src/plugins/SchemaIO/components/RadioView.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/RadioView.tsx
@@ -15,7 +15,7 @@ export default function RadioView(props: RadioGroupProps) {
   const { view = {} } = schema;
   const { choices, label, description, orientation, readOnly } = view;
 
-  const [key, setUserChanged] = useKey(path, schema);
+  const [key, setUserChanged] = useKey(path, schema, data, true);
 
   return (
     <FormControl {...getComponentProps(props, "container")}>
@@ -29,7 +29,7 @@ export default function RadioView(props: RadioGroupProps) {
       )}
       <MUIRadioGroup
         key={key}
-        defaultValue={schema.default}
+        defaultValue={data}
         onChange={(e, value) => {
           onChange(path, value);
           setUserChanged();
@@ -88,4 +88,7 @@ export type RadioGroupProps = {
   description?: string;
   choices: Array<Choice>;
   onChange: (path: string, value: string) => void;
+  schema: any; // todo
+  path: string;
+  data: unknown;
 };

--- a/app/packages/core/src/plugins/SchemaIO/components/SliderView.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/SliderView.tsx
@@ -2,9 +2,10 @@ import React, { useEffect, useRef } from "react";
 import { Slider } from "@mui/material";
 import FieldWrapper from "./FieldWrapper";
 import { autoFocus, getComponentProps } from "../utils";
+import { useKey } from "../hooks";
 
 export default function SliderView(props) {
-  const { data, onChange, path, schema } = props;
+  const { onChange, path, schema } = props;
   const sliderRef = useRef<HTMLInputElement>(null);
   const focus = autoFocus(props);
   const { min = 0, max = 100, multipleOf = 1 } = schema;
@@ -15,17 +16,21 @@ export default function SliderView(props) {
     }
   }, [sliderRef, focus]);
 
+  const [key, setUserChanged] = useKey(path, schema);
+
   return (
     <FieldWrapper {...props}>
       <Slider
         min={min}
         max={max}
         step={multipleOf}
+        key={key}
         disabled={schema.view?.readOnly}
         valueLabelDisplay="auto"
-        value={data ?? schema.default}
+        defaultValue={schema.default}
         onChange={(e, value) => {
           onChange(path, value);
+          setUserChanged();
         }}
         ref={sliderRef}
         {...getComponentProps(props, "slider")}

--- a/app/packages/core/src/plugins/SchemaIO/components/SliderView.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/SliderView.tsx
@@ -6,7 +6,7 @@ import { useKey } from "../hooks";
 import { isNumber } from "lodash";
 
 export default function SliderView(props) {
-  const { onChange, path, schema } = props;
+  const { data, onChange, path, schema } = props;
   const sliderRef = useRef<HTMLInputElement>(null);
   const focus = autoFocus(props);
   const { type, min, max, multipleOf } = schema;
@@ -22,7 +22,7 @@ export default function SliderView(props) {
     }
   }, [sliderRef, focus]);
 
-  const [key, setUserChanged] = useKey(path, schema);
+  const [key, setUserChanged] = useKey(path, schema, data, true);
 
   return (
     <FieldWrapper {...props}>
@@ -33,7 +33,7 @@ export default function SliderView(props) {
         key={key}
         disabled={schema.view?.readOnly}
         valueLabelDisplay="auto"
-        defaultValue={schema.default}
+        defaultValue={data}
         onChange={(e, value: string) => {
           onChange(path, type === "number" ? parseFloat(value) : value);
           setUserChanged();

--- a/app/packages/core/src/plugins/SchemaIO/components/SliderView.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/SliderView.tsx
@@ -3,12 +3,18 @@ import { Slider } from "@mui/material";
 import FieldWrapper from "./FieldWrapper";
 import { autoFocus, getComponentProps } from "../utils";
 import { useKey } from "../hooks";
+import { isNumber } from "lodash";
 
 export default function SliderView(props) {
   const { onChange, path, schema } = props;
   const sliderRef = useRef<HTMLInputElement>(null);
   const focus = autoFocus(props);
-  const { min = 0, max = 100, multipleOf = 1 } = schema;
+  const { type, min, max, multipleOf } = schema;
+  const computedMin = isNumber(min) ? min : 0;
+  const computedMax = isNumber(max) ? max : 100;
+  const computedMultipleOf = isNumber(multipleOf)
+    ? multipleOf
+    : (computedMax - computedMin) / 100;
 
   useEffect(() => {
     if (sliderRef.current && focus) {
@@ -21,15 +27,15 @@ export default function SliderView(props) {
   return (
     <FieldWrapper {...props}>
       <Slider
-        min={min}
-        max={max}
-        step={multipleOf}
+        min={computedMin}
+        max={computedMax}
+        step={computedMultipleOf}
         key={key}
         disabled={schema.view?.readOnly}
         valueLabelDisplay="auto"
         defaultValue={schema.default}
-        onChange={(e, value) => {
-          onChange(path, value);
+        onChange={(e, value: string) => {
+          onChange(path, type === "number" ? parseFloat(value) : value);
           setUserChanged();
         }}
         ref={sliderRef}

--- a/app/packages/core/src/plugins/SchemaIO/components/SwitchView.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/SwitchView.tsx
@@ -2,18 +2,25 @@ import { FormControlLabel, Switch } from "@mui/material";
 import React from "react";
 import { HeaderView } from ".";
 import { autoFocus, getComponentProps } from "../utils";
+import { useKey } from "../hooks";
 
 export default function SwitchView(props) {
-  const { schema, data, onChange, path } = props;
+  const { onChange, path, schema, data } = props;
+
+  const [key, setUserChanged] = useKey(path, schema);
 
   return (
     <FormControlLabel
       control={
         <Switch
+          key={key}
           disabled={schema.view?.readOnly}
           autoFocus={autoFocus(props)}
           defaultChecked={data === true || schema.default === true}
-          onChange={(e, checked) => onChange(path, checked)}
+          onChange={(e, checked) => {
+            onChange(path, checked);
+            setUserChanged();
+          }}
           {...getComponentProps(props, "switch")}
         />
       }

--- a/app/packages/core/src/plugins/SchemaIO/components/SwitchView.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/SwitchView.tsx
@@ -7,7 +7,7 @@ import { useKey } from "../hooks";
 export default function SwitchView(props) {
   const { onChange, path, schema, data } = props;
 
-  const [key, setUserChanged] = useKey(path, schema);
+  const [key, setUserChanged] = useKey(path, schema, data, true);
 
   return (
     <FormControlLabel
@@ -16,7 +16,7 @@ export default function SwitchView(props) {
           key={key}
           disabled={schema.view?.readOnly}
           autoFocus={autoFocus(props)}
-          defaultChecked={data === true || schema.default === true}
+          defaultChecked={data === true}
           onChange={(e, checked) => {
             onChange(path, checked);
             setUserChanged();

--- a/app/packages/core/src/plugins/SchemaIO/components/TextFieldView.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/TextFieldView.tsx
@@ -11,7 +11,7 @@ export default function TextFieldView(props) {
 
   const { inputProps = {}, ...fieldProps } = getComponentProps(props, "field");
 
-  const [key, setUserChanged] = useKey(path, schema);
+  const [key, setUserChanged] = useKey(path, schema, data, true);
 
   return (
     <FieldWrapper {...props}>
@@ -19,7 +19,7 @@ export default function TextFieldView(props) {
         key={key}
         disabled={view.readOnly}
         autoFocus={autoFocus(props)}
-        defaultValue={data ?? schema.default}
+        defaultValue={data}
         size="small"
         fullWidth
         placeholder={view.placeholder}

--- a/app/packages/core/src/plugins/SchemaIO/components/TextFieldView.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/TextFieldView.tsx
@@ -1,8 +1,9 @@
-import React from "react";
 import { TextField } from "@mui/material";
-import FieldWrapper from "./FieldWrapper";
-import autoFocus from "../utils/auto-focus";
+import React from "react";
+import { useKey } from "../hooks";
 import { getComponentProps } from "../utils";
+import autoFocus from "../utils/auto-focus";
+import FieldWrapper from "./FieldWrapper";
 
 export default function TextFieldView(props) {
   const { schema, onChange, path, data } = props;
@@ -10,9 +11,12 @@ export default function TextFieldView(props) {
 
   const { inputProps = {}, ...fieldProps } = getComponentProps(props, "field");
 
+  const [key, setUserChanged] = useKey(path, schema);
+
   return (
     <FieldWrapper {...props}>
       <TextField
+        key={key}
         disabled={view.readOnly}
         autoFocus={autoFocus(props)}
         defaultValue={data ?? schema.default}
@@ -23,6 +27,7 @@ export default function TextFieldView(props) {
         onChange={(e) => {
           const value = e.target.value;
           onChange(path, type === "number" ? parseFloat(value) : value);
+          setUserChanged();
         }}
         inputProps={{ min, max, step: multipleOf, ...inputProps }}
         {...fieldProps}

--- a/app/packages/core/src/plugins/SchemaIO/components/TupleView.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/TupleView.tsx
@@ -36,6 +36,8 @@ export default function TuplesView(props) {
                 schema={itemSchema}
                 path={getPath(path, i)}
                 data={data?.[i] ?? itemSchema?.default ?? schema?.default?.[i]}
+                parentSchema={schema}
+                relativePath={i}
               />
             </Grid>
           );

--- a/app/packages/core/src/plugins/SchemaIO/hooks/index.ts
+++ b/app/packages/core/src/plugins/SchemaIO/hooks/index.ts
@@ -1,0 +1,1 @@
+export * from "./useKey";

--- a/app/packages/core/src/plugins/SchemaIO/hooks/useKey.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/hooks/useKey.tsx
@@ -1,0 +1,36 @@
+import { isNullish } from "@fiftyone/utilities";
+import { get } from "lodash";
+import { useCallback, useMemo } from "react";
+
+// todo: move to state?
+const userChangedPaths = new Set<string>();
+const pathsRefreshCount = new Map<string, number>();
+
+export function useKey(
+  path: string,
+  schema: { default: unknown }
+): [string, () => void] {
+  const key = useMemo(() => {
+    let refreshCount: number = pathsRefreshCount.get(path) || 0;
+    if (!isNullish(get(schema, "default")) && !userChangedPaths.has(path)) {
+      refreshCount++;
+      pathsRefreshCount.set(path, refreshCount);
+    }
+    return `${path}-${refreshCount}`;
+  }, [path, schema]);
+
+  const setUserChanged = useCallback(() => {
+    userChangedPaths.add(path);
+  }, [path]);
+
+  return [key, setUserChanged];
+}
+
+export function clearUseKeyStores() {
+  userChangedPaths.clear();
+  pathsRefreshCount.clear();
+}
+
+export function isPathUserChanged(path: string) {
+  return userChangedPaths.has(path);
+}

--- a/app/packages/core/src/plugins/SchemaIO/index.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/index.tsx
@@ -1,5 +1,5 @@
 import { PluginComponentType, registerComponent } from "@fiftyone/plugins";
-import { set } from "lodash";
+import { cloneDeep, set } from "lodash";
 import React, { useCallback, useEffect, useRef, useState } from "react";
 import DynamicIO from "./components/DynamicIO";
 import { clearUseKeyStores } from "./hooks";
@@ -20,8 +20,8 @@ export function SchemaIOComponent(props) {
   const onIOChange = useCallback(
     (path, value) => {
       setState((state) => {
-        const updatedState = structuredClone(state);
-        set(updatedState, path, structuredClone(value));
+        const updatedState = cloneDeep(state);
+        set(updatedState, path, cloneDeep(value));
         return updatedState;
       });
     },

--- a/app/packages/core/src/plugins/SchemaIO/index.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/index.tsx
@@ -1,24 +1,32 @@
-import React, { useEffect, useRef, useState } from "react";
-import DynamicIO from "./components/DynamicIO";
-import { set } from "lodash";
 import { PluginComponentType, registerComponent } from "@fiftyone/plugins";
+import { set } from "lodash";
+import React, { useCallback, useEffect, useRef, useState } from "react";
+import DynamicIO from "./components/DynamicIO";
+import { clearUseKeyStores } from "./hooks";
 
 export function SchemaIOComponent(props) {
   const { onChange } = props;
   const [state, setState] = useState({});
   const autoFocused = useRef(false);
 
-  function onIOChange(path, value) {
-    setState((state) => {
-      const updatedState = structuredClone(state);
-      set(updatedState, path, structuredClone(value));
-      return updatedState;
-    });
-  }
+  useEffect(() => {
+    clearUseKeyStores();
+  }, []);
 
   useEffect(() => {
     if (onChange) onChange(state);
-  }, [state]);
+  }, [onChange, state]);
+
+  const onIOChange = useCallback(
+    (path, value) => {
+      setState((state) => {
+        const updatedState = structuredClone(state);
+        set(updatedState, path, structuredClone(value));
+        return updatedState;
+      });
+    },
+    [setState]
+  );
 
   return (
     <DynamicIO

--- a/app/packages/core/src/plugins/SchemaIO/utils/generate-schema.ts
+++ b/app/packages/core/src/plugins/SchemaIO/utils/generate-schema.ts
@@ -1,4 +1,7 @@
 // Auto generate SchemaIO compatible schema based on a value
+
+import { isPrimitiveType } from "@fiftyone/utilities";
+
 // todo: add support for OneOfView, TupleView, and MapView
 export function generateSchema(value, options?) {
   const type = getType(value);
@@ -16,7 +19,7 @@ export function generateSchema(value, options?) {
           readOnly: true,
         },
       };
-    } else if (primitives.includes(dominantType) && readOnly) {
+    } else if (isPrimitiveType(dominantType) && readOnly) {
       return {
         type,
         view: {
@@ -87,7 +90,7 @@ function getDominantType(array) {
     } else if (count > dominantTypeCount) {
       dominantType = type;
       dominantTypeCount = count;
-    } else if (count === dominantTypeCount && primitives.includes(type)) {
+    } else if (count === dominantTypeCount && isPrimitiveType(type)) {
       dominantType = type;
     }
   }
@@ -116,5 +119,3 @@ function getTableColumns(array) {
   const [firstItem] = array;
   return Object.keys(firstItem).map((key) => ({ key, label: key }));
 }
-
-const primitives = ["string", "number", "boolean"];

--- a/app/packages/utilities/src/type-check.ts
+++ b/app/packages/utilities/src/type-check.ts
@@ -5,3 +5,13 @@ export function isPrimitiveString(value: unknown) {
 export function isNullish(value) {
   return value === undefined || value === null;
 }
+
+export function isPrimitiveType(type: string) {
+  return PRIMITIVE_TYPES.includes(type);
+}
+
+export type NumberKeyObjectType<V = unknown> = {
+  [key: string]: V;
+};
+
+const PRIMITIVE_TYPES = ["string", "number", "boolean"];


### PR DESCRIPTION
## What changes are proposed in this pull request?

- Support passing a default value of a descendent schema
- Re-render non-modified fields when the default value is updated

> Note: updated default will no longer be applied if a value was modified by a user in IO

Usage:
> Code snippet below takes advantage of inheritance of default value to dynamically set default value for a property in an object within a list. 
```py

     # List view
        current_people = ctx.params.get("people", None)
        people_default = None
        if current_people is not None:
            people_default = []
            for person in current_people:
                name = person.get("name")
                people_default.append(
                    {"title": f"Mr. {name if name else 'Anonymous'}!"}
                )
        people = types.Object()
        people.str("name", label="Name")
        people.str("title", label="Title")
        inputs.list("people", people, default=people_default)

```

## How is this patch tested? If it is not, please explain why.

Using various example operators

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
