### PR TITLE
Handle flashlight page errors

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -24,23 +24,11 @@ jobs:
         with:
           node-version: 18
 
-      - name: Set up Python 3.8 and cache pip
-        uses: actions/setup-python@v4
-        id: pip-cache
-        with:
-          python-version: 3.8
-          cache: "pip"
-          cache-dependency-path: |
-            requirements/common.txt
-            requirements/github.txt
-            requirements/test.txt
-
       - name: Install setup dependencies
         run: |
           pip install --upgrade pip setuptools wheel
 
       - name: Install requirements.txt
-        if: steps.pip-cache.outputs.cache-hit != true
         run: |
           pip install -r requirements/github.txt
 

--- a/app/packages/components/src/components/ErrorBoundary/ErrorBoundary.tsx
+++ b/app/packages/components/src/components/ErrorBoundary/ErrorBoundary.tsx
@@ -76,7 +76,10 @@ const Errors = (onReset?: () => void, disableReset?: boolean) => {
     }
 
     return (
-      <div className={classnames(style.wrapper, scrollable)}>
+      <div
+        className={classnames(style.wrapper, scrollable)}
+        data-cy={"error-boundary"}
+      >
         <div className={classnames(style.container, scrollable)}>
           <div className={style.heading}>
             <div>

--- a/app/packages/core/src/useFlashlightPager.ts
+++ b/app/packages/core/src/useFlashlightPager.ts
@@ -3,6 +3,7 @@ import { zoomAspectRatio } from "@fiftyone/looker";
 import * as foq from "@fiftyone/relay";
 import * as fos from "@fiftyone/state";
 import { useMemo, useRef, useState } from "react";
+import { useErrorHandler } from "react-error-boundary";
 import { VariablesOf, fetchQuery, useRelayEnvironment } from "react-relay";
 import { RecoilValueReadOnly, selector, useRecoilValue } from "recoil";
 
@@ -47,6 +48,7 @@ const useFlashlightPager = (
   const page = useRecoilValue(pageSelector);
   const zoom = useRecoilValue(zoomSelector || defaultZoom);
   const [isEmpty, setIsEmpty] = useState(false);
+  const handleError = useErrorHandler();
 
   const pager = useMemo(() => {
     return async (pageNumber: number) => {
@@ -77,10 +79,11 @@ const useFlashlightPager = (
                 : null,
             });
           },
+          error: handleError,
         });
       });
     };
-  }, [environment, page, store, zoom]);
+  }, [environment, handleError, page, store, zoom]);
 
   const ref = useRef<FlashlightConfig<number>["get"]>(pager);
   ref.current = pager;

--- a/e2e-pw/src/oss/fixtures/loader.ts
+++ b/e2e-pw/src/oss/fixtures/loader.ts
@@ -110,7 +110,12 @@ export class OssLoader extends AbstractFiftyoneLoader {
     throw new Error("Method not implemented.");
   }
 
-  async waitUntilLoad(page: Page, datasetName: string, savedView?: string) {
+  async waitUntilLoad(
+    page: Page,
+    datasetName: string,
+    savedView?: string,
+    withGrid = true
+  ) {
     const forceDatasetFromSelector = async () => {
       await page.goto("/");
       await page.getByTestId(`selector-Select dataset`).click();
@@ -145,8 +150,11 @@ export class OssLoader extends AbstractFiftyoneLoader {
       }
     }
 
-    await page.waitForSelector("[data-cy=flashlight-section]", {
-      state: "visible",
-    });
+    await page.waitForSelector(
+      `[data-cy=${withGrid ? "flashlight-section" : "panel-container"}]`,
+      {
+        state: "visible",
+      }
+    );
   }
 }

--- a/e2e-pw/src/oss/poms/panel.ts
+++ b/e2e-pw/src/oss/poms/panel.ts
@@ -39,12 +39,20 @@ export class PanelPom {
   async open(option = "samples") {
     await this.tab(option).first().click();
   }
+
+  errorBoundary() {
+    return this.locator.getByTestId("error-boundary");
+  }
 }
 
 class PanelAsserter {
-  constructor(private readonly gridPom: PanelPom) {}
+  constructor(private readonly panelPom: PanelPom) {}
 
   async histogramLoaded() {
-    await expect(this.gridPom.distributionContainer()).toBeVisible();
+    await expect(this.panelPom.distributionContainer()).toBeVisible();
+  }
+
+  async hasError() {
+    await expect(this.panelPom.errorBoundary()).toBeVisible();
   }
 }

--- a/e2e-pw/src/oss/specs/groups/empty-groups.spec.ts
+++ b/e2e-pw/src/oss/specs/groups/empty-groups.spec.ts
@@ -8,7 +8,7 @@ const test = base.extend<{ panel: PanelPom }>({
   },
 });
 
-const datasetName = getUniqueDatasetNameWithPrefix(`dynamic-groups-cifar`);
+const datasetName = getUniqueDatasetNameWithPrefix(`empty-groups`);
 
 test.beforeAll(async ({ fiftyoneLoader }) => {
   await fiftyoneLoader.executePythonCode(`

--- a/e2e-pw/src/oss/specs/groups/empty-groups.spec.ts
+++ b/e2e-pw/src/oss/specs/groups/empty-groups.spec.ts
@@ -1,0 +1,28 @@
+import { test as base } from "src/oss/fixtures";
+import { PanelPom } from "src/oss/poms/panel";
+import { getUniqueDatasetNameWithPrefix } from "src/oss/utils";
+
+const test = base.extend<{ panel: PanelPom }>({
+  panel: async ({ page }, use) => {
+    await use(new PanelPom(page));
+  },
+});
+
+const datasetName = getUniqueDatasetNameWithPrefix(`dynamic-groups-cifar`);
+
+test.beforeAll(async ({ fiftyoneLoader }) => {
+  await fiftyoneLoader.executePythonCode(`
+    import fiftyone as fo
+    dataset = fo.Dataset("${datasetName}")
+    dataset.add_group_field("group", default="empty")
+    dataset.persistent = True
+  `);
+});
+
+test.beforeEach(async ({ page, fiftyoneLoader }) => {
+  await fiftyoneLoader.waitUntilLoad(page, datasetName, undefined, false);
+});
+
+test("empty dataset without default slice", async ({ panel }) => {
+  await panel.assert.hasError();
+});

--- a/e2e-pw/src/shared/abstract-loader.ts
+++ b/e2e-pw/src/shared/abstract-loader.ts
@@ -56,10 +56,12 @@ export abstract class AbstractFiftyoneLoader {
    * @param page Playwright page object.
    * @param datasetName Name of the dataset to be loaded into the view.
    * @param savedView Optional saved view name
+   * @param savedView Optional flag to wait until grid load. Default is true
    */
   abstract waitUntilLoad(
     page: Page,
     datasetName: string,
-    savedView?: string
+    savedView?: string,
+    withGrid?: boolean
   ): Promise<void>;
 }


### PR DESCRIPTION
#3333 introduces the shared pagination hook for samples (grid and carousel) `useFlashlightPager`. Error handling for pagination requests is missing in this new hook.

Group datasets do not have defined slices until samples are added, so I've added an e2e test that asserts an expected error from the grid when paginating over the undefined default slice.
```py
import fiftyone as fo
dataset = fo.Dataset("empty-group-dataset")
dataset.add_group_field("group", default="empty")
```
<img width="1470" alt="Screen Shot 2023-08-02 at 10 39 10 AM" src="https://github.com/voxel51/fiftyone/assets/19821840/99d7bca2-c772-4cc7-8396-3b5643cbf56c">

