### PR TITLE
bugfix/Filter+Visibility in sidebar

### DIFF
--- a/app/packages/state/src/recoil/pathFilters/index.ts
+++ b/app/packages/state/src/recoil/pathFilters/index.ts
@@ -114,10 +114,19 @@ export const pathFilter = selectorFamily<PathFilterSelector, boolean>({
               primitiveFilter({ modal, path: `${expandedPath}.${name}` })
             );
 
-            return (value: unknown) =>
-              isKeypoints && typeof value[name] === "object" // keypoints ListFields
-                ? () => true
-                : filter(value[name === "id" ? "id" : dbField || name]);
+            return (value: unknown) => {
+              if (isKeypoints && typeof value[name] === "object") {
+                // keypoints ListFields
+                return () => true;
+              }
+
+              if (value[0]) {
+                // for classification type, value needs a conversion to get into the same shape as other types
+                return filter(value[0][name === "id" ? "id" : dbField || name]);
+              } else {
+                return filter(value[name === "id" ? "id" : dbField || name]);
+              }
+            };
           });
 
           f[path] = (value: unknown) => {

--- a/app/packages/state/src/recoil/pathFilters/string.ts
+++ b/app/packages/state/src/recoil/pathFilters/string.ts
@@ -195,7 +195,15 @@ export const string = selectorFamily<
       if (filter && visibility) {
         const visibilityFn = helperStringFunction(visibility);
         const filterFn = helperStringFunction(filter);
-        return (value: string | null) => filterFn(value) && visibilityFn(value);
+        if (filter.isMatching) {
+          return (value: string | null) => {
+            return visibilityFn(value);
+          };
+        }
+
+        return (value: string | null) => {
+          return filterFn(value) && visibilityFn(value);
+        };
       }
 
       return () => true; // not needed, but eslint complains


### PR DESCRIPTION
Fix bugs related to visibility settings: 
- When both filter and visibility settings are active, "Show samples" and "Hide Samples" + visibility setting won't show labels that should be shown.
- Visibility could not change classification labels settings

https://github.com/voxel51/fiftyone/assets/17770824/bf498ffc-d42f-4d38-a7fa-74213dbf061c






The e2e test is in the other e2e sidebar PR. 

## What changes are proposed in this pull request?

(Please fill in changes proposed in this fix)

## How is this patch tested? If it is not, please explain why.

(Details)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
