### PR TITLE
Looker3D sparse slices handling

### DIFF
--- a/app/packages/core/src/components/Modal/Group/GroupSample3d.tsx
+++ b/app/packages/core/src/components/Modal/Group/GroupSample3d.tsx
@@ -1,6 +1,6 @@
 import { Loading } from "@fiftyone/components";
 import * as fos from "@fiftyone/state";
-import React, { useEffect } from "react";
+import { useEffect } from "react";
 import {
   useRecoilState,
   useRecoilTransaction_UNSTABLE,
@@ -47,12 +47,13 @@ export default () => {
   const assignSlices = useRecoilTransaction_UNSTABLE(
     ({ set }) =>
       (
+        pinnedSlice: string | null,
         slices: string[],
         samples: {
           [k: string]: fos.ModalSample;
         }
       ) => {
-        let newSlice: string | null = null;
+        let newSlice: string | null = samples[pinnedSlice] ? pinnedSlice : null;
         for (let index = 0; index < slices.length; index++) {
           const element = slices[index];
           if (samples[element]) {
@@ -82,11 +83,7 @@ export default () => {
       return;
     }
 
-    if (pinnedSlice && pcdSlices.contents[pinnedSlice]) {
-      return;
-    }
-
-    assignSlices(slices, pcdSlices.contents);
+    assignSlices(pinnedSlice, slices, pcdSlices.contents);
   }, [assignSlices, modalId, slices, groupSlice, pinnedSlice, pcdSlices]);
 
   if (


### PR DESCRIPTION
e2e test in progress
```py
import fiftyone as fo
import fiftyone.zoo as foz

dataset = fo.Dataset("pcd-only-sparse")
dataset.add_group_field("group", default="shared")
dataset.persistent = True

source = foz.load_zoo_dataset("quickstart-groups", max_samples=9)
source.group_slice = "pcd"

first = fo.Group()
one = source.first().copy()
one.group = first.element("shared")

two = source.skip(1).first().copy()
two.group = first.element("unique")

second = fo.Group()
three = source.skip(2).first().copy()
three.group = second.element("shared")

dataset.add_samples([one, two, three])
```

https://github.com/voxel51/fiftyone/assets/19821840/af987331-90d2-4484-a2ae-05aace2125db

