### PR TITLE
regression test for video labels bug + media field bug fix

### DIFF
--- a/app/packages/looker-3d/src/Looker3d.tsx
+++ b/app/packages/looker-3d/src/Looker3d.tsx
@@ -542,7 +542,7 @@ class ErrorBoundary extends React.Component<
   { children: React.ReactNode },
   { error: Error | null }
 > {
-  state = { error: null };
+  state = { error: null, hasError: false };
 
   static getDerivedStateFromError = (error: Error) => ({
     hasError: true,
@@ -554,8 +554,8 @@ class ErrorBoundary extends React.Component<
   }
 
   render() {
-    if (this.state.error) {
-      return <Loading dataCy={"looker3d"}>{this.state.error}</Loading>;
+    if (this.state.hasError) {
+      return <Loading dataCy={"looker3d"}>{this.state.error.message}</Loading>;
     }
 
     return this.props.children;

--- a/app/packages/looker-3d/src/Looker3d.tsx
+++ b/app/packages/looker-3d/src/Looker3d.tsx
@@ -322,9 +322,14 @@ export const Looker3d = () => {
           let mediaUrlUnresolved;
 
           if (Array.isArray(sample.urls)) {
-            mediaUrlUnresolved = sample.urls.find(
+            const mediaFieldObj = sample.urls.find(
               (u) => u.field === mediaField
-            ).url;
+            );
+            if (mediaFieldObj) {
+              mediaUrlUnresolved = mediaFieldObj.url;
+            } else {
+              return null;
+            }
           } else {
             mediaUrlUnresolved = sample.urls[mediaField];
           }

--- a/app/packages/looker-3d/src/containers.ts
+++ b/app/packages/looker-3d/src/containers.ts
@@ -74,6 +74,9 @@ export const Container = styled.div`
   height: 100%;
   width: 100%;
   position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 `;
 
 export const ViewButton = styled.div`

--- a/e2e-pw/src/oss/fixtures/loader.ts
+++ b/e2e-pw/src/oss/fixtures/loader.ts
@@ -116,7 +116,6 @@ export class OssLoader extends AbstractFiftyoneLoader {
       await page.getByTestId(`selector-Select dataset`).click();
 
       if (datasetName) {
-        console.log("attempting to click", `selector-result-${datasetName}`);
         await page.getByTestId(`selector-result-${datasetName}`).click();
       } else {
         const firstSelectorResult = page.locator(

--- a/e2e-pw/src/oss/poms/action-row/grid-slice-selector.ts
+++ b/e2e-pw/src/oss/poms/action-row/grid-slice-selector.ts
@@ -20,9 +20,14 @@ export class GridSliceSelectorPom {
   async getAvailableSlices() {
     const sliceResultsContainer = await this.openSliceSelector();
 
-    return await sliceResultsContainer.evaluate((div) =>
+    const slices = await sliceResultsContainer.evaluate((div) =>
       Array.from(div.childNodes).map((node: HTMLElement) => node.innerText)
     );
+
+    // close slice selector by clicking outside of it
+    await this.page.getByTestId("entry-counts").click();
+
+    return slices;
   }
 
   async selectSlice(sliceName: string) {
@@ -43,8 +48,14 @@ class GridSliceSelectorAsserter {
     ).toBeVisible();
   }
 
+  async verifyActiveSlice(expectedActiveSlice: string) {
+    await expect(
+      this.gridSliceSelectorPom.page.getByTestId(SLICE_SELECTOR_TEST_ID)
+    ).toHaveValue(expectedActiveSlice);
+  }
+
   async verifyHasSlices(expectedSlices: string[]) {
     const actualSlices = await this.gridSliceSelectorPom.getAvailableSlices();
-    expect(actualSlices).toEqual(expectedSlices);
+    expect(actualSlices.sort()).toEqual(expectedSlices.sort());
   }
 }

--- a/e2e-pw/src/oss/poms/grid/index.ts
+++ b/e2e-pw/src/oss/poms/grid/index.ts
@@ -52,6 +52,20 @@ export class GridPom {
     await this.page.getByTestId("selector-slice").fill(slice);
     await this.page.getByTestId("selector-slice").press("Enter");
   }
+
+  async getSampleLoadEventPromiseForFilepath(sampleFilepath: string) {
+    return this.page.evaluate(
+      (sampleFilepath_) =>
+        new Promise<void>((resolve, _reject) => {
+          document.addEventListener("sample-loaded", (e: CustomEvent) => {
+            if ((e.detail.sampleFilepath as string) === sampleFilepath_) {
+              resolve();
+            }
+          });
+        }),
+      sampleFilepath
+    );
+  }
 }
 
 class GridAsserter {

--- a/e2e-pw/src/oss/poms/modal/index.ts
+++ b/e2e-pw/src/oss/poms/modal/index.ts
@@ -61,6 +61,13 @@ export class ModalPom {
     return this.waitForSampleLoadDomAttribute(allowErrorInfo);
   }
 
+  async waitForCarouselToLoad() {
+    await this.groupCarousel
+      .getByTestId("looker")
+      .first()
+      .waitFor({ state: "visible" });
+  }
+
   async navigateSlice(
     groupField: string,
     slice: string,
@@ -87,7 +94,9 @@ export class ModalPom {
   }
 
   async close() {
-    return this.page.press("body", "Escape");
+    // await this.locator.press("Escape");
+    await this.page.click("body", { position: { x: 0, y: 0 } });
+    await this.locator.waitFor({ state: "detached" });
   }
 
   async navigateNextSample(allowErrorInfo = false) {
@@ -167,10 +176,10 @@ class ModalAsserter {
     expect(count).toBe(String(n));
   }
 
-  async verifyCarouselLength(count: number) {
-    const lookers = await this.modalPom.groupCarousel
+  async verifyCarouselLength(expectedCount: number) {
+    const actualLookerCount = await this.modalPom.groupCarousel
       .getByTestId("looker")
       .count();
-    expect(lookers).toBe(count);
+    expect(actualLookerCount).toBe(expectedCount);
   }
 }

--- a/e2e-pw/src/oss/poms/modal/index.ts
+++ b/e2e-pw/src/oss/poms/modal/index.ts
@@ -94,7 +94,7 @@ export class ModalPom {
   }
 
   async close() {
-    // await this.locator.press("Escape");
+    // close by clicking outside of modal
     await this.page.click("body", { position: { x: 0, y: 0 } });
     await this.locator.waitFor({ state: "detached" });
   }

--- a/e2e-pw/src/oss/specs/regression-tests/group-video/default-video-slice-group.spec.ts
+++ b/e2e-pw/src/oss/specs/regression-tests/group-video/default-video-slice-group.spec.ts
@@ -1,0 +1,101 @@
+import { test as base } from "src/oss/fixtures";
+import { GridPom } from "src/oss/poms/grid";
+import { ModalPom } from "src/oss/poms/modal";
+import { getUniqueDatasetNameWithPrefix } from "src/oss/utils";
+
+/**
+ * This test makes sure that a ragged group dataset with default video slice works as expected.
+ * Video also has bounding box labels.
+ */
+
+const datasetName = getUniqueDatasetNameWithPrefix(
+  "video-default-group-slice-regression"
+);
+const testVideoPath = `/tmp/test-video-${datasetName}.webm`;
+const testImgPath = `/tmp/test-img-${datasetName}.jpg`;
+const testImgPath2 = `/tmp/test-img-2-${datasetName}.jpg`;
+
+const test = base.extend<{ grid: GridPom; modal: ModalPom }>({
+  grid: async ({ page }, use) => {
+    await use(new GridPom(page));
+  },
+  modal: async ({ page }, use) => {
+    await use(new ModalPom(page));
+  },
+});
+
+test.describe("default video slice group", () => {
+  test.beforeAll(async ({ fiftyoneLoader, mediaFactory }) => {
+    await mediaFactory.createBlankVideo({
+      outputPath: testVideoPath,
+      duration: 2,
+      width: 50,
+      height: 50,
+      frameRate: 5,
+      color: "#000000",
+    });
+
+    await mediaFactory.createBlankImage({
+      outputPath: testImgPath,
+      width: 50,
+      height: 50,
+    });
+
+    await mediaFactory.createBlankImage({
+      outputPath: testImgPath2,
+      width: 50,
+      height: 50,
+    });
+
+    await fiftyoneLoader.executePythonCode(`
+        import fiftyone as fo
+
+        dataset = fo.Dataset("${datasetName}")
+        dataset.persistent = True
+
+        dataset.add_group_field("group", default="video")
+
+        group1 = fo.Group()
+        image_sample = fo.Sample(filepath="${testImgPath}", group=group1.element("image"))
+        video_sample = fo.Sample(filepath="${testVideoPath}", group=group1.element("video"))
+
+        group2 = fo.Group()
+        image_sample2 = fo.Sample(filepath="${testImgPath2}", group=group2.element("image"))
+
+        dataset.ensure_frames();
+        for _, frame in video_sample.frames.items():
+          d1 = fo.Detection(bounding_box=[0.1, 0.1, 0.2, 0.2])
+          frame["d1"] = d1
+        dataset.add_samples([video_sample, image_sample, image_sample2])
+        `);
+  });
+
+  test.beforeEach(async ({ page, fiftyoneLoader }) => {
+    fiftyoneLoader.waitUntilLoad(page, datasetName);
+  });
+
+  test("video as default slice renders", async ({ grid, modal, page }) => {
+    await grid.sliceSelector.assert.verifyHasSlices(["video", "image"]);
+    await grid.sliceSelector.assert.verifyActiveSlice("video");
+    await grid.assert.assertNLookers(1);
+
+    await grid.openFirstLooker();
+    await modal.waitForSampleLoadDomAttribute();
+    await modal.waitForCarouselToLoad();
+    await modal.assert.verifyCarouselLength(2);
+    await modal.close();
+
+    const imgLoadedPromise =
+      grid.getSampleLoadEventPromiseForFilepath(testImgPath);
+    await grid.selectSlice("image");
+    await imgLoadedPromise;
+
+    await grid.assert.assertNLookers(2);
+    await grid.openFirstLooker();
+    await modal.waitForSampleLoadDomAttribute();
+    await modal.waitForCarouselToLoad();
+    await modal.assert.verifyCarouselLength(2);
+    await modal.navigateNextSample();
+    await modal.assert.verifyCarouselLength(1);
+  });
+});

--- a/e2e-pw/src/oss/specs/regression-tests/group-video/group-video-label.spec.ts
+++ b/e2e-pw/src/oss/specs/regression-tests/group-video/group-video-label.spec.ts
@@ -18,8 +18,8 @@ const test = base.extend<{ grid: GridPom; modal: ModalPom }>({
 
 test.describe("groups video labels", () => {
   test.beforeAll(async ({ fiftyoneLoader, mediaFactory }) => {
-    [testVideoPath1, testVideoPath2].forEach((outputPath) => {
-      mediaFactory.createBlankVideo({
+    [testVideoPath1, testVideoPath2].forEach(async (outputPath) => {
+      await mediaFactory.createBlankVideo({
         outputPath,
         duration: 3,
         width: 100,

--- a/e2e-pw/src/shared/media-factory/image.ts
+++ b/e2e-pw/src/shared/media-factory/image.ts
@@ -1,16 +1,16 @@
 import Jimp from "jimp";
 
 export const createBlankImage = async (options: {
+  outputPath: string;
   width: number;
   height: number;
-  fileName: string;
   fillColor?: string;
 }) => {
-  const { width, height, fileName, fillColor } = options;
+  const { width, height, outputPath, fillColor } = options;
   const startTime = performance.now();
   console.log(`Creating blank image with options: ${JSON.stringify(options)}`);
-  const image = new Jimp(width, height, fillColor ?? "#000000");
-  await image.writeAsync(fileName);
+  const image = new Jimp(width, height, fillColor ?? "#00ddff");
+  await image.writeAsync(outputPath);
   const endTime = performance.now();
   const timeTaken = endTime - startTime;
   console.log(`Image generation completed in ${timeTaken} milliseconds`);

--- a/e2e-pw/src/shared/media-factory/index.ts
+++ b/e2e-pw/src/shared/media-factory/index.ts
@@ -1,7 +1,9 @@
 import { createBlankImage } from "./image";
+import { createPcd } from "./pcd";
 import { createBlankVideo } from "./video";
 
 export const MediaFactory = {
   createBlankVideo,
   createBlankImage,
+  createPcd,
 };

--- a/e2e-pw/src/shared/media-factory/pcd.ts
+++ b/e2e-pw/src/shared/media-factory/pcd.ts
@@ -1,0 +1,33 @@
+import { spawnSync } from "child_process";
+import { Duration, getPythonCommand } from "src/oss/utils";
+
+/**
+ * This function creates a new pcd file with the specified number of points.
+ * The points are arranged in a diagonal line in 3D space.
+ */
+export const createPcd = (options: {
+  outputPath: string;
+  numPoints: number;
+}) => {
+  const { outputPath, numPoints } = options;
+  const startTime = performance.now();
+  console.log(`Creating blank pcd with options: ${JSON.stringify(options)}`);
+  const pythonCode = `import open3d as o3d
+  pcd = o3d.geometry.PointCloud()
+  pcd.points = o3d.utility.Vector3dVector([[i, i, i] for i in range(${numPoints})])
+  o3d.io.write_point_cloud('${outputPath}', pcd)`;
+
+  const pythonCodeSingleLine = pythonCode.split("\n").join(";");
+  const command = getPythonCommand(["-c", `"${pythonCodeSingleLine}"`]);
+  const proc = spawnSync(command, {
+    shell: true,
+    timeout: Duration.Seconds(5),
+  });
+  if (proc.stderr) {
+    console.error(proc.stderr.toString());
+  }
+
+  const endTime = performance.now();
+  const timeTaken = endTime - startTime;
+  console.log(`Pcd generation completed in ${timeTaken} milliseconds`);
+};


### PR DESCRIPTION
## What changes are proposed in this pull request?

- Add regression test for video label bug
- Add pcd media factory
- Fix looker3d code that was causing media field bug (e2e coverage in upcoming PR)

## How is this patch tested? If it is not, please explain why.

Ran this spec with flake-analysis utility for ten runs, all green.

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
