### PR TITLE
Add back missing grid filters

### DIFF
--- a/app/packages/relay/src/queries/__generated__/paginateSamplesQuery.graphql.ts
+++ b/app/packages/relay/src/queries/__generated__/paginateSamplesQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<7797065bb3c327d3793aacf1027c22f5>>
+ * @generated SignedSource<<be111ef8fc4bc0dd0c7a4428bb11eea4>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -24,6 +24,7 @@ export type paginateSamplesQuery$variables = {
   dataset: string;
   extendedStages?: object | null;
   filter: SampleFilter;
+  filters?: object | null;
   view: Array;
 };
 export type paginateSamplesQuery$data = {
@@ -104,30 +105,35 @@ v4 = {
 v5 = {
   "defaultValue": null,
   "kind": "LocalArgument",
-  "name": "view"
+  "name": "filters"
 },
 v6 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "view"
+},
+v7 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "id",
   "storageKey": null
 },
-v7 = {
+v8 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "aspectRatio",
   "storageKey": null
 },
-v8 = {
+v9 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "sample",
   "storageKey": null
 },
-v9 = {
+v10 = {
   "alias": null,
   "args": null,
   "concreteType": "MediaURL",
@@ -152,7 +158,7 @@ v9 = {
   ],
   "storageKey": null
 },
-v10 = [
+v11 = [
   {
     "alias": null,
     "args": [
@@ -175,6 +181,11 @@ v10 = [
         "kind": "Variable",
         "name": "filter",
         "variableName": "filter"
+      },
+      {
+        "kind": "Variable",
+        "name": "filters",
+        "variableName": "filters"
       },
       {
         "kind": "Variable",
@@ -243,10 +254,10 @@ v10 = [
               {
                 "kind": "InlineFragment",
                 "selections": [
-                  (v6/*: any*/),
                   (v7/*: any*/),
                   (v8/*: any*/),
-                  (v9/*: any*/)
+                  (v9/*: any*/),
+                  (v10/*: any*/)
                 ],
                 "type": "ImageSample",
                 "abstractKey": null
@@ -254,10 +265,10 @@ v10 = [
               {
                 "kind": "InlineFragment",
                 "selections": [
-                  (v7/*: any*/),
-                  (v6/*: any*/),
                   (v8/*: any*/),
-                  (v9/*: any*/)
+                  (v7/*: any*/),
+                  (v9/*: any*/),
+                  (v10/*: any*/)
                 ],
                 "type": "PointCloudSample",
                 "abstractKey": null
@@ -265,8 +276,8 @@ v10 = [
               {
                 "kind": "InlineFragment",
                 "selections": [
-                  (v6/*: any*/),
                   (v7/*: any*/),
+                  (v8/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -281,8 +292,8 @@ v10 = [
                     "name": "frameNumber",
                     "storageKey": null
                   },
-                  (v8/*: any*/),
-                  (v9/*: any*/)
+                  (v9/*: any*/),
+                  (v10/*: any*/)
                 ],
                 "type": "VideoSample",
                 "abstractKey": null
@@ -305,12 +316,13 @@ return {
       (v2/*: any*/),
       (v3/*: any*/),
       (v4/*: any*/),
-      (v5/*: any*/)
+      (v5/*: any*/),
+      (v6/*: any*/)
     ],
     "kind": "Fragment",
     "metadata": null,
     "name": "paginateSamplesQuery",
-    "selections": (v10/*: any*/),
+    "selections": (v11/*: any*/),
     "type": "Query",
     "abstractKey": null
   },
@@ -320,25 +332,26 @@ return {
       (v1/*: any*/),
       (v0/*: any*/),
       (v2/*: any*/),
-      (v5/*: any*/),
+      (v6/*: any*/),
       (v4/*: any*/),
+      (v5/*: any*/),
       (v3/*: any*/)
     ],
     "kind": "Operation",
     "name": "paginateSamplesQuery",
-    "selections": (v10/*: any*/)
+    "selections": (v11/*: any*/)
   },
   "params": {
-    "cacheID": "463be9824dac55e82d92fdfc5f09909b",
+    "cacheID": "5da3bdec208ca69bb5668016d72693f5",
     "id": null,
     "metadata": {},
     "name": "paginateSamplesQuery",
     "operationKind": "query",
-    "text": "query paginateSamplesQuery(\n  $count: Int = 20\n  $after: String = null\n  $dataset: String!\n  $view: BSONArray!\n  $filter: SampleFilter!\n  $extendedStages: BSON\n) {\n  samples(dataset: $dataset, view: $view, first: $count, after: $after, filter: $filter, extendedStages: $extendedStages) {\n    pageInfo {\n      hasNextPage\n    }\n    edges {\n      cursor\n      node {\n        __typename\n        ... on ImageSample {\n          id\n          aspectRatio\n          sample\n          urls {\n            field\n            url\n          }\n        }\n        ... on PointCloudSample {\n          aspectRatio\n          id\n          sample\n          urls {\n            field\n            url\n          }\n        }\n        ... on VideoSample {\n          id\n          aspectRatio\n          frameRate\n          frameNumber\n          sample\n          urls {\n            field\n            url\n          }\n        }\n      }\n    }\n  }\n}\n"
+    "text": "query paginateSamplesQuery(\n  $count: Int = 20\n  $after: String = null\n  $dataset: String!\n  $view: BSONArray!\n  $filter: SampleFilter!\n  $filters: BSON = null\n  $extendedStages: BSON\n) {\n  samples(dataset: $dataset, view: $view, first: $count, after: $after, filter: $filter, filters: $filters, extendedStages: $extendedStages) {\n    pageInfo {\n      hasNextPage\n    }\n    edges {\n      cursor\n      node {\n        __typename\n        ... on ImageSample {\n          id\n          aspectRatio\n          sample\n          urls {\n            field\n            url\n          }\n        }\n        ... on PointCloudSample {\n          aspectRatio\n          id\n          sample\n          urls {\n            field\n            url\n          }\n        }\n        ... on VideoSample {\n          id\n          aspectRatio\n          frameRate\n          frameNumber\n          sample\n          urls {\n            field\n            url\n          }\n        }\n      }\n    }\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "9c411553230ff7447820992e6c3b4c42";
+(node as any).hash = "cfa64cc39868505de9a7955ce77acf1d";
 
 export default node;

--- a/app/packages/relay/src/queries/paginateSamples.ts
+++ b/app/packages/relay/src/queries/paginateSamples.ts
@@ -8,6 +8,7 @@ export default r(graphql`
     $dataset: String!
     $view: BSONArray!
     $filter: SampleFilter!
+    $filters: BSON = null
     $extendedStages: BSON
   ) {
     samples(
@@ -16,6 +17,7 @@ export default r(graphql`
       first: $count
       after: $after
       filter: $filter
+      filters: $filters
       extendedStages: $extendedStages
     ) {
       pageInfo {

--- a/app/schema.graphql
+++ b/app/schema.graphql
@@ -443,6 +443,7 @@ type Query {
     after: String = null
     filter: SampleFilter = null
     extendedStages: BSON = null
+    filters: BSON = null
   ): SampleItemStrConnection!
   sample(
     dataset: String!

--- a/fiftyone/server/query.py
+++ b/fiftyone/server/query.py
@@ -418,11 +418,12 @@ class Query(fosa.AggregateQuery):
         after: t.Optional[str] = None,
         filter: t.Optional[SampleFilter] = None,
         extended_stages: t.Optional[BSON] = None,
+        filters: t.Optional[BSON] = None,
     ) -> Connection[SampleItem, str]:
         return await paginate_samples(
             dataset,
             view,
-            None,
+            filters,
             first,
             after,
             sample_filter=filter,


### PR DESCRIPTION
Adds missing `filters` variable to `paginateSamples` in the sample grid's flashlight parameters


https://github.com/voxel51/fiftyone/assets/19821840/ecdc07c8-5bf7-40f3-8d2f-08d5ed680666

