### PR TITLE
Update pytube requirement to fix zoo YouTube download error

### DIFF
--- a/fiftyone/utils/activitynet.py
+++ b/fiftyone/utils/activitynet.py
@@ -371,7 +371,7 @@ class ActivityNetDatasetManager(object):
         return self.info.existing_split_sample_ids(split)
 
     def split_sample_ids(self, split):
-        return self.info.split_sample_ids[split]
+        return self.info.split_sample_ids(split)
 
     def process_source(self, source_dir, copy_files):
         source_dir = os.path.expanduser(source_dir)
@@ -727,6 +727,12 @@ class ActivityNetDatasetManager(object):
             prev_errors = {}
 
         for video, e in download_errors.items():
+            if not isinstance(e, (str, int, float, bool)) and e != None:
+                try:
+                    e = str(e)
+                except:
+                    e = "Cannot parse error message"
+
             if e in prev_errors:
                 prev_errors[e].append(video)
             else:

--- a/fiftyone/utils/kinetics.py
+++ b/fiftyone/utils/kinetics.py
@@ -248,6 +248,11 @@ class KineticsDatasetManager(object):
 
         split = self.info.split
         for e, videos in download_errors.items():
+            if not isinstance(e, (str, int, float, bool)) and e != None:
+                try:
+                    e = str(e)
+                except:
+                    e = "Cannot parse error message"
             if e in prev_errors[split]:
                 prev_errors[split][e].extend(videos)
                 prev_errors[split][e] = sorted(set(prev_errors[split][e]))

--- a/fiftyone/utils/youtube.py
+++ b/fiftyone/utils/youtube.py
@@ -27,9 +27,7 @@ import fiftyone.core.utils as fou
 
 
 def _ensure_pytube():
-    fou.ensure_package("pytube>=11.0.2")
-    if metadata.version("pytube") == "11.0.2":
-        _patch_pytube_cypher()
+    fou.ensure_package("pytube>=15")
 
 
 pytube = fou.lazy_import("pytube", callback=_ensure_pytube)
@@ -486,79 +484,3 @@ def _download_clip(stream, clip_segment, video_path):
     etav.extract_clip(
         stream.url, video_path, start_time=start_time, duration=duration
     )
-
-
-def _patch_pytube_cypher():
-    filepath = os.path.normpath(
-        os.path.join(
-            os.path.dirname(importlib.util.find_spec("pytube").origin),
-            "cipher.py",
-        )
-    )
-
-    find = """
-    function_patterns = [
-        # https://github.com/ytdl-org/youtube-dl/issues/29326#issuecomment-865985377
-        # a.C&&(b=a.get("n"))&&(b=Dea(b),a.set("n",b))}};
-        # In above case, `Dea` is the relevant function name
-        r'a\.[A-Z]&&\(b=a\.get\("n"\)\)&&\(b=([^(]+)\(b\)',
-    ]
-    logger.debug('Finding throttling function name')
-    for pattern in function_patterns:
-        regex = re.compile(pattern)
-        function_match = regex.search(js)
-        if function_match:
-            logger.debug("finished regex search, matched: %s", pattern)
-            return function_match.group(1)"""
-
-    replace = """
-    # Patched by FiftyOne: https://github.com/voxel51/fiftyone
-    # PR: https://github.com/pytube/pytube/pull/1222
-    function_patterns = [
-        # https://github.com/ytdl-org/youtube-dl/issues/29326#issuecomment-865985377
-        # https://github.com/yt-dlp/yt-dlp/commit/48416bc4a8f1d5ff07d5977659cb8ece7640dcd8
-        # var Bpa = [iha];
-        # ...
-        # a.C && (b = a.get("n")) && (b = Bpa[0](b), a.set("n", b),
-        # Bpa.length || iha("")) }};
-        # In the above case, `iha` is the relevant function name
-        r'a\.[a-zA-Z]\s*&&\s*\([a-z]\s*=\s*a\.get\("n"\)\)\s*&&\s*'
-        r'\([a-z]\s*=\s*([a-zA-Z0-9$]{3})(\[\d+\])?\([a-z]\)',
-    ]
-    logger.debug('Finding throttling function name')
-    for pattern in function_patterns:
-        regex = re.compile(pattern)
-        function_match = regex.search(js)
-        if function_match:
-            logger.debug("finished regex search, matched: %s", pattern)
-            if len(function_match.groups()) == 1:
-                return function_match.group(1)
-            idx = function_match.group(2)
-            if idx:
-                idx = idx.strip("[]")
-                array = re.search(
-                    r'var {nfunc}\s*=\s*(\[.+?\]);'.format(
-                        nfunc=function_match.group(1)),
-                    js
-                )
-                if array:
-                    array = array.group(1).strip("[]").split(",")
-                    array = [x.strip() for x in array]
-                    return array[int(idx)]"""
-
-    try:
-        with open(filepath, "r") as f:
-            code = f.read()
-
-        if find in code:
-            logger.debug("Patching '%s'", filepath)
-            fixed = code.replace(find, replace)
-            with open(filepath, "w") as f:
-                f.write(fixed)
-        elif replace in code:
-            logger.debug("Already patched '%s'", filepath)
-        else:
-            logger.debug("Unable to patch '%s'", filepath)
-    except Exception as e:
-        logger.debug(e)
-        logger.debug("Unable to patch '%s'", filepath)


### PR DESCRIPTION
Some video datasets in the zoo like ActivityNet and Kinetics will optionally download the videos directly from the sources on YouTube using `pytube`. However, with PyTube versions <15, the video downloads would fail with this error:
```
Failed to download video 'https://www.youtube.com/watch?v=-9l1Rh10bO8': 'streamingData' 
```

[Updating the minimum supported Pytube version to >=15 resolves this issue.](https://stackoverflow.com/a/76268388/14277626)
This also lets us get rid of the patching code we were using for pytube v11.0.2.

There is also a new error that pytube throws which was causing issues with the error parsing in the zoo datasets, the error handling of kinetics/activitynet was updated to properly log this error now.