### PR TITLE
helper texts for custom color saving capabilities

### DIFF
--- a/app/packages/core/src/components/ColorModal/ColorModal.tsx
+++ b/app/packages/core/src/components/ColorModal/ColorModal.tsx
@@ -138,6 +138,8 @@ const ColorModal = () => {
                   <SidebarList />
                   <Display>
                     {field === ACTIVE_FIELD.global && <GlobalSetting />}
+                    Note that in this panel the color pool is the only savable
+                    option for now.
                     {field === ACTIVE_FIELD.json && <JSONViewer />}
                     {typeof field !== "string" && field && (
                       <FieldSetting prop={activeColorModalField} />

--- a/app/packages/core/src/components/ColorModal/GlobalSetting.tsx
+++ b/app/packages/core/src/components/ColorModal/GlobalSetting.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Divider, Slider } from "@mui/material";
+import { Divider, Slider, Typography } from "@mui/material";
 import { SettingsBackupRestore } from "@mui/icons-material";
 
 import * as fos from "@fiftyone/state";
@@ -35,6 +35,10 @@ const GlobalSetting: React.FC = ({}) => {
         </SectionWrapper>
         <ShuffleColor />
         <LabelTitle>Color pool</LabelTitle>
+        <Typography fontSize="1rem" pb={0.5}>
+          Pool of colors from which otherwise unconfigured fields/values are
+          randomly assigned colors.
+        </Typography>
         <SectionWrapper>
           <ColorPalette />
         </SectionWrapper>

--- a/app/packages/core/src/components/ColorModal/ShareStyledDiv.ts
+++ b/app/packages/core/src/components/ColorModal/ShareStyledDiv.ts
@@ -84,7 +84,7 @@ export const IconDiv = styled.div`
 `;
 
 export const ControlGroupWrapper = styled.div`
-  margin: 0.5rem 2rem;
+  margin: 0.5rem;
 `;
 
 export const SectionWrapper = styled.div`
@@ -92,8 +92,8 @@ export const SectionWrapper = styled.div`
 `;
 
 export const LabelTitle = styled.div`
-  margin: 0 -0.5rem;
-  padding: 0 0.5rem;
+  margin: 0;
+  padding: 0.5rem 0;
   font-size: 1rem;
   line-height: 2;
   font-weight: bold;


### PR DESCRIPTION
## What changes are proposed in this pull request?

Adds helper text to custom color modal 
- explaining what color pool is
- A note that only color pool changes are saved (for now)

<img width="895" alt="Screen Shot 2023-08-03 at 7 26 56 AM" src="https://github.com/voxel51/fiftyone/assets/109545780/de764815-ccb2-411d-9724-f3545e9ca48f">




## How is this patch tested? If it is not, please explain why.

(Details)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
