### PR TITLE
PCD tagging and group modal resets

### DIFF
--- a/app/packages/core/src/components/Actions/Tagger.tsx
+++ b/app/packages/core/src/components/Actions/Tagger.tsx
@@ -1,13 +1,7 @@
 import { PopoutSectionTitle, useTheme } from "@fiftyone/components";
 import { FrameLooker, ImageLooker, VideoLooker } from "@fiftyone/looker";
 import * as fos from "@fiftyone/state";
-import {
-  Lookers,
-  currentSlice,
-  groupId,
-  groupStatistics,
-  refresher,
-} from "@fiftyone/state";
+import { Lookers, groupId, groupStatistics, refresher } from "@fiftyone/state";
 import { getFetchFunction } from "@fiftyone/utilities";
 import { useSpring } from "@react-spring/web";
 import numeral from "numeral";
@@ -329,7 +323,7 @@ const useTagCallback = (
     ({ snapshot, set, reset }) =>
       async ({ changes }) => {
         const isGroup = await snapshot.getPromise(fos.isGroup);
-        const slice = await snapshot.getPromise(currentSlice(modal));
+        const slices = await snapshot.getPromise(fos.currentSlices(modal));
         const { samples } = await getFetchFunction()("POST", "/tag", {
           ...tagParameters({
             activeFields: await snapshot.getPromise(
@@ -343,7 +337,8 @@ const useTagCallback = (
             groupData: isGroup
               ? {
                   id: modal ? await snapshot.getPromise(groupId) : null,
-                  slices: slice ? [slice] : [],
+                  slices,
+                  slice: await snapshot.getPromise(fos.groupSlice(false)),
                   mode: await snapshot.getPromise(groupStatistics(modal)),
                 }
               : null,

--- a/app/packages/core/src/components/Actions/Tagger.tsx
+++ b/app/packages/core/src/components/Actions/Tagger.tsx
@@ -328,9 +328,6 @@ const useTagCallback = (
   return useRecoilCallback(
     ({ snapshot, set, reset }) =>
       async ({ changes }) => {
-        const modalData = modal
-          ? await snapshot.getPromise(fos.modalSample)
-          : null;
         const isGroup = await snapshot.getPromise(fos.isGroup);
         const slice = await snapshot.getPromise(currentSlice(modal));
         const { samples } = await getFetchFunction()("POST", "/tag", {
@@ -375,13 +372,6 @@ const useTagCallback = (
         } else if (samples) {
           set(fos.refreshGroupQuery, (cur) => cur + 1);
           updateSamples(samples.map((sample) => [sample._id, sample]));
-          samples.forEach((sample) => {
-            if (modalData?.id === sample._id) {
-              lookerRef &&
-                lookerRef.current &&
-                lookerRef.current.updateSample(sample);
-            }
-          });
         }
 
         set(fos.anyTagging, false);

--- a/app/packages/core/src/components/Actions/utils.tsx
+++ b/app/packages/core/src/components/Actions/utils.tsx
@@ -161,6 +161,7 @@ export const tagParameters = ({
   activeFields: string[];
   groupData: {
     id: string | null;
+    slice: string | null;
     slices: string[] | null;
     mode: "group" | "slice";
   } | null;
@@ -188,6 +189,7 @@ export const tagParameters = ({
     label_fields: activeFields,
     target_labels: targetLabels,
     slices: !groups ? groupData?.slices : null,
+    slice: groupData?.slice,
     group_id: params.modal ? groupData?.id : null,
     sample_ids: getSampleIds(),
     labels:

--- a/app/packages/core/src/components/Filters/categoricalFilter/CategoricalFilter.tsx
+++ b/app/packages/core/src/components/Filters/categoricalFilter/CategoricalFilter.tsx
@@ -1,7 +1,7 @@
 import { Selector, useTheme } from "@fiftyone/components";
 import LoadingDots from "@fiftyone/components/src/components/Loading/LoadingDots";
 import * as fos from "@fiftyone/state";
-import { currentSlice, groupId, groupStatistics } from "@fiftyone/state";
+import { groupId, groupStatistics } from "@fiftyone/state";
 import { VALID_KEYPOINTS, getFetchFunction } from "@fiftyone/utilities";
 import { MutableRefObject, useEffect, useRef } from "react";
 import {
@@ -85,9 +85,10 @@ const categoricalSearchResults = selectorFamily<
           selected,
           group_id: modal ? get(groupId) || null : null,
           mixed,
-          slices: mixed ? null : get(currentSlice(modal)), // when mixed, slice is not needed
+          slice: get(fos.groupSlice(false)),
+          slices: mixed ? null : get(fos.currentSlices(modal)), // when mixed, slice is not needed
           sample_id:
-            modal && get(groupId) && !mixed ? get(fos.modalSampleId) : null,
+            modal && !get(groupId) && !mixed ? get(fos.modalSampleId) : null,
           ...sorting,
         });
       }

--- a/app/packages/core/src/components/Modal/Looker.tsx
+++ b/app/packages/core/src/components/Modal/Looker.tsx
@@ -98,7 +98,7 @@ const Looker = ({
   });
   const looker = React.useMemo(
     () => createLooker.current(sampleData),
-    [reset, sampleData, createLooker]
+    [reset, createLooker]
   );
 
   useEffect(() => {

--- a/app/packages/state/src/hooks/useExpandSample.ts
+++ b/app/packages/state/src/hooks/useExpandSample.ts
@@ -54,13 +54,17 @@ export default <T extends Lookers>(store: LookerStore<T>) => {
           groupAtoms.groupSlice(false)
         );
 
+        let pinned3d = false;
+        let activeSlices = [];
         if (groupSlice) {
           const map = await snapshot.getPromise(groupAtoms.groupMediaTypesMap);
           if (map[groupSlice] === "point_cloud") {
-            set(groupAtoms.pinned3d, true);
-            set(groupAtoms.activePcdSlices, [groupSlice]);
+            pinned3d = true;
+            activeSlices = [groupSlice];
           }
         }
+        set(groupAtoms.pinned3d, pinned3d);
+        set(groupAtoms.activePcdSlices, activeSlices);
 
         const results = await Promise.all(
           data.map(([_, get]) =>

--- a/app/packages/state/src/hooks/useSetExpandedSample.ts
+++ b/app/packages/state/src/hooks/useSetExpandedSample.ts
@@ -22,7 +22,7 @@ export default () => {
         groupId?: string,
         groupByFieldValue?: string
       ) => {
-        groupId && set(groupAtoms.groupId, groupId);
+        set(groupAtoms.groupId, groupId || null);
         set(currentModalSample, { id, index });
         reset(groupAtoms.nestedGroupIndex);
         reset(dynamicGroupCurrentElementIndex);

--- a/fiftyone/server/routes/tag.py
+++ b/fiftyone/server/routes/tag.py
@@ -37,6 +37,7 @@ class Tag(HTTPEndpoint):
         extended = data.get("extended", None)
         current_frame = data.get("current_frame", None)
         slices = data.get("slices", None)
+        slice = data.get("slice", None)
         group_id = data.get("group_id", None)
         view = fost.get_tag_view(
             dataset,
@@ -46,7 +47,9 @@ class Tag(HTTPEndpoint):
             labels=labels,
             hidden_labels=hidden_labels,
             sample_filter=SampleFilter(
-                group=GroupElementFilter(id=group_id, slices=slices)
+                group=GroupElementFilter(
+                    slice=slice, id=group_id, slices=slices
+                )
                 if not sample_ids
                 else None
             ),

--- a/fiftyone/server/routes/tagging.py
+++ b/fiftyone/server/routes/tagging.py
@@ -32,6 +32,7 @@ class Tagging(HTTPEndpoint):
         extended = data.get("extended", None)
         slices = data.get("slices", None)
         group_id = data.get("group_id", None)
+        slice = data.get("slice", None)
         view = fost.get_tag_view(
             dataset,
             stages=stages,
@@ -41,7 +42,9 @@ class Tagging(HTTPEndpoint):
             labels=labels,
             hidden_labels=hidden_labels,
             sample_filter=SampleFilter(
-                group=GroupElementFilter(id=group_id, slices=slices)
+                group=GroupElementFilter(
+                    slice=slice, id=group_id, slices=slices
+                )
                 if not sample_ids
                 else None
             ),

--- a/fiftyone/server/routes/values.py
+++ b/fiftyone/server/routes/values.py
@@ -33,13 +33,16 @@ class Values(HTTPEndpoint):
         extended = data.get("extended", None)
         group_id = data.get("group_id", None)
         slices = data.get("slices", None)
+        slice = data.get("slice", None)
 
         view = fosv.get_view(
             dataset,
             stages=stages,
             extended_stages=extended,
             sample_filter=SampleFilter(
-                group=GroupElementFilter(id=group_id, slices=slices)
+                group=GroupElementFilter(
+                    slice=slice, id=group_id, slices=slices
+                )
             ),
         )
 


### PR DESCRIPTION
Fixes and/or adds support for tagging all visible (selected) PCD slices. Also ensures modal state is configured correctly on expansion. Currently on `release/v0.21.5`, opening a group dataset sample and then closing, and switching to non-group dataset and _then_ opening the modal will crash the App.


Example multi-pcd slice group dataset
```py
import fiftyone as fo
import fiftyone.zoo as foz

dataset = fo.Dataset("pcd-only-sparse")
dataset.add_group_field("group", default="shared")
dataset.persistent = True

source = foz.load_zoo_dataset("quickstart-groups", max_samples=9)
source.group_slice = "pcd"

first = fo.Group()
one = source.first().copy()
one.group = first.element("shared")

two = source.skip(1).first().copy()
two.group = first.element("unique")

second = fo.Group()
three = source.skip(2).first().copy()
three.group = second.element("shared")

dataset.add_samples([one, two, three])
```