### PR TITLE
Fix dynamic groups modal of a view

### DIFF
--- a/app/packages/state/src/recoil/view.ts
+++ b/app/packages/state/src/recoil/view.ts
@@ -220,7 +220,10 @@ export const dynamicGroupViewQuery = selector<Stage[]>({
       });
     }
 
-    return viewStages;
+    return [
+      ...get(view).filter(({ _cls }) => _cls !== GROUP_BY_VIEW_STAGE),
+      ...viewStages,
+    ];
   },
 });
 

--- a/app/packages/state/src/recoil/view.ts
+++ b/app/packages/state/src/recoil/view.ts
@@ -40,6 +40,7 @@ export const LIMIT_VIEW_STAGE = "fiftyone.core.stages.Limit";
 export const MATCH_VIEW_STAGE = "fiftyone.core.stages.Match";
 export const SKIP_VIEW_STAGE = "fiftyone.core.stages.Skip";
 export const SORT_VIEW_STAGE = "fiftyone.core.stages.SortBy";
+export const TAKE_VIEW_STAGE = "fiftyone.core.stages.Take";
 
 enum ELEMENT_NAMES {
   CLIP = "clip",
@@ -238,7 +239,13 @@ export const dynamicGroupViewQuery = selector<Stage[]>({
         continue;
       }
 
-      if (![LIMIT_VIEW_STAGE, SKIP_VIEW_STAGE].includes(stage._cls)) {
+      // Assume these stages should be filtered out because they apply to the slices
+      // and not a slice list. To be improved
+      if (
+        ![LIMIT_VIEW_STAGE, SKIP_VIEW_STAGE, TAKE_VIEW_STAGE].includes(
+          stage._cls
+        )
+      ) {
         modalView.push(stage);
       }
     }


### PR DESCRIPTION
Will follow up with e2e.

Dynamic grouping of a group dataset requires pagination over the dynamically grouped samples. These results require providing the current view while replacing the `GroupBy` stage with the matching stage and filtering limit and skip stages post matching stage.
```py
import fiftyone as fo
import fiftyone.zoo as foz

ds = foz.load_zoo_dataset('quickstart-groups',dataset_name='qsg-test')

scene_id = ['scene1','scene2','scene3','scene4']*50
frame = range(len(ds))
for slice in ds.group_slices:
    ds.group_slice = slice
    ds.set_values('scene_id',scene_id)
    ds.set_values('frame',frame)

v = ds.limit(10)
view = v.group_by('scene_id', order_by='frame')
ds.save_view('dynamic-limit', view)

session = fo.launch_app(view)
```
<img width="1470" alt="Screen Shot 2023-08-04 at 10 34 05 AM" src="https://github.com/voxel51/fiftyone/assets/19821840/f07f2701-3044-42ae-906f-bae74bfee09e">
