### PR TITLE
bugfix/colorModal active field in sidemenu

### DIFF
--- a/app/packages/core/src/components/ColorModal/ColorModal.tsx
+++ b/app/packages/core/src/components/ColorModal/ColorModal.tsx
@@ -138,8 +138,6 @@ const ColorModal = () => {
                   <SidebarList />
                   <Display>
                     {field === ACTIVE_FIELD.global && <GlobalSetting />}
-                    Note that in this panel the color pool is the only savable
-                    option for now.
                     {field === ACTIVE_FIELD.json && <JSONViewer />}
                     {typeof field !== "string" && field && (
                       <FieldSetting prop={activeColorModalField} />

--- a/app/packages/core/src/components/ColorModal/GlobalSetting.tsx
+++ b/app/packages/core/src/components/ColorModal/GlobalSetting.tsx
@@ -1,12 +1,12 @@
-import React from "react";
-import { Divider, Slider, Typography } from "@mui/material";
 import { SettingsBackupRestore } from "@mui/icons-material";
+import { Divider, Slider, Typography } from "@mui/material";
+import React from "react";
 
 import * as fos from "@fiftyone/state";
 
+import Checkbox from "../Common/Checkbox";
 import RadioGroup from "../Common/RadioGroup";
 import ColorPalette from "./colorPalette/ColorPalette";
-import Checkbox from "../Common/Checkbox";
 
 import {
   ControlGroupWrapper,
@@ -78,6 +78,7 @@ const GlobalSetting: React.FC = ({}) => {
           setValue={(v) => props.setShowSkeleton(v)}
         />
       </ControlGroupWrapper>
+      Note that in this panel the color pool is the only savable option for now.
     </div>
   );
 };

--- a/app/packages/core/src/components/ColorModal/SidebarList.tsx
+++ b/app/packages/core/src/components/ColorModal/SidebarList.tsx
@@ -49,10 +49,10 @@ const SidebarList: React.FC = () => {
   );
 
   const getCurrentField = (activeField) => {
-    if (activeField === ACTIVE_FIELD.global) return ACTIVE_FIELD.global;
-    if (activeField === ACTIVE_FIELD.json) return ACTIVE_FIELD.json;
+    if (activeField === ACTIVE_FIELD.global) return [ACTIVE_FIELD.global];
+    if (activeField === ACTIVE_FIELD.json) return [ACTIVE_FIELD.json];
 
-    return activeField?.expandedPath;
+    return [activeField?.expandedPath, activeField.field.path];
   };
   return (
     <Resizable
@@ -121,7 +121,7 @@ const SidebarList: React.FC = () => {
                         },
                       }}
                       key={`menu-${pathIdx}`}
-                      selected={path === getCurrentField(activeField)}
+                      selected={getCurrentField(activeField).includes(path)}
                       disableRipple
                     >
                       <ListItemText


### PR DESCRIPTION
## What changes are proposed in this pull request?
Fix the following bugs:
1) note on global panel was showing in field level setting in the color modal.
2) open the color modal from ground_truth or predictions, the corresponding tab was not highlighted.

## How is this patch tested? If it is not, please explain why.

(Details)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
