### PR TITLE
Reset empty grid state

### DIFF
--- a/app/packages/core/src/components/Grid/Grid.tsx
+++ b/app/packages/core/src/components/Grid/Grid.tsx
@@ -179,11 +179,12 @@ const Grid: React.FC<{}> = () => {
     init();
   }, [init]);
 
-  if (isEmpty) {
-    return <Loading>No data</Loading>;
-  }
-
-  return <div id={id} className={flashlightLooker} data-cy="fo-grid"></div>;
+  return (
+    <>
+      {isEmpty && <Loading>No data</Loading>}
+      <div id={id} className={flashlightLooker} data-cy="fo-grid"></div>
+    </>
+  );
 };
 
 export default Grid;

--- a/app/packages/core/src/components/Grid/Grid.tsx
+++ b/app/packages/core/src/components/Grid/Grid.tsx
@@ -1,4 +1,3 @@
-import { Loading } from "@fiftyone/components";
 import Flashlight from "@fiftyone/flashlight";
 import { freeVideos } from "@fiftyone/looker";
 import * as fos from "@fiftyone/state";
@@ -34,7 +33,7 @@ const Grid: React.FC<{}> = () => {
   const resize = useResize();
 
   const isModalOpen = useRecoilValue(fos.isModalActive);
-  const { isEmpty, page, reset } = useFlashlightPager(
+  const { page, reset } = useFlashlightPager(
     store,
     pageParameters,
     gridCropCallback
@@ -179,12 +178,7 @@ const Grid: React.FC<{}> = () => {
     init();
   }, [init]);
 
-  return (
-    <>
-      {isEmpty && <Loading>No data</Loading>}
-      <div id={id} className={flashlightLooker} data-cy="fo-grid"></div>
-    </>
-  );
+  return <div id={id} className={flashlightLooker} data-cy="fo-grid"></div>;
 };
 
 export default Grid;

--- a/app/packages/core/src/components/Modal/Group/GroupCarousel.tsx
+++ b/app/packages/core/src/components/Modal/Group/GroupCarousel.tsx
@@ -170,19 +170,22 @@ const Column: React.FC = () => {
   }, [init]);
 
   if (isEmpty) {
-    return <Loading>No data</Loading>;
+    return;
   }
 
   return (
-    <div
-      style={{
-        display: "block",
-        width: "100%",
-        height: "100%",
-        position: "relative",
-      }}
-      id={id}
-    ></div>
+    <>
+      {isEmpty && <Loading>No data</Loading>}
+      <div
+        style={{
+          display: "block",
+          width: "100%",
+          height: "100%",
+          position: "relative",
+        }}
+        id={id}
+      ></div>
+    </>
   );
 };
 

--- a/app/packages/core/src/components/Modal/Group/GroupCarousel.tsx
+++ b/app/packages/core/src/components/Modal/Group/GroupCarousel.tsx
@@ -169,10 +169,6 @@ const Column: React.FC = () => {
     init();
   }, [init]);
 
-  if (isEmpty) {
-    return;
-  }
-
   return (
     <>
       {isEmpty && <Loading>No data</Loading>}

--- a/app/packages/core/src/useFlashlightPager.ts
+++ b/app/packages/core/src/useFlashlightPager.ts
@@ -69,9 +69,8 @@ const useFlashlightPager = (
             );
 
             subscription.unsubscribe();
-            if (!pageNumber && !items.length) {
-              setIsEmpty(true);
-            }
+            !pageNumber && setIsEmpty(!items.length);
+
             resolve({
               items,
               nextRequestKey: data.samples.pageInfo.hasNextPage

--- a/app/packages/looker-3d/src/Looker3d.tsx
+++ b/app/packages/looker-3d/src/Looker3d.tsx
@@ -2,6 +2,7 @@ import { Loading, useTheme } from "@fiftyone/components";
 import { isValidColor } from "@fiftyone/looker/src/overlays/util";
 import * as fop from "@fiftyone/plugins";
 import * as fos from "@fiftyone/state";
+import { Typography } from "@mui/material";
 import { OrbitControlsProps as OrbitControls } from "@react-three/drei";
 import { Canvas } from "@react-three/fiber";
 import _ from "lodash";
@@ -49,7 +50,6 @@ import {
   isPointSizeAttenuatedAtom,
   shadeByAtom,
 } from "./state";
-import { Typography } from "@mui/material";
 
 type View = "pov" | "top";
 
@@ -540,7 +540,7 @@ export const Looker3d = () => {
 
 class ErrorBoundary extends React.Component<
   { children: React.ReactNode },
-  { error: Error | null }
+  { error: Error | string | null }
 > {
   state = { error: null, hasError: false };
 
@@ -555,7 +555,15 @@ class ErrorBoundary extends React.Component<
 
   render() {
     if (this.state.hasError) {
-      return <Loading dataCy={"looker3d"}>{this.state.error.message}</Loading>;
+      // useLoader from @react-three/fiber throws a raw string for PCD 404
+      // not an error
+      return (
+        <Loading dataCy={"looker3d"}>
+          {this.state.error instanceof Error
+            ? this.state.error.message
+            : this.state.error}
+        </Loading>
+      );
     }
 
     return this.props.children;


### PR DESCRIPTION
Fixes empty grid resets, a regression introduced by `useFlashlightPager`. The attached recording shows how to currently reproduce the error on `release/v0.21.5`

https://github.com/voxel51/fiftyone/assets/19821840/8c07fbca-e22b-44f1-b5a4-dd69c6c3ba0e


