### PR TITLE
Update Ultralytics YOLO `dataset.yaml` format

### DIFF
--- a/fiftyone/utils/yolo.py
+++ b/fiftyone/utils/yolo.py
@@ -944,8 +944,9 @@ class YOLOv5DatasetExporter(
             d["path"] = os.path.dirname(self.yaml_path)
 
         d[self.split] = _make_yolo_v5_path(self.data_path, self.yaml_path)
-        d["nc"] = len(classes)
-        d["names"] = classes
+
+        # New data.yaml format https://docs.ultralytics.com/datasets/detect/
+        d["names"] = dict(enumerate(classes))  # class names dictionary
 
         _write_yaml_file(d, self.yaml_path, default_flow_style=False)
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

@brimoor PR per https://github.com/voxel51/fiftyone/issues/3392. 

If we could squeeze this into `fiftyone==0.21.5` that would be awesome!

Replaced `nc` integer and `names` list with a `names` dictionary per the new format in https://docs.ultralytics.com/datasets/detect/. 

This new format works for all Ultralytics YOLO repos (v3/v5/v8) and has been in place for about a year, so this should be widely compatible with most forks and copies in the wild.

The old format is being maintained through 2023 and will be deprecated in 2024.

## How is this patch tested? If it is not, please explain why.

Not tested.

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

> Replaced deprecated `nc` integer and `names` list with a `names` dictionary per the new format in https://docs.ultralytics.com/datasets/detect/. This new format works for all Ultralytics YOLO repos (v3/v5/v8) and has been in place for about a year, so this should be widely compatible with most forks and copies in the wild.


### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
