### PR TITLE
add event utils fixture

### DIFF
--- a/e2e-pw/src/oss/fixtures/index.ts
+++ b/e2e-pw/src/oss/fixtures/index.ts
@@ -1,15 +1,24 @@
 import { test as base } from "@playwright/test";
+import { EventUtils } from "src/shared/event-utils";
 import { MediaFactory } from "src/shared/media-factory";
 import { AbstractFiftyoneLoader } from "../../shared/abstract-loader";
 import { OssLoader } from "./loader";
 
-export type CustomFixtures = {
+// note: this difference between "with" and "without" is only for type safety
+
+// these fixtures do not have access to the {page} fixture
+export type CustomFixturesWithoutPage = {
   fiftyoneLoader: AbstractFiftyoneLoader;
   fiftyoneServerPort: number;
   mediaFactory: typeof MediaFactory;
 };
 
-export const test = base.extend<{}, CustomFixtures>({
+// these fixtures have access to the {page} fixture
+export type CustomFixturesWithPage = {
+  eventUtils: EventUtils;
+};
+
+const customFixtures = base.extend<{}, CustomFixturesWithoutPage>({
   fiftyoneServerPort: [
     async ({}, use, workerInfo) => {
       if (process.env.USE_DEV_BUILD) {
@@ -41,6 +50,12 @@ export const test = base.extend<{}, CustomFixtures>({
     },
     { scope: "worker" },
   ],
+});
+
+export const test = customFixtures.extend<CustomFixturesWithPage>({
+  eventUtils: async ({ page }, use) => {
+    await use(new EventUtils(page));
+  },
   baseURL: async ({ fiftyoneServerPort }, use) => {
     if (process.env.USE_DEV_BUILD) {
       if (process.env.IS_UTILITY_DOCKER) {

--- a/e2e-pw/src/oss/poms/grid/index.ts
+++ b/e2e-pw/src/oss/poms/grid/index.ts
@@ -52,20 +52,6 @@ export class GridPom {
     await this.page.getByTestId("selector-slice").fill(slice);
     await this.page.getByTestId("selector-slice").press("Enter");
   }
-
-  async getSampleLoadEventPromiseForFilepath(sampleFilepath: string) {
-    return this.page.evaluate(
-      (sampleFilepath_) =>
-        new Promise<void>((resolve, _reject) => {
-          document.addEventListener("sample-loaded", (e: CustomEvent) => {
-            if ((e.detail.sampleFilepath as string) === sampleFilepath_) {
-              resolve();
-            }
-          });
-        }),
-      sampleFilepath
-    );
-  }
 }
 
 class GridAsserter {

--- a/e2e-pw/src/oss/poms/modal/index.ts
+++ b/e2e-pw/src/oss/poms/modal/index.ts
@@ -149,20 +149,6 @@ export class ModalPom {
       { timeout: Duration.Seconds(10) }
     );
   }
-
-  async getSampleLoadEventPromiseForFilepath(sampleFilepath: string) {
-    return this.page.evaluate(
-      (sampleFilepath_) =>
-        new Promise<void>((resolve, _reject) => {
-          document.addEventListener("sample-loaded", (e: CustomEvent) => {
-            if ((e.detail.sampleFilepath as string) === sampleFilepath_) {
-              resolve();
-            }
-          });
-        }),
-      sampleFilepath
-    );
-  }
 }
 
 class ModalAsserter {

--- a/e2e-pw/src/oss/specs/regression-tests/group-video/default-video-slice-group.spec.ts
+++ b/e2e-pw/src/oss/specs/regression-tests/group-video/default-video-slice-group.spec.ts
@@ -74,7 +74,11 @@ test.describe("default video slice group", () => {
     fiftyoneLoader.waitUntilLoad(page, datasetName);
   });
 
-  test("video as default slice renders", async ({ grid, modal, page }) => {
+  test("video as default slice renders", async ({
+    grid,
+    modal,
+    eventUtils,
+  }) => {
     await grid.sliceSelector.assert.verifyHasSlices(["video", "image"]);
     await grid.sliceSelector.assert.verifyActiveSlice("video");
     await grid.assert.assertNLookers(1);
@@ -85,8 +89,10 @@ test.describe("default video slice group", () => {
     await modal.assert.verifyCarouselLength(2);
     await modal.close();
 
-    const imgLoadedPromise =
-      grid.getSampleLoadEventPromiseForFilepath(testImgPath);
+    const imgLoadedPromise = eventUtils.getEventReceivedPromiseForPredicate(
+      "sample-loaded",
+      (e) => e.detail.sampleFilepath === testImgPath
+    );
     await grid.selectSlice("image");
     await imgLoadedPromise;
 

--- a/e2e-pw/src/oss/specs/regression-tests/group-video/group-video-label.spec.ts
+++ b/e2e-pw/src/oss/specs/regression-tests/group-video/group-video-label.spec.ts
@@ -87,6 +87,7 @@ test.describe("groups video labels", () => {
   test("video plays with correct label for each slice", async ({
     grid,
     modal,
+    eventUtils,
   }) => {
     await grid.openFirstLooker();
     await modal.waitForSampleLoadDomAttribute();
@@ -122,7 +123,10 @@ test.describe("groups video labels", () => {
     await checkVideo("v1");
 
     const sampleLoadEventPromiseForv2 =
-      modal.getSampleLoadEventPromiseForFilepath(testVideoPath2);
+      eventUtils.getEventReceivedPromiseForPredicate(
+        "sample-loaded",
+        (e) => e.detail.sampleFilepath === testVideoPath2
+      );
 
     // change slice and repeat
     await modal.group.selectNthItemFromCarousel(1);

--- a/e2e-pw/src/shared/event-utils/index.ts
+++ b/e2e-pw/src/shared/event-utils/index.ts
@@ -1,0 +1,31 @@
+import { Page } from "@playwright/test";
+
+export class EventUtils {
+  constructor(private readonly page: Page) {}
+
+  public async getEventReceivedPromiseForPredicate(
+    eventName: string,
+    predicate: (e: CustomEvent) => boolean
+  ) {
+    const exposedFunctionName = getFunctionNameWithRandomSuffix(eventName);
+    this.page.exposeFunction(exposedFunctionName, (e: CustomEvent) => {
+      return predicate(e);
+    });
+
+    // note: cannot directly pass function to `evaluate`, which is why we expose it to the `window` object first
+    return this.page.evaluate(
+      ({ eventName_, exposedFunctionName_ }) =>
+        new Promise<void>((resolve, _reject) => {
+          document.addEventListener(eventName_, (e: CustomEvent) => {
+            if (window[exposedFunctionName_](e)) {
+              resolve();
+            }
+          });
+        }),
+      { eventName_: eventName, exposedFunctionName_: exposedFunctionName }
+    );
+  }
+}
+
+const getFunctionNameWithRandomSuffix = (name: string) =>
+  `${name}_${Math.random().toString(36).substring(7)}`;


### PR DESCRIPTION
## What changes are proposed in this pull request?

Add a generic `EventUtils` fixture that can be used to wait on arbitrary events until a predicate is satisfied.

## How is this patch tested? If it is not, please explain why.

locally

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
