### PR TITLE
Count text when toPatches, then groupBy fix + e2e

### DIFF
--- a/app/packages/core/src/components/Actions/Common.tsx
+++ b/app/packages/core/src/components/Actions/Common.tsx
@@ -8,6 +8,7 @@ import { ItemAction } from "./ItemAction";
 import { useHighlightHover } from "./utils";
 
 type ActionOptionProps = {
+  id: string;
   onClick?: (event?: Event) => void;
   href?: string;
   text: string;
@@ -20,6 +21,7 @@ type ActionOptionProps = {
 
 export const ActionOption = React.memo(
   ({
+    id,
     onClick,
     text,
     href,
@@ -37,6 +39,7 @@ export const ActionOption = React.memo(
     }
     return (
       <ItemAction
+        data-cy={`${id}-${text}`}
         title={title ? title : text}
         onClick={disabled ? null : onClick}
         {...rest}

--- a/app/packages/core/src/components/Actions/Patcher.tsx
+++ b/app/packages/core/src/components/Actions/Patcher.tsx
@@ -124,6 +124,7 @@ const LabelsPatches = ({ close }) => {
       {fields.map((field) => {
         return (
           <ActionOption
+            id="labels-patches"
             key={field}
             text={field}
             title={`Switch to patches view for the "${field}" field`}

--- a/app/packages/core/src/components/ImageContainerHeader.tsx
+++ b/app/packages/core/src/components/ImageContainerHeader.tsx
@@ -11,7 +11,7 @@ import { GridActionsRow } from "./Actions";
 import { Slider } from "./Common/RangeSlider";
 import { gridZoom, gridZoomRange } from "./Grid";
 import GroupSliceSelector from "./GroupSliceSelector";
-import { PathEntryCounts } from "./Sidebar/Entries/EntryCounts";
+import ResourceCount from "./ResourceCount";
 
 export const SamplesHeader = styled.div`
   position: absolute;
@@ -56,58 +56,6 @@ const SliderContainer = styled.div`
   padding-right: 1rem;
 `;
 
-const Count = () => {
-  let element = useRecoilValue(fos.elementNames);
-  const total = useRecoilValue(
-    fos.count({ path: "", extended: false, modal: false })
-  );
-  const isGroup = useRecoilValue(isGroupAtom);
-  const slice = useRecoilValue(fos.groupSlice(false));
-  if (isGroup) {
-    element = {
-      plural: "groups",
-      singular: "group",
-    };
-  }
-
-  return (
-    <RightDiv data-cy="entry-counts">
-      <div style={{ whiteSpace: "nowrap" }}>
-        <PathEntryCounts modal={false} path={""} />
-        {` `}
-        {total === 1 ? element.singular : element.plural}
-        {slice && ` with slice`}
-      </div>
-    </RightDiv>
-  );
-};
-
-const GroupsCount = () => {
-  const element = useRecoilValue(fos.elementNames);
-  const total = useRecoilValue(
-    fos.count({ path: "_", extended: false, modal: false })
-  );
-
-  const elementTotal = useRecoilValue(
-    fos.count({ path: "", extended: false, modal: false })
-  );
-  const groupSlice = useRecoilValue(fos.groupSlice(false));
-
-  return (
-    <RightDiv data-cy="entry-counts">
-      <div>
-        (<PathEntryCounts modal={false} path={""} />
-        {` `}
-        {elementTotal === 1 ? element.singular : element.plural}){` `}
-        <PathEntryCounts modal={false} path={"_"} ignoreSidebarMode />
-        {` `}
-        {total === 1 ? "group" : "groups"}
-        {groupSlice && ` with slice`}
-      </div>
-    </RightDiv>
-  );
-};
-
 const ImageContainerHeader = () => {
   const setGridZoom = useSetRecoilState(gridZoom);
   const gridZoomRangeValue = useRecoilValue(gridZoomRange);
@@ -132,7 +80,7 @@ const ImageContainerHeader = () => {
             </RightDiv>
           }
         >
-          {groupStats === "group" ? <GroupsCount /> : <Count />}
+          <ResourceCount isGroup={groupStats === "group"} />
         </Suspense>
         {shouldShowSliceSelector && (
           <RightDiv>

--- a/app/packages/core/src/components/ResourceCount.tsx
+++ b/app/packages/core/src/components/ResourceCount.tsx
@@ -1,0 +1,92 @@
+import React from "react";
+import { useRecoilValue } from "recoil";
+
+import styled from "styled-components";
+import * as fos from "@fiftyone/state";
+import { isGroup as isGroupAtom } from "@fiftyone/state";
+import { PathEntryCounts } from "./Sidebar/Entries/EntryCounts";
+
+const Container = styled.div`
+  display: flex;
+  width: 100%;
+  height: 100%;
+`;
+
+const RightDiv = styled.div`
+  display: flex;
+  justify-content: center;
+  align-content: center;
+  flex-direction: column;
+  border-color: ${({ theme }) => theme.primary.plainBorder};
+  border-right-style: solid;
+  border-right-width: 1px;
+  margin: 0 0.25rem;
+  padding-right: 1rem;
+  font-weight: bold;
+`;
+
+interface Props {
+  isGroup: boolean;
+}
+
+const ResourceCount = ({ isGroup }: Props) => {
+  return <Container>{isGroup ? <GroupsCount /> : <Count />}</Container>;
+};
+
+const GroupsCount = () => {
+  const element = useRecoilValue(fos.elementNames);
+  const total = useRecoilValue(
+    fos.count({ path: "_", extended: false, modal: false })
+  );
+
+  const elementTotal = useRecoilValue(
+    fos.count({ path: "", extended: false, modal: false })
+  );
+  const groupSlice = useRecoilValue(fos.groupSlice(false));
+
+  return (
+    <RightDiv data-cy="entry-counts">
+      <div>
+        (<PathEntryCounts modal={false} path={""} />
+        {` `}
+        {elementTotal === 1 ? element.singular : element.plural}){` `}
+        <PathEntryCounts modal={false} path={"_"} ignoreSidebarMode />
+        {` `}
+        {total === 1 ? "group" : "groups"}
+        {groupSlice && ` with slice`}
+      </div>
+    </RightDiv>
+  );
+};
+
+const Count = () => {
+  let element = useRecoilValue(fos.elementNames);
+  const isDynamicGroupViewStageActive = useRecoilValue(fos.isDynamicGroup);
+  const total = useRecoilValue(
+    fos.count({ path: "", extended: false, modal: false })
+  );
+  const isGroup = useRecoilValue(isGroupAtom);
+  const slice = useRecoilValue(fos.groupSlice(false));
+  if (isGroup) {
+    element = {
+      plural: "groups",
+      singular: "group",
+    };
+  }
+
+  return (
+    <RightDiv data-cy="entry-counts">
+      <div style={{ whiteSpace: "nowrap" }}>
+        <PathEntryCounts modal={false} path={""} />
+        {` `}
+        {isDynamicGroupViewStageActive &&
+          !isGroup &&
+          `group${total === 1 ? "" : "s"} of `}
+        {total === 1 ? element.singular : element.plural}
+        {slice && ` with slice`}
+      </div>
+    </RightDiv>
+  );
+};
+
+export default ResourceCount;

--- a/app/packages/core/src/components/ResourceCount.tsx
+++ b/app/packages/core/src/components/ResourceCount.tsx
@@ -1,16 +1,10 @@
 import React from "react";
 import { useRecoilValue } from "recoil";
 
-import styled from "styled-components";
 import * as fos from "@fiftyone/state";
 import { isGroup as isGroupAtom } from "@fiftyone/state";
+import styled from "styled-components";
 import { PathEntryCounts } from "./Sidebar/Entries/EntryCounts";
-
-const Container = styled.div`
-  display: flex;
-  width: 100%;
-  height: 100%;
-`;
 
 const RightDiv = styled.div`
   display: flex;
@@ -23,6 +17,7 @@ const RightDiv = styled.div`
   margin: 0 0.25rem;
   padding-right: 1rem;
   font-weight: bold;
+  white-space: nowrap;
 `;
 
 interface Props {
@@ -30,7 +25,7 @@ interface Props {
 }
 
 const ResourceCount = ({ isGroup }: Props) => {
-  return <Container>{isGroup ? <GroupsCount /> : <Count />}</Container>;
+  return isGroup ? <GroupsCount /> : <Count />;
 };
 
 const GroupsCount = () => {

--- a/app/packages/core/src/components/index.ts
+++ b/app/packages/core/src/components/index.ts
@@ -6,3 +6,4 @@ export { default as FieldLabelAndInfo } from "./FieldLabelAndInfo";
 export { default as Loading } from "./Loading";
 export { default as Setup } from "./Setup";
 export { default as ViewBar } from "./ViewBar/ViewBar";
+export { default as ResourceCount } from "./ResourceCount";

--- a/e2e-pw/src/oss/poms/action-row/grid-actions-row.ts
+++ b/e2e-pw/src/oss/poms/action-row/grid-actions-row.ts
@@ -44,4 +44,12 @@ export class GridActionsRowPom {
   async toggleColorSettings() {
     return this.openAction("action-color-settings");
   }
+
+  toPatchesByLabelField(fieldName: string) {
+    return this.page.getByTestId(`labels-patches-${fieldName}`);
+  }
+
+  async clickToPatchesByLabelField(fieldName: string) {
+    await this.toPatchesByLabelField(fieldName).click();
+  }
 }

--- a/e2e-pw/src/oss/poms/action-row/grid-actions-row.ts
+++ b/e2e-pw/src/oss/poms/action-row/grid-actions-row.ts
@@ -45,11 +45,19 @@ export class GridActionsRowPom {
     return this.openAction("action-color-settings");
   }
 
-  toPatchesByLabelField(fieldName: string) {
-    return this.page.getByTestId(`labels-patches-${fieldName}`);
-  }
-
   async clickToPatchesByLabelField(fieldName: string) {
     await this.toPatchesByLabelField(fieldName).click();
+  }
+
+  async groupBy(path: string) {
+    await this.gridActionsRow.getByTestId("group-by-selector").click();
+    await this.gridActionsRow.getByTestId("group-by-selector").type(path);
+
+    await this.gridActionsRow.getByTestId("group-by-selector").press("Enter");
+    await this.gridActionsRow.getByTestId("dynamic-group-btn-submit").click();
+  }
+
+  toPatchesByLabelField(fieldName: string) {
+    return this.page.getByTestId(`labels-patches-${fieldName}`);
   }
 }

--- a/e2e-pw/src/oss/specs/smoke-tests/quickstart.spec.ts
+++ b/e2e-pw/src/oss/specs/smoke-tests/quickstart.spec.ts
@@ -33,13 +33,21 @@ test.describe("quickstart", () => {
     await modal.waitForSampleLoadDomAttribute();
   });
 
-  test("entry counts show correct text when toPatches then groupedBy", async ({
+  test("entry counts text when toPatches then groupedBy", async ({
     grid,
     fiftyoneLoader,
     page,
   }) => {
-    await grid.actionsRow.openToClipsOrPatches();
+    await grid.actionsRow.toggleToClipsOrPatches();
     await grid.actionsRow.clickToPatchesByLabelField("predictions");
     await fiftyoneLoader.waitUntilGridVisible(page, datasetName);
+
+    await grid.assert.isEntryCountTextEqualTo("122 patches");
+
+    await grid.actionsRow.toggleCreateDynamicGroups();
+    await grid.actionsRow.groupBy("predictions.label");
+
+    await fiftyoneLoader.waitUntilGridVisible(page, datasetName);
+    await grid.assert.isEntryCountTextEqualTo("33 groups of patches");
   });
 });

--- a/e2e-pw/src/oss/specs/smoke-tests/quickstart.spec.ts
+++ b/e2e-pw/src/oss/specs/smoke-tests/quickstart.spec.ts
@@ -24,10 +24,18 @@ test.beforeEach(async ({ page, fiftyoneLoader }) => {
   await fiftyoneLoader.waitUntilGridVisible(page, datasetName);
 });
 
-test("smoke", async ({ page, grid, modal }) => {
-  await expect(page.getByTestId("entry-counts")).toHaveText("5 samples");
+test.describe("quickstart", () => {
+  test("smoke", async ({ page, grid, modal }) => {
+    await expect(page.getByTestId("entry-counts")).toHaveText("5 samples");
 
-  // test navigation
-  await grid.openFirstSample();
-  await modal.waitForSampleLoadDomAttribute();
+    // test navigation
+    await grid.openFirstSample();
+    await modal.waitForSampleLoadDomAttribute();
+  });
+
+  test("entry counts show correct text when toPatches then groupedBy", async ({
+    grid,
+  }) => {
+    await grid.actionsRow.openToClipsOrPatches();
+  });
 });

--- a/e2e-pw/src/oss/specs/smoke-tests/quickstart.spec.ts
+++ b/e2e-pw/src/oss/specs/smoke-tests/quickstart.spec.ts
@@ -35,7 +35,11 @@ test.describe("quickstart", () => {
 
   test("entry counts show correct text when toPatches then groupedBy", async ({
     grid,
+    fiftyoneLoader,
+    page,
   }) => {
     await grid.actionsRow.openToClipsOrPatches();
+    await grid.actionsRow.clickToPatchesByLabelField("predictions");
+    await fiftyoneLoader.waitUntilGridVisible(page, datasetName);
   });
 });


### PR DESCRIPTION
## What changes are proposed in this pull request?

If groupBy stage is active, we inject "groups of" in the count text if appropriate.
minor refactor to move Count into its own component

https://github.com/voxel51/fiftyone/assets/109545780/998f8d18-b783-47cd-bd55-4c8fd7d17135



## How is this patch tested? If it is not, please explain why.

(Details)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
