### PR TITLE
empty groups should be hidden if field visibility active + e2e

### DIFF
--- a/app/packages/core/src/components/Schema/SchemaSelectionRow.tsx
+++ b/app/packages/core/src/components/Schema/SchemaSelectionRow.tsx
@@ -128,6 +128,7 @@ export const SchemaSelectionRow = (props: Props) => {
         <Box display="flex" flexDirection="row" width="100%">
           <Box>
             <Checkbox
+              data-cy={`schema-selection-${path}`}
               name={"Carousel"}
               value={path}
               checked={isSelected}

--- a/app/packages/core/src/components/Schema/SchemaSettings.tsx
+++ b/app/packages/core/src/components/Schema/SchemaSettings.tsx
@@ -133,6 +133,7 @@ const SchemaSettings = () => {
             padding: "1.5rem",
             backgroundColor: theme.background.level2,
           }}
+          data-cy="field-visibility-container"
         >
           <Box
             style={{
@@ -221,6 +222,7 @@ const SchemaSettings = () => {
             }}
           >
             <Button
+              data-cy="field-visibility-btn-apply"
               style={{
                 color: theme.text.primary,
                 marginRight: "0.5rem",

--- a/app/packages/core/src/components/Sidebar/Entries/AddGroupEntry.tsx
+++ b/app/packages/core/src/components/Sidebar/Entries/AddGroupEntry.tsx
@@ -1,6 +1,6 @@
 import * as fos from "@fiftyone/state";
 import React, { useContext, useState } from "react";
-import { useRecoilCallback } from "recoil";
+import { useRecoilCallback, useRecoilValue } from "recoil";
 
 import { getDatasetName, RouterContext } from "@fiftyone/state";
 import { InputDiv } from "./utils";
@@ -8,6 +8,8 @@ import { InputDiv } from "./utils";
 const AddGroup = () => {
   const [value, setValue] = useState("");
   const context = useContext(RouterContext);
+  const isFieldVisibilityApplied = useRecoilValue(fos.isFieldVisibilityActive);
+
   const addGroup = useRecoilCallback(
     ({ set, snapshot }) =>
       async (newGroup: string) => {
@@ -39,9 +41,14 @@ const AddGroup = () => {
     []
   );
 
+  if (isFieldVisibilityApplied) {
+    return null;
+  }
+
   return (
     <InputDiv style={{ margin: 0 }}>
       <input
+        data-cy="sidebar-field-add-group-input"
         type={"text"}
         placeholder={"+ add group"}
         value={value}

--- a/app/packages/core/src/components/Sidebar/Entries/AddGroupEntry.tsx
+++ b/app/packages/core/src/components/Sidebar/Entries/AddGroupEntry.tsx
@@ -40,7 +40,7 @@ const AddGroup = () => {
   );
 
   return (
-    <InputDiv>
+    <InputDiv style={{ margin: 0 }}>
       <input
         type={"text"}
         placeholder={"+ add group"}

--- a/app/packages/core/src/components/Sidebar/Entries/AddGroupEntry.tsx
+++ b/app/packages/core/src/components/Sidebar/Entries/AddGroupEntry.tsx
@@ -30,6 +30,7 @@ const AddGroup = () => {
         const view = await snapshot.getPromise(fos.view);
         set(fos.sidebarGroupsDefinition(false), newGroups);
         fos.persistSidebarGroups({
+          subscription: await snapshot.getPromise(fos.stateSubscription),
           dataset: getDatasetName(context),
           stages: view,
           sidebarGroups: newGroups,

--- a/app/packages/core/src/components/Sidebar/Entries/Draggable.tsx
+++ b/app/packages/core/src/components/Sidebar/Entries/Draggable.tsx
@@ -41,10 +41,16 @@ const Draggable: React.FC<
         : "grab"
       : "pointer",
   });
+  const dataCyKey = entryKey
+    ?.split(",")?.[1]
+    ?.replace(/["]/g, "")
+    ?.replace("]", "");
 
   return (
     <>
       <animated.div
+        data-draggable={!disableDrag && trigger && !isReadOnly}
+        data-cy={`sidebar-entry-draggable-${dataCyKey}`}
         onClick={(event) => {
           event.stopPropagation();
         }}

--- a/app/packages/core/src/components/Sidebar/Entries/Draggable.tsx
+++ b/app/packages/core/src/components/Sidebar/Entries/Draggable.tsx
@@ -2,7 +2,7 @@ import { useTheme } from "@fiftyone/components";
 import { isFieldVisibilityActive, readOnly } from "@fiftyone/state";
 import { DragIndicator } from "@mui/icons-material";
 import { animated, useSpring } from "@react-spring/web";
-import React, { useState } from "react";
+import React, { useMemo, useState } from "react";
 import { useRecoilValue } from "recoil";
 
 const Draggable: React.FC<
@@ -46,16 +46,21 @@ const Draggable: React.FC<
     ?.replace(/["]/g, "")
     ?.replace("]", "");
 
+  const isDraggable = useMemo(
+    () => !disableDrag && trigger && !isReadOnly,
+    [disableDrag, trigger, isReadOnly]
+  );
+
   return (
     <>
       <animated.div
-        data-draggable={!disableDrag && trigger && !isReadOnly}
+        data-draggable={isDraggable}
         data-cy={`sidebar-entry-draggable-${dataCyKey}`}
         onClick={(event) => {
           event.stopPropagation();
         }}
         onMouseDown={
-          !disableDrag && trigger && !isReadOnly
+          isDraggable
             ? (event) => {
                 setDragging(true);
                 trigger(event, entryKey, () => setDragging(false));

--- a/app/packages/core/src/components/Sidebar/Entries/Draggable.tsx
+++ b/app/packages/core/src/components/Sidebar/Entries/Draggable.tsx
@@ -1,5 +1,5 @@
 import { useTheme } from "@fiftyone/components";
-import { readOnly } from "@fiftyone/state";
+import { isFieldVisibilityActive, readOnly } from "@fiftyone/state";
 import { DragIndicator } from "@mui/icons-material";
 import { animated, useSpring } from "@react-spring/web";
 import React, { useState } from "react";
@@ -20,11 +20,14 @@ const Draggable: React.FC<
   const [hovering, setHovering] = useState(false);
   const [dragging, setDragging] = useState(false);
   const isReadOnly = useRecoilValue(readOnly);
+  const isFieldVisibilityApplied = useRecoilValue(isFieldVisibilityActive);
+
   const disableDrag =
     !entryKey ||
     entryKey.split(",")[1]?.includes("tags") ||
     entryKey.split(",")[1]?.includes("_label_tags") ||
-    isReadOnly;
+    isReadOnly ||
+    isFieldVisibilityApplied;
   const active = trigger && (dragging || hovering) && !disableDrag;
 
   const style = useSpring({
@@ -46,7 +49,7 @@ const Draggable: React.FC<
           event.stopPropagation();
         }}
         onMouseDown={
-          trigger && !isReadOnly
+          !disableDrag && trigger && !isReadOnly
             ? (event) => {
                 setDragging(true);
                 trigger(event, entryKey, () => setDragging(false));

--- a/app/packages/core/src/components/Sidebar/Entries/FilterEntry.tsx
+++ b/app/packages/core/src/components/Sidebar/Entries/FilterEntry.tsx
@@ -5,12 +5,7 @@ import FilterAltIcon from "@mui/icons-material/FilterAlt";
 import VisibilityIcon from "@mui/icons-material/Visibility";
 import { Box, Typography } from "@mui/material";
 import React from "react";
-import {
-  useRecoilState,
-  useRecoilValue,
-  useResetRecoilState,
-  useSetRecoilState,
-} from "recoil";
+import { useRecoilState, useResetRecoilState, useSetRecoilState } from "recoil";
 import styled from "styled-components";
 import { FilterInputDiv } from "./utils";
 
@@ -21,7 +16,6 @@ const Filter = ({ modal }: { modal: boolean }) => {
   );
 
   const setSchemaModal = useSetRecoilState(fos.settingsModal);
-  const selectedFieldsStage = useRecoilValue(fos.selectedFieldsStageState);
   const resetSelectedFieldStages = useResetRecoilState(
     fos.selectedFieldsStageState
   );
@@ -31,6 +25,7 @@ const Filter = ({ modal }: { modal: boolean }) => {
     resetExcludedPaths,
     affectedPathCount,
     mergedSchema,
+    isFieldVisibilityActive,
   } = fos.useSchemaSettings();
 
   const { setSearchResults } = fos.useSearchSchemaFields(mergedSchema);
@@ -92,7 +87,7 @@ const Filter = ({ modal }: { modal: boolean }) => {
       </Box>
       {!modal && (
         <Box display="flex" alignItems="center">
-          {selectedFieldsStage && affectedPathCount > 0 && (
+          {isFieldVisibilityActive && (
             <Tooltip text="Clear field selection" placement="bottom-center">
               <Box
                 data-cy="field-visibility-btn-clear"

--- a/app/packages/core/src/components/Sidebar/Entries/FilterEntry.tsx
+++ b/app/packages/core/src/components/Sidebar/Entries/FilterEntry.tsx
@@ -134,6 +134,7 @@ const Filter = ({ modal }: { modal: boolean }) => {
           )}
           <Tooltip text="Change field visibility" placement="bottom-center">
             <Settings
+              data-cy="field-visibility-icon"
               onClick={() => {
                 setSchemaModal({
                   open: true,

--- a/app/packages/core/src/components/Sidebar/Entries/FilterEntry.tsx
+++ b/app/packages/core/src/components/Sidebar/Entries/FilterEntry.tsx
@@ -95,6 +95,7 @@ const Filter = ({ modal }: { modal: boolean }) => {
           {selectedFieldsStage && affectedPathCount > 0 && (
             <Tooltip text="Clear field selection" placement="bottom-center">
               <Box
+                data-cy="field-visibility-btn-clear"
                 sx={{
                   minWidth: "50px",
                   maxWidth: "100px",

--- a/app/packages/core/src/components/Sidebar/Sidebar.tsx
+++ b/app/packages/core/src/components/Sidebar/Sidebar.tsx
@@ -700,7 +700,6 @@ const InteractiveSidebar = ({
   );
   const theme = useTheme();
   const resizableSide = modal ? "left" : "right";
-  console.log("items", items);
 
   return shown ? (
     <Resizable

--- a/app/packages/core/src/components/Sidebar/Sidebar.tsx
+++ b/app/packages/core/src/components/Sidebar/Sidebar.tsx
@@ -6,7 +6,7 @@ import { move } from "@fiftyone/utilities";
 
 import { useTheme } from "@fiftyone/components";
 import * as fos from "@fiftyone/state";
-import { useEventHandler, replace } from "@fiftyone/state";
+import { replace, useEventHandler } from "@fiftyone/state";
 import { scrollbarStyles } from "@fiftyone/utilities";
 import { Box } from "@mui/material";
 import { Resizable } from "re-resizable";
@@ -245,22 +245,18 @@ const isDisabledEntry = (
 ) => {
   if (entry.kind === fos.EntryKind.PATH) {
     return (
-      entry.path.startsWith("tags.") ||
-      entry.path.startsWith("_label_tags.") ||
+      entry.path === "tags" ||
+      entry.path === "_label_tags" ||
       disabled.has(entry.path)
     );
   }
 
   if (entry.kind === fos.EntryKind.EMPTY) {
-    return entry.group === "tags" || entry.group === "label tags";
+    return entry.group === "tags";
   }
 
   if (excludeGroups && entry.kind === fos.EntryKind.GROUP) {
-    return (
-      entry.name === "tags" ||
-      entry.name === "label tags" ||
-      entry.name === "other"
-    );
+    return entry.name === "tags" || entry.name === "other";
   }
 
   if (entry.kind === fos.EntryKind.INPUT) {

--- a/app/packages/core/src/components/Sidebar/Sidebar.tsx
+++ b/app/packages/core/src/components/Sidebar/Sidebar.tsx
@@ -700,6 +700,7 @@ const InteractiveSidebar = ({
   );
   const theme = useTheme();
   const resizableSide = modal ? "left" : "right";
+  console.log("items", items);
 
   return shown ? (
     <Resizable
@@ -794,9 +795,18 @@ const InteractiveSidebar = ({
                 style.zIndex = 0;
               }
 
+              let dataCy = `-field`;
+              if (entry.kind === fos.EntryKind.GROUP) {
+                dataCy = `sidebar-group-${entry.name}` + dataCy;
+              } else if (entry.kind === fos.EntryKind.PATH) {
+                dataCy = entry.path + dataCy;
+              } else {
+                dataCy = "sidebar" + dataCy;
+              }
+
               return (
                 <animated.div
-                  data-cy={`${entry?.path}-field`}
+                  data-cy={dataCy}
                   onMouseDownCapture={() => {
                     lastTouched.current = undefined;
                     placeItems();

--- a/app/packages/core/src/components/Sidebar/Sidebar.tsx
+++ b/app/packages/core/src/components/Sidebar/Sidebar.tsx
@@ -796,6 +796,7 @@ const InteractiveSidebar = ({
 
               return (
                 <animated.div
+                  data-cy={`${entry?.path}-field`}
                   onMouseDownCapture={() => {
                     lastTouched.current = undefined;
                     placeItems();

--- a/app/packages/state/src/hooks/useSchemaSettings.ts
+++ b/app/packages/state/src/hooks/useSchemaSettings.ts
@@ -23,6 +23,7 @@ export default function useSchemaSettings() {
   const [showMetadata, setShowMetadata] = useRecoilState(fos.showMetadataState);
   const dataset = useRecoilValue(fos.dataset);
   const isGroupDataset = dataset?.groupField;
+  const isFieldVisibilityActive = useRecoilValue(fos.isFieldVisibilityActive);
 
   const resetTextFilter = useResetRecoilState(fos.textFilter(false));
   const datasetName = useRecoilValue(fos.datasetName);
@@ -515,5 +516,6 @@ export default function useSchemaSettings() {
     toggleSelection,
     mergedSchema,
     resetAttributeFilters,
+    isFieldVisibilityActive,
   };
 }

--- a/app/packages/state/src/recoil/schemaSettings.atoms.ts
+++ b/app/packages/state/src/recoil/schemaSettings.atoms.ts
@@ -318,7 +318,4 @@ export const isFieldVisibilityActive = selector({
 
     return isSelectedFieldsStageActive && affectedCount > 0;
   },
-  cachePolicy_UNSTABLE: {
-    eviction: "most-recent",
-  },
 });

--- a/app/packages/state/src/recoil/schemaSettings.atoms.ts
+++ b/app/packages/state/src/recoil/schemaSettings.atoms.ts
@@ -309,3 +309,16 @@ export const selectedFieldsStageState = atom<any>({
     },
   ],
 });
+
+export const isFieldVisibilityActive = selector({
+  key: "isClearFieldVisibilityVisible",
+  get: ({ get }) => {
+    const isSelectedFieldsStageActive = get(fos.selectedFieldsStageState);
+    const affectedCount = get(fos.affectedPathCountState);
+
+    return isSelectedFieldsStageActive && affectedCount > 0;
+  },
+  cachePolicy_UNSTABLE: {
+    eviction: "most-recent",
+  },
+});

--- a/app/packages/state/src/recoil/sidebar.ts
+++ b/app/packages/state/src/recoil/sidebar.ts
@@ -344,12 +344,6 @@ export const sidebarGroups = selectorFamily<
         }
       }
 
-      // if field visibility is active, remove empty groups
-      const isFieldVisibilityActive = get(isFieldVisibilityActiveState);
-      if (isFieldVisibilityActive) {
-        return groups.filter((group) => group.paths.length > 0);
-      }
-
       return groups;
     },
   set:
@@ -441,9 +435,18 @@ export const sidebarEntries = selectorFamily<
   get:
     (params) =>
     ({ get }) => {
+      const isFieldVisibilityActive = get(isFieldVisibilityActiveState);
       const entries = [
         ...get(sidebarGroups(params))
           .map(({ name, paths }) => {
+            // if field visibility is active, return a hidden group
+            if (isFieldVisibilityActive && paths?.length === 0) {
+              return {
+                kind: EntryKind.EMPTY,
+                shown: false,
+              };
+            }
+
             const group: GroupEntry = {
               name: name,
               kind: EntryKind.GROUP,

--- a/app/packages/state/src/recoil/sidebar.ts
+++ b/app/packages/state/src/recoil/sidebar.ts
@@ -41,6 +41,7 @@ import {
   unsupportedMatcher,
 } from "./utils";
 import * as viewAtoms from "./view";
+import { isFieldVisibilityActive as isFieldVisibilityActiveState } from "./schemaSettings.atoms";
 
 export enum EntryKind {
   EMPTY = "EMPTY",
@@ -341,6 +342,12 @@ export const sidebarGroups = selectorFamily<
         ) {
           groups[framesIndex].expanded = false;
         }
+      }
+
+      // if field visibility is active, remove empty groups
+      const isFieldVisibilityActive = get(isFieldVisibilityActiveState);
+      if (isFieldVisibilityActive) {
+        return groups.filter((group) => group.paths.length > 0);
       }
 
       return groups;

--- a/e2e-pw/src/oss/poms/field-visibility/field-visibility.ts
+++ b/e2e-pw/src/oss/poms/field-visibility/field-visibility.ts
@@ -1,0 +1,52 @@
+import { expect, Locator, Page } from "src/oss/fixtures";
+
+export class FieldVisibilityPom {
+  readonly page: Page;
+  readonly assert: FieldVisibilityAsserter;
+
+  readonly sidebar: Locator;
+  readonly dialogLocator: Locator;
+
+  constructor(page: Page) {
+    this.page = page;
+    this.assert = new FieldVisibilityAsserter(this);
+
+    this.sidebar = page.getByTestId("sidebar");
+  }
+
+  fieldVisibilityBtn() {
+    return this.sidebar.getByTestId("field-visibility-icon");
+  }
+
+  async openFieldVisibilityModal() {
+    await this.fieldVisibilityBtn().click();
+  }
+
+  async hideFields(fieldNames: string[]) {
+    await this.openFieldVisibilityModal();
+    for (let fName in fieldNames) {
+      await this.sidebar.getByTestId(fName).hover();
+    }
+  }
+
+  // TODO: possibly replace when sidebar pom available
+  sidebarField(fieldName: string) {
+    return this.sidebar
+      .getByTestId(`${fieldName}-field`)
+      .locator("div")
+      .filter({ hasText: fieldName })
+      .nth(1);
+  }
+}
+
+class FieldVisibilityAsserter {
+  constructor(private readonly svp: FieldVisibilityPom) {}
+
+  async assertFieldInSidebar(fieldName: string) {
+    await expect(this.svp.sidebarField(fieldName)).toBeVisible();
+  }
+
+  async assertFieldNotInSidebar(fieldName: string) {
+    await expect(this.svp.sidebarField(fieldName)).toBeHidden();
+  }
+}

--- a/e2e-pw/src/oss/poms/field-visibility/field-visibility.ts
+++ b/e2e-pw/src/oss/poms/field-visibility/field-visibility.ts
@@ -1,4 +1,5 @@
 import { expect, Locator, Page } from "src/oss/fixtures";
+import { SidebarPom } from "../sidebar";
 
 export class FieldVisibilityPom {
   readonly page: Page;
@@ -9,7 +10,8 @@ export class FieldVisibilityPom {
 
   constructor(page: Page) {
     this.page = page;
-    this.assert = new FieldVisibilityAsserter(this);
+
+    this.assert = new FieldVisibilityAsserter(this, new SidebarPom(page));
 
     this.sidebar = page.getByTestId("sidebar");
   }
@@ -54,50 +56,11 @@ export class FieldVisibilityPom {
   applyBtn() {
     return this.modalContainer().getByTestId("field-visibility-btn-apply");
   }
-
-  // TODO: replace with sidebar pom coming up
-  sidebarField(fieldName: string) {
-    return this.sidebar
-      .getByTestId(`${fieldName}-field`)
-      .locator("div")
-      .filter({ hasText: fieldName })
-      .nth(1);
-  }
-
-  // TODO: move to sidebar pom coming up
-  groupField(groupName: string) {
-    return this.sidebar.getByTestId(`sidebar-group-${groupName}-field`);
-  }
 }
 
 class FieldVisibilityAsserter {
-  constructor(private readonly svp: FieldVisibilityPom) {}
-
-  async assertFieldInSidebar(fieldName: string) {
-    await expect(this.svp.sidebarField(fieldName)).toBeVisible();
-  }
-
-  async assertFieldsInSidebar(fieldNames: string[]) {
-    for (let i = 0; i < fieldNames.length; i++) {
-      await this.assertFieldInSidebar(fieldNames[i]);
-    }
-  }
-
-  async assertFieldsNotInSidebar(fieldNames: string[]) {
-    for (let i = 0; i < fieldNames.length; i++) {
-      await this.assertFieldNotInSidebar(fieldNames[i]);
-    }
-  }
-
-  async assertFieldNotInSidebar(fieldName: string) {
-    await expect(this.svp.sidebarField(fieldName)).toBeHidden();
-  }
-
-  async assertSidebarGroupIsVisibile(groupName: string) {
-    await expect(this.svp.groupField(groupName)).toBeVisible();
-  }
-
-  async assertSidebarGroupIsHidden(groupName: string) {
-    await expect(this.svp.groupField(groupName)).toBeHidden({ timeout: 1000 });
-  }
+  constructor(
+    private readonly fv: FieldVisibilityPom,
+    private readonly sb: SidebarPom
+  ) {}
 }

--- a/e2e-pw/src/oss/poms/field-visibility/field-visibility.ts
+++ b/e2e-pw/src/oss/poms/field-visibility/field-visibility.ts
@@ -5,7 +5,7 @@ export class FieldVisibilityPom {
   readonly page: Page;
   readonly assert: FieldVisibilityAsserter;
 
-  readonly sidebar: Locator;
+  readonly sidebarLocator: Locator;
   readonly dialogLocator: Locator;
 
   constructor(page: Page) {
@@ -13,19 +13,19 @@ export class FieldVisibilityPom {
 
     this.assert = new FieldVisibilityAsserter(this, new SidebarPom(page));
 
-    this.sidebar = page.getByTestId("sidebar");
+    this.sidebarLocator = page.getByTestId("sidebar");
   }
 
-  modalContainer() {
+  get modalContainer() {
     return this.page.getByTestId("field-visibility-container");
   }
 
-  fieldVisibilityBtn() {
-    return this.sidebar.getByTestId("field-visibility-icon");
+  get fieldVisibilityBtn() {
+    return this.sidebarLocator.getByTestId("field-visibility-icon");
   }
 
   async openFieldVisibilityModal() {
-    await this.fieldVisibilityBtn().click();
+    await this.fieldVisibilityBtn.click();
   }
 
   async hideFields(paths: string[]) {
@@ -42,19 +42,19 @@ export class FieldVisibilityPom {
   }
 
   async submitFieldVisibilityChanges() {
-    await this.applyBtn().click();
+    await this.applyBtn.click();
   }
 
   async clearFieldVisibilityChanges() {
-    await this.clearBtn().click();
+    await this.clearBtn.click();
   }
 
-  clearBtn() {
-    return this.sidebar.getByTestId("field-visibility-btn-clear");
+  get clearBtn() {
+    return this.sidebarLocator.getByTestId("field-visibility-btn-clear");
   }
 
-  applyBtn() {
-    return this.modalContainer().getByTestId("field-visibility-btn-apply");
+  get applyBtn() {
+    return this.modalContainer.getByTestId("field-visibility-btn-apply");
   }
 }
 

--- a/e2e-pw/src/oss/poms/field-visibility/field-visibility.ts
+++ b/e2e-pw/src/oss/poms/field-visibility/field-visibility.ts
@@ -1,4 +1,4 @@
-import { expect, Locator, Page } from "src/oss/fixtures";
+import { Locator, Page } from "src/oss/fixtures";
 import { SidebarPom } from "../sidebar";
 
 export class FieldVisibilityPom {

--- a/e2e-pw/src/oss/poms/field-visibility/field-visibility.ts
+++ b/e2e-pw/src/oss/poms/field-visibility/field-visibility.ts
@@ -14,6 +14,10 @@ export class FieldVisibilityPom {
     this.sidebar = page.getByTestId("sidebar");
   }
 
+  modalContainer() {
+    return this.page.getByTestId("field-visibility-container");
+  }
+
   fieldVisibilityBtn() {
     return this.sidebar.getByTestId("field-visibility-icon");
   }
@@ -22,11 +26,33 @@ export class FieldVisibilityPom {
     await this.fieldVisibilityBtn().click();
   }
 
-  async hideFields(fieldNames: string[]) {
+  async hideFields(paths: string[]) {
     await this.openFieldVisibilityModal();
-    for (let fName in fieldNames) {
-      await this.sidebar.getByTestId(fName).hover();
+
+    for (let i = 0; i < paths.length; i++) {
+      await this.page
+        .getByTestId(`schema-selection-${paths[i]}`)
+        .getByRole("checkbox", { checked: true })
+        .click();
     }
+
+    await this.submitFieldVisibilityChanges();
+  }
+
+  async submitFieldVisibilityChanges() {
+    await this.applyBtn().click();
+  }
+
+  async clearFieldVisibilityChanges() {
+    await this.clearBtn().click();
+  }
+
+  clearBtn() {
+    return this.sidebar.getByTestId("field-visibility-btn-clear");
+  }
+
+  applyBtn() {
+    return this.modalContainer().getByTestId("field-visibility-btn-apply");
   }
 
   // TODO: possibly replace when sidebar pom available
@@ -37,6 +63,11 @@ export class FieldVisibilityPom {
       .filter({ hasText: fieldName })
       .nth(1);
   }
+
+  // TODO: move to sidebar pom when available
+  groupField(groupName: string) {
+    return this.sidebar.getByTestId(`sidebar-group-${groupName}-field`);
+  }
 }
 
 class FieldVisibilityAsserter {
@@ -46,7 +77,27 @@ class FieldVisibilityAsserter {
     await expect(this.svp.sidebarField(fieldName)).toBeVisible();
   }
 
+  async assertFieldsInSidebar(fieldNames: string[]) {
+    for (let i = 0; i < fieldNames.length; i++) {
+      await this.assertFieldInSidebar(fieldNames[i]);
+    }
+  }
+
+  async assertFieldsNotInSidebar(fieldNames: string[]) {
+    for (let i = 0; i < fieldNames.length; i++) {
+      await this.assertFieldNotInSidebar(fieldNames[i]);
+    }
+  }
+
   async assertFieldNotInSidebar(fieldName: string) {
     await expect(this.svp.sidebarField(fieldName)).toBeHidden();
+  }
+
+  async assertSidebarGroupIsVisibile(groupName: string) {
+    await expect(this.svp.groupField(groupName)).toBeVisible();
+  }
+
+  async assertSidebarGroupIsHidden(groupName: string) {
+    await expect(this.svp.groupField(groupName)).toBeHidden();
   }
 }

--- a/e2e-pw/src/oss/poms/field-visibility/field-visibility.ts
+++ b/e2e-pw/src/oss/poms/field-visibility/field-visibility.ts
@@ -55,7 +55,7 @@ export class FieldVisibilityPom {
     return this.modalContainer().getByTestId("field-visibility-btn-apply");
   }
 
-  // TODO: possibly replace when sidebar pom available
+  // TODO: replace with sidebar pom coming up
   sidebarField(fieldName: string) {
     return this.sidebar
       .getByTestId(`${fieldName}-field`)
@@ -64,7 +64,7 @@ export class FieldVisibilityPom {
       .nth(1);
   }
 
-  // TODO: move to sidebar pom when available
+  // TODO: move to sidebar pom coming up
   groupField(groupName: string) {
     return this.sidebar.getByTestId(`sidebar-group-${groupName}-field`);
   }
@@ -98,6 +98,6 @@ class FieldVisibilityAsserter {
   }
 
   async assertSidebarGroupIsHidden(groupName: string) {
-    await expect(this.svp.groupField(groupName)).toBeHidden();
+    await expect(this.svp.groupField(groupName)).toBeHidden({ timeout: 1000 });
   }
 }

--- a/e2e-pw/src/oss/poms/sidebar.ts
+++ b/e2e-pw/src/oss/poms/sidebar.ts
@@ -16,6 +16,10 @@ export class SidebarPom {
     return this.sidebar.getByTestId(`sidebar-group-${groupName}-field`);
   }
 
+  get addGroupField() {
+    return this.sidebar.getByTestId("sidebar-field-add-group-input");
+  }
+
   field(fieldName: string) {
     return this.sidebar
       .getByTestId(`${fieldName}-field`)
@@ -146,6 +150,14 @@ class SidebarAsserter {
 
   async assertSidebarGroupIsHidden(groupName: string) {
     await expect(this.sb.groupField(groupName)).toBeHidden({ timeout: 1000 });
+  }
+
+  async assertAddGroupVisible() {
+    await expect(this.sb.addGroupField).toBeVisible({ timeout: 1000 });
+  }
+
+  async assertAddGroupHidden() {
+    await expect(this.sb.addGroupField).toBeHidden({ timeout: 1000 });
   }
 
   async assertCanDragFieldToGroup(fieldName: string, groupName: string) {

--- a/e2e-pw/src/oss/poms/sidebar.ts
+++ b/e2e-pw/src/oss/poms/sidebar.ts
@@ -3,11 +3,29 @@ import { Locator, Page, expect } from "src/oss/fixtures";
 export class SidebarPom {
   readonly page: Page;
   readonly sidebar: Locator;
+  readonly asserter: SidebarAsserter;
 
   constructor(page: Page) {
     this.page = page;
+    this.asserter = new SidebarAsserter(this);
 
     this.sidebar = page.getByTestId("sidebar");
+  }
+
+  groupField(groupName: string) {
+    return this.sidebar.getByTestId(`sidebar-group-${groupName}-field`);
+  }
+
+  field(fieldName: string) {
+    return this.sidebar
+      .getByTestId(`${fieldName}-field`)
+      .locator("div")
+      .filter({ hasText: fieldName })
+      .nth(1);
+  }
+
+  sidebarEntryDraggableArea(fieldName: string) {
+    return this.sidebar.getByTestId(`sidebar-entry-draggable-${fieldName}`);
   }
 
   async clickFieldCheckbox(field: string) {
@@ -96,5 +114,67 @@ export class SidebarPom {
 
   async toggleSidebarGroup(name: string) {
     await this.sidebar.getByTestId(`sidebar-group-${name}`).click();
+  }
+}
+
+class SidebarAsserter {
+  constructor(private readonly sb: SidebarPom) {}
+
+  async assertFieldInSidebar(fieldName: string) {
+    await expect(this.sb.field(fieldName)).toBeVisible();
+  }
+
+  async assertFieldsInSidebar(fieldNames: string[]) {
+    for (let i = 0; i < fieldNames.length; i++) {
+      await this.sb.asserter.assertFieldInSidebar(fieldNames[i]);
+    }
+  }
+
+  async assertFieldsNotInSidebar(fieldNames: string[]) {
+    for (let i = 0; i < fieldNames.length; i++) {
+      await this.assertFieldNotInSidebar(fieldNames[i]);
+    }
+  }
+
+  async assertFieldNotInSidebar(fieldName: string) {
+    await expect(this.sb.field(fieldName)).toBeHidden();
+  }
+
+  async assertSidebarGroupIsVisibile(groupName: string) {
+    await expect(this.sb.groupField(groupName)).toBeVisible();
+  }
+
+  async assertSidebarGroupIsHidden(groupName: string) {
+    await expect(this.sb.groupField(groupName)).toBeHidden({ timeout: 1000 });
+  }
+
+  async assertCanDragFieldToGroup(fieldName: string, groupName: string) {
+    const targetGroup = this.sb.groupField(groupName);
+
+    const draggableSidebarFieldArea =
+      this.sb.sidebarEntryDraggableArea(fieldName);
+
+    const draggableAreaBB = await draggableSidebarFieldArea.boundingBox();
+    await draggableSidebarFieldArea.dragTo(targetGroup);
+
+    const newDraggableAreaBB = await draggableSidebarFieldArea.boundingBox();
+    expect(draggableAreaBB.x).not.toEqual(newDraggableAreaBB.x);
+    expect(draggableAreaBB.y).not.toEqual(newDraggableAreaBB.y);
+
+    expect(draggableSidebarFieldArea.getAttribute("draggable")).toBeTruthy();
+    await expect(draggableSidebarFieldArea).toHaveAttribute(
+      "data-draggable",
+      "true"
+    );
+  }
+
+  async assertCannotDragField(fieldName: string) {
+    const draggableSidebarFieldArea =
+      this.sb.sidebarEntryDraggableArea(fieldName);
+
+    await expect(draggableSidebarFieldArea).toHaveAttribute(
+      "data-draggable",
+      "false"
+    );
   }
 }

--- a/e2e-pw/src/oss/specs/smoke-tests/field-visibility.spec.ts
+++ b/e2e-pw/src/oss/specs/smoke-tests/field-visibility.spec.ts
@@ -28,10 +28,6 @@ test.describe("field visibility", () => {
     await fiftyoneLoader.waitUntilGridVisible(page, datasetName);
   });
 
-  test("field visibility modal opens", async ({ fieldVisibility }) => {
-    await fieldVisibility.openFieldVisibilityModal();
-  });
-
   test("sidebar group is hidden if all its fields are hidden using field visibility", async ({
     fieldVisibility,
     sidebar,

--- a/e2e-pw/src/oss/specs/smoke-tests/field-visibility.spec.ts
+++ b/e2e-pw/src/oss/specs/smoke-tests/field-visibility.spec.ts
@@ -1,12 +1,19 @@
-import { test as base, expect } from "src/oss/fixtures";
+import { test as base } from "src/oss/fixtures";
 import { FieldVisibilityPom } from "src/oss/poms/field-visibility/field-visibility";
 import { getUniqueDatasetNameWithPrefix } from "src/oss/utils";
+import { SidebarPom } from "src/oss/poms/sidebar";
 
 const datasetName = getUniqueDatasetNameWithPrefix("smoke-quickstart");
 
-const test = base.extend<{ fieldVisibility: FieldVisibilityPom }>({
+const test = base.extend<{
+  fieldVisibility: FieldVisibilityPom;
+  sidebar: SidebarPom;
+}>({
   fieldVisibility: async ({ page }, use) => {
     await use(new FieldVisibilityPom(page));
+  },
+  sidebar: async ({ page }, use) => {
+    await use(new SidebarPom(page));
   },
 });
 
@@ -27,24 +34,25 @@ test.describe("field visibility", () => {
 
   test("sidebar group is hidden if all its fields are hidden using field visibility", async ({
     fieldVisibility,
+    sidebar,
   }) => {
-    await fieldVisibility.assert.assertSidebarGroupIsVisibile("labels");
-    await fieldVisibility.assert.assertFieldsInSidebar([
+    await sidebar.asserter.assertSidebarGroupIsVisibile("labels");
+    await sidebar.asserter.assertFieldsInSidebar([
       "predictions",
       "ground_truth",
     ]);
 
     await fieldVisibility.hideFields(["predictions", "ground_truth"]);
-    await fieldVisibility.assert.assertFieldsNotInSidebar([
+    await sidebar.asserter.assertFieldsNotInSidebar([
       "predictions",
       "ground_truth",
     ]);
 
-    await fieldVisibility.assert.assertSidebarGroupIsHidden("labels");
+    await sidebar.asserter.assertSidebarGroupIsHidden("labels");
 
     await fieldVisibility.clearFieldVisibilityChanges();
-    await fieldVisibility.assert.assertSidebarGroupIsVisibile("labels");
-    await fieldVisibility.assert.assertFieldsInSidebar([
+    await sidebar.asserter.assertSidebarGroupIsVisibile("labels");
+    await sidebar.asserter.assertFieldsInSidebar([
       "predictions",
       "ground_truth",
     ]);
@@ -52,15 +60,15 @@ test.describe("field visibility", () => {
 
   test("sidebar entries are not draggable when field visibility is active", async ({
     fieldVisibility,
+    sidebar,
   }) => {
-    // TODO: assert draggable
+    // drag predictions to metadata group succeeds
+    await sidebar.asserter.assertCanDragFieldToGroup("predictions", "metadata");
 
-    await fieldVisibility.hideFields(["predictions", "ground_truth"]);
-    await fieldVisibility.assert.assertFieldsNotInSidebar([
-      "predictions",
-      "ground_truth",
-    ]);
+    await fieldVisibility.hideFields(["ground_truth"]);
+    await sidebar.asserter.assertFieldsNotInSidebar(["ground_truth"]);
 
-    // TODO: assert not draggable
+    // drag predictions back to labels group fails
+    await sidebar.asserter.assertCannotDragField("predictions");
   });
 });

--- a/e2e-pw/src/oss/specs/smoke-tests/field-visibility.spec.ts
+++ b/e2e-pw/src/oss/specs/smoke-tests/field-visibility.spec.ts
@@ -1,0 +1,35 @@
+import { test as base, expect } from "src/oss/fixtures";
+import { FieldVisibilityPom } from "src/oss/poms/field-visibility/field-visibility";
+import { getUniqueDatasetNameWithPrefix } from "src/oss/utils";
+
+const datasetName = getUniqueDatasetNameWithPrefix("smoke-quickstart");
+
+const test = base.extend<{ fieldVisibility: FieldVisibilityPom }>({
+  fieldVisibility: async ({ page }, use) => {
+    await use(new FieldVisibilityPom(page));
+  },
+});
+
+test.describe("field visibility", () => {
+  test.beforeAll(async ({ fiftyoneLoader }) => {
+    await fiftyoneLoader.loadZooDataset("quickstart", datasetName, {
+      max_samples: 5,
+    });
+  });
+
+  test.beforeEach(async ({ page, fiftyoneLoader, fieldVisibility }) => {
+    await fiftyoneLoader.waitUntilLoad(page, datasetName);
+  });
+
+  test("Field visibility modal opens", async ({ fieldVisibility }) => {
+    await fieldVisibility.openFieldVisibilityModal();
+  });
+
+  test("predictions field should no longer be in the sidebar if it was hidden using field visibility", async ({
+    fieldVisibility,
+  }) => {
+    await fieldVisibility.assert.assertFieldInSidebar("predictions");
+    await fieldVisibility.hideFields(["predictions"]);
+    // await fieldVisibility.assert.assertFieldNotInSidebar("predictions");
+  });
+});

--- a/e2e-pw/src/oss/specs/smoke-tests/field-visibility.spec.ts
+++ b/e2e-pw/src/oss/specs/smoke-tests/field-visibility.spec.ts
@@ -17,19 +17,37 @@ test.describe("field visibility", () => {
     });
   });
 
-  test.beforeEach(async ({ page, fiftyoneLoader, fieldVisibility }) => {
-    await fiftyoneLoader.waitUntilLoad(page, datasetName);
+  test.beforeEach(async ({ page, fiftyoneLoader }) => {
+    await fiftyoneLoader.waitUntilGridVisible(page, datasetName);
   });
 
-  test("Field visibility modal opens", async ({ fieldVisibility }) => {
+  test("field visibility modal opens", async ({ fieldVisibility }) => {
     await fieldVisibility.openFieldVisibilityModal();
   });
 
-  test("predictions field should no longer be in the sidebar if it was hidden using field visibility", async ({
+  test("sidebar group is hidden if all its fields are hidden using field visibility", async ({
     fieldVisibility,
   }) => {
-    await fieldVisibility.assert.assertFieldInSidebar("predictions");
-    await fieldVisibility.hideFields(["predictions"]);
-    // await fieldVisibility.assert.assertFieldNotInSidebar("predictions");
+    await fieldVisibility.assert.assertSidebarGroupIsVisibile("labels");
+    await fieldVisibility.assert.assertFieldsInSidebar([
+      "predictions",
+      "ground_truth",
+    ]);
+
+    await fieldVisibility.hideFields(["predictions", "ground_truth"]);
+    await fieldVisibility.assert.assertFieldsNotInSidebar([
+      "predictions",
+      "ground_truth",
+    ]);
+
+    // TODO - fix me
+    await fieldVisibility.assert.assertSidebarGroupIsHidden("labels");
+
+    await fieldVisibility.clearFieldVisibilityChanges();
+    await fieldVisibility.assert.assertSidebarGroupIsVisibile("labels");
+    await fieldVisibility.assert.assertFieldsInSidebar([
+      "predictions",
+      "ground_truth",
+    ]);
   });
 });

--- a/e2e-pw/src/oss/specs/smoke-tests/field-visibility.spec.ts
+++ b/e2e-pw/src/oss/specs/smoke-tests/field-visibility.spec.ts
@@ -49,4 +49,18 @@ test.describe("field visibility", () => {
       "ground_truth",
     ]);
   });
+
+  test("sidebar entries are not draggable when field visibility is active", async ({
+    fieldVisibility,
+  }) => {
+    // TODO: assert draggable
+
+    await fieldVisibility.hideFields(["predictions", "ground_truth"]);
+    await fieldVisibility.assert.assertFieldsNotInSidebar([
+      "predictions",
+      "ground_truth",
+    ]);
+
+    // TODO: assert not draggable
+  });
 });

--- a/e2e-pw/src/oss/specs/smoke-tests/field-visibility.spec.ts
+++ b/e2e-pw/src/oss/specs/smoke-tests/field-visibility.spec.ts
@@ -40,7 +40,6 @@ test.describe("field visibility", () => {
       "ground_truth",
     ]);
 
-    // TODO - fix me
     await fieldVisibility.assert.assertSidebarGroupIsHidden("labels");
 
     await fieldVisibility.clearFieldVisibilityChanges();

--- a/e2e-pw/src/oss/specs/smoke-tests/field-visibility.spec.ts
+++ b/e2e-pw/src/oss/specs/smoke-tests/field-visibility.spec.ts
@@ -71,4 +71,13 @@ test.describe("field visibility", () => {
     // drag predictions back to labels group fails
     await sidebar.asserter.assertCannotDragField("predictions");
   });
+
+  test("sidebar add group input is hidden when field visibility is active", async ({
+    sidebar,
+    fieldVisibility,
+  }) => {
+    await sidebar.asserter.assertAddGroupVisible();
+    await fieldVisibility.hideFields(["ground_truth"]);
+    await sidebar.asserter.assertAddGroupHidden();
+  });
 });


### PR DESCRIPTION
## What changes are proposed in this pull request?

Empty groups should be hidden if field visibility applied
- [x] write E2E test failing first
- [x] Fix
- [x] Re-ordering is disabled when field visibility active
- [x] E2E for ^

https://github.com/voxel51/fiftyone/assets/109545780/d002535b-c2ea-4f41-9198-5298d08dbf45

E2E for disabling (not too clear in video)

https://github.com/voxel51/fiftyone/assets/109545780/1821bc0b-bbf3-44ea-aaf1-f4e9378bbbf9




## How is this patch tested? If it is not, please explain why.


(Details)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
