### PR TITLE
Fix OpenLABEL importer when given incomplete keypoint skeletons

### DIFF
--- a/fiftyone/utils/openlabel.py
+++ b/fiftyone/utils/openlabel.py
@@ -1170,6 +1170,10 @@ class OpenLABELPoint(OpenLABELShape):
     """An OpenLABEL keypoint."""
 
     @classmethod
+    def _get_empty_value_for_type(cls, example_type):
+        return example_type()
+
+    @classmethod
     def _sort_by_skeleton(cls, points, attrs, label_order, skeleton_order):
         if len(points) != len(label_order):
             return points, attrs
@@ -1184,6 +1188,8 @@ class OpenLABELPoint(OpenLABELShape):
             if isinstance(v, list) and len(v) == len(points):
                 attrs_to_sort[k] = v
                 sorted_attrs[k] = []
+            elif isinstance(v, list) and len(v) == 0:
+                continue
             else:
                 sorted_attrs[k] = v
 
@@ -1191,7 +1197,9 @@ class OpenLABELPoint(OpenLABELShape):
             if label not in label_order:
                 sorted_points.append([float("nan"), float("nan")])
                 for k in attrs_to_sort:
-                    sorted_attrs[k].append(None)
+                    example_type = type(attrs_to_sort[k][0])
+                    empty_value = cls._get_empty_value_for_type(example_type)
+                    sorted_attrs[k].append(empty_value)
             else:
                 ind = label_order.index(label)
                 sorted_points.append(points[ind])

--- a/tests/unittests/import_export_tests.py
+++ b/tests/unittests/import_export_tests.py
@@ -3356,6 +3356,7 @@ class OpenLABELImageDatasetTests(ImageDatasetTests):
             label_types="keypoints",
             skeleton_key=skeleton_key,
             skeleton=skeleton,
+            dynamic=True,
         )
         dataset.default_skeleton = skeleton
 

--- a/tests/unittests/utils/openlabel.py
+++ b/tests/unittests/utils/openlabel.py
@@ -222,10 +222,18 @@ def _make_image_labels(tmp_dir):
         "pose_point2", [20, 30], "point2d", as_list=False
     )
     pose_obj_data_2.add_attribute("skeleton_key", "point2")
+    pose_obj_data_2.add_attribute("str_attr", "test")
+    pose_obj_data_2.add_attribute("int_attr", 51)
+    pose_obj_data_2.add_attribute("float_attr", 51.51)
+    pose_obj_data_2.add_attribute("bool_attr", True)
     pose_obj_data_1 = OpenLABELObjectData(
         "pose_point1", [10, 20], "point2d", as_list=False
     )
     pose_obj_data_1.add_attribute("skeleton_key", "point1")
+    pose_obj_data_1.add_attribute("str_attr", "test")
+    pose_obj_data_1.add_attribute("int_attr", 51)
+    pose_obj_data_1.add_attribute("float_attr", 51.51)
+    pose_obj_data_1.add_attribute("bool_attr", True)
     pose_obj_datas = [pose_obj_data_2, pose_obj_data_1]
     pose_obj_data = _merge_object_datas(pose_obj_datas)
     pose_obj = OpenLABELObject("pose1", "Keypoints")


### PR DESCRIPTION
The OpenLABEL importer is designed to set `None` values for missing list attributes of keypoints. 
The issue is that setting None values like that for these attributes:
```python

keypoint = fo.Keypoint(
    label="rectangle",
    points=[
        (0.3, 0.3),
        (float("nan"), float("nan")),  # use nan to encode missing points
        (0.7, 0.7),
        (0.3, 0.7),
    ],
    my_occluded_attr=[
        "partially",
        None,
        "fully",
        "partially",
    ]
)
```
Will result in errors when trying to add the attributes to the dataset schema (`dataset.add_dynamic_sample_fields()`)


This PR updates this logic to set them to be `""` instead for strings, `0` or `0.0` for numeric types, and `False` for booleans.

Also updated the OpenLABEL tests to check for this so it would have failed previously and now passes.