### PR TITLE
[HOLD] run results shared between dataset clones

### DIFF
--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -7335,12 +7335,9 @@ def _clone_run(run_doc):
     _run_doc.id = ObjectId()
     _run_doc.results = None
 
-    # Unfortunately the only way to copy GridFS files is to read-write them...
-    # https://jira.mongodb.org/browse/TOOLS-2208
+    # Use copy_from to make a shallow copy
     if run_doc.results:
-        run_doc.results.seek(0)
-        results_bytes = run_doc.results.read()
-        _run_doc.results.put(results_bytes, content_type="application/json")
+        _run_doc.results.copy_from(run_doc.results)
 
     return _run_doc
 

--- a/fiftyone/core/odm/fields.py
+++ b/fiftyone/core/odm/fields.py
@@ -1,0 +1,88 @@
+"""
+Dataset sample fields.
+
+| Copyright 2017-2023, Voxel51, Inc.
+| `voxel51.com <https://voxel51.com/>`_
+|
+"""
+
+import mongoengine
+
+_reference_count_field = "reference_count"
+
+
+class ReferenceCountingGridFSProxy(mongoengine.fields.GridFSProxy):
+    """GridFSProxy base that only deletes when there are no references"""
+
+    def copy_from(self, other):
+        self.grid_id = other.grid_id
+        self._inc_reference_count()
+        self._mark_as_changed()
+
+    def delete(self):
+        if self.grid_id is None:
+            return
+
+        has_more_references = self._test_and_dec_ref_count()
+        if has_more_references:
+            self.grid_id = None
+            self.gridout = None
+            self._mark_as_changed()
+        else:
+            super().delete()
+
+    def put(self, file_obj, **kwargs):
+        kwargs.update({_reference_count_field: 1})
+        super().put(file_obj, **kwargs)
+
+    def _test_and_dec_ref_count(self):
+        db = mongoengine.get_db(self.db_alias)
+        file_metadata_collection = f"{self.collection_name}.files"
+        update_result = db[file_metadata_collection].update_one(
+            {"_id": self.grid_id, _reference_count_field: {"$gt": 1}},
+            {"$inc": {_reference_count_field: -1}},
+        )
+        return update_result.modified_count > 0
+
+    def _inc_reference_count(self):
+        db = mongoengine.get_db(self.db_alias)
+        file_metadata_collection = f"{self.collection_name}.files"
+        # Happy case: Just increment reference count field atomically
+        update_result = db[file_metadata_collection].update_one(
+            {"_id": self.grid_id, _reference_count_field: {"$exists": True}},
+            {"$inc": {_reference_count_field: 1}},
+        )
+        # Reference count field did not exist before
+        if update_result.modified_count <= 0:
+            # Where reference count field doesn't exist, set to 2. 1 for this
+            #   instance and 1 for the copied-from instance.
+            update_result = db[file_metadata_collection].update_one(
+                {
+                    "_id": self.grid_id,
+                    _reference_count_field: {"$exists": False},
+                },
+                {"$set": {_reference_count_field: 2}},
+            )
+            # Super rare case: reference count field didn't exist before but
+            #   it does now, meaning someone beat us to creating it. So just
+            #   make a simple unconditional increment.
+            if update_result.modified_count <= 0:
+                db[file_metadata_collection].update_one(
+                    {"_id": self.grid_id},
+                    {"$inc": {_reference_count_field: 1}},
+                )
+
+    def write(self, *args, **kwargs):
+        raise RuntimeError('Please use "put" method instead')
+
+    def writelines(self, *args, **kwargs):
+        raise RuntimeError('Please use "put" method instead')
+
+    def new_file(self, **kwargs):
+        raise RuntimeError('Please use "put" method instead')
+
+
+class SharedFileField(mongoengine.fields.FileField):
+    """FileField that shares file references"""
+
+    proxy_class = ReferenceCountingGridFSProxy

--- a/fiftyone/core/odm/runs.py
+++ b/fiftyone/core/odm/runs.py
@@ -5,7 +5,6 @@ Dataset run documents.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
-from mongoengine import FileField
 
 from fiftyone.core.fields import (
     DateTimeField,
@@ -16,6 +15,7 @@ from fiftyone.core.fields import (
 )
 
 from .document import Document
+from .fields import SharedFileField
 
 
 class RunDocument(Document):
@@ -30,4 +30,4 @@ class RunDocument(Document):
     timestamp = DateTimeField()
     config = DictField()
     view_stages = ListField(StringField())
-    results = FileField()
+    results = SharedFileField()

--- a/tests/unittests/odm_tests.py
+++ b/tests/unittests/odm_tests.py
@@ -1,0 +1,163 @@
+"""
+FiftyOne odm unit tests.
+
+| Copyright 2017-2023, Voxel51, Inc.
+| `voxel51.com <https://voxel51.com/>`_
+|
+"""
+import unittest
+
+import mongoengine
+
+from fiftyone.core.odm import fields
+
+
+class TestDocument(mongoengine.Document):
+    __test__ = False
+    file = fields.SharedFileField()
+
+
+class TestSharedFileField(unittest.TestCase):
+    content = b"Hello, world"
+    content_type = "application/text"
+
+    def _delete_file_and_assert(self, doc):
+        doc.file.delete()
+        self.assertFalse(doc.file)
+        self.assertIsNone(doc.file.grid_id)
+        self.assertIsNone(doc.file.gridout)
+
+    def test_simple(self):
+        """Retains simple put-delete functionality as FileField"""
+        doc = TestDocument()
+        doc.file.put(self.content, content_type=self.content_type)
+        grid_id = doc.file.grid_id
+
+        self.assertEqual(doc.file.read(), self.content)
+        self._delete_file_and_assert(doc)
+
+        self.assertFalse(doc.file.fs.exists(grid_id))
+
+    def test_copy_from(self):
+        """Test new copy_from() function shares file pointer"""
+        doc1 = TestDocument()
+        doc2 = TestDocument()
+
+        # Put something to the file
+        doc1.file.put(self.content, content_type=self.content_type)
+        self.assertEqual(doc1.file.content_type, self.content_type)
+        self.assertEqual(doc1.file.reference_count, 1)
+        grid_id = doc1.file.grid_id
+
+        # Use new copy_from() method to update ref count only
+        doc2.file.copy_from(doc1.file)
+        self.assertEqual(doc2.file.content_type, self.content_type)
+        self.assertEqual(doc2.file.reference_count, 2)
+        self.assertEqual(doc1.file.read(), self.content)
+        self.assertEqual(doc2.file.read(), self.content)
+        self.assertEqual(doc1.file.grid_id, doc2.file.grid_id)
+
+        # "Delete" file in doc1 but file isn't actually deleted since its
+        #   still referenced by doc2
+        self._delete_file_and_assert(doc1)
+        self.assertTrue(doc2.file.fs.exists(grid_id))
+        doc2.file.seek(0)
+        self.assertEqual(doc2.file.read(), self.content)
+
+        # Note we can't assert doc2.file.reference_count here because it won't
+        #   auto-update to 1, as the object is cached.
+
+        # Now really delete the file by deleting final reference
+        self._delete_file_and_assert(doc2)
+        self.assertFalse(doc2.file.fs.exists(grid_id))
+
+    def test_no_write_funcs(self):
+        """write() and friends are not allowed"""
+        doc = TestDocument()
+
+        self.assertRaises(RuntimeError, doc.file.write)
+        self.assertRaises(RuntimeError, doc.file.writelines)
+        self.assertRaises(RuntimeError, doc.file.new_file)
+
+    def test_no_repeated_put(self):
+        """Can't put() multiple files"""
+        doc = TestDocument()
+
+        doc.file.put(self.content, content_type=self.content_type)
+        grid_id = doc.file.grid_id
+        self.assertRaises(mongoengine.GridFSError, doc.file.put, self.content)
+        doc.file.replace(self.content + b"!")
+        self.assertNotEqual(grid_id, doc.file.grid_id)
+        self.assertFalse(doc.file.fs.exists(grid_id))
+        self._delete_file_and_assert(doc)
+
+    def test_shared_doc_replace(self):
+        doc1 = TestDocument()
+        doc2 = TestDocument()
+
+        # Setup
+        doc1.file.put(self.content, content_type=self.content_type)
+        grid_id = doc1.file.grid_id
+        doc2.file.copy_from(doc1.file)
+
+        # Replace with something else
+        doc1.file.replace(self.content + b"!")
+        self.assertNotEqual(doc1.file.grid_id, grid_id)
+        self.assertTrue(doc2.file.fs.exists(grid_id))
+        self.assertEqual(doc2.file.read(), self.content)
+        self.assertEqual(doc1.file.read(), self.content + b"!")
+
+        self._delete_file_and_assert(doc1)
+        self._delete_file_and_assert(doc2)
+
+    def test_delete_no_reference_count_to_begin(self):
+        """Test that if there's no reference count stored initially, it will
+        still work properly when copy_from is not called
+        """
+        doc1 = TestDocument()
+
+        # Put data without a reference count field
+        file_proxy = doc1.file
+        # pylint: disable-next=bad-super-call
+        super(type(file_proxy), file_proxy).put(
+            self.content, content_type=self.content_type
+        )
+        grid_id = file_proxy.grid_id
+
+        self.assertRaises(
+            AttributeError, doc1.file.__getattr__, "reference_count"
+        )
+        self._delete_file_and_assert(doc1)
+        self.assertFalse(file_proxy.fs.exists(grid_id))
+
+    def test_copy_from_no_reference_count_to_begin(self):
+        """Test that if there's no reference count stored initially, it will
+        still work properly when copy_from *is* called
+        """
+        doc1 = TestDocument()
+        doc2 = TestDocument()
+
+        # Put data without a reference count field
+        file_proxy = doc1.file
+        # pylint: disable-next=bad-super-call
+        super(type(file_proxy), file_proxy).put(
+            self.content, content_type=self.content_type
+        )
+        grid_id = file_proxy.grid_id
+
+        self.assertRaises(
+            AttributeError, doc1.file.__getattr__, "reference_count"
+        )
+
+        doc2.file.copy_from(doc1.file)
+        self.assertEqual(doc2.file.content_type, self.content_type)
+        self.assertEqual(doc2.file.reference_count, 2)
+        self.assertEqual(doc1.file.read(), self.content)
+        self.assertEqual(doc2.file.read(), self.content)
+        self.assertEqual(doc1.file.grid_id, doc2.file.grid_id)
+
+        self._delete_file_and_assert(doc1)
+        self.assertTrue(file_proxy.fs.exists(grid_id))
+
+        self._delete_file_and_assert(doc2)
+        self.assertFalse(file_proxy.fs.exists(grid_id))

--- a/tests/unittests/sample_tests.py
+++ b/tests/unittests/sample_tests.py
@@ -5,7 +5,6 @@ FiftyOne sample-related unit tests.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
-import datetime
 import os
 import unittest
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

Proposal is to have dataset clones share run result documents in GridFS through the use of reference counts on the metadata of the file object.

#### Why?
It saves a marginal amount of space in MongoDB by not duplicating run result documents in GridFS for fully-cloned datasets.

However the primary motivator is to set this baseline usage so that snapshots in FiftyOneTeams work seamlessly as well as clones.

#### Implementation Details
1. dataset1 create run with results with id X
2. dataset2 is cloned from dataset1. Instead of copying the results contents to a new file, it increments the reference counter.
   1. **Note** changing the metadata of a GridFS file after it's written is technically not a part of the public API. However they are just normal collections in most ways, so if we only edit our reference count field atomically and change nothing else, we should be OK.
3. If one of these datasets delete the run result (either through deletion or saving a new one), the reference count is decremented.
4. File is deleted after reference count hits 0.

This is done through creation of `SharedFileField` and `ReferenceCountingGridFSProxy` which subclass `mongoengine.fields.FileField` and `mongoengine.fields.GridFSProxy`, respectively. It wraps the functionality of `GridFSProxy` with adding the `reference_count` field to the file's metadata. We try to atomically test-and-update this counter whenever possible to avoid race conditions.

## How is this patch tested? If it is not, please explain why.

- Added unit tests for `SharedFileField` directly in `odm_tests.py`
- Added a test to `evaluation_tests.py` to test sharing documents works from the higher level
- Manual testing like the below example

``` python
import fiftyone as fo
dataset = fo.zoo.load_zoo_dataset("quickstart")
results = dataset.evaluate_detections("predictions", gt_field="ground_truth", eval_key="eval")
original_results = results.serialize()
results_id = dataset._doc.evaluations["eval"].results.grid_id

clone = dataset.clone()
results_id2 = clone._doc.evaluations["eval"].results.grid_id

# Sharing same result object
assert results_id == results_id2

# Deleting original evaluation should not delete clone evaluation
dataset.delete_evaluation("eval")
clone_results = clone.load_evaluation_results("eval", cache=False)
assert clone_results.serialize() == original_results
```

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
