### PR TITLE
Omit `close_app` in `launch_app`

### DIFF
--- a/fiftyone/core/session/session.py
+++ b/fiftyone/core/session/session.py
@@ -181,19 +181,6 @@ def launch_app(
         a :class:`Session`
     """
     global _session  # pylint: disable=global-statement
-
-    #
-    # Note, we always `close_app()` here rather than just calling
-    # `session.open()` if a session already exists, because the app may have
-    # been closed in some way other than `session.close()` --- e.g., the user
-    # closing the GUI --- in which case the underlying Electron process may
-    # still exist; in this case, `session.open()` does not seem to reopen the
-    # app
-    #
-    # @todo this can probably be improved
-    #
-    close_app()
-
     _session = Session(
         dataset=dataset,
         view=view,


### PR DESCRIPTION
When launching the via `fiftyone.core.session.session.launch_app()`, the current behavior is to close the existing global `_session` if it is defined.

This change proposes to omit that step for faster launches when `launch_app` is used multiple times. The previous `session` will be cleaned up when the main process exits.