### PR TITLE
Unique ID for full sample JSON in modal

### DIFF
--- a/app/packages/core/src/components/Actions/Tagger.tsx
+++ b/app/packages/core/src/components/Actions/Tagger.tsx
@@ -364,7 +364,9 @@ const useTagCallback = (
               ids.add(sample.sample._id);
             });
           });
-          updateSamples(Array.from(ids).map((id) => [id, undefined]));
+          updateSamples(
+            Array.from(ids).map((id) => [id.split("-")[0], undefined])
+          );
         } else if (samples) {
           set(fos.refreshGroupQuery, (cur) => cur + 1);
           updateSamples(samples.map((sample) => [sample._id, sample]));

--- a/app/packages/core/src/components/Modal/Group/GroupImageVideoSample.tsx
+++ b/app/packages/core/src/components/Modal/Group/GroupImageVideoSample.tsx
@@ -18,7 +18,7 @@ export const GroupImageVideoSample: React.FC<{
 
   return (
     <GroupSampleWrapper
-      sampleId={sample.id}
+      sampleId={sample.sample._id}
       pinned={pinned}
       onClick={reset}
       {...hover.handlers}

--- a/app/packages/core/src/components/Modal/Group/GroupSample3d.tsx
+++ b/app/packages/core/src/components/Modal/Group/GroupSample3d.tsx
@@ -1,6 +1,6 @@
 import { Loading } from "@fiftyone/components";
 import * as fos from "@fiftyone/state";
-import { useEffect } from "react";
+import React, { useEffect } from "react";
 import {
   useRecoilState,
   useRecoilTransaction_UNSTABLE,
@@ -19,7 +19,7 @@ const Sample3dWrapper = () => {
 
   return hasGroupView ? (
     <GroupSampleWrapper
-      sampleId={sample.id}
+      sampleId={sample.sample._id}
       pinned={pinned}
       onClick={() => setPinned(true)}
       {...hover.handlers}
@@ -53,7 +53,8 @@ export default () => {
           [k: string]: fos.ModalSample;
         }
       ) => {
-        let newSlice: string | null = samples[pinnedSlice] ? pinnedSlice : null;
+        let newSlice: string | null =
+          pinnedSlice && samples[pinnedSlice] ? pinnedSlice : null;
         for (let index = 0; index < slices.length; index++) {
           const element = slices[index];
           if (samples[element]) {
@@ -79,7 +80,7 @@ export default () => {
       return;
     }
 
-    if (groupSlice && slices.includes(groupSlice)) {
+    if (groupSlice && slices.includes(groupSlice) && pinnedSlice) {
       return;
     }
 

--- a/app/packages/core/src/components/Modal/Sample.tsx
+++ b/app/packages/core/src/components/Modal/Sample.tsx
@@ -1,10 +1,8 @@
-import { AbstractLooker } from "@fiftyone/looker";
 import {
   Lookers,
   ModalSample,
   modalSample,
   modalSampleId,
-  useClearModal,
   useHoveredSample,
 } from "@fiftyone/state";
 import React, { MutableRefObject, useCallback, useRef, useState } from "react";
@@ -52,7 +50,7 @@ export const SampleWrapper = ({
       {...hover.handlers}
     >
       <SampleBar
-        sampleId={sample.id}
+        sampleId={sample.sample._id}
         lookerRef={lookerRef}
         visible={hovering}
         hoveringRef={hoveringRef}

--- a/app/packages/core/src/useFlashlightPager.ts
+++ b/app/packages/core/src/useFlashlightPager.ts
@@ -20,8 +20,9 @@ const processSamplePageData = (
       throw new Error("unexpected sample type");
     }
 
-    store.samples.set(edge.node.id, edge.node as fos.ModalSample);
-    store.indices.set(offset + i, edge.node.id);
+    const node = edge.node as fos.ModalSample;
+    store.samples.set(node.sample._id, node);
+    store.indices.set(offset + i, node.sample._id);
 
     return {
       aspectRatio: zoom

--- a/app/packages/looker/src/state.ts
+++ b/app/packages/looker/src/state.ts
@@ -58,7 +58,7 @@ export type Sample = {
     height: number;
     mime_type?: string;
   };
-  id: string;
+  _id: string;
   filepath: string;
   tags: string[];
   _label_tags: string[];

--- a/app/packages/state/src/hooks/useUpdateSamples.ts
+++ b/app/packages/state/src/hooks/useUpdateSamples.ts
@@ -1,13 +1,13 @@
 import { useCallback } from "react";
 import { commitLocalUpdate, useRelayEnvironment } from "react-relay";
-import { AppSample } from "../recoil";
+import { ModalSample } from "../recoil";
 import { stores } from "./useLookerStore";
 
 export const useUpdateSamples = () => {
   const environment = useRelayEnvironment();
 
   return useCallback(
-    (samples: [string, AppSample | undefined][]) => {
+    (samples: [string, ModalSample["sample"] | undefined][]) => {
       commitLocalUpdate(environment, (store) => {
         samples.forEach(([id, sample]) => {
           sample &&
@@ -20,17 +20,21 @@ export const useUpdateSamples = () => {
                 sampleStore.lookers.get(id)?.updateSample(sample);
               }
             });
-          const record = store.get(id);
-          if (record) {
-            if (sample) {
-              // Relay will not allow objects when hydrating a scalar value
-              // - https://github.com/voxel51/fiftyone/pull/2622
-              // - https://github.com/facebook/relay/issues/91
-              record?.setValue(JSON.stringify(sample), "sample");
-            } else {
-              record.invalidateRecord();
+
+          const ids = [id, `${id}-modal`];
+          ids.forEach((id) => {
+            const record = store.get(id);
+            if (record) {
+              if (sample) {
+                // Relay will not allow objects when hydrating a scalar value
+                // - https://github.com/voxel51/fiftyone/pull/2622
+                // - https://github.com/facebook/relay/issues/91
+                record?.setValue(JSON.stringify(sample), "sample");
+              } else {
+                record.invalidateRecord();
+              }
             }
-          }
+          });
         });
       });
     },

--- a/fiftyone/server/routes/media.py
+++ b/fiftyone/server/routes/media.py
@@ -5,8 +5,10 @@ FiftyOne Server /media route
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+import os
 import typing as t
 
+import anyio
 import aiofiles
 from aiofiles.threadpool.binary import AsyncBufferedReader
 from aiofiles.os import stat as aio_stat
@@ -58,6 +60,12 @@ class Media(HTTPEndpoint):
         path = request.query_params["filepath"]
 
         response: t.Union[FileResponse, StreamingResponse]
+
+        try:
+            await anyio.to_thread.run_sync(os.stat, path)
+        except FileNotFoundError:
+            return Response(content="Not found", status_code=404)
+
         if request.headers.get("range"):
             response = await self.ranged_file_response(path, request)
         else:

--- a/fiftyone/server/samples.py
+++ b/fiftyone/server/samples.py
@@ -129,7 +129,9 @@ async def paginate_samples(
     url_cache = {}
     nodes = await asyncio.gather(
         *[
-            _create_sample_item(view, sample, metadata_cache, url_cache)
+            _create_sample_item(
+                view, sample, metadata_cache, url_cache, pagination_data
+            )
             for sample in samples
         ]
     )
@@ -159,6 +161,7 @@ async def _create_sample_item(
     sample: t.Dict,
     metadata_cache: t.Dict[str, t.Dict],
     url_cache: t.Dict[str, str],
+    pagination_data: bool,
 ) -> SampleItem:
     media_type = fom.get_media_type(sample["filepath"])
 
@@ -178,4 +181,9 @@ async def _create_sample_item(
     if cls == VideoSample:
         metadata = dict(**metadata, frame_number=sample.get("frame_number", 1))
 
-    return from_dict(cls, {"id": sample["_id"], "sample": sample, **metadata})
+    _id = sample["_id"]
+
+    if not pagination_data:
+        _id = f"{_id}-modal"
+
+    return from_dict(cls, {"id": _id, "sample": sample, **metadata})

--- a/tests/unittests/server_tests.py
+++ b/tests/unittests/server_tests.py
@@ -819,6 +819,7 @@ class AysncServerViewTests(unittest.IsolatedAsyncioTestCase):
                     slice="first", id=first.group.id, slices=["first"]
                 )
             ),
+            pagination_data=True,
         )
         self.assertEqual(len(first_samples.edges), 1)
         self.assertEqual(first_samples.edges[0].node.id, first._id)
@@ -833,6 +834,7 @@ class AysncServerViewTests(unittest.IsolatedAsyncioTestCase):
                     slice="second", id=second.group.id, slices=["second"]
                 )
             ),
+            pagination_data=True,
         )
         self.assertEqual(len(second_samples.edges), 1)
         self.assertEqual(second_samples.edges[0].node.id, second._id)


### PR DESCRIPTION
Resolves #3431 

In `0.21.6`, modal sample data can be overwritten by the group carousel due to globally unique id store in relay. Adding a `-modal` suffix to sample IDs when they are requested without pagination data resolves the issue. The `-modal` naming is tentative.

The best way to add an e2e test is to screenshot the JSON panel in a group dataset, if it is practical.