### PR TITLE
Revert follow symlinks in `static`

### DIFF
--- a/fiftyone/server/app.py
+++ b/fiftyone/server/app.py
@@ -112,7 +112,6 @@ app = Starlette(
             app=Static(
                 directory=os.path.join(os.path.dirname(__file__), "static"),
                 html=True,
-                follow_symlink=True,
             ),
             name="static",
         ),


### PR DESCRIPTION
Resolves #3424 

Reverts the change in #3338 as it is causing 404 issues on some existing installations