### PR TITLE
Delegated operators CLI fix

### DIFF
--- a/fiftyone/core/cli.py
+++ b/fiftyone/core/cli.py
@@ -2770,9 +2770,12 @@ class DelegatedLaunchCommand(Command):
 
 
 def _launch_delegated_local():
+    from fiftyone.core.session.session import _WELCOME_MESSAGE
+
     try:
         dos = food.DelegatedOperationService()
 
+        print(_WELCOME_MESSAGE.format(foc.VERSION))
         print("Delegated operation service running")
         print("\nTo exit, press ctrl + c")
         while True:

--- a/fiftyone/core/cli.py
+++ b/fiftyone/core/cli.py
@@ -2869,15 +2869,10 @@ class DelegatedListCommand(Command):
 
 
 def _parse_state(state):
-    from fiftyone.operators.executor import ExecutionRunState
+    if state is None:
+        return None
 
-    if state is not None:
-        try:
-            state = ExecutionRunState[state.upper()]
-        except:
-            raise ValueError("Invalid run state '%s'" % state)
-
-    return state
+    return state.lower()
 
 
 def _parse_paging(sort_by=None, reverse=None, limit=None):

--- a/fiftyone/core/cli.py
+++ b/fiftyone/core/cli.py
@@ -2928,7 +2928,7 @@ def _print_delegated_list(ops):
                 "operator": op.operator,
                 "dataset": op.context.request_params.get("dataset_name", None),
                 "queued_at": op.queued_at,
-                "state": op.run_state.value,
+                "state": op.run_state,
                 "completed": op.run_state == ExecutionRunState.COMPLETED,
             }
         )


### PR DESCRIPTION
Updates the `fiftyone delegated` CLI commands, which were broken as `ExecutionRunState` is no longer an `enum`.

Also adds the FO welcome message when launching the delegated operation service locally:

```
$ fiftyone delegated launch

Welcome to

███████╗██╗███████╗████████╗██╗   ██╗ ██████╗ ███╗   ██╗███████╗
██╔════╝██║██╔════╝╚══██╔══╝╚██╗ ██╔╝██╔═══██╗████╗  ██║██╔════╝
█████╗  ██║█████╗     ██║    ╚████╔╝ ██║   ██║██╔██╗ ██║█████╗
██╔══╝  ██║██╔══╝     ██║     ╚██╔╝  ██║   ██║██║╚██╗██║██╔══╝
██║     ██║██║        ██║      ██║   ╚██████╔╝██║ ╚████║███████╗
╚═╝     ╚═╝╚═╝        ╚═╝      ╚═╝    ╚═════╝ ╚═╝  ╚═══╝╚══════╝ v0.21.6

If you're finding FiftyOne helpful, here's how you can get involved:

|
|  ⭐⭐⭐ Give the project a star on GitHub ⭐⭐⭐
|  https://github.com/voxel51/fiftyone
|
|  🚀🚀🚀 Join the FiftyOne Slack community 🚀🚀🚀
|  https://slack.voxel51.com
|

Delegated operation service running

To exit, press ctrl + c
```


