### PR TITLE
remove unnecessary refresh with visibility reset

### DIFF
--- a/app/packages/core/src/components/Filters/NumericFieldFilter.tsx
+++ b/app/packages/core/src/components/Filters/NumericFieldFilter.tsx
@@ -149,7 +149,6 @@ const NumericFieldFilter = ({
     ? useSetRecoilState(isMatchingAtom)
     : null;
 
-  const setFilter = useSetRecoilState(fos.filter({ modal, path }));
   const bounds = useRecoilValue(fos.boundsAtom({ path, defaultRange }));
   const ftype = useRecoilValue(fos.fieldType({ path }));
   const field = useRecoilValue(fos.field(path));

--- a/app/packages/core/src/components/Filters/NumericFieldFilter.tsx
+++ b/app/packages/core/src/components/Filters/NumericFieldFilter.tsx
@@ -136,7 +136,7 @@ const NumericFieldFilter = ({
     modal,
     defaultRange,
   });
-  const values = useRecoilValue(
+  const [values, setValues] = useRecoilState(
     fos.rangeAtom({
       modal,
       path,
@@ -203,9 +203,9 @@ const NumericFieldFilter = ({
   const isKeyPoints = fieldSchema?.dbField === "keypoints";
 
   const initializeSettings = () => {
-    setFilter([null, null]);
+    setValues([null, null]);
     setExcluded && setExcluded(false);
-    setIsMatching && setIsMatching(!nestedField);
+    isFilterMode && setIsMatching && setIsMatching(!nestedField);
   };
 
   // we do not want to show nestedfield's index field

--- a/app/packages/core/src/components/Filters/categoricalFilter/CategoricalFilter.tsx
+++ b/app/packages/core/src/components/Filters/categoricalFilter/CategoricalFilter.tsx
@@ -3,7 +3,7 @@ import LoadingDots from "@fiftyone/components/src/components/Loading/LoadingDots
 import * as fos from "@fiftyone/state";
 import { groupId, groupStatistics } from "@fiftyone/state";
 import { VALID_KEYPOINTS, getFetchFunction } from "@fiftyone/utilities";
-import { MutableRefObject, useEffect, useRef } from "react";
+import React, { MutableRefObject, useEffect, useRef } from "react";
 import {
   RecoilState,
   RecoilValue,

--- a/app/packages/core/src/components/Filters/categoricalFilter/Wrapper.tsx
+++ b/app/packages/core/src/components/Filters/categoricalFilter/Wrapper.tsx
@@ -83,7 +83,12 @@ const Wrapper = ({
 
   const initializeSettings = () => {
     excluded && setExcluded(false);
-    setIsMatching(!nestedField);
+    isFilterMode && setIsMatching(!nestedField);
+  };
+
+  const handleReset = () => {
+    setSelected([]);
+    initializeSettings();
   };
 
   if (totalCount === 0) {
@@ -111,7 +116,7 @@ const Wrapper = ({
           name={value}
           count={
             count < 0 || !isFilterMode
-              ? null
+              ? undefined
               : selectedCounts.current.has(value)
               ? selectedCounts.current.get(value)
               : count
@@ -150,10 +155,7 @@ const Wrapper = ({
           <Button
             text={"Reset"}
             color={color}
-            onClick={() => {
-              setSelected([]);
-              initializeSettings();
-            }}
+            onClick={handleReset}
             style={{
               margin: "0.25rem -0.5rem",
               height: "2rem",


### PR DESCRIPTION
## What changes are proposed in this pull request?

Fix bug: remove unnecessary refresh with visibility setting reset. 

## How is this patch tested? If it is not, please explain why.

https://github.com/voxel51/fiftyone/assets/17770824/de6d3851-ca86-4d1f-8a22-77a19b92fde2

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
