### PR TITLE
Delegated operators linting

### DIFF
--- a/fiftyone/core/cli.py
+++ b/fiftyone/core/cli.py
@@ -33,6 +33,7 @@ import fiftyone.core.utils as fou
 import fiftyone.migrations as fom
 import fiftyone.operators as foo
 import fiftyone.operators.delegated as food
+import fiftyone.operators.executor as fooe
 import fiftyone.plugins as fop
 import fiftyone.utils.data as foud
 import fiftyone.utils.image as foui
@@ -2876,36 +2877,32 @@ def _parse_state(state):
 
 
 def _parse_paging(sort_by=None, reverse=None, limit=None):
-    from fiftyone.factory import DelegatedOpPagingParams
+    from fiftyone.factory import DelegatedOperationPagingParams
 
     sort_by = _parse_sort_by(sort_by)
     sort_direction = _parse_reverse(reverse)
-    return DelegatedOpPagingParams(
+    return DelegatedOperationPagingParams(
         sort_by=sort_by, sort_direction=sort_direction, limit=limit
     )
 
 
 def _parse_sort_by(sort_by):
-    from fiftyone.factory import SortByField
+    if sort_by is None:
+        return None
 
-    if sort_by is not None:
-        try:
-            sort_by = SortByField[sort_by.upper()]
-        except:
-            raise ValueError("Invalid sort by '%s'" % sort_by)
-
-    return sort_by
+    return sort_by.lower()
 
 
 def _parse_reverse(reverse):
     from fiftyone.factory import SortDirection
 
+    if reverse is None:
+        return None
+
     return SortDirection.ASCENDING if reverse else SortDirection.DESCENDING
 
 
 def _print_delegated_list(ops):
-    from fiftyone.operators.executor import ExecutionRunState
-
     headers = [
         "id",
         "operator",
@@ -2924,7 +2921,7 @@ def _print_delegated_list(ops):
                 "dataset": op.context.request_params.get("dataset_name", None),
                 "queued_at": op.queued_at,
                 "state": op.run_state,
-                "completed": op.run_state == ExecutionRunState.COMPLETED,
+                "completed": op.run_state == fooe.ExecutionRunState.COMPLETED,
             }
         )
 
@@ -3050,9 +3047,7 @@ def _cleanup_orphan_delegated(dry_run=False):
 
 
 def _cleanup_delegated(operator=None, dataset=None, state=None, dry_run=False):
-    from fiftyone.operators.executor import ExecutionRunState
-
-    if state == ExecutionRunState.RUNNING:
+    if state == fooe.ExecutionRunState.RUNNING:
         raise ValueError(
             "Deleting operations that are currently running is not allowed"
         )
@@ -3066,7 +3061,7 @@ def _cleanup_delegated(operator=None, dataset=None, state=None, dry_run=False):
 
     del_ids = set()
     for op in ops:
-        if op.run_state != ExecutionRunState.RUNNING:
+        if op.run_state != fooe.ExecutionRunState.RUNNING:
             del_ids.add(op.id)
 
     num_del = len(del_ids)

--- a/fiftyone/core/cli.py
+++ b/fiftyone/core/cli.py
@@ -2770,9 +2770,12 @@ class DelegatedLaunchCommand(Command):
 
 
 def _launch_delegated_local():
+    from fiftyone.core.session.session import _WELCOME_MESSAGE
+
     try:
         dos = food.DelegatedOperationService()
 
+        print(_WELCOME_MESSAGE.format(foc.VERSION))
         print("Delegated operation service running")
         print("\nTo exit, press ctrl + c")
         while True:

--- a/fiftyone/core/cli.py
+++ b/fiftyone/core/cli.py
@@ -2869,15 +2869,10 @@ class DelegatedListCommand(Command):
 
 
 def _parse_state(state):
-    from fiftyone.operators.executor import ExecutionRunState
+    if state is None:
+        return None
 
-    if state is not None:
-        try:
-            state = ExecutionRunState[state.upper()]
-        except:
-            raise ValueError("Invalid run state '%s'" % state)
-
-    return state
+    return state.lower()
 
 
 def _parse_paging(sort_by=None, reverse=None, limit=None):

--- a/fiftyone/core/cli.py
+++ b/fiftyone/core/cli.py
@@ -2928,7 +2928,7 @@ def _print_delegated_list(ops):
                 "operator": op.operator,
                 "dataset": op.context.request_params.get("dataset_name", None),
                 "queued_at": op.queued_at,
-                "state": op.run_state.value,
+                "state": op.run_state,
                 "completed": op.run_state == ExecutionRunState.COMPLETED,
             }
         )

--- a/fiftyone/factory/__init__.py
+++ b/fiftyone/factory/__init__.py
@@ -1,13 +1,15 @@
 """
-FiftyOne Repository Factory
+FiftyOne repository factory.
+
 | Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
-from enum import Enum
 
 
-class SortByField(Enum):
+class SortByField(object):
+    """Sort by enum for delegated operations."""
+
     UPDATED_AT = "updated_at"
     QUEUED_AT = "queued_at"
     COMPLETED_AT = "completed_at"
@@ -16,12 +18,16 @@ class SortByField(Enum):
     OPERATOR = "operator"
 
 
-class SortDirection(Enum):
+class SortDirection(object):
+    """Sort direction enum for delegated operations."""
+
     ASCENDING = 1
     DESCENDING = -1
 
 
-class DelegatedOpPagingParams:
+class DelegatedOperationPagingParams(object):
+    """Paging parameters for delegated operations."""
+
     def __init__(
         self,
         sort_by: SortByField = SortByField.QUEUED_AT,

--- a/fiftyone/factory/repo_factory.py
+++ b/fiftyone/factory/repo_factory.py
@@ -1,5 +1,5 @@
 """
-FiftyOne Repository Factory
+FiftyOne repository factory.
 
 | Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
@@ -8,18 +8,19 @@ FiftyOne Repository Factory
 import pymongo
 from pymongo.database import Database
 
+import fiftyone as fo
+import fiftyone.core.odm as foo
 from fiftyone.factory.repos.delegated_operation import (
     DelegatedOperationRepo,
     MongoDelegatedOperationRepo,
 )
-import fiftyone.core.odm as foo
-import fiftyone as fo
+
 
 db_client: pymongo.mongo_client.MongoClient = foo.get_db_client()
 db: Database = db_client[fo.config.database_name]
 
 
-class RepositoryFactory:
+class RepositoryFactory(object):
     repos = {}
 
     @staticmethod

--- a/fiftyone/factory/repos/__init__.py
+++ b/fiftyone/factory/repos/__init__.py
@@ -1,5 +1,5 @@
 """
-FiftyOne repository factory
+FiftyOne repository factory.
 
 | Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_

--- a/fiftyone/factory/repos/delegated_operation_doc.py
+++ b/fiftyone/factory/repos/delegated_operation_doc.py
@@ -1,10 +1,10 @@
 """
-FiftyOne Delegated Operation Repository Document
+FiftyOne delegated operation repository document.
+
 | Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
-
 from datetime import datetime
 
 from fiftyone.operators.executor import (

--- a/fiftyone/operators/executor.py
+++ b/fiftyone/operators/executor.py
@@ -6,12 +6,12 @@ FiftyOne operator execution.
 |
 """
 import asyncio
-import types as python_types
 import traceback
-from enum import Enum
+import types as python_types
 
 import fiftyone as fo
 import fiftyone.core.dataset as fod
+import fiftyone.core.utils as fou
 import fiftyone.core.view as fov
 import fiftyone.server.view as fosv
 import fiftyone.operators.types as types
@@ -19,10 +19,11 @@ import fiftyone.operators.types as types
 from .decorators import coroutine_timeout
 from .registry import OperatorRegistry
 from .message import GeneratedMessage, MessageType
-from fiftyone.core.utils import run_sync_task
 
 
-class ExecutionRunState:
+class ExecutionRunState(object):
+    """Enumeration of the available operator run states."""
+
     QUEUED = "queued"
     RUNNING = "running"
     COMPLETED = "completed"
@@ -182,7 +183,7 @@ async def execute_or_delegate_operator(operator_uri, request_params):
             raw_result = await (
                 operator.execute(ctx)
                 if asyncio.iscoroutinefunction(operator.execute)
-                else run_sync_task(operator.execute, ctx)
+                else fou.run_sync_task(operator.execute, ctx)
             )
 
         except Exception as e:

--- a/tests/unittests/delegated_operators_tests.py
+++ b/tests/unittests/delegated_operators_tests.py
@@ -13,16 +13,17 @@ from bson import ObjectId
 
 from fiftyone import Dataset
 from fiftyone.factory import (
-    DelegatedOpPagingParams,
+    DelegatedOperationPagingParams,
     SortDirection,
     SortByField,
 )
-from fiftyone.operators.executor import ExecutionContext, ExecutionResult
-from fiftyone.operators.operator import Operator, OperatorConfig
-from fiftyone.operators.delegated import (
-    DelegatedOperationService,
+from fiftyone.operators.delegated import DelegatedOperationService
+from fiftyone.operators.executor import (
+    ExecutionContext,
+    ExecutionResult,
     ExecutionRunState,
 )
+from fiftyone.operators.operator import Operator, OperatorConfig
 
 
 class MockOperator(Operator):
@@ -372,7 +373,7 @@ class DelegatedOperationServiceTests(unittest.TestCase):
         # test paging - get a page of everything
         docs = self.svc.list_operations(
             dataset_name=dataset_name,
-            paging=DelegatedOpPagingParams(
+            paging=DelegatedOperationPagingParams(
                 skip=0,
                 limit=25,
                 sort_by=SortByField.QUEUED_AT,
@@ -385,7 +386,7 @@ class DelegatedOperationServiceTests(unittest.TestCase):
 
         docs = self.svc.list_operations(
             dataset_name=dataset_name,
-            paging=DelegatedOpPagingParams(
+            paging=DelegatedOperationPagingParams(
                 skip=0,
                 limit=1000,
                 sort_by=SortByField.UPDATED_AT,
@@ -398,7 +399,7 @@ class DelegatedOperationServiceTests(unittest.TestCase):
 
         docs = self.svc.list_operations(
             dataset_name=dataset_name,
-            paging=DelegatedOpPagingParams(
+            paging=DelegatedOperationPagingParams(
                 skip=0,
                 limit=1,
                 sort_by=SortByField.QUEUED_AT,
@@ -411,7 +412,7 @@ class DelegatedOperationServiceTests(unittest.TestCase):
 
         docs = self.svc.list_operations(
             operator=f"@voxelfiftyone/operator/test_0",
-            paging=DelegatedOpPagingParams(skip=0, limit=100),
+            paging=DelegatedOperationPagingParams(skip=0, limit=100),
         )
         self.assertEqual(len(docs), 25)
         states = [doc.run_state for doc in docs]
@@ -419,7 +420,7 @@ class DelegatedOperationServiceTests(unittest.TestCase):
 
         docs = self.svc.list_operations(
             operator=f"@voxelfiftyone/operator/test_1",
-            paging=DelegatedOpPagingParams(skip=0, limit=100),
+            paging=DelegatedOperationPagingParams(skip=0, limit=100),
         )
         self.assertEqual(len(docs), 25)
         states = [doc.run_state for doc in docs]
@@ -427,7 +428,7 @@ class DelegatedOperationServiceTests(unittest.TestCase):
 
         docs = self.svc.list_operations(
             operator=f"@voxelfiftyone/operator/test_2",
-            paging=DelegatedOpPagingParams(skip=0, limit=100),
+            paging=DelegatedOperationPagingParams(skip=0, limit=100),
         )
         self.assertEqual(len(docs), 25)
         states = [doc.run_state for doc in docs]
@@ -435,7 +436,7 @@ class DelegatedOperationServiceTests(unittest.TestCase):
 
         docs = self.svc.list_operations(
             operator=f"@voxelfiftyone/operator/test_3",
-            paging=DelegatedOpPagingParams(skip=0, limit=100),
+            paging=DelegatedOperationPagingParams(skip=0, limit=100),
         )
         self.assertEqual(len(docs), 25)
         states = [doc.run_state for doc in docs]
@@ -450,7 +451,7 @@ class DelegatedOperationServiceTests(unittest.TestCase):
             docs = self.svc.list_operations(
                 dataset_name=dataset_name,
                 run_state=ExecutionRunState.QUEUED,
-                paging=DelegatedOpPagingParams(
+                paging=DelegatedOperationPagingParams(
                     skip=pages * limit,
                     limit=limit,
                     sort_by=SortByField.QUEUED_AT,
@@ -522,7 +523,7 @@ class DelegatedOperationServiceTests(unittest.TestCase):
 
         ops = self.svc.list_operations(
             dataset_name=dataset_name,
-            paging=DelegatedOpPagingParams(
+            paging=DelegatedOperationPagingParams(
                 skip=0,
                 limit=100,
                 sort_by=SortByField.QUEUED_AT,
@@ -536,7 +537,7 @@ class DelegatedOperationServiceTests(unittest.TestCase):
 
         ops = self.svc.list_operations(
             dataset_name=dataset_name,
-            paging=DelegatedOpPagingParams(
+            paging=DelegatedOperationPagingParams(
                 skip=0,
                 limit=100,
                 sort_by=SortByField.QUEUED_AT,
@@ -578,7 +579,7 @@ class DelegatedOperationServiceTests(unittest.TestCase):
         # test paging - get a page of everything
         docs = self.svc.list_operations(
             search={"operator\/test": {"operator"}},
-            paging=DelegatedOpPagingParams(
+            paging=DelegatedOperationPagingParams(
                 skip=0,
                 limit=5000,
                 sort_by=SortByField.QUEUED_AT,
@@ -590,7 +591,7 @@ class DelegatedOperationServiceTests(unittest.TestCase):
 
         docs = self.svc.list_operations(
             search={"test_0": {"operator"}},
-            paging=DelegatedOpPagingParams(
+            paging=DelegatedOperationPagingParams(
                 skip=0,
                 limit=5000,
                 sort_by=SortByField.QUEUED_AT,


### PR DESCRIPTION
Quick editing pass to apply our [Python style guide](https://github.com/voxel51/fiftyone/blob/develop/STYLE_GUIDE.md#python-style-guide) to delegated operators.

Notes
- convert `SortBy` and `SortDirection` to regular classes, not enums, for consistency with `ExecutionRunState`
- rename `DelegatedOpPagingParams` to `DelegatedOperationPagingParams` for consistency with how `Operation` is not abbreviated in other class names
- don't use type annotations in `fiftyone.operators.delegated`, for consistency with other modules in this subpackage
- apply 79 character line limit to docstrings and fix broken `:class:` links
- alphabetize imports
- adds some missing type annotations/docstrings in `fiftyone.factory`
