### PR TITLE
fix dynamic groups e2e bug

### DIFF
--- a/app/packages/core/src/components/Actions/DynamicGroup.tsx
+++ b/app/packages/core/src/components/Actions/DynamicGroup.tsx
@@ -165,7 +165,7 @@ export default ({
             <PopoutSectionTitle>Group By</PopoutSectionTitle>
             <Selector
               id={SELECTOR_RESULTS_ID}
-              data-cy="group-by-selector"
+              cy="group by"
               inputStyle={{
                 fontSize: "1rem",
                 minWidth: "100%",

--- a/e2e-pw/src/oss/poms/action-row/grid-actions-row.ts
+++ b/e2e-pw/src/oss/poms/action-row/grid-actions-row.ts
@@ -1,5 +1,6 @@
 import { Locator, Page } from "src/oss/fixtures";
 import { DisplayOptionsPom } from "./display-options";
+import { SelectorPom } from "../selector";
 
 export class GridActionsRowPom {
   readonly page: Page;
@@ -49,11 +50,9 @@ export class GridActionsRowPom {
     await this.toPatchesByLabelField(fieldName).click();
   }
 
-  async groupBy(path: string) {
-    await this.gridActionsRow.getByTestId("group-by-selector").click();
-    await this.gridActionsRow.getByTestId("group-by-selector").type(path);
-
-    await this.gridActionsRow.getByTestId("group-by-selector").press("Enter");
+  async groupBy(path: string, selector: SelectorPom) {
+    await selector.openResults();
+    await selector.selectResult(path);
     await this.gridActionsRow.getByTestId("dynamic-group-btn-submit").click();
   }
 

--- a/e2e-pw/src/oss/specs/dynamic-groups-cifar.spec.ts
+++ b/e2e-pw/src/oss/specs/dynamic-groups-cifar.spec.ts
@@ -34,7 +34,7 @@ test.skip("valid candidates for group-by keys", async ({ grid }) => {
 });
 
 const verifyCandidateFields = async (grid: GridPom, fields: string[]) => {
-  await grid.actionsRow.gridActionsRow.getByTestId("group-by-selector").click();
+  await grid.actionsRow.gridActionsRow.getByTestId("group by").click();
   const results = grid.actionsRow.gridActionsRow.getByTestId(
     "selector-results-container"
   );

--- a/e2e-pw/src/oss/specs/smoke-tests/quickstart.spec.ts
+++ b/e2e-pw/src/oss/specs/smoke-tests/quickstart.spec.ts
@@ -1,16 +1,30 @@
 import { test as base, expect } from "src/oss/fixtures";
 import { GridPom } from "src/oss/poms/grid";
 import { ModalPom } from "src/oss/poms/modal";
+import { SelectorPom } from "src/oss/poms/selector";
 import { getUniqueDatasetNameWithPrefix } from "src/oss/utils";
 
 const datasetName = getUniqueDatasetNameWithPrefix("smoke-quickstart");
 
-const test = base.extend<{ grid: GridPom; modal: ModalPom }>({
+const test = base.extend<{
+  grid: GridPom;
+  modal: ModalPom;
+  selector: SelectorPom;
+}>({
   grid: async ({ page, eventUtils }, use) => {
     await use(new GridPom(page, eventUtils));
   },
   modal: async ({ page }, use) => {
     await use(new ModalPom(page));
+  },
+  selector: async ({ page, eventUtils }, use) => {
+    await use(
+      new SelectorPom(
+        page.getByTestId("fo-grid-actions"),
+        eventUtils,
+        "group by"
+      )
+    );
   },
 });
 
@@ -33,7 +47,10 @@ test.describe("quickstart", () => {
     await modal.waitForSampleLoadDomAttribute();
   });
 
-  test("entry counts text when toPatches then groupedBy", async ({ grid }) => {
+  test("entry counts text when toPatches then groupedBy", async ({
+    grid,
+    selector,
+  }) => {
     await grid.actionsRow.toggleToClipsOrPatches();
 
     const gridRefreshPromisePredictions = grid.getWaitForGridRefreshPromise();
@@ -45,7 +62,7 @@ test.describe("quickstart", () => {
     await grid.actionsRow.toggleCreateDynamicGroups();
 
     const gridRefreshPromiseGroupByLabel = grid.getWaitForGridRefreshPromise();
-    await grid.actionsRow.groupBy("predictions.label");
+    await grid.actionsRow.groupBy("predictions.label", selector);
     await gridRefreshPromiseGroupByLabel;
 
     await grid.assert.isEntryCountTextEqualTo("33 groups of patches");


### PR DESCRIPTION
## What changes are proposed in this pull request?

- This fixes the flaky behavior of some e2e tests related to dynamic groups caused by selecting a group-by field before it's populated.

## How is this patch tested? If it is not, please explain why.

- Locally