### PR TITLE
early return for empty dir and ignore hidden files

### DIFF
--- a/fiftyone/operators/decorators.py
+++ b/fiftyone/operators/decorators.py
@@ -6,6 +6,8 @@ FiftyOne operator decorators.
 |
 """
 import asyncio
+import glob
+
 from cachetools.keys import hashkey
 from contextlib import contextmanager
 from functools import wraps
@@ -85,6 +87,8 @@ def plugins_cache(func):
 def dir_state(dirpath):
     if not os.path.isdir(dirpath):
         return None
-    return max(
-        os.path.getmtime(os.path.join(dirpath, f)) for f in os.listdir(dirpath)
-    )
+    # use glob instead of os.listdir to ignore hidden files (eg .DS_STORE)
+    dirs = glob.glob(os.path.join(dirpath, "*"))
+    if not dirs:
+        return None
+    return max(os.path.getmtime(f) for f in dirs)

--- a/fiftyone/operators/decorators.py
+++ b/fiftyone/operators/decorators.py
@@ -88,7 +88,7 @@ def dir_state(dirpath):
     if not os.path.isdir(dirpath):
         return None
     # use glob instead of os.listdir to ignore hidden files (eg .DS_STORE)
-    dirs = glob.glob(os.path.join(dirpath, "*"))
-    if not dirs:
-        return None
-    return max(os.path.getmtime(f) for f in dirs)
+    return max(
+        (os.path.getmtime(f) for f in glob.glob(os.path.join(dirpath, "*"))),
+        default=None,
+    )

--- a/tests/unittests/operators/decorators_tests.py
+++ b/tests/unittests/operators/decorators_tests.py
@@ -5,8 +5,7 @@ Unit tests for operators/decorators.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
-import glob
-from tempfile import TemporaryDirectory
+import os
 import unittest
 from unittest import mock
 from unittest.mock import patch
@@ -15,24 +14,49 @@ from fiftyone.operators.decorators import dir_state
 
 
 class DirStateTests(unittest.TestCase):
-    def test_dir_state_nonexistant(self):
-        dirpath = "/tmp/this/path/does/not/exist"
-        glob_mock = mock.Mock(speck=glob.glob)
+    @patch("glob.glob")
+    @patch("os.path.isdir")
+    def test_dir_state_non_existing_dir(self, mock_isdir, mock_glob):
+        mock_isdir.return_value = False
+        dirpath = "/non/existing/dir"
         try:
-            dir_state(dirpath)
+            result = dir_state(dirpath)
         except Exception as e:
             self.fail(e)
 
-        assert not glob_mock.called
+        self.assertIsNone(result)
+        assert not mock_glob.called
 
     @patch("glob.glob")
-    def test_dir_state_empty(self, mock_glob):
+    @patch("os.path.isdir")
+    def test_dir_state_existing_empty_dir(self, mock_isdir, mock_glob):
+        mock_isdir.return_value = True
         mock_glob.return_value = []
-        with TemporaryDirectory() as d:
-            dir_path = d
-            try:
-                dir_state(dir_path)
-            except Exception as e:
-                self.fail(e)
+        dirpath = "/existing/empty/dir"
 
-        mock_glob.assert_called_once_with(dir_path + "/*")
+        try:
+            result = dir_state(dirpath)
+        except Exception as e:
+            self.fail(e)
+        self.assertIsNone(result)
+        mock_isdir.assert_called_once_with(dirpath)
+        mock_glob.assert_called_once_with(os.path.join(dirpath, "*"))
+
+    @patch("os.path.isdir")
+    @patch("glob.glob")
+    @patch("os.path.getmtime")
+    def test_dir_state_with_existing_nonempty_dir(
+        self, mock_getmtime, mock_glob, mock_isdir
+    ):
+        mock_isdir.return_value = True
+        mock_glob.return_value = ["file1.txt", "file2.txt"]
+        mock_getmtime.side_effect = [1000, 2000]
+
+        result = dir_state("/my/dir/path")
+
+        self.assertEqual(result, 2000)
+        mock_isdir.assert_called_once_with("/my/dir/path")
+        mock_glob.assert_called_once_with(os.path.join("/my/dir/path", "*"))
+        mock_getmtime.assert_has_calls(
+            [unittest.mock.call("file1.txt"), unittest.mock.call("file2.txt")]
+        )

--- a/tests/unittests/operators/decorators_tests.py
+++ b/tests/unittests/operators/decorators_tests.py
@@ -1,0 +1,38 @@
+"""
+Unit tests for operators/decorators.
+
+| Copyright 2017-2023, Voxel51, Inc.
+| `voxel51.com <https://voxel51.com/>`_
+|
+"""
+import glob
+from tempfile import TemporaryDirectory
+import unittest
+from unittest import mock
+from unittest.mock import patch
+
+from fiftyone.operators.decorators import dir_state
+
+
+class DirStateTests(unittest.TestCase):
+    def test_dir_state_nonexistant(self):
+        dirpath = "/tmp/this/path/does/not/exist"
+        glob_mock = mock.Mock(speck=glob.glob)
+        try:
+            dir_state(dirpath)
+        except Exception as e:
+            self.fail(e)
+
+        assert not glob_mock.called
+
+    @patch("glob.glob")
+    def test_dir_state_empty(self, mock_glob):
+        mock_glob.return_value = []
+        with TemporaryDirectory() as d:
+            dir_path = d
+            try:
+                dir_state(dir_path)
+            except Exception as e:
+                self.fail(e)
+
+        mock_glob.assert_called_once_with(dir_path + "/*")


### PR DESCRIPTION
## What changes are proposed in this pull request?
Fix `ValueError: max() arg is an empty sequence` for when a plugin dir exists but is empty