### PR TITLE
Corrected SegmentAnythingModel's incorrect loading and unprompted inference.

### DIFF
--- a/fiftyone/utils/sam.py
+++ b/fiftyone/utils/sam.py
@@ -132,9 +132,17 @@ class SegmentAnythingModel(fout.TorchImageModel, fout.TorchSamplesMixin):
     def _download_model(self, config):
         config.download_model_if_necessary()
 
-    def _load_network(self, config):
+    def _load_model(self, config):
         entrypoint = etau.get_function(config.entrypoint_fcn)
-        return entrypoint(checkpoint=config.model_path)
+        model = entrypoint(checkpoint=config.model_path)
+
+        model = model.to(self._device)
+        if self.using_half_precision:
+            model = model.half()
+
+        model.eval()
+
+        return model
 
     def predict_all(self, imgs, samples=None):
         field_name = self._get_field()


### PR DESCRIPTION
## What changes are proposed in this pull request?

Running SAM from the Model Zoo with the given [example code](https://docs.voxel51.com/user_guide/model_zoo/models.html#segment-anything-vitl-torch) was not working.

It turns out that it is because the model's weights were never loaded into the model.
Moreover, when running the unprompted inference, the _forward_pass_auto() was incorrect and yielded a unique Segmentation, discarding the whole hierarchy of masks.

This PR corrects both issues, by loading the model properly onto the chosen device, as well as producing Detections for each inference result produced by SAM.

## How is this patch tested? If it is not, please explain why.

```python
import fiftyone as fo
import fiftyone.zoo as foz

dataset = foz.load_zoo_dataset("quickstart")

model_name = "segment-anything-vitb-torch"
model = foz.load_zoo_model(model_name)

label_field = f"{model_name}_unprompted_segmentation"
label_field = label_field.replace("-", "_").replace(".", "_")

dataset.apply_model(model=model, label_field=label_field, num_workers=4)

session = fo.launch_app(dataset)
session.wait()
```

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
