### PR TITLE
Sunny/e2e field visibility

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -4,8 +4,8 @@ on: workflow_call
 
 jobs:
   test-e2e:
-    timeout-minutes: 30
-    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    runs-on: ubuntu-latest-m
     env:
       FIFTYONE_DO_NOT_TRACK: true
       ELECTRON_EXTRA_LAUNCH_ARGS: "--disable-gpu"

--- a/app/packages/components/src/components/TabOption/TabOption.tsx
+++ b/app/packages/components/src/components/TabOption/TabOption.tsx
@@ -80,7 +80,7 @@ const TabOption = ({
     >
       {options.map(({ text, title, onClick, dataCy }, i) => (
         <Tab
-          data-cy={dataCy}
+          data-cy={dataCy || `tab-option-${title}`}
           onClick={() => {
             !disabled && onClick();
           }}

--- a/app/packages/components/src/components/TabOption/TabOption.tsx
+++ b/app/packages/components/src/components/TabOption/TabOption.tsx
@@ -34,6 +34,7 @@ type TabOption = {
   title: string;
   text: string;
   onClick: () => void;
+  dataCy?: string;
 };
 
 export type TabOptionProps = {
@@ -77,9 +78,9 @@ const TabOption = ({
       onMouseEnter={() => set({ background: theme.background.body })}
       onMouseLeave={() => set({ background: theme.background.level1 })}
     >
-      {options.map(({ text, title, onClick }, i) => (
+      {options.map(({ text, title, onClick, dataCy }, i) => (
         <Tab
-          data-cy={`tab-option-${title}`}
+          data-cy={dataCy}
           onClick={() => {
             !disabled && onClick();
           }}

--- a/app/packages/core/src/components/Schema/SchemaSearch.tsx
+++ b/app/packages/core/src/components/Schema/SchemaSearch.tsx
@@ -32,6 +32,7 @@ export const SchemaSearch = (props: Props) => {
     >
       <Box width="100%" paddingTop="0.5rem">
         <input
+          data-cy="filter-visibility-filter-rule-input"
           value={searchTerm}
           placeholder="search by fields and attributes"
           style={{

--- a/app/packages/core/src/components/Schema/SchemaSearchHelp.tsx
+++ b/app/packages/core/src/components/Schema/SchemaSearchHelp.tsx
@@ -26,7 +26,7 @@ const EXAMPLES = [
   },
   {
     title: "Match fields whose owner contains “foo”",
-    code: "info.owner:foo",
+    code: "owner:foo",
   },
   {
     title: 'Match fields whose description contains "foo"',
@@ -42,7 +42,7 @@ export const SchemaSearchHelp = (props: Props) => {
   const theme = useTheme();
 
   return (
-    <Box display="flex" flexDirection="column">
+    <Box display="flex" flexDirection="column" data-cy="filter-rule-container">
       {EXAMPLES.map(({ title, primaryTextColor, code }: Example) => (
         <Box
           key={title}

--- a/app/packages/core/src/components/Schema/SchemaSelectControls.tsx
+++ b/app/packages/core/src/components/Schema/SchemaSelectControls.tsx
@@ -96,6 +96,9 @@ export const SchemaSelectionControls = () => {
                       checked={checked}
                       onChange={onChange}
                       disabled={disabled}
+                      data-cy={`field-visibility-controls-${label
+                        .toLowerCase()
+                        .replace(/ /g, "-")}`}
                     />
                   }
                   label={label}

--- a/app/packages/core/src/components/Schema/SchemaSelectionRow.tsx
+++ b/app/packages/core/src/components/Schema/SchemaSelectionRow.tsx
@@ -199,8 +199,13 @@ export const SchemaSelectionRow = (props: Props) => {
       </Box>
       <Box>
         {expandedPathsKeys.has(path) && (
-          <Box maxHeight={MAX_ROW_HEIGHT} overflow="auto" position="relative">
-            {renderInfo(info, path)}
+          <Box
+            maxHeight={MAX_ROW_HEIGHT}
+            overflow="auto"
+            position="relative"
+            data-cy={`schema-selection-info-container-${path}`}
+          >
+            {renderInfo()}
             {description && (
               <MetaInfoBlock key={description}>
                 <MetaInfoKey>Description: </MetaInfoKey>

--- a/app/packages/core/src/components/Schema/SchemaSettings.tsx
+++ b/app/packages/core/src/components/Schema/SchemaSettings.tsx
@@ -269,6 +269,7 @@ const SchemaSettings = () => {
               Apply
             </Button>
             <Button
+              data-cy="field-visibility-btn-reset"
               style={{
                 color: theme.text.primary,
                 boxShadow: "none",

--- a/app/packages/core/src/components/Sidebar/Entries/FilterEntry.tsx
+++ b/app/packages/core/src/components/Sidebar/Entries/FilterEntry.tsx
@@ -128,7 +128,11 @@ const Filter = ({ modal }: { modal: boolean }) => {
               </Box>
             </Tooltip>
           )}
-          <Tooltip text="Change field visibility" placement="bottom-center">
+          <Tooltip
+            text="Change field visibility"
+            placement="bottom-center"
+            data-cy="field-visibility-toggle-tooltip"
+          >
             <Settings
               data-cy="field-visibility-icon"
               onClick={() => {

--- a/e2e-pw/src/oss/poms/field-visibility/field-visibility.ts
+++ b/e2e-pw/src/oss/poms/field-visibility/field-visibility.ts
@@ -1,19 +1,43 @@
 import { Locator, Page } from "src/oss/fixtures";
 import { SidebarPom } from "../sidebar";
 
+const enabledParentPaths = ["uniqueness", "predictions", "ground_truth"];
+const disabledParentPaths = ["filepath", "id", "metadata", "tags"];
+const allParentPaths = [...enabledParentPaths, ...disabledParentPaths];
+const annotationSubpaths = (type: "detections" | "ground_truth") => [
+  `${type}.detections.confidence`,
+  `${type}.detections.id`,
+  `${type}.detections.label`,
+  `${type}.detections.tags`,
+];
+const metadataSubpaths = [
+  "metadata.height",
+  "metadata.mime_type",
+  "metadata.num_channels",
+  "metadata.size_bytes",
+  "metadata.width",
+];
+const allSubpaths = [
+  ...annotationSubpaths("detections"),
+  ...annotationSubpaths("ground_truth"),
+  ...metadataSubpaths,
+];
+const allPaths = [...allParentPaths, ...allSubpaths];
+
 export class FieldVisibilityPom {
   readonly page: Page;
-  readonly assert: FieldVisibilityAsserter;
+  readonly asserter: FieldVisibilityAsserter;
 
   readonly sidebarLocator: Locator;
-  readonly dialogLocator: Locator;
+  readonly containerLocator: Locator;
 
   constructor(page: Page) {
     this.page = page;
 
-    this.assert = new FieldVisibilityAsserter(this, new SidebarPom(page));
+    this.asserter = new FieldVisibilityAsserter(this, new SidebarPom(page));
 
     this.sidebarLocator = page.getByTestId("sidebar");
+    this.containerLocator = page.getByTestId("field-visibility-container");
   }
 
   get modalContainer() {
@@ -24,13 +48,87 @@ export class FieldVisibilityPom {
     return this.sidebarLocator.getByTestId("field-visibility-icon");
   }
 
+  getFieldVisibilityToggleTooltip() {
+    return this.page.getByText("Change field visibility");
+  }
+
+  getFieldCheckbox(name: string) {
+    return this.page
+      .getByTestId(`schema-selection-${name}`)
+      .getByRole("checkbox");
+  }
+
+  async getSelectionFields(
+    status: "checked" | "unchecked" | "all" = "checked",
+    mode: "parents-only" | "nested-only" | "all" = "parents-only"
+  ) {
+    let paths = [];
+    switch (mode) {
+      case "parents-only":
+        paths = allParentPaths;
+        break;
+      case "nested-only":
+        paths = allSubpaths;
+        break;
+      case "all":
+        paths = allPaths;
+        break;
+      default:
+        break;
+    }
+
+    const checked = status === "checked";
+    const fields = [];
+
+    for (let i = 0; i < paths.length; i++) {
+      const cc = this.getFieldCheckbox(paths[i]);
+      if (status === "all") {
+        fields.push(cc);
+        continue;
+      }
+
+      const isCheckedFinal = await cc.isChecked();
+      if ((checked && isCheckedFinal) || (!checked && !isCheckedFinal)) {
+        fields.push(cc);
+      }
+    }
+    return fields;
+  }
+
+  getFieldVisibilityBtn() {
+    return this.sidebarLocator.getByTestId("field-visibility-icon");
+  }
+
+  getFieldVisibilityControl(label: string) {
+    return this.containerLocator.getByTestId(
+      `field-visibility-controls-${label}`
+    );
+  }
+
+  getControl(name: "select-all" | "show-nested-fields" | "show-metadata") {
+    return this.getFieldVisibilityControl(name);
+  }
+
+  async toggleAllSelection() {
+    const toggle = this.getControl("select-all");
+    await toggle.click();
+  }
+
+  async toggleShowNestedFields() {
+    const toggle = this.getControl("show-nested-fields");
+    await toggle.click();
+  }
+
+  async toggleShowMetadata() {
+    const toggle = this.getControl("show-metadata");
+    await toggle.click();
+  }
+
   async openFieldVisibilityModal() {
     await this.fieldVisibilityBtn.click();
   }
 
   async hideFields(paths: string[]) {
-    await this.openFieldVisibilityModal();
-
     for (let i = 0; i < paths.length; i++) {
       await this.page
         .getByTestId(`schema-selection-${paths[i]}`)
@@ -56,6 +154,20 @@ export class FieldVisibilityPom {
   get applyBtn() {
     return this.modalContainer.getByTestId("field-visibility-btn-apply");
   }
+
+  getFieldInfoContainer(path: string) {
+    return this.modalContainer().getByTestId(
+      `schema-selection-info-container-${path}`
+    );
+  }
+
+  getResetBtn() {
+    return this.modalContainer().getByTestId("field-visibility-btn-reset");
+  }
+
+  async clickReset() {
+    return await this.getResetBtn().click();
+  }
 }
 
 class FieldVisibilityAsserter {
@@ -63,4 +175,48 @@ class FieldVisibilityAsserter {
     private readonly fv: FieldVisibilityPom,
     private readonly sb: SidebarPom
   ) {}
+
+  async fieldVisibilityIconHasTooltip() {
+    const visibilityIcon = this.fv.getFieldVisibilityBtn();
+    await visibilityIcon.hover();
+    await expect(this.fv.getFieldVisibilityToggleTooltip()).toBeVisible();
+  }
+
+  async assertAllFieldsSelected() {
+    await this.fv.openFieldVisibilityModal();
+    const selectionFields = await this.fv.getSelectionFields();
+
+    expect(selectionFields.length).toEqual(allParentPaths.length);
+  }
+
+  async assertEnabledFieldsAreUnselected() {
+    const fields = await this.fv.getSelectionFields("unchecked");
+    expect(fields.length).toEqual(enabledParentPaths.length);
+  }
+
+  async assertEnabledFieldsAreSelected() {
+    const fields = await this.fv.getSelectionFields();
+    expect(fields.length).toEqual(disabledParentPaths.length);
+  }
+
+  async assertNestedFieldsVisible() {
+    const fields = await this.fv.getSelectionFields("all", "all");
+    expect(fields.length).toBeGreaterThan(allParentPaths.length);
+  }
+
+  async assertMetadataInvisibile(path: string = "ground_truth") {
+    const fieldInfoContainer = this.fv.getFieldInfoContainer(path);
+    await expect(fieldInfoContainer).toBeHidden();
+  }
+
+  async assertMetadataVisibile(path: string = "ground_truth") {
+    const fieldInfoContainer = this.fv.getFieldInfoContainer(path);
+    await expect(fieldInfoContainer).toBeVisible();
+    await expect(
+      fieldInfoContainer.getByText(`${path} description`)
+    ).toBeVisible();
+    await expect(
+      fieldInfoContainer.getByText("https://fiftyone.ai")
+    ).toBeVisible();
+  }
 }

--- a/e2e-pw/src/oss/poms/field-visibility/field-visibility.ts
+++ b/e2e-pw/src/oss/poms/field-visibility/field-visibility.ts
@@ -176,7 +176,7 @@ export class FieldVisibilityPom {
       await this.page
         .getByTestId(`schema-selection-${paths[i]}`)
         .getByRole("checkbox", { checked: true })
-        .click();
+        .click({ timeout: 1000 });
     }
 
     await this.submitFieldVisibilityChanges();

--- a/e2e-pw/src/oss/poms/field-visibility/field-visibility.ts
+++ b/e2e-pw/src/oss/poms/field-visibility/field-visibility.ts
@@ -1,4 +1,4 @@
-import { Locator, Page } from "src/oss/fixtures";
+import { Locator, Page, expect } from "src/oss/fixtures";
 import { SidebarPom } from "../sidebar";
 
 const enabledParentPaths = ["uniqueness", "predictions", "ground_truth"];
@@ -58,8 +58,30 @@ export class FieldVisibilityPom {
     return this.sidebarLocator.getByTestId("field-visibility-icon");
   }
 
-  getFieldVisibilityToggleTooltip() {
+  get fieldVisibilityToggleTooltip() {
     return this.page.getByText("Change field visibility");
+  }
+
+  get clearBtn() {
+    return this.sidebarLocator.getByTestId("field-visibility-btn-clear");
+  }
+
+  get applyBtn() {
+    return this.containerLocator.getByTestId("field-visibility-btn-apply");
+  }
+
+  get resetBtn() {
+    return this.containerLocator.getByTestId("field-visibility-btn-reset");
+  }
+
+  get filterRuleContainer() {
+    return this.containerLocator.getByTestId("filter-rule-container");
+  }
+
+  get filterRuleInput() {
+    return this.containerLocator.getByTestId(
+      "filter-visibility-filter-rule-input"
+    );
   }
 
   getFieldCheckbox(name: string) {
@@ -68,16 +90,35 @@ export class FieldVisibilityPom {
       .getByRole("checkbox");
   }
 
+  getFieldVisibilityControl(label: string) {
+    return this.containerLocator.getByTestId(
+      `field-visibility-controls-${label}`
+    );
+  }
+
+  getControl(name: "select-all" | "show-metadata" | "show-nested-fields") {
+    return this.getFieldVisibilityControl(name);
+  }
+
+  getFieldInfoContainer(path: string) {
+    return this.containerLocator.getByTestId(
+      `schema-selection-info-container-${path}`
+    );
+  }
+
+  getTab(tabName: TabType) {
+    return this.containerLocator.getByTitle(tabName);
+  }
+
   async getSelectionFields(
     status: "checked" | "unchecked" | "all" = "checked",
     mode:
       | "parents-only"
       | "nested-only"
       | "all"
-      | "customFields" = "parents-only",
-    customFields?: string[]
+      | "customFields" = "parents-only"
   ) {
-    let paths = [];
+    let paths: string[] = [];
     switch (mode) {
       case "parents-only":
         paths = allParentPaths;
@@ -94,7 +135,7 @@ export class FieldVisibilityPom {
     }
 
     const checked = status === "checked";
-    const fields = [];
+    const fields: string[] = [];
 
     for (let i = 0; i < paths.length; i++) {
       const cc = this.getFieldCheckbox(paths[i]);
@@ -109,20 +150,6 @@ export class FieldVisibilityPom {
       }
     }
     return fields;
-  }
-
-  getFieldVisibilityBtn() {
-    return this.sidebarLocator.getByTestId("field-visibility-icon");
-  }
-
-  getFieldVisibilityControl(label: string) {
-    return this.containerLocator.getByTestId(
-      `field-visibility-controls-${label}`
-    );
-  }
-
-  getControl(name: "select-all" | "show-nested-fields" | "show-metadata") {
-    return this.getFieldVisibilityControl(name);
   }
 
   async toggleAllSelection() {
@@ -163,49 +190,17 @@ export class FieldVisibilityPom {
     await this.clearBtn.click();
   }
 
-  get clearBtn() {
-    return this.sidebarLocator.getByTestId("field-visibility-btn-clear");
-  }
-
-  get applyBtn() {
-    return this.modalContainer.getByTestId("field-visibility-btn-apply");
-  }
-
-  getFieldInfoContainer(path: string) {
-    return this.modalContainer().getByTestId(
-      `schema-selection-info-container-${path}`
-    );
-  }
-
-  getResetBtn() {
-    return this.modalContainer().getByTestId("field-visibility-btn-reset");
-  }
-
   async clickReset() {
-    return await this.getResetBtn().click();
-  }
-
-  getTab(tabName: TabType) {
-    return this.modalContainer().getByTitle(tabName);
+    return await this.resetBtn.click();
   }
 
   async openTab(tabName: TabType) {
     return await this.getTab(tabName).click();
   }
 
-  getFilterRuleContainer() {
-    return this.modalContainer().getByTestId("filter-rule-container");
-  }
-
-  getFilterRuleInput() {
-    return this.modalContainer().getByTestId(
-      "filter-visibility-filter-rule-input"
-    );
-  }
-
   async addFilterRuleInput(input: string) {
-    await this.getFilterRuleInput().type(input);
-    await this.getFilterRuleInput().press("Enter");
+    await this.filterRuleInput.type(input);
+    await this.filterRuleInput.press("Enter");
   }
 }
 
@@ -216,9 +211,8 @@ class FieldVisibilityAsserter {
   ) {}
 
   async fieldVisibilityIconHasTooltip() {
-    const visibilityIcon = this.fv.getFieldVisibilityBtn();
-    await visibilityIcon.hover();
-    await expect(this.fv.getFieldVisibilityToggleTooltip()).toBeVisible();
+    await this.fv.fieldVisibilityBtn.hover();
+    await expect(this.fv.fieldVisibilityToggleTooltip).toBeVisible();
   }
 
   async assertAllFieldsSelected() {
@@ -257,9 +251,7 @@ class FieldVisibilityAsserter {
   }
 
   async assertFilterRuleExamplesVisibile() {
-    const exampleContainer = this.fv.getFilterRuleContainer();
-    console.log("exampleContainer", exampleContainer);
-    await expect(exampleContainer).toBeVisible();
+    await expect(this.fv.filterRuleContainer).toBeVisible();
   }
 
   async assertDefaultParentPathsSelected() {

--- a/e2e-pw/src/oss/poms/field-visibility/field-visibility.ts
+++ b/e2e-pw/src/oss/poms/field-visibility/field-visibility.ts
@@ -140,7 +140,7 @@ export class FieldVisibilityPom {
     for (let i = 0; i < paths.length; i++) {
       const cc = this.getFieldCheckbox(paths[i]);
       if (status === "all") {
-        fields.push(cc);
+        fields.push(paths[i]);
         continue;
       }
 
@@ -205,21 +205,18 @@ export class FieldVisibilityPom {
 }
 
 class FieldVisibilityAsserter {
-  constructor(
-    private readonly fv: FieldVisibilityPom,
-    private readonly sb: SidebarPom
-  ) {}
+  constructor(private readonly fv: FieldVisibilityPom) {}
 
   async fieldVisibilityIconHasTooltip() {
     await this.fv.fieldVisibilityBtn.hover();
     await expect(this.fv.fieldVisibilityToggleTooltip).toBeVisible();
   }
 
-  async assertAllFieldsSelected() {
+  async assertAllFieldsSelected(selectionFields: string[] = allParentPaths) {
     await this.fv.openFieldVisibilityModal();
-    const selectionFields = await this.fv.getSelectionFields();
+    const expectedSelectionFields = await this.fv.getSelectionFields();
 
-    expect(selectionFields.length).toEqual(allParentPaths.length);
+    expect(expectedSelectionFields.length).toEqual(selectionFields.length);
   }
 
   async assertEnabledFieldsAreUnselected() {

--- a/e2e-pw/src/oss/poms/sidebar.ts
+++ b/e2e-pw/src/oss/poms/sidebar.ts
@@ -29,7 +29,9 @@ export class SidebarPom {
   }
 
   sidebarEntryDraggableArea(fieldName: string) {
-    return this.sidebar.getByTestId(`sidebar-entry-draggable-${fieldName}`);
+    return this.sidebar
+      .getByTestId(`sidebar-entry-draggable-${fieldName}`)
+      .first();
   }
 
   getNumericSliderContainer(field: string) {

--- a/e2e-pw/src/oss/specs/display-options/display-options.spec.ts
+++ b/e2e-pw/src/oss/specs/display-options/display-options.spec.ts
@@ -46,5 +46,6 @@ test.describe("Display Options", () => {
     await panel.bringPanelToForeground("Histograms");
 
     await histogram.assert.isLoaded();
+    await panel.bringPanelToForeground("Samples");
   });
 });

--- a/e2e-pw/src/oss/specs/smoke-tests/field-visibility.spec.ts
+++ b/e2e-pw/src/oss/specs/smoke-tests/field-visibility.spec.ts
@@ -29,12 +29,12 @@ test.describe("field visibility", () => {
 
       field = dataset.get_field("ground_truth")
       field.description = "ground_truth description"
-      field.info = {"url": "https://fiftyone.ai"}
+      field.info = {"owner": "bob"}
       field.save()
 
       field = dataset.get_field("metadata.width")
       field.description = "metadata.width description"
-      field.info = {"url": "https://fiftyone.ai"}
+      field.info = {"owner": "bob"}
       field.save()
 
       dataset.add_samples([fo.Sample(filepath=f"{i}.png", group=1, i=i) for i in range(0, 21)])
@@ -104,6 +104,57 @@ test.describe("field visibility", () => {
       "predictions",
       "ground_truth",
     ]);
+  });
+
+  test("filter rule tab has Examples when no filter rule", async ({
+    fieldVisibility,
+  }) => {
+    await fieldVisibility.openFieldVisibilityModal();
+    await fieldVisibility.openTab("Filter rule");
+    await fieldVisibility.asserter.assertFilterRuleExamplesVisibile();
+  });
+
+  test("non-matching filter rule shows default paths as results", async ({
+    fieldVisibility,
+  }) => {
+    await fieldVisibility.openFieldVisibilityModal();
+    await fieldVisibility.openTab("Filter rule");
+    await fieldVisibility.addFilterRuleInput("metadata");
+    await fieldVisibility.asserter.assertDefaultPathsSelected();
+  });
+
+  test("filter rule by info shows results", async ({ fieldVisibility }) => {
+    await fieldVisibility.openFieldVisibilityModal();
+    await fieldVisibility.openTab("Filter rule");
+    await fieldVisibility.addFilterRuleInput("owner:bob");
+    await fieldVisibility.asserter.assertFieldsAreSelected(["ground_truth"]);
+  });
+
+  test("filter rule by description shows results", async ({
+    fieldVisibility,
+  }) => {
+    await fieldVisibility.openFieldVisibilityModal();
+    await fieldVisibility.openTab("Filter rule");
+    await fieldVisibility.addFilterRuleInput(
+      "description:ground_truth description"
+    );
+    await fieldVisibility.asserter.assertFieldsAreSelected(["ground_truth"]);
+  });
+
+  test("filter rule by name shows results", async ({ fieldVisibility }) => {
+    await fieldVisibility.openFieldVisibilityModal();
+    await fieldVisibility.openTab("Filter rule");
+    await fieldVisibility.addFilterRuleInput("name:predictions");
+    await fieldVisibility.asserter.assertFieldsAreSelected(["predictions"]);
+  });
+
+  test("filter rule by free text shows results if text in field info", async ({
+    fieldVisibility,
+  }) => {
+    await fieldVisibility.openFieldVisibilityModal();
+    await fieldVisibility.openTab("Filter rule");
+    await fieldVisibility.addFilterRuleInput("bob");
+    await fieldVisibility.asserter.assertFieldsAreSelected(["ground_truth"]);
   });
 
   test("sidebar group is hidden if all its fields are hidden using field visibility", async ({

--- a/e2e-pw/src/oss/specs/smoke-tests/field-visibility.spec.ts
+++ b/e2e-pw/src/oss/specs/smoke-tests/field-visibility.spec.ts
@@ -197,6 +197,8 @@ test.describe("field visibility", () => {
 
     // drag predictions back to labels group fails
     await sidebar.asserter.assertCannotDragField("predictions");
+
+    await fieldVisibility.clearFieldVisibilityChanges();
   });
 
   test("sidebar add group input is hidden when field visibility is active", async ({
@@ -204,6 +206,7 @@ test.describe("field visibility", () => {
     fieldVisibility,
   }) => {
     await sidebar.asserter.assertAddGroupVisible();
+    await fieldVisibility.openFieldVisibilityModal();
     await fieldVisibility.hideFields(["ground_truth"]);
     await sidebar.asserter.assertAddGroupHidden();
   });

--- a/fiftyone/server/mutation.py
+++ b/fiftyone/server/mutation.py
@@ -449,7 +449,6 @@ class Mutation:
 
         try:
             view = dataset.select_fields(meta_filter=meta_filter)
-            print("\nmeta_filter\n", meta_filter)
         except Exception as e:
             try:
                 view = dataset.select_fields(meta_filter)


### PR DESCRIPTION
## What changes are proposed in this pull request?

Core e2e test for selection and search for field visibility

example run

https://github.com/voxel51/fiftyone/assets/109545780/d597911c-ac40-41d7-83ad-c444495d1e05


## How is this patch tested? If it is not, please explain why.

(Details)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
