### PR TITLE
Fix dynamic grouping for disjoint group datasets

### DIFF
--- a/app/packages/components/src/components/Selector/Selector.tsx
+++ b/app/packages/components/src/components/Selector/Selector.tsx
@@ -70,6 +70,7 @@ export interface SelectorProps<T> {
   containerStyle?: React.CSSProperties;
   resultsPlacement?: UseLayerOptions["placement"];
   overflow?: boolean;
+  overflowContainer?: boolean;
   onMouseEnter?: React.MouseEventHandler;
   cy?: string;
 }
@@ -88,6 +89,7 @@ const Selector = <T extends unknown>(props: SelectorProps<T>) => {
     containerStyle,
     resultsPlacement,
     overflow = false,
+    overflowContainer = false,
     onMouseEnter,
     cy,
     ...otherProps
@@ -123,7 +125,7 @@ const Selector = <T extends unknown>(props: SelectorProps<T>) => {
 
   const { renderLayer, triggerProps, layerProps, triggerBounds } = useLayer({
     isOpen: editing,
-    overflowContainer: false,
+    overflowContainer,
     auto: true,
     snap: true,
     placement: resultsPlacement ? resultsPlacement : "bottom-center",

--- a/app/packages/core/src/components/Actions/DynamicGroup.tsx
+++ b/app/packages/core/src/components/Actions/DynamicGroup.tsx
@@ -149,7 +149,10 @@ export default ({
 
   return (
     <Popout modal={false} fixed anchorRef={anchorRef}>
-      <DynamicGroupContainer ref={ref}>
+      <DynamicGroupContainer
+        ref={ref}
+        data-cy={"dynamic-group-action-container"}
+      >
         {isDynamicGroupViewStageActive ? (
           <Button
             style={{
@@ -157,6 +160,7 @@ export default ({
               cursor: "pointer",
             }}
             onClick={onClear}
+            data-cy={"dynamic-group-action-reset"}
           >
             Reset Dynamic Groups
           </Button>
@@ -165,7 +169,7 @@ export default ({
             <PopoutSectionTitle>Group By</PopoutSectionTitle>
             <Selector
               id={SELECTOR_RESULTS_ID}
-              cy="group by"
+              cy="dynamic-group-action-group-by"
               inputStyle={{
                 fontSize: "1rem",
                 minWidth: "100%",
@@ -197,7 +201,7 @@ export default ({
             {useOrdered && (
               <Selector
                 id={SELECTOR_RESULTS_ID}
-                data-cy="order-by-selector"
+                cy="dynamic-group-action-order-by"
                 inputStyle={{ fontSize: "1rem", minWidth: "100%" }}
                 component={SelectorValueComponent}
                 onSelect={setOrderBy}
@@ -221,7 +225,7 @@ export default ({
               </Alert>
             )}
             <Button
-              data-cy="dynamic-group-btn-submit"
+              data-cy="dynamic-group-action-submit"
               style={{
                 width: "100%",
                 marginTop: "0.5rem",

--- a/app/packages/core/src/components/Actions/DynamicGroup.tsx
+++ b/app/packages/core/src/components/Actions/DynamicGroup.tsx
@@ -173,6 +173,7 @@ export default ({
               component={SelectorValueComponent}
               onSelect={setGroupBy}
               overflow={true}
+              overflowContainer={true}
               placeholder={"group by"}
               useSearch={groupByOptionsSearchSelector}
               value={groupBy ?? ""}
@@ -201,6 +202,7 @@ export default ({
                 component={SelectorValueComponent}
                 onSelect={setOrderBy}
                 overflow={true}
+                overflowContainer={true}
                 placeholder={"order by"}
                 useSearch={groupByOptionsSearchSelector}
                 value={orderBy ?? ""}

--- a/app/packages/core/src/components/Actions/DynamicGroupAction.tsx
+++ b/app/packages/core/src/components/Actions/DynamicGroupAction.tsx
@@ -55,7 +55,7 @@ export const DynamicGroupAction = () => {
         style={{
           cursor: "pointer",
         }}
-        data-cy="dynamic-group-action-button"
+        data-cy="action-create-dynamic-groups"
       />
       {open && (
         <DynamicGroup

--- a/app/packages/core/src/components/Actions/DynamicGroupAction.tsx
+++ b/app/packages/core/src/components/Actions/DynamicGroupAction.tsx
@@ -55,7 +55,7 @@ export const DynamicGroupAction = () => {
         style={{
           cursor: "pointer",
         }}
-        data-cy="action-create-dynamic-groups"
+        data-cy="dynamic-group-action-button"
       />
       {open && (
         <DynamicGroup

--- a/app/packages/core/src/components/Modal/Group/DynamicGroup/NestedGroup/GroupElementsLinkBar.tsx
+++ b/app/packages/core/src/components/Modal/Group/DynamicGroup/NestedGroup/GroupElementsLinkBar.tsx
@@ -47,6 +47,7 @@ export const GroupElementsLinkBar = () => {
   const dataset = useRecoilValue(fos.datasetName);
   const view = useRecoilValue(fos.dynamicGroupViewQuery);
   const cursor = useRecoilValue(fos.nestedGroupIndex);
+  const slice = useRecoilValue(fos.groupSlice(false));
   const environment = useRelayEnvironment();
   const loadDynamicGroupSamples = useCallback(
     (cursor?: number) => {
@@ -56,12 +57,16 @@ export const GroupElementsLinkBar = () => {
         {
           after: cursor ? String(cursor) : null,
           dataset,
-          filter: {},
+          filter: {
+            group: {
+              slice,
+            },
+          },
           view,
         }
       );
     },
-    [dataset, environment, view]
+    [dataset, environment, slice, view]
   );
 
   const queryRef = useMemo(
@@ -90,6 +95,7 @@ const GroupElementsLinkBarImpl = React.memo(
     const { orderBy } = useRecoilValue(fos.dynamicGroupParameters)!;
 
     const data = usePreloadedQuery(foq.paginateSamples, queryRef);
+    console.log(data);
 
     const [
       dynamicGroupCurrentElementIndex,

--- a/app/packages/relay/src/queries/__generated__/aggregationsQuery.graphql.ts
+++ b/app/packages/relay/src/queries/__generated__/aggregationsQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<2163a053e1776a9b76a989bf7a7f626b>>
+ * @generated SignedSource<<e37d762f250a359c1af7c71a7a793116>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -19,6 +19,7 @@ export type AggregationForm = {
   mixed: boolean;
   paths: ReadonlyArray<string>;
   sampleIds: ReadonlyArray<string>;
+  slice?: string | null;
   slices?: ReadonlyArray<string> | null;
   view: Array;
   viewName?: string | null;

--- a/app/packages/state/src/recoil/aggregations.ts
+++ b/app/packages/state/src/recoil/aggregations.ts
@@ -7,7 +7,7 @@ import { graphQLSelectorFamily } from "recoil-relay";
 import { ResponseFrom } from "../utils";
 import { refresher } from "./atoms";
 import * as filterAtoms from "./filters";
-import { currentSlices, groupId, groupStatistics } from "./groups";
+import { currentSlices, groupId, groupSlice, groupStatistics } from "./groups";
 import { sidebarSampleId } from "./modal";
 import { RelayEnvironmentKey } from "./relay";
 import * as schemaAtoms from "./schema";
@@ -63,6 +63,7 @@ export const aggregationQuery = graphQLSelectorFamily<
         sampleIds:
           !root && modal && !group && !mixed ? [get(sidebarSampleId)] : [],
         slices: mixed ? null : get(currentSlices(modal)), // when mixed, slice is not needed
+        slice: get(groupSlice(false)),
         view: customView ? customView : !root ? get(viewAtoms.view) : [],
       };
 

--- a/app/schema.graphql
+++ b/app/schema.graphql
@@ -28,6 +28,7 @@ input AggregationForm {
   mixed: Boolean!
   paths: [String!]!
   sampleIds: [ID!]!
+  slice: String
   slices: [String!]
   view: BSONArray!
   viewName: String = null

--- a/e2e-pw/src/oss/fixtures/loader.ts
+++ b/e2e-pw/src/oss/fixtures/loader.ts
@@ -94,17 +94,14 @@ export class OssLoader extends AbstractFiftyoneLoader {
   ) {
     const kwargsStringified = getStringifiedKwargs(kwargs);
 
-    return this.pythonRunner.exec(
-      `
-      import fiftyone as fo
+    return this.pythonRunner.exec(`
       import fiftyone.zoo as foz
 
-      quickstart_groups_dataset = foz.load_zoo_dataset(
+      dataset = foz.load_zoo_dataset(
         "${zooDatasetName}", dataset_name="${id}"${kwargsStringified}
       )
-      quickstart_groups_dataset.persistent = True
-    `
-    );
+      dataset.persistent = True
+    `);
   }
 
   async loadTestDataset() {

--- a/e2e-pw/src/oss/poms/action-row/dynamic-group.ts
+++ b/e2e-pw/src/oss/poms/action-row/dynamic-group.ts
@@ -3,7 +3,6 @@ import { EventUtils } from "src/shared/event-utils";
 import { SelectorPom } from "../selector";
 
 export class DynamicGroupPom {
-  private readonly actionBtn: Locator;
   private readonly container: Locator;
   private readonly resetBtn: Locator;
   private readonly submitBtn: Locator;
@@ -12,7 +11,6 @@ export class DynamicGroupPom {
   readonly orderBy: SelectorPom;
 
   constructor(private readonly page: Page, eventUtils: EventUtils) {
-    this.actionBtn = this.page.getByTestId("dynamic-group-action-button");
     this.container = this.page.getByTestId("dynamic-group-action-container");
     this.groupBy = new SelectorPom(
       page,
@@ -38,9 +36,5 @@ export class DynamicGroupPom {
 
   async submit() {
     await this.submitBtn.click();
-  }
-
-  async toggle() {
-    await this.actionBtn.click();
   }
 }

--- a/e2e-pw/src/oss/poms/action-row/dynamic-group.ts
+++ b/e2e-pw/src/oss/poms/action-row/dynamic-group.ts
@@ -1,0 +1,46 @@
+import { Locator, Page } from "src/oss/fixtures";
+import { EventUtils } from "src/shared/event-utils";
+import { SelectorPom } from "../selector";
+
+export class DynamicGroupPom {
+  private readonly actionBtn: Locator;
+  private readonly container: Locator;
+  private readonly resetBtn: Locator;
+  private readonly submitBtn: Locator;
+
+  readonly groupBy: SelectorPom;
+  readonly orderBy: SelectorPom;
+
+  constructor(private readonly page: Page, eventUtils: EventUtils) {
+    this.actionBtn = this.page.getByTestId("dynamic-group-action-button");
+    this.container = this.page.getByTestId("dynamic-group-action-container");
+    this.groupBy = new SelectorPom(
+      page,
+      eventUtils,
+      "dynamic-group-action-group-by"
+    );
+    this.orderBy = new SelectorPom(
+      page,
+      eventUtils,
+      "dynamic-group-action-order-by"
+    );
+    this.submitBtn = this.page.getByTestId("dynamic-group-action-submit");
+    this.resetBtn = this.page.getByTestId("dynamic-group-action-reset");
+  }
+
+  async reset() {
+    await this.resetBtn.click();
+  }
+
+  async selectTabOption(option: "Ordered" | "Unordered") {
+    await this.container.getByTestId(`tab-option-${option}`).click();
+  }
+
+  async submit() {
+    await this.submitBtn.click();
+  }
+
+  async toggle() {
+    await this.actionBtn.click();
+  }
+}

--- a/e2e-pw/src/oss/poms/action-row/grid-actions-row.ts
+++ b/e2e-pw/src/oss/poms/action-row/grid-actions-row.ts
@@ -56,12 +56,14 @@ export class GridActionsRowPom {
   }
 
   async groupBy(groupBy: string, orderBy?: string) {
-    await this.dynamicGroup.toggle();
+    await this.dynamicGroup.groupBy.openResults();
     await this.dynamicGroup.groupBy.selectResult(groupBy);
     if (orderBy) {
       await this.dynamicGroup.selectTabOption("Ordered");
+      await this.dynamicGroup.orderBy.openResults();
       await this.dynamicGroup.orderBy.selectResult(orderBy);
     }
+
     await this.dynamicGroup.submit();
   }
 

--- a/e2e-pw/src/oss/poms/action-row/grid-actions-row.ts
+++ b/e2e-pw/src/oss/poms/action-row/grid-actions-row.ts
@@ -1,16 +1,21 @@
 import { Locator, Page } from "src/oss/fixtures";
+import { EventUtils } from "src/shared/event-utils";
 import { DisplayOptionsPom } from "./display-options";
-import { SelectorPom } from "../selector";
+import { DynamicGroupPom } from "./dynamic-group";
 
 export class GridActionsRowPom {
   readonly page: Page;
   readonly gridActionsRow: Locator;
-  readonly displayActions: DisplayOptionsPom;
 
-  constructor(page: Page) {
+  readonly displayActions: DisplayOptionsPom;
+  readonly dynamicGroup: DynamicGroupPom;
+
+  constructor(page: Page, eventUtils: EventUtils) {
     this.page = page;
-    this.displayActions = new DisplayOptionsPom(page);
     this.gridActionsRow = page.getByTestId("fo-grid-actions");
+
+    this.displayActions = new DisplayOptionsPom(page);
+    this.dynamicGroup = new DynamicGroupPom(page, eventUtils);
   }
 
   private async openAction(actionTestId: string) {
@@ -50,10 +55,14 @@ export class GridActionsRowPom {
     await this.toPatchesByLabelField(fieldName).click();
   }
 
-  async groupBy(path: string, selector: SelectorPom) {
-    await selector.openResults();
-    await selector.selectResult(path);
-    await this.gridActionsRow.getByTestId("dynamic-group-btn-submit").click();
+  async groupBy(groupBy: string, orderBy?: string) {
+    await this.dynamicGroup.toggle();
+    await this.dynamicGroup.groupBy.selectResult(groupBy);
+    if (orderBy) {
+      await this.dynamicGroup.selectTabOption("Ordered");
+      await this.dynamicGroup.orderBy.selectResult(orderBy);
+    }
+    await this.dynamicGroup.submit();
   }
 
   toPatchesByLabelField(fieldName: string) {

--- a/e2e-pw/src/oss/poms/grid/index.ts
+++ b/e2e-pw/src/oss/poms/grid/index.ts
@@ -59,8 +59,7 @@ export class GridPom {
   }
 
   async selectSlice(slice: string) {
-    await this.page.getByTestId("selector-slice").fill(slice);
-    await this.page.getByTestId("selector-slice").press("Enter");
+    await this.sliceSelector.selectSlice(slice);
   }
 
   /**

--- a/e2e-pw/src/oss/poms/grid/index.ts
+++ b/e2e-pw/src/oss/poms/grid/index.ts
@@ -1,7 +1,7 @@
 import { expect, Locator, Page } from "src/oss/fixtures";
+import { EventUtils } from "src/shared/event-utils";
 import { GridActionsRowPom } from "../action-row/grid-actions-row";
 import { GridSliceSelectorPom } from "../action-row/grid-slice-selector";
-import { EventUtils } from "src/shared/event-utils";
 
 export class GridPom {
   readonly actionsRow: GridActionsRowPom;
@@ -14,7 +14,7 @@ export class GridPom {
     public readonly page: Page,
     private readonly eventUtils: EventUtils
   ) {
-    this.actionsRow = new GridActionsRowPom(page);
+    this.actionsRow = new GridActionsRowPom(page, eventUtils);
     this.sliceSelector = new GridSliceSelectorPom(page);
 
     this.assert = new GridAsserter(this);

--- a/e2e-pw/src/oss/poms/modal/dynamic-group-pagination-bar.ts
+++ b/e2e-pw/src/oss/poms/modal/dynamic-group-pagination-bar.ts
@@ -1,0 +1,41 @@
+import { Locator, Page, expect } from "src/oss/fixtures";
+import { ModalPom } from ".";
+
+export class DynamicGroupPaginationPom {
+  readonly locator: Locator;
+  readonly input: Locator;
+  readonly assert: DynamicGroupPaginationAsserter;
+
+  constructor(private readonly page: Page, private readonly modal: ModalPom) {
+    this.locator = modal.locator.getByTestId("dynamic-group-pagination-bar");
+    this.input = this.locator.getByTestId("dynamic-group-pagination-bar-input");
+    this.assert = new DynamicGroupPaginationAsserter(this);
+  }
+
+  async navigatePage(page: number) {
+    await this.input.fill(`${page}`);
+    await this.modal.waitForCarouselToLoad();
+  }
+
+  getPageButton(page: number) {
+    return this.locator.getByTestId(`dynamic-group-pagination-item-${page}`);
+  }
+}
+
+class DynamicGroupPaginationAsserter {
+  constructor(private readonly nestedGroupPom: DynamicGroupPaginationPom) {}
+
+  async verifyPage(page: number) {
+    const button = this.nestedGroupPom.getPageButton(page);
+    await expect(button).toBeVisible();
+    await expect(button).toHaveText(String(page));
+  }
+
+  async verifyTooltip(page: number, text: string) {
+    const button = this.nestedGroupPom.getPageButton(page);
+    await button.hover();
+    const tooltip = this.nestedGroupPom.locator.getByTestId(`tooltip-${text}`);
+    await expect(tooltip).toBeVisible();
+    await expect(tooltip).toHaveText(text);
+  }
+}

--- a/e2e-pw/src/oss/poms/modal/dynamic-group-pagination-bar.ts
+++ b/e2e-pw/src/oss/poms/modal/dynamic-group-pagination-bar.ts
@@ -42,4 +42,12 @@ class DynamicGroupPaginationAsserter {
     await expect(tooltip).toBeVisible();
     await expect(tooltip).toHaveText(text);
   }
+
+  async verifyTooltips(pages: { [page: number]: string }) {
+    await Promise.all(
+      Object.entries(pages).map(([page, text]) =>
+        this.verifyTooltip(Number(page), text)
+      )
+    );
+  }
 }

--- a/e2e-pw/src/oss/poms/modal/dynamic-group-pagination-bar.ts
+++ b/e2e-pw/src/oss/poms/modal/dynamic-group-pagination-bar.ts
@@ -44,10 +44,8 @@ class DynamicGroupPaginationAsserter {
   }
 
   async verifyTooltips(pages: { [page: number]: string }) {
-    await Promise.all(
-      Object.entries(pages).map(([page, text]) =>
-        this.verifyTooltip(Number(page), text)
-      )
-    );
+    for (const page in pages) {
+      await this.verifyTooltip(Number(page), pages[page]);
+    }
   }
 }

--- a/e2e-pw/src/oss/poms/modal/dynamic-group-pagination-bar.ts
+++ b/e2e-pw/src/oss/poms/modal/dynamic-group-pagination-bar.ts
@@ -13,12 +13,16 @@ export class DynamicGroupPaginationPom {
   }
 
   async navigatePage(page: number) {
-    await this.input.fill(`${page}`);
+    await this.getPageButton(page).click();
     await this.modal.waitForCarouselToLoad();
   }
 
   getPageButton(page: number) {
     return this.locator.getByTestId(`dynamic-group-pagination-item-${page}`);
+  }
+
+  getTooltip(text: string) {
+    return this.page.getByTestId(`tooltip-${text}`);
   }
 }
 
@@ -34,7 +38,7 @@ class DynamicGroupPaginationAsserter {
   async verifyTooltip(page: number, text: string) {
     const button = this.nestedGroupPom.getPageButton(page);
     await button.hover();
-    const tooltip = this.nestedGroupPom.locator.getByTestId(`tooltip-${text}`);
+    const tooltip = this.nestedGroupPom.getTooltip(text);
     await expect(tooltip).toBeVisible();
     await expect(tooltip).toHaveText(text);
   }

--- a/e2e-pw/src/oss/poms/modal/group-actions.ts
+++ b/e2e-pw/src/oss/poms/modal/group-actions.ts
@@ -1,14 +1,17 @@
 import { Page, expect } from "src/oss/fixtures";
 import { ModalPom } from ".";
+import { DynamicGroupPaginationPom } from "./dynamic-group-pagination-bar";
 
 export class ModalGroupActionsPom {
   readonly page: Page;
   readonly modal: ModalPom;
   readonly assert: ModalGroupActionsAsserter;
+  readonly dynamicGroupPagination: DynamicGroupPaginationPom;
 
   constructor(page: Page, modal: ModalPom) {
     this.page = page;
     this.modal = modal;
+    this.dynamicGroupPagination = new DynamicGroupPaginationPom(page, modal);
     this.assert = new ModalGroupActionsAsserter(this);
   }
 

--- a/e2e-pw/src/oss/poms/modal/modal-sidebar.ts
+++ b/e2e-pw/src/oss/poms/modal/modal-sidebar.ts
@@ -44,4 +44,12 @@ class SidebarAsserter {
       .textContent();
     expect(text).toBe(value);
   }
+
+  async verifySidebarEntryTexts(entries: { [key: string]: string }) {
+    await Promise.all(
+      Object.entries(entries).map(([key, value]) =>
+        this.verifySidebarEntryText(key, value)
+      )
+    );
+  }
 }

--- a/e2e-pw/src/oss/poms/selector.ts
+++ b/e2e-pw/src/oss/poms/selector.ts
@@ -49,9 +49,7 @@ class SelectorAsserter {
     await expect(this.selectorPom.input).toHaveValue(value);
   }
 
-  async verifyPage(values: string[]) {
-    await this.selectorPom.openResults();
-
+  async verifyResults(values: string[]) {
     const count = await this.selectorPom.results.count();
     expect(count).toBe(values.length);
 

--- a/e2e-pw/src/oss/poms/selector.ts
+++ b/e2e-pw/src/oss/poms/selector.ts
@@ -49,7 +49,7 @@ class SelectorAsserter {
     await expect(this.selectorPom.input).toHaveValue(value);
   }
 
-  async verifyResults(values: string[]) {
+  async verifyPage(values: string[]) {
     await this.selectorPom.openResults();
 
     const count = await this.selectorPom.results.count();

--- a/e2e-pw/src/oss/poms/selector.ts
+++ b/e2e-pw/src/oss/poms/selector.ts
@@ -1,4 +1,4 @@
-import { expect, Locator } from "src/oss/fixtures";
+import { expect, Locator, Page } from "src/oss/fixtures";
 import { EventUtils } from "src/shared/event-utils";
 
 export class SelectorPom {
@@ -8,7 +8,7 @@ export class SelectorPom {
   readonly resultsContainer: Locator;
 
   constructor(
-    private readonly parent: Locator,
+    private readonly parent: Locator | Page,
     private readonly eventUtils: EventUtils,
     private readonly title: string
   ) {

--- a/e2e-pw/src/oss/specs/groups/sparse-dynamic-groups.spec.ts
+++ b/e2e-pw/src/oss/specs/groups/sparse-dynamic-groups.spec.ts
@@ -66,16 +66,22 @@ test(`left slice (default)`, async ({ fiftyoneLoader, page, grid, modal }) => {
   await grid.assert.isEntryCountTextEqualTo("1 group with slice");
   await grid.openFirstSample();
   await modal.sidebar.toggleSidebarGroup("GROUP");
-  await modal.sidebar.assert.verifySidebarEntryText("group.name", "left");
-  await modal.sidebar.assert.verifySidebarEntryText("scene", "a");
-  await modal.sidebar.assert.verifySidebarEntryText("frame", "0");
+  await modal.sidebar.assert.verifySidebarEntryTexts({
+    frame: "0",
+    "group.name": "left",
+    scene: "a",
+  });
   await modal.group.dynamicGroupPagination.assert.verifyPage(2);
-  await modal.group.dynamicGroupPagination.assert.verifyTooltip(1, "frame: 0");
-  await modal.group.dynamicGroupPagination.assert.verifyTooltip(2, "frame: 1");
+  await modal.group.dynamicGroupPagination.assert.verifyTooltips({
+    1: "frame: 0",
+    2: "frame: 1",
+  });
   await modal.group.dynamicGroupPagination.navigatePage(2);
-  await modal.sidebar.assert.verifySidebarEntryText("group.name", "left");
-  await modal.sidebar.assert.verifySidebarEntryText("scene", "a");
-  await modal.sidebar.assert.verifySidebarEntryText("frame", "1");
+  await modal.sidebar.assert.verifySidebarEntryTexts({
+    frame: "1",
+    "group.name": "left",
+    scene: "a",
+  });
   await modal.close();
 });
 
@@ -87,15 +93,21 @@ test(`right slice`, async ({ fiftyoneLoader, page, grid, modal }) => {
   await grid.assert.isEntryCountTextEqualTo("1 group with slice");
   await grid.openFirstSample();
   await modal.sidebar.toggleSidebarGroup("GROUP");
-  await modal.sidebar.assert.verifySidebarEntryText("group.name", "right");
-  await modal.sidebar.assert.verifySidebarEntryText("scene", "b");
-  await modal.sidebar.assert.verifySidebarEntryText("frame", "0");
+  await modal.sidebar.assert.verifySidebarEntryTexts({
+    frame: "0",
+    "group.name": "right",
+    scene: "b",
+  });
   await modal.group.dynamicGroupPagination.assert.verifyPage(2);
-  await modal.group.dynamicGroupPagination.assert.verifyTooltip(1, "frame: 0");
-  await modal.group.dynamicGroupPagination.assert.verifyTooltip(2, "frame: 1");
+  await modal.group.dynamicGroupPagination.assert.verifyTooltips({
+    1: "frame: 0",
+    2: "frame: 1",
+  });
   await modal.group.dynamicGroupPagination.navigatePage(2);
-  await modal.sidebar.assert.verifySidebarEntryText("group.name", "right");
-  await modal.sidebar.assert.verifySidebarEntryText("scene", "b");
-  await modal.sidebar.assert.verifySidebarEntryText("frame", "1");
+  await modal.sidebar.assert.verifySidebarEntryTexts({
+    frame: "1",
+    "group.name": "right",
+    scene: "b",
+  });
   await modal.close();
 });

--- a/e2e-pw/src/oss/specs/groups/sparse-dynamic-groups.spec.ts
+++ b/e2e-pw/src/oss/specs/groups/sparse-dynamic-groups.spec.ts
@@ -1,0 +1,89 @@
+import { test as base } from "src/oss/fixtures";
+import { GridPom } from "src/oss/poms/grid";
+import { ModalPom } from "src/oss/poms/modal";
+import { getUniqueDatasetNameWithPrefix } from "src/oss/utils";
+
+const test = base.extend<{ grid: GridPom; modal: ModalPom }>({
+  grid: async ({ page, eventUtils }, use) => {
+    await use(new GridPom(page, eventUtils));
+  },
+  modal: async ({ page }, use) => {
+    await use(new ModalPom(page));
+  },
+});
+
+// todo: skipping pcd because slice navigation behavior is different
+const extensionDatasetNamePairs = ["mp4", "png"].map(
+  (extension) =>
+    [
+      extension,
+      getUniqueDatasetNameWithPrefix(`${extension}-sparse-dynamic-groups`),
+    ] as const
+);
+
+test.beforeAll(async ({ fiftyoneLoader }) => {
+  let pythonCode = `
+      import fiftyone as fo
+  `;
+
+  extensionDatasetNamePairs.forEach(([extension, datasetName]) => {
+    pythonCode += `
+      # ${extension} dataset
+      dataset = fo.Dataset("${datasetName}")
+      dataset.persistent = True
+
+      first = fo.Group()
+      second = fo.Group()
+      third = fo.Group()
+      fourth = fo.Group()
+      
+      one = fo.Sample(
+          filepath="one.${extension}",
+          group=first.element("left"),
+          scene="a",
+          frame=0,
+      )
+      two = fo.Sample(
+          filepath="two.${extension}",
+          group=second.element("left"),
+          scene="a",
+          frame=1,
+      )
+      three = fo.Sample(
+          filepath="three.${extension}",
+          group=third.element("right"),
+          scene="b",
+          frame=0,
+      )
+      four = fo.Sample(
+          filepath="four.${extension}",
+          group=fourth.element("right"),
+          scene="b",
+          frame=1,
+      )
+      
+      dataset.add_samples([one, two, three, four])
+      view = dataset.group_by("scene", order_by="frame")
+      dataset.save_view("group", view)
+      `;
+  });
+  await fiftyoneLoader.executePythonCode(pythonCode);
+});
+
+extensionDatasetNamePairs.forEach(([extension, datasetName]) => {
+  test(`${extension} default slice`, async ({
+    fiftyoneLoader,
+    page,
+    grid,
+    modal,
+  }) => {
+    await fiftyoneLoader.waitUntilGridVisible(page, datasetName, {
+      savedView: "group",
+    });
+    await grid.assert.isEntryCountTextEqualTo("1 group with slice");
+    await grid.openFirstSample();
+    await modal.sidebar.toggleSidebarGroup("GROUP");
+    await modal.sidebar.assert.verifySidebarEntryText("group.name", "left");
+    await modal.close();
+  });
+});

--- a/e2e-pw/src/oss/specs/groups/sparse-dynamic-groups.spec.ts
+++ b/e2e-pw/src/oss/specs/groups/sparse-dynamic-groups.spec.ts
@@ -84,6 +84,53 @@ extensionDatasetNamePairs.forEach(([extension, datasetName]) => {
     await grid.openFirstSample();
     await modal.sidebar.toggleSidebarGroup("GROUP");
     await modal.sidebar.assert.verifySidebarEntryText("group.name", "left");
+    await modal.sidebar.assert.verifySidebarEntryText("scene", "a");
+    await modal.sidebar.assert.verifySidebarEntryText("frame", "0");
+    await modal.group.dynamicGroupPagination.assert.verifyPage(2);
+    await modal.group.dynamicGroupPagination.assert.verifyTooltip(
+      1,
+      "frame: 0"
+    );
+    await modal.group.dynamicGroupPagination.assert.verifyTooltip(
+      2,
+      "frame: 1"
+    );
+    await modal.group.dynamicGroupPagination.navigatePage(2);
+    await modal.sidebar.assert.verifySidebarEntryText("group.name", "left");
+    await modal.sidebar.assert.verifySidebarEntryText("scene", "a");
+    await modal.sidebar.assert.verifySidebarEntryText("frame", "1");
+    await modal.close();
+  });
+
+  test(`${extension} right slice`, async ({
+    fiftyoneLoader,
+    page,
+    grid,
+    modal,
+  }) => {
+    await fiftyoneLoader.waitUntilGridVisible(page, datasetName, {
+      savedView: "group",
+    });
+    await grid.selectSlice("right");
+    await grid.assert.isEntryCountTextEqualTo("1 group with slice");
+    await grid.openFirstSample();
+    await modal.sidebar.toggleSidebarGroup("GROUP");
+    await modal.sidebar.assert.verifySidebarEntryText("group.name", "right");
+    await modal.sidebar.assert.verifySidebarEntryText("scene", "b");
+    await modal.sidebar.assert.verifySidebarEntryText("frame", "0");
+    await modal.group.dynamicGroupPagination.assert.verifyPage(2);
+    await modal.group.dynamicGroupPagination.assert.verifyTooltip(
+      1,
+      "frame: 0"
+    );
+    await modal.group.dynamicGroupPagination.assert.verifyTooltip(
+      2,
+      "frame: 1"
+    );
+    await modal.group.dynamicGroupPagination.navigatePage(2);
+    await modal.sidebar.assert.verifySidebarEntryText("group.name", "right");
+    await modal.sidebar.assert.verifySidebarEntryText("scene", "b");
+    await modal.sidebar.assert.verifySidebarEntryText("frame", "1");
     await modal.close();
   });
 });

--- a/e2e-pw/src/oss/specs/groups/sparse-dynamic-groups.spec.ts
+++ b/e2e-pw/src/oss/specs/groups/sparse-dynamic-groups.spec.ts
@@ -60,6 +60,7 @@ test(`left slice (default)`, async ({ fiftyoneLoader, page, grid, modal }) => {
   await fiftyoneLoader.waitUntilGridVisible(page, datasetName);
 
   const groupByRefresh = grid.getWaitForGridRefreshPromise();
+  await grid.actionsRow.toggleCreateDynamicGroups();
   await grid.actionsRow.groupBy("scene", "frame");
   await groupByRefresh;
   await grid.assert.isEntryCountTextEqualTo("1 group with slice");

--- a/e2e-pw/src/oss/specs/groups/sparse-dynamic-groups.spec.ts
+++ b/e2e-pw/src/oss/specs/groups/sparse-dynamic-groups.spec.ts
@@ -77,9 +77,11 @@ extensionDatasetNamePairs.forEach(([extension, datasetName]) => {
     grid,
     modal,
   }) => {
-    await fiftyoneLoader.waitUntilGridVisible(page, datasetName, {
-      savedView: "group",
-    });
+    await fiftyoneLoader.waitUntilGridVisible(page, datasetName);
+
+    const groupByRefresh = grid.getWaitForGridRefreshPromise();
+    await grid.actionsRow.groupBy("scene", "frame");
+    await groupByRefresh;
     await grid.assert.isEntryCountTextEqualTo("1 group with slice");
     await grid.openFirstSample();
     await modal.sidebar.toggleSidebarGroup("GROUP");

--- a/e2e-pw/src/oss/specs/groups/sparse-dynamic-groups.spec.ts
+++ b/e2e-pw/src/oss/specs/groups/sparse-dynamic-groups.spec.ts
@@ -12,127 +12,89 @@ const test = base.extend<{ grid: GridPom; modal: ModalPom }>({
   },
 });
 
-// todo: skipping pcd because slice navigation behavior is different
-const extensionDatasetNamePairs = ["mp4", "png"].map(
-  (extension) =>
-    [
-      extension,
-      getUniqueDatasetNameWithPrefix(`${extension}-sparse-dynamic-groups`),
-    ] as const
-);
+const datasetName = getUniqueDatasetNameWithPrefix(`sparse-dynamic-groups`);
 
 test.beforeAll(async ({ fiftyoneLoader }) => {
-  let pythonCode = `
-      import fiftyone as fo
-  `;
+  await fiftyoneLoader.executePythonCode(`
+  import fiftyone as fo
+  dataset = fo.Dataset("${datasetName}")
+  dataset.persistent = True
 
-  extensionDatasetNamePairs.forEach(([extension, datasetName]) => {
-    pythonCode += `
-      # ${extension} dataset
-      dataset = fo.Dataset("${datasetName}")
-      dataset.persistent = True
-
-      first = fo.Group()
-      second = fo.Group()
-      third = fo.Group()
-      fourth = fo.Group()
-      
-      one = fo.Sample(
-          filepath="one.${extension}",
-          group=first.element("left"),
-          scene="a",
-          frame=0,
-      )
-      two = fo.Sample(
-          filepath="two.${extension}",
-          group=second.element("left"),
-          scene="a",
-          frame=1,
-      )
-      three = fo.Sample(
-          filepath="three.${extension}",
-          group=third.element("right"),
-          scene="b",
-          frame=0,
-      )
-      four = fo.Sample(
-          filepath="four.${extension}",
-          group=fourth.element("right"),
-          scene="b",
-          frame=1,
-      )
-      
-      dataset.add_samples([one, two, three, four])
-      view = dataset.group_by("scene", order_by="frame")
-      dataset.save_view("group", view)
-      `;
-  });
-  await fiftyoneLoader.executePythonCode(pythonCode);
+  first = fo.Group()
+  second = fo.Group()
+  third = fo.Group()
+  fourth = fo.Group()
+  
+  one = fo.Sample(
+      filepath="one.png",
+      group=first.element("left"),
+      scene="a",
+      frame=0,
+  )
+  two = fo.Sample(
+      filepath="two.png",
+      group=second.element("left"),
+      scene="a",
+      frame=1,
+  )
+  three = fo.Sample(
+      filepath="three.png",
+      group=third.element("right"),
+      scene="b",
+      frame=0,
+  )
+  four = fo.Sample(
+      filepath="four.png",
+      group=fourth.element("right"),
+      scene="b",
+      frame=1,
+  )
+  
+  dataset.add_samples([one, two, three, four])
+  view = dataset.group_by("scene", order_by="frame")
+  dataset.save_view("group", view)
+  `);
 });
 
-extensionDatasetNamePairs.forEach(([extension, datasetName]) => {
-  test(`${extension} default slice`, async ({
-    fiftyoneLoader,
-    page,
-    grid,
-    modal,
-  }) => {
-    await fiftyoneLoader.waitUntilGridVisible(page, datasetName);
+test(`left slice (default)`, async ({ fiftyoneLoader, page, grid, modal }) => {
+  await fiftyoneLoader.waitUntilGridVisible(page, datasetName);
 
-    const groupByRefresh = grid.getWaitForGridRefreshPromise();
-    await grid.actionsRow.groupBy("scene", "frame");
-    await groupByRefresh;
-    await grid.assert.isEntryCountTextEqualTo("1 group with slice");
-    await grid.openFirstSample();
-    await modal.sidebar.toggleSidebarGroup("GROUP");
-    await modal.sidebar.assert.verifySidebarEntryText("group.name", "left");
-    await modal.sidebar.assert.verifySidebarEntryText("scene", "a");
-    await modal.sidebar.assert.verifySidebarEntryText("frame", "0");
-    await modal.group.dynamicGroupPagination.assert.verifyPage(2);
-    await modal.group.dynamicGroupPagination.assert.verifyTooltip(
-      1,
-      "frame: 0"
-    );
-    await modal.group.dynamicGroupPagination.assert.verifyTooltip(
-      2,
-      "frame: 1"
-    );
-    await modal.group.dynamicGroupPagination.navigatePage(2);
-    await modal.sidebar.assert.verifySidebarEntryText("group.name", "left");
-    await modal.sidebar.assert.verifySidebarEntryText("scene", "a");
-    await modal.sidebar.assert.verifySidebarEntryText("frame", "1");
-    await modal.close();
-  });
+  const groupByRefresh = grid.getWaitForGridRefreshPromise();
+  await grid.actionsRow.groupBy("scene", "frame");
+  await groupByRefresh;
+  await grid.assert.isEntryCountTextEqualTo("1 group with slice");
+  await grid.openFirstSample();
+  await modal.sidebar.toggleSidebarGroup("GROUP");
+  await modal.sidebar.assert.verifySidebarEntryText("group.name", "left");
+  await modal.sidebar.assert.verifySidebarEntryText("scene", "a");
+  await modal.sidebar.assert.verifySidebarEntryText("frame", "0");
+  await modal.group.dynamicGroupPagination.assert.verifyPage(2);
+  await modal.group.dynamicGroupPagination.assert.verifyTooltip(1, "frame: 0");
+  await modal.group.dynamicGroupPagination.assert.verifyTooltip(2, "frame: 1");
+  await modal.group.dynamicGroupPagination.navigatePage(2);
+  await modal.sidebar.assert.verifySidebarEntryText("group.name", "left");
+  await modal.sidebar.assert.verifySidebarEntryText("scene", "a");
+  await modal.sidebar.assert.verifySidebarEntryText("frame", "1");
+  await modal.close();
+});
 
-  test(`${extension} right slice`, async ({
-    fiftyoneLoader,
-    page,
-    grid,
-    modal,
-  }) => {
-    await fiftyoneLoader.waitUntilGridVisible(page, datasetName, {
-      savedView: "group",
-    });
-    await grid.selectSlice("right");
-    await grid.assert.isEntryCountTextEqualTo("1 group with slice");
-    await grid.openFirstSample();
-    await modal.sidebar.toggleSidebarGroup("GROUP");
-    await modal.sidebar.assert.verifySidebarEntryText("group.name", "right");
-    await modal.sidebar.assert.verifySidebarEntryText("scene", "b");
-    await modal.sidebar.assert.verifySidebarEntryText("frame", "0");
-    await modal.group.dynamicGroupPagination.assert.verifyPage(2);
-    await modal.group.dynamicGroupPagination.assert.verifyTooltip(
-      1,
-      "frame: 0"
-    );
-    await modal.group.dynamicGroupPagination.assert.verifyTooltip(
-      2,
-      "frame: 1"
-    );
-    await modal.group.dynamicGroupPagination.navigatePage(2);
-    await modal.sidebar.assert.verifySidebarEntryText("group.name", "right");
-    await modal.sidebar.assert.verifySidebarEntryText("scene", "b");
-    await modal.sidebar.assert.verifySidebarEntryText("frame", "1");
-    await modal.close();
+test(`right slice`, async ({ fiftyoneLoader, page, grid, modal }) => {
+  await fiftyoneLoader.waitUntilGridVisible(page, datasetName, {
+    savedView: "group",
   });
+  await grid.selectSlice("right");
+  await grid.assert.isEntryCountTextEqualTo("1 group with slice");
+  await grid.openFirstSample();
+  await modal.sidebar.toggleSidebarGroup("GROUP");
+  await modal.sidebar.assert.verifySidebarEntryText("group.name", "right");
+  await modal.sidebar.assert.verifySidebarEntryText("scene", "b");
+  await modal.sidebar.assert.verifySidebarEntryText("frame", "0");
+  await modal.group.dynamicGroupPagination.assert.verifyPage(2);
+  await modal.group.dynamicGroupPagination.assert.verifyTooltip(1, "frame: 0");
+  await modal.group.dynamicGroupPagination.assert.verifyTooltip(2, "frame: 1");
+  await modal.group.dynamicGroupPagination.navigatePage(2);
+  await modal.sidebar.assert.verifySidebarEntryText("group.name", "right");
+  await modal.sidebar.assert.verifySidebarEntryText("scene", "b");
+  await modal.sidebar.assert.verifySidebarEntryText("frame", "1");
+  await modal.close();
 });

--- a/e2e-pw/src/oss/specs/plugins/histograms.spec.ts
+++ b/e2e-pw/src/oss/specs/plugins/histograms.spec.ts
@@ -45,8 +45,11 @@ test.beforeEach(async ({ page, fiftyoneLoader }) => {
 
 test("histograms panel", async ({ histogram, panel }) => {
   await panel.open("Histograms");
+  await histogram.assert.isLoaded();
+
   await histogram.assert.verifyField("bool");
 
+  await histogram.selector.openResults();
   await histogram.assert.verifyFields([
     "bool",
     "classification.confidence",
@@ -70,11 +73,10 @@ test("histograms panel", async ({ histogram, panel }) => {
     "str",
     "tags",
   ]);
-
-  await histogram.assert.isLoaded();
   await expect(await histogram.locator).toHaveScreenshot("bool-histogram.png", {
     animations: "allow",
   });
+
   await histogram.selectField("float");
   await expect(await histogram.locator).toHaveScreenshot(
     "float-histogram.png",

--- a/e2e-pw/src/oss/specs/smoke-tests/quickstart.spec.ts
+++ b/e2e-pw/src/oss/specs/smoke-tests/quickstart.spec.ts
@@ -1,7 +1,6 @@
 import { test as base, expect } from "src/oss/fixtures";
 import { GridPom } from "src/oss/poms/grid";
 import { ModalPom } from "src/oss/poms/modal";
-import { SelectorPom } from "src/oss/poms/selector";
 import { getUniqueDatasetNameWithPrefix } from "src/oss/utils";
 
 const datasetName = getUniqueDatasetNameWithPrefix("smoke-quickstart");
@@ -9,22 +8,12 @@ const datasetName = getUniqueDatasetNameWithPrefix("smoke-quickstart");
 const test = base.extend<{
   grid: GridPom;
   modal: ModalPom;
-  selector: SelectorPom;
 }>({
   grid: async ({ page, eventUtils }, use) => {
     await use(new GridPom(page, eventUtils));
   },
   modal: async ({ page }, use) => {
     await use(new ModalPom(page));
-  },
-  selector: async ({ page, eventUtils }, use) => {
-    await use(
-      new SelectorPom(
-        page.getByTestId("fo-grid-actions"),
-        eventUtils,
-        "group by"
-      )
-    );
   },
 });
 
@@ -47,10 +36,7 @@ test.describe("quickstart", () => {
     await modal.waitForSampleLoadDomAttribute();
   });
 
-  test("entry counts text when toPatches then groupedBy", async ({
-    grid,
-    selector,
-  }) => {
+  test("entry counts text when toPatches then groupedBy", async ({ grid }) => {
     await grid.actionsRow.toggleToClipsOrPatches();
 
     const gridRefreshPromisePredictions = grid.getWaitForGridRefreshPromise();
@@ -62,7 +48,7 @@ test.describe("quickstart", () => {
     await grid.actionsRow.toggleCreateDynamicGroups();
 
     const gridRefreshPromiseGroupByLabel = grid.getWaitForGridRefreshPromise();
-    await grid.actionsRow.groupBy("predictions.label", selector);
+    await grid.actionsRow.groupBy("predictions.label");
     await gridRefreshPromiseGroupByLabel;
 
     await grid.assert.isEntryCountTextEqualTo("33 groups of patches");

--- a/e2e-pw/src/oss/specs/smoke-tests/quickstart.spec.ts
+++ b/e2e-pw/src/oss/specs/smoke-tests/quickstart.spec.ts
@@ -46,7 +46,6 @@ test.describe("quickstart", () => {
     await grid.assert.isEntryCountTextEqualTo("122 patches");
 
     await grid.actionsRow.toggleCreateDynamicGroups();
-
     const gridRefreshPromiseGroupByLabel = grid.getWaitForGridRefreshPromise();
     await grid.actionsRow.groupBy("predictions.label");
     await gridRefreshPromiseGroupByLabel;

--- a/fiftyone/server/aggregations.py
+++ b/fiftyone/server/aggregations.py
@@ -37,6 +37,7 @@ class AggregationForm:
     mixed: bool
     paths: t.List[str]
     sample_ids: t.List[gql.ID]
+    slice: t.Optional[str]
     slices: t.Optional[t.List[str]]
     view: BSONArray
     view_name: t.Optional[str] = None
@@ -119,7 +120,9 @@ async def aggregate_resolver(
         filters=form.filters,
         extended_stages=form.extended_stages,
         sample_filter=SampleFilter(
-            group=GroupElementFilter(id=form.group_id, slices=form.slices)
+            group=GroupElementFilter(
+                id=form.group_id, slice=form.slice, slices=form.slices
+            )
             if not form.sample_ids
             else None
         ),


### PR DESCRIPTION
Fixes dynamic groups in the context of a sparse group dataset. In the below example, the non-default `right` slice should have pagination for the `third` and `fourth` groups. Adds e2e and includes new `DynamicGroup` and `DynamicGroupPagination` poms.

```py
import fiftyone as fo

dataset = fo.Dataset("sparse-dynamic-groups")
dataset.persistent = True

first = fo.Group()
second = fo.Group()
third = fo.Group()
fourth = fo.Group()

one = fo.Sample(
    filepath="one.png",
    group=first.element("left"),
    scene="a",
    frame=0,
)
two = fo.Sample(
    filepath="two.png",
    group=second.element("left"),
    scene="a",
    frame=1,
)
three = fo.Sample(
    filepath="three.png",
    group=third.element("right"),
    scene="b",
    frame=0,
)
four = fo.Sample(
    filepath="four.png",
    group=fourth.element("right"),
    scene="b",
    frame=1,
)

dataset.add_samples([one, two, three, four])
session = fo.launch_app(dataset.group_by("scene", order_by="frame"))
```

https://github.com/voxel51/fiftyone/assets/19821840/c25819ce-638f-4a15-bb9d-f3791fcf3a09

