### PR TITLE
Fix esc hierarchy bug

### DIFF
--- a/app/packages/core/src/components/Grid/Grid.tsx
+++ b/app/packages/core/src/components/Grid/Grid.tsx
@@ -1,12 +1,7 @@
 import Flashlight from "@fiftyone/flashlight";
 import { freeVideos } from "@fiftyone/looker";
 import * as fos from "@fiftyone/state";
-import {
-  stringifyObj,
-  useDeferrer,
-  useEventHandler,
-  useExpandSample,
-} from "@fiftyone/state";
+import { stringifyObj, useDeferrer, useExpandSample } from "@fiftyone/state";
 import React, { useEffect, useLayoutEffect, useRef } from "react";
 import { useRecoilCallback, useRecoilValue } from "recoil";
 import { v4 as uuid } from "uuid";
@@ -31,6 +26,8 @@ const Grid: React.FC<{}> = () => {
   const selected = useRecoilValue(fos.selectedSamples);
   const threshold = useRecoilValue(rowAspectRatioThreshold);
   const resize = useResize();
+
+  const setSelectedSamples = fos.useSetSelected();
 
   const isModalOpen = useRecoilValue(fos.isModalActive);
   const { page, reset } = useFlashlightPager(
@@ -156,23 +153,35 @@ const Grid: React.FC<{}> = () => {
   );
   const isTagging = taggingLabels || taggingSamples;
 
-  useEventHandler(
-    document,
-    "keydown",
-    useRecoilCallback(
-      ({ snapshot, reset }) =>
-        async (event: KeyboardEvent) => {
-          if (event.key !== "Escape") {
-            return;
-          }
+  const escEventHandler = useRecoilCallback(
+    ({ reset }) =>
+      async (event: KeyboardEvent) => {
+        if (event.key !== "Escape") {
+          return;
+        }
 
-          if (!(await snapshot.getPromise(fos.isModalActive))) {
-            reset(fos.selectedSamples);
-          }
-        },
-      []
-    )
+        if (!isModalOpen) {
+          reset(fos.selectedSamples);
+          setSelectedSamples([]);
+        }
+      },
+    [setSelectedSamples, isModalOpen]
   );
+
+  useEffect(() => {
+    // this deferred execution is a hack to address problem caused by a race condition in `isModalOpen`
+    setTimeout(() => {
+      if (!isModalOpen) {
+        document.addEventListener("keydown", escEventHandler);
+      } else {
+        document.removeEventListener("keydown", escEventHandler);
+      }
+    }, 0);
+
+    return () => {
+      document.removeEventListener("keydown", escEventHandler);
+    };
+  }, [isModalOpen]);
 
   useEffect(() => {
     init();

--- a/app/packages/core/src/components/Modal/Group/GroupSample3d.tsx
+++ b/app/packages/core/src/components/Modal/Group/GroupSample3d.tsx
@@ -14,7 +14,7 @@ import { GroupSampleWrapper } from "./GroupSampleWrapper";
 const Sample3dWrapper = () => {
   const sample = useRecoilValue(fos.pinned3DSample);
   const [pinned, setPinned] = useRecoilState(fos.pinned3d);
-  const hover = fos.useHoveredSample(sample);
+  const hover = fos.useHoveredSample(sample.sample);
   const hasGroupView = !useRecoilValue(fos.onlyPcd);
 
   return hasGroupView ? (

--- a/app/packages/core/src/components/Modal/Looker.tsx
+++ b/app/packages/core/src/components/Modal/Looker.tsx
@@ -4,6 +4,7 @@ import * as fos from "@fiftyone/state";
 import { useEventHandler, useOnSelectLabel } from "@fiftyone/state";
 import React, {
   MutableRefObject,
+  useCallback,
   useEffect,
   useMemo,
   useRef,
@@ -88,6 +89,7 @@ const Looker = ({
   const { sample } = sampleData;
 
   const theme = useTheme();
+  const clearModal = fos.useClearModal();
   const initialRef = useRef<boolean>(true);
   const lookerOptions = fos.useLookerOptions(true);
   const [reset, setReset] = useState(false);
@@ -128,15 +130,24 @@ const Looker = ({
     setReset((c) => !c);
   });
 
-  useEventHandler(looker, "close", (e: Event) => {
-    jsonPanel.close();
-    helpPanel.close();
-  });
+  const jsonPanel = fos.useJSONPanel();
+  const helpPanel = fos.useHelpPanel();
+
+  useEventHandler(
+    looker,
+    "close",
+    useCallback(
+      (e: Event) => {
+        jsonPanel.close();
+        helpPanel.close();
+        clearModal();
+      },
+      [clearModal, jsonPanel, helpPanel]
+    )
+  );
 
   useEventHandler(looker, "select", useOnSelectLabel());
   useEventHandler(looker, "error", (event) => handleError(event.detail));
-  const jsonPanel = fos.useJSONPanel();
-  const helpPanel = fos.useHelpPanel();
   useEventHandler(
     looker,
     "panels",

--- a/app/packages/core/src/components/Modal/Looker.tsx
+++ b/app/packages/core/src/components/Modal/Looker.tsx
@@ -1,5 +1,4 @@
 import { useTheme } from "@fiftyone/components";
-import { AbstractLooker } from "@fiftyone/looker";
 import * as fos from "@fiftyone/state";
 import { useEventHandler, useOnSelectLabel } from "@fiftyone/state";
 import React, {
@@ -13,8 +12,6 @@ import React, {
 import { useErrorHandler } from "react-error-boundary";
 import { useRecoilCallback, useRecoilValue } from "recoil";
 import { v4 as uuid } from "uuid";
-
-type EventCallback = (event: CustomEvent) => void;
 
 const useLookerOptionsUpdate = () => {
   return useRecoilCallback(
@@ -136,14 +133,11 @@ const Looker = ({
   useEventHandler(
     looker,
     "close",
-    useCallback(
-      (e: Event) => {
-        jsonPanel.close();
-        helpPanel.close();
-        clearModal();
-      },
-      [clearModal, jsonPanel, helpPanel]
-    )
+    useCallback(() => {
+      jsonPanel.close();
+      helpPanel.close();
+      clearModal();
+    }, [clearModal, jsonPanel, helpPanel])
   );
 
   useEventHandler(looker, "select", useOnSelectLabel());

--- a/app/packages/core/src/components/Modal/ModalNavigation.tsx
+++ b/app/packages/core/src/components/Modal/ModalNavigation.tsx
@@ -46,7 +46,6 @@ const ModalNavigation = ({ onNavigate }: { onNavigate: () => void }) => {
 
   const index = useRecoilValue(fos.modalSampleIndex);
   const setModal = fos.useSetExpandedSample();
-  const clearModal = fos.useClearModal();
 
   const navigateNext = useCallback(() => {
     onNavigate();

--- a/app/packages/core/src/components/Modal/ModalNavigation.tsx
+++ b/app/packages/core/src/components/Modal/ModalNavigation.tsx
@@ -72,8 +72,6 @@ const ModalNavigation = ({ onNavigate }: { onNavigate: () => void }) => {
         navigateNext();
       } else if (e.key === "c") {
         setIsNavigationHidden((prev) => !prev);
-      } else if (e.key === "Escape") {
-        clearModal();
       }
       // note: don't stop event propagation here
     },

--- a/app/packages/core/src/components/Sidebar/Entries/FilterEntry.tsx
+++ b/app/packages/core/src/components/Sidebar/Entries/FilterEntry.tsx
@@ -14,6 +14,10 @@ import {
 import styled from "styled-components";
 import { FilterInputDiv } from "./utils";
 
+const Text = styled.div`
+  font-size: 1rem;
+`;
+
 const Filter = ({ modal }: { modal: boolean }) => {
   const theme = useTheme();
   const [isFilterMode, setIsFilterMode] = useRecoilState(
@@ -37,10 +41,6 @@ const Filter = ({ modal }: { modal: boolean }) => {
 
   const { setViewToFields: setSelectedFieldsStage } =
     fos.useSetSelectedFieldsStage();
-
-  const Text = styled.div`
-    font-size: 1rem;
-  `;
 
   return (
     <FilterInputDiv modal={modal}>

--- a/app/packages/looker-3d/src/Looker3d.tsx
+++ b/app/packages/looker-3d/src/Looker3d.tsx
@@ -252,7 +252,6 @@ export const Looker3d = () => {
 
       for (const panel of ["help", "json"]) {
         if (panels[panel].isOpen) {
-          console.log("here panel open");
           set(fos.lookerPanels, {
             ...panels,
             [panel]: { ...panels[panel], isOpen: false },

--- a/app/packages/looker-3d/src/Looker3d.tsx
+++ b/app/packages/looker-3d/src/Looker3d.tsx
@@ -252,6 +252,7 @@ export const Looker3d = () => {
 
       for (const panel of ["help", "json"]) {
         if (panels[panel].isOpen) {
+          console.log("here panel open");
           set(fos.lookerPanels, {
             ...panels,
             [panel]: { ...panels[panel], isOpen: false },
@@ -259,8 +260,14 @@ export const Looker3d = () => {
           return;
         }
       }
+
+      // don't proceed if sample being hovered on is from looker2d
       const hovered = get(fos.hoveredSample);
-      if (hovered && hovered._id !== sample.id) {
+      const isHoveredSampleNotInLooker3d =
+        hovered &&
+        !Object.values(sampleMap).find((s) => s.sample._id === hovered._id);
+
+      if (isHoveredSampleNotInLooker3d) {
         return;
       }
 
@@ -270,12 +277,10 @@ export const Looker3d = () => {
         return;
       }
 
-      const changed = onChangeView("top");
-      if (changed) return;
-
+      set(fos.hiddenLabels, {});
       set(fos.currentModalSample, null);
     },
-    [jsonPanel, helpPanel, selectedLabels, hovering]
+    [sampleMap, jsonPanel, helpPanel, selectedLabels, hovering]
   );
 
   useEffect(() => {

--- a/app/packages/looker-3d/src/action-bar/ViewHelp.tsx
+++ b/app/packages/looker-3d/src/action-bar/ViewHelp.tsx
@@ -24,8 +24,6 @@ export const ViewHelp = (props: {
 }) => {
   const { helpPanel } = props;
 
-  const [currentAction, setAction] = recoil.useRecoilState(currentActionAtom);
-
   return (
     <>
       <ActionItem>
@@ -33,10 +31,6 @@ export const ViewHelp = (props: {
           sx={{ fontSize: 24 }}
           color="inherit"
           onClick={(e) => {
-            const targetAction = ACTION_VIEW_HELP;
-            const nextAction =
-              currentAction === targetAction ? null : targetAction;
-            setAction(nextAction);
             helpPanel.toggle(LOOKER3D_HELP_ITEMS);
             e.stopPropagation();
             e.preventDefault();

--- a/app/packages/looker-3d/src/action-bar/ViewHelp.tsx
+++ b/app/packages/looker-3d/src/action-bar/ViewHelp.tsx
@@ -1,8 +1,7 @@
 import { HelpIcon } from "@fiftyone/components";
 import { useHelpPanel } from "@fiftyone/state";
-import * as recoil from "recoil";
 import { ActionItem } from "../containers";
-import { ACTION_VIEW_HELP, currentActionAtom } from "../state";
+import { ACTION_VIEW_HELP } from "../state";
 
 const LOOKER3D_HELP_ITEMS = [
   { shortcut: "Wheel", title: "Zoom", detail: "Zoom in and out" },

--- a/app/packages/looker-3d/src/action-bar/ViewJson.tsx
+++ b/app/packages/looker-3d/src/action-bar/ViewJson.tsx
@@ -1,9 +1,8 @@
 import { JSONIcon } from "@fiftyone/components";
 import { Sample } from "@fiftyone/looker/src/state";
 import { useJSONPanel } from "@fiftyone/state";
-import * as recoil from "recoil";
 import { ActionItem } from "../containers";
-import { ACTION_VIEW_JSON, currentActionAtom } from "../state";
+import { ACTION_VIEW_JSON } from "../state";
 
 export const ViewJSON = (props: {
   sample: Sample;

--- a/app/packages/looker-3d/src/action-bar/ViewJson.tsx
+++ b/app/packages/looker-3d/src/action-bar/ViewJson.tsx
@@ -10,7 +10,6 @@ export const ViewJSON = (props: {
   jsonPanel: ReturnType<typeof useJSONPanel>;
 }) => {
   const { sample, jsonPanel } = props;
-  const [currentAction, setAction] = recoil.useRecoilState(currentActionAtom);
 
   return (
     <>
@@ -19,10 +18,6 @@ export const ViewJSON = (props: {
           sx={{ fontSize: 24 }}
           color="inherit"
           onClick={(e) => {
-            const targetAction = ACTION_VIEW_JSON;
-            const nextAction =
-              currentAction === targetAction ? null : targetAction;
-            setAction(nextAction);
             jsonPanel.toggle(sample);
             e.stopPropagation();
             e.preventDefault();

--- a/fiftyone/operators/delegated.py
+++ b/fiftyone/operators/delegated.py
@@ -279,8 +279,11 @@ class DelegatedOperationService(object):
             operator_uri, context.request_params
         )
 
+        # if a validation error happened during preparation,
+        # only an ExecutionResult with an error is returned.
+        # Raise it so the delegated operation is marked as a failure.
         if isinstance(prepared, ExecutionResult):
-            self.set_failed(doc_id=doc.id, result=prepared)
+            raise prepared.to_exception()
         else:
             operator, _, ctx = prepared
             self.set_running(doc_id=doc.id)


### PR DESCRIPTION
## What changes are proposed in this pull request?

Whereas previously we were just closing the modal on `Esc`, this PR makes sure we close the modal only after other sub-contexts have been properly closed.

Commit log:
- [fix hover sample bug in looker 3d](https://github.com/voxel51/fiftyone/pull/3473/commits/dcae6372bdd14b80487fb6360aaa020f2a04a85b)
- [remove redundant action handlers](https://github.com/voxel51/fiftyone/pull/3473/commits/0f638c357ee6af8e71a3c0550abb1de98a762077)
- [remove dynamically rendered component](https://github.com/voxel51/fiftyone/pull/3473/commits/553b43a6c97604cc9e2c510628a0d93095cabc6b)
- [fix grid esc race condition](https://github.com/voxel51/fiftyone/pull/3473/commits/d0faebb84af88027496eb37a9598a8ff7ca2fba6)

## How is this patch tested? If it is not, please explain why.

Locally.
Todo: add e2e coverage after routing PR (https://github.com/voxel51/fiftyone/pull/2742) is merged.

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
