### PR TITLE
fix polyline rendering artifact

### DIFF
--- a/app/packages/looker/src/lookers/abstract.ts
+++ b/app/packages/looker/src/lookers/abstract.ts
@@ -257,6 +257,7 @@ export abstract class AbstractLooker<
         ctx.textAlign = "left";
         ctx.textBaseline = "bottom";
         ctx.imageSmoothingEnabled = false;
+        ctx.lineJoin = "bevel";
         ctx.setTransform(1, 0, 0, 1, 0, 0);
         const dpr = getDPR();
         ctx.clearRect(


### PR DESCRIPTION
## What changes are proposed in this pull request?

The default `lineJoin` algorithm is `miter`, which extends the two lines to meet at a point called the "miter point". A `miterLimit` parameter is used to control how far the miter point can extend before it's beveled to prevent overly long, sharp corners. Reducing `miterLimit` to a low value like `1` made the corners look significantly better, but they were still not completely gone. `bevel`, which creates a more rounded corner by adding a diagonal line between the endpoints of the connected lines, is a nice compromise between `miter` and `round`.

([link to w3 playground for `lineJoin`](https://www.w3schools.com/tags/canvas_linejoin.asp))

### Before
<img width="161" alt="Screenshot 2023-08-31 at 4 24 00 PM" src="https://github.com/voxel51/fiftyone/assets/66688606/e3159a40-dfa0-4655-813a-99afb19785c3">
<img width="163" alt="Screenshot 2023-08-31 at 4 23 39 PM" src="https://github.com/voxel51/fiftyone/assets/66688606/30ec618d-5bed-41a3-95a5-cd332a0e42b3">

### After
<img width="162" alt="Screenshot 2023-08-31 at 4 24 40 PM" src="https://github.com/voxel51/fiftyone/assets/66688606/43d1e7d4-0e60-46b8-8737-294aae299637">
<img width="107" alt="Screenshot 2023-08-31 at 4 24 50 PM" src="https://github.com/voxel51/fiftyone/assets/66688606/70a2926d-0592-4033-8f1c-39e5ac803e0d">


## How is this patch tested? If it is not, please explain why.

Visually, locally

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
