### PR TITLE
Fix modal popout widths

### DIFF
--- a/app/packages/core/src/components/Actions/ActionsRow.tsx
+++ b/app/packages/core/src/components/Actions/ActionsRow.tsx
@@ -35,7 +35,6 @@ import React, {
   useRef,
   useState,
 } from "react";
-import useMeasure from "react-use-measure";
 import {
   selector,
   useRecoilCallback,
@@ -116,7 +115,6 @@ const Similarity = ({ modal }: { modal: boolean }) => {
   const hasSelectedSamples = useRecoilValue(fos.hasSelectedSamples);
   const hasSelectedLabels = useRecoilValue(fos.hasSelectedLabels);
   const hasSorting = Boolean(useRecoilValue(fos.similarityParameters));
-  const [mRef, bounds] = useMeasure();
   const ref = useRef<HTMLDivElement>(null);
   useOutsideClick(ref, () => open && setOpen(false));
 
@@ -138,7 +136,6 @@ const Similarity = ({ modal }: { modal: boolean }) => {
         open={open}
         onClick={toggleSimilarity}
         highlight={true}
-        ref={mRef}
         title={`Sort by ${
           showImageSimilarityIcon ? "image" : "text"
         } similarity`}
@@ -150,7 +147,6 @@ const Similarity = ({ modal }: { modal: boolean }) => {
           key={`similary-${isImageSearch}`}
           modal={modal}
           close={() => setOpen(false)}
-          bounds={bounds}
           isImageSearch={isImageSearch}
           anchorRef={ref}
         />
@@ -175,10 +171,8 @@ const Tag = ({
 
   const selected = labels.size > 0 || samples.size > 0;
   const tagging = useRecoilValue(fos.anyTagging);
-  const ref = useRef();
+  const ref = useRef<HTMLDivElement>(null);
   useOutsideClick(ref, () => open && setOpen(false));
-
-  const [mRef, bounds] = useMeasure();
 
   const disabled = tagging;
 
@@ -198,18 +192,15 @@ const Tag = ({
         open={open}
         onClick={() => !disabled && available && setOpen(!open)}
         highlight={(selected || open) && available}
-        ref={mRef}
         title={`Tag sample${modal ? "" : "s"} or labels`}
         data-cy="action-tag-sample-labels"
       />
       {open && available && (
         <Tagger
           modal={modal}
-          bounds={bounds}
           close={() => setOpen(false)}
           lookerRef={lookerRef}
           anchorRef={ref}
-          data-cy="selected-pill-button"
         />
       )}
     </ActionDiv>
@@ -227,9 +218,8 @@ const Selected = ({
   const [loading, setLoading] = useState(false);
   const samples = useRecoilValue(fos.selectedSamples);
   const labels = useRecoilValue(fos.selectedLabelIds);
-  const ref = useRef<HTMLElement>(null);
+  const ref = useRef<HTMLDivElement>(null);
   useOutsideClick(ref, () => open && setOpen(false));
-  const [mRef, bounds] = useMeasure();
 
   lookerRef &&
     useEventHandler(lookerRef.current, "buffering", (e) =>
@@ -260,7 +250,6 @@ const Selected = ({
         }}
         highlight={samples.size > 0 || open || (labels.size > 0 && modal)}
         text={text}
-        ref={mRef}
         title={`Manage selected`}
         style={{
           cursor: loading ? "default" : "pointer",
@@ -272,7 +261,6 @@ const Selected = ({
           modal={modal}
           close={() => setOpen(false)}
           lookerRef={lookerRef}
-          bounds={bounds}
           anchorRef={ref}
         />
       )}
@@ -284,7 +272,6 @@ const Options = ({ modal }) => {
   const [open, setOpen] = useState(false);
   const ref = useRef<HTMLDivElement>(null);
   useOutsideClick(ref, () => open && setOpen(false));
-  const [mRef, bounds] = useMeasure();
 
   return (
     <ActionDiv ref={ref}>
@@ -293,11 +280,10 @@ const Options = ({ modal }) => {
         open={open}
         onClick={() => setOpen(!open)}
         highlight={open}
-        ref={mRef}
         title={"Display options"}
         data-cy="action-display-options"
       />
-      {open && <OptionsActions modal={modal} bounds={bounds} anchorRef={ref} />}
+      {open && <OptionsActions modal={modal} anchorRef={ref} />}
     </ActionDiv>
   );
 };
@@ -365,32 +351,33 @@ const SaveFilters = () => {
   const setView = useSetView(true, false, onComplete);
 
   const saveFilters = useRecoilCallback(
-    ({ snapshot, set }) => async () => {
-      const loading = await snapshot.getPromise(fos.savingFilters);
-      const selected = await snapshot.getPromise(fos.selectedSamples);
+    ({ snapshot, set }) =>
+      async () => {
+        const loading = await snapshot.getPromise(fos.savingFilters);
+        const selected = await snapshot.getPromise(fos.selectedSamples);
 
-      if (loading) {
-        return;
-      }
+        if (loading) {
+          return;
+        }
 
-      set(fos.savingFilters, true);
-      if (selected.size > 0) {
-        setView(
-          (v) => [
-            ...v,
-            {
-              _cls: "fiftyone.core.stages.Select",
-              kwargs: [["sample_ids", [...selected]]],
-            },
-          ],
-          undefined,
-          undefined,
-          true
-        );
-      } else {
-        setView((v) => v);
-      }
-    },
+        set(fos.savingFilters, true);
+        if (selected.size > 0) {
+          setView(
+            (v) => [
+              ...v,
+              {
+                _cls: "fiftyone.core.stages.Select",
+                kwargs: [["sample_ids", [...selected]]],
+              },
+            ],
+            undefined,
+            undefined,
+            true
+          );
+        } else {
+          setView((v) => v);
+        }
+      },
     []
   );
 

--- a/app/packages/core/src/components/Actions/DynamicGroup.tsx
+++ b/app/packages/core/src/components/Actions/DynamicGroup.tsx
@@ -40,7 +40,7 @@ export default ({
   close: (e?: React.MouseEvent<Element>) => void;
   isProcessing: boolean;
   setIsProcessing: (value: boolean) => void;
-  anchorRef: MutableRefObject<unknown>;
+  anchorRef: MutableRefObject<HTMLElement>;
 }) => {
   const [groupBy, setGroupBy] = useState<string>("");
   const [orderBy, setOrderBy] = useState<string>("");

--- a/app/packages/core/src/components/Actions/GroupMediaVisibilityContainer.tsx
+++ b/app/packages/core/src/components/Actions/GroupMediaVisibilityContainer.tsx
@@ -2,8 +2,7 @@ import { PillButton, PopoutSectionTitle } from "@fiftyone/components";
 import * as fos from "@fiftyone/state";
 import { useOutsideClick } from "@fiftyone/state";
 import ViewComfyIcon from "@mui/icons-material/ViewComfy";
-import React, { useRef, useState } from "react";
-import useMeasure from "react-use-measure";
+import React from "react";
 import { useRecoilState, useRecoilValue } from "recoil";
 import styled from "styled-components";
 import Checkbox from "../Common/Checkbox";
@@ -65,10 +64,9 @@ const GroupMediaVisibilityPopout = ({ modal }: { modal: boolean }) => {
 export const GroupMediaVisibilityContainer = ({
   modal,
 }: GroupMediaVisibilityProps) => {
-  const [open, setOpen] = useState(false);
-  const ref = useRef<HTMLDivElement>(null);
+  const [open, setOpen] = React.useState(false);
+  const ref = React.useRef<HTMLDivElement>(null);
   useOutsideClick(ref, () => open && setOpen(false));
-  const [mRef] = useMeasure();
 
   return (
     <Container ref={ref}>
@@ -82,7 +80,6 @@ export const GroupMediaVisibilityContainer = ({
         }}
         title={TITLE}
         highlight={open}
-        ref={mRef}
       />
       {open && <GroupMediaVisibilityPopout modal={modal} />}
     </Container>

--- a/app/packages/core/src/components/Actions/Options.tsx
+++ b/app/packages/core/src/components/Actions/Options.tsx
@@ -1,4 +1,3 @@
-import { Autorenew } from "@mui/icons-material";
 import React, { MutableRefObject } from "react";
 import { useRecoilState, useRecoilValue, useSetRecoilState } from "recoil";
 
@@ -125,16 +124,15 @@ const SidebarMode = ({ modal }) => {
 
 type OptionsProps = {
   modal: boolean;
-  bounds: [number, number];
-  anchorRef: MutableRefObject<unknown>;
+  anchorRef: MutableRefObject<HTMLElement>;
 };
 
-const Options = ({ modal, bounds, anchorRef }: OptionsProps) => {
+const Options = ({ modal, anchorRef }: OptionsProps) => {
   const isGroup = useRecoilValue(fos.isGroup);
   const isDynamicGroup = useRecoilValue(fos.isDynamicGroup);
 
   return (
-    <Popout modal={modal} bounds={bounds} fixed anchorRef={anchorRef}>
+    <Popout modal={modal} fixed anchorRef={anchorRef}>
       {isGroup && !isDynamicGroup && <GroupStatistics modal={modal} />}
       <MediaFields modal={modal} />
       <Patches modal={modal} />

--- a/app/packages/core/src/components/Actions/Patcher.tsx
+++ b/app/packages/core/src/components/Actions/Patcher.tsx
@@ -10,7 +10,7 @@ import {
   PATCHES_FIELDS,
 } from "@fiftyone/utilities";
 import { useSpring } from "@react-spring/web";
-import React, { MutableRefObject, RefObject, useState } from "react";
+import React, { MutableRefObject, useState } from "react";
 import { selector, useRecoilValue } from "recoil";
 import {
   CLIPS_VIEWS,
@@ -176,10 +176,10 @@ const EvaluationPatches = ({ close }) => {
 
 type PatcherProps = {
   close: () => void;
-  anchorRef?: MutableRefObject<unknown>;
+  anchorRef?: MutableRefObject<HTMLElement>;
 };
 
-const Patcher = ({ bounds, close, anchorRef }: PatcherProps) => {
+const Patcher = ({ close, anchorRef }: PatcherProps) => {
   const theme = useTheme();
   const isVideo =
     useRecoilValue(fos.isVideoDataset) && useRecoilValue(fos.isRootView);
@@ -199,7 +199,7 @@ const Patcher = ({ bounds, close, anchorRef }: PatcherProps) => {
     cursor: labels ? "pointer" : "default",
   });
   return (
-    <Popout modal={false} bounds={bounds} fixed anchorRef={anchorRef}>
+    <Popout modal={false} fixed anchorRef={anchorRef}>
       <SwitcherDiv>
         <SwitchDiv
           style={labelProps}

--- a/app/packages/core/src/components/Actions/Popout.tsx
+++ b/app/packages/core/src/components/Actions/Popout.tsx
@@ -1,5 +1,5 @@
-import React, { Ref, RefObject, useLayoutEffect, useState } from "react";
 import { useSpring } from "@react-spring/web";
+import React, { RefObject, useLayoutEffect, useState } from "react";
 
 import { PopoutDiv } from "../utils";
 
@@ -35,7 +35,6 @@ const Popout = ({
         ...show,
         ...style,
         zIndex: 100001,
-        right: modal ? 0 : "unset",
         ...positionStyle,
       }}
     >

--- a/app/packages/core/src/components/Actions/Popout.tsx
+++ b/app/packages/core/src/components/Actions/Popout.tsx
@@ -1,7 +1,31 @@
 import { useSpring } from "@react-spring/web";
-import React, { RefObject, useLayoutEffect, useState } from "react";
+import React, {
+  MutableRefObject,
+  RefObject,
+  useLayoutEffect,
+  useState,
+} from "react";
 
 import { PopoutDiv } from "../utils";
+
+const useAlign = (
+  anchorRef: MutableRefObject<HTMLElement>,
+  modal?: boolean
+) => {
+  const [align, setAlign] = useState("auto");
+  useLayoutEffect(() => {
+    const anchorElem = anchorRef?.current;
+    if (anchorElem) {
+      let offset = anchorElem.getBoundingClientRect()[modal ? "right" : "left"];
+      if (modal) {
+        offset = window.innerWidth - offset;
+      }
+      setAlign(`${offset}px`);
+    }
+  }, [anchorRef, modal]);
+
+  return modal ? { right: align } : { left: align };
+};
 
 const Popout = ({
   children,
@@ -10,7 +34,6 @@ const Popout = ({
   fixed,
   anchorRef,
 }: PopoutPropsType) => {
-  const [left, setLeft] = useState("auto");
   const show = useSpring({
     opacity: 1,
     from: {
@@ -20,21 +43,17 @@ const Popout = ({
       duration: 100,
     },
   });
-  useLayoutEffect(() => {
-    const anchorElem = anchorRef?.current;
-    if (anchorElem) {
-      setLeft(`${anchorElem.getBoundingClientRect().left}px`);
-    }
-  }, [anchorRef]);
+  const alignStyle = useAlign(anchorRef, modal);
 
-  const positionStyle = fixed ? { position: "fixed", left } : {};
+  const positionStyle = fixed ? { position: "fixed" } : {};
 
   return (
     <PopoutDiv
       style={{
+        zIndex: 100001,
         ...show,
         ...style,
-        zIndex: 100001,
+        ...alignStyle,
         ...positionStyle,
       }}
     >
@@ -47,7 +66,7 @@ export default React.memo(Popout);
 
 type PopoutPropsType = {
   children;
-  style: object;
+  style?: React.CSSProperties;
   modal?: boolean;
   fixed?: boolean;
   anchorRef?: RefObject<HTMLDivElement>;

--- a/app/packages/core/src/components/Actions/Popout.tsx
+++ b/app/packages/core/src/components/Actions/Popout.tsx
@@ -69,5 +69,5 @@ type PopoutPropsType = {
   style?: React.CSSProperties;
   modal?: boolean;
   fixed?: boolean;
-  anchorRef?: RefObject<HTMLDivElement>;
+  anchorRef?: RefObject<HTMLElement>;
 };

--- a/app/packages/core/src/components/Actions/Selected.tsx
+++ b/app/packages/core/src/components/Actions/Selected.tsx
@@ -267,15 +267,13 @@ interface SelectionActionsProps {
   lookerRef?: MutableRefObject<
     VideoLooker | ImageLooker | FrameLooker | undefined
   >;
-  bounds: any;
-  anchorRef?: MutableRefObject<unknown>;
+  anchorRef?: MutableRefObject<HTMLElement>;
 }
 
 const SelectionActions = ({
   modal,
   close,
   lookerRef,
-  bounds,
   anchorRef,
 }: SelectionActionsProps) => {
   useLayoutEffect(() => {
@@ -291,7 +289,7 @@ const SelectionActions = ({
   lookerRef && useEventHandler(lookerRef.current, "play", close);
 
   return (
-    <Popout modal={modal} bounds={bounds} fixed anchorRef={anchorRef} data-cy="selected-popout">
+    <Popout modal={modal} fixed anchorRef={anchorRef}>
       {actions.map((props, i) => (
         <ActionOption {...props} key={i} />
       ))}

--- a/app/packages/core/src/components/Actions/Tagger.tsx
+++ b/app/packages/core/src/components/Actions/Tagger.tsx
@@ -442,7 +442,6 @@ const SuspenseLoading = () => {
 
 type TaggerProps = {
   modal: boolean;
-  bounds: any;
   close: () => void;
   lookerRef?: MutableRefObject<
     VideoLooker | ImageLooker | FrameLooker | undefined
@@ -450,13 +449,7 @@ type TaggerProps = {
   anchorRef?: MutableRefObject<HTMLDivElement>;
 };
 
-const Tagger = ({
-  modal,
-  bounds,
-  close,
-  lookerRef,
-  anchorRef,
-}: TaggerProps) => {
+const Tagger = ({ modal, close, lookerRef, anchorRef }: TaggerProps) => {
   const [labels, setLabels] = useState(modal);
   const elementNames = useRecoilValue(fos.elementNames);
   const theme = useTheme();
@@ -481,7 +474,6 @@ const Tagger = ({
     <Popout
       style={{ width: "12rem" }}
       modal={modal}
-      bounds={bounds}
       fixed
       anchorRef={anchorRef}
     >

--- a/app/packages/core/src/components/Actions/similar/Similar.tsx
+++ b/app/packages/core/src/components/Actions/similar/Similar.tsx
@@ -6,10 +6,11 @@ import React, {
   useMemo,
   useState,
 } from "react";
-import { atom, useRecoilCallback, useRecoilValue } from "recoil";
+import { useRecoilCallback, useRecoilValue } from "recoil";
 
 import { useExternalLink } from "@fiftyone/components";
 import * as fos from "@fiftyone/state";
+import { useBrowserStorage } from "@fiftyone/state";
 import { SORT_BY_SIMILARITY } from "../../../utils/links";
 import Input from "../../Common/Input";
 import RadioGroup from "../../Common/RadioGroup";
@@ -17,6 +18,7 @@ import { Button } from "../../utils";
 import Popout from "../Popout";
 import GroupButton, { ButtonDetail } from "./GroupButton";
 import MaxKWarning from "./MaxKWarning";
+import Warning from "./Warning";
 import {
   availableSimilarityKeys,
   currentBrainConfig,
@@ -24,8 +26,6 @@ import {
   sortType,
   useSortBySimilarity,
 } from "./utils";
-import Warning from "./Warning";
-import { useBrowserStorage } from "@fiftyone/state";
 
 const DEFAULT_K = 25;
 
@@ -40,13 +40,11 @@ interface SortBySimilarityProps {
   isImageSearch: boolean;
   modal: boolean;
   close: () => void;
-  bounds?: any; // fix me
-  anchorRef?: MutableRefObject<unknown>;
+  anchorRef?: MutableRefObject<HTMLElement>;
 }
 
 const SortBySimilarity = ({
   modal,
-  bounds,
   close,
   isImageSearch,
   anchorRef,
@@ -188,13 +186,7 @@ const SortBySimilarity = ({
   );
 
   return (
-    <Popout
-      modal={modal}
-      bounds={bounds}
-      style={{ minWidth: 280 }}
-      fixed
-      anchorRef={anchorRef}
-    >
+    <Popout modal={modal} style={{ minWidth: 280 }} fixed anchorRef={anchorRef}>
       {hasSimilarityKeys && (
         <div
           style={{


### PR DESCRIPTION
Adds the `useAlign` hook to `left` aligned popouts for the grid, and `right` aligned popouts for the modal.

Before:
<img width="1470" alt="Screen Shot 2023-09-01 at 2 00 15 PM" src="https://github.com/voxel51/fiftyone/assets/19821840/91e669f2-d351-4463-b118-06251ff04402">
After:
<img width="1470" alt="Screen Shot 2023-09-01 at 2 04 26 PM" src="https://github.com/voxel51/fiftyone/assets/19821840/49f72baa-9100-47ed-b841-76611f493488">
