### PR TITLE
fix ghroup media visibility container regression

### DIFF
--- a/app/packages/core/src/components/Actions/GroupMediaVisibilityContainer.tsx
+++ b/app/packages/core/src/components/Actions/GroupMediaVisibilityContainer.tsx
@@ -2,7 +2,7 @@ import { PillButton, PopoutSectionTitle } from "@fiftyone/components";
 import * as fos from "@fiftyone/state";
 import { useOutsideClick } from "@fiftyone/state";
 import ViewComfyIcon from "@mui/icons-material/ViewComfy";
-import React, { useRef, useState } from "react";
+import { MutableRefObject, useRef, useState } from "react";
 import useMeasure from "react-use-measure";
 import { useRecoilState, useRecoilValue } from "recoil";
 import styled from "styled-components";
@@ -20,7 +20,13 @@ const Container = styled.div`
   position: relative;
 `;
 
-const GroupMediaVisibilityPopout = ({ modal }: { modal: boolean }) => {
+const GroupMediaVisibilityPopout = ({
+  modal,
+  anchorRef,
+}: {
+  modal: boolean;
+  anchorRef: MutableRefObject<HTMLDivElement>;
+}) => {
   const [isSlotVisible, setIsSlotVisible] = useRecoilState(
     fos.groupMedia3dVisibleSetting
   );
@@ -35,7 +41,7 @@ const GroupMediaVisibilityPopout = ({ modal }: { modal: boolean }) => {
   );
 
   return (
-    <Popout modal={modal}>
+    <Popout fixed anchorRef={anchorRef} modal={modal}>
       <PopoutSectionTitle>{TITLE}</PopoutSectionTitle>
       {pointCloudSliceExists && (
         <Checkbox
@@ -84,7 +90,7 @@ export const GroupMediaVisibilityContainer = ({
         highlight={open}
         ref={mRef}
       />
-      {open && <GroupMediaVisibilityPopout modal={modal} />}
+      {open && <GroupMediaVisibilityPopout anchorRef={ref} modal={modal} />}
     </Container>
   );
 };

--- a/app/packages/core/src/components/Actions/Popout.tsx
+++ b/app/packages/core/src/components/Actions/Popout.tsx
@@ -1,5 +1,5 @@
-import React, { Ref, RefObject, useLayoutEffect, useState } from "react";
 import { useSpring } from "@react-spring/web";
+import React, { RefObject, useLayoutEffect, useState } from "react";
 
 import { PopoutDiv } from "../utils";
 
@@ -48,7 +48,7 @@ export default React.memo(Popout);
 
 type PopoutPropsType = {
   children;
-  style: object;
+  style?: object;
   modal?: boolean;
   fixed?: boolean;
   anchorRef?: RefObject<HTMLDivElement>;


### PR DESCRIPTION
## What changes are proposed in this pull request?

Pass missing `anchorRef` to `Popout` component in group media visibility container so that it shows properly. Note that `Popout` in modal should be right anchored to `anchorRef` and not overflow as shown in the screenshot below but that's addressed in another PR.
<img width="739" alt="Screenshot 2023-09-01 at 3 11 13 PM" src="https://github.com/voxel51/fiftyone/assets/66688606/efe6a9f4-e7a1-4fb5-a0ee-523701678c2a">

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
