### PR TITLE
Generalize _is_docker() to is_container()

### DIFF
--- a/fiftyone/core/session/session.py
+++ b/fiftyone/core/session/session.py
@@ -358,7 +358,7 @@ class Session(object):
             )
 
         if address is None:
-            if fou.is_docker() or focx.is_databricks_context():
+            if fou.is_container() or focx.is_databricks_context():
                 address = "0.0.0.0"
             else:
                 address = fo.config.default_app_address

--- a/fiftyone/core/utils.py
+++ b/fiftyone/core/utils.py
@@ -1651,18 +1651,26 @@ def is_32_bit():
     return struct.calcsize("P") * 8 == 32
 
 
-def is_docker():
-    """Determines if we're currently running in a Docker container.
+def is_container():
+    """Determines if we're currently running as a container.
 
     Returns:
         True/False
     """
+    return _is_docker() or _is_podman()
+
+
+def _is_docker():
     path = "/proc/self/cgroup"
     return (
         os.path.exists("/.dockerenv")
         or os.path.isfile(path)
         and any("docker" in line for line in open(path))
     )
+
+
+def _is_podman():
+    return os.path.exists("/run/.containerenv")
 
 
 def get_multiprocessing_context():


### PR DESCRIPTION
## What changes are proposed in this pull request?

Generalize _is_docker() to is_container(), in order for same behavior using docker and podman. 
The is_docker() method allowed a host to connect to Fiftyone running in a docker container without extra config. Using podman, extra config was needed.

## How is this patch tested? If it is not, please explain why.

Tested by running is_container() using podman, docker, and without container. The function returns true for both podman and docker, and false without running as container.

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
