### PR TITLE
Enable async unit tests

### DIFF
--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -4,4 +4,5 @@ werkzeug==2.0.3
 pytest==7.3.1
 pytest-cov==4.0.0
 pytest-mock==3.10.0
+pytest-asyncio
 twine>=3


### PR DESCRIPTION
## What changes are proposed in this pull request?

Update test requirements so that async unit tests will run. Currently any async unit tests are skipped in the test runner: 
```

tests/unittests/utils_tests.py::UIDTests::test_log_import
  /opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/httpx/_content.py:204: DeprecationWarning: Use 'content=<...>' to upload raw bytes/text content.
    warnings.warn(message, DeprecationWarning)

tests/unittests/plugins/secrets_tests.py::TestExecutionContext::test_resolve_secret_values
tests/unittests/secrets/provider_tests.py::TestEnvSecretProvider::test_get_existing_secret
tests/unittests/secrets/provider_tests.py::TestEnvSecretProvider::test_get_non_existing_secret
tests/unittests/secrets/provider_tests.py::TestEnvSecretProvider::test_get_multiple_secrets_all_existing
tests/unittests/secrets/provider_tests.py::TestEnvSecretProvider::test_get_multiple_secrets_some_existing
tests/unittests/secrets/provider_tests.py::TestEnvSecretProvider::test_get_multiple_secrets_empty_list
  /opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/_pytest/python.py:183: PytestUnhandledCoroutineWarning: async def functions are not natively supported and have been skipped.
  You need to install a suitable plugin for your async framework, for example:
    - anyio
    - pytest-asyncio
    - pytest-tornasync
    - pytest-trio
    - pytest-twisted
    warnings.warn(PytestUnhandledCoroutineWarning(msg.format(nodeid)))

tests/unittests/plugins/secrets_tests.py::TestGetSecret::test_get_secret
  /opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/unittest/case.py:633: RuntimeWarning: coroutine 'TestGetSecret.test_get_secret' was never awaited
    method()
  Enable tracemalloc to get traceback where the object was allocated.
  See https://docs.pytest.org/en/stable/how-to/capture-warnings.html#resource-warnings for more info.

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html

---------- coverage: platform linux, python 3.8.18-final-0 -----------
Coverage XML written to file coverage.xml
```