### PR TITLE
[Docs] fix fiftyone-plugins links

### DIFF
--- a/docs/source/plugins/index.rst
+++ b/docs/source/plugins/index.rst
@@ -10,7 +10,7 @@ FiftyOne provides a powerful plugin framework that allows for extending and cust
 .. note::
 
     Check out the
-    `fiftyone-plugins <https://github.com/voxel51/fiftyone-plugins>`_
+    `voxel51/fiftyone-plugins <https://github.com/voxel51/fiftyone-plugins>`_
     repository for a growing collection of prebuilt plugins that you can easily
     :ref:`download <plugins-download>` and use locally!
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

Fix internal ref links for `fiftyone-plugins` that were broken due to the name/label conflict with the link to the github repo