### PR TITLE
Gracefully handle empty SAM prompts V2

### DIFF
--- a/fiftyone/utils/sam.py
+++ b/fiftyone/utils/sam.py
@@ -234,10 +234,7 @@ class SegmentAnythingModel(fout.TorchImageModel, fout.TorchSamplesMixin):
         outputs = []
         for img, detections in zip(imgs, self._curr_prompts):
             ## If no detections, return empty tensors instead of running SAM
-            if (
-                detections.detections is None
-                or len(detections.detections) == 0
-            ):
+            if detections is None or len(detections.detections) == 0:
                 h, w = img.shape[1], img.shape[2]
                 outputs.append(
                     {
@@ -293,7 +290,7 @@ class SegmentAnythingModel(fout.TorchImageModel, fout.TorchSamplesMixin):
             boxes, labels, scores, masks = [], [], [], []
 
             ## If no keypoints, return empty tensors instead of running SAM
-            if keypoints.keypoints is None or len(keypoints.keypoints) == 0:
+            if keypoints is None or len(keypoints.keypoints) == 0:
                 outputs.append(
                     {
                         "boxes": torch.tensor([[]]),

--- a/fiftyone/utils/sam.py
+++ b/fiftyone/utils/sam.py
@@ -293,6 +293,17 @@ class SegmentAnythingModel(fout.TorchImageModel, fout.TorchSamplesMixin):
 
             boxes, labels, scores, masks = [], [], [], []
 
+            ## If no keypoints, return empty tensors instead of running SAM
+            if len(keypoints.keypoints) == 0:
+                outputs.append(
+                    {
+                        "boxes": torch.tensor([[]]),
+                        "labels": torch.empty([0, 4]),
+                        "masks": torch.empty([0, 1, h, w]),
+                    }
+                )
+                continue
+
             for kp in keypoints.keypoints:
                 sam_points, sam_labels = _to_sam_points(kp.points, w, h)
 

--- a/fiftyone/utils/sam.py
+++ b/fiftyone/utils/sam.py
@@ -234,13 +234,16 @@ class SegmentAnythingModel(fout.TorchImageModel, fout.TorchSamplesMixin):
         outputs = []
         for img, detections in zip(imgs, self._curr_prompts):
             ## If no detections, return empty tensors instead of running SAM
-            if len(detections.detections) == 0:
-                H, W = img.shape[1], img.shape[2]
+            if (
+                detections.detections is None
+                or len(detections.detections) == 0
+            ):
+                h, w = img.shape[1], img.shape[2]
                 outputs.append(
                     {
                         "boxes": torch.tensor([[]]),
                         "labels": torch.empty([0, 4]),
-                        "masks": torch.empty([0, 1, H, W]),
+                        "masks": torch.empty([0, 1, h, w]),
                     }
                 )
                 continue
@@ -263,19 +266,15 @@ class SegmentAnythingModel(fout.TorchImageModel, fout.TorchSamplesMixin):
                 device=sam_predictor.device,
             )
 
-            try:
-                masks, _, _ = sam_predictor.predict_torch(
-                    point_coords=None,
-                    point_labels=None,
-                    boxes=transformed_boxes,
-                    multimask_output=False,
-                )
-                outputs.append(
-                    {"boxes": input_boxes, "labels": labels, "masks": masks}
-                )
-
-            except ValueError:
-                print("ValueError in sam_predictor.predict_torch")
+            masks, _, _ = sam_predictor.predict_torch(
+                point_coords=None,
+                point_labels=None,
+                boxes=transformed_boxes,
+                multimask_output=False,
+            )
+            outputs.append(
+                {"boxes": input_boxes, "labels": labels, "masks": masks}
+            )
 
         return outputs
 
@@ -294,7 +293,7 @@ class SegmentAnythingModel(fout.TorchImageModel, fout.TorchSamplesMixin):
             boxes, labels, scores, masks = [], [], [], []
 
             ## If no keypoints, return empty tensors instead of running SAM
-            if len(keypoints.keypoints) == 0:
+            if keypoints.keypoints is None or len(keypoints.keypoints) == 0:
                 outputs.append(
                     {
                         "boxes": torch.tensor([[]]),


### PR DESCRIPTION
## What changes are proposed in this pull request?

Before this, if there were empty prompt fields, either detection or keypoint, the following errors would be passed to the user:
```
Batch: 64f8fb2b89625d1f64eb5449 - 64f8fb2b89625d1f64eb5449                       
Error: cannot reshape tensor of 0 elements into shape [0, -1, 256, 256] because the unspecified dimension size -1 can be any value and is ambiguous
```
Now, this case is handled separately by checking for the length of the `Detections` or `Keypoints` contents, and when 0, returning empty torch tensors to the `InstanceSegmentationOutputParser`.

## How is this patch tested? If it is not, please explain why.

To test empty detection bounding box prompts:

```
import fiftyone as fo
import fiftyone.zoo as foz
dataset = foz.load_zoo_dataset("quickstart", max_samples=25)

### make some empty
view = dataset.take(10)
for sample in view.iter_samples():
    sample["ground_truth"] = fo.Detections(detections=[])
    sample.save()
view.save()

model = foz.load_zoo_model("segment-anything-vitb-torch")
dataset.apply_model(
    model,
    label_field="segmentations",
    prompt_field="ground_truth",
)
```

For keypoints:
```
dataset = foz.load_zoo_dataset(
    "coco-2017",
    split="validation",
    label_types="detections",
    classes=["person"],
    max_samples=25,
    only_matching=True,
)

# Generate some keypoints
kp_model = foz.load_zoo_model("keypoint-rcnn-resnet50-fpn-coco-torch")
dataset.default_skeleton = kp_model.skeleton
dataset.apply_model(kp_model, label_field="gt")

### make some empty
view = dataset.take(10)
for sample in view.iter_samples():
    sample["gt_keypoints"] = fo.Keypoints(keypoints=[])
    sample.save()
view.save()

model = foz.load_zoo_model("segment-anything-vitb-torch")
# Prompt with keypoints
dataset.apply_model(
    model,
    label_field="segmentations",
    prompt_field="gt_keypoints",
)
```


## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
