### PR TITLE
Fix delegated operators schedule button

### DIFF
--- a/fiftyone/operators/operator.py
+++ b/fiftyone/operators/operator.py
@@ -143,8 +143,8 @@ class Operator(object):
             return definition
 
         # pylint: disable=assignment-from-none
-        input_property = self.resolve_input(ctx)
-        output_property = self.resolve_output(ctx)
+        input_property = self.resolve_type(ctx, "inputs")
+        output_property = self.resolve_type(ctx, "outputs")
 
         if input_property is not None:
             definition.add_property("inputs", input_property)
@@ -192,7 +192,7 @@ class Operator(object):
         if type == "inputs":
             # pylint: disable=assignment-from-none
             input_property = self.resolve_input(ctx)
-            if input_property.view is None:
+            if input_property and input_property.view is None:
                 should_delegate = self.resolve_delegation(ctx)
                 if should_delegate:
                     input_property.view = PromptView(
@@ -209,7 +209,8 @@ class Operator(object):
         """Returns the resolved input property.
 
         Subclasses can implement this method to define the inputs to the
-        operator.
+        operator. This method should never be called directly. Instead
+        use :meth:`resolve_type`.
 
         By default, this method is called once when the operator is created.
         If the operator is dynamic, this method is called each time the input

--- a/fiftyone/operators/types.py
+++ b/fiftyone/operators/types.py
@@ -26,10 +26,15 @@ class Void(BaseType):
 
 
 class Object(BaseType):
-    """Represents a JSON object."""
+    """Represents a JSON object.
 
-    def __init__(self):
+    Args:
+        root_view (None): the :class:`View` used to display the object
+    """
+
+    def __init__(self, root_view=None):
         self.properties = {}
+        self.root_view = root_view
 
     def add_property(self, name, property):
         """Adds a property to the object.


### PR DESCRIPTION
This fixes an issue where non-dynamic operators would show `Execute` instead of `Schedule` for delegated operators.