### PR TITLE
no response stored from delegated operators that execute as generators

### DIFF
--- a/fiftyone/operators/delegated.py
+++ b/fiftyone/operators/delegated.py
@@ -295,11 +295,9 @@ class DelegatedOperationService(object):
                 else fou.run_sync_task(operator.execute, ctx)
             )
 
-            if isinstance(
+            is_generator = isinstance(
                 raw_result, python_types.GeneratorType
-            ) or isinstance(raw_result, python_types.AsyncGeneratorType):
+            ) or isinstance(raw_result, python_types.AsyncGeneratorType)
 
-                out = list(raw_result)
-                return out
-
-            return raw_result
+            if not is_generator:
+                return raw_result

--- a/tests/unittests/delegated_operators_tests.py
+++ b/tests/unittests/delegated_operators_tests.py
@@ -292,10 +292,8 @@ class DelegatedOperationServiceTests(unittest.TestCase):
         self.assertIsNotNone(doc.started_at)
         self.assertIsNotNone(doc.queued_at)
         self.assertIsNotNone(doc.completed_at)
-        self.assertIsNone(doc.result.error)
+        self.assertIsNone(doc.result)
         self.assertIsNone(doc.failed_at)
-
-        self.assertEqual(doc.result.result, [{"executed": True}])
 
     @patch(
         "fiftyone.core.dataset.load_dataset",


### PR DESCRIPTION
## What changes are proposed in this pull request?

(Please fill in changes proposed in this fix)

## How is this patch tested? If it is not, please explain why.

(Details)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
