### PR TITLE
Always log stack traces in server

### DIFF
--- a/fiftyone/server/app.py
+++ b/fiftyone/server/app.py
@@ -87,7 +87,7 @@ app = Starlette(
         ),
         Middleware(HeadersMiddleware),
     ],
-    debug=foc.DEV_INSTALL,
+    debug=True,
     routes=[Route(route, endpoint) for route, endpoint in routes]
     + [
         Route(


### PR DESCRIPTION
In starlette, the `debug` flag for an `App` is documented as:
```
Boolean indicating if debug tracebacks should be returned on errors.
```
which is always useful 🚀 