### PR TITLE
App support for expressions and fields lists in dynamic groups

### DIFF
--- a/app/packages/core/src/components/Modal/Group/DynamicGroup/NestedGroup/GroupElementsLinkBar.tsx
+++ b/app/packages/core/src/components/Modal/Group/DynamicGroup/NestedGroup/GroupElementsLinkBar.tsx
@@ -95,7 +95,6 @@ const GroupElementsLinkBarImpl = React.memo(
     const { orderBy } = useRecoilValue(fos.dynamicGroupParameters)!;
 
     const data = usePreloadedQuery(foq.paginateSamples, queryRef);
-    console.log(data);
 
     const [
       dynamicGroupCurrentElementIndex,
@@ -112,9 +111,7 @@ const GroupElementsLinkBarImpl = React.memo(
         (sample: fos.ModalSample) => {
           const current = get(fos.currentModalSample);
           const currentGroup = get(fos.groupByFieldValue);
-          const nextGroup = String(
-            getValue(sample.sample, dynamicGroupParameters.groupBy)
-          );
+          const nextGroup = sample.sample._group_by_key;
 
           if (
             current &&

--- a/app/packages/core/src/components/Modal/Group/DynamicGroup/NestedGroup/GroupElementsLinkBar.tsx
+++ b/app/packages/core/src/components/Modal/Group/DynamicGroup/NestedGroup/GroupElementsLinkBar.tsx
@@ -4,6 +4,7 @@ import * as fos from "@fiftyone/state";
 import { currentModalSample } from "@fiftyone/state";
 import { PaginationItem } from "@mui/material";
 import Pagination, { PaginationProps } from "@mui/material/Pagination";
+import * as _ from "lodash";
 import { get as getValue } from "lodash";
 import React, {
   Suspense,
@@ -111,12 +112,16 @@ const GroupElementsLinkBarImpl = React.memo(
         (sample: fos.ModalSample) => {
           const current = get(fos.currentModalSample);
           const currentGroup = get(fos.groupByFieldValue);
-          const nextGroup = sample.sample._group_by_key;
+          let nextGroup: unknown;
+          if (dynamicGroupParameters?.groupBy) {
+            const key = sample.sample._group_by_key;
+            nextGroup = sample.sample._group_by_key_is_id ? { $oid: key } : key;
+          }
 
           if (
             current &&
             current.id !== sample.id &&
-            currentGroup === nextGroup
+            _.isEqual(currentGroup, nextGroup)
           ) {
             set(currentModalSample, { index: current.index, id: sample.id });
             set(fos.groupId, getValue(sample.sample, groupField)._id as string);

--- a/app/packages/looker/src/state.ts
+++ b/app/packages/looker/src/state.ts
@@ -63,6 +63,8 @@ export type Sample = {
   tags: string[];
   _label_tags: string[];
   _media_type: "image" | "video" | "point-cloud";
+  _group_by_key?: unknown;
+  _group_by_key_is_id?: boolean;
 } & GenericLabel;
 
 export interface LabelData {

--- a/app/packages/state/src/hooks/useExpandSample.ts
+++ b/app/packages/state/src/hooks/useExpandSample.ts
@@ -9,7 +9,6 @@ import * as modalAtoms from "../recoil/modal";
 import * as schemaAtoms from "../recoil/schema";
 import * as selectors from "../recoil/selectors";
 import * as sidebarAtoms from "../recoil/sidebar";
-import { getSanitizedGroupByExpression } from "../recoil/utils";
 import * as viewAtoms from "../recoil/view";
 import { LookerStore, Lookers } from "./useLookerStore";
 import useSetExpandedSample from "./useSetExpandedSample";
@@ -112,14 +111,9 @@ export default <T extends Lookers>(store: LookerStore<T>) => {
             groupId = get(sample.sample, groupField)._id as string;
           }
 
-          let groupByFieldValue: string;
+          let groupByFieldValue: unknown;
           if (dynamicGroupParameters?.groupBy) {
-            groupByFieldValue = String(
-              get(
-                sample.sample,
-                getSanitizedGroupByExpression(dynamicGroupParameters.groupBy)
-              )
-            );
+            groupByFieldValue = sample.sample._group_by_key;
           }
 
           return { id, groupId, groupByFieldValue };

--- a/app/packages/state/src/hooks/useExpandSample.ts
+++ b/app/packages/state/src/hooks/useExpandSample.ts
@@ -113,7 +113,10 @@ export default <T extends Lookers>(store: LookerStore<T>) => {
 
           let groupByFieldValue: unknown;
           if (dynamicGroupParameters?.groupBy) {
-            groupByFieldValue = sample.sample._group_by_key;
+            const key = sample.sample._group_by_key;
+            groupByFieldValue = sample.sample._group_by_key_is_id
+              ? { $oid: key }
+              : key;
           }
 
           return { id, groupId, groupByFieldValue };

--- a/app/packages/state/src/hooks/useSetExpandedSample.ts
+++ b/app/packages/state/src/hooks/useSetExpandedSample.ts
@@ -7,12 +7,14 @@ import {
   currentModalNavigation,
   currentModalSample,
   dynamicGroupCurrentElementIndex,
+  isDynamicGroup,
 } from "../recoil";
 import * as groupAtoms from "../recoil/groups";
 
 export default () => {
   const types = useRecoilValue(groupAtoms.groupMediaTypes);
   const map = useRecoilValue(groupAtoms.groupMediaTypesMap);
+  const isDynamic = useRecoilValue(isDynamicGroup);
 
   const setter = useRecoilTransaction_UNSTABLE(
     ({ get, reset, set }) =>
@@ -20,14 +22,13 @@ export default () => {
         id: string,
         index: number,
         groupId?: string,
-        groupByFieldValue?: string
+        groupByFieldValue?: unknown
       ) => {
         set(groupAtoms.groupId, groupId || null);
         set(currentModalSample, { id, index });
         reset(groupAtoms.nestedGroupIndex);
         reset(dynamicGroupCurrentElementIndex);
-        groupByFieldValue &&
-          set(groupAtoms.groupByFieldValue, groupByFieldValue);
+        isDynamic && set(groupAtoms.groupByFieldValue, groupByFieldValue);
 
         let fallback = get(groupAtoms.groupSlice(false));
         if (map[fallback] === "point_cloud") {
@@ -38,7 +39,7 @@ export default () => {
         }
         set(groupAtoms.groupSlice(true), fallback);
       },
-    [map, types]
+    [isDynamic, map, types]
   );
 
   return useRecoilCallback(

--- a/app/packages/state/src/recoil/modal.ts
+++ b/app/packages/state/src/recoil/modal.ts
@@ -60,7 +60,7 @@ export const currentModalSample = atom<ModalSelector | null>({
 
 export type ModalNavigation = (
   index: number
-) => Promise<{ id: string; groupId?: string; groupByFieldValue?: string }>;
+) => Promise<{ id: string; groupId?: string; groupByFieldValue?: unknown }>;
 
 export const currentModalNavigation = atom<Nullable<ModalNavigation>>({
   key: "currentModalNavigation",

--- a/app/packages/state/src/recoil/utils.ts
+++ b/app/packages/state/src/recoil/utils.ts
@@ -24,14 +24,6 @@ export const getSampleSrc = (url: string) => {
   )}`;
 };
 
-export const getSanitizedGroupByExpression = (expression: string) => {
-  // todo: why this special case for sample_id...?
-  if (expression === "sample_id") {
-    return "_sample_id";
-  }
-  return expression;
-};
-
 export const mapSampleResponse = <
   T extends Nullable<{
     readonly sample?: Sample;

--- a/fiftyone/core/view.py
+++ b/fiftyone/core/view.py
@@ -16,7 +16,6 @@ from pymongo.errors import CursorNotFound
 
 import eta.core.utils as etau
 
-import fiftyone.core.aggregations as foa
 import fiftyone.core.collections as foc
 import fiftyone.core.expressions as foe
 import fiftyone.core.fields as fof
@@ -168,13 +167,6 @@ class DatasetView(foc.SampleCollection):
             if isinstance(stage, fost.GroupBy):
                 break
 
-        parent = self.__class__(
-            self.__dataset,
-            _stages=deepcopy(self.__stages),
-            _media_type=self.__media_type,
-            _group_slice=self.__group_slice,
-            _name=self.__name,
-        )
         return DatasetView._build(
             self._dataset, self._serialize()[:idx]
         ).media_type

--- a/fiftyone/server/samples.py
+++ b/fiftyone/server/samples.py
@@ -9,7 +9,6 @@ import asyncio
 import strawberry as gql
 import typing as t
 
-
 from fiftyone.core.collections import SampleCollection
 import fiftyone.core.media as fom
 import fiftyone.core.odm as foo
@@ -101,6 +100,19 @@ async def paginate_samples(
 
     if int(after) > -1:
         view = view.skip(int(after) + 1)
+
+    if view._is_dynamic_groups:
+        expr, is_id_field, _, __ = view._parse_dynamic_groups()
+        view = view.set_field(
+            "_group_by_key",
+            expr,
+            _allow_missing=True,
+        )
+        view = view.set_field(
+            "_group_by_key_is_id",
+            is_id_field,
+            _allow_missing=True,
+        )
 
     pipeline = view._pipeline(
         attach_frames=has_frames,


### PR DESCRIPTION
Adds support for dynamic group carousels and nested pagination when the group key is an expression. Also adds support for field lists. General support for expressions requires resolving the expressions for each sample in grid pagination requests (via hidden `_group_by_key` and `_group_by_key_is_id`) fields.

The frontend constructs the equivalent `Mongo` stage returned by `view.get_dynamic_group()` using these hidden fields
```py
import fiftyone as fo
import fiftyone.zoo as foz

E, F = fo.ViewExpression, fo.ViewField

dataset = foz.load_zoo_dataset("cifar10", max_samples=200)

# examples

field_list = dataset.group_by(["ground_truth.label", "ground_truth.label"])
field_list_expr = dataset.group_by(E([F("ground_truth.label"), F("ground_truth.label")]))

id = dataset.group_by(F("ground_truth.id"))
id_expr = dataset.group_by("ground_truth.id")

expression = dataset.group_by(F("ground_truth.label").concat(F("ground_truth.label")))
```