### PR TITLE
Fix group modal when grid filters are present

### DIFF
--- a/app/packages/state/src/hooks/useExpandSample.ts
+++ b/app/packages/state/src/hooks/useExpandSample.ts
@@ -1,7 +1,7 @@
 import { FlashlightConfig } from "@fiftyone/flashlight";
 import { get } from "lodash";
 import { useRelayEnvironment } from "react-relay";
-import { RecoilState, useRecoilCallback } from "recoil";
+import { CallbackInterface, RecoilState, useRecoilCallback } from "recoil";
 import * as atoms from "../recoil/atoms";
 import * as filterAtoms from "../recoil/filters";
 import * as groupAtoms from "../recoil/groups";
@@ -14,70 +14,80 @@ import * as viewAtoms from "../recoil/view";
 import { LookerStore, Lookers } from "./useLookerStore";
 import useSetExpandedSample from "./useSetExpandedSample";
 
+const setModalFilters = async ({ snapshot, set }: CallbackInterface) => {
+  const paths = await snapshot.getPromise(
+    schemaAtoms.labelPaths({ expanded: false })
+  );
+  const filters = await snapshot.getPromise(filterAtoms.filters);
+  const modalFilters = Object.fromEntries(
+    Object.entries(filters).filter(([path]) =>
+      paths.some((p) => path.startsWith(p))
+    )
+  );
+
+  set(filterAtoms.modalFilters, modalFilters);
+};
+
 export default <T extends Lookers>(store: LookerStore<T>) => {
   const environment = useRelayEnvironment();
   const setExpandedSample = useSetExpandedSample();
 
   const setModalState = useRecoilCallback(
-    ({ set, snapshot }) =>
-      async (navigation: modalAtoms.ModalNavigation) => {
-        const data = [
-          [filterAtoms.modalFilters, filterAtoms.filters],
-          ...["colorBy", "multicolorKeypoints", "showSkeletons"].map((key) => {
-            return [
-              selectors.appConfigOption({ key, modal: false }),
-              selectors.appConfigOption({ key, modal: false }),
-            ];
-          }),
-          [
-            schemaAtoms.activeFields({ modal: true }),
-            schemaAtoms.activeFields({ modal: false }),
-          ],
-          [atoms.cropToContent(true), atoms.cropToContent(false)],
-          [atoms.sortFilterResults(true), atoms.sortFilterResults(false)],
-          [
-            sidebarAtoms.sidebarGroupsDefinition(true),
-            sidebarAtoms.sidebarGroupsDefinition(false),
-          ],
-          [sidebarAtoms.sidebarWidth(true), sidebarAtoms.sidebarWidth(false)],
-          [
-            sidebarAtoms.sidebarVisible(true),
-            sidebarAtoms.sidebarVisible(false),
-          ],
-          [sidebarAtoms.textFilter(true), sidebarAtoms.textFilter(false)],
+    (cbInterface) => async (navigation: modalAtoms.ModalNavigation) => {
+      const { snapshot, set } = cbInterface;
+      const data = [
+        [filterAtoms.modalFilters, filterAtoms.filters],
+        ...["colorBy", "multicolorKeypoints", "showSkeletons"].map((key) => {
+          return [
+            selectors.appConfigOption({ key, modal: false }),
+            selectors.appConfigOption({ key, modal: false }),
+          ];
+        }),
+        [
+          schemaAtoms.activeFields({ modal: true }),
+          schemaAtoms.activeFields({ modal: false }),
+        ],
+        [atoms.cropToContent(true), atoms.cropToContent(false)],
+        [atoms.sortFilterResults(true), atoms.sortFilterResults(false)],
+        [
+          sidebarAtoms.sidebarGroupsDefinition(true),
+          sidebarAtoms.sidebarGroupsDefinition(false),
+        ],
+        [sidebarAtoms.sidebarWidth(true), sidebarAtoms.sidebarWidth(false)],
+        [sidebarAtoms.sidebarVisible(true), sidebarAtoms.sidebarVisible(false)],
+        [sidebarAtoms.textFilter(true), sidebarAtoms.textFilter(false)],
 
-          [groupAtoms.groupStatistics(true), groupAtoms.groupStatistics(false)],
-          [groupAtoms.groupSlice(true), groupAtoms.groupSlice(false)],
-        ];
+        [groupAtoms.groupStatistics(true), groupAtoms.groupStatistics(false)],
+        [groupAtoms.groupSlice(true), groupAtoms.groupSlice(false)],
+      ];
 
-        const groupSlice = await snapshot.getPromise(
-          groupAtoms.groupSlice(false)
-        );
+      const groupSlice = await snapshot.getPromise(
+        groupAtoms.groupSlice(false)
+      );
 
-        let pinned3d = false;
-        let activeSlices = [];
-        if (groupSlice) {
-          const map = await snapshot.getPromise(groupAtoms.groupMediaTypesMap);
-          if (map[groupSlice] === "point_cloud") {
-            pinned3d = true;
-            activeSlices = [groupSlice];
-          }
+      let pinned3d = false;
+      let activeSlices = [];
+      if (groupSlice) {
+        const map = await snapshot.getPromise(groupAtoms.groupMediaTypesMap);
+        if (map[groupSlice] === "point_cloud") {
+          pinned3d = true;
+          activeSlices = [groupSlice];
         }
-        set(groupAtoms.pinned3d, pinned3d);
-        set(groupAtoms.activePcdSlices, activeSlices);
+      }
+      set(groupAtoms.pinned3d, pinned3d);
+      set(groupAtoms.activePcdSlices, activeSlices);
 
-        const results = await Promise.all(
-          data.map(([_, get]) =>
-            snapshot.getPromise(get as RecoilState<unknown>)
-          )
-        );
+      const results = await Promise.all(
+        data.map(([_, get]) => snapshot.getPromise(get as RecoilState<unknown>))
+      );
 
-        for (const i in results) {
-          set(data[i][0], results[i]);
-        }
+      for (const i in results) {
+        set(data[i][0], results[i]);
+      }
+      await setModalFilters(cbInterface);
 
-        set(modalAtoms.currentModalNavigation, () => navigation);
-      },
+      set(modalAtoms.currentModalNavigation, () => navigation);
+    },
     [environment]
   );
 

--- a/app/packages/state/src/hooks/useExpandSample.ts
+++ b/app/packages/state/src/hooks/useExpandSample.ts
@@ -20,8 +20,9 @@ const setModalFilters = async ({ snapshot, set }: CallbackInterface) => {
   );
   const filters = await snapshot.getPromise(filterAtoms.filters);
   const modalFilters = Object.fromEntries(
-    Object.entries(filters).filter(([path]) =>
-      paths.some((p) => path.startsWith(p))
+    Object.entries(filters).filter(
+      ([path]) =>
+        paths.some((p) => path.startsWith(p)) || path === "_label_tags"
     )
   );
 

--- a/app/packages/state/src/recoil/modal.ts
+++ b/app/packages/state/src/recoil/modal.ts
@@ -5,7 +5,6 @@ import { graphQLSelector } from "recoil-relay";
 import { VariablesOf } from "relay-runtime";
 import { Nullable } from "vitest";
 import { ResponseFrom } from "../utils";
-import { filters } from "./filters";
 import {
   groupId,
   groupSlice,
@@ -134,7 +133,6 @@ export const modalSample = graphQLSelector<
     return {
       dataset: get(datasetName),
       view: get(view),
-      filters: get(filters),
       filter: {
         id: current.id,
         group: slice


### PR DESCRIPTION
This change removes the `filters` variable from the main sample query selector and limits inherited filters when expanding a sample or group to only include labels and label tags settings. Grid filters on primitive values should not exclude slices in the expanded view. This is a subtle detail so we can also discuss offline @manivoxel51 @lanzhenw 


e2e has been added with the example of filtering by the `left` slice in the grid in `quickstart-groups`. See recordings for before and after behavior

Before:
https://github.com/voxel51/fiftyone/assets/19821840/dd7fd961-b714-410d-8a98-1a60622bb721

After:
https://github.com/voxel51/fiftyone/assets/19821840/81e8919a-5701-4dbf-8362-e98c438ecddd


