### PR TITLE
[Proposal] Add lint step to e2e

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -97,6 +97,10 @@ jobs:
         run: yarn e2e
         working-directory: e2e-pw
 
+      - name: Lint Playwright tests
+        run: yarn lint
+        working-directory: e2e-pw
+
       - name: Upload test report
         if: always()
         uses: actions/upload-artifact@v3

--- a/e2e-pw/src/oss/poms/field-visibility/field-visibility.ts
+++ b/e2e-pw/src/oss/poms/field-visibility/field-visibility.ts
@@ -1,4 +1,3 @@
-import { SidebarPom } from "../sidebar";
 import { Locator, Page, expect } from "src/oss/fixtures";
 
 const enabledParentPaths = ["uniqueness", "predictions", "ground_truth"];

--- a/e2e-pw/src/oss/specs/display-options/display-options.spec.ts
+++ b/e2e-pw/src/oss/specs/display-options/display-options.spec.ts
@@ -9,8 +9,8 @@ const test = base.extend<{
   histogram: HistogramPom;
   panel: PanelPom;
 }>({
-  actionsRow: async ({ page }, use) => {
-    await use(new GridActionsRowPom(page));
+  actionsRow: async ({ page, eventUtils }, use) => {
+    await use(new GridActionsRowPom(page, eventUtils));
   },
   histogram: async ({ page, eventUtils }, use) => {
     await use(new HistogramPom(page, eventUtils));

--- a/e2e-pw/src/oss/specs/smoke-tests/embeddings.spec.ts
+++ b/e2e-pw/src/oss/specs/smoke-tests/embeddings.spec.ts
@@ -1,7 +1,7 @@
 import { test as base } from "src/oss/fixtures";
 import { GridPom } from "src/oss/poms/grid";
-import { PanelPom } from "src/oss/poms/panels/panel";
 import { EmbeddingsPom } from "src/oss/poms/panels/embeddings-panel";
+import { PanelPom } from "src/oss/poms/panels/panel";
 import { getUniqueDatasetNameWithPrefix } from "src/oss/utils";
 
 const datasetName = getUniqueDatasetNameWithPrefix("smoke-quickstart");
@@ -56,7 +56,7 @@ test.describe("embeddings on quickstart dataset", () => {
   }) => {
     await panel.open("Embeddings");
     await embeddings.asserter.verifySelectorVisible();
-    await panel.close("Embeddings");
+    await panel.close();
   });
 
   test("lasso samples work", async ({
@@ -68,6 +68,6 @@ test.describe("embeddings on quickstart dataset", () => {
   }) => {
     await panel.open("Embeddings");
     await embeddings.asserter.verifyLassoSelectsSamples();
-    await panel.close("Embeddings");
+    await panel.close();
   });
 });

--- a/e2e-pw/src/oss/specs/smoke-tests/quickstart-groups.spec.ts
+++ b/e2e-pw/src/oss/specs/smoke-tests/quickstart-groups.spec.ts
@@ -20,8 +20,8 @@ const test = base.extend<{
   modal: async ({ page }, use) => {
     await use(new ModalPom(page));
   },
-  sidebar: async ({ page, eventUtils }, use) => {
-    await use(new SidebarPom(page, eventUtils));
+  sidebar: async ({ page }, use) => {
+    await use(new SidebarPom(page));
   },
 });
 

--- a/e2e-pw/src/oss/specs/smoke-tests/tagger.spec.ts
+++ b/e2e-pw/src/oss/specs/smoke-tests/tagger.spec.ts
@@ -22,8 +22,8 @@ const test = base.extend<{
   grid: async ({ page, eventUtils }, use) => {
     await use(new GridPom(page, eventUtils));
   },
-  gridActionsRow: async ({ page }, use) => {
-    await use(new GridActionsRowPom(page));
+  gridActionsRow: async ({ page, eventUtils }, use) => {
+    await use(new GridActionsRowPom(page, eventUtils));
   },
 });
 


### PR DESCRIPTION
We have added a lot poms and specs recently 🚀 . Proposing we add a lint stage to `e2e` to catch changes to poms, etc. I find myself tweaking constructors and methods a lot, so I think it's good to have the automation catch these changes so specs don't fall behind