### PR TITLE
Only process instance masks with width and height

### DIFF
--- a/app/packages/looker/src/overlays/detection.ts
+++ b/app/packages/looker/src/overlays/detection.ts
@@ -43,6 +43,11 @@ export default class DetectionOverlay<
 
     if (this.label.mask) {
       const [height, width] = this.label.mask.data.shape;
+
+      if (!height || !width) {
+        return;
+      }
+
       this.canvas = document.createElement("canvas");
       this.canvas.width = width;
       this.canvas.height = height;


### PR DESCRIPTION
Closes #1750 

It is already the case that segmentation and heatmap overlays safely avoid processing image data without defined dimensions, but instance masks are missing this check.

Without this check, users have been encountering the this error when their browser is creating the mask `ImageData`
```
Uncaught DOMException: Failed to construct 'ImageData': The source width is zero or not a number
```