### PR TITLE
Fix issue with empty segmentations in coco

### DIFF
--- a/fiftyone/utils/coco.py
+++ b/fiftyone/utils/coco.py
@@ -2159,6 +2159,8 @@ def _coco_segmentation_to_mask(segmentation, bbox, frame_size):
     if isinstance(segmentation, list):
         # Polygon -- a single object might consist of multiple parts, so merge
         # all parts into one mask RLE code
+        if sum(len(seg) for seg in segmentation) == 0:
+            return None
         rle = mask_utils.merge(
             mask_utils.frPyObjects(segmentation, height, width)
         )


### PR DESCRIPTION
## What changes are proposed in this pull request?
This fixes the issue when the segmentation list is empty - e.g. cases with annotation.json containing:

```json
{
         "id":7,
         "image_id":9,
         "category_id":1,
         "segmentation":[
            [
               
            ]
         ],
         "area":0,
         "bbox":[
            503.3053894042969,
            3167.2109375,
            49.400482177734375,
            119.207763671875
         ],
         "iscrowd":0,
      },
```

## How is this patch tested? If it is not, please explain why.
Pre-fix the dataset loader errors with pycocotools not knowing how to handle this type of segmentation.

```
  File "/home/bot/.local/lib/python3.10/site-packages/fiftyone/utils/coco.py", line 2149, in _coco_segmentation_to_mask
    rle = mask_utils.merge(mask_utils.frPyObjects(segmentation, height, width))
  File "pycocotools/_mask.pyx", line 308, in pycocotools._mask.frPyObjects
Exception: input type is not supported.
```

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
