### PR TITLE
update Actions versions to reduce error noise

### DIFF
--- a/.github/workflows/build-db.yml
+++ b/.github/workflows/build-db.yml
@@ -25,7 +25,7 @@ jobs:
           - win-amd64
     steps:
       - name: Clone fiftyone
-        uses: actions/checkout@v1
+        uses: actions/checkout@v4
       - name: Set up Python 3.9
         uses: actions/setup-python@v4
         with:
@@ -78,7 +78,7 @@ jobs:
           cd package/db
           python setup.py bdist_wheel --plat-name linux-x86_64
       - name: Upload wheel(s)
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: wheel-${{ matrix.platform }}
           path: package/db/dist/*.whl
@@ -90,9 +90,9 @@ jobs:
       FIFTYONE_DO_NOT_TRACK: true
     steps:
       - name: Clone fiftyone
-        uses: actions/checkout@v1
+        uses: actions/checkout@v4
       - name: Download fiftyone-db wheel
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: wheel-linux-x86_64
           path: downloads
@@ -113,7 +113,7 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/db-v')
     steps:
       - name: Download wheels
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           path: downloads
       - name: Install dependencies

--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -24,7 +24,7 @@ jobs:
           - win-amd64
     steps:
       - name: Clone fiftyone
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           submodules: true
       - name: Set up Python 3.8
@@ -72,7 +72,7 @@ jobs:
         working-directory: package/desktop
         run: python setup.py bdist_wheel --plat-name ${{ matrix.platform }}
       - name: Upload wheel
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: wheel-${{ matrix.platform }}
           path: package/desktop/dist/*.whl
@@ -83,7 +83,7 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/desktop-v')
     steps:
       - name: Download wheels
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           path: downloads
       - name: Install dependencies

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -43,9 +43,9 @@ jobs:
       FIFTYONE_DO_NOT_TRACK: true
     steps:
       - name: Clone fiftyone
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Checkout fiftyone-teams
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: voxel51/fiftyone-teams
           path: fiftyone-teams
@@ -87,7 +87,7 @@ jobs:
         run: |
           ./docs/generate_docs.bash -t fiftyone-teams
       - name: Upload docs
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: docs
           path: docs/build/html/
@@ -98,7 +98,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Download docs
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: docs
           path: docs-download/

--- a/.github/workflows/build-graphql.yml
+++ b/.github/workflows/build-graphql.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Clone fiftyone
-        uses: actions/checkout@v1
+        uses: actions/checkout@v4
       - name: Set up Python 3.9
         uses: actions/setup-python@v4
         with:
@@ -34,7 +34,7 @@ jobs:
           cd package/graphql
           python setup.py sdist bdist_wheel
       - name: Upload wheel(s)
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: dist
           path: package/graphql/dist/*
@@ -45,7 +45,7 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/db-v')
     steps:
       - name: Download wheels
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           path: downloads
       - name: Install dependencies

--- a/.github/workflows/build-graphql.yml
+++ b/.github/workflows/build-graphql.yml
@@ -41,7 +41,7 @@ jobs:
 
   publish:
     runs-on: ubuntu-20.04
-    needs: [build, test]
+    needs: [build]
     if: startsWith(github.ref, 'refs/tags/db-v')
     steps:
       - name: Download wheels

--- a/.github/workflows/build-graphql.yml
+++ b/.github/workflows/build-graphql.yml
@@ -4,10 +4,10 @@ on:
   push:
     tags:
       - graphql-v*
-  pull_request:
-    paths:
-      - package/graphql/**
-      - .github/workflows/build-graphql.yml
+  # pull_request:
+  #   paths:
+  #     - package/graphql/**
+  #     - .github/workflows/build-graphql.yml
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ jobs:
     outputs:
       changes: ${{ steps.filter.outputs.changes }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: dorny/paths-filter@v2
         id: filter
         with:
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Clone fiftyone
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           submodules: true
       - name: Set up Python 3.8
@@ -56,7 +56,7 @@ jobs:
       - name: Build python
         run: make python -o app
       - name: Upload dist
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: dist
           path: dist/

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -15,7 +15,7 @@ jobs:
         shell: bash
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: true
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -46,16 +46,16 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Clone fiftyone
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Download dist
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: dist
           path: dist
       - name: docker
         run: make docker-export -o python
       - name: Upload image
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: docker-image
           path: fiftyone.tar.gz

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Cache
         id: node-cache
         uses: actions/cache@v3
@@ -51,7 +51,7 @@ jobs:
         shell: bash
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Setup
         uses: actions/setup-python@v4
         id: pip-cache


### PR DESCRIPTION
There are a lot of unnecessary warnings in the GitHub Actions logs related to actions that are out of date:

![Screenshot 2023-09-25 at 11 55 35 AM](https://github.com/voxel51/fiftyone/assets/6401385/82274e72-7e52-4b16-85be-5a445709b57b)

Bumping the actions versions to eliminate those.