### PR TITLE
Update Playwright .env.dev.template

### DIFF
--- a/e2e-pw/.env.dev.template
+++ b/e2e-pw/.env.dev.template
@@ -1,6 +1,4 @@
-export PYTHONPATH=/Users/johndoe/code/fiftyone
-export VENV_PATH=/Users/johndoe/fiftyone/venvs/oss
-
 export FIFTYONE_DATABASE_NAME=playwright
-
+export FIFTYONE_ROOT_DIR=/Users/johndoe/code/fiftyone
 export USE_DEV_BUILD=true
+export VENV_PATH=/Users/johndoe/fiftyone/venvs/oss


### PR DESCRIPTION
Updating the playwright `.env.dev.template` to us `FIFTYONE_ROOT_DIR`, which has replaced `PYTHONPATH`