### PR TITLE
Visualize primitives nested under list of EmbeddedDocuments

### DIFF
--- a/app/packages/looker/src/elements/common/tags.test.ts
+++ b/app/packages/looker/src/elements/common/tags.test.ts
@@ -52,23 +52,32 @@ const TEST_SCHEMA = {
         subfield: null,
         path: "test.str_field",
       },
+      str_list_field: {
+        dbField: "str_list_field",
+        description: null,
+        embeddedDocType: null,
+        fields: {},
+        ftype: "fiftyone.core.fields.ListField",
+        info: null,
+        name: "str_list_field",
+        path: "test.str_list_field",
+        subfield: "fiftyone.core.fields.StringField",
+      },
       predictions_field: {
         dbField: "predictions_field",
         description: null,
         embeddedDocType: "fiftyone.core.labels.Detection",
-        fields: [
-          {
-            dbField: "detections",
-            description: null,
-            embeddedDocType: null,
-            fields: [],
-            ftype: "fiftyone.core.fields.ListField",
-            info: null,
-            name: "detections",
-            subfield: "fiftyone.core.fields.EmbeddedDocumentField",
-            path: "ground_truth.detections",
-          },
-        ],
+        fields: {
+          dbField: "detections",
+          description: null,
+          embeddedDocType: null,
+          fields: [],
+          ftype: "fiftyone.core.fields.ListField",
+          info: null,
+          name: "detections",
+          subfield: "fiftyone.core.fields.EmbeddedDocumentField",
+          path: "ground_truth.detections",
+        },
         ftype: "fiftyone.core.fields.EmbeddedDocumentField",
         info: null,
         name: "predictions_field",
@@ -86,19 +95,17 @@ const TEST_SCHEMA = {
     dbField: "predictions",
     description: null,
     embeddedDocType: "fiftyone.core.labels.Detection",
-    fields: [
-      {
-        dbField: "detections",
-        description: null,
-        embeddedDocType: null,
-        fields: [],
-        ftype: "fiftyone.core.fields.ListField",
-        info: null,
-        name: "detections",
-        subfield: "fiftyone.core.fields.EmbeddedDocumentField",
-        path: "ground_truth.detections",
-      },
-    ],
+    fields: {
+      dbField: "detections",
+      description: null,
+      embeddedDocType: null,
+      fields: [],
+      ftype: "fiftyone.core.fields.ListField",
+      info: null,
+      name: "detections",
+      subfield: "fiftyone.core.fields.EmbeddedDocumentField",
+      path: "ground_truth.detections",
+    },
     ftype: "fiftyone.core.fields.EmbeddedDocumentField",
     info: null,
     name: "predictions",
@@ -145,5 +152,14 @@ describe(`
       "test.predictions"
     );
     expect(resultField).toBeNull();
+  });
+
+  it("nested primitive list in a list of embedded document return correct field:values", () => {
+    const [resultField, _] = getFieldAndValue(
+      TEST_SAMPLE,
+      TEST_SCHEMA,
+      "test.str_list_field"
+    );
+    expect(resultField.name).toEqual("str_list_field");
   });
 });

--- a/app/packages/looker/src/elements/common/tags.test.ts
+++ b/app/packages/looker/src/elements/common/tags.test.ts
@@ -1,0 +1,149 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { getFieldAndValue } from "./tags";
+
+const TEST_SAMPLE = {
+  metadata: {
+    width: 0,
+    height: 0,
+  },
+  _id: "1",
+  filepath: "/path",
+  tags: ["foo"],
+  _label_tags: ["bar"],
+  _media_type: "image" as const,
+};
+
+const TEST_SCHEMA = {
+  filepath: {
+    dbField: "filepath",
+    description: null,
+    embeddedDocType: null,
+    fields: [],
+    ftype: "fiftyone.core.fields.StringField",
+    info: null,
+    name: "filepath",
+    path: "filepath",
+    subfield: null,
+  },
+  test: {
+    dbField: "test",
+    description: null,
+    embeddedDocType: null,
+    fields: {
+      int_field: {
+        dbField: "int_field",
+        description: null,
+        embeddedDocType: null,
+        fields: [],
+        ftype: "fiftyone.core.fields.IntField",
+        info: null,
+        name: "int_field",
+        subfield: null,
+        path: "test.int_field",
+      },
+      str_field: {
+        dbField: "str_field",
+        description: null,
+        embeddedDocType: null,
+        fields: [],
+        ftype: "fiftyone.core.fields.StringField",
+        info: null,
+        name: "str_field",
+        subfield: null,
+        path: "test.str_field",
+      },
+      predictions_field: {
+        dbField: "predictions_field",
+        description: null,
+        embeddedDocType: "fiftyone.core.labels.Detection",
+        fields: [
+          {
+            dbField: "detections",
+            description: null,
+            embeddedDocType: null,
+            fields: [],
+            ftype: "fiftyone.core.fields.ListField",
+            info: null,
+            name: "detections",
+            subfield: "fiftyone.core.fields.EmbeddedDocumentField",
+            path: "ground_truth.detections",
+          },
+        ],
+        ftype: "fiftyone.core.fields.EmbeddedDocumentField",
+        info: null,
+        name: "predictions_field",
+        subfield: null,
+        path: "test.predictions_field",
+      },
+    },
+    ftype: "fiftyone.core.fields.ListField",
+    info: null,
+    name: "test",
+    subfield: "fiftyone.core.fields.EmbeddedDocumentField",
+    path: "test",
+  },
+  predictions: {
+    dbField: "predictions",
+    description: null,
+    embeddedDocType: "fiftyone.core.labels.Detection",
+    fields: [
+      {
+        dbField: "detections",
+        description: null,
+        embeddedDocType: null,
+        fields: [],
+        ftype: "fiftyone.core.fields.ListField",
+        info: null,
+        name: "detections",
+        subfield: "fiftyone.core.fields.EmbeddedDocumentField",
+        path: "ground_truth.detections",
+      },
+    ],
+    ftype: "fiftyone.core.fields.EmbeddedDocumentField",
+    info: null,
+    name: "predictions",
+    subfield: null,
+    path: "predictions",
+  },
+};
+
+describe(`
+  getFieldAndValue works
+`, () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("filepath field returns correct field and value", () => {
+    const res = getFieldAndValue(TEST_SAMPLE, TEST_SCHEMA, "filepath");
+    expect(res[0].name).toEqual("filepath");
+    expect(res[1]).toContain("/path");
+  });
+
+  it("nested primitive in a list of embedded document return correct field:values", () => {
+    // top level test (LIST<EmbeddedDocument{int_field, str_field}>)
+    let [resultField, _] = getFieldAndValue(TEST_SAMPLE, TEST_SCHEMA, "test");
+    expect(resultField).toBeNull();
+
+    [resultField, _] = getFieldAndValue(
+      TEST_SAMPLE,
+      TEST_SCHEMA,
+      "test.int_field"
+    );
+    expect(resultField.name).toEqual("int_field");
+
+    [resultField, _] = getFieldAndValue(
+      TEST_SAMPLE,
+      TEST_SCHEMA,
+      "predictions"
+    );
+    expect(resultField.name).toBe("predictions");
+
+    [resultField, _] = getFieldAndValue(
+      TEST_SAMPLE,
+      TEST_SCHEMA,
+      "test.predictions"
+    );
+    expect(resultField).toBeNull();
+  });
+});

--- a/app/packages/looker/src/elements/common/tags.ts
+++ b/app/packages/looker/src/elements/common/tags.ts
@@ -524,7 +524,11 @@ export const getFieldAndValue = (
       // single-level nested primitives in a list of dynamic documents can be visualized
       if (Object.keys(field.fields).length) {
         for (const value of Object.values(field.fields)) {
-          if (
+          if (value["path"] === path && value.ftype === LIST_FIELD) {
+            if (!VALID_PRIMITIVE_TYPES.includes(value.subfield)) {
+              return [null, null];
+            }
+          } else if (
             value["path"] === path &&
             !VALID_PRIMITIVE_TYPES.includes(value.ftype)
           ) {

--- a/app/packages/looker/src/elements/common/tags.ts
+++ b/app/packages/looker/src/elements/common/tags.ts
@@ -486,7 +486,7 @@ const unwind = (
   }
 };
 
-const getFieldAndValue = (
+export const getFieldAndValue = (
   sample: Sample,
   schema: Schema,
   path: string
@@ -517,16 +517,22 @@ const getFieldAndValue = (
       field.ftype === LIST_FIELD &&
       field.subfield === EMBEDDED_DOCUMENT_FIELD
     ) {
+      if (path === field.name) {
+        return [null, null];
+      }
+
       // single-level nested primitives in a list of dynamic documents can be visualized
       if (Object.keys(field.fields).length) {
-        for (const [innerField, value] of Object.entries(field.fields)) {
+        for (const value of Object.values(field.fields)) {
           if (
-            innerField === path &&
+            value["path"] === path &&
             !VALID_PRIMITIVE_TYPES.includes(value.ftype)
           ) {
             return [null, null];
           }
         }
+      } else {
+        return [null, null];
       }
     }
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

- Primitives under a list of dynamic documents were not rendering because we are filtering everything out.
- [x] Fix is to be more selective when filtering in getFieldAndValue() and allow primitives to go through
- [x] unit test getFieldAndValue -> new logic

After fix

https://github.com/voxel51/fiftyone/assets/109545780/4dadeb0e-e8f3-4c75-88ae-28861f4ccafc

After fix with list of primitives


Uploading Screen Recording 2023-09-26 at 10.56.15 AM.mov…



With unit test

https://github.com/voxel51/fiftyone/assets/109545780/c16e7a37-1c48-45b5-8317-0a83ecd3d5d5





## How is this patch tested? If it is not, please explain why.

(Details)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
