### PR TITLE
Fix coco polygon with 4 points

### DIFF
--- a/fiftyone/utils/coco.py
+++ b/fiftyone/utils/coco.py
@@ -2159,7 +2159,17 @@ def _coco_segmentation_to_mask(segmentation, bbox, frame_size):
     if isinstance(segmentation, list):
         # Polygon -- a single object might consist of multiple parts, so merge
         # all parts into one mask RLE code
-        if sum(len(seg) for seg in segmentation) == 0:
+        # Filter out empty lists. For polygons of 4 points (1 pixel), duplicate
+        # to convert to valid polygon.
+        new_segmentation = []
+        for seg in segmentation:
+            if len(seg) == 0:
+                continue
+            if len(seg) == 4:
+                seg = seg * 4
+            new_segmentation.append(seg)
+        segmentation = new_segmentation
+        if len(segmentation) == 0:
             return None
         rle = mask_utils.merge(
             mask_utils.frPyObjects(segmentation, height, width)


### PR DESCRIPTION
## What changes are proposed in this pull request?

There are two types of invalid polygons - empty polygons and ones covering a single pixel, which can be made full by completing them. This allows for other corner cases to be later added.

## How is this patch tested? If it is not, please explain why.

After the patch, polygons with 4 values are correctly accepted.

Previously:
```bash
  File "/home/bot/.local/lib/python3.10/site-packages/fiftyone/utils/coco.py", line 1088, in to_detection
    mask = _coco_segmentation_to_mask(self.segmentation, self.bbox, frame_size)
  File "/home/bot/.local/lib/python3.10/site-packages/fiftyone/utils/coco.py", line 2156, in _coco_segmentation_to_mask
    rle = mask_utils.merge(mask_utils.frPyObjects(segmentation, height, width))
  File "pycocotools/_mask.pyx", line 294, in pycocotools._mask.frPyObjects
TypeError: Argument 'bb' has incorrect type (expected numpy.ndarray, got list)
```

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
