### PR TITLE
improve read-only mode

### DIFF
--- a/app/packages/components/src/components/PillButton/PillButton.tsx
+++ b/app/packages/components/src/components/PillButton/PillButton.tsx
@@ -38,7 +38,6 @@ const PillButton = React.forwardRef<HTMLButtonElement, PillButtonProps>(
         id={id}
         ref={ref}
         style={{ ...baseStyles, ...style }}
-        title={title}
       >
         {text && <span>{text}</span>}
         {icon}

--- a/app/packages/components/src/components/Selection/Option.tsx
+++ b/app/packages/components/src/components/Selection/Option.tsx
@@ -3,8 +3,7 @@ import React from "react";
 import styled from "styled-components";
 import { useHover } from "@fiftyone/state";
 import { Edit, Check } from "@mui/icons-material";
-import { useTheme } from "@fiftyone/components";
-import * as fos from "@fiftyone/state";
+import { IconButton, useTheme } from "@fiftyone/components";
 
 const Box = styled.div`
   display: flex;
@@ -73,31 +72,43 @@ export default function SelectionOption(props: Props) {
         <TextContainer>{label}</TextContainer>
       </Box>
       <Box style={{ width: "18%" }}>
-        {!readonly && (isHovered || isSelected) && (
+        {(isHovered || isSelected) && (
           <EditBox>
             <Box>
               {isHovered && item.id !== "1" && (
-                <Edit
-                  data-cy="btn-edit-selection"
-                  fontSize="small"
-                  sx={{
-                    color: theme.neutral[400],
-                    zIndex: "9999",
-                    marginRight: isSelected ? "0.5rem" : "0",
+                <IconButton
+                  title={
+                    readonly ? "Can not edit in read-only mode" : undefined
+                  }
+                  disableRipple
+                >
+                  <Edit
+                    data-cy="btn-edit-selection"
+                    fontSize="small"
+                    sx={{
+                      color: readonly
+                        ? theme.text.disabled
+                        : theme.text.secondary,
+                      zIndex: "9999",
+                      marginRight: isSelected ? "0.5rem" : "0",
 
-                    "&:hover": {
-                      color: theme.text.primary,
-                    },
-                  }}
-                  onClick={(e: React.MouseEvent) => {
-                    e.stopPropagation();
-                    e.preventDefault();
+                      "&:hover": {
+                        color: readonly
+                          ? theme.text.disabled
+                          : theme.text.primary,
+                      },
+                      cursor: readonly ? "not-allowed" : "inherit",
+                    }}
+                    onClick={(e: React.MouseEvent) => {
+                      e.stopPropagation();
+                      e.preventDefault();
 
-                    if (onEdit) {
-                      onEdit(item);
-                    }
-                  }}
-                />
+                      if (onEdit && !readonly) {
+                        onEdit(item);
+                      }
+                    }}
+                  />
+                </IconButton>
               )}
               {isSelected && (
                 <Check

--- a/app/packages/core/src/components/Actions/ActionsRow.tsx
+++ b/app/packages/core/src/components/Actions/ActionsRow.tsx
@@ -164,6 +164,7 @@ const Tag = ({
   const [available, setAvailable] = useState(true);
   const labels = useRecoilValue(fos.selectedLabelIds);
   const samples = useRecoilValue(fos.selectedSamples);
+  const readOnly = useRecoilValue(fos.readOnly);
 
   const selected = labels.size > 0 || samples.size > 0;
   const tagging = useRecoilValue(fos.anyTagging);
@@ -180,15 +181,26 @@ const Tag = ({
   lookerRef &&
     useEventHandler(lookerRef.current, "pause", () => setAvailable(true));
 
+  const baseTitle = `Tag sample${modal ? "" : "s"} or labels`;
+  const title = readOnly
+    ? `Can not ${baseTitle.toLowerCase()} in read-only mode.`
+    : baseTitle;
+
   return (
     <ActionDiv ref={ref}>
       <PillButton
-        style={{ cursor: disabled || !available ? "default" : "pointer" }}
+        style={{
+          cursor: readOnly
+            ? "not-allowed"
+            : disabled || !available
+            ? "default"
+            : "pointer",
+        }}
         icon={disabled ? <Loading /> : <LocalOffer />}
         open={open}
-        onClick={() => !disabled && available && setOpen(!open)}
+        onClick={() => !disabled && available && !readOnly && setOpen(!open)}
         highlight={(selected || open) && available}
-        title={`Tag sample${modal ? "" : "s"} or labels`}
+        title={title}
         data-cy="action-tag-sample-labels"
       />
       {open && available && (
@@ -458,7 +470,6 @@ export const BrowseOperations = () => {
 };
 
 export const GridActionsRow = () => {
-  const hideTagging = useRecoilValue(fos.readOnly);
   const datasetColorScheme = useRecoilValue(fos.datasetAppConfig)?.colorScheme;
   const setSessionColor = useSetRecoilState(fos.sessionColorScheme);
   const isUsingSessionColorScheme = useRecoilValue(
@@ -516,7 +527,7 @@ export const GridActionsRow = () => {
     >
       <ToggleSidebar modal={false} />
       <Colors />
-      {hideTagging ? null : <Tag modal={false} />}
+      <Tag modal={false} />
       <Patches />
       <Similarity modal={false} />
       <SaveFilters />
@@ -537,8 +548,6 @@ export const ModalActionsRow = ({
   lookerRef?: MutableRefObject<fos.Lookers | undefined>;
   isGroup?: boolean;
 }) => {
-  const hideTagging = useRecoilValue(fos.readOnly);
-
   return (
     <ActionsRowDiv
       style={{
@@ -550,7 +559,7 @@ export const ModalActionsRow = ({
       <Selected modal={true} lookerRef={lookerRef} />
       <Colors />
       <Similarity modal={true} />
-      {!hideTagging && <Tag modal={true} lookerRef={lookerRef} />}
+      <Tag modal={true} lookerRef={lookerRef} />
       <Options modal={true} />
       {isGroup && <GroupMediaVisibilityContainer modal={true} />}
       <OperatorPlacements place={types.Places.SAMPLES_VIEWER_ACTIONS} />

--- a/app/packages/core/src/components/Actions/similar/Similar.tsx
+++ b/app/packages/core/src/components/Actions/similar/Similar.tsx
@@ -278,20 +278,22 @@ const SortBySimilarity = ({
               setValue={(brainKey) => onChangeBrainKey(brainKey)}
             />
           </div>
-          {!isReadOnly && (
-            <>
-              Optional: store the distance between each sample and the query in
-              this field
-              <Input
-                placeholder={"dist_field (default = None)"}
-                validator={(value) => !value.startsWith("_")}
-                value={state.distField ?? ""}
-                setter={(value) =>
-                  updateState({ distField: !value.length ? undefined : value })
-                }
-              />
-            </>
-          )}
+          Optional: store the distance between each sample and the query in this
+          field
+          <Input
+            disabled={isReadOnly}
+            placeholder={"dist_field (default = None)"}
+            validator={(value) => !value.startsWith("_")}
+            value={state.distField ?? ""}
+            setter={(value) =>
+              updateState({ distField: !value.length ? undefined : value })
+            }
+            title={
+              isReadOnly
+                ? "Can not store the distance in a field in read-only mode"
+                : undefined
+            }
+          />
         </div>
       )}
     </Popout>

--- a/app/packages/core/src/components/ColorModal/ColorFooter.tsx
+++ b/app/packages/core/src/components/ColorModal/ColorFooter.tsx
@@ -7,13 +7,8 @@ import {
   useSetRecoilState,
 } from "recoil";
 
-import { Button } from "../utils";
-import {
-  BUTTON_STYLE,
-  ButtonGroup,
-  LONG_BUTTON_STYLE,
-  ModalActionButtonContainer,
-} from "./ShareStyledDiv";
+import { Button } from "@fiftyone/components";
+import { ButtonGroup, ModalActionButtonContainer } from "./ShareStyledDiv";
 import { isDefaultSetting } from "./utils";
 
 // this reset is used to trigger a sync of local state input with the session color values
@@ -52,37 +47,41 @@ const ColorFooter: React.FC = () => {
 
   return (
     <ModalActionButtonContainer>
-      <ButtonGroup>
+      <ButtonGroup style={{ marginRight: "4px" }}>
         <Button
-          text={"Reset"}
           title={`Clear session settings and revert to default settings`}
           onClick={() => {
             setColorScheme(false, isTeams ? datasetDefault : null);
             setReset((prev) => prev + 1);
           }}
-          style={BUTTON_STYLE}
-        />
-        {canEdit && (
+        >
+          Reset
+        </Button>
+        <Button
+          title={
+            canEdit
+              ? `Save to dataset appConfig`
+              : "Can not save to dataset appConfig in read-only mode"
+          }
+          onClick={() => {
+            setColorScheme(true, colorScheme);
+            setActiveColorModalField(null);
+          }}
+          disabled={!canEdit}
+        >
+          Save as default
+        </Button>
+        {hasSavedSettings && (
           <Button
-            text={"Save as default"}
-            title={`Save to dataset appConfig`}
-            onClick={() => {
-              setColorScheme(true, colorScheme);
-              setActiveColorModalField(null);
-            }}
-            style={LONG_BUTTON_STYLE}
-          />
-        )}
-        {canEdit && hasSavedSettings && (
-          <Button
-            text={"Clear default"}
-            title={`Clear`}
+            title={canEdit ? "Clear" : "Can not clear in read-only mode"}
             onClick={() => {
               setColorScheme(true, null);
               setReset((prev) => prev + 1);
             }}
-            style={LONG_BUTTON_STYLE}
-          />
+            disabled={!canEdit}
+          >
+            Clear default
+          </Button>
         )}
       </ButtonGroup>
     </ModalActionButtonContainer>

--- a/app/packages/core/src/components/ColorModal/ShareStyledDiv.ts
+++ b/app/packages/core/src/components/ColorModal/ShareStyledDiv.ts
@@ -72,6 +72,7 @@ export const Text = styled.div`
 export const ButtonGroup = styled.div`
   display: flex;
   flex-direction: row;
+  gap: 8px;
 `;
 
 export const ActionDiv = styled.div`

--- a/app/packages/core/src/components/Common/Input.tsx
+++ b/app/packages/core/src/components/Common/Input.tsx
@@ -44,6 +44,7 @@ interface InputProps {
   onBlur?: () => void;
   onKeyDown?: (event: React.KeyboardEvent<HTMLInputElement>) => void;
   style?: React.CSSProperties;
+  title?: string;
 }
 
 const Input = React.memo(
@@ -61,6 +62,7 @@ const Input = React.memo(
         onBlur,
         onKeyDown,
         style,
+        title,
       }: InputProps,
       ref
     ) => {
@@ -87,12 +89,17 @@ const Input = React.memo(
               e.key === "Escape" && e.currentTarget.blur();
               onKeyDown && onKeyDown(e);
             }}
-            style={disabled ? { color: theme.text.secondary } : {}}
+            style={
+              disabled
+                ? { color: theme.text.secondary, cursor: "not-allowed" }
+                : {}
+            }
             disabled={disabled}
             onFocus={(_: React.FocusEvent<HTMLInputElement>) => {
               onFocus && onFocus();
             }}
             onBlur={onBlur}
+            title={title}
           />
         </StyledInputContainer>
       );

--- a/app/packages/core/src/components/Sidebar/Entries/Draggable.tsx
+++ b/app/packages/core/src/components/Sidebar/Entries/Draggable.tsx
@@ -85,8 +85,15 @@ const Draggable: React.FC<
           boxShadow: `0 2px 20px ${theme.custom.shadow}`,
           overflow: "hidden",
           ...style,
+          ...(isReadOnly ? { cursor: "not-allowed" } : {}),
         }}
-        title={trigger ? "Drag to reorder" : null}
+        title={
+          isReadOnly
+            ? "Can not reorder in read-only mode"
+            : trigger
+            ? "Drag to reorder"
+            : undefined
+        }
       >
         {active && <DragIndicator style={{ color: theme.background.level1 }} />}
       </animated.div>

--- a/app/packages/core/src/components/Sidebar/ViewSelection/index.tsx
+++ b/app/packages/core/src/components/Sidebar/ViewSelection/index.tsx
@@ -250,6 +250,11 @@ export default function ViewSelection() {
               data-cy={`saved-views-create-new`}
               onClick={() => canEdit && !isEmptyView && setIsOpen(true)}
               disabled={isEmptyView || !canEdit}
+              title={
+                canEdit
+                  ? undefined
+                  : "Can not save filters as a view in read-only mode"
+              }
             >
               <Box style={{ width: "12%" }}>
                 <AddIcon fontSize="small" disabled={isEmptyView || !canEdit} />


### PR DESCRIPTION
## What changes are proposed in this pull request?

Previously, when viewing the app in the read-only mode, action buttons and triggers would be hidden which caused some confusion to users. However, with the changes in this PR, buttons and triggers will be always displayed and will be disabled with an explanation in a tooltip.

Flows affected:
- Creating a saved view
- Editing a saved view
- Saving colour configuration as default
- Clearing saved colour settings
- Tagging
- Storing similarity distance in a field
- Dragging sidebar item

## How is this patch tested? If it is not, please explain why.

(Details)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
