### PR TITLE
Only run one delegated operation at a time

### DIFF
--- a/fiftyone/core/cli.py
+++ b/fiftyone/core/cli.py
@@ -2800,8 +2800,8 @@ def _launch_delegated_local():
         print("Delegated operation service running")
         print("\nTo exit, press ctrl + c")
         while True:
-            dos.execute_queued_operations(log=True)
-            time.sleep(1)
+            dos.execute_queued_operations(limit=1, log=True)
+            time.sleep(0.5)
     except KeyboardInterrupt:
         pass
 


### PR DESCRIPTION
Updating the `fiftyone delegated launch` command to only run one operation at a time.

This is functionality equivalent to the previous implementation (with a small delay between consecutive jobs) but is more parallel-friendly. Previously if a new service were launched while the first service was halfway through a batch of queued runs, the new service would start executing the same jobs and the original service would not realize that they are no longer in queued and re-execute them.