### PR TITLE
Color by instance

### DIFF
--- a/app/packages/components/src/components/Popout/index.tsx
+++ b/app/packages/components/src/components/Popout/index.tsx
@@ -2,6 +2,8 @@ import { useSpring } from "@react-spring/web";
 import React, { PropsWithChildren } from "react";
 import PopoutDiv from "./PopoutDiv";
 
+export { PopoutDiv };
+
 export type PopoutProps = PropsWithChildren<{
   style?: any;
   modal?: boolean;

--- a/app/packages/components/src/components/index.ts
+++ b/app/packages/components/src/components/index.ts
@@ -14,7 +14,7 @@ export { default as Link } from "./Link";
 export { default as Loading, LoadingDots } from "./Loading";
 export { default as Pending } from "./Pending";
 export { default as PillButton } from "./PillButton";
-export { default as Popout } from "./Popout";
+export { default as Popout, PopoutDiv } from "./Popout";
 export { default as PopoutSectionTitle } from "./PopoutSectionTitle";
 export { default as Selection } from "./Selection";
 export { default as Selector } from "./Selector";

--- a/app/packages/core/src/components/ColorModal/FieldSetting.tsx
+++ b/app/packages/core/src/components/ColorModal/FieldSetting.tsx
@@ -307,6 +307,9 @@ const FieldSetting = ({ path }: { path: string }) => {
       {coloring.by == "value" && !isTypeValueSupported && (
         <div>Color by value is not supported for this field type</div>
       )}
+      {coloring.by == "instance" && (
+        <div>Cannot customize settings under color by instance mode</div>
+      )}
     </div>
   );
 };

--- a/app/packages/core/src/components/ColorModal/FieldSetting.tsx
+++ b/app/packages/core/src/components/ColorModal/FieldSetting.tsx
@@ -4,6 +4,7 @@ import * as fos from "@fiftyone/state";
 import {
   FLOAT_FIELD,
   NOT_VISIBLE_LIST,
+  SEGMENTATION,
   VALID_MASK_TYPES,
 } from "@fiftyone/utilities";
 import { Divider } from "@mui/material";

--- a/app/packages/core/src/components/ColorModal/GlobalSetting.tsx
+++ b/app/packages/core/src/components/ColorModal/GlobalSetting.tsx
@@ -22,11 +22,12 @@ const GlobalSetting = () => {
         <LabelTitle>Color annotations by</LabelTitle>
         <SectionWrapper data-cy="colorBy-controls">
           <RadioGroup
-            choices={["field", "value"]}
+            choices={["field", "value", "instance"]}
             value={colorScheme.colorBy ?? "field"}
             setValue={(mode) =>
               setColorScheme({ ...colorScheme, colorBy: mode })
             }
+            horizontal
           />
         </SectionWrapper>
         <ShuffleColor />

--- a/app/packages/core/src/components/ColorModal/controls/ModeControl.tsx
+++ b/app/packages/core/src/components/ColorModal/controls/ModeControl.tsx
@@ -1,5 +1,4 @@
-import { useTheme } from "@fiftyone/components/src/components";
-import PopoutDiv from "@fiftyone/components/src/components/Popout/PopoutDiv";
+import { PopoutDiv, useTheme } from "@fiftyone/components";
 import * as fos from "@fiftyone/state";
 import KeyboardArrowDownOutlinedIcon from "@mui/icons-material/KeyboardArrowDownOutlined";
 import KeyboardArrowUpOutlinedIcon from "@mui/icons-material/KeyboardArrowUpOutlined";

--- a/app/packages/core/src/components/ColorModal/controls/ModeControl.tsx
+++ b/app/packages/core/src/components/ColorModal/controls/ModeControl.tsx
@@ -22,31 +22,31 @@ const Controls = styled.div`
   flex-direction: row;
 `;
 
+const SelectButton = styled.div`
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.25rem;
+  margin: 0.25rem;
+  background-color: ${({ theme }) => theme.background.level3};
+`;
+
+const Option = styled.div`
+  cursor: pointer;
+  padding-left: 0.25rem;
+  background-color: ${({ theme }) => theme.background.secondary};
+  &:hover {
+    background-color: ${({ theme }) => theme.primary.main};
+  }
+`;
+
 const ModeControl: React.FC = () => {
   const [colorScheme, setColorScheme] = useRecoilState(fos.colorScheme);
   const [open, setOpen] = React.useState(false);
   const ref = React.useRef<HTMLDivElement>(null);
   fos.useOutsideClick(ref, () => open && setOpen(false));
   const theme = useTheme();
-
-  const SelectButton = styled.div`
-    display: flex;
-    flex-direction: row;
-    justify-content: space-between;
-    align-items: center;
-    padding: 0.25rem;
-    margin: 0.25rem;
-    background-color: ${({ theme }) => theme.background.level3};
-  `;
-
-  const Option = styled.div`
-    cursor: pointer;
-    padding-left: 0.25rem;
-    background-color: ${({ theme }) => theme.background.secondary};
-    &:hover {
-      background-color: ${({ theme }) => theme.primary.main};
-    }
-  `;
 
   const options = ["field", "value", "instance"].map((option) => ({
     value: option,
@@ -60,8 +60,6 @@ const ModeControl: React.FC = () => {
     },
   }));
 
-  const selected = colorScheme.colorBy;
-
   return (
     <ModeControlContainer>
       <Controls ref={ref}>
@@ -71,7 +69,7 @@ const ModeControl: React.FC = () => {
           theme={theme}
           data-cy="custom-colors-select-attribute"
         >
-          <div>{selected}</div>
+          <div>{colorScheme.colorBy}</div>
           {open ? (
             <KeyboardArrowUpOutlinedIcon />
           ) : (
@@ -88,7 +86,9 @@ const ModeControl: React.FC = () => {
             }}
           >
             {options.map((option) => (
-              <Option onClick={option.onClick}>{option.value}</Option>
+              <Option onClick={option.onClick} key={option.value}>
+                {option.value}
+              </Option>
             ))}
           </PopoutDiv>
         )}

--- a/app/packages/core/src/components/ColorModal/controls/ModeControl.tsx
+++ b/app/packages/core/src/components/ColorModal/controls/ModeControl.tsx
@@ -1,8 +1,11 @@
+import { useTheme } from "@fiftyone/components/src/components";
+import PopoutDiv from "@fiftyone/components/src/components/Popout/PopoutDiv";
 import * as fos from "@fiftyone/state";
+import KeyboardArrowDownOutlinedIcon from "@mui/icons-material/KeyboardArrowDownOutlined";
+import KeyboardArrowUpOutlinedIcon from "@mui/icons-material/KeyboardArrowUpOutlined";
 import React from "react";
 import { useRecoilState } from "recoil";
 import styled from "styled-components";
-import { Button } from "../../utils";
 
 export const ModeControlContainer = styled.div`
   display: flex;
@@ -10,37 +13,87 @@ export const ModeControlContainer = styled.div`
   justify-content: flex-end;
   margin-bottom: 0.5rem;
 `;
-
 const Text = styled.div`
   font-size: 1.2rem;
   margin: auto 0.5rem;
 `;
 
+const Controls = styled.div`
+  display: flex;
+  flex-direction: row;
+`;
+
 const ModeControl: React.FC = () => {
   const [colorScheme, setColorScheme] = useRecoilState(fos.colorScheme);
+  const [open, setOpen] = React.useState(false);
+  const ref = React.useRef<HTMLDivElement>(null);
+  fos.useOutsideClick(ref, () => open && setOpen(false));
+  const theme = useTheme();
+
+  const SelectButton = styled.div`
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: center;
+    padding: 0.25rem;
+    margin: 0.25rem;
+    background-color: ${({ theme }) => theme.background.level3};
+  `;
+
+  const Option = styled.div`
+    cursor: pointer;
+    padding-left: 0.25rem;
+    background-color: ${({ theme }) => theme.background.secondary};
+    &:hover {
+      background-color: ${({ theme }) => theme.primary.main};
+    }
+  `;
+
+  const options = ["field", "value", "instance"].map((option) => ({
+    value: option,
+    onClick: (e: React.MouseEvent) => {
+      e.preventDefault();
+      setColorScheme({
+        ...colorScheme,
+        colorBy: option,
+      });
+      setOpen(false);
+    },
+  }));
+
+  const selected = colorScheme.colorBy;
 
   return (
     <ModeControlContainer>
-      <>
+      <Controls ref={ref}>
         <Text>Color by </Text>
-        <Button
-          text={colorScheme.colorBy ?? "field"}
-          data-cy="color-by-toggle"
-          title={`toggle between color by value or color by field mode`}
-          onClick={() =>
-            setColorScheme({
-              ...colorScheme,
-              colorBy: colorScheme.colorBy === "value" ? "field" : "value",
-            })
-          }
-          style={{
-            textAlign: "center",
-            width: 80,
-            display: "inline-block",
-            marginTop: 0,
-          }}
-        />
-      </>
+        <SelectButton
+          onClick={() => setOpen((o) => !o)}
+          theme={theme}
+          data-cy="custom-colors-select-attribute"
+        >
+          <div>{selected}</div>
+          {open ? (
+            <KeyboardArrowUpOutlinedIcon />
+          ) : (
+            <KeyboardArrowDownOutlinedIcon />
+          )}
+        </SelectButton>
+        {open && (
+          <PopoutDiv
+            style={{
+              zIndex: 1000000001,
+              opacity: 1,
+              width: "50%",
+              marginTop: "2rem",
+            }}
+          >
+            {options.map((option) => (
+              <Option onClick={option.onClick}>{option.value}</Option>
+            ))}
+          </PopoutDiv>
+        )}
+      </Controls>
     </ModeControlContainer>
   );
 };

--- a/app/packages/core/src/components/Common/RadioGroup.tsx
+++ b/app/packages/core/src/components/Common/RadioGroup.tsx
@@ -49,12 +49,16 @@ const Radio = React.memo(
     );
   }
 );
-
-const RadioGroupContainer = styled.div`
+type Props = {
+  horizontal: boolean;
+};
+const RadioGroupContainer = styled.div<Props>`
   overflow: auto visible;
   max-height: 165px;
   margin: 0 -0.5rem;
   scrollbar-width: none;
+  display: flex;
+  flex-direction: ${(props) => (props.horizontal ? "row" : "column")};
 
   &::-webkit-scrollbar {
     width: 0px;
@@ -72,10 +76,17 @@ interface RadioGroupProps {
   setValue: (value: string) => void;
   value: string;
   color?: string;
+  horizontal?: boolean;
 }
 
 const RadioGroup = React.memo(
-  ({ choices, color = null, value, setValue }: RadioGroupProps) => {
+  ({
+    choices,
+    color = null,
+    value,
+    setValue,
+    horizontal = false,
+  }: RadioGroupProps) => {
     const theme = useTheme();
     color = color ?? theme.primary.plainColor;
 
@@ -88,7 +99,7 @@ const RadioGroup = React.memo(
     }
 
     return (
-      <RadioGroupContainer>
+      <RadioGroupContainer horizontal={horizontal}>
         {choices.map((choice) => (
           <Radio
             value={choice}

--- a/app/packages/core/src/components/FieldLabelAndInfo/index.tsx
+++ b/app/packages/core/src/components/FieldLabelAndInfo/index.tsx
@@ -341,7 +341,7 @@ const CustomizeColor: React.FunctionComponent<CustomizeColorProp> = ({
           <td>
             <ContentValue>
               Customize colors by{" "}
-              {props.colorBy == "field" ? "field" : "attribute value"}
+              {props.colorBy == "value" ? "attribute value" : props.colorBy}
             </ContentValue>
           </td>
         </tr>

--- a/app/packages/looker/src/elements/common/tags.ts
+++ b/app/packages/looker/src/elements/common/tags.ts
@@ -44,7 +44,7 @@ export class TagsElement<State extends BaseState> extends BaseElement<State> {
   private activePaths: string[] = [];
   private customizedColors: CustomizeColor[] = [];
   private colorPool: string[];
-  private colorByValue: boolean;
+  private colorBy: "field" | "value" | "instance";
   private colorSeed: number;
   private playing = false;
   private attributeVisibility: object;
@@ -82,7 +82,7 @@ export class TagsElement<State extends BaseState> extends BaseElement<State> {
       }
     } else if (
       (arraysAreEqual(activePaths, this.activePaths) &&
-        this.colorByValue === (coloring.by === "value") &&
+        this.colorBy === coloring.by &&
         arraysAreEqual(this.colorPool, coloring.pool as string[]) &&
         compareObjectArrays(this.customizedColors, customizeColorSetting) &&
         _.isEqual(this.attributeVisibility, attributeVisibility) &&
@@ -249,6 +249,7 @@ export class TagsElement<State extends BaseState> extends BaseElement<State> {
       if (!param.label) {
         return null;
       }
+
       return {
         path,
         value: param.label,
@@ -398,7 +399,7 @@ export class TagsElement<State extends BaseState> extends BaseElement<State> {
       }
     }
 
-    this.colorByValue = coloring.by === "value";
+    this.colorBy = coloring.by;
     this.colorSeed = coloring.seed;
     this.activePaths = [...activePaths];
     this.element.innerHTML = "";

--- a/app/packages/looker/src/elements/common/tags.ts
+++ b/app/packages/looker/src/elements/common/tags.ts
@@ -290,7 +290,7 @@ export class TagsElement<State extends BaseState> extends BaseElement<State> {
         if (Array.isArray(sample.tags)) {
           sample.tags.forEach((tag) => {
             if (filter(path, [tag])) {
-              const v = coloring.by === "value" ? tag : "tags";
+              const v = coloring.by !== "field" ? tag : "tags";
               elements.push({
                 color: getAssignedColor({
                   coloring,
@@ -310,7 +310,7 @@ export class TagsElement<State extends BaseState> extends BaseElement<State> {
       } else if (path === "_label_tags") {
         Object.entries(sample._label_tags ?? {}).forEach(([tag, count]) => {
           const value = `${tag}: ${count}`;
-          const v = coloring.by === "value" ? tag : path;
+          const v = coloring.by !== "field" ? tag : path;
           if (shouldShowLabelTag(tag, attributeVisibility["_label_tags"])) {
             elements.push({
               color: getColor(coloring.pool, coloring.seed, v),

--- a/app/packages/looker/src/elements/common/util.ts
+++ b/app/packages/looker/src/elements/common/util.ts
@@ -18,6 +18,7 @@ import {
 } from "../../state";
 
 import { lookerCheckbox, lookerLabel } from "./util.module.css";
+import { getHashLabel } from "../../overlays/util";
 
 export const dispatchTooltipEvent = <State extends BaseState>(
   dispatchEvent: DispatchEvent,
@@ -259,6 +260,14 @@ export function getAssignedColor({
     value,
     by === "value"
   );
+
+  if (by === "instance") {
+    return getColor(
+      coloring.pool,
+      coloring.seed,
+      path === "tags" ? param : getHashLabel(param)
+    );
+  }
 
   if (by === "field") {
     return getColorByField(setting, pool, seed, path, isValidColor);

--- a/app/packages/looker/src/elements/common/util.ts
+++ b/app/packages/looker/src/elements/common/util.ts
@@ -260,7 +260,7 @@ export function getAssignedColor({
     value,
     by === "value"
   );
-  debugger;
+
   if (by === "instance") {
     return getColor(
       coloring.pool,

--- a/app/packages/looker/src/elements/common/util.ts
+++ b/app/packages/looker/src/elements/common/util.ts
@@ -260,7 +260,7 @@ export function getAssignedColor({
     value,
     by === "value"
   );
-
+  debugger;
   if (by === "instance") {
     return getColor(
       coloring.pool,

--- a/app/packages/looker/src/overlays/base.ts
+++ b/app/packages/looker/src/overlays/base.ts
@@ -114,7 +114,9 @@ export abstract class CoordinateOverlay<
       if (field) {
         if (field.colorByAttribute) {
           if (field.colorByAttribute === "index") {
-            key = this.label["index"] ? "index" : "id";
+            key = ["string", "number"].includes(typeof this.label["index"])
+              ? "index"
+              : "id";
           } else {
             key = field.colorByAttribute;
           }

--- a/app/packages/looker/src/overlays/base.ts
+++ b/app/packages/looker/src/overlays/base.ts
@@ -4,7 +4,7 @@
 
 import { getColor } from "@fiftyone/utilities";
 import { BaseState, Coordinates, NONFINITE } from "../state";
-import { isValidColor, sizeBytes } from "./util";
+import { getHashLabel, isValidColor, sizeBytes } from "./util";
 
 // in numerical order (CONTAINS_BORDER takes precedence over CONTAINS_CONTENT)
 export enum CONTAINS {
@@ -99,6 +99,11 @@ export abstract class CoordinateOverlay<
     let key;
     const path = this.field;
     const field = customizeColorSetting.find((s) => s.path === path);
+
+    if (coloring.by === "instance") {
+      return getColor(coloring.pool, coloring.seed, getHashLabel(this.label));
+    }
+
     if (coloring.by === "field") {
       if (isValidColor(field?.fieldColor)) {
         return field.fieldColor;
@@ -107,11 +112,15 @@ export abstract class CoordinateOverlay<
     }
     if (coloring.by === "value") {
       if (field) {
-        key = field.colorByAttribute
-          ? field.colorByAttribute === "index"
-            ? "id"
-            : field.colorByAttribute
-          : "label";
+        if (field.colorByAttribute) {
+          if (field.colorByAttribute === "index") {
+            key = this.label["index"] ? "index" : "id";
+          } else {
+            key = field.colorByAttribute;
+          }
+        } else {
+          key = "label";
+        }
 
         // use the first value as the fallback default if it's a listField
         const currentValue = Array.isArray(this.label[key])

--- a/app/packages/looker/src/overlays/classifications.ts
+++ b/app/packages/looker/src/overlays/classifications.ts
@@ -59,10 +59,8 @@ export class ClassificationsOverlay<
     const setting = customizeColorSetting.find((s) => s.path === field);
 
     if (coloring.by === "instance") {
-      if (label._cls === REGRESSION) {
-        return getColor(coloring.pool, coloring.seed, field);
-      }
-      return getColor(coloring.pool, coloring.seed, getHashLabel(label));
+      const key = label._cls === REGRESSION ? field : getHashLabel(label);
+      return getColor(coloring.pool, coloring.seed, key);
     }
 
     // check if the field has a customized color, use it if it is a valid color

--- a/app/packages/looker/src/overlays/classifications.ts
+++ b/app/packages/looker/src/overlays/classifications.ts
@@ -21,7 +21,7 @@ import {
   SelectData,
   isShown,
 } from "./base";
-import { isValidColor, sizeBytes } from "./util";
+import { getHashLabel, isValidColor, sizeBytes } from "./util";
 
 export type Classification = RegularLabel;
 
@@ -58,6 +58,13 @@ export class ClassificationsOverlay<
     const { coloring, customizeColorSetting } = state.options;
     const setting = customizeColorSetting.find((s) => s.path === field);
 
+    if (coloring.by === "instance") {
+      if (label._cls === REGRESSION) {
+        return getColor(coloring.pool, coloring.seed, field);
+      }
+      return getColor(coloring.pool, coloring.seed, getHashLabel(label));
+    }
+
     // check if the field has a customized color, use it if it is a valid color
     if (
       coloring.by === "field" &&
@@ -67,7 +74,7 @@ export class ClassificationsOverlay<
       return setting.fieldColor;
     }
 
-    if (coloring.by !== "field") {
+    if (coloring.by === "value") {
       key = setting?.colorByAttribute ?? key;
 
       // check if this label has a assigned color, use it if it is a valid color

--- a/app/packages/looker/src/overlays/util.ts
+++ b/app/packages/looker/src/overlays/util.ts
@@ -126,7 +126,7 @@ export const convertId = (obj: Record<string, any>): Record<string, any> => {
 };
 
 export const getHashLabel = (label: RegularLabel): string => {
-  if ([null, undefined].includes(label["index"])) {
+  if (label["index"] || label["index"] === 0) {
     return `${label.label}.${label.index}`;
   } else {
     return `${label.label}.${label.id}`;

--- a/app/packages/looker/src/overlays/util.ts
+++ b/app/packages/looker/src/overlays/util.ts
@@ -5,7 +5,7 @@
 import colorString from "color-string";
 import { INFO_COLOR } from "../constants";
 import { BaseState, Coordinates, MaskTargets, RgbMaskTargets } from "../state";
-import { BaseLabel } from "./base";
+import { BaseLabel, RegularLabel } from "./base";
 
 export const t = (state: BaseState, x: number, y: number): Coordinates => {
   const [ctlx, ctly, cw, ch] = state.canvasBBox;
@@ -123,4 +123,12 @@ export const convertId = (obj: Record<string, any>): Record<string, any> => {
       return [key, value];
     })
   );
+};
+
+export const getHashLabel = (label: RegularLabel): string => {
+  if ([null, undefined].includes(label["index"])) {
+    return `${label.label}.${label.index}`;
+  } else {
+    return `${label.label}.${label.id}`;
+  }
 };

--- a/app/packages/looker/src/overlays/util.ts
+++ b/app/packages/looker/src/overlays/util.ts
@@ -126,7 +126,7 @@ export const convertId = (obj: Record<string, any>): Record<string, any> => {
 };
 
 export const getHashLabel = (label: RegularLabel): string => {
-  if (label["index"] || label["index"] === 0) {
+  if (["number", "string"].includes(typeof label.index)) {
     return `${label.label}.${label.index}`;
   } else {
     return `${label.label}.${label.id}`;

--- a/app/packages/looker/src/state.ts
+++ b/app/packages/looker/src/state.ts
@@ -10,7 +10,7 @@ import { AppError, Schema, Stage } from "@fiftyone/utilities";
 export type RGB = [number, number, number];
 export type RGBA = [number, number, number, number];
 export interface Coloring {
-  by: "field" | "value";
+  by: "field" | "value" | "instance";
   pool: readonly string[];
   scale: RGB[];
   seed: number;

--- a/app/packages/looker/src/worker/painter.ts
+++ b/app/packages/looker/src/worker/painter.ts
@@ -234,12 +234,20 @@ export const PainterFactory = (requestColor) => ({
       maskData.buffer = maskData.buffer.slice(0, overlay.length);
     } else {
       const cache = {};
-
       let color;
-      if (maskTargets && Object.keys(maskTargets).length === 1) {
+      let colorKey;
+      if (maskTargets && Object.keys(maskTargets).length === 0) {
+        if (coloring.by === "field") {
+          colorKey = field;
+        } else {
+          colorKey = label.id;
+        }
+
         color = get32BitColor(
-          setting?.fieldColor ??
-            (await requestColor(coloring.pool, coloring.seed, field))
+          coloring.by === "field"
+            ? setting?.fieldColor ??
+                (await requestColor(coloring.pool, coloring.seed, colorKey))
+            : await requestColor(coloring.pool, coloring.seed, colorKey)
         );
       }
 
@@ -267,6 +275,8 @@ export const PainterFactory = (requestColor) => ({
           }
         }
       }
+
+      // console.info(color, overlay)
     }
   },
 });

--- a/app/packages/looker/src/worker/painter.ts
+++ b/app/packages/looker/src/worker/painter.ts
@@ -243,13 +243,11 @@ export const PainterFactory = (requestColor) => ({
           colorKey = label.id;
         }
 
-        color = get32BitColor(
         const requestedColor =
           coloring.by === "field" && setting?.fieldColor
             ? setting?.fieldColor
             : await requestColor(coloring.pool, coloring.seed, colorKey);
         color = get32BitColor(requestedColor);
-        );
       }
 
       const getColor = (i) => {

--- a/app/packages/looker/src/worker/painter.ts
+++ b/app/packages/looker/src/worker/painter.ts
@@ -244,10 +244,11 @@ export const PainterFactory = (requestColor) => ({
         }
 
         color = get32BitColor(
-          coloring.by === "field"
-            ? setting?.fieldColor ??
-                (await requestColor(coloring.pool, coloring.seed, colorKey))
-            : await requestColor(coloring.pool, coloring.seed, colorKey)
+        const requestedColor =
+          coloring.by === "field" && setting?.fieldColor
+            ? setting?.fieldColor
+            : await requestColor(coloring.pool, coloring.seed, colorKey);
+        color = get32BitColor(requestedColor);
         );
       }
 
@@ -275,8 +276,6 @@ export const PainterFactory = (requestColor) => ({
           }
         }
       }
-
-      // console.info(color, overlay)
     }
   },
 });


### PR DESCRIPTION
1. Add color by instance option back in the UI.
2. Fix a bug related to color by value (index). When there is an index value, use the index value, otherwise use id, to get the color value. 

Testing
- [x] Detection
- [x] Polylines
- [x] Instance Segmentation
- [x] Segmentation
- [x] Classification


## What changes are proposed in this pull request?

(Please fill in changes proposed in this fix)

## How is this patch tested? If it is not, please explain why.

Segmentation example:
https://github.com/voxel51/fiftyone/assets/17770824/5766f1cd-e532-48a0-9bbb-ffcd007cb0b5


## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
