### PR TITLE
add support for read-only mode in FileExplorerView

### DIFF
--- a/app/packages/core/src/plugins/SchemaIO/components/FileExplorerView/FileExplorer.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/FileExplorerView/FileExplorer.tsx
@@ -14,7 +14,7 @@ import {
   IconButton,
   CircularProgress,
 } from "@mui/material";
-import { useFileExplorer } from "./state";
+import { useAvailableFileSystems, useFileExplorer } from "./state";
 import Close from "@mui/icons-material/Close";
 import { Folder, FolderOff } from "@mui/icons-material";
 
@@ -29,11 +29,10 @@ export default function FileExplorer({
   label,
   description,
   chooseButtonLabel,
-  buttonLabel,
   chooseMode,
   onChoose,
-  fsInfo,
 }) {
+  const fsInfo = useAvailableFileSystems();
   const {
     abort,
     clear,

--- a/app/packages/core/src/plugins/SchemaIO/components/FileExplorerView/FileExplorerView.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/FileExplorerView/FileExplorerView.tsx
@@ -1,30 +1,28 @@
 import React from "react";
 import FileExplorer from "./FileExplorer";
 import FieldWrapper from "../FieldWrapper";
-import { useAvailableFileSystems } from "./state";
+import ObjectView from "../ObjectView";
 
 export default function FileExplorerView(props) {
   const { schema, onChange } = props;
   const { view = {} } = schema;
-  const { label, description, button_label, choose_button_label } = view;
+  const { label, description, choose_button_label, readOnly } = view;
   const chooseMode = view.choose_dir ? "directory" : "file";
 
   const handleChoose = (selectedFile) => {
     onChange(props.path, selectedFile);
   };
 
-  const fsInfo = useAvailableFileSystems();
+  if (readOnly) return <ObjectView {...props} />;
 
   return (
     <FieldWrapper {...props}>
       <FileExplorer
         label={label}
         description={description}
-        buttonLabel={button_label}
         chooseButtonLabel={choose_button_label}
         chooseMode={chooseMode}
         onChoose={handleChoose}
-        fsInfo={fsInfo}
       />
     </FieldWrapper>
   );


### PR DESCRIPTION
## What changes are proposed in this pull request?

When using the `FileExplorerView` with read_only flag, display value for the property as an read-only ObjectView as shown below:

![image](https://github.com/voxel51/fiftyone/assets/25350704/88f90217-acdf-4684-ac17-8afc2d7eebd7)


## How is this patch tested? If it is not, please explain why.

(Details)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
