### PR TITLE
fix react hooks warning for spaces

### DIFF
--- a/app/packages/plugins/src/index.ts
+++ b/app/packages/plugins/src/index.ts
@@ -210,16 +210,12 @@ export function getAbsolutePluginPath(name: string, path: string): string {
  * @returns A list of active plugins
  */
 export function useActivePlugins(type: PluginComponentType, ctx: any) {
-  return useMemo(
-    () =>
-      usePlugin(type).filter((p) => {
-        if (typeof p.activator === "function") {
-          return p.activator(ctx);
-        }
-        return false;
-      }),
-    [ctx]
-  );
+  return usePlugin(type).filter((p) => {
+    if (typeof p.activator === "function") {
+      return p.activator(ctx);
+    }
+    return false;
+  });
 }
 
 /**


### PR DESCRIPTION
## What changes are proposed in this pull request?

Fixes warning below:
```
Warning: Do not call Hooks inside useEffect(...), useMemo(...), or other built-in Hooks. You can only call Hooks at the top level of your React function
```

Removing of useMemo should not impact performance as it was mostly redundant due to always getting called.

## How is this patch tested? If it is not, please explain why.

(Details)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
