### PR TITLE
FileExplorerView read-only mode tweak

### DIFF
--- a/app/packages/core/src/plugins/SchemaIO/components/FileExplorerView/FileExplorerView.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/FileExplorerView/FileExplorerView.tsx
@@ -1,10 +1,11 @@
+import Folder from "@mui/icons-material/Folder";
+import { TextField } from "@mui/material";
 import React from "react";
-import FileExplorer from "./FileExplorer";
 import FieldWrapper from "../FieldWrapper";
-import ObjectView from "../ObjectView";
+import FileExplorer from "./FileExplorer";
 
 export default function FileExplorerView(props) {
-  const { schema, onChange } = props;
+  const { schema, onChange, data } = props;
   const { view = {} } = schema;
   const { label, description, choose_button_label, readOnly } = view;
   const chooseMode = view.choose_dir ? "directory" : "file";
@@ -13,17 +14,25 @@ export default function FileExplorerView(props) {
     onChange(props.path, selectedFile);
   };
 
-  if (readOnly) return <ObjectView {...props} />;
-
   return (
     <FieldWrapper {...props}>
-      <FileExplorer
-        label={label}
-        description={description}
-        chooseButtonLabel={choose_button_label}
-        chooseMode={chooseMode}
-        onChoose={handleChoose}
-      />
+      {readOnly ? (
+        <TextField
+          value={data?.absolute_path}
+          disabled
+          InputProps={{ endAdornment: <Folder color="disabled" /> }}
+          fullWidth
+          size="small"
+        />
+      ) : (
+        <FileExplorer
+          label={label}
+          description={description}
+          chooseButtonLabel={choose_button_label}
+          chooseMode={chooseMode}
+          onChoose={handleChoose}
+        />
+      )}
     </FieldWrapper>
   );
 }


### PR DESCRIPTION
## What changes are proposed in this pull request?

Render read-only FileExplorerView style input Instead of rendering as a read-only ObjectView:

![image](https://github.com/voxel51/fiftyone/assets/25350704/9fe96acc-34e3-421e-b997-c66ee3e9da03)


## How is this patch tested? If it is not, please explain why.

(Details)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
