### PR TITLE
Bugfix: color by value (index) on video

### DIFF
--- a/app/packages/looker-3d/src/Looker3d.tsx
+++ b/app/packages/looker-3d/src/Looker3d.tsx
@@ -410,7 +410,11 @@ export const Looker3d = () => {
             let key;
             if (setting?.colorByAttribute) {
               if (setting.colorByAttribute === "index") {
-                key = l._id;
+                if (["string", "number"].includes(l["index"])) {
+                  key = l.index;
+                } else {
+                  key = l._id;
+                }
               } else if (setting.colorByAttribute === "label") {
                 key = l.label;
               } else if (l.attributes[setting.colorByAttribute]) {

--- a/app/packages/looker/src/overlays/base.ts
+++ b/app/packages/looker/src/overlays/base.ts
@@ -110,11 +110,17 @@ export abstract class CoordinateOverlay<
     }
     if (coloring.by === "value") {
       if (field) {
-        key = field.colorByAttribute
-          ? field.colorByAttribute === "index"
-            ? "id"
-            : field.colorByAttribute
-          : "label";
+        if (field.colorByAttribute) {
+          if (field.colorByAttribute === "index") {
+            key = ["string", "number"].includes(typeof this.label["index"])
+              ? "index"
+              : "id";
+          } else {
+            key = field.colorByAttribute;
+          }
+        } else {
+          key = "label";
+        }
 
         // use the first value as the fallback default if it's a listField
         const currentValue = Array.isArray(this.label[key])

--- a/app/packages/looker/src/worker/painter.ts
+++ b/app/packages/looker/src/worker/painter.ts
@@ -32,7 +32,9 @@ export const PainterFactory = (requestColor) => ({
       if (setting) {
         const key = setting.colorByAttribute
           ? setting.colorByAttribute === "index"
-            ? "id"
+            ? label["index"] !== undefined
+              ? "index"
+              : "id"
             : setting.colorByAttribute
           : "label";
         const valueColor = setting?.valueColors?.find((l) => {
@@ -226,11 +228,19 @@ export const PainterFactory = (requestColor) => ({
       const cache = {};
 
       let color;
-      if (maskTargets && Object.keys(maskTargets).length === 1) {
-        color = get32BitColor(
-          setting?.fieldColor ??
-            (await requestColor(coloring.pool, coloring.seed, field))
-        );
+      let colorKey;
+      if (maskTargets && Object.keys(maskTargets).length === 0) {
+        if (coloring.by === "field") {
+          colorKey = field;
+        } else {
+          colorKey = label.id;
+        }
+
+        const requestedColor =
+          coloring.by === "field" && setting?.fieldColor
+            ? setting?.fieldColor
+            : await requestColor(coloring.pool, coloring.seed, colorKey);
+        color = get32BitColor(requestedColor);
       }
 
       const getColor = (i) => {

--- a/app/packages/looker/src/worker/painter.ts
+++ b/app/packages/looker/src/worker/painter.ts
@@ -229,7 +229,7 @@ export const PainterFactory = (requestColor) => ({
 
       let color;
       let colorKey;
-      if (maskTargets && Object.keys(maskTargets).length === 0) {
+      if (maskTargets && Object.keys(maskTargets).length === 1) {
         if (coloring.by === "field") {
           colorKey = field;
         } else {


### PR DESCRIPTION
## What changes are proposed in this pull request?
Right now, color by value (index) is actually using id to get colors. 
Fix: Use label.index if there is a value in index field, otherwise use id. 

## How is this patch tested? If it is not, please explain why.
https://github.com/voxel51/fiftyone/assets/17770824/cd33a365-4c84-48de-af08-864b1124a095



## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
