### PR TITLE
Fix release PRs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,7 +36,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - ubuntu-20.04
+          - ubuntu-latest-m
           - windows-latest
         python:
           - 3.8
@@ -69,6 +69,7 @@ jobs:
       - name: Install fiftyone
         run: |
           pip install .
+          pip install fiftyone-db-ubuntu2204
       - name: Configure
         id: test_config
         run: |


### PR DESCRIPTION
The Python `test` workflow has been updated on `develop` to increase the runner to `ubuntu-latest-m`, but PRs into `release/v0.22.1` are still facing "out of space" issues on the actions, e.g. https://github.com/voxel51/fiftyone/pull/3606