### PR TITLE
Databricks update

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -5,7 +5,7 @@ on: workflow_call
 jobs:
   test-e2e:
     timeout-minutes: 60
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-m
     env:
       FIFTYONE_DO_NOT_TRACK: true
       ELECTRON_EXTRA_LAUNCH_ARGS: "--disable-gpu"

--- a/app/packages/state/src/recoil/utils.test.ts
+++ b/app/packages/state/src/recoil/utils.test.ts
@@ -1,0 +1,16 @@
+import { setFetchParameters } from "@fiftyone/utilities";
+import { describe, expect, it } from "vitest";
+import { getSampleSrc } from "./utils";
+
+describe("getSampleSrc tests", () => {
+  it("includes proxy in pathname", () => {
+    const image = "/path/to/image.png";
+    const proxy = "/proxy/test";
+    setFetchParameters(window.location.origin, {}, proxy);
+    expect(getSampleSrc("/path/to/image.png")).toEqual(
+      `${window.location.origin}${proxy}/media?filepath=${encodeURIComponent(
+        image
+      )}`
+    );
+  });
+});

--- a/app/packages/state/src/recoil/utils.ts
+++ b/app/packages/state/src/recoil/utils.ts
@@ -6,8 +6,7 @@ import {
   StrictField,
   UNSUPPORTED_FILTER_TYPES,
   VALID_PRIMITIVE_TYPES,
-  getFetchOrigin,
-  getFetchPathPrefix,
+  getFetchParameters,
 } from "@fiftyone/utilities";
 import { Nullable } from "vitest";
 
@@ -19,9 +18,10 @@ export const getSampleSrc = (url: string) => {
     }
   } catch {}
 
-  const path = `${getFetchPathPrefix()}/media`.replaceAll("//", "/");
+  const params = getFetchParameters();
+  const path = `${params.pathPrefix}/media`.replaceAll("//", "/");
 
-  return `${getFetchOrigin()}${path}?filepath=${encodeURIComponent(url)}`;
+  return `${params.origin}${path}?filepath=${encodeURIComponent(url)}`;
 };
 
 export const getSanitizedGroupByExpression = (expression: string) => {

--- a/app/packages/state/src/recoil/utils.ts
+++ b/app/packages/state/src/recoil/utils.ts
@@ -19,9 +19,9 @@ export const getSampleSrc = (url: string) => {
     }
   } catch {}
 
-  return `${getFetchOrigin()}${getFetchPathPrefix()}/media?filepath=${encodeURIComponent(
-    url
-  )}`;
+  const path = `${getFetchPathPrefix()}/media`.replaceAll("//", "/");
+
+  return `${getFetchOrigin()}${path}?filepath=${encodeURIComponent(url)}`;
 };
 
 export const getSanitizedGroupByExpression = (expression: string) => {

--- a/app/packages/utilities/src/fetch.ts
+++ b/app/packages/utilities/src/fetch.ts
@@ -39,6 +39,7 @@ export const getFetchOrigin = () => {
 
   return fetchOrigin;
 };
+
 export function getFetchPathPrefix(): string {
   // window is not defined in the web worker
   if (hasWindow && typeof window.FIFTYONE_SERVER_PATH_PREFIX === "string") {
@@ -53,11 +54,21 @@ export function getFetchPathPrefix(): string {
   return "";
 }
 
+export const setFetchParameters = (
+  origin: string,
+  headers: HeadersInit = {},
+  pathPrefix = ""
+) => {
+  fetchHeaders = headers;
+  fetchOrigin = origin;
+  fetchPathPrefix = pathPrefix;
+};
+
 export const getFetchParameters = () => {
   return {
-    origin: getFetchOrigin(),
-    headers: getFetchHeaders(),
-    pathPrefix: getFetchPathPrefix(),
+    origin: fetchOrigin,
+    headers: fetchHeaders,
+    pathPrefix: fetchPathPrefix,
   };
 };
 
@@ -66,9 +77,7 @@ export const setFetchFunction = (
   headers: HeadersInit = {},
   pathPrefix = ""
 ) => {
-  fetchHeaders = headers;
-  fetchOrigin = origin;
-  fetchPathPrefix = pathPrefix;
+  setFetchParameters(origin, headers, pathPrefix);
   const fetchFunction: FetchFunction = async (
     method,
     path,

--- a/app/packages/utilities/src/fetch.ts
+++ b/app/packages/utilities/src/fetch.ts
@@ -81,7 +81,7 @@ export const setFetchFunction = (
     const controller = new AbortController();
 
     if (fetchPathPrefix) {
-      path = `${fetchPathPrefix}${path}`;
+      path = `${fetchPathPrefix}${path}`.replaceAll("//", "/");
     }
 
     try {
@@ -254,7 +254,7 @@ export const getEventSource = (
     pollingEventSource(path, events, signal, body);
   } else {
     if (fetchPathPrefix) {
-      path = `${fetchPathPrefix}${path}`;
+      path = `${fetchPathPrefix}${path}`.replaceAll("//", "/");
     }
 
     fetchEventSource(`${getFetchOrigin()}${path}`, {

--- a/docs/source/user_guide/plots.rst
+++ b/docs/source/user_guide/plots.rst
@@ -123,9 +123,10 @@ data.
 .. note::
 
     Support for interactive plots in non-notebook contexts and in
-    `Google Colab <https://colab.research.google.com>`_ is coming soon! In the
-    meantime, you can still use FiftyOne's plotting features in these
-    environments, but you must manually call
+    `Google Colab <https://colab.research.google.com>`_ and
+    `Databricks <https://docs.databricks.com/en/notebooks/index.html>`_
+    is coming soon! In the meantime, you can still use FiftyOne's plotting
+    features in these environments, but you must manually call
     :meth:`plot.show() <fiftyone.core.plots.base.Plot.show>` to update the
     state of a plot to match the state of a connected |Session|, and any
     callbacks that would normally be triggered in response to interacting with

--- a/fiftyone/core/plots/plotly.py
+++ b/fiftyone/core/plots/plotly.py
@@ -1564,11 +1564,11 @@ class PlotlyWidgetMixin(object):
             msg = (
                 "Interactive plots are currently only supported in Jupyter "
                 "notebooks. Support outside of notebooks and in Google Colab "
-                "will be included in an upcoming release. In the meantime, "
-                "you can still use this plot, but note that (i) selecting "
-                "data will not trigger callbacks, and (ii) you must manually "
-                "call `plot.show()` to launch a new plot that reflects the "
-                "current state of an attached session.\n\n"
+                "and Databricks will be included in an upcoming release. In "
+                "the meantime, you can still use this plot, but note that (i) "
+                "selecting data will not trigger callbacks, and (ii) you must "
+                "manually call `plot.show()` to launch a new plot that "
+                "reflects the current state of an attached session.\n\n"
                 "See https://docs.voxel51.com/user_guide/plots.html#working-in-notebooks"
                 " for more information."
             )

--- a/fiftyone/core/plots/plotly.py
+++ b/fiftyone/core/plots/plotly.py
@@ -1668,7 +1668,7 @@ def _check_plotly_jupyter_environment():
     #
     # Requirements source: https://plotly.com/python/getting-started
     #
-    # There is also a `notebook>=5.3` requirement in Jupyter notebooks, but
+    # There is also a `notebook>=6` requirement in Jupyter notebooks, but
     # we do not explicitly check that here because the requirement for
     # JupyterLab is different and I don't know how to distinguish Jupyter
     # notebooks from JupyterLab right now...


### PR DESCRIPTION
Fixes databricks notebook URLs. An effort was made to add support for interactive notebooks,  but it seems plotly support is also limited like in Google's Colab. Interactive `ipywidgets` with callbacks do not seem to be supported, and the officially recommend using plotly [offline](https://docs.databricks.com/en/visualizations/plotly.html)

<img width="1470" alt="Screenshot 2023-10-02 at 2 40 41 PM" src="https://github.com/voxel51/fiftyone/assets/19821840/3583a9c9-ee4d-4f01-a6a7-90802cf34038">
