### PR TITLE
use debounce in operator prompt

### DIFF
--- a/app/packages/operators/src/constants.ts
+++ b/app/packages/operators/src/constants.ts
@@ -1,5 +1,5 @@
 export const BROWSER_CONTROL_KEYS = ["ArrowDown", "ArrowUp", "`"];
 export const PALETTE_CONTROL_KEYS = ["`", "Enter", "Escape"];
 export const RESOLVE_PLACEMENTS_TTL = 2500;
-export const RESOLVE_TYPE_TTL = 1000;
-export const RESOLVE_INPUT_VALIDATION_TTL = 1500;
+export const RESOLVE_TYPE_TTL = 500;
+export const RESOLVE_INPUT_VALIDATION_TTL = 750;

--- a/app/packages/operators/src/state.ts
+++ b/app/packages/operators/src/state.ts
@@ -1,5 +1,5 @@
 import * as fos from "@fiftyone/state";
-import { throttle } from "lodash";
+import { debounce } from "lodash";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   atom,
@@ -157,7 +157,7 @@ export const useOperatorPrompt = () => {
   const notify = fos.useNotification();
 
   const resolveInput = useCallback(
-    throttle(
+    debounce(
       async (ctx) => {
         try {
           setResolving(true);
@@ -175,7 +175,8 @@ export const useOperatorPrompt = () => {
         setResolving(false);
         setResolvedCtx(ctx);
       },
-      operator.isRemote ? RESOLVE_TYPE_TTL : 0
+      operator.isRemote ? RESOLVE_TYPE_TTL : 0,
+      { leading: true }
     ),
     []
   );
@@ -207,7 +208,7 @@ export const useOperatorPrompt = () => {
     });
   }, []);
   const validateThrottled = useCallback(
-    throttle(validate, RESOLVE_INPUT_VALIDATION_TTL),
+    debounce(validate, RESOLVE_INPUT_VALIDATION_TTL, { leading: true }),
     []
   );
 
@@ -786,13 +787,7 @@ export function useOperatorPlacements(place: Place) {
   const selectedSamples = useRecoilValue(fos.selectedSamples);
   const setContext = useSetRecoilState(operatorThrottledContext);
   const setThrottledContext = useCallback(
-    throttle(
-      (context) => {
-        setContext(context);
-      },
-      RESOLVE_PLACEMENTS_TTL,
-      { leading: true, trailing: true }
-    ),
+    debounce(setContext, RESOLVE_PLACEMENTS_TTL, { leading: true }),
     []
   );
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

Use debounce instead of throttle for resolving operator type in prompt and placement

## How is this patch tested? If it is not, please explain why.

(Details)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
