### PR TITLE
Plugin utils

### DIFF
--- a/fiftyone/plugins/core.py
+++ b/fiftyone/plugins/core.py
@@ -27,7 +27,7 @@ from fiftyone.plugins.definitions import PluginDefinition
 from fiftyone.utils.github import GitHubRepository
 
 
-PLUGIN_METADATA_FILENAMES = ("fiftyone.yaml", "fiftyone.yml")
+PLUGIN_METADATA_FILENAMES = ("fiftyone.yml", "fiftyone.yaml")
 
 logger = logging.getLogger(__name__)
 

--- a/fiftyone/plugins/core.py
+++ b/fiftyone/plugins/core.py
@@ -27,7 +27,7 @@ from fiftyone.plugins.definitions import PluginDefinition
 from fiftyone.utils.github import GitHubRepository
 
 
-_PLUGIN_METADATA_FILENAMES = ["fiftyone.yaml", "fiftyone.yml"]
+PLUGIN_METADATA_FILENAMES = ("fiftyone.yaml", "fiftyone.yml")
 
 logger = logging.getLogger(__name__)
 
@@ -226,7 +226,7 @@ def download_plugin(
         )
         if not metadata_paths:
             logger.info(
-                f"No {_PLUGIN_METADATA_FILENAMES} files found in {url} (max_depth={max_depth})"
+                f"No {PLUGIN_METADATA_FILENAMES} files found in {url} (max_depth={max_depth})"
             )
 
         for metadata_path in metadata_paths:
@@ -462,7 +462,7 @@ def create_plugin(
 
     yaml_path = _find_plugin_metadata_file(plugin_dir)
     if yaml_path is None:
-        yaml_path = os.path.join(plugin_dir, _PLUGIN_METADATA_FILENAMES[0])
+        yaml_path = os.path.join(plugin_dir, PLUGIN_METADATA_FILENAMES[0])
 
     pd = {"name": plugin_name}
     if description:
@@ -488,11 +488,11 @@ def create_plugin(
 
 
 def _is_plugin_metadata_file(path):
-    return os.path.basename(path) in _PLUGIN_METADATA_FILENAMES
+    return os.path.basename(path) in PLUGIN_METADATA_FILENAMES
 
 
 def _find_plugin_metadata_file(dirpath):
-    for filename in _PLUGIN_METADATA_FILENAMES:
+    for filename in PLUGIN_METADATA_FILENAMES:
         metadata_path = os.path.join(dirpath, filename)
         if os.path.isfile(metadata_path):
             return metadata_path
@@ -543,7 +543,7 @@ def _list_plugins_by_name(enabled=None, check_for_duplicates=True):
 def _find_plugin_metadata_files(root_dir, max_depth=1):
     return fou.find_files(
         root_dir,
-        _PLUGIN_METADATA_FILENAMES,
+        PLUGIN_METADATA_FILENAMES,
         max_depth=max_depth,
     )
 

--- a/fiftyone/plugins/utils.py
+++ b/fiftyone/plugins/utils.py
@@ -20,7 +20,7 @@ logger = logging.getLogger(__name__)
 
 
 def list_zoo_plugins(info=False):
-    """Returs a list of available plugins registered in the
+    """Returns a list of available plugins registered in the
     `FiftyOne Plugins repository <https://github.com/voxel51/fiftyone-plugins>`_
     README.
 

--- a/fiftyone/plugins/utils.py
+++ b/fiftyone/plugins/utils.py
@@ -67,7 +67,7 @@ def list_zoo_plugins(info=False):
 
 
 def find_plugins(gh_repo, info=False):
-    """Returns the paths to the ``fiftyone.yml`` files for all plugins found in
+    """Returns the paths to the fiftyone YAML files for all plugins found in
     the given GitHub repository.
 
     Example usage::
@@ -87,10 +87,10 @@ def find_plugins(gh_repo, info=False):
             :class:`GitHubRepository <fiftyone.utils.github.GitHubRepository>`
             for details
         info (False): whether to retrieve full plugin info for each plugin
-            (True) or just return paths to the ``fiftyone.yml`` files (False)
+            (True) or just return paths to the fiftyone YAML files (False)
 
     Returns:
-        a list of paths to ``fiftyone.yml`` files or plugin info dicts
+        a list of paths to fiftyone YAML files or plugin info dicts
     """
     try:
         root = GitHubRepository.parse_url(gh_repo).get("path", None)
@@ -122,7 +122,7 @@ def get_plugin_info(gh_repo, path=None):
 
         import fiftyone.plugins.utils as fopu
 
-        # Directly link to a repository with a top-level `fiftyone.yml`
+        # Directly link to a repository with a top-level`fiftyone YAML
         info = fopu.get_plugin_info("https://github.com/voxel51/voxelgpt")
         print(info)
 
@@ -137,7 +137,7 @@ def get_plugin_info(gh_repo, path=None):
         info = fopu.get_plugin_info("https://github.com/voxel51/fiftyone-plugins/tree/main/plugins/annotation")
         print(info)
 
-        # Directly link to a `fiftyone.yml` file
+        # Directly link to a fiftyone YAML file
         info = fopu.get_plugin_info("https://github.com/voxel51/fiftyone-plugins/blob/main/plugins/annotation/fiftyone.yml")
         print(info)
 
@@ -145,8 +145,8 @@ def get_plugin_info(gh_repo, path=None):
         gh_repo: a GitHub repository, identifier, tree root, or blob. See
             :class:`GitHubRepository <fiftyone.utils.github.GitHubRepository>`
             for details
-        path (None): the path to a ``fiftyone.yml`` file or the directory that
-            contains it. This is only necessary if the ``fiftyone.yml`` file is
+        path (None): the path to a fiftyone YAML file or the directory that
+            contains it. This is only necessary if the fiftyone YAML file is
             not at the root of the repository and you have not implicitly
             included this path in ``gh_repo`` by providing a tree or blob path
 
@@ -176,6 +176,7 @@ def get_plugin_info(gh_repo, path=None):
     for path in paths:
         try:
             content = repo.get_file(path).decode()
+            break
         except Exception as e:
             if exception is None:
                 exception = e

--- a/fiftyone/plugins/utils.py
+++ b/fiftyone/plugins/utils.py
@@ -1,0 +1,217 @@
+"""
+FiftyOne plugin utilities.
+
+| Copyright 2017-2023, Voxel51, Inc.
+| `voxel51.com <https://voxel51.com/>`_
+|
+"""
+import logging
+import multiprocessing
+import os
+
+from bs4 import BeautifulSoup
+import yaml
+
+from fiftyone.utils.github import GitHubRepository
+from fiftyone.plugins.core import PLUGIN_METADATA_FILENAMES
+
+
+logger = logging.getLogger(__name__)
+
+
+def list_zoo_plugins(info=False):
+    """Returs a list of available plugins registered in the
+    `FiftyOne Plugins repository <https://github.com/voxel51/fiftyone-plugins>`_
+    README.
+
+    Example usage::
+
+        import fiftyone.plugins.utils as fopu
+
+        plugins = fopu.list_zoo_plugins()
+        print(plugins)
+
+        plugins = fopu.list_zoo_plugins(info=True)
+        print(plugins)
+
+    Args:
+        info (False): whether to retrieve full plugin info for each plugin
+            (True) or just return the available info from the README (False)
+
+    Returns:
+        a list of dicts describing the plugins
+    """
+    repo = GitHubRepository("https://github.com/voxel51/fiftyone-plugins")
+    content = repo.get_file("README.md").decode()
+    soup = BeautifulSoup(content, "html.parser")
+
+    plugins = []
+    for row in soup.find_all("tr"):
+        cols = row.find_all(["td"])
+        if len(cols) != 2:
+            continue
+
+        try:
+            name = cols[0].text.strip()
+            url = cols[0].find("a")["href"]
+            description = cols[1].text.strip()
+            plugins.append(dict(name=name, url=url, description=description))
+        except Exception as e:
+            logger.debug("Failed to parse plugin row: %s", e)
+
+    if not info:
+        return plugins
+
+    tasks = [(p["url"], None) for p in plugins]
+    return _get_all_plugin_info(tasks)
+
+
+def find_plugins(gh_repo, info=False):
+    """Returns the paths to the ``fiftyone.yml`` files for all plugins found in
+    the given GitHub repository.
+
+    Example usage::
+
+        import fiftyone.plugins.utils as fopu
+
+        # Search the entire repository
+        plugins = fopu.find_plugins("https://github.com/voxel51/fiftyone-plugins")
+        print(plugins)
+
+        # Search a specific tree
+        plugins = fopu.find_plugins("https://github.com/voxel51/fiftyone-plugins/tree/main/plugins/annotation")
+        print(plugins)
+
+    Args:
+        gh_repo: a GitHub repository, identifier, or tree root. See
+            :class:`GitHubRepository <fiftyone.utils.github.GitHubRepository>`
+            for details
+        info (False): whether to retrieve full plugin info for each plugin
+            (True) or just return paths to the ``fiftyone.yml`` files (False)
+
+    Returns:
+        a list of paths to ``fiftyone.yml`` files or plugin info dicts
+    """
+    try:
+        root = GitHubRepository.parse_url(gh_repo).get("path", None)
+    except:
+        root = None
+
+    repo = GitHubRepository(gh_repo)
+
+    paths = []
+    for d in repo.list_repo_contents(recursive=True):
+        path = d["path"]
+        if root is not None and not path.startswith(root):
+            continue
+
+        if os.path.basename(path) in PLUGIN_METADATA_FILENAMES:
+            paths.append(path)
+
+    if not info:
+        return paths
+
+    tasks = [(gh_repo, path) for path in paths]
+    return _get_all_plugin_info(tasks)
+
+
+def get_plugin_info(gh_repo, path=None):
+    """Returns a dict of plugin info for a FiftyOne plugin hosted in GitHub.
+
+    Example usage::
+
+        import fiftyone.plugins.utils as fopu
+
+        # Directly link to a repository with a top-level `fiftyone.yml`
+        info = fopu.get_plugin_info("https://github.com/voxel51/voxelgpt")
+        print(info)
+
+        # Provide repository and path separately
+        info = fopu.get_plugin_info(
+            "voxel51/fiftyone-plugins",
+            path="plugins/annotation",
+        )
+        print(info)
+
+        # Directly link to a plugin directory
+        info = fopu.get_plugin_info("https://github.com/voxel51/fiftyone-plugins/tree/main/plugins/annotation")
+        print(info)
+
+        # Directly link to a `fiftyone.yml` file
+        info = fopu.get_plugin_info("https://github.com/voxel51/fiftyone-plugins/blob/main/plugins/annotation/fiftyone.yml")
+        print(info)
+
+    Args:
+        gh_repo: a GitHub repository, identifier, tree root, or blob. See
+            :class:`GitHubRepository <fiftyone.utils.github.GitHubRepository>`
+            for details
+        path (None): the path to a ``fiftyone.yml`` file or the directory that
+            contains it. This is only necessary if the ``fiftyone.yml`` file is
+            not at the root of the repository and you have not implicitly
+            included this path in ``gh_repo`` by providing a tree or blob path
+
+    Returns:
+        a dict or list of dicts of plugin info
+    """
+    if path is None:
+        try:
+            path = GitHubRepository.parse_url(gh_repo).get("path", None)
+        except:
+            pass
+
+    # If the user didn't directly provide a blob path, we must try all possible
+    # `PLUGIN_METADATA_FILENAMES` values
+    paths = []
+    if path is None:
+        paths.extend(PLUGIN_METADATA_FILENAMES)
+    elif not path.endswith(PLUGIN_METADATA_FILENAMES):
+        paths.extend(path + "/" + f for f in PLUGIN_METADATA_FILENAMES)
+    else:
+        paths = [path]
+
+    repo = GitHubRepository(gh_repo)
+
+    content = None
+    exception = None
+    for path in paths:
+        try:
+            content = repo.get_file(path).decode()
+        except Exception as e:
+            if exception is None:
+                exception = e
+
+    if content is None:
+        raise exception
+
+    return yaml.safe_load(content)
+
+
+def _get_all_plugin_info(tasks):
+    num_tasks = len(tasks)
+
+    if num_tasks == 0:
+        return []
+
+    if num_tasks == 1:
+        return [_do_get_plugin_info(tasks[0])]
+
+    info = []
+    with multiprocessing.dummy.Pool(processes=min(num_tasks, 4)) as pool:
+        for d in pool.imap_unordered(_do_get_plugin_info, tasks):
+            info.append(d)
+
+    return info
+
+
+def _do_get_plugin_info(task):
+    gh_repo, path = task
+
+    try:
+        return get_plugin_info(gh_repo, path=path)
+    except Exception as e:
+        if path is not None:
+            spec = f"{gh_repo} ({path})"
+        else:
+            spec = gh_repo
+
+        logger.debug("Failed to retrieve plugin info for %s: %s", spec, e)

--- a/fiftyone/utils/github.py
+++ b/fiftyone/utils/github.py
@@ -195,7 +195,7 @@ class GitHubRepository(object):
             resp = self._get_session().get(url)
             resp.raise_for_status()
         except requests.exceptions.HTTPError as e:
-            if e.response.status_code == 403:
+            if e.response.status_code in (403, 404):
                 raise requests.exceptions.HTTPError(
                     (
                         "You can interact with private repositories and avoid "

--- a/fiftyone/utils/github.py
+++ b/fiftyone/utils/github.py
@@ -38,9 +38,9 @@ class GitHubRepository(object):
 
     def __init__(self, repo):
         if etaw.is_url(repo):
-            params = self._parse_url(repo)
+            params = self.parse_url(repo)
         else:
-            params = self._parse_identifier(repo)
+            params = self.parse_identifier(repo)
 
         self._user = params.get("user")
         self._repo = params.get("repo")
@@ -84,8 +84,37 @@ class GitHubRepository(object):
         url = f"https://api.github.com/repos/{self.user}/{self.repo}"
         return self._get(url)
 
+    def get_file(self, path, outpath=None):
+        """Downloads the file at the given path.
+
+        Args:
+            path: the filepath in the repository
+            outpath (None): a path on disk to write the file
+
+        Returns:
+            the file bytes, if no ``outpath`` is provided
+        """
+        if self.ref:
+            ref = self.ref
+        else:
+            ref = self.get_repo_info()["default_branch"]
+
+        url = f"https://raw.githubusercontent.com/{self.user}/{self.repo}/{ref}/{path}"
+        content = self._get(url, json=False)
+
+        if outpath is not None:
+            etau.write_file(content, outpath)
+            return
+
+        return content
+
     def list_path_contents(self, path=None):
         """Returns the contents of the repo rooted at the given path.
+
+        .. note::
+
+            This method has a limit of 1,000 files.
+            `Documentation <https://docs.github.com/en/rest/repos/contents>`_.
 
         Args:
             path (None): an optional root path to start the search from
@@ -105,6 +134,11 @@ class GitHubRepository(object):
     def list_repo_contents(self, recursive=True):
         """Returns a flat list of the repository's contents.
 
+        .. note::
+
+            This method has a limit of 100,000 entries and 7MB response size.
+            `Documentation <https://docs.github.com/en/rest/git/trees>`_.
+
         Args:
             recursive (True): whether to recursively traverse subdirectories
 
@@ -116,7 +150,10 @@ class GitHubRepository(object):
         else:
             ref = self.get_repo_info()["default_branch"]
 
-        url = f"https://api.github.com/repos/{self.user}/{self.repo}/git/trees/{ref}?recursive={int(recursive)}"
+        url = f"https://api.github.com/repos/{self.user}/{self.repo}/git/trees/{ref}"
+        if recursive:
+            url += "?recursive=1"
+
         return self._get(url)["tree"]
 
     def download(self, outdir):
@@ -153,23 +190,45 @@ class GitHubRepository(object):
 
         return session
 
-    def _get(self, url):
-        session = self._get_session()
-        resp = session.get(url).json()
+    def _get(self, url, json=True):
+        try:
+            resp = self._get_session().get(url)
+            resp.raise_for_status()
+        except requests.exceptions.HTTPError as e:
+            if e.response.status_code == 403:
+                raise requests.exceptions.HTTPError(
+                    (
+                        "You can interact with private repositories and avoid "
+                        "rate limit errors by providing a personal access "
+                        "token via the 'GITHUB_TOKEN' environment variable"
+                    ),
+                    response=e.response,
+                )
+
+            raise
+
+        resp = resp.json() if json else resp.content
         if isinstance(resp, dict) and "message" in resp:
             error = resp["message"]
             raise ValueError(f"{error}: {self.identifier}")
 
         return resp
 
-    def _parse_url(self, url):
-        return re.search(
+    @staticmethod
+    def parse_url(url):
+        m = re.search(
             "github.com/(?P<user>[A-Za-z0-9_-]+)/((?P<repo>["
-            "A-Za-z0-9_-]+)((/.+?)?/(?P<ref>[A-Za-z0-9_-]+)?(?P<path>.*)?)?)",
-            url,
-        ).groupdict()
+            "A-Za-z0-9_-]+)((/.+?)?/(?P<ref>[A-Za-z0-9_-]+)?/(?P<path>.*)?)?)",
+            url.rstrip("/"),
+        )
 
-    def _parse_identifier(self, repo):
+        try:
+            return m.groupdict()
+        except:
+            raise ValueError(f"Invalid GitHub URL '{url}'")
+
+    @staticmethod
+    def parse_identifier(repo):
         params = repo.split("/")
         if len(params) < 2:
             raise ValueError(

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ INSTALL_REQUIRES = [
     # third-party packages
     "aiofiles",
     "argcomplete",
+    "beautifulsoup4",
     "boto3",
     "cachetools",
     "dacite>=1.6.0,<1.8.0",


### PR DESCRIPTION
Adds a `fiftyone.plugins.utils` module with a few helpful utilities for parsing plugin info from GitHub repositories. All are used by https://github.com/voxel51/fiftyone-plugins/pull/66.