### PR TITLE
Adds a Snackbar alert when onSetView fails.

### DIFF
--- a/app/packages/app/src/Renderer.tsx
+++ b/app/packages/app/src/Renderer.tsx
@@ -12,10 +12,21 @@ import {
 import { Queries } from "./makeRoutes";
 import { Entry, useRouterContext } from "./routing";
 
-export const pendingEntry = atom<boolean>({
-  key: "pendingEntry",
-  default: false,
-});
+export const [pendingEntry, setPending] = (() => {
+  let set: (value: boolean) => void;
+  return [
+    atom<boolean>({
+      key: "pendingEntry",
+      default: false,
+      effects: [
+        ({ setSelf }) => {
+          set = setSelf;
+        },
+      ],
+    }),
+    (value: boolean) => set(value),
+  ];
+})();
 
 export const entry = atom<Entry<Queries> | null>({
   key: "Entry",

--- a/app/packages/app/src/Renderer.tsx
+++ b/app/packages/app/src/Renderer.tsx
@@ -12,21 +12,10 @@ import {
 import { Queries } from "./makeRoutes";
 import { Entry, useRouterContext } from "./routing";
 
-export const [pendingEntry, setPending] = (() => {
-  let set: (value: boolean) => void;
-  return [
-    atom<boolean>({
-      key: "pendingEntry",
-      default: false,
-      effects: [
-        ({ setSelf }) => {
-          set = setSelf;
-        },
-      ],
-    }),
-    (value: boolean) => set(value),
-  ];
-})();
+export const pendingEntry = atom<boolean>({
+  key: "pendingEntry",
+  default: false,
+});
 
 export const entry = atom<Entry<Queries> | null>({
   key: "Entry",

--- a/app/packages/app/src/pages/datasets/DatasetPage.tsx
+++ b/app/packages/app/src/pages/datasets/DatasetPage.tsx
@@ -9,12 +9,14 @@ import { datasetQueryContext } from "@fiftyone/state";
 import { NotFoundError } from "@fiftyone/utilities";
 import React, { useEffect } from "react";
 import { usePreloadedQuery } from "react-relay";
-import { useRecoilValue } from "recoil";
+import { useRecoilState, useRecoilValue } from "recoil";
 import { graphql } from "relay-runtime";
 import Nav from "../../components/Nav";
 import { Route } from "../../routing";
 import style from "../index.module.css";
 import { DatasetPageQuery } from "./__generated__/DatasetPageQuery.graphql";
+import { Snackbar } from "@material-ui/core";
+import MuiAlert, { AlertProps } from "@mui/material/Alert";
 
 const DatasetPageQueryNode = graphql`
   query DatasetPageQuery(
@@ -58,9 +60,20 @@ const DatasetPageQueryNode = graphql`
   }
 `;
 
+const Alert = React.forwardRef<HTMLDivElement, AlertProps>(function Alert(
+  props,
+  ref
+) {
+  return <MuiAlert elevation={6} ref={ref} variant="filled" {...props} />;
+});
+
+const SNACK_VISIBLE_DURATION = 5000;
+
 const DatasetPage: Route<DatasetPageQuery> = ({ prepared }) => {
   const data = usePreloadedQuery(DatasetPageQueryNode, prepared);
   const isModalActive = Boolean(useRecoilValue(fos.isModalActive));
+  const [snackErrors, setSnackErrors] = useRecoilState(fos.gqlNotiErrorsAtom);
+
   useEffect(() => {
     document
       .getElementById("modal")
@@ -80,6 +93,23 @@ const DatasetPage: Route<DatasetPageQuery> = ({ prepared }) => {
           <Dataset />
         </datasetQueryContext.Provider>
       </div>
+      <Snackbar
+        open={!!snackErrors.length}
+        autoHideDuration={SNACK_VISIBLE_DURATION}
+        onClose={() => {
+          setSnackErrors([]);
+        }}
+      >
+        <Alert
+          onClose={() => {
+            setSnackErrors([]);
+          }}
+          severity="error"
+          sx={{ width: "100%" }}
+        >
+          {snackErrors}
+        </Alert>
+      </Snackbar>
     </>
   );
 };

--- a/app/packages/app/src/pages/datasets/DatasetPage.tsx
+++ b/app/packages/app/src/pages/datasets/DatasetPage.tsx
@@ -72,7 +72,7 @@ const SNACK_VISIBLE_DURATION = 5000;
 const DatasetPage: Route<DatasetPageQuery> = ({ prepared }) => {
   const data = usePreloadedQuery(DatasetPageQueryNode, prepared);
   const isModalActive = Boolean(useRecoilValue(fos.isModalActive));
-  const [snackErrors, setSnackErrors] = useRecoilState(fos.gqlNotiErrorsAtom);
+  const [snackErrors, setSnackErrors] = useRecoilState(fos.snackbarErrors);
 
   useEffect(() => {
     document

--- a/app/packages/app/src/useSetters/onSetView.ts
+++ b/app/packages/app/src/useSetters/onSetView.ts
@@ -5,7 +5,6 @@ import {
   stateSubscription,
   viewStateForm_INTERNAL,
 } from "@fiftyone/state";
-import { GQLError, GraphQLError } from "@fiftyone/utilities";
 import { DefaultValue } from "recoil";
 import { commitMutation } from "relay-runtime";
 import { pendingEntry } from "../Renderer";
@@ -29,9 +28,7 @@ const onSetView: RegisteredSetter =
       variables,
       onCompleted: ({ setView: view }, errors) => {
         if (errors?.length) {
-          handleError(
-            new GraphQLError({ errors: errors as GQLError[], variables })
-          );
+          handleError(errors.map((e) => e.message));
           return;
         }
         sessionRef.current.selectedLabels = [];

--- a/app/packages/app/src/useSetters/onSetView.ts
+++ b/app/packages/app/src/useSetters/onSetView.ts
@@ -8,7 +8,7 @@ import {
 } from "@fiftyone/state";
 import { DefaultValue } from "recoil";
 import { commitMutation } from "relay-runtime";
-import { pendingEntry, setPending } from "../Renderer";
+import { pendingEntry } from "../Renderer";
 import { RegisteredSetter } from "./registerSetter";
 
 const onSetView: RegisteredSetter =
@@ -31,7 +31,6 @@ const onSetView: RegisteredSetter =
         if (errors?.length) {
           handleError(errors.map((e) => e.message));
           rollbackViewBar();
-          setPending(false);
           return;
         }
         sessionRef.current.selectedLabels = [];

--- a/app/packages/app/src/useSetters/onSetView.ts
+++ b/app/packages/app/src/useSetters/onSetView.ts
@@ -1,3 +1,4 @@
+import { rollbackViewBar } from "@fiftyone/core";
 import { setView, setViewMutation } from "@fiftyone/relay";
 import {
   State,
@@ -7,7 +8,7 @@ import {
 } from "@fiftyone/state";
 import { DefaultValue } from "recoil";
 import { commitMutation } from "relay-runtime";
-import { pendingEntry } from "../Renderer";
+import { pendingEntry, setPending } from "../Renderer";
 import { RegisteredSetter } from "./registerSetter";
 
 const onSetView: RegisteredSetter =
@@ -29,6 +30,8 @@ const onSetView: RegisteredSetter =
       onCompleted: ({ setView: view }, errors) => {
         if (errors?.length) {
           handleError(errors.map((e) => e.message));
+          rollbackViewBar();
+          setPending(false);
           return;
         }
         sessionRef.current.selectedLabels = [];

--- a/app/packages/app/src/useSetters/registerSetter.ts
+++ b/app/packages/app/src/useSetters/registerSetter.ts
@@ -1,6 +1,5 @@
 import { Setter } from "@fiftyone/relay";
 import { Session } from "@fiftyone/state";
-import { GraphQLError } from "@fiftyone/utilities";
 import { MutableRefObject } from "react";
 import { Environment } from "react-relay";
 import { Queries } from "../makeRoutes";
@@ -10,7 +9,8 @@ type SetterContext = {
   environment: Environment;
   router: RoutingContext<Queries>;
   sessionRef: MutableRefObject<Session>;
-  handleError: (error: GraphQLError) => void;
+  // for showing snackbar errors
+  handleError: (errors: string[]) => void;
 };
 
 export type RegisteredSetter = (ctx: SetterContext) => Setter;

--- a/app/packages/app/src/useSetters/useSetters.ts
+++ b/app/packages/app/src/useSetters/useSetters.ts
@@ -1,21 +1,33 @@
 import { Setter } from "@fiftyone/relay";
-import { Session } from "@fiftyone/state";
+import { Session, gqlNotiErrorsAtom } from "@fiftyone/state";
 import { MutableRefObject, useMemo } from "react";
-import { useErrorHandler } from "react-error-boundary";
 import { Environment } from "react-relay";
 import { Queries } from "../makeRoutes";
 import { RoutingContext } from "../routing";
 import { REGISTERED_SETTERS } from "./registerSetter";
+import { useRecoilCallback } from "recoil";
 
 const useSetters = (
   environment: Environment,
   router: RoutingContext<Queries>,
   sessionRef: MutableRefObject<Session>
 ) => {
-  const handleError = useErrorHandler();
+  const handleError = useRecoilCallback(
+    ({ set: setRecoil }) =>
+      async (errors: string[] = []) => {
+        setRecoil(gqlNotiErrorsAtom, errors);
+      },
+    []
+  );
+
   return useMemo(() => {
     const setters = new Map<string, Setter>();
-    const ctx = { environment, handleError, router, sessionRef };
+    const ctx = {
+      environment,
+      handleError,
+      router,
+      sessionRef,
+    };
     REGISTERED_SETTERS.forEach((value, key) => {
       setters.set(key, value(ctx));
     });

--- a/app/packages/app/src/useSetters/useSetters.ts
+++ b/app/packages/app/src/useSetters/useSetters.ts
@@ -2,10 +2,11 @@ import { Setter } from "@fiftyone/relay";
 import { Session, snackbarErrors } from "@fiftyone/state";
 import { MutableRefObject, useMemo } from "react";
 import { Environment } from "react-relay";
+import { useRecoilCallback } from "recoil";
+import { pendingEntry } from "../Renderer";
 import { Queries } from "../makeRoutes";
 import { RoutingContext } from "../routing";
 import { REGISTERED_SETTERS } from "./registerSetter";
-import { useRecoilCallback } from "recoil";
 
 const useSetters = (
   environment: Environment,
@@ -16,6 +17,7 @@ const useSetters = (
     ({ set: setRecoil }) =>
       async (errors: string[] = []) => {
         setRecoil(snackbarErrors, errors);
+        setRecoil(pendingEntry, false);
       },
     []
   );

--- a/app/packages/app/src/useSetters/useSetters.ts
+++ b/app/packages/app/src/useSetters/useSetters.ts
@@ -1,5 +1,5 @@
 import { Setter } from "@fiftyone/relay";
-import { Session, gqlNotiErrorsAtom } from "@fiftyone/state";
+import { Session, snackbarErrors } from "@fiftyone/state";
 import { MutableRefObject, useMemo } from "react";
 import { Environment } from "react-relay";
 import { Queries } from "../makeRoutes";
@@ -15,7 +15,7 @@ const useSetters = (
   const handleError = useRecoilCallback(
     ({ set: setRecoil }) =>
       async (errors: string[] = []) => {
-        setRecoil(gqlNotiErrorsAtom, errors);
+        setRecoil(snackbarErrors, errors);
       },
     []
   );

--- a/app/packages/core/src/components/ViewBar/ViewBar.tsx
+++ b/app/packages/core/src/components/ViewBar/ViewBar.tsx
@@ -69,6 +69,8 @@ const viewBarKeyMap = {
   VIEW_BAR_ENTER: "enter",
 };
 
+export let rollbackViewBar: () => void;
+
 const ViewBar = React.memo(() => {
   const [state, send] = useMachine(viewBarMachine);
   const view = useRecoilValue(fos.view);
@@ -78,13 +80,17 @@ const ViewBar = React.memo(() => {
 
   const fieldPaths = useRecoilValue(fos.fieldPaths({}));
   useEffect(() => {
-    send({
-      type: "UPDATE",
-      view,
-      setView,
-      fieldNames: fieldPaths,
-      stageDefinitions,
-    });
+    const setViewBar = () =>
+      send({
+        type: "UPDATE",
+        view,
+        setView,
+        fieldNames: fieldPaths,
+        stageDefinitions,
+      });
+
+    setViewBar();
+    rollbackViewBar = setViewBar;
   }, [view, fieldPaths]);
 
   const { stages, activeStage } = state.context;

--- a/app/packages/core/src/components/index.ts
+++ b/app/packages/core/src/components/index.ts
@@ -4,6 +4,6 @@ export { default as Dataset } from "./Dataset";
 export { default as EmptySamples } from "./EmptySamples";
 export { default as FieldLabelAndInfo } from "./FieldLabelAndInfo";
 export { default as Loading } from "./Loading";
-export * from "./Sidebar";
-export { default as ViewBar } from "./ViewBar/ViewBar";
 export { default as ResourceCount } from "./ResourceCount";
+export * from "./Sidebar";
+export { default as ViewBar, rollbackViewBar } from "./ViewBar/ViewBar";

--- a/app/packages/state/src/recoil/atoms.ts
+++ b/app/packages/state/src/recoil/atoms.ts
@@ -101,8 +101,8 @@ export const loading = atom<boolean>({
   default: false,
 });
 
-export const gqlNotiErrorsAtom = atom<string[]>({
-  key: "gqlNotiErrorsAtom",
+export const snackbarErrors = atom<string[]>({
+  key: "snackbarErrors",
   default: [],
 });
 

--- a/app/packages/state/src/recoil/atoms.ts
+++ b/app/packages/state/src/recoil/atoms.ts
@@ -101,6 +101,11 @@ export const loading = atom<boolean>({
   default: false,
 });
 
+export const gqlNotiErrorsAtom = atom<string[]>({
+  key: "gqlNotiErrorsAtom",
+  default: [],
+});
+
 // labels: whether label tag or sample tag
 export const tagging = atomFamily<boolean, { modal: boolean; labels: boolean }>(
   {

--- a/fiftyone/core/stages.py
+++ b/fiftyone/core/stages.py
@@ -6937,7 +6937,7 @@ class SortBy(ViewStage):
         return [
             {
                 "name": "field_or_expr",
-                "type": "field",
+                "type": "field|str|json",
                 "placeholder": "field or expression",
             },
             {

--- a/fiftyone/core/stages.py
+++ b/fiftyone/core/stages.py
@@ -6937,7 +6937,7 @@ class SortBy(ViewStage):
         return [
             {
                 "name": "field_or_expr",
-                "type": "field|str|json",
+                "type": "field",
                 "placeholder": "field or expression",
             },
             {


### PR DESCRIPTION
## What changes are proposed in this pull request?

Adds a Snackbar alert when onSetView fails.
- [x] Add error handling
- [x] Add Snackbar alert

Before change

https://github.com/voxel51/fiftyone/assets/109545780/ad4ce15e-a5bb-466a-ab9d-b16a6407c1ea

After change

https://github.com/voxel51/fiftyone/assets/109545780/369e115d-e6f7-4f2e-aec6-7f9b0e83245b

@benjaminpkane @imanjra and anyone else, can you advise on the followings please,
- Is there a better way? I had to bypass ErrorBoundary because it was refreshing the page and getting tricky to show Alert and Children in ErrorBoundary without this refresh.
- How do I stop the loading state when onSetView --> onComplete returns data.errors? The top loader stays visible and the event call never gets cancelled. I tried setting AppState to Close in useEventSource.ts but no success.





## How is this patch tested? If it is not, please explain why.

(Details)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
