### PR TITLE
fix groups aggregation problem resulting in unstable ordering of documents

### DIFF
--- a/fiftyone/core/stages.py
+++ b/fiftyone/core/stages.py
@@ -3437,15 +3437,15 @@ class GroupBy(ViewStage):
 
         pipeline = []
 
-        if self._sort_stage is not None:
-            pipeline.extend(self._sort_stage.to_mongo(sample_collection))
-
         pipeline.extend(
             [
                 {"$group": {"_id": group_expr, "doc": {"$first": "$$ROOT"}}},
                 {"$replaceRoot": {"newRoot": "$doc"}},
             ]
         )
+
+        if self._sort_stage is not None:
+            pipeline.extend(self._sort_stage.to_mongo(sample_collection))
 
         return pipeline
 

--- a/fiftyone/core/stages.py
+++ b/fiftyone/core/stages.py
@@ -3450,11 +3450,7 @@ class GroupBy(ViewStage):
 
         # add a sort stage so that we return a stable ordering of groups
         # sort by _id to preserve insertion order
-        pipeline.extend(
-            [
-                {"$sort": {"_id": 1}},
-            ]
-        )
+        pipeline.append({"$sort": {"_id": 1}})
 
         return pipeline
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

This PR fixes #3421.

#### Previous Aggregation Pipeline

The previous pipeline (somewhat inexplicably) outputs an unstable ordering of documents. While the `group` stage doesn't guarantee a stable sort, the absence of the `lookup` stage, which adds the sorted `frames` object from the frames collection, results in a stable order of documents. This might be due to the presence of a nested field object, such as `frames`, outputted by the `lookup` stage, which could be affecting how the `group` stage operates.

```
[
  {
    $lookup: {
      from: "frames.samples.6421c8af194325086c697069",
      let: {
        sample_id: "$_id",
      },
      pipeline: [
        {
          $match: {
            $expr: {
              $eq: ["$$sample_id", "$_sample_id"],
            },
          },
        },
        {
          $sort: {
            frame_number: 1,
          },
        },
      ],
      as: "frames",
    },
  },
  {
    $sort: {
      "metadata.duration": 1,
      "metadata.size_bytes": 1,
    },
  },
  {
    $group: {
      _id: "$metadata.duration",
      doc: {
        $first: "$$ROOT",
      },
    },
  },
  {
    $replaceRoot: {
      newRoot: "$doc",
    },
  },
]
```

#### New Aggregation Pipeline

This PR solves the unstable sort problem by applying the `sort` stage _after_ the `group` stage.

```
[
  {
    $lookup: {
      from: "frames.samples.6421c8af194325086c697069",
      let: {
        sample_id: "$_id",
      },
      pipeline: [
        {
          $match: {
            $expr: {
              $eq: ["$$sample_id", "$_sample_id"],
            },
          },
        },
        {
          $sort: {
            frame_number: 1,
          },
        },
      ],
      as: "frames",
    },
  },
  {
    $group: {
      _id: "$metadata.duration",
      doc: {
        $first: "$$ROOT",
      },
    },
  },
  {
    $replaceRoot: {
      newRoot: "$doc",
    },
  },
    {
    $sort: {
      "metadata.duration": 1,
      "metadata.size_bytes": 1,
    },
  },
]
```

## How is this patch tested? If it is not, please explain why.

Locally.


## Release Notes

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
