### PR TITLE
Add build system to pyproject.toml

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,8 +3,11 @@ global-exclude *.py[cod]
 
 prune .*
 prune app
+prune e2e
+prune e2e-pw
 prune eta
 prune package
+prune requirements
 prune tools
 prune tests
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,5 @@
+[build-system]
+requires = ["importlib-metadata; python_version<'3.8'", "setuptools", "wheel"]
 [tool.black]
 line-length = 79
 include = '\.pyi?$'


### PR DESCRIPTION
Due to [PEP 517](https://peps.python.org/pep-0517/), installing `fiftyone` from source occurs in an isolated build environment. For Python 3.7, this requires the `importlib-metadata` package. This build requirement has been added to the `pyproject.toml` per [PEP 518](https://peps.python.org/pep-0518/).

I've also updated the `MANIFEST.in` because unwanted directories are currently included in a build (`e2e`, etc.). More could be done here, but this update removes most of the unnecessary files