### PR TITLE
improve e2e test stability (cifar sidebar)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -5,7 +5,7 @@ on: workflow_call
 jobs:
   test-e2e:
     timeout-minutes: 60
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-m
     env:
       FIFTYONE_DO_NOT_TRACK: true
       ELECTRON_EXTRA_LAUNCH_ARGS: "--disable-gpu"

--- a/e2e-pw/src/oss/poms/sidebar.ts
+++ b/e2e-pw/src/oss/poms/sidebar.ts
@@ -78,9 +78,10 @@ export class SidebarPom {
   }
 
   async applyFilter(label: string) {
-    const selectionDiv = this.sidebar.getByTestId(`checkbox-${label}`);
-    await selectionDiv.waitFor({ state: "visible" });
-    await selectionDiv.locator("input").check({ force: true });
+    const selectionDiv = this.sidebar
+      .getByTestId("checkbox-" + label)
+      .getByTitle(label);
+    await selectionDiv.click({ force: true });
   }
 
   // apply a filter to a field

--- a/e2e-pw/src/oss/specs/sidebar/sidebar-cifar.spec.ts
+++ b/e2e-pw/src/oss/specs/sidebar/sidebar-cifar.spec.ts
@@ -83,6 +83,8 @@ test.describe("classification-sidebar-filter-visibility", () => {
 
     await sidebar.clickFieldDropdown("ground_truth");
     await entryExpandPromise;
+    await sidebar.waitForElement("checkbox-frog");
+    await sidebar.waitForElement("checkbox-ship");
     await sidebar.applyLabelFromList(
       "ground_truth.detections.label",
       ["frog", "ship"],

--- a/e2e-pw/src/oss/specs/sidebar/sidebar-cifar.spec.ts
+++ b/e2e-pw/src/oss/specs/sidebar/sidebar-cifar.spec.ts
@@ -83,18 +83,23 @@ test.describe("classification-sidebar-filter-visibility", () => {
 
     await sidebar.clickFieldDropdown("ground_truth");
     await entryExpandPromise;
+
     await sidebar.waitForElement("checkbox-frog");
     await sidebar.waitForElement("checkbox-ship");
     await sidebar.applyLabelFromList(
       "ground_truth.detections.label",
-      ["frog", "ship"],
+      ["frog"],
+      "show-samples-with-label"
+    );
+
+    await sidebar.applyLabelFromList(
+      "ground_truth.detections.label",
+      ["ship"],
       "show-samples-with-label"
     );
 
     // verify the number of samples in the result
-    await grid.waitForGridToLoad();
     await grid.assert.isEntryCountTextEqualTo("3 of 5 samples");
-
     await expect(await grid.getNthFlashlightSection(0)).toHaveScreenshot(
       "show-frog.png",
       { animations: "allow" }
@@ -152,7 +157,6 @@ test.describe("classification-sidebar-filter-visibility", () => {
       "omit-samples-with-label"
     );
 
-    await grid.waitForGridToLoad();
     await expect(await grid.getNthFlashlightSection(0)).toHaveScreenshot(
       "hide-ship.png",
       { animations: "allow" }


### PR DESCRIPTION
Improve the test stability of sidebar-cifar when selecting multiple checkboxes. 

## What changes are proposed in this pull request?

(Please fill in changes proposed in this fix)

## How is this patch tested? If it is not, please explain why.

(Details)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
