### PR TITLE
Fix group.id index

### DIFF
--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -6722,7 +6722,7 @@ def _create_group_indexes(sample_collection_name, group_field):
     conn = foo.get_db_conn()
 
     sample_collection = conn[sample_collection_name]
-    sample_collection.create_index(group_field + ".id")
+    sample_collection.create_index(group_field + "._id")
     sample_collection.create_index(group_field + ".name")
 
 


### PR DESCRIPTION
While working on related sidebar/index features, I'm noticing that `Group` fields create an index on an `id` field, as opposed to `_id`. Looking at MongoDB compass (see recording) this results in collection scans when matching on a `group._id` value in `quickstart-groups`.

A migration should probably be added if this a change want. I can add after confirming that this is a bug

https://github.com/voxel51/fiftyone/assets/19821840/b6d3ddd0-f094-42c5-b538-61f88e9a475c