### PR TITLE
Update voc.py

### DIFF
--- a/fiftyone/utils/voc.py
+++ b/fiftyone/utils/voc.py
@@ -491,7 +491,9 @@ class VOCAnnotation(object):
         Returns:
             a :class:`VOCAnnotation`
         """
-        annotation = d["annotation"]
+        
+        ann_key= "annotation" if "annotation" in d else "Annotation"
+        annotation = d[ann_key]
 
         path = annotation.get("path", None)
         folder = annotation.get("folder", None)


### PR DESCRIPTION
## What changes are proposed in this pull request?

https://github.com/voxel51/fiftyone/issues/3636#issue-1929907148

When FiftyOne loads annotations in VOC format, an error occurs if the XML uses 'Annotation' as the root tag instead of 'annotation'. My modification makes it compatible with this difference.

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
