### PR TITLE
add header placement

### DIFF
--- a/app/packages/app/src/components/Nav.tsx
+++ b/app/packages/app/src/components/Nav.tsx
@@ -27,6 +27,7 @@ import Teams from "./Teams";
 import { NavDatasets$key } from "./__generated__/NavDatasets.graphql";
 import { NavFragment$key } from "./__generated__/NavFragment.graphql";
 import { NavGA$key } from "./__generated__/NavGA.graphql";
+import { OperatorPlacements, types } from "@fiftyone/operators";
 
 const getUseSearch = (fragment: NavDatasets$key) => {
   return (search: string) => {
@@ -170,6 +171,7 @@ const Nav: React.FC<{
           <SlackLink />
           <GitHubLink />
           <DocsLink />
+          <OperatorPlacements place={types.Places.HEADER_ACTIONS} />
         </div>
       </Header>
       {ReactDOM.createPortal(

--- a/app/packages/operators/src/OperatorPlacements.tsx
+++ b/app/packages/operators/src/OperatorPlacements.tsx
@@ -12,6 +12,7 @@ import {
 } from "./state";
 import { Placement, Places } from "./types";
 import { isPrimitiveString } from "@fiftyone/utilities";
+import { IconButton, Tooltip } from "@mui/material";
 
 function OperatorPlacements(props: OperatorPlacementsProps) {
   const { place } = props;
@@ -91,6 +92,14 @@ function ButtonPlacement(props: OperatorPlacementProps) {
         highlight={place === types.Places.SAMPLES_GRID_ACTIONS}
         style={{ whiteSpace: "nowrap" }}
       />
+    );
+  }
+
+  if (place === types.Places.HEADER_ACTIONS) {
+    return (
+      <Tooltip title={label} onClick={handleClick}>
+        <IconButton sx={{ p: 0 }}>{IconComponent}</IconButton>
+      </Tooltip>
     );
   }
 

--- a/app/packages/operators/src/types.ts
+++ b/app/packages/operators/src/types.ts
@@ -1095,6 +1095,7 @@ export enum Places {
   MAP_ACTIONS = "map-actions",
   MAP_SECONDARY_ACTIONS = "map-secondary-actions",
   DISPLAY_OPTIONS = "display-options",
+  HEADER_ACTIONS = "header-actions",
 }
 
 // NOTE: keys should always match fiftyone/operators/types.py

--- a/fiftyone/operators/types.py
+++ b/fiftyone/operators/types.py
@@ -1148,6 +1148,7 @@ class Places(enum.Enum):
     MAP_ACTIONS = "map-actions"
     MAP_SECONDARY_ACTIONS = "map-secondary-actions"
     DISPLAY_OPTIONS = "display-options"
+    HEADER_ACTIONS = "header-actions"
 
     def to_json(self):
         return self.value


### PR DESCRIPTION
## What changes are proposed in this pull request?

Add `HEADER_ACTIONS` placement support:

**Preview:**

<img width="1728" alt="Screenshot 2023-10-06 at 2 58 49 PM" src="https://github.com/voxel51/fiftyone/assets/25350704/c2ea0f24-ecb5-4cc1-8368-b8211e233f0e">
    
**Usage:**
```py
def resolve_placement(self, ctx):
    return types.Placement(
        types.Places.HEADER_ACTIONS, # <----- New place for placements
        types.Button(
            label="Open VoxelGPT",
            icon="/assets/icon-dark.svg",
            prompt=False,
        ),
    )
```

## How is this patch tested? If it is not, please explain why.

Using an example operator

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

Refer to the proposed changed section above

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
