### PR TITLE
Add polling to Colab session URL

### DIFF
--- a/fiftyone/core/context.py
+++ b/fiftyone/core/context.py
@@ -153,7 +153,7 @@ def get_url(
         from google.colab.output import eval_js
 
         _url = eval_js(f"google.colab.kernel.proxyPort({port})")
-        kwargs["polling"] = True
+        kwargs["polling"] = "true"
     elif _context == _DATABRICKS:
         _url = _get_databricks_proxy_url(port)
         kwargs["proxy"] = _get_databricks_proxy(port)

--- a/fiftyone/core/context.py
+++ b/fiftyone/core/context.py
@@ -153,6 +153,7 @@ def get_url(
         from google.colab.output import eval_js
 
         _url = eval_js(f"google.colab.kernel.proxyPort({port})")
+        kwargs["polling"] = True
     elif _context == _DATABRICKS:
         _url = _get_databricks_proxy_url(port)
         kwargs["proxy"] = _get_databricks_proxy(port)


### PR DESCRIPTION
This change ensures colab notebooks provide a functional URL when accessing the `session.url` property by including the required `polling` search param, i.e. `https://LONG_ID-5151-colab.googleusercontent.com/?polling=true`