### PR TITLE
Move ensureColorScheme to state and fix minor color related bugs

### DIFF
--- a/app/packages/app/src/Sync.tsx
+++ b/app/packages/app/src/Sync.tsx
@@ -22,7 +22,7 @@ import {
 } from "./pages/datasets/__generated__/DatasetPageQuery.graphql";
 import { Entry, useRouterContext } from "./routing";
 import { AppReadyState } from "./useEvents/registerEvent";
-import { ensureColorScheme } from "./useEvents/utils";
+
 import useEventSource, { getDatasetName } from "./useEventSource";
 import useSetters from "./useSetters";
 import useWriters from "./useWriters";
@@ -127,7 +127,7 @@ const dispatchSideEffect = ({
   const data: DatasetPageQuery$data = nextEntry.data;
   if (currentDataset !== nextDataset) {
     session.sessionSpaces = fos.SPACES_DEFAULT;
-    session.colorScheme = ensureColorScheme(
+    session.colorScheme = fos.ensureColorScheme(
       data.dataset?.appConfig?.colorScheme,
       {
         colorPool: data.config.colorPool,

--- a/app/packages/app/src/Sync.tsx
+++ b/app/packages/app/src/Sync.tsx
@@ -22,7 +22,6 @@ import {
 } from "./pages/datasets/__generated__/DatasetPageQuery.graphql";
 import { Entry, useRouterContext } from "./routing";
 import { AppReadyState } from "./useEvents/registerEvent";
-
 import useEventSource, { getDatasetName } from "./useEventSource";
 import useSetters from "./useSetters";
 import useWriters from "./useWriters";

--- a/app/packages/app/src/Sync.tsx
+++ b/app/packages/app/src/Sync.tsx
@@ -129,13 +129,7 @@ const dispatchSideEffect = ({
     session.sessionSpaces = fos.SPACES_DEFAULT;
     session.colorScheme = fos.ensureColorScheme(
       data.dataset?.appConfig?.colorScheme,
-      {
-        colorPool: data.config.colorPool,
-        colorBy: data.config.colorBy,
-        opacity: 0.7,
-        multicolorKeypoints: false,
-        showSkeletons: true,
-      }
+      data.config
     );
     session.sessionGroupSlice = data.dataset?.defaultGroupSlice || undefined;
   }

--- a/app/packages/app/src/useEvents/useSetColorScheme.ts
+++ b/app/packages/app/src/useEvents/useSetColorScheme.ts
@@ -1,13 +1,20 @@
-import { useSessionSetter } from "@fiftyone/state";
+import { ensureColorScheme, useSessionSetter } from "@fiftyone/state";
 import { useCallback } from "react";
 import { EventHandlerHook } from "./registerEvent";
-import { ensureColorScheme } from "./utils";
 
 const useSetColorScheme: EventHandlerHook = () => {
   const setter = useSessionSetter();
   return useCallback(
     (payload) => {
-      setter("colorScheme", ensureColorScheme(payload.color_scheme));
+      setter(
+        "colorScheme",
+        ensureColorScheme(payload.color_scheme, {
+          colorPool: [],
+          colorBy: "field",
+          opacity: 0.7,
+          multicolorKeypoints: false,
+        })
+      );
     },
     [setter]
   );

--- a/app/packages/app/src/useEvents/useSetColorScheme.ts
+++ b/app/packages/app/src/useEvents/useSetColorScheme.ts
@@ -6,15 +6,7 @@ const useSetColorScheme: EventHandlerHook = () => {
   const setter = useSessionSetter();
   return useCallback(
     (payload) => {
-      setter(
-        "colorScheme",
-        ensureColorScheme(payload.color_scheme, {
-          colorPool: [],
-          colorBy: "field",
-          opacity: 0.7,
-          multicolorKeypoints: false,
-        })
-      );
+      setter("colorScheme", ensureColorScheme(payload.color_scheme));
     },
     [setter]
   );

--- a/app/packages/app/src/useEvents/utils.ts
+++ b/app/packages/app/src/useEvents/utils.ts
@@ -15,12 +15,7 @@ export const processState = (
 ) => {
   setter(
     "colorScheme",
-    ensureColorScheme(state.color_scheme as ColorSchemeInput, {
-      colorPool: [],
-      colorBy: "field",
-      opacity: 0.7,
-      multicolorKeypoints: false,
-    })
+    ensureColorScheme(state.color_scheme as ColorSchemeInput)
   );
   setter("sessionGroupSlice", state.group_slice);
   setter("selectedSamples", new Set(state.selected));

--- a/app/packages/app/src/useEvents/utils.ts
+++ b/app/packages/app/src/useEvents/utils.ts
@@ -1,5 +1,5 @@
 import { ColorSchemeInput } from "@fiftyone/relay";
-import { State, useSessionSetter } from "@fiftyone/state";
+import { State, ensureColorScheme, useSessionSetter } from "@fiftyone/state";
 import { toCamelCase } from "@fiftyone/utilities";
 import { atom } from "recoil";
 import { AppReadyState } from "./registerEvent";
@@ -8,22 +8,6 @@ export const appReadyState = atom<AppReadyState>({
   key: "appReadyState",
   default: AppReadyState.CONNECTING,
 });
-
-export const ensureColorScheme = (
-  colorScheme: any,
-  defaultValue: any
-): ColorSchemeInput => {
-  colorScheme = toCamelCase(colorScheme);
-  return {
-    colorPool: colorScheme.colorPool || defaultValue.colorPool,
-    colorBy: colorScheme.colorBy || defaultValue.colorBy,
-    fields: colorScheme.fields as ColorSchemeInput["fields"],
-    multicolorKeypoints:
-      colorScheme.multicolorKeypoints || colorScheme.multicolorKeypoints,
-    opacity: colorScheme.opacity || defaultValue.opacity,
-    showSkeletons: colorScheme.showSkeletons == false ? false : true,
-  };
-};
 
 export const processState = (
   setter: ReturnType<typeof useSessionSetter>,

--- a/app/packages/state/src/recoil/color.ts
+++ b/app/packages/state/src/recoil/color.ts
@@ -1,5 +1,6 @@
 import { Coloring } from "@fiftyone/looker";
 import { isValidColor } from "@fiftyone/looker/src/overlays/util";
+import { ColorSchemeInput, datasetQuery$data } from "@fiftyone/relay";
 import {
   DYNAMIC_EMBEDDED_DOCUMENT_PATH,
   RGB,
@@ -13,7 +14,6 @@ import * as atoms from "./atoms";
 import * as schemaAtoms from "./schema";
 import * as selectors from "./selectors";
 import { PathEntry, sidebarEntries } from "./sidebar";
-import { ColorSchemeInput } from "@fiftyone/relay";
 
 export const coloring = selector<Coloring>({
   key: "coloring",
@@ -114,16 +114,20 @@ export const eligibleFieldsToCustomizeColor = selector({
 
 export const ensureColorScheme = (
   colorScheme: any,
-  defaultValue: any
+  appConfig?: datasetQuery$data["config"]
 ): ColorSchemeInput => {
   colorScheme = toCamelCase(colorScheme);
   return {
-    colorPool: colorScheme.colorPool || defaultValue.colorPool,
-    colorBy: colorScheme.colorBy || defaultValue.colorBy,
+    colorPool: colorScheme.colorPool || appConfig.colorPool,
+    colorBy: colorScheme.colorBy || appConfig.colorBy,
     fields: colorScheme.fields as ColorSchemeInput["fields"],
     multicolorKeypoints:
-      colorScheme.multicolorKeypoints || colorScheme.multicolorKeypoints,
-    opacity: colorScheme.opacity || defaultValue.opacity,
-    showSkeletons: colorScheme.showSkeletons == false ? false : true,
+      colorScheme.multicolorKeypoints || appConfig.multicolorKeypoints,
+    opacity:
+      typeof colorScheme.opacity === "number" ? colorScheme.opacity : 0.7,
+    showSkeletons:
+      typeof colorScheme.showSkeletons == "boolean"
+        ? colorScheme.showSkeletons
+        : appConfig.showSkeletons,
   };
 };

--- a/app/packages/state/src/recoil/color.ts
+++ b/app/packages/state/src/recoil/color.ts
@@ -6,12 +6,14 @@ import {
   createColorGenerator,
   getColor,
   hexToRgb,
+  toCamelCase,
 } from "@fiftyone/utilities";
 import { selector, selectorFamily } from "recoil";
 import * as atoms from "./atoms";
 import * as schemaAtoms from "./schema";
 import * as selectors from "./selectors";
 import { PathEntry, sidebarEntries } from "./sidebar";
+import { ColorSchemeInput } from "@fiftyone/relay";
 
 export const coloring = selector<Coloring>({
   key: "coloring",
@@ -23,7 +25,7 @@ export const coloring = selector<Coloring>({
       pool: colorScheme.colorPool,
       scale: [],
       by: colorScheme.colorBy,
-      points: colorScheme.useMultiColorKeypoints,
+      points: colorScheme.multicolorKeypoints,
       defaultMaskTargets: get(selectors.defaultTargets),
       maskTargets: get(selectors.targets).fields,
       targets: new Array(colorScheme.colorPool.length)
@@ -109,3 +111,19 @@ export const eligibleFieldsToCustomizeColor = selector({
     return fields;
   },
 });
+
+export const ensureColorScheme = (
+  colorScheme: any,
+  defaultValue: any
+): ColorSchemeInput => {
+  colorScheme = toCamelCase(colorScheme);
+  return {
+    colorPool: colorScheme.colorPool || defaultValue.colorPool,
+    colorBy: colorScheme.colorBy || defaultValue.colorBy,
+    fields: colorScheme.fields as ColorSchemeInput["fields"],
+    multicolorKeypoints:
+      colorScheme.multicolorKeypoints || colorScheme.multicolorKeypoints,
+    opacity: colorScheme.opacity || defaultValue.opacity,
+    showSkeletons: colorScheme.showSkeletons == false ? false : true,
+  };
+};


### PR DESCRIPTION
## What changes are proposed in this pull request?

- move `ensureColorScheme` to `fiftyone/state`
- fix minor bugs related to colorBy global changes

## How is this patch tested? If it is not, please explain why.

(Details)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
