### PR TITLE
Adding support for directly exporting object patches

### DIFF
--- a/docs/source/user_guide/export_datasets.rst
+++ b/docs/source/user_guide/export_datasets.rst
@@ -264,6 +264,30 @@ exported.
         label_field="ground_truth",
     )
 
+You can also directly call
+:meth:`export() <fiftyone.core.collections.SampleCollection.export>` on
+:ref:`patches views <object-patches-views>` to export the specified object
+patches along with their appropriately typed labels.
+
+.. code-block:: python
+    :linenos:
+
+    # Continuing from above...
+
+    patches = dataset.to_patches("ground_truth")
+
+    # Export the object patches as a directory of images
+    patches.export(
+        export_dir="/tmp/quickstart/also-patches",
+        dataset_type=fo.types.ImageDirectory,
+    )
+
+    # Export the object patches as an image classification directory tree
+    patches.export(
+        export_dir="/tmp/quickstart/also-objects",
+        dataset_type=fo.types.ImageClassificationDirectoryTree,
+    )
+
 Video clips
 ~~~~~~~~~~~
 
@@ -278,7 +302,7 @@ specified :ref:`video clips <app-video-clips>` will be exported.
     import fiftyone as fo
     import fiftyone.zoo as foz
 
-    dataset = foz.load_zoo_dataset("quickstart-video").limit(2).clone()
+    dataset = foz.load_zoo_dataset("quickstart-video", max_samples=2)
 
     # Add some temporal detections to the dataset
     sample1 = dataset.first()
@@ -333,12 +357,10 @@ their appropriately typed labels.
         dataset_type=fo.types.VideoDirectory,
     )
 
-    # A classification field is provided, so the clips are exported as a video
-    # classification directory tree
+    # Export the clips as a video classification directory tree
     clips.export(
         export_dir="/tmp/quickstart-video/clip-classifications",
         dataset_type=fo.types.VideoClassificationDirectoryTree,
-        label_field="events",
     )
 
     # Export the clips along with their associated frame labels

--- a/fiftyone/utils/coco.py
+++ b/fiftyone/utils/coco.py
@@ -615,9 +615,6 @@ class COCODetectionDatasetExporter(
 ):
     """Exporter that writes COCO detection datasets to disk.
 
-    This class currently only supports exporting detections and instance
-    segmentations.
-
     See :ref:`this page <COCODetectionDataset-export>` for format details.
 
     Args:

--- a/fiftyone/utils/patches.py
+++ b/fiftyone/utils/patches.py
@@ -23,12 +23,13 @@ class ImagePatchesExtractor(object):
 
     Args:
         samples: a :class:`fiftyone.core.collections.SampleCollection`
-        patches_field: the name of the field defining the image patches in each
-            sample to extract. Must be of type
+        patches_field (None): the name of the field defining the image patches
+            in each sample to extract. Must be of type
             :class:`fiftyone.core.labels.Detection`,
             :class:`fiftyone.core.labels.Detections`,
             :class:`fiftyone.core.labels.Polyline`, or
-            :class:`fiftyone.core.labels.Polylines`
+            :class:`fiftyone.core.labels.Polylines`. This can be automatically
+            inferred (only) if ``samples`` is a patches view
         include_labels (False): whether to emit ``(img_patch, label)`` tuples
             rather than just image patches
         force_rgb (False): whether to force convert the images to RGB
@@ -45,12 +46,21 @@ class ImagePatchesExtractor(object):
     def __init__(
         self,
         samples,
-        patches_field,
+        patches_field=None,
         include_labels=False,
         force_rgb=False,
         force_square=False,
         alpha=None,
     ):
+        if patches_field is None:
+            if samples._is_patches:
+                patches_field = samples._label_fields[0]
+            else:
+                raise ValueError(
+                    "You must provide a 'patches_field' when 'samples' is not "
+                    "a patches view"
+                )
+
         self.samples = samples
         self.patches_field = patches_field
         self.include_labels = include_labels

--- a/tests/unittests/import_export_tests.py
+++ b/tests/unittests/import_export_tests.py
@@ -282,6 +282,45 @@ class ImageExportCoersionTests(ImageDatasetTests):
             len(dataset3), dataset.count("ground_truth.detections")
         )
 
+        #
+        # A patches view is provided, so object patches are exported as images
+        #
+
+        export_dir4 = self._new_dir()
+
+        patches = dataset.to_patches("ground_truth")
+        patches.export(
+            export_dir=export_dir4,
+            dataset_type=fo.types.ImageDirectory,
+        )
+
+        dataset2 = fo.Dataset.from_dir(
+            dataset_dir=export_dir4,
+            dataset_type=fo.types.ImageDirectory,
+        )
+
+        self.assertEqual(len(dataset2), len(patches))
+
+        #
+        # A patches view is provided, so the object patches are exported as an
+        # image classification directory tree
+        #
+
+        export_dir5 = self._new_dir()
+
+        patches = dataset.to_patches("ground_truth")
+        patches.export(
+            export_dir=export_dir5,
+            dataset_type=fo.types.ImageClassificationDirectoryTree,
+        )
+
+        dataset2 = fo.Dataset.from_dir(
+            dataset_dir=export_dir5,
+            dataset_type=fo.types.ImageClassificationDirectoryTree,
+        )
+
+        self.assertEqual(len(dataset2), len(patches))
+
     @drop_datasets
     def test_single_label_to_lists(self):
         sample = fo.Sample(
@@ -3703,15 +3742,15 @@ class VideoExportCoersionTests(VideoDatasetTests):
         )
 
         #
-        # Export video classification clips directly from a ClipsView
+        # Export video classification clips directly from a clips view
         #
 
         export_dir = self._new_dir()
 
-        dataset.to_clips("predictions").export(
+        clips = dataset.to_clips("predictions")
+        clips.export(
             export_dir=export_dir,
             dataset_type=fo.types.VideoClassificationDirectoryTree,
-            label_field="predictions",
         )
 
         dataset2 = fo.Dataset.from_dir(
@@ -3753,7 +3792,6 @@ class VideoExportCoersionTests(VideoDatasetTests):
         export_dir = self._new_dir()
 
         clips = dataset.to_clips("predictions")
-
         clips.export(
             export_dir=export_dir, dataset_type=fo.types.FiftyOneDataset
         )

--- a/tests/unittests/import_export_tests.py
+++ b/tests/unittests/import_export_tests.py
@@ -299,7 +299,9 @@ class ImageExportCoersionTests(ImageDatasetTests):
             dataset_type=fo.types.ImageDirectory,
         )
 
-        self.assertEqual(len(dataset2), len(patches))
+        self.assertEqual(
+            len(dataset2), dataset.count("ground_truth.detections")
+        )
 
         #
         # A patches view is provided, so the object patches are exported as an
@@ -319,7 +321,9 @@ class ImageExportCoersionTests(ImageDatasetTests):
             dataset_type=fo.types.ImageClassificationDirectoryTree,
         )
 
-        self.assertEqual(len(dataset2), len(patches))
+        self.assertEqual(
+            len(dataset2), dataset.count("ground_truth.detections")
+        )
 
     @drop_datasets
     def test_single_label_to_lists(self):
@@ -3735,6 +3739,27 @@ class VideoExportCoersionTests(VideoDatasetTests):
         dataset2 = fo.Dataset.from_dir(
             dataset_dir=export_dir,
             dataset_type=fo.types.VideoClassificationDirectoryTree,
+        )
+
+        self.assertEqual(
+            len(dataset2), dataset.count("predictions.detections")
+        )
+
+        #
+        # Export video clips directly from a clips view
+        #
+
+        export_dir = self._new_dir()
+
+        clips = dataset.to_clips("predictions")
+        clips.export(
+            export_dir=export_dir,
+            dataset_type=fo.types.VideoDirectory,
+        )
+
+        dataset2 = fo.Dataset.from_dir(
+            dataset_dir=export_dir,
+            dataset_type=fo.types.VideoDirectory,
         )
 
         self.assertEqual(


### PR DESCRIPTION
This syntax for exporting object patches was previously not possible, but should have been:

```py
import fiftyone as fo
import fiftyone.zoo as foz

dataset = foz.load_zoo_dataset("quickstart")

patches = dataset.to_patches("ground_truth")
patches.export(
    export_dir="/tmp/patches",
    dataset_type=fo.types.ImageDirectory,
)
```
