### PR TITLE
use FileExplorerView by default for type File

### DIFF
--- a/app/packages/core/src/plugins/OperatorIO/utils/index.ts
+++ b/app/packages/core/src/plugins/OperatorIO/utils/index.ts
@@ -9,6 +9,7 @@ const inputComponentsByType = {
   OneOf: "OneOfView",
   Tuple: "TupleView",
   Map: "MapView",
+  File: "FileExplorerView",
 };
 const outputComponentsByType = {
   Object: "ObjectView",
@@ -18,6 +19,7 @@ const outputComponentsByType = {
   List: "ListView",
   OneOf: "OneOfView",
   Tuple: "TupleView",
+  File: "FileExplorerView",
 };
 const baseViews = ["View", "PromptView"];
 const viewAliases = {
@@ -41,6 +43,7 @@ const operatorTypeToJSONSchemaType = {
   OneOf: "oneOf",
   Tuple: "array",
   Map: "object",
+  File: "object",
 };
 const unsupportedView = "UnsupportedView";
 

--- a/app/packages/operators/src/types.ts
+++ b/app/packages/operators/src/types.ts
@@ -22,7 +22,7 @@ class OperatorObject extends BaseType {
    *  property it self. (default: `new Map()`)
    * @param properties initial properties on the object
    */
-  constructor(public properties: Map<string, Property> = new Map()) {
+  constructor(public properties: ObjectProperties = new Map()) {
     super();
   }
   /**
@@ -165,17 +165,19 @@ class OperatorObject extends BaseType {
   tuple(name, items: ANY_TYPE[], options: any = {}) {
     return this.defineProperty(name, new Tuple(items), options);
   }
+  static propertiesFromJSON(json: any): ObjectProperties {
+    const entries: Array<[string, Property]> = Object.entries(
+      json.properties
+    ).map(([k, v]) => [k, Property.fromJSON(v)]);
+    return new Map(entries);
+  }
   /**
    * Define an `Object` operator type by providing a json representing the type
    * @param json json object representing the definition of the property
    * @returns operator type `Object` created with json provided
    */
   static fromJSON(json: any) {
-    const entries = Object.entries(json.properties).map(([k, v]) => [
-      k,
-      Property.fromJSON(v),
-    ]);
-    return new OperatorObject(new Map(entries));
+    return new OperatorObject(OperatorObject.propertiesFromJSON(json));
   }
 }
 export { OperatorObject as Object };
@@ -413,6 +415,10 @@ export class File extends OperatorObject {
       label: "Directory Contents",
       description: "The contents of the directory",
     });
+  }
+
+  static fromJSON(json: any): File {
+    return new File(OperatorObject.propertiesFromJSON(json));
   }
 }
 
@@ -1127,3 +1133,4 @@ type PropertyOptions = {
   description?: string;
   view?: View;
 };
+type ObjectProperties = Map<string, Property>;


### PR DESCRIPTION
## What changes are proposed in this pull request?

When using the operator type `File`, use `FileExplorerView` as the default when no view is provided.

## How is this patch tested? If it is not, please explain why.

Using an example operator

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
