### PR TITLE
Standardizing handling of thread/process pool sizes

### DIFF
--- a/docs/source/cli/index.rst
+++ b/docs/source/cli/index.rst
@@ -1506,8 +1506,7 @@ Populates the `metadata` field of all samples in the dataset.
       -h, --help            show this help message and exit
       -o, --overwrite       whether to overwrite existing metadata
       -n NUM_WORKERS, --num-workers NUM_WORKERS
-                            the number of worker processes to use. The default
-                            is `multiprocessing.cpu_count()`
+                            a suggested number of worker processes to use
       -s, --skip-failures   whether to gracefully continue without raising an
                             error if metadata cannot be computed for a sample
 
@@ -1583,8 +1582,7 @@ Transforms the images in a dataset per the specified parameters.
       -d, --delete-originals
                             whether to delete the original images after transforming
       -n NUM_WORKERS, --num-workers NUM_WORKERS
-                            the number of worker processes to use. The default is
-                            `multiprocessing.cpu_count()`
+                            a suggested number of worker processes to use
       -s, --skip-failures   whether to gracefully continue without raising an
                             error if an image cannot be transformed
 

--- a/docs/source/user_guide/config.rst
+++ b/docs/source/user_guide/config.rst
@@ -79,6 +79,10 @@ FiftyOne supports the configuration options described below:
 | `logging_level`               | `FIFTYONE_LOGGING_LEVEL`            | `INFO`                        | Controls FiftyOne's package-wide logging level. Can be any valid ``logging`` level as  |
 |                               |                                     |                               | a string: ``DEBUG, INFO, WARNING, ERROR, CRITICAL``.                                   |
 +-------------------------------+-------------------------------------+-------------------------------+----------------------------------------------------------------------------------------+
+| `max_thread_pool_workers`     | `FIFTYONE_MAX_THREAD_POOL_WORKERS`  | `None`                        | An optional maximum number of workers to use when creating thread pools                |
++-------------------------------+-------------------------------------+-------------------------------+----------------------------------------------------------------------------------------+
+| `max_process_pool_workers`    | `FIFTYONE_MAX_PROCESS_POOL_WORKERS` | `None`                        | An optional maximum number of workers to use when creating process pools               |
++-------------------------------+-------------------------------------+-------------------------------+----------------------------------------------------------------------------------------+
 | `model_zoo_dir`               | `FIFTYONE_MODEL_ZOO_DIR`            | `~/fiftyone/__models__`       | The default directory in which to store models that are downloaded from the            |
 |                               |                                     |                               | :ref:`FiftyOne Model Zoo <model-zoo>`.                                                 |
 +-------------------------------+-------------------------------------+-------------------------------+----------------------------------------------------------------------------------------+
@@ -151,6 +155,8 @@ and the CLI:
             "desktop_app": false,
             "do_not_track": false,
             "logging_level": "INFO",
+            "max_thread_pool_workers": null,
+            "max_process_pool_workers": null,
             "model_zoo_dir": "~/fiftyone/__models__",
             "model_zoo_manifest_paths": null,
             "module_path": null,
@@ -196,6 +202,8 @@ and the CLI:
             "desktop_app": false,
             "do_not_track": false,
             "logging_level": "INFO",
+            "max_thread_pool_workers": null,
+            "max_process_pool_workers": null,
             "model_zoo_dir": "~/fiftyone/__models__",
             "model_zoo_manifest_paths": null,
             "module_path": null,

--- a/fiftyone/core/cli.py
+++ b/fiftyone/core/cli.py
@@ -3751,10 +3751,7 @@ class ComputeMetadataCommand(Command):
             "--num-workers",
             default=None,
             type=int,
-            help=(
-                "the number of worker processes to use. The default is "
-                "`multiprocessing.cpu_count()`"
-            ),
+            help="a suggested number of worker processes to use",
         )
         parser.add_argument(
             "-s",
@@ -3896,10 +3893,7 @@ class TransformImagesCommand(Command):
             "--num-workers",
             default=None,
             type=int,
-            help=(
-                "the number of worker processes to use. The default is "
-                "`multiprocessing.cpu_count()`"
-            ),
+            help="a suggested number of worker processes to use",
         )
         parser.add_argument(
             "-s",

--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -2666,8 +2666,7 @@ class SampleCollection(object):
 
         Args:
             overwrite (False): whether to overwrite existing metadata
-            num_workers (None): the number of processes to use. By default,
-                ``multiprocessing.cpu_count()`` is used
+            num_workers (None): a suggested number of processes to use
             skip_failures (True): whether to gracefully continue without
                 raising an error if metadata cannot be computed for a sample
         """

--- a/fiftyone/core/config.py
+++ b/fiftyone/core/config.py
@@ -218,11 +218,16 @@ class FiftyOneConfig(EnvConfig):
         self.timezone = self.parse_string(
             d, "timezone", env_var="FIFTYONE_TIMEZONE", default=None
         )
-
         self.max_thread_pool_workers = self.parse_int(
             d,
             "max_thread_pool_workers",
             env_var="FIFTYONE_MAX_THREAD_POOL_WORKERS",
+            default=None,
+        )
+        self.max_process_pool_workers = self.parse_int(
+            d,
+            "max_process_pool_workers",
+            env_var="FIFTYONE_MAX_PROCESS_POOL_WORKERS",
             default=None,
         )
 

--- a/fiftyone/core/metadata.py
+++ b/fiftyone/core/metadata.py
@@ -7,7 +7,6 @@ Metadata stored in dataset samples.
 """
 import itertools
 import logging
-import multiprocessing
 import os
 import requests
 
@@ -16,6 +15,7 @@ from PIL import Image
 import eta.core.utils as etau
 import eta.core.video as etav
 
+import fiftyone as fo
 from fiftyone.core.odm import DynamicEmbeddedDocument
 import fiftyone.core.fields as fof
 import fiftyone.core.media as fom
@@ -240,13 +240,11 @@ def compute_metadata(
         sample_collection: a
             :class:`fiftyone.core.collections.SampleCollection`
         overwrite (False): whether to overwrite existing metadata
-        num_workers (None): the number of processes to use. By default,
-            ``multiprocessing.cpu_count()`` is used
+        num_workers (None): a suggested number of processes to use
         skip_failures (True): whether to gracefully continue without raising an
             error if metadata cannot be computed for a sample
     """
-    if num_workers is None:
-        num_workers = multiprocessing.cpu_count()
+    num_workers = fou.recommend_process_pool_workers(num_workers)
 
     if sample_collection.media_type == fom.GROUP:
         sample_collection = sample_collection.select_group_slices(

--- a/fiftyone/core/storage.py
+++ b/fiftyone/core/storage.py
@@ -827,16 +827,14 @@ def run(fcn, tasks, num_workers=None, progress=False):
     Args:
         fcn: a function that accepts a single argument
         tasks: an iterable of function aguments
-        num_workers (None): the number of threads to use. By default,
-            ``multiprocessing.cpu_count()`` is used
+        num_workers (None): a suggested number of threads to use
         progress (False): whether to render a progress bar tracking the status
             of the operation
 
     Returns:
         the list of function outputs
     """
-    if num_workers is None:
-        num_workers = multiprocessing.cpu_count()
+    num_workers = fou.recommend_thread_pool_workers(num_workers)
 
     try:
         num_tasks = len(tasks)
@@ -845,7 +843,7 @@ def run(fcn, tasks, num_workers=None, progress=False):
 
     kwargs = dict(total=num_tasks, iters_str="files", quiet=not progress)
 
-    if not num_workers or num_workers <= 1:
+    if num_workers <= 1:
         with fou.ProgressBar(**kwargs) as pb:
             results = [fcn(task) for task in pb(tasks)]
     else:
@@ -863,8 +861,7 @@ def _copy_files(inpaths, outpaths, skip_failures, progress):
 
 
 def _run(fcn, tasks, num_workers=None, progress=False):
-    if num_workers is None:
-        num_workers = multiprocessing.cpu_count()
+    num_workers = fou.recommend_thread_pool_workers(num_workers)
 
     try:
         num_tasks = len(tasks)
@@ -873,7 +870,7 @@ def _run(fcn, tasks, num_workers=None, progress=False):
 
     kwargs = dict(total=num_tasks, iters_str="files", quiet=not progress)
 
-    if not num_workers or num_workers <= 1:
+    if num_workers <= 1:
         with fou.ProgressBar(**kwargs) as pb:
             for task in pb(tasks):
                 fcn(task)

--- a/fiftyone/core/utils.py
+++ b/fiftyone/core/utils.py
@@ -5,7 +5,6 @@ Core utilities.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
-import typing as t
 import atexit
 from base64 import b64encode, b64decode
 from collections import defaultdict
@@ -1691,6 +1690,77 @@ def get_multiprocessing_context():
     return multiprocessing.get_context()
 
 
+def recommend_thread_pool_workers(num_workers=None):
+    """Recommends a number of workers for a thread pool.
+
+    If a ``fo.config.max_thread_pool_workers`` is set, this limit is applied.
+
+    Args:
+        num_workers (None): a suggested number of workers
+
+    Returns:
+        a number of workers
+    """
+    if num_workers is None:
+        num_workers = multiprocessing.cpu_count()
+
+    if fo.config.max_thread_pool_workers is not None:
+        num_workers = min(num_workers, fo.config.max_thread_pool_workers)
+
+    return num_workers
+
+
+def recommend_process_pool_workers(num_workers=None):
+    """Recommends a number of workers for a process pool.
+
+    If a ``fo.config.max_process_pool_workers`` is set, this limit is applied.
+
+    Args:
+        num_workers (None): a suggested number of workers
+
+    Returns:
+        a number of workers
+    """
+    if num_workers is None:
+        if sys.platform.startswith("win"):
+            # Windows tends to have multiprocessing issues
+            num_workers = 1
+        else:
+            num_workers = multiprocessing.cpu_count()
+
+    if fo.config.max_process_pool_workers is not None:
+        num_workers = min(num_workers, fo.config.max_process_pool_workers)
+
+    return num_workers
+
+
+sync_task_executor = None
+
+
+def _get_sync_task_executor():
+    global sync_task_executor
+
+    max_workers = fo.config.max_thread_pool_workers
+    if sync_task_executor is None and max_workers is not None:
+        sync_task_executor = ThreadPoolExecutor(max_workers=max_workers)
+
+    return sync_task_executor
+
+
+async def run_sync_task(func, *args):
+    """Run a synchronous function as an async background task.
+
+    Args:
+        func: a synchronous callable
+        *args: function arguments
+
+    Returns:
+        the function's return value(s)
+    """
+    loop = asyncio.get_running_loop()
+    return await loop.run_in_executor(_get_sync_task_executor(), func, *args)
+
+
 def datetime_to_timestamp(dt):
     """Converts a `datetime.date` or `datetime.datetime` to milliseconds since
     epoch.
@@ -1874,31 +1944,6 @@ def to_slug(name):
         )
 
     return slug
-
-
-_T = t.TypeVar("_T")
-
-sync_task_executor = None
-
-
-def get_sync_task_executor():
-    global sync_task_executor
-    max_workers = fo.config.max_thread_pool_workers
-    if sync_task_executor is None and max_workers is not None:
-        sync_task_executor = ThreadPoolExecutor(max_workers=max_workers)
-    return sync_task_executor
-
-
-async def run_sync_task(func: t.Callable[..., _T], *args: t.Any):
-    """
-    Run a synchronous function as an async background task
-
-    Args:
-        run: a synchronous callable
-    """
-    loop = asyncio.get_running_loop()
-
-    return await loop.run_in_executor(get_sync_task_executor(), func, *args)
 
 
 def validate_color(value):

--- a/fiftyone/plugins/utils.py
+++ b/fiftyone/plugins/utils.py
@@ -6,12 +6,13 @@ FiftyOne plugin utilities.
 |
 """
 import logging
-import multiprocessing
+import multiprocessing.dummy
 import os
 
 from bs4 import BeautifulSoup
 import yaml
 
+import fiftyone.core.utils as fou
 from fiftyone.utils.github import GitHubRepository
 from fiftyone.plugins.core import PLUGIN_METADATA_FILENAMES
 
@@ -196,8 +197,10 @@ def _get_all_plugin_info(tasks):
     if num_tasks == 1:
         return [_do_get_plugin_info(tasks[0])]
 
+    num_workers = fou.recommend_thread_pool_workers(min(num_tasks, 4))
+
     info = []
-    with multiprocessing.dummy.Pool(processes=min(num_tasks, 4)) as pool:
+    with multiprocessing.dummy.Pool(processes=num_workers) as pool:
         for d in pool.imap_unordered(_do_get_plugin_info, tasks):
             info.append(d)
 

--- a/fiftyone/utils/activitynet.py
+++ b/fiftyone/utils/activitynet.py
@@ -54,9 +54,8 @@ def download_activitynet_split(
         copy_files (True): whether to move (False) or create copies (True) of
             the source files when populating ``dataset_dir``. This is only
             relevant when a ``source_dir`` is provided
-        num_workers (None): the number of threads to use when downloading
-            individual video. By default, ``multiprocessing.cpu_count()`` is
-            used
+        num_workers (None): a suggested number of threads to use when
+            downloading individual videos
         shuffle (False): whether to randomly shuffle the order in which samples
             are chosen for partial downloads
         seed (None): a random seed to use when shuffling

--- a/fiftyone/utils/aws.py
+++ b/fiftyone/utils/aws.py
@@ -6,7 +6,6 @@ Utilities for working with `Amazon Web Services <https://aws.amazon.com>`.
 |
 """
 import logging
-import multiprocessing
 import multiprocessing.dummy
 import os
 from urllib.parse import urlparse
@@ -50,8 +49,8 @@ def download_public_s3_files(
             the `download_dir` argument is required
         download_dir (None): the directory to store all downloaded objects.
             This is only used if `urls` is a list
-        num_workers (None): the number of processes to use when downloading
-            files. By default, ``multiprocessing.cpu_count()`` is used
+        num_workers (None): a suggested number of threads to use when
+            downloading files
         overwrite (True): whether to overwrite existing files
     """
     if not isinstance(urls, dict):
@@ -65,8 +64,7 @@ def download_public_s3_files(
     if download_dir:
         etau.ensure_dir(download_dir)
 
-    if num_workers is None:
-        num_workers = multiprocessing.cpu_count()
+    num_workers = fou.recommend_thread_pool_workers(num_workers)
 
     s3_client = boto3.client(
         "s3",

--- a/fiftyone/utils/beam.py
+++ b/fiftyone/utils/beam.py
@@ -6,7 +6,6 @@
 |
 """
 import logging
-import multiprocessing
 import numpy as np
 
 import fiftyone.core.dataset as fod
@@ -89,14 +88,13 @@ def beam_import(
         options (None): a
             ``apache_beam.options.pipeline_options.PipelineOptions`` that
             configures how to run the pipeline. By default, the pipeline will
-            be run via Beam's direct runner using
-            ``multiprocessing.cpu_count()`` threads
+            be run via Beam's direct runner using threads
         verbose (False): whether to log the Beam pipeline's messages
     """
     if options is None:
         options = PipelineOptions(
             runner="direct",
-            direct_num_workers=multiprocessing.cpu_count(),
+            direct_num_workers=fou.recommend_thread_pool_workers(),
             direct_running_mode="multi_threading",
         )
 
@@ -183,8 +181,7 @@ def beam_merge(
         options (None): a
             ``apache_beam.options.pipeline_options.PipelineOptions`` that
             configures how to run the pipeline. By default, the pipeline will
-            be run via Beam's direct runner using
-            ``multiprocessing.cpu_count()`` threads
+            be run via Beam's direct runner using threads
         verbose (False): whether to log the Beam pipeline's messages
         **kwargs: keyword arguments for
             :meth:`fiftyone.core.dataset.Dataset.merge_samples`
@@ -213,7 +210,7 @@ def beam_merge(
     if options is None:
         options = PipelineOptions(
             runner="direct",
-            direct_num_workers=multiprocessing.cpu_count(),
+            direct_num_workers=fou.recommend_thread_pool_workers(),
             direct_running_mode="multi_threading",
         )
 
@@ -290,8 +287,7 @@ def beam_export(
         options (None): a
             ``apache_beam.options.pipeline_options.PipelineOptions`` that
             configures how to run the pipeline. By default, the pipeline will
-            be run via Beam's direct runner using
-            ``min(num_shards, multiprocessing.cpu_count())`` processes
+            be run via Beam's direct runner using multiprocessing
         verbose (False): whether to log the Beam pipeline's messages
         render_kwargs (None): a function that renders ``kwargs`` for the
             current shard. The function should have signature
@@ -303,7 +299,7 @@ def beam_export(
             :meth:`fiftyone.core.collections.SampleCollection.export`
     """
     if options is None:
-        num_workers = min(num_shards, multiprocessing.cpu_count())
+        num_workers = min(num_shards, fou.recommend_process_pool_workers())
         options = PipelineOptions(
             runner="direct",
             direct_num_workers=num_workers,

--- a/fiftyone/utils/coco.py
+++ b/fiftyone/utils/coco.py
@@ -11,7 +11,6 @@ import csv
 from datetime import datetime
 from itertools import groupby
 import logging
-import multiprocessing
 import multiprocessing.dummy
 import os
 import random
@@ -1482,9 +1481,8 @@ def download_coco_dataset_split(
             -   the path to a text (newline-separated), JSON, or CSV file
                 containing the list of image IDs to load in either of the first
                 two formats
-        num_workers (None): the number of processes to use when downloading
-            individual images. By default, ``multiprocessing.cpu_count()`` is
-            used
+        num_workers (None): a suggested number of threads to use when
+            downloading individual images
         shuffle (False): whether to randomly shuffle the order in which samples
             are chosen for partial downloads
         seed (None): a random seed to use when shuffling
@@ -1849,8 +1847,7 @@ def _get_existing_ids(images_dir, images, image_ids):
 
 
 def _download_images(images_dir, image_ids, images, num_workers):
-    if num_workers is None:
-        num_workers = multiprocessing.cpu_count()
+    num_workers = fou.recommend_thread_pool_workers(num_workers)
 
     tasks = []
     for image_id in image_ids:

--- a/fiftyone/utils/cvat.py
+++ b/fiftyone/utils/cvat.py
@@ -12,7 +12,6 @@ from datetime import datetime
 import itertools
 import logging
 import math
-import multiprocessing
 import multiprocessing.dummy
 import os
 from packaging.version import Version
@@ -118,8 +117,8 @@ def import_annotations(
         download_media (False): whether to download the images or videos found
             in CVAT to the directory or filepaths in ``data_path`` if not
             already present
-        num_workers (None): the number of processes to use when downloading
-            media. By default, ``multiprocessing.cpu_count()`` is used
+        num_workers (None): a suggested number of threads to use when
+            downloading media
         occluded_attr (None): an optional attribute name in which to store the
             occlusion information for all spatial labels
         group_id_attr (None): an optional attribute name in which to store the
@@ -325,8 +324,7 @@ def _parse_task_metadata(
 
 
 def _download_media(tasks, num_workers):
-    if num_workers is None:
-        num_workers = multiprocessing.cpu_count()
+    num_workers = fou.recommend_thread_pool_workers(num_workers)
 
     logger.info("Downloading media...")
     if num_workers <= 1:

--- a/fiftyone/utils/data/base.py
+++ b/fiftyone/utils/data/base.py
@@ -6,7 +6,7 @@ Data utilities.
 |
 """
 import logging
-import multiprocessing
+import multiprocessing.dummy
 import requests
 import os
 import pathlib
@@ -118,8 +118,8 @@ def download_image_classification_dataset(
         dataset_dir: the directory to write the dataset
         classes (None): an optional list of classes. By default, this will be
             inferred from the contents of ``csv_path``
-        num_workers (None): the number of processes to use to download images.
-            By default, ``multiprocessing.cpu_count()`` is used
+        num_workers (None): a suggested number of threads to use to download
+            images
     """
     labels, image_urls = zip(
         *[
@@ -161,14 +161,12 @@ def download_images(image_urls, output_dir, num_workers=None):
     Args:
         image_urls: a list of image URLs to download
         output_dir: the directory to write the images
-        num_workers (None): the number of processes to use. By default,
-            ``multiprocessing.cpu_count()`` is used
+        num_workers (None): a suggested number of threads to use
 
     Returns:
         the list of downloaded image paths
     """
-    if num_workers is None:
-        num_workers = multiprocessing.cpu_count()
+    num_workers = fou.recommend_thread_pool_workers(num_workers)
 
     inputs = []
     for url in image_urls:
@@ -192,9 +190,7 @@ def _download_images(inputs):
 
 def _download_images_multi(inputs, num_workers):
     with fou.ProgressBar(inputs) as pb:
-        with fou.get_multiprocessing_context().Pool(
-            processes=num_workers
-        ) as pool:
+        with multiprocessing.dummy.Pool(processes=num_workers) as pool:
             for _ in pb(pool.imap_unordered(_download_image, inputs)):
                 pass
 

--- a/fiftyone/utils/image.py
+++ b/fiftyone/utils/image.py
@@ -6,7 +6,6 @@ Image utilities.
 |
 """
 import logging
-import multiprocessing
 import os
 
 import eta.core.image as etai
@@ -98,8 +97,7 @@ def reencode_images(
             sample collection
         delete_originals (False): whether to delete the original images after
             re-encoding
-        num_workers (None): the number of worker processes to use. By default,
-            ``multiprocessing.cpu_count()`` is used
+        num_workers (None): a suggested number of worker processes to use
         skip_failures (False): whether to gracefully continue without raising
             an error if an image cannot be re-encoded
     """
@@ -188,8 +186,7 @@ def transform_images(
             sample collection
         delete_originals (False): whether to delete the original images if any
             transformation was applied
-        num_workers (None): the number of worker processes to use. By default,
-            ``multiprocessing.cpu_count()`` is used
+        num_workers (None): a suggested number of worker processes to use
         skip_failures (False): whether to gracefully continue without raising
             an error if an image cannot be transformed
     """
@@ -277,8 +274,7 @@ def _transform_images(
 ):
     ext = _parse_ext(ext)
 
-    if num_workers is None:
-        num_workers = multiprocessing.cpu_count()
+    num_workers = fou.recommend_process_pool_workers(num_workers)
 
     if num_workers <= 1:
         _transform_images_single(

--- a/fiftyone/utils/kinetics.py
+++ b/fiftyone/utils/kinetics.py
@@ -48,9 +48,8 @@ def download_kinetics_split(
         classes (None): a string or list of strings specifying required classes
             to load. If provided, only samples containing at least one instance
             of a specified class will be loaded
-        num_workers (None): the number of processes to use when downloading
-            individual video. By default, ``multiprocessing.cpu_count()`` is
-            used
+        num_workers (None): a suggested number of threads to use when
+            downloading individual videos
         shuffle (False): whether to randomly shuffle the order in which samples
             are chosen for partial downloads
         seed (None): a random seed to use when shuffling

--- a/fiftyone/utils/openimages.py
+++ b/fiftyone/utils/openimages.py
@@ -720,9 +720,8 @@ def download_open_images_split(
             -   the path to a text (newline-separated), JSON, or CSV file
                 containing the list of image IDs to load in either of the first
                 two formats
-        num_workers (None): the number of processes to use when downloading
-            individual images. By default, ``multiprocessing.cpu_count()`` is
-            used
+        num_workers (None): a suggested number of threads to use when
+            downloading individual images
         shuffle (False): whether to randomly shuffle the order in which samples
             are chosen for partial downloads
         seed (None): a random seed to use when shuffling

--- a/fiftyone/utils/sama.py
+++ b/fiftyone/utils/sama.py
@@ -1,3 +1,10 @@
+"""
+Sama utilities.
+
+| Copyright 2017-2023, Voxel51, Inc.
+| `voxel51.com <https://voxel51.com/>`_
+|
+"""
 import os
 import glob
 import random
@@ -54,9 +61,8 @@ def download_sama_coco_dataset_split(
             -   the path to a text (newline-separated), JSON, or CSV file
                 containing the list of image IDs to load in either of the first
                 two formats
-        num_workers (None): the number of processes to use when downloading
-            individual images. By default, ``multiprocessing.cpu_count()`` is
-            used
+        num_workers (None): a suggested number of threads to use when
+            downloading individual images
         shuffle (False): whether to randomly shuffle the order in which samples
             are chosen for partial downloads
         seed (None): a random seed to use when shuffling

--- a/fiftyone/utils/youtube.py
+++ b/fiftyone/utils/youtube.py
@@ -14,7 +14,6 @@ except ImportError:
 
 import itertools
 import logging
-import multiprocessing
 import multiprocessing.dummy
 import os
 
@@ -113,9 +112,8 @@ def download_youtube_videos(
                 whose resolution is closest to this target value is downloaded
         max_videos (None): the maximum number of videos to successfully
             download. By default, all videos are downloaded
-        num_workers (None): the number of threads or processes to use when
-            downloading videos. By default, ``multiprocessing.cpu_count()`` is
-            used
+        num_workers (None): a suggested number of threads/processes to use when
+            downloading videos
         skip_failures (True): whether to gracefully continue without raising
             an error if a video cannot be downloaded
         quiet (False): whether to suppress logging, except for a progress bar
@@ -165,14 +163,10 @@ def download_youtube_videos(
 
 
 def _parse_num_workers(num_workers, use_threads=False):
-    if num_workers is None:
-        if os.name == "nt" and not use_threads:
-            # Multiprocessing on Windows is bad news
-            return 1
+    if use_threads:
+        return fou.recommend_thread_pool_workers(num_workers)
 
-        return multiprocessing.cpu_count()
-
-    return num_workers
+    return fou.recommend_process_pool_workers(num_workers)
 
 
 def _build_tasks_list(
@@ -280,11 +274,11 @@ def _download_multi(
 
     with fou.ProgressBar(total=max_videos, iters_str="videos") as pb:
         if use_threads:
-            pool_cls = multiprocessing.dummy.Pool
+            ctx = multiprocessing.dummy
         else:
-            pool_cls = multiprocessing.Pool
+            ctx = fou.get_multiprocessing_context()
 
-        with pool_cls(num_workers) as pool:
+        with ctx.Pool(num_workers) as pool:
             for idx, url, video_path, error, warnings in pool.imap_unordered(
                 _do_download, tasks
             ):

--- a/fiftyone/zoo/datasets/base.py
+++ b/fiftyone/zoo/datasets/base.py
@@ -146,9 +146,8 @@ class ActivityNet100Dataset(FiftyOneDataset):
         copy_files (True): whether to move (False) or create copies (True) of
             the source files when populating ``dataset_dir``. This is only
             relevant when a ``source_dir`` is provided
-        num_workers (None): the number of processes to use when downloading
-            individual images. By default, ``multiprocessing.cpu_count()`` is
-            used
+        num_workers (None): a suggested number of threads to use when
+            downloading individual images
         shuffle (False): whether to randomly shuffle the order in which samples
             are chosen for partial downloads
         seed (None): a random seed to use when shuffling
@@ -326,9 +325,8 @@ class ActivityNet200Dataset(FiftyOneDataset):
         copy_files (True): whether to move (False) or create copies (True) of
             the source files when populating ``dataset_dir``. This is only
             relevant when a ``source_dir`` is provided
-        num_workers (None): the number of processes to use when downloading
-            individual images. By default, ``multiprocessing.cpu_count()`` is
-            used
+        num_workers (None): a suggested number of threads to use when
+            downloading individual images
         shuffle (False): whether to randomly shuffle the order in which samples
             are chosen for partial downloads
         seed (None): a random seed to use when shuffling
@@ -892,9 +890,8 @@ class COCO2014Dataset(FiftyOneDataset):
             -   the path to a text (newline-separated), JSON, or CSV file
                 containing the list of image IDs to load in either of the first
                 two formats
-        num_workers (None): the number of processes to use when downloading
-            individual images. By default, ``multiprocessing.cpu_count()`` is
-            used
+        num_workers (None): a suggested number of threads to use when
+            downloading individual images
         shuffle (False): whether to randomly shuffle the order in which samples
             are chosen for partial downloads
         seed (None): a random seed to use when shuffling
@@ -1087,9 +1084,8 @@ class COCO2017Dataset(FiftyOneDataset):
             -   the path to a text (newline-separated), JSON, or CSV file
                 containing the list of image IDs to load in either of the first
                 two formats
-        num_workers (None): the number of processes to use when downloading
-            individual images. By default, ``multiprocessing.cpu_count()`` is
-            used
+        num_workers (None): a suggested number of threads to use when
+            downloading individual images
         shuffle (False): whether to randomly shuffle the order in which samples
             are chosen for partial downloads
         seed (None): a random seed to use when shuffling
@@ -1283,9 +1279,8 @@ class SamaCOCODataset(FiftyOneDataset):
             -   the path to a text (newline-separated), JSON, or CSV file
                 containing the list of image IDs to load in either of the first
                 two formats
-        num_workers (None): the number of processes to use when downloading
-            individual images. By default, ``multiprocessing.cpu_count()`` is
-            used
+        num_workers (None): a suggested number of threads to use when
+            downloading individual images
         shuffle (False): whether to randomly shuffle the order in which samples
             are chosen for partial downloads
         seed (None): a random seed to use when shuffling
@@ -1777,9 +1772,8 @@ class Kinetics400Dataset(FiftyOneDataset):
         classes (None): a string or list of strings specifying required classes
             to load. If provided, only samples containing at least one instance
             of a specified class will be loaded
-        num_workers (None): the number of processes to use when downloading
-            individual images. By default, ``multiprocessing.cpu_count()`` is
-            used
+        num_workers (None): a suggested number of threads to use when
+            downloading individual images
         shuffle (False): whether to randomly shuffle the order in which samples
             are chosen for partial downloads
         seed (None): a random seed to use when shuffling
@@ -1933,9 +1927,8 @@ class Kinetics600Dataset(FiftyOneDataset):
         classes (None): a string or list of strings specifying required classes
             to load. If provided, only samples containing at least one instance
             of a specified class will be loaded
-        num_workers (None): the number of processes to use when downloading
-            individual images. By default, ``multiprocessing.cpu_count()`` is
-            used
+        num_workers (None): a suggested number of threads to use when
+            downloading individual images
         shuffle (False): whether to randomly shuffle the order in which samples
             are chosen for partial downloads
         seed (None): a random seed to use when shuffling
@@ -2083,9 +2076,8 @@ class Kinetics700Dataset(FiftyOneDataset):
         classes (None): a string or list of strings specifying required classes
             to load. If provided, only samples containing at least one instance
             of a specified class will be loaded
-        num_workers (None): the number of processes to use when downloading
-            individual images. By default, ``multiprocessing.cpu_count()`` is
-            used
+        num_workers (None): a suggested number of threads to use when
+            downloading individual images
         shuffle (False): whether to randomly shuffle the order in which samples
             are chosen for partial downloads
         seed (None): a random seed to use when shuffling
@@ -2240,9 +2232,8 @@ class Kinetics7002020Dataset(FiftyOneDataset):
         classes (None): a string or list of strings specifying required classes
             to load. If provided, only samples containing at least one instance
             of a specified class will be loaded
-        num_workers (None): the number of processes to use when downloading
-            individual images. By default, ``multiprocessing.cpu_count()`` is
-            used
+        num_workers (None): a suggested number of threads to use when
+            downloading individual images
         shuffle (False): whether to randomly shuffle the order in which samples
             are chosen for partial downloads
         seed (None): a random seed to use when shuffling
@@ -2630,9 +2621,8 @@ class OpenImagesV6Dataset(FiftyOneDataset):
             -   the path to a text (newline-separated), JSON, or CSV file
                 containing the list of image IDs to load in either of the first
                 two formats
-        num_workers (None): the number of processes to use when downloading
-            individual images. By default, ``multiprocessing.cpu_count()`` is
-            used
+        num_workers (None): a suggested number of threads to use when
+            downloading individual images
         shuffle (False): whether to randomly shuffle the order in which samples
             are chosen for partial downloads
         seed (None): a random seed to use when shuffling
@@ -2822,9 +2812,8 @@ class OpenImagesV7Dataset(FiftyOneDataset):
             -   the path to a text (newline-separated), JSON, or CSV file
                 containing the list of image IDs to load in either of the first
                 two formats
-        num_workers (None): the number of processes to use when downloading
-            individual images. By default, ``multiprocessing.cpu_count()`` is
-            used
+        num_workers (None): a suggested number of threads to use when
+            downloading individual images
         shuffle (False): whether to randomly shuffle the order in which samples
             are chosen for partial downloads
         seed (None): a random seed to use when shuffling


### PR DESCRIPTION
## Change log

- Adds new `fou.recommend_process_pool_workers()` and `fou.recommend_thread_pool_workers()` methods that standardize the processing of all `num_workers` arguments throughout the codebase
- Adds a new `fo.config.max_process_pool_workers` config setting to match `fo.config.max_thread_pool_workers` and wires up both of these settings to the aforementioned two methods so that users have a single place to limit the number of threads/processes used by FO

## Example usage

```py
import fiftyone as fo
import fiftyone.zoo as foz

dataset = foz.load_zoo_dataset("quickstart")

# Uses a process pool by default
dataset.compute_metadata()

# No process pool used
fo.config.max_process_pool_workers = 1
dataset.compute_metadata(overwrite=True)
```
