### PR TITLE
Fix dataset deletion/recreation across processes

### DIFF
--- a/fiftyone/core/singletons.py
+++ b/fiftyone/core/singletons.py
@@ -36,7 +36,11 @@ class DatasetSingleton(type):
             instance.__init__(name=name, _create=_create, *args, **kwargs)
             name = instance.name  # `__init__` may have changed `name`
         else:
-            instance._update_last_loaded_at()
+            try:
+                instance._update_last_loaded_at()
+            except ValueError:
+                instance._deleted = True
+                return cls.__call__(name=name, _create=False, *args, **kwargs)
 
         cls._instances[name] = instance
 

--- a/fiftyone/core/singletons.py
+++ b/fiftyone/core/singletons.py
@@ -40,7 +40,9 @@ class DatasetSingleton(type):
                 instance._update_last_loaded_at()
             except ValueError:
                 instance._deleted = True
-                return cls.__call__(name=name, _create=False, *args, **kwargs)
+                return cls.__call__(
+                    name=name, _create=_create, *args, **kwargs
+                )
 
         cls._instances[name] = instance
 

--- a/tests/unittests/synchronization_tests.py
+++ b/tests/unittests/synchronization_tests.py
@@ -9,6 +9,7 @@ import os
 import unittest
 
 import fiftyone as fo
+import fiftyone.core.odm as foo
 
 from decorators import drop_datasets
 
@@ -29,6 +30,13 @@ class SingleProcessSynchronizationTests(unittest.TestCase):
 
         with self.assertRaises(ValueError):
             fo.Dataset("test_dataset")
+
+        dataset1.delete()
+        new_dataset1 = fo.Dataset("test_dataset")
+
+        dataset1.__class__._instances["test_dataset"] = dataset1
+        new_dataset1 = fo.load_dataset("test_dataset")
+        self.assertIsNot(dataset1, new_dataset1)
 
     @drop_datasets
     def test_sample_singletons(self):

--- a/tests/unittests/synchronization_tests.py
+++ b/tests/unittests/synchronization_tests.py
@@ -9,7 +9,6 @@ import os
 import unittest
 
 import fiftyone as fo
-import fiftyone.core.odm as foo
 
 from decorators import drop_datasets
 


### PR DESCRIPTION
Dataset singletons are currently keyed by name. The consequence of this is that when a dataset is deleted and recreated in one process, any other processes will raise a dataset is deleted exception if the original dataset singleton is still in memory. This causes the App server to remain in a persisted error state if the session is attached to the original (now deleted) dataset.

This is a sensitive change, but references to dataset singleton instances seem minimal, and keying by an immutable value seems more robust.

The below now works with this change.
```py
import fiftyone as fo
import fiftyone.zoo as foz

dataset, session = fo.quickstart()
# wait for app to launch

# delete and recreate quickstart
dataset.delete()
dataset = foz.load_zoo_dataset("quickstart")

# refreshing the App page loads the new quickstart, currently broken on `release/v0.22.2`
```

Screenshot of existing error
<img width="1470" alt="Screenshot 2023-10-11 at 10 29 40 AM" src="https://github.com/voxel51/fiftyone/assets/19821840/a32c752f-829a-4bf4-9c95-d1f203119288">
