### PR TITLE
default view and mappings for File and UploadedFile type

### DIFF
--- a/app/packages/core/src/plugins/OperatorIO/utils/index.ts
+++ b/app/packages/core/src/plugins/OperatorIO/utils/index.ts
@@ -10,6 +10,7 @@ const inputComponentsByType = {
   Tuple: "TupleView",
   Map: "MapView",
   File: "FileExplorerView",
+  UploadedFile: "FileView",
 };
 const outputComponentsByType = {
   Object: "ObjectView",
@@ -20,6 +21,7 @@ const outputComponentsByType = {
   OneOf: "OneOfView",
   Tuple: "TupleView",
   File: "FileExplorerView",
+  UploadedFile: "FileView",
 };
 const baseViews = ["View", "PromptView"];
 const viewAliases = {
@@ -44,6 +46,7 @@ const operatorTypeToJSONSchemaType = {
   Tuple: "array",
   Map: "object",
   File: "object",
+  UploadedFile: "object",
 };
 const unsupportedView = "UnsupportedView";
 

--- a/app/packages/core/src/plugins/OperatorIO/utils/index.ts
+++ b/app/packages/core/src/plugins/OperatorIO/utils/index.ts
@@ -9,6 +9,7 @@ const inputComponentsByType = {
   OneOf: "OneOfView",
   Tuple: "TupleView",
   Map: "MapView",
+  File: "FileExplorerView",
 };
 const outputComponentsByType = {
   Object: "ObjectView",
@@ -18,6 +19,7 @@ const outputComponentsByType = {
   List: "ListView",
   OneOf: "OneOfView",
   Tuple: "TupleView",
+  File: "FileExplorerView",
 };
 const baseViews = ["View", "PromptView"];
 const viewAliases = {
@@ -41,6 +43,7 @@ const operatorTypeToJSONSchemaType = {
   OneOf: "oneOf",
   Tuple: "array",
   Map: "object",
+  File: "object",
 };
 const unsupportedView = "UnsupportedView";
 

--- a/app/packages/operators/src/types.ts
+++ b/app/packages/operators/src/types.ts
@@ -22,7 +22,7 @@ class OperatorObject extends BaseType {
    *  property it self. (default: `new Map()`)
    * @param properties initial properties on the object
    */
-  constructor(public properties: Map<string, Property> = new Map()) {
+  constructor(public properties: ObjectProperties = new Map()) {
     super();
   }
   /**
@@ -165,17 +165,19 @@ class OperatorObject extends BaseType {
   tuple(name, items: ANY_TYPE[], options: any = {}) {
     return this.defineProperty(name, new Tuple(items), options);
   }
+  static propertiesFromJSON(json: any): ObjectProperties {
+    const entries: Array<[string, Property]> = Object.entries(
+      json.properties
+    ).map(([k, v]) => [k, Property.fromJSON(v)]);
+    return new Map(entries);
+  }
   /**
    * Define an `Object` operator type by providing a json representing the type
    * @param json json object representing the definition of the property
    * @returns operator type `Object` created with json provided
    */
   static fromJSON(json: any) {
-    const entries = Object.entries(json.properties).map(([k, v]) => [
-      k,
-      Property.fromJSON(v),
-    ]);
-    return new OperatorObject(new Map(entries));
+    return new OperatorObject(OperatorObject.propertiesFromJSON(json));
   }
 }
 export { OperatorObject as Object };
@@ -424,6 +426,10 @@ export class File extends OperatorObject {
       label: "Directory Contents",
       description: "The contents of the directory",
     });
+  }
+
+  static fromJSON(json: any): File {
+    return new File(OperatorObject.propertiesFromJSON(json));
   }
 }
 
@@ -1138,3 +1144,4 @@ type PropertyOptions = {
   description?: string;
   view?: View;
 };
+type ObjectProperties = Map<string, Property>;

--- a/app/packages/operators/src/types.ts
+++ b/app/packages/operators/src/types.ts
@@ -165,6 +165,24 @@ class OperatorObject extends BaseType {
   tuple(name, items: ANY_TYPE[], options: any = {}) {
     return this.defineProperty(name, new Tuple(items), options);
   }
+  /**
+   * Define a property of type {@link File} on the object
+   * @param name name of the property
+   * @param options
+   * @returns newly defined property
+   */
+  file(name, options: any = {}) {
+    return this.defineProperty(name, new File(), options);
+  }
+  /**
+   * Define a property of type {@link UploadedFile} on the object
+   * @param name name of the property
+   * @param options
+   * @returns newly defined property
+   */
+  uploadedFile(name, options: any = {}) {
+    return this.defineProperty(name, new UploadedFile(), options);
+  }
   static propertiesFromJSON(json: any): ObjectProperties {
     const entries: Array<[string, Property]> = Object.entries(
       json.properties
@@ -430,6 +448,41 @@ export class File extends OperatorObject {
 
   static fromJSON(json: any): File {
     return new File(OperatorObject.propertiesFromJSON(json));
+  }
+}
+
+/**
+ * Operator type for defining an uploaded file and its metadata.
+ */
+
+export class UploadedFile extends OperatorObject {
+  constructor(public properties: Map<string, Property> = new Map()) {
+    super(properties);
+    this.str("name", {
+      label: "Name",
+      description: "The name of the uploaded file",
+    });
+    this.str("type", {
+      label: "Type",
+      description: "The mime type of the uploaded file",
+    });
+    this.int("size", {
+      label: "Size",
+      description: "The size of the uploaded file in bytes",
+    });
+    this.str("content", {
+      label: "Content",
+      description: "The base64 encoded content of the uploaded file",
+    });
+    this.int("last_modified", {
+      label: "Last Modified",
+      description:
+        "The last modified time of the uploaded file in ms since epoch",
+    });
+  }
+
+  static fromJSON(json: object): File {
+    return new UploadedFile(OperatorObject.propertiesFromJSON(json));
   }
 }
 
@@ -1057,6 +1110,7 @@ const TYPES = {
   Tuple,
   Map: OperatorMap,
   File,
+  UploadedFile,
 };
 
 // NOTE: this should always match fiftyone/operators/types.py
@@ -1125,7 +1179,9 @@ export type ANY_TYPE =
   | Enum
   | OneOf
   | Tuple
-  | OperatorMap;
+  | OperatorMap
+  | File
+  | UploadedFile;
 export type ViewOrientation = "horizontal" | "vertical";
 export type ViewPropertyTypes =
   | string

--- a/fiftyone/operators/types.py
+++ b/fiftyone/operators/types.py
@@ -212,9 +212,18 @@ class Object(BaseType):
 
         Args:
             name: the name of the property
-            view (None): the :class:`FileExplorerView` of the property
+            view (None): the :class:`View` of the property
         """
         return self.define_property(name, File(), **kwargs)
+
+    def uploaded_file(self, name, **kwargs):
+        """Defines a property on the object that is an uploaded file.
+
+        Args:
+            name: the name of the property
+            view (None): the :class:`View` of the property
+        """
+        return self.define_property(name, UploadedFile(), **kwargs)
 
     def view(self, name, view, **kwargs):
         """Defines a view-only property.
@@ -531,6 +540,45 @@ class File(Object):
             "date_modified",
             label="Last Modified",
             description="The last modified time of the file in isoformat",
+        )
+
+
+class UploadedFile(Object):
+    """Represents an object with uploaded file content and its metadata in
+    properties.
+
+    Properties:
+        name: the name of the file
+        type: the mime type of the file
+        size: the size of the file in bytes
+        content: the base64 encoded content of the file
+        last_modified: the last modified time of the file in ms since epoch
+    """
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.str(
+            "name", label="Name", description="The name of the uploaded file"
+        )
+        self.str(
+            "type",
+            label="Type",
+            description="The mime type of the uploaded file",
+        )
+        self.int(
+            "size",
+            label="Size",
+            description="The size of the uploaded file in bytes",
+        )
+        self.str(
+            "content",
+            label="Content",
+            description="The base64 encoded content of the uploaded file",
+        )
+        self.int(
+            "last_modified",
+            label="Last Modified",
+            description="The last modified time of the uploaded file in ms since epoch",
         )
 
 
@@ -992,29 +1040,15 @@ class AutocompleteView(Choices):
         super().__init__(**kwargs)
 
 
-class UploadedFile(dict):
-    """Represents an uploaded file.
-
-    Attributes:
-        name: the name of the file
-        type: the mime type of the file
-        size: the size of the file in bytes
-        content: the base64 encoded contents of the file
-        last_modified: the last modified time of the file in ms since epoch
-    """
-
-    def __init__(self):
-        pass
-
-
 class FileView(View):
     """Displays a file input.
 
     .. note::
 
-        This view can be used on string or object properties. If used on a
-        string property, the value will be the file base64 encoded contents.
-        If used on an object the value will be a :class:`UploadedFile` object.
+        This view can be used on :class:`String` or :class:`UploadedFile`
+        properties. If used on a :class:`String` property, the value will be the
+        value will be the file base64 encoded contents. If used on a
+        :class:`UploadedFile`, the value will be a :class:`UploadedFile` object.
 
     Args:
         max_size: the maximum size of the file in bytes


### PR DESCRIPTION
## What changes are proposed in this pull request?

Tweak UploadedFile type to have a default view when no view is provided. 

## How is this patch tested? If it is not, please explain why.

Tested in the app with an example operator

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

Refer to https://github.com/voxel51/fiftyone/pull/3629

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
