### PR TITLE
use fallback icon when operator is non-executable

### DIFF
--- a/app/packages/operators/src/OperatorIcon.tsx
+++ b/app/packages/operators/src/OperatorIcon.tsx
@@ -3,11 +3,19 @@ import { useColorScheme } from "@mui/material";
 import { resolveServerPath } from "./utils";
 
 export default function OperatorIcon(props: CustomIconPropsType) {
-  const { pluginName, icon, lightIcon, darkIcon, _builtIn, Fallback } = props;
+  const {
+    pluginName,
+    icon,
+    lightIcon,
+    darkIcon,
+    _builtIn,
+    Fallback,
+    canExecute,
+  } = props;
   const { mode } = useColorScheme();
   const iconPath = mode === "dark" && darkIcon ? darkIcon : lightIcon || icon;
 
-  if (!iconPath) return Fallback ? <Fallback /> : null;
+  if (!iconPath || !canExecute) return Fallback ? <Fallback /> : null;
   if (_builtIn) return <ImageIcon src={iconPath} />;
   return <CustomOperatorIcon pluginName={pluginName} iconPath={iconPath} />;
 }
@@ -32,6 +40,7 @@ export type CustomIconPropsType = {
   darkIcon?: string;
   _builtIn?: boolean;
   Fallback?: React.ComponentType;
+  canExecute?: boolean;
 };
 
 type CustomOperatorIconPropsType = {


### PR DESCRIPTION
## What changes are proposed in this pull request?

Use the `Fallback` icon when the operator is not executable to prevent missing plugin exceptions. The Lock icon for non-executable will be displayed instead

## How is this patch tested? If it is not, please explain why.

By disabling a plugin with an operator that has custom icon

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
