### PR TITLE
Fix error with Esc key

### DIFF
--- a/app/packages/core/src/components/Actions/ActionsRow.tsx
+++ b/app/packages/core/src/components/Actions/ActionsRow.tsx
@@ -234,7 +234,7 @@ const Selected = ({
       setLoading(e.detail)
     );
 
-  if (samples.size < 1 && !modal) {
+  if (!samples.size || (samples.size < 1 && !modal)) {
     return null;
   }
 

--- a/app/packages/core/src/components/Actions/ActionsRow.tsx
+++ b/app/packages/core/src/components/Actions/ActionsRow.tsx
@@ -234,7 +234,7 @@ const Selected = ({
       setLoading(e.detail)
     );
 
-  if (!samples.size || (samples.size < 1 && !modal)) {
+  if (samples.size < 1 && !modal) {
     return null;
   }
 

--- a/app/packages/core/src/components/Grid/Grid.tsx
+++ b/app/packages/core/src/components/Grid/Grid.tsx
@@ -162,7 +162,7 @@ const Grid: React.FC<{}> = () => {
 
         if (!isModalOpen) {
           reset(fos.selectedSamples);
-          setSelectedSamples([]);
+          setSelectedSamples(new Set());
         }
       },
     [setSelectedSamples, isModalOpen]


### PR DESCRIPTION
## What changes are proposed in this pull request?

Fix error when pressing Esc button while in grid view with and without anything selected 
- reset to new set not array
- check selected.size exists 
![image](https://github.com/voxel51/fiftyone/assets/30936736/5d4e2818-bbc6-4e63-82e5-9ffbb766a6bb)


## How is this patch tested? If it is not, please explain why.

run locally. no error when press escape

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
