### PR TITLE
fix placement icon showing fallback icon

### DIFF
--- a/app/packages/operators/src/OperatorPlacements.tsx
+++ b/app/packages/operators/src/OperatorPlacements.tsx
@@ -50,6 +50,7 @@ function ButtonPlacement(props: OperatorPlacementProps) {
   const { label } = view;
   const { icon, darkIcon, lightIcon, prompt = true } = view?.options || {};
   const { execute } = useOperatorExecutor(uri);
+  const canExecute = operator?.config?.canExecute;
 
   const showIcon =
     isPrimitiveString(icon) ||
@@ -64,6 +65,7 @@ function ButtonPlacement(props: OperatorPlacementProps) {
       darkIcon={darkIcon}
       lightIcon={lightIcon}
       Fallback={Extension}
+      canExecute={canExecute}
     />
   );
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

Fix placement icon showing fallback icon even when the custom icon is provided. Regressed in #3661

## How is this patch tested? If it is not, please explain why.

In the App with an operator containing a placement with icon provided

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
