### PR TITLE
remove unneeded Flask dep

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -4,7 +4,6 @@ boto3==1.17.36
 cachetools==5.2.0
 dacite==1.6.0
 Deprecated==1.2.11
-Flask==1.1.2
 ftfy==6.1.1
 httpx==0.23.0
 hypercorn==0.13.2


### PR DESCRIPTION
Dependabot complains about Flask but I don't think we even use it anywhere, so maybe we can just get rid of it. It's not included in the fiftyone package, only when built from source. Dep line last touched 3 yrs ago. @benjaminpkane confirm?

https://github.com/voxel51/fiftyone/security/dependabot/69