### PR TITLE
include dataset name when resolving operators list

### DIFF
--- a/app/packages/operators/src/built-in-operators.ts
+++ b/app/packages/operators/src/built-in-operators.ts
@@ -780,9 +780,9 @@ export function registerBuiltInOperators() {
   }
 }
 
-export async function loadOperators() {
+export async function loadOperators(datasetName: string) {
   registerBuiltInOperators();
-  await loadOperatorsFromServer();
+  await loadOperatorsFromServer(datasetName);
 }
 
 function getLayout(layout) {

--- a/app/packages/operators/src/operators.ts
+++ b/app/packages/operators/src/operators.ts
@@ -294,10 +294,14 @@ export function _registerBuiltInOperator(OperatorType: typeof Operator) {
   localRegistry.register(operator);
 }
 
-export async function loadOperatorsFromServer() {
+export async function loadOperatorsFromServer(datasetName: string) {
   initializationErrors = [];
   try {
-    const { operators, errors } = await getFetchFunction()("GET", "/operators");
+    const { operators, errors } = await getFetchFunction()(
+      "POST",
+      "/operators",
+      { dataset_name: datasetName }
+    );
     const operatorInstances = operators.map((d: any) =>
       Operator.fromRemoteJSON(d)
     );

--- a/app/packages/operators/src/state.ts
+++ b/app/packages/operators/src/state.ts
@@ -389,9 +389,15 @@ export function filterChoicesByQuery(query, all) {
   });
 }
 
+export const availableOperatorsRefreshCount = atom({
+  key: "availableOperatorsRefreshCount",
+  default: 0,
+});
+
 export const availableOperators = selector({
   key: "availableOperators",
-  get: () => {
+  get: ({ get }) => {
+    get(availableOperatorsRefreshCount); // triggers force refresh manually
     return listLocalAndRemoteOperators().allOperators.map((operator) => {
       return {
         label: operator.label,

--- a/fiftyone/operators/permissions.py
+++ b/fiftyone/operators/permissions.py
@@ -29,9 +29,11 @@ class PermissionedOperatorRegistry(OperatorRegistry):
         return self.managed_operators.has_operator(operator_uri)
 
     @classmethod
-    async def from_list_request(cls, request):
+    async def from_list_request(cls, request, dataset_ids=None):
         return PermissionedOperatorRegistry(
-            await ManagedOperators.for_request(request),
+            await ManagedOperators.for_request(
+                request, dataset_ids=dataset_ids
+            ),
         )
 
     @classmethod

--- a/fiftyone/operators/server.py
+++ b/fiftyone/operators/server.py
@@ -25,9 +25,11 @@ from .permissions import PermissionedOperatorRegistry
 
 class ListOperators(HTTPEndpoint):
     @route
-    async def get(self, request: Request, data: dict):
+    async def post(self, request: Request, data: dict):
+        dataset_name = data.get("dataset_name", None)
+        dataset_ids = [dataset_name]
         registry = await PermissionedOperatorRegistry.from_list_request(
-            request
+            request, dataset_ids=dataset_ids
         )
         ctx = ExecutionContext()
         operators_as_json = [


### PR DESCRIPTION
## What changes are proposed in this pull request?

When resolving list of operators, include the dataset name in body

## How is this patch tested? If it is not, please explain why.

Using operators browser in the app

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
