### PR TITLE
primitive types validation enhancements

### DIFF
--- a/app/packages/operators/src/types.ts
+++ b/app/packages/operators/src/types.ts
@@ -237,10 +237,21 @@ export class Property {
  * Operator type for representing a string value for operator input/output.
  */
 class OperatorString extends BaseType {
+  allowEmpty?: boolean;
+
+  /**
+   * Construct operator type for string values
+   * @param options options for defining constraints on a string value
+   * @param options.allowEmpty allow an empty string value
+   * number
+   */
+  constructor(options: { allowEmpty?: boolean } = {}) {
+    super();
+    this.allowEmpty = options.allowEmpty;
+  }
+
   static fromJSON(json: any) {
-    const Type = this;
-    const type = new Type();
-    return type;
+    return new OperatorString({ allowEmpty: json.allow_empty });
   }
 }
 export { OperatorString as String };

--- a/app/packages/operators/src/validation.ts
+++ b/app/packages/operators/src/validation.ts
@@ -56,7 +56,7 @@ export class ValidationContext {
         ),
         true
       );
-    } else if (property.required && valueIsNullish) {
+    } else if (!existsOrNonRequired(property, value)) {
       this.addError(new ValidationError("Required property", property, path));
     } else if (type instanceof Enum && !valueIsNullish) {
       this.validateEnum(path, property, value);
@@ -133,6 +133,17 @@ export class ValidationContext {
       );
     }
   }
+}
+
+function existsOrNonRequired(property, value) {
+  const expectedType = getOperatorTypeName(property.type);
+  if (expectedType === "string" && !property.type.allowEmpty && value === "") {
+    return false;
+  }
+  if (expectedType === "number" && isNaN(value)) {
+    return false;
+  }
+  return !property.required || !isNullish(value);
 }
 
 function getPath(prefix, path) {

--- a/fiftyone/operators/executor.py
+++ b/fiftyone/operators/executor.py
@@ -678,7 +678,7 @@ class ValidationContext(object):
                 property.error_message, property, path, True
             )
 
-        if property.required and value is None:
+        if not self.exists_or_non_required(property, value):
             return ValidationError("Required property", property, path)
 
         if value is not None:
@@ -739,3 +739,13 @@ class ValidationContext(object):
 
         if type_name == "Boolean" and value_type != bool:
             return ValidationError("Invalid value type", property, path)
+
+    def exists_or_non_required(self, property, value):
+        type_name = property.type.__class__.__name__
+
+        if type_name == "String":
+            allow_empty = property.type.allow_empty
+            if not allow_empty and value == "":
+                return False
+
+        return not property.required or value is not None

--- a/fiftyone/operators/types.py
+++ b/fiftyone/operators/types.py
@@ -92,7 +92,7 @@ class Object(BaseType):
         self.add_property(name, property)
         return property
 
-    def str(self, name, **kwargs):
+    def str(self, name, allow_empty=False, **kwargs):
         """Defines a property on the object that is a string.
 
         Args:
@@ -104,7 +104,9 @@ class Object(BaseType):
         Returns:
             a :class:`Property`
         """
-        return self.define_property(name, String(), **kwargs)
+        return self.define_property(
+            name, String(allow_empty=allow_empty), **kwargs
+        )
 
     def bool(self, name, **kwargs):
         """Defines a property on the object that is a boolean.
@@ -302,6 +304,7 @@ class Property(BaseType):
         self.invalid = kwargs.get("invalid", False)
         self.default = kwargs.get("default", None)
         self.required = kwargs.get("required", False)
+        # todo: deprecate and remove
         self.choices = kwargs.get("choices", None)
         self.error_message = kwargs.get("error_message", "Invalid property")
         self.view = kwargs.get("view", None)
@@ -319,10 +322,20 @@ class Property(BaseType):
 
 
 class String(BaseType):
-    """Represents a string."""
+    """Represents a string.
 
-    def __init__(self):
-        pass
+    Args:
+        allow_empty (False): allow an empty string value
+    """
+
+    def __init__(self, allow_empty=False):
+        self.allow_empty = allow_empty
+
+    def to_json(self):
+        return {
+            **super().to_json(),
+            "allow_empty": self.allow_empty,
+        }
 
 
 class Boolean(BaseType):


### PR DESCRIPTION
## What changes are proposed in this pull request?

When using the `String` for a field, the empty value `""` will now be considered invalid by default.

You may opt-out of this default behaviour by setting the `allow_empty` option to `True`:

```py
    def resolve_input(self, ctx):
        inputs = types.Object()

        # when using Object.str method
        inputs.str("my_str", allow_empty=True, required=True)

        # when using String constructor directly
        inputs.define_property("my_str", types.String(allow_empty=True), required=True)

        return types.Property(inputs)
```

## How is this patch tested? If it is not, please explain why.

Using a test operator in the app

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

See above

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
