### PR TITLE
Improve operator registry and plugin loading

### DIFF
--- a/fiftyone/core/cli.py
+++ b/fiftyone/core/cli.py
@@ -2736,7 +2736,7 @@ class OperatorsInfoCommand(Command):
 
 
 def _print_operator_info(operator_uri):
-    operator = foo.get_operator(operator_uri)
+    operator = foo.get_operator(operator_uri, include_disabled=True)
 
     d = operator.config.to_json()
     _print_dict_as_table(d)

--- a/fiftyone/operators/__init__.py
+++ b/fiftyone/operators/__init__.py
@@ -6,7 +6,12 @@ FiftyOne operators.
 |
 """
 from .operator import Operator, OperatorConfig
-from .registry import OperatorRegistry, get_operator, list_operators
+from .registry import (
+    OperatorRegistry,
+    get_operator,
+    list_operators,
+    reload_registry,
+)
 from .executor import execute_operator, execute_or_delegate_operator
 
 # This enables Sphinx refs to directly use paths imported here

--- a/fiftyone/operators/delegated.py
+++ b/fiftyone/operators/delegated.py
@@ -19,6 +19,7 @@ from fiftyone.operators.executor import (
     ExecutionRunState,
     ExecutionProgress,
 )
+import fiftyone.operators as foo
 
 logger = logging.getLogger(__name__)
 
@@ -304,7 +305,13 @@ class DelegatedOperationService(object):
         )
 
         for op in queued_ops:
-            self.execute_operation(operation=op, log=log)
+            if op.operator in foo.list_operators():
+                self.execute_operation(operation=op, log=log)
+            else:
+                logger.info(
+                    "Skipping execution of unknown or " "disabled operator %s",
+                    op,
+                )
 
     def count(self, filters=None, search=None):
         """Counts the delegated operations matching the given criteria.

--- a/fiftyone/operators/registry.py
+++ b/fiftyone/operators/registry.py
@@ -17,7 +17,7 @@ def get_operator(operator_uri, include_disabled=False):
 
     Args:
         operator_uri: the operator URI
-        enabled: whether to include only enabled operators (True) or any
+        include_disabled (False): whether to include disabled operators
 
     Returns:
         an :class:`fiftyone.operators.Operator`
@@ -46,10 +46,16 @@ def list_operators(enabled=True):
     return _operator_registry.list_operators(include_builtin=enabled != False)
 
 
-def reload_registry():
-    """Reloads the operator registry."""
+def reload_registry(include_disabled=False):
+    """Reloads the operator registry.
+
+    Args:
+        include_disabled (False): whether to include disabled operators
+    """
     global _operator_registry
-    _operator_registry = OperatorRegistry()
+    _operator_registry = OperatorRegistry(
+        enabled="all" if include_disabled else True
+    )
 
 
 class OperatorRegistry(object):
@@ -62,7 +68,6 @@ class OperatorRegistry(object):
     def __init__(self, enabled=True):
         self.plugin_contexts = fopc.build_plugin_contexts(enabled=enabled)
 
-    # @plugins_cache
     def list_operators(self, include_builtin=True):
         """Lists the available FiftyOne operators.
 

--- a/fiftyone/plugins/context.py
+++ b/fiftyone/plugins/context.py
@@ -136,10 +136,22 @@ class PluginContext(object):
             sys.modules[module.__name__] = module
             spec.loader.exec_module(module)
             module.register(self)
+        except ModuleNotFoundError as e:
+            logger.warning(
+                f"Disabling plugin {self.name} due to "
+                f"missing "
+                f"requirements: {e.name}.\n Install `{e.name}` "
+                f"and "
+                f"run `fiftyone plugins enable {self.name}` to "
+                f"use this plugin in the App."
+            )
+            fop.disable_plugin(self.name)
+            self.errors.append(traceback.format_exc())
         except:
             logger.warning(
                 f"Failed to register operators for plugin {self.name}"
             )
+            traceback.print_exc()
             self.errors.append(traceback.format_exc())
 
     def dispose_all(self):

--- a/fiftyone/plugins/context.py
+++ b/fiftyone/plugins/context.py
@@ -138,12 +138,9 @@ class PluginContext(object):
             module.register(self)
         except ModuleNotFoundError as e:
             logger.warning(
-                f"Disabling plugin {self.name} due to "
-                f"missing "
-                f"requirements: {e.name}.\n Install `{e.name}` "
-                f"and "
-                f"run `fiftyone plugins enable {self.name}` to "
-                f"use this plugin in the App."
+                f"Disabling plugin {self.name} due to missing requirements: "
+                f"{e.name}. Install `{e.name}` and run `fiftyone plugins enable"
+                f"{self.name}` to use this plugin in the App."
             )
             fop.disable_plugin(self.name)
             self.errors.append(traceback.format_exc())
@@ -151,7 +148,6 @@ class PluginContext(object):
             logger.warning(
                 f"Failed to register operators for plugin {self.name}"
             )
-            traceback.print_exc()
             self.errors.append(traceback.format_exc())
 
     def dispose_all(self):


### PR DESCRIPTION
- reduce the number of times plugins are reloaded by listing operators from a global registry
- add method for forcing refresh of the registry
- for delegated operations, only run enabled operations
- disable plugins if missing requirements to run

This should prevent errors like: 

```
Delegated operation service running

To exit, press ctrl + c
Failed to register operators for plugin @jacobmarks/twilio_automation

Running operation 6529bbd8de97d1438e00bd89 (@jacobmarks/fuzzy_search/create_text_index)
Failed to register operators for plugin @jacobmarks/twilio_automation
 100% |███████████████████████████████████████████████████████████████████████████████████████████████| 193/193 [2.6m elapsed, 0s remaining, 0.8 samples/s]
Failed to register operators for plugin @jacobmarks/twilio_automation
Operation 6529bbd8de97d1438e00bd89 complete
Failed to register operators for plugin @jacobmarks/twilio_automation
Failed to register operators for plugin @jacobmarks/twilio_automation
Failed to register operators for plugin @jacobmarks/twilio_automation
Failed to register operators for plugin @jacobmarks/twilio_automation
Failed to register operators for plugin @jacobmarks/twilio_automation
Failed to register operators for plugin @jacobmarks/twilio_automation
Failed to register operators for plugin @jacobmarks/twilio_automation
Failed to register operators for plugin @jacobmarks/twilio_automation
Failed to register operators for plugin @jacobmarks/twilio_automation
Failed to register operators for plugin @jacobmarks/twilio_automation
Failed to register operators for plugin @jacobmarks/twilio_automation
Failed to register operators for plugin @jacobmarks/twilio_automation
Failed to register operators for plugin @jacobmarks/twilio_automation
Failed to register operators for plugin @jacobmarks/twilio_automation
Failed to register operators for plugin @jacobmarks/twilio_automation
Failed to register operators for plugin @jacobmarks/twilio_automation
Failed to register operators for plugin @jacobmarks/twilio_automation
```

## What changes are proposed in this pull request?

(Please fill in changes proposed in this fix)

## How is this patch tested? If it is not, please explain why.

(Details)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
