### PR TITLE
Delegated operation tweaks

### DIFF
--- a/fiftyone/core/cli.py
+++ b/fiftyone/core/cli.py
@@ -2736,7 +2736,7 @@ class OperatorsInfoCommand(Command):
 
 
 def _print_operator_info(operator_uri):
-    operator = foo.get_operator(operator_uri)
+    operator = foo.get_operator(operator_uri, enabled="all")
 
     d = operator.config.to_json()
     _print_dict_as_table(d)

--- a/fiftyone/factory/repos/delegated_operation.py
+++ b/fiftyone/factory/repos/delegated_operation.py
@@ -281,7 +281,7 @@ class MongoDelegatedOperationRepo(DelegatedOperationRepo):
         if paging.limit:
             docs = docs.limit(paging.limit)
 
-        registry = OperatorRegistry(enabled="all")
+        registry = OperatorRegistry()
         return [
             DelegatedOperationDocument().from_pymongo(doc, registry=registry)
             for doc in docs

--- a/fiftyone/factory/repos/delegated_operation_doc.py
+++ b/fiftyone/factory/repos/delegated_operation_doc.py
@@ -92,7 +92,7 @@ class DelegatedOperationDocument(object):
         # generated fields:
         try:
             if registry is None:
-                registry = OperatorRegistry(enabled="all")
+                registry = OperatorRegistry()
 
             if registry.operator_exists(self.operator) is False:
                 raise ValueError(

--- a/fiftyone/operators/__init__.py
+++ b/fiftyone/operators/__init__.py
@@ -6,7 +6,12 @@ FiftyOne operators.
 |
 """
 from .operator import Operator, OperatorConfig
-from .registry import OperatorRegistry, get_operator, list_operators
+from .registry import (
+    OperatorRegistry,
+    get_operator,
+    list_operators,
+    operator_exists,
+)
 from .executor import execute_operator, execute_or_delegate_operator
 
 # This enables Sphinx refs to directly use paths imported here

--- a/fiftyone/operators/registry.py
+++ b/fiftyone/operators/registry.py
@@ -9,16 +9,21 @@ from .builtin import BUILTIN_OPERATORS
 import fiftyone.plugins.context as fopc
 
 
-def get_operator(operator_uri):
+def get_operator(operator_uri, enabled=True):
     """Gets the operator with the given URI.
 
     Args:
         operator_uri: the operator URI
+        enabled (True): whether to include only enabled operators (True) or
+            only disabled operators (False) or all operators ("all")
 
     Returns:
         an :class:`fiftyone.operators.Operator`
+
+    Raises:
+        ValueError: if the operator is not found
     """
-    registry = OperatorRegistry(enabled="all")
+    registry = OperatorRegistry(enabled=enabled)
     operator = registry.get_operator(operator_uri)
     if operator is None:
         raise ValueError(f"Operator '{operator_uri}' not found")
@@ -38,6 +43,21 @@ def list_operators(enabled=True):
     """
     registry = OperatorRegistry(enabled=enabled)
     return registry.list_operators(include_builtin=enabled != False)
+
+
+def operator_exists(operator_uri, enabled=True):
+    """Checks if the given operator exists.
+
+    Args:
+        operator_uri: the operator URI
+        enabled (True): whether to include only enabled operators (True) or
+            only disabled operators (False) or all operators ("all")
+
+    Returns:
+        True/False
+    """
+    registry = OperatorRegistry(enabled=enabled)
+    return registry.operator_exists(operator_uri)
 
 
 class OperatorRegistry(object):


### PR DESCRIPTION
- Fixes the spammed "Failed to register operators for plugin..." message discussed in https://github.com/voxel51/fiftyone/pull/3692#issue-1951043003
- Adds a `foo.operator_exists()` utility