### PR TITLE
strip b64 prefix from uploaded files

### DIFF
--- a/app/packages/core/src/plugins/SchemaIO/components/FileView.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/FileView.tsx
@@ -50,15 +50,16 @@ export default function FileView(props) {
                 return;
               }
               setCurrentError(null);
+              const resultStripped = stripBase64Prefix(result);
               const obj = {
-                contents: result,
+                content: resultStripped,
                 name: file.name,
                 type: file.type,
                 size: file.size,
                 last_modified: file.lastModified,
               };
               if (isObject) return onChange(path, obj);
-              onChange(path, result);
+              onChange(path, resultStripped);
             }}
             types={types}
             autoFocused={autoFocused}
@@ -85,4 +86,8 @@ function fileToBase64(
     fileReader.onload = () => resolve({ result: fileReader.result as string });
     fileReader.onerror = (error) => resolve({ error });
   });
+}
+
+function stripBase64Prefix(data: string): string {
+  return data.slice(data.indexOf(",") + 1);
 }

--- a/fiftyone/operators/types.py
+++ b/fiftyone/operators/types.py
@@ -999,7 +999,7 @@ class UploadedFile(dict):
         name: the name of the file
         type: the mime type of the file
         size: the size of the file in bytes
-        contents: the base64 encoded contents of the file
+        content: the base64 encoded contents of the file
         last_modified: the last modified time of the file in ms since epoch
     """
 


### PR DESCRIPTION
Cleanup the `UploadedFile` to now only included the base64 data and not the type prefix (if it exists).