### PR TITLE
[Cherrypick] Fix plugin cache check (#3676)

### DIFF
--- a/fiftyone/operators/decorators.py
+++ b/fiftyone/operators/decorators.py
@@ -87,8 +87,6 @@ def plugins_cache(func):
 def dir_state(dirpath):
     if not os.path.isdir(dirpath):
         return None
-    # use glob instead of os.listdir to ignore hidden files (eg .DS_STORE)
-    return max(
-        (os.path.getmtime(f) for f in glob.glob(os.path.join(dirpath, "*"))),
-        default=None,
-    )
+    # we only need to check top level dir, which will update if any subdirs
+    # change and in the case that files are deleted
+    return os.path.getmtime(dirpath)

--- a/tests/unittests/operators/decorators_tests.py
+++ b/tests/unittests/operators/decorators_tests.py
@@ -6,57 +6,136 @@ Unit tests for operators/decorators.
 |
 """
 import os
+import asyncio
+import shutil
+import tempfile
 import unittest
-from unittest import mock
+import time
 from unittest.mock import patch
 
-from fiftyone.operators.decorators import dir_state
+from fiftyone.operators.decorators import coroutine_timeout, dir_state
 
 
 class DirStateTests(unittest.TestCase):
-    @patch("glob.glob")
     @patch("os.path.isdir")
-    def test_dir_state_non_existing_dir(self, mock_isdir, mock_glob):
+    @patch("os.path.getmtime")
+    def test_dir_state_non_existing_dir(self, mock_getmtime, mock_isdir):
         mock_isdir.return_value = False
         dirpath = "/non/existing/dir"
         try:
             result = dir_state(dirpath)
         except Exception as e:
             self.fail(e)
-
+        mock_isdir.assert_called_once_with(dirpath)
         self.assertIsNone(result)
-        assert not mock_glob.called
+        mock_getmtime.assert_not_called()
 
-    @patch("glob.glob")
     @patch("os.path.isdir")
-    def test_dir_state_existing_empty_dir(self, mock_isdir, mock_glob):
+    @patch("os.path.getmtime")
+    def test_dir_state_existing_empty_dir(self, mock_getmtime, mock_isdir):
         mock_isdir.return_value = True
-        mock_glob.return_value = []
         dirpath = "/existing/empty/dir"
+        mock_getmtime.return_value = 1000
 
         try:
             result = dir_state(dirpath)
         except Exception as e:
             self.fail(e)
-        self.assertIsNone(result)
         mock_isdir.assert_called_once_with(dirpath)
-        mock_glob.assert_called_once_with(os.path.join(dirpath, "*"))
+        mock_getmtime.assert_called_once_with(dirpath)
+        self.assertEqual(result, 1000)
 
     @patch("os.path.isdir")
-    @patch("glob.glob")
     @patch("os.path.getmtime")
     def test_dir_state_with_existing_nonempty_dir(
-        self, mock_getmtime, mock_glob, mock_isdir
+        self, mock_getmtime, mock_isdir
     ):
         mock_isdir.return_value = True
-        mock_glob.return_value = ["file1.txt", "file2.txt"]
-        mock_getmtime.side_effect = [1000, 2000]
+        mock_getmtime.return_value = 2000
 
         result = dir_state("/my/dir/path")
 
-        self.assertEqual(result, 2000)
         mock_isdir.assert_called_once_with("/my/dir/path")
-        mock_glob.assert_called_once_with(os.path.join("/my/dir/path", "*"))
-        mock_getmtime.assert_has_calls(
-            [unittest.mock.call("file1.txt"), unittest.mock.call("file2.txt")]
-        )
+        mock_getmtime.assert_called_once_with("/my/dir/path")
+        self.assertEqual(result, 2000)
+
+    def test_rgrs_dir_state_empty(self):
+        with tempfile.TemporaryDirectory() as tmpdirname:
+            self.assertGreater(dir_state(tmpdirname), 0)
+
+    def test_rgrs_dir_state_change_with_delete(self):
+        plugin_paths = ["plugin1/file1.txt", "plugin2/file2.txt"]
+        with tempfile.TemporaryDirectory() as tmpdirname:
+            initial_dir_state = dir_state(tmpdirname)
+            for p in plugin_paths:
+                time.sleep(1)
+                os.makedirs(os.path.join(tmpdirname, p))
+
+            # verify that max time is greater after adding files
+            dir_state1 = dir_state(tmpdirname)
+            self.assertGreater(dir_state1, initial_dir_state)
+
+            # verify that max time is greater after deleting files
+            shutil.rmtree(
+                os.path.join(tmpdirname, plugin_paths[0].split("/")[0])
+            )
+            dir_state2 = dir_state(tmpdirname)
+            self.assertGreaterEqual(dir_state2, dir_state1)
+            time.sleep(1)
+
+            shutil.rmtree(
+                os.path.join(tmpdirname, plugin_paths[1].split("/")[0])
+            )
+            dir_state3 = dir_state(tmpdirname)
+            self.assertGreaterEqual(dir_state3, dir_state2)
+
+    def test_rgrs_dir_state_change_with_rename(self):
+        plugin_paths = ["plugin1/file1.txt", "plugin2/file2.txt"]
+        with tempfile.TemporaryDirectory() as tmpdirname:
+            initial_dir_state = dir_state(tmpdirname)
+            for p in plugin_paths:
+                time.sleep(1)
+                os.makedirs(os.path.join(tmpdirname, p))
+
+            # verify that max time is greater after adding files
+            dir_state1 = dir_state(tmpdirname)
+            self.assertGreater(dir_state1, initial_dir_state)
+
+            # verify that max time is greater after renaming plugin dir
+            os.rename(
+                os.path.join(tmpdirname, plugin_paths[0].split("/")[0]),
+                os.path.join(
+                    tmpdirname, plugin_paths[0].split("/")[0] + "renamed"
+                ),
+            )
+            dir_state2 = dir_state(tmpdirname)
+            self.assertGreaterEqual(dir_state2, dir_state1)
+
+
+async def dummy_coroutine_fn(duration):
+    await asyncio.sleep(duration)
+    return "Success"
+
+
+@coroutine_timeout(seconds=2)
+async def timeout_dummy_coroutine_fn(duration):
+    return await dummy_coroutine_fn(duration)
+
+
+def non_coroutine_fn():
+    pass
+
+
+class TestCoroutineTimeoutDecorator(unittest.TestCase):
+    def test_successful_execution(self):
+        result = asyncio.run(timeout_dummy_coroutine_fn(1))
+        self.assertEqual(result, "Success")
+
+    def test_timeout_exception(self):
+        with self.assertRaises(TimeoutError):
+            asyncio.run(timeout_dummy_coroutine_fn(3))
+
+    def test_non_coroutine_function(self):
+        decorated_function = coroutine_timeout(2)(non_coroutine_fn)
+        with self.assertRaises(TypeError):
+            asyncio.run(decorated_function())


### PR DESCRIPTION
* check top level dir and add test

* cleanup

* remove glob and refactor tests

* cleanup

* add test for renaming and add wait

* add test for renaming and add sleep

## What changes are proposed in this pull request?

(Please fill in changes proposed in this fix)

## How is this patch tested? If it is not, please explain why.

(Details)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
