### PR TITLE
Expand relative `mask_path` and make paths valid for used OS (#3257)

### DIFF
--- a/fiftyone/core/utils.py
+++ b/fiftyone/core/utils.py
@@ -1368,6 +1368,26 @@ def safe_relpath(path, start=None, default=None):
     return relpath
 
 
+def expand_mask_paths(sample, rel_path):
+    """Finds all `mask_path` keys inside a serialized sample recursively and expand relative paths.
+    It is assumed that `mask_path` can only exist in `dict`.
+    
+    Args:
+        sample: a serialized sample
+        rel_path: part of path to make relative paths absolute
+    """
+    if isinstance(sample, dict):
+        for key, value in sample.items():
+            if key == "mask_path" and not os.path.isabs(key):
+                # Expand relative path
+                sample[key] = os.path.join(rel_path, value)
+            elif isinstance(value, (dict, list, tuple)):
+                expand_mask_paths(value, rel_path)
+    elif isinstance(sample, (list, tuple)):
+        for item in sample:
+            expand_mask_paths(item, rel_path)
+
+
 def compute_filehash(filepath, method=None, chunk_size=None):
     """Computes the hash of the given file.
 

--- a/fiftyone/core/utils.py
+++ b/fiftyone/core/utils.py
@@ -1379,13 +1379,28 @@ def expand_mask_paths(sample, rel_path):
     if isinstance(sample, dict):
         for key, value in sample.items():
             if key == "mask_path" and not os.path.isabs(key):
-                # Expand relative path
-                sample[key] = os.path.join(rel_path, value)
+                expanded = os.path.join(rel_path, value)
+                sample[key] = make_path_os_safe(expanded)
             elif isinstance(value, (dict, list, tuple)):
                 expand_mask_paths(value, rel_path)
     elif isinstance(sample, (list, tuple)):
         for item in sample:
             expand_mask_paths(item, rel_path)
+
+
+def make_path_os_safe(path):
+    """Convert path delimiters depending on OS.
+    
+    Args:
+        path: path to make OS safe
+        
+    Returns:
+        valid path
+    """
+    if sys.platform == "win32":
+        return path.replace("/", "\\")
+    else:
+        return path.replace("\\", "/")
 
 
 def compute_filehash(filepath, method=None, chunk_size=None):

--- a/fiftyone/utils/data/importers.py
+++ b/fiftyone/utils/data/importers.py
@@ -1856,6 +1856,10 @@ class FiftyOneDatasetImporter(BatchDatasetImporter):
                 _parse_media_fields(sd, media_fields, rel_dir)
 
             sd["_dataset_id"] = dataset_id
+
+            # Find all mask_path keys recursively and extend relative paths
+            fou.expand_mask_paths(sd, rel_dir)
+            
             return sd
 
         sample_ids = foo.insert_documents(

--- a/fiftyone/utils/data/importers.py
+++ b/fiftyone/utils/data/importers.py
@@ -1848,6 +1848,7 @@ class FiftyOneDatasetImporter(BatchDatasetImporter):
         def _parse_sample(sd):
             if not os.path.isabs(sd["filepath"]):
                 sd["filepath"] = os.path.join(rel_dir, sd["filepath"])
+                sd["filepath"] = fou.make_path_os_safe(sd["filepath"])
 
             if tags is not None:
                 sd["tags"].extend(tags)
@@ -1857,9 +1858,9 @@ class FiftyOneDatasetImporter(BatchDatasetImporter):
 
             sd["_dataset_id"] = dataset_id
 
-            # Find all mask_path keys recursively and extend relative paths
+            # Find all mask_path keys recursively and expand relative paths
             fou.expand_mask_paths(sd, rel_dir)
-            
+
             return sd
 
         sample_ids = foo.insert_documents(


### PR DESCRIPTION
## What changes are proposed in this pull request?

When importing a dataset relative `mask_path` keys get expanded as well.
This even works with nested structures.
Additionally, `filepath` and `mask_path` path separators get converted based on the OS.

## How is this patch tested? If it is not, please explain why.

Importing a dataset in Ubuntu (which was exported in Windows) with relative `mask_path` and check if path is absolute and valid now.

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [x] Other
