### PR TITLE
bugfix: Boolean not displayed in modal view sidebar entry 

### DIFF
--- a/app/packages/core/src/utils/generic.tsx
+++ b/app/packages/core/src/utils/generic.tsx
@@ -29,7 +29,7 @@ export const prettify = (
     );
   }
 
-  return v;
+  return result;
 };
 
 export const genSort = (a, b, asc) => {


### PR DESCRIPTION
## What changes are proposed in this pull request?

Boolean field are not displayed in the modal view. Looks like a regression typo. 

## How is this patch tested? If it is not, please explain why.

![Screenshot 2023-10-22 at 10 14 41 PM](https://github.com/voxel51/fiftyone/assets/17770824/9cd1a62c-4571-4992-a91e-d2261941493e)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
