### PR TITLE
bugfix: last used brain key should be loaded by default in similarity sort

### DIFF
--- a/app/packages/app/src/pages/datasets/DatasetPage.tsx
+++ b/app/packages/app/src/pages/datasets/DatasetPage.tsx
@@ -7,6 +7,8 @@ import "@fiftyone/relay";
 import * as fos from "@fiftyone/state";
 import { datasetQueryContext } from "@fiftyone/state";
 import { NotFoundError } from "@fiftyone/utilities";
+import { Snackbar } from "@material-ui/core";
+import MuiAlert, { AlertProps } from "@mui/material/Alert";
 import React, { useEffect } from "react";
 import { usePreloadedQuery } from "react-relay";
 import { useRecoilState, useRecoilValue } from "recoil";
@@ -15,8 +17,6 @@ import Nav from "../../components/Nav";
 import { Route } from "../../routing";
 import style from "../index.module.css";
 import { DatasetPageQuery } from "./__generated__/DatasetPageQuery.graphql";
-import { Snackbar } from "@material-ui/core";
-import MuiAlert, { AlertProps } from "@mui/material/Alert";
 
 const DatasetPageQueryNode = graphql`
   query DatasetPageQuery(

--- a/app/packages/app/src/pages/datasets/__generated__/DatasetPageQuery.graphql.ts
+++ b/app/packages/app/src/pages/datasets/__generated__/DatasetPageQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<76f7845852deb4d79bffcdfe13475608>>
+ * @generated SignedSource<<3c823d6405382834144148707cbb8ccb>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -275,66 +275,73 @@ v23 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "info",
+  "name": "datasetId",
   "storageKey": null
 },
 v24 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "lastLoadedAt",
+  "name": "info",
   "storageKey": null
 },
 v25 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "mediaType",
+  "name": "lastLoadedAt",
   "storageKey": null
 },
 v26 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "version",
+  "name": "mediaType",
   "storageKey": null
 },
 v27 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "key",
+  "name": "version",
   "storageKey": null
 },
 v28 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "timestamp",
+  "name": "key",
   "storageKey": null
 },
 v29 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "viewStages",
+  "name": "timestamp",
   "storageKey": null
 },
 v30 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "cls",
+  "name": "viewStages",
   "storageKey": null
 },
 v31 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
+  "name": "cls",
+  "storageKey": null
+},
+v32 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
   "name": "type",
   "storageKey": null
 },
-v32 = [
+v33 = [
   {
     "alias": null,
     "args": null,
@@ -344,56 +351,56 @@ v32 = [
   },
   (v17/*: any*/)
 ],
-v33 = {
+v34 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "labels",
   "storageKey": null
 },
-v34 = {
+v35 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "edges",
   "storageKey": null
 },
-v35 = {
+v36 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "ftype",
   "storageKey": null
 },
-v36 = {
+v37 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "subfield",
   "storageKey": null
 },
-v37 = {
+v38 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "embeddedDocType",
   "storageKey": null
 },
-v38 = {
+v39 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "dbField",
   "storageKey": null
 },
-v39 = {
+v40 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "description",
   "storageKey": null
 },
-v40 = [
+v41 = [
   {
     "kind": "Variable",
     "name": "after",
@@ -410,18 +417,18 @@ v40 = [
     "variableName": "search"
   }
 ],
-v41 = {
+v42 = {
   "kind": "Variable",
   "name": "datasetName",
   "variableName": "name"
 },
-v42 = [
+v43 = [
   (v15/*: any*/),
-  (v35/*: any*/),
   (v36/*: any*/),
   (v37/*: any*/),
-  (v23/*: any*/),
-  (v39/*: any*/)
+  (v38/*: any*/),
+  (v24/*: any*/),
+  (v40/*: any*/)
 ];
 return {
   "fragment": {
@@ -686,6 +693,7 @@ return {
             "storageKey": null
           },
           (v22/*: any*/),
+          (v23/*: any*/),
           {
             "alias": null,
             "args": null,
@@ -694,10 +702,10 @@ return {
             "storageKey": null
           },
           (v14/*: any*/),
-          (v23/*: any*/),
           (v24/*: any*/),
           (v25/*: any*/),
           (v26/*: any*/),
+          (v27/*: any*/),
           {
             "alias": null,
             "args": null,
@@ -706,10 +714,10 @@ return {
             "name": "brainMethods",
             "plural": true,
             "selections": [
-              (v27/*: any*/),
-              (v26/*: any*/),
               (v28/*: any*/),
+              (v27/*: any*/),
               (v29/*: any*/),
+              (v30/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -718,7 +726,7 @@ return {
                 "name": "config",
                 "plural": false,
                 "selections": [
-                  (v30/*: any*/),
+                  (v31/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -747,7 +755,7 @@ return {
                     "name": "supportsPrompts",
                     "storageKey": null
                   },
-                  (v31/*: any*/),
+                  (v32/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -775,7 +783,7 @@ return {
             "kind": "LinkedField",
             "name": "defaultMaskTargets",
             "plural": true,
-            "selections": (v32/*: any*/),
+            "selections": (v33/*: any*/),
             "storageKey": null
           },
           {
@@ -786,8 +794,8 @@ return {
             "name": "defaultSkeleton",
             "plural": false,
             "selections": [
-              (v33/*: any*/),
-              (v34/*: any*/)
+              (v34/*: any*/),
+              (v35/*: any*/)
             ],
             "storageKey": null
           },
@@ -799,10 +807,10 @@ return {
             "name": "evaluations",
             "plural": true,
             "selections": [
-              (v27/*: any*/),
-              (v26/*: any*/),
               (v28/*: any*/),
+              (v27/*: any*/),
               (v29/*: any*/),
+              (v30/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -811,7 +819,7 @@ return {
                 "name": "config",
                 "plural": false,
                 "selections": [
-                  (v30/*: any*/),
+                  (v31/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -841,7 +849,7 @@ return {
             "plural": true,
             "selections": [
               (v12/*: any*/),
-              (v25/*: any*/)
+              (v26/*: any*/)
             ],
             "storageKey": null
           },
@@ -861,7 +869,7 @@ return {
                 "kind": "LinkedField",
                 "name": "targets",
                 "plural": true,
-                "selections": (v32/*: any*/),
+                "selections": (v33/*: any*/),
                 "storageKey": null
               }
             ],
@@ -876,8 +884,8 @@ return {
             "plural": true,
             "selections": [
               (v12/*: any*/),
-              (v33/*: any*/),
-              (v34/*: any*/)
+              (v34/*: any*/),
+              (v35/*: any*/)
             ],
             "storageKey": null
           },
@@ -889,13 +897,13 @@ return {
             "name": "frameFields",
             "plural": true,
             "selections": [
-              (v35/*: any*/),
               (v36/*: any*/),
               (v37/*: any*/),
-              (v15/*: any*/),
               (v38/*: any*/),
+              (v15/*: any*/),
               (v39/*: any*/),
-              (v23/*: any*/)
+              (v40/*: any*/),
+              (v24/*: any*/)
             ],
             "storageKey": null
           },
@@ -908,12 +916,12 @@ return {
             "plural": true,
             "selections": [
               (v15/*: any*/),
-              (v35/*: any*/),
               (v36/*: any*/),
               (v37/*: any*/),
               (v38/*: any*/),
               (v39/*: any*/),
-              (v23/*: any*/)
+              (v40/*: any*/),
+              (v24/*: any*/)
             ],
             "storageKey": null
           },
@@ -954,7 +962,7 @@ return {
       },
       {
         "alias": null,
-        "args": (v40/*: any*/),
+        "args": (v41/*: any*/),
         "concreteType": "DatasetStrConnection",
         "kind": "LinkedField",
         "name": "datasets",
@@ -1035,7 +1043,7 @@ return {
       },
       {
         "alias": null,
-        "args": (v40/*: any*/),
+        "args": (v41/*: any*/),
         "filters": [
           "search"
         ],
@@ -1072,7 +1080,7 @@ return {
         "name": "uid",
         "storageKey": null
       },
-      (v26/*: any*/),
+      (v27/*: any*/),
       {
         "alias": null,
         "args": null,
@@ -1083,7 +1091,7 @@ return {
       {
         "alias": null,
         "args": [
-          (v41/*: any*/)
+          (v42/*: any*/)
         ],
         "concreteType": "SavedView",
         "kind": "LinkedField",
@@ -1091,13 +1099,7 @@ return {
         "plural": true,
         "selections": [
           (v14/*: any*/),
-          {
-            "alias": null,
-            "args": null,
-            "kind": "ScalarField",
-            "name": "datasetId",
-            "storageKey": null
-          },
+          (v23/*: any*/),
           (v12/*: any*/),
           {
             "alias": null,
@@ -1106,9 +1108,9 @@ return {
             "name": "slug",
             "storageKey": null
           },
-          (v39/*: any*/),
+          (v40/*: any*/),
           (v16/*: any*/),
-          (v29/*: any*/),
+          (v30/*: any*/),
           (v22/*: any*/),
           {
             "alias": null,
@@ -1117,7 +1119,7 @@ return {
             "name": "lastModifiedAt",
             "storageKey": null
           },
-          (v24/*: any*/)
+          (v25/*: any*/)
         ],
         "storageKey": null
       },
@@ -1140,7 +1142,7 @@ return {
             "plural": true,
             "selections": [
               (v12/*: any*/),
-              (v31/*: any*/),
+              (v32/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -1164,7 +1166,7 @@ return {
       {
         "alias": null,
         "args": [
-          (v41/*: any*/),
+          (v42/*: any*/),
           {
             "kind": "Variable",
             "name": "viewStages",
@@ -1183,7 +1185,7 @@ return {
             "kind": "LinkedField",
             "name": "fieldSchema",
             "plural": true,
-            "selections": (v42/*: any*/),
+            "selections": (v43/*: any*/),
             "storageKey": null
           },
           {
@@ -1193,7 +1195,7 @@ return {
             "kind": "LinkedField",
             "name": "frameFieldSchema",
             "plural": true,
-            "selections": (v42/*: any*/),
+            "selections": (v43/*: any*/),
             "storageKey": null
           }
         ],
@@ -1202,12 +1204,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "63fb18c91a8280d85dc5c7f6c6e8502c",
+    "cacheID": "259ef010999c3587bd982d14bf123e45",
     "id": null,
     "metadata": {},
     "name": "DatasetPageQuery",
     "operationKind": "query",
-    "text": "query DatasetPageQuery(\n  $search: String = \"\"\n  $count: Int\n  $cursor: String\n  $savedViewSlug: String\n  $name: String!\n  $view: BSONArray!\n  $extendedView: BSONArray\n) {\n  config {\n    colorBy\n    colorPool\n    multicolorKeypoints\n    showSkeletons\n  }\n  dataset(name: $name, view: $extendedView, savedViewSlug: $savedViewSlug) {\n    name\n    defaultGroupSlice\n    appConfig {\n      colorScheme {\n        id\n        colorBy\n        colorPool\n        multicolorKeypoints\n        opacity\n        showSkeletons\n        fields {\n          colorByAttribute\n          fieldColor\n          path\n          valueColors {\n            color\n            value\n          }\n        }\n      }\n    }\n    ...datasetFragment\n    id\n  }\n  ...NavFragment\n  ...savedViewsFragment\n  ...configFragment\n  ...stageDefinitionsFragment\n  ...viewSchemaFragment\n}\n\nfragment NavDatasets on Query {\n  datasets(search: $search, first: $count, after: $cursor) {\n    total\n    edges {\n      cursor\n      node {\n        name\n        id\n        __typename\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n\nfragment NavFragment on Query {\n  ...NavDatasets\n  ...NavGA\n  teamsSubmission\n}\n\nfragment NavGA on Query {\n  context\n  dev\n  doNotTrack\n  uid\n  version\n}\n\nfragment configFragment on Query {\n  config {\n    colorBy\n    colorPool\n    colorscale\n    gridZoom\n    loopVideos\n    multicolorKeypoints\n    notebookHeight\n    plugins\n    showConfidence\n    showIndex\n    showLabel\n    showSkeletons\n    showTooltip\n    sidebarMode\n    theme\n    timezone\n    useFrameNumber\n  }\n  colorscale\n}\n\nfragment datasetAppConfigFragment on DatasetAppConfig {\n  gridMediaField\n  mediaFields\n  modalMediaField\n  plugins\n  sidebarMode\n  colorScheme {\n    id\n    colorBy\n    colorPool\n    multicolorKeypoints\n    opacity\n    showSkeletons\n    fields {\n      colorByAttribute\n      fieldColor\n      path\n      valueColors {\n        color\n        value\n      }\n    }\n  }\n}\n\nfragment datasetFragment on Dataset {\n  createdAt\n  groupField\n  id\n  info\n  lastLoadedAt\n  mediaType\n  name\n  version\n  appConfig {\n    ...datasetAppConfigFragment\n  }\n  brainMethods {\n    key\n    version\n    timestamp\n    viewStages\n    config {\n      cls\n      embeddingsField\n      method\n      patchesField\n      supportsPrompts\n      type\n      maxK\n      supportsLeastSimilarity\n    }\n  }\n  defaultMaskTargets {\n    target\n    value\n  }\n  defaultSkeleton {\n    labels\n    edges\n  }\n  evaluations {\n    key\n    version\n    timestamp\n    viewStages\n    config {\n      cls\n      predField\n      gtField\n    }\n  }\n  groupMediaTypes {\n    name\n    mediaType\n  }\n  maskTargets {\n    name\n    targets {\n      target\n      value\n    }\n  }\n  skeletons {\n    name\n    labels\n    edges\n  }\n  ...frameFieldsFragment\n  ...groupSliceFragment\n  ...mediaFieldsFragment\n  ...mediaTypeFragment\n  ...sampleFieldsFragment\n  ...sidebarGroupsFragment\n  ...viewFragment\n}\n\nfragment frameFieldsFragment on Dataset {\n  frameFields {\n    ftype\n    subfield\n    embeddedDocType\n    path\n    dbField\n    description\n    info\n  }\n}\n\nfragment groupSliceFragment on Dataset {\n  defaultGroupSlice\n}\n\nfragment mediaFieldsFragment on Dataset {\n  name\n  appConfig {\n    gridMediaField\n  }\n  sampleFields {\n    path\n  }\n}\n\nfragment mediaTypeFragment on Dataset {\n  mediaType\n}\n\nfragment sampleFieldsFragment on Dataset {\n  sampleFields {\n    ftype\n    subfield\n    embeddedDocType\n    path\n    dbField\n    description\n    info\n  }\n}\n\nfragment savedViewsFragment on Query {\n  savedViews(datasetName: $name) {\n    id\n    datasetId\n    name\n    slug\n    description\n    color\n    viewStages\n    createdAt\n    lastModifiedAt\n    lastLoadedAt\n  }\n}\n\nfragment sidebarGroupsFragment on Dataset {\n  name\n  appConfig {\n    sidebarGroups {\n      expanded\n      paths\n      name\n    }\n  }\n  ...frameFieldsFragment\n  ...sampleFieldsFragment\n}\n\nfragment stageDefinitionsFragment on Query {\n  stageDefinitions {\n    name\n    params {\n      name\n      type\n      default\n      placeholder\n    }\n  }\n}\n\nfragment viewFragment on Dataset {\n  stages(slug: $savedViewSlug, view: $view)\n  viewCls\n  viewName\n}\n\nfragment viewSchemaFragment on Query {\n  schemaForViewStages(datasetName: $name, viewStages: $view) {\n    fieldSchema {\n      path\n      ftype\n      subfield\n      embeddedDocType\n      info\n      description\n    }\n    frameFieldSchema {\n      path\n      ftype\n      subfield\n      embeddedDocType\n      info\n      description\n    }\n  }\n}\n"
+    "text": "query DatasetPageQuery(\n  $search: String = \"\"\n  $count: Int\n  $cursor: String\n  $savedViewSlug: String\n  $name: String!\n  $view: BSONArray!\n  $extendedView: BSONArray\n) {\n  config {\n    colorBy\n    colorPool\n    multicolorKeypoints\n    showSkeletons\n  }\n  dataset(name: $name, view: $extendedView, savedViewSlug: $savedViewSlug) {\n    name\n    defaultGroupSlice\n    appConfig {\n      colorScheme {\n        id\n        colorBy\n        colorPool\n        multicolorKeypoints\n        opacity\n        showSkeletons\n        fields {\n          colorByAttribute\n          fieldColor\n          path\n          valueColors {\n            color\n            value\n          }\n        }\n      }\n    }\n    ...datasetFragment\n    id\n  }\n  ...NavFragment\n  ...savedViewsFragment\n  ...configFragment\n  ...stageDefinitionsFragment\n  ...viewSchemaFragment\n}\n\nfragment NavDatasets on Query {\n  datasets(search: $search, first: $count, after: $cursor) {\n    total\n    edges {\n      cursor\n      node {\n        name\n        id\n        __typename\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n\nfragment NavFragment on Query {\n  ...NavDatasets\n  ...NavGA\n  teamsSubmission\n}\n\nfragment NavGA on Query {\n  context\n  dev\n  doNotTrack\n  uid\n  version\n}\n\nfragment configFragment on Query {\n  config {\n    colorBy\n    colorPool\n    colorscale\n    gridZoom\n    loopVideos\n    multicolorKeypoints\n    notebookHeight\n    plugins\n    showConfidence\n    showIndex\n    showLabel\n    showSkeletons\n    showTooltip\n    sidebarMode\n    theme\n    timezone\n    useFrameNumber\n  }\n  colorscale\n}\n\nfragment datasetAppConfigFragment on DatasetAppConfig {\n  gridMediaField\n  mediaFields\n  modalMediaField\n  plugins\n  sidebarMode\n  colorScheme {\n    id\n    colorBy\n    colorPool\n    multicolorKeypoints\n    opacity\n    showSkeletons\n    fields {\n      colorByAttribute\n      fieldColor\n      path\n      valueColors {\n        color\n        value\n      }\n    }\n  }\n}\n\nfragment datasetFragment on Dataset {\n  createdAt\n  datasetId\n  groupField\n  id\n  info\n  lastLoadedAt\n  mediaType\n  name\n  version\n  appConfig {\n    ...datasetAppConfigFragment\n  }\n  brainMethods {\n    key\n    version\n    timestamp\n    viewStages\n    config {\n      cls\n      embeddingsField\n      method\n      patchesField\n      supportsPrompts\n      type\n      maxK\n      supportsLeastSimilarity\n    }\n  }\n  defaultMaskTargets {\n    target\n    value\n  }\n  defaultSkeleton {\n    labels\n    edges\n  }\n  evaluations {\n    key\n    version\n    timestamp\n    viewStages\n    config {\n      cls\n      predField\n      gtField\n    }\n  }\n  groupMediaTypes {\n    name\n    mediaType\n  }\n  maskTargets {\n    name\n    targets {\n      target\n      value\n    }\n  }\n  skeletons {\n    name\n    labels\n    edges\n  }\n  ...frameFieldsFragment\n  ...groupSliceFragment\n  ...mediaFieldsFragment\n  ...mediaTypeFragment\n  ...sampleFieldsFragment\n  ...sidebarGroupsFragment\n  ...viewFragment\n}\n\nfragment frameFieldsFragment on Dataset {\n  frameFields {\n    ftype\n    subfield\n    embeddedDocType\n    path\n    dbField\n    description\n    info\n  }\n}\n\nfragment groupSliceFragment on Dataset {\n  defaultGroupSlice\n}\n\nfragment mediaFieldsFragment on Dataset {\n  name\n  appConfig {\n    gridMediaField\n  }\n  sampleFields {\n    path\n  }\n}\n\nfragment mediaTypeFragment on Dataset {\n  mediaType\n}\n\nfragment sampleFieldsFragment on Dataset {\n  sampleFields {\n    ftype\n    subfield\n    embeddedDocType\n    path\n    dbField\n    description\n    info\n  }\n}\n\nfragment savedViewsFragment on Query {\n  savedViews(datasetName: $name) {\n    id\n    datasetId\n    name\n    slug\n    description\n    color\n    viewStages\n    createdAt\n    lastModifiedAt\n    lastLoadedAt\n  }\n}\n\nfragment sidebarGroupsFragment on Dataset {\n  name\n  appConfig {\n    sidebarGroups {\n      expanded\n      paths\n      name\n    }\n  }\n  ...frameFieldsFragment\n  ...sampleFieldsFragment\n}\n\nfragment stageDefinitionsFragment on Query {\n  stageDefinitions {\n    name\n    params {\n      name\n      type\n      default\n      placeholder\n    }\n  }\n}\n\nfragment viewFragment on Dataset {\n  stages(slug: $savedViewSlug, view: $view)\n  viewCls\n  viewName\n}\n\nfragment viewSchemaFragment on Query {\n  schemaForViewStages(datasetName: $name, viewStages: $view) {\n    fieldSchema {\n      path\n      ftype\n      subfield\n      embeddedDocType\n      info\n      description\n    }\n    frameFieldSchema {\n      path\n      ftype\n      subfield\n      embeddedDocType\n      info\n      description\n    }\n  }\n}\n"
   }
 };
 })();

--- a/app/packages/core/src/components/Actions/similar/GroupButton.tsx
+++ b/app/packages/core/src/components/Actions/similar/GroupButton.tsx
@@ -28,7 +28,7 @@ const GroupButton: React.FunctionComponent<GroupButtonProps> = ({
   buttons,
 }) => {
   return (
-    <>
+    <div style={{ display: "flex", flexDirection: "row" }}>
       {buttons.map((button) => (
         <Tooltip
           text={button.tooltipText}
@@ -51,7 +51,7 @@ const GroupButton: React.FunctionComponent<GroupButtonProps> = ({
           </Container>
         </Tooltip>
       ))}
-    </>
+    </div>
   );
 };
 

--- a/app/packages/core/src/components/Actions/similar/Similar.tsx
+++ b/app/packages/core/src/components/Actions/similar/Similar.tsx
@@ -49,9 +49,7 @@ const SortBySimilarity = ({
   anchorRef,
 }: SortBySimilarityProps) => {
   const current = useRecoilValue(fos.similarityParameters);
-  const datasetId =
-    useRecoilValue(fos.dataset)?.name! +
-    useRecoilValue(fos.dataset)?.createdAt!;
+  const datasetId = fos.useAssertedRecoilValue(fos.datasetId);
   const [lastUsedBrainKeys] = useBrowserStorage("lastUsedBrainKeys");
 
   const lastUsedBrainkey = useMemo(() => {

--- a/app/packages/core/src/components/Actions/similar/Similar.tsx
+++ b/app/packages/core/src/components/Actions/similar/Similar.tsx
@@ -49,7 +49,9 @@ const SortBySimilarity = ({
   anchorRef,
 }: SortBySimilarityProps) => {
   const current = useRecoilValue(fos.similarityParameters);
-  const datasetId = useRecoilValue(fos.dataset)?.id as string;
+  const datasetId =
+    useRecoilValue(fos.dataset)?.name! +
+    useRecoilValue(fos.dataset)?.createdAt!;
   const [lastUsedBrainKeys] = useBrowserStorage("lastUsedBrainKeys");
 
   const lastUsedBrainkey = useMemo(() => {

--- a/app/packages/core/src/components/Actions/similar/utils.ts
+++ b/app/packages/core/src/components/Actions/similar/utils.ts
@@ -86,7 +86,7 @@ export const useSortBySimilarity = (close) => {
         setLastUsedBrainKeys(
           JSON.stringify({
             ...current,
-            [dataset.id]: combinedParameters.brainKey,
+            [dataset.name + dataset.createdAt]: combinedParameters.brainKey,
           })
         );
         await getFetchFunction()("POST", "/sort", {

--- a/app/packages/core/src/components/Actions/similar/utils.ts
+++ b/app/packages/core/src/components/Actions/similar/utils.ts
@@ -86,7 +86,7 @@ export const useSortBySimilarity = (close) => {
         setLastUsedBrainKeys(
           JSON.stringify({
             ...current,
-            [dataset.name + dataset.createdAt]: combinedParameters.brainKey,
+            [dataset.datasetId]: combinedParameters.brainKey,
           })
         );
         await getFetchFunction()("POST", "/sort", {

--- a/app/packages/relay/src/fragments/__generated__/datasetFragment.graphql.ts
+++ b/app/packages/relay/src/fragments/__generated__/datasetFragment.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<415b2906dc1dd0c5d4059cd4e775f7ed>>
+ * @generated SignedSource<<29e6fc779d6a822bf9e7a7d115a93420>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -33,6 +33,7 @@ export type datasetFragment$data = {
     readonly viewStages: ReadonlyArray<string> | null;
   }> | null;
   readonly createdAt: any | null;
+  readonly datasetId: string;
   readonly defaultMaskTargets: ReadonlyArray<{
     readonly target: string;
     readonly value: string;
@@ -174,6 +175,13 @@ return {
       "args": null,
       "kind": "ScalarField",
       "name": "createdAt",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "datasetId",
       "storageKey": null
     },
     {
@@ -453,6 +461,6 @@ return {
 };
 })();
 
-(node as any).hash = "85d19a2f683ddaa9b25ad3ba09246b41";
+(node as any).hash = "2ec789cd45082d3452d58dfd4a7288af";
 
 export default node;

--- a/app/packages/relay/src/fragments/datasetFragment.ts
+++ b/app/packages/relay/src/fragments/datasetFragment.ts
@@ -3,6 +3,7 @@ import { graphql } from "relay-runtime";
 export default graphql`
   fragment datasetFragment on Dataset {
     createdAt
+    datasetId
     groupField
     id
     info

--- a/app/packages/relay/src/queries/__generated__/datasetQuery.graphql.ts
+++ b/app/packages/relay/src/queries/__generated__/datasetQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<bb2ab616b0b4864bfbdfdc9937006fb5>>
+ * @generated SignedSource<<b62b93662549274bc4872da91c64ff86>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -265,66 +265,73 @@ v21 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "info",
+  "name": "datasetId",
   "storageKey": null
 },
 v22 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "lastLoadedAt",
+  "name": "info",
   "storageKey": null
 },
 v23 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "mediaType",
+  "name": "lastLoadedAt",
   "storageKey": null
 },
 v24 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "version",
+  "name": "mediaType",
   "storageKey": null
 },
 v25 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "key",
+  "name": "version",
   "storageKey": null
 },
 v26 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "timestamp",
+  "name": "key",
   "storageKey": null
 },
 v27 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "viewStages",
+  "name": "timestamp",
   "storageKey": null
 },
 v28 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "cls",
+  "name": "viewStages",
   "storageKey": null
 },
 v29 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
+  "name": "cls",
+  "storageKey": null
+},
+v30 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
   "name": "type",
   "storageKey": null
 },
-v30 = [
+v31 = [
   {
     "alias": null,
     "args": null,
@@ -334,67 +341,67 @@ v30 = [
   },
   (v15/*: any*/)
 ],
-v31 = {
+v32 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "labels",
   "storageKey": null
 },
-v32 = {
+v33 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "edges",
   "storageKey": null
 },
-v33 = {
+v34 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "ftype",
   "storageKey": null
 },
-v34 = {
+v35 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "subfield",
   "storageKey": null
 },
-v35 = {
+v36 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "embeddedDocType",
   "storageKey": null
 },
-v36 = {
+v37 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "dbField",
   "storageKey": null
 },
-v37 = {
+v38 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "description",
   "storageKey": null
 },
-v38 = {
+v39 = {
   "kind": "Variable",
   "name": "datasetName",
   "variableName": "name"
 },
-v39 = [
+v40 = [
   (v13/*: any*/),
-  (v33/*: any*/),
   (v34/*: any*/),
   (v35/*: any*/),
-  (v21/*: any*/),
-  (v37/*: any*/)
+  (v36/*: any*/),
+  (v22/*: any*/),
+  (v38/*: any*/)
 ];
 return {
   "fragment": {
@@ -650,6 +657,7 @@ return {
             "storageKey": null
           },
           (v20/*: any*/),
+          (v21/*: any*/),
           {
             "alias": null,
             "args": null,
@@ -658,10 +666,10 @@ return {
             "storageKey": null
           },
           (v12/*: any*/),
-          (v21/*: any*/),
           (v22/*: any*/),
           (v23/*: any*/),
           (v24/*: any*/),
+          (v25/*: any*/),
           {
             "alias": null,
             "args": null,
@@ -670,10 +678,10 @@ return {
             "name": "brainMethods",
             "plural": true,
             "selections": [
-              (v25/*: any*/),
-              (v24/*: any*/),
               (v26/*: any*/),
+              (v25/*: any*/),
               (v27/*: any*/),
+              (v28/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -682,7 +690,7 @@ return {
                 "name": "config",
                 "plural": false,
                 "selections": [
-                  (v28/*: any*/),
+                  (v29/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -711,7 +719,7 @@ return {
                     "name": "supportsPrompts",
                     "storageKey": null
                   },
-                  (v29/*: any*/),
+                  (v30/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -739,7 +747,7 @@ return {
             "kind": "LinkedField",
             "name": "defaultMaskTargets",
             "plural": true,
-            "selections": (v30/*: any*/),
+            "selections": (v31/*: any*/),
             "storageKey": null
           },
           {
@@ -750,8 +758,8 @@ return {
             "name": "defaultSkeleton",
             "plural": false,
             "selections": [
-              (v31/*: any*/),
-              (v32/*: any*/)
+              (v32/*: any*/),
+              (v33/*: any*/)
             ],
             "storageKey": null
           },
@@ -763,10 +771,10 @@ return {
             "name": "evaluations",
             "plural": true,
             "selections": [
-              (v25/*: any*/),
-              (v24/*: any*/),
               (v26/*: any*/),
+              (v25/*: any*/),
               (v27/*: any*/),
+              (v28/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -775,7 +783,7 @@ return {
                 "name": "config",
                 "plural": false,
                 "selections": [
-                  (v28/*: any*/),
+                  (v29/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -805,7 +813,7 @@ return {
             "plural": true,
             "selections": [
               (v9/*: any*/),
-              (v23/*: any*/)
+              (v24/*: any*/)
             ],
             "storageKey": null
           },
@@ -825,7 +833,7 @@ return {
                 "kind": "LinkedField",
                 "name": "targets",
                 "plural": true,
-                "selections": (v30/*: any*/),
+                "selections": (v31/*: any*/),
                 "storageKey": null
               }
             ],
@@ -840,8 +848,8 @@ return {
             "plural": true,
             "selections": [
               (v9/*: any*/),
-              (v31/*: any*/),
-              (v32/*: any*/)
+              (v32/*: any*/),
+              (v33/*: any*/)
             ],
             "storageKey": null
           },
@@ -853,13 +861,13 @@ return {
             "name": "frameFields",
             "plural": true,
             "selections": [
-              (v33/*: any*/),
               (v34/*: any*/),
               (v35/*: any*/),
-              (v13/*: any*/),
               (v36/*: any*/),
+              (v13/*: any*/),
               (v37/*: any*/),
-              (v21/*: any*/)
+              (v38/*: any*/),
+              (v22/*: any*/)
             ],
             "storageKey": null
           },
@@ -872,12 +880,12 @@ return {
             "plural": true,
             "selections": [
               (v13/*: any*/),
-              (v33/*: any*/),
               (v34/*: any*/),
               (v35/*: any*/),
               (v36/*: any*/),
               (v37/*: any*/),
-              (v21/*: any*/)
+              (v38/*: any*/),
+              (v22/*: any*/)
             ],
             "storageKey": null
           },
@@ -912,7 +920,7 @@ return {
       {
         "alias": null,
         "args": [
-          (v38/*: any*/)
+          (v39/*: any*/)
         ],
         "concreteType": "SavedView",
         "kind": "LinkedField",
@@ -920,13 +928,7 @@ return {
         "plural": true,
         "selections": [
           (v12/*: any*/),
-          {
-            "alias": null,
-            "args": null,
-            "kind": "ScalarField",
-            "name": "datasetId",
-            "storageKey": null
-          },
+          (v21/*: any*/),
           (v9/*: any*/),
           {
             "alias": null,
@@ -935,9 +937,9 @@ return {
             "name": "slug",
             "storageKey": null
           },
-          (v37/*: any*/),
+          (v38/*: any*/),
           (v14/*: any*/),
-          (v27/*: any*/),
+          (v28/*: any*/),
           (v20/*: any*/),
           {
             "alias": null,
@@ -946,7 +948,7 @@ return {
             "name": "lastModifiedAt",
             "storageKey": null
           },
-          (v22/*: any*/)
+          (v23/*: any*/)
         ],
         "storageKey": null
       },
@@ -969,7 +971,7 @@ return {
             "plural": true,
             "selections": [
               (v9/*: any*/),
-              (v29/*: any*/),
+              (v30/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -993,7 +995,7 @@ return {
       {
         "alias": null,
         "args": [
-          (v38/*: any*/),
+          (v39/*: any*/),
           {
             "kind": "Variable",
             "name": "viewStages",
@@ -1012,7 +1014,7 @@ return {
             "kind": "LinkedField",
             "name": "fieldSchema",
             "plural": true,
-            "selections": (v39/*: any*/),
+            "selections": (v40/*: any*/),
             "storageKey": null
           },
           {
@@ -1022,7 +1024,7 @@ return {
             "kind": "LinkedField",
             "name": "frameFieldSchema",
             "plural": true,
-            "selections": (v39/*: any*/),
+            "selections": (v40/*: any*/),
             "storageKey": null
           }
         ],
@@ -1031,12 +1033,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "232e18a5ea2ff036213f3418ca225a1a",
+    "cacheID": "6f7afad8384b15f248c4a2cad528defb",
     "id": null,
     "metadata": {},
     "name": "datasetQuery",
     "operationKind": "query",
-    "text": "query datasetQuery(\n  $savedViewSlug: String\n  $name: String!\n  $view: BSONArray!\n  $extendedView: BSONArray!\n) {\n  config {\n    colorBy\n    colorPool\n    multicolorKeypoints\n    showSkeletons\n  }\n  dataset(name: $name, view: $extendedView, savedViewSlug: $savedViewSlug) {\n    name\n    defaultGroupSlice\n    viewName\n    appConfig {\n      colorScheme {\n        id\n        colorBy\n        colorPool\n        multicolorKeypoints\n        opacity\n        showSkeletons\n        fields {\n          colorByAttribute\n          fieldColor\n          path\n          valueColors {\n            color\n            value\n          }\n        }\n      }\n    }\n    ...datasetFragment\n    id\n  }\n  ...savedViewsFragment\n  ...configFragment\n  ...stageDefinitionsFragment\n  ...viewSchemaFragment\n}\n\nfragment configFragment on Query {\n  config {\n    colorBy\n    colorPool\n    colorscale\n    gridZoom\n    loopVideos\n    multicolorKeypoints\n    notebookHeight\n    plugins\n    showConfidence\n    showIndex\n    showLabel\n    showSkeletons\n    showTooltip\n    sidebarMode\n    theme\n    timezone\n    useFrameNumber\n  }\n  colorscale\n}\n\nfragment datasetAppConfigFragment on DatasetAppConfig {\n  gridMediaField\n  mediaFields\n  modalMediaField\n  plugins\n  sidebarMode\n  colorScheme {\n    id\n    colorBy\n    colorPool\n    multicolorKeypoints\n    opacity\n    showSkeletons\n    fields {\n      colorByAttribute\n      fieldColor\n      path\n      valueColors {\n        color\n        value\n      }\n    }\n  }\n}\n\nfragment datasetFragment on Dataset {\n  createdAt\n  groupField\n  id\n  info\n  lastLoadedAt\n  mediaType\n  name\n  version\n  appConfig {\n    ...datasetAppConfigFragment\n  }\n  brainMethods {\n    key\n    version\n    timestamp\n    viewStages\n    config {\n      cls\n      embeddingsField\n      method\n      patchesField\n      supportsPrompts\n      type\n      maxK\n      supportsLeastSimilarity\n    }\n  }\n  defaultMaskTargets {\n    target\n    value\n  }\n  defaultSkeleton {\n    labels\n    edges\n  }\n  evaluations {\n    key\n    version\n    timestamp\n    viewStages\n    config {\n      cls\n      predField\n      gtField\n    }\n  }\n  groupMediaTypes {\n    name\n    mediaType\n  }\n  maskTargets {\n    name\n    targets {\n      target\n      value\n    }\n  }\n  skeletons {\n    name\n    labels\n    edges\n  }\n  ...frameFieldsFragment\n  ...groupSliceFragment\n  ...mediaFieldsFragment\n  ...mediaTypeFragment\n  ...sampleFieldsFragment\n  ...sidebarGroupsFragment\n  ...viewFragment\n}\n\nfragment frameFieldsFragment on Dataset {\n  frameFields {\n    ftype\n    subfield\n    embeddedDocType\n    path\n    dbField\n    description\n    info\n  }\n}\n\nfragment groupSliceFragment on Dataset {\n  defaultGroupSlice\n}\n\nfragment mediaFieldsFragment on Dataset {\n  name\n  appConfig {\n    gridMediaField\n  }\n  sampleFields {\n    path\n  }\n}\n\nfragment mediaTypeFragment on Dataset {\n  mediaType\n}\n\nfragment sampleFieldsFragment on Dataset {\n  sampleFields {\n    ftype\n    subfield\n    embeddedDocType\n    path\n    dbField\n    description\n    info\n  }\n}\n\nfragment savedViewsFragment on Query {\n  savedViews(datasetName: $name) {\n    id\n    datasetId\n    name\n    slug\n    description\n    color\n    viewStages\n    createdAt\n    lastModifiedAt\n    lastLoadedAt\n  }\n}\n\nfragment sidebarGroupsFragment on Dataset {\n  name\n  appConfig {\n    sidebarGroups {\n      expanded\n      paths\n      name\n    }\n  }\n  ...frameFieldsFragment\n  ...sampleFieldsFragment\n}\n\nfragment stageDefinitionsFragment on Query {\n  stageDefinitions {\n    name\n    params {\n      name\n      type\n      default\n      placeholder\n    }\n  }\n}\n\nfragment viewFragment on Dataset {\n  stages(slug: $savedViewSlug, view: $view)\n  viewCls\n  viewName\n}\n\nfragment viewSchemaFragment on Query {\n  schemaForViewStages(datasetName: $name, viewStages: $view) {\n    fieldSchema {\n      path\n      ftype\n      subfield\n      embeddedDocType\n      info\n      description\n    }\n    frameFieldSchema {\n      path\n      ftype\n      subfield\n      embeddedDocType\n      info\n      description\n    }\n  }\n}\n"
+    "text": "query datasetQuery(\n  $savedViewSlug: String\n  $name: String!\n  $view: BSONArray!\n  $extendedView: BSONArray!\n) {\n  config {\n    colorBy\n    colorPool\n    multicolorKeypoints\n    showSkeletons\n  }\n  dataset(name: $name, view: $extendedView, savedViewSlug: $savedViewSlug) {\n    name\n    defaultGroupSlice\n    viewName\n    appConfig {\n      colorScheme {\n        id\n        colorBy\n        colorPool\n        multicolorKeypoints\n        opacity\n        showSkeletons\n        fields {\n          colorByAttribute\n          fieldColor\n          path\n          valueColors {\n            color\n            value\n          }\n        }\n      }\n    }\n    ...datasetFragment\n    id\n  }\n  ...savedViewsFragment\n  ...configFragment\n  ...stageDefinitionsFragment\n  ...viewSchemaFragment\n}\n\nfragment configFragment on Query {\n  config {\n    colorBy\n    colorPool\n    colorscale\n    gridZoom\n    loopVideos\n    multicolorKeypoints\n    notebookHeight\n    plugins\n    showConfidence\n    showIndex\n    showLabel\n    showSkeletons\n    showTooltip\n    sidebarMode\n    theme\n    timezone\n    useFrameNumber\n  }\n  colorscale\n}\n\nfragment datasetAppConfigFragment on DatasetAppConfig {\n  gridMediaField\n  mediaFields\n  modalMediaField\n  plugins\n  sidebarMode\n  colorScheme {\n    id\n    colorBy\n    colorPool\n    multicolorKeypoints\n    opacity\n    showSkeletons\n    fields {\n      colorByAttribute\n      fieldColor\n      path\n      valueColors {\n        color\n        value\n      }\n    }\n  }\n}\n\nfragment datasetFragment on Dataset {\n  createdAt\n  datasetId\n  groupField\n  id\n  info\n  lastLoadedAt\n  mediaType\n  name\n  version\n  appConfig {\n    ...datasetAppConfigFragment\n  }\n  brainMethods {\n    key\n    version\n    timestamp\n    viewStages\n    config {\n      cls\n      embeddingsField\n      method\n      patchesField\n      supportsPrompts\n      type\n      maxK\n      supportsLeastSimilarity\n    }\n  }\n  defaultMaskTargets {\n    target\n    value\n  }\n  defaultSkeleton {\n    labels\n    edges\n  }\n  evaluations {\n    key\n    version\n    timestamp\n    viewStages\n    config {\n      cls\n      predField\n      gtField\n    }\n  }\n  groupMediaTypes {\n    name\n    mediaType\n  }\n  maskTargets {\n    name\n    targets {\n      target\n      value\n    }\n  }\n  skeletons {\n    name\n    labels\n    edges\n  }\n  ...frameFieldsFragment\n  ...groupSliceFragment\n  ...mediaFieldsFragment\n  ...mediaTypeFragment\n  ...sampleFieldsFragment\n  ...sidebarGroupsFragment\n  ...viewFragment\n}\n\nfragment frameFieldsFragment on Dataset {\n  frameFields {\n    ftype\n    subfield\n    embeddedDocType\n    path\n    dbField\n    description\n    info\n  }\n}\n\nfragment groupSliceFragment on Dataset {\n  defaultGroupSlice\n}\n\nfragment mediaFieldsFragment on Dataset {\n  name\n  appConfig {\n    gridMediaField\n  }\n  sampleFields {\n    path\n  }\n}\n\nfragment mediaTypeFragment on Dataset {\n  mediaType\n}\n\nfragment sampleFieldsFragment on Dataset {\n  sampleFields {\n    ftype\n    subfield\n    embeddedDocType\n    path\n    dbField\n    description\n    info\n  }\n}\n\nfragment savedViewsFragment on Query {\n  savedViews(datasetName: $name) {\n    id\n    datasetId\n    name\n    slug\n    description\n    color\n    viewStages\n    createdAt\n    lastModifiedAt\n    lastLoadedAt\n  }\n}\n\nfragment sidebarGroupsFragment on Dataset {\n  name\n  appConfig {\n    sidebarGroups {\n      expanded\n      paths\n      name\n    }\n  }\n  ...frameFieldsFragment\n  ...sampleFieldsFragment\n}\n\nfragment stageDefinitionsFragment on Query {\n  stageDefinitions {\n    name\n    params {\n      name\n      type\n      default\n      placeholder\n    }\n  }\n}\n\nfragment viewFragment on Dataset {\n  stages(slug: $savedViewSlug, view: $view)\n  viewCls\n  viewName\n}\n\nfragment viewSchemaFragment on Query {\n  schemaForViewStages(datasetName: $name, viewStages: $view) {\n    fieldSchema {\n      path\n      ftype\n      subfield\n      embeddedDocType\n      info\n      description\n    }\n    frameFieldSchema {\n      path\n      ftype\n      subfield\n      embeddedDocType\n      info\n      description\n    }\n  }\n}\n"
   }
 };
 })();

--- a/app/packages/state/src/recoil/selectors.ts
+++ b/app/packages/state/src/recoil/selectors.ts
@@ -38,6 +38,21 @@ export const datasetName = graphQLSyncFragmentAtom<
   }
 );
 
+export const datasetId = graphQLSyncFragmentAtom<
+  datasetFragment$key,
+  string | null
+>(
+  {
+    fragments: [datasetFragment],
+    keys: ["dataset"],
+    read: ({ datasetId }) => datasetId,
+    default: null,
+  },
+  {
+    key: "datasetId",
+  }
+);
+
 export const isNotebook = selector<boolean>({
   key: "isNotebook",
   get: () => {

--- a/app/packages/state/src/recoil/types.ts
+++ b/app/packages/state/src/recoil/types.ts
@@ -128,6 +128,7 @@ export namespace State {
     id: string;
     brainMethods: BrainRun[];
     createdAt: DateTime;
+    datasetId: string;
     defaultMaskTargets: Targets;
     evaluations: EvaluationRun[];
     lastLoadedAt: DateTime;

--- a/app/packages/state/src/recoil/utils.ts
+++ b/app/packages/state/src/recoil/utils.ts
@@ -163,9 +163,7 @@ export const getEmbeddedLabelFields = (fields: StrictField[], prefix = "") =>
     )
     .flat();
 
-export function useAssertedRecoilValue<T>(
-  recoilValue: RecoilValue<T>
-): NonNullable<T> {
+export function useAssertedRecoilValue<T>(recoilValue: RecoilValue<T>) {
   const value = useRecoilValue(recoilValue);
 
   if (!value) {

--- a/app/packages/state/src/recoil/utils.ts
+++ b/app/packages/state/src/recoil/utils.ts
@@ -8,6 +8,7 @@ import {
   VALID_PRIMITIVE_TYPES,
   getFetchParameters,
 } from "@fiftyone/utilities";
+import { RecoilValue, useRecoilValue } from "recoil";
 import { Nullable } from "vitest";
 
 export const getSampleSrc = (url: string) => {
@@ -161,3 +162,15 @@ export const getEmbeddedLabelFields = (fields: StrictField[], prefix = "") =>
       )
     )
     .flat();
+
+export function useAssertedRecoilValue<T>(
+  recoilValue: RecoilValue<T>
+): NonNullable<T> {
+  const value = useRecoilValue(recoilValue);
+
+  if (!value) {
+    throw new Error(`${recoilValue.key} is not defined`);
+  }
+
+  return value;
+}

--- a/app/schema.graphql
+++ b/app/schema.graphql
@@ -168,6 +168,7 @@ type DataAggregation implements Aggregation {
 
 type Dataset {
   id: ID!
+  datasetId: ID!
   name: String!
   createdAt: date
   lastLoadedAt: datetime

--- a/fiftyone/server/query.py
+++ b/fiftyone/server/query.py
@@ -227,6 +227,7 @@ class DatasetAppConfig:
 @gql.type
 class Dataset:
     id: gql.ID
+    dataset_id: gql.ID
     name: str
     created_at: t.Optional[date]
     last_loaded_at: t.Optional[datetime]
@@ -266,6 +267,7 @@ class Dataset:
     @staticmethod
     def modifier(doc: dict) -> dict:
         doc["id"] = doc.pop("_id")
+        doc["dataset_id"] = doc["id"]
         doc["default_mask_targets"] = _convert_targets(
             doc.get("default_mask_targets", {})
         )


### PR DESCRIPTION
## What changes are proposed in this pull request?

Fixed the regression that last used brain key was not loaded by default.
Updated the unique identifier of dataset when we store the key in local storage

## How is this patch tested? If it is not, please explain why.

https://github.com/voxel51/fiftyone/assets/17770824/339f86af-4135-4f3c-b432-a07f97bebb37



## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
