### PR TITLE
sample (de)select keyboard shortcut for modal and Grid

### DIFF
--- a/app/packages/core/src/components/Actions/ActionsRow.tsx
+++ b/app/packages/core/src/components/Actions/ActionsRow.tsx
@@ -357,7 +357,6 @@ const SaveFilters = () => {
       async () => {
         const loading = await snapshot.getPromise(fos.savingFilters);
         const selected = await snapshot.getPromise(fos.selectedSamples);
-        console.log("save filters", selected);
         if (loading) {
           return;
         }

--- a/app/packages/core/src/components/Actions/ActionsRow.tsx
+++ b/app/packages/core/src/components/Actions/ActionsRow.tsx
@@ -357,7 +357,7 @@ const SaveFilters = () => {
       async () => {
         const loading = await snapshot.getPromise(fos.savingFilters);
         const selected = await snapshot.getPromise(fos.selectedSamples);
-
+        console.log("save filters", selected);
         if (loading) {
           return;
         }

--- a/app/packages/core/src/components/Actions/ActionsRow.tsx
+++ b/app/packages/core/src/components/Actions/ActionsRow.tsx
@@ -357,6 +357,7 @@ const SaveFilters = () => {
       async () => {
         const loading = await snapshot.getPromise(fos.savingFilters);
         const selected = await snapshot.getPromise(fos.selectedSamples);
+
         if (loading) {
           return;
         }

--- a/app/packages/core/src/components/Grid/Grid.tsx
+++ b/app/packages/core/src/components/Grid/Grid.tsx
@@ -151,20 +151,15 @@ const Grid: React.FC<{}> = () => {
   );
   const isTagging = taggingLabels || taggingSamples;
 
-  const keydownEventHandler = useRecoilCallback(
-    ({ reset }) =>
+  const escEventHandler = useRecoilCallback(
+    ({ snapshot, reset }) =>
       async (event: KeyboardEvent) => {
-        if ((event.ctrlKey || event.metaKey) && !isModalOpen) {
-          return;
-        }
-
         if (event.key !== "Escape") {
           return;
         }
 
-        if (!isModalOpen) {
-          reset(fos.selectedSamples);
-        }
+        const isModalOpen = await snapshot.getPromise(fos.isModalActive);
+        isModalOpen && reset(fos.selectedSamples);
       },
     [isModalOpen]
   );
@@ -173,16 +168,16 @@ const Grid: React.FC<{}> = () => {
     // this deferred execution is a hack to address problem caused by a race condition in `isModalOpen`
     setTimeout(() => {
       if (!isModalOpen) {
-        document.addEventListener("keydown", keydownEventHandler);
+        document.addEventListener("keydown", escEventHandler);
       } else {
-        document.removeEventListener("keydown", keydownEventHandler);
+        document.removeEventListener("keydown", escEventHandler);
       }
     }, 0);
 
     return () => {
-      document.removeEventListener("keydown", keydownEventHandler);
+      document.removeEventListener("keydown", escEventHandler);
     };
-  }, [isModalOpen, keydownEventHandler]);
+  }, [isModalOpen, escEventHandler]);
 
   useEffect(() => {
     init();

--- a/app/packages/core/src/components/Grid/Grid.tsx
+++ b/app/packages/core/src/components/Grid/Grid.tsx
@@ -155,7 +155,7 @@ const Grid: React.FC<{}> = () => {
   );
   const isTagging = taggingLabels || taggingSamples;
 
-  const setCtrlMetaDown = useSetRecoilState(fos.ctrlOrMetdaKeyDown);
+  const setCtrlMetaDown = useSetRecoilState(fos.ctrlOrMetaKeyDown);
   const keydownEventHandler = useRecoilCallback(
     ({ reset }) =>
       async (event: KeyboardEvent) => {

--- a/app/packages/core/src/components/Grid/Grid.tsx
+++ b/app/packages/core/src/components/Grid/Grid.tsx
@@ -161,7 +161,7 @@ const Grid: React.FC<{}> = () => {
         const isModalOpen = await snapshot.getPromise(fos.isModalActive);
         isModalOpen && reset(fos.selectedSamples);
       },
-    [isModalOpen]
+    []
   );
 
   useEffect(() => {

--- a/app/packages/core/src/components/Modal/ModalNavigation.tsx
+++ b/app/packages/core/src/components/Modal/ModalNavigation.tsx
@@ -4,7 +4,12 @@ import {
 } from "@fiftyone/components";
 import * as fos from "@fiftyone/state";
 import React, { useCallback, useRef } from "react";
-import { useRecoilValue, useRecoilValueLoadable } from "recoil";
+import {
+  useRecoilSnapshot,
+  useRecoilState,
+  useRecoilValue,
+  useRecoilValueLoadable,
+} from "recoil";
 import styled from "styled-components";
 
 const Arrow = styled.span<{ isRight?: boolean }>`
@@ -43,6 +48,8 @@ const ModalNavigation = ({ onNavigate }: { onNavigate: () => void }) => {
   if (countLoadable.state === "hasValue") {
     count.current = countLoadable.contents;
   }
+  const current = useRecoilValue(fos.currentModalSample);
+  const [selected, setSelected] = useRecoilState(fos.selectedSamples);
 
   const index = useRecoilValue(fos.modalSampleIndex);
   const setModal = fos.useSetExpandedSample();
@@ -65,7 +72,18 @@ const ModalNavigation = ({ onNavigate }: { onNavigate: () => void }) => {
           return;
         }
       }
-      if (e.key === "ArrowLeft") {
+      if (e.key === "x") {
+        const newSelected = new Set([...selected]);
+
+        if (current) {
+          if (newSelected.has(current.id)) {
+            newSelected.delete(current.id);
+          } else {
+            newSelected.add(current.id);
+          }
+        }
+        setSelected(newSelected);
+      } else if (e.key === "ArrowLeft") {
         navigatePrevious();
       } else if (e.key === "ArrowRight") {
         navigateNext();
@@ -74,7 +92,7 @@ const ModalNavigation = ({ onNavigate }: { onNavigate: () => void }) => {
       }
       // note: don't stop event propagation here
     },
-    [navigateNext, navigatePrevious]
+    [current, navigateNext, navigatePrevious, selected, setSelected]
   );
 
   fos.useEventHandler(document, "keydown", keyboardHandler);

--- a/app/packages/core/src/components/Modal/ModalNavigation.tsx
+++ b/app/packages/core/src/components/Modal/ModalNavigation.tsx
@@ -69,8 +69,8 @@ const ModalNavigation = ({ onNavigate }: { onNavigate: () => void }) => {
             return;
           }
         }
-        const current = await snapshot.getPromise(fos.currentModalSample);
         if (e.key === "x") {
+          const current = await snapshot.getPromise(fos.currentModalSample);
           set(fos.selectedSamples, (selected) => {
             const newSelected = new Set([...selected]);
             if (current) {

--- a/app/packages/flashlight/src/index.ts
+++ b/app/packages/flashlight/src/index.ts
@@ -593,15 +593,20 @@ export default class Flashlight<K> {
     return state;
   }
 
-  private getOnItemClick(): (id: string) => void | null {
+  private getOnItemClick(): (id: string, event: MouseEvent) => void | null {
     if (!this.state.onItemClick) {
       return null;
     }
 
-    return (id) =>
-      this.state.onItemClick(() => this.get(), id, {
-        ...this.state.itemIndexMap,
-      });
+    return (id, event) =>
+      this.state.onItemClick(
+        () => this.get(),
+        id,
+        {
+          ...this.state.itemIndexMap,
+        },
+        event
+      );
   }
 
   private createContainer(): HTMLDivElement {

--- a/app/packages/flashlight/src/section.ts
+++ b/app/packages/flashlight/src/section.ts
@@ -32,7 +32,7 @@ export default class SectionElement implements Section {
     rows: RowData[],
     render: Render,
     horizontal: boolean,
-    onItemClick?: (id: string) => void
+    onItemClick?: (id: string, event: MouseEvent) => void
   ) {
     this.index = index;
     this.itemIndex = itemIndex;
@@ -56,10 +56,11 @@ export default class SectionElement implements Section {
           if (onItemClick) {
             itemElement.addEventListener("click", (event) => {
               event.preventDefault();
-              onItemClick(itemData.id);
+              onItemClick(itemData.id, event);
             });
             itemElement.addEventListener("contextmenu", (event) => {
-              onItemClick(itemData.id);
+              event.preventDefault();
+              onItemClick(itemData.id, event);
             });
           }
 

--- a/app/packages/flashlight/src/state.ts
+++ b/app/packages/flashlight/src/state.ts
@@ -43,7 +43,8 @@ export type ItemIndexMap = { [key: string]: number };
 export type OnItemClick = (
   next: () => Promise<void>,
   id: string,
-  itemIndexMap: ItemIndexMap
+  itemIndexMap: ItemIndexMap,
+  event: MouseEvent
 ) => void;
 
 export type Render = (

--- a/app/packages/looker/src/elements/common/actions.ts
+++ b/app/packages/looker/src/elements/common/actions.ts
@@ -368,6 +368,14 @@ export const json: Control = {
   },
 };
 
+export const selectSample: Control = {
+  title: "Select or Deselect Sample",
+  shortcut: "x",
+  eventKeys: null,
+  detail: "Grid → Control + Click",
+  action: () => null,
+};
+
 export const COMMON = {
   escape,
   rotateNext,
@@ -383,6 +391,7 @@ export const COMMON = {
   json,
   wheel,
   toggleOverlays,
+  selectSample,
 };
 
 export const COMMON_SHORTCUTS = readActions(COMMON);

--- a/app/packages/state/src/hooks/useExpandSample.ts
+++ b/app/packages/state/src/hooks/useExpandSample.ts
@@ -5,8 +5,6 @@ import {
   CallbackInterface,
   RecoilState,
   useRecoilCallback,
-  useRecoilState,
-  useRecoilValue,
   useSetRecoilState,
 } from "recoil";
 import * as atoms from "../recoil/atoms";
@@ -20,7 +18,6 @@ import { getSanitizedGroupByExpression } from "../recoil/utils";
 import * as viewAtoms from "../recoil/view";
 import { LookerStore, Lookers } from "./useLookerStore";
 import useSetExpandedSample from "./useSetExpandedSample";
-import useSetSelected from "./useSetSelected";
 
 const setModalFilters = async ({ snapshot, set }: CallbackInterface) => {
   const paths = await snapshot.getPromise(
@@ -104,20 +101,16 @@ export default <T extends Lookers>(store: LookerStore<T>) => {
     void
   >(
     ({ snapshot }) =>
-      async (next, sampleId, itemIndexMap) => {
+      async (next, sampleId, itemIndexMap, event) => {
         const selected = await snapshot.getPromise(atoms.selectedSamples);
-        const isCtrlOrMetaDown = await snapshot.getPromise(
-          atoms.ctrlOrMetaKeyDown
-        );
-        if (isCtrlOrMetaDown) {
+        if (event.ctrlKey || event.metaKey) {
           const newSelected = new Set([...selected]);
-          if (sampleId) {
-            if (newSelected.has(sampleId)) {
-              newSelected.delete(sampleId);
-            } else {
-              newSelected.add(sampleId);
-            }
+          if (newSelected.has(sampleId)) {
+            newSelected.delete(sampleId);
+          } else {
+            newSelected.add(sampleId);
           }
+
           setSelectedSamples(newSelected);
           return;
         }

--- a/app/packages/state/src/hooks/useExpandSample.ts
+++ b/app/packages/state/src/hooks/useExpandSample.ts
@@ -1,12 +1,7 @@
 import { FlashlightConfig } from "@fiftyone/flashlight";
 import { get } from "lodash";
 import { useRelayEnvironment } from "react-relay";
-import {
-  CallbackInterface,
-  RecoilState,
-  useRecoilCallback,
-  useSetRecoilState,
-} from "recoil";
+import { CallbackInterface, RecoilState, useRecoilCallback } from "recoil";
 import * as atoms from "../recoil/atoms";
 import * as filterAtoms from "../recoil/filters";
 import * as groupAtoms from "../recoil/groups";
@@ -37,7 +32,6 @@ const setModalFilters = async ({ snapshot, set }: CallbackInterface) => {
 export default <T extends Lookers>(store: LookerStore<T>) => {
   const environment = useRelayEnvironment();
   const setExpandedSample = useSetExpandedSample();
-  const setSelectedSamples = useSetRecoilState(atoms.selectedSamples);
 
   const setModalState = useRecoilCallback(
     (cbInterface) => async (navigation: modalAtoms.ModalNavigation) => {
@@ -100,18 +94,19 @@ export default <T extends Lookers>(store: LookerStore<T>) => {
     Parameters<NonNullable<FlashlightConfig<number>["onItemClick"]>>,
     void
   >(
-    ({ snapshot }) =>
+    ({ snapshot, set }) =>
       async (next, sampleId, itemIndexMap, event) => {
-        const selected = await snapshot.getPromise(atoms.selectedSamples);
         if (event.ctrlKey || event.metaKey) {
-          const newSelected = new Set([...selected]);
-          if (newSelected.has(sampleId)) {
-            newSelected.delete(sampleId);
-          } else {
-            newSelected.add(sampleId);
-          }
+          set(atoms.selectedSamples, (selected) => {
+            const newSelected = new Set([...selected]);
+            if (newSelected.has(sampleId)) {
+              newSelected.delete(sampleId);
+            } else {
+              newSelected.add(sampleId);
+            }
 
-          setSelectedSamples(newSelected);
+            return newSelected;
+          });
           return;
         }
         const clickedIndex = itemIndexMap[sampleId];
@@ -154,6 +149,6 @@ export default <T extends Lookers>(store: LookerStore<T>) => {
 
         setModalState(getIndex).then(() => setExpandedSample(clickedIndex));
       },
-    [setExpandedSample, setModalState, store, setSelectedSamples]
+    [setExpandedSample, setModalState, store]
   );
 };

--- a/app/packages/state/src/hooks/useExpandSample.ts
+++ b/app/packages/state/src/hooks/useExpandSample.ts
@@ -107,7 +107,7 @@ export default <T extends Lookers>(store: LookerStore<T>) => {
       async (next, sampleId, itemIndexMap) => {
         const selected = await snapshot.getPromise(atoms.selectedSamples);
         const isCtrlOrMetaDown = await snapshot.getPromise(
-          atoms.ctrlOrMetdaKeyDown
+          atoms.ctrlOrMetaKeyDown
         );
         if (isCtrlOrMetaDown) {
           const newSelected = new Set([...selected]);

--- a/app/packages/state/src/recoil/atoms.ts
+++ b/app/packages/state/src/recoil/atoms.ts
@@ -14,13 +14,13 @@ import {
   sampleFieldsFragment$key,
 } from "@fiftyone/relay";
 import { StrictField } from "@fiftyone/utilities";
-import { AtomEffect, DefaultValue, atom, atomFamily, selector } from "recoil";
+import { DefaultValue, atom, atomFamily, selector } from "recoil";
 import { ModalSample } from "..";
 import { SPACES_DEFAULT, sessionAtom } from "../session";
 import { collapseFields, transformDataset } from "../utils";
+import { getBrowserStorageEffectForKey } from "./customEffects";
 import { groupMediaTypesSet } from "./groups";
 import { State } from "./types";
-import { getBrowserStorageEffectForKey } from "./customEffects";
 
 export const refresher = atom<number>({
   key: "refresher",
@@ -243,11 +243,6 @@ export const appTeamsIsOpen = atom({
 export const savedLookerOptions = atom({
   key: "savedLookerOptions",
   default: {},
-});
-
-export const ctrlOrMetaKeyDown = atom({
-  key: "ctrlOrMetaKeyDown",
-  default: false,
 });
 
 export const patching = atom<boolean>({

--- a/app/packages/state/src/recoil/atoms.ts
+++ b/app/packages/state/src/recoil/atoms.ts
@@ -245,6 +245,11 @@ export const savedLookerOptions = atom({
   default: {},
 });
 
+export const ctrlOrMetdaKeyDown = atom({
+  key: "ctrlOrMetdaKeyDown",
+  default: false,
+});
+
 export const patching = atom<boolean>({
   key: "patching",
   default: false,

--- a/app/packages/state/src/recoil/atoms.ts
+++ b/app/packages/state/src/recoil/atoms.ts
@@ -245,8 +245,8 @@ export const savedLookerOptions = atom({
   default: {},
 });
 
-export const ctrlOrMetdaKeyDown = atom({
-  key: "ctrlOrMetdaKeyDown",
+export const ctrlOrMetaKeyDown = atom({
+  key: "ctrlOrMetaKeyDown",
   default: false,
 });
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

Shortcuts for selecting and deselecting samples quicker
- [x] when sample modal open, pressing `x` will toggle current sample selection
- [x] when in Grid, holding down `Meta` or `Control` key and pressing `x` toggles targeted sample selection
- [x] Add shortcut to help panel


https://github.com/voxel51/fiftyone/assets/109545780/3fbf35fe-4d6a-47b3-8d64-d37f0653c97f



## How is this patch tested? If it is not, please explain why.

(Details)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
