### PR TITLE
Bugfix: out of sync metadata.json on export

### DIFF
--- a/fiftyone/utils/data/exporters.py
+++ b/fiftyone/utils/data/exporters.py
@@ -2118,6 +2118,7 @@ class FiftyOneDatasetExporter(BatchDatasetExporter):
             )
 
         dataset = sample_collection._dataset
+        dataset._doc.reload()
         dataset_dict = dataset._doc.to_dict()
         dataset_dict["saved_views"] = []
         dataset_dict["annotation_runs"] = {}


### PR DESCRIPTION
Reload dataset document before exporting metadata.json in case it has been updated by another process.
Samples are exported straight from database backing so we must reload dataset doc otherwise metadata.json may not match samples.json.

Note there could still be a race condition between 2 processes but the window for that is quite small.

## How is this patch tested? If it is not, please explain why.

Scripts below written by a reporting user. Thanks.

Run first script then run second script. Make sure `field` shows up in metadata.json as well as samples.json

```python
# main1.py
import time

import fiftyone as fo

DATASET_NAME = "quickstart"
EXPORT_PATH = "export-test"

dataset: fo.Dataset = fo.zoo.load_zoo_dataset(DATASET_NAME)
dataset.export(
    export_dir=EXPORT_PATH,
    dataset_type=fo.types.FiftyOneDataset,
    export_media=False,
    overwrite=True,
)

print("SLEEPING, RUN YOUR SECOND SCRIPT")
time.sleep(30)

dataset: fo.Dataset = fo.load_dataset(DATASET_NAME)
dataset.export(
    export_dir=EXPORT_PATH,
    dataset_type=fo.types.FiftyOneDataset,
    export_media=False,
    overwrite=True,
)
```
```python
# main2.py
import fiftyone as fo

DATASET_NAME = "quickstart"
dataset: fo.Dataset = fo.load_dataset(DATASET_NAME)

dataset.add_sample(
    fo.Sample(
        "blah.jpg",
        field1=fo.DynamicEmbeddedDocument(some_field="abc")
    ),
    dynamic=True
)
dataset.save()
```

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
