### PR TITLE
add LazyFieldView to OperatorIO

### DIFF
--- a/app/packages/core/src/plugins/SchemaIO/components/LazyFieldView.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/LazyFieldView.tsx
@@ -1,0 +1,92 @@
+import { Replay, Save } from "@mui/icons-material";
+import { Box, IconButton, Stack } from "@mui/material";
+import { merge } from "lodash";
+import React, { useCallback, useState } from "react";
+import FieldView from "./FieldView";
+
+export default function LazyFieldView(props) {
+  const { onChange, path, schema } = props;
+  const [value, setValue] = useState(schema?.default || "");
+  const [state, setState] = useState(value);
+  const saveOnBlur = schema?.view?.save_on_blur;
+
+  const applyChanges = useCallback(() => {
+    setValue(state);
+    onChange(path, state);
+  }, [onChange, path, setValue, state]);
+
+  const schemaOverrides = {
+    view: {
+      componentsProps: {
+        field: {
+          value: state,
+          InputProps: {
+            endAdornment: (
+              <ApplyReset
+                key={state}
+                hasChanges={value !== state}
+                onApply={applyChanges}
+                onReset={() => {
+                  setState(value);
+                }}
+              />
+            ),
+          },
+          onBlur: saveOnBlur ? applyChanges : undefined,
+        },
+      },
+    },
+  };
+  const computedSchema = merge(schema, schemaOverrides);
+
+  return (
+    <FieldView
+      {...props}
+      schema={computedSchema}
+      onChange={(_: string, value: string) => {
+        setState(value);
+      }}
+    />
+  );
+}
+
+function ApplyReset(props: ApplyResetPropsType) {
+  const { hasChanges, onApply, onReset } = props;
+  return (
+    <Stack direction="row">
+      {hasChanges && (
+        <IconButton
+          title="Reset changes"
+          size="small"
+          onMouseDown={(e) => {
+            e.preventDefault();
+            e.stopPropagation();
+          }}
+          onClick={onReset}
+        >
+          <Replay color="secondary" fontSize="small" />
+        </IconButton>
+      )}
+      <Box
+        title={hasChanges ? "Apply changes" : "No pending changes"}
+        sx={{ cursor: hasChanges ? undefined : "default" }}
+      >
+        <IconButton size="small" onClick={onApply} disabled={!hasChanges}>
+          <Save
+            sx={{
+              color: (theme) =>
+                theme.palette.text[hasChanges ? "primary" : "tertiary"],
+            }}
+            fontSize="small"
+          />
+        </IconButton>
+      </Box>
+    </Stack>
+  );
+}
+
+type ApplyResetPropsType = {
+  hasChanges: boolean;
+  onApply: () => void;
+  onReset: () => void;
+};

--- a/app/packages/core/src/plugins/SchemaIO/components/index.ts
+++ b/app/packages/core/src/plugins/SchemaIO/components/index.ts
@@ -44,3 +44,4 @@ export { default as TagsView } from "./TagsView";
 export { default as TextFieldView } from "./TextFieldView";
 export { default as TupleView } from "./TupleView";
 export { default as UnsupportedView } from "./UnsupportedView";
+export { default as LazyFieldView } from "./LazyFieldView";

--- a/app/packages/operators/src/types.ts
+++ b/app/packages/operators/src/types.ts
@@ -1084,6 +1084,49 @@ export class PromptView extends View {
 }
 
 /**
+ * Operator class for describing a FieldView {@link View} for an
+ * operator type.
+ */
+export class FieldView extends View {
+  constructor(options: ViewProps) {
+    super(options);
+    this.name = "FieldView";
+  }
+  static fromJSON(json) {
+    return new FieldView(json);
+  }
+}
+
+/**
+ * Operator class for describing a TextFieldView {@link View} for an
+ * operator type.
+ */
+export class TextFieldView extends View {
+  constructor(options: ViewProps) {
+    super(options);
+    this.name = "TextFieldView";
+  }
+  static fromJSON(json) {
+    return new TextFieldView(json);
+  }
+}
+
+/**
+ * Operator class for describing a LazyFieldView {@link View} for an
+ * operator type. When using LazyFieldView, only apply input field changes on
+ * blur or when user clicks the save button within the field.
+ */
+export class LazyFieldView extends View {
+  constructor(options: ViewProps) {
+    super(options);
+    this.name = "LazyFieldView";
+  }
+  static fromJSON(json) {
+    return new LazyFieldView(json);
+  }
+}
+
+/**
  * Places where you can have your operator placement rendered.
  */
 export enum Places {
@@ -1147,6 +1190,9 @@ const VIEWS = {
   ProgressView,
   MarkdownView,
   PromptView,
+  FieldView,
+  TextFieldView,
+  LazyFieldView,
 };
 
 export function typeFromJSON({ name, ...rest }): ANY_TYPE {

--- a/fiftyone/operators/types.py
+++ b/fiftyone/operators/types.py
@@ -1378,6 +1378,28 @@ class FieldView(View):
         super().__init__(**kwargs)
 
 
+class LazyFieldView(View):
+    """Displays a lazy text input which only apply input field changes on blur
+    or when user clicks the save button within the field.
+
+    .. note::
+
+        Must be used with :class:`String` or :class:`Number` properties.
+
+    Args:
+        save_on_blur (True): when set to False, changes in input field will not
+            be automatically applied when user moves mouse out of the changed
+            field. To apply changes, user must click the save button.
+    """
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.save_on_blur = kwargs.get("save_on_blur", True)
+
+    def to_json(self):
+        return {**super().to_json(), "save_on_blur": self.save_on_blur}
+
+
 class DropdownView(Dropdown):
     """Displays a dropdown selector input."""
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

Add a new LazyFieldView to OperatorIO which only applies changes in the input field when a save button within an input field is clicked or optionally (enabled by default) when you blur the input field. When a field is unsaved, reset button (to go back to the previously applied or initial state) and save button (to apply changes) will appear

Preview (unsaved state of a LazyFieldView):
![image](https://github.com/voxel51/fiftyone/assets/25350704/10615fa7-219e-412a-884e-6396f8d5efee)


Usage:

```
def resolve_input(self, ctx):
    inputs = types.Object()
    inputs.str("url", view=types.LazyFieldView(save_on_blur=False))
    return types.Property(inputs)
```

## How is this patch tested? If it is not, please explain why.

Using a test operator in the app

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

```
- Added a new :class:`LazyFieldView <fiftyone.operators.types.LazyFieldView>` type that extends capabilities of :class:`FieldView <fiftyone.operators.types.FieldView >` to allow applying user changes in an input field only with a click of a save button within an input field; or, optionally (enabled by default) with a input field blur event on an input field `#3728<https://github.com/voxel51/fiftyone/pull/3728>`_
```

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
