### PR TITLE
fix on_startup operators not executed

### DIFF
--- a/app/packages/operators/src/OperatorInvocationRequestExecutor.tsx
+++ b/app/packages/operators/src/OperatorInvocationRequestExecutor.tsx
@@ -3,21 +3,9 @@ import {
   useInvocationRequestExecutor,
   useInvocationRequestQueue,
 } from "./state";
-import { executeStartupOperators } from "./operators";
-
-let called = false;
-async function onMount() {
-  if (called) return;
-  called = true;
-  await executeStartupOperators();
-}
 
 export default function OperatorInvocationRequestExecutor() {
   const { requests, onSuccess, onError } = useInvocationRequestQueue();
-
-  useEffect(() => {
-    onMount();
-  }, [onMount]);
 
   return (
     <>

--- a/app/packages/operators/src/built-in-operators.ts
+++ b/app/packages/operators/src/built-in-operators.ts
@@ -15,6 +15,7 @@ import {
   Operator,
   OperatorConfig,
   executeOperator,
+  executeStartupOperators,
   listLocalAndRemoteOperators,
   loadOperatorsFromServer,
   registerOperator,
@@ -780,9 +781,15 @@ export function registerBuiltInOperators() {
   }
 }
 
+let startupOperatorsExecuted = false;
 export async function loadOperators(datasetName: string) {
   registerBuiltInOperators();
+  // todo: move to better spot
   await loadOperatorsFromServer(datasetName);
+  if (!startupOperatorsExecuted) {
+    executeStartupOperators();
+    startupOperatorsExecuted = true;
+  }
 }
 
 function getLayout(layout) {


### PR DESCRIPTION
## What changes are proposed in this pull request?

Fixes race condition where startup operator executing flow is triggered before loading operators from server and preventing them from executing on launch

## How is this patch tested? If it is not, please explain why.

Using an example operator with `on_startup` set to `True`

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

```
- Fixed on startup operators not getting executed `#3731 <https://github.com/voxel51/fiftyone/pull/3731>`_
```

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
