### PR TITLE
Remove max_depth constraint from plugin listing/caching

### DIFF
--- a/docs/source/cli/index.rst
+++ b/docs/source/cli/index.rst
@@ -1202,11 +1202,7 @@ formats:
 
 .. code-block:: text
 
-    fiftyone plugins download [-h]
-                              [-n [PLUGIN_NAMES ...]]
-                              [-d MAX_DEPTH]
-                              [-o]
-                              URL_OR_GH_REPO
+    fiftyone plugins download [-h] [-n [PLUGIN_NAMES ...]] [-o] URL_OR_GH_REPO
 
 **Arguments**
 
@@ -1219,8 +1215,6 @@ formats:
       -h, --help            show this help message and exit
       -n [PLUGIN_NAMES ...], --plugin-names [PLUGIN_NAMES ...]
                             a plugin name or list of plugin names to download
-      -d MAX_DEPTH, --max-depth MAX_DEPTH
-                            a maximum depth to search for plugins
       -o, --overwrite       whether to overwrite existing plugins
 
 **Examples**
@@ -1237,11 +1231,8 @@ formats:
 
 .. code-block:: shell
 
-    # Download specific plugins from a URL with a custom search depth
-    fiftyone plugins download \
-        <url> \
-        --plugin-names <name1> <name2> <name3> \
-        --max-depth 2  # search nested directories for plugins
+    # Download specific plugins from a URL
+    fiftyone plugins download <url> --plugin-names <name1> <name2> <name3>
 
 .. _cli-fiftyone-plugins-requirements:
 

--- a/fiftyone/core/cli.py
+++ b/fiftyone/core/cli.py
@@ -3249,11 +3249,8 @@ class PluginsDownloadCommand(Command):
         # Download plugins by specifying the GitHub repository details
         fiftyone plugins download <user>/<repo>[/<ref>]
 
-        # Download specific plugins from a URL with a custom search depth
-        fiftyone plugins download \\
-            <url> \\
-            --plugin-names <name1> <name2> <name3> \\
-            --max-depth 2  # search nested directories for plugins
+        # Download specific plugins from a URL
+        fiftyone plugins download <url> --plugin-names <name1> <name2> <name3>
     """
 
     @staticmethod
@@ -3272,14 +3269,6 @@ class PluginsDownloadCommand(Command):
             help="a plugin name or list of plugin names to download",
         )
         parser.add_argument(
-            "-d",
-            "--max-depth",
-            type=int,
-            default=3,
-            metavar="MAX_DEPTH",
-            help="a maximum depth to search for plugins",
-        )
-        parser.add_argument(
             "-o",
             "--overwrite",
             action="store_true",
@@ -3291,7 +3280,6 @@ class PluginsDownloadCommand(Command):
         fop.download_plugin(
             args.url_or_gh_repo,
             plugin_names=args.plugin_names,
-            max_depth=args.max_depth,
             overwrite=args.overwrite,
         )
 

--- a/fiftyone/operators/decorators.py
+++ b/fiftyone/operators/decorators.py
@@ -6,7 +6,6 @@ FiftyOne operator decorators.
 |
 """
 import asyncio
-import glob
 
 from cachetools.keys import hashkey
 from contextlib import contextmanager
@@ -15,6 +14,7 @@ import signal
 import os
 
 import fiftyone as fo
+from fiftyone.plugins.core import _iter_plugin_metadata_files
 
 
 def coroutine_timeout(seconds):
@@ -85,8 +85,12 @@ def plugins_cache(func):
 
 
 def dir_state(dirpath):
-    if not os.path.isdir(dirpath):
+    try:
+        state = hash(os.path.getmtime(dirpath))
+    except:
         return None
-    # we only need to check top level dir, which will update if any subdirs
-    # change and in the case that files are deleted
-    return os.path.getmtime(dirpath)
+
+    for p in _iter_plugin_metadata_files(root_dir=dirpath):
+        state ^= hash(os.path.getmtime(os.path.dirname(p)))
+
+    return state

--- a/fiftyone/operators/decorators.py
+++ b/fiftyone/operators/decorators.py
@@ -60,9 +60,8 @@ dir_cache = {"state": None}
 
 
 def plugins_cache(func):
-    """Decorator that returns cached function results as long as no
-    subdirectories of ``fo.config.plugins_dir`` have been modified since last
-    time.
+    """Decorator that returns cached function results as long as no plugins
+    have been modified since last time.
     """
 
     @wraps(func)


### PR DESCRIPTION
- update `@plugin_cache` so that it always changes whenever any addition/edit/removal of plugins occurs (including `touch PLUGINS_DIR`)
- remove `max_depth` flag from `download_plugin()`, for consistency with how `list_plugins()` searches infinitely deep, if necessary, to find plugins