### PR TITLE
Optimize use_view() usage

### DIFF
--- a/fiftyone/core/stages.py
+++ b/fiftyone/core/stages.py
@@ -7215,7 +7215,7 @@ class SortBySimilarity(ViewStage):
         results = sample_collection.load_brain_results(brain_key)
 
         with contextlib.ExitStack() as context:
-            if sample_collection != results.view:
+            if sample_collection.view() != results.view.view():
                 results.use_view(sample_collection)
                 context.enter_context(results)  # pylint: disable=no-member
 

--- a/fiftyone/server/routes/embeddings.py
+++ b/fiftyone/server/routes/embeddings.py
@@ -73,7 +73,8 @@ class OnPlotLoad(HTTPEndpoint):
 
         # Determines which points from `results` are in `view`, which are the
         # only points we want to display in the embeddings plot
-        results.use_view(view, allow_missing=True)
+        if view.view() != results.view.view():
+            results.use_view(view, allow_missing=True)
 
         # The total number of embeddings in `results`
         index_size = results.total_index_size
@@ -175,7 +176,7 @@ class EmbeddingsSelection(HTTPEndpoint):
             stages=stages,
             sample_filter=get_sample_filter(slices),
         )
-        if results.view != view:
+        if view.view() != results.view.view():
             results.use_view(view, allow_missing=True)
 
         patches_field = results.config.patches_field


### PR DESCRIPTION
Avoids unnecessary duplicate calls to `SimilarityIndex.use_view(view)` in situations where the index was created for `dataset` and the `view` being passed is the trivial view: `view = dataset.view()`.

This is a worthy optimization for large datasets because `use_view(view)` requires calling `view.values("id")` to retrieve the IDs from the view.

For example, previously `dataset.sort_by_similarity(...)` would unnecessarily call `SimilarityIndex.use_view(...)` when creating its `SortBySimilarity` stage, since the view stage is technically appended to `dataset.view()`, not directly to `dataset`.

Using `a.view() != b.view()` instead of `a != b` allows `dataset` to be "equal" to `dataset.view()`, which *is* an equality we want in this case because `dataset.view()` is guaranteed to contain every sample in the dataset.