### PR TITLE
Fix active field on view change

### DIFF
--- a/app/packages/state/src/recoil/schema.ts
+++ b/app/packages/state/src/recoil/schema.ts
@@ -433,7 +433,6 @@ export const _activeFields = (() => {
   try {
     data = JSON.parse(sessionStorage.getItem("activeFields"));
   } catch {}
-  console.log(data);
 
   let { activeFields: current, datasetId } = data || {};
   let modalCurrent: string[] = null;
@@ -452,7 +451,8 @@ export const _activeFields = (() => {
           dataset?.datasetId === undefined ||
           dataset?.datasetId !== datasetId
         ) {
-          datasetId = dataset.datasetId;
+          datasetId = dataset?.datasetId;
+          sessionStorage.removeItem("activeFields");
           modalCurrent = null;
           current = null;
         }

--- a/app/packages/state/src/recoil/schema.ts
+++ b/app/packages/state/src/recoil/schema.ts
@@ -441,7 +441,7 @@ export const _activeFields = (() => {
       keys: ["dataset"],
       default: null,
       read: (data, previous, { modal }) => {
-        if (data.id !== previous?.id) {
+        if (data?.datasetId !== previous?.datasetId) {
           modalCurrent = null;
           current = null;
         }


### PR DESCRIPTION
Fixes active (checked) fields in the sidebar on view change and persists the value to session storage



https://github.com/voxel51/fiftyone/assets/19821840/d4c46813-b19e-4038-b93f-62fc9e5f6a9b


