### PR TITLE
fix placements flash and remove duplicate resolve

### DIFF
--- a/app/packages/operators/src/OperatorCore.tsx
+++ b/app/packages/operators/src/OperatorCore.tsx
@@ -1,8 +1,11 @@
 import OperatorBrowser from "./OperatorBrowser";
 import OperatorInvocationRequestExecutor from "./OperatorInvocationRequestExecutor";
 import OperatorPrompt, { OperatorViewModal } from "./OperatorPrompt";
+import { useOperatorPlacementsResolver } from "./hooks";
 
 export default function OperatorCore() {
+  useOperatorPlacementsResolver();
+
   return (
     <>
       <OperatorBrowser />

--- a/app/packages/operators/src/hooks.ts
+++ b/app/packages/operators/src/hooks.ts
@@ -1,0 +1,38 @@
+import { useEffect, useRef, useState } from "react";
+import { useRecoilValue, useSetRecoilState } from "recoil";
+import { isEqual } from "lodash";
+import {
+  ExecutionContext,
+  fetchRemotePlacements,
+  resolveLocalPlacements,
+} from "./operators";
+import { operatorPlacementsAtom, operatorThrottledContext } from "./state";
+
+export function useOperatorPlacementsResolver() {
+  const context = useRecoilValue(operatorThrottledContext);
+  const setOperatorPlacementsAtom = useSetRecoilState(operatorPlacementsAtom);
+  const [resolving, setResolving] = useState(false);
+  const lastContext = useRef(null);
+
+  useEffect(() => {
+    async function updateOperatorPlacementsAtom() {
+      setResolving(true);
+      try {
+        const ctx = new ExecutionContext({}, context);
+        const remotePlacements = await fetchRemotePlacements(ctx);
+        const localPlacements = await resolveLocalPlacements(ctx);
+        const placements = [...remotePlacements, ...localPlacements];
+        setOperatorPlacementsAtom(placements);
+      } catch (error) {
+        console.error(error);
+      }
+      setResolving(false);
+    }
+    if (!isEqual(lastContext.current, context) && context?.datasetName) {
+      lastContext.current = context;
+      updateOperatorPlacementsAtom();
+    }
+  }, [context, setOperatorPlacementsAtom]);
+
+  return { resolving };
+}


### PR DESCRIPTION
## What changes are proposed in this pull request?

- Fix disappearance and re-appearance of placements when placements are re-resolved on context changes
- Fix multiple duplicate calls to resolve placements on the initial app load

## How is this patch tested? If it is not, please explain why.

Interactively within the app using an example operator and with network profiling

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

```
- Fixed disappearance and re-appearance of placements when placements are re-resolved on context changes `#3742 <https://github.com/voxel51/fiftyone/pull/3742 >`_
- Fixed multiple duplicate calls to resolve placements on the initial app load `#3742 <https://github.com/voxel51/fiftyone/pull/3742 >`_
```

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
