### PR TITLE
add back the selected labels to operator context

### DIFF
--- a/app/packages/operators/src/state.ts
+++ b/app/packages/operators/src/state.ts
@@ -83,8 +83,16 @@ const globalContextSelector = selector({
     const extended = get(fos.extendedStages);
     const filters = get(fos.filters);
     const selectedSamples = get(fos.selectedSamples);
+    const selectedLabels = get(fos.selectedLabels);
 
-    return { datasetName, view, extended, filters, selectedSamples };
+    return {
+      datasetName,
+      view,
+      extended,
+      filters,
+      selectedSamples,
+      selectedLabels,
+    };
   },
 });
 
@@ -635,7 +643,6 @@ export function useOperatorExecutor(uri, handlers: any = {}) {
   const [isDelegated, setIsDelegated] = useState(false);
 
   const [needsOutput, setNeedsOutput] = useState(false);
-  const selectedSamples = useRecoilValue(fos.selectedSamples);
   const ctx = useExecutionContext(uri);
   const hooks = operator.useHooks(ctx);
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

Fixes #3740 

## How is this patch tested? If it is not, please explain why.

Using a test operator with some labels selected in looker 

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

```
- Fixed selectedLabels is missing in operator context when resolve type is invoked`#3745 <https://github.com/voxel51/fiftyone/pull/3745>`_
```

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
