### PR TITLE
[Proposal] add browse operations button to sample modal

### DIFF
--- a/app/packages/core/src/components/Actions/ActionsRow.tsx
+++ b/app/packages/core/src/components/Actions/ActionsRow.tsx
@@ -553,6 +553,7 @@ export const ModalActionsRow = ({
       <Tag modal={true} lookerRef={lookerRef} />
       <Options modal={true} />
       {isGroup && <GroupMediaVisibilityContainer modal={true} />}
+      <BrowseOperations />
       <OperatorPlacements place={types.Places.SAMPLES_VIEWER_ACTIONS} />
       <ToggleSidebar modal={true} />
     </ActionsRowDiv>


### PR DESCRIPTION
## What changes are proposed in this pull request?

Add the browse operations button to the sample modal

## How is this patch tested? If it is not, please explain why.

Interactively within the app

Preview:
![image](https://github.com/voxel51/fiftyone/assets/25350704/c13e3527-dc47-4e1f-ac35-54a01cdd9d69)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

```
- Add the browse operations button to the sample modal `#3746 <https://github.com/voxel51/fiftyone/pull/3746>`_
```

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
