### PR TITLE
Expand only labels and tags sidebar groups by default

### DIFF
--- a/app/packages/state/src/recoil/sidebar.ts
+++ b/app/packages/state/src/recoil/sidebar.ts
@@ -761,13 +761,7 @@ export const groupShown = selectorFamily<
       const data = get(sidebarGroupMapping({ modal, loading }))[group];
 
       if ([null, undefined].includes(data.expanded)) {
-        if (["tags"].includes(group)) {
-          return null;
-        }
-        return (
-          !data.paths.length ||
-          !data.paths.every((path) => get(collapsedPaths).has(path))
-        );
+        return ["tags", "frame labels", "labels"].includes(group);
       }
 
       return data.expanded;


### PR DESCRIPTION
<img width="1470" alt="Screenshot 2023-10-31 at 2 27 04 PM" src="https://github.com/voxel51/fiftyone/assets/19821840/8242c7de-e959-4390-868b-d108c7debb95">
