### PR TITLE
fix sidebar re-arranging bug

### DIFF
--- a/app/packages/core/src/components/Sidebar/Sidebar.tsx
+++ b/app/packages/core/src/components/Sidebar/Sidebar.tsx
@@ -535,6 +535,10 @@ const InteractiveSidebar = ({
       entry.kind !== fos.EntryKind.INPUT
     );
 
+    if (after === undefined) {
+      return lastOrder.current;
+    }
+
     if (after === null) {
       return [
         ...section,


### PR DESCRIPTION
## What changes are proposed in this pull request?

fixed sidebar group re-arranging issue where sample tags jumps to the moving group when the moving group is taken above tags group

## How is this patch tested? If it is not, please explain why.

By attempting to drag any of the group in sidebar above the sticky tags group

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

```
- Fixed sample tags jumping to sidebar group being re-arranged issue `#3753 <https://github.com/voxel51/fiftyone/pull/3753>`_
```

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
