### PR TITLE
Ensure main looker is clicked in e2e test

### DIFF
--- a/e2e-pw/src/oss/specs/groups/sparse-groups-scenes.spec.ts
+++ b/e2e-pw/src/oss/specs/groups/sparse-groups-scenes.spec.ts
@@ -65,8 +65,8 @@ test(`ego default group slice transitions`, async ({ grid, modal }) => {
   await modal.clickOnLooker3d();
   await modal.sidebar.assert.verifySidebarEntryText("group.name", "ego");
   await modal.navigateNextSample(true);
-  await modal.sidebar.assert.verifySidebarEntryText("group.name", "ego");
   await modal.assert.verifyCarouselLength(1);
+  await modal.sidebar.assert.verifySidebarEntryText("group.name", "ego");
   await modal.groupLooker.click();
   await modal.sidebar.assert.verifySidebarEntryText("group.name", "right");
   await modal.navigateNextSample(true);

--- a/e2e-pw/src/oss/specs/groups/sparse-groups-scenes.spec.ts
+++ b/e2e-pw/src/oss/specs/groups/sparse-groups-scenes.spec.ts
@@ -58,7 +58,7 @@ test(`ego default group slice transitions`, async ({ grid, modal }) => {
   await grid.openFirstSample();
   await modal.sidebar.toggleSidebarGroup("GROUP");
   await modal.sidebar.assert.verifySidebarEntryText("group.name", "ego");
-  await modal.clickOnLooker();
+  await modal.groupLooker.click();
   await modal.sidebar.assert.verifySidebarEntryText("group.name", "left");
   await modal.navigateSlice("group.name", "right", true);
   await modal.sidebar.assert.verifySidebarEntryText("group.name", "right");
@@ -66,9 +66,9 @@ test(`ego default group slice transitions`, async ({ grid, modal }) => {
   await modal.sidebar.assert.verifySidebarEntryText("group.name", "ego");
   await modal.navigateNextSample(true);
   await modal.sidebar.assert.verifySidebarEntryText("group.name", "ego");
-  await modal.clickOnLooker();
-  await modal.sidebar.assert.verifySidebarEntryText("group.name", "right");
   await modal.assert.verifyCarouselLength(1);
+  await modal.groupLooker.click();
+  await modal.sidebar.assert.verifySidebarEntryText("group.name", "right");
   await modal.navigateNextSample(true);
   await modal.sidebar.assert.verifySidebarEntryText("group.name", "left");
   await modal.assert.verifyCarouselLength(1);


### PR DESCRIPTION
Fix for unstable e2e test (example [action](https://github.com/voxel51/fiftyone/actions/runs/6721054954/job/18265921208))