### PR TITLE
Operator list is behind the modal

### DIFF
--- a/app/packages/core/src/components/ColorModal/ShareStyledDiv.ts
+++ b/app/packages/core/src/components/ColorModal/ShareStyledDiv.ts
@@ -6,7 +6,7 @@ export const ModalWrapper = styled.div`
   left: 0;
   width: 100%;
   height: 100%;
-  z-index: 100000000 !important;
+  z-index: 1000; // do not set more than 1300 (operator panel)
   align-items: center;
   display: flex;
   justify-content: center;

--- a/app/packages/core/src/components/Modal/Modal.tsx
+++ b/app/packages/core/src/components/Modal/Modal.tsx
@@ -27,7 +27,7 @@ const ModalWrapper = styled.div`
   left: 0;
   width: 100%;
   height: 100%;
-  z-index: 10000;
+  z-index: 1000; // do not set more than 1300 (operator panel)
   align-items: center;
   display: flex;
   justify-content: center;


### PR DESCRIPTION
## What changes are proposed in this pull request?

fix the zIndex conflict between modals. 

Operator List modal uses a z-index of 1300. I set the sample modal and color modal between 1300 to fix the problem. 

## How is this patch tested? If it is not, please explain why.
![Screenshot 2023-11-01 at 3 52 58 PM](https://github.com/voxel51/fiftyone/assets/17770824/bcc49556-3b0b-4583-9596-fdf46c4f7e6c)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
