### PR TITLE
Plugin secrets available in resolve_input

### DIFF
--- a/fiftyone/operators/executor.py
+++ b/fiftyone/operators/executor.py
@@ -225,14 +225,14 @@ async def prepare_operator_executor(operator_uri, request_params):
     operator = registry.get_operator(operator_uri)
     executor = Executor()
     ctx = ExecutionContext(request_params, executor)
+
+    await ctx.resolve_secret_values(operator._plugin_secrets)
     inputs = operator.resolve_input(ctx)
     validation_ctx = ValidationContext(ctx, inputs, operator)
     if validation_ctx.invalid:
         return ExecutionResult(
             error="Validation error", validation_ctx=validation_ctx
         )
-
-    await ctx.resolve_secret_values(operator._plugin_secrets)
 
     return operator, executor, ctx
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

Secrets should be available via `ctx.secrets` when `resolve_input` is called.