### PR TITLE
Sample and Frame created_at field

### DIFF
--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -2021,6 +2021,10 @@ class SampleCollection(object):
                 self, _sample_ids, values
             )
 
+        _field = self.get_field(field_name)
+        if _field is not None and _field.readonly:
+            raise ValueError(f"Readonly field '{field_name}' cannot be edited")
+
         if expand_schema:
             field, new_group_field = self._expand_schema_from_values(
                 field_name,

--- a/fiftyone/core/document.py
+++ b/fiftyone/core/document.py
@@ -452,7 +452,7 @@ class _Document(object):
             fields = {
                 f: f
                 for f in self.field_names
-                if f not in ("id", "_dataset_id")
+                if f not in ("id", "_dataset_id", "created_at")
             }
         elif etau.is_str(fields):
             fields = {fields: fields}

--- a/fiftyone/core/fields.py
+++ b/fiftyone/core/fields.py
@@ -266,10 +266,11 @@ class Field(mongoengine.fields.BaseField):
         info (None): an optional info dict
     """
 
-    def __init__(self, description=None, info=None, **kwargs):
+    def __init__(self, description=None, info=None, readonly=False, **kwargs):
         super().__init__(**kwargs)
         self._description = description
         self._info = info
+        self._readonly = readonly
 
         self.__dataset = None
         self.__path = None
@@ -362,6 +363,11 @@ class Field(mongoengine.fields.BaseField):
     @info.setter
     def info(self, info):
         self._info = info
+
+    @property
+    def readonly(self):
+        """If this property should be considered readonly after setting"""
+        return self._readonly
 
     def copy(self):
         """Returns a copy of the field.

--- a/fiftyone/core/frame.py
+++ b/fiftyone/core/frame.py
@@ -1139,6 +1139,10 @@ class FrameView(DocumentView):
 
     @property
     def created_at(self):
+        """Creation time of the frame, or ``None`` if unknown.
+
+        Frames only get a creation time when they're in a sample in a dataset.
+        """
         return self._doc.created_at
 
     @property

--- a/fiftyone/core/frame.py
+++ b/fiftyone/core/frame.py
@@ -5,6 +5,7 @@ Video frames.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+import datetime
 import itertools
 
 from bson import ObjectId
@@ -651,6 +652,7 @@ class Frames(object):
 
         d["_sample_id"] = self._sample_id
         d["_dataset_id"] = self._dataset._doc.id
+        d["created_at"] = datetime.datetime.utcnow()
 
         return d
 
@@ -1132,6 +1134,10 @@ class FrameView(DocumentView):
     """
 
     _DOCUMENT_CLS = Frame
+
+    @property
+    def created_at(self):
+        return self._doc.created_at
 
     @property
     def dataset_id(self):

--- a/fiftyone/core/frame.py
+++ b/fiftyone/core/frame.py
@@ -296,6 +296,8 @@ class Frames(object):
             doc = self._dataset._frame_dict_to_doc(d)
 
             for field, value in _frame.iter_fields():
+                if field in {"created_at"}:
+                    continue
                 doc.set_field(
                     field,
                     value,

--- a/fiftyone/core/odm/document.py
+++ b/fiftyone/core/odm/document.py
@@ -342,10 +342,18 @@ class MongoEngineBaseDocument(SerializableDocument):
             doc = self.get_field(chunks[0])
             return doc.set_field(chunks[1], value, create=create)
 
-        if not create and not self.has_field(field_name):
-            raise ValueError(
-                "%s has no field '%s'" % (self.__class__.__name__, field_name)
-            )
+        try:
+            field = self._get_field(field_name)
+            if field.readonly:
+                raise ValueError(
+                    f"Readonly field '{field_name}' cannot be edited"
+                )
+        except (KeyError, AttributeError):
+            if not create:
+                raise ValueError(
+                    "%s has no field '%s'"
+                    % (self.__class__.__name__, field_name)
+                )
 
         setattr(self, field_name, value)
 

--- a/fiftyone/core/odm/frame.py
+++ b/fiftyone/core/odm/frame.py
@@ -7,8 +7,6 @@ Backing document classes for :class:`fiftyone.core.frame.Frame` instances.
 """
 from collections import OrderedDict
 
-from bson import ObjectId
-
 import fiftyone.core.fields as fof
 
 from .document import Document, SerializableDocument
@@ -16,20 +14,19 @@ from .mixins import DatasetMixin, get_default_fields, NoDatasetMixin
 
 
 class DatasetFrameDocument(DatasetMixin, Document):
-
     meta = {"abstract": True}
 
     _is_frames_doc = True
 
     id = fof.ObjectIdField(required=True, primary_key=True, db_field="_id")
     frame_number = fof.FrameNumberField(required=True)
+    created_at = fof.DateTimeField(null=True)
 
     _sample_id = fof.ObjectIdField(required=True)
     _dataset_id = fof.ObjectIdField()
 
 
 class NoDatasetFrameDocument(NoDatasetMixin, SerializableDocument):
-
     _is_frames_doc = True
 
     # pylint: disable=no-member
@@ -47,6 +44,7 @@ class NoDatasetFrameDocument(NoDatasetMixin, SerializableDocument):
             [
                 ("id", None),
                 ("frame_number", None),
+                ("created_at", None),
                 ("_sample_id", sample_id),
                 ("_dataset_id", None),
             ]

--- a/fiftyone/core/odm/frame.py
+++ b/fiftyone/core/odm/frame.py
@@ -20,7 +20,7 @@ class DatasetFrameDocument(DatasetMixin, Document):
 
     id = fof.ObjectIdField(required=True, primary_key=True, db_field="_id")
     frame_number = fof.FrameNumberField(required=True)
-    created_at = fof.DateTimeField(null=True)
+    created_at = fof.DateTimeField(null=True, readonly=True)
 
     _sample_id = fof.ObjectIdField(required=True)
     _dataset_id = fof.ObjectIdField()

--- a/fiftyone/core/odm/mixins.py
+++ b/fiftyone/core/odm/mixins.py
@@ -136,9 +136,14 @@ class DatasetMixin(object):
                 raise ValueError(
                     "%s has no field '%s'" % (self._doc_name(), field_name)
                 )
-        elif value is not None:
+        else:
+            field = self._fields[field_name]
+            if field.readonly:
+                raise ValueError(
+                    f"Readonly field '{field_name}' cannot be edited"
+                )
             if validate:
-                self._fields[field_name].validate(value)
+                field.validate(value)
 
             if dynamic:
                 self.add_implied_field(
@@ -594,6 +599,9 @@ class DatasetMixin(object):
                 raise AttributeError(
                     "%s field '%s' does not exist" % (cls._doc_name(), path)
                 )
+
+            if field is not None and field.readonly:
+                raise ValueError(f"Readonly field '{path}' cannot be cleared")
 
             if is_dataset and is_root_field:
                 simple_paths.append(path)
@@ -1257,6 +1265,7 @@ class DatasetMixin(object):
             prev._set_dataset(None, None)
             field.required = prev.required
             field.null = prev.null
+            field._readonly = prev.readonly
 
         field._set_dataset(dataset, path)
         cls._fields[field_name] = field

--- a/fiftyone/core/odm/mixins.py
+++ b/fiftyone/core/odm/mixins.py
@@ -1630,7 +1630,7 @@ class NoDatasetMixin(object):
 
             if k == "_id":
                 k = "id"
-            elif k == "_dataset_id":
+            elif k in {"_dataset_id", "created_at"}:
                 continue
             elif isinstance(v, ObjectId) and k.startswith("_"):
                 k = k[1:]

--- a/fiftyone/core/odm/sample.py
+++ b/fiftyone/core/odm/sample.py
@@ -85,7 +85,7 @@ class DatasetSampleDocument(DatasetMixin, Document):
     filepath = fof.StringField(required=True)
     tags = fof.ListField(fof.StringField())
     metadata = fof.EmbeddedDocumentField(fom.Metadata, null=True)
-    created_at = fof.DateTimeField(null=True)
+    created_at = fof.DateTimeField(null=True, readonly=True)
 
     _media_type = fof.StringField()
     _rand = fof.FloatField(default=_generate_rand)

--- a/fiftyone/core/odm/sample.py
+++ b/fiftyone/core/odm/sample.py
@@ -85,6 +85,7 @@ class DatasetSampleDocument(DatasetMixin, Document):
     filepath = fof.StringField(required=True)
     tags = fof.ListField(fof.StringField())
     metadata = fof.EmbeddedDocumentField(fom.Metadata, null=True)
+    created_at = fof.DateTimeField(null=True)
 
     _media_type = fof.StringField()
     _rand = fof.FloatField(default=_generate_rand)
@@ -118,13 +119,18 @@ class NoDatasetSampleDocument(NoDatasetMixin, SerializableDocument):
         kwargs["_rand"] = _generate_rand(filepath=filepath)
         kwargs["_media_type"] = fomm.get_media_type(filepath)
         kwargs["_dataset_id"] = None
+        kwargs["created_at"] = None
 
         self._data = OrderedDict()
 
         for field_name in self.default_fields_ordered:
             value = kwargs.pop(field_name, None)
 
-            if value is None and field_name not in ("id", "_dataset_id"):
+            if value is None and field_name not in {
+                "id",
+                "_dataset_id",
+                "created_at",
+            }:
                 value = self._get_default(self.default_fields[field_name])
 
             self._data[field_name] = value

--- a/fiftyone/core/sample.py
+++ b/fiftyone/core/sample.py
@@ -50,6 +50,9 @@ class _SampleMixin(object):
             self.set_field("frames", value)
             return
 
+        # if name == "created_at":
+        #    raise AttributeError("can't set attribute 'created_at'")
+
         self._secure_media(name, value)
         super().__setattr__(name, value)
 
@@ -72,6 +75,15 @@ class _SampleMixin(object):
             return iter(self._frames)
 
         raise ValueError("Image samples are not iterable")
+
+    @property
+    def created_at(self):
+        """Creation time of the sample, or ``None`` if unknown.
+
+        Samples only get a creation
+
+        """
+        return self._doc.created_at
 
     @property
     def dataset_id(self):
@@ -606,6 +618,7 @@ class Sample(_SampleMixin, Document, metaclass=SampleSingleton):
             a :class:`Sample`
         """
         d.pop("_dataset_id", None)
+        d.pop("created_at", None)
 
         media_type = d.pop("_media_type", None)
         if media_type is None:

--- a/fiftyone/core/sample.py
+++ b/fiftyone/core/sample.py
@@ -50,9 +50,6 @@ class _SampleMixin(object):
             self.set_field("frames", value)
             return
 
-        # if name == "created_at":
-        #    raise AttributeError("can't set attribute 'created_at'")
-
         self._secure_media(name, value)
         super().__setattr__(name, value)
 
@@ -80,8 +77,7 @@ class _SampleMixin(object):
     def created_at(self):
         """Creation time of the sample, or ``None`` if unknown.
 
-        Samples only get a creation
-
+        Samples only get a creation time when they're added to a dataset.
         """
         return self._doc.created_at
 

--- a/fiftyone/core/stages.py
+++ b/fiftyone/core/stages.py
@@ -4288,6 +4288,14 @@ class SetField(ViewStage):
         if not self._allow_missing:
             sample_collection.validate_fields_exist(self._field)
 
+        # Check readonly Field
+        _field = sample_collection.get_field(self._field)
+
+        if _field and getattr(_field, "readonly", False):
+            raise ValueError(
+                f"Readonly field '{self._field}' cannot be edited"
+            )
+
         pipeline, expr_dict = sample_collection._make_set_field_pipeline(
             self._field,
             self._expr,

--- a/fiftyone/core/video.py
+++ b/fiftyone/core/video.py
@@ -5,6 +5,7 @@ Video frame views.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+import datetime
 from collections import defaultdict
 from copy import deepcopy
 import logging
@@ -691,12 +692,17 @@ def make_frames_dataset(
 
     pipeline.extend(
         [
-            {"$addFields": {"_dataset_id": dataset._doc.id}},
+            {
+                "$addFields": {
+                    "_dataset_id": dataset._doc.id,
+                    "created_at": datetime.datetime.utcnow(),
+                }
+            },
             {
                 "$merge": {
                     "into": dataset._sample_collection_name,
                     "on": ["_sample_id", "frame_number"],
-                    "whenMatched": "merge",
+                    "whenMatched": "merge",  # TODO STW what do when existing is merge with created_at
                     "whenNotMatched": "discard",
                 }
             },
@@ -870,6 +876,7 @@ def _init_frames(
             missing_docs = None
             missing_fps = None
 
+        now = datetime.datetime.utcnow()
         # Create necessary frame documents
         for fn in doc_frame_numbers:
             if is_clips:
@@ -899,6 +906,7 @@ def _init_frames(
                 "tags": tags,
                 "metadata": None,
                 "frame_number": fn,
+                "created_at": now,
                 "_media_type": "image",
                 "_rand": _rand,
                 "_sample_id": _sample_id,

--- a/fiftyone/utils/data/importers.py
+++ b/fiftyone/utils/data/importers.py
@@ -5,6 +5,7 @@ Dataset importers.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+import datetime
 import inspect
 import itertools
 import logging
@@ -1844,6 +1845,7 @@ class FiftyOneDatasetImporter(BatchDatasetImporter):
 
         media_fields = self._media_fields
         dataset_id = dataset._doc.id
+        now = datetime.datetime.utcnow()
 
         def _parse_sample(sd):
             if not os.path.isabs(sd["filepath"]):
@@ -1856,6 +1858,7 @@ class FiftyOneDatasetImporter(BatchDatasetImporter):
                 _parse_media_fields(sd, media_fields, rel_dir)
 
             sd["_dataset_id"] = dataset_id
+            sd["created_at"] = now
             return sd
 
         sample_ids = foo.insert_documents(
@@ -1884,6 +1887,7 @@ class FiftyOneDatasetImporter(BatchDatasetImporter):
 
             def _parse_frame(fd):
                 fd["_dataset_id"] = dataset_id
+                fd["created_at"] = now
                 return fd
 
             foo.insert_documents(


### PR DESCRIPTION
## What changes are proposed in this pull request?

Add `created_at` field to all samples and frames. It's set to now when added to the dataset, and reset back to `None` if removed from the dataset.
We could set `created_at` if the sample gets created outside of the dataset first, but it's slightly easier to do it this way and there's not likely to be a meaningful distinction between when a sample was created and when added to dataset.

Locations to add `created_at` were identified using as a template [adding dataset id to sample and frames docs](https://github.com/voxel51/fiftyone/pull/2711) 

### Notes
- Samples get a creation time only when they're added to a dataset.
- Followup PR will be sample/dataset `last_updated_at`
- Merge for existing samples was a little tricky but if we first `addField` but then add it to `delete_fields` when we create the `whenMatched` pipeline, we'll make sure that it will be added on insert but ignored on merge.
- Not sure what happens with generated datasets, or if it even matters. But I'll check on that.
- Writes to this field through `set_field`, `__setattr__`, `set_values()`, `clear_sample_field`, etc., are prohibited.
   -  I attempted to achieve this by creating a `readonly` flag for the `Field`, akin to the `is_virtual` property in [virtual fields PR](https://github.com/voxel51/fiftyone/pull/2429).

## How is this patch tested? If it is not, please explain why.

- Added tests for each case in both image and video, and ran manually. Created_at is set on creation but not again. Distinct cases below:
   - `add_samples()`
   - `clone()`
   - `add_collection(new_ids=True)`
   - `merge_samples()  # both existing and new samples`
   - `fo.Dataset.from_dir()`
- Also then tested that any manner of modifying the field throws an error.
- If you want to test manually, following along with the test cases is best rather than pasting full here.

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

Add `created_at` default `DateTimeField` to samples and frames, which contains the time the sample was added to the dataset.

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
