### PR TITLE
Move Snackbar to @fiftyone/core

### DIFF
--- a/app/packages/app/src/pages/IndexPage.tsx
+++ b/app/packages/app/src/pages/IndexPage.tsx
@@ -1,4 +1,5 @@
 import { Loading } from "@fiftyone/components";
+import { Snackbar } from "@fiftyone/core";
 import React from "react";
 import { usePreloadedQuery } from "react-relay";
 import { graphql } from "relay-runtime";
@@ -30,6 +31,7 @@ const IndexPage: Route<IndexPageQuery> = ({ prepared }) => {
       <div className={style.page} data-cy="no-dataset">
         <Loading>No dataset selected</Loading>
       </div>
+      <Snackbar />
     </>
   );
 };

--- a/app/packages/app/src/pages/datasets/DatasetPage.tsx
+++ b/app/packages/app/src/pages/datasets/DatasetPage.tsx
@@ -8,10 +8,9 @@ import * as fos from "@fiftyone/state";
 import { datasetQueryContext } from "@fiftyone/state";
 import { NotFoundError } from "@fiftyone/utilities";
 import { Snackbar } from "@material-ui/core";
-import MuiAlert, { AlertProps } from "@mui/material/Alert";
 import React, { useEffect } from "react";
 import { usePreloadedQuery } from "react-relay";
-import { useRecoilState, useRecoilValue } from "recoil";
+import { useRecoilValue } from "recoil";
 import { graphql } from "relay-runtime";
 import Nav from "../../components/Nav";
 import { Route } from "../../routing";
@@ -67,19 +66,9 @@ const DatasetPageQueryNode = graphql`
   }
 `;
 
-const Alert = React.forwardRef<HTMLDivElement, AlertProps>(function Alert(
-  props,
-  ref
-) {
-  return <MuiAlert elevation={6} ref={ref} variant="filled" {...props} />;
-});
-
-const SNACK_VISIBLE_DURATION = 5000;
-
 const DatasetPage: Route<DatasetPageQuery> = ({ prepared }) => {
   const data = usePreloadedQuery(DatasetPageQueryNode, prepared);
   const isModalActive = Boolean(useRecoilValue(fos.isModalActive));
-  const [snackErrors, setSnackErrors] = useRecoilState(fos.snackbarErrors);
 
   useEffect(() => {
     document
@@ -100,23 +89,7 @@ const DatasetPage: Route<DatasetPageQuery> = ({ prepared }) => {
           <Dataset />
         </datasetQueryContext.Provider>
       </div>
-      <Snackbar
-        open={!!snackErrors.length}
-        autoHideDuration={SNACK_VISIBLE_DURATION}
-        onClose={() => {
-          setSnackErrors([]);
-        }}
-      >
-        <Alert
-          onClose={() => {
-            setSnackErrors([]);
-          }}
-          severity="error"
-          sx={{ width: "100%" }}
-        >
-          {snackErrors}
-        </Alert>
-      </Snackbar>
+      <Snackbar />
     </>
   );
 };

--- a/app/packages/app/src/pages/datasets/DatasetPage.tsx
+++ b/app/packages/app/src/pages/datasets/DatasetPage.tsx
@@ -1,4 +1,4 @@
-import { Dataset } from "@fiftyone/core";
+import { Dataset, Snackbar } from "@fiftyone/core";
 import "@fiftyone/embeddings";
 import "@fiftyone/looker-3d";
 import "@fiftyone/map";
@@ -7,7 +7,6 @@ import "@fiftyone/relay";
 import * as fos from "@fiftyone/state";
 import { datasetQueryContext } from "@fiftyone/state";
 import { NotFoundError } from "@fiftyone/utilities";
-import { Snackbar } from "@material-ui/core";
 import React, { useEffect } from "react";
 import { usePreloadedQuery } from "react-relay";
 import { useRecoilValue } from "recoil";

--- a/app/packages/core/src/components/Snackbar.tsx
+++ b/app/packages/core/src/components/Snackbar.tsx
@@ -1,0 +1,37 @@
+import * as fos from "@fiftyone/state";
+import { Snackbar as SnackbarMui } from "@material-ui/core";
+import MuiAlert, { AlertProps } from "@mui/material/Alert";
+import React from "react";
+import { useRecoilState } from "recoil";
+
+const Alert = React.forwardRef<HTMLDivElement, AlertProps>(function Alert(
+  props,
+  ref
+) {
+  return <MuiAlert elevation={6} ref={ref} variant="filled" {...props} />;
+});
+
+const SNACK_VISIBLE_DURATION = 5000;
+
+export default function Snackbar() {
+  const [snackErrors, setSnackErrors] = useRecoilState(fos.snackbarErrors);
+  return (
+    <SnackbarMui
+      open={!!snackErrors.length}
+      autoHideDuration={SNACK_VISIBLE_DURATION}
+      onClose={() => {
+        setSnackErrors([]);
+      }}
+    >
+      <Alert
+        onClose={() => {
+          setSnackErrors([]);
+        }}
+        severity="error"
+        sx={{ width: "100%" }}
+      >
+        {snackErrors}
+      </Alert>
+    </SnackbarMui>
+  );
+}

--- a/app/packages/core/src/components/index.ts
+++ b/app/packages/core/src/components/index.ts
@@ -6,4 +6,5 @@ export { default as FieldLabelAndInfo } from "./FieldLabelAndInfo";
 export { default as Loading } from "./Loading";
 export { default as ResourceCount } from "./ResourceCount";
 export * from "./Sidebar";
+export { default as Snackbar } from "./Snackbar";
 export { default as ViewBar, rollbackViewBar } from "./ViewBar/ViewBar";


### PR DESCRIPTION
Moves the new Snackbar component from #3613 to `@fiftyone/core` for reusability and adds the component to the `IndexPage`


https://github.com/voxel51/fiftyone/assets/19821840/ae6b8605-155f-4f49-937c-5bb6a33405ab

