### PR TITLE
[HOLD] Add support for datasetless operator

### DIFF
--- a/app/packages/operators/src/built-in-operators.ts
+++ b/app/packages/operators/src/built-in-operators.ts
@@ -562,6 +562,7 @@ class ConsoleLog extends Operator {
       name: "console_log",
       label: "Console Log",
       unlisted: true,
+      datasetless: true,
     });
   }
   async resolveInput(ctx: ExecutionContext): Promise<types.Property> {
@@ -584,6 +585,7 @@ class ShowOutput extends Operator {
       name: "show_output",
       label: "Show Output",
       unlisted: true,
+      datasetless: true,
     });
   }
   async resolveInput(ctx: ExecutionContext): Promise<types.Property> {
@@ -619,6 +621,7 @@ class SetProgress extends Operator {
       name: "set_progress",
       label: "Set Progress",
       unlisted: true,
+      datasetless: true,
     });
   }
   async resolveInput(ctx: ExecutionContext): Promise<types.Property> {
@@ -661,6 +664,7 @@ class TestOperator extends Operator {
       name: "test_operator",
       label: "Test an Operator",
       dynamic: true,
+      datasetless: true,
     });
   }
   parseParams(rawParams: string) {

--- a/app/packages/operators/src/operators.ts
+++ b/app/packages/operators/src/operators.ts
@@ -114,6 +114,7 @@ export type OperatorConfigOptions = {
   icon?: string;
   darkIcon?: string;
   lightIcon?: string;
+  datasetless?: boolean;
 };
 export class OperatorConfig {
   public name: string;
@@ -128,6 +129,7 @@ export class OperatorConfig {
   public icon = null;
   public darkIcon = null;
   public lightIcon = null;
+  public datasetless = false;
   constructor(options: OperatorConfigOptions) {
     this.name = options.name;
     this.label = options.label || options.name;
@@ -142,6 +144,7 @@ export class OperatorConfig {
     this.icon = options.icon;
     this.darkIcon = options.darkIcon;
     this.lightIcon = options.lightIcon;
+    this.datasetless = options.datasetless;
   }
   static fromJSON(json) {
     return new OperatorConfig({
@@ -157,6 +160,7 @@ export class OperatorConfig {
       icon: json.icon,
       darkIcon: json.dark_icon,
       lightIcon: json.light_icon,
+      datasetless: json.datasetless,
     });
   }
 }

--- a/app/packages/operators/src/state.ts
+++ b/app/packages/operators/src/state.ts
@@ -411,6 +411,7 @@ export const availableOperators = selector({
         icon: operator.config.icon,
         darkIcon: operator.config.darkIcon,
         lightIcon: operator.config.lightIcon,
+        datasetless: operator.config.datasetless,
       };
     });
   },
@@ -425,7 +426,7 @@ export const operatorBrowserQueryState = atom({
   default: "",
 });
 
-function sortResults(results, recentlyUsedOperators) {
+function sortResults(results, recentlyUsedOperators, datasetless) {
   return results
     .map((result) => {
       let score = (result.description || result.label).charCodeAt(0);
@@ -433,7 +434,7 @@ function sortResults(results, recentlyUsedOperators) {
         const recentIdx = recentlyUsedOperators.indexOf(result.label);
         score = recentIdx * -1;
       }
-      if (result.canExecute === false) {
+      if (result.canExecute === false || (datasetless && !result.datasetless)) {
         score += results.length;
       }
       return {
@@ -457,12 +458,14 @@ export const operatorBrowserChoices = selector({
   get: ({ get }) => {
     const allChoices = get(availableOperators);
     const query = get(operatorBrowserQueryState);
+    const datasetName = get(fos.datasetName);
+    const datasetless = datasetName === null;
     let results = [...allChoices];
     results = results.filter(({ unlisted }) => !unlisted);
     if (query && query.length > 0) {
       results = filterChoicesByQuery(query, results);
     }
-    return sortResults(results, get(recentlyUsedOperatorsState));
+    return sortResults(results, get(recentlyUsedOperatorsState), datasetless);
   },
 });
 export const operatorDefaultChoice = selector({

--- a/fiftyone/operators/builtin.py
+++ b/fiftyone/operators/builtin.py
@@ -275,6 +275,7 @@ class PrintStdout(foo.Operator):
             name="print_stdout",
             label="Print to stdout",
             unlisted=True,
+            datasetless=True,
         )
 
     def resolve_input(self, ctx):
@@ -294,6 +295,7 @@ class ListFiles(foo.Operator):
             name="list_files",
             label="List Files",
             unlisted=True,
+            datasetless=True,
         )
 
     def execute(self, ctx):

--- a/fiftyone/operators/operator.py
+++ b/fiftyone/operators/operator.py
@@ -32,6 +32,7 @@ class OperatorConfig(object):
             when app is in the light mode
         dark_icon (None): icon to show for the operator in the Operator Browser
             when app is in the dark mode
+        datasetless (False): whether the operator can be executed without dataset
     """
 
     def __init__(
@@ -48,6 +49,8 @@ class OperatorConfig(object):
         icon=None,
         light_icon=None,
         dark_icon=None,
+        datasetless=False,
+        **kwargs
     ):
         self.name = name
         self.label = label or name
@@ -61,6 +64,8 @@ class OperatorConfig(object):
         self.icon = icon
         self.dark_icon = dark_icon
         self.light_icon = light_icon
+        self.datasetless = datasetless
+        self._kwargs = kwargs
 
     def to_json(self):
         return {
@@ -76,6 +81,8 @@ class OperatorConfig(object):
             "icon": self.icon,
             "dark_icon": self.dark_icon,
             "light_icon": self.light_icon,
+            "datasetless": self.datasetless,
+            **self._kwargs,
         }
 
 


### PR DESCRIPTION
**Todo: add execution time protection to prevent execution**

## What changes are proposed in this pull request?

(Please fill in changes proposed in this fix)

## How is this patch tested? If it is not, please explain why.

(Details)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
