### PR TITLE
Add Debian 12 fiftyone-db support and permit failed Linux downloads

### DIFF
--- a/package/db/setup.py
+++ b/package/db/setup.py
@@ -36,6 +36,10 @@ LINUX_DOWNLOADS = {
         "11": {
             "x86_64": "https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-debian11-5.0.4.tgz"
         },
+        "12": {
+            "aarch64": "https://fastdl.mongodb.org/linux/mongodb-linux-aarch64-ubuntu2204-6.0.5.tgz",
+            "x86_64": "https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-ubuntu2204-6.0.5.tgz",
+        },
     },
     "rhel": {
         "7": {

--- a/package/db/setup.py
+++ b/package/db/setup.py
@@ -108,7 +108,7 @@ def _get_download():
 # mongodb binaries to distribute
 MONGODB_BINARIES = ["mongod"]
 
-VERSION = "0.4.1"
+VERSION = "0.4.2"
 
 
 def get_version():

--- a/package/db/setup.py
+++ b/package/db/setup.py
@@ -179,21 +179,15 @@ class CustomBdistWheel(bdist_wheel):
                     mongo_zip_dest, "wb"
                 ) as dest:
                     shutil.copyfileobj(conn, dest)
+
         except:
-            json_dest = os.path.join(
-                os.path.dirname(os.path.abspath(__file__)),
-                "download.json",
+            exc_dest = os.path.join(
+                bin_dir,
+                "exception.txt",
             )
-            with open(json_dest, "w", encoding="utf-8") as f:
-                json.dump(
-                    {
-                        "url": mongo_zip_url,
-                        "exception": traceback.format_exc(),
-                    },
-                    f,
-                    ensure_ascii=False,
-                    indent=4,
-                )
+            with open(exc_dest, "w", encoding="utf-8") as f:
+                f.write(traceback.format_exc())
+            return
 
         if mongo_zip_dest.endswith(".zip"):
             # Windows


### PR DESCRIPTION
MongoDB does not explicitly offer a Debian 12 download, but it has been noted that Ubuntu 22.04 downloads can be used. 0.4.2 adds Debian 12 support via Ubuntu 22.04 downloads

0.4.3 fixes Debian 11 URLs and allows building a Linux wheel even when the MongoDB download fails which permits database URI only connections


0.4.1 and 0.4.2 will be yanked after publishing 0.4.3