### PR TITLE
prevent re-applying default in OperatorIO

### DIFF
--- a/app/packages/core/src/plugins/SchemaIO/components/DynamicIO.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/DynamicIO.tsx
@@ -1,14 +1,16 @@
 import { PluginComponentType, useActivePlugins } from "@fiftyone/plugins";
 import React, { useEffect } from "react";
 import { getComponent, getErrorsForView } from "../utils";
+import { isNullish } from "@fiftyone/utilities";
 
 export default function DynamicIO(props) {
-  const { schema, onChange, path } = props;
+  const { data, schema, onChange, path } = props;
   const customComponents = useCustomComponents();
   const Component = getComponent(schema, customComponents);
 
   // todo: need to improve initializing default value in state
   useEffect(() => {
+    if (!isNullish(data)) return;
     if (schema.default) onChange(path, schema.default);
     else if (schema.type === "boolean") onChange(path, false);
   }, []);

--- a/app/packages/operators/src/validation.ts
+++ b/app/packages/operators/src/validation.ts
@@ -1,4 +1,4 @@
-import { pluralize } from "@fiftyone/utilities";
+import { isNullish, pluralize } from "@fiftyone/utilities";
 import { Enum, List, Object, Boolean, String, Number } from "./types";
 
 export class ValidationError {
@@ -167,10 +167,6 @@ function existsOrNonRequired(property, value) {
 
 function getPath(prefix, path) {
   return prefix ? prefix + "." + path : path;
-}
-
-function isNullish(value) {
-  return value === undefined || value === null;
 }
 
 function isNumber(value) {

--- a/app/packages/utilities/src/type-check.ts
+++ b/app/packages/utilities/src/type-check.ts
@@ -1,3 +1,7 @@
 export function isPrimitiveString(value: unknown) {
   return typeof value === "string";
 }
+
+export function isNullish(value) {
+  return value === undefined || value === null;
+}


### PR DESCRIPTION
## What changes are proposed in this pull request?

Fixes an issue where default value of a param is re-applied in some cases for OperatorIO

## How is this patch tested? If it is not, please explain why.

Using a test operator

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

See above

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
