### PR TITLE
DB docs

### DIFF
--- a/docs/source/faq/index.rst
+++ b/docs/source/faq/index.rst
@@ -187,6 +187,15 @@ What operating systems does FiftyOne support?
 FiftyOne officially supports the latest versions of MacOS and Windows, as well
 as Debian 9+ (x86_64 only), Ubuntu 18.04+, and RHEL/CentOS 7+.
 
+.. note::
+
+    If installing on Ubuntu 22.04+, Debian, or RHEL/CentOS,
+    ``fiftyone-db==0.4.3`` must be requested.
+
+    .. code-block:: shell
+
+        pip install fiftyone-db==0.4.3 fiftyone
+
 .. _faq-image-types:
 
 What image file types are supported?

--- a/docs/source/getting_started/troubleshooting.rst
+++ b/docs/source/getting_started/troubleshooting.rst
@@ -209,7 +209,16 @@ Troubleshooting Linux imports
 
 `fiftyone-db` officially supports Debian 9+ (x86_64 only), Ubuntu 18.04+, and
 RHEL/CentOS 7+ Linux distributions. The correct MongoDB build is downloaded
-and installed while building the package wheel on your machine. 
+and installed while building the package wheel on your machine.
+
+.. note::
+
+    If installing on Ubuntu 22.04, Debian, or RHEL/CentOS,
+    ``fiftyone-db==0.4.3`` must be requested.
+
+    .. code-block:: shell
+
+        pip install fiftyone-db==0.4.3 fiftyone
 
 If a suitable MongoDB build is not available or otherwise does not
 work in your environment, you may encounter a `FiftyOneConfigError`.

--- a/docs/source/release-notes.rst
+++ b/docs/source/release-notes.rst
@@ -33,8 +33,6 @@ Core
 - Optimized
   :meth:`sort_by_similarity() <fiftyone.core.collections.SampleCollection.sort_by_similarity>`
   `#3733 <https://github.com/voxel51/fiftyone/pull/3733>`_
-- Fixed default ``fiftyone-db`` installs on Ubuntu 22.04, Debian, and RHEL
-  `#3675 <https://github.com/voxel51/fiftyone/pull/3675>`_
 
 App
 


### PR DESCRIPTION
`fiftyone-db>0.4` releases have been yanked due to existing installation issues. The next release of `FiftyOne` will fix `fiftyone-db` installs on Linux distributions by default. In the meantime, `pip install fiftyone-db==0.4.3 fiftyone` should be used to install on Ubuntu 22.04+, Debian, and RHEL/CentOS