### PR TITLE
loosen OperatorConfig constructor signature

### DIFF
--- a/fiftyone/operators/operator.py
+++ b/fiftyone/operators/operator.py
@@ -48,6 +48,7 @@ class OperatorConfig(object):
         icon=None,
         light_icon=None,
         dark_icon=None,
+        **kwargs
     ):
         self.name = name
         self.label = label or name
@@ -61,6 +62,7 @@ class OperatorConfig(object):
         self.icon = icon
         self.dark_icon = dark_icon
         self.light_icon = light_icon
+        self.kwargs = kwargs  # unused, placeholder for future extensibility
 
     def to_json(self):
         return {


### PR DESCRIPTION
## What changes are proposed in this pull request?

Loosen OperatorConfig constructor signature for future extensibility without the need to break backward compatibility

## How is this patch tested? If it is not, please explain why.

Using a test operator with an extra config kwarg

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
