### PR TITLE
Better App group slice persistence

### DIFF
--- a/app/packages/app/src/Sync.tsx
+++ b/app/packages/app/src/Sync.tsx
@@ -40,14 +40,12 @@ const Plugins = ({ children }: { children: React.ReactNode }) => {
 const Sync = ({ children }: { children?: React.ReactNode }) => {
   const environment = useRelayEnvironment();
   const subscription = useRecoilValue(stateSubscription);
-
   const router = useRouterContext();
-  const readyState = useEventSource(router);
-
   const sessionRef = useRef<Session>(SESSION_DEFAULT);
   const setters = useSetters(environment, router, sessionRef);
   useWriters(subscription, environment, router, sessionRef);
 
+  const readyState = useEventSource(router, sessionRef);
   useEffect(
     () =>
       subscribe((_, { reset }) => {

--- a/app/packages/app/src/routing/RouterContext.ts
+++ b/app/packages/app/src/routing/RouterContext.ts
@@ -114,7 +114,7 @@ export const createRouter = <T extends OperationType>(
     history,
 
     load(hard = false) {
-      const runUpdate = currentEntryResource && hard;
+      const runUpdate = !currentEntryResource || hard;
       if (!currentEntryResource || hard) {
         currentEntryResource = getEntryResource(
           environment,

--- a/app/packages/app/src/useEventSource.ts
+++ b/app/packages/app/src/useEventSource.ts
@@ -1,6 +1,6 @@
-import { stateSubscription, useClearModal } from "@fiftyone/state";
+import { Session, stateSubscription, useClearModal } from "@fiftyone/state";
 import { env, getEventSource } from "@fiftyone/utilities";
-import { useEffect, useMemo, useRef } from "react";
+import { MutableRefObject, useEffect, useMemo, useRef } from "react";
 import { useErrorHandler } from "react-error-boundary";
 import { useRecoilState, useRecoilValue } from "recoil";
 import { Queries } from "./makeRoutes";
@@ -9,16 +9,20 @@ import useEvents from "./useEvents";
 import { AppReadyState } from "./useEvents/registerEvent";
 import { appReadyState } from "./useEvents/utils";
 
-const useEventSource = (router: RoutingContext<Queries>) => {
+const useEventSource = (
+  router: RoutingContext<Queries>,
+  session: MutableRefObject<Session>
+) => {
   const [readyState, setReadyState] = useRecoilState(appReadyState);
   const readyStateRef = useRef<AppReadyState>(readyState);
   readyStateRef.current = readyState;
   const controller = useMemo(() => new AbortController(), []);
   const subscription = useRecoilValue(stateSubscription);
   const { subscriptions, handler } = useEvents(
-    router,
     controller,
-    readyStateRef
+    router,
+    readyStateRef,
+    session
   );
   const handleError = useErrorHandler();
   const clearModal = useClearModal();

--- a/app/packages/app/src/useEvents/index.ts
+++ b/app/packages/app/src/useEvents/index.ts
@@ -14,7 +14,7 @@ registerEvent("refresh", useRefresh);
 registerEvent("selectLabels", useSelectLabels);
 registerEvent("selectSamples", useSetSelectedSamples);
 registerEvent("setColorScheme", useSetColorScheme);
-registerEvent("sessionGroupSlice", useSetGroupSlice);
+registerEvent("setGroupSlice", useSetGroupSlice);
 registerEvent("setSpaces", useSetSpaces);
 registerEvent("stateUpdate", useStateUpdate);
 registerEvent("setFieldVisibilityStage", useSetFieldVisibilityStage);

--- a/app/packages/app/src/useEvents/registerEvent.ts
+++ b/app/packages/app/src/useEvents/registerEvent.ts
@@ -1,3 +1,4 @@
+import { Session } from "@fiftyone/state";
 import { snakeCase } from "lodash";
 import { MutableRefObject } from "react";
 import { Queries } from "../makeRoutes";
@@ -10,9 +11,10 @@ export enum AppReadyState {
 }
 
 type EventContext = {
-  router: RoutingContext<Queries>;
   controller: AbortController;
+  router: RoutingContext<Queries>;
   readyStateRef: MutableRefObject<AppReadyState>;
+  session: MutableRefObject<Session>;
 };
 
 export type EventHandlerHook = (ctx: EventContext) => (payload) => void;

--- a/app/packages/app/src/useEvents/useEvents.ts
+++ b/app/packages/app/src/useEvents/useEvents.ts
@@ -1,3 +1,4 @@
+import { Session } from "@fiftyone/state";
 import { snakeCase } from "lodash";
 import { MutableRefObject, useCallback, useMemo } from "react";
 import { Queries } from "../makeRoutes";
@@ -7,16 +8,17 @@ import { AppReadyState, EVENTS } from "./registerEvent";
 const HANDLERS = {};
 
 const useEvents = (
-  router: RoutingContext<Queries>,
   controller: AbortController,
-  readyStateRef: MutableRefObject<AppReadyState>
+  router: RoutingContext<Queries>,
+  readyStateRef: MutableRefObject<AppReadyState>,
+  session: MutableRefObject<Session>
 ) => {
   const eventNames = useMemo(() => Object.keys(EVENTS), []);
   const subscriptions = useMemo(() => eventNames.map(snakeCase), [eventNames]);
 
   const ctx = useMemo(
-    () => ({ router, controller, readyStateRef }),
-    [router, controller, readyStateRef]
+    () => ({ controller, router, readyStateRef, session }),
+    [controller, router, readyStateRef, session]
   );
   for (let index = 0; index < eventNames.length; index++) {
     HANDLERS[eventNames[index]] = EVENTS[eventNames[index]](ctx);

--- a/app/packages/app/src/useEvents/useSetGroupSlice.ts
+++ b/app/packages/app/src/useEvents/useSetGroupSlice.ts
@@ -2,7 +2,7 @@ import { useSessionSetter } from "@fiftyone/state";
 import { useCallback } from "react";
 import { EventHandlerHook } from "./registerEvent";
 
-const useSelectLabels: EventHandlerHook = () => {
+const useSetGroupSlice: EventHandlerHook = () => {
   const setter = useSessionSetter();
 
   return useCallback(
@@ -13,4 +13,4 @@ const useSelectLabels: EventHandlerHook = () => {
   );
 };
 
-export default useSelectLabels;
+export default useSetGroupSlice;

--- a/app/packages/app/src/useEvents/useStateUpdate.ts
+++ b/app/packages/app/src/useEvents/useStateUpdate.ts
@@ -1,16 +1,18 @@
-import { useSessionSetter } from "@fiftyone/state";
 import { useCallback } from "react";
 import { useSetRecoilState } from "recoil";
 import { AppReadyState, EventHandlerHook } from "./registerEvent";
 import { appReadyState, processState } from "./utils";
 
-const useStateUpdate: EventHandlerHook = ({ router, readyStateRef }) => {
-  const setter = useSessionSetter();
+const useStateUpdate: EventHandlerHook = ({
+  router,
+  readyStateRef,
+  session,
+}) => {
   const setReadyState = useSetRecoilState(appReadyState);
 
   return useCallback(
     (payload: any) => {
-      const state = processState(setter, payload.state);
+      const state = processState(session.current, payload.state);
 
       const searchParams = new URLSearchParams(router.history.location.search);
 
@@ -39,7 +41,7 @@ const useStateUpdate: EventHandlerHook = ({ router, readyStateRef }) => {
         router.history.push(path, state);
       }
     },
-    [readyStateRef, router, setter, setReadyState]
+    [readyStateRef, router, session, setReadyState]
   );
 };
 

--- a/app/packages/app/src/useEvents/utils.ts
+++ b/app/packages/app/src/useEvents/utils.ts
@@ -1,5 +1,5 @@
-import { ColorSchemeInput } from "@fiftyone/relay";
-import { State, ensureColorScheme, useSessionSetter } from "@fiftyone/state";
+import { ColorSchemeInput, subscribeBefore } from "@fiftyone/relay";
+import { Session, State, ensureColorScheme } from "@fiftyone/state";
 import { env, toCamelCase } from "@fiftyone/utilities";
 import { atom } from "recoil";
 import { DatasetPageQuery } from "../pages/datasets/__generated__/DatasetPageQuery.graphql";
@@ -12,24 +12,28 @@ export const appReadyState = atom<AppReadyState>({
 });
 
 export const processState = (
-  setter: ReturnType<typeof useSessionSetter>,
+  session: Session,
   state: any
 ): Partial<LocationState<DatasetPageQuery>> => {
   if (env().VITE_NO_STATE) {
     return { view: [], fieldVisibility: undefined };
   }
-  setter(
-    "colorScheme",
-    ensureColorScheme(state.color_scheme as ColorSchemeInput)
-  );
-  setter("sessionGroupSlice", state.group_slice);
-  setter("selectedSamples", new Set(state.selected));
-  setter(
-    "selectedLabels",
-    toCamelCase(state.selected_labels) as State.SelectedLabel[]
-  );
-  state.spaces && setter("sessionSpaces", state.spaces);
-  setter("fieldVisibilityStage", state.field_visibility_stage || undefined);
+
+  const unsubscribe = subscribeBefore<DatasetPageQuery>(({ data }) => {
+    session.colorScheme = ensureColorScheme(
+      state.color_scheme as ColorSchemeInput
+    );
+    session.sessionGroupSlice =
+      state.group_slice ?? data.dataset?.defaultGroupSlice;
+    session.selectedLabels = toCamelCase(
+      state.selected_labels
+    ) as State.SelectedLabel[];
+    session.selectedSamples = new Set(state.selected);
+    session.sessionSpaces = state.spaces || session.sessionSpaces;
+    session.fieldVisibilityStage = state.field_visibility_stage || undefined;
+
+    unsubscribe();
+  });
 
   return {
     view: state.view || [],

--- a/app/packages/app/src/useEvents/utils.ts
+++ b/app/packages/app/src/useEvents/utils.ts
@@ -15,11 +15,11 @@ export const processState = (
   session: Session,
   state: any
 ): Partial<LocationState<DatasetPageQuery>> => {
-  if (env().VITE_NO_STATE) {
-    return { view: [], fieldVisibility: undefined };
-  }
-
   const unsubscribe = subscribeBefore<DatasetPageQuery>(({ data }) => {
+    if (env().VITE_NO_STATE) {
+      session.sessionGroupSlice = data.dataset?.defaultGroupSlice || undefined;
+      return;
+    }
     session.colorScheme = ensureColorScheme(
       state.color_scheme as ColorSchemeInput
     );
@@ -34,6 +34,10 @@ export const processState = (
 
     unsubscribe();
   });
+
+  if (env().VITE_NO_STATE) {
+    return { view: [], fieldVisibility: undefined };
+  }
 
   return {
     view: state.view || [],

--- a/app/packages/app/src/useWriters/useWriters.ts
+++ b/app/packages/app/src/useWriters/useWriters.ts
@@ -13,7 +13,7 @@ const useWriters = (
   sessionRef: MutableRefObject<Session>
 ) => {
   useSession((key, value) => {
-    if (env().VITE_NO_STATE && key !== "selectedFields") {
+    if (env().VITE_NO_STATE) {
       return;
     }
 

--- a/app/packages/state/src/session.ts
+++ b/app/packages/state/src/session.ts
@@ -108,7 +108,7 @@ export function sessionAtom<K extends keyof Session>(
         if (trigger === "get" && !isTest) {
           assertValue();
           setSelf(
-            isTest || sessionRef[options.key] === undefined
+            sessionRef[options.key] === undefined
               ? options.default
               : sessionRef[options.key]
           );

--- a/e2e-pw/src/oss/specs/regression-tests/group-video/default-video-slice-group.spec.ts
+++ b/e2e-pw/src/oss/specs/regression-tests/group-video/default-video-slice-group.spec.ts
@@ -74,11 +74,7 @@ test.describe("default video slice group", () => {
     fiftyoneLoader.waitUntilGridVisible(page, datasetName);
   });
 
-  test("video as default slice renders", async ({
-    grid,
-    modal,
-    eventUtils,
-  }) => {
+  test("video as default slice renders", async ({ grid, modal }) => {
     await grid.sliceSelector.assert.verifyHasSlices(["video", "image"]);
     await grid.sliceSelector.assert.verifyActiveSlice("video");
     await grid.assert.isLookerCountEqualTo(1);
@@ -89,12 +85,9 @@ test.describe("default video slice group", () => {
     await modal.assert.verifyCarouselLength(2);
     await modal.close();
 
-    const imgLoadedPromise = eventUtils.getEventReceivedPromiseForPredicate(
-      "sample-loaded",
-      (e) => e.detail.sampleFilepath === testImgPath
-    );
+    const promise = grid.getWaitForGridRefreshPromise();
     await grid.selectSlice("image");
-    await imgLoadedPromise;
+    await promise;
 
     await grid.assert.isLookerCountEqualTo(2);
     await grid.openFirstSample();

--- a/fiftyone/core/session/session.py
+++ b/fiftyone/core/session/session.py
@@ -659,6 +659,9 @@ class Session(object):
     def _set_dataset(self, dataset):
         if dataset is not None:
             dataset._reload()
+            self._state.group_slice = dataset.group_slice
+        else:
+            self._state.group_slice = None
 
         self._state.dataset = dataset
         self._state.view = None
@@ -696,12 +699,14 @@ class Session(object):
 
     def _set_view(self, view):
         if view is None:
+            self._state.group_slice = None
             self._state.view = None
             self._state.view_name = None
         else:
             if view._root_dataset != self.dataset:
                 self._set_dataset(view._root_dataset)
 
+            self._state.group_slice = view.group_slice
             self._state.view = view
             self._state.view_name = view.name
 

--- a/fiftyone/core/state.py
+++ b/fiftyone/core/state.py
@@ -116,6 +116,9 @@ class StateDescription(etas.Serializable):
                     )
                 ]
 
+                if self.view.group_slice:
+                    d["group_slice"] = self.view.group_slice
+
             d["config"]["timezone"] = fo.config.timezone
 
             if self.config.colorscale:

--- a/fiftyone/core/state.py
+++ b/fiftyone/core/state.py
@@ -116,8 +116,9 @@ class StateDescription(etas.Serializable):
                     )
                 ]
 
-                if self.view.group_slice:
-                    d["group_slice"] = self.view.group_slice
+                view = self.view if self.view is not None else self.dataset
+                if view.group_slice:
+                    d["group_slice"] = view.group_slice
 
             d["config"]["timezone"] = fo.config.timezone
 

--- a/fiftyone/core/state.py
+++ b/fiftyone/core/state.py
@@ -60,6 +60,7 @@ class StateDescription(etas.Serializable):
         view=None,
         view_name=None,
         field_visibility_stage=None,
+        group_slice=None,
     ):
         self.config = config or fo.app_config.copy()
         self.dataset = dataset
@@ -75,6 +76,9 @@ class StateDescription(etas.Serializable):
         self.spaces = spaces
         self.color_scheme = color_scheme or build_color_scheme()
         self.field_visibility_stage = field_visibility_stage
+        if group_slice is None and view is not None:
+            group_slice = view.group_slice
+        self.group_slice = group_slice
 
     def serialize(self, reflective=True):
         with fou.disable_progress_bars():
@@ -111,10 +115,6 @@ class StateDescription(etas.Serializable):
                         collection.get_frame_field_schema(flat=True)
                     )
                 ]
-
-                view = self.view if self.view is not None else self.dataset
-                if view.media_type == fom.GROUP:
-                    d["group_slice"] = view.group_slice
 
             d["config"]["timezone"] = fo.config.timezone
 
@@ -169,14 +169,6 @@ class StateDescription(etas.Serializable):
                     dataset.reload()
                     view = fov.DatasetView._build(dataset, stages)
 
-        group_slice = d.get("group_slice", None)
-        if group_slice:
-            if dataset is not None:
-                dataset.group_slice = group_slice
-
-            if view is not None:
-                view.group_slice = group_slice
-
         config = with_config or fo.app_config.copy()
         for field, value in d.get("config", {}).items():
             setattr(config, field, value)
@@ -200,6 +192,7 @@ class StateDescription(etas.Serializable):
             spaces=spaces,
             color_scheme=color_scheme,
             field_visibility_stage=d.get("field_visibility_stage", None),
+            group_slice=d.get("group_slice", None),
         )
 
 

--- a/fiftyone/core/state.py
+++ b/fiftyone/core/state.py
@@ -116,10 +116,6 @@ class StateDescription(etas.Serializable):
                     )
                 ]
 
-                view = self.view if self.view is not None else self.dataset
-                if view.group_slice:
-                    d["group_slice"] = view.group_slice
-
             d["config"]["timezone"] = fo.config.timezone
 
             if self.config.colorscale:

--- a/fiftyone/server/events.py
+++ b/fiftyone/server/events.py
@@ -87,11 +87,7 @@ async def dispatch_event(
         _state.field_visibility_stage = event.stage
 
     if isinstance(event, SetGroupSlice):
-        if _state.view is not None:
-            _state.view.group_slice = event.slice
-
-        elif _state.dataset is not None:
-            _state.dataset.group_slice = event.slice
+        _state.group_slice = event.slice
 
     if isinstance(event, (StateUpdate, Refresh)):
         _state = event.state

--- a/fiftyone/server/mutation.py
+++ b/fiftyone/server/mutation.py
@@ -91,6 +91,7 @@ class Mutation(SetColorScheme):
         state.color_scheme = build_color_scheme(
             None, state.dataset, state.config
         )
+        state.group_slice = state.dataset.group_slice
         await dispatch_event(subscription, StateUpdate(state=state))
         return True
 
@@ -101,8 +102,6 @@ class Mutation(SetColorScheme):
         session: t.Optional[str],
         slice: str,
     ) -> bool:
-        state = get_state()
-        state.dataset.group_slice = slice
         await dispatch_event(subscription, fose.SetGroupSlice(slice=slice))
         return True
 
@@ -185,6 +184,7 @@ class Mutation(SetColorScheme):
             state.dataset = None
             state.view = None
             state.spaces = default_spaces
+            state.group_slice = None
             await dispatch_event(subscription, StateUpdate(state=state))
 
         result_view = None


### PR DESCRIPTION
### Changes

* Fixes the `useSetGroupSlice` subscription event in `@fiftyone/app/useEvents`
* Fixes `groupSlice` persistence in multi-tab contexts and across page reloads/refreshes

The underlying goal of this change is to keep the group slice setting across page loads even when a view without a `group` media type is present

### Before

https://github.com/voxel51/fiftyone/assets/19821840/3c3c670b-bf3f-4cc1-8b16-022441c4b547

### After

https://github.com/voxel51/fiftyone/assets/19821840/b695e480-b3db-4c6c-8220-1922b6be0bd9

