### PR TITLE
Cleanup saved views loading in set_view mutation

### DIFF
--- a/fiftyone/server/mutation.py
+++ b/fiftyone/server/mutation.py
@@ -190,23 +190,17 @@ class Mutation(SetColorScheme):
         result_view = None
         ds = fod.load_dataset(dataset_name)
         state.dataset = ds
-        if saved_view_slug is not None:
-            try:
-                doc = ds._get_saved_view_doc(saved_view_slug, slug=True)
-            except:
-                pass
 
-        # Load saved views
+        # Create the view using the saved view doc if loading a saved view
         if saved_view_slug is not None:
             try:
-                ds = fod.load_dataset(dataset_name)
                 doc = ds._get_saved_view_doc(saved_view_slug, slug=True)
                 result_view = ds._load_saved_view_from_doc(doc)
             except:
                 pass
 
+        # Otherwise, build the view using the params
         if result_view is None:
-            # Update current view with form parameters
             result_view = get_view(
                 dataset_name,
                 stages=view if view else None,
@@ -220,8 +214,6 @@ class Mutation(SetColorScheme):
                 if form.slice
                 else None,
             )
-
-        result_view = _build_result_view(result_view, form)
 
         # Set view state
         slug = (
@@ -238,11 +230,7 @@ class Mutation(SetColorScheme):
             StateUpdate(state=state),
         )
 
-        final_view = []
-        if state and state.view:
-            final_view = state.view._serialize()
-
-        return final_view
+        return result_view._serialize()
 
     @gql.mutation
     async def store_teams_submission(self) -> bool:

--- a/fiftyone/server/mutation.py
+++ b/fiftyone/server/mutation.py
@@ -199,7 +199,7 @@ class Mutation(SetColorScheme):
             except:
                 pass
 
-        # Otherwise, build the view using the params
+        # # Otherwise, build the view using the params
         if result_view is None:
             result_view = get_view(
                 dataset_name,
@@ -213,7 +213,10 @@ class Mutation(SetColorScheme):
                 )
                 if form.slice
                 else None,
+                # sample_ids=form.sample_ids if form else None
             )
+
+            result_view = _build_result_view(result_view, form)
 
         # Set view state
         slug = (


### PR DESCRIPTION
## What changes are proposed in this pull request?

Cleanup the mutation so that saves views are only built/loaded once using `load_saved_view` from the sdk to ensure the view is loaded properly

## How is this patch tested? If it is not, please explain why.

(Details)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
