### PR TITLE
Use non-default browser to launch the app

### DIFF
--- a/docs/source/cli/index.rst
+++ b/docs/source/cli/index.rst
@@ -1864,7 +1864,7 @@ Launch the FiftyOne App.
 
 .. code-block:: text
 
-    fiftyone app launch [-h] [-p PORT] [-A ADDRESS] [-r] [-a] [-w WAIT] [NAME]
+    fiftyone app launch [-h] [-p PORT] [-A ADDRESS] [-b BROWSER] [-r] [-a] [-w WAIT] [NAME]
 
 **Arguments**
 
@@ -1880,6 +1880,8 @@ Launch the FiftyOne App.
                             the address (server name) to use
       -r, --remote          whether to launch a remote App session
       -a, --desktop         whether to launch a desktop App instance
+      -b BROWSER, --browser BROWSER
+                            the browser to use to open the App
       -w WAIT, --wait WAIT  the number of seconds to wait for a new App
                             connection before returning if all connections are
                             lost. If negative, the process will wait forever,
@@ -1906,6 +1908,11 @@ Launch the FiftyOne App.
 
     # Launch a desktop App session
     fiftyone app launch ... --desktop
+
+.. code-block:: shell
+
+    # Launch a desktop App session
+    fiftyone app launch ... --browser <name>
 
 .. _cli-fiftyone-app-view:
 

--- a/fiftyone/core/cli.py
+++ b/fiftyone/core/cli.py
@@ -1170,6 +1170,9 @@ class AppLaunchCommand(Command):
 
         # Launch a desktop App session
         fiftyone app launch ... --desktop
+
+        # Launch the App in the non-default browser
+        fiftyone app launch ... --browser firefox
     """
 
     @staticmethod
@@ -1209,6 +1212,14 @@ class AppLaunchCommand(Command):
             help="whether to launch a desktop App instance",
         )
         parser.add_argument(
+            "-b",
+            "--browser",
+            metavar="BROWSER",
+            default=None,
+            type=str,
+            help="the browser to use to open the App",
+        )
+        parser.add_argument(
             "-w",
             "--wait",
             metavar="WAIT",
@@ -1237,6 +1248,7 @@ class AppLaunchCommand(Command):
             address=args.address,
             remote=args.remote,
             desktop=desktop,
+            browser=args.browser,
         )
 
         _watch_session(session, args.wait)

--- a/fiftyone/core/session/session.py
+++ b/fiftyone/core/session/session.py
@@ -146,6 +146,7 @@ def launch_app(
     address: str = None,
     remote: bool = False,
     desktop: bool = None,
+    browser: str = None,
     height: int = None,
     auto: bool = True,
     config: AppConfig = None,
@@ -177,6 +178,9 @@ def launch_app(
         desktop (None): whether to launch the App in the browser (False) or as
             a desktop App (True). If None, ``fiftyone.config.desktop_app`` is
             used. Not applicable to notebook contexts
+        browser (None): an optional browser to use to open the App. If None,
+            the default browser will be used. Refer to list of supported
+            browsers at https://docs.python.org/3/library/webbrowser.html
         height (None): an optional height, in pixels, at which to render App
             instances in notebook cells. Only applicable in notebook contexts
         auto (True): whether to automatically show a new App window
@@ -199,6 +203,7 @@ def launch_app(
         address=address,
         remote=remote,
         desktop=desktop,
+        browser=browser,
         height=height,
         auto=auto,
         config=config,
@@ -319,6 +324,9 @@ class Session(object):
         desktop (None): whether to launch the App in the browser (False) or as
             a desktop App (True). If None, ``fiftyone.config.desktop_app`` is
             used. Not applicable to notebook contexts (e.g., Jupyter and Colab)
+        browser (None): an optional browser to use to open the App. If None,
+            the default browser will be used. Refer to list of supported
+            browsers at https://docs.python.org/3/library/webbrowser.html
         height (None): an optional height, in pixels, at which to render App
             instances in notebook cells. Only applicable in notebook contexts
         auto (True): whether to automatically show a new App window
@@ -340,6 +348,7 @@ class Session(object):
         address: str = None,
         remote: bool = False,
         desktop: bool = None,
+        browser: str = None,
         height: int = None,
         auto: bool = True,
         config: AppConfig = None,
@@ -423,6 +432,8 @@ class Session(object):
 
         if self.auto and focx.is_notebook_context():
             self.show(height=config.notebook_height)
+
+        self.browser = browser
 
         if self.remote:
             if focx.is_notebook_context():
@@ -1001,7 +1012,11 @@ class Session(object):
             )
             return
 
-        webbrowser.open(self.url, new=2)
+        if self.browser is None:
+            webbrowser.open(self.url, new=2)
+        else:
+            # open in a specified browser
+            webbrowser.get(self.browser).open(self.url, new=2)
 
     @update_state()
     def show(self, height: int = None) -> None:


### PR DESCRIPTION
## What changes are proposed in this pull request?

Fiftyone works best in Chrome, while users might prefer other browsers for surfing the internet.

Add a `--browser <browser_name>` parameter to `fiftyone app launch` to use a non-default browser to open the App.

## How is this patch tested? If it is not, please explain why.

Running these commands:
```
fiftyone app launch -b chrome
fiftyone app launch --browser safari
fiftyone app launch --browser oper  # fails (no browser registered with this name)
 fiftyone app launch --browser opera  # fails (non-executable found)
```

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

Launch the app in the non-default browser. 

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [x] Documentation: FiftyOne documentation changes
-   [ ] Other
