### PR TITLE
prevent backtick key from closing operator palette

### DIFF
--- a/app/packages/operators/src/OperatorPalette.tsx
+++ b/app/packages/operators/src/OperatorPalette.tsx
@@ -47,7 +47,6 @@ export default function OperatorPalette(props: OperatorPaletteProps) {
       }
       switch (key) {
         case "Escape":
-        case "`":
           if (onClose) onClose();
           if (onCancel) onCancel();
           break;

--- a/app/packages/operators/src/constants.ts
+++ b/app/packages/operators/src/constants.ts
@@ -1,5 +1,5 @@
 export const BROWSER_CONTROL_KEYS = ["ArrowDown", "ArrowUp", "`"];
-export const PALETTE_CONTROL_KEYS = ["`", "Enter", "Escape"];
+export const PALETTE_CONTROL_KEYS = ["Enter", "Escape"];
 export const RESOLVE_PLACEMENTS_TTL = 2500;
 export const RESOLVE_TYPE_TTL = 500;
 export const RESOLVE_INPUT_VALIDATION_TTL = 750;

--- a/app/packages/operators/src/state.ts
+++ b/app/packages/operators/src/state.ts
@@ -350,6 +350,17 @@ const operatorIOState = atom({
   default: { visible: false },
 });
 
+export const operatorPaletteOpened = selector({
+  key: "operatorPaletteOpened",
+  get: ({ get }) => {
+    return (
+      get(showOperatorPromptSelector) ||
+      get(operatorBrowserVisibleState) ||
+      get(operatorIOState).visible
+    );
+  },
+});
+
 export function useShowOperatorIO() {
   const [state, setState] = useRecoilState(operatorIOState);
   return {
@@ -497,6 +508,7 @@ export function useOperatorBrowser() {
   const defaultSelected = useRecoilValue(operatorDefaultChoice);
   const choices = useRecoilValue(operatorBrowserChoices);
   const promptForInput = usePromptOperatorInput();
+  const isOperatorPaletteOpened = useRecoilValue(operatorPaletteOpened);
 
   const selectedValue = useMemo(() => {
     return selected ?? defaultSelected;
@@ -558,6 +570,7 @@ export function useOperatorBrowser() {
   const onKeyDown = useCallback(
     (e) => {
       if (e.key !== "`" && !isVisible) return;
+      if (e.key === "`" && isOperatorPaletteOpened) return;
       if (BROWSER_CONTROL_KEYS.includes(e.key)) e.preventDefault();
       switch (e.key) {
         case "ArrowDown":
@@ -567,6 +580,7 @@ export function useOperatorBrowser() {
           selectPrevious();
           break;
         case "`":
+          if (isOperatorPaletteOpened) break;
           if (isVisible) {
             close();
           } else {
@@ -581,7 +595,15 @@ export function useOperatorBrowser() {
           break;
       }
     },
-    [selectNext, selectPrevious, isVisible, onSubmit, close, setIsVisible]
+    [
+      selectNext,
+      selectPrevious,
+      isVisible,
+      onSubmit,
+      close,
+      setIsVisible,
+      isOperatorPaletteOpened,
+    ]
   );
 
   const toggle = useCallback(() => {


### PR DESCRIPTION
## What changes are proposed in this pull request?

Fixes a bug where typing a `Backtick` into an input or other operator field closes the operator palette. Before this change, pressing `Backtick` was supported for both opening and closing an operator browser and palette. With this change, `Backtick` will no longer support closing the palette. Instead, the `Escape` key should be used to close an OperatorPalette

## How is this patch tested? If it is not, please explain why.

Using a test operator with input filed such as MarkdownView

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

See above

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
