### PR TITLE
Update Labelbox integration to handle existing data rows

### DIFF
--- a/docs/source/integrations/labelbox.rst
+++ b/docs/source/integrations/labelbox.rst
@@ -782,8 +782,9 @@ to see the available keys on a dataset.
 
     However, you can pass `cleanup=True` to delete all information associated
     with the run from the backend after the annotations are downloaded.
-    Specifically, it will delete the project, data rows, and ontology
-    associated with this annotation run.
+    Specifically, it will delete the project and ontology
+    associated with this annotation run. Data rows are not deleted since they
+    can be reused by other annotation runs.
 
 You can use the optional `dest_field` parameter to override the task's
 label schema and instead load annotations into different field name(s) of your

--- a/fiftyone/utils/labelbox.py
+++ b/fiftyone/utils/labelbox.py
@@ -1386,7 +1386,7 @@ class LabelboxAnnotationResults(foua.AnnotationResults):
         """
         if self.project_id is not None:
             api = self.connect_to_api()
-            api.delete_project(self.project_id, delete_batches=True)
+            api.delete_project(self.project_id)
 
         # @todo save updated results to DB?
         self.project_id = None

--- a/fiftyone/utils/labelbox.py
+++ b/fiftyone/utils/labelbox.py
@@ -499,7 +499,31 @@ class LabelboxAnnotationAPI(foua.AnnotationAPI):
 
         webbrowser.open(url, new=2)
 
-    def upload_data(self, samples, lb_dataset, media_field="filepath"):
+    def _skip_existing_global_keys(self, media_paths, sample_ids):
+        lb_logger = logging.getLogger("labelbox.client")
+        lb_logger_level = lb_logger.level
+        lb_logger.setLevel(logging.ERROR)
+        response = self._client.get_data_row_ids_for_global_keys(sample_ids)
+        lb_logger.setLevel(lb_logger_level)
+
+        results = response["results"]
+        new_media_paths = []
+        new_sample_ids = []
+        for i, result in enumerate(results):
+            if result == "":
+                new_media_paths.append(media_paths[i])
+                new_sample_ids.append(sample_ids[i])
+        num_existing_samples = len(media_paths) - len(new_media_paths)
+        if num_existing_samples:
+            logger.info(
+                "Found %d data row(s) with a global key matching a sample id. "
+                "These samples will not be reuploaded..."
+                % num_existing_samples
+            )
+
+        return new_media_paths, new_sample_ids
+
+    def upload_data(self, samples, dataset_name, media_field="filepath"):
         """Uploads the media for the given samples to Labelbox.
 
         This method uses ``labelbox.schema.dataset.Dataset.create_data_rows()``
@@ -509,12 +533,15 @@ class LabelboxAnnotationAPI(foua.AnnotationAPI):
         Args:
             samples: a :class:`fiftyone.core.collections.SampleCollection`
                 containing the media to upload
-            lb_dataset: a ``labelbox.schema.dataset.Dataset`` to which to
-                add the media
+            dataset_name: the name of the Labelbox dataset created if data
+                needs to be uploaded
             media_field ("filepath"): string field name containing the paths to
                 media files on disk to upload
         """
         media_paths, sample_ids = samples.values([media_field, "id"])
+        media_paths, sample_ids = self._skip_existing_global_keys(
+            media_paths, sample_ids
+        )
 
         upload_info = []
 
@@ -528,8 +555,14 @@ class LabelboxAnnotationAPI(foua.AnnotationAPI):
                     }
                 )
 
-        task = lb_dataset.create_data_rows(upload_info)
-        task.wait_till_done()
+        if upload_info:
+            lb_dataset = self._client.create_dataset(name=dataset_name)
+            task = lb_dataset.create_data_rows(upload_info)
+            task.wait_till_done()
+            if task.errors:
+                logger.warning(
+                    "Datarow creation failed with error: %s" % task.errors
+                )
 
     def upload_samples(self, samples, anno_key, backend):
         """Uploads the given samples to Labelbox according to the given
@@ -563,11 +596,11 @@ class LabelboxAnnotationAPI(foua.AnnotationAPI):
             _dataset_name = samples._root_dataset.name.replace(" ", "_")
             project_name = "FiftyOne_%s" % _dataset_name
 
-        dataset = self._client.create_dataset(name=project_name)
-        self.upload_data(samples, dataset, media_field=media_field)
+        self.upload_data(samples, project_name, media_field=media_field)
+        global_keys = samples.values("id")
 
         project = self._setup_project(
-            project_name, dataset, label_schema, classes_as_attrs, is_video
+            project_name, global_keys, label_schema, classes_as_attrs, is_video
         )
 
         if members:
@@ -720,7 +753,12 @@ class LabelboxAnnotationAPI(foua.AnnotationAPI):
         return frame_id_map
 
     def _setup_project(
-        self, project_name, dataset, label_schema, classes_as_attrs, is_video
+        self,
+        project_name,
+        global_keys,
+        label_schema,
+        classes_as_attrs,
+        is_video,
     ):
         media_type = lb.MediaType.Video if is_video else lb.MediaType.Image
         project = self._client.create_project(
@@ -729,7 +767,7 @@ class LabelboxAnnotationAPI(foua.AnnotationAPI):
         )
         project.create_batch(
             name=str(uuid4()),
-            data_rows=dataset.data_rows(),
+            global_keys=global_keys,
         )
 
         self._setup_editor(project, label_schema, classes_as_attrs)


### PR DESCRIPTION
In our Labelbox integration, each sample that is annotated is uploaded as a Labelbox data row with a global key that is equal to the FiftyOne sample id. However, these are globally unique, so if the same samples are being annotated twice, they cannot and should not be uploaded again.

This PR adds logic that checks if existing samples already exists in Labelbox by referencing existing global keys and avoids reuploading them if they are found.