### PR TITLE
Exhaust generator operators when executing directly

### DIFF
--- a/fiftyone/operators/delegated.py
+++ b/fiftyone/operators/delegated.py
@@ -6,17 +6,14 @@ FiftyOne delegated operations.
 |
 """
 import asyncio
-import collections
-import inspect
 import logging
 import traceback
-import types as python_types
-import fiftyone.core.utils as fou
 
 from fiftyone.factory.repo_factory import RepositoryFactory
 from fiftyone.factory import DelegatedOperationPagingParams
 from fiftyone.operators.executor import (
     prepare_operator_executor,
+    do_execute_operator,
     ExecutionResult,
     ExecutionRunState,
     ExecutionProgress,
@@ -42,7 +39,8 @@ class DelegatedOperationService(object):
         Args:
             operator: the operator name
             delegation_target (None): an optional delegation target
-            label (None): an optional label for the operation (will default to the operator if not supplied)
+            label (None): an optional label for the operation (will default to
+                the operator if not supplied)
             context (None): an
                 :class:`fiftyone.operators.executor.ExecutionContext`
 
@@ -75,7 +73,8 @@ class DelegatedOperationService(object):
 
         Args:
             doc_id: the ID of the delegated operation
-            run_link (None): an optional run link to orchestrator specific run information
+            run_link (None): an optional run link to orchestrator specific run
+                information
             progress (None): the optional progress of the operation
 
         Returns:
@@ -102,7 +101,8 @@ class DelegatedOperationService(object):
             result (None): the
                 :class:`fiftyone.operators.executor.ExecutionResult` of the
                 operation
-            run_link (None): the optional run link to orchestrator specific run information
+            run_link (None): the optional run link to orchestrator specific run
+                information
             progress (None): the optional progress of the operation
 
         Returns:
@@ -130,7 +130,8 @@ class DelegatedOperationService(object):
             result (None): the
                 :class:`fiftyone.operators.executor.ExecutionResult` of the
                 operation
-            run_link (None): the optional run link to orchestrator specific run information
+            run_link (None): the optional run link to orchestrator specific run
+                information
             progress (None): the optional progress of the operation
 
         Returns:
@@ -324,33 +325,37 @@ class DelegatedOperationService(object):
         """Executes the given delegated operation.
 
         Args:
-            operation: the :class:`fiftyone.factory.repos.DelegatedOperationDocument`
+            operation: the
+                :class:`fiftyone.factory.repos.DelegatedOperationDocument`
             log (False): the optional boolean flag to log the execution of the
                 delegated operations
-            run_link (None): the optional run link to orchestrator specific run information
+            run_link (None): the optional run link to orchestrator specific run
+                information
         """
         try:
+            self.set_running(doc_id=operation.id, run_link=run_link)
             if log:
                 logger.info(
                     "\nRunning operation %s (%s)",
                     operation.id,
                     operation.operator,
                 )
-            execution_result = asyncio.run(
-                self._execute_operator(operation, log, run_link=run_link)
-            )
-            self.set_completed(doc_id=operation.id, result=execution_result)
+
+            result = asyncio.run(self._execute_operator(operation))
+
+            self.set_completed(doc_id=operation.id, result=result)
             if log:
                 logger.info("Operation %s complete", operation.id)
         except Exception as e:
             result = ExecutionResult(error=traceback.format_exc())
+
             self.set_failed(doc_id=operation.id, result=result)
             if log:
                 logger.info(
                     "Operation %s failed\n%s", operation.id, result.error
                 )
 
-    async def _execute_operator(self, doc, log=False, run_link=None):
+    async def _execute_operator(self, doc):
         operator_uri = doc.operator
         context = doc.context
         context.request_params["run_doc"] = doc.id
@@ -362,30 +367,8 @@ class DelegatedOperationService(object):
             set_progress=self.set_progress,
         )
 
-        # if a validation error happened during preparation,
-        # only an ExecutionResult with an error is returned.
-        # Raise it so the delegated operation is marked as a failure.
         if isinstance(prepared, ExecutionResult):
             raise prepared.to_exception()
-        else:
-            operator, _, ctx = prepared
 
-            if log:
-                logger.info("Running operator %s", operator_uri)
-            self.set_running(doc_id=doc.id, run_link=run_link)
-
-            raw_result = await (
-                operator.execute(ctx)
-                if asyncio.iscoroutinefunction(operator.execute)
-                else fou.run_sync_task(operator.execute, ctx)
-            )
-
-            if inspect.isgenerator(raw_result):
-                # Fastest way to exhaust sync generator, re: itertools consume()
-                #   https://docs.python.org/3/library/itertools.html
-                collections.deque(raw_result, maxlen=0)
-            elif inspect.isasyncgen(raw_result):
-                async for _ in raw_result:
-                    pass
-            else:
-                return raw_result
+        operator, _, ctx = prepared
+        return await do_execute_operator(operator, ctx, exhaust=True)

--- a/fiftyone/operators/executor.py
+++ b/fiftyone/operators/executor.py
@@ -571,16 +571,25 @@ class ExecutionResult(object):
             self.result
         )
 
+    def raise_exceptions(self):
+        """Raises an :class:`ExecutionError` (only) if the operation failed."""
+        exception = self.to_exception()
+        if exception is not None:
+            raise exception
+
     def to_exception(self):
         """Returns an :class:`ExecutionError` representing a failed execution
         result.
 
         Returns:
-            a :class:`ExecutionError`
+            a :class:`ExecutionError`, or None if the execution did not fail
         """
+        if not self.error:
+            return None
+
         msg = self.error
 
-        if self.validation_ctx.invalid:
+        if self.validation_ctx and self.validation_ctx.invalid:
             val_error = self.validation_ctx.errors[0]
             path = val_error.path.lstrip(".")
             reason = val_error.reason

--- a/fiftyone/operators/executor.py
+++ b/fiftyone/operators/executor.py
@@ -6,6 +6,8 @@ FiftyOne operator execution.
 |
 """
 import asyncio
+import collections
+import inspect
 import traceback
 import types as python_types
 
@@ -144,7 +146,9 @@ def execute_operator(operator_uri, ctx, params=None):
     )
 
     return asyncio.run(
-        execute_or_delegate_operator(operator_uri, request_params)
+        execute_or_delegate_operator(
+            operator_uri, request_params, exhaust=True
+        )
     )
 
 
@@ -177,12 +181,15 @@ def _parse_ctx(ctx, params=None):
 
 
 @coroutine_timeout(seconds=fo.config.operator_timeout)
-async def execute_or_delegate_operator(operator_uri, request_params):
+async def execute_or_delegate_operator(
+    operator_uri, request_params, exhaust=False
+):
     """Executes the operator with the given name.
 
     Args:
         operator_uri: the URI of the operator
         request_params: a dictionary of parameters for the operator
+        exhaust (False): whether to immediately exhaust generator operators
 
     Returns:
         an :class:`ExecutionResult`
@@ -219,18 +226,13 @@ async def execute_or_delegate_operator(operator_uri, request_params):
             )
     else:
         try:
-            raw_result = await (
-                operator.execute(ctx)
-                if asyncio.iscoroutinefunction(operator.execute)
-                else fou.run_sync_task(operator.execute, ctx)
-            )
-
+            result = await do_execute_operator(operator, ctx, exhaust=exhaust)
         except Exception as e:
             return ExecutionResult(
                 executor=executor, error=traceback.format_exc()
             )
 
-        return ExecutionResult(result=raw_result, executor=executor)
+        return ExecutionResult(result=result, executor=executor)
 
 
 async def prepare_operator_executor(
@@ -262,10 +264,25 @@ async def prepare_operator_executor(
     return operator, executor, ctx
 
 
-def _is_generator(value):
-    return isinstance(value, python_types.GeneratorType) or isinstance(
-        value, python_types.AsyncGeneratorType
+async def do_execute_operator(operator, ctx, exhaust=False):
+    result = await (
+        operator.execute(ctx)
+        if asyncio.iscoroutinefunction(operator.execute)
+        else fou.run_sync_task(operator.execute, ctx)
     )
+
+    if not exhaust:
+        return result
+
+    if inspect.isgenerator(result):
+        # Fastest way to exhaust sync generator, re: itertools consume()
+        #   https://docs.python.org/3/library/itertools.html
+        collections.deque(result, maxlen=0)
+    elif inspect.isasyncgen(result):
+        async for _ in result:
+            pass
+    else:
+        return result
 
 
 def resolve_type(registry, operator_uri, request_params):
@@ -319,8 +336,10 @@ class ExecutionContext(object):
     Args:
         request_params (None): a optional dictionary of request parameters
         executor (None): an optional :class:`Executor` instance
-        set_progress (None): an optional function to set the progress of the current operation
-        delegated_operation_id (None): an optional ID of the delegated operation
+        set_progress (None): an optional function to set the progress of the
+            current operation
+        delegated_operation_id (None): an optional ID of the delegated
+            operation
     """
 
     def __init__(
@@ -548,7 +567,9 @@ class ExecutionResult(object):
     @property
     def is_generator(self):
         """Whether the result is a generator or an async generator."""
-        return _is_generator(self.result)
+        return inspect.isgenerator(self.result) or inspect.isasyncgen(
+            self.result
+        )
 
     def to_exception(self):
         """Returns an :class:`ExecutionError` representing a failed execution


### PR DESCRIPTION
Fixes a bug where `foo.execute_operator()` would not exhaust generator operators. While fixing this, took the opportunity to remove code duplication, since the same logic was already in-place when executing delegated operations.

```py
import fiftyone as fo
import fiftyone.zoo as foz
import fiftyone.operators as foo

dataset = foz.load_zoo_dataset("quickstart")

ctx = {
    "dataset": dataset,
    "params": {
        "num_workers": 1,
        "delegate": False,
    }
}

# Previously did no computation, now works as expected
foo.execute_operator("@voxel51/utils/compute_metadata", ctx)
```
