### PR TITLE
Synchronously resolve secrets via ctx.secret

### DIFF
--- a/fiftyone/internal/secrets/providers/iprovider.py
+++ b/fiftyone/internal/secrets/providers/iprovider.py
@@ -19,10 +19,27 @@ class ISecretProvider(abc.ABC):
         """
         ...
 
+    @abc.abstractmethod
+    def get_sync(self, key: str, **kwargs) -> Optional[ISecret]:
+        """
+        Get a secret by key in a synchronous context.
+        """
+        ...
+
+    @abc.abstractmethod
     async def get_multiple(
         self, keys: List[str], **kwargs
     ) -> Dict[str, Optional[ISecret]]:
         """
         Get multiple secrets by key.
+        """
+        ...
+
+    @abc.abstractmethod
+    async def search(
+        self, regex: str, **kwargs
+    ) -> Dict[str, Optional[ISecret]]:
+        """
+        Get secrets with keys matching regex
         """
         ...

--- a/fiftyone/internal/secrets/providers/local.py
+++ b/fiftyone/internal/secrets/providers/local.py
@@ -5,6 +5,8 @@ FiftyOne env secrets provider
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+import re
+
 from ..providers.iprovider import ISecretProvider
 from ..secret import UnencryptedSecret, ISecret
 import os
@@ -21,8 +23,21 @@ class EnvSecretProvider(ISecretProvider):
             return UnencryptedSecret(key, os.getenv(key))
         return None
 
+    def get_sync(self, key, **kwargs) -> Optional[ISecret]:
+        if key in os.environ:
+            return UnencryptedSecret(key, os.getenv(key))
+        return None
+
     async def get_multiple(
         self, keys: List[str], **kwargs
     ) -> Dict[str, Optional[ISecret]]:
         secrets = [await self.get(key) for key in keys]
         return {secret.key: secret for secret in secrets if secret}
+
+    async def search(
+        self, regex: str, **kwargs
+    ) -> Dict[str, Optional[ISecret]]:
+        keys = list(filter(lambda x: re.search(regex, x), os.environ.keys()))
+        if keys:
+            return await self.get_multiple(keys)
+        return {}

--- a/fiftyone/operators/executor.py
+++ b/fiftyone/operators/executor.py
@@ -19,7 +19,7 @@ import fiftyone.core.utils as fou
 import fiftyone.core.view as fov
 import fiftyone.server.view as fosv
 import fiftyone.operators.types as types
-from fiftyone.plugins.secrets import PluginSecretsResolver
+from fiftyone.plugins.secrets import PluginSecretsResolver, SecretsDictionary
 
 from .decorators import coroutine_timeout
 from .registry import OperatorRegistry
@@ -482,9 +482,13 @@ class ExecutionContext(object):
         return self.request_params.get("results", {})
 
     @property
-    def secrets(self) -> list[str]:
-        """The list of secrets that have been resolved (if any)."""
-        return [k for k, v in self._secrets.items() if v is not None]
+    def secrets(self) -> SecretsDictionary:
+        """A read-only mapping of keys to their resolved values."""
+        return SecretsDictionary(
+            self._secrets,
+            operator_uri=self._operator_uri,
+            resolver_fn=self._secrets_client.get_secret_sync,
+        )
 
     def secret(self, key):
         """Retrieves the secret with the given key.

--- a/fiftyone/operators/executor.py
+++ b/fiftyone/operators/executor.py
@@ -482,9 +482,9 @@ class ExecutionContext(object):
         return self.request_params.get("results", {})
 
     @property
-    def secrets(self) -> dict:
-        """The dict of secrets available to the operation (if any)."""
-        return self._secrets
+    def secrets(self) -> list[str]:
+        """The list of secrets that have been resolved (if any)."""
+        return [k for k, v in self._secrets.items() if v is not None]
 
     def secret(self, key):
         """Retrieves the secret with the given key.

--- a/fiftyone/operators/executor.py
+++ b/fiftyone/operators/executor.py
@@ -12,6 +12,7 @@ import logging
 import os
 import traceback
 import types as python_types
+import typing
 
 import fiftyone as fo
 import fiftyone.core.dataset as fod
@@ -364,7 +365,7 @@ class ExecutionContext(object):
         set_progress=None,
         delegated_operation_id=None,
         operator_uri=None,
-        required_secrets: list[str] = None,
+        required_secrets: typing.List[str] = None,
     ):
         self.request_params = request_params or {}
         self.params = self.request_params.get("params", {})

--- a/fiftyone/operators/types.py
+++ b/fiftyone/operators/types.py
@@ -323,7 +323,7 @@ class Property(BaseType):
         self.required = kwargs.get("required", False)
         # todo: deprecate and remove
         self.choices = kwargs.get("choices", None)
-        self.error_message = kwargs.get("error_message", "Invalid property")
+        self.error_message = kwargs.get("error_message", "")
         self.view = kwargs.get("view", None)
 
     def to_json(self):

--- a/fiftyone/plugins/secrets.py
+++ b/fiftyone/plugins/secrets.py
@@ -6,6 +6,7 @@ Plugin secrets resolver.
 |
 """
 import logging
+import typing
 from typing import Optional
 from ..internal import secrets as fois
 
@@ -24,7 +25,7 @@ class PluginSecretsResolver:
         return cls._instance
 
     def register_operator(
-        self, operator_uri: str, required_secrets: list[str]
+        self, operator_uri: str, required_secrets: typing.List[str]
     ) -> None:
         self._registered_secrets[operator_uri] = required_secrets
 

--- a/fiftyone/plugins/secrets.py
+++ b/fiftyone/plugins/secrets.py
@@ -9,15 +9,13 @@ import logging
 from typing import Optional
 from ..internal import secrets as fois
 
-config_cache = {}
-
 
 class PluginSecretsResolver:
     """Injects secrets from environmental variables into the execution
     context."""
 
     _instance = None
-    config_cache = {}
+    _registered_secrets = {}
 
     def __new__(cls):
         if cls._instance is None:
@@ -28,7 +26,7 @@ class PluginSecretsResolver:
     def register_operator(
         self, operator_uri: str, required_secrets: list[str]
     ) -> None:
-        self.config_cache[operator_uri] = required_secrets
+        self._registered_secrets[operator_uri] = required_secrets
 
     def client(self) -> fois.ISecretProvider:
         if not self._instance:
@@ -48,7 +46,7 @@ class PluginSecretsResolver:
         """
         # pylint: disable=no-member
 
-        secret_requirements = self.config_cache.get(operator_uri, None)
+        secret_requirements = self._registered_secrets.get(operator_uri, None)
 
         if not secret_requirements:
             logging.error(
@@ -78,7 +76,7 @@ class PluginSecretsResolver:
         """
         # pylint: disable=no-member
 
-        secret_requirements = self.config_cache.get(operator_uri, None)
+        secret_requirements = self._registered_secrets.get(operator_uri, None)
         if not secret_requirements:
             logging.error(
                 f"Cannot resolve secrets for unregistered "

--- a/fiftyone/plugins/secrets.py
+++ b/fiftyone/plugins/secrets.py
@@ -5,15 +5,19 @@ Plugin secrets resolver.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
-
+import logging
 from typing import Optional
 from ..internal import secrets as fois
 
+config_cache = {}
+
 
 class PluginSecretsResolver:
-    """Injects secrets from environmental variables into the plugin context."""
+    """Injects secrets from environmental variables into the execution
+    context."""
 
     _instance = None
+    config_cache = {}
 
     def __new__(cls):
         if cls._instance is None:
@@ -21,12 +25,19 @@ class PluginSecretsResolver:
             cls._instance.client = _get_secrets_client()
         return cls._instance
 
+    def register_operator(
+        self, operator_uri: str, required_secrets: list[str]
+    ) -> None:
+        self.config_cache[operator_uri] = required_secrets
+
     def client(self) -> fois.ISecretProvider:
         if not self._instance:
             self._instance = self.__new__(self.__class__)
         return self._instance.client
 
-    async def get_secret(self, key, **kwargs) -> Optional[fois.ISecret]:
+    async def get_secret(
+        self, key: str, operator_uri: str, **kwargs
+    ) -> Optional[fois.ISecret]:
         """
         Get the value of a secret.
 
@@ -36,8 +47,51 @@ class PluginSecretsResolver:
             client for authentication if required
         """
         # pylint: disable=no-member
+
+        secret_requirements = self.config_cache.get(operator_uri, None)
+
+        if not secret_requirements:
+            logging.error(
+                f"Cannot resolve secrets for unregistered "
+                f"operator`{operator_uri}` "
+            )
+            return None
+        if key not in secret_requirements:
+            logging.error(
+                f"Cannot resolve secret {key} because it is not "
+                f"included in the plugins definition "
+            )
+            return None
         resolved_secret = await self.client.get(key, **kwargs)
         return resolved_secret
+
+    def get_secret_sync(
+        self, key: str, operator_uri: str, **kwargs
+    ) -> Optional[fois.ISecret]:
+        """
+        Get the value of a secret.
+
+        Args:
+            key (str): unique secret identifier
+            kwargs: additional keyword arguments to pass to the secrets
+            client for authentication if required
+        """
+        # pylint: disable=no-member
+
+        secret_requirements = self.config_cache.get(operator_uri, None)
+        if not secret_requirements:
+            logging.error(
+                f"Cannot resolve secrets for unregistered "
+                f"operator`{operator_uri}` "
+            )
+            return None
+        if key not in secret_requirements:
+            logging.error(
+                f"Cannot resolve secret {key} because it is not "
+                f"included in the plugins definition "
+            )
+            return None
+        return self.client.get_sync(key, **kwargs)
 
 
 def _get_secrets_client():

--- a/tests/unittests/plugins/secrets_tests.py
+++ b/tests/unittests/plugins/secrets_tests.py
@@ -151,3 +151,17 @@ class TestGetSecretSync:
         )
 
         assert "mocked_sync_secret_value" == result
+
+    def test_get_secret_sync_not_in_pd(self, mocker):
+        mocker.patch.dict(
+            os.environ, {"MY_SECRET_KEY": "mocked_sync_secret_value"}
+        )
+
+        resolver = fop.PluginSecretsResolver()
+        resolver._registered_secrets = {"operator": ["SOME_OTHER_SECRET_KEY"]}
+
+        result = resolver.get_secret_sync(
+            key="MY_SECRET_KEY", operator_uri="operator"
+        )
+
+        assert result is None

--- a/tests/unittests/plugins/secrets_tests.py
+++ b/tests/unittests/plugins/secrets_tests.py
@@ -102,7 +102,7 @@ class TestGetSecret(unittest.TestCase):
     @pytest.fixture(autouse=False)
     def plugin_secrets_resolver(self):
         resolver = fop.PluginSecretsResolver()
-        resolver.config_cache = {"operator": ["MY_SECRET_KEY"]}
+        resolver._registered_secrets = {"operator": ["MY_SECRET_KEY"]}
         return resolver
 
     @patch(
@@ -130,7 +130,7 @@ class TestGetSecretSync:
         )
 
         resolver = fop.PluginSecretsResolver()
-        resolver.config_cache = {"operator": ["MY_SECRET_KEY"]}
+        resolver._registered_secrets = {"operator": ["MY_SECRET_KEY"]}
 
         result = resolver.get_secret_sync(
             key="MY_SECRET_KEY", operator_uri="operator"

--- a/tests/unittests/secrets/provider_tests.py
+++ b/tests/unittests/secrets/provider_tests.py
@@ -17,7 +17,9 @@ class MockUnencryptedSecret(UnencryptedSecret):
 class TestEnvSecretProvider:
     @pytest.mark.asyncio
     async def test_get_existing_secret(self, mocker):
-        mocker.patch.dict(os.environ, {"SECRET_KEY": "my_secret_value"})
+        mocker.patch.dict(
+            os.environ, {"SECRET_KEY": "my_secret_value"}, clear=True
+        )
         provider = EnvSecretProvider()
 
         secret = await provider.get("SECRET_KEY")
@@ -37,7 +39,9 @@ class TestEnvSecretProvider:
     @pytest.mark.asyncio
     async def test_get_multiple_secrets_all_existing(self, mocker):
         mocker.patch.dict(
-            os.environ, {"KEY1": "value1", "KEY2": "value2", "KEY3": "value3"}
+            os.environ,
+            {"KEY1": "value1", "KEY2": "value2", "KEY3": "value3"},
+            clear=True,
         )
         provider = EnvSecretProvider()
 
@@ -60,7 +64,9 @@ class TestEnvSecretProvider:
 
     @pytest.mark.asyncio
     async def test_get_multiple_secrets_some_existing(self, mocker):
-        mocker.patch.dict(os.environ, {"KEY1": "value1", "KEY2": "value2"})
+        mocker.patch.dict(
+            os.environ, {"KEY1": "value1", "KEY2": "value2"}, clear=True
+        )
         provider = EnvSecretProvider()
 
         secrets = await provider.get_multiple(["KEY1", "KEY2", "KEY3"])
@@ -84,3 +90,38 @@ class TestEnvSecretProvider:
         secrets = await provider.get_multiple([])
 
         assert not secrets
+
+    def test_get_sync(self, mocker):
+        mocker.patch.dict(os.environ, {"KEY1": "value1"})
+        provider = EnvSecretProvider()
+
+        secret = provider.get_sync("KEY1")
+
+        assert secret is not None
+        assert secret.value == "value1"
+
+    def test_get_sync_none(self, mocker):
+        mocker.patch.dict(os.environ, {"KEY1": "value1"})
+        provider = EnvSecretProvider()
+
+        try:
+            secret = provider.get_sync("KEY2")
+        except:
+            pytest.fail("Unresolved secrets should not throw an error")
+
+        assert secret is None
+
+    @pytest.mark.asyncio
+    async def test_search(self, mocker):
+        mocker.patch.dict(
+            os.environ, {"KEY1": "value1", "KEY2": "value2"}, clear=True
+        )
+        provider = EnvSecretProvider()
+
+        try:
+            secrets = await provider.search("KEY")
+        except:
+            pytest.fail("Unresolved secrets should not throw an error")
+        assert set(secrets.keys()) == {"KEY1", "KEY2"}
+        assert secrets["KEY1"].value == "value1"
+        assert secrets["KEY2"].value == "value2"


### PR DESCRIPTION
- Currently, secrets are only resolved in the ExecutionContext via the `prepare_operator_executor()` method. This limits secret resolution to the execution phase when running an operator. 
- Adding sync methods for querying secrets enables on demand access to secrets anywhere in user defined code/plugin operator code via `ctx.secret(<KEY>)`
- added custom dictionary class `SecretsDictionary` for `ctx.secrets`:
  -  enables `ctx.secrets[<key>]` to also resolve plugin secrets automatically
  - adds some security by disabling copying or printing all values via .items() or .values()
  
- **Note**: `ctx.secret(<KEY>)` will only resolve a secret if the `KEY` is included in the secrets section of the plugin's `fiftyone.yml`. Will return None even if the value is set, but the key is not listed in the plugin's definition. 
<img width="896" alt="image" src="https://github.com/voxel51/fiftyone/assets/30936736/2637c21f-8244-4946-b98a-9d9713adf825">


## What changes are proposed in this pull request?
- add sync request methods
- add unit tests

## How is this patch tested? If it is not, please explain why.

- add unit tests
- tested locally

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

Enables on demand access to secrets anywhere in user defined code/plugin operator code via `ctx.secret(<KEY>)` or `ctx.secrets[<KEY>]`

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
