### PR TITLE
Add support for parsing and exporting COCO keypoint visibility

### DIFF
--- a/fiftyone/utils/coco.py
+++ b/fiftyone/utils/coco.py
@@ -2245,6 +2245,7 @@ def _make_coco_keypoints(keypoint, frame_size):
 
     keypoints = []
     num_points = len(keypoint.points)
+    visibility = [None] * num_points
     if "visible" in keypoint:
         if (
             isinstance(keypoint.visible, list)
@@ -2253,8 +2254,6 @@ def _make_coco_keypoints(keypoint, frame_size):
             visibility = keypoint.visible
         if isinstance(keypoint.visible, int):
             visibility = [keypoint.visible] * num_points
-    else:
-        visibility = [None] * num_points
 
     for visible, (x, y) in zip(visibility, keypoint.points):
         if np.isnan(x) or np.isnan(y):

--- a/fiftyone/utils/coco.py
+++ b/fiftyone/utils/coco.py
@@ -2247,11 +2247,16 @@ def _make_coco_keypoints(keypoint, frame_size):
     num_points = len(keypoint.points)
     visibility = [None] * num_points
     if "visible" in keypoint:
-        if (
-            isinstance(keypoint.visible, list)
-            and len(keypoint.visible) == num_points
-        ):
-            visibility = keypoint.visible
+        if isinstance(keypoint.visible, list):
+            if len(keypoint.visible) == num_points:
+                visibility = keypoint.visible
+            else:
+                logger.warning(
+                    "Ignoring 'visible' attribute of length %d for keypoint %s."
+                    " The length does not match the 'points' attribute of"
+                    " length %d."
+                    % (len(keypoint.visible), str(keypoint.id), num_points)
+                )
         if isinstance(keypoint.visible, int):
             visibility = [keypoint.visible] * num_points
 


### PR DESCRIPTION
Following up on [this thread](https://github.com/voxel51/fiftyone/issues/1581#issuecomment-1638313430), this PR adds support for parsing the keypoint visibility information:
```
v=0: not labeled / not in the image
v=1: labeled but not visible, and
v=2: labeled and visible.
```
When working with the COCO format. Specifically, the visibility from the COCO labels is parsed into a `field_name.keypoints.visible` attribute which is a list of integers for the visibility of each point corresponding to the points in the `field_name.keypoints.points` list. 
When exporting, if that attribute exists, then that visibility will be used for each keypoint in the resulting COCO labels, otherwise it falls back to the current approach where all `nan` points are visibility `0` and all others are visibility `2`.

This should allow users to incorporate keypoint visibility when using [this workaround](https://github.com/voxel51/fiftyone/issues/2194#issuecomment-1594925723) to annotate keypoint skeletons with CVAT until that direct integration is supported.

To test:
```python
import fiftyone.zoo as foz
import fiftyone as fo

dataset = foz.load_zoo_dataset("coco-2017", split="validation", max_samples=10)
dataset = fo.Dataset.from_dir(data_path="~/fiftyone/coco-2017/validation/data", labels_path="~/fiftyone/coco-2017/raw/person_keypoints_val2017.json", dataset_type=fo.types.COCODetectionDataset, max_samples=10)

dataset.export("/tmp/coco", dataset_type=fo.types.COCODetectionDataset, label_field="keypoints")
dataset = fo.Dataset.from_dir("/tmp/coco", dataset_type=fo.types.COCODetectionDataset)

print(dataset.first().keypoints.keypoints[0])
```
```
<Keypoint: {
    'id': '65563b3d968420e998667b0f',
    'attributes': {},
    'tags': [],
    'label': 'person',
    'points': [
        [0.6671875, 0.39906103286384975],
        [0.6703125, 0.3967136150234742],
        [nan, nan],
        [0.678125, 0.39436619718309857],
        [nan, nan],
        [0.6890625, 0.4154929577464789],
        [0.696875, 0.4154929577464789],
        [0.6828125, 0.4694835680751174],
        [0.671875, 0.4835680751173709],
        [0.671875, 0.5164319248826291],
        [0.65625, 0.5023474178403756],
        [0.6953125, 0.5305164319248826],
        [0.70625, 0.5234741784037559],
        [0.6984375, 0.6103286384976526],
        [0.709375, 0.6032863849765259],
        [0.7109375, 0.6807511737089202],
        [0.7171875, 0.6713615023474179],
    ],
    'confidence': None,
    'index': None,
    'visible': [1, 2, 0, 2, 0, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2],
    'supercategory': 'person',
    'iscrowd': 0,
    'num_keypoints': 15,
}>
```