### PR TITLE
Prevent receding loading state on empty page transition

### DIFF
--- a/app/packages/app/src/Sync.tsx
+++ b/app/packages/app/src/Sync.tsx
@@ -31,7 +31,8 @@ export const SessionContext = React.createContext<Session>(SESSION_DEFAULT);
 
 const Plugins = ({ children }: { children: React.ReactNode }) => {
   const plugins = usePlugins();
-  if (plugins.isLoading) return <Loading>Pixelating...</Loading>;
+
+  if (plugins.state === "loading") return <Loading>Pixelating...</Loading>;
   if (plugins.hasError) return <Loading>Plugin error...</Loading>;
 
   return <>{children}</>;

--- a/app/packages/plugins/src/index.ts
+++ b/app/packages/plugins/src/index.ts
@@ -3,7 +3,7 @@ import * as fos from "@fiftyone/state";
 import * as fou from "@fiftyone/utilities";
 import { getFetchFunction, getFetchOrigin } from "@fiftyone/utilities";
 import * as _ from "lodash";
-import React, { FunctionComponent, useEffect, useMemo, useState } from "react";
+import React, { FunctionComponent, useEffect, useMemo } from "react";
 import * as recoil from "recoil";
 import { wrapCustomComponent } from "./components";
 import "./externalize";
@@ -157,6 +157,7 @@ export function usePlugins() {
   }, [setState]);
 
   return {
+    state,
     isLoading: state === "loading" || !operatorsReady,
     hasError: state === "error",
     ready: state === "ready" && operatorsReady,


### PR DESCRIPTION
Removes a small pixelating state flicker when navigating from the empty dataset page. Wondering if this change is ok @imanjra?

## Before


https://github.com/voxel51/fiftyone/assets/19821840/4a81fdc4-e385-4a70-a388-c45d9818aae9

## After

https://github.com/voxel51/fiftyone/assets/19821840/6887fa01-560f-41ad-a3b0-94b186fdd797

