### PR TITLE
Fixes #3763

### DIFF
--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -7605,14 +7605,16 @@ def _merge_samples_python(
     dynamic=False,
     num_samples=None,
 ):
+    if dataset.media_type == fom.GROUP:
+        dst = dataset.select_group_slices(_allow_mixed=True)
+    else:
+        dst = dataset
+
     if (
         isinstance(samples, foc.SampleCollection)
         and samples.media_type == fom.GROUP
     ):
         samples = samples.select_group_slices(_allow_mixed=True)
-        dst = dataset.select_group_slices(_allow_mixed=True)
-    else:
-        dst = dataset
 
     if num_samples is None:
         try:

--- a/tests/unittests/group_tests.py
+++ b/tests/unittests/group_tests.py
@@ -1047,6 +1047,26 @@ class GroupTests(unittest.TestCase):
         self.assertEqual(len(set(samples.values("frames.id", unwind=True))), 4)
 
     @drop_datasets
+    def test_merge_groups6(self):
+        dataset = _make_group_dataset()
+
+        view = dataset.select_group_slices(_allow_mixed=True)
+        samples = list(view)
+
+        self.assertEqual(len(dataset), 2)
+        self.assertEqual(dataset.count("frames"), 2)
+        self.assertEqual(len(view), 6)
+
+        key_fcn = lambda sample: sample.filepath
+        dataset.merge_samples(samples, key_fcn=key_fcn)
+
+        view = dataset.select_group_slices(_allow_mixed=True)
+
+        self.assertEqual(len(dataset), 2)
+        self.assertEqual(dataset.count("frames"), 2)
+        self.assertEqual(len(view), 6)
+
+    @drop_datasets
     def test_indexes(self):
         dataset = _make_group_dataset()
 


### PR DESCRIPTION
Resolves https://github.com/voxel51/fiftyone/issues/3763

Fixes a bug with:

```py
dataset.merge_samples(samples, key_field=key_field, ...)
```

when `dataset` is a grouped dataset, `samples` is a list of samples, and a `key_field` is provided.