### PR TITLE
Removing buttons from builtin operators

### DIFF
--- a/app/packages/operators/src/built-in-operators.ts
+++ b/app/packages/operators/src/built-in-operators.ts
@@ -456,7 +456,10 @@ class SetSelectedSamples extends Operator {
     };
   }
   async execute({ hooks, params }: ExecutionContext) {
-    hooks.setSelected(params.samples);
+    const { samples } = params || {};
+    if (!Array.isArray(samples))
+      throw new Error("param 'samples' must be an array of string");
+    hooks.setSelected(new Set(samples));
   }
 }
 
@@ -539,7 +542,7 @@ class ShowSamples extends Operator {
           ]
         : []),
     ];
-    hooks.setView(fos.view, newView);
+    hooks.setView(newView);
   }
 }
 

--- a/fiftyone/operators/builtin.py
+++ b/fiftyone/operators/builtin.py
@@ -52,7 +52,6 @@ class CloneSelectedSamples(foo.Operator):
 
         ctx.trigger("clear_selected_samples")
         ctx.trigger("reload_samples")
-        ctx.trigger("show_samples", {"samples": sample_ids})
 
 
 class CloneSampleField(foo.Operator):
@@ -246,6 +245,7 @@ class DeleteSelectedSamples(foo.Operator):
             return
 
         ctx.dataset.delete_samples(ctx.selected)
+
         ctx.trigger("clear_selected_samples")
         ctx.trigger("reload_samples")
 

--- a/fiftyone/operators/builtin.py
+++ b/fiftyone/operators/builtin.py
@@ -24,46 +24,35 @@ class CloneSelectedSamples(foo.Operator):
 
     def resolve_input(self, ctx):
         inputs = types.Object()
-        sample_ids = ctx.selected
-        count = len(sample_ids)
-        header = "Clone sample"
+
+        count = len(ctx.selected)
         if count > 0:
             sample_text = "sample" if count == 1 else "samples"
-            header = f"Clone {count} {sample_text}?"
             inputs.str(
                 "msg",
-                label=f"Press 'Execute' to clone {count} selected {sample_text}",
-                view=types.Notice(space=6),
-            )
-            inputs.str(
-                "btn",
-                label="Show selected samples",
-                view=types.Button(operator="show_selected_samples", space=3),
+                label=f"Clone {count} selected {sample_text}?",
+                view=types.Warning(),
             )
         else:
-            header = "No selected samples"
             inputs.str(
                 "msg",
                 label="You must select samples in the grid to clone",
                 view=types.Warning(),
             )
 
-        return types.Property(inputs, view=types.View(label=header))
+        view = types.View(label="Clone selected samples")
+        return types.Property(inputs, view=view)
 
     def execute(self, ctx):
-        sample_ids = ctx.selected
-        if len(sample_ids) > 0:
-            samples = ctx.dataset.select(sample_ids)
-            cloned_samples = [
-                fo.Sample.from_dict(dict(**sample.to_dict(), id=None))
-                for sample in samples
-            ]
-            ctx.dataset.add_samples(cloned_samples)
-            ctx.trigger("reload_samples")
-            ctx.trigger(
-                "show_samples",
-                {"samples": [sample.id for sample in cloned_samples]},
-            )
+        if not ctx.selected:
+            return
+
+        samples = ctx.dataset.select(ctx.selected)
+        sample_ids = ctx.dataset.add_collection(samples, new_ids=True)
+
+        ctx.trigger("clear_selected_samples")
+        ctx.trigger("reload_samples")
+        ctx.trigger("show_samples", {"samples": sample_ids})
 
 
 class CloneSampleField(foo.Operator):
@@ -232,31 +221,24 @@ class DeleteSelectedSamples(foo.Operator):
 
     def resolve_input(self, ctx):
         inputs = types.Object()
-        sample_ids = ctx.selected
-        count = len(sample_ids)
-        header = "Delete samples"
+
+        count = len(ctx.selected)
         if count > 0:
             sample_text = "sample" if count == 1 else "samples"
-            header = f"Delete {count} {sample_text}?"
             inputs.str(
                 "msg",
-                label=f"Press 'Execute' to delete {count} selected {sample_text}",
-                view=types.Notice(space=6),
-            )
-            inputs.str(
-                "btn",
-                label="Show selected samples",
-                view=types.Button(operator="show_selected_samples", space=3),
+                label=f"Delete {count} selected {sample_text}s?",
+                view=types.Warning(),
             )
         else:
-            header = "No selected samples"
             inputs.str(
                 "msg",
                 label="You must select samples in the grid to delete",
                 view=types.Warning(),
             )
 
-        return types.Property(inputs, view=types.View(label=header))
+        view = types.View(label="Delete selected samples")
+        return types.Property(inputs, view=view)
 
     def execute(self, ctx):
         num_samples = len(ctx.selected)


### PR DESCRIPTION
Simplifies the interface of the builtin `clone_selected_samples` and `delete_selected_samples` operators:
- Removes the `Show selected samples` buttons, which didn't look good layout-wise. Also this is already possible by clicking the bookmark icon in the actions row
- Cleans up the UI copy
- Optimizes the implementation of cloning samples

Also fixes the builtin `set_selected_samples` and `show_samples` thanks to @imanjra merging https://github.com/voxel51/fiftyone/pull/3818 into this PR 🎉  

