### PR TITLE
fix select/show samples built-in operator

### DIFF
--- a/app/packages/operators/src/built-in-operators.ts
+++ b/app/packages/operators/src/built-in-operators.ts
@@ -456,7 +456,10 @@ class SetSelectedSamples extends Operator {
     };
   }
   async execute({ hooks, params }: ExecutionContext) {
-    hooks.setSelected(params.samples);
+    const { samples } = params || {};
+    if (!Array.isArray(samples))
+      throw new Error("param 'samples' must be an array of string");
+    hooks.setSelected(new Set(samples));
   }
 }
 
@@ -539,7 +542,7 @@ class ShowSamples extends Operator {
           ]
         : []),
     ];
-    hooks.setView(fos.view, newView);
+    hooks.setView(newView);
   }
 }
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

Fixes built-in operators `set_selected_samples` and `show_samples`

## How is this patch tested? If it is not, please explain why.

Tested using an example operator which trigger both of these operators using ctx.trigger

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
