### PR TITLE
fiftyone-db 1.0

### DIFF
--- a/package/db/setup.py
+++ b/package/db/setup.py
@@ -149,6 +149,12 @@ class CustomBdistWheel(bdist_wheel):
         return impl, abi_tag, self.plat_name
 
     def write_wheelfile(self, *args, **kwargs):
+        try:
+            self._write_wheelfile(*args, **kwargs)
+        except:
+            pass
+
+    def _write_wheelfile(self, *args, **kwargs):
         bdist_wheel.write_wheelfile(self, *args, **kwargs)
         bin_dir = os.path.join(
             self.bdist_dir, self.data_dir, "purelib", "fiftyone", "db", "bin"

--- a/package/db/setup.py
+++ b/package/db/setup.py
@@ -104,7 +104,7 @@ def _get_download():
 # mongodb binaries to distribute
 MONGODB_BINARIES = ["mongod"]
 
-VERSION = "0.4.1"
+VERSION = "1.0"
 
 
 def get_version():


### PR DESCRIPTION
For v0.23.0, I propose we bump the `fiftyone-db`package to 1.0 to indicate general support for Linux distributions