### PR TITLE
fix: #3815 remove cvat filename prefixing

### DIFF
--- a/fiftyone/utils/cvat.py
+++ b/fiftyone/utils/cvat.py
@@ -4233,6 +4233,9 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
 
         files, open_files = self._parse_local_files(paths)
 
+        if self._server_version >= Version("2.4.6"):
+            data["sorting_method"] = "predefined"
+
         try:
             self.post(self.task_data_url(task_id), data=data, files=files)
         except Exception as e:
@@ -4294,10 +4297,12 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
         else:
             # Image task
             for idx, path in enumerate(paths):
-                # IMPORTANT: CVAT organizes media within a task alphabetically
-                # by filename, so we must give CVAT filenames whose
-                # alphabetical order matches the order of `paths`
-                filename = "%06d_%s" % (idx, os.path.basename(path))
+                filename = os.path.basename(path)
+                if self._server_version < Version("2.4.6"):
+                    # IMPORTANT: older versions of CVAT organizes media within
+                    # a task alphabetically by filename, so we must give CVAT
+                    # filenames whose alphabetical order matches the order of `paths`
+                    filename = "%06d_%s" % (idx, os.path.basename(path))
 
                 if self._server_version >= Version("2.3"):
                     with open(path, "rb") as f:


### PR DESCRIPTION
Resolves #3815

keeping old behavior for cvat versions < 2.4.6 because of cvat bug fix https://github.com/opencv/cvat/pull/5083

Change-Id: I542695437c05c09bb48023d598af479965abb384

## What changes are proposed in this pull request?

For cvat server versions >= 2.4.6
- remove the sequence prefix added to maintain the lexographical order of older cvat versions.

## How is this patch tested? If it is not, please explain why.

Verified on our local cvat instance before and after patch

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

Solves issue #3815 addressing filename prefixing of cvat samples.

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
