### PR TITLE
Add PIL image rotation according to exif info (PR 3779 alt)

### DIFF
--- a/fiftyone/core/metadata.py
+++ b/fiftyone/core/metadata.py
@@ -10,7 +10,7 @@ import logging
 import os
 import requests
 
-from PIL import Image, ImageOps
+from PIL import ExifTags, Image
 
 import eta.core.utils as etau
 import eta.core.video as etav
@@ -273,6 +273,30 @@ def compute_metadata(
             raise ValueError(msg)
 
 
+def _image_has_flipped_dimensions(img):
+    """Returns True if image has flipped width/height dimensions
+
+    EXIF Orientation metadata can specify that an image be rotated or otherwise
+    transposed. ``PIL.Image`` does not handle this by default so we have to
+    inspect the EXIF info. See ``PIL.ImageOps.exif_transpose()`` for the basis
+    of this function, except we don't actually want to transpose the image
+    when we only need the dimensions.
+
+    Tag name reference: https://exiftool.org/TagNames/EXIF.html
+    PIL.ImageOps reference: https://github.com/python-pillow/Pillow/blob/main/src/PIL/ImageOps.py
+
+    Args:
+        img: a ``PIL.Image``
+
+    Returns:
+        True if image width/height should be flipped
+    """
+    exif_orientation = img.getexif().get(ExifTags.Base.Orientation)
+    # 5, 6, 7, 8 --> TRANSPOSE, ROTATE_270, TRANSVERSE, ROTATE_90
+    is_rotated = exif_orientation in {5, 6, 7, 8}
+    return is_rotated
+
+
 def get_image_info(f):
     """Retrieves the dimensions and number of channels of the given image from
     a file-like object that is streaming its contents.
@@ -284,9 +308,15 @@ def get_image_info(f):
         ``(width, height, num_channels)``
     """
     img = Image.open(f)
-    if 'exif' in img.info:
-        img = ImageOps.exif_transpose(img)
-    return (img.width, img.height, len(img.getbands()))
+
+    # Flip the dimensions if image metadata requires us to. PIL.Image doesn't
+    #   handle by default.
+    if _image_has_flipped_dimensions(img):
+        width, height = img.height, img.width
+    else:
+        width, height = img.width, img.height
+
+    return width, height, len(img.getbands())
 
 
 def _compute_metadata(sample_collection, overwrite=False):

--- a/fiftyone/core/metadata.py
+++ b/fiftyone/core/metadata.py
@@ -283,7 +283,9 @@ def get_image_info(f):
     Returns:
         ``(width, height, num_channels)``
     """
-    img = ImageOps.exif_transpose(Image.open(f))
+    img = Image.open(f)
+    if 'exif' in img.info:
+        img = ImageOps.exif_transpose(img)
     return (img.width, img.height, len(img.getbands()))
 
 

--- a/fiftyone/core/metadata.py
+++ b/fiftyone/core/metadata.py
@@ -10,7 +10,7 @@ import logging
 import os
 import requests
 
-from PIL import Image
+from PIL import Image, ImageOps
 
 import eta.core.utils as etau
 import eta.core.video as etav
@@ -283,7 +283,7 @@ def get_image_info(f):
     Returns:
         ``(width, height, num_channels)``
     """
-    img = Image.open(f)
+    img = ImageOps.exif_transpose(Image.open(f))
     return (img.width, img.height, len(img.getbands()))
 
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

Introduce exif orientation support when importing images into a dataset - see https://github.com/voxel51/fiftyone/issues/3778

## How is this patch tested? If it is not, please explain why.

Tested on the code posted in the Issue linked above.

Before the fix image dimensions are flipped and annotation is displayed in the wrong position:
<img width="955" alt="image" src="https://github.com/voxel51/fiftyone/assets/33780601/3c170e30-c313-430c-b2d9-5e809141a941">

After the fix dimensions are correct and annotation is displayed in the correct position:
<img width="957" alt="image" src="https://github.com/voxel51/fiftyone/assets/33780601/b5b6af46-33db-460a-ada8-76b8f00163a5">


## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?


-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
