### PR TITLE
[Fix] fixes the segmentation source key in embedded document

### DIFF
--- a/app/packages/looker/src/worker/index.ts
+++ b/app/packages/looker/src/worker/index.ts
@@ -214,7 +214,7 @@ const processLabels = async (
 
       if (DENSE_LABELS.has(label._cls)) {
         await imputeOverlayFromPath(
-          field,
+          `${prefix || ""}${field}`,
           label,
           coloring,
           customizeColorSetting,


### PR DESCRIPTION
## What changes are proposed in this pull request?

segmentation masks in a dynamic embedded document is not renderable (I believe a recent regression).
The sources map where the mask's path is picked up is expecting a full path as a key. for example `embedded_document.segmentation` instead of `segmentation`. 

## How is this patch tested? If it is not, please explain why.

create a dataset with top level segmentation mask and a nested segmentation mask within an embedded doc.
```
import fiftyone as fo
import fiftyone.zoo as foz

dataset = foz.load_zoo_dataset("quickstart", dataset_name="seg-embed-3", max_samples=1)
dataset.persistent = True # optional

sample = dataset.first()

# segmentation top level
sample["top_level_mask"] = fo.Segmentation(mask_path="/tmp/mask.png")

# segmentation within an embedded document
sample["filepath_mask_embed"] = fo.DynamicEmbeddedDocument(seg=fo.Segmentation(mask_path="/tmp/mask.png"))

sample.save()
dataset.add_dynamic_sample_fields()
```

before

https://github.com/voxel51/fiftyone/assets/109545780/cbfab846-3a99-4f10-9a14-450acd5a672f

After

https://github.com/voxel51/fiftyone/assets/109545780/a71aae82-8df2-4b75-97c6-42f5f8fc724b




## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
