### PR TITLE
[WIP] Allow reloading database connection

### DIFF
--- a/fiftyone/__public__.py
+++ b/fiftyone/__public__.py
@@ -6,12 +6,39 @@ FiftyOne's public interface.
 |
 """
 
-import fiftyone.core.config as _foc
+config = None
+annotation_config = None
+evaluation_config = None
+app_config = None
 
-config = _foc.load_config()
-annotation_config = _foc.load_annotation_config()
-evaluation_config = _foc.load_evaluation_config()
-app_config = _foc.load_app_config()
+
+def reload(hard=False):
+    """Reloads the current database connection.
+
+    Args:
+        hard (False): whether to reconnect using the current in-memory config
+            values (False) or reload configs from environment variables (True)
+    """
+    global config
+    global annotation_config
+    global evaluation_config
+    global app_config
+
+    import fiftyone.core.config as foc
+    import fiftyone.core.odm as foo
+
+    if hard:
+        config = foc.load_config()
+        annotation_config = foc.load_annotation_config()
+        evaluation_config = foc.load_evaluation_config()
+        app_config = foc.load_app_config()
+
+    foo.disconnect_db()
+    foo.establish_db_conn(config)
+
+
+reload(hard=True)
+
 
 from .core.aggregations import (
     Aggregation,

--- a/fiftyone/core/odm/__init__.py
+++ b/fiftyone/core/odm/__init__.py
@@ -11,6 +11,7 @@ from .database import (
     aggregate,
     get_db_config,
     establish_db_conn,
+    disconnect_db,
     get_db_client,
     get_db_conn,
     get_async_db_client,


### PR DESCRIPTION
Marked as draft for discussion.

Inspired by a Slack community question, I wanted to see what it would look like to allow changing databases mid-Python session by calling a `fo.reload()` method.

I believe this PR is fully functional for programmatic usage, but there are a couple snags when using the App:
- The App runs in a subprocess which currently re-reads its `fo.config` from environment variables, so you have to change database via `os.environ` rather than just editing `fo.config` in order for `launch_app()` to work after the database change in the example below
- If I `launch_app()` before _and_ after the database change, the second App does not connect to the new database

```py
import os
import fiftyone as fo
import fiftyone.zoo as foz

# do stuff with default database
print(fo.list_datasets())

#
# Change database
#

"""
os.environ["FIFTYONE_DATABASE_URI"] = "mongodb://localhost:12345"
os.environ["FIFTYONE_DATABASE_DIR"] = "/path/to/new/db"
fo.reload(hard=True)
"""

fo.config.database_uri = "mongodb://localhost:12345"
fo.config.database_dir = "/path/to/new/db"
fo.reload()

# do stuff with new database
print(fo.list_datasets())
dataset = foz.load_zoo_dataset("quickstart")

# Only works with `fo.reload(hard=True)` since subprocess reads config from env vars
session = fo.launch_app(dataset)
```
