### PR TITLE
use get_db_conn instead of get_db_client

### DIFF
--- a/fiftyone/factory/repo_factory.py
+++ b/fiftyone/factory/repo_factory.py
@@ -15,9 +15,7 @@ from fiftyone.factory.repos.delegated_operation import (
     MongoDelegatedOperationRepo,
 )
 
-
-db_client: pymongo.mongo_client.MongoClient = foo.get_db_client()
-db: Database = db_client[fo.config.database_name]
+db: Database = foo.get_db_conn()
 
 
 class RepositoryFactory(object):

--- a/fiftyone/factory/repos/delegated_operation.py
+++ b/fiftyone/factory/repos/delegated_operation.py
@@ -8,8 +8,8 @@ FiftyOne delegated operation repository.
 from datetime import datetime
 from typing import Any, List
 
-from bson import ObjectId
 import pymongo
+from bson import ObjectId
 from pymongo import IndexModel
 from pymongo.collection import Collection
 
@@ -17,9 +17,9 @@ import fiftyone.core.dataset as fod
 from fiftyone.factory import DelegatedOperationPagingParams
 from fiftyone.factory.repos import DelegatedOperationDocument
 from fiftyone.operators.executor import (
+    ExecutionProgress,
     ExecutionResult,
     ExecutionRunState,
-    ExecutionProgress,
 )
 
 
@@ -117,11 +117,10 @@ class MongoDelegatedOperationRepo(DelegatedOperationRepo):
         self._create_indexes()
 
     def _get_collection(self) -> Collection:
-        import fiftyone.core.odm as foo
         import fiftyone as fo
+        import fiftyone.core.odm as foo
 
-        db_client: pymongo.mongo_client.MongoClient = foo.get_db_client()
-        database = db_client[fo.config.database_name]
+        database: pymongo.database.Database = foo.get_db_conn()
         return database[self.COLLECTION_NAME]
 
     def _create_indexes(self):


### PR DESCRIPTION
## What changes are proposed in this pull request?

use get_db_conn instead of get_db_client

## How is this patch tested? If it is not, please explain why.

via unit tests

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [X] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
