### PR TITLE
bump `develop` version for next minor release

### DIFF
--- a/package/desktop/setup.py
+++ b/package/desktop/setup.py
@@ -16,7 +16,7 @@ import os
 import shutil
 
 
-VERSION = "0.32.0"
+VERSION = "0.34.0"
 
 
 def get_version():

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ import re
 from setuptools import setup, find_packages
 
 
-VERSION = "0.23.0"
+VERSION = "0.24.0"
 
 
 def get_version():


### PR DESCRIPTION
Now that the `release` branches have been thrown, work for this branche should be towards the next minor release