### PR TITLE
fix OperatorIO crash and changed field re-render

### DIFF
--- a/app/packages/core/src/plugins/SchemaIO/components/AutocompleteView.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/AutocompleteView.tsx
@@ -47,6 +47,7 @@ export default function AutocompleteView(props) {
         onInputChange={(e) => {
           if (!multiple && e) {
             onChange(path, e.target.value);
+            setUserChanged();
           }
         }}
         isOptionEqualToValue={() => false} // allow duplicates

--- a/app/packages/core/src/plugins/SchemaIO/index.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/index.tsx
@@ -1,31 +1,28 @@
 import { PluginComponentType, registerComponent } from "@fiftyone/plugins";
 import { cloneDeep, set } from "lodash";
-import React, { useCallback, useEffect, useRef, useState } from "react";
+import React, { useCallback, useEffect, useRef } from "react";
 import DynamicIO from "./components/DynamicIO";
 import { clearUseKeyStores } from "./hooks";
 
 export function SchemaIOComponent(props) {
   const { onChange } = props;
-  const [state, setState] = useState({});
+  const stateRef = useRef({});
   const autoFocused = useRef(false);
 
   useEffect(() => {
-    clearUseKeyStores();
+    return clearUseKeyStores;
   }, []);
-
-  useEffect(() => {
-    if (onChange) onChange(state);
-  }, [onChange, state]);
 
   const onIOChange = useCallback(
     (path, value) => {
-      setState((state) => {
-        const updatedState = cloneDeep(state);
-        set(updatedState, path, cloneDeep(value));
-        return updatedState;
-      });
+      const currentState = stateRef.current;
+      const updatedState = cloneDeep(currentState);
+      set(updatedState, path, cloneDeep(value));
+      stateRef.current = updatedState;
+      onChange(updatedState);
+      return updatedState;
     },
-    [setState]
+    [onChange]
   );
 
   return (


### PR DESCRIPTION
## What changes are proposed in this pull request?

- Fixes an issue where OperatorIO crashes every now and then due to infinite re-render
- Fixes an issue where AutocompleteView is re-rendered even when modified by the user

## How is this patch tested? If it is not, please explain why.

Using some test operators

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
