### PR TITLE
Update to read intensity and visualization

### DIFF
--- a/app/packages/looker-3d/package.json
+++ b/app/packages/looker-3d/package.json
@@ -21,7 +21,7 @@
         "lodash": "^4.17.21",
         "react-color": "^2.19.3",
         "styled-components": "^5.3.5",
-        "three": "^0.141.0"
+        "three": "^0.143.0"
     },
     "devDependencies": {
         "@types/node": "^18.0.3",

--- a/app/packages/looker-3d/src/renderables/pointcloud/index.tsx
+++ b/app/packages/looker-3d/src/renderables/pointcloud/index.tsx
@@ -66,6 +66,8 @@ export const PointCloudMesh = ({
     max: 1,
   });
 
+  const [useIntensity, setUseIntensity] = useState(false);
+
   const pointsGeometry = points.geometry;
 
   const boundingBox = useMemo(() => {
@@ -81,8 +83,13 @@ export const PointCloudMesh = ({
     onLoad(boundingBox);
 
     const colorAttribute = pointsGeometry.getAttribute("color");
+    const intensityAttribute = pointsGeometry.getAttribute("intensity");
 
-    if (colorAttribute) {
+    setUseIntensity(!!intensityAttribute);
+    if (intensityAttribute) {
+      setColorMinMax(computeMinMaxForColorBufferAttribute(intensityAttribute));
+    }
+    if (colorAttribute && !intensityAttribute) {
       setColorMinMax(computeMinMaxForColorBufferAttribute(colorAttribute));
     }
   }, [boundingBox, pointsGeometry, points, onLoad]);
@@ -113,6 +120,7 @@ export const PointCloudMesh = ({
             gradients={ShadingGradients}
             pointSize={pointSizeNum}
             isPointSizeAttenuated={isPointSizeAttenuated}
+            useIntensity={useIntensity}
           />
         );
 

--- a/app/packages/looker-3d/src/renderables/pointcloud/shaders.tsx
+++ b/app/packages/looker-3d/src/renderables/pointcloud/shaders.tsx
@@ -9,6 +9,7 @@ export type ShaderProps = {
   max: number;
   pointSize: number;
   isPointSizeAttenuated: boolean;
+  useIntensity: boolean;
 };
 
 const useGradientMap = (gradients: Gradients) => {
@@ -120,9 +121,11 @@ const ShadeByIntensityShaders = {
   uniform float min;
   uniform float pointSize;
   uniform bool isPointSizeAttenuated;
+  uniform bool useIntensity;
 
   varying vec2 vUv;
   varying float hValue;
+  attribute float intensity;
   attribute vec3 color;
 
   float remap ( float minval, float maxval, float curval ) {
@@ -132,7 +135,8 @@ const ShadeByIntensityShaders = {
   void main() {
     vUv = uv;
     vec3 pos = position;
-    hValue = remap(min, max, color.r);
+    float effectiveIntensity = useIntensity ? intensity : color.r;
+    hValue = remap(min, max, effectiveIntensity);
 
     vec4 mvPosition = modelViewMatrix * vec4(pos, 1.0);
 
@@ -210,6 +214,7 @@ export const ShadeByIntensity = ({
   max,
   pointSize,
   isPointSizeAttenuated,
+  useIntensity,
 }: ShaderProps) => {
   const gradientMap = useGradientMap(gradients);
 
@@ -222,6 +227,7 @@ export const ShadeByIntensity = ({
           gradientMap: { value: gradientMap },
           pointSize: { value: pointSize },
           isPointSizeAttenuated: { value: isPointSizeAttenuated },
+          useIntensity: { value: useIntensity },
         },
         vertexShader: ShadeByIntensityShaders.vertexShader,
         fragmentShader: ShadeByIntensityShaders.fragmentShader,

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -2718,7 +2718,7 @@ __metadata:
     react-color: ^2.19.3
     rollup-plugin-external-globals: ^0.6.1
     styled-components: ^5.3.5
-    three: ^0.141.0
+    three: ^0.143.0
     typescript: ^4.6.3
     vite: ^3.2.7
     vite-plugin-externals: ^0.5.0
@@ -20202,10 +20202,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"three@npm:^0.141.0":
-  version: 0.141.0
-  resolution: "three@npm:0.141.0"
-  checksum: d161350b5134f2db616c7081d625c84235a1d50658b9f9c6ffe94143ddb77944b1c1b6831ad0be00037f8c744c8c60ee8d740ea4d48844b54f4525ee73a2d44f
+"three@npm:^0.143.0":
+  version: 0.143.0
+  resolution: "three@npm:0.143.0"
+  checksum: 6fe8793a04a931c8fb86bad566ac4310a6243c9e9139678b5084e0773457a63fe254109479c4d4a2b484812d0932940eabf9baa21749c8c8d8dceb2815ca747b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

1. update three to support `intensity` field parse in pcd
2. Determine if `intensity` field exists, if not then use `color.r` for _ShadeByIntensity_

## How is this patch tested? If it is not, please explain why.
test local with pcd file which has `intensity` field
```
# .PCD v0.7 - Point Cloud Data file format
VERSION 0.7
FIELDS x y z intensity timestamp ring
SIZE 4 4 4 4 8 2
TYPE F F F F F U
COUNT 1 1 1 1 1 1
WIDTH 201191
HEIGHT 1
VIEWPOINT 0 0 0 1 0 0 0
POINTS 201191
DATA binary_compressed
```

![image](https://github.com/voxel51/fiftyone/assets/23700932/0cf1c6a3-3ebe-426c-b2bf-d886c4dc5a82)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

There is almost no impact on existing users, if pcd doesn't have an intensity field it will continue to use color.r for rendering, maybe the documentation section needs to be updated a bit

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
