### PR TITLE
[Draft] reload dataset if view not loadable

### DIFF
--- a/fiftyone/core/state.py
+++ b/fiftyone/core/state.py
@@ -161,7 +161,12 @@ class StateDescription(etas.Serializable):
         view_name = d.get("view_name", None)
         if dataset is not None:
             if view_name:
-                view = dataset.load_saved_view(view_name)
+                try:
+                    view = dataset.load_saved_view(view_name)
+                except Exception as e:
+                    dataset.reload()
+                    view = dataset.load_saved_view(view_name)
+
             elif stages:
                 try:
                     view = fov.DatasetView._build(dataset, stages)


### PR DESCRIPTION
## What changes are proposed in this pull request?

Potential fix:
After dataset.reload() change in the pr, the view is successfully loaded.

## How is this patch tested? If it is not, please explain why.
```
import fiftyone as fo
import fiftyone.zoo as foz

dataset = foz.load_zoo_dataset("quickstart")
session = fo.launch_app(dataset)
```
In App
```
- Save view as `test`
```
In terminal
- See the crash
```
Traceback (most recent call last):
  File "/Users/maniaskari/opt/anaconda3/envs/conda-oss-3.9.16/lib/python3.9/threading.py", line 980, in _bootstrap_inner
    self.run()
  File "/Users/maniaskari/opt/anaconda3/envs/conda-oss-3.9.16/lib/python3.9/threading.py", line 917, in run
    self._target(*self._args, **self._kwargs)
  File "/Users/maniaskari/code/fiftyone/fiftyone/core/session/client.py", line 120, in run_client
    raise e
  File "/Users/maniaskari/code/fiftyone/fiftyone/core/session/client.py", line 117, in run_client
    subscribe()
  File "/Users/maniaskari/code/fiftyone/fiftyone/core/session/client.py", line 110, in subscribe
    event = Event.from_data(message.event, message.data)
  File "/Users/maniaskari/code/fiftyone/fiftyone/core/session/events.py", line 67, in from_data
    data["state"] = fos.StateDescription.from_dict(data["state"])
  File "/Users/maniaskari/code/fiftyone/fiftyone/core/state.py", line 164, in from_dict
    print("view_name", view_name)
  File "/Users/maniaskari/code/fiftyone/fiftyone/core/dataset.py", line 3583, in load_saved_view
    view_doc = self._get_saved_view_doc(name)
  File "/Users/maniaskari/code/fiftyone/fiftyone/core/dataset.py", line 3632, in _get_saved_view_doc
    raise ValueError("Dataset has no saved view '%s'" % name)
ValueError: Dataset has no saved view 'test'
```
 
## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
