### PR TITLE
fix SchemaIO exception when onChange is missing

### DIFF
--- a/app/packages/core/src/plugins/SchemaIO/index.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/index.tsx
@@ -19,7 +19,7 @@ export function SchemaIOComponent(props) {
       const updatedState = cloneDeep(currentState);
       set(updatedState, path, cloneDeep(value));
       stateRef.current = updatedState;
-      onChange(updatedState);
+      if (onChange) onChange(updatedState);
       return updatedState;
     },
     [onChange]


### PR DESCRIPTION
## What changes are proposed in this pull request?

Fixes an exception in SchemaIO when onChange is not provided. Regressed in https://github.com/voxel51/fiftyone/pull/3833

## How is this patch tested? If it is not, please explain why.

Using OperatorIO debugging panel

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
