### PR TITLE
Set color scheme tweaks

### DIFF
--- a/app/packages/app/src/useSetters/onSetColorScheme.ts
+++ b/app/packages/app/src/useSetters/onSetColorScheme.ts
@@ -5,11 +5,10 @@ import {
   setColorScheme,
   setColorSchemeMutation,
 } from "@fiftyone/relay";
-import { ensureColorScheme } from "@fiftyone/state";
+import { ensureColorScheme, removeRgbProperty } from "@fiftyone/state";
 import { DefaultValue } from "recoil";
 import { commitMutation } from "relay-runtime";
 import { RegisteredSetter } from "./registerSetter";
-import { cloneDeep } from "lodash";
 
 const onSetColorScheme: RegisteredSetter =
   ({ environment, setter, subscription }) =>
@@ -41,26 +40,3 @@ const onSetColorScheme: RegisteredSetter =
   };
 
 export default onSetColorScheme;
-
-export function removeRgbProperty(input) {
-  // Clone the input to avoid mutating the original object
-  const clonedInput = cloneDeep(input);
-
-  // Process the 'colorscales' array
-  if (clonedInput.colorscales && Array.isArray(clonedInput.colorscales)) {
-    clonedInput.colorscales = clonedInput.colorscales.map(
-      ({ rgb, ...rest }) => rest
-    );
-  }
-
-  // Process the 'defaultColorscale' object
-  if (
-    clonedInput.defaultColorscale &&
-    typeof clonedInput.defaultColorscale === "object"
-  ) {
-    const { rgb, ...rest } = clonedInput.defaultColorscale;
-    clonedInput.defaultColorscale = rest;
-  }
-
-  return clonedInput;
-}

--- a/app/packages/state/src/recoil/color.ts
+++ b/app/packages/state/src/recoil/color.ts
@@ -25,6 +25,7 @@ import { configData } from "./config";
 import * as schemaAtoms from "./schema";
 import * as selectors from "./selectors";
 import { PathEntry, sidebarEntries } from "./sidebar";
+import { cloneDeep } from "lodash";
 
 export const datasetColorScheme = graphQLSyncFragmentAtom<
   colorSchemeFragment$key,
@@ -176,3 +177,26 @@ export const ensureColorScheme = (
         : appConfig?.showSkeletons ?? true,
   };
 };
+
+export function removeRgbProperty(input) {
+  // Clone the input to avoid mutating the original object
+  const clonedInput = cloneDeep(input);
+
+  // Process the 'colorscales' array
+  if (clonedInput.colorscales && Array.isArray(clonedInput.colorscales)) {
+    clonedInput.colorscales = clonedInput.colorscales.map(
+      ({ rgb, ...rest }) => rest
+    );
+  }
+
+  // Process the 'defaultColorscale' object
+  if (
+    clonedInput.defaultColorscale &&
+    typeof clonedInput.defaultColorscale === "object"
+  ) {
+    const { rgb, ...rest } = clonedInput.defaultColorscale;
+    clonedInput.defaultColorscale = rest;
+  }
+
+  return clonedInput;
+}

--- a/fiftyone/server/color.py
+++ b/fiftyone/server/color.py
@@ -176,6 +176,9 @@ class SetColorScheme:
         subscription: str,
         color_scheme: ColorSchemeInput,
     ) -> ColorScheme:
+        if color_scheme.id is None:
+            color_scheme.id = str(ObjectId())
+
         state = get_state()
         state.color_scheme = _to_odm_color_scheme(color_scheme)
         await dispatch_event(

--- a/package/desktop/setup.py
+++ b/package/desktop/setup.py
@@ -16,7 +16,7 @@ import os
 import shutil
 
 
-VERSION = "0.32.0"
+VERSION = "0.33.0"
 
 
 def get_version():

--- a/setup.py
+++ b/setup.py
@@ -114,7 +114,7 @@ def get_install_requirements(install_requires, choose_install_requires):
     return install_requires
 
 
-EXTRAS_REQUIREMENTS = {"desktop": ["fiftyone-desktop~=0.32"]}
+EXTRAS_REQUIREMENTS = {"desktop": ["fiftyone-desktop~=0.33"]}
 
 with open("README.md", "r") as fh:
     long_description = fh.read()


### PR DESCRIPTION
Moves `removeRgbProperty` to `@fiftyone/state` for reuse, and ensures an color scheme `id` in the `setColorScheme` mutation

handle scenarios that `ensureColorscheme` takes `null` as the first argument. 