### PR TITLE
[WIP] Secrets interface cleanup

### DIFF
--- a/fiftyone/internal/__init__.py
+++ b/fiftyone/internal/__init__.py
@@ -5,5 +5,3 @@ Internal classes and utilities.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
-
-from .secrets import *

--- a/fiftyone/operators/executor.py
+++ b/fiftyone/operators/executor.py
@@ -422,7 +422,7 @@ class ExecutionContext(object):
         self._secrets = None
         self._resolved_secrets = False
 
-        if operator.has_secrets:
+        if operator is not None and operator.has_secrets:
             self._secrets_client = PluginSecretsResolver()
             self._secrets_client.register_operator(
                 operator_uri=operator.uri, secrets=operator.secrets
@@ -551,7 +551,7 @@ class ExecutionContext(object):
 
         self._resolved_secrets = True
 
-        if not self.operator.has_secrets:
+        if self.operator is None or not self.operator.has_secrets:
             return
 
         self._secrets_dict.clear()
@@ -568,7 +568,7 @@ class ExecutionContext(object):
 
         self._resolved_secrets = True
 
-        if not self.operator.has_secrets:
+        if self.operator is None or not self.operator.has_secrets:
             return
 
         self._secrets_dict.clear()

--- a/fiftyone/operators/operator.py
+++ b/fiftyone/operators/operator.py
@@ -120,12 +120,13 @@ class Operator(object):
         # Plugin names are populated when the operators are registered
         plugin_name = BUILTIN_OPERATOR_PREFIX if _builtin else None
 
-        self._builtin = _builtin
-        self._plugin_secrets = None
         self.plugin_name = plugin_name
         self.definition = Object()
         self.definition.define_property("inputs", Object())
         self.definition.define_property("outputs", Object())
+
+        self._builtin = _builtin
+        self._secrets = None
 
     @property
     def name(self):
@@ -147,6 +148,27 @@ class Operator(object):
     def config(self):
         """The :class:`OperatorConfig` for the operator."""
         raise NotImplementedError("subclass must implement config")
+
+    @property
+    def has_secrets(self):
+        """Whther this operator has any secrets registered."""
+        return bool(self._secrets)
+
+    @property
+    def secrets(self):
+        """The list of secrets known to the operator, or None."""
+        return self._secrets
+
+    def register_secrets(self, secrets):
+        """Registers the given secrets on the operator.
+
+        Args:
+            secrets: a list of secrets
+        """
+        if self._secrets is None:
+            self._secrets = []
+
+        self._secrets.extend(secrets)
 
     def resolve_definition(self, resolve_dynamic, ctx):
         """Returns a resolved definition of the operator.
@@ -335,13 +357,3 @@ class Operator(object):
             "_builtin": self._builtin,
             "uri": self.uri,
         }
-
-    def add_secrets(self, secrets):
-        """Adds secrets to the operator.
-
-        Args:
-            secrets: a list of secrets
-        """
-        if not self._plugin_secrets:
-            self._plugin_secrets = []
-        self._plugin_secrets.extend(secrets)

--- a/fiftyone/operators/server.py
+++ b/fiftyone/operators/server.py
@@ -34,11 +34,7 @@ class ListOperators(HTTPEndpoint):
         )
         operators_as_json = []
         for operator in registry.list_operators():
-
-            ctx = ExecutionContext(
-                operator_uri=operator.uri,
-                required_secrets=operator._plugin_secrets,
-            )
+            ctx = ExecutionContext(operator=operator)
             serialized_op = operator.to_json(ctx)
             config = serialized_op["config"]
             config["can_execute"] = registry.can_execute(serialized_op["uri"])

--- a/fiftyone/plugins/__init__.py
+++ b/fiftyone/plugins/__init__.py
@@ -26,7 +26,6 @@ from .core import (
 )
 from .definitions import PluginDefinition
 from .context import PluginContext
-from .secrets import PluginSecretsResolver
 
 # This enables Sphinx refs to directly use paths imported here
 __all__ = [

--- a/fiftyone/plugins/context.py
+++ b/fiftyone/plugins/context.py
@@ -103,7 +103,8 @@ class PluginContext(object):
             if self.can_register(instance):
                 instance.plugin_name = self.name
                 if self.secrets:
-                    instance.add_secrets(self.secrets)
+                    instance.register_secrets(self.secrets)
+
                 self.instances.append(instance)
         except:
             logger.warning(

--- a/fiftyone/plugins/secrets.py
+++ b/fiftyone/plugins/secrets.py
@@ -63,8 +63,7 @@ class PluginSecretsResolver(object):
             return None
 
         # pylint: disable=no-member
-        resolved_secret = await self.client.get(key, **kwargs)
-        return resolved_secret
+        return await self.client.get(key, **kwargs)
 
     def get_secret_sync(self, key, operator_uri, **kwargs):
         """Gets the value of a secret.

--- a/fiftyone/plugins/secrets.py
+++ b/fiftyone/plugins/secrets.py
@@ -5,6 +5,7 @@ Plugin secrets resolver.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+from collections.abc import Mapping
 import logging
 import traceback
 import typing
@@ -13,9 +14,11 @@ from typing import Optional
 from ..internal import secrets as fois
 
 
-class PluginSecretsResolver:
-    """Injects secrets from environmental variables into the execution
-    context."""
+logger = logging.getLogger(__name__)
+
+
+class PluginSecretsResolver(object):
+    """Injects secrets into the execution context."""
 
     _instance = None
     _registered_secrets = {}
@@ -26,72 +29,69 @@ class PluginSecretsResolver:
             cls._instance.client = _get_secrets_client()
         return cls._instance
 
-    def register_operator(
-        self, operator_uri: str, required_secrets: typing.List[str]
-    ) -> None:
-        self._registered_secrets[operator_uri] = required_secrets
+    def register_operator(self, operator_uri, secrets):
+        self._registered_secrets[operator_uri] = secrets
 
-    def client(self) -> fois.ISecretProvider:
+    def client(self):
         if not self._instance:
             self._instance = self.__new__(self.__class__)
         return self._instance.client
 
-    async def get_secret(
-        self, key: str, operator_uri: str, **kwargs
-    ) -> Optional[fois.ISecret]:
-        """
-        Get the value of a secret.
+    async def get_secret(self, key, operator_uri, **kwargs):
+        """Gets the value of a secret.
 
         Args:
-            key (str): unique secret identifier
-            kwargs: additional keyword arguments to pass to the secrets
-            client for authentication if required
+            key: a secret key
+            operator_uri: the operator URI
+            **kwargs: additional keyword arguments to pass to the secrets
+                client for authentication
         """
-        # pylint: disable=no-member
-
         secret_requirements = self._registered_secrets.get(operator_uri, None)
 
         if not secret_requirements:
-            logging.error(
-                f"Cannot resolve secrets for unregistered "
-                f"operator`{operator_uri}` "
+            logger.error(
+                f"Cannot resolve secret for unregistered "
+                f"operator `{operator_uri}`"
             )
             return None
+
         if key not in secret_requirements:
-            logging.error(
+            logger.error(
                 f"Cannot resolve secret {key} because it is not "
-                f"included in the plugins definition "
+                f"included in the plugin definition "
             )
             return None
+
+        # pylint: disable=no-member
         resolved_secret = await self.client.get(key, **kwargs)
         return resolved_secret
 
-    def get_secret_sync(
-        self, key: str, operator_uri: str, **kwargs
-    ) -> Optional[fois.ISecret]:
-        """
-        Get the value of a secret.
+    def get_secret_sync(self, key, operator_uri, **kwargs):
+        """Gets the value of a secret.
 
         Args:
-            key (str): unique secret identifier
-            kwargs: additional keyword arguments to pass to the secrets
-            client for authentication if required
+            key: a secret key
+            operator_uri: the operator URI
+            **kwargs: additional keyword arguments to pass to the secrets
+                client for authentication
         """
-        # pylint: disable=no-member
-
         secret_requirements = self._registered_secrets.get(operator_uri, None)
+
         if not secret_requirements:
-            logging.error(
-                f"Cannot resolve secrets for unregistered "
-                f"operator`{operator_uri}` "
+            logger.error(
+                f"Cannot resolve secret for unregistered "
+                f"operator `{operator_uri}`"
             )
             return None
+
         if key not in secret_requirements:
-            logging.error(
+            logger.error(
                 f"Cannot resolve secret {key} because it is not "
                 f"included in the plugins definition "
             )
             return None
+
+        # pylint: disable=no-member
         return self.client.get_sync(key, **kwargs)
 
 
@@ -103,123 +103,17 @@ def _get_secrets_client():
     return client()
 
 
-class SecretsDictionary:
-    """
-    A more secure dictionary for accessing plugin secrets in
-    operators that will attempt to resolve missing plugin secrets upon access.
-    """
+class SecretsDictionary(Mapping):
+    """A read-only mapping between secret keys and values."""
 
-    def __init__(
-        self,
-        secrets_dict: typing.Dict[str, str],
-        operator_uri: str = None,
-        resolver_fn: typing.Callable = None,
-        required_keys: typing.List[str] = None,
-    ):
-        self.__frozen = False
-        if required_keys:
-            self.__required_keys = frozenset(required_keys)
-            self.__secrets = secrets_dict
-            self._operator_uri = operator_uri
-            if resolver_fn:
-                self._resolver = resolver_fn
-            else:
-                self._resolver = None
-
-            self.__frozen = True
-        else:
-            self.__required_keys = []
-            self.__secrets = {}
-            self._operator_uri = None
-            self._resolver = None
-
-    def __len__(self):
-        """Returns the number of secrets defined in the plugin definition"""
-        return len(self.__required_keys)
-
-    def __iter__(self):
-        for key in self.__required_keys:
-            yield key
-
-    def __eq__(self, other):
-        return self.__secrets == other
-
-    def __ne__(self, other):
-        return self.__secrets != other
+    def __init__(self, secrets):
+        self._secrets = secrets
 
     def __getitem__(self, key):
-        # Override __getitem__ to suppress KeyError and attempt to resolve
-        # plugin secrets if not yet resolved
-        if not self.__frozen:
-            return None
-        if key not in self.__required_keys:
-            return None
-        val = self.__secrets.get(key, None)
-        if self._resolver and val is None:
-            val = self._resolver(key=key, operator_uri=self._operator_uri)
-            if val:
-                self.__secrets[key] = val.value
-            else:
-                # If the secret is not found, set it to an empty string to
-                # prevent continually trying to resolve it
-                self.__secrets[key] = ""
-        return val
+        return self._secrets.get(key, None)
 
-    def __setattr__(self, key, value):
-        if not getattr(
-            self, "_SecretsDictionary__frozen", False
-        ) or not hasattr(self, key):
-            super().__setattr__(key, value)
-            return
+    def __len__(self):
+        return len(self._secrets)
 
-        if key == "_SecretsDictionary__secrets" and value != {}:
-            is_allowed = all(v in self.__required_keys for v in value.keys())
-            if not is_allowed:
-                raise KeyError(
-                    "Cannot access secrets not defined in the "
-                    "plugin's definition"
-                )
-        elif key == "_SecretsDictionary__required_keys" and self.__frozen:
-            raise AttributeError("Cannot mutate plugin secrets requirement")
-        elif (
-            key == "_SecretsDictionary__frozen"
-            and len(self.__required_keys) > 0
-        ):
-            raise AttributeError("Cannot mutate plugin secrets requirement")
-
-        elif hasattr(super(), key):
-            super().__setattr__(key, value)
-
-    def __setitem__(self, key, value):
-        raise RuntimeError("Setting values is not allowed")
-
-    def __deepcopy__(self, memodict={}):
-        logging.warning("Copying the SecretsDictionary values is not allowed.")
-
-        return {k: None for k in self.__secrets.keys()}
-
-    def __dict__(self):
-        return {k: True for k, v in self.__secrets.items() if v is not None}
-
-    def copy(self):
-        logging.warning("Copying the SecretsDictionary  is not allowed.")
-        return self.__deepcopy__()
-
-    def keys(self):
-        return [k for k in self.__required_keys if k in self.__secrets]
-
-    def values(self):
-        # Override values() to ensure that resolvable secrets are always
-        # returned upon iteration
-        return [self[k] for k in self.keys()]
-
-    def items(self):
-        # Override items() to use __getitem__ to automatically resolve
-        # missing secrets upon iteration
-        try:
-            if self.__frozen:
-                for key in self.__required_keys:
-                    yield key, self[key]
-        except Exception as e:
-            logging.error(f"Error when iterating through secrets:\n{e}")
-            logging.debug(traceback.print_exc())
+    def __iter__(self):
+        return iter(self._secrets)

--- a/tests/unittests/plugins/core_tests.py
+++ b/tests/unittests/plugins/core_tests.py
@@ -1,11 +1,20 @@
+"""
+FiftyOne core plugin unit tests.
+
+| Copyright 2017-2023, Voxel51, Inc.
+| `voxel51.com <https://voxel51.com/>`_
+|
+"""
+import json
 import os
 
-import fiftyone as fo
-import pytest
-import json
-import yaml
 from unittest import mock
+import pytest
+import yaml
+
+import fiftyone as fo
 import fiftyone.plugins as fop
+
 
 _DEFAULT_TEST_PLUGINS = ["test-plugin1", "test-plugin2"]
 _DEFAULT_APP_CONFIG = {}


### PR DESCRIPTION
Change log
- Avoids usage of `operator._plugin_secrets` outside of the `Operator` class
- All secret resolution now happens in `ExecutionContext`, as opposed to being partly in `ExecutionContext` and partly in `SecretsDictionary`

Notes
- Ideally (to me) it would be the case that all secret resolution happens when `ctx.resolve_secret_values()` is called. Currently that is not the case, as it also appears to be necessary for `ctx.secrets` to dynamically resolve secrets. That behavior is maintained in this PR (although all secrets are resolved in a batch the first time `ctx.secrets` is accessed, rather than resolving one-by-one).