### PR TITLE
throw an error in open_dataset for invalid params

### DIFF
--- a/app/packages/operators/src/built-in-operators.ts
+++ b/app/packages/operators/src/built-in-operators.ts
@@ -325,6 +325,10 @@ class OpenDataset extends Operator {
     };
   }
   async execute({ hooks, params }: ExecutionContext) {
+    const { dataset } = params;
+    if (typeof dataset !== "string" || dataset.trim().length === 0) {
+      throw new Error('Param "dataset" must be a non-empty string');
+    }
     hooks.setDataset(params.dataset);
   }
 }


### PR DESCRIPTION
## What changes are proposed in this pull request?

Throw an error in the built-in operator `open_dataset` for invalid params and prevent execution.

## How is this patch tested? If it is not, please explain why.

Using an example operator

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
