### PR TITLE
add ExecutionOptions to execute_operator()

### DIFF
--- a/fiftyone/operators/__init__.py
+++ b/fiftyone/operators/__init__.py
@@ -14,7 +14,6 @@ from .registry import (
 )
 from .executor import (
     execute_operator,
-    execute_or_delegate_operator,
     ExecutionOptions,
 )
 

--- a/fiftyone/operators/executor.py
+++ b/fiftyone/operators/executor.py
@@ -12,8 +12,6 @@ import inspect
 import logging
 import os
 import traceback
-import types as python_types
-import typing
 
 import fiftyone as fo
 import fiftyone.core.dataset as fod
@@ -26,6 +24,9 @@ from fiftyone.plugins.secrets import PluginSecretsResolver, SecretsDictionary
 from .decorators import coroutine_timeout
 from .registry import OperatorRegistry
 from .message import GeneratedMessage, MessageType
+
+
+logger = logging.getLogger(__name__)
 
 
 class ExecutionRunState(object):
@@ -56,16 +57,15 @@ class InvocationRequest(object):
         }
 
 
-class ExecutionProgress:
+class ExecutionProgress(object):
     """Represents the status of an operator execution.
 
-    at least one of progress or label must be provided
     Args:
         progress (None): an optional float between 0 and 1 (0% to 100%)
         label (None): an optional label to display
     """
 
-    def __init__(self, progress: float = None, label: str = None):
+    def __init__(self, progress=None, label=None):
         self.progress = progress
         self.label = label
         self.updated_at = None
@@ -111,44 +111,38 @@ class Executor(object):
         }
 
 
-# TODO: add request_delegation and delegation_target
-def execute_operator(operator_uri, ctx, params=None):
+def execute_operator(operator_uri, ctx=None, **kwargs):
     """Executes the operator with the given name.
 
     Args:
         operator_uri: the URI of the operator
-        ctx: a dictionary of parameters defining the execution context. The
-            supported keys are:
+        ctx (None): a dictionary of parameters defining the execution context.
+            The supported keys are:
 
             -   ``dataset``: a :class:`fiftyone.core.dataset.Dataset` or the
                 name of a dataset to process. This is required unless a
                 ``view`` is provided
-            -   ``view``: an optional :class:`fiftyone.core.view.DatasetView`
-                to process
-            -   ``selected``: an optional list of selected sample IDs
-            -   ``selected_labels``: an optional list of selected labels in the
-                format returned by
+            -   ``view`` (None): an optional
+                :class:`fiftyone.core.view.DatasetView` to process
+            -   ``selected`` ([]): an optional list of selected sample IDs
+            -   ``selected_labels`` ([]): an optional list of selected labels
+                in the format returned by
                 :attr:`fiftyone.core.session.Session.selected_labels`
+            -   ``current_sample`` (None): an optional ID of the current sample
+                being processed
             -   ``params``: a dictionary of parameters for the operator.
                 Consult the operator's documentation for details
-        params (None): you can optionally provide the ``ctx.params`` dict as
-            a separate argument
+            -   ``request_delegation`` (False): whether to request delegated
+                execution, if supported by the operator
+            -   ``delegation_target`` (None): an optional orchestrator on which
+                to schedule the operation, if it is delegated
+        **kwargs: you can optionally provide any of the supported ``ctx`` keys
+            as keyword arguments rather than including them in ``ctx``
 
     Returns:
         an :class:`ExecutionResult`
     """
-    dataset_name, view_stages, selected, selected_labels, params = _parse_ctx(
-        ctx, params=params
-    )
-
-    request_params = dict(
-        operator_uri=operator_uri,
-        dataset_name=dataset_name,
-        view=view_stages,
-        selected=selected,
-        selected_labels=selected_labels,
-        params=params,
-    )
+    request_params = _parse_ctx(ctx=ctx, **kwargs)
 
     return asyncio.run(
         execute_or_delegate_operator(
@@ -157,14 +151,13 @@ def execute_operator(operator_uri, ctx, params=None):
     )
 
 
-def _parse_ctx(ctx, params=None):
-    dataset = ctx.get("dataset", None)
-    view = ctx.get("view", None)
-    selected = ctx.get("selected", None)
-    selected_labels = ctx.get("selected_labels", None)
+def _parse_ctx(ctx=None, **kwargs):
+    if ctx is None:
+        ctx = {}
 
-    if params is None:
-        params = ctx.get("params", {})
+    ctx = {**ctx, **kwargs}  # don't modify input `ctx` in-place
+    dataset = ctx.pop("dataset", None)
+    view = ctx.pop("view", None)
 
     if dataset is None and isinstance(view, fov.DatasetView):
         dataset = view._root_dataset
@@ -175,14 +168,14 @@ def _parse_ctx(ctx, params=None):
 
         view = dataset.view()
 
-    view_stages = view._serialize()
+    view = view._serialize()
 
     if isinstance(dataset, fod.Dataset):
         dataset_name = dataset.name
     else:
         dataset_name = dataset
 
-    return dataset_name, view_stages, selected, selected_labels, params
+    return dict(dataset_name=dataset_name, view=view, **ctx)
 
 
 @coroutine_timeout(seconds=fo.config.operator_timeout)
@@ -206,10 +199,29 @@ async def execute_or_delegate_operator(
         operator, executor, ctx = prepared
 
     execution_options = operator.resolve_execution_options(ctx)
-    resolved_delegation = operator.resolve_delegation(ctx)
-    should_delegate = (
-        ctx.requesting_delegated_execution or resolved_delegation
-    ) and execution_options.allow_delegated_execution
+    if ctx.requesting_delegated_execution or operator.resolve_delegation(ctx):
+        if execution_options.allow_delegated_execution:
+            should_delegate = True
+        else:
+            logger.warning(
+                (
+                    "This operation does not support delegated execution; it "
+                    "will be executed immediately"
+                )
+            )
+            should_delegate = False
+    else:
+        if execution_options.allow_immediate_execution:
+            should_delegate = False
+        else:
+            logger.warning(
+                (
+                    "This operation does not support immediate execution; it "
+                    "will be delegated"
+                )
+            )
+            should_delegate = True
+
     if should_delegate:
         try:
             from .delegated import DelegatedOperationService
@@ -264,8 +276,6 @@ async def prepare_operator_executor(
         delegated_operation_id=delegated_operation_id,
         operator_uri=operator_uri,
         required_secrets=operator._plugin_secrets,
-        delegation_target=request_params.get("delegation_target", None),
-        request_delegation=request_params.get("request_delegation", False),
     )
 
     await ctx.resolve_secret_values(operator._plugin_secrets)
@@ -338,8 +348,7 @@ def resolve_execution_options(registry, operator_uri, request_params):
         request_params: a dictionary of request parameters
 
     Returns:
-        the type of the inputs :class:`fiftyone.operators.executor.ExecutionOptions` of
-        the operator, or None
+        a :class:`fiftyone.operators.executor.ExecutionOptions` or None
     """
     if registry.operator_exists(operator_uri) is False:
         raise ValueError("Operator '%s' does not exist" % operator_uri)
@@ -352,7 +361,6 @@ def resolve_execution_options(registry, operator_uri, request_params):
     )
     try:
         return operator.resolve_execution_options(ctx)
-
     except Exception as e:
         return ExecutionResult(error=traceback.format_exc())
 
@@ -403,9 +411,7 @@ class ExecutionContext(object):
         set_progress=None,
         delegated_operation_id=None,
         operator_uri=None,
-        required_secrets: typing.List[str] = None,
-        delegation_target=None,
-        request_delegation=False,
+        required_secrets=None,
     ):
         self.request_params = request_params or {}
         self.params = self.request_params.get("params", {})
@@ -425,8 +431,6 @@ class ExecutionContext(object):
                 operator_uri=self._operator_uri,
                 required_secrets=self._required_secret_keys,
             )
-        self._delegation_target = delegation_target
-        self._request_delegation = request_delegation
 
     @property
     def dataset(self):
@@ -454,13 +458,6 @@ class ExecutionContext(object):
         on.
         """
         return self.request_params.get("dataset_id", None)
-
-    @property
-    def delegation_target(self):
-        """The ID of the Orchestrator being used to delegate the operation."""
-        return self.request_params.get(
-            "delegation_target", self._delegation_target
-        )
 
     @property
     def view(self):
@@ -516,24 +513,26 @@ class ExecutionContext(object):
 
     @property
     def delegated(self):
-        """Whether the operation's execution was delegated to an orchestrator.
-
-        This property is only available for methods that are invoked after an
-        operator is executed, e.g. :meth:`resolve_output`.
-        """
+        """Whether the operation's execution was delegated to an orchestrator."""
         return self.request_params.get("delegated", False)
 
     @property
-    def results(self):
-        """A ``dict`` of results for the current operation.
+    def requesting_delegated_execution(self):
+        """Whether the invocation requested delegated execution."""
+        return self.request_params.get("request_delegation", False)
 
-        This property is only available for methods that are invoked after an
-        operator is executed, e.g. :meth:`resolve_output`.
-        """
+    @property
+    def delegation_target(self):
+        """The orchestrator to which the operation was delegated (if any)."""
+        return self.request_params.get("delegation_target", None)
+
+    @property
+    def results(self):
+        """A ``dict`` of results for the current operation."""
         return self.request_params.get("results", {})
 
     @property
-    def secrets(self) -> SecretsDictionary:
+    def secrets(self):
         """A read-only mapping of keys to their resolved values."""
         return SecretsDictionary(
             self._secrets,
@@ -541,11 +540,6 @@ class ExecutionContext(object):
             resolver_fn=self._secrets_client.get_secret_sync,
             required_keys=self._required_secret_keys,
         )
-
-    @property
-    def requesting_delegated_execution(self):
-        """Whether the invocation requested delegated execution."""
-        return self._request_delegation
 
     def secret(self, key):
         """Retrieves the secret with the given key.
@@ -630,7 +624,7 @@ class ExecutionContext(object):
             k: v for k, v in self.__dict__.items() if not k.startswith("_")
         }
 
-    def set_progress(self, progress: float = None, label: str = None):
+    def set_progress(self, progress=None, label=None):
         """Sets the progress of the current operation.
 
         Args:
@@ -952,36 +946,42 @@ class ValidationContext(object):
 
 
 class ExecutionOptions(object):
-    """Represents the execution options of an operator.
+    """Represents the execution options of an operation.
 
     Args:
-        allow_immediate_execution (True): whether the operator can be executed
+        allow_immediate_execution (True): whether the operation can be executed
             immediately
-        allow_delegated_execution (True): whether the operator can be delegated
-            to an orchestrator
-        default_choice_to_delegated (True): when True the default option is to delegate
+        allow_delegated_execution (False): whether the operation can be
+            delegated to an orchestrator
+        default_choice_to_delegated (False): whether to default to delegated
+            execution, if allowed
     """
 
     def __init__(
         self,
         allow_immediate_execution=True,
-        allow_delegated_execution=True,
-        default_choice_to_delegated=True,
+        allow_delegated_execution=False,
+        default_choice_to_delegated=False,
     ):
         self._allow_immediate_execution = allow_immediate_execution
         self._allow_delegated_execution = allow_delegated_execution
-        self._available_orchestrators = []
         self._default_choice_to_delegated = default_choice_to_delegated
+        self._available_orchestrators = []
+
         if not allow_delegated_execution and not allow_immediate_execution:
             self._allow_immediate_execution = True
+
+    @property
+    def allow_immediate_execution(self):
+        return self._allow_immediate_execution
 
     @property
     def allow_delegated_execution(self):
         return self._allow_delegated_execution
 
     @property
-    def allow_immediate_execution(self):
-        return self._allow_immediate_execution
+    def default_choice_to_delegated(self):
+        return self._default_choice_to_delegated
 
     @property
     def available_orchestrators(self):
@@ -993,10 +993,6 @@ class ExecutionOptions(object):
             os.environ.get("FIFTYONE_ENABLE_ORCHESTRATOR_REGISTRATION", False)
         )
 
-    @property
-    def default_choice_to_delegated(self):
-        return self._default_choice_to_delegated
-
     def update(self, available_orchestrators=None):
         self._available_orchestrators = available_orchestrators
 
@@ -1004,9 +1000,9 @@ class ExecutionOptions(object):
         return {
             "allow_immediate_execution": self._allow_immediate_execution,
             "allow_delegated_execution": self._allow_delegated_execution,
+            "default_choice_to_delegated": self._default_choice_to_delegated,
             "orchestrator_registration_enabled": self.orchestrator_registration_enabled,
             "available_orchestrators": [
                 x.__dict__ for x in self.available_orchestrators
             ],
-            "default_choice_to_delegated": self._default_choice_to_delegated,
         }

--- a/fiftyone/operators/operator.py
+++ b/fiftyone/operators/operator.py
@@ -31,9 +31,14 @@ class OperatorConfig(object):
             when app is in the light mode
         dark_icon (None): icon to show for the operator in the Operator Browser
             when app is in the dark mode
-        allow_immediate_execution (True): whether the operator should allow immediate execution
-        allow_delegated_execution (False): whether the operator should allow delegated execution
-        resolve_execution_options_on_change (False): whether the execution options are resolved on change
+        allow_immediate_execution (True): whether the operator should allow
+            immediate execution
+        allow_delegated_execution (False): whether the operator should allow
+            delegated execution
+        default_choice_to_delegated (False): whether to default to delegated
+            execution, if allowed
+        resolve_execution_options_on_change (None): whether to resolve
+            execution options are resolved on change
     """
 
     def __init__(
@@ -176,43 +181,48 @@ class Operator(object):
 
         return definition
 
-    def resolve_delegation(self, ctx) -> bool:
+    def resolve_delegation(self, ctx):
         """Returns the resolved delegation flag.
 
         Subclasses can implement this method to define the logic which decides
-        if the operation should be queued for delegation
+        if the operation should be queued for delegation.
 
         Args:
             ctx: the :class:`fiftyone.operators.executor.ExecutionContext`
 
         Returns:
-            a boolean indicating whether the operation should be delegated or `None`
-            to allow the default logic to be used
+            True/False whether the operation should be delegated, or None to
+            defer to :meth:`resolve_execution_options` to specify the available
+            options
         """
         return None
 
     def resolve_execution_options(self, ctx):
         """Returns the resolved execution options.
 
-        Subclasses can implement this method to define the execution options. This
-        defines the behavior of the Execute button in the FiftyOne App.
+        Subclasses can implement this method to define the execution options
+        available for the operation.
+
+        Args:
+            ctx: the :class:`fiftyone.operators.executor.ExecutionContext`
 
         Returns:
             a :class:`fiftyone.operators.executor.ExecutionOptions` instance
         """
         from .executor import ExecutionOptions
 
+        # pylint: disable=assignment-from-none
         resolved_delegation = self.resolve_delegation(ctx)
-        if resolved_delegation is None:
-            # legacy behavior
+        if resolved_delegation is not None:
             return ExecutionOptions(
-                allow_immediate_execution=self.config.allow_immediate_execution,
-                allow_delegated_execution=self.config.allow_delegated_execution,
+                allow_immediate_execution=not resolved_delegation,
+                allow_delegated_execution=resolved_delegation,
             )
 
         return ExecutionOptions(
-            allow_immediate_execution=not resolved_delegation,
-            allow_delegated_execution=resolved_delegation,
+            allow_immediate_execution=self.config.allow_immediate_execution,
+            allow_delegated_execution=self.config.allow_delegated_execution,
+            default_choice_to_delegated=self.config.default_choice_to_delegated,
         )
 
     def execute(self, ctx):


### PR DESCRIPTION
As currently implemented, if a user passes `request_delegation=True` but the operator doesn't support delegated execution, it will log a warning and just execute immediately instead:

```py
foo.execute_operator(operator_uri, ctx=ctx, request_delegation=True)
# This operation does not support delegated execution; it will be executed immediately
```

We could decide to raise an exception instead though.