### PR TITLE
selectGroupSlices stage should 🏃 before Select samples stage

### DIFF
--- a/app/packages/core/src/components/Actions/utils.tsx
+++ b/app/packages/core/src/components/Actions/utils.tsx
@@ -77,6 +77,7 @@ export const tagStatistics = selectorFamily<
               ? {
                   id: modal ? get(groupId) : null,
                   slices: get(fos.currentSlices(modal)),
+                  slice: get(fos.currentSlice(modal)),
                   mode: get(groupStatistics(modal)),
                 }
               : null,

--- a/app/packages/looker/src/elements/common/controls.ts
+++ b/app/packages/looker/src/elements/common/controls.ts
@@ -66,7 +66,6 @@ export class ControlsElement<
     error,
     loaded,
   }: Readonly<State>) {
-    console.log("showcontrols is ", showControls);
     showControls = showControls && !disableControls && !error && loaded;
     if (this.showControls === showControls) {
       return this.element;

--- a/app/packages/state/src/hooks/useSetExpandedSample.ts
+++ b/app/packages/state/src/hooks/useSetExpandedSample.ts
@@ -49,7 +49,6 @@ export default () => {
     ({ snapshot }) =>
       async (index: number | ((current: number) => number)) => {
         const current = await snapshot.getPromise(currentModalSample);
-
         if (index instanceof Function) {
           index = index(current.index);
         }

--- a/app/packages/state/src/hooks/useSetExpandedSample.ts
+++ b/app/packages/state/src/hooks/useSetExpandedSample.ts
@@ -27,6 +27,7 @@ export default () => {
       ) => {
         set(groupAtoms.groupId, groupId || null);
         set(currentModalSample, { id, index });
+
         reset(groupAtoms.dynamicGroupIndex);
         reset(dynamicGroupCurrentElementIndex);
         groupByFieldValue &&
@@ -48,6 +49,7 @@ export default () => {
     ({ snapshot }) =>
       async (index: number | ((current: number) => number)) => {
         const current = await snapshot.getPromise(currentModalSample);
+
         if (index instanceof Function) {
           index = index(current.index);
         }

--- a/app/packages/state/src/recoil/modal.ts
+++ b/app/packages/state/src/recoil/modal.ts
@@ -21,7 +21,6 @@ import { RelayEnvironmentKey } from "./relay";
 import { datasetName } from "./selectors";
 import { mapSampleResponse } from "./utils";
 import { view } from "./view";
-import { modal } from "./atoms";
 
 export const modalLooker = atom<AbstractLooker<BaseState> | null>({
   key: "modalLooker",
@@ -122,7 +121,6 @@ export const modalSampleIndex = selector<number>({
   key: "modalSampleIndex",
   get: ({ get }) => {
     const current = get(currentModalSample);
-
     if (!current) {
       throw new Error("modal sample is not defined");
     }

--- a/app/packages/state/src/recoil/modal.ts
+++ b/app/packages/state/src/recoil/modal.ts
@@ -21,6 +21,7 @@ import { RelayEnvironmentKey } from "./relay";
 import { datasetName } from "./selectors";
 import { mapSampleResponse } from "./utils";
 import { view } from "./view";
+import { modal } from "./atoms";
 
 export const modalLooker = atom<AbstractLooker<BaseState> | null>({
   key: "modalLooker",
@@ -180,6 +181,7 @@ export const modalSample = graphQLSelector<
   },
   variables: ({ get }) => {
     const current = get(currentModalSample);
+
     if (current === null) return null;
 
     const slice = get(groupSlice);

--- a/fiftyone/core/stages.py
+++ b/fiftyone/core/stages.py
@@ -8504,6 +8504,12 @@ _STAGES_THAT_SELECT_OR_REORDER = {
     MatchTags,
     Select,
     SelectBy,
+    SelectGroupSlices,
     Skip,
     Take,
+}
+
+# Registry of select stages that should select first
+_STAGES_THAT_SELECT_FIRST = {
+    SelectGroupSlices,
 }

--- a/fiftyone/core/view.py
+++ b/fiftyone/core/view.py
@@ -1820,6 +1820,10 @@ def make_optimized_select_view(
     else:
         if view.media_type == fom.GROUP and view.group_slices and flatten:
             view = view.select_group_slices(_allow_mixed=True)
+        else:
+            for stage in stages:
+                if type(stage) in fost._STAGES_THAT_SELECT_FIRST:
+                    view = view._add_view_stage(stage, validate=False)
 
         view = view.select(sample_ids, ordered=ordered)
 

--- a/fiftyone/server/view.py
+++ b/fiftyone/server/view.py
@@ -144,7 +144,6 @@ def get_view(
             pagination_data=pagination_data,
             extended_stages=extended_stages,
         )
-
     return view
 
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

### problem
The Select samples stage is running before selectGroupSlices and causing the sample modal to crash (not open).

### solution
Make sure selectGroupSlices stage is computed before Select samples stage when making optimized view function is called.

#### Before

https://github.com/voxel51/fiftyone/assets/109545780/5e8f12d0-985e-47a4-bf79-19599883a7e8

#### After

https://github.com/voxel51/fiftyone/assets/109545780/586f6c23-b25d-418c-b767-3b70b01915c2



## How is this patch tested? If it is not, please explain why.

- unit test making sure select group slices is computed before Select stage
- test script 

```
import fiftyone as fo
import fiftyone.zoo as foz

dataset = foz.load_zoo_dataset("quickstart-groups")
view = dataset.select_group_slices(["left", "right"])

session = fo.launch_app(view)
```

- Try clicking on the second sample (right slice) and it should open modal
- Try tagging the second sample or its labels and it should work
- Try tagging the first sample (left slice) and it should work

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
