### PR TITLE
Fixes histogram aggregation when statistics is toggled between `slice` and `group`

### DIFF
--- a/app/packages/state/src/recoil/distributions.ts
+++ b/app/packages/state/src/recoil/distributions.ts
@@ -29,7 +29,7 @@ import { selector, selectorFamily } from "recoil";
 import { graphQLSelectorFamily } from "recoil-relay";
 import { extendedSelection } from "./atoms";
 import { filters } from "./filters";
-import { groupSlice, groupStatistics } from "./groups";
+import { groupId, groupSlice, groupStatistics } from "./groups";
 import { RelayEnvironmentKey } from "./relay";
 import { field, fieldPaths } from "./schema";
 import { datasetName } from "./selectors";
@@ -46,11 +46,13 @@ export type AggregationResponseFrom<
 const extendedViewForm = selector({
   key: "extendedViewForm",
   get: ({ get }) => {
+    const mixed = get(groupStatistics(false)) === "group";
+
     return {
       sampleIds: get(extendedSelection)?.selection,
       filters: get(filters),
-      slice: get(groupSlice),
-      mixed: get(groupStatistics(false)) === "group",
+      slice: mixed ? "" : get(groupSlice),
+      mixed,
     };
   },
 });

--- a/e2e-pw/src/oss/poms/panels/histogram-panel.ts
+++ b/e2e-pw/src/oss/poms/panels/histogram-panel.ts
@@ -5,6 +5,7 @@ import { SelectorPom } from "../selector";
 export class HistogramPom {
   readonly assert: HistogramAsserter;
   readonly locator: Locator;
+  readonly bars: Locator;
   readonly selector: SelectorPom;
 
   constructor(
@@ -15,6 +16,18 @@ export class HistogramPom {
 
     this.locator = this.page.getByTestId("histograms-container");
     this.selector = new SelectorPom(this.locator, eventUtils, "histograms");
+  }
+
+  bar(nth: number) {
+    return this.page.locator('[class="recharts-rectangle"]').nth(nth);
+  }
+
+  async barTooltipText(nth: number) {
+    await this.bar(nth).hover();
+    await this.page.locator(".recharts-tooltip-wrapper").waitFor();
+
+    const tooltip = this.page.locator(".recharts-tooltip-wrapper").first();
+    return await tooltip.innerText();
   }
 
   async selectField(field: string) {

--- a/e2e-pw/src/oss/specs/histogram/display-options-group-dataset.spec.ts
+++ b/e2e-pw/src/oss/specs/histogram/display-options-group-dataset.spec.ts
@@ -1,4 +1,4 @@
-import { test as base } from "src/oss/fixtures";
+import { test as base, expect } from "src/oss/fixtures";
 import { GridActionsRowPom } from "src/oss/poms/action-row/grid-actions-row";
 import { HistogramPom } from "src/oss/poms/panels/histogram-panel";
 import { PanelPom } from "src/oss/poms/panels/panel";
@@ -20,7 +20,7 @@ const test = base.extend<{
   },
 });
 
-test.describe("Display Options", () => {
+test.describe("Histogram in group dataset", () => {
   const datasetName = getUniqueDatasetNameWithPrefix("quickstart-groups");
 
   test.beforeAll(async ({ fiftyoneLoader }) => {
@@ -47,5 +47,25 @@ test.describe("Display Options", () => {
 
     await histogram.assert.isLoaded();
     await panel.bringPanelToForeground("Samples");
+  });
+
+  test("histogram updates when settings statistics option change", async ({
+    panel,
+    histogram,
+    actionsRow,
+  }) => {
+    await panel.open("Histograms");
+    await histogram.selectField("ground_truth.detections.label");
+
+    const firstBarTooltipTextBefore = await histogram.barTooltipText(0);
+    await panel.bringPanelToForeground("Samples");
+    await actionsRow.toggleDisplayOptions();
+    await actionsRow.displayActions.setSidebarStatisticsMode("group");
+    await actionsRow.toggleDisplayOptions();
+    await panel.bringPanelToForeground("Histograms");
+    await histogram.selectField("ground_truth.detections.label");
+
+    const firstBarTooltipTextAfter = await histogram.barTooltipText(0);
+    expect(firstBarTooltipTextBefore).not.toEqual(firstBarTooltipTextAfter);
   });
 });


### PR DESCRIPTION
## What changes are proposed in this pull request?

#### problem

Histogram does not update when the statistics option changes between `slice` and `group` for group datasets. The `slice` variable to the query is always set (even when in group statistics mode) where it should be empty for the aggregations to work correctly.

## How is this patch tested? If it is not, please explain why.

- [x] E2E tests that changing the statistics between `slice` and `group` refreshes the Histogram with new values.

https://github.com/voxel51/fiftyone/assets/109545780/123793e5-2da8-4145-93cb-44f0bb25bcf7


- [x] Manual testing

Before fix

https://github.com/voxel51/fiftyone/assets/109545780/0d9c53ad-7f63-4908-9b62-d6910728b681



After fix

https://github.com/voxel51/fiftyone/assets/109545780/13832a0d-daa9-4585-80d4-b3f448eb07e9



## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
