### PR TITLE
bugfix: tag labels in multiple samples can only tag labels in the last sample successfully

### DIFF
--- a/app/packages/core/src/components/Actions/utils.tsx
+++ b/app/packages/core/src/components/Actions/utils.tsx
@@ -174,6 +174,9 @@ export const tagParameters = ({
       if (groupData?.slices) {
         return null;
       }
+      if (targetLabels && selectedLabels.length) {
+        return [...new Set(selectedLabels.map((l) => l.sampleId))];
+      }
       return [sampleId];
     } else if (selectedSamples.size) {
       return [...selectedSamples];


### PR DESCRIPTION
## What changes are proposed in this pull request?

As a user, when I go to the modal view, select labels and go to the next sample and select more labels, and tag labels, only labels from the last sample get actually tagged. 

This PR fixed the regression described above. 

## How is this patch tested? If it is not, please explain why.

https://github.com/voxel51/fiftyone/assets/17770824/6044348b-4c5c-4023-a1c9-cc9a47b76101


## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
