### PR TITLE
include request_delegation for generator

### DIFF
--- a/app/packages/operators/src/operators.ts
+++ b/app/packages/operators/src/operators.ts
@@ -445,7 +445,6 @@ async function executeOperatorAsGenerator(
       params: ctx.params,
       dataset_name: currentContext.datasetName,
       delegation_target: currentContext.delegationTarget,
-      delegate_execution: currentContext.delegateExecution,
       extended: currentContext.extended,
       view: currentContext.view,
       filters: currentContext.filters,
@@ -454,6 +453,7 @@ async function executeOperatorAsGenerator(
         : [],
       selected_labels: formatSelectedLabels(currentContext.selectedLabels),
       current_sample: currentContext.currentSample,
+      request_delegation: ctx.requestDelegation,
     },
     "json-stream"
   );


### PR DESCRIPTION
## What changes are proposed in this pull request?

Fix an issue where generator operator is executed immediately even when requested to be scheduled

## How is this patch tested? If it is not, please explain why.

Using a generator operator with option to delegate

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
