### PR TITLE
fix generator operator notify and error

### DIFF
--- a/app/packages/operators/src/operators.ts
+++ b/app/packages/operators/src/operators.ts
@@ -462,21 +462,26 @@ async function executeOperatorAsGenerator(
   const abortQueue = getAbortableOperationQueue();
   abortQueue.add(operator.uri, ctx.params, parser);
 
-  let result = null;
-  let triggerPromises = [];
+  const result = { result: {} };
   const onChunk = (chunk) => {
+    if (chunk?.delegated) {
+      result.delegated = chunk?.delegated;
+    }
+    if (chunk?.error) {
+      result.error = chunk?.error;
+    }
     const message = GeneratedMessage.fromJSON(chunk);
     if (message.cls == InvocationRequest) {
       executeOperator(message.body.operator_uri, message.body.params);
     } else if (message.cls == ExecutionResult) {
-      result = message.body;
+      result.result = message.body;
     }
   };
   await parser.parse(onChunk);
   abortQueue.remove(operator.uri);
   // Should we wait for all triggered operators finish execution?
   // e.g. await Promise.all(triggerPromises)
-  return result || {};
+  return result;
 }
 
 export function resolveOperatorURI(operatorURI) {
@@ -507,7 +512,10 @@ export async function executeOperatorWithContext(
   if (isRemote) {
     if (operator.config.executeAsGenerator) {
       try {
-        result = await executeOperatorAsGenerator(operator, ctx);
+        const serverResult = await executeOperatorAsGenerator(operator, ctx);
+        result = serverResult.result;
+        delegated = serverResult.delegated;
+        error = serverResult.error;
       } catch (e) {
         const isAbortError =
           e.name === "AbortError" || e instanceof DOMException;


### PR DESCRIPTION
## What changes are proposed in this pull request?

Fix the scheduled generator operator not showing up issue and handle some generator operator error

## How is this patch tested? If it is not, please explain why.

Using a generator operator in delegated and non-delegated mode

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
