### PR TITLE
Bugfix Orthographic projection

### DIFF
--- a/app/packages/state/src/hooks/useCreateLooker.ts
+++ b/app/packages/state/src/hooks/useCreateLooker.ts
@@ -115,6 +115,20 @@ export default <T extends AbstractLooker>(
 
         let sampleMediaFilePath = urls[mediaField];
 
+        if (constructor === PcdLooker) {
+          const orthographicProjectionField = Object.entries(sample)
+            .find(
+              (el) =>
+                el[1] && el[1]["_cls"] === "OrthographicProjectionMetadata"
+            )
+            ?.at(0) as string | undefined;
+          if (orthographicProjectionField) {
+            sampleMediaFilePath = urls[
+              `${orthographicProjectionField}.filepath`
+            ] as string;
+          }
+        }
+
         const config: ConstructorParameters<T>[1] = {
           fieldSchema: {
             ...fieldSchema,
@@ -144,20 +158,6 @@ export default <T extends AbstractLooker>(
             name: sample.group.name,
             id: sample.group._id,
           };
-        }
-
-        if (constructor === PcdLooker) {
-          const orthographicProjectionField = Object.entries(sample)
-            .find(
-              (el) =>
-                el[1] && el[1]["_cls"] === "OrthographicProjectionMetadata"
-            )
-            ?.at(0) as string | undefined;
-          if (orthographicProjectionField) {
-            sampleMediaFilePath = urls[
-              `${orthographicProjectionField}.filepath`
-            ] as string;
-          }
         }
 
         if (constructor === ImaVidLooker) {


### PR DESCRIPTION
## What changes are proposed in this pull request?

This PR fixes a bug where orthographic projections weren't showing because `sampleMediaFilePath` was being set after sample config was already instantiated.

<img width="1504" alt="Screenshot 2023-12-01 at 10 18 31 PM" src="https://github.com/voxel51/fiftyone/assets/66688606/981a6f0f-b62d-4785-9b5f-65ade6fb9fe6">
