### PR TITLE
regression fix: RGB segmentation corruption

### DIFF
--- a/app/packages/looker/src/worker/index.ts
+++ b/app/packages/looker/src/worker/index.ts
@@ -311,7 +311,7 @@ const processSample = ({
 
   let bufferPromises = [];
 
-  if (sample._media_type === "point-cloud") {
+  if (sample?._media_type === "point-cloud") {
     process3DLabels(sample);
   } else {
     bufferPromises = [

--- a/app/packages/looker/src/worker/painter.ts
+++ b/app/packages/looker/src/worker/painter.ts
@@ -279,7 +279,8 @@ export const PainterFactory = (requestColor) => ({
           ].intTarget;
         } else {
           // assign an arbitrary uint8 value here; this isn't used anywhere but absence of it affects tooltip behavior
-          targets[i] = r;
+          // having this line caused the mask to corrupt
+          // targets[i] = r;
         }
       }
 


### PR DESCRIPTION
## What changes are proposed in this pull request?
In `painter.ts`, commented out `targets[i]=r`, as this corrupts rgb masks. 
```
 if (isRgbMaskTargets_) {
          targets[i] = (maskTargets as RgbMaskTargets)[
            currentHexCode
          ].intTarget;
        } else {
          // assign an arbitrary uint8 value here; this isn't used anywhere but absence of it affects tooltip behavior
          // having this line caused the mask to corrupt
          **// targets[i] = r;**
        }
```



## How is this patch tested? If it is not, please explain why.

After the fix: 

https://github.com/voxel51/fiftyone/assets/17770824/c5e449c4-24df-44fc-9506-73860f11eb51



## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
