### PR TITLE
Lightning numeric modal bounds

### DIFF
--- a/app/packages/state/src/recoil/aggregations.ts
+++ b/app/packages/state/src/recoil/aggregations.ts
@@ -133,18 +133,21 @@ export const aggregation = selectorFamily({
     }) =>
     ({ get }) => {
       let paths = get(schemaAtoms.filterFields(path));
+      let mixed = params.mixed;
       const numeric = get(schemaAtoms.isNumericField(path));
       if (params.modal) {
         paths = paths.filter((p) => {
           const n = get(schemaAtoms.isNumericField(p));
           return numeric ? n : !n;
         });
+        // mixed only when in a group dataset
+        mixed ||= Boolean(get(groupId) && numeric);
       }
 
       return get(
         aggregations({
           ...params,
-          mixed: params.modal && numeric,
+          mixed,
           paths,
         })
       ).filter((data) => data.path === path)[0];


### PR DESCRIPTION
Fixes numeric bounds requests for range sliders in the modal. The change ensures the bounds are calculated only using the current modal sample or group (when viewing a group a dataset)