### PR TITLE
fiftyone-db 1.0

### DIFF
--- a/fiftyone/core/odm/database.py
+++ b/fiftyone/core/odm/database.py
@@ -204,7 +204,7 @@ def establish_db_conn(config):
 
         except fos.ServiceExecutableNotFound:
             raise FiftyOneConfigError(
-                "MongoDB is not supported on your system. Please "
+                "MongoDB could not be installed on your system. Please "
                 "define a `database_uri` in your "
                 "`fiftyone.core.config.FiftyOneConfig` to connect to your"
                 "own MongoDB instance or cluster "

--- a/package/db/setup.py
+++ b/package/db/setup.py
@@ -120,7 +120,7 @@ def _get_download():
 MONGODB_BINARIES = ["mongod"]
 
 
-VERSION = "0.5.0"
+VERSION = "1.0"
 
 
 def get_version():

--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,7 @@ INSTALL_REQUIRES = [
     "universal-analytics-python3>=1.0.1,<2",
     # internal packages
     "fiftyone-brain~=0.13.2",
-    "fiftyone-db>=0.4",
+    "fiftyone-db~=1.0",
     "voxel51-eta~=0.12",
 ]
 


### PR DESCRIPTION
To not break existing installations, general support for Linux distributions should via a source distribution should be released a `fiftyone-db==1.0` 