### PR TITLE
Fix `NoneType` object error in migration

### DIFF
--- a/fiftyone/migrations/revisions/v0_23_0.py
+++ b/fiftyone/migrations/revisions/v0_23_0.py
@@ -44,10 +44,9 @@ def up(db, dataset_name):
             )
 
             # Handle nested fields within 'fields'
-            if color_scheme["fields"] is not None:
-                for field in color_scheme["fields"]:
-                    if field is not None:
-                        field.setdefault("maskTargetsColors", [])
+            for field in color_scheme.get("fields", []):
+                if field is not None:
+                    field.setdefault("maskTargetsColors", [])
 
     db.datasets.replace_one(match_d, dataset_dict)
 
@@ -83,6 +82,7 @@ def down(db, dataset_name):
 
             # Handle nested fields within 'fields'
             for field in color_scheme.get("fields", []):
-                field.pop("maskTargetsColors", None)
+                if field is not None:
+                    field.pop("maskTargetsColors", None)
 
     db.datasets.replace_one(match_d, dataset_dict)

--- a/fiftyone/migrations/revisions/v0_23_0.py
+++ b/fiftyone/migrations/revisions/v0_23_0.py
@@ -44,8 +44,10 @@ def up(db, dataset_name):
             )
 
             # Handle nested fields within 'fields'
-            for field in color_scheme["fields"]:
-                field.setdefault("maskTargetsColors", [])
+            if color_scheme["fields"] is not None:
+                for field in color_scheme["fields"]:
+                    if field is not None:
+                        field.setdefault("maskTargetsColors", [])
 
     db.datasets.replace_one(match_d, dataset_dict)
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

fix the `NoneType` object (colorscheme.fields) is not iterable bug when migrating dataset.

## How is this patch tested? If it is not, please explain why.

(Details)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
