### PR TITLE
Always show lightning search input 

### DIFF
--- a/app/packages/components/src/components/TabOption/TabOption.tsx
+++ b/app/packages/components/src/components/TabOption/TabOption.tsx
@@ -27,6 +27,7 @@ const TabOptionDiv = animated(styled.div`
   & > div > div {
     display: flex;
     justify-content: center;
+    padding: 0 1rem;
   }
 `);
 
@@ -74,7 +75,7 @@ const TabOption = ({
 
   return (
     <TabOptionDiv
-      style={{ ...style, minWidth: `${6 * options.length || 1}rem` }}
+      style={style}
       onMouseEnter={() => set({ background: theme.background.body })}
       onMouseLeave={() => set({ background: theme.background.level1 })}
     >

--- a/app/packages/core/src/components/Filters/StringFilter/useSelected.ts
+++ b/app/packages/core/src/components/Filters/StringFilter/useSelected.ts
@@ -45,15 +45,18 @@ export default function (
   const resultsLoadable = useRecoilValueLoadable(resultsAtom);
   const showSearch = useRecoilValue(showSearchSelector({ modal, path }));
   const useSearch = useUseSearch({ modal, path });
+  const lightningOn = useRecoilValue(fos.lightning);
+  const lightning =
+    useRecoilValue(fos.isLightningPath(path)) && !modal && lightningOn;
 
   if (resultsLoadable.state === "hasError") throw resultsLoadable.contents;
   const results =
     resultsLoadable.state === "hasValue" ? resultsLoadable.contents : null;
   const length = results?.results?.length ?? 0;
-  const shown =
-    resultsLoadable.state !== "loading" &&
-    (showSearch || length > CHECKBOX_LIMIT);
 
+  const shown =
+    (resultsLoadable.state !== "loading" || lightning) &&
+    (showSearch || length > CHECKBOX_LIMIT);
   return {
     results,
     useSearch: useRecoilValue(hasSearchResultsSelector(path))


### PR DESCRIPTION
A regression from #3846, lightning search input should always be shown. Also improves Options popout sizing.
Before
<img width="1470" alt="Screenshot 2023-12-05 at 2 01 55 PM" src="https://github.com/voxel51/fiftyone/assets/19821840/8157e576-e99c-458a-ba45-a550d311dddf">

After
<img width="1470" alt="Screenshot 2023-12-05 at 2 01 40 PM" src="https://github.com/voxel51/fiftyone/assets/19821840/80d46abc-b10d-4147-88da-736e63b0c6d5">


