### PR TITLE
Fix `session.dataset = None`

### DIFF
--- a/app/packages/app/src/useEvents/useSetFieldVisibilityStage.ts
+++ b/app/packages/app/src/useEvents/useSetFieldVisibilityStage.ts
@@ -24,10 +24,16 @@ const useSetFieldVisibilityStage: EventHandlerHook = () => {
           unsubscribe();
         });
 
-        router.history.replace(resolveURL(router), {
-          ...router.get().state,
-          fieldVisibility: stage,
-        });
+        router.history.replace(
+          resolveURL({
+            currentPathname: router.history.location.pathname,
+            currentSearch: router.history.location.search,
+          }),
+          {
+            ...router.get().state,
+            fieldVisibility: stage,
+          }
+        );
       },
     [session, setter]
   );

--- a/app/packages/app/src/useEvents/useStateUpdate.ts
+++ b/app/packages/app/src/useEvents/useStateUpdate.ts
@@ -16,11 +16,16 @@ const useStateUpdate: EventHandlerHook = ({
     (payload: any) => {
       const state = processState(session.current, payload.state);
       const stateless = env().VITE_NO_STATE;
-      const path = resolveURL(
-        router,
-        stateless ? getDatasetName() : payload.state.dataset,
-        stateless ? getSavedViewName() : payload.state.saved_view_slug
-      );
+      const path = resolveURL({
+        currentPathname: router.history.location.pathname,
+        currentSearch: router.history.location.search,
+        nextDataset: stateless
+          ? getDatasetName()
+          : payload.state.dataset ?? null,
+        nextView: stateless
+          ? getSavedViewName()
+          : payload.state.saved_view_slug,
+      });
       if (readyStateRef.current !== AppReadyState.OPEN) {
         router.history.replace(path, state);
         router.load().then(() => setReadyState(AppReadyState.OPEN));

--- a/app/packages/app/src/useSetters/onSetDataset.ts
+++ b/app/packages/app/src/useSetters/onSetDataset.ts
@@ -39,9 +39,16 @@ const onSetDataset: RegisteredSetter =
         entry.data.dataset?.defaultGroupSlice || undefined;
     });
 
-    router.history.push(resolveURL(router, datasetName || null), {
-      view: [],
-    });
+    router.history.push(
+      resolveURL({
+        currentPathname: router.history.location.pathname,
+        currentSearch: router.history.location.search,
+        nextDataset: datasetName || null,
+      }),
+      {
+        view: [],
+      }
+    );
   };
 
 export default onSetDataset;

--- a/app/packages/app/src/useSetters/onSetFieldVisibilityStage.ts
+++ b/app/packages/app/src/useSetters/onSetFieldVisibilityStage.ts
@@ -31,10 +31,16 @@ const onSetFieldVisibilityStage: RegisteredSetter =
     });
 
     // reload page query with new extended view
-    router.history.replace(resolveURL(router), {
-      ...router.get().state,
-      fieldVisibility: stage,
-    });
+    router.history.replace(
+      resolveURL({
+        currentPathname: router.history.location.pathname,
+        currentSearch: router.history.location.search,
+      }),
+      {
+        ...router.get().state,
+        fieldVisibility: stage,
+      }
+    );
 
     // send event as side effect
     commitMutation<setFieldVisibilityStageMutation>(environment, {

--- a/app/packages/app/src/useSetters/onSetView.ts
+++ b/app/packages/app/src/useSetters/onSetView.ts
@@ -43,9 +43,16 @@ const onSetView: RegisteredSetter =
         sessionRef.current.selectedLabels = [];
         sessionRef.current.selectedSamples = new Set();
         sessionRef.current.fieldVisibilityStage = undefined;
-        router.history.push(resolveURL(router, dataset), {
-          view,
-        });
+        router.history.push(
+          resolveURL({
+            currentPathname: router.history.location.pathname,
+            currentSearch: router.history.location.search,
+            nextDataset: dataset,
+          }),
+          {
+            view,
+          }
+        );
       },
     });
   };

--- a/app/packages/app/src/useSetters/onSetViewName.ts
+++ b/app/packages/app/src/useSetters/onSetViewName.ts
@@ -33,9 +33,17 @@ const onSetViewName: RegisteredSetter =
     sessionRef.current.selectedLabels = [];
     sessionRef.current.selectedSamples = new Set();
     sessionRef.current.fieldVisibilityStage = undefined;
-    router.history.push(resolveURL(router, dataset, slug || undefined), {
-      view: [],
-    });
+    router.history.push(
+      resolveURL({
+        currentPathname: router.history.location.pathname,
+        currentSearch: router.history.location.search,
+        nextDataset: dataset,
+        nextView: slug || undefined,
+      }),
+      {
+        view: [],
+      }
+    );
   };
 
 export default onSetViewName;

--- a/app/packages/app/src/utils.test.ts
+++ b/app/packages/app/src/utils.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+import { resolveURL } from "./utils";
+
+describe("resolves datasets", () => {
+  it("resolves to /", () => {
+    expect(
+      resolveURL({
+        currentPathname: "/datasets/my-dataset",
+        currentSearch: "",
+        nextDataset: null,
+      })
+    ).toBe("/");
+    expect(
+      resolveURL({ currentPathname: "/datasets/my-dataset", currentSearch: "" })
+    ).toBe("/datasets/my-dataset");
+  });
+});
+
+describe("resolves wih proxy", () => {
+  it("resolves to /", () => {
+    expect(
+      resolveURL({
+        currentPathname: "/datasets/my-dataset",
+        currentSearch: "?proxy=/my/proxy",
+        nextDataset: null,
+      })
+    ).toBe(`/my/proxy?proxy=${encodeURIComponent("/my/proxy")}`);
+    expect(
+      resolveURL({
+        currentPathname: "/my/proxy/datasets/my-dataset",
+        currentSearch: "?proxy=/my/proxy",
+      })
+    ).toBe(
+      `/my/proxy/datasets/my-dataset?proxy=${encodeURIComponent("/my/proxy")}`
+    );
+  });
+});
+
+describe("resolves views", () => {
+  it("throws error", () => {
+    expect(() =>
+      resolveURL({
+        currentPathname: "",
+        currentSearch: "",
+        nextDataset: null,
+        nextView: "view",
+      })
+    ).toThrowError();
+  });
+
+  it("throws error", () => {
+    expect(() =>
+      resolveURL({
+        currentPathname: "",
+        currentSearch: "",
+        nextView: "view",
+      })
+    ).toThrowError();
+  });
+
+  it("resolves with saved view", () => {
+    expect(
+      resolveURL({
+        currentPathname: "/datasets/my-dataset",
+        currentSearch: "",
+        nextDataset: "my-dataset",
+        nextView: "view",
+      })
+    ).toBe(`/datasets/my-dataset?view=view`);
+  });
+});
+
+describe("resolves current", () => {
+  it("does not change location", () => {
+    expect(
+      resolveURL({
+        currentPathname: "/datasets/my-dataset",
+        currentSearch: "?view=view",
+      })
+    ).toBe("/datasets/my-dataset?view=view");
+  });
+});


### PR DESCRIPTION
In 0.23.0, `session.dataset = None` does not return the App to the index page. Updates and adds unit tests to `resolveURL` to ensure this fix.

```py
import fiftyone as fo

dataset, session = fo.quickstart()
# wait for App to load dataset...

# unset dataset
session.dataset = None
```
https://github.com/voxel51/fiftyone/assets/19821840/81599ee9-1ca9-4bc9-9cd8-787e6305634d

