### PR TITLE
Ignores the rollup-plugin-preserve-directives warning on app production

### DIFF
--- a/app/packages/app/vite.config.ts
+++ b/app/packages/app/vite.config.ts
@@ -22,6 +22,16 @@ export default defineConfig({
       path: "path-browserify",
     },
   },
+  build: {
+    rollupOptions: {
+      onwarn(warning, warn) {
+        if (warning.code === "MODULE_LEVEL_DIRECTIVE") {
+          return;
+        }
+        warn(warning);
+      },
+    },
+  },
   server: {
     port: parseInt(process.env.FIFTYONE_DEFAULT_APP_PORT || "5173"),
     proxy: {


### PR DESCRIPTION
## What changes are proposed in this pull request?

The production build of the app is throwing many lines of `Module level directives cause errors when bundled, 'use client' was ignored. messages when fiftyone` warning. It seems to be coming from [this plugin](https://socket.dev/npm/package/rollup-plugin-preserve-directives) used by the libs. I am not sure what has caused the sudden burst.

solution: override the `onwarn` handler and ignore the directive's warning. 
sources
https://rollupjs.org/configuration-options/#onwarn
https://socket.dev/npm/package/rollup-plugin-preserve-directives

## How is this patch tested? If it is not, please explain why.

Run `yarn build` in `fiftyone/app` and the warning is gone.

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
