### PR TITLE
Enable loading dataset via id for ExecutionContext.Dataset

### DIFF
--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -262,8 +262,11 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
         overwrite=False,
         _create=True,
         _virtual=False,
+        _doc=None,
         **kwargs,
     ):
+        if _doc:
+            name = _doc.name
         if name is None and _create:
             name = get_default_dataset_name()
 
@@ -276,7 +279,7 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
             )
         else:
             doc, sample_doc_cls, frame_doc_cls = _load_dataset(
-                self, name, virtual=_virtual
+                self, name, virtual=_virtual, doc=_doc
             )
 
         self._doc = doc
@@ -6808,11 +6811,13 @@ def _load_clips_source_dataset(frame_collection_name):
     return load_dataset(doc["name"])
 
 
-def _load_dataset(obj, name, virtual=False):
+def _load_dataset(obj, name, virtual=False, doc=None):
     if not virtual:
         fomi.migrate_dataset_if_necessary(name)
 
     try:
+        if doc:
+            return _do_load_dataset_from_doc(obj, doc)
         return _do_load_dataset(obj, name)
     except Exception as e:
         try:
@@ -6836,6 +6841,13 @@ def _do_load_dataset(obj, name):
         dataset_doc = foo.DatasetDocument.objects.get(name=name)
     except moe.DoesNotExist:
         raise ValueError("Dataset '%s' not found" % name)
+
+    return _do_load_dataset_from_doc(obj, dataset_doc)
+
+
+def _do_load_dataset_from_doc(obj, dataset_doc):
+    if isinstance(dataset_doc, dict):
+        dataset_doc = foo.DatasetDocument(**dataset_doc)
 
     sample_collection_name = dataset_doc.sample_collection_name
     frame_collection_name = dataset_doc.frame_collection_name

--- a/fiftyone/core/odm/database.py
+++ b/fiftyone/core/odm/database.py
@@ -220,12 +220,12 @@ def establish_db_conn(config):
 
     connect(config.database_name, **_connection_kwargs)
 
-    config = get_db_config()
-    if foc.CLIENT_TYPE != config.type:
-        raise ConnectionError(
-            "Cannot connect to database type '%s' with client type '%s'"
-            % (config.type, foc.CLIENT_TYPE)
-        )
+    # config = get_db_config()
+    # if foc.CLIENT_TYPE != config.type:
+    #     raise ConnectionError(
+    #         "Cannot connect to database type '%s' with client type '%s'"
+    #         % (config.type, foc.CLIENT_TYPE)
+    #     )
 
 
 def _connect():

--- a/fiftyone/core/odm/database.py
+++ b/fiftyone/core/odm/database.py
@@ -220,12 +220,12 @@ def establish_db_conn(config):
 
     connect(config.database_name, **_connection_kwargs)
 
-    # config = get_db_config()
-    # if foc.CLIENT_TYPE != config.type:
-    #     raise ConnectionError(
-    #         "Cannot connect to database type '%s' with client type '%s'"
-    #         % (config.type, foc.CLIENT_TYPE)
-    #     )
+    config = get_db_config()
+    if foc.CLIENT_TYPE != config.type:
+        raise ConnectionError(
+            "Cannot connect to database type '%s' with client type '%s'"
+            % (config.type, foc.CLIENT_TYPE)
+        )
 
 
 def _connect():

--- a/fiftyone/core/utils.py
+++ b/fiftyone/core/utils.py
@@ -31,6 +31,9 @@ import timeit
 import types
 from xml.parsers.expat import ExpatError
 import zlib
+
+from bson import ObjectId
+from bson.errors import InvalidId
 from matplotlib import colors as mcolors
 from concurrent.futures import ThreadPoolExecutor
 
@@ -1992,3 +1995,26 @@ def validate_hex_color(value):
 
 
 fos = lazy_import("fiftyone.core.storage")
+
+
+def load_dataset(identifier):
+    """Loads the dataset from the database with the given name or id."""
+    import fiftyone.core.odm as foo
+    import fiftyone.core.dataset as fod
+
+    db = foo.get_db_conn()
+    try:
+        query_key = "_id"
+        query_val = ObjectId(identifier)
+
+    except:
+        query_key = "name"
+        query_val = identifier
+
+    res = db.datasets.find_one({query_key: query_val})
+    if not res:
+        raise ValueError(
+            f"Dataset with {query_key}={query_val} does not " f"exist"
+        )
+    dataset_doc = foo.DatasetDocument.from_dict(res)
+    return fod.Dataset(_doc=dataset_doc, _create=False, _virtual=True)

--- a/fiftyone/factory/repos/delegated_operation.py
+++ b/fiftyone/factory/repos/delegated_operation.py
@@ -173,7 +173,7 @@ class MongoDelegatedOperationRepo(DelegatedOperationRepo):
                 )
             elif isinstance(op.context, ExecutionContext):
                 context = op.context
-            if context:
+            if context and context.dataset:
                 op.dataset_id = context.dataset._doc.id
 
         doc = self._collection.insert_one(op.to_pymongo())

--- a/fiftyone/operators/delegated.py
+++ b/fiftyone/operators/delegated.py
@@ -365,10 +365,12 @@ class DelegatedOperationService(object):
         operator_uri = doc.operator
         context = doc.context
         context.request_params["run_doc"] = doc.id
-        # pass the dataset_id so that the execution context can load the
-        # dataset by id in case a dataset has been renamed since the task
-        # was initially queued
-        context.request_params["dataset_id"] = doc.dataset_id
+
+        if not context.request_params.get("dataset_id", None):
+            # Pass the dataset_id so that the execution context can load the
+            # dataset by id in case a dataset has been renamed since the task
+            # was initially queued. However, don't overwrite it if it exists.
+            context.request_params["dataset_id"] = doc.dataset_id
 
         prepared = await prepare_operator_executor(
             operator_uri=operator_uri,

--- a/fiftyone/operators/delegated.py
+++ b/fiftyone/operators/delegated.py
@@ -365,6 +365,10 @@ class DelegatedOperationService(object):
         operator_uri = doc.operator
         context = doc.context
         context.request_params["run_doc"] = doc.id
+        # pass the dataset_id so that the execution context can load the
+        # dataset by id in case a dataset has been renamed since the task
+        # was initially queued
+        context.request_params["dataset_id"] = doc.dataset_id
 
         prepared = await prepare_operator_executor(
             operator_uri=operator_uri,

--- a/fiftyone/operators/executor.py
+++ b/fiftyone/operators/executor.py
@@ -468,10 +468,7 @@ class ExecutionContext(object):
     @property
     def view(self):
         """The :class:`fiftyone.core.view.DatasetView` being operated on."""
-        # since the context.dataset may have been changed, we should only
-        # return the current view if the current DatasetView's root dataset
-        # matches the dataset in the context
-        if self._view and self._view._root_dataset.name == self.dataset.name:
+        if self._view:
             return self._view
 
         # Always derive the view from the context's dataset

--- a/fiftyone/operators/executor.py
+++ b/fiftyone/operators/executor.py
@@ -482,18 +482,19 @@ class ExecutionContext(object):
                 "context first."
             )
 
-        dataset_name = dataset.name
         stages = self.request_params.get("view", None)
         filters = self.request_params.get("filters", None)
         extended = self.request_params.get("extended", None)
 
-        self._view = fosv.get_view(
-            dataset_name,
-            stages=stages,
-            filters=filters,
-            extended_stages=extended,
-            reload=False,
-        )
+        if stages:
+            view = fov.DatasetView._build(dataset, stages)
+        else:
+            view = dataset.view()
+        if filters or extended:
+            view = fosv.get_extended_view(
+                view, filters=filters, extended_stages=extended
+            )
+        self._view = view
 
         return self._view
 

--- a/fiftyone/operators/executor.py
+++ b/fiftyone/operators/executor.py
@@ -494,13 +494,20 @@ class ExecutionContext(object):
     @property
     def view(self):
         """The :class:`fiftyone.core.view.DatasetView` being operated on."""
-        if self._view is not None:
+        # since the context.dataset may have been changed, we should only
+        # return the current view if the current DatasetView's root dataset
+        # matches the dataset in the context
+        if self._view and self._view._root_dataset.name == self.dataset.name:
             return self._view
 
-        # Forces a dataset reload if necessary
-        _ = self.dataset
+        # Always derive the view from the context's dataset
+        dataset = self.dataset
+        if not dataset:
+            raise RuntimeError(
+                "Cannot create a view without setting the dataset in the context first."
+            )
 
-        dataset_name = self.request_params.get("dataset_name", None)
+        dataset_name = dataset.name
         stages = self.request_params.get("view", None)
         filters = self.request_params.get("filters", None)
         extended = self.request_params.get("extended", None)

--- a/fiftyone/operators/executor.py
+++ b/fiftyone/operators/executor.py
@@ -486,15 +486,13 @@ class ExecutionContext(object):
         filters = self.request_params.get("filters", None)
         extended = self.request_params.get("extended", None)
 
-        if stages:
-            view = fov.DatasetView._build(dataset, stages)
-        else:
-            view = dataset.view()
-        if filters or extended:
-            view = fosv.get_extended_view(
-                view, filters=filters, extended_stages=extended
-            )
-        self._view = view
+        self._view = fosv.get_view(
+            dataset,
+            stages=stages,
+            filters=filters,
+            extended_stages=extended,
+            reload=False,
+        )
 
         return self._view
 

--- a/fiftyone/operators/executor.py
+++ b/fiftyone/operators/executor.py
@@ -202,8 +202,7 @@ async def execute_or_delegate_operator(
         and not execution_options.allow_delegated_execution
     ):
         raise RuntimeError(
-            "This operation does not support immediate OR delegated "
-            "execution"
+            "This operation does not support immediate OR delegated execution"
         )
 
     should_delegate = (
@@ -212,21 +211,15 @@ async def execute_or_delegate_operator(
     if should_delegate:
         if not execution_options.allow_delegated_execution:
             logger.warning(
-                (
-                    "This operation does not support delegated "
-                    "execution; it "
-                    "will be executed immediately"
-                )
+                "This operation does not support delegated "
+                "execution; it will be executed immediately"
             )
             should_delegate = False
     else:
         if not execution_options.allow_immediate_execution:
             logger.warning(
-                (
-                    "This operation does not support immediate "
-                    "execution; it "
-                    "will be delegated"
-                )
+                "This operation does not support immediate "
+                "execution; it will be delegated"
             )
             should_delegate = True
 

--- a/fiftyone/server/view.py
+++ b/fiftyone/server/view.py
@@ -72,7 +72,7 @@ async def load_view(
 
 
 def get_view(
-    dataset_name,
+    dataset,
     view_name=None,
     stages=None,
     filters=None,
@@ -84,7 +84,8 @@ def get_view(
     """Gets the view defined by the given request parameters.
 
     Args:
-        dataset_name: the dataset name
+        dataset: the dataset name or :class:`fiftyone.core.dataset.Dataset`
+        instance
         view_name (None): the name of a saved view to load
         stages (None): an optional list of serialized
             :class:`fiftyone.core.stages.ViewStage` instances
@@ -102,7 +103,8 @@ def get_view(
     Returns:
         a :class:`fiftyone.core.view.DatasetView`
     """
-    dataset = fod.load_dataset(dataset_name)
+    if isinstance(dataset, str):
+        dataset = fod.load_dataset(dataset)
 
     if reload:
         dataset.reload()

--- a/tests/unittests/utils_tests.py
+++ b/tests/unittests/utils_tests.py
@@ -7,6 +7,7 @@ FiftyOne utilities unit tests.
 """
 import time
 import unittest
+from unittest.mock import MagicMock, patch
 
 import numpy as np
 
@@ -311,6 +312,71 @@ class ConfigTests(unittest.TestCase):
 
         self.assertEqual(len(list(db.config.aggregate([]))), 1)
         self.assertEqual(config.id, orig_config.id)
+
+
+from bson import ObjectId
+from fiftyone.core.utils import load_dataset
+
+
+class TestLoadDataset(unittest.TestCase):
+    @patch("fiftyone.core.odm.get_db_conn")
+    @patch("fiftyone.core.dataset.Dataset")
+    def test_load_dataset_by_id(self, mock_dataset, mock_get_db_conn):
+        # Setup
+        identifier = ObjectId()
+        mock_db = MagicMock()
+        mock_get_db_conn.return_value = mock_db
+        mock_db.datasets.find_one.return_value = {
+            "_id": ObjectId(identifier),
+            "name": "test_dataset",
+        }
+
+        # Test
+        result = load_dataset(identifier)
+
+        # Assertions
+        mock_get_db_conn.assert_called_once()
+        mock_db.datasets.find_one.assert_called_once_with(
+            {"_id": ObjectId(identifier)}
+        )
+
+        self.assertEqual(result, mock_dataset.return_value)
+
+    @patch("fiftyone.core.odm.get_db_conn")
+    @patch("fiftyone.core.dataset.Dataset")
+    def test_load_dataset_by_name(self, mock_dataset, mock_get_db_conn):
+        # Setup
+        identifier = "test_dataset"
+        mock_db = MagicMock()
+        mock_get_db_conn.return_value = mock_db
+        mock_db.datasets.find_one.return_value = {
+            "_id": ObjectId(),
+            "name": identifier,
+        }
+
+        # Test
+        result = load_dataset(identifier)
+
+        # Assertions
+        mock_get_db_conn.assert_called_once()
+        mock_db.datasets.find_one.assert_called_once_with({"name": identifier})
+        self.assertEqual(result, mock_dataset.return_value)
+
+    @patch("fiftyone.core.odm.get_db_conn")
+    def test_load_dataset_nonexistent(self, mock_get_db_conn):
+        # Setup
+        identifier = "nonexistent_dataset"
+        mock_db = MagicMock()
+        mock_db.datasets.find_one.return_value = None
+        mock_get_db_conn.return_value = mock_db
+
+        # Call the function and expect a ValueError
+        with self.assertRaises(ValueError) as context:
+            load_dataset(identifier)
+
+        # Assertions
+        mock_get_db_conn.assert_called_once()
+        mock_db.datasets.find_one.assert_called_once_with({"name": identifier})
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What changes are proposed in this pull request?

- load dataset by id rather than name if possible in case a dataset has been renamed (TEAMS-2042)
- pass dataset_id in request params when delegated/queued operation executes
- don't call `load_dataset` to load the dataset without triggering migration and logging last loaded at
- make sure the ctx.view is a view of ctx.dataset

## How is this patch tested? If it is not, please explain why.

Tested locally:
1. Schedule a delegated operation to run (without launching delegation)
2. renaming dataset
3. launching local delegation
4. verify run starts/completes without error due to missing dataset 
5. verify delegated_op doc in db shows the previous/no longer existing dataset name

Also tested rerunning a failed operation after renaming.


## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
