### PR TITLE
Handle App query errors

### DIFF
--- a/app/packages/app/src/pages/datasets/DatasetPage.tsx
+++ b/app/packages/app/src/pages/datasets/DatasetPage.tsx
@@ -6,7 +6,6 @@ import { OperatorCore } from "@fiftyone/operators";
 import "@fiftyone/relay";
 import * as fos from "@fiftyone/state";
 import { datasetQueryContext } from "@fiftyone/state";
-import { NotFoundError } from "@fiftyone/utilities";
 import React, { useEffect } from "react";
 import { usePreloadedQuery } from "react-relay";
 import { useRecoilValue } from "recoil";
@@ -109,10 +108,6 @@ const DatasetPage: Route<DatasetPageQuery> = ({ prepared }) => {
       .getElementById("modal")
       ?.classList.toggle("modalon", isModalActive);
   }, [isModalActive]);
-
-  if (!data.dataset?.name) {
-    throw new NotFoundError({ path: `/datasets/${prepared.variables.name}` });
-  }
 
   return (
     <>

--- a/app/packages/app/src/routing/useRouter.ts
+++ b/app/packages/app/src/routing/useRouter.ts
@@ -1,6 +1,7 @@
 import { getEnvironment, setCurrentEnvironment } from "@fiftyone/state";
 import { useMemo, useRef } from "react";
 
+import { useErrorHandler } from "react-error-boundary";
 import { createRouter, Router } from ".";
 import makeRoutes, { Queries } from "../makeRoutes";
 
@@ -9,11 +10,12 @@ setCurrentEnvironment(environment);
 
 const useRouter = () => {
   const router = useRef<Router<Queries>>();
+  const handleError = useErrorHandler();
 
   router.current = useMemo(() => {
     router.current && router.current.cleanup();
 
-    return createRouter<Queries>(environment, makeRoutes());
+    return createRouter<Queries>(environment, makeRoutes(), handleError);
   }, []);
 
   return { context: router.current.context, environment };

--- a/app/packages/app/src/useEvents/useStateUpdate.ts
+++ b/app/packages/app/src/useEvents/useStateUpdate.ts
@@ -28,7 +28,7 @@ const useStateUpdate: EventHandlerHook = ({
       });
       if (readyStateRef.current !== AppReadyState.OPEN) {
         router.history.replace(path, state);
-        router.load().then(() => setReadyState(AppReadyState.OPEN));
+        router.load().then((e) => setReadyState(AppReadyState.OPEN));
       } else {
         router.history.push(path, state);
       }

--- a/app/packages/app/src/useEvents/useStateUpdate.ts
+++ b/app/packages/app/src/useEvents/useStateUpdate.ts
@@ -28,7 +28,7 @@ const useStateUpdate: EventHandlerHook = ({
       });
       if (readyStateRef.current !== AppReadyState.OPEN) {
         router.history.replace(path, state);
-        router.load().then((e) => setReadyState(AppReadyState.OPEN));
+        router.load().then(() => setReadyState(AppReadyState.OPEN));
       } else {
         router.history.push(path, state);
       }

--- a/app/packages/state/src/utils.ts
+++ b/app/packages/state/src/utils.ts
@@ -179,6 +179,7 @@ const fetchRelay: FetchFunction = async (
     }
   );
 
+  // mutation errors are handled by the calling component or hook
   if (params.operationKind !== "mutation" && "errors" in data && data.errors) {
     throw new GraphQLError({
       errors: data.errors,

--- a/app/packages/state/src/utils.ts
+++ b/app/packages/state/src/utils.ts
@@ -3,13 +3,17 @@ import {
   clone,
   Field,
   getFetchFunction,
+  GQLError,
+  GraphQLError,
   Schema,
   StrictField,
 } from "@fiftyone/utilities";
 import React, { MutableRefObject, useCallback, useRef } from "react";
 import {
   Environment,
+  FetchFunction,
   GraphQLResponse,
+  GraphQLResponseWithData,
   Network,
   RecordSource,
   Store,
@@ -158,22 +162,31 @@ export const setCurrentEnvironment = (environment: Environment) => {
   currentEnvironment = environment;
 };
 
-async function fetchGraphQL(
-  text: string | null | undefined,
-  variables: object
-): Promise<GraphQLResponse> {
-  return await getFetchFunction()<unknown, GraphQLResponse>(
+type GQLResponse = Omit<GraphQLResponseWithData, "errors"> & {
+  errors?: GQLError[];
+};
+
+const fetchRelay: FetchFunction = async (
+  params,
+  variables
+): Promise<GraphQLResponse> => {
+  const data = await await getFetchFunction()<unknown, GQLResponse>(
     "POST",
     "/graphql",
     {
-      query: text,
+      query: params.text,
       variables,
     }
   );
-}
 
-const fetchRelay = async (params, variables) => {
-  return fetchGraphQL(params.text, variables);
+  if (params.operationKind !== "mutation" && "errors" in data && data.errors) {
+    throw new GraphQLError({
+      errors: data.errors,
+      variables,
+    });
+  }
+
+  return data;
 };
 
 export const getEnvironment = () =>


### PR DESCRIPTION
Fixes error boundary handling of the App query and retains view bar error handling introduced in #3613 
<img width="1470" alt="Screenshot 2023-12-07 at 3 30 02 PM" src="https://github.com/voxel51/fiftyone/assets/19821840/4b0362e8-d75d-4c84-b782-e9295e6274c7">

https://github.com/voxel51/fiftyone/assets/19821840/eb3c94d7-b5fb-47da-ba1c-48ffc2e93ba6

