### PR TITLE
bugfix: similarity search only works on default_group_slice

### DIFF
--- a/app/packages/core/src/components/Actions/similar/utils.ts
+++ b/app/packages/core/src/components/Actions/similar/utils.ts
@@ -72,6 +72,7 @@ export const useSortBySimilarity = (close) => {
 
         const view = await snapshot.getPromise(fos.view);
         const subscription = await snapshot.getPromise(fos.stateSubscription);
+        const slice = await snapshot.getPromise(fos.sessionGroupSlice);
 
         const { query, ...commonParams } = parameters;
 
@@ -95,6 +96,7 @@ export const useSortBySimilarity = (close) => {
           subscription,
           filters,
           extended: toSnakeCase(combinedParameters),
+          slice,
         });
         set(fos.similarityParameters, combinedParameters);
         close();

--- a/app/packages/state/src/recoil/groups.ts
+++ b/app/packages/state/src/recoil/groups.ts
@@ -25,7 +25,12 @@ import {
 import { graphQLSelectorFamily } from "recoil-relay";
 import { getSessionRef, sessionAtom } from "../session";
 import type { ResponseFrom } from "../utils";
-import { mediaType, similarityParameters } from "./atoms";
+import {
+  mediaType,
+  selectedLabels,
+  selectedSamples,
+  similarityParameters,
+} from "./atoms";
 import { getBrowserStorageEffectForKey } from "./customEffects";
 import { dataset } from "./dataset";
 import { ModalSample, modalLooker, modalSample } from "./modal";
@@ -127,13 +132,19 @@ export const groupSlice = selector<string>({
     if (get(similarityParameters)) {
       // avoid this pattern
       const unsubscribe = foq.subscribeBefore(() => {
-        getSessionRef().sessionGroupSlice =
+        const session = getSessionRef();
+        session.sessionGroupSlice =
           slice instanceof DefaultValue ? defaultSlice : slice;
+        session.selectedSamples = new Set();
+        session.selectedLabels = [];
+
         unsubscribe();
       });
       reset(similarityParameters);
     } else {
       set(sessionGroupSlice, slice);
+      set(selectedLabels, []);
+      set(selectedSamples, new Set());
     }
   },
 });

--- a/app/packages/state/src/recoil/groups.ts
+++ b/app/packages/state/src/recoil/groups.ts
@@ -19,7 +19,7 @@ import { atom, atomFamily, selector, selectorFamily } from "recoil";
 import { graphQLSelectorFamily } from "recoil-relay";
 import { sessionAtom } from "../session";
 import type { ResponseFrom } from "../utils";
-import { mediaType } from "./atoms";
+import { mediaType, similarityParameters } from "./atoms";
 import { getBrowserStorageEffectForKey } from "./customEffects";
 import { dataset } from "./dataset";
 import { ModalSample, modalLooker, modalSample } from "./modal";
@@ -116,7 +116,14 @@ export const groupSlice = selector<string>({
   get: ({ get }) => {
     return get(isGroup) && get(hasGroupSlices) ? get(sessionGroupSlice) : null;
   },
-  set: ({ set }, slice) => set(sessionGroupSlice, slice),
+  set: ({ get, set }, slice) => {
+    if (Boolean(get(similarityParameters))) {
+      set(similarityParameters, null);
+      set(sessionGroupSlice, slice);
+    } else {
+      set(sessionGroupSlice, slice);
+    }
+  },
 });
 
 export const defaultGroupSlice = graphQLSyncFragmentAtom<

--- a/app/packages/state/src/recoil/selectors.ts
+++ b/app/packages/state/src/recoil/selectors.ts
@@ -8,14 +8,14 @@ import {
   datasetFragment$key,
   graphQLSyncFragmentAtom,
 } from "@fiftyone/relay";
-import { fieldVisibilityStage } from "@fiftyone/state";
+import { currentSlice, fieldVisibilityStage, isGroup } from "@fiftyone/state";
 import { toSnakeCase } from "@fiftyone/utilities";
 import { DefaultValue, atomFamily, selector, selectorFamily } from "recoil";
 import { v4 as uuid } from "uuid";
 import * as atoms from "./atoms";
 import { config } from "./config";
 import { dataset as datasetAtom } from "./dataset";
-import { currentModalSample, modalSample } from "./modal";
+import { currentModalSample, isModalActive, modalSample } from "./modal";
 import { pathFilter } from "./pathFilters";
 import { State } from "./types";
 import { isPatchesView } from "./view";
@@ -384,7 +384,24 @@ export const similarityMethods = selector<{
 }>({
   key: "similarityMethods",
   get: ({ get }) => {
-    const methods = get(datasetAtom)?.brainMethods || [];
+    let methods = get(datasetAtom)?.brainMethods || [];
+    const isGroupDataset = get(isGroup);
+    const activeSlice = get(currentSlice(get(isModalActive)));
+
+    if (isGroupDataset && activeSlice) {
+      methods = methods.filter(({ viewStages }) => {
+        return viewStages.some((vs) => {
+          const { _cls, kwargs } = JSON.parse(vs);
+          if (_cls === "fiftyone.core.stages.SelectGroupSlices") {
+            const sliceValue = kwargs.filter(
+              (kwarg: string[]) => kwarg[0] === "slices"
+            )?.[0]?.[1];
+            if (sliceValue && sliceValue !== activeSlice) return false;
+          }
+          return true;
+        });
+      });
+    }
 
     return methods
       .filter(

--- a/app/packages/state/src/session.ts
+++ b/app/packages/state/src/session.ts
@@ -81,6 +81,10 @@ export const useSessionRef = () => {
   return sessionRef;
 };
 
+export const getSessionRef = () => {
+  return sessionRef;
+};
+
 export const useSessionSetter = () => {
   return useCallback(<K extends SetterKeys>(key: K, value: Session[K]) => {
     const setter = setters[key];

--- a/fiftyone/server/routes/sort.py
+++ b/fiftyone/server/routes/sort.py
@@ -17,6 +17,7 @@ from fiftyone.server.decorators import route
 import fiftyone.server.events as fose
 from fiftyone.server.query import serialize_dataset
 import fiftyone.server.view as fosv
+from fiftyone.server.filters import GroupElementFilter, SampleFilter
 
 
 class Sort(HTTPEndpoint):
@@ -26,6 +27,7 @@ class Sort(HTTPEndpoint):
         filters = data.get("filters", {})
         stages = data.get("view", None)
         subscription = data.get("subscription", None)
+        slice = data.get("slice", None)
 
         await run_sync_task(
             lambda: fosv.get_view(
@@ -35,6 +37,11 @@ class Sort(HTTPEndpoint):
                 extended_stages={
                     "fiftyone.core.stages.SortBySimilarity": data["extended"]
                 },
+                sample_filter=SampleFilter(
+                    group=GroupElementFilter(slice=slice)
+                )
+                if slice is not None
+                else None,
             )
         )
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

Pass in the active session group slice as a parameter for similarity sort requests to update samples
Fixes a bug: similarity search only works on default_group_slice


https://github.com/voxel51/fiftyone/assets/17770824/264345d7-63cf-47e7-9fed-f20a942b224e


## How is this patch tested? If it is not, please explain why.

```
import fiftyone as fo
import fiftyone.zoo as foz
import fiftyone.brain as fob

ds = foz.load_zoo_dataset('quickstart-groups',max_samples=50)
print(ds.default_group_slice) # prints 'left'
view = ds.select_group_slices('right')
fob.compute_similarity(view,model='clip-vit-base32-torch',brain_key='sim_right')

# now Open Dataset in FOT App. Select 'right' group slice. 
# Select an image in the grid or type in "mountian/road/anything" in similarity search prompt to run an Image Sim Search. 

# this should be working as expected
```

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
