### PR TITLE
Adds a toggle to show/hide fields in sample modal that are undefined

### DIFF
--- a/app/packages/core/src/components/Actions/Options.tsx
+++ b/app/packages/core/src/components/Actions/Options.tsx
@@ -269,6 +269,36 @@ const Lightning = () => {
   );
 };
 
+const HideFieldSetting = () => {
+  const [hideNone, setHideNone] = useRecoilState(fos.hideNoneValuedFields);
+  const theme = useTheme();
+
+  return (
+    <>
+      <ActionOption
+        id="hide-none-valued-field-setting"
+        text="Hide None fields"
+        title={"More on hiding none fields"}
+        style={{
+          background: "unset",
+          color: theme.text.primary,
+          paddingTop: 0,
+          paddingBottom: 0,
+        }}
+        svgStyles={{ height: "1rem", marginTop: 7.5 }}
+      />
+      <TabOption
+        active={hideNone ? "enable" : "disable"}
+        options={["disable", "enable"].map((value) => ({
+          text: value,
+          title: value,
+          onClick: () => setHideNone(value === "enable" ? true : false),
+        }))}
+      />
+    </>
+  );
+};
+
 type OptionsProps = {
   modal: boolean;
   anchorRef: RefObject<HTMLElement>;
@@ -282,6 +312,7 @@ const Options = ({ modal, anchorRef }: OptionsProps) => {
 
   return (
     <Popout modal={modal} fixed anchorRef={anchorRef}>
+      {modal && <HideFieldSetting />}
       {isNonNestedDynamicGroup && <DynamicGroupsViewMode modal={modal} />}
       {isGroup && !isDynamicGroup && <GroupStatistics modal={modal} />}
       <MediaFields modal={modal} />

--- a/app/packages/core/src/components/Modal/Modal.tsx
+++ b/app/packages/core/src/components/Modal/Modal.tsx
@@ -66,6 +66,7 @@ const SampleModal = () => {
     : { width: "95%", height: "90%", borderRadius: "3px" };
   const isGroup = useRecoilValue(fos.isGroup);
   const isPcd = useRecoilValue(fos.isPointcloudDataset);
+  const sampleId = useRecoilValue(fos.currentSampleId);
 
   const clearModal = fos.useClearModal();
   const { jsonPanel, helpPanel, onNavigate } = usePanels();
@@ -91,7 +92,7 @@ const SampleModal = () => {
     [eventHandler]
   );
 
-  const noneValuedPaths = useRecoilValue(fos.noneValuedPaths);
+  const noneValuedPaths = useRecoilValue(fos.noneValuedPaths)?.[sampleId];
   const hideNoneFields = useRecoilValue(fos.hideNoneValuedFields);
 
   const renderEntry = useCallback(
@@ -115,7 +116,7 @@ const SampleModal = () => {
           const isFieldPrimitive =
             !isLabelTag && !isLabel && !isOther && !(isTag && mode === "group");
 
-          if (hideNoneFields && noneValuedPaths.has(entry?.path)) {
+          if (hideNoneFields && noneValuedPaths?.has(entry?.path)) {
             return { children: null };
           }
 

--- a/app/packages/core/src/components/Modal/Modal.tsx
+++ b/app/packages/core/src/components/Modal/Modal.tsx
@@ -91,6 +91,9 @@ const SampleModal = () => {
     [eventHandler]
   );
 
+  const noneValuedPaths = useRecoilValue(fos.noneValuedPaths);
+  const hideNoneFields = useRecoilValue(fos.hideNoneValuedFields);
+
   const renderEntry = useCallback(
     (
       key: string,
@@ -104,13 +107,18 @@ const SampleModal = () => {
       ) => void
     ) => {
       switch (entry.kind) {
-        case fos.EntryKind.PATH:
+        case fos.EntryKind.PATH: {
           const isTag = entry.path === "tags";
           const isLabelTag = entry.path === "_label_tags";
           const isLabel = labelPaths.includes(entry.path);
           const isOther = disabled.has(entry.path);
           const isFieldPrimitive =
             !isLabelTag && !isLabel && !isOther && !(isTag && mode === "group");
+
+          if (hideNoneFields && noneValuedPaths.has(entry?.path)) {
+            return { children: null };
+          }
+
           return {
             children: (
               <>
@@ -146,7 +154,7 @@ const SampleModal = () => {
             ),
             disabled: isTag || isOther,
           };
-
+        }
         case fos.EntryKind.GROUP: {
           return {
             children: (
@@ -180,7 +188,7 @@ const SampleModal = () => {
           throw new Error("invalid entry");
       }
     },
-    [disabled, labelPaths, mode]
+    [disabled, hideNoneFields, labelPaths, mode, noneValuedPaths]
   );
 
   useEffect(() => {

--- a/app/packages/core/src/components/Sidebar/Entries/PathValueEntry.tsx
+++ b/app/packages/core/src/components/Sidebar/Entries/PathValueEntry.tsx
@@ -357,13 +357,19 @@ const Loadable = ({ path }: { path: string }) => {
   const color = useRecoilValue(fos.pathColor(path));
   const timeZone = useRecoilValue(fos.timeZone);
   const formatted = format({ ftype, value, timeZone });
-  const [noneValued, setNoneValued] = useRecoilState(fos.noneValuedPaths);
+  const [noneValuedPaths, setNoneValued] = useRecoilState(fos.noneValuedPaths);
+  const sampleId = useRecoilValue(fos.currentSampleId);
+  const noneValued = noneValuedPaths?.[sampleId];
 
   useEffect(() => {
-    if (none && path && !noneValued.has(path)) {
-      setNoneValued(new Set([...noneValued]).add(path));
+    if (none && path && !noneValued?.has(path) && sampleId) {
+      setNoneValued({
+        [sampleId]: noneValued
+          ? new Set([...noneValued]).add(path)
+          : new Set([]),
+      });
     }
-  }, [noneValued, none, path, setNoneValued]);
+  }, [noneValued, none, path, setNoneValued, sampleId]);
 
   return (
     <div

--- a/app/packages/core/src/components/Sidebar/Entries/PathValueEntry.tsx
+++ b/app/packages/core/src/components/Sidebar/Entries/PathValueEntry.tsx
@@ -11,8 +11,8 @@ import {
 } from "@fiftyone/utilities";
 import { KeyboardArrowDown, KeyboardArrowUp } from "@mui/icons-material";
 import { useSpring } from "@react-spring/core";
-import React, { Suspense, useMemo, useState } from "react";
-import { useRecoilValue, useRecoilValueLoadable } from "recoil";
+import React, { Suspense, useEffect, useMemo, useState } from "react";
+import { useRecoilState, useRecoilValue, useRecoilValueLoadable } from "recoil";
 import styled from "styled-components";
 import LoadingDots from "../../../../../components/src/components/Loading/LoadingDots";
 import { prettify } from "../../../utils/generic";
@@ -357,6 +357,13 @@ const Loadable = ({ path }: { path: string }) => {
   const color = useRecoilValue(fos.pathColor(path));
   const timeZone = useRecoilValue(fos.timeZone);
   const formatted = format({ ftype, value, timeZone });
+  const [noneValued, setNoneValued] = useRecoilState(fos.noneValuedPaths);
+
+  useEffect(() => {
+    if (none && path && !noneValued.has(path)) {
+      setNoneValued(new Set([...noneValued]).add(path));
+    }
+  }, [noneValued, none, path, setNoneValued]);
 
   return (
     <div

--- a/app/packages/state/src/recoil/atoms.ts
+++ b/app/packages/state/src/recoil/atoms.ts
@@ -346,3 +346,13 @@ export const isSidebarFilterMode = atom<boolean>({
   key: "isSidebarFilterMode",
   default: true,
 });
+
+export const hideNoneValuedFields = atom<boolean>({
+  key: "hideNoneValuedFields",
+  default: false,
+});
+
+export const noneValuedPaths = atom<Set<string>>({
+  key: "noneValuedPaths",
+  default: new Set(),
+});

--- a/app/packages/state/src/recoil/atoms.ts
+++ b/app/packages/state/src/recoil/atoms.ts
@@ -350,9 +350,14 @@ export const isSidebarFilterMode = atom<boolean>({
 export const hideNoneValuedFields = atom<boolean>({
   key: "hideNoneValuedFields",
   default: false,
+  effects: [
+    getBrowserStorageEffectForKey("hideNoneValuedFields", {
+      valueClass: "boolean",
+    }),
+  ],
 });
 
-export const noneValuedPaths = atom<Set<string>>({
+export const noneValuedPaths = atom<Record<string, Set<string>>>({
   key: "noneValuedPaths",
-  default: new Set(),
+  default: {},
 });


### PR DESCRIPTION
## What changes are proposed in this pull request?

Adds a new settings to sample modal Display Options. Toggling it, hides/ shows the fields with `path = 'None'` to reduce sidebar clutter.

## How is this patch tested? If it is not, please explain why.

Manual

https://github.com/voxel51/fiftyone/assets/109545780/ec054ac9-d3c7-44e9-8d0d-e6545b36dfba

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
