### PR TITLE
improvements to exporters.py

### DIFF
--- a/fiftyone/utils/data/exporters.py
+++ b/fiftyone/utils/data/exporters.py
@@ -1211,7 +1211,7 @@ class MediaExporter(object):
                 outpath = self._filename_maker.get_output_path(media_path)
                 uuid = self._get_uuid(outpath)
 
-            if self.export_mode == True:
+            if self.export_mode is True:
                 etau.copy_file(media_path, outpath)
             elif self.export_mode == "move":
                 etau.move_file(media_path, outpath)
@@ -1228,9 +1228,9 @@ class MediaExporter(object):
                 outpath = self._filename_maker.get_output_path()
                 uuid = self._get_uuid(outpath)
 
-            if self.export_mode == True:
+            if self.export_mode is True:
                 self._write_media(media, outpath)
-            elif self.export_mode != False:
+            elif self.export_mode is not False:
                 raise ValueError(
                     "Cannot export in-memory media when 'export_mode=%s'"
                     % self.export_mode
@@ -2071,7 +2071,7 @@ class FiftyOneDatasetExporter(BatchDatasetExporter):
 
         def _prep_sample(sd):
             filepath = sd["filepath"]
-            if self.export_media != False:
+            if self.export_media is not False:
                 # Store relative path
                 _, uuid = self._media_exporter.export(filepath)
                 sd["filepath"] = os.path.join("data", uuid)
@@ -2212,7 +2212,7 @@ class FiftyOneDatasetExporter(BatchDatasetExporter):
         if value is None:
             return
 
-        if self.export_media != False:
+        if self.export_media is not False:
             # Store relative path
             media_exporter = self._get_media_field_exporter(field_name)
             _, uuid = media_exporter.export(value)
@@ -2713,6 +2713,7 @@ class ImageClassificationDirectoryTreeExporter(LabeledImageDatasetExporter):
         self._media_exporter = ImageExporter(
             self.export_media,
             supported_modes=(True, "move", "symlink"),
+            export_path=self.export_dir,
         )
         self._media_exporter.setup()
 
@@ -2820,6 +2821,7 @@ class VideoClassificationDirectoryTreeExporter(LabeledVideoDatasetExporter):
         self._media_exporter = VideoExporter(
             self.export_media,
             supported_modes=(True, "move", "symlink"),
+            export_path=self.export_dir,
         )
         self._media_exporter.setup()
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

- pass `export_dir` as `export_path` in `ImageClassificationDirectoryTreeExporter` and `VideoClassificationDirectoryTreeExporter`. Not really used in this context but needed in Teams code.
- minor cleanup: `is True` is preferable to `== True` - changed in a few places in this file for export_mode.
https://www.flake8rules.com/rules/E712.html

## How is this patch tested? If it is not, please explain why.

Just minor cleanup - ran export unit tests. Nothing else to test.

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
