### PR TITLE
Remove loading from mongoengine cache

### DIFF
--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -6831,12 +6831,12 @@ def _load_dataset(obj, name, virtual=False):
 
 
 def _do_load_dataset(obj, name):
-    try:
-        # pylint: disable=no-member
-        db = foo.get_db_conn()
-        dataset_doc = db.datasets.find_one({"name": name})
-    except moe.DoesNotExist:
+    # pylint: disable=no-member
+    db = foo.get_db_conn()
+    res = db.datasets.find_one({"name": name})
+    if not res:
         raise ValueError("Dataset '%s' not found" % name)
+    dataset_doc = foo.DatasetDocument.from_dict(res)
 
     sample_collection_name = dataset_doc.sample_collection_name
     frame_collection_name = dataset_doc.frame_collection_name

--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -6833,7 +6833,8 @@ def _load_dataset(obj, name, virtual=False):
 def _do_load_dataset(obj, name):
     try:
         # pylint: disable=no-member
-        dataset_doc = foo.DatasetDocument.objects.get(name=name)
+        db = foo.get_db_conn()
+        dataset_doc = db.datasets.find_one({"name": name})
     except moe.DoesNotExist:
         raise ValueError("Dataset '%s' not found" % name)
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

- Current dataset loading relies on getting the DatasetDocument from the local mongoengine queryset cache, which is problematic when using fiftyone in different processes
- This change should prevent errors like "Dataset does not exist" immediately after creating a dataset or "Dataset already exists" after deleting a dataset, especially when using the python sdk locally but connecting to a remote app.

```
As of MongoEngine 0.8 the querysets utilise a local cache. 
```
link to mongoengine doc: https://docs.mongoengine.org/guide/querying.html

## How is this patch tested? If it is not, please explain why.

(Details)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
