### PR TITLE
Toggle dynamic batcher for add_samples(), others

### DIFF
--- a/docs/source/user_guide/config.rst
+++ b/docs/source/user_guide/config.rst
@@ -74,9 +74,10 @@ FiftyOne supports the configuration options described below:
 +-------------------------------+-------------------------------------+-------------------------------+----------------------------------------------------------------------------------------+
 | `batcher_static_size`         | `FIFTYONE_BATCHER_STATIC_SIZE`      | `100`                         | Fixed size of batches. Ignored if `default_batcher` is not `static`.                   |
 +-------------------------------+-------------------------------------+-------------------------------+----------------------------------------------------------------------------------------+
-| `batcher_target_size`         | `FIFTYONE_BATCHER_TARGET_SIZE`      | `2 ** 20`                     | Target content size of batches, in bytes. Ignored if `default_batcher` is not `size`.  |
+| `batcher_target_size_bytes`   | `FIFTYONE_BATCHER_TARGET_SIZE_BYTES`| `2 ** 20`                     | Target content size of batches, in bytes. Ignored if `default_batcher` is not `size`.  |
 +-------------------------------+-------------------------------------+-------------------------------+----------------------------------------------------------------------------------------+
-| `batcher_target_latency`      | `FIFTYONE_BATCHER_TARGET_LATENCY`   | `0.2`                         | Target latency between batches. Ignored if `default_batcher` is not `latency`.         |
+| `batcher_target_latency`      | `FIFTYONE_BATCHER_TARGET_LATENCY`   | `0.2`                         | Target latency between batches, in seconds. Ignored if `default_batcher` is not        |
+|                               |                                     |                               | `latency`.                                                                             |
 +-------------------------------+-------------------------------------+-------------------------------+----------------------------------------------------------------------------------------+
 | `default_sequence_idx`        | `FIFTYONE_DEFAULT_SEQUENCE_IDX`     | `%06d`                        | The default numeric string pattern to use when writing sequential lists of             |
 |                               |                                     |                               | files.                                                                                 |

--- a/docs/source/user_guide/config.rst
+++ b/docs/source/user_guide/config.rst
@@ -55,7 +55,10 @@ FiftyOne supports the configuration options described below:
 +-------------------------------+-------------------------------------+-------------------------------+----------------------------------------------------------------------------------------+
 | `default_batch_size`          | `FIFTYONE_DEFAULT_BATCH_SIZE`       | `None`                        | A default batch size to use when :ref:`applying models to datasets <model-zoo-apply>`. |
 +-------------------------------+-------------------------------------+-------------------------------+----------------------------------------------------------------------------------------+
-| `bulk_write_batch_size`       | `FIFTYONE_BULK_WRITE_BATCH_SIZE`    | `100_000`                     | Batch size to use for bulk writing MongoDB operations; cannot be > 100,000             |
+| `bulk_write_batch_size`       | `FIFTYONE_BULK_WRITE_BATCH_SIZE`    | `100_000`                     | Batch size to use for bulk writing MongoDB operations; cannot be > 100,000.            |
+|                               |                                     |                               |                                                                                        |
+|                               |                                     |                               | Default changes to `10_000` for                                                        |
+|                               |                                     |                               | :ref:`Teams SDK in API connection mode <teams-api-connection>`.                        |
 +-------------------------------+-------------------------------------+-------------------------------+----------------------------------------------------------------------------------------+
 | `default_batcher`             | `FIFTYONE_DEFAULT_BATCHER`          | `latency`                     | Batching implementation to use in some batched database operations such as             |
 |                               |                                     |                               | :meth:`add_samples() <fiftyone.core.dataset.Dataset.add_samples>`. Supported values    |
@@ -65,6 +68,9 @@ FiftyOne supports the configuration options described below:
 |                               |                                     |                               | of `dynamic_batch_target_latency` between calls. `size` is the default for the         |
 |                               |                                     |                               | FiftyOne Teams SDK, which targets a size of `dynamic_batch_target_size` bytes for      |
 |                               |                                     |                               | each call. `static` uses a fixed batch size of `batcher_static_size`.                  |
+|                               |                                     |                               |                                                                                        |
+|                               |                                     |                               | Default changes to `size` for                                                          |
+|                               |                                     |                               | :ref:`Teams SDK in API connection mode <teams-api-connection>`.                        |
 +-------------------------------+-------------------------------------+-------------------------------+----------------------------------------------------------------------------------------+
 | `batcher_static_size`         | `FIFTYONE_BATCHER_STATIC_SIZE`      | `100`                         | Fixed size of batches. Ignored if `default_batcher` is not `static`.                   |
 +-------------------------------+-------------------------------------+-------------------------------+----------------------------------------------------------------------------------------+

--- a/docs/source/user_guide/config.rst
+++ b/docs/source/user_guide/config.rst
@@ -64,13 +64,13 @@ FiftyOne supports the configuration options described below:
 |                               |                                     |                               | `latency` is the default, which uses a dynamic batch size to achieve a target latency  |
 |                               |                                     |                               | of `dynamic_batch_target_latency` between calls. `size` is the default for the         |
 |                               |                                     |                               | FiftyOne Teams SDK, which targets a size of `dynamic_batch_target_size` bytes for      |
-|                               |                                     |                               | each call. `static` uses a fixed batch size of `database_static_batch_size`.           |
+|                               |                                     |                               | each call. `static` uses a fixed batch size of `batcher_static_size`.                  |
 +-------------------------------+-------------------------------------+-------------------------------+----------------------------------------------------------------------------------------+
-| `dynamic_batch_target_latency`| `FIFTYONE_DYNAMIC_BATCH_LATENCY`    | `0.2`                         | Target latency between batches. Ignored if `default_batcher` is not `latency`.         |
+| `batcher_static_size`         | `FIFTYONE_BATCHER_STATIC_SIZE`      | `100`                         | Fixed size of batches. Ignored if `default_batcher` is not `static`.                   |
 +-------------------------------+-------------------------------------+-------------------------------+----------------------------------------------------------------------------------------+
-| `dynamic_batch_target_size`   | `FIFTYONE_DYNAMIC_BATCH_TARGET_SIZE`| `2 ** 20`                     | Target content size of batches, in bytes. Ignored if `default_batcher` is not `size`.  |
+| `batcher_target_size`         | `FIFTYONE_BATCHER_TARGET_SIZE`      | `2 ** 20`                     | Target content size of batches, in bytes. Ignored if `default_batcher` is not `size`.  |
 +-------------------------------+-------------------------------------+-------------------------------+----------------------------------------------------------------------------------------+
-| `database_static_batch_size`  | `FIFTYONE_STATIC_BATCH_SIZE`        | `100`                         | Fixed size of batches. Ignored if `default_batcher` is not `static`.                   |
+| `batcher_target_latency`      | `FIFTYONE_BATCHER_TARGET_LATENCY`   | `0.2`                         | Target latency between batches. Ignored if `default_batcher` is not `latency`.         |
 +-------------------------------+-------------------------------------+-------------------------------+----------------------------------------------------------------------------------------+
 | `default_sequence_idx`        | `FIFTYONE_DEFAULT_SEQUENCE_IDX`     | `%06d`                        | The default numeric string pattern to use when writing sequential lists of             |
 |                               |                                     |                               | files.                                                                                 |
@@ -153,6 +153,9 @@ and the CLI:
     .. code-block:: text
 
         {
+            "batcher_static_size": 100,
+            "batcher_target_latency": 0.2,
+            "batcher_target_size": 1048576,
             "bulk_write_batch_size": 100000,
             "database_admin": true,
             "database_dir": "~/.fiftyone/var/lib/mongo",
@@ -164,6 +167,7 @@ and the CLI:
             "default_app_address": null,
             "default_app_port": 5151,
             "default_batch_size": null,
+            "default_batcher": "latency",
             "default_dataset_dir": "~/fiftyone",
             "default_image_ext": ".jpg",
             "default_ml_backend": "torch",
@@ -200,6 +204,9 @@ and the CLI:
     .. code-block:: text
 
         {
+            "batcher_static_size": 100,
+            "batcher_target_latency": 0.2,
+            "batcher_target_size": 1048576,
             "bulk_write_batch_size": 100000,
             "database_admin": true,
             "database_dir": "~/.fiftyone/var/lib/mongo",
@@ -211,6 +218,7 @@ and the CLI:
             "default_app_address": null,
             "default_app_port": 5151,
             "default_batch_size": null,
+            "default_batcher": "latency",
             "default_dataset_dir": "~/fiftyone",
             "default_image_ext": ".jpg",
             "default_ml_backend": "torch",

--- a/docs/source/user_guide/config.rst
+++ b/docs/source/user_guide/config.rst
@@ -59,11 +59,12 @@ FiftyOne supports the configuration options described below:
 +-------------------------------+-------------------------------------+-------------------------------+----------------------------------------------------------------------------------------+
 | `default_batcher`             | `FIFTYONE_DEFAULT_BATCHER`          | `latency`                     | Batching implementation to use in some batched database operations such as             |
 |                               |                                     |                               | :meth:`add_samples() <fiftyone.core.dataset.Dataset.add_samples>`. Supported values    |
-|                               |                                     |                               | are `latency`, `size`, and `static`. `latency` is the default, which uses a dynamic    |
-|                               |                                     |                               | batch size attempting to achieve a target latency between calls                        |
-|                               |                                     |                               | `default_dynamic_batcher_target_latency`. `size` is the default for FiftyOne Teams SDK,|
-|                               |                                     |                               | which attempts to achieve a target content size `default_dynamic_batcher_target_size`. |
-|                               |                                     |                               | `static` uses a fixed batch size `default_database_static_batch_size`.                 |
+|                               |                                     |                               | are `latency`, `size`, and `static`.                                                   |
+|                               |                                     |                               |                                                                                        |
+|                               |                                     |                               | `latency` is the default, which uses a dynamic batch size to achieve a target latency  |
+|                               |                                     |                               | of `dynamic_batch_target_latency` between calls. `size` is the default for the         |
+|                               |                                     |                               | FiftyOne Teams SDK, which targets a size of `dynamic_batch_target_size` bytes for      |
+|                               |                                     |                               | each call. `static` uses a fixed batch size of `database_static_batch_size`.           |
 +-------------------------------+-------------------------------------+-------------------------------+----------------------------------------------------------------------------------------+
 | `dynamic_batch_target_latency`| `FIFTYONE_DYNAMIC_BATCH_LATENCY`    | `0.2`                         | Target latency between batches. Ignored if `default_batcher` is not `latency`.         |
 +-------------------------------+-------------------------------------+-------------------------------+----------------------------------------------------------------------------------------+

--- a/docs/source/user_guide/config.rst
+++ b/docs/source/user_guide/config.rst
@@ -65,8 +65,8 @@ FiftyOne supports the configuration options described below:
 |                               |                                     |                               | are `latency`, `size`, and `static`.                                                   |
 |                               |                                     |                               |                                                                                        |
 |                               |                                     |                               | `latency` is the default, which uses a dynamic batch size to achieve a target latency  |
-|                               |                                     |                               | of `dynamic_batch_target_latency` between calls. `size` is the default for the         |
-|                               |                                     |                               | FiftyOne Teams SDK, which targets a size of `dynamic_batch_target_size` bytes for      |
+|                               |                                     |                               | of `batcher_target_latency` between calls. `size` is the default for the         |
+|                               |                                     |                               | FiftyOne Teams SDK, which targets a size of `batcher_target_size` bytes for      |
 |                               |                                     |                               | each call. `static` uses a fixed batch size of `batcher_static_size`.                  |
 |                               |                                     |                               |                                                                                        |
 |                               |                                     |                               | Default changes to `size` for                                                          |

--- a/docs/source/user_guide/config.rst
+++ b/docs/source/user_guide/config.rst
@@ -57,6 +57,20 @@ FiftyOne supports the configuration options described below:
 +-------------------------------+-------------------------------------+-------------------------------+----------------------------------------------------------------------------------------+
 | `bulk_write_batch_size`       | `FIFTYONE_BULK_WRITE_BATCH_SIZE`    | `100_000`                     | Batch size to use for bulk writing MongoDB operations; cannot be > 100,000             |
 +-------------------------------+-------------------------------------+-------------------------------+----------------------------------------------------------------------------------------+
+| `default_batcher`             | `FIFTYONE_DEFAULT_BATCHER`          | `latency`                     | Batching implementation to use in some batched database operations such as             |
+|                               |                                     |                               | :meth:`add_samples() <fiftyone.core.dataset.Dataset.add_samples>`. Supported values    |
+|                               |                                     |                               | are `latency`, `size`, and `static`. `latency` is the default, which uses a dynamic    |
+|                               |                                     |                               | batch size attempting to achieve a target latency between calls                        |
+|                               |                                     |                               | `default_dynamic_batcher_target_latency`. `size` is the default for FiftyOne Teams SDK,|
+|                               |                                     |                               | which attempts to achieve a target content size `default_dynamic_batcher_target_size`. |
+|                               |                                     |                               | `static` uses a fixed batch size `default_database_static_batch_size`.                 |
++-------------------------------+-------------------------------------+-------------------------------+----------------------------------------------------------------------------------------+
+| `dynamic_batch_target_latency`| `FIFTYONE_DYNAMIC_BATCH_LATENCY`    | `0.2`                         | Target latency between batches. Ignored if `default_batcher` is not `latency`.         |
++-------------------------------+-------------------------------------+-------------------------------+----------------------------------------------------------------------------------------+
+| `dynamic_batch_target_size`   | `FIFTYONE_DYNAMIC_BATCH_TARGET_SIZE`| `2 ** 20`                     | Target content size of batches, in bytes. Ignored if `default_batcher` is not `size`.  |
++-------------------------------+-------------------------------------+-------------------------------+----------------------------------------------------------------------------------------+
+| `database_static_batch_size`  | `FIFTYONE_STATIC_BATCH_SIZE`        | `100`                         | Fixed size of batches. Ignored if `default_batcher` is not `static`.                   |
++-------------------------------+-------------------------------------+-------------------------------+----------------------------------------------------------------------------------------+
 | `default_sequence_idx`        | `FIFTYONE_DEFAULT_SEQUENCE_IDX`     | `%06d`                        | The default numeric string pattern to use when writing sequential lists of             |
 |                               |                                     |                               | files.                                                                                 |
 +-------------------------------+-------------------------------------+-------------------------------+----------------------------------------------------------------------------------------+

--- a/fiftyone/core/config.py
+++ b/fiftyone/core/config.py
@@ -160,17 +160,29 @@ class FiftyOneConfig(EnvConfig):
             env_var="FIFTYONE_BULK_WRITE_BATCH_SIZE",
             default=100_000,  # mongodb limit
         )
-        self.default_database_batch_size = self.parse_int(
-            d,
-            "default_database_batch_size",
-            env_var="FIFTYONE_DEFAULT_DATABASE_BATCH_SIZE",
-            default=100,
-        )
         self.default_batcher = self.parse_string(
             d,
             "default_batcher",
             env_var="FIFTYONE_DEFAULT_BATCHER",
-            default="dynamic",
+            default="latency",
+        )
+        self.default_database_static_batch_size = self.parse_int(
+            d,
+            "default_database_static_batch_size",
+            env_var="FIFTYONE_DEFAULT_DATABASE_STATIC_BATCH_SIZE",
+            default=100,
+        )
+        self.default_dynamic_batcher_target_size = self.parse_int(
+            d,
+            "default_dynamic_batcher_target_size",
+            env_var="FIFTYONE_DEFAULT_DYNAMIC_BATCHER_TARGET_SIZE",
+            default=2**20,
+        )
+        self.default_dynamic_batcher_target_latency = self.parse_number(
+            d,
+            "default_dynamic_batcher_target_latency",
+            env_var="FIFTYONE_DEFAULT_DYNAMIC_BATCHER_TARGET_LATENCY",
+            default=0.2,
         )
         self.default_sequence_idx = self.parse_string(
             d,

--- a/fiftyone/core/config.py
+++ b/fiftyone/core/config.py
@@ -166,22 +166,22 @@ class FiftyOneConfig(EnvConfig):
             env_var="FIFTYONE_DEFAULT_BATCHER",
             default="latency",
         )
-        self.database_static_batch_size = self.parse_int(
+        self.batcher_static_size = self.parse_int(
             d,
-            "database_static_batch_size",
-            env_var="FIFTYONE_STATIC_BATCH_SIZE",
+            "batcher_static_size",
+            env_var="FIFTYONE_BATCHER_STATIC_SIZE",
             default=100,
         )
-        self.dynamic_batch_target_size = self.parse_int(
+        self.batcher_target_size = self.parse_int(
             d,
-            "dynamic_batch_target_size",
-            env_var="FIFTYONE_DYNAMIC_BATCH_TARGET_SIZE",
+            "batcher_target_size",
+            env_var="FIFTYONE_BATCHER_TARGET_SIZE",
             default=2**20,
         )
-        self.dynamic_batch_target_latency = self.parse_number(
+        self.batcher_target_latency = self.parse_number(
             d,
-            "dynamic_batch_target_latency",
-            env_var="FIFTYONE_DYNAMIC_BATCH_LATENCY",
+            "batcher_target_latency",
+            env_var="FIFTYONE_BATCHER_TARGET_LATENCY",
             default=0.2,
         )
         self.default_sequence_idx = self.parse_string(

--- a/fiftyone/core/config.py
+++ b/fiftyone/core/config.py
@@ -160,6 +160,18 @@ class FiftyOneConfig(EnvConfig):
             env_var="FIFTYONE_BULK_WRITE_BATCH_SIZE",
             default=100_000,  # mongodb limit
         )
+        self.default_database_batch_size = self.parse_int(
+            d,
+            "default_database_batch_size",
+            env_var="FIFTYONE_DEFAULT_DATABASE_BATCH_SIZE",
+            default=100,
+        )
+        self.default_batcher = self.parse_string(
+            d,
+            "default_batcher",
+            env_var="FIFTYONE_DEFAULT_BATCHER",
+            default="dynamic",
+        )
         self.default_sequence_idx = self.parse_string(
             d,
             "default_sequence_idx",

--- a/fiftyone/core/config.py
+++ b/fiftyone/core/config.py
@@ -166,22 +166,22 @@ class FiftyOneConfig(EnvConfig):
             env_var="FIFTYONE_DEFAULT_BATCHER",
             default="latency",
         )
-        self.default_database_static_batch_size = self.parse_int(
+        self.database_static_batch_size = self.parse_int(
             d,
-            "default_database_static_batch_size",
-            env_var="FIFTYONE_DEFAULT_DATABASE_STATIC_BATCH_SIZE",
+            "database_static_batch_size",
+            env_var="FIFTYONE_STATIC_BATCH_SIZE",
             default=100,
         )
-        self.default_dynamic_batcher_target_size = self.parse_int(
+        self.dynamic_batch_target_size = self.parse_int(
             d,
-            "default_dynamic_batcher_target_size",
-            env_var="FIFTYONE_DEFAULT_DYNAMIC_BATCHER_TARGET_SIZE",
+            "dynamic_batch_target_size",
+            env_var="FIFTYONE_DYNAMIC_BATCH_TARGET_SIZE",
             default=2**20,
         )
-        self.default_dynamic_batcher_target_latency = self.parse_number(
+        self.dynamic_batch_target_latency = self.parse_number(
             d,
-            "default_dynamic_batcher_target_latency",
-            env_var="FIFTYONE_DEFAULT_DYNAMIC_BATCHER_TARGET_LATENCY",
+            "dynamic_batch_target_latency",
+            env_var="FIFTYONE_DYNAMIC_BATCH_LATENCY",
             default=0.2,
         )
         self.default_sequence_idx = self.parse_string(

--- a/fiftyone/core/config.py
+++ b/fiftyone/core/config.py
@@ -172,10 +172,10 @@ class FiftyOneConfig(EnvConfig):
             env_var="FIFTYONE_BATCHER_STATIC_SIZE",
             default=100,
         )
-        self.batcher_target_size = self.parse_int(
+        self.batcher_target_size_bytes = self.parse_int(
             d,
-            "batcher_target_size",
-            env_var="FIFTYONE_BATCHER_TARGET_SIZE",
+            "batcher_target_size_bytes",
+            env_var="FIFTYONE_BATCHER_TARGET_SIZE_BYTES",
             default=2**20,
         )
         self.batcher_target_latency = self.parse_number(

--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -2581,11 +2581,6 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
             except:
                 pass
 
-        # Get default batcher:
-        # dynamic - Dynamically size batches so that they are as large as
-        #   possible while still achieving a nice frame rate on the progress bar
-        # size - Dynamically size batches to reach a target bson content size
-        # static - fixed size batches
         batcher = fou.get_default_batcher(samples, progress=True)
 
         with batcher:

--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -2563,7 +2563,7 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
                 sample.frames.save()
 
         if batcher is not None and batcher.manual_backpressure:
-            batcher.register_backpressure(dicts)
+            batcher.apply_backpressure(dicts)
 
         return [str(d["_id"]) for d in dicts]
 
@@ -2623,7 +2623,7 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
                 sample.frames.save()
 
         if batcher is not None and batcher.manual_backpressure:
-            batcher.register_backpressure(dicts)
+            batcher.apply_backpressure(dicts)
 
     def _make_dict(self, sample, include_id=False):
         d = sample.to_mongo_dict(include_id=include_id)

--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -2474,13 +2474,8 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
 
         # Dynamically size batches so that they are as large as possible while
         # still achieving a nice frame rate on the progress bar
-        batcher = fou.DynamicBatcher(
-            samples,
-            target_latency=0.2,
-            init_batch_size=1,
-            max_batch_beta=2.0,
-            progress=True,
-            total=num_samples,
+        batcher = fou.get_default_batcher(
+            samples, progress=True, total=num_samples
         )
 
         sample_ids = []
@@ -2585,13 +2580,7 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
 
         # Dynamically size batches so that they are as large as possible while
         # still achieving a nice frame rate on the progress bar
-        batcher = fou.DynamicBatcher(
-            samples,
-            target_latency=0.2,
-            init_batch_size=1,
-            max_batch_beta=2.0,
-            progress=True,
-        )
+        batcher = fou.get_default_batcher(samples, progress=True)
 
         with batcher:
             for batch in batcher:

--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -2472,11 +2472,6 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
             except:
                 pass
 
-        # Get default batcher:
-        # latency - Dynamically size batches so that they are as large as
-        #   possible while still achieving a nice frame rate on the progress bar
-        # size - Dynamically size batches to reach a target bson content size
-        # static - fixed size batches
         batcher = fou.get_default_batcher(
             samples, progress=True, total=num_samples
         )

--- a/fiftyone/core/odm/database.py
+++ b/fiftyone/core/odm/database.py
@@ -755,17 +755,9 @@ def insert_documents(docs, coll, ordered=False, progress=False, num_docs=None):
         a list of IDs of the inserted documents
     """
     ids = []
+    batcher = fou.get_default_batcher(docs, progress=progress, total=num_docs)
 
     try:
-        # Get default batcher:
-        # dynamic - Dynamically size batches so that they are as large as
-        #   possible while still achieving a nice frame rate on the progress bar
-        # size - Dynamically size batches to reach a target bson content size
-        # static - fixed size batches
-        batcher = fou.get_default_batcher(
-            docs, progress=progress, total=num_docs
-        )
-
         with batcher:
             for batch in batcher:
                 batch = list(batch)

--- a/fiftyone/core/odm/database.py
+++ b/fiftyone/core/odm/database.py
@@ -757,14 +757,8 @@ def insert_documents(docs, coll, ordered=False, progress=False, num_docs=None):
     ids = []
 
     try:
-        batcher = fou.DynamicBatcher(
-            docs,
-            target_latency=0.2,
-            init_batch_size=1,
-            max_batch_beta=2.0,
-            max_batch_size=100000,  # mongodb limit
-            progress=progress,
-            total=num_docs,
+        batcher = fou.get_default_batcher(
+            docs, progress=progress, total=num_docs
         )
 
         with batcher:

--- a/fiftyone/core/utils.py
+++ b/fiftyone/core/utils.py
@@ -1411,6 +1411,22 @@ class StaticBatcher(Batcher):
 
 
 def get_default_batcher(iterable, progress=True, total=None):
+    """Returns a ``Batcher`` over ``iterable`` using defaults from the config.
+
+    Uses ``fiftyone.config.default_batcher`` to determine the implementation
+    to use, and related configuration values as needed for each.
+
+    Args:
+        iterable: an iterable to batch over
+        progress (True): whether to render a progress bar tracking the
+            consumption of the batches
+        total (None): the length of ``iterable``. Only applicable when
+            ``progress=True``. If not provided, it is computed via
+            ``len(iterable)``, if possible
+
+    Returns:
+        ``fiftyone.core.utils.Batcher``
+    """
     default_batcher = fo.config.default_batcher
     if default_batcher == "latency":
         target_latency = fo.config.dynamic_batch_target_latency

--- a/fiftyone/core/utils.py
+++ b/fiftyone/core/utils.py
@@ -1413,7 +1413,7 @@ class StaticBatcher(Batcher):
 def get_default_batcher(iterable, progress=True, total=None):
     default_batcher = fo.config.default_batcher
     if default_batcher == "latency":
-        target_latency = fo.config.default_dynamic_batcher_target_latency
+        target_latency = fo.config.dynamic_batch_target_latency
         return LatencyDynamicBatcher(
             iterable,
             target_latency=target_latency,
@@ -1424,7 +1424,7 @@ def get_default_batcher(iterable, progress=True, total=None):
             total=total,
         )
     elif default_batcher == "size":
-        target_content_size = fo.config.default_dynamic_batcher_target_size
+        target_content_size = fo.config.dynamic_batch_target_size
         return BsonSizeDynamicBatcher(
             iterable,
             target_size=target_content_size,
@@ -1435,7 +1435,7 @@ def get_default_batcher(iterable, progress=True, total=None):
             total=total,
         )
     elif default_batcher == "static":
-        batch_size = fo.config.default_database_static_batch_size
+        batch_size = fo.config.database_static_batch_size
         return StaticBatcher(
             iterable, batch_size=batch_size, progress=progress, total=total
         )

--- a/fiftyone/core/utils.py
+++ b/fiftyone/core/utils.py
@@ -958,7 +958,7 @@ class ProgressBar(etau.ProgressBar):
 
 
 class Batcher(abc.ABC):
-    """Base class for iterating over the elements of an iterable in batches"""
+    """Base class for iterating over the elements of an iterable in batches."""
 
     manual_backpressure = False
 
@@ -1020,8 +1020,8 @@ class Batcher(abc.ABC):
                 self._pb.__enter__()
             else:
                 logger.warning(
-                    "DynamicBatcher must be invoked as a context manager in "
-                    "order to print progress"
+                    "Batcher must be invoked as a context manager in order to "
+                    "print progress"
                 )
                 self.progress = False
 
@@ -1073,7 +1073,7 @@ class Batcher(abc.ABC):
         """Apply backpressure needed to rightsize the next batch.
 
         Required to be implemented and called every iteration, if
-            ``self.manual_backpressure == True``
+        ``self.manual_backpressure == True``.
 
         Subclass defines arguments and behavior of this method.
         """
@@ -1149,7 +1149,7 @@ class BaseDynamicBatcher(Batcher):
 
     @abc.abstractmethod
     def _get_measurement(self):
-        """Get backpressure measurement for current batch"""
+        """Get backpressure measurement for current batch."""
 
 
 class LatencyDynamicBatcher(BaseDynamicBatcher):
@@ -1180,7 +1180,7 @@ class LatencyDynamicBatcher(BaseDynamicBatcher):
             elements,
             target_latency=0.1,
             max_batch_beta=2.0,
-            progress=True
+            progress=True,
         )
 
         with batcher:
@@ -1243,7 +1243,7 @@ class LatencyDynamicBatcher(BaseDynamicBatcher):
 
 
 # Define this for backwards compatibility in case someone was using this
-#   batcher directly
+# batcher directly
 DynamicBatcher = LatencyDynamicBatcher
 
 
@@ -1362,18 +1362,12 @@ class StaticBatcher(Batcher):
 
         elements = range(int(1e7))
 
-        batcher = fou.StaticBatcher(
-            elements, batch_size=10000
-        )
+        batcher = fou.StaticBatcher(elements, batch_size=10000)
 
         for batch in batcher:
             print("batch size: %d" % len(batch))
 
-        batcher = fou.StaticBatcher(
-            elements,
-            batch_size=10000,
-            progress=True
-        )
+        batcher = fou.StaticBatcher(elements, batch_size=10000, progress=True)
 
         with batcher:
             for batch in batcher:
@@ -1411,7 +1405,8 @@ class StaticBatcher(Batcher):
 
 
 def get_default_batcher(iterable, progress=True, total=None):
-    """Returns a ``Batcher`` over ``iterable`` using defaults from the config.
+    """Returns a :class:`Batcher` over ``iterable`` using defaults from your
+    FiftyOne config.
 
     Uses ``fiftyone.config.default_batcher`` to determine the implementation
     to use, and related configuration values as needed for each.
@@ -1425,7 +1420,7 @@ def get_default_batcher(iterable, progress=True, total=None):
             ``len(iterable)``, if possible
 
     Returns:
-        ``fiftyone.core.utils.Batcher``
+        a :class:`Batcher`
     """
     default_batcher = fo.config.default_batcher
     if default_batcher == "latency":

--- a/fiftyone/core/utils.py
+++ b/fiftyone/core/utils.py
@@ -1435,7 +1435,7 @@ def get_default_batcher(iterable, progress=True, total=None):
             total=total,
         )
     elif default_batcher == "size":
-        target_content_size = fo.config.batcher_target_size
+        target_content_size = fo.config.batcher_target_size_bytes
         return BSONSizeDynamicBatcher(
             iterable,
             target_size=target_content_size,

--- a/fiftyone/core/utils.py
+++ b/fiftyone/core/utils.py
@@ -1247,7 +1247,7 @@ class LatencyDynamicBatcher(BaseDynamicBatcher):
 DynamicBatcher = LatencyDynamicBatcher
 
 
-class BsonSizeDynamicBatcher(BaseDynamicBatcher):
+class BSONSizeDynamicBatcher(BaseDynamicBatcher):
     """Class for iterating over the elements of an iterable with a dynamic
     batch size to achieve a desired BSON content size.
 
@@ -1268,7 +1268,7 @@ class BsonSizeDynamicBatcher(BaseDynamicBatcher):
 
         elements = range(int(1e7))
 
-        batcher = fou.BsonSizeDynamicBatcher(
+        batcher = fou.BSONSizeDynamicBatcher(
             elements, target_size=2**20, max_batch_beta=2.0
         )
 
@@ -1281,7 +1281,7 @@ class BsonSizeDynamicBatcher(BaseDynamicBatcher):
             print("batch size: %d" % len(batch))
             batcher.apply_backpressure(batch)
 
-        batcher = fou.BsonSizeDynamicBatcher(
+        batcher = fou.BSONSizeDynamicBatcher(
             elements,
             target_size=2**20,
             max_batch_beta=2.0,
@@ -1316,7 +1316,7 @@ class BsonSizeDynamicBatcher(BaseDynamicBatcher):
     def __init__(
         self,
         iterable,
-        target_size=2**15,
+        target_size=2**20,
         init_batch_size=1,
         min_batch_size=1,
         max_batch_size=None,
@@ -1424,7 +1424,7 @@ def get_default_batcher(iterable, progress=True, total=None):
     """
     default_batcher = fo.config.default_batcher
     if default_batcher == "latency":
-        target_latency = fo.config.dynamic_batch_target_latency
+        target_latency = fo.config.batcher_target_latency
         return LatencyDynamicBatcher(
             iterable,
             target_latency=target_latency,
@@ -1435,8 +1435,8 @@ def get_default_batcher(iterable, progress=True, total=None):
             total=total,
         )
     elif default_batcher == "size":
-        target_content_size = fo.config.dynamic_batch_target_size
-        return BsonSizeDynamicBatcher(
+        target_content_size = fo.config.batcher_target_size
+        return BSONSizeDynamicBatcher(
             iterable,
             target_size=target_content_size,
             init_batch_size=1,
@@ -1446,7 +1446,7 @@ def get_default_batcher(iterable, progress=True, total=None):
             total=total,
         )
     elif default_batcher == "static":
-        batch_size = fo.config.database_static_batch_size
+        batch_size = fo.config.batcher_static_size
         return StaticBatcher(
             iterable, batch_size=batch_size, progress=progress, total=total
         )

--- a/tests/unittests/utils_tests.py
+++ b/tests/unittests/utils_tests.py
@@ -29,7 +29,7 @@ class BatcherTests(unittest.TestCase):
         with patch.object(fo.config, "default_batcher", "latency"):
             with patch.object(
                 fo.config,
-                "default_dynamic_batcher_target_latency",
+                "dynamic_batch_target_latency",
                 target_latency,
             ):
                 batcher = fou.get_default_batcher(iterable)
@@ -40,7 +40,7 @@ class BatcherTests(unittest.TestCase):
         with patch.object(fo.config, "default_batcher", "static"):
             with patch.object(
                 fo.config,
-                "default_database_static_batch_size",
+                "database_static_batch_size",
                 static_batch_size,
             ):
                 batcher = fou.get_default_batcher(iterable)
@@ -51,7 +51,7 @@ class BatcherTests(unittest.TestCase):
         with patch.object(fo.config, "default_batcher", "size"):
             with patch.object(
                 fo.config,
-                "default_dynamic_batcher_target_size",
+                "dynamic_batch_target_size",
                 target_size,
             ):
                 batcher = fou.get_default_batcher(iterable)

--- a/tests/unittests/utils_tests.py
+++ b/tests/unittests/utils_tests.py
@@ -51,7 +51,7 @@ class BatcherTests(unittest.TestCase):
         with patch.object(fo.config, "default_batcher", "size"):
             with patch.object(
                 fo.config,
-                "batcher_target_size",
+                "batcher_target_size_bytes",
                 target_size,
             ):
                 batcher = fou.get_default_batcher(iterable)

--- a/tests/unittests/utils_tests.py
+++ b/tests/unittests/utils_tests.py
@@ -29,7 +29,7 @@ class BatcherTests(unittest.TestCase):
         with patch.object(fo.config, "default_batcher", "latency"):
             with patch.object(
                 fo.config,
-                "dynamic_batch_target_latency",
+                "batcher_target_latency",
                 target_latency,
             ):
                 batcher = fou.get_default_batcher(iterable)
@@ -40,7 +40,7 @@ class BatcherTests(unittest.TestCase):
         with patch.object(fo.config, "default_batcher", "static"):
             with patch.object(
                 fo.config,
-                "database_static_batch_size",
+                "batcher_static_size",
                 static_batch_size,
             ):
                 batcher = fou.get_default_batcher(iterable)
@@ -51,12 +51,12 @@ class BatcherTests(unittest.TestCase):
         with patch.object(fo.config, "default_batcher", "size"):
             with patch.object(
                 fo.config,
-                "dynamic_batch_target_size",
+                "batcher_target_size",
                 target_size,
             ):
                 batcher = fou.get_default_batcher(iterable)
                 self.assertTrue(
-                    isinstance(batcher, fou.BsonSizeDynamicBatcher)
+                    isinstance(batcher, fou.BSONSizeDynamicBatcher)
                 )
                 self.assertEqual(batcher.target_measurement, target_size)
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

- Add `StaticBatcher` as an option to use in place of `DynamicBatcher`. The latter attempts to optimize for a nice flowing progress bar, whereas the former optimizes for predictability and is better in cases where latency between machine and MongoDB is higher.
- Add `BSONSizeDynamicBatcher` as an option. Instead of using latency between calls as a target, attempts to achieve a target BSON content size. The caller must register "backpressure" with the batcher so it can adjust the batch size - by giving it an iterable of BSON-able items that would approximate the size you want to optimize for. In the main case, it would be `list[fo.Sample]` in the batches and corresponding `list[dict]` provided back to the batcher.
- Add configuration to allow switching from the default "latency" to new "static" and "size" batchers. Also database batcher size (for static), target latency (for default 'latency' batcher) and target content size (for 'size' batcher) are all configurable.

## How is this patch tested? If it is not, please explain why.

- By default, add_samples() should do the same thing.
- Only if you configure it to use `StaticBatcher` will it change behavior.
- Added some unit tests for batch factory and static batcher

```python
import fiftyone as fo

dataset1 = fo.zoo.load_zoo_dataset("quickstart")

dataset2 = fo.Dataset()

# Can set this or not, default is 'latency'
#fo.config.default_batcher = "latency"

# Should see irregular batch size with progress bar flowing smoothly,
#  approximately 5 updates per second.
fo.config.batcher_target_latency = 0.2
dataset2.add_samples(dataset1)

# Should see regular batch size of 10 in the progress bar
fo.config.default_batcher = "static"
fo.config.batcher_static_size = 10
dataset2.add_samples(dataset1)

# Should see irregular batch size, where the sample dict size is approximately 32 KiB,
#  or 6-8 samples of "quickstart" dataset.
fo.config.default_batcher = "size"
fo.config.batcher_target_size = 2 ** 15
dataset2.add_samples(dataset1)

dataset1.delete()
dataset2.delete()
```

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

Added new batcher choices (static; target-content-size-based) for greater predictability in some batched database operations such as `add_samples()`.

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
