### PR TITLE
use recoil datasetAppConfig over dataset.appConfig

### DIFF
--- a/app/packages/plugins/src/index.ts
+++ b/app/packages/plugins/src/index.ts
@@ -349,11 +349,11 @@ export function usePluginSettings<T>(
   pluginName: string,
   defaults?: Partial<T>
 ): T {
-  const dataset = recoil.useRecoilValue(fos.dataset);
+  const datasetAppConfig = recoil.useRecoilValue(fos.datasetAppConfig);
   const appConfig = recoil.useRecoilValue(fos.config);
 
   const settings = useMemo(() => {
-    const datasetPlugins = _.get(dataset, "appConfig.plugins", {});
+    const datasetPlugins = _.get(datasetAppConfig, "plugins", {});
     const appConfigPlugins = _.get(appConfig, "plugins", {});
 
     return _.merge<T | {}, Partial<T>, Partial<T>>(
@@ -361,7 +361,7 @@ export function usePluginSettings<T>(
       _.get(appConfigPlugins, pluginName, {}),
       _.get(datasetPlugins, pluginName, {})
     );
-  }, [dataset, appConfig, pluginName, defaults]);
+  }, [appConfig, pluginName, defaults, datasetAppConfig]);
 
   return settings as T;
 }


### PR DESCRIPTION
## What changes are proposed in this pull request?

use recoil datasetAppConfig over dataset.appConfig so dataset appconfig plugin values are recognized 

## How is this patch tested? If it is not, please explain why.

locally, ensuring map loads with key provided on dataset.appConfig.map

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [X] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
