### PR TITLE
Improves field visibility's show metadata toggle text and adds a link…

### DIFF
--- a/app/packages/core/src/components/Schema/SchemaSelectControls.tsx
+++ b/app/packages/core/src/components/Schema/SchemaSelectControls.tsx
@@ -2,7 +2,9 @@ import React, { useMemo } from "react";
 import { Box, FormControlLabel, FormGroup, Switch } from "@mui/material";
 
 import { useSchemaSettings, useSearchSchemaFields } from "@fiftyone/state";
-import styled from "styled-components";
+import styled, { useTheme } from "styled-components";
+import { ExternalLink, InfoIcon } from "@fiftyone/components";
+import { FIELD_METADATA } from "../../utils/links";
 
 const ContainerBox = styled(Box)`
   position: relative;
@@ -25,6 +27,7 @@ export const SchemaSelectionControls = () => {
     setIncludeNestedFields,
     mergedSchema,
   } = useSchemaSettings();
+  const theme = useTheme();
 
   const { searchResults } = useSearchSchemaFields(mergedSchema);
   const showMetadataVisible = !(isFilterRuleActive && !searchResults.length);
@@ -33,7 +36,8 @@ export const SchemaSelectionControls = () => {
   const controlList = useMemo(() => {
     return [
       {
-        label: "Show metadata",
+        label: "Show field metadata",
+        link: FIELD_METADATA,
         isVisible: showMetadataVisible,
         value: showMetadata,
         checked: showMetadata,
@@ -86,27 +90,45 @@ export const SchemaSelectionControls = () => {
       <Box display="flex" width="100%" flexDirection="row" marginTop="1rem">
         {controlList
           .filter(({ isVisible }) => isVisible)
-          .map(({ label, value, checked, onChange, disabled = false }) => (
-            <ContainerBox key={label} flex="1">
-              <FormGroup>
-                <FormControlLabel
-                  control={
-                    <Switch
-                      value={value}
-                      checked={checked}
-                      onChange={onChange}
-                      disabled={disabled}
-                      data-cy={`field-visibility-controls-${label
-                        .toLowerCase()
-                        .replace(/ /g, "-")}`}
-                    />
-                  }
-                  label={label}
-                  sx={{ letterSpacing: "0.05rem" }}
-                />
-              </FormGroup>
-            </ContainerBox>
-          ))}
+          .map(
+            ({ label, value, checked, onChange, disabled = false, link }) => (
+              <ContainerBox key={label} flex="1">
+                <FormGroup>
+                  <FormControlLabel
+                    control={
+                      <Switch
+                        value={value}
+                        checked={checked}
+                        onChange={onChange}
+                        disabled={disabled}
+                        data-cy={`field-visibility-controls-${label
+                          .toLowerCase()
+                          .replace(/ /g, "-")}`}
+                      />
+                    }
+                    label={
+                      <>
+                        {label}{" "}
+                        {link && (
+                          <ExternalLink href={link}>
+                            <InfoIcon
+                              sx={{
+                                color: theme.text.tertiary,
+                                position: "absolute",
+                                ml: 0.5,
+                                mt: "1px",
+                              }}
+                            />
+                          </ExternalLink>
+                        )}
+                      </>
+                    }
+                    sx={{ letterSpacing: "0.05rem" }}
+                  />
+                </FormGroup>
+              </ContainerBox>
+            )
+          )}
       </Box>
     </Box>
   );

--- a/app/packages/core/src/utils/links.ts
+++ b/app/packages/core/src/utils/links.ts
@@ -7,6 +7,9 @@ export const COLOR_SCHEME =
 export const EVALUATION_PATCHES =
   "https://docs.voxel51.com/user_guide/app.html#app-evaluation-patches";
 
+export const FIELD_METADATA =
+  "https://docs.voxel51.com/user_guide/using_datasets.html#storing-field-metadata";
+
 export const LIGHTNING_MODE =
   "https://docs.voxel51.com/user_guide/app.html#lightning-mode";
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

Users often confuse the field's metadata they can attach to any fields with the Metadata field itself. This PR improves it.

## How is this patch tested? If it is not, please explain why.

- Change the "Show metadata" to "Show field metadata"
- Adds a link to the relevant doc


https://github.com/voxel51/fiftyone/assets/109545780/5a11ee10-6a1d-4bcd-8284-dd5db1a86304




## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
