### PR TITLE
ensure line breaks in embeddings legend

### DIFF
--- a/app/packages/embeddings/src/tracesToData.tsx
+++ b/app/packages/embeddings/src/tracesToData.tsx
@@ -84,7 +84,7 @@ export function tracesToData(
 }
 
 const addLineBreaks = ([key, trace]) => {
-  // split the key into chunks of <maxLegendLineLength>> characters or less, respecting word boundaries.
+  // split the key into chunks of <maxLegendLineLength> characters or less, respecting word boundaries.
   // (\s|$) forces match termination on whitespace or the end of the string.
   // {1,35}(\s|$) will match up to 35 characters followed by a whitespace character,
   // then we can join the result on <br /> to get a line break.


### PR DESCRIPTION
## What changes are proposed in this pull request?

ensure line breaks in the embedding legend so the legend doesn't stretch too far into the plot when the values are very long strings 

![image](https://github.com/voxel51/fiftyone/assets/520477/d250f010-d177-4547-be6d-e68fb2b42c3c)


## How is this patch tested? If it is not, please explain why.

locally

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [X] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
