### PR TITLE
Update selected sample operators

### DIFF
--- a/app/packages/operators/src/built-in-operators.ts
+++ b/app/packages/operators/src/built-in-operators.ts
@@ -58,14 +58,7 @@ class ClearSelectedSamples extends Operator {
       label: "Clear selected samples",
     });
   }
-  useHooks() {
-    return {
-      setSelected: fos.useSetSelected(),
-    };
-  }
-  async execute({ hooks, state }: ExecutionContext) {
-    // needs to mutate the server / session
-    hooks.setSelected([]);
+  async execute({ state }: ExecutionContext) {
     state.reset(fos.selectedSamples);
   }
 }
@@ -373,7 +366,6 @@ class ClearAllStages extends Operator {
     state.reset(fos.filters);
     hooks.resetExtended();
     state.reset(fos.selectedSamples);
-    hooks.setSelected([]);
   }
 }
 
@@ -435,7 +427,6 @@ class ConvertExtendedSelectionToSelectedSamples extends Operator {
     );
     state.set(fos.selectedSamples, new Set(extendedSelection.selection));
     state.set(fos.extendedSelection, { selection: null });
-    hooks.setSelected(extendedSelection.selection);
     hooks.resetExtended();
   }
 }

--- a/app/packages/operators/src/built-in-operators.ts
+++ b/app/packages/operators/src/built-in-operators.ts
@@ -357,7 +357,6 @@ class ClearAllStages extends Operator {
   }
   useHooks(): {} {
     return {
-      setSelected: fos.useSetSelected(),
       resetExtended: fos.useResetExtendedSelection(),
     };
   }
@@ -391,12 +390,7 @@ class ShowSelectedSamples extends Operator {
       label: "Show selected samples",
     });
   }
-  useHooks(): {} {
-    return {
-      setSelected: fos.useSetSelected(),
-    };
-  }
-  async execute({ hooks, state }: ExecutionContext) {
+  async execute({ state }: ExecutionContext) {
     const selectedSamples = await state.snapshot.getPromise(
       fos.selectedSamples
     );
@@ -417,7 +411,6 @@ class ConvertExtendedSelectionToSelectedSamples extends Operator {
   }
   useHooks(): {} {
     return {
-      setSelected: fos.useSetSelected(),
       resetExtended: fos.useResetExtendedSelection(),
     };
   }


### PR DESCRIPTION
Updates the the built-in operators that update the current sample selection. Due to routing updates, it is unnecessary to use the `useSetSelected` and update the `selectedSamples` atom as they are equivalent.

Tested locally

