### PR TITLE
Fix Lightning threshold reset

### DIFF
--- a/app/packages/state/src/recoil/lightning.ts
+++ b/app/packages/state/src/recoil/lightning.ts
@@ -5,7 +5,7 @@ import {
   STRING_FIELD,
   VALID_PRIMITIVE_TYPES,
 } from "@fiftyone/utilities";
-import { atomFamily, selector, selectorFamily } from "recoil";
+import { DefaultValue, atomFamily, selector, selectorFamily } from "recoil";
 import { graphQLSelectorFamily } from "recoil-relay";
 import { ResponseFrom } from "../utils";
 import { config } from "./config";
@@ -219,7 +219,10 @@ export const lightningThreshold = selector<null | number>({
     return Number(setting);
   },
   set: ({ get, reset, set }, value) => {
-    set(lightningThresholdAtom(get(datasetId)), String(value));
+    set(
+      lightningThresholdAtom(get(datasetId)),
+      value instanceof DefaultValue ? value : String(value)
+    );
     reset(granularSidebarExpandedStore);
     reset(sidebarExpandedStore(false));
     reset(filters);


### PR DESCRIPTION
Fixes the Lightning threshold `Reset` button by ensuring Recoil's `DefaultValue` is not converted to a string.

### Testing

```shell
# dev app
cd ./app/packages/app && yarn dev
``` 

```shell
# server
FIFTYONE_APP_LIGHTNING_THRESHOLD=1 python fiftyone/server/main.py
``` 

```python
import fiftyone as fo
fo.app_config.proxy_url = "http://localhost:5173"

dataset, session = fo.quickstart()
``` 

https://github.com/voxel51/fiftyone/assets/19821840/dc0197db-27bd-4019-9c61-f881c2cdf686



