### PR TITLE
Add fiftyone-db support for Ubuntu 23

### DIFF
--- a/package/db/setup.py
+++ b/package/db/setup.py
@@ -78,6 +78,10 @@ LINUX_DOWNLOADS = {
             "aarch64": "https://fastdl.mongodb.org/linux/mongodb-linux-aarch64-ubuntu2204-6.0.5.tgz",
             "x86_64": "https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-ubuntu2204-6.0.5.tgz",
         },
+        "23": {
+            "aarch64": "https://fastdl.mongodb.org/linux/mongodb-linux-aarch64-ubuntu2204-7.0.4.tgz",
+            "x86_64": "https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-ubuntu2204-7.0.4.tgz",
+        },
     },
 }
 
@@ -120,7 +124,7 @@ def _get_download():
 MONGODB_BINARIES = ["mongod"]
 
 
-VERSION = "1.0"
+VERSION = "1.1"
 
 
 def get_version():


### PR DESCRIPTION
Adds aarch64 an x86_64 downloads for Ubuntu 23 in the `fiftyone-db`. Resolves #3928 

Support for Ubuntu 23 using Ubuntu 22 downloads can be verified in a docker container
```shell
docker run -it ubuntu:23.10 /bin/bash
```

In the container
```shell
apt update
apt install libcurl4 wget
wget https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-ubuntu2204-7.0.4.tgz
tar -xvf mongodb-linux-x86_64-ubuntu2204-7.0.4.tgz
cd mongodb-linux-x86_64-ubuntu2204-7.0.4/bin/
./mongod --version
``` 