### PR TITLE
add parsing of string version list of sample ids in _parse_sample_ids

### DIFF
--- a/fiftyone/core/stages.py
+++ b/fiftyone/core/stages.py
@@ -8110,6 +8110,10 @@ class ToFrames(ViewStage):
 
 def _parse_sample_ids(arg):
     if etau.is_str(arg):
+        # this might be a comma delimited string of ids
+        if arg.find(",") > -1:
+            return arg.split(","), False
+
         return [arg], False
 
     if isinstance(arg, (fos.Sample, fos.SampleView)):

--- a/tests/unittests/view_tests.py
+++ b/tests/unittests/view_tests.py
@@ -4268,6 +4268,20 @@ class ViewStageTests(unittest.TestCase):
         ]
         self.assertEqual(optimized_view._all_stages, expected_stages)
 
+    def test_make_optimized_select_view_group_dataset_with_strings_and_lists(
+        self,
+    ):
+        dataset, sample_ids = self._make_group_dataset()
+
+        optimized_view = fov.make_optimized_select_view(
+            dataset, [sample_ids[0], sample_ids[0]], flatten=True
+        )
+        expected_stages = [
+            fosg.SelectGroupSlices(),
+            fosg.Select(f"{sample_ids[0]},{sample_ids[0]}"),
+        ]
+        self.assertEqual(optimized_view._all_stages, expected_stages)
+
     def test_make_optimized_select_view_select_group_slices_before_sample_selection(
         self,
     ):


### PR DESCRIPTION
## What changes are proposed in this pull request?

added check & conversion for comma delimited string of sample ids in _parse_sample_ids

## How is this patch tested? If it is not, please explain why.

locally & with unit test

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [X] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
