### PR TITLE
Lightning bug fixes

### DIFF
--- a/app/packages/components/src/components/Selector/Selector.tsx
+++ b/app/packages/components/src/components/Selector/Selector.tsx
@@ -13,6 +13,8 @@ import LoadingDots from "../Loading/LoadingDots";
 import SearchResults, { UseSearch } from "./SearchResults";
 import style from "./Selector.module.css";
 
+export class SelectorValidationError extends Error {}
+
 export interface SelectorProps<T> {
   id?: string;
   value?: string;
@@ -66,11 +68,18 @@ function Selector<T>(props: SelectorProps<T>) {
           ? valuesRef.current[active]
           : valuesRef.current.find((v) => toKey(v) === search);
 
-      const result = await onSelect(value ? toKey(value) : search, value);
-      if (result !== undefined) {
-        local.current = result;
+      try {
+        const result = await onSelect(value ? toKey(value) : search, value);
+        if (result !== undefined) {
+          local.current = result;
+        }
+        setEditing(false);
+      } catch (error) {
+        if (error instanceof SelectorValidationError) {
+          return;
+        }
+        throw error;
       }
-      setEditing(false);
     };
   }, [active, onSelect, toKey, valuesRef]);
 

--- a/app/packages/components/src/components/Selector/index.ts
+++ b/app/packages/components/src/components/Selector/index.ts
@@ -1,2 +1,2 @@
-export { default } from "./Selector";
-export type { UseSearch } from "./Selector";
+export type { UseSearch } from "./SearchResults";
+export { SelectorValidationError, default } from "./Selector";

--- a/app/packages/components/src/components/index.ts
+++ b/app/packages/components/src/components/index.ts
@@ -1,6 +1,7 @@
 export { default as Bar } from "./Bar";
 export { default as Button } from "./Button";
 export { default as CodeBlock } from "./CodeBlock";
+export { default as CodeTabs } from "./CodeTabs";
 export { default as CopyButton } from "./CopyButton";
 export { default as ErrorBoundary } from "./ErrorBoundary";
 export { default as ExternalLink, useExternalLink } from "./ExternalLink";
@@ -17,9 +18,8 @@ export { default as PillButton } from "./PillButton";
 export { default as Popout, PopoutDiv } from "./Popout";
 export { default as PopoutSectionTitle } from "./PopoutSectionTitle";
 export { default as Selection } from "./Selection";
-export { default as Selector } from "./Selector";
+export { default as Selector, SelectorValidationError } from "./Selector";
 export type { UseSearch } from "./Selector";
 export { default as TabOption } from "./TabOption";
 export { default as ThemeProvider, useTheme } from "./ThemeProvider";
 export { default as Tooltip } from "./Tooltip";
-export { default as CodeTabs } from "./CodeTabs";

--- a/app/packages/core/src/components/Actions/Options.tsx
+++ b/app/packages/core/src/components/Actions/Options.tsx
@@ -235,6 +235,7 @@ const Lightning = () => {
         options={["disable", "enable"].map((value) => ({
           text: value,
           title: value,
+          dataCy: `lightning-mode-${value}`,
           onClick: () =>
             setThreshold(value === "disable" ? null : config ?? count),
         }))}

--- a/app/packages/core/src/components/Filters/StringFilter/StringFilter.tsx
+++ b/app/packages/core/src/components/Filters/StringFilter/StringFilter.tsx
@@ -106,6 +106,7 @@ const StringFilter = ({
             placeholder={`+ ${
               isFilterMode ? "filter" : "set visibility"
             } by ${name}`}
+            cy={`sidebar-search-${path}`}
             component={ResultComponent}
             onSelect={onSelect}
             inputStyle={{

--- a/app/packages/core/src/components/Filters/StringFilter/useOnSelect.ts
+++ b/app/packages/core/src/components/Filters/StringFilter/useOnSelect.ts
@@ -1,3 +1,6 @@
+import { SelectorValidationError } from "@fiftyone/components/src/components/Selector";
+import { isObjectIdField, snackbarErrors } from "@fiftyone/state";
+import { isObjectIdString } from "@fiftyone/utilities";
 import { useRef } from "react";
 import { RecoilState, useRecoilCallback } from "recoil";
 import { Result } from "./Result";
@@ -12,6 +15,14 @@ export default function (
     onSelect: useRecoilCallback(
       ({ snapshot, set }) =>
         async (value: string | null, d?: Result) => {
+          const isObjectId = await snapshot.getPromise(isObjectIdField(path));
+          if (isObjectId && (value === null || !isObjectIdString(value))) {
+            set(snackbarErrors, [
+              `${value} is not a 24 character hexadecimal string`,
+            ]);
+            throw new SelectorValidationError();
+          }
+
           const selected = new Set(await snapshot.getPromise(selectedAtom));
           if (d?.value === null) {
             value = null;
@@ -19,6 +30,7 @@ export default function (
           selectedMap.current.set(value, d?.count || null);
           selected.add(value);
           set(selectedAtom, [...selected].sort());
+
           return "";
         },
       [modal, path, selectedAtom, selectedMap]

--- a/app/packages/core/src/components/Filters/StringFilter/useOnSelect.ts
+++ b/app/packages/core/src/components/Filters/StringFilter/useOnSelect.ts
@@ -1,4 +1,4 @@
-import { SelectorValidationError } from "@fiftyone/components/src/components/Selector";
+import { SelectorValidationError } from "@fiftyone/components";
 import { isObjectIdField, snackbarErrors } from "@fiftyone/state";
 import { isObjectIdString } from "@fiftyone/utilities";
 import { useRef } from "react";

--- a/app/packages/core/src/components/Sidebar/Entries/FilterablePathEntry/Arrow.tsx
+++ b/app/packages/core/src/components/Sidebar/Entries/FilterablePathEntry/Arrow.tsx
@@ -27,7 +27,7 @@ export default ({
     return (
       <Tooltip text={<AddIndex />} placement="top-center">
         <Arrow
-          data-cy={`sidebar-field-arrow-${id}`}
+          data-cy={`sidebar-field-arrow-disabled-${id}`}
           style={{ margin: 0, color: theme.text.secondary }}
         />
       </Tooltip>
@@ -36,7 +36,7 @@ export default ({
 
   return (
     <Arrow
-      data-cy={`sidebar-field-arrow-${id}`}
+      data-cy={`sidebar-field-arrow-enabled-${id}`}
       style={{
         cursor: "pointer",
         margin: 0,

--- a/app/packages/core/src/components/ViewBar/ViewStage/utils.ts
+++ b/app/packages/core/src/components/ViewBar/ViewStage/utils.ts
@@ -21,3 +21,27 @@ export const getMatch = (options, value) => {
   }
   return null;
 };
+
+export const cleanCSV = (values: string) => {
+  return (
+    values
+      // replace spaces with a single space (to allow search by words with spaces)
+      .replace(/[\s\'\"\[\]]+/g, " ")
+      // replace comma followed by trailing spaces with a single comma
+      .replace(/,\s*/g, ",")
+      // remove trailing spaces
+      .replace(/[ \t]+$/, "")
+  );
+};
+
+export const getArray = (value: string | unknown[]): unknown[] => {
+  if (typeof value === "string") {
+    try {
+      return JSON.parse(value);
+    } catch {
+      return value.replace(/[\s]/g, "").split(",");
+    }
+  }
+
+  return value;
+};

--- a/app/packages/core/src/components/ViewBar/ViewStage/viewStageParameterMachine.ts
+++ b/app/packages/core/src/components/ViewBar/ViewStage/viewStageParameterMachine.ts
@@ -1,7 +1,8 @@
 import { v4 as uuid } from "uuid";
 import { actions, Machine, sendParent } from "xstate";
 
-import { computeBestMatchString, getMatch } from "./utils";
+import { isObjectIdString } from "@fiftyone/utilities";
+import { cleanCSV, computeBestMatchString, getArray, getMatch } from "./utils";
 
 const { assign } = actions;
 
@@ -85,7 +86,7 @@ export const PARSER = {
     castFrom: (value) => value,
     castTo: (value) => value,
     parse: (value) => value,
-    validate: (value) => /[0-9A-Fa-f]{24}/g.test(value),
+    validate: (value) => isObjectIdString(value),
   },
   int: {
     castFrom: (value) => String(value).replace(/\B(?=(\d{3})+(?!\d))/g, ","),
@@ -113,66 +114,25 @@ export const PARSER = {
   "list<field>": {
     castFrom: (value) => value.join(","),
     castTo: (value) => value.split(","),
-    parse: (value) => value.replace(/[\s\'\"\[\]]/g, ""),
+    parse: (value) => cleanCSV(value),
     validate: (value, fields) => {
-      const stripped = value.replace(/[\s]/g, "");
-      let array = null;
-      try {
-        array = JSON.parse(stripped);
-      } catch {
-        array = stripped.split(",");
-      }
-      return (
-        typeof value !== "string" &&
-        Array.isArray(array) &&
-        array.every((e) => PARSER.field.validate(e, fields))
-      );
+      return getArray(value).every((e) => PARSER.field.validate(e, fields));
     },
   },
   "list<id>": {
     castFrom: (value) => value.join(","),
     castTo: (value) => value.split(","),
-    parse: (value) => value.replace(/[\s\'\"\[\]]/g, ""),
+    parse: (value) => cleanCSV(value),
     validate: (value) => {
-      const stripped = value.replace(/[\s]/g, "");
-      let array = null;
-      try {
-        array = JSON.parse(stripped);
-      } catch {
-        array = stripped.split(",");
-      }
-      return (
-        typeof value !== "string" &&
-        Array.isArray(array) &&
-        array.every((e) => PARSER.id.validate(e))
-      );
+      return getArray(value).every((e) => PARSER.id.validate(e));
     },
   },
   "list<str>": {
     castFrom: (value) => value.join(","),
     castTo: (value) => value.split(","),
-    parse: (value) =>
-      value
-        // replace spaces with a single space (to allow search by words with spaces)
-        .replace(/[\s\'\"\[\]]+/g, " ")
-        // replace comma followed by trailing spaces with a single comma
-        .replace(/,\s*/g, ",")
-        // remove trailing spaces
-        .replace(/[ \t]+$/, ""),
+    parse: (value) => cleanCSV(value),
     validate: (value) => {
-      const stripped = value.replace(/[\s]/g, "");
-      let array = null;
-      try {
-        array = JSON.parse(stripped);
-      } catch {
-        // ex: exclude_fields('a, b'). 'a,b' => ['a', 'b']
-        array = stripped.split(",");
-      }
-      return (
-        typeof array !== "string" &&
-        Array.isArray(array) &&
-        array.every((e) => PARSER.str.validate(e))
-      );
+      return getArray(value).every((e) => PARSER.str.validate(e));
     },
   },
   NoneType: {

--- a/app/packages/state/src/recoil/lightning.ts
+++ b/app/packages/state/src/recoil/lightning.ts
@@ -103,6 +103,8 @@ const indexesByPath = selector({
     ) => {
       const projection = frames ? framesProjection : samplesProjection;
 
+      fields = fields.map((field) => get(schemaAtoms.dbPath(field)));
+
       if (field === "$**") {
         if (!projection) {
           return fields;
@@ -143,8 +145,7 @@ export const pathIndex = selectorFamily({
     (path: string) =>
     ({ get }) => {
       const indexes = get(indexesByPath);
-
-      return indexes.has(path);
+      return indexes.has(get(schemaAtoms.dbPath(path)));
     },
 });
 

--- a/app/packages/utilities/src/type-check.ts
+++ b/app/packages/utilities/src/type-check.ts
@@ -11,7 +11,7 @@ export function isPrimitiveType(type: string) {
 }
 
 export function isHex(value: string) {
-  return parseInt(value, 16).toString(16) === value;
+  return /[0-9a-f]{24}/g.test(value);
 }
 
 export function isObjectIdString(value: string) {

--- a/app/packages/utilities/src/type-check.ts
+++ b/app/packages/utilities/src/type-check.ts
@@ -10,6 +10,14 @@ export function isPrimitiveType(type: string) {
   return PRIMITIVE_TYPES.includes(type);
 }
 
+export function isHex(value: string) {
+  return parseInt(value, 16).toString(16) === value;
+}
+
+export function isObjectIdString(value: string) {
+  return isHex(value) && value.length === 24;
+}
+
 export type NumberKeyObjectType<V = unknown> = {
   [key: string]: V;
 };

--- a/e2e-pw/src/oss/poms/action-row/display-options.ts
+++ b/e2e-pw/src/oss/poms/action-row/display-options.ts
@@ -3,12 +3,18 @@ import { Page } from "src/oss/fixtures";
 type SidebarStatisticsMode = "slice" | "group";
 type SidebarMode = "fast" | "best" | "all";
 type SidebarSortMode = "count" | "value";
+type LightningMode = "enable" | "disable";
 
 export class DisplayOptionsPom {
   readonly page: Page;
 
   constructor(page: Page) {
     this.page = page;
+  }
+
+  async setLightningMode(mode: LightningMode) {
+    const selector = this.page.getByTestId(`lightning-mode-${mode}`);
+    return selector.click();
   }
 
   async setSidebarStatisticsMode(mode: SidebarStatisticsMode) {

--- a/e2e-pw/src/oss/poms/sidebar.ts
+++ b/e2e-pw/src/oss/poms/sidebar.ts
@@ -68,7 +68,9 @@ export class SidebarPom {
   }
 
   async clickFieldDropdown(field: string) {
-    const selector = this.sidebar.getByTestId(`sidebar-field-arrow-${field}`);
+    const selector = this.sidebar.getByTestId(
+      `sidebar-field-arrow-enabled-${field}`
+    );
     return selector.click();
   }
 
@@ -100,6 +102,12 @@ export class SidebarPom {
       .getByTestId("checkbox-" + label)
       .getByTitle(label);
     await selectionDiv.click({ force: true });
+  }
+
+  async applySearch(field: string, search: string) {
+    const input = this.sidebar.getByTestId(`selector-sidebar-search-${field}`);
+    await input.fill(search);
+    await input.press("Enter");
   }
 
   // apply a filter to a field

--- a/e2e-pw/src/oss/poms/sidebar.ts
+++ b/e2e-pw/src/oss/poms/sidebar.ts
@@ -28,6 +28,16 @@ export class SidebarPom {
       .nth(1);
   }
 
+  fieldContainer(fieldName: string) {
+    return this.sidebar.getByTestId(`sidebar-field-container-${fieldName}`);
+  }
+
+  fieldArrow(fieldName: string, enabled: boolean) {
+    return this.fieldContainer(fieldName).getByTestId(
+      `sidebar-field-arrow-${enabled ? "enabled" : "disabled"}-${fieldName}`
+    );
+  }
+
   sidebarEntryDraggableArea(fieldName: string) {
     return this.sidebar
       .getByTestId(`sidebar-entry-draggable-${fieldName}`)
@@ -137,9 +147,29 @@ class SidebarAsserter {
     await expect(this.sb.field(fieldName)).toBeVisible();
   }
 
+  async assertFieldDisabled(fieldName: string) {
+    await expect(this.sb.fieldArrow(fieldName, false)).toBeVisible();
+  }
+
+  async assertFieldsDisabled(fieldNames: string[]) {
+    for (let i = 0; i < fieldNames.length; i++) {
+      await this.assertFieldDisabled(fieldNames[i]);
+    }
+  }
+
+  async assertFieldEnabled(fieldName: string) {
+    await expect(this.sb.fieldArrow(fieldName, true)).toBeVisible();
+  }
+
+  async assertFieldsEnabled(fieldNames: string[]) {
+    for (let i = 0; i < fieldNames.length; i++) {
+      await this.assertFieldEnabled(fieldNames[i]);
+    }
+  }
+
   async assertFieldsInSidebar(fieldNames: string[]) {
     for (let i = 0; i < fieldNames.length; i++) {
-      await this.sb.asserter.assertFieldInSidebar(fieldNames[i]);
+      await this.assertFieldInSidebar(fieldNames[i]);
     }
   }
 

--- a/e2e-pw/src/oss/specs/sidebar/lightning.spec.ts
+++ b/e2e-pw/src/oss/specs/sidebar/lightning.spec.ts
@@ -33,14 +33,13 @@ test.describe("lightning", () => {
     );
   });
 
-  test.beforeEach(async ({ page, fiftyoneLoader }) => {
+  test.beforeEach(async ({ grid, page, fiftyoneLoader }) => {
     await fiftyoneLoader.waitUntilGridVisible(page, datasetName);
-  });
-
-  test("assert enabled fields", async ({ grid, sidebar }) => {
     await grid.actionsRow.toggleDisplayOptions();
     await grid.actionsRow.displayActions.setLightningMode("enable");
+  });
 
+  test("assert enabled fields", async ({ sidebar }) => {
     await sidebar.asserter.assertFieldsEnabled([
       "tags",
       "metadata.mime_type",

--- a/e2e-pw/src/oss/specs/sidebar/lightning.spec.ts
+++ b/e2e-pw/src/oss/specs/sidebar/lightning.spec.ts
@@ -57,7 +57,18 @@ test.describe("lightning", () => {
     ]);
   });
 
-  test("assert id field validation error", async ({ grid, sidebar }) => {
+  test("assert id search no page error", async ({
+    sidebar,
+    grid,
+    eventUtils,
+  }) => {
+    const entryExpandPromise = eventUtils.getEventReceivedPromiseForPredicate(
+      "animation-onRest",
+      () => true
+    );
     await sidebar.clickFieldDropdown("id");
+    await entryExpandPromise;
+    await sidebar.applySearch("id", "not an id");
+    await grid.assert.isLookerCountEqualTo(2);
   });
 });

--- a/e2e-pw/src/oss/specs/sidebar/lightning.spec.ts
+++ b/e2e-pw/src/oss/specs/sidebar/lightning.spec.ts
@@ -1,0 +1,63 @@
+import { test as base } from "src/oss/fixtures";
+import { GridPom } from "src/oss/poms/grid";
+import { SidebarPom } from "src/oss/poms/sidebar";
+import { getUniqueDatasetNameWithPrefix } from "src/oss/utils";
+
+const datasetName = getUniqueDatasetNameWithPrefix("lightning");
+
+const test = base.extend<{ sidebar: SidebarPom; grid: GridPom }>({
+  sidebar: async ({ page }, use) => {
+    await use(new SidebarPom(page));
+  },
+  grid: async ({ page, eventUtils }, use) => {
+    await use(new GridPom(page, eventUtils));
+  },
+});
+
+test.describe("lightning", () => {
+  test.beforeAll(async ({ fiftyoneLoader }) => {
+    await fiftyoneLoader.executePythonCode(
+      `
+        import fiftyone as fo
+
+        dataset = fo.Dataset("${datasetName}")
+        dataset.persistent = True
+        dataset.add_sample_field(
+            "ground_truth", fo.EmbeddedDocumentField, embedded_doc_type=fo.Detections
+        )
+        dataset.add_samples(
+            [fo.Sample(filepath="one.png"), fo.Sample(filepath="two.png")]
+        )
+        dataset.create_index("$**")
+        `
+    );
+  });
+
+  test.beforeEach(async ({ page, fiftyoneLoader }) => {
+    await fiftyoneLoader.waitUntilGridVisible(page, datasetName);
+  });
+
+  test("assert enabled fields", async ({ grid, sidebar }) => {
+    await grid.actionsRow.toggleDisplayOptions();
+    await grid.actionsRow.displayActions.setLightningMode("enable");
+
+    await sidebar.asserter.assertFieldsEnabled([
+      "tags",
+      "metadata.mime_type",
+      "ground_truth",
+      "id",
+      "filepath",
+    ]);
+    await sidebar.asserter.assertFieldsDisabled([
+      "_label_tags",
+      "metadata.size_bytes",
+      "metadata.width",
+      "metadata.height",
+      "metadata.num_channels",
+    ]);
+  });
+
+  test("assert id field validation error", async ({ grid, sidebar }) => {
+    await sidebar.clickFieldDropdown("id");
+  });
+});


### PR DESCRIPTION
Fixes two `id` field bugs related to lightning mode

### Changes

* Ensures the root `id` field is enabled in lightning mode by looking up the schema db path in the `pathIndexes` selector
* Adds snackbar error handling for invalid `ObjectId` field searches in the sidebar

Related e2e tests have been added for verification


https://github.com/voxel51/fiftyone/assets/19821840/1f566ec2-64d8-4183-9e49-390147db25c2


