### PR TITLE
Optimize reload docs when performing bulk writes

### DIFF
--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -1537,11 +1537,14 @@ class SampleCollection(object):
         view._edit_sample_tags(update)
 
     def _edit_sample_tags(self, update):
+        ids = []
         ops = []
-        for ids in fou.iter_batches(self.values("_id"), 100000):
-            ops.append(UpdateMany({"_id": {"$in": ids}}, update))
+        for _ids in fou.iter_batches(self.values("_id"), 100000):
+            ids.extend(_ids)
+            ops.append(UpdateMany({"_id": {"$in": _ids}}, update))
 
-        self._dataset._bulk_write(ops)
+        if ops:
+            self._dataset._bulk_write(ops, ids=ids)
 
     def count_sample_tags(self):
         """Counts the occurrences of sample tags in this collection.
@@ -1669,7 +1672,7 @@ class SampleCollection(object):
                 )
 
         if ops:
-            self._dataset._bulk_write(ops, frames=is_frame_field)
+            self._dataset._bulk_write(ops, ids=ids, frames=is_frame_field)
 
         return ids, label_ids
 
@@ -2574,7 +2577,8 @@ class SampleCollection(object):
 
             ops.append(UpdateOne({"_id": _id}, {"$set": {field_name: value}}))
 
-        self._dataset._bulk_write(ops, frames=frames)
+        if ops:
+            self._dataset._bulk_write(ops, ids=ids, frames=frames)
 
     def _set_list_values_by_id(
         self,
@@ -2628,7 +2632,8 @@ class SampleCollection(object):
                     )
                 )
 
-        self._dataset._bulk_write(ops, frames=frames)
+        if ops:
+            self._dataset._bulk_write(ops, ids=ids, frames=frames)
 
     def _set_label_list_values(
         self,
@@ -2645,6 +2650,7 @@ class SampleCollection(object):
         leaf = field_name[len(root) + 1 :]
         path = root + ".$[label]." + leaf
 
+        ids = []
         ops = []
         for label_id, value in values.items():
             if value is None and skip_none:
@@ -2655,16 +2661,18 @@ class SampleCollection(object):
                     field_name, field, value, validate=validate
                 )
 
+            _id = id_map[label_id]
+            ids.append(_id)
             ops.append(
                 UpdateOne(
-                    {"_id": id_map[label_id]},
+                    {"_id": _id},
                     {"$set": {path: value}},
                     array_filters=[{"label._id": ObjectId(label_id)}],
                 )
             )
 
         if ops:
-            self._dataset._bulk_write(ops, frames=frames)
+            self._dataset._bulk_write(ops, ids=ids, frames=frames)
 
     def _set_labels(self, field_name, sample_ids, label_docs):
         if self._is_group_field(field_name):
@@ -2676,6 +2684,7 @@ class SampleCollection(object):
         root, is_list_field = self._get_label_field_root(field_name)
         field_name, is_frame_field = self._handle_frame_field(field_name)
 
+        ids = []
         ops = []
         if is_list_field:
             elem_id = root + "._id"
@@ -2691,6 +2700,7 @@ class SampleCollection(object):
                 if not isinstance(_docs, (list, tuple)):
                     _docs = [_docs]
 
+                ids.append(_id)
                 for doc in _docs:
                     ops.append(
                         UpdateOne(
@@ -2705,6 +2715,7 @@ class SampleCollection(object):
                 if etau.is_str(_id):
                     _id = ObjectId(_id)
 
+                ids.append(_id)
                 ops.append(
                     UpdateOne(
                         {"_id": _id, elem_id: doc["_id"]},
@@ -2712,7 +2723,8 @@ class SampleCollection(object):
                     )
                 )
 
-        self._dataset._bulk_write(ops, frames=is_frame_field)
+        if ops:
+            self._dataset._bulk_write(ops, ids=ids, frames=is_frame_field)
 
     def _delete_labels(self, ids, fields=None):
         self._dataset.delete_labels(ids=ids, fields=fields)
@@ -10562,9 +10574,9 @@ def _parse_frame_values_dicts(sample_collection, sample_ids, values):
 
     # Insert frame documents for new frame numbers
     if dicts:
-        sample_collection._dataset._bulk_write(
-            [InsertOne(d) for d in dicts], frames=True
-        )  # adds `_id` to each dict
+        # adds `_id` to each dict
+        ops = [InsertOne(d) for d in dicts]
+        sample_collection._dataset._bulk_write(ops, ids=[], frames=True)
 
         for d in dicts:
             id_map[(str(d["_sample_id"]), d["frame_number"])] = d["_id"]

--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -2642,7 +2642,7 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
 
         return d
 
-    def _bulk_write(self, ops, frames=False, ordered=False):
+    def _bulk_write(self, ops, ids=None, frames=False, ordered=False):
         if frames:
             coll = self._frame_collection
         else:
@@ -2651,9 +2651,11 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
         foo.bulk_write(ops, coll, ordered=ordered)
 
         if frames:
-            fofr.Frame._reload_docs(self._frame_collection_name)
+            fofr.Frame._reload_docs(self._frame_collection_name, frame_ids=ids)
         else:
-            fos.Sample._reload_docs(self._sample_collection_name)
+            fos.Sample._reload_docs(
+                self._sample_collection_name, sample_ids=ids
+            )
 
     def _merge_doc(
         self,
@@ -7545,7 +7547,7 @@ def _add_collection_with_new_ids(
             )
             ops.append(op)
 
-        dataset._bulk_write(ops)
+        dataset._bulk_write(ops, ids=[])
 
     if not contains_videos:
         return new_ids
@@ -7586,7 +7588,7 @@ def _add_collection_with_new_ids(
         for old_id, new_id in zip(old_ids, new_ids)
     ]
 
-    dataset._bulk_write(ops, frames=True)
+    dataset._bulk_write(ops, ids=[], frames=True)
 
     return new_ids
 

--- a/fiftyone/core/singletons.py
+++ b/fiftyone/core/singletons.py
@@ -158,7 +158,7 @@ class SampleSingleton(DocumentSingleton):
         if collection_name not in cls._instances:
             return
 
-        sample = cls._instances[collection_name].get(sample_id, None)
+        sample = cls._instances[collection_name].get(str(sample_id), None)
         if sample is not None:
             sample.reload(hard=hard)
 
@@ -174,7 +174,7 @@ class SampleSingleton(DocumentSingleton):
         samples = cls._instances[collection_name]
 
         if sample_ids is not None:
-            sample_ids = set(sample_ids)
+            sample_ids = set(str(_id) for _id in sample_ids)
             for sample in samples.values():
                 if sample.id in sample_ids:
                     sample.reload(hard=hard)
@@ -194,7 +194,7 @@ class SampleSingleton(DocumentSingleton):
 
         samples = cls._instances[collection_name]
 
-        sample_ids = set(sample_ids)
+        sample_ids = set(str(_id) for _id in sample_ids)
         reset_ids = set()
         for sample in samples.values():
             if sample.id in sample_ids:
@@ -220,7 +220,7 @@ class SampleSingleton(DocumentSingleton):
         if sample_ids is not None:
             samples = cls._instances[collection_name]
             for sample_id in sample_ids:
-                sample = samples.pop(sample_id, None)
+                sample = samples.pop(str(sample_id), None)
                 if sample is not None:
                     sample._reset_backing_doc()
         else:
@@ -270,7 +270,9 @@ class FrameSingleton(DocumentSingleton):
         """Returns a frame number -> Frame dict containing all in-memory frame
         instances for the specified sample.
         """
-        return dict(cls._instances.get(collection_name, {}).get(sample_id, {}))
+        return dict(
+            cls._instances.get(collection_name, {}).get(str(sample_id), {})
+        )
 
     def _rename_fields(cls, collection_name, field_names, new_field_names):
         """Renames the field on all in-memory frames in the collection."""
@@ -312,7 +314,7 @@ class FrameSingleton(DocumentSingleton):
         if collection_name not in cls._instances:
             return
 
-        frames = cls._instances[collection_name].get(sample_id, {})
+        frames = cls._instances[collection_name].get(str(sample_id), {})
         frame = frames.get(frame_number, None)
         if frame is not None:
             frame.reload(hard=hard)
@@ -330,7 +332,7 @@ class FrameSingleton(DocumentSingleton):
             return
 
         samples = cls._instances[collection_name]
-        frames = samples.get(sample_id, {})
+        frames = samples.get(str(sample_id), {})
 
         if not frames:
             return
@@ -365,7 +367,7 @@ class FrameSingleton(DocumentSingleton):
 
         samples = cls._instances[collection_name]
 
-        sample_ids = set(sample_ids)
+        sample_ids = set(str(_id) for _id in sample_ids)
         reset_ids = set()
         for sample_id, frames in samples.items():
             if sample_id in sample_ids:
@@ -379,7 +381,9 @@ class FrameSingleton(DocumentSingleton):
         for sample_id in reset_ids:
             frames = samples.pop(sample_id)
 
-    def _reload_docs(cls, collection_name, sample_ids=None, hard=False):
+    def _reload_docs(
+        cls, collection_name, sample_ids=None, frame_ids=None, hard=False
+    ):
         """Reloads the backing documents for in-memory frames in the
         collection.
 
@@ -392,11 +396,17 @@ class FrameSingleton(DocumentSingleton):
         samples = cls._instances[collection_name]
 
         if sample_ids is not None:
-            sample_ids = set(sample_ids)
+            sample_ids = set(str(_id) for _id in sample_ids)
             for sample_id in sample_ids:
                 frames = samples.get(sample_id, {})
                 for frame in frames.values():
                     frame.reload(hard=hard)
+        elif frame_ids is not None:
+            frame_ids = set(str(_id) for _id in frame_ids)
+            for frames in samples.values():
+                for frame in frames.values():
+                    if frame.id in frame_ids:
+                        frame.reload(hard=hard)
         else:
             for frames in samples.values():
                 for frame in frames.values():
@@ -414,7 +424,7 @@ class FrameSingleton(DocumentSingleton):
         if sample_ids is not None:
             samples = cls._instances[collection_name]
             for sample_id in sample_ids:
-                frames = samples.pop(sample_id, {})
+                frames = samples.pop(str(sample_id), {})
                 for frame in frames.values():
                     frame._reset_backing_doc()
         else:
@@ -436,7 +446,7 @@ class FrameSingleton(DocumentSingleton):
             return
 
         samples = cls._instances[collection_name]
-        frames = samples.get(sample_id, {})
+        frames = samples.get(str(sample_id), {})
 
         if not frames:
             return
@@ -473,7 +483,7 @@ class FrameSingleton(DocumentSingleton):
 
         samples = cls._instances[collection_name]
 
-        frame_ids = set(frame_ids)
+        frame_ids = set(str(_id) for _id in frame_ids)
         reset = []
 
         if keep:


### PR DESCRIPTION
When performing `dataset._bulk_write()`, only reload the docs that were involved in the mutations, if known.