### PR TITLE
[WIP] Adding config setting to disable singleton cache

### DIFF
--- a/docs/source/user_guide/config.rst
+++ b/docs/source/user_guide/config.rst
@@ -108,6 +108,10 @@ FiftyOne supports the configuration options described below:
 |                               |                                     |                               | operations such reading/writing large datasets or activiating FiftyOne                 |
 |                               |                                     |                               | Brain methods on datasets.                                                             |
 +-------------------------------+-------------------------------------+-------------------------------+----------------------------------------------------------------------------------------+
+| `singleton_cache`             | `FIFTYONE_SINGLETON_CACHE`          | `True`                        | Whether to treat :class:`Dataset <fiftyone.core.dataset.Dataset>`,                     |
+|                               |                                     |                               | :class:`Sample <fiftyone.core.sample.Sample>`, and                                     |
+|                               |                                     |                               | :class:`Frame <fiftyone.core.frame.Frame>` instances as singletons.                    |
++-------------------------------+-------------------------------------+-------------------------------+----------------------------------------------------------------------------------------+
 | `timezone`                    | `FIFTYONE_TIMEZONE`                 | `None`                        | An optional timzone string. If provided, all datetimes read from FiftyOne datasets     |
 |                               |                                     |                               | will be expressed in this timezone. See :ref:`this section <configuring-timezone>` for |
 |                               |                                     |                               | more information.                                                                      |
@@ -165,6 +169,7 @@ and the CLI:
             "plugins_cache_enabled": false,
             "requirement_error_level": 0,
             "show_progress_bars": true,
+            "singleton_cache": true,
             "timezone": null
         }
 
@@ -212,6 +217,7 @@ and the CLI:
             "plugins_cache_enabled": false,
             "requirement_error_level": 0,
             "show_progress_bars": true,
+            "singleton_cache": true,
             "timezone": null
         }
 

--- a/fiftyone/core/config.py
+++ b/fiftyone/core/config.py
@@ -230,6 +230,12 @@ class FiftyOneConfig(EnvConfig):
             env_var="FIFTYONE_MAX_PROCESS_POOL_WORKERS",
             default=None,
         )
+        self.singleton_cache = self.parse_bool(
+            d,
+            "singleton_cache",
+            env_var="FIFTYONE_SINGLETON_CACHE",
+            default=True,
+        )
 
         self._init()
 

--- a/fiftyone/core/singletons.py
+++ b/fiftyone/core/singletons.py
@@ -8,6 +8,8 @@ FiftyOne singleton implementations.
 from collections import defaultdict
 import weakref
 
+import fiftyone as fo
+
 
 class DatasetSingleton(type):
     """Singleton metaclass for :class:`fiftyone.core.dataset.Dataset`.
@@ -44,7 +46,8 @@ class DatasetSingleton(type):
                     name=name, _create=_create, *args, **kwargs
                 )
 
-        cls._instances[name] = instance
+        if fo.config.singleton_cache:
+            cls._instances[name] = instance
 
         return instance
 
@@ -107,7 +110,8 @@ class SampleSingleton(DocumentSingleton):
         return cls
 
     def _register_instance(cls, obj):
-        cls._instances[obj._doc.collection_name][obj.id] = obj
+        if fo.config.singleton_cache:
+            cls._instances[obj._doc.collection_name][obj.id] = obj
 
     def _get_instance(cls, doc):
         try:
@@ -248,9 +252,10 @@ class FrameSingleton(DocumentSingleton):
         return cls
 
     def _register_instance(cls, obj):
-        cls._instances[obj._doc.collection_name][obj.sample_id][
-            obj.frame_number
-        ] = obj
+        if fo.config.singleton_cache:
+            cls._instances[obj._doc.collection_name][obj.sample_id][
+                obj.frame_number
+            ] = obj
 
     def _get_instance(cls, doc):
         try:


### PR DESCRIPTION
## Example usage

```py
import fiftyone as fo

fo.config.singleton_cache = False

dataset = fo.Dataset()
sample = fo.Sample(filepath="image.jpg")

dataset.add_sample(sample)
print(sample.in_dataset)  # True

also_sample = dataset.first()
print(sample is also_sample)  # False

also_dataset = fo.load_dataset(dataset.name)
print(also_dataset is dataset)  # False
```

## TODO

When singleton caching is disabled, there are a variety of places where patterns like this are used where the `reload()` is now always unnecessary:

```py
dataset = fo.load_dataset(name)
dataset.reload()  # reload in case we got a singleton rather than a refresh load from the database
```

We should probably refactor those calls into a single method call so that unnecessary reloads can be skipped:

```py
# Reload the dataset (only) if a singleton instance was returned
dataset = fo.load_dataset(name, reload=True)
```
