### PR TITLE
Configurable batch size for bulk_write

### DIFF
--- a/docs/source/user_guide/config.rst
+++ b/docs/source/user_guide/config.rst
@@ -138,6 +138,7 @@ and the CLI:
     .. code-block:: text
 
         {
+            "bulk_write_batch_size": 100000,
             "database_admin": true,
             "database_dir": "~/.fiftyone/var/lib/mongo",
             "database_name": "fiftyone",
@@ -145,9 +146,8 @@ and the CLI:
             "database_validation": true,
             "dataset_zoo_dir": "~/fiftyone",
             "dataset_zoo_manifest_paths": null,
-            "default_app_config_path": "~/.fiftyone/app_config.json",
-            "default_app_port": 5151,
             "default_app_address": null,
+            "default_app_port": 5151,
             "default_batch_size": null,
             "default_dataset_dir": "~/fiftyone",
             "default_image_ext": ".jpg",
@@ -157,14 +157,14 @@ and the CLI:
             "desktop_app": false,
             "do_not_track": false,
             "logging_level": "INFO",
-            "max_thread_pool_workers": null,
             "max_process_pool_workers": null,
+            "max_thread_pool_workers": null,
             "model_zoo_dir": "~/fiftyone/__models__",
             "model_zoo_manifest_paths": null,
             "module_path": null,
             "operator_timeout": 600,
-            "plugins_dir": null,
             "plugins_cache_enabled": false,
+            "plugins_dir": null,
             "requirement_error_level": 0,
             "show_progress_bars": true,
             "timezone": null
@@ -185,6 +185,7 @@ and the CLI:
     .. code-block:: text
 
         {
+            "bulk_write_batch_size": 100000,
             "database_admin": true,
             "database_dir": "~/.fiftyone/var/lib/mongo",
             "database_name": "fiftyone",
@@ -192,9 +193,8 @@ and the CLI:
             "database_validation": true,
             "dataset_zoo_dir": "~/fiftyone",
             "dataset_zoo_manifest_paths": null,
-            "default_app_config_path": "~/.fiftyone/app_config.json",
-            "default_app_port": 5151,
             "default_app_address": null,
+            "default_app_port": 5151,
             "default_batch_size": null,
             "default_dataset_dir": "~/fiftyone",
             "default_image_ext": ".jpg",
@@ -204,14 +204,14 @@ and the CLI:
             "desktop_app": false,
             "do_not_track": false,
             "logging_level": "INFO",
-            "max_thread_pool_workers": null,
             "max_process_pool_workers": null,
+            "max_thread_pool_workers": null,
             "model_zoo_dir": "~/fiftyone/__models__",
             "model_zoo_manifest_paths": null,
             "module_path": null,
             "operator_timeout": 600,
-            "plugins_dir": null,
             "plugins_cache_enabled": false,
+            "plugins_dir": null,
             "requirement_error_level": 0,
             "show_progress_bars": true,
             "timezone": null

--- a/docs/source/user_guide/config.rst
+++ b/docs/source/user_guide/config.rst
@@ -55,6 +55,8 @@ FiftyOne supports the configuration options described below:
 +-------------------------------+-------------------------------------+-------------------------------+----------------------------------------------------------------------------------------+
 | `default_batch_size`          | `FIFTYONE_DEFAULT_BATCH_SIZE`       | `None`                        | A default batch size to use when :ref:`applying models to datasets <model-zoo-apply>`. |
 +-------------------------------+-------------------------------------+-------------------------------+----------------------------------------------------------------------------------------+
+| `bulk_write_batch_size`       | `FIFTYONE_BULK_WRITE_BATCH_SIZE`    | `100_000`                     | Batch size to use for bulk writing MongoDB operations; cannot be > 100,000             |
++-------------------------------+-------------------------------------+-------------------------------+----------------------------------------------------------------------------------------+
 | `default_sequence_idx`        | `FIFTYONE_DEFAULT_SEQUENCE_IDX`     | `%06d`                        | The default numeric string pattern to use when writing sequential lists of             |
 |                               |                                     |                               | files.                                                                                 |
 +-------------------------------+-------------------------------------+-------------------------------+----------------------------------------------------------------------------------------+

--- a/fiftyone/core/config.py
+++ b/fiftyone/core/config.py
@@ -154,6 +154,12 @@ class FiftyOneConfig(EnvConfig):
             env_var="FIFTYONE_DEFAULT_BATCH_SIZE",
             default=None,
         )
+        self.bulk_write_batch_size = self.parse_int(
+            d,
+            "bulk_write_batch_size",
+            env_var="FIFTYONE_BULK_WRITE_BATCH_SIZE",
+            default=100_000,  # mongodb limit
+        )
         self.default_sequence_idx = self.parse_string(
             d,
             "default_sequence_idx",

--- a/fiftyone/core/odm/database.py
+++ b/fiftyone/core/odm/database.py
@@ -788,7 +788,8 @@ def bulk_write(ops, coll, ordered=False):
         ordered (False): whether the operations must be performed in order
     """
     try:
-        for ops_batch in fou.iter_batches(ops, 100000):  # mongodb limit
+        batch_size = fo.config.bulk_write_batch_size
+        for ops_batch in fou.iter_batches(ops, batch_size):
             coll.bulk_write(list(ops_batch), ordered=ordered)
     except BulkWriteError as bwe:
         msg = bwe.details["writeErrors"][0]["errmsg"]


### PR DESCRIPTION
## What changes are proposed in this pull request?

Let batch size used for `bulk_write()` (previously hard coded 100k) be configurable.

## How is this patch tested? If it is not, please explain why.

Wrap `core.odm.database.bulk_write()` function in `fou.ProgressBar` to make it easier. Like this

```python
    try:
        batch_size = fo.config.bulk_write_batch_size
        with fou.ProgressBar(total=len(ops)) as pb:
            for ops_batch in fou.iter_batches(ops, batch_size):
                coll.bulk_write(list(ops_batch), ordered=ordered)
                pb.update(batch_size)
```
Test code
```python
import fiftyone as fo

ds=fo.zoo.load_zoo_dataset('coco-2017', splits='validation')

# progress bar goes from 0 to 100
ds.set_values("new_field", [51] * len(ds))

# progress bar goes in increments of 10
fo.config.bulk_write_batch_size=10
ds.set_values("new_field", [52] * len(ds))
ds.delete()
```
