### PR TITLE
[WIP] standardizing reload usage

### DIFF
--- a/docs/source/user_guide/config.rst
+++ b/docs/source/user_guide/config.rst
@@ -14,121 +14,130 @@ Configuration options
 
 FiftyOne supports the configuration options described below:
 
-+-------------------------------+---------------------------------------+-------------------------------+----------------------------------------------------------------------------------------+
-| Config field                  | Environment variable                  | Default value                 | Description                                                                            |
-+===============================+=======================================+===============================+========================================================================================+
-| `database_admin`              | `FIFTYONE_DATABASE_ADMIN`             | `True`                        | Whether the client is allowed to trigger database migrations. See                      |
-|                               |                                       |                               | :ref:`this section <database-migrations>` for more information.                        |
-+-------------------------------+---------------------------------------+-------------------------------+----------------------------------------------------------------------------------------+
-| `database_dir`                | `FIFTYONE_DATABASE_DIR`               | `~/.fiftyone/var/lib/mongo`   | The directory in which to store FiftyOne's backing database. Only applicable if        |
-|                               |                                       |                               | `database_uri` is not defined.                                                         |
-+-------------------------------+---------------------------------------+-------------------------------+----------------------------------------------------------------------------------------+
-| `database_name`               | `FIFTYONE_DATABASE_NAME`              | `fiftyone`                    | A name to use for FiftyOne's backing database in your MongoDB instance. The database   |
-|                               |                                       |                               | is automatically created if necessary.                                                 |
-+-------------------------------+---------------------------------------+-------------------------------+----------------------------------------------------------------------------------------+
-| `database_uri`                | `FIFTYONE_DATABASE_URI`               | `None`                        | A `MongoDB URI <https://docs.mongodb.com/manual/reference/connection-string/>`_ to     |
-|                               |                                       |                               | specifying a custom MongoDB database to which to connect. See                          |
-|                               |                                       |                               | :ref:`this section <configuring-mongodb-connection>` for more information.             |
-+-------------------------------+---------------------------------------+-------------------------------+----------------------------------------------------------------------------------------+
-| `database_validation`         | `FIFTYONE_DATABASE_VALIDATION`        | `True`                        | Whether to validate the compatibility of database before connecting to it. See         |
-|                               |                                       |                               | :ref:`this section <configuring-mongodb-connection>` for more information.             |
-+-------------------------------+---------------------------------------+-------------------------------+----------------------------------------------------------------------------------------+
-| `dataset_zoo_dir`             | `FIFTYONE_DATASET_ZOO_DIR`            | `~/fiftyone`                  | The default directory in which to store datasets that are downloaded from the          |
-|                               |                                       |                               | :ref:`FiftyOne Dataset Zoo <dataset-zoo>`.                                             |
-+-------------------------------+---------------------------------------+-------------------------------+----------------------------------------------------------------------------------------+
-| `dataset_zoo_manifest_paths`  | `FIFTYONE_ZOO_MANIFEST_PATHS`         | `None`                        | A list of manifest JSON files specifying additional zoo datasets. See                  |
-|                               |                                       |                               | :ref:`adding datasets to the zoo <dataset-zoo-add>` for more information.              |
-+-------------------------------+---------------------------------------+-------------------------------+----------------------------------------------------------------------------------------+
-| `default_dataset_dir`         | `FIFTYONE_DEFAULT_DATASET_DIR`        | `~/fiftyone`                  | The default directory to use when performing FiftyOne operations that                  |
-|                               |                                       |                               | require writing dataset contents to disk, such as ingesting datasets via               |
-|                               |                                       |                               | :meth:`ingest_labeled_images() <fiftyone.core.dataset.Dataset.ingest_labeled_images>`. |
-+-------------------------------+---------------------------------------+-------------------------------+----------------------------------------------------------------------------------------+
-| `default_ml_backend`          | `FIFTYONE_DEFAULT_ML_BACKEND`         | `torch`                       | The default ML backend to use when performing operations such as                       |
-|                               |                                       |                               | downloading datasets from the FiftyOne Dataset Zoo that support multiple ML            |
-|                               |                                       |                               | backends. Supported values are `torch` and `tensorflow`. By default,                   |
-|                               |                                       |                               | `torch` is used if `PyTorch <https://pytorch.org>`_ is installed in your               |
-|                               |                                       |                               | Python environment, and `tensorflow` is used if                                        |
-|                               |                                       |                               | `TensorFlow <http://tensorflow.org>`_ is installed. If no supported backend            |
-|                               |                                       |                               | is detected, this defaults to `None`, and any operation that requires an               |
-|                               |                                       |                               | installed ML backend will raise an informative error message if invoked in             |
-|                               |                                       |                               | this state.                                                                            |
-+-------------------------------+---------------------------------------+-------------------------------+----------------------------------------------------------------------------------------+
-| `default_batch_size`          | `FIFTYONE_DEFAULT_BATCH_SIZE`         | `None`                        | A default batch size to use when :ref:`applying models to datasets <model-zoo-apply>`. |
-+-------------------------------+---------------------------------------+-------------------------------+----------------------------------------------------------------------------------------+
-| `default_batcher`             | `FIFTYONE_DEFAULT_BATCHER`            | `latency`                     | Batching implementation to use in some batched database operations such as             |
-|                               |                                       |                               | :meth:`add_samples() <fiftyone.core.dataset.Dataset.add_samples>`,                     |
-|                               |                                       |                               | :meth:`set_values() <fiftyone.core.collections.SampleCollection.set_values>`, and      |
-|                               |                                       |                               | :meth:`save_context() <fiftyone.core.collections.SampleCollection.save_context>`.      |
-|                               |                                       |                               | Supported values are `latency`, `size`, and `static`.                                  |
-|                               |                                       |                               |                                                                                        |
-|                               |                                       |                               | `latency` is the default, which uses a dynamic batch size to achieve a target latency  |
-|                               |                                       |                               | of `batcher_target_latency` between calls. The default changes to `size` for the       |
-|                               |                                       |                               | FiftyOne Enterprise SDK in :ref:`API connection mode <enterprise-api-connection>`,     |
-|                               |                                       |                               | which targets a size of `batcher_target_size_bytes` for each call. `static` uses a     |
-|                               |                                       |                               | fixed batch size of `batcher_static_size`.                                             |
-+-------------------------------+---------------------------------------+-------------------------------+----------------------------------------------------------------------------------------+
-| `batcher_static_size`         | `FIFTYONE_BATCHER_STATIC_SIZE`        | `100`                         | Fixed size of batches. Only used when `default_batcher` is `static`.                   |
-+-------------------------------+---------------------------------------+-------------------------------+----------------------------------------------------------------------------------------+
-| `batcher_target_size_bytes`   | `FIFTYONE_BATCHER_TARGET_SIZE_BYTES`  | `2 ** 20`                     | Target content size of batches, in bytes. Only used when `default_batcher` is `size`.  |
-+-------------------------------+---------------------------------------+-------------------------------+----------------------------------------------------------------------------------------+
-| `batcher_target_latency`      | `FIFTYONE_BATCHER_TARGET_LATENCY`     | `0.2`                         | Target latency between batches, in seconds. Only used when `default_batcher` is        |
-|                               |                                       |                               | `latency`.                                                                             |
-+-------------------------------+---------------------------------------+-------------------------------+----------------------------------------------------------------------------------------+
-| `default_sequence_idx`        | `FIFTYONE_DEFAULT_SEQUENCE_IDX`       | `%06d`                        | The default numeric string pattern to use when writing sequential lists of             |
-|                               |                                       |                               | files.                                                                                 |
-+-------------------------------+---------------------------------------+-------------------------------+----------------------------------------------------------------------------------------+
-| `default_image_ext`           | `FIFTYONE_DEFAULT_IMAGE_EXT`          | `.jpg`                        | The default image format to use when writing images to disk.                           |
-+-------------------------------+---------------------------------------+-------------------------------+----------------------------------------------------------------------------------------+
-| `default_video_ext`           | `FIFTYONE_DEFAULT_VIDEO_EXT`          | `.mp4`                        | The default video format to use when writing videos to disk.                           |
-+-------------------------------+---------------------------------------+-------------------------------+----------------------------------------------------------------------------------------+
-| `default_app_port`            | `FIFTYONE_DEFAULT_APP_PORT`           | `5151`                        | The default port to use to serve the :ref:`FiftyOne App <fiftyone-app>`.               |
-+-------------------------------+---------------------------------------+-------------------------------+----------------------------------------------------------------------------------------+
-| `default_app_address`         | `FIFTYONE_DEFAULT_APP_ADDRESS`        | `localhost`                   | The default address to use to serve the :ref:`FiftyOne App <fiftyone-app>`. This may   |
-|                               |                                       |                               | be either an IP address or hostname. If it's a hostname, the App will listen to all    |
-|                               |                                       |                               | IP addresses associated with the name. The default is `localhost`, which means the App |
-|                               |                                       |                               | will only listen on the local interface. See :ref:`this page <restricting-app-address>`|
-|                               |                                       |                               | for more information.                                                                  |
-+-------------------------------+---------------------------------------+-------------------------------+----------------------------------------------------------------------------------------+
-| `do_not_track`                | `FIFTYONE_DO_NOT_TRACK`               | `False`                       | Controls whether UUID based import and App usage events are tracked.                   |
-+-------------------------------+---------------------------------------+-------------------------------+----------------------------------------------------------------------------------------+
-| `logging_level`               | `FIFTYONE_LOGGING_LEVEL`              | `INFO`                        | Controls FiftyOne's package-wide logging level. Can be any valid ``logging`` level as  |
-|                               |                                       |                               | a string: ``DEBUG, INFO, WARNING, ERROR, CRITICAL``.                                   |
-+-------------------------------+---------------------------------------+-------------------------------+----------------------------------------------------------------------------------------+
-| `max_thread_pool_workers`     | `FIFTYONE_MAX_THREAD_POOL_WORKERS`    | `None`                        | An optional maximum number of workers to use when creating thread pools                |
-+-------------------------------+---------------------------------------+-------------------------------+----------------------------------------------------------------------------------------+
-| `max_process_pool_workers`    | `FIFTYONE_MAX_PROCESS_POOL_WORKERS`   | `None`                        | An optional maximum number of workers to use when creating process pools               |
-+-------------------------------+---------------------------------------+-------------------------------+----------------------------------------------------------------------------------------+
-| `model_zoo_dir`               | `FIFTYONE_MODEL_ZOO_DIR`              | `~/fiftyone/__models__`       | The default directory in which to store models that are downloaded from the            |
-|                               |                                       |                               | :ref:`FiftyOne Model Zoo <model-zoo>`.                                                 |
-+-------------------------------+---------------------------------------+-------------------------------+----------------------------------------------------------------------------------------+
-| `model_zoo_manifest_paths`    | `FIFTYONE_MODEL_ZOO_MANIFEST_PATHS`   | `None`                        | A list of manifest JSON files specifying additional zoo models. See                    |
-|                               |                                       |                               | :ref:`adding models to the zoo <model-zoo-add>` for more information.                  |
-+-------------------------------+---------------------------------------+-------------------------------+----------------------------------------------------------------------------------------+
-| `module_path`                 | `FIFTYONE_MODULE_PATH`                | `None`                        | A list of modules that should be automatically imported whenever FiftyOne is imported. |
-|                               |                                       |                               | See :ref:`this page <custom-embedded-documents>` for an example usage.                 |
-+-------------------------------+---------------------------------------+-------------------------------+----------------------------------------------------------------------------------------+
-| `operator_timeout`            | `FIFTYONE_OPERATOR_TIMEOUT`           | `600`                         | The timeout for execution of an operator. See :ref:`this page <fiftyone-plugins>` for  |
-|                               |                                       |                               | more information.                                                                      |
-+-------------------------------+---------------------------------------+-------------------------------+----------------------------------------------------------------------------------------+
-| `allow_legacy_orchestrators`  | `FIFTYONE_ALLOW_LEGACY_ORCHESTRATORS` | `False`                       | Whether to allow delegated operations to be scheduled locally.                         |
-|                               |                                       |                               | See :ref:`this page <delegated-orchestrator-open-source>` for more information.        |
-+-------------------------------+---------------------------------------+-------------------------------+----------------------------------------------------------------------------------------+
-| `plugins_dir`                 | `FIFTYONE_PLUGINS_DIR`                | `None`                        | A directory containing custom App plugins. See :ref:`this page <fiftyone-plugins>` for |
-|                               |                                       |                               | more information.                                                                      |
-+-------------------------------+---------------------------------------+-------------------------------+----------------------------------------------------------------------------------------+
-| `plugins_cache_enabled`       | `FIFTYONE_PLUGINS_CACHE_ENABLED`      | `False`                       | When set to ``True`` plugins will be cached until their directory's ``mtime`` changes. |
-|                               |                                       |                               | This is intended to be used in production.                                             |
-+-------------------------------+---------------------------------------+-------------------------------+----------------------------------------------------------------------------------------+
-| `do_not_track`                | `FIFTYONE_DO_NOT_TRACK`               | `False`                       | Controls whether UUID based import and App usage events are tracked.                   |
-+-------------------------------+---------------------------------------+-------------------------------+----------------------------------------------------------------------------------------+
-| `show_progress_bars`          | `FIFTYONE_SHOW_PROGRESS_BARS`         | `True`                        | Controls whether progress bars are printed to the terminal when performing             |
-|                               |                                       |                               | operations such reading/writing large datasets or activating FiftyOne                  |
-|                               |                                       |                               | Brain methods on datasets.                                                             |
-+-------------------------------+---------------------------------------+-------------------------------+----------------------------------------------------------------------------------------+
-| `timezone`                    | `FIFTYONE_TIMEZONE`                   | `None`                        | An optional timezone string. If provided, all datetimes read from FiftyOne datasets    |
-|                               |                                       |                               | will be expressed in this timezone. See :ref:`this section <configuring-timezone>` for |
-|                               |                                       |                               | more information.                                                                      |
-+-------------------------------+---------------------------------------+-------------------------------+----------------------------------------------------------------------------------------+
++-------------------------------+-------------------------------------+-------------------------------+----------------------------------------------------------------------------------------+
+| Config field                  | Environment variable                | Default value                 | Description                                                                            |
++===============================+=====================================+===============================+========================================================================================+
+| `database_admin`              | `FIFTYONE_DATABASE_ADMIN`           | `True`                        | Whether the client is allowed to trigger database migrations. See                      |
+|                               |                                     |                               | :ref:`this section <database-migrations>` for more information.                        |
++-------------------------------+-------------------------------------+-------------------------------+----------------------------------------------------------------------------------------+
+| `database_dir`                | `FIFTYONE_DATABASE_DIR`             | `~/.fiftyone/var/lib/mongo`   | The directory in which to store FiftyOne's backing database. Only applicable if        |
+|                               |                                     |                               | `database_uri` is not defined.                                                         |
++-------------------------------+-------------------------------------+-------------------------------+----------------------------------------------------------------------------------------+
+| `database_name`               | `FIFTYONE_DATABASE_NAME`            | `fiftyone`                    | A name to use for FiftyOne's backing database in your MongoDB instance. The database   |
+|                               |                                     |                               | is automatically created if necessary.                                                 |
++-------------------------------+-------------------------------------+-------------------------------+----------------------------------------------------------------------------------------+
+| `database_uri`                | `FIFTYONE_DATABASE_URI`             | `None`                        | A `MongoDB URI <https://docs.mongodb.com/manual/reference/connection-string/>`_ to     |
+|                               |                                     |                               | specifying a custom MongoDB database to which to connect. See                          |
+|                               |                                     |                               | :ref:`this section <configuring-mongodb-connection>` for more information.             |
++-------------------------------+-------------------------------------+-------------------------------+----------------------------------------------------------------------------------------+
+| `database_validation`         | `FIFTYONE_DATABASE_VALIDATION`      | `True`                        | Whether to validate the compatibility of database before connecting to it. See         |
+|                               |                                     |                               | :ref:`this section <configuring-mongodb-connection>` for more information.             |
++-------------------------------+-------------------------------------+-------------------------------+----------------------------------------------------------------------------------------+
+| `dataset_zoo_dir`             | `FIFTYONE_DATASET_ZOO_DIR`          | `~/fiftyone`                  | The default directory in which to store datasets that are downloaded from the          |
+|                               |                                     |                               | :ref:`FiftyOne Dataset Zoo <dataset-zoo>`.                                             |
++-------------------------------+-------------------------------------+-------------------------------+----------------------------------------------------------------------------------------+
+| `dataset_zoo_manifest_paths`  | `FIFTYONE_ZOO_MANIFEST_PATHS`       | `None`                        | A list of manifest JSON files specifying additional zoo datasets. See                  |
+|                               |                                     |                               | :ref:`adding datasets to the zoo <dataset-zoo-add>` for more information.              |
++-------------------------------+-------------------------------------+-------------------------------+----------------------------------------------------------------------------------------+
+| `default_dataset_dir`         | `FIFTYONE_DEFAULT_DATASET_DIR`      | `~/fiftyone`                  | The default directory to use when performing FiftyOne operations that                  |
+|                               |                                     |                               | require writing dataset contents to disk, such as ingesting datasets via               |
+|                               |                                     |                               | :meth:`ingest_labeled_images() <fiftyone.core.dataset.Dataset.ingest_labeled_images>`. |
++-------------------------------+-------------------------------------+-------------------------------+----------------------------------------------------------------------------------------+
+| `default_ml_backend`          | `FIFTYONE_DEFAULT_ML_BACKEND`       | `torch`                       | The default ML backend to use when performing operations such as                       |
+|                               |                                     |                               | downloading datasets from the FiftyOne Dataset Zoo that support multiple ML            |
+|                               |                                     |                               | backends. Supported values are `torch` and `tensorflow`. By default,                   |
+|                               |                                     |                               | `torch` is used if `PyTorch <https://pytorch.org>`_ is installed in your               |
+|                               |                                     |                               | Python environment, and `tensorflow` is used if                                        |
+|                               |                                     |                               | `TensorFlow <http://tensorflow.org>`_ is installed. If no supported backend            |
+|                               |                                     |                               | is detected, this defaults to `None`, and any operation that requires an               |
+|                               |                                     |                               | installed ML backend will raise an informative error message if invoked in             |
+|                               |                                     |                               | this state.                                                                            |
++-------------------------------+-------------------------------------+-------------------------------+----------------------------------------------------------------------------------------+
+| `default_batch_size`          | `FIFTYONE_DEFAULT_BATCH_SIZE`       | `None`                        | A default batch size to use when :ref:`applying models to datasets <model-zoo-apply>`. |
++-------------------------------+-------------------------------------+-------------------------------+----------------------------------------------------------------------------------------+
+| `bulk_write_batch_size`       | `FIFTYONE_BULK_WRITE_BATCH_SIZE`    | `100,000`                     | Batch size to use for bulk writing MongoDB operations. Must be <= 100,000.             |
+|                               |                                     |                               |                                                                                        |
+|                               |                                     |                               | Default changes to 10,000 for the FiftyOne Teams SDK in                                |
+|                               |                                     |                               | :ref:`API connection mode <teams-api-connection>`.                                     |
++-------------------------------+-------------------------------------+-------------------------------+----------------------------------------------------------------------------------------+
+| `default_batcher`             | `FIFTYONE_DEFAULT_BATCHER`          | `latency`                     | Batching implementation to use in some batched database operations such as             |
+|                               |                                     |                               | :meth:`add_samples() <fiftyone.core.dataset.Dataset.add_samples>`. Supported values    |
+|                               |                                     |                               | are `latency`, `size`, and `static`.                                                   |
+|                               |                                     |                               |                                                                                        |
+|                               |                                     |                               | `latency` is the default, which uses a dynamic batch size to achieve a target latency  |
+|                               |                                     |                               | of `batcher_target_latency` between calls. The default changes to `size` for the       |
+|                               |                                     |                               | FiftyOne Teams SDK in :ref:`API connection mode <teams-api-connection>`, which targets |
+|                               |                                     |                               | a size of `batcher_target_size_bytes` for each call. `static` uses a fixed batch size  |
+|                               |                                     |                               | of `batcher_static_size`.                                                              |
++-------------------------------+-------------------------------------+-------------------------------+----------------------------------------------------------------------------------------+
+| `batcher_static_size`         | `FIFTYONE_BATCHER_STATIC_SIZE`      | `100`                         | Fixed size of batches. Only used when `default_batcher` is `static`.                   |
++-------------------------------+-------------------------------------+-------------------------------+----------------------------------------------------------------------------------------+
+| `batcher_target_size_bytes`   | `FIFTYONE_BATCHER_TARGET_SIZE_BYTES`| `2 ** 20`                     | Target content size of batches, in bytes. Only used when `default_batcher` is `size`.  |
++-------------------------------+-------------------------------------+-------------------------------+----------------------------------------------------------------------------------------+
+| `batcher_target_latency`      | `FIFTYONE_BATCHER_TARGET_LATENCY`   | `0.2`                         | Target latency between batches, in seconds. Only used when `default_batcher` is        |
+|                               |                                     |                               | `latency`.                                                                             |
++-------------------------------+-------------------------------------+-------------------------------+----------------------------------------------------------------------------------------+
+| `default_sequence_idx`        | `FIFTYONE_DEFAULT_SEQUENCE_IDX`     | `%06d`                        | The default numeric string pattern to use when writing sequential lists of             |
+|                               |                                     |                               | files.                                                                                 |
++-------------------------------+-------------------------------------+-------------------------------+----------------------------------------------------------------------------------------+
+| `default_image_ext`           | `FIFTYONE_DEFAULT_IMAGE_EXT`        | `.jpg`                        | The default image format to use when writing images to disk.                           |
++-------------------------------+-------------------------------------+-------------------------------+----------------------------------------------------------------------------------------+
+| `default_video_ext`           | `FIFTYONE_DEFAULT_VIDEO_EXT`        | `.mp4`                        | The default video format to use when writing videos to disk.                           |
++-------------------------------+-------------------------------------+-------------------------------+----------------------------------------------------------------------------------------+
+| `default_app_port`            | `FIFTYONE_DEFAULT_APP_PORT`         | `5151`                        | The default port to use to serve the :ref:`FiftyOne App <fiftyone-app>`.               |
++-------------------------------+-------------------------------------+-------------------------------+----------------------------------------------------------------------------------------+
+| `default_app_address`         | `FIFTYONE_DEFAULT_APP_ADDRESS`      | `localhost`                   | The default address to use to serve the :ref:`FiftyOne App <fiftyone-app>`. This may   |
+|                               |                                     |                               | be either an IP address or hostname. If it's a hostname, the App will listen to all    |
+|                               |                                     |                               | IP addresses associated with the name. The default is `localhost`, which means the App |
+|                               |                                     |                               | will only listen on the local interface. See :ref:`this page <restricting-app-address>`|
+|                               |                                     |                               | for more information.                                                                  |
++-------------------------------+-------------------------------------+-------------------------------+----------------------------------------------------------------------------------------+
+| `desktop_app`                 | `FIFTYONE_DESKTOP_APP`              | `False`                       | Whether to launch the FiftyOne App in the browser (False) or as a desktop App (True)   |
+|                               |                                     |                               | by default. If True, the :ref:`FiftyOne Desktop App <installing-fiftyone-desktop>`     |
+|                               |                                     |                               | must be installed.                                                                     |
++-------------------------------+-------------------------------------+-------------------------------+----------------------------------------------------------------------------------------+
+| `do_not_track`                | `FIFTYONE_DO_NOT_TRACK`             | `False`                       | Controls whether UUID based import and App usage events are tracked.                   |
++-------------------------------+-------------------------------------+-------------------------------+----------------------------------------------------------------------------------------+
+| `logging_level`               | `FIFTYONE_LOGGING_LEVEL`            | `INFO`                        | Controls FiftyOne's package-wide logging level. Can be any valid ``logging`` level as  |
+|                               |                                     |                               | a string: ``DEBUG, INFO, WARNING, ERROR, CRITICAL``.                                   |
++-------------------------------+-------------------------------------+-------------------------------+----------------------------------------------------------------------------------------+
+| `max_thread_pool_workers`     | `FIFTYONE_MAX_THREAD_POOL_WORKERS`  | `None`                        | An optional maximum number of workers to use when creating thread pools                |
++-------------------------------+-------------------------------------+-------------------------------+----------------------------------------------------------------------------------------+
+| `max_process_pool_workers`    | `FIFTYONE_MAX_PROCESS_POOL_WORKERS` | `None`                        | An optional maximum number of workers to use when creating process pools               |
++-------------------------------+-------------------------------------+-------------------------------+----------------------------------------------------------------------------------------+
+| `model_zoo_dir`               | `FIFTYONE_MODEL_ZOO_DIR`            | `~/fiftyone/__models__`       | The default directory in which to store models that are downloaded from the            |
+|                               |                                     |                               | :ref:`FiftyOne Model Zoo <model-zoo>`.                                                 |
++-------------------------------+-------------------------------------+-------------------------------+----------------------------------------------------------------------------------------+
+| `model_zoo_manifest_paths`    | `FIFTYONE_MODEL_ZOO_MANIFEST_PATHS` | `None`                        | A list of manifest JSON files specifying additional zoo models. See                    |
+|                               |                                     |                               | :ref:`adding models to the zoo <model-zoo-add>` for more information.                  |
++-------------------------------+-------------------------------------+-------------------------------+----------------------------------------------------------------------------------------+
+| `module_path`                 | `FIFTYONE_MODULE_PATH`              | `None`                        | A list of modules that should be automatically imported whenever FiftyOne is imported. |
+|                               |                                     |                               | See :ref:`this page <custom-embedded-documents>` for an example usage.                 |
++-------------------------------+-------------------------------------+-------------------------------+----------------------------------------------------------------------------------------+
+| `operator_timeout`            | `FIFTYONE_OPERATOR_TIMEOUT`         | `600`                         | The timeout for execution of an operator. See :ref:`this page <fiftyone-plugins>` for  |
+|                               |                                     |                               | more information.                                                                      |
++-------------------------------+-------------------------------------+-------------------------------+----------------------------------------------------------------------------------------+
+| `plugins_dir`                 | `FIFTYONE_PLUGINS_DIR`              | `None`                        | A directory containing custom App plugins. See :ref:`this page <fiftyone-plugins>` for |
+|                               |                                     |                               | more information.                                                                      |
++-------------------------------+-------------------------------------+-------------------------------+----------------------------------------------------------------------------------------+
+| `plugins_cache_enabled`       | `FIFTYONE_PLUGINS_CACHE_ENABLED`    | `False`                       | When set to ``True`` plugins will be cached until their directory's ``mtime`` changes. |
+|                               |                                     |                               | This is intended to be used in production.                                             |
++-------------------------------+-------------------------------------+-------------------------------+----------------------------------------------------------------------------------------+
+| `requirement_error_level`     | `FIFTYONE_REQUIREMENT_ERROR_LEVEL`  | `0`                           | A default error level to use when ensuring/installing requirements such as third-party |
+|                               |                                     |                               | packages. See :ref:`loading zoo models <model-zoo-load>` for an example usage.         |
++-------------------------------+-------------------------------------+-------------------------------+----------------------------------------------------------------------------------------+
+| `show_progress_bars`          | `FIFTYONE_SHOW_PROGRESS_BARS`       | `True`                        | Controls whether progress bars are printed to the terminal when performing             |
+|                               |                                     |                               | operations such reading/writing large datasets or activiating FiftyOne                 |
+|                               |                                     |                               | Brain methods on datasets.                                                             |
++-------------------------------+-------------------------------------+-------------------------------+----------------------------------------------------------------------------------------+
+| `singleton_cache`             | `FIFTYONE_SINGLETON_CACHE`          | `True`                        | Whether to treat :class:`Dataset <fiftyone.core.dataset.Dataset>`,                     |
+|                               |                                     |                               | :class:`Sample <fiftyone.core.sample.Sample>`, and                                     |
+|                               |                                     |                               | :class:`Frame <fiftyone.core.frame.Frame>` instances as singletons.                    |
++-------------------------------+-------------------------------------+-------------------------------+----------------------------------------------------------------------------------------+
+| `timezone`                    | `FIFTYONE_TIMEZONE`                 | `None`                        | An optional timzone string. If provided, all datetimes read from FiftyOne datasets     |
+|                               |                                     |                               | will be expressed in this timezone. See :ref:`this section <configuring-timezone>` for |
+|                               |                                     |                               | more information.                                                                      |
++-------------------------------+-------------------------------------+-------------------------------+----------------------------------------------------------------------------------------+
 
 Viewing your config
 -------------------
@@ -185,6 +194,7 @@ and the CLI:
             "plugins_dir": null,
             "requirement_error_level": 0,
             "show_progress_bars": true,
+            "singleton_cache": true,
             "timezone": null
         }
 
@@ -235,6 +245,7 @@ and the CLI:
             "plugins_dir": null,
             "requirement_error_level": 0,
             "show_progress_bars": true,
+            "singleton_cache": true,
             "timezone": null
         }
 

--- a/fiftyone/core/config.py
+++ b/fiftyone/core/config.py
@@ -250,6 +250,12 @@ class FiftyOneConfig(EnvConfig):
             env_var="FIFTYONE_MAX_PROCESS_POOL_WORKERS",
             default=None,
         )
+        self.singleton_cache = self.parse_bool(
+            d,
+            "singleton_cache",
+            env_var="FIFTYONE_SINGLETON_CACHE",
+            default=True,
+        )
 
         self._init()
 

--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -142,7 +142,7 @@ def _validate_dataset_name(name, skip=None):
     return slug
 
 
-def load_dataset(name, create_if_necessary=False):
+def load_dataset(name, create_if_necessary=False, reload=False):
     """Loads the FiftyOne dataset with the given name.
 
     To create a new dataset, use the :class:`Dataset` constructor.
@@ -156,6 +156,7 @@ def load_dataset(name, create_if_necessary=False):
     Args:
         name: the name of the dataset
         create_if_necessary (False): if no dataset exists, create an empty one
+        reload (False): whether to reload the dataset if necessary
 
     Raises:
         DatasetNotFoundError: if the dataset does not exist and
@@ -165,7 +166,7 @@ def load_dataset(name, create_if_necessary=False):
         a :class:`Dataset`
     """
     try:
-        return Dataset(name, _create=False)
+        return Dataset(name, _create=False, _reload=reload)
     except DatasetNotFoundError as ex:
         if create_if_necessary:
             return Dataset(name, _create=True)
@@ -316,6 +317,7 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
         overwrite=False,
         _create=True,
         _virtual=False,
+        _reload=False,
         **kwargs,
     ):
         if name is None and _create:

--- a/fiftyone/core/odm/utils.py
+++ b/fiftyone/core/odm/utils.py
@@ -698,13 +698,14 @@ class DocumentRegistryError(Exception):
 _document_registry = DocumentRegistry()
 
 
-def load_dataset(id=None, name=None):
+def load_dataset(id=None, name=None, reload=False):
     """Loads the dataset from the database by its unique id or name. Throws
     an error if neither id nor name is provided.
 
     Args:
         id (None): the unique id of the dataset
         name (None): the name of the dataset
+        reload (False): whether to reload the dataset if necessary
 
     Returns:
         a :class:`fiftyone.core.dataset.Dataset`
@@ -720,13 +721,14 @@ def load_dataset(id=None, name=None):
 
     db = foo.get_db_conn()
     try:
-        uid = ObjectId(id)
+        _id = ObjectId(id)
     except:
         # Although _id is an ObjectId by default, it's possible to set it to
         # something else
-        uid = id
+        _id = id
 
-    res = db.datasets.find_one({"_id": uid}, {"name": True})
+    res = db.datasets.find_one({"_id": _id}, {"name": True})
     if not res:
-        raise ValueError(f"Dataset with _id={uid} does not exist")
-    return fod.load_dataset(res.get("name"))
+        raise ValueError(f"Dataset with _id={_id} does not exist")
+
+    return fod.load_dataset(res.get("name"), reload=reload)

--- a/fiftyone/core/singletons.py
+++ b/fiftyone/core/singletons.py
@@ -9,6 +9,8 @@ FiftyOne singleton implementations.
 from collections import defaultdict
 import weakref
 
+import fiftyone as fo
+
 
 class DatasetSingleton(type):
     """Singleton metaclass for :class:`fiftyone.core.dataset.Dataset`.
@@ -47,7 +49,8 @@ class DatasetSingleton(type):
                     name=name, _create=_create, *args, **kwargs
                 )
 
-        cls._instances[name] = instance
+        if fo.config.singleton_cache:
+            cls._instances[name] = instance
 
         return instance
 
@@ -110,7 +113,8 @@ class SampleSingleton(DocumentSingleton):
         return cls
 
     def _register_instance(cls, obj):
-        cls._instances[obj._doc.collection_name][obj.id] = obj
+        if fo.config.singleton_cache:
+            cls._instances[obj._doc.collection_name][obj.id] = obj
 
     def _get_instance(cls, doc):
         try:
@@ -255,9 +259,10 @@ class FrameSingleton(DocumentSingleton):
         return cls
 
     def _register_instance(cls, obj):
-        cls._instances[obj._doc.collection_name][obj.sample_id][
-            obj.frame_number
-        ] = obj
+        if fo.config.singleton_cache:
+            cls._instances[obj._doc.collection_name][obj.sample_id][
+                obj.frame_number
+            ] = obj
 
     def _get_instance(cls, doc):
         try:

--- a/fiftyone/core/singletons.py
+++ b/fiftyone/core/singletons.py
@@ -26,7 +26,7 @@ class DatasetSingleton(type):
         cls._instances = weakref.WeakValueDictionary()
         return cls
 
-    def __call__(cls, name=None, _create=True, *args, **kwargs):
+    def __call__(cls, name=None, _create=True, _reload=False, *args, **kwargs):
         instance = cls._instances.pop(name, None)
 
         if (
@@ -48,6 +48,9 @@ class DatasetSingleton(type):
                 return cls.__call__(
                     name=name, _create=_create, *args, **kwargs
                 )
+
+            if _reload:
+                instance.reload()
 
         if fo.config.singleton_cache:
             cls._instances[name] = instance

--- a/fiftyone/core/state.py
+++ b/fiftyone/core/state.py
@@ -83,8 +83,6 @@ class StateDescription(etas.Serializable):
         self.sample_id = sample_id
         self.selected = selected or []
         self.selected_labels = selected_labels or []
-        self.spaces = spaces
-
         self.view = (
             dataset.load_saved_view(view_name)
             if dataset is not None and view_name
@@ -162,25 +160,16 @@ class StateDescription(etas.Serializable):
         """
         dataset = d.get("dataset", None)
         if dataset is not None:
-            dataset = fod.load_dataset(dataset)
+            dataset = fod.load_dataset(dataset, reload=True)
 
         stages = d.get("view", None)
         view = None
         view_name = d.get("view_name", None)
         if dataset is not None:
             if view_name:
-                try:
-                    view = dataset.load_saved_view(view_name)
-                except Exception as e:
-                    dataset.reload()
-                    view = dataset.load_saved_view(view_name)
-
+                view = dataset.load_saved_view(view_name)
             elif stages:
-                try:
-                    view = fov.DatasetView._build(dataset, stages)
-                except:
-                    dataset.reload()
-                    view = fov.DatasetView._build(dataset, stages)
+                view = fov.DatasetView._build(dataset, stages)
 
         config = (
             fo.AppConfig.from_dict(d["config"])

--- a/fiftyone/core/state.py
+++ b/fiftyone/core/state.py
@@ -83,6 +83,8 @@ class StateDescription(etas.Serializable):
         self.sample_id = sample_id
         self.selected = selected or []
         self.selected_labels = selected_labels or []
+        self.spaces = spaces
+
         self.view = (
             dataset.load_saved_view(view_name)
             if dataset is not None and view_name

--- a/fiftyone/operators/executor.py
+++ b/fiftyone/operators/executor.py
@@ -513,7 +513,7 @@ class ExecutionContext(object):
         # id if it is available
         uid = self.request_params.get("dataset_id", None)
         if uid:
-            self._dataset = focu.load_dataset(id=uid)
+            self._dataset = focu.load_dataset(id=uid, reload=True)
 
             # Set the dataset_name using the dataset object in case the dataset
             # has been renamed or changed since the context was created
@@ -521,12 +521,7 @@ class ExecutionContext(object):
         else:
             uid = self.request_params.get("dataset_name", None)
             if uid:
-                self._dataset = focu.load_dataset(name=uid)
-
-        # TODO: refactor so that this additional reload post-load is not
-        #  required
-        if self._dataset is not None:
-            self._dataset.reload()
+                self._dataset = focu.load_dataset(name=uid, reload=True)
 
         if (
             self.group_slice is not None
@@ -556,7 +551,6 @@ class ExecutionContext(object):
         if self._view is not None:
             return self._view
 
-        # Always derive the view from the context's dataset
         dataset = self.dataset
         view_name = self.request_params.get("view_name", None)
         stages = self.request_params.get("view", None)
@@ -572,7 +566,6 @@ class ExecutionContext(object):
                 stages=stages,
                 filters=filters,
                 extended_stages=extended,
-                reload=False,
             )
         else:
             self._view = dataset.load_saved_view(view_name)

--- a/fiftyone/server/color.py
+++ b/fiftyone/server/color.py
@@ -198,7 +198,7 @@ class SetColorScheme:
             color_scheme.id = str(ObjectId())
 
         def run():
-            dataset = fo.load_dataset(dataset_name)
+            dataset = fo.load_dataset(dataset_name, reload=True)
             dataset.app_config.color_scheme = (
                 _to_odm_color_scheme(color_scheme) if color_scheme else None
             )

--- a/fiftyone/server/lightning.py
+++ b/fiftyone/server/lightning.py
@@ -126,7 +126,7 @@ LightningResults = gql.union(
 async def lightning_resolver(
     input: LightningInput, info: Info
 ) -> t.List[LightningResults]:
-    dataset: fo.Dataset = fo.load_dataset(input.dataset)
+    dataset: fo.Dataset = fo.load_dataset(input.dataset, reload=True)
     collections, queries, resolvers, is_frames = zip(
         *[
             _resolve_lightning_path_queries(path, dataset, info)

--- a/fiftyone/server/mutation.py
+++ b/fiftyone/server/mutation.py
@@ -89,7 +89,9 @@ class Mutation(SetColorScheme):
         info: Info,
     ) -> bool:
         state = get_state()
-        state.dataset = fod.load_dataset(name) if name is not None else None
+        state.dataset = (
+            fod.load_dataset(name, reload=True) if name is not None else None
+        )
 
         state.color_scheme = build_color_scheme(
             None, state.dataset, state.config
@@ -218,7 +220,7 @@ class Mutation(SetColorScheme):
             return None
 
         result_view = None
-        ds = fod.load_dataset(dataset_name)
+        ds = fod.load_dataset(dataset_name, reload=True)
         state.dataset = ds
 
         # Create the view using the saved view doc if loading a saved view
@@ -289,7 +291,7 @@ class Mutation(SetColorScheme):
         dataset = state.dataset
         use_state = dataset is not None
         if dataset is None:
-            dataset = fod.load_dataset(dataset_name)
+            dataset = fod.load_dataset(dataset_name, reload=True)
 
         if dataset is None:
             raise ValueError(
@@ -312,7 +314,6 @@ class Mutation(SetColorScheme):
             view_name, result_view, description=description, color=color
         )
         if use_state:
-            dataset.reload()
             state.view = dataset.load_saved_view(view_name)
             await dispatch_event(subscription, fose.StateUpdate(state=state))
 
@@ -340,7 +341,7 @@ class Mutation(SetColorScheme):
                 view_name,
             )
 
-        dataset = fod.load_dataset(dataset_name)
+        dataset = fod.load_dataset(dataset_name, reload=True)
         if not dataset:
             raise ValueError(f"No dataset found with name {dataset_name}")
 
@@ -383,11 +384,10 @@ class Mutation(SetColorScheme):
             view_name: name of the existing saved view
             updated_info: input type with values only for fields requiring
             update
-
         """
         state = get_state()
         if state is None or state.dataset is None:
-            dataset = fod.load_dataset(dataset_name)
+            dataset = fod.load_dataset(dataset_name, reload=True)
         else:
             dataset = state.dataset
 
@@ -401,7 +401,7 @@ class Mutation(SetColorScheme):
                 "%s",
                 view_name,
             )
-        dataset.reload()
+
         current_name = (
             updated_info["name"]
             if "name" in updated_info and updated_info["name"] is not None
@@ -440,7 +440,7 @@ class Mutation(SetColorScheme):
         state = get_state()
         dataset = state.dataset
         if dataset is None:
-            dataset = fod.load_dataset(dataset_name)
+            dataset = fod.load_dataset(dataset_name, reload=True)
 
         try:
             view = dataset.select_fields(meta_filter=meta_filter)

--- a/fiftyone/server/query.py
+++ b/fiftyone/server/query.py
@@ -494,7 +494,7 @@ class Query(fosa.AggregateQuery):
     @gql.field
     def saved_views(self, dataset_name: str) -> t.Optional[t.List[SavedView]]:
         try:
-            ds = fod.load_dataset(dataset_name)
+            ds = fod.load_dataset(dataset_name, reload=True)
             return [
                 SavedView.from_doc(view_doc)
                 for view_doc in ds._doc.saved_views
@@ -509,7 +509,7 @@ class Query(fosa.AggregateQuery):
         view_stages: BSONArray,
     ) -> SchemaResult:
         try:
-            ds = fod.load_dataset(dataset_name)
+            ds = fod.load_dataset(dataset_name, reload=True)
             if view_stages:
                 view = fov.DatasetView._build(ds, view_stages or [])
 
@@ -590,8 +590,8 @@ async def serialize_dataset(
         if not fod.dataset_exists(dataset_name):
             return None
 
-        dataset = fo.Dataset(dataset_name, _create=False, _force_load=True)
-        dataset.reload()
+        dataset = fod.load_dataset(dataset_name, reload=True)
+
         view_name = None
         try:
             doc = dataset._get_saved_view_doc(saved_view_slug, slug=True)

--- a/fiftyone/server/samples.py
+++ b/fiftyone/server/samples.py
@@ -84,19 +84,14 @@ async def paginate_samples(
     sample_filter: t.Optional[SampleFilter] = None,
     pagination_data: t.Optional[bool] = False,
 ) -> Connection[t.Union[ImageSample, VideoSample], str]:
-    run = lambda reload: fosv.get_view(
+    view = fosv.get_view(
         dataset,
         stages=stages,
         filters=filters,
         pagination_data=pagination_data,
         extended_stages=extended_stages,
         sample_filter=sample_filter,
-        reload=reload,
     )
-    try:
-        view = await run_sync_task(run, False)
-    except:
-        view = await run_sync_task(run, True)
 
     if after is None:
         after = "-1"

--- a/fiftyone/server/utils.py
+++ b/fiftyone/server/utils.py
@@ -39,7 +39,7 @@ def load_and_cache_dataset(name):
     Returns:
         a :class:`fiftyone.core.dataset.Dataset`
     """
-    dataset = fod.load_dataset(name)
+    dataset = fod.load_dataset(name, reload=True)
 
     # Store reference in TTL cache to defer garbage collection
     # IMPORTANT: we don't return already cached objects here because a dataset

--- a/fiftyone/server/view.py
+++ b/fiftyone/server/view.py
@@ -108,36 +108,34 @@ def get_view(
         if isinstance(dataset, str):
             dataset = fod.load_dataset(dataset, reload=reload)
 
-            if view_name is not None:
-                return dataset.load_saved_view(view_name)
+        if view_name is not None:
+            return dataset.load_saved_view(view_name)
 
-            if stages:
-                view = fov.DatasetView._build(dataset, stages)
-            else:
-                view = dataset.view()
+        if stages:
+            view = fov.DatasetView._build(dataset, stages)
+        else:
+            view = dataset.view()
 
-            media_types = None
-            if sample_filter is not None:
-                if sample_filter.group:
-                    view, media_types = handle_group_filter(
-                        dataset, view, sample_filter.group
-                    )
-
-                elif sample_filter.id:
-                    view = fov.make_optimized_select_view(
-                        view, sample_filter.id
-                    )
-
-            if filters or extended_stages or pagination_data:
-                view = get_extended_view(
-                    view,
-                    filters,
-                    pagination_data=pagination_data,
-                    extended_stages=extended_stages,
-                    media_types=media_types,
+        media_types = None
+        if sample_filter is not None:
+            if sample_filter.group:
+                view, media_types = handle_group_filter(
+                    dataset, view, sample_filter.group
                 )
 
-            return view
+            elif sample_filter.id:
+                view = fov.make_optimized_select_view(view, sample_filter.id)
+
+        if filters or extended_stages or pagination_data:
+            view = get_extended_view(
+                view,
+                filters,
+                pagination_data=pagination_data,
+                extended_stages=extended_stages,
+                media_types=media_types,
+            )
+
+        return view
 
     if awaitable:
         return fou.run_sync_task(run, dataset, stages)


### PR DESCRIPTION
Untested attempts to standardized `dataset.reload()` usage such that unnecessary reloads are not be performed when `load_dataset()` does *not* use a cached singleton reference.

Cam: I am picking up this PR plz ignore until I move it into review

TODO:
- Test that these changes actually work and don't break anything
- Look for new instances of load or reload dataset that might be impacted by these changes
- Discuss the server changes more in depth with ben and sash