### PR TITLE
Fix sort by similarity for datasets with a color scheme

### DIFF
--- a/fiftyone/server/routes/sort.py
+++ b/fiftyone/server/routes/sort.py
@@ -51,14 +51,7 @@ class Sort(HTTPEndpoint):
 
         await fose.dispatch_event(subscription, fose.StateUpdate(state))
 
-        dataset = stringify(
-            asdict(
-                await serialize_dataset(
-                    dataset_name=dataset_name,
-                    serialized_view=stages,
-                )
-            )
-        )
-
-        dataset["stages"] = None
-        return {"dataset": dataset}
+        # empty response
+        #
+        # /sort is only used to populate a dist_field, if provided
+        return {}


### PR DESCRIPTION
The `/sort` route is currently used only to ensure a `dist_field` is correctly populated if the parameter is provided. Before routing updates, this meant a new dataset scheme was needed in the response. Omitting the response prevents serialization errors when a dataset has a `color_scheme`