### PR TITLE
Exposing OpenCLIP embeddings

### DIFF
--- a/fiftyone/zoo/models/manifest-torch.json
+++ b/fiftyone/zoo/models/manifest-torch.json
@@ -1869,10 +1869,6 @@
             "description": "OPEN CLIP text/image encoder from `Learning Transferable Visual Models From Natural Language Supervision <https://arxiv.org/abs/2103.00020>`_ trained on 400M text-image pairs",
             "source": "https://github.com/mlfoundations/open_clip",
             "size_bytes": 353976522,
-            "manager": {
-                "type": "fiftyone.core.models.ModelManager",
-                "config": {}
-            },
             "default_deployment_config_dict": {
                 "type": "fiftyone.utils.open_clip.TorchOpenClipModel",
                 "config": {


### PR DESCRIPTION
## What changes are proposed in this pull request?

Exposing prompt embedding capabilities for OpenCLIP model recently added to zoo

- Set `can_embed_prompts` to True
- Added an `embed_prompts()` method

Test the embedding directly:

```py
import fiftyone as fo
import fiftyone.zoo as foz

model = foz.load_zoo_model("open-clip-torch")
embeddings = model.embed_prompts(["dog", "cat"])
```

Now you can also do natural language image searches with OpenCLIP:

```py
import fiftyone as fo
import fiftyone.brain as fob
import fiftyone.zoo as foz

dataset = foz.load_zoo_dataset("quickstart")

fob.compute_similarity(dataset, model="open-clip-torch", brain_key="oc_sim")
dataset.sort_by_similarity("cat")
```

## Additional Notes

- We may want to go through the docs and wherever CLIP is used, offer this as an alternative
- Should add this to the model zoo listing
- At present, this only allows for using the DEFAULT OpenCLIP weights/architecture, not EVA-CLIP, MetaCLIP etc, because the natural language image search only works when you pass the name of the model into `compute_similarity`, not the model object itself!


### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [x] Other
