### PR TITLE
show primitive in embedded document in ListField

### DIFF
--- a/app/packages/core/src/components/Sidebar/Entries/PathValueEntry.tsx
+++ b/app/packages/core/src/components/Sidebar/Entries/PathValueEntry.tsx
@@ -3,7 +3,8 @@ import * as fos from "@fiftyone/state";
 import {
   DATE_FIELD,
   DATE_TIME_FIELD,
-  DYNAMIC_EMBEDDED_DOCUMENT_PATH,
+  DYNAMIC_EMBEDDED_DOCUMENT_FIELD,
+  EMBEDDED_DOCUMENT_FIELD,
   formatDate,
   formatDateTime,
   FRAME_SUPPORT_FIELD,
@@ -386,6 +387,20 @@ const Loadable = ({ path }: { path: string }) => {
   );
 };
 
+const isOfDocumentFieldList = selectorFamily({
+  key: "isOfDocumentField",
+  get:
+    (path: string) =>
+    ({ get }) => {
+      const field = get(fos.field(path.split(".")[0]));
+
+      return [
+        DYNAMIC_EMBEDDED_DOCUMENT_FIELD,
+        EMBEDDED_DOCUMENT_FIELD,
+      ].includes(field?.subfield || "");
+    },
+});
+
 const useData = <T,>(path: string): T => {
   const keys = path.split(".");
   const loadable = useRecoilValueLoadable(fos.activeModalSidebarSample);
@@ -405,7 +420,7 @@ const useData = <T,>(path: string): T => {
   let data = loadable.contents;
   let field = useRecoilValue(fos.field(keys[0]));
 
-  if (field?.embeddedDocType === DYNAMIC_EMBEDDED_DOCUMENT_PATH) {
+  if (useRecoilValue(isOfDocumentFieldList(path))) {
     data = data?.[field?.dbField || keys[0]]?.map((d) => d[keys[1]]);
   } else {
     for (let index = 0; index < keys.length; index++) {

--- a/app/packages/core/src/components/Sidebar/Entries/PathValueEntry.tsx
+++ b/app/packages/core/src/components/Sidebar/Entries/PathValueEntry.tsx
@@ -4,6 +4,7 @@ import {
   DATE_FIELD,
   DATE_TIME_FIELD,
   DYNAMIC_EMBEDDED_DOCUMENT_FIELD,
+  DYNAMIC_EMBEDDED_DOCUMENT_PATH,
   formatDate,
   formatDateTime,
   FRAME_SUPPORT_FIELD,
@@ -382,7 +383,11 @@ const Loadable = ({ path }: { path: string }) => {
   );
 };
 
-const useData = <T extends unknown>(path: string): T => {
+const EMBEDDED_DOCUMENT_TYPES = [
+  DYNAMIC_EMBEDDED_DOCUMENT_FIELD,
+  DYNAMIC_EMBEDDED_DOCUMENT_PATH,
+];
+const useData = <T,>(path: string): T => {
   const keys = path.split(".");
   const loadable = useRecoilValueLoadable(fos.activeModalSidebarSample);
 
@@ -400,8 +405,9 @@ const useData = <T extends unknown>(path: string): T => {
 
   let data = loadable.contents;
   let field = useRecoilValue(fos.field(keys[0]));
+  const embeddedDocType = field?.embeddedDocType;
 
-  if (field?.embeddedDocType === DYNAMIC_EMBEDDED_DOCUMENT_FIELD) {
+  if (embeddedDocType && EMBEDDED_DOCUMENT_TYPES.includes(embeddedDocType)) {
     data = data?.[field?.dbField || keys[0]]?.map((d) => d[keys[1]]).join(", ");
   } else {
     for (let index = 0; index < keys.length; index++) {
@@ -414,7 +420,7 @@ const useData = <T extends unknown>(path: string): T => {
       data = data[field?.dbField || key];
 
       if (keys[index + 1]) {
-        field = field?.fields[keys[index + 1]];
+        field = field?.fields?.[keys[index + 1]] || null;
       }
     }
   }

--- a/app/packages/core/src/components/Sidebar/Entries/PathValueEntry.tsx
+++ b/app/packages/core/src/components/Sidebar/Entries/PathValueEntry.tsx
@@ -466,8 +466,6 @@ const PathValueEntry = ({
   const slices = Boolean(pinned3DSample) && (activePcdSlices?.length || 1) > 1;
 
   const isScalar = useRecoilValue(isScalarValue(path));
-  console.log(path, isScalar);
-
   return isScalar ? (
     <ScalarValueEntry
       entryKey={entryKey}

--- a/app/packages/state/src/recoil/schema.ts
+++ b/app/packages/state/src/recoil/schema.ts
@@ -7,6 +7,7 @@ import {
 import {
   DETECTION,
   DETECTIONS,
+  DYNAMIC_EMBEDDED_DOCUMENT_FIELD,
   EMBEDDED_DOCUMENT_FIELD,
   Field,
   LABELS,
@@ -693,7 +694,9 @@ export const isInListField = selectorFamily({
 
       return (
         parent?.ftype === LIST_FIELD &&
-        parent?.subfield === EMBEDDED_DOCUMENT_FIELD
+        [EMBEDDED_DOCUMENT_FIELD, DYNAMIC_EMBEDDED_DOCUMENT_FIELD].includes(
+          parent.subfield
+        )
       );
     },
 });


### PR DESCRIPTION
## What changes are proposed in this pull request?

Fixes an issue where primitive values in DynamicEmbeddedDocument within ListField is displayed as `None` sample modal

## How is this patch tested? If it is not, please explain why.

Verified values are displayed as CSV in the sample modal for the embedded fields:

![image](https://github.com/voxel51/fiftyone/assets/25350704/6a4d1be2-9c90-4f74-b20d-a9e73b0e7d8b)
![image](https://github.com/voxel51/fiftyone/assets/25350704/962bc046-acb4-4df0-bc29-86994ce4be02)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

Primitive values in DynamicEmbeddedDocument within ListField will be displayed as comma separated values (previously, displayed as `None`) in the sample modal

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
