### PR TITLE
fix keyboard navigation for selectors

### DIFF
--- a/app/packages/components/src/components/Results/Results.tsx
+++ b/app/packages/components/src/components/Results/Results.tsx
@@ -1,5 +1,5 @@
 import classNames from "classnames";
-import React, { useLayoutEffect, useRef } from "react";
+import React, { useEffect, useLayoutEffect, useRef } from "react";
 import style from "./Results.module.css";
 
 export interface ResultProps<T> {
@@ -39,6 +39,14 @@ export function Result<T>({
   component,
 }: ResultProps<T>) {
   const Component = component;
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const elem = ref.current;
+    if (active && elem) {
+      elem.scrollIntoView({ block: "center" });
+    }
+  }, [active]);
 
   const classes = active ? [style.active, style.result] : [style.result];
 
@@ -47,6 +55,7 @@ export function Result<T>({
       data-cy={`selector-result-${result}`}
       onClick={onClick}
       className={classNames(...classes)}
+      ref={ref}
     >
       <Component value={result} />
     </div>

--- a/app/packages/components/src/components/Results/Results.tsx
+++ b/app/packages/components/src/components/Results/Results.tsx
@@ -114,7 +114,7 @@ function Results<T>({
       </div>
       <div className={style.footer}>
         {!results && !!noResults && <>{noResults}</>}
-        {total && results?.length && (
+        {!!total && !!results?.length && (
           <>
             {results.length} of {total.toLocaleString()}
           </>

--- a/app/packages/components/src/components/Selector/Selector.tsx
+++ b/app/packages/components/src/components/Selector/Selector.tsx
@@ -60,9 +60,9 @@ function Selector<T>(props: SelectorProps<T>) {
   const local = useRef(value || "");
 
   const onSelectWrapper = useMemo(() => {
-    return async (search: string) => {
+    return async (search: string, useSearch?: boolean) => {
       const value =
-        active !== undefined
+        active !== undefined && !useSearch
           ? valuesRef.current[active]
           : valuesRef.current.find((v) => toKey(v) === search);
 
@@ -87,9 +87,12 @@ function Selector<T>(props: SelectorProps<T>) {
       document.activeElement === ref.current && ref.current?.blur();
     } else {
       setSearch("");
-      setActive(undefined);
+      const defaultActive = valuesRef.current.findIndex(
+        (item) => value === item
+      );
+      setActive(defaultActive || 0);
     }
-  }, [editing]);
+  }, [editing, value]);
 
   const onResults = useCallback((results: T[]) => {
     valuesRef.current = results;
@@ -201,7 +204,7 @@ function Selector<T>(props: SelectorProps<T>) {
                     noResults={noResults}
                     search={search}
                     useSearch={useSearch}
-                    onSelect={(value) => onSelectWrapper(toKey(value))}
+                    onSelect={(value) => onSelectWrapper(toKey(value), true)}
                     component={component}
                     onResults={onResults}
                     toKey={toKey}

--- a/app/packages/components/src/components/Selector/Selector.tsx
+++ b/app/packages/components/src/components/Selector/Selector.tsx
@@ -56,7 +56,10 @@ function Selector<T>(props: SelectorProps<T>) {
   const [editing, setEditing] = useState(false);
   const [search, setSearch] = useState("");
   const valuesRef = useRef<T[]>([]);
-  const [active, setActive] = useState<number>();
+
+  // active is an index in the values array, or "undefined" which is the unset
+  // pivot between 0 and (length - 1)
+  const [active, setActive] = useState<number | undefined>(undefined);
   const local = useRef(value || "");
 
   const onSelectWrapper = useMemo(() => {
@@ -146,6 +149,7 @@ function Selector<T>(props: SelectorProps<T>) {
         }}
         onChange={(e) => {
           setSearch(e.target.value);
+          setActive(undefined);
         }}
         onKeyDown={(e) => {
           if (e.key === "Enter") {
@@ -157,20 +161,10 @@ function Selector<T>(props: SelectorProps<T>) {
               editing && setEditing(false);
               break;
             case "ArrowDown":
-              setActive(
-                active === valuesRef.current.length - 1
-                  ? undefined
-                  : Math.min((active ?? -1) + 1, valuesRef.current.length - 1)
-              );
+              setActive(down(active, valuesRef.current.length));
               break;
             case "ArrowUp":
-              setActive(
-                active === undefined
-                  ? valuesRef.current.length - 1
-                  : active === 0
-                  ? undefined
-                  : Math.max(active - 1, 0)
-              );
+              setActive(up(active, valuesRef.current.length));
               break;
           }
         }}
@@ -224,5 +218,25 @@ function Selector<T>(props: SelectorProps<T>) {
     </div>
   );
 }
+
+const down = (active: number | undefined, length: number) => {
+  if (active === length - 1) {
+    return undefined; // we are at the end, go to pivot
+  }
+
+  return Math.min((active ?? -1) + 1, length - 1);
+};
+
+const up = (active: number | undefined, length: number) => {
+  if (active === undefined) {
+    return length - 1; // go to end
+  }
+
+  if (active === 0) {
+    return undefined; // return to pivot
+  }
+
+  return Math.max(active - 1, 0);
+};
 
 export default Selector;

--- a/app/packages/components/src/components/Selector/Selector.tsx
+++ b/app/packages/components/src/components/Selector/Selector.tsx
@@ -92,7 +92,7 @@ function Selector<T>(props: SelectorProps<T>) {
     } else {
       setSearch("");
     }
-  }, [editing, value]);
+  }, [editing]);
 
   const onResults = useCallback((results: T[]) => {
     valuesRef.current = results;

--- a/app/packages/components/src/components/Selector/Selector.tsx
+++ b/app/packages/components/src/components/Selector/Selector.tsx
@@ -85,12 +85,9 @@ function Selector<T>(props: SelectorProps<T>) {
   useLayoutEffect(() => {
     if (!editing) {
       document.activeElement === ref.current && ref.current?.blur();
+      setActive(undefined);
     } else {
       setSearch("");
-      const defaultActive = valuesRef.current.findIndex(
-        (item) => value === item
-      );
-      setActive(defaultActive || 0);
     }
   }, [editing, value]);
 
@@ -160,11 +157,20 @@ function Selector<T>(props: SelectorProps<T>) {
               editing && setEditing(false);
               break;
             case "ArrowDown":
-              active !== undefined &&
-                setActive(Math.min(active + 1, valuesRef.current.length - 1));
+              setActive(
+                active === valuesRef.current.length - 1
+                  ? undefined
+                  : Math.min((active ?? -1) + 1, valuesRef.current.length - 1)
+              );
               break;
             case "ArrowUp":
-              active !== undefined && setActive(Math.max(active - 1, 0));
+              setActive(
+                active === undefined
+                  ? valuesRef.current.length - 1
+                  : active === 0
+                  ? undefined
+                  : Math.max(active - 1, 0)
+              );
               break;
           }
         }}


### PR DESCRIPTION
## What changes are proposed in this pull request?

- fix keyboard navigation for selectors
- add tweak to auto-scroll to active selector option when navigating to hidden options

## How is this patch tested? If it is not, please explain why.

Using the dataset selector in the app with both keyboard and mouse navigation

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

fix keyboard navigation for selectors in the app

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
