### PR TITLE
Use mixed mode in select_group_slices

### DIFF
--- a/fiftyone/server/mutation.py
+++ b/fiftyone/server/mutation.py
@@ -217,6 +217,17 @@ class Mutation(SetColorScheme):
                 else None,
             )
 
+            is_to_patches_in_stages = False
+
+            if form.add_stages:
+                is_to_patches_in_stages = any(
+                    stage.get("_cls") == "fiftyone.core.stages.ToPatches"
+                    for stage in form.add_stages
+                )
+
+            if result_view.media_type == "mixed" and is_to_patches_in_stages:
+                result_view._set_media_type(ds.group_media_types[form.slice])
+
             result_view = _build_result_view(result_view, form)
 
         # Set view state

--- a/fiftyone/server/mutation.py
+++ b/fiftyone/server/mutation.py
@@ -217,6 +217,9 @@ class Mutation(SetColorScheme):
                 else None,
             )
 
+            # special case for group datasets with ToPatches
+            # `result_view` will output a `mixed` media type dataset
+            # but `ToPatches` expects an `image` media type dataset
             is_to_patches_in_stages = False
 
             if form.add_stages:

--- a/fiftyone/server/mutation.py
+++ b/fiftyone/server/mutation.py
@@ -10,6 +10,7 @@ import strawberry as gql
 import typing as t
 
 import eta.core.serial as etas
+import eta.core.utils as etau
 
 import fiftyone.constants as foc
 import fiftyone.core.dataset as fod
@@ -33,6 +34,15 @@ from fiftyone.server.query import (
 )
 from fiftyone.server.scalars import BSON, BSONArray, JSON, JSONArray
 from fiftyone.server.view import get_view
+
+
+_CONVERSION_STAGES = {
+    fos.ToClips,
+    fos.ToEvaluationPatches,
+    fos.ToFrames,
+    fos.ToPatches,
+    fos.ToTrajectories,
+}
 
 
 @gql.input
@@ -217,18 +227,17 @@ class Mutation(SetColorScheme):
                 else None,
             )
 
-            # special case for group datasets with ToPatches
-            # `result_view` will output a `mixed` media type dataset
-            # but `ToPatches` expects an `image` media type dataset
-            is_to_patches_in_stages = False
-
+            # special case for group datasets where conversion stage is added
+            # `result_view` will output a `mixed` media type dataset but a real
+            # type, e.g. "image", is needed
+            is_in_conversion_stage = False
             if form.add_stages:
-                is_to_patches_in_stages = any(
-                    stage.get("_cls") == "fiftyone.core.stages.ToPatches"
+                is_in_conversion_stage = any(
+                    etau.get_class(stage.get("_cls")) in _CONVERSION_STAGES
                     for stage in form.add_stages
                 )
 
-            if result_view.media_type == "mixed" and is_to_patches_in_stages:
+            if result_view.media_type == "mixed" and is_in_conversion_stage:
                 result_view._set_media_type(ds.group_media_types[form.slice])
 
             result_view = _build_result_view(result_view, form)

--- a/fiftyone/server/view.py
+++ b/fiftyone/server/view.py
@@ -93,8 +93,6 @@ def get_view(
         pagination_data (False): whether process samples as pagination data
             - excludes all :class:`fiftyone.core.fields.DictField` values
             - filters label fields
-        only_matches (True): whether to filter unmatches samples when filtering
-            labels
         extended_stages (None): extended view stages
         sample_filter (None): an optional
             :class:`fiftyone.server.filters.SampleFilter`
@@ -128,14 +126,9 @@ def get_view(
                 )
 
             if sample_filter.group.slices:
-                if view._is_patches:
-                    use_mixed = len(sample_filter.group.slices) > 1
-                else:
-                    use_mixed = True
-
                 view = view.select_group_slices(
                     sample_filter.group.slices,
-                    _force_mixed=use_mixed,
+                    _force_mixed=True,
                 )
 
         elif sample_filter.id:

--- a/fiftyone/server/view.py
+++ b/fiftyone/server/view.py
@@ -126,10 +126,16 @@ def get_view(
                 view = fov.make_optimized_select_view(
                     view, sample_filter.group.id, groups=True
                 )
+
             if sample_filter.group.slices:
+                if view._is_patches:
+                    use_mixed = len(sample_filter.group.slices) > 1
+                else:
+                    use_mixed = True
+
                 view = view.select_group_slices(
                     sample_filter.group.slices,
-                    _force_mixed=len(sample_filter.group.slices) > 1,
+                    _force_mixed=use_mixed,
                 )
 
         elif sample_filter.id:


### PR DESCRIPTION
## What changes are proposed in this pull request?

When a group dataset is created that has a video and image slice and frame fields (like frame detections) are added to the video slice, then images cause an error in the App when you try to open them in the sample modal. This PR fixes this bug.

This bug is a potential regression introduced by #3666.

## How is this patch tested? If it is not, please explain why.

Smoke tested with the following test code.

```
import fiftyone as fo

dataset = fo.Dataset('group-frame-fields-bug, persistent=True)

video_sample = fo.Sample(filepath='/Users/abc/video.mp4', group=fo.Group().element('video'))
dataset.add_sample(video_sample)
dataset.add_frame_field('boxes', fo.EmbeddedDocumentField, embedded_doc_type=fo.Detections)

thumbnail_sample = fo.Sample(
    filepath='/Users/abc/image.jpg',
    group=fo.Group().element('thumbnail')
)
dataset.add_sample(thumbnail_sample)
```

`to_patches` was also verified to be working. This was tested against `quickstart` dataset's `predictions.detections` field.

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
