### PR TITLE
support output-only views in input

### DIFF
--- a/app/packages/core/src/plugins/SchemaIO/components/KeyValueView.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/KeyValueView.tsx
@@ -10,9 +10,17 @@ import {
 import React from "react";
 import { HeaderView } from ".";
 import { getComponentProps } from "../utils";
+import { isPlainObject } from "lodash";
 
 export default function KeyValueView(props) {
   const { path, schema, data, nested } = props;
+  const defaultValue = schema?.default;
+
+  const keyValue = isPlainObject(data)
+    ? data
+    : isPlainObject(defaultValue)
+    ? defaultValue
+    : {};
 
   return (
     <Box {...getComponentProps(props, "container")}>
@@ -23,7 +31,7 @@ export default function KeyValueView(props) {
       >
         <Table {...getComponentProps(props, "table")}>
           <TableBody {...getComponentProps(props, "tableBody")}>
-            {Object.entries(data).map(([key, value]) => (
+            {Object.entries(keyValue).map(([key, value]) => (
               <TableRow
                 key={`${path}-${key}`}
                 sx={{ "&:last-child td, &:last-child th": { border: 0 } }}

--- a/app/packages/core/src/plugins/SchemaIO/components/LabelValueView.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/LabelValueView.tsx
@@ -4,7 +4,7 @@ import { getComponentProps } from "../utils";
 
 export default function LabelValueView(props) {
   const { data, schema } = props;
-  const { view = {} } = schema;
+  const { view = {}, default: defaultValue } = schema;
   const { label } = view;
   return (
     <Box {...getComponentProps(props, "container")}>
@@ -17,7 +17,7 @@ export default function LabelValueView(props) {
           {label || schema?.id}:
         </Typography>
         <Typography {...getComponentProps(props, "value")}>
-          {data?.toString() || "No value provided"}
+          {(data || defaultValue)?.toString() || "No value provided"}
         </Typography>
       </Stack>
     </Box>

--- a/app/packages/core/src/plugins/SchemaIO/components/TableView.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/TableView.tsx
@@ -15,10 +15,16 @@ import { getComponentProps } from "../utils";
 
 export default function TableView(props) {
   const { schema, data } = props;
-  const { view = {} } = schema;
+  const { view = {}, default: defaultValue } = schema;
   const { columns } = view;
 
-  const dataMissing = !Array.isArray(data) || data.length === 0;
+  const table = Array.isArray(data)
+    ? data
+    : Array.isArray(defaultValue)
+    ? defaultValue
+    : [];
+
+  const dataMissing = table.length === 0;
 
   return (
     <Box {...getComponentProps(props, "container")}>
@@ -44,7 +50,7 @@ export default function TableView(props) {
               </TableRow>
             </TableHead>
             <TableBody {...getComponentProps(props, "tableBody")}>
-              {data.map((item) => (
+              {table.map((item) => (
                 <TableRow
                   key={item.id}
                   sx={{ "&:last-child td, &:last-child th": { border: 0 } }}

--- a/app/packages/core/src/plugins/SchemaIO/components/TagsView.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/TagsView.tsx
@@ -4,12 +4,18 @@ import HeaderView from "./HeaderView";
 import { getComponentProps } from "../utils";
 
 export default function TagsView(props) {
-  const { data, path } = props;
+  const { data, path, schema } = props;
+  const defaultValue = schema.default;
+  const tags = Array.isArray(data)
+    ? data
+    : Array.isArray(defaultValue)
+    ? defaultValue
+    : [];
 
   return (
     <Box {...getComponentProps(props, "container")}>
       <HeaderView {...props} divider nested />
-      {data.map((item, i) => (
+      {tags.map((item, i) => (
         <Chip
           key={`${path}-${i}`}
           label={item.toString()}


### PR DESCRIPTION
## What changes are proposed in this pull request?

Fix some operator's read-only-views crashing when rendered in operator's input

## How is this patch tested? If it is not, please explain why.

Using all the affected views in a test operator to ensure they render without an issue

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

Fix some operator's read-only-views crashing when rendered in operator's inputs

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
