### PR TITLE
fix url construction

### DIFF
--- a/app/packages/utilities/src/fetch.ts
+++ b/app/packages/utilities/src/fetch.ts
@@ -89,14 +89,15 @@ export const setFetchFunction = (
     let url: string;
     const controller = new AbortController();
 
-    if (fetchPathPrefix) {
-      path = `${fetchPathPrefix}${path}`.replaceAll("//", "/");
-    }
-
     try {
+      // if a valid URL is provided, make no adjustments
       new URL(path);
       url = path;
     } catch {
+      if (fetchPathPrefix) {
+        path = `${fetchPathPrefix}${path}`.replaceAll("//", "/");
+      }
+
       url = `${origin}${
         !origin.endsWith("/") && !path.startsWith("/") ? "/" : ""
       }${path}`;


### PR DESCRIPTION
This PR fixes the edge case in fetch URL construction where fetch `origin` is already encapsulated in `path`, in which case `origin` can be omitted.