### PR TITLE
Apply YOLO Models Directly to FiftyOne Datasets

### DIFF
--- a/docs/source/integrations/ultralytics.rst
+++ b/docs/source/integrations/ultralytics.rst
@@ -52,10 +52,8 @@ the following sample dataset:
 Object detection
 ----------------
 
-You can use the builtin
-:func:`to_detections() <fiftyone.utils.ultralytics.to_detections>` utility to
-convert Ultralytics bounding boxes to
-:ref:`FiftyOne format <object-detection>`:
+You can directly pass Ultralytics YOLO detection models to
+:meth:`apply_model() <fiftyone.core.collections.SampleCollection.apply_model>`:
 
 .. code-block:: python
     :linenos:
@@ -72,12 +70,22 @@ convert Ultralytics bounding boxes to
     # model = YOLO("yolov5l.pt")
     # model = YOLO("yolov5x.pt")
 
+    dataset.apply_model(model, label_field="boxes")
+
+    session = fo.launch_app(dataset)
+
+Alternatively, you can use the
+:func:`to_detections() <fiftyone.utils.ultralytics.to_detections>` utility to
+manually convert Ultralytics predictions to
+:ref:`FiftyOne format <object-detection>`:
+
+.. code-block:: python
+    :linenos:
+
     for sample in dataset.iter_samples(progress=True):
         result = model(sample.filepath)[0]
         sample["boxes"] = fou.to_detections(result)
         sample.save()
-
-    session = fo.launch_app(dataset)
 
 .. image:: /images/integrations/ultralytics_boxes.jpg
    :alt: ultralytics-boxes
@@ -88,15 +96,8 @@ convert Ultralytics bounding boxes to
 Instance segmentation
 ---------------------
 
-You can use the builtin
-:func:`to_instances() <fiftyone.utils.ultralytics.to_instances>` and
-:func:`to_polylines() <fiftyone.utils.ultralytics.to_polylines>` utilities to
-convert Ultralytics instance segmentations to
-:ref:`FiftyOne format <instance-segmentation>`:
-
-You can use the builtin
-:func:`to_detections() <fiftyone.utils.ultralytics.to_detections>` utility to
-convert YOLO boxes to FiftyOne format:
+You can directly pass Ultralytics YOLO segmentation models to
+:meth:`apply_model() <fiftyone.core.collections.SampleCollection.apply_model>`:
 
 .. code-block:: python
     :linenos:
@@ -106,14 +107,25 @@ convert YOLO boxes to FiftyOne format:
     # model = YOLO("yolov8l-seg.pt")
     # model = YOLO("yolov8x-seg.pt")
 
+    dataset.apply_model(model, label_field="instances")
+
+    session = fo.launch_app(dataset)
+
+Alternatively, you can use the
+:func:`to_instances() <fiftyone.utils.ultralytics.to_instances>` and
+:func:`to_polylines() <fiftyone.utils.ultralytics.to_polylines>` utilities to
+manually convert Ultralytics predictions into the desired
+:ref:`FiftyOne format <instance-segmentation>`:
+
+.. code-block:: python
+    :linenos:
+
     for sample in dataset.iter_samples(progress=True):
         result = model(sample.filepath)[0]
         sample["detections"] = fou.to_detections(result)
         sample["instances"] = fou.to_instances(result)
         sample["polylines"] = fou.to_polylines(result)
         sample.save()
-
-    session = fo.launch_app(dataset)
 
 .. image:: /images/integrations/ultralytics_instances.jpg
    :alt: ultralytics-instances
@@ -124,9 +136,8 @@ convert YOLO boxes to FiftyOne format:
 Keypoints
 ---------
 
-You can use the builtin
-:func:`to_keypoints() <fiftyone.utils.ultralytics.to_keypoints>` utility to
-convert Ultralytics keypoints to :ref:`FiftyOne format <keypoints>`:
+You can directly pass Ultralytics YOLO pose models to
+:meth:`apply_model() <fiftyone.core.collections.SampleCollection.apply_model>`:
 
 .. code-block:: python
     :linenos:
@@ -136,10 +147,7 @@ convert Ultralytics keypoints to :ref:`FiftyOne format <keypoints>`:
     # model = YOLO("yolov8l-pose.pt")
     # model = YOLO("yolov8x-pose.pt")
 
-    for sample in dataset.iter_samples(progress=True):
-        result = model(sample.filepath)[0]
-        sample["keypoints"] = fou.to_keypoints(result)
-        sample.save()
+    dataset.apply_model(model, label_field="keypoints")
 
     # Store the COCO-pose keypoint skeleton so the App can render it
     dataset.default_skeleton = fo.KeypointSkeleton(
@@ -158,6 +166,18 @@ convert Ultralytics keypoints to :ref:`FiftyOne format <keypoints>`:
 
     session = fo.launch_app(dataset)
 
+Alternatively, you can use the
+:func:`to_keypoints() <fiftyone.utils.ultralytics.to_keypoints>` utility to
+manually convert Ultralytics predictions to :ref:`FiftyOne format <keypoints>`:
+
+.. code-block:: python
+    :linenos:
+
+    for sample in dataset.iter_samples(progress=True):
+        result = model(sample.filepath)[0]
+        sample["keypoints"] = fou.to_keypoints(result)
+        sample.save()
+
 .. image:: /images/integrations/ultralytics_keypoints.jpg
    :alt: ultralytics-keypoints
    :align: center
@@ -167,20 +187,29 @@ convert Ultralytics keypoints to :ref:`FiftyOne format <keypoints>`:
 Batch inference
 ---------------
 
-Any of the above loops can be executed using batch inference using the pattern
-below:
+When using
+:meth:`apply_model() <fiftyone.core.collections.SampleCollection.apply_model>`,
+you can request batch inference by passing the optional `batch_size` parameter:
+
+.. code-block:: python
+    :linenos:
+
+    dataset.apply_model(model, label_field="predictions", batch_size=16)
+
+The manual inference loops can be also executed using batch inference via the
+pattern below:
 
 .. code-block:: python
     :linenos:
 
     from fiftyone.core.utils import iter_batches
 
-    # The inference batch size
-    batch_size = 4
+    filepaths = dataset.values("filepath")
+    batch_size = 16
 
     predictions = []
-    for filepaths in iter_batches(dataset.values("filepath"), batch_size):
-        results = model(filepaths)
+    for paths in iter_batches(filepaths, batch_size):
+        results = model(paths)
         predictions.extend(fou.to_detections(results))
 
     dataset.set_values("predictions", predictions)
@@ -188,7 +217,7 @@ below:
 .. note::
 
     See :ref:`this section <batch-updates>` for more information about
-    performing batch updates to your FiftyOne dataset.
+    performing batch updates to your FiftyOne datasets.
 
 .. _ultralytics-training:
 

--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -2786,8 +2786,8 @@ class SampleCollection(object):
             video collection
 
         Args:
-            model: a :class:`fiftyone.core.models.Model` or
-                :class:`flash:flash.core.model.Task`
+            model: a :class:`Model` or :class:`flash:flash.core.model.Task` or
+                `ultralytics.YOLO` model
             label_field ("predictions"): the name of the field in which to
                 store the model predictions. When performing inference on video
                 frames, the "frames." prefix is optional

--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -2842,8 +2842,7 @@ class SampleCollection(object):
         **kwargs,
     ):
         """Computes embeddings for the samples in the collection using the
-        given :class:`FiftyOne model <fiftyone.core.models.Model>` or
-        :class:`Lightning Flash model <flash:flash.core.model.Task>`.
+        given model.
 
         This method supports all the following cases:
 
@@ -2924,7 +2923,7 @@ class SampleCollection(object):
     ):
         """Computes embeddings for the image patches defined by
         ``patches_field`` of the samples in the collection using the given
-        :class:`fiftyone.core.models.Model`.
+        model.
 
         This method supports all the following cases:
 

--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -2770,9 +2770,7 @@ class SampleCollection(object):
         rel_dir=None,
         **kwargs,
     ):
-        """Applies the :class:`FiftyOne model <fiftyone.core.models.Model>` or
-        :class:`Lightning Flash model <flash:flash.core.model.Task>` to the
-        samples in the collection.
+        """Applies the model to the samples in the collection.
 
         This method supports all of the following cases:
 
@@ -2782,12 +2780,13 @@ class SampleCollection(object):
             of a video collection
         -   Applying a video :class:`fiftyone.core.models.Model` to a video
             collection
+        -   Applying an ``ultralytics.YOLO`` model to an image collection
         -   Applying a :class:`flash:flash.core.model.Task` to an image or
             video collection
 
         Args:
-            model: a :class:`Model` or :class:`flash:flash.core.model.Task` or
-                `ultralytics.YOLO` model
+            model: a :class:`fiftyone.core.models.Model`, ``ultralytics.YOLO``
+                model, or :class:`flash:flash.core.model.Task`
             label_field ("predictions"): the name of the field in which to
                 store the model predictions. When performing inference on video
                 frames, the "frames." prefix is optional

--- a/fiftyone/core/models.py
+++ b/fiftyone/core/models.py
@@ -122,19 +122,6 @@ def apply_model(
     try:
         if isinstance(model, ultralytics.YOLO):
             model = fouu._convert_yolo_model(model)
-            return apply_model(
-                samples,
-                model,
-                label_field=label_field,
-                confidence_thresh=confidence_thresh,
-                store_logits=store_logits,
-                batch_size=batch_size,
-                num_workers=num_workers,
-                skip_failures=skip_failures,
-                output_dir=output_dir,
-                rel_dir=rel_dir,
-                **kwargs,
-            )
     except ImportError:
         pass
 

--- a/fiftyone/core/models.py
+++ b/fiftyone/core/models.py
@@ -118,7 +118,7 @@ def apply_model(
         )
 
     if _is_ultralytics_model(model):
-        model = fouu.convert_model(model)
+        model = fouu.convert_ultralytics_model(model)
 
     if not isinstance(model, Model):
         raise ValueError("Unsupported model type: %s" % type(model))
@@ -788,7 +788,7 @@ def compute_embeddings(
         )
 
     if _is_ultralytics_model(model):
-        model = fouu.convert_model(model)
+        model = fouu.convert_ultralytics_model(model)
 
     if not isinstance(model, Model):
         raise ValueError("Unsupported model type: %s" % type(model))
@@ -1272,12 +1272,10 @@ def compute_patch_embeddings(
             missing or ``None`` values to indicate uncomputable embeddings
     """
     if _is_ultralytics_model(model):
-        model = fouu.convert_model(model)
+        model = fouu.convert_ultralytics_model(model)
 
     if not isinstance(model, Model):
-        raise ValueError(
-            "Model must be a %s instance; found %s" % (Model, type(model))
-        )
+        raise ValueError("Unsupported model type: %s" % type(model))
 
     if not model.has_embeddings:
         raise ValueError(

--- a/fiftyone/core/models.py
+++ b/fiftyone/core/models.py
@@ -59,22 +59,21 @@ def apply_model(
     rel_dir=None,
     **kwargs,
 ):
-    """Applies the :class:`FiftyOne model <Model>` or
-    :class:`Lightning Flash model <flash:flash.core.model.Task>` to the samples
-    in the collection.
+    """Applies the model to the samples in the collection.
 
     This method supports all of the following cases:
 
     -   Applying an image :class:`Model` to an image collection
     -   Applying an image :class:`Model` to the frames of a video collection
     -   Applying a video :class:`Model` to a video collection
+    -   Applying an ``ultralytics.YOLO`` model to an image collection
     -   Applying a :class:`flash:flash.core.model.Task` to an image or video
         collection
 
     Args:
         samples: a :class:`fiftyone.core.collections.SampleCollection`
-        model: a :class:`Model` or :class:`flash:flash.core.model.Task` or
-            `ultralytics.YOLO` model
+        model: a :class:`Model`, ``ultralytics.YOLO`` model, or
+            :class:`flash:flash.core.model.Task`
         label_field ("predictions"): the name of the field in which to store
             the model predictions. When performing inference on video frames,
             the "frames." prefix is optional

--- a/fiftyone/core/models.py
+++ b/fiftyone/core/models.py
@@ -280,13 +280,7 @@ def _is_flash_model(model):
 
 
 def _is_ultralytics_model(model):
-    try:
-        # pylint: disable=import-error
-        import ultralytics
-
-        return isinstance(model, ultralytics.YOLO)
-    except:
-        return False
+    return type(model).__module__.startswith("ultralytics.")
 
 
 def _apply_image_model_single(

--- a/fiftyone/core/models.py
+++ b/fiftyone/core/models.py
@@ -34,7 +34,6 @@ foup = fou.lazy_import("fiftyone.utils.patches")
 fout = fou.lazy_import("fiftyone.utils.torch")
 fouu = fou.lazy_import("fiftyone.utils.ultralytics")
 
-ultralytics = fou.lazy_import("ultralytics")
 
 logger = logging.getLogger(__name__)
 
@@ -120,8 +119,10 @@ def apply_model(
         )
 
     try:
+        import ultralytics
+
         if isinstance(model, ultralytics.YOLO):
-            model = fouu._convert_yolo_model(model)
+            model = fouu.convert_model(model)
     except ImportError:
         pass
 

--- a/fiftyone/core/models.py
+++ b/fiftyone/core/models.py
@@ -75,7 +75,7 @@ def apply_model(
     Args:
         samples: a :class:`fiftyone.core.collections.SampleCollection`
         model: a :class:`Model` or :class:`flash:flash.core.model.Task` or
-            `YOLO` model from `ultralytics
+            `ultralytics.YOLO` model
         label_field ("predictions"): the name of the field in which to store
             the model predictions. When performing inference on video frames,
             the "frames." prefix is optional
@@ -119,21 +119,24 @@ def apply_model(
             **kwargs,
         )
 
-    if isinstance(model, ultralytics.YOLO):
-        model = fouu._convert_yolo_model(model)
-        return apply_model(
-            samples,
-            model,
-            label_field=label_field,
-            confidence_thresh=confidence_thresh,
-            store_logits=store_logits,
-            batch_size=batch_size,
-            num_workers=num_workers,
-            skip_failures=skip_failures,
-            output_dir=output_dir,
-            rel_dir=rel_dir,
-            **kwargs,
-        )
+    try:
+        if isinstance(model, ultralytics.YOLO):
+            model = fouu._convert_yolo_model(model)
+            return apply_model(
+                samples,
+                model,
+                label_field=label_field,
+                confidence_thresh=confidence_thresh,
+                store_logits=store_logits,
+                batch_size=batch_size,
+                num_workers=num_workers,
+                skip_failures=skip_failures,
+                output_dir=output_dir,
+                rel_dir=rel_dir,
+                **kwargs,
+            )
+    except ImportError:
+        pass
 
     if not isinstance(model, Model):
         raise ValueError(

--- a/fiftyone/core/models.py
+++ b/fiftyone/core/models.py
@@ -32,7 +32,9 @@ fouf = fou.lazy_import("fiftyone.utils.flash")
 foui = fou.lazy_import("fiftyone.utils.image")
 foup = fou.lazy_import("fiftyone.utils.patches")
 fout = fou.lazy_import("fiftyone.utils.torch")
+fouu = fou.lazy_import("fiftyone.utils.ultralytics")
 
+ultralytics = fou.lazy_import("ultralytics")
 
 logger = logging.getLogger(__name__)
 
@@ -72,7 +74,8 @@ def apply_model(
 
     Args:
         samples: a :class:`fiftyone.core.collections.SampleCollection`
-        model: a :class:`Model` or :class:`flash:flash.core.model.Task`
+        model: a :class:`Model` or :class:`flash:flash.core.model.Task` or
+            `YOLO` model from `ultralytics
         label_field ("predictions"): the name of the field in which to store
             the model predictions. When performing inference on video frames,
             the "frames." prefix is optional
@@ -111,6 +114,22 @@ def apply_model(
             store_logits=store_logits,
             batch_size=batch_size,
             num_workers=num_workers,
+            output_dir=output_dir,
+            rel_dir=rel_dir,
+            **kwargs,
+        )
+
+    if isinstance(model, ultralytics.YOLO):
+        model = fouu._convert_yolo_model(model)
+        return apply_model(
+            samples,
+            model,
+            label_field=label_field,
+            confidence_thresh=confidence_thresh,
+            store_logits=store_logits,
+            batch_size=batch_size,
+            num_workers=num_workers,
+            skip_failures=skip_failures,
             output_dir=output_dir,
             rel_dir=rel_dir,
             **kwargs,

--- a/fiftyone/utils/ultralytics.py
+++ b/fiftyone/utils/ultralytics.py
@@ -24,7 +24,7 @@ def convert_model(model):
     """Converts the given Ultralytics model into a FiftyOne model.
 
     Args:
-        model: an ``ultralytics.YOLO` model
+        model: an ``ultralytics.YOLO`` model
 
     Returns:
          a :class:`fiftyone.core.models.Model`
@@ -312,7 +312,7 @@ class FiftyOneYOLOModel(Model):
         if config.model is not None:
             return config.model
 
-        return FiftyOneYOLOConfig(config.checkpoint_path)
+        return ultralytics.YOLO(config.checkpoint_path)
 
     @property
     def media_type(self):

--- a/fiftyone/utils/ultralytics.py
+++ b/fiftyone/utils/ultralytics.py
@@ -389,5 +389,8 @@ def _convert_yolo_model(model):
         return _convert_yolo_pose_model(model)
     elif isinstance(model.model, ultralytics.nn.tasks.DetectionModel):
         return _convert_yolo_detection_model(model)
-
-    return model
+    else:
+        raise ValueError(
+            "Unsupported model type. Cannot convert to a FiftyOne,"
+            ":class:`Model`."
+        )

--- a/fiftyone/utils/ultralytics.py
+++ b/fiftyone/utils/ultralytics.py
@@ -319,9 +319,7 @@ class FiftyOneYOLOModel(Model):
         return False
 
     def predict(self, args):
-        raise NotImplementedError(
-            "Subclass must implement `predict` or `predict_all`"
-        )
+        raise NotImplementedError("Subclass must implement `predict`")
 
     def predict_all(self, args):
         return self.predict(args)

--- a/fiftyone/utils/ultralytics.py
+++ b/fiftyone/utils/ultralytics.py
@@ -20,7 +20,7 @@ import fiftyone.core.utils as fou
 ultralytics = fou.lazy_import("ultralytics")
 
 
-def convert_model(model):
+def convert_ultralytics_model(model):
     """Converts the given Ultralytics model into a FiftyOne model.
 
     Args:

--- a/fiftyone/utils/ultralytics.py
+++ b/fiftyone/utils/ultralytics.py
@@ -395,6 +395,11 @@ class FiftyOneYOLOPoseModel(FiftyOneYOLOModel):
     def _format_predictions(self, predictions):
         return to_keypoints(predictions)
 
+    def predict_all(self, args):
+        images = [Image.fromarray(arg) for arg in args]
+        predictions = self.model(images, verbose=False)
+        return self._format_predictions(predictions)
+
 
 def _convert_yolo_detection_model(model):
     config = FiftyOneYOLOConfig({"model": model})


### PR DESCRIPTION
## What changes are proposed in this pull request?

Adds support for passing Ultralytics YOLO models directly to `sample_collection.apply_model()`!

Example Usage:

```py
import fiftyone as fo
import fiftyone.zoo as foz
from ultralytics import YOLO

dataset = foz.load_zoo_dataset("quickstart")

yolov5n = YOLO('yolov5n.pt')
yolov8n = YOLO('yolov8n.pt')
yolov8seg = YOLO('yolov8n-seg.pt')
yolov8npose = YOLO('yolov8n-pose.pt')

## YOLOv5 detection model, which we previously supported
dataset.apply_model(yolov5n, label_field="yolov5n")

## New: YOLOv8 — we get it for free!
dataset.apply_model(yolov8n, label_field="yolov8n")

## Instance segmentation model
dataset.apply_model(yolov8seg, label_field="yolov8seg")

## Pose estimation model
dataset.apply_model(yolov8npose, label_field="yolov8npose")
```

Additionally, I found that the previous YOLO instance segmentation conversion was incorrect, so this patches that!


## Additional Notes:
It would be pretty easy for us to do something similar for CLIP, SAM, OpenCLIP, YOLO-NAS, and potentially even HF models! Of course, too many and we would likely want to reorganize the code, but I think this will make life easier for users :)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [x] Other
