### PR TITLE
fix missing default/data propagation for operator views

### DIFF
--- a/app/packages/core/src/plugins/SchemaIO/components/DynamicIO.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/DynamicIO.tsx
@@ -1,9 +1,9 @@
 import { PluginComponentType, useActivePlugins } from "@fiftyone/plugins";
-import { isPrimitiveType } from "@fiftyone/utilities";
-import { get } from "lodash";
+import { isNullish } from "@fiftyone/utilities";
+import { get, isEqual } from "lodash";
 import React, { useEffect } from "react";
-import { getComponent, getErrorsForView } from "../utils";
 import { isPathUserChanged } from "../hooks";
+import { getComponent, getErrorsForView, isCompositeView } from "../utils";
 
 export default function DynamicIO(props) {
   const { data, schema, onChange, path, parentSchema, relativePath } = props;
@@ -19,9 +19,10 @@ export default function DynamicIO(props) {
   // todo: need to improve initializing default value in state
   useEffect(() => {
     if (
-      isPrimitiveType(type) &&
-      data !== defaultValue &&
-      !isPathUserChanged(path)
+      !isCompositeView(schema) &&
+      !isEqual(data, defaultValue) &&
+      !isPathUserChanged(path) &&
+      !isNullish(defaultValue)
     ) {
       onChange(path, defaultValue);
     }

--- a/app/packages/core/src/plugins/SchemaIO/utils/index.ts
+++ b/app/packages/core/src/plugins/SchemaIO/utils/index.ts
@@ -47,3 +47,16 @@ export function getErrorsForView(props) {
 
 export * from "./generate-schema";
 export { default as autoFocus } from "./auto-focus";
+
+// Views that renders DynamicIO as a child component
+const COMPOSITE_VIEWS = [
+  "InferredView",
+  "ListView",
+  "ObjectView",
+  "OneOfView",
+  "TupleView",
+];
+
+export function isCompositeView(schema) {
+  return COMPOSITE_VIEWS.includes(schema?.view?.component);
+}


### PR DESCRIPTION
## What changes are proposed in this pull request?

- Fixes an issue where data is unset due to missing default in the output of an operator
- Fixes an issue where the default for the `List` type is not initialized when rendered as non-composite views

## How is this patch tested? If it is not, please explain why.

Using an example operator with rendering both scenarios above

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

See changes proposed above

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
