### PR TITLE
Adding gpu support for openclip models

### DIFF
--- a/fiftyone/utils/open_clip.py
+++ b/fiftyone/utils/open_clip.py
@@ -90,7 +90,9 @@ class TorchOpenClipModel(fout.TorchImageModel, fom.PromptMixin):
             _,
             self.preprocess,
         ) = open_clip.create_model_and_transforms(
-            config.clip_model, pretrained=config.pretrained
+            config.clip_model,
+            pretrained=config.pretrained,
+            device=config.device,
         )
         self._tokenizer = open_clip.get_tokenizer(config.clip_model)
         return self._model
@@ -102,6 +104,8 @@ class TorchOpenClipModel(fout.TorchImageModel, fom.PromptMixin):
             ]
             # Tokenize text
             text = self._tokenizer(prompts)
+            if self._using_gpu:
+                text = text.cuda()
             self._text_features = self._model.encode_text(text)
 
         return self._text_features


### PR DESCRIPTION
## What changes are proposed in this pull request?

Added gpu support in the new open_clip models by adding checks for config.device

## How is this patch tested? If it is not, please explain why.

Running openclip model on gpu 

model = foz.load_zoo_model("open-clip-torch", device="cuda")

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

GPU now supported with OpenClip models



### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ X] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
