### PR TITLE
Fix embedded patches fields in the App

### DIFF
--- a/app/packages/looker/src/overlays/index.ts
+++ b/app/packages/looker/src/overlays/index.ts
@@ -88,7 +88,7 @@ const accumulateOverlays = <State extends BaseState>(
       continue;
     }
 
-    if (label._cls === DYNAMIC_EMBEDDED_DOCUMENT && depth) {
+    if (depth && label._cls === DYNAMIC_EMBEDDED_DOCUMENT) {
       const nestedResult = accumulateOverlays(label, `${field}.`, depth - 1);
       classifications.push(...nestedResult.classifications);
       overlays.push(...nestedResult.overlays);

--- a/app/packages/looker/src/util.ts
+++ b/app/packages/looker/src/util.ts
@@ -11,7 +11,6 @@ import {
   BufferRange,
   Buffers,
   Coordinates,
-  CustomizeColor,
   Dimensions,
   DispatchEvent,
 } from "./state";
@@ -23,9 +22,8 @@ import {
   NetworkError,
   ServerError,
 } from "@fiftyone/utilities";
-import LookerWorker from "./worker/index.ts?worker&inline";
-import { BufferManager } from "./lookers/imavid/buffer-manager";
 import { DEFAULT_FRAME_RATE } from "./lookers/imavid/constants";
+import LookerWorker from "./worker/index.ts?worker&inline";
 
 /**
  * Shallow data-object comparison for equality
@@ -407,9 +405,9 @@ export const clampScale = (
 };
 
 export const mergeUpdates = <State extends BaseState>(
-  state: Partial<State>,
+  state: State,
   updates: Partial<State>
-): Partial<State> => {
+): State => {
   const merger = (o, n) => {
     if (Array.isArray(n)) {
       return n;

--- a/fiftyone/core/patches.py
+++ b/fiftyone/core/patches.py
@@ -853,11 +853,17 @@ def _make_patches_view(
         "metadata": True,
         "tags": True,
         field + "._cls": True,
+        field.split(".")[0] + "._cls": True,  # embedded fields
         root: True,
     }
 
     if other_fields is not None:
-        project.update({f: True for f in other_fields})
+        update = {}
+        for f in other_fields:
+            update[f] = True
+            update[f.split(".")[0] + "._cls"] = True  # embedded fields
+
+        project.update(update)
 
     if sample_collection._is_frames:
         project["_sample_id"] = True

--- a/fiftyone/core/patches.py
+++ b/fiftyone/core/patches.py
@@ -853,17 +853,17 @@ def _make_patches_view(
         "metadata": True,
         "tags": True,
         field + "._cls": True,
-        field.split(".")[0] + "._cls": True,  # embedded fields
         root: True,
     }
 
-    if other_fields is not None:
-        update = {}
-        for f in other_fields:
-            update[f] = True
-            update[f.split(".")[0] + "._cls"] = True  # embedded fields
+    if "." in field:
+        project[field.split(".", 1)[0] + ".cls"] = True  # embedded fields
 
-        project.update(update)
+    if other_fields is not None:
+        for f in other_fields:
+            project[f] = True
+            if "." in f:
+                project[f.split(".", 1)[0] + "._cls"] = True  # embedded fields
 
     if sample_collection._is_frames:
         project["_sample_id"] = True

--- a/fiftyone/core/patches.py
+++ b/fiftyone/core/patches.py
@@ -857,7 +857,7 @@ def _make_patches_view(
     }
 
     if "." in field:
-        project[field.split(".", 1)[0] + ".cls"] = True  # embedded fields
+        project[field.split(".", 1)[0] + "._cls"] = True  # embedded fields
 
     if other_fields is not None:
         for f in other_fields:


### PR DESCRIPTION
Fixes patches views in the App. Note the `fiftyone.core.patches` changes are due to the `_cls` requirement by Looker for `DynamicEmbeddedDocument` values.

The changes should also support evaluation patches views. Though I am unable to confirm due to #3996

```python
import fiftyone as fo
import fiftyone.zoo as foz

dataset = foz.load_zoo_dataset("quickstart", max_samples=1)

for sample in dataset:
    sample["embedded"] = fo.DynamicEmbeddedDocument(
        ground_truth=sample.ground_truth, predictions=sample.predictions
    )
    sample.save()

dataset.delete_sample_field("ground_truth")
dataset.delete_sample_field("predictions")
dataset.add_dynamic_sample_fields()
``` 

https://github.com/voxel51/fiftyone/assets/19821840/8b317873-27d8-4e00-bb90-ebd907ac3d78


