### PR TITLE
Bump the brain to v0.15.0 (or greater, still in the v0.15.* version)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -75,7 +75,7 @@ INSTALL_REQUIRES = [
     "xmltodict",
     "universal-analytics-python3>=1.0.1,<2",
     # internal packages
-    "fiftyone-brain>=0.14.2,<0.15",
+    "fiftyone-brain~=0.15.0",
     "fiftyone-db>=0.4,<2.0",
     "voxel51-eta>=0.12.1,<0.13",
 ]


### PR DESCRIPTION
## What changes are proposed in this pull request?

Time to bump the brain

## How is this patch tested? If it is not, please explain why.

`~=0.15.0` is syntactically equivalent to `>=0.15.0, ==0.15.*`

So any future brain bumps in the `0.15.*` range will work, starting with `0.15.0`

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
