### PR TITLE
show operator palette over modal

### DIFF
--- a/app/packages/components/src/components/ThemeProvider/index.tsx
+++ b/app/packages/components/src/components/ThemeProvider/index.tsx
@@ -18,6 +18,10 @@ let theme = extendMuiTheme({
   typography: {
     fontFamily: "Palanquin, sans-serif",
   },
+  zIndex: {
+    // MUI default max is zIndex.tooltip=1500
+    operatorPalette: 1501,
+  },
   colorSchemes: {
     light: {
       palette: {

--- a/app/packages/operators/src/OperatorPalette.tsx
+++ b/app/packages/operators/src/OperatorPalette.tsx
@@ -1,18 +1,15 @@
-// import { Button } from "@fiftyone/components";
-
 import {
   PropsWithChildren,
   ReactElement,
   useCallback,
   useEffect,
   useRef,
-  useState,
 } from "react";
 import SplitButton from "./SplitButton";
 import { PALETTE_CONTROL_KEYS } from "./constants";
 import { BaseStylesProvider } from "./styled-components";
 
-import { scrollable, Button } from "@fiftyone/components";
+import { Button, scrollable } from "@fiftyone/components";
 import {
   Alert,
   AlertTitle,
@@ -88,11 +85,6 @@ export default function OperatorPalette(props: OperatorPaletteProps) {
     };
   }, [paletteElem, keyDownHandler]);
 
-  const [selectedMenuOptionId, setSelectedMenuOptionId] = useState(null);
-  const handleMenuItemClick = (id) => {
-    selectedMenuOptionId(id);
-  };
-
   return (
     <Dialog
       open
@@ -106,6 +98,7 @@ export default function OperatorPalette(props: OperatorPaletteProps) {
         "& .MuiDialog-container": {
           alignItems: "flex-start",
         },
+        zIndex: (theme) => theme.zIndex.operatorPalette,
       }}
     >
       {title && (


### PR DESCRIPTION
## What changes are proposed in this pull request?

When samples modal is opened, operator palette is hidden behind the modal. PR increased zIndex of operator palettes to make it appear on top of modal

## How is this patch tested? If it is not, please explain why.

By launching operator palette while samples modal is opened

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

Fix operator palette appearing behind the samples modal

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
