### PR TITLE
use fetch path prefix instead of origin for operator icon

### DIFF
--- a/app/packages/operators/src/utils.ts
+++ b/app/packages/operators/src/utils.ts
@@ -1,4 +1,4 @@
-import { getFetchOrigin } from "@fiftyone/utilities";
+import { getFetchParameters, getFetchPathPrefix } from "@fiftyone/utilities";
 import { KeyboardEventHandler } from "react";
 
 export function stringifyError(error, fallback?) {
@@ -24,8 +24,8 @@ export function onEnter(
 }
 
 export function resolveServerPath(plugin) {
-  const origin = getFetchOrigin();
-  return origin + plugin.serverPath;
+  const { pathPrefix } = getFetchParameters();
+  return pathPrefix + plugin.serverPath;
 }
 
 export function formatValidationErrors(errors: []) {


### PR DESCRIPTION
## What changes are proposed in this pull request?

Use fetch path prefix instead of fetch origin for operator icon URL resolution

## How is this patch tested? If it is not, please explain why.

Using an operator placement and an operator with custom icon

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
