### PR TITLE
fix z-index conflicts in operator palette

### DIFF
--- a/app/packages/components/src/components/ThemeProvider/index.tsx
+++ b/app/packages/components/src/components/ThemeProvider/index.tsx
@@ -19,8 +19,8 @@ let theme = extendMuiTheme({
     fontFamily: "Palanquin, sans-serif",
   },
   zIndex: {
-    // MUI default max is zIndex.tooltip=1500
-    operatorPalette: 1501,
+    // Samples modal zIndex is set to 1000
+    operatorPalette: 1001,
   },
   colorSchemes: {
     light: {

--- a/app/packages/core/src/plugins/SchemaIO/components/DropdownView.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/DropdownView.tsx
@@ -49,6 +49,7 @@ export default function DropdownView(props) {
     labels[choice.value] = choice.label;
     return labels;
   }, {});
+  const { MenuProps = {}, ...selectProps } = getComponentProps(props, "select");
 
   return (
     <FieldWrapper {...props}>
@@ -79,7 +80,14 @@ export default function DropdownView(props) {
           setUserChanged();
         }}
         multiple={multiple}
-        {...getComponentProps(props, "select")}
+        {...selectProps}
+        MenuProps={{
+          ...MenuProps,
+          sx: {
+            zIndex: (theme) => theme.zIndex.operatorPalette + 1,
+            ...(MenuProps?.sx || {}),
+          },
+        }}
       >
         {choices.map(({ value, ...choice }) => (
           <MenuItem

--- a/app/packages/core/src/plugins/SchemaIO/components/FileExplorerView/FileExplorer.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/FileExplorerView/FileExplorer.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import { Button } from "@fiftyone/components";
 import ExplorerActions from "./ExplorerActions";
 import FileTable from "./FileTable";
@@ -68,7 +68,7 @@ export default function FileExplorer({
   const fsError = fsInfo?.error;
 
   return (
-    <div>
+    <Box>
       <Box>
         <TextField
           size="small"
@@ -120,6 +120,7 @@ export default function FileExplorer({
         aria-describedby="alert-dialog-description"
         PaperProps={{ sx: { backgroundImage: "none" } }}
         maxWidth={false}
+        sx={{ zIndex: (theme) => theme.zIndex.operatorPalette + 1 }}
       >
         <ModalContent>
           <Grid container direction="row" spacing={1}>
@@ -209,6 +210,6 @@ export default function FileExplorer({
           </Grid>
         </ModalContent>
       </Dialog>
-    </div>
+    </Box>
   );
 }


### PR DESCRIPTION
## What changes are proposed in this pull request?

Fix z-index conflicts between the operator palette and dropdown within oprator

## How is this patch tested? If it is not, please explain why.

With a test operator using various views which has component which may appear behind the palette

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
