### PR TITLE
Add dynamic batching to bulk writes

### DIFF
--- a/docs/source/user_guide/config.rst
+++ b/docs/source/user_guide/config.rst
@@ -55,14 +55,10 @@ FiftyOne supports the configuration options described below:
 +-------------------------------+-------------------------------------+-------------------------------+----------------------------------------------------------------------------------------+
 | `default_batch_size`          | `FIFTYONE_DEFAULT_BATCH_SIZE`       | `None`                        | A default batch size to use when :ref:`applying models to datasets <model-zoo-apply>`. |
 +-------------------------------+-------------------------------------+-------------------------------+----------------------------------------------------------------------------------------+
-| `bulk_write_batch_size`       | `FIFTYONE_BULK_WRITE_BATCH_SIZE`    | `100,000`                     | Batch size to use for bulk writing MongoDB operations. Must be <= 100,000.             |
-|                               |                                     |                               |                                                                                        |
-|                               |                                     |                               | Default changes to 10,000 for the FiftyOne Teams SDK in                                |
-|                               |                                     |                               | :ref:`API connection mode <teams-api-connection>`.                                     |
-+-------------------------------+-------------------------------------+-------------------------------+----------------------------------------------------------------------------------------+
 | `default_batcher`             | `FIFTYONE_DEFAULT_BATCHER`          | `latency`                     | Batching implementation to use in some batched database operations such as             |
-|                               |                                     |                               | :meth:`add_samples() <fiftyone.core.dataset.Dataset.add_samples>`. Supported values    |
-|                               |                                     |                               | are `latency`, `size`, and `static`.                                                   |
+|                               |                                     |                               | :meth:`add_samples() <fiftyone.core.dataset.Dataset.add_samples>` and                  |
+|                               |                                     |                               | :meth:`set_values() <fiftyone.core.collections.SampleCollection.set_values>`.          |
+|                               |                                     |                               | Supported values are `latency`, `size`, and `static`.                                  |
 |                               |                                     |                               |                                                                                        |
 |                               |                                     |                               | `latency` is the default, which uses a dynamic batch size to achieve a target latency  |
 |                               |                                     |                               | of `batcher_target_latency` between calls. The default changes to `size` for the       |
@@ -161,7 +157,6 @@ and the CLI:
             "batcher_static_size": 100,
             "batcher_target_latency": 0.2,
             "batcher_target_size_bytes": 1048576,
-            "bulk_write_batch_size": 100000,
             "database_admin": true,
             "database_dir": "~/.fiftyone/var/lib/mongo",
             "database_name": "fiftyone",
@@ -212,7 +207,6 @@ and the CLI:
             "batcher_static_size": 100,
             "batcher_target_latency": 0.2,
             "batcher_target_size_bytes": 1048576,
-            "bulk_write_batch_size": 100000,
             "database_admin": true,
             "database_dir": "~/.fiftyone/var/lib/mongo",
             "database_name": "fiftyone",

--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -1541,10 +1541,10 @@ class SampleCollection(object):
     def _edit_sample_tags(self, update):
         ids = []
         ops = []
-        # size chosen to keep request smaller than 1MB
-        #   ( 35,000 IDs of 24 printable digits ~= 0.8 MB )
-        id_set_batch_size = 35_000
-        for _ids in fou.iter_batches(self.values("_id"), id_set_batch_size):
+        batch_size = fou.recommend_batch_size_for_value(
+            ObjectId(), max_size=100000
+        )
+        for _ids in fou.iter_batches(self.values("_id"), batch_size):
             ids.extend(_ids)
             ops.append(UpdateMany({"_id": {"$in": _ids}}, update))
 
@@ -1667,10 +1667,10 @@ class SampleCollection(object):
                 else:
                     label_ids = self.values(id_path)
 
-            # size chosen to keep request smaller than 1MB
-            #   ( 35,000 IDs of 24 printable digits ~= 0.8 MB )
-            id_set_batch_size = 35_000
-            for _label_ids in fou.iter_batches(label_ids, id_set_batch_size):
+            batch_size = fou.recommend_batch_size_for_value(
+                ObjectId(), max_size=100000
+            )
+            for _label_ids in fou.iter_batches(label_ids, batch_size):
                 _label_ids = [_id for _id in _label_ids if _id is not None]
                 if _label_ids:
                     ops.append(

--- a/fiftyone/core/config.py
+++ b/fiftyone/core/config.py
@@ -154,12 +154,6 @@ class FiftyOneConfig(EnvConfig):
             env_var="FIFTYONE_DEFAULT_BATCH_SIZE",
             default=None,
         )
-        self.bulk_write_batch_size = self.parse_int(
-            d,
-            "bulk_write_batch_size",
-            env_var="FIFTYONE_BULK_WRITE_BATCH_SIZE",
-            default=100_000,  # mongodb limit
-        )
         self.default_batcher = self.parse_string(
             d,
             "default_batcher",

--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -2569,6 +2569,7 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
                 sample.frames.save()
 
         if batcher is not None and batcher.manual_backpressure:
+            # @todo can we infer content size from insert_many() above?
             batcher.apply_backpressure(dicts)
 
         return [str(d["_id"]) for d in dicts]
@@ -2617,7 +2618,11 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
                 d.pop("_id", None)
                 ops.append(InsertOne(d))  # adds `_id` to dict
 
-        foo.bulk_write(ops, self._sample_collection, ordered=False)
+        try:
+            self._sample_collection.bulk_write(ops, ordered=False)
+        except BulkWriteError as bwe:
+            msg = bwe.details["writeErrors"][0]["errmsg"]
+            raise ValueError(msg) from bwe
 
         for sample, d in zip(samples, dicts):
             doc = self._sample_dict_to_doc(d)
@@ -2627,6 +2632,7 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
                 sample.frames.save()
 
         if batcher is not None and batcher.manual_backpressure:
+            # @todo can we infer content size from bulk_write() above?
             batcher.apply_backpressure(dicts)
 
     def _make_dict(self, sample, include_id=False):
@@ -2641,13 +2647,15 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
 
         return d
 
-    def _bulk_write(self, ops, ids=None, frames=False, ordered=False):
+    def _bulk_write(
+        self, ops, ids=None, frames=False, ordered=False, progress=False
+    ):
         if frames:
             coll = self._frame_collection
         else:
             coll = self._sample_collection
 
-        foo.bulk_write(ops, coll, ordered=ordered)
+        foo.bulk_write(ops, coll, ordered=ordered, progress=progress)
 
         if frames:
             fofr.Frame._reload_docs(self._frame_collection_name, frame_ids=ids)

--- a/fiftyone/core/odm/database.py
+++ b/fiftyone/core/odm/database.py
@@ -777,6 +777,7 @@ def insert_documents(docs, coll, ordered=False, progress=None, num_docs=None):
                 coll.insert_many(batch, ordered=ordered)
                 ids.extend(b["_id"] for b in batch)
                 if batcher.manual_backpressure:
+                    # @todo can we infer content size from insert_many() above?
                     batcher.apply_backpressure(batch)
 
     except BulkWriteError as bwe:
@@ -786,18 +787,30 @@ def insert_documents(docs, coll, ordered=False, progress=None, num_docs=None):
     return ids
 
 
-def bulk_write(ops, coll, ordered=False):
+def bulk_write(ops, coll, ordered=False, progress=False):
     """Performs a batch of write operations on a collection.
 
     Args:
         ops: a list of pymongo operations
         coll: a pymongo collection
         ordered (False): whether the operations must be performed in order
+        progress (False): whether to render a progress bar (True/False), use
+            the default value ``fiftyone.config.show_progress_bars`` (None), or
+            a progress callback function to invoke instead
     """
+    batcher = fou.get_default_batcher(ops, progress=progress)
+
     try:
-        batch_size = fo.config.bulk_write_batch_size
-        for ops_batch in fou.iter_batches(ops, batch_size):
-            coll.bulk_write(list(ops_batch), ordered=ordered)
+        with batcher:
+            for batch in batcher:
+                batch = list(batch)
+                coll.bulk_write(batch, ordered=ordered)
+                if batcher.manual_backpressure:
+                    # @todo can we infer content size from bulk_write() above?
+                    # @todo do we need a more accurate measure of size here?
+                    content_size = sum(len(str(b)) for b in batch)
+                    batcher.apply_backpressure(content_size)
+
     except BulkWriteError as bwe:
         msg = bwe.details["writeErrors"][0]["errmsg"]
         raise ValueError(msg) from bwe

--- a/fiftyone/core/utils.py
+++ b/fiftyone/core/utils.py
@@ -1594,6 +1594,30 @@ def get_default_batcher(iterable, progress=False, total=None):
         )
 
 
+def recommend_batch_size_for_value(value, alpha=0.9, max_size=None):
+    """Computes a recommended batch size for the given value type such that a
+    request involving a list of values of this size will be less than
+    ``alpha * fo.config.batcher_target_size_bytes`` bytes.
+
+    Args:
+        value: a value
+        alpha (0.9): a safety factor
+        max_size (None): an optional max batch size
+
+    Returns:
+         a recommended batch size
+    """
+    # Even if ``fo.config.default_batcher != "size"``, it's still reasonable to
+    # use the size threshold to limit the size of individual requests
+    target_size = fo.config.batcher_target_size_bytes
+    value_bytes = sys.getsizeof(value, 40)  # 40 is size of an ObjectId
+    batch_size = int(alpha * target_size / value_bytes)
+    if max_size is not None:
+        batch_size = min(batch_size, max_size)
+
+    return batch_size
+
+
 @contextmanager
 def disable_progress_bars():
     """Context manager that temporarily disables all progress bars.

--- a/fiftyone/core/utils.py
+++ b/fiftyone/core/utils.py
@@ -1611,7 +1611,7 @@ def recommend_batch_size_for_value(value, alpha=0.9, max_size=None):
     # use the size threshold to limit the size of individual requests
     target_size = fo.config.batcher_target_size_bytes
     value_bytes = sys.getsizeof(value, 40)  # 40 is size of an ObjectId
-    batch_size = int(alpha * target_size / value_bytes)
+    batch_size = int(alpha * target_size / max(value_bytes, 1))
     if max_size is not None:
         batch_size = min(batch_size, max_size)
 

--- a/fiftyone/core/utils.py
+++ b/fiftyone/core/utils.py
@@ -21,6 +21,7 @@ import io
 import itertools
 import logging
 import multiprocessing
+import numbers
 import os
 import platform
 import re
@@ -1467,10 +1468,14 @@ class BSONSizeDynamicBatcher(BaseDynamicBatcher):
         )
         self._last_batch_content_size = 0
 
-    def apply_backpressure(self, bsonable_batch):
-        batch_content_size = sum(
-            len(json_util.dumps(obj)) for obj in bsonable_batch
-        )
+    def apply_backpressure(self, batch_or_size):
+        if isinstance(batch_or_size, numbers.Number):
+            batch_content_size = batch_or_size
+        else:
+            batch_content_size = sum(
+                len(json_util.dumps(obj)) for obj in batch_or_size
+            )
+
         self._last_batch_content_size = batch_content_size
         self._manually_applied_backpressure = True
 
@@ -1562,7 +1567,7 @@ def get_default_batcher(iterable, progress=False, total=None):
             iterable,
             target_latency=target_latency,
             init_batch_size=1,
-            max_batch_beta=2.0,
+            max_batch_beta=8.0,
             max_batch_size=100000,
             progress=progress,
             total=total,

--- a/fiftyone/core/utils.py
+++ b/fiftyone/core/utils.py
@@ -1375,17 +1375,17 @@ class LatencyDynamicBatcher(BaseDynamicBatcher):
 DynamicBatcher = LatencyDynamicBatcher
 
 
-class BSONSizeDynamicBatcher(BaseDynamicBatcher):
+class ContentSizeDynamicBatcher(BaseDynamicBatcher):
     """Class for iterating over the elements of an iterable with a dynamic
-    batch size to achieve a desired BSON content size.
+    batch size to achieve a desired content size.
 
     The batch sizes emitted when iterating over this object are dynamically
-    scaled such that the total BSON size of the batch is as close as
+    scaled such that the total content size of the batch is as close as
     possible to a specified target size.
 
-    This batcher requires that backpressure feedback be manually provided,
-    so that the provided list is BSON-able in order to calculate an accurate
-    estimate of total batch content size to adjust next batch size.
+    This batcher requires that backpressure feedback be provided, either by
+    providing a BSON-able batch from which the content size can be computed,
+    or by manaully providing the content size.
 
     This class is often used in conjunction with a :class:`ProgressBar` to keep
     the user appraised on the status of a long-running task.
@@ -1396,7 +1396,7 @@ class BSONSizeDynamicBatcher(BaseDynamicBatcher):
 
         elements = range(int(1e7))
 
-        batcher = fou.BSONSizeDynamicBatcher(
+        batcher = fou.ContentSizeDynamicBatcher(
             elements, target_size=2**20, max_batch_beta=2.0
         )
 
@@ -1409,7 +1409,7 @@ class BSONSizeDynamicBatcher(BaseDynamicBatcher):
             print("batch size: %d" % len(batch))
             batcher.apply_backpressure(batch)
 
-        batcher = fou.BSONSizeDynamicBatcher(
+        batcher = fou.ContentSizeDynamicBatcher(
             elements,
             target_size=2**20,
             max_batch_beta=2.0,
@@ -1574,7 +1574,7 @@ def get_default_batcher(iterable, progress=False, total=None):
         )
     elif default_batcher == "size":
         target_content_size = fo.config.batcher_target_size_bytes
-        return BSONSizeDynamicBatcher(
+        return ContentSizeDynamicBatcher(
             iterable,
             target_size=target_content_size,
             init_batch_size=1,

--- a/tests/unittests/utils_tests.py
+++ b/tests/unittests/utils_tests.py
@@ -56,7 +56,7 @@ class BatcherTests(unittest.TestCase):
             ):
                 batcher = fou.get_default_batcher(iterable)
                 self.assertTrue(
-                    isinstance(batcher, fou.BSONSizeDynamicBatcher)
+                    isinstance(batcher, fou.ContentSizeDynamicBatcher)
                 )
                 self.assertEqual(batcher.target_measurement, target_size)
 

--- a/tests/unittests/utils_tests.py
+++ b/tests/unittests/utils_tests.py
@@ -80,6 +80,55 @@ class BatcherTests(unittest.TestCase):
             batches = [batch for batch in batcher]
             self.assertListEqual(batches, [iterable])
 
+    @drop_datasets
+    def test_batching_static_default(self):
+        with patch.object(fo.config, "default_batcher", "static"):
+            self._test_batching()
+
+    @drop_datasets
+    def test_batching_static_custom(self):
+        with patch.object(fo.config, "default_batcher", "static"):
+            with patch.object(fo.config, "batcher_static_size", 1):
+                self._test_batching()
+
+    @drop_datasets
+    def test_batching_latency_default(self):
+        with patch.object(fo.config, "default_batcher", "latency"):
+            self._test_batching()
+
+    @drop_datasets
+    def test_batching_latency_custom(self):
+        with patch.object(fo.config, "default_batcher", "latency"):
+            # test a value that forces batch size == 1
+            with patch.object(fo.config, "batcher_target_latency", 1e-6):
+                self._test_batching()
+
+    @drop_datasets
+    def test_batching_size_default(self):
+        with patch.object(fo.config, "default_batcher", "size"):
+            self._test_batching()
+
+    @drop_datasets
+    def test_batching_size_custom(self):
+        with patch.object(fo.config, "default_batcher", "size"):
+            # test a value that forces batch size == 1
+            with patch.object(fo.config, "batcher_target_size_bytes", 1):
+                self._test_batching()
+
+    def _test_batching(self):
+        n = 100
+        dataset = fo.Dataset()
+        dataset.add_samples([fo.Sample(filepath=f"{i}.jpg") for i in range(n)])
+
+        embeddings = np.random.randn(n, 512)
+        dataset.set_values("embeddings", embeddings)
+
+        self.assertEqual(len(dataset), n)
+        self.assertEqual(len(dataset.exists("embeddings")), n)
+
+        sample = dataset.view().first()
+        self.assertIsInstance(sample.embeddings, np.ndarray)
+
 
 class CoreUtilsTests(unittest.TestCase):
     def test_validate_hex_color(self):


### PR DESCRIPTION
## Change log

- use `get_default_batcher()` inside `bulk_write()`
- removes now-unused `bulk_write_batch_size` config setting
- add optional ability to render progress bars on bulk write operations like `set_values()` and `set_label_values()`

## Examples

### set_values()

```py
import fiftyone as fo

dataset = fo.Dataset()
_ = dataset.add_samples([fo.Sample(filepath=f"{i}.jpg") for i in range(10000)])

dataset.set_values("int", [1] * len(dataset))
dataset.set_values("int", [1] * len(dataset), progress=True)
```

### set_label_values()

```py
import fiftyone as fo
import fiftyone.zoo as foz

dataset = foz.load_zoo_dataset("quickstart")
values = {_id: True for _id in dataset.values("predictions.detections.id", unwind=True)}

dataset.set_label_values("predictions.detections.bool", values)
dataset.set_label_values("predictions.detections.bool", values, progress=True)
```
