### PR TITLE
Include sample/frame singletons when clearing dataset cache

### DIFF
--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -6738,7 +6738,15 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
         self._reload_docs(hard=True)
 
     def clear_cache(self):
-        """Clears the dataset's in-memory cache."""
+        """Clears the dataset's in-memory cache.
+
+        Dataset caches may contain sample/frame singletons and
+        annotation/brain/evaluation/custom runs.
+        """
+        fos.Sample._clear(self._sample_collection_name)
+        if self._frame_collection_name is not None:
+            fofr.Frame._clear(self._frame_collection_name)
+
         self._annotation_cache.clear()
         self._brain_cache.clear()
         self._evaluation_cache.clear()

--- a/fiftyone/core/singletons.py
+++ b/fiftyone/core/singletons.py
@@ -228,6 +228,10 @@ class SampleSingleton(DocumentSingleton):
             for sample in samples.values():
                 sample._reset_backing_doc()
 
+    def _clear(cls, collection_name):
+        """Removes all samples for the given collection from the cache."""
+        cls._instances.pop(collection_name, None)
+
 
 class FrameSingleton(DocumentSingleton):
     """Singleton metaclass for :class:`fiftyone.core.frame.Frame`.
@@ -501,3 +505,7 @@ class FrameSingleton(DocumentSingleton):
 
         for sample_id, fn in reset:
             samples[sample_id].pop(fn)
+
+    def _clear(cls, collection_name):
+        """Removes all frames for the given collection from the cache."""
+        cls._instances.pop(collection_name, None)

--- a/tests/unittests/dataset_tests.py
+++ b/tests/unittests/dataset_tests.py
@@ -2431,6 +2431,30 @@ class DatasetTests(unittest.TestCase):
             frame.predictions.detections[0].field_copy
 
     @drop_datasets
+    def test_clear_cache(self):
+        samples = [fo.Sample(filepath=f"{i}.mp4") for i in range(10)]
+        sample1 = samples[0]
+        sample1.frames[1] = fo.Frame()
+        frame1 = sample1.frames[1]
+
+        dataset = fo.Dataset()
+        dataset.add_samples(samples)
+
+        also_sample1 = dataset.first()
+        also_frame1 = also_sample1.frames[1]
+
+        self.assertTrue(also_sample1 is sample1)
+        self.assertTrue(also_frame1 is frame1)
+
+        dataset.clear_cache()
+
+        not_sample1 = dataset.first()
+        not_frame1 = not_sample1.frames[1]
+
+        self.assertFalse(not_sample1 is sample1)
+        self.assertFalse(not_frame1 is frame1)
+
+    @drop_datasets
     def test_classes(self):
         dataset = fo.Dataset()
 


### PR DESCRIPTION
Primary intended usage here is situations like the following:

```py
dataset = fo.Dataset()
dataset.add_samples(lots_of_samples)

# clear sample cache so that operation below does NOT reload n docs
dataset.clear_cache()

dataset.set_values("field", lots_of_values)
```
