### PR TITLE
[`fiftyone-db`] Fix /etc/os-release files with empty lines

### DIFF
--- a/package/db/setup.py
+++ b/package/db/setup.py
@@ -99,7 +99,8 @@ def _get_linux_download():
     path = pathlib.Path("/etc/os-release")
     with open(path) as stream:
         reader = csv.reader(stream, delimiter="=")
-        d = dict(reader)
+        # filter empty lines
+        d = dict(line for line in reader if line)
 
     for k, v in LINUX_DOWNLOADS[d["ID"]].items():
         if d["VERSION_ID"].startswith(k):
@@ -124,7 +125,7 @@ def _get_download():
 MONGODB_BINARIES = ["mongod"]
 
 
-VERSION = "1.1"
+VERSION = "1.1.1"
 
 
 def get_version():


### PR DESCRIPTION
Resolves an `/etc/os-release` parsing issue mentioned in https://github.com/voxel51/fiftyone/issues/3975#issuecomment-1900421186