### PR TITLE
Enable relative imports in plugins

### DIFF
--- a/fiftyone/plugins/context.py
+++ b/fiftyone/plugins/context.py
@@ -130,7 +130,7 @@ class PluginContext(object):
                 module_dir, fo.config.plugins_dir
             ).replace("/", ".")
             spec = importlib.util.spec_from_file_location(
-                module_name, module_path
+                module_name, module_path, submodule_search_locations=[]
             )
             module = importlib.util.module_from_spec(spec)
             sys.modules[module.__name__] = module

--- a/fiftyone/plugins/context.py
+++ b/fiftyone/plugins/context.py
@@ -126,9 +126,10 @@ class PluginContext(object):
             if not os.path.isfile(module_path):
                 return
 
-            module_name = os.path.relpath(
-                module_dir, fo.config.plugins_dir
-            ).replace("/", ".")
+            # name used to import a plugin will be the name of the directory
+            # containing the fiftyone.yml file
+            module_name = module_dir.rsplit("/", 1)[-1]
+
             spec = importlib.util.spec_from_file_location(
                 module_name, module_path, submodule_search_locations=[]
             )


### PR DESCRIPTION
## What changes are proposed in this pull request?

- load plugins as packages so they can use relative imports

## How is this patch tested? If it is not, please explain why.

- tested locally with demo plugin:
<img width="291" alt="image" src="https://github.com/voxel51/fiftyone/assets/30936736/d4af2a0c-3c01-4015-b2e5-d3f6ff16f80a">

```py
# fiftyone_plugins/relative_imports_test/__init__.py

from relative_imports_test import relative_file
import relative_imports_test.nested_dir.another_python_file as nested_file
import check_azure_creds

class RelativeImportsTestPlugin(foo.Operator):
    @property
    def config(self):
        return foo.OperatorConfig(
                name="relative_imports_test_plugin",
                label="relative_imports_test_plugin",
        )

   def resolve_input(self, ctx):
        inputs = types.Object()
        print()
        print('*' * 80)
        print("resolve_input called for RelativeImportsTestPlugin")
        print('#' * 100)
        print('calling relative_file.some_function() from ',__file__)
        print(relative_file.some_function())
        print('calling nested_file.some_function() from ',__file__)

        print(nested_file.some_function())
        print('referencing another plugin from current plugin')
        
        check_azure_creds.CheckAzureCredsSuccess().resolve_input(ctx)
        return types.Property(inputs)

```

```py
# fiftyone-plugins/relative_imports_test/nested_dir/another_python_file.py

def some_function():
    print('-'*100)
    print('called some_function inside nested dir defined at', __file__)
```

```py
# fiftyone-plugins/relative_imports_test/relative_file.py

def some_function():
    print('-'*100)
    print('executed some_function from relative_file', __file__)
```

```py
# fiftyone-plugins/check_azure_creds/__init__.py

class CheckAzureCredsSuccess(foo.Operator):
    @property
    def config(self):
        return foo.OperatorConfig(
                name="check_azure_creds_success",
                label="Check Azure Creds success",
        )

    def resolve_input(self, ctx):
        inputs = types.Object()
        print('%'*100)
        print('check_azure_creds.resolve_input called from ',__file__)
        return types.Property(inputs)
```

- output when resolve_input called:
<img width="1212" alt="image" src="https://github.com/voxel51/fiftyone/assets/30936736/26909c29-b8db-4ede-925f-8dad857c9da7">
 

## Release Notes

- enables importing other plugins from within a plugin as well as other modules within the same plugin
