### PR TITLE
excluding 10 from zero-padding

### DIFF
--- a/app/packages/looker/src/elements/util.ts
+++ b/app/packages/looker/src/elements/util.ts
@@ -83,7 +83,7 @@ const stringifyNumber = function (
   pad: boolean = false
 ): string {
   let str = "";
-  if (pad && number <= 10) {
+  if (pad && number < 10) {
     str += "0" + number;
   } else if (number === 0) {
     str = "0";


### PR DESCRIPTION
## What changes are proposed in this pull request?

not "0" left padding the number 10, to avoid "0.010" after "0.9" and before "0.11"  

## How is this patch tested? If it is not, please explain why.

by rewatching the videos for more than 9 seconds 

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [X] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [X] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
