### PR TITLE
Add support for passing kwargs directly when creating custom runs

### DIFF
--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -3663,13 +3663,16 @@ class SampleCollection(object):
         """
         return fors.Run.list_runs(self, **kwargs)
 
-    def init_run(self):
+    def init_run(self, **kwargs):
         """Initializes a config instance for a new run.
+
+        Args:
+            **kwargs: JSON serializable config parameters
 
         Returns:
             a :class:`fiftyone.core.runs.RunConfig`
         """
-        return fors.RunConfig()
+        return fors.RunConfig(**kwargs)
 
     def register_run(
         self,
@@ -3751,17 +3754,18 @@ class SampleCollection(object):
 
         fors.Run.update_run_config(self, run_key, config)
 
-    def init_run_results(self, run_key):
+    def init_run_results(self, run_key, **kwargs):
         """Initializes a results instance for the run with the given key.
 
         Args:
             run_key: a run key
+            **kwargs: JSON serializable config parameters
 
         Returns:
             a :class:`fiftyone.core.runs.RunResults`
         """
         info = fors.Run.get_run_info(self, run_key)
-        return fors.RunResults(self, info.config, run_key)
+        return fors.RunResults(self, info.config, run_key, **kwargs)
 
     def save_run_results(self, run_key, results, overwrite=True, cache=True):
         """Saves run results for the run with the given key.

--- a/fiftyone/core/runs.py
+++ b/fiftyone/core/runs.py
@@ -110,7 +110,14 @@ class BaseRunConfig(Config):
         Returns:
             a list of attributes
         """
-        return ["type", "method", "cls"] + super().attributes()
+        return ["cls", "type", "method"] + super().attributes()
+
+    @classmethod
+    def _virtual_attributes(cls):
+        """A list of attributes that are serialized but should *not* be treated
+        as parameters when loading the config class from the database.
+        """
+        return ["cls", "type", "method"]
 
     @classmethod
     def from_dict(cls, d):
@@ -123,9 +130,11 @@ class BaseRunConfig(Config):
         Returns:
             a :class:`BaseRunConfig`
         """
-        config_cls = d.pop("cls", None)
-        type = d.pop("type", None)
-        d.pop("method", None)
+        config_cls = d.get("cls", None)
+        type = d.get("type", None)
+
+        for key in cls._virtual_attributes():
+            d.pop(key, None)
 
         try:
             config_cls = etau.get_class(config_cls)
@@ -1070,8 +1079,14 @@ class RunConfig(BaseRunConfig):
     """
 
     def __init__(self, **kwargs):
+        method = None
         for name, value in kwargs.items():
-            setattr(self, name, value)
+            if name == "method":
+                method = value
+            else:
+                setattr(self, name, value)
+
+        self._method = method
 
     @property
     def type(self):
@@ -1079,7 +1094,15 @@ class RunConfig(BaseRunConfig):
 
     @property
     def method(self):
-        return None
+        return self._method
+
+    @method.setter
+    def method(self, method):
+        self._method = method
+
+    @classmethod
+    def _virtual_attributes(cls):
+        return ["cls", "type"]
 
 
 class Run(BaseRun):

--- a/tests/unittests/run_tests.py
+++ b/tests/unittests/run_tests.py
@@ -100,6 +100,35 @@ class RunTests(unittest.TestCase):
         self.assertFalse(dataset2.has_runs)
         self.assertListEqual(dataset2.list_runs(), [])
 
+    @drop_datasets
+    def test_custom_run_kwargs(self):
+        dataset = fo.Dataset()
+        kwargs = {"foo": "bar", "spam": "eggs"}
+
+        config1 = dataset.init_run(**kwargs)
+        dataset.register_run("custom1", config1)
+
+        results1 = dataset.init_run_results("custom1", **kwargs)
+        dataset.save_run_results("custom1", results1)
+
+        config2 = dataset.init_run(method="test", **kwargs)
+        dataset.register_run("custom2", config2)
+
+        results2 = dataset.init_run_results("custom2", **kwargs)
+        dataset.save_run_results("custom2", results2)
+
+        runs = dataset.list_runs()
+        self.assertListEqual(runs, ["custom1", "custom2"])
+
+        info1 = dataset.get_run_info("custom1")
+        self.assertEqual(info1.config.method, None)
+
+        info2 = dataset.get_run_info("custom2")
+        self.assertEqual(info2.config.method, "test")
+
+        runs = dataset.list_runs(method="test")
+        self.assertListEqual(runs, ["custom2"])
+
 
 if __name__ == "__main__":
     fo.config.show_progress_bars = False


### PR DESCRIPTION
1. Adds support for passing kwargs to `init_run()` and `init_run_results()`:

```py
dataset = fo.Dataset()

config = dataset.init_run(foo="bar", spam="eggs")
dataset.register_run("test", config)

results = dataset.init_run_results("test", foo="bar", spam="eggs")
dataset.save_run_results("test", results)
```

2. Adds support for defining the builtin `method` property of custom runs:

```py
import fiftyone as fo

dataset = fo.Dataset()

# Declare that this run is an instance of the "albumentations" method
config = dataset.init_run(method="albumentations")
dataset.register_run("test", config)

# This run has no method declared; 
config = dataset.init_run(foo="bar")
dataset.register_run("other", config)

# Only list runs of the "albumentations" method
print(dataset.list_runs(method="albumentations"))  # ['test']
```

Note that `dataset.list_runs(key=value)` already allows you to search on any arbitrary key, even if it does not exist. The reason that I wanted to specifically allow custom runs to set the `method` property is that other types of runs (annotation, evaluation, brain) use the `method` property to declare their type, ie `method={"similarity", "visualization"}` for brain runs. So, for consistency, it's nice to be able to set the `method` property for custom runs.
