### PR TITLE
fix fetch prefix for loading plugins

### DIFF
--- a/app/packages/plugins/src/index.ts
+++ b/app/packages/plugins/src/index.ts
@@ -1,7 +1,7 @@
 import { useOperators } from "@fiftyone/operators";
 import * as fos from "@fiftyone/state";
 import * as fou from "@fiftyone/utilities";
-import { getFetchFunction, getFetchOrigin } from "@fiftyone/utilities";
+import { getFetchFunction, getFetchParameters } from "@fiftyone/utilities";
 import * as _ from "lodash";
 import React, { FunctionComponent, useEffect, useMemo, useState } from "react";
 import * as recoil from "recoil";
@@ -96,6 +96,7 @@ class PluginDefinition {
 
 export async function loadPlugins() {
   const plugins = await fetchPluginsMetadata();
+  const { pathPrefix } = getFetchParameters();
   for (const plugin of plugins) {
     usingRegistry().registerPluginDefinition(plugin);
     if (plugin.hasJS) {
@@ -106,7 +107,7 @@ export async function loadPlugins() {
         continue;
       }
       try {
-        await loadScript(name, `${getFetchOrigin()}${scriptPath}`);
+        await loadScript(name, pathPrefix + scriptPath);
       } catch (e) {
         console.error(`Plugin "${name}": failed to load!`);
         console.error(e);


### PR DESCRIPTION
## What changes are proposed in this pull request?

fix fetch prefix being omitted when loading plugins from fiftyone server in a prefixed environment

## How is this patch tested? If it is not, please explain why.

By verifying JS plugins load in both prefixed and non-prefixed environment

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

Fix JavaScript plugins not loading in Fiftyone Teams

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
