### PR TITLE
Fix multi PCD groups in the modal

### DIFF
--- a/app/packages/core/src/components/Sidebar/Entries/PathValueEntry.tsx
+++ b/app/packages/core/src/components/Sidebar/Entries/PathValueEntry.tsx
@@ -296,7 +296,7 @@ const SlicesLoadable = ({ path }: { path: string }) => {
           >
             <div style={{ color: theme.text.secondary }}>{slice}</div>
             <div
-              data-cy={`sidebar-entry-${path}`}
+              data-cy={`sidebar-entry-${slice}-${path}`}
               style={{
                 ...add,
                 flex: 1,

--- a/app/packages/core/src/components/Sidebar/Entries/PathValueEntry.tsx
+++ b/app/packages/core/src/components/Sidebar/Entries/PathValueEntry.tsx
@@ -333,16 +333,16 @@ const useSlicesData = <T extends unknown>(path: string) => {
 
   const data = { ...loadable.contents };
 
-  let field = useRecoilValue(fos.field(keys[0]));
+  const target = useRecoilValue(fos.field(keys[0]));
   slices.forEach((slice) => {
     let sliceData = data[slice].sample;
+    let field = target;
 
     for (let index = 0; index < keys.length; index++) {
       if (!sliceData) {
         break;
       }
       const key = keys[index];
-
       sliceData = sliceData[field?.dbField || key];
 
       if (keys[index + 1]) {

--- a/app/packages/looker-3d/src/action-bar/SliceSelector.tsx
+++ b/app/packages/looker-3d/src/action-bar/SliceSelector.tsx
@@ -43,7 +43,10 @@ export const SliceSelector = () => {
 
   return (
     <>
-      <ActionItem title="Select point clouds">
+      <ActionItem
+        data-cy={"looker3d-select-slices"}
+        title="Select point clouds"
+      >
         <div onClick={handleActionClick}>{activeSlicesLabel}</div>
       </ActionItem>
 
@@ -70,7 +73,7 @@ const PcdsSelector = () => {
   return (
     <ActionPopOver>
       <PopoutSectionTitle>Select point clouds</PopoutSectionTitle>
-      <div>
+      <div data-cy={"looker3d-slice-checkboxes"}>
         {allPcdSlices.map((slice) => {
           return (
             <Checkbox

--- a/app/packages/state/src/recoil/groups.ts
+++ b/app/packages/state/src/recoil/groups.ts
@@ -544,7 +544,9 @@ export const activeModalSample = selector({
   key: "activeModalSample",
   get: ({ get }) => {
     if (get(pinned3d)) {
-      return get(activePcdSlicesToSampleMap)[get(pinned3DSampleSlice)]?.sample;
+      const slices = get(activePcdSlices);
+      const key = slices.length === 1 ? slices[0] : get(pinned3DSampleSlice);
+      return get(activePcdSlicesToSampleMap)[key]?.sample;
     }
 
     return get(modalSample).sample;

--- a/e2e-pw/src/oss/poms/modal/index.ts
+++ b/e2e-pw/src/oss/poms/modal/index.ts
@@ -45,6 +45,10 @@ export class ModalPom {
     return this.locator.getByTestId("looker3d");
   }
 
+  get looker3dActionBar() {
+    return this.locator.getByTestId("looker3d-action-bar");
+  }
+
   get carousel() {
     return this.locator.getByTestId("group-carousel");
   }
@@ -189,6 +193,17 @@ export class ModalPom {
 
   async clickOnLooker3d() {
     return this.looker3d.click();
+  }
+
+  async toggleLooker3dSlice(slice: string) {
+    await this.looker3dActionBar.getByTestId("looker3d-select-slices").click();
+
+    await this.looker3dActionBar
+      .getByTestId("looker3d-slice-checkboxes")
+      .getByTestId(`checkbox-${slice}`)
+      .click();
+
+    await this.clickOnLooker3d();
   }
 
   async clickOnLooker() {

--- a/e2e-pw/src/oss/specs/groups/modal-multi-pcd.spec.ts
+++ b/e2e-pw/src/oss/specs/groups/modal-multi-pcd.spec.ts
@@ -12,7 +12,6 @@ const test = base.extend<{ grid: GridPom; modal: ModalPom }>({
   },
 });
 
-// todo: skipping pcd because slice navigation behavior is different
 const datasetName = getUniqueDatasetNameWithPrefix(`modal-multi-pcd`);
 
 test.beforeAll(async ({ fiftyoneLoader }) => {

--- a/e2e-pw/src/oss/specs/groups/modal-multi-pcd.spec.ts
+++ b/e2e-pw/src/oss/specs/groups/modal-multi-pcd.spec.ts
@@ -1,0 +1,55 @@
+import { test as base } from "src/oss/fixtures";
+import { GridPom } from "src/oss/poms/grid";
+import { ModalPom } from "src/oss/poms/modal";
+import { getUniqueDatasetNameWithPrefix } from "src/oss/utils";
+
+const test = base.extend<{ grid: GridPom; modal: ModalPom }>({
+  grid: async ({ page, eventUtils }, use) => {
+    await use(new GridPom(page, eventUtils));
+  },
+  modal: async ({ page, eventUtils }, use) => {
+    await use(new ModalPom(page, eventUtils));
+  },
+});
+
+// todo: skipping pcd because slice navigation behavior is different
+const datasetName = getUniqueDatasetNameWithPrefix(`modal-multi-pcd`);
+
+test.beforeAll(async ({ fiftyoneLoader }) => {
+  await fiftyoneLoader.executePythonCode(`
+    import fiftyone.zoo as foz
+
+    dataset = foz.load_zoo_dataset(
+        "quickstart-groups", dataset_name="${datasetName}", max_samples=3
+    )
+    dataset.persistent = True
+    dataset.group_slice = "pcd"
+    extra = dataset.first().copy()
+    extra.group.name = "extra"
+    dataset.add_sample(extra)`);
+});
+
+test.beforeEach(async ({ page, fiftyoneLoader }) => {
+  await fiftyoneLoader.waitUntilGridVisible(page, datasetName);
+});
+
+test.describe("multi-pcd", () => {
+  test("multi-pcd slice in modal", async ({ grid, modal }) => {
+    await grid.openFirstSample();
+    await modal.group.toggleMedia("carousel");
+    await modal.group.toggleMedia("viewer");
+    await modal.clickOnLooker3d();
+
+    await modal.toggleLooker3dSlice("extra");
+
+    await modal.sidebar.assert.verifySidebarEntryText("pcd-group.name", "pcd");
+    await modal.sidebar.assert.verifySidebarEntryText(
+      "extra-group.name",
+      "extra"
+    );
+
+    await modal.toggleLooker3dSlice("pcd");
+
+    await modal.sidebar.assert.verifySidebarEntryText("group.name", "extra");
+  });
+});


### PR DESCRIPTION
Fixes non-default pcd slice rendering in the modal
```py
import fiftyone.zoo as foz

dataset = foz.load_zoo_dataset("quickstart-groups", max_samples=3)
dataset.persistent = True
dataset.group_slice = "pcd"
extra = dataset.first().copy()
extra.group.name = "extra"
dataset.add_sample(extra)
```
### Before


https://github.com/voxel51/fiftyone/assets/19821840/ea703ee5-cfd9-4193-a53a-f745a4a866f3



### After


https://github.com/voxel51/fiftyone/assets/19821840/6ab0b721-9a43-4054-af8d-9c0638d3d018

