### PR TITLE
Fix dockerfile deployment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,3 @@
-*
+tests
+docs
 !Dockerfile
-!dist

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,2 @@
 tests
-docs
 !Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -94,8 +94,8 @@ RUN pip --no-cache-dir install --upgrade pip setuptools wheel ipython
 # Install FiftyOne from source
 #
 
-COPY dist dist
-RUN pip --no-cache-dir install dist/*.whl && rm -rf dist
+COPY . dist
+RUN pip --no-cache-dir install dist/. && rm -rf dist
 
 # Use this instead if you want the latest FiftyOne release
 # RUN pip --no-cache-dir install fiftyone

--- a/Dockerfile
+++ b/Dockerfile
@@ -116,8 +116,4 @@ ENV FIFTYONE_DATABASE_DIR=${ROOT_DIR}/db \
 #
 # Default behavior
 #
-
-CMD ipython
-
-# Use this if you want the default behavior to instead be to launch the App
-# CMD python /usr/local/lib/python/dist-packages/fiftyone/server/main.py --port 5151
+CMD python /usr/local/lib/python/dist-packages/fiftyone/server/main.py --port 5151


### PR DESCRIPTION
## What changes are proposed in this pull request?

Following the documentation (https://docs.voxel51.com/environments/index.html#docker), while building a docker image with the provided ```Dockerfile```, the process fails when it attempts to copy a ```dist``` folder that is not present in the current directory.
With this, the entire repository will be copied into the container and will then be deleted once it is installed.

In addition, i propose to change the entrypoint of the dockerfile in order to launch the server directly instead of running ipython. This way, anyone can launch a voxel instance using docker compose just by pointing the ```build``` entry to the Fiftyone repository.

## How is this patch tested? If it is not, please explain why.

Just contains changes to the ```Dockerfile``` and ```.dockerignore``` thus i don't think there are currently any automated tests for this.
I tested the build myself in a local environment with docker compose.

## Release Notes

Fix issue on building a docker image with the provided Dockerfile.

### Is this a user-facing change that should be mentioned in the release notes?

-   [X] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.
