### PR TITLE
Shuffle Stage Random Number Bug

### DIFF
--- a/fiftyone/core/stages.py
+++ b/fiftyone/core/stages.py
@@ -6669,7 +6669,7 @@ class Shuffle(ViewStage):
 
     def __init__(self, seed=None, _randint=None):
         self._seed = seed
-        self._randint = _randint or _get_rng(seed).randint(1e7, 1e10)
+        self._randint = _randint or _get_rng(seed).randint(int(1e7), int(1e10))
 
     @property
     def seed(self):
@@ -7322,7 +7322,7 @@ class Take(ViewStage):
     def __init__(self, size, seed=None, _randint=None):
         self._seed = seed
         self._size = size
-        self._randint = _randint or _get_rng(seed).randint(1e7, 1e10)
+        self._randint = _randint or _get_rng(seed).randint(int(1e7), int(1e10))
 
     @property
     def size(self):


### PR DESCRIPTION
## What changes are proposed in this pull request?

Cast floats to ints to fix https://github.com/voxel51/fiftyone/issues/4051

## How is this patch tested? If it is not, please explain why.

Verified that the bug in https://github.com/voxel51/fiftyone/issues/4051 has been resolved with updated source.  I could not find existing test code for `stages.py`, would be happy to amend this PR to begin them.

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
