### PR TITLE
Plugin Utils for getting, setting, and listing views

### DIFF
--- a/fiftyone/plugins/utils.py
+++ b/fiftyone/plugins/utils.py
@@ -5,11 +5,13 @@ FiftyOne plugin utilities.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+from bson import json_util
 import logging
 import multiprocessing.dummy
 import os
 
 from bs4 import BeautifulSoup
+import json
 import yaml
 
 import fiftyone.core.utils as fou
@@ -268,3 +270,14 @@ def _list_target_views(ctx, inputs):
         )
     else:
         ctx.params["target"] = "DATASET"
+
+
+def _serialize_view(view):
+    return json.loads(json_util.dumps(view._serialize()))
+
+
+def _set_view(ctx, view):
+    ctx.trigger(
+        "set_view",
+        params=dict(view=_serialize_view(view)),
+    )

--- a/fiftyone/plugins/utils.py
+++ b/fiftyone/plugins/utils.py
@@ -225,6 +225,19 @@ def _do_get_plugin_info(task):
 
 
 def get_target_view(ctx, target):
+    """
+    Get the target view for the current context. This is a helper function that
+    returns the view based on the `target` parameter. To be used in conjunction
+    with `list_target_views()`.
+
+    Args:
+        ctx: the current context
+        target: the target view
+
+    Returns:
+        the target view
+
+    """
     if target == "SELECTED_SAMPLES":
         return ctx.view.select(ctx.selected)
 
@@ -235,6 +248,21 @@ def get_target_view(ctx, target):
 
 
 def list_target_views(ctx, inputs):
+    """
+    List the available target views for the current context. This is a helper
+    function that sets the `target` parameter based on the current context. Use
+    it in the `inputs` method of a plugin to allow the user to select the target
+    view from selected samples, the current view, or the entire dataset. To be
+    used in conjunction with `get_target_view()`.
+
+    Args:
+        ctx: the current context
+        inputs: the inputs object
+
+    Returns:
+        None
+
+    """
     has_view = ctx.view != ctx.dataset.view()
     has_selected = bool(ctx.selected)
     default_target = "DATASET"
@@ -277,6 +305,19 @@ def _serialize_view(view):
 
 
 def set_view(ctx, view):
+    """
+    Set the view of the current context. This is a helper function that
+    triggers the `set_view` event. It performs serialization of the view
+    before triggering the event.
+
+    Args:
+        ctx: the current context
+        view: the view to set
+
+    Returns:
+        None
+
+    """
     ctx.trigger(
         "set_view",
         params=dict(view=_serialize_view(view)),

--- a/fiftyone/plugins/utils.py
+++ b/fiftyone/plugins/utils.py
@@ -224,7 +224,7 @@ def _do_get_plugin_info(task):
         logger.debug("Failed to retrieve plugin info for %s: %s", spec, e)
 
 
-def _get_target_view(ctx, target):
+def get_target_view(ctx, target):
     if target == "SELECTED_SAMPLES":
         return ctx.view.select(ctx.selected)
 
@@ -234,7 +234,7 @@ def _get_target_view(ctx, target):
     return ctx.view
 
 
-def _list_target_views(ctx, inputs):
+def list_target_views(ctx, inputs):
     has_view = ctx.view != ctx.dataset.view()
     has_selected = bool(ctx.selected)
     default_target = "DATASET"
@@ -243,14 +243,14 @@ def _list_target_views(ctx, inputs):
         target_choices.add_choice(
             "DATASET",
             label="Entire dataset",
-            description="Run model on the entire dataset",
+            description="Run on the entire dataset",
         )
 
         if has_view:
             target_choices.add_choice(
                 "CURRENT_VIEW",
                 label="Current view",
-                description="Run model on the current view",
+                description="Run on the current view",
             )
             default_target = "CURRENT_VIEW"
 
@@ -258,7 +258,7 @@ def _list_target_views(ctx, inputs):
             target_choices.add_choice(
                 "SELECTED_SAMPLES",
                 label="Selected samples",
-                description="Run model on the selected samples",
+                description="Run on the selected samples",
             )
             default_target = "SELECTED_SAMPLES"
 
@@ -276,7 +276,7 @@ def _serialize_view(view):
     return json.loads(json_util.dumps(view._serialize()))
 
 
-def _set_view(ctx, view):
+def set_view(ctx, view):
     ctx.trigger(
         "set_view",
         params=dict(view=_serialize_view(view)),


### PR DESCRIPTION
Implements 3 utility functions for plugins:

1. `list_target_views()`: adds target view choices to inputs
2. `get_target_view()`: decodes user's choice from `list_target_views()`
3. `set_view()`: wrapper for `ctx.trigger()` with `set_view` operator, utilizing serialization

Usage:

```py

import fiftyone as fo
import fiftyone.operators as foo
from fiftyone.operators import types
import fiftyone.plugins.utils as fopu

class MyOperator(foo.Operator):
    ....
 
    def resolve_input(self, ctx):
       inputs = types.Object()
       ....
       fopu.list_target_views(ctx, inputs)
       ....

    def execute(self, ctx):
       ....
       target_view = fopu.get_target_view(ctx, target)
       ....
       view = ...
       fopu.set_view(ctx, view)
```

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [x] Other
