### PR TITLE
WIP: add operations object to ctx

### DIFF
--- a/fiftyone/operators/executor.py
+++ b/fiftyone/operators/executor.py
@@ -23,6 +23,7 @@ from fiftyone.plugins.secrets import PluginSecretsResolver, SecretsDictionary
 from .decorators import coroutine_timeout
 from .message import GeneratedMessage, MessageType
 from .registry import OperatorRegistry
+from .operations import Operations
 
 logger = logging.getLogger(__name__)
 
@@ -429,6 +430,7 @@ class ExecutionContext(object):
 
         self._dataset = None
         self._view = None
+        self._ops = Operations(self)
 
         self._set_progress = set_progress
         self._delegated_operation_id = delegated_operation_id
@@ -558,6 +560,11 @@ class ExecutionContext(object):
             resolver_fn=self._secrets_client.get_secret_sync,
             required_keys=self._required_secret_keys,
         )
+
+    @property
+    def ops(self):
+        """A :class:`fiftyone.operators.Operations` instance."""
+        return self._ops
 
     def secret(self, key):
         """Retrieves the secret with the given key.

--- a/fiftyone/operators/operations.py
+++ b/fiftyone/operators/operations.py
@@ -1,0 +1,27 @@
+import json
+from bson import json_util
+
+
+class Operations(object):
+    def __init__(self, ctx):
+        self._ctx = ctx
+
+    """
+    Call the "set_view" operator. This operator sets the view of the FiftyOne App.
+
+    Args:
+        ctx: the current context
+        view: the view to set
+    Returns:
+        The :class:`fiftyone.operators.message.GeneratedMessage` object
+    """
+
+    def set_view(self, view):
+        return self._ctx.trigger(
+            "set_view",
+            params=dict(view=_serialize_view(view)),
+        )
+
+
+def _serialize_view(view):
+    return json.loads(json_util.dumps(view._serialize()))


### PR DESCRIPTION
Adds a new collection of methods to the `ctx` via `ctx.ops`. This should eventually contain all built in operators - both JS and python.