### PR TITLE
Fix several spelling errors in the documentation

### DIFF
--- a/docs/source/user_guide/annotation.rst
+++ b/docs/source/user_guide/annotation.rst
@@ -235,7 +235,7 @@ Alternatively, you can more permanently configure your backend(s) via your
 Annotation config
 _________________
 
-FiftyOne provides an annnotation config that you can use to either temporarily
+FiftyOne provides an annotation config that you can use to either temporarily
 or permanently configure the behavior of the annotation API.
 
 Viewing your config
@@ -331,7 +331,7 @@ server without changing any other default config settings:
     }
 
 When `fiftyone` is imported, any options from your JSON config are merged into
-the default config, as per the order of precendence described above.
+the default config, as per the order of precedence described above.
 
 .. note::
 
@@ -746,8 +746,8 @@ types like lists, dictionaries, and arrays will be omitted.
 Restricting additions, deletions, and edits
 -------------------------------------------
 
-When you create annotation runs that invovle editing existing label fields, you
-can optionally specify that certain changes are not alllowed by passing the
+When you create annotation runs that involve editing existing label fields, you
+can optionally specify that certain changes are not allowed by passing the
 following flags to
 :meth:`annotate() <fiftyone.core.collections.SampleCollection.annotate>`:
 

--- a/docs/source/user_guide/app.rst
+++ b/docs/source/user_guide/app.rst
@@ -167,7 +167,7 @@ Remote sessions
 _______________
 
 If your data is stored on a remote machine, you can forward a session from
-the remote machine to your local machine and seemlessly browse your remote
+the remote machine to your local machine and seamlessly browse your remote
 dataset from you web browser.
 
 Check out the :ref:`environments page <environments>` for more information on
@@ -1099,7 +1099,7 @@ customizing the rendering of your labels, including whether to show object
 labels, confidences, or the tooltip. The default settings for these parameters
 can be configured via the :ref:`App config <app-config>`.
 
-Keyboard shortcuts are availble for almost every action. Click the `?` icon
+Keyboard shortcuts are available for almost every action. Click the `?` icon
 in the controls HUD or use the `?` keyboard shortcut to display the list of
 available actions and their associated hotkeys.
 

--- a/docs/source/user_guide/basics.rst
+++ b/docs/source/user_guide/basics.rst
@@ -152,7 +152,7 @@ Custom fields can contain any Python primitive data type:
 -   |ListField|: contains Python `list` instances
 -   |DictField|: contains Python `dict` instances
 
-The elements of list and dict fields may be homogenous or heterogeneous, and
+The elements of list and dict fields may be homogeneous or heterogeneous, and
 may even contain nested lists and dicts. Fields can also contain more complex
 data types like :ref:`labels <using-labels>`.
 
@@ -377,7 +377,7 @@ Dataset views are a powerful tool for exploring your datasets. You can use
 datasets to perform the analysis that you need.
 
 .. custombutton::
-    :button_text: Get a full walkthough of dataset views
+    :button_text: Get a full walkthrough of dataset views
     :button_link: using_views.html
 
 .. code-block:: python

--- a/docs/source/user_guide/brain.rst
+++ b/docs/source/user_guide/brain.rst
@@ -1955,7 +1955,7 @@ config settings:
     }
 
 When `fiftyone.brain` is imported, any options from your JSON config are merged
-into the default config, as per the order of precendence described above.
+into the default config, as per the order of precedence described above.
 
 .. note::
 

--- a/docs/source/user_guide/config.rst
+++ b/docs/source/user_guide/config.rst
@@ -123,7 +123,7 @@ FiftyOne supports the configuration options described below:
 |                               |                                     |                               | packages. See :ref:`loading zoo models <model-zoo-load>` for an example usage.         |
 +-------------------------------+-------------------------------------+-------------------------------+----------------------------------------------------------------------------------------+
 | `show_progress_bars`          | `FIFTYONE_SHOW_PROGRESS_BARS`       | `True`                        | Controls whether progress bars are printed to the terminal when performing             |
-|                               |                                     |                               | operations such reading/writing large datasets or activiating FiftyOne                 |
+|                               |                                     |                               | operations such reading/writing large datasets or activating FiftyOne                 |
 |                               |                                     |                               | Brain methods on datasets.                                                             |
 +-------------------------------+-------------------------------------+-------------------------------+----------------------------------------------------------------------------------------+
 | `timezone`                    | `FIFTYONE_TIMEZONE`                 | `None`                        | An optional timzone string. If provided, all datetimes read from FiftyOne datasets     |
@@ -479,7 +479,7 @@ Restricting migrations
 
 You can use the `database_admin` config setting to control whether a client is
 allowed to upgrade/downgrade your FiftyOne database. The default is `True`,
-which means that upgrades are automatically peformed when you connect to your
+which means that upgrades are automatically performed when you connect to your
 database with newer Python client versions.
 
 If you set `database_admin` to `False`, your client will **never** cause the

--- a/docs/source/user_guide/evaluation.rst
+++ b/docs/source/user_guide/evaluation.rst
@@ -721,7 +721,7 @@ calculated:
 
 -   For object detections, IoUs are computed between each pair of bounding boxes
 -   For instance segmentations and polygons, IoUs are computed between the
-    polgyonal shapes rather than their rectangular bounding boxes
+    polygonal shapes rather than their rectangular bounding boxes
 -   For keypoint tasks,
     `object keypoint similarity <https://cocodataset.org/#keypoints-eval>`_
     is computed for each pair of objects, using the extent of the ground truth
@@ -2401,7 +2401,7 @@ evaluation backend without changing any other default config settings:
     }
 
 When `fiftyone` is imported, any options from your JSON config are merged into
-the default config, as per the order of precendence described above.
+the default config, as per the order of precedence described above.
 
 .. note::
 

--- a/docs/source/user_guide/export_datasets.rst
+++ b/docs/source/user_guide/export_datasets.rst
@@ -1945,7 +1945,7 @@ the `labels_path` parameter instead of `export_dir`:
         LABELS_PATH=/path/for/voc-labels
         LABEL_FIELD=ground_truth  # for example
 
-        # Export labaels
+        # Export labels
         fiftyone datasets export $NAME \
             --label-field $LABEL_FIELD \
             --type fiftyone.types.VOCDetectionDataset \
@@ -2567,8 +2567,8 @@ Datasets of this type are exported in the following format:
 where `labels/` contains the semantic segmentations stored as images.
 
 By default, the masks will be stored as PNG images, but you can customize this
-by pasing the optional `mask_format` parameter. The masks will be stored as 8
-bit images if they contain at most 256 classes, otherise 16 bits will be used.
+by passing the optional `mask_format` parameter. The masks will be stored as 8
+bit images if they contain at most 256 classes, otherwise 16 bits will be used.
 
 Unlabeled images have no corresponding file in `labels/`.
 

--- a/docs/source/user_guide/plots.rst
+++ b/docs/source/user_guide/plots.rst
@@ -967,7 +967,7 @@ cells in which they were defined and shown.
 
     :meth:`session.freeze() <fiftyone.core.session.Session.freeze>` and
     :meth:`plot.freeze() <fiftyone.core.plots.base.ResponsivePlot.freeze>` are
-    only appliclable when working in notebook contexts.
+    only applicable when working in notebook contexts.
 
 .. _saving-plots:
 

--- a/docs/source/user_guide/using_aggregations.rst
+++ b/docs/source/user_guide/using_aggregations.rst
@@ -559,7 +559,7 @@ The example below demonstrates this capability:
     **Frame fields:** When you write an aggregation that refers to a
     frame-level field of a video dataset; i.e.,
     ``frames.classification.label`` is automatically coerced to
-    ``frames[].classifcation.label`` if necessary.
+    ``frames[].classification.label`` if necessary.
 
     **Embedded list fields:** When you write an aggregation that refers to a
     list attribute that is declared on a |Sample|, |Frame|, or |Label| class,

--- a/docs/source/user_guide/using_datasets.rst
+++ b/docs/source/user_guide/using_datasets.rst
@@ -2943,7 +2943,7 @@ dataset and configuring the App's colorscale in various ways on-the-fly:
 .. note::
 
     Did you know? You customize your App config in various ways, from
-    environment varibables to directly editing a |Session| object's config.
+    environment variables to directly editing a |Session| object's config.
     See :ref:`this page <configuring-fiftyone-app>` for more details.
 
 .. _temporal-detection:
@@ -2951,7 +2951,7 @@ dataset and configuring the App's colorscale in various ways on-the-fly:
 Temporal detection
 ------------------
 
-The |TemporalDetection| class represents an event occuring during a specified
+The |TemporalDetection| class represents an event occurring during a specified
 range of frames in a video.
 
 The :attr:`label <fiftyone.core.labels.TemporalDetection.label>` attribute
@@ -3198,7 +3198,7 @@ properties:
 
 If you have multiple geometries of each type that you wish to store on a single
 sample, then you can use the |GeoLocations| class and its appropriate
-properites to do so.
+properties to do so.
 
 .. code-block:: python
     :linenos:
@@ -3898,7 +3898,7 @@ The simplest way to define custom embedded documents on your datasets is to
 declare empty |DynamicEmbeddedDocument| field(s) and then incrementally
 populate new :ref:`dynamic attributes <dynamic-attributes>` as needed.
 
-To illusrate, let's start by defining an empty embedded document field:
+To illustrate, let's start by defining an empty embedded document field:
 
 .. code-block:: python
     :linenos:

--- a/docs/source/user_guide/using_views.rst
+++ b/docs/source/user_guide/using_views.rst
@@ -93,7 +93,7 @@ Or, you can access individual samples in a view by their ID or filepath:
 .. note::
 
     Accessing samples in a |DatasetView| returns |SampleView| objects, not
-    |Sample| objects. The two classes are largely interchangable, but
+    |Sample| objects. The two classes are largely interchangeable, but
     |SampleView| provides some extra features. See
     :ref:`filtering sample contents <filtering-sample-contents>` for more
     details.
@@ -708,7 +708,7 @@ stage to filter the contents of arbitrarily-typed fields:
     When you create a |DatasetView| that contains filtered detections or
     classifications, the other labels are not removed from the source dataset,
     even if you :meth:`save() <fiftyone.core.sample.Sample.save>` a
-    |SampleView| after modifying the filtered detections. This is becauase each
+    |SampleView| after modifying the filtered detections. This is because each
     label is updated individually, and other labels in the field are left
     unchanged.
 
@@ -1111,7 +1111,7 @@ detection dataset:
 
 .. note::
 
-    You can pass the optional `other_fields` pararmeter to
+    You can pass the optional `other_fields` parameter to
     :meth:`to_patches() <fiftyone.core.collections.SampleCollection.to_patches>`
     to specify additional read-only sample-level fields that each patch should
     include from their parent samples.
@@ -1296,7 +1296,7 @@ ___________
 
 Most view stages naturally support video datasets. For example, stages that
 refer to fields can be applied to the frame-level fields of video samples by
-prepending ``"frames."`` to the relevent parameters:
+prepending ``"frames."`` to the relevant parameters:
 
 .. code-block:: python
     :linenos:
@@ -1548,7 +1548,7 @@ constructing frame expressions.
 
 .. note::
 
-    You can pass optional `tol` and `min_len` pararmeters to
+    You can pass optional `tol` and `min_len` parameters to
     :meth:`to_clips() <fiftyone.core.collections.SampleCollection.to_clips>` to
     configure a missing frame tolerance and minimum length for clips generated
     from frame-level fields or expressions.
@@ -1652,7 +1652,7 @@ as shown below:
 
 .. warning::
 
-    Trajectory views can contain signficantly more frames than their source
+    Trajectory views can contain significantly more frames than their source
     collection, since the number of frames is now `O(# boxes)` rather than
     `O(# video frames)`.
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

Several clear spelling mistakes in the documentation are fixed.

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [x] Documentation: FiftyOne documentation changes
-   [ ] Other
