### PR TITLE
check if view is group before assigning slice

### DIFF
--- a/fiftyone/server/routes/frames.py
+++ b/fiftyone/server/routes/frames.py
@@ -15,6 +15,7 @@ import fiftyone.core.odm as foo
 import fiftyone.core.view as fov
 
 from fiftyone.server.decorators import route
+import fiftyone.core.media as fom
 import fiftyone.server.view as fosv
 
 
@@ -33,7 +34,7 @@ class Frames(HTTPEndpoint):
         view = fosv.get_view(dataset, stages=stages, extended_stages=extended)
         view = fov.make_optimized_select_view(view, sample_id)
 
-        if group_slice is not None:
+        if view.media_type == fom.GROUP and group_slice is not None:
             view.group_slice = group_slice
 
         end_frame = min(num_frames + start_frame, frame_count)


### PR DESCRIPTION
This PR makes sure that for grouped datasets with videos, if `SelectGroupSlices` view stage is applied with only one slice, the resulting view is only assigned `group_slice` if it's media type is `fom.GROUP`.

```
import fiftyone as fo
import fiftyone.zoo as foz

dataset = fo.Dataset("video-slice-bug")

# qsv = fo.load_dataset("quickstart-video")
qsv = foz.load_zoo_dataset("quickstart-video", max_samples=1)

group = fo.Group()
sample = fo.Sample(qsv.first().filepath, group=group.element("video"))
dataset.add_sample(sample)

view = dataset.select_group_slices(["video"])
fo.launch_app(view)
```