### PR TITLE
saved views bug fix + e2e fixes

### DIFF
--- a/app/packages/core/src/components/Sidebar/ViewSelection/ViewDialog.tsx
+++ b/app/packages/core/src/components/Sidebar/ViewSelection/ViewDialog.tsx
@@ -194,8 +194,8 @@ export default function ViewDialog(props: Props) {
 
   return (
     <Dialog
+      // might have to disablePortal or disableEnforceFocus if we run into issues
       // see https://github.com/mui/material-ui/issues/10341
-      disablePortal
       open={isOpen}
       onClose={() => {
         setIsOpen(false);

--- a/app/packages/core/src/components/Sidebar/ViewSelection/ViewDialog.tsx
+++ b/app/packages/core/src/components/Sidebar/ViewSelection/ViewDialog.tsx
@@ -194,6 +194,9 @@ export default function ViewDialog(props: Props) {
 
   return (
     <Dialog
+      // see https://github.com/mui/material-ui/issues/10341
+      disablePortal
+      disableEnforceFocus
       open={isOpen}
       onClose={() => {
         setIsOpen(false);

--- a/app/packages/core/src/components/Sidebar/ViewSelection/ViewDialog.tsx
+++ b/app/packages/core/src/components/Sidebar/ViewSelection/ViewDialog.tsx
@@ -196,7 +196,6 @@ export default function ViewDialog(props: Props) {
     <Dialog
       // see https://github.com/mui/material-ui/issues/10341
       disablePortal
-      disableEnforceFocus
       open={isOpen}
       onClose={() => {
         setIsOpen(false);

--- a/e2e-pw/package.json
+++ b/e2e-pw/package.json
@@ -21,7 +21,7 @@
         "wait-on": "^7.2.0"
     },
     "scripts": {
-        "lint": "bash -c 'set +e; eslint --quiet --ignore-pattern *.js .; set -e; tsc --skipLibCheck --sourceMap false'",
+        "lint": "bash -c 'set +e; eslint --quiet --ignore-pattern *.js .; set -e; tsc --skipLibCheck --noImplicitAny --sourceMap false'",
         "unittests": "vitest",
         "check-flaky": "./scripts/check-flaky.sh",
         "kill-port": "./scripts/kill-port.sh",

--- a/e2e-pw/src/oss/poms/color-modal/index.ts
+++ b/e2e-pw/src/oss/poms/color-modal/index.ts
@@ -81,7 +81,7 @@ export class ColorModalPom {
       .click({ force: true });
   }
 
-  async addNewPairs(pairs) {
+  async addNewPairs(pairs: { value: string; color: string }[]) {
     for (let i = 0; i < pairs.length; i++) {
       await this.addANewPair(pairs[i].value, pairs[i].color, i);
     }

--- a/e2e-pw/src/oss/poms/saved-views.ts
+++ b/e2e-pw/src/oss/poms/saved-views.ts
@@ -11,6 +11,15 @@ export type Color =
   | "Orange"
   | "Purple";
 
+export type SaveViewParams = {
+  name: string;
+  description: string;
+  color: Color;
+  id?: number;
+  newColor?: Color;
+  slug?: string;
+};
+
 const defaultColor = "Gray";
 
 export class SavedViewsPom {
@@ -47,14 +56,14 @@ export class SavedViewsPom {
     return this.savedViewOption(slug).getByTestId("btn-edit-selection");
   }
 
-  async saveViewInputs({ name, description, color, newColor }) {
+  async saveViewInputs({ name, description, color, newColor }: SaveViewParams) {
     await this.nameInput().fill(name, { timeout: 2000 });
     await this.descriptionInput().fill(description, { timeout: 2000 });
     await this.colorInput(color).click({ timeout: 2000 });
     await this.colorOption(newColor).click();
   }
 
-  async saveView(view) {
+  async saveView(view: SaveViewParams) {
     await this.openCreateModal();
     await this.saveViewInputs(view);
     await this.saveButton().click();

--- a/e2e-pw/src/oss/specs/groups/ima-vid.spec.ts
+++ b/e2e-pw/src/oss/specs/groups/ima-vid.spec.ts
@@ -8,10 +8,7 @@ import { getUniqueDatasetNameWithPrefix } from "src/oss/utils";
 import { createBlankImage } from "src/shared/media-factory/image";
 
 const NUM_VIDEOS = 2;
-const FRAME_COLORS = {
-  0: "#ff0000",
-  1: "#00ff00",
-};
+const FRAME_COLORS = ["#ff0000", "#00ff00"];
 const NUM_FRAMES_PER_VIDEO = 150;
 
 const datasetName = getUniqueDatasetNameWithPrefix(`group-ima-vid`);

--- a/e2e-pw/src/oss/specs/smoke-tests/saved-views.spec.ts
+++ b/e2e-pw/src/oss/specs/smoke-tests/saved-views.spec.ts
@@ -1,5 +1,5 @@
 import { test as base, expect } from "src/oss/fixtures";
-import { Color, SavedViewsPom } from "src/oss/poms/saved-views";
+import { Color, SaveViewParams, SavedViewsPom } from "src/oss/poms/saved-views";
 import { getUniqueDatasetNameWithPrefix } from "src/oss/utils";
 
 const ColorList = [
@@ -14,20 +14,20 @@ const ColorList = [
   "Purple",
 ];
 
-export const updatedView = {
+export const updatedView: SaveViewParams = {
   name: "test updated",
   description: "test updated",
   color: "Yellow" as Color,
 };
 
-export const updatedView2 = {
+export const updatedView2: SaveViewParams = {
   name: "test updated 2",
   description: "test updated 2",
   color: "Orange" as Color,
   slug: "test-updated-2",
 };
 
-const testView = {
+const testView: SaveViewParams = {
   id: 0,
   name: "test",
   description: "description",
@@ -36,7 +36,7 @@ const testView = {
   slug: "test",
 };
 
-const testView1 = {
+const testView1: SaveViewParams = {
   id: 1,
   name: "test 1",
   description: "description ",
@@ -45,7 +45,7 @@ const testView1 = {
   slug: "test-1",
 };
 
-const testView2 = {
+const testView2: SaveViewParams = {
   id: 2,
   name: "test 2",
   description: "description 2",
@@ -75,7 +75,7 @@ test.describe("saved views", () => {
     await deleteSavedView(savedViews, updatedView2.slug);
   });
 
-  async function deleteSavedView(savedViews, slug: string) {
+  async function deleteSavedView(savedViews: SavedViewsPom, slug: string) {
     const hasUnsaved = savedViews.canClearView();
     if (!hasUnsaved) {
       await savedViews.clearView();
@@ -89,10 +89,6 @@ test.describe("saved views", () => {
       await savedViews.clickDeleteBtn();
     }
   }
-
-  test("page has the correct title", async ({ page }) => {
-    await expect(page).toHaveTitle(/FiftyOne/);
-  });
 
   test("saved views selector exists", async ({ savedViews }) => {
     await expect(savedViews.selector()).toBeVisible();

--- a/e2e-pw/src/oss/specs/smoke-tests/saved-views.spec.ts
+++ b/e2e-pw/src/oss/specs/smoke-tests/saved-views.spec.ts
@@ -123,7 +123,7 @@ test.describe("saved views", () => {
     await savedViews.assert.verifySaveBtnIsEnabled();
   });
 
-  test.fixme("cancel button clears the inputs", async ({ savedViews }) => {
+  test("cancel button clears the inputs", async ({ savedViews }) => {
     await savedViews.openCreateModal();
 
     await savedViews.nameInput().fill("test");
@@ -141,16 +141,15 @@ test.describe("saved views", () => {
     await savedViews.assert.verifySavedView();
   });
 
-  test.fixme(
-    "clearing a saved view clears the url and view selection",
-    async ({ savedViews }) => {
-      await savedViews.saveView(testView);
-      await savedViews.assert.verifySavedView();
+  test("clearing a saved view clears the url and view selection", async ({
+    savedViews,
+  }) => {
+    await savedViews.saveView(testView);
+    await savedViews.assert.verifySavedView();
 
-      await savedViews.clearView();
-      await savedViews.assert.verifyUnsavedView();
-    }
-  );
+    await savedViews.clearView();
+    await savedViews.assert.verifyUnsavedView();
+  });
 
   test("clicking on the close icon closes the save view modal", async ({
     savedViews,
@@ -176,32 +175,30 @@ test.describe("saved views", () => {
     await savedViews.assert.verifySelectionHasNewOption();
   });
 
-  test.fixme(
-    "saving a view with an already existing name fails",
-    async ({ savedViews }) => {
-      await savedViews.saveView(testView);
-      await savedViews.clearView();
+  test("saving a view with an already existing name fails", async ({
+    savedViews,
+  }) => {
+    await savedViews.saveView(testView);
+    await savedViews.clearView();
 
-      await savedViews.openCreateModal();
-      await savedViews.saveViewInputs(testView);
+    await savedViews.openCreateModal();
+    await savedViews.saveViewInputs(testView);
 
-      await savedViews.assert.verifySaveViewFails();
-    }
-  );
+    await savedViews.assert.verifySaveViewFails();
+  });
 
-  test.fixme(
-    "create and edit modals have the correct titles",
-    async ({ savedViews }) => {
-      await savedViews.openCreateModal();
-      await savedViews.assert.verifyModalTitle("Create view close");
-      await savedViews.closeModalBtn().click();
+  test("create and edit modals have the correct titles", async ({
+    savedViews,
+  }) => {
+    await savedViews.openCreateModal();
+    await savedViews.assert.verifyModalTitle("Create view close");
+    await savedViews.closeModalBtn().click();
 
-      await savedViews.saveView(testView);
-      await savedViews.clickEdit("test");
-      await savedViews.assert.verifyModalTitle("Edit view close");
-      await savedViews.clickCloseModal();
-    }
-  );
+    await savedViews.saveView(testView);
+    await savedViews.clickEdit("test");
+    await savedViews.assert.verifyModalTitle("Edit view close");
+    await savedViews.clickCloseModal();
+  });
 
   test.fixme("searching through saved views works", async ({ savedViews }) => {
     await savedViews.saveView(testView1);
@@ -225,86 +222,82 @@ test.describe("saved views", () => {
     await savedViews.deleteView("test-2");
   });
 
-  test.fixme(
-    "edit modal has a delete button but a create modal does not",
-    async ({ savedViews }) => {
-      await savedViews.openCreateModal();
-      await savedViews.assert.verifyDeleteBtnHidden();
+  test("edit modal has a delete button but a create modal does not", async ({
+    savedViews,
+  }) => {
+    await savedViews.openCreateModal();
+    await savedViews.assert.verifyDeleteBtnHidden();
 
-      await savedViews.closeModalBtn().click();
-      await savedViews.saveView(testView);
+    await savedViews.closeModalBtn().click();
+    await savedViews.saveView(testView);
 
-      await savedViews.clickEdit("test");
-      await savedViews.assert.verifyDeleteBtn();
+    await savedViews.clickEdit("test");
+    await savedViews.assert.verifyDeleteBtn();
 
-      await savedViews.deleteViewClick();
-    }
-  );
+    await savedViews.deleteViewClick();
+  });
 
-  test.fixme(
-    "deleting a saved view clears the URL view parameter and view selection",
-    async ({ savedViews }) => {
-      await savedViews.saveView(testView);
-      await savedViews.clearView();
+  test("deleting a saved view clears the URL view parameter and view selection", async ({
+    savedViews,
+  }) => {
+    await savedViews.saveView(testView);
+    await savedViews.clearView();
 
-      await savedViews.openSelect();
-      await savedViews.assert.verifyViewOption();
+    await savedViews.openSelect();
+    await savedViews.assert.verifyViewOption();
 
-      await savedViews.clickOptionEdit(testView.name);
-      await savedViews.clickDeleteBtn();
+    await savedViews.clickOptionEdit(testView.name);
+    await savedViews.clickDeleteBtn();
 
-      await savedViews.assert.verifyUnsavedView();
-      await savedViews.openCreateModal();
-      await savedViews.assert.verifyViewOptionHidden();
-    }
-  );
+    await savedViews.assert.verifyUnsavedView();
+    await savedViews.openCreateModal();
+    await savedViews.assert.verifyViewOptionHidden();
+  });
 
-  test.fixme(
-    "editing a saved view updates the view's name and description",
-    async ({ savedViews }) => {
-      await savedViews.saveView(testView);
-      await savedViews.clearView();
+  test("editing a saved view updates the view's name and description", async ({
+    savedViews,
+  }) => {
+    await savedViews.saveView(testView);
+    await savedViews.clearView();
 
-      await savedViews.openSelect();
-      await savedViews.clickOptionEdit(testView.name);
-      await savedViews.assert.verifyInput({
-        name: testView.name,
-        description: testView.description,
-        color: testView.newColor,
-      });
+    await savedViews.openSelect();
+    await savedViews.clickOptionEdit(testView.name);
+    await savedViews.assert.verifyInput({
+      name: testView.name,
+      description: testView.description,
+      color: testView.newColor,
+    });
 
-      await savedViews.editView(
-        updatedView2.name,
-        updatedView2.description,
-        "Blue",
-        updatedView2.color
-      );
+    await savedViews.editView(
+      updatedView2.name,
+      updatedView2.description,
+      "Blue",
+      updatedView2.color
+    );
 
-      await savedViews.clickEdit(updatedView2.slug);
-      await savedViews.assert.verifyInputUpdated(updatedView2);
-    }
-  );
+    await savedViews.clickEdit(updatedView2.slug);
+    await savedViews.assert.verifyInputUpdated(updatedView2);
+  });
 
-  test.fixme(
-    "editing a saved view should update the view URL parameter and selection",
-    async ({ savedViews }) => {
-      await savedViews.assert.verifyUnsavedView();
+  test("editing a saved view should update the view URL parameter and selection", async ({
+    savedViews,
+  }) => {
+    await savedViews.assert.verifyUnsavedView();
 
-      await savedViews.saveView(testView);
-      await savedViews.assert.verifySavedView();
+    await savedViews.saveView(testView);
+    await savedViews.assert.verifySavedView();
 
-      await savedViews.clearView();
+    await savedViews.clearView();
 
-      await savedViews.openSelect();
-      await savedViews.clickOptionEdit(testView.name);
-      await savedViews.editView(
-        updatedView2.name,
-        updatedView2.description,
-        "Blue",
-        updatedView2.color
-      );
+    await savedViews.openSelect();
+    await savedViews.clickOptionEdit(testView.name);
+    await savedViews.editView(
+      updatedView2.name,
+      updatedView2.description,
+      "Blue",
+      updatedView2.color
+    );
 
-      await savedViews.assert.verifySavedView("test-updated");
-    }
-  );
+    await savedViews.assert.verifySavedView("test-updated");
+  });
 });

--- a/e2e-pw/src/oss/specs/smoke-tests/saved-views.spec.ts
+++ b/e2e-pw/src/oss/specs/smoke-tests/saved-views.spec.ts
@@ -141,15 +141,16 @@ test.describe("saved views", () => {
     await savedViews.assert.verifySavedView();
   });
 
-  test("clearing a saved view clears the url and view selection", async ({
-    savedViews,
-  }) => {
-    await savedViews.saveView(testView);
-    await savedViews.assert.verifySavedView();
+  test.fixme(
+    "clearing a saved view clears the url and view selection",
+    async ({ savedViews }) => {
+      await savedViews.saveView(testView);
+      await savedViews.assert.verifySavedView();
 
-    await savedViews.clearView();
-    await savedViews.assert.verifyUnsavedView();
-  });
+      await savedViews.clearView();
+      await savedViews.assert.verifyUnsavedView();
+    }
+  );
 
   test("clicking on the close icon closes the save view modal", async ({
     savedViews,
@@ -175,32 +176,34 @@ test.describe("saved views", () => {
     await savedViews.assert.verifySelectionHasNewOption();
   });
 
-  test("saving a view with an already existing name fails", async ({
-    savedViews,
-  }) => {
-    await savedViews.saveView(testView);
-    await savedViews.clearView();
+  test.fixme(
+    "saving a view with an already existing name fails",
+    async ({ savedViews }) => {
+      await savedViews.saveView(testView);
+      await savedViews.clearView();
 
-    await savedViews.openCreateModal();
-    await savedViews.saveViewInputs(testView);
+      await savedViews.openCreateModal();
+      await savedViews.saveViewInputs(testView);
 
-    await savedViews.assert.verifySaveViewFails();
-  });
+      await savedViews.assert.verifySaveViewFails();
+    }
+  );
 
-  test("create and edit modals have the correct titles", async ({
-    savedViews,
-  }) => {
-    await savedViews.openCreateModal();
-    await savedViews.assert.verifyModalTitle("Create view close");
-    await savedViews.closeModalBtn().click();
+  test.fixme(
+    "create and edit modals have the correct titles",
+    async ({ savedViews }) => {
+      await savedViews.openCreateModal();
+      await savedViews.assert.verifyModalTitle("Create view close");
+      await savedViews.closeModalBtn().click();
 
-    await savedViews.saveView(testView);
-    await savedViews.clickEdit("test");
-    await savedViews.assert.verifyModalTitle("Edit view close");
-    await savedViews.clickCloseModal();
-  });
+      await savedViews.saveView(testView);
+      await savedViews.clickEdit("test");
+      await savedViews.assert.verifyModalTitle("Edit view close");
+      await savedViews.clickCloseModal();
+    }
+  );
 
-  test("searching through saved views works", async ({ savedViews }) => {
+  test.fixme("searching through saved views works", async ({ savedViews }) => {
     await savedViews.saveView(testView1);
     await savedViews.clearViewBtn().waitFor({ state: "visible" });
     await savedViews.clearViewBtn().click();
@@ -222,82 +225,86 @@ test.describe("saved views", () => {
     await savedViews.deleteView("test-2");
   });
 
-  test("edit modal has a delete button but a create modal does not", async ({
-    savedViews,
-  }) => {
-    await savedViews.openCreateModal();
-    await savedViews.assert.verifyDeleteBtnHidden();
+  test.fixme(
+    "edit modal has a delete button but a create modal does not",
+    async ({ savedViews }) => {
+      await savedViews.openCreateModal();
+      await savedViews.assert.verifyDeleteBtnHidden();
 
-    await savedViews.closeModalBtn().click();
-    await savedViews.saveView(testView);
+      await savedViews.closeModalBtn().click();
+      await savedViews.saveView(testView);
 
-    await savedViews.clickEdit("test");
-    await savedViews.assert.verifyDeleteBtn();
+      await savedViews.clickEdit("test");
+      await savedViews.assert.verifyDeleteBtn();
 
-    await savedViews.deleteViewClick();
-  });
+      await savedViews.deleteViewClick();
+    }
+  );
 
-  test("deleting a saved view clears the URL view parameter and view selection", async ({
-    savedViews,
-  }) => {
-    await savedViews.saveView(testView);
-    await savedViews.clearView();
+  test.fixme(
+    "deleting a saved view clears the URL view parameter and view selection",
+    async ({ savedViews }) => {
+      await savedViews.saveView(testView);
+      await savedViews.clearView();
 
-    await savedViews.openSelect();
-    await savedViews.assert.verifyViewOption();
+      await savedViews.openSelect();
+      await savedViews.assert.verifyViewOption();
 
-    await savedViews.clickOptionEdit(testView.name);
-    await savedViews.clickDeleteBtn();
+      await savedViews.clickOptionEdit(testView.name);
+      await savedViews.clickDeleteBtn();
 
-    await savedViews.assert.verifyUnsavedView();
-    await savedViews.openCreateModal();
-    await savedViews.assert.verifyViewOptionHidden();
-  });
+      await savedViews.assert.verifyUnsavedView();
+      await savedViews.openCreateModal();
+      await savedViews.assert.verifyViewOptionHidden();
+    }
+  );
 
-  test("editing a saved view updates the view's name and description", async ({
-    savedViews,
-  }) => {
-    await savedViews.saveView(testView);
-    await savedViews.clearView();
+  test.fixme(
+    "editing a saved view updates the view's name and description",
+    async ({ savedViews }) => {
+      await savedViews.saveView(testView);
+      await savedViews.clearView();
 
-    await savedViews.openSelect();
-    await savedViews.clickOptionEdit(testView.name);
-    await savedViews.assert.verifyInput({
-      name: testView.name,
-      description: testView.description,
-      color: testView.newColor,
-    });
+      await savedViews.openSelect();
+      await savedViews.clickOptionEdit(testView.name);
+      await savedViews.assert.verifyInput({
+        name: testView.name,
+        description: testView.description,
+        color: testView.newColor,
+      });
 
-    await savedViews.editView(
-      updatedView2.name,
-      updatedView2.description,
-      "Blue",
-      updatedView2.color
-    );
+      await savedViews.editView(
+        updatedView2.name,
+        updatedView2.description,
+        "Blue",
+        updatedView2.color
+      );
 
-    await savedViews.clickEdit(updatedView2.slug);
-    await savedViews.assert.verifyInputUpdated(updatedView2);
-  });
+      await savedViews.clickEdit(updatedView2.slug);
+      await savedViews.assert.verifyInputUpdated(updatedView2);
+    }
+  );
 
-  test("editing a saved view should update the view URL parameter and selection", async ({
-    savedViews,
-  }) => {
-    await savedViews.assert.verifyUnsavedView();
+  test.fixme(
+    "editing a saved view should update the view URL parameter and selection",
+    async ({ savedViews }) => {
+      await savedViews.assert.verifyUnsavedView();
 
-    await savedViews.saveView(testView);
-    await savedViews.assert.verifySavedView();
+      await savedViews.saveView(testView);
+      await savedViews.assert.verifySavedView();
 
-    await savedViews.clearView();
+      await savedViews.clearView();
 
-    await savedViews.openSelect();
-    await savedViews.clickOptionEdit(testView.name);
-    await savedViews.editView(
-      updatedView2.name,
-      updatedView2.description,
-      "Blue",
-      updatedView2.color
-    );
+      await savedViews.openSelect();
+      await savedViews.clickOptionEdit(testView.name);
+      await savedViews.editView(
+        updatedView2.name,
+        updatedView2.description,
+        "Blue",
+        updatedView2.color
+      );
 
-    await savedViews.assert.verifySavedView("test-updated");
-  });
+      await savedViews.assert.verifySavedView("test-updated");
+    }
+  );
 });

--- a/e2e-pw/src/oss/specs/smoke-tests/saved-views.spec.ts
+++ b/e2e-pw/src/oss/specs/smoke-tests/saved-views.spec.ts
@@ -54,7 +54,7 @@ const testView2: SaveViewParams = {
   slug: "test-2",
 };
 
-const datasetName = getUniqueDatasetNameWithPrefix("smoke-quickstart");
+const datasetName = getUniqueDatasetNameWithPrefix("quickstart-saved-views");
 
 const test = base.extend<{ savedViews: SavedViewsPom }>({
   savedViews: async ({ page }, use) => {
@@ -64,9 +64,15 @@ const test = base.extend<{ savedViews: SavedViewsPom }>({
 
 test.describe("saved views", () => {
   test.beforeAll(async ({ fiftyoneLoader }) => {
-    await fiftyoneLoader.loadZooDataset("quickstart", datasetName, {
-      max_samples: 5,
-    });
+    await fiftyoneLoader.executePythonCode(`
+      import fiftyone as fo
+
+      dataset_name = "${datasetName}"
+      dataset = fo.Dataset(name=dataset_name)
+      dataset.persistent = True
+
+      dataset.add_sample(fo.Sample(filepath="image1.jpg"))
+    `);
   });
 
   test.beforeEach(async ({ page, fiftyoneLoader, savedViews }) => {
@@ -210,6 +216,7 @@ test.describe("saved views", () => {
     await savedViews.assert.verifySearch("test 3", [], ["test-1", "test-2"]);
     await savedViews.assert.verifySearch("test", ["test-1", "test-2"], []);
 
+    await savedViews.openSelect();
     await savedViews.deleteView("test-1");
     await savedViews.selector().click();
     await savedViews.deleteView("test-2");

--- a/e2e-pw/src/oss/specs/smoke-tests/saved-views.spec.ts
+++ b/e2e-pw/src/oss/specs/smoke-tests/saved-views.spec.ts
@@ -123,7 +123,7 @@ test.describe("saved views", () => {
     await savedViews.assert.verifySaveBtnIsEnabled();
   });
 
-  test("cancel button clears the inputs", async ({ savedViews }) => {
+  test.fixme("cancel button clears the inputs", async ({ savedViews }) => {
     await savedViews.openCreateModal();
 
     await savedViews.nameInput().fill("test");

--- a/e2e-pw/src/shared/event-utils/index.ts
+++ b/e2e-pw/src/shared/event-utils/index.ts
@@ -17,6 +17,7 @@ export class EventUtils {
       ({ eventName_, exposedFunctionName_ }) =>
         new Promise<void>((resolve) => {
           const cb = (e: CustomEvent) => {
+            // @ts-expect-error - TS doesn't know that the function is exposed
             if (window[exposedFunctionName_](e)) {
               resolve();
               document.removeEventListener(eventName_, cb);

--- a/e2e-pw/tsconfig.json
+++ b/e2e-pw/tsconfig.json
@@ -4,6 +4,7 @@
         "moduleResolution": "node",
         "esModuleInterop": true,
         "module": "CommonJS",
+        "noImplicitAny": true,
         "lib": ["ES6", "dom", "dom.iterable"],
         "types": ["node"],
         "sourceMap": true,


### PR DESCRIPTION
- Fixed a bug in saved views editor caused by https://github.com/mui/material-ui/issues/10341.
- The editor doesn't work without `disablePortal` prop. On e2e side, because of this change, MUI backdrop intercepts mouse clicks and keypresses, and tests fail. The broken tests in saved views spec have been annotated with `.fixme()` until we we have a fix.
- Update e2e dependencies, run linter, fix type issues, etc.