### PR TITLE
Added an optional argument map_type so that a user can choose between

### DIFF
--- a/fiftyone/core/plots/plotly.py
+++ b/fiftyone/core/plots/plotly.py
@@ -1211,6 +1211,7 @@ def location_scatterplot(
     sizes_title=None,
     edges_title=None,
     show_colorbar_title=None,
+    map_type="roadmap",
     **kwargs,
 ):
     """Generates an interactive scatterplot of the given location coordinates
@@ -1304,6 +1305,8 @@ def location_scatterplot(
             default, a title will be shown only if a value was pasesd to
             ``labels_title`` or an appropriate default can be inferred from
             the ``labels`` parameter
+        map_type ("satellite"): the map type to render. Supported values are
+            ``("roadmap", "satellite")``
         **kwargs: optional keyword arguments for
             :meth:`plotly:plotly.graph_objects.Figure.update_layout`
 
@@ -1413,6 +1416,8 @@ def location_scatterplot(
             edges_title,
             colorbar_title,
         )
+
+    _set_map_type_to_figure(figure, map_type)
 
     figure.update_layout(**_DEFAULT_LAYOUT)
     figure.update_layout(title=title, **kwargs)
@@ -2558,6 +2563,30 @@ def _plot_scatter_numeric(
 
     return figure
 
+def _set_map_type_to_figure(
+    figure, 
+    map_type,
+):
+    if map_type == "satellite":
+        figure.update_layout(mapbox_style="white-bg",
+            mapbox_layers=[
+                {
+                    "below": 'traces',
+                    "sourcetype": "raster",
+                    "sourceattribution": "United States Geological Survey",
+                    "source": [
+                        "https://basemap.nationalmap.gov/arcgis/rest/services/USGSImageryOnly/MapServer/tile/{z}/{y}/{x}"
+                    ]
+                }
+            ],
+            margin={"r":0,"t":0,"l":0,"b":0},
+        )
+    elif map_type == "roadmap":
+        figure.update_layout(mapbox_style="carto-positron")
+    else:
+        figure.update_layout(mapbox_style="carto-positron")
+        msg = "Unsupported map type '%s'; defaulted to 'roadmap'" % map_type
+        warnings.warn(msg)
 
 def _plot_scatter_mapbox_categorical(
     coords,
@@ -2643,7 +2672,6 @@ def _plot_scatter_mapbox_categorical(
 
     zoom, (center_lon, center_lat) = _compute_zoom_center(coords)
     figure.update_layout(
-        mapbox_style="carto-positron",
         mapbox=dict(center=dict(lat=center_lat, lon=center_lon), zoom=zoom),
         legend_title_text=colorbar_title,
         legend_itemsizing="constant",
@@ -2741,7 +2769,6 @@ def _plot_scatter_mapbox_categorical_single_trace(
 
     zoom, (center_lon, center_lat) = _compute_zoom_center(coords)
     figure.update_layout(
-        mapbox_style="carto-positron",
         mapbox=dict(center=dict(lat=center_lat, lon=center_lon), zoom=zoom),
     )
 
@@ -2836,7 +2863,6 @@ def _plot_scatter_mapbox_numeric(
 
     zoom, (center_lon, center_lat) = _compute_zoom_center(coords)
     figure.update_layout(
-        mapbox_style="carto-positron",
         mapbox=dict(center=dict(lat=center_lat, lon=center_lon), zoom=zoom),
     )
 
@@ -2913,7 +2939,6 @@ def _plot_scatter_mapbox_density(
 
     zoom, (center_lon, center_lat) = _compute_zoom_center(coords)
     figure.update_layout(
-        mapbox_style="carto-positron",
         mapbox=dict(center=dict(lat=center_lat, lon=center_lon), zoom=zoom),
     )
 


### PR DESCRIPTION

## What changes are proposed in this pull request?

Add an optional argument named `map_type` to `location_scatterplot()` so that a user can choose between 
  `roadmap` and `satellite`. Currently Fiftyone only supports `roadmap` (carto-positron).

The `satellite` option uses a public USGS imagery map with no token needed (see https://plotly.com/python/mapbox-layers/).

The `map_type` option is added through the following changes:

1. Add a method `_set_map_type_to_figure()` to set `mapbox_style` based on `map_type`.
2. Remove `mapbox_style="carto-positron"`  from `_plot_scatter_mapbox_numeric()`, `_plot_scatter_mapbox_density()`, `_plot_scatter_mapbox_categorical()`, and `_plot_scatter_mapbox_categorical_single_trace()`.
3. Call `_set_map_type_to_figure()` after the invoke of the `_plot_scatter_mapbox_*` methods.

The default value of `map_type` is `roadmap`. If a value other than `roadmap` and `satellite` is supplied by a user, `map_type` is defaulted to `roadmap` and a warning is displayed.

## How is this patch tested? If it is not, please explain why.

Tested `_plot_scatter_mapbox_numeric()`, `_plot_scatter_mapbox_density()`, `_plot_scatter_mapbox_categorical()`, and `_plot_scatter_mapbox_categorical_single_trace()` using the scripts provided in https://docs.voxel51.com/user_guide/plots.html#id7 and by Allen Lee.

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->
Not sure.
-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
