### PR TITLE
Add target view utilities to operators

### DIFF
--- a/fiftyone/operators/executor.py
+++ b/fiftyone/operators/executor.py
@@ -508,12 +508,25 @@ class ExecutionContext(object):
         """The target :class:`fiftyone.core.view.DatasetView` for the operator
         being executed.
         """
-        target = self.request_params.get(param_name, None)
+        target = self.params.get(param_name, None)
         if target == "SELECTED_SAMPLES":
             return self.view.select(self.selected)
         if target == "DATASET":
             return self.dataset
         return self.view
+
+    @property
+    def has_custom_view(self):
+        """Whether the operator has a custom view."""
+        stages = self.request_params.get("view", None)
+        filters = self.request_params.get("filters", None)
+        extended = self.request_params.get("extended", None)
+        has_stages = stages is not None and stages != [] and stages != {}
+        has_filters = filters is not None and filters != [] and filters != {}
+        has_extended = (
+            extended is not None and extended != [] and extended != {}
+        )
+        return has_stages or has_filters or has_extended
 
     @property
     def selected(self):

--- a/fiftyone/operators/executor.py
+++ b/fiftyone/operators/executor.py
@@ -491,6 +491,9 @@ class ExecutionContext(object):
         filters = self.request_params.get("filters", None)
         extended = self.request_params.get("extended", None)
 
+        if dataset is None:
+            return None
+
         self._view = fosv.get_view(
             dataset,
             stages=stages,

--- a/fiftyone/operators/executor.py
+++ b/fiftyone/operators/executor.py
@@ -501,6 +501,17 @@ class ExecutionContext(object):
 
         return self._view
 
+    def target_view(self, param_name="view_target"):
+        """The target :class:`fiftyone.core.view.DatasetView` for the operator
+        being executed.
+        """
+        target = self.request_params.get(param_name, None)
+        if target == "SELECTED_SAMPLES":
+            return self.view.select(self.selected)
+        if target == "DATASET":
+            return self.dataset
+        return self.view
+
     @property
     def selected(self):
         """The list of selected sample IDs (if any)."""

--- a/fiftyone/operators/types.py
+++ b/fiftyone/operators/types.py
@@ -794,7 +794,7 @@ class Choices(View):
 
     def clone(self):
         clone = super().clone()
-        clone.choices = [choice.clone() for choice in self.choices]
+        clone._choices = [choice.clone() for choice in self.choices]
         return clone
 
     def to_json(self):
@@ -1645,6 +1645,14 @@ class PromptView(View):
 
 
 class ViewTargetOptions(object):
+    """Represents the options for a :class:`ViewTargetProperty`.
+
+    Attributes:
+        entire_dataset: a :class:`Choice` for the entire dataset
+        current_view: a :class:`Choice` for the current view
+        selected_samples: a :class:`Choice` for the selected samples
+    """
+
     def __init__(self, choices_view, **kwargs):
         super().__init__(**kwargs)
         self.choices_view = choices_view
@@ -1696,6 +1704,9 @@ class ViewTargetProperty(Property):
 
         # in execute()
         target_view = ctx.target_view()
+
+    Attributes:
+        options: a :class:`ViewTargetOptions` instance
 
     Args:
         ctx: the :class:`fiftyone.operators.ExecutionContext`

--- a/fiftyone/operators/types.py
+++ b/fiftyone/operators/types.py
@@ -271,6 +271,33 @@ class Object(BaseType):
         return clone
 
     def view_target(self, ctx, name="view_target", view_type=None, **kwargs):
+        """Defines a view target property.
+
+        Examples::
+
+
+        import fiftyone.operators.types as types
+
+        # in resolve_input
+        inputs = types.Object()
+        vt = inputs.view_target(ctx)
+        # or add the property directly
+        # vt = types.ViewTargetProperty(ctx)
+        # inputs.add_property("view_target", vt)
+        return types.Property(inputs)
+
+        # in execute()
+        target_view = ctx.target_view()
+
+        Args:
+            ctx: the :class:`fiftyone.operators.ExecutionContext`
+            name: the name of the property
+            view_type (RadioGroup): the view type to use (RadioGroup, Dropdown,
+                etc.)
+
+        Returns:
+            a :class:`ViewTargetProperty`
+        """
         view_type = view_type or RadioGroup
         property = ViewTargetProperty(ctx, view_type)
         self.add_property(name, property)
@@ -1653,12 +1680,30 @@ class ViewTargetOptions(object):
 
 
 class ViewTargetProperty(Property):
+    """Displays a view target selector.
+
+    Examples::
+
+        import fiftyone.operators.types as types
+
+        # in resolve_input
+        inputs = types.Object()
+        vt = inputs.view_target(ctx)
+        # or add the property directly
+        # vt = types.ViewTargetProperty(ctx)
+        # inputs.add_property("view_target", vt)
+        return types.Property(inputs)
+
+        # in execute()
+        target_view = ctx.target_view()
+
+    Args:
+        ctx: the :class:`fiftyone.operators.ExecutionContext`
+        view_type (RadioGroup): the type of view to use (RadioGroup or Dropdown)
+    """
+
     def __init__(self, ctx, view_type=RadioGroup, **kwargs):
-        has_dataset = ctx.dataset is not None
-        has_view = ctx.view is not None
-        has_custom_view = (
-            has_dataset and has_view
-        ) and ctx.view != ctx.dataset
+        has_custom_view = ctx.has_custom_view
         has_selected = bool(ctx.selected)
         default_target = "DATASET"
         choice_view = view_type()


### PR DESCRIPTION
Enables this usage for adding the ability to select the source of the "target view`. This is a pattern that exists in many plugins.

```py
# common usage
class MyOperator(foo.Operator):
    def resolve_input(self, ctx):
       inputs = types.Object()
       inputs.select_view(ctx)

    def execute(self, ctx):
       selected_view = ctx.target_view()
       ctx.ops.set_view(view)

# advanced usage
view_target_property = ViewTargetProperty(ctx, view_type=Dropdown)
view_target_property.choices.entire_dataset.label = "My Custom Label"
view_target_property.choices.selected_samples.include = False # hide an option
inputs.define_property("view_target", view_target_property)
view = ctx.target_view("view_target")
```

Tested via [this example operator](https://github.com/voxel51/fiftyone-plugins/pull/108/files#diff-836176c6defe9a0b797ef30b54545233875a1ef48cbef6c5a3d28d45f76adc64R796).