### PR TITLE
Fixing ColorScheme serialization

### DIFF
--- a/fiftyone/core/odm/dataset.py
+++ b/fiftyone/core/odm/dataset.py
@@ -290,7 +290,7 @@ class ColorScheme(EmbeddedDocument):
 
     id = ObjectIdField(
         required=True,
-        default=ObjectId,
+        default=lambda: str(ObjectId()),
         db_field="_id",
     )
     color_pool = ListField(ColorField(), null=True)
@@ -304,17 +304,13 @@ class ColorScheme(EmbeddedDocument):
     colorscales = ListField(DictField(), null=True)
     default_colorscale = DictField(null=True)
 
-    def to_dict(self, extended=False):
-        d = super().to_dict(extended)
-        d["id"] = str(d.pop("_id"))
+    @property
+    def _id(self):
+        return ObjectId(self.id)
 
-        return d
-
-    @classmethod
-    def from_dict(cls, d):
-        d = dict(**d)
-        d["_id"] = ObjectId(d.get("id", None))
-        return super().from_dict(d)
+    @_id.setter
+    def _id(self, value):
+        self.id = str(value)
 
 
 class KeypointSkeleton(EmbeddedDocument):

--- a/tests/unittests/odm_tests.py
+++ b/tests/unittests/odm_tests.py
@@ -14,8 +14,18 @@ import fiftyone as fo
 
 class ColorSchemeTests(unittest.TestCase):
     def test_color_scheme_serialization(self):
-        color_scheme = fo.ColorScheme.from_dict({})
+        color_scheme = fo.ColorScheme()
+
         self.assertIsInstance(color_scheme.id, str)
 
-        d = fo.ColorScheme().to_dict()
-        self.assertIsInstance(d["id"], str)
+        d = color_scheme.to_dict()
+        also_color_scheme = fo.ColorScheme.from_dict(d)
+
+        self.assertIsInstance(d["_id"], ObjectId)
+        assert color_scheme == also_color_scheme
+
+        d = color_scheme.to_dict(extended=True)
+        also_color_scheme = fo.ColorScheme.from_dict(d, extended=True)
+
+        self.assertIsInstance(d["_id"], dict)
+        assert color_scheme == also_color_scheme


### PR DESCRIPTION
Fixes `ColorScheme` serialization by using the [same ID field pattern used by Label classes](https://github.com/voxel51/fiftyone/blob/0b8c3bb04e0fa5fc7d702b6dbac9a81173e432f1/fiftyone/core/labels.py#L314-L333).

The existing logic did not satisfy the following requirement, which, for example, was causing the `@voxel51/utils/edit_dataset_info` operator to be unable to understand custom color schemes.

```py
import fiftyone as fo

color_scheme = fo.ColorScheme()
d = color_scheme.to_dict(extended=True)

# previously raised an error; now succeeds
also_color_scheme = fo.ColorScheme.from_dict(d, extended=True)

assert color_scheme == also_color_scheme
```
