### PR TITLE
Fix slice change when filters are present

### DIFF
--- a/app/packages/core/src/components/Filters/StringFilter/state.ts
+++ b/app/packages/core/src/components/Filters/StringFilter/state.ts
@@ -40,7 +40,7 @@ export const pathSearchCount = selectorFamily({
             path,
             filter: { path, value },
           })
-        )?.values?.[0].count || 0
+        )?.values?.[0]?.count || 0
       );
     },
 });


### PR DESCRIPTION
## What changes are proposed in this pull request?

Fixes changing the group grid slice when a filter is present. Optional chaining was missing. See recording

### Before

https://github.com/voxel51/fiftyone/assets/19821840/8b65ea18-65c6-44fd-b0e4-0155e5e798f1

### After

https://github.com/voxel51/fiftyone/assets/19821840/9cceaf95-7152-4a9a-b66a-d87cd07c6b45


## How is this patch tested? If it is not, please explain why.

Locally

## Release Notes

* Fixed changing group slice in the grid when a sidebar filter is present

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
