### PR TITLE
Allow infinitely iterable batchers instead of over a fixed iterable

### DIFF
--- a/fiftyone/core/utils.py
+++ b/fiftyone/core/utils.py
@@ -1129,11 +1129,12 @@ class Batcher(abc.ABC):
             self._pb.__exit__(*args)
 
     def __iter__(self):
-        if self.return_views:
-            self._last_offset = 0
-            self._num_samples = len(self.iterable)
-        else:
-            self._iter = iter(self.iterable)
+        if self.iterable is not None:
+            if self.return_views:
+                self._last_offset = 0
+                self._num_samples = len(self.iterable)
+            else:
+                self._iter = iter(self.iterable)
 
         if self._render_progress:
             if self._in_context:
@@ -1167,6 +1168,10 @@ class Batcher(abc.ABC):
             self._pb.update(count=self._last_batch_size)
 
         batch_size = self._compute_batch_size()
+        self._last_batch_size = batch_size
+
+        if self.iterable is None:
+            return batch_size
 
         if self.return_views:
             if self._last_offset >= self._num_samples:
@@ -1190,8 +1195,6 @@ class Batcher(abc.ABC):
 
             if not batch:
                 raise StopIteration
-
-        self._last_batch_size = len(batch)
 
         return batch
 
@@ -1314,7 +1317,9 @@ class LatencyDynamicBatcher(BaseDynamicBatcher):
                 print("batch size: %d" % len(batch))
 
     Args:
-        iterable: an iterable
+        iterable: an iterable to batch over. If ``None``, the result of
+            ``next()`` will be a batch size instead of a batch, and is an
+            infinite iterator.
         target_latency (0.2): the target latency between ``next()``
             calls, in seconds
         init_batch_size (1): the initial batch size to use
@@ -1422,7 +1427,9 @@ class ContentSizeDynamicBatcher(BaseDynamicBatcher):
                 batcher.apply_backpressure(batch)
 
     Args:
-        iterable: an iterable
+        iterable: an iterable to batch over. If ``None``, the result of
+            ``next()`` will be a batch size instead of a batch, and is an
+            infinite iterator.
         target_size (1048576): the target batch bson content size, in bytes
         init_batch_size (1): the initial batch size to use
         min_batch_size (1): the minimum allowed batch size
@@ -1508,7 +1515,9 @@ class StaticBatcher(Batcher):
                 print("batch size: %d" % len(batch))
 
     Args:
-        iterable: an iterable
+        iterable: an iterable to batch over. If ``None``, the result of
+            ``next()`` will be a batch size instead of a batch, and is an
+            infinite iterator.
         batch_size: size of batches to generate
         return_views (False): whether to return each batch as a
             :class:`fiftyone.core.view.DatasetView`. Only applicable when the
@@ -1548,7 +1557,9 @@ def get_default_batcher(iterable, progress=False, total=None):
     to use, and related configuration values as needed for each.
 
     Args:
-        iterable: an iterable to batch over
+        iterable: an iterable to batch over. If ``None``, the result of
+            ``next()`` will be a batch size instead of a batch, and is an
+            infinite iterator.
         progress (False): whether to render a progress bar tracking the
             consumption of the batches (True/False), use the default value
             ``fiftyone.config.show_progress_bars`` (None), or a progress


### PR DESCRIPTION
## What changes are proposed in this pull request?

Allow the batching utilities to be an infinite iterator rather than creating batches over a fixed iterable.
This is useful for reusing the backpressure/adjustment mechanism within the dynamic batchers.

## How is this patch tested? If it is not, please explain why.

Unit tests added. Tested within Teams context also, passing next batch size to server based on perceived size of current batch.
