### PR TITLE
Patch fix for zero-shot detection batching

### DIFF
--- a/fiftyone/utils/transformers.py
+++ b/fiftyone/utils/transformers.py
@@ -776,11 +776,6 @@ class FiftyOneZeroShotTransformerForObjectDetection(
         inputs = self._process_inputs(arg)
         return self._predict(inputs, target_sizes)
 
-    def predict_all(self, args):
-        target_sizes = [i.shape[:-1][::-1] for i in args]
-        inputs = self._process_inputs(args)
-        return self._predict(inputs, target_sizes)
-
 
 class FiftyOneTransformerForObjectDetectionConfig(FiftyOneTransformerConfig):
     """Configuration for a :class:`FiftyOneTransformerForObjectDetection`.


### PR DESCRIPTION
Zero-shot object detection transformers used for batch inference had shape mismatch issue. This reverts to naive implementation, just for zero-shot object detection transformers.

## How is this patch tested? If it is not, please explain why.

(Details)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [x] Other
