### PR TITLE
[DOCS] Updating hyperlink formatting for Dimensionality Reduction tutorial

### DIFF
--- a/docs/source/tutorials/dimension_reduction.ipynb
+++ b/docs/source/tutorials/dimension_reduction.ipynb
@@ -167,14 +167,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Before we dive into the details of each dimensionality reduction technique, let’s recap the API for running dimensionality reduction in FiftyOne. The [FiftyOne Brain](https://docs.voxel51.com/user_guide/brain.html) provides a [`compute_visualization()`](https://docs.voxel51.com/api/fiftyone.brain.html#fiftyone.brain.compute_visualization) function that can be used to run dimensionality reduction on your data."
+    "Before we dive into the details of each dimensionality reduction technique, let’s recap the API for running dimensionality reduction in FiftyOne. The [FiftyOne Brain](https://docs.voxel51.com/user_guide/brain.html) provides a [compute_visualization()](https://docs.voxel51.com/api/fiftyone.brain.html#fiftyone.brain.compute_visualization) function that can be used to run dimensionality reduction on your data."
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The first and only positional argument to this function is a sample collection, which can be either a [`Dataset`](https://docs.voxel51.com/user_guide/using_datasets.html#datasets) or a [`DatasetView`](https://docs.voxel51.com/user_guide/using_views.html)."
+    "The first and only positional argument to this function is a sample collection, which can be either a [Dataset](https://docs.voxel51.com/user_guide/using_datasets.html#datasets) or a [DatasetView](https://docs.voxel51.com/user_guide/using_views.html)."
    ]
   },
   {


### PR DESCRIPTION
links like this: [`compute_visualization()`](https://docs.voxel51.com/api/fiftyone.brain.html#fiftyone.brain.compute_visualization) don't render properly in the docs. This PR removes the backticks.

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [x] Documentation: FiftyOne documentation changes
-   [ ] Other
