### PR TITLE
[BUGFIX] fix bug with operator target view utility when no view or selection

### DIFF
--- a/fiftyone/operators/types.py
+++ b/fiftyone/operators/types.py
@@ -1722,27 +1722,33 @@ class ViewTargetProperty(Property):
     """
 
     def __init__(self, ctx, view_type=RadioGroup, **kwargs):
-        has_custom_view = ctx.has_custom_view
-        has_selected = bool(ctx.selected)
-        default_target = "DATASET"
         choice_view = view_type()
         options = ViewTargetOptions(choice_view)
+
         self._options = options
 
-        if has_custom_view or has_selected:
-            options.entire_dataset.include = True
+        # Entire dataset is always an option
+        default_target = options.entire_dataset.value
+        options.entire_dataset.include = True
 
-            if has_custom_view:
-                options.current_view.include = True
-                default_target = "CURRENT_VIEW"
+        has_custom_view = ctx.has_custom_view
+        if has_custom_view:
+            options.current_view.include = True
+            default_target = options.current_view.value
 
-            if has_selected:
-                options.selected_samples.include = True
-                default_target = "SELECTED_SAMPLES"
+        has_selected = bool(ctx.selected)
+        if has_selected:
+            options.selected_samples.include = True
+            default_target = options.selected_samples.value
 
-        type = Enum(options.values())
+        _type = Enum(options.values())
+
+        # Only 1 option so no need for a radio group, just hide it.
+        if len(options.values()) == 1:
+            choice_view = HiddenView(read_only=True)
+
         super().__init__(
-            type, default=default_target, view=choice_view, **kwargs
+            _type, default=default_target, view=choice_view, **kwargs
         )
 
     @property


### PR DESCRIPTION
## What changes are proposed in this pull request?

When there's no view or sample selection, the target view utility creates a radio group with no values. This results in the error in screenshot below because the default of `DATASET` isn't an enum in the radio group.

Proposed fix is to always put `DATASET` into the enum of options.
This will cause the radio group to appear with only one option though which is silly. So if there is only 1 option, we make it a `HiddenView`.

Also did some code tidying while I was here.

![image](https://github.com/voxel51/fiftyone/assets/6363888/506a02d5-17fe-48ff-9b25-7114d26e3e05)


## How is this patch tested? If it is not, please explain why.

1. Use an operator that uses target view utility such as jacobmarks/image-quality-issues compute aspect ratio operator.
2. No view or selection: no target view input exists but execution is allowed and occurs over the entire dataset.
3. View or selection: target view input exists and offers entire dataset or view/selection - execution is allowed and occurs on the appropriate sample collection based on input selection.
