### PR TITLE
More doc typos

### DIFF
--- a/docs/source/environments/index.rst
+++ b/docs/source/environments/index.rst
@@ -528,7 +528,7 @@ For prototyping, it is *possible* to work with data in cloud storage buckets in
 FiftyOne by mounting the buckets as local drives.
 
 The following sections describe how to do this in the :ref:`AWS <aws>`,
-:ref:`Google Cloud <google-cloud>`, and :ref:`Miscrosoft Azure <azure>`
+:ref:`Google Cloud <google-cloud>`, and :ref:`Microsoft Azure <azure>`
 environments.
 
 .. warning::

--- a/docs/source/faq/index.rst
+++ b/docs/source/faq/index.rst
@@ -241,7 +241,7 @@ The App can play any video codec that is supported by
 including MP4 (H.264), WebM, and Ogg. If you try to view a video with an
 unsupported codec in the App, you will be prompted to use the
 :func:`reencode_videos() <fiftyone.utils.video.reencode_videos>` utility method
-to reencode the source video so it is viewable in the App.
+to re-encode the source video so it is viewable in the App.
 
 .. note::
 

--- a/docs/source/integrations/coco.rst
+++ b/docs/source/integrations/coco.rst
@@ -617,7 +617,7 @@ to compute true positives, false positives, and false negatives:
     (`via mergesort <https://github.com/cocodataset/cocoapi/blob/8c9bcc3cf640524c4c20a9c40e89cb6a2f2fa0e9/PythonAPI/pycocotools/cocoeval.py#L366>`_)
     by confidence
 
--   Compute the cumlative sum of the true positive and false positive array
+-   Compute the cumulative sum of the true positive and false positive array
 
 -   Compute precision by elementwise dividing the TP-FP-sum array by the total
     number of predictions up to that point

--- a/docs/source/plugins/developing_plugins.rst
+++ b/docs/source/plugins/developing_plugins.rst
@@ -638,7 +638,7 @@ subsequent sections.
             """You can optionally implement this method to configure a button
             or icon in the App that triggers this operator.
 
-            By default the operator only appears in the operator brower
+            By default the operator only appears in the operator browser
             (unless it is unlisted).
 
             Returns:
@@ -967,7 +967,7 @@ programmatically.
 
 However, many interesting operations like model inference, embeddings
 computation, evaluation, and exports are computationally intensive and/or not
-suitable for immediate exeuction.
+suitable for immediate execution.
 
 In such cases, :ref:`delegated operations <delegated-operations>` come to the
 rescue by allowing operators to schedule tasks that are executed on a connected

--- a/docs/source/plugins/using_plugins.rst
+++ b/docs/source/plugins/using_plugins.rst
@@ -811,7 +811,7 @@ Managing delegated operations
 _____________________________
 
 The :ref:`fiftyone delegated <cli-fiftyone-delegated>` CLI command contains a
-number of useful utilties for viewing the status of your delegated operations.
+number of useful utilities for viewing the status of your delegated operations.
 
 Listing delegated operations
 ----------------------------

--- a/docs/source/release-notes.rst
+++ b/docs/source/release-notes.rst
@@ -387,7 +387,7 @@ Bugs
   sometimes stay open after making a selection
 - Fixed an issue when downloading plugins via the API that contain bytes data
   or ``.pyc`` files
-- Fixed an isssue where certain disabled operators were not correctly appearing
+- Fixed an issue where certain disabled operators were not correctly appearing
   as disabled in the operator browser
 - Improved reliability of similarity sort actions
 
@@ -2218,7 +2218,7 @@ FiftyOne 0.17.2
 
 App
 
-- Fixed a backward compatability bug when connecting to older database versions
+- Fixed a backward compatibility bug when connecting to older database versions
   `#2103 <https://github.com/voxel51/fiftyone/pull/2103>`_
 
 .. _release-notes-v0.17.1:
@@ -2354,7 +2354,7 @@ Core
   `#1922 <https://github.com/voxel51/fiftyone/pull/1922>`_
 - Added support for dynamic attributes when performing coerced exports
   `#1993 <https://github.com/voxel51/fiftyone/pull/1993>`_
-- Introduced the notion of client compatability versions
+- Introduced the notion of client compatibility versions
   `#2017 <https://github.com/voxel51/fiftyone/pull/2017>`_
 - Extended :meth:`stats() <fiftyone.core.collections.SampleCollection>` to all
   sample collections `#1940 <https://github.com/voxel51/fiftyone/pull/1940>`_
@@ -3329,7 +3329,7 @@ Core
   working with :ref:`BDD format <BDDDataset-import>`
 - Fixed some Windows-style path bugs
 
-Annnotation
+Annotation
 
 - Added a powerful :ref:`annotation API <fiftyone-annotation>` that makes it
   easy to add or edit labels on your FiftyOne datasets or specific views into
@@ -3883,7 +3883,7 @@ Core
       |Session| to explore the samples/labels in a dataset based on their
       locations in a low-dimensional embedding space
     - :meth:`location_scatterplot() <fiftyone.core.plots.base.location_scatterplot>`:
-      an interacive scatterplot of a dataset via its |GeoLocation| coordinates
+      an interactive scatterplot of a dataset via its |GeoLocation| coordinates
     - Added |GeoLocation| and |GeoLocations| label types that can be used to store
       arbitrary GeoJSON location data on samples
     - Added the :class:`GeoJSONDataset <fiftyone.types.GeoJSONDataset>` dataset
@@ -4387,7 +4387,7 @@ FiftyOne 0.6.5
 
 App
 
-- Added concurrency to the server wich greatly improves loading speeds and
+- Added concurrency to the server which greatly improves loading speeds and
   time-to-interaction in the Grid, View Bar, and Filters Sidebar for larger
   datasets and views
 - Renamed the Display Options Sidebar to the Filters Sidebar
@@ -4469,7 +4469,7 @@ Core
 
 - Added the
   :meth:`filter_labels() <fiftyone.core.collections.SampleCollection.filter_labels>`
-  view stage, which supercedes the old dedicated per-label-type filtering
+  view stage, which supersedes the old dedicated per-label-type filtering
   stages
 - Added
   :meth:`select_labels() <fiftyone.core.collections.SampleCollection.select_labels>`

--- a/docs/source/teams/dataset_versioning.rst
+++ b/docs/source/teams/dataset_versioning.rst
@@ -652,7 +652,7 @@ method in the Management SDK:
 Unarchive snapshot
 ------------------
 
-To make an archived snapshot browseable again, users with Can Manage
+To make an archived snapshot browsable again, users with Can Manage
 permissions to the dataset can unarchive it via the UI or Management SDK.
 
 Teams UI
@@ -792,7 +792,7 @@ Best practices
 --------------
 
 As this feature matures, we will have better recommendations for best practices.
-For now given the limited starting options in the intial iteration, we have the
+For now given the limited starting options in the initial iteration, we have the
 following advice:
 
 -   Use snapshots on smaller datasets if possible.

--- a/docs/source/teams/roles_and_permissions.rst
+++ b/docs/source/teams/roles_and_permissions.rst
@@ -10,7 +10,7 @@ as possible for engineers, data scientists, and stakeholders to work together
 to build high quality datasets and computer vision models.
 
 Accordingly, FiftyOne Teams gives you the flexibility to configure user roles
-and fine-grained permissions so that you can safely and securly collaborate
+and fine-grained permissions so that you can safely and securely collaborate
 both inside and outside your organization at all stages of your workflows.
 
 This page introduces the basic roles and permissions available in FiftyOne

--- a/docs/source/teams/teams_app.rst
+++ b/docs/source/teams/teams_app.rst
@@ -117,7 +117,7 @@ description, and tags for the dataset:
 
 .. note::
 
-   A dataset's name, desription, and tags can be edited later from the
+   A dataset's name, description, and tags can be edited later from the
    dataset's :ref:`Manage tab <teams-managing-datasets>`.
 
 .. image:: /images/teams/create_dataset.png

--- a/docs/source/tutorials/index.rst
+++ b/docs/source/tutorials/index.rst
@@ -35,7 +35,7 @@ your datasets and turn your good models into *great models*.
 
 .. customcarditem::
     :header: pandas-style queries in FiftyOne
-    :description: Translate your pandas knowledge to FiftyOne. This tutorial gives a side-by-side comparison of performing common opertaions in pandas and FiftyOne.
+    :description: Translate your pandas knowledge to FiftyOne. This tutorial gives a side-by-side comparison of performing common operations in pandas and FiftyOne.
     :link: pandas_comparison.html
     :image: ../_static/images/tutorials/pandas_tutorial.png
     :tags: Filtering,Dataset-Evaluation

--- a/docs/source/user_guide/app.rst
+++ b/docs/source/user_guide/app.rst
@@ -780,7 +780,7 @@ determine which fields to include in the sidebar.
 
 .. note::
 
-    Fitler rules are dynamic. If you :ref:`save a view <app-saving-views>` that
+    Filter rules are dynamic. If you :ref:`save a view <app-saving-views>` that
     contains a filter rule, the matching fields may increase or decrease over
     time as you modify the dataset's schema.
 
@@ -1090,7 +1090,7 @@ currently visible (or selected) labels by clicking on the `Crop` icon in the
 controls HUD or using the `z` keyboard shortcut. Press `ESC` to reset your
 view.
 
-When multiple labels are overlayed on top of each other, the up and down
+When multiple labels are overlaid on top of each other, the up and down
 arrows offer a convenient way to rotate the z-order of the labels that your
 cursor is hovering over, so every label and it's tooltip can be viewed.
 

--- a/docs/source/user_guide/config.rst
+++ b/docs/source/user_guide/config.rst
@@ -123,10 +123,10 @@ FiftyOne supports the configuration options described below:
 |                               |                                     |                               | packages. See :ref:`loading zoo models <model-zoo-load>` for an example usage.         |
 +-------------------------------+-------------------------------------+-------------------------------+----------------------------------------------------------------------------------------+
 | `show_progress_bars`          | `FIFTYONE_SHOW_PROGRESS_BARS`       | `True`                        | Controls whether progress bars are printed to the terminal when performing             |
-|                               |                                     |                               | operations such reading/writing large datasets or activating FiftyOne                 |
+|                               |                                     |                               | operations such reading/writing large datasets or activating FiftyOne                  |
 |                               |                                     |                               | Brain methods on datasets.                                                             |
 +-------------------------------+-------------------------------------+-------------------------------+----------------------------------------------------------------------------------------+
-| `timezone`                    | `FIFTYONE_TIMEZONE`                 | `None`                        | An optional timzone string. If provided, all datetimes read from FiftyOne datasets     |
+| `timezone`                    | `FIFTYONE_TIMEZONE`                 | `None`                        | An optional timezone string. If provided, all datetimes read from FiftyOne datasets    |
 |                               |                                     |                               | will be expressed in this timezone. See :ref:`this section <configuring-timezone>` for |
 |                               |                                     |                               | more information.                                                                      |
 +-------------------------------+-------------------------------------+-------------------------------+----------------------------------------------------------------------------------------+

--- a/docs/source/user_guide/dataset_creation/datasets.rst
+++ b/docs/source/user_guide/dataset_creation/datasets.rst
@@ -2686,7 +2686,7 @@ directory of TFRecords in the above format as follows:
 
     When the above command is executed, the images in the TFRecords will be
     written to the provided `IMAGES_DIR`, which is required because FiftyOne
-    datasets must make their images available as invididual files on disk.
+    datasets must make their images available as individual files on disk.
 
     To view an object detection dataset stored as a directory of TFRecords in
     the FiftyOne App without creating a persistent FiftyOne dataset, you can

--- a/fiftyone/core/aggregations.py
+++ b/fiftyone/core/aggregations.py
@@ -2911,7 +2911,7 @@ def _handle_reduce_unwinds(path, unwind_list_fields, other_list_fields):
     for idx in range(1, num_list_fields):
         list_field, unwind = list_fields[idx]
 
-        # If we're unwinding a list field that is preceeded by another list
+        # If we're unwinding a list field that is preceded by another list
         # field that is *not* unwound, we must use `reduce()` to achieve it
         if unwind and not list_fields[idx - 1][1]:
             prev_list = list_fields[idx - 1][0]

--- a/fiftyone/core/cli.py
+++ b/fiftyone/core/cli.py
@@ -4240,7 +4240,7 @@ class TransformVideosCommand(Command):
             size=args.size,
             min_size=args.min_size,
             max_size=args.max_size,
-            re-encode=args.re-encode,
+            reencode=args.reencode,
             force_reencode=args.force_reencode,
             media_field=args.media_field,
             output_field=args.output_field,

--- a/fiftyone/core/cli.py
+++ b/fiftyone/core/cli.py
@@ -4240,7 +4240,7 @@ class TransformVideosCommand(Command):
             size=args.size,
             min_size=args.min_size,
             max_size=args.max_size,
-            reencode=args.reencode,
+            re-encode=args.re-encode,
             force_reencode=args.force_reencode,
             media_field=args.media_field,
             output_field=args.output_field,

--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -3447,7 +3447,7 @@ class SampleCollection(object):
             method (None): a specific
                 :attr:`fiftyone.core.evaluations.EvaluationMethodConfig.method`
                 string to match
-            **kwargs: optional config paramters to match
+            **kwargs: optional config parameters to match
 
         Returns:
             a list of evaluation keys
@@ -3555,7 +3555,7 @@ class SampleCollection(object):
             method (None): a specific
                 :attr:`fiftyone.core.brain.BrainMethodConfig.method` string to
                 match
-            **kwargs: optional config paramters to match
+            **kwargs: optional config parameters to match
 
         Returns:
             a list of brain keys
@@ -3656,7 +3656,7 @@ class SampleCollection(object):
         """Returns a list of run keys on this collection.
 
         Args:
-            **kwargs: optional config paramters to match
+            **kwargs: optional config parameters to match
 
         Returns:
             a list of run keys
@@ -6523,11 +6523,11 @@ class SampleCollection(object):
     def sort_by_similarity(
         self, query, k=None, reverse=False, dist_field=None, brain_key=None
     ):
-        """Sorts the collection by similiarity to a specified query.
+        """Sorts the collection by similarity to a specified query.
 
         In order to use this stage, you must first use
         :meth:`fiftyone.brain.compute_similarity` to index your dataset by
-        similiarity.
+        similarity.
 
         Examples::
 
@@ -8715,7 +8715,7 @@ class SampleCollection(object):
             method (None): a specific
                 :attr:`fiftyone.core.annotations.AnnotationMethodConfig.method`
                 string to match
-            **kwargs: optional config paramters to match
+            **kwargs: optional config parameters to match
 
         Returns:
             a list of annotation keys
@@ -8809,7 +8809,7 @@ class SampleCollection(object):
             anno_key: an annotation key
             dest_field (None): an optional name of a new destination field
                 into which to load the annotations, or a dict mapping field names
-                in the run's label schema to new desination field names
+                in the run's label schema to new destination field names
             unexpected ("prompt"): how to deal with any unexpected labels that
                 don't match the run's label schema when importing. The
                 supported values are:

--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -7337,7 +7337,7 @@ def _save_view(view, fields=None):
         pipeline = view._pipeline(frames_only=True)
 
         # Clips datasets may contain overlapping clips, so we must select only
-        # the first occurrance of each frame
+        # the first occurrence of each frame
         if dataset._is_clips:
             pipeline.extend(
                 [
@@ -8089,7 +8089,7 @@ def _merge_samples_pipeline(
     # here, but here's the current workflow:
     #
     # - Store the `key_field` value on each frame document in both the source
-    #   and destination collections corresopnding to its parent sample in a
+    #   and destination collections corresponding to its parent sample in a
     #   temporary `frame_key_field` field
     # - Merge the sample documents without frames attached
     # - Merge the frame documents on `[frame_key_field, frame_number]` with

--- a/fiftyone/core/expressions.py
+++ b/fiftyone/core/expressions.py
@@ -2032,7 +2032,7 @@ class ViewExpression(object):
             dataset = foz.load_zoo_dataset("quickstart")
 
             #
-            # Replaces the `label` attritubes of the objects in the
+            # Replaces the `label` attributes of the objects in the
             # `predictions` field according to the following rule:
             #
             #   If the `label` starts with `b`, replace it with `b`. Otherwise,
@@ -3374,7 +3374,7 @@ class ViewExpression(object):
         return ViewExpression({"$rtrim": rtrim})
 
     def replace(self, old, new):
-        """Replaces all occurances of ``old`` with ``new`` in this expression,
+        """Replaces all occurrences of ``old`` with ``new`` in this expression,
         which must resolve to a string.
 
         Examples::
@@ -3661,7 +3661,7 @@ class ViewExpression(object):
         delimiter.
 
         If the number of chunks exceeds ``maxsplit``, splits are only performed
-        on the last ``maxsplit`` occurances of the delimiter.
+        on the last ``maxsplit`` occurrences of the delimiter.
 
         The result is a string array that contains the chunks with the
         delimiter removed. If the delimiter is not found, this full string is
@@ -4167,7 +4167,7 @@ class ViewExpression(object):
         """Returns an expression representing the given value without parsing.
 
         See `this page <https://docs.mongodb.com/manual/reference/operator/aggregation/literal>`_
-        for more information on when this method is reqiured.
+        for more information on when this method is required.
 
         Examples::
 
@@ -4608,7 +4608,7 @@ class ViewField(ViewExpression):
     .. automethod:: __getitem__
 
     Args:
-        name (None): the name of the field, with an optional "$" preprended if
+        name (None): the name of the field, with an optional "$" prepended if
             you wish to freeze this field to the root document
     """
 

--- a/fiftyone/core/frame_utils.py
+++ b/fiftyone/core/frame_utils.py
@@ -1,5 +1,5 @@
 """
-Frame utilites.
+Frame utilities.
 
 | Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_

--- a/fiftyone/core/models.py
+++ b/fiftyone/core/models.py
@@ -667,7 +667,7 @@ def _iter_batches(video_reader, batch_size):
 
 def _make_data_loader(samples, model, batch_size, num_workers, skip_failures):
     # This function supports DataLoaders that emit numpy arrays that can
-    # therefore be used for non-Torch models; but we do not currenly use this
+    # therefore be used for non-Torch models; but we do not currently use this
     # functionality
     use_numpy = not isinstance(model, TorchModelMixin)
 
@@ -1713,7 +1713,7 @@ def _make_patch_data_loader(
     skip_failures,
 ):
     # This function supports DataLoaders that emit numpy arrays that can
-    # therefore be used for non-Torch models; but we do not currenly use this
+    # therefore be used for non-Torch models; but we do not currently use this
     # functionality
     use_numpy = not isinstance(model, TorchModelMixin)
 
@@ -1947,7 +1947,7 @@ class Model(etal.Model):
         raise NotImplementedError("subclasses must implement preprocess")
 
     def predict(self, arg):
-        """Peforms prediction on the given data.
+        """Performs prediction on the given data.
 
         Image models should support, at minimum, processing ``arg`` values that
         are uint8 numpy arrays (HWC).
@@ -2147,7 +2147,7 @@ class SamplesMixin(object):
         self._fields = fields
 
     def predict(self, arg, sample=None):
-        """Peforms prediction on the given data.
+        """Performs prediction on the given data.
 
         Image models should support, at minimum, processing ``arg`` values that
         are uint8 numpy arrays (HWC).

--- a/fiftyone/core/odm/database.py
+++ b/fiftyone/core/odm/database.py
@@ -99,7 +99,7 @@ def get_db_config():
     if config.version is None:
         #
         # The database version was added to this config in v0.15.0, so if no
-        # version is available, assume the database is at the preceeding
+        # version is available, assume the database is at the preceding
         # release. It's okay if the database's version is actually older,
         # because there are no significant admin migrations prior to v0.14.4.
         #

--- a/fiftyone/core/odm/utils.py
+++ b/fiftyone/core/odm/utils.py
@@ -661,7 +661,7 @@ _document_registry = DocumentRegistry()
 
 def load_dataset(id=None, name=None):
     """Loads the dataset from the database by its unique id or name. Throws
-    an error if neigher id nor name is provided.
+    an error if neither id nor name is provided.
 
     Args:
         id (None): the unique id of the dataset

--- a/fiftyone/core/patches.py
+++ b/fiftyone/core/patches.py
@@ -492,7 +492,7 @@ class EvaluationPatchesView(_PatchesView):
     """A :class:`fiftyone.core.view.DatasetView` containing evaluation patches
     from a :class:`fiftyone.core.dataset.Dataset`.
 
-    Evalation patches views contain an ordered collection of evaluation
+    Evaluation patches views contain an ordered collection of evaluation
     examples, each of which contains the ground truth and/or predicted labels
     for a true positive, false positive, or false negative example from an
     evaluation run on the underlying dataset.

--- a/fiftyone/core/plots/base.py
+++ b/fiftyone/core/plots/base.py
@@ -270,8 +270,8 @@ def plot_roc_curve(
     """Plots a receiver operating characteristic (ROC) curve.
 
     Args:
-        fpr: an array-like of false postive rates
-        tpr: an array-like of true postive rates
+        fpr: an array-like of false positive rates
+        tpr: an array-like of true positive rates
         thresholds (None): an array-like of decision thresholds
         roc_auc (None): the area under the ROC curve
         backend ("plotly"): the plotting backend to use. Supported values are
@@ -334,11 +334,11 @@ def lines(
                 of array-likes of values for multiple line traces
             -   the name of a sample field or ``embedded.field.name`` of
                 ``samples`` from which to extract values for a single line
-            -   the name of a frame field or ``frames.embbeded.field.name`` of
+            -   the name of a frame field or ``frames.embedded.field.name`` of
                 ``samples`` from which to extract values for per-sample line
                 traces
             -   a :class:`fiftyone.core.expressions.ViewExpression` that
-                resolves to a list (one line plot) or list of lists (muliple
+                resolves to a list (one line plot) or list of lists (multiple
                 line plots) of numeric values to compute from ``samples`` via
                 :meth:`fiftyone.core.collections.SampleCollection.values`
         y (None): the y data to plot. Can be any of the following:
@@ -348,11 +348,11 @@ def lines(
                 of array-likes of values for multiple line traces
             -   the name of a sample field or ``embedded.field.name`` of
                 ``samples`` from which to extract values for a single line
-            -   the name of a frame field or ``frames.embbeded.field.name`` of
+            -   the name of a frame field or ``frames.embedded.field.name`` of
                 ``samples`` from which to extract values for per-sample line
                 traces
             -   a :class:`fiftyone.core.expressions.ViewExpression` that
-                resolves to a list (one line plot) or list of lists (muliple
+                resolves to a list (one line plot) or list of lists (multiple
                 line plots) of numeric values to compute from ``samples`` via
                 :meth:`fiftyone.core.collections.SampleCollection.values`
         samples (None): the :class:`fiftyone.core.collections.SampleCollection`
@@ -1049,7 +1049,7 @@ class InteractivePlot(ResponsivePlot):
         Selection callbacks are functions that take a single argument
         containing the list of currently selected IDs.
 
-        If a selection callback is registred, this plot should invoke it each
+        If a selection callback is registered, this plot should invoke it each
         time their selection is updated.
 
         Args:

--- a/fiftyone/core/plots/manager.py
+++ b/fiftyone/core/plots/manager.py
@@ -151,7 +151,7 @@ class PlotManager(object):
         """Returns an iterator over the names of plots in this manager.
 
         Returns:
-            an interator over plot names
+            an iterator over plot names
         """
         return self._plots.keys()
 

--- a/fiftyone/core/plots/matplotlib.py
+++ b/fiftyone/core/plots/matplotlib.py
@@ -381,8 +381,8 @@ def plot_roc_curve(
     """Plots a receiver operating characteristic (ROC) curve.
 
     Args:
-        fpr: an array-like of false postive rates
-        tpr: an array-like of true postive rates
+        fpr: an array-like of false positive rates
+        tpr: an array-like of true positive rates
         roc_auc (None): the area under the ROC curve
         title (None): a title for the plot
         ax (None): a matplotlib axis to plot in
@@ -452,11 +452,11 @@ def lines(
                 of array-likes of values for multiple line traces
             -   the name of a sample field or ``embedded.field.name`` of
                 ``samples`` from which to extract values for a single line
-            -   the name of a frame field or ``frames.embbeded.field.name`` of
+            -   the name of a frame field or ``frames.embedded.field.name`` of
                 ``samples`` from which to extract values for per-sample line
                 traces
             -   a :class:`fiftyone.core.expressions.ViewExpression` that
-                resolves to a list (one line plot) or list of lists (muliple
+                resolves to a list (one line plot) or list of lists (multiple
                 line plots) of numeric values to compute from ``samples`` via
                 :meth:`fiftyone.core.collections.SampleCollection.values`
         y (None): the y data to plot. Can be any of the following:
@@ -466,11 +466,11 @@ def lines(
                 of array-likes of values for multiple line traces
             -   the name of a sample field or ``embedded.field.name`` of
                 ``samples`` from which to extract values for a single line
-            -   the name of a frame field or ``frames.embbeded.field.name`` of
+            -   the name of a frame field or ``frames.embedded.field.name`` of
                 ``samples`` from which to extract values for per-sample line
                 traces
             -   a :class:`fiftyone.core.expressions.ViewExpression` that
-                resolves to a list (one line plot) or list of lists (muliple
+                resolves to a list (one line plot) or list of lists (multiple
                 line plots) of numeric values to compute from ``samples`` via
                 :meth:`fiftyone.core.collections.SampleCollection.values`
         samples (None): the :class:`fiftyone.core.collections.SampleCollection`

--- a/fiftyone/core/plots/plotly.py
+++ b/fiftyone/core/plots/plotly.py
@@ -137,7 +137,7 @@ def _plot_confusion_matrix_static(
     xlabels = labels[:num_cols]
     ylabels = labels[:num_rows]
 
-    # Flip data so plot will have the standard descending diagnoal
+    # Flip data so plot will have the standard descending diagonal
     # Flipping the yaxis via `autorange="reversed"` isn't an option because
     # screenshots don't seem to respect that setting...
     confusion_matrix = np.flip(confusion_matrix, axis=0)
@@ -214,7 +214,7 @@ def _plot_confusion_matrix_interactive(
     xlabels = labels[:num_cols]
     ylabels = labels[:num_rows]
 
-    # Flip data so plot will have the standard descending diagnoal
+    # Flip data so plot will have the standard descending diagonal
     # Flipping the yaxis via `autorange="reversed"` isn't an option because
     # screenshots don't seem to respect that setting...
     confusion_matrix = np.flip(confusion_matrix, axis=0)
@@ -326,7 +326,7 @@ def plot_regressions(
             By default, if ``sizes`` is a field name, this name will be used,
             otherwise the tooltip will use "size"
         show_colorbar_title (None): whether to show the colorbar title. By
-            default, a title will be shown only if a value was pasesd to
+            default, a title will be shown only if a value was passed to
             ``labels_title`` or an appropriate default can be inferred from
             the ``labels`` parameter
         **kwargs: optional keyword arguments for
@@ -618,8 +618,8 @@ def plot_roc_curve(
     """Plots a receiver operating characteristic (ROC) curve.
 
     Args:
-        fpr: an array-like of false postive rates
-        tpr: an array-like of true postive rates
+        fpr: an array-like of false positive rates
+        tpr: an array-like of true positive rates
         thresholds (None): an array-like of decision thresholds
         roc_auc (None): the area under the ROC curve
         style ("area"): a plot style to use. Supported values are
@@ -729,11 +729,11 @@ def lines(
                 of array-likes of values for multiple line traces
             -   the name of a sample field or ``embedded.field.name`` of
                 ``samples`` from which to extract values for a single line
-            -   the name of a frame field or ``frames.embbeded.field.name`` of
+            -   the name of a frame field or ``frames.embedded.field.name`` of
                 ``samples`` from which to extract values for per-sample line
                 traces
             -   a :class:`fiftyone.core.expressions.ViewExpression` that
-                resolves to a list (one line plot) or list of lists (muliple
+                resolves to a list (one line plot) or list of lists (multiple
                 line plots) of numeric values to compute from ``samples`` via
                 :meth:`fiftyone.core.collections.SampleCollection.values`
         y (None): the y data to plot. Can be any of the following:
@@ -743,11 +743,11 @@ def lines(
                 of array-likes of values for multiple line traces
             -   the name of a sample field or ``embedded.field.name`` of
                 ``samples`` from which to extract values for a single line
-            -   the name of a frame field or ``frames.embbeded.field.name`` of
+            -   the name of a frame field or ``frames.embedded.field.name`` of
                 ``samples`` from which to extract values for per-sample line
                 traces
             -   a :class:`fiftyone.core.expressions.ViewExpression` that
-                resolves to a list (one line plot) or list of lists (muliple
+                resolves to a list (one line plot) or list of lists (multiple
                 line plots) of numeric values to compute from ``samples`` via
                 :meth:`fiftyone.core.collections.SampleCollection.values`
         samples (None): the :class:`fiftyone.core.collections.SampleCollection`
@@ -1027,7 +1027,7 @@ def scatterplot(
         edges_title (None): a title string to use for ``edges`` in the legend.
             If none is provided, edges are not included in the legend
         show_colorbar_title (None): whether to show the colorbar title. By
-            default, a title will be shown only if a value was pasesd to
+            default, a title will be shown only if a value was passed to
             ``labels_title`` or an appropriate default can be inferred from
             the ``labels`` parameter
         axis_equal (False): whether to set the axes to equal scale
@@ -1301,7 +1301,7 @@ def location_scatterplot(
         edges_title (None): a title string to use for ``edges`` in the legend.
             If none is provided, edges are not included in the legend
         show_colorbar_title (None): whether to show the colorbar title. By
-            default, a title will be shown only if a value was pasesd to
+            default, a title will be shown only if a value was passed to
             ``labels_title`` or an appropriate default can be inferred from
             the ``labels`` parameter
         **kwargs: optional keyword arguments for

--- a/fiftyone/core/stages.py
+++ b/fiftyone/core/stages.py
@@ -755,7 +755,7 @@ class ExcludeFields(ViewStage):
                 sample_collection, self._meta_filter
             )
 
-            # Cannnot exclude default fields
+            # Cannot exclude default fields
             default_paths = sample_collection._get_default_sample_fields(
                 include_private=True
             )
@@ -787,7 +787,7 @@ class ExcludeFields(ViewStage):
                 sample_collection, self._meta_filter, frames=True
             )
 
-            # Cannnot exclude default fields
+            # Cannot exclude default fields
             default_paths = sample_collection._get_default_frame_fields(
                 include_private=True
             )
@@ -7011,11 +7011,11 @@ def _parse_sort_order(order):
 
 
 class SortBySimilarity(ViewStage):
-    """Sorts a collection by similiarity to a specified query.
+    """Sorts a collection by similarity to a specified query.
 
     In order to use this stage, you must first use
     :meth:`fiftyone.brain.compute_similarity` to index your dataset by
-    similiarity.
+    similarity.
 
     Examples::
 
@@ -7112,7 +7112,7 @@ class SortBySimilarity(ViewStage):
 
     @property
     def reverse(self):
-        """Whether to sort by least similiarity."""
+        """Whether to sort by least similarity."""
         return self._reverse
 
     @property

--- a/fiftyone/core/storage.py
+++ b/fiftyone/core/storage.py
@@ -831,7 +831,7 @@ def run(fcn, tasks, num_workers=None, progress=None):
 
     Args:
         fcn: a function that accepts a single argument
-        tasks: an iterable of function aguments
+        tasks: an iterable of function arguments
         num_workers (None): a suggested number of threads to use
         progress (None): whether to render a progress bar (True/False), use the
             default value ``fiftyone.config.show_progress_bars`` (None), or a

--- a/fiftyone/core/utils.py
+++ b/fiftyone/core/utils.py
@@ -408,16 +408,16 @@ def ensure_package(
         error_level (None): the error level to use, defined as:
 
             -   0: raise error if requirement is not satisfied
-            -   1: log warning if requirement is not satisifed
+            -   1: log warning if requirement is not satisfied
             -   2: ignore unsatisifed requirements
 
             By default, ``fiftyone.config.requirement_error_level`` is used
         error_msg (None): an optional custom error message to use
         log_success (False): whether to generate a log message if the
-            requirement is satisifed
+            requirement is satisfied
 
     Returns:
-        True/False whether the requirement is satisifed
+        True/False whether the requirement is satisfied
     """
     if error_level is None:
         error_level = fo.config.requirement_error_level
@@ -492,12 +492,12 @@ def ensure_requirements(
         error_level (None): the error level to use, defined as:
 
             -   0: raise error if requirement is not satisfied
-            -   1: log warning if requirement is not satisifed
+            -   1: log warning if requirement is not satisfied
             -   2: ignore unsatisifed requirements
 
             By default, ``fiftyone.config.requirement_error_level`` is used
         log_success (False): whether to generate a log message if a requirement
-            is satisifed
+            is satisfied
     """
     for req_str in load_requirements(requirements_path):
         ensure_package(
@@ -527,16 +527,16 @@ def ensure_import(
         error_level (None): the error level to use, defined as:
 
             -   0: raise error if requirement is not satisfied
-            -   1: log warning if requirement is not satisifed
+            -   1: log warning if requirement is not satisfied
             -   2: ignore unsatisifed requirements
 
             By default, ``fiftyone.config.requirement_error_level`` is used
         error_msg (None): an optional custom error message to use
         log_success (False): whether to generate a log message if the
-            requirement is satisifed
+            requirement is satisfied
 
     Returns:
-        True/False whether the requirement is satisifed
+        True/False whether the requirement is satisfied
     """
     if error_level is None:
         error_level = fo.config.requirement_error_level
@@ -560,14 +560,14 @@ def ensure_tf(eager=False, error_level=None, error_msg=None):
         error_level (None): the error level to use, defined as:
 
             -   0: raise error if requirement is not satisfied
-            -   1: log warning if requirement is not satisifed
+            -   1: log warning if requirement is not satisfied
             -   2: ignore unsatisifed requirements
 
             By default, ``fiftyone.config.requirement_error_level`` is used
         error_msg (None): an optional custom error message to print
 
     Returns:
-        True/False whether the requirement is satisifed
+        True/False whether the requirement is satisfied
     """
     if error_level is None:
         error_level = fo.config.requirement_error_level
@@ -613,14 +613,14 @@ def ensure_tfds(error_level=None, error_msg=None):
         error_level (None): the error level to use, defined as:
 
             -   0: raise error if requirement is not satisfied
-            -   1: log warning if requirement is not satisifed
+            -   1: log warning if requirement is not satisfied
             -   2: ignore unsatisifed requirements
 
             By default, ``fiftyone.config.requirement_error_level`` is used
         error_msg (None): an optional custom error message to print
 
     Returns:
-        True/False whether the requirement is satisifed
+        True/False whether the requirement is satisfied
     """
     if error_level is None:
         error_level = fo.config.requirement_error_level
@@ -643,14 +643,14 @@ def ensure_torch(error_level=None, error_msg=None):
         error_level (None): the error level to use, defined as:
 
             -   0: raise error if requirement is not satisfied
-            -   1: log warning if requirement is not satisifed
+            -   1: log warning if requirement is not satisfied
             -   2: ignore unsatisifed requirements
 
             By default, ``fiftyone.config.requirement_error_level`` is used
         error_msg (None): an optional custom error message to print
 
     Returns:
-        True/False whether the requirement is satisifed
+        True/False whether the requirement is satisfied
     """
     if error_level is None:
         error_level = fo.config.requirement_error_level
@@ -1390,7 +1390,7 @@ class ContentSizeDynamicBatcher(BaseDynamicBatcher):
 
     This batcher requires that backpressure feedback be provided, either by
     providing a BSON-able batch from which the content size can be computed,
-    or by manaully providing the content size.
+    or by manually providing the content size.
 
     This class is often used in conjunction with a :class:`ProgressBar` to keep
     the user appraised on the status of a long-running task.
@@ -2000,7 +2000,7 @@ class MonkeyPatchFunction(object):
     Args:
         module_or_fcn: a module or function
         monkey_fcn: the function to monkey patch in
-        fcn_name (None): the name of the funciton to monkey patch. Required iff
+        fcn_name (None): the name of the function to monkey patch. Required iff
             ``module_or_fcn`` is a module
         namespace (None): an optional package namespace
     """

--- a/fiftyone/core/view.py
+++ b/fiftyone/core/view.py
@@ -1540,7 +1540,7 @@ class DatasetView(foc.SampleCollection):
 
         #######################################################################
 
-        # Insert group lookup pipline if needed
+        # Insert group lookup pipeline if needed
         if _attach_groups_idx is not None:
             _pipeline = self._dataset._attach_groups_pipeline(
                 group_slices=_group_slices

--- a/fiftyone/plugins/core.py
+++ b/fiftyone/plugins/core.py
@@ -302,12 +302,12 @@ def ensure_plugin_requirements(
         error_level (None): the error level to use, defined as:
 
             -   0: raise error if requirement is not satisfied
-            -   1: log warning if requirement is not satisifed
+            -   1: log warning if requirement is not satisfied
             -   2: ignore unsatisifed requirements
 
             By default, ``fiftyone.config.requirement_error_level`` is used
         log_success (False): whether to generate a log message if a requirement
-            is satisifed
+            is satisfied
     """
 
     req_path = _find_requirements(plugin_name)
@@ -330,15 +330,15 @@ def _find_requirements(plugin_name):
 def ensure_plugin_compatibility(
     plugin_name, error_level=None, log_success=False
 ):
-    """Ensures that the given plugin is compatibile with your current FiftyOne
-    pacakge version.
+    """Ensures that the given plugin is compatible with your current FiftyOne
+    package version.
 
     Args:
         plugin_name: the plugin name
         error_level (None): the error level to use, defined as:
 
-            -   0: raise error if plugin is not compatibile
-            -   1: log warning if plugin is not satisifed
+            -   0: raise error if plugin is not compatible
+            -   1: log warning if plugin is not satisfied
             -   2: ignore fiftyone compatibility requirements
 
             By default, ``fiftyone.config.requirement_error_level`` is used

--- a/fiftyone/plugins/definitions.py
+++ b/fiftyone/plugins/definitions.py
@@ -66,7 +66,7 @@ class PluginDefinition(object):
 
     @property
     def fiftyone_compatibility(self):
-        """The FiftyOne compatibilty version."""
+        """The FiftyOne compatibility version."""
         return self._metadata.get("fiftyone", {}).get("version", None)
 
     @property

--- a/fiftyone/server/events.py
+++ b/fiftyone/server/events.py
@@ -58,7 +58,7 @@ _app_count = 0
 async def dispatch_event(
     subscription: t.Optional[str], event: EventType
 ) -> None:
-    """Dispatch an event to all listeners registed for the server process
+    """Dispatch an event to all listeners registered for the server process
 
     Args:
         subscription: the calling subscription id

--- a/fiftyone/server/metadata.py
+++ b/fiftyone/server/metadata.py
@@ -289,7 +289,7 @@ async def get_image_dimensions(input):
             height = abs(int(h))
         else:
             raise MetadataException(
-                "Unkown DIB header size: %s" % str(headersize)
+                "Unknown DIB header size: %s" % str(headersize)
             )
     elif (size >= 8) and data[:4] in (b"II\052\000", b"MM\000\052"):
         # Standard TIFF, big- or little-endian

--- a/fiftyone/server/routes/values.py
+++ b/fiftyone/server/routes/values.py
@@ -53,7 +53,7 @@ class Values(HTTPEndpoint):
 
         sort_by = "count" if count else "_id"
 
-        # escape special characters, add support for wilcard pattern matching
+        # escape special characters, add support for wildcard pattern matching
         regex_safe_search = (
             re.escape(search).replace(r"\*", ".*").replace(r"\?", ".")
             if search

--- a/fiftyone/utils/annotations.py
+++ b/fiftyone/utils/annotations.py
@@ -1006,7 +1006,7 @@ def load_annotations(
         anno_key: an annotation key
         dest_field (None): an optional name of a new destination field
             into which to load the annotations, or a dict mapping field names
-            in the run's label schema to new desination field names
+            in the run's label schema to new destination field names
         unexpected ("prompt"): how to deal with any unexpected labels that
             don't match the run's label schema when importing. The supported
             values are:
@@ -2342,7 +2342,7 @@ def draw_labeled_images(
             converted to an absolute path (if necessary) via
             :func:`fiftyone.core.storage.normalize_path`
         label_fields (None): a label field or list of label fields to render.
-            If omitted, all compatiable fields are rendered
+            If omitted, all compatible fields are rendered
         config (None): an optional :class:`DrawConfig` configuring how to draw
             the labels
         progress (None): whether to render a progress bar (True/False), use the
@@ -2386,7 +2386,7 @@ def draw_labeled_image(
         sample: a :class:`fiftyone.core.sample.Sample`
         outpath: the path to write the annotated image
         label_fields (None): a label field or list of label fields to render.
-            If omitted, all compatiable fields are rendered
+            If omitted, all compatible fields are rendered
         config (None): an optional :class:`DrawConfig` configuring how to draw
             the labels
         **kwargs: optional keyword arguments specifying parameters of the
@@ -2432,7 +2432,7 @@ def draw_labeled_videos(
             converted to an absolute path (if necessary) via
             :func:`fiftyone.core.storage.normalize_path`
         label_fields (None): a label field or list of label fields to render.
-            If omitted, all compatiable fields are rendered
+            If omitted, all compatible fields are rendered
         config (None): an optional :class:`DrawConfig` configuring how to draw
             the labels
         progress (None): whether to render a progress bar (True/False), use the
@@ -2488,7 +2488,7 @@ def draw_labeled_video(
         support (None): an optional ``[first, last]`` range of frames to
             render
         label_fields (None): a label field or list of label fields to render.
-            If omitted, all compatiable fields are rendered
+            If omitted, all compatible fields are rendered
         config (None): an optional :class:`DrawConfig` configuring how to draw
             the labels
         **kwargs: optional keyword arguments specifying parameters of the

--- a/fiftyone/utils/bdd.py
+++ b/fiftyone/utils/bdd.py
@@ -409,7 +409,7 @@ def parse_bdd100k_dataset(
                 data/
 
     Args:
-        source_dir: the source directory containing the manually dowloaded
+        source_dir: the source directory containing the manually downloaded
             BDD100K files
         dataset_dir: the directory to construct the output split directories
         copy_files (True): whether to move (False) or create copies (True) of
@@ -519,7 +519,7 @@ def _parse_bdd_annotation(d, frame_size, extra_attrs):
     # Frame attributes
     #
     # @todo problems may occur if frame attributes have names "detections" or
-    # "polylines", but we cross our fingers and proceeed
+    # "polylines", but we cross our fingers and proceed
     #
     frame_labels = _parse_frame_labels(d.get("attributes", {}))
     labels.update(frame_labels)

--- a/fiftyone/utils/clip/tokenizer.py
+++ b/fiftyone/utils/clip/tokenizer.py
@@ -33,7 +33,7 @@ def bytes_to_unicode():
     want to avoid UNKs.
 
     When you're at something like a 10B token dataset you end up needing around
-    5K for decent coverage. This is a signficant percentage of your normal,
+    5K for decent coverage. This is a significant percentage of your normal,
     say, 32K bpe vocab. To avoid that, we want lookup tables between utf-8
     bytes and unicode strings.
 

--- a/fiftyone/utils/coco.py
+++ b/fiftyone/utils/coco.py
@@ -1705,7 +1705,7 @@ def download_coco_dataset_split(
     num_samples = len(downloaded_filenames)  # total downloaded
 
     #
-    # Write usable annotations file to `anno_path`, if necesary
+    # Write usable annotations file to `anno_path`, if necessary
     #
 
     if not os.path.isfile(anno_path):

--- a/fiftyone/utils/cvat.py
+++ b/fiftyone/utils/cvat.py
@@ -3522,7 +3522,7 @@ class CVATAnnotationResults(foua.AnnotationResults):
 class CVATAnnotationAPI(foua.AnnotationAPI):
     """A class to facilitate connection to and management of tasks in CVAT.
 
-    On initializiation, this class constructs a session based on the provided
+    On initialization, this class constructs a session based on the provided
     server url and credentials.
 
     This API provides methods to easily get, put, post, patch, and delete tasks
@@ -4032,7 +4032,7 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
                     tasks.append(task)
                 else:
                     # For v1 servers, project tasks are dictionaries we need to
-                    # exctract "id" from
+                    # extract "id" from
                     tasks.append(task["id"])
 
         return tasks
@@ -6926,9 +6926,9 @@ class CVATShape(CVATLabel):
         index (None): the tracking index of the shape
         immutable_attrs (None): immutable attributes inherited by this shape
             from its track
-        occluded_attrs (None): a dictonary mapping class names to the
+        occluded_attrs (None): a dictionary mapping class names to the
             corresponding attribute linked to the CVAT occlusion widget, if any
-        group_id_attrs (None): a dictonary mapping class names to the
+        group_id_attrs (None): a dictionary mapping class names to the
             corresponding attribute linked to the CVAT group id, if any
         group_id (None): an optional group id value for this shape when it
             cannot be parsed from the label dict

--- a/fiftyone/utils/data/exporters.py
+++ b/fiftyone/utils/data/exporters.py
@@ -1298,7 +1298,7 @@ class VideoExporter(MediaExporter):
 
 
 class DatasetExporter(object):
-    """Base interface for exporting datsets.
+    """Base interface for exporting datasets.
 
     See :ref:`this page <writing-a-custom-dataset-exporter>` for information
     about implementing/using dataset exporters.

--- a/fiftyone/utils/eval/openimages.py
+++ b/fiftyone/utils/eval/openimages.py
@@ -55,7 +55,7 @@ class OpenImagesEvaluationConfig(DetectionEvaluationConfig):
 
             If ``error_level > 0``, any calculation that raises a geometric
             error will default to an IoU of 0
-        hierarchy (None): an optional dict containing a hierachy of classes for
+        hierarchy (None): an optional dict containing a hierarchy of classes for
             evaluation following the structure
             ``{"LabelName": label, "Subcategory": [{...}, ...]}``
         pos_label_field (None): the name of a field containing image-level
@@ -873,7 +873,7 @@ def _build_plain_hierarchy(hierarchy, skip_root=False):
             keyed_parent, keyed_child, children = _build_plain_hierarchy(node)
 
             # Update is not done through dict.update() since some children have
-            # multiple parents in the hiearchy
+            # multiple parents in the hierarchy
             _update_dict(all_keyed_parent, keyed_parent)
             _update_dict(all_keyed_child, keyed_child)
             all_children.update(children)

--- a/fiftyone/utils/eval/segmentation.py
+++ b/fiftyone/utils/eval/segmentation.py
@@ -314,7 +314,7 @@ class SimpleEvaluationConfig(SegmentationEvaluationConfig):
 
 
 class SimpleEvaluation(SegmentationEvaluation):
-    """Stardard pixelwise segmentation evaluation.
+    """Standard pixelwise segmentation evaluation.
 
     This class can optionally be configured to evaluate along only the
     boundaries of the ground truth segmentation masks.

--- a/fiftyone/utils/kitti.py
+++ b/fiftyone/utils/kitti.py
@@ -458,9 +458,9 @@ def download_kitti_multiview_dataset(
         dataset_dir: the directory in which to construct the dataset
         splits (None): the split or list of splits to download. Supported
             values are ``("train", "test")``
-        scratch_dir (None): a scratch directory to use to downoad any necessary
+        scratch_dir (None): a scratch directory to use to download any necessary
             temporary files
-        overwrite (False): whether to redownload/regnerate files if they
+        overwrite (False): whether to redownload/regenerate files if they
             already exist
         cleanup (False): whether to delete the downloaded zips and scratch
             directory
@@ -571,7 +571,7 @@ def download_kitti_detection_dataset(
         dataset_dir: the directory in which to construct the dataset
         splits (None): the split or list of splits to download. Supported
             values are ``("train", "test")``
-        scratch_dir (None): a scratch directory to use to downoad any necessary
+        scratch_dir (None): a scratch directory to use to download any necessary
             temporary files
         overwrite (False): whether to redownload the zips if they already exist
         cleanup (False): whether to delete the downloaded zips and scratch

--- a/fiftyone/utils/labelbox.py
+++ b/fiftyone/utils/labelbox.py
@@ -200,7 +200,7 @@ class LabelboxAnnotationAPI(foua.AnnotationAPI):
     """A class to facilitate connection to and management of projects in
     Labelbox.
 
-    On initializiation, this class constructs a client based on the provided
+    On initialization, this class constructs a client based on the provided
     server url and credentials.
 
     This API provides methods to easily upload, download, create, and delete

--- a/fiftyone/utils/openimages.py
+++ b/fiftyone/utils/openimages.py
@@ -66,7 +66,7 @@ class OpenImagesDatasetImporter(foud.LabeledImageDatasetImporter):
         only_matching (False): whether to only load labels that match the
             ``classes`` or ``attrs`` requirements that you provide (True), or
             to load all labels for samples that match the requirements (False)
-        load_hierarchy (True): whether to load the classes hiearchy and add it
+        load_hierarchy (True): whether to load the classes hierarchy and add it
             to the dataset's ``info`` dictionary
         shuffle (False): whether to randomly shuffle the order in which the
             samples are imported
@@ -406,7 +406,7 @@ class OpenImagesV6DatasetImporter(OpenImagesDatasetImporter):
         only_matching (False): whether to only load labels that match the
             ``classes`` or ``attrs`` requirements that you provide (True), or
             to load all labels for samples that match the requirements (False)
-        load_hierarchy (True): whether to load the classes hiearchy and add it
+        load_hierarchy (True): whether to load the classes hierarchy and add it
             to the dataset's ``info`` dictionary
         shuffle (False): whether to randomly shuffle the order in which the
             samples are imported
@@ -485,7 +485,7 @@ class OpenImagesV7DatasetImporter(OpenImagesDatasetImporter):
         only_matching (False): whether to only load labels that match the
             ``classes`` or ``attrs`` requirements that you provide (True), or
             to load all labels for samples that match the requirements (False)
-        load_hierarchy (True): whether to load the classes hiearchy and add it
+        load_hierarchy (True): whether to load the classes hierarchy and add it
             to the dataset's ``info`` dictionary
         shuffle (False): whether to randomly shuffle the order in which the
             samples are imported

--- a/fiftyone/utils/openlabel.py
+++ b/fiftyone/utils/openlabel.py
@@ -990,7 +990,7 @@ class OpenLABELStreams(OpenLABELGroup):
         for a given media file identifier.
 
         Args:
-            uri: the unique media file identifer for which to get all stream
+            uri: the unique media file identifier for which to get all stream
                 infos
 
         Returns:
@@ -2028,7 +2028,7 @@ def _remove_ext(p):
 
 def _merge_frame_labels(sample_labels, frame_labels, seg_type):
     # Add frame labels to sample labels, if there is a key collision, merge the
-    # labels if they are a list field otherewise skip
+    # labels if they are a list field otherwise skip
     for labels in frame_labels.values():
         for name, value in labels.items():
             if name == "detections":

--- a/fiftyone/utils/sama.py
+++ b/fiftyone/utils/sama.py
@@ -282,7 +282,7 @@ def download_sama_coco_dataset_split(
     num_samples = len(downloaded_filenames)  # total downloaded
 
     #
-    # Write usable annotations file to `anno_path`, if necesary
+    # Write usable annotations file to `anno_path`, if necessary
     #
 
     if not os.path.isfile(anno_path):

--- a/fiftyone/utils/torch.py
+++ b/fiftyone/utils/torch.py
@@ -231,12 +231,12 @@ def ensure_torch_hub_requirements(
         error_level (None): the error level to use, defined as:
 
             -   0: raise error if requirement is not satisfied
-            -   1: log warning if requirement is not satisifed
+            -   1: log warning if requirement is not satisfied
             -   2: ignore unsatisifed requirements
 
             By default, ``fiftyone.config.requirement_error_level`` is used
         log_success (False): whether to generate a log message if a requirement
-            is satisifed
+            is satisfied
     """
     for req_str in load_torch_hub_requirements(repo_or_dir, source=source):
         fou.ensure_package(
@@ -643,7 +643,7 @@ class TorchImageModel(
         return self._skeleton
 
     def predict(self, img):
-        """Peforms prediction on the given image.
+        """Performs prediction on the given image.
 
         Args:
             img: the image to process, which can be any of the following:
@@ -665,7 +665,7 @@ class TorchImageModel(
         return self._predict_all(imgs)[0]
 
     def predict_all(self, imgs):
-        """Peforms prediction on the given batch of images.
+        """Performs prediction on the given batch of images.
 
         Args:
             imgs: the batch of images to process, which can be any of the

--- a/fiftyone/utils/transformers.py
+++ b/fiftyone/utils/transformers.py
@@ -1,6 +1,6 @@
 """
 Utilities for working with
-`Hugging Face Transformers <hhttps://huggingface.co/docs/transformers>`_.
+`Hugging Face Transformers <https://huggingface.co/docs/transformers>`_.
 
 | Copyright 2017-2023, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_

--- a/fiftyone/utils/utils3d.py
+++ b/fiftyone/utils/utils3d.py
@@ -185,7 +185,7 @@ class _Box(object):
         return _Box(new_rotation, new_translation, self.scale)
 
     def _scaled_axis_aligned_vertices(self, scale):
-        """Returns axis-aligned verticies for a box of the given scale."""
+        """Returns axis-aligned vertices for a box of the given scale."""
         x = scale[0] / 2.0
         y = scale[1] / 2.0
         z = scale[2] / 2.0

--- a/fiftyone/utils/video.py
+++ b/fiftyone/utils/video.py
@@ -36,7 +36,7 @@ def extract_clip(
 ):
     """Extracts the specified clip from the video.
 
-    Provide either ``suppport`` or ``timestamps`` to this method.
+    Provide either ``support`` or ``timestamps`` to this method.
 
     When fast=False, the following ffmpeg command is used::
 

--- a/fiftyone/zoo/models/__init__.py
+++ b/fiftyone/zoo/models/__init__.py
@@ -171,12 +171,12 @@ def ensure_zoo_model_requirements(name, error_level=None, log_success=True):
             requirements, defined as:
 
             -   0: raise error if a requirement is not satisfied
-            -   1: log warning if a requirement is not satisifed
-            -   2: ignore unsatisifed requirements
+            -   1: log warning if a requirement is not satisfied
+            -   2: ignore unsatisfied requirements
 
             By default, ``fo.config.requirement_error_level`` is used
         log_success (True): whether to generate a log message when a
-            requirement is satisifed
+            requirement is satisfied
     """
     if error_level is None:
         error_level = fo.config.requirement_error_level
@@ -214,8 +214,8 @@ def load_zoo_model(
             requirements, defined as:
 
             -   0: raise error if a requirement is not satisfied
-            -   1: log warning if a requirement is not satisifed
-            -   2: ignore unsatisifed requirements
+            -   1: log warning if a requirement is not satisfied
+            -   2: ignore unsatisfied requirements
 
             By default, ``fo.config.requirement_error_level`` is used
         cache (True): whether to store a weak reference to the model so that


### PR DESCRIPTION
## What changes are proposed in this pull request?

Ran [codespell](https://github.com/codespell-project/codespell) on python and docs source to find more typos. Could be some false negatives left, but this should find most typos.
In the future we can add codespell as a precommit or github action check, which we have already done in other repos.

## How is this patch tested? If it is not, please explain why.

No testing, all comments and docs.