### PR TITLE
fix on_startup operator not executing on startup

### DIFF
--- a/app/packages/operators/src/OperatorCore.tsx
+++ b/app/packages/operators/src/OperatorCore.tsx
@@ -1,12 +1,14 @@
 import OperatorBrowser from "./OperatorBrowser";
 import OperatorInvocationRequestExecutor from "./OperatorInvocationRequestExecutor";
 import OperatorPrompt, { OperatorViewModal } from "./OperatorPrompt";
+import StartupOperatorExecutor from "./StartupOperatorExecutor";
 
 export default function OperatorCore() {
   return (
     <>
       <OperatorBrowser />
       <OperatorInvocationRequestExecutor />
+      <StartupOperatorExecutor />
       <OperatorPrompt />
       <OperatorViewModal />
     </>

--- a/app/packages/operators/src/StartupOperatorExecutor.tsx
+++ b/app/packages/operators/src/StartupOperatorExecutor.tsx
@@ -1,0 +1,15 @@
+import { useEffect } from "react";
+import { executeStartupOperators } from "./operators";
+
+let startupOperatorsExecuted = false;
+
+export default function StartupOperatorExecutor() {
+  useEffect(() => {
+    if (!startupOperatorsExecuted) {
+      executeStartupOperators();
+      startupOperatorsExecuted = true;
+    }
+  }, []);
+
+  return null;
+}

--- a/app/packages/operators/src/loader.tsx
+++ b/app/packages/operators/src/loader.tsx
@@ -4,21 +4,15 @@ import { useEffect, useState } from "react";
 import { useRecoilValue, useSetRecoilState } from "recoil";
 import { registerBuiltInOperators } from "./built-in-operators";
 import { useOperatorPlacementsResolver } from "./hooks";
-import { executeStartupOperators, loadOperatorsFromServer } from "./operators";
+import { loadOperatorsFromServer } from "./operators";
 import {
   availableOperatorsRefreshCount,
   operatorsInitializedAtom,
 } from "./state";
 
-let startupOperatorsExecuted = false;
-
 async function loadOperators(datasetName: string) {
   registerBuiltInOperators();
   await loadOperatorsFromServer(datasetName);
-  if (!startupOperatorsExecuted) {
-    executeStartupOperators();
-    startupOperatorsExecuted = true;
-  }
 }
 
 /**


### PR DESCRIPTION
## What changes are proposed in this pull request?

Fix `on_startup` not executing on startup due to race condition where on_startup operator are executed before invocation queue is initialized

## How is this patch tested? If it is not, please explain why.

Using the VoxelGPT plugin and verifying that the VoxelGPT panel launches on startup 

## Release Notes

Fix `on_startup` not executing on app startup

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
