### PR TITLE
Add support for executing operators programmatically in notebooks

### DIFF
--- a/docs/source/plugins/using_plugins.rst
+++ b/docs/source/plugins/using_plugins.rst
@@ -634,17 +634,14 @@ data, you can access it via the ``result`` property of the returned
 .. note::
 
     When working in notebook contexts, executing operators returns an
-    ``asyncio.Task`` that you can ``await`` if necessary and then retrieve the
+    ``asyncio.Task`` that you can ``await`` to retrieve the
     :class:`ExecutionResult <fiftyone.operators.executor.ExecutionResult>`:
 
     .. code-block:: python
 
         op = foo.get_operator("@an-operator/with-results")
 
-        task = op(...)
-
-        await task
-        result = task.result()
+        result = await op(...)
         print(result.result) # {...}
 
 .. _delegating-function-calls:
@@ -771,15 +768,12 @@ data, you can access it via the ``result`` property of the returned
 .. note::
 
     When working in notebook contexts, executing operators returns an
-    ``asyncio.Task`` that you can ``await`` if necessary and then retrieve the
+    ``asyncio.Task`` that you can ``await`` to retrieve the
     :class:`ExecutionResult <fiftyone.operators.executor.ExecutionResult>`:
 
     .. code-block:: python
 
-        task = foo.execute_operator("@an-operator/with-results", ctx)
-
-        await task
-        result = task.result()
+        result = await foo.execute_operator("@an-operator/with-results", ctx)
         print(result.result)  # {...}
 
 .. _requesting-operator-delegation:

--- a/docs/source/plugins/using_plugins.rst
+++ b/docs/source/plugins/using_plugins.rst
@@ -626,7 +626,7 @@ data, you can access it via the ``result`` property of the returned
 .. code-block:: python
     :linenos:
 
-    op = foo.get_operator("@operator/with-results")
+    op = foo.get_operator("@an-operator/with-results")
 
     result = op(...)
     print(result.result) # {...}
@@ -638,6 +638,8 @@ data, you can access it via the ``result`` property of the returned
     :class:`ExecutionResult <fiftyone.operators.executor.ExecutionResult>`:
 
     .. code-block:: python
+
+        op = foo.get_operator("@an-operator/with-results")
 
         task = op(...)
 
@@ -763,7 +765,7 @@ data, you can access it via the ``result`` property of the returned
 .. code-block:: python
     :linenos:
 
-    result = foo.execute_operator("@operator/with-results", ctx)
+    result = foo.execute_operator("@an-operator/with-results", ctx)
     print(result.result)  # {...}
 
 .. note::
@@ -774,7 +776,7 @@ data, you can access it via the ``result`` property of the returned
 
     .. code-block:: python
 
-        task = foo.execute_operator("@operator/with-results", ctx)
+        task = foo.execute_operator("@an-operator/with-results", ctx)
 
         await task
         result = task.result()

--- a/docs/source/plugins/using_plugins.rst
+++ b/docs/source/plugins/using_plugins.rst
@@ -618,6 +618,33 @@ for the operator's `ctx.params` and then passes them to
 :func:`execute_operator() <fiftyone.operators.execute_operator>`, which
 performs the execution.
 
+For operators whose
+:meth:`execute() <fiftyone.operators.operator.Operator.execute>` method returns
+data, you can access it via the ``result`` property of the returned
+:class:`ExecutionResult <fiftyone.operators.executor.ExecutionResult>` object:
+
+.. code-block:: python
+    :linenos:
+
+    op = foo.get_operator("@operator/with-results")
+
+    result = op(...)
+    print(result.result) # {...}
+
+.. note::
+
+    When working in notebook contexts, executing operators returns an
+    ``asyncio.Task`` that you can ``await`` if necessary and then retrieve the
+    :class:`ExecutionResult <fiftyone.operators.executor.ExecutionResult>`:
+
+    .. code-block:: python
+
+        task = op(...)
+
+        await task
+        result = task.result()
+        print(result.result) # {...}
+
 .. _delegating-function-calls:
 
 Delegating function calls
@@ -705,7 +732,7 @@ You can also programmatically execute any operator by directly calling
         )
     }
 
-    result = foo.execute_operator("@voxel51/io/export_samples", ctx)
+    foo.execute_operator("@voxel51/io/export_samples", ctx)
 
 In the above example, the `delegate=True/False` parameter controls whether
 execution happens immediately or is
@@ -727,6 +754,31 @@ as follows:
     inspect the operator's
     :meth:`execute() <fiftyone.operators.operator.Operator.execute>`
     implementation to understand what parameters are required.
+
+For operators whose
+:meth:`execute() <fiftyone.operators.operator.Operator.execute>` method returns
+data, you can access it via the ``result`` property of the returned
+:class:`ExecutionResult <fiftyone.operators.executor.ExecutionResult>` object:
+
+.. code-block:: python
+    :linenos:
+
+    result = foo.execute_operator("@operator/with-results", ctx)
+    print(result.result)  # {...}
+
+.. note::
+
+    When working in notebook contexts, executing operators returns an
+    ``asyncio.Task`` that you can ``await`` if necessary and then retrieve the
+    :class:`ExecutionResult <fiftyone.operators.executor.ExecutionResult>`:
+
+    .. code-block:: python
+
+        task = foo.execute_operator("@operator/with-results", ctx)
+
+        await task
+        result = task.result()
+        print(result.result)  # {...}
 
 .. _requesting-operator-delegation:
 

--- a/fiftyone/operators/executor.py
+++ b/fiftyone/operators/executor.py
@@ -138,7 +138,8 @@ def execute_operator(operator_uri, ctx=None, **kwargs):
             as keyword arguments rather than including them in ``ctx``
 
     Returns:
-        an :class:`ExecutionResult`
+        an :class:`ExecutionResult`, or an ``asyncio.Task`` if you run this
+        method in a notebook context
 
     Raises:
         ExecutionError: if an error occurred while immediately executing an
@@ -157,11 +158,10 @@ def execute_operator(operator_uri, ctx=None, **kwargs):
         loop = None
 
     if loop is not None:
-        # @todo how can we await result here?
+        # @todo is it possible to await result here?
         # Sadly, run_until_complete() is not allowed in Jupyter notebooks
         # https://nocomplexity.com/documents/jupyterlab/tip-asyncio.html
-        loop.create_task(coroutine)
-        result = None
+        result = loop.create_task(coroutine)
     else:
         result = asyncio.run(coroutine)
         result.raise_exceptions()

--- a/fiftyone/operators/operator.py
+++ b/fiftyone/operators/operator.py
@@ -235,6 +235,9 @@ class Operator(object):
 
         Args:
             ctx: the :class:`fiftyone.operators.executor.ExecutionContext`
+
+        Returns:
+            JSON serializable data, or None
         """
         raise NotImplementedError("subclass must implement execute()")
 


### PR DESCRIPTION
`foo.execute_operator()` currently does not work in notebooks. Upon investigation, the reason is that notebooks internally use an async event loop to do their thing, and `foo.execute_operator()` uses `asyncio.run()`, which is not allowed when there is already an event loop running.

Using `asyncio.get_running_loop().create_task(...)` in place of `asyncio.run(...)` seems to do the trick when running in notebooks 💡 

https://github.com/voxel51/fiftyone/assets/25985824/47bf4c76-9e8a-48b9-834b-d265d2a75e58
