### PR TITLE
notify new subscriber of pending operator invocation requests

### DIFF
--- a/app/packages/operators/src/operators.ts
+++ b/app/packages/operators/src/operators.ts
@@ -751,16 +751,22 @@ export class InvocationRequestQueue {
     this._queue = [];
   }
   private _queue: QueueItem[];
-  private _subscribers: ((queue: InvocationRequestQueue) => void)[] = [];
+  private _subscribers: InvocationRequestQueueSubscriberType[] = [];
   private _notifySubscribers() {
     for (const subscriber of this._subscribers) {
-      subscriber(this);
+      this._notifySubscriber(subscriber);
     }
   }
-  subscribe(subscriber: (queue: InvocationRequestQueue) => void) {
-    this._subscribers.push(subscriber);
+  private _notifySubscriber(subscriber: InvocationRequestQueueSubscriberType) {
+    subscriber(this);
   }
-  unsubscribe(subscriber: (queue: InvocationRequestQueue) => void) {
+  subscribe(subscriber: InvocationRequestQueueSubscriberType) {
+    this._subscribers.push(subscriber);
+    if (this.hasPendingRequests()) {
+      this._notifySubscriber(subscriber);
+    }
+  }
+  unsubscribe(subscriber: InvocationRequestQueueSubscriberType) {
     const index = this._subscribers.indexOf(subscriber);
     if (index !== -1) {
       this._subscribers.splice(index, 1);
@@ -894,3 +900,7 @@ export function abortOperationsByURI(uri) {
 export function abortOperationsByExpression(expression) {
   getAbortableOperationQueue().abortByExpression(expression);
 }
+
+type InvocationRequestQueueSubscriberType = (
+  queue: InvocationRequestQueue
+) => void;


### PR DESCRIPTION
## What changes are proposed in this pull request?

Fix `on_startup` not executing on startup due to race condition where on_startup operators are executed before the invocation queue is initialized. With the change in the PR, when a subscriber is added, it will be notified of the queue if there are any pending invocation requests in the queue

## How is this patch tested? If it is not, please explain why.

Using the VoxelGPT plugin and verifying that the VoxelGPT panel launches on startup 

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

Fix `on_startup` not executing on app startup

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
