### PR TITLE
add ability to auto-execute operator on opening a dataset

### DIFF
--- a/app/packages/operators/src/index.ts
+++ b/app/packages/operators/src/index.ts
@@ -5,7 +5,6 @@ export {
   registerOperator,
   Operator,
   OperatorConfig,
-  executeStartupOperators,
   executeOperator,
   abortOperationsByExpression,
   abortOperationsByURI,

--- a/app/packages/operators/src/loader.tsx
+++ b/app/packages/operators/src/loader.tsx
@@ -4,7 +4,7 @@ import { useEffect, useState } from "react";
 import { useRecoilValue, useSetRecoilState } from "recoil";
 import { registerBuiltInOperators } from "./built-in-operators";
 import { useOperatorPlacementsResolver } from "./hooks";
-import { executeStartupOperators, loadOperatorsFromServer } from "./operators";
+import { executeOperatorsForEvent, loadOperatorsFromServer } from "./operators";
 import {
   availableOperatorsRefreshCount,
   operatorsInitializedAtom,
@@ -15,8 +15,9 @@ let startupOperatorsExecuted = false;
 async function loadOperators(datasetName: string) {
   registerBuiltInOperators();
   await loadOperatorsFromServer(datasetName);
+  executeOperatorsForEvent("onDatasetOpen");
   if (!startupOperatorsExecuted) {
-    executeStartupOperators();
+    executeOperatorsForEvent("onStartup");
     startupOperatorsExecuted = true;
   }
 }

--- a/app/packages/operators/src/operators.ts
+++ b/app/packages/operators/src/operators.ts
@@ -111,6 +111,7 @@ export type OperatorConfigOptions = {
   dynamic?: boolean;
   unlisted?: boolean;
   onStartup?: boolean;
+  onDatasetOpen?: boolean;
   canExecute?: boolean;
   disableSchemaValidation?: boolean;
   icon?: string;
@@ -126,6 +127,7 @@ export class OperatorConfig {
   public dynamic: boolean;
   public unlisted: boolean;
   public onStartup: boolean;
+  public onDatasetOpen: boolean;
   public canExecute = true;
   public disableSchemaValidation = false;
   public icon = null;
@@ -140,6 +142,7 @@ export class OperatorConfig {
     this.dynamic = options.dynamic || false;
     this.unlisted = options.unlisted || false;
     this.onStartup = options.onStartup || false;
+    this.onDatasetOpen = options.onDatasetOpen || false;
     this.canExecute = options.canExecute === false ? false : true;
     this.disableSchemaValidation =
       options.disableSchemaValidation === true ? true : false;
@@ -157,7 +160,8 @@ export class OperatorConfig {
       executeAsGenerator: json.execute_as_generator,
       dynamic: json.dynamic,
       unlisted: json.unlisted,
-      onStartup: json.on_startup,
+      onStartup: Boolean(json.on_startup),
+      onDatasetOpen: Boolean(json.on_dataset_open),
       canExecute: json.can_execute,
       disableSchemaValidation: json.disable_schema_validation,
       icon: json.icon,
@@ -349,13 +353,14 @@ export function listLocalAndRemoteOperators() {
   };
 }
 
-export async function executeStartupOperators() {
+export async function executeOperatorsForEvent(
+  event: "onStartup" | "onDatasetOpen"
+) {
   const { allOperators } = listLocalAndRemoteOperators();
-  const startupOperators = allOperators.filter(
-    (o) => o.config.onStartup === true
-  );
-  for (const operator of startupOperators) {
-    if (operator.config.canExecute) executeOperator(operator.uri);
+  for (const operator of allOperators) {
+    if (operator.config.canExecute && operator.config[event] === true) {
+      executeOperator(operator.uri);
+    }
   }
 }
 

--- a/docs/source/plugins/developing_plugins.rst
+++ b/docs/source/plugins/developing_plugins.rst
@@ -619,8 +619,12 @@ subsequent sections.
                 unlisted=True/False,  # default False
 
                 # Whether the operator should be executed every time a new App
-                # session starts (eg dataset is changed)
+                # session starts
                 on_startup=True/False,  # default False
+
+                # Whether the operator should be executed every time a new
+                # dataset is opened in the App
+                on_dataset_open=True/False,  # default False
 
                 # Custom icons to use
                 icon="/assets/icon.svg",
@@ -802,8 +806,12 @@ execution:
             unlisted=True/False,  # default False
 
             # Whether the operator should be executed every time a new App
-            # session starts (eg dataset is changed)
+            # session starts
             on_startup=True/False,  # default False
+
+            # Whether the operator should be executed every time a new dataset
+            # is opened in the App
+            on_dataset_open=True/False,  # default False
 
             # Custom icons to use
             icon="/assets/icon.svg",

--- a/docs/source/plugins/using_plugins.rst
+++ b/docs/source/plugins/using_plugins.rst
@@ -183,8 +183,8 @@ downloaded or created locally:
 
 .. code-block:: text
 
-    uri                                          enabled   builtin   unlisted   on_startup
-    -------------------------------------------  --------  --------  ---------  -----------
+    uri                                          enabled   builtin   unlisted
+    -------------------------------------------  --------  --------  ---------
     @voxel51/annotation/request_annotations      ✓
     @voxel51/annotation/load_annotations         ✓
     @voxel51/annotation/get_annotation_info      ✓
@@ -274,7 +274,7 @@ available metadata about a plugin:
     url                     https://github.com/voxel51/fiftyone-plugins/.../annotation/README.md
     license                 Apache 2.0
     description             Utilities for integrating FiftyOne with annotation tools
-    fiftyone_compatibility  *
+    fiftyone_compatibility  >=0.22
     operators               request_annotations
                             load_annotations
                             get_annotation_info
@@ -309,20 +309,25 @@ view the available metadata about an individual operator within a plugin:
 
 .. code-block:: text
 
-    key                        value
-    -------------------------  ----------------------
-    name                       import_samples
-    label                      Import samples
+    key                                  value
+    -----------------------------------  ----------------------
+    name                                 import_samples
+    label                                Import samples
     description
-    execute_as_generator       True
-    unlisted                   False
-    dynamic                    True
-    on_startup                 False
-    disable_schema_validation  False
+    execute_as_generator                 True
+    unlisted                             False
+    dynamic                              True
+    on_startup                           False
+    on_dataset_open                      False
+    disable_schema_validation            False
     delegation_target
     icon
-    dark_icon                  /assets/icon-dark.svg
-    light_icon                 /assets/icon-light.svg
+    dark_icon                            /assets/icon-dark.svg
+    light_icon                           /assets/icon-light.svg
+    allow_immediate_execution            True
+    allow_delegated_execution            False
+    default_choice_to_delegated          False
+    resolve_execution_options_on_change  True
 
 Installing plugin requirements
 ------------------------------

--- a/fiftyone/core/cli.py
+++ b/fiftyone/core/cli.py
@@ -2771,13 +2771,7 @@ def _print_operators_list(enabled, names_only):
 
         return
 
-    headers = [
-        "uri",
-        "enabled",
-        "builtin",
-        "unlisted",
-        "on_startup",
-    ]
+    headers = ["uri", "enabled", "builtin", "unlisted"]
 
     enabled_plugins = set(fop.list_enabled_plugins())
 
@@ -2789,7 +2783,6 @@ def _print_operators_list(enabled, names_only):
                 "enabled": op.builtin or op.plugin_name in enabled_plugins,
                 "builtin": op.builtin,
                 "unlisted": op.config.unlisted,
-                "on_startup": op.config.on_startup,
             }
         )
 

--- a/fiftyone/operators/operator.py
+++ b/fiftyone/operators/operator.py
@@ -26,6 +26,7 @@ class OperatorConfig(object):
         unlisted (False): whether the operator should be hidden from the
             Operator Browser
         on_startup (False): whether the operator should be executed on startup
+        on_dataset_open (False): whether the operator should be executed on opening a dataset
         disable_schema_validation (False): whether the operator built-in schema
             validation should be disabled
         icon (None): icon to show for the operator in the Operator Browser
@@ -53,6 +54,7 @@ class OperatorConfig(object):
         execute_as_generator=False,
         unlisted=False,
         on_startup=False,
+        on_dataset_open=False,
         disable_schema_validation=False,
         delegation_target=None,
         icon=None,
@@ -71,6 +73,7 @@ class OperatorConfig(object):
         self.execute_as_generator = execute_as_generator
         self.unlisted = unlisted
         self.on_startup = on_startup
+        self.on_dataset_open = on_dataset_open
         self.disable_schema_validation = disable_schema_validation
         self.delegation_target = delegation_target
         self.icon = icon
@@ -96,6 +99,7 @@ class OperatorConfig(object):
             "unlisted": self.unlisted,
             "dynamic": self.dynamic,
             "on_startup": self.on_startup,
+            "on_dataset_open": self.on_dataset_open,
             "disable_schema_validation": self.disable_schema_validation,
             "delegation_target": self.delegation_target,
             "icon": self.icon,

--- a/fiftyone/operators/operator.py
+++ b/fiftyone/operators/operator.py
@@ -26,7 +26,8 @@ class OperatorConfig(object):
         unlisted (False): whether the operator should be hidden from the
             Operator Browser
         on_startup (False): whether the operator should be executed on startup
-        on_dataset_open (False): whether the operator should be executed on opening a dataset
+        on_dataset_open (False): whether the operator should be executed on
+            opening a dataset
         disable_schema_validation (False): whether the operator built-in schema
             validation should be disabled
         icon (None): icon to show for the operator in the Operator Browser


### PR DESCRIPTION
## What changes are proposed in this pull request?

Add a new boolean OperatorConfig param `on_dataset_open` (`onDatasetOpen` in JS) to indicate if an operator should execute on opening a dataset. When set to `true`, the operator will execute for cases below:
- When a dataset is loaded on launching the app
- When a dataset is switched from dataset selector in the app
- When a dataset is switching using `session.dataset`
- When a dataset is switched using a trigger in the execution of an operator
- When a dataset is opened/switced by using a direct URL in the browser

## How is this patch tested? If it is not, please explain why.

Using cases listed above in the app

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

Add a new boolean OperatorConfig param `on_dataset_open` (`onDatasetOpen` in JS) to indicate if an operator should execute on opening a dataset.

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
