### PR TITLE
Fix indexed BooleanFields in Lightning Mode

### DIFF
--- a/app/packages/core/src/components/Common/Checkbox.tsx
+++ b/app/packages/core/src/components/Common/Checkbox.tsx
@@ -2,7 +2,7 @@ import { LoadingDots, useTheme } from "@fiftyone/components";
 import { Checkbox as MaterialCheckbox } from "@mui/material";
 import { animated } from "@react-spring/web";
 import React, { useMemo } from "react";
-import { constSelector, RecoilValueReadOnly } from "recoil";
+import { RecoilValueReadOnly, constSelector } from "recoil";
 import styled from "styled-components";
 import { prettify } from "../../utils/generic";
 import { ItemAction } from "../Actions/ItemAction";

--- a/app/packages/core/src/components/Filters/StringFilter/Checkboxes.tsx
+++ b/app/packages/core/src/components/Filters/StringFilter/Checkboxes.tsx
@@ -161,6 +161,7 @@ const Checkboxes = ({
 
   const show = useRecoilValue(showSearchSelector({ modal, path }));
   const keypoints = useRecoilValue(isInKeypointsField(path));
+  const lightning = useRecoilValue(fos.isLightningPath(path));
 
   if (loading) {
     return <LoadingDots text={"Loading"} />;
@@ -186,7 +187,8 @@ const Checkboxes = ({
             name={value === null ? "None" : value}
             loading={loading}
             count={
-              typeof count !== "number" || !isFilterMode || keypoints
+              (typeof count !== "number" || !isFilterMode || keypoints) &&
+              !lightning
                 ? // only string and id fields use pathSearchCount
                   pathSearchCount({ modal, path, value: value as string })
                 : count

--- a/app/packages/state/src/recoil/pathData/boolean.ts
+++ b/app/packages/state/src/recoil/pathData/boolean.ts
@@ -1,7 +1,6 @@
 import { selectorFamily } from "recoil";
 import { aggregation } from "../aggregations";
 import { isLightningPath, lightning } from "../lightning";
-import { noneCount } from "./counts";
 import { lightningBooleanResults } from "./lightningBoolean";
 
 export const booleanResults = selectorFamily<
@@ -19,7 +18,7 @@ export const booleanResults = selectorFamily<
         return get(lightningBooleanResults(params));
       }
 
-      return booleanCountResults(params);
+      return get(booleanCountResults(params));
     },
 });
 
@@ -29,7 +28,6 @@ export const booleanCountResults = selectorFamily({
     (params: { path: string; modal: boolean; extended: boolean }) =>
     ({ get }) => {
       const data = get(aggregation(params));
-      const none = get(noneCount(params));
 
       if (data.__typename !== "BooleanAggregation") {
         throw new Error("unexpected");
@@ -42,9 +40,7 @@ export const booleanCountResults = selectorFamily({
           { value: "True", count: data.true },
         ].filter(({ count }) => count),
       };
-      if (none) {
-        result.results.push({ value: null, count: none });
-      }
+
       return result;
     },
 });

--- a/app/packages/state/src/recoil/pathData/lightningBoolean.ts
+++ b/app/packages/state/src/recoil/pathData/lightningBoolean.ts
@@ -15,7 +15,9 @@ export const lightningBooleanResults = selectorFamily<
       const [data] = get(lightningQuery([{ path: params.path }]));
 
       if (data.__typename !== "BooleanLightningResult") {
-        throw new Error("unexpected");
+        throw new Error(
+          `unexpected result ${data.__typename} for path ${params.path}`
+        );
       }
 
       return {

--- a/app/packages/state/src/recoil/pathData/lightningBoolean.ts
+++ b/app/packages/state/src/recoil/pathData/lightningBoolean.ts
@@ -16,7 +16,7 @@ export const lightningBooleanResults = selectorFamily<
 
       if (data.__typename !== "BooleanLightningResult") {
         throw new Error(
-          `unexpected result ${data.__typename} for path ${params.path}`
+          `unexpected ${data.__typename} for path '${params.path}' in lightningBooleanResults`
         );
       }
 

--- a/app/packages/state/src/recoil/pathData/lightningNumeric.ts
+++ b/app/packages/state/src/recoil/pathData/lightningNumeric.ts
@@ -34,7 +34,7 @@ export const lightningNumericResults = selectorFamily({
       }
 
       throw new Error(
-        `unexpected type '${data.__typename}' for path '${path}'`
+        `unexpected ${data.__typename} for path '${path}' in lightningNumericResults`
       );
     },
 });

--- a/app/packages/state/src/recoil/pathData/lightningString.ts
+++ b/app/packages/state/src/recoil/pathData/lightningString.ts
@@ -12,7 +12,9 @@ export const lightningStringResults = selectorFamily<
       const [data] = get(lightningQuery([params]));
 
       if (data.__typename !== "StringLightningResult") {
-        throw new Error("bad");
+        throw new Error(
+          `unexpected result ${data.__typename} for path ${params.path}`
+        );
       }
 
       if (!data.values) {

--- a/app/packages/state/src/recoil/pathData/lightningString.ts
+++ b/app/packages/state/src/recoil/pathData/lightningString.ts
@@ -13,7 +13,7 @@ export const lightningStringResults = selectorFamily<
 
       if (data.__typename !== "StringLightningResult") {
         throw new Error(
-          `unexpected result ${data.__typename} for path ${params.path}`
+          `unexpected ${data.__typename} for path '${params.path}' in lightningStringResults`
         );
       }
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

Fixes a regression introduced by #3973 where indexed `BooleanField`s will throw an error in the `pathSearchResults` selector

## How is this patch tested? If it is not, please explain why.

```python
import fiftyone.zoo as foz

dataset = foz.load_zoo_dataset("quickstart", max_samples=1)
dataset.create_index("$**")
sample = dataset.first()
sample["bool"] = True
sample.save()
``` 

Opening the filter currently raises an error (see recording)

https://github.com/voxel51/fiftyone/assets/19821840/04383ecd-7e41-46b5-b675-605b04d96848


## Release Notes

* Fix indexed BooleanFields in Lightning Mode

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
