### PR TITLE
Avoid re-exporting media unnecessarily

### DIFF
--- a/fiftyone/utils/data/exporters.py
+++ b/fiftyone/utils/data/exporters.py
@@ -1221,6 +1221,7 @@ class MediaExporter(object):
             outpath = fos.normalize_path(outpath)
 
         if etau.is_str(media_or_path):
+            seen = False
             media_path = fos.normalize_path(media_or_path)
 
             if outpath is not None:
@@ -1229,17 +1230,19 @@ class MediaExporter(object):
                 outpath = media_or_path
                 uuid = self._get_uuid(media_path)
             else:
+                seen = self._filename_maker.seen_input_path(media_path)
                 outpath = self._filename_maker.get_output_path(media_path)
                 uuid = self._get_uuid(outpath)
 
-            if self.export_mode is True:
-                etau.copy_file(media_path, outpath)
-            elif self.export_mode == "move":
-                etau.move_file(media_path, outpath)
-            elif self.export_mode == "symlink":
-                etau.symlink_file(media_path, outpath)
-            elif self.export_mode == "manifest":
-                self._manifest[uuid] = media_path
+            if not seen:
+                if self.export_mode is True:
+                    etau.copy_file(media_path, outpath)
+                elif self.export_mode == "move":
+                    etau.move_file(media_path, outpath)
+                elif self.export_mode == "symlink":
+                    etau.symlink_file(media_path, outpath)
+                elif self.export_mode == "manifest":
+                    self._manifest[uuid] = media_path
         else:
             media = media_or_path
 


### PR DESCRIPTION
Small optimization to the `MediaExporter` class to avoid re-exporting the same media file multiple times, which would previously happen in situations like below where we are exporting a collection that contains multiple samples with the same `filepath`:

```py
import fiftyone as fo
import fiftyone.zoo as foz

dataset = foz.load_zoo_dataset("quickstart", max_samples=1)

view = dataset.to_patches("ground_truth")

assert len(view.distinct("filepath")) == 1

# Now only exports the common image once
view.export(
    export_dir="/tmp/test",
    dataset_type=fo.types.COCODetectionDataset,
    label_field="ground_truth",
)

dataset2 = fo.Dataset.from_dir(
    dataset_dir="/tmp/test",
    dataset_type=fo.types.COCODetectionDataset,
    label_field="ground_truth",
)

assert len(dataset2.distinct("filepath")) == 1
```
