### PR TITLE
Adding utilities for converting PCD datasets/slices to 3D

### DIFF
--- a/fiftyone/utils/data/exporters.py
+++ b/fiftyone/utils/data/exporters.py
@@ -1235,6 +1235,13 @@ class MediaExporter(object):
         if export_mode == "move":
             etau.delete_file(fo3d_path)
 
+    def __enter__(self):
+        self.setup()
+        return self
+
+    def __exit__(self, *args):
+        self.close()
+
     def _write_media(self, media, outpath):
         raise NotImplementedError("subclass must implement _write_media()")
 

--- a/fiftyone/utils/utils3d.py
+++ b/fiftyone/utils/utils3d.py
@@ -5,7 +5,7 @@
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
-
+import contextlib
 import itertools
 import logging
 import os
@@ -15,16 +15,19 @@ import numpy as np
 import scipy.spatial as sp
 
 import eta.core.numutils as etan
+import eta.core.utils as etau
 
 import fiftyone.core.fields as fof
 import fiftyone.core.labels as fol
 import fiftyone.core.media as fom
+import fiftyone.core.storage as fos
 import fiftyone.core.utils as fou
 import fiftyone.core.validation as fov
+import fiftyone.utils.data as foud
 import fiftyone.utils.image as foui
 from fiftyone.core.odm import DynamicEmbeddedDocument
 from fiftyone.core.sample import Sample
-from fiftyone.core.threed import Scene
+from fiftyone.core.threed import Pointcloud, Scene
 
 o3d = fou.lazy_import("open3d", callback=lambda: fou.ensure_package("open3d"))
 
@@ -857,3 +860,206 @@ def _fill_none(values, ref_values):
         return ref_values
 
     return [v if v is not None else r for v, r in zip(values, ref_values)]
+
+
+def pcd_to_3d(
+    dataset,
+    output_dir=None,
+    assets_dir=None,
+    rel_dir=None,
+    abs_paths=False,
+    progress=None,
+):
+    """Converts the point cloud samples in the given collection to equivalent
+    3D samples.
+
+    Args:
+        dataset: a point cloud :class:`fiftyone.core.dataset.Dataset`
+        output_dir (None): an optional output directory for the ``.fo3d`` files
+        assets_dir (None): an optional directory to copy the ``.pcd`` files
+            into. Can be either an absolute directory, a subdirectory of
+            ``output_dir``, or None if you do not wish to copy point clouds
+        rel_dir (None): an optional relative directory to strip from each point
+            cloud path to generate a unique identifier for each scene, which is
+            joined with ``output_dir`` to generate an output path for each
+            ``.fo3d`` file. This argument allows for populating nested
+            subdirectories that match the shape of the input paths. The path is
+            converted to an absolute path (if necessary) via
+            :func:`fiftyone.core.storage.normalize_path`
+        abs_paths (False): whether to store absolute paths to the point cloud
+            files in the exported ``.fo3d`` files
+        progress (None): whether to render a progress bar (True/False), use the
+            default value ``fiftyone.config.show_progress_bars`` (None), or a
+            progress callback function to invoke instead
+    """
+    fov.validate_collection(dataset, media_type=fom.POINT_CLOUD)
+
+    _pcd_to_3d(
+        dataset,
+        output_dir=output_dir,
+        assets_dir=assets_dir,
+        rel_dir=rel_dir,
+        abs_paths=abs_paths,
+        progress=progress,
+    )
+
+    dataset._doc.media_type = fom.THREE_D
+    dataset.save()
+
+
+def pcd_slices_to_3d_slices(
+    dataset,
+    slices=None,
+    output_dir=None,
+    assets_dir=None,
+    rel_dir=None,
+    abs_paths=False,
+    progress=None,
+):
+    """Converts the point cloud slice(s) of the given dataset to equivalent 3D
+    slices.
+
+    Args:
+        dataset: a :class:`fiftyone.core.dataset.Dataset` that contains groups
+        slices (None): optional point cloud slice(s) to convert, which can be:
+
+            -   None (default): all point cloud slices are converted in-place
+            -   a slice or iterable of slices to convert in-place
+            -   a dict mapping point cloud slices
+        output_dir (None): an optional output directory for the ``.fo3d`` files
+        assets_dir (None): an optional directory to copy the ``.pcd`` files
+            into. Can be either an absolute directory, a subdirectory of
+            ``output_dir``, or None if you do not wish to copy point clouds
+        rel_dir (None): an optional relative directory to strip from each point
+            cloud path to generate a unique identifier for each scene, which is
+            joined with ``output_dir`` to generate an output path for each
+            ``.fo3d`` file. This argument allows for populating nested
+            subdirectories that match the shape of the input paths. The path is
+            converted to an absolute path (if necessary) via
+            :func:`fiftyone.core.storage.normalize_path`
+        abs_paths (False): whether to store absolute paths to the point cloud
+            files in the exported scenes
+        progress (None): whether to render a progress bar (True/False), use the
+            default value ``fiftyone.config.show_progress_bars`` (None), or a
+            progress callback function to invoke instead
+
+    Returns:
+        the :class:`fiftyone.core.dataset.Dataset` containing the 3D samples
+    """
+    fov.validate_collection(dataset, media_type=fom.GROUP)
+
+    if isinstance(slices, dict):
+        pass
+    elif etau.is_container(slices):
+        slices = {s: s for s in slices}
+    elif slices is not None:
+        slices = {slices: slices}
+    else:
+        slices = {
+            k: k
+            for k, v in dataset.group_media_types.items()
+            if v == fom.POINT_CLOUD
+        }
+
+    curr_slice = slices.get(dataset.group_slice, dataset.group_slice)
+
+    try:
+        for in_slice, out_slice in slices.items():
+            dataset.group_slice = in_slice
+
+            _pcd_to_3d(
+                dataset,
+                output_dir=output_dir,
+                assets_dir=assets_dir,
+                rel_dir=rel_dir,
+                abs_paths=abs_paths,
+                progress=progress,
+            )
+
+            dataset._doc.group_media_types[in_slice] = fom.THREE_D
+            dataset.save()
+
+            if in_slice != out_slice:
+                dataset.rename_group_slice(in_slice, out_slice)
+    finally:
+        dataset.group_slice = curr_slice
+
+
+def _pcd_to_3d(
+    dataset,
+    output_dir=None,
+    assets_dir=None,
+    rel_dir=None,
+    abs_paths=False,
+    progress=None,
+):
+    filename_maker = None
+    media_exporter = None
+
+    if output_dir is not None:
+        filename_maker = fou.UniqueFilenameMaker(
+            output_dir=output_dir,
+            rel_dir=rel_dir,
+            ignore_existing=True,
+        )
+
+        if assets_dir is not None:
+            if not fos.isabs(assets_dir):
+                assets_dir = fos.join(output_dir, assets_dir)
+
+            media_exporter = foud.MediaExporter(
+                True,
+                export_path=assets_dir,
+                rel_dir=rel_dir,
+            )
+
+    ids, pcd_paths = dataset.values(["id", "filepath"])
+
+    scene_paths = []
+    with contextlib.ExitStack() as context:
+        if media_exporter is not None:
+            context.enter_context(media_exporter)
+
+        pb = context.enter_context(fou.ProgressBar(progress=progress))
+
+        for pcd_path in pb(pcd_paths):
+            scene_path = _make_scene(
+                pcd_path,
+                filename_maker=filename_maker,
+                media_exporter=media_exporter,
+                abs_paths=abs_paths,
+            )
+            scene_paths.append(scene_path)
+
+    dataset.set_values(
+        "filepath", dict(zip(ids, scene_paths)), key_field="id", validate=False
+    )
+    dataset.set_field("_media_type", fom.THREE_D, _allow_missing=True).save()
+
+
+def _make_scene(
+    pcd_path,
+    filename_maker=None,
+    media_exporter=None,
+    abs_paths=False,
+):
+    if filename_maker is not None:
+        scene_path = filename_maker.get_output_path(
+            input_path=pcd_path, output_ext=".fo3d"
+        )
+    else:
+        scene_path = os.path.splitext(pcd_path)[0] + ".fo3d"
+
+    if media_exporter is not None:
+        pcd_path, _ = media_exporter.export(pcd_path)
+
+    if not abs_paths:
+        rel_path = os.path.relpath(pcd_path, os.path.dirname(scene_path))
+        if not rel_path.startswith(".."):
+            pcd_path = rel_path
+
+    scene = Scene()
+    scene.add(Pointcloud("pcd", pcd_path))
+    scene.write(scene_path)
+
+    return scene_path

--- a/fiftyone/utils/utils3d.py
+++ b/fiftyone/utils/utils3d.py
@@ -1046,7 +1046,7 @@ def _make_scene(
             pcd_path = rel_path
 
     scene = Scene()
-    scene.add(Pointcloud("pcd", pcd_path))
+    scene.add(Pointcloud("point cloud", pcd_path))
     scene.write(scene_path)
 
     return scene_path


### PR DESCRIPTION
TODO before merging: apply cloud-friendly change described below

## Copy point clouds to `assets/` folder

```py
import fiftyone as fo
import fiftyone.zoo as foz

import fiftyone.utils.utils3d as fou3

dataset = foz.load_zoo_dataset("quickstart-groups")
dataset2 = dataset.select_group_slices("pcd").exclude_fields("group").clone()

fou3.pcd_to_3d(
    dataset,
    slices={"pcd": "3d"},
    output_dir="/tmp/test1",
    assets_dir="assets/",
    # abs_paths=True,  # if you want pcdPath in .fo3d to be absolute
)

fou3.pcd_to_3d(
    dataset2,
    output_dir="/tmp/test2",
    assets_dir="assets/",
    # abs_paths=True,  # if you want pcdPath in .fo3d to be absolute
)

dataset.group_slice = "3d"
dataset[:5].values("filepath")
dataset2[:5].values("filepath")
```

```
python -m json.tool /tmp/test1/003037.fo3d | head -n 50
python -m json.tool /tmp/test2/003037.fo3d | head -n 50
rm -rf /tmp/test1 /tmp/test2
```

## Write .fo3d files next to existing .pcd files

```py
import fiftyone as fo
import fiftyone.zoo as foz

import fiftyone.utils.utils3d as fou3

dataset = foz.load_zoo_dataset("quickstart-groups")
dataset2 = dataset.select_group_slices("pcd").exclude_fields("group").clone()

fou3.pcd_to_3d(dataset, slices={"pcd": "3d"})
fou3.pcd_to_3d(dataset2)

dataset.group_slice = "3d"
dataset[:5].values("filepath")
dataset2[:5].values("filepath")
```

```
python -m json.tool ~/fiftyone/quickstart-groups/data/003037.fo3d | head -n 50
```

## Cloud-friendly

```
diff --git a/fiftyone/utils/utils3d.py b/fiftyone/utils/utils3d.py
index 1ab3dec68..927faa5c3 100644
--- a/fiftyone/utils/utils3d.py
+++ b/fiftyone/utils/utils3d.py
@@ -1001,10 +1001,12 @@ def _pcd_to_3d(
             context.enter_context(media_exporter)
 
         pb = context.enter_context(fou.ProgressBar(progress=progress))
+        file_writer = context.enter_context(fos.FileWriter())
 
         for pcd_path in pb(pcd_paths):
             scene_path = _make_scene(
                 pcd_path,
+                file_writer,
                 filename_maker=filename_maker,
                 media_exporter=media_exporter,
                 abs_paths=abs_paths,
@@ -1019,6 +1021,7 @@ def _pcd_to_3d(
 
 def _make_scene(
     pcd_path,
+    file_writer,
     filename_maker=None,
     media_exporter=None,
     abs_paths=False,
@@ -1038,8 +1041,10 @@ def _make_scene(
         if not rel_path.startswith(".."):
             pcd_path = rel_path
 
+    local_scene_path = file_writer.get_local_path(scene_path)
+
     scene = Scene()
     scene.add(Pointcloud("point cloud", pcd_path))
-    scene.export(scene_path)
+    scene.export(local_scene_path)
 
     return scene_path
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced data export functionalities with context management for better setup and cleanup.
	- Upgraded 3D data processing capabilities, including support for additional arguments in point cloud conversion functions, facilitating more flexible dataset manipulations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->