### PR TITLE
Group dataset validation

### DIFF
--- a/fiftyone/core/media.py
+++ b/fiftyone/core/media.py
@@ -46,16 +46,24 @@ class MediaTypeError(TypeError):
 class SelectGroupSlicesError(ValueError):
     """Exception raised when a grouped collection is passed to a method that
     expects a primitive media type to be selected.
+
+    Args:
+        supported_media_types (None): an optional media type or iterable of
+            media types that are supported
     """
 
-    def __init__(self, supported_media_types):
-        if not isinstance(supported_media_types, str):
-            supported_media_types = "/".join(supported_media_types)
+    def __init__(self, supported_media_types=None):
+        if isinstance(supported_media_types, str):
+            type_str = supported_media_types + " "
+        elif supported_media_types is not None:
+            type_str = "/".join(supported_media_types) + " "
+        else:
+            type_str = ""
 
         message = (
             "This method does not directly support grouped collections. "
-            "You must use `select_group_slices()` to select %s slice(s) to "
+            "You must use `select_group_slices()` to select %sslice(s) to "
             "process"
-        ) % supported_media_types
+        ) % type_str
 
         super().__init__(message)

--- a/fiftyone/core/validation.py
+++ b/fiftyone/core/validation.py
@@ -159,6 +159,11 @@ def validate_non_grouped_collection(sample_collection):
     validate_collection(sample_collection)
 
     if sample_collection.media_type == fom.GROUP:
+        if sample_collection._is_dynamic_groups:
+            raise ValueError(
+                "This method does not support dynamic group views"
+            )
+
         raise fom.SelectGroupSlicesError()
 
 

--- a/fiftyone/core/validation.py
+++ b/fiftyone/core/validation.py
@@ -59,7 +59,7 @@ def validate_collection(sample_collection, media_type=None):
             that the collection must have
 
     Raises:
-        ValueError: if ``samples`` is not a
+        ValueError: if the provided samples are not a
         :class:`fiftyone.core.collections.SampleCollection`
     """
     if not isinstance(sample_collection, foc.SampleCollection):
@@ -97,7 +97,7 @@ def validate_image_collection(sample_collection):
         sample_collection: a sample collection
 
     Raises:
-        ValueError: if ``samples`` is not an image
+        ValueError: if the provided samples are not an image
         :class:`fiftyone.core.collections.SampleCollection`
     """
     validate_collection(sample_collection)
@@ -130,7 +130,7 @@ def validate_video_collection(sample_collection):
         sample_collection: a sample collection
 
     Raises:
-        ValueError: if ``samples`` is not a video
+        ValueError: if the provided samples are not a video
         :class:`fiftyone.core.collections.SampleCollection`
     """
     validate_collection(sample_collection)
@@ -143,6 +143,23 @@ def validate_video_collection(sample_collection):
             "Expected collection to have media type %s; found %s"
             % (fom.VIDEO, sample_collection.media_type)
         )
+
+
+def validate_non_grouped_collection(sample_collection):
+    """Validates that the provided samples are a
+    :class:`fiftyone.core.collections.SampleCollection` that is *not* grouped.
+
+    Args:
+        sample_collection: a sample collection
+
+    Raises:
+        ValueError: if the provided samples are a grouped
+        :class:`fiftyone.core.collections.SampleCollection`
+    """
+    validate_collection(sample_collection)
+
+    if sample_collection.media_type == fom.GROUP:
+        raise fom.SelectGroupSlicesError()
 
 
 def validate_collection_label_fields(

--- a/fiftyone/utils/annotations.py
+++ b/fiftyone/utils/annotations.py
@@ -216,9 +216,10 @@ def annotate(
     anno_backend.ensure_requirements()
 
     supported_media_types = anno_backend.supported_media_types
-    if samples.media_type == fomm.GROUP:
-        raise fomm.SelectGroupSlicesError(supported_media_types)
-    elif samples.media_type not in supported_media_types:
+    if samples.media_type not in supported_media_types:
+        if samples.media_type == fomm.GROUP:
+            raise fomm.SelectGroupSlicesError(supported_media_types)
+
         raise fomm.MediaTypeError(
             "The '%s' backend does not supported annotating '%s' collections"
             % (anno_backend.config.name, samples.media_type)

--- a/fiftyone/utils/cvat.py
+++ b/fiftyone/utils/cvat.py
@@ -127,6 +127,16 @@ def import_annotations(
         **kwargs: CVAT authentication credentials to pass to
             :class:`CVATBackendConfig`
     """
+    if sample_collection.media_type == fom.GROUP:
+        if insert_new:
+            raise ValueError(
+                "insert_new=True is not support for grouped collections"
+            )
+
+        sample_collection = sample_collection.select_group_slices(
+            _allow_mixed=True
+        )
+
     if bool(project_name) + bool(project_id) + bool(task_ids) != 1:
         raise ValueError(
             "Exactly one of 'project_name', 'project_id', or 'task_ids' must "

--- a/fiftyone/utils/cvat.py
+++ b/fiftyone/utils/cvat.py
@@ -130,7 +130,7 @@ def import_annotations(
     if sample_collection.media_type == fom.GROUP:
         if insert_new:
             raise ValueError(
-                "insert_new=True is not support for grouped collections"
+                "insert_new=True is not supported for grouped collections"
             )
 
         sample_collection = sample_collection.select_group_slices(

--- a/fiftyone/utils/eval/classification.py
+++ b/fiftyone/utils/eval/classification.py
@@ -91,6 +91,7 @@ def evaluate_classifications(
     Returns:
         a :class:`ClassificationResults`
     """
+    fov.validate_non_grouped_collection(samples)
     fov.validate_collection_label_fields(
         samples, (pred_field, gt_field), fol.Classification, same_type=True
     )

--- a/fiftyone/utils/eval/detection.py
+++ b/fiftyone/utils/eval/detection.py
@@ -141,6 +141,7 @@ def evaluate_detections(
     Returns:
         a :class:`DetectionResults`
     """
+    fov.validate_non_grouped_collection(samples)
     fov.validate_collection_label_fields(
         samples,
         (pred_field, gt_field),

--- a/fiftyone/utils/eval/regression.py
+++ b/fiftyone/utils/eval/regression.py
@@ -84,6 +84,7 @@ def evaluate_regressions(
     Returns:
         a :class:`RegressionResults`
     """
+    fov.validate_non_grouped_collection(samples)
     fov.validate_collection_label_fields(
         samples, (pred_field, gt_field), fol.Regression, same_type=True
     )

--- a/fiftyone/utils/eval/segmentation.py
+++ b/fiftyone/utils/eval/segmentation.py
@@ -96,6 +96,7 @@ def evaluate_segmentations(
     Returns:
         a :class:`SegmentationResults`
     """
+    fov.validate_non_grouped_collection(samples)
     fov.validate_collection_label_fields(
         samples, (pred_field, gt_field), fol.Segmentation, same_type=True
     )

--- a/fiftyone/utils/labels.py
+++ b/fiftyone/utils/labels.py
@@ -66,6 +66,7 @@ def objects_to_segmentations(
             default value ``fiftyone.config.show_progress_bars`` (None), or a
             progress callback function to invoke instead
     """
+    fov.validate_non_grouped_collection(sample_collection)
     fov.validate_collection_label_fields(
         sample_collection,
         in_field,
@@ -179,6 +180,7 @@ def export_segmentations(
             default value ``fiftyone.config.show_progress_bars`` (None), or a
             progress callback function to invoke instead
     """
+    fov.validate_non_grouped_collection(sample_collection)
     fov.validate_collection_label_fields(
         sample_collection, in_field, (fol.Segmentation, fol.Heatmap)
     )
@@ -240,6 +242,7 @@ def import_segmentations(
             default value ``fiftyone.config.show_progress_bars`` (None), or a
             progress callback function to invoke instead
     """
+    fov.validate_non_grouped_collection(sample_collection)
     fov.validate_collection_label_fields(
         sample_collection, in_field, (fol.Segmentation, fol.Heatmap)
     )
@@ -319,6 +322,7 @@ def transform_segmentations(
             default value ``fiftyone.config.show_progress_bars`` (None), or a
             progress callback function to invoke instead
     """
+    fov.validate_non_grouped_collection(sample_collection)
     fov.validate_collection_label_fields(
         sample_collection, in_field, fol.Segmentation
     )
@@ -422,6 +426,7 @@ def segmentations_to_detections(
             default value ``fiftyone.config.show_progress_bars`` (None), or a
             progress callback function to invoke instead
     """
+    fov.validate_non_grouped_collection(sample_collection)
     fov.validate_collection_label_fields(
         sample_collection,
         in_field,
@@ -477,6 +482,7 @@ def instances_to_polylines(
             default value ``fiftyone.config.show_progress_bars`` (None), or a
             progress callback function to invoke instead
     """
+    fov.validate_non_grouped_collection(sample_collection)
     fov.validate_collection_label_fields(
         sample_collection,
         in_field,
@@ -549,6 +555,7 @@ def segmentations_to_polylines(
             default value ``fiftyone.config.show_progress_bars`` (None), or a
             progress callback function to invoke instead
     """
+    fov.validate_non_grouped_collection(sample_collection)
     fov.validate_collection_label_fields(
         sample_collection,
         in_field,
@@ -595,6 +602,7 @@ def classification_to_detections(
             default value ``fiftyone.config.show_progress_bars`` (None), or a
             progress callback function to invoke instead
     """
+    fov.validate_non_grouped_collection(sample_collection)
     fov.validate_collection_label_fields(
         sample_collection, in_field, fol.Classification
     )
@@ -641,6 +649,7 @@ def classifications_to_detections(
             default value ``fiftyone.config.show_progress_bars`` (None), or a
             progress callback function to invoke instead
     """
+    fov.validate_non_grouped_collection(sample_collection)
     fov.validate_collection_label_fields(
         sample_collection, in_field, fol.Classifications
     )


### PR DESCRIPTION
Adds validation to nudge users to use `select_group_slices()` if they are passing a grouped collection to a method that was not specifically designed to handle grouped datasets/views.

This is intended to avoid confusion where users might expect that all slices of a grouped dataset will "automatically" be processed, when in fact the method would only process the active slice.
