### PR TITLE
Add YOLOv8, YOLOv9, and YOLO-World to FiftyOne Model Zoo

### DIFF
--- a/docs/source/integrations/ultralytics.rst
+++ b/docs/source/integrations/ultralytics.rst
@@ -21,7 +21,7 @@ following packages:
 
 .. code-block:: shell
 
-    pip install ultralytics "torch>=1.8"
+    pip install "ultralytics>=8.1.0" "torch>=1.8"
 
 .. _ultralytics-inference:
 
@@ -70,6 +70,10 @@ You can directly pass Ultralytics YOLO detection models to
     # model = YOLO("yolov5l.pt")
     # model = YOLO("yolov5x.pt")
 
+    # YOLOv9
+    # model = YOLO('yolov9c.pt')
+    # model = YOLO('yolov9e.pt')
+
     dataset.apply_model(model, label_field="boxes")
 
     session = fo.launch_app(dataset)
@@ -90,6 +94,34 @@ manually convert Ultralytics predictions to
 .. image:: /images/integrations/ultralytics_boxes.jpg
    :alt: ultralytics-boxes
    :align: center
+
+
+You can also load any of these detection models from the model zoo. To get a 
+list of available models, you can use the :meth:`fiftyone.zoo.list_zoo_models`
+method, and pass in `tags="yolo"` to filter the list to only show YOLO models. 
+This will limit the list to only show models that are compatible with 
+Ultralytics or Super-Gradients. In general, the model names will contain 
+"yolov", followed by the version number, then the model size (as in "n", "s", "m", 
+"l", or "x"), and an indicator of the label classes ("coco" for MS COCO or
+"world" for open-world), followed by "torch". 
+
+.. code-block:: python
+    :linenos:
+
+    model_name = 'yolov5l-coco-torch'
+    # model_name = 'yolov8m-coco-torch'
+    # model_name = 'yolov9e-coco-torch'
+
+    model = foz.load_zoo_model(
+        "yolov5s", 
+        label_field="boxes", 
+        confidence_thresh=0.5, 
+        iou_thresh=0.5
+        )
+
+    dataset.apply_model(model)
+
+    session = fo.launch_app(dataset)
 
 .. _ultralytics-open-vocabulary-object-detection:
 
@@ -118,7 +150,10 @@ that you can set the classes that the model should detect:
     
     ## Load model
     from ultralytics import YOLO
-    model = YOLO('yolov8l-world.pt') # or YOLO('yolov8s-world.pt')
+    model = YOLO('yolov8l-world.pt') 
+    # or YOLO('yolov8s-world.pt')
+    # or YOLO('yolov8m-world.pt')
+    # or YOLO('yolov8x-world.pt')
 
     ## Set open vocabulary classes
     model.set_classes(
@@ -138,6 +173,26 @@ that you can set the classes that the model should detect:
    :alt: ultralytics-open-world-boxes
    :align: center
 
+
+You can also load these open-vocabulary models from the model zoo, optionally
+specifying the classes that the model should detect:
+
+.. code-block:: python
+    :linenos:
+
+    model_name = 'yolov8l-world-torch'
+    # model_name = 'yolov8m-world-torch'
+    # model_name = 'yolov8x-world-torch'
+
+    model = foz.load_zoo_model(
+        model_name, 
+        label_field="yolo_world_detections", 
+        classes=["plant", "window", "keyboard", "human baby", "computer monitor"]
+        )
+
+    dataset.apply_model(model)
+
+    session = fo.launch_app(dataset)
 
 .. _ultralytics-instance-segmentation:
 

--- a/docs/source/integrations/ultralytics.rst
+++ b/docs/source/integrations/ultralytics.rst
@@ -71,8 +71,8 @@ You can directly pass Ultralytics YOLO detection models to
     # model = YOLO("yolov5x.pt")
 
     # YOLOv9
-    # model = YOLO('yolov9c.pt')
-    # model = YOLO('yolov9e.pt')
+    # model = YOLO("yolov9c.pt")
+    # model = YOLO("yolov9e.pt")
 
     dataset.apply_model(model, label_field="boxes")
 
@@ -95,104 +95,39 @@ manually convert Ultralytics predictions to
    :alt: ultralytics-boxes
    :align: center
 
-
-You can also load any of these detection models from the model zoo. To get a 
-list of available models, you can use the :meth:`fiftyone.zoo.list_zoo_models`
-method, and pass in `tags="yolo"` to filter the list to only show YOLO models. 
-This will limit the list to only show models that are compatible with 
-Ultralytics or Super-Gradients. In general, the model names will contain 
-"yolov", followed by the version number, then the model size (as in "n", "s", "m", 
-"l", or "x"), and an indicator of the label classes ("coco" for MS COCO or
-"world" for open-world), followed by "torch". 
+You can also load any of these models directly from the
+:ref:`FiftyOne Model Zoo <model-zoo>`:
 
 .. code-block:: python
     :linenos:
 
-    model_name = 'yolov5l-coco-torch'
-    # model_name = 'yolov8m-coco-torch'
-    # model_name = 'yolov9e-coco-torch'
+    model_name = "yolov5l-coco-torch"
+    # model_name = "yolov8m-coco-torch"
+    # model_name = "yolov9e-coco-torch"
 
     model = foz.load_zoo_model(
-        "yolov5s", 
+        model_name,
         label_field="boxes", 
         confidence_thresh=0.5, 
-        iou_thresh=0.5
-        )
+        iou_thresh=0.5,
+    )
 
     dataset.apply_model(model)
 
     session = fo.launch_app(dataset)
 
-.. _ultralytics-open-vocabulary-object-detection:
-
-Open vocabulary detection
--------------------------
-
-FiftyOne's Ultralytics integration also supports real-time open vocabulary
-object detection via `YOLO World <https://docs.ultralytics.com/models/yolo-world/>`_.
-
-The usage syntax is the same as for regular object detection, with the caveat
-that you can set the classes that the model should detect:
+You can use :func:`list_zoo_models() <fiftyone.zoo.list_zoo_models>` to see all
+available YOLO models that are compatible with Ultralytics or SuperGradients:
 
 .. code-block:: python
     :linenos:
 
-    import os; os.environ["YOLO_VERBOSE"] = "False"
+    print(foz.list_zoo_models(tags="yolo"))
 
-    import fiftyone as fo
-    import fiftyone.zoo as foz
-
-    ## Load dataset
-    dataset = foz.load_zoo_dataset(
-        "voc-2007", split="validation", max_samples=100
-        )
-    dataset.select_fields().keep_fields()
-    
-    ## Load model
-    from ultralytics import YOLO
-    model = YOLO('yolov8l-world.pt') 
-    # or YOLO('yolov8s-world.pt')
-    # or YOLO('yolov8m-world.pt')
-    # or YOLO('yolov8x-world.pt')
-
-    ## Set open vocabulary classes
-    model.set_classes(
-        ["plant", "window", "keyboard", "human baby", "computer monitor"]
-        )
-
-    label_field = "yolo_world_detections"
-
-    ## Apply model
-    dataset.apply_model(model, label_field=label_field)
-    
-    ## Visualize the detection patches
-    session = fo.launch_app(dataset.to_patches(label_field))
-
-
-.. image:: /images/integrations/ultralytics_open_world_boxes.png
-   :alt: ultralytics-open-world-boxes
-   :align: center
-
-
-You can also load these open-vocabulary models from the model zoo, optionally
-specifying the classes that the model should detect:
-
-.. code-block:: python
-    :linenos:
-
-    model_name = 'yolov8l-world-torch'
-    # model_name = 'yolov8m-world-torch'
-    # model_name = 'yolov8x-world-torch'
-
-    model = foz.load_zoo_model(
-        model_name, 
-        label_field="yolo_world_detections", 
-        classes=["plant", "window", "keyboard", "human baby", "computer monitor"]
-        )
-
-    dataset.apply_model(model)
-
-    session = fo.launch_app(dataset)
+In general, model names will contain "yolov", followed by the version number,
+then the model size ("n", "s", "m",  "l", or "x"), and an indicator of the
+label classes ("coco" for MS COCO or "world" for open-world), followed by
+"torch".
 
 .. _ultralytics-instance-segmentation:
 
@@ -284,6 +219,77 @@ manually convert Ultralytics predictions to :ref:`FiftyOne format <keypoints>`:
 .. image:: /images/integrations/ultralytics_keypoints.jpg
    :alt: ultralytics-keypoints
    :align: center
+
+.. _ultralytics-open-vocabulary-object-detection:
+
+Open vocabulary detection
+-------------------------
+
+FiftyOne's Ultralytics integration also supports real-time open vocabulary
+object detection via
+`YOLO World <https://docs.ultralytics.com/models/yolo-world/>`_.
+
+The usage syntax is the same as for regular object detection, with the caveat
+that you can set the classes that the model should detect:
+
+.. code-block:: python
+    :linenos:
+
+    import fiftyone as fo
+    import fiftyone.zoo as foz
+
+    from ultralytics import YOLO
+
+    ## Load dataset
+    dataset = foz.load_zoo_dataset(
+        "voc-2007", split="validation", max_samples=100
+    )
+    dataset.select_fields().keep_fields()
+
+    ## Load model
+    model = YOLO("yolov8l-world.pt")
+    # model = YOLO("yolov8s-world.pt")
+    # model =  YOLO("yolov8m-world.pt")
+    # model =  YOLO("yolov8x-world.pt")
+
+    ## Set open vocabulary classes
+    model.set_classes(
+        ["plant", "window", "keyboard", "human baby", "computer monitor"]
+    )
+
+    label_field = "yolo_world_detections"
+
+    ## Apply model
+    dataset.apply_model(model, label_field=label_field)
+
+    ## Visualize the detection patches
+    patches = dataset.to_patches(label_field)
+    session = fo.launch_app(patches)
+
+.. image:: /images/integrations/ultralytics_open_world_boxes.png
+   :alt: ultralytics-open-world-boxes
+   :align: center
+
+You can also load these open-vocabulary models from the
+:ref:`FiftyOne Model Zoo <model-zoo>`, optionally specifying the classes that
+the model should detect:
+
+.. code-block:: python
+    :linenos:
+
+    model_name = "yolov8l-world-torch"
+    # model_name = "yolov8m-world-torch"
+    # model_name = "yolov8x-world-torch"
+
+    model = foz.load_zoo_model(
+        model_name,
+        label_field="yolo_world_detections",
+        classes=["plant", "window", "keyboard", "human baby", "computer monitor"],
+    )
+
+    dataset.apply_model(model)
+
+    session = fo.launch_app(dataset)
 
 .. _ultralytics-batch-inference:
 

--- a/fiftyone/utils/ultralytics.py
+++ b/fiftyone/utils/ultralytics.py
@@ -301,7 +301,7 @@ class FiftyOneYOLOModelConfig(Config, fozm.HasZooModel):
         self.checkpoint_path = self.parse_string(
             d, "checkpoint_path", default=None
         )
-        self.model_name = d.get("model_name", "yolov5s-coco-torch")
+        self.model_name = d.get("model_name", None)
         self.classes = d.get("classes", None)
 
 
@@ -314,7 +314,8 @@ class FiftyOneYOLOModel(Model):
 
     def __init__(self, config):
         self.config = config
-        config.download_model_if_necessary()
+        if not hasattr(config, "model") or config.model is None:
+            config.download_model_if_necessary()
         self.model = self._load_model(config)
 
     def _get_checkpoint_path(self, config):
@@ -406,7 +407,7 @@ class FiftyOneYOLODetectionModelConfig(FiftyOneYOLOModelConfig):
         self.checkpoint_path = self.parse_string(
             d, "checkpoint_path", default=None
         )
-        self.model_name = d.get("model_name", "yolov5s-coco-torch")
+        self.model_name = d.get("model_name", None)
         self.classes = d.get("classes", None)
 
 

--- a/fiftyone/zoo/models/manifest-torch.json
+++ b/fiftyone/zoo/models/manifest-torch.json
@@ -2258,7 +2258,7 @@
                     "support": true
                 }
             },
-            "tags": ["detection", "coco", "torch"],
+            "tags": ["detection", "coco", "torch", "yolo"],
             "date_added": "2023-08-22 19:22:51"
         },
         {
@@ -2288,7 +2288,7 @@
                     "support": true
                 }
             },
-            "tags": ["detection", "coco", "torch"],
+            "tags": ["detection", "coco", "torch", "yolo"],
             "date_added": "2023-08-22 19:22:51"
         },
         {
@@ -2318,7 +2318,7 @@
                     "support": true
                 }
             },
-            "tags": ["detection", "coco", "torch"],
+            "tags": ["detection", "coco", "torch", "yolo"],
             "date_added": "2023-08-22 19:22:51"
         },
         {
@@ -2348,7 +2348,7 @@
                     "support": true
                 }
             },
-            "tags": ["detection", "coco", "torch"],
+            "tags": ["detection", "coco", "torch", "yolo"],
             "date_added": "2023-08-22 19:22:51"
         },
         {
@@ -2388,7 +2388,7 @@
                     "support": true
                 }
             },
-            "tags": ["detection", "coco", "torch"],
+            "tags": ["detection", "coco", "torch", "yolo"],
             "date_added": "2024-03-11 19:22:51"
         },
         {
@@ -2428,7 +2428,7 @@
                     "support": true
                 }
             },
-            "tags": ["detection", "coco", "torch"],
+            "tags": ["detection", "coco", "torch", "yolo"],
             "date_added": "2024-03-11 19:22:51"
         },
         {
@@ -2468,7 +2468,7 @@
                     "support": true
                 }
             },
-            "tags": ["detection", "coco", "torch"],
+            "tags": ["detection", "coco", "torch", "yolo"],
             "date_added": "2024-03-11 19:22:51"
         },
         {
@@ -2508,7 +2508,7 @@
                     "support": true
                 }
             },
-            "tags": ["detection", "coco", "torch"],
+            "tags": ["detection", "coco", "torch", "yolo"],
             "date_added": "2024-03-11 19:22:51"
         },
         {
@@ -2548,7 +2548,7 @@
                     "support": true
                 }
             },
-            "tags": ["detection", "coco", "torch"],
+            "tags": ["detection", "coco", "torch", "yolo"],
             "date_added": "2024-03-11 19:22:51"
         },
         {
@@ -2588,7 +2588,7 @@
                     "support": true
                 }
             },
-            "tags": ["detection", "coco", "torch"],
+            "tags": ["detection", "coco", "torch", "yolo"],
             "date_added": "2024-03-11 19:22:51"
         },
         {
@@ -2628,7 +2628,7 @@
                     "support": true
                 }
             },
-            "tags": ["detection", "coco", "torch"],
+            "tags": ["detection", "coco", "torch", "yolo"],
             "date_added": "2024-03-11 19:22:51"
         },
         {
@@ -2667,7 +2667,7 @@
                     "support": true
                 }
             },
-            "tags": ["detection", "torch", "zero-shot"],
+            "tags": ["detection", "torch", "yolo", "zero-shot"],
             "date_added": "2024-03-11 19:22:51"
         },
         {
@@ -2706,7 +2706,7 @@
                     "support": true
                 }
             },
-            "tags": ["detection", "torch", "zero-shot"],
+            "tags": ["detection", "torch", "yolo", "zero-shot"],
             "date_added": "2024-03-11 19:22:51"
         },
         {
@@ -2745,7 +2745,7 @@
                     "support": true
                 }
             },
-            "tags": ["detection", "torch", "zero-shot"],
+            "tags": ["detection", "torch", "yolo", "zero-shot"],
             "date_added": "2024-03-11 19:22:51"
         },
         {
@@ -2784,7 +2784,7 @@
                     "support": true
                 }
             },
-            "tags": ["detection", "torch", "zero-shot"],
+            "tags": ["detection", "torch", "yolo", "zero-shot"],
             "date_added": "2024-03-11 19:22:51"
         },
         {

--- a/fiftyone/zoo/models/manifest-torch.json
+++ b/fiftyone/zoo/models/manifest-torch.json
@@ -2365,11 +2365,7 @@
             },
             "default_deployment_config_dict": {
                 "type": "fiftyone.utils.ultralytics.FiftyOneYOLODetectionModel",
-                "config": {
-                    "model_name": "yolov8n-coco-torch",
-                    "output_processor_cls": "fiftyone.utils.ultralytics.UltralyticsOutputProcessor",
-                    "raw_inputs": true
-                }
+                "config": {}
             },
             "requirements": {
                 "packages": [
@@ -2401,11 +2397,7 @@
             },
             "default_deployment_config_dict": {
                 "type": "fiftyone.utils.ultralytics.FiftyOneYOLODetectionModel",
-                "config": {
-                    "model_name": "yolov8s-coco-torch",
-                    "output_processor_cls": "fiftyone.utils.ultralytics.UltralyticsOutputProcessor",
-                    "raw_inputs": true
-                }
+                "config": {}
             },
             "requirements": {
                 "packages": [
@@ -2437,11 +2429,7 @@
             },
             "default_deployment_config_dict": {
                 "type": "fiftyone.utils.ultralytics.FiftyOneYOLODetectionModel",
-                "config": {
-                    "model_name": "yolov8m-coco-torch",
-                    "output_processor_cls": "fiftyone.utils.ultralytics.UltralyticsOutputProcessor",
-                    "raw_inputs": true
-                }
+                "config": {}
             },
             "requirements": {
                 "packages": [
@@ -2473,11 +2461,7 @@
             },
             "default_deployment_config_dict": {
                 "type": "fiftyone.utils.ultralytics.FiftyOneYOLODetectionModel",
-                "config": {
-                    "model_name": "yolov8l-coco-torch",
-                    "output_processor_cls": "fiftyone.utils.ultralytics.UltralyticsOutputProcessor",
-                    "raw_inputs": true
-                }
+                "config": {}
             },
             "requirements": {
                 "packages": [
@@ -2509,11 +2493,7 @@
             },
             "default_deployment_config_dict": {
                 "type": "fiftyone.utils.ultralytics.FiftyOneYOLODetectionModel",
-                "config": {
-                    "model_name": "yolov8x-coco-torch",
-                    "output_processor_cls": "fiftyone.utils.ultralytics.UltralyticsOutputProcessor",
-                    "raw_inputs": true
-                }
+                "config": {}
             },
             "requirements": {
                 "packages": [
@@ -2545,11 +2525,7 @@
             },
             "default_deployment_config_dict": {
                 "type": "fiftyone.utils.ultralytics.FiftyOneYOLODetectionModel",
-                "config": {
-                    "model_name": "yolov9c-coco-torch",
-                    "output_processor_cls": "fiftyone.utils.ultralytics.UltralyticsOutputProcessor",
-                    "raw_inputs": true
-                }
+                "config": {}
             },
             "requirements": {
                 "packages": [
@@ -2581,11 +2557,7 @@
             },
             "default_deployment_config_dict": {
                 "type": "fiftyone.utils.ultralytics.FiftyOneYOLODetectionModel",
-                "config": {
-                    "model_name": "yolov9e-coco-torch",
-                    "output_processor_cls": "fiftyone.utils.ultralytics.UltralyticsOutputProcessor",
-                    "raw_inputs": true
-                }
+                "config": {}
             },
             "requirements": {
                 "packages": [
@@ -2617,11 +2589,7 @@
             },
             "default_deployment_config_dict": {
                 "type": "fiftyone.utils.ultralytics.FiftyOneYOLODetectionModel",
-                "config": {
-                    "model_name": "yolov8s-world-torch",
-                    "output_processor_cls": "fiftyone.utils.ultralytics.UltralyticsOutputProcessor",
-                    "raw_inputs": true
-                }
+                "config": {}
             },
             "requirements": {
                 "packages": [
@@ -2653,11 +2621,7 @@
             },
             "default_deployment_config_dict": {
                 "type": "fiftyone.utils.ultralytics.FiftyOneYOLODetectionModel",
-                "config": {
-                    "model_name": "yolov8m-world-torch",
-                    "output_processor_cls": "fiftyone.utils.ultralytics.UltralyticsOutputProcessor",
-                    "raw_inputs": true
-                }
+                "config": {}
             },
             "requirements": {
                 "packages": [
@@ -2689,11 +2653,7 @@
             },
             "default_deployment_config_dict": {
                 "type": "fiftyone.utils.ultralytics.FiftyOneYOLODetectionModel",
-                "config": {
-                    "model_name": "yolov8l-world-torch",
-                    "output_processor_cls": "fiftyone.utils.ultralytics.UltralyticsOutputProcessor",
-                    "raw_inputs": true
-                }
+                "config": {}
             },
             "requirements": {
                 "packages": [
@@ -2725,11 +2685,7 @@
             },
             "default_deployment_config_dict": {
                 "type": "fiftyone.utils.ultralytics.FiftyOneYOLODetectionModel",
-                "config": {
-                    "model_name": "yolov8x-world-torch",
-                    "output_processor_cls": "fiftyone.utils.ultralytics.UltralyticsOutputProcessor",
-                    "raw_inputs": true
-                }
+                "config": {}
             },
             "requirements": {
                 "packages": [

--- a/fiftyone/zoo/models/manifest-torch.json
+++ b/fiftyone/zoo/models/manifest-torch.json
@@ -2811,7 +2811,7 @@
                     "support": true
                 }
             },
-            "tags": ["classification", "torch"],
+            "tags": ["classification", "torch", "yolo"],
             "date_added": "2024-01-06 08:51:14"
         },
         {
@@ -2841,7 +2841,7 @@
                     "support": true
                 }
             },
-            "tags": ["detection", "coco", "torch"],
+            "tags": ["detection", "coco", "torch", "yolo"],
             "date_added": "2023-08-22 19:22:51"
         }
     ]

--- a/fiftyone/zoo/models/manifest-torch.json
+++ b/fiftyone/zoo/models/manifest-torch.json
@@ -2352,6 +2352,442 @@
             "date_added": "2023-08-22 19:22:51"
         },
         {
+            "base_name": "yolov8n-coco-torch",
+            "base_filename": "yolov8n-coco.pt",
+            "description": "Ultralytics YOLOv8n model trained on COCO",
+            "source": "https://docs.ultralytics.com/models/yolov8/",
+            "size_bytes": 6534387,
+            "manager": {
+                "type": "fiftyone.core.models.ModelManager",
+                "config": {
+                    "url": "https://github.com/ultralytics/assets/releases/download/v8.1.0/yolov8n.pt"
+                }
+            },
+            "default_deployment_config_dict": {
+                "type": "fiftyone.utils.ultralytics.FiftyOneYOLODetectionModel",
+                "config": {
+                    "entrypoint_fcn": "fiftyone.utils.ultralytics.load_yolo_model",
+                    "entrypoint_args": {
+                        "model_name": "yolov8n-coco-torch"
+                    },
+                    "labels_path": "{{eta-resources}}/ms-coco-labels.txt",
+                    "output_processor_cls": "fiftyone.utils.ultralytics.UltralyticsOutputProcessor",
+                    "raw_inputs": true
+                }
+            },
+            "requirements": {
+                "packages": [
+                    "torch>=1.7.0",
+                    "torchvision>=0.8.1",
+                    "ultralytics"
+                ],
+                "cpu": {
+                    "support": true
+                },
+                "gpu": {
+                    "support": true
+                }
+            },
+            "tags": ["detection", "coco", "torch"],
+            "date_added": "2024-03-11 19:22:51"
+        },
+        {
+            "base_name": "yolov8s-coco-torch",
+            "base_filename": "yolov8s-coco.pt",
+            "description": "Ultralytics YOLOv8s model trained on COCO",
+            "source": "https://docs.ultralytics.com/models/yolov8/",
+            "size_bytes": 22573363,
+            "manager": {
+                "type": "fiftyone.core.models.ModelManager",
+                "config": {
+                    "url": "https://github.com/ultralytics/assets/releases/download/v8.1.0/yolov8s.pt"
+                }
+            },
+            "default_deployment_config_dict": {
+                "type": "fiftyone.utils.ultralytics.FiftyOneYOLODetectionModel",
+                "config": {
+                    "entrypoint_fcn": "fiftyone.utils.ultralytics.load_yolo_model",
+                    "entrypoint_args": {
+                        "model_name": "yolov8s-coco-torch"
+                    },
+                    "labels_path": "{{eta-resources}}/ms-coco-labels.txt",
+                    "output_processor_cls": "fiftyone.utils.ultralytics.UltralyticsOutputProcessor",
+                    "raw_inputs": true
+                }
+            },
+            "requirements": {
+                "packages": [
+                    "torch>=1.7.0",
+                    "torchvision>=0.8.1",
+                    "ultralytics"
+                ],
+                "cpu": {
+                    "support": true
+                },
+                "gpu": {
+                    "support": true
+                }
+            },
+            "tags": ["detection", "coco", "torch"],
+            "date_added": "2024-03-11 19:22:51"
+        },
+        {
+            "base_name": "yolov8m-coco-torch",
+            "base_filename": "yolov8m-coco.pt",
+            "description": "Ultralytics YOLOv8m model trained on COCO",
+            "source": "https://docs.ultralytics.com/models/yolov8/",
+            "size_bytes": 52117635,
+            "manager": {
+                "type": "fiftyone.core.models.ModelManager",
+                "config": {
+                    "url": "https://github.com/ultralytics/assets/releases/download/v8.1.0/yolov8m.pt"
+                }
+            },
+            "default_deployment_config_dict": {
+                "type": "fiftyone.utils.ultralytics.FiftyOneYOLODetectionModel",
+                "config": {
+                    "entrypoint_fcn": "fiftyone.utils.ultralytics.load_yolo_model",
+                    "entrypoint_args": {
+                        "model_name": "yolov8m-coco-torch"
+                    },
+                    "labels_path": "{{eta-resources}}/ms-coco-labels.txt",
+                    "output_processor_cls": "fiftyone.utils.ultralytics.UltralyticsOutputProcessor",
+                    "raw_inputs": true
+                }
+            },
+            "requirements": {
+                "packages": [
+                    "torch>=1.7.0",
+                    "torchvision>=0.8.1",
+                    "ultralytics"
+                ],
+                "cpu": {
+                    "support": true
+                },
+                "gpu": {
+                    "support": true
+                }
+            },
+            "tags": ["detection", "coco", "torch"],
+            "date_added": "2024-03-11 19:22:51"
+        },
+        {
+            "base_name": "yolov8l-coco-torch",
+            "base_filename": "yolov8l-coco.pt",
+            "description": "Ultralytics YOLOv8l model trained on COCO",
+            "source": "https://docs.ultralytics.com/models/yolov8/",
+            "size_bytes": 87769683,
+            "manager": {
+                "type": "fiftyone.core.models.ModelManager",
+                "config": {
+                    "url": "https://github.com/ultralytics/assets/releases/download/v8.1.0/yolov8l.pt"
+                }
+            },
+            "default_deployment_config_dict": {
+                "type": "fiftyone.utils.ultralytics.FiftyOneYOLODetectionModel",
+                "config": {
+                    "entrypoint_fcn": "fiftyone.utils.ultralytics.load_yolo_model",
+                    "entrypoint_args": {
+                        "model_name": "yolov8l-coco-torch"
+                    },
+                    "labels_path": "{{eta-resources}}/ms-coco-labels.txt",
+                    "output_processor_cls": "fiftyone.utils.ultralytics.UltralyticsOutputProcessor",
+                    "raw_inputs": true
+                }
+            },
+            "requirements": {
+                "packages": [
+                    "torch>=1.7.0",
+                    "torchvision>=0.8.1",
+                    "ultralytics"
+                ],
+                "cpu": {
+                    "support": true
+                },
+                "gpu": {
+                    "support": true
+                }
+            },
+            "tags": ["detection", "coco", "torch"],
+            "date_added": "2024-03-11 19:22:51"
+        },
+        {
+            "base_name": "yolov8x-coco-torch",
+            "base_filename": "yolov8x-coco.pt",
+            "description": "Ultralytics YOLOv8x model trained on COCO",
+            "source": "https://docs.ultralytics.com/models/yolov8/",
+            "size_bytes": 136867539,
+            "manager": {
+                "type": "fiftyone.core.models.ModelManager",
+                "config": {
+                    "url": "https://github.com/ultralytics/assets/releases/download/v8.1.0/yolov8x.pt"
+                }
+            },
+            "default_deployment_config_dict": {
+                "type": "fiftyone.utils.ultralytics.FiftyOneYOLODetectionModel",
+                "config": {
+                    "entrypoint_fcn": "fiftyone.utils.ultralytics.load_yolo_model",
+                    "entrypoint_args": {
+                        "model_name": "yolov8x-coco-torch"
+                    },
+                    "labels_path": "{{eta-resources}}/ms-coco-labels.txt",
+                    "output_processor_cls": "fiftyone.utils.ultralytics.UltralyticsOutputProcessor",
+                    "raw_inputs": true
+                }
+            },
+            "requirements": {
+                "packages": [
+                    "torch>=1.7.0",
+                    "torchvision>=0.8.1",
+                    "ultralytics"
+                ],
+                "cpu": {
+                    "support": true
+                },
+                "gpu": {
+                    "support": true
+                }
+            },
+            "tags": ["detection", "coco", "torch"],
+            "date_added": "2024-03-11 19:22:51"
+        },
+        {
+            "base_name": "yolov9c-coco-torch",
+            "base_filename": "yolov9c-coco.pt",
+            "description": "YOLOv9-C model trained on COCO",
+            "source": "https://docs.ultralytics.com/models/yolov9/",
+            "size_bytes": 51802599,
+            "manager": {
+                "type": "fiftyone.core.models.ModelManager",
+                "config": {
+                    "url": "https://github.com/ultralytics/assets/releases/download/v8.1.0/yolov9c.pt"
+                }
+            },
+            "default_deployment_config_dict": {
+                "type": "fiftyone.utils.ultralytics.FiftyOneYOLODetectionModel",
+                "config": {
+                    "entrypoint_fcn": "fiftyone.utils.ultralytics.load_yolo_model",
+                    "entrypoint_args": {
+                        "model_name": "yolov9c-coco-torch"
+                    },
+                    "labels_path": "{{eta-resources}}/ms-coco-labels.txt",
+                    "output_processor_cls": "fiftyone.utils.ultralytics.UltralyticsOutputProcessor",
+                    "raw_inputs": true
+                }
+            },
+            "requirements": {
+                "packages": [
+                    "torch>=1.7.0",
+                    "torchvision>=0.8.1",
+                    "ultralytics>=8.1.0"
+                ],
+                "cpu": {
+                    "support": true
+                },
+                "gpu": {
+                    "support": true
+                }
+            },
+            "tags": ["detection", "coco", "torch"],
+            "date_added": "2024-03-11 19:22:51"
+        },
+        {
+            "base_name": "yolov9e-coco-torch",
+            "base_filename": "yolov9e-coco.pt",
+            "description": "YOLOv9-E model trained on COCO",
+            "source": "https://docs.ultralytics.com/models/yolov9/",
+            "size_bytes": 117530476,
+            "manager": {
+                "type": "fiftyone.core.models.ModelManager",
+                "config": {
+                    "url": "https://github.com/ultralytics/assets/releases/download/v8.1.0/yolov9e.pt"
+                }
+            },
+            "default_deployment_config_dict": {
+                "type": "fiftyone.utils.ultralytics.FiftyOneYOLODetectionModel",
+                "config": {
+                    "entrypoint_fcn": "fiftyone.utils.ultralytics.load_yolo_model",
+                    "entrypoint_args": {
+                        "model_name": "yolov9e-coco-torch"
+                    },
+                    "labels_path": "{{eta-resources}}/ms-coco-labels.txt",
+                    "output_processor_cls": "fiftyone.utils.ultralytics.UltralyticsOutputProcessor",
+                    "raw_inputs": true
+                }
+            },
+            "requirements": {
+                "packages": [
+                    "torch>=1.7.0",
+                    "torchvision>=0.8.1",
+                    "ultralytics>=8.1.0"
+                ],
+                "cpu": {
+                    "support": true
+                },
+                "gpu": {
+                    "support": true
+                }
+            },
+            "tags": ["detection", "coco", "torch"],
+            "date_added": "2024-03-11 19:22:51"
+        },
+        {
+            "base_name": "yolov8s-world-torch",
+            "base_filename": "yolov8s-world.pt",
+            "description": "YOLOv8s-World model",
+            "source": "https://docs.ultralytics.com/models/yolo-world/",
+            "size_bytes": 27166882,
+            "manager": {
+                "type": "fiftyone.core.models.ModelManager",
+                "config": {
+                    "url": "https://github.com/ultralytics/assets/releases/download/v8.1.0/yolov8s-world.pt"
+                }
+            },
+            "default_deployment_config_dict": {
+                "type": "fiftyone.utils.ultralytics.FiftyOneYOLODetectionModel",
+                "config": {
+                    "entrypoint_fcn": "fiftyone.utils.ultralytics.load_yolo_model",
+                    "entrypoint_args": {
+                        "model_name": "yolov8s-world-torch"
+                    },
+                    "output_processor_cls": "fiftyone.utils.ultralytics.UltralyticsOutputProcessor",
+                    "raw_inputs": true
+                }
+            },
+            "requirements": {
+                "packages": [
+                    "torch>=1.7.0",
+                    "torchvision>=0.8.1",
+                    "ultralytics>=8.1.0"
+                ],
+                "cpu": {
+                    "support": true
+                },
+                "gpu": {
+                    "support": true
+                }
+            },
+            "tags": ["detection", "torch", "zero-shot"],
+            "date_added": "2024-03-11 19:22:51"
+        },
+        {
+            "base_name": "yolov8m-world-torch",
+            "base_filename": "yolov8m-world.pt",
+            "description": "YOLOv8m-World model",
+            "source": "https://docs.ultralytics.com/models/yolo-world/",
+            "size_bytes": 58607810,
+            "manager": {
+                "type": "fiftyone.core.models.ModelManager",
+                "config": {
+                    "url": "https://github.com/ultralytics/assets/releases/download/v8.1.0/yolov8m-world.pt"
+                }
+            },
+            "default_deployment_config_dict": {
+                "type": "fiftyone.utils.ultralytics.FiftyOneYOLODetectionModel",
+                "config": {
+                    "entrypoint_fcn": "fiftyone.utils.ultralytics.load_yolo_model",
+                    "entrypoint_args": {
+                        "model_name": "yolov8m-world-torch"
+                    },
+                    "output_processor_cls": "fiftyone.utils.ultralytics.UltralyticsOutputProcessor",
+                    "raw_inputs": true
+                }
+            },
+            "requirements": {
+                "packages": [
+                    "torch>=1.7.0",
+                    "torchvision>=0.8.1",
+                    "ultralytics>=8.1.0"
+                ],
+                "cpu": {
+                    "support": true
+                },
+                "gpu": {
+                    "support": true
+                }
+            },
+            "tags": ["detection", "torch", "zero-shot"],
+            "date_added": "2024-03-11 19:22:51"
+        },
+        {
+            "base_name": "yolov8l-world-torch",
+            "base_filename": "yolov8l-world.pt",
+            "description": "YOLOv8l-World model",
+            "source": "https://docs.ultralytics.com/models/yolo-world/",
+            "size_bytes": 95664610,
+            "manager": {
+                "type": "fiftyone.core.models.ModelManager",
+                "config": {
+                    "url": "https://github.com/ultralytics/assets/releases/download/v8.1.0/yolov8l-world.pt"
+                }
+            },
+            "default_deployment_config_dict": {
+                "type": "fiftyone.utils.ultralytics.FiftyOneYOLODetectionModel",
+                "config": {
+                    "entrypoint_fcn": "fiftyone.utils.ultralytics.load_yolo_model",
+                    "entrypoint_args": {
+                        "model_name": "yolov8l-world-torch"
+                    },
+                    "output_processor_cls": "fiftyone.utils.ultralytics.UltralyticsOutputProcessor",
+                    "raw_inputs": true
+                }
+            },
+            "requirements": {
+                "packages": [
+                    "torch>=1.7.0",
+                    "torchvision>=0.8.1",
+                    "ultralytics>=8.1.0"
+                ],
+                "cpu": {
+                    "support": true
+                },
+                "gpu": {
+                    "support": true
+                }
+            },
+            "tags": ["detection", "torch", "zero-shot"],
+            "date_added": "2024-03-11 19:22:51"
+        },
+        {
+            "base_name": "yolov8x-world-torch",
+            "base_filename": "yolov8x-world.pt",
+            "description": "YOLOv8x-World model",
+            "source": "https://docs.ultralytics.com/models/yolo-world/",
+            "size_bytes": 147959522,
+            "manager": {
+                "type": "fiftyone.core.models.ModelManager",
+                "config": {
+                    "url": "https://github.com/ultralytics/assets/releases/download/v8.1.0/yolov8x-world.pt"
+                }
+            },
+            "default_deployment_config_dict": {
+                "type": "fiftyone.utils.ultralytics.FiftyOneYOLODetectionModel",
+                "config": {
+                    "entrypoint_fcn": "fiftyone.utils.ultralytics.load_yolo_model",
+                    "entrypoint_args": {
+                        "model_name": "yolov8x-world-torch"
+                    },
+                    "output_processor_cls": "fiftyone.utils.ultralytics.UltralyticsOutputProcessor",
+                    "raw_inputs": true
+                }
+            },
+            "requirements": {
+                "packages": [
+                    "torch>=1.7.0",
+                    "torchvision>=0.8.1",
+                    "ultralytics>=8.1.0"
+                ],
+                "cpu": {
+                    "support": true
+                },
+                "gpu": {
+                    "support": true
+                }
+            },
+            "tags": ["detection", "torch", "zero-shot"],
+            "date_added": "2024-03-11 19:22:51"
+        },
+        {
             "base_name": "yolo-nas-torch",
             "base_filename": null,
             "version": null,

--- a/fiftyone/zoo/models/manifest-torch.json
+++ b/fiftyone/zoo/models/manifest-torch.json
@@ -2366,11 +2366,7 @@
             "default_deployment_config_dict": {
                 "type": "fiftyone.utils.ultralytics.FiftyOneYOLODetectionModel",
                 "config": {
-                    "entrypoint_fcn": "fiftyone.utils.ultralytics.load_yolo_model",
-                    "entrypoint_args": {
-                        "model_name": "yolov8n-coco-torch"
-                    },
-                    "labels_path": "{{eta-resources}}/ms-coco-labels.txt",
+                    "model_name": "yolov8n-coco-torch",
                     "output_processor_cls": "fiftyone.utils.ultralytics.UltralyticsOutputProcessor",
                     "raw_inputs": true
                 }
@@ -2406,11 +2402,7 @@
             "default_deployment_config_dict": {
                 "type": "fiftyone.utils.ultralytics.FiftyOneYOLODetectionModel",
                 "config": {
-                    "entrypoint_fcn": "fiftyone.utils.ultralytics.load_yolo_model",
-                    "entrypoint_args": {
-                        "model_name": "yolov8s-coco-torch"
-                    },
-                    "labels_path": "{{eta-resources}}/ms-coco-labels.txt",
+                    "model_name": "yolov8s-coco-torch",
                     "output_processor_cls": "fiftyone.utils.ultralytics.UltralyticsOutputProcessor",
                     "raw_inputs": true
                 }
@@ -2446,11 +2438,7 @@
             "default_deployment_config_dict": {
                 "type": "fiftyone.utils.ultralytics.FiftyOneYOLODetectionModel",
                 "config": {
-                    "entrypoint_fcn": "fiftyone.utils.ultralytics.load_yolo_model",
-                    "entrypoint_args": {
-                        "model_name": "yolov8m-coco-torch"
-                    },
-                    "labels_path": "{{eta-resources}}/ms-coco-labels.txt",
+                    "model_name": "yolov8m-coco-torch",
                     "output_processor_cls": "fiftyone.utils.ultralytics.UltralyticsOutputProcessor",
                     "raw_inputs": true
                 }
@@ -2486,11 +2474,7 @@
             "default_deployment_config_dict": {
                 "type": "fiftyone.utils.ultralytics.FiftyOneYOLODetectionModel",
                 "config": {
-                    "entrypoint_fcn": "fiftyone.utils.ultralytics.load_yolo_model",
-                    "entrypoint_args": {
-                        "model_name": "yolov8l-coco-torch"
-                    },
-                    "labels_path": "{{eta-resources}}/ms-coco-labels.txt",
+                    "model_name": "yolov8l-coco-torch",
                     "output_processor_cls": "fiftyone.utils.ultralytics.UltralyticsOutputProcessor",
                     "raw_inputs": true
                 }
@@ -2526,11 +2510,7 @@
             "default_deployment_config_dict": {
                 "type": "fiftyone.utils.ultralytics.FiftyOneYOLODetectionModel",
                 "config": {
-                    "entrypoint_fcn": "fiftyone.utils.ultralytics.load_yolo_model",
-                    "entrypoint_args": {
-                        "model_name": "yolov8x-coco-torch"
-                    },
-                    "labels_path": "{{eta-resources}}/ms-coco-labels.txt",
+                    "model_name": "yolov8x-coco-torch",
                     "output_processor_cls": "fiftyone.utils.ultralytics.UltralyticsOutputProcessor",
                     "raw_inputs": true
                 }
@@ -2566,11 +2546,7 @@
             "default_deployment_config_dict": {
                 "type": "fiftyone.utils.ultralytics.FiftyOneYOLODetectionModel",
                 "config": {
-                    "entrypoint_fcn": "fiftyone.utils.ultralytics.load_yolo_model",
-                    "entrypoint_args": {
-                        "model_name": "yolov9c-coco-torch"
-                    },
-                    "labels_path": "{{eta-resources}}/ms-coco-labels.txt",
+                    "model_name": "yolov9c-coco-torch",
                     "output_processor_cls": "fiftyone.utils.ultralytics.UltralyticsOutputProcessor",
                     "raw_inputs": true
                 }
@@ -2606,11 +2582,7 @@
             "default_deployment_config_dict": {
                 "type": "fiftyone.utils.ultralytics.FiftyOneYOLODetectionModel",
                 "config": {
-                    "entrypoint_fcn": "fiftyone.utils.ultralytics.load_yolo_model",
-                    "entrypoint_args": {
-                        "model_name": "yolov9e-coco-torch"
-                    },
-                    "labels_path": "{{eta-resources}}/ms-coco-labels.txt",
+                    "model_name": "yolov9e-coco-torch",
                     "output_processor_cls": "fiftyone.utils.ultralytics.UltralyticsOutputProcessor",
                     "raw_inputs": true
                 }
@@ -2646,10 +2618,7 @@
             "default_deployment_config_dict": {
                 "type": "fiftyone.utils.ultralytics.FiftyOneYOLODetectionModel",
                 "config": {
-                    "entrypoint_fcn": "fiftyone.utils.ultralytics.load_yolo_model",
-                    "entrypoint_args": {
-                        "model_name": "yolov8s-world-torch"
-                    },
+                    "model_name": "yolov8s-world-torch",
                     "output_processor_cls": "fiftyone.utils.ultralytics.UltralyticsOutputProcessor",
                     "raw_inputs": true
                 }
@@ -2685,10 +2654,7 @@
             "default_deployment_config_dict": {
                 "type": "fiftyone.utils.ultralytics.FiftyOneYOLODetectionModel",
                 "config": {
-                    "entrypoint_fcn": "fiftyone.utils.ultralytics.load_yolo_model",
-                    "entrypoint_args": {
-                        "model_name": "yolov8m-world-torch"
-                    },
+                    "model_name": "yolov8m-world-torch",
                     "output_processor_cls": "fiftyone.utils.ultralytics.UltralyticsOutputProcessor",
                     "raw_inputs": true
                 }
@@ -2724,10 +2690,7 @@
             "default_deployment_config_dict": {
                 "type": "fiftyone.utils.ultralytics.FiftyOneYOLODetectionModel",
                 "config": {
-                    "entrypoint_fcn": "fiftyone.utils.ultralytics.load_yolo_model",
-                    "entrypoint_args": {
-                        "model_name": "yolov8l-world-torch"
-                    },
+                    "model_name": "yolov8l-world-torch",
                     "output_processor_cls": "fiftyone.utils.ultralytics.UltralyticsOutputProcessor",
                     "raw_inputs": true
                 }
@@ -2763,10 +2726,7 @@
             "default_deployment_config_dict": {
                 "type": "fiftyone.utils.ultralytics.FiftyOneYOLODetectionModel",
                 "config": {
-                    "entrypoint_fcn": "fiftyone.utils.ultralytics.load_yolo_model",
-                    "entrypoint_args": {
-                        "model_name": "yolov8x-world-torch"
-                    },
+                    "model_name": "yolov8x-world-torch",
                     "output_processor_cls": "fiftyone.utils.ultralytics.UltralyticsOutputProcessor",
                     "raw_inputs": true
                 }


### PR DESCRIPTION
With our Ultralytics integration, it is currently possible to load a YOLOv8, YOLOv9, or YOLO-World model from Ultralytics and then apply it to a FiftyOne dataset. This PR goes a step further and directly adds these models to the model zoo.

One upside of this approach is that model location is managed by FiftyOne, as opposed to loading directly from Ultralytics, which results in the checkpoint being downloaded to your current working directory.

The PR updates the Ultralytics integration docs to reflect these new changes.


(Details)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

Adds YOLOv8, YOLOv9, and YOLO-World models directly to the zoo

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [x] Documentation: FiftyOne documentation changes
-   [x] Other
