### PR TITLE
Declaring compatibility with python 3.11 and (partially) 3.12

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -93,7 +93,7 @@ jobs:
             --ignore tests/intensive/ \
             --ignore tests/no_wrapper
       - name: Upload
-        if: ${{ !startsWith(matrix.os, 'windows') && matrix.python == '3.10' }}
+        if: ${{ !startsWith(matrix.os, 'windows') && matrix.python == '3.9' }}
         uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,13 +39,16 @@ jobs:
           - ubuntu-latest-m
           - windows-latest
         python:
-          - 3.8
+          - "3.8"
           - "3.10"
+          - "3.11"
         exclude:
           - os: windows-latest
-            python: 3.8
+            python: "3.8"
           - os: windows-latest
             python: "3.10"
+          - os: windows-latest
+            python: "3.11"
     defaults:
       run:
         shell: bash
@@ -90,7 +93,7 @@ jobs:
             --ignore tests/intensive/ \
             --ignore tests/no_wrapper
       - name: Upload
-        if: ${{ !startsWith(matrix.os, 'windows') && matrix.python == '3.9' }}
+        if: ${{ !startsWith(matrix.os, 'windows') && matrix.python == '3.10' }}
         uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/docs/source/getting_started/install.rst
+++ b/docs/source/getting_started/install.rst
@@ -20,9 +20,11 @@ Prerequisites
 -------------
 
 You will need a working Python installation. FiftyOne currently requires
-**Python 3.7 - 3.10**.
+**Python 3.7 - 3.12** (3D features may not be available in 3.12 until
+`open3d <https://pypi.org/project/open3d/>`_ supports it)
 
-On Linux, we recommended installing Python through your system package manager
+
+On Linux, we recommend installing Python through your system package manager
 (APT, YUM, etc.) if it is available. On other platforms, Python can be
 downloaded `from python.org <https://www.python.org/downloads>`_. To verify that
 a suitable Python version is installed and accessible, run `python --version`.

--- a/docs/source/getting_started/install.rst
+++ b/docs/source/getting_started/install.rst
@@ -20,8 +20,7 @@ Prerequisites
 -------------
 
 You will need a working Python installation. FiftyOne currently requires
-**Python 3.7 - 3.12** (3D features may not be available in 3.12 until
-`open3d <https://pypi.org/project/open3d/>`_ supports it)
+**Python 3.7 - 3.12**
 
 
 On Linux, we recommend installing Python through your system package manager

--- a/setup.py
+++ b/setup.py
@@ -165,6 +165,8 @@ setup(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
     ],
     entry_points={"console_scripts": ["fiftyone=fiftyone.core.cli:main"]},
     python_requires=">=3.7",

--- a/tests/unittests/delegated_operators_tests.py
+++ b/tests/unittests/delegated_operators_tests.py
@@ -1054,12 +1054,12 @@ class DelegatedOperationServiceTests(unittest.TestCase):
             delegation_target=f"test_target",
             context=ctx.serialize(),
         )
-        self.assertEquals(doc.label, mock_get_operator.return_value.name)
+        self.assertEqual(doc.label, mock_get_operator.return_value.name)
 
         self.docs_to_delete.append(doc)
 
         doc = self.svc.set_label(doc.id, "this is my delegated operation run.")
-        self.assertEquals(doc.label, "this is my delegated operation run.")
+        self.assertEqual(doc.label, "this is my delegated operation run.")
 
         doc = self.svc.get(doc.id)
-        self.assertEquals(doc.label, "this is my delegated operation run.")
+        self.assertEqual(doc.label, "this is my delegated operation run.")


### PR DESCRIPTION
## What changes are proposed in this pull request?

Declare support for python 3.11 and python 3.12.

With caveat that 3D in python 3.12 is not yet supported until `open3d` [supports 3.12](https://github.com/isl-org/Open3D/issues/6433)

## How is this patch tested? If it is not, please explain why.

For version in python3.11, python3.12 ...
- Unit tests passing
- Launched app with quickstart and did various cursory manual testing
- Read through documented release notes / breaking changes / deprecations to identify potential issues.

There is probably something I missed (if unit tests don’t cover). But mostly it seems to just work.

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

Officially support python 3.11 and 3.12

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [x] Documentation: FiftyOne documentation changes
-   [ ] Other
