### PR TITLE
add support for setting saved view in set-view operator

### DIFF
--- a/app/packages/operators/src/built-in-operators.ts
+++ b/app/packages/operators/src/built-in-operators.ts
@@ -19,6 +19,7 @@ import {
   listLocalAndRemoteOperators,
 } from "./operators";
 import { useShowOperatorIO } from "./state";
+import { useSetRecoilState } from "recoil";
 
 //
 // BUILT-IN OPERATORS
@@ -459,18 +460,23 @@ class SetView extends Operator {
   useHooks(ctx: ExecutionContext): {} {
     return {
       setView: fos.useSetView(),
+      setViewName: useSetRecoilState(fos.viewName),
     };
   }
   async resolveInput(ctx: ExecutionContext): Promise<types.Property> {
     const inputs = new types.Object();
-    inputs.obj("view", {
-      label: "View",
-      required: true,
-    });
+    inputs.obj("view", { view: new types.HiddenView({}) });
+    inputs.str("name", { label: "Name of a saved view" });
     return new types.Property(inputs);
   }
-  async execute({ state, hooks, params }: ExecutionContext) {
-    hooks.setView(params.view);
+  async execute({ hooks, params }: ExecutionContext) {
+    if (params.view) {
+      hooks.setView(params.view);
+    } else if (params.name) {
+      hooks.setViewName(params.name);
+    } else {
+      throw new Error('Param "view" or "name" is required to set a view');
+    }
   }
 }
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

add support for setting a saved view with the `set_view` built-in operator

### Usage: setting a view using the name of a saved view
```py
def execute(self, ctx):
    ctx.trigger("set_view", {"name": "my-saved-view-name"})
```

## How is this patch tested? If it is not, please explain why.

Using an example operator with a snippet above

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

add support for setting a saved view with the `set_view` built-in operator

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
