### PR TITLE
Adding Non-Maximum Suppression (NMS) utility to fiftyone.utils.labels through perform_nms()

### DIFF
--- a/fiftyone/utils/labels.py
+++ b/fiftyone/utils/labels.py
@@ -5,6 +5,7 @@ Label utilities.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+import eta.core.serial as etas
 import eta.core.utils as etau
 
 import fiftyone.core.labels as fol
@@ -673,3 +674,116 @@ def classifications_to_detections(
                 detections.append(detection)
 
             image[out_field] = fol.Detections(detections=detections)
+
+
+def perform_nms(
+    sample_collection,
+    in_field,
+    out_field,
+    conf_threshold=0.6,
+    iou_threshold=0.5,
+    progress=None,
+):
+    """Performs Non-Maximum Suppression (NMS) on the
+    :class:`fiftyone.core.labels.Detections` field containing detections.
+
+    NMS is a post-processing technique used in object detection to eliminate
+    duplicate detections and select the most relevant detected objects. This
+    helps reduce false positives.
+
+    Args:
+        sample_collection: a
+            :class:`fiftyone.core.collections.SampleCollection`
+        in_field: the name of the :class:`fiftyone.core.labels.Detections` field
+        out_field: the name of the :class:`fiftyone.core.labels.Detections`
+            field to populate. Creates a new field if one doesn't already exist
+            with this name.
+        conf_threshold (0.6): a floating-point value between 0 and 1 representing
+            the minimum confidence score required for a detection to be considered
+            valid. Detections with confidence scores lower than this threshold
+            will be discarded during the Non-Maximum Suppression (NMS) process.
+        iou_threshold (0.5): a floating-point value between 0 and 1 representing
+            the Intersection over Union (IoU) threshold used in the NMS algorithm.
+            It determines the minimum overlap required between bounding boxes for
+            them to be considered duplicates. Bounding boxes with IoU values
+            greater than or equal to this threshold will be suppressed.
+        progress (None): whether to render a progress bar (True/False), use the
+            default value ``fiftyone.config.show_progress_bars`` (None), or a
+            progress callback function to invoke instead
+    """
+    fov.validate_collection_label_fields(
+        sample_collection, in_field, fol.Detections
+    )
+
+    samples = sample_collection.select_fields(in_field)
+
+    with fou.ProgressBar(progress=progress) as pb:
+        for sample in pb(samples):
+            detections_data_json_str = sample[in_field].to_json()
+            nms_detections_data_json_str = _perform_nms(
+                detections_data_json_str, conf_threshold, iou_threshold
+            )
+            nms_processed_detections = fol.Detections.from_json(
+                nms_detections_data_json_str
+            )
+            sample[out_field] = nms_processed_detections
+            sample.save()
+
+
+def _perform_nms(
+    detections_data_json_str, conf_threshold=0.6, iou_threshold=0.5
+):
+    detections_data_json = etas.load_json(detections_data_json_str)
+    detections = detections_data_json["detections"]
+
+    # Sort detections by confidence in descending order
+    detections.sort(key=lambda x: x["confidence"], reverse=True)
+
+    # Remove detections with confidence less than the conf_threshold
+    detections = [d for d in detections if d["confidence"] >= conf_threshold]
+
+    nms_detections = []
+
+    while len(detections) > 0:
+        # Pick the detection with highest confidence
+        selected_detection = detections[0]
+        nms_detections.append(selected_detection)
+        del detections[0]
+
+        # Compare with other detections for NMS
+        for d in detections:
+            if d["label"] == selected_detection["label"]:
+                iou = _calculate_iou(
+                    selected_detection["bounding_box"], d["bounding_box"]
+                )
+                if iou >= iou_threshold:
+                    # Remove the detection if IoU is greater than iou_threshold
+                    detections.remove(d)
+
+    # Update detections_data_json with NMS results
+    detections_data_json["detections"] = nms_detections
+    return etas.json_to_str(detections_data_json, pretty_print=False)
+
+
+def _calculate_iou(box1, box2):
+    x1_tl, y1_tl, w1, h1 = box1
+    x2_tl, y2_tl, w2, h2 = box2
+
+    x1_br, y1_br = x1_tl + w1, y1_tl + h1
+    x2_br, y2_br = x2_tl + w2, y2_tl + h2
+
+    # Calculate the coordinates of the intersection rectangle
+    x_overlap = max(0, min(x1_br, x2_br) - max(x1_tl, x2_tl))
+    y_overlap = max(0, min(y1_br, y2_br) - max(y1_tl, y2_tl))
+    intersection_area = x_overlap * y_overlap
+
+    # Calculate the area of each bounding box
+    box1_area = w1 * h1
+    box2_area = w2 * h2
+
+    # Calculate the Union area by using Formula: Union(A,B) = A + B - Inter(A,B)
+    union_area = box1_area + box2_area - intersection_area
+
+    # Compute IoU
+    iou = intersection_area / union_area
+    return iou

--- a/fiftyone/utils/labels.py
+++ b/fiftyone/utils/labels.py
@@ -5,7 +5,6 @@ Label utilities.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
-import eta.core.serial as etas
 import eta.core.utils as etau
 
 import fiftyone.core.labels as fol

--- a/fiftyone/utils/labels.py
+++ b/fiftyone/utils/labels.py
@@ -11,6 +11,7 @@ import eta.core.utils as etau
 import fiftyone.core.labels as fol
 import fiftyone.core.utils as fou
 import fiftyone.core.validation as fov
+import fiftyone.utils.iou as foi
 
 
 def objects_to_segmentations(
@@ -679,7 +680,7 @@ def classifications_to_detections(
 def perform_nms(
     sample_collection,
     in_field,
-    out_field,
+    out_field=None,
     conf_threshold=0.6,
     iou_threshold=0.5,
     progress=None,
@@ -695,9 +696,9 @@ def perform_nms(
         sample_collection: a
             :class:`fiftyone.core.collections.SampleCollection`
         in_field: the name of the :class:`fiftyone.core.labels.Detections` field
-        out_field: the name of the :class:`fiftyone.core.labels.Detections`
-            field to populate. Creates a new field if one doesn't already exist
-            with this name.
+        out_field (None): the name of the :class:`fiftyone.core.labels.Detections`
+            field to populate. If not specified (None), the input field is updated
+            in-place.
         conf_threshold (0.6): a floating-point value between 0 and 1 representing
             the minimum confidence score required for a detection to be considered
             valid. Detections with confidence scores lower than this threshold
@@ -719,28 +720,25 @@ def perform_nms(
 
     with fou.ProgressBar(progress=progress) as pb:
         for sample in pb(samples):
-            detections_data_json_str = sample[in_field].to_json()
-            nms_detections_data_json_str = _perform_nms(
-                detections_data_json_str, conf_threshold, iou_threshold
+            detections_data = sample[in_field].copy()
+            nms_processed_detections = _perform_nms(
+                detections_data, conf_threshold, iou_threshold
             )
-            nms_processed_detections = fol.Detections.from_json(
-                nms_detections_data_json_str
-            )
-            sample[out_field] = nms_processed_detections
+            if out_field is None:
+                sample[in_field] = nms_processed_detections
+            else:
+                sample[out_field] = nms_processed_detections
             sample.save()
 
 
-def _perform_nms(
-    detections_data_json_str, conf_threshold=0.6, iou_threshold=0.5
-):
-    detections_data_json = etas.load_json(detections_data_json_str)
-    detections = detections_data_json["detections"]
+def _perform_nms(detections_data, conf_threshold=0.6, iou_threshold=0.5):
+    detections = detections_data.detections
 
     # Sort detections by confidence in descending order
-    detections.sort(key=lambda x: x["confidence"], reverse=True)
+    detections.sort(key=lambda x: x.confidence, reverse=True)
 
     # Remove detections with confidence less than the conf_threshold
-    detections = [d for d in detections if d["confidence"] >= conf_threshold]
+    detections = [d for d in detections if d.confidence >= conf_threshold]
 
     nms_detections = []
 
@@ -752,38 +750,12 @@ def _perform_nms(
 
         # Compare with other detections for NMS
         for d in detections:
-            if d["label"] == selected_detection["label"]:
-                iou = _calculate_iou(
-                    selected_detection["bounding_box"], d["bounding_box"]
-                )
+            if d.label == selected_detection.label:
+                iou = foi.compute_ious([selected_detection], [d])[0][0]
                 if iou >= iou_threshold:
                     # Remove the detection if IoU is greater than iou_threshold
                     detections.remove(d)
 
     # Update detections_data_json with NMS results
-    detections_data_json["detections"] = nms_detections
-    return etas.json_to_str(detections_data_json, pretty_print=False)
-
-
-def _calculate_iou(box1, box2):
-    x1_tl, y1_tl, w1, h1 = box1
-    x2_tl, y2_tl, w2, h2 = box2
-
-    x1_br, y1_br = x1_tl + w1, y1_tl + h1
-    x2_br, y2_br = x2_tl + w2, y2_tl + h2
-
-    # Calculate the coordinates of the intersection rectangle
-    x_overlap = max(0, min(x1_br, x2_br) - max(x1_tl, x2_tl))
-    y_overlap = max(0, min(y1_br, y2_br) - max(y1_tl, y2_tl))
-    intersection_area = x_overlap * y_overlap
-
-    # Calculate the area of each bounding box
-    box1_area = w1 * h1
-    box2_area = w2 * h2
-
-    # Calculate the Union area by using Formula: Union(A,B) = A + B - Inter(A,B)
-    union_area = box1_area + box2_area - intersection_area
-
-    # Compute IoU
-    iou = intersection_area / union_area
-    return iou
+    detections_data.detections = nms_detections
+    return detections_data

--- a/fiftyone/utils/labels.py
+++ b/fiftyone/utils/labels.py
@@ -756,6 +756,6 @@ def _perform_nms(detections_data, conf_threshold=0.6, iou_threshold=0.5):
                     # Remove the detection if IoU is greater than iou_threshold
                     detections.remove(d)
 
-    # Update detections_data_json with NMS results
+    # Update detections_data with NMS results
     detections_data.detections = nms_detections
     return detections_data


### PR DESCRIPTION
## What changes are proposed in this pull request?

Adds Non-Maximum Suppression (NMS) utility to fiftyone.utils.labels through `perform_nms()`! :tada:

It can be loaded as follows:
```python
import fiftyone.utils.labels as fl

dataset = foz.load_zoo_dataset(
    "coco-2017",
    split="validation",
    dataset_name="detector-recipe",
)

predictions_view = dataset.take(10, seed=51)

fl.perform_nms(sample_collection=predictions_view, in_field="predictions", out_field="nms_predictions", conf_threshold=0.65, iou_threshold=0.4, progress=True)
```

## How is this patch tested? If it is not, please explain why.

It has been thoroughly tested, as seen in this [nms_test.pdf](https://github.com/voxel51/fiftyone/files/14607543/nms_test.pdf)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

Addition of perform_nms() utility to fiftyone.utils.labels

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [x] Documentation: FiftyOne documentation changes
-   [ ] Other
