### PR TITLE
Clashing dataset slug - better error message

### DIFF
--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -105,8 +105,19 @@ def _validate_dataset_name(name, skip=None):
         query = {"$and": [query, {"_id": {"$ne": skip._doc.id}}]}
 
     conn = foo.get_db_conn()
-    if bool(list(conn.datasets.find(query, {"_id": 1}).limit(1))):
-        raise ValueError("Dataset name '%s' is not available" % name)
+
+    clashing_name_doc = conn.datasets.find_one(
+        query, {"name": True, "_id": False}
+    )
+    if clashing_name_doc is not None:
+        clashing_name = clashing_name_doc["name"]
+        if clashing_name == name:
+            raise ValueError(f"Dataset name '{name}' is not available")
+        else:
+            raise ValueError(
+                f"Dataset name '{name}' with slug '{slug}' clashes "
+                f"with existing dataset '{clashing_name}'"
+            )
 
     return slug
 

--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -115,8 +115,8 @@ def _validate_dataset_name(name, skip=None):
             raise ValueError(f"Dataset name '{name}' is not available")
         else:
             raise ValueError(
-                f"Dataset name '{name}' with slug '{slug}' clashes "
-                f"with existing dataset '{clashing_name}'"
+                f"Dataset name '{name}' is not available: slug '{slug}' "
+                f"in use by dataset '{clashing_name}'"
             )
 
     return slug


### PR DESCRIPTION
## What changes are proposed in this pull request?

Coming from a user issue / complaint.

If you are trying to create a dataset that clashes in slug, it's really unclear why. It just says "Dataset name is not available". Even if you try to delete the dataset name, you'll still be unable to create that name.

Proposing a more clear error message in the case that the name is unavailable due to slug clash. Open to wording suggestions.

Also changed to `find_one` because not sure why it used `list(find().limit(1))` in the first place. And use f-string over formatted string.

## How is this patch tested? If it is not, please explain why.
Before
```python
import fiftyone as fo

ds = fo.Dataset("test_dataset")

# some time later
ds2 = fo.Dataset("test-dataset")

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/stuart/dev/fiftyone/fiftyone/core/singletons.py", line 36, in __call__
    instance.__init__(name=name, _create=_create, *args, **kwargs)
  File "/Users/stuart/dev/fiftyone/fiftyone/core/dataset.py", line 274, in __init__
    doc, sample_doc_cls, frame_doc_cls = _create_dataset(
  File "/Users/stuart/dev/fiftyone/fiftyone/core/dataset.py", line 6868, in _create_dataset
    slug = _validate_dataset_name(name)
  File "/Users/stuart/dev/fiftyone/fiftyone/core/dataset.py", line 109, in _validate_dataset_name
    raise ValueError("Dataset name '%s' is not available" % name)
ValueError: Dataset name 'test-dataset' is not available
```
After
```python
import fiftyone as fo

ds = fo.Dataset("test_dataset")

# some time later
ds2 = fo.Dataset("test-dataset")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/stuart/dev/fiftyone/fiftyone/core/singletons.py", line 36, in __call__
    instance.__init__(name=name, _create=_create, *args, **kwargs)
  File "/Users/stuart/dev/fiftyone/fiftyone/core/dataset.py", line 285, in __init__
    doc, sample_doc_cls, frame_doc_cls = _create_dataset(
  File "/Users/stuart/dev/fiftyone/fiftyone/core/dataset.py", line 6879, in _create_dataset
    slug = _validate_dataset_name(name)
  File "/Users/stuart/dev/fiftyone/fiftyone/core/dataset.py", line 117, in _validate_dataset_name
    raise ValueError(
ValueError: Dataset name 'test-dataset' is not available: slug 'test-dataset' in use by dataset 'test_dataset'

# Make sure skip argument still works and we can set name
ds.name = "test-dataset"
assert ds.name == "test-dataset"

# Same error as before when it's the same name
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/stuart/dev/fiftyone/fiftyone/core/singletons.py", line 36, in __call__
    instance.__init__(name=name, _create=_create, *args, **kwargs)
  File "/Users/stuart/dev/fiftyone/fiftyone/core/dataset.py", line 285, in __init__
    doc, sample_doc_cls, frame_doc_cls = _create_dataset(
  File "/Users/stuart/dev/fiftyone/fiftyone/core/dataset.py", line 6879, in _create_dataset
    slug = _validate_dataset_name(name)
  File "/Users/stuart/dev/fiftyone/fiftyone/core/dataset.py", line 115, in _validate_dataset_name
    raise ValueError(f"Dataset name '{name}' is not available")
ValueError: Dataset name 'test-dataset' is not available
```
## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

Better error message when a unique dataset name clashes with an existing slug

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
