### PR TITLE
Use py3.11 for codecov

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -93,7 +93,7 @@ jobs:
             --ignore tests/intensive/ \
             --ignore tests/no_wrapper
       - name: Upload
-        if: ${{ !startsWith(matrix.os, 'windows') && matrix.python == '3.9' }}
+        if: ${{ !startsWith(matrix.os, 'windows') && matrix.python == '3.11' }}
         uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
Simple addendum to previous python3.11/python3.12 support PR - this has been broken for a while.