### PR TITLE
resolve secret for resolve operator type and options

### DIFF
--- a/fiftyone/operators/executor.py
+++ b/fiftyone/operators/executor.py
@@ -333,7 +333,7 @@ async def do_execute_operator(operator, ctx, exhaust=False):
         return result
 
 
-def resolve_type(registry, operator_uri, request_params):
+async def resolve_type(registry, operator_uri, request_params):
     """Resolves the inputs property type of the operator with the given name.
 
     Args:
@@ -354,6 +354,7 @@ def resolve_type(registry, operator_uri, request_params):
         operator_uri=operator_uri,
         required_secrets=operator._plugin_secrets,
     )
+    await ctx.resolve_secret_values(operator._plugin_secrets)
     try:
         return operator.resolve_type(
             ctx, request_params.get("target", "inputs")
@@ -362,7 +363,7 @@ def resolve_type(registry, operator_uri, request_params):
         return ExecutionResult(error=traceback.format_exc())
 
 
-def resolve_execution_options(registry, operator_uri, request_params):
+async def resolve_execution_options(registry, operator_uri, request_params):
     """Resolves the execution options of the operator with the given name.
 
     Args:
@@ -382,6 +383,7 @@ def resolve_execution_options(registry, operator_uri, request_params):
         operator_uri=operator_uri,
         required_secrets=operator._plugin_secrets,
     )
+    await ctx.resolve_secret_values(operator._plugin_secrets)
     try:
         return operator.resolve_execution_options(ctx)
     except Exception as e:

--- a/fiftyone/operators/server.py
+++ b/fiftyone/operators/server.py
@@ -188,7 +188,7 @@ class ResolveType(HTTPEndpoint):
             }
             raise HTTPException(status_code=404, detail=error_detail)
 
-        result = resolve_type(registry, operator_uri, data)
+        result = await resolve_type(registry, operator_uri, data)
         return result.to_json() if result else {}
 
 
@@ -214,7 +214,7 @@ class ResolveExecutionOptions(HTTPEndpoint):
             }
             raise HTTPException(status_code=404, detail=error_detail)
 
-        result = resolve_execution_options(registry, operator_uri, data)
+        result = await resolve_execution_options(registry, operator_uri, data)
         return result.to_dict() if result else {}
 
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

Currently, secrets are not being resolved in ExecutionContext for ResolveType and ResolveExecutionOptions routes. As a result, `ctx.secret` is not functional in `resolve_input`, `resolve_output` and `resolve_execution_options`

## How is this patch tested? If it is not, please explain why.

Using an example Python operator

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

Fix secrets not accessible in `resolve_input`, `resolve_output` and `resolve_execution_options` of a Python operator

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
