### PR TITLE
Validate JS Operators on ctx.trigger()

### DIFF
--- a/app/packages/operators/src/state.ts
+++ b/app/packages/operators/src/state.ts
@@ -836,6 +836,7 @@ export function useOperatorExecutor(uri, handlers: any = {}) {
   const [needsOutput, setNeedsOutput] = useState(false);
   const ctx = useExecutionContext(uri);
   const hooks = operator.useHooks(ctx);
+  const notify = fos.useNotification();
 
   const clear = useCallback(() => {
     setIsExecuting(false);
@@ -879,6 +880,7 @@ export function useOperatorExecutor(uri, handlers: any = {}) {
           handlers.onError?.(e);
           console.error("Error executing operator", operator, ctx);
           console.error(e);
+          notify({ msg: e.message, variant: "error" });
         }
       }
       setHasExecuted(true);


### PR DESCRIPTION
Consider the following execution request from the example `OpenHistogramPanel` python operator:

```py
         ctx.trigger(
            "open_panel",
            params=dict(),
        )
```

Prior to this PR, this would silently fail to execute in the browser. After this change validation is enforced regardless of how the JS operator was executed. In cases where the operator prompt was used, this would be redundant, but this change doesn't attempt to prevent that since the validation is essentially free in the browser context.

With this change, when a JS operator is executed and the inputs are not valid the following error is shown to the user:

![image](https://github.com/voxel51/fiftyone/assets/462228/d90ec989-7f47-4733-8261-b73447d1b2b1)

...with these errors in the console:

![image](https://github.com/voxel51/fiftyone/assets/462228/4107ec38-d8c1-404e-bfb7-87d3aa81bcdb)
