### PR TITLE
persist space sizes in session

### DIFF
--- a/app/packages/components/src/components/ThemeProvider/index.tsx
+++ b/app/packages/components/src/components/ThemeProvider/index.tsx
@@ -210,6 +210,15 @@ let theme = extendMuiTheme({
         },
       },
     },
+    MuiIconButton: {
+      styleOverrides: {
+        root: {
+          "&:hover": {
+            backgroundColor: "unset",
+          },
+        },
+      },
+    },
   },
   fontFamily: {
     body: "Palanquin, sans-serif",

--- a/app/packages/spaces/src/SpaceNode.tsx
+++ b/app/packages/spaces/src/SpaceNode.tsx
@@ -11,7 +11,7 @@ export default class SpaceNode {
   // if layout is set, render as space container instead of panel container
   layout?: Layout;
   pinned?: boolean;
-  sizes?: string[];
+  sizes?: number[];
   constructor(
     id?: string,
     children?: SpaceNode[],

--- a/app/packages/spaces/src/SpaceNode.tsx
+++ b/app/packages/spaces/src/SpaceNode.tsx
@@ -11,6 +11,7 @@ export default class SpaceNode {
   // if layout is set, render as space container instead of panel container
   layout?: Layout;
   pinned?: boolean;
+  sizes?: string[];
   constructor(
     id?: string,
     children?: SpaceNode[],
@@ -109,6 +110,7 @@ export default class SpaceNode {
       layout: this.layout,
       pinned: this.pinned,
       activeChild: this.activeChild,
+      sizes: this.sizes,
     };
   }
 }

--- a/app/packages/spaces/src/SpaceTree.ts
+++ b/app/packages/spaces/src/SpaceTree.ts
@@ -62,6 +62,7 @@ export default class SpaceTree {
     let ancestorNode = parentNode;
     if (parentNode?.parent && parentNode?.children.length === 1) {
       ancestorNode = parentNode?.parent;
+      ancestorNode.sizes = undefined;
       parentNode?.remove();
       this.joinNode(ancestorNode);
     } else if (ancestorNode) {
@@ -79,6 +80,11 @@ export default class SpaceTree {
       node.parent.activeChild = node.id;
       this.updateTree(node);
     }
+  }
+
+  setNodeSizes(node: SpaceNode, sizes: string[]) {
+    node.sizes = sizes;
+    this.updateTree(node);
   }
 
   // a method for moving a node in the tree

--- a/app/packages/spaces/src/SpaceTree.ts
+++ b/app/packages/spaces/src/SpaceTree.ts
@@ -82,7 +82,7 @@ export default class SpaceTree {
     }
   }
 
-  setNodeSizes(node: SpaceNode, sizes: string[]) {
+  setNodeSizes(node: SpaceNode, sizes: number[]) {
     node.sizes = sizes;
     this.updateTree(node);
   }

--- a/app/packages/spaces/src/components/Space.tsx
+++ b/app/packages/spaces/src/components/Space.tsx
@@ -7,7 +7,11 @@ import SpaceNode from "../SpaceNode";
 import { Layout } from "../enums";
 import { usePanelTabAutoPosition, useSpaces } from "../hooks";
 import { SpaceProps } from "../types";
-import { getAbsoluteSizes, getRelativeSizes } from "../utils/sizes";
+import {
+  getAbsoluteSizes,
+  getRelativeSizes,
+  toPercentage,
+} from "../utils/sizes";
 import AddPanelButton from "./AddPanelButton";
 import Panel from "./Panel";
 import PanelTab from "./PanelTab";
@@ -18,7 +22,7 @@ export default function Space({ node, id }: SpaceProps) {
   const { spaces } = useSpaces(id);
   const autoPosition = usePanelTabAutoPosition();
   const spaceRef = useRef<AllotmentHandle>(null);
-  const previousSizesRef = useRef<string[]>();
+  const previousSizesRef = useRef<number[]>();
   const currentTotalSize = useRef();
   const { sizes } = node;
 
@@ -34,9 +38,10 @@ export default function Space({ node, id }: SpaceProps) {
 
   // apply sizes updates from remote session
   useEffect(() => {
-    const lastSizes = previousSizesRef.current;
+    const lastSizes = previousSizesRef.current?.toString();
+    const currentSizes = sizes?.toString();
     const totalSize = currentTotalSize.current;
-    if (lastSizes && totalSize && sizes && lastSizes !== sizes) {
+    if (lastSizes && totalSize && sizes && lastSizes !== currentSizes) {
       spaceRef.current?.resize(getAbsoluteSizes(sizes, totalSize));
     }
     previousSizesRef.current = sizes;
@@ -57,7 +62,7 @@ export default function Space({ node, id }: SpaceProps) {
           ref={spaceRef}
         >
           {node.children.map((space, i) => {
-            const preferredSize = node.sizes?.[i];
+            const preferredSize = toPercentage(node.sizes?.[i]);
             return (
               <Allotment.Pane key={space.id} preferredSize={preferredSize}>
                 <Space node={space} id={id} />

--- a/app/packages/spaces/src/components/Space.tsx
+++ b/app/packages/spaces/src/components/Space.tsx
@@ -1,7 +1,7 @@
 import { Allotment, AllotmentHandle } from "allotment";
 import "allotment/dist/style.css";
 import { debounce } from "lodash";
-import { useCallback, useRef, useEffect } from "react";
+import { useCallback, useEffect, useRef } from "react";
 import { ReactSortable } from "react-sortablejs";
 import SpaceNode from "../SpaceNode";
 import { Layout } from "../enums";
@@ -23,16 +23,20 @@ export default function Space({ node, id }: SpaceProps) {
   const autoPosition = usePanelTabAutoPosition();
   const spaceRef = useRef<AllotmentHandle>(null);
   const previousSizesRef = useRef<number[]>();
-  const currentTotalSize = useRef();
+  const currentTotalSize = useRef<number>();
   const { sizes } = node;
 
   const setSpaceSizes = useCallback(
-    debounce((node, sizes) => {
-      currentTotalSize.current = sizes.reduce((total, item) => total + item, 0);
-      const relativeSizes = getRelativeSizes(sizes);
-      previousSizesRef.current = relativeSizes;
-      spaces.setNodeSizes(node, relativeSizes);
-    }, 500),
+    (node: SpaceNode, sizes: number[]) =>
+      debounce(() => {
+        currentTotalSize.current = sizes.reduce(
+          (total, item) => total + item,
+          0
+        );
+        const relativeSizes = getRelativeSizes(sizes);
+        previousSizesRef.current = relativeSizes;
+        spaces.setNodeSizes(node, relativeSizes);
+      }, 500),
     [spaces]
   );
 

--- a/app/packages/spaces/src/components/Space.tsx
+++ b/app/packages/spaces/src/components/Space.tsx
@@ -1,10 +1,13 @@
-import { Allotment } from "allotment";
+import { Allotment, AllotmentHandle } from "allotment";
 import "allotment/dist/style.css";
+import { debounce } from "lodash";
+import { useCallback, useRef, useEffect } from "react";
 import { ReactSortable } from "react-sortablejs";
-import { Layout } from "../enums";
-import { useSpaces, usePanelTabAutoPosition } from "../hooks";
 import SpaceNode from "../SpaceNode";
+import { Layout } from "../enums";
+import { usePanelTabAutoPosition, useSpaces } from "../hooks";
 import { SpaceProps } from "../types";
+import { getAbsoluteSizes, getRelativeSizes } from "../utils/sizes";
 import AddPanelButton from "./AddPanelButton";
 import Panel from "./Panel";
 import PanelTab from "./PanelTab";
@@ -14,16 +17,53 @@ import { PanelContainer, PanelTabs, SpaceContainer } from "./StyledElements";
 export default function Space({ node, id }: SpaceProps) {
   const { spaces } = useSpaces(id);
   const autoPosition = usePanelTabAutoPosition();
+  const spaceRef = useRef<AllotmentHandle>(null);
+  const previousSizesRef = useRef<string[]>();
+  const currentTotalSize = useRef();
+  const { sizes } = node;
+
+  const setSpaceSizes = useCallback(
+    debounce((node, sizes) => {
+      currentTotalSize.current = sizes.reduce((total, item) => total + item, 0);
+      const relativeSizes = getRelativeSizes(sizes);
+      previousSizesRef.current = relativeSizes;
+      spaces.setNodeSizes(node, relativeSizes);
+    }, 500),
+    [spaces]
+  );
+
+  // apply sizes updates from remote session
+  useEffect(() => {
+    const lastSizes = previousSizesRef.current;
+    const totalSize = currentTotalSize.current;
+    if (lastSizes && totalSize && sizes && lastSizes !== sizes) {
+      spaceRef.current?.resize(getAbsoluteSizes(sizes, totalSize));
+    }
+    previousSizesRef.current = sizes;
+  }, [sizes]);
 
   if (node.layout) {
     return (
       <SpaceContainer data-type="space-container">
-        <Allotment vertical={node.layout === Layout.Vertical}>
-          {node.children.map((space) => (
-            <Allotment.Pane key={space.id}>
-              <Space node={space} id={id} />
-            </Allotment.Pane>
-          ))}
+        <Allotment
+          vertical={node.layout === Layout.Vertical}
+          onReset={() => {
+            // todo: support more than two panel per space
+            spaceRef.current?.resize([0, 0]);
+          }}
+          onChange={(sizes) => {
+            setSpaceSizes(node, sizes);
+          }}
+          ref={spaceRef}
+        >
+          {node.children.map((space, i) => {
+            const preferredSize = node.sizes?.[i];
+            return (
+              <Allotment.Pane key={space.id} preferredSize={preferredSize}>
+                <Space node={space} id={id} />
+              </Allotment.Pane>
+            );
+          })}
         </Allotment>
       </SpaceContainer>
     );

--- a/app/packages/spaces/src/types.ts
+++ b/app/packages/spaces/src/types.ts
@@ -40,6 +40,7 @@ export type SpaceNodeJSON = {
   layout?: SpaceNode["layout"];
   type?: SpaceNode["type"];
   pinned?: SpaceNode["pinned"];
+  sizes?: string[];
 };
 
 export type PanelProps = {

--- a/app/packages/spaces/src/types.ts
+++ b/app/packages/spaces/src/types.ts
@@ -40,7 +40,7 @@ export type SpaceNodeJSON = {
   layout?: SpaceNode["layout"];
   type?: SpaceNode["type"];
   pinned?: SpaceNode["pinned"];
-  sizes?: string[];
+  sizes?: number[];
 };
 
 export type PanelProps = {

--- a/app/packages/spaces/src/utils.ts
+++ b/app/packages/spaces/src/utils.ts
@@ -9,6 +9,7 @@ export function spaceNodeFromJSON(json: SpaceNodeJSON, parent?: SpaceNode) {
   node.children = json.children.map((child) => spaceNodeFromJSON(child, node));
   node.parent = parent;
   node.pinned = json.pinned;
+  node.sizes = json.sizes;
   return node;
 }
 

--- a/app/packages/spaces/src/utils/sizes.test.ts
+++ b/app/packages/spaces/src/utils/sizes.test.ts
@@ -1,34 +1,41 @@
 import { describe, expect, it } from "vitest";
-import { getRelativeSizes, getAbsoluteSizes } from "./sizes";
+import { getRelativeSizes, getAbsoluteSizes, toPercentage } from "./sizes";
 
 describe("getRelativeSizes", () => {
   it("returns correct relative sizes based on provided numerical sizes", () => {
-    expect(getRelativeSizes([10, 10])).toEqual(["50%", "50%"]);
-    expect(getRelativeSizes([10, 15])).toEqual(["40%", "60%"]);
-    expect(getRelativeSizes([15, 10])).toEqual(["60%", "40%"]);
-    expect(getRelativeSizes([10])).toEqual(["100%"]);
-    // last panel should take remaining size to add up to 100%
-    expect(getRelativeSizes([10, 10, 10])).toEqual(["33%", "33%", "34%"]);
+    expect(getRelativeSizes([10, 10])).toEqual([0.5, 0.5]);
+    expect(getRelativeSizes([10, 15])).toEqual([0.4, 0.6]);
+    expect(getRelativeSizes([15, 10])).toEqual([0.6, 0.4]);
+    expect(getRelativeSizes([10])).toEqual([1]);
     expect(getRelativeSizes([10, 10, 10, 10])).toEqual([
-      "25%",
-      "25%",
-      "25%",
-      "25%",
+      0.25, 0.25, 0.25, 0.25,
     ]);
+    // last panel should take remaining size to add up to 100%
+    expect(getRelativeSizes([10, 10, 10])).toEqual([0.33, 0.33, 0.34]);
     expect(getRelativeSizes([10, 15, 10, 10])).toEqual([
-      "22%",
-      "33%",
-      "22%",
-      "23%",
+      0.22, 0.33, 0.22, 0.23,
     ]);
   });
 });
 
 describe("getAbsoluteSizes", () => {
   it("returns correct absolute sizes based on provided relative sizes", () => {
-    expect(getAbsoluteSizes(["30%", "70%"], 100)).toEqual([30, 70]);
-    expect(getAbsoluteSizes(["70%", "30%"], 100)).toEqual([70, 30]);
+    expect(getAbsoluteSizes([0.3, 0.7], 100)).toEqual([30, 70]);
+    expect(getAbsoluteSizes([0.7, 0.3], 100)).toEqual([70, 30]);
     // last panel should take remaining size to add up to totalSize
-    expect(getAbsoluteSizes(["70%", "100%"], 100)).toEqual([70, 30]);
+    expect(getAbsoluteSizes([0.7, 1], 100)).toEqual([70, 30]);
+  });
+});
+
+describe("toPercentage", () => {
+  it("converts floating points to percentage correctly", () => {
+    expect(toPercentage(0.3)).toBe("30%");
+    expect(toPercentage(0.33)).toBe("33%");
+    expect(toPercentage(0.333)).toBe("33%");
+    expect(toPercentage(0.3333338)).toBe("33%");
+    expect(toPercentage(0.335)).toBe("34%");
+    expect(toPercentage(0.338)).toBe("34%");
+    expect(toPercentage(1)).toBe("100%");
+    expect(toPercentage(1.1)).toBe("110%");
   });
 });

--- a/app/packages/spaces/src/utils/sizes.test.ts
+++ b/app/packages/spaces/src/utils/sizes.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { getRelativeSizes, getAbsoluteSizes } from "./sizes";
+
+describe("getRelativeSizes", () => {
+  it("returns correct relative sizes based on provided numerical sizes", () => {
+    expect(getRelativeSizes([10, 10])).toEqual(["50%", "50%"]);
+    expect(getRelativeSizes([10, 15])).toEqual(["40%", "60%"]);
+    expect(getRelativeSizes([15, 10])).toEqual(["60%", "40%"]);
+    expect(getRelativeSizes([10])).toEqual(["100%"]);
+    // last panel should take remaining size to add up to 100%
+    expect(getRelativeSizes([10, 10, 10])).toEqual(["33%", "33%", "34%"]);
+    expect(getRelativeSizes([10, 10, 10, 10])).toEqual([
+      "25%",
+      "25%",
+      "25%",
+      "25%",
+    ]);
+    expect(getRelativeSizes([10, 15, 10, 10])).toEqual([
+      "22%",
+      "33%",
+      "22%",
+      "23%",
+    ]);
+  });
+});
+
+describe("getAbsoluteSizes", () => {
+  it("returns correct absolute sizes based on provided relative sizes", () => {
+    expect(getAbsoluteSizes(["30%", "70%"], 100)).toEqual([30, 70]);
+    expect(getAbsoluteSizes(["70%", "30%"], 100)).toEqual([70, 30]);
+    // last panel should take remaining size to add up to totalSize
+    expect(getAbsoluteSizes(["70%", "100%"], 100)).toEqual([70, 30]);
+  });
+});

--- a/app/packages/spaces/src/utils/sizes.ts
+++ b/app/packages/spaces/src/utils/sizes.ts
@@ -1,0 +1,21 @@
+export function getRelativeSizes(sizes: number[]) {
+  const sizesTotal = sizes.reduce((total, item) => total + item, 0);
+  let sizeAvailable = 100;
+  return sizes.map((size, i) => {
+    const relativeSize = Math.round((size / sizesTotal) * 100);
+    const adjustedSize = i === sizes.length - 1 ? sizeAvailable : relativeSize;
+    sizeAvailable -= adjustedSize;
+    return `${adjustedSize}%`;
+  });
+}
+
+export function getAbsoluteSizes(sizes: string[], totalSize: number) {
+  let sizeAvailable = totalSize;
+  return sizes.map((size, i) => {
+    const numericSize = parseFloat(size) / 100;
+    const relativeSize = Math.round(totalSize * numericSize);
+    const adjustedSize = i === sizes.length - 1 ? sizeAvailable : relativeSize;
+    sizeAvailable -= adjustedSize;
+    return adjustedSize;
+  });
+}

--- a/app/packages/spaces/src/utils/sizes.ts
+++ b/app/packages/spaces/src/utils/sizes.ts
@@ -5,17 +5,22 @@ export function getRelativeSizes(sizes: number[]) {
     const relativeSize = Math.round((size / sizesTotal) * 100);
     const adjustedSize = i === sizes.length - 1 ? sizeAvailable : relativeSize;
     sizeAvailable -= adjustedSize;
-    return `${adjustedSize}%`;
+    return adjustedSize / 100;
   });
 }
 
-export function getAbsoluteSizes(sizes: string[], totalSize: number) {
+export function getAbsoluteSizes(sizes: number[], totalSize: number) {
   let sizeAvailable = totalSize;
   return sizes.map((size, i) => {
-    const numericSize = parseFloat(size) / 100;
-    const relativeSize = Math.round(totalSize * numericSize);
+    const relativeSize = Math.round(totalSize * size);
     const adjustedSize = i === sizes.length - 1 ? sizeAvailable : relativeSize;
     sizeAvailable -= adjustedSize;
     return adjustedSize;
   });
+}
+
+export function toPercentage(floatingPoint?: number) {
+  if (typeof floatingPoint === "number") {
+    return `${Math.round(floatingPoint * 100)}%`;
+  }
 }

--- a/app/packages/state/src/hooks/useSessionSpaces.ts
+++ b/app/packages/state/src/hooks/useSessionSpaces.ts
@@ -49,6 +49,7 @@ function toAPIFormat(state, panelsState = {}) {
     apiState.children = toAPIFormat(state.children, panelsState);
     if (state.layout) apiState.orientation = state.layout;
     if (state.activeChild) apiState.active_child = state.activeChild;
+    if (state.sizes) apiState.sizes = state.sizes;
   }
   return apiState;
 }
@@ -65,6 +66,7 @@ function toAppFormat(state) {
       type: state.type,
       state: state.state || {}, // not used in SpaceNode atm
       pinned: state.pinned,
+      sizes: state.sizes,
     };
   return state;
 }

--- a/fiftyone/core/spaces.py
+++ b/fiftyone/core/spaces.py
@@ -60,7 +60,7 @@ class Space(Component):
         active_child: the ``component_id`` of this space's currently active
             child
         sizes: the ordered list of relative sizes for children of a space in
-            ``[0, 1]`
+            ``[0, 1]``
     """
 
     meta = {"strict": False, "allow_inheritance": True}

--- a/fiftyone/core/spaces.py
+++ b/fiftyone/core/spaces.py
@@ -5,6 +5,7 @@ App Space configuration.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 from bson import ObjectId
 from mongoengine.errors import ValidationError
 import uuid
@@ -57,7 +58,8 @@ class Space(Component):
         orientation (["horizontal", "vertical"]): the orientation of this
             space's children
         active_child: the ``component_id`` of this space's currently active
-            chilld
+            child
+        sizes: the ordered list of sizes for children of space
     """
 
     meta = {"strict": False, "allow_inheritance": True}
@@ -70,6 +72,7 @@ class Space(Component):
         choices=["horizontal", "vertical"], default=None
     )
     active_child = fof.StringField(default=None)
+    sizes = fof.ListField(fof.StringField(), default=None)
 
 
 samples_panel = Panel(type="Samples", pinned=True)

--- a/fiftyone/core/spaces.py
+++ b/fiftyone/core/spaces.py
@@ -73,7 +73,7 @@ class Space(Component):
         choices=["horizontal", "vertical"], default=None
     )
     active_child = fof.StringField(default=None)
-    sizes = fof.ListField(fof.StringField(), default=None)
+    sizes = fof.ListField(fof.FloatField(), default=None)
 
 
 samples_panel = Panel(type="Samples", pinned=True)

--- a/fiftyone/core/spaces.py
+++ b/fiftyone/core/spaces.py
@@ -59,7 +59,8 @@ class Space(Component):
             space's children
         active_child: the ``component_id`` of this space's currently active
             child
-        sizes: the ordered list of sizes for children of space
+        sizes: the ordered list of relative sizes for children of a space in
+            ``[0, 1]`
     """
 
     meta = {"strict": False, "allow_inheritance": True}


### PR DESCRIPTION
## What changes are proposed in this pull request?

Currently, if a space is resized in the app, the updated sizes of spaces is not persisted in session. As a result, if app reloads, the resizing is lost. PR adds changes to persist sizes of all spaces in the app. In addition, it also adds the ability to update the sizes of spaces from active Python session

## How is this patch tested? If it is not, please explain why.

- resizing in the app and refreshing the app
- setting sizes of a space from python shell
- unit test

### Preview


https://github.com/voxel51/fiftyone/assets/25350704/9084d71a-a06a-49b2-b010-571a414fa0f7


## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

Persist sizes of spaces in app session

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
