### PR TITLE
Add og:image to docs / FAQ update

### DIFF
--- a/docs/source/_templates/layout.html
+++ b/docs/source/_templates/layout.html
@@ -1,7 +1,7 @@
 {% extends "!layout.html" %} {% block extrahead %}
 <meta
   property="og:image"
-  content="https://voxel51.com/wp-content/uploads/2024/02/1.24_Webpages_MeetupLandingSC_AV.png"
+  content="{{og_image}}"
 />
 
 <link
@@ -14,18 +14,6 @@
 />
 {% endblock %} {% block custom_header %}
 <div class="container-fluid header-holder tutorials-header" id="header-holder">
-  <!--
-  <a class="banner" href="{{banner_link}}">
-    <div>
-      <span>
-        With support from the COCO team,
-        <span><b class="text-secondary-on-dark">Fifty</b><b class="text-brand">One</b></span>
-        is now a recommended tool for the
-        <b class="gray">COCO dataset and evaluation</b>!</span
-      >
-    </div>
-  </a>
-  -->
 
   <nav id="nav__main" class="nav__main">
     <div class="nav__main__logo">

--- a/docs/source/_templates/layout.html
+++ b/docs/source/_templates/layout.html
@@ -1,4 +1,9 @@
 {% extends "!layout.html" %} {% block extrahead %}
+<meta
+  property="og:image"
+  content="https://voxel51.com/wp-content/uploads/2024/02/1.24_Webpages_MeetupLandingSC_AV.png"
+/>
+
 <link
   href="https://fonts.googleapis.com/css?family=Palanquin:400,600,700,800"
   rel="stylesheet"

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -212,7 +212,7 @@ html_context = {
     "link_voxel51_slack": "https://slack.voxel51.com",
     "link_voxel51_twitter": "https://twitter.com/voxel51",
     "link_voxel51_blog": "https://voxel51.com/blog/",
-    "og_image": "https://voxel51.com/wp-content/uploads/2024/02/1.24_Webpages_MeetupLandingSC_AV.png",
+    "og_image": "https://voxel51.com/wp-content/uploads/2024/03/3.24_webpages_Home_AV.png",
 }
 
 # -- Custom app setup --------------------------------------------------------

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -8,6 +8,7 @@ https://www.sphinx-doc.org/en/master/usage/configuration.html
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 import os
 import re
 import sys
@@ -211,7 +212,7 @@ html_context = {
     "link_voxel51_slack": "https://slack.voxel51.com",
     "link_voxel51_twitter": "https://twitter.com/voxel51",
     "link_voxel51_blog": "https://voxel51.com/blog/",
-    "banner_link": "https://docs.voxel51.com/integrations/coco.html",
+    "og_image": "https://voxel51.com/wp-content/uploads/2024/02/1.24_Webpages_MeetupLandingSC_AV.png",
 }
 
 # -- Custom app setup --------------------------------------------------------

--- a/docs/source/faq/index.rst
+++ b/docs/source/faq/index.rst
@@ -706,10 +706,10 @@ instructions on using the various Brain methods.
 Does FiftyOne track me?
 -----------------------
 
-FiftyOne tracks anonymous UUID-based usage of the Python library and the App by
-default. We are a small team building an open source project, and basic
-knowledge of how users are engaging with the project is critical to informing
-the roadmap of the project.
+FiftyOne tracks anonymous UUID-based usage of the App by default. We are a
+small team building an open source project, and basic knowledge of how users
+are engaging with the project is critical to informing the roadmap of the
+project.
 
 .. note::
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

Adds the `og:image` meta tag to the docs for social purposes. Also updates the tracking FAQ as Python imports are no longer tracked.

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [x] Documentation: FiftyOne documentation changes
-   [ ] Other
