### PR TITLE
np.int -> int in labels.py

### DIFF
--- a/fiftyone/core/labels.py
+++ b/fiftyone/core/labels.py
@@ -1568,7 +1568,7 @@ def _parse_segmentation_target(mask, frame_size, target):
             raise ValueError("Either `mask` or `frame_size` must be provided")
 
         if target is not None and not is_rgb and target > 255:
-            dtype = np.int
+            dtype = int
         else:
             dtype = np.uint8
 
@@ -1595,7 +1595,7 @@ def _parse_segmentation_mask_targets(mask, frame_size, mask_targets):
             raise ValueError("Either `mask` or `frame_size` must be provided")
 
         if mask_targets is not None and not is_rgb and max(mask_targets) > 255:
-            dtype = np.int
+            dtype = int
         else:
             dtype = np.uint8
 


### PR DESCRIPTION
`numpy.int` is deprecated. It was an alias for `int`, so this change yields identical behavior and fixes the `AttributeError` that gets thrown with newer versions of NumPy.

The release notes for NumPy 1.20.0 list all the builtin aliases that were deprecated:

https://numpy.org/devdocs/release/1.20.0-notes.html#using-the-aliases-of-builtin-types-like-np-int-is-deprecated


## What changes are proposed in this pull request?

Replace `np.int` with `int`.

## How is this patch tested? If it is not, please explain why.

`np.int` was just an alias for `int`, so this change should yield identical behavior.

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
