### PR TITLE
add support for setting view by name and slug

### DIFF
--- a/app/packages/app/src/pages/datasets/DatasetPage.tsx
+++ b/app/packages/app/src/pages/datasets/DatasetPage.tsx
@@ -116,9 +116,9 @@ const DatasetPage: Route<DatasetPageQuery> = ({ prepared }) => {
         <Starter mode="ADD_SAMPLE" />
       ) : (
         <>
-          <OperatorCore />
           <div className={style.page}>
             <datasetQueryContext.Provider value={data}>
+              <OperatorCore />
               <Dataset />
             </datasetQueryContext.Provider>
           </div>

--- a/app/packages/core/src/components/Sidebar/ViewSelection/index.tsx
+++ b/app/packages/core/src/components/Sidebar/ViewSelection/index.tsx
@@ -1,13 +1,7 @@
 import { Selection } from "@fiftyone/components";
-import {
-  savedViewsFragment,
-  savedViewsFragment$key,
-  savedViewsFragmentQuery,
-} from "@fiftyone/relay";
+import { useRefetchableSavedViews } from "@fiftyone/core";
 import * as fos from "@fiftyone/state";
-import { datasetQueryContext } from "@fiftyone/state";
-import React, { Suspense, useContext, useEffect, useMemo } from "react";
-import { useRefetchableFragment } from "react-relay";
+import React, { Suspense, useEffect, useMemo } from "react";
 import {
   atom,
   useRecoilState,
@@ -49,19 +43,13 @@ export default function ViewSelection() {
   const setEditView = useSetRecoilState(viewDialogContent);
   const resetView = useResetRecoilState(fos.view);
   const [viewSearch, setViewSearch] = useRecoilState<string>(viewSearchTerm);
-  const fragmentRef = useContext(datasetQueryContext);
   const isReadOnly = useRecoilValue(fos.readOnly);
   const canEdit = useMemo(
     () => canEditSavedViews && !isReadOnly,
     [canEditSavedViews, isReadOnly]
   );
 
-  if (!fragmentRef) throw new Error("ref not defined");
-
-  const [data, refetch] = useRefetchableFragment<
-    savedViewsFragmentQuery,
-    savedViewsFragment$key
-  >(savedViewsFragment, fragmentRef);
+  const [data, refetch] = useRefetchableSavedViews();
 
   const items = useMemo(() => data.savedViews || [], [data]);
 

--- a/app/packages/core/src/hooks/index.ts
+++ b/app/packages/core/src/hooks/index.ts
@@ -1,0 +1,1 @@
+export { default as useRefetchableSavedViews } from "./useRefetchableSavedViews";

--- a/app/packages/core/src/hooks/useRefetchableSavedViews.ts
+++ b/app/packages/core/src/hooks/useRefetchableSavedViews.ts
@@ -1,0 +1,21 @@
+import {
+  savedViewsFragment,
+  savedViewsFragment$key,
+  savedViewsFragmentQuery,
+} from "@fiftyone/relay";
+import { datasetQueryContext } from "@fiftyone/state";
+import { useContext } from "react";
+import { useRefetchableFragment } from "react-relay";
+
+export default function useRefetchableSavedViews() {
+  const fragmentRef = useContext(datasetQueryContext);
+
+  if (!fragmentRef) throw new Error("ref not defined");
+
+  const [data, refetch] = useRefetchableFragment<
+    savedViewsFragmentQuery,
+    savedViewsFragment$key
+  >(savedViewsFragment, fragmentRef);
+
+  return [data, refetch];
+}

--- a/app/packages/core/src/index.ts
+++ b/app/packages/core/src/index.ts
@@ -1,2 +1,3 @@
 export * from "./components";
 export * from "./plugins";
+export * from "./hooks";

--- a/app/packages/operators/src/operators.ts
+++ b/app/packages/operators/src/operators.ts
@@ -570,6 +570,7 @@ export async function executeOperatorWithContext(
       error = e;
       console.error(`Error executing operator ${operatorURI}:`);
       console.error(error);
+      throw error;
     }
   }
 

--- a/docs/source/release-notes.rst
+++ b/docs/source/release-notes.rst
@@ -63,10 +63,11 @@ Plugins and Operators
   :meth:`resolve_input() <fiftyone.operators.operator.Operator.resolve_input>`
   on demand
   `#4152 <https://github.com/voxel51/fiftyone/pull/4152>`_
-- Added support for loading saved views by name when using the
+- Added support for loading saved views by name or slug when using the
   :meth:`set_view() <fiftyone.operators.operations.Operations.set_view>`
   operator
-  `#4159 <https://github.com/voxel51/fiftyone/pull/4159>`_
+  `#4159 <https://github.com/voxel51/fiftyone/pull/4159>`_ and 
+  `#4178 <https://github.com/voxel51/fiftyone/pull/4178>`_
 - Added ability to :ref:`trigger builtin operators <operator-execution>` during
   operator execution via
   :meth:`ctx.ops <fiftyone.operators.executor.ExecutionContext.ops>`

--- a/docs/source/release-notes.rst
+++ b/docs/source/release-notes.rst
@@ -75,6 +75,10 @@ Plugins and Operators
 - Fixed issue where JS operator input was not validated when calling
   `ctx.trigger()` or `executeOperator()` directly
   `#4170 <https://github.com/voxel51/fiftyone/pull/4170>`_
+- Show execution error of an operator in a notification when calling
+  `ctx.trigger()` or `executeOperator()` directly 
+  `#4170 <https://github.com/voxel51/fiftyone/pull/4170>`_ and 
+  `#4178 <https://github.com/voxel51/fiftyone/pull/4178>`_
 
 Core
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

add support for setting view by name and slug

### Usage: setting a view using the slug of a saved view
```py
def execute(self, ctx):
    ctx.trigger("set_view", {"name": "my-saved-view-name"})
```
### Usage: setting a view using the name of a saved view
```py
def execute(self, ctx):
    ctx.trigger("set_view", {"name": "My Saved View Name"})
```

## How is this patch tested? If it is not, please explain why.

Using a test operator

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

add support for setting view by name and slug

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
