### PR TITLE
joining spaces sometimes renders invalid layout

### DIFF
--- a/app/packages/spaces/src/components/Space.tsx
+++ b/app/packages/spaces/src/components/Space.tsx
@@ -55,6 +55,7 @@ export default function Space({ node, id }: SpaceProps) {
     return (
       <SpaceContainer data-type="space-container">
         <Allotment
+          key={node.layout}
           vertical={node.layout === Layout.Vertical}
           onReset={() => {
             // todo: support more than two panel per space


### PR DESCRIPTION
## What changes are proposed in this pull request?

When Ritchie was demoing, I noticed that joining spaces sometimes renders an invalid layout. See before and after below

## How is this patch tested? If it is not, please explain why.

### Before

https://github.com/voxel51/fiftyone/assets/25350704/b9fe4ca9-c1f0-44b7-9497-4a55e76e56ce

### After


https://github.com/voxel51/fiftyone/assets/25350704/e4860f9e-0eef-48b7-af48-6b4fce4cca59


## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

Fixed an issue where joining spaces sometimes renders an invalid layout

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
