### PR TITLE
Speed up segmentation conversion and `_transform_mask()`.

### DIFF
--- a/fiftyone/core/labels.py
+++ b/fiftyone/core/labels.py
@@ -7,10 +7,14 @@ Labels stored in dataset samples.
 """
 import itertools
 import warnings
+from functools import partial
 
 from bson import ObjectId
 import cv2
 import numpy as np
+from scipy.ndimage import find_objects
+from skimage.segmentation import relabel_sequential
+from skimage.measure import label
 
 import eta.core.frameutils as etaf
 import eta.core.image as etai
@@ -758,7 +762,9 @@ class Polyline(_HasAttributesDict, _HasID, Label):
         return sg.MultiLineString(points)
 
     @classmethod
-    def from_mask(cls, mask, label=None, tolerance=2, **attributes):
+    def from_mask(
+        cls, mask, label=None, tolerance=2, round_coords=False, **attributes
+    ):
         """Creates a :class:`Polyline` instance with polygons describing the
         non-zero region(s) of the given full image mask.
 
@@ -767,6 +773,9 @@ class Polyline(_HasAttributesDict, _HasID, Label):
             label (None): the label string
             tolerance (2): a tolerance, in pixels, when generating approximate
                 polygons for each region. Typical values are 1-3 pixels
+            round_coords (False): whether to round polyline coordinates before
+                converting to relative coordinates. This can help align
+                coordinates to actual pixel values in the mask.
             **attributes: additional attributes for the :class:`Polyline`
 
         Returns:
@@ -775,7 +784,9 @@ class Polyline(_HasAttributesDict, _HasID, Label):
         if mask.ndim > 2:
             mask = mask[:, :, 0]
 
-        points = _get_polygons(mask.astype(bool), tolerance)
+        points = _get_polygons(
+            mask.astype(bool), tolerance=tolerance, round_coords=round_coords
+        )
 
         return cls(
             label=label, points=points, filled=True, closed=True, **attributes
@@ -1141,7 +1152,13 @@ class Segmentation(_HasID, _HasMedia, Label):
         )
         return Detections(detections=detections)
 
-    def to_polylines(self, mask_targets=None, mask_types="stuff", tolerance=2):
+    def to_polylines(
+        self,
+        mask_targets=None,
+        mask_types="stuff",
+        tolerance=2,
+        round_coords=False,
+    ):
         """Returns a :class:`Polylines` representation of this instance.
 
         Each ``"stuff"`` class will be converted to a single :class:`Polyline`
@@ -1166,12 +1183,16 @@ class Segmentation(_HasID, _HasMedia, Label):
                     (3D masks) to ``"stuff"`` or ``"thing"`` for each class
             tolerance (2): a tolerance, in pixels, when generating approximate
                 polylines for each region. Typical values are 1-3 pixels
+            round_coords (False): whether to round polyline coordinates before
+                converting to relative coordinates. This can help align
+                coordinates to actual pixel values in the mask.
 
         Returns:
             a :class:`Polylines`
+
         """
         polylines = _segmentation_to_polylines(
-            self, mask_targets, mask_types, tolerance
+            self, mask_targets, mask_types, tolerance, round_coords
         )
         return Polylines(polylines=polylines)
 
@@ -1507,8 +1528,10 @@ def _transform_mask(in_mask, targets_map):
         dtype = np.uint8
 
     out_mask = np.zeros_like(in_mask, dtype=dtype)
+    objects = _find_slices(in_mask)
     for in_val, out_val in targets_map.items():
-        out_mask[in_mask == in_val] = out_val
+        slices = objects[in_val]
+        out_mask[slices][in_mask[slices] == in_val] = out_val
 
     if rgb_out:
         out_mask = _int_array_to_rgb(out_mask)
@@ -1654,7 +1677,23 @@ def _render_polyline(mask, polyline, target, thickness):
         )
 
 
-def _segmentation_to_detections(segmentation, mask_targets, mask_types):
+def _find_slices(mask):
+    """Return slices that tightly bound each unique object in `mask`."""
+    relabeled, forward, backward = relabel_sequential(mask)
+    slices = find_objects(relabeled)
+    result = dict((backward[idx + 1], slc) for idx, slc in enumerate(slices))
+    return result
+
+
+def _convert_segmentation(segmentation, mask_targets, mask_types, converter):
+    """convert segmentation to a collection of detections, polylines, etc.
+
+    `converter(label_mask, label, label_type, offset, frame_size)` is
+    a function that returns a list of detections, polylines, etc. It
+    gets called for each value in `mask_targets`, or for all values in
+    the mask if `mask_targets` is `None`.
+
+    """
     if isinstance(mask_types, dict):
         default = None
     else:
@@ -1665,21 +1704,20 @@ def _segmentation_to_detections(segmentation, mask_targets, mask_types):
     is_rgb = mask.ndim == 3
 
     if is_rgb:
-        array_targets = np.unique(mask.reshape(-1, mask.shape[2]), axis=0)
-        targets = [_rgb_to_hex(t) for t in array_targets]
-    else:
-        targets = np.unique(mask)
-        array_targets = itertools.repeat(None)
+        # convert to int, like in transform_mask
+        mask = _rgb_array_to_int(mask)
+        if mask_targets is not None:
+            mask_targets = {_hex_to_int(k): v for k, v in mask_targets.items()}
 
-    detections = []
-    for target, array_target in zip(targets, array_targets):
-        if target in (0, "#000000"):
-            continue  # skip background
+    mask = mask.squeeze()
+    if mask.ndim != 2:
+        raise ValueError(f"Unsupported mask dimensions: {mask.ndim}")
 
+    objects = _find_slices(mask)
+    results = []
+    for target, slices in objects.items():
         if mask_targets is not None:
             label = mask_targets.get(target, None)
-            if is_rgb and label is None:
-                label = mask_targets.get(target.upper(), None)
 
             if label is None:
                 continue  # skip unknown target
@@ -1687,8 +1725,6 @@ def _segmentation_to_detections(segmentation, mask_targets, mask_types):
             label = str(target)
 
         label_type = mask_types.get(target, None)
-        if is_rgb and label_type is None:
-            label_type = mask_types.get(target.upper(), None)
 
         if label_type is None:
             if default is None:
@@ -1696,97 +1732,86 @@ def _segmentation_to_detections(segmentation, mask_targets, mask_types):
 
             label_type = default
 
-        if is_rgb:
-            label_mask = np.all(mask == array_target.reshape(1, 1, 3), axis=2)
-        else:
-            label_mask = mask == target
+        label_mask = mask[slices] == target
+        offset = list(s.start for s in slices)[::-1]
+        frame_size = mask.shape[:2][::-1]
 
-        if label_type == "stuff":
-            instances = [_parse_stuff_instance(label_mask)]
-        elif label_type == "thing":
-            instances = _parse_thing_instances(label_mask)
-        else:
-            raise ValueError(
-                "Unsupported mask type '%s'. Supported values are "
-                "('stuff', 'thing')"
-            )
+        new_results = converter(
+            label_mask, label, label_type, offset, frame_size
+        )
+        results.extend(new_results)
 
-        for bbox, instance_mask in instances:
-            detections.append(
-                Detection(label=label, bounding_box=bbox, mask=instance_mask)
-            )
+    return results
 
-    return detections
+
+def _mask_to_detections(label_mask, label, label_type, offset, frame_size):
+    """convert a mask to a detection
+
+    offset: (width, height)
+    frame_sizes: (width_height)
+
+    """
+    if label_type == "stuff":
+        instances = [_parse_stuff_instance(label_mask, offset, frame_size)]
+    elif label_type == "thing":
+        instances = _parse_thing_instances(label_mask, offset, frame_size)
+    else:
+        raise ValueError(
+            "Unsupported mask type '%s'. Supported values are "
+            "('stuff', 'thing')"
+        )
+
+    results = list(
+        Detection(label=label, bounding_box=bbox, mask=instance_mask)
+        for bbox, instance_mask in instances
+    )
+    return results
+
+
+def _mask_to_polylines(
+    label_mask, label, label_type, offset, frame_size, tolerance, round_coords
+):
+    polygons = _get_polygons(
+        label_mask,
+        tolerance=tolerance,
+        round_coords=round_coords,
+        offset=offset,
+        frame_size=frame_size,
+    )
+
+    if label_type == "stuff":
+        polygons = [polygons]
+    elif label_type == "thing":
+        polygons = [[p] for p in polygons]
+    else:
+        raise ValueError(
+            "Unsupported mask type '%s'. Supported values are "
+            "('stuff', 'thing')"
+        )
+
+    polylines = list(
+        Polyline(label=label, points=points, filled=True, closed=True)
+        for points in polygons
+    )
+
+    return polylines
+
+
+def _segmentation_to_detections(segmentation, mask_targets, mask_types):
+    return _convert_segmentation(
+        segmentation, mask_targets, mask_types, _mask_to_detections
+    )
 
 
 def _segmentation_to_polylines(
-    segmentation, mask_targets, mask_types, tolerance
+    segmentation, mask_targets, mask_types, tolerance, round_coords
 ):
-    if isinstance(mask_types, dict):
-        default = None
-    else:
-        default = mask_types
-        mask_types = {}
-
-    mask = segmentation.get_mask()
-    is_rgb = mask.ndim == 3
-
-    if is_rgb:
-        array_targets = np.unique(mask.reshape(-1, mask.shape[2]), axis=0)
-        targets = [_rgb_to_hex(t) for t in array_targets]
-    else:
-        targets = np.unique(mask)
-        array_targets = itertools.repeat(None)
-
-    polylines = []
-    for target, array_target in zip(targets, array_targets):
-        if target in (0, "#000000"):
-            continue  # skip background
-
-        if mask_targets is not None:
-            label = mask_targets.get(target, None)
-            if is_rgb and label is None:
-                label = mask_targets.get(target.upper(), None)
-
-            if label is None:
-                continue  # skip unknown target
-        else:
-            label = str(target)
-
-        label_type = mask_types.get(target, None)
-        if is_rgb and label is None:
-            label_type = mask_types.get(target.upper(), None)
-
-        if label_type is None:
-            if default is None:
-                continue  # skip unknown type
-
-            label_type = default
-
-        if is_rgb:
-            label_mask = np.all(mask == array_target.reshape(1, 1, 3), axis=2)
-        else:
-            label_mask = mask == target
-
-        polygons = _get_polygons(label_mask, tolerance)
-
-        if label_type == "stuff":
-            polygons = [polygons]
-        elif label_type == "thing":
-            polygons = [[p] for p in polygons]
-        else:
-            raise ValueError(
-                "Unsupported mask type '%s'. Supported values are "
-                "('stuff', 'thing')"
-            )
-
-        for points in polygons:
-            polyline = Polyline(
-                label=label, points=points, filled=True, closed=True
-            )
-            polylines.append(polyline)
-
-    return polylines
+    converter = partial(
+        _mask_to_polylines, tolerance=tolerance, round_coords=round_coords
+    )
+    return _convert_segmentation(
+        segmentation, mask_targets, mask_types, converter
+    )
 
 
 def _hex_to_rgb(hex_str):
@@ -1830,15 +1855,29 @@ def _int_array_to_rgb(mask):
     return out_mask
 
 
-def _parse_stuff_instance(mask):
+def _parse_stuff_instance(mask, offset=None, frame_size=None):
+    """
+    offset: (width, height)
+    frame_size: (width, height)
+
+    """
     cols = np.any(mask, axis=0)
     rows = np.any(mask, axis=1)
     xmin, xmax = np.where(cols)[0][[0, -1]]
     ymin, ymax = np.where(rows)[0][[0, -1]]
 
-    height, width = mask.shape
-    x = xmin / width
-    y = ymin / height
+    if offset is None:
+        x_offset, y_offset = (0, 0)
+    else:
+        x_offset, y_offset = offset
+
+    if frame_size is None:
+        height, width = mask.shape
+    else:
+        width, height = frame_size
+
+    x = (xmin + x_offset) / width
+    y = (ymin + y_offset) / height
     w = (xmax - xmin + 1) / width
     h = (ymax - ymin + 1) / height
 
@@ -1848,21 +1887,34 @@ def _parse_stuff_instance(mask):
     return bbox, instance_mask
 
 
-def _parse_thing_instances(mask):
-    height, width = mask.shape
-    polygons = _get_polygons(mask, 2, abs_coords=True)
+def _parse_thing_instances(mask, offset=None, frame_size=None):
+    """
+    offset: (width, height)
+    frame_size: (width, height)
+
+    """
+    if offset is None:
+        x_offset, y_offset = (0, 0)
+    else:
+        x_offset, y_offset = offset
+
+    if frame_size is None:
+        height, width = mask.shape
+    else:
+        width, height = frame_size
+
+    labeled = label(mask)
+    objects = _find_slices(labeled)
 
     instances = []
-    for p in polygons:
-        p = np.array(p)
-        xmin, ymin = np.floor(p.min(axis=0)).astype(int)
-        xmax, ymax = np.ceil(p.max(axis=0)).astype(int)
+    for idx, (yslice, xslice) in objects.items():
+        xmin = xslice.start
+        xmax = xslice.stop
+        ymin = yslice.start
+        ymax = yslice.stop
 
-        xmax = max(xmin + 1, xmax)
-        ymax = max(ymin + 1, ymax)
-
-        x = xmin / width
-        y = ymin / height
+        x = (xmin + x_offset) / width
+        y = (ymin + y_offset) / height
         w = (xmax - xmin) / width
         h = (ymax - ymin) / height
 
@@ -1874,13 +1926,44 @@ def _parse_thing_instances(mask):
     return instances
 
 
-def _get_polygons(mask, tolerance, abs_coords=False):
-    polygons = etai._mask_to_polygons(mask, tolerance=tolerance)
-    if abs_coords:
-        return polygons
+def _get_polygons(
+    mask,
+    tolerance,
+    round_coords=False,
+    offset=None,
+    frame_size=None,
+    abs_coords=False,
+):
+    if offset is None:
+        x_offset, y_offset = (0, 0)
+    else:
+        x_offset, y_offset = offset
 
-    height, width = mask.shape
-    return [[(x / width, y / height) for x, y in p] for p in polygons]
+    if abs_coords:
+        height, width = (1, 1)
+    else:
+        if frame_size is None:
+            height, width = mask.shape
+        else:
+            width, height = frame_size
+
+    if round_coords:
+        round_fun = np.round
+    else:
+        round_fun = lambda x: x
+
+    polygons = etai._mask_to_polygons(mask, tolerance=tolerance)
+    polygons = list(
+        list(
+            (
+                (round_fun(x) + x_offset) / width,
+                (round_fun(y) + y_offset) / height,
+            )
+            for x, y in p
+        )
+        for p in polygons
+    )
+    return polygons
 
 
 def _from_geo_json_single(d):

--- a/setup.py
+++ b/setup.py
@@ -66,6 +66,7 @@ INSTALL_REQUIRES = [
     "retrying",
     "scikit-learn",
     "scikit-image",
+    "scipy",
     "setuptools",
     "sseclient-py>=1.7.2,<2",
     "sse-starlette>=0.10.3,<1",

--- a/tests/unittests/label_tests.py
+++ b/tests/unittests/label_tests.py
@@ -418,13 +418,11 @@ class LabelTests(unittest.TestCase):
                 mask_targets=mask_targets,
                 mask_types="thing",
                 tolerance=2,
-                round_coords=True,
             )
             poly4 = seg4.to_polylines(
                 mask_targets=mask_targets,
                 mask_types="stuff",
                 tolerance=2,
-                round_coords=True,
             )
 
             self.assertEqual(len(dets1.detections), 2)
@@ -447,27 +445,29 @@ class LabelTests(unittest.TestCase):
             # check polylines
             #
             # polyline -> detection -> polyline does not always return
-            # the exact same values, so it's not possible in general
-            # to check for exact equality. However, in this case,
-            # using `tolerance=2 and `round_coords=True` does return the
-            # same bounds.
+            # the exact same values because of interpolation, so it's
+            # not possible in general to check for exact
+            # equality.
             def poly_bounds(p):
                 a = np.array(p["points"]).squeeze()
                 ymin, xmin = a.min(axis=0)
                 ymax, xmax = a.max(axis=0)
                 return (xmin, xmax, ymin, ymax)
 
-            self.assertEqual(
+            nptest.assert_almost_equal(
                 poly_bounds(poly3.polylines[0]),
                 poly_bounds(polylines.polylines[0]),
+                decimal=1,
             )
-            self.assertEqual(
+            nptest.assert_almost_equal(
                 poly_bounds(poly3.polylines[1]),
                 poly_bounds(polylines.polylines[1]),
+                decimal=1,
             )
-            self.assertEqual(
+            nptest.assert_almost_equal(
                 poly_bounds(poly4.polylines[0]),
                 poly_bounds(polylines.polylines[0]),
+                decimal=1,
             )
 
     @drop_datasets

--- a/tests/unittests/label_tests.py
+++ b/tests/unittests/label_tests.py
@@ -9,8 +9,10 @@ import unittest
 
 from bson import Binary, ObjectId
 import numpy as np
+import numpy.testing as nptest
 
 import fiftyone as fo
+import fiftyone.core.labels as focl
 import fiftyone.utils.labels as foul
 from fiftyone import ViewField as F
 
@@ -384,83 +386,119 @@ class LabelTests(unittest.TestCase):
         detection = detections.detections[0]
         polyline = polylines.polylines[0]
 
-        #
-        # Grayscale
-        #
+        # check both int and RGB
+        for target, ndim in ((128, 2), ("#ff6d04", 3)):
+            mask_targets = {target: label}
 
-        target = 128
-        mask_targets = {target: label}
+            seg1 = detections.to_segmentation(
+                frame_size=frame_size, mask_targets=mask_targets
+            )
+            seg2 = detection.to_segmentation(
+                frame_size=frame_size, target=target
+            )
+            seg3 = polylines.to_segmentation(
+                frame_size=frame_size, mask_targets=mask_targets
+            )
+            seg4 = polyline.to_segmentation(
+                frame_size=frame_size, target=target
+            )
 
-        seg1 = detections.to_segmentation(
-            frame_size=frame_size, mask_targets=mask_targets
-        )
-        seg2 = detection.to_segmentation(frame_size=frame_size, target=target)
-        seg3 = polylines.to_segmentation(
-            frame_size=frame_size, mask_targets=mask_targets
-        )
-        seg4 = polyline.to_segmentation(frame_size=frame_size, target=target)
+            self.assertEqual(seg1.mask.ndim, ndim)
+            self.assertEqual(seg2.mask.ndim, ndim)
+            self.assertEqual(seg3.mask.ndim, ndim)
+            self.assertEqual(seg4.mask.ndim, ndim)
 
-        self.assertEqual(seg1.mask.ndim, 2)
-        self.assertEqual(seg2.mask.ndim, 2)
-        self.assertEqual(seg3.mask.ndim, 2)
-        self.assertEqual(seg4.mask.ndim, 2)
+            dets1 = seg1.to_detections(
+                mask_targets=mask_targets, mask_types="thing"
+            )
+            dets2 = seg2.to_detections(
+                mask_targets=mask_targets, mask_types="stuff"
+            )
+            poly3 = seg3.to_polylines(
+                mask_targets=mask_targets,
+                mask_types="thing",
+                tolerance=2,
+                round_coords=True,
+            )
+            poly4 = seg4.to_polylines(
+                mask_targets=mask_targets,
+                mask_types="stuff",
+                tolerance=2,
+                round_coords=True,
+            )
 
-        dets1 = seg1.to_detections(
-            mask_targets=mask_targets, mask_types="thing"
-        )
-        dets2 = seg2.to_detections(
-            mask_targets=mask_targets, mask_types="stuff"
-        )
-        poly3 = seg3.to_polylines(
-            mask_targets=mask_targets, mask_types="thing"
-        )
-        poly4 = seg4.to_polylines(
-            mask_targets=mask_targets, mask_types="stuff"
+            self.assertEqual(len(dets1.detections), 2)
+            self.assertEqual(len(dets2.detections), 1)
+            self.assertEqual(len(poly3.polylines), 2)
+            self.assertEqual(len(poly4.polylines), 1)
+
+            # check bounding boxes
+            self.assertEqual(
+                dets1.detections[0].bounding_box, [0.1, 0.1, 0.3, 0.3]
+            )
+            self.assertEqual(
+                dets1.detections[1].bounding_box, [0.6, 0.6, 0.3, 0.3]
+            )
+
+            self.assertEqual(
+                dets2.detections[0].bounding_box, [0.1, 0.1, 0.3, 0.3]
+            )
+
+            # check polylines
+            #
+            # polyline -> detection -> polyline does not always return
+            # the exact same values, so it's not possible in general
+            # to check for exact equality. However, in this case,
+            # using `tolerance=2 and `round_coords=True` does return the
+            # same bounds.
+            def poly_bounds(p):
+                a = np.array(p["points"]).squeeze()
+                ymin, xmin = a.min(axis=0)
+                ymax, xmax = a.max(axis=0)
+                return (xmin, xmax, ymin, ymax)
+
+            self.assertEqual(
+                poly_bounds(poly3.polylines[0]),
+                poly_bounds(polylines.polylines[0]),
+            )
+            self.assertEqual(
+                poly_bounds(poly3.polylines[1]),
+                poly_bounds(polylines.polylines[1]),
+            )
+            self.assertEqual(
+                poly_bounds(poly4.polylines[0]),
+                poly_bounds(polylines.polylines[0]),
+            )
+
+    @drop_datasets
+    def test_transform_mask(self):
+        # int to int
+        mask = np.arange(9).reshape((3, 3))
+        targets_map = dict((i, i + 1) for i in range(1, 9))
+        int_to_int = focl._transform_mask(mask, targets_map)
+        nptest.assert_array_equal(
+            int_to_int[int_to_int != 0], mask[mask != 0] + 1
         )
 
-        self.assertEqual(len(dets1.detections), 2)
-        self.assertEqual(len(dets2.detections), 1)
-        self.assertEqual(len(poly3.polylines), 2)
-        self.assertEqual(len(poly4.polylines), 1)
+        # int to rgb
+        targets_map = dict((i, focl._int_to_hex(i)) for i in range(1, 9))
+        int_to_rgb = focl._transform_mask(mask, targets_map)
+        self.assertEqual(int_to_rgb.shape, (3, 3, 3))
+        nptest.assert_array_equal(int_to_rgb[:, :, 0], np.zeros_like(mask))
+        nptest.assert_array_equal(int_to_rgb[:, :, 1], np.zeros_like(mask))
+        nptest.assert_array_equal(int_to_rgb[:, :, 2], mask)
 
-        #
-        # Color
-        #
+        # rgb back to int
+        targets_map = dict((focl._int_to_hex(i), i) for i in range(1, 9))
+        rgb_to_int = focl._transform_mask(int_to_rgb, targets_map)
+        nptest.assert_array_equal(rgb_to_int, mask)
 
-        target = "#ff6d04"
-        mask_targets = {target: label}
-
-        seg1 = detections.to_segmentation(
-            frame_size=frame_size, mask_targets=mask_targets
+        # rgb to rgb
+        targets_map = dict(
+            (focl._int_to_hex(i), focl._int_to_hex(0)) for i in range(1, 9)
         )
-        seg2 = detection.to_segmentation(frame_size=frame_size, target=target)
-        seg3 = polylines.to_segmentation(
-            frame_size=frame_size, mask_targets=mask_targets
-        )
-        seg4 = polyline.to_segmentation(frame_size=frame_size, target=target)
-
-        self.assertEqual(seg1.mask.ndim, 3)
-        self.assertEqual(seg2.mask.ndim, 3)
-        self.assertEqual(seg3.mask.ndim, 3)
-        self.assertEqual(seg4.mask.ndim, 3)
-
-        dets1 = seg1.to_detections(
-            mask_targets=mask_targets, mask_types="thing"
-        )
-        dets2 = seg2.to_detections(
-            mask_targets=mask_targets, mask_types="stuff"
-        )
-        poly3 = seg3.to_polylines(
-            mask_targets=mask_targets, mask_types="thing"
-        )
-        poly4 = seg4.to_polylines(
-            mask_targets=mask_targets, mask_types="stuff"
-        )
-
-        self.assertEqual(len(dets1.detections), 2)
-        self.assertEqual(len(dets2.detections), 1)
-        self.assertEqual(len(poly3.polylines), 2)
-        self.assertEqual(len(poly4.polylines), 1)
+        rgb_to_rgb = focl._transform_mask(int_to_rgb, targets_map)
+        nptest.assert_array_equal(rgb_to_rgb, np.zeros((3, 3, 3), dtype=int))
 
 
 class LabelUtilsTests(unittest.TestCase):


### PR DESCRIPTION
`_segmentation_to_detections()`, `_segmentations_to_polylines()`, and `_transform_mask()` create a new full-sized mask for each object in the mask, which scales badly. In our use case we have images with dimension about 22,000 x 9,000, with tens of thousands of objects in them. Looping through each object and creating a new full-sized mask object in each iteration is extremely slow.

The proposed changes scale exponentially better. In a 10,000 x 10,000 image with 10,000 objects, the old method would have taken almost three hours, whereas the new method took only 8 seconds.

Here are timing comparisons with a mask of shape 10,000 x 10,000 on a MacBook M2 Air.

`_segmentation_to_detections()` and `_segmentations_to_polylines()` - similar numbers for both:
| method  | n objects | time (seconds) |
|--- | --- | ---|
| old | 10   | 11.3   |
| | 100 | 101.2 |
| | 1,000 | 1,022.5 |
| | 10,000 | ~10,000 (skipped) |
| new | 10 | 2.0 |
| | 100 | 2.0 |
| | 1,000 | 2.11 |
| | 10,000 | 8.26 |

`transform_mask()`:
| method  | n objects | time (seconds) |
|--- | --- | ---|
| old | 10   | 0.4   |
| | 100 | 3.5 |
| | 1,000 | 35.7 |
| | 10,000 | 352.2 |
| new | 10 | 2.0 |
| | 100 | 1.9 |
| | 1,000 | 2.0 |
| | 10,000 | 7.4 |

## What changes are proposed in this pull request?

- Implement a new function `_find_slices()` to preprocess a mask and find the extent of each unique object. This function is the key to speeding up the others.

- Use that function to speed up `_segmentations_to_detections()`, `_segmentations_to_polylines()`, and `_transform_mask()`.

- Keep track of offsets and overall segmentation mask size, to ensure the new detections have correct relative bounding boxes and the new polylines have the correct coordinates. This includes switching from using `_get_polygons()` to `skimage.measure.label()` in `_parse_thing_instances()`, which avoids the problem of polygon tolerance being off by one or more pixels.

- Combine the core functionality of `_segmentations_to_detections()` and `_segmentations_to_polylines()` into a single function, `_convert_segmentations()`. This eliminates code duplication and allows future segmentation conversions to reuse this code.

- In `_convert_segmentations()`, convert RGB masks to integer masks, matching the way it is done in `_transform_mask()`. This eliminates a number of if/then branches and makes the rest of the function easier to reason about.

- Add unit tests to ensure the changed functions behave as expected.

## How is this patch tested? If it is not, please explain why.

Updated and added new unit tests to check correctness.

Running times comparisons appear above.

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [X] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [X] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
