### PR TITLE
externalize fiftyone spaces package to share context

### DIFF
--- a/app/packages/plugins/src/externalize.ts
+++ b/app/packages/plugins/src/externalize.ts
@@ -2,6 +2,7 @@ import * as foc from "@fiftyone/components";
 import * as foo from "@fiftyone/operators";
 import * as fos from "@fiftyone/state";
 import * as fou from "@fiftyone/utilities";
+import * as fosp from "@fiftyone/spaces";
 import * as mui from "@mui/material";
 import React from "react";
 import ReactDOM from "react-dom";
@@ -17,6 +18,7 @@ declare global {
     __foc__: typeof foc;
     __fou__: typeof fou;
     __foo__: typeof foo;
+    __fosp__: typeof fosp;
     __mui__: typeof mui;
     __styled__: typeof styled;
   }
@@ -32,6 +34,7 @@ if (typeof window !== "undefined") {
   window.__foc__ = foc;
   window.__fou__ = fou;
   window.__foo__ = foo;
+  window.__fosp__ = fosp;
   window.__mui__ = mui;
   window.__styled__ = styled;
 }


### PR DESCRIPTION
## What changes are proposed in this pull request?

externalize fiftyone spaces package to share context

Depends on https://github.com/voxel51/fiftyone-plugins/pull/124

## How is this patch tested? If it is not, please explain why.

Using a an externally built plugin with a Panel

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

Fix `usePanelState` not persisting state in session due to missing panel context

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
