### PR TITLE
fix session not updated on space resize

### DIFF
--- a/app/packages/spaces/src/components/Space.tsx
+++ b/app/packages/spaces/src/components/Space.tsx
@@ -1,7 +1,7 @@
 import { Allotment, AllotmentHandle } from "allotment";
 import "allotment/dist/style.css";
 import { debounce } from "lodash";
-import { useCallback, useEffect, useRef } from "react";
+import { useEffect, useMemo, useRef } from "react";
 import { ReactSortable } from "react-sortablejs";
 import SpaceNode from "../SpaceNode";
 import { Layout } from "../enums";
@@ -26,19 +26,14 @@ export default function Space({ node, id }: SpaceProps) {
   const currentTotalSize = useRef<number>();
   const { sizes } = node;
 
-  const setSpaceSizes = useCallback(
-    (node: SpaceNode, sizes: number[]) =>
-      debounce(() => {
-        currentTotalSize.current = sizes.reduce(
-          (total, item) => total + item,
-          0
-        );
-        const relativeSizes = getRelativeSizes(sizes);
-        previousSizesRef.current = relativeSizes;
-        spaces.setNodeSizes(node, relativeSizes);
-      }, 500),
-    [spaces]
-  );
+  const setSpaceSizes = useMemo(() => {
+    return debounce((node: SpaceNode, sizes: number[]) => {
+      currentTotalSize.current = sizes.reduce((total, item) => total + item, 0);
+      const relativeSizes = getRelativeSizes(sizes);
+      previousSizesRef.current = relativeSizes;
+      spaces.setNodeSizes(node, relativeSizes);
+    }, 500);
+  }, [spaces]);
 
   // apply sizes updates from remote session
   useEffect(() => {


### PR DESCRIPTION
## What changes are proposed in this pull request?

fix session not updated on space resize

## How is this patch tested? If it is not, please explain why.

By resizing spaces in the App and refreshing to make sure space sizes are preserved

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
