### PR TITLE
Export/model inference cleanup

### DIFF
--- a/docs/source/teams/cloud_media.rst
+++ b/docs/source/teams/cloud_media.rst
@@ -387,6 +387,7 @@ _____________
     fo.Dataset.download_media(
         self,
         media_fields=None,
+        group_slices=None,
         update=False,
         skip_failures=True,
         progress=None,
@@ -402,6 +403,9 @@ _____________
             media_fields (None): a field or iterable of fields containing media
                 to download. By default, all media fields in the collection's
                 :meth:`app_config` are used
+            group_slices (None): an optional subset of group slices for which
+                to download media. Only applicable when the collection contains
+                groups
             update (False): whether to re-download media whose checksums no
                 longer match
             skip_failures (True): whether to gracefully continue without
@@ -416,17 +420,35 @@ _____________
 
     fo.Dataset.download_context(
         self,
-        batch_size=100,
+        batch_size=None,
+        target_size_bytes=None,
+        media_fields=None,
+        group_slices=None,
+        update=False,
+        skip_failures=True,
         clear=False,
         progress=None,
-        **kwargs,
     ):
-        """Returns a context that can be used to automatically pre-download
-        media when iterating over samples in this collection.
+        """Returns a context that can be used to pre-download media in batches
+        when iterating over samples in this collection.
+
+        By default, all media will be downloaded when the context is entered,
+        but you can configure a batching strategy via the `batch_size` or
+        `target_size_bytes` parameters.
 
         Args:
-            batch_size (100): the sample batch size to use when downloading
-                media
+            batch_size (None): a sample batch size to use for each download
+            target_size_bytes (None): a target content size, in bytes, for each
+                download batch
+            media_fields (None): a field or iterable of fields containing media
+                to download. By default, all media fields in the collection's
+                :meth:`app_config` are used
+            group_slices (None): an optional subset of group slices to download
+                media for. Only applicable when the collection contains groups
+            update (False): whether to re-download media whose checksums no
+                longer match
+            skip_failures (True): whether to gracefully continue without
+                raising an error if a remote file cannot be downloaded
             clear (False): whether to clear the media from the cache when the
                 context exits
             progress (None): whether to render a progress bar tracking the
@@ -468,7 +490,7 @@ _____________
 
 .. code-block:: python
 
-    fo.Dataset.cache_stats(self, media_fields=None):
+    fo.Dataset.cache_stats(self, media_fields=None, group_slices=None):
         """Returns a dictionary of stats about the cached media files in this
         collection.
 
@@ -478,6 +500,8 @@ _____________
             media_fields (None): a field or iterable of fields containing media
                 paths. By default, all media fields in the collection's
                 :meth:`app_config` are included
+            group_slices (None): an optional subset of group slices to include.
+                Only applicable when the collection contains groups
 
         Returns:
             a stats dict
@@ -485,7 +509,7 @@ _____________
 
 .. code-block:: python
 
-    fo.Dataset.clear_media(self, media_fields=None):
+    fo.Dataset.clear_media(self, media_fields=None, group_slices=None):
         """Deletes any local copies of media files in this collection from the
         media cache.
 
@@ -495,6 +519,9 @@ _____________
             media_fields (None): a field or iterable of fields containing media
                 paths to clear from the cache. By default, all media fields
                 in the collection's :meth:`app_config` are cleared
+            group_slices (None): an optional subset of group slices for which
+                to clear media. Only applicable when the collection contains
+                groups
         """
 
 `fiftyone.core.storage`

--- a/docs/source/user_guide/config.rst
+++ b/docs/source/user_guide/config.rst
@@ -56,8 +56,9 @@ FiftyOne supports the configuration options described below:
 | `default_batch_size`          | `FIFTYONE_DEFAULT_BATCH_SIZE`       | `None`                        | A default batch size to use when :ref:`applying models to datasets <model-zoo-apply>`. |
 +-------------------------------+-------------------------------------+-------------------------------+----------------------------------------------------------------------------------------+
 | `default_batcher`             | `FIFTYONE_DEFAULT_BATCHER`          | `latency`                     | Batching implementation to use in some batched database operations such as             |
-|                               |                                     |                               | :meth:`add_samples() <fiftyone.core.dataset.Dataset.add_samples>` and                  |
-|                               |                                     |                               | :meth:`set_values() <fiftyone.core.collections.SampleCollection.set_values>`.          |
+|                               |                                     |                               | :meth:`add_samples() <fiftyone.core.dataset.Dataset.add_samples>`,                     |
+|                               |                                     |                               | :meth:`set_values() <fiftyone.core.collections.SampleCollection.set_values>`, and      |
+|                               |                                     |                               | :meth:`save_context() <fiftyone.core.collections.SampleCollection.save_context>`.      |
 |                               |                                     |                               | Supported values are `latency`, `size`, and `static`.                                  |
 |                               |                                     |                               |                                                                                        |
 |                               |                                     |                               | `latency` is the default, which uses a dynamic batch size to achieve a target latency  |

--- a/docs/source/user_guide/using_datasets.rst
+++ b/docs/source/user_guide/using_datasets.rst
@@ -4818,9 +4818,11 @@ update strategy:
     As the above snippet shows, you should also optimize your iteration by
     :ref:`selecting only <efficient-iteration-views>` the required fields.
 
-By default, updates are batched and submitted every 0.2 seconds, but you can
-configure the batching strategy by passing the optional ``batch_size`` argument
-to :meth:`iter_samples() <fiftyone.core.dataset.Dataset.iter_samples>`.
+You can configure the default batching strategy that is used via your
+:ref:`FiftyOne config <configuring-fiftyone>`, or you can configure the
+batching strategy on a per-method call basis by passing the optional
+``batch_size`` and ``batching_strategy`` arguments to
+:meth:`iter_samples() <fiftyone.core.dataset.Dataset.iter_samples>`.
 
 You can also use the
 :meth:`save_context() <fiftyone.core.collections.SampleCollection.save_context>`

--- a/docs/source/user_guide/using_views.rst
+++ b/docs/source/user_guide/using_views.rst
@@ -2263,9 +2263,11 @@ update strategy:
     As the above snippet shows, you should also optimize your iteration by
     :ref:`selecting only <efficient-iteration-views>` the required fields.
 
-By default, updates are batched and submitted every 0.2 seconds, but you can
-configure the batching strategy by passing the optional ``batch_size`` argument
-to :meth:`iter_samples() <fiftyone.core.view.DatasetView.iter_samples>`.
+You can configure the default batching strategy that is used via your
+:ref:`FiftyOne config <configuring-fiftyone>`, or you can configure the
+batching strategy on a per-method call basis by passing the optional
+``batch_size`` and ``batching_strategy`` arguments to
+:meth:`iter_samples() <fiftyone.core.view.DatasetView.iter_samples>`.
 
 You can also use the
 :meth:`save_context() <fiftyone.core.collections.SampleCollection.save_context>`

--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -79,14 +79,30 @@ class SaveContext(object):
     Args:
         sample_collection: a
             :class:`fiftyone.core.collections.SampleCollection`
-        batch_size (None): the batching strategy to use. Can either be an
-            integer specifying the number of samples to save in a batch, or a
-            float number of seconds between batched saves
+        batch_size (None): the batch size to use. If a ``batching_strategy`` is
+            provided, this parameter configures the strategy as described below.
+            If no ``batching_strategy`` is provided, this can either be an
+            integer specifying the number of samples to save in a batch (in
+            which case ``batching_strategy`` is implicitly set to ``"static"``)
+            or a float number of seconds between batched saves (in which case
+            ``batching_strategy`` is implicitly set to ``"latency"``)
+        batching_strategy (None): the batching strategy to use for each save
+            operation. Supported values are:
+
+            -   ``"static"``: a fixed sample batch size for each save
+            -   ``"size"``: a target batch size, in bytes, for each save
+            -   ``"latency"``: a target latency, in seconds, between saves
     """
 
-    def __init__(self, sample_collection, batch_size=None):
-        if batch_size is None:
-            batch_size = 0.2
+    def __init__(
+        self,
+        sample_collection,
+        batch_size=None,
+        batching_strategy=None,
+    ):
+        batch_size, batching_strategy = fou.parse_batching_strategy(
+            batch_size=batch_size, batching_strategy=batching_strategy
+        )
 
         self.sample_collection = sample_collection
         self.batch_size = batch_size
@@ -99,15 +115,19 @@ class SaveContext(object):
         self._frame_ops = []
         self._reload_parents = []
 
+        self._batching_strategy = batching_strategy
         self._curr_batch_size = None
-        self._dynamic_batches = not isinstance(batch_size, numbers.Integral)
+        self._curr_batch_size_bytes = None
         self._last_time = None
 
     def __enter__(self):
-        if self._dynamic_batches:
+        if self._batching_strategy == "static":
+            self._curr_batch_size = 0
+        elif self._batching_strategy == "size":
+            self._curr_batch_size_bytes = 0
+        elif self._batching_strategy == "latency":
             self._last_time = timeit.default_timer()
 
-        self._curr_batch_size = 0
         return self
 
     def __exit__(self, *args):
@@ -129,8 +149,6 @@ class SaveContext(object):
         sample_ops, frame_ops = sample._save(deferred=True)
         updated = sample_ops or frame_ops
 
-        self._curr_batch_size += 1
-
         if sample_ops:
             self._sample_ops.extend(sample_ops)
 
@@ -140,16 +158,31 @@ class SaveContext(object):
         if updated and isinstance(sample, fosa.SampleView):
             self._reload_parents.append(sample)
 
-        if self._dynamic_batches:
+        if self._batching_strategy == "static":
+            self._curr_batch_size += 1
+            if self._curr_batch_size >= self.batch_size:
+                self._save_batch()
+                self._curr_batch_size = 0
+        elif self._batching_strategy == "size":
+            if sample_ops:
+                self._curr_batch_size_bytes += sum(
+                    len(str(op)) for op in sample_ops
+                )
+
+            if frame_ops:
+                self._curr_batch_size_bytes += sum(
+                    len(str(op)) for op in frame_ops
+                )
+
+            if self._curr_batch_size_bytes >= self.batch_size:
+                self._save_batch()
+                self._curr_batch_size_bytes = 0
+        elif self._batching_strategy == "latency":
             if timeit.default_timer() - self._last_time >= self.batch_size:
                 self._save_batch()
                 self._last_time = timeit.default_timer()
-        elif self._curr_batch_size >= self.batch_size:
-            self._save_batch()
 
     def _save_batch(self):
-        self._curr_batch_size = 0
-
         if self._sample_ops:
             foo.bulk_write(self._sample_ops, self._sample_coll, ordered=False)
             self._sample_ops.clear()
@@ -826,7 +859,13 @@ class SampleCollection(object):
         """
         raise NotImplementedError("Subclass must implement view()")
 
-    def iter_samples(self, progress=False, autosave=False, batch_size=None):
+    def iter_samples(
+        self,
+        progress=False,
+        autosave=False,
+        batch_size=None,
+        batching_strategy=None,
+    ):
         """Returns an iterator over the samples in the collection.
 
         Args:
@@ -835,9 +874,21 @@ class SampleCollection(object):
                 (None), or a progress callback function to invoke instead
             autosave (False): whether to automatically save changes to samples
                 emitted by this iterator
-            batch_size (None): a batch size to use when autosaving samples. Can
-                either be an integer specifying the number of samples to save
-                in a batch, or a float number of seconds between batched saves
+            batch_size (None): the batch size to use when autosaving samples.
+                If a ``batching_strategy`` is provided, this parameter
+                configures the strategy as described below. If no
+                ``batching_strategy`` is provided, this can either be an
+                integer specifying the number of samples to save in a batch
+                (in which case ``batching_strategy`` is implicitly set to
+                ``"static"``) or a float number of seconds between batched
+                saves (in which case ``batching_strategy`` is implicitly set to
+                ``"latency"``)
+            batching_strategy (None): the batching strategy to use for each
+                save operation when autosaving samples. Supported values are:
+
+                -   ``"static"``: a fixed sample batch size for each save
+                -   ``"size"``: a target batch size, in bytes, for each save
+                -   ``"latency"``: a target latency, in seconds, between saves
 
         Returns:
             an iterator over :class:`fiftyone.core.sample.Sample` or
@@ -851,6 +902,7 @@ class SampleCollection(object):
         progress=False,
         autosave=False,
         batch_size=None,
+        batching_strategy=None,
     ):
         """Returns an iterator over the groups in the collection.
 
@@ -861,9 +913,21 @@ class SampleCollection(object):
                 (None), or a progress callback function to invoke instead
             autosave (False): whether to automatically save changes to samples
                 emitted by this iterator
-            batch_size (None): a batch size to use when autosaving samples. Can
-                either be an integer specifying the number of samples to save
-                in a batch, or a float number of seconds between batched saves
+            batch_size (None): the batch size to use when autosaving samples.
+                If a ``batching_strategy`` is provided, this parameter
+                configures the strategy as described below. If no
+                ``batching_strategy`` is provided, this can either be an
+                integer specifying the number of samples to save in a batch
+                (in which case ``batching_strategy`` is implicitly set to
+                ``"static"``) or a float number of seconds between batched
+                saves (in which case ``batching_strategy`` is implicitly set to
+                ``"latency"``)
+            batching_strategy (None): the batching strategy to use for each
+                save operation when autosaving samples. Supported values are:
+
+                -   ``"static"``: a fixed sample batch size for each save
+                -   ``"size"``: a target batch size, in bytes, for each save
+                -   ``"latency"``: a target latency, in seconds, between saves
 
         Returns:
             an iterator that emits dicts mapping group slice names to
@@ -888,7 +952,7 @@ class SampleCollection(object):
         """
         raise NotImplementedError("Subclass must implement get_group()")
 
-    def save_context(self, batch_size=None):
+    def save_context(self, batch_size=None, batching_strategy=None):
         """Returns a context that can be used to save samples from this
         collection according to a configurable batching strategy.
 
@@ -923,14 +987,27 @@ class SampleCollection(object):
                     context.save(sample)
 
         Args:
-            batch_size (None): the batching strategy to use. Can either be an
-                integer specifying the number of samples to save in a batch, or
-                a float number of seconds between batched saves
+            batch_size (None): the batch size to use. If a ``batching_strategy``
+                is provided, this parameter configures the strategy as
+                described below. If no ``batching_strategy`` is provided, this
+                can either be an integer specifying the number of samples to
+                save in a batch (in which case ``batching_strategy`` is
+                implicitly set to ``"static"``) or a float number of seconds
+                between batched saves (in which case ``batching_strategy`` is
+                implicitly set to ``"latency"``)
+            batching_strategy (None): the batching strategy to use for each
+                save operation. Supported values are:
+
+                -   ``"static"``: a fixed sample batch size for each save
+                -   ``"size"``: a target batch size, in bytes, for each save
+                -   ``"latency"``: a target latency, in seconds, between saves
 
         Returns:
             a :class:`SaveContext`
         """
-        return SaveContext(self, batch_size=batch_size)
+        return SaveContext(
+            self, batch_size=batch_size, batching_strategy=batching_strategy
+        )
 
     def _get_default_sample_fields(
         self,

--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -92,6 +92,8 @@ class SaveContext(object):
             -   ``"static"``: a fixed sample batch size for each save
             -   ``"size"``: a target batch size, in bytes, for each save
             -   ``"latency"``: a target latency, in seconds, between saves
+
+            By default, ``fo.config.default_batcher`` is used
     """
 
     def __init__(
@@ -890,6 +892,8 @@ class SampleCollection(object):
                 -   ``"size"``: a target batch size, in bytes, for each save
                 -   ``"latency"``: a target latency, in seconds, between saves
 
+                By default, ``fo.config.default_batcher`` is used
+
         Returns:
             an iterator over :class:`fiftyone.core.sample.Sample` or
             :class:`fiftyone.core.sample.SampleView` instances
@@ -928,6 +932,8 @@ class SampleCollection(object):
                 -   ``"static"``: a fixed sample batch size for each save
                 -   ``"size"``: a target batch size, in bytes, for each save
                 -   ``"latency"``: a target latency, in seconds, between saves
+
+                By default, ``fo.config.default_batcher`` is used
 
         Returns:
             an iterator that emits dicts mapping group slice names to
@@ -974,6 +980,12 @@ class SampleCollection(object):
                 sample.ground_truth.label = make_label()
                 sample.save()
 
+            # Save using default batching strategy
+            with dataset.save_context() as context:
+                for sample in dataset.iter_samples(progress=True):
+                    sample.ground_truth.label = make_label()
+                    context.save(sample)
+
             # Save in batches of 10
             with dataset.save_context(batch_size=10) as context:
                 for sample in dataset.iter_samples(progress=True):
@@ -1001,6 +1013,8 @@ class SampleCollection(object):
                 -   ``"static"``: a fixed sample batch size for each save
                 -   ``"size"``: a target batch size, in bytes, for each save
                 -   ``"latency"``: a target latency, in seconds, between saves
+
+                By default, ``fo.config.default_batcher`` is used
 
         Returns:
             a :class:`SaveContext`

--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -10002,8 +10002,11 @@ class SampleCollection(object):
             schema = self.get_field_schema(flat=True)
             app_media_fields = set(self._dataset.app_config.media_fields)
 
-        if not include_filepath:
-            app_media_fields.discard("filepath")
+            if include_filepath:
+                # 'filepath' should already be in set, but add it just in case
+                app_media_fields.add("filepath")
+            else:
+                app_media_fields.discard("filepath")
 
         for field_name, field in schema.items():
             if field_name in app_media_fields:
@@ -10024,6 +10027,19 @@ class SampleCollection(object):
             }
 
         return media_fields
+
+    def _resolve_media_field(self, media_field):
+        _media_field, is_frame_field = self._handle_frame_field(media_field)
+
+        media_fields = self._get_media_fields(frames=is_frame_field)
+        for root, leaf in media_fields.items():
+            if leaf is not None:
+                leaf = root + "." + leaf
+
+            if _media_field in (root, leaf):
+                return leaf if leaf is not None else root
+
+        raise ValueError("'%s' is not a valid media field" % media_field)
 
     def _get_label_fields(self):
         return [path for path, _ in _iter_label_fields(self)]

--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -2207,6 +2207,8 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
                 -   ``"size"``: a target batch size, in bytes, for each save
                 -   ``"latency"``: a target latency, in seconds, between saves
 
+                By default, ``fo.config.default_batcher`` is used
+
         Returns:
             an iterator over :class:`fiftyone.core.sample.Sample` instances
         """
@@ -2329,6 +2331,8 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
                 -   ``"static"``: a fixed sample batch size for each save
                 -   ``"size"``: a target batch size, in bytes, for each save
                 -   ``"latency"``: a target latency, in seconds, between saves
+
+                By default, ``fo.config.default_batcher`` is used
 
         Returns:
             an iterator that emits dicts mapping group slice names to

--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -2142,7 +2142,13 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
 
         self.save()
 
-    def iter_samples(self, progress=False, autosave=False, batch_size=None):
+    def iter_samples(
+        self,
+        progress=False,
+        autosave=False,
+        batch_size=None,
+        batching_strategy=None,
+    ):
         """Returns an iterator over the samples in the dataset.
 
         Examples::
@@ -2163,6 +2169,10 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
                 sample.ground_truth.label = make_label()
                 sample.save()
 
+            # Save using default batching strategy
+            for sample in dataset.iter_samples(progress=True, autosave=True):
+                sample.ground_truth.label = make_label()
+
             # Save in batches of 10
             for sample in dataset.iter_samples(
                 progress=True, autosave=True, batch_size=10
@@ -2181,9 +2191,21 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
                 (None), or a progress callback function to invoke instead
             autosave (False): whether to automatically save changes to samples
                 emitted by this iterator
-            batch_size (None): a batch size to use when autosaving samples. Can
-                either be an integer specifying the number of samples to save
-                in a batch, or a float number of seconds between batched saves
+            batch_size (None): the batch size to use when autosaving samples.
+                If a ``batching_strategy`` is provided, this parameter
+                configures the strategy as described below. If no
+                ``batching_strategy`` is provided, this can either be an
+                integer specifying the number of samples to save in a batch
+                (in which case ``batching_strategy`` is implicitly set to
+                ``"static"``) or a float number of seconds between batched
+                saves (in which case ``batching_strategy`` is implicitly set to
+                ``"latency"``)
+            batching_strategy (None): the batching strategy to use for each
+                save operation when autosaving samples. Supported values are:
+
+                -   ``"static"``: a fixed sample batch size for each save
+                -   ``"size"``: a target batch size, in bytes, for each save
+                -   ``"latency"``: a target latency, in seconds, between saves
 
         Returns:
             an iterator over :class:`fiftyone.core.sample.Sample` instances
@@ -2196,7 +2218,11 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
             samples = pb(samples)
 
             if autosave:
-                save_context = foc.SaveContext(self, batch_size=batch_size)
+                save_context = foc.SaveContext(
+                    self,
+                    batch_size=batch_size,
+                    batching_strategy=batching_strategy,
+                )
                 exit_context.enter_context(save_context)
 
             for sample in samples:
@@ -2239,6 +2265,7 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
         progress=False,
         autosave=False,
         batch_size=None,
+        batching_strategy=None,
     ):
         """Returns an iterator over the groups in the dataset.
 
@@ -2261,6 +2288,11 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
                     sample["test"] = make_label()
                     sample.save()
 
+            # Save using default batching strategy
+            for group in dataset.iter_groups(progress=True, autosave=True):
+                for sample in group.values():
+                    sample["test"] = make_label()
+
             # Save in batches of 10
             for group in dataset.iter_groups(
                 progress=True, autosave=True, batch_size=10
@@ -2282,9 +2314,21 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
                 (None), or a progress callback function to invoke instead
             autosave (False): whether to automatically save changes to samples
                 emitted by this iterator
-            batch_size (None): a batch size to use when autosaving samples. Can
-                either be an integer specifying the number of samples to save
-                in a batch, or a float number of seconds between batched saves
+            batch_size (None): the batch size to use when autosaving samples.
+                If a ``batching_strategy`` is provided, this parameter
+                configures the strategy as described below. If no
+                ``batching_strategy`` is provided, this can either be an
+                integer specifying the number of samples to save in a batch
+                (in which case ``batching_strategy`` is implicitly set to
+                ``"static"``) or a float number of seconds between batched
+                saves (in which case ``batching_strategy`` is implicitly set to
+                ``"latency"``)
+            batching_strategy (None): the batching strategy to use for each
+                save operation when autosaving samples. Supported values are:
+
+                -   ``"static"``: a fixed sample batch size for each save
+                -   ``"size"``: a target batch size, in bytes, for each save
+                -   ``"latency"``: a target latency, in seconds, between saves
 
         Returns:
             an iterator that emits dicts mapping group slice names to
@@ -2301,7 +2345,11 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
             groups = pb(groups)
 
             if autosave:
-                save_context = foc.SaveContext(self, batch_size=batch_size)
+                save_context = foc.SaveContext(
+                    self,
+                    batch_size=batch_size,
+                    batching_strategy=batching_strategy,
+                )
                 exit_context.enter_context(save_context)
 
             for group in groups:

--- a/fiftyone/core/frame.py
+++ b/fiftyone/core/frame.py
@@ -671,9 +671,9 @@ class Frames(object):
                     {"_sample_id": self._sample_id}
                 )
 
-            Frame._reset_docs(
-                self._frame_collection_name, sample_ids=[self._sample.id]
-            )
+                Frame._reset_docs(
+                    self._frame_collection_name, sample_ids=[self._sample.id]
+                )
 
             self._delete_all = False
             self._delete_frames.clear()
@@ -692,11 +692,11 @@ class Frames(object):
             if not deferred:
                 self._frame_collection.bulk_write(ops, ordered=False)
 
-            Frame._reset_docs_for_sample(
-                self._frame_collection_name,
-                self._sample.id,
-                self._delete_frames,
-            )
+                Frame._reset_docs_for_sample(
+                    self._frame_collection_name,
+                    self._sample.id,
+                    self._delete_frames,
+                )
 
             self._delete_frames.clear()
 
@@ -748,15 +748,15 @@ class Frames(object):
         if not deferred:
             self._frame_collection.bulk_write(ops, ordered=False)
 
-        if new_dicts:
-            ids_map = self._get_ids_map()
-            for frame_number, d in new_dicts.items():
-                frame = replacements[frame_number]
-                if isinstance(frame._doc, foo.NoDatasetFrameDocument):
-                    doc = self._dataset._frame_dict_to_doc(d)
-                    frame._set_backing_doc(doc, dataset=self._dataset)
+            if new_dicts:
+                ids_map = self._get_ids_map()
+                for frame_number, d in new_dicts.items():
+                    frame = replacements[frame_number]
+                    if isinstance(frame._doc, foo.NoDatasetFrameDocument):
+                        doc = self._dataset._frame_dict_to_doc(d)
+                        frame._set_backing_doc(doc, dataset=self._dataset)
 
-                frame._doc.id = ids_map[frame_number]
+                    frame._doc.id = ids_map[frame_number]
 
         self._replacements.clear()
 

--- a/fiftyone/core/models.py
+++ b/fiftyone/core/models.py
@@ -175,7 +175,6 @@ def apply_model(
             else:
                 cthresh = model.config.confidence_thresh
 
-            # pylint: disable=no-member
             context.enter_context(
                 fou.SetAttributes(model.config, confidence_thresh=cthresh)
             )
@@ -183,20 +182,16 @@ def apply_model(
             pass
 
         if store_logits:
-            # pylint: disable=no-member
             context.enter_context(fou.SetAttributes(model, store_logits=True))
 
         if use_data_loader:
-            # pylint: disable=no-member
             context.enter_context(fou.SetAttributes(model, preprocess=False))
 
         if needs_samples:
-            # pylint: disable=no-member
             context.enter_context(
                 fou.SetAttributes(model, needs_fields=kwargs)
             )
 
-        # pylint: disable=no-member
         context.enter_context(model)
 
         if needs_samples:
@@ -880,10 +875,8 @@ def compute_embeddings(
 
     with contextlib.ExitStack() as context:
         if use_data_loader:
-            # pylint: disable=no-member
             context.enter_context(fou.SetAttributes(model, preprocess=False))
 
-        # pylint: disable=no-member
         context.enter_context(model)
 
         samples = samples.select_fields()
@@ -1396,10 +1389,8 @@ def compute_patch_embeddings(
 
     with contextlib.ExitStack() as context:
         if use_data_loader:
-            # pylint: disable=no-member
             context.enter_context(fou.SetAttributes(model, preprocess=False))
 
-        # pylint: disable=no-member
         context.enter_context(model)
 
         if samples.media_type == fom.VIDEO:

--- a/fiftyone/core/stages.py
+++ b/fiftyone/core/stages.py
@@ -7217,7 +7217,7 @@ class SortBySimilarity(ViewStage):
         with contextlib.ExitStack() as context:
             if sample_collection.view() != results.view.view():
                 results.use_view(sample_collection)
-                context.enter_context(results)  # pylint: disable=no-member
+                context.enter_context(results)
 
             return results.sort_by_similarity(
                 self._query,

--- a/fiftyone/core/storage.py
+++ b/fiftyone/core/storage.py
@@ -168,11 +168,8 @@ class TempDir(object):
         delete_dir(self._name)
 
 
-@contextmanager
 def open_file(path, mode="r"):
     """Opens the given file for reading or writing.
-
-    This function *must* be used as a context manager.
 
     Example usage::
 
@@ -187,13 +184,30 @@ def open_file(path, mode="r"):
     Args:
         path: the path
         mode ("r"): the mode. Supported values are ``("r", "rb", "w", "wb")``
-    """
-    f = open(path, mode)
 
-    try:
-        yield f
-    finally:
-        f.close()
+    Returns:
+        an open file-like object
+    """
+    return _open_file(path, mode)
+
+
+def open_files(paths, mode="r", skip_failures=False, progress=None):
+    """Opens the given files for reading or writing.
+
+    Args:
+        paths: a list of paths
+        mode ("r"): the mode. Supported values are ``("r", "rb", "w", "wb")``
+        skip_failures (False): whether to gracefully continue without raising
+            an error if an operation fails
+        progress (None): whether to render a progress bar (True/False), use the
+            default value ``fiftyone.config.show_progress_bars`` (None), or a
+            progress callback function to invoke instead
+
+    Returns:
+        a list of open file-like objects
+    """
+    tasks = [(p, mode, skip_failures) for p in paths]
+    return _run(_do_open_file, tasks, progress=progress)
 
 
 def read_file(path, binary=False):
@@ -206,9 +220,26 @@ def read_file(path, binary=False):
     Returns:
         the file contents
     """
-    mode = "rb" if binary else "r"
-    with open(path, mode) as f:
-        return f.read()
+    return _read_file(path, binary=binary)
+
+
+def read_files(paths, binary=False, skip_failures=False, progress=None):
+    """Reads the specified files into memory.
+
+    Args:
+        paths: a list of filepaths
+        binary (False): whether to read the files in binary mode
+        skip_failures (False): whether to gracefully continue without raising
+            an error if an operation fails
+        progress (None): whether to render a progress bar (True/False), use the
+            default value ``fiftyone.config.show_progress_bars`` (None), or a
+            progress callback function to invoke instead
+
+    Returns:
+        a list of file contents
+    """
+    tasks = [(p, binary, skip_failures) for p in paths]
+    return _run(_do_read_file, tasks, progress=progress)
 
 
 def write_file(str_or_bytes, path):
@@ -227,10 +258,6 @@ def write_file(str_or_bytes, path):
 
 def sep(path):
     """Returns the path separator for the given path.
-
-    For local paths, ``os.path.sep`` is returned.
-
-    For remote paths, ``"/"`` is returned.
 
     Args:
         path: the filepath
@@ -756,8 +783,7 @@ def move_files(inpaths, outpaths, skip_failures=False, progress=None):
             progress callback function to invoke instead
     """
     tasks = [(i, o, skip_failures) for i, o in zip(inpaths, outpaths)]
-    if tasks:
-        _run(_do_move_file, tasks, progress=progress)
+    _run(_do_move_file, tasks, progress=progress)
 
 
 def move_dir(
@@ -812,8 +838,7 @@ def delete_files(paths, skip_failures=False, progress=None):
             progress callback function to invoke instead
     """
     tasks = [(p, skip_failures) for p in paths]
-    if tasks:
-        _run(_do_delete_file, tasks, progress=progress)
+    _run(_do_delete_file, tasks, progress=progress)
 
 
 def delete_dir(dirpath):
@@ -862,29 +887,31 @@ def run(fcn, tasks, num_workers=None, progress=None):
 
 def _copy_files(inpaths, outpaths, skip_failures, progress):
     tasks = [(i, o, skip_failures) for i, o in zip(inpaths, outpaths)]
-    if tasks:
-        _run(_do_copy_file, tasks, progress=progress)
+    _run(_do_copy_file, tasks, progress=progress)
 
 
 def _run(fcn, tasks, num_workers=None, progress=None):
-    num_workers = fou.recommend_thread_pool_workers(num_workers)
+    num_tasks = len(tasks)
+    if num_tasks == 0:
+        return []
 
-    try:
-        num_tasks = len(tasks)
-    except:
-        num_tasks = None
+    num_workers = fou.recommend_thread_pool_workers(num_workers)
 
     kwargs = dict(total=num_tasks, iters_str="files", progress=progress)
 
+    results = []
     if num_workers <= 1:
         with fou.ProgressBar(**kwargs) as pb:
             for task in pb(tasks):
-                fcn(task)
+                result = fcn(task)
+                results.append(result)
     else:
         with multiprocessing.dummy.Pool(processes=num_workers) as pool:
             with fou.ProgressBar(**kwargs) as pb:
-                for _ in pb(pool.imap_unordered(fcn, tasks)):
-                    pass
+                for result in pb(pool.imap_unordered(fcn, tasks)):
+                    results.append(result)
+
+    return results
 
 
 def _do_copy_file(arg):
@@ -924,6 +951,42 @@ def _do_delete_file(arg):
 
         if skip_failures != "ignore":
             logger.warning(e)
+
+
+def _do_open_file(arg):
+    filepath, mode, skip_failures = arg
+
+    try:
+        return _open_file(filepath, mode)
+    except Exception as e:
+        if not skip_failures:
+            raise
+
+        if skip_failures != "ignore":
+            logger.warning(e)
+
+
+def _open_file(path, mode):
+    return open(path, mode)
+
+
+def _do_read_file(arg):
+    filepath, binary, skip_failures = arg
+
+    try:
+        return _read_file(filepath, binary=binary)
+    except Exception as e:
+        if not skip_failures:
+            raise
+
+        if skip_failures != "ignore":
+            logger.warning(e)
+
+
+def _read_file(filepath, binary=False):
+    mode = "rb" if binary else "r"
+    with open(filepath, mode) as f:
+        return f.read()
 
 
 def _copy_file(inpath, outpath, cleanup=False):

--- a/fiftyone/core/utils.py
+++ b/fiftyone/core/utils.py
@@ -1961,10 +1961,20 @@ def iter_slices(sliceable, batch_size):
         yield sliceable
         return
 
+    try:
+        end = len(sliceable)
+    except:
+        end = None
+
     start = 0
     while True:
+        if end is not None and start >= end:
+            return
+
         chunk = sliceable[start : (start + batch_size)]
-        if len(chunk) == 0:  # works for numpy arrays, Torch tensors, etc
+
+        # works for numpy arrays, Torch tensors, etc
+        if end is None and len(chunk) == 0:
             return
 
         start += batch_size

--- a/fiftyone/core/utils.py
+++ b/fiftyone/core/utils.py
@@ -1605,6 +1605,56 @@ def get_default_batcher(iterable, progress=False, total=None):
         )
 
 
+def parse_batching_strategy(batch_size=None, batching_strategy=None):
+    """Parses the given batching strategy configuration, applying any default
+    config settings as necessary.
+
+    Args:
+        batch_size (None): the batch size to use. If a ``batching_strategy`` is
+            provided, this parameter configures that strategy as described
+            below. If no ``batching_strategy`` is provided, this can either be
+            an integer specifying the number of samples to save in a batch (in
+            which case ``batching_strategy`` is implicitly set to ``"static"``)
+            or a float number of seconds between batched saves (in which case
+            ``batching_strategy`` is implicitly set to ``"latency"``)
+        batching_strategy (None): the batching strategy to use for each save
+            operation. Supported values are:
+
+            -   ``"static"``: a fixed sample batch size for each save
+            -   ``"size"``: a target batch size, in bytes, for each save
+            -   ``"latency"``: a target latency, in seconds, between saves
+    """
+    if batching_strategy is None:
+        if batch_size is None:
+            batching_strategy = fo.config.default_batcher
+        elif isinstance(batch_size, numbers.Integral):
+            batching_strategy = "static"
+        elif isinstance(batch_size, numbers.Number):
+            batching_strategy = "latency"
+        else:
+            raise ValueError(
+                "Unsupported batch size %s; must be an integer or float"
+                % batch_size
+            )
+
+    supported_batching_strategies = ("static", "size", "latency")
+    if batching_strategy not in supported_batching_strategies:
+        raise ValueError(
+            "Unsupported batching strategy '%s'; supported values are %s"
+            % (batching_strategy, supported_batching_strategies)
+        )
+
+    if batch_size is None:
+        if batching_strategy == "static":
+            batch_size = fo.config.batcher_static_size
+        elif batching_strategy == "size":
+            batch_size = fo.config.batcher_target_size_bytes
+        elif batching_strategy == "latency":
+            batch_size = fo.config.batcher_target_latency
+
+    return batch_size, batching_strategy
+
+
 def recommend_batch_size_for_value(value, alpha=0.9, max_size=None):
     """Computes a recommended batch size for the given value type such that a
     request involving a list of values of this size will be less than

--- a/fiftyone/core/utils.py
+++ b/fiftyone/core/utils.py
@@ -1623,6 +1623,11 @@ def parse_batching_strategy(batch_size=None, batching_strategy=None):
             -   ``"static"``: a fixed sample batch size for each save
             -   ``"size"``: a target batch size, in bytes, for each save
             -   ``"latency"``: a target latency, in seconds, between saves
+
+            By default, ``fo.config.default_batcher`` is used
+
+    Returns:
+        a tuple of ``(batch_size, batching_strategy)``
     """
     if batching_strategy is None:
         if batch_size is None:

--- a/fiftyone/core/view.py
+++ b/fiftyone/core/view.py
@@ -431,7 +431,13 @@ class DatasetView(foc.SampleCollection):
         """
         return copy(self)
 
-    def iter_samples(self, progress=False, autosave=False, batch_size=None):
+    def iter_samples(
+        self,
+        progress=False,
+        autosave=False,
+        batch_size=None,
+        batching_strategy=None,
+    ):
         """Returns an iterator over the samples in the view.
 
         Examples::
@@ -453,6 +459,10 @@ class DatasetView(foc.SampleCollection):
                 sample.ground_truth.label = make_label()
                 sample.save()
 
+            # Save using default batching strategy
+            for sample in view.iter_samples(progress=True, autosave=True):
+                sample.ground_truth.label = make_label()
+
             # Save in batches of 10
             for sample in view.iter_samples(
                 progress=True, autosave=True, batch_size=10
@@ -471,9 +481,21 @@ class DatasetView(foc.SampleCollection):
                 (None), or a progress callback function to invoke instead
             autosave (False): whether to automatically save changes to samples
                 emitted by this iterator
-            batch_size (None): a batch size to use when autosaving samples. Can
-                either be an integer specifying the number of samples to save
-                in a batch, or a float number of seconds between batched saves
+            batch_size (None): the batch size to use when autosaving samples.
+                If a ``batching_strategy`` is provided, this parameter
+                configures the strategy as described below. If no
+                ``batching_strategy`` is provided, this can either be an
+                integer specifying the number of samples to save in a batch
+                (in which case ``batching_strategy`` is implicitly set to
+                ``"static"``) or a float number of seconds between batched
+                saves (in which case ``batching_strategy`` is implicitly set to
+                ``"latency"``)
+            batching_strategy (None): the batching strategy to use for each
+                save operation when autosaving samples. Supported values are:
+
+                -   ``"static"``: a fixed sample batch size for each save
+                -   ``"size"``: a target batch size, in bytes, for each save
+                -   ``"latency"``: a target latency, in seconds, between saves
 
         Returns:
             an iterator over :class:`fiftyone.core.sample.SampleView` instances
@@ -486,7 +508,11 @@ class DatasetView(foc.SampleCollection):
             samples = pb(samples)
 
             if autosave:
-                save_context = foc.SaveContext(self, batch_size=batch_size)
+                save_context = foc.SaveContext(
+                    self,
+                    batch_size=batch_size,
+                    batching_strategy=batching_strategy,
+                )
                 exit_context.enter_context(save_context)
 
             for sample in samples:
@@ -543,6 +569,7 @@ class DatasetView(foc.SampleCollection):
         progress=False,
         autosave=False,
         batch_size=None,
+        batching_strategy=None,
     ):
         """Returns an iterator over the groups in the view.
 
@@ -566,6 +593,11 @@ class DatasetView(foc.SampleCollection):
                     sample["test"] = make_label()
                     sample.save()
 
+            # Save using default batching strategy
+            for group in view.iter_groups(progress=True, autosave=True):
+                for sample in group.values():
+                    sample["test"] = make_label()
+
             # Save in batches of 10
             for group in view.iter_groups(
                 progress=True, autosave=True, batch_size=10
@@ -587,9 +619,21 @@ class DatasetView(foc.SampleCollection):
                 (None), or a progress callback function to invoke instead
             autosave (False): whether to automatically save changes to samples
                 emitted by this iterator
-            batch_size (None): a batch size to use when autosaving samples. Can
-                either be an integer specifying the number of samples to save
-                in a batch, or a float number of seconds between batched saves
+            batch_size (None): the batch size to use when autosaving samples.
+                If a ``batching_strategy`` is provided, this parameter
+                configures the strategy as described below. If no
+                ``batching_strategy`` is provided, this can either be an
+                integer specifying the number of samples to save in a batch
+                (in which case ``batching_strategy`` is implicitly set to
+                ``"static"``) or a float number of seconds between batched
+                saves (in which case ``batching_strategy`` is implicitly set to
+                ``"latency"``)
+            batching_strategy (None): the batching strategy to use for each
+                save operation when autosaving samples. Supported values are:
+
+                -   ``"static"``: a fixed sample batch size for each save
+                -   ``"size"``: a target batch size, in bytes, for each save
+                -   ``"latency"``: a target latency, in seconds, between saves
 
         Returns:
             an iterator that emits dicts mapping slice names to
@@ -611,7 +655,11 @@ class DatasetView(foc.SampleCollection):
             groups = pb(groups)
 
             if autosave:
-                save_context = foc.SaveContext(self, batch_size=batch_size)
+                save_context = foc.SaveContext(
+                    self,
+                    batch_size=batch_size,
+                    batching_strategy=batching_strategy,
+                )
                 exit_context.enter_context(save_context)
 
             for group in groups:

--- a/fiftyone/core/view.py
+++ b/fiftyone/core/view.py
@@ -497,6 +497,8 @@ class DatasetView(foc.SampleCollection):
                 -   ``"size"``: a target batch size, in bytes, for each save
                 -   ``"latency"``: a target latency, in seconds, between saves
 
+                By default, ``fo.config.default_batcher`` is used
+
         Returns:
             an iterator over :class:`fiftyone.core.sample.SampleView` instances
         """
@@ -634,6 +636,8 @@ class DatasetView(foc.SampleCollection):
                 -   ``"static"``: a fixed sample batch size for each save
                 -   ``"size"``: a target batch size, in bytes, for each save
                 -   ``"latency"``: a target latency, in seconds, between saves
+
+                By default, ``fo.config.default_batcher`` is used
 
         Returns:
             an iterator that emits dicts mapping slice names to

--- a/fiftyone/utils/annotations.py
+++ b/fiftyone/utils/annotations.py
@@ -1310,7 +1310,7 @@ def _merge_scalars(
     num_deletions = 0
 
     logger.info("Loading scalars for field '%s'...", label_field)
-    for sample in view.iter_samples(progress=progress):
+    for sample in view.iter_samples(progress=progress, autosave=True):
         sample_annos = anno_dict.get(sample.id, None)
 
         if is_frame_field:
@@ -1346,8 +1346,6 @@ def _merge_scalars(
                 else:
                     # Edit value
                     image[field] = new_value
-
-        sample.save()
 
     if num_additions > 0 and not allow_additions:
         logger.warning(
@@ -1493,7 +1491,7 @@ def _merge_labels(
     # Add/merge labels from the annotation task
     sample_ids = list(anno_dict.keys())
     view = view.select(sample_ids).select_fields(label_field)
-    for sample in view.iter_samples(progress=progress):
+    for sample in view.iter_samples(progress=progress, autosave=True):
         sample_id = sample.id
         sample_annos = anno_dict[sample_id]
 
@@ -1578,8 +1576,6 @@ def _merge_labels(
                             added_id_map[sample_id][frame_id].append(label_id)
                         else:
                             added_id_map[sample_id].append(label_id)
-
-        sample.save()
 
     if new_ids and not allow_additions:
         logger.warning(

--- a/fiftyone/utils/data/exporters.py
+++ b/fiftyone/utils/data/exporters.py
@@ -285,7 +285,9 @@ def export_samples(
             dataset_exporter.export_media = "move"
 
         sample_parser = FiftyOneUnlabeledVideoSampleParser(
-            compute_metadata=True, export_media=_export_media, **clips_kwargs
+            compute_metadata=True,
+            write_clips=_export_media,
+            **clips_kwargs,
         )
 
     elif isinstance(dataset_exporter, UnlabeledMediaDatasetExporter):
@@ -350,7 +352,7 @@ def export_samples(
             label_fcn=label_fcn,
             frame_labels_fcn=frame_labels_fcn,
             compute_metadata=True,
-            export_media=_export_media,
+            write_clips=_export_media,
             **clips_kwargs,
         )
 

--- a/fiftyone/utils/data/parsers.py
+++ b/fiftyone/utils/data/parsers.py
@@ -1678,8 +1678,8 @@ class ExtractClipsMixin(object):
         compute_metadata (False): whether to compute
             :class:`fiftyone.core.metadata.VideoMetadata` instances on-the-fly
             when no pre-computed metadata is available
-        export_media (True): whether to actually write clips when their paths
-            are requested
+        write_clips (True): whether to write clips when their paths are
+            requested
         clip_dir (None): a directory to write clips. Only applicable when
             parsing :class:`fiftyone.core.clips.ClipView` instances
         video_format (None): the video format to use when writing video clips
@@ -1689,7 +1689,7 @@ class ExtractClipsMixin(object):
     def __init__(
         self,
         compute_metadata=False,
-        export_media=True,
+        write_clips=True,
         clip_dir=None,
         video_format=None,
     ):
@@ -1697,7 +1697,7 @@ class ExtractClipsMixin(object):
             video_format = fo.config.default_video_ext
 
         self.compute_metadata = compute_metadata
-        self.export_media = export_media
+        self.write_clips = write_clips
         self.clip_dir = clip_dir
         self.video_format = video_format
 
@@ -1707,7 +1707,7 @@ class ExtractClipsMixin(object):
         video_path = sample.filepath
         basename, ext = os.path.splitext(os.path.basename(video_path))
 
-        if self.export_media:
+        if self.write_clips:
             if self.clip_dir is None:
                 self.clip_dir = etau.make_temp_dir()
 
@@ -1724,7 +1724,7 @@ class ExtractClipsMixin(object):
         )
         clip_path = os.path.join(dirname, clip_name)
 
-        if self.export_media:
+        if self.write_clips:
             self._curr_clip_path = clip_path
             fouv.extract_clip(
                 video_path,
@@ -1757,7 +1757,7 @@ class FiftyOneUnlabeledVideoSampleParser(
             :class:`fiftyone.core.metadata.VideoMetadata` instances on-the-fly
             if :meth:`get_video_metadata` is called and no metadata is
             available
-        export_media (True): whether to write clips when :meth:`get_video_path`
+        write_clips (True): whether to write clips when :meth:`get_video_path`
             is called
         clip_dir (None): a directory to write clips. Only applicable when
             parsing :class:`fiftyone.core.clips.ClipView` instances
@@ -1768,14 +1768,14 @@ class FiftyOneUnlabeledVideoSampleParser(
     def __init__(
         self,
         compute_metadata=False,
-        export_media=True,
+        write_clips=True,
         clip_dir=None,
         video_format=None,
     ):
         ExtractClipsMixin.__init__(
             self,
             compute_metadata=compute_metadata,
-            export_media=export_media,
+            write_clips=write_clips,
             clip_dir=clip_dir,
             video_format=video_format,
         )
@@ -1830,7 +1830,7 @@ class FiftyOneLabeledVideoSampleParser(
             :class:`fiftyone.core.metadata.VideoMetadata` instances on-the-fly
             if :meth:`get_video_metadata` is called and no metadata is
             available
-        export_media (True): whether to write clips when :meth:`get_video_path`
+        write_clips (True): whether to write clips when :meth:`get_video_path`
             is called
         clip_dir (None): a directory to write clips. Only applicable when
             parsing :class:`fiftyone.core.clips.ClipView` instances
@@ -1845,7 +1845,7 @@ class FiftyOneLabeledVideoSampleParser(
         label_fcn=None,
         frame_labels_fcn=None,
         compute_metadata=False,
-        export_media=True,
+        write_clips=True,
         clip_dir=None,
         video_format=None,
     ):
@@ -1856,7 +1856,7 @@ class FiftyOneLabeledVideoSampleParser(
         ExtractClipsMixin.__init__(
             self,
             compute_metadata=compute_metadata,
-            export_media=export_media,
+            write_clips=write_clips,
             clip_dir=clip_dir,
             video_format=video_format,
         )

--- a/fiftyone/utils/eval/detection.py
+++ b/fiftyone/utils/eval/detection.py
@@ -174,8 +174,9 @@ def evaluate_detections(
     eval_method.register_samples(samples, eval_key, dynamic=dynamic)
 
     processing_frames = samples._is_frame_field(pred_field)
+    save = eval_key is not None
 
-    if eval_key is not None:
+    if save:
         tp_field = "%s_tp" % eval_key
         fp_field = "%s_fp" % eval_key
         fn_field = "%s_fn" % eval_key
@@ -187,7 +188,7 @@ def evaluate_detections(
 
     matches = []
     logger.info("Evaluating detections...")
-    for sample in _samples.iter_samples(progress=progress):
+    for sample in _samples.iter_samples(progress=progress, autosave=save):
         if processing_frames:
             docs = sample.frames.values()
         else:
@@ -204,16 +205,15 @@ def evaluate_detections(
             sample_fp += fp
             sample_fn += fn
 
-            if processing_frames and eval_key is not None:
+            if processing_frames and save:
                 doc[tp_field] = tp
                 doc[fp_field] = fp
                 doc[fn_field] = fn
 
-        if eval_key is not None:
+        if save:
             sample[tp_field] = sample_tp
             sample[fp_field] = sample_fp
             sample[fn_field] = sample_fn
-            sample.save()
 
     results = eval_method.generate_results(
         samples,

--- a/fiftyone/utils/eval/segmentation.py
+++ b/fiftyone/utils/eval/segmentation.py
@@ -353,8 +353,9 @@ class SimpleEvaluation(SegmentationEvaluation):
         bandwidth = self.config.bandwidth
         average = self.config.average
         compute_dice = self.config.compute_dice
+        save = eval_key is not None
 
-        if eval_key is not None:
+        if save:
             acc_field = "%s_accuracy" % eval_key
             pre_field = "%s_precision" % eval_key
             rec_field = "%s_recall" % eval_key
@@ -362,7 +363,7 @@ class SimpleEvaluation(SegmentationEvaluation):
                 dice_field = "%s_dice" % eval_key
 
         logger.info("Evaluating segmentations...")
-        for sample in _samples.iter_samples(progress=progress):
+        for sample in _samples.iter_samples(progress=progress, autosave=save):
             if processing_frames:
                 images = sample.frames.values()
             else:
@@ -390,8 +391,7 @@ class SimpleEvaluation(SegmentationEvaluation):
                 )
                 sample_conf_mat += image_conf_mat
 
-                # Record frame stats, if requested
-                if processing_frames and eval_key is not None:
+                if processing_frames and save:
                     facc, fpre, frec = _compute_accuracy_precision_recall(
                         image_conf_mat, values, average
                     )
@@ -403,8 +403,7 @@ class SimpleEvaluation(SegmentationEvaluation):
 
             confusion_matrix += sample_conf_mat
 
-            # Record sample stats, if requested
-            if eval_key is not None:
+            if save:
                 sacc, spre, srec = _compute_accuracy_precision_recall(
                     sample_conf_mat, values, average
                 )
@@ -413,8 +412,6 @@ class SimpleEvaluation(SegmentationEvaluation):
                 sample[rec_field] = srec
                 if compute_dice:
                     sample[dice_field] = _compute_dice_score(confusion_matrix)
-
-                sample.save()
 
         if nc > 0:
             missing = classes[0] if values[0] in (0, "#000000") else None

--- a/fiftyone/utils/geojson.py
+++ b/fiftyone/utils/geojson.py
@@ -142,15 +142,20 @@ def load_location_data(
         logger.info("No matching location data found")
         return
 
-    logger.info("Loading location data for %d samples...", len(found_keys))
-    _samples = samples.select_fields(location_field)
-    with fou.ProgressBar(progress=progress) as pb:
-        for key in pb(found_keys):
-            sample_id = lookup[key]
-            geometry = geometries[key]
-            sample = _samples[sample_id]
-            sample[location_field] = location_cls.from_geo_json(geometry)
-            sample.save()
+    locations = {}
+
+    try:
+        logger.info("Loading location data...")
+        with fou.ProgressBar(progress=progress) as pb:
+            for key in pb(found_keys):
+                sample_id = lookup[key]
+                geometry = geometries[key]
+                locations[sample_id] = location_cls.from_geo_json(geometry)
+    finally:
+        logger.info("Saving location data...")
+        samples.set_values(
+            location_field, locations, key_field="id", progress=progress
+        )
 
 
 def to_geo_json_geometry(label):

--- a/fiftyone/utils/image.py
+++ b/fiftyone/utils/image.py
@@ -347,11 +347,11 @@ def _transform_images_single(
         output_field = media_field
 
     diff_field = output_field != media_field
+    save = update_filepaths
 
     view = sample_collection.select_fields(media_field)
-
-    with fou.ProgressBar(progress=progress) as pb:
-        for sample in pb(view):
+    with fou.ProgressBar(total=view, progress=progress) as pb:
+        for sample in pb(view.iter_samples(autosave=save)):
             inpath = sample[media_field]
 
             outpath = _get_outpath(
@@ -375,7 +375,6 @@ def _transform_images_single(
 
             if update_filepaths and (diff_field or outpath != inpath):
                 sample[output_field] = outpath
-                sample.save()
 
 
 def _transform_images_multi(

--- a/fiftyone/utils/iou.py
+++ b/fiftyone/utils/iou.py
@@ -539,7 +539,6 @@ def _compute_polygon_ious(
         # We're ignoring errors, so suppress shapely logging that occurs when
         # invalid geometries are encountered
         if error_level > 1:
-            # pylint: disable=no-member
             context.enter_context(
                 fou.LoggingLevel(logging.CRITICAL, logger="shapely")
             )
@@ -629,7 +628,6 @@ def _compute_mask_ious(
         # We're ignoring errors, so suppress shapely logging that occurs when
         # invalid geometries are encountered
         if error_level > 1:
-            # pylint: disable=no-member
             context.enter_context(
                 fou.LoggingLevel(logging.CRITICAL, logger="shapely")
             )

--- a/fiftyone/utils/labelstudio.py
+++ b/fiftyone/utils/labelstudio.py
@@ -237,8 +237,6 @@ class LabelStudioAnnotationAPI(foua.AnnotationAPI):
 
     def _prepare_tasks(self, samples, label_schema, media_field):
         """Prepares Label Studio tasks for the given data."""
-        samples.compute_metadata()
-
         ids, mime_types, filepaths = samples.values(
             ["id", "metadata.mime_type", media_field]
         )
@@ -450,6 +448,9 @@ class LabelStudioAnnotationAPI(foua.AnnotationAPI):
 
         project = self._init_project(config, samples)
 
+        samples.compute_metadata()
+
+        # @todo can we add support for uploading tasks in batches?
         tasks, predictions, id_map = self._prepare_tasks(
             samples,
             config.label_schema,

--- a/fiftyone/utils/patches.py
+++ b/fiftyone/utils/patches.py
@@ -52,6 +52,8 @@ class ImagePatchesExtractor(object):
         force_square=False,
         alpha=None,
     ):
+        fov.validate_image_collection(samples)
+
         if patches_field is None:
             if samples._is_patches:
                 patches_field = samples._label_fields[0]
@@ -79,7 +81,6 @@ class ImagePatchesExtractor(object):
             )
 
             if patches is not None:
-                fov.validate_image_sample(sample)
                 img = _load_image(sample.filepath, force_rgb=self.force_rgb)
                 for detection in patches.detections:
                     patch = extract_patch(

--- a/fiftyone/utils/scale.py
+++ b/fiftyone/utils/scale.py
@@ -432,7 +432,6 @@ def export_to_scale(
                 "when exporting labels for video datasets"
             )
 
-    # Compute metadata if necessary
     sample_collection.compute_metadata()
 
     # Export the labels

--- a/fiftyone/utils/scale.py
+++ b/fiftyone/utils/scale.py
@@ -20,6 +20,7 @@ import eta.core.serial as etas
 import eta.core.utils as etau
 import eta.core.web as etaw
 
+import fiftyone.core.collections as foc
 import fiftyone.core.labels as fol
 import fiftyone.core.media as fomm
 import fiftyone.core.metadata as fom
@@ -207,7 +208,9 @@ def import_from_scale(
     else:
         label_key = lambda k: k
 
-    with fou.ProgressBar(total=len(labels), progress=progress) as pb:
+    pb = fou.ProgressBar(total=len(labels), progress=progress)
+    ctx = foc.SaveContext(dataset)
+    with pb, ctx:
         for task_id, task_labels in pb(labels.items()):
             if task_id not in id_map:
                 logger.info(
@@ -246,7 +249,7 @@ def import_from_scale(
                     {label_key(k): v for k, v in labels_dict.items()}
                 )
 
-            sample.save()
+            ctx.save(sample)
 
 
 # @todo add support for `duration_time`, `frame_rate`, and `start_time`

--- a/fiftyone/utils/utils3d.py
+++ b/fiftyone/utils/utils3d.py
@@ -521,16 +521,13 @@ def compute_orthographic_projection_images(
         fov.validate_collection(samples, media_type=fom.GROUP)
         group_field = samples.group_field
 
-        point_cloud_view = samples.select_group_slices(in_group_slice)
-        fov.validate_collection(point_cloud_view, media_type=fom.POINT_CLOUD)
-
-        filepaths, groups = point_cloud_view.values(["filepath", group_field])
+        view = samples.select_group_slices(in_group_slice).select_fields(
+            group_field
+        )
     else:
-        fov.validate_collection(samples, media_type=fom.POINT_CLOUD)
-        point_cloud_view = samples
+        view = samples.select_fields()
 
-        filepaths = point_cloud_view.values("filepath")
-        groups = itertools.repeat(None)
+    fov.validate_collection(view, media_type=fom.POINT_CLOUD)
 
     filename_maker = fou.UniqueFilenameMaker(
         output_dir=output_dir, rel_dir=rel_dir
@@ -539,39 +536,34 @@ def compute_orthographic_projection_images(
     if out_group_slice is not None:
         out_samples = []
 
-    all_metadata = []
+    for sample in view.iter_samples(autosave=True, progress=progress):
+        image_path = filename_maker.get_output_path(
+            sample.filepath, output_ext=".png"
+        )
 
-    with fou.ProgressBar(total=len(filepaths), progress=progress) as pb:
-        for filepath, group in pb(zip(filepaths, groups)):
-            image_path = filename_maker.get_output_path(
-                filepath, output_ext=".png"
-            )
+        img, metadata = compute_orthographic_projection_image(
+            sample.filepath,
+            size,
+            shading_mode=shading_mode,
+            colormap=colormap,
+            subsampling_rate=subsampling_rate,
+            projection_normal=projection_normal,
+            bounds=bounds,
+        )
 
-            img, metadata = compute_orthographic_projection_image(
-                filepath,
-                size,
-                shading_mode=shading_mode,
-                colormap=colormap,
-                subsampling_rate=subsampling_rate,
-                projection_normal=projection_normal,
-                bounds=bounds,
-            )
+        foui.write(img, image_path)
+        metadata.filepath = image_path
 
-            foui.write(img, image_path)
-            metadata.filepath = image_path
+        sample[metadata_field] = metadata
 
-            if out_group_slice is not None:
-                sample = Sample(filepath=image_path)
-                sample[group_field] = group.element(out_group_slice)
-                sample[metadata_field] = metadata
-                out_samples.append(sample)
-
-            all_metadata.append(metadata)
+        if out_group_slice is not None:
+            s = Sample(filepath=image_path)
+            s[group_field] = sample[group_field].element(out_group_slice)
+            s[metadata_field] = metadata
+            out_samples.append(s)
 
     if out_group_slice is not None:
-        samples.add_samples(out_samples)
-
-    point_cloud_view.set_values(metadata_field, all_metadata)
+        samples._root_dataset.add_samples(out_samples)
 
 
 def compute_orthographic_projection_image(

--- a/fiftyone/utils/utils3d.py
+++ b/fiftyone/utils/utils3d.py
@@ -554,11 +554,14 @@ def compute_orthographic_projection_images(
                 projection_normal=projection_normal,
                 bounds=bounds,
             )
-        except:
-            if skip_failures:
-                continue
+        except Exception as e:
+            if not skip_failures:
+                raise
 
-            raise
+            if skip_failures != "ignore":
+                logger.warning(e)
+
+            continue
 
         foui.write(img, image_path)
         metadata.filepath = image_path

--- a/fiftyone/utils/utils3d.py
+++ b/fiftyone/utils/utils3d.py
@@ -446,6 +446,7 @@ def compute_orthographic_projection_images(
     subsampling_rate=None,
     projection_normal=None,
     bounds=None,
+    skip_failures=False,
     progress=None,
 ):
     """Computes orthographic projection images for the point clouds in the
@@ -510,6 +511,8 @@ def compute_orthographic_projection_images(
             to generate each map. Either element of the tuple or any/all of its
             values can be None, in which case a tight crop of the point cloud
             along the missing dimension(s) are used
+        skip_failures (False): whether to gracefully continue without raising
+            an error if a projection fails
         progress (None): whether to render a progress bar (True/False), use the
             default value ``fiftyone.config.show_progress_bars`` (None), or a
             progress callback function to invoke instead
@@ -541,15 +544,21 @@ def compute_orthographic_projection_images(
             sample.filepath, output_ext=".png"
         )
 
-        img, metadata = compute_orthographic_projection_image(
-            sample.filepath,
-            size,
-            shading_mode=shading_mode,
-            colormap=colormap,
-            subsampling_rate=subsampling_rate,
-            projection_normal=projection_normal,
-            bounds=bounds,
-        )
+        try:
+            img, metadata = compute_orthographic_projection_image(
+                sample.filepath,
+                size,
+                shading_mode=shading_mode,
+                colormap=colormap,
+                subsampling_rate=subsampling_rate,
+                projection_normal=projection_normal,
+                bounds=bounds,
+            )
+        except:
+            if skip_failures:
+                continue
+
+            raise
 
         foui.write(img, image_path)
         metadata.filepath = image_path

--- a/fiftyone/utils/video.py
+++ b/fiftyone/utils/video.py
@@ -747,6 +747,7 @@ def _transform_videos(
         output_field = media_field
 
     diff_field = output_field != media_field
+    save = (save_filepaths and sample_frames) or update_filepaths
 
     if sample_frames:
         reencode = True
@@ -761,7 +762,9 @@ def _transform_videos(
         frames = itertools.repeat(None)
 
     with fou.ProgressBar(total=view, progress=progress) as pb:
-        for sample, _frames in pb(zip(view, frames)):
+        for sample, _frames in pb(
+            zip(view.iter_samples(autosave=save), frames)
+        ):
             inpath = sample[media_field]
 
             _outpath = _get_outpath(
@@ -827,15 +830,12 @@ def _transform_videos(
                     if os.path.isfile(frame_path):
                         sample.frames[fn][output_field] = frame_path
 
-                sample.save()
-
             if (
                 update_filepaths
                 and not sample_frames
                 and (diff_field or outpath != inpath)
             ):
                 sample[output_field] = outpath
-                sample.save()
 
 
 def _transform_video(

--- a/tests/unittests/model_tests.py
+++ b/tests/unittests/model_tests.py
@@ -1,0 +1,293 @@
+"""
+FiftyOne model inference unit tests.
+
+| Copyright 2017-2024, Voxel51, Inc.
+| `voxel51.com <https://voxel51.com/>`_
+|
+"""
+import os
+import random
+import string
+import unittest
+
+import numpy as np
+
+import eta.core.utils as etau
+import eta.core.video as etav
+
+import fiftyone as fo
+import fiftyone.utils.image as foui
+
+from decorators import drop_datasets
+
+
+class MockImageModel(fo.EmbeddingsMixin, fo.Model):
+    @property
+    def media_type(self):
+        return "image"
+
+    @property
+    def has_embeddings(self):
+        return True
+
+    @property
+    def ragged_batches(self):
+        return True  # no batching
+
+    @property
+    def transforms(self):
+        return None
+
+    @property
+    def preprocess(self):
+        return False
+
+    @preprocess.setter
+    def preprocess(self, value):
+        pass
+
+    def predict(self, arg):
+        return fo.Classification(label="foo")
+
+    def get_embeddings(self):
+        return np.random.randn(128)
+
+
+class MockBatchImageModel(MockImageModel):
+    @property
+    def ragged_batches(self):
+        return False  # allow batching
+
+
+class ImageDatasetTests(unittest.TestCase):
+    def setUp(self):
+        temp_dir = etau.TempDir()
+        root_dir = temp_dir.__enter__()
+        ref_image_path = os.path.join(root_dir, "_ref_image.jpg")
+        images_dir = os.path.join(root_dir, "_images")
+
+        img = np.random.randint(255, size=(480, 640, 3), dtype=np.uint8)
+        foui.write(img, ref_image_path)
+
+        self.root_dir = root_dir
+        self.images_dir = images_dir
+
+        self._temp_dir = temp_dir
+        self._ref_image_path = ref_image_path
+
+    def tearDown(self):
+        self._temp_dir.__exit__()
+
+    def _new_image(self, name=None):
+        if name is None:
+            name = self._new_name()
+
+        filepath = os.path.join(
+            self.images_dir,
+            name + os.path.splitext(self._ref_image_path)[1],
+        )
+
+        etau.copy_file(self._ref_image_path, filepath)
+        return filepath
+
+    def _new_name(self):
+        return "".join(
+            random.choice(string.ascii_lowercase + string.digits)
+            for _ in range(24)
+        )
+
+    def _new_dir(self):
+        return os.path.join(self.root_dir, self._new_name())
+
+
+class ImageModelTests(ImageDatasetTests):
+    def _make_dataset(self):
+        samples = []
+        for _ in range(5):
+            sample = fo.Sample(
+                filepath=self._new_image(),
+                patches=fo.Detections(
+                    detections=[
+                        fo.Detection(bounding_box=[0.1, 0.1, 0.4, 0.2]),
+                        fo.Detection(bounding_box=[0.3, 0.3, 0.2, 0.4]),
+                        fo.Detection(bounding_box=[0.5, 0.5, 0.5, 0.5]),
+                    ],
+                ),
+            )
+            samples.append(sample)
+
+        dataset = fo.Dataset()
+        dataset.add_samples(samples)
+
+        return dataset
+
+    def _test_model(self, model, batch_size=None):
+        dataset = self._make_dataset()
+
+        # Model inference
+
+        dataset.apply_model(
+            model, label_field="predictions", batch_size=batch_size
+        )
+        self.assertEqual(len(dataset.exists("predictions")), 5)
+
+        # Embeddings
+
+        embeddings = dataset.compute_embeddings(model, batch_size=batch_size)
+        self.assertEqual(embeddings.shape, (5, 128))
+
+        dataset.compute_embeddings(
+            model, embeddings_field="embeddings", batch_size=batch_size
+        )
+        self.assertEqual(len(dataset.exists("embeddings")), 5)
+
+        # Patch embeddings
+
+        embeddings = dataset.compute_patch_embeddings(
+            model, "patches", batch_size=batch_size
+        )
+        self.assertEqual(len(embeddings), 5)
+        for e in embeddings.values():
+            self.assertEqual(e.shape, (3, 128))
+
+        dataset.compute_patch_embeddings(
+            model,
+            "patches",
+            embeddings_field="embeddings",
+            batch_size=batch_size,
+        )
+        self.assertEqual(dataset.count("patches.detections.embeddings"), 15)
+
+    @drop_datasets
+    def test_image_model(self):
+        model = MockImageModel()
+        self._test_model(model)
+
+    @drop_datasets
+    def test_image_model_batch(self):
+        model = MockBatchImageModel()
+        self._test_model(model, batch_size=2)
+
+
+class VideoDatasetTests(unittest.TestCase):
+    def setUp(self):
+        temp_dir = etau.TempDir()
+        root_dir = temp_dir.__enter__()
+        ref_video_path = os.path.join(root_dir, "_ref_video.mp4")
+        videos_dir = os.path.join(root_dir, "_videos")
+
+        with etav.FFmpegVideoWriter(ref_video_path, 5, (640, 480)) as writer:
+            for _ in range(5):
+                img = np.random.randint(
+                    255, size=(480, 640, 3), dtype=np.uint8
+                )
+                writer.write(img)
+
+        self.root_dir = root_dir
+        self.videos_dir = videos_dir
+
+        self._temp_dir = temp_dir
+        self._ref_video_path = ref_video_path
+
+    def tearDown(self):
+        self._temp_dir.__exit__()
+
+    def _new_video(self, filename=None):
+        if filename is None:
+            filename = self._new_name()
+        filepath = os.path.join(
+            self.videos_dir,
+            filename + os.path.splitext(self._ref_video_path)[1],
+        )
+
+        etau.copy_file(self._ref_video_path, filepath)
+        return filepath
+
+    def _new_name(self):
+        return "".join(
+            random.choice(string.ascii_lowercase + string.digits)
+            for _ in range(24)
+        )
+
+    def _new_dir(self):
+        return os.path.join(self.root_dir, self._new_name())
+
+
+class VideoModelTests(VideoDatasetTests):
+    def _make_dataset(self):
+        samples = []
+        for i in range(5):
+            sample = fo.Sample(filepath=self._new_video())
+            sample.frames[i + 1] = fo.Frame(
+                patches=fo.Detections(
+                    detections=[
+                        fo.Detection(bounding_box=[0.1, 0.1, 0.4, 0.2]),
+                        fo.Detection(bounding_box=[0.3, 0.3, 0.2, 0.4]),
+                        fo.Detection(bounding_box=[0.5, 0.5, 0.5, 0.5]),
+                    ],
+                ),
+            )
+            samples.append(sample)
+
+        dataset = fo.Dataset()
+        dataset.add_samples(samples)
+
+        dataset.compute_metadata()
+
+        return dataset
+
+    def _test_model(self, model, batch_size=None):
+        dataset = self._make_dataset()
+
+        # Model inference
+
+        dataset.apply_model(
+            model, label_field="predictions", batch_size=batch_size
+        )
+        self.assertEqual(dataset.count("frames.predictions"), 25)
+
+        # Embeddings
+
+        embeddings = dataset.compute_embeddings(model, batch_size=batch_size)
+        self.assertEqual(len(embeddings), 5)
+        for e in embeddings.values():
+            self.assertEqual(e.shape, (5, 128))
+
+        dataset.compute_embeddings(
+            model, embeddings_field="embeddings", batch_size=batch_size
+        )
+        self.assertEqual(dataset.count("frames.embeddings"), 25)
+
+        # Patch embeddings
+
+        embeddings = dataset.compute_patch_embeddings(
+            model, "patches", batch_size=batch_size
+        )
+        self.assertEqual(len(embeddings), 5)
+        for sample_embeddings in embeddings.values():
+            self.assertEqual(len(sample_embeddings), 5)
+            for e in sample_embeddings.values():
+                # only one frame per video has patches
+                if e is not None:
+                    self.assertEqual(e.shape, (3, 128))
+
+        dataset.compute_patch_embeddings(
+            model,
+            "patches",
+            embeddings_field="embeddings",
+            batch_size=batch_size,
+        )
+        self.assertEqual(
+            dataset.count("frames.patches.detections.embeddings"),
+            15,  # only one frame per video has patches
+        )
+
+    @drop_datasets
+    def test_image_model_frames(self):
+        model = MockImageModel()
+        self._test_model(model)
+
+    @drop_datasets
+    def test_image_model_frames_batch(self):
+        model = MockBatchImageModel()
+        self._test_model(model, batch_size=2)


### PR DESCRIPTION
## Change log

- Autosave contexts now respect the default batching strategy and can be configured to use content size-based batching
- All SDK methods now use `autosave=True` or its equivalent rather than calling `sample.save()` in a loop
- Renames `export_media` parameter to `write_clips` in video sample parsers, for clarity
- Centralizes the application of `select_fields()` in `compute_embeddings()` and `compute_patch_embeddings()`, for consistency with how this is handled in the `apply_model()` utility.
- Adds support for sample collections to `fou.iter_slices()`
- Adds a `SampleCollection._resolve_media_field()` utility
- Adds a `fos.read_files()` method to efficiently read from multiple files in a threadpool
- Adds a warning when uploading large amounts of data to CVAT
- Removes unneeded `pylint: disable=no-member`
