### PR TITLE
include extended stages in param when tagging

### DIFF
--- a/app/packages/core/src/components/Actions/Tagger.tsx
+++ b/app/packages/core/src/components/Actions/Tagger.tsx
@@ -368,6 +368,9 @@ const useTagCallback = (
             selectedSamples: await snapshot.getPromise(fos.selectedSamples),
             targetLabels,
             view: await snapshot.getPromise(fos.view),
+            extended: !modal
+              ? await snapshot.getPromise(fos.extendedStages)
+              : null,
           }),
           current_frame: lookerRef?.current?.frameNumber,
           changes,
@@ -418,7 +421,9 @@ const useLabelPlaceHolder = (
   return (): [number, string] => {
     const selectedSamples = useRecoilValue(fos.selectedSamples).size;
     const selectedLabels = useRecoilValue(fos.selectedLabelIds).size;
-    const selectedLabelCount = useRecoilValue(numItemsInSelection(true));
+    const selectedLabelCount = useRecoilValue(
+      numItemsInSelection({ labels: true, modal })
+    );
     const totalLabelCount = useRecoilValue(
       fos.labelCount({ modal, extended: true })
     );

--- a/app/packages/core/src/components/Actions/utils.tsx
+++ b/app/packages/core/src/components/Actions/utils.tsx
@@ -92,17 +92,21 @@ export const tagStatistics = selectorFamily<
           selectedLabels: get(fos.selectedLabels),
           targetLabels: countLabels,
           view: get(fos.view),
+          extended: !modal ? get(fos.extendedStages) : null,
         })
       );
     },
 });
 
-export const numItemsInSelection = selectorFamily<number, boolean>({
+export const numItemsInSelection = selectorFamily<
+  number,
+  { modal: boolean; labels: boolean }
+>({
   key: "numLabelsInSelectedSamples",
   get:
-    (labels) =>
+    ({ modal = false, labels }) =>
     ({ get }) => {
-      return get(tagStatistics({ modal: false, labels })).count;
+      return get(tagStatistics({ modal, labels })).count;
     },
 });
 

--- a/e2e-pw/src/oss/poms/modal/video-controls.ts
+++ b/e2e-pw/src/oss/poms/modal/video-controls.ts
@@ -28,7 +28,7 @@ export class ModalVideoControlsPom {
 
   private async togglePlay() {
     // this is to clear popups, if any
-    this.controls.click();
+    await this.controls.click();
     await this.modal.locator.press("Space");
   }
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

Include extended stages in params for tagging and tag requests to ensure tagging is performed on only view filtered by extended stages

## How is this patch tested? If it is not, please explain why.

Using Embedding and Tagging

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

Include extended stages in params for tagging and tag requests to ensure tagging is performed on only view filtered by extended stages

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced tagging capabilities with an extended property for improved user interactions and analytics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->