### PR TITLE
change type to array of object for view param of set_view

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -12,6 +12,7 @@ jobs:
       FIFTYONE_DATABASE_NAME: playwright
       ELECTRON_EXTRA_LAUNCH_ARGS: "--disable-gpu"
       PLAYWRIGHT_BROWSERS_PATH: ${{ github.workspace }}/ms-playwright
+      FIFTYONE_PLUGINS_DIR: ${{ github.workspace }}/e2e-pw/src/shared/assets/plugins
     defaults:
       run:
         shell: bash

--- a/app/packages/core/src/components/ViewBar/ViewBar.tsx
+++ b/app/packages/core/src/components/ViewBar/ViewBar.tsx
@@ -132,6 +132,7 @@ const ViewBar = React.memo(() => {
           state.matches("running.focus.blurred") && send("TOGGLE_FOCUS")
         }
         ref={barRef}
+        data-cy="view-bar"
       >
         {state.matches("running")
           ? stages.map((stage, i) => {

--- a/app/packages/operators/src/OperatorBrowser.tsx
+++ b/app/packages/operators/src/OperatorBrowser.tsx
@@ -144,6 +144,7 @@ export default function OperatorBrowser() {
               autoFocus
               placeholder="Search operations by name..."
               onChange={(e) => browser.onChangeQuery(e.target.value)}
+              data-cy="operators-browser-search"
             />
           </QueryDiv>
           <IconsContainer>
@@ -172,6 +173,7 @@ export default function OperatorBrowser() {
           </IconsContainer>
         </TopBarDiv>
       }
+      dialogProps={{ PaperProps: { "data-cy": "operators-browser" } }}
     >
       <PaletteContentContainer>
         {browser.choices.map((choice) => (

--- a/app/packages/operators/src/OperatorPalette.tsx
+++ b/app/packages/operators/src/OperatorPalette.tsx
@@ -45,6 +45,7 @@ export default function OperatorPalette(props: OperatorPaletteProps) {
     showWarning,
     warningMessage,
     warningTitle,
+    dialogProps,
   } = props;
   const hideActions = !onSubmit && !onCancel;
   const scroll = "paper";
@@ -87,13 +88,17 @@ export default function OperatorPalette(props: OperatorPaletteProps) {
 
   return (
     <Dialog
+      {...dialogProps}
       open
       onClose={onClose || onOutsideClick}
       scroll={scroll}
       maxWidth={false}
       aria-labelledby=""
       aria-describedby="scroll-dialog-description"
-      PaperProps={{ sx: { backgroundImage: "none" } }}
+      PaperProps={{
+        ...(dialogProps?.PaperProps || {}),
+        sx: { backgroundImage: "none" },
+      }}
       sx={{
         "& .MuiDialog-container": {
           alignItems: "flex-start",
@@ -206,4 +211,5 @@ export type OperatorPaletteProps = PropsWithChildren & {
   showWarning?: boolean;
   warningTitle: string;
   warningMessage?: string;
+  dialogProps?: Omit<DialogProps, "open">;
 };

--- a/app/packages/operators/src/built-in-operators.ts
+++ b/app/packages/operators/src/built-in-operators.ts
@@ -470,7 +470,7 @@ class SetView extends Operator {
   }
   async resolveInput(ctx: ExecutionContext): Promise<types.Property> {
     const inputs = new types.Object();
-    inputs.obj("view", { view: new types.HiddenView({}) });
+    inputs.list("view", new types.Object(), { view: new types.HiddenView({}) });
     inputs.str("name", { label: "Name or slug of a saved view" });
     return new types.Property(inputs);
   }

--- a/e2e-pw/src/oss/poms/operators/operators-browser.ts
+++ b/e2e-pw/src/oss/poms/operators/operators-browser.ts
@@ -1,0 +1,39 @@
+import { Locator, Page, expect } from "src/oss/fixtures";
+
+export class OperatorsBrowserPom {
+  readonly page: Page;
+  readonly locator: Locator;
+  readonly assert: OperatorsBrowserAsserter;
+  readonly selectionCount: Locator;
+
+  constructor(page: Page) {
+    this.page = page;
+    this.assert = new OperatorsBrowserAsserter(this);
+
+    this.locator = this.page.getByTestId("operators-browser");
+  }
+
+  get browseOperationsBtn() {
+    return this.page.getByTestId("action-browse-operations");
+  }
+
+  show() {
+    return this.browseOperationsBtn.click();
+  }
+
+  search(term: string) {
+    return this.locator.getByTestId("operators-browser-search").fill(term);
+  }
+
+  choose(operator: string) {
+    return this.locator.getByText(operator).click();
+  }
+}
+
+class OperatorsBrowserAsserter {
+  constructor(private readonly panelPom: OperatorsBrowserPom) {}
+
+  async isOpen() {
+    await expect(this.panelPom.locator).toBeVisible();
+  }
+}

--- a/e2e-pw/src/oss/poms/viewbar/viewbar.ts
+++ b/e2e-pw/src/oss/poms/viewbar/viewbar.ts
@@ -1,0 +1,38 @@
+import { Locator, Page, expect } from "src/oss/fixtures";
+
+export class ViewBarPom {
+  readonly page: Page;
+  readonly locator: Locator;
+  readonly assert: ViewBarAsserter;
+  readonly selectionCount: Locator;
+
+  constructor(page: Page) {
+    this.page = page;
+    this.assert = new ViewBarAsserter(this);
+    this.locator = this.page.getByTestId("view-bar");
+  }
+
+  get clearBtn() {
+    return this.locator.getByTestId("btn-clear-view-bar");
+  }
+
+  get viewStages() {
+    return this.locator.getByTestId("view-stage-container");
+  }
+
+  clear() {
+    return this.clearBtn.click();
+  }
+}
+
+class ViewBarAsserter {
+  constructor(private readonly viewBar: ViewBarPom) {}
+
+  async isVisible() {
+    await expect(this.viewBar.locator).toBeVisible();
+  }
+
+  async hasViewStage(text: string) {
+    await expect(this.viewBar.viewStages).toContainText(text);
+  }
+}

--- a/e2e-pw/src/oss/specs/operators/built-in-operators.spec.ts
+++ b/e2e-pw/src/oss/specs/operators/built-in-operators.spec.ts
@@ -1,0 +1,59 @@
+import { test as base, expect } from "src/oss/fixtures";
+import { OperatorsBrowserPom } from "src/oss/poms/operators/operators-browser";
+import { HistogramPom } from "src/oss/poms/panels/histogram-panel";
+import { ViewBarPom } from "src/oss/poms/viewbar/viewbar";
+import { getUniqueDatasetNameWithPrefix } from "src/oss/utils";
+
+const datasetName = getUniqueDatasetNameWithPrefix(`built-in-operators`);
+const test = base.extend<{
+  operatorsBrowser: OperatorsBrowserPom;
+  viewBar: ViewBarPom;
+  histogramPanel: HistogramPom;
+}>({
+  operatorsBrowser: async ({ page }, use) => {
+    await use(new OperatorsBrowserPom(page));
+  },
+  viewBar: async ({ page }, use) => {
+    await use(new ViewBarPom(page));
+  },
+  histogramPanel: async ({ page, eventUtils }, use) => {
+    await use(new HistogramPom(page, eventUtils));
+  },
+});
+
+test.beforeAll(async ({ fiftyoneLoader }) => {
+  await fiftyoneLoader.executePythonCode(`
+    import fiftyone as fo
+    dataset = fo.Dataset("${datasetName}")
+    dataset.persistent = True
+
+    samples = []
+    for i in range(0, 10):
+        sample = fo.Sample(
+            filepath=f"{i}.png",
+            detections=fo.Detections(detections=[fo.Detection(label=f"label-{i}")]),
+            classification=fo.Classification(label=f"label-{i}"),
+            bool=i % 2 == 0,
+            str=f"{i}",
+            int=i % 2,
+            float=i / 2,
+            list_str=[f"{i}"],
+            list_int=[i % 2],
+            list_float=[i / 2],
+            list_bool=[i % 2 == 0],
+        )
+        samples.append(sample)
+    
+    dataset.add_samples(samples)`);
+});
+
+test.beforeEach(async ({ page, fiftyoneLoader }) => {
+  await fiftyoneLoader.waitUntilGridVisible(page, datasetName);
+});
+
+test("Built-in operators: set view", async ({ viewBar, operatorsBrowser }) => {
+  await operatorsBrowser.show();
+  await operatorsBrowser.search("E2E");
+  await operatorsBrowser.choose("E2E: Set view");
+  await viewBar.assert.hasViewStage("Limit3");
+});

--- a/e2e-pw/src/shared/assets/plugins/e2e/__init__.py
+++ b/e2e-pw/src/shared/assets/plugins/e2e/__init__.py
@@ -1,0 +1,25 @@
+import fiftyone.operators as foo
+import json
+from bson import json_util
+
+
+def serialize_view(view):
+    return json.loads(json_util.dumps(view._serialize()))
+
+
+class E2ESetView(foo.Operator):
+    @property
+    def config(self):
+        return foo.OperatorConfig(
+            name="e2e_set_view",
+            label="E2E: Set view",
+        )
+
+    def execute(self, ctx):
+        view = ctx.dataset.limit(3)
+        ctx.trigger("set_view", {"view": serialize_view(view)})
+        return {}
+
+
+def register(p):
+    p.register(E2ESetView)

--- a/e2e-pw/src/shared/assets/plugins/e2e/fiftyone.yml
+++ b/e2e-pw/src/shared/assets/plugins/e2e/fiftyone.yml
@@ -1,0 +1,7 @@
+fiftyone:
+  version: "~0.21.0"
+name: "@voxel51/e2e"
+version: "1.0.0"
+description: "Operators for E2E tests"
+operators:
+  - e2e_set_view


### PR DESCRIPTION
## What changes are proposed in this pull request?

change type to array of object for view param of set_view

## How is this patch tested? If it is not, please explain why.

Using a test operator

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

change type to array of object for view param of set_view

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced accessibility and testing capabilities by adding `data-cy` attributes to various components in the app.
	- Introduced new classes and methods for interacting with the operators browser and view bar in a web application.
	- Implemented functionality for testing built-in operators, including setting up test scenarios and verifying functionality.
	- Added serialization and setting of views in an E2E context using `fiftyone` operators.

- **Chores**
	- Declared `FIFTYONE_PLUGINS_DIR` in the workflow for plugins directory setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->