### PR TITLE
fix resolve input not debounce

### DIFF
--- a/app/packages/operators/src/state.ts
+++ b/app/packages/operators/src/state.ts
@@ -333,7 +333,7 @@ export const useOperatorPrompt = () => {
       operator.isRemote ? RESOLVE_TYPE_TTL : 0,
       { leading: true }
     ),
-    [cachedResolvedInput, setResolvedCtx, ctx]
+    [cachedResolvedInput, setResolvedCtx]
   );
   const resolveInputFields = useCallback(async () => {
     ctx.hooks = hooks;


### PR DESCRIPTION
## What changes are proposed in this pull request?

Typo in PR https://github.com/voxel51/fiftyone/pull/4152 regressed debounced resolution of operator input causing operator prompt to re-resolve input in every change and potentially degrading performance. Changes in this PR fixes the issue to ensure input schema is not resolved for every change. 

## How is this patch tested? If it is not, please explain why.

Using a dynamic operator.

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

fix the dynamic operator's input schema getting resolved for every change

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved the logic for resolving input fields in certain functions to enhance user experience.
- **Chores**
	- Updated the application version to 0.23.8.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->