### PR TITLE
make ctx.view saved view aware for python operators

### DIFF
--- a/app/packages/operators/src/hooks.ts
+++ b/app/packages/operators/src/hooks.ts
@@ -28,6 +28,7 @@ function useCurrentSample() {
 function useOperatorThrottledContextSetter() {
   const datasetName = useRecoilValue(fos.datasetName);
   const view = useRecoilValue(fos.view);
+  const viewName = useRecoilValue(fos.viewName);
   const extendedStages = useRecoilValue(fos.extendedStages);
   const filters = useRecoilValue(fos.filters);
   const selectedSamples = useRecoilValue(fos.selectedSamples);
@@ -53,6 +54,7 @@ function useOperatorThrottledContextSetter() {
       selectedSamples,
       selectedLabels,
       currentSample,
+      viewName,
     });
   }, [
     setThrottledContext,
@@ -63,6 +65,7 @@ function useOperatorThrottledContextSetter() {
     selectedSamples,
     selectedLabels,
     currentSample,
+    viewName,
   ]);
 }
 

--- a/app/packages/operators/src/operators.ts
+++ b/app/packages/operators/src/operators.ts
@@ -443,6 +443,7 @@ async function executeOperatorAsGenerator(
       selected_labels: formatSelectedLabels(currentContext.selectedLabels),
       current_sample: currentContext.currentSample,
       request_delegation: ctx.requestDelegation,
+      view_name: currentContext.viewName,
     },
     "json-stream"
   );
@@ -542,6 +543,7 @@ export async function executeOperatorWithContext(
           current_sample: currentContext.currentSample,
           delegation_target: ctx.delegationTarget,
           request_delegation: ctx.requestDelegation,
+          view_name: currentContext.viewName,
         }
       );
       result = serverResult.result;
@@ -608,6 +610,7 @@ export async function resolveRemoteType(
       results: results ? results.result : null,
       delegated: results ? results.delegated : null,
       current_sample: currentContext.currentSample,
+      view_name: currentContext.viewName,
     }
   );
 
@@ -675,6 +678,7 @@ export async function resolveExecutionOptions(
         ? Array.from(currentContext.selectedSamples)
         : [],
       selected_labels: formatSelectedLabels(currentContext.selectedLabels),
+      view_name: currentContext.viewName,
     }
   );
 
@@ -703,6 +707,7 @@ export async function fetchRemotePlacements(ctx: ExecutionContext) {
         : [],
       selected_labels: formatSelectedLabels(currentContext.selectedLabels),
       current_sample: currentContext.currentSample,
+      view_name: currentContext.viewName,
     }
   );
   if (result && result.error) {

--- a/app/packages/operators/src/state.ts
+++ b/app/packages/operators/src/state.ts
@@ -83,6 +83,7 @@ const globalContextSelector = selector({
     const selectedSamples = get(fos.selectedSamples);
     const selectedLabels = get(fos.selectedLabels);
     const currentSample = get(fos.currentSampleId);
+    const viewName = get(fos.viewName);
 
     return {
       datasetName,
@@ -92,6 +93,7 @@ const globalContextSelector = selector({
       selectedSamples,
       selectedLabels,
       currentSample,
+      viewName,
     };
   },
 });
@@ -121,6 +123,7 @@ const useExecutionContext = (operatorName, hooks = {}) => {
     params,
     selectedLabels,
     currentSample,
+    viewName,
   } = curCtx;
   const ctx = useMemo(() => {
     return new ExecutionContext(
@@ -133,6 +136,7 @@ const useExecutionContext = (operatorName, hooks = {}) => {
         selectedSamples,
         selectedLabels,
         currentSample,
+        viewName,
       },
       hooks
     );
@@ -145,6 +149,8 @@ const useExecutionContext = (operatorName, hooks = {}) => {
     selectedSamples,
     selectedLabels,
     hooks,
+    viewName,
+    currentSample,
   ]);
 
   return ctx;

--- a/fiftyone/operators/executor.py
+++ b/fiftyone/operators/executor.py
@@ -5,6 +5,7 @@ FiftyOne operator execution.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 import asyncio
 import collections
 import inspect
@@ -503,6 +504,7 @@ class ExecutionContext(object):
 
         # Always derive the view from the context's dataset
         dataset = self.dataset
+        view_name = self.request_params.get("view_name", None)
         stages = self.request_params.get("view", None)
         filters = self.request_params.get("filters", None)
         extended = self.request_params.get("extended", None)
@@ -510,13 +512,16 @@ class ExecutionContext(object):
         if dataset is None:
             return None
 
-        self._view = fosv.get_view(
-            dataset,
-            stages=stages,
-            filters=filters,
-            extended_stages=extended,
-            reload=False,
-        )
+        if view_name is None:
+            self._view = fosv.get_view(
+                dataset,
+                stages=stages,
+                filters=filters,
+                extended_stages=extended,
+                reload=False,
+            )
+        else:
+            self._view = dataset.load_saved_view(view_name)
 
         return self._view
 
@@ -797,9 +802,9 @@ class ExecutionResult(object):
             "executor": self.executor.to_json() if self.executor else None,
             "error": self.error,
             "delegated": self.delegated,
-            "validation_ctx": self.validation_ctx.to_json()
-            if self.validation_ctx
-            else None,
+            "validation_ctx": (
+                self.validation_ctx.to_json() if self.validation_ctx else None
+            ),
         }
 
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

make ctx.view saved view aware for python operators

## How is this patch tested? If it is not, please explain why.

using an example Python operator that access ctx.view

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

make ctx.view saved view aware for python operators

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced context management with the introduction of `viewName` variable, improving data handling and execution context.
	- Updated several functions to utilize the `view_name` property, refining operations and data fetching.
	- Improved view retrieval process by conditionally loading saved views based on the `view_name` parameter, ensuring more accurate and efficient data representation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->