### PR TITLE
Fix 0º and 180º singularity cases in _rotation_matrix_from_vectors

### DIFF
--- a/tests/unittests/utils/utils3d_tests.py
+++ b/tests/unittests/utils/utils3d_tests.py
@@ -1,0 +1,34 @@
+"""
+| Copyright 2017-2024, Voxel51, Inc.
+| `voxel51.com <https://voxel51.com/>`_
+|
+"""
+
+import numpy as np
+import pytest
+
+import fiftyone.utils.utils3d as fou3d
+
+
+@pytest.mark.parametrize(
+    ("vec1", "vec2"),
+    [
+        ((0, 1, 0), (0, 0, 1)),  # normal 90º rotation
+        ((0, 0, 1), (0, 0, 1)),  # singular case of 0º rotation
+        ((0, 0, -1), (0, 0, 1)),  # singular case of 180º rotation
+        ((0.5, 0, 2), (2, 1, 0)),  # random vector
+    ],
+)
+def test_rotation_matrix_from_vectors(vec1, vec2):
+    """Validates the returned rotation matrix transforms rotates vec1 to vec2."""
+    R = fou3d._rotation_matrix_from_vectors(vec1, vec2)
+
+    vec1_rot = R @ vec1
+    vec1_rn = vec1_rot / np.linalg.norm(vec1_rot)
+    vec2_n = vec2 / np.linalg.norm(vec2)
+
+    # The returned matrix is a rotation matrix
+    np.testing.assert_allclose(np.eye(3), R.T @ R, atol=1e-15)
+    np.testing.assert_allclose(1, np.linalg.det(R))
+
+    np.testing.assert_allclose(vec2_n, vec1_rn, atol=1e-15)


### PR DESCRIPTION
## What changes are proposed in this pull request?

Fixes #4203.

The method [_rotation_matrix_from_vectors](https://github.com/voxel51/fiftyone/blob/7bea0c2b4aae5cad19d84c1ac49e0baa65fbe817/fiftyone/utils/utils3d.py#L777-L786) is ill-defined and returnes `NaN` when the angle between `vec1` and `vec2` was 0º or 180º.

From a geometrical standpoint the issue is being cause by the fact that there is no longer a single "shortest" rotation that transforms vec1 to vec2 There are now infinite perpendicular axes to vec1 and vec2 that can be used to rotate vec1 onto vec2.

This PR addresses that. 

## How is this patch tested? If it is not, please explain why.

With unit tests validating exactly the cases described above, as well as the original cases.

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
