### PR TITLE
Fix matplotlib style deprecation error

### DIFF
--- a/fiftyone/core/plots/matplotlib.py
+++ b/fiftyone/core/plots/matplotlib.py
@@ -37,7 +37,7 @@ from .utils import (
 logger = logging.getLogger(__name__)
 
 
-_DEFAULT_STYLE = "seaborn-ticks"
+_DEFAULT_STYLE = "default"
 _DEFAULT_LINE_COLOR = "#FF6D04"
 _DEFAULT_CONTINUOUS_COLORSCALE = "viridis"
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

Fixes #4210 by changing the default matplotlib style from 'seaborn-ticks' (which is deprecated as of matplotlib 3.6.0) to 'default'. They look visually identical. The only difference seems to be that 'seaborn-ticks' defaults to a gray colormap for images, while 'default' uses viridis.

## How is this patch tested? If it is not, please explain why.

I ran the code from #4210 with matplotlib 3.8.3 to check the error is gone.

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Updated the default plotting style to enhance visual appeal and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->