### PR TITLE
Fix brain.brain.brain in docs build

### DIFF
--- a/docs/generate_docs.bash
+++ b/docs/generate_docs.bash
@@ -125,7 +125,7 @@ fi
 
 echo "Building docs"
 # sphinx-build [OPTIONS] SOURCEDIR OUTPUTDIR [FILENAMES...]
-sphinx-build -M html source build "$SPHINXOPTS"
+sphinx-build -M html source build $SPHINXOPTS
 
 # Remove symlink to fiftyone-teams
 if [[ -n "${PATH_TO_TEAMS}" ]]; then

--- a/docs/generate_docs.bash
+++ b/docs/generate_docs.bash
@@ -86,8 +86,8 @@ if [[ ! -z "${PATH_TO_TEAMS}" ]]; then
     )
     cd -
 
-    ln -sf "${PATH_TO_TEAMS}/fiftyone/management" "${PATH_TO_FIFTYONE_DIR}/management"
-    ln -sf "${PATH_TO_TEAMS}/fiftyone/api" "${PATH_TO_FIFTYONE_DIR}/api"
+    ln -sfn "${PATH_TO_TEAMS}/fiftyone/management" "${PATH_TO_FIFTYONE_DIR}/management"
+    ln -sfn "${PATH_TO_TEAMS}/fiftyone/api" "${PATH_TO_FIFTYONE_DIR}/api"
     echo "Linking to fiftyone-teams at: ${PATH_TO_TEAMS}"
     echo "In fiftyone path: ${PATH_TO_FIFTYONE_DIR}"
 fi
@@ -95,7 +95,7 @@ fi
 cd "${THIS_DIR}/.."
 
 # Symlink to fiftyone-brain
-ln -sf $FIFTYONE_BRAIN_DIR fiftyone/brain
+ln -sfn $FIFTYONE_BRAIN_DIR fiftyone/brain
 
 echo "Generating API docs"
 # sphinx-apidoc [OPTIONS] -o <OUTPUT_PATH> <MODULE_PATH> [EXCLUDE_PATTERN, ...]
@@ -109,7 +109,7 @@ sphinx-apidoc --force --no-toc --separate --follow-links \
         fiftyone/api
 
 # Remove symlink
-rm fiftyone/brain
+unlink fiftyone/brain
 
 cd docs
 

--- a/docs/generate_docs.bash
+++ b/docs/generate_docs.bash
@@ -95,7 +95,7 @@ fi
 cd "${THIS_DIR}/.."
 
 # Symlink to fiftyone-brain
-ln -sfn $FIFTYONE_BRAIN_DIR fiftyone/brain
+ln -sfn "$FIFTYONE_BRAIN_DIR" fiftyone/brain
 
 echo "Generating API docs"
 # sphinx-apidoc [OPTIONS] -o <OUTPUT_PATH> <MODULE_PATH> [EXCLUDE_PATTERN, ...]

--- a/docs/generate_docs.bash
+++ b/docs/generate_docs.bash
@@ -75,9 +75,9 @@ fi
 echo "**** Generating documentation ****"
 
 # Symlink to fiftyone-teams
-if [[ ! -z "${PATH_TO_TEAMS}" ]]; then
+if [[ -n "${PATH_TO_TEAMS}" ]]; then
     # macOS users may need to run `brew install coreutils` to get `realpath``
-    PATH_TO_TEAMS="$(realpath $PATH_TO_TEAMS)"
+    PATH_TO_TEAMS="$(realpath "$PATH_TO_TEAMS")"
 
     cd "${THIS_DIR}"
     PATH_TO_FIFTYONE_DIR=$(
@@ -125,10 +125,10 @@ fi
 
 echo "Building docs"
 # sphinx-build [OPTIONS] SOURCEDIR OUTPUTDIR [FILENAMES...]
-sphinx-build -M html source build $SPHINXOPTS
+sphinx-build -M html source build "$SPHINXOPTS"
 
 # Remove symlink to fiftyone-teams
-if [[ ! -z "${PATH_TO_TEAMS}" ]]; then
+if [[ -n "${PATH_TO_TEAMS}" ]]; then
     unlink "$PATH_TO_FIFTYONE_DIR/management"
     unlink "$PATH_TO_FIFTYONE_DIR/api"
 fi


### PR DESCRIPTION


## What changes are proposed in this pull request?

Docs generation script creates symlinks to brain and teams directories so they're included in autodoc.
If this gets interrupted then a symlink can be left without getting cleaned up.
Without the `-n` argument, it will follow the existing symlink then place a new symlink in *that* directory.
With `-n`, it will simply replace any existing symlink with the proper one.

```
fiftyone/brain -> /my/path/to/fiftyone/brain
fiftyone/brain/brain -> /my/path/to/fiftyone/brain/brain/
...
```

```text
       -n, --no-dereference
              treat LINK_NAME as a normal file if it is a symbolic link
              to a directory
```

NOTE for posterity if you do see `brain.brain.brain`, just run script with clean build or delete the bad source files.
```shell
generate_docs.bash -c
# OR
rm docs/source/api/fiftyone.brain.brain*
```

## How is this patch tested? If it is not, please explain why.

Comment out `unlink fiftyone/brain` on line 112. Run generate docs a few times, see `brain.brain.brain` doesn't happen.

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Chores**
	- Improved symbolic link management in documentation generation script by updating symbolic links creation and removal.
	- Enhanced the script by using safer symbolic link creation and removal commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->