### PR TITLE
add panel state built in operators

### DIFF
--- a/app/packages/core/src/plugins/SchemaIO/components/ButtonView.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/ButtonView.tsx
@@ -3,6 +3,8 @@ import { Box } from "@mui/material";
 import { useOperatorExecutor } from "@fiftyone/operators";
 import Button from "./Button";
 import { getComponentProps } from "../utils";
+import { useCustomPanelState, usePanelId } from "@fiftyone/spaces";
+import { usePromptOperatorInput } from "@fiftyone/operators/src/state";
 
 export default function ButtonView(props) {
   return props?.schema?.view?.operator ? (
@@ -32,12 +34,24 @@ function BaseButtonView(props) {
 
 function OperatorButtonView(props) {
   const { operator, params = {} } = props.schema.view;
+  const panel_state = useCustomPanelState();
   const operatorExecutor = useOperatorExecutor(operator);
+  const promptForOperator = usePromptOperatorInput();
+  const panelId = usePanelId();
   return (
     <BaseButtonView
       {...props}
       onClick={() => {
-        operatorExecutor.execute(params);
+        const actualParams = {
+          panel_id: panelId,
+          panel_state,
+          ...params,
+        };
+        if (props.schema.view.prompt) {
+          promptForOperator(operator, actualParams);
+        } else {
+          operatorExecutor.execute(actualParams);
+        }
       }}
     />
   );

--- a/app/packages/core/src/plugins/SchemaIO/components/PlotlyView.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/PlotlyView.tsx
@@ -4,60 +4,184 @@ import React from "react";
 import Plot from "react-plotly.js";
 import { HeaderView } from ".";
 import { getComponentProps } from "../utils";
+import { merge } from "lodash";
+import { usePanelState } from "@fiftyone/spaces";
+import { executeOperator } from "@fiftyone/operators";
 
 export default function PlotlyView(props) {
+  console.log(props);
   const { data, schema } = props;
   const { view = {} } = schema;
   const { config = {}, layout = {} } = view;
   const theme = useTheme();
+  const [selectedpoints, setSelectedPoints] = React.useState(null);
+  let range = [0, 0];
+  const handleEvent = (event?: string) => (e) => {
+    if (view.controller) {
+      // TODO: add more interesting/useful event data
+      console.log("event", event);
+      console.log("event_data", e);
+      const data = EventDataMappers[event]?.(e) || {};
+      const x_data_source = view.x_data_source;
+      if (event === "onClick") {
+        const values = e.points[0];
+        let selected = [];
+        let xBinsSize = null;
+        let xValue = null;
+        for (const p of e.points) {
+          const { data, fullData } = p;
+          const { x, y } = data;
+          xBinsSize = fullData.xbins.size;
+          selected = selected.concat(p.pointIndices);
+          xValue = p.x;
+        }
+        //
+        // TODO: histogram only
+        //
+        range = [xValue - xBinsSize / 2, xValue + xBinsSize / 2];
+        console.log("range", range);
+        if (selected.length === 0) {
+          selected = null;
+        }
+        setSelectedPoints(selected);
+      }
+      executeOperator(view.controller, {
+        event,
+        panel_id: view.panel_id,
+        data,
+        x_data_source,
+        range,
+      });
+    }
+  };
+  const eventHandlers = createPlotlyHandlers(handleEvent);
 
-  function handleSelectionChange() {
-    // invoke operator name in view.onSelectionChange
-  }
+  const dataDefaults = {
+    selectedpoints,
+  };
+  const layoutDefaults = {
+    // dragmode: "lasso",
+    // uirevision: 1,
+    font: { family: "var(--fo-fontFamily-body)", size: 14 },
+    showlegend: false,
+    // width: "100%",
+    // height: 700,
+    // hovermode: false,
+    xaxis: {
+      showgrid: true,
+      zeroline: false,
+      visible: true,
+    },
+    yaxis: {
+      showgrid: false,
+      zeroline: false,
+      visible: true,
+    },
+    autosize: true,
+    margin: {
+      t: 0,
+      l: 0,
+      b: 0,
+      r: 0,
+      pad: 0,
+    },
+    paper_bgcolor: "rgba(0,0,0,0)",
+    plot_bgcolor: "rgba(0,0,0,0)",
+    legend: {
+      x: 1,
+      y: 1,
+      bgcolor: theme.background.level1,
+      font: { color: theme.text.secondary },
+    },
+  };
+  const configDefaults = {
+    displaylogo: false,
+    scrollZoom: true,
+    responsive: true,
+    displayModeBar: true,
+  };
+
+  const mergedLayout = merge({}, layoutDefaults, layout);
+  const mergedConfig = merge({}, configDefaults, config);
+  const mergedData = mergeData(data, dataDefaults);
 
   return (
-    <Box {...getComponentProps(props, "container")}>
+    <Box
+      {...getComponentProps(props, "container")}
+      useResizeHandler
+      sx={{ height: "100%", width: "100%" }}
+    >
       <HeaderView {...props} nested />
       <Plot
-        data={data}
-        style={{ zIndex: 1 }}
-        onSelected={handleSelectionChange}
-        onDeselect={() => handleSelectionChange()}
-        config={{
-          scrollZoom: true,
-          displaylogo: false,
-          responsive: true,
-          displayModeBar: false,
-          ...config,
-        }}
-        layout={{
-          dragmode: "lasso",
-          uirevision: 1,
-          font: { family: "var(--fo-fontFamily-body)", size: 14 },
-          showlegend: false,
-          width: "100%",
-          height: "100%",
-          hovermode: false,
-          xaxis: { showgrid: true, zeroline: false, visible: false },
-          yaxis: {
-            showgrid: false,
-            zeroline: false,
-            visible: false,
-          },
-          autosize: true,
-          margin: { t: 0, l: 0, b: 0, r: 0, pad: 0 },
-          paper_bgcolor: "rgba(0,0,0,0)",
-          plot_bgcolor: "rgba(0,0,0,0)",
-          legend: {
-            x: 1,
-            y: 1,
-            bgcolor: theme.background.level1,
-            font: { color: theme.text.secondary },
-          },
-          ...layout,
-        }}
+        data={mergedData}
+        style={{ height: "100%", width: "100%", zIndex: 1 }}
+        config={mergedConfig}
+        layout={mergedLayout}
+        {...eventHandlers}
         {...getComponentProps(props, "plotly")}
       />
     </Box>
   );
+}
+
+function createPlotlyHandlers(handleEvent: any) {
+  const PLOTLY_EVENTS = [
+    // 'onAfterExport',
+    // 'onAfterPlot',
+    // 'onAnimated',
+    // 'onAnimatingFrame',
+    // 'onAnimationInterrupted',
+    // 'onAutoSize',
+    // 'onBeforeExport',
+    // 'onBeforeHover',
+    // 'onButtonClicked',
+    "onClick",
+    "onClickAnnotation",
+    "onDeselect",
+    "onDoubleClick",
+    // 'onFramework',
+    // 'onHover',
+    // 'onLegendClick',
+    // 'onLegendDoubleClick',
+    // 'onRelayout',
+    // 'onRelayouting',
+    // 'onRestyle',
+    // 'onRedraw',
+    "onSelected",
+    // 'onSelecting',
+    "onSliderChange",
+    "onSliderEnd",
+    "onSliderStart",
+    // 'onSunburstClick',
+    // 'onTransitioning',
+    // 'onTransitionInterrupted',
+    // 'onUnhover',
+    // 'onWebGlContextLost'
+  ];
+  let handlers = {} as any;
+  for (const event of PLOTLY_EVENTS) {
+    handlers[event] = handleEvent(event);
+  }
+  return handlers;
+}
+
+const EventDataMappers = {
+  onClick: ({ event, points }) => {
+    const { data, fullData, xaxis, yaxis, ...pointdata } = points[0];
+    const { x, y, z, ...metadata } = data;
+    const result = {
+      ...pointdata,
+      data: metadata,
+    };
+    return result;
+  },
+};
+
+function mergeData(data, defaults) {
+  return (data || []).map((trace) => {
+    return {
+      ...trace,
+      ...defaults,
+    };
+  });
 }

--- a/app/packages/operators/src/CustomPanel.tsx
+++ b/app/packages/operators/src/CustomPanel.tsx
@@ -40,7 +40,7 @@ export function CustomPanel({
         setPanelState((s) => ({ ...s, loaded: true }));
       }
     }
-    console.log("panelState", panelState);
+
     return () => {
       if (onUnLoad) executeOperator(onUnLoad, { panel_id: panelId });
     };
@@ -93,7 +93,6 @@ export function CustomPanel({
         onChange={handlePanelStateChange}
         data={data}
       />
-      <pre>{JSON.stringify(panelState, null, 2)}</pre>
     </div>
   );
 }

--- a/app/packages/operators/src/CustomPanel.tsx
+++ b/app/packages/operators/src/CustomPanel.tsx
@@ -1,9 +1,15 @@
 import { usePanelState } from "@fiftyone/spaces";
 import { useEffect } from "react";
 import { executeOperator } from "./operators";
+import OperatorIO from "./OperatorIO";
 
 export function CustomPanel({ panelId, onLoad, onUnLoad }) {
   const [panelState, setPanelState] = usePanelState(panelId);
+  const renderableSchema = panelState?.schema;
+  const data = panelState?.state;
+  const handlePanelStateChange = (newState) => {
+    console.log(newState);
+  };
 
   useEffect(() => {
     if (onLoad) executeOperator(onLoad, { panel_id: panelId });
@@ -13,7 +19,13 @@ export function CustomPanel({ panelId, onLoad, onUnLoad }) {
     };
   }, []);
 
-  return <pre>{JSON.stringify(panelState, null, 2)}</pre>;
+  return (
+    <OperatorIO
+      schema={renderableSchema}
+      onChange={handlePanelStateChange}
+      data={data}
+    />
+  );
 }
 
 export function defineCustomPanel(onLoad, onUnLoad) {

--- a/app/packages/operators/src/CustomPanel.tsx
+++ b/app/packages/operators/src/CustomPanel.tsx
@@ -1,0 +1,18 @@
+import { usePanelState } from "@fiftyone/spaces";
+import { useEffect } from "react";
+import { executeOperator } from "./operators";
+
+export function CustomPanel({ panelId, onLoad }) {
+  const [panelState, setPanelState] = usePanelState(panelId);
+
+  useEffect(() => {
+    executeOperator(onLoad, { panel_id: panelId });
+    console.log("panelState", panelState);
+  }, []);
+
+  return <pre>{JSON.stringify(panelState, null, 2)}</pre>;
+}
+
+export function defineCustomPanel(onLoad) {
+  return ({ panelId }) => <CustomPanel panelId={panelId} onLoad={onLoad} />;
+}

--- a/app/packages/operators/src/CustomPanel.tsx
+++ b/app/packages/operators/src/CustomPanel.tsx
@@ -2,17 +2,22 @@ import { usePanelState } from "@fiftyone/spaces";
 import { useEffect } from "react";
 import { executeOperator } from "./operators";
 
-export function CustomPanel({ panelId, onLoad }) {
+export function CustomPanel({ panelId, onLoad, onUnLoad }) {
   const [panelState, setPanelState] = usePanelState(panelId);
 
   useEffect(() => {
-    executeOperator(onLoad, { panel_id: panelId });
+    if (onLoad) executeOperator(onLoad, { panel_id: panelId });
     console.log("panelState", panelState);
+    return () => {
+      if (onUnLoad) executeOperator(onUnLoad, { panel_id: panelId });
+    };
   }, []);
 
   return <pre>{JSON.stringify(panelState, null, 2)}</pre>;
 }
 
-export function defineCustomPanel(onLoad) {
-  return ({ panelId }) => <CustomPanel panelId={panelId} onLoad={onLoad} />;
+export function defineCustomPanel(onLoad, onUnLoad) {
+  return ({ panelId }) => (
+    <CustomPanel panelId={panelId} onLoad={onLoad} onUnLoad={onUnLoad} />
+  );
 }

--- a/app/packages/operators/src/built-in-operators.ts
+++ b/app/packages/operators/src/built-in-operators.ts
@@ -1,6 +1,7 @@
 import {
   Layout,
   SpaceNode,
+  usePanelState,
   usePanels,
   useSpaceNodes,
   useSpaces,
@@ -22,6 +23,7 @@ import {
   listLocalAndRemoteOperators,
 } from "./operators";
 import { useShowOperatorIO } from "./state";
+import { merge } from "lodash";
 
 //
 // BUILT-IN OPERATORS
@@ -764,6 +766,65 @@ class SetSpaces extends Operator {
   }
 }
 
+class ClearPanelState extends Operator {
+  get config(): OperatorConfig {
+    return new OperatorConfig({
+      name: "clear_panel_state",
+      label: "Clear panel state",
+      unlisted: true,
+    });
+  }
+  useHooks(ctx: ExecutionContext): {} {
+    const [panelState, setPanelState] = usePanelState();
+    return {
+      setPanelState,
+    };
+  }
+  async execute(ctx: ExecutionContext): Promise<void> {
+    ctx.hooks.setPanelState({});
+  }
+}
+
+class SetPanelState extends Operator {
+  get config(): OperatorConfig {
+    return new OperatorConfig({
+      name: "set_panel_state",
+      label: "Set panel state",
+      unlisted: true,
+    });
+  }
+  useHooks(ctx: ExecutionContext): {} {
+    const [panelState, setPanelState] = usePanelState();
+    return {
+      setPanelState,
+    };
+  }
+  async execute(ctx: ExecutionContext): Promise<void> {
+    ctx.hooks.setPanelState(ctx.params.state);
+  }
+}
+
+class PatchPanelState extends Operator {
+  get config(): OperatorConfig {
+    return new OperatorConfig({
+      name: "patch_panel_state",
+      label: "Patch panel state",
+      unlisted: true,
+    });
+  }
+  useHooks(ctx: ExecutionContext): {} {
+    const [panelState, setPanelState] = usePanelState();
+    return {
+      panelState,
+      setPanelState,
+    };
+  }
+  async execute(ctx: ExecutionContext): Promise<void> {
+    const mergedState = merge(ctx.hooks.panelState, ctx.params.state);
+    ctx.hooks.setPanelState(mergedState);
+  }
+}
+
 export function registerBuiltInOperators() {
   try {
     _registerBuiltInOperator(CopyViewAsJSON);
@@ -794,6 +855,9 @@ export function registerBuiltInOperators() {
     _registerBuiltInOperator(SetSelectedLabels);
     _registerBuiltInOperator(ClearSelectedLabels);
     _registerBuiltInOperator(SetSpaces);
+    _registerBuiltInOperator(SetPanelState);
+    _registerBuiltInOperator(ClearPanelState);
+    _registerBuiltInOperator(PatchPanelState);
   } catch (e) {
     console.error("Error registering built-in operators");
     console.error(e);

--- a/app/packages/operators/src/built-in-operators.ts
+++ b/app/packages/operators/src/built-in-operators.ts
@@ -475,7 +475,7 @@ class SetView extends Operator {
   }
   async resolveInput(ctx: ExecutionContext): Promise<types.Property> {
     const inputs = new types.Object();
-    inputs.obj("view", { view: new types.HiddenView({}) });
+    inputs.list("view", { view: new types.HiddenView({}) });
     inputs.str("name", { label: "Name or slug of a saved view" });
     return new types.Property(inputs);
   }
@@ -819,6 +819,30 @@ class SetPanelState extends Operator {
   }
 }
 
+class SetPanelData extends Operator {
+  get config(): OperatorConfig {
+    return new OperatorConfig({
+      name: "set_panel_data",
+      label: "Set panel data",
+      unlisted: true,
+    });
+  }
+  useHooks(ctx: ExecutionContext): {} {
+    const setPanelStateById = useSetPanelStateById();
+    return { setPanelStateById };
+  }
+  async execute(ctx: ExecutionContext): Promise<void> {
+    setTimeout(() => {
+      ctx.hooks.setPanelStateById(ctx.getCurrentPanelId(), (current) => {
+        return {
+          ...current,
+          data: ctx.params.data,
+        };
+      });
+    }, 1);
+  }
+}
+
 class PatchPanelState extends Operator {
   get config(): OperatorConfig {
     return new OperatorConfig({
@@ -971,6 +995,7 @@ export function registerBuiltInOperators() {
     _registerBuiltInOperator(RegisterPanel);
     _registerBuiltInOperator(ShowPanelOutput);
     _registerBuiltInOperator(ReducePanelState);
+    _registerBuiltInOperator(SetPanelData);
   } catch (e) {
     console.error("Error registering built-in operators");
     console.error(e);

--- a/app/packages/operators/src/built-in-operators.ts
+++ b/app/packages/operators/src/built-in-operators.ts
@@ -766,6 +766,10 @@ class SetSpaces extends Operator {
   }
 }
 
+function usePanelStateForContext(ctx: ExecutionContext) {
+  return usePanelState(ctx.getCurrentPanelId());
+}
+
 class ClearPanelState extends Operator {
   get config(): OperatorConfig {
     return new OperatorConfig({
@@ -775,7 +779,7 @@ class ClearPanelState extends Operator {
     });
   }
   useHooks(ctx: ExecutionContext): {} {
-    const [panelState, setPanelState] = usePanelState();
+    const [panelState, setPanelState] = usePanelStateForContext(ctx);
     return {
       setPanelState,
     };
@@ -794,7 +798,7 @@ class SetPanelState extends Operator {
     });
   }
   useHooks(ctx: ExecutionContext): {} {
-    const [panelState, setPanelState] = usePanelState();
+    const [panelState, setPanelState] = usePanelStateForContext(ctx);
     return {
       setPanelState,
     };
@@ -813,7 +817,7 @@ class PatchPanelState extends Operator {
     });
   }
   useHooks(ctx: ExecutionContext): {} {
-    const [panelState, setPanelState] = usePanelState();
+    const [panelState, setPanelState] = usePanelStateForContext(ctx);
     return {
       panelState,
       setPanelState,

--- a/app/packages/operators/src/built-in-operators.ts
+++ b/app/packages/operators/src/built-in-operators.ts
@@ -847,6 +847,9 @@ class RegisterPanel extends Operator {
       label: "On load operator",
       required: true,
     });
+    inputs.str("on_unload", {
+      label: "On unload operator",
+    });
     inputs.bool("allow_duplicates", {
       label: "Allow duplicates",
       default: false,
@@ -857,14 +860,13 @@ class RegisterPanel extends Operator {
     registerComponent({
       type: PluginComponentType.Panel,
       name: ctx.params.panel_name,
-      component: defineCustomPanel(ctx.params.on_load),
+      component: defineCustomPanel(ctx.params.on_load, ctx.params.on_unload),
       label: ctx.params.panel_label,
       activator: () => true,
       panelOptions: {
         allowDuplicates: ctx.params.allow_duplicates,
       },
     });
-    ctx.hooks.registerPanel(ctx.params.panel);
   }
 }
 

--- a/app/packages/operators/src/built-in-operators.ts
+++ b/app/packages/operators/src/built-in-operators.ts
@@ -783,7 +783,8 @@ class ClearPanelState extends Operator {
   useHooks(ctx: ExecutionContext): {} {
     const [panelState, setPanelState] = usePanelStateForContext(ctx);
     return {
-      setPanelState,
+      panelState: panelState.state || {},
+      setPanelState: (state) => setPanelState({ state }),
     };
   }
   async execute(ctx: ExecutionContext): Promise<void> {

--- a/app/packages/operators/src/built-in-operators.ts
+++ b/app/packages/operators/src/built-in-operators.ts
@@ -3,6 +3,7 @@ import {
   SpaceNode,
   usePanelState,
   usePanels,
+  useSetPanelStateById,
   useSpaceNodes,
   useSpaces,
 } from "@fiftyone/spaces";
@@ -781,14 +782,16 @@ class ClearPanelState extends Operator {
     });
   }
   useHooks(ctx: ExecutionContext): {} {
-    const [panelState, setPanelState] = usePanelStateForContext(ctx);
-    return {
-      panelState: panelState.state || {},
-      setPanelState: (state) => setPanelState({ state }),
-    };
+    const setPanelStateById = useSetPanelStateById();
+    return { setPanelStateById };
   }
   async execute(ctx: ExecutionContext): Promise<void> {
-    ctx.hooks.setPanelState({});
+    ctx.hooks.setPanelStateById(ctx.getCurrentPanelId(), (current) => {
+      return {
+        ...current,
+        state: {},
+      };
+    });
   }
 }
 
@@ -801,13 +804,18 @@ class SetPanelState extends Operator {
     });
   }
   useHooks(ctx: ExecutionContext): {} {
-    const [panelState, setPanelState] = usePanelStateForContext(ctx);
-    return {
-      setPanelState,
-    };
+    const setPanelStateById = useSetPanelStateById();
+    return { setPanelStateById };
   }
   async execute(ctx: ExecutionContext): Promise<void> {
-    ctx.hooks.setPanelState(ctx.params.state);
+    setTimeout(() => {
+      ctx.hooks.setPanelStateById(ctx.getCurrentPanelId(), (current) => {
+        return {
+          ...current,
+          state: ctx.params.state,
+        };
+      });
+    }, 1);
   }
 }
 
@@ -820,15 +828,67 @@ class PatchPanelState extends Operator {
     });
   }
   useHooks(ctx: ExecutionContext): {} {
-    const [panelState, setPanelState] = usePanelStateForContext(ctx);
+    const setPanelStateById = useSetPanelStateById();
+    return { setPanelStateById };
+  }
+  async execute(ctx: ExecutionContext): Promise<void> {
+    ctx.hooks.setPanelStateById(ctx.getCurrentPanelId(), (current) => {
+      current = current || {};
+      const mergedState = merge(current.state, ctx.params.state);
+      return mergedState;
+    });
+  }
+}
+
+function createFunctionFromSource(src) {
+  return eval(src.trim());
+}
+
+class ReducePanelState extends Operator {
+  get config(): OperatorConfig {
+    return new OperatorConfig({
+      name: "reduce_panel_state",
+      label: "Reduce panel state",
+      unlisted: true,
+    });
+  }
+  useHooks(ctx: ExecutionContext): {} {
+    const setPanelStateById = useSetPanelStateById();
+    return { setPanelStateById };
+  }
+  async execute(ctx: ExecutionContext): Promise<void> {
+    const actualReducer = createFunctionFromSource(ctx.params.reducer);
+    ctx.hooks.setPanelStateById(ctx.getCurrentPanelId(), (current) => {
+      return {
+        ...current,
+        state: actualReducer(current.state || {}),
+      };
+    });
+  }
+}
+
+class ShowPanelOutput extends Operator {
+  get config(): OperatorConfig {
+    return new OperatorConfig({
+      name: "show_panel_output",
+      label: "Show panel output",
+      unlisted: true,
+    });
+  }
+  useHooks(ctx: ExecutionContext): any {
+    const setPanelStateById = useSetPanelStateById();
+
     return {
-      panelState,
-      setPanelState,
+      setPanelStateById,
     };
   }
   async execute(ctx: ExecutionContext): Promise<void> {
-    const mergedState = merge(ctx.hooks.panelState, ctx.params.state);
-    ctx.hooks.setPanelState(mergedState);
+    ctx.hooks.setPanelStateById(ctx.getCurrentPanelId(), (current) => {
+      return {
+        ...current,
+        schema: ctx.params.output,
+      };
+    });
   }
 }
 
@@ -846,7 +906,11 @@ class RegisterPanel extends Operator {
     inputs.str("panel_label", { label: "Panel label", required: true });
     inputs.str("on_load", {
       label: "On load operator",
-      required: true,
+      // required: true,
+    });
+    inputs.str("on_change", {
+      label: "On change operator",
+      // required: true,
     });
     inputs.str("on_unload", {
       label: "On unload operator",
@@ -861,7 +925,7 @@ class RegisterPanel extends Operator {
     registerComponent({
       type: PluginComponentType.Panel,
       name: ctx.params.panel_name,
-      component: defineCustomPanel(ctx.params.on_load, ctx.params.on_unload),
+      component: defineCustomPanel(ctx.params),
       label: ctx.params.panel_label,
       activator: () => true,
       panelOptions: {
@@ -905,6 +969,8 @@ export function registerBuiltInOperators() {
     _registerBuiltInOperator(ClearPanelState);
     _registerBuiltInOperator(PatchPanelState);
     _registerBuiltInOperator(RegisterPanel);
+    _registerBuiltInOperator(ShowPanelOutput);
+    _registerBuiltInOperator(ReducePanelState);
   } catch (e) {
     console.error("Error registering built-in operators");
     console.error(e);

--- a/app/packages/operators/src/operators.ts
+++ b/app/packages/operators/src/operators.ts
@@ -50,6 +50,13 @@ export class Executor {
   }
 }
 
+class Panel {
+  constructor(public id: string) {}
+  static fromJSON(json: any) {
+    return new Panel(json.id);
+  }
+}
+
 export class ExecutionContext {
   public state: CallbackInterface;
   constructor(
@@ -62,6 +69,10 @@ export class ExecutionContext {
   }
   public delegationTarget: string = null;
   public requestDelegation: boolean = false;
+  public currentPanel?: Panel = null;
+  getCurrentPanelId(): string | null {
+    return this.params.panel_id || this.currentPanel?.id || null;
+  }
   trigger(operatorURI: string, params: any = {}) {
     if (!this.executor) {
       throw new Error(

--- a/app/packages/operators/src/state.ts
+++ b/app/packages/operators/src/state.ts
@@ -61,13 +61,13 @@ export const usePromptOperatorInput = () => {
   );
   const setPromptingOperator = useSetRecoilState(promptingOperatorState);
 
-  const prompt = (operatorName) => {
+  const prompt = (operatorName, params = {}) => {
     setRecentlyUsedOperators((recentlyUsedOperators) => {
       const update = new Set([...recentlyUsedOperators, operatorName]);
       return Array.from(update).slice(-5);
     });
 
-    setPromptingOperator({ operatorName, params: {} });
+    setPromptingOperator({ operatorName, params });
   };
 
   return prompt;

--- a/app/packages/spaces/src/hooks.ts
+++ b/app/packages/spaces/src/hooks.ts
@@ -144,6 +144,42 @@ export function usePanelState<T>(
   return [computedState, setState];
 }
 
+export function useSetPanelStateById<T>(local = false) {
+  return useRecoilCallback(
+    ({ set, snapshot }) =>
+      async (panelId: string, fn: (state: any) => any) => {
+        const panelState = await snapshot.getPromise(
+          panelStateSelector({ panelId, local })
+        );
+        const updatedValue = fn(panelState);
+        set(panelStateSelector({ panelId, local }), updatedValue);
+      },
+    []
+  );
+}
+
+export function usePanelId() {
+  const panelContext = usePanelContext();
+  const panelId = panelContext?.node?.id as string;
+  return panelId;
+}
+
+export function useSetCustomPanelState<T>(local = false) {
+  const [panelState, setPanelState] = usePanelState<T>(null, undefined, local);
+  return (fn: (state: T) => T) => {
+    setPanelState((panelState) => {
+      const customPanelState = fn(panelState.state || {});
+      const state = fn(customPanelState);
+      return { ...panelState, state };
+    });
+  };
+}
+
+export function useCustomPanelState(panelId?: string, local = false) {
+  const [panelState] = usePanelState(null, panelId, local);
+  return panelState.state || {};
+}
+
 /**
  * Can only be used within a panel component
  */

--- a/fiftyone/operators/operations.py
+++ b/fiftyone/operators/operations.py
@@ -192,6 +192,22 @@ class Operations(object):
 
         return self._ctx.trigger("open_panel", params=params)
 
+    def register_panel(self, name, label, on_load=None, on_unload=None):
+        """Register a panel with the given name and lifecycle callbacks.
+
+        Args:
+            name: the name of the panel to register
+            on_load (None): an operator to invoke when the panel is loaded
+            on_unload (None): an operator to invoke when the panel is unloaded
+        """
+        params = {
+            "panel_name": name,
+            "panel_label": label,
+            "on_load": on_load,
+            "on_unload": on_unload,
+        }
+        return self._ctx.trigger("register_panel", params=params)
+
     def open_all_panels(self):
         """Open all available panels in the App."""
         return self._ctx.trigger("open_all_panel")

--- a/fiftyone/operators/operations.py
+++ b/fiftyone/operators/operations.py
@@ -137,7 +137,7 @@ class Operations(object):
     def _create_panel_params(self, panel_id, state=None):
         params = {"panel_id": panel_id}
         if panel_id is None:
-            params["panel_id"] = self._ctx.current_panel.id
+            params["panel_id"] = self._ctx.params.get("panel_id", None)
         if state is not None:
             params["state"] = state
         return params
@@ -153,7 +153,7 @@ class Operations(object):
             "clear_panel_state", params=self._create_panel_params(panel_id)
         )
 
-    def set_panel_state(self, panel_id=None, state=None):
+    def set_panel_state(self, state, panel_id=None):
         """Set the state of the specified panel in the App.
 
         Args:
@@ -177,6 +177,38 @@ class Operations(object):
             params=self._create_panel_params(panel_id, state=state),
         )
 
+    def reduce_panel_state(self, reducer, panel_id=None):
+        """Reduce the state of the specified panel in the App.
+
+        Args:
+            panel_id (None): the optional ID of the panel to clear.
+                If not provided, the ctx.current_panel.id will be used.
+        """
+        return self._ctx.trigger(
+            "reduce_panel_state",
+            params={
+                **self._create_panel_params(panel_id),
+                "reducer": reducer,
+            },
+        )
+
+    def show_panel_output(self, output, panel_id=None):
+        """Show output in the specified panel in the App.
+
+        Args:
+            output: the output to show
+            panel_id (None): the optional ID of the panel to clear.
+                If not provided, the ctx.current_panel.id will be used.
+        """
+        params = self._create_panel_params(panel_id)
+        return self._ctx.trigger(
+            "show_panel_output",
+            params={
+                **params,
+                "output": output.to_json(),
+            },
+        )
+
     def open_panel(self, name, is_active=True, layout=None):
         """Open a panel with the given name and layout options in the App.
 
@@ -192,7 +224,9 @@ class Operations(object):
 
         return self._ctx.trigger("open_panel", params=params)
 
-    def register_panel(self, name, label, on_load=None, on_unload=None):
+    def register_panel(
+        self, name, label, on_load=None, on_unload=None, on_change=None
+    ):
         """Register a panel with the given name and lifecycle callbacks.
 
         Args:
@@ -205,6 +239,7 @@ class Operations(object):
             "panel_label": label,
             "on_load": on_load,
             "on_unload": on_unload,
+            "on_change": on_change,
         }
         return self._ctx.trigger("register_panel", params=params)
 

--- a/fiftyone/operators/operations.py
+++ b/fiftyone/operators/operations.py
@@ -134,6 +134,49 @@ class Operations(object):
         """Set the view in the App from JSON present in clipboard."""
         return self._ctx.trigger("view_from_clipboard")
 
+    def _create_panel_params(self, panel_id, state=None):
+        params = {"panel_id": panel_id}
+        if panel_id is None:
+            params["panel_id"] = self._ctx.current_panel.id
+        if state is not None:
+            params["state"] = state
+        return params
+
+    def clear_panel_state(self, panel_id=None):
+        """Clear the state of the specified panel in the App.
+
+        Args:
+            panel_id (None): the optional ID of the panel to clear.
+                If not provided, the ctx.current_panel.id will be used.
+        """
+        return self._ctx.trigger(
+            "clear_panel_state", params=self._create_panel_params(panel_id)
+        )
+
+    def set_panel_state(self, panel_id=None, state=None):
+        """Set the state of the specified panel in the App.
+
+        Args:
+            panel_id (None): the optional ID of the panel to clear.
+                If not provided, the ctx.current_panel.id will be used.
+        """
+        return self._ctx.trigger(
+            "set_panel_state",
+            params=self._create_panel_params(panel_id, state=state),
+        )
+
+    def patch_panel_state(self, panel_id=None, state=None):
+        """Patch the state of the specified panel in the App.
+
+        Args:
+            panel_id (None): the optional ID of the panel to clear.
+                If not provided, the ctx.current_panel.id will be used.
+        """
+        return self._ctx.trigger(
+            "patch_panel_state",
+            params=self._create_panel_params(panel_id, state=state),
+        )
+
     def open_panel(self, name, is_active=True, layout=None):
         """Open a panel with the given name and layout options in the App.
 

--- a/fiftyone/operators/operations.py
+++ b/fiftyone/operators/operations.py
@@ -134,12 +134,14 @@ class Operations(object):
         """Set the view in the App from JSON present in clipboard."""
         return self._ctx.trigger("view_from_clipboard")
 
-    def _create_panel_params(self, panel_id, state=None):
+    def _create_panel_params(self, panel_id, state=None, data=None):
         params = {"panel_id": panel_id}
         if panel_id is None:
             params["panel_id"] = self._ctx.params.get("panel_id", None)
         if state is not None:
             params["state"] = state
+        if data is not None:
+            params["data"] = data
         return params
 
     def clear_panel_state(self, panel_id=None):
@@ -163,6 +165,18 @@ class Operations(object):
         return self._ctx.trigger(
             "set_panel_state",
             params=self._create_panel_params(panel_id, state=state),
+        )
+
+    def set_panel_data(self, data, panel_id=None):
+        """Set the data of the specified panel in the App.
+
+        Args:
+            panel_id (None): the optional ID of the panel to clear.
+                If not provided, the ctx.current_panel.id will be used.
+        """
+        return self._ctx.trigger(
+            "set_panel_data",
+            params=self._create_panel_params(panel_id, data=data),
         )
 
     def patch_panel_state(self, panel_id=None, state=None):
@@ -225,7 +239,14 @@ class Operations(object):
         return self._ctx.trigger("open_panel", params=params)
 
     def register_panel(
-        self, name, label, on_load=None, on_unload=None, on_change=None
+        self,
+        name,
+        label,
+        on_load=None,
+        on_unload=None,
+        on_change=None,
+        on_view_change=None,
+        allow_duplicates=False,
     ):
         """Register a panel with the given name and lifecycle callbacks.
 
@@ -233,6 +254,8 @@ class Operations(object):
             name: the name of the panel to register
             on_load (None): an operator to invoke when the panel is loaded
             on_unload (None): an operator to invoke when the panel is unloaded
+            on_change (None): an operator to invoke when the panel state changes
+            allow_duplicates (False): whether to allow multiple instances of the panel
         """
         params = {
             "panel_name": name,
@@ -240,6 +263,8 @@ class Operations(object):
             "on_load": on_load,
             "on_unload": on_unload,
             "on_change": on_change,
+            "allow_duplicates": allow_duplicates,
+            "on_view_change": on_view_change,
         }
         return self._ctx.trigger("register_panel", params=params)
 

--- a/fiftyone/operators/types.py
+++ b/fiftyone/operators/types.py
@@ -245,6 +245,13 @@ class Object(BaseType):
         """
         return self.define_property(name, Void(), view=view, **kwargs)
 
+    def btn(self, name, label, on_click=None, prompt=False, params=None):
+        """Defines a button to display to the user as a :class:`Button`."""
+        btn = Button(
+            label=label, operator=on_click, prompt=prompt, params=params
+        )
+        return self.view(name, btn)
+
     def message(self, name, label, **kwargs):
         """Defines a message to display to the user as a :class:`Notice`.
 
@@ -944,6 +951,7 @@ class Button(View):
         super().__init__(**kwargs)
         self.href = kwargs.get("href", None)
         self.operator = kwargs.get("operator", None)
+        self.prompt = kwargs.get("prompt", False)
         self.params = kwargs.get("params", None)
 
     def to_json(self):
@@ -952,6 +960,7 @@ class Button(View):
             "href": self.href,
             "operator": self.operator,
             "params": self.params,
+            "prompt": self.prompt,
         }
 
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

Adds the following built in JS operators:

 - clear_panel_state
 - set_panel_state
 - patch_panel_state
 - register_panel

## How is this patch tested? If it is not, please explain why.

(Details)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced button components to optionally prompt for operator input.
  - Improved Plotly integration with new event handling and default configuration merging.
  - Introduced custom panel functionality with state management and operator execution.
  - Expanded panel operator capabilities, including state management and panel registration.
  - Added comprehensive methods for panel operations in Python modules.

- **Enhancements**
  - Added new hooks for managing panel states more efficiently.

- **Bug Fixes**
  - Adjusted `SetView` operator to handle list inputs properly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->