### PR TITLE
Add video support to SAM

### DIFF
--- a/fiftyone/utils/sam.py
+++ b/fiftyone/utils/sam.py
@@ -46,7 +46,7 @@ class SegmentAnythingModelConfig(fout.TorchImageModelConfig, fozm.HasZooModel):
             raise ValueError("mask_index must be 0, 1, or 2")
 
 
-class SegmentAnythingModel(fout.TorchImageModel, fout.TorchSamplesMixin):
+class SegmentAnythingModel(fout.TorchSamplesMixin, fout.TorchImageModel):
     """Wrapper for running `Segment Anything <https://segment-anything.com>`_
     inference.
 
@@ -121,10 +121,9 @@ class SegmentAnythingModel(fout.TorchImageModel, fout.TorchSamplesMixin):
     """
 
     def __init__(self, config):
-        super().__init__(config)
         fout.TorchSamplesMixin.__init__(self)
+        fout.TorchImageModel.__init__(self, config)
 
-        self._preprocess = False
         self._curr_prompt_type = None
         self._curr_prompts = None
         self._curr_classes = None
@@ -161,9 +160,14 @@ class SegmentAnythingModel(fout.TorchImageModel, fout.TorchSamplesMixin):
 
     def _get_field(self):
         if "prompt_field" in self.needs_fields:
-            return self.needs_fields["prompt_field"]
+            prompt_field = self.needs_fields["prompt_field"]
+        else:
+            prompt_field = next(iter(self.needs_fields.values()), None)
 
-        return next(iter(self.needs_fields.values()), None)
+        if prompt_field is not None and prompt_field.startswith("frames."):
+            prompt_field = prompt_field[len("frames.") :]
+
+        return prompt_field
 
     def _parse_samples(self, samples, field_name):
         prompt_type = self._get_prompt_type(samples, field_name)


### PR DESCRIPTION
```py
import fiftyone as fo
import fiftyone.zoo as foz

model = foz.load_zoo_model("segment-anything-vitb-torch")

dataset = foz.load_zoo_dataset("quickstart", max_samples=1)
dataset.apply_model(model, label_field="segmentations", prompt_field="ground_truth")

dataset = foz.load_zoo_dataset("quickstart-video", max_samples=1)
dataset.apply_model(model, label_field="frames.segmentations", prompt_field="frames.detections")
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved the inheritance structure and initialization logic in the `SegmentAnythingModel`.
	- Enhanced the method for obtaining prompt fields during predictions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->