### PR TITLE
Feat/ultralytics obb support

### DIFF
--- a/fiftyone/utils/ultralytics.py
+++ b/fiftyone/utils/ultralytics.py
@@ -169,7 +169,7 @@ def _to_instances(result, confidence_thresh=None):
     return fol.Detections(detections=detections)
 
 
-def obb_to_polylines(results, confidence_thresh=None,filled=False):
+def obb_to_polylines(results, confidence_thresh=None, filled=False):
     """Converts ``ultralytics.YOLO`` instance segmentations to FiftyOne format.
 
     Args:
@@ -186,9 +186,7 @@ def obb_to_polylines(results, confidence_thresh=None,filled=False):
         results = [results]
 
     batch = [
-        _obb_to_polylines(
-            r, filled, confidence_thresh=confidence_thresh
-        )
+        _obb_to_polylines(r, filled, confidence_thresh=confidence_thresh)
         for r in results
     ]
 
@@ -198,7 +196,7 @@ def obb_to_polylines(results, confidence_thresh=None,filled=False):
     return batch
 
 
-def _obb_to_polylines(result,filled, confidence_thresh=None):
+def _obb_to_polylines(result, filled, confidence_thresh=None):
     if result.obb is None:
         return None
     classes = np.rint(result.obb.cls.detach().cpu().numpy()).astype(int)
@@ -222,6 +220,7 @@ def _obb_to_polylines(result,filled, confidence_thresh=None):
         )
         polylines.append(polyline)
     return fol.Polylines(polylines=polylines)
+
 
 def to_polylines(results, confidence_thresh=None, tolerance=2, filled=True):
     """Converts ``ultralytics.YOLO`` instance segmentations to FiftyOne format.
@@ -441,6 +440,7 @@ class FiftyOneYOLODetectionModel(FiftyOneYOLOModel):
 class FiftyOneYOLOOBBConfig(FiftyOneYOLOModelConfig):
     pass
 
+
 class FiftyOneYOLOOBBModel(FiftyOneYOLOModel):
     """FiftyOne wrapper around an Ultralytics YOLO OBB detection model.
 
@@ -455,7 +455,6 @@ class FiftyOneYOLOOBBModel(FiftyOneYOLOModel):
         images = [Image.fromarray(arg) for arg in args]
         predictions = self.model(images, verbose=False)
         return self._format_predictions(predictions)
-
 
 
 class FiftyOneYOLOSegmentationModelConfig(FiftyOneYOLOModelConfig):
@@ -502,9 +501,11 @@ def _convert_yolo_detection_model(model):
     config = FiftyOneYOLODetectionModelConfig({"model": model})
     return FiftyOneYOLODetectionModel(config)
 
+
 def _convert_yolo_obb_model(model):
     config = FiftyOneYOLOOBBConfig({"model": model})
     return FiftyOneYOLOOBBModel(config)
+
 
 def _convert_yolo_segmentation_model(model):
     config = FiftyOneYOLOSegmentationModelConfig({"model": model})

--- a/fiftyone/utils/ultralytics.py
+++ b/fiftyone/utils/ultralytics.py
@@ -42,7 +42,10 @@ def convert_ultralytics_model(model):
     elif isinstance(model.model, ultralytics.nn.tasks.PoseModel):
         return _convert_yolo_pose_model(model)
     elif isinstance(model.model, ultralytics.nn.tasks.DetectionModel):
-        return _convert_yolo_detection_model(model)
+        if isinstance(model.model, ultralytics.nn.tasks.OBBModel):
+            return _convert_yolo_obb_model(model)
+        else:
+            return _convert_yolo_detection_model(model)
     else:
         raise ValueError(
             "Unsupported model type; cannot convert %s to a FiftyOne model"
@@ -165,6 +168,60 @@ def _to_instances(result, confidence_thresh=None):
 
     return fol.Detections(detections=detections)
 
+
+def obb_to_polylines(results, confidence_thresh=None,filled=False):
+    """Converts ``ultralytics.YOLO`` instance segmentations to FiftyOne format.
+
+    Args:
+        results: a single or list of ``ultralytics.engine.results.Results``
+        confidence_thresh (None): a confidence threshold to filter boxes
+        filled (False): whether the polyline should be filled
+
+    Returns:
+        a single or list of :class:`fiftyone.core.labels.PolyLines`
+    """
+
+    single = not isinstance(results, list)
+    if single:
+        results = [results]
+
+    batch = [
+        _obb_to_polylines(
+            r, filled, confidence_thresh=confidence_thresh
+        )
+        for r in results
+    ]
+
+    if single:
+        return batch[0]
+
+    return batch
+
+
+def _obb_to_polylines(result,filled, confidence_thresh=None):
+    if result.obb is None:
+        return None
+    classes = np.rint(result.obb.cls.detach().cpu().numpy()).astype(int)
+    confs = result.obb.conf.detach().cpu().numpy().astype(float)
+    points = result.obb.xyxyxyxyn.detach().cpu().numpy()
+    polylines = []
+    for cls, _points, conf in zip(classes, points, confs):
+        if confidence_thresh is not None and conf < confidence_thresh:
+            continue
+
+        _points = [_points.astype(float)]
+
+        label = result.names[cls]
+
+        polyline = fol.Polyline(
+            label=label,
+            points=_points,
+            confidence=conf,
+            closed=True,
+            filled=filled,
+        )
+        polylines.append(polyline)
+    return fol.Polylines(polylines=polylines)
 
 def to_polylines(results, confidence_thresh=None, tolerance=2, filled=True):
     """Converts ``ultralytics.YOLO`` instance segmentations to FiftyOne format.
@@ -381,6 +438,26 @@ class FiftyOneYOLODetectionModel(FiftyOneYOLOModel):
         return self._format_predictions(predictions)
 
 
+class FiftyOneYOLOOBBConfig(FiftyOneYOLOModelConfig):
+    pass
+
+class FiftyOneYOLOOBBModel(FiftyOneYOLOModel):
+    """FiftyOne wrapper around an Ultralytics YOLO OBB detection model.
+
+    Args:
+        config: a :class:`FiftyOneYOLOConfig`
+    """
+
+    def _format_predictions(self, predictions):
+        return obb_to_polylines(predictions)
+
+    def predict_all(self, args):
+        images = [Image.fromarray(arg) for arg in args]
+        predictions = self.model(images, verbose=False)
+        return self._format_predictions(predictions)
+
+
+
 class FiftyOneYOLOSegmentationModelConfig(FiftyOneYOLOModelConfig):
     pass
 
@@ -425,6 +502,9 @@ def _convert_yolo_detection_model(model):
     config = FiftyOneYOLODetectionModelConfig({"model": model})
     return FiftyOneYOLODetectionModel(config)
 
+def _convert_yolo_obb_model(model):
+    config = FiftyOneYOLOOBBConfig({"model": model})
+    return FiftyOneYOLOOBBModel(config)
 
 def _convert_yolo_segmentation_model(model):
     config = FiftyOneYOLOSegmentationModelConfig({"model": model})


### PR DESCRIPTION
- Add YoloOBB class adapter
- Use obb attribute from OBB ultralytics model outputs to create 51 polyline label.

## What changes are proposed in this pull request?

Model outputs from OBB ultralytics models were ignored. This commit enables use of *apply_model* method on a 51 dataset. 

```python
import fiftyone as fo
import fiftyone.zoo as foz
from ultralytics import YOLO

model = YOLO('yolov8n-obb.pt')
dataset = foz.load_zoo_dataset(
    'coco-2017',
    split='validation',
)
fo.apply_model(dataset, model)
```

(Details)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced functionality to convert Ultralytics YOLO instance segmentations to FiftyOne format.
	- Added support for YOLO OBB detection models, including configuration and model handling enhancements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->