### PR TITLE
Lazily connect to database when needed

### DIFF
--- a/docs/generate_docs.bash
+++ b/docs/generate_docs.bash
@@ -125,7 +125,7 @@ fi
 
 echo "Building docs"
 # sphinx-build [OPTIONS] SOURCEDIR OUTPUTDIR [FILENAMES...]
-sphinx-build -M html source build $SPHINXOPTS
+_FIFTYONE_FORCE_DB_CONNECT_ON_IMPORT=1 sphinx-build -M html source build $SPHINXOPTS
 
 # Remove symlink to fiftyone-teams
 if [[ -n "${PATH_TO_TEAMS}" ]]; then

--- a/docs/generate_docs.bash
+++ b/docs/generate_docs.bash
@@ -125,7 +125,7 @@ fi
 
 echo "Building docs"
 # sphinx-build [OPTIONS] SOURCEDIR OUTPUTDIR [FILENAMES...]
-_FIFTYONE_FORCE_DB_CONNECT_ON_IMPORT=1 sphinx-build -M html source build $SPHINXOPTS
+sphinx-build -M html source build $SPHINXOPTS
 
 # Remove symlink to fiftyone-teams
 if [[ -n "${PATH_TO_TEAMS}" ]]; then

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -75,6 +75,7 @@ autodoc_default_options = {
     "inherited-members": True,
     "member-order": "bysource",
     "autosummary": True,
+    "exclude-members": "objects",
 }
 autodoc_inherit_docstrings = True
 autoclass_content = "class"

--- a/fiftyone/__init__.py
+++ b/fiftyone/__init__.py
@@ -7,8 +7,8 @@ See https://voxel51.com/fiftyone for more information.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 from pkgutil import extend_path as _extend_path
-import os as _os
 
 #
 # This statement allows multiple `fiftyone.XXX` packages to be installed in the

--- a/fiftyone/__init__.py
+++ b/fiftyone/__init__.py
@@ -26,8 +26,6 @@ from fiftyone.__public__ import *
 
 import fiftyone.core.logging as _fol
 
-_fol.init_logging()
-
 # The old way of doing things, migrating database on import. If we
 #   REALLY need to do this, for example doc build, we can.
 if (
@@ -37,3 +35,5 @@ if (
     import fiftyone.migrations as _fom
 
     _fom.migrate_database_if_necessary()
+
+_fol.init_logging()

--- a/fiftyone/__init__.py
+++ b/fiftyone/__init__.py
@@ -26,6 +26,8 @@ from fiftyone.__public__ import *
 
 import fiftyone.core.logging as _fol
 
+_fol.init_logging()
+
 # The old way of doing things, migrating database on import. If we
 #   REALLY need to do this, for example doc build, we can.
 if (
@@ -35,5 +37,3 @@ if (
     import fiftyone.migrations as _fom
 
     _fom.migrate_database_if_necessary()
-
-_fol.init_logging()

--- a/fiftyone/__init__.py
+++ b/fiftyone/__init__.py
@@ -25,9 +25,6 @@ __version__ = _foc.VERSION
 from fiftyone.__public__ import *
 
 import fiftyone.core.logging as _fol
-import fiftyone.migrations as _fom
+
 
 _fol.init_logging()
-
-if _os.environ.get("FIFTYONE_DISABLE_SERVICES", "0") != "1":
-    _fom.migrate_database_if_necessary()

--- a/fiftyone/__init__.py
+++ b/fiftyone/__init__.py
@@ -26,14 +26,5 @@ from fiftyone.__public__ import *
 
 import fiftyone.core.logging as _fol
 
-# The old way of doing things, migrating database on import. If we
-#   REALLY need to do this, for example doc build, we can.
-if (
-    _os.environ.get("FIFTYONE_DISABLE_SERVICES", "0") != "1"
-    and "_FIFTYONE_FORCE_DB_CONNECT_ON_IMPORT" in _os.environ
-):
-    import fiftyone.migrations as _fom
-
-    _fom.migrate_database_if_necessary()
 
 _fol.init_logging()

--- a/fiftyone/__init__.py
+++ b/fiftyone/__init__.py
@@ -26,5 +26,14 @@ from fiftyone.__public__ import *
 
 import fiftyone.core.logging as _fol
 
+# The old way of doing things, migrating database on import. If we
+#   REALLY need to do this, for example doc build, we can.
+if (
+    _os.environ.get("FIFTYONE_DISABLE_SERVICES", "0") != "1"
+    and "_FIFTYONE_FORCE_DB_CONNECT_ON_IMPORT" in _os.environ
+):
+    import fiftyone.migrations as _fom
+
+    _fom.migrate_database_if_necessary()
 
 _fol.init_logging()

--- a/fiftyone/__public__.py
+++ b/fiftyone/__public__.py
@@ -5,7 +5,6 @@ FiftyOne's public interface.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
-import os as _os
 
 import fiftyone.core.config as _foc
 
@@ -13,13 +12,6 @@ config = _foc.load_config()
 annotation_config = _foc.load_annotation_config()
 evaluation_config = _foc.load_evaluation_config()
 app_config = _foc.load_app_config()
-
-# The old way of doing things, connecting to database on import. If we
-#   REALLY need to do this, for example doc build, we can.
-if "_FIFTYONE_FORCE_DB_CONNECT_ON_IMPORT" in _os.environ:
-    import fiftyone.core.odm as _foo
-
-    _foo.establish_db_conn(config)
 
 from .core.aggregations import (
     Aggregation,

--- a/fiftyone/__public__.py
+++ b/fiftyone/__public__.py
@@ -7,14 +7,11 @@ FiftyOne's public interface.
 """
 
 import fiftyone.core.config as _foc
-import fiftyone.core.odm as _foo
 
 config = _foc.load_config()
 annotation_config = _foc.load_annotation_config()
 evaluation_config = _foc.load_evaluation_config()
 app_config = _foc.load_app_config()
-
-_foo.establish_db_conn(config)
 
 from .core.aggregations import (
     Aggregation,

--- a/fiftyone/__public__.py
+++ b/fiftyone/__public__.py
@@ -5,6 +5,7 @@ FiftyOne's public interface.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+import os as _os
 
 import fiftyone.core.config as _foc
 
@@ -12,6 +13,13 @@ config = _foc.load_config()
 annotation_config = _foc.load_annotation_config()
 evaluation_config = _foc.load_evaluation_config()
 app_config = _foc.load_app_config()
+
+# The old way of doing things, connecting to database on import. If we
+#   REALLY need to do this, for example doc build, we can.
+if "_FIFTYONE_FORCE_DB_CONNECT_ON_IMPORT" in _os.environ:
+    import fiftyone.core.odm as _foo
+
+    _foo.establish_db_conn(config)
 
 from .core.aggregations import (
     Aggregation,

--- a/fiftyone/core/odm/database.py
+++ b/fiftyone/core/odm/database.py
@@ -72,7 +72,8 @@ class DatabaseConfigDocument:
     type: str
 
     def __init__(self, conn, version=None, type=None, *args, **kwargs):
-        # Create our own __init__ so we can ignore extra kwargs
+        # Create our own __init__ so we can ignore extra kwargs / unknown
+        #   fields from other versions
         self._conn = conn
         self.version = version
         self.type = type

--- a/fiftyone/core/odm/database.py
+++ b/fiftyone/core/odm/database.py
@@ -27,7 +27,7 @@ import eta.core.utils as etau
 
 import fiftyone as fo
 import fiftyone.constants as foc
-import fiftyone.migrations as fom
+
 from fiftyone.core.config import FiftyOneConfigError
 import fiftyone.core.fields as fof
 import fiftyone.core.service as fos
@@ -35,6 +35,7 @@ import fiftyone.core.utils as fou
 
 from .document import Document
 
+fom = fou.lazy_import("fiftyone.migrations")
 foa = fou.lazy_import("fiftyone.core.annotation")
 fob = fou.lazy_import("fiftyone.core.brain")
 fod = fou.lazy_import("fiftyone.core.dataset")
@@ -228,7 +229,14 @@ def establish_db_conn(config):
             % (db_config.type, foc.CLIENT_TYPE)
         )
 
-    if os.environ.get("FIFTYONE_DISABLE_SERVICES", "0") != "1":
+    # Migrate the database if necessary after establishing connection.
+    #   If we are forcing immediate connection upon import though, migration
+    #   is being performed at that time, and we cannot do it here as well,
+    #   or else it'll be a circular import.
+    if (
+        os.environ.get("FIFTYONE_DISABLE_SERVICES", "0") != "1"
+        and "_FIFTYONE_FORCE_DB_CONNECT_ON_IMPORT" not in os.environ
+    ):
         fom.migrate_database_if_necessary()
 
 

--- a/fiftyone/core/odm/database.py
+++ b/fiftyone/core/odm/database.py
@@ -6,6 +6,7 @@ Database utilities.
 |
 """
 import atexit
+import dataclasses
 from datetime import datetime
 import logging
 from multiprocessing.pool import ThreadPool
@@ -15,7 +16,6 @@ import asyncio
 from bson import json_util, ObjectId
 from bson.codec_options import CodecOptions
 from mongoengine import connect
-import mongoengine.errors as moe
 import motor.motor_asyncio as mtr
 
 from packaging.version import Version
@@ -29,11 +29,8 @@ import fiftyone as fo
 import fiftyone.constants as foc
 import fiftyone.migrations as fom
 from fiftyone.core.config import FiftyOneConfigError
-import fiftyone.core.fields as fof
 import fiftyone.core.service as fos
 import fiftyone.core.utils as fou
-
-from .document import Document
 
 foa = fou.lazy_import("fiftyone.core.annotation")
 fob = fou.lazy_import("fiftyone.core.brain")
@@ -55,26 +52,35 @@ _db_service = None
 #
 # All past and future versions of FiftyOne must be able to deduce the
 # database's current version and type from the `config` collection without an
-# error being raised so that migrations can be properly run and, if necsssary,
+# error being raised so that migrations can be properly run and, if necessary,
 # informative errors can be raised alerting the user that they are using the
 # wrong version or type of client.
 #
 # This is currently guaranteed because:
 #   - `DatabaseConfigDocument` is declared as non-strict, so any past or future
 #     fields that are not currently defined will not cause an error
-#   - All declared fields are optional and we have promised ourselves that
+#   - All declared fields are optional, and we have promised ourselves that
 #     their type and meaning will never change
 #
 
 
-class DatabaseConfigDocument(Document):
+@dataclasses.dataclass(init=False)
+class DatabaseConfigDocument:
     """Backing document for the database config."""
 
-    # strict=False lets this class ignore unknown fields from other versions
-    meta = {"collection": "config", "strict": False}
+    version: str
+    type: str
 
-    version = fof.StringField()
-    type = fof.StringField()
+    def __init__(self, conn, version=None, type=None, *args, **kwargs):
+        # Create our own __init__ so we can ignore extra kwargs
+        self._conn = conn
+        self.version = version
+        self.type = type
+
+    def save(self):
+        self._conn.config.replace_one(
+            {}, dataclasses.asdict(self), upsert=True
+        )
 
 
 def get_db_config():
@@ -83,19 +89,18 @@ def get_db_config():
     Returns:
         a :class:`DatabaseConfigDocument`
     """
+    conn = get_db_conn()
     save = False
-
-    try:
-        # pylint: disable=no-member
-        config = DatabaseConfigDocument.objects.get()
-    except moe.DoesNotExist:
-        config = DatabaseConfigDocument()
+    config_docs = list(conn.config.find())
+    if not config_docs:
         save = True
-    except moe.MultipleObjectsReturned:
-        cleanup_multiple_config_docs()
-
-        # pylint: disable=no-member
-        config = DatabaseConfigDocument.objects.first()
+        config = DatabaseConfigDocument(conn)
+    elif len(config_docs) > 1:
+        config = DatabaseConfigDocument(
+            conn, **cleanup_multiple_config_docs(conn, config_docs)
+        )
+    else:
+        config = DatabaseConfigDocument(conn, **config_docs[0])
 
     if config.version is None:
         #
@@ -129,39 +134,25 @@ def get_db_config():
     return config
 
 
-def cleanup_multiple_config_docs():
+def cleanup_multiple_config_docs(conn, config_docs):
     """Internal utility that ensures that there is only one
     :class:`DatabaseConfigDocument` in the database.
     """
 
-    # We use mongoengine here because `get_db_conn()` will not currently work
-    # until `import fiftyone` succeeds, which requires a single config doc
-    # pylint: disable=no-member
-    docs = list(DatabaseConfigDocument.objects)
-    if len(docs) <= 1:
-        return
+    if not config_docs:
+        return {}
+    elif len(config_docs) <= 1:
+        return config_docs[0]
 
     logger.warning(
         "Unexpectedly found %d documents in the 'config' collection; assuming "
         "the one with latest 'version' is the correct one",
-        len(docs),
+        len(config_docs),
     )
+    keep_doc = max(config_docs, key=lambda d: Version(d.get("version", 0)))
 
-    versions = []
-    for doc in docs:
-        try:
-            versions.append((doc.id, Version(doc.version)))
-        except:
-            pass
-
-    try:
-        keep_id = max(versions, key=lambda kv: kv[1])[0]
-    except:
-        keep_id = docs[0].id
-
-    for doc in docs:
-        if doc.id != keep_id:
-            doc.delete()
+    conn.config.delete_many({"_id": {"$ne": keep_doc["_id"]}})
+    return keep_doc
 
 
 def establish_db_conn(config):
@@ -229,7 +220,7 @@ def establish_db_conn(config):
         )
 
     if os.environ.get("FIFTYONE_DISABLE_SERVICES", "0") != "1":
-        fom.migrate_database_if_necessary()
+        fom.migrate_database_if_necessary(config=db_config)
 
 
 def _connect():
@@ -375,6 +366,11 @@ async def _do_async_pooled_aggregate(collection, pipelines):
 
 async def _do_async_aggregate(collection, pipeline):
     return [i async for i in collection.aggregate(pipeline, allowDiskUse=True)]
+
+
+def ensure_connection():
+    """Ensures database connection exists"""
+    _connect()
 
 
 def get_db_client():

--- a/fiftyone/core/odm/database.py
+++ b/fiftyone/core/odm/database.py
@@ -27,7 +27,7 @@ import eta.core.utils as etau
 
 import fiftyone as fo
 import fiftyone.constants as foc
-
+import fiftyone.migrations as fom
 from fiftyone.core.config import FiftyOneConfigError
 import fiftyone.core.fields as fof
 import fiftyone.core.service as fos
@@ -35,7 +35,6 @@ import fiftyone.core.utils as fou
 
 from .document import Document
 
-fom = fou.lazy_import("fiftyone.migrations")
 foa = fou.lazy_import("fiftyone.core.annotation")
 fob = fou.lazy_import("fiftyone.core.brain")
 fod = fou.lazy_import("fiftyone.core.dataset")
@@ -229,14 +228,7 @@ def establish_db_conn(config):
             % (db_config.type, foc.CLIENT_TYPE)
         )
 
-    # Migrate the database if necessary after establishing connection.
-    #   If we are forcing immediate connection upon import though, migration
-    #   is being performed at that time, and we cannot do it here as well,
-    #   or else it'll be a circular import.
-    if (
-        os.environ.get("FIFTYONE_DISABLE_SERVICES", "0") != "1"
-        and "_FIFTYONE_FORCE_DB_CONNECT_ON_IMPORT" not in os.environ
-    ):
+    if os.environ.get("FIFTYONE_DISABLE_SERVICES", "0") != "1":
         fom.migrate_database_if_necessary()
 
 

--- a/fiftyone/core/odm/database.py
+++ b/fiftyone/core/odm/database.py
@@ -241,8 +241,8 @@ def _connect():
 
 
 def _async_connect(use_global=False):
-    # Regular connect here to ensure connection kwargs are established for
-    #   below.
+    # Regular connect here first, to ensure connection kwargs are established
+    #   for below.
     _connect()
 
     global _async_client

--- a/fiftyone/core/odm/database.py
+++ b/fiftyone/core/odm/database.py
@@ -149,7 +149,9 @@ def cleanup_multiple_config_docs(conn, config_docs):
         "the one with latest 'version' is the correct one",
         len(config_docs),
     )
-    keep_doc = max(config_docs, key=lambda d: Version(d.get("version", 0)))
+    # Keep config with latest version. If no version key, use 0.0 so it sorts
+    #   to the bottom.
+    keep_doc = max(config_docs, key=lambda d: Version(d.get("version", "0.0")))
 
     conn.config.delete_many({"_id": {"$ne": keep_doc["_id"]}})
     return keep_doc

--- a/fiftyone/core/odm/document.py
+++ b/fiftyone/core/odm/document.py
@@ -17,6 +17,7 @@ import eta.core.serial as etas
 
 import fiftyone.core.utils as fou
 
+from .database import ensure_connection
 from .utils import serialize_value, deserialize_value
 
 
@@ -644,6 +645,8 @@ class Document(BaseDocument, mongoengine.Document):
             raise mongoengine.InvalidDocumentError(
                 "Cannot save an abstract document"
             )
+
+        ensure_connection()
 
         if validate:
             self.validate(clean=clean)

--- a/fiftyone/factory/repo_factory.py
+++ b/fiftyone/factory/repo_factory.py
@@ -26,7 +26,6 @@ def _get_db():
 
 class RepositoryFactory(object):
     repos = {}
-    db = None
 
     @staticmethod
     def delegated_operation_repo() -> DelegatedOperationRepo:

--- a/fiftyone/factory/repo_factory.py
+++ b/fiftyone/factory/repo_factory.py
@@ -15,11 +15,19 @@ from fiftyone.factory.repos.delegated_operation import (
     MongoDelegatedOperationRepo,
 )
 
-db: Database = foo.get_db_conn()
+_db: Database = None
+
+
+def _get_db():
+    global _db
+    if _db is None:
+        _db = foo.get_db_conn()
+    return _db
 
 
 class RepositoryFactory(object):
     repos = {}
+    db = None
 
     @staticmethod
     def delegated_operation_repo() -> DelegatedOperationRepo:
@@ -30,7 +38,9 @@ class RepositoryFactory(object):
             RepositoryFactory.repos[
                 MongoDelegatedOperationRepo.COLLECTION_NAME
             ] = MongoDelegatedOperationRepo(
-                collection=db[MongoDelegatedOperationRepo.COLLECTION_NAME]
+                collection=_get_db()[
+                    MongoDelegatedOperationRepo.COLLECTION_NAME
+                ]
             )
 
         return RepositoryFactory.repos[

--- a/fiftyone/factory/repo_factory.py
+++ b/fiftyone/factory/repo_factory.py
@@ -5,10 +5,9 @@ FiftyOne repository factory.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
-import pymongo
+
 from pymongo.database import Database
 
-import fiftyone as fo
 import fiftyone.core.odm as foo
 from fiftyone.factory.repos.delegated_operation import (
     DelegatedOperationRepo,

--- a/fiftyone/migrations/runner.py
+++ b/fiftyone/migrations/runner.py
@@ -94,7 +94,9 @@ def migrate_all(destination=None, error_level=0, verbose=False):
         )
 
 
-def migrate_database_if_necessary(destination=None, verbose=False):
+def migrate_database_if_necessary(
+    destination=None, verbose=False, config=None
+):
     """Migrates the database to the specified revision, if necessary.
 
     If ``fiftyone.config.database_admin`` is ``False`` and no ``destination``
@@ -105,11 +107,14 @@ def migrate_database_if_necessary(destination=None, verbose=False):
         destination (None): the destination revision. By default, the
             ``fiftyone`` client version is used
         verbose (False): whether to log incremental migrations that are run
+        config (None): an optional :class:`DatabaseConfigDocument`. By default,
+            DB config is pulled from the database.
     """
     if _migrations_disabled():
         return
 
-    config = foo.get_db_config()
+    if config is None:
+        config = foo.get_db_config()
     head = config.version
 
     default_destination = destination is None

--- a/tests/no_wrapper/multiprocess_tests.py
+++ b/tests/no_wrapper/multiprocess_tests.py
@@ -15,14 +15,18 @@ import fiftyone.core.odm.database as food
 
 class MultiprocessTest(unittest.TestCase):
     def test_multiprocessing(self):
-        with multiprocessing.Pool(1, _check_process) as pool:
-            for _ in pool.imap(_check_process, [None]):
+        food.establish_db_conn(fo.config)
+        port = food._connection_kwargs["port"]
+        with multiprocessing.Pool(2, _check_process, [port]) as pool:
+            for _ in pool.imap(_check_process, [port, port]):
                 pass
 
 
-def _check_process(*args):
+def _check_process(port):
     assert "FIFTYONE_PRIVATE_DATABASE_PORT" in os.environ
-    port = os.environ["FIFTYONE_PRIVATE_DATABASE_PORT"]
+    env_port = os.environ["FIFTYONE_PRIVATE_DATABASE_PORT"]
+    assert port == int(env_port)
+    food.establish_db_conn(fo.config)
     assert int(port) == food._connection_kwargs["port"]
 
 

--- a/tests/unittests/plugins/secrets_tests.py
+++ b/tests/unittests/plugins/secrets_tests.py
@@ -88,6 +88,7 @@ class TestExecutionContext:
         )
         context._secrets = {}
         assert "MY_SECRET_KEY" not in context.secrets.keys()
+        _ = context.secrets["MY_SECRET_KEY"]
         assert "MY_SECRET_KEY" in context.secrets.keys()
         assert context.secrets["MY_SECRET_KEY"] == "mocked_sync_secret_value"
         assert context.secrets == context._secrets

--- a/tests/unittests/plugins/secrets_tests.py
+++ b/tests/unittests/plugins/secrets_tests.py
@@ -1,6 +1,6 @@
 import os
 import unittest
-from unittest.mock import MagicMock, Mock, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 

--- a/tests/unittests/plugins/secrets_tests.py
+++ b/tests/unittests/plugins/secrets_tests.py
@@ -74,7 +74,7 @@ class TestExecutionContext:
                 assert k in context._secrets
                 assert context._secrets[k] == v
                 assert context.secrets.get(k) == v
-        except Exception as e:
+        except Exception:
             pytest.fail(
                 "secrets proproperty items should be the same as _secrets items"
             )
@@ -88,7 +88,6 @@ class TestExecutionContext:
         )
         context._secrets = {}
         assert "MY_SECRET_KEY" not in context.secrets.keys()
-        secret_val = context.secrets["MY_SECRET_KEY"]
         assert "MY_SECRET_KEY" in context.secrets.keys()
         assert context.secrets["MY_SECRET_KEY"] == "mocked_sync_secret_value"
         assert context.secrets == context._secrets

--- a/tests/unittests/utils_tests.py
+++ b/tests/unittests/utils_tests.py
@@ -444,16 +444,14 @@ class ConfigTests(unittest.TestCase):
         orig_config = foo.get_db_config()
 
         # Add some duplicate documents
-        d = dict(orig_config.to_dict())
-        for _ in range(2):
-            d.pop("_id", None)
-            db.config.insert_one(d)
+        db.config.insert_one({"version": "0.14.4", "type": "fiftyone"})
+        db.config.insert_one({"version": "0.1.4", "type": "fiftyone"})
 
         # Ensure that duplicate documents are automatically cleaned up
         config = foo.get_db_config()
 
         self.assertEqual(len(list(db.config.aggregate([]))), 1)
-        self.assertEqual(config.id, orig_config.id)
+        self.assertEqual(config, orig_config)
 
 
 from bson import ObjectId


### PR DESCRIPTION
Closes #182
Closes #1964
Closes #1804 
Closes #3189 
## What changes are proposed in this pull request?

Lazily connect to database so you can import `fiftyone` without a database connection.
Most of the work was testing.

## How is this patch tested? If it is not, please explain why.

### Lazy connection testing
A sampling of things users might want to be able to do without connecting to a database
#### Version
BEFORE
```shell
$ FIFTYONE_DATABASE_URI=invalid.com:27017 fiftyone --version
...
Traceback (most recent call last):
  File "/Users/stuart/dev/fiftyone/fresh_venv/bin/fiftyone", line 5, in <module>
    from fiftyone.core.cli import main
  File "/Users/stuart/dev/fiftyone/fiftyone/__init__.py", line 25, in <module>
    from fiftyone.__public__ import *
  File "/Users/stuart/dev/fiftyone/fiftyone/__public__.py", line 17, in <module>
    _foo.establish_db_conn(config)
  File "/Users/stuart/dev/fiftyone/fiftyone/core/odm/database.py", line 216, in establish_db_conn
    _validate_db_version(config, _client)
  File "/Users/stuart/dev/fiftyone/fiftyone/core/odm/database.py", line 301, in _validate_db_version
    raise ConnectionError("Could not connect to `mongod`") from e
ConnectionError: Could not connect to `mongod`
```
AFTER
```shell
$FIFTYONE_DATABASE_URI=invalid.com:27017 fiftyone --version
FiftyOne v0.24.0, Voxel51, Inc.
```
#### Config
BEFORE
```shell
$FIFTYONE_DATABASE_URI=invalid.com:27017 fiftyone config
...
ConnectionError: Could not connect to `mongod`
```
AFTER
```shell
$FIFTYONE_DATABASE_URI=invalid.com:27017 fiftyone config
FiftyOne v0.24.0, Voxel51, Inc.
```
#### Zoo
BEFORE
```shell
$FIFTYONE_DATABASE_URI=invalid.com:27017 fiftyone zoo datasets download quickstart
...
ConnectionError: Could not connect to `mongod`
```

AFTER
```shell
$FIFTYONE_DATABASE_URI=invalid.com:27017 fiftyone zoo datasets download quickstart
Dataset already downloaded
```
#### Data model
BEFORE
```python
import fiftyone as fo

...
ConnectionError: Could not connect to `mongod`
```
AFTER
```python
import fiftyone as fo

test_sample = fo.Sample(
    "/path/to/sample.png",
    ground_truth=fo.Detections(
        detections=[
            fo.Detection(label="thing", bounding_box=[0.5, 0.5, 0.5, 0.5])
        ]
    ),
)
assert test_sample.ground_truth.detections[0].label == "thing"
```

#### Actually requires DB stuff
BOTH
```python
import fiftyone as fo

ds = fo.Dataset()

...
ConnectionError: Could not connect to `mongod`
```

### Correctness Testing
Made sure things still work for normal operation.
This is where I'll likely need some input / ideas.

Works with both database_uri set and mongodb spun up for me.
1. Unit tests pass
2. `fiftyone datasets list`
3. `fiftyone app launch` and launch app from shell
   1. Load dataset
   2. Manipulate view via session
   3. Save view
   4. Filter via sidebar
   5. Patches
   6. Compute/view embeddings+viz
   7. simple dataset-using operator (example_target_view)
4. Debug mode: run `server/main.py` and `yarn dev` separately
5. Make sure migration gets checked/run on first DB-usage also
6. mongoengine documents can be saved before other operations where connection established

Other
1. Spins up 1 mongodb which is shared by other fo's (that are using DB). And it's not killed until last user is done.

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

<pre>
Importing ``fiftyone`` doesn't attempt a database connection, rather it's deferred to when actually required.
</pre>

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Refactor**
	- Improved database migration process based on environment variable configuration.
	- Enhanced database connection management in the repository factory module.

- **Tests**
	- Optimized unit tests for plugin secrets management with streamlined code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->