### PR TITLE
fix sidebar group rename not persisting

### DIFF
--- a/app/packages/core/src/components/Sidebar/Entries/GroupEntries.tsx
+++ b/app/packages/core/src/components/Sidebar/Entries/GroupEntries.tsx
@@ -128,7 +128,7 @@ const GroupEntry = React.memo(
   }: GroupEntryProps) => {
     const [editing, setEditing] = useState(false);
     const [hovering, setHovering] = useState(false);
-    const ref = useRef<HTMLInputElement>();
+    const ref = useRef<HTMLInputElement>(null);
     const canCommit = useRef(false);
     const theme = useTheme();
     const notify = fos.useNotification();
@@ -286,10 +286,8 @@ interface PathGroupProps {
 export const PathGroupEntry = React.memo(
   ({ entryKey, name, modal, mutable = true, trigger }: PathGroupProps) => {
     const [expanded, setExpanded] = useShown(name, modal);
-
-    const renameGroup = useRenameGroup(modal, name);
-    const onDelete = !modal ? useDeleteGroup(modal, name) : null;
-    const empty = useRecoilValue(fos.groupIsEmpty({ modal, group: name }));
+    const renameGroup = useRenameGroup(!modal, name);
+    const onDelete = useDeleteGroup(!modal && mutable, name);
 
     return (
       <GroupEntry
@@ -297,8 +295,8 @@ export const PathGroupEntry = React.memo(
         title={name.toUpperCase()}
         expanded={expanded}
         onClick={() => setExpanded(!expanded)}
-        setValue={modal || !mutable ? null : (value) => renameGroup(value)}
-        onDelete={!empty ? null : onDelete}
+        setValue={renameGroup}
+        onDelete={onDelete}
         pills={
           <Pills
             entries={[

--- a/app/packages/core/src/components/Sidebar/Entries/GroupEntries.tsx
+++ b/app/packages/core/src/components/Sidebar/Entries/GroupEntries.tsx
@@ -131,6 +131,7 @@ const GroupEntry = React.memo(
     const ref = useRef<HTMLInputElement>();
     const canCommit = useRef(false);
     const theme = useTheme();
+    const notify = fos.useNotification();
 
     return (
       <div
@@ -175,20 +176,28 @@ const GroupEntry = React.memo(
                 }}
                 defaultValue={title}
                 onKeyDown={(event) => {
+                  const inputElem = event.target as HTMLInputElement;
+                  const updatedTitle = inputElem.value;
+                  const unchanged = updatedTitle === title;
                   if (event.key === "Enter") {
-                    setValue(event.target.value).then((success) => {
+                    if (unchanged) {
+                      return inputElem.blur();
+                    }
+                    setValue?.(updatedTitle).then((success) => {
                       if (!success) {
-                        event.target.value = title;
+                        inputElem.value = title;
+                        notify({
+                          msg: "Failed to rename the group",
+                          variant: "error",
+                        });
                       }
-
-                      setEditing(false);
-                      event.target.blur();
+                      inputElem.blur();
                     });
 
                     return;
                   }
                   if (event.key === "Escape") {
-                    event.target.blur();
+                    inputElem.blur();
                   }
                 }}
                 onFocus={() => !editing && setEditing(true)}

--- a/app/packages/state/src/hooks/useGroupEntries.ts
+++ b/app/packages/state/src/hooks/useGroupEntries.ts
@@ -37,9 +37,10 @@ export const useRenameGroup = (modal: boolean, group: string) => {
         set(fos.sidebarGroupsDefinition(modal), newGroups);
         !modal &&
           fos.persistSidebarGroups({
-            dataset: await snapshot.getPromise(datasetName),
+            dataset: await snapshot.getPromise(fos.datasetName),
             stages: view,
             sidebarGroups: newGroups,
+            subscription: await snapshot.getPromise(fos.stateSubscription),
           });
         return true;
       },


### PR DESCRIPTION
## What changes are proposed in this pull request?

In the app, renaming sidebar is not persisted

## How is this patch tested? If it is not, please explain why.

Using the sidebar rename UI in the app

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

Fixed sidebar group renaming not being presited

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced notification functionality for better user feedback during group renaming in the sidebar.

- **Refactor**
	- Enhanced logic to prevent unnecessary updates for unchanged group titles.
	- Improved error handling for a smoother user experience during group renaming operations.

- **Bug Fixes**
	- Fixed an issue with group renaming by updating parameter handling for better data consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->