### PR TITLE
fix saved view selector covering expanded view stage popover

### DIFF
--- a/app/packages/components/src/components/Selection/Selection.tsx
+++ b/app/packages/components/src/components/Selection/Selection.tsx
@@ -114,7 +114,6 @@ export default function Selection(props: SelectionProps) {
         defaultValue={selectedId}
         sx={{
           width: "100%",
-          zIndex: 999,
           background: theme.background.level3,
         }}
         renderValue={() => {

--- a/e2e-pw/src/oss/poms/saved-views.ts
+++ b/e2e-pw/src/oss/poms/saved-views.ts
@@ -143,7 +143,8 @@ export class SavedViewsPom {
   }
 
   async openSelect() {
-    await this.selector().click({ timeout: 2000 });
+    // need to force click otherwise intercepted by material-ui backdrop
+    await this.selector().click({ timeout: 2000, force: true });
   }
 
   async openCreateModal() {

--- a/e2e-pw/src/oss/specs/smoke-tests/saved-views.spec.ts
+++ b/e2e-pw/src/oss/specs/smoke-tests/saved-views.spec.ts
@@ -275,6 +275,7 @@ test.describe("saved views", () => {
       updatedView2.color
     );
 
+    await savedViews.openSelect();
     await savedViews.clickEdit(updatedView2.slug);
     await savedViews.assert.verifyInputUpdated(updatedView2);
   });


### PR DESCRIPTION
## What changes are proposed in this pull request?

fix saved view selector covering expanded view stage popover

## How is this patch tested? If it is not, please explain why.

Using the view bar in the app

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

fix saved view selector covering expanded view stage popover

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved the visual layering of the `Selection` component by adjusting its style properties.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->