### PR TITLE
fix proxy port in e2e devserver

### DIFF
--- a/app/packages/app/vite.config.ts
+++ b/app/packages/app/vite.config.ts
@@ -6,6 +6,10 @@ import { basePlugins } from "../../vite.base.config";
 
 async function loadConfig() {
   const pluginRewriteAll = (await import("vite-plugin-rewrite-all")).default;
+  const serverPort =
+    process.env.FIFTYONE_SERVER_PORT ??
+    process.env.FIFTYONE_DEFAULT_APP_PORT ??
+    "5151";
 
   return defineConfig({
     base: "",
@@ -38,17 +42,13 @@ async function loadConfig() {
       port: parseInt(process.env.FIFTYONE_DEFAULT_APP_PORT || "5173"),
       proxy: {
         "/plugins": {
-          target: `http://127.0.0.1:${
-            process.env.FIFTYONE_DEFAULT_APP_PORT ?? "5151"
-          }`,
+          target: `http://127.0.0.1:${serverPort}`,
           changeOrigin: false,
           secure: false,
           ws: false,
         },
         "/aggregate": {
-          target: `http://127.0.0.1:${
-            process.env.FIFTYONE_DEFAULT_APP_PORT ?? "5151"
-          }`,
+          target: `http://127.0.0.1:${serverPort}`,
           changeOrigin: false,
           secure: false,
           ws: false,

--- a/app/packages/core/vite.config.ts
+++ b/app/packages/core/vite.config.ts
@@ -4,6 +4,11 @@ import { defineConfig } from "vite";
 import relay from "vite-plugin-relay";
 
 export default defineConfig(({ mode }) => {
+  const serverPort =
+    process.env.FIFTYONE_SERVER_PORT ??
+    process.env.FIFTYONE_DEFAULT_APP_PORT ??
+    "5151";
+
   return {
     base: mode === "desktop" ? "" : "/",
     plugins: [
@@ -16,17 +21,13 @@ export default defineConfig(({ mode }) => {
     server: {
       proxy: {
         "/plugins": {
-          target: `http://localhost:${
-            process.env.FIFTYONE_DEFAULT_APP_PORT ?? "5151"
-          }`,
+          target: `http://localhost:${serverPort}`,
           changeOrigin: false,
           secure: false,
           ws: false,
         },
         "/aggregate": {
-          target: `http://localhost:${
-            process.env.FIFTYONE_DEFAULT_APP_PORT ?? "5151"
-          }`,
+          target: `http://localhost:${serverPort}`,
           changeOrigin: false,
           secure: false,
           ws: false,

--- a/e2e-pw/package.json
+++ b/e2e-pw/package.json
@@ -28,6 +28,6 @@
         "build-linux-screenshot-docker-image": "./scripts/generate-screenshots-docker-image/build-docker-image.sh",
         "e2e:ui": "npx playwright test --ui -c playwright.config.ts",
         "e2e": "playwright test -c playwright.config.ts",
-        "devserver": "export VITE_API=http://localhost:8787 VITE_NO_STATE=true FIFTYONE_DEFAULT_APP_PORT=5193 && (cd ../app && yarn dev --host 0.0.0.0)"
+        "devserver": "export VITE_API=http://localhost:8787 FIFTYONE_SERVER_PORT=8787 VITE_NO_STATE=true FIFTYONE_DEFAULT_APP_PORT=5193 && (cd ../app && yarn dev --host 0.0.0.0)"
     }
 }


### PR DESCRIPTION
## What changes are proposed in this pull request?

In E2E devserver, proxied endpoint are pointing back to self and timing out

## How is this patch tested? If it is not, please explain why.

Using devserver and e2e tests locally

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a default server port configuration, enhancing the flexibility and ease of setup for the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->