### PR TITLE
Support Labelbox v2 export APIs and formats

### DIFF
--- a/docs/source/integrations/labelbox.rst
+++ b/docs/source/integrations/labelbox.rst
@@ -743,7 +743,7 @@ The meaning of the `mutable` attribute is defined as follows:
 -   `True` (default): the attribute is dynamic and can have a different value
     for every frame in which the object track appears
 -   `False`: the attribute is static and is the same for every frame in which
-    the object track appears
+    the object track appears (**Not yet supported**)
 
 .. _labelbox-loading-annotations:
 

--- a/docs/source/integrations/labelbox.rst
+++ b/docs/source/integrations/labelbox.rst
@@ -487,6 +487,8 @@ can also be provided:
     top level of the editor (False) or whether to show the label field at the
     top level and annotate the class as a required attribute of each object
     (True)
+-   **export_version** (*"v2"*): the Labelbox export format and API version to
+    use. Suppoted values are `("v1", "v2")`
 
 .. note::
 
@@ -680,8 +682,6 @@ For Labelbox, the following `type` values are supported:
 -   `text`: a free-form text box. In this case, `values` is unused
 -   `radio`: a radio button list UI. In this case, `values` is required
 -   `checkbox`: a list of checkboxes. In this case, `values` is required
-
-(The `select` type has been deprecated and removed by Labelbox)
 
 When you are annotating existing label fields, the `attributes` parameter can
 take additional values:
@@ -1481,10 +1481,6 @@ or
 methods to delete specific Labelbox project(s) associated with an annotation
 run.
 
-Note that if setting `delete_batches=True` when deleting projects, then the
-corresponding datarows will no longer be deleted from Labelbox since the
-transition to Labelbox export v2.
-
 .. code:: python
     :linenos:
 
@@ -1522,3 +1518,9 @@ transition to Labelbox export v2.
     # Delete all projects and datasets from your Labelbox account
     api.delete_projects(project_ids)
     api.delete_datasets(dataset_ids)
+
+.. note::
+
+    Note that passing `delete_batches=True` when deleting projects will not
+    delete the corresponding data rows from Labelbox when using the V2 export
+    API (the default).

--- a/docs/source/integrations/labelbox.rst
+++ b/docs/source/integrations/labelbox.rst
@@ -488,7 +488,7 @@ can also be provided:
     top level and annotate the class as a required attribute of each object
     (True)
 -   **export_version** (*"v2"*): the Labelbox export format and API version to
-    use. Suppoted values are `("v1", "v2")`
+    use. Supported values are `("v1", "v2")`
 
 .. note::
 

--- a/fiftyone/utils/annotations.py
+++ b/fiftyone/utils/annotations.py
@@ -2279,7 +2279,7 @@ class AnnotationAPI(object):
             prefix = "FIFTYONE_%s_" % backend.upper()
             logger.info(
                 "Please enter your API key.\nYou can avoid this in the future "
-                "by setting your `%sKEY` environment variable",
+                "by setting your `%sAPI_KEY` environment variable",
                 prefix,
             )
 

--- a/fiftyone/utils/labelbox.py
+++ b/fiftyone/utils/labelbox.py
@@ -2146,7 +2146,9 @@ class _FiftyOneToLabelboxConverterBase(object):
         if isinstance(label, fol.Classification):
             label_ids = [label.id]
         elif isinstance(label, fol.Classifications):
-            label_ids = [l.id for l in label.classifications]
+            label_ids = [
+                classification.id for classification in label.classifications
+            ]
         else:
             label_ids = []
 

--- a/fiftyone/utils/labelbox.py
+++ b/fiftyone/utils/labelbox.py
@@ -2667,7 +2667,7 @@ class _LabelboxExportToFiftyOneConverterV1(object):
                         )
                         warnings.warn(msg)
                 else:
-                    # Segementations are later loaded as either fo.Segmentation
+                    # Segmentations are later loaded as either fo.Segmentation
                     # or fo.Detection instances once the label schema of the
                     # annotation task is available
                     current_mask_instance_uri = cls._get_mask_url(od)

--- a/fiftyone/utils/labelbox.py
+++ b/fiftyone/utils/labelbox.py
@@ -73,7 +73,7 @@ class LabelboxBackendConfig(foua.AnnotationBackendConfig):
             the top level and annotate the class as a required attribute of
             each object (True)
         export_version ("v2"): the Labelbox export format and API version to
-            use. Suppoted values are ``("v1", "v2")``
+            use. Supported values are ``("v1", "v2")``
     """
 
     def __init__(
@@ -228,7 +228,7 @@ class LabelboxAnnotationAPI(foua.AnnotationAPI):
         url: url of the Labelbox server
         api_key (None): the Labelbox API key
         export_version ("v2"): the Labelbox export format and API version to
-            use. Suppoted values are ``("v1", "v2")``
+            use. Supported values are ``("v1", "v2")``
     """
 
     def __init__(
@@ -1889,7 +1889,7 @@ def download_labels_from_labelbox(
         labelbox_project: a ``labelbox.schema.project.Project``
         outpath (None): the path to write the JSON export on disk
         export_version ("v2"): the Labelbox export format and API version to
-            use. Suppoted values are ``("v1", "v2")``
+            use. Supported values are ``("v1", "v2")``
 
     Returns:
         ``None`` if an ``outpath`` is provided, or the loaded JSON itself if no

--- a/fiftyone/utils/labelbox.py
+++ b/fiftyone/utils/labelbox.py
@@ -2617,7 +2617,7 @@ class _LabelboxExportToFiftyOneConverterV1(object):
                 polyline = fol.Polyline(
                     label=label,
                     points=[points],
-                    closed=True,
+                    closed=False,
                     filled=False,
                     **attributes,
                 )

--- a/tests/intensive/labelbox_tests.py
+++ b/tests/intensive/labelbox_tests.py
@@ -20,6 +20,31 @@ import fiftyone.zoo as foz
 import fiftyone.utils.labelbox as foul
 
 
+_anno_key = "anno_key"
+
+
+def _image_dataset(dataset_name):
+    dataset = foz.load_zoo_dataset(
+        "quickstart",
+        max_samples=3,
+        dataset_name=dataset_name,
+        drop_existing_dataset=True,
+    )
+    dataset.persistent = True
+    return dataset
+
+
+def _video_dataset(dataset_name):
+    dataset = foz.load_zoo_dataset(
+        "quickstart-video",
+        max_samples=1,
+        dataset_name=dataset_name,
+        drop_existing_dataset=True,
+    )
+    dataset.persistent = True
+    return dataset
+
+
 def test_labelbox_image():
     # Image dataset
     dataset = foz.load_zoo_dataset(
@@ -35,6 +60,155 @@ def test_labelbox_image():
     ]
 
     _test_labelbox_image(dataset, label_field)
+
+
+_image_dataset_name = "qs-lb-image"
+
+
+def test_labelbox_launch_image_base():
+    # Image dataset, single detections field
+
+    dataset = _image_dataset(_image_dataset_name)
+
+    label_schema = {
+        "new_field": {
+            "type": "detections",
+            "classes": ["dog", "cat"],
+            "attributes": {
+                "test": {
+                    "type": "checkbox",
+                    "values": ["testattr", "testattr2"],
+                }
+            },
+        }
+    }
+
+    results = dataset.annotate(
+        _anno_key,
+        label_schema=label_schema,
+        backend="labelbox",
+        launch_editor=True,
+    )
+
+
+def test_labelbox_load_image_base():
+    dataset = fo.load_dataset(_image_dataset_name)
+    dataset.load_annotations(_anno_key)
+
+
+_image_instance_segs_dataset_name = "qs-lb-image-segs"
+
+
+def test_labelbox_launch_image_instance_segs():
+    # Image dataset, instance segmentations and classifications, attributes dict from doc
+
+    dataset = _image_dataset(_image_instance_segs_dataset_name)
+
+    label_schema = {
+        "segs": {
+            "type": "instances",
+            "classes": ["c1", "c2"],
+            "attributes": ["attr1", "attr2"],
+        },
+        "classifications": {
+            "type": "classifications",
+            "classes": ["ccc1", "ccc2", "ccc3"],
+            "attributes": {
+                "occluded": {
+                    "type": "radio",
+                    "values": [True, False],
+                },
+                "weather": {
+                    "type": "select",
+                    "values": ["cloudy", "sunny", "overcast"],
+                },
+                "caption": {
+                    "type": "text",
+                },
+            },
+        },
+    }
+
+    results = dataset.annotate(
+        _anno_key,
+        label_schema=label_schema,
+        backend="labelbox",
+        launch_editor=True,
+    )
+
+
+def test_labelbox_load_image_instance_segs():
+    dataset = fo.load_dataset(_image_instance_segs_dataset_name)
+    dataset.load_annotations(_anno_key, cleanup=True)
+
+
+_image_polylines_dataset_name = "qs-lb-image-polylines"
+
+
+def test_labelbox_launch_image_polylines():
+    # Image dataset, polylines, classes_as_attrs, project_name
+
+    dataset = _image_dataset(_image_polylines_dataset_name)
+
+    attributes = {
+        "radio": {
+            "type": "radio",
+            "values": [1, 2, 3],
+        }
+    }
+
+    results = dataset.annotate(
+        _anno_key,
+        label_field="polylines",
+        label_type="polylines",
+        classes=["p0", "p1", "p2", "p3"],
+        attributes=attributes,
+        backend="labelbox",
+        classes_as_attrs=False,
+        project_name="proj_polylines",
+        launch_editor=True,
+    )
+
+
+def test_labelbox_load_image_polylines():
+    dataset = fo.load_dataset(_image_polylines_dataset_name)
+    dataset.load_annotations(_anno_key, cleanup=True)
+
+
+_video_dataset_name = "qs-lb-video"
+
+
+def test_labelbox_launch_video_base():
+    # Video dataset, doc example video label attributes
+
+    dataset = _video_dataset(_video_dataset_name)
+
+    attributes = {
+        "type": {
+            "type": "select",
+            "values": ["sedan", "suv", "truck"],
+            "mutable": False,
+        },
+        "occluded": {
+            "type": "radio",
+            "values": [True, False],
+            "mutable": True,
+        },
+    }
+
+    dataset.annotate(
+        _anno_key,
+        backend="labelbox",
+        label_field="frames.new_field",
+        label_type="detections",
+        classes=["vehicle"],
+        attributes=attributes,
+    )
+
+
+def test_labelbox_load_video_base():
+    dataset = fo.load_dataset(_video_dataset_name)
+    dataset.load_annotations(_anno_key, cleanup=True)
 
 
 def test_labelbox_video_objects():


### PR DESCRIPTION
At the end of April 2024, Labelbox is removing support for their v1 exports which the FiftyOne integration utilized: https://docs.labelbox.com/docs/migration-guide-export-v1-to-export-v2

This PR adds support to the v2 export format and API. Specifically, the main changes include:
* Removal of `project.export_labels()`
* Removal of `batch.export_data_rows()`
* Support for parsing v2 formatted label exports
     * This specifically was done by reformatting much of the code that converts Labelbox label formats to FiftyOne label formats. Adding the relevant methods into `_LabelboxExportToFiftyOneConverterV1` and `_LabelboxExportToFiftyOneConverterV2`
     * It also created the `_FiftyOneToLabelboxExportConverterV1` that converts FiftyOne to Labelbox labels, but the v2 of this was not implemented since the integration doesn't support uploading labels from FiftyOne to Labelbox anyway
         * The only methods where this is relevant are the utilities `import_from_labelbox`, `export_to_labelbox`, and `convert_labelbox_export_to_import`, but for now these just have a deprecation warning added to them since they are not part of the core integration.


To test:
* Go to app.labelbox.com and create an account/sign in
* Create a labelbox API key through their App
* `export FIFTYONE_LABELBOX_API_KEY=...` and `pip install labelbox`
* Test the integration:
```python
import fiftyone.zoo as foz

dataset = foz.load_zoo_dataset("quickstart", max_samples=3).clone()
label_schema = {
    "new_field": {
        "type": "detections", 
        "classes": ["dog", "cat"],
        "attributes": {"test": {"type": "checkbox", "values": ["testattr"]}},
    }
}
results = dataset.annotate(
    "anno_key",
    label_schema=label_schema,
    backend="labelbox",
    launch_editor=True,
)

# Edit in Labelbox

dataset.load_annotations("anno_key", cleanup=True)
```

This was tested by manually running through the examples in [the integration docs](https://docs.voxel51.com/integrations/labelbox.html) as well as testing other edge cases. Found and fixed an additional issue with the `select` attribute type having been deprecated.
I also ran into [this bug](https://github.com/voxel51/fiftyone/issues/4255) which can be fixed in a follow up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Documentation**
	- Updated integration guide for Labelbox: removed note about using Model Assisted Labeling with a paid Labelbox account, changed attribute types from `select` to `checkbox` and `radio`.
	- Added information on editing existing labels, and clarified instructions on deleting projects and datasets in Labelbox.

- **Bug Fixes**
	- Corrected the environment variable name in the API key setup prompt message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->