### PR TITLE
Fix App modal tags in 'group' stats mode

### DIFF
--- a/app/packages/state/src/recoil/aggregations.test.ts
+++ b/app/packages/state/src/recoil/aggregations.test.ts
@@ -29,6 +29,7 @@ describe("test aggregation path accumulation", () => {
       groupId: "groupId",
     });
     expect(testModalSampleAggregationPaths()).toStrictEqual([
+      "tags",
       "ground_truth.detections",
       "ground_truth.detections.one",
       "ground_truth.detections.two",

--- a/app/packages/state/src/recoil/aggregations.ts
+++ b/app/packages/state/src/recoil/aggregations.ts
@@ -182,7 +182,8 @@ export const modalAggregationPaths = selectorFamily({
       ).map((path) => get(schemaAtoms.expandPath(path)));
 
       // separate frames path requests and sample path requests
-      let paths = frames.some((p) => params.path.startsWith(p))
+      const isFramesPath = frames.some((p) => params.path.startsWith(p));
+      let paths = isFramesPath
         ? frames
         : get(schemaAtoms.labelFields({ space: State.SPACE.SAMPLE })).map(
             (path) => get(schemaAtoms.expandPath(path))
@@ -195,10 +196,17 @@ export const modalAggregationPaths = selectorFamily({
 
       const numeric = get(schemaAtoms.isNumericField(params.path));
       if (params.mixed || get(groupId)) {
-        paths = paths.filter((p) => {
-          const n = get(schemaAtoms.isNumericField(p));
-          return numeric ? n : !n;
-        });
+        paths = [
+          ...paths.filter((p) => {
+            const n = get(schemaAtoms.isNumericField(p));
+            return numeric ? n : !n;
+          }),
+        ];
+
+        if (!numeric && !isFramesPath) {
+          // the modal currently requires a 'tags' aggregation
+          paths = ["tags", ...paths];
+        }
       }
 
       return paths;


### PR DESCRIPTION
## What changes are proposed in this pull request?

Fixes a regression from #4182 

`release/v0.23.8`

https://github.com/voxel51/fiftyone/assets/19821840/30ddaf9e-f6c6-4741-b5f2-0d87b06bae4e

`bugfix/modal-tags-aggregation`

https://github.com/voxel51/fiftyone/assets/19821840/8a28ec3a-3411-410a-adbe-a9d3903f71bd

## How is this patch tested? If it is not, please explain why.

Amended recoil test

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other

