### PR TITLE
add option to auto-execute operator on params change

### DIFF
--- a/app/packages/operators/src/constants.ts
+++ b/app/packages/operators/src/constants.ts
@@ -13,3 +13,5 @@ export enum QueueItemStatus {
   Completed,
   Failed,
 }
+export const REMOTE_OPERATOR_DEFAULT_AUTO_EXECUTE_DELAY = 1000;
+export const LOCAL_OPERATOR_DEFAULT_AUTO_EXECUTE_DELAY = 250;

--- a/app/packages/operators/src/utils.ts
+++ b/app/packages/operators/src/utils.ts
@@ -71,6 +71,11 @@ export function getOperatorPromptConfigs(operatorPrompt: OperatorPromptType) {
     cancelButtonText = "Close";
   }
 
+  if (operatorPrompt.autoExecuteOnChange) {
+    onSubmit = undefined;
+    onCancel = undefined;
+  }
+
   const title = getPromptTitle(operatorPrompt);
   const hasValidationErrors = operatorPrompt.validationErrors?.length > 0;
   const { resolving, pendingResolve } = operatorPrompt;

--- a/fiftyone/operators/types.py
+++ b/fiftyone/operators/types.py
@@ -1647,6 +1647,8 @@ class PromptView(View):
         label (None): the title for the prompt
         submit_button_label (None): the label for the submit button
         cancel_button_label (None): the label for the cancel button
+        auto_execute (False): whether to automatically execute the operator on params change
+        auto_execute_delay (1000): delay in milliseconds before auto-executing the operator
     """
 
     def __init__(self, **kwargs):
@@ -1771,6 +1773,11 @@ class DrawerView(View):
         return types.Property(inputs, view=prompt)
 
     Args:
+        label (None): the title for the prompt
+        submit_button_label (None): the label for the submit button
+        cancel_button_label (None): the label for the cancel button
+        auto_execute (False): whether to automatically execute the operator on params change
+        auto_execute_delay (1000): delay in milliseconds before auto-executing the operator
         placement (None): the placement of the drawer. Can be one of the
             following
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

Add support for `auto_execute`. When set to `True`, the operator will automatically execute when an operator prompt input change

## How is this patch tested? If it is not, please explain why.

### Usage

```py
class LiveSavedView(foo.Operator):
    @property
    def config(self):
        return foo.OperatorConfig(
            name="playground_py_live_saved_view",
            label="Playground_Py: Live Saved View",
        )

    def resolve_input(self, ctx):
        inputs = types.Object()
        inputs.enum("saved_view", ctx.dataset.list_saved_views(), label="Saved View")
        return types.Property(
            inputs,
            view=types.DrawerView(
                auto_execute=True, auto_execute_delay=250, placement="left"
            ),
        )

    def execute(self, ctx):
        saved_view = ctx.params.get("saved_view", None)
        if saved_view:
            ctx.ops.set_view(name=saved_view)
        return {}
```

### Preview

https://github.com/voxel51/fiftyone/assets/25350704/0270018c-e98e-4dec-87c8-fb51ada19247


## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

Add support for `execute_on_change`. When set to `True`, the operator will automatically execute when a operator prompt input change 

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced auto-execution delay settings for operators, allowing for customized execution timing.
  
- **Improvements**
  - Enhanced operator prompt logic to support auto-execution based on new delay settings.
  
- **Bug Fixes**
  - Improved handling of operator prompts to ensure correct behavior when auto-execution is enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->