### PR TITLE
Remove suspend from 3D viewer during modal navigation

### DIFF
--- a/app/packages/core/src/components/Modal/Modal.tsx
+++ b/app/packages/core/src/components/Modal/Modal.tsx
@@ -66,8 +66,6 @@ const SampleModal = () => {
   const isGroup = useRecoilValue(fos.isGroup);
   const isPcd = useRecoilValue(fos.isPointcloudDataset);
   const is3D = useRecoilValue(fos.is3DDataset);
-  const sampleId = useRecoilValue(fos.currentSampleId);
-
   const clearModal = fos.useClearModal();
   const { jsonPanel, helpPanel, onNavigate } = usePanels();
   const tooltip = fos.useTooltip();
@@ -92,9 +90,6 @@ const SampleModal = () => {
     [eventHandler]
   );
 
-  const noneValuedPaths = useRecoilValue(fos.noneValuedPaths)?.[sampleId];
-  const hideNoneFields = useRecoilValue(fos.hideNoneValuedFields);
-
   const renderEntry = useCallback(
     (
       key: string,
@@ -115,10 +110,6 @@ const SampleModal = () => {
           const isOther = disabled.has(entry.path);
           const isFieldPrimitive =
             !isLabelTag && !isLabel && !isOther && !(isTag && mode === "group");
-
-          if (hideNoneFields && noneValuedPaths?.has(entry?.path)) {
-            return { children: null };
-          }
 
           return {
             children: (
@@ -189,7 +180,7 @@ const SampleModal = () => {
           throw new Error("invalid entry");
       }
     },
-    [disabled, hideNoneFields, labelPaths, mode, noneValuedPaths]
+    [disabled, labelPaths, mode]
   );
 
   useEffect(() => {

--- a/app/packages/core/src/components/Sidebar/Entries/PathValueEntry.tsx
+++ b/app/packages/core/src/components/Sidebar/Entries/PathValueEntry.tsx
@@ -3,8 +3,6 @@ import * as fos from "@fiftyone/state";
 import {
   DATE_FIELD,
   DATE_TIME_FIELD,
-  DYNAMIC_EMBEDDED_DOCUMENT_FIELD,
-  EMBEDDED_DOCUMENT_FIELD,
   formatDate,
   formatDateTime,
   FRAME_SUPPORT_FIELD,
@@ -12,12 +10,7 @@ import {
 import { KeyboardArrowDown, KeyboardArrowUp } from "@mui/icons-material";
 import { useSpring } from "@react-spring/core";
 import React, { Suspense, useMemo, useState } from "react";
-import {
-  selectorFamily,
-  useRecoilState,
-  useRecoilValue,
-  useRecoilValueLoadable,
-} from "recoil";
+import { selectorFamily, useRecoilValue, useRecoilValueLoadable } from "recoil";
 import styled from "styled-components";
 import LoadingDots from "../../../../../components/src/components/Loading/LoadingDots";
 import { prettify } from "../../../utils/generic";
@@ -314,7 +307,7 @@ const SlicesLoadable = ({ path }: { path: string }) => {
   );
 };
 
-const useSlicesData = <T extends unknown>(path: string) => {
+const useSlicesData = <T,>(path: string) => {
   const keys = path.split(".");
   const loadable = useRecoilValueLoadable(fos.activePcdSlicesToSampleMap);
   const slices = Array.from(useRecoilValue(fos.activePcdSlices) || []).sort();
@@ -328,14 +321,14 @@ const useSlicesData = <T extends unknown>(path: string) => {
   }
 
   if (!slices.every((slice) => loadable.contents[slice])) {
-    throw new Promise(() => {});
+    throw new Promise(() => null);
   }
 
-  const data = { ...loadable.contents };
+  const data = { ...loadable.contents } as object;
 
   const target = useRecoilValue(fos.field(keys[0]));
   slices.forEach((slice) => {
-    let sliceData = data[slice].sample;
+    let sliceData = data[slice].sample as object;
     let field = target;
 
     for (let index = 0; index < keys.length; index++) {
@@ -346,7 +339,7 @@ const useSlicesData = <T extends unknown>(path: string) => {
       sliceData = sliceData[field?.dbField || key];
 
       if (keys[index + 1]) {
-        field = field?.fields[keys[index + 1]];
+        field = field?.fields?.[keys[index + 1]] ?? null;
       }
     }
     data[slice] = sliceData;
@@ -374,25 +367,9 @@ const Loadable = ({ path }: { path: string }) => {
   );
 };
 
-const isOfDocumentFieldList = selectorFamily({
-  key: "isOfDocumentField",
-  get:
-    (path: string) =>
-    ({ get }) => {
-      const field = get(fos.field(path.split(".")[0]));
-
-      return [
-        DYNAMIC_EMBEDDED_DOCUMENT_FIELD,
-        EMBEDDED_DOCUMENT_FIELD,
-      ].includes(field?.subfield || "");
-    },
-});
-
 const useData = <T,>(path: string): T => {
   const keys = path.split(".");
   const loadable = useRecoilValueLoadable(fos.activeModalSidebarSample);
-  const [noneValuedPaths, setNoneValued] = useRecoilState(fos.noneValuedPaths);
-  const sampleId = useRecoilValue(fos.currentSampleId);
 
   if (loadable.state === "loading") {
     throw loadable.contents;
@@ -400,7 +377,7 @@ const useData = <T,>(path: string): T => {
 
   if (loadable.state === "hasError") {
     if (loadable.contents instanceof fos.SampleNotFound) {
-      throw new Promise(() => {});
+      throw new Promise(() => null);
     }
 
     throw loadable.contents;
@@ -409,7 +386,7 @@ const useData = <T,>(path: string): T => {
   let data = loadable.contents;
   let field = useRecoilValue(fos.field(keys[0]));
 
-  if (useRecoilValue(isOfDocumentFieldList(path))) {
+  if (useRecoilValue(fos.isOfDocumentFieldList(path))) {
     data = data?.[field?.dbField || keys[0]]?.map((d) => d[keys[1]]);
   } else {
     for (let index = 0; index < keys.length; index++) {
@@ -422,21 +399,6 @@ const useData = <T,>(path: string): T => {
       if (keys[index + 1]) {
         field = field?.fields?.[keys[index + 1]] || null;
       }
-    }
-  }
-
-  const noneValued = noneValuedPaths?.[sampleId];
-  if (
-    (data === undefined || data === null) &&
-    path &&
-    !noneValued?.has(path) &&
-    sampleId
-  ) {
-    const newNoneValued = noneValued
-      ? new Set([...noneValued]).add(path)
-      : new Set([path]);
-    if (newNoneValued) {
-      setNoneValued({ [sampleId]: new Set([...newNoneValued, path]) });
     }
   }
 

--- a/app/packages/core/src/components/Sidebar/Entries/index.tsx
+++ b/app/packages/core/src/components/Sidebar/Entries/index.tsx
@@ -5,4 +5,4 @@ import Filter from "./FilterEntry";
 import { PathGroupEntry as PathGroup } from "./GroupEntries";
 import PathValue from "./PathValueEntry";
 
-export { AddGroup, Empty, FilterablePath, Filter, PathGroup, PathValue };
+export { AddGroup, Empty, Filter, FilterablePath, PathGroup, PathValue };

--- a/app/packages/core/src/components/Sidebar/Sidebar.tsx
+++ b/app/packages/core/src/components/Sidebar/Sidebar.tsx
@@ -199,12 +199,12 @@ const measureGroups = (
   data: { top: number; height: number; key: string }[];
   activeHeight: number;
 } => {
-  const data = [];
   let current = {
     top: -MARGIN,
     height: 0,
     key: getEntryKey(items[order[0]].entry),
   };
+  const data: typeof current[] = [];
   let activeHeight = -MARGIN;
 
   for (let i = 0; i < order.length; i++) {
@@ -264,24 +264,25 @@ const isDisabledEntry = (
 };
 
 const getAfterKey = (
-  activeKey: string,
+  activeKey: string | null,
   items: InteractiveItems,
   order: string[],
   direction: Direction,
   disabled: Set<string>
 ): string | null => {
-  if (!items[activeKey]) {
-    return;
+  if (activeKey === null || !items[activeKey]) {
+    return null;
   }
 
   const up = direction === Direction.UP;
-  const baseTop = items[order[0]].el.parentElement.getBoundingClientRect().y;
+  const baseTop =
+    items[order[0]].el.parentElement?.getBoundingClientRect().y || 0;
   const isGroup = items[activeKey].entry.kind === fos.EntryKind.GROUP;
-  let { data, activeHeight } = isGroup
+  const measurement = isGroup
     ? measureGroups(activeKey, items, order)
     : measureEntries(activeKey, items, order);
 
-  data = data.filter(
+  const data = measurement.data.filter(
     ({ key }) => !isDisabledEntry(items[key].entry, disabled, !isGroup)
   );
 
@@ -289,7 +290,7 @@ const getAfterKey = (
   let y = top - baseTop;
 
   if (!up) {
-    y += activeHeight;
+    y += measurement.activeHeight;
   }
 
   let filtered = data
@@ -435,7 +436,7 @@ const InteractiveSidebar = ({
     throw entries;
   }
 
-  let group = null;
+  let group: string | null = null;
   order.current = [...entries].map((entry) => getEntryKey(entry));
   for (const entry of entries) {
     const key = getEntryKey(entry);

--- a/app/packages/state/src/recoil/schema.ts
+++ b/app/packages/state/src/recoil/schema.ts
@@ -780,3 +780,17 @@ export const parentField = selectorFamily({
       return get(field(parent));
     },
 });
+
+export const isOfDocumentFieldList = selectorFamily({
+  key: "isOfDocumentField",
+  get:
+    (path: string) =>
+    ({ get }) => {
+      const f = get(field(path.split(".")[0]));
+
+      return [
+        DYNAMIC_EMBEDDED_DOCUMENT_FIELD,
+        EMBEDDED_DOCUMENT_FIELD,
+      ].includes(f.subfield || "");
+    },
+});

--- a/app/packages/state/src/recoil/schema.ts
+++ b/app/packages/state/src/recoil/schema.ts
@@ -17,13 +17,13 @@ import {
   LABEL_LISTS,
   LABEL_LISTS_MAP,
   LIST_FIELD,
+  meetsFieldType,
   OBJECT_ID_FIELD,
-  STRING_FIELD,
   Schema,
   StrictField,
+  STRING_FIELD,
   VALID_NUMERIC_TYPES,
   VALID_PRIMITIVE_TYPES,
-  meetsFieldType,
   withPath,
 } from "@fiftyone/utilities";
 import { RecoilState, selector, selectorFamily } from "recoil";
@@ -782,7 +782,7 @@ export const parentField = selectorFamily({
 });
 
 export const isOfDocumentFieldList = selectorFamily({
-  key: "isOfDocumentField",
+  key: "isOfDocumentFieldList",
   get:
     (path: string) =>
     ({ get }) => {

--- a/app/packages/state/src/recoil/sidebar.test.ts
+++ b/app/packages/state/src/recoil/sidebar.test.ts
@@ -452,6 +452,30 @@ describe("hiddenNoneGroups selector", () => {
     groups: new Set(["field", "list_field"]),
   };
 
+  const base = {
+    hideNoneValuedFields: true,
+    isOfDocumentFieldList: (p) => p === "my_list_field.subfield",
+    sidebarGroups: ({ filtered, loading, modal }) => {
+      assertSidebarGroupsRequest(filtered, loading, modal);
+
+      return [
+        {
+          name: "tags",
+          paths: [],
+        },
+        {
+          name: "field",
+          paths: ["my_field"],
+        },
+        {
+          name: "list_field",
+          paths: ["my_list_field.subfield"],
+        },
+      ];
+    },
+    field: () => TEST_FIELD_DATA,
+  };
+
   it("tests disabled", () => {
     setMockAtoms({
       hideNoneValuedFields: false,
@@ -461,30 +485,7 @@ describe("hiddenNoneGroups selector", () => {
   });
 
   it("tests single slice enabled", () => {
-    setMockAtoms({
-      hideNoneValuedFields: true,
-      isOfDocumentFieldList: (p) => p === "my_list_field.subfield",
-      sidebarGroups: ({ filtered, loading, modal }) => {
-        assertSidebarGroupsRequest(filtered, loading, modal);
-
-        return [
-          {
-            name: "tags",
-            paths: [],
-          },
-          {
-            name: "field",
-            paths: ["my_field"],
-          },
-          {
-            name: "list_field",
-            paths: ["my_list_field.subfield"],
-          },
-        ];
-      },
-      field: () => TEST_FIELD_DATA,
-    });
-
+    setMockAtoms(base);
     // test null
     setMockAtoms({
       activeModalSidebarSample: {
@@ -521,6 +522,45 @@ describe("hiddenNoneGroups selector", () => {
         my_field: "value",
         my_list_field: [{ subfield: "value" }],
       },
+    });
+
+    expect(testHiddenNoneGroups()).toStrictEqual(present);
+  });
+
+  it("tests multiple slices enabled", () => {
+    setMockAtoms(base);
+
+    // test null
+    setMockAtoms({
+      activePcdSlices: ["one", "two"],
+      activePcdSlicesToSampleMap: {
+        one: {
+          sample: {},
+        },
+        two: {
+          sample: {},
+        },
+      },
+      pinned3DSampleSlice: "one",
+    });
+
+    expect(testHiddenNoneGroups()).toStrictEqual(hidden);
+
+    // test null and present
+    setMockAtoms({
+      activePcdSlices: ["one", "two"],
+      activePcdSlicesToSampleMap: {
+        one: {
+          sample: {},
+        },
+        two: {
+          sample: {
+            my_field: "value",
+            my_list_field: [{ subfield: "value" }],
+          },
+        },
+      },
+      pinned3DSampleSlice: "one",
     });
 
     expect(testHiddenNoneGroups()).toStrictEqual(present);

--- a/app/packages/state/src/recoil/sidebar.test.ts
+++ b/app/packages/state/src/recoil/sidebar.test.ts
@@ -1,3 +1,4 @@
+import { Field } from "@fiftyone/utilities";
 import { describe, expect, it } from "vitest";
 import * as sidebar from "./sidebar";
 
@@ -354,5 +355,62 @@ describe("test sidebar groups resolution", () => {
     expect(labels.name).toBe("labels");
     expect(labels.paths).toEqual(["predictions"]);
     expect(labels.expanded).toBe(true);
+  });
+});
+
+const TEST_FIELD_DATA: Field = {
+  name: "unused",
+  path: "unused",
+  embeddedDocType: null,
+  dbField: null,
+  description: null,
+  ftype: null,
+  info: {},
+  subfield: null,
+};
+
+describe("test pullSidebarValue", () => {
+  it("handles dbField values", () => {
+    expect(
+      sidebar.pullSidebarValue(
+        { ...TEST_FIELD_DATA, dbField: "_id" },
+        ["id"],
+        { _id: "idValue" },
+        false
+      )
+    ).toBe("idValue");
+  });
+
+  it("handles embedded list values", () => {
+    expect(
+      sidebar.pullSidebarValue(
+        TEST_FIELD_DATA,
+        ["nested", "field"],
+        { nested: [{ field: "nestedListValue" }] },
+        true
+      )
+    ).toStrictEqual(["nestedListValue"]);
+  });
+
+  it("handles nested values", () => {
+    expect(
+      sidebar.pullSidebarValue(
+        TEST_FIELD_DATA,
+        ["nested", "field"],
+        { nested: { field: "nestedValue" } },
+        false
+      )
+    ).toBe("nestedValue");
+  });
+
+  it("handles undefined values", () => {
+    expect(
+      sidebar.pullSidebarValue(
+        TEST_FIELD_DATA,
+        ["undefined", "value"],
+        {},
+        false
+      )
+    ).toBe(undefined);
   });
 });

--- a/app/packages/state/src/recoil/sidebar.ts
+++ b/app/packages/state/src/recoil/sidebar.ts
@@ -24,10 +24,10 @@ import {
   VALID_PRIMITIVE_TYPES,
   withPath,
 } from "@fiftyone/utilities";
-import { commitMutation, VariablesOf } from "react-relay";
+import { VariablesOf, commitMutation } from "react-relay";
 import {
-  atomFamily,
   DefaultValue,
+  atomFamily,
   selector,
   selectorFamily,
   useRecoilStateLoadable,


### PR DESCRIPTION
## What changes are proposed in this pull request?

An unwanted suspend occurs (in the background) when navigating between _groups_ while the 3D viewer is pinned. This is due to a pending request for the 3D sample(s) when the `Hide None fields` option is enabled. This results in a **hard error** in Teams

The `None` values computation has been moved to the `sidebarEntries` data flow to avoid this.

### Before


https://github.com/voxel51/fiftyone/assets/19821840/7409b5f7-b8fa-4dc8-8249-ab34af0722f1



### After


https://github.com/voxel51/fiftyone/assets/19821840/71a3a706-448d-4664-ab60-835d9bed0eb1



## How is this patch tested? If it is not, please explain why.

`hiddenNoneGroups` selectors tests. Also, a common `pullSidebarValue` function has been added for better reuse with added unit tests

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

* Fixed expanded sample view navigation in Teams when the 3D viewer is active

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
    - Added a new selector for identifying specific document field types in the application's state management.
- **Enhancements**
    - Improved data retrieval, manipulation, and processing for sidebar entries.
    - Enhanced error handling and data processing in key components.
- **Refactor**
    - Removed unused references and imports in the `SampleModal` and sidebar components.
    - Streamlined data handling by replacing and refactoring functions for better performance and readability.
    - Adjusted the export order of entities for consistency.
- **Tests**
    - Added new tests for sidebar functionality, ensuring reliability and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->