### PR TITLE
Feat/scrollable tooltip

### DIFF
--- a/app/packages/components/src/components/Tooltip/Tooltip.module.css
+++ b/app/packages/components/src/components/Tooltip/Tooltip.module.css
@@ -7,4 +7,5 @@
   z-index: 100000;
   font-size: 14px;
   color: var(--fo-palette-text-secondary);
+  user-select: none;
 }

--- a/app/packages/components/src/components/Tooltip/Tooltip.module.css
+++ b/app/packages/components/src/components/Tooltip/Tooltip.module.css
@@ -4,7 +4,7 @@
   border: 1px solid var(--fo-palette-primary-plainBorder);
   padding: 0.25rem;
   border-radius: 3px;
-  z-index: 1000;
+  z-index: 100000;
   font-size: 14px;
   color: var(--fo-palette-text-secondary);
 }

--- a/app/packages/core/src/components/Modal/Looker.tsx
+++ b/app/packages/core/src/components/Modal/Looker.tsx
@@ -12,7 +12,12 @@ import React, {
   useState,
 } from "react";
 import { useErrorHandler } from "react-error-boundary";
-import { useRecoilCallback, useRecoilValue, useSetRecoilState } from "recoil";
+import {
+  useRecoilCallback,
+  useRecoilState,
+  useRecoilValue,
+  useSetRecoilState,
+} from "recoil";
 import { v4 as uuid } from "uuid";
 import { useInitializeImaVidSubscriptions } from "./hooks";
 
@@ -98,6 +103,10 @@ const Looker = ({
   const setModalLooker = useSetRecoilState(fos.modalLooker);
   const { subscribeToImaVidStateChanges } = useInitializeImaVidSubscriptions();
 
+  const [isTooltipLocked, setIsTooltipLocked] = useRecoilState(
+    fos.isTooltipLocked
+  );
+
   const createLooker = fos.useCreateLooker(true, false, {
     ...lookerOptions,
   });
@@ -150,10 +159,15 @@ const Looker = ({
     looker,
     "close",
     useCallback(() => {
+      if (isTooltipLocked) {
+        setIsTooltipLocked(false);
+        return;
+      }
+
       jsonPanel.close();
       helpPanel.close();
       clearModal();
-    }, [clearModal, jsonPanel, helpPanel])
+    }, [clearModal, jsonPanel, helpPanel, isTooltipLocked])
   );
 
   useEventHandler(looker, "select", useOnSelectLabel());

--- a/app/packages/core/src/components/Modal/Modal.tsx
+++ b/app/packages/core/src/components/Modal/Modal.tsx
@@ -71,14 +71,32 @@ const SampleModal = () => {
   const clearModal = fos.useClearModal();
   const { jsonPanel, helpPanel, onNavigate } = usePanels();
   const tooltip = fos.useTooltip();
-
-  const eventHandler = useCallback(
-    (e) => {
-      tooltip.setDetail(e.detail ? e.detail : null);
-      e.detail && tooltip.setCoords(e.detail.coordinates);
-    },
-    [tooltip]
+  const isTooltipControlKeyPressed = useRecoilValue(
+    fos.isTooltipControlKeyPressed
   );
+  const setTooltipDetail = useSetRecoilState(fos.tooltipDetail);
+
+  const tooltipEventHandler = useCallback(
+    (e) => {
+      if (e.detail) {
+        setTooltipDetail(e.detail);
+
+        if (!isTooltipControlKeyPressed && e.detail?.coordinates) {
+          tooltip.setCoords(e.detail.coordinates);
+        }
+      } else {
+        setTooltipDetail(null);
+      }
+    },
+    [isTooltipControlKeyPressed, tooltip, setTooltipDetail]
+  );
+
+  useEffect(() => {
+    tooltip.registerCtrlKeyListener();
+    return () => {
+      tooltip.removeListeners();
+    };
+  }, [tooltip]);
 
   /**
    * a bit hacky, this is using the callback-ref pattern to get looker reference so that event handler can be registered
@@ -87,9 +105,9 @@ const SampleModal = () => {
   const lookerRefCallback = useCallback(
     (looker: fos.Lookers) => {
       lookerRef.current = looker;
-      looker.addEventListener("tooltip", eventHandler);
+      looker.addEventListener("tooltip", tooltipEventHandler);
     },
-    [eventHandler]
+    [tooltipEventHandler]
   );
 
   const noneValuedPaths = useRecoilValue(fos.noneValuedPaths)?.[sampleId];
@@ -195,9 +213,9 @@ const SampleModal = () => {
   useEffect(() => {
     return () => {
       lookerRef.current &&
-        lookerRef.current.removeEventListener("tooltip", eventHandler);
+        lookerRef.current.removeEventListener("tooltip", tooltipEventHandler);
     };
-  }, [eventHandler]);
+  }, [tooltipEventHandler]);
 
   const isNestedDynamicGroup = useRecoilValue(fos.isNestedDynamicGroup);
   const isOrderedDynamicGroup = useRecoilValue(fos.isOrderedDynamicGroup);

--- a/app/packages/core/src/components/Modal/Modal.tsx
+++ b/app/packages/core/src/components/Modal/Modal.tsx
@@ -71,8 +71,8 @@ const SampleModal = () => {
   const clearModal = fos.useClearModal();
   const { jsonPanel, helpPanel, onNavigate } = usePanels();
   const tooltip = fos.useTooltip();
-  const isTooltipControlKeyPressed = useRecoilValue(
-    fos.isTooltipControlKeyPressed
+  const [isTooltipLocked, setIsTooltipLocked] = useRecoilState(
+    fos.isTooltipLocked
   );
   const setTooltipDetail = useSetRecoilState(fos.tooltipDetail);
 
@@ -80,23 +80,22 @@ const SampleModal = () => {
     (e) => {
       if (e.detail) {
         setTooltipDetail(e.detail);
-
-        if (!isTooltipControlKeyPressed && e.detail?.coordinates) {
+        if (!isTooltipLocked && e.detail?.coordinates) {
           tooltip.setCoords(e.detail.coordinates);
         }
-      } else {
-        setTooltipDetail(null);
       }
     },
-    [isTooltipControlKeyPressed, tooltip, setTooltipDetail]
+    [isTooltipLocked, tooltip]
   );
 
   useEffect(() => {
-    tooltip.registerCtrlKeyListener();
+    // reset tooltip state when modal is closed
+    setIsTooltipLocked(false);
+
     return () => {
-      tooltip.removeListeners();
+      setTooltipDetail(null);
     };
-  }, [tooltip]);
+  }, []);
 
   /**
    * a bit hacky, this is using the callback-ref pattern to get looker reference so that event handler can be registered

--- a/app/packages/core/src/components/Modal/Modal.tsx
+++ b/app/packages/core/src/components/Modal/Modal.tsx
@@ -83,6 +83,8 @@ const SampleModal = () => {
         if (!isTooltipLocked && e.detail?.coordinates) {
           tooltip.setCoords(e.detail.coordinates);
         }
+      } else if (!isTooltipLocked) {
+        setTooltipDetail(null);
       }
     },
     [isTooltipLocked, tooltip]

--- a/app/packages/core/src/components/Modal/TooltipInfo.tsx
+++ b/app/packages/core/src/components/Modal/TooltipInfo.tsx
@@ -1,12 +1,12 @@
 import { animated, useSpring } from "@react-spring/web";
-import React, { useRef } from "react";
+import React, { useMemo, useRef } from "react";
 import ReactDOM from "react-dom";
 import styled from "styled-components";
 
 import * as fos from "@fiftyone/state";
 import { useRecoilValue } from "recoil";
-import { ContentDiv, ContentHeader } from "../utils";
 import { joinStringArray } from "../Filters/utils";
+import { ContentDiv, ContentHeader } from "../utils";
 
 const TooltipDiv = animated(styled(ContentDiv)`
   position: absolute;
@@ -96,10 +96,12 @@ const TagInfo = ({ tags }: { tags: string[] }) => {
 };
 
 export const TooltipInfo = React.memo(() => {
-  const { detail, coords } = fos.useTooltip();
-  const position = detail
-    ? coords
-    : { top: -1000, left: -1000, bottom: "unset" };
+  const detail = useRecoilValue(fos.tooltipDetail);
+  const coords = useRecoilValue(fos.tooltipCoordinates);
+  const position = useMemo(
+    () => (detail ? coords : { top: -1000, left: -1000, bottom: "unset" }),
+    [coords, detail]
+  );
 
   const coordsProps = useSpring({
     ...position,

--- a/app/packages/core/src/components/Modal/TooltipInfo.tsx
+++ b/app/packages/core/src/components/Modal/TooltipInfo.tsx
@@ -122,7 +122,6 @@ const CtrlToLockContainer = styled.div`
 `;
 
 const getHiddenLabelsKey = (datasetName: string, labelName: string) => {
-  console.log("getting key for dataset", datasetName, "label", labelName);
   return `fo-hiddenLabels-${datasetName}-${labelName}`;
 };
 

--- a/app/packages/core/src/components/Modal/TooltipInfo.tsx
+++ b/app/packages/core/src/components/Modal/TooltipInfo.tsx
@@ -5,6 +5,7 @@ import styled from "styled-components";
 
 import { Close as CloseIcon } from "@fiftyone/components";
 import * as fos from "@fiftyone/state";
+import { Typography } from "@mui/material";
 import Draggable from "react-draggable";
 import { useRecoilState, useRecoilValue, useSetRecoilState } from "recoil";
 import { joinStringArray } from "../Filters/utils";
@@ -41,6 +42,13 @@ const ContentName = styled.div`
   font-weight: bold;
   padding-bottom: 0.3rem;
   color: ${({ theme }) => theme.text.secondary};
+`;
+
+const CtrlToLockContainer = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: end;
+  width: 5em;
 `;
 
 export const ContentItem = ({
@@ -188,7 +196,7 @@ const Header = ({ title }: { title: string }) => {
       id={TOOLTIP_HEADER_ID}
     >
       <span>{title}</span>
-      {isTooltipLocked && (
+      {isTooltipLocked ? (
         <CloseIcon
           style={{ cursor: "pointer" }}
           onClick={() => {
@@ -196,8 +204,20 @@ const Header = ({ title }: { title: string }) => {
             setIsTooltipLocked(false);
           }}
         />
+      ) : (
+        <CtrlToLock />
       )}
     </ContentHeader>
+  );
+};
+
+const CtrlToLock = () => {
+  return (
+    <CtrlToLockContainer>
+      <Typography variant="caption" color="gray" fontSize={"0.5em"}>
+        Press Ctrl to lock
+      </Typography>
+    </CtrlToLockContainer>
   );
 };
 

--- a/app/packages/core/src/components/Modal/TooltipInfo.tsx
+++ b/app/packages/core/src/components/Modal/TooltipInfo.tsx
@@ -245,6 +245,7 @@ const TagInfo = ({ tags }: { tags: string[] }) => {
   return (
     <TagBlock>
       <ContentItem
+        field={"tags"}
         key={"tags"}
         name={"tags"}
         value={tags.length ? tags.join(", ") : "No tags"}
@@ -315,7 +316,7 @@ export const TooltipInfo = React.memo(() => {
   }, []);
 
   const tooltipDiv = useMemo(() => {
-    if (!Component) {
+    if (!detail) {
       return null;
     }
 
@@ -711,7 +712,7 @@ const OVERLAY_INFO = {
 };
 
 const HIDDEN_LABELS = {
-  Classification: ["logtis"],
+  Classification: ["logits"],
   Detection: ["bounding_box", "mask"],
   Heatmap: ["map"],
   Keypoint: ["points", "occluded", "confidence"],

--- a/app/packages/core/src/components/Modal/TooltipInfo.tsx
+++ b/app/packages/core/src/components/Modal/TooltipInfo.tsx
@@ -1,9 +1,11 @@
 import { IconButton, Tooltip } from "@fiftyone/components";
 import * as fos from "@fiftyone/state";
 import CloseIcon from "@mui/icons-material/Close";
+import ArrowDropDownIcon from "@mui/icons-material/KeyboardArrowDownOutlined";
+import ArrowUpIcon from "@mui/icons-material/KeyboardArrowUpOutlined";
 import VisibilityIcon from "@mui/icons-material/Visibility";
 import VisibilityOffIcon from "@mui/icons-material/VisibilityOff";
-import { Button, Typography } from "@mui/material";
+import { Typography } from "@mui/material";
 import { animated, useSpring } from "@react-spring/web";
 import React, {
   useCallback,
@@ -69,7 +71,7 @@ const HiddenItemRowDiv = styled.div`
   height: 1.5rem;
 `;
 
-const HiddenHeader = styled.div`
+const Row = styled.div`
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -378,25 +380,32 @@ const HiddenItems = ({ field }: { field: string }) => {
 
   if (!shouldShowHidden) {
     return (
-      <Button onClick={() => setShouldShowHidden(true)} size="small">
-        Show hidden
-      </Button>
+      <Row onClick={() => setShouldShowHidden(true)}>
+        <Typography variant="caption" color="gray" fontSize="0.8em">
+          Hidden
+        </Typography>
+        <IconButton size="small">
+          <ArrowDropDownIcon fontSize="small" />
+        </IconButton>
+      </Row>
     );
   }
 
   return (
     <>
-      <HiddenHeader>
-        <ContentHeader>Hidden</ContentHeader>
-        <IconButton onClick={() => setShouldShowHidden(false)} size="small">
-          <Tooltip text="Hide hidden items" placement="bottom-center">
-            <VisibilityOffIcon fontSize="small" />
-          </Tooltip>
+      <Row onClick={() => setShouldShowHidden(false)}>
+        <Typography variant="caption" color="gray" fontSize="0.8em">
+          Hidden
+        </Typography>
+        <IconButton size="small">
+          <ArrowUpIcon fontSize="small" />
         </IconButton>
-      </HiddenHeader>
+      </Row>
 
       {currentHiddenLabels.size === 0 ? (
-        <Typography>No items hidden</Typography>
+        <Typography variant="caption" fontSize="small">
+          No items hidden
+        </Typography>
       ) : (
         <div style={{ display: "flex", flexDirection: "column" }}>
           {[...currentHiddenLabels].map((label) => (

--- a/app/packages/core/src/components/Modal/TooltipInfo.tsx
+++ b/app/packages/core/src/components/Modal/TooltipInfo.tsx
@@ -243,6 +243,8 @@ const BorderDiv = styled.div`
 const AttrBlock = styled.div`
   padding: 0.1rem 0 0 0;
   margin: 0;
+  max-height: 50vh;
+  overflow-y: scroll;
 `;
 
 const useTarget = (field, target) => {

--- a/app/packages/core/src/components/Modal/TooltipInfo.tsx
+++ b/app/packages/core/src/components/Modal/TooltipInfo.tsx
@@ -1,20 +1,24 @@
 import { animated, useSpring } from "@react-spring/web";
-import React, { useMemo, useRef } from "react";
+import React, { useLayoutEffect, useMemo, useRef } from "react";
 import ReactDOM from "react-dom";
 import styled from "styled-components";
 
+import { Close as CloseIcon } from "@fiftyone/components";
 import * as fos from "@fiftyone/state";
-import { useRecoilValue } from "recoil";
+import Draggable from "react-draggable";
+import { useRecoilState, useRecoilValue, useSetRecoilState } from "recoil";
 import { joinStringArray } from "../Filters/utils";
 import { ContentDiv, ContentHeader } from "../utils";
 
-const TooltipDiv = animated(styled(ContentDiv)`
+const TOOLTIP_HEADER_ID = "fo-tooltip-header";
+
+const TooltipDiv = animated(styled(ContentDiv)<{ isTooltipLocked: boolean }>`
   position: absolute;
   margin-top: 0;
   left: -1000;
   top: -1000;
   z-index: 20000;
-  pointer-events: none;
+  pointer-events: ${(props) => (props.isTooltipLocked ? "auto" : "none")};
 `);
 
 const ContentItemDiv = styled.div`
@@ -96,6 +100,9 @@ const TagInfo = ({ tags }: { tags: string[] }) => {
 };
 
 export const TooltipInfo = React.memo(() => {
+  const [isTooltipLocked, setIsTooltipLocked] = useRecoilState(
+    fos.isTooltipLocked
+  );
   const detail = useRecoilValue(fos.tooltipDetail);
   const coords = useRecoilValue(fos.tooltipCoordinates);
   const position = useMemo(
@@ -117,23 +124,82 @@ export const TooltipInfo = React.memo(() => {
   });
   const Component = detail ? OVERLAY_INFO[detail.type] : null;
 
-  return Component
-    ? ReactDOM.createPortal(
-        <TooltipDiv
-          style={{ ...coordsProps, ...showProps, position: "fixed" }}
-          ref={ref}
-        >
-          <ContentHeader key="header">{detail.field}</ContentHeader>
-          <Border color={detail.color} id={detail.label.id} />
-          {detail.label.tags && detail.label.tags.length > 0 && (
-            <TagInfo key={"tags"} tags={detail.label?.tags} />
-          )}
-          <Component key={"attrs"} detail={detail} />
-        </TooltipDiv>,
-        document.body
-      )
-    : null;
+  useLayoutEffect(() => {
+    const lockTooltip = (e: KeyboardEvent) => {
+      if (e.key === "Control") {
+        setIsTooltipLocked(true);
+      }
+    };
+
+    document.addEventListener("keydown", lockTooltip);
+
+    return () => {
+      document.removeEventListener("keydown", lockTooltip);
+    };
+  }, []);
+
+  const tooltipDiv = useMemo(() => {
+    if (!Component) {
+      return null;
+    }
+
+    return (
+      <TooltipDiv
+        isTooltipLocked={isTooltipLocked}
+        style={{ ...coordsProps, ...showProps, position: "fixed" }}
+        ref={ref}
+      >
+        <Header title={detail.field} />
+        <Border color={detail.color} id={detail.label.id} />
+        {detail.label.tags && detail.label.tags.length > 0 && (
+          <TagInfo key={"tags"} tags={detail.label?.tags} />
+        )}
+        <Component key={"attrs"} detail={detail} />
+      </TooltipDiv>
+    );
+  }, [Component, coordsProps, detail, isTooltipLocked, showProps]);
+
+  if (!Component) {
+    return null;
+  }
+
+  if (!isTooltipLocked) {
+    return ReactDOM.createPortal(tooltipDiv, document.body);
+  }
+
+  return ReactDOM.createPortal(
+    <div>
+      <Draggable handle={"#" + TOOLTIP_HEADER_ID}>{tooltipDiv}</Draggable>
+    </div>,
+    document.body
+  );
 });
+
+const Header = ({ title }: { title: string }) => {
+  const [isTooltipLocked, setIsTooltipLocked] = useRecoilState(
+    fos.isTooltipLocked
+  );
+  const setTooltipDetail = useSetRecoilState(fos.tooltipDetail);
+
+  return (
+    <ContentHeader
+      isTooltipLocked={isTooltipLocked}
+      key="header"
+      id={TOOLTIP_HEADER_ID}
+    >
+      <span>{title}</span>
+      {isTooltipLocked && (
+        <CloseIcon
+          style={{ cursor: "pointer" }}
+          onClick={() => {
+            setTooltipDetail(null);
+            setIsTooltipLocked(false);
+          }}
+        />
+      )}
+    </ContentHeader>
+  );
+};
 
 const Border = ({ color, id }) => {
   const selectedLabels = useRecoilValue(fos.selectedLabelIds);

--- a/app/packages/core/src/components/Modal/TooltipInfo.tsx
+++ b/app/packages/core/src/components/Modal/TooltipInfo.tsx
@@ -19,8 +19,32 @@ const TooltipDiv = animated(styled(ContentDiv)<{ isTooltipLocked: boolean }>`
   left: -1000;
   top: -1000;
   z-index: 20000;
+  min-width: 13rem;
   pointer-events: ${(props) => (props.isTooltipLocked ? "auto" : "none")};
 `);
+
+const TooltipContentDiv = styled.div`
+  overflow-y: auto;
+  max-height: 50vh;
+
+  /* Customize the scrollbar (non-standard across browsers) */
+  scrollbar-width: thin;
+  scrollbar-color: #888 #f0f0f0;
+
+  &::-webkit-scrollbar {
+    width: 12px;
+  }
+
+  &::-webkit-scrollbar-track {
+    background: #f0f0f0; /* Color of the track (background of the scrollbar) */
+  }
+
+  &::-webkit-scrollbar-thumb {
+    background-color: #888; /* color of the scrollbar thumb (the draggable part) */
+    border-radius: 6px; /* roundness of the scrollbar thumb */
+    border: 3px solid #f0f0f0; /* creates a border around the thumb (should match the track color) */
+  }
+`;
 
 const ContentItemDiv = styled.div`
   margin: 0;
@@ -159,10 +183,12 @@ export const TooltipInfo = React.memo(() => {
       >
         <Header title={detail.field} />
         <Border color={detail.color} id={detail.label.id} />
-        {detail.label.tags && detail.label.tags.length > 0 && (
-          <TagInfo key={"tags"} tags={detail.label?.tags} />
-        )}
-        <Component key={"attrs"} detail={detail} />
+        <TooltipContentDiv>
+          {detail.label.tags && detail.label.tags.length > 0 && (
+            <TagInfo key={"tags"} tags={detail.label?.tags} />
+          )}
+          <Component key={"attrs"} detail={detail} />
+        </TooltipContentDiv>
       </TooltipDiv>
     );
   }, [Component, coordsProps, detail, isTooltipLocked, showProps]);
@@ -243,8 +269,6 @@ const BorderDiv = styled.div`
 const AttrBlock = styled.div`
   padding: 0.1rem 0 0 0;
   margin: 0;
-  max-height: 50vh;
-  overflow-y: scroll;
 `;
 
 const useTarget = (field, target) => {

--- a/app/packages/core/src/components/utils.tsx
+++ b/app/packages/core/src/components/utils.tsx
@@ -1,7 +1,7 @@
 import { useTheme } from "@fiftyone/components";
+import { animated, useSpring, useSprings } from "@react-spring/web";
 import React, { useState } from "react";
 import styled from "styled-components";
-import { animated, useSpring, useSprings } from "@react-spring/web";
 
 export const Box = styled.div`
   padding: 1em;
@@ -32,10 +32,13 @@ export const ContentDiv = styled.div`
   z-index: 802;
 `;
 
-export const ContentHeader = styled.div`
+export const ContentHeader = styled.div<{ isTooltipLocked: boolean }>`
   color: ${({ theme }) => theme.text.primary};
   display: flex;
+  justify-content: space-between;
+  align-items: center;
   padding-bottom: 0.5rem;
+  cursor: ${({ isTooltipLocked }) => (isTooltipLocked ? "grab" : "default")};
 `;
 
 export const PopoutDiv = animated(styled.div`

--- a/app/packages/core/src/components/utils.tsx
+++ b/app/packages/core/src/components/utils.tsx
@@ -32,7 +32,7 @@ export const ContentDiv = styled.div`
   z-index: 802;
 `;
 
-export const ContentHeader = styled.div<{ isTooltipLocked: boolean }>`
+export const ContentHeader = styled.div<{ isTooltipLocked?: boolean }>`
   color: ${({ theme }) => theme.text.primary};
   display: flex;
   justify-content: space-between;

--- a/app/packages/looker-3d/src/Looker3d.tsx
+++ b/app/packages/looker-3d/src/Looker3d.tsx
@@ -65,6 +65,13 @@ export const Looker3d = () => {
   useHotkey(
     "Escape",
     async ({ snapshot, set }) => {
+      const isTooltipLocked = await snapshot.getPromise(fos.isTooltipLocked);
+
+      if (isTooltipLocked) {
+        set(fos.isTooltipLocked, false);
+        return;
+      }
+
       const panels = await snapshot.getPromise(fos.lookerPanels);
       const currentAction = await snapshot.getPromise(currentActionAtom);
 

--- a/app/packages/looker-3d/src/labels/index.tsx
+++ b/app/packages/looker-3d/src/labels/index.tsx
@@ -32,12 +32,10 @@ export const ThreeDLabels = ({ sampleMap }: ThreeDLabelsProps) => {
     defaultPluginSettings
   );
   const onSelectLabel = fos.useOnSelectLabel();
-  const getFieldColor = useRecoilValue(fos.colorMap);
   const pathFilter = usePathFilter();
   const colorScheme = useRecoilValue(fos.colorScheme);
   const selectedLabels = useRecoilValue(fos.selectedLabelMap);
   const tooltip = fos.useTooltip();
-  const colorSchemeFields = colorScheme?.fields;
   const labelAlpha = colorScheme.opacity;
 
   const handleSelect = useCallback(

--- a/app/packages/looker-3d/src/labels/loader.ts
+++ b/app/packages/looker-3d/src/labels/loader.ts
@@ -46,7 +46,7 @@ export const load3dOverlayForSample = (
         sampleId,
         path,
         selected: label._id in selectedLabels,
-        _cls: cls,
+        type: cls,
       });
     } else if (RENDERABLE_LIST.includes(cls) && label[LABEL_LIST[cls]]) {
       overlays = [

--- a/app/packages/looker-3d/src/labels/polyline.tsx
+++ b/app/packages/looker-3d/src/labels/polyline.tsx
@@ -1,3 +1,5 @@
+import { useCursor } from "@react-three/drei";
+import { useMemo, useState } from "react";
 import * as THREE from "three";
 import { Line } from "./line";
 import { OverlayProps } from "./shared";
@@ -20,25 +22,39 @@ export const Polyline = ({
   tooltip,
   label,
 }: PolyLineProps) => {
+  const lines = useMemo(
+    () =>
+      points3d.map((points) => (
+        <Line
+          key={`polyline-${label}-${points3d[0][0]}`}
+          rotation={rotation}
+          points={points}
+          opacity={opacity}
+          color={selected ? "orange" : color}
+          onClick={onClick}
+          tooltip={tooltip}
+          label={label}
+        />
+      )),
+    [points3d, rotation, opacity, color, selected, onClick, tooltip, label]
+  );
+
+  const [isPolylineHovered, setIsPolylineHovered] = useState(false);
+
+  useCursor(isPolylineHovered);
+
   if (filled) {
     // @todo: filled not yet supported
+    // @todo: closed prop not used
     return null;
   }
 
-  // @todo: closed prop isn't used
-
-  const lines = points3d.map((points) => (
-    <Line
-      key={`polyline-${label}-${points3d[0][0]}`}
-      rotation={rotation}
-      points={points}
-      opacity={opacity}
-      color={selected ? "orange" : color}
-      onClick={onClick}
-      tooltip={tooltip}
-      label={label}
-    />
-  ));
-
-  return <group>{lines}</group>;
+  return (
+    <group
+      onPointerOver={() => setIsPolylineHovered(true)}
+      onPointerOut={() => setIsPolylineHovered(false)}
+    >
+      {lines}
+    </group>
+  );
 };

--- a/app/packages/looker/src/index.ts
+++ b/app/packages/looker/src/index.ts
@@ -5,7 +5,9 @@
 export { createColorGenerator, getRGB } from "@fiftyone/utilities";
 export { freeVideos } from "./elements/util";
 export * from "./lookers";
+export type { PointInfo } from "./overlays";
 export type {
+  BaseState,
   Coloring,
   CustomizeColor,
   FrameConfig,

--- a/app/packages/looker/src/overlays/base.ts
+++ b/app/packages/looker/src/overlays/base.ts
@@ -20,7 +20,7 @@ export interface BaseLabel {
   index?: number;
 }
 
-export interface PointInfo<Label extends BaseLabel> {
+export interface PointInfo<Label extends BaseLabel = BaseLabel> {
   color: string;
   field: string;
   label: Label;

--- a/app/packages/looker/src/overlays/index.ts
+++ b/app/packages/looker/src/overlays/index.ts
@@ -25,6 +25,8 @@ import KeypointOverlay, { getKeypointPoints } from "./keypoint";
 import PolylineOverlay, { getPolylinePoints } from "./polyline";
 import SegmentationOverlay, { getSegmentationPoints } from "./segmentation";
 
+export type { PointInfo } from "./base";
+
 export const fromLabel = (overlayType) => (field, label) =>
   label ? [new overlayType(field, label)] : [];
 

--- a/app/packages/state/src/hooks/useTooltip.ts
+++ b/app/packages/state/src/hooks/useTooltip.ts
@@ -1,117 +1,55 @@
 import * as fos from "@fiftyone/state";
-import { useCallback, useEffect } from "react";
+import { useCallback } from "react";
 import { useRecoilState, useSetRecoilState } from "recoil";
 
 export default function useTooltip() {
-  const setIsControlKeyPressed = useSetRecoilState(
-    fos.isTooltipControlKeyPressed
+  const [isTooltipLocked, setIsTooltipLocked] = useRecoilState(
+    fos.isTooltipLocked
   );
   const setTooltipDetail = useSetRecoilState(fos.tooltipDetail);
-  const [isTooltipOn3DLabel, setIsTooltipOn3DLabel] = useRecoilState(
-    fos.isTooltipOn3DLabel
-  );
   const setTooltipCoordinates = useSetRecoilState(fos.tooltipCoordinates);
 
-  const setCoords = useCallback(
-    (coordinates: [number, number]) => {
-      const coords = computeCoordinates(coordinates);
-      setTooltipCoordinates(coords);
-    },
-    [setTooltipCoordinates]
-  );
-
-  const handleMouseMove = useCallback(
-    (e: MouseEvent) => {
-      setCoords([e.pageX, e.pageY]);
-    },
-    [setCoords]
-  );
-
-  const registerMouseListener = useCallback(() => {
-    window.addEventListener("mousemove", handleMouseMove);
-    console.log("mouse listener added");
-  }, [handleMouseMove]);
-
-  const removeMouseListener = useCallback(() => {
-    window.removeEventListener("mousemove", handleMouseMove);
-    console.log("removing mouse listener");
-  }, [handleMouseMove]);
-
-  const handleKeyDown = useCallback(
-    (e: KeyboardEvent) => {
-      if (e.key === "Control") {
-        console.log("control key pressed");
-        setIsControlKeyPressed(true);
-      }
-    },
-    [setIsControlKeyPressed]
-  );
-
-  useEffect(() => {
-    if (!isTooltipOn3DLabel) {
-      removeMouseListener();
-    }
-  }, [isTooltipOn3DLabel, removeMouseListener]);
-
-  const handleKeyUp = useCallback(
-    (e) => {
-      if (e.key === "Control") {
-        console.log("control key lifted up");
-        setIsControlKeyPressed(false);
-      }
-    },
-    [setIsControlKeyPressed]
-  );
-
-  const registerCtrlKeyListener = useCallback(() => {
-    window.addEventListener("keydown", handleKeyDown);
-    window.addEventListener("keyup", handleKeyUp);
-    console.log("key listeners added");
-  }, [handleKeyDown, handleKeyUp]);
-
-  const removeKeyListeners = useCallback(() => {
-    window.removeEventListener("keydown", handleKeyDown);
-    window.removeEventListener("keyup", handleKeyUp);
-    console.log("key listeners removed");
-  }, [handleKeyDown, handleKeyUp]);
-
-  const removeListeners = useCallback(() => {
-    removeMouseListener();
-    removeKeyListeners();
-  }, [removeMouseListener, removeKeyListeners]);
+  const setCoords = useCallback((coordinates: [number, number]) => {
+    const coords = computeCoordinates(coordinates);
+    setTooltipCoordinates(coords);
+  }, []);
 
   // only relevant for looker-3d
   const getMeshProps = useCallback(
     (label) => {
       return {
         onPointerOver: () => {
-          setIsTooltipOn3DLabel(true);
           setTooltipDetail(getDetailsFromLabel(label));
         },
         onPointerOut: () => {
-          setIsTooltipOn3DLabel(true);
+          if (!isTooltipLocked) {
+            setTooltipDetail(null);
+          }
+        },
+        onPointerMissed: () => {
+          if (!isTooltipLocked) {
+            setTooltipDetail(null);
+            setIsTooltipLocked(false);
+          }
+        },
+        onPointerMove: (e: MouseEvent) => {
+          if (isTooltipLocked) {
+            return;
+          }
+
+          if (e.ctrlKey) {
+            setIsTooltipLocked(true);
+          } else {
+            setCoords([e.clientX, e.clientY]);
+          }
         },
       };
     },
-    [setTooltipDetail, setIsTooltipOn3DLabel]
+    [setCoords, isTooltipLocked]
   );
-
-  function getDetailsFromLabel(label) {
-    const field = label.path[label.path.length - 1];
-    const { color, selected, ...labelToView } = label;
-    return {
-      field,
-      label: labelToView,
-      type: label._cls,
-      color: label.color,
-    };
-  }
 
   return {
     getMeshProps,
-    registerCtrlKeyListener,
-    registerMouseListener,
-    removeListeners,
     setCoords,
   };
 }
@@ -138,6 +76,17 @@ function computeCoordinates([x, y]: [number, number]): {
     right: x > window.innerWidth / 2 ? window.innerWidth - x + 24 : "unset",
   };
 }
+
+const getDetailsFromLabel = (label) => {
+  const field = label.path[label.path.length - 1];
+  const { ...labelToView } = label;
+  return {
+    field,
+    label: labelToView,
+    type: label._cls,
+    color: label.color,
+  };
+};
 
 export type ComputeCoordinatesReturnType = ReturnType<
   typeof computeCoordinates

--- a/app/packages/state/src/hooks/useTooltip.ts
+++ b/app/packages/state/src/hooks/useTooltip.ts
@@ -78,12 +78,13 @@ function computeCoordinates([x, y]: [number, number]): {
 }
 
 const getDetailsFromLabel = (label) => {
-  const field = label.path[label.path.length - 1];
-  const { ...labelToView } = label;
+  const field = Array.isArray(label.path)
+    ? [label.path.length - 1]
+    : label.path;
   return {
     field,
-    label: labelToView,
-    type: label._cls,
+    label,
+    type: label.type,
     color: label.color,
   };
 };

--- a/app/packages/state/src/recoil/modal.ts
+++ b/app/packages/state/src/recoil/modal.ts
@@ -1,5 +1,9 @@
-import { AbstractLooker, type Sample } from "@fiftyone/looker";
-import { BaseState } from "@fiftyone/looker/src/state";
+import {
+  AbstractLooker,
+  BaseState,
+  PointInfo,
+  type Sample,
+} from "@fiftyone/looker";
 import { mainSample, mainSampleQuery } from "@fiftyone/relay";
 import { atom, selector } from "recoil";
 import { graphQLSelector } from "recoil-relay";
@@ -209,7 +213,7 @@ export const tooltipCoordinates = atom<ComputeCoordinatesReturnType | null>({
   default: null,
 });
 
-export const tooltipDetail = atom<Record<string, string> | null>({
+export const tooltipDetail = atom<PointInfo | null>({
   key: "tooltipDetail",
   default: null,
 });

--- a/app/packages/state/src/recoil/modal.ts
+++ b/app/packages/state/src/recoil/modal.ts
@@ -214,23 +214,8 @@ export const tooltipDetail = atom<Record<string, string> | null>({
   default: null,
 });
 
-export const isTooltipControlKeyPressed = atom<boolean>({
-  key: "isTooltipControlKeyPressed",
-  default: false,
-});
-
-export const isTooltipKeyListenersOn = atom<boolean>({
-  key: "isTooltipKeyListenersOn",
-  default: false,
-});
-
-export const isTooltipMouseListenerOn = atom<boolean>({
-  key: "isTooltipMouseListenerOn",
-  default: false,
-});
-
-export const isTooltipOn3DLabel = atom<boolean>({
-  key: "isTooltipOn3DLabel",
+export const isTooltipLocked = atom<boolean>({
+  key: "isTooltipLocked",
   default: false,
 });
 

--- a/app/packages/state/src/recoil/modal.ts
+++ b/app/packages/state/src/recoil/modal.ts
@@ -5,6 +5,7 @@ import { atom, selector } from "recoil";
 import { graphQLSelector } from "recoil-relay";
 import { VariablesOf } from "relay-runtime";
 import { Nullable } from "vitest";
+import { ComputeCoordinatesReturnType } from "../hooks/useTooltip";
 import { ResponseFrom } from "../utils";
 import {
   activeModalSidebarSample,
@@ -201,6 +202,36 @@ export const modalSample = graphQLSelector<
       },
     };
   },
+});
+
+export const tooltipCoordinates = atom<ComputeCoordinatesReturnType | null>({
+  key: "tooltipCoordinates",
+  default: null,
+});
+
+export const tooltipDetail = atom<Record<string, string> | null>({
+  key: "tooltipDetail",
+  default: null,
+});
+
+export const isTooltipControlKeyPressed = atom<boolean>({
+  key: "isTooltipControlKeyPressed",
+  default: false,
+});
+
+export const isTooltipKeyListenersOn = atom<boolean>({
+  key: "isTooltipKeyListenersOn",
+  default: false,
+});
+
+export const isTooltipMouseListenerOn = atom<boolean>({
+  key: "isTooltipMouseListenerOn",
+  default: false,
+});
+
+export const isTooltipOn3DLabel = atom<boolean>({
+  key: "isTooltipOn3DLabel",
+  default: false,
 });
 
 export class SampleNotFound extends Error {}


### PR DESCRIPTION
## What changes are proposed in this pull request?

This PR introduces a new tooltip behavior that allows it to be locked, dragged, and show/hide label attributes.

![tooltip-gif-small](https://github.com/voxel51/fiftyone/assets/66688606/5c974f86-49e3-4cf9-ab70-3153afdb5763)

## How is this patch tested? If it is not, please explain why.

Manually. Todo: automated tests

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced tooltip functionality with locking, hidden labels, dynamic visibility toggling, and improved styling.
	- Updated modal components for new tooltip locking functionality and state management.
	- Improved 3D viewing components with hover effects and updated event handling.

- **Style Updates**
	- Increased tooltip visibility with higher z-index values and disabled text selection for better user interaction.
	- Added styling properties to content headers for improved alignment and usability.

- **Bug Fixes**
	- Fixed color mapping logic in 3D labels to ensure consistent visual representation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->