### PR TITLE
Add server group tests

### DIFF
--- a/fiftyone/server/filters.py
+++ b/fiftyone/server/filters.py
@@ -19,9 +19,7 @@ class OneOf:
 @gql.input
 class GroupElementFilter:
     id: t.Optional[str] = None
-    slice: t.Optional[str] = gql.field(
-        default=None, deprecation_reason="unused, use 'slices' instead"
-    )
+    slice: t.Optional[str] = None
     slices: t.Optional[t.List[str]] = None
 
 

--- a/fiftyone/server/filters.py
+++ b/fiftyone/server/filters.py
@@ -5,6 +5,7 @@ FiftyOne Server filter inputs
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 import strawberry as gql
 from strawberry.schema_directive import Location
 import typing as t
@@ -18,7 +19,9 @@ class OneOf:
 @gql.input
 class GroupElementFilter:
     id: t.Optional[str] = None
-    slice: t.Optional[str] = None
+    slice: t.Optional[str] = gql.field(
+        deprecation_reason="unused, use 'slices' instead"
+    )
     slices: t.Optional[t.List[str]] = None
 
 

--- a/fiftyone/server/filters.py
+++ b/fiftyone/server/filters.py
@@ -20,7 +20,7 @@ class OneOf:
 class GroupElementFilter:
     id: t.Optional[str] = None
     slice: t.Optional[str] = gql.field(
-        deprecation_reason="unused, use 'slices' instead"
+        default=None, deprecation_reason="unused, use 'slices' instead"
     )
     slices: t.Optional[t.List[str]] = None
 

--- a/fiftyone/server/view.py
+++ b/fiftyone/server/view.py
@@ -227,8 +227,8 @@ def handle_group_filter(
         filter: the :class:`fiftyone.server.aggregations.GroupElementFilter`
 
     Returns:
-        a :class:`fiftyone.core.collections.SampleCollection` with a group or
-        slice selection
+        a :class:`fiftyone.core.view.DatasetView` with a group or slice
+        selection
     """
     stages = view._stages
     group_field = dataset.group_field

--- a/fiftyone/server/view.py
+++ b/fiftyone/server/view.py
@@ -21,7 +21,7 @@ import fiftyone.core.stages as fosg
 import fiftyone.core.utils as fou
 import fiftyone.core.view as fov
 
-from fiftyone.server.aggregations import GroupElementFilter, SampleFilter
+from fiftyone.server.filters import GroupElementFilter, SampleFilter
 from fiftyone.server.scalars import BSONArray, JSON
 
 
@@ -236,7 +236,7 @@ def handle_group_filter(
     unselected = not any(
         isinstance(stage, fosg.SelectGroupSlices) for stage in stages
     )
-    if unselected and filter.slices:
+    if unselected and filter.slice:
         # flatten the collection if the view has no slice(s) selected
         view = dataset.select_group_slices(_force_mixed=True)
 
@@ -249,6 +249,13 @@ def handle_group_filter(
         for stage in stages:
             # add stages after flattening and group match
             view = view._add_view_stage(stage, validate=False)
+
+    else:
+        if filter.slice:
+            view.group_slice = filter.slice
+
+        if filter.id:
+            view = fov.make_optimized_select_view(view, filter.id, groups=True)
 
     if filter.slices:
         # use 'match' to select requested slices, and avoid media type

--- a/fiftyone/server/view.py
+++ b/fiftyone/server/view.py
@@ -231,10 +231,11 @@ def handle_group_filter(
         slice selection
     """
     stages = view._stages
-    unselected = all(
-        not isinstance(stage, fosg.SelectGroupSlices) for stage in stages
-    )
     group_field = dataset.group_field
+
+    unselected = not any(
+        isinstance(stage, fosg.SelectGroupSlices) for stage in stages
+    )
     if unselected and filter.slices:
         # flatten the collection if the view has no slice(s) selected
         view = dataset.select_group_slices(_force_mixed=True)

--- a/tests/unittests/server_group_tests.py
+++ b/tests/unittests/server_group_tests.py
@@ -12,7 +12,6 @@ from bson import ObjectId
 
 import fiftyone as fo
 from fiftyone import ViewExpression as F
-import fiftyone.core.media as fom
 from fiftyone.server.aggregations import GroupElementFilter
 import fiftyone.server.view as fosv
 

--- a/tests/unittests/server_group_tests.py
+++ b/tests/unittests/server_group_tests.py
@@ -1,0 +1,63 @@
+"""
+FiftyOne Server group tests.
+
+| Copyright 2017-2024, Voxel51, Inc.
+| `voxel51.com <https://voxel51.com/>`_
+|
+"""
+
+import unittest
+
+from bson import ObjectId
+
+import fiftyone as fo
+from fiftyone import ViewExpression as F
+import fiftyone.core.media as fom
+from fiftyone.server.aggregations import GroupElementFilter
+import fiftyone.server.view as fosv
+
+from decorators import drop_datasets
+
+
+class ServerGroupTests(unittest.TestCase):
+    @drop_datasets
+    def test_manual_group_slice(self):
+        dataset: fo.Dataset = fo.Dataset()
+        group = fo.Group()
+        image = fo.Sample(
+            filepath="image.png",
+            group=group.element("image"),
+            label=fo.Classification(label="label"),
+        )
+        dataset.add_sample(image)
+        expr = F("label") == "label"
+        filtered = dataset.filter_labels("label", F("label") == "label")
+
+        view = fosv.handle_group_filter(
+            dataset,
+            filtered,
+            GroupElementFilter(slices=["image"]),
+        )
+        self.assertEqual(
+            view._all_stages,
+            [
+                fo.SelectGroupSlices(_force_mixed=True),
+                fo.FilterLabels("label", expr),
+                fo.Match({"group.name": {"$in": ["image"]}}),
+            ],
+        )
+
+        view = fosv.handle_group_filter(
+            dataset,
+            filtered,
+            GroupElementFilter(id=image.group.id, slices=["image"]),
+        )
+        self.assertEqual(
+            view._all_stages,
+            [
+                fo.SelectGroupSlices(_force_mixed=True),
+                fo.Match({"group._id": {"$in": [ObjectId(image.group.id)]}}),
+                fo.FilterLabels("label", expr),
+                fo.Match({"group.name": {"$in": ["image"]}}),
+            ],
+        )

--- a/tests/unittests/server_group_tests.py
+++ b/tests/unittests/server_group_tests.py
@@ -35,7 +35,7 @@ class ServerGroupTests(unittest.TestCase):
         view = fosv.handle_group_filter(
             dataset,
             filtered,
-            GroupElementFilter(slices=["image"]),
+            GroupElementFilter(slice="image", slices=["image"]),
         )
         self.assertEqual(
             view._all_stages,
@@ -49,7 +49,9 @@ class ServerGroupTests(unittest.TestCase):
         view = fosv.handle_group_filter(
             dataset,
             filtered,
-            GroupElementFilter(id=image.group.id, slices=["image"]),
+            GroupElementFilter(
+                id=image.group.id, slice="image", slices=["image"]
+            ),
         )
         self.assertEqual(
             view._all_stages,


### PR DESCRIPTION
## What changes are proposed in this pull request?

Adds coverage to `handle_group_filter` and removes unused code paths

```python
from fiftyone import ViewField as F
import fiftyone as fo
import fiftyone.zoo as foz

tmp = foz.load_zoo_dataset("quickstart", max_samples=2)


dataset: fo.Dataset = fo.Dataset("test-app-groups")
group = fo.Group()

annotate = lambda: fo.Detections(
    detections=[
        fo.Detection(label="top-left", bounding_box=[0, 0, 0.5, 0.5]),
        fo.Detection(label="bottom-right", bounding_box=[0.5, 0.5, 0.5, 0.5]),
    ]
)

one = fo.Sample(
    tmp.first().filepath, annotations=annotate(), group=group.element("first")
)
two = fo.Sample(
    tmp.skip(1).first().filepath,
    annotations=annotate(),
    group=group.element("second"),
)
dataset.add_samples([one, two])


# only 'top-left' detections should be present
filtered = dataset.filter_labels("annotations", F("label") == "top-left")
dataset.save_view("top-left", filtered)
# session = fo.launch_app(filtered)

# NOTE: due to cloning behavior for group datasets, each group slice
# should be added individually to a new Dataset. DO NOT USE 'clone'
# directly

clone: fo.Dataset = fo.Dataset("my-filtered-clone")
clone.add_group_field("group", default="first")

for slice in filtered.group_slices:
    filtered.group_slice = slice
    clone.add_samples(filtered)

print(clone.values("annotations.detections")) # only 'top-left' should be present
``` 

## How is this patch tested? If it is not, please explain why.

Unit test for server `handle_group_filter`

## Release Notes

* Removed unwanted group slice selection when pinning or saving sidebar filters

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
    - Improved handling of group filters in App views to enhance user selection processes.
- **Deprecations**
    - Deprecated the `slice` field in favor of `slices` for better clarity and functionality.
- **Tests**
    - Added tests for new grouping and filtering functionalities in the FiftyOne Server.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->