### PR TITLE
use logging_level config for asyncio debug logging

### DIFF
--- a/fiftyone/server/main.py
+++ b/fiftyone/server/main.py
@@ -5,6 +5,7 @@ FiftyOne Server main
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 import argparse
 import os
 
@@ -12,9 +13,6 @@ import asyncio
 from hypercorn.asyncio import serve
 from hypercorn.config import Config
 import logging
-
-if os.environ.get("FIFTYONE_ENABLE_DEBUG_LOGGING", False):
-    logging.getLogger("asyncio").setLevel(logging.DEBUG)
 
 if os.environ.get("FIFTYONE_DISABLE_SERVICES", False):
     del os.environ["FIFTYONE_DISABLE_SERVICES"]
@@ -27,6 +25,10 @@ import fiftyone.constants as foc
 from fiftyone.server.app import app
 from fiftyone.server.events import set_port
 
+DEBUG_LOGGING = fo.config.logging_level == "DEBUG"
+
+if DEBUG_LOGGING:
+    logging.getLogger("asyncio").setLevel(logging.DEBUG)
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
@@ -45,4 +47,4 @@ if __name__ == "__main__":
     if args.clean_start:
         fo.delete_datasets("*")
 
-    asyncio.run(serve(app, config), debug=foc.DEV_INSTALL)
+    asyncio.run(serve(app, config), debug=DEBUG_LOGGING)


### PR DESCRIPTION
## What changes are proposed in this pull request?

AsyncIO debug logging is enabled by default in the dev install. PR changes the debug logging to be opt-in based on the `logging_level` config

## How is this patch tested? If it is not, please explain why.

Using the dev server and verifying asyncio debug logs are not printed

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated the handling of debug logging to be controlled by the configuration's logging level, enhancing consistency and control over log settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->