### PR TITLE
Updating 3D zoo datasets to use FO3D format

### DIFF
--- a/docs/source/user_guide/app.rst
+++ b/docs/source/user_guide/app.rst
@@ -1181,19 +1181,10 @@ Using the 3D visualizer
 _______________________
 
 The 3D visualizer allows you to interactively visualize
-:ref:`fo3d samples <three-d-datasets>` or
+:ref:`3D samples <3d-datasets>` or
 :ref:`point cloud samples <point-cloud-datasets>`
 along with any associated
 :ref:`3D detections <3d-detections>` and :ref:`3D polylines <3d-polylines>`:
-
-.. note::
-
-    Deprecation notice:
-
-    The `point-cloud` media type has been deprecated in favor of the
-    `3d` media type. While we'll keep supporting the `point-cloud` media type
-    for backward compatibility, we recommend using the `3d` media type for new
-    datasets.
 
 .. image:: /images/app/app-new-3d-visualizer.gif
    :alt: 3d-visualizer
@@ -1268,7 +1259,7 @@ dataset, the projection images will be rendered for each sample in the grid:
     import fiftyone.utils.utils3d as fou3d
     import fiftyone.zoo as foz
 
-    # Load an example point cloud dataset
+    # Load an example 3D dataset
     dataset = (
         foz.load_zoo_dataset("quickstart-groups")
         .select_group_slices("pcd")

--- a/docs/source/user_guide/groups.rst
+++ b/docs/source/user_guide/groups.rst
@@ -587,7 +587,7 @@ points that demonstrates how
     o3d.io.write_point_cloud("/tmp/toy.pcd", pc)
 
     scene = fo.Scene()
-    scene.add(fo.Pointcloud("point cloud", "/tmp/toy.pcd"))
+    scene.add(fo.PointCloud("point cloud", "/tmp/toy.pcd"))
     scene.write("/tmp/toy.fo3d")
 
     group = fo.Group()

--- a/docs/source/user_guide/groups.rst
+++ b/docs/source/user_guide/groups.rst
@@ -6,12 +6,13 @@ Grouped datasets
 .. default-role:: code
 
 FiftyOne supports the creation of **grouped datasets**, which contain multiple
-slices of samples of possibly different modalities (image, video, or point
-cloud) that are organized into groups.
+slices of samples of possibly different modalities (e.g.,
+:ref:`image <dataset-media-type>`, :ref:`video <video-datasets>`, or
+:ref:`3D scenes <3d-datasets>`) that are organized into groups.
 
-Grouped datasets can be used, for example, to represent multiview scenes, where
-data for multiple perspectives of the same scene can be stored, visualized, and
-queried in ways that respect the relationships between the slices of data.
+Grouped datasets can be used to represent multiview scenes, where data for
+multiple perspectives of the same scene can be stored, visualized, and queried
+in ways that respect the relationships between the slices of data.
 
 .. image:: /images/groups/groups-modal.gif
    :alt: groups-sizzle
@@ -179,9 +180,9 @@ expanded as you add samples to a grouped dataset.
 
 .. note::
 
-    Grouped datasets may contain a mix of images, videos, and point clouds, but
-    FiftyOne strictly enforces that each **slice** of a grouped dataset must
-    have a homogeneous media type.
+    Grouped datasets may contain a mix of different modalities (e.g., images,
+    videos, and 3D scenes), but FiftyOne strictly enforces that each **slice**
+    of a grouped dataset must have a homogeneous media type.
 
     For example, you would see an error if you tried to add a video sample to
     the `left` slice of the above dataset, since it contains images.
@@ -509,7 +510,7 @@ data:
     dataset = foz.load_zoo_dataset("quickstart-groups")
 
     print(dataset.group_media_types)
-    # {'left': 'image', 'right': 'image', 'pcd': 'point-cloud'}
+    # {'left': 'image', 'right': 'image', 'pcd': '3d'}
 
     print(dataset)
 
@@ -585,6 +586,10 @@ points that demonstrates how
     pc.points = o3d.utility.Vector3dVector(np.array(point_cloud))
     o3d.io.write_point_cloud("/tmp/toy.pcd", pc)
 
+    scene = fo.Scene()
+    scene.add(fo.Pointcloud("point cloud", "/tmp/toy.pcd"))
+    scene.write("/tmp/toy.fo3d")
+
     group = fo.Group()
     samples = [
         fo.Sample(
@@ -592,7 +597,7 @@ points that demonstrates how
             group=group.element("image"),
         ),
         fo.Sample(
-            filepath="/tmp/toy.pcd",
+            filepath="/tmp/toy.fo3d",
             group=group.element("pcd"),
             detections=fo.Detections(detections=detections),
         )
@@ -611,15 +616,6 @@ points that demonstrates how
 .. image:: /images/groups/toy-point-cloud.png
    :alt: toy-point-cloud
    :align: center
-
-.. _groups-point-clouds:
-
-Point cloud slices
-__________________
-
-Grouped datasets may contain one or more
-:ref:`point cloud slices <point-cloud-datasets>`, which can be visualized in
-the App's :ref:`3D visualizer <app-3d-visualizer>`.
 
 .. _groups-views:
 
@@ -990,7 +986,7 @@ You can use the selector shown below to change which slice you are viewing:
 
 .. note::
 
-    In order to view point cloud slices in the grid view, you must populate
+    In order to view 3D scenes in the grid view, you must populate
     :ref:`orthographic projection images <orthographic-projection-images>`.
 
 When you open the expanded modal with a grouped dataset or view loaded in the
@@ -1000,8 +996,8 @@ If the group contains image/video slices, the lefthand side of the modal will
 contain a scrollable carousel that you can use to choose which sample to load
 in the maximized image/video visualizer below.
 
-If the group contains point cloud slices, the righthand side of the modal will
-contain a :ref:`3D visualizer <app-3d-visualizer>`:
+If the group contains 3D slices, the righthand side of the modal will contain a
+:ref:`3D visualizer <app-3d-visualizer>`:
 
 .. image:: /images/groups/groups-modal.gif
    :alt: groups-modal

--- a/fiftyone/utils/data/exporters.py
+++ b/fiftyone/utils/data/exporters.py
@@ -1893,6 +1893,10 @@ class LegacyFiftyOneDatasetExporter(GenericSampleDatasetExporter):
     def log_collection(self, sample_collection):
         self._metadata["name"] = sample_collection._dataset.name
         self._metadata["media_type"] = sample_collection.media_type
+        if sample_collection.media_type == fomm.GROUP:
+            self._metadata[
+                "group_media_types"
+            ] = sample_collection.group_media_types
 
         schema = sample_collection._serialize_field_schema()
         self._metadata["sample_fields"] = schema

--- a/fiftyone/utils/kitti.py
+++ b/fiftyone/utils/kitti.py
@@ -1139,7 +1139,7 @@ def _write_fo3d_files(pcd_dir, fo3d_dir, overwrite=False, abs_paths=False):
 
             scene = fo3d.Scene(camera=fo3d.PerspectiveCamera(up="Z"))
             scene.add(
-                fo3d.Pointcloud(
+                fo3d.PointCloud(
                     "point cloud", pcd_filepath, flag_for_projection=True
                 )
             )

--- a/fiftyone/utils/kitti.py
+++ b/fiftyone/utils/kitti.py
@@ -1138,9 +1138,5 @@ def _write_fo3d_files(pcd_dir, fo3d_dir, overwrite=False, abs_paths=False):
                 pcd_filepath = os.path.relpath(pcd_filepath, fo3d_dir)
 
             scene = fo3d.Scene(camera=fo3d.PerspectiveCamera(up="Z"))
-            scene.add(
-                fo3d.PointCloud(
-                    "point cloud", pcd_filepath, flag_for_projection=True
-                )
-            )
+            scene.add(fo3d.PointCloud("point cloud", pcd_filepath))
             scene.write(scene_filepath)

--- a/fiftyone/utils/kitti.py
+++ b/fiftyone/utils/kitti.py
@@ -1137,7 +1137,7 @@ def _write_fo3d_files(pcd_dir, fo3d_dir, overwrite=False, abs_paths=False):
             if not abs_paths:
                 pcd_filepath = os.path.relpath(pcd_filepath, fo3d_dir)
 
-            scene = fo3d.Scene()
+            scene = fo3d.Scene(camera=fo3d.PerspectiveCamera(up="Z"))
             scene.add(
                 fo3d.Pointcloud(
                     "point cloud", pcd_filepath, flag_for_projection=True

--- a/fiftyone/utils/kitti.py
+++ b/fiftyone/utils/kitti.py
@@ -20,6 +20,7 @@ import fiftyone as fo
 import fiftyone.core.labels as fol
 import fiftyone.core.metadata as fom
 import fiftyone.core.storage as fos
+import fiftyone.core.threed as fo3d
 import fiftyone.core.utils as fou
 import fiftyone.utils.data as foud
 
@@ -532,9 +533,11 @@ def download_kitti_multiview_dataset(
 
     for split in splits:
         split_dir = os.path.join(dataset_dir, split)
-        _prepare_kitti_split(
-            split_dir, overwrite=overwrite, num_workers=num_workers
-        )
+        samples_path = os.path.join(split_dir, "samples.json")
+        if overwrite or not os.path.isfile(samples_path):
+            _prepare_kitti_split(
+                split_dir, overwrite=overwrite, num_workers=num_workers
+            )
 
     if cleanup:
         etau.delete_dir(scratch_dir)
@@ -815,10 +818,6 @@ def _make_kitti_detection_row(detection, frame_size):
 
 
 def _prepare_kitti_split(split_dir, overwrite=False, num_workers=None):
-    samples_path = os.path.join(split_dir, "samples.json")
-    if not overwrite and os.path.isfile(samples_path):
-        return
-
     group_field = "group"
     label_field = "ground_truth"
 
@@ -836,6 +835,7 @@ def _prepare_kitti_split(split_dir, overwrite=False, num_workers=None):
     left_images_dir = os.path.join(split_dir, "left")
     right_images_dir = os.path.join(split_dir, "right")
     pcd_dir = os.path.join(split_dir, "pcd")
+    fo3d_dir = os.path.join(split_dir, "fo3d")
 
     make_map = lambda d: {
         os.path.splitext(os.path.basename(p))[0]: p
@@ -856,9 +856,11 @@ def _prepare_kitti_split(split_dir, overwrite=False, num_workers=None):
         num_workers=num_workers,
     )
 
+    _write_fo3d_files(pcd_dir, fo3d_dir, overwrite=overwrite)
+
     left_map = make_map(left_images_dir)
     right_map = make_map(right_images_dir)
-    pcd_map = make_map(pcd_dir)
+    fo3d_map = make_map(fo3d_dir)
 
     is_labeled = os.path.isdir(labels_dir)
     if is_labeled:
@@ -873,7 +875,7 @@ def _prepare_kitti_split(split_dir, overwrite=False, num_workers=None):
 
             left_filepath = left_map[uuid]
             right_filepath = right_map[uuid]
-            pcd_filepath = pcd_map[uuid]
+            scene_filepath = fo3d_map[uuid]
 
             left_sample = fo.Sample(filepath=left_filepath)
             left_sample[group_field] = group.element("left")
@@ -881,7 +883,7 @@ def _prepare_kitti_split(split_dir, overwrite=False, num_workers=None):
             right_sample = fo.Sample(filepath=right_filepath)
             right_sample[group_field] = group.element("right")
 
-            pcd_sample = fo.Sample(filepath=pcd_filepath)
+            pcd_sample = fo.Sample(filepath=scene_filepath)
             pcd_sample[group_field] = group.element("pcd")
 
             if is_labeled:
@@ -915,11 +917,13 @@ def _prepare_kitti_split(split_dir, overwrite=False, num_workers=None):
 
             samples.extend([left_sample, right_sample, pcd_sample])
 
+    logger.info("Adding samples...")
     dataset.add_samples(samples)
 
     if is_labeled:
         dataset.compute_metadata()
 
+    logger.info("Writing samples...")
     dataset.export(
         export_dir=split_dir,
         dataset_type=fo.types.FiftyOneDataset,
@@ -1120,3 +1124,19 @@ def _do_conversion(input):
     pcd.colors = o3d.utility.Vector3dVector(colors)
 
     o3d.io.write_point_cloud(pcd_path, pcd)
+
+
+def _write_fo3d_files(pcd_dir, fo3d_dir, overwrite=False, abs_paths=False):
+    for pcd_filepath in etau.list_files(pcd_dir, abs_paths=True):
+        scene_filepath = os.path.join(
+            fo3d_dir,
+            os.path.splitext(os.path.basename(pcd_filepath))[0] + ".fo3d",
+        )
+
+        if overwrite or not os.path.isfile(scene_filepath):
+            if not abs_paths:
+                pcd_filepath = os.path.relpath(pcd_filepath, fo3d_dir)
+
+            scene = fo3d.Scene()
+            scene.add(fo3d.Pointcloud("point cloud", pcd_filepath))
+            scene.write(scene_filepath)

--- a/fiftyone/utils/kitti.py
+++ b/fiftyone/utils/kitti.py
@@ -1138,5 +1138,9 @@ def _write_fo3d_files(pcd_dir, fo3d_dir, overwrite=False, abs_paths=False):
                 pcd_filepath = os.path.relpath(pcd_filepath, fo3d_dir)
 
             scene = fo3d.Scene()
-            scene.add(fo3d.Pointcloud("point cloud", pcd_filepath))
+            scene.add(
+                fo3d.Pointcloud(
+                    "point cloud", pcd_filepath, flag_for_projection=True
+                )
+            )
             scene.write(scene_filepath)

--- a/fiftyone/utils/utils3d.py
+++ b/fiftyone/utils/utils3d.py
@@ -20,14 +20,14 @@ import eta.core.utils as etau
 import fiftyone.core.fields as fof
 import fiftyone.core.labels as fol
 import fiftyone.core.media as fom
+from fiftyone.core.sample import Sample
 import fiftyone.core.storage as fos
+from fiftyone.core.threed import PerspectiveCamera, PointCloud, Scene
+from fiftyone.core.odm import DynamicEmbeddedDocument
 import fiftyone.core.utils as fou
 import fiftyone.core.validation as fov
 import fiftyone.utils.data as foud
 import fiftyone.utils.image as foui
-from fiftyone.core.odm import DynamicEmbeddedDocument
-from fiftyone.core.sample import Sample
-from fiftyone.core.threed import PointCloud, Scene
 
 o3d = fou.lazy_import("open3d", callback=lambda: fou.ensure_package("open3d"))
 
@@ -1158,7 +1158,7 @@ def _make_scene(
         if not rel_path.startswith(".."):
             pcd_path = rel_path
 
-    scene = Scene()
+    scene = Scene(camera=PerspectiveCamera(up="Z"))
     scene.add(
         PointCloud(
             "point cloud",

--- a/fiftyone/utils/utils3d.py
+++ b/fiftyone/utils/utils3d.py
@@ -972,7 +972,6 @@ def pcd_to_3d(
     assets_dir=None,
     rel_dir=None,
     abs_paths=False,
-    flag_for_projection=True,
     progress=None,
 ):
     """Converts the point cloud samples in the given dataset to 3D samples.
@@ -999,8 +998,6 @@ def pcd_to_3d(
             :func:`fiftyone.core.storage.normalize_path`
         abs_paths (False): whether to store absolute paths to the point cloud
             files in the exported ``.fo3d`` files
-        flag_for_projection (True): whether to flag the point clouds for usage
-            in orthographic projection
         progress (None): whether to render a progress bar (True/False), use the
             default value ``fiftyone.config.show_progress_bars`` (None), or a
             progress callback function to invoke instead
@@ -1015,7 +1012,6 @@ def pcd_to_3d(
             assets_dir=assets_dir,
             rel_dir=rel_dir,
             abs_paths=abs_paths,
-            flag_for_projection=flag_for_projection,
             progress=progress,
         )
         return
@@ -1026,7 +1022,6 @@ def pcd_to_3d(
         assets_dir=assets_dir,
         rel_dir=rel_dir,
         abs_paths=abs_paths,
-        flag_for_projection=flag_for_projection,
         progress=progress,
     )
 
@@ -1041,7 +1036,6 @@ def _pcd_slices_to_3d_slices(
     assets_dir=None,
     rel_dir=None,
     abs_paths=False,
-    flag_for_projection=True,
     progress=None,
 ):
     if isinstance(slices, dict):
@@ -1069,7 +1063,6 @@ def _pcd_slices_to_3d_slices(
                 assets_dir=assets_dir,
                 rel_dir=rel_dir,
                 abs_paths=abs_paths,
-                flag_for_projection=flag_for_projection,
                 progress=progress,
             )
 
@@ -1088,7 +1081,6 @@ def _pcd_to_3d(
     assets_dir=None,
     rel_dir=None,
     abs_paths=False,
-    flag_for_projection=True,
     progress=None,
 ):
     filename_maker = None
@@ -1126,7 +1118,6 @@ def _pcd_to_3d(
                 filename_maker=filename_maker,
                 media_exporter=media_exporter,
                 abs_paths=abs_paths,
-                flag_for_projection=flag_for_projection,
             )
             scene_paths.append(scene_path)
 
@@ -1141,7 +1132,6 @@ def _make_scene(
     filename_maker=None,
     media_exporter=None,
     abs_paths=False,
-    flag_for_projection=True,
 ):
     if filename_maker is not None:
         scene_path = filename_maker.get_output_path(
@@ -1159,13 +1149,7 @@ def _make_scene(
             pcd_path = rel_path
 
     scene = Scene(camera=PerspectiveCamera(up="Z"))
-    scene.add(
-        PointCloud(
-            "point cloud",
-            pcd_path,
-            flag_for_projection=flag_for_projection,
-        )
-    )
+    scene.add(PointCloud("point cloud", pcd_path))
     scene.write(scene_path)
 
     return scene_path

--- a/fiftyone/utils/utils3d.py
+++ b/fiftyone/utils/utils3d.py
@@ -972,6 +972,7 @@ def pcd_to_3d(
     assets_dir=None,
     rel_dir=None,
     abs_paths=False,
+    flag_for_projection=True,
     progress=None,
 ):
     """Converts the point cloud samples in the given dataset to 3D samples.
@@ -998,6 +999,8 @@ def pcd_to_3d(
             :func:`fiftyone.core.storage.normalize_path`
         abs_paths (False): whether to store absolute paths to the point cloud
             files in the exported ``.fo3d`` files
+        flag_for_projection (True): whether to flag the point clouds for usage
+            in orthographic projection
         progress (None): whether to render a progress bar (True/False), use the
             default value ``fiftyone.config.show_progress_bars`` (None), or a
             progress callback function to invoke instead
@@ -1012,6 +1015,7 @@ def pcd_to_3d(
             assets_dir=assets_dir,
             rel_dir=rel_dir,
             abs_paths=abs_paths,
+            flag_for_projection=flag_for_projection,
             progress=progress,
         )
         return
@@ -1022,6 +1026,7 @@ def pcd_to_3d(
         assets_dir=assets_dir,
         rel_dir=rel_dir,
         abs_paths=abs_paths,
+        flag_for_projection=flag_for_projection,
         progress=progress,
     )
 
@@ -1036,6 +1041,7 @@ def _pcd_slices_to_3d_slices(
     assets_dir=None,
     rel_dir=None,
     abs_paths=False,
+    flag_for_projection=True,
     progress=None,
 ):
     if isinstance(slices, dict):
@@ -1063,6 +1069,7 @@ def _pcd_slices_to_3d_slices(
                 assets_dir=assets_dir,
                 rel_dir=rel_dir,
                 abs_paths=abs_paths,
+                flag_for_projection=flag_for_projection,
                 progress=progress,
             )
 
@@ -1081,6 +1088,7 @@ def _pcd_to_3d(
     assets_dir=None,
     rel_dir=None,
     abs_paths=False,
+    flag_for_projection=True,
     progress=None,
 ):
     filename_maker = None
@@ -1118,6 +1126,7 @@ def _pcd_to_3d(
                 filename_maker=filename_maker,
                 media_exporter=media_exporter,
                 abs_paths=abs_paths,
+                flag_for_projection=flag_for_projection,
             )
             scene_paths.append(scene_path)
 
@@ -1132,6 +1141,7 @@ def _make_scene(
     filename_maker=None,
     media_exporter=None,
     abs_paths=False,
+    flag_for_projection=True,
 ):
     if filename_maker is not None:
         scene_path = filename_maker.get_output_path(
@@ -1149,7 +1159,13 @@ def _make_scene(
             pcd_path = rel_path
 
     scene = Scene()
-    scene.add(PointCloud("point cloud", pcd_path))
+    scene.add(
+        PointCloud(
+            "point cloud",
+            pcd_path,
+            flag_for_projection=flag_for_projection,
+        )
+    )
     scene.write(scene_path)
 
     return scene_path

--- a/fiftyone/zoo/datasets/base.py
+++ b/fiftyone/zoo/datasets/base.py
@@ -3130,10 +3130,10 @@ class QuickstartGroupsDataset(FiftyOneDataset):
         session = fo.launch_app(dataset)
 
     Dataset size
-        516.3 MB
+        576 MB
     """
 
-    _GDRIVE_ID = "1mLfmb0Bj9L7SaDwcgpKVetvKEGt-b7Lb"
+    _GDRIVE_ID = "1OcuP2daa_usoinLm64CueObGFxLBwOjE"
     _ARCHIVE_NAME = "quickstart-groups.zip"
     _DIR_IN_ARCHIVE = "quickstart-groups"
 
@@ -3302,7 +3302,7 @@ def _should_patch_pcd(dataset_dir):
         return False
 
     try:
-        # LegacyFiftyOneDataset format
+        # v1 patch: for LegacyFiftyOneDataset format
         config = metadata["info"]["app_config"]["plugins"]["3d"]
         if "itemRotation" in config["overlay"]:
             return True
@@ -3310,8 +3310,16 @@ def _should_patch_pcd(dataset_dir):
         pass
 
     try:
-        # PCD format
-        if metadata["group_media_types"]["pcd"] == "point-cloud":
+        # v1 patch: for FiftyOneDataset format
+        config = metadata["app_config"]["plugins"]["3d"]
+        if "itemRotation" in config["overlay"]:
+            return True
+    except:
+        pass
+
+    try:
+        # v2 patch: point-cloud -> 3D conversion
+        if metadata.get("group_media_types", {}).get("pcd", None) != "3d":
             return True
     except:
         pass


### PR DESCRIPTION
Updates the zoo datasets below to use the new `'3d'` media type rather than `'point-cloud'`.

If a user has already downloaded these datasets, the on-disk files will be patched in-place (only once) to use the 3D media type.

```py
import fiftyone as fo
import fiftyone.zoo as foz

dataset = foz.load_zoo_dataset("quickstart-groups")
dataset = foz.load_zoo_dataset("kitti-multiview")
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Documentation**
	- Updated user guide to reflect the transition from `point cloud` to `3D` media types across various sections.
	- Enhanced guidance on organizing grouped datasets and handling multi-view scenes.
	- Revised example code snippets and recommendations for using 3D datasets and GLTF format.
- **New Features**
	- Introduced new parameters and functions to support 3D data handling and projections in utility scripts.
- **Refactor**
	- Modified data handling logic to better support new 3D dataset structures and metadata settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->