### PR TITLE
Bump Desktop to 0.33.7 for 0.23.8

### DIFF
--- a/package/desktop/setup.py
+++ b/package/desktop/setup.py
@@ -16,7 +16,7 @@ import os
 import shutil
 
 
-VERSION = "0.33.6"
+VERSION = "0.33.7"
 
 
 def get_version():

--- a/setup.py
+++ b/setup.py
@@ -115,7 +115,7 @@ def get_install_requirements(install_requires, choose_install_requires):
     return install_requires
 
 
-EXTRAS_REQUIREMENTS = {"desktop": ["fiftyone-desktop~=0.33.6"]}
+EXTRAS_REQUIREMENTS = {"desktop": ["fiftyone-desktop~=0.33.7"]}
 
 
 with open("README.md", "r") as fh:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the `fiftyone-desktop` package version to "0.33.7" to ensure compatibility and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->