### PR TITLE
initial python panel e2e test

### DIFF
--- a/app/packages/spaces/src/components/Panel.tsx
+++ b/app/packages/spaces/src/components/Panel.tsx
@@ -15,9 +15,11 @@ function Panel({ node }: PanelProps) {
   const dimensions = fos.useDimensions();
   const pending = fos.useTimeout(PANEL_LOADING_TIMEOUT);
 
+  const panelContentTestId = `panel-content-${panelName}`;
+
   if (!panel) {
     return (
-      <StyledPanel>
+      <StyledPanel data-cy={panelContentTestId}>
         <CenteredStack>
           {pending ? (
             <PanelSkeleton />
@@ -34,7 +36,7 @@ function Panel({ node }: PanelProps) {
   const { component: Component } = panel;
 
   return (
-    <StyledPanel id={node.id} ref={dimensions.ref}>
+    <StyledPanel id={node.id} ref={dimensions.ref} data-cy={panelContentTestId}>
       <PanelContext.Provider value={{ node }}>
         <Component panelNode={node} dimensions={dimensions} />
       </PanelContext.Provider>

--- a/e2e-pw/src/oss/poms/panels/panel.ts
+++ b/e2e-pw/src/oss/poms/panels/panel.ts
@@ -1,6 +1,11 @@
 import { Locator, Page, expect } from "src/oss/fixtures";
 
-export type PanelName = "Samples" | "Histograms" | "Embeddings" | "OperatorIO";
+export type PanelName =
+  | "Samples"
+  | "Histograms"
+  | "Embeddings"
+  | "OperatorIO"
+  | string;
 export class PanelPom {
   readonly page: Page;
   readonly locator: Locator;
@@ -27,12 +32,16 @@ export class PanelPom {
     return this.locator.getByTitle("Close");
   }
 
-  getPanelOption(panelName: PanelName) {
-    return this.locator.getByTestId(`new-panel-option-${panelName}`);
+  getPanelOption(name: PanelName) {
+    return this.locator.getByTestId(`new-panel-option-${name}`);
   }
 
   getTab(name: PanelName) {
     return this.locator.getByTestId(`panel-tab-${name.toLocaleLowerCase()}`);
+  }
+
+  getContent(name: PanelName) {
+    return this.page.getByTestId(`panel-content-${name}`);
   }
 
   async open(panelName: PanelName) {

--- a/e2e-pw/src/oss/specs/operators/python-panels.spec.ts
+++ b/e2e-pw/src/oss/specs/operators/python-panels.spec.ts
@@ -1,0 +1,53 @@
+import { test as base, expect } from "src/oss/fixtures";
+import { PanelPom } from "src/oss/poms/panels/panel";
+import { getUniqueDatasetNameWithPrefix } from "src/oss/utils";
+
+const datasetName = getUniqueDatasetNameWithPrefix(`python-panels`);
+const test = base.extend<{ panel: PanelPom }>({
+  panel: async ({ page }, use) => {
+    await use(new PanelPom(page));
+  },
+});
+
+test.beforeAll(async ({ fiftyoneLoader }) => {
+  await fiftyoneLoader.executePythonCode(`
+    import fiftyone as fo
+    dataset = fo.Dataset("${datasetName}")
+    dataset.persistent = True
+
+    samples = []
+    for i in range(0, 10):
+        sample = fo.Sample(
+            filepath=f"{i}.png",
+            detections=fo.Detections(detections=[fo.Detection(label=f"label-{i}")]),
+            classification=fo.Classification(label=f"label-{i}"),
+            bool=i % 2 == 0,
+            str=f"{i}",
+            int=i % 2,
+            float=i / 2,
+            list_str=[f"{i}"],
+            list_int=[i % 2],
+            list_float=[i / 2],
+            list_bool=[i % 2 == 0],
+        )
+        samples.append(sample)
+    
+    dataset.add_samples(samples)`);
+});
+
+test.beforeEach(async ({ page, fiftyoneLoader }) => {
+  await fiftyoneLoader.waitUntilGridVisible(page, datasetName);
+});
+
+test("Python Panels: Counter", async ({ panel }) => {
+  const panelName = "e2e_counter_python_panel";
+  await panel.open(panelName);
+  const content = panel.getContent(panelName);
+  await expect(content.locator(".MuiAlert-standard")).toHaveText("Count: 0");
+  await content.locator("button:text('Increment')").click();
+  await expect(content.locator(".MuiAlert-standard")).toHaveText("Count: 1");
+  await content.locator("button:text('Increment')").click();
+  await expect(content.locator(".MuiAlert-standard")).toHaveText("Count: 2");
+  await content.locator("button:text('Decrement')").click();
+  await expect(content.locator(".MuiAlert-standard")).toHaveText("Count: 1");
+});

--- a/e2e-pw/src/shared/assets/plugins/e2e/__init__.py
+++ b/e2e-pw/src/shared/assets/plugins/e2e/__init__.py
@@ -94,8 +94,38 @@ class E2EProgress(foo.Operator):
             await asyncio.sleep(0.5)
 
 
+class E2ECounterPythonPanel(foo.Panel):
+    @property
+    def config(self):
+        return foo.PanelOperatorConfig(
+            name="e2e_counter_python_panel",
+            label="E2E: Counter Python Panel",
+            allow_multiple=True,
+        )
+
+    def on_load(self, ctx):
+        ctx.panel.state.count = 0
+
+    def render(self, ctx):
+        panel = types.Object()
+        panel.message("Count", f"Count: {ctx.panel.state.count}")
+        panel.btn("increment", label="Increment", on_click=self.increment)
+        panel.btn("decrement", label="Decrement", on_click=self.decrement)
+        return types.Property(panel)
+
+    def increment(self, ctx):
+        current_count = ctx.panel.state.count or 0
+        ctx.panel.state.count = current_count + 1
+
+    def decrement(self, ctx):
+        current_count = ctx.panel.state.count or 0
+        if current_count > 0:
+            ctx.panel.state.count = current_count - 1
+
+
 def register(p):
     p.register(E2ESetView)
     p.register(E2ESayHelloInModal)
     p.register(E2ESayHelloInDrawer)
     p.register(E2EProgress)
+    p.register(E2ECounterPythonPanel)

--- a/e2e-pw/src/shared/assets/plugins/e2e/fiftyone.yml
+++ b/e2e-pw/src/shared/assets/plugins/e2e/fiftyone.yml
@@ -8,3 +8,4 @@ operators:
   - e2e_say_hello_in_modal
   - e2e_say_hello_in_drawer
   - e2e_progress
+  - e2e_counter_python_panel


### PR DESCRIPTION
## What changes are proposed in this pull request?

Add an e2e test for panel registered using a python operator

## How is this patch tested? If it is not, please explain why.

GitHub Actions

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Expanded the `PanelName` type to include custom string options.

- **Tests**
  - Introduced new test cases for Python panels, including setup for loading datasets and opening the Python panel for testing.

- **Documentation**
  - Added details about the `e2e_counter_python_panel` operator in the configuration file.

- **Style**
  - Updated the `StyledPanel` component to include a `data-cy` attribute for better test identification.

- **Chores**
  - Added a new class `E2ECounterPythonPanel` with methods for panel interaction and configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->