### PR TITLE
convert properties in set selected label from snake-cased to camel-cased

### DIFF
--- a/app/packages/operators/src/built-in-operators.ts
+++ b/app/packages/operators/src/built-in-operators.ts
@@ -735,7 +735,18 @@ class SetSelectedLabels extends Operator {
     };
   }
   async execute({ hooks, params }: ExecutionContext) {
-    hooks.setSelected(params.labels);
+    const labels = params?.labels;
+    const formattedLabels = Array.isArray(labels)
+      ? labels.map((label) => {
+          return {
+            field: label.field,
+            sampleId: label.sampleId ?? label.sample_id,
+            labelId: label.labelId ?? label.label_id,
+            frameNumber: label.frameNumber ?? label.frame_number,
+          };
+        })
+      : [];
+    hooks.setSelected(formattedLabels);
   }
 }
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

convert properties in set selected label from snake-cased to camel-cased

## How is this patch tested? If it is not, please explain why.

Using a test operator to set label of a sample

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

Fix built-in operator set selected label not working when label properties are snake-cased

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Enhanced label formatting in the selection process to handle null values and map properties more effectively.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->