### PR TITLE
add media_fallback option to fallback to filepath field for media

### DIFF
--- a/app/packages/app/src/pages/__generated__/IndexPageQuery.graphql.ts
+++ b/app/packages/app/src/pages/__generated__/IndexPageQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<f5b436d9a239fa5b47cf43bc20a39377>>
+ * @generated SignedSource<<71edb5ac87b47af3f7d703b59fffb591>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -262,6 +262,13 @@ return {
             "kind": "ScalarField",
             "name": "useFrameNumber",
             "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "mediaFallback",
+            "storageKey": null
           }
         ],
         "storageKey": null
@@ -410,12 +417,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "0c55ce94421a57a68f03347c93283c4d",
+    "cacheID": "4be27983cf9d8ad6ba5448771ba43f28",
     "id": null,
     "metadata": {},
     "name": "IndexPageQuery",
     "operationKind": "query",
-    "text": "query IndexPageQuery(\n  $search: String = \"\"\n  $count: Int\n  $cursor: String\n) {\n  config {\n    colorBy\n    colorPool\n    colorscale\n    multicolorKeypoints\n    showSkeletons\n  }\n  allDatasets: estimatedDatasetCount\n  ...NavFragment\n  ...configFragment\n}\n\nfragment NavDatasets on Query {\n  datasets(search: $search, first: $count, after: $cursor) {\n    total\n    edges {\n      cursor\n      node {\n        name\n        id\n        __typename\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n\nfragment NavFragment on Query {\n  ...NavDatasets\n  ...NavGA\n}\n\nfragment NavGA on Query {\n  context\n  dev\n  doNotTrack\n  uid\n  version\n}\n\nfragment configFragment on Query {\n  config {\n    colorBy\n    colorPool\n    colorscale\n    gridZoom\n    lightningThreshold\n    loopVideos\n    multicolorKeypoints\n    notebookHeight\n    plugins\n    showConfidence\n    showIndex\n    showLabel\n    showSkeletons\n    showTooltip\n    sidebarMode\n    theme\n    timezone\n    useFrameNumber\n  }\n  colorscale\n}\n"
+    "text": "query IndexPageQuery(\n  $search: String = \"\"\n  $count: Int\n  $cursor: String\n) {\n  config {\n    colorBy\n    colorPool\n    colorscale\n    multicolorKeypoints\n    showSkeletons\n  }\n  allDatasets: estimatedDatasetCount\n  ...NavFragment\n  ...configFragment\n}\n\nfragment NavDatasets on Query {\n  datasets(search: $search, first: $count, after: $cursor) {\n    total\n    edges {\n      cursor\n      node {\n        name\n        id\n        __typename\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n\nfragment NavFragment on Query {\n  ...NavDatasets\n  ...NavGA\n}\n\nfragment NavGA on Query {\n  context\n  dev\n  doNotTrack\n  uid\n  version\n}\n\nfragment configFragment on Query {\n  config {\n    colorBy\n    colorPool\n    colorscale\n    gridZoom\n    lightningThreshold\n    loopVideos\n    multicolorKeypoints\n    notebookHeight\n    plugins\n    showConfidence\n    showIndex\n    showLabel\n    showSkeletons\n    showTooltip\n    sidebarMode\n    theme\n    timezone\n    useFrameNumber\n    mediaFallback\n  }\n  colorscale\n}\n"
   }
 };
 })();

--- a/app/packages/app/src/pages/datasets/__generated__/DatasetPageQuery.graphql.ts
+++ b/app/packages/app/src/pages/datasets/__generated__/DatasetPageQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<0ae44e3b7abfdee7506dc000ada3e13a>>
+ * @generated SignedSource<<e401c8331011bf35e5d74fedc1fb8f51>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -396,80 +396,87 @@ v27 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "createdAt",
+  "name": "mediaFallback",
   "storageKey": null
 },
 v28 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "datasetId",
+  "name": "createdAt",
   "storageKey": null
 },
 v29 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "info",
+  "name": "datasetId",
   "storageKey": null
 },
 v30 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "lastLoadedAt",
+  "name": "info",
   "storageKey": null
 },
 v31 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "mediaType",
+  "name": "lastLoadedAt",
   "storageKey": null
 },
 v32 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "version",
+  "name": "mediaType",
   "storageKey": null
 },
 v33 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "key",
+  "name": "version",
   "storageKey": null
 },
 v34 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "timestamp",
+  "name": "key",
   "storageKey": null
 },
 v35 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "viewStages",
+  "name": "timestamp",
   "storageKey": null
 },
 v36 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "cls",
+  "name": "viewStages",
   "storageKey": null
 },
 v37 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
+  "name": "cls",
+  "storageKey": null
+},
+v38 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
   "name": "type",
   "storageKey": null
 },
-v38 = [
+v39 = [
   {
     "alias": null,
     "args": null,
@@ -479,56 +486,56 @@ v38 = [
   },
   (v18/*: any*/)
 ],
-v39 = {
+v40 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "labels",
   "storageKey": null
 },
-v40 = {
+v41 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "edges",
   "storageKey": null
 },
-v41 = {
+v42 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "ftype",
   "storageKey": null
 },
-v42 = {
+v43 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "subfield",
   "storageKey": null
 },
-v43 = {
+v44 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "embeddedDocType",
   "storageKey": null
 },
-v44 = {
+v45 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "dbField",
   "storageKey": null
 },
-v45 = {
+v46 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "description",
   "storageKey": null
 },
-v46 = [
+v47 = [
   (v13/*: any*/),
   {
     "alias": null,
@@ -552,7 +559,7 @@ v46 = [
         "name": "field",
         "storageKey": null
       },
-      (v37/*: any*/)
+      (v38/*: any*/)
     ],
     "storageKey": null
   },
@@ -582,7 +589,7 @@ v46 = [
     "storageKey": null
   }
 ],
-v47 = [
+v48 = [
   {
     "kind": "Variable",
     "name": "after",
@@ -599,18 +606,18 @@ v47 = [
     "variableName": "search"
   }
 ],
-v48 = {
+v49 = {
   "kind": "Variable",
   "name": "datasetName",
   "variableName": "name"
 },
-v49 = [
+v50 = [
   (v21/*: any*/),
-  (v41/*: any*/),
   (v42/*: any*/),
   (v43/*: any*/),
-  (v29/*: any*/),
-  (v45/*: any*/)
+  (v44/*: any*/),
+  (v30/*: any*/),
+  (v46/*: any*/)
 ];
 return {
   "fragment": {
@@ -808,7 +815,8 @@ return {
             "kind": "ScalarField",
             "name": "useFrameNumber",
             "storageKey": null
-          }
+          },
+          (v27/*: any*/)
         ],
         "storageKey": null
       },
@@ -855,6 +863,7 @@ return {
               },
               (v25/*: any*/),
               (v26/*: any*/),
+              (v27/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -884,8 +893,8 @@ return {
             ],
             "storageKey": null
           },
-          (v27/*: any*/),
           (v28/*: any*/),
+          (v29/*: any*/),
           {
             "alias": null,
             "args": null,
@@ -894,9 +903,9 @@ return {
             "storageKey": null
           },
           (v15/*: any*/),
-          (v29/*: any*/),
           (v30/*: any*/),
           (v31/*: any*/),
+          (v32/*: any*/),
           {
             "alias": null,
             "args": null,
@@ -904,7 +913,7 @@ return {
             "name": "parentMediaType",
             "storageKey": null
           },
-          (v32/*: any*/),
+          (v33/*: any*/),
           {
             "alias": null,
             "args": null,
@@ -913,10 +922,10 @@ return {
             "name": "brainMethods",
             "plural": true,
             "selections": [
-              (v33/*: any*/),
-              (v32/*: any*/),
               (v34/*: any*/),
+              (v33/*: any*/),
               (v35/*: any*/),
+              (v36/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -925,7 +934,7 @@ return {
                 "name": "config",
                 "plural": false,
                 "selections": [
-                  (v36/*: any*/),
+                  (v37/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -954,7 +963,7 @@ return {
                     "name": "supportsPrompts",
                     "storageKey": null
                   },
-                  (v37/*: any*/),
+                  (v38/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -982,7 +991,7 @@ return {
             "kind": "LinkedField",
             "name": "defaultMaskTargets",
             "plural": true,
-            "selections": (v38/*: any*/),
+            "selections": (v39/*: any*/),
             "storageKey": null
           },
           {
@@ -993,8 +1002,8 @@ return {
             "name": "defaultSkeleton",
             "plural": false,
             "selections": [
-              (v39/*: any*/),
-              (v40/*: any*/)
+              (v40/*: any*/),
+              (v41/*: any*/)
             ],
             "storageKey": null
           },
@@ -1006,10 +1015,10 @@ return {
             "name": "evaluations",
             "plural": true,
             "selections": [
-              (v33/*: any*/),
-              (v32/*: any*/),
               (v34/*: any*/),
+              (v33/*: any*/),
               (v35/*: any*/),
+              (v36/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -1018,7 +1027,7 @@ return {
                 "name": "config",
                 "plural": false,
                 "selections": [
-                  (v36/*: any*/),
+                  (v37/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -1048,7 +1057,7 @@ return {
             "plural": true,
             "selections": [
               (v13/*: any*/),
-              (v31/*: any*/)
+              (v32/*: any*/)
             ],
             "storageKey": null
           },
@@ -1068,7 +1077,7 @@ return {
                 "kind": "LinkedField",
                 "name": "targets",
                 "plural": true,
-                "selections": (v38/*: any*/),
+                "selections": (v39/*: any*/),
                 "storageKey": null
               }
             ],
@@ -1083,8 +1092,8 @@ return {
             "plural": true,
             "selections": [
               (v13/*: any*/),
-              (v39/*: any*/),
-              (v40/*: any*/)
+              (v40/*: any*/),
+              (v41/*: any*/)
             ],
             "storageKey": null
           },
@@ -1110,13 +1119,13 @@ return {
             "name": "frameFields",
             "plural": true,
             "selections": [
-              (v41/*: any*/),
               (v42/*: any*/),
               (v43/*: any*/),
-              (v21/*: any*/),
               (v44/*: any*/),
+              (v21/*: any*/),
               (v45/*: any*/),
-              (v29/*: any*/)
+              (v46/*: any*/),
+              (v30/*: any*/)
             ],
             "storageKey": null
           },
@@ -1127,7 +1136,7 @@ return {
             "kind": "LinkedField",
             "name": "frameIndexes",
             "plural": true,
-            "selections": (v46/*: any*/),
+            "selections": (v47/*: any*/),
             "storageKey": null
           },
           {
@@ -1137,7 +1146,7 @@ return {
             "kind": "LinkedField",
             "name": "sampleIndexes",
             "plural": true,
-            "selections": (v46/*: any*/),
+            "selections": (v47/*: any*/),
             "storageKey": null
           },
           {
@@ -1149,12 +1158,12 @@ return {
             "plural": true,
             "selections": [
               (v21/*: any*/),
-              (v41/*: any*/),
               (v42/*: any*/),
               (v43/*: any*/),
               (v44/*: any*/),
               (v45/*: any*/),
-              (v29/*: any*/)
+              (v46/*: any*/),
+              (v30/*: any*/)
             ],
             "storageKey": null
           },
@@ -1195,7 +1204,7 @@ return {
       },
       {
         "alias": null,
-        "args": (v47/*: any*/),
+        "args": (v48/*: any*/),
         "concreteType": "DatasetStrConnection",
         "kind": "LinkedField",
         "name": "datasets",
@@ -1276,7 +1285,7 @@ return {
       },
       {
         "alias": null,
-        "args": (v47/*: any*/),
+        "args": (v48/*: any*/),
         "filters": [
           "search"
         ],
@@ -1313,11 +1322,11 @@ return {
         "name": "uid",
         "storageKey": null
       },
-      (v32/*: any*/),
+      (v33/*: any*/),
       {
         "alias": null,
         "args": [
-          (v48/*: any*/)
+          (v49/*: any*/)
         ],
         "concreteType": "SavedView",
         "kind": "LinkedField",
@@ -1325,7 +1334,7 @@ return {
         "plural": true,
         "selections": [
           (v15/*: any*/),
-          (v28/*: any*/),
+          (v29/*: any*/),
           (v13/*: any*/),
           {
             "alias": null,
@@ -1334,10 +1343,10 @@ return {
             "name": "slug",
             "storageKey": null
           },
-          (v45/*: any*/),
+          (v46/*: any*/),
           (v16/*: any*/),
-          (v35/*: any*/),
-          (v27/*: any*/),
+          (v36/*: any*/),
+          (v28/*: any*/),
           {
             "alias": null,
             "args": null,
@@ -1345,7 +1354,7 @@ return {
             "name": "lastModifiedAt",
             "storageKey": null
           },
-          (v30/*: any*/)
+          (v31/*: any*/)
         ],
         "storageKey": null
       },
@@ -1367,7 +1376,7 @@ return {
             "plural": true,
             "selections": [
               (v13/*: any*/),
-              (v37/*: any*/),
+              (v38/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -1391,7 +1400,7 @@ return {
       {
         "alias": null,
         "args": [
-          (v48/*: any*/),
+          (v49/*: any*/),
           {
             "kind": "Variable",
             "name": "viewStages",
@@ -1410,7 +1419,7 @@ return {
             "kind": "LinkedField",
             "name": "fieldSchema",
             "plural": true,
-            "selections": (v49/*: any*/),
+            "selections": (v50/*: any*/),
             "storageKey": null
           },
           {
@@ -1420,7 +1429,7 @@ return {
             "kind": "LinkedField",
             "name": "frameFieldSchema",
             "plural": true,
-            "selections": (v49/*: any*/),
+            "selections": (v50/*: any*/),
             "storageKey": null
           }
         ],
@@ -1429,12 +1438,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "2db2bbf015897d3b3fbdca5e51eb51e2",
+    "cacheID": "e086aa7786045cb0f54d959d188f2fad",
     "id": null,
     "metadata": {},
     "name": "DatasetPageQuery",
     "operationKind": "query",
-    "text": "query DatasetPageQuery(\n  $search: String = \"\"\n  $count: Int\n  $cursor: String\n  $savedViewSlug: String\n  $name: String!\n  $view: BSONArray!\n  $extendedView: BSONArray\n) {\n  config {\n    colorBy\n    colorPool\n    colorscale\n    multicolorKeypoints\n    showSkeletons\n  }\n  colorscale\n  dataset(name: $name, view: $extendedView, savedViewSlug: $savedViewSlug) {\n    name\n    defaultGroupSlice\n    appConfig {\n      colorScheme {\n        id\n        colorBy\n        colorPool\n        multicolorKeypoints\n        opacity\n        showSkeletons\n        defaultMaskTargetsColors {\n          intTarget\n          color\n        }\n        defaultColorscale {\n          name\n          list {\n            value\n            color\n          }\n          rgb\n        }\n        colorscales {\n          path\n          name\n          list {\n            value\n            color\n          }\n          rgb\n        }\n        fields {\n          colorByAttribute\n          fieldColor\n          path\n          valueColors {\n            color\n            value\n          }\n          maskTargetsColors {\n            intTarget\n            color\n          }\n        }\n        labelTags {\n          fieldColor\n          valueColors {\n            color\n            value\n          }\n        }\n      }\n    }\n    ...datasetFragment\n    id\n  }\n  ...NavFragment\n  ...savedViewsFragment\n  ...configFragment\n  ...stageDefinitionsFragment\n  ...viewSchemaFragment\n}\n\nfragment NavDatasets on Query {\n  datasets(search: $search, first: $count, after: $cursor) {\n    total\n    edges {\n      cursor\n      node {\n        name\n        id\n        __typename\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n\nfragment NavFragment on Query {\n  ...NavDatasets\n  ...NavGA\n}\n\nfragment NavGA on Query {\n  context\n  dev\n  doNotTrack\n  uid\n  version\n}\n\nfragment colorSchemeFragment on ColorScheme {\n  id\n  colorBy\n  colorPool\n  multicolorKeypoints\n  opacity\n  showSkeletons\n  labelTags {\n    fieldColor\n    valueColors {\n      color\n      value\n    }\n  }\n  defaultMaskTargetsColors {\n    intTarget\n    color\n  }\n  defaultColorscale {\n    name\n    list {\n      value\n      color\n    }\n    rgb\n  }\n  colorscales {\n    path\n    name\n    list {\n      value\n      color\n    }\n    rgb\n  }\n  fields {\n    colorByAttribute\n    fieldColor\n    path\n    valueColors {\n      color\n      value\n    }\n    maskTargetsColors {\n      intTarget\n      color\n    }\n  }\n}\n\nfragment configFragment on Query {\n  config {\n    colorBy\n    colorPool\n    colorscale\n    gridZoom\n    lightningThreshold\n    loopVideos\n    multicolorKeypoints\n    notebookHeight\n    plugins\n    showConfidence\n    showIndex\n    showLabel\n    showSkeletons\n    showTooltip\n    sidebarMode\n    theme\n    timezone\n    useFrameNumber\n  }\n  colorscale\n}\n\nfragment datasetAppConfigFragment on DatasetAppConfig {\n  gridMediaField\n  mediaFields\n  modalMediaField\n  plugins\n  sidebarMode\n  colorScheme {\n    ...colorSchemeFragment\n    id\n  }\n}\n\nfragment datasetFragment on Dataset {\n  createdAt\n  datasetId\n  groupField\n  id\n  info\n  lastLoadedAt\n  mediaType\n  name\n  parentMediaType\n  version\n  appConfig {\n    ...datasetAppConfigFragment\n  }\n  brainMethods {\n    key\n    version\n    timestamp\n    viewStages\n    config {\n      cls\n      embeddingsField\n      method\n      patchesField\n      supportsPrompts\n      type\n      maxK\n      supportsLeastSimilarity\n    }\n  }\n  defaultMaskTargets {\n    target\n    value\n  }\n  defaultSkeleton {\n    labels\n    edges\n  }\n  evaluations {\n    key\n    version\n    timestamp\n    viewStages\n    config {\n      cls\n      predField\n      gtField\n    }\n  }\n  groupMediaTypes {\n    name\n    mediaType\n  }\n  maskTargets {\n    name\n    targets {\n      target\n      value\n    }\n  }\n  skeletons {\n    name\n    labels\n    edges\n  }\n  ...estimatedCountsFragment\n  ...frameFieldsFragment\n  ...groupSliceFragment\n  ...indexesFragment\n  ...mediaFieldsFragment\n  ...mediaTypeFragment\n  ...sampleFieldsFragment\n  ...sidebarGroupsFragment\n  ...viewFragment\n}\n\nfragment estimatedCountsFragment on Dataset {\n  estimatedFrameCount\n  estimatedSampleCount\n}\n\nfragment frameFieldsFragment on Dataset {\n  frameFields {\n    ftype\n    subfield\n    embeddedDocType\n    path\n    dbField\n    description\n    info\n  }\n}\n\nfragment groupSliceFragment on Dataset {\n  defaultGroupSlice\n}\n\nfragment indexesFragment on Dataset {\n  frameIndexes {\n    name\n    unique\n    key {\n      field\n      type\n    }\n    wildcardProjection {\n      fields\n      inclusion\n    }\n  }\n  sampleIndexes {\n    name\n    unique\n    key {\n      field\n      type\n    }\n    wildcardProjection {\n      fields\n      inclusion\n    }\n  }\n}\n\nfragment mediaFieldsFragment on Dataset {\n  name\n  appConfig {\n    gridMediaField\n    mediaFields\n    modalMediaField\n  }\n  sampleFields {\n    path\n  }\n}\n\nfragment mediaTypeFragment on Dataset {\n  mediaType\n}\n\nfragment sampleFieldsFragment on Dataset {\n  sampleFields {\n    ftype\n    subfield\n    embeddedDocType\n    path\n    dbField\n    description\n    info\n  }\n}\n\nfragment savedViewsFragment on Query {\n  savedViews(datasetName: $name) {\n    id\n    datasetId\n    name\n    slug\n    description\n    color\n    viewStages\n    createdAt\n    lastModifiedAt\n    lastLoadedAt\n  }\n}\n\nfragment sidebarGroupsFragment on Dataset {\n  name\n  appConfig {\n    sidebarGroups {\n      expanded\n      paths\n      name\n    }\n  }\n  ...frameFieldsFragment\n  ...sampleFieldsFragment\n}\n\nfragment stageDefinitionsFragment on Query {\n  stageDefinitions {\n    name\n    params {\n      name\n      type\n      default\n      placeholder\n    }\n  }\n}\n\nfragment viewFragment on Dataset {\n  stages(slug: $savedViewSlug, view: $view)\n  viewCls\n  viewName\n}\n\nfragment viewSchemaFragment on Query {\n  schemaForViewStages(datasetName: $name, viewStages: $view) {\n    fieldSchema {\n      path\n      ftype\n      subfield\n      embeddedDocType\n      info\n      description\n    }\n    frameFieldSchema {\n      path\n      ftype\n      subfield\n      embeddedDocType\n      info\n      description\n    }\n  }\n}\n"
+    "text": "query DatasetPageQuery(\n  $search: String = \"\"\n  $count: Int\n  $cursor: String\n  $savedViewSlug: String\n  $name: String!\n  $view: BSONArray!\n  $extendedView: BSONArray\n) {\n  config {\n    colorBy\n    colorPool\n    colorscale\n    multicolorKeypoints\n    showSkeletons\n  }\n  colorscale\n  dataset(name: $name, view: $extendedView, savedViewSlug: $savedViewSlug) {\n    name\n    defaultGroupSlice\n    appConfig {\n      colorScheme {\n        id\n        colorBy\n        colorPool\n        multicolorKeypoints\n        opacity\n        showSkeletons\n        defaultMaskTargetsColors {\n          intTarget\n          color\n        }\n        defaultColorscale {\n          name\n          list {\n            value\n            color\n          }\n          rgb\n        }\n        colorscales {\n          path\n          name\n          list {\n            value\n            color\n          }\n          rgb\n        }\n        fields {\n          colorByAttribute\n          fieldColor\n          path\n          valueColors {\n            color\n            value\n          }\n          maskTargetsColors {\n            intTarget\n            color\n          }\n        }\n        labelTags {\n          fieldColor\n          valueColors {\n            color\n            value\n          }\n        }\n      }\n    }\n    ...datasetFragment\n    id\n  }\n  ...NavFragment\n  ...savedViewsFragment\n  ...configFragment\n  ...stageDefinitionsFragment\n  ...viewSchemaFragment\n}\n\nfragment NavDatasets on Query {\n  datasets(search: $search, first: $count, after: $cursor) {\n    total\n    edges {\n      cursor\n      node {\n        name\n        id\n        __typename\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n\nfragment NavFragment on Query {\n  ...NavDatasets\n  ...NavGA\n}\n\nfragment NavGA on Query {\n  context\n  dev\n  doNotTrack\n  uid\n  version\n}\n\nfragment colorSchemeFragment on ColorScheme {\n  id\n  colorBy\n  colorPool\n  multicolorKeypoints\n  opacity\n  showSkeletons\n  labelTags {\n    fieldColor\n    valueColors {\n      color\n      value\n    }\n  }\n  defaultMaskTargetsColors {\n    intTarget\n    color\n  }\n  defaultColorscale {\n    name\n    list {\n      value\n      color\n    }\n    rgb\n  }\n  colorscales {\n    path\n    name\n    list {\n      value\n      color\n    }\n    rgb\n  }\n  fields {\n    colorByAttribute\n    fieldColor\n    path\n    valueColors {\n      color\n      value\n    }\n    maskTargetsColors {\n      intTarget\n      color\n    }\n  }\n}\n\nfragment configFragment on Query {\n  config {\n    colorBy\n    colorPool\n    colorscale\n    gridZoom\n    lightningThreshold\n    loopVideos\n    multicolorKeypoints\n    notebookHeight\n    plugins\n    showConfidence\n    showIndex\n    showLabel\n    showSkeletons\n    showTooltip\n    sidebarMode\n    theme\n    timezone\n    useFrameNumber\n    mediaFallback\n  }\n  colorscale\n}\n\nfragment datasetAppConfigFragment on DatasetAppConfig {\n  gridMediaField\n  mediaFields\n  modalMediaField\n  plugins\n  sidebarMode\n  colorScheme {\n    ...colorSchemeFragment\n    id\n  }\n  mediaFallback\n}\n\nfragment datasetFragment on Dataset {\n  createdAt\n  datasetId\n  groupField\n  id\n  info\n  lastLoadedAt\n  mediaType\n  name\n  parentMediaType\n  version\n  appConfig {\n    ...datasetAppConfigFragment\n  }\n  brainMethods {\n    key\n    version\n    timestamp\n    viewStages\n    config {\n      cls\n      embeddingsField\n      method\n      patchesField\n      supportsPrompts\n      type\n      maxK\n      supportsLeastSimilarity\n    }\n  }\n  defaultMaskTargets {\n    target\n    value\n  }\n  defaultSkeleton {\n    labels\n    edges\n  }\n  evaluations {\n    key\n    version\n    timestamp\n    viewStages\n    config {\n      cls\n      predField\n      gtField\n    }\n  }\n  groupMediaTypes {\n    name\n    mediaType\n  }\n  maskTargets {\n    name\n    targets {\n      target\n      value\n    }\n  }\n  skeletons {\n    name\n    labels\n    edges\n  }\n  ...estimatedCountsFragment\n  ...frameFieldsFragment\n  ...groupSliceFragment\n  ...indexesFragment\n  ...mediaFieldsFragment\n  ...mediaTypeFragment\n  ...sampleFieldsFragment\n  ...sidebarGroupsFragment\n  ...viewFragment\n}\n\nfragment estimatedCountsFragment on Dataset {\n  estimatedFrameCount\n  estimatedSampleCount\n}\n\nfragment frameFieldsFragment on Dataset {\n  frameFields {\n    ftype\n    subfield\n    embeddedDocType\n    path\n    dbField\n    description\n    info\n  }\n}\n\nfragment groupSliceFragment on Dataset {\n  defaultGroupSlice\n}\n\nfragment indexesFragment on Dataset {\n  frameIndexes {\n    name\n    unique\n    key {\n      field\n      type\n    }\n    wildcardProjection {\n      fields\n      inclusion\n    }\n  }\n  sampleIndexes {\n    name\n    unique\n    key {\n      field\n      type\n    }\n    wildcardProjection {\n      fields\n      inclusion\n    }\n  }\n}\n\nfragment mediaFieldsFragment on Dataset {\n  name\n  appConfig {\n    gridMediaField\n    mediaFields\n    modalMediaField\n    mediaFallback\n  }\n  sampleFields {\n    path\n  }\n}\n\nfragment mediaTypeFragment on Dataset {\n  mediaType\n}\n\nfragment sampleFieldsFragment on Dataset {\n  sampleFields {\n    ftype\n    subfield\n    embeddedDocType\n    path\n    dbField\n    description\n    info\n  }\n}\n\nfragment savedViewsFragment on Query {\n  savedViews(datasetName: $name) {\n    id\n    datasetId\n    name\n    slug\n    description\n    color\n    viewStages\n    createdAt\n    lastModifiedAt\n    lastLoadedAt\n  }\n}\n\nfragment sidebarGroupsFragment on Dataset {\n  name\n  appConfig {\n    sidebarGroups {\n      expanded\n      paths\n      name\n    }\n  }\n  ...frameFieldsFragment\n  ...sampleFieldsFragment\n}\n\nfragment stageDefinitionsFragment on Query {\n  stageDefinitions {\n    name\n    params {\n      name\n      type\n      default\n      placeholder\n    }\n  }\n}\n\nfragment viewFragment on Dataset {\n  stages(slug: $savedViewSlug, view: $view)\n  viewCls\n  viewName\n}\n\nfragment viewSchemaFragment on Query {\n  schemaForViewStages(datasetName: $name, viewStages: $view) {\n    fieldSchema {\n      path\n      ftype\n      subfield\n      embeddedDocType\n      info\n      description\n    }\n    frameFieldSchema {\n      path\n      ftype\n      subfield\n      embeddedDocType\n      info\n      description\n    }\n  }\n}\n"
   }
 };
 })();

--- a/app/packages/looker/src/state.ts
+++ b/app/packages/looker/src/state.ts
@@ -184,6 +184,7 @@ interface BaseOptions {
   isPointcloudDataset: boolean;
   pointFilter: (path: string, point: Point) => boolean;
   thumbnailTitle?: (sample: any) => string;
+  mediaFallback: boolean;
 }
 
 export type BoundingBox = [number, number, number, number];
@@ -460,6 +461,7 @@ export const DEFAULT_BASE_OPTIONS: BaseOptions = {
   showOverlays: true,
   pointFilter: (path: string, point: Point) => true,
   attributeVisibility: {},
+  mediaFallback: false,
 };
 
 export const DEFAULT_FRAME_OPTIONS: FrameOptions = {

--- a/app/packages/relay/src/fragments/__generated__/configFragment.graphql.ts
+++ b/app/packages/relay/src/fragments/__generated__/configFragment.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<15cdc78ae84090b5314f587ba80558b9>>
+ * @generated SignedSource<<7975210351fb59c391c34db0a0433aa1>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -22,6 +22,7 @@ export type configFragment$data = {
     readonly gridZoom: number;
     readonly lightningThreshold: number | null;
     readonly loopVideos: boolean;
+    readonly mediaFallback: boolean;
     readonly multicolorKeypoints: boolean;
     readonly notebookHeight: number;
     readonly plugins: object | null;
@@ -183,6 +184,13 @@ return {
           "kind": "ScalarField",
           "name": "useFrameNumber",
           "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "mediaFallback",
+          "storageKey": null
         }
       ],
       "storageKey": null
@@ -194,6 +202,6 @@ return {
 };
 })();
 
-(node as any).hash = "bb8881f0e6c36892097f4168c2c64f79";
+(node as any).hash = "bc14e5070d7a1c87baa60bc81fcccb5d";
 
 export default node;

--- a/app/packages/relay/src/fragments/__generated__/datasetAppConfigFragment.graphql.ts
+++ b/app/packages/relay/src/fragments/__generated__/datasetAppConfigFragment.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<0e53882eaec766b9e68a577cda17ae34>>
+ * @generated SignedSource<<dfcae771bc1b5b240300aa6e545b330c>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -16,6 +16,7 @@ export type datasetAppConfigFragment$data = {
     readonly " $fragmentSpreads": FragmentRefs<"colorSchemeFragment">;
   } | null;
   readonly gridMediaField: string;
+  readonly mediaFallback: boolean;
   readonly mediaFields: ReadonlyArray<string> | null;
   readonly modalMediaField: string;
   readonly plugins: object | null;
@@ -83,12 +84,19 @@ const node: ReaderFragment = {
         }
       ],
       "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "mediaFallback",
+      "storageKey": null
     }
   ],
   "type": "DatasetAppConfig",
   "abstractKey": null
 };
 
-(node as any).hash = "c962e7928367bf9097b33f5970633612";
+(node as any).hash = "6b71b3fc8c5a07b921938d7d0cf03272";
 
 export default node;

--- a/app/packages/relay/src/fragments/__generated__/mediaFieldsFragment.graphql.ts
+++ b/app/packages/relay/src/fragments/__generated__/mediaFieldsFragment.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<6a026f47ac9fe6e3324ad7be21c88269>>
+ * @generated SignedSource<<04b7313af6c823a25d93c822f2e9f8eb>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -13,6 +13,7 @@ import { FragmentRefs } from "relay-runtime";
 export type mediaFieldsFragment$data = {
   readonly appConfig: {
     readonly gridMediaField: string;
+    readonly mediaFallback: boolean;
     readonly mediaFields: ReadonlyArray<string> | null;
     readonly modalMediaField: string;
   } | null;
@@ -68,6 +69,13 @@ const node: ReaderFragment = {
           "kind": "ScalarField",
           "name": "modalMediaField",
           "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "mediaFallback",
+          "storageKey": null
         }
       ],
       "storageKey": null
@@ -95,6 +103,6 @@ const node: ReaderFragment = {
   "abstractKey": null
 };
 
-(node as any).hash = "f65b23fc366d07867fc580339a336842";
+(node as any).hash = "fcece821cb951d5759a3b3ff76a70516";
 
 export default node;

--- a/app/packages/relay/src/fragments/configFragment.ts
+++ b/app/packages/relay/src/fragments/configFragment.ts
@@ -23,6 +23,7 @@ export default r(graphql`
       theme
       timezone
       useFrameNumber
+      mediaFallback
     }
     colorscale
   }

--- a/app/packages/relay/src/fragments/datasetAppConfigFragment.ts
+++ b/app/packages/relay/src/fragments/datasetAppConfigFragment.ts
@@ -10,5 +10,6 @@ export default graphql`
     colorScheme {
       ...colorSchemeFragment
     }
+    mediaFallback
   }
 `;

--- a/app/packages/relay/src/fragments/mediaFieldsFragment.ts
+++ b/app/packages/relay/src/fragments/mediaFieldsFragment.ts
@@ -7,6 +7,7 @@ export default graphql`
       gridMediaField
       mediaFields
       modalMediaField
+      mediaFallback
     }
     sampleFields {
       path

--- a/app/packages/relay/src/queries/__generated__/datasetQuery.graphql.ts
+++ b/app/packages/relay/src/queries/__generated__/datasetQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<3617b9505570291184fa15300d328097>>
+ * @generated SignedSource<<d0f2a978c5bbcd20358d7456bfd895d6>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -394,80 +394,87 @@ v25 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "createdAt",
+  "name": "mediaFallback",
   "storageKey": null
 },
 v26 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "datasetId",
+  "name": "createdAt",
   "storageKey": null
 },
 v27 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "info",
+  "name": "datasetId",
   "storageKey": null
 },
 v28 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "lastLoadedAt",
+  "name": "info",
   "storageKey": null
 },
 v29 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "mediaType",
+  "name": "lastLoadedAt",
   "storageKey": null
 },
 v30 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "version",
+  "name": "mediaType",
   "storageKey": null
 },
 v31 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "key",
+  "name": "version",
   "storageKey": null
 },
 v32 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "timestamp",
+  "name": "key",
   "storageKey": null
 },
 v33 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "viewStages",
+  "name": "timestamp",
   "storageKey": null
 },
 v34 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "cls",
+  "name": "viewStages",
   "storageKey": null
 },
 v35 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
+  "name": "cls",
+  "storageKey": null
+},
+v36 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
   "name": "type",
   "storageKey": null
 },
-v36 = [
+v37 = [
   {
     "alias": null,
     "args": null,
@@ -477,56 +484,56 @@ v36 = [
   },
   (v16/*: any*/)
 ],
-v37 = {
+v38 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "labels",
   "storageKey": null
 },
-v38 = {
+v39 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "edges",
   "storageKey": null
 },
-v39 = {
+v40 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "ftype",
   "storageKey": null
 },
-v40 = {
+v41 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "subfield",
   "storageKey": null
 },
-v41 = {
+v42 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "embeddedDocType",
   "storageKey": null
 },
-v42 = {
+v43 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "dbField",
   "storageKey": null
 },
-v43 = {
+v44 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "description",
   "storageKey": null
 },
-v44 = [
+v45 = [
   (v10/*: any*/),
   {
     "alias": null,
@@ -550,7 +557,7 @@ v44 = [
         "name": "field",
         "storageKey": null
       },
-      (v35/*: any*/)
+      (v36/*: any*/)
     ],
     "storageKey": null
   },
@@ -580,18 +587,18 @@ v44 = [
     "storageKey": null
   }
 ],
-v45 = {
+v46 = {
   "kind": "Variable",
   "name": "datasetName",
   "variableName": "name"
 },
-v46 = [
+v47 = [
   (v20/*: any*/),
-  (v39/*: any*/),
   (v40/*: any*/),
   (v41/*: any*/),
-  (v27/*: any*/),
-  (v43/*: any*/)
+  (v42/*: any*/),
+  (v28/*: any*/),
+  (v44/*: any*/)
 ];
 return {
   "fragment": {
@@ -778,7 +785,8 @@ return {
             "kind": "ScalarField",
             "name": "useFrameNumber",
             "storageKey": null
-          }
+          },
+          (v25/*: any*/)
         ],
         "storageKey": null
       },
@@ -825,6 +833,7 @@ return {
               },
               (v23/*: any*/),
               (v24/*: any*/),
+              (v25/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -854,8 +863,8 @@ return {
             ],
             "storageKey": null
           },
-          (v25/*: any*/),
           (v26/*: any*/),
+          (v27/*: any*/),
           {
             "alias": null,
             "args": null,
@@ -864,9 +873,9 @@ return {
             "storageKey": null
           },
           (v13/*: any*/),
-          (v27/*: any*/),
           (v28/*: any*/),
           (v29/*: any*/),
+          (v30/*: any*/),
           {
             "alias": null,
             "args": null,
@@ -874,7 +883,7 @@ return {
             "name": "parentMediaType",
             "storageKey": null
           },
-          (v30/*: any*/),
+          (v31/*: any*/),
           {
             "alias": null,
             "args": null,
@@ -883,10 +892,10 @@ return {
             "name": "brainMethods",
             "plural": true,
             "selections": [
-              (v31/*: any*/),
-              (v30/*: any*/),
               (v32/*: any*/),
+              (v31/*: any*/),
               (v33/*: any*/),
+              (v34/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -895,7 +904,7 @@ return {
                 "name": "config",
                 "plural": false,
                 "selections": [
-                  (v34/*: any*/),
+                  (v35/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -924,7 +933,7 @@ return {
                     "name": "supportsPrompts",
                     "storageKey": null
                   },
-                  (v35/*: any*/),
+                  (v36/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -952,7 +961,7 @@ return {
             "kind": "LinkedField",
             "name": "defaultMaskTargets",
             "plural": true,
-            "selections": (v36/*: any*/),
+            "selections": (v37/*: any*/),
             "storageKey": null
           },
           {
@@ -963,8 +972,8 @@ return {
             "name": "defaultSkeleton",
             "plural": false,
             "selections": [
-              (v37/*: any*/),
-              (v38/*: any*/)
+              (v38/*: any*/),
+              (v39/*: any*/)
             ],
             "storageKey": null
           },
@@ -976,10 +985,10 @@ return {
             "name": "evaluations",
             "plural": true,
             "selections": [
-              (v31/*: any*/),
-              (v30/*: any*/),
               (v32/*: any*/),
+              (v31/*: any*/),
               (v33/*: any*/),
+              (v34/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -988,7 +997,7 @@ return {
                 "name": "config",
                 "plural": false,
                 "selections": [
-                  (v34/*: any*/),
+                  (v35/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -1018,7 +1027,7 @@ return {
             "plural": true,
             "selections": [
               (v10/*: any*/),
-              (v29/*: any*/)
+              (v30/*: any*/)
             ],
             "storageKey": null
           },
@@ -1038,7 +1047,7 @@ return {
                 "kind": "LinkedField",
                 "name": "targets",
                 "plural": true,
-                "selections": (v36/*: any*/),
+                "selections": (v37/*: any*/),
                 "storageKey": null
               }
             ],
@@ -1053,8 +1062,8 @@ return {
             "plural": true,
             "selections": [
               (v10/*: any*/),
-              (v37/*: any*/),
-              (v38/*: any*/)
+              (v38/*: any*/),
+              (v39/*: any*/)
             ],
             "storageKey": null
           },
@@ -1080,13 +1089,13 @@ return {
             "name": "frameFields",
             "plural": true,
             "selections": [
-              (v39/*: any*/),
               (v40/*: any*/),
               (v41/*: any*/),
-              (v20/*: any*/),
               (v42/*: any*/),
+              (v20/*: any*/),
               (v43/*: any*/),
-              (v27/*: any*/)
+              (v44/*: any*/),
+              (v28/*: any*/)
             ],
             "storageKey": null
           },
@@ -1097,7 +1106,7 @@ return {
             "kind": "LinkedField",
             "name": "frameIndexes",
             "plural": true,
-            "selections": (v44/*: any*/),
+            "selections": (v45/*: any*/),
             "storageKey": null
           },
           {
@@ -1107,7 +1116,7 @@ return {
             "kind": "LinkedField",
             "name": "sampleIndexes",
             "plural": true,
-            "selections": (v44/*: any*/),
+            "selections": (v45/*: any*/),
             "storageKey": null
           },
           {
@@ -1119,12 +1128,12 @@ return {
             "plural": true,
             "selections": [
               (v20/*: any*/),
-              (v39/*: any*/),
               (v40/*: any*/),
               (v41/*: any*/),
               (v42/*: any*/),
               (v43/*: any*/),
-              (v27/*: any*/)
+              (v44/*: any*/),
+              (v28/*: any*/)
             ],
             "storageKey": null
           },
@@ -1159,7 +1168,7 @@ return {
       {
         "alias": null,
         "args": [
-          (v45/*: any*/)
+          (v46/*: any*/)
         ],
         "concreteType": "SavedView",
         "kind": "LinkedField",
@@ -1167,7 +1176,7 @@ return {
         "plural": true,
         "selections": [
           (v13/*: any*/),
-          (v26/*: any*/),
+          (v27/*: any*/),
           (v10/*: any*/),
           {
             "alias": null,
@@ -1176,10 +1185,10 @@ return {
             "name": "slug",
             "storageKey": null
           },
-          (v43/*: any*/),
+          (v44/*: any*/),
           (v14/*: any*/),
-          (v33/*: any*/),
-          (v25/*: any*/),
+          (v34/*: any*/),
+          (v26/*: any*/),
           {
             "alias": null,
             "args": null,
@@ -1187,7 +1196,7 @@ return {
             "name": "lastModifiedAt",
             "storageKey": null
           },
-          (v28/*: any*/)
+          (v29/*: any*/)
         ],
         "storageKey": null
       },
@@ -1210,7 +1219,7 @@ return {
             "plural": true,
             "selections": [
               (v10/*: any*/),
-              (v35/*: any*/),
+              (v36/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -1234,7 +1243,7 @@ return {
       {
         "alias": null,
         "args": [
-          (v45/*: any*/),
+          (v46/*: any*/),
           {
             "kind": "Variable",
             "name": "viewStages",
@@ -1253,7 +1262,7 @@ return {
             "kind": "LinkedField",
             "name": "fieldSchema",
             "plural": true,
-            "selections": (v46/*: any*/),
+            "selections": (v47/*: any*/),
             "storageKey": null
           },
           {
@@ -1263,7 +1272,7 @@ return {
             "kind": "LinkedField",
             "name": "frameFieldSchema",
             "plural": true,
-            "selections": (v46/*: any*/),
+            "selections": (v47/*: any*/),
             "storageKey": null
           }
         ],
@@ -1272,12 +1281,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "48bacea284b02415fa9b4ffdc2dea42a",
+    "cacheID": "ca42e46fc185ee9529fd876445a9c434",
     "id": null,
     "metadata": {},
     "name": "datasetQuery",
     "operationKind": "query",
-    "text": "query datasetQuery(\n  $savedViewSlug: String\n  $name: String!\n  $view: BSONArray!\n  $extendedView: BSONArray!\n) {\n  config {\n    colorBy\n    colorPool\n    colorscale\n    multicolorKeypoints\n    showSkeletons\n  }\n  dataset(name: $name, view: $extendedView, savedViewSlug: $savedViewSlug) {\n    name\n    defaultGroupSlice\n    viewName\n    appConfig {\n      colorScheme {\n        id\n        colorBy\n        colorPool\n        multicolorKeypoints\n        opacity\n        showSkeletons\n        defaultMaskTargetsColors {\n          intTarget\n          color\n        }\n        defaultColorscale {\n          name\n          list {\n            value\n            color\n          }\n          rgb\n        }\n        colorscales {\n          path\n          name\n          list {\n            value\n            color\n          }\n          rgb\n        }\n        labelTags {\n          fieldColor\n          valueColors {\n            value\n            color\n          }\n        }\n        fields {\n          colorByAttribute\n          fieldColor\n          path\n          maskTargetsColors {\n            intTarget\n            color\n          }\n          valueColors {\n            color\n            value\n          }\n        }\n      }\n    }\n    ...datasetFragment\n    id\n  }\n  ...savedViewsFragment\n  ...configFragment\n  ...stageDefinitionsFragment\n  ...viewSchemaFragment\n}\n\nfragment colorSchemeFragment on ColorScheme {\n  id\n  colorBy\n  colorPool\n  multicolorKeypoints\n  opacity\n  showSkeletons\n  labelTags {\n    fieldColor\n    valueColors {\n      color\n      value\n    }\n  }\n  defaultMaskTargetsColors {\n    intTarget\n    color\n  }\n  defaultColorscale {\n    name\n    list {\n      value\n      color\n    }\n    rgb\n  }\n  colorscales {\n    path\n    name\n    list {\n      value\n      color\n    }\n    rgb\n  }\n  fields {\n    colorByAttribute\n    fieldColor\n    path\n    valueColors {\n      color\n      value\n    }\n    maskTargetsColors {\n      intTarget\n      color\n    }\n  }\n}\n\nfragment configFragment on Query {\n  config {\n    colorBy\n    colorPool\n    colorscale\n    gridZoom\n    lightningThreshold\n    loopVideos\n    multicolorKeypoints\n    notebookHeight\n    plugins\n    showConfidence\n    showIndex\n    showLabel\n    showSkeletons\n    showTooltip\n    sidebarMode\n    theme\n    timezone\n    useFrameNumber\n  }\n  colorscale\n}\n\nfragment datasetAppConfigFragment on DatasetAppConfig {\n  gridMediaField\n  mediaFields\n  modalMediaField\n  plugins\n  sidebarMode\n  colorScheme {\n    ...colorSchemeFragment\n    id\n  }\n}\n\nfragment datasetFragment on Dataset {\n  createdAt\n  datasetId\n  groupField\n  id\n  info\n  lastLoadedAt\n  mediaType\n  name\n  parentMediaType\n  version\n  appConfig {\n    ...datasetAppConfigFragment\n  }\n  brainMethods {\n    key\n    version\n    timestamp\n    viewStages\n    config {\n      cls\n      embeddingsField\n      method\n      patchesField\n      supportsPrompts\n      type\n      maxK\n      supportsLeastSimilarity\n    }\n  }\n  defaultMaskTargets {\n    target\n    value\n  }\n  defaultSkeleton {\n    labels\n    edges\n  }\n  evaluations {\n    key\n    version\n    timestamp\n    viewStages\n    config {\n      cls\n      predField\n      gtField\n    }\n  }\n  groupMediaTypes {\n    name\n    mediaType\n  }\n  maskTargets {\n    name\n    targets {\n      target\n      value\n    }\n  }\n  skeletons {\n    name\n    labels\n    edges\n  }\n  ...estimatedCountsFragment\n  ...frameFieldsFragment\n  ...groupSliceFragment\n  ...indexesFragment\n  ...mediaFieldsFragment\n  ...mediaTypeFragment\n  ...sampleFieldsFragment\n  ...sidebarGroupsFragment\n  ...viewFragment\n}\n\nfragment estimatedCountsFragment on Dataset {\n  estimatedFrameCount\n  estimatedSampleCount\n}\n\nfragment frameFieldsFragment on Dataset {\n  frameFields {\n    ftype\n    subfield\n    embeddedDocType\n    path\n    dbField\n    description\n    info\n  }\n}\n\nfragment groupSliceFragment on Dataset {\n  defaultGroupSlice\n}\n\nfragment indexesFragment on Dataset {\n  frameIndexes {\n    name\n    unique\n    key {\n      field\n      type\n    }\n    wildcardProjection {\n      fields\n      inclusion\n    }\n  }\n  sampleIndexes {\n    name\n    unique\n    key {\n      field\n      type\n    }\n    wildcardProjection {\n      fields\n      inclusion\n    }\n  }\n}\n\nfragment mediaFieldsFragment on Dataset {\n  name\n  appConfig {\n    gridMediaField\n    mediaFields\n    modalMediaField\n  }\n  sampleFields {\n    path\n  }\n}\n\nfragment mediaTypeFragment on Dataset {\n  mediaType\n}\n\nfragment sampleFieldsFragment on Dataset {\n  sampleFields {\n    ftype\n    subfield\n    embeddedDocType\n    path\n    dbField\n    description\n    info\n  }\n}\n\nfragment savedViewsFragment on Query {\n  savedViews(datasetName: $name) {\n    id\n    datasetId\n    name\n    slug\n    description\n    color\n    viewStages\n    createdAt\n    lastModifiedAt\n    lastLoadedAt\n  }\n}\n\nfragment sidebarGroupsFragment on Dataset {\n  name\n  appConfig {\n    sidebarGroups {\n      expanded\n      paths\n      name\n    }\n  }\n  ...frameFieldsFragment\n  ...sampleFieldsFragment\n}\n\nfragment stageDefinitionsFragment on Query {\n  stageDefinitions {\n    name\n    params {\n      name\n      type\n      default\n      placeholder\n    }\n  }\n}\n\nfragment viewFragment on Dataset {\n  stages(slug: $savedViewSlug, view: $view)\n  viewCls\n  viewName\n}\n\nfragment viewSchemaFragment on Query {\n  schemaForViewStages(datasetName: $name, viewStages: $view) {\n    fieldSchema {\n      path\n      ftype\n      subfield\n      embeddedDocType\n      info\n      description\n    }\n    frameFieldSchema {\n      path\n      ftype\n      subfield\n      embeddedDocType\n      info\n      description\n    }\n  }\n}\n"
+    "text": "query datasetQuery(\n  $savedViewSlug: String\n  $name: String!\n  $view: BSONArray!\n  $extendedView: BSONArray!\n) {\n  config {\n    colorBy\n    colorPool\n    colorscale\n    multicolorKeypoints\n    showSkeletons\n  }\n  dataset(name: $name, view: $extendedView, savedViewSlug: $savedViewSlug) {\n    name\n    defaultGroupSlice\n    viewName\n    appConfig {\n      colorScheme {\n        id\n        colorBy\n        colorPool\n        multicolorKeypoints\n        opacity\n        showSkeletons\n        defaultMaskTargetsColors {\n          intTarget\n          color\n        }\n        defaultColorscale {\n          name\n          list {\n            value\n            color\n          }\n          rgb\n        }\n        colorscales {\n          path\n          name\n          list {\n            value\n            color\n          }\n          rgb\n        }\n        labelTags {\n          fieldColor\n          valueColors {\n            value\n            color\n          }\n        }\n        fields {\n          colorByAttribute\n          fieldColor\n          path\n          maskTargetsColors {\n            intTarget\n            color\n          }\n          valueColors {\n            color\n            value\n          }\n        }\n      }\n    }\n    ...datasetFragment\n    id\n  }\n  ...savedViewsFragment\n  ...configFragment\n  ...stageDefinitionsFragment\n  ...viewSchemaFragment\n}\n\nfragment colorSchemeFragment on ColorScheme {\n  id\n  colorBy\n  colorPool\n  multicolorKeypoints\n  opacity\n  showSkeletons\n  labelTags {\n    fieldColor\n    valueColors {\n      color\n      value\n    }\n  }\n  defaultMaskTargetsColors {\n    intTarget\n    color\n  }\n  defaultColorscale {\n    name\n    list {\n      value\n      color\n    }\n    rgb\n  }\n  colorscales {\n    path\n    name\n    list {\n      value\n      color\n    }\n    rgb\n  }\n  fields {\n    colorByAttribute\n    fieldColor\n    path\n    valueColors {\n      color\n      value\n    }\n    maskTargetsColors {\n      intTarget\n      color\n    }\n  }\n}\n\nfragment configFragment on Query {\n  config {\n    colorBy\n    colorPool\n    colorscale\n    gridZoom\n    lightningThreshold\n    loopVideos\n    multicolorKeypoints\n    notebookHeight\n    plugins\n    showConfidence\n    showIndex\n    showLabel\n    showSkeletons\n    showTooltip\n    sidebarMode\n    theme\n    timezone\n    useFrameNumber\n    mediaFallback\n  }\n  colorscale\n}\n\nfragment datasetAppConfigFragment on DatasetAppConfig {\n  gridMediaField\n  mediaFields\n  modalMediaField\n  plugins\n  sidebarMode\n  colorScheme {\n    ...colorSchemeFragment\n    id\n  }\n  mediaFallback\n}\n\nfragment datasetFragment on Dataset {\n  createdAt\n  datasetId\n  groupField\n  id\n  info\n  lastLoadedAt\n  mediaType\n  name\n  parentMediaType\n  version\n  appConfig {\n    ...datasetAppConfigFragment\n  }\n  brainMethods {\n    key\n    version\n    timestamp\n    viewStages\n    config {\n      cls\n      embeddingsField\n      method\n      patchesField\n      supportsPrompts\n      type\n      maxK\n      supportsLeastSimilarity\n    }\n  }\n  defaultMaskTargets {\n    target\n    value\n  }\n  defaultSkeleton {\n    labels\n    edges\n  }\n  evaluations {\n    key\n    version\n    timestamp\n    viewStages\n    config {\n      cls\n      predField\n      gtField\n    }\n  }\n  groupMediaTypes {\n    name\n    mediaType\n  }\n  maskTargets {\n    name\n    targets {\n      target\n      value\n    }\n  }\n  skeletons {\n    name\n    labels\n    edges\n  }\n  ...estimatedCountsFragment\n  ...frameFieldsFragment\n  ...groupSliceFragment\n  ...indexesFragment\n  ...mediaFieldsFragment\n  ...mediaTypeFragment\n  ...sampleFieldsFragment\n  ...sidebarGroupsFragment\n  ...viewFragment\n}\n\nfragment estimatedCountsFragment on Dataset {\n  estimatedFrameCount\n  estimatedSampleCount\n}\n\nfragment frameFieldsFragment on Dataset {\n  frameFields {\n    ftype\n    subfield\n    embeddedDocType\n    path\n    dbField\n    description\n    info\n  }\n}\n\nfragment groupSliceFragment on Dataset {\n  defaultGroupSlice\n}\n\nfragment indexesFragment on Dataset {\n  frameIndexes {\n    name\n    unique\n    key {\n      field\n      type\n    }\n    wildcardProjection {\n      fields\n      inclusion\n    }\n  }\n  sampleIndexes {\n    name\n    unique\n    key {\n      field\n      type\n    }\n    wildcardProjection {\n      fields\n      inclusion\n    }\n  }\n}\n\nfragment mediaFieldsFragment on Dataset {\n  name\n  appConfig {\n    gridMediaField\n    mediaFields\n    modalMediaField\n    mediaFallback\n  }\n  sampleFields {\n    path\n  }\n}\n\nfragment mediaTypeFragment on Dataset {\n  mediaType\n}\n\nfragment sampleFieldsFragment on Dataset {\n  sampleFields {\n    ftype\n    subfield\n    embeddedDocType\n    path\n    dbField\n    description\n    info\n  }\n}\n\nfragment savedViewsFragment on Query {\n  savedViews(datasetName: $name) {\n    id\n    datasetId\n    name\n    slug\n    description\n    color\n    viewStages\n    createdAt\n    lastModifiedAt\n    lastLoadedAt\n  }\n}\n\nfragment sidebarGroupsFragment on Dataset {\n  name\n  appConfig {\n    sidebarGroups {\n      expanded\n      paths\n      name\n    }\n  }\n  ...frameFieldsFragment\n  ...sampleFieldsFragment\n}\n\nfragment stageDefinitionsFragment on Query {\n  stageDefinitions {\n    name\n    params {\n      name\n      type\n      default\n      placeholder\n    }\n  }\n}\n\nfragment viewFragment on Dataset {\n  stages(slug: $savedViewSlug, view: $view)\n  viewCls\n  viewName\n}\n\nfragment viewSchemaFragment on Query {\n  schemaForViewStages(datasetName: $name, viewStages: $view) {\n    fieldSchema {\n      path\n      ftype\n      subfield\n      embeddedDocType\n      info\n      description\n    }\n    frameFieldSchema {\n      path\n      ftype\n      subfield\n      embeddedDocType\n      info\n      description\n    }\n  }\n}\n"
   }
 };
 })();

--- a/app/packages/state/src/hooks/useCreateLooker.ts
+++ b/app/packages/state/src/hooks/useCreateLooker.ts
@@ -14,6 +14,7 @@ import {
   EMBEDDED_DOCUMENT_FIELD,
   LIST_FIELD,
   getMimeType,
+  isNullish,
 } from "@fiftyone/utilities";
 import { get } from "lodash";
 import { useRef } from "react";
@@ -139,6 +140,9 @@ export default <T extends AbstractLooker>(
         };
 
         let sampleMediaFilePath = urls[mediaField];
+        if (isNullish(sampleMediaFilePath) && options.mediaFallback === true) {
+          sampleMediaFilePath = urls["filepath"];
+        }
 
         if (constructor === ThreeDLooker) {
           config.isFo3d = (sample["filepath"] as string).endsWith(".fo3d");

--- a/app/packages/state/src/recoil/looker.ts
+++ b/app/packages/state/src/recoil/looker.ts
@@ -45,6 +45,13 @@ export const lookerOptions = selectorFamily<
       const useFrameNumber = get(
         selectors.appConfigOption({ modal: true, key: "useFrameNumber" })
       );
+      const globalMediaFallback = Boolean(
+        get(selectors.appConfigOption({ modal: true, key: "mediaFallback" }))
+      );
+      const datasetMediaFallback = Boolean(
+        get(selectors.datasetAppConfig)?.mediaFallback
+      );
+      const mediaFallback = globalMediaFallback || datasetMediaFallback;
 
       const video = get(selectors.isVideoDataset)
         ? {
@@ -105,6 +112,7 @@ export const lookerOptions = selectorFamily<
           get(dataset)?.skeletons.map(({ name, ...rest }) => [name, rest])
         ),
         pointFilter: get(skeletonFilter(modal)),
+        mediaFallback,
       };
     },
 });

--- a/app/packages/state/src/recoil/types.ts
+++ b/app/packages/state/src/recoil/types.ts
@@ -37,6 +37,7 @@ export namespace State {
     theme: "browser" | "dark" | "light";
     useFrameNumber: boolean;
     mediaFields?: string[];
+    mediaFallback: boolean;
   }
 
   export interface ID {

--- a/app/packages/utilities/src/paths.ts
+++ b/app/packages/utilities/src/paths.ts
@@ -11,7 +11,7 @@ export function determinePathType(path: string): PathType {
     return PathType.URL;
   }
   // backslashes = windows
-  if (path.includes("\\")) {
+  if (path?.includes("\\")) {
     return PathType.WINDOWS;
   }
   // linux by default

--- a/app/schema.graphql
+++ b/app/schema.graphql
@@ -63,6 +63,7 @@ type AppConfig {
   timezone: String
   useFrameNumber: Boolean!
   spaces: JSON
+  mediaFallback: Boolean!
 }
 
 scalar BSON
@@ -250,6 +251,7 @@ type DatasetAppConfig {
   spaces: JSON
   gridMediaField: String!
   modalMediaField: String!
+  mediaFallback: Boolean!
 }
 
 type DatasetStrConnection {

--- a/docs/source/user_guide/config.rst
+++ b/docs/source/user_guide/config.rst
@@ -711,8 +711,8 @@ The FiftyOne App can be configured in the ways described below:
 | `plugins`                 | N/A                                    | `{}`                        | A dict of plugin configurations. See :ref:`this section <configuring-plugins>` for        |
 |                           |                                        |                             | details.                                                                                  |
 +---------------------------+----------------------------------------+-----------------------------+-------------------------------------------------------------------------------------------+
-| `media_fallback`          | `FIFTYONE_APP_MEDIA_FALLBACK`          | `False`                     | Whether to fallback to the default media field ("filepath") when the alternate media      |
-|                           |                                        |                             | field value for a sample is None.                                                         |
+| `media_fallback`          | `FIFTYONE_APP_MEDIA_FALLBACK`          | `False`                     | Whether to fall back to the default media field (`"filepath"`) when the configured media  |
+|                           |                                        |                             | field's value for a sample is not defined.                                                |
 +---------------------------+----------------------------------------+-----------------------------+-------------------------------------------------------------------------------------------+
 
 Viewing your App config

--- a/docs/source/user_guide/config.rst
+++ b/docs/source/user_guide/config.rst
@@ -711,6 +711,9 @@ The FiftyOne App can be configured in the ways described below:
 | `plugins`                 | N/A                                    | `{}`                        | A dict of plugin configurations. See :ref:`this section <configuring-plugins>` for        |
 |                           |                                        |                             | details.                                                                                  |
 +---------------------------+----------------------------------------+-----------------------------+-------------------------------------------------------------------------------------------+
+| `media_fallback`          | `FIFTYONE_APP_MEDIA_FALLBACK`          | `False`                     | Whether to fallback to the default media field ("filepath") when the alternate media      |
+|                           |                                        |                             | field value for a sample is None.                                                         |
++---------------------------+----------------------------------------+-----------------------------+-------------------------------------------------------------------------------------------+
 
 Viewing your App config
 -----------------------
@@ -765,7 +768,8 @@ You can print your App config at any time via the Python library and the CLI:
             "sidebar_mode": "fast",
             "theme": "browser",
             "use_frame_number": false,
-            "plugins": {}
+            "plugins": {},
+            "media_fallback": false
         }
 
         True
@@ -814,7 +818,8 @@ You can print your App config at any time via the Python library and the CLI:
             "sidebar_mode": "fast",
             "theme": "browser",
             "use_frame_number": false,
-            "plugins": {}
+            "plugins": {},
+            "media_fallback": false
         }
 
         True

--- a/fiftyone/core/config.py
+++ b/fiftyone/core/config.py
@@ -5,6 +5,7 @@ FiftyOne config.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 import logging
 import os
 
@@ -437,6 +438,12 @@ class AppConfig(EnvConfig):
             default=False,
         )
         self.plugins = d.get("plugins", {})
+        self.media_fallback = self.parse_bool(
+            d,
+            "media_fallback",
+            env_var="FIFTYONE_APP_MEDIA_FALLBACK",
+            default=False,
+        )
 
         self._init()
 

--- a/fiftyone/core/config.py
+++ b/fiftyone/core/config.py
@@ -371,6 +371,12 @@ class AppConfig(EnvConfig):
             env_var="FIFTYONE_APP_LOOP_VIDEOS",
             default=False,
         )
+        self.media_fallback = self.parse_bool(
+            d,
+            "media_fallback",
+            env_var="FIFTYONE_APP_MEDIA_FALLBACK",
+            default=False,
+        )
         self.multicolor_keypoints = self.parse_bool(
             d,
             "multicolor_keypoints",
@@ -438,12 +444,6 @@ class AppConfig(EnvConfig):
             default=False,
         )
         self.plugins = d.get("plugins", {})
-        self.media_fallback = self.parse_bool(
-            d,
-            "media_fallback",
-            env_var="FIFTYONE_APP_MEDIA_FALLBACK",
-            default=False,
-        )
 
         self._init()
 

--- a/fiftyone/core/odm/dataset.py
+++ b/fiftyone/core/odm/dataset.py
@@ -387,8 +387,9 @@ class DatasetAppConfig(EmbeddedDocument):
             -   ``"point-cloud"``: See the
                 :ref:`3D visualizer docs <app-3d-visualizer-config>` for
                 supported options
-        media_fallback (False): whether to fallback to the default media field ("filepath") when the
-            alternate media field value for a sample is None.
+        media_fallback (False): whether to fall back to the default media field
+            (``"filepath"``) when the alternate media field value for a sample
+            is not defined
     """
 
     # strict=False lets this class ignore unknown fields from other versions

--- a/fiftyone/core/odm/dataset.py
+++ b/fiftyone/core/odm/dataset.py
@@ -387,6 +387,8 @@ class DatasetAppConfig(EmbeddedDocument):
             -   ``"point-cloud"``: See the
                 :ref:`3D visualizer docs <app-3d-visualizer-config>` for
                 supported options
+        media_fallback (False): whether to fallback to the default media field ("filepath") when the
+            alternate media field value for a sample is None.
     """
 
     # strict=False lets this class ignore unknown fields from other versions
@@ -401,6 +403,7 @@ class DatasetAppConfig(EmbeddedDocument):
     )
     color_scheme = EmbeddedDocumentField(ColorScheme, default=None)
     plugins = DictField()
+    media_fallback = BooleanField(default=False)
 
     @staticmethod
     def default_sidebar_groups(sample_collection):

--- a/fiftyone/server/query.py
+++ b/fiftyone/server/query.py
@@ -225,6 +225,7 @@ class DatasetAppConfig:
 
     grid_media_field: str = "filepath"
     modal_media_field: str = "filepath"
+    media_fallback: bool = False
 
 
 @gql.type
@@ -373,6 +374,7 @@ class AppConfig:
     timezone: t.Optional[str]
     use_frame_number: bool
     spaces: t.Optional[JSON]
+    media_fallback: bool = False
 
 
 @gql.type


### PR DESCRIPTION
## What changes are proposed in this pull request?

If a grid or modal media is configured to use a field in a sample other than `filepath` and the configured field value is none, use media in `fileback` field as a fallback for  a sample

## How is this patch tested? If it is not, please explain why.

```py
import fiftyone as fo
import fiftyone.utils.image as foui
import fiftyone.zoo as foz

dataset = foz.load_zoo_dataset("quickstart")

# Generate thumbnail images for samples
foui.transform_images(
    dataset,
    size=(-1, 32),
    output_field="thumbnail_path",
    output_dir="/tmp/thumbnails",
)

# Modify dataset's App config to use a different field for grid media
dataset.app_config.media_fields = ["filepath", "thumbnail_path"]
dataset.app_config.grid_media_field = "thumbnail_path"
dataset.app_config.media_fallback = True # Enable media_fallback

# Set thumbnail_path field for the first sample to None
sample = dataset.first()
sample.set_field("thumbnail_path", None)
sample.save()

dataset.save()
```

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

Add a config `media_fallback` to have the app fallback to `filepath` field for media when alternate media field value for a sample is None

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
  - Added `mediaFallback` configuration option to control fallback behavior for media fields in various parts of the app.
- **Documentation**
  - Updated user guide with details on the new `media_fallback` setting.
- **Bug Fixes**
  - Improved handling of non-string path inputs in utility functions for more reliable path determination.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->