### PR TITLE
Validate 'tags' argument of match_tags()

### DIFF
--- a/fiftyone/core/stages.py
+++ b/fiftyone/core/stages.py
@@ -5356,7 +5356,7 @@ class MatchTags(ViewStage):
             tags = [tags]
         else:
             tags = list(tags)
-            if not builtins.all([etau.is_str(t) for t in tags]):
+            if not builtins.all(etau.is_str(t) for t in tags):
                 raise ValueError(
                     "The `tags` argument must be a string or iterable of "
                     "strings."

--- a/fiftyone/core/stages.py
+++ b/fiftyone/core/stages.py
@@ -6,6 +6,7 @@ View stages.
 |
 """
 
+import builtins
 from collections import defaultdict, OrderedDict
 import contextlib
 from copy import deepcopy
@@ -5355,6 +5356,11 @@ class MatchTags(ViewStage):
             tags = [tags]
         else:
             tags = list(tags)
+            if not builtins.all([etau.is_str(t) for t in tags]):
+                raise ValueError(
+                    "The `tags` argument must be a string or iterable of "
+                    "strings."
+                )
 
         if bool is None:
             bool = True


### PR DESCRIPTION
## What changes are proposed in this pull request?

Adds validation to the `SampleCollection.match_tags()` method to ensure the `tags` argument is a string or iterable of strings. Otherwise, it raises an obscure error like this if you accidentally pass in, say, a `DatasetView`:
```
InvalidDocument: cannot encode object: <SampleView: {
    'id': '662001ac9379aa4cf021c06e',
    'media_type': 'image',
    'filepath': '/path/to/image.jpg',
    'tags': [],
    'metadata': None,
}>, of type: <class 'fiftyone.core.sample.SampleView'>
```

## How is this patch tested? If it is not, please explain why.

Tested by calling match_tags() with various types of input for the `tags` argument.

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced validation for the `tags` argument to ensure it is either a string or an iterable of strings, improving data integrity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->