### PR TITLE
fix recently used operator not shown first

### DIFF
--- a/app/packages/operators/src/state.ts
+++ b/app/packages/operators/src/state.ts
@@ -63,8 +63,8 @@ export const usePromptOperatorInput = () => {
 
   const prompt = (operatorName) => {
     setRecentlyUsedOperators((recentlyUsedOperators) => {
-      const update = new Set([...recentlyUsedOperators, operatorName]);
-      return Array.from(update).slice(-5);
+      const update = new Set([operatorName, ...recentlyUsedOperators]);
+      return Array.from(update).slice(0, 5);
     });
 
     setPromptingOperator({ operatorName, params: {} });
@@ -615,12 +615,13 @@ export const operatorBrowserQueryState = atom({
 });
 
 function sortResults(results, recentlyUsedOperators) {
+  const recentlyUsedOperatorsCount = recentlyUsedOperators.length;
   return results
     .map((result) => {
       let score = (result.description || result.label).charCodeAt(0);
       if (recentlyUsedOperators.includes(result.value)) {
-        const recentIdx = recentlyUsedOperators.indexOf(result.label);
-        score = recentIdx * -1;
+        const recentIdx = recentlyUsedOperators.indexOf(result.value);
+        score = (recentlyUsedOperatorsCount - recentIdx) * -1;
       }
       if (result.canExecute === false) {
         score += results.length;
@@ -634,7 +635,7 @@ function sortResults(results, recentlyUsedOperators) {
       if (a.score < b.score) {
         return -1;
       }
-      if (a.scrote > b.scrote) {
+      if (a.score > b.score) {
         return 1;
       }
       return 0;
@@ -670,7 +671,11 @@ export const operatorChoiceState = atom({
 export const recentlyUsedOperatorsState = atom({
   key: "recentlyUsedOperators",
   default: [],
-  effects: [fos.getBrowserStorageEffectForKey("operators-recently-used")],
+  effects: [
+    fos.getBrowserStorageEffectForKey("recently-used-operators", {
+      useJsonSerialization: true,
+    }),
+  ],
 });
 
 export function useOperatorBrowser() {


### PR DESCRIPTION
## What changes are proposed in this pull request?

Five recently used operators in the operators browser are no shown first consistently

## How is this patch tested? If it is not, please explain why.

Using operator browser

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

Fixed an issue where the five most recently used operators in the operators browser are not shown first consistently

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Bug Fixes**
	- Improved the logic for updating recently used operators and sorting results based on their recent usage.
	- Updated effects configuration for `recentlyUsedOperatorsState` to use JSON serialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->