### PR TITLE
Fix set state in server

### DIFF
--- a/fiftyone/core/state.py
+++ b/fiftyone/core/state.py
@@ -169,7 +169,11 @@ class StateDescription(etas.Serializable):
                     dataset.reload()
                     view = fov.DatasetView._build(dataset, stages)
 
-        config = fo.AppConfig.from_dict(d["config"]) if "config" in d else None
+        config = (
+            fo.AppConfig.from_dict(d["config"])
+            if d.get("config", None)
+            else None
+        )
 
         for field, value in d.get("config", {}).items():
             setattr(config, field, value)

--- a/fiftyone/server/events/dispatch.py
+++ b/fiftyone/server/events/dispatch.py
@@ -28,7 +28,7 @@ from fiftyone.core.session.events import (
     SetFieldVisibilityStage,
 )
 
-from fiftyone.server.events.state import get_listeners, get_state
+from fiftyone.server.events.state import get_listeners, get_state, set_state
 
 
 async def dispatch_event(
@@ -66,7 +66,7 @@ async def dispatch_event(
         state.group_slice = event.slice
 
     if isinstance(event, (StateUpdate, Refresh)):
-        state = event.state
+        set_state(event.state)
 
     if isinstance(event, ReactivateNotebookCell):
         await dispatch_event(subscription, DeactivateNotebookCell())

--- a/fiftyone/server/events/state.py
+++ b/fiftyone/server/events/state.py
@@ -45,6 +45,16 @@ def get_state() -> fos.StateDescription:
     return _state
 
 
+def set_state(state: fos.StateDescription):
+    """Set the current state.
+
+    Args:
+        state: a :class:`fiftyone.core.state.StateDescription` instance
+    """
+    global _state
+    _state = state
+
+
 def get_app_count():
     return _app_count
 

--- a/tests/unittests/server_events_tests.py
+++ b/tests/unittests/server_events_tests.py
@@ -10,7 +10,10 @@ import unittest
 
 import fiftyone as fo
 import fiftyone.core.state as fos
+import fiftyone.core.session.events as fose
 import fiftyone.server.events.initialize as fosi
+import fiftyone.server.events.dispatch as fosd
+import fiftyone.server.events.state as foss
 
 from decorators import drop_datasets
 
@@ -80,3 +83,15 @@ class ServerEventsTests(unittest.TestCase):
         )
         fosi.handle_workspace(state, slug=my_workspace.name)
         self.assertEqual(state.spaces.name, my_workspace.name)
+
+    def test_set_state(self):
+        state = fos.StateDescription()
+        foss.set_state(state)
+        self.assertEqual(state, foss.get_state())
+
+
+class TestServerEvents(unittest.IsolatedAsyncioTestCase):
+    async def test_dispatch_state_update(self):
+        state = fos.StateDescription()
+        await fosd.dispatch_event(None, fose.StateUpdate(state))
+        self.assertEqual(state, foss.get_state())


### PR DESCRIPTION
## What changes are proposed in this pull request?

Fixes state update changes in the App server. Follow up to #4275 that ensures the below snippet works
```py
import fiftyone as fo
import fiftyone.zoo as foz

fo.app_config.sidebar_mode = "disabled"
session = fo.Session(remote=True)
``` 

## How is this patch tested? If it is not, please explain why.

Server events tests

## Release Notes

Fixed session state updates from Python

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved state management in the application by ensuring proper state updates and initialization when certain data is absent.
- **Tests**
	- Enhanced testing for server event handling to ensure robustness and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->