### PR TITLE
Adds Support for Grounding DINO

### DIFF
--- a/docs/source/integrations/huggingface.rst
+++ b/docs/source/integrations/huggingface.rst
@@ -569,6 +569,34 @@ FiftyOne format:
     Some zero-shot models are compatible with multiple tasks, so it is
     recommended that you specify the task type when converting the model.
 
+
+As of `transformers` version `4.40.0` and FiftyOne version `0.24.0`, you can also
+use `Grounding DINO <https://huggingface.co/docs/transformers/main/en/model_doc/grounding-dino>`_
+models for zero-shot object detection:
+
+.. code-block:: python
+    :linenos:
+
+    import fiftyone.zoo as foz
+
+    model = foz.load_zoo_model(
+        "zero-shot-detection-transformer-torch",
+        name_or_path="IDEA-Research/grounding-dino-tiny",
+        classes=["cat"]
+    )
+
+    dataset.apply_model(model, label_field="cats", confidence_thresh=0.2)
+
+
+.. note::
+
+    The `confidence_thresh` parameter is optional and can be used to filter out
+    predictions with confidence scores below the specified threshold. You may
+    need to adjust this value based on the model and dataset you are working. 
+    Also note that whereas OwlViT models accept multiple classes, Grounding DINO
+    models only accept a single class.
+
+
 .. _huggingface-transformers-batch-inference:
 
 Batch inference

--- a/docs/source/integrations/huggingface.rst
+++ b/docs/source/integrations/huggingface.rst
@@ -569,9 +569,8 @@ FiftyOne format:
     Some zero-shot models are compatible with multiple tasks, so it is
     recommended that you specify the task type when converting the model.
 
-
-As of `transformers` version `4.40.0` and FiftyOne version `0.24.0`, you can also
-use `Grounding DINO <https://huggingface.co/docs/transformers/main/en/model_doc/grounding-dino>`_
+As of `transformers>=4.40.0` and `fiftyone>=0.24.0`, you can also use
+`Grounding DINO <https://huggingface.co/docs/transformers/main/en/model_doc/grounding-dino>`_
 models for zero-shot object detection:
 
 .. code-block:: python
@@ -582,11 +581,10 @@ models for zero-shot object detection:
     model = foz.load_zoo_model(
         "zero-shot-detection-transformer-torch",
         name_or_path="IDEA-Research/grounding-dino-tiny",
-        classes=["cat"]
+        classes=["cat"],
     )
 
     dataset.apply_model(model, label_field="cats", confidence_thresh=0.2)
-
 
 .. note::
 
@@ -595,7 +593,6 @@ models for zero-shot object detection:
     need to adjust this value based on the model and dataset you are working. 
     Also note that whereas OwlViT models accept multiple classes, Grounding DINO
     models only accept a single class.
-
 
 .. _huggingface-transformers-batch-inference:
 

--- a/fiftyone/utils/transformers.py
+++ b/fiftyone/utils/transformers.py
@@ -268,6 +268,14 @@ def to_detections(results, id2label, image_sizes):
     ]
 
 
+def _get_class(label, id2label):
+    # if the label is not in the id2label mapping, return the first label
+    l = label.item()
+    if l not in id2label:
+        return id2label[0]
+    return id2label[l]
+
+
 def _to_detections(result, id2label, image_size):
     detections = []
 
@@ -279,7 +287,7 @@ def _to_detections(result, id2label, image_size):
         box = _convert_bounding_box(box, image_size)
         detections.append(
             fol.Detection(
-                label=id2label[label.item()],
+                label=_get_class(label, id2label),
                 bounding_box=box,
                 confidence=score.item(),
             )
@@ -763,7 +771,7 @@ class FiftyOneZeroShotTransformerForObjectDetection(
         with torch.no_grad():
             outputs = self.model(**inputs)
 
-        results = self.processor.post_process_object_detection(
+        results = self.processor.image_processor.post_process_object_detection(
             outputs, target_sizes=target_sizes
         )
         image_shapes = [i[::-1] for i in target_sizes]


### PR DESCRIPTION
As of the latest release of `transformers` (yesterday), Grounding DINO is now available for zero-shot object detection. The model works slightly differently than the only other model that HF supports for this task (OwlViT) so I needed to tweak the integration very slightly to support this.


## Release Notes

Adds support for Grounding DINO zero-shot detection via Hugging Face Transformers:

```py
model = foz.load_zoo_model(
    "zero-shot-detection-transformer-torch",
    name_or_path="IDEA-Research/grounding-dino-tiny",
    classes=["cat"],
)

 ## detect all cats with conf above 0,2
dataset.apply_model(model, label_field="cat", confidence_thresh=0.2)
```

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [x] Documentation: FiftyOne documentation changes
-   [x] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Integrated support for using Grounding DINO models in zero-shot object detection tasks within the HuggingFace integration, starting from specific versions.
- **Documentation**
	- Updated integration documentation to include details on the new detection capabilities and usage parameters.
- **Bug Fixes**
	- Improved label handling in detection functions to ensure robustness when labels are missing from mappings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->