### PR TITLE
Bugfix: Server context getter use get_async_db_conn

### DIFF
--- a/fiftyone/core/odm/database.py
+++ b/fiftyone/core/odm/database.py
@@ -409,13 +409,13 @@ def get_async_db_client(use_global=False):
     return _async_connect(use_global)
 
 
-def get_async_db_conn():
+def get_async_db_conn(use_global=False):
     """Returns an async connection to the database.
 
     Returns:
         a ``motor.motor_asyncio.AsyncIOMotorDatabase``
     """
-    db = get_async_db_client()[fo.config.database_name]
+    db = get_async_db_client(use_global=use_global)[fo.config.database_name]
     return _apply_options(db)
 
 

--- a/fiftyone/server/context.py
+++ b/fiftyone/server/context.py
@@ -13,7 +13,7 @@ import strawberry.asgi as gqla
 
 
 import fiftyone as fo
-from fiftyone.core.odm import get_async_db_client
+from fiftyone.core.odm import get_async_db_conn
 
 from fiftyone.server.data import Context
 from fiftyone.server.dataloader import dataloaders, get_dataloader
@@ -24,8 +24,7 @@ def get_context(
     response: t.Optional[strp.Response] = None,
     use_global_db_client: bool = False,
 ):
-    db_client = get_async_db_client(use_global=use_global_db_client)
-    db = db_client[fo.config.database_name]
+    db = get_async_db_conn(use_global=use_global_db_client)
     loaders = {}
     for cls, config in dataloaders.items():
         loaders[cls] = get_dataloader(cls, config, db)

--- a/fiftyone/server/context.py
+++ b/fiftyone/server/context.py
@@ -12,7 +12,6 @@ import starlette.responses as strp
 import strawberry.asgi as gqla
 
 
-import fiftyone as fo
 from fiftyone.core.odm import get_async_db_conn
 
 from fiftyone.server.data import Context


### PR DESCRIPTION
## What changes are proposed in this pull request?

Make server get DB for graphql context from `get_async_db_conn` instead of `get_async_db_client` then using `fo.config.database_name`

Impact for OSS
- Calls `_apply_options(db)` now, so it is timezone aware based on `fo.config.timezone`
  - This may be a subtle bugfix on its own?

Unique impact for Teams (and impetus for this change)
- database name is determined from server if connecting through server, instead of `fo.config.database_name`


## How is this patch tested? If it is not, please explain why.

(in Teams) 
1. Connect through API when db name for API is not equal to `fo.config.database_name` of client.
2. Load a dataset and launch local app.
3. See you can load dataset properly and do not get "Access to the fiftyone database is not allowed"

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

Fixed issue with launching local app over Teams API connection when using a non-default database name.

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Refactor**
    - Improved database connection management for enhanced flexibility in handling connections within the app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->