### PR TITLE
Automatically set vertex coloring to true in ply when applicable

### DIFF
--- a/app/packages/looker-3d/src/fo3d/Stl.tsx
+++ b/app/packages/looker-3d/src/fo3d/Stl.tsx
@@ -29,7 +29,7 @@ export const Stl = ({
   const points = useLoader(STLLoader, stl.stlUrl);
   const [mesh, setMesh] = useState(null);
 
-  const { material } = useMeshMaterialControls(name, stl);
+  const { material } = useMeshMaterialControls(name, stl.defaultMaterial);
 
   useEffect(() => {
     if (!material) {

--- a/app/packages/looker-3d/src/fo3d/mesh/Obj.tsx
+++ b/app/packages/looker-3d/src/fo3d/mesh/Obj.tsx
@@ -19,7 +19,7 @@ const ObjMeshDefaultMaterial = ({
   const { objUrl } = obj;
   const mesh = useLoader(OBJLoader, objUrl);
 
-  const { material } = useMeshMaterialControls(name, obj);
+  const { material } = useMeshMaterialControls(name, obj.defaultMaterial);
 
   useEffect(() => {
     if (!mesh) {

--- a/app/packages/looker-3d/src/fo3d/mesh/Ply.tsx
+++ b/app/packages/looker-3d/src/fo3d/mesh/Ply.tsx
@@ -1,9 +1,76 @@
 import { useLoader } from "@react-three/fiber";
-import { useEffect, useState } from "react";
-import { Mesh, Quaternion, Vector3 } from "three";
+import { useEffect, useMemo, useState } from "react";
+import { BufferGeometry, Mesh, Quaternion, Vector3 } from "three";
 import { PLYLoader } from "three/examples/jsm/loaders/PLYLoader";
-import { PlyAsset } from "../../hooks";
+import {
+  FoMeshBasicMaterialProps,
+  FoMeshMaterial,
+  PlyAsset,
+} from "../../hooks";
 import { useMeshMaterialControls } from "../../hooks/use-mesh-material-controls";
+
+interface PlyProps {
+  name: string;
+  ply: PlyAsset;
+  position: Vector3;
+  quaternion: Quaternion;
+  scale: Vector3;
+  children?: React.ReactNode;
+}
+
+const PlyWithMaterialOverride = ({
+  name,
+  geometry,
+  defaultMaterial,
+}: {
+  name: string;
+  geometry: BufferGeometry;
+  defaultMaterial: FoMeshMaterial;
+}) => {
+  const basicMaterial = useMemo(
+    () =>
+      ({
+        ...defaultMaterial,
+        vertexColors: true,
+        color: "#ffffff",
+      } as FoMeshBasicMaterialProps),
+    [defaultMaterial]
+  );
+
+  const { material } = useMeshMaterialControls(name, basicMaterial);
+
+  const mesh = useMemo(() => {
+    return new Mesh(geometry, material);
+  }, [geometry, material]);
+
+  if (!mesh) {
+    return null;
+  }
+
+  return <primitive object={mesh} />;
+};
+
+const PlyWithNoMaterialOverride = ({
+  name,
+  geometry,
+  defaultMaterial,
+}: {
+  name: string;
+  geometry: BufferGeometry;
+  defaultMaterial: FoMeshMaterial;
+}) => {
+  const { material } = useMeshMaterialControls(name, defaultMaterial);
+
+  const mesh = useMemo(() => {
+    return new Mesh(geometry, material);
+  }, [geometry, material]);
+
+  if (!mesh) {
+    return null;
+  }
+
+  return <primitive object={mesh} />;
+};
 
 export const Ply = ({
   name,
@@ -12,48 +79,70 @@ export const Ply = ({
   quaternion,
   scale,
   children,
-}: {
-  name: string;
-  ply: PlyAsset;
-  position: Vector3;
-  quaternion: Quaternion;
-  scale: Vector3;
-  children?: React.ReactNode;
-}) => {
+}: PlyProps) => {
   const geometry = useLoader(PLYLoader, ply.plyUrl);
-  const [mesh, setMesh] = useState(null);
 
-  const { material } = useMeshMaterialControls(name, ply);
+  const [isUsingVertexColors, setIsUsingVertexColors] = useState(false);
+  const [isGeometryResolved, setIsGeometryResolved] = useState(false);
 
   useEffect(() => {
-    if (!material) {
+    if (!geometry) {
       return;
     }
 
-    if (geometry) {
-      // todo: check if geometry is meshes or points
-      // todo: no need to compute vertex normals for points
+    if (
+      geometry.attributes?.position?.count &&
+      !geometry.attributes.normal?.count
+    ) {
       geometry.computeVertexNormals();
       geometry.center();
-
-      // todo: use points material for points
-      const newMesh = new Mesh(geometry, material);
-      setMesh(newMesh);
     }
-  }, [geometry, material]);
 
-  if (mesh) {
+    if (geometry.attributes?.color?.count) {
+      setIsUsingVertexColors(true);
+    }
+
+    setIsGeometryResolved(true);
+  }, [geometry]);
+
+  const mesh = useMemo(() => {
+    if (!isGeometryResolved) {
+      return null;
+    }
+
+    if (isUsingVertexColors) {
+      return (
+        <PlyWithMaterialOverride
+          name={name}
+          geometry={geometry}
+          defaultMaterial={ply.defaultMaterial}
+        />
+      );
+    }
+
     return (
-      <primitive
-        object={mesh}
-        position={position}
-        quaternion={quaternion}
-        scale={scale}
-      >
-        {children ?? null}
-      </primitive>
+      <PlyWithNoMaterialOverride
+        name={name}
+        geometry={geometry}
+        defaultMaterial={ply.defaultMaterial}
+      />
     );
+  }, [
+    isGeometryResolved,
+    isUsingVertexColors,
+    geometry,
+    name,
+    ply.defaultMaterial,
+  ]);
+
+  if (!mesh) {
+    return null;
   }
 
-  return null;
+  return (
+    <group position={position} quaternion={quaternion} scale={scale}>
+      {mesh}
+      <group>{children ?? null}</group>
+    </group>
+  );
 };

--- a/app/packages/looker-3d/src/fo3d/shape/Box.tsx
+++ b/app/packages/looker-3d/src/fo3d/shape/Box.tsx
@@ -32,7 +32,7 @@ export const Box = ({
       ),
     [box]
   );
-  const { material } = useMeshMaterialControls(name, box);
+  const { material } = useMeshMaterialControls(name, box.defaultMaterial);
 
   const mesh = useMemo(() => {
     if (!material) {

--- a/app/packages/looker-3d/src/fo3d/shape/Cylinder.tsx
+++ b/app/packages/looker-3d/src/fo3d/shape/Cylinder.tsx
@@ -32,7 +32,7 @@ export const Cylinder = ({
       ),
     [cylinder]
   );
-  const { material } = useMeshMaterialControls(name, cylinder);
+  const { material } = useMeshMaterialControls(name, cylinder.defaultMaterial);
 
   const mesh = useMemo(() => {
     if (!material) {

--- a/app/packages/looker-3d/src/fo3d/shape/Plane.tsx
+++ b/app/packages/looker-3d/src/fo3d/shape/Plane.tsx
@@ -30,7 +30,7 @@ export const Plane = ({
       ),
     [plane]
   );
-  const { material } = useMeshMaterialControls(name, plane);
+  const { material } = useMeshMaterialControls(name, plane.defaultMaterial);
 
   const mesh = useMemo(() => {
     if (!material) {

--- a/app/packages/looker-3d/src/fo3d/shape/Sphere.tsx
+++ b/app/packages/looker-3d/src/fo3d/shape/Sphere.tsx
@@ -31,7 +31,7 @@ export const Sphere = ({
       ),
     [sphere]
   );
-  const { material } = useMeshMaterialControls(name, sphere);
+  const { material } = useMeshMaterialControls(name, sphere.defaultMaterial);
 
   const mesh = useMemo(() => {
     if (!material) {

--- a/app/packages/looker-3d/src/hooks/use-mesh-material-controls.ts
+++ b/app/packages/looker-3d/src/hooks/use-mesh-material-controls.ts
@@ -2,23 +2,24 @@ import { folder, useControls } from "leva";
 import { useMemo, useState } from "react";
 import { PANEL_ORDER_PCD_CONTROLS } from "../constants";
 import { getThreeMaterialFromFo3dMaterial } from "../fo3d/utils";
-import { ObjAsset } from "./use-fo3d";
+import { FoMeshMaterial } from "./use-fo3d";
 
-export const useMeshMaterialControls = (name: string, node: ObjAsset) => {
-  const { defaultMaterial } = node;
-
-  const [opacity, setOpacity] = useState(defaultMaterial.opacity);
+export const useMeshMaterialControls = (
+  name: string,
+  foMeshMaterial: FoMeshMaterial
+) => {
+  const [opacity, setOpacity] = useState(foMeshMaterial.opacity);
   const [renderAsWireframe, setRenderAsWireframe] = useState(
-    defaultMaterial.wireframe
+    foMeshMaterial.wireframe
   );
-  const [color, setColor] = useState(defaultMaterial["color"] ?? "#ffffff");
-  const [metalness, setMetalness] = useState(defaultMaterial["metalness"] ?? 0);
-  const [roughness, setRoughness] = useState(defaultMaterial["roughness"] ?? 1);
+  const [color, setColor] = useState(foMeshMaterial["color"] ?? "#ffffff");
+  const [metalness, setMetalness] = useState(foMeshMaterial["metalness"] ?? 0);
+  const [roughness, setRoughness] = useState(foMeshMaterial["roughness"] ?? 1);
   const [emissiveColor, setEmissiveColor] = useState(
-    defaultMaterial["emissive"] ?? "#000000"
+    foMeshMaterial["emissive"] ?? "#000000"
   );
   const [emissiveIntensity, setEmissiveIntensity] = useState(
-    defaultMaterial["emissiveIntensity"] ?? 0.1
+    foMeshMaterial["emissiveIntensity"] ?? 0.1
   );
 
   // note: we're not making attributes like reflectivity, IOR, etc. configurable
@@ -28,7 +29,7 @@ export const useMeshMaterialControls = (name: string, node: ObjAsset) => {
       [name]: folder(
         {
           materialTypeLabel: {
-            value: defaultMaterial._type,
+            value: foMeshMaterial._type,
             label: "Material Type",
             editable: false,
             order: -1,
@@ -52,7 +53,7 @@ export const useMeshMaterialControls = (name: string, node: ObjAsset) => {
             value: color,
             label: "Color",
             onChange: setColor,
-            render: () => defaultMaterial._type !== "MeshDepthMaterial",
+            render: () => foMeshMaterial._type !== "MeshDepthMaterial",
             order: 1004,
           },
           metalness: {
@@ -62,7 +63,7 @@ export const useMeshMaterialControls = (name: string, node: ObjAsset) => {
             step: 0.1,
             label: "Metalness",
             onChange: setMetalness,
-            render: () => defaultMaterial._type === "MeshStandardMaterial",
+            render: () => foMeshMaterial._type === "MeshStandardMaterial",
             order: 1005,
           },
           roughness: {
@@ -72,7 +73,7 @@ export const useMeshMaterialControls = (name: string, node: ObjAsset) => {
             step: 0.1,
             label: "Roughness",
             onChange: setRoughness,
-            render: () => defaultMaterial._type === "MeshStandardMaterial",
+            render: () => foMeshMaterial._type === "MeshStandardMaterial",
             order: 1006,
           },
           emissiveIntensity: {
@@ -83,8 +84,8 @@ export const useMeshMaterialControls = (name: string, node: ObjAsset) => {
             label: "Emissive Intensity",
             onChange: setEmissiveIntensity,
             render: () =>
-              defaultMaterial._type !== "MeshDepthMaterial" &&
-              defaultMaterial._type !== "MeshBasicMaterial",
+              foMeshMaterial._type !== "MeshDepthMaterial" &&
+              foMeshMaterial._type !== "MeshBasicMaterial",
             order: 1007,
           },
           emissiveColor: {
@@ -103,7 +104,7 @@ export const useMeshMaterialControls = (name: string, node: ObjAsset) => {
       ),
     }),
     [
-      defaultMaterial,
+      foMeshMaterial,
       opacity,
       metalness,
       roughness,
@@ -117,7 +118,7 @@ export const useMeshMaterialControls = (name: string, node: ObjAsset) => {
 
   const material = useMemo(() => {
     return getThreeMaterialFromFo3dMaterial({
-      ...defaultMaterial,
+      ...foMeshMaterial,
       opacity,
       wireframe: renderAsWireframe,
       color,
@@ -127,7 +128,7 @@ export const useMeshMaterialControls = (name: string, node: ObjAsset) => {
       emissiveIntensity,
     });
   }, [
-    defaultMaterial,
+    foMeshMaterial,
     opacity,
     renderAsWireframe,
     color,

--- a/fiftyone/core/threed/material_3d.py
+++ b/fiftyone/core/threed/material_3d.py
@@ -26,17 +26,14 @@ class Material3D:
 
     Args:
         opacity (1.0): the opacity of the material, in the range ``[0, 1]``
-        vertex_colors (False): whether the material uses vertex colors
     """
 
     opacity: float = 1.0
-    vertex_colors: bool = False
 
     def as_dict(self):
         return {
             "_type": self.__class__.__name__,
             "opacity": self.opacity,
-            "vertexColors": self.vertex_colors,
         }
 
     @staticmethod

--- a/fiftyone/core/threed/mesh.py
+++ b/fiftyone/core/threed/mesh.py
@@ -18,7 +18,7 @@ class Mesh(Object3D):
     Args:
         material (:class:`fiftyone.core.threed.MeshMaterial`, optional):
             the default material for the mesh. Defaults to
-            :class:`fiftyone.core.threed.MeshLambertMaterial`
+            :class:`fiftyone.core.threed.MeshStandardMaterial`
             if not provided
         **kwargs: keyword arguments for the
             :class:`fiftyone.core.threed.Object3D` parent class
@@ -61,7 +61,7 @@ class ObjMesh(Mesh):
         material (:class:`fiftyone.core.threed.MeshMaterial`, optional):
             the default material for the mesh if ``mtl_path`` is not provided
             or if material in ``mtl_path`` is not found. Defaults to
-            :class:`fiftyone.core.threed.MeshLambertMaterial`
+            :class:`fiftyone.core.threed.MeshStandardMaterial`
         **kwargs: keyword arguments for the :class:`Mesh` parent class
 
     Raises:
@@ -147,7 +147,7 @@ class GltfMesh(Mesh):
         material (:class:`fiftyone.core.threed.MeshMaterial`, optional):
             the default material for the mesh if gLTF file does not contain
             material information. Defaults to
-            :class:`fiftyone.core.threed.MeshLambertMaterial`
+            :class:`fiftyone.core.threed.MeshStandardMaterial`
         **kwargs: keyword arguments for the :class:`Mesh` parent class
 
     Raises:
@@ -188,7 +188,9 @@ class PlyMesh(Mesh):
         material (:class:`fiftyone.core.threed.MeshMaterial`, optional):
             default material for the mesh if PLY file does not contain
             vertex colors. Defaults to
-            :class:`fiftyone.core.threed.MeshLambertMaterial`
+            :class:`fiftyone.core.threed.MeshStandardMaterial`. If the PLY
+            file contains vertex colors, the material will be ignored and
+            vertex colors will be used.
         **kwargs: keyword arguments for the :class:`Mesh` parent class
 
     Raises:
@@ -226,7 +228,7 @@ class StlMesh(Mesh):
             file
         material (:class:`fiftyone.core.threed.MeshMaterial`, optional):
             default material for the mesh. Defaults to
-            :class:`fiftyone.core.threed.MeshLambertMaterial`
+            :class:`fiftyone.core.threed.MeshStandardMaterial`
         **kwargs: keyword arguments for the :class:`Mesh` parent class
 
     Raises:

--- a/fiftyone/core/threed/mesh.py
+++ b/fiftyone/core/threed/mesh.py
@@ -189,8 +189,8 @@ class PlyMesh(Mesh):
             default material for the mesh if PLY file does not contain
             vertex colors. Defaults to
             :class:`fiftyone.core.threed.MeshStandardMaterial`. If the PLY
-            file contains vertex colors, the material will be ignored and
-            vertex colors will be used.
+            file contains vertex colors, the material is ignored and vertex
+            colors are used
         **kwargs: keyword arguments for the :class:`Mesh` parent class
 
     Raises:

--- a/fiftyone/core/threed/shape_3d.py
+++ b/fiftyone/core/threed/shape_3d.py
@@ -19,7 +19,7 @@ class Shape3D(Mesh):
     Args:
         material (:class:`fiftyone.core.threed.MeshMaterial`, optional):
             default material for the shape mesh. Defaults to
-            :class:`fiftyone.core.threed.MeshLambertMaterial` if not provided
+            :class:`fiftyone.core.threed.MeshStandardMaterial` if not provided
         **kwargs: keyword arguments for the :class:`fiftyone.core.threed.Mesh`
             parent class
     """
@@ -37,7 +37,7 @@ class BoxGeometry(Shape3D):
         depth (float): the depth of the box. Defaults to 1
         material (:class:`fiftyone.core.threed.MeshMaterial`, optional):
             default material for the box. Defaults to
-            :class:`fiftyone.core.threed.MeshLambertMaterial`
+            :class:`fiftyone.core.threed.MeshStandardMaterial`
         **kwargs: keyword arguments for the :class:`Shape3D` parent class
     """
 
@@ -88,7 +88,7 @@ class CylinderGeometry(Shape3D):
             to 2*Math.PI, which makes for a complete cylinder
         material (:class:`fiftyone.core.threed.MeshMaterial`, optional):
             default material for the cylinder. Defaults to
-            :class:`fiftyone.core.threed.MeshLambertMaterial`
+            :class:`fiftyone.core.threed.MeshStandardMaterial`
         **kwargs: keyword arguments for the :class:`Shape3D` parent class
     """
 
@@ -152,7 +152,7 @@ class SphereGeometry(Shape3D):
             ``math.pi``, which makes for a complete sphere
         material (:class:`fiftyone.core.threed.MeshMaterial`, optional):
             the default material for the sphere. Defaults to
-            :class:`fiftyone.core.threed.MeshLambertMaterial`
+            :class:`fiftyone.core.threed.MeshStandardMaterial`
         **kwargs: keyword arguments for the :class:`Shape3D` parent class
     """
 
@@ -202,7 +202,7 @@ class PlaneGeometry(Shape3D):
         height (float): the height of the plane. Defaults to 1
         material (:class:`fiftyone.core.threed.MeshMaterial`, optional):
             the default material for the plane. Defaults to
-            :class:`fiftyone.core.threed.MeshLambertMaterial`
+            :class:`fiftyone.core.threed.MeshStandardMaterial`
         **kwargs: keyword arguments for the :class:`Shape3D` parent class
     """
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

It makes for a better customer experience to automatically set vertex colors to true if present in the PLY file. This is what this PR does. If vertex colors are detected, material override is done for the color attribute. This is because default material's color is gray, and that gets multiplied with vertex colors leading to undesirable rendering (darker tint). There's no problem with white since 0xfff x vertexColors = vertexColors.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced material override components for better visual representation based on vertex colors in 3D models.
- **Enhancements**
	- Improved material settings for various 3D shapes and meshes, enhancing visual quality and performance.
- **Refactor**
	- Updated internal material handling logic to better support dynamic settings like opacity, color, and emissiveness.
- **Bug Fixes**
	- Removed unused attributes from material settings, streamlining the configuration process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->