### PR TITLE
Fix dynamically grouping group datasets in the App

### DIFF
--- a/app/packages/core/src/components/Modal/Group/DynamicGroup/carousel/DynamicGroupsFlashlightWrapper.tsx
+++ b/app/packages/core/src/components/Modal/Group/DynamicGroup/carousel/DynamicGroupsFlashlightWrapper.tsx
@@ -30,7 +30,7 @@ const pageParams = selector({
 
     const params = {
       dataset,
-      view: get(fos.dynamicGroupViewQuery({})),
+      view: get(fos.dynamicGroupViewQuery(null)),
     };
 
     return (page: number, pageSize: number) => {

--- a/app/packages/core/src/components/Modal/Group/DynamicGroup/useDynamicGroupSamples.ts
+++ b/app/packages/core/src/components/Modal/Group/DynamicGroup/useDynamicGroupSamples.ts
@@ -7,7 +7,7 @@ import { useRecoilValue } from "recoil";
 export const useDynamicGroupSamples = () => {
   const environment = useRelayEnvironment();
   const slice = useRecoilValue(fos.groupSlice);
-  const view = useRecoilValue(fos.dynamicGroupViewQuery({}));
+  const view = useRecoilValue(fos.dynamicGroupViewQuery(null));
   const dataset = useRecoilValue(fos.datasetName);
   const dynamicGroupIndex = useRecoilValue(fos.dynamicGroupIndex);
   const shouldRenderImavid = useRecoilValue(fos.shouldRenderImaVidLooker);

--- a/app/packages/core/src/components/Modal/Group/GroupCarousel.tsx
+++ b/app/packages/core/src/components/Modal/Group/GroupCarousel.tsx
@@ -34,7 +34,9 @@ const pageParams = selector({
   get: ({ get }) => {
     const params = {
       dataset: get(fos.datasetName) as string,
-      view: get(fos.view),
+      view: get(fos.view)?.filter(
+        (stage) => stage._cls !== fos.GROUP_BY_VIEW_STAGE
+      ),
       filter: {
         group: {
           slice: get(fos.groupSlice),

--- a/app/packages/core/src/components/Modal/Group/GroupCarousel.tsx
+++ b/app/packages/core/src/components/Modal/Group/GroupCarousel.tsx
@@ -34,9 +34,7 @@ const pageParams = selector({
   get: ({ get }) => {
     const params = {
       dataset: get(fos.datasetName) as string,
-      view: get(fos.view)?.filter(
-        (stage) => stage._cls !== fos.GROUP_BY_VIEW_STAGE
-      ),
+      view: get(fos.groupView),
       filter: {
         group: {
           slice: get(fos.groupSlice),

--- a/app/packages/state/README.md
+++ b/app/packages/state/README.md
@@ -6,29 +6,26 @@ FiftyOne App state APIs
 
 This package can be used in the following contexts
 
-- internal - for interacting with the app state within the core app modules
-- external - for interacting with the state of an embeded app aka the `<Dataset />` component
-- plugin - for interacting with app state in your plugin
+-   internal - for interacting with the app state within the core app modules
+-   external - for interacting with the state of an embeded app aka the
+    `<Dataset />` component
+-   plugin - for interacting with app state in your plugin
 
 ## Types
 
-The API assumes you are running in one of the contexts listed above, which requires the ability to interact with the following types of objects.
+The API assumes you are running in one of the contexts listed above, which
+requires the ability to interact with the following types of objects.
 
 ### Recoil
 
-- `Atom`
-- `Selector`
-- `SelectorFamily`
+-   `Atom`
+-   `Selector`
+-   `SelectorFamily`
 
 ### React Hooks
 
 Custom hooks following similar patterns to the following:
 
-- `useEffect`
-- `useState`
-- `useCallback`
-- etc.
-
-## API Reference
-
-Coming soon. This will describe each of the exported objects and functions.
+-   `useEffect`
+-   `useState`
+-   `useCallback`

--- a/app/packages/state/src/hooks/useCreateLooker.ts
+++ b/app/packages/state/src/hooks/useCreateLooker.ts
@@ -9,7 +9,7 @@ import {
 } from "@fiftyone/looker";
 import { ImaVidFramesController } from "@fiftyone/looker/src/lookers/imavid/controller";
 import { ImaVidFramesControllerStore } from "@fiftyone/looker/src/lookers/imavid/store";
-import { ImaVidConfig } from "@fiftyone/looker/src/state";
+import { BaseState, ImaVidConfig } from "@fiftyone/looker/src/state";
 import {
   EMBEDDED_DOCUMENT_FIELD,
   LIST_FIELD,
@@ -26,7 +26,7 @@ import {
   selectedMediaField,
 } from "../recoil";
 import { selectedSamples } from "../recoil/atoms";
-import * as groupAtoms from "../recoil/groups";
+import * as dynamicGroupAtoms from "../recoil/dynamicGroups";
 import * as schemaAtoms from "../recoil/schema";
 import { datasetName } from "../recoil/selectors";
 import { State } from "../recoil/types";
@@ -34,7 +34,7 @@ import { getSampleSrc, getSanitizedGroupByExpression } from "../recoil/utils";
 import * as viewAtoms from "../recoil/view";
 import { getStandardizedUrls } from "../utils";
 
-export default <T extends AbstractLooker>(
+export default <T extends AbstractLooker<BaseState>>(
   isModal: boolean,
   thumbnail: boolean,
   options: Omit<Parameters<T["updateOptions"]>[0], "selected">,
@@ -59,7 +59,7 @@ export default <T extends AbstractLooker>(
   );
 
   const shouldRenderImaVidLooker = useRecoilValue(
-    groupAtoms.shouldRenderImaVidLooker
+    dynamicGroupAtoms.shouldRenderImaVidLooker
   );
 
   // callback to get the latest promise inside another recoil callback
@@ -162,34 +162,35 @@ export default <T extends AbstractLooker>(
 
         if (constructor === ImaVidLooker) {
           const { groupBy } = snapshot
-            .getLoadable(groupAtoms.dynamicGroupParameters)
+            .getLoadable(dynamicGroupAtoms.dynamicGroupParameters)
             .valueMaybe();
           const groupByFieldValue = get(
             sample,
             getSanitizedGroupByExpression(groupBy)
           );
-          const groupByFieldValueTransformed = groupByFieldValue
-            ? String(groupByFieldValue)
-            : null;
+          const groupByFieldValueTransformed =
+            groupByFieldValue !== null ? String(groupByFieldValue) : null;
 
           const totalFrameCountPromise = getPromise(
             dynamicGroupsElementCount(groupByFieldValueTransformed)
           );
           const page = snapshot
             .getLoadable(
-              groupAtoms.dynamicGroupPageSelector(groupByFieldValueTransformed)
+              dynamicGroupAtoms.dynamicGroupPageSelector(
+                groupByFieldValueTransformed
+              )
             )
             .valueMaybe();
 
           const firstFrameNumber = isModal
             ? snapshot
-                .getLoadable(groupAtoms.dynamicGroupCurrentElementIndex)
+                .getLoadable(dynamicGroupAtoms.dynamicGroupCurrentElementIndex)
                 .valueMaybe() ?? 1
             : 1;
 
           const imavidKey = snapshot
             .getLoadable(
-              groupAtoms.imaVidStoreKey({
+              dynamicGroupAtoms.imaVidStoreKey({
                 groupByFieldValue: groupByFieldValueTransformed,
                 modal: isModal,
               })
@@ -216,7 +217,9 @@ export default <T extends AbstractLooker>(
             frameRate: 24,
             firstFrameNumber: isModal
               ? snapshot
-                  .getLoadable(groupAtoms.dynamicGroupCurrentElementIndex)
+                  .getLoadable(
+                    dynamicGroupAtoms.dynamicGroupCurrentElementIndex
+                  )
                   .valueMaybe() ?? 1
               : 1,
           } as ImaVidConfig;

--- a/app/packages/state/src/hooks/useExpandSample.ts
+++ b/app/packages/state/src/hooks/useExpandSample.ts
@@ -3,6 +3,7 @@ import { get } from "lodash";
 import { useRelayEnvironment } from "react-relay";
 import { CallbackInterface, RecoilState, useRecoilCallback } from "recoil";
 import * as atoms from "../recoil/atoms";
+import * as dynamicGroupAtoms from "../recoil/dynamicGroups";
 import * as filterAtoms from "../recoil/filters";
 import * as groupAtoms from "../recoil/groups";
 import * as modalAtoms from "../recoil/modal";
@@ -114,7 +115,7 @@ export default <T extends Lookers>(store: LookerStore<T>) => {
         );
         const groupField = await snapshot.getPromise(groupAtoms.groupField);
         const dynamicGroupParameters = await snapshot.getPromise(
-          groupAtoms.dynamicGroupParameters
+          dynamicGroupAtoms.dynamicGroupParameters
         );
 
         const getItemAtIndex = async (index: number) => {

--- a/app/packages/state/src/hooks/useHoveredSample.ts
+++ b/app/packages/state/src/hooks/useHoveredSample.ts
@@ -1,9 +1,9 @@
-import { AppSample } from "../recoil";
-import * as fos from "../..";
+import { Sample } from "@fiftyone/looker";
 import { useSetRecoilState } from "recoil";
+import * as fos from "../..";
 
 export default function useHoveredSample(
-  sample: AppSample,
+  sample: Sample,
   auxHandlers: any = {}
 ) {
   const setSample = useSetRecoilState(fos.hoveredSample);

--- a/app/packages/state/src/hooks/useSetExpandedSample.ts
+++ b/app/packages/state/src/hooks/useSetExpandedSample.ts
@@ -9,6 +9,7 @@ import {
   currentModalSample,
   dynamicGroupCurrentElementIndex,
 } from "../recoil";
+import * as dynamicGroupAtoms from "../recoil/dynamicGroups";
 import * as groupAtoms from "../recoil/groups";
 
 export default () => {
@@ -28,10 +29,10 @@ export default () => {
         set(groupAtoms.groupId, groupId || null);
         set(currentModalSample, { id, index });
 
-        reset(groupAtoms.dynamicGroupIndex);
+        reset(dynamicGroupAtoms.dynamicGroupIndex);
         reset(dynamicGroupCurrentElementIndex);
         groupByFieldValue &&
-          set(groupAtoms.groupByFieldValue, groupByFieldValue);
+          set(dynamicGroupAtoms.groupByFieldValue, groupByFieldValue);
 
         let fallback = r.current;
         if (map[groupSlice] === "point_cloud") {

--- a/app/packages/state/src/recoil/aggregations.ts
+++ b/app/packages/state/src/recoil/aggregations.ts
@@ -150,28 +150,6 @@ export const aggregation = selectorFamily({
     },
 });
 
-export const dynamicGroupsElementCount = selectorFamily<number, string | null>({
-  key: "dynamicGroupsElementCount",
-  get:
-    (groupByFieldValueExplicit: string | null = null) =>
-    ({ get }) => {
-      return (
-        get(
-          aggregationQuery({
-            customView: get(
-              viewAtoms.dynamicGroupViewQuery(
-                groupByFieldValueExplicit ? { groupByFieldValueExplicit } : {}
-              )
-            ),
-            extended: false,
-            modal: false,
-            paths: [""],
-          })
-        ).at(0)?.count ?? 0
-      );
-    },
-});
-
 export const modalAggregationPaths = selectorFamily({
   key: "modalAggregationPaths",
   get:

--- a/app/packages/state/src/recoil/dynamicGroups.test.ts
+++ b/app/packages/state/src/recoil/dynamicGroups.test.ts
@@ -26,5 +26,3 @@ describe("handles non-nested dynamic groups", () => {
     expect(testNesting()).toBe(false);
   });
 });
-
-describe("dynamic group view modifications", () => {});

--- a/app/packages/state/src/recoil/dynamicGroups.test.ts
+++ b/app/packages/state/src/recoil/dynamicGroups.test.ts
@@ -3,12 +3,12 @@ vi.mock("recoil");
 vi.mock("recoil-relay");
 
 import { setMockAtoms, TestSelector } from "../../../../__mocks__/recoil";
-import * as groups from "./groups";
+import * as dynamicGroups from "./dynamicGroups";
 
 describe("handles non-nested dynamic groups", () => {
-  const testNesting = <TestSelector<typeof groups.isNonNestedDynamicGroup>>(
-    (<unknown>groups.isNonNestedDynamicGroup)
-  );
+  const testNesting = <
+    TestSelector<typeof dynamicGroups.isNonNestedDynamicGroup>
+  >(<unknown>dynamicGroups.isNonNestedDynamicGroup);
 
   it("resolves as non-nesting", () => {
     setMockAtoms({
@@ -26,3 +26,5 @@ describe("handles non-nested dynamic groups", () => {
     expect(testNesting()).toBe(false);
   });
 });
+
+describe("dynamic group view modifications", () => {});

--- a/app/packages/state/src/recoil/dynamicGroups.ts
+++ b/app/packages/state/src/recoil/dynamicGroups.ts
@@ -1,0 +1,312 @@
+import { ImaVidLooker } from "@fiftyone/looker";
+import {
+  DYNAMIC_GROUP_FIELDS,
+  EMBEDDED_DOCUMENT_FIELD,
+  GROUP,
+  LIST_FIELD,
+} from "@fiftyone/utilities";
+import { atom, atomFamily, selector, selectorFamily } from "recoil";
+import { currentSlice, hasGroupSlices } from "./groups";
+import { modalLooker } from "./modal";
+import { dynamicGroupsViewMode } from "./options";
+import { fieldPaths } from "./schema";
+import { datasetName, parentMediaTypeSelector } from "./selectors";
+import { State } from "./types";
+import { getSanitizedGroupByExpression } from "./utils";
+import {
+  GROUP_BY_VIEW_STAGE,
+  LIMIT_VIEW_STAGE,
+  MATCH_VIEW_STAGE,
+  SKIP_VIEW_STAGE,
+  SORT_VIEW_STAGE,
+  TAKE_VIEW_STAGE,
+  view,
+} from "./view";
+
+export const dynamicGroupCurrentElementIndex = atom<number>({
+  key: "dynamicGroupCurrentElementIndex",
+  default: 1,
+});
+
+export const dynamicGroupIndex = atom<number>({
+  key: "dynamicGroupIndex",
+  default: null,
+});
+
+export const dynamicGroupFields = selector<string[]>({
+  key: "dynamicGroupFields",
+  get: ({ get }) => {
+    const groups = get(
+      fieldPaths({
+        ftype: EMBEDDED_DOCUMENT_FIELD,
+        embeddedDocType: GROUP,
+        space: State.SPACE.SAMPLE,
+      })
+    );
+    const lists = get(
+      fieldPaths({ ftype: LIST_FIELD, space: State.SPACE.SAMPLE })
+    );
+    const primitives = get(
+      fieldPaths({ ftype: DYNAMIC_GROUP_FIELDS, space: State.SPACE.SAMPLE })
+    ).filter((path) => path !== "filepath" && path !== "id");
+
+    const filtered = primitives.filter(
+      (path) =>
+        lists.every((list) => !path.startsWith(list)) &&
+        groups.every(
+          (group) => path !== `${group}.id` && path !== `${group}.name`
+        )
+    );
+
+    return filtered;
+  },
+});
+
+export const dynamicGroupPageSelector = selectorFamily<
+  (
+    cursor: number,
+    pageSize: number
+  ) => {
+    after: string | null;
+    count: number;
+    dataset: string;
+    filter: Record<string, never>;
+    view: State.Stage[];
+  },
+  string
+>({
+  key: "paginateDynamicGroupVariables",
+  get:
+    (value) =>
+    ({ get }) => {
+      const params = {
+        dataset: get(datasetName),
+        view: get(dynamicGroupViewQuery(value)),
+      };
+
+      return (cursor: number, pageSize: number) => ({
+        ...params,
+        after: cursor ? String(cursor) : null,
+        count: pageSize,
+        filter: {},
+      });
+    },
+});
+
+export const dynamicGroupParameters =
+  selector<State.DynamicGroupParameters | null>({
+    key: "dynamicGroupParameters",
+    get: ({ get }) => {
+      const viewArr = get(view);
+      if (!viewArr) return null;
+
+      const groupByViewStageNode = viewArr.find(
+        (view) => view._cls === GROUP_BY_VIEW_STAGE
+      );
+      if (!groupByViewStageNode) return null;
+
+      // third index is 'flat', we want it to be false for dynamic groups
+      const isFlat = groupByViewStageNode.kwargs[2][1];
+      if (isFlat) return null;
+
+      return {
+        // first index is 'field_or_expr', which defines group-by
+        groupBy: groupByViewStageNode.kwargs[0][1] as string,
+        // second index is 'order_by', which defines order-by
+        orderBy: groupByViewStageNode.kwargs[1][1] as string,
+      };
+    },
+  });
+
+export const dynamicGroupViewQuery = selectorFamily<
+  State.Stage[],
+  string | null
+>({
+  key: "dynamicGroupViewQuery",
+  get:
+    (groupByFieldValueExplicit) =>
+    ({ get }) => {
+      const params = get(dynamicGroupParameters);
+      if (!params) return [];
+
+      const { groupBy, orderBy } = params;
+
+      // todo: fix sample_id issue
+      // todo: sanitize expressions
+      const groupBySanitized = getSanitizedGroupByExpression(groupBy);
+
+      let groupByValue;
+
+      if (groupByFieldValueExplicit !== null) {
+        groupByValue = String(groupByFieldValueExplicit);
+      } else {
+        groupByValue = get(groupByFieldValue);
+
+        if (groupByValue) {
+          groupByValue = String(groupByValue);
+        }
+      }
+      const viewStages: State.Stage[] = [
+        {
+          _cls: MATCH_VIEW_STAGE,
+          kwargs: [
+            [
+              "filter",
+              {
+                $expr: {
+                  $let: {
+                    vars: {
+                      expr: `$${groupBySanitized}`,
+                    },
+                    in: {
+                      $in: [
+                        {
+                          $toString: "$$expr",
+                        },
+                        [groupByValue],
+                      ],
+                    },
+                  },
+                },
+              },
+            ],
+          ],
+        },
+      ];
+
+      if (orderBy?.length) {
+        viewStages.push({
+          _cls: SORT_VIEW_STAGE,
+          kwargs: [
+            ["field_or_expr", orderBy],
+            ["reverse", false],
+          ],
+        });
+      }
+
+      const baseView = [...get(view)];
+      let modalView: State.Stage[] = [];
+      let pastGroup = false;
+      for (let index = 0; index < baseView.length; index++) {
+        const stage = baseView[index];
+        if (stage._cls === GROUP_BY_VIEW_STAGE) {
+          modalView = [...modalView, ...viewStages];
+          pastGroup = true;
+          continue;
+        }
+
+        if (!pastGroup) {
+          modalView.push(stage);
+          continue;
+        }
+
+        // Assume these stages should be filtered out because they apply to
+        // the slices and not the contents of a group
+        if (
+          ![LIMIT_VIEW_STAGE, SKIP_VIEW_STAGE, TAKE_VIEW_STAGE].includes(
+            stage._cls
+          )
+        ) {
+          modalView.push(stage);
+        }
+      }
+
+      return modalView;
+    },
+});
+
+export const groupByFieldValue = atom<string | null>({
+  key: "groupByFieldValue",
+  default: null,
+});
+
+export const imaVidLookerState = atomFamily<any, string>({
+  key: "imaVidLookerState",
+  default: null,
+  effects: (key) => [
+    ({ setSelf, getPromise, onSet }) => {
+      let unsubscribe;
+
+      onSet((_newValue) => {
+        // note: resetRecoilState is not triggering `onSet` in effect,
+        // see https://github.com/facebookexperimental/Recoil/issues/2183
+        // replace with `useResetRecoileState` when fixed
+
+        // if (!isReset) {
+        //   throw new Error("cannot set ima-vid state directly");
+        // }
+        unsubscribe && unsubscribe();
+
+        getPromise(modalLooker)
+          .then((looker: ImaVidLooker) => {
+            if (looker) {
+              unsubscribe = looker.subscribeToState(key, (stateValue) => {
+                setSelf(stateValue);
+              });
+            }
+          })
+          .catch((e) => {
+            console.error(e);
+          });
+      });
+
+      return () => {
+        unsubscribe();
+      };
+    },
+  ],
+});
+
+export const imaVidStoreKey = selectorFamily<
+  string,
+  { modal: boolean; groupByFieldValue: string }
+>({
+  key: "imaVidStoreKey",
+  get:
+    ({ modal, groupByFieldValue }) =>
+    ({ get }) => {
+      const { groupBy, orderBy } = get(dynamicGroupParameters);
+      const slice = get(currentSlice(modal)) ?? "UNSLICED";
+
+      return `$${groupBy}-${orderBy}-${groupByFieldValue}-${slice}`;
+    },
+});
+
+export const isDynamicGroup = selector<boolean>({
+  key: "isDynamicGroup",
+  get: ({ get }) => {
+    return Boolean(get(dynamicGroupParameters));
+  },
+});
+
+export const isNonNestedDynamicGroup = selector<boolean>({
+  key: "isNonNestedDynamicGroup",
+  get: ({ get }) => {
+    return get(isDynamicGroup) && get(parentMediaTypeSelector) !== "group";
+  },
+});
+
+export const isNestedDynamicGroup = selector<boolean>({
+  key: "isNestedDynamicGroup",
+  get: ({ get }) => {
+    return get(isDynamicGroup) && get(hasGroupSlices);
+  },
+});
+
+export const isOrderedDynamicGroup = selector<boolean>({
+  key: "isOrderedDynamicGroup",
+  get: ({ get }) => {
+    const params = get(dynamicGroupParameters);
+    if (!params) return false;
+
+    const { orderBy } = params;
+    return Boolean(orderBy?.length);
+  },
+});
+
+export const shouldRenderImaVidLooker = selector<boolean>({
+  key: "shouldRenderImaVidLooker",
+  get: ({ get }) => {
+    return get(isOrderedDynamicGroup) && get(dynamicGroupsViewMode) === "video";
+  },
+});

--- a/app/packages/state/src/recoil/groups.test.ts
+++ b/app/packages/state/src/recoil/groups.test.ts
@@ -28,3 +28,30 @@ describe("hasGroupSlices handles nested dynamic groups", () => {
     expect(testHasGroupSlices()).toBe(true);
   });
 });
+
+describe("groupView  does not contain GroupBy stage", () => {
+  it("filters the GroupBy stage", () => {
+    const testGroupView = <TestSelector<typeof groups.groupView>>(
+      (<unknown>groups.groupView)
+    );
+    setMockAtoms({
+      //  _NAME_setter syntax due to graphQLSyncFrangmentImplementation
+      _view__setter: [
+        {
+          _cls: "fiftyone.core.stages.GroupBy",
+          kwargs: [
+            ["field_or_expr", "scene_id"],
+            ["order_by", "timestamp"],
+            ["reverse", false],
+            ["flat", false],
+            ["match_expr", null],
+            ["sort_expr", null],
+            ["create_index", true],
+          ],
+        },
+      ],
+    });
+
+    expect(testGroupView()).toStrictEqual([]);
+  });
+});

--- a/app/packages/state/src/recoil/groups.ts
+++ b/app/packages/state/src/recoil/groups.ts
@@ -6,13 +6,6 @@ import {
   groupSliceFragment,
   groupSliceFragment$key,
 } from "@fiftyone/relay";
-import {
-  DYNAMIC_GROUP_FIELDS,
-  EMBEDDED_DOCUMENT_FIELD,
-  GROUP,
-  LIST_FIELD,
-  Stage,
-} from "@fiftyone/utilities";
 import { get as getPath } from "lodash";
 import { VariablesOf } from "react-relay";
 import {
@@ -33,14 +26,17 @@ import {
 } from "./atoms";
 import { getBrowserStorageEffectForKey } from "./customEffects";
 import { dataset } from "./dataset";
+import {
+  imaVidLookerState,
+  isDynamicGroup,
+  isNestedDynamicGroup,
+  shouldRenderImaVidLooker,
+} from "./dynamicGroups";
 import { ModalSample, modalLooker, modalSample } from "./modal";
-import { dynamicGroupsViewMode } from "./options";
 import { RelayEnvironmentKey } from "./relay";
-import { fieldPaths } from "./schema";
 import { datasetName, parentMediaTypeSelector } from "./selectors";
-import { State } from "./types";
 import { mapSampleResponse } from "./utils";
-import { GROUP_BY_VIEW_STAGE, dynamicGroupViewQuery, view } from "./view";
+import * as viewAtoms from "./view";
 
 export const groupMediaIsCarouselVisibleSetting = atom<boolean>({
   key: "groupMediaIsCarouselVisibleSetting",
@@ -371,7 +367,9 @@ export const groupSamples = graphQLSelectorFamily<
       return {
         count,
         dataset: get(datasetName),
-        view: get(view),
+        view: get(viewAtoms.view).filter(
+          (stage) => stage._cls !== viewAtoms.GROUP_BY_VIEW_STAGE
+        ),
         filter: {
           group: {
             slice: get(groupSlice),
@@ -406,138 +404,6 @@ export const pcdSamples = selector({
         paginationData: false,
       })
     ),
-});
-
-export const groupByFieldValue = atom<string | null>({
-  key: "groupByFieldValue",
-  default: null,
-});
-
-export const dynamicGroupIndex = atom<number>({
-  key: "dynamicGroupIndex",
-  default: null,
-});
-
-export const dynamicGroupCurrentElementIndex = atom<number>({
-  key: "dynamicGroupCurrentElementIndex",
-  default: 1,
-});
-
-export const dynamicGroupParameters =
-  selector<State.DynamicGroupParameters | null>({
-    key: "dynamicGroupParameters",
-    get: ({ get }) => {
-      const viewArr = get(view);
-      if (!viewArr) return null;
-
-      const groupByViewStageNode = viewArr.find(
-        (view) => view._cls === GROUP_BY_VIEW_STAGE
-      );
-      if (!groupByViewStageNode) return null;
-
-      const isFlat = groupByViewStageNode.kwargs[2][1]; // third index is 'flat', we want it to be false for dynamic groups
-      if (isFlat) return null;
-
-      return {
-        groupBy: groupByViewStageNode.kwargs[0][1] as string, // first index is 'field_or_expr', which defines group-by
-        orderBy: groupByViewStageNode.kwargs[1][1] as string, // second index is 'order_by', which defines order-by
-      };
-    },
-  });
-
-export const isDynamicGroup = selector<boolean>({
-  key: "isDynamicGroup",
-  get: ({ get }) => {
-    return Boolean(get(dynamicGroupParameters));
-  },
-});
-
-export const isNonNestedDynamicGroup = selector<boolean>({
-  key: "isNonNestedDynamicGroup",
-  get: ({ get }) => {
-    return get(isDynamicGroup) && get(parentMediaTypeSelector) !== "group";
-  },
-});
-
-export const isNestedDynamicGroup = selector<boolean>({
-  key: "isNestedDynamicGroup",
-  get: ({ get }) => {
-    return get(isDynamicGroup) && get(hasGroupSlices);
-  },
-});
-
-export const imaVidStoreKey = selectorFamily<
-  string,
-  { modal: boolean; groupByFieldValue: string }
->({
-  key: "imaVidStoreKey",
-  get:
-    ({ modal, groupByFieldValue }) =>
-    ({ get }) => {
-      const { groupBy, orderBy } = get(dynamicGroupParameters);
-      const slice = get(currentSlice(modal)) ?? "UNSLICED";
-
-      return `$${groupBy}-${orderBy}-${groupByFieldValue}-${slice}`;
-    },
-});
-
-export const shouldRenderImaVidLooker = selector<boolean>({
-  key: "shouldRenderImaVidLooker",
-  get: ({ get }) => {
-    return get(isOrderedDynamicGroup) && get(dynamicGroupsViewMode) === "video";
-  },
-});
-
-export const isOrderedDynamicGroup = selector<boolean>({
-  key: "isOrderedDynamicGroup",
-  get: ({ get }) => {
-    const params = get(dynamicGroupParameters);
-    if (!params) return false;
-
-    const { orderBy } = params;
-    return Boolean(orderBy?.length);
-  },
-});
-
-export const dynamicGroupPageSelector = selectorFamily<
-  (
-    cursor: number,
-    pageSize: number
-  ) => {
-    filter: Record<string, never>;
-    after: string;
-    count: number;
-    dataset: string;
-    view: Stage[];
-  },
-  string
->({
-  key: "paginateDynamicGroupVariables",
-  get:
-    (groupByValue) =>
-    ({ get }) => {
-      const params = {
-        dataset: get(datasetName),
-        view: get(
-          dynamicGroupViewQuery({ groupByFieldValueExplicit: groupByValue })
-        ),
-      };
-
-      const filter = get(hasGroupSlices)
-        ? {
-            group: {
-              slice: get(groupSlice),
-            },
-          }
-        : {};
-
-      return (cursor: number, pageSize: number) => ({
-        ...params,
-        filter,
-        after: cursor ? String(cursor) : null,
-        count: pageSize,
-      });
-    },
 });
 
 export const activeModalSample = selector({
@@ -578,73 +444,7 @@ export const activeModalSidebarSample = selector({
   },
 });
 
-export const imaVidLookerState = atomFamily<any, string>({
-  key: "imaVidLookerState",
-  default: null,
-  effects: (key) => [
-    ({ setSelf, getPromise, onSet }) => {
-      let unsubscribe;
-
-      onSet((_newValue) => {
-        // note: resetRecoilState is not triggering `onSet` in effect,
-        // see https://github.com/facebookexperimental/Recoil/issues/2183
-        // replace with `useResetRecoileState` when fixed
-
-        // if (!isReset) {
-        //   throw new Error("cannot set ima-vid state directly");
-        // }
-        unsubscribe && unsubscribe();
-
-        getPromise(modalLooker)
-          .then((looker: ImaVidLooker) => {
-            if (looker) {
-              unsubscribe = looker.subscribeToState(key, (stateValue) => {
-                setSelf(stateValue);
-              });
-            }
-          })
-          .catch((e) => {
-            console.error(e);
-          });
-      });
-
-      return () => {
-        unsubscribe();
-      };
-    },
-  ],
-});
-
 export const groupStatistics = atomFamily<"group" | "slice", boolean>({
   key: "groupStatistics",
   default: "slice",
-});
-
-export const dynamicGroupFields = selector<string[]>({
-  key: "dynamicGroupFields",
-  get: ({ get }) => {
-    const groups = get(
-      fieldPaths({
-        ftype: EMBEDDED_DOCUMENT_FIELD,
-        embeddedDocType: GROUP,
-        space: State.SPACE.SAMPLE,
-      })
-    );
-    const lists = get(
-      fieldPaths({ ftype: LIST_FIELD, space: State.SPACE.SAMPLE })
-    );
-    const primitives = get(
-      fieldPaths({ ftype: DYNAMIC_GROUP_FIELDS, space: State.SPACE.SAMPLE })
-    ).filter((path) => path !== "filepath" && path !== "id");
-
-    const filtered = primitives.filter(
-      (path) =>
-        lists.every((list) => !path.startsWith(list)) &&
-        groups.every(
-          (group) => path !== `${group}.id` && path !== `${group}.name`
-        )
-    );
-
-    return filtered;
-  },
 });

--- a/app/packages/state/src/recoil/groups.ts
+++ b/app/packages/state/src/recoil/groups.ts
@@ -35,6 +35,7 @@ import {
 import { ModalSample, modalLooker, modalSample } from "./modal";
 import { RelayEnvironmentKey } from "./relay";
 import { datasetName, parentMediaTypeSelector } from "./selectors";
+import { State } from "./types";
 import { mapSampleResponse } from "./utils";
 import * as viewAtoms from "./view";
 
@@ -367,9 +368,7 @@ export const groupSamples = graphQLSelectorFamily<
       return {
         count,
         dataset: get(datasetName),
-        view: get(viewAtoms.view).filter(
-          (stage) => stage._cls !== viewAtoms.GROUP_BY_VIEW_STAGE
-        ),
+        view: get(groupView),
         filter: {
           group: {
             slice: get(groupSlice),
@@ -447,4 +446,16 @@ export const activeModalSidebarSample = selector({
 export const groupStatistics = atomFamily<"group" | "slice", boolean>({
   key: "groupStatistics",
   default: "slice",
+});
+
+/**
+ * A group view, i.e. all slices of a group, can potentially be of a dynamic
+ * group. The GroupBy stage is filtered to accomodate this
+ */
+export const groupView = selector<State.Stage[]>({
+  key: "groupView",
+  get: ({ get }) =>
+    get(viewAtoms.view).filter(
+      (stage) => stage._cls !== viewAtoms.GROUP_BY_VIEW_STAGE
+    ),
 });

--- a/app/packages/state/src/recoil/index.ts
+++ b/app/packages/state/src/recoil/index.ts
@@ -6,6 +6,7 @@ export * from "./config";
 export * from "./customEffects";
 export * from "./dataset";
 export * from "./distributions";
+export * from "./dynamicGroups";
 export * from "./filters";
 export * from "./groupEntries";
 export * from "./groups";

--- a/app/packages/state/src/recoil/modal.ts
+++ b/app/packages/state/src/recoil/modal.ts
@@ -6,17 +6,16 @@ import { graphQLSelector } from "recoil-relay";
 import { VariablesOf } from "relay-runtime";
 import { Nullable } from "vitest";
 import { ResponseFrom } from "../utils";
+import { imaVidLookerState, shouldRenderImaVidLooker } from "./dynamicGroups";
 import {
   activeModalSidebarSample,
   groupId,
   groupSlice,
   hasGroupSlices,
-  imaVidLookerState,
   modalGroupSlice,
   pinned3DSample,
   pinned3DSampleSlice,
   pinned3d,
-  shouldRenderImaVidLooker,
 } from "./groups";
 import { RelayEnvironmentKey } from "./relay";
 import { datasetName } from "./selectors";

--- a/app/packages/state/src/recoil/pathData/groups.ts
+++ b/app/packages/state/src/recoil/pathData/groups.ts
@@ -7,9 +7,6 @@ export const dynamicGroupsElementCount = selectorFamily<number, string | null>({
   get:
     (groupByFieldValueExplicit: string | null = null) =>
     ({ get }) => {
-      if (groupByFieldValueExplicit === null) {
-        throw new Error("E");
-      }
       return (
         get(
           aggregationQuery({

--- a/app/packages/state/src/recoil/pathData/groups.ts
+++ b/app/packages/state/src/recoil/pathData/groups.ts
@@ -1,16 +1,24 @@
-import { selector } from "recoil";
+import { selectorFamily } from "recoil";
 import { aggregationQuery } from "../aggregations";
-import { dynamicGroupViewQuery } from "../view";
+import { dynamicGroupViewQuery } from "../dynamicGroups";
 
-export const dynamicGroupsElementCount = selector<number>({
+export const dynamicGroupsElementCount = selectorFamily<number, string | null>({
   key: "dynamicGroupsElementCount",
-  get: ({ get }) =>
-    get(
-      aggregationQuery({
-        customView: get(dynamicGroupViewQuery),
-        extended: false,
-        modal: false,
-        paths: [""],
-      })
-    ).at(0)?.count ?? 0,
+  get:
+    (groupByFieldValueExplicit: string | null = null) =>
+    ({ get }) => {
+      if (groupByFieldValueExplicit === null) {
+        throw new Error("E");
+      }
+      return (
+        get(
+          aggregationQuery({
+            customView: get(dynamicGroupViewQuery(groupByFieldValueExplicit)),
+            extended: false,
+            modal: false,
+            paths: [""],
+          })
+        ).at(0)?.count ?? 0
+      );
+    },
 });

--- a/app/packages/state/src/recoil/pathData/index.ts
+++ b/app/packages/state/src/recoil/pathData/index.ts
@@ -1,5 +1,6 @@
 export * from "./boolean";
 export * from "./counts";
+export * from "./groups";
 export * from "./labels";
 export * from "./lightningBoolean";
 export * from "./lightningNumeric";

--- a/fiftyone/server/filters.py
+++ b/fiftyone/server/filters.py
@@ -5,6 +5,7 @@ FiftyOne Server filter inputs
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 import strawberry as gql
 from strawberry.schema_directive import Location
 import typing as t

--- a/tests/unittests/server_group_tests.py
+++ b/tests/unittests/server_group_tests.py
@@ -1,0 +1,64 @@
+"""
+FiftyOne Server group tests.
+
+| Copyright 2017-2024, Voxel51, Inc.
+| `voxel51.com <https://voxel51.com/>`_
+|
+"""
+
+import unittest
+
+from bson import ObjectId
+
+import fiftyone as fo
+from fiftyone import ViewExpression as F
+from fiftyone.server.aggregations import GroupElementFilter
+import fiftyone.server.view as fosv
+
+from decorators import drop_datasets
+
+
+class ServerGroupTests(unittest.TestCase):
+    @drop_datasets
+    def test_manual_group_slice(self):
+        dataset: fo.Dataset = fo.Dataset()
+        group = fo.Group()
+        image = fo.Sample(
+            filepath="image.png",
+            group=group.element("image"),
+            label=fo.Classification(label="label"),
+        )
+        dataset.add_sample(image)
+        expr = F("label") == "label"
+        filtered = dataset.filter_labels("label", F("label") == "label")
+
+        view = fosv.handle_group_filter(
+            dataset,
+            filtered,
+            GroupElementFilter(slice="image", slices=["image"]),
+        )
+        self.assertEqual(
+            view._all_stages,
+            [
+                fo.SelectGroupSlices(_force_mixed=True),
+                fo.FilterLabels("label", expr),
+                fo.Match({"group.name": {"$in": ["image"]}}),
+            ],
+        )
+
+        view = fosv.handle_group_filter(
+            dataset,
+            filtered,
+            GroupElementFilter(
+                id=image.group.id, slice="image", slices=["image"]
+            ),
+        )
+        self.assertEqual(
+            view._all_stages,
+            [
+                fo.SelectGroupSlices(_force_mixed=True),
+                fo.Match({"group._id": {"$in": [ObjectId(image.group.id)]}}),
+                fo.FilterLabels("label", expr),
+                fo.Match({"group.name": {"$in": ["image"]}}),
+            ],
+        )


### PR DESCRIPTION
## What changes are proposed in this pull request?

Fixes a regression in 0.23.8 due to https://github.com/voxel51/fiftyone/pull/4097. The behavior of filtering was improved https://github.com/voxel51/fiftyone/pull/4097, but dynamic groups was overlooked 😞 

In light of this! A new `groupView` selector has been added that supplies the correct representation of a view for group requests, i.e. all slices of group in **group dataset**. The only case for modification presently is when the group dataset is _dynamically grouped_, and the `GroupBy` stage is filtered.


In reviewing the functionality, I took the opportunity to move **dynamic** group state in `@fiftyone/state` to a new `dynamicGroups` module, as it is distinct from **group dataset** state (yet they _can_ interact as features, e.g. the above)


### Test code

```python
import fiftyone as fo
import fiftyone.zoo as foz
from fiftyone import ViewField as F

dataset = foz.load_zoo_dataset("quickstart-groups")

step = 25
for slice in dataset.group_slices:
    dataset.group_slice = slice
    scene_id = 0
    order_by = 0
    for sample in dataset:
        sample.set_field("scene_id", scene_id // step)
        sample.set_field("timestamp", order_by % step)
        sample.save()
        scene_id += 1
        order_by += 1

dataset.save()
``` 

Will also review offline with @sashankaryal 

## How is this patch tested? If it is not, please explain why.

In progress

## Release Notes

* Fixed dynamic groups of group datasets in the App

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
