### PR TITLE
Replace outdated app_config attribute

### DIFF
--- a/docs/source/user_guide/config.rst
+++ b/docs/source/user_guide/config.rst
@@ -734,7 +734,7 @@ You can print your App config at any time via the Python library and the CLI:
         print(fo.app_config)
 
         # Print a specific App config field
-        print(fo.app_config.show_attributes)
+        print(fo.app_config.show_label)
 
     .. code-block:: text
 
@@ -784,7 +784,7 @@ You can print your App config at any time via the Python library and the CLI:
         fiftyone app config
 
         # Print a specific App config field
-        fiftyone app config show_attributes
+        fiftyone app config show_label
 
     .. code-block:: text
 
@@ -875,7 +875,7 @@ via the following pattern:
     # Create a custom App config
     app_config = fo.app_config.copy()
     app_config.show_confidence = False
-    app_config.show_attributes = False
+    app_config.show_label = False
 
     session = fo.launch_app(dataset, config=app_config)
 
@@ -889,7 +889,7 @@ apply the changes:
 
     # Customize the config of a live session
     session.config.show_confidence = True
-    session.config.show_attributes = True
+    session.config.show_label = True
     session.refresh()  # must refresh after edits
 
 Editing your JSON App config
@@ -905,7 +905,7 @@ For example, a valid App config JSON file is:
 
     {
         "show_confidence": false,
-        "show_attributes": false
+        "show_label": false
     }
 
 When `fiftyone` is imported, any options from your JSON App config are applied,
@@ -931,7 +931,7 @@ issuing the following commands prior to launching your Python interpreter:
 .. code-block:: shell
 
     export FIFTYONE_APP_SHOW_CONFIDENCE=false
-    export FIFTYONE_APP_SHOW_ATTRIBUTES=false
+    export FIFTYONE_APP_SHOW_LABEL=false
 
 Modifying your App config in code
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -949,7 +949,7 @@ current session.
     import fiftyone as fo
 
     fo.app_config.show_confidence = False
-    fo.app_config.show_attributes = False
+    fo.app_config.show_label = False
 
 .. _configuring-plugins:
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

Replace `show_attributes` -> `show_label` in "Configuring FiftyOne" doc

## How is this patch tested? If it is not, please explain why.
Minor doc update

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?


-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [x] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the user guide to reflect the renaming of the `show_attributes` field to `show_label` in the configuration settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->