### PR TITLE
Fix to load on Linux filepaths generated on Windows

### DIFF
--- a/fiftyone/utils/data/importers.py
+++ b/fiftyone/utils/data/importers.py
@@ -1904,7 +1904,7 @@ class FiftyOneDatasetImporter(BatchDatasetImporter):
 
         def _parse_sample(sd):
             if not os.path.isabs(sd["filepath"]):
-                sd["filepath"] = os.path.join(rel_dir, sd["filepath"])
+                sd["filepath"] = os.path.join(rel_dir, sd["filepath"].replace("\\", "/"))
 
             if tags is not None:
                 sd["tags"].extend(tags)


### PR DESCRIPTION
## What changes are proposed in this pull request?

When importing datasets, change the '\' to '/' in the file path so it will load properly on Linux. Currently, Windows generate those paths, that can't be opened on Linux.

## How is this patch tested? If it is not, please explain why.

I've tested it doing the following process on Windows and Linux:
1. Import the dataset;
2. See how the images are loaded on the app;
3. Change the importers.py so it changes the slashes;
4. Import the dataset again and see how the images are loaded.

On Linux, during the step 2, the images weren't loaded properly due to the path, but after the change they were.

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [x] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved file path handling in sample import function to ensure compatibility across different operating systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->