### PR TITLE
fix workspace visibility issue on hover

### DIFF
--- a/app/packages/spaces/src/components/SavedSpaces/SavedSpace.tsx
+++ b/app/packages/spaces/src/components/SavedSpaces/SavedSpace.tsx
@@ -24,7 +24,7 @@ export default function SavedSpace(props: SavedSpacePropsType) {
         p: 0,
         background: (theme) => theme.palette.background.body,
         borderBottom: (theme) => `1px solid ${theme.palette.divider}`,
-        "&:hover": { ".MuiStack-root": { visibility: "visible" } },
+        "&:hover": { ".workspace-actions-stack": { visibility: "visible" } },
       }}
       title={description}
     >
@@ -46,6 +46,7 @@ export default function SavedSpace(props: SavedSpacePropsType) {
             visibility: "hidden",
             cursor: !canEdit ? "not-allowed" : undefined,
           }}
+          className="workspace-actions-stack"
           title={disabledInfo}
         >
           <IconButton


### PR DESCRIPTION
## What changes are proposed in this pull request?

use a custom CSS class instead of mui to fix visibility of workspace actions on hover

## How is this patch tested? If it is not, please explain why.

Using the workspace dropdown

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Updated visibility control on hover by changing the CSS selector, enhancing the styling behavior in the Saved Spaces component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->