### PR TITLE
fix circular imports in operator

### DIFF
--- a/app/packages/operators/src/OperatorPrompt/index.tsx
+++ b/app/packages/operators/src/OperatorPrompt/index.tsx
@@ -2,7 +2,10 @@ import { createPortal } from "react-dom";
 import { useRecoilValue } from "recoil";
 import { showOperatorPromptSelector, useOperatorPrompt } from "../state";
 import { BaseStylesProvider } from "../styled-components";
-import { getPromptComponent, getPromptTarget } from "../utils";
+import { OperatorPromptType } from "../types";
+import OperatorModalPrompt from "./OperatorModalPrompt";
+import OperatorDrawerPrompt from "./OperatorDrawerPrompt";
+import { OPERATOR_PROMPT_AREAS } from "../constants";
 
 export default function OperatorPrompt() {
   const show = useRecoilValue(showOperatorPromptSelector);
@@ -25,4 +28,32 @@ function DynamicOperatorPrompt() {
   if (!prompt.resolvedIO.input && !prompt.resolvedIO.output) return null;
 
   return createPortal(<Component prompt={prompt} />, target);
+}
+
+const defaultTargetResolver = () => document.body;
+const targetResolverByName = {
+  DrawerView: (promptView: OperatorPromptType["promptView"]) => {
+    const promptArea =
+      promptView.placement === "left"
+        ? OPERATOR_PROMPT_AREAS.DRAWER_LEFT
+        : OPERATOR_PROMPT_AREAS.DRAWER_RIGHT;
+    return document.getElementById(promptArea);
+  },
+};
+export function getPromptTarget(operatorPrompt: OperatorPromptType) {
+  const { promptView } = operatorPrompt;
+  const targetResolver =
+    targetResolverByName[promptView?.name] || defaultTargetResolver;
+  return targetResolver(promptView);
+}
+
+const defaultPromptComponentResolver = () => OperatorModalPrompt;
+const promptComponentByName = {
+  DrawerView: () => OperatorDrawerPrompt,
+};
+export function getPromptComponent(operatorPrompt: OperatorPromptType) {
+  const { promptView } = operatorPrompt;
+  const targetResolver =
+    promptComponentByName[promptView?.name] || defaultPromptComponentResolver;
+  return targetResolver(promptView);
 }

--- a/app/packages/operators/src/components/OperatorPromptOutput.tsx
+++ b/app/packages/operators/src/components/OperatorPromptOutput.tsx
@@ -1,6 +1,6 @@
 import { Box } from "@mui/material";
 import OperatorIO from "../OperatorIO";
-import { ErrorView } from "../../../core/src/plugins/SchemaIO/components";
+import ErrorView from "../../../core/src/plugins/SchemaIO/components/ErrorView";
 import { stringifyError } from "../utils";
 
 export default function OperatorPromptOutput({ operatorPrompt, outputFields }) {

--- a/app/packages/operators/src/utils.ts
+++ b/app/packages/operators/src/utils.ts
@@ -1,9 +1,6 @@
 import { getFetchParameters } from "@fiftyone/utilities";
 import { KeyboardEventHandler } from "react";
-import { OPERATOR_PROMPT_AREAS, types } from ".";
-import OperatorDrawerPrompt from "./OperatorPrompt/OperatorDrawerPrompt";
-import OperatorModalPrompt from "./OperatorPrompt/OperatorModalPrompt";
-import { ValidationErrorsType, OperatorPromptType } from "./types";
+import { ValidationErrorsType, OperatorPromptType, PromptView } from "./types";
 
 export function stringifyError(error, fallback?) {
   if (typeof error === "string") return error;
@@ -60,7 +57,7 @@ export function getOperatorPromptConfigs(operatorPrompt: OperatorPromptType) {
   let onSubmit, onCancel;
 
   if (customPromptName == "PromptView") {
-    const prompt = types.PromptView.fromJSON(customPrompt);
+    const prompt = PromptView.fromJSON(customPrompt);
     if (prompt.submitButtonLabel) {
       submitButtonText = prompt.submitButtonLabel;
     }
@@ -110,32 +107,4 @@ function getPromptTitle(operatorPrompt) {
     ? operatorPrompt?.inputFields
     : operatorPrompt?.outputFields;
   return definition?.view?.label;
-}
-
-const defaultTargetResolver = () => document.body;
-const targetResolverByName = {
-  DrawerView: (promptView: OperatorPromptType["promptView"]) => {
-    const promptArea =
-      promptView.placement === "left"
-        ? OPERATOR_PROMPT_AREAS.DRAWER_LEFT
-        : OPERATOR_PROMPT_AREAS.DRAWER_RIGHT;
-    return document.getElementById(promptArea);
-  },
-};
-export function getPromptTarget(operatorPrompt: OperatorPromptType) {
-  const { promptView } = operatorPrompt;
-  const targetResolver =
-    targetResolverByName[promptView?.name] || defaultTargetResolver;
-  return targetResolver(promptView);
-}
-
-const defaultPromptComponentResolver = () => OperatorModalPrompt;
-const promptComponentByName = {
-  DrawerView: () => OperatorDrawerPrompt,
-};
-export function getPromptComponent(operatorPrompt: OperatorPromptType) {
-  const { promptView } = operatorPrompt;
-  const targetResolver =
-    promptComponentByName[promptView?.name] || defaultPromptComponentResolver;
-  return targetResolver(promptView);
 }


### PR DESCRIPTION
## What changes are proposed in this pull request?

Fix circular import in operator package

## How is this patch tested? If it is not, please explain why.

Using a production build

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the `OperatorPrompt` component with new modal and drawer prompt types for improved user interaction.

- **Refactor**
	- Simplified and improved code organization in utility functions for better maintainability and performance.

- **Bug Fixes**
	- Corrected the import path for `ErrorView` to ensure error handling components are properly integrated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->