### PR TITLE
fix: coco category ids can now be not sequential - avoiding memory leak

### DIFF
--- a/fiftyone/utils/coco.py
+++ b/fiftyone/utils/coco.py
@@ -129,7 +129,8 @@ def add_coco_labels(
             will be created if necessary
         labels_or_path: a list of COCO annotations or the path to a JSON file
             containing such data on disk
-        classes: the list of class label strings
+        classes: the list of class label strings or a dict mapping class IDs to
+            class labels
         label_type ("detections"): the type of labels to load. Supported values
             are ``("detections", "segmentations", "keypoints")``
         coco_id_field (None): this parameter determines how to map the
@@ -194,7 +195,10 @@ def add_coco_labels(
     view.compute_metadata()
     widths, heights = view.values(["metadata.width", "metadata.height"])
 
-    classes_map = {i: label for i, label in enumerate(classes)}
+    if isinstance(classes, dict):
+        classes_map = classes
+    else:
+        classes_map = {i: label for i, label in enumerate(classes)}
 
     labels = []
     for _coco_objects, width, height in zip(coco_objects, widths, heights):
@@ -1433,7 +1437,7 @@ def parse_coco_categories(categories):
     Returns:
         a tuple of
 
-        -   classes_map: a dict mapping class ids to labels
+        -   classes_map: a dict mapping class IDs to labels
         -   supercategory_map: a dict mapping class labels to category dicts
     """
     classes_map = {

--- a/fiftyone/utils/coco.py
+++ b/fiftyone/utils/coco.py
@@ -410,7 +410,7 @@ class COCODetectionDatasetImporter(
 
         self._label_types = _label_types
         self._info = None
-        self._classes = None
+        self._classes_map = None
         self._license_map = None
         self._supercategory_map = None
         self._image_paths_map = None
@@ -453,15 +453,16 @@ class COCODetectionDatasetImporter(
             frame_size = (width, height)
 
             if self.classes is not None and self.only_matching:
+                all_classes = list(self._classes_map.values())
                 coco_objects = _get_matching_objects(
-                    coco_objects, self.classes, self._classes
+                    coco_objects, self.classes, all_classes
                 )
 
             if "detections" in self._label_types:
                 detections = _coco_objects_to_detections(
                     coco_objects,
                     frame_size,
-                    self._classes,
+                    self._classes_map,
                     self._supercategory_map,
                     False,  # no segmentations
                     self.include_annotation_id,
@@ -474,7 +475,7 @@ class COCODetectionDatasetImporter(
                     segmentations = _coco_objects_to_polylines(
                         coco_objects,
                         frame_size,
-                        self._classes,
+                        self._classes_map,
                         self._supercategory_map,
                         self.tolerance,
                         self.include_annotation_id,
@@ -483,7 +484,7 @@ class COCODetectionDatasetImporter(
                     segmentations = _coco_objects_to_detections(
                         coco_objects,
                         frame_size,
-                        self._classes,
+                        self._classes_map,
                         self._supercategory_map,
                         True,  # load segmentations
                         self.include_annotation_id,
@@ -496,7 +497,7 @@ class COCODetectionDatasetImporter(
                 keypoints = _coco_objects_to_keypoints(
                     coco_objects,
                     frame_size,
-                    self._classes,
+                    self._classes_map,
                     self._supercategory_map,
                     self.include_annotation_id,
                 )
@@ -603,7 +604,7 @@ class COCODetectionDatasetImporter(
             license_map = None
 
         self._info = info
-        self._classes = classes_map
+        self._classes_map = classes_map
         self._license_map = license_map
         self._supercategory_map = supercategory_map
         self._image_paths_map = image_paths_map


### PR DESCRIPTION
Closes #4293.

## What changes are proposed in this pull request?

`parse_coco_categories` returns `classes_map` instead of `classes`. It is a dict mapping class IDs to class labels. In areas where the list of classes are needed, it it obtained through `list(classes_map.values())`.

The caveat I see here is that the public facing `add_coco_labels` function takes classes as an argument (the list of class labels). To avoid changing the public interface, I did not modify that and built `classes_map`using `classes_map = {i: label for i, label in enumerate(classes)}`. This should work but requires that in `labels_or_path` files, the category IDs are sequential (starting from zero). This was already the case before this change.
If we want to allow non-sequential category IDs here also, we need to change the public interface and require `classes_map`instead of `classes`. Or do you see another solution ? Should we change the public interface or leave it like that ?

## How is this patch tested? If it is not, please explain why.

Not thoroughly. I am opening a draft PR to run the tests, as explained in [Contributing](https://github.com/voxel51/fiftyone/blob/develop/CONTRIBUTING.md).

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced label handling in COCO dataset utilities by introducing a mapping of class IDs to labels for improved accuracy and flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->