### PR TITLE
fix mui slider thumb position at theme lever

### DIFF
--- a/app/packages/components/src/components/ThemeProvider/index.tsx
+++ b/app/packages/components/src/components/ThemeProvider/index.tsx
@@ -222,6 +222,16 @@ let theme = extendMuiTheme({
         },
       },
     },
+    MuiSlider: {
+      styleOverrides: {
+        root: {
+          ".MuiSlider-thumb": {
+            transform: "translate(-50%, -50%)",
+            top: "50%",
+          },
+        },
+      },
+    },
   },
   fontFamily: {
     body: "Palanquin, sans-serif",

--- a/app/packages/core/src/components/Common/RangeSlider.tsx
+++ b/app/packages/core/src/components/Common/RangeSlider.tsx
@@ -43,8 +43,6 @@ const SliderStyled = styled(SliderUnstyled)`
   }
 
   .thumb {
-    margin-top: -8px;
-    margin-left: -8px;
     height: 16px;
     width: 16px;
     border-radius: 8px;


### PR DESCRIPTION
## What changes are proposed in this pull request?

Fixes MUI Slider thumb position in SliderView of operators

## How is this patch tested? If it is not, please explain why.

Using the test OperatorIO panel

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced theming options for the slider component.

- **Style**
	- Adjusted slider styling to remove unnecessary margins for a cleaner appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->