### PR TITLE
3D compute metadata assets

### DIFF
--- a/fiftyone/core/metadata.py
+++ b/fiftyone/core/metadata.py
@@ -110,15 +110,19 @@ class SceneMetadata(Metadata):
         asset_counts = collections.defaultdict(int)
         mime_type = "application/octet-stream"
 
+        # Get asset paths and resolve all to absolute
         asset_paths = scene.get_asset_paths()
         scene_dir = os.path.dirname(scene_path)
         for i, asset_path in enumerate(asset_paths):
             if not fos.isabs(asset_path):
-                asset_paths[i] = fos.join(scene_dir, asset_path)
+                asset_paths[i] = fos.resolve(fos.join(scene_dir, asset_path))
             file_type = pathlib.Path(asset_path).suffix[1:]
             asset_counts[file_type] += 1
+
+        # Dedupe asset paths within this single scene
         asset_paths = list(set(asset_paths))
 
+        # compute metadata for all asset paths
         asset_metadatas = fos.run(
             _do_compute_metadata,
             [

--- a/fiftyone/core/metadata.py
+++ b/fiftyone/core/metadata.py
@@ -84,7 +84,8 @@ class SceneMetadata(Metadata):
     Args:
         size_bytes (None): the size of scene definition and all children
             assets on disk, in bytes
-        mime_type (None): the MIME type of the image
+        mime_type (None): the MIME type of the scene media. Always set to
+            application/octet-stream
         asset_counts (None): dict of child asset file type to count
     """
 
@@ -96,7 +97,8 @@ class SceneMetadata(Metadata):
 
         Args:
             scene_path: a scene path or URL
-            mime_type (None): Ignored
+            mime_type (None): Ignored. mime_type always set to
+                application/octet-stream
 
         Returns:
             a :class:`SceneMetadata`
@@ -122,7 +124,6 @@ class SceneMetadata(Metadata):
 
         # Dedupe asset paths within this single scene
         asset_paths = list(set(asset_paths))
-        print(asset_paths)
 
         # compute metadata for all asset paths
         asset_metadatas = fos.run(

--- a/fiftyone/core/metadata.py
+++ b/fiftyone/core/metadata.py
@@ -115,12 +115,14 @@ class SceneMetadata(Metadata):
         scene_dir = os.path.dirname(scene_path)
         for i, asset_path in enumerate(asset_paths):
             if not fos.isabs(asset_path):
-                asset_paths[i] = fos.resolve(fos.join(scene_dir, asset_path))
+                asset_path = fos.join(scene_dir, asset_path)
+            asset_paths[i] = fos.resolve(asset_path)
             file_type = pathlib.Path(asset_path).suffix[1:]
             asset_counts[file_type] += 1
 
         # Dedupe asset paths within this single scene
         asset_paths = list(set(asset_paths))
+        print(asset_paths)
 
         # compute metadata for all asset paths
         asset_metadatas = fos.run(

--- a/fiftyone/core/storage.py
+++ b/fiftyone/core/storage.py
@@ -281,6 +281,19 @@ def join(a, *p):
     return os.path.join(a, *p)
 
 
+def resolve(path):
+    """Resolves path to absolute, resolving symlinks and relative path
+        indicators such as `.` and `..`.
+
+    Args:
+        path: the filepath
+
+    Returns:
+        the resolved path
+    """
+    return os.path.realpath(path)
+
+
 def isabs(path):
     """Determines whether the given path is absolute.
 

--- a/fiftyone/core/storage.py
+++ b/fiftyone/core/storage.py
@@ -281,19 +281,17 @@ def join(a, *p):
     return os.path.join(a, *p)
 
 
-def join_resolve(a, *p):
-    """Joins the given path components into a single path. Also resolves path
-    to absolute, resolving symlinks and relative path indicators such as
-    ``.`` and ``..``
+def resolve(path):
+    """Resolves path to absolute, resolving symlinks and relative path
+        indicators such as `.` and `..`.
 
     Args:
-        a: the root
-        *p: additional path components
+        path: the filepath
 
     Returns:
-        the joined and resolved absolute path
+        the resolved path
     """
-    return os.path.realpath(os.path.join(a, *p))
+    return os.path.realpath(path)
 
 
 def isabs(path):

--- a/fiftyone/core/storage.py
+++ b/fiftyone/core/storage.py
@@ -281,17 +281,19 @@ def join(a, *p):
     return os.path.join(a, *p)
 
 
-def resolve(path):
-    """Resolves path to absolute, resolving symlinks and relative path
-        indicators such as `.` and `..`.
+def join_resolve(a, *p):
+    """Joins the given path components into a single path. Also resolves path
+    to absolute, resolving symlinks and relative path indicators such as
+    ``.`` and ``..``
 
     Args:
-        path: the filepath
+        a: the root
+        *p: additional path components
 
     Returns:
-        the resolved path
+        the joined and resolved absolute path
     """
-    return os.path.realpath(path)
+    return os.path.realpath(os.path.join(a, *p))
 
 
 def isabs(path):

--- a/fiftyone/utils/utils3d.py
+++ b/fiftyone/utils/utils3d.py
@@ -6,7 +6,7 @@
 |
 """
 import contextlib
-import itertools
+import json
 import logging
 import os
 import warnings
@@ -439,35 +439,63 @@ class OrthographicProjectionMetadata(DynamicEmbeddedDocument, fol._HasMedia):
     height = fof.IntField()
 
 
-def _get_pcd_filepath_from_fo3d_scene(scene: Scene, scene_path: str):
-    explicitly_flagged_pcd_path = None
-    fallover_pcd_path = None
+def _get_scene_paths(scene_paths):
+    """Return Tuple of scene paths to use and whether all are local
+    This function is a no-op here but could be different in a repo fork.
+    """
+    return scene_paths, True
 
-    def _visit_node_dfs(node):
-        nonlocal explicitly_flagged_pcd_path
-        nonlocal fallover_pcd_path
 
-        if hasattr(node, "pcd_path") and node.flag_for_projection:
-            explicitly_flagged_pcd_path = node.pcd_path
-        else:
-            if hasattr(node, "pcd_path"):
-                fallover_pcd_path = node.pcd_path
+def get_scene_asset_paths(
+    scene_paths, abs_paths=False, skip_failures=True, progress=None
+):
+    """Extracts all asset paths for the specified 3D scenes.
 
-            for child in node.children:
-                _visit_node_dfs(child)
+    Args:
+        scene_paths: an iterable of ``.fo3d`` paths
+        abs_paths (False): whether to return absolute paths
+        skip_failures (True): whether to gracefully continue without raising an
+            error if metadata cannot be computed for a file
+        progress (None): whether to render a progress bar (True/False), use the
+            default value ``fiftyone.config.show_progress_bars`` (None), or a
+            progress callback function to invoke instead
 
-    _visit_node_dfs(scene)
+    Returns:
+        a dict mapping scene paths to lists of asset paths
+    """
+    if not scene_paths:
+        return {}
 
-    pcd_path = (
-        explicitly_flagged_pcd_path
-        if explicitly_flagged_pcd_path
-        else fallover_pcd_path
+    asset_map = {}
+
+    _scene_paths, all_local = _get_scene_paths(scene_paths)
+
+    if all_local:
+        if progress is None:
+            progress = False
+    else:
+        logger.info("Getting asset paths...")
+
+    scene_strs = fos.read_files(
+        _scene_paths,
+        binary=False,
+        skip_failures=skip_failures,
+        progress=progress,
     )
 
-    if pcd_path is None or os.path.isabs(pcd_path):
-        return pcd_path
+    for scene_path, scene_str in zip(scene_paths, scene_strs):
+        scene = Scene._from_fo3d_dict(json.loads(scene_str))
+        asset_paths = scene.get_asset_paths()
 
-    return os.path.join(os.path.dirname(scene_path), pcd_path)
+        if abs_paths:
+            scene_dir = os.path.dirname(scene_path)
+            for i, asset_path in enumerate(asset_paths):
+                if not fos.isabs(asset_path):
+                    asset_paths[i] = fos.join(scene_dir, asset_path)
+
+        asset_map[scene_path] = asset_paths
+
+    return asset_map
 
 
 def compute_orthographic_projection_images(
@@ -569,28 +597,26 @@ def compute_orthographic_projection_images(
 
     fov.validate_collection(view, media_type={fom.POINT_CLOUD, fom.THREE_D})
 
+    if out_group_slice is not None:
+        out_samples = []
+
     filename_maker = fou.UniqueFilenameMaker(
         output_dir=output_dir, rel_dir=rel_dir
     )
 
-    if out_group_slice is not None:
-        out_samples = []
-
     for sample in view.iter_samples(autosave=True, progress=progress):
-        projection_pcd_filepath = sample.filepath
-
         if view.media_type == fom.THREE_D:
-            projection_pcd_filepath = _get_pcd_filepath_from_fo3d_scene(
-                Scene.from_fo3d(sample.filepath), sample.filepath
-            )
+            pcd_filepath = _get_pcd_filepath_from_scene(sample.filepath)
+        else:
+            pcd_filepath = sample.filepath
 
         image_path = filename_maker.get_output_path(
-            projection_pcd_filepath, output_ext=".png"
+            pcd_filepath, output_ext=".png"
         )
 
         try:
             img, metadata = compute_orthographic_projection_image(
-                projection_pcd_filepath,
+                pcd_filepath,
                 size,
                 shading_mode=shading_mode,
                 colormap=colormap,
@@ -736,6 +762,42 @@ def compute_orthographic_projection_image(
     image = np.rot90(image, k=1, axes=(0, 1))
 
     return image, metadata
+
+
+def _get_pcd_filepath_from_scene(scene_path: str):
+    scene = Scene.from_fo3d(scene_path)
+
+    explicitly_flagged_pcd_path = None
+    fallover_pcd_path = None
+
+    def _visit_node_dfs(node):
+        nonlocal explicitly_flagged_pcd_path
+        nonlocal fallover_pcd_path
+
+        if hasattr(node, "pcd_path") and node.flag_for_projection:
+            explicitly_flagged_pcd_path = node.pcd_path
+        else:
+            if hasattr(node, "pcd_path"):
+                fallover_pcd_path = node.pcd_path
+
+            for child in node.children:
+                _visit_node_dfs(child)
+
+    _visit_node_dfs(scene)
+
+    pcd_path = (
+        explicitly_flagged_pcd_path
+        if explicitly_flagged_pcd_path
+        else fallover_pcd_path
+    )
+
+    if pcd_path is None:
+        return None
+
+    if not fos.isabs(pcd_path):
+        return pcd_path
+
+    return fos.join(os.path.dirname(scene_path), pcd_path)
 
 
 def _parse_point_cloud(

--- a/fiftyone/utils/utils3d.py
+++ b/fiftyone/utils/utils3d.py
@@ -469,7 +469,7 @@ def _get_scene_asset_paths_single(task, abs_paths=False, skip_failures=True):
         scene_dir = os.path.dirname(original_scene_path)
         for i, asset_path in enumerate(asset_paths):
             if not fos.isabs(asset_path):
-                asset_paths[i] = fos.resolve(fos.join(scene_dir, asset_path))
+                asset_paths[i] = fos.join_resolve(scene_dir, asset_path)
 
     return asset_paths
 
@@ -811,13 +811,10 @@ def _get_pcd_filepath_from_scene(scene_path: str):
         else fallover_pcd_path
     )
 
-    if pcd_path is None:
-        return None
-
-    if not fos.isabs(pcd_path):
+    if pcd_path is None or fos.isabs(pcd_path):
         return pcd_path
 
-    return fos.resolve(fos.join(os.path.dirname(scene_path), pcd_path))
+    return fos.join_resolve(os.path.dirname(scene_path), pcd_path)
 
 
 def _parse_point_cloud(

--- a/fiftyone/utils/utils3d.py
+++ b/fiftyone/utils/utils3d.py
@@ -469,7 +469,7 @@ def _get_scene_asset_paths_single(task, abs_paths=False, skip_failures=True):
         scene_dir = os.path.dirname(original_scene_path)
         for i, asset_path in enumerate(asset_paths):
             if not fos.isabs(asset_path):
-                asset_paths[i] = fos.join(scene_dir, asset_path)
+                asset_paths[i] = fos.resolve(fos.join(scene_dir, asset_path))
 
     return asset_paths
 
@@ -817,7 +817,7 @@ def _get_pcd_filepath_from_scene(scene_path: str):
     if not fos.isabs(pcd_path):
         return pcd_path
 
-    return fos.join(os.path.dirname(scene_path), pcd_path)
+    return fos.resolve(fos.join(os.path.dirname(scene_path), pcd_path))
 
 
 def _parse_point_cloud(

--- a/fiftyone/utils/utils3d.py
+++ b/fiftyone/utils/utils3d.py
@@ -469,7 +469,7 @@ def _get_scene_asset_paths_single(task, abs_paths=False, skip_failures=True):
         scene_dir = os.path.dirname(original_scene_path)
         for i, asset_path in enumerate(asset_paths):
             if not fos.isabs(asset_path):
-                asset_paths[i] = fos.join_resolve(scene_dir, asset_path)
+                asset_paths[i] = fos.resolve(fos.join(scene_dir, asset_path))
 
     return asset_paths
 
@@ -811,10 +811,13 @@ def _get_pcd_filepath_from_scene(scene_path: str):
         else fallover_pcd_path
     )
 
-    if pcd_path is None or fos.isabs(pcd_path):
+    if pcd_path is None:
+        return None
+
+    if not fos.isabs(pcd_path):
         return pcd_path
 
-    return fos.join_resolve(os.path.dirname(scene_path), pcd_path)
+    return fos.resolve(fos.join(os.path.dirname(scene_path), pcd_path))
 
 
 def _parse_point_cloud(

--- a/fiftyone/utils/utils3d.py
+++ b/fiftyone/utils/utils3d.py
@@ -457,7 +457,9 @@ def _get_scene_asset_paths_single(task, abs_paths=False, skip_failures=True):
             raise
 
         if skip_failures != "ignore":
-            logger.warning(e)
+            logger.warning(
+                "Failed to process scene at '%s': %s", original_scene_path, e
+            )
         return []
 
     asset_paths = scene.get_asset_paths()

--- a/fiftyone/utils/utils3d.py
+++ b/fiftyone/utils/utils3d.py
@@ -469,7 +469,8 @@ def _get_scene_asset_paths_single(task, abs_paths=False, skip_failures=True):
         scene_dir = os.path.dirname(original_scene_path)
         for i, asset_path in enumerate(asset_paths):
             if not fos.isabs(asset_path):
-                asset_paths[i] = fos.resolve(fos.join(scene_dir, asset_path))
+                asset_path = fos.join(scene_dir, asset_path)
+            asset_paths[i] = fos.resolve(asset_path)
 
     return asset_paths
 
@@ -815,9 +816,9 @@ def _get_pcd_filepath_from_scene(scene_path: str):
         return None
 
     if not fos.isabs(pcd_path):
-        return pcd_path
+        pcd_path = fos.join(os.path.dirname(scene_path), pcd_path)
 
-    return fos.resolve(fos.join(os.path.dirname(scene_path), pcd_path))
+    return fos.resolve(pcd_path)
 
 
 def _parse_point_cloud(

--- a/tests/unittests/metadata_tests.py
+++ b/tests/unittests/metadata_tests.py
@@ -1,0 +1,54 @@
+"""
+FiftyOne metadata unit tests.
+
+| Copyright 2017-2024, Voxel51, Inc.
+| `voxel51.com <https://voxel51.com/>`_
+|
+"""
+import json
+import os
+import tempfile
+import unittest
+
+import fiftyone.core.metadata as fom
+import fiftyone.core.storage as fos
+import fiftyone.core.threed as fo3d
+
+
+class SceneMetadataTests(unittest.TestCase):
+    def test_build_for(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            scene_path = os.path.join(temp_dir, "scene.fo3d")
+            files = [("stl", 123), ("obj", 321), ("jpeg", 5151), ("mtl", 867)]
+            for file, num_bytes in files:
+                with open(
+                    os.path.join(temp_dir, f"{file}.{file}"), "wb"
+                ) as of:
+                    of.write(b"A" * num_bytes)
+
+            scene = fo3d.Scene()
+            scene.background = fo3d.SceneBackground(image="jpeg.jpeg")
+            scene.add(fo3d.ObjMesh("blah-obj", "obj.obj", "mtl.mtl"))
+            scene.add(fo3d.StlMesh("blah-stl", "stl.stl"))
+
+            # Add same file again - should not add to size_bytes though,
+            #   even though this is abs and the other was relative
+            scene.add(
+                fo3d.ObjMesh("blah-obj2", os.path.join(temp_dir, "obj.obj"))
+            )
+
+            scene.write(scene_path)
+
+            metadata = fom.SceneMetadata.build_for(scene_path)
+
+            self.assertEqual(metadata.mime_type, "application/octet-stream")
+
+            # Read the scene back again so we'll compare more accurately
+            expected_size = len(
+                json.dumps(fo3d.Scene.from_fo3d(scene_path).as_dict())
+            ) + sum(t[1] for t in files)
+            self.assertEqual(metadata.size_bytes, expected_size)
+            self.assertDictEqual(
+                metadata.asset_counts,
+                {"obj": 2, "jpeg": 1, "stl": 1, "mtl": 1},
+            )

--- a/tests/unittests/metadata_tests.py
+++ b/tests/unittests/metadata_tests.py
@@ -11,7 +11,6 @@ import tempfile
 import unittest
 
 import fiftyone.core.metadata as fom
-import fiftyone.core.storage as fos
 import fiftyone.core.threed as fo3d
 
 

--- a/tests/unittests/utils3d_tests.py
+++ b/tests/unittests/utils3d_tests.py
@@ -373,16 +373,16 @@ class GetSceneAssetPaths(unittest.TestCase):
             self.assertSetEqual(
                 set(asset_paths[scene_paths[0]]),
                 {
-                    f"{temp_dir}/back/ground.jpeg",
-                    f"{temp_dir}/relative.obj",
-                    f"{temp_dir}/absolute.pcd",
+                    os.path.realpath(f"{temp_dir}/back/ground.jpeg"),
+                    os.path.realpath(f"{temp_dir}/relative.obj"),
+                    os.path.realpath(f"{temp_dir}/absolute.pcd"),
                 },
             )
             self.assertSetEqual(
                 set(asset_paths[scene_paths[1]]),
                 {
-                    f"{temp_dir}/back/ground.jpeg",
-                    f"{temp_dir}/relative2.stl",
+                    os.path.realpath(f"{temp_dir}/back/ground.jpeg"),
+                    os.path.realpath(f"{temp_dir}/relative2.stl"),
                 },
             )
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

- Add `SceneMetadata` which adds children asset sizes to `size_bytes` for fo3d files.
   - `asset_counts` field is a dict mapping extension to number of assets with that extension. For example, `{"obj": 8, "pcd": 1, "jpeg": 6}`
   - de-dupes asset paths within the same fo3d file
   - does NOT de-dupe across samples so sum of `size_bytes` for all samples may not be the same as the media size on export. A common case would be a background image or cube (6 images).
- Added FOU3D utility `get_scene_asset_paths()`, pulled in from a Teams PR by @brimoor 

both use `fos.run()` to run as tasks so we don't bring too much into memory at once. Protects against many giant .fo3d files.

## How is this patch tested? If it is not, please explain why.

-added tests for both functions

```python
# sorry don't have a public zoo option right now
ds = fo.load_dataset("my-3d-dataset")
ds.compute_metadata()
# see metadata is accurate. previously would just be size of .fo3d file

import fiftyone.utils.utils3d as fou3d
fou3d.get_scene_asset_paths(ds.values('filepath'))

# looks something like
{
  "/path/to/sample.fo3d": ["/path/to/absolute.pcd", "relative.obj"],
  "/path/to/sample2.fo3d": ...
}
```

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced `SceneMetadata` for enhanced metadata management of 3D scenes.
  - Added a function to resolve file paths to their absolute forms, improving file handling across the platform.
  - Enhanced functionalities for extracting and managing asset paths from 3D scenes.

- **Tests**
  - Implemented new unit tests for metadata and 3D utilities to ensure robustness and reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->