### PR TITLE
Add workspace field to GraphQL Dataset

### DIFF
--- a/app/packages/relay/src/queries/__generated__/datasetQuery.graphql.ts
+++ b/app/packages/relay/src/queries/__generated__/datasetQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<fe897ea77c34073e55ca67d7ed0fe553>>
+ * @generated SignedSource<<1ef537a200400000330897fbf71058c6>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -16,6 +16,7 @@ export type datasetQuery$variables = {
   name: string;
   savedViewSlug?: string | null;
   view: Array;
+  workspaceSlug?: string | null;
 };
 export type datasetQuery$data = {
   readonly config: {
@@ -81,6 +82,11 @@ export type datasetQuery$data = {
     readonly name: string;
     readonly savedViewSlug: string | null;
     readonly viewName: string | null;
+    readonly workspace: {
+      readonly child: object;
+      readonly id: string;
+      readonly slug: string | null;
+    } | null;
     readonly " $fragmentSpreads": FragmentRefs<"datasetFragment">;
   } | null;
   readonly " $fragmentSpreads": FragmentRefs<"configFragment" | "savedViewsFragment" | "stageDefinitionsFragment" | "viewSchemaFragment">;
@@ -91,62 +97,69 @@ export type datasetQuery = {
 };
 
 const node: ConcreteRequest = (function(){
-var v0 = {
-  "defaultValue": null,
-  "kind": "LocalArgument",
-  "name": "extendedView"
-},
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "extendedView"
+  },
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "name"
+  },
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "savedViewSlug"
+  },
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "view"
+  },
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "workspaceSlug"
+  }
+],
 v1 = {
-  "defaultValue": null,
-  "kind": "LocalArgument",
-  "name": "name"
-},
-v2 = {
-  "defaultValue": null,
-  "kind": "LocalArgument",
-  "name": "savedViewSlug"
-},
-v3 = {
-  "defaultValue": null,
-  "kind": "LocalArgument",
-  "name": "view"
-},
-v4 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "colorBy",
   "storageKey": null
 },
-v5 = {
+v2 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "colorPool",
   "storageKey": null
 },
-v6 = {
+v3 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "colorscale",
   "storageKey": null
 },
-v7 = {
+v4 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "multicolorKeypoints",
   "storageKey": null
 },
-v8 = {
+v5 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "showSkeletons",
   "storageKey": null
 },
-v9 = [
+v6 = [
   {
     "kind": "Variable",
     "name": "name",
@@ -163,49 +176,49 @@ v9 = [
     "variableName": "extendedView"
   }
 ],
-v10 = {
+v7 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "name",
   "storageKey": null
 },
-v11 = {
+v8 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "defaultGroupSlice",
   "storageKey": null
 },
-v12 = {
+v9 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "viewName",
   "storageKey": null
 },
-v13 = {
+v10 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "savedViewSlug",
   "storageKey": null
 },
-v14 = {
+v11 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "id",
   "storageKey": null
 },
-v15 = {
+v12 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "color",
   "storageKey": null
 },
-v16 = [
+v13 = [
   {
     "alias": null,
     "args": null,
@@ -213,51 +226,51 @@ v16 = [
     "name": "intTarget",
     "storageKey": null
   },
-  (v15/*: any*/)
+  (v12/*: any*/)
 ],
-v17 = {
+v14 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "value",
   "storageKey": null
 },
-v18 = [
-  (v17/*: any*/),
-  (v15/*: any*/)
+v15 = [
+  (v14/*: any*/),
+  (v12/*: any*/)
 ],
-v19 = {
+v16 = {
   "alias": null,
   "args": null,
   "concreteType": "ColorscaleList",
   "kind": "LinkedField",
   "name": "list",
   "plural": true,
-  "selections": (v18/*: any*/),
+  "selections": (v15/*: any*/),
   "storageKey": null
 },
-v20 = {
+v17 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "rgb",
   "storageKey": null
 },
-v21 = {
+v18 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "path",
   "storageKey": null
 },
-v22 = {
+v19 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "fieldColor",
   "storageKey": null
 },
-v23 = {
+v20 = {
   "alias": null,
   "args": null,
   "concreteType": "ColorScheme",
@@ -265,10 +278,10 @@ v23 = {
   "name": "colorScheme",
   "plural": false,
   "selections": [
-    (v14/*: any*/),
+    (v11/*: any*/),
+    (v1/*: any*/),
+    (v2/*: any*/),
     (v4/*: any*/),
-    (v5/*: any*/),
-    (v7/*: any*/),
     {
       "alias": null,
       "args": null,
@@ -276,7 +289,7 @@ v23 = {
       "name": "opacity",
       "storageKey": null
     },
-    (v8/*: any*/),
+    (v5/*: any*/),
     {
       "alias": null,
       "args": null,
@@ -284,7 +297,7 @@ v23 = {
       "kind": "LinkedField",
       "name": "defaultMaskTargetsColors",
       "plural": true,
-      "selections": (v16/*: any*/),
+      "selections": (v13/*: any*/),
       "storageKey": null
     },
     {
@@ -295,9 +308,9 @@ v23 = {
       "name": "defaultColorscale",
       "plural": false,
       "selections": [
-        (v10/*: any*/),
-        (v19/*: any*/),
-        (v20/*: any*/)
+        (v7/*: any*/),
+        (v16/*: any*/),
+        (v17/*: any*/)
       ],
       "storageKey": null
     },
@@ -309,10 +322,10 @@ v23 = {
       "name": "colorscales",
       "plural": true,
       "selections": [
-        (v21/*: any*/),
-        (v10/*: any*/),
-        (v19/*: any*/),
-        (v20/*: any*/)
+        (v18/*: any*/),
+        (v7/*: any*/),
+        (v16/*: any*/),
+        (v17/*: any*/)
       ],
       "storageKey": null
     },
@@ -324,7 +337,7 @@ v23 = {
       "name": "labelTags",
       "plural": false,
       "selections": [
-        (v22/*: any*/),
+        (v19/*: any*/),
         {
           "alias": null,
           "args": null,
@@ -332,7 +345,7 @@ v23 = {
           "kind": "LinkedField",
           "name": "valueColors",
           "plural": true,
-          "selections": (v18/*: any*/),
+          "selections": (v15/*: any*/),
           "storageKey": null
         }
       ],
@@ -353,8 +366,8 @@ v23 = {
           "name": "colorByAttribute",
           "storageKey": null
         },
-        (v22/*: any*/),
-        (v21/*: any*/),
+        (v19/*: any*/),
+        (v18/*: any*/),
         {
           "alias": null,
           "args": null,
@@ -362,7 +375,7 @@ v23 = {
           "kind": "LinkedField",
           "name": "maskTargetsColors",
           "plural": true,
-          "selections": (v16/*: any*/),
+          "selections": (v13/*: any*/),
           "storageKey": null
         },
         {
@@ -373,8 +386,8 @@ v23 = {
           "name": "valueColors",
           "plural": true,
           "selections": [
-            (v15/*: any*/),
-            (v17/*: any*/)
+            (v12/*: any*/),
+            (v14/*: any*/)
           ],
           "storageKey": null
         }
@@ -384,105 +397,138 @@ v23 = {
   ],
   "storageKey": null
 },
-v24 = {
+v21 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "slug",
+  "storageKey": null
+},
+v22 = {
+  "alias": null,
+  "args": [
+    {
+      "kind": "Variable",
+      "name": "slug",
+      "variableName": "workspaceSlug"
+    }
+  ],
+  "concreteType": "Workspace",
+  "kind": "LinkedField",
+  "name": "workspace",
+  "plural": false,
+  "selections": [
+    (v11/*: any*/),
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "child",
+      "storageKey": null
+    },
+    (v21/*: any*/)
+  ],
+  "storageKey": null
+},
+v23 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "plugins",
   "storageKey": null
 },
-v25 = {
+v24 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "sidebarMode",
   "storageKey": null
 },
-v26 = {
+v25 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "mediaFallback",
   "storageKey": null
 },
-v27 = {
+v26 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "createdAt",
   "storageKey": null
 },
-v28 = {
+v27 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "datasetId",
   "storageKey": null
 },
-v29 = {
+v28 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "info",
   "storageKey": null
 },
-v30 = {
+v29 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "lastLoadedAt",
   "storageKey": null
 },
-v31 = {
+v30 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "mediaType",
   "storageKey": null
 },
-v32 = {
+v31 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "version",
   "storageKey": null
 },
-v33 = {
+v32 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "key",
   "storageKey": null
 },
-v34 = {
+v33 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "timestamp",
   "storageKey": null
 },
-v35 = {
+v34 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "viewStages",
   "storageKey": null
 },
-v36 = {
+v35 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "cls",
   "storageKey": null
 },
-v37 = {
+v36 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "type",
   "storageKey": null
 },
-v38 = [
+v37 = [
   {
     "alias": null,
     "args": null,
@@ -490,59 +536,59 @@ v38 = [
     "name": "target",
     "storageKey": null
   },
-  (v17/*: any*/)
+  (v14/*: any*/)
 ],
-v39 = {
+v38 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "labels",
   "storageKey": null
 },
-v40 = {
+v39 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "edges",
   "storageKey": null
 },
-v41 = {
+v40 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "ftype",
   "storageKey": null
 },
-v42 = {
+v41 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "subfield",
   "storageKey": null
 },
-v43 = {
+v42 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "embeddedDocType",
   "storageKey": null
 },
-v44 = {
+v43 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "dbField",
   "storageKey": null
 },
-v45 = {
+v44 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "description",
   "storageKey": null
 },
-v46 = [
-  (v10/*: any*/),
+v45 = [
+  (v7/*: any*/),
   {
     "alias": null,
     "args": null,
@@ -565,7 +611,7 @@ v46 = [
         "name": "field",
         "storageKey": null
       },
-      (v37/*: any*/)
+      (v36/*: any*/)
     ],
     "storageKey": null
   },
@@ -595,27 +641,22 @@ v46 = [
     "storageKey": null
   }
 ],
-v47 = {
+v46 = {
   "kind": "Variable",
   "name": "datasetName",
   "variableName": "name"
 },
-v48 = [
-  (v21/*: any*/),
+v47 = [
+  (v18/*: any*/),
+  (v40/*: any*/),
   (v41/*: any*/),
   (v42/*: any*/),
-  (v43/*: any*/),
-  (v29/*: any*/),
-  (v45/*: any*/)
+  (v28/*: any*/),
+  (v44/*: any*/)
 ];
 return {
   "fragment": {
-    "argumentDefinitions": [
-      (v0/*: any*/),
-      (v1/*: any*/),
-      (v2/*: any*/),
-      (v3/*: any*/)
-    ],
+    "argumentDefinitions": (v0/*: any*/),
     "kind": "Fragment",
     "metadata": null,
     "name": "datasetQuery",
@@ -628,26 +669,26 @@ return {
         "name": "config",
         "plural": false,
         "selections": [
+          (v1/*: any*/),
+          (v2/*: any*/),
+          (v3/*: any*/),
           (v4/*: any*/),
-          (v5/*: any*/),
-          (v6/*: any*/),
-          (v7/*: any*/),
-          (v8/*: any*/)
+          (v5/*: any*/)
         ],
         "storageKey": null
       },
       {
         "alias": null,
-        "args": (v9/*: any*/),
+        "args": (v6/*: any*/),
         "concreteType": "Dataset",
         "kind": "LinkedField",
         "name": "dataset",
         "plural": false,
         "selections": [
+          (v7/*: any*/),
+          (v8/*: any*/),
+          (v9/*: any*/),
           (v10/*: any*/),
-          (v11/*: any*/),
-          (v12/*: any*/),
-          (v13/*: any*/),
           {
             "alias": null,
             "args": null,
@@ -656,10 +697,11 @@ return {
             "name": "appConfig",
             "plural": false,
             "selections": [
-              (v23/*: any*/)
+              (v20/*: any*/)
             ],
             "storageKey": null
           },
+          (v22/*: any*/),
           {
             "args": null,
             "kind": "FragmentSpread",
@@ -694,12 +736,7 @@ return {
   },
   "kind": "Request",
   "operation": {
-    "argumentDefinitions": [
-      (v2/*: any*/),
-      (v1/*: any*/),
-      (v3/*: any*/),
-      (v0/*: any*/)
-    ],
+    "argumentDefinitions": (v0/*: any*/),
     "kind": "Operation",
     "name": "datasetQuery",
     "selections": [
@@ -711,11 +748,11 @@ return {
         "name": "config",
         "plural": false,
         "selections": [
+          (v1/*: any*/),
+          (v2/*: any*/),
+          (v3/*: any*/),
           (v4/*: any*/),
           (v5/*: any*/),
-          (v6/*: any*/),
-          (v7/*: any*/),
-          (v8/*: any*/),
           {
             "alias": null,
             "args": null,
@@ -744,7 +781,7 @@ return {
             "name": "notebookHeight",
             "storageKey": null
           },
-          (v24/*: any*/),
+          (v23/*: any*/),
           {
             "alias": null,
             "args": null,
@@ -773,7 +810,7 @@ return {
             "name": "showTooltip",
             "storageKey": null
           },
-          (v25/*: any*/),
+          (v24/*: any*/),
           {
             "alias": null,
             "args": null,
@@ -795,22 +832,22 @@ return {
             "name": "useFrameNumber",
             "storageKey": null
           },
-          (v26/*: any*/)
+          (v25/*: any*/)
         ],
         "storageKey": null
       },
       {
         "alias": null,
-        "args": (v9/*: any*/),
+        "args": (v6/*: any*/),
         "concreteType": "Dataset",
         "kind": "LinkedField",
         "name": "dataset",
         "plural": false,
         "selections": [
+          (v7/*: any*/),
+          (v8/*: any*/),
+          (v9/*: any*/),
           (v10/*: any*/),
-          (v11/*: any*/),
-          (v12/*: any*/),
-          (v13/*: any*/),
           {
             "alias": null,
             "args": null,
@@ -819,7 +856,7 @@ return {
             "name": "appConfig",
             "plural": false,
             "selections": [
-              (v23/*: any*/),
+              (v20/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -841,9 +878,9 @@ return {
                 "name": "modalMediaField",
                 "storageKey": null
               },
+              (v23/*: any*/),
               (v24/*: any*/),
               (v25/*: any*/),
-              (v26/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -866,15 +903,16 @@ return {
                     "name": "paths",
                     "storageKey": null
                   },
-                  (v10/*: any*/)
+                  (v7/*: any*/)
                 ],
                 "storageKey": null
               }
             ],
             "storageKey": null
           },
+          (v22/*: any*/),
+          (v26/*: any*/),
           (v27/*: any*/),
-          (v28/*: any*/),
           {
             "alias": null,
             "args": null,
@@ -882,10 +920,10 @@ return {
             "name": "groupField",
             "storageKey": null
           },
-          (v14/*: any*/),
+          (v11/*: any*/),
+          (v28/*: any*/),
           (v29/*: any*/),
           (v30/*: any*/),
-          (v31/*: any*/),
           {
             "alias": null,
             "args": null,
@@ -893,7 +931,7 @@ return {
             "name": "parentMediaType",
             "storageKey": null
           },
-          (v32/*: any*/),
+          (v31/*: any*/),
           {
             "alias": null,
             "args": null,
@@ -902,10 +940,10 @@ return {
             "name": "brainMethods",
             "plural": true,
             "selections": [
-              (v33/*: any*/),
               (v32/*: any*/),
+              (v31/*: any*/),
+              (v33/*: any*/),
               (v34/*: any*/),
-              (v35/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -914,7 +952,7 @@ return {
                 "name": "config",
                 "plural": false,
                 "selections": [
-                  (v36/*: any*/),
+                  (v35/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -943,7 +981,7 @@ return {
                     "name": "supportsPrompts",
                     "storageKey": null
                   },
-                  (v37/*: any*/),
+                  (v36/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -971,7 +1009,7 @@ return {
             "kind": "LinkedField",
             "name": "defaultMaskTargets",
             "plural": true,
-            "selections": (v38/*: any*/),
+            "selections": (v37/*: any*/),
             "storageKey": null
           },
           {
@@ -982,8 +1020,8 @@ return {
             "name": "defaultSkeleton",
             "plural": false,
             "selections": [
-              (v39/*: any*/),
-              (v40/*: any*/)
+              (v38/*: any*/),
+              (v39/*: any*/)
             ],
             "storageKey": null
           },
@@ -995,10 +1033,10 @@ return {
             "name": "evaluations",
             "plural": true,
             "selections": [
-              (v33/*: any*/),
               (v32/*: any*/),
+              (v31/*: any*/),
+              (v33/*: any*/),
               (v34/*: any*/),
-              (v35/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -1007,7 +1045,7 @@ return {
                 "name": "config",
                 "plural": false,
                 "selections": [
-                  (v36/*: any*/),
+                  (v35/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -1036,8 +1074,8 @@ return {
             "name": "groupMediaTypes",
             "plural": true,
             "selections": [
-              (v10/*: any*/),
-              (v31/*: any*/)
+              (v7/*: any*/),
+              (v30/*: any*/)
             ],
             "storageKey": null
           },
@@ -1049,7 +1087,7 @@ return {
             "name": "maskTargets",
             "plural": true,
             "selections": [
-              (v10/*: any*/),
+              (v7/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -1057,7 +1095,7 @@ return {
                 "kind": "LinkedField",
                 "name": "targets",
                 "plural": true,
-                "selections": (v38/*: any*/),
+                "selections": (v37/*: any*/),
                 "storageKey": null
               }
             ],
@@ -1071,9 +1109,9 @@ return {
             "name": "skeletons",
             "plural": true,
             "selections": [
-              (v10/*: any*/),
-              (v39/*: any*/),
-              (v40/*: any*/)
+              (v7/*: any*/),
+              (v38/*: any*/),
+              (v39/*: any*/)
             ],
             "storageKey": null
           },
@@ -1099,13 +1137,13 @@ return {
             "name": "frameFields",
             "plural": true,
             "selections": [
+              (v40/*: any*/),
               (v41/*: any*/),
               (v42/*: any*/),
+              (v18/*: any*/),
               (v43/*: any*/),
-              (v21/*: any*/),
               (v44/*: any*/),
-              (v45/*: any*/),
-              (v29/*: any*/)
+              (v28/*: any*/)
             ],
             "storageKey": null
           },
@@ -1116,7 +1154,7 @@ return {
             "kind": "LinkedField",
             "name": "frameIndexes",
             "plural": true,
-            "selections": (v46/*: any*/),
+            "selections": (v45/*: any*/),
             "storageKey": null
           },
           {
@@ -1126,7 +1164,7 @@ return {
             "kind": "LinkedField",
             "name": "sampleIndexes",
             "plural": true,
-            "selections": (v46/*: any*/),
+            "selections": (v45/*: any*/),
             "storageKey": null
           },
           {
@@ -1137,13 +1175,13 @@ return {
             "name": "sampleFields",
             "plural": true,
             "selections": [
-              (v21/*: any*/),
+              (v18/*: any*/),
+              (v40/*: any*/),
               (v41/*: any*/),
               (v42/*: any*/),
               (v43/*: any*/),
               (v44/*: any*/),
-              (v45/*: any*/),
-              (v29/*: any*/)
+              (v28/*: any*/)
             ],
             "storageKey": null
           },
@@ -1178,27 +1216,21 @@ return {
       {
         "alias": null,
         "args": [
-          (v47/*: any*/)
+          (v46/*: any*/)
         ],
         "concreteType": "SavedView",
         "kind": "LinkedField",
         "name": "savedViews",
         "plural": true,
         "selections": [
-          (v14/*: any*/),
-          (v28/*: any*/),
-          (v10/*: any*/),
-          {
-            "alias": null,
-            "args": null,
-            "kind": "ScalarField",
-            "name": "slug",
-            "storageKey": null
-          },
-          (v45/*: any*/),
-          (v15/*: any*/),
-          (v35/*: any*/),
+          (v11/*: any*/),
           (v27/*: any*/),
+          (v7/*: any*/),
+          (v21/*: any*/),
+          (v44/*: any*/),
+          (v12/*: any*/),
+          (v34/*: any*/),
+          (v26/*: any*/),
           {
             "alias": null,
             "args": null,
@@ -1206,11 +1238,11 @@ return {
             "name": "lastModifiedAt",
             "storageKey": null
           },
-          (v30/*: any*/)
+          (v29/*: any*/)
         ],
         "storageKey": null
       },
-      (v6/*: any*/),
+      (v3/*: any*/),
       {
         "alias": null,
         "args": null,
@@ -1219,7 +1251,7 @@ return {
         "name": "stageDefinitions",
         "plural": true,
         "selections": [
-          (v10/*: any*/),
+          (v7/*: any*/),
           {
             "alias": null,
             "args": null,
@@ -1228,8 +1260,8 @@ return {
             "name": "params",
             "plural": true,
             "selections": [
-              (v10/*: any*/),
-              (v37/*: any*/),
+              (v7/*: any*/),
+              (v36/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -1253,7 +1285,7 @@ return {
       {
         "alias": null,
         "args": [
-          (v47/*: any*/),
+          (v46/*: any*/),
           {
             "kind": "Variable",
             "name": "viewStages",
@@ -1272,7 +1304,7 @@ return {
             "kind": "LinkedField",
             "name": "fieldSchema",
             "plural": true,
-            "selections": (v48/*: any*/),
+            "selections": (v47/*: any*/),
             "storageKey": null
           },
           {
@@ -1282,7 +1314,7 @@ return {
             "kind": "LinkedField",
             "name": "frameFieldSchema",
             "plural": true,
-            "selections": (v48/*: any*/),
+            "selections": (v47/*: any*/),
             "storageKey": null
           }
         ],
@@ -1291,16 +1323,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "be1db75ace91abfdb6d75b65ac8c0314",
+    "cacheID": "c113090a10334512e43ab8b7b5bfbbd0",
     "id": null,
     "metadata": {},
     "name": "datasetQuery",
     "operationKind": "query",
-    "text": "query datasetQuery(\n  $savedViewSlug: String\n  $name: String!\n  $view: BSONArray!\n  $extendedView: BSONArray!\n) {\n  config {\n    colorBy\n    colorPool\n    colorscale\n    multicolorKeypoints\n    showSkeletons\n  }\n  dataset(name: $name, view: $extendedView, savedViewSlug: $savedViewSlug) {\n    name\n    defaultGroupSlice\n    viewName\n    savedViewSlug\n    appConfig {\n      colorScheme {\n        id\n        colorBy\n        colorPool\n        multicolorKeypoints\n        opacity\n        showSkeletons\n        defaultMaskTargetsColors {\n          intTarget\n          color\n        }\n        defaultColorscale {\n          name\n          list {\n            value\n            color\n          }\n          rgb\n        }\n        colorscales {\n          path\n          name\n          list {\n            value\n            color\n          }\n          rgb\n        }\n        labelTags {\n          fieldColor\n          valueColors {\n            value\n            color\n          }\n        }\n        fields {\n          colorByAttribute\n          fieldColor\n          path\n          maskTargetsColors {\n            intTarget\n            color\n          }\n          valueColors {\n            color\n            value\n          }\n        }\n      }\n    }\n    ...datasetFragment\n    id\n  }\n  ...savedViewsFragment\n  ...configFragment\n  ...stageDefinitionsFragment\n  ...viewSchemaFragment\n}\n\nfragment colorSchemeFragment on ColorScheme {\n  id\n  colorBy\n  colorPool\n  multicolorKeypoints\n  opacity\n  showSkeletons\n  labelTags {\n    fieldColor\n    valueColors {\n      color\n      value\n    }\n  }\n  defaultMaskTargetsColors {\n    intTarget\n    color\n  }\n  defaultColorscale {\n    name\n    list {\n      value\n      color\n    }\n    rgb\n  }\n  colorscales {\n    path\n    name\n    list {\n      value\n      color\n    }\n    rgb\n  }\n  fields {\n    colorByAttribute\n    fieldColor\n    path\n    valueColors {\n      color\n      value\n    }\n    maskTargetsColors {\n      intTarget\n      color\n    }\n  }\n}\n\nfragment configFragment on Query {\n  config {\n    colorBy\n    colorPool\n    colorscale\n    gridZoom\n    lightningThreshold\n    loopVideos\n    multicolorKeypoints\n    notebookHeight\n    plugins\n    showConfidence\n    showIndex\n    showLabel\n    showSkeletons\n    showTooltip\n    sidebarMode\n    theme\n    timezone\n    useFrameNumber\n    mediaFallback\n  }\n  colorscale\n}\n\nfragment datasetAppConfigFragment on DatasetAppConfig {\n  gridMediaField\n  mediaFields\n  modalMediaField\n  plugins\n  sidebarMode\n  colorScheme {\n    ...colorSchemeFragment\n    id\n  }\n  mediaFallback\n}\n\nfragment datasetFragment on Dataset {\n  createdAt\n  datasetId\n  groupField\n  id\n  info\n  lastLoadedAt\n  mediaType\n  name\n  parentMediaType\n  version\n  appConfig {\n    ...datasetAppConfigFragment\n  }\n  brainMethods {\n    key\n    version\n    timestamp\n    viewStages\n    config {\n      cls\n      embeddingsField\n      method\n      patchesField\n      supportsPrompts\n      type\n      maxK\n      supportsLeastSimilarity\n    }\n  }\n  defaultMaskTargets {\n    target\n    value\n  }\n  defaultSkeleton {\n    labels\n    edges\n  }\n  evaluations {\n    key\n    version\n    timestamp\n    viewStages\n    config {\n      cls\n      predField\n      gtField\n    }\n  }\n  groupMediaTypes {\n    name\n    mediaType\n  }\n  maskTargets {\n    name\n    targets {\n      target\n      value\n    }\n  }\n  skeletons {\n    name\n    labels\n    edges\n  }\n  ...estimatedCountsFragment\n  ...frameFieldsFragment\n  ...groupSliceFragment\n  ...indexesFragment\n  ...mediaFieldsFragment\n  ...mediaTypeFragment\n  ...sampleFieldsFragment\n  ...sidebarGroupsFragment\n  ...viewFragment\n}\n\nfragment estimatedCountsFragment on Dataset {\n  estimatedFrameCount\n  estimatedSampleCount\n}\n\nfragment frameFieldsFragment on Dataset {\n  frameFields {\n    ftype\n    subfield\n    embeddedDocType\n    path\n    dbField\n    description\n    info\n  }\n}\n\nfragment groupSliceFragment on Dataset {\n  defaultGroupSlice\n}\n\nfragment indexesFragment on Dataset {\n  frameIndexes {\n    name\n    unique\n    key {\n      field\n      type\n    }\n    wildcardProjection {\n      fields\n      inclusion\n    }\n  }\n  sampleIndexes {\n    name\n    unique\n    key {\n      field\n      type\n    }\n    wildcardProjection {\n      fields\n      inclusion\n    }\n  }\n}\n\nfragment mediaFieldsFragment on Dataset {\n  name\n  appConfig {\n    gridMediaField\n    mediaFields\n    modalMediaField\n    mediaFallback\n  }\n  sampleFields {\n    path\n  }\n}\n\nfragment mediaTypeFragment on Dataset {\n  mediaType\n}\n\nfragment sampleFieldsFragment on Dataset {\n  sampleFields {\n    ftype\n    subfield\n    embeddedDocType\n    path\n    dbField\n    description\n    info\n  }\n}\n\nfragment savedViewsFragment on Query {\n  savedViews(datasetName: $name) {\n    id\n    datasetId\n    name\n    slug\n    description\n    color\n    viewStages\n    createdAt\n    lastModifiedAt\n    lastLoadedAt\n  }\n}\n\nfragment sidebarGroupsFragment on Dataset {\n  name\n  appConfig {\n    sidebarGroups {\n      expanded\n      paths\n      name\n    }\n  }\n  ...frameFieldsFragment\n  ...sampleFieldsFragment\n}\n\nfragment stageDefinitionsFragment on Query {\n  stageDefinitions {\n    name\n    params {\n      name\n      type\n      default\n      placeholder\n    }\n  }\n}\n\nfragment viewFragment on Dataset {\n  stages(slug: $savedViewSlug, view: $view)\n  viewCls\n  viewName\n}\n\nfragment viewSchemaFragment on Query {\n  schemaForViewStages(datasetName: $name, viewStages: $view) {\n    fieldSchema {\n      path\n      ftype\n      subfield\n      embeddedDocType\n      info\n      description\n    }\n    frameFieldSchema {\n      path\n      ftype\n      subfield\n      embeddedDocType\n      info\n      description\n    }\n  }\n}\n"
+    "text": "query datasetQuery(\n  $extendedView: BSONArray!\n  $name: String!\n  $savedViewSlug: String\n  $view: BSONArray!\n  $workspaceSlug: String\n) {\n  config {\n    colorBy\n    colorPool\n    colorscale\n    multicolorKeypoints\n    showSkeletons\n  }\n  dataset(name: $name, view: $extendedView, savedViewSlug: $savedViewSlug) {\n    name\n    defaultGroupSlice\n    viewName\n    savedViewSlug\n    appConfig {\n      colorScheme {\n        id\n        colorBy\n        colorPool\n        multicolorKeypoints\n        opacity\n        showSkeletons\n        defaultMaskTargetsColors {\n          intTarget\n          color\n        }\n        defaultColorscale {\n          name\n          list {\n            value\n            color\n          }\n          rgb\n        }\n        colorscales {\n          path\n          name\n          list {\n            value\n            color\n          }\n          rgb\n        }\n        labelTags {\n          fieldColor\n          valueColors {\n            value\n            color\n          }\n        }\n        fields {\n          colorByAttribute\n          fieldColor\n          path\n          maskTargetsColors {\n            intTarget\n            color\n          }\n          valueColors {\n            color\n            value\n          }\n        }\n      }\n    }\n    workspace(slug: $workspaceSlug) {\n      id\n      child\n      slug\n    }\n    ...datasetFragment\n    id\n  }\n  ...savedViewsFragment\n  ...configFragment\n  ...stageDefinitionsFragment\n  ...viewSchemaFragment\n}\n\nfragment colorSchemeFragment on ColorScheme {\n  id\n  colorBy\n  colorPool\n  multicolorKeypoints\n  opacity\n  showSkeletons\n  labelTags {\n    fieldColor\n    valueColors {\n      color\n      value\n    }\n  }\n  defaultMaskTargetsColors {\n    intTarget\n    color\n  }\n  defaultColorscale {\n    name\n    list {\n      value\n      color\n    }\n    rgb\n  }\n  colorscales {\n    path\n    name\n    list {\n      value\n      color\n    }\n    rgb\n  }\n  fields {\n    colorByAttribute\n    fieldColor\n    path\n    valueColors {\n      color\n      value\n    }\n    maskTargetsColors {\n      intTarget\n      color\n    }\n  }\n}\n\nfragment configFragment on Query {\n  config {\n    colorBy\n    colorPool\n    colorscale\n    gridZoom\n    lightningThreshold\n    loopVideos\n    multicolorKeypoints\n    notebookHeight\n    plugins\n    showConfidence\n    showIndex\n    showLabel\n    showSkeletons\n    showTooltip\n    sidebarMode\n    theme\n    timezone\n    useFrameNumber\n    mediaFallback\n  }\n  colorscale\n}\n\nfragment datasetAppConfigFragment on DatasetAppConfig {\n  gridMediaField\n  mediaFields\n  modalMediaField\n  plugins\n  sidebarMode\n  colorScheme {\n    ...colorSchemeFragment\n    id\n  }\n  mediaFallback\n}\n\nfragment datasetFragment on Dataset {\n  createdAt\n  datasetId\n  groupField\n  id\n  info\n  lastLoadedAt\n  mediaType\n  name\n  parentMediaType\n  version\n  appConfig {\n    ...datasetAppConfigFragment\n  }\n  brainMethods {\n    key\n    version\n    timestamp\n    viewStages\n    config {\n      cls\n      embeddingsField\n      method\n      patchesField\n      supportsPrompts\n      type\n      maxK\n      supportsLeastSimilarity\n    }\n  }\n  defaultMaskTargets {\n    target\n    value\n  }\n  defaultSkeleton {\n    labels\n    edges\n  }\n  evaluations {\n    key\n    version\n    timestamp\n    viewStages\n    config {\n      cls\n      predField\n      gtField\n    }\n  }\n  groupMediaTypes {\n    name\n    mediaType\n  }\n  maskTargets {\n    name\n    targets {\n      target\n      value\n    }\n  }\n  skeletons {\n    name\n    labels\n    edges\n  }\n  ...estimatedCountsFragment\n  ...frameFieldsFragment\n  ...groupSliceFragment\n  ...indexesFragment\n  ...mediaFieldsFragment\n  ...mediaTypeFragment\n  ...sampleFieldsFragment\n  ...sidebarGroupsFragment\n  ...viewFragment\n}\n\nfragment estimatedCountsFragment on Dataset {\n  estimatedFrameCount\n  estimatedSampleCount\n}\n\nfragment frameFieldsFragment on Dataset {\n  frameFields {\n    ftype\n    subfield\n    embeddedDocType\n    path\n    dbField\n    description\n    info\n  }\n}\n\nfragment groupSliceFragment on Dataset {\n  defaultGroupSlice\n}\n\nfragment indexesFragment on Dataset {\n  frameIndexes {\n    name\n    unique\n    key {\n      field\n      type\n    }\n    wildcardProjection {\n      fields\n      inclusion\n    }\n  }\n  sampleIndexes {\n    name\n    unique\n    key {\n      field\n      type\n    }\n    wildcardProjection {\n      fields\n      inclusion\n    }\n  }\n}\n\nfragment mediaFieldsFragment on Dataset {\n  name\n  appConfig {\n    gridMediaField\n    mediaFields\n    modalMediaField\n    mediaFallback\n  }\n  sampleFields {\n    path\n  }\n}\n\nfragment mediaTypeFragment on Dataset {\n  mediaType\n}\n\nfragment sampleFieldsFragment on Dataset {\n  sampleFields {\n    ftype\n    subfield\n    embeddedDocType\n    path\n    dbField\n    description\n    info\n  }\n}\n\nfragment savedViewsFragment on Query {\n  savedViews(datasetName: $name) {\n    id\n    datasetId\n    name\n    slug\n    description\n    color\n    viewStages\n    createdAt\n    lastModifiedAt\n    lastLoadedAt\n  }\n}\n\nfragment sidebarGroupsFragment on Dataset {\n  name\n  appConfig {\n    sidebarGroups {\n      expanded\n      paths\n      name\n    }\n  }\n  ...frameFieldsFragment\n  ...sampleFieldsFragment\n}\n\nfragment stageDefinitionsFragment on Query {\n  stageDefinitions {\n    name\n    params {\n      name\n      type\n      default\n      placeholder\n    }\n  }\n}\n\nfragment viewFragment on Dataset {\n  stages(slug: $savedViewSlug, view: $view)\n  viewCls\n  viewName\n}\n\nfragment viewSchemaFragment on Query {\n  schemaForViewStages(datasetName: $name, viewStages: $view) {\n    fieldSchema {\n      path\n      ftype\n      subfield\n      embeddedDocType\n      info\n      description\n    }\n    frameFieldSchema {\n      path\n      ftype\n      subfield\n      embeddedDocType\n      info\n      description\n    }\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "fda32f168ff5147a56f3dee52de90af4";
+(node as any).hash = "a5edcbc186105a918451852ba2eecdbe";
 
 export default node;

--- a/app/packages/relay/src/queries/dataset.ts
+++ b/app/packages/relay/src/queries/dataset.ts
@@ -2,10 +2,11 @@ import { graphql } from "relay-runtime";
 
 export default graphql`
   query datasetQuery(
-    $savedViewSlug: String
-    $name: String!
-    $view: BSONArray!
     $extendedView: BSONArray!
+    $name: String!
+    $savedViewSlug: String
+    $view: BSONArray!
+    $workspaceSlug: String
   ) {
     config {
       colorBy
@@ -71,6 +72,13 @@ export default graphql`
           }
         }
       }
+
+      workspace(slug: $workspaceSlug) {
+        id
+        child
+        slug
+      }
+
       ...datasetFragment
     }
     ...savedViewsFragment

--- a/app/schema.graphql
+++ b/app/schema.graphql
@@ -240,6 +240,7 @@ type Dataset {
   frameIndexes: [Index!]
   sampleIndexes: [Index!]
   stages(slug: String = null, view: BSONArray = null): BSONArray
+  workspace(slug: String): Workspace
 }
 
 type DatasetAppConfig {
@@ -739,8 +740,8 @@ input SidebarGroupInput {
 
 enum SidebarMode {
   all
-  disabled
   best
+  disabled
   fast
 }
 
@@ -831,6 +832,19 @@ type VideoSample implements Sample {
 type WildcardProjection {
   fields: [String!]!
   inclusion: Boolean!
+}
+
+type Workspace {
+  id: ID!
+  color: String
+  child: BSON!
+  datasetId: ID!
+  createdAt: datetime
+  description: String
+  name: String
+  lastModifiedAt: datetime
+  lastLoadedAt: datetime
+  slug: String
 }
 
 scalar date

--- a/fiftyone/server/query.py
+++ b/fiftyone/server/query.py
@@ -47,6 +47,7 @@ from fiftyone.server.samples import (
 from fiftyone.server.scalars import BSON, BSONArray, JSON
 from fiftyone.server.stage_definitions import stage_definitions
 from fiftyone.server.utils import from_dict
+from fiftyone.server.workspace import Workspace
 
 
 ID = gql.scalar(
@@ -290,6 +291,20 @@ class Dataset:
             return await info.context.db[
                 self.frame_collection_name
             ].estimated_document_count()
+
+    @gql.field
+    async def workspace(
+        self, slug: t.Optional[str], info: Info
+    ) -> t.Optional[Workspace]:
+        if slug:
+            doc = await info.context.db["workspaces"].find_one({"slug": slug})
+
+            if doc:
+                doc["id"] = doc.pop("_id")
+                doc["dataset_id"] = doc.pop("_dataset_id")
+                return from_dict(Workspace, doc)
+
+        return None
 
     @staticmethod
     def modifier(doc: dict) -> dict:

--- a/fiftyone/server/workspace.py
+++ b/fiftyone/server/workspace.py
@@ -1,0 +1,29 @@
+"""
+FiftyOne Server workspace.
+
+| Copyright 2017-2024, Voxel51, Inc.
+| `voxel51.com <https://voxel51.com/>`_
+|
+"""
+
+from datetime import datetime
+import typing as t
+
+import strawberry as gql
+
+from fiftyone.server.scalars import BSON
+
+
+@gql.type
+class Workspace:
+    id: gql.ID
+
+    color: t.Optional[str]
+    child: BSON
+    dataset_id: gql.ID
+    created_at: t.Optional[datetime]
+    description: t.Optional[str]
+    name: t.Optional[str]
+    last_modified_at: t.Optional[datetime]
+    last_loaded_at: t.Optional[datetime]
+    slug: t.Optional[str]

--- a/tests/unittests/lightning_tests.py
+++ b/tests/unittests/lightning_tests.py
@@ -17,7 +17,6 @@ from strawberry.schema.config import StrawberryConfig
 import fiftyone as fo
 
 from fiftyone.server.constants import SCALAR_OVERRIDES
-from fiftyone.server.context import get_context
 from fiftyone.server.lightning import (
     lightning_resolver,
     LightningInput,
@@ -25,6 +24,7 @@ from fiftyone.server.lightning import (
 )
 
 from decorators import drop_async_dataset
+from utils.graphql import execute
 
 
 @gql.type
@@ -711,9 +711,10 @@ def _add_samples(dataset: fo.Dataset, lower: t.Dict, upper: t.Dict):
 async def _execute(
     query: str, dataset: fo.Dataset, field: fo.Field, keys: t.Set[str]
 ):
-    return await schema.execute(
+    return await execute(
+        schema,
         query,
-        variable_values={
+        {
             "input": asdict(
                 LightningInput(
                     dataset=dataset.name,
@@ -721,7 +722,6 @@ async def _execute(
                 )
             )
         },
-        context_value=get_context(use_global_db_client=False),
     )
 
 

--- a/tests/unittests/server_aggregations_tests.py
+++ b/tests/unittests/server_aggregations_tests.py
@@ -6,7 +6,6 @@ FiftyOne Server aggregation count tests.
 |
 """
 
-import typing as t
 import unittest
 
 import strawberry as gql
@@ -15,11 +14,11 @@ from strawberry.schema.config import StrawberryConfig
 import fiftyone as fo
 
 from fiftyone.server.constants import SCALAR_OVERRIDES
-from fiftyone.server.context import get_context
 from fiftyone.server.aggregate import AggregateQuery
 from fiftyone.server.aggregations import aggregate_resolver
 
 from decorators import drop_async_dataset
+from utils.graphql import execute
 
 
 @gql.type
@@ -55,7 +54,8 @@ class TestGroupModeSidebarCounts(unittest.IsolatedAsyncioTestCase):
             }
         """
 
-        result = await _execute(
+        result = await execute(
+            schema,
             query,
             {
                 "form": {
@@ -127,7 +127,8 @@ class TestGroupModeHistogramCounts(unittest.IsolatedAsyncioTestCase):
             }
         """
 
-        result = await _execute(
+        result = await execute(
+            schema,
             query,
             {
                 "dataset": dataset.name,
@@ -172,12 +173,4 @@ def _add_samples(dataset: fo.Dataset):
                 label=fo.Classification(label="other"),
             ),
         ]
-    )
-
-
-async def _execute(query: str, variables: t.Dict):
-    return await schema.execute(
-        query,
-        variable_values=variables,
-        context_value=get_context(use_global_db_client=False),
     )

--- a/tests/unittests/server_workspace_tests.py
+++ b/tests/unittests/server_workspace_tests.py
@@ -6,7 +6,6 @@ FiftyOne Server workspace tests.
 |
 """
 
-import typing as t
 import unittest
 
 import strawberry as gql

--- a/tests/unittests/server_workspace_tests.py
+++ b/tests/unittests/server_workspace_tests.py
@@ -1,0 +1,75 @@
+"""
+FiftyOne Server workspace tests.
+
+| Copyright 2017-2024, Voxel51, Inc.
+| `voxel51.com <https://voxel51.com/>`_
+|
+"""
+
+import typing as t
+import unittest
+
+import strawberry as gql
+from strawberry.schema.config import StrawberryConfig
+
+import fiftyone as fo
+
+from fiftyone.server.constants import SCALAR_OVERRIDES
+from fiftyone.server.context import get_context
+from fiftyone.server.query import Dataset
+from fiftyone.server.aggregations import aggregate_resolver
+
+from decorators import drop_async_dataset
+from utils.graphql import execute
+
+
+@gql.type
+class DatasetQuery(Dataset):
+    dataset: Dataset = gql.field(resolver=Dataset.resolver)
+
+
+schema = gql.Schema(
+    query=DatasetQuery,
+    scalar_overrides=SCALAR_OVERRIDES,
+    config=StrawberryConfig(auto_camel_case=False),
+)
+
+
+class TestGroupModeSidebarCounts(unittest.IsolatedAsyncioTestCase):
+    @drop_async_dataset
+    async def test_workspace_field(self, dataset: fo.Dataset):
+        histograms_panel = fo.Panel(type="Histograms")
+        name = "histograms"
+        workspace = fo.Space(children=[histograms_panel])
+        dataset.save_workspace(name, workspace)
+
+        query = """
+            query Query($name: String!, $slug: String!) {
+                dataset(name: $name) {
+                    workspace(slug: $slug) {
+                        child
+                        name
+                        slug
+                    }
+                }
+            }
+        """
+
+        result = await execute(
+            schema,
+            query,
+            {"name": dataset.name, "slug": name},
+        )
+
+        self.assertEqual(
+            result.data,
+            {
+                "dataset": {
+                    "workspace": {
+                        "child": workspace.to_dict(),
+                        "name": "histograms",
+                        "slug": name,
+                    }
+                }
+            },
+        )

--- a/tests/unittests/server_workspace_tests.py
+++ b/tests/unittests/server_workspace_tests.py
@@ -15,9 +15,7 @@ from strawberry.schema.config import StrawberryConfig
 import fiftyone as fo
 
 from fiftyone.server.constants import SCALAR_OVERRIDES
-from fiftyone.server.context import get_context
 from fiftyone.server.query import Dataset
-from fiftyone.server.aggregations import aggregate_resolver
 
 from decorators import drop_async_dataset
 from utils.graphql import execute

--- a/tests/unittests/utils/graphql.py
+++ b/tests/unittests/utils/graphql.py
@@ -1,0 +1,23 @@
+import typing as t
+
+import strawberry as gql
+
+from fiftyone.server.context import get_context
+
+
+async def execute(schema: gql.Schema, query: str, variables: t.Dict):
+    """Execute a test GraphQL query.
+
+    Args:
+        schema: a :class:`strawberry.Schema`
+        query: a GraphQL query string
+        variables: a variables dictionary
+
+    Returns:
+        an :class:`strawberry.types.execution.ExecutionResult`
+    """
+    return await schema.execute(
+        query,
+        variable_values=variables,
+        context_value=get_context(use_global_db_client=False),
+    )


### PR DESCRIPTION
## What changes are proposed in this pull request?

Adds `workspace` field to the `Dataset` GraphQL object on the server
## How is this patch tested? If it is not, please explain why.

GraphQL server test

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
    - Enhanced dataset queries with additional workspace-related fields and variables.
    - Introduced a new `Workspace` type in the GraphQL schema with comprehensive attributes.
    - Added functionality to retrieve workspace details based on a slug.

- **Bug Fixes**
    - Streamlined query execution in server tests by using updated utility functions.

- **Documentation**
    - Enum order updated in the GraphQL schema for better clarity.

- **Tests**
    - Added new tests for workspace functionality in FiftyOne Server.
    - Improved existing tests by refining the execution process and removing redundant code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->