### PR TITLE
Allow sidebar changes during lightning loading state

### DIFF
--- a/app/__mocks__/recoil.ts
+++ b/app/__mocks__/recoil.ts
@@ -23,9 +23,8 @@ export const getValue = (atom) => {
   if (atom.params !== undefined) {
     return mockValues[atom.key](atom.params);
   }
-  const mockValue = mockValues[atom.key];
 
-  console.log(atom.key, mockValue);
+  const mockValue = mockValues[atom.key];
   if (mockValue instanceof Function) {
     return mockValue();
   }
@@ -44,9 +43,12 @@ const resetValue = (atom) => {
 const setValue = (atom, value) => {
   if (atom.params) {
     if (!mockValuesStore[atom.key]) mockValuesStore[atom.key] = {};
-    mockValuesStore[atom.key][JSON.stringify(atom.params)] = value;
+    const current = mockValuesStore[atom.key][JSON.stringify(atom.params)];
+    mockValuesStore[atom.key][JSON.stringify(atom.params)] =
+      value instanceof Function ? value(current) : value;
   } else {
-    mockValues[atom.key] = value;
+    const current = mockValues[atom.key];
+    mockValues[atom.key] = value instanceof Function ? value(current) : value;
   }
 };
 

--- a/app/__mocks__/recoil.ts
+++ b/app/__mocks__/recoil.ts
@@ -23,7 +23,14 @@ export const getValue = (atom) => {
   if (atom.params !== undefined) {
     return mockValues[atom.key](atom.params);
   }
-  return mockValues[atom.key];
+  const mockValue = mockValues[atom.key];
+
+  console.log(atom.key, mockValue);
+  if (mockValue instanceof Function) {
+    return mockValue();
+  }
+
+  return mockValue;
 };
 
 const resetValue = (atom) => {
@@ -103,7 +110,10 @@ export function selectorFamily<
     resolver.key = options.key;
     resolver.params = params;
     resolver.set = (value) =>
-      options.set({ set: setValue, get: getValue, reset: resetValue }, value);
+      options.set(params)(
+        { set: setValue, get: getValue, reset: resetValue },
+        value
+      );
     return resolver;
   };
 }

--- a/app/__mocks__/recoil.ts
+++ b/app/__mocks__/recoil.ts
@@ -119,6 +119,7 @@ export type TestSelectorFamily<
   P = any
 > = {
   (): ReturnType<T>["__tag"][0];
+  set: (params: ReturnType<T>["__tag"][0]) => void;
   key: string;
   params: P;
 };

--- a/app/packages/state/src/recoil/filters.test.ts
+++ b/app/packages/state/src/recoil/filters.test.ts
@@ -51,3 +51,18 @@ describe("hasFilter resolves correctly", () => {
     expect(test2()).toBe(true);
   });
 });
+
+describe("setting a filter does not use async state", () => {
+  const test = <TestSelectorFamily<typeof filters.filter>>(
+    (<unknown>filters.filter({ modal: false, path: "my_field" }))
+  );
+
+  it("does not use lightningUnlocked ", () => {
+    setMockAtoms({
+      lightningUnlocked: () => {
+        throw new Error("do not call me");
+      },
+    });
+    test.set({ exclude: false, isMatching: false, values: ["value"] });
+  });
+});

--- a/app/packages/state/src/recoil/filters.test.ts
+++ b/app/packages/state/src/recoil/filters.test.ts
@@ -5,7 +5,7 @@ vi.mock("recoil-relay");
 import { setMockAtoms, TestSelectorFamily } from "../../../../__mocks__/recoil";
 import * as filters from "./filters";
 
-describe.skip("filter resolves correctly", () => {
+describe("filter resolves correctly", () => {
   const testModal = <TestSelectorFamily<typeof filters.filter>>(
     (<unknown>filters.filter({ path: "test", modal: true }))
   );
@@ -28,7 +28,7 @@ describe.skip("filter resolves correctly", () => {
   });
 });
 
-describe.skip("hasFilter resolves correctly", () => {
+describe("hasFilter resolves correctly", () => {
   const test = <TestSelectorFamily<typeof filters.hasFilters>>(
     (<unknown>filters.hasFilters(false))
   );
@@ -59,7 +59,9 @@ describe("setting a filter does not use async state", () => {
 
   it("does not use lightningUnlocked ", () => {
     setMockAtoms({
+      granularSidebarExpandedStore: {},
       lightning: true,
+      lightningPaths: () => new Set(["my_field"]),
       lightningUnlocked: () => {
         throw new Error("do not call me");
       },

--- a/app/packages/state/src/recoil/filters.test.ts
+++ b/app/packages/state/src/recoil/filters.test.ts
@@ -5,7 +5,7 @@ vi.mock("recoil-relay");
 import { setMockAtoms, TestSelectorFamily } from "../../../../__mocks__/recoil";
 import * as filters from "./filters";
 
-describe("filter resolves correctly", () => {
+describe.skip("filter resolves correctly", () => {
   const testModal = <TestSelectorFamily<typeof filters.filter>>(
     (<unknown>filters.filter({ path: "test", modal: true }))
   );
@@ -28,7 +28,7 @@ describe("filter resolves correctly", () => {
   });
 });
 
-describe("hasFilter resolves correctly", () => {
+describe.skip("hasFilter resolves correctly", () => {
   const test = <TestSelectorFamily<typeof filters.hasFilters>>(
     (<unknown>filters.hasFilters(false))
   );
@@ -59,6 +59,7 @@ describe("setting a filter does not use async state", () => {
 
   it("does not use lightningUnlocked ", () => {
     setMockAtoms({
+      lightning: true,
       lightningUnlocked: () => {
         throw new Error("do not call me");
       },

--- a/app/packages/state/src/recoil/filters.ts
+++ b/app/packages/state/src/recoil/filters.ts
@@ -5,7 +5,7 @@ import {
 } from "@fiftyone/relay";
 import { VALID_PRIMITIVE_TYPES } from "@fiftyone/utilities";
 import { atom, DefaultValue, selector, selectorFamily } from "recoil";
-import { lightning, lightningPaths, lightningUnlocked } from "./lightning";
+import { lightning, lightningPaths } from "./lightning";
 import { dbPath, expandPath, fields } from "./schema";
 import { hiddenLabelIds } from "./selectors";
 import {
@@ -79,29 +79,26 @@ export const filter = selectorFamily<
     ({ get, reset, set }, filter) => {
       const atom = modal ? modalFilters : filters;
       const newFilters = Object.assign({}, get(atom));
+      const currentLightningPaths = get(lightningPaths(""));
 
-      if (!modal && get(lightningUnlocked)) {
-        const paths = get(lightningPaths(""));
+      if (!modal && currentLightningPaths.has(path)) {
+        for (const p in newFilters) {
+          if (!currentLightningPaths.has(p)) {
+            delete newFilters[p];
+          }
+        }
+        reset(granularSidebarExpandedStore);
+        set(sidebarExpandedStore(false), (current) => {
+          const next = { ...current };
 
-        if (paths.has(path)) {
-          for (const p in newFilters) {
-            if (!paths.has(p)) {
-              delete newFilters[p];
+          for (const parent in next) {
+            if (![...currentLightningPaths].some((p) => p.startsWith(parent))) {
+              delete next[parent];
             }
           }
-          reset(granularSidebarExpandedStore);
-          set(sidebarExpandedStore(false), (current) => {
-            const next = { ...current };
 
-            for (const parent in next) {
-              if (![...paths].some((p) => p.startsWith(parent))) {
-                delete next[parent];
-              }
-            }
-
-            return next;
-          });
-        }
+          return next;
+        });
       }
 
       if (filter === null || filter instanceof DefaultValue) {

--- a/app/packages/state/src/recoil/filters.ts
+++ b/app/packages/state/src/recoil/filters.ts
@@ -4,7 +4,7 @@ import {
   graphQLSyncFragmentAtom,
 } from "@fiftyone/relay";
 import { VALID_PRIMITIVE_TYPES } from "@fiftyone/utilities";
-import { DefaultValue, atom, selector, selectorFamily } from "recoil";
+import { atom, DefaultValue, selector, selectorFamily } from "recoil";
 import { lightning, lightningPaths, lightningUnlocked } from "./lightning";
 import { dbPath, expandPath, fields } from "./schema";
 import { hiddenLabelIds } from "./selectors";

--- a/app/packages/state/src/recoil/sidebarExpanded.ts
+++ b/app/packages/state/src/recoil/sidebarExpanded.ts
@@ -1,5 +1,5 @@
 import { subscribe } from "@fiftyone/relay";
-import { DefaultValue, atom, atomFamily, selectorFamily } from "recoil";
+import { atom, atomFamily, DefaultValue, selectorFamily } from "recoil";
 
 export const sidebarExpandedStore = atomFamily<
   { [key: string]: boolean },
@@ -29,7 +29,7 @@ export const sidebarExpanded = selectorFamily<
 });
 
 export const granularSidebarExpandedStore = atom<{ [key: string]: boolean }>({
-  key: "granularSidebarExpanded",
+  key: "granularSidebarExpandedStore",
   default: {},
   effects: [({ node }) => subscribe((_, { set }) => set(node, {}))],
 });


### PR DESCRIPTION
## What changes are proposed in this pull request?

Recoil does not allow reading an asynchronous selector, in this case `lightningUnlocked`, when setting a new value for a `selector` instance.

This change removes the `lightningUnlocked` read from the `filter` selector family setter which allows sidebar filter changes, e.g. checking a field value checkbox, while in a loading state.

## How is this patch tested? If it is not, please explain why.

Recoil setter test

## Release Notes

* Fixed an unresponsive sidebar while loading new filter results in :ref:`lightning mode <app-lightning-mode>`

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved the structure and naming conventions in state management files for better clarity and maintenance.
  
- **Tests**
	- Added a new test case to verify the correct handling of filter settings without asynchronous dependencies.

- **Bug Fixes**
	- Enhanced the logic for handling specific filter conditions in the app, ensuring more accurate and reliable filtering operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->