### PR TITLE
[WIP] Make CVAT import annotations more concurrency friendly

### DIFF
--- a/fiftyone/utils/cvat.py
+++ b/fiftyone/utils/cvat.py
@@ -284,6 +284,7 @@ def import_annotations(
                     **kwargs,
                 )
     finally:
+        dataset.reload()
         anno_backend.delete_run(dataset, anno_key)
         api.close()
 


### PR DESCRIPTION
Whenever you call `delete_run()` in one process, it can delete runs that have been recently created in a different process.

One instance of this issue is if you create an annotation run in one process, then call `fiftyone.utils.cvat.import_annotations()` in another process, the `delete_run(...)` at `cvat.py` line 288 can corrupt any annotation runs that have been created while since the `import_annotations()` process was started.

This PR reloads the dataset before deleting the run to minimize the potential case where another annotation run is created between when the dataset was loaded and `delete_run()` is called.

TODO:
- [ ] Test this in a situations with multiple processes creating and importing annotation runs