### PR TITLE
Fix concurrency bug when updating/deleting runs

### DIFF
--- a/fiftyone/core/runs.py
+++ b/fiftyone/core/runs.py
@@ -501,11 +501,13 @@ class BaseRun(Configurable):
 
         # Update run doc
         run_docs = getattr(dataset._doc, cls._runs_field())
-        run_doc = run_docs.pop(key)
+        # DON'T use pop()! https://github.com/voxel51/fiftyone/issues/4322
+        run_doc = run_docs[key]
+        del run_docs[key]
         run_doc.key = new_key
         run_docs[new_key] = run_doc
         run_doc.save()
-        dataset._doc.save()
+        dataset.save()
 
         # Update results cache
         results_cache = getattr(dataset, cls._results_cache_field())
@@ -822,7 +824,11 @@ class BaseRun(Configurable):
 
         # Delete run from dataset
         run_docs = getattr(dataset._doc, cls._runs_field())
-        run_docs.pop(key, None)
+        try:
+            # DON'T use pop()! https://github.com/voxel51/fiftyone/issues/4322
+            del run_docs[key]
+        except KeyError:
+            pass
         results_cache = getattr(dataset, cls._results_cache_field())
         run_results = results_cache.pop(key, None)
         if run_results is not None:

--- a/tests/unittests/run_tests.py
+++ b/tests/unittests/run_tests.py
@@ -129,6 +129,47 @@ class RunTests(unittest.TestCase):
         runs = dataset.list_runs(method="test")
         self.assertListEqual(runs, ["custom2"])
 
+    @drop_datasets
+    def test_concurrent_run_updates(self):
+        dataset = fo.Dataset()
+        kwargs = {"foo": "bar", "spam": "eggs"}
+
+        config1 = dataset.init_run(**kwargs)
+        dataset.register_run("custom1", config1)
+
+        results1 = dataset.init_run_results("custom1", **kwargs)
+        dataset.save_run_results("custom1", results1)
+
+        # Don't reuse singleton; we want to test concurrent edits here
+        dataset._instances.pop(dataset.name)
+        also_dataset = fo.load_dataset(dataset.name)
+        self.assertIsNot(dataset, also_dataset)
+
+        config2 = also_dataset.init_run(**kwargs)
+        also_dataset.register_run("custom2", config2)
+
+        results2 = also_dataset.init_run_results("custom2", **kwargs)
+        also_dataset.save_run_results("custom2", results2)
+
+        self.assertListEqual(dataset.list_runs(), ["custom1"])
+
+        dataset.rename_run("custom1", "still_custom1")
+        also_dataset.reload()
+
+        self.assertListEqual(
+            also_dataset.list_runs(),
+            ["custom2", "still_custom1"],
+        )
+
+        dataset.delete_run("still_custom1")
+        also_dataset.reload()
+
+        self.assertListEqual(also_dataset.list_runs(), ["custom2"])
+
+        dataset.reload()
+
+        self.assertListEqual(dataset.list_runs(), ["custom2"])
+
 
 if __name__ == "__main__":
     fo.config.show_progress_bars = False


### PR DESCRIPTION
Resolves https://github.com/voxel51/fiftyone/issues/4322

Fixes the bug pointed out in https://github.com/voxel51/fiftyone/pull/4320 with root cause analysis detailed in https://github.com/voxel51/fiftyone/issues/4322.

The solution is (annoyingly) to replace `d.pop(key)` with `del d[key]`. Both are equivalent Python operations, but apparently `mongoengine` converts `del` to **nested** pymongo updates, which are robust to situations where a concurrent process has added/deleted other runs.

A unit test is added that verifies that concurrent run updates will work going forward.

## Example

### Process 1

```py
import fiftyone as fo

dataset = fo.Dataset("zzz")

config = dataset.init_run(foo="bar")
dataset.register_run("test1", config)

print(dataset.list_runs())
# ['test1']
```

### Process 2

```py
import fiftyone as fo

dataset = fo.load_dataset("zzz")

config = dataset.init_run(spam="eggs")
dataset.register_run("test2", config)

print(dataset.list_runs())
# ['test1', 'test2']
```

### Back in Process 1

```py
dataset.rename_run("test1", "still_test1")
"""
BEFORE
{'$set': {'runs': {'still_test1': ObjectId('663043c40e1de06966c90021')}}}

AFTER
{
    '$set': {'runs.still_test1': ObjectId('6630446149a8040d98c51068')},
    '$unset': {'runs.test1': 1},
}
"""

dataset.delete_run("still_test1")
"""
BEFORE
{'$unset': {'runs': 1}}

AFTER
{'$unset': {'runs.still_test1': 1}}
"""
```

### Back in Process 2

```py
dataset.reload()
print(dataset.list_runs())
"""
BEFORE
[] <-- data loss!!!

AFTER
['test2'] <-- no data loss
"""
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Enhanced the handling of run documents in the application to avoid using the `pop()` method, improving reliability and error management.

- **Tests**
	- Added a new test to ensure concurrent updates on runs across multiple datasets function correctly, enhancing the robustness of run operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->