### PR TITLE
Fix compute visualization results from operators

### DIFF
--- a/fiftyone/server/decorators.py
+++ b/fiftyone/server/decorators.py
@@ -50,7 +50,7 @@ def route(func):
             if isinstance(response, Response):
                 return response
 
-            return create_response(response)
+            return await create_response(response)
 
         except Exception as e:
             logging.exception(e)

--- a/fiftyone/server/decorators.py
+++ b/fiftyone/server/decorators.py
@@ -32,6 +32,12 @@ class Encoder(JSONEncoder):
         return JSONEncoder.default(self, o)
 
 
+async def create_response(response: dict):
+    return Response(
+        await run_sync_task(lambda: json_util.dumps(response, cls=Encoder))
+    )
+
+
 def route(func):
     async def wrapper(
         endpoint: HTTPEndpoint, request: Request, *args
@@ -44,11 +50,8 @@ def route(func):
             if isinstance(response, Response):
                 return response
 
-            return Response(
-                await run_sync_task(
-                    lambda: json_util.dumps(response, cls=Encoder)
-                )
-            )
+            return create_response(response)
+
         except Exception as e:
             logging.exception(e)
             return JSONResponse(

--- a/fiftyone/server/decorators.py
+++ b/fiftyone/server/decorators.py
@@ -23,11 +23,11 @@ from starlette.requests import Request
 
 class Encoder(JSONEncoder):
     def default(self, o):
-        if issubclass(o.dtype.type, np.floating):
-            return o.astype(float)
+        if isinstance(o, np.floating):
+            return float(o)
 
-        if issubclass(o.dtype.type, np.integer):
-            return o.astype(int)
+        if isinstance(o, np.integer):
+            return int(o)
 
         return JSONEncoder.default(self, o)
 

--- a/tests/unittests/server_decorators_tests.py
+++ b/tests/unittests/server_decorators_tests.py
@@ -1,0 +1,32 @@
+"""
+FiftyOne Server decorators.
+
+| Copyright 2017-2024, Voxel51, Inc.
+| `voxel51.com <https://voxel51.com/>`_
+|
+"""
+
+import unittest
+
+import numpy as np
+
+from fiftyone.server.decorators import create_response
+
+
+class TestNumPyResponse(unittest.IsolatedAsyncioTestCase):
+    async def test_numpy_response(self):
+        await create_response(
+            {
+                "float16": np.array([16.0], dtype=np.float16),
+                "float32": np.array([32.0], dtype=np.float32),
+                "float64": np.array([64.0], dtype=np.float64),
+                "int8": np.array([8], dtype=np.int8),
+                "int16": np.array([8], dtype=np.int16),
+                "int32": np.array([8], dtype=np.int32),
+                "int64": np.array([8], dtype=np.int64),
+                "uint8": np.array([8], dtype=np.uint8),
+                "uint6": np.array([8], dtype=np.uint16),
+                "uint32": np.array([8], dtype=np.uint32),
+                "uint64": np.array([8], dtype=np.uint64),
+            }
+        )


### PR DESCRIPTION
## What changes are proposed in this pull request?

Running compute_visualization (and potentially other methods) can sometimes lead to unserializable dtypes in numpy results. Adding a custom `JSONEncoder` on the server that handles these dtypes fixes the issue

## How is this patch tested? If it is not, please explain why.

Unit test

## Release Notes

* Fixed serialization of NumPy scalars for the App

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Improved data handling by introducing a custom JSON encoder for NumPy types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->