### PR TITLE
show panel render error

### DIFF
--- a/app/packages/operators/src/built-in-operators.ts
+++ b/app/packages/operators/src/built-in-operators.ts
@@ -871,7 +871,7 @@ function useUpdatePanelStatePartial(local?: boolean) {
     targetParam = targetParam || targetPartial;
     setTimeout(() => {
       setPanelStateById(ctx.getCurrentPanelId(), (current = {}) => {
-        const currentCustomPanelState = current[targetPartial] || {};
+        const currentCustomPanelState = current?.[targetPartial] || {};
         let updatedState;
         const param = ctx.params[targetParam];
         if (patch) {
@@ -1002,8 +1002,13 @@ class PromptUserForOperation extends Operator {
     return { triggerEvent };
   }
   async execute(ctx: ExecutionContext): Promise<void> {
-    const { params, operator_uri, on_success, on_error, on_cancel } =
-      ctx.params;
+    const {
+      params,
+      operator_uri,
+      on_success,
+      on_error,
+      on_cancel,
+    } = ctx.params;
     const { triggerEvent } = ctx.hooks;
     const panelId = ctx.getCurrentPanelId();
 

--- a/app/packages/operators/src/useCustomPanelHooks.ts
+++ b/app/packages/operators/src/useCustomPanelHooks.ts
@@ -108,8 +108,10 @@ export function useCustomPanelHooks(props: CustomPanelProps): CustomPanelHooks {
 
   useEffect(() => {
     if (props.onLoad && !panelState?.loaded) {
-      onLoad();
-      setPanelStateLocal((s) => ({ ...s, loaded: true }));
+      executeOperator(props.onLoad, { panel_id: panelId }, (result) => {
+        const { error: onLoadError } = result;
+        setPanelState((s) => ({ ...s, onLoadError, loaded: true }));
+      });
     }
 
     return () => {


### PR DESCRIPTION
## What changes are proposed in this pull request?

Show panel render method error for python panel

## How is this patch tested? If it is not, please explain why.

Using an example Python panel


```py

class LayoutPanel(foo.Panel):
    @property
    def config(self):
        return foo.PanelOperatorConfig(name="python_panel_02_layout", label="PythonPanel0.2: Layout")

    def render(self, ctx):
        panel = types.Object()
        raise Exception("Error!")
        return types.Property(panel)
```

![image](https://github.com/voxel51/fiftyone/assets/25350704/6d58c3e8-7387-4deb-a598-0377b90b4b6b)


## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced error handling in custom panel operations to improve stability and user experience.
- **Bug Fixes**
	- Implemented optional chaining in property access to prevent application errors due to undefined or null values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->