### PR TITLE
Fix concurrency bug when updating/deleting runs

### DIFF
--- a/fiftyone/core/runs.py
+++ b/fiftyone/core/runs.py
@@ -501,11 +501,13 @@ class BaseRun(Configurable):
 
         # Update run doc
         run_docs = getattr(dataset._doc, cls._runs_field())
-        run_doc = run_docs.pop(key)
+        # DON'T use pop()! https://github.com/voxel51/fiftyone/issues/4322
+        run_doc = run_docs[key]
+        del run_docs[key]
         run_doc.key = new_key
         run_docs[new_key] = run_doc
         run_doc.save()
-        dataset._doc.save()
+        dataset.save()
 
         # Update results cache
         results_cache = getattr(dataset, cls._results_cache_field())
@@ -822,7 +824,11 @@ class BaseRun(Configurable):
 
         # Delete run from dataset
         run_docs = getattr(dataset._doc, cls._runs_field())
-        run_docs.pop(key, None)
+        try:
+            # DON'T use pop()! https://github.com/voxel51/fiftyone/issues/4322
+            del run_docs[key]
+        except KeyError:
+            pass
         results_cache = getattr(dataset, cls._results_cache_field())
         run_results = results_cache.pop(key, None)
         if run_results is not None:

--- a/tests/unittests/run_tests.py
+++ b/tests/unittests/run_tests.py
@@ -129,6 +129,47 @@ class RunTests(unittest.TestCase):
         runs = dataset.list_runs(method="test")
         self.assertListEqual(runs, ["custom2"])
 
+    @drop_datasets
+    def test_concurrent_run_updates(self):
+        dataset = fo.Dataset()
+        kwargs = {"foo": "bar", "spam": "eggs"}
+
+        config1 = dataset.init_run(**kwargs)
+        dataset.register_run("custom1", config1)
+
+        results1 = dataset.init_run_results("custom1", **kwargs)
+        dataset.save_run_results("custom1", results1)
+
+        # Don't reuse singleton; we want to test concurrent edits here
+        dataset._instances.pop(dataset.name)
+        also_dataset = fo.load_dataset(dataset.name)
+        self.assertIsNot(dataset, also_dataset)
+
+        config2 = also_dataset.init_run(**kwargs)
+        also_dataset.register_run("custom2", config2)
+
+        results2 = also_dataset.init_run_results("custom2", **kwargs)
+        also_dataset.save_run_results("custom2", results2)
+
+        self.assertListEqual(dataset.list_runs(), ["custom1"])
+
+        dataset.rename_run("custom1", "still_custom1")
+        also_dataset.reload()
+
+        self.assertListEqual(
+            also_dataset.list_runs(),
+            ["custom2", "still_custom1"],
+        )
+
+        dataset.delete_run("still_custom1")
+        also_dataset.reload()
+
+        self.assertListEqual(also_dataset.list_runs(), ["custom2"])
+
+        dataset.reload()
+
+        self.assertListEqual(dataset.list_runs(), ["custom2"])
+
 
 if __name__ == "__main__":
     fo.config.show_progress_bars = False


### PR DESCRIPTION
Alternative to https://github.com/voxel51/fiftyone/pull/4323 that uses `reload()` rather than replacing `pop` with `del`.

IMO this is slightly less ideal than https://github.com/voxel51/fiftyone/pull/4323 because:
- this version is not fully protected against concurrent edits (although now the window of concurrency issues is the time it takes to execute a few lines of Python code and then make a pymongo API call)
- `reload()` is an extra API call
- a breaking change in how `mongoengine` implements pop/del deltas is unlikely, given that the package is not being actively developed (only like 1-2 releases in last 12 months)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced dataset run management to support concurrent edits and reliable updates.
- **Bug Fixes**
	- Improved the reliability of run deletions from datasets.
- **Tests**
	- Added a new test for concurrent run updates to ensure robustness in multi-user environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->