### PR TITLE
Some 3D cleanup

### DIFF
--- a/fiftyone/core/threed/mesh.py
+++ b/fiftyone/core/threed/mesh.py
@@ -69,6 +69,8 @@ class ObjMesh(Mesh):
         ValueError: if ``mtl_path`` does not end with ``.mtl``
     """
 
+    _asset_path_fields = ["obj_path", "mtl_path"]
+
     def __init__(
         self,
         name: str,
@@ -125,6 +127,8 @@ class FbxMesh(Mesh):
         ValueError: If ``fbx_path`` does not end with ``.fbx``
     """
 
+    _asset_path_fields = ["fbx_path"]
+
     def __init__(
         self,
         name: str,
@@ -169,6 +173,8 @@ class GltfMesh(Mesh):
     Raises:
         ValueError: if ``gltf_path`` does not end with '.gltf' or ``.glb``
     """
+
+    _asset_path_fields = ["gltf_path"]
 
     def __init__(
         self,
@@ -218,6 +224,8 @@ class PlyMesh(Mesh):
         ValueError: if ``ply_path`` does not end with ``.ply``
     """
 
+    _asset_path_fields = ["ply_path"]
+
     def __init__(
         self,
         name: str,
@@ -260,6 +268,8 @@ class StlMesh(Mesh):
     Raises:
         ValueError: if ``stl_path`` does not end with ``.stl``
     """
+
+    _asset_path_fields = ["stl_path"]
 
     def __init__(
         self,

--- a/fiftyone/core/threed/mesh.py
+++ b/fiftyone/core/threed/mesh.py
@@ -16,6 +16,7 @@ class Mesh(Object3D):
     """Represents an abstract 3D mesh.
 
     Args:
+        name (str): the name of the mesh
         material (:class:`fiftyone.core.threed.MeshMaterial`, optional):
             the default material for the mesh. Defaults to
             :class:`fiftyone.core.threed.MeshStandardMaterial`
@@ -24,8 +25,10 @@ class Mesh(Object3D):
             :class:`fiftyone.core.threed.Object3D` parent class
     """
 
-    def __init__(self, material: Optional[MeshMaterial] = None, **kwargs):
-        super().__init__(**kwargs)
+    def __init__(
+        self, name: str, material: Optional[MeshMaterial] = None, **kwargs
+    ):
+        super().__init__(name, **kwargs)
 
         if isinstance(material, dict):
             material = MeshMaterial._from_dict(material)

--- a/fiftyone/core/threed/object_3d.py
+++ b/fiftyone/core/threed/object_3d.py
@@ -31,6 +31,8 @@ class Object3D:
         scale (None): the scale of the object in object space
     """
 
+    _asset_path_fields = None
+
     def __init__(
         self,
         name: str,
@@ -211,6 +213,14 @@ class Object3D:
     def clear(self) -> None:
         """Remove all children from this object."""
         self.children = []
+
+    def _get_asset_paths(self) -> List[str]:
+        """Get asset paths for this node"""
+        return [
+            getattr(self, f, None)
+            for f in (self._asset_path_fields or [])
+            if getattr(self, f, None) is not None
+        ]
 
     def traverse(self, include_self=True):
         """Traverse the scene graph."""

--- a/fiftyone/core/threed/object_3d.py
+++ b/fiftyone/core/threed/object_3d.py
@@ -208,6 +208,9 @@ class Object3D:
 
     def add(self, *objs: "Object3D") -> None:
         """Add one or more objects as children of this one."""
+        if any(o is self for o in objs):
+            raise ValueError("Loop detected; can't add self as a child")
+
         self.children.extend(objs)
 
     def clear(self) -> None:

--- a/fiftyone/core/threed/pointcloud.py
+++ b/fiftyone/core/threed/pointcloud.py
@@ -35,6 +35,8 @@ class PointCloud(Object3D):
         ValueError: if ``pcd_path`` does not end with ``.pcd``
     """
 
+    _asset_path_fields = ["pcd_path"]
+
     def __init__(
         self,
         name: str,

--- a/fiftyone/core/threed/scene_3d.py
+++ b/fiftyone/core/threed/scene_3d.py
@@ -5,7 +5,7 @@
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
-
+import itertools
 import json
 import os
 from collections import Counter
@@ -240,23 +240,11 @@ class Scene(Object3D):
         """Collect all asset paths in the scene. Asset paths aren't resolved to
         absolute paths.
         """
-        asset_paths = []
-
-        for node in self.traverse():
-            if isinstance(node, PointCloud):
-                asset_paths.append(node.pcd_path)
-            elif isinstance(node, GltfMesh):
-                asset_paths.append(node.gltf_path)
-            elif isinstance(node, FbxMesh):
-                asset_paths.append(node.fbx_path)
-            elif isinstance(node, StlMesh):
-                asset_paths.append(node.stl_path)
-            elif isinstance(node, PlyMesh):
-                asset_paths.append(node.ply_path)
-            elif isinstance(node, ObjMesh):
-                asset_paths.append(node.obj_path)
-                if node.mtl_path is not None:
-                    asset_paths.append(node.mtl_path)
+        asset_paths = list(
+            itertools.chain.from_iterable(
+                node._get_asset_paths() for node in self.traverse()
+            )
+        )
 
         # append paths in scene background, if any
         if self.background is not None:

--- a/fiftyone/core/threed/scene_3d.py
+++ b/fiftyone/core/threed/scene_3d.py
@@ -177,6 +177,7 @@ class Scene(Object3D):
 
             visited_nodes.add(node.name)
 
+            # Resolve child's asset paths
             if resolve_relative_paths:
                 for asset_path_field in node._asset_path_fields or []:
                     asset_path = getattr(node, asset_path_field, None)
@@ -186,6 +187,7 @@ class Scene(Object3D):
                         )
                         setattr(node, asset_path_field, resolved_asset_path)
 
+        # Now resolve any asset paths in scene background
         if resolve_relative_paths and validated_scene.background is not None:
             if validated_scene.background.image is not None:
                 validated_scene.background.image = self._resolve_asset_path(

--- a/fiftyone/core/threed/scene_3d.py
+++ b/fiftyone/core/threed/scene_3d.py
@@ -178,34 +178,13 @@ class Scene(Object3D):
             visited_nodes.add(node.name)
 
             if resolve_relative_paths:
-                if hasattr(node, "pcd_path"):
-                    node.pcd_path = self._resolve_asset_path(
-                        fo3d_path_dir, node.pcd_path
-                    )
-                if hasattr(node, "obj_path"):
-                    node.obj_path = self._resolve_asset_path(
-                        fo3d_path_dir, node.obj_path
-                    )
-                if hasattr(node, "mtl_path"):
-                    node.mtl_path = self._resolve_asset_path(
-                        fo3d_path_dir, node.mtl_path
-                    )
-                if hasattr(node, "gltf_path"):
-                    node.gltf_path = self._resolve_asset_path(
-                        fo3d_path_dir, node.gltf_path
-                    )
-                if hasattr(node, "fbx_path"):
-                    node.fbx_path = self._resolve_asset_path(
-                        fo3d_path_dir, node.fbx_path
-                    )
-                if hasattr(node, "stl_path"):
-                    node.stl_path = self._resolve_asset_path(
-                        fo3d_path_dir, node.stl_path
-                    )
-                if hasattr(node, "ply_path"):
-                    node.ply_path = self._resolve_asset_path(
-                        fo3d_path_dir, node.ply_path
-                    )
+                for asset_path_field in node._asset_path_fields:
+                    asset_path = getattr(node, asset_path_field, None)
+                    if asset_path:
+                        resolved_asset_path = self._resolve_asset_path(
+                            fo3d_path_dir, asset_path
+                        )
+                        setattr(node, asset_path_field, resolved_asset_path)
 
         fos.write_json(
             validated_scene.as_dict(), fo3d_path, pretty_print=pprint
@@ -258,10 +237,10 @@ class Scene(Object3D):
         if path is None:
             return None
 
-        if not os.path.isabs(path):
-            path = os.path.join(root, path)
+        if not fos.isabs(path):
+            path = fos.join(root, path)
 
-        return path
+        return fos.resolve(path)
 
     def _to_dict_extra(self):
         return {

--- a/fiftyone/core/threed/scene_3d.py
+++ b/fiftyone/core/threed/scene_3d.py
@@ -64,7 +64,7 @@ class SceneBackground:
         }
 
     @staticmethod
-    def _from_dict(d):
+    def _from_dict(d: dict):
         return SceneBackground(
             color=d.get("color"),
             image=d.get("image"),

--- a/fiftyone/core/threed/scene_3d.py
+++ b/fiftyone/core/threed/scene_3d.py
@@ -8,6 +8,7 @@
 
 import json
 import os
+from collections import Counter
 from typing import List, Optional
 
 from pydantic.dataclasses import dataclass
@@ -224,38 +225,15 @@ class Scene(Object3D):
 
     def get_scene_summary(self):
         """Returns a summary of the scene."""
-        total_objs = 0
-        total_point_clouds = 0
-        total_gltfs = 0
-        total_fbxs = 0
-        total_stls = 0
-        total_plys = 0
-        total_shapes = 0
-
-        for node in self.traverse():
-            if isinstance(node, PointCloud):
-                total_point_clouds += 1
-            elif isinstance(node, GltfMesh):
-                total_gltfs += 1
-            elif isinstance(node, FbxMesh):
-                total_fbxs += 1
-            elif isinstance(node, StlMesh):
-                total_stls += 1
-            elif isinstance(node, PlyMesh):
-                total_plys += 1
-            elif isinstance(node, ObjMesh):
-                total_objs += 1
-            elif isinstance(node, Shape3D):
-                total_shapes += 1
-
+        node_types = Counter(map(type, self.traverse()))
         return {
-            "objs": total_objs,
-            "point clouds": total_point_clouds,
-            "gltfs": total_gltfs,
-            "fbxs": total_fbxs,
-            "stls": total_stls,
-            "plys": total_plys,
-            "shapes": total_shapes,
+            "objs": node_types[ObjMesh],
+            "point clouds": node_types[PointCloud],
+            "gltfs": node_types[GltfMesh],
+            "fbxs": node_types[FbxMesh],
+            "stls": node_types[StlMesh],
+            "plys": node_types[PlyMesh],
+            "shapes": node_types[Shape3D],
         }
 
     def get_asset_paths(self):

--- a/fiftyone/core/threed/scene_3d.py
+++ b/fiftyone/core/threed/scene_3d.py
@@ -178,13 +178,24 @@ class Scene(Object3D):
             visited_nodes.add(node.name)
 
             if resolve_relative_paths:
-                for asset_path_field in node._asset_path_fields:
+                for asset_path_field in node._asset_path_fields or []:
                     asset_path = getattr(node, asset_path_field, None)
                     if asset_path:
                         resolved_asset_path = self._resolve_asset_path(
                             fo3d_path_dir, asset_path
                         )
                         setattr(node, asset_path_field, resolved_asset_path)
+
+        if resolve_relative_paths and validated_scene.background is not None:
+            if validated_scene.background.image is not None:
+                validated_scene.background.image = self._resolve_asset_path(
+                    fo3d_path_dir, validated_scene.background.image
+                )
+            if validated_scene.background.cube is not None:
+                validated_scene.background.cube = [
+                    self._resolve_asset_path(fo3d_path_dir, ci)
+                    for ci in validated_scene.background.cube
+                ]
 
         fos.write_json(
             validated_scene.as_dict(), fo3d_path, pretty_print=pprint

--- a/fiftyone/core/threed/shape_3d.py
+++ b/fiftyone/core/threed/shape_3d.py
@@ -17,6 +17,7 @@ class Shape3D(Mesh):
     """Represents an abstract 3D shape.
 
     Args:
+        name (str): the name of the mesh
         material (:class:`fiftyone.core.threed.MeshMaterial`, optional):
             default material for the shape mesh. Defaults to
             :class:`fiftyone.core.threed.MeshStandardMaterial` if not provided

--- a/fiftyone/utils/utils3d.py
+++ b/fiftyone/utils/utils3d.py
@@ -855,12 +855,17 @@ def _parse_point_cloud(
         min_bound, max_bound = bounds
 
     if _contains_none(min_bound):
-        _min_bound = np.nanmin(np.asarray(pc.points), axis=0)
+        _min_bound = pc.get_min_bound()
         min_bound = _fill_none(min_bound, _min_bound)
 
     if _contains_none(max_bound):
-        _max_bound = np.nanmax(np.asarray(pc.points), axis=0)
+        _max_bound = pc.get_max_bound()
         max_bound = _fill_none(max_bound, _max_bound)
+
+    # Ensure bbox will not have 0 volume by adding a small value if max_bound
+    #   and min_bound are close to each other
+    delta = np.isclose(max_bound - min_bound, 0) * np.repeat(0.000001, 3)
+    max_bound += delta
 
     bbox = o3d.geometry.AxisAlignedBoundingBox(
         min_bound=min_bound, max_bound=max_bound

--- a/fiftyone/utils/utils3d.py
+++ b/fiftyone/utils/utils3d.py
@@ -835,13 +835,21 @@ def _parse_point_cloud(
     ):
         # rotate points so that they are perpendicular to the projection plane
         # as opposed to the default XY plane
-        normal = np.asarray(projection_normal).reshape((1, 3))
+        try:
+            normal = np.asarray(projection_normal).reshape((1, 3))
+        except Exception as e:
+            raise ValueError(
+                f"Invalid projection normal argument. Must be an XYZ vector of"
+                f" shape (1,3): {projection_normal}"
+            ) from e
+
+        # There are multiple rotations that can align two vectors. This is known
+        # and accepted, so we suppress the warning.
         with warnings.catch_warnings():
-            # There are multiple rotations that can align two vectors. This is known
-            # and accepted, so we suppress the warning.
             warnings.filterwarnings(
                 "ignore",
-                message="Optimal rotation is not uniquely or poorly defined for the given sets of vectors\.",
+                message="Optimal rotation is not uniquely or poorly defined "
+                "for the given sets of vectors",
                 category=UserWarning,
             )
             R = sp.transform.Rotation.align_vectors([[0, 0, 1]], normal)[

--- a/fiftyone/utils/utils3d.py
+++ b/fiftyone/utils/utils3d.py
@@ -872,7 +872,9 @@ def _parse_point_cloud(
 
     # Ensure bbox will not have 0 volume by adding a small value if max_bound
     #   and min_bound are close to each other
-    delta = np.isclose(max_bound - min_bound, 0) * np.repeat(0.000001, 3)
+    delta = np.isclose(
+        np.asarray(max_bound) - np.asarray(min_bound), 0
+    ) * np.repeat(0.000001, 3)
     max_bound += delta
 
     bbox = o3d.geometry.AxisAlignedBoundingBox(

--- a/tests/unittests/threed/scene_3d_tests.py
+++ b/tests/unittests/threed/scene_3d_tests.py
@@ -7,32 +7,121 @@ FiftyOne Scene3D unit tests.
 """
 
 import json
+import os
+import tempfile
 import unittest
 from unittest.mock import mock_open, patch
 
-from fiftyone.core.threed import GltfMesh, PointCloud, Scene
+from fiftyone.core import threed
 from fiftyone.core.threed.utils import convert_keys_to_snake_case
 
 
 class TestScene(unittest.TestCase):
     def setUp(self):
-        self.scene = Scene()
-        self.scene.add(GltfMesh("gltf", gltf_path="/path/to/gltf.gltf"))
-        self.scene.add(PointCloud("pcd", pcd_path="/path/to/pcd.pcd"))
+        self.scene = threed.Scene()
+        self.scene.add(threed.GltfMesh("gltf", gltf_path="/path/to/gltf.gltf"))
+        self.scene.add(threed.GltfMesh("gltf2", gltf_path="relative.gltf"))
+        self.scene.add(threed.PointCloud("pcd", pcd_path="/path/to/pcd.pcd"))
+        self.scene.add(threed.Shape3D(name="shape"))
+        self.scene.add(threed.StlMesh("stl", stl_path="/path/to/stl.stl"))
+        self.scene.add(threed.PlyMesh("ply", ply_path="/path/to/ply.ply"))
+        self.scene.add(threed.FbxMesh("fbx", fbx_path="/path/to/fbx.fbx"))
+        self.scene.add(threed.ObjMesh("obj", obj_path="/path/to/obj.obj"))
+        self.scene.background = threed.SceneBackground(
+            image="../background.jpeg",
+            cube=[
+                "n1.jpeg",
+                "n2.jpeg",
+                "n3.jpeg",
+                "n4.jpeg",
+                "n5.jpeg",
+                "n6.jpeg",
+            ],
+        )
 
     def test_export_invalid_extension(self):
         with self.assertRaises(ValueError):
             self.scene.write("/path/to/scene.invalid")
 
+    def test_get_asset_paths(self):
+        asset_paths = set(self.scene.get_asset_paths())
+        self.assertSetEqual(
+            asset_paths,
+            {
+                "/path/to/gltf.gltf",
+                "/path/to/pcd.pcd",
+                "../background.jpeg",
+                "/path/to/stl.stl",
+                "/path/to/fbx.fbx",
+                "/path/to/ply.ply",
+                "/path/to/obj.obj",
+                "relative.gltf",
+                "n1.jpeg",
+                "n2.jpeg",
+                "n3.jpeg",
+                "n4.jpeg",
+                "n5.jpeg",
+                "n6.jpeg",
+            },
+        )
+
+    def test_write(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            path = os.path.join(temp_dir, "blah.fo3d")
+            self.scene.write(path)
+            scene2 = threed.Scene.from_fo3d(path)
+            self.assertDictEqual(scene2.as_dict(), self.scene.as_dict())
+
+    def test_write_resolve_relative(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            path = os.path.join(temp_dir, "blah.fo3d")
+            self.scene.write(
+                path,
+                resolve_relative_paths=True,
+            )
+            scene2 = threed.Scene.from_fo3d(path)
+            real_background = os.path.realpath(
+                os.path.join(temp_dir, "../background.jpeg")
+            )
+            self.assertEqual(scene2.background.image, real_background)
+            real_cubes = [
+                os.path.realpath(os.path.join(temp_dir, ci))
+                for ci in self.scene.background.cube
+            ]
+            self.assertListEqual(scene2.background.cube, real_cubes)
+            for node in scene2.traverse():
+                if node.name == "gltf2":
+                    self.assertEqual(
+                        node.gltf_path,
+                        os.path.realpath(
+                            os.path.join(temp_dir, "relative.gltf")
+                        ),
+                    )
+
+    def test_get_scene_summary(self):
+        summary = self.scene.get_scene_summary()
+        self.assertDictEqual(
+            summary,
+            {
+                "point clouds": 1,
+                "gltfs": 2,
+                "fbxs": 1,
+                "plys": 1,
+                "objs": 1,
+                "shapes": 1,
+                "stls": 1,
+            },
+        )
+
     def test_from_fo3d(self):
         mock_file = mock_open(read_data=json.dumps(self.scene.as_dict()))
 
         with patch("builtins.open", mock_file):
-            scene_from_file = Scene.from_fo3d("/path/to/scene.fo3d")
+            scene_from_file = threed.Scene.from_fo3d("/path/to/scene.fo3d")
 
         mock_file.assert_called_once_with("/path/to/scene.fo3d", "r")
 
-        self.assertEqual(scene_from_file.as_dict(), self.scene.as_dict())
+        self.assertDictEqual(scene_from_file.as_dict(), self.scene.as_dict())
 
     def test_snake_case_conversion(self):
         # test simple dict


### PR DESCRIPTION
## What changes are proposed in this pull request?

- refactor/clean some scene_3d functions - this was requested in original PR but decided to follow up later. This is that.
- add more comprehensive tests
- Fix orthographic projection for 2D point cloud all on the projection plane.
- Fix `write(path, resolve_relative_paths=True)` for background image assets.

## How is this patch tested? If it is not, please explain why.

Added automated tests.
Manual testing to ensure calls touched still work.

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
  - Added `name` parameter to the `Mesh` class constructor.
  - Introduced `_asset_path_fields` attribute to various 3D model classes.
  - Enhanced asset path retrieval methods for improved 3D object integration.
  - Updated point cloud bounding box calculations for more accurate spatial analysis.

- **Refactor**
  - Optimized asset path resolution and node type counting in 3D scenes for improved performance and readability.

- **Bug Fixes**
  - Corrected attribute renaming in `FbxMesh` to align with functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->