### PR TITLE
refactor(threed): push args in docstring to child class

### DIFF
--- a/fiftyone/core/threed/lights.py
+++ b/fiftyone/core/threed/lights.py
@@ -96,7 +96,7 @@ class AmbientLight(Light):
             ("color", self.color),
             ("intensity", self.intensity),
         ]:
-            kwargs_list.append(f"{k}={v if not isinstance(v, str) else v!r}")
+            kwargs_list.append(f"{k}={repr(v)}")
         return f"{self.__class__.__name__}({', '.join(kwargs_list)})"
 
 
@@ -147,7 +147,7 @@ class DirectionalLight(Light):
             ("color", self.color),
             ("intensity", self.intensity),
         ]:
-            kwargs_list.append(f"{k}={v if not isinstance(v, (str)) else v!r}")
+            kwargs_list.append(f"{k}={repr(v)}")
         return f"{self.__class__.__name__}({', '.join(kwargs_list)})"
 
     def _to_dict_extra(self):
@@ -202,7 +202,7 @@ class PointLight(Light):
             ("color", self.color),
             ("intensity", self.intensity),
         ]:
-            kwargs_list.append(f"{k}={v if not isinstance(v, (str)) else v!r}")
+            kwargs_list.append(f"{k}={repr(v)}")
         return f"{self.__class__.__name__}({', '.join(kwargs_list)})"
 
     def _to_dict_extra(self):
@@ -271,7 +271,7 @@ class SpotLight(Light):
             ("color", self.color),
             ("intensity", self.intensity),
         ]:
-            kwargs_list.append(f"{k}={v if not isinstance(v, (str)) else v!r}")
+            kwargs_list.append(f"{k}={repr(v)}")
         return f"{self.__class__.__name__}({', '.join(kwargs_list)})"
 
     def _to_dict_extra(self):

--- a/fiftyone/core/threed/lights.py
+++ b/fiftyone/core/threed/lights.py
@@ -7,9 +7,10 @@ Lights definition for 3D visualization.
 """
 
 from math import pi as PI
+from typing import Optional
 
 from .object_3d import Object3D
-from .transformation import Vec3UnionType, Vector3
+from .transformation import Quaternion, Vec3UnionType, Vector3
 from .validators import normalize_to_vec3
 
 COLOR_DEFAULT_WHITE = "#ffffff"
@@ -21,17 +22,28 @@ class Light(Object3D):
     Args:
         color ("#ffffff"): the color of the light
         intensity (1.0): the intensity of the light in the range ``[0, 1]``
+        visible (True): default visibility of the object in the scene
+        position (None): the position of the light in object space
+        quaternion (None): the quaternion of the light in object space
+        scale (None): the scale of the light in object space
     """
 
     def __init__(
         self,
         color: str = COLOR_DEFAULT_WHITE,
         intensity: float = 1.0,
-        **kwargs,
+        visible=True,
+        position: Optional[Vec3UnionType] = None,
+        scale: Optional[Vec3UnionType] = None,
+        quaternion: Optional[Quaternion] = None,
     ):
-        # remove 'name' from kwargs, if present
-        kwargs = {k: v for k, v in kwargs.items() if k != "name"}
-        super().__init__(name=self.__class__.__name__, **kwargs)
+        super().__init__(
+            name=self.__class__.__name__,
+            visible=visible,
+            position=position,
+            scale=scale,
+            quaternion=quaternion,
+        )
         self.color = color
         self.intensity = intensity
 
@@ -53,16 +65,29 @@ class AmbientLight(Light):
     Args:
         intensity (0.1): the intensity of the light in the range ``[0, 1]``
         color ("#ffffff"): the color of the light
-        kwargs: keyword arguments for the :class:`Light` parent class
+        visible (True): default visibility of the object in the scene
+        position (None): the position of the light in object space
+        quaternion (None): the quaternion of the light in object space
+        scale (None): the scale of the light in object space
     """
 
     def __init__(
         self,
         intensity: float = 0.1,
         color: str = COLOR_DEFAULT_WHITE,
-        **kwargs,
+        visible=True,
+        position: Optional[Vec3UnionType] = None,
+        scale: Optional[Vec3UnionType] = None,
+        quaternion: Optional[Quaternion] = None,
     ):
-        super().__init__(intensity=intensity, color=color, **kwargs)
+        super().__init__(
+            intensity=intensity,
+            color=color,
+            visible=visible,
+            position=position,
+            scale=scale,
+            quaternion=quaternion,
+        )
 
     def __repr__(self):
         kwargs_list = []
@@ -71,7 +96,7 @@ class AmbientLight(Light):
             ("color", self.color),
             ("intensity", self.intensity),
         ]:
-            kwargs_list.append(f"{k}={v if not isinstance(v, (str)) else v!r}")
+            kwargs_list.append(f"{k}={v if not isinstance(v, str) else v!r}")
         return f"{self.__class__.__name__}({', '.join(kwargs_list)})"
 
 
@@ -86,7 +111,10 @@ class DirectionalLight(Light):
         target ([0,0,0]): the target of the light
         color ("#ffffff"): the color of the light
         intensity (1.0): the intensity of the light in the range ``[0, 1]``
-        **kwargs: keyword arguments for the :class:`Light` parent class
+        visible (True): default visibility of the object in the scene
+        position (None): the position of the light in object space
+        quaternion (None): the quaternion of the light in object space
+        scale (None): the scale of the light in object space
     """
 
     target: Vec3UnionType = Vector3(0, 0, 0)
@@ -96,9 +124,19 @@ class DirectionalLight(Light):
         target: Vec3UnionType = Vector3(0, 0, 0),
         color: str = COLOR_DEFAULT_WHITE,
         intensity: float = 1.0,
-        **kwargs,
+        visible=True,
+        position: Optional[Vec3UnionType] = None,
+        scale: Optional[Vec3UnionType] = None,
+        quaternion: Optional[Quaternion] = None,
     ):
-        super().__init__(color=color, intensity=intensity, **kwargs)
+        super().__init__(
+            color=color,
+            intensity=intensity,
+            visible=visible,
+            position=position,
+            scale=scale,
+            quaternion=quaternion,
+        )
         self.target = normalize_to_vec3(target)
 
     def __repr__(self):
@@ -127,7 +165,10 @@ class PointLight(Light):
         decay (2.0): the amount the light dims along the distance of the light
         color ("#ffffff"): the color of the light
         intensity (1.0): the intensity of the light in the range ``[0, 1]``
-        **kwargs: keyword arguments for the :class:`Light` parent class
+        visible (True): default visibility of the object in the scene
+        position (None): the position of the light in object space
+        quaternion (None): the quaternion of the light in object space
+        scale (None): the scale of the light in object space
     """
 
     def __init__(
@@ -136,9 +177,19 @@ class PointLight(Light):
         decay: float = 2.0,
         color: str = COLOR_DEFAULT_WHITE,
         intensity: float = 1.0,
-        **kwargs,
+        visible=True,
+        position: Optional[Vec3UnionType] = None,
+        scale: Optional[Vec3UnionType] = None,
+        quaternion: Optional[Quaternion] = None,
     ):
-        super().__init__(color=color, intensity=intensity, **kwargs)
+        super().__init__(
+            color=color,
+            intensity=intensity,
+            visible=visible,
+            position=position,
+            scale=scale,
+            quaternion=quaternion,
+        )
         self.distance = distance
         self.decay = decay
 
@@ -175,8 +226,10 @@ class SpotLight(Light):
         penumbra (0.0): the angle of the penumbra of the light's spotlight, in radians
         color ("#ffffff"): the color of the light
         intensity (1.0): the intensity of the light in the range ``[0, 1]``
-        **kwargs: keyword arguments for the :class:`Light` parent class
-    """
+        visible (True): default visibility of the object in the scene
+        position (None): the position of the light in object space
+        quaternion (None): the quaternion of the light in object space
+        scale (None): the scale of the light in object space"""
 
     def __init__(
         self,
@@ -187,9 +240,19 @@ class SpotLight(Light):
         penumbra: float = 0.0,
         color: str = COLOR_DEFAULT_WHITE,
         intensity: float = 1.0,
-        **kwargs,
+        visible=True,
+        position: Optional[Vec3UnionType] = None,
+        scale: Optional[Vec3UnionType] = None,
+        quaternion: Optional[Quaternion] = None,
     ):
-        super().__init__(color=color, intensity=intensity, **kwargs)
+        super().__init__(
+            color=color,
+            intensity=intensity,
+            visible=visible,
+            position=position,
+            scale=scale,
+            quaternion=quaternion,
+        )
         self.target = normalize_to_vec3(target) if target else Vector3(0, 0, 0)
         self.distance = distance
         self.decay = decay

--- a/fiftyone/core/threed/material_3d.py
+++ b/fiftyone/core/threed/material_3d.py
@@ -58,7 +58,7 @@ class PointCloudMaterial(Material3D):
         point_size (1.0): the size of the points in the point cloud
         attenuate_by_distance (False): whether to attenuate the point size
             based on distance from the camera
-        **kwargs: keyword arguments forn the :class:`Material3D` parent class
+        opacity (1.0): the opacity of the material, in the range ``[0, 1]``
     """
 
     shading_mode: Literal["height", "intensity", "rgb", "custom"] = "height"
@@ -84,7 +84,7 @@ class MeshMaterial(Material3D):
 
     Args:
         wireframe (False): whether to render the mesh as a wireframe
-        **kwargs: keyword arguments for the :class:`Material3D` parent class
+        opacity (1.0): the opacity of the material, in the range ``[0, 1]``
     """
 
     wireframe: bool = False
@@ -101,7 +101,8 @@ class MeshBasicMaterial(MeshMaterial):
 
     Args:
         color ("#ffffff"): the color of the material
-        **kwargs: keyword arguments for the :class:`MeshMaterial` parent class
+        wireframe (False): whether to render the mesh as a wireframe
+        opacity (1.0): the opacity of the material, in the range ``[0, 1]``
     """
 
     color: str = COLOR_DEFAULT_GRAY
@@ -125,7 +126,8 @@ class MeshStandardMaterial(MeshMaterial):
         emissive_intensity (0.0): the intensity of the emissive color
         metalness (0.0): the metalness of the material
         roughness (1.0): the roughness of the material
-        **kwargs: keyword arguments for the :class:`MeshMaterial` parent class
+        wireframe (False): whether to render the mesh as a wireframe
+        opacity (1.0): the opacity of the material, in the range ``[0, 1]``
     """
 
     color: str = COLOR_DEFAULT_GRAY
@@ -163,7 +165,8 @@ class MeshLambertMaterial(MeshMaterial):
         emissive_intensity (0.0): the intensity of the emissive color
         reflectivity (1.0): the reflectivity of the material
         refraction_ratio (0.98): the refraction ratio (IOR) of the material
-        **kwargs: keyword arguments for the :class:`MeshMaterial` parent class
+        wireframe (False): whether to render the mesh as a wireframe
+        opacity (1.0): the opacity of the material, in the range ``[0, 1]``
     """
 
     color: str = COLOR_DEFAULT_GRAY
@@ -196,8 +199,15 @@ class MeshPhongMaterial(MeshLambertMaterial):
     Args:
         shininess (30): the shininess of the material
         specular_color ("#111111"): the specular color of the material
-        **kwargs: keyword arguments for the :class:`MeshLambertMaterial` parent
-            class
+        color ("#ffffff"): the color of the material
+        emissive_color ("#000000"): the emissive color of the material.
+            This is the color emitted by the material itself independent of
+            the light
+        emissive_intensity (0.0): the intensity of the emissive color
+        reflectivity (1.0): the reflectivity of the material
+        refraction_ratio (0.98): the refraction ratio (IOR) of the material
+        wireframe (False): whether to render the mesh as a wireframe
+        opacity (1.0): the opacity of the material, in the range ``[0, 1]``
     """
 
     shininess: float = 30.0
@@ -221,7 +231,8 @@ class MeshDepthMaterial(MeshMaterial):
     off of the camera near and far plane. White is nearest, black is farthest.
 
     Args:
-        **kwargs: keyword arguments for the :class:`MeshMaterial` parent class
+        wireframe (False): whether to render the mesh as a wireframe
+        opacity (1.0): the opacity of the material, in the range ``[0, 1]``
     """
 
     pass

--- a/fiftyone/core/threed/mesh.py
+++ b/fiftyone/core/threed/mesh.py
@@ -10,25 +10,40 @@ from typing import Optional
 
 from .material_3d import MeshMaterial, MeshStandardMaterial
 from .object_3d import Object3D
+from .transformation import Quaternion, Vec3UnionType
 
 
 class Mesh(Object3D):
     """Represents an abstract 3D mesh.
 
     Args:
-        name (str): the name of the mesh
+        name: the name of the mesh
         material (:class:`fiftyone.core.threed.MeshMaterial`, optional):
             the default material for the mesh. Defaults to
             :class:`fiftyone.core.threed.MeshStandardMaterial`
             if not provided
-        **kwargs: keyword arguments for the
-            :class:`fiftyone.core.threed.Object3D` parent class
+        visible (True): default visibility of the mesh in the scene
+        position (None): the position of the mesh in object space
+        quaternion (None): the quaternion of the mesh in object space
+        scale (None): the scale of the mesh in object space
     """
 
     def __init__(
-        self, name: str, material: Optional[MeshMaterial] = None, **kwargs
+        self,
+        name: str,
+        material: Optional[MeshMaterial] = None,
+        visible=True,
+        position: Optional[Vec3UnionType] = None,
+        scale: Optional[Vec3UnionType] = None,
+        quaternion: Optional[Quaternion] = None,
     ):
-        super().__init__(name, **kwargs)
+        super().__init__(
+            name=name,
+            visible=visible,
+            position=position,
+            scale=scale,
+            quaternion=quaternion,
+        )
 
         if isinstance(material, dict):
             material = MeshMaterial._from_dict(material)
@@ -65,7 +80,10 @@ class ObjMesh(Mesh):
             the default material for the mesh if ``mtl_path`` is not provided
             or if material in ``mtl_path`` is not found. Defaults to
             :class:`fiftyone.core.threed.MeshStandardMaterial`
-        **kwargs: keyword arguments for the :class:`Mesh` parent class
+        visible (True): default visibility of the mesh in the scene
+        position (None): the position of the mesh in object space
+        quaternion (None): the quaternion of the mesh in object space
+        scale (None): the scale of the mesh in object space
 
     Raises:
         ValueError: if ``obj_path`` does not end with ``.obj``
@@ -80,9 +98,19 @@ class ObjMesh(Mesh):
         obj_path: str,
         mtl_path: Optional[str] = None,
         default_material: Optional[MeshMaterial] = None,
-        **kwargs
+        visible=True,
+        position: Optional[Vec3UnionType] = None,
+        scale: Optional[Vec3UnionType] = None,
+        quaternion: Optional[Quaternion] = None,
     ):
-        super().__init__(name=name, material=default_material, **kwargs)
+        super().__init__(
+            name=name,
+            material=default_material,
+            visible=visible,
+            position=position,
+            scale=scale,
+            quaternion=quaternion,
+        )
 
         if not obj_path.lower().endswith(".obj"):
             raise ValueError("OBJ mesh must be a .obj file")
@@ -124,7 +152,10 @@ class FbxMesh(Mesh):
             the default material for the mesh if FBX file does not contain
             material information. Defaults to
             :class:`fiftyone.core.threed.MeshStandardMaterial`
-        **kwargs: keyword arguments for the :class:`Mesh` parent class
+        visible (True): default visibility of the mesh in the scene
+        position (None): the position of the mesh in object space
+        quaternion (None): the quaternion of the mesh in object space
+        scale (None): the scale of the mesh in object space
 
     Raises:
         ValueError: If ``fbx_path`` does not end with ``.fbx``
@@ -137,9 +168,19 @@ class FbxMesh(Mesh):
         name: str,
         fbx_path: str,
         default_material: Optional[MeshMaterial] = None,
-        **kwargs
+        visible=True,
+        position: Optional[Vec3UnionType] = None,
+        scale: Optional[Vec3UnionType] = None,
+        quaternion: Optional[Quaternion] = None,
     ):
-        super().__init__(name=name, material=default_material, **kwargs)
+        super().__init__(
+            name=name,
+            material=default_material,
+            visible=visible,
+            position=position,
+            scale=scale,
+            quaternion=quaternion,
+        )
 
         if not (fbx_path.lower().endswith(".fbx")):
             raise ValueError("FBX mesh must be a .fbx file")
@@ -171,7 +212,10 @@ class GltfMesh(Mesh):
             the default material for the mesh if gLTF file does not contain
             material information. Defaults to
             :class:`fiftyone.core.threed.MeshStandardMaterial`
-        **kwargs: keyword arguments for the :class:`Mesh` parent class
+        visible (True): default visibility of the mesh in the scene
+        position (None): the position of the mesh in object space
+        quaternion (None): the quaternion of the mesh in object space
+        scale (None): the scale of the mesh in object space
 
     Raises:
         ValueError: if ``gltf_path`` does not end with '.gltf' or ``.glb``
@@ -184,9 +228,19 @@ class GltfMesh(Mesh):
         name: str,
         gltf_path: str,
         default_material: Optional[MeshMaterial] = None,
-        **kwargs
+        visible=True,
+        position: Optional[Vec3UnionType] = None,
+        scale: Optional[Vec3UnionType] = None,
+        quaternion: Optional[Quaternion] = None,
     ):
-        super().__init__(name=name, material=default_material, **kwargs)
+        super().__init__(
+            name=name,
+            material=default_material,
+            visible=visible,
+            position=position,
+            scale=scale,
+            quaternion=quaternion,
+        )
 
         if not (
             gltf_path.lower().endswith(".gltf")
@@ -221,7 +275,10 @@ class PlyMesh(Mesh):
             :class:`fiftyone.core.threed.MeshStandardMaterial`. If the PLY
             file contains vertex colors, the material is ignored and vertex
             colors are used
-        **kwargs: keyword arguments for the :class:`Mesh` parent class
+        visible (True): default visibility of the mesh in the scene
+        position (None): the position of the mesh in object space
+        quaternion (None): the quaternion of the mesh in object space
+        scale (None): the scale of the mesh in object space
 
     Raises:
         ValueError: if ``ply_path`` does not end with ``.ply``
@@ -235,9 +292,19 @@ class PlyMesh(Mesh):
         ply_path: str,
         is_point_cloud: bool = False,
         default_material: Optional[MeshMaterial] = None,
-        **kwargs
+        visible=True,
+        position: Optional[Vec3UnionType] = None,
+        scale: Optional[Vec3UnionType] = None,
+        quaternion: Optional[Quaternion] = None,
     ):
-        super().__init__(name=name, material=default_material, **kwargs)
+        super().__init__(
+            name=name,
+            material=default_material,
+            visible=visible,
+            position=position,
+            scale=scale,
+            quaternion=quaternion,
+        )
 
         if not ply_path.lower().endswith(".ply"):
             raise ValueError("PLY mesh must be a .ply file")
@@ -266,7 +333,10 @@ class StlMesh(Mesh):
         material (:class:`fiftyone.core.threed.MeshMaterial`, optional):
             default material for the mesh. Defaults to
             :class:`fiftyone.core.threed.MeshStandardMaterial`
-        **kwargs: keyword arguments for the :class:`Mesh` parent class
+        visible (True): default visibility of the mesh in the scene
+        position (None): the position of the mesh in object space
+        quaternion (None): the quaternion of the mesh in object space
+        scale (None): the scale of the mesh in object space
 
     Raises:
         ValueError: if ``stl_path`` does not end with ``.stl``
@@ -279,9 +349,19 @@ class StlMesh(Mesh):
         name: str,
         stl_path: str,
         default_material: Optional[MeshMaterial] = None,
-        **kwargs
+        visible=True,
+        position: Optional[Vec3UnionType] = None,
+        scale: Optional[Vec3UnionType] = None,
+        quaternion: Optional[Quaternion] = None,
     ):
-        super().__init__(name=name, material=default_material, **kwargs)
+        super().__init__(
+            name=name,
+            material=default_material,
+            visible=visible,
+            position=position,
+            scale=scale,
+            quaternion=quaternion,
+        )
 
         if not stl_path.lower().endswith(".stl"):
             raise ValueError("STL mesh must be a .stl file")

--- a/fiftyone/core/threed/pointcloud.py
+++ b/fiftyone/core/threed/pointcloud.py
@@ -29,7 +29,6 @@ class PointCloud(Object3D):
             :class:`fiftyone.core.threed.Scene` can have at most one asset
             flagged for orthographic projection. Defaults to ``False``. If
             multiple assets are flagged, the first one will be chosen
-                name: the name of the object
         visible (True): default visibility of the point cloud in the scene
         position (None): the position of the object in point cloud space
         quaternion (None): the quaternion of the point cloud in object space

--- a/fiftyone/core/threed/pointcloud.py
+++ b/fiftyone/core/threed/pointcloud.py
@@ -10,6 +10,7 @@ from typing import Optional
 
 from .material_3d import PointCloudMaterial
 from .object_3d import Object3D
+from .transformation import Quaternion, Vec3UnionType
 
 
 class PointCloud(Object3D):
@@ -28,8 +29,11 @@ class PointCloud(Object3D):
             :class:`fiftyone.core.threed.Scene` can have at most one asset
             flagged for orthographic projection. Defaults to ``False``. If
             multiple assets are flagged, the first one will be chosen
-        **kwargs: keyword arguments for the
-            :class:`fiftyone.core.threed.Object3D` parent class
+                name: the name of the object
+        visible (True): default visibility of the point cloud in the scene
+        position (None): the position of the object in point cloud space
+        quaternion (None): the quaternion of the point cloud in object space
+        scale (None): the scale of the point cloud in object space
 
     Raises:
         ValueError: if ``pcd_path`` does not end with ``.pcd``
@@ -43,9 +47,18 @@ class PointCloud(Object3D):
         pcd_path: str,
         material: Optional[PointCloudMaterial] = None,
         flag_for_projection: bool = False,
-        **kwargs
+        visible=True,
+        position: Optional[Vec3UnionType] = None,
+        scale: Optional[Vec3UnionType] = None,
+        quaternion: Optional[Quaternion] = None,
     ):
-        super().__init__(name=name, **kwargs)
+        super().__init__(
+            name=name,
+            visible=visible,
+            position=position,
+            scale=scale,
+            quaternion=quaternion,
+        )
 
         if not pcd_path.lower().endswith(".pcd"):
             raise ValueError("Point cloud must be a .pcd file")

--- a/fiftyone/core/threed/shape_3d.py
+++ b/fiftyone/core/threed/shape_3d.py
@@ -11,18 +11,21 @@ from typing import Optional
 
 from .material_3d import MeshMaterial
 from .mesh import Mesh
+from .transformation import Quaternion, Vec3UnionType
 
 
 class Shape3D(Mesh):
     """Represents an abstract 3D shape.
 
     Args:
-        name (str): the name of the mesh
+        name: the name of the mesh
         material (:class:`fiftyone.core.threed.MeshMaterial`, optional):
             default material for the shape mesh. Defaults to
             :class:`fiftyone.core.threed.MeshStandardMaterial` if not provided
-        **kwargs: keyword arguments for the :class:`fiftyone.core.threed.Mesh`
-            parent class
+        visible (True): default visibility of the mesh in the scene
+        position (None): the position of the mesh in object space
+        quaternion (None): the quaternion of the mesh in object space
+        scale (None): the scale of the mesh in object space
     """
 
     pass
@@ -39,7 +42,10 @@ class BoxGeometry(Shape3D):
         material (:class:`fiftyone.core.threed.MeshMaterial`, optional):
             default material for the box. Defaults to
             :class:`fiftyone.core.threed.MeshStandardMaterial`
-        **kwargs: keyword arguments for the :class:`Shape3D` parent class
+        visible (True): default visibility of the mesh in the scene
+        position (None): the position of the mesh in object space
+        quaternion (None): the quaternion of the mesh in object space
+        scale (None): the scale of the mesh in object space
     """
 
     def __init__(
@@ -49,9 +55,19 @@ class BoxGeometry(Shape3D):
         height: float = 1,
         depth: float = 1,
         default_material: Optional[MeshMaterial] = None,
-        **kwargs
+        visible=True,
+        position: Optional[Vec3UnionType] = None,
+        scale: Optional[Vec3UnionType] = None,
+        quaternion: Optional[Quaternion] = None,
     ):
-        super().__init__(name=name, material=default_material, **kwargs)
+        super().__init__(
+            name=name,
+            material=default_material,
+            visible=visible,
+            position=position,
+            scale=scale,
+            quaternion=quaternion,
+        )
         self.width = width
         self.height = height
         self.depth = depth
@@ -90,7 +106,10 @@ class CylinderGeometry(Shape3D):
         material (:class:`fiftyone.core.threed.MeshMaterial`, optional):
             default material for the cylinder. Defaults to
             :class:`fiftyone.core.threed.MeshStandardMaterial`
-        **kwargs: keyword arguments for the :class:`Shape3D` parent class
+        visible (True): default visibility of the mesh in the scene
+        position (None): the position of the mesh in object space
+        quaternion (None): the quaternion of the mesh in object space
+        scale (None): the scale of the mesh in object space
     """
 
     def __init__(
@@ -105,9 +124,19 @@ class CylinderGeometry(Shape3D):
         theta_start: float = 0,
         theta_length: float = 2 * math.pi,
         default_material: Optional[MeshMaterial] = None,
-        **kwargs
+        visible=True,
+        position: Optional[Vec3UnionType] = None,
+        scale: Optional[Vec3UnionType] = None,
+        quaternion: Optional[Quaternion] = None,
     ):
-        super().__init__(name=name, material=default_material, **kwargs)
+        super().__init__(
+            name=name,
+            material=default_material,
+            visible=visible,
+            position=position,
+            scale=scale,
+            quaternion=quaternion,
+        )
         self.radius_top = radius_top
         self.radius_bottom = radius_bottom
         self.height = height
@@ -154,7 +183,10 @@ class SphereGeometry(Shape3D):
         material (:class:`fiftyone.core.threed.MeshMaterial`, optional):
             the default material for the sphere. Defaults to
             :class:`fiftyone.core.threed.MeshStandardMaterial`
-        **kwargs: keyword arguments for the :class:`Shape3D` parent class
+        visible (True): default visibility of the mesh in the scene
+        position (None): the position of the mesh in object space
+        quaternion (None): the quaternion of the mesh in object space
+        scale (None): the scale of the mesh in object space
     """
 
     def __init__(
@@ -168,9 +200,19 @@ class SphereGeometry(Shape3D):
         theta_start: float = 0,
         theta_length: float = math.pi,
         default_material: Optional[MeshMaterial] = None,
-        **kwargs
+        visible=True,
+        position: Optional[Vec3UnionType] = None,
+        scale: Optional[Vec3UnionType] = None,
+        quaternion: Optional[Quaternion] = None,
     ):
-        super().__init__(name=name, material=default_material, **kwargs)
+        super().__init__(
+            name=name,
+            material=default_material,
+            visible=visible,
+            position=position,
+            scale=scale,
+            quaternion=quaternion,
+        )
         self.radius = radius
         self.width_segments = width_segments
         self.height_segments = height_segments
@@ -204,7 +246,10 @@ class PlaneGeometry(Shape3D):
         material (:class:`fiftyone.core.threed.MeshMaterial`, optional):
             the default material for the plane. Defaults to
             :class:`fiftyone.core.threed.MeshStandardMaterial`
-        **kwargs: keyword arguments for the :class:`Shape3D` parent class
+        visible (True): default visibility of the mesh in the scene
+        position (None): the position of the mesh in object space
+        quaternion (None): the quaternion of the mesh in object space
+        scale (None): the scale of the mesh in object space
     """
 
     def __init__(
@@ -213,9 +258,19 @@ class PlaneGeometry(Shape3D):
         width: float = 1,
         height: float = 1,
         default_material: Optional[MeshMaterial] = None,
-        **kwargs
+        visible=True,
+        position: Optional[Vec3UnionType] = None,
+        scale: Optional[Vec3UnionType] = None,
+        quaternion: Optional[Quaternion] = None,
     ):
-        super().__init__(name=name, material=default_material, **kwargs)
+        super().__init__(
+            name=name,
+            material=default_material,
+            visible=visible,
+            position=position,
+            scale=scale,
+            quaternion=quaternion,
+        )
         self.width = width
         self.height = height
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

In service of `Explicit is better than implicit`, I like putting all inherited args in the child class docstring and init up front. This way you see exactly how to create an instance and don't have to hop back and forth in the family tree.

The flip side is that there is a lot of duplication and if an arg is added to `Object3D` then it has to be pushed to all children. I would argue this is an acceptable few-time cost in exchange for more readable code and user documentation.

`**kwargs` is interesting if the args can truly be dynamic, in my opinion.

Open for discussion.

## How is this patch tested? If it is not, please explain why.

unit tests still fine

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved lighting customization with added parameters for visibility, position, scale, and orientation in various light classes.
  - Introduced opacity control for different material types, enabling users to adjust transparency.
  - Updated 3D objects and shapes to include customizable visibility, position, scale, and orientation settings.

- **Refactor**
  - Enhanced constructor parameter lists for lights, materials, meshes, point clouds, and 3D shapes to provide advanced customization options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->