### PR TITLE
Relax pydantic requirement to allow 1 or 2

### DIFF
--- a/fiftyone/core/threed/validators.py
+++ b/fiftyone/core/threed/validators.py
@@ -28,6 +28,6 @@ def normalize_to_vec3(v: Optional[Vec3UnionType]) -> Union[Vector3, None]:
 
 
 def vec3_normalizing_validator(field: str) -> classmethod:
-    decorator = field_validator(field)
+    decorator = field_validator(field, allow_reuse=True)
     validator_class_method = decorator(normalize_to_vec3)
     return validator_class_method

--- a/fiftyone/core/threed/validators.py
+++ b/fiftyone/core/threed/validators.py
@@ -7,7 +7,7 @@ Fiftyone 3D Scene.
 """
 from typing import Optional, Union
 
-from pydantic import field_validator
+from pydantic import validator as field_validator
 
 from .transformation import Vec3UnionType, Vector3
 

--- a/fiftyone/core/threed/validators.py
+++ b/fiftyone/core/threed/validators.py
@@ -7,6 +7,8 @@ Fiftyone 3D Scene.
 """
 from typing import Optional, Union
 
+# Note, this function is deprecated in pydantic V2, however, for backwards
+#   compatibility with V1, we'll use it for now.
 from pydantic import validator as field_validator
 
 from .transformation import Vec3UnionType, Vector3

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ INSTALL_REQUIRES = [
     "plotly>=4.14",
     "pprintpp",
     "psutil",
-    "pydantic",
+    "pydantic>=1.2",
     "pymongo>=3.12",
     "pytz",
     "PyYAML",

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ INSTALL_REQUIRES = [
     "plotly>=4.14",
     "pprintpp",
     "psutil",
-    "pydantic>=2",
+    "pydantic",
     "pymongo>=3.12",
     "pytz",
     "PyYAML",


### PR DESCRIPTION
## What changes are proposed in this pull request?
Relax pydantic requirement in `setup.py` to allow v1 or v2.

Our usage of pydantic is pretty minimal but could be used more in the future so I think requiring pydantic is fine.
That being said, we **must not** break any user setups that must have pydantic v1.

So this change just makes our use of pydantic compatible with both v1 and v2 by using the deprecated `validator` instead of the newer `field_validator`. We can stick with this for a bit then re-evaluate if we do need the features of `field_validator`.

## How is this patch tested? If it is not, please explain why.

unit tests, creating objects and seeing validation still work

```python
import fiftyone.core.threed as fo3d
obj = fo3d.Object3D(name="blah", position=1)
obj.position # (1.0, 1.0, 1.0)
obj.position = "blah"  # validation error
obj.position = 2.0  # (2.0, 2.0, 2.0)
```

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Refactor**
	- Enhanced stability by updating import statements in the 3D module.
- **Chores**
	- Ensured broader compatibility by modifying package dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->