### PR TITLE
Fix overlay processing for empty label lists

### DIFF
--- a/app/packages/looker/src/overlays/index.test.ts
+++ b/app/packages/looker/src/overlays/index.test.ts
@@ -15,4 +15,10 @@ describe("label overlay processing", () => {
       index.fromLabelList(DetectionOverlay, "detections")("field", undefined)
     ).toStrictEqual([]);
   });
+
+  it("resolves empty object label lists", () => {
+    expect(
+      index.fromLabelList(DetectionOverlay, "detections")("field", {})
+    ).toStrictEqual([]);
+  });
 });

--- a/app/packages/looker/src/overlays/index.ts
+++ b/app/packages/looker/src/overlays/index.ts
@@ -31,7 +31,7 @@ export const fromLabel = (overlayType) => (field, label) =>
   label ? [new overlayType(field, label)] : [];
 
 export const fromLabelList = (overlayType, list_key) => (field, labels) =>
-  labels?.[list_key].map((label) => new overlayType(field, label)) ?? [];
+  labels?.[list_key]?.map((label) => new overlayType(field, label)) ?? [];
 
 export { ClassificationsOverlay };
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

Fixes Looker overlay processing for label lists without a list value present, e.g. the below
```python
import fiftyone as fo
import fiftyone.zoo as foz

dataset = foz.load_zoo_dataset("quickstart", max_samples=1)
dataset.set_field("ground_truth", {}).save()

session = fo.launch_app(dataset)
``` 

## How is this patch tested? If it is not, please explain why.

Added test case

## Release Notes

* Fixed the 2D visualizer when label lists, e.g. |Detections| have no list value

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved label overlay processing to handle cases where label lists are empty or contain null values, ensuring more robust functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->