### PR TITLE
Fix temporal detections filtering

### DIFF
--- a/app/packages/looker/src/overlays/classifications.test.ts
+++ b/app/packages/looker/src/overlays/classifications.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+
+import { TEMPORAL_DETECTION, TEMPORAL_DETECTIONS } from "@fiftyone/utilities";
+import { filterTemporalLabel } from "./classifications";
+
+const LABEL_BASE = {
+  id: "",
+  label: "",
+  tags: [],
+};
+
+describe("classification and temporal detection label filtering", () => {
+  it("filters temporal detections", () => {
+    for (const cls of [TEMPORAL_DETECTION, TEMPORAL_DETECTIONS]) {
+      expect(
+        filterTemporalLabel(cls, { ...LABEL_BASE, support: [1, 2] }, 2)
+      ).toBe(true);
+
+      expect(
+        filterTemporalLabel(cls, { ...LABEL_BASE, support: [1, 2] }, 3)
+      ).toBe(false);
+    }
+  });
+});

--- a/app/packages/looker/src/overlays/classifications.ts
+++ b/app/packages/looker/src/overlays/classifications.ts
@@ -2,7 +2,12 @@
  * Copyright 2017-2024, Voxel51, Inc.
  */
 
-import { getCls, REGRESSION, TEMPORAL_DETECTION } from "@fiftyone/utilities";
+import {
+  getCls,
+  REGRESSION,
+  TEMPORAL_DETECTION,
+  TEMPORAL_DETECTIONS,
+} from "@fiftyone/utilities";
 
 import { INFO_COLOR, MOMENT_CLASSIFICATIONS } from "../constants";
 import {
@@ -353,7 +358,11 @@ export class TemporalDetectionOverlay extends ClassificationsOverlay<
         field,
         labels.filter((label) => {
           const shown = isShown(state, field, label) && label.label;
-          if (this.getCls(field, state) === TEMPORAL_DETECTION) {
+          if (
+            [TEMPORAL_DETECTION, TEMPORAL_DETECTIONS].includes(
+              this.getCls(field, state)
+            )
+          ) {
             return (
               shown &&
               label.support[0] <= state.frameNumber &&

--- a/app/packages/looker/src/overlays/classifications.ts
+++ b/app/packages/looker/src/overlays/classifications.ts
@@ -38,6 +38,8 @@ export type ClassificationLabel = Classification & Regression;
 
 export type Labels<T> = [string, T[]][];
 
+const TEMPORAL_LABELS = new Set([TEMPORAL_DETECTION, TEMPORAL_DETECTIONS]);
+
 export class ClassificationsOverlay<
   State extends BaseState,
   Label extends Classification = ClassificationLabel
@@ -358,24 +360,33 @@ export class TemporalDetectionOverlay extends ClassificationsOverlay<
         field,
         labels.filter((label) => {
           const shown = isShown(state, field, label) && label.label;
-          if (
-            [TEMPORAL_DETECTION, TEMPORAL_DETECTIONS].includes(
-              this.getCls(field, state)
-            )
-          ) {
-            return (
-              shown &&
-              label.support[0] <= state.frameNumber &&
-              label.support[1] >= state.frameNumber
-            );
+
+          if (!shown) {
+            return false;
           }
 
-          return shown;
+          const cls = this.getCls(field, state);
+          return filterTemporalLabel(cls, label, state.frameNumber);
         }),
       ];
     });
   }
 }
+
+export const filterTemporalLabel = (
+  cls,
+  label: ClassificationLabel | TemporalDetectionLabel,
+  frameNumber: number
+) => {
+  if (!TEMPORAL_LABELS.has(cls)) {
+    return true;
+  }
+
+  const temporal = label as TemporalDetectionLabel;
+  return (
+    temporal.support[0] <= frameNumber && temporal.support[1] >= frameNumber
+  );
+};
 
 export const getClassificationPoints = (
   labels: ClassificationLabel[]

--- a/app/packages/looker/src/overlays/classifications.ts
+++ b/app/packages/looker/src/overlays/classifications.ts
@@ -374,7 +374,7 @@ export class TemporalDetectionOverlay extends ClassificationsOverlay<
 }
 
 export const filterTemporalLabel = (
-  cls,
+  cls: string,
   label: ClassificationLabel | TemporalDetectionLabel,
   frameNumber: number
 ) => {
@@ -383,6 +383,11 @@ export const filterTemporalLabel = (
   }
 
   const temporal = label as TemporalDetectionLabel;
+
+  if (temporal.support?.length !== 2) {
+    return false;
+  }
+
   return (
     temporal.support[0] <= frameNumber && temporal.support[1] >= frameNumber
   );


### PR DESCRIPTION
## What changes are proposed in this pull request?

Fixes `support` filtering in the expanded view for `TemporalDetections` field values

```python
import fiftyone as fo
import fiftyone.zoo as foz

dataset = foz.load_zoo_dataset("quickstart-video", max_samples=1)
sample = dataset.first()
sample["temporal_list"] = fo.TemporalDetections(
    detections=[fo.TemporalDetection(support=[1, 2], label="test")]
)
sample.save()

session = fo.launch_app(dataset)
``` 

https://github.com/voxel51/fiftyone/assets/19821840/cee28b73-a865-4c35-9745-f400ae2ee198


## How is this patch tested? If it is not, please explain why.

Added test

## Release Notes

* Fixed |TemporalDetections| `support` filtering in expanded 2D visualizer

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced label classification system with support for temporal detections, improving accuracy in frame-specific scenarios.
- **Bug Fixes**
	- Updated filtering logic to correctly handle temporal labels, ensuring more reliable classification results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->