### PR TITLE
Add state processing to the refresh event

### DIFF
--- a/app/packages/app/src/useEvents/useRefresh.ts
+++ b/app/packages/app/src/useEvents/useRefresh.ts
@@ -1,8 +1,7 @@
 import { subscribe } from "@fiftyone/relay";
 import * as fos from "@fiftyone/state";
-import { env } from "@fiftyone/utilities";
 import { useCallback } from "react";
-import { getDatasetName, getParam, resolveURL } from "../utils";
+import { resolveURL } from "../utils";
 import { EventHandlerHook } from "./registerEvent";
 import { processState } from "./utils";
 
@@ -10,14 +9,11 @@ const useRefresh: EventHandlerHook = ({ router, session }) => {
   return useCallback(
     (payload: any) => {
       const state = processState(session.current, payload.state);
-      const stateless = env().VITE_NO_STATE;
       const path = resolveURL({
         currentPathname: router.history.location.pathname,
         currentSearch: router.history.location.search,
-        nextDataset: stateless
-          ? getDatasetName()
-          : payload.state.dataset ?? null,
-        nextView: stateless ? getParam("view") : payload.state.saved_view_slug,
+        nextDataset: payload.state.dataset ?? null,
+        nextView: payload.state.saved_view_slug,
         extra: {
           workspace: state.workspace?._name || null,
         },

--- a/app/packages/app/src/useEvents/useRefresh.ts
+++ b/app/packages/app/src/useEvents/useRefresh.ts
@@ -1,5 +1,6 @@
 import { subscribe } from "@fiftyone/relay";
 import * as fos from "@fiftyone/state";
+import { env } from "@fiftyone/utilities";
 import { useCallback } from "react";
 import { resolveURL } from "../utils";
 import { EventHandlerHook } from "./registerEvent";
@@ -8,6 +9,12 @@ import { processState } from "./utils";
 const useRefresh: EventHandlerHook = ({ router, session }) => {
   return useCallback(
     (payload: any) => {
+      const stateless = env().VITE_NO_STATE;
+      if (stateless) {
+        // skip in e2e
+        return;
+      }
+
       const state = processState(session.current, payload.state);
       const path = resolveURL({
         currentPathname: router.history.location.pathname,

--- a/app/packages/app/src/useEvents/useRefresh.ts
+++ b/app/packages/app/src/useEvents/useRefresh.ts
@@ -1,20 +1,17 @@
 import { subscribe } from "@fiftyone/relay";
 import * as fos from "@fiftyone/state";
-import { env } from "@fiftyone/utilities";
 import { useCallback } from "react";
 import { resolveURL } from "../utils";
 import { EventHandlerHook } from "./registerEvent";
 import { processState } from "./utils";
 
+/**
+ * Handles a session state refresh event from the server and reloads the page
+ * query and aggregation requests
+ */
 const useRefresh: EventHandlerHook = ({ router, session }) => {
   return useCallback(
     (payload: any) => {
-      const stateless = env().VITE_NO_STATE;
-      if (stateless) {
-        // skip in e2e
-        return;
-      }
-
       const state = processState(session.current, payload.state);
       const path = resolveURL({
         currentPathname: router.history.location.pathname,

--- a/app/packages/app/src/useEvents/useRefresh.ts
+++ b/app/packages/app/src/useEvents/useRefresh.ts
@@ -1,8 +1,37 @@
-import { useRefresh as useRefreshState } from "@fiftyone/state";
+import { subscribe } from "@fiftyone/relay";
+import * as fos from "@fiftyone/state";
+import { env } from "@fiftyone/utilities";
+import { useCallback } from "react";
+import { getDatasetName, getParam, resolveURL } from "../utils";
 import { EventHandlerHook } from "./registerEvent";
+import { processState } from "./utils";
 
-const useRefresh: EventHandlerHook = () => {
-  return useRefreshState();
+const useRefresh: EventHandlerHook = ({ router, session }) => {
+  return useCallback(
+    (payload: any) => {
+      const state = processState(session.current, payload.state);
+      const stateless = env().VITE_NO_STATE;
+      const path = resolveURL({
+        currentPathname: router.history.location.pathname,
+        currentSearch: router.history.location.search,
+        nextDataset: stateless
+          ? getDatasetName()
+          : payload.state.dataset ?? null,
+        nextView: stateless ? getParam("view") : payload.state.saved_view_slug,
+        extra: {
+          workspace: state.workspace?._name || null,
+        },
+      });
+
+      const unsubscribe = subscribe((_, { set }) => {
+        set(fos.refresher, (cur) => cur + 1);
+        unsubscribe();
+      });
+
+      router.history.replace(path, state);
+    },
+    [router, session]
+  );
 };
 
 export default useRefresh;


### PR DESCRIPTION
## What changes are proposed in this pull request?

Adds `state` processing to the `Refresh` event

### Updating view in-place

```pyt
import fiftyone as fo
import fiftyone.zoo as foz

dataset = foz.load_zoo_dataset("quickstart")
view = dataset.limit(10)

session = fo.launch_app(view)

# Modify view in-place
session.view._stages[0]._limit = 20
session.refresh()
``` 

### Updating spaces in-place

```py
import fiftyone as fo
import fiftyone.brain as fob
import fiftyone.zoo as foz

dataset = foz.load_zoo_dataset("quickstart")
fob.compute_visualization(dataset, brain_key="img_viz")

samples_panel = fo.Panel(type="Samples", pinned=True)

embeddings_panel = fo.Panel(
    type="Embeddings",
    state=dict(brainResult="img_viz"),
)

spaces = fo.Space(
    children=[samples_panel, embeddings_panel],
    orientation="horizontal",
)

session = fo.launch_app(dataset, spaces=spaces)

# Update spaces in-place
session.spaces.children[1].state["colorByField"] = "metadata.size_bytes"
session.refresh()
```

## How is this patch tested? If it is not, please explain why.

TODO

## Release Notes

* Added state updates to :meth:`session.refresh() <fiftyone.core.session.Session.refresh>`

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Refactor**
	- Improved the `useRefresh` function to enhance state management, event subscription handling, and dependency utilization for better app performance and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->