### PR TITLE
Render ply as pcd if specified in the SDK

### DIFF
--- a/app/packages/looker-3d/src/fo3d/mesh/Ply.tsx
+++ b/app/packages/looker-3d/src/fo3d/mesh/Ply.tsx
@@ -1,15 +1,17 @@
 import { getSampleSrc } from "@fiftyone/state";
 import { useLoader } from "@react-three/fiber";
-import { useEffect, useMemo, useState } from "react";
-import { BufferGeometry, Mesh, Quaternion, Vector3 } from "three";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { BufferGeometry, Mesh, Points, Quaternion, Vector3 } from "three";
 import { PLYLoader } from "three/examples/jsm/loaders/PLYLoader";
 import {
   FoMeshBasicMaterialProps,
   FoMeshMaterial,
+  FoPointcloudMaterialProps,
   PlyAsset,
 } from "../../hooks";
 import { useMeshMaterialControls } from "../../hooks/use-mesh-material-controls";
 import { useFo3dContext } from "../context";
+import { usePcdMaterial } from "../point-cloud/use-pcd-material";
 import { getBasePathForTextures, getResolvedUrlForFo3dAsset } from "../utils";
 
 interface PlyProps {
@@ -20,6 +22,45 @@ interface PlyProps {
   scale: Vector3;
   children?: React.ReactNode;
 }
+
+const PlyWithPointsMaterial = ({
+  name,
+  geometry,
+  defaultMaterial,
+}: {
+  name: string;
+  geometry: BufferGeometry;
+  defaultMaterial: FoMeshMaterial;
+}) => {
+  const overrideMaterial = {
+    shadingMode: "height",
+    customColor: defaultMaterial["color"] ?? "#ffffff",
+    pointSize: 2,
+    attenuateByDistance: false,
+    opacity: defaultMaterial.opacity,
+  } as FoPointcloudMaterialProps;
+
+  const pointsContainerRef = useRef();
+
+  const pointsMaterialJsx = usePcdMaterial(
+    name,
+    geometry,
+    overrideMaterial,
+    pointsContainerRef
+  );
+
+  const mesh = useMemo(() => new Points(geometry), [geometry]);
+
+  if (!geometry || !pointsMaterialJsx) {
+    return null;
+  }
+
+  return (
+    <primitive ref={pointsContainerRef} object={mesh}>
+      {pointsMaterialJsx}
+    </primitive>
+  );
+};
 
 const PlyWithMaterialOverride = ({
   name,
@@ -77,7 +118,7 @@ const PlyWithNoMaterialOverride = ({
 
 export const Ply = ({
   name,
-  ply: { plyPath, preTransformedPlyPath, defaultMaterial },
+  ply: { plyPath, preTransformedPlyPath, defaultMaterial, isPcd },
   position,
   quaternion,
   scale,
@@ -129,6 +170,16 @@ export const Ply = ({
       return null;
     }
 
+    if (isPcd) {
+      return (
+        <PlyWithPointsMaterial
+          name={name}
+          geometry={geometry}
+          defaultMaterial={defaultMaterial}
+        />
+      );
+    }
+
     if (isUsingVertexColors) {
       return (
         <PlyWithMaterialOverride
@@ -150,6 +201,7 @@ export const Ply = ({
     isGeometryResolved,
     isUsingVertexColors,
     geometry,
+    isPcd,
     name,
     defaultMaterial,
   ]);

--- a/app/packages/looker-3d/src/fo3d/mesh/Ply.tsx
+++ b/app/packages/looker-3d/src/fo3d/mesh/Ply.tsx
@@ -42,7 +42,7 @@ const PlyWithPointsMaterial = ({
 
   const pointsContainerRef = useRef();
 
-  const pointsMaterialJsx = usePcdMaterial(
+  const pointsMaterialElement = usePcdMaterial(
     name,
     geometry,
     overrideMaterial,
@@ -51,13 +51,13 @@ const PlyWithPointsMaterial = ({
 
   const mesh = useMemo(() => new Points(geometry), [geometry]);
 
-  if (!geometry || !pointsMaterialJsx) {
+  if (!geometry || !pointsMaterialElement) {
     return null;
   }
 
   return (
     <primitive ref={pointsContainerRef} object={mesh}>
-      {pointsMaterialJsx}
+      {pointsMaterialElement}
     </primitive>
   );
 };

--- a/app/packages/looker-3d/src/fo3d/point-cloud/Pcd.tsx
+++ b/app/packages/looker-3d/src/fo3d/point-cloud/Pcd.tsx
@@ -35,7 +35,7 @@ export const Pcd = ({
   const points = useLoader(PCDLoader, pcdUrl);
   const pcdContainerRef = useRef();
 
-  const pointsMaterialJsx = usePcdMaterial(
+  const pointsMaterialElement = usePcdMaterial(
     name,
     points.geometry,
     defaultMaterial,
@@ -54,7 +54,7 @@ export const Pcd = ({
       quaternion={quaternion}
       scale={scale}
     >
-      {pointsMaterialJsx}
+      {pointsMaterialElement}
       {children ?? null}
     </primitive>
   );

--- a/app/packages/looker-3d/src/fo3d/point-cloud/Pcd.tsx
+++ b/app/packages/looker-3d/src/fo3d/point-cloud/Pcd.tsx
@@ -1,27 +1,12 @@
 import { getSampleSrc } from "@fiftyone/state";
 import { useLoader } from "@react-three/fiber";
-import { useCallback, useMemo, useRef } from "react";
+import { useMemo, useRef } from "react";
 import { Quaternion, Vector3 } from "three";
 import { PCDLoader } from "three/examples/jsm/loaders/PCDLoader";
-import {
-  PCD_SHADING_GRADIENTS,
-  SHADE_BY_CUSTOM,
-  SHADE_BY_HEIGHT,
-  SHADE_BY_INTENSITY,
-  SHADE_BY_RGB,
-} from "../../constants";
 import { PcdAsset } from "../../hooks";
-import { useFo3dBounds } from "../../hooks/use-bounds";
-import { usePcdMaterialControls } from "../../hooks/use-pcd-material-controls";
-import {
-  CustomColorShader,
-  RgbShader,
-  ShadeByHeight,
-  ShadeByIntensity,
-} from "../../renderables/pcd/shaders";
-import { computeMinMaxForColorBufferAttribute } from "../../utils";
 import { useFo3dContext } from "../context";
 import { getResolvedUrlForFo3dAsset } from "../utils";
+import { usePcdMaterial } from "./use-pcd-material";
 
 export const Pcd = ({
   name,
@@ -38,7 +23,7 @@ export const Pcd = ({
   scale: Vector3;
   children?: React.ReactNode;
 }) => {
-  const { upVector, pluginSettings, fo3dRoot } = useFo3dContext();
+  const { fo3dRoot } = useFo3dContext();
 
   const pcdUrl = useMemo(
     () =>
@@ -50,129 +35,12 @@ export const Pcd = ({
   const points = useLoader(PCDLoader, pcdUrl);
   const pcdContainerRef = useRef();
 
-  const { customColor, pointSize, isPointSizeAttenuated, shadeBy, opacity } =
-    usePcdMaterialControls(name, defaultMaterial);
-
-  const pcdBoundingBox = useFo3dBounds(
-    pcdContainerRef,
-    useCallback(() => {
-      return !!points && shadeBy === SHADE_BY_HEIGHT;
-    }, [points, shadeBy])
-  );
-
-  const minMaxCoordinates = useMemo(() => {
-    if (shadeBy !== SHADE_BY_HEIGHT || !pcdBoundingBox || !upVector) {
-      return null;
-    }
-
-    // note: we should deprecate minZ in the plugin settings, since it doesn't account for non-z up vectors
-    if (pluginSettings?.pointCloud?.minZ) {
-      return [pluginSettings.pointCloud.minZ, pcdBoundingBox.max.z];
-    }
-
-    const min = pcdBoundingBox.min.dot(upVector);
-    const max = pcdBoundingBox.max.dot(upVector);
-
-    return [min, max];
-  }, [upVector, pcdBoundingBox, shadeBy, pluginSettings]);
-
-  const { min: minIntensity, max: maxIntensity } = useMemo(() => {
-    if (shadeBy !== SHADE_BY_INTENSITY || !points) {
-      return { min: 0, max: 1 };
-    }
-
-    const intensity =
-      points.geometry.getAttribute("color") ??
-      points.geometry.getAttribute("intensity");
-
-    if (intensity) {
-      return computeMinMaxForColorBufferAttribute(intensity);
-    }
-
-    return { min: 0, max: 1 };
-  }, [points, shadeBy]);
-
-  const pointsMaterial = useMemo(() => {
-    // to trigger rerender
-    const key = `${name}-${opacity}-${pointSize}-${isPointSizeAttenuated}-${shadeBy}-${customColor}-${minMaxCoordinates}-${minIntensity}-${maxIntensity}-${upVector}`;
-
-    switch (shadeBy) {
-      case SHADE_BY_HEIGHT:
-        /**
-         * FIX ME: while `pointsMaterial` respects `upVector` in shade-by-height, it disregards rotation / translation / scale
-         * applied to the pcd. This is because the shader is applied to the points, not the pcd container.
-         *
-         * The behavior is undefined if the pcd is rotated / translated / scaled.
-         */
-        return (
-          <ShadeByHeight
-            gradients={PCD_SHADING_GRADIENTS}
-            min={minMaxCoordinates?.at(0) ?? 0}
-            max={minMaxCoordinates?.at(1) ?? 100}
-            upVector={upVector}
-            key={key}
-            pointSize={pointSize}
-            opacity={opacity}
-            isPointSizeAttenuated={isPointSizeAttenuated}
-          />
-        );
-
-      case SHADE_BY_INTENSITY:
-        return (
-          <ShadeByIntensity
-            key={key}
-            min={minIntensity}
-            max={maxIntensity}
-            gradients={PCD_SHADING_GRADIENTS}
-            pointSize={pointSize}
-            opacity={opacity}
-            isPointSizeAttenuated={isPointSizeAttenuated}
-          />
-        );
-
-      case SHADE_BY_RGB:
-        return (
-          <RgbShader
-            pointSize={pointSize}
-            opacity={opacity}
-            isPointSizeAttenuated={isPointSizeAttenuated}
-          />
-        );
-
-      case SHADE_BY_CUSTOM:
-        return (
-          <CustomColorShader
-            key={key}
-            pointSize={pointSize}
-            opacity={opacity}
-            isPointSizeAttenuated={isPointSizeAttenuated}
-            color={customColor || "#ffffff"}
-          />
-        );
-      default:
-        return (
-          <pointsMaterial
-            color={"white"}
-            // color={defaultShadingColor}
-            // 1000 and 2 are arbitrary values that seem to work well
-            size={isPointSizeAttenuated ? pointSize / 1000 : pointSize / 2}
-            opacity={opacity}
-            sizeAttenuation={isPointSizeAttenuated}
-          />
-        );
-    }
-  }, [
-    shadeBy,
-    pointSize,
-    isPointSizeAttenuated,
-    customColor,
-    minMaxCoordinates,
-    minIntensity,
-    maxIntensity,
-    upVector,
-    opacity,
+  const pointsMaterialJsx = usePcdMaterial(
     name,
-  ]);
+    points.geometry,
+    defaultMaterial,
+    pcdContainerRef
+  );
 
   if (!points) {
     return null;
@@ -186,7 +54,7 @@ export const Pcd = ({
       quaternion={quaternion}
       scale={scale}
     >
-      {pointsMaterial}
+      {pointsMaterialJsx}
       {children ?? null}
     </primitive>
   );

--- a/app/packages/looker-3d/src/fo3d/point-cloud/use-pcd-material.tsx
+++ b/app/packages/looker-3d/src/fo3d/point-cloud/use-pcd-material.tsx
@@ -1,0 +1,154 @@
+import { useCallback, useMemo } from "react";
+import { BufferGeometry } from "three";
+import {
+  PCD_SHADING_GRADIENTS,
+  SHADE_BY_CUSTOM,
+  SHADE_BY_HEIGHT,
+  SHADE_BY_INTENSITY,
+  SHADE_BY_RGB,
+} from "../../constants";
+import { PcdAsset } from "../../hooks";
+import { useFo3dBounds } from "../../hooks/use-bounds";
+import { usePcdMaterialControls } from "../../hooks/use-pcd-material-controls";
+import {
+  CustomColorShader,
+  RgbShader,
+  ShadeByHeight,
+  ShadeByIntensity,
+} from "../../renderables/pcd/shaders";
+import { computeMinMaxForColorBufferAttribute } from "../../utils";
+import { useFo3dContext } from "../context";
+
+export const usePcdMaterial = (
+  name: string,
+  geometry: BufferGeometry,
+  defaultMaterial: PcdAsset["defaultMaterial"],
+  pcdContainerRef: React.RefObject<any>
+) => {
+  const { upVector, pluginSettings } = useFo3dContext();
+
+  const { customColor, pointSize, isPointSizeAttenuated, shadeBy, opacity } =
+    usePcdMaterialControls(name, defaultMaterial);
+
+  const pcdBoundingBox = useFo3dBounds(
+    pcdContainerRef,
+    useCallback(() => {
+      return !!geometry && shadeBy === SHADE_BY_HEIGHT;
+    }, [geometry, shadeBy])
+  );
+
+  const minMaxCoordinates = useMemo(() => {
+    if (shadeBy !== SHADE_BY_HEIGHT || !pcdBoundingBox || !upVector) {
+      return null;
+    }
+
+    // note: we should deprecate minZ in the plugin settings, since it doesn't account for non-z up vectors
+    if (pluginSettings?.pointCloud?.minZ) {
+      return [pluginSettings.pointCloud.minZ, pcdBoundingBox.max.z];
+    }
+
+    const min = pcdBoundingBox.min.dot(upVector);
+    const max = pcdBoundingBox.max.dot(upVector);
+
+    return [min, max];
+  }, [upVector, pcdBoundingBox, shadeBy, pluginSettings]);
+
+  const { min: minIntensity, max: maxIntensity } = useMemo(() => {
+    if (shadeBy !== SHADE_BY_INTENSITY || !geometry) {
+      return { min: 0, max: 1 };
+    }
+
+    const intensity =
+      geometry.getAttribute("color") ?? geometry.getAttribute("intensity");
+
+    if (intensity) {
+      return computeMinMaxForColorBufferAttribute(intensity);
+    }
+
+    return { min: 0, max: 1 };
+  }, [geometry, shadeBy]);
+
+  const pointsMaterial = useMemo(() => {
+    // to trigger rerender
+    const key = `${name}-${opacity}-${pointSize}-${isPointSizeAttenuated}-${shadeBy}-${customColor}-${minMaxCoordinates}-${minIntensity}-${maxIntensity}-${upVector}`;
+
+    switch (shadeBy) {
+      case SHADE_BY_HEIGHT:
+        /**
+         * FIX ME: while `pointsMaterial` respects `upVector` in shade-by-height, it disregards rotation / translation / scale
+         * applied to the pcd. This is because the shader is applied to the points, not the pcd container.
+         *
+         * The behavior is undefined if the pcd is rotated / translated / scaled.
+         */
+        return (
+          <ShadeByHeight
+            gradients={PCD_SHADING_GRADIENTS}
+            min={minMaxCoordinates?.at(0) ?? 0}
+            max={minMaxCoordinates?.at(1) ?? 100}
+            upVector={upVector}
+            key={key}
+            pointSize={pointSize}
+            opacity={opacity}
+            isPointSizeAttenuated={isPointSizeAttenuated}
+          />
+        );
+
+      case SHADE_BY_INTENSITY:
+        return (
+          <ShadeByIntensity
+            key={key}
+            min={minIntensity}
+            max={maxIntensity}
+            gradients={PCD_SHADING_GRADIENTS}
+            pointSize={pointSize}
+            opacity={opacity}
+            isPointSizeAttenuated={isPointSizeAttenuated}
+          />
+        );
+
+      case SHADE_BY_RGB:
+        return (
+          <RgbShader
+            pointSize={pointSize}
+            opacity={opacity}
+            isPointSizeAttenuated={isPointSizeAttenuated}
+          />
+        );
+
+      case SHADE_BY_CUSTOM:
+        return (
+          <CustomColorShader
+            key={key}
+            pointSize={pointSize}
+            opacity={opacity}
+            isPointSizeAttenuated={isPointSizeAttenuated}
+            color={customColor || "#ffffff"}
+          />
+        );
+      default:
+        return (
+          <pointsMaterial
+            color={"#ffffff"}
+            // 1000 and 2 are arbitrary values that seem to work well
+            size={isPointSizeAttenuated ? pointSize / 1000 : pointSize / 2}
+            opacity={opacity}
+            sizeAttenuation={isPointSizeAttenuated}
+          />
+        );
+    }
+  }, [
+    shadeBy,
+    pointSize,
+    isPointSizeAttenuated,
+    customColor,
+    minMaxCoordinates,
+    minIntensity,
+    maxIntensity,
+    geometry,
+    upVector,
+    opacity,
+    name,
+  ]);
+
+  return pointsMaterial;
+};

--- a/app/packages/looker-3d/src/hooks/use-fo3d.ts
+++ b/app/packages/looker-3d/src/hooks/use-fo3d.ts
@@ -102,7 +102,8 @@ export class PlyAsset {
   constructor(
     readonly plyPath?: string,
     readonly preTransformedPlyPath?: string,
-    readonly defaultMaterial?: FoMeshMaterial
+    readonly defaultMaterial?: FoMeshMaterial,
+    readonly isPcd?: boolean
   ) {}
 }
 
@@ -304,7 +305,8 @@ export const useFo3d = (
             asset = new PlyAsset(
               node["plyPath"],
               node["preTransformedPlyPath"],
-              material as FoMeshMaterial
+              material as FoMeshMaterial,
+              node["isPointCloud"] ?? false
             );
           }
         }

--- a/app/packages/looker-3d/src/hooks/use-pcd-material-controls.ts
+++ b/app/packages/looker-3d/src/hooks/use-pcd-material-controls.ts
@@ -32,16 +32,16 @@ export const usePcdMaterialControls = (
       [name]: folder(
         {
           pointSize: {
-            value: pointSize,
-            min: 0.1,
+            value: pointSize ?? 1,
+            min: 0.01,
             max: 20,
-            step: 0.1,
+            step: 0.01,
             onChange: onChangeTextBox,
             label: "Points Size",
             order: -2,
           },
           shadeBy: {
-            value: shadeBy,
+            value: shadeBy ?? SHADE_BY_HEIGHT,
             options: [
               SHADE_BY_NONE,
               SHADE_BY_HEIGHT,
@@ -65,7 +65,7 @@ export const usePcdMaterialControls = (
             },
           },
           isPointSizeAttenuated: {
-            value: isPointSizeAttenuated,
+            value: isPointSizeAttenuated ?? false,
             onChange: setIsPointSizeAttenuated,
             label: "Attenuated",
             order: 1000,

--- a/fiftyone/core/threed/mesh.py
+++ b/fiftyone/core/threed/mesh.py
@@ -235,7 +235,10 @@ class PlyMesh(Mesh):
         self.is_point_cloud = is_point_cloud
 
     def _to_dict_extra(self):
-        r = {**super()._to_dict_extra(), **{"plyPath": self.ply_path}}
+        r = {
+            **super()._to_dict_extra(),
+            **{"plyPath": self.ply_path, "isPointCloud": self.is_point_cloud},
+        }
 
         if hasattr(self, "_pre_transformed_ply_path"):
             r["preTransformedPlyPath"] = self._pre_transformed_ply_path


### PR DESCRIPTION
## What changes are proposed in this pull request?

When constructing a `fo.PlyMesh`, it's possible to mark it as a point cloud, in which case the app should render it as a point cloud. Currently, the ply is rendered as a mesh even when it's flagged as a point cloud. This PR fixes that.


<img width="1129" alt="Screenshot 2024-05-03 at 3 55 05 PM" src="https://github.com/voxel51/fiftyone/assets/66688606/bb21fa78-77aa-4b2c-ae48-5e63f4792fef">


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new `PlyWithPointsMaterial` component for enhanced 3D visualization.
  - Implemented a custom hook `usePcdMaterial` to generate dynamic materials for point cloud visualization.
  - Added an `isPcd` property to the `PlyAsset` class to identify point cloud assets.
  
- **Enhancements**
  - Updated material handling in the `Pcd` component for improved performance and simplicity.
  - Adjusted default settings and range values in `usePcdMaterialControls` for better control over point cloud rendering.

- **Refactor**
  - Streamlined imports across various components to optimize dependencies and maintenance.
  
- **Bug Fixes**
  - Fixed dictionary structure in the `Mesh` class to include `isPointCloud` status, enhancing data integrity and usage clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->