### PR TITLE
Fix concurrency bugs when updating views/workspaces/group-slices

### DIFF
--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -3590,7 +3590,7 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
 
         # Targeted reload of saved views for better concurrency safety.
         # @todo improve list field updates in general so this isn't necessary
-        self._doc.reload(["saved_views"])
+        self._doc.reload("saved_views")
 
         self._doc.saved_views.append(view_doc)
         self.save()
@@ -3710,7 +3710,7 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
 
         # Targeted reload of saved views for better concurrency safety.
         # @todo improve list field updates in general so this isn't necessary
-        self._doc.reload(["saved_views"])
+        self._doc.reload("saved_views")
 
         for view_doc in self._doc.saved_views:
             if isinstance(view_doc, DBRef):
@@ -3741,7 +3741,7 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
             # Targeted reload of saved views for better concurrency safety.
             # @todo improve list field updates in general so this
             #   isn't necessary
-            self._doc.reload(["saved_views"])
+            self._doc.reload("saved_views")
 
         for i, view_doc in enumerate(self._doc.get_saved_views()):
             if name == getattr(view_doc, key):
@@ -3895,7 +3895,7 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
 
         # Targeted reload of workspaces for better concurrency safety.
         # @todo improve list field updates in general so this isn't necessary
-        self._doc.reload(["workspaces"])
+        self._doc.reload("workspaces")
 
         self._doc.workspaces.append(workspace_doc)
         self.save()
@@ -4038,7 +4038,7 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
 
         # Targeted reload of workspaces for better concurrency safety.
         # @todo improve list field updates in general so this isn't necessary
-        self._doc.reload(["workspaces"])
+        self._doc.reload("workspaces")
 
         for workspace_doc in self._doc.workspaces:
             if isinstance(workspace_doc, DBRef):
@@ -4076,7 +4076,7 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
             # Targeted reload of workspaces for better concurrency safety.
             # @todo improve list field updates in general so this
             #   isn't necessary
-            self._doc.reload(["workspaces"])
+            self._doc.reload("workspaces")
 
         for i, workspace_doc in enumerate(self._doc.get_workspaces()):
             if name == getattr(workspace_doc, key):

--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -3588,6 +3588,10 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
         )
         view_doc.save(upsert=True)
 
+        # Targeted reload of saved views for better concurrency safety.
+        # @todo improve list field updates in general so this isn't necessary
+        self._doc.reload(["saved_views"])
+
         self._doc.saved_views.append(view_doc)
         self.save()
 
@@ -3703,6 +3707,11 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
 
     def delete_saved_views(self):
         """Deletes all saved views from this dataset."""
+
+        # Targeted reload of saved views for better concurrency safety.
+        # @todo improve list field updates in general so this isn't necessary
+        self._doc.reload(["saved_views"])
+
         for view_doc in self._doc.saved_views:
             if isinstance(view_doc, DBRef):
                 continue
@@ -3727,6 +3736,12 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
     def _get_saved_view_doc(self, name, pop=False, slug=False):
         idx = None
         key = "slug" if slug else "name"
+
+        if pop:
+            # Targeted reload of saved views for better concurrency safety.
+            # @todo improve list field updates in general so this
+            #   isn't necessary
+            self._doc.reload(["saved_views"])
 
         for i, view_doc in enumerate(self._doc.get_saved_views()):
             if name == getattr(view_doc, key):
@@ -3878,6 +3893,10 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
 
         workspace_doc.save(upsert=True)
 
+        # Targeted reload of workspaces for better concurrency safety.
+        # @todo improve list field updates in general so this isn't necessary
+        self._doc.reload(["workspaces"])
+
         self._doc.workspaces.append(workspace_doc)
         self.save()
 
@@ -4016,6 +4035,11 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
 
     def delete_workspaces(self):
         """Deletes all saved workspaces from this dataset."""
+
+        # Targeted reload of workspaces for better concurrency safety.
+        # @todo improve list field updates in general so this isn't necessary
+        self._doc.reload(["workspaces"])
+
         for workspace_doc in self._doc.workspaces:
             if isinstance(workspace_doc, DBRef):
                 continue
@@ -4047,6 +4071,12 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
     def _get_workspace_doc(self, name, pop=False, slug=False):
         idx = None
         key = "slug" if slug else "name"
+
+        if pop:
+            # Targeted reload of workspaces for better concurrency safety.
+            # @todo improve list field updates in general so this
+            #   isn't necessary
+            self._doc.reload(["workspaces"])
 
         for i, workspace_doc in enumerate(self._doc.get_workspaces()):
             if name == getattr(workspace_doc, key):

--- a/tests/unittests/dataset_tests.py
+++ b/tests/unittests/dataset_tests.py
@@ -3095,7 +3095,7 @@ class DatasetExtrasTests(unittest.TestCase):
         also_dataset = fo.load_dataset(dataset.name)
         self.assertIsNot(dataset, also_dataset)
 
-        # Test add save view safety
+        # Test add workspace safety
         dataset.save_workspace("ws1", space)
         also_dataset.save_workspace("ws2", space)
 
@@ -3104,14 +3104,14 @@ class DatasetExtrasTests(unittest.TestCase):
         dataset.reload()
         self.assertListEqual(dataset.list_workspaces(), ["ws1", "ws2"])
 
-        # Test delete saved view safety
+        # Test delete workspace safety
         also_dataset.reload()
         dataset.delete_workspace("ws1")
         also_dataset.delete_workspace("ws2")
         dataset.reload()
         self.assertListEqual(dataset.list_workspaces(), [])
 
-        # Test delete all saved views safety
+        # Test delete all workspaces safety
         also_dataset.reload()
         dataset.save_workspace("ws1", space)
         also_dataset.delete_workspaces()

--- a/tests/unittests/dataset_tests.py
+++ b/tests/unittests/dataset_tests.py
@@ -2858,6 +2858,40 @@ class DatasetExtrasTests(unittest.TestCase):
 
         self.assertListEqual(dataset._doc.saved_views, [])
 
+    @drop_datasets
+    def test_concurrent_saved_view_updates(self):
+        dataset = fo.Dataset()
+        v = dataset.limit(2)
+
+        # Don't reuse singleton; we want to test concurrent edits here
+        dataset._instances.pop(dataset.name)
+        also_dataset = fo.load_dataset(dataset.name)
+        v2 = also_dataset.limit(5)
+        self.assertIsNot(dataset, also_dataset)
+
+        # Test add save view safety
+        dataset.save_view("view1", v)
+        also_dataset.save_view("view2", v2)
+
+        self.assertListEqual(dataset.list_saved_views(), ["view1"])
+
+        dataset.reload()
+        self.assertListEqual(dataset.list_saved_views(), ["view1", "view2"])
+
+        # Test delete saved view safety
+        also_dataset.reload()
+        dataset.delete_saved_view("view1")
+        also_dataset.delete_saved_view("view2")
+        dataset.reload()
+        self.assertListEqual(dataset.list_saved_views(), [])
+
+        # Test delete all saved views safety
+        also_dataset.reload()
+        dataset.save_view("view1", v)
+        also_dataset.delete_saved_views()
+        also_dataset.reload()
+        self.assertListEqual(also_dataset.list_saved_views(), [])
+
     def test_workspaces(self):
         dataset = self.dataset
 
@@ -3050,6 +3084,39 @@ class DatasetExtrasTests(unittest.TestCase):
         dataset.delete_workspaces()
 
         self.assertListEqual(dataset._doc.workspaces, [])
+
+    @drop_datasets
+    def test_concurrent_workspace_updates(self):
+        dataset = fo.Dataset()
+        space = fo.Space()
+
+        # Don't reuse singleton; we want to test concurrent edits here
+        dataset._instances.pop(dataset.name)
+        also_dataset = fo.load_dataset(dataset.name)
+        self.assertIsNot(dataset, also_dataset)
+
+        # Test add save view safety
+        dataset.save_workspace("ws1", space)
+        also_dataset.save_workspace("ws2", space)
+
+        self.assertListEqual(dataset.list_workspaces(), ["ws1"])
+
+        dataset.reload()
+        self.assertListEqual(dataset.list_workspaces(), ["ws1", "ws2"])
+
+        # Test delete saved view safety
+        also_dataset.reload()
+        dataset.delete_workspace("ws1")
+        also_dataset.delete_workspace("ws2")
+        dataset.reload()
+        self.assertListEqual(dataset.list_workspaces(), [])
+
+        # Test delete all saved views safety
+        also_dataset.reload()
+        dataset.save_workspace("ws1", space)
+        also_dataset.delete_workspaces()
+        also_dataset.reload()
+        self.assertListEqual(also_dataset.list_workspaces(), [])
 
     def test_runs(self):
         dataset = self.dataset


### PR DESCRIPTION
## What changes are proposed in this pull request?

Improve concurrent edits of saved views and workspaces by getting out our reload salt shaker and sprinkling it around.

Improve concurrent edits of group slices by shaking it some more AND converting `dict.pop(key)` to `del dict[key]` (see https://github.com/voxel51/fiftyone/pull/4323/). As opposed to 4323, we do need to do the targeted reload also here because of the `default_group_slice` field that should be in sync. The last part of the added groups test exercises this.

a la https://github.com/voxel51/fiftyone/pull/3308
As explained in the todo, this is a bit of a hack to specifically avoid issues when concurrently modifying a dataset's schema.

added targeted reload to:
- save new
- delete (circa `get()` with `pop` parameter)
- delete all

dont need for:
- update info - this just edits the view/workspace doc and so there's no changes to the list in the dataset doc.

I don't think there is any other critical place where we need to do this immediately. Tags maybe but that's hard because it's a user setting it. The rest can wait for better list delta support.

Unit tests were added that verifies that concurrent saved view / workspace updates will work going forward, for add/delete/delete-all.
Also added for concurrent updates to group slices and default_group_slice field.

## Example

### Process 1

```py
import fiftyone as fo

dataset = fo.Dataset("zzz")

print(dataset.list_saved_views()())
# []
```

### Process 2

```py
import fiftyone as fo

dataset = fo.load_dataset("zzz")

dataset.save_view("view2", dataset.limit(1))
print(dataset.list_runs())

# ['test2']
```

### Back in Process 1

```py
dataset.save_view("view1", dataset.limit(1))
"""
BEFORE
{'$set': {'saved_views': [ObjectId('663781cfd7c7ab4e1c83c6dd')]}}

AFTER
{'$set': {'saved_views': [ObjectId('6637818ee0bc8c516066763a'), ObjectId('663781cfd7c7ab4e1c83c6dd')]}}
"""
```

### Back in Process 2

```py
dataset.reload()
print(dataset.list_saved_views())
"""
BEFORE
['view1'] <-- data loss!!!

AFTER
['view2', 'view1] <-- no data loss
"""
```

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the dataset management system to support better concurrency safety, allowing for more reliable updates and interactions with saved views and workspaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->