### PR TITLE
Normalize paths when importing FiftyOneDataset

### DIFF
--- a/fiftyone/utils/data/importers.py
+++ b/fiftyone/utils/data/importers.py
@@ -1508,7 +1508,9 @@ class LegacyFiftyOneDatasetImporter(GenericSampleDatasetImporter):
         sd = next(self._iter_samples)
 
         if not os.path.isabs(sd["filepath"]):
-            sd["filepath"] = os.path.join(self._rel_dir, sd["filepath"])
+            sd["filepath"] = fos.normpath(
+                os.path.join(self._rel_dir, sd["filepath"])
+            )
 
         if self._media_fields:
             _parse_media_fields(sd, self._media_fields, self._rel_dir)
@@ -1517,7 +1519,9 @@ class LegacyFiftyOneDatasetImporter(GenericSampleDatasetImporter):
             self._media_type == fomm.GROUP
             and fomm.get_media_type(sd["filepath"]) == fomm.VIDEO
         ):
-            labels_path = os.path.join(self.dataset_dir, sd.pop("frames"))
+            labels_path = fos.normpath(
+                os.path.join(self.dataset_dir, sd.pop("frames"))
+            )
 
             sample = Sample.from_dict(sd)
             self._import_frame_labels(sample, labels_path)
@@ -1904,7 +1908,9 @@ class FiftyOneDatasetImporter(BatchDatasetImporter):
 
         def _parse_sample(sd):
             if not os.path.isabs(sd["filepath"]):
-                sd["filepath"] = os.path.join(rel_dir, sd["filepath"].replace("\\", "/"))
+                sd["filepath"] = fos.normpath(
+                    os.path.join(rel_dir, sd["filepath"])
+                )
 
             if tags is not None:
                 sd["tags"].extend(tags)


### PR DESCRIPTION
Extension of the root cause ID'd in https://github.com/voxel51/fiftyone/pull/4304 that handles Unix <> Windows conversions when importing `FiftyOneDataset` instances that were created on the opposite OS.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved file path handling by normalizing paths before joining, ensuring consistent path management across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->