### PR TITLE
python panel state persistence

### DIFF
--- a/app/packages/core/src/components/MainSpace/MainSpace.tsx
+++ b/app/packages/core/src/components/MainSpace/MainSpace.tsx
@@ -1,7 +1,9 @@
+import { panelsStateUpdatesCountAtom } from "@fiftyone/operators/src/state";
 import { SpacesRoot, usePanelsState, useSpaces } from "@fiftyone/spaces";
 import { constants, useSessionSpaces } from "@fiftyone/state";
 import { isEqual, size } from "lodash";
 import React, { useEffect, useRef } from "react";
+import { useSetRecoilState } from "recoil";
 
 const { FIFTYONE_SPACE_ID } = constants;
 
@@ -10,6 +12,9 @@ function MainSpace() {
     useSessionSpaces();
   const { spaces, updateSpaces } = useSpaces(FIFTYONE_SPACE_ID, sessionSpaces);
   const [panelsState, setPanelsState] = usePanelsState();
+  const setPanelStateUpdatesCount = useSetRecoilState(
+    panelsStateUpdatesCountAtom
+  );
   const oldSpaces = useRef(spaces);
   const oldPanelsState = useRef(panelsState);
   const isMounted = useRef(false);
@@ -21,7 +26,8 @@ function MainSpace() {
   }, [sessionSpaces]);
 
   useEffect(() => {
-    if (size(sessionPanelsState)) {
+    if (size(sessionPanelsState) && !isEqual(sessionPanelsState, panelsState)) {
+      setPanelStateUpdatesCount((count) => count + 1);
       setPanelsState(sessionPanelsState);
     }
   }, [sessionPanelsState]);

--- a/app/packages/core/src/plugins/SchemaIO/components/ButtonView.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/ButtonView.tsx
@@ -35,7 +35,6 @@ function BaseButtonView(props) {
 
 function OperatorButtonView(props) {
   let { operator, params = {}, prompt } = props.schema.view;
-  const panelState = useCustomPanelState();
   const panelId = usePanelId();
   const handleClick = usePanelEvent();
   return (

--- a/app/packages/operators/src/CustomPanel.tsx
+++ b/app/packages/operators/src/CustomPanel.tsx
@@ -37,9 +37,9 @@ export function CustomPanel(props: CustomPanelProps) {
     panelState,
     handlePanelStateChange,
     handlePanelStatePathChange,
+    panelSchema,
     data,
   } = useCustomPanelHooks(props);
-  const panelSchema = panelState?.schema;
   const onLoadError = panelState?.onLoadError;
   const pending = fos.useTimeout(PANEL_LOAD_TIMEOUT);
 

--- a/app/packages/operators/src/built-in-operators.ts
+++ b/app/packages/operators/src/built-in-operators.ts
@@ -812,7 +812,7 @@ class ClearPanelData extends Operator {
     });
   }
   useHooks(ctx: ExecutionContext): {} {
-    return { updatePanelState: useUpdatePanelStatePartial() };
+    return { updatePanelState: useUpdatePanelStatePartial(true) };
   }
   async execute(ctx: ExecutionContext): Promise<void> {
     ctx.hooks.updatePanelState(ctx, { targetPartial: "data", clear: true });
@@ -844,7 +844,7 @@ class SetPanelData extends Operator {
     });
   }
   useHooks(ctx: ExecutionContext): {} {
-    return { updatePanelState: useUpdatePanelStatePartial() };
+    return { updatePanelState: useUpdatePanelStatePartial(true) };
   }
   async execute(ctx: ExecutionContext): Promise<void> {
     ctx.hooks.updatePanelState(ctx, { targetPartial: "data" });
@@ -860,19 +860,19 @@ class PatchPanelData extends Operator {
     });
   }
   useHooks(ctx: ExecutionContext): {} {
-    return { updatePanelState: useUpdatePanelStatePartial() };
+    return { updatePanelState: useUpdatePanelStatePartial(true) };
   }
   async execute(ctx: ExecutionContext): Promise<void> {
     ctx.hooks.updatePanelState(ctx, { targetPartial: "data", patch: true });
   }
 }
 
-function useUpdatePanelStatePartial() {
-  const setPanelStateById = useSetPanelStateById();
+function useUpdatePanelStatePartial(local?: boolean) {
+  const setPanelStateById = useSetPanelStateById(local);
   return (ctx, { targetPartial = "state", targetParam, patch, clear }) => {
     targetParam = targetParam || targetPartial;
     setTimeout(() => {
-      setPanelStateById(ctx.getCurrentPanelId(), (current) => {
+      setPanelStateById(ctx.getCurrentPanelId(), (current = {}) => {
         const currentCustomPanelState = current[targetPartial] || {};
         let updatedState;
         const param = ctx.params[targetParam];
@@ -942,7 +942,7 @@ class ShowPanelOutput extends Operator {
     });
   }
   useHooks(ctx: ExecutionContext): {} {
-    return { updatePanelState: useUpdatePanelStatePartial() };
+    return { updatePanelState: useUpdatePanelStatePartial(true) };
   }
   async execute(ctx: ExecutionContext): Promise<void> {
     ctx.hooks.updatePanelState(ctx, {

--- a/app/packages/operators/src/constants.ts
+++ b/app/packages/operators/src/constants.ts
@@ -7,3 +7,4 @@ export enum OPERATOR_PROMPT_AREAS {
   DRAWER_LEFT = "operator_prompt_area_drawer_left",
   DRAWER_RIGHT = "operator_prompt_area_drawer_right",
 }
+export const PANEL_LOAD_TIMEOUT = 5000;

--- a/app/packages/operators/src/state.ts
+++ b/app/packages/operators/src/state.ts
@@ -1006,3 +1006,8 @@ export function useOperatorPlacements(place: Places) {
 
   return { placements };
 }
+
+export const panelsStateUpdatesCountAtom = atom({
+  key: "panelsStateUpdatesCountAtom",
+  default: 0,
+});

--- a/app/packages/operators/src/useCustomPanelHooks.ts
+++ b/app/packages/operators/src/useCustomPanelHooks.ts
@@ -29,16 +29,24 @@ export interface CustomPanelHooks {
   handlePanelStateChange: Function;
   handlePanelStatePathChange: Function;
   data: any;
-  renderableSchema: any;
+  panelSchema: any;
   loaded: boolean;
 }
 
 export function useCustomPanelHooks(props: CustomPanelProps): CustomPanelHooks {
   const { panelId } = props;
   const [panelState, setPanelState] = usePanelState(null, panelId);
+  const [panelStateLocal, setPanelStateLocal] = usePanelState(
+    null,
+    panelId,
+    true
+  );
   const setCustomPanelState = useSetCustomPanelState();
-  const data = getPanelViewData(panelState);
-  const renderableSchema = panelState?.schema;
+  const data = getPanelViewData({
+    state: panelState?.state,
+    data: panelStateLocal?.data,
+  });
+  const panelSchema = panelStateLocal?.schema;
   const [loaded] = useState(false);
   const view = useRecoilValue(fos.view);
   const panelsStateUpdatesCount = useRecoilValue(panelsStateUpdatesCountAtom);
@@ -47,11 +55,20 @@ export function useCustomPanelHooks(props: CustomPanelProps): CustomPanelHooks {
     state: panelState,
   });
 
+  function onLoad() {
+    if (props.onLoad) {
+      executeOperator(props.onLoad, {
+        panel_id: panelId,
+        panel_state: panelState?.state,
+      });
+    }
+  }
+
   useEffect(() => {
     log("CustomPanel loaded", panelId, props.onLoad);
     if (props.onLoad && !panelState?.loaded) {
-      executeOperator(props.onLoad, { panel_id: panelId });
-      setPanelState((s) => ({ ...s, loaded: true }));
+      onLoad();
+      setPanelStateLocal((s) => ({ ...s, loaded: true }));
     }
 
     return () => {
@@ -66,7 +83,7 @@ export function useCustomPanelHooks(props: CustomPanelProps): CustomPanelHooks {
       lastPanelLoadState.current?.count !== panelsStateUpdatesCount &&
       !isEqual(lastPanelLoadState.current?.state, panelState)
     ) {
-      executeOperator(props.onLoad, { panel_id: panelId });
+      onLoad();
     }
     lastPanelLoadState.current = {
       count: panelsStateUpdatesCount,
@@ -113,7 +130,7 @@ export function useCustomPanelHooks(props: CustomPanelProps): CustomPanelHooks {
     handlePanelStateChange,
     handlePanelStatePathChange,
     data,
-    renderableSchema,
+    panelSchema,
     loaded,
   };
 }

--- a/app/packages/operators/src/useCustomPanelHooks.ts
+++ b/app/packages/operators/src/useCustomPanelHooks.ts
@@ -1,11 +1,12 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import { useRecoilValue } from "recoil";
-import { merge } from "lodash";
+import { merge, isEqual } from "lodash";
 
 import { usePanelState, useSetCustomPanelState } from "@fiftyone/spaces";
 import { executeOperator } from "./operators";
 import * as fos from "@fiftyone/state";
 import usePanelEvent from "./usePanelEvent";
+import { panelsStateUpdatesCountAtom } from "./state";
 
 export interface CustomPanelProps {
   panelId: string;
@@ -14,9 +15,11 @@ export interface CustomPanelProps {
   onUnLoad?: Function;
   onViewChange?: Function;
   dimensions: {
-    height?: number;
-    width?: number;
-  };
+    bounds: {
+      height?: number;
+      width?: number;
+    };
+  } | null;
   panelName?: string;
   panelLabel?: string;
 }
@@ -32,12 +35,17 @@ export interface CustomPanelHooks {
 
 export function useCustomPanelHooks(props: CustomPanelProps): CustomPanelHooks {
   const { panelId } = props;
-  const [panelState, setPanelState] = usePanelState(null, panelId, true);
+  const [panelState, setPanelState] = usePanelState(null, panelId);
   const setCustomPanelState = useSetCustomPanelState();
   const data = getPanelViewData(panelState);
   const renderableSchema = panelState?.schema;
-  const [loaded, setLoaded] = useState(false);
+  const [loaded] = useState(false);
   const view = useRecoilValue(fos.view);
+  const panelsStateUpdatesCount = useRecoilValue(panelsStateUpdatesCountAtom);
+  const lastPanelLoadState = useRef({
+    count: panelsStateUpdatesCount,
+    state: panelState,
+  });
 
   useEffect(() => {
     log("CustomPanel loaded", panelId, props.onLoad);
@@ -51,6 +59,20 @@ export function useCustomPanelHooks(props: CustomPanelProps): CustomPanelHooks {
         executeOperator(props.onUnLoad, { panel_id: panelId });
     };
   }, [panelId, props.onLoad, props.onUnLoad]);
+
+  // Trigger panel "onLoad" operator when panel state changes externally
+  useEffect(() => {
+    if (
+      lastPanelLoadState.current?.count !== panelsStateUpdatesCount &&
+      !isEqual(lastPanelLoadState.current?.state, panelState)
+    ) {
+      executeOperator(props.onLoad, { panel_id: panelId });
+    }
+    lastPanelLoadState.current = {
+      count: panelsStateUpdatesCount,
+      state: panelState,
+    };
+  }, [panelsStateUpdatesCount, panelState, panelId, props.onLoad]);
 
   useEffect(() => {
     if (props.onViewChange)

--- a/app/packages/operators/src/usePanelEvent.ts
+++ b/app/packages/operators/src/usePanelEvent.ts
@@ -31,5 +31,5 @@ export default function usePanelEvent() {
     } else {
       executeOperator(operator, actualParams, options.callback);
     }
-  }, true); // local true since all custom panels are local
+  });
 }

--- a/app/packages/spaces/src/hooks.ts
+++ b/app/packages/spaces/src/hooks.ts
@@ -159,9 +159,7 @@ export function usePanelState<T>(
   return [computedState, setState];
 }
 
-// TODO - look into the default local=true - which works around the
-//        session infinite loop issue
-export function useSetPanelStateById<T>(local = true) {
+export function useSetPanelStateById<T>(local?: boolean) {
   return useRecoilCallback(
     ({ set, snapshot }) =>
       async (panelId: string, fn: (state: any) => any) => {
@@ -181,20 +179,15 @@ export function usePanelId() {
   return panelId;
 }
 
-export function useSetCustomPanelState<T>(local = true) {
+export function useSetCustomPanelState<T>(local?: boolean) {
   const [panelState, setPanelState] = usePanelState<T>(null, undefined, local);
   return (fn: (state: T) => T) => {
     setPanelState((panelState) => {
-      const customPanelState = fn(panelState.state || {});
+      const customPanelState = fn(panelState?.state || {});
       const state = fn(customPanelState);
       return { ...panelState, state };
     });
   };
-}
-
-export function useCustomPanelState(panelId?: string, local = true) {
-  const [panelState] = usePanelState(null, panelId, local);
-  return panelState.state || {};
 }
 
 /**


### PR DESCRIPTION
## What changes are proposed in this pull request?

(Please fill in changes proposed in this fix)

## How is this patch tested? If it is not, please explain why.

(Details)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a new constant for panel load timeout to enhance performance.
  - Improved panel state management with new tracking mechanisms.
  
- **Enhancements**
  - Updated functions to handle panel state updates more effectively by introducing optional parameters.
  - Enhanced custom panel functionality with additional parameters and refined state handling.

- **Bug Fixes**
  - Removed unnecessary parameters in panel event handling to streamline operations.

- **Refactor**
  - Simplified and optimized the handling of panel states across various components and hooks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->