### PR TITLE
Fixes a bug in embed prompts where the gpu was not used

### DIFF
--- a/fiftyone/utils/open_clip.py
+++ b/fiftyone/utils/open_clip.py
@@ -116,6 +116,8 @@ class TorchOpenClipModel(fout.TorchImageModel, fom.PromptMixin):
         ]
         # Tokenize text
         text = self._tokenizer(formatted_prompts)
+        if self._using_gpu:
+                text = text.cuda()
         return self._model.encode_text(text)
 
     def _get_class_logits(self, text_features, image_features):

--- a/fiftyone/utils/open_clip.py
+++ b/fiftyone/utils/open_clip.py
@@ -117,7 +117,7 @@ class TorchOpenClipModel(fout.TorchImageModel, fom.PromptMixin):
         # Tokenize text
         text = self._tokenizer(formatted_prompts)
         if self._using_gpu:
-                text = text.cuda()
+            text = text.cuda()
         return self._model.encode_text(text)
 
     def _get_class_logits(self, text_features, image_features):


### PR DESCRIPTION
## What changes are proposed in this pull request?

Fixes a bug where embed prompts did not properly use the gpu

## How is this patch tested? If it is not, please explain why.

```
m2 = foz.load_zoo_model('open-clip-torch',
                        clip_model='ViT-L-14',
                        pretrained='laion400m_e31')

e2 = m2.embed_prompt('bear')
```



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Improved tokenized text processing by conditionally moving it to the GPU for faster encoding, enhancing performance for users with GPU acceleration capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->