### PR TITLE
3D replace pydantic use

### DIFF
--- a/fiftyone/core/threed/camera.py
+++ b/fiftyone/core/threed/camera.py
@@ -7,10 +7,12 @@ Camera definition for 3D visualization.
 """
 
 from dataclasses import dataclass
-from typing import Optional, Union
+from typing import Literal, Optional, Union
 
 from .transformation import Vector3, Vec3UnionType, normalize_to_vec3
-from .validators import BaseValidatedDataClass, validate_choice
+from .validators import BaseValidatedDataClass, validate_choice, validate_float
+
+UpDirection = Literal["X", "Y", "Z"]
 
 
 @dataclass
@@ -36,13 +38,13 @@ class PerspectiveCamera(BaseValidatedDataClass):
 
     def __init__(
         self,
-        position=None,
-        look_at=None,
-        up=None,
-        aspect=None,
-        fov=50.0,
-        near=0.1,
-        far=2000.0,
+        position: Optional[Vector3] = None,
+        look_at: Optional[Vector3] = None,
+        up: Optional[UpDirection] = None,
+        aspect: Optional[float] = None,
+        fov: float = 50.0,
+        near: float = 0.1,
+        far: float = 2000.0,
     ):
         self.position = position
         self.look_at = look_at
@@ -82,7 +84,7 @@ class PerspectiveCamera(BaseValidatedDataClass):
 
     @aspect.setter
     def aspect(self, value: Optional[float]) -> None:
-        self._aspect = None if value is None else float(value)
+        self._aspect = validate_float(value, nullable=True)
 
     @property
     def fov(self) -> float:
@@ -90,7 +92,7 @@ class PerspectiveCamera(BaseValidatedDataClass):
 
     @fov.setter
     def fov(self, value: float) -> None:
-        self._fov = float(value)
+        self._fov = validate_float(value)
 
     @property
     def near(self) -> float:
@@ -98,7 +100,7 @@ class PerspectiveCamera(BaseValidatedDataClass):
 
     @near.setter
     def near(self, value: float) -> None:
-        self._near = float(value)
+        self._near = validate_float(value)
 
     @property
     def far(self) -> float:
@@ -106,7 +108,7 @@ class PerspectiveCamera(BaseValidatedDataClass):
 
     @far.setter
     def far(self, value: float) -> None:
-        self._far = float(value)
+        self._far = validate_float(value)
 
     def as_dict(self) -> dict:
         return {

--- a/fiftyone/core/threed/camera.py
+++ b/fiftyone/core/threed/camera.py
@@ -12,6 +12,8 @@ from typing import Literal, Optional, Union
 from .transformation import Vector3, Vec3UnionType, normalize_to_vec3
 from .validators import BaseValidatedDataClass, validate_choice, validate_float
 
+
+UP_DIRECTIONS = frozenset(["X", "Y", "Z"])
 UpDirection = Literal["X", "Y", "Z"]
 
 
@@ -76,7 +78,7 @@ class PerspectiveCamera(BaseValidatedDataClass):
 
     @up.setter
     def up(self, value):
-        self._up = validate_choice(value, frozenset(["X", "Y", "Z"]), True)
+        self._up = validate_choice(value, UP_DIRECTIONS, True)
 
     @property
     def aspect(self):

--- a/fiftyone/core/threed/lights.py
+++ b/fiftyone/core/threed/lights.py
@@ -10,8 +10,13 @@ from math import pi as PI
 from typing import Optional
 
 from .object_3d import Object3D
-from .transformation import Quaternion, Vec3UnionType, Vector3
-from .validators import normalize_to_vec3
+
+from .transformation import (
+    Quaternion,
+    Vec3UnionType,
+    Vector3,
+    normalize_to_vec3,
+)
 
 COLOR_DEFAULT_WHITE = "#ffffff"
 

--- a/fiftyone/core/threed/material_3d.py
+++ b/fiftyone/core/threed/material_3d.py
@@ -171,8 +171,13 @@ class MeshBasicMaterial(MeshMaterial):
         opacity (1.0): the opacity of the material, in the range ``[0, 1]``
     """
 
-    def __init__(self, color: str = COLOR_DEFAULT_GRAY, opacity: float = 1.0):
-        super().__init__(opacity=opacity)
+    def __init__(
+        self,
+        color: str = COLOR_DEFAULT_GRAY,
+        wireframe: bool = False,
+        opacity: float = 1.0,
+    ):
+        super().__init__(wireframe=wireframe, opacity=opacity)
         self.color = color
 
     @property

--- a/fiftyone/core/threed/material_3d.py
+++ b/fiftyone/core/threed/material_3d.py
@@ -10,7 +10,13 @@ from typing import Literal
 
 import fiftyone.core.utils as fou
 
-from .validators import BaseValidatedDataClass, validate_choice, validate_color
+from .validators import (
+    BaseValidatedDataClass,
+    validate_bool,
+    validate_choice,
+    validate_color,
+    validate_float,
+)
 
 threed = fou.lazy_import("fiftyone.core.threed")
 
@@ -36,7 +42,7 @@ class Material3D(BaseValidatedDataClass):
 
     @opacity.setter
     def opacity(self, value: float) -> None:
-        self._opacity = float(value)
+        self._opacity = validate_float(value)
 
     def as_dict(self):
         return {
@@ -109,7 +115,7 @@ class PointCloudMaterial(Material3D):
 
     @point_size.setter
     def point_size(self, value: float) -> None:
-        self._point_size = float(value)
+        self._point_size = validate_float(value)
 
     @property
     def attenuate_by_distance(self) -> bool:
@@ -117,7 +123,7 @@ class PointCloudMaterial(Material3D):
 
     @attenuate_by_distance.setter
     def attenuate_by_distance(self, value: bool) -> None:
-        self._attenuate_by_distance = bool(value)
+        self._attenuate_by_distance = validate_float(value)
 
     def as_dict(self):
         return {
@@ -149,7 +155,7 @@ class MeshMaterial(Material3D):
 
     @wireframe.setter
     def wireframe(self, value: bool) -> None:
-        self._wireframe = bool(value)
+        self._wireframe = validate_bool(value)
 
     def as_dict(self):
         return {**super().as_dict(), **{"wireframe": self.wireframe}}
@@ -239,7 +245,7 @@ class MeshStandardMaterial(MeshMaterial):
 
     @emissive_intensity.setter
     def emissive_intensity(self, value: float) -> None:
-        self._emissive_intensity = float(value)
+        self._emissive_intensity = validate_float(value)
 
     @property
     def metalness(self) -> float:
@@ -247,7 +253,7 @@ class MeshStandardMaterial(MeshMaterial):
 
     @metalness.setter
     def metalness(self, value: float) -> None:
-        self._metalness = float(value)
+        self._metalness = validate_float(value)
 
     @property
     def roughness(self) -> float:
@@ -255,7 +261,7 @@ class MeshStandardMaterial(MeshMaterial):
 
     @roughness.setter
     def roughness(self, value: float) -> None:
-        self._roughness = float(value)
+        self._roughness = validate_float(value)
 
     def as_dict(self):
         return {
@@ -328,7 +334,7 @@ class MeshLambertMaterial(MeshMaterial):
 
     @emissive_intensity.setter
     def emissive_intensity(self, value: float) -> None:
-        self._emissive_intensity = float(value)
+        self._emissive_intensity = validate_float(value)
 
     @property
     def reflectivity(self) -> float:
@@ -336,7 +342,7 @@ class MeshLambertMaterial(MeshMaterial):
 
     @reflectivity.setter
     def reflectivity(self, value: float) -> None:
-        self._reflectivity = float(value)
+        self._reflectivity = validate_float(value)
 
     @property
     def refraction_ratio(self) -> float:
@@ -344,7 +350,7 @@ class MeshLambertMaterial(MeshMaterial):
 
     @refraction_ratio.setter
     def refraction_ratio(self, value: float) -> None:
-        self._refraction_ratio = float(value)
+        self._refraction_ratio = validate_float(value)
 
     def as_dict(self):
         return {
@@ -410,7 +416,7 @@ class MeshPhongMaterial(MeshLambertMaterial):
 
     @shininess.setter
     def shininess(self, value: float) -> None:
-        self._shininess = float(value)
+        self._shininess = validate_float(value)
 
     @property
     def specular_color(self) -> str:

--- a/fiftyone/core/threed/material_3d.py
+++ b/fiftyone/core/threed/material_3d.py
@@ -60,6 +60,7 @@ class Material3D(BaseValidatedDataClass):
         return clz(**d)
 
 
+SHADING_MODES = frozenset(["height", "intensity", "rgb", "custom"])
 ShadingMode = Literal["height", "intensity", "rgb", "custom"]
 
 
@@ -97,9 +98,7 @@ class PointCloudMaterial(Material3D):
 
     @shading_mode.setter
     def shading_mode(self, value: ShadingMode) -> None:
-        self._shading_mode = validate_choice(
-            value, ["height", "intensity", "rgb", "custom"]
-        )
+        self._shading_mode = validate_choice(value, SHADING_MODES)
 
     @property
     def custom_color(self) -> str:

--- a/fiftyone/core/threed/material_3d.py
+++ b/fiftyone/core/threed/material_3d.py
@@ -122,7 +122,7 @@ class PointCloudMaterial(Material3D):
 
     @attenuate_by_distance.setter
     def attenuate_by_distance(self, value: bool) -> None:
-        self._attenuate_by_distance = validate_float(value)
+        self._attenuate_by_distance = validate_bool(value)
 
     def as_dict(self):
         return {

--- a/fiftyone/core/threed/object_3d.py
+++ b/fiftyone/core/threed/object_3d.py
@@ -13,9 +13,15 @@ from scipy.spatial.transform import Rotation
 
 import fiftyone.core.utils as fou
 
-from .transformation import Euler, Quaternion, Vec3UnionType, Vector3
+from .transformation import (
+    Euler,
+    Quaternion,
+    Vec3UnionType,
+    Vector3,
+    coerce_to_vec3,
+    normalize_to_vec3,
+)
 from .utils import FO3D_VERSION_KEY
-from .validators import coerce_to_vec3, normalize_to_vec3
 
 threed = fou.lazy_import("fiftyone.core.threed")
 

--- a/fiftyone/core/threed/object_3d.py
+++ b/fiftyone/core/threed/object_3d.py
@@ -15,7 +15,7 @@ import fiftyone.core.utils as fou
 
 from .transformation import Euler, Quaternion, Vec3UnionType, Vector3
 from .utils import FO3D_VERSION_KEY
-from .validators import normalize_to_vec3
+from .validators import coerce_to_vec3, normalize_to_vec3
 
 threed = fou.lazy_import("fiftyone.core.threed")
 
@@ -46,7 +46,7 @@ class Object3D:
 
         self._position = normalize_to_vec3(position) if position else Vector3()
         self._scale = (
-            normalize_to_vec3(scale) if scale else Vector3(1.0, 1.0, 1.0)
+            coerce_to_vec3(scale) if scale else Vector3(1.0, 1.0, 1.0)
         )
         self._quaternion = quaternion or Quaternion()
 
@@ -132,7 +132,7 @@ class Object3D:
 
     @scale.setter
     def scale(self, value: Vec3UnionType):
-        self._scale = normalize_to_vec3(value)
+        self._scale = coerce_to_vec3(value)
         self._update_matrix()
 
     @property

--- a/fiftyone/core/threed/transformation.py
+++ b/fiftyone/core/threed/transformation.py
@@ -3,7 +3,13 @@ from typing import List, Literal, Optional, Tuple, Union
 import numpy as np
 from scipy.spatial.transform import Rotation
 
-from .validators import BaseValidatedDataClass, validate_choice, validate_list
+from .validators import (
+    BaseValidatedDataClass,
+    validate_bool,
+    validate_choice,
+    validate_float,
+    validate_list,
+)
 
 
 EULER_AXES_SEQUENCES = ["XYZ", "XZY", "YXZ", "YZX", "ZXY", "ZYX"]
@@ -19,9 +25,9 @@ class Vector3(BaseValidatedDataClass):
         y: float = 0.0,
         z: float = 0.0,
     ):
-        self._x = float(x)
-        self._y = float(y)
-        self._z = float(z)
+        self._x = validate_float(x)
+        self._y = validate_float(y)
+        self._z = validate_float(z)
 
     @property
     def x(self) -> float:
@@ -40,7 +46,7 @@ class Vector3(BaseValidatedDataClass):
         return np.array([self.x, self.y, self.z])
 
 
-class Euler(BaseValidatedDataClass):
+class Euler(Vector3):
     """Represents intrinsic rotations about the object's own principal axes."""
 
     def __init__(
@@ -51,23 +57,9 @@ class Euler(BaseValidatedDataClass):
         degrees: bool = False,
         sequence: EulerAxesSequence = "XYZ",
     ):
-        self._x = float(x)
-        self._y = float(y)
-        self._z = float(z)
-        self._degrees = bool(degrees)
+        super().__init__(x, y, z)
+        self._degrees = validate_bool(degrees)
         self._sequence = validate_choice(sequence, EULER_AXES_SEQUENCES, False)
-
-    @property
-    def x(self) -> float:
-        return self._x
-
-    @property
-    def y(self) -> float:
-        return self._y
-
-    @property
-    def z(self) -> float:
-        return self._z
 
     @property
     def degrees(self) -> bool:
@@ -84,10 +76,6 @@ class Euler(BaseValidatedDataClass):
         )
         return Quaternion(*q.as_quat())
 
-    def to_arr(self):
-        """Converts the euler angles to a numpy array."""
-        return np.array([self.x, self.y, self.z])
-
 
 class Quaternion(BaseValidatedDataClass):
     """Represents a quaternion."""
@@ -99,10 +87,10 @@ class Quaternion(BaseValidatedDataClass):
         z: float = 0.0,
         w: float = 1.0,
     ):
-        self._x = float(x)
-        self._y = float(y)
-        self._z = float(z)
-        self._w = float(w)
+        self._x = validate_float(x)
+        self._y = validate_float(y)
+        self._z = validate_float(z)
+        self._w = validate_float(w)
 
     @property
     def x(self) -> float:

--- a/fiftyone/core/threed/transformation.py
+++ b/fiftyone/core/threed/transformation.py
@@ -140,7 +140,7 @@ def coerce_to_vec3(v: Optional[Vec3UnionType]) -> Union[Vector3, None]:
     if v is None:
         return None
 
-    if isinstance(v, (int, float)):
+    if isinstance(v, (int, float, np.number)):
         return Vector3(v, v, v)
 
     return normalize_to_vec3(v)

--- a/fiftyone/core/threed/transformation.py
+++ b/fiftyone/core/threed/transformation.py
@@ -1,3 +1,4 @@
+import numbers
 from typing import List, Literal, Optional, Tuple, Union
 
 import numpy as np
@@ -140,7 +141,7 @@ def coerce_to_vec3(v: Optional[Vec3UnionType]) -> Union[Vector3, None]:
     if v is None:
         return None
 
-    if isinstance(v, (int, float, np.number)):
+    if isinstance(v, (int, float, numbers.Real)):
         return Vector3(v, v, v)
 
     return normalize_to_vec3(v)

--- a/fiftyone/core/threed/transformation.py
+++ b/fiftyone/core/threed/transformation.py
@@ -12,7 +12,7 @@ from .validators import (
 )
 
 
-EULER_AXES_SEQUENCES = ["XYZ", "XZY", "YXZ", "YZX", "ZXY", "ZYX"]
+EULER_AXES_SEQUENCES = frozenset(["XYZ", "XZY", "YXZ", "YZX", "ZXY", "ZYX"])
 EulerAxesSequence = Literal["XYZ", "XZY", "YXZ", "YZX", "ZXY", "ZYX"]
 
 

--- a/fiftyone/core/threed/validators.py
+++ b/fiftyone/core/threed/validators.py
@@ -16,15 +16,23 @@ def normalize_to_vec3(v: Optional[Vec3UnionType]) -> Union[Vector3, None]:
     if v is None:
         return None
 
-    if isinstance(v, (int, float)):
-        v = Vector3(v, v, v)
-    elif isinstance(v, (list, tuple)) and len(v) == 3:
+    if isinstance(v, (list, tuple)) and len(v) == 3:
         v = Vector3(*v)
 
     if not isinstance(v, Vector3):
         raise ValueError("Expected a list / tuple of length 3 or a Vector3")
 
     return v
+
+
+def coerce_to_vec3(v: Optional[Vec3UnionType]) -> Union[Vector3, None]:
+    if v is None:
+        return None
+
+    if isinstance(v, (int, float)):
+        return Vector3(v, v, v)
+
+    return normalize_to_vec3(v)
 
 
 def vec3_normalizing_validator(field: str) -> classmethod:

--- a/fiftyone/core/threed/validators.py
+++ b/fiftyone/core/threed/validators.py
@@ -9,6 +9,15 @@ import re
 from typing import Any, Iterable, Optional
 
 
+def validate_bool(v: Any, nullable: bool = False):
+    if v is None:
+        if nullable:
+            return None
+        else:
+            raise ValueError("Field cannot be None")
+    return bool(v)
+
+
 def validate_choice(v: Any, options: Iterable, nullable: bool = False):
     if nullable and v is None:
         return None
@@ -30,6 +39,15 @@ def validate_color(v: Optional[str], nullable: bool = False):
         raise ValueError(f"Color string '{v}' must be in the form #ffffff")
 
     return v
+
+
+def validate_float(v: Any, nullable: bool = False):
+    if nullable and v is None:
+        return None
+    try:
+        return float(v)
+    except TypeError as e:
+        raise ValueError(e.args)
 
 
 def validate_list(
@@ -70,10 +88,9 @@ class BaseValidatedDataClass(object):
     def __repr__(self):
         # Looks like:
         #   ClassName(prop1="foo", prop2=3.14159)
-        attribute_strings = []
-        for attribute, value in vars(self).items():
-            if isinstance(value, str):
-                value = '"' + value + '"'
-            attribute_strings.append(f"{attribute.lstrip('_')}={str(value)}")
+        attribute_strings = [
+            f"{attribute.lstrip('_')}={repr(value)}"
+            for attribute, value in vars(self).items()
+        ]
 
         return f"{self.__class__.__name__}({', '.join(attribute_strings)})"

--- a/fiftyone/core/threed/validators.py
+++ b/fiftyone/core/threed/validators.py
@@ -9,20 +9,24 @@ import re
 from typing import Any, Iterable, Optional
 
 
-def validate_bool(v: Any, nullable: bool = False):
+def validate_bool(v: Optional[bool], nullable: bool = False):
     if v is None:
         if nullable:
             return None
         else:
             raise ValueError("Field cannot be None")
-    return bool(v)
+
+    if not isinstance(v, bool):
+        raise ValueError(f"Invalid boolean value '{v}' of type: {type(v)}")
+
+    return v
 
 
 def validate_choice(v: Any, options: Iterable, nullable: bool = False):
     if nullable and v is None:
         return None
 
-    if v not in options:
+    if v not in frozenset(options):
         raise ValueError(f"Value '{v}' not in options: {options}")
 
     return v
@@ -35,13 +39,13 @@ def validate_color(v: Optional[str], nullable: bool = False):
     if not isinstance(v, str):
         raise ValueError(f"Color must be of string type: {v}")
 
-    if not re.fullmatch(r"#[0-9a-f]{6}", v):
+    if not re.fullmatch(r"#[0-9a-fA-F]{6}", v):
         raise ValueError(f"Color string '{v}' must be in the form #ffffff")
 
     return v
 
 
-def validate_float(v: Any, nullable: bool = False):
+def validate_float(v: Optional[float], nullable: bool = False):
     if nullable and v is None:
         return None
     try:

--- a/fiftyone/core/threed/validators.py
+++ b/fiftyone/core/threed/validators.py
@@ -6,7 +6,9 @@ Simple validator utilities
 |
 """
 import re
-from typing import Any, Iterable, Optional
+from typing import Any, Optional
+
+import matplotlib.colors as mcolors
 
 
 def validate_bool(v: Optional[bool], nullable: bool = False):
@@ -22,11 +24,11 @@ def validate_bool(v: Optional[bool], nullable: bool = False):
     return v
 
 
-def validate_choice(v: Any, options: Iterable, nullable: bool = False):
+def validate_choice(v: Any, options: frozenset, nullable: bool = False):
     if nullable and v is None:
         return None
 
-    if v not in frozenset(options):
+    if v not in options:
         raise ValueError(f"Value '{v}' not in options: {options}")
 
     return v
@@ -39,10 +41,17 @@ def validate_color(v: Optional[str], nullable: bool = False):
     if not isinstance(v, str):
         raise ValueError(f"Color must be of string type: {v}")
 
-    if not re.fullmatch(r"#[0-9a-fA-F]{6}", v):
-        raise ValueError(f"Color string '{v}' must be in the form #ffffff")
+    lowered = v.strip().replace("_", "").lower()
+    if lowered in mcolors.CSS4_COLORS:
+        return lowered
 
-    return v
+    if re.fullmatch(r"(0x|#)[0-9a-fA-F]{6}", lowered):
+        return lowered
+
+    raise ValueError(
+        f"Color string '{v}' must be in the form '#ffffff', '0xffffff', or"
+        " web color name such as 'red'"
+    )
 
 
 def validate_float(v: Optional[float], nullable: bool = False):

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -19,7 +19,6 @@ plotly==5.17.0
 pprintpp==0.4.0
 psutil>=5.7.0
 pymongo>=3.12
-pydantic==2.6.4
 pytz==2022.1
 PyYAML==6.0.1
 regex==2022.8.17

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,6 @@ INSTALL_REQUIRES = [
     "plotly>=4.14",
     "pprintpp",
     "psutil",
-    "pydantic>=2",
     "pymongo>=3.12",
     "pytz",
     "PyYAML",

--- a/tests/unittests/threed/camera_tests.py
+++ b/tests/unittests/threed/camera_tests.py
@@ -10,7 +10,13 @@ import unittest
 
 from fiftyone.core import threed
 
-from tests.unittests.threed.dataclass_test_utils import *
+from fiftyone.core.threed.utils import convert_keys_to_snake_case
+
+from tests.unittests.threed.dataclass_test_utils import (
+    assert_choice_prop,
+    assert_float_prop,
+    assert_vec3_prop,
+)
 
 
 class TestCamera(unittest.TestCase):
@@ -32,5 +38,7 @@ class TestCamera(unittest.TestCase):
         assert_float_prop(self, obj, "near")
         assert_float_prop(self, obj, "far")
 
-        obj2 = threed.PerspectiveCamera._from_dict(obj.as_dict())
+        obj2 = threed.PerspectiveCamera._from_dict(
+            convert_keys_to_snake_case(obj.as_dict())
+        )
         self.assertEqual(obj, obj2)

--- a/tests/unittests/threed/camera_tests.py
+++ b/tests/unittests/threed/camera_tests.py
@@ -1,0 +1,36 @@
+"""
+FiftyOne 3D Camera unit tests.
+
+| Copyright 2017-2024, Voxel51, Inc.
+| `voxel51.com <https://voxel51.com/>`_
+|
+"""
+
+import unittest
+
+from fiftyone.core import threed
+
+from tests.unittests.threed.dataclass_test_utils import *
+
+
+class TestCamera(unittest.TestCase):
+    def test_it(self):
+        obj = threed.PerspectiveCamera()
+        self.assertEqual(
+            obj,
+            threed.PerspectiveCamera(
+                None, None, None, None, 50.0, 0.1, 2000.0
+            ),
+        )
+        self.assertRaises(ValueError, setattr, obj, "another_field", 51)
+
+        assert_vec3_prop(self, obj, "position", nullable=True)
+        assert_vec3_prop(self, obj, "look_at", nullable=True)
+        assert_choice_prop(self, obj, "up", ["X", "Y", "Z"], nullable=True)
+        assert_float_prop(self, obj, "aspect", True)
+        assert_float_prop(self, obj, "fov")
+        assert_float_prop(self, obj, "near")
+        assert_float_prop(self, obj, "far")
+
+        obj2 = threed.PerspectiveCamera._from_dict(obj.as_dict())
+        self.assertEqual(obj, obj2)

--- a/tests/unittests/threed/camera_tests.py
+++ b/tests/unittests/threed/camera_tests.py
@@ -12,7 +12,7 @@ from fiftyone.core import threed
 
 from fiftyone.core.threed.utils import convert_keys_to_snake_case
 
-from tests.unittests.threed.dataclass_test_utils import (
+from dataclass_test_utils import (
     assert_choice_prop,
     assert_float_prop,
     assert_vec3_prop,

--- a/tests/unittests/threed/dataclass_test_utils.py
+++ b/tests/unittests/threed/dataclass_test_utils.py
@@ -1,5 +1,10 @@
 import unittest
 
+import numpy as np
+
+from fiftyone.core.threed.transformation import Vector3
+from fiftyone.core.threed.utils import convert_keys_to_snake_case
+
 
 def _none_check(tester, obj, attribute, nullable):
     if nullable:
@@ -7,6 +12,28 @@ def _none_check(tester, obj, attribute, nullable):
         tester.assertIsNone(getattr(obj, attribute))
     else:
         tester.assertRaises(ValueError, setattr, obj, attribute, None)
+
+
+def assert_bool_prop(
+    tester: unittest.TestCase, obj, attribute, nullable=False
+):
+    _none_check(tester, obj, attribute, nullable)
+    setattr(obj, attribute, True)
+    tester.assertEqual(getattr(obj, attribute), True)
+    setattr(obj, attribute, False)
+    tester.assertEqual(getattr(obj, attribute), False)
+
+
+def assert_choice_prop(
+    tester: unittest.TestCase, obj, attribute, choices: list, nullable=False
+):
+    tester.assertRaises(ValueError, setattr, obj, attribute, "blah")
+    tester.assertRaises(ValueError, setattr, obj, attribute, 8675309)
+    _none_check(tester, obj, attribute, nullable)
+
+    for choice in choices:
+        setattr(obj, attribute, choice)
+        tester.assertEqual(getattr(obj, attribute), choice)
 
 
 def assert_color_prop(
@@ -17,11 +44,11 @@ def assert_color_prop(
     tester.assertRaises(ValueError, setattr, obj, attribute, "#00001")
     tester.assertRaises(ValueError, setattr, obj, attribute, "#10000g")
 
+    _none_check(tester, obj, attribute, nullable)
+
     # Happy path
     setattr(obj, attribute, "#ff6d04")
     tester.assertEqual(getattr(obj, attribute), "#ff6d04")
-
-    _none_check(tester, obj, attribute, nullable)
 
 
 def assert_float_prop(
@@ -29,14 +56,40 @@ def assert_float_prop(
 ):
     tester.assertRaises(ValueError, setattr, obj, attribute, "blah")
 
+    _none_check(tester, obj, attribute, nullable)
+
     setattr(obj, attribute, 51.51)
     tester.assertEqual(getattr(obj, attribute), 51.51)
-    _none_check(tester, obj, attribute, nullable)
 
 
 def assert_string_prop(
     tester: unittest.TestCase, obj, attribute, nullable=False
 ):
+    _none_check(tester, obj, attribute, nullable)
+
     setattr(obj, attribute, "test string")
     tester.assertEqual(getattr(obj, attribute), "test string")
+
+
+def assert_vec3_prop(
+    tester: unittest.TestCase, obj, attribute, nullable=False
+):
+    tester.assertRaises(ValueError, setattr, obj, attribute, "blah")
+    tester.assertRaises(ValueError, setattr, obj, attribute, 1)
+    tester.assertRaises(ValueError, setattr, obj, attribute, 2.0)
+    tester.assertRaises(ValueError, setattr, obj, attribute, [1.0, 2.0])
+    tester.assertRaises(
+        ValueError, setattr, obj, attribute, [1.0, 2.0, 3.0, 4.0]
+    )
+    tester.assertRaises(
+        ValueError, setattr, obj, attribute, [1.0, 2.0, "blah"]
+    )
+
     _none_check(tester, obj, attribute, nullable)
+
+    setattr(obj, attribute, [1.0, 2.0, 3.0])
+    tester.assertEqual(getattr(obj, attribute), Vector3(1.0, 2.0, 3.0))
+    setattr(obj, attribute, (3.0, 2.0, 1.0))
+    tester.assertEqual(getattr(obj, attribute), Vector3(3.0, 2.0, 1.0))
+    setattr(obj, attribute, np.array([1, 2, 3]))
+    tester.assertEqual(getattr(obj, attribute), Vector3(1.0, 2.0, 3.0))

--- a/tests/unittests/threed/dataclass_test_utils.py
+++ b/tests/unittests/threed/dataclass_test_utils.py
@@ -47,12 +47,18 @@ def assert_color_prop(
     tester.assertRaises(ValueError, setattr, obj, attribute, "#00001")
     tester.assertRaises(ValueError, setattr, obj, attribute, "#10000g")
     tester.assertRaises(ValueError, setattr, obj, attribute, "#GGGFFF")
+    tester.assertRaises(ValueError, setattr, obj, attribute, "0xGGGFFF")
+    tester.assertRaises(ValueError, setattr, obj, attribute, "majesticunknown")
 
     _none_check(tester, obj, attribute, nullable)
 
     # Happy path
     setattr(obj, attribute, "#ff6D04")
-    tester.assertEqual(getattr(obj, attribute), "#ff6D04")
+    tester.assertEqual(getattr(obj, attribute), "#ff6d04")
+    setattr(obj, attribute, "0xff6D04")
+    tester.assertEqual(getattr(obj, attribute), "0xff6d04")
+    setattr(obj, attribute, "red")
+    tester.assertEqual(getattr(obj, attribute), "red")
 
 
 def assert_float_prop(

--- a/tests/unittests/threed/dataclass_test_utils.py
+++ b/tests/unittests/threed/dataclass_test_utils.py
@@ -3,7 +3,6 @@ import unittest
 import numpy as np
 
 from fiftyone.core.threed.transformation import Vector3
-from fiftyone.core.threed.utils import convert_keys_to_snake_case
 
 
 def _none_check(tester, obj, attribute, nullable):
@@ -17,6 +16,10 @@ def _none_check(tester, obj, attribute, nullable):
 def assert_bool_prop(
     tester: unittest.TestCase, obj, attribute, nullable=False
 ):
+    tester.assertRaises(ValueError, setattr, obj, attribute, 1)
+    tester.assertRaises(ValueError, setattr, obj, attribute, "true")
+    tester.assertRaises(ValueError, setattr, obj, attribute, "1")
+
     _none_check(tester, obj, attribute, nullable)
     setattr(obj, attribute, True)
     tester.assertEqual(getattr(obj, attribute), True)
@@ -43,12 +46,13 @@ def assert_color_prop(
     tester.assertRaises(ValueError, setattr, obj, attribute, "000000")
     tester.assertRaises(ValueError, setattr, obj, attribute, "#00001")
     tester.assertRaises(ValueError, setattr, obj, attribute, "#10000g")
+    tester.assertRaises(ValueError, setattr, obj, attribute, "#GGGFFF")
 
     _none_check(tester, obj, attribute, nullable)
 
     # Happy path
-    setattr(obj, attribute, "#ff6d04")
-    tester.assertEqual(getattr(obj, attribute), "#ff6d04")
+    setattr(obj, attribute, "#ff6D04")
+    tester.assertEqual(getattr(obj, attribute), "#ff6D04")
 
 
 def assert_float_prop(

--- a/tests/unittests/threed/dataclass_test_utils.py
+++ b/tests/unittests/threed/dataclass_test_utils.py
@@ -1,0 +1,42 @@
+import unittest
+
+
+def _none_check(tester, obj, attribute, nullable):
+    if nullable:
+        setattr(obj, attribute, None)
+        tester.assertIsNone(getattr(obj, attribute))
+    else:
+        tester.assertRaises(ValueError, setattr, obj, attribute, None)
+
+
+def assert_color_prop(
+    tester: unittest.TestCase, obj, attribute, nullable=False
+):
+    # Validation errors
+    tester.assertRaises(ValueError, setattr, obj, attribute, "000000")
+    tester.assertRaises(ValueError, setattr, obj, attribute, "#00001")
+    tester.assertRaises(ValueError, setattr, obj, attribute, "#10000g")
+
+    # Happy path
+    setattr(obj, attribute, "#ff6d04")
+    tester.assertEqual(getattr(obj, attribute), "#ff6d04")
+
+    _none_check(tester, obj, attribute, nullable)
+
+
+def assert_float_prop(
+    tester: unittest.TestCase, obj, attribute, nullable=False
+):
+    tester.assertRaises(ValueError, setattr, obj, attribute, "blah")
+
+    setattr(obj, attribute, 51.51)
+    tester.assertEqual(getattr(obj, attribute), 51.51)
+    _none_check(tester, obj, attribute, nullable)
+
+
+def assert_string_prop(
+    tester: unittest.TestCase, obj, attribute, nullable=False
+):
+    setattr(obj, attribute, "test string")
+    tester.assertEqual(getattr(obj, attribute), "test string")
+    _none_check(tester, obj, attribute, nullable)

--- a/tests/unittests/threed/material_3d_tests.py
+++ b/tests/unittests/threed/material_3d_tests.py
@@ -10,7 +10,14 @@ import unittest
 
 from fiftyone.core.threed import material_3d
 
-from tests.unittests.threed.dataclass_test_utils import *
+from fiftyone.core.threed.utils import convert_keys_to_snake_case
+
+from tests.unittests.threed.dataclass_test_utils import (
+    assert_bool_prop,
+    assert_choice_prop,
+    assert_color_prop,
+    assert_float_prop,
+)
 
 
 class TestMaterial3D(unittest.TestCase):

--- a/tests/unittests/threed/material_3d_tests.py
+++ b/tests/unittests/threed/material_3d_tests.py
@@ -12,7 +12,7 @@ from fiftyone.core.threed import material_3d
 
 from fiftyone.core.threed.utils import convert_keys_to_snake_case
 
-from tests.unittests.threed.dataclass_test_utils import (
+from dataclass_test_utils import (
     assert_bool_prop,
     assert_choice_prop,
     assert_color_prop,

--- a/tests/unittests/threed/material_3d_tests.py
+++ b/tests/unittests/threed/material_3d_tests.py
@@ -1,0 +1,177 @@
+"""
+FiftyOne Material 3D unit tests.
+
+| Copyright 2017-2024, Voxel51, Inc.
+| `voxel51.com <https://voxel51.com/>`_
+|
+"""
+
+import unittest
+
+from fiftyone.core.threed import material_3d
+
+from tests.unittests.threed.dataclass_test_utils import *
+
+
+class TestMaterial3D(unittest.TestCase):
+    def test_material_3d(self):
+        obj = material_3d.Material3D()
+        self.assertEqual(
+            obj,
+            material_3d.Material3D(1.0),
+        )
+        self.assertRaises(ValueError, setattr, obj, "another_field", 51)
+
+        assert_float_prop(self, obj, "opacity")
+
+    def test_point_cloud_material(self):
+        # PointCloudMaterial
+        obj = material_3d.PointCloudMaterial()
+        self.assertEqual(
+            obj,
+            material_3d.PointCloudMaterial(
+                "height", "#ffffff", 1.0, False, opacity=1.0
+            ),
+        )
+        self.assertRaises(ValueError, setattr, obj, "another_field", 51)
+
+        assert_float_prop(self, obj, "opacity")
+        assert_choice_prop(
+            self,
+            obj,
+            "shading_mode",
+            ["height", "intensity", "rgb", "custom"],
+            nullable=False,
+        )
+        assert_color_prop(self, obj, "custom_color", False)
+        assert_float_prop(self, obj, "point_size", False)
+        assert_bool_prop(self, obj, "attenuate_by_distance", False)
+
+        obj2 = material_3d.PointCloudMaterial._from_dict(
+            convert_keys_to_snake_case(obj.as_dict())
+        )
+        self.assertEqual(obj, obj2)
+
+    def test_mesh_material(self):
+        obj = material_3d.MeshMaterial()
+        self.assertEqual(
+            obj,
+            material_3d.MeshMaterial(False, opacity=1.0),
+        )
+        self.assertRaises(ValueError, setattr, obj, "another_field", 51)
+
+        assert_bool_prop(self, obj, "wireframe", nullable=False)
+        assert_float_prop(self, obj, "opacity", False)
+
+    def test_basic_mesh_material(self):
+        obj = material_3d.MeshBasicMaterial()
+        self.assertEqual(
+            obj,
+            material_3d.MeshBasicMaterial(
+                material_3d.COLOR_DEFAULT_GRAY, wireframe=False, opacity=1.0
+            ),
+        )
+        self.assertRaises(ValueError, setattr, obj, "another_field", 51)
+
+        assert_bool_prop(self, obj, "wireframe", nullable=False)
+        assert_float_prop(self, obj, "opacity", False)
+        assert_color_prop(self, obj, "color", False)
+
+        obj2 = material_3d.MeshBasicMaterial._from_dict(
+            convert_keys_to_snake_case(obj.as_dict())
+        )
+        self.assertEqual(obj, obj2)
+
+    def test_standard_mesh_material(self):
+        obj = material_3d.MeshStandardMaterial()
+        self.assertEqual(
+            obj,
+            material_3d.MeshStandardMaterial(
+                material_3d.COLOR_DEFAULT_GRAY,
+                material_3d.COLOR_DEFAULT_BLACK,
+                0.0,
+                0.0,
+                1.0,
+                wireframe=False,
+                opacity=1.0,
+            ),
+        )
+        self.assertRaises(ValueError, setattr, obj, "another_field", 51)
+
+        assert_color_prop(self, obj, "color", False)
+        assert_color_prop(self, obj, "emissive_color", False)
+        assert_float_prop(self, obj, "emissive_intensity", False)
+        assert_float_prop(self, obj, "metalness", False)
+        assert_float_prop(self, obj, "roughness", False)
+        assert_float_prop(self, obj, "opacity", False)
+        assert_bool_prop(self, obj, "wireframe", False)
+
+        obj2 = material_3d.MeshStandardMaterial._from_dict(
+            convert_keys_to_snake_case(obj.as_dict())
+        )
+        self.assertEqual(obj, obj2)
+
+    def test_lambert_mesh_material(self):
+        obj = material_3d.MeshLambertMaterial()
+        self.assertEqual(
+            obj,
+            material_3d.MeshLambertMaterial(
+                material_3d.COLOR_DEFAULT_GRAY,
+                material_3d.COLOR_DEFAULT_BLACK,
+                0.0,
+                1.0,
+                0.98,
+                wireframe=False,
+                opacity=1.0,
+            ),
+        )
+        self.assertRaises(ValueError, setattr, obj, "another_field", 51)
+
+        assert_color_prop(self, obj, "color", False)
+        assert_color_prop(self, obj, "emissive_color", False)
+        assert_float_prop(self, obj, "emissive_intensity", False)
+        assert_float_prop(self, obj, "reflectivity", False)
+        assert_float_prop(self, obj, "refraction_ratio", False)
+        assert_float_prop(self, obj, "opacity", False)
+        assert_bool_prop(self, obj, "wireframe", False)
+
+        obj.reflectivity = 0.51
+        obj2 = material_3d.MeshLambertMaterial._from_dict(
+            convert_keys_to_snake_case(obj.as_dict())
+        )
+        self.assertEqual(obj, obj2)
+
+    def test_phong_mesh_material(self):
+        obj = material_3d.MeshPhongMaterial()
+        self.assertEqual(
+            obj,
+            material_3d.MeshPhongMaterial(
+                30.0,
+                material_3d.COLOR_DEFAULT_DARK_GRAY,
+                color=material_3d.COLOR_DEFAULT_GRAY,
+                emissive_color=material_3d.COLOR_DEFAULT_BLACK,
+                emissive_intensity=0.0,
+                reflectivity=1.0,
+                refraction_ratio=0.98,
+                wireframe=False,
+                opacity=1.0,
+            ),
+        )
+        self.assertRaises(ValueError, setattr, obj, "another_field", 51)
+
+        assert_float_prop(self, obj, "shininess", False)
+        assert_color_prop(self, obj, "specular_color", False)
+        assert_color_prop(self, obj, "color", False)
+        assert_color_prop(self, obj, "emissive_color", False)
+        assert_float_prop(self, obj, "emissive_intensity", False)
+        assert_float_prop(self, obj, "reflectivity", False)
+        assert_float_prop(self, obj, "refraction_ratio", False)
+        assert_float_prop(self, obj, "opacity", False)
+        assert_bool_prop(self, obj, "wireframe", False)
+
+        obj.reflectivity = 0.51
+        obj.shininess = 51.51
+        obj2 = material_3d.MeshLambertMaterial._from_dict(
+            convert_keys_to_snake_case(obj.as_dict())
+        )
+        self.assertEqual(obj, obj2)

--- a/tests/unittests/threed/object_3d_tests.py
+++ b/tests/unittests/threed/object_3d_tests.py
@@ -251,3 +251,96 @@ class TestObject3DSerialization(unittest.TestCase):
             obj.rotation.to_arr(), np.array([1.5708, 0, 0]), decimal=5
         )
         np.testing.assert_equal(obj.scale.to_arr(), np.array([1, 1, 1]))
+
+
+class TestObject3DBasics(unittest.TestCase):
+    def test_position_init(self):
+        self.assertRaises(ValueError, Object3D, "invalid", position=1)
+        self.assertEqual(
+            Object3D("astuple", position=(1, 2, 3)).position,
+            Vector3(1.0, 2.0, 3.0),
+        )
+        self.assertEqual(
+            Object3D("aslist", position=[1, 2, 3]).position,
+            Vector3(1.0, 2.0, 3.0),
+        )
+
+    def test_position_setter(self):
+        obj = Object3D("instance")
+        self.assertRaises(ValueError, obj.__setattr__, "position", 1)
+
+        obj.position = (1.0, 2.0, 3.0)
+        self.assertEqual(
+            obj.position,
+            Vector3(1.0, 2.0, 3.0),
+        )
+        obj.position = [3.0, 2.0, 1]
+        self.assertEqual(
+            obj.position,
+            Vector3(3.0, 2.0, 1.0),
+        )
+
+    def test_scale_init(self):
+        self.assertEqual(
+            Object3D("asfloat", scale=0.5).scale,
+            Vector3(0.5, 0.5, 0.5),
+        )
+        self.assertEqual(
+            Object3D("asint", scale=3).scale,
+            Vector3(3, 3, 3),
+        )
+        self.assertEqual(
+            Object3D("astuple", scale=(1, 2, 3)).scale,
+            Vector3(1.0, 2.0, 3.0),
+        )
+        self.assertEqual(
+            Object3D("aslist", scale=[1, 2, 3]).scale,
+            Vector3(1.0, 2.0, 3.0),
+        )
+
+    def test_scale_setter(self):
+        obj = Object3D("instance")
+
+        obj.scale = 0.5
+        self.assertEqual(
+            obj.scale,
+            Vector3(0.5, 0.5, 0.5),
+        )
+        obj.scale = 3
+        self.assertEqual(
+            obj.scale,
+            Vector3(3, 3, 3),
+        )
+
+        obj.scale = (1.0, 2.0, 3.0)
+        self.assertEqual(
+            obj.scale,
+            Vector3(1.0, 2.0, 3.0),
+        )
+        obj.scale = [3.0, 2.0, 1]
+        self.assertEqual(
+            obj.scale,
+            Vector3(3.0, 2.0, 1.0),
+        )
+
+    def test_cant_add_self(self):
+        obj = Object3D("looper")
+        self.assertRaises(ValueError, obj.add, obj)
+
+    def test_traverse(self):
+        objects = [Object3D(f"object{i}") for i in range(5)]
+        root = objects[0]
+        sub = objects[1]
+        sub.add(objects[2], objects[3])
+        root.add(sub, objects[4])
+
+        self.assertListEqual(list(root.traverse(include_self=True)), objects)
+        self.assertListEqual(
+            list(root.traverse(include_self=False)), objects[1:]
+        )
+
+        root.clear()
+        self.assertListEqual(list(root.traverse(include_self=False)), [])
+        self.assertListEqual(
+            list(sub.traverse(include_self=False)), objects[2:4]
+        )

--- a/tests/unittests/threed/object_3d_tests.py
+++ b/tests/unittests/threed/object_3d_tests.py
@@ -13,36 +13,6 @@ import numpy as np
 from fiftyone.core.threed import Euler, Object3D, Quaternion, Vector3
 
 
-class Test3DBasicGeometry(unittest.TestCase):
-    def test_euler_initialization(self):
-        e = Euler(90, 45, 30)
-        self.assertEqual((e.x, e.y, e.z), (90, 45, 30))
-
-    def test_vector3_initialization(self):
-        v = Vector3(1, 2, 3)
-        self.assertEqual((v.x, v.y, v.z), (1, 2, 3))
-
-    def test_quaternion_initialization(self):
-        q = Quaternion()
-        self.assertEqual((q.x, q.y, q.z, q.w), (0, 0, 0, 1))
-
-    def test_euler_to_quaternion_conversion(self):
-        e = Euler(90, 0, 0, degrees=True)
-        q = e.to_quaternion()
-        self.assertIsInstance(q, Quaternion)
-        np.testing.assert_array_almost_equal(
-            (q.x, q.y, q.z, q.w), (0.70710678, 0, 0, 0.70710678), decimal=5
-        )
-
-    def test_quaternion_to_euler_conversion(self):
-        q = Quaternion(0.5609855, -0.4304593, 0.7010574, 0.092296)
-        e = q.to_euler(degrees=True)
-        self.assertIsInstance(e, Euler)
-        np.testing.assert_array_almost_equal(
-            (e.x, e.y, e.z), (90, 45, 120), decimal=5
-        )
-
-
 class TestObject3DMatrixUpdates(unittest.TestCase):
     def setUp(self):
         self.obj = Object3D("TestObject")

--- a/tests/unittests/threed/scene_3d_tests.py
+++ b/tests/unittests/threed/scene_3d_tests.py
@@ -15,7 +15,11 @@ from unittest.mock import mock_open, patch
 from fiftyone.core import threed
 from fiftyone.core.threed.utils import convert_keys_to_snake_case
 
-from tests.unittests.threed.dataclass_test_utils import *
+from tests.unittests.threed.dataclass_test_utils import (
+    assert_color_prop,
+    assert_float_prop,
+    assert_string_prop,
+)
 
 
 class TestScene(unittest.TestCase):

--- a/tests/unittests/threed/scene_3d_tests.py
+++ b/tests/unittests/threed/scene_3d_tests.py
@@ -15,7 +15,7 @@ from unittest.mock import mock_open, patch
 from fiftyone.core import threed
 from fiftyone.core.threed.utils import convert_keys_to_snake_case
 
-from tests.unittests.threed.dataclass_test_utils import (
+from dataclass_test_utils import (
     assert_color_prop,
     assert_float_prop,
     assert_string_prop,

--- a/tests/unittests/threed/scene_3d_tests.py
+++ b/tests/unittests/threed/scene_3d_tests.py
@@ -181,3 +181,6 @@ class TestSceneBackground(unittest.TestCase):
         self.assertRaises(ValueError, setattr, obj, "cube", ["1", "2"])
         obj.cube = ["1", "2", "3", "4", "5", "6"]
         self.assertListEqual(obj.cube, ["1", "2", "3", "4", "5", "6"])
+
+        obj2 = threed.SceneBackground._from_dict(obj.as_dict())
+        self.assertEqual(obj, obj2)

--- a/tests/unittests/threed/scene_3d_tests.py
+++ b/tests/unittests/threed/scene_3d_tests.py
@@ -15,6 +15,8 @@ from unittest.mock import mock_open, patch
 from fiftyone.core import threed
 from fiftyone.core.threed.utils import convert_keys_to_snake_case
 
+from tests.unittests.threed.dataclass_test_utils import *
+
 
 class TestScene(unittest.TestCase):
     def setUp(self):
@@ -162,3 +164,20 @@ class TestScene(unittest.TestCase):
             "another_key": "value",
         }
         self.assertEqual(convert_keys_to_snake_case(input_dict), expected_dict)
+
+
+class TestSceneBackground(unittest.TestCase):
+    def test_it(self):
+        obj = threed.SceneBackground()
+        self.assertEqual(obj, threed.SceneBackground(None, None, None, 1.0))
+        self.assertRaises(ValueError, setattr, obj, "another_field", 51)
+
+        assert_color_prop(self, obj, "color", nullable=True)
+        assert_string_prop(self, obj, "image", nullable=True)
+        assert_float_prop(self, obj, "intensity", nullable=True)
+
+        # Custom cube tests
+        self.assertRaises(ValueError, setattr, obj, "cube", 51.51)
+        self.assertRaises(ValueError, setattr, obj, "cube", ["1", "2"])
+        obj.cube = ["1", "2", "3", "4", "5", "6"]
+        self.assertListEqual(obj.cube, ["1", "2", "3", "4", "5", "6"])

--- a/tests/unittests/threed/transformation_tests.py
+++ b/tests/unittests/threed/transformation_tests.py
@@ -12,8 +12,6 @@ import numpy as np
 
 from fiftyone.core import threed
 
-from tests.unittests.threed.dataclass_test_utils import *
-
 
 class Test3DBasicGeometry(unittest.TestCase):
     def test_euler_initialization(self):
@@ -21,7 +19,7 @@ class Test3DBasicGeometry(unittest.TestCase):
         self.assertEqual((e.x, e.y, e.z), (90, 45, 30))
 
     def test_vector3_initialization(self):
-        v = Vector3(1, 2, 3)
+        v = threed.Vector3(1, 2, 3)
         self.assertEqual((v.x, v.y, v.z), (1, 2, 3))
 
     def test_quaternion_initialization(self):

--- a/tests/unittests/threed/transformation_tests.py
+++ b/tests/unittests/threed/transformation_tests.py
@@ -1,0 +1,136 @@
+"""
+FiftyOne 3D transformation unit tests.
+
+| Copyright 2017-2024, Voxel51, Inc.
+| `voxel51.com <https://voxel51.com/>`_
+|
+"""
+
+import unittest
+
+import numpy as np
+
+from fiftyone.core import threed
+
+from tests.unittests.threed.dataclass_test_utils import *
+
+
+class Test3DBasicGeometry(unittest.TestCase):
+    def test_euler_initialization(self):
+        e = threed.Euler(90, 45, 30)
+        self.assertEqual((e.x, e.y, e.z), (90, 45, 30))
+
+    def test_vector3_initialization(self):
+        v = Vector3(1, 2, 3)
+        self.assertEqual((v.x, v.y, v.z), (1, 2, 3))
+
+    def test_quaternion_initialization(self):
+        q = threed.Quaternion()
+        self.assertEqual((q.x, q.y, q.z, q.w), (0, 0, 0, 1))
+
+    def test_euler_to_quaternion_conversion(self):
+        e = threed.Euler(90, 0, 0, degrees=True)
+        q = e.to_quaternion()
+        self.assertIsInstance(q, threed.Quaternion)
+        np.testing.assert_array_almost_equal(
+            (q.x, q.y, q.z, q.w), (0.70710678, 0, 0, 0.70710678), decimal=5
+        )
+
+    def test_quaternion_to_euler_conversion(self):
+        q = threed.Quaternion(0.5609855, -0.4304593, 0.7010574, 0.092296)
+        e = q.to_euler(degrees=True)
+        self.assertIsInstance(e, threed.Euler)
+        np.testing.assert_array_almost_equal(
+            (e.x, e.y, e.z), (90, 45, 120), decimal=5
+        )
+
+
+class TestTransformationDataclasses(unittest.TestCase):
+    def test_vector3(self):
+        obj = threed.Vector3()
+        self.assertEqual(
+            obj,
+            threed.Vector3(0.0, 0.0, 0.0),
+        )
+        self.assertRaises(ValueError, setattr, obj, "another_field", 51)
+
+        self.assertRaises(AttributeError, setattr, obj, "x", 51.51)
+        self.assertRaises(AttributeError, setattr, obj, "y", 51.51)
+        self.assertRaises(AttributeError, setattr, obj, "z", 51.51)
+
+        obj = threed.Vector3(51.51, 52.52, 53.53)
+        self.assertEqual((obj.x, obj.y, obj.z), (51.51, 52.52, 53.53))
+
+        self.assertTrue(
+            np.array_equal(obj.to_arr(), np.array([51.51, 52.52, 53.53]))
+        )
+
+    def test_euler(self):
+        obj = threed.Euler()
+        self.assertEqual(
+            obj,
+            threed.Euler(0.0, 0.0, 0.0, False, "XYZ"),
+        )
+        self.assertRaises(ValueError, setattr, obj, "another_field", 51)
+
+        self.assertRaises(AttributeError, setattr, obj, "x", 51.51)
+        self.assertRaises(AttributeError, setattr, obj, "y", 51.51)
+        self.assertRaises(AttributeError, setattr, obj, "z", 51.51)
+        self.assertRaises(AttributeError, setattr, obj, "degrees", True)
+        self.assertRaises(AttributeError, setattr, obj, "sequence", "ZYX")
+
+        obj = threed.Euler(51.51, 52.52, 53.53, True, "ZYX")
+        self.assertEqual(
+            (obj.x, obj.y, obj.z, obj.degrees, obj.sequence),
+            (51.51, 52.52, 53.53, True, "ZYX"),
+        )
+
+        self.assertRaises(
+            ValueError, threed.Euler, 0.0, 0.0, 0.0, False, "blah"
+        )
+        self.assertRaises(ValueError, threed.Euler, 0.0, 0.0, 0.0, False, None)
+        self.assertRaises(ValueError, threed.Euler, "error", 0.0, 0.0)
+        self.assertRaises(ValueError, threed.Euler, 0.0, "error", 0.0)
+        self.assertRaises(ValueError, threed.Euler, 0.0, 0.0, "error")
+
+        self.assertTrue(
+            np.array_equal(obj.to_arr(), np.array([51.51, 52.52, 53.53]))
+        )
+
+    def test_quaternion(self):
+        obj = threed.Quaternion()
+        self.assertEqual(
+            obj,
+            threed.Quaternion(0.0, 0.0, 0.0, 1.0),
+        )
+        self.assertRaises(ValueError, setattr, obj, "another_field", 51)
+
+        self.assertRaises(AttributeError, setattr, obj, "x", 51.51)
+        self.assertRaises(AttributeError, setattr, obj, "y", 51.51)
+        self.assertRaises(AttributeError, setattr, obj, "z", 51.51)
+        self.assertRaises(AttributeError, setattr, obj, "w", 51.51)
+
+        obj = threed.Quaternion(51.51, 52.52, 53.53, 54.54)
+        self.assertEqual(
+            (obj.x, obj.y, obj.z, obj.w),
+            (51.51, 52.52, 53.53, 54.54),
+        )
+
+        self.assertRaises(
+            ValueError, threed.Quaternion, "error", 0.0, 0.0, 1.0
+        )
+        self.assertRaises(
+            ValueError, threed.Quaternion, 0.0, "error", 0.0, 1.0
+        )
+        self.assertRaises(
+            ValueError, threed.Quaternion, 0.0, 0.0, "error", 1.0
+        )
+        self.assertRaises(
+            ValueError, threed.Quaternion, 0.0, 0.0, 0.0, "error"
+        )
+
+        self.assertTrue(
+            np.array_equal(
+                obj.to_arr(), np.array([51.51, 52.52, 53.53, 54.54])
+            )
+        )


### PR DESCRIPTION
## What changes are proposed in this pull request?

Remove `pydantic` requirement previously introduced but not yet included in a release.

Rationale: we were not using `pydantic` pervasively. And while it is a solid library, we should be frugal in adding new dependencies, else we run the risk of breaking some users' environments.

To do this while maintaining functionality (actually improving on it as it was previously implemented because validation setting didn't seem to be turned on):
- transform `pydantic.dataclass` into a "dataclass" of our own that enforces validation on both init and set.
- disallows setting unknown public properties (further footgun protection which pydantic itself does not even do.
- maintain same `__eq__()` and `__repr()__` behavior by implementing in `BaseValidatedDataClass`
- left classes alone that were NOT `dataclasses` previously, like `Object3D` and descendants.

If we use `pydantic` for something more pervasive such as replacing `mongoengine` in the future, we should come back and replace this.

### Alternatives
1. Nothing, require pydantic>=2
   - too restrictive, will break some user envs
2. Relax pydantic to either 1 or 2
   - Better but still adds a new dep for somewhat minimal usage (deemed not worth it)
3. Use builtin `dataclasses` without type validation
   - Less boilerplate code but introduces footguns in a place where it would be hard to debug why a certain setting wasn't being respected.
4. Use builtin `dataclasses` with validation
   - Hard to add validation on both init and set.

### Downsides
- higher amount of boilerplate code that would be abstracted away when using `dataclasses` (builtin or pydantic).

## How is this patch tested? If it is not, please explain why.

added a bajillion unit tests like for real


## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Enhanced testing frameworks for 3D components, including cameras, materials, and transformations.
  - Introduced comprehensive validation tests for data properties.
  
- **New Features**
  - Improved data validation logic for 3D transformations, enhancing stability and reliability.
  
- **Refactor**
  - Updated 3D transformation classes to inherit new base validation functionalities, ensuring more robust data handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->