### PR TITLE
fix mistaken falsey 0 bug

### DIFF
--- a/app/packages/looker/src/overlays/index.test.ts
+++ b/app/packages/looker/src/overlays/index.test.ts
@@ -37,7 +37,7 @@ describe("label overlay processing", () => {
       index: 1,
     } as RegularLabel);
 
-    const hashLabelWithUndefindedIndex = getHashLabel({
+    const hashLabelWithUndefinedIndex = getHashLabel({
       id: "id-no-index",
       label: "label-no-index",
     } as RegularLabel);
@@ -48,7 +48,7 @@ describe("label overlay processing", () => {
 
     expect(hashLabelWithIndex0).toEqual("zero-index-label.0");
     expect(hashLabelWithIndex1).toEqual("one-index-label.1");
-    expect(hashLabelWithUndefindedIndex).toEqual("label-no-index.id-no-index");
+    expect(hashLabelWithUndefinedIndex).toEqual("label-no-index.id-no-index");
     expect(hashLabelWithUndefinedIndexUndefinedId).toEqual(
       "only-label-no-index-no-id"
     );

--- a/app/packages/looker/src/overlays/index.test.ts
+++ b/app/packages/looker/src/overlays/index.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from "vitest";
 
+import { RegularLabel } from "./base";
 import DetectionOverlay from "./detection";
 import * as index from "./index";
+import { getHashLabel } from "./util";
 
 describe("label overlay processing", () => {
   it("omits undefined labels", () => {
@@ -20,5 +22,35 @@ describe("label overlay processing", () => {
     expect(
       index.fromLabelList(DetectionOverlay, "detections")("field", {})
     ).toStrictEqual([]);
+  });
+
+  it("label hash is generated correctly", () => {
+    const hashLabelWithIndex0 = getHashLabel({
+      id: "id-0",
+      label: "zero-index-label",
+      index: 0,
+    } as RegularLabel);
+
+    const hashLabelWithIndex1 = getHashLabel({
+      id: "id-1",
+      label: "one-index-label",
+      index: 1,
+    } as RegularLabel);
+
+    const hashLabelWithUndefindedIndex = getHashLabel({
+      id: "id-no-index",
+      label: "label-no-index",
+    } as RegularLabel);
+
+    const hashLabelWithUndefinedIndexUndefinedId = getHashLabel({
+      label: "only-label-no-index-no-id",
+    } as RegularLabel);
+
+    expect(hashLabelWithIndex0).toEqual("zero-index-label.0");
+    expect(hashLabelWithIndex1).toEqual("one-index-label.1");
+    expect(hashLabelWithUndefindedIndex).toEqual("label-no-index.id-no-index");
+    expect(hashLabelWithUndefinedIndexUndefinedId).toEqual(
+      "only-label-no-index-no-id"
+    );
   });
 });

--- a/app/packages/looker/src/overlays/util.ts
+++ b/app/packages/looker/src/overlays/util.ts
@@ -135,7 +135,10 @@ export const convertId = (obj: Record<string, any>): Record<string, any> => {
 };
 
 export const getHashLabel = (label: RegularLabel): string => {
-  if (label?.index && ["number", "string"].includes(typeof label?.index)) {
+  if (
+    typeof label?.index !== "undefined" &&
+    ["number", "string"].includes(typeof label?.index)
+  ) {
     return `${label.label}.${label.index}`;
   } else if (label?.label && label?.id) {
     return `${label.label}.${label.id}`;

--- a/app/packages/looker/src/overlays/util.ts
+++ b/app/packages/looker/src/overlays/util.ts
@@ -137,11 +137,11 @@ export const convertId = (obj: Record<string, any>): Record<string, any> => {
 export const getHashLabel = (label: RegularLabel): string => {
   if (["number", "string"].includes(typeof label?.index)) {
     return `${label.label}.${label.index}`;
-  } else if (label?.label && label?.id) {
-    return `${label.label}.${label.id}`;
-  } else {
-    return `${label}`;
   }
+  if (typeof label?.label !== "undefined" && typeof label?.id !== "undefined") {
+    return `${label.label}.${label.id}`;
+  }
+  return `${label.label}`;
 };
 
 export const shouldShowLabelTag = (

--- a/app/packages/looker/src/overlays/util.ts
+++ b/app/packages/looker/src/overlays/util.ts
@@ -135,10 +135,7 @@ export const convertId = (obj: Record<string, any>): Record<string, any> => {
 };
 
 export const getHashLabel = (label: RegularLabel): string => {
-  if (
-    typeof label?.index !== "undefined" &&
-    ["number", "string"].includes(typeof label?.index)
-  ) {
+  if (["number", "string"].includes(typeof label?.index)) {
     return `${label.label}.${label.index}`;
   } else if (label?.label && label?.id) {
     return `${label.label}.${label.id}`;


### PR DESCRIPTION
`0` is falsey in JS, which is what led to this bug of index-0 labels getting assigned randomized colors 😭 

### Before
![color-bug-before-small](https://github.com/voxel51/fiftyone/assets/66688606/d1d8caeb-92dc-48ec-9357-daa8987ab005)

### After 
![color-bug-after-small](https://github.com/voxel51/fiftyone/assets/66688606/213b208a-c038-4057-8feb-6f863cd41280)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Bug Fixes**
	- Improved reliability in label processing by ensuring checks for label index presence before evaluation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->