### PR TITLE
add plot util

### DIFF
--- a/app/packages/core/src/plugins/SchemaIO/components/DropdownView.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/DropdownView.tsx
@@ -76,7 +76,7 @@ export default function DropdownView(props) {
             Array.isArray(value) && type !== "array"
               ? value.join(separator)
               : value;
-          onChange(path, computedValue);
+          onChange(path, computedValue, schema);
           setUserChanged();
         }}
         multiple={multiple}

--- a/app/packages/core/src/plugins/SchemaIO/components/PlotlyView.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/PlotlyView.tsx
@@ -113,8 +113,6 @@ export default function PlotlyView(props) {
   const mergedConfig = merge({}, configDefaults, config);
   const mergedData = mergeData(data, dataDefaults);
 
-  console.log(mergedLayout);
-
   return (
     <Box
       {...getComponentProps(props, "container")}
@@ -188,6 +186,9 @@ const EventDataMappers = {
 };
 
 function mergeData(data, defaults) {
+  if (!Array.isArray(data)) {
+    data = [data];
+  }
   return (data || []).map((trace) => {
     return {
       ...trace,

--- a/app/packages/core/src/plugins/SchemaIO/index.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/index.tsx
@@ -16,6 +16,7 @@ export function SchemaIOComponent(props) {
   const onIOChange = useCallback(
     (path, value, schema) => {
       if (onPathChange) {
+        console.log("onPathChange", path, value, schema);
         onPathChange(path, value, schema);
       }
       const currentState = stateRef.current;

--- a/app/packages/core/src/plugins/SchemaIO/index.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/index.tsx
@@ -16,7 +16,6 @@ export function SchemaIOComponent(props) {
   const onIOChange = useCallback(
     (path, value, schema) => {
       if (onPathChange) {
-        console.log("onPathChange", path, value, schema);
         onPathChange(path, value, schema);
       }
       const currentState = stateRef.current;

--- a/app/packages/operators/src/constants.ts
+++ b/app/packages/operators/src/constants.ts
@@ -3,6 +3,7 @@ export const PALETTE_CONTROL_KEYS = ["Enter", "Escape"];
 export const RESOLVE_PLACEMENTS_TTL = 2500;
 export const RESOLVE_TYPE_TTL = 500;
 export const RESOLVE_INPUT_VALIDATION_TTL = 750;
+export const PANEL_LOAD_TIMEOUT = 3000;
 export enum OPERATOR_PROMPT_AREAS {
   DRAWER_LEFT = "operator_prompt_area_drawer_left",
   DRAWER_RIGHT = "operator_prompt_area_drawer_right",

--- a/app/packages/operators/src/operators.ts
+++ b/app/packages/operators/src/operators.ts
@@ -538,7 +538,6 @@ export async function executeOperatorWithContext(
   uri: string,
   ctx: ExecutionContext
 ) {
-  console.log("executeOperatorWithContext", uri);
   const { operatorURI, params } = resolveOperatorURIWithMethod(uri, ctx.params);
   ctx.params = params;
   const { operator, isRemote } = getLocalOrRemoteOperator(operatorURI);

--- a/app/packages/operators/src/useCustomPanelHooks.ts
+++ b/app/packages/operators/src/useCustomPanelHooks.ts
@@ -40,7 +40,6 @@ export function useCustomPanelHooks(props: CustomPanelProps): CustomPanelHooks {
   const view = useRecoilValue(fos.view);
 
   useEffect(() => {
-    log("CustomPanel loaded", panelId, props.onLoad);
     if (props.onLoad && !panelState?.loaded) {
       executeOperator(props.onLoad, { panel_id: panelId });
       setPanelState((s) => ({ ...s, loaded: true }));
@@ -77,7 +76,6 @@ export function useCustomPanelHooks(props: CustomPanelProps): CustomPanelHooks {
   };
 
   const handlePanelStatePathChange = (path, value, schema) => {
-    log("handlePanelStatePathChange", path, value, schema);
     if (schema?.onChange) {
       triggerPanelPropertyChange(panelId, {
         operator: schema.onChange,
@@ -100,8 +98,4 @@ function getPanelViewData(panelState) {
   const state = panelState?.state;
   const data = panelState?.data;
   return merge({}, { ...state }, { ...data });
-}
-
-function log(message: string, ...data: any[]) {
-  console.log(message, ...data);
 }

--- a/fiftyone/operators/types.py
+++ b/fiftyone/operators/types.py
@@ -276,7 +276,7 @@ class Object(BaseType):
         return obj
 
     def plot(self, name, **kwargs):
-        """Defines a plot view as a :class:`View`.
+        """Defines an object property displayed as a plot.
 
         Args:
             name: the name of the property

--- a/fiftyone/operators/types.py
+++ b/fiftyone/operators/types.py
@@ -275,6 +275,19 @@ class Object(BaseType):
         self.define_property(name, obj, view=grid)
         return obj
 
+    def plot(self, name, **kwargs):
+        """Defines a plot view as a :class:`View`.
+
+        Args:
+            name: the name of the property
+            config (None): the chart config
+            layout (None): the chart layout
+        """
+        plot = PlotlyView(**kwargs)
+        obj = Object()
+        self.define_property(name, obj, view=plot)
+        return obj
+
     def clone(self):
         """Clones the definition of the object.
 


### PR DESCRIPTION
Adds a utility to `foo.types.Object()` for quickly defining a plot object property.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
  - Added enhanced functionality to the dropdown component to support schema-based operations.
  - Introduced a new plotting method in the operators to facilitate advanced data visualization.

- **Bug Fixes**
  - Improved data handling in the plotting component to ensure stability and correctness.

- **Chores**
  - Implemented a new constant to manage panel loading timeouts more effectively.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->