### PR TITLE
doc: remove link to unsupported tiff extension

### DIFF
--- a/docs/source/faq/index.rst
+++ b/docs/source/faq/index.rst
@@ -216,9 +216,8 @@ which includes standard image types like JPEG, PNG, and BMP.
 
 Some browsers like Safari natively support other image types such as TIFF,
 while others do not. You may be able to install a browser extension to work
-with additional image types. For example, you can install
-`this extension <https://github.com/my-codeworks/tiff-viewer-extension>`_ to
-view TIFF images in Chrome or Firefox.
+with additional image types, but Voxel51 does not currently recommend any
+such extensions in particular.
 
 .. note::
 


### PR DESCRIPTION
The chrome extension for TIFF viewing has been reported to be unsupported / not working. We should remove the link and just say we don't have a recommendation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Removed a specific recommendation for browser extensions from the FAQ section regarding viewing TIFF images in Chrome or Firefox.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->