### PR TITLE
debounce spaces updates to session

### DIFF
--- a/app/packages/state/src/hooks/useSessionSpaces.ts
+++ b/app/packages/state/src/hooks/useSessionSpaces.ts
@@ -1,7 +1,9 @@
-import { size } from "lodash";
-import { useMemo } from "react";
+import { debounce, size } from "lodash";
+import { useCallback, useMemo } from "react";
 import { useRecoilState } from "recoil";
 import { sessionSpaces } from "../recoil";
+
+const SESSION_UPDATE_DEBOUNCE = 500;
 
 const useSessionSpaces = () => {
   const [sessionSpacesState, setSessionSpacesState] =
@@ -17,11 +19,26 @@ const useSessionSpaces = () => {
     [computedSessionSpaces]
   );
 
-  function setSessionSpaces(spaces: object, panelsState?: object) {
-    const formattedSpaces = toAPIFormat(spaces, panelsState);
-    setSessionSpacesState(formattedSpaces);
-  }
-  return [computedSessionSpaces, setSessionSpaces, computedPanelsState];
+  const setSessionSpaces = useCallback(
+    (spaces: object, panelsState?: object) => {
+      const formattedSpaces = toAPIFormat(spaces, panelsState);
+      setSessionSpacesState(formattedSpaces);
+    },
+    [setSessionSpacesState]
+  );
+
+  const setSessionSpacesDebounced = useMemo(() => {
+    return debounce(setSessionSpaces, SESSION_UPDATE_DEBOUNCE, {
+      leading: true,
+      trailing: true,
+    });
+  }, [setSessionSpaces]);
+
+  return [
+    computedSessionSpaces,
+    setSessionSpacesDebounced,
+    computedPanelsState,
+  ];
 };
 
 export default useSessionSpaces;


### PR DESCRIPTION
## What changes are proposed in this pull request?

Debounce updating session on spaces layout/state update to avoid per change session mutation requests

## How is this patch tested? If it is not, please explain why.

Using a panel with a text input whose state is stored in persistent panel state

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Enhancements**
  - Improved the `useSessionSpaces` hook with debouncing to optimize performance when updating session spaces.

- **Refactor**
  - Removed the `PANEL_LOAD_TIMEOUT` constant from the codebase.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->