### PR TITLE
add translate on shift + left mouse

### DIFF
--- a/app/packages/looker-3d/src/action-bar/ViewHelp.tsx
+++ b/app/packages/looker-3d/src/action-bar/ViewHelp.tsx
@@ -7,7 +7,7 @@ export const LOOKER3D_HELP_ITEMS = [
   { shortcut: "Left mouse drag", title: "Rotate", detail: "Rotate the camera" },
   { shortcut: "Wheel", title: "Zoom", detail: "Zoom in and out" },
   {
-    shortcut: "Middle mouse drag",
+    shortcut: "Shift + drag",
     title: "Translate",
     detail: "Translate the camera",
   },

--- a/app/packages/looker-3d/src/fo3d/MediaTypeFo3d.tsx
+++ b/app/packages/looker-3d/src/fo3d/MediaTypeFo3d.tsx
@@ -2,6 +2,7 @@ import { usePluginSettings } from "@fiftyone/plugins";
 import * as fos from "@fiftyone/state";
 import { AdaptiveDpr, AdaptiveEvents, CameraControls } from "@react-three/drei";
 import { Canvas, RootState } from "@react-three/fiber";
+import CameraControlsImpl from "camera-controls";
 import {
   Suspense,
   useCallback,
@@ -103,6 +104,42 @@ export const MediaTypeFo3dComponent = () => {
 
   const cameraRef = useRef<THREE.PerspectiveCamera>();
   const cameraControlsRef = useRef<CameraControls>();
+
+  const keyState = useRef({
+    shiftRight: false,
+    shiftLeft: false,
+    controlRight: false,
+    controlLeft: false,
+  });
+
+  const updateCameraControlsConfig = useCallback(() => {
+    if (keyState.current.shiftRight || keyState.current.shiftLeft) {
+      cameraControlsRef.current.mouseButtons.left =
+        CameraControlsImpl.ACTION.TRUCK;
+    } else if (keyState.current.controlRight || keyState.current.controlLeft) {
+      cameraControlsRef.current.mouseButtons.left =
+        CameraControlsImpl.ACTION.DOLLY;
+    } else {
+      cameraControlsRef.current.mouseButtons.left =
+        CameraControlsImpl.ACTION.ROTATE;
+    }
+  }, [keyState]);
+
+  fos.useEventHandler(document, "keydown", (e: KeyboardEvent) => {
+    if (e.code === "ShiftRight") keyState.current.shiftRight = true;
+    if (e.code === "ShiftLeft") keyState.current.shiftLeft = true;
+    if (e.code === "ControlRight") keyState.current.controlRight = true;
+    if (e.code === "ControlLeft") keyState.current.controlLeft = true;
+    updateCameraControlsConfig();
+  });
+
+  fos.useEventHandler(document, "keyup", (e: KeyboardEvent) => {
+    if (e.code === "ShiftRight") keyState.current.shiftRight = false;
+    if (e.code === "ShiftLeft") keyState.current.shiftLeft = false;
+    if (e.code === "ControlRight") keyState.current.controlRight = false;
+    if (e.code === "ControlLeft") keyState.current.controlLeft = false;
+    updateCameraControlsConfig();
+  });
 
   const assetsGroupRef = useRef<THREE.Group>();
   const sceneBoundingBox = useFo3dBounds(assetsGroupRef);


### PR DESCRIPTION
## What changes are proposed in this pull request?

New camera controls doesn't have translate on shift + left click by default. Instead, it uses right mouse, or two-finger move / three-finger move on trackpads. This isn't consistent with our prior CX, which used shift + click for trucking. This PR fixes that.

## How is this patch tested? If it is not, please explain why.

Manually.