### PR TITLE
include location, dimensions, and rotation in fo3d

### DIFF
--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -1041,7 +1041,7 @@ class SampleCollection(object):
                 use_db_fields=use_db_fields,
             )
 
-            # These fields are currently not declared by default on point cloud
+            # These fields are currently not declared by default on 3D
             # datasets/slices, but they should be considered as default
             media_types = media_types if media_types else set()
             if issubclass(field.document_type, fol.Detection) and (
@@ -1102,11 +1102,12 @@ class SampleCollection(object):
                 use_db_fields=use_db_fields,
             )
 
-            # These fields are currently not declared by default on point cloud
-            # datasets/slices, but they should be considered as default
-            if issubclass(
-                field.document_type, fol.Detection
-            ) and self._contains_media_type(fom.POINT_CLOUD, any_slice=True):
+            # These fields are currently not declared by default on 3D
+            # datasets/slices, but they should be
+            if issubclass(field.document_type, fol.Detection) and (
+                self._contains_media_type(fom.POINT_CLOUD, any_slice=True)
+                or self._contains_media_type(fom.THREE_D, any_slice=True)
+            ):
                 field_names = tuple(
                     set(field_names) | {"location", "dimensions", "rotation"}
                 )

--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -1045,8 +1045,12 @@ class SampleCollection(object):
             # datasets/slices, but they should be considered as default
             media_types = media_types if media_types else set()
             if issubclass(field.document_type, fol.Detection) and (
-                self._contains_media_type(fom.POINT_CLOUD, any_slice=True)
-                or fom.POINT_CLOUD in media_types
+                (
+                    self._contains_media_type(fom.POINT_CLOUD, any_slice=True)
+                    or self._contains_media_type(fom.THREE_D, any_slice=True)
+                    or fom.POINT_CLOUD in media_types
+                    or fom.THREE_D in media_types
+                )
             ):
                 field_names = tuple(
                     set(field_names) | {"location", "dimensions", "rotation"}


### PR DESCRIPTION
PCD detection fields are treated as default by `SelectFields`, but that should also apply to FO3D. One of the symptoms of it not being included is that labels are not painted in the grid for fo3d files. This PR fixes that.

<img width="1511" alt="Screenshot 2024-05-07 at 3 55 06 PM" src="https://github.com/voxel51/fiftyone/assets/66688606/ecd4c490-1174-48e3-a6df-0b96afd4abd6">

<img width="1512" alt="Screenshot 2024-05-07 at 3 55 34 PM" src="https://github.com/voxel51/fiftyone/assets/66688606/d179e66e-b302-4c24-93cb-1cf8d551b0c7">


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced media type handling to include 3D models in addition to point clouds for field name determination in collections management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->