### PR TITLE
3D export fixes and tests

### DIFF
--- a/fiftyone/core/threed/scene_3d.py
+++ b/fiftyone/core/threed/scene_3d.py
@@ -248,12 +248,56 @@ class Scene(Object3D):
 
         Args:
             include_self: whether to include the current node in the traversal
+
+        Yields:
+            :class:`Object3D`
+
         """
         if include_self:
             yield self
 
         for child in self.children:
             yield from child.traverse(include_self=True)
+
+    def update_asset_paths(self, asset_rewrite_paths: dict):
+        """Update asset paths in this scene according to an input dict mapping.
+
+        Asset path is unchanged if it does not exist in ``asset_rewrite_paths``
+
+        Args:
+            asset_rewrite_paths: ``dict`` mapping asset path to new asset path
+
+        Returns:
+            ``True`` if the scene was modified.
+        """
+        scene_modified = False
+        for node in self.traverse():
+            for path_attribute in node._asset_path_fields:
+                asset_path = getattr(node, path_attribute, None)
+                new_asset_path = asset_rewrite_paths.get(asset_path)
+
+                if asset_path is not None and asset_path != new_asset_path:
+                    setattr(node, path_attribute, new_asset_path)
+                    scene_modified = True
+
+        # modify scene background paths, if any
+        if self.background is not None:
+            if self.background.image is not None:
+                new_asset_path = asset_rewrite_paths.get(self.background.image)
+                if new_asset_path != self.background.image:
+                    self.background.image = new_asset_path
+                    scene_modified = True
+
+            if self.background.cube is not None:
+                new_cube = [
+                    asset_rewrite_paths.get(face)
+                    for face in self.background.cube
+                ]
+                if new_cube != self.background.cube:
+                    self.background.cube = new_cube
+                    scene_modified = True
+
+        return scene_modified
 
     def get_scene_summary(self):
         """Returns a summary of the scene."""

--- a/fiftyone/utils/data/exporters.py
+++ b/fiftyone/utils/data/exporters.py
@@ -1221,13 +1221,6 @@ class MediaExporter(object):
                     is_scene_modified = True
 
             if scene.background.cube is not None:
-                new_asset_path = input_to_output_paths.get(
-                    scene.background.image
-                )
-                if new_asset_path != scene.background.image:
-                    scene.background.image = new_asset_path
-                    is_scene_modified = True
-
                 new_cube = [
                     input_to_output_paths.get(face)
                     for face in scene.background.cube

--- a/fiftyone/utils/data/exporters.py
+++ b/fiftyone/utils/data/exporters.py
@@ -1199,35 +1199,7 @@ class MediaExporter(object):
             elif export_mode == "symlink":
                 etau.symlink_file(absolute_asset_path, asset_output_path)
 
-        is_scene_modified = False
-
-        for node in scene.traverse():
-            for path_attribute in node._asset_path_fields:
-                asset_path = getattr(node, path_attribute, None)
-                new_asset_path = input_to_output_paths.get(asset_path)
-
-                if asset_path is not None and asset_path != new_asset_path:
-                    setattr(node, path_attribute, new_asset_path)
-                    is_scene_modified = True
-
-        # modify scene background paths, if any
-        if scene.background is not None:
-            if scene.background.image is not None:
-                new_asset_path = input_to_output_paths.get(
-                    scene.background.image
-                )
-                if new_asset_path != scene.background.image:
-                    scene.background.image = new_asset_path
-                    is_scene_modified = True
-
-            if scene.background.cube is not None:
-                new_cube = [
-                    input_to_output_paths.get(face)
-                    for face in scene.background.cube
-                ]
-                if new_cube != scene.background.cube:
-                    scene.background.cube = new_cube
-                    is_scene_modified = True
+        is_scene_modified = scene.update_asset_paths(input_to_output_paths)
 
         if is_scene_modified:
             # note: we can't have different behavior for "symlink" because

--- a/tests/unittests/import_export_tests.py
+++ b/tests/unittests/import_export_tests.py
@@ -4897,7 +4897,6 @@ class ThreeDMediaTests(unittest.TestCase):
             self.assertEqual(scene3.background.image, "../../image.jpeg")
 
             for file in scene3.get_asset_paths():
-                print(file)
                 with open(os.path.join(export_dir, "label2/test/", file)) as f:
                     self.assertEqual(
                         f.read(),


### PR DESCRIPTION
Checkpointing my work in case I don't get to finish it.

1. added tests for at least 4 different configurations of fo3d data layout + relative vs. absolute + flatten vs. rel_dir.
2. Fixed a few bugs caught by tests
   - .mtl file in ObjMesh wasn't getting rewritten (it was only checking first asset path for each node)
   - use input to output asset path map to determine when we need to rewrite asset path in the fo3d file. fixes the case when flattening (no `rel_dir`) causes a file to be renamed from, say, `pcd.pcd` to `pcd-2.pcd`

The tests are absolutely horrendous on the eyes, I'm so sorry!! They could be refactored to something nicer but didn't have time right now.

What I would like to do if I have time:
- allow `asset_dir`
- make changes work with Teams which includes `fos.resolve()` and a cloud friendly `os.path.relpath()` if it doesn't already exist. Actually the latter probably just works but we would want to double check.
- make a batch media exporter that does this in bulk instead of one at a time. Then re-use that for `fos.upload_media()` and `download_media()` in Teams so we don't have the same fragile code implemented twice. With the side benefit that export should be faster.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a method to update asset paths in 3D scenes, enhancing the management of asset locations based on user-defined mappings.
- **Tests**
	- Added new tests for 3D media handling, ensuring robustness and reliability in asset path updates and scene integrity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->