### PR TITLE
operator callback and workspaces cleanup and fixes

### DIFF
--- a/app/packages/components/src/components/MuiButton/index.tsx
+++ b/app/packages/components/src/components/MuiButton/index.tsx
@@ -1,0 +1,23 @@
+import React from "react";
+import { ButtonProps, CircularProgress, Button, Stack } from "@mui/material";
+
+export default function MuiButton(props: ButtonPropsType) {
+  const { loading, ...otherProps } = props;
+  return (
+    <Stack
+      direction="row"
+      spacing={2}
+      alignItems="center"
+      sx={{ position: "relative" }}
+    >
+      <Button {...otherProps} />
+      {loading && (
+        <CircularProgress size={20} sx={{ position: "absolute", left: 6 }} />
+      )}
+    </Stack>
+  );
+}
+
+type ButtonPropsType = ButtonProps & {
+  loading?: boolean;
+};

--- a/app/packages/components/src/components/index.ts
+++ b/app/packages/components/src/components/index.ts
@@ -29,3 +29,4 @@ export { default as TabOption } from "./TabOption";
 export { default as TextField } from "./TextField";
 export { default as ThemeProvider, useFont, useTheme } from "./ThemeProvider";
 export { default as Tooltip } from "./Tooltip";
+export { default as MuiButton } from "./MuiButton";

--- a/app/packages/operators/src/OperatorInvocationRequestExecutor.tsx
+++ b/app/packages/operators/src/OperatorInvocationRequestExecutor.tsx
@@ -29,7 +29,9 @@ function RequestExecutor({ queueItem, onSuccess, onError }) {
   });
 
   useEffect(() => {
-    executor.execute(queueItem.request.params);
+    executor.execute(queueItem.request.params, {
+      callback: queueItem.callback,
+    });
   }, []);
 
   return null;

--- a/app/packages/operators/src/OperatorInvocationRequestExecutor.tsx
+++ b/app/packages/operators/src/OperatorInvocationRequestExecutor.tsx
@@ -31,6 +31,7 @@ function RequestExecutor({ queueItem, onSuccess, onError }) {
   useEffect(() => {
     executor.execute(queueItem.request.params, {
       callback: queueItem.callback,
+      ...(queueItem?.request?.options || {}),
     });
   }, []);
 

--- a/app/packages/operators/src/state.ts
+++ b/app/packages/operators/src/state.ts
@@ -27,8 +27,8 @@ import {
   resolveExecutionOptions,
 } from "./operators";
 import { Places } from "./types";
+import { OperatorExecutorOptions } from "./types-internal";
 import { ValidationContext } from "./validation";
-import { ExecutionCallback } from "./types-internal";
 
 export const promptingOperatorState = atom({
   key: "promptingOperator",
@@ -831,13 +831,6 @@ export function useOperatorBrowser() {
     query,
   };
 }
-
-type OperatorExecutorOptions = {
-  delegationTarget?: string;
-  requestDelegation?: boolean;
-  skipOutput?: boolean;
-  callback?: ExecutionCallback;
-};
 
 export function useOperatorExecutor(uri, handlers: any = {}) {
   if (!uri.includes("/")) {

--- a/app/packages/operators/src/types-internal.ts
+++ b/app/packages/operators/src/types-internal.ts
@@ -1,0 +1,3 @@
+import { OperatorResult } from "./operators";
+
+export type ExecutionCallback = (result: OperatorResult) => void;

--- a/app/packages/operators/src/types-internal.ts
+++ b/app/packages/operators/src/types-internal.ts
@@ -1,3 +1,10 @@
 import { OperatorResult } from "./operators";
 
 export type ExecutionCallback = (result: OperatorResult) => void;
+
+export type OperatorExecutorOptions = {
+  delegationTarget?: string;
+  requestDelegation?: boolean;
+  skipOutput?: boolean;
+  callback?: ExecutionCallback;
+};

--- a/app/packages/spaces/src/components/Space.tsx
+++ b/app/packages/spaces/src/components/Space.tsx
@@ -15,7 +15,7 @@ import {
 import AddPanelButton from "./AddPanelButton";
 import Panel from "./Panel";
 import PanelTab from "./PanelTab";
-import SavedSpaces from "./SavedSpaces";
+import Workspaces from "./Workspaces";
 import SplitPanelButton from "./SplitPanelButton";
 import { PanelContainer, PanelTabs, SpaceContainer } from "./StyledElements";
 
@@ -50,7 +50,7 @@ export default function Space({ node, id }: SpaceProps) {
   if (node.layout) {
     return (
       <SpaceContainer data-type="space-container">
-        {node.isRoot() && <SavedSpaces />}
+        {node.isRoot() && <Workspaces />}
         <Allotment
           key={node.layout}
           vertical={node.layout === Layout.Vertical}
@@ -80,7 +80,7 @@ export default function Space({ node, id }: SpaceProps) {
 
     return (
       <PanelContainer>
-        {node.isRoot() && <SavedSpaces />}
+        {node.isRoot() && <Workspaces />}
         <PanelTabs data-type="panel-container" data-cy="panel-container">
           <ReactSortable
             group="panel-tabs"

--- a/app/packages/spaces/src/components/Workspaces/Workspace.tsx
+++ b/app/packages/spaces/src/components/Workspaces/Workspace.tsx
@@ -13,7 +13,7 @@ import { useSetRecoilState } from "recoil";
 import { workspaceEditorStateAtom } from "../../state";
 import { useWorkspacePermission } from "./hooks";
 
-export default function SavedSpace(props: SavedSpacePropsType) {
+export default function Workspace(props: WorkspacePropsType) {
   const { name, description, color, onClick, onEdit } = props;
   const setWorkspaceEditorState = useSetRecoilState(workspaceEditorStateAtom);
   const { canEdit, disabledInfo } = useWorkspacePermission();
@@ -79,7 +79,7 @@ export default function SavedSpace(props: SavedSpacePropsType) {
   );
 }
 
-type SavedSpacePropsType = {
+type WorkspacePropsType = {
   name: string;
   color: string;
   description: string;

--- a/app/packages/spaces/src/components/Workspaces/WorkspaceEditor.tsx
+++ b/app/packages/spaces/src/components/Workspaces/WorkspaceEditor.tsx
@@ -108,12 +108,15 @@ export default function WorkspaceEditor() {
                 executeOperator(
                   DELETE_WORKSPACE_OPERATOR,
                   { name },
-                  (result) => {
-                    if (!result.error) {
-                      reset();
-                      handleClose();
-                      setStatus("");
-                    }
+                  {
+                    callback: (result) => {
+                      if (!result.error) {
+                        reset();
+                        handleClose();
+                        setStatus("");
+                      }
+                    },
+                    skipOutput: true,
                   }
                 );
               }}
@@ -139,17 +142,24 @@ export default function WorkspaceEditor() {
                   current_name: edit ? state.oldName : undefined,
                   spaces: await getSessionSpaces(),
                 },
-                (result) => {
-                  if (!result.error) {
-                    reset();
-                    handleClose();
-                    setStatus("");
-                    if (!edit) {
-                      executeOperator(LOAD_WORKSPACE_OPERATOR, {
-                        name: state.name,
-                      });
+                {
+                  callback: (result) => {
+                    if (!result.error) {
+                      reset();
+                      handleClose();
+                      setStatus("");
+                      if (!edit) {
+                        executeOperator(
+                          LOAD_WORKSPACE_OPERATOR,
+                          {
+                            name: state.name,
+                          },
+                          { skipOutput: true }
+                        );
+                      }
                     }
-                  }
+                  },
+                  skipOutput: true,
                 }
               );
             }}

--- a/app/packages/spaces/src/components/Workspaces/constants.ts
+++ b/app/packages/spaces/src/components/Workspaces/constants.ts
@@ -1,0 +1,5 @@
+export const LOAD_WORKSPACE_OPERATOR = "@voxel51/operators/load_workspace";
+export const SAVE_WORKSPACE_OPERATOR = "@voxel51/operators/save_workspace";
+export const DELETE_WORKSPACE_OPERATOR = "@voxel51/operators/delete_workspace";
+export const LIST_WORKSPACES_OPERATOR = "@voxel51/operators/list_workspaces";
+export const UNSAVED_WORKSPACE_COLOR = "#9E9E9E";

--- a/app/packages/spaces/src/components/Workspaces/hooks.ts
+++ b/app/packages/spaces/src/components/Workspaces/hooks.ts
@@ -1,51 +1,43 @@
-import { useOperatorExecutor } from "@fiftyone/operators";
+import { executeOperator } from "@fiftyone/operators";
 import { canEditWorkspaces, datasetName, readOnly } from "@fiftyone/state";
 import { toSlug } from "@fiftyone/utilities";
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { useRecoilState, useRecoilValue, useResetRecoilState } from "recoil";
-import { Workspace, savedWorkspacesAtom } from "../../state";
+import { savedWorkspacesAtom } from "../../state";
+import { LIST_WORKSPACES_OPERATOR, LOAD_WORKSPACE_OPERATOR } from "./constants";
 
-export function useSavedSpaces() {
+export function useWorkspaces() {
   const [state, setState] = useRecoilState(savedWorkspacesAtom);
   const resetState = useResetRecoilState(savedWorkspacesAtom);
-  const listOperator = useOperatorExecutor(
-    "@voxel51/operators/list_saved_workspaces"
-  );
-  const loadOperator = useOperatorExecutor("@voxel51/operators/load_workspace");
   const [listWorkspaceExecuting, setListWorkspaceExecuting] = useState(false);
   const currentDataset = useRecoilValue(datasetName);
 
-  const listWorkspace = () => {
+  const listWorkspace = useCallback(() => {
     if (listWorkspaceExecuting) return;
     setListWorkspaceExecuting(true);
-    listOperator.execute({}, { skipOutput: true });
-  };
+    executeOperator(LIST_WORKSPACES_OPERATOR, {}, (result) => {
+      setState((state) => {
+        return {
+          ...state,
+          initialized: true,
+          workspaces: result?.result?.workspaces,
+          dataset: currentDataset,
+        };
+      });
+      setListWorkspaceExecuting(false);
+      if (result.error) {
+        console.error(result.error);
+      }
+    });
+  }, [listWorkspaceExecuting, setState, currentDataset]);
 
-  const loadWorkspace = (name: string) => {
-    loadOperator.execute({ name }, { skipOutput: true });
-  };
+  const loadWorkspace = useCallback((name: string) => {
+    executeOperator(LOAD_WORKSPACE_OPERATOR, { name });
+  }, []);
+
   const existingSlugs = useMemo(() => {
     return state.workspaces.map(({ name }) => toSlug(name));
   }, [state.workspaces]);
-
-  useEffect(() => {
-    if (listOperator.hasExecuted) {
-      const workspaces: Workspace[] = listOperator.result?.workspaces || [];
-      setState((state) => ({
-        ...state,
-        initialized: true,
-        workspaces,
-        dataset: currentDataset,
-      }));
-      listOperator.clear();
-      setListWorkspaceExecuting(false);
-    }
-  }, [
-    currentDataset,
-    listOperator.hasExecuted,
-    listOperator.result,
-    setListWorkspaceExecuting,
-  ]);
 
   useEffect(() => {
     if (currentDataset !== state.dataset) {
@@ -55,7 +47,7 @@ export function useSavedSpaces() {
 
   return {
     initialized: state.initialized,
-    savedSpaces: state.workspaces || [],
+    workspaces: state.workspaces || [],
     loadWorkspace,
     listWorkspace,
     reset: resetState,

--- a/app/packages/spaces/src/components/Workspaces/hooks.ts
+++ b/app/packages/spaces/src/components/Workspaces/hooks.ts
@@ -15,24 +15,31 @@ export function useWorkspaces() {
   const listWorkspace = useCallback(() => {
     if (listWorkspaceExecuting) return;
     setListWorkspaceExecuting(true);
-    executeOperator(LIST_WORKSPACES_OPERATOR, {}, (result) => {
-      setState((state) => {
-        return {
-          ...state,
-          initialized: true,
-          workspaces: result?.result?.workspaces,
-          dataset: currentDataset,
-        };
-      });
-      setListWorkspaceExecuting(false);
-      if (result.error) {
-        console.error(result.error);
+    executeOperator(
+      LIST_WORKSPACES_OPERATOR,
+      {},
+      {
+        callback: (result) => {
+          setState((state) => {
+            return {
+              ...state,
+              initialized: true,
+              workspaces: result?.result?.workspaces,
+              dataset: currentDataset,
+            };
+          });
+          setListWorkspaceExecuting(false);
+          if (result.error) {
+            console.error(result.error);
+          }
+        },
+        skipOutput: true,
       }
-    });
+    );
   }, [listWorkspaceExecuting, setState, currentDataset]);
 
   const loadWorkspace = useCallback((name: string) => {
-    executeOperator(LOAD_WORKSPACE_OPERATOR, { name });
+    executeOperator(LOAD_WORKSPACE_OPERATOR, { name }, { skipOutput: true });
   }, []);
 
   const existingSlugs = useMemo(() => {

--- a/app/packages/spaces/src/components/Workspaces/index.tsx
+++ b/app/packages/spaces/src/components/Workspaces/index.tsx
@@ -21,30 +21,31 @@ import "allotment/dist/style.css";
 import { useEffect, useMemo, useState } from "react";
 import { useRecoilValue, useSetRecoilState } from "recoil";
 import { workspaceEditorStateAtom } from "../../state";
-import SavedSpace from "./SavedSpace";
+import Workspace from "./Workspace";
 import WorkspaceEditor from "./WorkspaceEditor";
-import { useSavedSpaces, useWorkspacePermission } from "./hooks";
+import { useWorkspaces, useWorkspacePermission } from "./hooks";
 import { sessionSpaces } from "@fiftyone/state";
+import { UNSAVED_WORKSPACE_COLOR } from "./constants";
 
-export default function SavedSpaces() {
+export default function Workspaces() {
   const [open, setOpen] = useState(false);
   const [input, setInput] = useState("");
-  const { savedSpaces, loadWorkspace, initialized, listWorkspace } =
-    useSavedSpaces();
+  const { workspaces, loadWorkspace, initialized, listWorkspace } =
+    useWorkspaces();
   const setWorkspaceEditorState = useSetRecoilState(workspaceEditorStateAtom);
   const { canEdit, disabledInfo } = useWorkspacePermission();
   const sessionSpacesState = useRecoilValue(sessionSpaces);
   const currentWorkspaceName = sessionSpacesState._name;
 
   const currentWorkspace = useMemo(() => {
-    return savedSpaces.find((space) => space.name === currentWorkspaceName);
-  }, [savedSpaces, currentWorkspaceName]);
+    return workspaces.find((space) => space.name === currentWorkspaceName);
+  }, [workspaces, currentWorkspaceName]);
 
   const items = useMemo(() => {
-    return savedSpaces.filter((space) =>
+    return workspaces.filter((space) =>
       space.name.toLowerCase().includes(input.toLowerCase())
     );
-  }, [savedSpaces, input]);
+  }, [workspaces, input]);
 
   useEffect(() => {
     if (!initialized) {
@@ -65,19 +66,15 @@ export default function SavedSpaces() {
           zIndex: 1,
           color: (theme) => theme.palette.text.secondary,
           fontSize: 14,
+          pr: "20px",
         }}
-        endIcon={
-          <AutoAwesomeMosaicOutlined
-            sx={{
-              color: (theme) => theme.palette.primary.main,
-              fontSize: 18,
-            }}
-          />
-        }
+        endIcon={<AutoAwesomeMosaicOutlined sx={{ fontSize: 18 }} />}
       >
         {!initialized && <Skeleton width={64} />}
         {initialized && (
-          <ColoredDot color={currentWorkspace?.color || DEFAULT_COLOR} />
+          <ColoredDot
+            color={currentWorkspace?.color || UNSAVED_WORKSPACE_COLOR}
+          />
         )}
         {initialized && (currentWorkspace?.name || "Unsaved")}
       </Button>
@@ -118,7 +115,7 @@ export default function SavedSpaces() {
                     className={scrollable}
                   >
                     {items.map((space) => (
-                      <SavedSpace
+                      <Workspace
                         key={space.id}
                         onEdit={() => {
                           setOpen(false);
@@ -159,7 +156,12 @@ export default function SavedSpaces() {
                       }}
                     >
                       <ListItemIcon sx={{ minWidth: "auto" }}>
-                        <Add />
+                        <Add
+                          sx={{
+                            color: (theme) => theme.palette.text.primary,
+                            mr: 0.5,
+                          }}
+                        />
                       </ListItemIcon>
                       <ListItemText
                         primary={"Save current spaces as a workspace"}

--- a/app/packages/spaces/src/components/Workspaces/index.tsx
+++ b/app/packages/spaces/src/components/Workspaces/index.tsx
@@ -1,9 +1,4 @@
-import {
-  ColoredDot,
-  DEFAULT_COLOR,
-  Popout,
-  scrollable,
-} from "@fiftyone/components";
+import { ColoredDot, Popout, scrollable } from "@fiftyone/components";
 import { Add, AutoAwesomeMosaicOutlined } from "@mui/icons-material";
 import {
   Box,
@@ -66,7 +61,7 @@ export default function Workspaces() {
           zIndex: 1,
           color: (theme) => theme.palette.text.secondary,
           fontSize: 14,
-          pr: "20px",
+          pr: "19px",
         }}
         endIcon={<AutoAwesomeMosaicOutlined sx={{ fontSize: 18 }} />}
       >

--- a/fiftyone/operators/builtin.py
+++ b/fiftyone/operators/builtin.py
@@ -419,13 +419,11 @@ def list_files(dirpath):
     return dirs + files
 
 
-class ListSavedWorkspaces(foo.Operator):
+class ListWorkspaces(foo.Operator):
     @property
     def config(self):
         return foo.OperatorConfig(
-            name="list_saved_workspaces",
-            label="List Saved Workspaces",
-            unlisted=True,
+            name="list_workspaces", label="List Workspaces", unlisted=True
         )
 
     def execute(self, ctx):
@@ -525,7 +523,7 @@ BUILTIN_OPERATORS = [
     DeleteSampleField(_builtin=True),
     PrintStdout(_builtin=True),
     ListFiles(_builtin=True),
-    ListSavedWorkspaces(_builtin=True),
+    ListWorkspaces(_builtin=True),
     LoadWorkspace(_builtin=True),
     SaveWorkspace(_builtin=True),
     DeleteWorkspace(_builtin=True),


### PR DESCRIPTION
## What changes are proposed in this pull request?

- Load workspace on save
- Add loading state to delete and save
- code cleanup
- Style tweaks

## How is this patch tested? If it is not, please explain why.

Using the workspaces in the app

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced operator execution by introducing a new callback functionality for improved interactivity and responsiveness.
	- Added new constants for workspace operations (load, save, delete, list) in the `Workspaces` component.
	- Renamed components from `SavedSpaces` to `Workspaces` and `SavedSpace` to `Workspace` for clarity and consistency.
	- Introduced a new `MuiButton` component with a loading indicator for enhanced user experience.

- **Bug Fixes**
	- Ensured functionality consistency by updating function calls and hooks to align with new component and operator names.

- **Refactor**
	- Utilized the newly introduced `MuiButton` component in modified components and functions.
	- Replaced deprecated hooks and methods with updated ones in the workspace management components.

- **Documentation**
	- Updated component names and descriptions to reflect the renaming and new features in workspace management tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->