### PR TITLE
tweak zoom and workspace right alignment

### DIFF
--- a/app/packages/core/src/components/ImageContainerHeader.tsx
+++ b/app/packages/core/src/components/ImageContainerHeader.tsx
@@ -52,8 +52,8 @@ const RightContainer = styled.div`
 const SliderContainer = styled.div`
   display: flex;
   align-items: center;
-  width: 8rem;
-  padding-right: 1rem;
+  width: 7.375rem;
+  padding-right: 0.375rem;
 `;
 
 const ImageContainerHeader = () => {

--- a/app/packages/spaces/src/components/Workspaces/index.tsx
+++ b/app/packages/spaces/src/components/Workspaces/index.tsx
@@ -61,7 +61,7 @@ export default function Workspaces() {
           zIndex: 1,
           color: (theme) => theme.palette.text.secondary,
           fontSize: 14,
-          pr: "19px",
+          pr: "0.75rem",
         }}
         endIcon={<AutoAwesomeMosaicOutlined sx={{ fontSize: 18 }} />}
       >


### PR DESCRIPTION
## What changes are proposed in this pull request?

Align zoom and workspace button with the right edge of samples grid 

## How is this patch tested? If it is not, please explain why.

Using the app

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Adjusted the width and padding of the `SliderContainer` in the `ImageContainerHeader` for improved layout.
	- Updated padding value in the `Workspaces` component for consistency in spacing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->