### PR TITLE
Fix DateField for GMT+ users

### DIFF
--- a/fiftyone/core/fields.py
+++ b/fiftyone/core/fields.py
@@ -514,10 +514,7 @@ class DateField(mongoengine.fields.DateField, Field):
         if value is None:
             return None
 
-        # Explicitly converting to UTC is important here because PyMongo loads
-        # everything as `datetime`, which will respect `fo.config.timezone`,
-        # but we always need UTC here for the conversion back to `date`
-        return value.astimezone(pytz.utc).date()
+        return value.date()
 
     def validate(self, value):
         if not isinstance(value, date):

--- a/fiftyone/core/fields.py
+++ b/fiftyone/core/fields.py
@@ -514,6 +514,15 @@ class DateField(mongoengine.fields.DateField, Field):
         if value is None:
             return None
 
+        # Explicitly converting to UTC is important here because PyMongo loads
+        # everything as `datetime`, which will respect `fo.config.timezone`,
+        # but we always need UTC here for the conversion back to `date` because
+        # we write to the DB in UTC time.
+        # If value is timezone unaware, then do not convert because it will be
+        # assumed to be in local timezone and date will be wrong for GMT+
+        # localities.
+        if value.tzinfo is not None:
+            value = value.astimezone(pytz.utc)
         return value.date()
 
     def validate(self, value):

--- a/fiftyone/core/odm/database.py
+++ b/fiftyone/core/odm/database.py
@@ -422,7 +422,7 @@ def get_async_db_conn(use_global=False):
 def _apply_options(db):
     timezone = fo.config.timezone
 
-    if not timezone or timezone.lower() == "utc":
+    if not timezone:
         return db
 
     if timezone.lower() == "local":

--- a/fiftyone/core/odm/database.py
+++ b/fiftyone/core/odm/database.py
@@ -423,7 +423,7 @@ def _apply_options(db):
     timezone = fo.config.timezone
 
     if not timezone:
-        timezone = "utc"
+        return db
 
     if timezone.lower() == "local":
         tzinfo = datetime.now().astimezone().tzinfo

--- a/fiftyone/core/odm/database.py
+++ b/fiftyone/core/odm/database.py
@@ -423,7 +423,7 @@ def _apply_options(db):
     timezone = fo.config.timezone
 
     if not timezone:
-        return db
+        timezone = "utc"
 
     if timezone.lower() == "local":
         tzinfo = datetime.now().astimezone().tzinfo

--- a/tests/unittests/dataset_tests.py
+++ b/tests/unittests/dataset_tests.py
@@ -5,6 +5,7 @@ FiftyOne dataset-related unit tests.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+import time
 from copy import deepcopy, copy
 from datetime import date, datetime, timedelta
 import gc
@@ -554,6 +555,22 @@ class DatasetTests(unittest.TestCase):
 
         fo.config.timezone = None
         dataset.reload()
+
+        self.assertEqual(type(sample.date), date)
+        self.assertEqual(int((sample.date - date1).total_seconds()), 0)
+
+        # Now change system time to something GMT+
+        system_timezone = os.environ.get("TZ")
+        try:
+            os.environ["TZ"] = "Europe/Madrid"
+            time.tzset()
+            dataset.reload()
+        finally:
+            if system_timezone is None:
+                del os.environ["TZ"]
+            else:
+                os.environ["TZ"] = system_timezone
+            time.tzset()
 
         self.assertEqual(type(sample.date), date)
         self.assertEqual(int((sample.date - date1).total_seconds()), 0)


### PR DESCRIPTION
## What changes are proposed in this pull request?

Closes #4365

When the DB is not made timezone aware, it is not UTC by default but rather timezone agnostic. So when you call `astimezone(pytz.utc)` it assumes local timezone in order to do the conversion.
When timezone is GMT-2, the stored date (2023, 9, 8, 0, 0) becomes (2023, 9, 8, 2, 0) which results in the same date so you don't see a difference.
When timezone is GMT+2, like the reporting user, (2023, 9, 8, 0, 0) becomes (2023, 9, 7, 22, 0) which is a different date (2023/09/07) than expected!

1. Use `db.with_options()` to apply timezone awareness of "UTC" if that is specified in `fo.config`. A datetime with timezone UTC is not the same as a datetime with no timezone.
   - Would love to change the default behavior as well but it would be a potential behavior change whereas I believe the above is strictly a bug fix.
2. Remove conversion to UTC in `Date` field which will do the wrong thing in the case that the datetime is not timezone aware. I don't know why we wanted to convert to UTC in the first place. See inline PR comments.

## How is this patch tested? If it is not, please explain why.

I am not sure how to test because you have to fake localized timezone. There's probably a way to do that.

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

```
Fixed :class:`fiftyone.core.fields.DateField` for users in GMT+ timezones when `fo.config.timezone` is unset.
```

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Refactor**
    - Simplified datetime to date conversion for improved reliability and performance.
    - Enhanced timezone handling logic for consistent behavior across user environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->