### PR TITLE
DeepSort tracking enhancements

### DIFF
--- a/fiftyone/utils/tracking/deepsort.py
+++ b/fiftyone/utils/tracking/deepsort.py
@@ -68,9 +68,9 @@ class DeepSort(object):
             sample_collection, _in_field, fo.Detections
         )
 
-        for sample in sample_collection.iter_samples(
-            autosave=True, progress=progress
-        ):
+        view = sample_collection.select_fields(_in_field)
+
+        for sample in view.iter_samples(autosave=True, progress=progress):
             try:
                 DeepSort.track_sample(
                     sample,


### PR DESCRIPTION
## Change log

- add validation based on media/field types 
- handle frames where input detections field is null/missing
- use `select_fields()` to optimize I/O
- add `skip_failures=True/False` flag
- use `FFmpegVideoReader` for more robust/idiomatic video processing
- add `track_sample()` method for running tracking on individual samples

## Example usage

```py
import fiftyone as fo
import fiftyone.zoo as foz
from fiftyone.utils.tracking import DeepSort

dataset = foz.load_zoo_dataset("quickstart-video")

DeepSort.track(dataset, "frames.detections")

session = fo.launch_app(dataset)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Refactor**
  - Enhanced class and method definitions in the tracking module for improved functionality and error handling.
- **New Features**
  - Added a new method for tracking individual samples within collections, enhancing user flexibility and control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->