### PR TITLE
fix absolute css position for view bar icons

### DIFF
--- a/app/packages/core/src/components/ViewBar/ViewBar.tsx
+++ b/app/packages/core/src/components/ViewBar/ViewBar.tsx
@@ -43,6 +43,7 @@ const IconsContainer = styled.div`
   display: flex;
   align-items: center;
   position: absolute;
+  top: 2px;
   z-index: 1;
   height: 100%;
   border-radius: 3px;


### PR DESCRIPTION
Fixes view bar icons, which are currently hidden
<img width="1470" alt="Screenshot 2024-05-08 at 6 35 01 PM" src="https://github.com/voxel51/fiftyone/assets/19821840/3e3e50d5-b1fb-48d5-81d3-555317df9f3a">


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Adjusted the position of icons in the ViewBar for better visual alignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->