### PR TITLE
add results to prompt success

### DIFF
--- a/app/packages/operators/src/built-in-operators.ts
+++ b/app/packages/operators/src/built-in-operators.ts
@@ -1036,7 +1036,7 @@ class PromptUserForOperation extends Operator {
         } else {
           triggerEvent(panelId, {
             operator: on_success,
-            params: result.result,
+            params: { result: result.result },
           });
         }
       },


### PR DESCRIPTION
<!-- TEAMS-2757 -->

Prior to this change: when using `ctx.prompt()` like in the example below:

```python
ctx.prompt(
  "@voxel51/dashboard/plotly_plot_operator",
  params=ctx.panel.state.plot_config,
  on_success=self.update_plot_data
)
```

The `on_success` callback would not receive the results of the prompted operation. After this change this callback no longer needs to rely on the prompted operator calling `ctx.panel.state.x = y`. That allows for this style in the example `on_success` callback below.

```python
def update_plot_data(self, ctx):
    success_result = ctx.params.get('result', {})
    success_results_plot_config = success_result.get('plot_config', None)
    plot_config = success_results_plot_config or ctx.panel.state.plot_config
    # ...
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved parameter handling in user prompts to enhance operation accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->