### PR TITLE
Add new permission flags for tagging, changing sidebar groups, creating new field for similarity search

### DIFF
--- a/app/packages/app/src/useWriters/registerWriter.ts
+++ b/app/packages/app/src/useWriters/registerWriter.ts
@@ -6,7 +6,11 @@ import { RoutingContext } from "../routing";
 
 type WriterKeys = keyof Omit<
   Session,
-  "canCreateNewField" | "canEditCustomColors" | "canEditSavedViews" | "readOnly"
+  | "canAddSidebarGroup"
+  | "canCreateNewField"
+  | "canEditCustomColors"
+  | "canEditSavedViews"
+  | "readOnly"
 >;
 
 type WriterContext = {

--- a/app/packages/app/src/useWriters/registerWriter.ts
+++ b/app/packages/app/src/useWriters/registerWriter.ts
@@ -6,7 +6,7 @@ import { RoutingContext } from "../routing";
 
 type WriterKeys = keyof Omit<
   Session,
-  "canEditCustomColors" | "canEditSavedViews" | "readOnly"
+  "canCreateNewField" | "canEditCustomColors" | "canEditSavedViews" | "readOnly"
 >;
 
 type WriterContext = {

--- a/app/packages/app/src/useWriters/registerWriter.ts
+++ b/app/packages/app/src/useWriters/registerWriter.ts
@@ -6,9 +6,9 @@ import { RoutingContext } from "../routing";
 
 type WriterKeys = keyof Omit<
   Session,
-  | "canAddSidebarGroup"
+  | "canModifySidebarGroup"
   | "canCreateNewField"
-  | "canTagSamples"
+  | "canTagSamplesOrLabels"
   | "canEditCustomColors"
   | "canEditSavedViews"
   | "readOnly"

--- a/app/packages/app/src/useWriters/registerWriter.ts
+++ b/app/packages/app/src/useWriters/registerWriter.ts
@@ -8,6 +8,7 @@ type WriterKeys = keyof Omit<
   Session,
   | "canAddSidebarGroup"
   | "canCreateNewField"
+  | "canTagSamples"
   | "canEditCustomColors"
   | "canEditSavedViews"
   | "readOnly"

--- a/app/packages/core/src/components/Actions/ActionsRow.tsx
+++ b/app/packages/core/src/components/Actions/ActionsRow.tsx
@@ -163,8 +163,7 @@ const Tag = ({
   const labels = useRecoilValue(fos.selectedLabelIds);
   const samples = useRecoilValue(fos.selectedSamples);
   const canTag = useRecoilValue(fos.canTagSamplesOrLabels);
-  const readOnly = useRecoilValue(fos.readOnly);
-  const isReadOnly = readOnly || !canTag;
+  const isReadOnly = canTag.enabled !== true;
 
   const selected = labels.size > 0 || samples.size > 0;
   const tagging = useRecoilValue(fos.anyTagging);
@@ -182,7 +181,9 @@ const Tag = ({
 
   const baseTitle = `Tag sample${modal ? "" : "s"} or labels`;
   const title = isReadOnly
-    ? `Can not ${baseTitle.toLowerCase()} in read-only mode.`
+    ? `Can not ${baseTitle.toLowerCase()} in read-only mode` + canTag.message
+      ? `: ${canTag.message}`
+      : ""
     : baseTitle;
 
   return (

--- a/app/packages/core/src/components/Actions/ActionsRow.tsx
+++ b/app/packages/core/src/components/Actions/ActionsRow.tsx
@@ -162,8 +162,9 @@ const Tag = ({
   const [available, setAvailable] = useState(true);
   const labels = useRecoilValue(fos.selectedLabelIds);
   const samples = useRecoilValue(fos.selectedSamples);
-  const readOnly =
-    useRecoilValue(fos.readOnly) || !useRecoilValue(fos.canTagSamplesOrLabels);
+  const canTag = useRecoilValue(fos.canTagSamplesOrLabels);
+  const readOnly = useRecoilValue(fos.readOnly);
+  const isReadOnly = readOnly || !canTag;
 
   const selected = labels.size > 0 || samples.size > 0;
   const tagging = useRecoilValue(fos.anyTagging);
@@ -180,7 +181,7 @@ const Tag = ({
     useEventHandler(lookerRef.current, "pause", () => setAvailable(true));
 
   const baseTitle = `Tag sample${modal ? "" : "s"} or labels`;
-  const title = readOnly
+  const title = isReadOnly
     ? `Can not ${baseTitle.toLowerCase()} in read-only mode.`
     : baseTitle;
 
@@ -188,7 +189,7 @@ const Tag = ({
     <ActionDiv ref={ref}>
       <PillButton
         style={{
-          cursor: readOnly
+          cursor: isReadOnly
             ? "not-allowed"
             : disabled || !available
             ? "default"
@@ -196,7 +197,7 @@ const Tag = ({
         }}
         icon={tagging ? <Loading /> : <LocalOffer />}
         open={open}
-        onClick={() => !disabled && available && !readOnly && setOpen(!open)}
+        onClick={() => !disabled && available && !isReadOnly && setOpen(!open)}
         highlight={(selected || open) && available}
         title={title}
         data-cy="action-tag-sample-labels"

--- a/app/packages/core/src/components/Actions/ActionsRow.tsx
+++ b/app/packages/core/src/components/Actions/ActionsRow.tsx
@@ -162,9 +162,7 @@ const Tag = ({
   const [available, setAvailable] = useState(true);
   const labels = useRecoilValue(fos.selectedLabelIds);
   const samples = useRecoilValue(fos.selectedSamples);
-  const canTag = useRecoilValue(fos.canTagSamples);
-  const isSnapshot = useRecoilValue(fos.readOnly);
-  const readOnly = isSnapshot || !canTag;
+  const readOnly = useRecoilValue(fos.readOnly) || !useRecoilValue(fos.canTagSamples);
 
   const selected = labels.size > 0 || samples.size > 0;
   const tagging = useRecoilValue(fos.anyTagging);

--- a/app/packages/core/src/components/Actions/ActionsRow.tsx
+++ b/app/packages/core/src/components/Actions/ActionsRow.tsx
@@ -162,7 +162,8 @@ const Tag = ({
   const [available, setAvailable] = useState(true);
   const labels = useRecoilValue(fos.selectedLabelIds);
   const samples = useRecoilValue(fos.selectedSamples);
-  const readOnly = useRecoilValue(fos.readOnly) || !useRecoilValue(fos.canTagSamples);
+  const readOnly =
+    useRecoilValue(fos.readOnly) || !useRecoilValue(fos.canTagSamplesOrLabels);
 
   const selected = labels.size > 0 || samples.size > 0;
   const tagging = useRecoilValue(fos.anyTagging);

--- a/app/packages/core/src/components/Actions/ActionsRow.tsx
+++ b/app/packages/core/src/components/Actions/ActionsRow.tsx
@@ -162,7 +162,9 @@ const Tag = ({
   const [available, setAvailable] = useState(true);
   const labels = useRecoilValue(fos.selectedLabelIds);
   const samples = useRecoilValue(fos.selectedSamples);
-  const readOnly = useRecoilValue(fos.readOnly);
+  const canTag = useRecoilValue(fos.canTagSamples);
+  const isSnapshot = useRecoilValue(fos.readOnly);
+  const readOnly = isSnapshot || !canTag;
 
   const selected = labels.size > 0 || samples.size > 0;
   const tagging = useRecoilValue(fos.anyTagging);

--- a/app/packages/core/src/components/Actions/ActionsRow.tsx
+++ b/app/packages/core/src/components/Actions/ActionsRow.tsx
@@ -163,13 +163,13 @@ const Tag = ({
   const labels = useRecoilValue(fos.selectedLabelIds);
   const samples = useRecoilValue(fos.selectedSamples);
   const canTag = useRecoilValue(fos.canTagSamplesOrLabels);
-  const isReadOnly = canTag.enabled !== true;
+  const disableTag = canTag.enabled !== true;
 
   const selected = labels.size > 0 || samples.size > 0;
   const tagging = useRecoilValue(fos.anyTagging);
   const ref = useRef<HTMLDivElement>(null);
   useOutsideClick(ref, () => open && setOpen(false));
-  const disabled = tagging;
+  const disabled = tagging || disableTag;
 
   lookerRef &&
     useEventHandler(lookerRef.current, "play", () => {
@@ -180,15 +180,15 @@ const Tag = ({
     useEventHandler(lookerRef.current, "pause", () => setAvailable(true));
 
   const baseTitle = `Tag sample${modal ? "" : "s"} or labels`;
-  const title = isReadOnly
-    ? canTag.message ?? "Cannot tag in read-only mode"
+  const title = disabled
+    ? canTag.message ?? "cannot tag in read-only mode"
     : baseTitle;
 
   return (
     <ActionDiv ref={ref}>
       <PillButton
         style={{
-          cursor: isReadOnly
+          cursor: disableTag
             ? "not-allowed"
             : disabled || !available
             ? "default"
@@ -196,7 +196,7 @@ const Tag = ({
         }}
         icon={tagging ? <Loading /> : <LocalOffer />}
         open={open}
-        onClick={() => !disabled && available && !isReadOnly && setOpen(!open)}
+        onClick={() => !disabled && available && setOpen(!open)}
         highlight={(selected || open) && available}
         title={title}
         data-cy="action-tag-sample-labels"

--- a/app/packages/core/src/components/Actions/ActionsRow.tsx
+++ b/app/packages/core/src/components/Actions/ActionsRow.tsx
@@ -180,8 +180,9 @@ const Tag = ({
     useEventHandler(lookerRef.current, "pause", () => setAvailable(true));
 
   const baseTitle = `Tag sample${modal ? "" : "s"} or labels`;
+
   const title = disabled
-    ? canTag.message ?? "cannot tag in read-only mode"
+    ? (canTag.message || "").replace("#action", baseTitle.toLowerCase())
     : baseTitle;
 
   return (
@@ -196,7 +197,7 @@ const Tag = ({
         }}
         icon={tagging ? <Loading /> : <LocalOffer />}
         open={open}
-        onClick={() => !disabled && available && setOpen(!open)}
+        onClick={() => !disabled && available && !disableTag && setOpen(!open)}
         highlight={(selected || open) && available}
         title={title}
         data-cy="action-tag-sample-labels"

--- a/app/packages/core/src/components/Actions/ActionsRow.tsx
+++ b/app/packages/core/src/components/Actions/ActionsRow.tsx
@@ -163,7 +163,7 @@ const Tag = ({
   const labels = useRecoilValue(fos.selectedLabelIds);
   const samples = useRecoilValue(fos.selectedSamples);
   const canTag = useRecoilValue(fos.canTagSamplesOrLabels);
-  const disableTag = canTag.enabled !== true;
+  const disableTag = !canTag.enabled;
 
   const selected = labels.size > 0 || samples.size > 0;
   const tagging = useRecoilValue(fos.anyTagging);

--- a/app/packages/core/src/components/Actions/ActionsRow.tsx
+++ b/app/packages/core/src/components/Actions/ActionsRow.tsx
@@ -181,9 +181,7 @@ const Tag = ({
 
   const baseTitle = `Tag sample${modal ? "" : "s"} or labels`;
   const title = isReadOnly
-    ? `Can not ${baseTitle.toLowerCase()} in read-only mode` + canTag.message
-      ? `: ${canTag.message}`
-      : ""
+    ? canTag.message ?? "Cannot tag in read-only mode"
     : baseTitle;
 
   return (

--- a/app/packages/core/src/components/Actions/similar/Similar.tsx
+++ b/app/packages/core/src/components/Actions/similar/Similar.tsx
@@ -94,7 +94,7 @@ const SortBySimilarity = ({
   );
   const isLoading = useRecoilValue(fos.similaritySorting);
   const canCreateNewField = useRecoilValue(fos.canCreateNewField);
-  const disabled = canCreateNewField.enabled !== true;
+  const disabled = !canCreateNewField.enabled;
   const disableMsg = canCreateNewField.message;
 
   useLayoutEffect(() => {

--- a/app/packages/core/src/components/Actions/similar/Similar.tsx
+++ b/app/packages/core/src/components/Actions/similar/Similar.tsx
@@ -94,7 +94,8 @@ const SortBySimilarity = ({
   );
   const isLoading = useRecoilValue(fos.similaritySorting);
   const canCreateNewField = useRecoilValue(fos.canCreateNewField);
-  const isReadOnly = useRecoilValue(fos.readOnly);
+  const disabled = canCreateNewField.enabled !== true;
+  const disableMsg = canCreateNewField.message;
 
   useLayoutEffect(() => {
     if (!choices.choices.includes(state.brainKey)) {
@@ -282,18 +283,14 @@ const SortBySimilarity = ({
           Optional: store the distance between each sample and the query in this
           field
           <Input
-            disabled={isReadOnly && canCreateNewField}
+            disabled={disabled}
             placeholder={"dist_field (default = None)"}
             validator={(value) => !value.startsWith("_")}
             value={state.distField ?? ""}
             setter={(value) =>
               updateState({ distField: !value.length ? undefined : value })
             }
-            title={
-              isReadOnly
-                ? "Can not store the distance in a field in read-only mode"
-                : undefined
-            }
+            title={disableMsg}
           />
         </div>
       )}

--- a/app/packages/core/src/components/Actions/similar/Similar.tsx
+++ b/app/packages/core/src/components/Actions/similar/Similar.tsx
@@ -93,6 +93,7 @@ const SortBySimilarity = ({
     []
   );
   const isLoading = useRecoilValue(fos.similaritySorting);
+  const canCreateNewField = useRecoilValue(fos.canCreateNewField);
   const isReadOnly = useRecoilValue(fos.readOnly);
 
   useLayoutEffect(() => {
@@ -281,7 +282,7 @@ const SortBySimilarity = ({
           Optional: store the distance between each sample and the query in this
           field
           <Input
-            disabled={isReadOnly}
+            disabled={isReadOnly && canCreateNewField}
             placeholder={"dist_field (default = None)"}
             validator={(value) => !value.startsWith("_")}
             value={state.distField ?? ""}

--- a/app/packages/core/src/components/ColorModal/ColorFooter.tsx
+++ b/app/packages/core/src/components/ColorModal/ColorFooter.tsx
@@ -1,19 +1,18 @@
 import { Button } from "@fiftyone/components";
 import * as foq from "@fiftyone/relay";
 import * as fos from "@fiftyone/state";
-import React, { useEffect, useMemo } from "react";
+import React, { useEffect } from "react";
 import { useMutation } from "react-relay";
 import { useRecoilState, useRecoilValue } from "recoil";
 import { ButtonGroup, ModalActionButtonContainer } from "./ShareStyledDiv";
 import { activeColorEntry } from "./state";
 
 const ColorFooter: React.FC = () => {
-  const isReadOnly = useRecoilValue(fos.readOnly);
   const canEditCustomColors = useRecoilValue(fos.canEditCustomColors);
-  const canEdit = useMemo(
-    () => !isReadOnly && canEditCustomColors,
-    [canEditCustomColors, isReadOnly]
-  );
+  const disabled = canEditCustomColors.enabled! == true;
+  const title = disabled
+    ? canEditCustomColors.message ?? ""
+    : "Save to dataset app config";
   const setColorScheme = fos.useSetSessionColorScheme();
   const [activeColorModalField, setActiveColorModalField] =
     useRecoilState(activeColorEntry);
@@ -30,6 +29,7 @@ const ColorFooter: React.FC = () => {
     () => foq.subscribe(() => setActiveColorModalField(null)),
     [setActiveColorModalField]
   );
+
   if (!activeColorModalField) return null;
   if (!datasetName) {
     throw new Error("dataset not defined");
@@ -53,11 +53,7 @@ const ColorFooter: React.FC = () => {
           Reset
         </Button>
         <Button
-          title={
-            canEdit
-              ? "Save to dataset app config"
-              : "Can not save to dataset appConfig in read-only mode"
-          }
+          title={title}
           onClick={() => {
             // remove rgb list from defaultColorscale and colorscales
             const { rgb, ...rest } = colorScheme.defaultColorscale;
@@ -105,13 +101,13 @@ const ColorFooter: React.FC = () => {
             });
             setActiveColorModalField(null);
           }}
-          disabled={!canEdit}
+          disabled={disabled}
         >
           Save as default
         </Button>
-        {datasetDefault && (
+        {datasetDefault && !disabled && (
           <Button
-            title={canEdit ? "Clear" : "Can not clear in read-only mode"}
+            title="Clear"
             onClick={() => {
               setDatasetColorScheme({
                 variables: { subscription, datasetName, colorScheme: null },
@@ -135,7 +131,6 @@ const ColorFooter: React.FC = () => {
                 showSkeletons: configDefault.showSkeletons ?? true,
               }));
             }}
-            disabled={!canEdit}
           >
             Clear default
           </Button>

--- a/app/packages/core/src/components/ColorModal/ColorFooter.tsx
+++ b/app/packages/core/src/components/ColorModal/ColorFooter.tsx
@@ -11,7 +11,7 @@ const ColorFooter: React.FC = () => {
   const canEditCustomColors = useRecoilValue(fos.canEditCustomColors);
   const disabled = canEditCustomColors.enabled! == true;
   const title = disabled
-    ? canEditCustomColors.message ?? ""
+    ? canEditCustomColors.message
     : "Save to dataset app config";
   const setColorScheme = fos.useSetSessionColorScheme();
   const [activeColorModalField, setActiveColorModalField] =

--- a/app/packages/core/src/components/Sidebar/Entries/AddGroupEntry.tsx
+++ b/app/packages/core/src/components/Sidebar/Entries/AddGroupEntry.tsx
@@ -7,9 +7,7 @@ import { InputDiv } from "./utils";
 const AddGroup = () => {
   const [value, setValue] = useState("");
   const isFieldVisibilityApplied = useRecoilValue(fos.isFieldVisibilityActive);
-  const isSnapShot = useRecoilValue(fos.readOnly);
-  const canAddSidebarGroup = useRecoilValue(fos.canAddSidebarGroup);
-  const isReadOnly = isSnapShot || !canAddSidebarGroup;
+  const isReadOnly = useRecoilValue(fos.readOnly) || !useRecoilValue(fos.canAddSidebarGroup);
 
   const addGroup = useRecoilCallback(
     ({ set, snapshot }) =>

--- a/app/packages/core/src/components/Sidebar/Entries/AddGroupEntry.tsx
+++ b/app/packages/core/src/components/Sidebar/Entries/AddGroupEntry.tsx
@@ -7,7 +7,8 @@ import { InputDiv } from "./utils";
 const AddGroup = () => {
   const [value, setValue] = useState("");
   const isFieldVisibilityApplied = useRecoilValue(fos.isFieldVisibilityActive);
-  const isReadOnly = useRecoilValue(fos.readOnly) || !useRecoilValue(fos.canAddSidebarGroup);
+  const isReadOnly =
+    useRecoilValue(fos.readOnly) || !useRecoilValue(fos.canModifySidebarGroup);
 
   const addGroup = useRecoilCallback(
     ({ set, snapshot }) =>

--- a/app/packages/core/src/components/Sidebar/Entries/AddGroupEntry.tsx
+++ b/app/packages/core/src/components/Sidebar/Entries/AddGroupEntry.tsx
@@ -7,8 +7,9 @@ import { InputDiv } from "./utils";
 const AddGroup = () => {
   const [value, setValue] = useState("");
   const isFieldVisibilityApplied = useRecoilValue(fos.isFieldVisibilityActive);
-  const isReadOnly =
-    useRecoilValue(fos.readOnly) || !useRecoilValue(fos.canModifySidebarGroup);
+  const readOnly = useRecoilValue(fos.readOnly);
+  const canModifySidebarGroup = useRecoilValue(fos.canModifySidebarGroup);
+  const isReadOnly = readOnly || !canModifySidebarGroup;
 
   const addGroup = useRecoilCallback(
     ({ set, snapshot }) =>

--- a/app/packages/core/src/components/Sidebar/Entries/AddGroupEntry.tsx
+++ b/app/packages/core/src/components/Sidebar/Entries/AddGroupEntry.tsx
@@ -8,7 +8,7 @@ const AddGroup = () => {
   const [value, setValue] = useState("");
   const isFieldVisibilityApplied = useRecoilValue(fos.isFieldVisibilityActive);
   const canModifySidebarGroup = useRecoilValue(fos.canModifySidebarGroup);
-  const isReadOnly = canModifySidebarGroup.enabled !== true;
+  const disabled = canModifySidebarGroup.enabled !== true;
 
   const addGroup = useRecoilCallback(
     ({ set, snapshot }) =>
@@ -41,7 +41,7 @@ const AddGroup = () => {
     []
   );
 
-  if (isFieldVisibilityApplied || isReadOnly) {
+  if (isFieldVisibilityApplied || disabled) {
     return null;
   }
 

--- a/app/packages/core/src/components/Sidebar/Entries/AddGroupEntry.tsx
+++ b/app/packages/core/src/components/Sidebar/Entries/AddGroupEntry.tsx
@@ -7,7 +7,9 @@ import { InputDiv } from "./utils";
 const AddGroup = () => {
   const [value, setValue] = useState("");
   const isFieldVisibilityApplied = useRecoilValue(fos.isFieldVisibilityActive);
-  const readOnly = useRecoilValue(fos.readOnly);
+  const isSnapShot = useRecoilValue(fos.readOnly);
+  const canAddSidebarGroup = useRecoilValue(fos.canAddSidebarGroup);
+  const isReadOnly = isSnapShot || !canAddSidebarGroup;
 
   const addGroup = useRecoilCallback(
     ({ set, snapshot }) =>
@@ -40,7 +42,7 @@ const AddGroup = () => {
     []
   );
 
-  if (isFieldVisibilityApplied || readOnly) {
+  if (isFieldVisibilityApplied || isReadOnly) {
     return null;
   }
 

--- a/app/packages/core/src/components/Sidebar/Entries/AddGroupEntry.tsx
+++ b/app/packages/core/src/components/Sidebar/Entries/AddGroupEntry.tsx
@@ -7,9 +7,8 @@ import { InputDiv } from "./utils";
 const AddGroup = () => {
   const [value, setValue] = useState("");
   const isFieldVisibilityApplied = useRecoilValue(fos.isFieldVisibilityActive);
-  const readOnly = useRecoilValue(fos.readOnly);
   const canModifySidebarGroup = useRecoilValue(fos.canModifySidebarGroup);
-  const isReadOnly = readOnly || !canModifySidebarGroup;
+  const isReadOnly = canModifySidebarGroup.enabled !== true;
 
   const addGroup = useRecoilCallback(
     ({ set, snapshot }) =>

--- a/app/packages/core/src/components/Sidebar/Entries/Draggable.tsx
+++ b/app/packages/core/src/components/Sidebar/Entries/Draggable.tsx
@@ -1,5 +1,5 @@
 import { useTheme } from "@fiftyone/components";
-import { isFieldVisibilityActive, readOnly } from "@fiftyone/state";
+import * as fos from "@fiftyone/state";
 import { DragIndicator } from "@mui/icons-material";
 import { animated, useSpring } from "@react-spring/web";
 import React, { useMemo, useState } from "react";
@@ -19,8 +19,10 @@ const Draggable: React.FC<
   const theme = useTheme();
   const [hovering, setHovering] = useState(false);
   const [dragging, setDragging] = useState(false);
-  const isReadOnly = useRecoilValue(readOnly);
-  const isFieldVisibilityApplied = useRecoilValue(isFieldVisibilityActive);
+  const isSnapShot = useRecoilValue(fos.readOnly);
+  const canAddSidebarGroup = useRecoilValue(fos.canAddSidebarGroup);
+  const isReadOnly = isSnapShot || !canAddSidebarGroup;
+  const isFieldVisibilityApplied = useRecoilValue(fos.isFieldVisibilityActive);
 
   const disableDrag =
     !entryKey ||

--- a/app/packages/core/src/components/Sidebar/Entries/Draggable.tsx
+++ b/app/packages/core/src/components/Sidebar/Entries/Draggable.tsx
@@ -19,7 +19,8 @@ const Draggable: React.FC<
   const theme = useTheme();
   const [hovering, setHovering] = useState(false);
   const [dragging, setDragging] = useState(false);
-  const isReadOnly = useRecoilValue(fos.readOnly) || !useRecoilValue(fos.canAddSidebarGroup);
+  const isReadOnly =
+    useRecoilValue(fos.readOnly) || !useRecoilValue(fos.canModifySidebarGroup);
   const isFieldVisibilityApplied = useRecoilValue(fos.isFieldVisibilityActive);
 
   const disableDrag =

--- a/app/packages/core/src/components/Sidebar/Entries/Draggable.tsx
+++ b/app/packages/core/src/components/Sidebar/Entries/Draggable.tsx
@@ -19,9 +19,7 @@ const Draggable: React.FC<
   const theme = useTheme();
   const [hovering, setHovering] = useState(false);
   const [dragging, setDragging] = useState(false);
-  const isSnapShot = useRecoilValue(fos.readOnly);
-  const canAddSidebarGroup = useRecoilValue(fos.canAddSidebarGroup);
-  const isReadOnly = isSnapShot || !canAddSidebarGroup;
+  const isReadOnly = useRecoilValue(fos.readOnly) || !useRecoilValue(fos.canAddSidebarGroup);
   const isFieldVisibilityApplied = useRecoilValue(fos.isFieldVisibilityActive);
 
   const disableDrag =

--- a/app/packages/core/src/components/Sidebar/Entries/Draggable.tsx
+++ b/app/packages/core/src/components/Sidebar/Entries/Draggable.tsx
@@ -19,8 +19,9 @@ const Draggable: React.FC<
   const theme = useTheme();
   const [hovering, setHovering] = useState(false);
   const [dragging, setDragging] = useState(false);
-  const isReadOnly =
-    useRecoilValue(fos.readOnly) || !useRecoilValue(fos.canModifySidebarGroup);
+  const readOnly = useRecoilValue(fos.readOnly);
+  const canModifySidebarGroup = useRecoilValue(fos.canModifySidebarGroup);
+  const isReadOnly = readOnly || !canModifySidebarGroup;
   const isFieldVisibilityApplied = useRecoilValue(fos.isFieldVisibilityActive);
 
   const disableDrag =

--- a/app/packages/core/src/components/Sidebar/Entries/Draggable.tsx
+++ b/app/packages/core/src/components/Sidebar/Entries/Draggable.tsx
@@ -52,6 +52,12 @@ const Draggable: React.FC<
     [disableDrag, trigger, disabled]
   );
 
+  const title = disabled
+    ? canModifySidebarGroup.message || "Can not reorder in read-only mode"
+    : trigger
+    ? "Drag to reorder"
+    : undefined;
+
   return (
     <>
       <animated.div
@@ -86,14 +92,7 @@ const Draggable: React.FC<
           ...style,
           ...(disabled ? { cursor: "not-allowed" } : {}),
         }}
-        title={
-          disabled
-            ? canModifySidebarGroup.message ??
-              "Can not reorder in read-only mode"
-            : trigger
-            ? "Drag to reorder"
-            : undefined
-        }
+        title={title}
       >
         {active && <DragIndicator style={{ color: theme.background.level1 }} />}
       </animated.div>

--- a/app/packages/core/src/components/Sidebar/Entries/Draggable.tsx
+++ b/app/packages/core/src/components/Sidebar/Entries/Draggable.tsx
@@ -19,9 +19,8 @@ const Draggable: React.FC<
   const theme = useTheme();
   const [hovering, setHovering] = useState(false);
   const [dragging, setDragging] = useState(false);
-  const readOnly = useRecoilValue(fos.readOnly);
   const canModifySidebarGroup = useRecoilValue(fos.canModifySidebarGroup);
-  const isReadOnly = readOnly || !canModifySidebarGroup;
+  const isReadOnly = canModifySidebarGroup.enabled !== true;
   const isFieldVisibilityApplied = useRecoilValue(fos.isFieldVisibilityActive);
 
   const disableDrag =
@@ -91,7 +90,10 @@ const Draggable: React.FC<
         }}
         title={
           isReadOnly
-            ? "Can not reorder in read-only mode"
+            ? "Can not reorder in read-only mode" +
+              canModifySidebarGroup.message
+              ? ": " + canModifySidebarGroup.message
+              : ""
             : trigger
             ? "Drag to reorder"
             : undefined

--- a/app/packages/core/src/components/Sidebar/Entries/Draggable.tsx
+++ b/app/packages/core/src/components/Sidebar/Entries/Draggable.tsx
@@ -90,10 +90,8 @@ const Draggable: React.FC<
         }}
         title={
           isReadOnly
-            ? "Can not reorder in read-only mode" +
-              canModifySidebarGroup.message
-              ? ": " + canModifySidebarGroup.message
-              : ""
+            ? canModifySidebarGroup.message ??
+              "Can not reorder in read-only mode"
             : trigger
             ? "Drag to reorder"
             : undefined

--- a/app/packages/core/src/components/Sidebar/Entries/Draggable.tsx
+++ b/app/packages/core/src/components/Sidebar/Entries/Draggable.tsx
@@ -20,14 +20,14 @@ const Draggable: React.FC<
   const [hovering, setHovering] = useState(false);
   const [dragging, setDragging] = useState(false);
   const canModifySidebarGroup = useRecoilValue(fos.canModifySidebarGroup);
-  const isReadOnly = canModifySidebarGroup.enabled !== true;
+  const disabled = canModifySidebarGroup.enabled !== true;
   const isFieldVisibilityApplied = useRecoilValue(fos.isFieldVisibilityActive);
 
   const disableDrag =
     !entryKey ||
     entryKey.split(",")[1]?.includes("tags") ||
     entryKey.split(",")[1]?.includes("_label_tags") ||
-    isReadOnly ||
+    disabled ||
     isFieldVisibilityApplied;
   const active = trigger && (dragging || hovering) && !disableDrag;
 
@@ -48,8 +48,8 @@ const Draggable: React.FC<
     ?.replace("]", "");
 
   const isDraggable = useMemo(
-    () => !disableDrag && trigger && !isReadOnly,
-    [disableDrag, trigger, isReadOnly]
+    () => !disableDrag && trigger && !disabled,
+    [disableDrag, trigger, disabled]
   );
 
   return (
@@ -68,10 +68,8 @@ const Draggable: React.FC<
               }
             : undefined
         }
-        onMouseEnter={
-          isReadOnly ? undefined : () => trigger && setHovering(true)
-        }
-        onMouseLeave={isReadOnly ? undefined : () => setHovering(false)}
+        onMouseEnter={disabled ? undefined : () => trigger && setHovering(true)}
+        onMouseLeave={disabled ? undefined : () => setHovering(false)}
         style={{
           backgroundColor: color,
           position: "absolute",
@@ -86,10 +84,10 @@ const Draggable: React.FC<
           boxShadow: `0 2px 20px ${theme.custom.shadow}`,
           overflow: "hidden",
           ...style,
-          ...(isReadOnly ? { cursor: "not-allowed" } : {}),
+          ...(disabled ? { cursor: "not-allowed" } : {}),
         }}
         title={
-          isReadOnly
+          disabled
             ? canModifySidebarGroup.message ??
               "Can not reorder in read-only mode"
             : trigger

--- a/app/packages/core/src/components/Sidebar/Entries/GroupEntries.tsx
+++ b/app/packages/core/src/components/Sidebar/Entries/GroupEntries.tsx
@@ -132,9 +132,8 @@ const GroupEntry = React.memo(
     const canCommit = useRef(false);
     const theme = useTheme();
     const notify = fos.useNotification();
-    const readOnly = useRecoilValue(fos.readOnly);
     const canModifySidebarGroup = useRecoilValue(fos.canModifySidebarGroup);
-    const canModify = !readOnly && canModifySidebarGroup;
+    const isReadOnly = canModifySidebarGroup.enabled !== true;
 
     return (
       <div
@@ -210,7 +209,7 @@ const GroupEntry = React.memo(
                   }
                 }}
               />
-              {hovering && !editing && setValue && canModify && (
+              {hovering && !editing && setValue && isReadOnly && (
                 <span title={"Rename group"} style={{ margin: "0 0.25rem" }}>
                   <Edit
                     onMouseDown={(event) => {
@@ -231,7 +230,7 @@ const GroupEntry = React.memo(
                 </span>
               )}
               {pills}
-              {onDelete && !editing && canModify && (
+              {onDelete && !editing && isReadOnly && (
                 <span title={"Delete group"} style={{ margin: "0 0.25rem" }}>
                   <Close
                     onMouseDown={(event) => {

--- a/app/packages/core/src/components/Sidebar/Entries/GroupEntries.tsx
+++ b/app/packages/core/src/components/Sidebar/Entries/GroupEntries.tsx
@@ -132,6 +132,9 @@ const GroupEntry = React.memo(
     const canCommit = useRef(false);
     const theme = useTheme();
     const notify = fos.useNotification();
+    const readOnly = useRecoilValue(fos.readOnly);
+    const canModifySidebarGroup = useRecoilValue(fos.canModifySidebarGroup);
+    const canModify = !readOnly && canModifySidebarGroup;
 
     return (
       <div
@@ -207,7 +210,7 @@ const GroupEntry = React.memo(
                   }
                 }}
               />
-              {hovering && !editing && setValue && (
+              {hovering && !editing && setValue && canModify && (
                 <span title={"Rename group"} style={{ margin: "0 0.25rem" }}>
                   <Edit
                     onMouseDown={(event) => {
@@ -228,7 +231,7 @@ const GroupEntry = React.memo(
                 </span>
               )}
               {pills}
-              {onDelete && !editing && (
+              {onDelete && !editing && canModify && (
                 <span title={"Delete group"} style={{ margin: "0 0.25rem" }}>
                   <Close
                     onMouseDown={(event) => {

--- a/app/packages/core/src/components/Sidebar/Entries/GroupEntries.tsx
+++ b/app/packages/core/src/components/Sidebar/Entries/GroupEntries.tsx
@@ -133,7 +133,7 @@ const GroupEntry = React.memo(
     const theme = useTheme();
     const notify = fos.useNotification();
     const canModifySidebarGroup = useRecoilValue(fos.canModifySidebarGroup);
-    const isReadOnly = canModifySidebarGroup.enabled !== true;
+    const disabled = canModifySidebarGroup.enabled !== true;
 
     return (
       <div
@@ -209,7 +209,7 @@ const GroupEntry = React.memo(
                   }
                 }}
               />
-              {hovering && !editing && setValue && isReadOnly && (
+              {hovering && !editing && setValue && !disabled && (
                 <span title={"Rename group"} style={{ margin: "0 0.25rem" }}>
                   <Edit
                     onMouseDown={(event) => {
@@ -230,7 +230,7 @@ const GroupEntry = React.memo(
                 </span>
               )}
               {pills}
-              {onDelete && !editing && isReadOnly && (
+              {onDelete && !editing && !disabled && (
                 <span title={"Delete group"} style={{ margin: "0 0.25rem" }}>
                   <Close
                     onMouseDown={(event) => {

--- a/app/packages/core/src/components/Sidebar/ViewSelection/index.tsx
+++ b/app/packages/core/src/components/Sidebar/ViewSelection/index.tsx
@@ -43,11 +43,9 @@ export default function ViewSelection() {
   const setEditView = useSetRecoilState(viewDialogContent);
   const resetView = useResetRecoilState(fos.view);
   const [viewSearch, setViewSearch] = useRecoilState<string>(viewSearchTerm);
-  const readOnly = useRecoilValue(fos.readOnly);
-  const canEdit = useMemo(
-    () => canEditSavedViews && !readOnly,
-    [canEditSavedViews, readOnly]
-  );
+
+  const disabled = canEditSavedViews.enabled !== true;
+  const disabledMsg = canEditSavedViews.message;
 
   const [data, refetch] = useRefetchableSavedViews();
 
@@ -145,7 +143,7 @@ export default function ViewSelection() {
 
   useEffect(() => {
     const callback = (event: KeyboardEvent) => {
-      if (!canEdit) {
+      if (!disabled) {
         return;
       }
       if ((event.metaKey || event.ctrlKey) && event.code === "KeyS") {
@@ -160,13 +158,13 @@ export default function ViewSelection() {
     return () => {
       document.removeEventListener("keydown", callback);
     };
-  }, [isEmptyView, canEdit]);
+  }, [isEmptyView, disabled]);
 
   return (
     <Suspense fallback="Loading saved views...">
       <Box>
         <ViewDialog
-          canEdit={canEdit}
+          canEdit={!disabled}
           id="saved-views"
           savedViews={items}
           onEditSuccess={(
@@ -204,7 +202,7 @@ export default function ViewSelection() {
           }}
         />
         <Selection
-          readonly={!canEdit}
+          readonly={disabled}
           id="saved-views"
           selected={selected}
           setSelected={(item: fos.DatasetViewOption) => {
@@ -235,18 +233,14 @@ export default function ViewSelection() {
           lastFixedOption={
             <LastOption
               data-cy={`saved-views-create-new`}
-              onClick={() => canEdit && !isEmptyView && setIsOpen(true)}
-              disabled={isEmptyView || !canEdit}
-              title={
-                canEdit
-                  ? undefined
-                  : "Can not save filters as a view in read-only mode"
-              }
+              onClick={() => !disabled && !isEmptyView && setIsOpen(true)}
+              disabled={isEmptyView || disabled}
+              title={disabledMsg}
             >
               <Box style={{ width: "12%" }}>
-                <AddIcon fontSize="small" disabled={isEmptyView || !canEdit} />
+                <AddIcon fontSize="small" disabled={isEmptyView || disabled} />
               </Box>
-              <TextContainer disabled={isEmptyView || !canEdit}>
+              <TextContainer disabled={isEmptyView || disabled}>
                 Save current filters as view
               </TextContainer>
             </LastOption>

--- a/app/packages/core/src/components/Sidebar/ViewSelection/index.tsx
+++ b/app/packages/core/src/components/Sidebar/ViewSelection/index.tsx
@@ -43,10 +43,10 @@ export default function ViewSelection() {
   const setEditView = useSetRecoilState(viewDialogContent);
   const resetView = useResetRecoilState(fos.view);
   const [viewSearch, setViewSearch] = useRecoilState<string>(viewSearchTerm);
-  const isSnapShot = useRecoilValue(fos.readOnly);
+  const readOnly = useRecoilValue(fos.readOnly);
   const canEdit = useMemo(
-    () => canEditSavedViews && !isSnapShot,
-    [canEditSavedViews, isSnapShot]
+    () => canEditSavedViews && !readOnly,
+    [canEditSavedViews, readOnly]
   );
 
   const [data, refetch] = useRefetchableSavedViews();

--- a/app/packages/core/src/components/Sidebar/ViewSelection/index.tsx
+++ b/app/packages/core/src/components/Sidebar/ViewSelection/index.tsx
@@ -143,7 +143,7 @@ export default function ViewSelection() {
 
   useEffect(() => {
     const callback = (event: KeyboardEvent) => {
-      if (!disabled) {
+      if (disabled) {
         return;
       }
       if ((event.metaKey || event.ctrlKey) && event.code === "KeyS") {

--- a/app/packages/core/src/components/Sidebar/ViewSelection/index.tsx
+++ b/app/packages/core/src/components/Sidebar/ViewSelection/index.tsx
@@ -43,10 +43,10 @@ export default function ViewSelection() {
   const setEditView = useSetRecoilState(viewDialogContent);
   const resetView = useResetRecoilState(fos.view);
   const [viewSearch, setViewSearch] = useRecoilState<string>(viewSearchTerm);
-  const isReadOnly = useRecoilValue(fos.readOnly);
+  const isSnapShot = useRecoilValue(fos.readOnly);
   const canEdit = useMemo(
-    () => canEditSavedViews && !isReadOnly,
-    [canEditSavedViews, isReadOnly]
+    () => canEditSavedViews && !isSnapShot,
+    [canEditSavedViews, isSnapShot]
   );
 
   const [data, refetch] = useRefetchableSavedViews();

--- a/app/packages/spaces/src/components/Workspaces/Workspace.tsx
+++ b/app/packages/spaces/src/components/Workspaces/Workspace.tsx
@@ -1,4 +1,5 @@
 import { ColoredDot } from "@fiftyone/components";
+import { canEditWorkspaces } from "@fiftyone/state";
 import { Edit } from "@mui/icons-material";
 import {
   IconButton,
@@ -9,14 +10,15 @@ import {
   Stack,
 } from "@mui/material";
 import "allotment/dist/style.css";
-import { useSetRecoilState } from "recoil";
+import { useRecoilValue, useSetRecoilState } from "recoil";
 import { workspaceEditorStateAtom } from "../../state";
-import { useWorkspacePermission } from "./hooks";
 
 export default function Workspace(props: WorkspacePropsType) {
   const { name, description, color, onClick, onEdit } = props;
   const setWorkspaceEditorState = useSetRecoilState(workspaceEditorStateAtom);
-  const { canEdit, disabledInfo } = useWorkspacePermission();
+  const canEdit = useRecoilValue(canEditWorkspaces);
+  const disabled = canEdit.enabled !== true;
+  const disabledMsg = canEdit.message;
 
   return (
     <ListItem
@@ -44,15 +46,15 @@ export default function Workspace(props: WorkspacePropsType) {
           spacing={0}
           sx={{
             visibility: "hidden",
-            cursor: !canEdit ? "not-allowed" : undefined,
+            cursor: disabled ? "not-allowed" : undefined,
           }}
           className="workspace-actions-stack"
-          title={disabledInfo}
+          title={disabledMsg}
         >
           <IconButton
             size="small"
             onClick={(e) => {
-              if (!canEdit) return;
+              if (disabled) return;
               e.preventDefault();
               e.stopPropagation();
               setWorkspaceEditorState((state) => ({
@@ -66,10 +68,10 @@ export default function Workspace(props: WorkspacePropsType) {
               }));
               onEdit();
             }}
-            disabled={!canEdit}
+            disabled={disabled}
           >
             <Edit
-              color={canEdit ? "secondary" : "disabled"}
+              color={disabled ? "disabled" : "secondary"}
               sx={{ fontSize: 18 }}
             />
           </IconButton>

--- a/app/packages/spaces/src/components/Workspaces/hooks.ts
+++ b/app/packages/spaces/src/components/Workspaces/hooks.ts
@@ -1,5 +1,5 @@
 import { executeOperator } from "@fiftyone/operators";
-import { canEditWorkspaces, datasetName, readOnly } from "@fiftyone/state";
+import { datasetName } from "@fiftyone/state";
 import { toSlug } from "@fiftyone/utilities";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useRecoilState, useRecoilValue, useResetRecoilState } from "recoil";
@@ -60,22 +60,4 @@ export function useWorkspaces() {
     reset: resetState,
     existingSlugs,
   };
-}
-
-export function useWorkspacePermission() {
-  const canEditSavedViews = useRecoilValue(canEditWorkspaces);
-  const isReadOnly = useRecoilValue(readOnly);
-  const canEdit = useMemo(
-    () => canEditSavedViews && !isReadOnly,
-    [canEditSavedViews, isReadOnly]
-  );
-  const disabledInfo = useMemo(() => {
-    return !canEditSavedViews
-      ? "You do not have permission to save a workspace"
-      : isReadOnly
-      ? "Can not save workspace in read-only mode"
-      : undefined;
-  }, [canEditSavedViews, isReadOnly]);
-
-  return { canEdit, disabledInfo };
 }

--- a/app/packages/spaces/src/components/Workspaces/index.tsx
+++ b/app/packages/spaces/src/components/Workspaces/index.tsx
@@ -1,4 +1,5 @@
 import { ColoredDot, Popout, scrollable } from "@fiftyone/components";
+import { canEditWorkspaces, sessionSpaces } from "@fiftyone/state";
 import { Add, AutoAwesomeMosaicOutlined } from "@mui/icons-material";
 import {
   Box,
@@ -18,9 +19,8 @@ import { useRecoilValue, useSetRecoilState } from "recoil";
 import { workspaceEditorStateAtom } from "../../state";
 import Workspace from "./Workspace";
 import WorkspaceEditor from "./WorkspaceEditor";
-import { useWorkspaces, useWorkspacePermission } from "./hooks";
-import { sessionSpaces } from "@fiftyone/state";
 import { UNSAVED_WORKSPACE_COLOR } from "./constants";
+import { useWorkspaces } from "./hooks";
 
 export default function Workspaces() {
   const [open, setOpen] = useState(false);
@@ -28,7 +28,9 @@ export default function Workspaces() {
   const { workspaces, loadWorkspace, initialized, listWorkspace } =
     useWorkspaces();
   const setWorkspaceEditorState = useSetRecoilState(workspaceEditorStateAtom);
-  const { canEdit, disabledInfo } = useWorkspacePermission();
+  const canEditWorkSpace = useRecoilValue(canEditWorkspaces);
+  const disabled = canEditWorkSpace.enabled !== true;
+  const disabledMsg = canEditWorkSpace.message;
   const sessionSpacesState = useRecoilValue(sessionSpaces);
   const currentWorkspaceName = sessionSpacesState._name;
 
@@ -132,16 +134,16 @@ export default function Workspaces() {
                       "&:hover": {
                         ".MuiStack-root": { visibility: "visible" },
                       },
-                      cursor: !canEdit ? "not-allowed" : undefined,
+                      cursor: disabled ? "not-allowed" : undefined,
                     }}
-                    title={disabledInfo}
+                    title={disabledMsg}
                   >
                     <ListItemButton
                       component="a"
                       sx={{ py: 0.5, pr: 0.5 }}
-                      disabled={!canEdit}
+                      disabled={disabled}
                       onClick={() => {
-                        if (!canEdit) return;
+                        if (disabled) return;
                         setOpen(false);
                         setWorkspaceEditorState((state) => ({
                           ...state,

--- a/app/packages/state/src/recoil/atoms.ts
+++ b/app/packages/state/src/recoil/atoms.ts
@@ -320,17 +320,17 @@ export const canEditCustomColors = sessionAtom({
 
 export const canCreateNewField = sessionAtom({
   key: "canCreateNewField",
-  default: true,
+  default: { enabled: true, message: null },
 });
 
 export const canModifySidebarGroup = sessionAtom({
   key: "canModifySidebarGroup",
-  default: true,
+  default: { enabled: true, message: null },
 });
 
 export const canTagSamplesOrLabels = sessionAtom({
   key: "canTagSamplesOrLabels",
-  default: true,
+  default: { enabled: true, message: null },
 });
 
 export const readOnly = sessionAtom({

--- a/app/packages/state/src/recoil/atoms.ts
+++ b/app/packages/state/src/recoil/atoms.ts
@@ -323,13 +323,13 @@ export const canCreateNewField = sessionAtom({
   default: true,
 });
 
-export const canAddSidebarGroup = sessionAtom({
-  key: "canAddSidebarGroup",
+export const canModifySidebarGroup = sessionAtom({
+  key: "canModifySidebarGroup",
   default: true,
 });
 
-export const canTagSamples = sessionAtom({
-  key: "canTagSamples",
+export const canTagSamplesOrLabels = sessionAtom({
+  key: "canTagSamplesOrLabels",
   default: true,
 });
 

--- a/app/packages/state/src/recoil/atoms.ts
+++ b/app/packages/state/src/recoil/atoms.ts
@@ -328,6 +328,11 @@ export const canAddSidebarGroup = sessionAtom({
   default: true,
 });
 
+export const canTagSamples = sessionAtom({
+  key: "canTagSamples",
+  default: true,
+});
+
 export const readOnly = sessionAtom({
   key: "readOnly",
   default: false,

--- a/app/packages/state/src/recoil/atoms.ts
+++ b/app/packages/state/src/recoil/atoms.ts
@@ -318,6 +318,11 @@ export const canEditCustomColors = sessionAtom({
   default: true,
 });
 
+export const canCreateNewField = sessionAtom({
+  key: "canCreateNewField",
+  default: true,
+});
+
 export const readOnly = sessionAtom({
   key: "readOnly",
   default: false,

--- a/app/packages/state/src/recoil/atoms.ts
+++ b/app/packages/state/src/recoil/atoms.ts
@@ -305,17 +305,17 @@ export const theme = atom<"dark" | "light">({
 
 export const canEditSavedViews = sessionAtom({
   key: "canEditSavedViews",
-  default: true,
+  default: { enabled: true, message: null },
 });
 
 export const canEditWorkspaces = sessionAtom({
   key: "canEditWorkspaces",
-  default: true,
+  default: { enabled: true, message: null },
 });
 
 export const canEditCustomColors = sessionAtom({
   key: "canEditCustomColors",
-  default: true,
+  default: { enabled: true, message: null },
 });
 
 export const canCreateNewField = sessionAtom({

--- a/app/packages/state/src/recoil/atoms.ts
+++ b/app/packages/state/src/recoil/atoms.ts
@@ -323,6 +323,11 @@ export const canCreateNewField = sessionAtom({
   default: true,
 });
 
+export const canAddSidebarGroup = sessionAtom({
+  key: "canAddSidebarGroup",
+  default: true,
+});
+
 export const readOnly = sessionAtom({
   key: "readOnly",
   default: false,

--- a/app/packages/state/src/session.ts
+++ b/app/packages/state/src/session.ts
@@ -31,6 +31,7 @@ export interface Session {
   canEditWorkspaces: boolean;
   canCreateNewField: boolean;
   canAddSidebarGroup: boolean;
+  canTagSamples: boolean;
   colorScheme: ColorSchemeInput;
   readOnly: boolean;
   selectedSamples: Set<string>;
@@ -46,6 +47,7 @@ export const SESSION_DEFAULT: Session = {
   canEditWorkspaces: true,
   canCreateNewField: true,
   canAddSidebarGroup: true,
+  canTagSamples: true,
   readOnly: false,
   selectedSamples: new Set(),
   selectedLabels: [],
@@ -70,6 +72,7 @@ type SetterKeys = keyof Omit<
   | "canCreateNewField"
   | "canAddSidebarGroup"
   | "canEditCustomColors"
+  | "canTagSamples"
   | "canEditSavedViews"
   | "canEditWorkspaces"
   | "readOnly"
@@ -183,6 +186,7 @@ export function sessionAtom<K extends keyof Session>(
         options.key === "canCreateNewField" ||
         options.key === "canAddSidebarGroup" ||
         options.key === "canEditCustomColors" ||
+        options.key === "canTagSamples" ||
         options.key === "readOnly" ||
         options.key === "canEditSavedViews" ||
         options.key === "canEditWorkspaces" ||

--- a/app/packages/state/src/session.ts
+++ b/app/packages/state/src/session.ts
@@ -29,6 +29,7 @@ export interface Session {
   canEditCustomColors: boolean;
   canEditSavedViews: boolean;
   canEditWorkspaces: boolean;
+  canCreateNewField: boolean;
   colorScheme: ColorSchemeInput;
   readOnly: boolean;
   selectedSamples: Set<string>;
@@ -40,6 +41,7 @@ export interface Session {
 
 export const SESSION_DEFAULT: Session = {
   canEditCustomColors: true,
+  canCreateNewField: true,
   canEditSavedViews: true,
   canEditWorkspaces: true,
   readOnly: false,
@@ -63,7 +65,11 @@ export const SESSION_DEFAULT: Session = {
 
 type SetterKeys = keyof Omit<
   Session,
-  "canEditCustomColors" | "canEditSavedViews" | "canEditWorkspaces" | "readOnly"
+  | "canCreateNewField"
+  | "canEditCustomColors"
+  | "canEditSavedViews"
+  | "canEditWorkspaces"
+  | "readOnly"
 >;
 type Setter = <K extends SetterKeys>(key: K, value: Session[K]) => void;
 
@@ -171,6 +177,7 @@ export function sessionAtom<K extends keyof Session>(
       }
 
       if (
+        options.key === "canCreateNewField" ||
         options.key === "canEditCustomColors" ||
         options.key === "readOnly" ||
         options.key === "canEditSavedViews" ||

--- a/app/packages/state/src/session.ts
+++ b/app/packages/state/src/session.ts
@@ -29,9 +29,9 @@ export interface Session {
   canEditCustomColors: boolean;
   canEditSavedViews: boolean;
   canEditWorkspaces: boolean;
-  canCreateNewField: boolean;
-  canModifySidebarGroup: boolean;
-  canTagSamplesOrLabels: boolean;
+  canCreateNewField: { enabled: boolean; message: string | null };
+  canModifySidebarGroup: { enabled: boolean; message: string | null };
+  canTagSamplesOrLabels: { enabled: boolean; message: string | null };
   colorScheme: ColorSchemeInput;
   readOnly: boolean;
   selectedSamples: Set<string>;
@@ -45,9 +45,9 @@ export const SESSION_DEFAULT: Session = {
   canEditCustomColors: true,
   canEditSavedViews: true,
   canEditWorkspaces: true,
-  canCreateNewField: true,
-  canModifySidebarGroup: true,
-  canTagSamplesOrLabels: true,
+  canCreateNewField: { enabled: true, message: null },
+  canModifySidebarGroup: { enabled: true, message: null },
+  canTagSamplesOrLabels: { enabled: true, message: null },
   readOnly: false,
   selectedSamples: new Set(),
   selectedLabels: [],

--- a/app/packages/state/src/session.ts
+++ b/app/packages/state/src/session.ts
@@ -30,6 +30,7 @@ export interface Session {
   canEditSavedViews: boolean;
   canEditWorkspaces: boolean;
   canCreateNewField: boolean;
+  canAddSidebarGroup: boolean;
   colorScheme: ColorSchemeInput;
   readOnly: boolean;
   selectedSamples: Set<string>;
@@ -41,9 +42,10 @@ export interface Session {
 
 export const SESSION_DEFAULT: Session = {
   canEditCustomColors: true,
-  canCreateNewField: true,
   canEditSavedViews: true,
   canEditWorkspaces: true,
+  canCreateNewField: true,
+  canAddSidebarGroup: true,
   readOnly: false,
   selectedSamples: new Set(),
   selectedLabels: [],
@@ -66,6 +68,7 @@ export const SESSION_DEFAULT: Session = {
 type SetterKeys = keyof Omit<
   Session,
   | "canCreateNewField"
+  | "canAddSidebarGroup"
   | "canEditCustomColors"
   | "canEditSavedViews"
   | "canEditWorkspaces"
@@ -178,6 +181,7 @@ export function sessionAtom<K extends keyof Session>(
 
       if (
         options.key === "canCreateNewField" ||
+        options.key === "canAddSidebarGroup" ||
         options.key === "canEditCustomColors" ||
         options.key === "readOnly" ||
         options.key === "canEditSavedViews" ||

--- a/app/packages/state/src/session.ts
+++ b/app/packages/state/src/session.ts
@@ -30,8 +30,8 @@ export interface Session {
   canEditSavedViews: boolean;
   canEditWorkspaces: boolean;
   canCreateNewField: boolean;
-  canAddSidebarGroup: boolean;
-  canTagSamples: boolean;
+  canModifySidebarGroup: boolean;
+  canTagSamplesOrLabels: boolean;
   colorScheme: ColorSchemeInput;
   readOnly: boolean;
   selectedSamples: Set<string>;
@@ -46,8 +46,8 @@ export const SESSION_DEFAULT: Session = {
   canEditSavedViews: true,
   canEditWorkspaces: true,
   canCreateNewField: true,
-  canAddSidebarGroup: true,
-  canTagSamples: true,
+  canModifySidebarGroup: true,
+  canTagSamplesOrLabels: true,
   readOnly: false,
   selectedSamples: new Set(),
   selectedLabels: [],
@@ -70,9 +70,9 @@ export const SESSION_DEFAULT: Session = {
 type SetterKeys = keyof Omit<
   Session,
   | "canCreateNewField"
-  | "canAddSidebarGroup"
+  | "canModifySidebarGroup"
   | "canEditCustomColors"
-  | "canTagSamples"
+  | "canTagSamplesOrLabels"
   | "canEditSavedViews"
   | "canEditWorkspaces"
   | "readOnly"
@@ -184,9 +184,9 @@ export function sessionAtom<K extends keyof Session>(
 
       if (
         options.key === "canCreateNewField" ||
-        options.key === "canAddSidebarGroup" ||
+        options.key === "canModifySidebarGroup" ||
         options.key === "canEditCustomColors" ||
-        options.key === "canTagSamples" ||
+        options.key === "canTagSamplesOrLabels" ||
         options.key === "readOnly" ||
         options.key === "canEditSavedViews" ||
         options.key === "canEditWorkspaces" ||

--- a/app/packages/state/src/session.ts
+++ b/app/packages/state/src/session.ts
@@ -26,12 +26,12 @@ export const SPACES_DEFAULT = {
 };
 
 export interface Session {
-  canEditCustomColors: boolean;
-  canEditSavedViews: boolean;
-  canEditWorkspaces: boolean;
-  canCreateNewField: { enabled: boolean; message: string | null };
-  canModifySidebarGroup: { enabled: boolean; message: string | null };
-  canTagSamplesOrLabels: { enabled: boolean; message: string | null };
+  canEditCustomColors: { enabled: boolean; message?: string };
+  canEditSavedViews: { enabled: boolean; message?: string };
+  canEditWorkspaces: { enabled: boolean; message?: string };
+  canCreateNewField: { enabled: boolean; message?: string };
+  canModifySidebarGroup: { enabled: boolean; message?: string };
+  canTagSamplesOrLabels: { enabled: boolean; message?: string };
   colorScheme: ColorSchemeInput;
   readOnly: boolean;
   selectedSamples: Set<string>;
@@ -42,12 +42,12 @@ export interface Session {
 }
 
 export const SESSION_DEFAULT: Session = {
-  canEditCustomColors: true,
-  canEditSavedViews: true,
-  canEditWorkspaces: true,
-  canCreateNewField: { enabled: true, message: null },
-  canModifySidebarGroup: { enabled: true, message: null },
-  canTagSamplesOrLabels: { enabled: true, message: null },
+  canEditCustomColors: { enabled: true, message: undefined },
+  canEditSavedViews: { enabled: true, message: undefined },
+  canEditWorkspaces: { enabled: true, message: undefined },
+  canCreateNewField: { enabled: true, message: undefined },
+  canModifySidebarGroup: { enabled: true, message: undefined },
+  canTagSamplesOrLabels: { enabled: true, message: undefined },
   readOnly: false,
   selectedSamples: new Set(),
   selectedLabels: [],


### PR DESCRIPTION
## What changes are proposed in this pull request?

(Please fill in changes proposed in this fix)

## How is this patch tested? If it is not, please explain why.

(Details)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced permissions system with new capabilities:
    - Modify sidebar groups
    - Create new fields
    - Tag samples or labels
    - Edit custom colors
    - Edit saved views
  
- **Bug Fixes**
  - Improved logic for enabling/disabling actions based on permissions.

- **Refactor**
  - Replaced `readOnly` state with specific permission checks across multiple components for better modularity and clarity.

- **Usability Improvements**
  - Dynamic titles and disabled states for better user feedback based on permissions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->