### PR TITLE
add set_spaces operation

### DIFF
--- a/app/packages/operators/src/built-in-operators.ts
+++ b/app/packages/operators/src/built-in-operators.ts
@@ -8,6 +8,7 @@ import {
 import * as fos from "@fiftyone/state";
 import * as types from "./types";
 
+import { LOAD_WORKSPACE_OPERATOR } from "@fiftyone/spaces/src/components/Workspaces/constants";
 import { toSlug } from "@fiftyone/utilities";
 import copyToClipboard from "copy-to-clipboard";
 import { useSetRecoilState } from "recoil";
@@ -771,7 +772,14 @@ class SetSpaces extends Operator {
     return { setSessionSpacesState };
   }
   async execute(ctx: ExecutionContext) {
-    ctx.hooks.setSessionSpacesState(ctx.params.spaces);
+    const { name, spaces } = ctx.params || {};
+    if (spaces) {
+      ctx.hooks.setSessionSpacesState(spaces);
+    } else if (name) {
+      executeOperator(LOAD_WORKSPACE_OPERATOR, { name }, { skipOutput: true });
+    } else {
+      throw new Error('Param "spaces" or "name" is required to set a space');
+    }
   }
 }
 

--- a/fiftyone/operators/builtin.py
+++ b/fiftyone/operators/builtin.py
@@ -446,8 +446,7 @@ class LoadWorkspace(foo.Operator):
 
     def execute(self, ctx):
         name = ctx.params.get("name", None)
-        spaces = ctx.dataset.load_workspace(name)
-        ctx.trigger("set_spaces", {"spaces": spaces.to_dict()})
+        ctx.ops.set_spaces(name=name)
         return {}
 
 

--- a/fiftyone/operators/operations.py
+++ b/fiftyone/operators/operations.py
@@ -5,6 +5,7 @@ FiftyOne operator execution.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 import json
 
 from bson import json_util
@@ -315,6 +316,21 @@ class Operations(object):
     def clear_selected_labels(self):
         """Clear the selected labels in the App."""
         return self._ctx.trigger("clear_selected_labels")
+
+    def set_spaces(self, spaces=None, name=None):
+        """Set space in the App by name or :class:`fiftyone.core.odm.workspace.Space`.
+
+        Args:
+            spaces: the spaces (:class:`fiftyone.core.odm.workspace.Space`) to load
+            name: the name of the workspace to load
+        """
+        params = {}
+        if spaces is not None:
+            params["spaces"] = spaces.to_dict()
+        elif name is not None:
+            params["spaces"] = self._ctx.dataset.load_workspace(name).to_dict()
+
+        return self._ctx.trigger("set_spaces", params=params)
 
 
 def _serialize_view(view):


### PR DESCRIPTION
## What changes are proposed in this pull request?

Add `set_spaces` operation to `ctx.ops` available in operators execute

## How is this patch tested? If it is not, please explain why.

Using a test operator:

```py

class SetSpaces(foo.Operator):
    @property
    def config(self):
        return foo.OperatorConfig(
            name="playground_py_set_spaces",
            label="Playground_Py: Set spaces",
            dynamic=True,
        )

    def resolve_input(self, ctx):
        inputs = types.Object()
        inputs.enum(
            "workspace", ctx.dataset.list_workspaces(), label="Workspace", required=True
        )
        return types.Property(inputs)

    def execute(self, ctx):
        ctx.ops.set_spaces(name=ctx.params.get("workspace"))
        return {}
```


## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

See usage above

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced workspace management functionality, allowing users to set and load workspaces by name directly within the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->