### PR TITLE
Reduce the size of fiftyone package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -138,8 +138,7 @@ setup(
     long_description_content_type="text/markdown",
     packages=find_packages(
         exclude=["app", "eta", "package", "requirements", "tests", "tools"]
-    )
-    + ["fiftyone.recipes", "fiftyone.tutorials"],
+    ),
     package_dir={
         "fiftyone.recipes": "docs/source/recipes",
         "fiftyone.tutorials": "docs/source/tutorials",

--- a/setup.py
+++ b/setup.py
@@ -139,10 +139,6 @@ setup(
     packages=find_packages(
         exclude=["app", "eta", "package", "requirements", "tests", "tools"]
     ),
-    package_dir={
-        "fiftyone.recipes": "docs/source/recipes",
-        "fiftyone.tutorials": "docs/source/tutorials",
-    },
     install_requires=get_install_requirements(
         INSTALL_REQUIRES, CHOOSE_INSTALL_REQUIRES
     ),


### PR DESCRIPTION
## What changes are proposed in this pull request?

We want to get fiftyone package size to 250MB. 

Remove tutorials and recipes from setup.py can help to do that.

## How is this patch tested? If it is not, please explain why.

Rebuild `fiftyone` and check for size; this should not be a breaking change.

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [x] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Streamlined the installation process by excluding certain non-essential packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->