### PR TITLE
Adding a clean step to Makefile

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -10,6 +10,7 @@ prune package
 prune requirements
 prune tools
 prune tests
+prune dist
 
 global-exclude .*
 

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,10 @@
 app:
 	@cd app && yarn && yarn build && cd ..
 
-python: app
+clean:
+	@rm -rf ./dist/*
+
+python: app clean
 	@python -Im build
 
 docker: python


### PR DESCRIPTION
## What changes are proposed in this pull request?

Adding a clean step to Makefile so that we don't bundle existing dist content. I observed that running `make python` repeatedly right now will increase the size of the archived files because we are also bundling the dist content as well :) 

## How is this patch tested? If it is not, please explain why.

Tested locally and verified that the archived file no longer contains the dist folder.

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [x] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the packaging process to exclude the `dist` directory, ensuring cleaner distributions.
	- Enhanced the build process with a `clean` target to remove old distributions before creating new ones.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->