### PR TITLE
make contained button text color white by default

### DIFF
--- a/app/packages/components/src/components/MuiButton/index.tsx
+++ b/app/packages/components/src/components/MuiButton/index.tsx
@@ -2,7 +2,11 @@ import React from "react";
 import { ButtonProps, CircularProgress, Button, Stack } from "@mui/material";
 
 export default function MuiButton(props: ButtonPropsType) {
-  const { loading, ...otherProps } = props;
+  const { loading, variant, ...otherProps } = props;
+
+  const containedStyles =
+    variant === "contained" ? { sx: { color: "white" } } : {};
+
   return (
     <Stack
       direction="row"
@@ -10,7 +14,7 @@ export default function MuiButton(props: ButtonPropsType) {
       alignItems="center"
       sx={{ position: "relative" }}
     >
-      <Button {...otherProps} />
+      <Button {...containedStyles} variant={variant} {...otherProps} />
       {loading && (
         <CircularProgress size={20} sx={{ position: "absolute", left: 6 }} />
       )}


### PR DESCRIPTION
## What changes are proposed in this pull request?

Make text color of contained button white by default

## How is this patch tested? If it is not, please explain why.

Using the Button component in app

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new `variant` property to the `MuiButton` component, allowing users to customize the button's appearance based on the variant value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->