### PR TITLE
[Proposal] Automatic PRs into `develop`

### DIFF
--- a/.github/workflows/push-release.yml
+++ b/.github/workflows/push-release.yml
@@ -11,6 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: develop
       - run: git pull origin ${{ github.ref_name }} --no-rebase
       - uses: peter-evans/create-pull-request@v6
         with:

--- a/.github/workflows/push-release.yml
+++ b/.github/workflows/push-release.yml
@@ -1,0 +1,22 @@
+name: Push Release
+
+on:
+  push:
+    branches:
+      - main
+      - release/v[0-9]+.[0-9]+.[0-9]+
+
+jobs:
+  pr:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: git pull origin ${{ github.ref_name }} --no-rebase
+      - uses: peter-evans/create-pull-request@v6
+        with:
+          author: voxel51-bot <bot@voxel51.com>
+          token: ${{ secrets.FIFTYONE_GITHUB_TOKEN }}
+          base: develop
+          body: "Merge `${{ github.ref_name }}` to `develop`"
+          branch: merge/${{ github.ref_name }}
+          title: Merge `${{ github.ref_name }}` to `develop`

--- a/.github/workflows/push-release.yml
+++ b/.github/workflows/push-release.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - main
       - release/v[0-9]+.[0-9]+.[0-9]+
+  workflow_dispatch:
+    inputs:
+      ref_name:
+        type: string
 
 jobs:
   pr:
@@ -13,12 +17,12 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: develop
-      - run: git pull origin ${{ github.ref_name }} --no-rebase
+      - run: git pull origin ${{ inputs.ref_name || github.ref_name }} --no-rebase
       - uses: peter-evans/create-pull-request@v6
         with:
           author: voxel51-bot <bot@voxel51.com>
           token: ${{ secrets.FIFTYONE_GITHUB_TOKEN }}
           base: develop
-          body: "Merge `${{ github.ref_name }}` to `develop`"
-          branch: merge/${{ github.ref_name }}
-          title: Merge `${{ github.ref_name }}` to `develop`
+          body: Merge `${{ inputs.ref_name || github.ref_name }}` to `develop`
+          branch: merge/${{ inputs.ref_name || github.ref_name }}
+          title: Merge `${{ inputs.ref_name || github.ref_name }}` to `develop`


### PR DESCRIPTION
## What changes are proposed in this pull request?

Proposal to add automatic PRs into `develop` when `main` or `release/*` branches are pushed to

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [x] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
  - Introduced a GitHub Actions workflow "Push Release" to automate merging changes from `main` or `release` branches into `develop`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->