### PR TITLE
fix panel state changes

### DIFF
--- a/app/packages/operators/src/useCustomPanelHooks.ts
+++ b/app/packages/operators/src/useCustomPanelHooks.ts
@@ -44,12 +44,8 @@ export interface CustomPanelHooks {
 
 function useCtxChangePanelEvent(panelId, value, operator) {
   const triggerCtxChangedEvent = usePanelEvent();
-  const serializedValue = JSON.stringify(value);
-  console.log(operator, value);
   useEffect(() => {
-    console.log("useEffect");
     if (operator) {
-      console.log("triggering");
       triggerCtxChangedEvent(panelId, { operator, params: { value } });
     }
   }, [value, operator]);
@@ -156,10 +152,14 @@ export function useCustomPanelHooks(props: CustomPanelProps): CustomPanelHooks {
 
   const handlePanelStatePathChange = (path, value, schema) => {
     if (schema?.onChange) {
-      triggerPanelPropertyChange(panelId, {
-        operator: schema.onChange,
-        params: { path, value },
-      });
+      // This timeout allows the change to be applied before executing the operator
+      // it might make sense to do this for all operator executions
+      setTimeout(() => {
+        triggerPanelPropertyChange(panelId, {
+          operator: schema.onChange,
+          params: { path, value },
+        });
+      }, 0);
     }
   };
 


### PR DESCRIPTION
Prior to this change the following would display the previous choice:

```python
    def render(self, ctx):
        # ...
        choices = types.Choices()
        choices.add_choice(1, label="One")
        choices.add_choice(2, label="Two")
        choices.add_choice(3, label="Three")
        grid.enum('choice', values=choices.values(), on_change=self.on_change_choice)
        return types.Property(panel)

    def on_change_choice(self, ctx):
        print("Choice changed", ctx.panel.state)
        # this would show the previously selected choice! this PR fixes that issue
        ctx.ops.notify(f"Choice changed to {ctx.panel.state.grid.get('choice', 'No choice')}")
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved performance and reliability of context change events in custom panels.
  - Removed unnecessary console logs for cleaner code execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->