### PR TITLE
Add set_extended_selection operation

### DIFF
--- a/app/packages/core/src/plugins/SchemaIO/components/PlotlyView.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/PlotlyView.tsx
@@ -5,7 +5,7 @@ import Plot from "react-plotly.js";
 import { HeaderView } from ".";
 import { getComponentProps } from "../utils";
 import { merge } from "lodash";
-import { usePanelState } from "@fiftyone/spaces";
+import { usePanelId, usePanelState } from "@fiftyone/spaces";
 import { executeOperator } from "@fiftyone/operators";
 import usePanelEvent from "@fiftyone/operators/src/usePanelEvent";
 import { snakeCase } from "lodash";
@@ -15,6 +15,7 @@ export default function PlotlyView(props) {
   const { view = {} } = schema;
   const { config = {}, layout = {} } = view;
   const theme = useTheme();
+  const panelId = usePanelId();
   const [selectedpoints, setSelectedPoints] = React.useState(null);
   let range = [0, 0];
   const triggerPanelEvent = usePanelEvent();
@@ -73,7 +74,7 @@ export default function PlotlyView(props) {
           type: view.type,
         };
       }
-      triggerPanelEvent(view.panel_id, {
+      triggerPanelEvent(panelId, {
         operator: eventHandlerOperator,
         params,
       });

--- a/app/packages/operators/src/built-in-operators.ts
+++ b/app/packages/operators/src/built-in-operators.ts
@@ -1056,6 +1056,46 @@ class Notify extends Operator {
   }
 }
 
+class SetExtendedSelection extends Operator {
+  get config(): OperatorConfig {
+    return new OperatorConfig({
+      name: "set_extended_selection",
+      label: "Set extended selection",
+      unlisted: true,
+    });
+  }
+  useHooks(ctx: ExecutionContext): {} {
+    return {
+      setExtendedSelection: useSetRecoilState(fos.extendedSelection),
+      clearExtendedSelection: useSetRecoilState(fos.extendedSelection),
+      resetExtendedSelection: fos.useResetExtendedSelection(),
+    };
+  }
+  async resolveInput(ctx: ExecutionContext): Promise<types.Property> {
+    const inputs = new types.Object();
+    inputs.list("selection", new types.String(), {
+      label: "Selection",
+      required: false,
+    });
+    inputs.str("scope", { label: "Scope", required: false });
+    inputs.bool("clear", { label: "Clear", default: false });
+    inputs.bool("reset", { label: "Reset", default: false });
+    return new types.Property(inputs);
+  }
+  async execute(ctx: ExecutionContext): Promise<void> {
+    if (ctx.params.reset) {
+      ctx.hooks.resetExtendedSelection();
+    } else if (ctx.params.clear) {
+      ctx.hooks.clearExtendedSelection();
+    } else {
+      ctx.hooks.setExtendedSelection({
+        selection: ctx.params.selection,
+        scope: ctx.params.scope,
+      });
+    }
+  }
+}
+
 export function registerBuiltInOperators() {
   try {
     _registerBuiltInOperator(CopyViewAsJSON);
@@ -1097,6 +1137,7 @@ export function registerBuiltInOperators() {
     _registerBuiltInOperator(PatchPanelData);
     _registerBuiltInOperator(PromptUserForOperation);
     _registerBuiltInOperator(Notify);
+    _registerBuiltInOperator(SetExtendedSelection);
   } catch (e) {
     console.error("Error registering built-in operators");
     console.error(e);

--- a/fiftyone/operators/operations.py
+++ b/fiftyone/operators/operations.py
@@ -491,6 +491,27 @@ class Operations(object):
             "notify", params={"message": message, "variant": variant}
         )
 
+    def set_extended_selection(
+        self, selection, scope=None, clear=False, reset=False
+    ):
+        """Set the extended selection in the App.
+
+        Args:
+            selection: the selection to set
+            scope: the scope of the selection
+            clear: whether to clear the selection
+            reset: whether to reset the selection
+        """
+        return self._ctx.trigger(
+            "set_extended_selection",
+            params={
+                "selection": selection,
+                "scope": scope,
+                "clear": clear,
+                "reset": reset,
+            },
+        )
+
 
 def _serialize_view(view):
     return json.loads(json_util.dumps(view._serialize()))


### PR DESCRIPTION
 - Adds new set_extended_selection operation, which is an advanced way of telling the grid which samples to display.
 - Fixes an issue with plotly events where the panel_id was not properly included