### PR TITLE
add panel state deep get and set methods

### DIFF
--- a/fiftyone/operators/panel.py
+++ b/fiftyone/operators/panel.py
@@ -9,6 +9,8 @@ FiftyOne operators.
 import fiftyone.operators.types as types
 from fiftyone.operators.operator import OperatorConfig, Operator
 
+import pydash
+
 
 class PanelOperatorConfig(OperatorConfig):
     """A configuration for a panel operator."""
@@ -103,47 +105,125 @@ class Panel(Operator):
         ctx.ops.show_panel_output(panel_output)
 
 
-class PanelRefState:
+class WriteOnlyError(Exception):
+    """Error raised when trying to read a write-only property."""
+
+
+class PanelRefBase:
+    """
+    Base class for panel state and data.
+
+    Attributes:
+        _data (dict): A dictionary to store the data or state.
+        _ctx: The context object containing the operations.
+    """
+
     def __init__(self, ctx):
-        self._data = ctx.panel_state
+        self._data = {}
         self._ctx = ctx
+
+    def set(self, key, value):
+        """
+        Sets the value in the dictionary.
+
+        Args:
+            key (str): The key.
+            value (any): The value.
+        """
+        pydash.set_(self._data, key, value)
+
+    def get(self, key, default=None):
+        """
+        Gets the value from the dictionary.
+
+        Args:
+            key (str): The key.
+            default (any): The default value if key is not found.
+
+        Returns:
+            The value.
+        """
+        return pydash.get(self._data, key, default)
+
+    def clear(self):
+        """Clears the dictionary."""
+        self._data = {}
 
     def __setattr__(self, key, value):
         if key.startswith("_"):
             super().__setattr__(key, value)
         else:
-            self._data[key] = value
-            self._ctx.ops.set_panel_state({key: value})
+            self.set(key, value)
 
     def __getattr__(self, key):
-        return self._data.get(key, None)
+        if key == "_data":
+            return self._data
+        elif key == "_ctx":
+            return self._ctx
+        else:
+            return self.get(key)
+
+
+class PanelRefState(PanelRefBase):
+    """
+    Class representing the state of a panel.
+    """
+
+    def __init__(self, ctx):
+        super().__init__(ctx)
+        self._data = ctx.panel_state
+
+    def set(self, key, value):
+        """
+        Sets the state of the panel.
+
+        Args:
+            key (str): A dot delimited path.
+            value (any): The state value.
+        """
+        super().set(key, value)
+        args = {}
+        pydash.set_(args, key, value)
+        self._ctx.ops.patch_panel_state(args)
 
     def clear(self):
-        self._data = {}
+        """Clears the panel state."""
+        super().clear()
         self._ctx.ops.clear_panel_state()
 
 
-class PanelRefData:
-    def __init__(self, ctx):
-        self._data = {}
-        self._ctx = ctx
+class PanelRefData(PanelRefBase):
+    """
+    Class representing the data of a panel.
+    """
 
-    def __setattr__(self, key, value):
-        if key.startswith("_"):
-            super().__setattr__(key, value)
-        else:
-            self._data[key] = value
-            self._ctx.ops.patch_panel_data({key: value})
+    def set(self, key, value):
+        """
+        Sets the data of the panel.
 
-    def __getattr__(self, key):
-        raise KeyError("Cannot read panel data")
+        Args:
+            key (str): The data key.
+            value (any): The data value.
+        """
+        super().set(key, value)
+        args = {}
+        pydash.set_(args, key, value)
+        self._ctx.ops.patch_panel_data(args)
+
+    def get(self, key, default=None):
+        raise WriteOnlyError("Panel data is write-only")
 
     def clear(self):
-        self._data = {}
+        """Clears the panel data."""
+        super().clear()
         self._ctx.ops.clear_panel_data()
 
 
 class PanelRef:
+    """
+    Represents a panel in the app.
+    """
+
     def __init__(self, ctx):
         self._ctx = ctx
         self._state = PanelRefState(ctx)
@@ -151,15 +231,65 @@ class PanelRef:
 
     @property
     def data(self):
+        """Panel data."""
         return self._data
 
     @property
     def state(self):
+        """Panel state."""
         return self._state
 
     @property
     def id(self):
+        """Panel ID."""
         return self._ctx.panel_id
 
     def close(self):
+        """Closes the panel."""
         self._ctx.ops.close_panel()
+
+    def set_state(self, key, value):
+        """
+        Sets the state of the panel.
+
+        Args:
+            key (str): A dot delimited path.
+            value (any): The state value.
+        """
+        self._state.set(key, value)
+
+    def get_state(self, key, default=None):
+        """
+        Gets the state of the panel.
+
+        Args:
+            key (str): A dot delimited path.
+            default (any): The default value if key is not found.
+
+        Returns:
+            The state value.
+        """
+        return self._state.get(key, default)
+
+    def set_data(self, key, value):
+        """
+        Sets the data of the panel.
+
+        Args:
+            key (str): The data key.
+            value (any): The data value.
+        """
+        self._data.set(key, value)
+
+    def get_data(self, key, default=None):
+        """
+        Gets the data of the panel.
+
+        Args:
+            key (str): The data key.
+            default (any): The default value if key is not found.
+
+        Returns:
+            The data value.
+        """
+        return self._data.get(key, default)

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -20,6 +20,7 @@ pprintpp==0.4.0
 psutil>=5.7.0
 pymongo>=3.12
 pydantic==2.6.4
+pydash==8.0.1
 pytz==2022.1
 PyYAML==6.0.1
 regex==2022.8.17


### PR DESCRIPTION
Added several new ways of reading and writing panel state and data. Here's a summary of how you can interact with a `Panel` via `PanelRef` after these changes:

```python
# Setting and getting panel state
panel.set_state("user.settings.language", "en")
print(panel.get_state("user.settings.language"))  # => "en"

# Simple properties can be set via dot syntax
panel.state.foo = "bar"

# Can also read panel.state with dot syntax
print(panel.state.foo) # => "bar"

# Setting panel data
panel.set_data("foo.bar", {"bat": "baz"})

# Trying to read panel data fails
panel.data.foo # throws WriteOnlyError

# Clearing panel state and data
panel.state.clear()
panel.data.clear()

# Closing the panel
panel.close()
```