### PR TITLE
Reverting jinja2 requirement bump #4357

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -8,7 +8,7 @@ ftfy==6.1.1
 httpx==0.23.0
 hypercorn==0.13.2
 importlib-metadata==1.4.0; python_version<"3.8"
-Jinja2==3.1.4
+Jinja2==3.0.3
 kaleido==0.2.1
 matplotlib==3.5.2
 mongoengine==0.24.2


### PR DESCRIPTION
Reverts https://github.com/voxel51/fiftyone/pull/4357.

IDK about anyone else but `Jinja2==3.1.4` in my environment it is incompatible with `Sphinx==3.5.4` pinned below so I can't build the docs. Reverting fixing this.

https://github.com/voxel51/fiftyone/blob/5eb84f5bf6ef820f05b92875824127f534569832/requirements/docs.txt#L10C1-L11C1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Downgraded Jinja2 library to version 3.0.3 for compatibility improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->