### PR TITLE
Allow generated datasets to be directly created

### DIFF
--- a/fiftyone/core/clips.py
+++ b/fiftyone/core/clips.py
@@ -586,6 +586,8 @@ def make_clips_dataset(
     min_len=0,
     trajectories=False,
     name=None,
+    persistent=False,
+    _generated=False,
 ):
     """Creates a dataset that contains one sample per clip defined by the
     given field or expression in the collection.
@@ -650,6 +652,8 @@ def make_clips_dataset(
             trajectory defined by their ``(label, index)``. Only applicable
             when ``field_or_expr`` is a frame-level field
         name (None): a name for the dataset
+        persistent (False): whether the dataset should persist in the database
+            after the session terminates
 
     Returns:
         a :class:`fiftyone.core.dataset.Dataset`
@@ -675,9 +679,22 @@ def make_clips_dataset(
     else:
         clips_type = "manual"
 
+    if _generated:
+        _name = name
+        _persistent = persistent
+    else:
+        # We first create a temporary dataset with samples representing the
+        # clips; then we clone it to pull in the corresponding frames
+        _name = None
+        _persistent = False
+
     dataset = fod.Dataset(
-        name=name, _clips=True, _src_collection=sample_collection
+        name=_name,
+        persistent=_persistent,
+        _clips=True,
+        _src_collection=sample_collection,
     )
+
     dataset.media_type = fom.VIDEO
     dataset.add_sample_field("sample_id", fof.ObjectIdField)
     dataset.add_sample_field("support", fof.FrameSupportField)
@@ -749,6 +766,13 @@ def make_clips_dataset(
             field_or_expr,
             other_fields=other_fields,
         )
+
+    if not _generated:
+        # Clone so that dataset no longer shares the same underlying frames
+        # collection as the input collection
+        _dataset = dataset
+        dataset = _dataset.clone(name=name, persistent=persistent)
+        _dataset.delete()
 
     return dataset
 

--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -7806,7 +7806,7 @@ def _get_frames_pipeline(sample_collection):
         view = None
 
     if dataset._is_clips:
-        # Clips datasets use `sample_id` to associated with frames, but now as
+        # Clips datasets use `sample_id` to associate with frames, but now as
         # a standalone collection, they must use `_id`
         coll = dataset._sample_collection
         pipeline = sample_collection._pipeline(attach_frames=True) + [

--- a/fiftyone/core/patches.py
+++ b/fiftyone/core/patches.py
@@ -558,6 +558,8 @@ def make_patches_dataset(
     other_fields=None,
     keep_label_lists=False,
     name=None,
+    persistent=False,
+    _generated=False,
 ):
     """Creates a dataset that contains one sample per object patch in the
     specified field of the collection.
@@ -586,6 +588,8 @@ def make_patches_dataset(
             fields of the same type as the input collection rather than using
             their single label variants
         name (None): a name for the dataset
+        persistent (False): whether the dataset should persist in the database
+            after the session terminates
 
     Returns:
         a :class:`fiftyone.core.dataset.Dataset`
@@ -606,7 +610,12 @@ def make_patches_dataset(
         sample_collection, field, keep_label_lists
     )
 
-    dataset = fod.Dataset(name=name, _patches=True, _frames=is_frame_patches)
+    dataset = fod.Dataset(
+        name=name,
+        persistent=persistent,
+        _patches=_generated,
+        _frames=is_frame_patches and _generated,
+    )
     dataset.media_type = fom.IMAGE
     dataset.add_sample_field("sample_id", fof.ObjectIdField)
     dataset.create_index("sample_id")
@@ -671,7 +680,12 @@ def _get_patches_field(sample_collection, field_name, keep_label_lists):
 
 
 def make_evaluation_patches_dataset(
-    sample_collection, eval_key, other_fields=None, name=None
+    sample_collection,
+    eval_key,
+    other_fields=None,
+    name=None,
+    persistent=False,
+    _generated=False,
 ):
     """Creates a dataset based on the results of the evaluation with the given
     key that contains one sample for each true positive, false positive, and
@@ -720,6 +734,8 @@ def make_evaluation_patches_dataset(
             -   ``True`` to include all other fields
             -   ``None``/``False`` to include no other fields
         name (None): a name for the dataset
+        persistent (False): whether the dataset should persist in the database
+            after the session terminates
 
     Returns:
         a :class:`fiftyone.core.dataset.Dataset`
@@ -757,7 +773,12 @@ def make_evaluation_patches_dataset(
     _pred_field = sample_collection.get_field(pred_field)
 
     # Setup dataset with correct schema
-    dataset = fod.Dataset(name=name, _patches=True, _frames=is_frame_patches)
+    dataset = fod.Dataset(
+        name=name,
+        persistent=persistent,
+        _patches=_generated,
+        _frames=is_frame_patches and _generated,
+    )
     dataset.media_type = fom.IMAGE
     dataset.add_sample_field("sample_id", fof.ObjectIdField)
     dataset.create_index("sample_id")

--- a/fiftyone/core/stages.py
+++ b/fiftyone/core/stages.py
@@ -7479,7 +7479,10 @@ class ToPatches(ViewStage):
         if state != last_state or not fod.dataset_exists(name):
             kwargs = self._config or {}
             patches_dataset = fop.make_patches_dataset(
-                sample_collection, self._field, **kwargs
+                sample_collection,
+                self._field,
+                _generated=True,
+                **kwargs,
             )
 
             # Other views may use the same generated dataset, so reuse the old
@@ -7623,7 +7626,10 @@ class ToEvaluationPatches(ViewStage):
         if state != last_state or not fod.dataset_exists(name):
             kwargs = self._config or {}
             eval_patches_dataset = fop.make_evaluation_patches_dataset(
-                sample_collection, self._eval_key, **kwargs
+                sample_collection,
+                self._eval_key,
+                _generated=True,
+                **kwargs,
             )
 
             # Other views may use the same generated dataset, so reuse the old
@@ -7780,7 +7786,10 @@ class ToClips(ViewStage):
         if state != last_state or not fod.dataset_exists(name):
             kwargs = self._config or {}
             clips_dataset = focl.make_clips_dataset(
-                sample_collection, self._field_or_expr, **kwargs
+                sample_collection,
+                self._field_or_expr,
+                _generated=True,
+                **kwargs,
             )
 
             # Other views may use the same generated dataset, so reuse the old
@@ -7914,7 +7923,11 @@ class ToTrajectories(ViewStage):
         if state != last_state or not fod.dataset_exists(name):
             kwargs = self._config or {}
             clips_dataset = focl.make_clips_dataset(
-                sample_collection, self._field, trajectories=True, **kwargs
+                sample_collection,
+                self._field,
+                trajectories=True,
+                _generated=True,
+                **kwargs,
             )
 
             state["name"] = clips_dataset.name
@@ -8098,7 +8111,9 @@ class ToFrames(ViewStage):
         if state != last_state or not fod.dataset_exists(name):
             kwargs = self._config or {}
             frames_dataset = fovi.make_frames_dataset(
-                sample_collection, **kwargs
+                sample_collection,
+                _generated=True,
+                **kwargs,
             )
 
             # Other views may use the same generated dataset, so reuse the old

--- a/fiftyone/core/video.py
+++ b/fiftyone/core/video.py
@@ -484,6 +484,8 @@ def make_frames_dataset(
     skip_failures=True,
     verbose=False,
     name=None,
+    persistent=False,
+    _generated=False,
 ):
     """Creates a dataset that contains one sample per frame in the video
     collection.
@@ -556,11 +558,6 @@ def make_frames_dataset(
         True, existing frames will not be resampled unless you set
         ``force_sample`` to True.
 
-    .. note::
-
-        The returned dataset is independent from the source collection;
-        modifying it will not affect the source collection.
-
     Args:
         sample_collection: a
             :class:`fiftyone.core.collections.SampleCollection`
@@ -609,6 +606,8 @@ def make_frames_dataset(
         verbose (False): whether to log information about the frames that will
             be sampled, if any
         name (None): a name for the dataset
+        persistent (False): whether the dataset should persist in the database
+            after the session terminates
 
     Returns:
         a :class:`fiftyone.core.dataset.Dataset`
@@ -632,7 +631,7 @@ def make_frames_dataset(
     # Create dataset with proper schema
     #
 
-    dataset = fod.Dataset(name=name, _frames=True)
+    dataset = fod.Dataset(name=name, persistent=persistent, _frames=_generated)
     dataset.media_type = fom.IMAGE
     dataset.add_sample_field("sample_id", fof.ObjectIdField)
 


### PR DESCRIPTION
Resolves https://github.com/voxel51/fiftyone/issues/4397

The `make_{patches|frames|clips}_dataset()` methods were originally designed to be called internally by the `to_{patches|frames|clips}()` methods but not called directly. For example, as observed in https://github.com/voxel51/fiftyone/issues/4397, they currently return a dataset that behaves like a view in certain ways. Also, directly calling `make_clips_dataset()` is *especially* pernicious, as it currently returns a dataset that silently reuses the same frames collection as the input dataset.

However, there is a good use case for directly calling `make_{patches|frames|clips}_dataset()` to convert a collection into an independent dataset.

So, this PR maintains the behavior of `to_{patches|frames|clips}()` while tweaking the default behavior of the `make_{patches|frames|clips}_dataset()` methods so that they do return a completely normal dataset.

## Example usage

```py
import fiftyone as fo
import fiftyone.zoo as foz
import fiftyone.core.patches as fop
import fiftyone.core.clips as foc
import fiftyone.core.video as fov
from fiftyone import ViewField as F

#
# Patches dataset
#

dataset = foz.load_zoo_dataset("quickstart")

patches_view = dataset.to_patches("ground_truth")
patches_dataset = fop.make_patches_dataset(dataset, "ground_truth")

assert patches_view._is_generated == True
assert patches_dataset._is_generated == False
assert patches_dataset._sample_collection_name != dataset._sample_collection_name
assert patches_dataset._frame_collection_name is None
assert patches_dataset.count() == patches_view.count()
assert patches_dataset.count() == dataset.count("ground_truth.detections")

#
# Frames dataset
#

dataset = foz.load_zoo_dataset("quickstart-video")

frames_view = dataset.to_frames(sample_frames=True)
frames_dataset = fov.make_frames_dataset(dataset, sample_frames=True)

assert frames_view._is_generated == True
assert frames_dataset._is_generated == False
assert frames_dataset._sample_collection_name != dataset._sample_collection_name
assert frames_dataset._frame_collection_name is None
assert frames_dataset.count() == frames_view.count()
assert frames_dataset.count() == dataset.count("frames")

#
# Clips dataset
#

dataset = foz.load_zoo_dataset("quickstart-video")

expr = F("detections.detections").length() > 10
clips_view = dataset.to_clips(expr)
clips_dataset = foc.make_clips_dataset(dataset, expr)

assert clips_view._is_generated == True
assert clips_dataset._is_generated == False
assert clips_dataset._sample_collection_name != dataset._sample_collection_name
assert clips_dataset._frame_collection_name != dataset._frame_collection_name
assert clips_dataset.count() == clips_view.count()
assert clips_dataset.count("frames") == clips_view.count("frames")
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced dataset management with new parameters to control dataset persistence and generation behavior.

- **Bug Fixes**
  - Corrected comments related to frame and sample ID associations in clips datasets.

- **Tests**
  - Added new unit tests for patches, frames, and clips datasets to ensure proper creation and properties validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->