### PR TITLE
fix custom color disable condition

### DIFF
--- a/app/packages/core/src/components/ColorModal/ColorFooter.tsx
+++ b/app/packages/core/src/components/ColorModal/ColorFooter.tsx
@@ -9,7 +9,7 @@ import { activeColorEntry } from "./state";
 
 const ColorFooter: React.FC = () => {
   const canEditCustomColors = useRecoilValue(fos.canEditCustomColors);
-  const disabled = canEditCustomColors.enabled! == true;
+  const disabled = !canEditCustomColors.enabled;
   const title = disabled
     ? canEditCustomColors.message
     : "Save to dataset app config";


### PR DESCRIPTION
## What changes are proposed in this pull request?

(Please fill in changes proposed in this fix)

## How is this patch tested? If it is not, please explain why.

(Details)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Simplified the logic for determining the `disabled` state in the `ColorFooter` component of the Color Modal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->