### PR TITLE
fix dataset group slice is not being used on launch_app

### DIFF
--- a/fiftyone/core/session/session.py
+++ b/fiftyone/core/session/session.py
@@ -7,7 +7,6 @@ Session class for interacting with the FiftyOne App.
 """
 
 from collections import defaultdict
-from dataclasses import asdict
 from functools import wraps
 
 try:

--- a/fiftyone/core/session/session.py
+++ b/fiftyone/core/session/session.py
@@ -5,6 +5,7 @@ Session class for interacting with the FiftyOne App.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 from collections import defaultdict
 from dataclasses import asdict
 from functools import wraps
@@ -417,6 +418,7 @@ class Session(object):
             view_name=final_view_name,
             spaces=spaces,
             color_scheme=build_color_scheme(color_scheme, dataset, config),
+            group_slice=(dataset.group_slice if dataset else None),
         )
         self._client = fosc.Client(
             address=address,


### PR DESCRIPTION
## What changes are proposed in this pull request?

Fixes an issue where `dataset.group_slice` is not being used in the app on `launch_app`

## How is this patch tested? If it is not, please explain why.

Using snippet below in py shell and ensuring app is opened with `pcd` slice selected

```py
import fiftyone as fo
dataset = fo.load_dataset("quickstart-groups")
dataset.group_slice = "pcd"
session = fo.launch_app(dataset)
```

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

Fix launch_app not using `dataset.group_slice`

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
  - Enhanced session initialization to support group slicing when a dataset is present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->