### PR TITLE
Update `mask_path` argument description in `Segmentation` class of `fiftyone.core.labels`

### DIFF
--- a/fiftyone/core/labels.py
+++ b/fiftyone/core/labels.py
@@ -1012,7 +1012,7 @@ class Segmentation(_HasID, _HasMedia, Label):
     Args:
         mask (None): a numpy array with integer values encoding the semantic
             labels
-        mask_path (None): the path to the segmentation image on disk
+        mask_path (None): the absolute path to the segmentation image on disk
     """
 
     _MEDIA_FIELD = "mask_path"


### PR DESCRIPTION
## What changes are proposed in this pull request?

Updated the description of the `mask_path` argument in the `Segmentation` class of `fiftyone.core.labels` to specify that it requires an absolute path to the mask image on the disk.

## How is this patch tested? If it is not, please explain why.

(Details)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [x] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the `mask_path` parameter description in the `Segmentation` class to specify that it should be the absolute path to the segmentation image on disk.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->