### PR TITLE
Avoid slow session launch

### DIFF
--- a/fiftyone/core/session/session.py
+++ b/fiftyone/core/session/session.py
@@ -417,7 +417,7 @@ class Session(object):
             view_name=final_view_name,
             spaces=spaces,
             color_scheme=build_color_scheme(color_scheme, dataset, config),
-            group_slice=(dataset.group_slice if dataset else None),
+            group_slice=_pull_group_slice(dataset, view),
         )
         self._client = fosc.Client(
             address=address,
@@ -1317,3 +1317,15 @@ def _on_refresh(session: Session, state: t.Optional[StateDescription]):
 
     if session.dataset is not None:
         session.dataset.reload()
+
+
+def _pull_group_slice(
+    dataset: t.Optional[fod.Dataset], view: t.Optional[fov.DatasetView]
+) -> t.Union[None, str]:
+    if view is not None:
+        return view.group_slice
+
+    if dataset is not None:
+        return dataset.group_slice
+
+    return None


### PR DESCRIPTION
## What changes are proposed in this pull request?

Follow up to https://github.com/voxel51/fiftyone/pull/4423 to avoid `len(dataset)` calls which can be slow. Also adds `view` group slice handling

## How is this patch tested? If it is not, please explain why.

```py
import fiftyone as fo
dataset = fo.load_dataset("quickstart-groups")
dataset.group_slice = "pcd"
session = fo.launch_app(dataset)

# view
view = dataset.view()
view.group_slice = "right"
session = fo.launch_app(view)
```