### PR TITLE
store delegated operation IO in metadata

### DIFF
--- a/fiftyone/factory/repos/delegated_operation.py
+++ b/fiftyone/factory/repos/delegated_operation.py
@@ -5,6 +5,7 @@ FiftyOne delegated operation repository.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 import logging
 from datetime import datetime
 from typing import Any, List
@@ -43,6 +44,7 @@ class DelegatedOperationRepo(object):
         result: ExecutionResult = None,
         run_link: str = None,
         progress: ExecutionProgress = None,
+        outputs_schema: dict = None,
     ) -> DelegatedOperationDocument:
         """Update the run state of an operation."""
         raise NotImplementedError("subclass must implement update_run_state()")
@@ -163,6 +165,11 @@ class MongoDelegatedOperationRepo(DelegatedOperationRepo):
         if delegation_target:
             setattr(op, "delegation_target", delegation_target)
 
+        # also set the metadata (not required)
+        metadata = kwargs.get("metadata", None)
+        if metadata:
+            setattr(op, "metadata", metadata)
+
         context = None
         if isinstance(op.context, dict):
             context = ExecutionContext(
@@ -221,6 +228,7 @@ class MongoDelegatedOperationRepo(DelegatedOperationRepo):
         result: ExecutionResult = None,
         run_link: str = None,
         progress: ExecutionProgress = None,
+        outputs_schema: dict = None,
     ) -> DelegatedOperationDocument:
         update = None
 
@@ -234,20 +242,29 @@ class MongoDelegatedOperationRepo(DelegatedOperationRepo):
                     "run_state": run_state,
                     "completed_at": datetime.utcnow(),
                     "updated_at": datetime.utcnow(),
-                    "result": execution_result.to_json()
-                    if execution_result
-                    else None,
+                    "result": (
+                        execution_result.to_json()
+                        if execution_result
+                        else None
+                    ),
                 }
             }
+        if outputs_schema:
+            update["$set"]["metadata.outputs_schema"] = {
+                "$ifNull": [outputs_schema, {}]
+            }
+
         elif run_state == ExecutionRunState.FAILED:
             update = {
                 "$set": {
                     "run_state": run_state,
                     "failed_at": datetime.utcnow(),
                     "updated_at": datetime.utcnow(),
-                    "result": execution_result.to_json()
-                    if execution_result
-                    else None,
+                    "result": (
+                        execution_result.to_json()
+                        if execution_result
+                        else None
+                    ),
                 }
             }
         elif run_state == ExecutionRunState.RUNNING:
@@ -271,7 +288,7 @@ class MongoDelegatedOperationRepo(DelegatedOperationRepo):
 
         doc = self._collection.find_one_and_update(
             filter={"_id": _id},
-            update=update,
+            update=[update],
             return_document=pymongo.ReturnDocument.AFTER,
         )
 

--- a/fiftyone/factory/repos/delegated_operation_doc.py
+++ b/fiftyone/factory/repos/delegated_operation_doc.py
@@ -5,6 +5,7 @@ FiftyOne delegated operation repository document.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 import logging
 from datetime import datetime
 
@@ -48,6 +49,7 @@ class DelegatedOperationDocument(object):
         self.result = None
         self.id = None
         self._doc = None
+        self.metadata = None
 
     def from_pymongo(self, doc: dict):
         # required fields
@@ -101,6 +103,8 @@ class DelegatedOperationDocument(object):
         # internal fields
         self.id = doc["_id"]
         self._doc = doc
+
+        self.metadata = doc["metadata"] if "metadata" in doc else None
 
         return self
 

--- a/fiftyone/operators/delegated.py
+++ b/fiftyone/operators/delegated.py
@@ -5,6 +5,7 @@ FiftyOne delegated operations.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 import asyncio
 import logging
 import traceback
@@ -16,6 +17,7 @@ from fiftyone.operators.executor import (
     do_execute_operator,
     ExecutionResult,
     ExecutionRunState,
+    resolve_type_with_context,
 )
 
 
@@ -32,7 +34,12 @@ class DelegatedOperationService(object):
         self._repo = repo
 
     def queue_operation(
-        self, operator, label=None, delegation_target=None, context=None
+        self,
+        operator,
+        label=None,
+        delegation_target=None,
+        context=None,
+        metadata=None,
     ):
         """Queues the given delegated operation for execution.
 
@@ -43,6 +50,10 @@ class DelegatedOperationService(object):
                 the operator if not supplied)
             context (None): an
                 :class:`fiftyone.operators.executor.ExecutionContext`
+            metadata (None): an optional metadata dict containing properties below:
+                - inputs_schema: the schema of the operator's inputs
+                - outputs_schema: the schema of the operator's outputs
+
 
         Returns:
             a :class:`fiftyone.factory.repos.DelegatedOperationDocument`
@@ -52,6 +63,7 @@ class DelegatedOperationService(object):
             label=label if label else operator,
             delegation_target=delegation_target,
             context=context,
+            metadata=metadata,
         )
 
     def set_progress(self, doc_id, progress):
@@ -112,12 +124,27 @@ class DelegatedOperationService(object):
         Returns:
             a :class:`fiftyone.factory.repos.DelegatedOperationDocument`
         """
+
+        outputs_schema = None
+        try:
+            doc = self._repo.get(_id=doc_id)
+            outputs = asyncio.run(
+                resolve_type_with_context(doc.context, "outputs")
+            )
+            outputs_schema = outputs.to_json()
+        except:
+            logger.warning(
+                "Failed to resolve output schema for the operation."
+                + traceback.format_exc(),
+            )
+
         return self._repo.update_run_state(
             _id=doc_id,
             run_state=ExecutionRunState.COMPLETED,
             result=result,
             progress=progress,
             run_link=run_link,
+            outputs_schema=outputs_schema,
         )
 
     def set_failed(
@@ -382,5 +409,5 @@ class DelegatedOperationService(object):
         if isinstance(prepared, ExecutionResult):
             raise prepared.to_exception()
 
-        operator, _, ctx = prepared
+        operator, _, ctx, __ = prepared
         return await do_execute_operator(operator, ctx, exhaust=True)

--- a/fiftyone/operators/server.py
+++ b/fiftyone/operators/server.py
@@ -19,7 +19,6 @@ from .executor import (
     resolve_type,
     resolve_placement,
     resolve_execution_options,
-    ExecutionContext,
 )
 from .message import GeneratedMessage
 from .permissions import PermissionedOperatorRegistry


### PR DESCRIPTION
## What changes are proposed in this pull request?

Store delegated operation IO schema in metadata

## How is this patch tested? If it is not, please explain why.

Unit and manual testins

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced metadata handling in delegated operations, including input and output schemas.

- **Bug Fixes**
  - Improved accuracy in setting and extracting metadata during operation execution.

- **Tests**
  - Added new unit tests to validate metadata handling and schema extraction in delegated operations.

- **Refactor**
  - Streamlined code to include metadata parameters in various methods for better operation context management.

- **Chores**
  - Removed unused `ExecutionContext` import to clean up the codebase.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->