### PR TITLE
Fix background flicker during 3D navigation

### DIFF
--- a/app/packages/operators/src/hooks.ts
+++ b/app/packages/operators/src/hooks.ts
@@ -2,11 +2,7 @@ import { pluginsLoaderAtom } from "@fiftyone/plugins";
 import * as fos from "@fiftyone/state";
 import { debounce, isEqual } from "lodash";
 import { useEffect, useMemo, useRef, useState } from "react";
-import {
-  useRecoilValue,
-  useRecoilValueLoadable,
-  useSetRecoilState,
-} from "recoil";
+import { useRecoilValue, useSetRecoilState } from "recoil";
 import { RESOLVE_PLACEMENTS_TTL } from "./constants";
 import {
   ExecutionContext,
@@ -17,13 +13,8 @@ import {
   operatorPlacementsAtom,
   operatorThrottledContext,
   operatorsInitializedAtom,
+  useCurrentSample,
 } from "./state";
-
-function useCurrentSample() {
-  // 'currentSampleId' may suspend for group datasets, so we use a loadable
-  const currentSample = useRecoilValueLoadable(fos.currentSampleId);
-  return currentSample.state === "hasValue" ? currentSample.contents : null;
-}
 
 function useOperatorThrottledContextSetter() {
   const datasetName = useRecoilValue(fos.datasetName);


### PR DESCRIPTION
## What changes are proposed in this pull request?

Use `useCurrentSample` in `useOperatorExecutor` for avoid background loading

## How is this patch tested? If it is not, please explain why.

Locally

https://github.com/voxel51/fiftyone/assets/19821840/b7fd5547-e4a3-43b9-8eeb-9b311719a173

## Release Notes

* Fixed background flicker when navigating with 3D samples in the expanded view 

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved internal state management for better performance and maintainability.
  
- **New Features**
  - Enhanced state handling by introducing a new `useCurrentSample` function.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->