### PR TITLE
3D Scene I/O optimization and bugfixes

### DIFF
--- a/docs/source/teams/cloud_media.rst
+++ b/docs/source/teams/cloud_media.rst
@@ -391,6 +391,7 @@ _____________
     import fiftyone as fo
 
     fo.Dataset.download_media?
+    fo.Dataset.download_scenes?
     fo.Dataset.download_context?
     fo.Dataset.get_local_paths?
     fo.Dataset.cache_stats?
@@ -402,6 +403,7 @@ _____________
         self,
         media_fields=None,
         group_slices=None,
+        include_assets=True,
         update=False,
         skip_failures=True,
         progress=None,
@@ -420,7 +422,34 @@ _____________
             group_slices (None): an optional subset of group slices for which
                 to download media. Only applicable when the collection contains
                 groups
+            include_assets (True): whether to include 3D scene assets
             update (False): whether to re-download media whose checksums no
+                longer match
+            skip_failures (True): whether to gracefully continue without
+                raising an error if a remote file cannot be downloaded
+            progress (None): whether to render a progress bar tracking the
+                progress of any downloads (True/False), use the default value
+                ``fiftyone.config.show_progress_bars`` (None), or a progress
+                callback function to invoke instead
+        """
+
+.. code-block:: python
+
+    fo.Dataset.download_scenes(
+        self,
+        update=False,
+        skip_failures=True,
+        progress=None,
+    ):
+        """Downloads all ``.fo3d`` files for the samples in the collection.
+
+        This method is only useful for collections that contain remote media.
+
+        Any existing files are not re-downloaded, unless ``update == True`` and
+        their checksums no longer match.
+
+        Args:
+            update (False): whether to re-download files whose checksums no
                 longer match
             skip_failures (True): whether to gracefully continue without
                 raising an error if a remote file cannot be downloaded
@@ -438,6 +467,7 @@ _____________
         target_size_bytes=None,
         media_fields=None,
         group_slices=None,
+        include_assets=True,
         update=False,
         skip_failures=True,
         clear=False,
@@ -445,6 +475,12 @@ _____________
     ):
         """Returns a context that can be used to pre-download media in batches
         when iterating over samples in this collection.
+
+        This method is only useful for collections that contain remote media.
+
+        By default, all media will be downloaded when the context is entered,
+        but you can configure a batching strategy via the `batch_size` or
+        `target_size_bytes` parameters.
 
         If no ``batch_size`` or ``target_size_bytes`` is provided, media are
         downloaded in batches of ``fo.media_cache_config.download_size_bytes``.
@@ -459,6 +495,7 @@ _____________
                 :meth:`app_config` are used
             group_slices (None): an optional subset of group slices to download
                 media for. Only applicable when the collection contains groups
+            include_assets (True): whether to include 3D scene assets
             update (False): whether to re-download media whose checksums no
                 longer match
             skip_failures (True): whether to gracefully continue without
@@ -480,6 +517,7 @@ _____________
     fo.Dataset.get_local_paths(
         self,
         media_field="filepath",
+        include_assets=True,
         download=True,
         skip_failures=True,
         progress=None,
@@ -490,6 +528,7 @@ _____________
 
         Args:
             media_field ("filepath"): the field containing the media paths
+            include_assets (True): whether to include 3D scene assets
             download (True): whether to download any non-cached media files
             skip_failures (True): whether to gracefully continue without
                 raising an error if a remote file cannot be downloaded
@@ -504,7 +543,12 @@ _____________
 
 .. code-block:: python
 
-    fo.Dataset.cache_stats(self, media_fields=None, group_slices=None):
+    fo.Dataset.cache_stats(
+        self,
+        media_fields=None,
+        group_slices=None,
+        include_assets=True,
+    ):
         """Returns a dictionary of stats about the cached media files in this
         collection.
 
@@ -516,6 +560,7 @@ _____________
                 :meth:`app_config` are included
             group_slices (None): an optional subset of group slices to include.
                 Only applicable when the collection contains groups
+            include_assets (True): whether to include 3D scene assets
 
         Returns:
             a stats dict
@@ -523,7 +568,12 @@ _____________
 
 .. code-block:: python
 
-    fo.Dataset.clear_media(self, media_fields=None, group_slices=None):
+    fo.Dataset.clear_media(
+        self,
+        media_fields=None,
+        group_slices=None,
+        include_assets=True,
+    ):
         """Deletes any local copies of media files in this collection from the
         media cache.
 
@@ -536,6 +586,7 @@ _____________
             group_slices (None): an optional subset of group slices for which
                 to clear media. Only applicable when the collection contains
                 groups
+            include_assets (True): whether to include 3D scene assets
         """
 
 `fiftyone.core.storage`

--- a/fiftyone/core/metadata.py
+++ b/fiftyone/core/metadata.py
@@ -280,7 +280,7 @@ def _parse_assets(scene, scene_path, cache=None):
     scene_dir = os.path.dirname(scene_path)
     for i, asset_path in enumerate(asset_paths):
         if not fos.isabs(asset_path):
-            asset_path = fos.resolve(fos.join(scene_dir, asset_path))
+            asset_path = fos.abspath(fos.join(scene_dir, asset_path))
             asset_paths[i] = asset_path
 
         file_type = os.path.splitext(asset_path)[1][1:]

--- a/fiftyone/core/metadata.py
+++ b/fiftyone/core/metadata.py
@@ -5,23 +5,21 @@ Metadata stored in dataset samples.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
-import collections
-import json
+from collections import defaultdict
+import itertools
 import logging
 import multiprocessing.dummy
 import os
-import pathlib
 
 import requests
-
 from PIL import Image
 
 import eta.core.utils as etau
 import eta.core.video as etav
 
-from fiftyone.core.odm import DynamicEmbeddedDocument
 import fiftyone.core.fields as fof
 import fiftyone.core.media as fom
+from fiftyone.core.odm import DynamicEmbeddedDocument
 import fiftyone.core.storage as fos
 import fiftyone.core.threed as fo3d
 import fiftyone.core.utils as fou
@@ -76,71 +74,6 @@ class Metadata(DynamicEmbeddedDocument):
             size_bytes = int(r.headers["Content-Length"])
 
         return cls(size_bytes=size_bytes, mime_type=mime_type)
-
-
-class SceneMetadata(Metadata):
-    """Class for storing metadata about 3D scene samples.
-
-    Args:
-        size_bytes (None): the size of scene definition and all children
-            assets on disk, in bytes
-        mime_type (None): the MIME type of the scene media. Always set to
-            application/octet-stream
-        asset_counts (None): dict of child asset file type to count
-    """
-
-    asset_counts = fof.DictField
-
-    @classmethod
-    def build_for(cls, scene_path, mime_type=None):
-        """Builds a :class:`SceneMetadata` object for the given 3D Scene.
-
-        Args:
-            scene_path: a scene path or URL
-            mime_type (None): Ignored. mime_type always set to
-                application/octet-stream
-
-        Returns:
-            a :class:`SceneMetadata`
-        """
-        if not etau.is_str(scene_path):
-            raise ValueError("Invalid scene or path:", scene_path)
-
-        scene = fo3d.Scene.from_fo3d(scene_path)
-        scene_dict = scene.as_dict()
-        total_size = len(json.dumps(scene_dict))
-        asset_counts = collections.defaultdict(int)
-        mime_type = "application/octet-stream"
-
-        # Get asset paths and resolve all to absolute
-        asset_paths = scene.get_asset_paths()
-        scene_dir = os.path.dirname(scene_path)
-        for i, asset_path in enumerate(asset_paths):
-            if not fos.isabs(asset_path):
-                asset_path = fos.join(scene_dir, asset_path)
-            asset_paths[i] = fos.resolve(asset_path)
-            file_type = pathlib.Path(asset_path).suffix[1:]
-            asset_counts[file_type] += 1
-
-        # Dedupe asset paths within this single scene
-        asset_paths = list(set(asset_paths))
-
-        # compute metadata for all asset paths
-        asset_metadatas = fos.run(
-            _do_compute_metadata,
-            [
-                (i, asset_path, fom.MIXED)
-                for i, asset_path in enumerate(asset_paths)
-            ],
-            progress=False,
-        )
-        total_size += sum(m[1].size_bytes for m in asset_metadatas)
-
-        return cls(
-            size_bytes=total_size,
-            mime_type=mime_type,
-            asset_counts=asset_counts,
-        )
 
 
 class ImageMetadata(Metadata):
@@ -277,6 +210,100 @@ class VideoMetadata(Metadata):
             duration=stream_info.duration,
             encoding_str=stream_info.encoding_str,
         )
+
+
+class SceneMetadata(Metadata):
+    """Class for storing metadata about 3D scene samples.
+
+    Args:
+        size_bytes (None): the size of scene definition and all children
+            assets on disk, in bytes
+        mime_type (None): the MIME type of the scene
+        asset_counts (None): dict of child asset file type to count
+    """
+
+    asset_counts = fof.DictField()
+
+    @classmethod
+    def build_for(cls, scene_path, mime_type=None):
+        """Builds a :class:`SceneMetadata` object for the given 3D scene.
+
+        Args:
+            scene_path: a scene path
+            mime_type (None): the MIME type of the scene. If not provided,
+                defaults to ``application/octet-stream``
+
+        Returns:
+            a :class:`SceneMetadata`
+        """
+        return cls._build_for(scene_path, mime_type=mime_type)
+
+    @classmethod
+    def _build_for(cls, scene_path, mime_type=None, cache=None):
+        if mime_type is None:
+            mime_type = "application/octet-stream"
+
+        # Unclear how asset paths should be handled; the rest of the library is
+        # not equipped to handle URL asset paths
+        if scene_path.startswith("http"):
+            raise ValueError("Scene URLs are not currently supported")
+
+        total_size = os.path.getsize(scene_path)
+
+        scene = fo3d.Scene.from_fo3d(scene_path)
+        asset_paths = scene.get_asset_paths()
+
+        asset_counts = defaultdict(int)
+        scene_dir = os.path.dirname(scene_path)
+        for i, asset_path in enumerate(asset_paths):
+            if not fos.isabs(asset_path):
+                asset_path = fos.resolve(fos.join(scene_dir, asset_path))
+                asset_paths[i] = asset_path
+
+            file_type = os.path.splitext(asset_path)[1][1:]
+            asset_counts[file_type] += 1
+
+        asset_counts = dict(asset_counts)
+        total_size += _compute_asset_sizes(asset_paths, cache=cache)
+
+        return cls(
+            size_bytes=total_size,
+            mime_type=mime_type,
+            asset_counts=asset_counts,
+        )
+
+
+def _compute_asset_sizes(asset_paths, cache=None):
+    total_size = 0
+
+    tasks = []
+    for asset_path in asset_paths:
+        if cache is not None:
+            metadata = cache.get(asset_path, None)
+            if metadata is not None:
+                total_size += metadata.size_bytes
+                continue
+
+        tasks.append((None, asset_path, fom.MIXED, cache))
+
+    results = []
+    if len(tasks) <= 1:
+        for task in tasks:
+            results.append(_do_compute_metadata(task))
+    else:
+        num_workers = fou.recommend_thread_pool_workers(min(len(tasks), 8))
+        with multiprocessing.dummy.Pool(processes=num_workers) as pool:
+            results.extend(pool.imap(_do_compute_metadata, tasks))
+
+    for task, result in zip(tasks, results):
+        metadata = result[1]
+        total_size += metadata.size_bytes
+
+        if cache is not None:
+            scene_path = task[1]
+            cache[scene_path] = metadata
+
+    return total_size
 
 
 def compute_sample_metadata(sample, overwrite=False, skip_failures=False):
@@ -444,8 +471,9 @@ def _compute_metadata(
 
     logger.info("Computing metadata...")
 
-    inputs = zip(ids, filepaths, media_types)
+    cache = {}
     values = {}
+    inputs = zip(ids, filepaths, media_types, itertools.repeat(cache))
 
     try:
         with fou.ProgressBar(total=num_samples, progress=progress) as pb:
@@ -482,8 +510,9 @@ def _compute_metadata_multi(
 
     logger.info("Computing metadata...")
 
-    inputs = zip(ids, filepaths, media_types)
+    cache = {}
     values = {}
+    inputs = zip(ids, filepaths, media_types, itertools.repeat(cache))
 
     try:
         with multiprocessing.dummy.Pool(processes=num_workers) as pool:
@@ -502,30 +531,37 @@ def _compute_metadata_multi(
 
 
 def _do_compute_metadata(args):
-    sample_id, filepath, media_type = args
+    sample_id, filepath, media_type, cache = args
     metadata = _compute_sample_metadata(
-        filepath, media_type, skip_failures=True
+        filepath, media_type, skip_failures=True, cache=cache
     )
     return sample_id, metadata
 
 
-def _compute_sample_metadata(filepath, media_type, skip_failures=False):
+def _compute_sample_metadata(
+    filepath, media_type, skip_failures=False, cache=None
+):
     if not skip_failures:
-        return _get_metadata(filepath, media_type)
+        return _get_metadata(filepath, media_type, cache=cache)
 
     try:
-        return _get_metadata(filepath, media_type)
+        return _get_metadata(filepath, media_type, cache=cache)
     except:
         return None
 
 
-def _get_metadata(filepath, media_type):
+def _get_metadata(filepath, media_type, cache=None):
+    if cache is not None:
+        metadata = cache.get(filepath, None)
+        if metadata is not None:
+            return metadata
+
     if media_type == fom.IMAGE:
         metadata = ImageMetadata.build_for(filepath)
     elif media_type == fom.VIDEO:
         metadata = VideoMetadata.build_for(filepath)
     elif media_type == fom.THREE_D:
-        metadata = SceneMetadata.build_for(filepath)
+        metadata = SceneMetadata._build_for(filepath, cache=cache)
     else:
         metadata = Metadata.build_for(filepath)
 

--- a/fiftyone/core/metadata.py
+++ b/fiftyone/core/metadata.py
@@ -71,6 +71,7 @@ class Metadata(DynamicEmbeddedDocument):
             mime_type = etau.guess_mime_type(url)
 
         with requests.get(url, stream=True) as r:
+            r.raise_for_status()
             size_bytes = int(r.headers["Content-Length"])
 
         return cls(size_bytes=size_bytes, mime_type=mime_type)
@@ -135,6 +136,7 @@ class ImageMetadata(Metadata):
             mime_type = etau.guess_mime_type(url)
 
         with requests.get(url, stream=True) as r:
+            r.raise_for_status()
             size_bytes = int(r.headers["Content-Length"])
             width, height, num_channels = get_image_info(fou.ResponseStream(r))
 
@@ -225,7 +227,7 @@ class SceneMetadata(Metadata):
     asset_counts = fof.DictField()
 
     @classmethod
-    def build_for(cls, scene_path, mime_type=None):
+    def build_for(cls, scene_path, mime_type=None, _cache=None):
         """Builds a :class:`SceneMetadata` object for the given 3D scene.
 
         Args:
@@ -236,52 +238,62 @@ class SceneMetadata(Metadata):
         Returns:
             a :class:`SceneMetadata`
         """
-        return cls._build_for(scene_path, mime_type=mime_type)
+        if scene_path.startswith("http"):
+            return cls._build_for_url(
+                scene_path, mime_type=mime_type, cache=_cache
+            )
+
+        return cls._build_for_local(
+            scene_path, mime_type=mime_type, cache=_cache
+        )
 
     @classmethod
-    def _build_for(cls, scene_path, mime_type=None, cache=None):
+    def _build_for_local(cls, scene_path, mime_type=None, cache=None):
         if mime_type is None:
             mime_type = "application/octet-stream"
 
-        # Unclear how asset paths should be handled; the rest of the library is
-        # not equipped to handle URL asset paths
-        if scene_path.startswith("http"):
-            raise ValueError("Scene URLs are not currently supported")
-
-        total_size = os.path.getsize(scene_path)
-
+        scene_size = os.path.getsize(scene_path)
         scene = fo3d.Scene.from_fo3d(scene_path)
-        asset_paths = scene.get_asset_paths()
 
-        asset_counts = defaultdict(int)
-        scene_dir = os.path.dirname(scene_path)
-        for i, asset_path in enumerate(asset_paths):
-            if not fos.isabs(asset_path):
-                asset_path = fos.resolve(fos.join(scene_dir, asset_path))
-                asset_paths[i] = asset_path
-
-            file_type = os.path.splitext(asset_path)[1][1:]
-            asset_counts[file_type] += 1
-
-        asset_counts = dict(asset_counts)
-        total_size += _compute_asset_sizes(asset_paths, cache=cache)
+        asset_counts, asset_size = _parse_assets(
+            scene, scene_path, cache=cache
+        )
+        size_bytes = scene_size + asset_size
 
         return cls(
-            size_bytes=total_size,
+            size_bytes=size_bytes,
             mime_type=mime_type,
             asset_counts=asset_counts,
         )
 
+    @classmethod
+    def _build_for_url(cls, scene_path, mime_type=None, cache=None):
+        # Unclear how asset paths should be handled; the rest of the library is
+        # not equipped to handle URL asset paths
+        raise ValueError("Scene URLs are not currently supported")
 
-def _compute_asset_sizes(asset_paths, cache=None):
-    total_size = 0
+
+def _parse_assets(scene, scene_path, cache=None):
+    asset_paths = scene.get_asset_paths()
+
+    asset_counts = defaultdict(int)
+    scene_dir = os.path.dirname(scene_path)
+    for i, asset_path in enumerate(asset_paths):
+        if not fos.isabs(asset_path):
+            asset_path = fos.resolve(fos.join(scene_dir, asset_path))
+            asset_paths[i] = asset_path
+
+        file_type = os.path.splitext(asset_path)[1][1:]
+        asset_counts[file_type] += 1
+
+    asset_size = 0
 
     tasks = []
     for asset_path in asset_paths:
         if cache is not None:
             metadata = cache.get(asset_path, None)
             if metadata is not None:
-                total_size += metadata.size_bytes
+                asset_size += metadata.size_bytes
                 continue
 
         tasks.append((None, asset_path, fom.MIXED, cache))
@@ -297,13 +309,13 @@ def _compute_asset_sizes(asset_paths, cache=None):
 
     for task, result in zip(tasks, results):
         metadata = result[1]
-        total_size += metadata.size_bytes
+        asset_size += metadata.size_bytes
 
         if cache is not None:
             scene_path = task[1]
             cache[scene_path] = metadata
 
-    return total_size
+    return dict(asset_counts), asset_size
 
 
 def compute_sample_metadata(sample, overwrite=False, skip_failures=False):
@@ -561,7 +573,7 @@ def _get_metadata(filepath, media_type, cache=None):
     elif media_type == fom.VIDEO:
         metadata = VideoMetadata.build_for(filepath)
     elif media_type == fom.THREE_D:
-        metadata = SceneMetadata._build_for(filepath, cache=cache)
+        metadata = SceneMetadata.build_for(filepath, _cache=cache)
     else:
         metadata = Metadata.build_for(filepath)
 

--- a/fiftyone/core/storage.py
+++ b/fiftyone/core/storage.py
@@ -282,8 +282,8 @@ def join(a, *p):
 
 
 def resolve(path):
-    """Resolves path to absolute, resolving symlinks and relative path
-        indicators such as `.` and `..`.
+    """Resolves the given path to absolute, resolving symlinks and relative
+    path indicators such as ``.`` and ``..``.
 
     Args:
         path: the filepath

--- a/fiftyone/core/storage.py
+++ b/fiftyone/core/storage.py
@@ -281,8 +281,8 @@ def join(a, *p):
     return os.path.join(a, *p)
 
 
-def resolve(path):
-    """Resolves the given path to absolute, resolving symlinks and relative
+def realpath(path):
+    """Converts the given path to absolute, resolving symlinks and relative
     path indicators such as ``.`` and ``..``.
 
     Args:
@@ -297,8 +297,6 @@ def resolve(path):
 def isabs(path):
     """Determines whether the given path is absolute.
 
-    Remote paths are always considered absolute.
-
     Args:
         path: the filepath
 
@@ -309,9 +307,8 @@ def isabs(path):
 
 
 def abspath(path):
-    """Converts the given path to an absolute path.
-
-    Remote paths are returned unchanged.
+    """Converts the given path to an absolute path, resolving relative path
+    indicators such as ``.`` and ``..``.
 
     Args:
         path: the filepath

--- a/fiftyone/core/threed/object_3d.py
+++ b/fiftyone/core/threed/object_3d.py
@@ -26,7 +26,7 @@ from .utils import FO3D_VERSION_KEY
 threed = fou.lazy_import("fiftyone.core.threed")
 
 
-class Object3D:
+class Object3D(object):
     """The base class for all 3D objects in the scene.
 
     Args:
@@ -37,7 +37,7 @@ class Object3D:
         scale (None): the scale of the object in object space
     """
 
-    _asset_path_fields = None
+    _asset_path_fields = []
 
     def __init__(
         self,
@@ -227,7 +227,7 @@ class Object3D:
         """Get asset paths for this node"""
         return [
             getattr(self, f, None)
-            for f in (self._asset_path_fields or [])
+            for f in self._asset_path_fields
             if getattr(self, f, None) is not None
         ]
 

--- a/fiftyone/core/threed/scene_3d.py
+++ b/fiftyone/core/threed/scene_3d.py
@@ -342,9 +342,9 @@ class Scene(Object3D):
             return None
 
         if not fos.isabs(path):
-            path = fos.join(root, path)
+            path = fos.abspath(fos.join(root, path))
 
-        return fos.resolve(path)
+        return path
 
     def _to_dict_extra(self):
         return {

--- a/fiftyone/core/threed/scene_3d.py
+++ b/fiftyone/core/threed/scene_3d.py
@@ -276,7 +276,7 @@ class Scene(Object3D):
                 asset_path = getattr(node, path_attribute, None)
                 new_asset_path = asset_rewrite_paths.get(asset_path)
 
-                if asset_path is not None and asset_path != new_asset_path:
+                if new_asset_path is not None and asset_path != new_asset_path:
                     setattr(node, path_attribute, new_asset_path)
                     scene_modified = True
 
@@ -284,13 +284,16 @@ class Scene(Object3D):
         if self.background is not None:
             if self.background.image is not None:
                 new_asset_path = asset_rewrite_paths.get(self.background.image)
-                if new_asset_path != self.background.image:
+                if (
+                    new_asset_path is not None
+                    and new_asset_path != self.background.image
+                ):
                     self.background.image = new_asset_path
                     scene_modified = True
 
             if self.background.cube is not None:
                 new_cube = [
-                    asset_rewrite_paths.get(face)
+                    asset_rewrite_paths.get(face, face)
                     for face in self.background.cube
                 ]
                 if new_cube != self.background.cube:

--- a/fiftyone/core/threed/scene_3d.py
+++ b/fiftyone/core/threed/scene_3d.py
@@ -186,7 +186,7 @@ class Scene(Object3D):
         return Scene._from_fo3d_dict(self.as_dict())
 
     def _resolve_node_asset_paths(self, node, fo3d_path_dir):
-        for asset_path_field in node._asset_path_fields or []:
+        for asset_path_field in node._asset_path_fields:
             asset_path = getattr(node, asset_path_field, None)
             if asset_path:
                 resolved_asset_path = self._resolve_asset_path(

--- a/fiftyone/core/threed/scene_3d.py
+++ b/fiftyone/core/threed/scene_3d.py
@@ -323,19 +323,19 @@ class Scene(Object3D):
         Returns:
             a list of asset paths
         """
-        asset_paths = list(
+        asset_paths = set(
             itertools.chain.from_iterable(
                 node._get_asset_paths() for node in self.traverse()
             )
         )
 
-        # append paths in scene background, if any
         if self.background is not None:
             if self.background.image is not None:
-                asset_paths.append(self.background.image)
+                asset_paths.add(self.background.image)
             if self.background.cube is not None:
-                asset_paths.extend(self.background.cube)
-        return asset_paths
+                asset_paths.update(self.background.cube)
+
+        return list(asset_paths)
 
     def _resolve_asset_path(self, root: str, path: str):
         if path is None:

--- a/fiftyone/utils/data/exporters.py
+++ b/fiftyone/utils/data/exporters.py
@@ -1176,8 +1176,8 @@ class MediaExporter(object):
         input_to_output_paths = {}
         for asset_path in asset_paths:
             if not os.path.isabs(asset_path):
-                absolute_asset_path = os.path.join(
-                    os.path.dirname(fo3d_path), asset_path
+                absolute_asset_path = fos.abspath(
+                    os.path.join(os.path.dirname(fo3d_path), asset_path)
                 )
             else:
                 absolute_asset_path = asset_path
@@ -1187,6 +1187,7 @@ class MediaExporter(object):
             asset_output_path = self._filename_maker.get_output_path(
                 absolute_asset_path
             )
+            # By convention, we always write *relative* asset paths
             input_to_output_paths[asset_path] = os.path.relpath(
                 asset_output_path, os.path.dirname(fo3d_output_path)
             )

--- a/fiftyone/utils/data/exporters.py
+++ b/fiftyone/utils/data/exporters.py
@@ -1176,7 +1176,7 @@ class MediaExporter(object):
         input_to_output_paths = {}
         for asset_path in asset_paths:
             if not os.path.isabs(asset_path):
-                absolute_asset_path = fos.abspath(
+                absolute_asset_path = os.path.abspath(
                     os.path.join(os.path.dirname(fo3d_path), asset_path)
                 )
             else:

--- a/fiftyone/utils/data/exporters.py
+++ b/fiftyone/utils/data/exporters.py
@@ -238,13 +238,13 @@ def export_samples(
 
     sample_collection = samples
 
-    if isinstance(dataset_exporter, BatchDatasetExporter):
-        _write_batch_dataset(dataset_exporter, samples, progress=progress)
-        return
-
     if isinstance(
         dataset_exporter,
-        (GenericSampleDatasetExporter, GroupDatasetExporter),
+        (
+            BatchDatasetExporter,
+            GenericSampleDatasetExporter,
+            GroupDatasetExporter,
+        ),
     ):
         sample_parser = None
     elif isinstance(dataset_exporter, UnlabeledImageDatasetExporter):
@@ -406,7 +406,9 @@ def write_dataset(
     if sample_collection is None and isinstance(samples, foc.SampleCollection):
         sample_collection = samples
 
-    if isinstance(dataset_exporter, GenericSampleDatasetExporter):
+    if isinstance(dataset_exporter, BatchDatasetExporter):
+        _write_batch_dataset(dataset_exporter, samples, progress=progress)
+    elif isinstance(dataset_exporter, GenericSampleDatasetExporter):
         _write_generic_sample_dataset(
             dataset_exporter,
             samples,

--- a/fiftyone/utils/utils3d.py
+++ b/fiftyone/utils/utils3d.py
@@ -468,12 +468,10 @@ def _get_scene_asset_paths_single(task, abs_paths=False, skip_failures=True):
     asset_paths = scene.get_asset_paths()
 
     if abs_paths:
-        # Convert any relative-to-scene paths to absolute
         scene_dir = os.path.dirname(original_scene_path)
         for i, asset_path in enumerate(asset_paths):
             if not fos.isabs(asset_path):
-                asset_path = fos.join(scene_dir, asset_path)
-            asset_paths[i] = fos.resolve(asset_path)
+                asset_paths[i] = fos.resolve(fos.join(scene_dir, asset_path))
 
     return asset_paths
 

--- a/fiftyone/utils/utils3d.py
+++ b/fiftyone/utils/utils3d.py
@@ -452,7 +452,6 @@ def _get_scene_paths(scene_paths):
 def _get_scene_asset_paths_single(task, abs_paths=False, skip_failures=True):
     scene_path, original_scene_path = task
 
-    # Read scene file which is JSON
     try:
         scene = Scene.from_fo3d(scene_path)
     except Exception as e:
@@ -471,7 +470,7 @@ def _get_scene_asset_paths_single(task, abs_paths=False, skip_failures=True):
         scene_dir = os.path.dirname(original_scene_path)
         for i, asset_path in enumerate(asset_paths):
             if not fos.isabs(asset_path):
-                asset_paths[i] = fos.resolve(fos.join(scene_dir, asset_path))
+                asset_paths[i] = fos.abspath(fos.join(scene_dir, asset_path))
 
     return asset_paths
 
@@ -833,9 +832,9 @@ def _get_pcd_filepath_from_scene(scene_path: str):
         return None
 
     if not fos.isabs(pcd_path):
-        pcd_path = fos.join(os.path.dirname(scene_path), pcd_path)
+        pcd_path = fos.abspath(fos.join(os.path.dirname(scene_path), pcd_path))
 
-    return fos.resolve(pcd_path)
+    return pcd_path
 
 
 def _parse_point_cloud(

--- a/tests/unittests/metadata_tests.py
+++ b/tests/unittests/metadata_tests.py
@@ -30,11 +30,9 @@ class SceneMetadataTests(unittest.TestCase):
             scene.add(fo3d.ObjMesh("blah-obj", "obj.obj", "mtl.mtl"))
             scene.add(fo3d.StlMesh("blah-stl", "stl.stl"))
 
-            # Add same file again - should not add to size_bytes though,
-            #   even though this is abs and the other was relative
-            scene.add(
-                fo3d.ObjMesh("blah-obj2", os.path.join(temp_dir, "obj.obj"))
-            )
+            # Add same file again. This should not be counted in `size_bytes`
+            # or `asset_counts`
+            scene.add(fo3d.ObjMesh("blah-obj2", "obj.obj"))
 
             scene.write(scene_path)
 
@@ -42,12 +40,11 @@ class SceneMetadataTests(unittest.TestCase):
 
             self.assertEqual(metadata.mime_type, "application/octet-stream")
 
-            # Read the scene back again so we'll compare more accurately
-            expected_size = len(
-                json.dumps(fo3d.Scene.from_fo3d(scene_path).as_dict())
-            ) + sum(t[1] for t in files)
+            expected_size = os.path.getsize(scene_path)
+            expected_size += sum(t[1] for t in files)
+
             self.assertEqual(metadata.size_bytes, expected_size)
             self.assertDictEqual(
                 metadata.asset_counts,
-                {"obj": 2, "jpeg": 1, "stl": 1, "mtl": 1},
+                {"obj": 1, "jpeg": 1, "stl": 1, "mtl": 1},
             )

--- a/tests/unittests/threed/scene_3d_tests.py
+++ b/tests/unittests/threed/scene_3d_tests.py
@@ -116,12 +116,12 @@ class TestScene(unittest.TestCase):
                 resolve_relative_paths=True,
             )
             scene2 = threed.Scene.from_fo3d(path)
-            real_background = os.path.realpath(
+            real_background = os.path.abspath(
                 os.path.join(temp_dir, "../background.jpeg")
             )
             self.assertEqual(scene2.background.image, real_background)
             real_cubes = [
-                os.path.realpath(os.path.join(temp_dir, ci))
+                os.path.abspath(os.path.join(temp_dir, ci))
                 for ci in self.scene.background.cube
             ]
             self.assertListEqual(scene2.background.cube, real_cubes)
@@ -129,7 +129,7 @@ class TestScene(unittest.TestCase):
                 if node.name == "gltf2":
                     self.assertEqual(
                         node.gltf_path,
-                        os.path.realpath(
+                        os.path.abspath(
                             os.path.join(temp_dir, "relative.gltf")
                         ),
                     )

--- a/tests/unittests/threed/scene_3d_tests.py
+++ b/tests/unittests/threed/scene_3d_tests.py
@@ -71,6 +71,36 @@ class TestScene(unittest.TestCase):
             },
         )
 
+    def test_update_asset_paths(self):
+        d = {
+            "/path/to/pcd.pcd": "new.pcd",
+            "../background.jpeg": "new_background.jpeg",
+            "n3.jpeg": "new_n3.jpeg",
+        }
+
+        self.scene.update_asset_paths(d)
+
+        asset_paths = set(self.scene.get_asset_paths())
+        self.assertSetEqual(
+            asset_paths,
+            {
+                "/path/to/gltf.gltf",
+                "new.pcd",
+                "new_background.jpeg",
+                "/path/to/stl.stl",
+                "/path/to/fbx.fbx",
+                "/path/to/ply.ply",
+                "/path/to/obj.obj",
+                "relative.gltf",
+                "n1.jpeg",
+                "n2.jpeg",
+                "new_n3.jpeg",
+                "n4.jpeg",
+                "n5.jpeg",
+                "n6.jpeg",
+            },
+        )
+
     def test_write(self):
         with tempfile.TemporaryDirectory() as temp_dir:
             path = os.path.join(temp_dir, "blah.fo3d")

--- a/tests/unittests/utils3d_tests.py
+++ b/tests/unittests/utils3d_tests.py
@@ -375,16 +375,16 @@ class GetSceneAssetPaths(unittest.TestCase):
             self.assertSetEqual(
                 set(asset_paths[scene_paths[0]]),
                 {
-                    os.path.realpath(f"{temp_dir}/back/ground.jpeg"),
-                    os.path.realpath(f"{temp_dir}/relative.obj"),
-                    os.path.realpath(f"{temp_dir}/absolute.pcd"),
+                    f"{temp_dir}/back/ground.jpeg",
+                    f"{temp_dir}/relative.obj",
+                    f"{temp_dir}/absolute.pcd",
                 },
             )
             self.assertSetEqual(
                 set(asset_paths[scene_paths[1]]),
                 {
-                    os.path.realpath(f"{temp_dir}/back/ground.jpeg"),
-                    os.path.realpath(f"{temp_dir}/relative2.stl"),
+                    f"{temp_dir}/back/ground.jpeg",
+                    f"{temp_dir}/relative2.stl",
                 },
             )
 


### PR DESCRIPTION
## Change log

Optimizations
- Added a cache to `compute_metadata()` to avoid recomputing metadata for repeated 3D asset paths

Bugfixes
- Handle partial maps when updating Scene asset paths
    - Unit test added would previously fail but now succeeds as expected


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced `include_assets` parameter in various `fo.Dataset` methods to handle 3D scene assets.
  - Added `download_scenes` method to the `fo.Dataset` class.

- **Bug Fixes**
  - Enhanced asset path handling in `SceneMetadata` and `Scene` classes to ensure correct path resolution and scene modification.
  - Updated `Exporter` class to handle different export modes based on `self.export_mode`.

- **Tests**
  - Added `test_update_asset_paths` method to verify asset path updates in scenes.
  - Adjusted unit tests to align with new path handling logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->