### PR TITLE
Cherry picking PRs into v0.24.1

### DIFF
--- a/docs/source/teams/cloud_media.rst
+++ b/docs/source/teams/cloud_media.rst
@@ -391,6 +391,7 @@ _____________
     import fiftyone as fo
 
     fo.Dataset.download_media?
+    fo.Dataset.download_scenes?
     fo.Dataset.download_context?
     fo.Dataset.get_local_paths?
     fo.Dataset.cache_stats?
@@ -402,6 +403,7 @@ _____________
         self,
         media_fields=None,
         group_slices=None,
+        include_assets=True,
         update=False,
         skip_failures=True,
         progress=None,
@@ -420,7 +422,34 @@ _____________
             group_slices (None): an optional subset of group slices for which
                 to download media. Only applicable when the collection contains
                 groups
+            include_assets (True): whether to include 3D scene assets
             update (False): whether to re-download media whose checksums no
+                longer match
+            skip_failures (True): whether to gracefully continue without
+                raising an error if a remote file cannot be downloaded
+            progress (None): whether to render a progress bar tracking the
+                progress of any downloads (True/False), use the default value
+                ``fiftyone.config.show_progress_bars`` (None), or a progress
+                callback function to invoke instead
+        """
+
+.. code-block:: python
+
+    fo.Dataset.download_scenes(
+        self,
+        update=False,
+        skip_failures=True,
+        progress=None,
+    ):
+        """Downloads all ``.fo3d`` files for the samples in the collection.
+
+        This method is only useful for collections that contain remote media.
+
+        Any existing files are not re-downloaded, unless ``update == True`` and
+        their checksums no longer match.
+
+        Args:
+            update (False): whether to re-download files whose checksums no
                 longer match
             skip_failures (True): whether to gracefully continue without
                 raising an error if a remote file cannot be downloaded
@@ -438,6 +467,7 @@ _____________
         target_size_bytes=None,
         media_fields=None,
         group_slices=None,
+        include_assets=True,
         update=False,
         skip_failures=True,
         clear=False,
@@ -445,6 +475,12 @@ _____________
     ):
         """Returns a context that can be used to pre-download media in batches
         when iterating over samples in this collection.
+
+        This method is only useful for collections that contain remote media.
+
+        By default, all media will be downloaded when the context is entered,
+        but you can configure a batching strategy via the `batch_size` or
+        `target_size_bytes` parameters.
 
         If no ``batch_size`` or ``target_size_bytes`` is provided, media are
         downloaded in batches of ``fo.media_cache_config.download_size_bytes``.
@@ -459,6 +495,7 @@ _____________
                 :meth:`app_config` are used
             group_slices (None): an optional subset of group slices to download
                 media for. Only applicable when the collection contains groups
+            include_assets (True): whether to include 3D scene assets
             update (False): whether to re-download media whose checksums no
                 longer match
             skip_failures (True): whether to gracefully continue without
@@ -480,6 +517,7 @@ _____________
     fo.Dataset.get_local_paths(
         self,
         media_field="filepath",
+        include_assets=True,
         download=True,
         skip_failures=True,
         progress=None,
@@ -490,6 +528,7 @@ _____________
 
         Args:
             media_field ("filepath"): the field containing the media paths
+            include_assets (True): whether to include 3D scene assets
             download (True): whether to download any non-cached media files
             skip_failures (True): whether to gracefully continue without
                 raising an error if a remote file cannot be downloaded
@@ -504,7 +543,12 @@ _____________
 
 .. code-block:: python
 
-    fo.Dataset.cache_stats(self, media_fields=None, group_slices=None):
+    fo.Dataset.cache_stats(
+        self,
+        media_fields=None,
+        group_slices=None,
+        include_assets=True,
+    ):
         """Returns a dictionary of stats about the cached media files in this
         collection.
 
@@ -516,6 +560,7 @@ _____________
                 :meth:`app_config` are included
             group_slices (None): an optional subset of group slices to include.
                 Only applicable when the collection contains groups
+            include_assets (True): whether to include 3D scene assets
 
         Returns:
             a stats dict
@@ -523,7 +568,12 @@ _____________
 
 .. code-block:: python
 
-    fo.Dataset.clear_media(self, media_fields=None, group_slices=None):
+    fo.Dataset.clear_media(
+        self,
+        media_fields=None,
+        group_slices=None,
+        include_assets=True,
+    ):
         """Deletes any local copies of media files in this collection from the
         media cache.
 
@@ -536,6 +586,7 @@ _____________
             group_slices (None): an optional subset of group slices for which
                 to clear media. Only applicable when the collection contains
                 groups
+            include_assets (True): whether to include 3D scene assets
         """
 
 `fiftyone.core.storage`

--- a/docs/source/tutorials/anomaly_detection.ipynb
+++ b/docs/source/tutorials/anomaly_detection.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Anomaly Detection with FiftyOne and Anomalib"
+    "# Anomaly Detection with FiftyOne and Anomalib"
    ]
   },
   {

--- a/fiftyone/core/clips.py
+++ b/fiftyone/core/clips.py
@@ -586,6 +586,8 @@ def make_clips_dataset(
     min_len=0,
     trajectories=False,
     name=None,
+    persistent=False,
+    _generated=False,
 ):
     """Creates a dataset that contains one sample per clip defined by the
     given field or expression in the collection.
@@ -650,6 +652,8 @@ def make_clips_dataset(
             trajectory defined by their ``(label, index)``. Only applicable
             when ``field_or_expr`` is a frame-level field
         name (None): a name for the dataset
+        persistent (False): whether the dataset should persist in the database
+            after the session terminates
 
     Returns:
         a :class:`fiftyone.core.dataset.Dataset`
@@ -675,9 +679,22 @@ def make_clips_dataset(
     else:
         clips_type = "manual"
 
+    if _generated:
+        _name = name
+        _persistent = persistent
+    else:
+        # We first create a temporary dataset with samples representing the
+        # clips; then we clone it to pull in the corresponding frames
+        _name = None
+        _persistent = False
+
     dataset = fod.Dataset(
-        name=name, _clips=True, _src_collection=sample_collection
+        name=_name,
+        persistent=_persistent,
+        _clips=True,
+        _src_collection=sample_collection,
     )
+
     dataset.media_type = fom.VIDEO
     dataset.add_sample_field("sample_id", fof.ObjectIdField)
     dataset.add_sample_field("support", fof.FrameSupportField)
@@ -749,6 +766,13 @@ def make_clips_dataset(
             field_or_expr,
             other_fields=other_fields,
         )
+
+    if not _generated:
+        # Clone so that dataset no longer shares the same underlying frames
+        # collection as the input collection
+        _dataset = dataset
+        dataset = _dataset.clone(name=name, persistent=persistent)
+        _dataset.delete()
 
     return dataset
 

--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -7806,7 +7806,7 @@ def _get_frames_pipeline(sample_collection):
         view = None
 
     if dataset._is_clips:
-        # Clips datasets use `sample_id` to associated with frames, but now as
+        # Clips datasets use `sample_id` to associate with frames, but now as
         # a standalone collection, they must use `_id`
         coll = dataset._sample_collection
         pipeline = sample_collection._pipeline(attach_frames=True) + [

--- a/fiftyone/core/metadata.py
+++ b/fiftyone/core/metadata.py
@@ -280,7 +280,7 @@ def _parse_assets(scene, scene_path, cache=None):
     scene_dir = os.path.dirname(scene_path)
     for i, asset_path in enumerate(asset_paths):
         if not fos.isabs(asset_path):
-            asset_path = fos.resolve(fos.join(scene_dir, asset_path))
+            asset_path = fos.abspath(fos.join(scene_dir, asset_path))
             asset_paths[i] = asset_path
 
         file_type = os.path.splitext(asset_path)[1][1:]

--- a/fiftyone/core/metadata.py
+++ b/fiftyone/core/metadata.py
@@ -5,23 +5,21 @@ Metadata stored in dataset samples.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
-import collections
-import json
+from collections import defaultdict
+import itertools
 import logging
 import multiprocessing.dummy
 import os
-import pathlib
 
 import requests
-
 from PIL import Image
 
 import eta.core.utils as etau
 import eta.core.video as etav
 
-from fiftyone.core.odm import DynamicEmbeddedDocument
 import fiftyone.core.fields as fof
 import fiftyone.core.media as fom
+from fiftyone.core.odm import DynamicEmbeddedDocument
 import fiftyone.core.storage as fos
 import fiftyone.core.threed as fo3d
 import fiftyone.core.utils as fou
@@ -76,71 +74,6 @@ class Metadata(DynamicEmbeddedDocument):
             size_bytes = int(r.headers["Content-Length"])
 
         return cls(size_bytes=size_bytes, mime_type=mime_type)
-
-
-class SceneMetadata(Metadata):
-    """Class for storing metadata about 3D scene samples.
-
-    Args:
-        size_bytes (None): the size of scene definition and all children
-            assets on disk, in bytes
-        mime_type (None): the MIME type of the scene media. Always set to
-            application/octet-stream
-        asset_counts (None): dict of child asset file type to count
-    """
-
-    asset_counts = fof.DictField
-
-    @classmethod
-    def build_for(cls, scene_path, mime_type=None):
-        """Builds a :class:`SceneMetadata` object for the given 3D Scene.
-
-        Args:
-            scene_path: a scene path or URL
-            mime_type (None): Ignored. mime_type always set to
-                application/octet-stream
-
-        Returns:
-            a :class:`SceneMetadata`
-        """
-        if not etau.is_str(scene_path):
-            raise ValueError("Invalid scene or path:", scene_path)
-
-        scene = fo3d.Scene.from_fo3d(scene_path)
-        scene_dict = scene.as_dict()
-        total_size = len(json.dumps(scene_dict))
-        asset_counts = collections.defaultdict(int)
-        mime_type = "application/octet-stream"
-
-        # Get asset paths and resolve all to absolute
-        asset_paths = scene.get_asset_paths()
-        scene_dir = os.path.dirname(scene_path)
-        for i, asset_path in enumerate(asset_paths):
-            if not fos.isabs(asset_path):
-                asset_path = fos.join(scene_dir, asset_path)
-            asset_paths[i] = fos.resolve(asset_path)
-            file_type = pathlib.Path(asset_path).suffix[1:]
-            asset_counts[file_type] += 1
-
-        # Dedupe asset paths within this single scene
-        asset_paths = list(set(asset_paths))
-
-        # compute metadata for all asset paths
-        asset_metadatas = fos.run(
-            _do_compute_metadata,
-            [
-                (i, asset_path, fom.MIXED)
-                for i, asset_path in enumerate(asset_paths)
-            ],
-            progress=False,
-        )
-        total_size += sum(m[1].size_bytes for m in asset_metadatas)
-
-        return cls(
-            size_bytes=total_size,
-            mime_type=mime_type,
-            asset_counts=asset_counts,
-        )
 
 
 class ImageMetadata(Metadata):
@@ -277,6 +210,100 @@ class VideoMetadata(Metadata):
             duration=stream_info.duration,
             encoding_str=stream_info.encoding_str,
         )
+
+
+class SceneMetadata(Metadata):
+    """Class for storing metadata about 3D scene samples.
+
+    Args:
+        size_bytes (None): the size of scene definition and all children
+            assets on disk, in bytes
+        mime_type (None): the MIME type of the scene
+        asset_counts (None): dict of child asset file type to count
+    """
+
+    asset_counts = fof.DictField()
+
+    @classmethod
+    def build_for(cls, scene_path, mime_type=None):
+        """Builds a :class:`SceneMetadata` object for the given 3D scene.
+
+        Args:
+            scene_path: a scene path
+            mime_type (None): the MIME type of the scene. If not provided,
+                defaults to ``application/octet-stream``
+
+        Returns:
+            a :class:`SceneMetadata`
+        """
+        return cls._build_for(scene_path, mime_type=mime_type)
+
+    @classmethod
+    def _build_for(cls, scene_path, mime_type=None, cache=None):
+        if mime_type is None:
+            mime_type = "application/octet-stream"
+
+        # Unclear how asset paths should be handled; the rest of the library is
+        # not equipped to handle URL asset paths
+        if scene_path.startswith("http"):
+            raise ValueError("Scene URLs are not currently supported")
+
+        total_size = os.path.getsize(scene_path)
+
+        scene = fo3d.Scene.from_fo3d(scene_path)
+        asset_paths = scene.get_asset_paths()
+
+        asset_counts = defaultdict(int)
+        scene_dir = os.path.dirname(scene_path)
+        for i, asset_path in enumerate(asset_paths):
+            if not fos.isabs(asset_path):
+                asset_path = fos.resolve(fos.join(scene_dir, asset_path))
+                asset_paths[i] = asset_path
+
+            file_type = os.path.splitext(asset_path)[1][1:]
+            asset_counts[file_type] += 1
+
+        asset_counts = dict(asset_counts)
+        total_size += _compute_asset_sizes(asset_paths, cache=cache)
+
+        return cls(
+            size_bytes=total_size,
+            mime_type=mime_type,
+            asset_counts=asset_counts,
+        )
+
+
+def _compute_asset_sizes(asset_paths, cache=None):
+    total_size = 0
+
+    tasks = []
+    for asset_path in asset_paths:
+        if cache is not None:
+            metadata = cache.get(asset_path, None)
+            if metadata is not None:
+                total_size += metadata.size_bytes
+                continue
+
+        tasks.append((None, asset_path, fom.MIXED, cache))
+
+    results = []
+    if len(tasks) <= 1:
+        for task in tasks:
+            results.append(_do_compute_metadata(task))
+    else:
+        num_workers = fou.recommend_thread_pool_workers(min(len(tasks), 8))
+        with multiprocessing.dummy.Pool(processes=num_workers) as pool:
+            results.extend(pool.imap(_do_compute_metadata, tasks))
+
+    for task, result in zip(tasks, results):
+        metadata = result[1]
+        total_size += metadata.size_bytes
+
+        if cache is not None:
+            scene_path = task[1]
+            cache[scene_path] = metadata
+
+    return total_size
 
 
 def compute_sample_metadata(sample, overwrite=False, skip_failures=False):
@@ -444,8 +471,9 @@ def _compute_metadata(
 
     logger.info("Computing metadata...")
 
-    inputs = zip(ids, filepaths, media_types)
+    cache = {}
     values = {}
+    inputs = zip(ids, filepaths, media_types, itertools.repeat(cache))
 
     try:
         with fou.ProgressBar(total=num_samples, progress=progress) as pb:
@@ -482,8 +510,9 @@ def _compute_metadata_multi(
 
     logger.info("Computing metadata...")
 
-    inputs = zip(ids, filepaths, media_types)
+    cache = {}
     values = {}
+    inputs = zip(ids, filepaths, media_types, itertools.repeat(cache))
 
     try:
         with multiprocessing.dummy.Pool(processes=num_workers) as pool:
@@ -502,30 +531,37 @@ def _compute_metadata_multi(
 
 
 def _do_compute_metadata(args):
-    sample_id, filepath, media_type = args
+    sample_id, filepath, media_type, cache = args
     metadata = _compute_sample_metadata(
-        filepath, media_type, skip_failures=True
+        filepath, media_type, skip_failures=True, cache=cache
     )
     return sample_id, metadata
 
 
-def _compute_sample_metadata(filepath, media_type, skip_failures=False):
+def _compute_sample_metadata(
+    filepath, media_type, skip_failures=False, cache=None
+):
     if not skip_failures:
-        return _get_metadata(filepath, media_type)
+        return _get_metadata(filepath, media_type, cache=cache)
 
     try:
-        return _get_metadata(filepath, media_type)
+        return _get_metadata(filepath, media_type, cache=cache)
     except:
         return None
 
 
-def _get_metadata(filepath, media_type):
+def _get_metadata(filepath, media_type, cache=None):
+    if cache is not None:
+        metadata = cache.get(filepath, None)
+        if metadata is not None:
+            return metadata
+
     if media_type == fom.IMAGE:
         metadata = ImageMetadata.build_for(filepath)
     elif media_type == fom.VIDEO:
         metadata = VideoMetadata.build_for(filepath)
     elif media_type == fom.THREE_D:
-        metadata = SceneMetadata.build_for(filepath)
+        metadata = SceneMetadata._build_for(filepath, cache=cache)
     else:
         metadata = Metadata.build_for(filepath)
 

--- a/fiftyone/core/metadata.py
+++ b/fiftyone/core/metadata.py
@@ -71,6 +71,7 @@ class Metadata(DynamicEmbeddedDocument):
             mime_type = etau.guess_mime_type(url)
 
         with requests.get(url, stream=True) as r:
+            r.raise_for_status()
             size_bytes = int(r.headers["Content-Length"])
 
         return cls(size_bytes=size_bytes, mime_type=mime_type)
@@ -135,6 +136,7 @@ class ImageMetadata(Metadata):
             mime_type = etau.guess_mime_type(url)
 
         with requests.get(url, stream=True) as r:
+            r.raise_for_status()
             size_bytes = int(r.headers["Content-Length"])
             width, height, num_channels = get_image_info(fou.ResponseStream(r))
 
@@ -225,7 +227,7 @@ class SceneMetadata(Metadata):
     asset_counts = fof.DictField()
 
     @classmethod
-    def build_for(cls, scene_path, mime_type=None):
+    def build_for(cls, scene_path, mime_type=None, _cache=None):
         """Builds a :class:`SceneMetadata` object for the given 3D scene.
 
         Args:
@@ -236,52 +238,62 @@ class SceneMetadata(Metadata):
         Returns:
             a :class:`SceneMetadata`
         """
-        return cls._build_for(scene_path, mime_type=mime_type)
+        if scene_path.startswith("http"):
+            return cls._build_for_url(
+                scene_path, mime_type=mime_type, cache=_cache
+            )
+
+        return cls._build_for_local(
+            scene_path, mime_type=mime_type, cache=_cache
+        )
 
     @classmethod
-    def _build_for(cls, scene_path, mime_type=None, cache=None):
+    def _build_for_local(cls, scene_path, mime_type=None, cache=None):
         if mime_type is None:
             mime_type = "application/octet-stream"
 
-        # Unclear how asset paths should be handled; the rest of the library is
-        # not equipped to handle URL asset paths
-        if scene_path.startswith("http"):
-            raise ValueError("Scene URLs are not currently supported")
-
-        total_size = os.path.getsize(scene_path)
-
+        scene_size = os.path.getsize(scene_path)
         scene = fo3d.Scene.from_fo3d(scene_path)
-        asset_paths = scene.get_asset_paths()
 
-        asset_counts = defaultdict(int)
-        scene_dir = os.path.dirname(scene_path)
-        for i, asset_path in enumerate(asset_paths):
-            if not fos.isabs(asset_path):
-                asset_path = fos.resolve(fos.join(scene_dir, asset_path))
-                asset_paths[i] = asset_path
-
-            file_type = os.path.splitext(asset_path)[1][1:]
-            asset_counts[file_type] += 1
-
-        asset_counts = dict(asset_counts)
-        total_size += _compute_asset_sizes(asset_paths, cache=cache)
+        asset_counts, asset_size = _parse_assets(
+            scene, scene_path, cache=cache
+        )
+        size_bytes = scene_size + asset_size
 
         return cls(
-            size_bytes=total_size,
+            size_bytes=size_bytes,
             mime_type=mime_type,
             asset_counts=asset_counts,
         )
 
+    @classmethod
+    def _build_for_url(cls, scene_path, mime_type=None, cache=None):
+        # Unclear how asset paths should be handled; the rest of the library is
+        # not equipped to handle URL asset paths
+        raise ValueError("Scene URLs are not currently supported")
 
-def _compute_asset_sizes(asset_paths, cache=None):
-    total_size = 0
+
+def _parse_assets(scene, scene_path, cache=None):
+    asset_paths = scene.get_asset_paths()
+
+    asset_counts = defaultdict(int)
+    scene_dir = os.path.dirname(scene_path)
+    for i, asset_path in enumerate(asset_paths):
+        if not fos.isabs(asset_path):
+            asset_path = fos.resolve(fos.join(scene_dir, asset_path))
+            asset_paths[i] = asset_path
+
+        file_type = os.path.splitext(asset_path)[1][1:]
+        asset_counts[file_type] += 1
+
+    asset_size = 0
 
     tasks = []
     for asset_path in asset_paths:
         if cache is not None:
             metadata = cache.get(asset_path, None)
             if metadata is not None:
-                total_size += metadata.size_bytes
+                asset_size += metadata.size_bytes
                 continue
 
         tasks.append((None, asset_path, fom.MIXED, cache))
@@ -297,13 +309,13 @@ def _compute_asset_sizes(asset_paths, cache=None):
 
     for task, result in zip(tasks, results):
         metadata = result[1]
-        total_size += metadata.size_bytes
+        asset_size += metadata.size_bytes
 
         if cache is not None:
             scene_path = task[1]
             cache[scene_path] = metadata
 
-    return total_size
+    return dict(asset_counts), asset_size
 
 
 def compute_sample_metadata(sample, overwrite=False, skip_failures=False):
@@ -561,7 +573,7 @@ def _get_metadata(filepath, media_type, cache=None):
     elif media_type == fom.VIDEO:
         metadata = VideoMetadata.build_for(filepath)
     elif media_type == fom.THREE_D:
-        metadata = SceneMetadata._build_for(filepath, cache=cache)
+        metadata = SceneMetadata.build_for(filepath, _cache=cache)
     else:
         metadata = Metadata.build_for(filepath)
 

--- a/fiftyone/core/patches.py
+++ b/fiftyone/core/patches.py
@@ -558,6 +558,8 @@ def make_patches_dataset(
     other_fields=None,
     keep_label_lists=False,
     name=None,
+    persistent=False,
+    _generated=False,
 ):
     """Creates a dataset that contains one sample per object patch in the
     specified field of the collection.
@@ -586,6 +588,8 @@ def make_patches_dataset(
             fields of the same type as the input collection rather than using
             their single label variants
         name (None): a name for the dataset
+        persistent (False): whether the dataset should persist in the database
+            after the session terminates
 
     Returns:
         a :class:`fiftyone.core.dataset.Dataset`
@@ -606,7 +610,12 @@ def make_patches_dataset(
         sample_collection, field, keep_label_lists
     )
 
-    dataset = fod.Dataset(name=name, _patches=True, _frames=is_frame_patches)
+    dataset = fod.Dataset(
+        name=name,
+        persistent=persistent,
+        _patches=_generated,
+        _frames=is_frame_patches and _generated,
+    )
     dataset.media_type = fom.IMAGE
     dataset.add_sample_field("sample_id", fof.ObjectIdField)
     dataset.create_index("sample_id")
@@ -671,7 +680,12 @@ def _get_patches_field(sample_collection, field_name, keep_label_lists):
 
 
 def make_evaluation_patches_dataset(
-    sample_collection, eval_key, other_fields=None, name=None
+    sample_collection,
+    eval_key,
+    other_fields=None,
+    name=None,
+    persistent=False,
+    _generated=False,
 ):
     """Creates a dataset based on the results of the evaluation with the given
     key that contains one sample for each true positive, false positive, and
@@ -720,6 +734,8 @@ def make_evaluation_patches_dataset(
             -   ``True`` to include all other fields
             -   ``None``/``False`` to include no other fields
         name (None): a name for the dataset
+        persistent (False): whether the dataset should persist in the database
+            after the session terminates
 
     Returns:
         a :class:`fiftyone.core.dataset.Dataset`
@@ -757,7 +773,12 @@ def make_evaluation_patches_dataset(
     _pred_field = sample_collection.get_field(pred_field)
 
     # Setup dataset with correct schema
-    dataset = fod.Dataset(name=name, _patches=True, _frames=is_frame_patches)
+    dataset = fod.Dataset(
+        name=name,
+        persistent=persistent,
+        _patches=_generated,
+        _frames=is_frame_patches and _generated,
+    )
     dataset.media_type = fom.IMAGE
     dataset.add_sample_field("sample_id", fof.ObjectIdField)
     dataset.create_index("sample_id")

--- a/fiftyone/core/stages.py
+++ b/fiftyone/core/stages.py
@@ -7479,7 +7479,10 @@ class ToPatches(ViewStage):
         if state != last_state or not fod.dataset_exists(name):
             kwargs = self._config or {}
             patches_dataset = fop.make_patches_dataset(
-                sample_collection, self._field, **kwargs
+                sample_collection,
+                self._field,
+                _generated=True,
+                **kwargs,
             )
 
             # Other views may use the same generated dataset, so reuse the old
@@ -7623,7 +7626,10 @@ class ToEvaluationPatches(ViewStage):
         if state != last_state or not fod.dataset_exists(name):
             kwargs = self._config or {}
             eval_patches_dataset = fop.make_evaluation_patches_dataset(
-                sample_collection, self._eval_key, **kwargs
+                sample_collection,
+                self._eval_key,
+                _generated=True,
+                **kwargs,
             )
 
             # Other views may use the same generated dataset, so reuse the old
@@ -7780,7 +7786,10 @@ class ToClips(ViewStage):
         if state != last_state or not fod.dataset_exists(name):
             kwargs = self._config or {}
             clips_dataset = focl.make_clips_dataset(
-                sample_collection, self._field_or_expr, **kwargs
+                sample_collection,
+                self._field_or_expr,
+                _generated=True,
+                **kwargs,
             )
 
             # Other views may use the same generated dataset, so reuse the old
@@ -7914,7 +7923,11 @@ class ToTrajectories(ViewStage):
         if state != last_state or not fod.dataset_exists(name):
             kwargs = self._config or {}
             clips_dataset = focl.make_clips_dataset(
-                sample_collection, self._field, trajectories=True, **kwargs
+                sample_collection,
+                self._field,
+                trajectories=True,
+                _generated=True,
+                **kwargs,
             )
 
             state["name"] = clips_dataset.name
@@ -8098,7 +8111,9 @@ class ToFrames(ViewStage):
         if state != last_state or not fod.dataset_exists(name):
             kwargs = self._config or {}
             frames_dataset = fovi.make_frames_dataset(
-                sample_collection, **kwargs
+                sample_collection,
+                _generated=True,
+                **kwargs,
             )
 
             # Other views may use the same generated dataset, so reuse the old

--- a/fiftyone/core/storage.py
+++ b/fiftyone/core/storage.py
@@ -282,8 +282,8 @@ def join(a, *p):
 
 
 def resolve(path):
-    """Resolves path to absolute, resolving symlinks and relative path
-        indicators such as `.` and `..`.
+    """Resolves the given path to absolute, resolving symlinks and relative
+    path indicators such as ``.`` and ``..``.
 
     Args:
         path: the filepath

--- a/fiftyone/core/storage.py
+++ b/fiftyone/core/storage.py
@@ -281,8 +281,8 @@ def join(a, *p):
     return os.path.join(a, *p)
 
 
-def resolve(path):
-    """Resolves the given path to absolute, resolving symlinks and relative
+def realpath(path):
+    """Converts the given path to absolute, resolving symlinks and relative
     path indicators such as ``.`` and ``..``.
 
     Args:
@@ -297,8 +297,6 @@ def resolve(path):
 def isabs(path):
     """Determines whether the given path is absolute.
 
-    Remote paths are always considered absolute.
-
     Args:
         path: the filepath
 
@@ -309,9 +307,8 @@ def isabs(path):
 
 
 def abspath(path):
-    """Converts the given path to an absolute path.
-
-    Remote paths are returned unchanged.
+    """Converts the given path to an absolute path, resolving relative path
+    indicators such as ``.`` and ``..``.
 
     Args:
         path: the filepath

--- a/fiftyone/core/threed/object_3d.py
+++ b/fiftyone/core/threed/object_3d.py
@@ -26,7 +26,7 @@ from .utils import FO3D_VERSION_KEY
 threed = fou.lazy_import("fiftyone.core.threed")
 
 
-class Object3D:
+class Object3D(object):
     """The base class for all 3D objects in the scene.
 
     Args:
@@ -37,7 +37,7 @@ class Object3D:
         scale (None): the scale of the object in object space
     """
 
-    _asset_path_fields = None
+    _asset_path_fields = []
 
     def __init__(
         self,
@@ -227,7 +227,7 @@ class Object3D:
         """Get asset paths for this node"""
         return [
             getattr(self, f, None)
-            for f in (self._asset_path_fields or [])
+            for f in self._asset_path_fields
             if getattr(self, f, None) is not None
         ]
 

--- a/fiftyone/core/threed/scene_3d.py
+++ b/fiftyone/core/threed/scene_3d.py
@@ -342,9 +342,9 @@ class Scene(Object3D):
             return None
 
         if not fos.isabs(path):
-            path = fos.join(root, path)
+            path = fos.abspath(fos.join(root, path))
 
-        return fos.resolve(path)
+        return path
 
     def _to_dict_extra(self):
         return {

--- a/fiftyone/core/threed/scene_3d.py
+++ b/fiftyone/core/threed/scene_3d.py
@@ -276,7 +276,7 @@ class Scene(Object3D):
                 asset_path = getattr(node, path_attribute, None)
                 new_asset_path = asset_rewrite_paths.get(asset_path)
 
-                if asset_path is not None and asset_path != new_asset_path:
+                if new_asset_path is not None and asset_path != new_asset_path:
                     setattr(node, path_attribute, new_asset_path)
                     scene_modified = True
 
@@ -284,13 +284,16 @@ class Scene(Object3D):
         if self.background is not None:
             if self.background.image is not None:
                 new_asset_path = asset_rewrite_paths.get(self.background.image)
-                if new_asset_path != self.background.image:
+                if (
+                    new_asset_path is not None
+                    and new_asset_path != self.background.image
+                ):
                     self.background.image = new_asset_path
                     scene_modified = True
 
             if self.background.cube is not None:
                 new_cube = [
-                    asset_rewrite_paths.get(face)
+                    asset_rewrite_paths.get(face, face)
                     for face in self.background.cube
                 ]
                 if new_cube != self.background.cube:

--- a/fiftyone/core/threed/scene_3d.py
+++ b/fiftyone/core/threed/scene_3d.py
@@ -186,7 +186,7 @@ class Scene(Object3D):
         return Scene._from_fo3d_dict(self.as_dict())
 
     def _resolve_node_asset_paths(self, node, fo3d_path_dir):
-        for asset_path_field in node._asset_path_fields or []:
+        for asset_path_field in node._asset_path_fields:
             asset_path = getattr(node, asset_path_field, None)
             if asset_path:
                 resolved_asset_path = self._resolve_asset_path(

--- a/fiftyone/core/threed/scene_3d.py
+++ b/fiftyone/core/threed/scene_3d.py
@@ -323,19 +323,19 @@ class Scene(Object3D):
         Returns:
             a list of asset paths
         """
-        asset_paths = list(
+        asset_paths = set(
             itertools.chain.from_iterable(
                 node._get_asset_paths() for node in self.traverse()
             )
         )
 
-        # append paths in scene background, if any
         if self.background is not None:
             if self.background.image is not None:
-                asset_paths.append(self.background.image)
+                asset_paths.add(self.background.image)
             if self.background.cube is not None:
-                asset_paths.extend(self.background.cube)
-        return asset_paths
+                asset_paths.update(self.background.cube)
+
+        return list(asset_paths)
 
     def _resolve_asset_path(self, root: str, path: str):
         if path is None:

--- a/fiftyone/core/video.py
+++ b/fiftyone/core/video.py
@@ -484,6 +484,8 @@ def make_frames_dataset(
     skip_failures=True,
     verbose=False,
     name=None,
+    persistent=False,
+    _generated=False,
 ):
     """Creates a dataset that contains one sample per frame in the video
     collection.
@@ -556,11 +558,6 @@ def make_frames_dataset(
         True, existing frames will not be resampled unless you set
         ``force_sample`` to True.
 
-    .. note::
-
-        The returned dataset is independent from the source collection;
-        modifying it will not affect the source collection.
-
     Args:
         sample_collection: a
             :class:`fiftyone.core.collections.SampleCollection`
@@ -609,6 +606,8 @@ def make_frames_dataset(
         verbose (False): whether to log information about the frames that will
             be sampled, if any
         name (None): a name for the dataset
+        persistent (False): whether the dataset should persist in the database
+            after the session terminates
 
     Returns:
         a :class:`fiftyone.core.dataset.Dataset`
@@ -632,7 +631,7 @@ def make_frames_dataset(
     # Create dataset with proper schema
     #
 
-    dataset = fod.Dataset(name=name, _frames=True)
+    dataset = fod.Dataset(name=name, persistent=persistent, _frames=_generated)
     dataset.media_type = fom.IMAGE
     dataset.add_sample_field("sample_id", fof.ObjectIdField)
 

--- a/fiftyone/utils/cvat.py
+++ b/fiftyone/utils/cvat.py
@@ -3671,6 +3671,9 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
         else:
             return "%s/%d" % (self.jobs_url(task_id), job_id)
 
+    def job_annotation_url(self, job_id):
+        return "%s/annotations" % self.taskless_job_url(job_id)
+
     def taskless_job_url(self, job_id):
         return "%s/jobs/%d" % (self.base_api_url, job_id)
 
@@ -4263,16 +4266,7 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
         # It can take a bit for jobs to show up, so we poll
         job_ids = []
         while not job_ids:
-            url = self.jobs_url(task_id)
-            if self._server_version >= Version("2.4"):
-                job_resp_json = self._get_paginated_results(url)
-            else:
-                job_resp = self.get(url)
-                job_resp_json = job_resp.json()
-                if "results" in job_resp_json:
-                    job_resp_json = job_resp_json["results"]
-
-            job_ids = [j["id"] for j in job_resp_json]
+            job_ids = self._get_job_ids(task_id)
             if not job_ids:
                 time.sleep(1)
 
@@ -4641,119 +4635,73 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
                 attr_id_map, _class_map_rev = self._get_attr_class_maps(
                     task_id
                 )
-                task_resp = self.get(self.task_annotation_url(task_id)).json()
-                all_shapes = task_resp["shapes"]
-                all_tags = task_resp["tags"]
-                all_tracks = task_resp["tracks"]
 
-                # For videos that were subsampled, remap the frame numbers to
-                # those on the original video
-                all_shapes = _remap_annotation_frames(
-                    all_shapes, frame_start, frame_stop, frame_step
-                )
-                all_tags = _remap_annotation_frames(
-                    all_tags, frame_start, frame_stop, frame_step
-                )
-                all_tracks = _remap_annotation_frames(
-                    all_tracks, frame_start, frame_stop, frame_step
-                )
+                job_ids = self._get_job_ids(task_id)
+                for job_id in job_ids:
+                    job_resp = self.get(self.job_annotation_url(job_id)).json()
+                    all_shapes = job_resp["shapes"]
+                    all_tags = job_resp["tags"]
+                    all_tracks = job_resp["tracks"]
 
-                label_fields = labels_task_map_rev[task_id]
-                label_types = self._get_return_label_types(
-                    label_schema, label_fields
-                )
-
-                for lf_ind, label_field in enumerate(label_fields):
-                    label_info = label_schema[label_field]
-                    label_type = label_info.get("type", None)
-                    scalar_attrs = assigned_scalar_attrs.get(
-                        label_field, False
+                    # For videos that were subsampled, remap the frame numbers to
+                    # those on the original video
+                    all_shapes = _remap_annotation_frames(
+                        all_shapes, frame_start, frame_stop, frame_step
                     )
-                    _occluded_attrs = occluded_attrs.get(label_field, {})
-                    _group_id_attrs = group_id_attrs.get(label_field, {})
-                    _id_map = id_map.get(label_field, {})
-
-                    label_field_results = {}
-
-                    # Dict mapping class labels to the classes used in CVAT.
-                    # These are equal unless a class appears in multiple fields
-                    _classes = label_field_classes[label_field]
-
-                    # Maps CVAT IDs to FiftyOne labels
-                    class_map = {
-                        _class_map_rev[name_lf]: name
-                        for name, name_lf in _classes.items()
-                    }
-
-                    _cvat_classes = class_map.keys()
-                    tags, shapes, tracks = self._filter_field_classes(
-                        all_tags,
-                        all_shapes,
-                        all_tracks,
-                        _cvat_classes,
+                    all_tags = _remap_annotation_frames(
+                        all_tags, frame_start, frame_stop, frame_step
+                    )
+                    all_tracks = _remap_annotation_frames(
+                        all_tracks, frame_start, frame_stop, frame_step
                     )
 
-                    is_last_field = lf_ind == len(label_fields) - 1
-                    ignore_types = self._get_ignored_types(
-                        project_id, label_types, label_type, is_last_field
+                    label_fields = labels_task_map_rev[task_id]
+                    label_types = self._get_return_label_types(
+                        label_schema, label_fields
                     )
 
-                    tag_results = self._parse_shapes_tags(
-                        "tags",
-                        tags,
-                        frame_id_map[task_id],
-                        label_type,
-                        _id_map,
-                        server_id_map.get("tags", {}),
-                        class_map,
-                        attr_id_map,
-                        frames,
-                        ignore_types,
-                        frame_stop,
-                        frame_step,
-                        assigned_scalar_attrs=scalar_attrs,
-                    )
-                    label_field_results = self._merge_results(
-                        label_field_results, tag_results
-                    )
+                    for lf_ind, label_field in enumerate(label_fields):
+                        label_info = label_schema[label_field]
+                        label_type = label_info.get("type", None)
+                        scalar_attrs = assigned_scalar_attrs.get(
+                            label_field, False
+                        )
+                        _occluded_attrs = occluded_attrs.get(label_field, {})
+                        _group_id_attrs = group_id_attrs.get(label_field, {})
+                        _id_map = id_map.get(label_field, {})
 
-                    shape_results = self._parse_shapes_tags(
-                        "shapes",
-                        shapes,
-                        frame_id_map[task_id],
-                        label_type,
-                        _id_map,
-                        server_id_map.get("shapes", {}),
-                        class_map,
-                        attr_id_map,
-                        frames,
-                        ignore_types,
-                        frame_stop,
-                        frame_step,
-                        assigned_scalar_attrs=scalar_attrs,
-                        occluded_attrs=_occluded_attrs,
-                        group_id_attrs=_group_id_attrs,
-                    )
-                    label_field_results = self._merge_results(
-                        label_field_results, shape_results
-                    )
+                        label_field_results = {}
 
-                    for track_index, track in enumerate(tracks, 1):
-                        label_id = track["label_id"]
-                        shapes = track["shapes"]
-                        track_group_id = track.get("group", None)
-                        for shape in shapes:
-                            shape["label_id"] = label_id
+                        # Dict mapping class labels to the classes used in CVAT.
+                        # These are equal unless a class appears in multiple fields
+                        _classes = label_field_classes[label_field]
 
-                        immutable_attrs = track["attributes"]
+                        # Maps CVAT IDs to FiftyOne labels
+                        class_map = {
+                            _class_map_rev[name_lf]: name
+                            for name, name_lf in _classes.items()
+                        }
 
-                        track_shape_results = self._parse_shapes_tags(
-                            "track",
-                            shapes,
+                        _cvat_classes = class_map.keys()
+                        tags, shapes, tracks = self._filter_field_classes(
+                            all_tags,
+                            all_shapes,
+                            all_tracks,
+                            _cvat_classes,
+                        )
+
+                        is_last_field = lf_ind == len(label_fields) - 1
+                        ignore_types = self._get_ignored_types(
+                            project_id, label_types, label_type, is_last_field
+                        )
+
+                        tag_results = self._parse_shapes_tags(
+                            "tags",
+                            tags,
                             frame_id_map[task_id],
                             label_type,
                             _id_map,
-                            server_id_map.get("tracks", {}),
+                            server_id_map.get("tags", {}),
                             class_map,
                             attr_id_map,
                             frames,
@@ -4761,41 +4709,90 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
                             frame_stop,
                             frame_step,
                             assigned_scalar_attrs=scalar_attrs,
-                            track_index=track_index,
-                            track_group_id=track_group_id,
-                            immutable_attrs=immutable_attrs,
+                        )
+                        label_field_results = self._merge_results(
+                            label_field_results, tag_results
+                        )
+
+                        shape_results = self._parse_shapes_tags(
+                            "shapes",
+                            shapes,
+                            frame_id_map[task_id],
+                            label_type,
+                            _id_map,
+                            server_id_map.get("shapes", {}),
+                            class_map,
+                            attr_id_map,
+                            frames,
+                            ignore_types,
+                            frame_stop,
+                            frame_step,
+                            assigned_scalar_attrs=scalar_attrs,
                             occluded_attrs=_occluded_attrs,
                             group_id_attrs=_group_id_attrs,
                         )
                         label_field_results = self._merge_results(
-                            label_field_results, track_shape_results
+                            label_field_results, shape_results
                         )
 
-                    frames_metadata = {}
-                    for cvat_frame_id, frame_data in frame_id_map[
-                        task_id
-                    ].items():
-                        sample_id = frame_data["sample_id"]
-                        if "frame_id" in frame_data and len(frames) == 1:
-                            frames_metadata[sample_id] = frames[0]
-                            break
+                        for track_index, track in enumerate(tracks, 1):
+                            label_id = track["label_id"]
+                            shapes = track["shapes"]
+                            track_group_id = track.get("group", None)
+                            for shape in shapes:
+                                shape["label_id"] = label_id
 
-                        if len(frames) > cvat_frame_id:
-                            frame_metadata = frames[cvat_frame_id]
-                        else:
-                            frame_metadata = None
+                            immutable_attrs = track["attributes"]
 
-                        frames_metadata[sample_id] = frame_metadata
+                            track_shape_results = self._parse_shapes_tags(
+                                "track",
+                                shapes,
+                                frame_id_map[task_id],
+                                label_type,
+                                _id_map,
+                                server_id_map.get("tracks", {}),
+                                class_map,
+                                attr_id_map,
+                                frames,
+                                ignore_types,
+                                frame_stop,
+                                frame_step,
+                                assigned_scalar_attrs=scalar_attrs,
+                                track_index=track_index,
+                                track_group_id=track_group_id,
+                                immutable_attrs=immutable_attrs,
+                                occluded_attrs=_occluded_attrs,
+                                group_id_attrs=_group_id_attrs,
+                            )
+                            label_field_results = self._merge_results(
+                                label_field_results, track_shape_results
+                            )
 
-                    # Polyline(s) corresponding to instance/semantic masks need to
-                    # be converted to their final format
-                    self._convert_polylines_to_masks(
-                        label_field_results, label_info, frames_metadata
-                    )
+                        frames_metadata = {}
+                        for cvat_frame_id, frame_data in frame_id_map[
+                            task_id
+                        ].items():
+                            sample_id = frame_data["sample_id"]
+                            if "frame_id" in frame_data and len(frames) == 1:
+                                frames_metadata[sample_id] = frames[0]
+                                break
 
-                    annotations = self._merge_results(
-                        annotations, {label_field: label_field_results}
-                    )
+                            if len(frames) > cvat_frame_id:
+                                frame_metadata = frames[cvat_frame_id]
+                            else:
+                                frame_metadata = None
+
+                            frames_metadata[sample_id] = frame_metadata
+
+                        # Polyline(s) corresponding to instance/semantic masks need to
+                        # be converted to their final format
+                        self._convert_polylines_to_masks(
+                            label_field_results, label_info, frames_metadata
+                        )
+
+                        annotations = self._merge_results(
+                            annotations, {label_field: label_field_results}
+                        )
 
         if deleted_tasks:
             results._forget_tasks(deleted_tasks)
@@ -4902,6 +4899,19 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
             labels = self._get_paginated_results(labels["url"])
 
         return task_id, labels
+
+    def _get_job_ids(self, task_id):
+        url = self.jobs_url(task_id)
+        if self._server_version >= Version("2.4"):
+            job_resp_json = self._get_paginated_results(url)
+        else:
+            job_resp = self.get(url)
+            job_resp_json = job_resp.json()
+            if "results" in job_resp_json:
+                job_resp_json = job_resp_json["results"]
+
+        job_ids = [j["id"] for j in job_resp_json]
+        return job_ids
 
     def _parse_project_details(self, project_name, project_id):
         if project_id is not None:

--- a/fiftyone/utils/cvat.py
+++ b/fiftyone/utils/cvat.py
@@ -3052,8 +3052,8 @@ class CVATBackendConfig(foua.AnnotationBackendConfig):
             task. Videos are always uploaded one per task
         segment_size (None): maximum number of images per job. Not applicable
             to videos
-        image_quality (75): an int in ``[0, 100]`` determining the image quality
-            to upload to CVAT
+        image_quality (75): an int in ``[0, 100]`` determining the image
+            quality to upload to CVAT
         use_cache (True): whether to use a cache when uploading data. Using a
             cache reduces task creation time as data will be processed
             on-the-fly and stored in the cache when requested
@@ -3074,7 +3074,8 @@ class CVATBackendConfig(foua.AnnotationBackendConfig):
             default, no project is used
         project_id (None): an optional ID of an existing CVAT project to which
             to upload the annotation tasks. By default, no project is used
-        task_name (None): an optional task name to use for the created CVAT task
+        task_name (None): an optional task name to use for the created CVAT
+            task
         occluded_attr (None): an optional attribute name containing existing
             occluded values and/or in which to store downloaded occluded values
             for all objects in the annotation run
@@ -4311,7 +4312,8 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
                 if self._server_version < Version("2.4.6"):
                     # IMPORTANT: older versions of CVAT organizes media within
                     # a task alphabetically by filename, so we must give CVAT
-                    # filenames whose alphabetical order matches the order of `paths`
+                    # filenames whose alphabetical order matches the order of
+                    # `paths`
                     filename = "%06d_%s" % (idx, os.path.basename(path))
 
                 if self._server_version >= Version("2.3"):
@@ -4643,8 +4645,8 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
                     all_tags = job_resp["tags"]
                     all_tracks = job_resp["tracks"]
 
-                    # For videos that were subsampled, remap the frame numbers to
-                    # those on the original video
+                    # For videos that were subsampled, remap the frame numbers
+                    # to those on the original video
                     all_shapes = _remap_annotation_frames(
                         all_shapes, frame_start, frame_stop, frame_step
                     )
@@ -4672,8 +4674,9 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
 
                         label_field_results = {}
 
-                        # Dict mapping class labels to the classes used in CVAT.
-                        # These are equal unless a class appears in multiple fields
+                        # Dict mapping class labels to the classes used in
+                        # CVAT. These are equal unless a class appears in
+                        # multiple fields
                         _classes = label_field_classes[label_field]
 
                         # Maps CVAT IDs to FiftyOne labels
@@ -4784,8 +4787,8 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
 
                             frames_metadata[sample_id] = frame_metadata
 
-                        # Polyline(s) corresponding to instance/semantic masks need to
-                        # be converted to their final format
+                        # Polyline(s) corresponding to instance/semantic masks
+                        # need to be converted to their final format
                         self._convert_polylines_to_masks(
                             label_field_results, label_info, frames_metadata
                         )

--- a/fiftyone/utils/data/exporters.py
+++ b/fiftyone/utils/data/exporters.py
@@ -1176,8 +1176,8 @@ class MediaExporter(object):
         input_to_output_paths = {}
         for asset_path in asset_paths:
             if not os.path.isabs(asset_path):
-                absolute_asset_path = os.path.join(
-                    os.path.dirname(fo3d_path), asset_path
+                absolute_asset_path = fos.abspath(
+                    os.path.join(os.path.dirname(fo3d_path), asset_path)
                 )
             else:
                 absolute_asset_path = asset_path
@@ -1187,6 +1187,7 @@ class MediaExporter(object):
             asset_output_path = self._filename_maker.get_output_path(
                 absolute_asset_path
             )
+            # By convention, we always write *relative* asset paths
             input_to_output_paths[asset_path] = os.path.relpath(
                 asset_output_path, os.path.dirname(fo3d_output_path)
             )

--- a/fiftyone/utils/data/exporters.py
+++ b/fiftyone/utils/data/exporters.py
@@ -1176,7 +1176,7 @@ class MediaExporter(object):
         input_to_output_paths = {}
         for asset_path in asset_paths:
             if not os.path.isabs(asset_path):
-                absolute_asset_path = fos.abspath(
+                absolute_asset_path = os.path.abspath(
                     os.path.join(os.path.dirname(fo3d_path), asset_path)
                 )
             else:

--- a/fiftyone/utils/data/exporters.py
+++ b/fiftyone/utils/data/exporters.py
@@ -238,13 +238,13 @@ def export_samples(
 
     sample_collection = samples
 
-    if isinstance(dataset_exporter, BatchDatasetExporter):
-        _write_batch_dataset(dataset_exporter, samples, progress=progress)
-        return
-
     if isinstance(
         dataset_exporter,
-        (GenericSampleDatasetExporter, GroupDatasetExporter),
+        (
+            BatchDatasetExporter,
+            GenericSampleDatasetExporter,
+            GroupDatasetExporter,
+        ),
     ):
         sample_parser = None
     elif isinstance(dataset_exporter, UnlabeledImageDatasetExporter):
@@ -406,7 +406,9 @@ def write_dataset(
     if sample_collection is None and isinstance(samples, foc.SampleCollection):
         sample_collection = samples
 
-    if isinstance(dataset_exporter, GenericSampleDatasetExporter):
+    if isinstance(dataset_exporter, BatchDatasetExporter):
+        _write_batch_dataset(dataset_exporter, samples, progress=progress)
+    elif isinstance(dataset_exporter, GenericSampleDatasetExporter):
         _write_generic_sample_dataset(
             dataset_exporter,
             samples,

--- a/fiftyone/utils/utils3d.py
+++ b/fiftyone/utils/utils3d.py
@@ -468,12 +468,10 @@ def _get_scene_asset_paths_single(task, abs_paths=False, skip_failures=True):
     asset_paths = scene.get_asset_paths()
 
     if abs_paths:
-        # Convert any relative-to-scene paths to absolute
         scene_dir = os.path.dirname(original_scene_path)
         for i, asset_path in enumerate(asset_paths):
             if not fos.isabs(asset_path):
-                asset_path = fos.join(scene_dir, asset_path)
-            asset_paths[i] = fos.resolve(asset_path)
+                asset_paths[i] = fos.resolve(fos.join(scene_dir, asset_path))
 
     return asset_paths
 

--- a/fiftyone/utils/utils3d.py
+++ b/fiftyone/utils/utils3d.py
@@ -452,7 +452,6 @@ def _get_scene_paths(scene_paths):
 def _get_scene_asset_paths_single(task, abs_paths=False, skip_failures=True):
     scene_path, original_scene_path = task
 
-    # Read scene file which is JSON
     try:
         scene = Scene.from_fo3d(scene_path)
     except Exception as e:
@@ -471,7 +470,7 @@ def _get_scene_asset_paths_single(task, abs_paths=False, skip_failures=True):
         scene_dir = os.path.dirname(original_scene_path)
         for i, asset_path in enumerate(asset_paths):
             if not fos.isabs(asset_path):
-                asset_paths[i] = fos.resolve(fos.join(scene_dir, asset_path))
+                asset_paths[i] = fos.abspath(fos.join(scene_dir, asset_path))
 
     return asset_paths
 
@@ -833,9 +832,9 @@ def _get_pcd_filepath_from_scene(scene_path: str):
         return None
 
     if not fos.isabs(pcd_path):
-        pcd_path = fos.join(os.path.dirname(scene_path), pcd_path)
+        pcd_path = fos.abspath(fos.join(os.path.dirname(scene_path), pcd_path))
 
-    return fos.resolve(pcd_path)
+    return pcd_path
 
 
 def _parse_point_cloud(

--- a/fiftyone/zoo/models/manifest-torch.json
+++ b/fiftyone/zoo/models/manifest-torch.json
@@ -3088,6 +3088,166 @@
             "date_added": "2024-04-05 19:22:51"
         },
         {
+            "base_name": "yolov8n-oiv7-torch",
+            "base_filename": "yolov8n-oiv7.pt",
+            "description": "Ultralytics YOLOv8n model trained on Open Images v7",
+            "source": "https://docs.ultralytics.com/datasets/detect/open-images-v7",
+            "size_bytes": 6534387,
+            "manager": {
+                "type": "fiftyone.core.models.ModelManager",
+                "config": {
+                    "url": "https://github.com/ultralytics/assets/releases/download/v8.2.0/yolov8n-oiv7.pt"
+                }
+            },
+            "default_deployment_config_dict": {
+                "type": "fiftyone.utils.ultralytics.FiftyOneYOLODetectionModel",
+                "config": {}
+            },
+            "requirements": {
+                "packages": [
+                    "torch>=1.7.0",
+                    "torchvision>=0.8.1",
+                    "ultralytics"
+                ],
+                "cpu": {
+                    "support": true
+                },
+                "gpu": {
+                    "support": true
+                }
+            },
+            "tags": ["detection", "oiv7", "torch", "yolo"],
+            "date_added": "2024-05-20 19:22:51"
+        },
+        {
+            "base_name": "yolov8s-oiv7-torch",
+            "base_filename": "yolov8s-oiv7.pt",
+            "description": "Ultralytics YOLOv8s model trained on Open Images v7",
+            "source": "https://docs.ultralytics.com/datasets/detect/open-images-v7",
+            "size_bytes": 22573363,
+            "manager": {
+                "type": "fiftyone.core.models.ModelManager",
+                "config": {
+                    "url": "https://github.com/ultralytics/assets/releases/download/v8.2.0/yolov8s-oiv7.pt"
+                }
+            },
+            "default_deployment_config_dict": {
+                "type": "fiftyone.utils.ultralytics.FiftyOneYOLODetectionModel",
+                "config": {}
+            },
+            "requirements": {
+                "packages": [
+                    "torch>=1.7.0",
+                    "torchvision>=0.8.1",
+                    "ultralytics"
+                ],
+                "cpu": {
+                    "support": true
+                },
+                "gpu": {
+                    "support": true
+                }
+            },
+            "tags": ["detection", "oiv7", "torch", "yolo"],
+            "date_added": "2024-05-20 19:22:51"
+        },
+        {
+            "base_name": "yolov8m-oiv7-torch",
+            "base_filename": "yolov8m-oiv7.pt",
+            "description": "Ultralytics YOLOv8m model trained Open Images v7",
+            "source": "https://docs.ultralytics.com/datasets/detect/open-images-v7",
+            "size_bytes": 52117635,
+            "manager": {
+                "type": "fiftyone.core.models.ModelManager",
+                "config": {
+                    "url": "https://github.com/ultralytics/assets/releases/download/v8.2.0/yolov8m-oiv7.pt"
+                }
+            },
+            "default_deployment_config_dict": {
+                "type": "fiftyone.utils.ultralytics.FiftyOneYOLODetectionModel",
+                "config": {}
+            },
+            "requirements": {
+                "packages": [
+                    "torch>=1.7.0",
+                    "torchvision>=0.8.1",
+                    "ultralytics"
+                ],
+                "cpu": {
+                    "support": true
+                },
+                "gpu": {
+                    "support": true
+                }
+            },
+            "tags": ["detection", "oiv7", "torch", "yolo"],
+            "date_added": "2024-05-20 19:22:51"
+        },
+        {
+            "base_name": "yolov8l-oiv7-torch",
+            "base_filename": "yolov8l-oiv7.pt",
+            "description": "Ultralytics YOLOv8l model trained Open Images v7",
+            "source": "https://docs.ultralytics.com/datasets/detect/open-images-v7",
+            "size_bytes": 87769683,
+            "manager": {
+                "type": "fiftyone.core.models.ModelManager",
+                "config": {
+                    "url": "https://github.com/ultralytics/assets/releases/download/v8.2.0/yolov8l-oiv7.pt"
+                }
+            },
+            "default_deployment_config_dict": {
+                "type": "fiftyone.utils.ultralytics.FiftyOneYOLODetectionModel",
+                "config": {}
+            },
+            "requirements": {
+                "packages": [
+                    "torch>=1.7.0",
+                    "torchvision>=0.8.1",
+                    "ultralytics"
+                ],
+                "cpu": {
+                    "support": true
+                },
+                "gpu": {
+                    "support": true
+                }
+            },
+            "tags": ["detection", "oiv7", "torch", "yolo"],
+            "date_added": "2024-05-20 19:22:51"
+        },
+        {
+            "base_name": "yolov8x-oiv7-torch",
+            "base_filename": "yolov8x-oiv7.pt",
+            "description": "Ultralytics YOLOv8x model trained Open Images v7",
+            "source": "https://docs.ultralytics.com/datasets/detect/open-images-v7",
+            "size_bytes": 136867539,
+            "manager": {
+                "type": "fiftyone.core.models.ModelManager",
+                "config": {
+                    "url": "https://github.com/ultralytics/assets/releases/download/v8.2.0/yolov8x-oiv7.pt"
+                }
+            },
+            "default_deployment_config_dict": {
+                "type": "fiftyone.utils.ultralytics.FiftyOneYOLODetectionModel",
+                "config": {}
+            },
+            "requirements": {
+                "packages": [
+                    "torch>=1.7.0",
+                    "torchvision>=0.8.1",
+                    "ultralytics"
+                ],
+                "cpu": {
+                    "support": true
+                },
+                "gpu": {
+                    "support": true
+                }
+            },
+            "tags": ["detection", "oiv7", "torch", "yolo"],
+            "date_added": "2024-05-20 19:22:51"
+        },
+        {
             "base_name": "yolo-nas-torch",
             "base_filename": null,
             "version": null,

--- a/tests/intensive/cvat_tests.py
+++ b/tests/intensive/cvat_tests.py
@@ -306,6 +306,7 @@ class CVATTests(unittest.TestCase):
             backend="cvat",
             label_field="ground_truth",
             attributes=attributes,
+            segment_size=1,
         )
 
         with results:

--- a/tests/unittests/metadata_tests.py
+++ b/tests/unittests/metadata_tests.py
@@ -30,11 +30,9 @@ class SceneMetadataTests(unittest.TestCase):
             scene.add(fo3d.ObjMesh("blah-obj", "obj.obj", "mtl.mtl"))
             scene.add(fo3d.StlMesh("blah-stl", "stl.stl"))
 
-            # Add same file again - should not add to size_bytes though,
-            #   even though this is abs and the other was relative
-            scene.add(
-                fo3d.ObjMesh("blah-obj2", os.path.join(temp_dir, "obj.obj"))
-            )
+            # Add same file again. This should not be counted in `size_bytes`
+            # or `asset_counts`
+            scene.add(fo3d.ObjMesh("blah-obj2", "obj.obj"))
 
             scene.write(scene_path)
 
@@ -42,12 +40,11 @@ class SceneMetadataTests(unittest.TestCase):
 
             self.assertEqual(metadata.mime_type, "application/octet-stream")
 
-            # Read the scene back again so we'll compare more accurately
-            expected_size = len(
-                json.dumps(fo3d.Scene.from_fo3d(scene_path).as_dict())
-            ) + sum(t[1] for t in files)
+            expected_size = os.path.getsize(scene_path)
+            expected_size += sum(t[1] for t in files)
+
             self.assertEqual(metadata.size_bytes, expected_size)
             self.assertDictEqual(
                 metadata.asset_counts,
-                {"obj": 2, "jpeg": 1, "stl": 1, "mtl": 1},
+                {"obj": 1, "jpeg": 1, "stl": 1, "mtl": 1},
             )

--- a/tests/unittests/threed/scene_3d_tests.py
+++ b/tests/unittests/threed/scene_3d_tests.py
@@ -116,12 +116,12 @@ class TestScene(unittest.TestCase):
                 resolve_relative_paths=True,
             )
             scene2 = threed.Scene.from_fo3d(path)
-            real_background = os.path.realpath(
+            real_background = os.path.abspath(
                 os.path.join(temp_dir, "../background.jpeg")
             )
             self.assertEqual(scene2.background.image, real_background)
             real_cubes = [
-                os.path.realpath(os.path.join(temp_dir, ci))
+                os.path.abspath(os.path.join(temp_dir, ci))
                 for ci in self.scene.background.cube
             ]
             self.assertListEqual(scene2.background.cube, real_cubes)
@@ -129,7 +129,7 @@ class TestScene(unittest.TestCase):
                 if node.name == "gltf2":
                     self.assertEqual(
                         node.gltf_path,
-                        os.path.realpath(
+                        os.path.abspath(
                             os.path.join(temp_dir, "relative.gltf")
                         ),
                     )

--- a/tests/unittests/threed/scene_3d_tests.py
+++ b/tests/unittests/threed/scene_3d_tests.py
@@ -71,6 +71,36 @@ class TestScene(unittest.TestCase):
             },
         )
 
+    def test_update_asset_paths(self):
+        d = {
+            "/path/to/pcd.pcd": "new.pcd",
+            "../background.jpeg": "new_background.jpeg",
+            "n3.jpeg": "new_n3.jpeg",
+        }
+
+        self.scene.update_asset_paths(d)
+
+        asset_paths = set(self.scene.get_asset_paths())
+        self.assertSetEqual(
+            asset_paths,
+            {
+                "/path/to/gltf.gltf",
+                "new.pcd",
+                "new_background.jpeg",
+                "/path/to/stl.stl",
+                "/path/to/fbx.fbx",
+                "/path/to/ply.ply",
+                "/path/to/obj.obj",
+                "relative.gltf",
+                "n1.jpeg",
+                "n2.jpeg",
+                "new_n3.jpeg",
+                "n4.jpeg",
+                "n5.jpeg",
+                "n6.jpeg",
+            },
+        )
+
     def test_write(self):
         with tempfile.TemporaryDirectory() as temp_dir:
             path = os.path.join(temp_dir, "blah.fo3d")

--- a/tests/unittests/utils3d_tests.py
+++ b/tests/unittests/utils3d_tests.py
@@ -375,16 +375,16 @@ class GetSceneAssetPaths(unittest.TestCase):
             self.assertSetEqual(
                 set(asset_paths[scene_paths[0]]),
                 {
-                    os.path.realpath(f"{temp_dir}/back/ground.jpeg"),
-                    os.path.realpath(f"{temp_dir}/relative.obj"),
-                    os.path.realpath(f"{temp_dir}/absolute.pcd"),
+                    f"{temp_dir}/back/ground.jpeg",
+                    f"{temp_dir}/relative.obj",
+                    f"{temp_dir}/absolute.pcd",
                 },
             )
             self.assertSetEqual(
                 set(asset_paths[scene_paths[1]]),
                 {
-                    os.path.realpath(f"{temp_dir}/back/ground.jpeg"),
-                    os.path.realpath(f"{temp_dir}/relative2.stl"),
+                    f"{temp_dir}/back/ground.jpeg",
+                    f"{temp_dir}/relative2.stl",
                 },
             )
 


### PR DESCRIPTION
These PRs were included in the release notes for 0.24.0 but somehow appear to have not actually been released (I've moved their associated release notes into v0.24.1 in https://github.com/voxel51/fiftyone/pull/4456):
- https://github.com/voxel51/fiftyone/pull/4398
- https://github.com/voxel51/fiftyone/pull/4416

Also cherry-picks these bug fixes:
- https://github.com/voxel51/fiftyone/pull/4442
- https://github.com/voxel51/fiftyone/pull/4444

And the following PR which just missed the cutoff from v0.24.0 but has tests:
- https://github.com/voxel51/fiftyone/pull/4392

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced methods for downloading scenes and 3D assets with configurable options.
  - Added parameters to control dataset persistence and creation in various dataset functions.

- **Enhancements**
  - Improved handling of 3D scene metadata and asset paths.
  - Enhanced CVAT integration with refined parameter descriptions and logic updates.
  - Refactored dataset exporter logic for better efficiency.

- **Bug Fixes**
  - Corrected logic for counting file sizes and asset counts in scene metadata tests.
  - Fixed path resolution issues in 3D scene and asset handling.

- **Tests**
  - Added new test methods for patches, scenes, and video datasets.
  - Updated existing tests to reflect new parameters and logic changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->