### PR TITLE
Refetch saved views on dataset change

### DIFF
--- a/app/packages/core/src/components/Sidebar/ViewSelection/index.tsx
+++ b/app/packages/core/src/components/Sidebar/ViewSelection/index.tsx
@@ -81,6 +81,10 @@ export default function ViewSelection() {
   );
 
   useEffect(() => {
+    refetch({ name: datasetName });
+  }, [datasetName]);
+
+  useEffect(() => {
     if (
       selected &&
       selected?.id !== fos.DEFAULT_SELECTED.id &&

--- a/fiftyone/server/events/initialize.py
+++ b/fiftyone/server/events/initialize.py
@@ -132,6 +132,7 @@ def handle_dataset_change(
     """
     try:
         state.dataset = fod.load_dataset(initializer.dataset)
+        state.group_slice = state.dataset.group_slice
         state.selected = []
         state.selected_labels = []
         state.view = None
@@ -139,6 +140,7 @@ def handle_dataset_change(
 
     except:
         state.dataset = None
+        state.group_slice = None
         state.selected = []
         state.selected_labels = []
         state.view = None
@@ -151,7 +153,6 @@ def handle_dataset_change(
                 initializer.view, slug=True
             )
             state.view = state.dataset.load_saved_view(doc.name)
-            state.view_name = doc.name
         except:
             pass
 
@@ -191,7 +192,6 @@ def handle_saved_view(
         if slug:
             doc = state.dataset._get_saved_view_doc(slug, slug=True)
             state.view = state.dataset.load_saved_view(doc.name)
-            state.view_name = doc.name
         state.selected = []
         state.selected_labels = []
     except:

--- a/fiftyone/server/mutation.py
+++ b/fiftyone/server/mutation.py
@@ -93,7 +93,6 @@ class Mutation(SetColorScheme):
         state.selected = []
         state.selected_labels = []
         state.view = None
-        state.view_name = view_name if view_name is not None else None
         state.spaces = foo.default_workspace_factory()
         state.color_scheme = build_color_scheme(
             None, state.dataset, state.config
@@ -243,14 +242,7 @@ class Mutation(SetColorScheme):
             result_view = _build_result_view(result_view, form)
 
         # Set view state
-        slug = (
-            fou.to_slug(result_view.name)
-            if result_view.name
-            else saved_view_slug
-        )
         state.view = result_view
-        state.view_name = result_view.name
-        state.saved_view_slug = slug
 
         await dispatch_event(
             subscription,
@@ -300,7 +292,6 @@ class Mutation(SetColorScheme):
         if use_state:
             dataset.reload()
             state.view = dataset.load_saved_view(view_name)
-            state.view_name = view_name
             await dispatch_event(subscription, fose.StateUpdate(state=state))
 
         return next(
@@ -348,7 +339,6 @@ class Mutation(SetColorScheme):
             and state.view.name == view_name
         ):
             state.view = dataset.view()
-            state.view_name = None
 
         await dispatch_event(subscription, fose.StateUpdate(state=state))
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced `ViewSelection` component to automatically refetch data when the dataset name changes.

- **Bug Fixes**
  - Improved state management for dataset group slices to handle exceptions more gracefully.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->