### PR TITLE
fix workspace persistence issue

### DIFF
--- a/app/packages/core/src/components/MainSpace/MainSpace.tsx
+++ b/app/packages/core/src/components/MainSpace/MainSpace.tsx
@@ -8,11 +8,16 @@ const { FIFTYONE_SPACE_ID } = constants;
 function MainSpace() {
   const [sessionSpaces, setSessionSpaces, sessionPanelsState] =
     useSessionSpaces();
-  const { spaces, updateSpaces } = useSpaces(FIFTYONE_SPACE_ID, sessionSpaces);
+  const { spaces, updateSpaces, clearSpaces } = useSpaces(
+    FIFTYONE_SPACE_ID,
+    sessionSpaces
+  );
   const [panelsState, setPanelsState] = usePanelsState();
   const oldSpaces = useRef(spaces);
   const oldPanelsState = useRef(panelsState);
   const isMounted = useRef(false);
+
+  useEffect(() => clearSpaces, [clearSpaces]);
 
   useEffect(() => {
     if (!spaces.equals(sessionSpaces)) {

--- a/app/packages/operators/src/OperatorInvocationRequestExecutor.tsx
+++ b/app/packages/operators/src/OperatorInvocationRequestExecutor.tsx
@@ -1,15 +1,21 @@
-import { useEffect } from "react";
+import { useEffect, useMemo } from "react";
 import {
   useInvocationRequestExecutor,
   useInvocationRequestQueue,
 } from "./state";
+import { QueueItemStatus } from "./constants";
 
 export default function OperatorInvocationRequestExecutor() {
   const { requests, onSuccess, onError } = useInvocationRequestQueue();
+  const pendingRequests = useMemo(() => {
+    return requests.filter(
+      (queueItem) => queueItem.status === QueueItemStatus.Pending
+    );
+  }, [requests]);
 
   return (
     <>
-      {requests.map((queueItem) => (
+      {pendingRequests.map((queueItem) => (
         <RequestExecutor
           key={queueItem.id}
           queueItem={queueItem}

--- a/app/packages/operators/src/constants.ts
+++ b/app/packages/operators/src/constants.ts
@@ -7,3 +7,9 @@ export enum OPERATOR_PROMPT_AREAS {
   DRAWER_LEFT = "operator_prompt_area_drawer_left",
   DRAWER_RIGHT = "operator_prompt_area_drawer_right",
 }
+export enum QueueItemStatus {
+  Pending,
+  Executing,
+  Completed,
+  Failed,
+}

--- a/app/packages/operators/src/operators.ts
+++ b/app/packages/operators/src/operators.ts
@@ -4,6 +4,7 @@ import * as types from "./types";
 import { stringifyError } from "./utils";
 import { ValidationContext, ValidationError } from "./validation";
 import { ExecutionCallback, OperatorExecutorOptions } from "./types-internal";
+import { QueueItemStatus } from "./constants";
 
 class InvocationRequest {
   constructor(
@@ -745,16 +746,6 @@ export async function resolveLocalPlacements(ctx: ExecutionContext) {
   }
 
   return localPlacements;
-}
-
-// and allows for the execution of the requests in order of arrival
-// and removing the requests that have been completed
-
-enum QueueItemStatus {
-  Pending,
-  Executing,
-  Completed,
-  Failed,
 }
 
 class QueueItem {

--- a/app/packages/spaces/src/hooks.ts
+++ b/app/packages/spaces/src/hooks.ts
@@ -1,6 +1,6 @@
 import { PluginComponentType, useActivePlugins } from "@fiftyone/plugins";
 import * as fos from "@fiftyone/state";
-import { useContext, useEffect, useMemo, useRef } from "react";
+import { useCallback, useContext, useEffect, useMemo, useRef } from "react";
 import { SortableEvent } from "react-sortablejs";
 import {
   useRecoilCallback,
@@ -8,7 +8,6 @@ import {
   useRecoilValue,
   useSetRecoilState,
 } from "recoil";
-import SpaceNode from "./SpaceNode";
 import SpaceTree from "./SpaceTree";
 import { PanelContext } from "./contexts";
 import {
@@ -32,15 +31,18 @@ export function useSpaces(id: string, defaultState?: SpaceNodeJSON) {
   const [state, setState] = useRecoilState(spaceSelector(id));
 
   useEffect(() => {
-    if (!state) {
-      const baseState = new SpaceNode("root").toJSON();
-      setState(defaultState || baseState);
+    if (!state && defaultState) {
+      setState(defaultState);
     }
-  }, []);
+  }, [state, setState, defaultState]);
 
   const spaces = new SpaceTree(state, (spaces: SpaceNodeJSON) => {
     setState(spaces);
   });
+
+  const clearSpaces = useCallback(() => {
+    setState(undefined);
+  }, [setState]);
 
   return {
     spaces,
@@ -57,6 +59,7 @@ export function useSpaces(id: string, defaultState?: SpaceNodeJSON) {
         setState(serializedTreeOrUpdater);
       }
     },
+    clearSpaces,
   };
 }
 

--- a/app/packages/spaces/src/state.ts
+++ b/app/packages/spaces/src/state.ts
@@ -9,7 +9,9 @@ import {
 
 // a react hook for managing the state of all spaces in the app
 // it should use recoil to persist the tree
-export const spacesAtom = atom<{ [spaceId: string]: SpaceNodeJSON }>({
+export const spacesAtom = atom<{
+  [spaceId: string]: SpaceNodeJSON | undefined;
+}>({
   key: "spaces",
   default: {},
 });


### PR DESCRIPTION
## What changes are proposed in this pull request?

Fixes some issues with loading and using workspaces in the app

## How is this patch tested? If it is not, please explain why.

Using app and session

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

See above

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced automatic clearing of spaces on component mount for improved state management.
  - Added filtering of pending requests for better performance and user experience.

- **Bug Fixes**
  - Updated MongoDB download links for various platforms to ensure compatibility and successful installations.

- **Chores**
  - Organized code by moving `QueueItemStatus` enum to a separate file.
  - Added a build step to upload a wheel artifact for non-sdist platforms.

- **Refactor**
  - Improved state handling and effects in hooks for better performance and reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->