### PR TITLE
fix open_dataset validate and allow skipping IO

### DIFF
--- a/app/packages/operators/src/built-in-operators.ts
+++ b/app/packages/operators/src/built-in-operators.ts
@@ -315,7 +315,7 @@ class OpenDataset extends Operator {
   }
   async resolveInput(): Promise<types.Property> {
     const inputs = new types.Object();
-    inputs.str("dataset", { label: "Dataset name", required: true });
+    inputs.str("dataset", { label: "Dataset name" });
     return new types.Property(inputs);
   }
   useHooks(): object {

--- a/app/packages/operators/src/operators.ts
+++ b/app/packages/operators/src/operators.ts
@@ -146,6 +146,8 @@ export type OperatorConfigOptions = {
   darkIcon?: string;
   lightIcon?: string;
   resolveExecutionOptionsOnChange?: boolean;
+  skipInput?: boolean;
+  skipOutput?: boolean;
 };
 export class OperatorConfig {
   public name: string;
@@ -162,6 +164,9 @@ export class OperatorConfig {
   public darkIcon = null;
   public lightIcon = null;
   public resolveExecutionOptionsOnChange = false;
+  public skipInput: boolean;
+  public skipOutput: boolean;
+
   constructor(options: OperatorConfigOptions) {
     this.name = options.name;
     this.label = options.label || options.name;
@@ -179,6 +184,8 @@ export class OperatorConfig {
     this.lightIcon = options.lightIcon;
     this.resolveExecutionOptionsOnChange =
       options.resolveExecutionOptionsOnChange || false;
+    this.skipInput = options.skipInput || false;
+    this.skipOutput = options.skipOutput || false;
   }
   static fromJSON(json) {
     return new OperatorConfig({
@@ -196,6 +203,8 @@ export class OperatorConfig {
       darkIcon: json.dark_icon,
       lightIcon: json.light_icon,
       resolveExecutionOptionsOnChange: json.resolve_execution_options_on_change,
+      skipInput: json.skip_input,
+      skipOutput: json.skip_output,
     });
   }
 }
@@ -252,12 +261,16 @@ export class Operator {
     return {};
   }
   async resolveInput(ctx: ExecutionContext) {
+    if (this.config.skipInput) return null;
+
     if (this.isRemote) {
       return resolveRemoteType(this.uri, ctx, "inputs");
     }
     return null;
   }
   async resolveOutput(ctx: ExecutionContext, result: OperatorResult) {
+    if (this.config.skipOutput) return null;
+
     if (this.isRemote) {
       return resolveRemoteType(this.uri, ctx, "outputs", result);
     }

--- a/fiftyone/operators/server.py
+++ b/fiftyone/operators/server.py
@@ -22,6 +22,8 @@ from .executor import (
 )
 from .message import GeneratedMessage
 from .permissions import PermissionedOperatorRegistry
+from .utils import is_method_overridden
+from .operator import Operator
 
 
 class ListOperators(HTTPEndpoint):
@@ -36,6 +38,14 @@ class ListOperators(HTTPEndpoint):
         for operator in registry.list_operators():
             serialized_op = operator.to_json()
             config = serialized_op["config"]
+            skip_input = not is_method_overridden(
+                Operator, operator, "resolve_input"
+            )
+            skip_output = not is_method_overridden(
+                Operator, operator, "resolve_output"
+            )
+            config["skip_input"] = skip_input
+            config["skip_output"] = skip_output
             config["can_execute"] = registry.can_execute(serialized_op["uri"])
             operators_as_json.append(serialized_op)
 

--- a/fiftyone/operators/utils.py
+++ b/fiftyone/operators/utils.py
@@ -5,7 +5,9 @@ FiftyOne operator utilities.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 import logging
+from .operator import Operator
 
 
 class ProgressHandler(logging.Handler):
@@ -47,3 +49,20 @@ class ProgressHandler(logging.Handler):
     def emit(self, record):
         msg = self.format(record)
         self.ctx.set_progress(label=msg)
+
+
+def is_method_overridden(base_class, sub_class_instance, method_name):
+    """Returns whether a method is overridden in a subclass.
+
+    Args:
+        base_class: the base class
+        sub_class_instance: an instance of the subclass
+        method_name: the name of the method
+
+    Returns:
+        True/False
+    """
+
+    base_method = getattr(base_class, method_name, None)
+    sub_method = getattr(type(sub_class_instance), method_name, None)
+    return base_method != sub_method

--- a/tests/unittests/operators/operators_utils_tests.py
+++ b/tests/unittests/operators/operators_utils_tests.py
@@ -1,0 +1,75 @@
+"""
+Unit tests for operators utilities.
+
+| Copyright 2017-2024, Voxel51, Inc.
+| `voxel51.com <https://voxel51.com/>`_
+|
+"""
+
+import unittest
+
+from fiftyone.operators.utils import is_method_overridden
+
+
+class MockOperator:
+    def resolve_input(self):
+        return "default_input"
+
+    def resolve_output(self):
+        return "default_output"
+
+
+class MockOperatorOne(MockOperator):
+    def resolve_input(self):
+        return "custom_input"
+
+
+class MockOperatorTwo(MockOperator):
+    def resolve_input(self):
+        return "custom_input"
+
+    def resolve_output(self):
+        return "custom_output"
+
+
+class MockOperatorThree(MockOperator):
+    def resolve_output(self):
+        return "custom_output"
+
+
+class MockOperatorFour(MockOperator):
+    pass
+
+
+class TestOperatorUtilities(unittest.TestCase):
+    def test_is_method_overridden(self):
+
+        op_one = MockOperatorOne()
+        op_two = MockOperatorTwo()
+        op_three = MockOperatorThree()
+        op_four = MockOperatorFour()
+
+        self.assertTrue(
+            is_method_overridden(MockOperator, op_one, "resolve_input")
+        )
+        self.assertFalse(
+            is_method_overridden(MockOperator, op_one, "resolve_output")
+        )
+        self.assertTrue(
+            is_method_overridden(MockOperator, op_two, "resolve_input")
+        )
+        self.assertTrue(
+            is_method_overridden(MockOperator, op_two, "resolve_output")
+        )
+        self.assertFalse(
+            is_method_overridden(MockOperator, op_three, "resolve_input")
+        )
+        self.assertTrue(
+            is_method_overridden(MockOperator, op_three, "resolve_output")
+        )
+        self.assertFalse(
+            is_method_overridden(MockOperator, op_four, "resolve_input")
+        )
+        self.assertFalse(
+            is_method_overridden(MockOperator, op_four, "resolve_output")
+        )


### PR DESCRIPTION
## What changes are proposed in this pull request?

- Fix `open_dataset` validation error when the optional `dataset_name` param is not provided (can be undefined to unselect current dataset)
- Small optimization to skip IO resolution is method is not provided by an operator

## How is this patch tested? If it is not, please explain why.

Using an example operator in the app and unit test

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

See the list above

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added `skipInput` and `skipOutput` properties to operator configurations for enhanced control over input/output processing.
  - Implemented a new utility function to check if methods are overridden in subclasses.
  
- **Bug Fixes**
  - Removed the `required` constraint for the "dataset" input parameter in the `OpenDataset` class to improve flexibility.

- **Tests**
  - Added unit tests to validate the new utility function for detecting overridden methods in operator classes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->