### PR TITLE
Fix dynamic group player for group datasets

### DIFF
--- a/app/packages/state/src/hooks/useCreateLooker.ts
+++ b/app/packages/state/src/hooks/useCreateLooker.ts
@@ -188,9 +188,10 @@ export default <T extends AbstractLooker<BaseState>>(
           );
           const page = snapshot
             .getLoadable(
-              dynamicGroupAtoms.dynamicGroupPageSelector(
-                groupByFieldValueTransformed
-              )
+              dynamicGroupAtoms.dynamicGroupPageSelector({
+                value: groupByFieldValueTransformed,
+                modal: isModal,
+              })
             )
             .valueMaybe();
 
@@ -257,6 +258,7 @@ export default <T extends AbstractLooker<BaseState>>(
       highlight,
       isClip,
       isFrame,
+      isModal,
       shouldRenderImaVidLooker,
       isPatch,
       mediaField,

--- a/app/packages/state/src/recoil/dynamicGroups.test.ts
+++ b/app/packages/state/src/recoil/dynamicGroups.test.ts
@@ -2,10 +2,14 @@ import { describe, expect, it, vi } from "vitest";
 vi.mock("recoil");
 vi.mock("recoil-relay");
 
-import { setMockAtoms, TestSelector } from "../../../../__mocks__/recoil";
+import {
+  setMockAtoms,
+  TestSelector,
+  TestSelectorFamily,
+} from "../../../../__mocks__/recoil";
 import * as dynamicGroups from "./dynamicGroups";
 
-describe("handles non-nested dynamic groups", () => {
+describe("handles dynamic groups", () => {
   const testNesting = <
     TestSelector<typeof dynamicGroups.isNonNestedDynamicGroup>
   >(<unknown>dynamicGroups.isNonNestedDynamicGroup);
@@ -24,5 +28,32 @@ describe("handles non-nested dynamic groups", () => {
       parentMediaTypeSelector: "group",
     });
     expect(testNesting()).toBe(false);
+  });
+
+  const modalPageSelector = <
+    TestSelectorFamily<typeof dynamicGroups.dynamicGroupPageSelector>
+  >(<unknown>(
+    dynamicGroups.dynamicGroupPageSelector({ value: "test", modal: true })
+  ));
+  const pageSelector = <
+    TestSelectorFamily<typeof dynamicGroups.dynamicGroupPageSelector>
+  >(<unknown>(
+    dynamicGroups.dynamicGroupPageSelector({ value: "test", modal: false })
+  ));
+
+  it("uses correct slice", () => {
+    setMockAtoms({
+      datasetName: "dataset",
+      dynamicGroupViewQuery: () => [],
+      groupSlice: "main",
+      modalGroupSlice: "modal",
+    });
+
+    expect(pageSelector()(0, 1).filter).toStrictEqual({
+      group: { slice: "main" },
+    });
+    expect(modalPageSelector()(0, 1).filter).toStrictEqual({
+      group: { slice: "modal" },
+    });
   });
 });

--- a/app/packages/state/src/recoil/dynamicGroups.ts
+++ b/app/packages/state/src/recoil/dynamicGroups.ts
@@ -6,7 +6,12 @@ import {
   LIST_FIELD,
 } from "@fiftyone/utilities";
 import { atom, atomFamily, selector, selectorFamily } from "recoil";
-import { currentSlice, hasGroupSlices } from "./groups";
+import {
+  currentSlice,
+  groupSlice,
+  hasGroupSlices,
+  modalGroupSlice,
+} from "./groups";
 import { modalLooker } from "./modal";
 import { dynamicGroupsViewMode } from "./options";
 import { fieldPaths } from "./schema";
@@ -70,25 +75,25 @@ export const dynamicGroupPageSelector = selectorFamily<
     after: string | null;
     count: number;
     dataset: string;
-    filter: Record<string, never>;
+    filter: { group: { slice?: string } };
     view: State.Stage[];
   },
-  string
+  { modal: boolean; value: string }
 >({
   key: "paginateDynamicGroupVariables",
   get:
-    (value) =>
+    ({ modal, value }) =>
     ({ get }) => {
       const params = {
         dataset: get(datasetName),
         view: get(dynamicGroupViewQuery(value)),
+        filter: { group: { slice: get(modal ? modalGroupSlice : groupSlice) } },
       };
 
       return (cursor: number, pageSize: number) => ({
         ...params,
         after: cursor ? String(cursor) : null,
         count: pageSize,
-        filter: {},
       });
     },
 });


### PR DESCRIPTION
## What changes are proposed in this pull request?

Adds missing `slice` parameter to imavid pagination

## How is this patch tested? If it is not, please explain why.

Selector tests for `dynamicGroupPageSelector`

## Release Notes

* Fixed group slice selection when rendering dynamically grouped groups as a video

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit


- **New Features**
	- Added support for modal views in dynamic group selectors, enhancing flexibility in data presentation.

- **Tests**
	- Expanded test coverage to include new modal-related functionality in dynamic groups.
	- Updated test cases and assertions to ensure accurate handling of dynamic groups.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->