### PR TITLE
Move `Jinja2==3.0.3` to `docs.txt`

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -8,7 +8,6 @@ ftfy==6.1.1
 httpx==0.23.0
 hypercorn==0.13.2
 importlib-metadata==1.4.0; python_version<"3.8"
-Jinja2==3.0.3
 kaleido==0.2.1
 matplotlib==3.5.2
 mongoengine==0.24.2

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -2,6 +2,7 @@ autodocsumm==0.2.7
 docutils==0.16
 ipykernel==5.3.0
 ipython_genutils==0.2.0
+Jinja2==3.0.3
 jsx-lexer==2.0.0
 jupyter-client==6.1.3
 myst-parser==0.13.7

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ INSTALL_REQUIRES = [
     "humanize",
     "hypercorn>=0.13.2",
     "importlib-metadata; python_version<'3.8'",
-    "Jinja2==3.0.3",
+    "Jinja2>=3",
     # kaleido indirectly required by plotly for image export
     # https://plotly.com/python/static-image-export/
     "kaleido!=0.2.1.post1",


### PR DESCRIPTION
## What changes are proposed in this pull request?

Revert `Jinja2` requirement to [v0.23.8](https://github.com/voxel51/fiftyone/blob/d39a84cba6e1b62f9e43a9013f5766b911a498a1/setup.py#L48C12-L48C15) setting and move `Jinja2==3.0.3` to `docs.txt` requirements as it is only required for building documentation

## How is this patch tested? If it is not, please explain why.

Workflows

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [x] Other
