### PR TITLE
fix asyncio issue in pytest

### DIFF
--- a/fiftyone/factory/repos/delegated_operation.py
+++ b/fiftyone/factory/repos/delegated_operation.py
@@ -44,7 +44,6 @@ class DelegatedOperationRepo(object):
         result: ExecutionResult = None,
         run_link: str = None,
         progress: ExecutionProgress = None,
-        outputs_schema: dict = None,
     ) -> DelegatedOperationDocument:
         """Update the run state of an operation."""
         raise NotImplementedError("subclass must implement update_run_state()")
@@ -228,7 +227,6 @@ class MongoDelegatedOperationRepo(DelegatedOperationRepo):
         result: ExecutionResult = None,
         run_link: str = None,
         progress: ExecutionProgress = None,
-        outputs_schema: dict = None,
     ) -> DelegatedOperationDocument:
         update = None
 
@@ -236,19 +234,25 @@ class MongoDelegatedOperationRepo(DelegatedOperationRepo):
         if result is not None and not isinstance(result, ExecutionResult):
             execution_result = ExecutionResult(result=result)
 
+        execution_result_json = (
+            execution_result.to_json() if execution_result else None
+        )
+        outputs_schema = (
+            execution_result_json.pop("outputs_schema", None)
+            if execution_result_json
+            else None
+        )
+
         if run_state == ExecutionRunState.COMPLETED:
             update = {
                 "$set": {
                     "run_state": run_state,
                     "completed_at": datetime.utcnow(),
                     "updated_at": datetime.utcnow(),
-                    "result": (
-                        execution_result.to_json()
-                        if execution_result
-                        else None
-                    ),
+                    "result": execution_result_json,
                 }
             }
+
         if outputs_schema:
             update["$set"]["metadata.outputs_schema"] = {
                 "$ifNull": [outputs_schema, {}]
@@ -260,11 +264,7 @@ class MongoDelegatedOperationRepo(DelegatedOperationRepo):
                     "run_state": run_state,
                     "failed_at": datetime.utcnow(),
                     "updated_at": datetime.utcnow(),
-                    "result": (
-                        execution_result.to_json()
-                        if execution_result
-                        else None
-                    ),
+                    "result": execution_result_json,
                 }
             }
         elif run_state == ExecutionRunState.RUNNING:

--- a/fiftyone/operators/executor.py
+++ b/fiftyone/operators/executor.py
@@ -376,22 +376,22 @@ async def resolve_type(registry, operator_uri, request_params):
         return ExecutionResult(error=traceback.format_exc())
 
 
-async def resolve_type_with_context(context, target: str = None):
+async def resolve_type_with_context(request_params, target: str = None):
     """Resolves the "inputs" or "outputs" schema of an operator with the given context.
 
     Args:
-        context: the :class:`ExecutionContext` of an operator
+        request_params: a dictionary of request parameters
         target (None): the target schema ("inputs" or "outputs")
 
     Returns:
         the schema of "inputs" or "outputs" :class:`fiftyone.operators.types.Property` of
         an operator, or None
     """
-    computed_target = target or context.request_params.get("target", None)
-    request_params = {**context.request_params, "target": computed_target}
+    computed_target = target or request_params.get("target", None)
+    computed_request_params = {**request_params, "target": computed_target}
     operator_uri = request_params.get("operator_uri", None)
     registry = OperatorRegistry()
-    return await resolve_type(registry, operator_uri, request_params)
+    return await resolve_type(registry, operator_uri, computed_request_params)
 
 
 async def resolve_execution_options(registry, operator_uri, request_params):
@@ -772,6 +772,7 @@ class ExecutionResult(object):
         error (None): an error message
         validation_ctx (None): a :class:`ValidationContext`
         delegated (False): whether execution was delegated
+        outputs_schema (None): a JSON dict representing the output schema of the operator
     """
 
     def __init__(
@@ -781,12 +782,14 @@ class ExecutionResult(object):
         error=None,
         validation_ctx=None,
         delegated=False,
+        outputs_schema=None,
     ):
         self.result = result
         self.executor = executor
         self.error = error
         self.validation_ctx = validation_ctx
         self.delegated = delegated
+        self.outputs_schema = outputs_schema
 
     @property
     def is_generator(self):
@@ -835,6 +838,7 @@ class ExecutionResult(object):
             "validation_ctx": (
                 self.validation_ctx.to_json() if self.validation_ctx else None
             ),
+            "outputs_schema": self.outputs_schema,
         }
 
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

Fixes an issue where pytest fails on calling set_completed due to use of `asyncio.run` in teams env.

## How is this patch tested? If it is not, please explain why.

Using pytest in teams env

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Improved efficiency and clarity by refactoring how output schemas are handled within various functions and classes.
  
- **Tests**
  - Updated unit tests to reflect changes in input/output handling and progress reporting mechanisms.
  - Introduced new test scenarios to ensure robustness of the updated logic.
  
- **Bug Fixes**
  - Resolved inconsistencies in parameter handling within the `resolve_type_with_context` function.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->