### PR TITLE
fix ctx.panel.close and add ctx.panel.set_title

### DIFF
--- a/app/packages/operators/src/built-in-operators.ts
+++ b/app/packages/operators/src/built-in-operators.ts
@@ -2,6 +2,7 @@ import {
   Layout,
   SpaceNode,
   usePanelState,
+  usePanelTitle,
   usePanels,
   useSetPanelStateById,
   useSpaceNodes,
@@ -1011,8 +1012,7 @@ class PromptUserForOperation extends Operator {
     return { triggerEvent };
   }
   async execute(ctx: ExecutionContext): Promise<void> {
-    const { params, operator_uri, on_success, on_error, on_cancel } =
-      ctx.params;
+    const { params, operator_uri, on_success, on_error } = ctx.params;
     const { triggerEvent } = ctx.hooks;
     const panelId = ctx.getCurrentPanelId();
 
@@ -1113,7 +1113,7 @@ export class SetActiveFields extends Operator {
       unlisted: true,
     });
   }
-  useHooks(ctx: ExecutionContext): {
+  useHooks(): {
     setActiveFields: (fields: string[]) => void;
   } {
     return {
@@ -1126,7 +1126,7 @@ export class SetActiveFields extends Operator {
       ),
     };
   }
-  async resolveInput(ctx: ExecutionContext): Promise<types.Property> {
+  async resolveInput(): Promise<types.Property> {
     const inputs = new types.Object();
     inputs.list("fields", new types.String(), {
       label: "Fields",
@@ -1136,6 +1136,30 @@ export class SetActiveFields extends Operator {
   }
   async execute(ctx: ExecutionContext): Promise<void> {
     ctx.hooks.setActiveFields(ctx.params.fields);
+  }
+}
+
+export class SetPanelTitle extends Operator {
+  get config(): OperatorConfig {
+    return new OperatorConfig({
+      name: "set_panel_title",
+      label: "Set panel title",
+      unlisted: true,
+    });
+  }
+  useHooks() {
+    const [_, setTitle] = usePanelTitle();
+    return { setTitle };
+  }
+  async resolveInput(): Promise<types.Property> {
+    const inputs = new types.Object();
+    inputs.str("id", { label: "Panel ID", required: true });
+    inputs.str("title", { label: "Title", required: true });
+    return new types.Property(inputs);
+  }
+  async execute(ctx: ExecutionContext): Promise<void> {
+    const { title, id } = ctx.params;
+    ctx.hooks.setTitle(title, id);
   }
 }
 
@@ -1182,6 +1206,7 @@ export function registerBuiltInOperators() {
     _registerBuiltInOperator(Notify);
     _registerBuiltInOperator(SetExtendedSelection);
     _registerBuiltInOperator(SetActiveFields);
+    _registerBuiltInOperator(SetPanelTitle);
   } catch (e) {
     console.error("Error registering built-in operators");
     console.error(e);

--- a/app/packages/spaces/src/hooks.ts
+++ b/app/packages/spaces/src/hooks.ts
@@ -127,9 +127,9 @@ export function usePanelTitle(id?: string): [string, (title: string) => void] {
   const panelId = id || panelContext?.node?.id;
   const panelTitle = panelTitles.get(panelId);
 
-  function setPanelTitle(title: string) {
+  function setPanelTitle(title: string, id?: string) {
     const updatedPanelTitles = new Map(panelTitles);
-    updatedPanelTitles.set(panelId, title);
+    updatedPanelTitles.set(id || panelId, title);
     setPanelTitles(updatedPanelTitles);
   }
   return [panelTitle, setPanelTitle];

--- a/fiftyone/operators/operations.py
+++ b/fiftyone/operators/operations.py
@@ -542,6 +542,17 @@ class Operations(object):
             "set_active_fields", params={"fields": fields}
         )
 
+    def set_panel_title(self, id=None, title=None):
+        """Set the title of the specified panel in the App.
+
+        Args:
+            id: the ID of the panel to set the title
+            title: the title to set
+        """
+        return self._ctx.trigger(
+            "set_panel_title", params={"id": id, "title": title}
+        )
+
 
 def _serialize_view(view):
     return json.loads(json_util.dumps(view._serialize()))

--- a/fiftyone/operators/operations.py
+++ b/fiftyone/operators/operations.py
@@ -317,13 +317,16 @@ class Operations(object):
         """Open all available panels in the App."""
         return self._ctx.trigger("open_all_panel")
 
-    def close_panel(self, name):
+    def close_panel(self, name=None, id=None):
         """Close the panel with the given name in the App.
 
         Args:
             name: the name of the panel to close
+            id: the id of the panel to close
         """
-        return self._ctx.trigger("close_panel", params={"name": name})
+        return self._ctx.trigger(
+            "close_panel", params={"name": name, "id": id}
+        )
 
     def close_all_panels(self):
         """Close all open panels in the App."""

--- a/fiftyone/operators/panel.py
+++ b/fiftyone/operators/panel.py
@@ -248,7 +248,7 @@ class PanelRef:
 
     def close(self):
         """Closes the panel."""
-        self._ctx.ops.close_panel()
+        self._ctx.ops.close_panel(id=self.id)
 
     def set_state(self, key, value):
         """

--- a/fiftyone/operators/panel.py
+++ b/fiftyone/operators/panel.py
@@ -282,3 +282,14 @@ class PanelRef:
             value (any): The data value.
         """
         self._data.set(key, value)
+
+    def set_title(self, title):
+        """
+        Sets the title of the panel.
+
+        Args:
+            title (str): The title.
+        """
+        if title is None:
+            raise ValueError("title cannot be None")
+        self._ctx.ops.set_panel_title(id=self.id, title=title)


### PR DESCRIPTION
## What changes are proposed in this pull request?

- Fixes ctx.panel.close not working due to missing id param
- Add an operation ctx.panel.set_title to dynamically update panel title

## How is this patch tested? If it is not, please explain why.

Using python panel operator:
```py
class LayoutPanel(foo.Panel):
    @property
    def config(self):
        return foo.PanelOperatorConfig(
            name="python_panel_02_layout",
            label="PythonPanel0.2: Layout",
            allow_multiple=True,
            icon="auto_awesome_mosaic",
        )

    def on_load(self, ctx):
        pass

    def close(self, ctx):
        ctx.panel.close()

    def shuffle_title(self, ctx):
        random_number = str(random.randint(1, 100))
        ctx.panel.set_title(f"Title {random_number}")

    def render(self, ctx):
        panel = types.Object()
        panel.btn("close", label="Close", on_click=self.close)
        panel.btn("shuffle_title", label="Shuffle Title", on_click=self.shuffle_title)
        return types.Property(
            panel, view=types.GridView(width=100, height=100, orientation="vertical")
        )
```

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

Part of a larger feature

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced the ability to set panel titles with an optional `id` parameter for more flexible title management.

- **Enhancements**
  - Improved the `close_panel` method to accept an `id` parameter for better panel identification.
  - Updated the `usePanelTitle` hook to support setting titles based on an optional `id`.

- **Bug Fixes**
  - Refined various methods to streamline parameter usage and enhance performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->