### PR TITLE
rm main from push release

### DIFF
--- a/.github/workflows/push-release.yml
+++ b/.github/workflows/push-release.yml
@@ -3,7 +3,6 @@ name: Push Release
 on:
   push:
     branches:
-      - main
       - release/v[0-9]+.[0-9]+.[0-9]+
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
## What changes are proposed in this pull request?

Manual PRs are probably best when merging to `main` into `develop`

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [x] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated workflow to trigger only on `release/v[0-9]+.[0-9]+.[0-9]+` branches, removing the trigger for the `main` branch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->