### PR TITLE
Don't mutate expressions passed to to_clips() in-place

### DIFF
--- a/fiftyone/core/clips.py
+++ b/fiftyone/core/clips.py
@@ -974,9 +974,12 @@ def _write_expr_clips(
         _, path = src_collection._get_label_field_path(expr)
         leaf, _ = src_collection._handle_frame_field(path)
         expr = F(leaf).length() > 0
-
-    if isinstance(expr, dict):
+    elif isinstance(expr, dict):
         expr = foe.ViewExpression(expr)
+    else:
+        # map() modifies the expression in-place and we don't want to cause
+        # side effects to the caller
+        expr = deepcopy(expr)
 
     frame_numbers, bools = src_collection.values(
         ["frames.frame_number", F("frames").map(expr)]

--- a/fiftyone/core/expressions.py
+++ b/fiftyone/core/expressions.py
@@ -257,11 +257,6 @@ class ViewExpression(object):
     def _freeze_prefix(self, prefix):
         _do_freeze_prefix(self, prefix)
 
-    def _with_prefix(self, prefix):
-        expr = deepcopy(self)
-        expr._freeze_prefix(prefix)
-        return expr
-
     @property
     def is_frozen(self):
         """Whether this expression's prefix is frozen."""
@@ -1830,8 +1825,8 @@ class ViewExpression(object):
         Returns:
             a :class:`ViewExpression`
         """
-        _expr = expr._with_prefix("$$expr")
-        return ViewExpression({"$let": {"vars": {"expr": self}, "in": _expr}})
+        expr._freeze_prefix("$$expr")
+        return ViewExpression({"$let": {"vars": {"expr": self}, "in": expr}})
 
     def if_else(self, true_expr, false_expr):
         """Returns either ``true_expr`` or ``false_expr`` depending on the
@@ -1952,8 +1947,8 @@ class ViewExpression(object):
         """
         branches = []
         for key, value in mapping.items():
-            _key = key._with_prefix("$$expr")
-            branches.append({"case": _key, "then": value})
+            key._freeze_prefix("$$expr")
+            branches.append({"case": key, "then": value})
 
         switch = {"branches": branches}
         if default is not None:
@@ -2744,9 +2739,9 @@ class ViewExpression(object):
         Returns:
             a :class:`ViewExpression`
         """
-        _expr = expr._with_prefix("$$this")
+        expr._freeze_prefix("$$this")
         return ViewExpression(
-            {"$filter": {"input": self, "as": "this", "cond": _expr}}
+            {"$filter": {"input": self, "as": "this", "cond": expr}}
         )
 
     def map(self, expr):
@@ -2780,9 +2775,9 @@ class ViewExpression(object):
         Returns:
             a :class:`ViewExpression`
         """
-        _expr = expr._with_prefix("$$this")
+        expr._freeze_prefix("$$this")
         return ViewExpression(
-            {"$map": {"input": self, "as": "this", "in": _expr}}
+            {"$map": {"input": self, "as": "this", "in": expr}}
         )
 
     def reduce(self, expr, init_val=0):
@@ -2845,9 +2840,9 @@ class ViewExpression(object):
         Returns:
             a :class:`ViewExpression`
         """
-        _expr = expr._with_prefix("$$this")
+        expr._freeze_prefix("$$this")
         return ViewExpression(
-            {"$reduce": {"input": self, "initialValue": init_val, "in": _expr}}
+            {"$reduce": {"input": self, "initialValue": init_val, "in": expr}}
         )
 
     def prepend(self, value):

--- a/fiftyone/core/expressions.py
+++ b/fiftyone/core/expressions.py
@@ -257,6 +257,11 @@ class ViewExpression(object):
     def _freeze_prefix(self, prefix):
         _do_freeze_prefix(self, prefix)
 
+    def _with_prefix(self, prefix):
+        expr = deepcopy(self)
+        expr._freeze_prefix(prefix)
+        return expr
+
     @property
     def is_frozen(self):
         """Whether this expression's prefix is frozen."""
@@ -1825,8 +1830,8 @@ class ViewExpression(object):
         Returns:
             a :class:`ViewExpression`
         """
-        expr._freeze_prefix("$$expr")
-        return ViewExpression({"$let": {"vars": {"expr": self}, "in": expr}})
+        _expr = expr._with_prefix("$$expr")
+        return ViewExpression({"$let": {"vars": {"expr": self}, "in": _expr}})
 
     def if_else(self, true_expr, false_expr):
         """Returns either ``true_expr`` or ``false_expr`` depending on the
@@ -1947,8 +1952,8 @@ class ViewExpression(object):
         """
         branches = []
         for key, value in mapping.items():
-            key._freeze_prefix("$$expr")
-            branches.append({"case": key, "then": value})
+            _key = key._with_prefix("$$expr")
+            branches.append({"case": _key, "then": value})
 
         switch = {"branches": branches}
         if default is not None:
@@ -2739,9 +2744,9 @@ class ViewExpression(object):
         Returns:
             a :class:`ViewExpression`
         """
-        expr._freeze_prefix("$$this")
+        _expr = expr._with_prefix("$$this")
         return ViewExpression(
-            {"$filter": {"input": self, "as": "this", "cond": expr}}
+            {"$filter": {"input": self, "as": "this", "cond": _expr}}
         )
 
     def map(self, expr):
@@ -2775,9 +2780,9 @@ class ViewExpression(object):
         Returns:
             a :class:`ViewExpression`
         """
-        expr._freeze_prefix("$$this")
+        _expr = expr._with_prefix("$$this")
         return ViewExpression(
-            {"$map": {"input": self, "as": "this", "in": expr}}
+            {"$map": {"input": self, "as": "this", "in": _expr}}
         )
 
     def reduce(self, expr, init_val=0):
@@ -2840,9 +2845,9 @@ class ViewExpression(object):
         Returns:
             a :class:`ViewExpression`
         """
-        expr._freeze_prefix("$$this")
+        _expr = expr._with_prefix("$$this")
         return ViewExpression(
-            {"$reduce": {"input": self, "initialValue": init_val, "in": expr}}
+            {"$reduce": {"input": self, "initialValue": init_val, "in": _expr}}
         )
 
     def prepend(self, value):

--- a/tests/unittests/view_tests.py
+++ b/tests/unittests/view_tests.py
@@ -4340,6 +4340,77 @@ class ViewStageTests(unittest.TestCase):
         field = F("$ground_truth")
         self.assertEqual(str(field), str(deepcopy(field)))
 
+    def test_views_with_frozen_expressions(self):
+        sample1 = fo.Sample(filepath="video1.mp4")
+        sample1.frames[1] = fo.Frame(
+            detections=fo.Detections(
+                detections=[
+                    fo.Detection(
+                        label="vehicle",
+                        bounding_box=[0.2, 0.2, 0.2, 0.2],
+                    )
+                ]
+            )
+        )
+        sample1.frames[2] = fo.Frame()
+        sample1.frames[3] = fo.Frame(
+            detections=fo.Detections(
+                detections=[
+                    fo.Detection(
+                        label="vehicle",
+                        bounding_box=[0.2, 0.2, 0.2, 0.2],
+                    )
+                ]
+            )
+        )
+        sample1.frames[4] = fo.Frame(
+            detections=fo.Detections(
+                detections=[
+                    fo.Detection(
+                        label="vehicle",
+                        bounding_box=[0.2, 0.2, 0.2, 0.2],
+                    )
+                ]
+            )
+        )
+        sample1.frames[5] = fo.Frame()
+        sample1.frames[6] = fo.Frame(
+            detections=fo.Detections(
+                detections=[
+                    fo.Detection(
+                        label="vehicle",
+                        bounding_box=[0.2, 0.2, 0.2, 0.2],
+                    )
+                ]
+            )
+        )
+
+        sample2 = fo.Sample(filepath="video2.mp4")
+        sample2.frames[1] = fo.Frame()
+
+        sample3 = fo.Sample(filepath="video3.mp4")
+
+        dataset = fo.Dataset()
+        dataset.add_samples([sample1, sample2, sample3])
+
+        expr = F("label") == "vehicle"
+        vehicles = F("detections.detections").filter(expr)
+
+        # Composing expressions should not mutate arguments in-place
+        self.assertFalse(expr.is_frozen)
+
+        clips = dataset.to_clips(vehicles.length() >= 2)
+
+        dataset.save_view("clips", clips)
+
+        also_clips = dataset.load_saved_view("clips")
+
+        # Here we're making sure that serializing + reloading a view that
+        # involves the `ToClips` stage successfully detects that it can reuse
+        # the same `_state`
+        self.assertTrue(clips is not also_clips)
+        self.assertEqual(clips._dataset.name, also_clips._dataset.name)
+
     def test_make_optimized_select_view_group_dataset(self):
         dataset, sample_ids = self._make_group_dataset()
 

--- a/tests/unittests/view_tests.py
+++ b/tests/unittests/view_tests.py
@@ -4393,12 +4393,7 @@ class ViewStageTests(unittest.TestCase):
         dataset = fo.Dataset()
         dataset.add_samples([sample1, sample2, sample3])
 
-        expr = F("label") == "vehicle"
-        vehicles = F("detections.detections").filter(expr)
-
-        # Composing expressions should not mutate arguments in-place
-        self.assertFalse(expr.is_frozen)
-
+        vehicles = F("detections.detections").filter(F("label") == "vehicle")
         clips = dataset.to_clips(vehicles.length() >= 2)
 
         dataset.save_view("clips", clips)


### PR DESCRIPTION
```py
import fiftyone as fo
import fiftyone.zoo as foz
from fiftyone import ViewField as F

dataset = foz.load_zoo_dataset("quickstart-video")

vehicles = F("detections.detections").filter(F("label") == "vehicle")
clips = dataset.to_clips(vehicles.length() >= 2)

dataset.save_view("clips", clips)

also_clips = dataset.load_saved_view("clips")

# Bugfix: `ToClips._state` should not change, so existing `_dataset` is now reused
assert clips is not also_clips
assert clips._dataset.name == also_clips._dataset.name  # previously failed
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new method to handle expressions with a specific prefix.
  
- **Bug Fixes**
  - Improved handling of expressions to prevent in-place modifications, ensuring data integrity during operations.

- **Tests**
  - Added tests to verify correct behavior of view creation and serialization with frozen expressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->