### PR TITLE
add force option to open_panel operation

### DIFF
--- a/app/packages/operators/src/built-in-operators.ts
+++ b/app/packages/operators/src/built-in-operators.ts
@@ -136,6 +136,10 @@ class OpenPanel extends Operator {
       default: true,
     });
     inputs.enum("layout", ["horizontal", "vertical"]);
+    inputs.bool("force", {
+      label: "Force (skips panel exists check)",
+      default: false,
+    });
     return new types.Property(inputs);
   }
   useHooks() {
@@ -158,15 +162,16 @@ class OpenPanel extends Operator {
   }
   async execute({ hooks, params }: ExecutionContext) {
     const { spaces, openedPanels, availablePanels } = hooks;
-    const { name, isActive, layout } = params;
+    const { name, isActive, layout, force } = params;
     const targetSpace = this.findFirstPanelContainer(spaces.root);
     if (!targetSpace) {
       return console.error("No panel container found");
     }
     const openedPanel = openedPanels.find(({ type }) => type === name);
     const panel = availablePanels.find((panel) => name === panel.name);
-    if (!panel) return console.warn(`Panel with name ${name} does not exist`);
-    const allowDuplicate = panel?.panelOptions?.allowDuplicates;
+    if (!panel && !force)
+      return console.warn(`Panel with name ${name} does not exist`);
+    const allowDuplicate = force ? true : panel?.panelOptions?.allowDuplicates;
     if (openedPanel && !allowDuplicate) {
       if (isActive) spaces.setNodeActive(openedPanel);
       return;

--- a/fiftyone/operators/operations.py
+++ b/fiftyone/operators/operations.py
@@ -247,7 +247,7 @@ class Operations(object):
             },
         )
 
-    def open_panel(self, name, is_active=True, layout=None):
+    def open_panel(self, name, is_active=True, layout=None, force=False):
         """Open a panel with the given name and layout options in the App.
 
         Args:
@@ -255,8 +255,10 @@ class Operations(object):
             is_active (True): whether to activate the panel immediately
             layout (None): the layout orientation
                 ``("horizontal", "vertical")``, if applicable
+            force (False): whether to force open the panel. Skips the check to see if a panel with
+                the same name exists or not. Note: this also skips allowDuplicates check
         """
-        params = {"name": name, "isActive": is_active}
+        params = {"name": name, "isActive": is_active, "force": force}
         if layout is not None:
             params["layout"] = layout
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

Add an option to force open a panel even if a panel by name is not yet registered. This is useful for launching panel which may be registered later

## How is this patch tested? If it is not, please explain why.

Using an operator with `on_startup` set to true:
```py
class AutoLaunchConfusionMatrices(foo.Operator):
    @property
    def config(self):
        return foo.OperatorConfig(
            name="python_panel_02_auto_launch_confusion_matrices",
            label="PythonPanel0.2: Auto Launch Confusion Matrices",
            unlisted=True,
            # on_dataset_open=True,
            on_startup=True,
        )

    def execute(self, ctx):
        ctx.ops.open_panel(
            "python_panel_02_confusion_matrices", layout="horizontal", force=True
        )
        return {}
```

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

See above

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a "force" option to the panel opening functionality, allowing users to open a panel without checking for an existing panel with the same name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->