### PR TITLE
Use `textContent` in `@fiftyone/looker`

### DIFF
--- a/app/packages/looker/src/elements/common/error.ts
+++ b/app/packages/looker/src/elements/common/error.ts
@@ -3,7 +3,7 @@
  */
 import copy from "copy-to-clipboard";
 
-import { BaseState, StateUpdate } from "../../state";
+import { BaseState } from "../../state";
 import { BaseElement } from "../base";
 
 import { AppError } from "@fiftyone/utilities";
@@ -61,7 +61,7 @@ export class ErrorElement<State extends BaseState> extends BaseElement<State> {
 
           if (isVideo) {
             const videoText = document.createElement("p");
-            videoText.textContent = `You can use
+            videoText.innerHTML = `You can use
               <code>
                 <a>
                   fiftyone.utils.video.reencode_videos()

--- a/app/packages/looker/src/elements/common/error.ts
+++ b/app/packages/looker/src/elements/common/error.ts
@@ -61,7 +61,7 @@ export class ErrorElement<State extends BaseState> extends BaseElement<State> {
 
           if (isVideo) {
             const videoText = document.createElement("p");
-            videoText.innerHTML = `You can use
+            videoText.textContent = `You can use
               <code>
                 <a>
                   fiftyone.utils.video.reencode_videos()

--- a/app/packages/looker/src/elements/common/tags.test.ts
+++ b/app/packages/looker/src/elements/common/tags.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { getFieldAndValue } from "./tags";
+import { applyTagValue, getFieldAndValue } from "./tags";
 
 const TEST_SAMPLE = {
   metadata: {
@@ -161,5 +161,13 @@ describe(`
       "test.str_list_field"
     );
     expect(resultField.name).toEqual("str_list_field");
+  });
+});
+
+describe("applyTagValue", () => {
+  it("prevents XSS", () => {
+    const xss = "<img src=# onerror=alert('XSS')>";
+    const div = applyTagValue("white", "path", "title", xss);
+    expect(div.textContent).toEqual(xss);
   });
 });

--- a/app/packages/looker/src/elements/common/tags.ts
+++ b/app/packages/looker/src/elements/common/tags.ts
@@ -41,8 +41,6 @@ import { BaseElement } from "../base";
 import { lookerTags } from "./tags.module.css";
 import { getAssignedColor, prettify } from "./util";
 
-import _ from "lodash";
-
 interface TagData {
   color: string;
   title: string;
@@ -90,7 +88,7 @@ export class TagsElement<State extends BaseState> extends BaseElement<State> {
     if (this.playing !== playing) {
       this.playing = playing;
       if (playing) {
-        this.element.innerHTML = "";
+        this.element.textContent = "";
         return this.element;
       }
     } else if (
@@ -425,7 +423,7 @@ export class TagsElement<State extends BaseState> extends BaseElement<State> {
     this.colorBy = coloring.by;
     this.colorSeed = coloring.seed;
     this.activePaths = [...activePaths];
-    this.element.innerHTML = "";
+    this.element.textContent = "";
     this.customizedColors = customizeColorSetting;
     this.labelTagColors = labelTagColors;
     this.colorPool = coloring.pool as string[];
@@ -440,24 +438,35 @@ export class TagsElement<State extends BaseState> extends BaseElement<State> {
     elements
       .filter((e) => Boolean(e))
       .forEach(({ path, value, color, title }) => {
-        const div = document.createElement("div");
-        const child = prettify(value);
-        child instanceof HTMLElement
-          ? div.appendChild(child)
-          : (div.innerHTML = child);
-        div.title = title;
-        div.style.backgroundColor = color;
-        const tagValue = value.replace(/[\s.,/]/g, "-").toLowerCase();
-        const attribute = ["tags", "_label_tags"].includes(path)
-          ? `tag-${path}-${tagValue}`
-          : `tag-${path}`;
-        div.setAttribute("data-cy", attribute);
-        this.element.appendChild(div);
+        this.element.appendChild(applyTagValue(color, path, title, value));
       });
 
     return this.element;
   }
 }
+
+export const applyTagValue = (
+  color: string,
+  path: string,
+  title: string,
+  value: string
+) => {
+  const div = document.createElement("div");
+  const child = prettify(value);
+  child instanceof HTMLElement
+    ? div.appendChild(child)
+    : (div.textContent = child);
+
+  div.title = title;
+  div.style.backgroundColor = color;
+
+  const tagValue = value.replace(/[\s.,/]/g, "-").toLowerCase();
+  const attribute = ["tags", "_label_tags"].includes(path)
+    ? `tag-${path}-${tagValue}`
+    : `tag-${path}`;
+  div.setAttribute("data-cy", attribute);
+  return div;
+};
 
 const arraysAreEqual = (a: any[], b: any[]): boolean => {
   if (a === b) return true;

--- a/app/packages/looker/src/elements/common/util.ts
+++ b/app/packages/looker/src/elements/common/util.ts
@@ -65,7 +65,7 @@ export const makeCheckboxRow = function (
   const label = document.createElement("label");
   label.setAttribute("data-cy", `looker-checkbox-${text}`);
   label.classList.add(lookerLabel);
-  label.innerHTML = text;
+  label.textContent = text;
 
   const checkbox = document.createElement("input");
   checkbox.setAttribute("data-cy", `looker-checkbox-input-${text}`);
@@ -91,7 +91,7 @@ export const prettify = (
     const a = document.createElement("a");
     a.onclick = onClick;
     a.href = url;
-    a.innerHTML = url;
+    a.textContent = url;
     return a;
   }
 

--- a/app/packages/looker/src/elements/frame.ts
+++ b/app/packages/looker/src/elements/frame.ts
@@ -26,7 +26,11 @@ export class FrameNumberElement extends BaseElement<FrameState> {
     config: { frameRate, frameNumber },
   }: Readonly<FrameState>) {
     if (duration) {
-      this.element.innerHTML = getFrameString(frameNumber, duration, frameRate);
+      this.element.textContent = getFrameString(
+        frameNumber,
+        duration,
+        frameRate
+      );
     }
     return this.element;
   }

--- a/app/packages/looker/src/elements/imavid/frame-count.ts
+++ b/app/packages/looker/src/elements/imavid/frame-count.ts
@@ -12,7 +12,7 @@ export class FrameCountElement extends BaseElement<ImaVidState> {
   }
 
   renderSelf({ currentFrameNumber, config }: Readonly<ImaVidState>) {
-    this.element.innerHTML = `${currentFrameNumber} / ${
+    this.element.textContent = `${currentFrameNumber} / ${
       config.frameStoreController.totalFrameCount || 1
     }`;
     return this.element;

--- a/app/packages/looker/src/elements/imavid/play-button.ts
+++ b/app/packages/looker/src/elements/imavid/play-button.ts
@@ -119,7 +119,7 @@ export class PlayButtonElement extends BaseElement<
       this.isBuffering !== buffering ||
       !loaded
     ) {
-      this.element.innerHTML = "";
+      this.element.textContent = "";
       if (!loaded) {
         this.element.appendChild(this.buffering);
         this.element.title = "Loading";

--- a/app/packages/looker/src/elements/video.ts
+++ b/app/packages/looker/src/elements/video.ts
@@ -186,7 +186,7 @@ export class PlayButtonElement extends BaseElement<VideoState, HTMLDivElement> {
       this.isBuffering !== buffering ||
       !loaded
     ) {
-      this.element.innerHTML = "";
+      this.element.textContent = "";
       if (buffering || !loaded) {
         this.element.appendChild(this.buffering);
         this.element.title = "Loading";
@@ -378,14 +378,14 @@ export class TimeElement extends BaseElement<VideoState> {
     options: { useFrameNumber },
   }: Readonly<VideoState>) {
     if (typeof duration !== "number") {
-      this.element.innerHTML = "";
+      this.element.textContent = "";
       return this.element;
     }
 
     const timestamp = useFrameNumber
       ? getFrameString(frameNumber, duration, frameRate)
       : getFullTimeString(frameNumber, frameRate, duration);
-    this.element.innerHTML = timestamp;
+    this.element.textContent = timestamp;
     return this.element;
   }
 }


### PR DESCRIPTION
## What changes are proposed in this pull request?

Replaces `element.innerHTML` usage with `element.textContent`. In particular, Looker tags now use an `appleTagValue` function that prevents XSS

## How is this patch tested? If it is not, please explain why.

Unit test

## Release Notes

* Added XSS prevention for sample tag values in the grid

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Improved security by replacing `innerHTML` with `textContent` for various elements across multiple components.

- **Chores**
  - Removed unused `StateUpdate` import to clean up codebase.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->