### PR TITLE
add force_duplicate param for open_panel operation

### DIFF
--- a/app/packages/operators/src/built-in-operators.ts
+++ b/app/packages/operators/src/built-in-operators.ts
@@ -164,7 +164,7 @@ class OpenPanel extends Operator {
   }
   async execute({ hooks, params }: ExecutionContext) {
     const { spaces, openedPanels, availablePanels } = hooks;
-    const { name, isActive, layout, force } = params;
+    const { name, isActive, layout, force, forceDuplicate } = params;
     const targetSpace = this.findFirstPanelContainer(spaces.root);
     if (!targetSpace) {
       return console.error("No panel container found");
@@ -173,7 +173,9 @@ class OpenPanel extends Operator {
     const panel = availablePanels.find((panel) => name === panel.name);
     if (!panel && !force)
       return console.warn(`Panel with name ${name} does not exist`);
-    const allowDuplicate = force ? true : panel?.panelOptions?.allowDuplicates;
+    const allowDuplicate = force
+      ? Boolean(forceDuplicate)
+      : panel?.panelOptions?.allowDuplicates;
     if (openedPanel && !allowDuplicate) {
       if (isActive) spaces.setNodeActive(openedPanel);
       return;

--- a/fiftyone/operators/operations.py
+++ b/fiftyone/operators/operations.py
@@ -247,7 +247,14 @@ class Operations(object):
             },
         )
 
-    def open_panel(self, name, is_active=True, layout=None, force=False):
+    def open_panel(
+        self,
+        name,
+        is_active=True,
+        layout=None,
+        force=False,
+        force_duplicate=False,
+    ):
         """Open a panel with the given name and layout options in the App.
 
         Args:
@@ -257,8 +264,15 @@ class Operations(object):
                 ``("horizontal", "vertical")``, if applicable
             force (False): whether to force open the panel. Skips the check to see if a panel with
                 the same name exists or not. Note: this also skips allowDuplicates check
+            force_duplicate (False): whether to force open the panel even if it is already open.
+                Only applicable if force is ``True``
         """
-        params = {"name": name, "isActive": is_active, "force": force}
+        params = {
+            "name": name,
+            "isActive": is_active,
+            "force": force,
+            "forceDuplicate": force_duplicate,
+        }
         if layout is not None:
             params["layout"] = layout
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

Add a param to force open duplicate panel when force param is `True`

## How is this patch tested? If it is not, please explain why.

Using a test operator

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a `forceDuplicate` option in the panel opening functionality, allowing users to force-open a panel even if it is already open when `force` is enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->