### PR TITLE
fix markdown spacing

### DIFF
--- a/app/packages/core/src/plugins/SchemaIO/components/Markdown.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/Markdown.tsx
@@ -56,7 +56,8 @@ const CodeHeader = styled.div`
   background: ${({ theme }) => theme.background.level2};
 `;
 
-const defaultSx: SxProps = { color: "inherit" };
+const defaultSx: SxProps = { color: "inherit", mb: 1 };
+const boldSx: SxProps = { ...defaultSx, fontWeight: "bold" };
 
 const componentsMap = {
   a({ children, ...props }) {
@@ -72,7 +73,7 @@ const componentsMap = {
     }
 
     return (
-      <Link sx={defaultSx} {...props}>
+      <Link sx={{ color: "inherit", textDecoration: "underline" }} {...props}>
         {children}
       </Link>
     );
@@ -126,35 +127,44 @@ const componentsMap = {
     );
   },
   p: ({ children, ...props }) => (
-    <Typography sx={defaultSx}>{children}</Typography>
+    <Typography
+      sx={{
+        color: "inherit",
+        "&:not(:first-of-type)": {
+          mt: 1,
+        },
+      }}
+    >
+      {children}
+    </Typography>
   ),
   h1: ({ children, ...props }) => (
-    <Typography sx={defaultSx} variant="h1" {...props}>
+    <Typography sx={boldSx} variant="h1" {...props}>
       {children}
     </Typography>
   ),
   h2: ({ children, ...props }) => (
-    <Typography sx={defaultSx} variant="h2" {...props}>
+    <Typography sx={boldSx} variant="h2" {...props}>
       {children}
     </Typography>
   ),
   h3: ({ children, ...props }) => (
-    <Typography sx={defaultSx} variant="h3" {...props}>
+    <Typography sx={boldSx} variant="h3" {...props}>
       {children}
     </Typography>
   ),
   h4: ({ children, ...props }) => (
-    <Typography sx={defaultSx} variant="h4" {...props}>
+    <Typography sx={boldSx} variant="h4" {...props}>
       {children}
     </Typography>
   ),
   h5: ({ children, ...props }) => (
-    <Typography sx={defaultSx} variant="h5" {...props}>
+    <Typography sx={boldSx} variant="h5" {...props}>
       {children}
     </Typography>
   ),
   h6: ({ children, ...props }) => (
-    <Typography sx={defaultSx} variant="h6" {...props}>
+    <Typography sx={boldSx} variant="h6" {...props}>
       {children}
     </Typography>
   ),


### PR DESCRIPTION
Adds 1 margin between paragraphs and 1 margin (bottom) below all headings.

<img width="1116" alt="image" src="https://github.com/voxel51/fiftyone/assets/462228/84acbc99-44d9-4226-963b-3eb8451282ab">


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Enhanced visual presentation for Markdown headers (`h1` to `h6`) with bold styling.
  - Updated link styling to include underline and inherit color properties.
  - Added margin adjustments for better spacing between Markdown elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->