### PR TITLE
Add support for annotating clip views

### DIFF
--- a/fiftyone/utils/annotations.py
+++ b/fiftyone/utils/annotations.py
@@ -218,6 +218,12 @@ def annotate(
             % (anno_backend.config.name, samples.media_type)
         )
 
+    if samples._is_clips and not anno_backend.supports_clip_views:
+        raise ValueError(
+            "Backend '%s' does not support annotating clip views"
+            % anno_backend.config.name
+        )
+
     label_schema, samples = _build_label_schema(
         samples,
         anno_backend,
@@ -2026,6 +2032,11 @@ class AnnotationBackend(foa.AnnotationMethod):
         raise NotImplementedError(
             "subclass must implement supported_attr_types"
         )
+
+    @property
+    def supports_clip_views(self):
+        """Whether this backend supports annotating clip views."""
+        return False
 
     @property
     def supports_keyframes(self):

--- a/fiftyone/utils/annotations.py
+++ b/fiftyone/utils/annotations.py
@@ -218,9 +218,9 @@ def annotate(
             % (anno_backend.config.name, samples.media_type)
         )
 
-    if samples._is_clips and not anno_backend.supports_clip_views:
+    if samples._is_clips and not anno_backend.supports_clips_views:
         raise ValueError(
-            "Backend '%s' does not support annotating clip views"
+            "Backend '%s' does not support annotating clips views"
             % anno_backend.config.name
         )
 
@@ -2034,8 +2034,8 @@ class AnnotationBackend(foa.AnnotationMethod):
         )
 
     @property
-    def supports_clip_views(self):
-        """Whether this backend supports annotating clip views."""
+    def supports_clips_views(self):
+        """Whether this backend supports annotating clips views."""
         return False
 
     @property

--- a/fiftyone/utils/cvat.py
+++ b/fiftyone/utils/cvat.py
@@ -3254,6 +3254,10 @@ class CVATBackend(foua.AnnotationBackend):
         ]
 
     @property
+    def supports_clip_views(self):
+        return True
+
+    @property
     def supports_keyframes(self):
         return True
 

--- a/fiftyone/utils/cvat.py
+++ b/fiftyone/utils/cvat.py
@@ -4562,6 +4562,9 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
         )
 
         if is_clips:
+            # We must store clip start frame numbers because this information
+            # is required when downloading annotations to map the CVAT frame
+            # IDs back to the correct frame numbers
             frame_starts = [s[0] for s in samples.values("support")]
             results.id_map["_clips_frame_start"] = dict(
                 zip(task_ids, frame_starts)

--- a/fiftyone/utils/cvat.py
+++ b/fiftyone/utils/cvat.py
@@ -3254,7 +3254,7 @@ class CVATBackend(foua.AnnotationBackend):
         ]
 
     @property
-    def supports_clip_views(self):
+    def supports_clips_views(self):
         return True
 
     @property

--- a/fiftyone/utils/labelbox.py
+++ b/fiftyone/utils/labelbox.py
@@ -696,9 +696,7 @@ class LabelboxAnnotationAPI(foua.AnnotationAPI):
         labels_json = self._download_project_labels(project=project)
 
         dataset = results.samples._root_dataset
-        is_video = dataset._contains_videos(any_slice=True) and any(
-            dataset._is_frame_field(f) for f in label_schema.keys()
-        )
+        is_video = any(dataset._is_frame_field(f) for f in label_schema.keys())
 
         annotations = {}
 

--- a/fiftyone/utils/labelbox.py
+++ b/fiftyone/utils/labelbox.py
@@ -622,12 +622,6 @@ class LabelboxAnnotationAPI(foua.AnnotationAPI):
         classes_as_attrs = config.classes_as_attrs
         is_video = samples.media_type == fomm.VIDEO
 
-        if samples._is_clips:
-            raise ValueError(
-                "The Labelbox backend does not yet support annotating clip "
-                "views"
-            )
-
         for label_field, label_info in label_schema.items():
             if label_info["existing_field"]:
                 raise ValueError(

--- a/tests/intensive/cvat_tests.py
+++ b/tests/intensive/cvat_tests.py
@@ -1728,6 +1728,150 @@ class CVATTests(unittest.TestCase):
             ),
         )
 
+    def test_clips_view(self):
+        dataset = foz.load_zoo_dataset(
+            "quickstart-video", max_samples=2
+        ).clone()
+
+        sample = dataset.first()
+
+        def gen_temp_dets():
+            temp_dets = [
+                fo.TemporalDetection(label="test", support=[10, 20]),
+                fo.TemporalDetection(label="test2", support=[30, 40]),
+            ]
+            return fo.TemporalDetections(detections=temp_dets)
+
+        dataset.set_values(
+            "clips", [gen_temp_dets() for _ in range(len(dataset))]
+        )
+        view = dataset.to_clips("clips")
+
+        prev_ids = dataset.values(
+            "frames.detections.detections.id", unwind=True
+        )
+
+        # Test successful upload and download of annotations
+        anno_key = "anno_key_1"
+        results = view.annotate(
+            anno_key,
+            backend="cvat",
+            label_field="frames.detections",
+        )
+        with results:
+            api = results.connect_to_api()
+            task_id = results.task_ids[0]
+            shape_id = dataset.first().frames[11].detections.detections[0].id
+            self.assertIsNotNone(_get_shape(api, task_id, shape_id))
+
+            clip_id = list(list(results.frame_id_map.values())[0].values())[0][
+                "sample_id"
+            ]
+            self.assertEqual(clip_id, view.first().id)
+
+            sample_id = results.id_map["_clips"][clip_id]
+            self.assertEqual(sample_id, view.first().sample_id)
+
+            frame_id = list(list(results.frame_id_map.values())[0].values())[
+                0
+            ]["frame_id"]
+            self.assertEqual(frame_id, view.values("frames.id")[0][0])
+
+        dataset.reload()
+        view.load_annotations(anno_key, cleanup=True)
+
+        self.assertListEqual(
+            prev_ids,
+            dataset.values("frames.detections.detections.id", unwind=True),
+        )
+
+        # Test creating new shapes, tags and tracks
+        anno_key = "anno_key_2"
+        results = view.annotate(
+            anno_key,
+            backend="cvat",
+            label_schema={
+                "frames.detections_new": {
+                    "type": "detections",
+                    "classes": ["test_track", "test_shape"],
+                },
+                "frames.tags_new": {
+                    "type": "classification",
+                    "classes": ["test_tag"],
+                },
+            },
+        )
+        track_start = 5
+        track_end = 10
+        shape_frame = 1
+        tag_frame = 1
+        with results:
+            api = results.connect_to_api()
+            task_id = results.task_ids[0]
+            _create_annotation(
+                api,
+                task_id,
+                track=(track_start, track_end),
+                _label="test_track",
+            )
+            shape = {
+                "type": "rectangle",
+                "frame": shape_frame,
+                "label_id": _get_label(api, task_id, label="test_shape"),
+                "group": 0,
+                "attributes": [],
+                "points": [10, 20, 30, 40],
+                "occluded": False,
+            }
+            _create_annotation(api, task_id, shape=shape)
+            tag = {
+                "frame": tag_frame,
+                "label_id": _get_label(api, task_id, label="test_tag"),
+                "group": 0,
+                "attributes": [],
+            }
+            _create_annotation(api, task_id, tag=tag)
+
+        dataset.load_annotations(anno_key, cleanup=True)
+
+        start = 10
+        remapped_track_start = start + track_start
+        remapped_track_end = start + track_end
+        remapped_track_ids = list(
+            range(remapped_track_start, remapped_track_end)
+        )
+
+        remapped_shape_ids = [shape_frame + start]
+        remapped_tag_ids = [tag_frame + start]
+
+        track_view = dataset.filter_labels(
+            "frames.detections_new", F("label") == "test_track"
+        )
+        shape_view = dataset.filter_labels(
+            "frames.detections_new", F("label") == "test_shape"
+        )
+
+        self.assertListEqual(
+            remapped_track_ids,
+            track_view.match_frames(
+                F("detections_new.detections").length() > 0
+            ).values("frames.frame_number", unwind=True),
+        )
+
+        self.assertListEqual(
+            remapped_shape_ids,
+            shape_view.match_frames(
+                F("detections_new.detections").length() > 0
+            ).values("frames.frame_number", unwind=True),
+        )
+
+        self.assertListEqual(
+            remapped_tag_ids,
+            dataset.match_frames(F("tags_new").exists()).values(
+                "frames.frame_number", unwind=True
+            ),
+        )
+
 
 if __name__ == "__main__":
     fo.config.show_progress_bars = False


### PR DESCRIPTION
Adds support for passing clip views to `annotate()`.

So far only the CVAT backend supports clip views.

Unlike [frame views](https://github.com/voxel51/fiftyone/pull/4477), there may be a minor amount of backend-specific work required to support clips rather than full videos. For example, in the case of CVAT, a touch of work was required when uploading the videos (as frames) and then when mapping CVAT frame IDs to the correct frame numbers during annotation download.

```py
import fiftyone as fo
import fiftyone.zoo as foz

dataset = foz.load_zoo_dataset("quickstart-video")

# Three clips into the same sample
clips = dataset.limit(1).to_clips([[(10, 20), (30, 40), (50, 60)]])

# Three clips into different samples
# clips = dataset.limit(3).to_clips([[(10, 20)], [(30, 40)], [(50, 60)]])

anno_key = "test"
clips.annotate(
    anno_key,
    backend="cvat",
    label_field="frames.detections",
    label_type="detections",
    classes=["vehicle"],
    project_name=anno_key,
    launch_editor=True,
)

# Add, edit, and delete vehicle labels...

dataset.load_annotations(anno_key)

session = fo.launch_app(dataset)
```
