### PR TITLE
fix resolve output for operators in app

### DIFF
--- a/app/packages/operators/src/operators.ts
+++ b/app/packages/operators/src/operators.ts
@@ -86,6 +86,10 @@ export type RawContext = {
   requestDelegation: boolean;
   state: CallbackInterface;
   analyticsInfo: AnalyticsInfo;
+  extendedSelection: {
+    selection: string[] | null;
+    scope: string;
+  };
 };
 
 export class ExecutionContext {
@@ -99,7 +103,7 @@ export class ExecutionContext {
     this.state = _currentContext.state;
   }
   public delegationTarget: string = null;
-  public requestDelegation: boolean = false;
+  public requestDelegation = false;
   public currentPanel?: Panel = null;
   public get datasetName(): string {
     return this._currentContext.datasetName;
@@ -777,6 +781,8 @@ export async function resolveRemoteType(
       operator_uri: operatorURI,
       params: ctx.params,
       request_delegation: ctx.requestDelegation,
+      results: results ? results.result : null,
+      target,
       selected: currentContext.selectedSamples
         ? Array.from(currentContext.selectedSamples)
         : [],


### PR DESCRIPTION
## What changes are proposed in this pull request?

(Please fill in changes proposed in this fix)

## How is this patch tested? If it is not, please explain why.

(Details)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced the `RawContext` to include an `extendedSelection` field for better selection handling.

- **Refactor**
  - Simplified initialization of `requestDelegation` in `ExecutionContext`.

- **Bug Fixes**
  - Improved `resolveRemoteType` function with additional `results` and `target` parameters for more accurate remote type resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->