### PR TITLE
fix operator browser error details clipped

### DIFF
--- a/app/packages/operators/src/OperatorBrowser.tsx
+++ b/app/packages/operators/src/OperatorBrowser.tsx
@@ -159,7 +159,19 @@ export default function OperatorBrowser() {
             )}
             <ErrorView
               schema={{
-                view: { detailed: true, popout: true, left: true },
+                view: {
+                  detailed: true,
+                  popout: true,
+                  componentsProps: {
+                    container: {
+                      popoutStyles: {
+                        maxWidth: "45vw",
+                        right: 0,
+                        left: "unset",
+                      },
+                    },
+                  },
+                },
               }}
               data={initializationErrors}
             />


### PR DESCRIPTION
## What changes are proposed in this pull request?

Fixed issue where error stack trace on operators browser was getting clipped

## How is this patch tested? If it is not, please explain why.

Using the operator browser

### Before:
![image](https://github.com/voxel51/fiftyone/assets/25350704/178fc967-8017-475f-a734-eef19e6790f4)


### After:
![image](https://github.com/voxel51/fiftyone/assets/25350704/e1f29a9a-cc28-4c76-a2fd-eb189179b89e)


## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

See above

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the error view component with improved styling options for a better user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->