### PR TITLE
fix missing python panel load error trace

### DIFF
--- a/app/packages/operators/src/CustomPanel.tsx
+++ b/app/packages/operators/src/CustomPanel.tsx
@@ -1,52 +1,24 @@
-import { useEffect, useState } from "react";
-import { useRecoilValue } from "recoil";
 import { CenteredStack, CodeBlock } from "@fiftyone/components";
-import {
-  PanelSkeleton,
-  usePanelState,
-  useSetCustomPanelState,
-} from "@fiftyone/spaces";
+import { PanelSkeleton } from "@fiftyone/spaces";
 import * as fos from "@fiftyone/state";
 import { Box, Typography } from "@mui/material";
-import { merge } from "lodash";
 import OperatorIO from "./OperatorIO";
 import { PANEL_LOAD_TIMEOUT } from "./constants";
-import { executeOperator } from "./operators";
-import * as types from "./types";
+import { Property } from "./types";
 
-import {
-  useCustomPanelHooks,
-  CustomPanelHooks,
-  CustomPanelProps,
-} from "./useCustomPanelHooks";
+import { CustomPanelProps, useCustomPanelHooks } from "./useCustomPanelHooks";
 
 export function CustomPanel(props: CustomPanelProps) {
-  const {
-    panelId,
-    onLoad,
-    onChange,
-    onUnLoad,
-    onChangeCtx,
-    onChangeView,
-    onChangeDataset,
-    onChangeCurrentSample,
-    onChangeSelected,
-    onChangeSelectedLabels,
-    onChangeExtendedSelection,
-    dimensions,
-    panelName,
-    panelLabel,
-  } = props;
+  const { panelId, dimensions, panelName, panelLabel } = props;
   const { height, width } = dimensions?.bounds || {};
 
   const {
-    panelState,
     handlePanelStateChange,
     handlePanelStatePathChange,
     panelSchema,
     data,
+    onLoadError,
   } = useCustomPanelHooks(props);
-  const onLoadError = panelState?.onLoadError;
   const pending = fos.useTimeout(PANEL_LOAD_TIMEOUT);
 
   if (pending && !panelSchema && !onLoadError) {
@@ -73,7 +45,7 @@ export function CustomPanel(props: CustomPanelProps) {
       </CenteredStack>
     );
 
-  const schema = types.Property.fromJSON(panelSchema);
+  const schema = Property.fromJSON(panelSchema);
 
   return (
     <Box sx={{ height: "100%", width: "100%" }}>

--- a/app/packages/operators/src/useCustomPanelHooks.ts
+++ b/app/packages/operators/src/useCustomPanelHooks.ts
@@ -35,12 +35,16 @@ export interface CustomPanelProps {
 }
 
 export interface CustomPanelHooks {
-  panelState: any;
-  handlePanelStateChange: Function;
-  handlePanelStatePathChange: Function;
-  data: any;
-  panelSchema: any;
+  handlePanelStateChange: (state: unknown) => unknown;
+  handlePanelStatePathChange: (
+    path: string,
+    value: unknown,
+    schema: unknown
+  ) => void;
+  data: unknown;
+  panelSchema: unknown;
   loaded: boolean;
+  onLoadError?: string;
 }
 
 function useCtxChangePanelEvent(loaded, panelId, value, operator) {
@@ -73,7 +77,7 @@ export function useCustomPanelHooks(props: CustomPanelProps): CustomPanelHooks {
     state: panelState,
   });
   const ctx = useGlobalExecutionContext();
-  const isLoaded = useMemo(() => {
+  const isLoaded: boolean = useMemo(() => {
     return panelStateLocal?.loaded;
   }, [panelStateLocal?.loaded]);
 
@@ -205,11 +209,12 @@ export function useCustomPanelHooks(props: CustomPanelProps): CustomPanelHooks {
   };
 
   return {
-    panelState,
+    loaded: isLoaded,
     handlePanelStateChange,
     handlePanelStatePathChange,
     data,
     panelSchema,
+    onLoadError: panelStateLocal?.onLoadError,
   };
 }
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

(Please fill in changes proposed in this fix)

## How is this patch tested? If it is not, please explain why.

(Details)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved state management and performance of the Custom Panel component.
  - Optimized the handling of panel state changes and schema integration.

- **New Features**
  - Enhanced error handling with the introduction of `onLoadError` for Custom Panels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->