### PR TITLE
fix space persistence issue between datasets

### DIFF
--- a/app/packages/core/src/components/MainSpace/MainSpace.tsx
+++ b/app/packages/core/src/components/MainSpace/MainSpace.tsx
@@ -10,10 +10,7 @@ const { FIFTYONE_SPACE_ID } = constants;
 function MainSpace() {
   const [sessionSpaces, setSessionSpaces, sessionPanelsState] =
     useSessionSpaces();
-  const { spaces, updateSpaces, clearSpaces } = useSpaces(
-    FIFTYONE_SPACE_ID,
-    sessionSpaces
-  );
+  const { spaces, updateSpaces } = useSpaces(FIFTYONE_SPACE_ID, sessionSpaces);
   const [panelsState, setPanelsState] = usePanelsState();
   const setPanelStateUpdatesCount = useSetRecoilState(
     panelsStateUpdatesCountAtom
@@ -21,8 +18,6 @@ function MainSpace() {
   const oldSpaces = useRef(spaces);
   const oldPanelsState = useRef(panelsState);
   const isMounted = useRef(false);
-
-  useEffect(() => clearSpaces, [clearSpaces]);
 
   useEffect(() => {
     if (!spaces.equals(sessionSpaces)) {


### PR DESCRIPTION
## What changes are proposed in this pull request?

(Please fill in changes proposed in this fix)

## How is this patch tested? If it is not, please explain why.

(Details)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Optimized the `MainSpace` component by removing unnecessary `clearSpaces` function and associated `useEffect` hook.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->