### PR TITLE
overridable panel not found component

### DIFF
--- a/app/packages/plugins/src/index.ts
+++ b/app/packages/plugins/src/index.ts
@@ -231,6 +231,17 @@ export function useActivePlugins(type: PluginComponentType, ctx: any) {
 }
 
 /**
+ * A react hook that returns a component plugin by name if exist.
+ * @param name The name of the plugin
+ * @param ctx Argument passed to the plugin's activator function
+ * @returns The plugin component or `undefined`
+ */
+export function usePluginComponent(name: string, ctx?: unknown) {
+  const plugins = useActivePlugins(PluginComponentType.Component, ctx);
+  return plugins.find((p) => p.name === name);
+}
+
+/**
  * The type of plugin component.
  *
  * - `Panel` - A panel that can be added to `@fiftyone/spaces`

--- a/app/packages/spaces/src/components/Panel.tsx
+++ b/app/packages/spaces/src/components/Panel.tsx
@@ -1,15 +1,16 @@
 import { CenteredStack } from "@fiftyone/components";
 import * as fos from "@fiftyone/state";
-import { Typography } from "@mui/material";
 import React from "react";
 import { PANEL_LOADING_TIMEOUT } from "../constants";
 import { PanelContext } from "../contexts";
 import { useReactivePanel } from "../hooks";
 import { PanelProps } from "../types";
+import PanelNotFound from "./PanelNotFound";
 import PanelSkeleton from "./PanelSkeleton";
 import { StyledPanel } from "./StyledElements";
 
-function Panel({ node }: PanelProps) {
+function Panel(props: PanelProps) {
+  const { node } = props;
   const panelName = node.type as string;
   const panel = useReactivePanel(panelName);
   const dimensions = fos.useDimensions();
@@ -22,9 +23,7 @@ function Panel({ node }: PanelProps) {
           {pending ? (
             <PanelSkeleton />
           ) : (
-            <Typography>
-              Panel &quot;{panelName}&quot; no longer exists!
-            </Typography>
+            <PanelNotFound panelName={panelName} {...props} />
           )}
         </CenteredStack>
       </StyledPanel>

--- a/app/packages/spaces/src/components/PanelNotFound.tsx
+++ b/app/packages/spaces/src/components/PanelNotFound.tsx
@@ -1,0 +1,18 @@
+import { usePluginComponent } from "@fiftyone/plugins";
+import { Typography } from "@mui/material";
+import { PanelProps } from "../types";
+
+export default function PanelNotFound(props: PanelNotFoundPropsType) {
+  const { panelName } = props;
+  const CustomPanelNotFound = usePluginComponent("PanelNotFound")?.component;
+
+  if (CustomPanelNotFound) {
+    return <CustomPanelNotFound {...props} />;
+  }
+
+  return (
+    <Typography>Panel &quot;{panelName}&quot; no longer exists!</Typography>
+  );
+}
+
+type PanelNotFoundPropsType = PanelProps & { panelName: string };


### PR DESCRIPTION
## What changes are proposed in this pull request?

Overridable panel not found component

## How is this patch tested? If it is not, please explain why.

Using plugin component named `PanelNotFound`

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

See above

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a `usePluginComponent` function to retrieve plugin components by name from active plugins.
	- Added a `PanelNotFound` component to handle scenarios where a panel is not found, displaying a custom message.

- **Refactor**
	- Updated the `Panel` component to destructure props and utilize the new `PanelNotFound` component for better error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->