### PR TITLE
make dynamic groups work for fo3d files

### DIFF
--- a/app/packages/state/src/recoil/groups.ts
+++ b/app/packages/state/src/recoil/groups.ts
@@ -452,7 +452,7 @@ export const fo3dContent = atom({
 export const fo3dSample = selector({
   key: "fo3dSample",
   get: ({ get }) => {
-    if (!get(isGroup)) return get(modalSample);
+    if (!get(isGroup) || get(isDynamicGroup)) return get(modalSample);
 
     if (!get(hasFo3dSlice)) return null;
 

--- a/app/packages/state/src/recoil/groups.ts
+++ b/app/packages/state/src/recoil/groups.ts
@@ -452,7 +452,11 @@ export const fo3dContent = atom({
 export const fo3dSample = selector({
   key: "fo3dSample",
   get: ({ get }) => {
-    if (!get(isGroup) || get(isDynamicGroup)) return get(modalSample);
+    if (!get(isGroup)) return get(modalSample);
+
+    if (get(isDynamicGroup) && !get(hasFo3dSlice)) {
+      return get(modalSample);
+    }
 
     if (!get(hasFo3dSlice)) return null;
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

The app wasn't allowing creation of dynamic groups for fo3d media type. This PR fixes the bug.

### Before
![image](https://github.com/voxel51/fiftyone/assets/66688606/6be636af-934f-42fb-9052-d83337dbb853)

### After
![2024-06-24 15 23 59](https://github.com/voxel51/fiftyone/assets/66688606/a6809799-4e6c-44c7-b1b8-9271a0e24eca)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved logic for dynamic group handling, leading to better performance and accuracy in group-based features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->