### PR TITLE
fix jpeg heatmap issue

### DIFF
--- a/app/packages/looker/src/worker/index.ts
+++ b/app/packages/looker/src/worker/index.ts
@@ -154,7 +154,7 @@ const imputeOverlayFromPath = async (
 
   let overlayData;
 
-  if (overlayImageUrl.endsWith(".jpg")) {
+  if (overlayImageUrl.endsWith(".jpg") || overlayImageUrl.endsWith(".jpeg")) {
     overlayData = decodeJpg(overlayImageBuffer, { useTArray: true });
   } else {
     overlayData = decodePng(overlayImageBuffer);


### PR DESCRIPTION
We've had jpg decoding working for a while, but there was an incomplete conditional that didn't check for `.jpeg` extension (in addition to `.jpg`). This PR fixes that.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for handling JPEG images in addition to JPG images.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->