### PR TITLE
Add PR number and author to Teams workflow

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -32,7 +32,11 @@ jobs:
           workflow_file_name: merge-oss.yml
           ref: develop
           wait_interval: 20
-          client_payload: '{ "branch": "${{ github.head_ref || github.ref_name }}" }'
+          client_payload: |
+            {
+              "branch": "${{ github.head_ref || github.ref_name }}",
+              "pr": "${{ github.event.number }}"
+            }
           propagate_failure: true
           trigger_workflow: true
           wait_workflow: true

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -34,9 +34,9 @@ jobs:
           wait_interval: 20
           client_payload: |
             {
-              "author": ${{ github.event.pull_request.user.login }},
+              "author": "${{ github.event.pull_request.user.login }}",
               "branch": "${{ github.head_ref || github.ref_name }}",
-              "pr": "${{ github.event.pull_request.number }}"
+              "pr": ${{ github.event.pull_request.number }}
             }
           propagate_failure: true
           trigger_workflow: true

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -34,8 +34,9 @@ jobs:
           wait_interval: 20
           client_payload: |
             {
+              "author": ${{ github.event.pull_request.user.login }},
               "branch": "${{ github.head_ref || github.ref_name }}",
-              "pr": "${{ github.event.number }}"
+              "pr": "${{ github.event.pull_request.number }}"
             }
           propagate_failure: true
           trigger_workflow: true


### PR DESCRIPTION
## What changes are proposed in this pull request?

Adds the PR number and author from OSS to Teams automation for internal processing. The body input has been dropped in favor of an internal definition

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [x] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated GitHub workflow to include pull request number in the payload.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->