### PR TITLE
Add Ubuntu 24.04 `fiftyone-db` support

### DIFF
--- a/.github/workflows/build-db.yml
+++ b/.github/workflows/build-db.yml
@@ -66,9 +66,10 @@ jobs:
           python -Im build --sdist
       - name: Upload
         uses: actions/upload-artifact@v3
+        if: ${{ matrix.platform == 'sdist' }}
         with:
           name: dist-${{ matrix.platform }}
-          path: package/db/dist/*
+          path: package/db/dist/*.tar.gz
       - name: Upload wheel
         if: ${{ matrix.platform != 'sdist' }}
         uses: actions/upload-artifact@v3

--- a/package/db/setup.py
+++ b/package/db/setup.py
@@ -95,6 +95,10 @@ LINUX_DOWNLOADS = {
             "aarch64": "https://fastdl.mongodb.org/linux/mongodb-linux-aarch64-ubuntu2204-7.0.4.tgz",
             "x86_64": "https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-ubuntu2204-7.0.4.tgz",
         },
+        "24": {
+            "aarch64": "https://fastdl.mongodb.org/linux/mongodb-linux-aarch64-ubuntu2204-7.0.4.tgz",
+            "x86_64": "https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-ubuntu2204-7.0.4.tgz",
+        },
     },
 }
 
@@ -139,7 +143,7 @@ def _get_download():
 MONGODB_BINARIES = ["mongod"]
 
 
-VERSION = "1.1.3"
+VERSION = "1.1.4"
 
 
 def get_version():


### PR DESCRIPTION
## What changes are proposed in this pull request?

Resolves #4526 

## How is this patch tested? If it is not, please explain why.

Confirmed functionality in #4526  discussion

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [x] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Updated MongoDB setup to include new version support and download links.
- **Chores**
	- Updated artifact upload paths in build workflows to improve distribution handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->