### PR TITLE
expose camera position via recoil atom

### DIFF
--- a/app/packages/looker-3d/src/state.ts
+++ b/app/packages/looker-3d/src/state.ts
@@ -5,6 +5,11 @@ import { SHADE_BY_HEIGHT } from "./constants";
 import { FoSceneNode } from "./hooks";
 import { Actions, ShadeBy } from "./types";
 
+export const cameraPositionAtom = atom<[number, number, number] | null>({
+  key: "fo3d-cameraPosition",
+  default: null,
+});
+
 export const shadeByAtom = atom<ShadeBy>({
   key: "fo3d-shadeBy",
   default: SHADE_BY_HEIGHT,


### PR DESCRIPTION
This PR exposes camera position as a recoil atom so that operators can write to it dynamically and change camera pose. I tested it with a simple built-in JS operator (not part of the PR).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit


- **New Features**
	- Enhanced 3D viewer with new camera position settings based on user input.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->