### PR TITLE
unsupport python 3.7, deprecate python 3.8

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,21 +37,12 @@ jobs:
       matrix:
         os:
           - ubuntu-latest-m
-          - windows-latest
         python:
           - "3.8"
           - "3.9"
           - "3.10"
           - "3.11"
-        exclude:
-          - os: windows-latest
-            python: "3.8"
-          - os: windows-latest
-            python: "3.9"
-          - os: windows-latest
-            python: "3.10"
-          - os: windows-latest
-            python: "3.11"
+          - "3.12"
     defaults:
       run:
         shell: bash

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,11 +40,14 @@ jobs:
           - windows-latest
         python:
           - "3.8"
+          - "3.9"
           - "3.10"
           - "3.11"
         exclude:
           - os: windows-latest
             python: "3.8"
+          - os: windows-latest
+            python: "3.9"
           - os: windows-latest
             python: "3.10"
           - os: windows-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,12 +37,21 @@ jobs:
       matrix:
         os:
           - ubuntu-latest-m
+          - windows-latest
         python:
           - "3.8"
           - "3.9"
           - "3.10"
           - "3.11"
-          - "3.12"
+        exclude:
+          - os: windows-latest
+            python: "3.8"
+          - os: windows-latest
+            python: "3.9"
+          - os: windows-latest
+            python: "3.10"
+          - os: windows-latest
+            python: "3.11"
     defaults:
       run:
         shell: bash

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ to make adjustments. If you are working in Google Colab,
 
 You will need:
 
--   [Python](https://www.python.org) (3.8, 3.9, 3.10, or 3.11)
+-   [Python](https://www.python.org) (3.8 - 3.11)
 -   [Node.js](https://nodejs.org) - on Linux, we recommend using
     [nvm](https://github.com/nvm-sh/nvm) to install an up-to-date version.
 -   [Yarn](https://yarnpkg.com) - once Node.js is installed, you can

--- a/README.md
+++ b/README.md
@@ -135,8 +135,9 @@ You will need:
 -   [Python](https://www.python.org) (3.8 or newer)
 -   [Node.js](https://nodejs.org) - on Linux, we recommend using
     [nvm](https://github.com/nvm-sh/nvm) to install an up-to-date version.
--   [Yarn](https://yarnpkg.com) - once Node.js is installed, you can install
-    Yarn via `npm install -g yarn`
+-   [Yarn](https://yarnpkg.com) - once Node.js is installed, you can
+    [enable Yarn](https://yarnpkg.com/getting-started/install) via
+	`corepack enable`
 -   On Linux, you will need at least the `openssl` and `libcurl` packages. On
     Debian-based distributions, you will need to install `libcurl4` or
     `libcurl3` instead of `libcurl`, depending on the age of your distribution.

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ to make adjustments. If you are working in Google Colab,
 
 You will need:
 
--   [Python](https://www.python.org) (3.8 or newer)
+-   [Python](https://www.python.org) (3.8, 3.9, 3.10, or 3.11)
 -   [Node.js](https://nodejs.org) - on Linux, we recommend using
     [nvm](https://github.com/nvm-sh/nvm) to install an up-to-date version.
 -   [Yarn](https://yarnpkg.com) - once Node.js is installed, you can

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ to make adjustments. If you are working in Google Colab,
 
 You will need:
 
--   [Python](https://www.python.org) (3.7 or newer)
+-   [Python](https://www.python.org) (3.8 or newer)
 -   [Node.js](https://nodejs.org) - on Linux, we recommend using
     [nvm](https://github.com/nvm-sh/nvm) to install an up-to-date version.
 -   [Yarn](https://yarnpkg.com) - once Node.js is installed, you can install

--- a/docs/source/deprecation.rst
+++ b/docs/source/deprecation.rst
@@ -11,7 +11,7 @@ Python 3.8
 transitions to `end-of-life` effective October of 2024. FiftyOne releases after
 September 30, 2024 will no longer support Python 3.8.
 
-Versions of `fiftyone` after 0.24.1, or after `fiftyone` Teams version 0.18.0,
+Versions of `fiftyone` after 0.24.1, or after FiftyOne Teams SDK version 0.18.0,
 will provide a deprecation notice when `fiftyone` is imported using Python 3.8.
 
 You can disable this deprecation notice by setting the

--- a/docs/source/deprecation.rst
+++ b/docs/source/deprecation.rst
@@ -1,0 +1,19 @@
+FiftyOne Deprecation Notices
+============================
+
+.. default-role:: code
+
+Python 3.8
+----------
+*Support Ends October 2024*
+
+`Python 3.8 <https://devguide.python.org/versions/>`_
+transitions to `end-of-life` effective October of 2024. FiftyOne releases after
+September 30, 2024 will no longer support Python 3.8.
+
+Versions of `fiftyone` after 0.24.1, or after `fiftyone` Teams version 0.18.0,
+will provide a deprecation notice when `fiftyone` is imported using Python 3.8.
+
+You can disable this deprecation notice by setting the
+`FIFTYONE_PYTHON_38_DEPRECATION_NOTICE` environment variable to `false` prior
+to importing `fiftyone`.

--- a/docs/source/getting_started/install.rst
+++ b/docs/source/getting_started/install.rst
@@ -20,7 +20,7 @@ Prerequisites
 -------------
 
 You will need a working Python installation. FiftyOne currently requires
-**Python 3.8 - 3.12**
+**Python 3.8 - 3.11**
 
 
 On Linux, we recommend installing Python through your system package manager

--- a/docs/source/getting_started/install.rst
+++ b/docs/source/getting_started/install.rst
@@ -20,7 +20,7 @@ Prerequisites
 -------------
 
 You will need a working Python installation. FiftyOne currently requires
-**Python 3.7 - 3.12**
+**Python 3.8 - 3.12**
 
 
 On Linux, we recommend installing Python through your system package manager

--- a/docs/source/getting_started/troubleshooting.rst
+++ b/docs/source/getting_started/troubleshooting.rst
@@ -44,9 +44,9 @@ old, you may encounter errors like these:
 
 .. code-block:: text
 
-    fiftyone requires Python '>=3.7' but the running Python is 3.4.10
+    fiftyone requires Python '>=3.8' but the running Python is 3.4.10
 
-To resolve this, you will need to use Python 3.7 or newer, and pip 19.3 or
+To resolve this, you will need to use Python 3.8 or newer, and pip 19.3 or
 newer. See the :ref:`installation guide <installing-fiftyone>` for details. If
 you have installed a suitable version of Python in a virtual environment and
 still encounter this error, ensure that the virtual environment is activated.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -414,4 +414,5 @@ us at support@voxel51.com.
    CLI <cli/index>
    API Reference <api/fiftyone>
    Release Notes <release-notes>
+   Deprecation Notices <deprecation>
    FAQ <faq/index>

--- a/fiftyone/__init__.py
+++ b/fiftyone/__init__.py
@@ -9,6 +9,22 @@ See https://voxel51.com/fiftyone for more information.
 """
 
 from pkgutil import extend_path as _extend_path
+from sys import hexversion
+from os import getenv
+
+# Python 3.8 goes EoL in October, 2024
+#  We should tell folks we won't support those Python versions after 9/24
+
+PYTHON_38_NOTICE = getenv(
+    'FIFTYONE_PYTHON_38_DEPRECATION_NOTICE', "True"
+) == "True"
+
+if hexversion < 0x30900f0 and hexversion >= 0x30800f0 and PYTHON_38_NOTICE:
+    print("***Python 3.8 Deprecation Notice***")
+    print("Python 3.8 will no longer be supported in new releases after October"
+          " 1, 2024.")
+    print("Please upgrade to Python 3.9 or later.")
+    print("For additional details please see https://deprecation.voxel51.com")
 
 #
 # This statement allows multiple `fiftyone.XXX` packages to be installed in the

--- a/fiftyone/__init__.py
+++ b/fiftyone/__init__.py
@@ -8,6 +8,7 @@ See https://voxel51.com/fiftyone for more information.
 |
 """
 
+from logging import warning
 from pkgutil import extend_path as _extend_path
 from sys import hexversion
 from os import getenv
@@ -20,11 +21,11 @@ PYTHON_38_NOTICE = getenv(
 ) == "True"
 
 if hexversion < 0x30900f0 and hexversion >= 0x30800f0 and PYTHON_38_NOTICE:
-    print("***Python 3.8 Deprecation Notice***")
-    print("Python 3.8 will no longer be supported in new releases after October"
-          " 1, 2024.")
-    print("Please upgrade to Python 3.9 or later.")
-    print("For additional details please see https://deprecation.voxel51.com")
+    warning("***Python 3.8 Deprecation Notice***")
+    warning("Python 3.8 will no longer be supported in new releases after"
+            "October 1, 2024.")
+    warning("Please upgrade to Python 3.9 or later.")
+    warning("For additional details please see https://deprecation.voxel51.com")
 
 #
 # This statement allows multiple `fiftyone.XXX` packages to be installed in the

--- a/fiftyone/__init__.py
+++ b/fiftyone/__init__.py
@@ -8,10 +8,13 @@ See https://voxel51.com/fiftyone for more information.
 |
 """
 
-from logging import warning
+import logging
+from os import getenv
 from pkgutil import extend_path as _extend_path
 from sys import hexversion
-from os import getenv
+
+
+logger = logging.getLogger(__name__)
 
 # Python 3.8 goes EoL in October, 2024
 #  We should tell folks we won't support those Python versions after 9/24
@@ -21,11 +24,12 @@ PYTHON_38_NOTICE = getenv(
 ) == "True"
 
 if hexversion < 0x30900f0 and hexversion >= 0x30800f0 and PYTHON_38_NOTICE:
-    warning("***Python 3.8 Deprecation Notice***")
-    warning("Python 3.8 will no longer be supported in new releases after"
-            "October 1, 2024.")
-    warning("Please upgrade to Python 3.9 or later.")
-    warning("For additional details please see https://deprecation.voxel51.com")
+    logger.warning("***Python 3.8 Deprecation Notice***")
+    logger.warning("Python 3.8 will no longer be supported in new releases"
+                   " after October 1, 2024.")
+    logger.warning("Please upgrade to Python 3.9 or later.")
+    logger.warning("For additional details please see"
+                   " https://deprecation.voxel51.com")
 
 #
 # This statement allows multiple `fiftyone.XXX` packages to be installed in the

--- a/package/db/setup.py
+++ b/package/db/setup.py
@@ -294,11 +294,10 @@ setup(
         "Operating System :: POSIX :: Linux",
         "Operating System :: Microsoft :: Windows",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
     ],
-    python_requires=">=3.7",
+    python_requires=">=3.8",
     cmdclass=cmdclass,
 )

--- a/package/db/setup.py
+++ b/package/db/setup.py
@@ -299,6 +299,6 @@ setup(
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
     ],
-    python_requires=">=3.8,<3.12",
+    python_requires=">=3.8",
     cmdclass=cmdclass,
 )

--- a/package/db/setup.py
+++ b/package/db/setup.py
@@ -297,7 +297,8 @@ setup(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
     ],
-    python_requires=">=3.8",
+    python_requires=">=3.8,<3.12",
     cmdclass=cmdclass,
 )

--- a/package/desktop/setup.py
+++ b/package/desktop/setup.py
@@ -190,6 +190,7 @@ setup(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
     ],
     python_requires=">=3.8",
     cmdclass=cmdclass,

--- a/package/desktop/setup.py
+++ b/package/desktop/setup.py
@@ -187,11 +187,10 @@ setup(
         "Operating System :: POSIX :: Linux",
         "Operating System :: Microsoft :: Windows",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
     ],
-    python_requires=">=3.7",
+    python_requires=">=3.8",
     cmdclass=cmdclass,
 )

--- a/package/graphql/setup.py
+++ b/package/graphql/setup.py
@@ -57,5 +57,5 @@ setup(
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
     ],
-    python_requires=">=3.8,<3.12",
+    python_requires=">=3.8",
 )

--- a/package/graphql/setup.py
+++ b/package/graphql/setup.py
@@ -55,6 +55,7 @@ setup(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
     ],
-    python_requires=">=3.8",
+    python_requires=">=3.8,<3.12",
 )

--- a/package/graphql/setup.py
+++ b/package/graphql/setup.py
@@ -52,10 +52,9 @@ setup(
         "Operating System :: POSIX :: Linux",
         "Operating System :: Microsoft :: Windows",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
     ],
-    python_requires=">=3.7",
+    python_requires=">=3.8",
 )

--- a/setup.py
+++ b/setup.py
@@ -157,7 +157,6 @@ setup(
         "Operating System :: POSIX :: Linux",
         "Operating System :: Microsoft :: Windows",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
@@ -165,5 +164,5 @@ setup(
         "Programming Language :: Python :: 3.12",
     ],
     entry_points={"console_scripts": ["fiftyone=fiftyone.core.cli:main"]},
-    python_requires=">=3.7",
+    python_requires=">=3.8",
 )

--- a/setup.py
+++ b/setup.py
@@ -163,5 +163,5 @@ setup(
         "Programming Language :: Python :: 3.11",
     ],
     entry_points={"console_scripts": ["fiftyone=fiftyone.core.cli:main"]},
-    python_requires=">=3.8,<3.12",
+    python_requires=">=3.8",
 )

--- a/setup.py
+++ b/setup.py
@@ -161,8 +161,7 @@ setup(
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
-        "Programming Language :: Python :: 3.12",
     ],
     entry_points={"console_scripts": ["fiftyone=fiftyone.core.cli:main"]},
-    python_requires=">=3.8",
+    python_requires=">=3.8,<3.12",
 )


### PR DESCRIPTION
## What changes are proposed in this pull request?

Python 3.7 will no longer import `fiftyone` as of the 0.24.0 release.
- This PR removes Python 3.7 as an install target from the FiftyOne ecosystem.
- This PR updates documentation to reference Python 3.8

Python 3.8 [will go EOL](https://devguide.python.org/versions/) in October of 2024
- This PR introduces a deprecation notice when `fiftyone` is imported in a Python 3.8 environment
- This PR introduces a `FIFTYONE_PYTHON_38_DEPRECATION_NOTICE` env var to bypass the deprecation notce
- This PR creates a new `FiftyOne Deprecation Notices` page with information regarding the deprecation

## How is this patch tested? If it is not, please explain why.

```
root@b2d4a3697f02:/# python --version
Python 3.8.0
root@b2d4a3697f02:/# python -c 'import fiftyone as fo'
***Python 3.8 Deprecation Notice***
Python 3.8 will no longer be supported in new releases after October 1, 2024.
Please upgrade to Python 3.9 or later.
For additional details please see https://deprecation.voxel51.com
root@b2d4a3697f02:/# export FIFTYONE_PYTHON_38_DEPRECATION_NOTICE=false
root@b2d4a3697f02:/# python -c 'import fiftyone as fo'
root@b2d4a3697f02:/#

root@1d0574990290:/# python --version
Python 3.9.0
root@1d0574990290:/# python -c 'import fiftyone as fo'
root@1d0574990290:/#
```

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

Python 3.8 [will go EOL](https://devguide.python.org/versions/) in October of 2024.  FiftyOne will no longer support Python 3.8 in releases after September of 2024.

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added deprecation notices for Python 3.8 support, effective October 2024.

- **Documentation**
  - Updated installation, troubleshooting, and setup instructions to require Python 3.8 to 3.11.
  - Added a "Deprecation Notices" link under the FAQ section.

- **Chores**
  - Updated Python version requirements across various setup files to drop support for Python 3.7 and add support for Python 3.11.
  - Modified workflow configuration to add support for Python 3.9.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->