### PR TITLE
event path

### DIFF
--- a/app/packages/core/src/plugins/SchemaIO/components/ButtonView.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/ButtonView.tsx
@@ -32,6 +32,7 @@ function BaseButtonView(props) {
 }
 
 function OperatorButtonView(props) {
+  const path = props.path;
   let { operator, params = {}, prompt } = props.schema.view;
   const panelId = usePanelId();
   const handleClick = usePanelEvent();
@@ -39,6 +40,7 @@ function OperatorButtonView(props) {
     <BaseButtonView
       {...props}
       onClick={() => {
+        params = { ...params, path };
         handleClick(panelId, { params, operator, prompt });
       }}
     />

--- a/app/packages/core/src/plugins/SchemaIO/components/PlotlyView.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/PlotlyView.tsx
@@ -9,7 +9,7 @@ import { HeaderView } from ".";
 import { getComponentProps } from "../utils";
 
 export default function PlotlyView(props) {
-  const { data, schema } = props;
+  const { data, schema, path } = props;
   const { view = {} } = schema;
   const { config = {}, layout = {} } = view;
   const theme = useTheme();
@@ -17,6 +17,7 @@ export default function PlotlyView(props) {
   let range = [0, 0];
   const triggerPanelEvent = usePanelEvent();
   const handleEvent = (event?: string) => (e) => {
+    console.log(props);
     // TODO: add more interesting/useful event data
     const data = EventDataMappers[event]?.(e) || {};
     const x_data_source = view.x_data_source;
@@ -71,6 +72,10 @@ export default function PlotlyView(props) {
           type: view.type,
         };
       }
+      params = {
+        ...params,
+        path,
+      };
       triggerPanelEvent(panelId, {
         operator: eventHandlerOperator,
         params,


### PR DESCRIPTION
Add "path" param for plot and button events...

```python
class MyPanel(foo.Panel):
    def render():
        # ...
        panel.plot('plot1', on_click=self.on_click)
        panel.plot('plot2', on_click=self.on_click)
    
    def on_click(ctx):
        # which plot was clicked?
        print(ctx.params.get('path')) # "plot1" or "plot2"
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced `ButtonView` and `PlotlyView` components to support a new `path` property in their props.
  - Improved logging and parameter handling in `PlotlyView` to include the `path` property.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->