### PR TITLE
More robust handling of multiple config docs

### DIFF
--- a/fiftyone/core/odm/database.py
+++ b/fiftyone/core/odm/database.py
@@ -114,6 +114,7 @@ def get_db_config():
         # this information is required in order to run migrations...
         #
         config.version = foc.VERSION
+        if db_config.type != foc.CLIENT_TYPE:
         save = True
 
     if config.type is None:

--- a/fiftyone/core/odm/database.py
+++ b/fiftyone/core/odm/database.py
@@ -136,9 +136,6 @@ def get_db_config():
 
 
 def _handle_multiple_config_docs(conn, config_docs):
-    # Use the newest one
-    keep_doc = max(config_docs, key=lambda d: d["_id"])
-
     if fo.config.database_admin:
         logger.warning(
             "Unexpectedly found %d documents in the 'config' collection; "
@@ -152,7 +149,12 @@ def _handle_multiple_config_docs(conn, config_docs):
             [{"$sort": {"_id": -1}}, {"$limit": 1}, {"$out": "config"}]
         )
 
-    return keep_doc
+        config_doc = next(iter(conn.config.find()))
+    else:
+        # Use the newest one
+        config_doc = max(config_docs, key=lambda d: d["_id"])
+
+    return config_doc
 
 
 def establish_db_conn(config):

--- a/fiftyone/core/odm/database.py
+++ b/fiftyone/core/odm/database.py
@@ -91,29 +91,29 @@ def get_db_config():
         a :class:`DatabaseConfigDocument`
     """
     conn = get_db_conn()
-    save = False
+
     config_docs = list(conn.config.find())
-    if not config_docs:
-        save = True
-        config = DatabaseConfigDocument(conn)
-    elif len(config_docs) > 1:
-        config = DatabaseConfigDocument(
-            conn, **cleanup_multiple_config_docs(conn, config_docs)
-        )
+    if config_docs:
+        if len(config_docs) > 1:
+            config_doc = _cleanup_multiple_config_docs(conn, config_docs)
+        else:
+            config_doc = config_docs[0]
+
+        config = DatabaseConfigDocument(conn, **config_doc)
+        save = False
     else:
-        config = DatabaseConfigDocument(conn, **config_docs[0])
+        config = DatabaseConfigDocument(conn)
+        save = True
 
     if config.version is None:
         #
-        # The database version was added to this config in v0.15.0, so if no
-        # version is available, assume the database is at the preceding
-        # release. It's okay if the database's version is actually older,
-        # because there are no significant admin migrations prior to v0.14.4.
+        # If the database has no version, then assume the version of the client
+        # that is currently connecting to it.
         #
         # This needs to be implemented here rather than in a migration because
         # this information is required in order to run migrations...
         #
-        config.version = "0.14.4"
+        config.version = foc.VERSION
         save = True
 
     if config.type is None:
@@ -135,25 +135,19 @@ def get_db_config():
     return config
 
 
-def cleanup_multiple_config_docs(conn, config_docs):
-    """Internal utility that ensures that there is only one
-    :class:`DatabaseConfigDocument` in the database.
-    """
-
+def _cleanup_multiple_config_docs(conn, config_docs):
     if not config_docs:
         return {}
-    elif len(config_docs) <= 1:
+
+    if len(config_docs) <= 1:
         return config_docs[0]
 
     logger.warning(
         "Unexpectedly found %d documents in the 'config' collection; assuming "
-        "the one with latest 'version' is the correct one",
+        "the newest one is the correct one",
         len(config_docs),
     )
-    # Keep config with latest version. If no version key, use 0.0 so it sorts
-    #   to the bottom.
-    keep_doc = max(config_docs, key=lambda d: Version(d.get("version", "0.0")))
-
+    keep_doc = max(config_docs, key=lambda d: d["_id"])
     conn.config.delete_many({"_id": {"$ne": keep_doc["_id"]}})
     return keep_doc
 

--- a/fiftyone/core/odm/database.py
+++ b/fiftyone/core/odm/database.py
@@ -213,7 +213,7 @@ def establish_db_conn(config):
     connect(config.database_name, **_connection_kwargs)
 
     db_config = get_db_config()
-    if foc.CLIENT_TYPE != db_config.type:
+    if db_config.type != foc.CLIENT_TYPE:
         raise ConnectionError(
             "Cannot connect to database type '%s' with client type '%s'"
             % (db_config.type, foc.CLIENT_TYPE)

--- a/fiftyone/core/odm/database.py
+++ b/fiftyone/core/odm/database.py
@@ -114,7 +114,6 @@ def get_db_config():
         # this information is required in order to run migrations...
         #
         config.version = foc.VERSION
-        if db_config.type != foc.CLIENT_TYPE:
         save = True
 
     if config.type is None:

--- a/fiftyone/migrations/runner.py
+++ b/fiftyone/migrations/runner.py
@@ -115,6 +115,7 @@ def migrate_database_if_necessary(
 
     if config is None:
         config = foo.get_db_config()
+
     head = config.version
 
     default_destination = destination is None

--- a/tests/unittests/utils_tests.py
+++ b/tests/unittests/utils_tests.py
@@ -5,16 +5,20 @@ FiftyOne utilities unit tests.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
+from datetime import datetime
 import time
 import unittest
 from unittest.mock import MagicMock, patch
 
+from bson import ObjectId
 import numpy as np
 
 import fiftyone as fo
 import fiftyone.constants as foc
 import fiftyone.core.media as fom
 import fiftyone.core.odm as foo
+from fiftyone.core.odm.utils import load_dataset
 import fiftyone.core.utils as fou
 from fiftyone.migrations.runner import MigrationRunner
 
@@ -444,18 +448,26 @@ class ConfigTests(unittest.TestCase):
         orig_config = foo.get_db_config()
 
         # Add some duplicate documents
-        db.config.insert_one({"version": "0.14.4", "type": "fiftyone"})
-        db.config.insert_one({"version": "0.1.4", "type": "fiftyone"})
+        db.config.insert_one(
+            {
+                "_id": ObjectId.from_datetime(datetime(2022, 1, 1)),
+                "version": "0.14.4",
+                "type": "fiftyone",
+            }
+        )
+        db.config.insert_one(
+            {
+                "_id": ObjectId.from_datetime(datetime(2023, 1, 1)),
+                "version": "0.1.4",
+                "type": "fiftyone",
+            }
+        )
 
         # Ensure that duplicate documents are automatically cleaned up
         config = foo.get_db_config()
 
         self.assertEqual(len(list(db.config.aggregate([]))), 1)
         self.assertEqual(config, orig_config)
-
-
-from bson import ObjectId
-from fiftyone.core.odm.utils import load_dataset
 
 
 class TestLoadDataset(unittest.TestCase):


### PR DESCRIPTION
Under heavy concurrent SDK usage, some users have reported seeing the following error when connecting to the database:

```
OSError: Cannot connect to database v0.14.4 with client v0.24.0 (compatibility >=0.19,<0.25). See https://docs.voxel51.com/user_guide/config.html#database-migrations for more information
```

For context, the `config` collection is supposed to have exactly one document. However, if it were empty for some reason, then this error would occur. How could it be empty? I suspect that, under heavy concurrent usage, this function:
https://github.com/voxel51/fiftyone/blob/a5d2209903d3699be3d310a55ab1e518f858050a/fiftyone/core/odm/database.py#L101

could be subject to a race condition that accidentally deletes all config docs.

This PR makes two improvements to protect against such a race condition:
1. When there are multiple config docs, keep the newest one rather than the one with the latest `version`. Also, for extra protection, only delete the duplicate docs if `database_admin=True`
    - This is more robust to race conditions because `_id` are universally unique while the duplicate config docs likely have the same `version`, so the `max()` logic used to select which doc to keep may not be deterministic, thus causing concurrent sessions to accidentally delete *all* the config docs
    - Note that sorting by `_id` is equivalent to sorting by insertion date
2. When generating a new database config doc, directly insert the current `foc.VERSION` rather than `0.14.4`
    - `0.14.4` was previously being inserted to correctly handle migrating <0.14.4 databases up to 0.14.4 (when the `config` collection was introduced). However, the `0.14.4` release is now over 2 years old, so let's assume that everyone has already migrated up. Why? Because...
    - ... the benefit of this change is that *even if* the `config` collection still somehow becomes empty, the new doc will assume the current client version and thus the compatibility error that we're trying to avoid will no longer occur

I don't know for certain that this race condition is actually the reason that users are seeing the compatibility error, but this PR doesn't have any side effects so we might as well give it a shot 🚀 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved handling of database configuration, including better management of multiple config documents and setting default values for version and type.
  
- **Bug Fixes**
  - Enhanced selection of the newest configuration document to ensure more reliable behavior.

- **Tests**
  - Updated unit tests to ensure robust handling of new database configuration logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->