### PR TITLE
Add YOLOv10 and RT-DETR Models to Zoo

### DIFF
--- a/docs/source/integrations/ultralytics.rst
+++ b/docs/source/integrations/ultralytics.rst
@@ -52,7 +52,7 @@ the following sample dataset:
 Object detection
 ----------------
 
-You can directly pass Ultralytics YOLO detection models to
+You can directly pass Ultralytics `YOLO` or `RTDETR` detection models to
 :meth:`apply_model() <fiftyone.core.collections.SampleCollection.apply_model>`:
 
 .. code-block:: python
@@ -80,6 +80,10 @@ You can directly pass Ultralytics YOLO detection models to
     # model = YOLO("yolov10m.pt)
     # model = YOLO("yolov10l.pt)
     # model = YOLO("yolov10x.pt)
+
+    # RTDETR
+    # model = YOLO("rtdetr-l.pt")
+     # model = YOLO("rtdetr-x.pt")
 
     dataset.apply_model(model, label_field="boxes")
 
@@ -112,6 +116,7 @@ You can also load any of these models directly from the
     # model_name = "yolov8m-coco-torch"
     # model_name = "yolov9e-coco-torch"
     # model_name = "yolov10s-coco-torch"
+    # model_name = "rtdetr-l-coco-torch"
 
     model = foz.load_zoo_model(
         model_name,
@@ -132,7 +137,7 @@ available YOLO models that are compatible with Ultralytics or SuperGradients:
 
     print(foz.list_zoo_models(tags="yolo"))
 
-In general, model names will contain "yolov", followed by the version number,
+In general, YOLO model names will contain "yolov", followed by the version number,
 then the model size ("n", "s", "m",  "l", or "x"), and an indicator of the
 label classes ("coco" for MS COCO or "world" for open-world), followed by
 "torch".

--- a/docs/source/integrations/ultralytics.rst
+++ b/docs/source/integrations/ultralytics.rst
@@ -83,7 +83,7 @@ You can directly pass Ultralytics `YOLO` or `RTDETR` detection models to
 
     # RTDETR
     # model = YOLO("rtdetr-l.pt")
-     # model = YOLO("rtdetr-x.pt")
+    # model = YOLO("rtdetr-x.pt")
 
     dataset.apply_model(model, label_field="boxes")
 

--- a/docs/source/integrations/ultralytics.rst
+++ b/docs/source/integrations/ultralytics.rst
@@ -111,6 +111,7 @@ You can also load any of these models directly from the
     model_name = "yolov5l-coco-torch"
     # model_name = "yolov8m-coco-torch"
     # model_name = "yolov9e-coco-torch"
+    # model_name = "yolov10s-coco-torch"
 
     model = foz.load_zoo_model(
         model_name,

--- a/fiftyone/utils/ultralytics.py
+++ b/fiftyone/utils/ultralytics.py
@@ -445,7 +445,7 @@ class FiftyOneRTDETRModelConfig(FiftyOneYOLOModelConfig):
     """
 
     def __init__(self, d):
-        super().__init__(d)
+        pass
 
 
 class FiftyOneRTDETRModel(Model):

--- a/fiftyone/utils/ultralytics.py
+++ b/fiftyone/utils/ultralytics.py
@@ -12,8 +12,6 @@ import itertools
 import numpy as np
 from PIL import Image
 
-import eta.core.utils as etau
-
 from fiftyone.core.config import Config
 import fiftyone.core.labels as fol
 from fiftyone.core.models import Model
@@ -435,6 +433,68 @@ class FiftyOneYOLODetectionModel(FiftyOneYOLOModel):
         images = [Image.fromarray(arg) for arg in args]
         predictions = self.model(images, verbose=False)
         return self._format_predictions(predictions)
+
+
+class FiftyOneRTDETRModelConfig(FiftyOneYOLOModelConfig):
+    """Configuration for a :class:`FiftyOneRTDETRModel`.
+
+    Args:
+        model (None): an ``ultralytics.RTDETR`` model to use
+        model_name (None): the name of an ``ultralytics.RTDETR`` model to load
+        model_path (None): the path to an ``ultralytics.RTDETR`` model checkpoint
+    """
+
+    def __init__(self, d):
+        super().__init__(d)
+
+
+class FiftyOneRTDETRModel(Model):
+    """FiftyOne wrapper around an ``ultralytics.RTDETR`` model.
+
+    Args:
+        config: a :class:`FiftyOneRTDETRModelConfig`
+    """
+
+    def __init__(self, config):
+        self.config = config
+        self.model = self._load_model(config)
+
+    def _load_model(self, config):
+        if config.model is not None:
+            return config.model
+
+        if config.model_path is not None:
+            model = ultralytics.RTDETR(config.model_path)
+        elif config.model_name is not None:
+            model = ultralytics.RTDETR(config.model_name)
+        else:
+            model = ultralytics.RTDETR()
+
+        return model
+
+    @property
+    def media_type(self):
+        return "image"
+
+    @property
+    def ragged_batches(self):
+        return False
+
+    @property
+    def transforms(self):
+        return None
+
+    @property
+    def preprocess(self):
+        return False
+
+    def _format_predictions(self, predictions):
+        return to_detections(predictions)
+
+    def predict(self, arg):
+        image = Image.fromarray(arg)
+        predictions = self.model(image, verbose=False)
+        return self._format_predictions(predictions[0])
 
 
 class FiftyOneYOLOOBBModelConfig(FiftyOneYOLOModelConfig):

--- a/fiftyone/zoo/models/manifest-torch.json
+++ b/fiftyone/zoo/models/manifest-torch.json
@@ -2960,6 +2960,70 @@
             "date_added": "2024-07-01 19:22:51"
         },
         {
+            "base_name": "rtdetr-l-coco-torch",
+            "base_filename": "rtdetr-l-coco.pt",
+            "description": "RT-DETR-l model trained on COCO",
+            "source": "https://docs.ultralytics.com/models/rtdetr/",
+            "size_bytes": 66511432,
+            "manager": {
+                "type": "fiftyone.core.models.ModelManager",
+                "config": {
+                    "url": "https://github.com/ultralytics/assets/releases/download/v8.2.0/rtdetr-l.pt"
+                }
+            },
+            "default_deployment_config_dict": {
+                "type": "fiftyone.utils.ultralytics.FiftyOneRTDETRModel",
+                "config": {}
+            },
+            "requirements": {
+                "packages": [
+                    "torch>=1.7.0",
+                    "torchvision>=0.8.1",
+                    "ultralytics>=8.2.0"
+                ],
+                "cpu": {
+                    "support": true
+                },
+                "gpu": {
+                    "support": true
+                }
+            },
+            "tags": ["detection", "coco", "torch", "transformer"],
+            "date_added": "2024-07-01 19:22:51"
+        },
+        {
+            "base_name": "rtdetr-x-coco-torch",
+            "base_filename": "rtdetr-x-coco.pt",
+            "description": "RT-DETR-x model trained on COCO",
+            "source": "https://docs.ultralytics.com/models/rtdetr/",
+            "size_bytes": 135755662,
+            "manager": {
+                "type": "fiftyone.core.models.ModelManager",
+                "config": {
+                    "url": "https://github.com/ultralytics/assets/releases/download/v8.2.0/rtdetr-x.pt"
+                }
+            },
+            "default_deployment_config_dict": {
+                "type": "fiftyone.utils.ultralytics.FiftyOneRTDETRModel",
+                "config": {}
+            },
+            "requirements": {
+                "packages": [
+                    "torch>=1.7.0",
+                    "torchvision>=0.8.1",
+                    "ultralytics>=8.2.0"
+                ],
+                "cpu": {
+                    "support": true
+                },
+                "gpu": {
+                    "support": true
+                }
+            },
+            "tags": ["detection", "coco", "torch", "transformer"],
+            "date_added": "2024-07-01 19:22:51"
+        },
+        {
             "base_name": "yolov8s-world-torch",
             "base_filename": "yolov8s-world.pt",
             "description": "YOLOv8s-World model",

--- a/fiftyone/zoo/models/manifest-torch.json
+++ b/fiftyone/zoo/models/manifest-torch.json
@@ -2800,6 +2800,166 @@
             "date_added": "2024-04-02 19:22:51"
         },
         {
+            "base_name": "yolov10n-coco-torch",
+            "base_filename": "yolov10n-coco.pt",
+            "description": "YOLOv10-N model trained on COCO",
+            "source": "https://docs.ultralytics.com/models/yolov10/",
+            "size_bytes": 5860383,
+            "manager": {
+                "type": "fiftyone.core.models.ModelManager",
+                "config": {
+                    "url": "https://github.com/ultralytics/assets/releases/download/v8.2.0/yolov10n.pt"
+                }
+            },
+            "default_deployment_config_dict": {
+                "type": "fiftyone.utils.ultralytics.FiftyOneYOLODetectionModel",
+                "config": {}
+            },
+            "requirements": {
+                "packages": [
+                    "torch>=1.7.0",
+                    "torchvision>=0.8.1",
+                    "ultralytics>=8.2.0"
+                ],
+                "cpu": {
+                    "support": true
+                },
+                "gpu": {
+                    "support": true
+                }
+            },
+            "tags": ["detection", "coco", "torch", "yolo"],
+            "date_added": "2024-07-01 19:22:51"
+        },
+        {
+            "base_name": "yolov10s-coco-torch",
+            "base_filename": "yolov10s-coco.pt",
+            "description": "YOLOv10-S model trained on COCO",
+            "source": "https://docs.ultralytics.com/models/yolov10/",
+            "size_bytes": 16623111,
+            "manager": {
+                "type": "fiftyone.core.models.ModelManager",
+                "config": {
+                    "url": "https://github.com/ultralytics/assets/releases/download/v8.2.0/yolov10s.pt"
+                }
+            },
+            "default_deployment_config_dict": {
+                "type": "fiftyone.utils.ultralytics.FiftyOneYOLODetectionModel",
+                "config": {}
+            },
+            "requirements": {
+                "packages": [
+                    "torch>=1.7.0",
+                    "torchvision>=0.8.1",
+                    "ultralytics>=8.2.0"
+                ],
+                "cpu": {
+                    "support": true
+                },
+                "gpu": {
+                    "support": true
+                }
+            },
+            "tags": ["detection", "coco", "torch", "yolo"],
+            "date_added": "2024-07-01 19:22:51"
+        },
+        {
+            "base_name": "yolov10m-coco-torch",
+            "base_filename": "yolov10m-coco.pt",
+            "description": "YOLOv10-M model trained on COCO",
+            "source": "https://docs.ultralytics.com/models/yolov10/",
+            "size_bytes": 33643667,
+            "manager": {
+                "type": "fiftyone.core.models.ModelManager",
+                "config": {
+                    "url": "https://github.com/ultralytics/assets/releases/download/v8.2.0/yolov10m.pt"
+                }
+            },
+            "default_deployment_config_dict": {
+                "type": "fiftyone.utils.ultralytics.FiftyOneYOLODetectionModel",
+                "config": {}
+            },
+            "requirements": {
+                "packages": [
+                    "torch>=1.7.0",
+                    "torchvision>=0.8.1",
+                    "ultralytics>=8.2.0"
+                ],
+                "cpu": {
+                    "support": true
+                },
+                "gpu": {
+                    "support": true
+                }
+            },
+            "tags": ["detection", "coco", "torch", "yolo"],
+            "date_added": "2024-07-01 19:22:51"
+        },
+        {
+            "base_name": "yolov10l-coco-torch",
+            "base_filename": "yolov10l-coco.pt",
+            "description": "YOLOv10-L model trained on COCO",
+            "source": "https://docs.ultralytics.com/models/yolov10/",
+            "size_bytes": 52425230,
+            "manager": {
+                "type": "fiftyone.core.models.ModelManager",
+                "config": {
+                    "url": "https://github.com/ultralytics/assets/releases/download/v8.2.0/yolov10l.pt"
+                }
+            },
+            "default_deployment_config_dict": {
+                "type": "fiftyone.utils.ultralytics.FiftyOneYOLODetectionModel",
+                "config": {}
+            },
+            "requirements": {
+                "packages": [
+                    "torch>=1.7.0",
+                    "torchvision>=0.8.1",
+                    "ultralytics>=8.2.0"
+                ],
+                "cpu": {
+                    "support": true
+                },
+                "gpu": {
+                    "support": true
+                }
+            },
+            "tags": ["detection", "coco", "torch", "yolo"],
+            "date_added": "2024-07-01 19:22:51"
+        },
+        {
+            "base_name": "yolov10x-coco-torch",
+            "base_filename": "yolov10x-coco.pt",
+            "description": "YOLOv10-X model trained on COCO",
+            "source": "https://docs.ultralytics.com/models/yolov10/",
+            "size_bytes": 64395854,
+            "manager": {
+                "type": "fiftyone.core.models.ModelManager",
+                "config": {
+                    "url": "https://github.com/ultralytics/assets/releases/download/v8.2.0/yolov10x.pt"
+                }
+            },
+            "default_deployment_config_dict": {
+                "type": "fiftyone.utils.ultralytics.FiftyOneYOLODetectionModel",
+                "config": {}
+            },
+            "requirements": {
+                "packages": [
+                    "torch>=1.7.0",
+                    "torchvision>=0.8.1",
+                    "ultralytics>=8.2.0"
+                ],
+                "cpu": {
+                    "support": true
+                },
+                "gpu": {
+                    "support": true
+                }
+            },
+            "tags": ["detection", "coco", "torch", "yolo"],
+            "date_added": "2024-07-01 19:22:51"
+        },
+        {
             "base_name": "yolov8s-world-torch",
             "base_filename": "yolov8s-world.pt",
             "description": "YOLOv8s-World model",


### PR DESCRIPTION
## What changes are proposed in this pull request?

- Support for YOLOv10 and RT-DETR model checkpoints should be added via Ultralytics.
- Updated Integration docs


## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

Added support for loading all YOLOv10 and RT-DETR checkpoints via Ultralytics directly from the FiftyOne Model Zoo

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [x] Documentation: FiftyOne documentation changes
-   [x] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated integration guide to support Ultralytics `YOLO` and `RTDETR` models with `apply_model()` method.

- **New Features**
  - Added support for Ultralytics `RTDETR` models, including configuration and model handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->