### PR TITLE
Updated snippets for exporting dataset to use `load_dataset`

### DIFF
--- a/docs/source/user_guide/draw_labels.rst
+++ b/docs/source/user_guide/draw_labels.rst
@@ -32,7 +32,7 @@ your datasets that you have identified by constructing a |DatasetView|.
         import fiftyone as fo
 
         # The Dataset or DatasetView containing the samples you wish to draw
-        dataset_or_view = fo.Dataset(...)
+        dataset_or_view = fo.load_dataset(...)
 
         # The directory to which to write the annotated media
         output_dir = "/path/for/output"

--- a/docs/source/user_guide/export_datasets.rst
+++ b/docs/source/user_guide/export_datasets.rst
@@ -39,7 +39,7 @@ a |DatasetView| into any format of your choice via the basic recipe below.
         import fiftyone as fo
 
         # The Dataset or DatasetView containing the samples you wish to export
-        dataset_or_view = fo.Dataset(...)
+        dataset_or_view = fo.load_dataset(...)
 
         # The directory to which to write the exported dataset
         export_dir = "/path/for/export"
@@ -564,7 +564,7 @@ disk as follows:
         export_dir = "/path/for/images-dir"
 
         # The dataset or view to export
-        dataset_or_view = fo.Dataset(...)
+        dataset_or_view = fo.load_dataset(...)
 
         # Export the dataset
         dataset_or_view.export(
@@ -622,7 +622,7 @@ disk as follows:
         export_dir = "/path/for/videos-dir"
 
         # The dataset or view to export
-        dataset_or_view = fo.Dataset(...)
+        dataset_or_view = fo.load_dataset(...)
 
         # Export the dataset
         dataset_or_view.export(
@@ -680,7 +680,7 @@ disk as follows:
         export_dir = "/path/for/media-dir"
 
         # The dataset or view to export
-        dataset_or_view = fo.Dataset(...)
+        dataset_or_view = fo.load_dataset(...)
 
         # Export the dataset
         dataset_or_view.export(
@@ -828,7 +828,7 @@ disk in the above format as follows:
         label_field = "ground_truth"  # for example
 
         # The dataset or view to export
-        dataset_or_view = fo.Dataset(...)
+        dataset_or_view = fo.load_dataset(...)
 
         # Export the dataset
         dataset_or_view.export(
@@ -891,7 +891,7 @@ the input paths.
         label_field = "ground_truth"  # for example
 
         # The dataset or view to export
-        dataset_or_view = fo.Dataset(...)
+        dataset_or_view = fo.load_dataset(...)
 
         # Export labels using the basename of each image as keys
         dataset_or_view.export(
@@ -985,7 +985,7 @@ stored on disk in the above format as follows:
         label_field = "ground_truth"  # for example
 
         # The dataset or view to export
-        dataset_or_view = fo.Dataset(...)
+        dataset_or_view = fo.load_dataset(...)
 
         # Export the dataset
         dataset_or_view.export(
@@ -1061,7 +1061,7 @@ stored on disk in the above format as follows:
         label_field = "ground_truth"  # for example
 
         # The dataset or view to export
-        dataset_or_view = fo.Dataset(...)
+        dataset_or_view = fo.load_dataset(...)
 
         # Export the dataset
         dataset_or_view.export(
@@ -1151,7 +1151,7 @@ format as follows:
         label_field = "ground_truth"  # for example
 
         # The dataset or view to export
-        dataset_or_view = fo.Dataset(...)
+        dataset_or_view = fo.load_dataset(...)
 
         # Export the dataset
         dataset_or_view.export(
@@ -1277,7 +1277,7 @@ format as follows:
         label_field = "ground_truth"  # for example
 
         # The dataset or view to export
-        dataset_or_view = fo.Dataset(...)
+        dataset_or_view = fo.load_dataset(...)
 
         # Export the dataset
         dataset_or_view.export(
@@ -1340,7 +1340,7 @@ the input paths.
         label_field = "ground_truth"  # for example
 
         # The dataset or view to export
-        dataset_or_view = fo.Dataset(...)
+        dataset_or_view = fo.load_dataset(...)
 
         # Export labels using the basename of each image as keys
         dataset_or_view.export(
@@ -1502,7 +1502,7 @@ disk in the above format as follows:
         label_field = "ground_truth"  # for example
 
         # The dataset or view to export
-        dataset_or_view = fo.Dataset(...)
+        dataset_or_view = fo.load_dataset(...)
 
         # Export the dataset
         dataset_or_view.export(
@@ -1565,7 +1565,7 @@ the input paths.
         label_field = "ground_truth"  # for example
 
         # The dataset or view to export
-        dataset_or_view = fo.Dataset(...)
+        dataset_or_view = fo.load_dataset(...)
 
         # Export labels using the basename of each image as keys
         dataset_or_view.export(
@@ -1717,7 +1717,7 @@ format as follows:
         label_field = "ground_truth"  # for example
 
         # The dataset or view to export
-        dataset_or_view = fo.Dataset(...)
+        dataset_or_view = fo.load_dataset(...)
 
         # Export the dataset
         dataset_or_view.export(
@@ -1765,7 +1765,7 @@ the `labels_path` parameter instead of `export_dir`:
         label_field = "ground_truth"  # for example
 
         # The dataset or view to export
-        dataset_or_view = fo.Dataset(...)
+        dataset_or_view = fo.load_dataset(...)
 
         # Export labels
         dataset_or_view.export(
@@ -1890,7 +1890,7 @@ format as follows:
         label_field = "ground_truth"  # for example
 
         # The dataset or view to export
-        dataset_or_view = fo.Dataset(...)
+        dataset_or_view = fo.load_dataset(...)
 
         # Export the dataset
         dataset_or_view.export(
@@ -1929,7 +1929,7 @@ the `labels_path` parameter instead of `export_dir`:
         label_field = "ground_truth"  # for example
 
         # The dataset or view to export
-        dataset_or_view = fo.Dataset(...)
+        dataset_or_view = fo.load_dataset(...)
 
         # Export labels
         dataset_or_view.export(
@@ -2044,7 +2044,7 @@ format as follows:
         label_field = "ground_truth"  # for example
 
         # The dataset or view to export
-        dataset_or_view = fo.Dataset(...)
+        dataset_or_view = fo.load_dataset(...)
 
         # Export the dataset
         dataset_or_view.export(
@@ -2083,7 +2083,7 @@ the `labels_path` parameter instead of `export_dir`:
         label_field = "ground_truth"  # for example
 
         # The dataset or view to export
-        dataset_or_view = fo.Dataset(...)
+        dataset_or_view = fo.load_dataset(...)
 
         # Export labels
         dataset_or_view.export(
@@ -2194,7 +2194,7 @@ follows:
         label_field = "ground_truth"  # for example
 
         # The dataset or view to export
-        dataset_or_view = fo.Dataset(...)
+        dataset_or_view = fo.load_dataset(...)
 
         # Export the dataset
         dataset_or_view.export(
@@ -2241,7 +2241,7 @@ the `labels_path` parameter instead of `export_dir`:
         label_field = "ground_truth"  # for example
 
         # The dataset or view to export
-        dataset_or_view = fo.Dataset(...)
+        dataset_or_view = fo.load_dataset(...)
 
         # Export labels
         dataset_or_view.export(
@@ -2372,7 +2372,7 @@ follows:
 
     # The dataset or view to export
     # We assume the dataset uses sample tags to encode the splits to export
-    dataset_or_view = fo.Dataset(...)
+    dataset_or_view = fo.load_dataset(...)
 
     # Export the splits
     for split in splits:
@@ -2405,7 +2405,7 @@ the `labels_path` parameter instead of `export_dir`:
     label_field = "ground_truth"  # for example
 
     # The dataset or view to export
-    dataset_or_view = fo.Dataset(...)
+    dataset_or_view = fo.load_dataset(...)
 
     # Export labels
     dataset_or_view.export(
@@ -2506,7 +2506,7 @@ format as follows:
         label_field = "ground_truth"  # for example
 
         # The dataset or view to export
-        dataset_or_view = fo.Dataset(...)
+        dataset_or_view = fo.load_dataset(...)
 
         # Export the dataset
         dataset_or_view.export(
@@ -2604,7 +2604,7 @@ format as follows:
         label_field = "ground_truth"  # for example
 
         # The dataset or view to export
-        dataset_or_view = fo.Dataset(...)
+        dataset_or_view = fo.load_dataset(...)
 
         # Export the dataset
         dataset_or_view.export(
@@ -2643,7 +2643,7 @@ parameter instead of `export_dir`:
         label_field = "ground_truth"  # for example
 
         # The dataset or view to export
-        dataset_or_view = fo.Dataset(...)
+        dataset_or_view = fo.load_dataset(...)
 
         # Export labels
         dataset_or_view.export(
@@ -2810,7 +2810,7 @@ as follows:
         label_field = "ground_truth"  # for example
 
         # The dataset or view to export
-        dataset_or_view = fo.Dataset(...)
+        dataset_or_view = fo.load_dataset(...)
 
         # Export the dataset
         dataset_or_view.export(
@@ -2849,7 +2849,7 @@ the `labels_path` parameter instead of `export_dir`:
         label_field = "ground_truth"  # for example
 
         # The dataset or view to export
-        dataset_or_view = fo.Dataset(...)
+        dataset_or_view = fo.load_dataset(...)
 
         # Export labels
         dataset_or_view.export(
@@ -3017,7 +3017,7 @@ as follows:
         label_field = "ground_truth"  # for example
 
         # The dataset or view to export
-        dataset_or_view = fo.Dataset(...)
+        dataset_or_view = fo.load_dataset(...)
 
         # Export the dataset
         dataset_or_view.export(
@@ -3056,7 +3056,7 @@ the `labels_path` parameter instead of `export_dir`:
         label_field = "ground_truth"  # for example
 
         # The dataset or view to export
-        dataset_or_view = fo.Dataset(...)
+        dataset_or_view = fo.load_dataset(...)
 
         # Export labels
         dataset_or_view.export(
@@ -3157,7 +3157,7 @@ format as follows:
         label_field = "ground_truth"  # for example
 
         # The dataset or view to export
-        dataset_or_view = fo.Dataset(...)
+        dataset_or_view = fo.load_dataset(...)
 
         # Export the dataset
         dataset_or_view.export(
@@ -3257,7 +3257,7 @@ as follows:
         label_field = "ground_truth"  # for example
 
         # The dataset or view to export
-        dataset_or_view = fo.Dataset(...)
+        dataset_or_view = fo.load_dataset(...)
 
         # Export the dataset
         dataset_or_view.export(
@@ -3421,7 +3421,7 @@ follows:
         label_field = "ground_truth"  # for example
 
         # The dataset or view to export
-        dataset_or_view = fo.Dataset(...)
+        dataset_or_view = fo.load_dataset(...)
 
         # Export the dataset
         dataset_or_view.export(
@@ -3460,7 +3460,7 @@ the `labels_path` parameter instead of `export_dir`:
         label_field = "ground_truth"  # for example
 
         # The dataset or view to export
-        dataset_or_view = fo.Dataset(...)
+        dataset_or_view = fo.load_dataset(...)
 
         # Export labels
         dataset_or_view.export(
@@ -3540,7 +3540,7 @@ follows:
         export_dir = "/path/for/csv-dataset"
 
         # The dataset or view to export
-        dataset_or_view = fo.Dataset(...)
+        dataset_or_view = fo.load_dataset(...)
 
         # Export the dataset
         dataset_or_view.export(
@@ -3578,7 +3578,7 @@ parameter instead of `export_dir`:
         labels_path = "/path/for/labels.csv"
 
         # The dataset or view to export
-        dataset_or_view = fo.Dataset(...)
+        dataset_or_view = fo.load_dataset(...)
 
         # Export labels with absolute media paths
         dataset_or_view.export(
@@ -3695,7 +3695,7 @@ follows:
         export_dir = "/path/for/geojson-dataset"
 
         # The dataset or view to export
-        dataset_or_view = fo.Dataset(...)
+        dataset_or_view = fo.load_dataset(...)
 
         # Export the dataset
         dataset_or_view.export(
@@ -3731,7 +3731,7 @@ providing the `labels_path` parameter instead of `export_dir`:
         label_field = "ground_truth"  # for example
 
         # The dataset or view to export
-        dataset_or_view = fo.Dataset(...)
+        dataset_or_view = fo.load_dataset(...)
 
         # Export labels
         dataset_or_view.export(
@@ -3816,7 +3816,7 @@ You can export a FiftyOne dataset to disk in the above format as follows:
         export_dir = "/path/for/fiftyone-dataset"
 
         # The dataset or view to export
-        dataset_or_view = fo.Dataset(...)
+        dataset_or_view = fo.load_dataset(...)
 
         # Export the dataset
         dataset_or_view.export(
@@ -3862,7 +3862,7 @@ image's filepath, and then provide the new `rel_dir` when
         export_dir = "/path/for/fiftyone-dataset"
 
         # The dataset or view to export
-        dataset_or_view = fo.Dataset(...)
+        dataset_or_view = fo.load_dataset(...)
 
         # Export the dataset without copying the media files
         dataset_or_view.export(
@@ -3930,7 +3930,7 @@ media files per directory:
     export_dir = "/path/for/fiftyone-dataset"
 
     # The dataset or view to export
-    dataset_or_view = fo.Dataset(...)
+    dataset_or_view = fo.load_dataset(...)
 
     # Export the dataset with a maximum of 1000 media files per directory
     dataset_or_view.export(
@@ -3974,7 +3974,7 @@ a |Dataset| or |DatasetView| in your custom format using the following recipe:
     import fiftyone as fo
 
     # The dataset or view to export
-    dataset_or_view = fo.Dataset(...)
+    dataset_or_view = fo.load_dataset(...)
 
     # Create an instance of your custom dataset exporter
     exporter = CustomDatasetExporter(...)
@@ -3994,7 +3994,7 @@ datasets in your custom format using the following recipe:
     dataset_type = CustomDataset
 
     # The dataset or view to export
-    dataset_or_view = fo.Dataset(...)
+    dataset_or_view = fo.load_dataset(...)
 
     # Export the dataset
     dataset_or_view.export(dataset_type=dataset_type, ...)

--- a/fiftyone/__public__.py
+++ b/fiftyone/__public__.py
@@ -33,6 +33,7 @@ from .core.collections import SaveContext
 from .core.config import AppConfig
 from .core.dataset import (
     Dataset,
+    DatasetNotFoundError,
     list_datasets,
     dataset_exists,
     load_dataset,

--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -58,7 +58,7 @@ class MissingDatasetError(ValueError):
     """Exception raised when a dataset is missing."""
     def __init__(self, name):
         self._dataset_name = name
-        super().__init__("Dataset '%s' not found" % name)
+        super().__init__(f"Dataset {name} not found")
 
 
 def list_datasets(glob_patt=None, tags=None, info=False):
@@ -148,13 +148,12 @@ def load_dataset(name, create_if_missing=False):
     Returns:
         a :class:`Dataset`
     """
-    try:
+    if dataset_exists(name):
         return Dataset(name, _create=False)
-    except MissingDatasetError as ex:
-        if create_if_missing:
-            return Dataset(name)
-        else:
-            raise ex
+    elif create_if_missing:
+        return Dataset(name)
+    else:
+        raise MissingDatasetError(name)
 
 
 def get_default_dataset_name():

--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -153,10 +153,10 @@ def load_dataset(name, create_if_necessary=False):
         a :class:`Dataset`
     """
     try:
-        return Dataset(name, _create=create_if_necessary)
+        return Dataset(name, _create=False)
     except DatasetNotFoundError as ex:
         if create_if_necessary:
-            return Dataset(name)
+            return Dataset(name, _create=True)
         else:
             raise ex
 

--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -54,8 +54,8 @@ foud = fou.lazy_import("fiftyone.utils.data")
 logger = logging.getLogger(__name__)
 
 
-class MissingDatasetError(ValueError):
-    """Exception raised when a dataset is missing."""
+class DatasetNotFoundError(ValueError):
+    """Exception raised when a dataset is not found."""
     def __init__(self, name):
         self._dataset_name = name
         super().__init__(f"Dataset {name} not found")
@@ -130,7 +130,7 @@ def _validate_dataset_name(name, skip=None):
     return slug
 
 
-def load_dataset(name, create_if_missing=False):
+def load_dataset(name, create_if_necessary=False):
     """Loads the FiftyOne dataset with the given name.
 
     To create a new dataset, use the :class:`Dataset` constructor.
@@ -143,17 +143,21 @@ def load_dataset(name, create_if_missing=False):
 
     Args:
         name: the name of the dataset
-        create_if_missing (False): if no dataset exists, create empty one
+        create_if_necessary (False): if no dataset exists, create an empty one
+
+    Raises:
+        DatasetNotFoundError: if the dataset does not exist and
+            `create_if_necessary` is False
 
     Returns:
         a :class:`Dataset`
     """
     if dataset_exists(name):
         return Dataset(name, _create=False)
-    elif create_if_missing:
+    elif create_if_necessary:
         return Dataset(name)
     else:
-        raise MissingDatasetError(name)
+        raise DatasetNotFoundError(name)
 
 
 def get_default_dataset_name():
@@ -7604,7 +7608,7 @@ def _do_load_dataset(obj, name):
     db = foo.get_db_conn()
     res = db.datasets.find_one({"name": name})
     if not res:
-        raise MissingDatasetError(name)
+        raise DatasetNotFoundError(name)
     dataset_doc = foo.DatasetDocument.from_dict(res)
 
     sample_collection_name = dataset_doc.sample_collection_name

--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -152,12 +152,13 @@ def load_dataset(name, create_if_necessary=False):
     Returns:
         a :class:`Dataset`
     """
-    if dataset_exists(name):
-        return Dataset(name, _create=False)
-    elif create_if_necessary:
-        return Dataset(name)
-    else:
-        raise DatasetNotFoundError(name)
+    try:
+        return Dataset(name, _create=create_if_necessary)
+    except DatasetNotFoundError as ex:
+        if create_if_necessary:
+            return Dataset(name)
+        else:
+            raise ex
 
 
 def get_default_dataset_name():

--- a/fiftyone/migrations/runner.py
+++ b/fiftyone/migrations/runner.py
@@ -59,7 +59,7 @@ def get_dataset_revision(name):
     conn = foo.get_db_conn()
     dataset_doc = conn.datasets.find_one({"name": name}, {"version": 1})
     if dataset_doc is None:
-        raise ValueError("Dataset '%s' not found" % name)
+        raise fo.DatasetNotFoundError(name)
 
     return dataset_doc.get("version", None)
 

--- a/tests/unittests/dataset_tests.py
+++ b/tests/unittests/dataset_tests.py
@@ -110,8 +110,14 @@ class DatasetTests(unittest.TestCase):
         assert new_dataset_name_2 not in names
 
         # validate that the correct exception is raised
-        with self.assertRaises(fo.core.dataset.DatasetNotFoundError):
+        with self.assertRaises(fo.DatasetNotFoundError):
             fo.load_dataset(new_dataset_name_2)
+
+        # loading an existing dataset should work
+        assert len(names) > 0
+        for condition in [False, True]:
+            dataset = fo.load_dataset(names[0], create_if_necessary=condition)
+            assert dataset.name == names[0]
 
     @drop_datasets
     def test_delete_dataset(self):

--- a/tests/unittests/dataset_tests.py
+++ b/tests/unittests/dataset_tests.py
@@ -87,6 +87,33 @@ class DatasetTests(unittest.TestCase):
         self.assertEqual(dataset.slug, slug)
 
     @drop_datasets
+    def test_load_dataset(self):
+        new_dataset_name = "new-dataset-name"
+
+        # validate that the dataset does not exist
+        names = fo.list_datasets()
+        assert new_dataset_name not in names
+
+        # create the dataset by attempting to load it
+        dataset = fo.load_dataset(new_dataset_name, create_if_necessary=True)
+        assert dataset.name == new_dataset_name
+
+        dataset2 = fo.load_dataset(new_dataset_name)
+        self.assertIs(dataset, dataset2)
+
+        # validate that the new dataset is in the list of datasets
+        names = fo.list_datasets()
+        assert new_dataset_name in names
+
+        # validate that the dataset does not exist
+        new_dataset_name_2 = "new-dataset-name-2"
+        assert new_dataset_name_2 not in names
+
+        # validate that the correct exception is raised
+        with self.assertRaises(fo.core.dataset.DatasetNotFoundError):
+            fo.load_dataset(new_dataset_name_2)
+
+    @drop_datasets
     def test_delete_dataset(self):
         IGNORED_DATASET_NAMES = fo.list_datasets()
 

--- a/tests/unittests/utils_tests.py
+++ b/tests/unittests/utils_tests.py
@@ -459,9 +459,11 @@ from fiftyone.core.odm.utils import load_dataset
 
 
 class TestLoadDataset(unittest.TestCase):
+    @patch("fiftyone.core.dataset.dataset_exists")
     @patch("fiftyone.core.odm.get_db_conn")
     @patch("fiftyone.core.dataset.Dataset")
-    def test_load_dataset_by_id(self, mock_dataset, mock_get_db_conn):
+    def test_load_dataset_by_id(self, mock_dataset, mock_get_db_conn,
+                                dataset_exists):
         # Setup
         identifier = ObjectId()
         mock_db = MagicMock()
@@ -470,6 +472,7 @@ class TestLoadDataset(unittest.TestCase):
             "_id": ObjectId(identifier),
             "name": "test_dataset",
         }
+        dataset_exists.return_value = True
 
         # Test
         result = load_dataset(id=identifier)
@@ -482,9 +485,11 @@ class TestLoadDataset(unittest.TestCase):
 
         self.assertEqual(result, mock_dataset.return_value)
 
+    @patch("fiftyone.core.dataset.dataset_exists")
     @patch("fiftyone.core.odm.get_db_conn")
     @patch("fiftyone.core.dataset.Dataset")
-    def test_load_dataset_by_alt_id(self, mock_dataset, mock_get_db_conn):
+    def test_load_dataset_by_alt_id(self, mock_dataset, mock_get_db_conn,
+                                    dataset_exists):
         # Setup
         identifier = "alt_id"
         mock_db = MagicMock()
@@ -493,6 +498,7 @@ class TestLoadDataset(unittest.TestCase):
             "_id": "identifier",
             "name": "dataset_name",
         }
+        dataset_exists.return_value = True
 
         # Test
         result = load_dataset(id=identifier)
@@ -504,11 +510,13 @@ class TestLoadDataset(unittest.TestCase):
         )
         self.assertEqual(result, mock_dataset.return_value)
 
+    @patch("fiftyone.core.dataset.dataset_exists")
     @patch("fiftyone.core.dataset.Dataset")
-    def test_load_dataset_by_name(self, mock_dataset):
+    def test_load_dataset_by_name(self, mock_dataset, dataset_exists):
         # Setup
         identifier = "test_dataset"
         mock_dataset.return_value = {"_id": ObjectId(), "name": identifier}
+        dataset_exists.return_value = True
 
         # Test
         result = load_dataset(name=identifier)


### PR DESCRIPTION
## What changes are proposed in this pull request?

1. Currently, snippets for exporting dataset use `fo.Dataset(...)`, which is incorrect because this is the syntax for creating a new dataset. To load an existing dataset, use `fo.load_dataset(...)` instead.

Example snippet:
```
import fiftyone as fo
dataset_or_view = fo.Dataset("oi-v7full-2mm")
export_dir = "/path/for/export"
label_field = "ground_truth"
```

Error:
```
File ~/workspace/fiftyone-teams/fiftyone/core/dataset.py:117, in _validate_dataset_name(name, skip)
    115 clashing_name = clashing_name_doc["name"]
    116 if clashing_name == name:
--> 117     raise ValueError(f"Dataset name '{name}' is not available")
    118 else:
    119     raise ValueError(
    120         f"Dataset name '{name}' is not available: slug '{slug}' "
    121         f"in use by dataset '{clashing_name}'"
    122     )

ValueError: Dataset name 'oi-v7full-2mm' is not available
```

Correct snippet should be:
```
import fiftyone as fo
dataset_or_view = fo.load_dataset("oi-v7full-2mm")
```

2. Add a parameter `create_if_necessary ` to `load_dataset` to return an empty dataset if none currently exists.

## How is this patch tested? If it is not, please explain why.

1. Documentation should render correctly.
2. Passing `create_if_necessary ` to `load_dataset` should create a new dataset if an existing one does not exist.

Testing:
* Manual testing (✅ )
* Unit tests (✅ )

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [x] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved error handling with the introduction of `DatasetNotFoundError` for missing datasets.
- **Bug Fixes**
  - Enhanced error messaging by replacing `ValueError` with `DatasetNotFoundError` when datasets are not found.
- **Tests**
  - Added new tests validating dataset loading, creation, re-loading, and exception handling scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->