### PR TITLE
remove dependency that won`t ever be used

### DIFF
--- a/fiftyone/constants.py
+++ b/fiftyone/constants.py
@@ -11,10 +11,7 @@ import os
 
 from packaging.version import Version
 
-try:
-    from importlib.metadata import metadata  # Python 3.8
-except ImportError:
-    from importlib_metadata import metadata  # Python < 3.8
+from importlib.metadata import metadata
 
 
 CLIENT_TYPE = "fiftyone"

--- a/fiftyone/core/config.py
+++ b/fiftyone/core/config.py
@@ -8,12 +8,7 @@ FiftyOne config.
 
 import logging
 import os
-
-try:
-    from importlib import metadata as importlib_metadata  # Python 3.8
-except ImportError:
-    import importlib_metadata  # Python < 3.8
-
+from importlib import metadata
 import pytz
 
 import eta
@@ -941,7 +936,7 @@ def _parse_env_value(value):
 def _get_installed_packages():
     try:
         return set(
-            d.metadata["Name"] for d in importlib_metadata.distributions()
+            d.metadata["Name"] for d in metadata.distributions()
         )
     except:
         logger.debug("Failed to get installed packages")

--- a/fiftyone/core/session/session.py
+++ b/fiftyone/core/session/session.py
@@ -8,19 +8,15 @@ Session class for interacting with the FiftyOne App.
 
 from collections import defaultdict
 from functools import wraps
-
-try:
-    from importlib import metadata
-except ImportError:
-    import importlib_metadata as metadata
-
+from importlib import metadata
 import logging
 import os
 from packaging.requirements import Requirement
 import time
 import typing as t
-import webbrowser
 from uuid import uuid4
+import webbrowser
+
 
 try:
     import IPython.display

--- a/fiftyone/utils/youtube.py
+++ b/fiftyone/utils/youtube.py
@@ -6,12 +6,7 @@ Utilities for working with `YouTube <https://youtube.com>`.
 |
 """
 import importlib
-
-try:
-    from importlib import metadata
-except ImportError:
-    import importlib_metadata as metadata
-
+from importlib import metadata
 import itertools
 import logging
 import multiprocessing.dummy

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["importlib-metadata; python_version<'3.8'", "setuptools", "wheel"]
+requires = ["setuptools", "wheel"]
 [tool.black]
 line-length = 79
 include = '\.pyi?$'

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -7,7 +7,6 @@ Deprecated==1.2.11
 ftfy==6.1.1
 httpx==0.23.0
 hypercorn==0.13.2
-importlib-metadata==1.4.0; python_version<"3.8"
 kaleido==0.2.1
 matplotlib==3.5.2
 mongoengine==0.24.2

--- a/setup.py
+++ b/setup.py
@@ -6,11 +6,8 @@ Installs FiftyOne.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
-try:
-    from importlib import metadata
-except ImportError:
-    import importlib_metadata as metadata
 
+from importlib import metadata
 import os
 import re
 from setuptools import setup, find_packages

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,6 @@ INSTALL_REQUIRES = [
     "ftfy",
     "humanize",
     "hypercorn>=0.13.2",
-    "importlib-metadata; python_version<'3.8'",
     "Jinja2>=3",
     # kaleido indirectly required by plotly for image export
     # https://plotly.com/python/static-image-export/


### PR DESCRIPTION
## What changes are proposed in this pull request?

Remove the  `importlib-metadata` dependency since `<3.8` shouldn't ever happen again

## How is this patch tested? If it is not, please explain why.

`make python`

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [x] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Removed `importlib-metadata` dependency for Python versions below 3.8 across all configurations and code.
  - Simplified and standardized `metadata` import statements for compatibility with Python 3.8 and above.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->