### PR TITLE
add support for YOLOv8 classification models

### DIFF
--- a/docs/source/integrations/ultralytics.rst
+++ b/docs/source/integrations/ultralytics.rst
@@ -47,6 +47,30 @@ the following sample dataset:
     dataset = foz.load_zoo_dataset("quickstart", max_samples=25)
     dataset.select_fields().keep_fields()
 
+.. _ultralytics-image-classification:
+
+Image classification
+--------------------
+
+You can directly pass Ultralytics `YOLO` classification models to
+:meth:`apply_model() <fiftyone.core.collections.SampleCollection.apply_model>`:
+
+
+.. code-block:: python
+    :linenos:
+
+    # YOLOv8
+    model = YOLO("yolov8n-cls.pt")
+    # model = YOLO("yolov8s-cls.pt")
+    # model = YOLO("yolov8m-cls.pt")
+    # model = YOLO("yolov8l-cls.pt")
+    # model = YOLO("yolov8x-cls.pt")
+
+    dataset.apply_model(model, label_field="classif")
+
+    session = fo.launch_app(dataset)
+
+
 .. _ultralytics-object-detection:
 
 Object detection


### PR DESCRIPTION
## What changes are proposed in this pull request?

Now we support applying YOLOv8 classification models directly to FiftyOne datasets. This was a requested feature, and I also needed it to streamline one of my tutorials.

Here is the new usage:

```py
import fiftyone as fo
import fiftyone.zoo as foz

dataset = foz.load_zoo_dataset("quickstart")

from ultralytics import YOLO
model = YOLO("yolov8n-cls.pt")
dataset.apply_model(model, label_field="yolo_cls")
```


(Details)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [x] Documentation: FiftyOne documentation changes
-   [x] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for image classification using Ultralytics YOLO models.
  - Introduced new configuration and model classes for handling YOLO classification models.
- **Documentation**
  - Added a new section on image classification using Ultralytics YOLO models in the documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->