### PR TITLE
Ensure db connection for unpickled Dataset

### DIFF
--- a/fiftyone/core/odm/document.py
+++ b/fiftyone/core/odm/document.py
@@ -589,6 +589,7 @@ class Document(BaseDocument, mongoengine.Document):
         Args:
             *fields: an optional args list of specific fields to reload
         """
+        ensure_connection()
         super().reload(*fields, **kwargs)
 
     def save(


### PR DESCRIPTION
## What changes are proposed in this pull request?

Actual customer issue was due to using a parallel processing engine that basically created a `Dataset` object by deserializing, thereby bypassing any calls that make the DB connection in `Dataset.__init__()`.
So just like how we call `ensure_connection()` before `Document._save()` it should also be fine to call it before any `reload()` of a `Document`. If we already have a connection this is a no-op.

## How is this patch tested? If it is not, please explain why.

Easiest way to show the issue. 
```
import bson

import fiftyone as fo

doc = fo.core.odm.DatasetDocument(id=bson.ObjectId())
doc.reload()  # ConnectionFailure before, no error now
```

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability of the reload functionality by ensuring a database connection is established before reloading documents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->