### PR TITLE
Add track ids if present for ultralytics models 

### DIFF
--- a/fiftyone/utils/ultralytics.py
+++ b/fiftyone/utils/ultralytics.py
@@ -84,9 +84,14 @@ def _to_detections(result, confidence_thresh=None):
     classes = np.rint(result.boxes.cls.detach().cpu().numpy()).astype(int)
     boxes = result.boxes.xywhn.detach().cpu().numpy().astype(float)
     confs = result.boxes.conf.detach().cpu().numpy().astype(float)
+    track_ids = (
+        result.boxes.id.detach().cpu().numpy().astype(int)
+        if result.boxes.is_track
+        else [None] * len(boxes)
+    )
 
     detections = []
-    for cls, box, conf in zip(classes, boxes, confs):
+    for cls, box, conf, idx in zip(classes, boxes, confs, track_ids):
         if confidence_thresh is not None and conf < confidence_thresh:
             continue
 
@@ -97,6 +102,7 @@ def _to_detections(result, confidence_thresh=None):
             label=label,
             bounding_box=[xc - 0.5 * w, yc - 0.5 * h, w, h],
             confidence=conf,
+            index=idx,
         )
         detections.append(detection)
 

--- a/fiftyone/utils/ultralytics.py
+++ b/fiftyone/utils/ultralytics.py
@@ -53,6 +53,15 @@ def convert_ultralytics_model(model):
         )
 
 
+def _extract_track_ids(result):
+    """Get ultralytics track ids if present, else use Nones"""
+    return (
+        result.boxes.id.detach().cpu().numpy().astype(int)
+        if result.boxes.is_track
+        else [None] * len(result.boxes.conf.size(0))
+    )
+
+
 def to_detections(results, confidence_thresh=None):
     """Converts ``ultralytics.YOLO`` boxes to FiftyOne format.
 
@@ -84,11 +93,7 @@ def _to_detections(result, confidence_thresh=None):
     classes = np.rint(result.boxes.cls.detach().cpu().numpy()).astype(int)
     boxes = result.boxes.xywhn.detach().cpu().numpy().astype(float)
     confs = result.boxes.conf.detach().cpu().numpy().astype(float)
-    track_ids = (
-        result.boxes.id.detach().cpu().numpy().astype(int)
-        if result.boxes.is_track
-        else [None] * len(boxes)
-    )
+    track_ids = _extract_track_ids(result)
 
     detections = []
     for cls, box, conf, idx in zip(classes, boxes, confs, track_ids):
@@ -141,13 +146,16 @@ def _to_instances(result, confidence_thresh=None):
     boxes = result.boxes.xywhn.detach().cpu().numpy().astype(float)
     masks = result.masks.data.detach().cpu().numpy() > 0.5
     confs = result.boxes.conf.detach().cpu().numpy().astype(float)
+    track_ids = _extract_track_ids(result)
 
     # convert from center coords to corner coords
     boxes[:, 0] -= boxes[:, 2] / 2.0
     boxes[:, 1] -= boxes[:, 3] / 2.0
 
     detections = []
-    for cls, box, mask, conf in zip(classes, boxes, masks, confs):
+    for cls, box, mask, conf, idx in zip(
+        classes, boxes, masks, confs, track_ids
+    ):
         if confidence_thresh is not None and conf < confidence_thresh:
             continue
 
@@ -169,6 +177,7 @@ def _to_instances(result, confidence_thresh=None):
             bounding_box=list(box),
             mask=sub_mask.astype(bool),
             confidence=conf,
+            index=idx,
         )
         detections.append(detection)
 
@@ -264,6 +273,7 @@ def _to_polylines(result, tolerance, filled, confidence_thresh=None):
 
     classes = np.rint(result.boxes.cls.detach().cpu().numpy()).astype(int)
     confs = result.boxes.conf.detach().cpu().numpy().astype(float)
+    track_ids = _extract_track_ids(result)
 
     if tolerance > 1:
         masks = result.masks.data.detach().cpu().numpy() > 0.5
@@ -273,7 +283,9 @@ def _to_polylines(result, tolerance, filled, confidence_thresh=None):
         points = result.masks.xyn
 
     polylines = []
-    for cls, mask, _points, conf in zip(classes, masks, points, confs):
+    for cls, mask, _points, conf, idx in zip(
+        classes, masks, points, confs, track_ids
+    ):
         if confidence_thresh is not None and conf < confidence_thresh:
             continue
 
@@ -290,6 +302,7 @@ def _to_polylines(result, tolerance, filled, confidence_thresh=None):
             confidence=conf,
             closed=True,
             filled=filled,
+            index=idx,
         )
         polylines.append(polyline)
 
@@ -330,9 +343,10 @@ def _to_keypoints(result, confidence_thresh=None):
         confs = result.keypoints.conf.detach().cpu().numpy().astype(float)
     else:
         confs = itertools.repeat(None)
+    track_ids = _extract_track_ids(result)
 
     keypoints = []
-    for cls, _points, _confs in zip(classes, points, confs):
+    for cls, _points, _confs, idx in zip(classes, points, confs, track_ids):
         if confidence_thresh is not None:
             _points[_confs < confidence_thresh] = np.nan
 
@@ -343,6 +357,7 @@ def _to_keypoints(result, confidence_thresh=None):
             label=label,
             points=_points.tolist(),
             confidence=_confidence,
+            index=idx,
         )
         keypoints.append(keypoint)
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

If running `track` method from `ultralytics.YOLO` model, then track ids will be available video files.
If track ids are present, we add then to `fiftyone.Detection(index=track_id)` and other labels.

## How is this patch tested? If it is not, please explain why.

Works with detection and pose estimation models for the ultralytics integration.

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

When running ultralytics models on video files, track ids will be internally added to label fields with a instance index.

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced tracking capabilities by including track IDs in detection, instance, polyline, and keypoint results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->