### PR TITLE
Windows fo3d bug fix for finding asset files

### DIFF
--- a/app/packages/looker-3d/src/Logs.tsx
+++ b/app/packages/looker-3d/src/Logs.tsx
@@ -13,7 +13,7 @@ const LogContainer = styled.div`
   margin-left: 0.25em;
   display: flex;
   align-content: center;
-  overflow: scroll;
+  overflow: hidden;
   align-items: center;
 `;
 

--- a/app/packages/looker-3d/src/fo3d/tests/get-fo3d-root.test.ts
+++ b/app/packages/looker-3d/src/fo3d/tests/get-fo3d-root.test.ts
@@ -13,4 +13,10 @@ describe("getFo3dRoot", () => {
     const expectedRoot = "s3://bucket/path/to/file/";
     expect(getFo3dRoot(url)).toBe(expectedRoot);
   });
+
+  it("should extract the root of a valid fo3d file with backslashes", () => {
+    const url = "c:\\Users\\johndoe\\fiftyone\\store\\assets\\file.fo3d";
+    const expectedRoot = "c:\\Users\\johndoe\\fiftyone\\store\\assets/";
+    expect(getFo3dRoot(url)).toBe(expectedRoot);
+  });
 });

--- a/app/packages/looker-3d/src/fo3d/utils.ts
+++ b/app/packages/looker-3d/src/fo3d/utils.ts
@@ -125,7 +125,7 @@ export const getMediaPathForFo3dSample = (
 
 export const getFo3dRoot = (fo3dPath: string) => {
   // remove filename and the last slash to get the root
-  const root = fo3dPath.replace(/\/[^/]*\.fo3d$/, "/");
+  const root = fo3dPath.replace(/(\/[^/]*\.fo3d$|\\[^\\]*\.fo3d$)/, "/");
 
   return root;
 };


### PR DESCRIPTION
## What changes are proposed in this pull request?

Fixing error which was occurring on Windows machines when reading asset paths for fo3d.
![Animation](https://github.com/user-attachments/assets/ae1e2d0b-360e-4c73-b632-b5e7520a1a37)

## How is this patch tested? If it is not, please explain why.

Manual testing on windows computer and on mac laptop (to ensure it didn't break anything).

Used the dataset on local machine in the example and also used quickstart-3D.

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of file paths with backslashes in `getFo3dRoot` function.
  - Adjusted `LogContainer` component to prevent unwanted scrolling behavior.

- **Tests**
  - Added test case to verify `getFo3dRoot` function with Windows-style file paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->