### PR TITLE
python panel and operator views tweaks and fixes

### DIFF
--- a/app/packages/core/src/plugins/SchemaIO/components/DropdownView.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/DropdownView.tsx
@@ -84,7 +84,7 @@ export default function DropdownView(props: ViewPropsType) {
             Array.isArray(value) && type !== "array"
               ? value.join(separator)
               : value;
-          onChange(path, computedValue, schema);
+          onChange(path, computedValue);
           setUserChanged();
         }}
         multiple={multiple}

--- a/app/packages/core/src/plugins/SchemaIO/components/ImageView.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/ImageView.tsx
@@ -5,12 +5,19 @@ import { getComponentProps } from "../utils";
 
 export default function ImageView(props) {
   const { schema, data } = props;
+  const { height, width, alt } = schema?.view || {};
   const imageURI = data ?? schema?.default;
 
   return (
     <Box {...getComponentProps(props, "container")}>
       <HeaderView {...props} nested />
-      <img src={imageURI} {...getComponentProps(props, "image")} />
+      <img
+        src={imageURI}
+        height={height}
+        width={width}
+        alt={alt}
+        {...getComponentProps(props, "image")}
+      />
     </Box>
   );
 }

--- a/app/packages/core/src/plugins/SchemaIO/components/InferredView.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/InferredView.tsx
@@ -3,12 +3,13 @@ import { generateSchema } from "../utils";
 import DynamicIO from "./DynamicIO";
 
 export default function InferredView(props) {
-  const { schema = {} } = props;
+  const { data, schema = {} } = props;
   const { view = {}, default: defaultValue, readOnly } = schema;
-  const generatedSchema = generateSchema(defaultValue, {
+  const value = data ?? defaultValue;
+  const generatedSchema = generateSchema(value, {
     label: view.label,
     readOnly: readOnly || view.readOnly,
   });
-  const schemaWithDefault = { ...generatedSchema, default: defaultValue };
+  const schemaWithDefault = { ...generatedSchema, default: value };
   return <DynamicIO {...props} schema={schemaWithDefault} />;
 }

--- a/app/packages/core/src/plugins/SchemaIO/components/LinkView.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/LinkView.tsx
@@ -4,13 +4,28 @@ import { getComponentProps } from "../utils";
 
 export default function LinkView(props) {
   const { schema, data = {} } = props;
-  const { view = {} } = schema;
-  const { label: viewLabel, href: viewHref } = view;
-  const { label, href } = data;
+  const { view = {}, default: defaultValue } = schema;
+  const { new_window, newWindow } = view;
+  let { label, href } = view;
+  const value = data ?? defaultValue;
+  if (typeof value === "string") {
+    href = value;
+  } else {
+    if (value?.href) {
+      href = value.href;
+    }
+    if (value?.label) {
+      label = value.label;
+    }
+  }
   return (
     <Box {...getComponentProps(props, "container")}>
-      <Link href={href || viewHref} {...getComponentProps(props, "link")}>
-        {label || viewLabel}
+      <Link
+        href={href}
+        target={new_window || newWindow ? "_blank" : undefined}
+        {...getComponentProps(props, "link")}
+      >
+        {label}
       </Link>
     </Box>
   );

--- a/app/packages/core/src/plugins/SchemaIO/components/MediaPlayerView.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/MediaPlayerView.tsx
@@ -6,9 +6,10 @@ import { getComponentProps } from "../utils";
 
 export default function MediaPlayerView(props) {
   const { schema, data } = props;
-  const { default: defaultValue, playerProps = {} } = schema;
-  const actualData = data ?? defaultValue;
-  const mediaUrl = actualData?.url;
+  const { default: defaultValue } = schema;
+  const value = data ?? defaultValue;
+  const mediaUrl = typeof value === "string" ? value : value?.url;
+  const { view = {} } = schema;
 
   const handleEvent =
     (event) =>
@@ -32,7 +33,7 @@ export default function MediaPlayerView(props) {
       <HeaderView {...props} nested />
       <ReactPlayer
         url={mediaUrl}
-        {...playerProps}
+        {...view}
         {...eventHandlers}
         {...getComponentProps(props, "react-player")}
       />

--- a/app/packages/core/src/plugins/SchemaIO/components/RadioView.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/RadioView.tsx
@@ -31,7 +31,7 @@ export default function RadioView(props: RadioGroupProps) {
         key={key}
         defaultValue={data}
         onChange={(e, value) => {
-          onChange(path, value, schema);
+          onChange(path, value);
           setUserChanged();
         }}
         sx={{ alignItems: "flex-start" }}

--- a/app/packages/core/src/plugins/SchemaIO/components/TextFieldView.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/TextFieldView.tsx
@@ -28,7 +28,7 @@ export default function TextFieldView(props: ViewPropsType<NumberSchemaType>) {
         type={type}
         onChange={(e) => {
           const value = e.target.value;
-          onChange(path, type === "number" ? parseFloat(value) : value, schema);
+          onChange(path, type === "number" ? parseFloat(value) : value);
           setUserChanged();
         }}
         inputProps={{ min, max, step: multipleOf, ...inputProps }}

--- a/app/packages/core/src/plugins/SchemaIO/index.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/index.tsx
@@ -1,5 +1,5 @@
 import { PluginComponentType, registerComponent } from "@fiftyone/plugins";
-import { cloneDeep, set } from "lodash";
+import { cloneDeep, get, set } from "lodash";
 import React, { useCallback, useEffect, useRef } from "react";
 import DynamicIO from "./components/DynamicIO";
 import { clearUseKeyStores } from "./hooks";
@@ -14,7 +14,7 @@ export function SchemaIOComponent(props) {
   }, []);
 
   const onIOChange = useCallback(
-    (path, value, schema) => {
+    (path, value, schema, ancestors) => {
       if (onPathChange) {
         onPathChange(path, value, schema);
       }
@@ -23,6 +23,16 @@ export function SchemaIOComponent(props) {
       set(updatedState, path, cloneDeep(value));
       stateRef.current = updatedState;
       if (onChange) onChange(updatedState);
+
+      // propagate the change to all ancestors
+      for (const ancestorPath in ancestors) {
+        const ancestorSchema = ancestors[ancestorPath];
+        const ancestorValue = get(updatedState, ancestorPath);
+        if (onPathChange) {
+          onPathChange(ancestorPath, ancestorValue, ancestorSchema);
+        }
+      }
+
       return updatedState;
     },
     [onChange]

--- a/app/packages/core/src/plugins/SchemaIO/utils/types.ts
+++ b/app/packages/core/src/plugins/SchemaIO/utils/types.ts
@@ -28,7 +28,12 @@ export type ViewPropsType<Schema extends SchemaType = SchemaType> = {
   path: string;
   errors: { [key: string]: string[] };
   customComponents?: CustomComponentsType;
-  onChange: (path: string, value: any, schema?: Schema) => void;
+  onChange: (
+    path: string,
+    value: any,
+    schema?: Schema,
+    ancestors?: AncestorsType
+  ) => void;
   parentSchema?: SchemaType;
   relativePath: string;
   data?: any;
@@ -41,4 +46,8 @@ export type ViewPropsType<Schema extends SchemaType = SchemaType> = {
 
 export type CustomComponentsType = {
   [name: string]: React.ComponentType;
+};
+
+export type AncestorsType = {
+  [path: string]: SchemaType;
 };

--- a/app/packages/operators/src/constants.ts
+++ b/app/packages/operators/src/constants.ts
@@ -14,3 +14,4 @@ export enum QueueItemStatus {
   Completed,
   Failed,
 }
+export const PANEL_STATE_CHANGE_DEBOUNCE = 500;

--- a/fiftyone/operators/panel.py
+++ b/fiftyone/operators/panel.py
@@ -88,6 +88,9 @@ class Panel(Operator):
 
         ctx.ops.register_panel(**panel_config)
 
+    def on_load(self, ctx):
+        pass
+
     def execute(self, ctx):
         panel_id = ctx.params.get("panel_id", None)
         method_name = ctx.params.get("__method__", None)

--- a/fiftyone/operators/types.py
+++ b/fiftyone/operators/types.py
@@ -445,6 +445,54 @@ class Object(BaseType):
         )
         return self.view(name, view, **kwargs)
 
+    def map(self, name, key_type, value_type, **kwargs):
+        """Defines a map property on the object.
+
+        Args:
+            name: the name of the property
+            key_type: the type of the keys in the map
+            value_type: the type of the values in the map
+
+
+        Returns:
+            a :class:`Map`
+        """
+        map_view = MapView(**kwargs)
+        map_type = Map(key_type=key_type, value_type=value_type)
+        self.define_property(name, map_type, view=map_view, **kwargs)
+        return map_type
+
+    def oneof(self, name, types, **kwargs):
+        """Defines a one-of property on the object.
+
+        Args:
+            name: the name of the property
+            types: list of types that are instances of :class:`BaseType`
+
+
+        Returns:
+            a :class:`OneOf`
+        """
+
+        one_of = OneOf(types)
+        self.define_property(name, one_of, **kwargs)
+        return one_of
+
+    def tuple(self, name, *items, **kwargs):
+        """Defines a tuple property on the object.
+
+        Args:
+            name: the name of the property
+            *items: the types of the items in the tuple
+
+        Returns:
+            a :class:`Tuple`
+        """
+        tuple_view = TupleView(**kwargs)
+        tuple_type = Tuple(*items)
+        self.define_property(name, tuple_type, view=tuple_view, **kwargs)
+        return tuple_type
+
     def clone(self):
         """Clones the definition of the object.
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

- Make `on_load` optional for python panel
- Add `on_change` event support to all views
- Improve views configuration

## How is this patch tested? If it is not, please explain why.

(Details)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for dynamic property handling in `LinkView` and `MediaPlayerView` components.
  - Introduced new methods `map`, `oneof`, and `tuple` to enhance schema handling.
  - Added `PANEL_STATE_CHANGE_DEBOUNCE` constant to optimize panel state changes.

- **Enhancements**
  - Improved `DropdownView`, `RadioView`, and `TextFieldView` components by simplifying `onChange` function calls.
  - Enhanced `InferredView` to better handle default values.
  - Updated `SchemaIOComponent` to support cascading updates for ancestor paths.

- **Refactors**
  - Reorganized imports and optimized function implementations in various components to ensure better performance and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->