### PR TITLE
Fix setuptools in workflows

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -23,7 +23,7 @@ regex==2022.8.17
 retrying>=1.3.3
 scikit-learn>=0.23.2
 scikit-image>=0.16.2
-setuptools>=45.2.0,!=71.0.2
+setuptools>=45.2.0,<71
 sseclient-py>=1.7.2
 sse-starlette>=0.10.3
 starlette==0.36.2

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -23,7 +23,7 @@ regex==2022.8.17
 retrying>=1.3.3
 scikit-learn>=0.23.2
 scikit-image>=0.16.2
-setuptools>=45.2.0
+setuptools>=45.2.0,!=71.0.2
 sseclient-py>=1.7.2
 sse-starlette>=0.10.3
 starlette==0.36.2


### PR DESCRIPTION
Looks like recent releases of `setuptools` have some issues. `setuptools<71` fixes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated `requirements` to exclude `setuptools` version `71.0.2`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->