### PR TITLE
Add documentation for cache control headers on cloud-backed media

### DIFF
--- a/docs/source/teams/installation.rst
+++ b/docs/source/teams/installation.rst
@@ -177,6 +177,14 @@ If your datasets include cloud-backed
 cross-origin resource sharing (CORS) for your cloud buckets. Details are
 provided below for each cloud platform.
 
+Browser Caching
+-----------------
+
+If your datasets include cloud-backed media, we recommend configuring your data
+sources to allow for built in browser caching. This will cache signed URL responses
+so you don't need to reload assets from your cloud storage between sessions.
+Details are provided below for each cloud platform.
+
 .. _teams-amazon-s3:
 
 Amazon S3
@@ -263,6 +271,9 @@ here is an example configuration:
         }
     ]
 
+If you would like to take advantage of browser caching you can
+`specify cache-control headers on S3 objects <https://docs.aws.amazon.com/whitepapers/latest/build-static-websites-aws/controlling-how-long-amazon-s3-content-is-cached-by-amazon-cloudfront.html#specify-cache-control-headers>`_.
+
 .. _teams-google-cloud:
 
 Google Cloud Storage
@@ -327,6 +338,9 @@ here is an example configuration:
             "MaxAgeSeconds": 3000
         }
     ]
+
+If you would like to take advantage of browser caching you can
+`specify cache-control headers on GCP content <https://cloud.google.com/storage/docs/metadata#cache-control>`_.
 
 .. _teams-azure:
 
@@ -439,6 +453,9 @@ alias:
     `AZURE_STORAGE_ACCOUNT_URL` environment variable or by including the
     `account_url` key in your credentials `.ini` file.
 
+If you would like to take advantage of browser caching you can
+`specify cache-control headers on Azure blobs <https://learn.microsoft.com/en-us/azure/cdn/cdn-manage-expiration-of-blob-content#setting-cache-control-headers-by-using-azure-powershell>`_.
+
 .. _teams-minio:
 
 MinIO
@@ -509,6 +526,9 @@ alias:
 
     # For example
     filepath = "minio://test-bucket/image.jpg"
+
+If you would like to take advantage of browser caching you can
+`specify cache-control headers on MinIO content using the metadata field of the put_object API <https://min.io/docs/minio/linux/developers/python/API.html>`_.
 
 .. _teams-extra-kwargs:
 

--- a/docs/source/teams/installation.rst
+++ b/docs/source/teams/installation.rst
@@ -273,6 +273,8 @@ here is an example configuration:
 
 If you would like to take advantage of browser caching you can
 `specify cache-control headers on S3 objects <https://docs.aws.amazon.com/whitepapers/latest/build-static-websites-aws/controlling-how-long-amazon-s3-content-is-cached-by-amazon-cloudfront.html#specify-cache-control-headers>`_.
+By default S3 does not provide cache-control headers so it will be up to your browser's
+heuristics engine to determine how long to cache the object.
 
 .. _teams-google-cloud:
 
@@ -341,6 +343,7 @@ here is an example configuration:
 
 If you would like to take advantage of browser caching you can
 `specify cache-control headers on GCP content <https://cloud.google.com/storage/docs/metadata#cache-control>`_.
+By default GCP sets the max-age=0 seconds meaning no caching will occur.
 
 .. _teams-azure:
 
@@ -455,6 +458,8 @@ alias:
 
 If you would like to take advantage of browser caching you can
 `specify cache-control headers on Azure blobs <https://learn.microsoft.com/en-us/azure/cdn/cdn-manage-expiration-of-blob-content#setting-cache-control-headers-by-using-azure-powershell>`_.
+By default Azure does not provide cache-control headers so it will be up to your browser's
+heuristics engine to determine how long to cache the object.
 
 .. _teams-minio:
 
@@ -529,6 +534,8 @@ alias:
 
 If you would like to take advantage of browser caching you can
 `specify cache-control headers on MinIO content using the metadata field of the put_object API <https://min.io/docs/minio/linux/developers/python/API.html>`_.
+By default Minio does not provide cache-control headers so it will be up to your browser's
+heuristics engine to determine how long to cache the object.
 
 .. _teams-extra-kwargs:
 

--- a/docs/source/teams/installation.rst
+++ b/docs/source/teams/installation.rst
@@ -180,7 +180,7 @@ provided below for each cloud platform.
 Browser Caching
 -----------------
 
-If your datasets include cloud-backed media, we recommend configuring your data
+If your datasets include cloud-backed media, we strongly recommend configuring your data
 sources to allow for built in browser caching. This will cache signed URL responses
 so you don't need to reload assets from your cloud storage between sessions.
 Details are provided below for each cloud platform.


### PR DESCRIPTION
## What changes are proposed in this pull request?

Updating documentation to inform customers about how to enable browser caching for our supported cloud media types.

https://voxel51.atlassian.net/browse/TEAMS-3180

## How is this patch tested? If it is not, please explain why.

n/a

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [x] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
	- Added a new section on "Browser Caching" to improve guidance on optimizing performance for cloud-backed media.
	- Included specific recommendations for configuring cache-control headers for various cloud platforms, enhancing data handling efficiency for users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->