### PR TITLE
close more items of AdaptiveMenu on pressing ESC

### DIFF
--- a/app/packages/core/src/components/Actions/ActionsRow.tsx
+++ b/app/packages/core/src/components/Actions/ActionsRow.tsx
@@ -236,6 +236,7 @@ const Selected = ({
   modal: boolean;
   lookerRef?: MutableRefObject<fos.Lookers | undefined>;
 }) => {
+  const { refresh } = adaptiveMenuItemProps || {};
   const [open, setOpen] = useState(false);
   const [loading, setLoading] = useState(false);
   const samples = useRecoilValue(fos.selectedSamples);
@@ -247,6 +248,10 @@ const Selected = ({
     useEventHandler(lookerRef.current, "buffering", (e) =>
       setLoading(e.detail)
     );
+
+  useEffect(() => {
+    refresh?.();
+  }, [samples.size, refresh]);
 
   if (samples.size < 1 && !modal) {
     return null;

--- a/app/packages/core/src/components/Actions/DynamicGroupAction.tsx
+++ b/app/packages/core/src/components/Actions/DynamicGroupAction.tsx
@@ -5,7 +5,13 @@ import {
 import LoadingDots from "@fiftyone/components/src/components/Loading/LoadingDots";
 import * as fos from "@fiftyone/state";
 import MergeIcon from "@mui/icons-material/Merge";
-import React, { useCallback, useMemo, useRef, useState } from "react";
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import useMeasure from "react-use-measure";
 import { useRecoilValue } from "recoil";
 import DynamicGroup from "./DynamicGroup";
@@ -18,6 +24,7 @@ export const DynamicGroupAction = ({
 }: {
   adaptiveMenuItemProps: AdaptiveMenuItemComponentPropsType;
 }) => {
+  const { refresh } = adaptiveMenuItemProps;
   const [open, setOpen] = useState(false);
   const [isProcessing, setIsProcessing] = useState(false);
 
@@ -26,10 +33,16 @@ export const DynamicGroupAction = ({
 
   const pillComponent = useMemo(() => {
     if (isProcessing) {
-      return <LoadingDots text="Loading groups" />;
+      return (
+        <LoadingDots text="Loading groups" style={{ whiteSpace: "nowrap" }} />
+      );
     }
     return <MergeIcon />;
   }, [isProcessing]);
+
+  useEffect(() => {
+    refresh?.();
+  }, [isProcessing, refresh]);
 
   const isDynamicGroupViewStageActive = useRecoilValue(fos.isDynamicGroup);
 

--- a/app/packages/core/src/components/Grid/useEscape.ts
+++ b/app/packages/core/src/components/Grid/useEscape.ts
@@ -10,7 +10,10 @@ const useEscape = () => {
     useRecoilCallback(
       ({ reset, snapshot }) =>
         async (event: KeyboardEvent) => {
-          if (event.key !== "Escape") {
+          const escapeKeyHandlerIds = await snapshot.getPromise(
+            fos.escapeKeyHandlerIdsAtom
+          );
+          if (event.key !== "Escape" || escapeKeyHandlerIds.size > 0) {
             return;
           }
 

--- a/app/packages/state/src/hooks/index.ts
+++ b/app/packages/state/src/hooks/index.ts
@@ -47,3 +47,4 @@ export { default as useToPatches } from "./useToPatches";
 export { default as useTooltip } from "./useTooltip";
 export { default as useUpdateSamples } from "./useUpdateSamples";
 export { default as withSuspense } from "./withSuspense";
+export { default as useKeyDown } from "./useKeyDown";

--- a/app/packages/state/src/hooks/useKeyDown.tsx
+++ b/app/packages/state/src/hooks/useKeyDown.tsx
@@ -1,0 +1,22 @@
+import { DependencyList, useEffect } from "react";
+
+/**
+ * a react hook that calls the handler when a given key is down
+ */
+export default function useKeyDown(
+  key: KeyboardEvent["key"],
+  handler: (down: boolean, e: KeyboardEvent) => void,
+  deps: DependencyList = []
+) {
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === key) {
+        handler(true, e);
+      }
+    };
+    document.addEventListener("keydown", handleKeyDown);
+    return () => {
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [key, handler, ...deps]); // eslint-disable-line react-hooks/exhaustive-deps
+}

--- a/app/packages/state/src/recoil/atoms.ts
+++ b/app/packages/state/src/recoil/atoms.ts
@@ -367,3 +367,8 @@ export const noneValuedPaths = atom<Record<string, Set<string>>>({
   key: "noneValuedPaths",
   default: {},
 });
+
+export const escapeKeyHandlerIdsAtom = atom<Set<string>>({
+  key: "escapeKeyHandlerIdsAtom",
+  default: new Set(),
+});


### PR DESCRIPTION
## What changes are proposed in this pull request?

Close "More Items" popover of adaptive menu when ESC is pressed

## How is this patch tested? If it is not, please explain why.

Using ActionRow in split panel view

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced keyboard shortcut support to close the menu using the "Escape" key.
	- Added a new `useKeyDown` hook for managing keyboard events, improving interactive capabilities.

- **Improvements**
	- Enhanced performance by optimizing the menu closure function.
	- Improved responsiveness of components by incorporating refresh capabilities based on state changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->