### PR TITLE
Added index statistics to dataset.stats

### DIFF
--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -9028,12 +9028,15 @@ class SampleCollection(object):
         """
         return list(self.get_index_information().keys())
 
-    def get_index_information(self):
+    def get_index_information(self, include_size=False):
         """Returns a dictionary of information about the indexes on this
         collection.
 
         See :meth:`pymongo:pymongo.collection.Collection.index_information` for
         details on the structure of this dictionary.
+
+        include_size(False): whether to include the size of each index in the
+            collection
 
         Returns:
             a dict mapping index names to info dicts
@@ -9043,6 +9046,14 @@ class SampleCollection(object):
         # Sample-level indexes
         fields_map = self._get_db_fields_map(reverse=True)
         sample_info = self._dataset._sample_collection.index_information()
+
+        if include_size:
+            dataset_stats = self._dataset.stats(include_indexes=True)
+            for index_name in dataset_stats["indexSizes"]:
+                sample_info[index_name]["size"] = dataset_stats["indexSizes"][
+                    index_name
+                ]
+
         for key, info in sample_info.items():
             if len(info["key"]) == 1:
                 field = info["key"][0][0]

--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -9049,10 +9049,13 @@ class SampleCollection(object):
 
         if include_size:
             dataset_stats = self._dataset.stats(include_indexes=True)
-            for index_name in dataset_stats["indexSizes"]:
-                sample_info[index_name]["size"] = dataset_stats["indexSizes"][
+            for index_name in dataset_stats["index_sizes"]:
+                sample_info[index_name]["size"] = dataset_stats["index_sizes"][
                     index_name
                 ]
+                sample_info[index_name]["bytes"] = dataset_stats[
+                    "index_bytes"
+                ][index_name]
 
         for key, info in sample_info.items():
             if len(info["key"]) == 1:

--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -1145,7 +1145,10 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
         if include_indexes:
             stats["nindexes"] = cs["nindexes"]
             stats["totalIndexSize"] = cs["totalIndexSize"]
-            stats["indexSizes"] = cs["indexSizes"]
+            stats["indexSizes"] = {
+                k: etau.to_human_bytes_str(v)
+                for k, v in cs["indexSizes"].items()
+            }
 
         stats["total_bytes"] = total_bytes
         stats["total_size"] = etau.to_human_bytes_str(total_bytes)

--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -1143,9 +1143,13 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
             total_bytes += media_bytes
 
         if include_indexes:
-            stats["nindexes"] = cs["nindexes"]
-            stats["totalIndexSize"] = cs["totalIndexSize"]
-            stats["indexSizes"] = {
+            stats["num_indexes"] = cs["nindexes"]
+            stats["indexes_bytes"] = cs["totalIndexSize"]
+            stats["indexes_sizes"] = etau.to_human_bytes_str(
+                cs["totalIndexSize"]
+            )
+            stats["index_bytes"] = cs["indexSizes"]
+            stats["index_sizes"] = {
                 k: etau.to_human_bytes_str(v)
                 for k, v in cs["indexSizes"].items()
             }

--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -56,6 +56,7 @@ logger = logging.getLogger(__name__)
 
 class DatasetNotFoundError(ValueError):
     """Exception raised when a dataset is not found."""
+
     def __init__(self, name):
         self._dataset_name = name
         super().__init__(f"Dataset {name} not found")
@@ -1080,7 +1081,9 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
 
         return "\n".join(lines)
 
-    def stats(self, include_media=False, compressed=False):
+    def stats(
+        self, include_media=False, compressed=False, include_indexes=False
+    ):
         """Returns stats about the dataset on disk.
 
         The ``samples`` keys refer to the sample documents stored in the
@@ -1101,6 +1104,7 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
             compressed (False): whether to return the sizes of collections in
                 their compressed form on disk (True) or the logical
                 uncompressed size of the collections (False)
+            include_indexes (False): whether to return the stats on the indexes
 
         Returns:
             a stats dict
@@ -1137,6 +1141,11 @@ class Dataset(foc.SampleCollection, metaclass=DatasetSingleton):
             stats["media_bytes"] = media_bytes
             stats["media_size"] = etau.to_human_bytes_str(media_bytes)
             total_bytes += media_bytes
+
+        if include_indexes:
+            stats["nindexes"] = cs["nindexes"]
+            stats["totalIndexSize"] = cs["totalIndexSize"]
+            stats["indexSizes"] = cs["indexSizes"]
 
         stats["total_bytes"] = total_bytes
         stats["total_size"] = etau.to_human_bytes_str(total_bytes)

--- a/tests/unittests/dataset_tests.py
+++ b/tests/unittests/dataset_tests.py
@@ -533,6 +533,34 @@ class DatasetTests(unittest.TestCase):
             dataset.create_index("non_existent_field")
 
     @drop_datasets
+    def test_index_sizes(self):
+        gt = fo.Detections(detections=[fo.Detection(label="foo")])
+        sample = fo.Sample(filepath="video.mp4", gt=gt)
+        sample.frames[1] = fo.Frame(gt=gt)
+
+        dataset = fo.Dataset()
+        dataset.add_sample(sample)
+
+        dataset.create_index("gt.detections.label")
+        dataset.create_index("frames.gt.detections.label")
+
+        info = dataset.get_index_information(include_size=True)
+
+        indexes = [
+            "id",
+            "filepath",
+            "gt.detections.label",
+            "frames.id",
+            "frames._sample_id_1_frame_number_1",
+            "frames.gt.detections.label",
+        ]
+
+        self.assertListEqual(dataset.list_indexes(), indexes)
+        self.assertSetEqual(set(info.keys()), set(indexes))
+        for d in info.values():
+            self.assertTrue(d.get("size") is not None)
+
+    @drop_datasets
     def test_iter_samples(self):
         dataset = fo.Dataset()
         dataset.add_samples(


### PR DESCRIPTION
## What changes are proposed in this pull request?

Added an argument `include_indexes` so that we can return index statistics 

## How is this patch tested? If it is not, please explain why.

```py
import fiftyone as fo
import fiftyone.zoo as foz

dataset = foz.load_zoo_dataset("quickstart-video")

dataset.create_index("frames.detections.detections.label")

fo.pprint(dataset.get_index_information(include_size=True))

"""
{
    'id': {'v': 2, 'key': [('_id', 1)], 'size': 4096},
    'filepath': {'v': 2, 'key': [('filepath', 1)], 'size': 4096},
    'frames.id': {'v': 2, 'key': [('_id', 1)], 'size': 4096},
    'frames._sample_id_1_frame_number_1': {
        'v': 2,
        'key': [('_sample_id', 1), ('frame_number', 1)],
        'unique': True,
        'size': 4096,
    },
    'frames.detections.detections.label': {
        'v': 2,
        'key': [('detections.detections.label', 1)],
        'size': 28672,
    },
}
"""

fo.pprint(dataset.stats(include_indexes=True))

"""
{
    'samples_count': 10,
    'samples_bytes': 1820,
    'samples_size': '1.8KB',
    'frames_count': 1279,
    'frames_bytes': 2249818,
    'frames_size': '2.1MB',
    'indexes_count': 5,
    'indexes_bytes': 45056,
    'indexes_size': '44.0KB',
    'index_bytes': {
        'id': 4096,
        'filepath': 4096,
        'frames.id': 4096,
        'frames._sample_id_1_frame_number_1': 4096,
        'frames.detections.detections.label': 28672,
    },
    'index_sizes': {
        'id': '4.0KB',
        'filepath': '4.0KB',
        'frames.id': '4.0KB',
        'frames._sample_id_1_frame_number_1': '4.0KB',
        'frames.detections.detections.label': '28.0KB',
    },
    'total_bytes': 2296694,
    'total_size': '2.2MB',
}
"""
```

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

Users can now view index statistics using `dataset.stats(include_indexes=True)`

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- The `stats` method now includes an optional parameter to include index statistics, enhancing insights into the dataset structure.
	- The `get_index_information` method has been updated with a new parameter to optionally include index sizes, providing more comprehensive index information.
- **Tests**
	- Added a new test to validate the functionality of indexing within datasets, ensuring accurate creation and size retrieval for indices.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->