### PR TITLE
Dashboard edit

### DIFF
--- a/app/packages/core/src/plugins/SchemaIO/components/DashboardView.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/DashboardView.tsx
@@ -19,6 +19,7 @@ import { Button } from ".";
 import { getPath, getProps } from "../utils";
 import { ObjectSchemaType, ViewPropsType } from "../utils/types";
 import DynamicIO from "./DynamicIO";
+import { Edit } from "@mui/icons-material";
 
 const AddItemCTA = ({ onAdd }) => {
   return (
@@ -69,6 +70,7 @@ export default function DashboardView(props: ViewPropsType) {
   const propertiesAsArray = [];
   const allow_addition = schema.view.allow_addition;
   const allow_deletion = schema.view.allow_deletion;
+  const allow_edit = schema.view.allow_edit;
 
   for (const property in properties) {
     propertiesAsArray.push({ id: property, ...properties[property] });
@@ -76,6 +78,17 @@ export default function DashboardView(props: ViewPropsType) {
   const panelId = usePanelId();
   const triggerPanelEvent = usePanelEvent();
 
+  const onEditItem = useCallback(
+    ({ id, path }) => {
+      if (schema.view.on_edit_item) {
+        triggerPanelEvent(panelId, {
+          operator: schema.view.on_edit_item,
+          params: { id, path },
+        });
+      }
+    },
+    [panelId, props, schema.view.on_edit_item, triggerPanelEvent]
+  );
   const onCloseItem = useCallback(
     ({ id, path }) => {
       if (schema.view.on_remove_item) {
@@ -185,6 +198,19 @@ export default function DashboardView(props: ViewPropsType) {
             >
               <DragHandle className="drag-handle">
                 <Typography>{property.title || id}</Typography>
+                {allow_edit && (
+                  <IconButton
+                    size="small"
+                    onMouseDown={(e) => e.stopPropagation()}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      onEditItem({ id, path: getPath(path, id) });
+                    }}
+                    sx={{ color: theme.text.secondary }}
+                  >
+                    <Edit />
+                  </IconButton>
+                )}
                 {allow_deletion && (
                   <IconButton
                     size="small"

--- a/app/packages/core/src/plugins/SchemaIO/components/DashboardView.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/DashboardView.tsx
@@ -198,32 +198,34 @@ export default function DashboardView(props: ViewPropsType) {
             >
               <DragHandle className="drag-handle">
                 <Typography>{property.title || id}</Typography>
-                {allow_edit && (
-                  <IconButton
-                    size="small"
-                    onMouseDown={(e) => e.stopPropagation()}
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      onEditItem({ id, path: getPath(path, id) });
-                    }}
-                    sx={{ color: theme.text.secondary }}
-                  >
-                    <Edit />
-                  </IconButton>
-                )}
-                {allow_deletion && (
-                  <IconButton
-                    size="small"
-                    onMouseDown={(e) => e.stopPropagation()}
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      onCloseItem({ id, path: getPath(path, id) });
-                    }}
-                    sx={{ color: theme.text.secondary }}
-                  >
-                    <CloseIcon />
-                  </IconButton>
-                )}
+                <Box>
+                  {allow_edit && (
+                    <IconButton
+                      size="small"
+                      onMouseDown={(e) => e.stopPropagation()}
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        onEditItem({ id, path: getPath(path, id) });
+                      }}
+                      sx={{ color: theme.text.secondary }}
+                    >
+                      <Edit />
+                    </IconButton>
+                  )}
+                  {allow_deletion && (
+                    <IconButton
+                      size="small"
+                      onMouseDown={(e) => e.stopPropagation()}
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        onCloseItem({ id, path: getPath(path, id) });
+                      }}
+                      sx={{ color: theme.text.secondary }}
+                    >
+                      <CloseIcon />
+                    </IconButton>
+                  )}
+                </Box>
               </DragHandle>
               <Box sx={{ height: "calc(100% - 35px)", overflow: "auto" }}>
                 <DynamicIO

--- a/fiftyone/operators/types.py
+++ b/fiftyone/operators/types.py
@@ -2099,18 +2099,24 @@ class DashboardView(View):
         on_layout_change (None): event triggered when the layout changes
         on_add_item (None): event triggered when an item is added
         on_remove_item (None): event triggered when an item is closed
+        on_edit_item (None): event triggered when an item is edited
+        allow_addition (True): whether to allow adding items
+        allow_deletion (True): whether to allow deleting items
+        allow_edit (True): whether to allow editing items
     """
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
         self.allow_addition = kwargs.get("allow_addition", True)
         self.allow_deletion = kwargs.get("allow_deletion", True)
+        self.allow_edit = kwargs.get("allow_edit", True)
 
     def to_json(self):
         return {
             **super().to_json(),
             "allow_addition": self.allow_addition,
             "allow_deletion": self.allow_deletion,
+            "allow_edit": self.allow_edit,
         }
 
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

<img width="513" alt="image" src="https://github.com/user-attachments/assets/897cb92c-1162-4998-b931-e2ec0c668faa">
Allows for configuring a new mode/button for `DashboardView`. This allows a panel to implement `on_edit_item` similarly to `on_remove_item` and `on_add_item`.

## How is this patch tested? If it is not, please explain why.

With the new custom dashboard plugin.

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced item editing functionality in the Dashboard, allowing users to edit items directly from the grid layout.
	- Added properties for item management, including controls for adding, deleting, and editing items.

- **Enhancements**
	- Improved the interactivity of the Dashboard by enabling an edit button for individual grid items.
	- Updated the JSON representation of the DashboardView to include new item management properties.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->