### PR TITLE
rename PanelOperatorConfig to PanelConfig

### DIFF
--- a/e2e-pw/src/shared/assets/plugins/e2e/__init__.py
+++ b/e2e-pw/src/shared/assets/plugins/e2e/__init__.py
@@ -97,7 +97,7 @@ class E2EProgress(foo.Operator):
 class E2ECounterPythonPanel(foo.Panel):
     @property
     def config(self):
-        return foo.PanelOperatorConfig(
+        return foo.PanelConfig(
             name="e2e_counter_python_panel",
             label="E2E: Counter Python Panel",
             allow_multiple=True,

--- a/fiftyone/operators/__init__.py
+++ b/fiftyone/operators/__init__.py
@@ -17,7 +17,7 @@ from .executor import (
     ExecutionOptions,
 )
 from .utils import ProgressHandler
-from .panel import PanelOperatorConfig, Panel
+from .panel import Panel, PanelConfig, PanelOperatorConfig
 
 # This enables Sphinx refs to directly use paths imported here
 __all__ = [k for k, v in globals().items() if not k.startswith("_")]

--- a/fiftyone/operators/panel.py
+++ b/fiftyone/operators/panel.py
@@ -12,7 +12,7 @@ from fiftyone.operators.operator import OperatorConfig, Operator
 import pydash
 
 
-class PanelOperatorConfig(OperatorConfig):
+class PanelConfig(OperatorConfig):
     """A configuration for a panel operator."""
 
     def __init__(
@@ -47,6 +47,10 @@ class PanelOperatorConfig(OperatorConfig):
             "light_icon": self.light_icon,
             "allow_multiple": self.allow_multiple,
         }
+
+
+# Alias for backwards compatibility
+PanelOperatorConfig = PanelConfig
 
 
 class Panel(Operator):

--- a/tests/unittests/panels/panel_tests.py
+++ b/tests/unittests/panels/panel_tests.py
@@ -2,7 +2,7 @@ import pytest
 from unittest.mock import MagicMock
 from fiftyone.operators.panel import (
     Panel,
-    PanelOperatorConfig,
+    PanelConfig,
     PanelRef,
     PanelRefState,
     PanelRefData,
@@ -19,7 +19,7 @@ def simulate_event(panel, mock_ctx, event_name):
 class TestPanel(Panel):
     @property
     def config(self):
-        return PanelOperatorConfig(name="test_panel", label="Test Panel")
+        return PanelConfig(name="test_panel", label="Test Panel")
 
     def render(self, ctx):
         panel = Object()


### PR DESCRIPTION
PanelOperatorConfig => PanelConfig

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Updated class naming for improved clarity, renaming `PanelOperatorConfig` to `PanelConfig`.
	- Introduced an alias for backward compatibility, ensuring existing references to the old class name remain functional.
	- Enhanced the module interface by making `PanelConfig` available in the operators module.

- **Bug Fixes**
	- No changes affecting the control flow or functionality; existing features remain intact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->