### PR TITLE
show built-in panel first in add panels list

### DIFF
--- a/app/packages/core/src/plugins/OperatorIO/examples/Panel.tsx
+++ b/app/packages/core/src/plugins/OperatorIO/examples/Panel.tsx
@@ -13,6 +13,7 @@ import {
   simpleSchema,
 } from "./input.json";
 import { data, schema as outputSchema } from "./output.json";
+import { BUILT_IN_PANEL_PRIORITY_CONST } from "@fiftyone/utilities";
 
 // Panel enabled only in development environment for testing and debugging SchemaIO
 if (import.meta.env?.MODE === "development") {
@@ -22,6 +23,9 @@ if (import.meta.env?.MODE === "development") {
     component: OperatorIO,
     type: PluginComponentType.Panel,
     activator: () => true,
+    panelOptions: {
+      priority: BUILT_IN_PANEL_PRIORITY_CONST,
+    },
   });
 }
 

--- a/app/packages/core/src/plugins/histograms.tsx
+++ b/app/packages/core/src/plugins/histograms.tsx
@@ -14,6 +14,7 @@ import {
 } from "recoil";
 import styled from "styled-components";
 import Histogram from "../components/Histogram";
+import { BUILT_IN_PANEL_PRIORITY_CONST } from "@fiftyone/utilities";
 
 const HistogramsContainer = styled.div`
   position: relative;
@@ -105,4 +106,7 @@ registerComponent({
   type: PluginComponentType.Panel,
   activator: () => true,
   Icon: BarChart,
+  panelOptions: {
+    priority: BUILT_IN_PANEL_PRIORITY_CONST,
+  },
 });

--- a/app/packages/core/src/plugins/samples.tsx
+++ b/app/packages/core/src/plugins/samples.tsx
@@ -1,7 +1,9 @@
 import { FilterAndSelectionIndicator } from "@fiftyone/components";
 import { PluginComponentType, registerComponent } from "@fiftyone/plugins";
 import * as fos from "@fiftyone/state";
+import { BUILT_IN_PANEL_PRIORITY_CONST } from "@fiftyone/utilities";
 import AppsIcon from "@mui/icons-material/Apps";
+import React from "react";
 import { useRecoilValue, useResetRecoilState } from "recoil";
 import styled from "styled-components";
 import Grid from "../components/Grid/Grid";
@@ -28,7 +30,7 @@ registerComponent({
   type: PluginComponentType.Panel,
   Icon: AppsIcon,
   activator: () => true,
-  panelOptions: { TabIndicator },
+  panelOptions: { TabIndicator, priority: BUILT_IN_PANEL_PRIORITY_CONST },
 });
 
 function TabIndicator() {

--- a/app/packages/embeddings/src/index.ts
+++ b/app/packages/embeddings/src/index.ts
@@ -2,6 +2,7 @@ import { PluginComponentType, registerComponent } from "@fiftyone/plugins";
 import ScatterPlotIcon from "@mui/icons-material/ScatterPlot";
 import Embeddings from "./Embeddings";
 import EmbeddingsTabIndicator from "./EmbeddingsTabIndicator";
+import { BUILT_IN_PANEL_PRIORITY_CONST } from "@fiftyone/utilities";
 
 registerComponent({
   name: "Embeddings",
@@ -12,6 +13,7 @@ registerComponent({
   Icon: ScatterPlotIcon,
   panelOptions: {
     TabIndicator: EmbeddingsTabIndicator,
+    priority: BUILT_IN_PANEL_PRIORITY_CONST,
   },
 });
 

--- a/app/packages/map/src/index.ts
+++ b/app/packages/map/src/index.ts
@@ -1,5 +1,5 @@
 import { registerComponent, PluginComponentType } from "@fiftyone/plugins";
-import { Schema } from "@fiftyone/utilities";
+import { BUILT_IN_PANEL_PRIORITY_CONST, Schema } from "@fiftyone/utilities";
 import Map from "./Map";
 import MapIcon from "@mui/icons-material/Map";
 import MapTabIndicator from "./MapTabIndicator";
@@ -15,6 +15,7 @@ registerComponent({
   Icon: MapIcon,
   panelOptions: {
     TabIndicator: MapTabIndicator,
+    priority: BUILT_IN_PANEL_PRIORITY_CONST,
   },
 });
 

--- a/app/packages/plugins/src/index.ts
+++ b/app/packages/plugins/src/index.ts
@@ -260,6 +260,7 @@ type PluginActivator = (props: any) => boolean;
 type PanelOptions = {
   allowDuplicates?: boolean;
   TabIndicator?: React.ComponentType;
+  priority?: number;
 };
 
 type PluginComponentProps<T> = T & {

--- a/app/packages/spaces/src/components/AddPanelButton.tsx
+++ b/app/packages/spaces/src/components/AddPanelButton.tsx
@@ -6,31 +6,30 @@ import { usePanels, useSpaceNodes } from "../hooks";
 import { AddPanelButtonProps } from "../types";
 import AddPanelItem from "./AddPanelItem";
 import { AddPanelButtonContainer } from "./StyledElements";
+import { panelsCompareFn } from "../utils/sort";
 
 export default function AddPanelButton({ node, spaceId }: AddPanelButtonProps) {
   const [open, setOpen] = useState(false);
   const panels = usePanels();
   const spaceNodes = useSpaceNodes(spaceId);
-  const nodeTypes = useMemo(
-    () => spaceNodes.map((node) => node.type),
-    [spaceNodes]
-  );
+  const nodeTypes = useMemo(() => {
+    return spaceNodes.map((node) => {
+      return node.type;
+    });
+  }, [spaceNodes]);
   const popoutRef = useRef();
   useOutsideClick(popoutRef, () => {
     setOpen(false);
   });
 
   const availablePanels = panels
-    .filter(
-      (panel) =>
+    .filter((panel) => {
+      return (
         panel?.panelOptions?.allowDuplicates === true ||
         !nodeTypes.includes(panel.name)
-    )
-    .sort((panelA, panelB) => {
-      if (panelA.name < panelB.name) return -1;
-      if (panelA.name > panelB.name) return 1;
-      return 0;
-    });
+      );
+    })
+    .sort(panelsCompareFn);
 
   if (availablePanels.length === 0) return null;
 

--- a/app/packages/spaces/src/utils/sort.test.ts
+++ b/app/packages/spaces/src/utils/sort.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import { panelsCompareFn } from "./sort";
+
+describe("panelsCompareFn", () => {
+  it("compares panel by names correctly", () => {
+    expect(panelsCompareFn({ name: "a" }, { name: "b" })).toBe(-1);
+    expect(panelsCompareFn({ name: "b" }, { name: "a" })).toBe(1);
+    expect(panelsCompareFn({ name: "a" }, { name: "a" })).toBe(0);
+    expect(panelsCompareFn({ name: "a" }, { name: "A" })).toBe(1);
+  });
+
+  it("compares panel by priorities correctly", () => {
+    expect(
+      panelsCompareFn(
+        { name: "a", panelOptions: { priority: 1 } },
+        { name: "b", panelOptions: { priority: 2 } }
+      )
+    ).toBe(1);
+    expect(
+      panelsCompareFn(
+        { name: "b", panelOptions: { priority: 2 } },
+        { name: "a", panelOptions: { priority: 1 } }
+      )
+    ).toBe(-1);
+    expect(
+      panelsCompareFn(
+        { name: "a", panelOptions: { priority: 1 } },
+        { name: "a", panelOptions: { priority: 1 } }
+      )
+    ).toBe(0);
+  });
+
+  it("sorts panels by priority first and then by name", () => {
+    const panels = [
+      { name: "a", panelOptions: { priority: 1 } },
+      { name: "b", panelOptions: { priority: 1 } },
+      { name: "c", panelOptions: { priority: 2 } },
+      { name: "d", panelOptions: { priority: 2 } },
+    ];
+    const sortedPanels = panels.sort(panelsCompareFn);
+    expect(sortedPanels.map((panel) => panel.name).join("")).toEqual("cdab");
+  });
+
+  it("sorts panels FiftyOne", () => {
+    const panels = [
+      { name: "e", panelOptions: { priority: 1 } },
+      { name: "i", panelOptions: { priority: 6 } },
+      { name: "O", panelOptions: { priority: 3 } },
+      { name: "t", panelOptions: { priority: 4 } },
+      { name: "y", panelOptions: { priority: 4 } },
+      { name: "f", panelOptions: { priority: 5 } },
+      { name: "n", panelOptions: { priority: 2 } },
+      { name: "F", panelOptions: { priority: 7 } },
+    ];
+    const sortedPanels = panels.sort(panelsCompareFn);
+    expect(sortedPanels.map((panel) => panel.name).join("")).toEqual(
+      "FiftyOne"
+    );
+  });
+});

--- a/app/packages/spaces/src/utils/sort.ts
+++ b/app/packages/spaces/src/utils/sort.ts
@@ -1,0 +1,15 @@
+import { PluginComponentRegistration } from "@fiftyone/plugins";
+
+export function panelsCompareFn(
+  panelA: PluginComponentRegistration,
+  panelB: PluginComponentRegistration
+) {
+  const panelAPriority = panelA?.panelOptions?.priority || 0;
+  const panelBPriority = panelB?.panelOptions?.priority || 0;
+  if (panelAPriority !== panelBPriority) {
+    return panelBPriority - panelAPriority;
+  }
+  if (panelA.name < panelB.name) return -1;
+  if (panelA.name > panelB.name) return 1;
+  return 0;
+}

--- a/app/packages/state/src/hooks/hooks-utils.ts
+++ b/app/packages/state/src/hooks/hooks-utils.ts
@@ -58,7 +58,7 @@ export const useKeydownHandler = (handler: React.KeyboardEventHandler) =>
   useEventHandler(document.body, "keydown", handler);
 
 export const useOutsideClick = (
-  ref: React.MutableRefObject<HTMLElement | null>,
+  ref: React.MutableRefObject<HTMLElement | null | undefined>,
   handler: React.MouseEventHandler,
   eventName = "mousedown"
 ) => {

--- a/app/packages/utilities/src/index.ts
+++ b/app/packages/utilities/src/index.ts
@@ -474,7 +474,7 @@ export const GEOLOCATIONS_DISABLED_SUB_PATHS = [
   "line",
   "polygons",
 ];
-export const BUILT_IN_PANEL_PRIORITY_CONST = 1000;
+export const BUILT_IN_PANEL_PRIORITY_CONST = 51000;
 
 export function withPath(path: string, types: string): string;
 export function withPath(path: string, types: string[]): string[];

--- a/app/packages/utilities/src/index.ts
+++ b/app/packages/utilities/src/index.ts
@@ -474,6 +474,7 @@ export const GEOLOCATIONS_DISABLED_SUB_PATHS = [
   "line",
   "polygons",
 ];
+export const BUILT_IN_PANEL_PRIORITY_CONST = 1000;
 
 export function withPath(path: string, types: string): string;
 export function withPath(path: string, types: string[]): string[];


### PR DESCRIPTION
## What changes are proposed in this pull request?

Show list of built-in panels first in the add panel list

### Before
![image](https://github.com/user-attachments/assets/abfd3b4e-01ca-4bfd-9f7d-500d95fcd818)

### After
![image](https://github.com/user-attachments/assets/59560c43-4e00-44a3-9516-5ccddb441320)


## How is this patch tested? If it is not, please explain why.

Using the app

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

See above

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced a `priority` option in the panel configuration, allowing for dynamic management of panel rendering order and visibility.
	- Added a new constant `BUILT_IN_PANEL_PRIORITY_CONST` to standardize panel priority across various components.

- **Bug Fixes**
	- Enhanced type definition in `useOutsideClick` to improve reference handling, reducing potential runtime errors.

- **Refactor**
	- Improved code readability and maintainability in the `AddPanelButton` component without changing core functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->