### PR TITLE
Allow empty `paths` aggregation

### DIFF
--- a/fiftyone/server/aggregations.py
+++ b/fiftyone/server/aggregations.py
@@ -114,6 +114,9 @@ async def aggregate_resolver(
     if not form.dataset:
         raise ValueError("Aggregate form missing dataset")
 
+    if not form.paths:
+        return []
+
     view = await _load_view(form, form.slices)
 
     slice_view = None

--- a/tests/unittests/server_aggregations_tests.py
+++ b/tests/unittests/server_aggregations_tests.py
@@ -35,6 +35,46 @@ schema = gql.Schema(
 
 class TestGroupModeSidebarCounts(unittest.IsolatedAsyncioTestCase):
     @drop_async_dataset
+    async def test_empty(self, dataset: fo.Dataset):
+        query = """
+            query Query($form: AggregationForm!) {
+                aggregations(form: $form) {
+                    ... on StringAggregation {
+                        path
+                    }
+                }
+            }
+        """
+
+        result = await execute(
+            schema,
+            query,
+            {
+                "form": {
+                    "dataset": dataset.name,
+                    "extended_stages": {},
+                    "filters": {},
+                    "group_id": None,
+                    "hidden_labels": [],
+                    "index": 0,
+                    "mixed": False,
+                    "paths": [],
+                    "sample_ids": [],
+                    "slice": None,
+                    "slices": None,
+                    "view": [],
+                }
+            },
+        )
+
+        self.assertEqual(
+            result.data,
+            {
+                "aggregations": [],
+            },
+        )
+
+    @drop_async_dataset
     async def test_group_mode_sidebar_counts(self, dataset: fo.Dataset):
         _add_samples(dataset)
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

When no label fields are present on a dataset, the modal closes when attempting to tag a sample. The frontend should not need to issue this request, but improved server handling was straightforward

https://github.com/user-attachments/assets/fc5e392f-fee1-4282-b854-d0d02e0556a7


## How is this patch tested? If it is not, please explain why.

GraphQL test

## Release Notes

Fixed tagging sample(s) in the expanded when no label fields are present

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced aggregation functionality to handle cases where no paths are provided, improving robustness and user experience.
  
- **Bug Fixes**
	- Added logging to provide visibility into the paths being processed, aiding in debugging when paths are absent.

- **Tests**
	- Introduced a new test to verify correct handling of empty datasets in aggregation functionality, ensuring system reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->