### PR TITLE
Retain sample selection after modal pop history state

### DIFF
--- a/app/packages/app/src/Sync.tsx
+++ b/app/packages/app/src/Sync.tsx
@@ -117,9 +117,29 @@ const dispatchSideEffect = ({
     return;
   }
 
+  session.modalSelector = nextEntry.state.modalSelector;
+
+  if (
+    currentEntry.state.event === "modal" ||
+    nextEntry.state.event === "modal"
+  ) {
+    if (nextEntry.state.event !== "modal") {
+      session.selectedLabels = [];
+    }
+    commitMutation<setSampleMutation>(environment, {
+      mutation: setSample,
+      variables: {
+        groupId: nextEntry.state.modalSelector?.groupId,
+        id: nextEntry.state.modalSelector?.id,
+        subscription,
+      },
+    });
+    return;
+  }
+
   session.selectedLabels = [];
   session.selectedSamples = new Set();
-  session.modalSelector = nextEntry.state.modalSelector;
+
 
   const currentDataset: string | undefined =
     // @ts-ignore
@@ -139,20 +159,6 @@ const dispatchSideEffect = ({
     return;
   }
 
-  if (
-    currentEntry.state.event === "modal" ||
-    nextEntry.state.event === "modal"
-  ) {
-    commitMutation<setSampleMutation>(environment, {
-      mutation: setSample,
-      variables: {
-        groupId: nextEntry.state.modalSelector?.groupId,
-        id: nextEntry.state.modalSelector?.id,
-        subscription,
-      },
-    });
-    return;
-  }
 
   // @ts-ignore
   const data: DatasetPageQuery$data = nextEntry.data;

--- a/e2e-pw/src/oss/specs/selection.spec.ts
+++ b/e2e-pw/src/oss/specs/selection.spec.ts
@@ -92,5 +92,11 @@ extensionDatasetNamePairs.forEach(([extension, datasetName]) => {
     await modal.assert.verifySelectionCount(1);
     await modal.close();
     await grid.assert.isSelectionCountEqualTo(1);
+
+    await grid.openNthSample(1);
+    await modal.assert.verifySelectionCount(1);
+    await grid.url.back();
+    await modal.assert.isClosed();
+    await grid.assert.isSelectionCountEqualTo(1);
   });
 });


### PR DESCRIPTION
## What changes are proposed in this pull request?

Fixes sample selection clearing when popping history state in the modal. It is the currently intended behavior that selected labels _are_ cleared when leaving the modal.

## How is this patch tested? If it is not, please explain why.

New e2e assertions

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved handling of modal events within the application, enhancing state management based on user interactions.

- **Bug Fixes**
  - Enhanced test coverage for selection functionality, ensuring correct modal state and selection count after user actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->