### PR TITLE
Remove padding grid fill

### DIFF
--- a/app/packages/spotlight/src/index.ts
+++ b/app/packages/spotlight/src/index.ts
@@ -16,7 +16,7 @@ import {
   SCROLLBAR_WIDTH,
   TWO,
   ZERO,
-  ZOOMING_COEFFICIENT,
+  ZOOMING_COEFFICIENT
 } from "./constants";
 import createScrollReader from "./createScrollReader";
 import { Load, RowChange } from "./events";
@@ -280,7 +280,7 @@ export default class Spotlight<K, V> extends EventTarget {
     await this.#next(false);
 
     while (
-      this.#containerHeight < this.#height + this.#padding * TWO &&
+      this.#containerHeight < this.#height &&
       !this.#forward.finished
     ) {
       await this.#next(false);


### PR DESCRIPTION
## What changes are proposed in this pull request?

Prevent unnecessary page requests from blocking initial grid render

## How is this patch tested? If it is not, please explain why.

Locally

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Simplified condition in the `Spotlight` class to improve height management and scrolling behavior.
  
- **Style**
	- Minor formatting adjustments made to import statements for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->