### PR TITLE
Fix bug when loading HF transformers from zoo

### DIFF
--- a/fiftyone/utils/transformers.py
+++ b/fiftyone/utils/transformers.py
@@ -452,7 +452,7 @@ class FiftyOneTransformer(TransformerEmbeddingsMixin, Model):
         self.config = config
         self.model = self._load_model(config)
         self.device = (
-            "cuda" if next(config.model.parameters()).is_cuda else "cpu"
+            "cuda" if next(self.model.parameters()).is_cuda else "cpu"
         )
         self.image_processor = self._load_image_processor()
 
@@ -499,7 +499,7 @@ class FiftyOneZeroShotTransformer(
         self.classes = config.classes
         self.model = self._load_model(config)
         self.device = (
-            "cuda" if next(config.model.parameters()).is_cuda else "cpu"
+            "cuda" if next(self.model.parameters()).is_cuda else "cpu"
         )
         self.processor = self._load_processor()
         self._text_prompts = None
@@ -748,10 +748,10 @@ class FiftyOneZeroShotTransformerForObjectDetection(
         self.config = config
         self.classes = config.classes
         self.processor = self._load_processor(config)
-        self.device = (
-            "cuda" if next(config.model.parameters()).is_cuda else "cpu"
-        )
         self.model = self._load_model(config)
+        self.device = (
+            "cuda" if next(self.model.parameters()).is_cuda else "cpu"
+        )
         self._text_prompts = None
 
     def _load_processor(self, config):


### PR DESCRIPTION
This started failing when https://github.com/voxel51/fiftyone/pull/4587 was merged, now succeeds again:

```py
import fiftyone as fo
import fiftyone.zoo as foz
   
model = foz.load_zoo_model(
    "zero-shot-detection-transformer-torch",
    name_or_path="google/owlvit-base-patch32",
    classes=["cat", "dog", "bird", "fish", "turtle"],
)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Enhancements**
	- Improved the initialization logic for model and device assignment, leading to more reliable performance during setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->