### PR TITLE
Support save contexts for generated views

### DIFF
--- a/fiftyone/core/clips.py
+++ b/fiftyone/core/clips.py
@@ -47,13 +47,12 @@ class ClipView(fos.SampleView):
         return ObjectId(self._doc.sample_id)
 
     def _save(self, deferred=False):
-        if deferred:
-            raise NotImplementedError(
-                "Clips views do not support save contexts"
-            )
+        sample_ops, frame_ops = super()._save(deferred=deferred)
 
-        super()._save(deferred=deferred)
-        self._view._sync_source_sample(self)
+        if not deferred:
+            self._view._sync_source_sample(self)
+
+        return sample_ops, frame_ops
 
 
 class ClipsView(fov.DatasetView):

--- a/fiftyone/core/patches.py
+++ b/fiftyone/core/patches.py
@@ -37,13 +37,12 @@ class _PatchView(fos.SampleView):
         return ObjectId(self._doc.frame_id)
 
     def _save(self, deferred=False):
-        if deferred:
-            raise NotImplementedError(
-                "Patches views do not support save contexts"
-            )
+        sample_ops, frame_ops = super()._save(deferred=deferred)
 
-        super()._save(deferred=deferred)
-        self._view._sync_source_sample(self)
+        if not deferred:
+            self._view._sync_source_sample(self)
+
+        return sample_ops, frame_ops
 
 
 class PatchView(_PatchView):
@@ -231,7 +230,7 @@ class _PatchesView(fov.DatasetView):
         # The `set_values()` operation could change the contents of this view,
         # so we first record the sample IDs that need to be synced
         if must_sync and self._stages:
-            ids = self.values("_id")
+            ids = self.values("id")
         else:
             ids = None
 
@@ -284,7 +283,7 @@ class _PatchesView(fov.DatasetView):
         else:
             fields = [l for l in fields if l in self._label_fields]
 
-        self._sync_source_root(fields)
+        self._sync_source(fields=fields)
 
     def keep(self):
         """Deletes all patches that are **not** in this view from the
@@ -299,7 +298,7 @@ class _PatchesView(fov.DatasetView):
 
         # The `keep()` operation below will delete patches, so we must sync
         # deletions to the source dataset first
-        self._sync_source_root(self._label_fields, update=False, delete=True)
+        self._sync_source(update=False, delete=True)
 
         super().keep()
 
@@ -354,24 +353,47 @@ class _PatchesView(fov.DatasetView):
 
         self._source_collection._set_labels(field, [sample_id], [doc])
 
-    def _sync_source_field(self, field, ids=None):
+    def _sync_source(self, fields=None, ids=None, update=True, delete=False):
+        if fields is not None:
+            fields = [f for f in fields if f in self._label_fields]
+            if not fields:
+                return
+        else:
+            fields = self._label_fields
+
+        for field in fields:
+            self._sync_source_field(
+                field, ids=ids, update=update, delete=delete
+            )
+
+    def _sync_source_field(self, field, ids=None, update=True, delete=False):
         if field not in self._label_fields:
             return
 
         _, label_path = self._get_label_field_path(field)
 
         if ids is not None:
-            view = self._patches_dataset.mongo(
-                [{"$match": {"_id": {"$in": ids}}}]
-            )
+            view = self._patches_dataset.select(ids)
         else:
             view = self._patches_dataset
 
-        sample_ids, docs = view.aggregate(
-            [foa.Values(self._id_field), foa.Values(label_path, _raw=True)]
-        )
+        if update:
+            sample_ids, docs = view.aggregate(
+                [foa.Values(self._id_field), foa.Values(label_path, _raw=True)]
+            )
 
-        self._source_collection._set_labels(field, sample_ids, docs)
+            self._source_collection._set_labels(field, sample_ids, docs)
+
+        if delete:
+            label_id_path = label_path + ".id"
+            all_ids = self._patches_dataset.values(label_id_path, unwind=True)
+            self_ids = self.values(label_id_path, unwind=True)
+            del_ids = set(all_ids) - set(self_ids)
+
+            if del_ids:
+                self._source_collection._delete_labels(
+                    ids=del_ids, fields=field
+                )
 
     def _sync_source_field_schema(self, path):
         root = path.split(".", 1)[0]
@@ -393,37 +415,6 @@ class _PatchesView(fov.DatasetView):
 
         if self._source_collection._is_generated:
             self._source_collection._sync_source_field_schema(dst_path)
-
-    def _sync_source_root(self, fields, update=True, delete=False):
-        for field in fields:
-            self._sync_source_root_field(field, update=update, delete=delete)
-
-    def _sync_source_root_field(self, field, update=True, delete=False):
-        if field not in self._label_fields:
-            return
-
-        _, label_id_path = self._get_label_field_path(field, "id")
-        label_path = label_id_path.rsplit(".", 1)[0]
-
-        if update:
-            sample_ids, docs = self._patches_dataset.aggregate(
-                [
-                    foa.Values(self._id_field),
-                    foa.Values(label_path, _raw=True),
-                ]
-            )
-
-            self._source_collection._set_labels(field, sample_ids, docs)
-
-        if delete:
-            all_ids = self._patches_dataset.values(label_id_path, unwind=True)
-            self_ids = self.values(label_id_path, unwind=True)
-            del_ids = set(all_ids) - set(self_ids)
-
-            if del_ids:
-                self._source_collection._delete_labels(
-                    ids=del_ids, fields=field
-                )
 
     def _sync_source_keep_fields(self):
         src_schema = self.get_field_schema()

--- a/fiftyone/core/video.py
+++ b/fiftyone/core/video.py
@@ -54,13 +54,12 @@ class FrameView(fos.SampleView):
         return ObjectId(self._doc.sample_id)
 
     def _save(self, deferred=False):
-        if deferred:
-            raise NotImplementedError(
-                "Frames views do not support save contexts"
-            )
+        sample_ops, frame_ops = super()._save(deferred=deferred)
 
-        super()._save(deferred=deferred)
-        self._view._sync_source_sample(self)
+        if not deferred:
+            self._view._sync_source_sample(self)
+
+        return sample_ops, frame_ops
 
 
 class FramesView(fov.DatasetView):

--- a/tests/unittests/patches_tests.py
+++ b/tests/unittests/patches_tests.py
@@ -718,6 +718,42 @@ class PatchesTests(unittest.TestCase):
         )
         self.assertEqual(len(patches_dataset), len(patches_view))
 
+    @drop_datasets
+    def test_patches_save_context(self):
+        dataset = fo.Dataset()
+
+        sample1 = fo.Sample(
+            filepath="image1.png",
+            ground_truth=fo.Detections(
+                detections=[
+                    fo.Detection(label="cat"),
+                    fo.Detection(label="dog"),
+                    fo.Detection(label="rabbit"),
+                ]
+            ),
+        )
+
+        sample2 = fo.Sample(filepath="image2.png")
+
+        sample3 = fo.Sample(
+            filepath="image3.png",
+            ground_truth=fo.Detections(
+                detections=[
+                    fo.Detection(label="squirrel"),
+                ]
+            ),
+        )
+
+        dataset.add_samples([sample1, sample2, sample3])
+
+        view = dataset.to_patches("ground_truth")
+
+        for sample in view.iter_samples(autosave=True):
+            sample.ground_truth.foo = "bar"
+
+        self.assertEqual(view.count("ground_truth.foo"), 4)
+        self.assertEqual(dataset.count("ground_truth.detections.foo"), 4)
+
 
 if __name__ == "__main__":
     fo.config.show_progress_bars = False


### PR DESCRIPTION
Resolves #4619 

Prior to `fiftyone==0.23.8`, methods like `compute_embeddings()` and `apply_model()` were calling `sample.save()` in a loop, which is inefficient, so we updated these methods to use save contexts in https://github.com/voxel51/fiftyone/pull/4244.

However, save contexts were not yet implemented for generated views, so the above methods stopped working when invoked on generated views such as `to_patches()` 😭

This PR resolves this by fully implementing save contexts for generated views 🥂 

## Tested by

Added unit tests 🪄 

## Example usage

```py
import fiftyone as fo
import fiftyone.zoo as foz

dataset = foz.load_zoo_dataset("quickstart")
model = foz.load_zoo_model("resnet50-imagenet-torch")

patches = dataset.limit(10).to_patches("ground_truth")

# Started failing in 0.23.8, now succeeds again
patches.compute_patch_embeddings(model, "ground_truth", embeddings_field="resnet")
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved handling of deferred saves in sample management, allowing for more flexible saving options.
	- Enhanced tracking and synchronization of generated samples within collections.
	- Added functionality for managing source synchronization in patch operations.

- **Bug Fixes**
	- Resolved constraints on deferred saves that previously restricted functionality.

- **Tests**
	- Introduced new tests to validate context saving for patches, frames, and clips, ensuring robust dataset handling.

- **Refactor**
	- Streamlined synchronization logic in various components to improve maintainability and functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->