### PR TITLE
Session state enhancements

### DIFF
--- a/fiftyone/core/session/session.py
+++ b/fiftyone/core/session/session.py
@@ -720,14 +720,16 @@ class Session(object):
         else:
             self._state.group_slice = None
 
-        self._state.dataset = dataset
-        self._state.view = None
-        self._state.spaces = default_workspace_factory()
         self._state.color_scheme = build_color_scheme(
             None, dataset, self.config
         )
+        self._state.dataset = dataset
+        self._state.group_id = None
+        self._state.sample_id = None
+        self._state.spaces = default_workspace_factory()
         self._state.selected = []
         self._state.selected_labels = []
+        self._state.view = None
 
     @property
     def view(self) -> t.Union[fov.DatasetView, None]:
@@ -767,6 +769,8 @@ class Session(object):
             self._state.view = view
             self._state.view_name = view.name
 
+        self._state.group_id = None
+        self._state.sample_id = None
         self._state.selected = []
         self._state.selected_labels = []
 

--- a/fiftyone/server/mutation.py
+++ b/fiftyone/server/mutation.py
@@ -211,7 +211,7 @@ class Mutation(SetColorScheme):
 
         if not dataset_name:
             state.dataset = None
-            state.group_slice
+            state.group_slice = None
             state.spaces = foo.default_workspace_factory()
             state.view = None
             await dispatch_event(subscription, fose.StateUpdate(state=state))

--- a/fiftyone/server/mutation.py
+++ b/fiftyone/server/mutation.py
@@ -90,13 +90,17 @@ class Mutation(SetColorScheme):
     ) -> bool:
         state = get_state()
         state.dataset = fod.load_dataset(name) if name is not None else None
-        state.selected = []
-        state.selected_labels = []
-        state.view = None
-        state.spaces = foo.default_workspace_factory()
+
         state.color_scheme = build_color_scheme(
             None, state.dataset, state.config
         )
+        state.group_id = None
+        state.sample_id = None
+        state.selected = []
+        state.selected_labels = []
+        state.spaces = foo.default_workspace_factory()
+        state.view = None
+
         if state.dataset is not None:
             state.group_slice = state.dataset.group_slice
 
@@ -200,14 +204,18 @@ class Mutation(SetColorScheme):
         form: t.Optional[StateForm] = None,
     ) -> t.Union[BSONArray, None]:
         state = get_state()
+        state.group_id = None
+        state.sample_id = None
         state.selected = []
         state.selected_labels = []
+
         if not dataset_name:
             state.dataset = None
-            state.view = None
+            state.group_slice
             state.spaces = foo.default_workspace_factory()
-            state.group_slice = None
+            state.view = None
             await dispatch_event(subscription, fose.StateUpdate(state=state))
+            return None
 
         result_view = None
         ds = fod.load_dataset(dataset_name)


### PR DESCRIPTION
## What changes are proposed in this pull request?

Adds `sample_id` and `group_id` transition handling to mutations and `Session` state updates

## How is this patch tested? If it is not, please explain why.

Locally

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced session state management for dataset and view handling.
	- Improved initialization of identifiers for group and sample management.

- **Bug Fixes**
	- Clarified initialization process within async functions for dataset and view setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->