### PR TITLE
fix operator execution error being suppressed

### DIFF
--- a/app/packages/operators/src/operators.ts
+++ b/app/packages/operators/src/operators.ts
@@ -162,7 +162,8 @@ export class OperatorResult {
     public result: object = {},
     public executor: Executor = null,
     public error: string,
-    public delegated: boolean = false
+    public delegated: boolean = false,
+    public errorMessage: string = null
   ) {}
   hasOutputContent() {
     if (this.delegated) return false;
@@ -657,6 +658,7 @@ export async function executeOperatorWithContext(
 
   let result;
   let error;
+  let errorMessage;
   let executor;
   let delegated = false;
 
@@ -667,6 +669,7 @@ export async function executeOperatorWithContext(
         result = serverResult.result;
         delegated = serverResult.delegated;
         error = serverResult.error;
+        errorMessage = serverResult.error_message;
       } catch (e) {
         const isAbortError =
           e.name === "AbortError" || e instanceof DOMException;
@@ -674,6 +677,7 @@ export async function executeOperatorWithContext(
           error = e;
           console.error(`Error executing operator ${operatorURI}:`);
           console.error(error);
+          errorMessage = error.message;
         }
       }
     } else {
@@ -700,6 +704,7 @@ export async function executeOperatorWithContext(
       );
       result = serverResult.result;
       error = serverResult.error;
+      errorMessage = serverResult.error_message;
       executor = serverResult.executor;
       delegated = serverResult.delegated;
     }
@@ -741,7 +746,14 @@ export async function executeOperatorWithContext(
     error,
   });
 
-  return new OperatorResult(operator, result, executor, error, delegated);
+  return new OperatorResult(
+    operator,
+    result,
+    executor,
+    error,
+    delegated,
+    errorMessage
+  );
 }
 
 type CurrentContext = {

--- a/app/packages/operators/src/state.ts
+++ b/app/packages/operators/src/state.ts
@@ -921,13 +921,14 @@ export function useOperatorExecutor(uri, handlers: any = {}) {
         callback?.(new OperatorResult(operator, null, ctx.executor, e, false));
         const isAbortError =
           e.name === "AbortError" || e instanceof DOMException;
+        const msg = e.message || "Failed to execute an operation";
         if (!isAbortError) {
           setError(e);
           setResult(null);
           handlers.onError?.(e);
           console.error("Error executing operator", operator, ctx);
           console.error(e);
-          notify({ msg: e.message, variant: "error" });
+          notify({ msg, variant: "error" });
         }
       }
       setHasExecuted(true);

--- a/app/packages/operators/src/usePanelEvent.ts
+++ b/app/packages/operators/src/usePanelEvent.ts
@@ -2,6 +2,7 @@ import { usePanelStateByIdCallback } from "@fiftyone/spaces";
 import { executeOperator } from "./operators";
 import { usePromptOperatorInput } from "./state";
 import { ExecutionCallback } from "./types-internal";
+import { useNotification } from "@fiftyone/state";
 
 type HandlerOptions = {
   params: any;
@@ -13,6 +14,7 @@ type HandlerOptions = {
 
 export default function usePanelEvent() {
   const promptForOperator = usePromptOperatorInput();
+  const notify = useNotification();
   return usePanelStateByIdCallback((panelId, panelState, args) => {
     const options = args[0] as HandlerOptions;
     const { params, operator, prompt } = options;
@@ -21,10 +23,22 @@ export default function usePanelEvent() {
       panel_id: panelId,
       panel_state: panelState?.state || {},
     };
+
+    const eventCallback = (result) => {
+      const msg =
+        result.errorMessage || result.error || "Failed to execute operation";
+      const computedMsg = `${msg} (operation: ${operator})`;
+      if (result?.error) {
+        notify({ msg: computedMsg, variant: "error" });
+        console.error(result?.error);
+      }
+      options?.callback?.(result);
+    };
+
     if (prompt) {
-      promptForOperator(operator, actualParams, { callback: options.callback });
+      promptForOperator(operator, actualParams, { callback: eventCallback });
     } else {
-      executeOperator(operator, actualParams, { callback: options.callback });
+      executeOperator(operator, actualParams, { callback: eventCallback });
     }
   });
 }

--- a/fiftyone/operators/executor.py
+++ b/fiftyone/operators/executor.py
@@ -281,16 +281,20 @@ async def execute_or_delegate_operator(
                 else None
             )
             return execution
-        except:
+        except Exception as error:
             return ExecutionResult(
-                executor=executor, error=traceback.format_exc()
+                executor=executor,
+                error=traceback.format_exc(),
+                error_message=str(error),
             )
     else:
         try:
             result = await do_execute_operator(operator, ctx, exhaust=exhaust)
-        except:
+        except Exception as error:
             return ExecutionResult(
-                executor=executor, error=traceback.format_exc()
+                executor=executor,
+                error=traceback.format_exc(),
+                error_message=str(error),
             )
 
         return ExecutionResult(result=result, executor=executor)
@@ -839,7 +843,8 @@ class ExecutionResult(object):
     Args:
         result (None): the execution result
         executor (None): an :class:`Executor`
-        error (None): an error message
+        error (None): an error traceback, if an error occurred
+        error_message (None): an error message, if an error occurred
         validation_ctx (None): a :class:`ValidationContext`
         delegated (False): whether execution was delegated
         outputs_schema (None): a JSON dict representing the output schema of the operator
@@ -850,6 +855,7 @@ class ExecutionResult(object):
         result=None,
         executor=None,
         error=None,
+        error_message=None,
         validation_ctx=None,
         delegated=False,
         outputs_schema=None,
@@ -857,6 +863,7 @@ class ExecutionResult(object):
         self.result = result
         self.executor = executor
         self.error = error
+        self.error_message = error_message
         self.validation_ctx = validation_ctx
         self.delegated = delegated
         self.outputs_schema = outputs_schema
@@ -904,6 +911,7 @@ class ExecutionResult(object):
             "result": self.result,
             "executor": self.executor.to_json() if self.executor else None,
             "error": self.error,
+            "error_message": self.error_message,
             "delegated": self.delegated,
             "validation_ctx": (
                 self.validation_ctx.to_json() if self.validation_ctx else None


### PR DESCRIPTION
## What changes are proposed in this pull request?

Show panel events error as notification

## How is this patch tested? If it is not, please explain why.

using an example python panel with several events raising an exception

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced error reporting in operator execution with detailed error messages.
	- Integrated user notifications for operation failures to improve feedback.
- **Bug Fixes**
	- Improved clarity and consistency in error handling across various functions.
	- Refined logic for event handling related to panel state changes.
- **Refactor**
	- Streamlined event handling logic in the `useCustomPanelHooks` function.
	- Modified exception handling to improve robustness and specificity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->