### PR TITLE
Add SceneMetadata to missing locations

### DIFF
--- a/fiftyone/__public__.py
+++ b/fiftyone/__public__.py
@@ -113,6 +113,7 @@ from .core.metadata import (
     Metadata,
     ImageMetadata,
     VideoMetadata,
+    SceneMetadata,
 )
 from .core.models import (
     apply_model,

--- a/fiftyone/core/metadata.py
+++ b/fiftyone/core/metadata.py
@@ -350,6 +350,8 @@ def get_metadata_cls(media_type):
         return ImageMetadata
     elif media_type == fom.VIDEO:
         return VideoMetadata
+    elif media_type == fom.THREE_D:
+        return SceneMetadata
 
     return Metadata
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

Adding sceneMetadata to public and to get_metadata_cls

```
import fiftyone as fo

dataset = fo.load_dataset("quickstart-3d")
sample = dataset.first()
filepath = sample["filepath"]
size = fo.SceneMetadata.build_for(filepath, _cache=None).size_bytes
print(size)
print(filepath)
```

## How is this patch tested? If it is not, please explain why.

ipython

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced `SceneMetadata` to enhance functionality related to scene-specific data management.
  - Expanded metadata handling to support three-dimensional media types.
  - Added Elasticsearch integration for enhanced vector search capabilities.
  - New backend option for `compute_similarity()` method using Elasticsearch.

- **Documentation**
  - Updated documentation to include information about Elasticsearch integration and its setup.
  - Enhanced user guide with details on Elasticsearch as a backend option for similarity computations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->