### PR TITLE
overridable OperatorIO state and scoped cache

### DIFF
--- a/app/packages/core/src/plugins/OperatorIO/index.tsx
+++ b/app/packages/core/src/plugins/OperatorIO/index.tsx
@@ -13,11 +13,15 @@ function OperatorIOComponent(props) {
     layout,
     onPathChange,
     initialData,
+    id,
+    shouldClearUseKeyStores,
   } = props;
   const ioSchema = operatorToIOSchema(schema, { isOutput: type === "output" });
 
   return (
     <SchemaIOComponent
+      id={id}
+      shouldClearUseKeyStores={shouldClearUseKeyStores}
       schema={ioSchema}
       onChange={onChange}
       onPathChange={onPathChange}

--- a/app/packages/core/src/plugins/SchemaIO/components/DynamicIO.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/DynamicIO.tsx
@@ -2,7 +2,7 @@ import { PluginComponentType, useActivePlugins } from "@fiftyone/plugins";
 import { isNullish } from "@fiftyone/utilities";
 import { get, isEqual, set } from "lodash";
 import { useEffect, useMemo } from "react";
-import { isPathUserChanged } from "../hooks";
+import { isPathUserChanged, useUnboundState } from "../hooks";
 import {
   getComponent,
   getErrorsForView,
@@ -13,24 +13,12 @@ import { AncestorsType, SchemaType, ViewPropsType } from "../utils/types";
 import ContainerizedComponent from "./ContainerizedComponent";
 
 export default function DynamicIO(props: ViewPropsType) {
-  const { data, schema, onChange, path, root_id } = props;
+  const { schema, onChange } = props;
   const customComponents = useCustomComponents();
   const Component = getComponent(schema, customComponents);
   const computedSchema = getComputedSchema(props);
-  const { default: defaultValue } = computedSchema;
 
-  // todo: need to improve initializing default value in state
-  useEffect(() => {
-    if (
-      !isCompositeView(schema) &&
-      !isEqual(data, defaultValue) &&
-      !isPathUserChanged(path,root_id) &&
-      !isNullish(defaultValue) &&
-      !isInitialized(props)
-    ) {
-      onChange(path, defaultValue, computedSchema);
-    }
-  }, [defaultValue]);
+  useStateInitializer(props);
 
   const onChangeWithSchema = useMemo(() => {
     return (
@@ -70,6 +58,51 @@ function useCustomComponents() {
     componentsByName[component.name] = component.component;
     return componentsByName;
   }, {});
+}
+
+// todo: need to improve initializing the state... refactor this function
+function useStateInitializer(props: ViewPropsType) {
+  const { data, schema, onChange, path, root_id } = props;
+  const computedSchema = getComputedSchema(props);
+  const { default: defaultValue } = computedSchema;
+  const basicData = useMemo(() => {
+    if (!isCompositeView(schema)) {
+      return data;
+    }
+  }, [data, schema]);
+  const unboundState = useUnboundState({
+    computedSchema,
+    data,
+    path,
+    root_id,
+    props,
+  });
+
+  useEffect(() => {
+    const { computedSchema, data, path, root_id, props } = unboundState || {};
+    if (
+      !isCompositeView(computedSchema) &&
+      !isEqual(data, defaultValue) &&
+      !isPathUserChanged(path, root_id) &&
+      !isNullish(defaultValue) &&
+      !isInitialized(props)
+    ) {
+      onChange(path, defaultValue, computedSchema);
+    }
+  }, [defaultValue, onChange, unboundState]);
+
+  useEffect(() => {
+    if (basicData) {
+      const { computedSchema, path, data } = unboundState || {};
+      if (
+        !isEqual(data, basicData) &&
+        !isCompositeView(computedSchema) &&
+        !isNullish(path)
+      ) {
+        onChange(path, basicData, computedSchema);
+      }
+    }
+  }, [basicData, onChange, unboundState]);
 }
 
 function schemaWithInheritedDefault(

--- a/app/packages/core/src/plugins/SchemaIO/components/DynamicIO.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/DynamicIO.tsx
@@ -1,7 +1,7 @@
 import { PluginComponentType, useActivePlugins } from "@fiftyone/plugins";
 import { isNullish } from "@fiftyone/utilities";
 import { get, isEqual, set } from "lodash";
-import { useEffect, useMemo } from "react";
+import React, { useEffect, useMemo } from "react";
 import { isPathUserChanged, useUnboundState } from "../hooks";
 import {
   getComponent,
@@ -62,7 +62,7 @@ function useCustomComponents() {
 
 // todo: need to improve initializing the state... refactor this function
 function useStateInitializer(props: ViewPropsType) {
-  const { data, schema, onChange, path, root_id } = props;
+  const { data, schema, onChange } = props;
   const computedSchema = getComputedSchema(props);
   const { default: defaultValue } = computedSchema;
   const basicData = useMemo(() => {
@@ -70,16 +70,11 @@ function useStateInitializer(props: ViewPropsType) {
       return data;
     }
   }, [data, schema]);
-  const unboundState = useUnboundState({
-    computedSchema,
-    data,
-    path,
-    root_id,
-    props,
-  });
+  const unboundState = useUnboundState({ computedSchema, props });
 
   useEffect(() => {
-    const { computedSchema, data, path, root_id, props } = unboundState || {};
+    const { computedSchema, props } = unboundState || {};
+    const { data, path, root_id } = props || {};
     if (
       !isCompositeView(computedSchema) &&
       !isEqual(data, defaultValue) &&
@@ -93,7 +88,8 @@ function useStateInitializer(props: ViewPropsType) {
 
   useEffect(() => {
     if (basicData) {
-      const { computedSchema, path, data } = unboundState || {};
+      const { computedSchema, props } = unboundState || {};
+      const { data, path } = props || {};
       if (
         !isEqual(data, basicData) &&
         !isCompositeView(computedSchema) &&

--- a/app/packages/core/src/plugins/SchemaIO/components/DynamicIO.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/DynamicIO.tsx
@@ -13,7 +13,7 @@ import { AncestorsType, SchemaType, ViewPropsType } from "../utils/types";
 import ContainerizedComponent from "./ContainerizedComponent";
 
 export default function DynamicIO(props: ViewPropsType) {
-  const { data, schema, onChange, path } = props;
+  const { data, schema, onChange, path, root_id } = props;
   const customComponents = useCustomComponents();
   const Component = getComponent(schema, customComponents);
   const computedSchema = getComputedSchema(props);
@@ -24,7 +24,7 @@ export default function DynamicIO(props: ViewPropsType) {
     if (
       !isCompositeView(schema) &&
       !isEqual(data, defaultValue) &&
-      !isPathUserChanged(path) &&
+      !isPathUserChanged(path,root_id) &&
       !isNullish(defaultValue) &&
       !isInitialized(props)
     ) {

--- a/app/packages/core/src/plugins/SchemaIO/hooks/context.ts
+++ b/app/packages/core/src/plugins/SchemaIO/hooks/context.ts
@@ -1,0 +1,7 @@
+import { createContext } from "react";
+
+export const SchemaIOContext = createContext<SchemaIOContextType>({});
+
+type SchemaIOContextType = {
+  id?: string;
+};

--- a/app/packages/core/src/plugins/SchemaIO/hooks/index.ts
+++ b/app/packages/core/src/plugins/SchemaIO/hooks/index.ts
@@ -1,1 +1,2 @@
 export * from "./useKey";
+export * from "./context";

--- a/app/packages/core/src/plugins/SchemaIO/hooks/index.ts
+++ b/app/packages/core/src/plugins/SchemaIO/hooks/index.ts
@@ -1,2 +1,3 @@
 export * from "./useKey";
 export * from "./context";
+export * from "./useUnboundState";

--- a/app/packages/core/src/plugins/SchemaIO/hooks/useKey.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/hooks/useKey.tsx
@@ -1,10 +1,12 @@
 import { isNullish } from "@fiftyone/utilities";
 import { get } from "lodash";
-import { useCallback, useMemo } from "react";
+import { useCallback, useContext, useMemo } from "react";
 import { ViewPropsType } from "../utils/types";
+import { SchemaIOContext } from "./context";
 
-const userChangedPaths = new Set<string>();
-const pathsRefreshCount = new Map<string, number>();
+const userChangedPathsById = new Map<string, Set<string>>();
+const pathsRefreshCountById = new Map<string, Map<string, number>>();
+const DEFAULT_ID = "__global__";
 
 export function useKey(
   path: string,
@@ -16,6 +18,9 @@ export function useKey(
     return useData ? data : data ?? get(schema, "default");
   }, [useData, data, schema]);
   const memoizedPath = useMemo(() => path, [path]);
+  const { id = DEFAULT_ID } = useContext(SchemaIOContext);
+  const userChangedPaths = getUserChangedPaths(id);
+  const pathsRefreshCount = getPathsRefreshCount(id);
 
   const key = useMemo(() => {
     let refreshCount: number = pathsRefreshCount.get(memoizedPath) || 0;
@@ -24,20 +29,40 @@ export function useKey(
       pathsRefreshCount.set(memoizedPath, refreshCount);
     }
     return `${memoizedPath}-${refreshCount}`;
-  }, [memoizedPath, value]);
+  }, [memoizedPath, value, userChangedPaths, pathsRefreshCount]);
 
   const setUserChanged = useCallback(() => {
     userChangedPaths.add(memoizedPath);
-  }, [memoizedPath]);
+  }, [memoizedPath, userChangedPaths]);
 
   return [key, setUserChanged];
 }
 
-export function clearUseKeyStores() {
-  userChangedPaths.clear();
-  pathsRefreshCount.clear();
+export function clearUseKeyStores(id: string = DEFAULT_ID) {
+  userChangedPathsById.delete(id);
+  pathsRefreshCountById.delete(id);
 }
 
-export function isPathUserChanged(path: string) {
+export function isPathUserChanged(path: string, id: string = DEFAULT_ID) {
+  const userChangedPaths = getUserChangedPaths(id);
   return userChangedPaths.has(path);
+}
+
+export function setPathUserUnchanged(path: string, id: string = DEFAULT_ID) {
+  const userChangedPaths = getUserChangedPaths(id);
+  userChangedPaths.delete(path);
+}
+
+function getUserChangedPaths(id: string) {
+  if (!userChangedPathsById.has(id)) {
+    userChangedPathsById.set(id, new Set<string>());
+  }
+  return userChangedPathsById.get(id) as Set<string>;
+}
+
+function getPathsRefreshCount(id: string) {
+  if (!pathsRefreshCountById.has(id)) {
+    pathsRefreshCountById.set(id, new Map<string, number>());
+  }
+  return pathsRefreshCountById.get(id) as Map<string, number>;
 }

--- a/app/packages/core/src/plugins/SchemaIO/hooks/useUnboundState.ts
+++ b/app/packages/core/src/plugins/SchemaIO/hooks/useUnboundState.ts
@@ -1,0 +1,15 @@
+import { useEffect, useRef } from "react";
+
+/**
+ * The hook can be used to get the latest value of the state without
+ * re-rendering the component.
+ */
+export function useUnboundState<State>(value: State): State {
+  const stateRef = useRef({} as State);
+
+  useEffect(() => {
+    stateRef.current = value;
+  }, [value]);
+
+  return stateRef.current;
+}

--- a/app/packages/core/src/plugins/SchemaIO/index.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/index.tsx
@@ -20,27 +20,34 @@ export function SchemaIOComponent(props) {
 
   const onIOChange = useCallback(
     (path, value, schema, ancestors) => {
-      if (onPathChange) {
-        onPathChange(path, value, schema);
-      }
       const currentState = stateRef.current;
       const updatedState = cloneDeep(currentState);
       set(updatedState, path, cloneDeep(value));
       stateRef.current = updatedState;
-      if (onChange) onChange(updatedState);
+      if (onPathChange) {
+        onPathChange(path, value, schema, updatedState);
+      }
+      if (onChange) {
+        onChange(updatedState);
+      }
 
       // propagate the change to all ancestors
       for (const ancestorPath in ancestors) {
         const ancestorSchema = ancestors[ancestorPath];
         const ancestorValue = get(updatedState, ancestorPath);
         if (onPathChange) {
-          onPathChange(ancestorPath, ancestorValue, ancestorSchema);
+          onPathChange(
+            ancestorPath,
+            ancestorValue,
+            ancestorSchema,
+            updatedState
+          );
         }
       }
 
       return updatedState;
     },
-    [onChange]
+    [onChange, onPathChange]
   );
 
   return (

--- a/app/packages/core/src/plugins/SchemaIO/index.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/index.tsx
@@ -2,15 +2,20 @@ import { PluginComponentType, registerComponent } from "@fiftyone/plugins";
 import { cloneDeep, get, set } from "lodash";
 import React, { useCallback, useEffect, useRef } from "react";
 import DynamicIO from "./components/DynamicIO";
-import { clearUseKeyStores } from "./hooks";
+import { clearUseKeyStores, SchemaIOContext } from "./hooks";
 
 export function SchemaIOComponent(props) {
-  const { onChange, onPathChange } = props;
+  const { onChange, onPathChange, id, shouldClearUseKeyStores } = props;
   const stateRef = useRef({});
   const autoFocused = useRef(false);
+  const schemaIOContext = { id };
 
   useEffect(() => {
-    return clearUseKeyStores;
+    return () => {
+      if (shouldClearUseKeyStores !== false) {
+        clearUseKeyStores(id);
+      }
+    };
   }, []);
 
   const onIOChange = useCallback(
@@ -39,12 +44,15 @@ export function SchemaIOComponent(props) {
   );
 
   return (
-    <DynamicIO
-      {...props}
-      onChange={onIOChange}
-      path=""
-      autoFocused={autoFocused}
-    />
+    <SchemaIOContext.Provider value={schemaIOContext}>
+      <DynamicIO
+        {...props}
+        root_id={id}
+        onChange={onIOChange}
+        path=""
+        autoFocused={autoFocused}
+      />
+    </SchemaIOContext.Provider>
   );
 }
 

--- a/app/packages/core/src/plugins/SchemaIO/utils/index.ts
+++ b/app/packages/core/src/plugins/SchemaIO/utils/index.ts
@@ -97,6 +97,6 @@ export function isCompositeView(schema: SchemaType) {
 }
 
 export function isInitialized(props: ViewPropsType) {
-  const { initialData, path } = props;
+  const { initialData, path } = props || {};
   return !isNullish(get(initialData, path));
 }

--- a/app/packages/core/src/plugins/SchemaIO/utils/types.ts
+++ b/app/packages/core/src/plugins/SchemaIO/utils/types.ts
@@ -26,6 +26,7 @@ export type SchemaType =
   | NumberSchemaType;
 
 export type ViewPropsType<Schema extends SchemaType = SchemaType> = {
+  root_id?: string;
   schema: Schema;
   path: string;
   errors: { [key: string]: string[] };

--- a/app/packages/operators/src/CustomPanel.tsx
+++ b/app/packages/operators/src/CustomPanel.tsx
@@ -1,13 +1,13 @@
 import { CenteredStack, CodeBlock } from "@fiftyone/components";
-import { PanelSkeleton } from "@fiftyone/spaces";
+import { PanelSkeleton, useSetPanelCloseEffect } from "@fiftyone/spaces";
 import * as fos from "@fiftyone/state";
 import { Box, Typography } from "@mui/material";
 import OperatorIO from "./OperatorIO";
 import { PANEL_LOAD_TIMEOUT } from "./constants";
 import { Property } from "./types";
-
 import { CustomPanelProps, useCustomPanelHooks } from "./useCustomPanelHooks";
 import { useEffect } from "react";
+import { clearUseKeyStores } from "@fiftyone/core/src/plugins/SchemaIO/hooks";
 
 export function CustomPanel(props: CustomPanelProps) {
   const { panelId, dimensions, panelName, panelLabel } = props;
@@ -21,6 +21,13 @@ export function CustomPanel(props: CustomPanelProps) {
     onLoadError,
   } = useCustomPanelHooks(props);
   const pending = fos.useTimeout(PANEL_LOAD_TIMEOUT);
+  const setPanelCloseEffect = useSetPanelCloseEffect();
+
+  useEffect(() => {
+    setPanelCloseEffect(() => {
+      clearUseKeyStores(panelId);
+    });
+  }, []);
 
   if (pending && !panelSchema && !onLoadError) {
     return <PanelSkeleton />;
@@ -55,11 +62,13 @@ export function CustomPanel(props: CustomPanelProps) {
     >
       <DimensionRefresher dimensions={dimensions}>
         <OperatorIO
+          id={panelId}
           schema={schema}
           onChange={handlePanelStateChange}
           data={data}
           layout={{ height, width }}
           onPathChange={handlePanelStatePathChange}
+          shouldClearUseKeyStores={false}
         />
       </DimensionRefresher>
     </Box>

--- a/app/packages/operators/src/constants.ts
+++ b/app/packages/operators/src/constants.ts
@@ -15,3 +15,4 @@ export enum QueueItemStatus {
   Failed,
 }
 export const PANEL_STATE_CHANGE_DEBOUNCE = 500;
+export const PANEL_STATE_PATH_CHANGE_DEBOUNCE = 250;

--- a/app/packages/operators/src/usePanelEvent.ts
+++ b/app/packages/operators/src/usePanelEvent.ts
@@ -10,6 +10,7 @@ type HandlerOptions = {
   prompt?: boolean;
   panelId: string;
   callback?: ExecutionCallback;
+  currentPanelState?: any; // most current panel state
 };
 
 export default function usePanelEvent() {
@@ -17,11 +18,12 @@ export default function usePanelEvent() {
   const notify = useNotification();
   return usePanelStateByIdCallback((panelId, panelState, args) => {
     const options = args[0] as HandlerOptions;
-    const { params, operator, prompt } = options;
+    const { params, operator, prompt, currentPanelState } = options;
+
     const actualParams = {
       ...params,
       panel_id: panelId,
-      panel_state: panelState?.state || {},
+      panel_state: currentPanelState ?? (panelState?.state || {}),
     };
 
     const eventCallback = (result) => {

--- a/app/packages/operators/src/utils.ts
+++ b/app/packages/operators/src/utils.ts
@@ -1,6 +1,7 @@
 import { getFetchParameters } from "@fiftyone/utilities";
+import { debounce, DebounceSettings, memoize } from "lodash";
 import { KeyboardEventHandler } from "react";
-import { ValidationErrorsType, OperatorPromptType, PromptView } from "./types";
+import { OperatorPromptType, PromptView, ValidationErrorsType } from "./types";
 
 export function stringifyError(error, fallback?) {
   if (typeof error === "string") return error;
@@ -112,9 +113,31 @@ export function getOperatorPromptConfigs(operatorPrompt: OperatorPromptType) {
   };
 }
 
+/**
+ * Params aware debounce
+ */
+export function memoizedDebounce(
+  func,
+  wait = 0,
+  options?: MemoizedDebounceOptions
+) {
+  const memoizedFunc = memoize(function () {
+    return debounce(func, wait, options);
+  }, options?.resolver);
+  return function () {
+    memoizedFunc.apply(this, arguments).apply(this, arguments);
+  };
+}
+
 function getPromptTitle(operatorPrompt) {
   const definition = operatorPrompt.showPrompt
     ? operatorPrompt?.inputFields
     : operatorPrompt?.outputFields;
   return definition?.view?.label;
 }
+
+type MemoizeResolver = (...args) => any;
+
+type MemoizedDebounceOptions = DebounceSettings & {
+  resolver: MemoizeResolver;
+};

--- a/fiftyone/operators/operations.py
+++ b/fiftyone/operators/operations.py
@@ -232,6 +232,18 @@ class Operations(object):
             },
         )
 
+    def apply_panel_state_path(self, path, panel_id=None):
+        """Force update the state for path in the specified panel in the App.
+
+        Args:
+
+            path (str): the path to force update
+        """
+        return self._ctx.trigger(
+            "apply_panel_state_path",
+            params={**self._create_panel_params(panel_id), "path": path},
+        )
+
     def show_panel_output(self, output, panel_id=None):
         """Show output in the specified panel in the App.
 

--- a/fiftyone/operators/panel.py
+++ b/fiftyone/operators/panel.py
@@ -200,6 +200,15 @@ class PanelRefState(PanelRefBase):
         super().clear()
         self._ctx.ops.clear_panel_state()
 
+    def apply(self, path):
+        """
+        Applies the state to the panel.
+
+        Args:
+            path (str): The path to the state.
+        """
+        self._ctx.ops.apply_panel_state_path(path)
+
 
 class PanelRefData(PanelRefBase):
     """


### PR DESCRIPTION
## What changes are proposed in this pull request?

- Allow overriding user modified field in OperatorIO in panel context
- Scoped OperatorIO cache

## How is this patch tested? If it is not, please explain why.

Using a test python panel

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced `OperatorIOComponent` and `SchemaIOComponent` with additional props for improved functionality.
	- Introduced a new React context for centralized schema I/O operations.
	- Added a custom hook `useUnboundState` for efficient state management.
	- Introduced `apply_panel_state_path` and `apply` methods for managing panel states effectively.

- **Improvements**
	- Refactored state management and logic in various components for better readability and modularity.
	- Updated `CustomPanel` to enhance state tracking and management interactions.
	- Enhanced event handling to utilize the most recent panel state effectively.

- **Bug Fixes**
	- Adjusted logic in built-in operators and hooks to ensure more reliable state handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->