### PR TITLE
fix add panel item overflow issue

### DIFF
--- a/app/packages/spaces/src/components/AddPanelItem.tsx
+++ b/app/packages/spaces/src/components/AddPanelItem.tsx
@@ -1,10 +1,10 @@
 import { useTrackEvent } from "@fiftyone/analytics";
+import { Stack, Typography } from "@mui/material";
 import { Layout } from "../enums";
 import { useSpaces } from "../hooks";
 import SpaceNode from "../SpaceNode";
 import { AddPanelItemProps } from "../types";
 import PanelIcon from "./PanelIcon";
-import { StyledPanelItem } from "./StyledElements";
 
 export default function AddPanelItem({
   node,
@@ -16,7 +16,8 @@ export default function AddPanelItem({
   const trackEvent = useTrackEvent();
   const { spaces } = useSpaces(spaceId);
   return (
-    <StyledPanelItem
+    <Stack
+      direction="row"
       data-cy={`new-panel-option-${name}`}
       onClick={(e) => {
         trackEvent("open_panel", { panel: name });
@@ -30,9 +31,23 @@ export default function AddPanelItem({
         }
         if (onClick) onClick();
       }}
+      sx={{
+        cursor: "pointer",
+        padding: "4px 8px",
+        alignItems: "center",
+        "&:hover": { background: "var(--fo-palette-background-body)" },
+      }}
     >
       <PanelIcon name={name} />
-      {label || (name as string)}
-    </StyledPanelItem>
+      <Typography
+        sx={{
+          whiteSpace: "nowrap",
+          overflow: "hidden",
+          textOverflow: "ellipsis",
+        }}
+      >
+        {label || (name as string)}
+      </Typography>
+    </Stack>
   );
 }

--- a/app/packages/spaces/src/components/StyledElements.tsx
+++ b/app/packages/spaces/src/components/StyledElements.tsx
@@ -30,15 +30,6 @@ export const AddPanelButtonContainer = styled.div`
   margin-left: 4px;
 `;
 
-export const StyledPanelItem = styled.div`
-  cursor: pointer;
-  padding: 4px 8px;
-
-  &:hover {
-    background: var(--fo-palette-background-body);
-  }
-`;
-
 export const StyledTab = styled.button<{ active?: boolean }>`
   display: flex;
   align-items: center;


### PR DESCRIPTION
## What changes are proposed in this pull request?

Prevent wrapping of the panel item in add panel item pop over and show overflow label as ellipsis

## How is this patch tested? If it is not, please explain why.

Using a long panel label

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved layout of the `AddPanelItem` component with a more flexible stacking arrangement using Material-UI's `Stack`.
	- Enhanced visual representation with updated styles for better interactivity, including padding and hover effects.
	- Updated label rendering with `Typography` for better text management and responsiveness.

- **Bug Fixes**
	- Removed outdated `StyledPanelItem` to streamline component structure and eliminate redundancy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->