### PR TITLE
Fix grid media field updates

### DIFF
--- a/app/packages/core/src/components/Grid/useRefreshers.ts
+++ b/app/packages/core/src/components/Grid/useRefreshers.ts
@@ -11,6 +11,7 @@ export default function useRefreshers() {
   const extendedStages = fos.stringifyObj(useRecoilValue(fos.extendedStages));
   const filters = fos.stringifyObj(useRecoilValue(fos.filters));
   const groupSlice = useRecoilValue(fos.groupSlice);
+  const mediaField = useRecoilValue(fos.selectedMediaField(false));
   const refresher = useRecoilValue(fos.refresher);
   const shouldRenderImaVidLooker = useRecoilValue(fos.shouldRenderImaVidLooker);
   const view = fos.filterView(useRecoilValue(fos.view));
@@ -18,9 +19,10 @@ export default function useRefreshers() {
   // only reload, attempt to return to the last grid location
   const layoutReset = useMemo(() => {
     cropToContent;
+    mediaField;
     refresher;
     return uuid();
-  }, [cropToContent, refresher]);
+  }, [cropToContent, mediaField, refresher]);
 
   // the values reset the page, i.e. return to the top
   const pageReset = useMemo(() => {


### PR DESCRIPTION
## What changes are proposed in this pull request?

On `release/v0.25.0`, changing the grid media field in the app does not immediately update the grid

![app-multiple-media-fields](https://github.com/user-attachments/assets/a5383676-8e74-4124-86bc-bc6d95a7613d)



## How is this patch tested? If it is not, please explain why.


```python
import fiftyone as fo
import fiftyone.zoo as foz
import fiftyone.utils.image as foui

dataset = foz.load_zoo_dataset("quickstart")

foui.transform_images(
    dataset,
    max_size=(-1, 32),
    output_field="thumbnail_path",
    output_dir="/tmp/quickstart/thumbnails",
)

dataset.app_config.media_fields = ["filepath", "thumbnail_path"]

dataset.app_config.grid_media_field = "thumbnail_path"
dataset.app_config.modal_media_field = "filepath"
dataset.save()
``` 

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced grid layout management by incorporating a dynamic media field, allowing for more responsive design based on user selections. 

- **Bug Fixes**
	- Improved layout reset functionality to better react to changes in the media field, ensuring a more accurate representation of content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->