### PR TITLE
Nimble grid

### DIFF
--- a/app/packages/spotlight/src/createScrollReader.ts
+++ b/app/packages/spotlight/src/createScrollReader.ts
@@ -69,6 +69,6 @@ export default function createScrollReader(
     destroy: () => {
       destroyed = true;
     },
-    scrolling: () => scrolling,
+    zooming: () => zooming
   };
 }

--- a/app/packages/spotlight/src/index.ts
+++ b/app/packages/spotlight/src/index.ts
@@ -18,7 +18,7 @@ import {
   SCROLLBAR_WIDTH,
   TWO,
   ZERO,
-  ZOOMING_COEFFICIENT,
+  ZOOMING_COEFFICIENT
 } from "./constants";
 import createScrollReader from "./createScrollReader";
 import { Load, RowChange } from "./events";
@@ -190,7 +190,7 @@ export default class Spotlight<K, V> extends EventTarget {
           requestAnimationFrame(() => {
             if (
               this.#element.scrollTop > this.#containerHeight ||
-              this.#scrollReader.scrolling()
+              this.#scrollReader.zooming()
             ) {
               requestAnimationFrame(run);
               return;
@@ -258,7 +258,7 @@ export default class Spotlight<K, V> extends EventTarget {
           requestAnimationFrame(() => {
             if (
               this.#element.scrollTop < ZERO ||
-              this.#scrollReader.scrolling()
+              this.#scrollReader.zooming()
             ) {
               requestAnimationFrame(run);
               return;


### PR DESCRIPTION
## What changes are proposed in this pull request?

Proposing a more liberal approach to layout updates, where scrolling is allowed, but scrolling fast is not. This is more similar to how `@fiftyone/flashlight`

## How is this patch tested? If it is not, please explain why.

e2e

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new `zooming` method to replace the previous `scrolling` method, enhancing functionality for managing zoom events.
	- Updated the `Spotlight` class to utilize the new `zooming` method, altering animation control based on zoom status.

- **Bug Fixes**
	- Resolved issues related to scrolling behavior by implementing logic that better accommodates the new zooming functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->