### PR TITLE
add pie on_click

### DIFF
--- a/app/packages/core/src/plugins/SchemaIO/components/PlotlyView.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/PlotlyView.tsx
@@ -23,6 +23,8 @@ export default function PlotlyView(props: ViewPropsType) {
     const data = EventDataMappers[event]?.(e) || {};
     let xValue = null;
     let yValue = null;
+    let value;
+    let label;
     if (event === "onClick") {
       const values = e.points[0];
       let selected = [];
@@ -47,6 +49,9 @@ export default function PlotlyView(props: ViewPropsType) {
         } else if (type === "heatmap") {
           xValue = p.x;
           yValue = p.y;
+        } else if (type === "pie") {
+          value = p.v;
+          label = p.label;
         }
       }
       if (selected.length === 0) {
@@ -55,13 +60,14 @@ export default function PlotlyView(props: ViewPropsType) {
     }
 
     const eventHandlerOperator = view[snakeCase(event)];
-
     const defaultParams = {
       path: props.path,
       relative_path: props.relativePath,
       schema: props.schema,
       view,
       event,
+      value,
+      label,
     };
 
     if (eventHandlerOperator) {


### PR DESCRIPTION
Adds `label` and `value` to plot `on_click` events when `type == pie`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced pie chart interactions to capture additional data points (value and label) for improved user experience.
- **Bug Fixes**
	- Improved event handling within the `PlotlyView` component for better responsiveness to user actions across different chart types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->