### PR TITLE
Bumping eta/brain versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -73,9 +73,9 @@ INSTALL_REQUIRES = [
     "universal-analytics-python3>=1.0.1,<2",
     "pydash",
     # internal packages
-    "fiftyone-brain>=0.16.1,<0.17",
+    "fiftyone-brain>=0.17.0,<0.18",
     "fiftyone-db>=0.4,<2.0",
-    "voxel51-eta>=0.12.6,<0.13",
+    "voxel51-eta>=0.12.7,<0.13",
 ]
 
 


### PR DESCRIPTION
Don't merge until `fiftyone-brain==0.17.0` is released.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated dependencies to allow access to newer features and improvements from `fiftyone-brain` and `voxel51-eta`.
  
- **Bug Fixes**
  - Minor updates to the dependencies that may include bug fixes and enhancements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->