### PR TITLE
disable support for default value update in panel

### DIFF
--- a/app/packages/core/src/plugins/OperatorIO/index.tsx
+++ b/app/packages/core/src/plugins/OperatorIO/index.tsx
@@ -15,6 +15,7 @@ function OperatorIOComponent(props) {
     initialData,
     id,
     shouldClearUseKeyStores,
+    skipDefaultValueUpdates,
   } = props;
   const ioSchema = operatorToIOSchema(schema, { isOutput: type === "output" });
 
@@ -29,6 +30,7 @@ function OperatorIOComponent(props) {
       errors={getErrorsByPath(errors)}
       initialData={initialData}
       layout={layout}
+      skipDefaultValueUpdates={skipDefaultValueUpdates}
     />
   );
 }

--- a/app/packages/core/src/plugins/SchemaIO/components/DynamicIO.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/DynamicIO.tsx
@@ -4,6 +4,7 @@ import { get, isEqual, set } from "lodash";
 import React, { useEffect, useMemo } from "react";
 import { isPathUserChanged, useUnboundState } from "../hooks";
 import {
+  allowDefaultInitialization,
   getComponent,
   getErrorsForView,
   isCompositeView,
@@ -74,13 +75,14 @@ function useStateInitializer(props: ViewPropsType) {
 
   useEffect(() => {
     const { computedSchema, props } = unboundState || {};
-    const { data, path, root_id } = props || {};
+    const { data, path, root_id, skipDefaultValueUpdates } = props || {};
     if (
       !isCompositeView(computedSchema) &&
       !isEqual(data, defaultValue) &&
       !isPathUserChanged(path, root_id) &&
       !isNullish(defaultValue) &&
-      !isInitialized(props)
+      !isInitialized(props) &&
+      allowDefaultInitialization(computedSchema, data, skipDefaultValueUpdates)
     ) {
       onChange(path, defaultValue, computedSchema);
     }

--- a/app/packages/core/src/plugins/SchemaIO/utils/index.ts
+++ b/app/packages/core/src/plugins/SchemaIO/utils/index.ts
@@ -100,3 +100,13 @@ export function isInitialized(props: ViewPropsType) {
   const { initialData, path } = props || {};
   return !isNullish(get(initialData, path));
 }
+
+export function allowDefaultInitialization(
+  schema: SchemaType,
+  data: any,
+  skipDefaultValueUpdates?: boolean
+) {
+  if (!skipDefaultValueUpdates) return true;
+  const defaultValue = get(schema, "default");
+  return isNullish(data) && !isNullish(defaultValue);
+}

--- a/app/packages/core/src/plugins/SchemaIO/utils/types.ts
+++ b/app/packages/core/src/plugins/SchemaIO/utils/types.ts
@@ -60,6 +60,8 @@ export type ViewPropsType<Schema extends SchemaType = SchemaType> = {
     ROWS: number;
   };
   autoFocused?: React.MutableRefObject<boolean>;
+  shouldClearUseKeyStores?: boolean;
+  skipDefaultValueUpdates?: boolean;
 };
 
 export type CustomComponentsType = {

--- a/app/packages/operators/src/CustomPanel.tsx
+++ b/app/packages/operators/src/CustomPanel.tsx
@@ -69,6 +69,7 @@ export function CustomPanel(props: CustomPanelProps) {
           layout={{ height, width }}
           onPathChange={handlePanelStatePathChange}
           shouldClearUseKeyStores={false}
+          skipDefaultValueUpdates={true}
         />
       </DimensionRefresher>
     </Box>


### PR DESCRIPTION
## What changes are proposed in this pull request?

disable support for default value updates in the panel

## How is this patch tested? If it is not, please explain why.

Using an example panel with a default value

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a `skipDefaultValueUpdates` prop to enhance control over default value updates in the `OperatorIO` and `CustomPanel` components.
	- Added a new function `allowDefaultInitialization` to improve state initialization logic based on schema and data conditions in the `DynamicIO` component and its utility module. 
	- Enhanced the `ViewPropsType` to include optional properties for finer control over component behavior.

- **Bug Fixes**
	- Improved logic for handling default values during state changes, leading to better component performance and reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->