### PR TITLE
fix unexpected python panel reset and other misc issues

### DIFF
--- a/app/packages/core/src/components/MainSpace/MainSpace.tsx
+++ b/app/packages/core/src/components/MainSpace/MainSpace.tsx
@@ -1,9 +1,7 @@
-import { panelsStateUpdatesCountAtom } from "@fiftyone/operators/src/state";
 import { SpacesRoot, usePanelsState, useSpaces } from "@fiftyone/spaces";
 import { constants, useSessionSpaces } from "@fiftyone/state";
 import { isEqual, size } from "lodash";
 import React, { useEffect, useRef } from "react";
-import { useSetRecoilState } from "recoil";
 
 const { FIFTYONE_SPACE_ID } = constants;
 
@@ -15,9 +13,6 @@ function MainSpace() {
     sessionSpaces
   );
   const [panelsState, setPanelsState] = usePanelsState();
-  const setPanelStateUpdatesCount = useSetRecoilState(
-    panelsStateUpdatesCountAtom
-  );
   const oldSpaces = useRef(spaces);
   const oldPanelsState = useRef(panelsState);
   const isMounted = useRef(false);
@@ -32,7 +27,6 @@ function MainSpace() {
 
   useEffect(() => {
     if (size(sessionPanelsState) && !isEqual(sessionPanelsState, panelsState)) {
-      setPanelStateUpdatesCount((count) => count + 1);
       setPanelsState(sessionPanelsState);
     }
   }, [sessionPanelsState]);

--- a/app/packages/operators/src/state.ts
+++ b/app/packages/operators/src/state.ts
@@ -1040,11 +1040,6 @@ export function useOperatorPlacements(place: Places) {
   return { placements };
 }
 
-export const panelsStateUpdatesCountAtom = atom({
-  key: "panelsStateUpdatesCountAtom",
-  default: 0,
-});
-
 export const activePanelsEventCountAtom = atom({
   key: "activePanelsEventCountAtom",
   default: new Map<string, number>(),

--- a/app/packages/operators/src/useCustomPanelHooks.ts
+++ b/app/packages/operators/src/useCustomPanelHooks.ts
@@ -1,6 +1,5 @@
-import { debounce, isEqual, merge } from "lodash";
-import { useCallback, useEffect, useMemo, useRef } from "react";
-import { useRecoilValue } from "recoil";
+import { debounce, merge } from "lodash";
+import { useCallback, useEffect, useMemo } from "react";
 
 import { usePanelState, useSetCustomPanelState } from "@fiftyone/spaces";
 import {
@@ -8,10 +7,7 @@ import {
   PANEL_STATE_PATH_CHANGE_DEBOUNCE,
 } from "./constants";
 import { executeOperator } from "./operators";
-import {
-  panelsStateUpdatesCountAtom,
-  useGlobalExecutionContext,
-} from "./state";
+import { useGlobalExecutionContext } from "./state";
 import usePanelEvent from "./usePanelEvent";
 import { memoizedDebounce } from "./utils";
 
@@ -76,11 +72,6 @@ export function useCustomPanelHooks(props: CustomPanelProps): CustomPanelHooks {
     data: panelStateLocal?.data,
   });
   const panelSchema = panelStateLocal?.schema;
-  const panelsStateUpdatesCount = useRecoilValue(panelsStateUpdatesCountAtom);
-  const lastPanelLoadState = useRef({
-    count: panelsStateUpdatesCount,
-    state: panelState,
-  });
   const ctx = useGlobalExecutionContext();
   const isLoaded: boolean = useMemo(() => {
     return panelStateLocal?.loaded;
@@ -160,27 +151,6 @@ export function useCustomPanelHooks(props: CustomPanelProps): CustomPanelHooks {
       }
     };
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
-
-  // Trigger panel "onLoad" operator when panel state changes externally
-  useEffect(() => {
-    if (
-      lastPanelLoadState.current?.count !== panelsStateUpdatesCount &&
-      !isEqual(lastPanelLoadState.current?.state, panelState)
-    ) {
-      setPanelStateLocal({});
-      onLoad();
-    }
-    lastPanelLoadState.current = {
-      count: panelsStateUpdatesCount,
-      state: panelState,
-    };
-  }, [
-    panelsStateUpdatesCount,
-    panelState,
-    panelId,
-    onLoad,
-    setPanelStateLocal,
-  ]);
 
   const handlePanelStateChangeOpDebounced = useMemo(() => {
     return debounce(


### PR DESCRIPTION
## What changes are proposed in this pull request?

Remove panel reset unexpectedly due to external state change. The `on_load` is no longer needed as we have added another mechanism to sync state on external changes. See demo below which shows python panel correctly updating when state is updated from python and also when workspaces feature is used (which I believe was the main motive behind the removed change). 

## How is this patch tested? If it is not, please explain why.

https://github.com/user-attachments/assets/5eb99094-4348-4480-a7f3-7ce018a53ae2

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced additional validation in the panel event handling to ensure valid operator input.

- **Improvements**
	- Enhanced initialization of state management to reflect provided values accurately.
	- Streamlined control flow by removing unnecessary external state monitoring in panel hooks.
	- Removed redundant state variables to optimize state management.

- **Bug Fixes**
	- Improved error handling to prevent runtime issues when uninitialized state is accessed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->