### PR TITLE
prevent filter expansion resets from modal

### DIFF
--- a/app/packages/app/src/routing/RouterContext.ts
+++ b/app/packages/app/src/routing/RouterContext.ts
@@ -43,7 +43,8 @@ export interface Entry<T extends OperationType> extends FiftyOneLocation {
 
 type Subscription<T extends OperationType> = (
   entry: Entry<T>,
-  action?: Action
+  action?: Action,
+  previousEntry?: Entry<T>
 ) => void;
 
 type Subscribe<T extends OperationType> = (
@@ -102,7 +103,11 @@ export const createRouter = <T extends OperationType>(
       loadingResource.load().then((entry) => {
         nextCurrentEntryResource === loadingResource &&
           requestAnimationFrame(() => {
-            for (const [_, [cb]] of subscribers) cb(entry, action);
+            let current: Entry<T> | undefined = undefined;
+            try {
+              current = currentEntryResource.read();
+            } catch {}
+            for (const [_, [cb]] of subscribers) cb(entry, action, current);
             // update currentEntryResource after calling subscribers
             currentEntryResource = loadingResource;
             cleanup();

--- a/app/packages/core/src/components/Grid/useRefreshers.ts
+++ b/app/packages/core/src/components/Grid/useRefreshers.ts
@@ -50,8 +50,8 @@ export default function useRefreshers() {
 
   useEffect(
     () =>
-      subscribe(({ event }, { reset }) => {
-        if (event === "modal") return;
+      subscribe(({ event }, { reset }, previous) => {
+        if (event === "modal" || previous?.event === "modal") return;
 
         // if not a modal page change, reset the grid location
         reset(gridPage);

--- a/app/packages/state/src/recoil/sidebarExpanded.ts
+++ b/app/packages/state/src/recoil/sidebarExpanded.ts
@@ -9,7 +9,9 @@ export const sidebarExpandedStore = atomFamily<
   default: {},
   effects: [
     ({ node }) =>
-      subscribe(({ event }, { reset }) => event !== "modal" && reset(node)),
+      subscribe(({ event }, { reset }, previous) => {
+        event !== "modal" && previous?.event !== "modal" && reset(node);
+      }),
   ],
 });
 
@@ -36,7 +38,10 @@ export const granularSidebarExpandedStore = atom<{ [key: string]: boolean }>({
   default: {},
   effects: [
     ({ node }) =>
-      subscribe(({ event }, { set }) => event !== "modal" && set(node, {})),
+      subscribe(
+        ({ event }, { set }, previous) =>
+          event !== "modal" && previous?.event !== "modal" && set(node, {})
+      ),
   ],
 });
 

--- a/app/packages/state/src/recoil/sidebarExpanded.ts
+++ b/app/packages/state/src/recoil/sidebarExpanded.ts
@@ -1,5 +1,5 @@
 import { subscribe } from "@fiftyone/relay";
-import { atom, atomFamily, DefaultValue, selectorFamily } from "recoil";
+import { DefaultValue, atom, atomFamily, selectorFamily } from "recoil";
 
 export const sidebarExpandedStore = atomFamily<
   { [key: string]: boolean },
@@ -7,7 +7,10 @@ export const sidebarExpandedStore = atomFamily<
 >({
   key: "sidebarExpanded",
   default: {},
-  effects: [({ node }) => subscribe((_, { reset }) => reset(node))],
+  effects: [
+    ({ node }) =>
+      subscribe(({ event }, { reset }) => event !== "modal" && reset(node)),
+  ],
 });
 
 export const sidebarExpanded = selectorFamily<
@@ -31,7 +34,10 @@ export const sidebarExpanded = selectorFamily<
 export const granularSidebarExpandedStore = atom<{ [key: string]: boolean }>({
   key: "granularSidebarExpandedStore",
   default: {},
-  effects: [({ node }) => subscribe((_, { set }) => set(node, {}))],
+  effects: [
+    ({ node }) =>
+      subscribe(({ event }, { set }) => event !== "modal" && set(node, {})),
+  ],
 });
 
 export const granularSidebarExpanded = selectorFamily<boolean, string>({

--- a/e2e-pw/src/oss/poms/sidebar.ts
+++ b/e2e-pw/src/oss/poms/sidebar.ts
@@ -38,6 +38,10 @@ export class SidebarPom {
     );
   }
 
+  filter(fieldName: string, filterType: "categorical" | "numeric") {
+    return this.sidebar.getByTestId(`${filterType}-filter-${fieldName}`);
+  }
+
   sidebarEntryDraggableArea(fieldName: string) {
     return this.sidebar
       .getByTestId(`sidebar-entry-draggable-${fieldName}`)
@@ -218,6 +222,10 @@ class SidebarAsserter {
 
   async assertFieldNotInSidebar(fieldName: string) {
     await expect(this.sb.field(fieldName)).toBeHidden();
+  }
+
+  async assertFilterIsVisibile(fieldName: string, filterType: "categorical") {
+    await expect(this.sb.filter(fieldName, filterType)).toBeVisible();
   }
 
   async assertSidebarGroupIsVisibile(groupName: string) {

--- a/e2e-pw/src/oss/specs/smoke-tests/quickstart.spec.ts
+++ b/e2e-pw/src/oss/specs/smoke-tests/quickstart.spec.ts
@@ -1,6 +1,7 @@
 import { test as base, expect } from "src/oss/fixtures";
 import { GridPom } from "src/oss/poms/grid";
 import { ModalPom } from "src/oss/poms/modal";
+import { SidebarPom } from "src/oss/poms/sidebar";
 import { getUniqueDatasetNameWithPrefix } from "src/oss/utils";
 
 const datasetName = getUniqueDatasetNameWithPrefix("smoke-quickstart");
@@ -8,12 +9,16 @@ const datasetName = getUniqueDatasetNameWithPrefix("smoke-quickstart");
 const test = base.extend<{
   grid: GridPom;
   modal: ModalPom;
+  sidebar: SidebarPom;
 }>({
   grid: async ({ page, eventUtils }, use) => {
     await use(new GridPom(page, eventUtils));
   },
   modal: async ({ page, eventUtils }, use) => {
     await use(new ModalPom(page, eventUtils));
+  },
+  sidebar: async ({ page }, use) => {
+    await use(new SidebarPom(page));
   },
 });
 
@@ -28,10 +33,18 @@ test.beforeEach(async ({ page, fiftyoneLoader }) => {
 });
 
 test.describe("quickstart", () => {
-  test("smoke", async ({ grid, modal }) => {
+  test("smoke", async ({ eventUtils, grid, modal, sidebar }) => {
     await grid.assert.isEntryCountTextEqualTo("5 samples");
 
     // test navigation
+
+    const expanded = eventUtils.getEventReceivedPromiseForPredicate(
+      "animation-onRest",
+      () => true
+    );
+    await sidebar.clickFieldDropdown("id");
+    await expanded;
+    await sidebar.waitForElement("categorical-filter-id");
 
     await grid.openFirstSample();
     await modal.waitForSampleLoadDomAttribute();
@@ -42,6 +55,9 @@ test.describe("quickstart", () => {
     await grid.url.back();
     grid.url.assert.verifySampleId(null);
     await modal.assert.isClosed();
+
+    // id filter should still be open
+    await sidebar.waitForElement("categorical-filter-id");
   });
 
   test("entry counts text when toPatches then groupedBy", async ({ grid }) => {

--- a/e2e-pw/src/oss/specs/smoke-tests/quickstart.spec.ts
+++ b/e2e-pw/src/oss/specs/smoke-tests/quickstart.spec.ts
@@ -44,7 +44,7 @@ test.describe("quickstart", () => {
     );
     await sidebar.clickFieldDropdown("id");
     await expanded;
-    await sidebar.waitForElement("categorical-filter-id");
+    await sidebar.asserter.assertFilterIsVisibile("id", "categorical");
 
     await grid.openFirstSample();
     await modal.waitForSampleLoadDomAttribute();
@@ -57,7 +57,7 @@ test.describe("quickstart", () => {
     await modal.assert.isClosed();
 
     // id filter should still be open
-    await sidebar.waitForElement("categorical-filter-id");
+    await sidebar.asserter.assertFilterIsVisibile("id", "categorical");
   });
 
   test("entry counts text when toPatches then groupedBy", async ({ grid }) => {


### PR DESCRIPTION
## What changes are proposed in this pull request?

Modal page changes currently close expanded grid/modal sidebar filters. See recording

https://github.com/user-attachments/assets/d1b7772c-2e28-411c-b846-ffb2d2674c2c

## How is this patch tested? If it is not, please explain why.

e2e assertions in quickstart smoke test

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced sidebar state management by refining the conditions under which state changes occur, improving performance and reducing unintended interactions during modal usage.
	- Introduced filtering functionality in the sidebar, allowing users to interact with categorical and numeric filters.
	- Expanded event subscription logic to improve grid state management, reducing unnecessary resets during modal events.

- **Tests**
	- Improved smoke test coverage by integrating sidebar functionality, enabling more robust testing scenarios involving sidebar interactions and filter visibility assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->