### PR TITLE
Fixing #4627

### DIFF
--- a/fiftyone/utils/cvat.py
+++ b/fiftyone/utils/cvat.py
@@ -373,7 +373,7 @@ def _do_download_media(task):
                         task_id, chunk_id, data_type="chunk"
                     )
                 )
-                chunk_path = os.path.join(tmp_dir, "%d.%s" % (chunk_id, ext))
+                chunk_path = os.path.join(tmp_dir, "%d%s" % (chunk_id, ext))
                 etau.write_file(resp._content, chunk_path)
                 chunk_paths.append(chunk_path)
 


### PR DESCRIPTION
Resolves https://github.com/voxel51/fiftyone/issues/4627

As pointed out by @ChicoQi, the [current implementation](https://github.com/voxel51/fiftyone/blob/c0bc6b0e7020720acde533cf09e28249d42c52f5/fiftyone/utils/cvat.py#L376) of the CVAT chunked video download chooses temp filenames with double `..` in them:

```
file '/tmp/tmp44yd5t3h/0..mp4'
file '/tmp/tmp44yd5t3h/1..mp4'
file '/tmp/tmp44yd5t3h/2..mp4'
file '/tmp/tmp44yd5t3h/3..mp4'
file '/tmp/tmp44yd5t3h/4..mp4'
file '/tmp/tmp44yd5t3h/5..mp4'
file '/tmp/tmp44yd5t3h/6..mp4'
file '/tmp/tmp44yd5t3h/7..mp4'
file '/tmp/tmp44yd5t3h/8..mp4'
file '/tmp/tmp44yd5t3h/9..mp4'
```

and apparently some versions of `ffmpeg` [don't like that](https://github.com/voxel51/fiftyone/issues/4627#issuecomment-2272458312).

With this patch, the temp filenames will have single `.`:

```
file '/tmp/tmp44yd5t3h/0.mp4'
file '/tmp/tmp44yd5t3h/1.mp4'
file '/tmp/tmp44yd5t3h/2.mp4'
file '/tmp/tmp44yd5t3h/3.mp4'
file '/tmp/tmp44yd5t3h/4.mp4'
file '/tmp/tmp44yd5t3h/5.mp4'
file '/tmp/tmp44yd5t3h/6.mp4'
file '/tmp/tmp44yd5t3h/7.mp4'
file '/tmp/tmp44yd5t3h/8.mp4'
file '/tmp/tmp44yd5t3h/9.mp4'
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Adjusted file naming format for media downloads, removing the dot between chunk ID and file extension, which may enhance file retrieval processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->