### PR TITLE
Split modal/grid dynamic groups mode

### DIFF
--- a/app/packages/core/src/components/Actions/GroupMediaVisibilityContainer.tsx
+++ b/app/packages/core/src/components/Actions/GroupMediaVisibilityContainer.tsx
@@ -37,8 +37,8 @@ const GroupMediaVisibilityPopout = ({
     fos.groupMediaIsMainVisibleSetting
   );
   const isNestedDynamicGroup = useRecoilValue(fos.isNestedDynamicGroup);
-  const shouldRenderImaVid = useRecoilValue(fos.shouldRenderImaVidLooker);
-  const dynamicGroupsViewMode = useRecoilValue(fos.dynamicGroupsViewMode);
+  const shouldRenderImaVid = useRecoilValue(fos.shouldRenderImaVidLooker(true));
+  const dynamicGroupsViewMode = useRecoilValue(fos.dynamicGroupsViewMode(true));
   const hasGroupSlices = useRecoilValue(fos.hasGroupSlices);
 
   const isSequentialAccessAllowed =

--- a/app/packages/core/src/components/Actions/Options.tsx
+++ b/app/packages/core/src/components/Actions/Options.tsx
@@ -155,7 +155,7 @@ const DynamicGroupsViewMode = ({ modal }: { modal: boolean }) => {
   const isOrderedDynamicGroup = useRecoilValue(fos.isOrderedDynamicGroup);
   const hasGroupSlices = useRecoilValue(fos.hasGroupSlices);
 
-  const [mode, setMode] = useRecoilState(fos.dynamicGroupsViewMode);
+  const [mode, setMode] = useRecoilState(fos.dynamicGroupsViewMode(modal));
   const setIsCarouselVisible = useSetRecoilState(
     fos.groupMediaIsCarouselVisibleSetting
   );

--- a/app/packages/core/src/components/Grid/useRefreshers.ts
+++ b/app/packages/core/src/components/Grid/useRefreshers.ts
@@ -13,7 +13,9 @@ export default function useRefreshers() {
   const groupSlice = useRecoilValue(fos.groupSlice);
   const mediaField = useRecoilValue(fos.selectedMediaField(false));
   const refresher = useRecoilValue(fos.refresher);
-  const shouldRenderImaVidLooker = useRecoilValue(fos.shouldRenderImaVidLooker);
+  const shouldRenderImaVidLooker = useRecoilValue(
+    fos.shouldRenderImaVidLooker(false)
+  );
   const view = fos.filterView(useRecoilValue(fos.view));
 
   // only reload, attempt to return to the last grid location

--- a/app/packages/core/src/components/Modal/Group/DynamicGroup/NestedGroup/index.tsx
+++ b/app/packages/core/src/components/Modal/Group/DynamicGroup/NestedGroup/index.tsx
@@ -1,12 +1,12 @@
 import * as fos from "@fiftyone/state";
-import { Suspense } from "react";
+import React, { Suspense } from "react";
 import { useRecoilValue } from "recoil";
 import { GroupSuspense } from "../../GroupSuspense";
 import { GroupView } from "../../GroupView";
 import { GroupElementsLinkBar } from "../pagination";
 
 export const NestedGroup = () => {
-  const shouldRenderImaVid = useRecoilValue(fos.shouldRenderImaVidLooker);
+  const shouldRenderImaVid = useRecoilValue(fos.shouldRenderImaVidLooker(true));
 
   return (
     <>

--- a/app/packages/core/src/components/Modal/Group/DynamicGroup/NonNestedGroup/index.tsx
+++ b/app/packages/core/src/components/Modal/Group/DynamicGroup/NonNestedGroup/index.tsx
@@ -31,7 +31,7 @@ export const NonNestedDynamicGroup = () => {
   const [isBigLookerVisible, setIsBigLookerVisible] = useRecoilState(
     fos.groupMediaIsMainVisibleSetting
   );
-  const viewMode = useRecoilValue(fos.dynamicGroupsViewMode);
+  const viewMode = useRecoilValue(fos.dynamicGroupsViewMode(true));
   const isCarouselVisible = useRecoilValue(
     fos.groupMediaIsCarouselVisibleSetting
   );

--- a/app/packages/core/src/components/Modal/Group/DynamicGroup/index.tsx
+++ b/app/packages/core/src/components/Modal/Group/DynamicGroup/index.tsx
@@ -1,5 +1,5 @@
 import * as fos from "@fiftyone/state";
-import { useEffect } from "react";
+import React, { useEffect } from "react";
 import { useRecoilState, useRecoilValue, useSetRecoilState } from "recoil";
 import { NestedGroup } from "./NestedGroup";
 import { NonNestedDynamicGroup } from "./NonNestedGroup";
@@ -7,9 +7,9 @@ import { NonNestedDynamicGroup } from "./NonNestedGroup";
 export const DynamicGroup = () => {
   const hasGroupSlices = useRecoilValue(fos.hasGroupSlices);
 
-  const shouldRenderImaVid = useRecoilValue(fos.shouldRenderImaVidLooker);
+  const shouldRenderImaVid = useRecoilValue(fos.shouldRenderImaVidLooker(true));
   const [dynamicGroupsViewMode, setDynamicGroupsViewMode] = useRecoilState(
-    fos.dynamicGroupsViewMode
+    fos.dynamicGroupsViewMode(true)
   );
   const isOrderedDynamicGroup = useRecoilValue(fos.isOrderedDynamicGroup);
 
@@ -34,7 +34,7 @@ export const DynamicGroup = () => {
     if (dynamicGroupsViewMode === "video" && !isOrderedDynamicGroup) {
       setDynamicGroupsViewMode("pagination");
     }
-  }, [dynamicGroupsViewMode, isOrderedDynamicGroup]);
+  }, [dynamicGroupsViewMode, isOrderedDynamicGroup, setDynamicGroupsViewMode]);
 
   return hasGroupSlices ? <NestedGroup /> : <NonNestedDynamicGroup />;
 };

--- a/app/packages/core/src/components/Modal/Group/DynamicGroup/useDynamicGroupSamples.ts
+++ b/app/packages/core/src/components/Modal/Group/DynamicGroup/useDynamicGroupSamples.ts
@@ -10,7 +10,7 @@ export const useDynamicGroupSamples = () => {
   const view = useRecoilValue(fos.dynamicGroupViewQuery(null));
   const dataset = useRecoilValue(fos.datasetName);
   const dynamicGroupIndex = useRecoilValue(fos.dynamicGroupIndex);
-  const shouldRenderImavid = useRecoilValue(fos.shouldRenderImaVidLooker);
+  const shouldRenderImavid = useRecoilValue(fos.shouldRenderImaVidLooker(true));
 
   const filter = useMemo(
     () => (slice ? { group: { slice, slices: [slice] } } : {}),

--- a/app/packages/core/src/components/Modal/Looker.tsx
+++ b/app/packages/core/src/components/Modal/Looker.tsx
@@ -99,7 +99,9 @@ const Looker = ({
   const lookerOptions = fos.useLookerOptions(true);
   const [reset, setReset] = useState(false);
   const selectedMediaField = useRecoilValue(fos.selectedMediaField(true));
-  const shouldRenderImaVidLooker = useRecoilValue(fos.shouldRenderImaVidLooker);
+  const shouldRenderImaVidLooker = useRecoilValue(
+    fos.shouldRenderImaVidLooker(true)
+  );
   const setModalLooker = useSetRecoilState(fos.modalLooker);
   const { subscribeToImaVidStateChanges } = useInitializeImaVidSubscriptions();
 

--- a/app/packages/core/src/components/Modal/Modal.tsx
+++ b/app/packages/core/src/components/Modal/Modal.tsx
@@ -217,7 +217,7 @@ const SampleModal = () => {
   );
 
   const [dynamicGroupsViewMode, setDynamicGroupsViewMode] = useRecoilState(
-    fos.dynamicGroupsViewMode
+    fos.dynamicGroupsViewMode(true)
   );
   const setIsMainLookerVisible = useSetRecoilState(
     fos.groupMediaIsMainVisibleSetting

--- a/app/packages/state/src/hooks/useCreateLooker.ts
+++ b/app/packages/state/src/hooks/useCreateLooker.ts
@@ -57,7 +57,7 @@ export default <T extends AbstractLooker<BaseState>>(
   );
 
   const shouldRenderImaVidLooker = useRecoilValue(
-    dynamicGroupAtoms.shouldRenderImaVidLooker
+    dynamicGroupAtoms.shouldRenderImaVidLooker(isModal)
   );
 
   // callback to get the latest promise inside another recoil callback

--- a/app/packages/state/src/hooks/useSetModalState.ts
+++ b/app/packages/state/src/hooks/useSetModalState.ts
@@ -2,6 +2,7 @@ import type { CallbackInterface, RecoilState } from "recoil";
 
 import { useRelayEnvironment } from "react-relay";
 import { useRecoilCallback } from "recoil";
+import { dynamicGroupsViewMode } from "../recoil";
 import * as atoms from "../recoil/atoms";
 import * as filterAtoms from "../recoil/filters";
 import * as groupAtoms from "../recoil/groups";
@@ -58,6 +59,7 @@ export default () => {
 
         [groupAtoms.groupStatistics(true), groupAtoms.groupStatistics(false)],
         [groupAtoms.modalGroupSlice, groupAtoms.groupSlice],
+        [dynamicGroupsViewMode(true), dynamicGroupsViewMode(false)],
       ];
 
       const slice = await snapshot.getPromise(groupAtoms.groupSlice);

--- a/app/packages/state/src/recoil/dynamicGroups.ts
+++ b/app/packages/state/src/recoil/dynamicGroups.ts
@@ -326,9 +326,14 @@ export const isOrderedDynamicGroup = selector<boolean>({
   },
 });
 
-export const shouldRenderImaVidLooker = selector<boolean>({
+export const shouldRenderImaVidLooker = selectorFamily({
   key: "shouldRenderImaVidLooker",
-  get: ({ get }) => {
-    return get(isOrderedDynamicGroup) && get(dynamicGroupsViewMode) === "video";
-  },
+  get:
+    (modal: boolean) =>
+    ({ get }) => {
+      return (
+        get(isOrderedDynamicGroup) &&
+        get(dynamicGroupsViewMode(modal)) === "video"
+      );
+    },
 });

--- a/app/packages/state/src/recoil/groups.ts
+++ b/app/packages/state/src/recoil/groups.ts
@@ -59,7 +59,7 @@ export const groupMediaIsCarouselVisible = selector<boolean>({
   key: "groupMediaIsCarouselVisible",
   get: ({ get }) => {
     const isImaVidInNestedGroup =
-      get(shouldRenderImaVidLooker) && get(isNestedDynamicGroup);
+      get(shouldRenderImaVidLooker(true)) && get(isNestedDynamicGroup);
 
     return get(groupMediaIsCarouselVisibleSetting) && !isImaVidInNestedGroup;
   },
@@ -82,7 +82,7 @@ export const groupMediaIs3dVisible = selector<boolean>({
     const set = get(groupMediaTypesSet);
     const has3d = set.has(POINT_CLOUD) || set.has(THREE_D);
     const isImaVidInNestedGroup =
-      get(shouldRenderImaVidLooker) && get(isNestedDynamicGroup);
+      get(shouldRenderImaVidLooker(true)) && get(isNestedDynamicGroup);
     return get(groupMedia3dVisibleSetting) && has3d && !isImaVidInNestedGroup;
   },
 });
@@ -512,7 +512,7 @@ export const activeModalSample = selector({
 export const activeModalSidebarSample = selector({
   key: "activeModalSidebarSample",
   get: ({ get }) => {
-    if (get(shouldRenderImaVidLooker)) {
+    if (get(shouldRenderImaVidLooker(true))) {
       const currentFrameNumber = get(imaVidLookerState("currentFrameNumber"));
 
       if (!currentFrameNumber) {

--- a/app/packages/state/src/recoil/modal.ts
+++ b/app/packages/state/src/recoil/modal.ts
@@ -36,7 +36,7 @@ export const modalLooker = atom<AbstractLooker<BaseState> | null>({
 export const sidebarSampleId = selector({
   key: "sidebarSampleId",
   get: ({ get }) => {
-    if (get(shouldRenderImaVidLooker)) {
+    if (get(shouldRenderImaVidLooker(true))) {
       const thisFrameNumber = get(imaVidLookerState("currentFrameNumber"));
       const isPlaying = get(imaVidLookerState("playing"));
       const isSeeking = get(imaVidLookerState("seeking"));

--- a/app/packages/state/src/recoil/options.ts
+++ b/app/packages/state/src/recoil/options.ts
@@ -70,7 +70,9 @@ export const dynamicGroupsViewMode = atomFamily<
 >({
   key: "dynamicGroupsViewMode",
   default: "pagination",
-  effects: [getBrowserStorageEffectForKey("dynamicGroupsViewMode")],
+  effects: (modal) => [
+    getBrowserStorageEffectForKey(`dynamicGroupsViewMode-${modal}`),
+  ],
 });
 
 export const configuredSidebarModeDefault = selectorFamily<

--- a/app/packages/state/src/recoil/options.ts
+++ b/app/packages/state/src/recoil/options.ts
@@ -4,7 +4,7 @@ import {
   mediaFieldsFragment,
   mediaFieldsFragment$key,
 } from "@fiftyone/relay";
-import { atom, atomFamily, selector, selectorFamily } from "recoil";
+import { atomFamily, selector, selectorFamily } from "recoil";
 import { configData } from "./config";
 import { getBrowserStorageEffectForKey } from "./customEffects";
 import { datasetSampleCount } from "./dataset";
@@ -64,7 +64,10 @@ export const sidebarMode = atomFamily<"all" | "best" | "fast" | null, boolean>({
   default: null,
 });
 
-export const dynamicGroupsViewMode = atom<"carousel" | "pagination" | "video">({
+export const dynamicGroupsViewMode = atomFamily<
+  "carousel" | "pagination" | "video",
+  boolean
+>({
   key: "dynamicGroupsViewMode",
   default: "pagination",
   effects: [getBrowserStorageEffectForKey("dynamicGroupsViewMode")],


### PR DESCRIPTION
## What changes are proposed in this pull request?

Currently, changing dynamic groups view mode (e.g. pagination to video) in the modal resets the grid layout. See recording

https://github.com/user-attachments/assets/8b7f28e1-37aa-4e74-859c-6a5d352038ac



## How is this patch tested? If it is not, please explain why.

Existing e2e

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced dynamic rendering logic for images and videos based on modal state throughout various components.
	- Introduced parameterized state management for `dynamicGroupsViewMode`, allowing for more flexible UI behaviors.
  
- **Bug Fixes**
	- Improved rendering conditions for media elements by refining visibility checks across multiple selectors.

- **Chores**
	- Cleaned up import statements to streamline code and focus on essential dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->