### PR TITLE
add x,y,z to on_selected

### DIFF
--- a/app/packages/core/src/plugins/SchemaIO/components/PlotlyView.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/PlotlyView.tsx
@@ -247,6 +247,9 @@ const EventDataMappers = {
       selected.push({
         idx: point.pointIndex,
         id: Array.isArray(ids) ? ids[point.pointIndex] : null,
+        x: Array.isArray(x) ? x[point.pointIndex] : null,
+        y: Array.isArray(y) ? y[point.pointIndex] : null,
+        z: Array.isArray(z) ? z[point.pointIndex] : null,
       });
     }
     return selected;


### PR DESCRIPTION
Allows plot on_selected events to access `ctx.params.get('data', [])[0].x|y|z`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced data visualization capabilities by supporting three-dimensional data points in the Plotly view.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->