### PR TITLE
Adding safe mode to drop index

### DIFF
--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -24,6 +24,7 @@ from pymongo import InsertOne, UpdateOne, UpdateMany
 import eta.core.serial as etas
 import eta.core.utils as etau
 
+import fiftyone as fo
 import fiftyone.core.aggregations as foa
 import fiftyone.core.annotation as foan
 import fiftyone.core.brain as fob
@@ -9261,14 +9262,18 @@ class SampleCollection(object):
                 indexes
             safe_mode (True): whether to use safe mode when dropping the index
         """
-        if safe_mode:
+        if fo.config.database_safe_mode and safe_mode:
             agreement = None
-            while agreement not in {"y", "n", "yes", "no"}:
+            acceptable = {"y", "n", "yes", "no"}
+            while agreement not in acceptable:
                 agreement = input("Are you sure you want to drop the index? (y/n)?").lower()
+                if agreement not in acceptable:
+                    print("Invalid response. Please enter 'y' or 'n'.")
 
             if agreement in {"n", "no"}:
                 return
 
+        logging.info("Dropping index '%s'...", field_or_name)
         name, is_frame_index = self._handle_frame_field(field_or_name)
 
         if is_frame_index:

--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -9201,7 +9201,7 @@ class SampleCollection(object):
                     )
 
                 # We need to drop existing index and replace with a unique one
-                self.drop_index(field)
+                self.drop_index(field, safe_mode=False)
 
         is_frame_fields = []
         index_spec = []

--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -9252,14 +9252,23 @@ class SampleCollection(object):
 
         return name
 
-    def drop_index(self, field_or_name):
+    def drop_index(self, field_or_name, safe_mode=True):
         """Drops the index for the given field or name.
 
         Args:
             field_or_name: a field name, ``embedded.field.name``, or compound
                 index name. Use :meth:`list_indexes` to see the available
                 indexes
+            safe_mode (True): whether to use safe mode when dropping the index
         """
+        if safe_mode:
+            agreement = None
+            while agreement not in {"y", "n", "yes", "no"}:
+                agreement = input("Are you sure you want to drop the index? (y/n)?").lower()
+
+            if agreement in {"n", "no"}:
+                return
+
         name, is_frame_index = self._handle_frame_field(field_or_name)
 
         if is_frame_index:

--- a/fiftyone/core/config.py
+++ b/fiftyone/core/config.py
@@ -250,6 +250,12 @@ class FiftyOneConfig(EnvConfig):
             env_var="FIFTYONE_MAX_PROCESS_POOL_WORKERS",
             default=None,
         )
+        self.database_safe_mode = self.parse_bool(
+            d,
+            "database_safe_mode",
+            env_var="FIFTYONE_DATABASE_SAFE_MODE",
+            default=True,
+        )
 
         self._init()
 

--- a/tests/unittests/dataset_tests.py
+++ b/tests/unittests/dataset_tests.py
@@ -480,7 +480,8 @@ class DatasetTests(unittest.TestCase):
         self.assertIs(dataset1c, dataset1)
 
     @drop_datasets
-    def test_indexes(self):
+    @patch("builtins.input")
+    def test_indexes(self, mocked_input):
         dataset = fo.Dataset()
 
         sample = fo.Sample(
@@ -533,6 +534,18 @@ class DatasetTests(unittest.TestCase):
 
         with self.assertRaises(ValueError):
             dataset.create_index("non_existent_field")
+
+        # Test index removal with safe_mode=True
+        name = dataset.create_index("field")
+        self.assertIn("field", dataset.list_indexes())
+
+        mocked_input.side_effect = ["n"]
+        dataset.drop_index(name, safe_mode=True)
+        self.assertIn("field", dataset.list_indexes())
+
+        mocked_input.side_effect = ["y"]
+        dataset.drop_index(name, safe_mode=True)
+        self.assertNotIn("field", dataset.list_indexes())
 
     @drop_datasets
     def test_index_sizes(self):

--- a/tests/unittests/dataset_tests.py
+++ b/tests/unittests/dataset_tests.py
@@ -500,7 +500,7 @@ class DatasetTests(unittest.TestCase):
         dataset.create_index("id", unique=True)  # already exists
         dataset.create_index("id")  # sufficient index exists
         with self.assertRaises(ValueError):
-            dataset.drop_index("id")  # can't drop default
+            dataset.drop_index("id", safe_mode=False)  # can't drop default
 
         dataset.create_index("filepath")  # already exists
 
@@ -509,26 +509,26 @@ class DatasetTests(unittest.TestCase):
             dataset.create_index("filepath", unique=True)
 
         with self.assertRaises(ValueError):
-            dataset.drop_index("filepath")  # can't drop default index
+            dataset.drop_index("filepath", safe_mode=False)  # can't drop default index
 
         name = dataset.create_index("field")
         self.assertEqual(name, "field")
         self.assertIn("field", dataset.list_indexes())
 
-        dataset.drop_index("field")
+        dataset.drop_index("field", safe_mode=False)
         self.assertNotIn("field", dataset.list_indexes())
 
         name = dataset.create_index("cls.label")
         self.assertEqual(name, "cls.label")
         self.assertIn("cls.label", dataset.list_indexes())
 
-        dataset.drop_index("cls.label")
+        dataset.drop_index("cls.label", safe_mode=False)
         self.assertNotIn("cls.label", dataset.list_indexes())
 
         compound_index_name = dataset.create_index([("id", 1), ("field", 1)])
         self.assertIn(compound_index_name, dataset.list_indexes())
 
-        dataset.drop_index(compound_index_name)
+        dataset.drop_index(compound_index_name, safe_mode=False)
         self.assertNotIn(compound_index_name, dataset.list_indexes())
 
         with self.assertRaises(ValueError):

--- a/tests/unittests/patches_tests.py
+++ b/tests/unittests/patches_tests.py
@@ -102,13 +102,13 @@ class PatchesTests(unittest.TestCase):
         self.assertSetEqual(set(indexes), default_indexes)
 
         with self.assertRaises(ValueError):
-            view.drop_index("id")  # can't drop default index
+            view.drop_index("id", safe_mode=False)  # can't drop default index
 
         with self.assertRaises(ValueError):
-            view.drop_index("filepath")  # can't drop default index
+            view.drop_index("filepath", safe_mode=False)  # can't drop default index
 
         with self.assertRaises(ValueError):
-            view.drop_index("sample_id")  # can't drop default index
+            view.drop_index("sample_id", safe_mode=False)  # can't drop default index
 
         self.assertEqual(dataset.count("ground_truth.detections"), 6)
         self.assertEqual(view.count(), 6)
@@ -399,13 +399,13 @@ class PatchesTests(unittest.TestCase):
         self.assertSetEqual(set(indexes), default_indexes)
 
         with self.assertRaises(ValueError):
-            view.drop_index("id")  # can't drop default index
+            view.drop_index("id", safe_mode=False)  # can't drop default index
 
         with self.assertRaises(ValueError):
-            view.drop_index("filepath")  # can't drop default index
+            view.drop_index("filepath", safe_mode=False)  # can't drop default index
 
         with self.assertRaises(ValueError):
-            view.drop_index("sample_id")  # can't drop default index
+            view.drop_index("sample_id", safe_mode=False)  # can't drop default index
 
         self.assertEqual(dataset.count("ground_truth.detections"), 3)
         self.assertEqual(dataset.count("predictions.detections"), 4)

--- a/tests/unittests/video_tests.py
+++ b/tests/unittests/video_tests.py
@@ -143,20 +143,20 @@ class VideoTests(unittest.TestCase):
         dataset.create_index("frames.id", unique=True)  # already exists
         dataset.create_index("frames.id")  # sufficient index exists
         with self.assertRaises(ValueError):
-            dataset.drop_index("frames.id")  # can't drop default
+            dataset.drop_index("frames.id", safe_mode=False)  # can't drop default
 
         name = dataset.create_index("frames.field")
         self.assertEqual(name, "frames.field")
         self.assertIn("frames.field", dataset.list_indexes())
 
-        dataset.drop_index("frames.field")
+        dataset.drop_index("frames.field", safe_mode=False)
         self.assertNotIn("frames.field", dataset.list_indexes())
 
         name = dataset.create_index("frames.cls.label")
         self.assertEqual(name, "frames.cls.label")
         self.assertIn("frames.cls.label", dataset.list_indexes())
 
-        dataset.drop_index("frames.cls.label")
+        dataset.drop_index("frames.cls.label", safe_mode=False)
         self.assertNotIn("frames.cls.label", dataset.list_indexes())
 
         compound_index_name = dataset.create_index(
@@ -164,7 +164,7 @@ class VideoTests(unittest.TestCase):
         )
         self.assertIn(compound_index_name, dataset.list_indexes())
 
-        dataset.drop_index(compound_index_name)
+        dataset.drop_index(compound_index_name, safe_mode=False)
         self.assertNotIn(compound_index_name, dataset.list_indexes())
 
         with self.assertRaises(ValueError):
@@ -1513,13 +1513,13 @@ class VideoTests(unittest.TestCase):
         self.assertSetEqual(set(indexes), default_indexes)
 
         with self.assertRaises(ValueError):
-            view.drop_index("id")  # can't drop default index
+            view.drop_index("id", safe_mode=False)  # can't drop default index
 
         with self.assertRaises(ValueError):
-            view.drop_index("filepath")  # can't drop default index
+            view.drop_index("filepath", safe_mode=False)  # can't drop default index
 
         with self.assertRaises(ValueError):
-            view.drop_index("sample_id")  # can't drop default index
+            view.drop_index("sample_id", safe_mode=False)  # can't drop default index
 
         self.assertEqual(len(view), 4)
 
@@ -1910,13 +1910,13 @@ class VideoTests(unittest.TestCase):
         self.assertSetEqual(set(indexes), default_indexes)
 
         with self.assertRaises(ValueError):
-            view.drop_index("id")  # can't drop default index
+            view.drop_index("id", safe_mode=False)  # can't drop default index
 
         with self.assertRaises(ValueError):
-            view.drop_index("filepath")  # can't drop default index
+            view.drop_index("filepath", safe_mode=False)  # can't drop default index
 
         with self.assertRaises(ValueError):
-            view.drop_index("sample_id")  # can't drop default index
+            view.drop_index("sample_id", safe_mode=False)  # can't drop default index
 
         self.assertEqual(len(view), 6)
 
@@ -2387,13 +2387,13 @@ class VideoTests(unittest.TestCase):
         self.assertSetEqual(set(indexes), default_indexes)
 
         with self.assertRaises(ValueError):
-            view.drop_index("id")  # can't drop default index
+            view.drop_index("id", safe_mode=False)  # can't drop default index
 
         with self.assertRaises(ValueError):
-            view.drop_index("filepath")  # can't drop default index
+            view.drop_index("filepath", safe_mode=False)  # can't drop default index
 
         with self.assertRaises(ValueError):
-            view.drop_index("sample_id")  # can't drop default index
+            view.drop_index("sample_id", safe_mode=False)  # can't drop default index
 
         self.assertEqual(len(view), 9)
 
@@ -2634,16 +2634,16 @@ class VideoTests(unittest.TestCase):
         self.assertSetEqual(set(indexes), default_indexes)
 
         with self.assertRaises(ValueError):
-            patches.drop_index("id")  # can't drop default index
+            patches.drop_index("id", safe_mode=False)  # can't drop default index
 
         with self.assertRaises(ValueError):
-            patches.drop_index("filepath")  # can't drop default index
+            patches.drop_index("filepath", safe_mode=False)  # can't drop default index
 
         with self.assertRaises(ValueError):
-            patches.drop_index("sample_id")  # can't drop default index
+            patches.drop_index("sample_id", safe_mode=False)  # can't drop default index
 
         with self.assertRaises(ValueError):
-            patches.drop_index("frame_id")  # can't drop default index
+            patches.drop_index("frame_id", safe_mode=False)  # can't drop default index
 
         self.assertEqual(dataset.count("frames.ground_truth.detections"), 4)
         self.assertEqual(patches.count(), 4)


### PR DESCRIPTION
## What changes are proposed in this pull request?

Adding a default safe mode to `dataset.drop_index` where the users are prompted to confirm before dropping the index

## How is this patch tested? If it is not, please explain why.

* Manual (✅ )
* Unit test (✅ )

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

By default, `dataset.drop_index(...)` will include a confirmation prompt before proceeding.

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a `safe_mode` option for the `drop_index` method, allowing users to confirm before dropping indexes, enhancing safety against accidental deletions.
	- Added a `database_safe_mode` configuration option to improve safety during database interactions.

- **Tests**
	- Updated tests for the `drop_index` method to reflect the new `safe_mode` functionality, ensuring existing behaviors are maintained while allowing for more flexibility in index management.
	- Introduced new test cases to verify behavior when the `safe_mode` option is enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->