### PR TITLE
Bug fix/fo3d relative paths

### DIFF
--- a/app/packages/looker-3d/src/fo3d/utils.ts
+++ b/app/packages/looker-3d/src/fo3d/utils.ts
@@ -19,6 +19,7 @@ import type {
   FoScene,
   FoSceneNode,
 } from "../hooks";
+import * as paths from "../../../utilities/src/paths";
 
 export const getAssetUrlForSceneNode = (node: FoSceneNode): string => {
   if (!node.asset) return null;
@@ -142,7 +143,7 @@ export const getResolvedUrlForFo3dAsset = (
     assetUrl.startsWith("/") ||
     assetUrl.startsWith("data:")
   ) {
-    return assetUrl;
+    return paths.joinPaths(fo3dRoot, assetUrl);
   }
 
   return fo3dRoot + assetUrl;

--- a/app/packages/looker-3d/src/fo3d/utils.ts
+++ b/app/packages/looker-3d/src/fo3d/utils.ts
@@ -143,10 +143,10 @@ export const getResolvedUrlForFo3dAsset = (
     assetUrl.startsWith("/") ||
     assetUrl.startsWith("data:")
   ) {
-    return paths.joinPaths(fo3dRoot, assetUrl);
+    return assetUrl;
   }
 
-  return fo3dRoot + assetUrl;
+  return paths.joinPaths(fo3dRoot, assetUrl);
 };
 
 export const getThreeMaterialFromFo3dMaterial = (

--- a/app/packages/utilities/src/paths.ts
+++ b/app/packages/utilities/src/paths.ts
@@ -36,7 +36,9 @@ export function joinPaths(...paths: string[]): string {
     return url.toString();
   }
   if (pathType === PathType.WINDOWS) {
-    return pathUtils.win32.join(...paths);
+    // pathUtils.win32 doesn't handle backslashes w/ relative paths properly
+    const convertedPaths = paths.map((p) => p.replace(/\\/g, "/"));
+    return pathUtils.join(...convertedPaths).replace(/\//g, "\\");
   }
   return pathUtils.join(...paths);
 }


### PR DESCRIPTION
## What changes are proposed in this pull request?

make it so relative paths in fo3d file resolve properly on both linux and windows. Required updating the logic for paths.join because it does not properly handle if we have ".." in the relative path (it would return nothing). Instead we convert it to forward slashes, join / normalize, and then convert back into backslashes.

![fo3d-relative-paths-fix](https://github.com/user-attachments/assets/f0c7b377-6969-4ad3-ad8e-0cf459242f81)

## How is this patch tested? If it is not, please explain why.

Tested locally by setting up my mongo to have two videos containing fo3d files. One has a relative path for pcd and the other doesn't. 

Relative path fo3d (note the pcd path):
```
{"_type": "Scene","uuid": "46a57705-6cba-4269-a417-e3e5c49da27d","name": "Scene","visible": true,"position": [0.0,0.0,0.0],"quaternion": [0.0,0.0,0.0,1.0],"scale": [1.0,1.0,1.0],"children": [{"_type": "PointCloud","uuid": "669260e9-19d2-4816-9d97-ae8905a717da","name": "point cloud","visible": true,"position": [0.0,0.0,0.0],"quaternion": [0.0,0.0,0.0,1.0],"scale": [1.0,1.0,1.0],"children": [],"pcdPath": "..\\..\\pcd\\003037.pcd","defaultMaterial": {"_type": "PointCloudMaterial","opacity": 1.0,"shadingMode": "height","customColor": "#ffffff","pointSize": 1.0,"attenuateByDistance": false},"flagForProjection": false}],"__FO3D_VERSION": "1.0","camera": {"position": null,"lookAt": null,"aspect": null,"up": "Z","fov": 50.0,"near": 0.1,"far": 2000.0},"lights": null,"background": null}
```
## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

Fixes pcd relative path in fo3d files allowing for pcd to be placed in a folder other than where the fo3d file is located (tested on windows as well)

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved asset URL handling within the application for better path management.
	- Enhanced compatibility for file paths, specifically for Windows systems.

- **Bug Fixes**
	- Resolved issues related to path joining, ensuring greater robustness and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->