### PR TITLE
Add `mask_path` to `fo.Detection` labels

### DIFF
--- a/fiftyone/core/labels.py
+++ b/fiftyone/core/labels.py
@@ -470,49 +470,6 @@ class Detection(_HasAttributesDict, _HasID, Label):
                 self.mask = None
                 self.mask_path = outpath
 
-    def transform_mask(self, targets_map, outpath=None, update=False):
-        """Transforms this instance's mask according to the provided targets
-        map.
-
-        This method can be used to transform between grayscale and RGB masks,
-        or it can be used to edit the pixel values or colors of a mask without
-        changing the number of channels.
-
-        Note that any pixel values not in ``targets_map`` will be zero in the
-        transformed mask.
-
-        Args:
-            targets_map: a dict mapping existing pixel values (2D masks) or RGB
-                hex strings (3D masks) to new pixel values or RGB hex strings.
-                You may convert between grayscale and RGB using this argument
-            outpath (None): an optional path to write the transformed mask on
-                disk
-            update (False): whether to save the transformed mask on this
-                instance
-
-        Returns:
-            the transformed mask
-        """
-        mask = self.get_mask()
-        if mask is None:
-            return
-
-        mask = _transform_mask(mask, targets_map)
-
-        if outpath is not None:
-            _write_mask(mask, outpath)
-
-            if update:
-                self.mask = None
-                self.mask_path = outpath
-        elif update:
-            if self.mask_path is not None:
-                _write_mask(mask, self.mask_path)
-            else:
-                self.mask = mask
-
-        return mask
-
     def to_polyline(self, tolerance=2, filled=True):
         """Returns a :class:`Polyline` representation of this instance.
 

--- a/fiftyone/utils/coco.py
+++ b/fiftyone/utils/coco.py
@@ -1299,7 +1299,7 @@ class COCOObject(object):
             x, y, w, h = label.bounding_box
             bbox = [x * width, y * height, w * width, h * height]
 
-            if label.get_mask() is not None:
+            if label.has_mask() is not None:
                 segmentation = _instance_to_coco_segmentation(
                     label, frame_size, iscrowd=iscrowd, tolerance=tolerance
                 )
@@ -2110,7 +2110,7 @@ def _coco_objects_to_detections(
         )
 
         if detection is not None and (
-            not load_segmentations or detection.get_mask() is not None
+            not load_segmentations or detection.has_mask() is not None
         ):
             detections.append(detection)
 

--- a/fiftyone/utils/coco.py
+++ b/fiftyone/utils/coco.py
@@ -1299,7 +1299,7 @@ class COCOObject(object):
             x, y, w, h = label.bounding_box
             bbox = [x * width, y * height, w * width, h * height]
 
-            if label.mask is not None:
+            if label.get_mask() is not None:
                 segmentation = _instance_to_coco_segmentation(
                     label, frame_size, iscrowd=iscrowd, tolerance=tolerance
                 )
@@ -2110,7 +2110,7 @@ def _coco_objects_to_detections(
         )
 
         if detection is not None and (
-            not load_segmentations or detection.mask is not None
+            not load_segmentations or detection.get_mask() is not None
         ):
             detections.append(detection)
 

--- a/fiftyone/utils/cvat.py
+++ b/fiftyone/utils/cvat.py
@@ -6400,7 +6400,7 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
                     }
                 )
             elif label_type in ("instance", "instances"):
-                if det.get_mask() is None:
+                if det.has_mask() is None:
                     continue
 
                 polygon = det.to_polyline()

--- a/fiftyone/utils/cvat.py
+++ b/fiftyone/utils/cvat.py
@@ -6400,7 +6400,7 @@ class CVATAnnotationAPI(foua.AnnotationAPI):
                     }
                 )
             elif label_type in ("instance", "instances"):
-                if det.mask is None:
+                if det.get_mask() is None:
                     continue
 
                 polygon = det.to_polyline()

--- a/fiftyone/utils/eta.py
+++ b/fiftyone/utils/eta.py
@@ -596,7 +596,7 @@ def to_detected_object(detection, name=None, extra_attrs=True):
     bry = tly + h
     bounding_box = etag.BoundingBox.from_coords(tlx, tly, brx, bry)
 
-    mask = detection.mask
+    mask = detection.get_mask()
     confidence = detection.confidence
 
     attrs = _to_eta_attributes(detection, extra_attrs=extra_attrs)


### PR DESCRIPTION
## What changes are proposed in this pull request?

Fix #4486

## How is this patch tested? If it is not, please explain why.

I genuinely couldn't figure out how to run the tests, I followed the [instructions](https://github.com/voxel51/fiftyone/blob/develop/CONTRIBUTING.md#developer-guide) but kept getting errors when using `pytest`, so I don't know if I have inadvertently broken something.
I wrote a quick snippet to test the feature instead:
```py
import tempfile
import numpy as np
from PIL import Image
import fiftyone as fo

MASK_SIZE = 256
BBOX = [0, 0, 1, 1]

# create a "mask"
mask = (np.random.rand(MASK_SIZE, MASK_SIZE) * 255).astype(np.uint8)
mask_image = Image.fromarray(mask)
mask_path = tempfile.mktemp(".png")
mask_image.save(mask_path)
print(f"Saved mask to {mask_path}")

# check mask are the same, even though they are stored differently
detection1 = fo.Detection(label="detection1", mask=mask, bounding_box=BBOX)
detection2 = fo.Detection(label="detection2", mask_path=mask_path, bounding_box=BBOX)
assert np.allclose(detection1.get_mask(), detection2.get_mask()), "detection masks are different"  # type: ignore
print(detection1, detection2)

# check polyline conversion
polyline1 = detection1.to_polyline()
polyline2 = detection2.to_polyline()
assert np.allclose(polyline1.points, polyline2.points), "polyline points are different" # type: ignore

# check mask export
mask2_path = tempfile.mktemp(".png")
detection1.export_mask(mask2_path, update=True)
print(f"Exported mask to {mask2_path}")
mask2_image = Image.open(mask2_path)
mask2 = np.array(mask2_image)
assert np.allclose(mask, mask2), "exported mask is different"
print(detection1, detection2)

# check mask import
detection2.import_mask(update=True)
assert np.allclose(detection1.get_mask(), detection2.get_mask()), "imported mask is different"  # type: ignore
print(detection1, detection2)
```

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release notes for FiftyOne users.

Allows `Detection`s to store masks on disk, this allows to offload some disk usage from the mongo database to somewhere else. See also #4486

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced new capabilities for managing instance segmentation masks in the Detection class, including import/export functionality and transformations.
	- Enhanced mask retrieval processes across various modules for improved maintainability.

- **Bug Fixes**
	- Updated checks for mask presence to utilize the new mask retrieval methods, ensuring consistent access and functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->