### PR TITLE
Add Suspense to Sample3dWrapper

### DIFF
--- a/app/packages/core/src/components/Modal/Group/GroupSample3d.tsx
+++ b/app/packages/core/src/components/Modal/Group/GroupSample3d.tsx
@@ -10,6 +10,7 @@ import {
 import { SampleWrapper } from "../Sample";
 import { Sample3d } from "../Sample3d";
 import { GroupSampleWrapper } from "./GroupSampleWrapper";
+import { GroupSuspense } from "./GroupSuspense";
 
 const Sample3dWrapper = () => {
   const sample = useRecoilValue(fos.pinned3DSample);
@@ -102,5 +103,9 @@ export default () => {
     return <Loading>Pixelating...</Loading>;
   }
 
-  return <Sample3dWrapper />;
+  return (
+    <GroupSuspense>
+      <Sample3dWrapper />
+    </GroupSuspense>
+  );
 };


### PR DESCRIPTION
## What changes are proposed in this pull request?

Adds suspense handling to the 3d viewer so loading is not thrown to the full modal area

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new `GroupSuspense` component to enhance the loading experience for users interacting with the `Sample3dWrapper`.
	- Improved handling of asynchronous operations, providing users with fallback UI during data fetching or rendering.

- **Bug Fixes**
	- Enhanced error boundary capabilities around the `Sample3dWrapper`, improving resilience during data loading scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->