### PR TITLE
add dedupe logic in resolve-placements for operators

### DIFF
--- a/fiftyone/operators/server.py
+++ b/fiftyone/operators/server.py
@@ -69,18 +69,17 @@ class ResolvePlacements(HTTPEndpoint):
         registry = await PermissionedOperatorRegistry.from_exec_request(
             request, dataset_ids=dataset_ids
         )
-        placements = []
+        placements = {}
         for operator in get_operators(registry):
             placement = resolve_placement(operator, data)
             if placement is not None:
-                placements.append(
-                    {
-                        "operator_uri": operator.uri,
-                        "placement": placement.to_json(),
-                    }
-                )
+                placements[operator.uri] = placement.to_json()
+                placements[operator.uri] = {
+                    "operator_uri": operator.uri,
+                    "placement": placement.to_json(),
+                }
 
-        return {"placements": placements}
+        return {"placements": list(placements.values())}
 
 
 class ExecuteOperator(HTTPEndpoint):


### PR DESCRIPTION
A better solution perhaps is to make sure the registry doesn't include duplicate operators in the first place.

## How is this patch tested? If it is not, please explain why.

Smoke testing. Existing e2e and unit tests all green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improved Efficiency**
	- Enhanced the internal data structure for storing operator placements, improving clarity and performance.
- **Consistent Output**
	- Updated the return format to ensure compatibility with previous implementations while utilizing the new data structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->