### PR TITLE
Imavid/replay

### DIFF
--- a/app/packages/looker/src/elements/common/actions.ts
+++ b/app/packages/looker/src/elements/common/actions.ts
@@ -609,7 +609,6 @@ const videoEscape: Control<VideoState> = {
         options: { showHelp, showJSON, selectedLabels },
         lockedToSupport,
       }) => {
-        console.log("closing window");
         if (showHelp) {
           dispatchEvent("panels", { showHelp: "close" });
           return { showHelp: "close" };
@@ -640,7 +639,7 @@ const videoEscape: Control<VideoState> = {
 
         if (frameNumber !== 1) {
           return {
-            frameNumber: 1, //THIS IS WHERE THE ISSUE IS WITH CLOSING FRAME
+            frameNumber: 1,
             playing: false,
           };
         }

--- a/app/packages/looker/src/elements/common/actions.ts
+++ b/app/packages/looker/src/elements/common/actions.ts
@@ -484,7 +484,7 @@ export const playPause: Control<VideoState | ImaVidState> = {
         return {
           currentFrameNumber: reachedEnd ? 1 : currentFrameNumber,
           options: { showJSON: false },
-          playing: !playing && !reachedEnd,
+          playing: !playing || reachedEnd,
         };
       }
 
@@ -609,6 +609,7 @@ const videoEscape: Control<VideoState> = {
         options: { showHelp, showJSON, selectedLabels },
         lockedToSupport,
       }) => {
+        console.log("closing window");
         if (showHelp) {
           dispatchEvent("panels", { showHelp: "close" });
           return { showHelp: "close" };
@@ -639,7 +640,7 @@ const videoEscape: Control<VideoState> = {
 
         if (frameNumber !== 1) {
           return {
-            frameNumber: 1,
+            frameNumber: 1, //THIS IS WHERE THE ISSUE IS WITH CLOSING FRAME
             playing: false,
           };
         }

--- a/app/packages/looker/src/elements/common/actions.ts
+++ b/app/packages/looker/src/elements/common/actions.ts
@@ -471,7 +471,8 @@ export const playPause: Control<VideoState | ImaVidState> = {
       }
       dispatchEvent("options", { showJSON: false });
 
-      const isImaVid = (state as ImaVidState).currentFrameNumber;
+      const isImaVid = (state.config as ImaVidConfig)
+        .frameStoreController as ImaVidFramesController;
       if (isImaVid) {
         const {
           currentFrameNumber,

--- a/app/packages/looker/src/elements/imavid/index.ts
+++ b/app/packages/looker/src/elements/imavid/index.ts
@@ -194,7 +194,6 @@ export class ImaVidElement extends BaseElement<ImaVidState, HTMLImageElement> {
     if (shouldUpdatePlaying) {
       this.update(({ playing }) => {
         if (playing) {
-          console.log("pausing");
           return { playing: false, disabled: false, disableOverlays: false };
         }
         return {};

--- a/app/packages/looker/src/elements/imavid/index.ts
+++ b/app/packages/looker/src/elements/imavid/index.ts
@@ -93,6 +93,7 @@ export class ImaVidElement extends BaseElement<ImaVidState, HTMLImageElement> {
   private canvasFrameNumber: number;
   private isPlaying: boolean;
   private isSeeking: boolean;
+  private isLoop: boolean;
   private waitingToPause = false;
   private isAnimationActive = false;
 
@@ -229,7 +230,7 @@ export class ImaVidElement extends BaseElement<ImaVidState, HTMLImageElement> {
     // if abs(frameNumberToDraw, currentFrameNumber) > 1, then skip
     // this is to avoid drawing frames that are too far apart
     // this can happen when user is scrubbing through the video
-    if (Math.abs(frameNumberToDraw - this.frameNumber) > 1) {
+    if (Math.abs(frameNumberToDraw - this.frameNumber) > 1 && !this.isLoop) {
       skipAndTryAgain();
       return;
     }
@@ -301,7 +302,6 @@ export class ImaVidElement extends BaseElement<ImaVidState, HTMLImageElement> {
               });
               return;
             }
-
             this.drawFrame(next);
           });
         }, this.setTimeoutDelay);
@@ -389,7 +389,7 @@ export class ImaVidElement extends BaseElement<ImaVidState, HTMLImageElement> {
 
   renderSelf(state: Readonly<ImaVidState>) {
     const {
-      options: { playbackRate },
+      options: { playbackRate, loop },
       config: { thumbnail, src: thumbnailSrc },
       currentFrameNumber,
       seeking,
@@ -407,7 +407,7 @@ export class ImaVidElement extends BaseElement<ImaVidState, HTMLImageElement> {
     if (!loaded) {
       return;
     }
-
+    this.isLoop = loop;
     this.isPlaying = playing;
     this.isSeeking = seeking;
     this.frameNumber = currentFrameNumber;

--- a/app/packages/looker/src/elements/imavid/index.ts
+++ b/app/packages/looker/src/elements/imavid/index.ts
@@ -194,6 +194,7 @@ export class ImaVidElement extends BaseElement<ImaVidState, HTMLImageElement> {
     if (shouldUpdatePlaying) {
       this.update(({ playing }) => {
         if (playing) {
+          console.log("pausing");
           return { playing: false, disabled: false, disableOverlays: false };
         }
         return {};
@@ -208,9 +209,11 @@ export class ImaVidElement extends BaseElement<ImaVidState, HTMLImageElement> {
   }
 
   async drawFrame(frameNumberToDraw: number, animate = true) {
-    if (this.waitingToPause) {
+    if (this.waitingToPause && this.frameNumber > 1) {
       this.pause();
       return;
+    } else {
+      this.waitingToPause = false;
     }
 
     const skipAndTryAgain = () =>

--- a/app/packages/looker/src/elements/imavid/play-button.ts
+++ b/app/packages/looker/src/elements/imavid/play-button.ts
@@ -23,7 +23,7 @@ export const playPause: Control<ImaVidState> = {
         return {
           currentFrameNumber: reachedEnd ? 1 : currentFrameNumber,
           options: { showJSON: false },
-          playing: !playing && !reachedEnd,
+          playing: !playing || reachedEnd,
         };
       }
     );

--- a/app/packages/looker/src/elements/imavid/play-button.ts
+++ b/app/packages/looker/src/elements/imavid/play-button.ts
@@ -17,17 +17,13 @@ export const playPause: Control<ImaVidState> = {
         if (thumbnail) {
           return {};
         }
-
+        const reachedEnd =
+          currentFrameNumber >= frameStoreController.totalFrameCount;
         dispatchEvent("options", { showJSON: false });
-
-        // todo: figure out why setting frame number to 1 doesn't restart playback because of drawFrame
         return {
-          playing: !playing,
-          frameNumber:
-            currentFrameNumber === frameStoreController.totalFrameCount
-              ? 1
-              : currentFrameNumber,
+          currentFrameNumber: reachedEnd ? 1 : currentFrameNumber,
           options: { showJSON: false },
+          playing: !playing && !reachedEnd,
         };
       }
     );

--- a/app/packages/looker/src/lookers/imavid/index.ts
+++ b/app/packages/looker/src/lookers/imavid/index.ts
@@ -84,7 +84,7 @@ export class ImaVidLooker extends AbstractLooker<ImaVidState, Sample> {
     config: ImaVidState["config"],
     options: ImaVidState["options"]
   ): ImaVidState {
-    const firstFrame = config.firstFrameNumber ?? 1;
+    const firstFrame = 1;
 
     return {
       ...this.getInitialBaseState(),


### PR DESCRIPTION
## What changes are proposed in this pull request?

Fix two bugs in imavid:
- When clicking play on a finished video it doesn't replay from the start
- When selecting a frame in one video, opening another will resume at that frame even if it's outside the range of that video. This would cause the UI to break


![2024-08-20 14 27 49](https://github.com/user-attachments/assets/fdf7f235-7cda-4bfb-9103-622a55c69333)


## How is this patch tested? If it is not, please explain why.

1. Use any image dataset (I used the demo dataset)
2. Select group by
3. Group by some fields ordered
4. Select display as video in settings
5. Test samples

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

Fix bugs in images as video for grouping. Now you can press play to restart the video and if you pause on a specific frame and select a different sample you will be put back to the first frame.

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced play/pause control to manage multiple video state types, improving playback flexibility.
	- Improved logic for pausing video playback to ensure the first frame displays without interruption.
	- Added control for looping behavior during playback, enhancing the user experience.

- **Bug Fixes**
	- Resolved playback behavior to ensure seamless restarts when reaching the end of the video.

- **Documentation**
	- Updated method descriptions to reflect changes in functionality and initialization logic for improved user clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->