### PR TITLE
fix: wrong argument description in `extract_patch` function

### DIFF
--- a/fiftyone/utils/patches.py
+++ b/fiftyone/utils/patches.py
@@ -158,8 +158,8 @@ def extract_patch(img, detection, force_square=False, alpha=None):
         alpha (None): an optional expansion/contraction to apply to the patch
             before extracting it, in ``[-1, inf)``. If provided, the length and
             width of the box are expanded (or contracted, when ``alpha < 0``)
-            by ``(100 * alpha)%``. For example, set ``alpha = 1.1`` to expand
-            the box by 10%, and set ``alpha = 0.9`` to contract the box by 10%
+            by ``(100 * alpha)%``. For example, set ``alpha = 0.1`` to expand
+            the box by 10%, and set ``alpha = -0.1`` to contract the box by 10%
 
     Returns:
         the image patch


### PR DESCRIPTION
## What changes are proposed in this pull request?

The description of the `alpha` argument in the `extract_patch` function is misleading. `alpha` greater than 0 will expand the box, less than 0 will contract the box. So, setting `alpha` to 1.1 will actually expand the box by 110%.

## How is this patch tested? If it is not, please explain why.

Just modify docs, no test required.

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [x] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the documentation for the `alpha` parameter in the `extract_patch` function to clarify the correct values for expanding and contracting the box size.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->