### PR TITLE
Fixing alpha docs

### DIFF
--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -3184,8 +3184,8 @@ class SampleCollection(object):
                 patches before extracting them, in ``[-1, inf)``. If provided,
                 the length and width of the box are expanded (or contracted,
                 when ``alpha < 0``) by ``(100 * alpha)%``. For example, set
-                ``alpha = 1.1`` to expand the boxes by 10%, and set
-                ``alpha = 0.9`` to contract the boxes by 10%
+                ``alpha = 0.1`` to expand the boxes by 10%, and set
+                ``alpha = -0.1`` to contract the boxes by 10%
             handle_missing ("skip"): how to handle images with no patches.
                 Supported values are:
 

--- a/fiftyone/core/models.py
+++ b/fiftyone/core/models.py
@@ -1328,8 +1328,8 @@ def compute_patch_embeddings(
             before extracting them, in ``[-1, inf)``. If provided, the length
             and width of the box are expanded (or contracted, when
             ``alpha < 0``) by ``(100 * alpha)%``. For example, set
-            ``alpha = 1.1`` to expand the boxes by 10%, and set ``alpha = 0.9``
-            to contract the boxes by 10%
+            ``alpha = 0.1`` to expand the boxes by 10%, and set
+            ``alpha = -0.1`` to contract the boxes by 10%
         handle_missing ("skip"): how to handle images with no patches.
             Supported values are:
 

--- a/fiftyone/utils/patches.py
+++ b/fiftyone/utils/patches.py
@@ -39,8 +39,8 @@ class ImagePatchesExtractor(object):
             before extracting them, in ``[-1, inf)``. If provided, the length
             and width of the box are expanded (or contracted, when
             ``alpha < 0``) by ``(100 * alpha)%``. For example, set
-            ``alpha = 1.1`` to expand the boxes by 10%, and set ``alpha = 0.9``
-            to contract the boxes by 10%
+            ``alpha = 0.1`` to expand the boxes by 10%, and set
+            ``alpha = -0.1`` to contract the boxes by 10%
     """
 
     def __init__(

--- a/fiftyone/utils/torch.py
+++ b/fiftyone/utils/torch.py
@@ -1763,8 +1763,8 @@ class TorchImagePatchesDataset(Dataset):
             before extracting them, in ``[-1, inf)``. If provided, the length
             and width of the box are expanded (or contracted, when
             ``alpha < 0``) by ``(100 * alpha)%``. For example, set
-            ``alpha = 1.1`` to expand the boxes by 10%, and set ``alpha = 0.9``
-            to contract the boxes by 10%
+            ``alpha = 0.1`` to expand the boxes by 10%, and set
+            ``alpha = -0.1`` to contract the boxes by 10%
         skip_failures (False): whether to return an ``Exception`` object rather
             than raising it if an error occurs while loading a sample
     """


### PR DESCRIPTION
Applies the fix ID'd in https://github.com/voxel51/fiftyone/pull/4712 in more places.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
	- Updated examples for the `alpha` parameter across multiple components to clarify its usage for box expansion and contraction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->