### PR TITLE
display operator placement loading error

### DIFF
--- a/app/packages/operators/src/OperatorPlacements.tsx
+++ b/app/packages/operators/src/OperatorPlacements.tsx
@@ -24,7 +24,11 @@ export function OperatorPlacementWithErrorBoundary(
   props: OperatorPlacementProps
 ) {
   return (
-    <ErrorBoundary Fallback={() => null}>
+    <ErrorBoundary
+      Fallback={(errorProps) => {
+        return <PlacementError {...props} {...errorProps} />;
+      }}
+    >
       <OperatorPlacement {...props} />
     </ErrorBoundary>
   );
@@ -42,6 +46,28 @@ function OperatorPlacements(props: OperatorPlacementsProps) {
       {...placement}
     />
   ));
+}
+
+function PlacementError(props) {
+  const { adaptiveMenuItemProps, error, operator } = props;
+  console.error(error);
+  const operatorURI = operator?.uri;
+  const postfix = operatorURI ? ` for ${operatorURI}` : "";
+  return (
+    <PillButton
+      {...(getStringAndNumberProps(adaptiveMenuItemProps) || {})}
+      icon={
+        <OperatorIcon
+          icon="error"
+          iconProps={{ sx: { color: (theme) => theme.palette.error.main } }}
+        />
+      }
+      title={error?.message || `Failed to load placement${postfix}`}
+      onClick={() => {
+        // do nothing
+      }}
+    />
+  );
 }
 
 export default withSuspense(OperatorPlacements, () => null);


### PR DESCRIPTION
## What changes are proposed in this pull request?

Display operator placement loading error with details and print the error in console
![image](https://github.com/user-attachments/assets/72ef9468-fd5f-4286-91bd-c001c46552cb)

## How is this patch tested? If it is not, please explain why.

Using an operator placement which fails to load in the app

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

Details above

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new `PlacementError` component for enhanced error handling.
	- Improved error feedback to users by displaying detailed error messages and relevant information.
- **Bug Fixes**
	- Updated error handling to provide a more structured and informative user experience during errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->