### PR TITLE
Delegated outputs may be None

### DIFF
--- a/fiftyone/operators/delegated.py
+++ b/fiftyone/operators/delegated.py
@@ -405,7 +405,8 @@ class DelegatedOperationService(object):
             outputs = await resolve_type_with_context(
                 request_params, "outputs"
             )
-            outputs_schema = outputs.to_json()
+            if outputs is not None:
+                outputs_schema = outputs.to_json()
         except (AttributeError, Exception):
             logger.warning(
                 "Failed to resolve output schema for the operation."


### PR DESCRIPTION
Fixes a spurious warning that currently appears for delegated operations that don't return outputs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error handling by adding a check to prevent runtime errors when the outputs variable is `None`.
  
- **Chores**
  - Enhanced stability of the method by ensuring safe handling of outputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->