### PR TITLE
fix bug where obj doesn't load if custom mtl isn't provided

### DIFF
--- a/app/packages/looker-3d/src/fo3d/mesh/Obj.tsx
+++ b/app/packages/looker-3d/src/fo3d/mesh/Obj.tsx
@@ -24,13 +24,15 @@ const ObjMeshDefaultMaterial = ({
   obj: ObjAsset;
   onLoad?: () => void;
 }) => {
-  const { objPath } = obj;
+  const { objPath, preTransformedObjPath } = obj;
 
   const { fo3dRoot } = useFo3dContext();
 
   const objUrl = useMemo(
-    () => getSampleSrc(getResolvedUrlForFo3dAsset(objPath, fo3dRoot)),
-    [objPath, fo3dRoot]
+    () =>
+      preTransformedObjPath ??
+      getSampleSrc(getResolvedUrlForFo3dAsset(objPath, fo3dRoot)),
+    [objPath, preTransformedObjPath, fo3dRoot]
   );
 
   const mesh = useLoader(OBJLoader, objUrl);


### PR DESCRIPTION
## What changes are proposed in this pull request?

When loading a 3d sample with cloud backed media that doesn't have a custom mtl we are not able to load the asset because we aren't first checking if a preTrasformedObjPath is present. These changes fix that.

![2024-08-23 10 06 16](https://github.com/user-attachments/assets/ea9aab46-f25b-4070-b954-648ea248169e)


## How is this patch tested? If it is not, please explain why.

(Details)

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

When using cloud backed media that don't contain a custom mtl path objects should be able to load properly.

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new property, `preTransformedObjPath`, for enhanced flexibility in loading object paths.
	- Improved loading process by allowing the use of a pre-transformed object path when available. 

- **Bug Fixes**
	- Updated dependency tracking to ensure proper recalculations of memoized values based on the new property.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->