### PR TITLE
video-as-frames performance improvement: eagerly fetch images in addition to sample data

### DIFF
--- a/app/packages/looker/src/elements/base.ts
+++ b/app/packages/looker/src/elements/base.ts
@@ -10,10 +10,13 @@ type ElementEvent<State extends BaseState, E extends Event> = (args: {
   dispatchEvent: DispatchEvent;
 }) => void;
 
-export type Events<State extends BaseState> = {
-  [K in keyof HTMLElementEventMap]?: ElementEvent<
+export type Events<
+  State extends BaseState,
+  CustomEvents extends Record<string, Event> = {}
+> = {
+  [K in keyof (HTMLElementEventMap & CustomEvents)]?: ElementEvent<
     State,
-    HTMLElementEventMap[K]
+    (HTMLElementEventMap & CustomEvents)[K]
   >;
 };
 

--- a/app/packages/looker/src/elements/common/actions.ts
+++ b/app/packages/looker/src/elements/common/actions.ts
@@ -471,6 +471,8 @@ export const playPause: Control<VideoState | ImaVidState> = {
       }
       dispatchEvent("options", { showJSON: false });
 
+      // separate handling for imavid vs video state
+
       const isImaVid = (state.config as ImaVidConfig)
         .frameStoreController as ImaVidFramesController;
       if (isImaVid) {
@@ -488,7 +490,6 @@ export const playPause: Control<VideoState | ImaVidState> = {
         };
       }
 
-      //seperate imavid from video state
       const {
         playing,
         duration,

--- a/app/packages/looker/src/elements/imavid/index.ts
+++ b/app/packages/looker/src/elements/imavid/index.ts
@@ -208,6 +208,14 @@ export class ImaVidElement extends BaseElement<ImaVidState, HTMLImageElement> {
     this.ctx?.drawImage(this.element, 0, 0);
   }
 
+  paintImageOnCanvas(image: HTMLImageElement) {
+    this.ctx.setTransform(1, 0, 0, 1, 0, 0);
+
+    this.ctx.clearRect(0, 0, this.canvas.width, this.canvas.height);
+
+    this.ctx.drawImage(image, 0, 0);
+  }
+
   async drawFrame(frameNumberToDraw: number, animate = true) {
     if (this.waitingToPause && this.frameNumber > 1) {
       this.pause();
@@ -254,12 +262,12 @@ export class ImaVidElement extends BaseElement<ImaVidState, HTMLImageElement> {
     this.canvasFrameNumber = frameNumberToDraw;
     image.addEventListener("load", () => {
       if (this.isPlaying || this.isSeeking) {
-        this.ctx.drawImage(image, 0, 0);
+        this.paintImageOnCanvas(image);
       }
 
       // this is when frame number changed through methods like keyboard navigation
       if (!this.isPlaying && !this.isSeeking && !animate) {
-        this.ctx.drawImage(image, 0, 0);
+        this.paintImageOnCanvas(image);
         this.update(() => ({ currentFrameNumber: frameNumberToDraw }));
       }
 

--- a/app/packages/looker/src/elements/imavid/index.ts
+++ b/app/packages/looker/src/elements/imavid/index.ts
@@ -83,7 +83,6 @@ export class ImaVidElement extends BaseElement<ImaVidState, HTMLImageElement> {
   // adding a new state to track it because we want to compute it conditionally in renderSelf and not drawFrame
   private setTimeoutDelay = getMillisecondsFromPlaybackRate(this.playBackRate);
   private frameNumber = 1;
-  private mediaField: string;
   private thumbnailSrc: string;
   /**
    * This frame number is the authoritaive frame number that is drawn on the canvas.
@@ -151,7 +150,6 @@ export class ImaVidElement extends BaseElement<ImaVidState, HTMLImageElement> {
       }) => {
         this.framesController = framesController;
         this.framesController.setImaVidStateUpdater(this.update);
-        this.mediaField = mediaField;
 
         this.framesController.setFrameRate(frameRate);
         this.framesController.setMediaField(mediaField);

--- a/app/packages/looker/src/elements/imavid/play-button.ts
+++ b/app/packages/looker/src/elements/imavid/play-button.ts
@@ -14,7 +14,7 @@ export const playPause: Control<ImaVidState> = {
         playing,
         config: { frameStoreController, thumbnail },
       }) => {
-        if (thumbnail) {
+        if (thumbnail || frameStoreController.isStoreBufferManagerEmpty) {
           return {};
         }
         const reachedEnd =
@@ -109,14 +109,21 @@ export class PlayButtonElement extends BaseElement<
     return element;
   }
 
-  renderSelf({ playing, buffering, loaded }: Readonly<ImaVidState>) {
+  renderSelf({
+    playing,
+    buffering,
+    loaded,
+    config: {
+      frameStoreController: { isStoreBufferManagerEmpty },
+    },
+  }: Readonly<ImaVidState>) {
     if (
       playing !== this.isPlaying ||
       this.isBuffering !== buffering ||
       !loaded
     ) {
       this.element.textContent = "";
-      if (!loaded) {
+      if (!loaded || isStoreBufferManagerEmpty) {
         this.element.appendChild(this.buffering);
         this.element.title = "Loading";
         this.element.style.cursor = "default";

--- a/app/packages/looker/src/elements/imavid/playback-rate.ts
+++ b/app/packages/looker/src/elements/imavid/playback-rate.ts
@@ -3,6 +3,7 @@ import { BaseElement, Events } from "../base";
 import { lookerPlaybackRate } from "../video.module.css";
 import { lookerClickable } from "../common/controls.module.css";
 import { playbackRate } from "../../icons";
+import { IMAVID_PLAYBACK_RATE_LOCAL_STORAGE_KEY } from "../../lookers/imavid/constants";
 
 const resetPlaybackRate: Control<ImaVidState> = {
   title: "Reset playback rate",
@@ -90,6 +91,11 @@ class PlaybackRateBarElement extends BaseElement<
       );
       this.element.value = playbackRate.toFixed(4);
       this.playbackRate = playbackRate;
+
+      window.localStorage.setItem(
+        IMAVID_PLAYBACK_RATE_LOCAL_STORAGE_KEY,
+        playbackRate.toString()
+      );
     }
 
     return this.element;

--- a/app/packages/looker/src/lookers/imavid/constants.ts
+++ b/app/packages/looker/src/lookers/imavid/constants.ts
@@ -6,3 +6,5 @@ export const BUFFERS_REFRESH_TIMEOUT_YIELD = 500;
 export const MAX_FRAME_SAMPLES_CACHE_SIZE = 500;
 export const LOOK_AHEAD_MULTIPLIER = 4;
 export const ANIMATION_CANCELED_ID = -1;
+
+export const IMAVID_PLAYBACK_RATE_LOCAL_STORAGE_KEY = "fo-imavid-playback-rate";

--- a/app/packages/looker/src/lookers/imavid/controller.ts
+++ b/app/packages/looker/src/lookers/imavid/controller.ts
@@ -153,6 +153,10 @@ export class ImaVidFramesController {
     return this.frameRate;
   }
 
+  public get isStoreBufferManagerEmpty() {
+    return this.storeBufferManager.totalFramesInBuffer === 0;
+  }
+
   private get environment() {
     return this.config.environment;
   }

--- a/app/packages/looker/src/lookers/imavid/ima-vid-frame-samples.ts
+++ b/app/packages/looker/src/lookers/imavid/ima-vid-frame-samples.ts
@@ -1,11 +1,22 @@
-import { ModalSample } from "@fiftyone/state";
+import {
+  getSampleSrc,
+  getStandardizedUrls,
+  ModalSample,
+} from "@fiftyone/state";
 import { BufferManager } from "@fiftyone/utilities";
 import LRUCache from "lru-cache";
 import { MAX_FRAME_SAMPLES_CACHE_SIZE } from "./constants";
 import { SampleId } from "./types";
 
+const BASE64_BLACK_IMAGE =
+  "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkAAIAAAoAAv/lxKUAAAAASUVORK5CYII=";
+
+export type ModalSampleExtendedWithImage = ModalSample & {
+  image: HTMLImageElement;
+};
 export class ImaVidFrameSamples {
-  public readonly samples: LRUCache<SampleId, ModalSample>;
+  public readonly samples: LRUCache<SampleId, ModalSampleExtendedWithImage>;
+
   public readonly frameIndex: Map<number, SampleId>;
   public readonly reverseFrameIndex: Map<SampleId, number>;
 
@@ -14,7 +25,7 @@ export class ImaVidFrameSamples {
   constructor(storeBufferManager: BufferManager) {
     this.storeBufferManager = storeBufferManager;
 
-    this.samples = new LRUCache<SampleId, ModalSample>({
+    this.samples = new LRUCache<SampleId, ModalSampleExtendedWithImage>({
       max: MAX_FRAME_SAMPLES_CACHE_SIZE,
       dispose: (sampleId) => {
         // remove it from the frame index
@@ -44,11 +55,52 @@ export class ImaVidFrameSamples {
     return this.samples.get(sampleId);
   }
 
-  updateSample(id: string, newSample: ModalSample) {
+  async fetchImageForSample(
+    id: string,
+    urls: ModalSample["urls"],
+    mediaField: string
+  ): Promise<void> {
+    const standardizedUrls = getStandardizedUrls(urls);
+    const image = new Image();
+    const source = getSampleSrc(standardizedUrls[mediaField]);
+
+    image.addEventListener("load", () => {
+      const sample = this.samples.get(id);
+      sample.image = image;
+    });
+
+    image.addEventListener("error", () => {
+      console.error(
+        "Failed to load image for sample with id",
+        id,
+        "at url",
+        source
+      );
+
+      // use a placeholder blank black image to not block animation
+      // setting src should trigger the load event
+      image.src = BASE64_BLACK_IMAGE;
+    });
+
+    image.src = source;
+  }
+
+  /**
+   * Update sample metadata in the store.
+   * This doesn't update the media associated with the sample.
+   * Useful for tagging, etc.
+   */
+  updateSample(id: string, newSample: ModalSampleExtendedWithImage["sample"]) {
     const oldSample = this.samples.get(id);
-    if (oldSample) {
-      this.samples.set(id, { ...oldSample, sample: newSample });
+
+    if (!oldSample) {
+      return;
     }
+
+    this.samples.set(id, {
+      ...oldSample,
+      sample: { ...newSample },
+    });
   }
 
   reset() {

--- a/app/packages/looker/src/lookers/imavid/ima-vid-frame-samples.ts
+++ b/app/packages/looker/src/lookers/imavid/ima-vid-frame-samples.ts
@@ -9,7 +9,7 @@ import { MAX_FRAME_SAMPLES_CACHE_SIZE } from "./constants";
 import { SampleId } from "./types";
 
 const BASE64_BLACK_IMAGE =
-  "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkAAIAAAoAAv/lxKUAAAAASUVORK5CYII=";
+  "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAIAAAACCAYAAABytg0kAAAAAXNSR0IArs4c6QAAAAlwSFlzAAAWJQAAFiUBSVIk8AAAABNJREFUCB1jZGBg+A/EDEwgAgQADigBA//q6GsAAAAASUVORK5CYII=";
 
 export type ModalSampleExtendedWithImage = ModalSample & {
   image: HTMLImageElement;

--- a/app/packages/looker/src/lookers/imavid/index.ts
+++ b/app/packages/looker/src/lookers/imavid/index.ts
@@ -15,6 +15,10 @@ import {
   IMAVID_PLAYBACK_RATE_LOCAL_STORAGE_KEY,
 } from "./constants";
 
+const DEFAULT_PAN = 0;
+const DEFAULT_SCALE = 1;
+const FIRST_FRAME = 1;
+
 /**
  * Looker for image samples in an ordered dynamic group that are to be rendered as a video.
  *
@@ -87,8 +91,6 @@ export class ImaVidLooker extends AbstractLooker<ImaVidState, Sample> {
     config: ImaVidState["config"],
     options: ImaVidState["options"]
   ): ImaVidState {
-    const firstFrame = 1;
-
     return {
       ...this.getInitialBaseState(),
       options: {
@@ -98,23 +100,20 @@ export class ImaVidLooker extends AbstractLooker<ImaVidState, Sample> {
       config: { ...config },
       seeking: false,
       playing: false,
-      currentFrameNumber: firstFrame,
+      currentFrameNumber: FIRST_FRAME,
       totalFrames: config.frameStoreController.totalFrameCount ?? 1,
       buffering: false,
-      bufferManager: new BufferManager([[firstFrame, firstFrame]]),
+      bufferManager: new BufferManager([[FIRST_FRAME, FIRST_FRAME]]),
       seekBarHovering: false,
       SHORTCUTS: VIDEO_SHORTCUTS,
     };
   }
 
   hasDefaultZoom(state: ImaVidState): boolean {
-    let pan = [0, 0];
-    let scale = 1;
-
     return (
-      scale === state.scale &&
-      pan[0] === state.pan[0] &&
-      pan[1] === state.pan[1]
+      DEFAULT_SCALE === state.scale &&
+      DEFAULT_PAN === state.pan[0] &&
+      DEFAULT_PAN === state.pan[1]
     );
   }
 

--- a/app/packages/looker/src/lookers/imavid/index.ts
+++ b/app/packages/looker/src/lookers/imavid/index.ts
@@ -10,7 +10,10 @@ import {
 } from "../../state";
 import { AbstractLooker } from "../abstract";
 import { LookerUtils } from "../shared";
-import { DEFAULT_PLAYBACK_RATE } from "./constants";
+import {
+  DEFAULT_PLAYBACK_RATE,
+  IMAVID_PLAYBACK_RATE_LOCAL_STORAGE_KEY,
+} from "./constants";
 
 /**
  * Looker for image samples in an ordered dynamic group that are to be rendered as a video.
@@ -117,10 +120,20 @@ export class ImaVidLooker extends AbstractLooker<ImaVidState, Sample> {
   }
 
   getDefaultOptions(): ImaVidOptions {
+    let defaultPlaybackRate = DEFAULT_PLAYBACK_RATE;
+
+    const mayBePlayBackRateFromLocalStorage = localStorage.getItem(
+      IMAVID_PLAYBACK_RATE_LOCAL_STORAGE_KEY
+    );
+
+    if (mayBePlayBackRateFromLocalStorage) {
+      defaultPlaybackRate = parseFloat(mayBePlayBackRateFromLocalStorage);
+    }
+
     return {
       ...DEFAULT_BASE_OPTIONS,
       loop: false,
-      playbackRate: DEFAULT_PLAYBACK_RATE,
+      playbackRate: defaultPlaybackRate,
     } as ImaVidOptions;
   }
 

--- a/app/packages/looker/src/lookers/imavid/index.ts
+++ b/app/packages/looker/src/lookers/imavid/index.ts
@@ -99,7 +99,6 @@ export class ImaVidLooker extends AbstractLooker<ImaVidState, Sample> {
       seeking: false,
       playing: false,
       currentFrameNumber: firstFrame,
-      isCurrentFrameNumberAuthoritative: false,
       totalFrames: config.frameStoreController.totalFrameCount ?? 1,
       buffering: false,
       bufferManager: new BufferManager([[firstFrame, firstFrame]]),

--- a/app/packages/looker/src/state.ts
+++ b/app/packages/looker/src/state.ts
@@ -377,11 +377,6 @@ export interface ImaVidState extends BaseState {
    */
   currentFrameNumber: number;
   /**
-   * current frame number is usually synced from the player's state,
-   * if this flag is true, then the sync happens in the opposite direction
-   */
-  isCurrentFrameNumberAuthoritative: boolean;
-  /**
    * total number of frames
    */
   totalFrames: number;

--- a/app/packages/state/src/utils.ts
+++ b/app/packages/state/src/utils.ts
@@ -102,17 +102,19 @@ export const collapseFields = (paths): StrictField[] => {
 };
 
 export const getStandardizedUrls = (
-  urls: Array<{ field: string; url: string }> | { [field: string]: string }
+  urls:
+    | readonly { readonly field: string; readonly url: string }[]
+    | { [field: string]: string }
 ) => {
-  let standardizedUrls: { [field: string]: string } = {};
   if (Array.isArray(urls)) {
+    let standardizedUrls: { [field: string]: string } = {};
+
     for (const { field, url } of urls) {
       standardizedUrls[field] = url;
     }
-  } else {
-    standardizedUrls = urls;
+    return standardizedUrls;
   }
-  return standardizedUrls;
+  return urls;
 };
 
 const convertTargets = (

--- a/app/packages/state/src/utils.ts
+++ b/app/packages/state/src/utils.ts
@@ -106,15 +106,11 @@ export const getStandardizedUrls = (
     | readonly { readonly field: string; readonly url: string }[]
     | { [field: string]: string }
 ) => {
-  if (Array.isArray(urls)) {
-    let standardizedUrls: { [field: string]: string } = {};
-
-    for (const { field, url } of urls) {
-      standardizedUrls[field] = url;
-    }
-    return standardizedUrls;
+  if (!Array.isArray(urls)) {
+    return urls;
   }
-  return urls;
+
+  return Object.fromEntries(urls.map(({ field, url }) => [field, url]));
 };
 
 const convertTargets = (


### PR DESCRIPTION
## What changes are proposed in this pull request?

The buffering status bar shows status of buffered sample data (sample json payload). The media’s link is part of the sample data but it itself (`HTMLImageElement`) is not, which means the buffering bar is telling a small lie. We fetch the images during the playback loop which is not ideal. It's fine in subsequent replays since the media loads from browser cache.

This PR includes changes so that images are also fetched eagerly in addition to sample metadata. This should help with the playback speed of imavid.

Minor improvement = local storage integration to persist playback rate settings across sessions


Todo: 
1. Overlays are shifted by a tiny bit
2. When scrubbing, sidebar values are sometimes incorrect (return to original value) 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced flexibility in event handling with support for custom event types.
  - Playback rate settings now persist across sessions through local storage.

- **Bug Fixes**
  - Streamlined error handling and sample updating logic.

- **Refactor**
  - Improved clarity and modularity in media frame and playback controls.
  - Reorganized code for better maintainability and readability.
  - Enhanced type safety and control flow in URL standardization logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->