### PR TITLE
Fix ultralytics extract track IDs

### DIFF
--- a/fiftyone/utils/ultralytics.py
+++ b/fiftyone/utils/ultralytics.py
@@ -58,7 +58,7 @@ def _extract_track_ids(result):
     return (
         result.boxes.id.detach().cpu().numpy().astype(int)
         if result.boxes.is_track
-        else [None] * len(result.boxes.conf.size(0))
+        else [None] * result.boxes.conf.size(0)
     )
 
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

[This PR](https://github.com/voxel51/fiftyone/pull/4569) broke ultralytics models when track ID isn't present. Though I don't know what that even is TBH.

## How is this patch tested? If it is not, please explain why.
Notably, there are no automated tests. I'm not going to add them now.

```python
import fiftyone as fo
import fiftyone.zoo as foz
import fiftyone.utils.huggingface as fouh
dataset = fouh.load_from_hub(
    "Voxel51/VisDrone2019-DET",
    max_samples=25,
    overwrite=True
    )
model = foz.load_zoo_model(
    "yolov8l-coco-torch",
    device="cuda"
    )
dataset.apply_model(model, label_field="predictions")
```

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

Fix ultralytics models without track ID


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved handling of non-tracking cases, ensuring the system returns appropriate values based on the number of boxes detected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->