### PR TITLE
fix field sharing for sample/frame document cls

### DIFF
--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -7619,7 +7619,7 @@ def _declare_fields(dataset, doc_cls, field_docs=None):
             field = foo.create_field(field_name, **foo.get_field_kwargs(field))
         else:
             field = field.copy()
-            doc_cls._declare_field(dataset, field_name, field)
+
         doc_cls._declare_field(dataset, field_name, field)
 
     if field_docs is not None:

--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -7617,9 +7617,10 @@ def _declare_fields(dataset, doc_cls, field_docs=None):
 
         if isinstance(field, fof.EmbeddedDocumentField):
             field = foo.create_field(field_name, **foo.get_field_kwargs(field))
-            doc_cls._declare_field(dataset, field_name, field)
         else:
-            field._set_dataset(dataset, field_name)
+            field = field.copy()
+            doc_cls._declare_field(dataset, field_name, field)
+        doc_cls._declare_field(dataset, field_name, field)
 
     if field_docs is not None:
         for field_doc in field_docs:

--- a/tests/unittests/dataset_tests.py
+++ b/tests/unittests/dataset_tests.py
@@ -413,6 +413,27 @@ class DatasetTests(unittest.TestCase):
         self.assertEqual(field.info, {"foo2": "bar2"})
 
     @drop_datasets
+    def test_dataset_shared_field_metadata(self):
+        """Test field metadata for default/shared fields"""
+        dataset1 = fo.Dataset()
+        dataset2 = fo.Dataset()
+
+        f = dataset1.get_field("filepath")
+        self.assertIsNot(f, dataset2.get_field("filepath"))
+
+        # Save metadata on dataset1 field, should not show up in dataset2
+        f.info = {"foo": "bar"}
+        f.save()
+
+        dataset2.reload()
+        self.assertIsNone(dataset2.get_field("filepath").info)
+
+        # Really fresh reload
+        fo.Dataset._instances.clear()
+        dataset2b = fo.load_dataset(dataset2.name)
+        self.assertIsNone(dataset2b.get_field("filepath").info)
+
+    @drop_datasets
     def test_dataset_app_config(self):
         dataset_name = self.test_dataset_app_config.__name__
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

It's not that big of a bug right now but it WAS confounding for an upcoming PR adding `created_at` to fields.
I say not that big because it only happens under specific circumstances and it's not common to save stuff to Field definitions.

Basically the issue is that when we create a subclass of `foo.DatasetSampleDocument` with `type()`, mongoengine seems to be populating `cls._fields` with a new list of _shallow_ copies of the original fields. That means any changes will be shared amongst some other datasets past or future. The devious part is if you call `field.save()` then it actually writes back to the field schema of `field._dataset` which may not be the dataset you intended.

New fields or loaded datasets (or default embedded fields such as `metadata`) are unaffected, because they will get new `Field` instances constructed for them.

## How is this patch tested? If it is not, please explain why.

From the added test...

```python
import fiftyone as fo

dataset1 = fo.Dataset()
dataset2 = fo.Dataset()

f = dataset1.get_field("filepath")
f.info = {"foo": "bar"}
f.save()

fo.Dataset._instances.clear()
dataset2b = fo.load_dataset(dataset2.name)
assert dataset2b.get_field("filepath") is None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced handling of field declarations to prevent unintended modifications to the original field object.

- **Tests**
	- Introduced a new test to verify the behavior of shared field metadata across different dataset instances, ensuring data integrity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->