### PR TITLE
Add multi-label support for label-studio integration

### DIFF
--- a/tests/intensive/labelstudio_tests.py
+++ b/tests/intensive/labelstudio_tests.py
@@ -265,10 +265,12 @@ def label_mappings():
                 "from_name": "choice",
                 "type": "choices",
             },
-            "fiftyone": [
-                fo.Classification(label="Airbus"),
-                fo.Classification(label="Boeing"),
-            ],
+            "fiftyone": fo.Classifications(
+                classifications=[
+                    fo.Classification(label="Airbus"),
+                    fo.Classification(label="Boeing"),
+                ]
+            ),
         },
         {
             "labelstudio": {
@@ -477,7 +479,6 @@ def test_import_labels(label_mappings):
     for case in label_mappings:
         label = fouls.import_label_studio_annotation(case["labelstudio"])[1]
         expected = case["fiftyone"]
-
         if isinstance(expected, (list, tuple)):
             for pair in zip(label, expected):
                 _assert_labels_equal(*pair)
@@ -673,6 +674,8 @@ def _assert_labels_equal(converted, expected):
             _assert_labels_equal(*pair)
     elif expected._cls == "Regression":
         assert expected.value == converted.value
+    elif expected._cls == "Classifications":
+        assert all(cls_obj.label for cls_obj in expected.classifications)
     else:
         raise NotImplementedError()
 


### PR DESCRIPTION
## What changes are proposed in this pull request?
Resolves #2946.
This pull request adds multi-label classification support to FiftyOne's label studio integration.


## How is this patch tested? If it is not, please explain why.

A subset of the Fashion-MNIST dataset was used to generate a small multi-label classification dataset. The code for creating the dataset and launching label studio for annotation - 

```python
import fiftyone as fo
import fiftyone.zoo as foz
from fiftyone import ViewField as F

dataset = foz.load_zoo_dataset(
    "fashion-mnist", dataset_name="fmnist-multilabel-annotation", split="test"
)
dataset.persistent = True

# Add new classes for assigning multiple labels
classes = dataset.default_classes + ["UpperBody", "LowerBody", "FootWear"]

shirt_sneaker_view = (
    dataset
    .filter_labels("ground_truth", F("label").is_in(["Shirt", "Sneaker"]))
    .take(5, seed = 42)
    )

anno_key = "labelstudio_multilabel_recipe"
if anno_key in dataset.list_annotation_runs():
    print(f"Annotation run with key {anno_key} already exists. Deleting...")
    dataset.delete_annotation_run(anno_key)


label_schema = {
    "modified_ground_truth": {
        "type": "classifications",
        "classes": classes
    },
}

shirt_sneaker_view.annotate(
    anno_key,
    backend="labelstudio",
    label_schema=label_schema,
    launch_editor=True,
)
```

After annotating the 5 samples with multiple labels (jn this case, annotating shirt images with ("Shirt", "UpperBody") and  sneaker images with ("Sneaker", "Footwear"), view the annotations on the Fiftyone app.

```python
import fiftyone as fo
import fiftyone.zoo as foz

anno_key = "labelstudio_multilabel_recipe"

dataset = foz.load_zoo_dataset(
    "fashion-mnist", dataset_name="fmnist-multilabel-annotation", split="test"
)
dataset.load_annotations(anno_key)

# Load the view that was annotated in the App
view = dataset.load_annotation_view(anno_key)
session = fo.launch_app(view=view)
session.wait()
```

Screenshot of app with multi-label annotations

![fiftyone_labelstudio](https://github.com/user-attachments/assets/0b50747d-ade2-4a67-9152-8d39ed6bca39)




## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?
<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

Label Studio integration in FiftyOne now support multi-label classification. For more info, checkout the description 
of https://github.com/voxel51/fiftyone/issues/2946


### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [x] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced support for a new label type, "classifications", enhancing flexibility in the labeling system.
  
- **Improvements**
  - Enhanced handling of multi-label classifications for better organization and structure in label management.
  - Updated return type for classifications to ensure consistency across the module.

- **Bug Fixes**
  - Improved label verification by adding conditions to ensure valid classification objects.

- **Documentation**
  - Updated tests to reflect changes in classification handling, increasing robustness and code cleanliness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->