### PR TITLE
fix copied doc updates not insert

### DIFF
--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -7773,7 +7773,12 @@ def _clone_dataset_or_view(dataset_or_view, name, persistent):
 
     dataset._reload()
 
-    _id = ObjectId()
+    #
+    # Clone dataset document
+    #
+
+    dataset_doc = dataset._doc.copy_with_new_id()
+    _id = dataset_doc.id
 
     sample_collection_name = _make_sample_collection_name(_id)
 
@@ -7784,13 +7789,6 @@ def _clone_dataset_or_view(dataset_or_view, name, persistent):
     else:
         frame_collection_name = None
 
-    #
-    # Clone dataset document
-    #
-
-    dataset_doc = dataset._doc.copy()
-
-    dataset_doc.id = _id
     dataset_doc.name = name
     dataset_doc.slug = slug
     dataset_doc.created_at = datetime.utcnow()
@@ -8251,14 +8249,12 @@ def _clone_extras(src_dataset, dst_dataset):
 
 
 def _clone_reference_doc(ref_doc):
-    _ref_doc = ref_doc.copy()
-    _ref_doc.id = ObjectId()
+    _ref_doc = ref_doc.copy_with_new_id()
     return _ref_doc
 
 
 def _clone_run(run_doc):
-    _run_doc = run_doc.copy()
-    _run_doc.id = ObjectId()
+    _run_doc = run_doc.copy_with_new_id()
     _run_doc.results = None
 
     # Unfortunately the only way to copy GridFS files is to read-write them...

--- a/fiftyone/core/dataset.py
+++ b/fiftyone/core/dataset.py
@@ -7777,7 +7777,7 @@ def _clone_dataset_or_view(dataset_or_view, name, persistent):
     # Clone dataset document
     #
 
-    dataset_doc = dataset._doc.copy_with_new_id()
+    dataset_doc = dataset._doc.copy(new_id=True)
     _id = dataset_doc.id
 
     sample_collection_name = _make_sample_collection_name(_id)
@@ -8249,12 +8249,12 @@ def _clone_extras(src_dataset, dst_dataset):
 
 
 def _clone_reference_doc(ref_doc):
-    _ref_doc = ref_doc.copy_with_new_id()
+    _ref_doc = ref_doc.copy(new_id=True)
     return _ref_doc
 
 
 def _clone_run(run_doc):
-    _run_doc = run_doc.copy_with_new_id()
+    _run_doc = run_doc.copy(new_id=True)
     _run_doc.results = None
 
     # Unfortunately the only way to copy GridFS files is to read-write them...

--- a/fiftyone/core/odm/document.py
+++ b/fiftyone/core/odm/document.py
@@ -9,7 +9,6 @@ Base classes for documents that back dataset contents.
 from copy import deepcopy
 import json
 
-import bson
 from bson import json_util, ObjectId
 import mongoengine
 from pymongo import InsertOne, UpdateOne
@@ -588,21 +587,19 @@ class Document(BaseDocument, mongoengine.Document):
         """Returns a deep copy of the document.
 
         Args:
-            new_id (False): Whether to generate a new ID for the copied
-                document locally. By default, ID is set to None which causes
-                ID generation to be done on the server.
+            new_id (False): whether to generate a new ID for the copied
+                document. By default, the ID is left as ``None`` and will be
+                automatically populated when the document is added to the
+                database
         """
         doc_copy = super().copy()
-        if new_id:
-            new_id = bson.ObjectId()
 
+        if new_id:
             # pylint: disable=no-member
             id_field = self._meta.get("id_field", "id")
-            doc_copy.set_field(id_field, new_id)
-
-            # Setting _created explicitly as True because we know this is a new
-            #   document
+            doc_copy.set_field(id_field, ObjectId())
             doc_copy._created = True
+
         return doc_copy
 
     def reload(self, *fields, **kwargs):

--- a/fiftyone/core/odm/document.py
+++ b/fiftyone/core/odm/document.py
@@ -584,18 +584,25 @@ class Document(BaseDocument, mongoengine.Document):
     def _doc_name(cls):
         return "Document"
 
-    def copy_with_new_id(self):
-        """Returns a copy of this document with a new ID"""
-        doc_copy = self.copy()
-        new_id = bson.ObjectId()
+    def copy(self, new_id=False):
+        """Returns a deep copy of the document.
 
-        # pylint: disable=no-member
-        id_field = self._meta.get("id_field", "id")
-        doc_copy.set_field(id_field, new_id)
+        Args:
+            new_id (False): Whether to generate a new ID for the copied
+                document locally. By default, ID is set to None which causes
+                ID generation to be done on the server.
+        """
+        doc_copy = super().copy()
+        if new_id:
+            new_id = bson.ObjectId()
 
-        # Setting _created explicitly as True because we know this is a new
-        #   document
-        doc_copy._created = True
+            # pylint: disable=no-member
+            id_field = self._meta.get("id_field", "id")
+            doc_copy.set_field(id_field, new_id)
+
+            # Setting _created explicitly as True because we know this is a new
+            #   document
+            doc_copy._created = True
         return doc_copy
 
     def reload(self, *fields, **kwargs):

--- a/fiftyone/core/odm/document.py
+++ b/fiftyone/core/odm/document.py
@@ -9,6 +9,7 @@ Base classes for documents that back dataset contents.
 from copy import deepcopy
 import json
 
+import bson
 from bson import json_util, ObjectId
 import mongoengine
 from pymongo import InsertOne, UpdateOne
@@ -582,6 +583,20 @@ class Document(BaseDocument, mongoengine.Document):
     @classmethod
     def _doc_name(cls):
         return "Document"
+
+    def copy_with_new_id(self):
+        """Returns a copy of this document with a new ID"""
+        doc_copy = self.copy()
+        new_id = bson.ObjectId()
+
+        # pylint: disable=no-member
+        id_field = self._meta.get("id_field", "id")
+        doc_copy.set_field(id_field, new_id)
+
+        # Setting _created explicitly as True because we know this is a new
+        #   document
+        doc_copy._created = True
+        return doc_copy
 
     def reload(self, *fields, **kwargs):
         """Reloads the document from the database.

--- a/tests/unittests/odm_tests.py
+++ b/tests/unittests/odm_tests.py
@@ -10,6 +10,7 @@ import unittest
 from bson import ObjectId
 
 import fiftyone as fo
+import fiftyone.core.odm as foo
 
 
 class ColorSchemeTests(unittest.TestCase):
@@ -29,3 +30,27 @@ class ColorSchemeTests(unittest.TestCase):
 
         self.assertIsInstance(d["_id"], dict)
         assert color_scheme == also_color_scheme
+
+
+class DocumentTests(unittest.TestCase):
+    def test_doc_copy_with_new_id(self):
+        dataset_doc = foo.DatasetDocument(
+            name="unique",
+            slug="unique",
+            sample_collection_name="samples.unique",
+            version="51.51",
+        )
+        dataset_doc.save()
+
+        # Copy with new ID -- ID should be new, _created should be True
+        doc_copy = dataset_doc.copy_with_new_id()
+        self.assertNotEqual(
+            dataset_doc.get_field("id"), doc_copy.get_field("id")
+        )
+        self.assertTrue(doc_copy._created)
+
+        # Now if we set ID to be same, the doc should be the same
+        doc_copy.set_field("id", dataset_doc.get_field("id"))
+        self.assertEqual(doc_copy, dataset_doc)
+
+        dataset_doc.delete()

--- a/tests/unittests/odm_tests.py
+++ b/tests/unittests/odm_tests.py
@@ -40,17 +40,20 @@ class DocumentTests(unittest.TestCase):
             sample_collection_name="samples.unique",
             version="51.51",
         )
-        dataset_doc.save()
 
-        # Copy with new ID -- ID should be new, _created should be True
-        doc_copy = dataset_doc.copy_with_new_id()
-        self.assertNotEqual(
-            dataset_doc.get_field("id"), doc_copy.get_field("id")
-        )
-        self.assertTrue(doc_copy._created)
+        try:
+            dataset_doc.save()
 
-        # Now if we set ID to be same, the doc should be the same
-        doc_copy.set_field("id", dataset_doc.get_field("id"))
-        self.assertEqual(doc_copy, dataset_doc)
+            # Copy with new ID -- ID should be new, _created should be True
+            doc_copy = dataset_doc.copy(new_id=True)
+            self.assertNotEqual(
+                dataset_doc.get_field("id"), doc_copy.get_field("id")
+            )
+            self.assertTrue(doc_copy._created)
 
-        dataset_doc.delete()
+            # Now if we set ID to be same, the doc should be the same
+            doc_copy.set_field("id", dataset_doc.get_field("id"))
+            self.assertEqual(doc_copy, dataset_doc)
+
+        finally:
+            dataset_doc.delete()


### PR DESCRIPTION
## What changes are proposed in this pull request?

Another weird bug that doesn't cause issues really until to-come changes are introduced.

If you do this code (done 3 times with dataset clone)
```python
doc_copy = doc.copy()
_id = bson.ObjectId()
doc_copy.id = _id
```
Then `mongoengine` sets `_created` to `False` which means it thinks it's an update object not a new one.
When you call `save()` it emits an upsert call instead of an insert.
OK, not so bad, maybe a little weird but whatever ...

But in https://github.com/voxel51/fiftyone/pull/4597 @brimoor proposes an optimization where only changed fields are serialized to get the document. In combo, this causes all kinds of strange behavior. It just so happens to work in that PR because `doc._changed_fields` is uninitialized (a code smell in mongoengine, they have a [TODO](https://github.com/MongoEngine/mongoengine/blob/master/mongoengine/base/document.py#L40) to clean it up...) and so `doc._delta()` returns the whole doc.

But say we cleared changed fields because we didn't know about this strange requirement.
```python
import bson
import fiftyone.core.odm as foo

run_doc = foo.RunDocument(config={"foo": "bar"})
run_doc.save()
doc_copy = run_doc.copy()
doc_copy.id = bson.ObjectId()

doc_copy._clear_changed_fields()
doc_copy.version = "51.51"
print(doc_copy._get_changed_fields()  # ["version"]
doc_copy.save(upsert=True)
doc_copy.reload()

# Oops our config field is {} because it's not a changed field so update only wrote "version" field
assert doc_copy.config == {"foo": "bar"}

doc_copy.delete()
run_doc.delete()
```

Ok but we don't clear changed_field so we're fine? Nope, balancing on a thread due to another mongoengine weirdness where `_get_changed_fields()` can return something due to embedded documents being edited

```python
import bson
import fiftyone as fo

ds = fo.Dataset()

# Pretending to clone the dataset doc
doc_copy = ds._doc.copy()
doc_copy.id = bson.ObjectId()
doc_copy.sample_collection_name=f"samples.{str(doc_copy.id)}"
doc_copy.name="blah"
doc_copy.slug="blah"

# Making an embedded document update
doc_copy.sample_fields[0].description = "blah"

# Wha? changed fields is actually ["sample_fields.0.description"] because
#  simple fields aren't tracked but embedded docs are
assert doc_copy._get_changed_fields() == []

ds.delete()
doc_copy.delete()
```

In mongoengine code, this appears to be band-aided with [this](https://github.com/MongoEngine/mongoengine/blob/master/mongoengine/base/document.py#L692):
which is what @brimoor 's optimization is trying to avoid
```
        # Handles cases where not loaded from_son but has _id
        doc = self.to_mongo()
```

## How is this patch tested? If it is not, please explain why.

Added test for `copy_with_new_id`.

Ensured that cloning dataset uses INSERT methods not UPSERT. Added print in `Document._save()`
```python
import fiftyone as fo

ds = fo.Dataset()
ds.clone("blah")

$$ INSERT SON([('_id', ObjectId('66cc999093e25d6a662346e4')), ('name', 'blah'), ('slug', 'blah'), ('version', '0.24.1'), ('created_at', datetime.datetime(2024, 8, 26, 15, 4, 48, 474872)), ('sample_collection_name', 'samples.66cc999093e25d6a662346e4'), ('persistent', False), ('group_media_types', {}), ('tags', []), ('info', {}), ('app_config', SON([('grid_media_field', 'filepath'), ('media_fallback', False), ('media_fields', ['filepath']), ('modal_media_field', 'filepath'), ('plugins', {})])), ('classes', {}), ('default_classes', []), ('mask_targets', {}), ('default_mask_targets', {}), ('skeletons', {}), ('sample_fields', [SON([('name', 'id'), ('ftype', 'fiftyone.core.fields.ObjectIdField'), ('embedded_doc_type', None), ('subfield', None), ('fields', []), ('db_field', '_id'), ('description', None), ('info', None)]), SON([('name', 'filepath'), ('ftype', 'fiftyone.core.fields.StringField'), ('embedded_doc_type', None), ('subfield', None), ('fields', []), ('db_field', 'filepath'), ('description', None), ('info', None)]), SON([('name', 'tags'), ('ftype', 'fiftyone.core.fields.ListField'), ('embedded_doc_type', None), ('subfield', 'fiftyone.core.fields.StringField'), ('fields', []), ('db_field', 'tags'), ('description', None), ('info', None)]), SON([('name', 'metadata'), ('ftype', 'fiftyone.core.fields.EmbeddedDocumentField'), ('embedded_doc_type', 'fiftyone.core.metadata.Metadata'), ('subfield', None), ('fields', [SON([('name', 'size_bytes'), ('ftype', 'fiftyone.core.fields.IntField'), ('embedded_doc_type', None), ('subfield', None), ('fields', []), ('db_field', 'size_bytes'), ('description', None), ('info', None)]), SON([('name', 'mime_type'), ('ftype', 'fiftyone.core.fields.StringField'), ('embedded_doc_type', None), ('subfield', None), ('fields', []), ('db_field', 'mime_type'), ('description', None), ('info', None)])]), ('db_field', 'metadata'), ('description', None), ('info', None)]), SON([('name', '_media_type'), ('ftype', 'fiftyone.core.fields.StringField'), ('embedded_doc_type', None), ('subfield', None), ('fields', []), ('db_field', '_media_type'), ('description', None), ('info', None)]), SON([('name', '_rand'), ('ftype', 'fiftyone.core.fields.FloatField'), ('embedded_doc_type', None), ('subfield', None), ('fields', []), ('db_field', '_rand'), ('description', None), ('info', None)]), SON([('name', '_dataset_id'), ('ftype', 'fiftyone.core.fields.ObjectIdField'), ('embedded_doc_type', None), ('subfield', None), ('fields', []), ('db_field', '_dataset_id'), ('description', None), ('info', None)])]), ('frame_fields', []), ('saved_views', []), ('workspaces', []), ('annotation_runs', {}), ('brain_methods', {}), ('evaluations', {}), ('runs', {})])

^^UPDATES {'$set': {'last_loaded_at': datetime.datetime(2024, 8, 26, 15, 4, 48, 625081)}}
```

Previously,
```
^^UPDATES {'$set': SON([('name', 'blah2'), ('slug', 'blah2'), ('version', '0.24.1'), ('created_at', datetime.datetime(2024, 8, 26, 15, 7, 4, 166390)), ('sample_collection_name', 'samples.66cc9a1861678cf7500272b4'), ('persistent', False), ('app_config', SON([('grid_media_field', 'filepath'), ('media_fallback', False), ('media_fields', ['filepath']), ('modal_media_field', 'filepath'), ('plugins', {})])), ('sample_fields', [SON([('name', 'id'), ('ftype', 'fiftyone.core.fields.ObjectIdField'), ('embedded_doc_type', None), ('subfield', None), ('fields', []), ('db_field', '_id'), ('description', None), ('info', None)]), SON([('name', 'filepath'), ('ftype', 'fiftyone.core.fields.StringField'), ('embedded_doc_type', None), ('subfield', None), ('fields', []), ('db_field', 'filepath'), ('description', None), ('info', None)]), SON([('name', 'tags'), ('ftype', 'fiftyone.core.fields.ListField'), ('embedded_doc_type', None), ('subfield', 'fiftyone.core.fields.StringField'), ('fields', []), ('db_field', 'tags'), ('description', None), ('info', None)]), SON([('name', 'metadata'), ('ftype', 'fiftyone.core.fields.EmbeddedDocumentField'), ('embedded_doc_type', 'fiftyone.core.metadata.Metadata'), ('subfield', None), ('fields', [SON([('name', 'size_bytes'), ('ftype', 'fiftyone.core.fields.IntField'), ('embedded_doc_type', None), ('subfield', None), ('fields', []), ('db_field', 'size_bytes'), ('description', None), ('info', None)]), SON([('name', 'mime_type'), ('ftype', 'fiftyone.core.fields.StringField'), ('embedded_doc_type', None), ('subfield', None), ('fields', []), ('db_field', 'mime_type'), ('description', None), ('info', None)])]), ('db_field', 'metadata'), ('description', None), ('info', None)]), SON([('name', '_media_type'), ('ftype', 'fiftyone.core.fields.StringField'), ('embedded_doc_type', None), ('subfield', None), ('fields', []), ('db_field', '_media_type'), ('description', None), ('info', None)]), SON([('name', '_rand'), ('ftype', 'fiftyone.core.fields.FloatField'), ('embedded_doc_type', None), ('subfield', None), ('fields', []), ('db_field', '_rand'), ('description', None), ('info', None)]), SON([('name', '_dataset_id'), ('ftype', 'fiftyone.core.fields.ObjectIdField'), ('embedded_doc_type', None), ('subfield', None), ('fields', []), ('db_field', '_dataset_id'), ('description', None), ('info', None)])])]), '$unset': {'group_media_types': 1, 'tags': 1, 'info': 1, 'classes': 1, 'default_classes': 1, 'mask_targets': 1, 'default_mask_targets': 1, 'skeletons': 1, 'frame_fields': 1, 'saved_views': 1, 'workspaces': 1, 'annotation_runs': 1, 'brain_methods': 1, 'evaluations': 1, 'runs': 1}}

^^UPDATES {'$set': {'last_loaded_at': datetime.datetime(2024, 8, 26, 15, 7, 4, 291793)}}
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a method to duplicate documents with a new unique identifier, enhancing document management.

- **Bug Fixes**
	- Improved ID generation for copied documents, reducing potential errors and improving maintainability.

- **Tests**
	- Added new tests to ensure the functionality of copying documents with new IDs works as intended.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->