### PR TITLE
Fields have created_at attribute

### DIFF
--- a/fiftyone/core/fields.py
+++ b/fiftyone/core/fields.py
@@ -409,11 +409,19 @@ class Field(mongoengine.fields.BaseField):
         read_only (False): whether the field is read-only
     """
 
-    def __init__(self, description=None, info=None, read_only=False, **kwargs):
+    def __init__(
+        self,
+        description=None,
+        info=None,
+        read_only=False,
+        created_at=None,
+        **kwargs,
+    ):
         super().__init__(**kwargs)
         self._description = description
         self._info = info
         self._read_only = read_only
+        self._created_at = created_at
 
         self.__dataset = None
         self.__path = None
@@ -527,6 +535,11 @@ class Field(mongoengine.fields.BaseField):
     @read_only.setter
     def read_only(self, read_only):
         self._read_only = read_only
+
+    @property
+    def created_at(self):
+        """The datetime when the field was created or added to dataset."""
+        return self._created_at
 
     def copy(self):
         """Returns a copy of the field.
@@ -1436,6 +1449,7 @@ class EmbeddedDocumentField(mongoengine.fields.EmbeddedDocumentField, Field):
         description (None): an optional description
         info (None): an optional info dict
         read_only (False): whether the field is read-only
+        created_at (None): datetime field was created
     """
 
     def __init__(
@@ -1444,6 +1458,7 @@ class EmbeddedDocumentField(mongoengine.fields.EmbeddedDocumentField, Field):
         description=None,
         info=None,
         read_only=False,
+        created_at=None,
         **kwargs,
     ):
         super().__init__(document_type, **kwargs)
@@ -1451,6 +1466,7 @@ class EmbeddedDocumentField(mongoengine.fields.EmbeddedDocumentField, Field):
         self._description = description
         self._info = info
         self._read_only = read_only
+        self._created_at = created_at
         self._selected_fields = None
         self._excluded_fields = None
         self.__fields = None

--- a/fiftyone/core/odm/dataset.py
+++ b/fiftyone/core/odm/dataset.py
@@ -68,6 +68,7 @@ class SampleFieldDocument(EmbeddedDocument):
     description = StringField(null=True)
     info = DictField(null=True)
     read_only = BooleanField(default=False)
+    created_at = DateTimeField(null=True, default=None)
 
     def to_field(self):
         """Creates the :class:`fiftyone.core.fields.Field` specified by this
@@ -100,6 +101,7 @@ class SampleFieldDocument(EmbeddedDocument):
             description=self.description,
             info=self.info,
             read_only=self.read_only,
+            created_at=self.created_at,
         )
 
     @classmethod
@@ -128,6 +130,7 @@ class SampleFieldDocument(EmbeddedDocument):
             description=field.description,
             info=field.info,
             read_only=field.read_only,
+            created_at=field.created_at,
         )
 
     @staticmethod

--- a/fiftyone/core/odm/document.py
+++ b/fiftyone/core/odm/document.py
@@ -10,6 +10,7 @@ from copy import deepcopy
 from datetime import datetime
 import json
 
+import bson
 from bson import json_util, ObjectId
 import mongoengine
 from pymongo import InsertOne, UpdateOne
@@ -590,6 +591,10 @@ class Document(BaseDocument, mongoengine.Document):
 
     meta = {"abstract": True}
 
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self._changed_fields = []
+
     @classmethod
     def _doc_name(cls):
         return "Document"
@@ -639,6 +644,13 @@ class Document(BaseDocument, mongoengine.Document):
             raise
 
         return self
+
+    def copy_with_new_id(self):
+        _copy = self.copy()
+        _id = bson.ObjectId()
+        _copy.id = _id
+        _copy._created = True
+        return _copy
 
     def _save(
         self,

--- a/fiftyone/core/odm/mixins.py
+++ b/fiftyone/core/odm/mixins.py
@@ -338,6 +338,7 @@ class DatasetMixin(object):
         description=None,
         info=None,
         read_only=False,
+        created_at=None,
         expand_schema=True,
         recursive=True,
         validate=True,
@@ -364,6 +365,7 @@ class DatasetMixin(object):
             description (None): an optional description
             info (None): an optional info dict
             read_only (False): whether the field should be read-only
+            created_at (None): datetime when this field was added to dataset
             expand_schema (True): whether to add new fields to the schema
                 (True) or simply validate that the field already exists with a
                 consistent type (False)
@@ -389,6 +391,7 @@ class DatasetMixin(object):
             description=description,
             info=info,
             read_only=read_only,
+            created_at=created_at,
             **kwargs,
         )
 
@@ -433,7 +436,9 @@ class DatasetMixin(object):
             ValueError: if a field in the schema is not compliant with an
                 existing field of the same name
         """
-        field = create_implied_field(path, value, dynamic=dynamic)
+        field = create_implied_field(
+            path, value, dynamic=dynamic, created_at=datetime.utcnow()
+        )
 
         return cls.merge_field_schema(
             {path: field},
@@ -453,6 +458,7 @@ class DatasetMixin(object):
         description=None,
         info=None,
         read_only=False,
+        created_at=None,
         **kwargs,
     ):
         field_name = path.rsplit(".", 1)[-1]
@@ -465,6 +471,7 @@ class DatasetMixin(object):
             description=description,
             info=info,
             read_only=read_only,
+            created_at=created_at,
             **kwargs,
         )
 
@@ -1236,6 +1243,7 @@ class DatasetMixin(object):
     def _clone_field_schema(cls, path, new_path):
         field_name, doc, _, _ = cls._parse_path(path)
         field = doc._fields[field_name]
+        field._created_at = datetime.utcnow()
 
         cls._add_field_schema(new_path, field)
 

--- a/fiftyone/core/odm/utils.py
+++ b/fiftyone/core/odm/utils.py
@@ -185,6 +185,7 @@ def create_field(
     description=None,
     info=None,
     read_only=False,
+    created_at=None,
     **kwargs,
 ):
     """Creates the field defined by the given specification.
@@ -217,6 +218,7 @@ def create_field(
         description (None): an optional description
         info (None): an optional info dict
         read_only (False): whether the field should be read-only
+        created_at (None): datetime when this field was added to dataset
 
     Returns:
         a :class:`fiftyone.core.fields.Field`
@@ -233,6 +235,7 @@ def create_field(
         description=description,
         info=info,
         read_only=read_only,
+        created_at=created_at,
     )
     field_kwargs.update(kwargs)
 
@@ -281,20 +284,21 @@ def create_field(
     return field
 
 
-def create_implied_field(path, value, dynamic=False):
+def create_implied_field(path, value, dynamic=False, created_at=None):
     """Creates the field for the given value.
 
     Args:
         path: the field name or path
         value: a value
         dynamic (False): whether to declare dynamic embedded document fields
+        created_at (None): datetime the field was created
 
     Returns:
         a :class:`fiftyone.core.fields.Field`
     """
     field_name = path.rsplit(".", 1)[-1]
     kwargs = get_implied_field_kwargs(value, dynamic=dynamic)
-    return create_field(field_name, **kwargs)
+    return create_field(field_name, created_at=created_at, **kwargs)
 
 
 def get_field_kwargs(field):
@@ -319,6 +323,7 @@ def get_field_kwargs(field):
         "description": field.description,
         "info": field.info,
         "read_only": field.read_only,
+        "created_at": field.created_at,
     }
 
     if isinstance(field, (fof.ListField, fof.DictField)):
@@ -436,6 +441,7 @@ def _get_field_kwargs(value, field, dynamic):
         "description": field.description,
         "info": field.info,
         "read_only": field.read_only,
+        "created_at": field.created_at,
     }
 
     if isinstance(field, (fof.ListField, fof.DictField)):

--- a/fiftyone/utils/data/importers.py
+++ b/fiftyone/utils/data/importers.py
@@ -1861,6 +1861,14 @@ class FiftyOneDatasetImporter(BatchDatasetImporter):
                 tags.extend([t for t in new_tags if t not in tags])
                 keep_fields["tags"] = tags
 
+            # Set field created_at times to now, since we are directly setting
+            #   the dataset doc
+            created_at = dataset.created_at
+            for field in dataset_dict["sample_fields"]:
+                field["created_at"] = created_at
+            for field in dataset_dict["frame_fields"]:
+                field["created_at"] = created_at
+
             dataset_dict.update(keep_fields)
 
             conn = foo.get_db_conn()

--- a/tests/unittests/dataset_tests.py
+++ b/tests/unittests/dataset_tests.py
@@ -2802,6 +2802,8 @@ class DatasetTests(unittest.TestCase):
 
         created_at = dataset.get_field("field").created_at
         dataset.rename_sample_field("field", "new_field")
+
+        # Renaming doesn't cause created_at to update
         self.assertEqual(dataset.get_field("new_field").created_at, created_at)
         self.assertFalse("field" in dataset.get_field_schema())
         self.assertTrue("new_field" in dataset.get_field_schema())

--- a/tests/unittests/import_export_tests.py
+++ b/tests/unittests/import_export_tests.py
@@ -3294,9 +3294,6 @@ class MultitaskImageDatasetTests(ImageDatasetTests):
         created_at2 = dataset2.values("created_at")
         last_modified_at2 = dataset2.values("last_modified_at")
 
-        print(field_created_at1)
-        print(field_created_at2)
-        assert 0
         self.assertTrue(
             all(
                 f1 < f2 for f1, f2 in zip(field_created_at1, field_created_at2)

--- a/tests/unittests/import_export_tests.py
+++ b/tests/unittests/import_export_tests.py
@@ -2894,6 +2894,7 @@ class MultitaskImageDatasetTests(ImageDatasetTests):
     @drop_datasets
     def test_fiftyone_dataset(self):
         dataset = self._make_dataset()
+        dataset.reload()
 
         # Standard format
 
@@ -3281,12 +3282,26 @@ class MultitaskImageDatasetTests(ImageDatasetTests):
             dataset_type=fo.types.FiftyOneDataset,
         )
 
+        field_created_at1 = [
+            f.created_at for f in dataset.get_field_schema().values()
+        ]
         created_at1 = dataset.values("created_at")
         last_modified_at1 = dataset.values("last_modified_at")
 
+        field_created_at2 = [
+            f.created_at for f in dataset2.get_field_schema().values()
+        ]
         created_at2 = dataset2.values("created_at")
         last_modified_at2 = dataset2.values("last_modified_at")
 
+        print(field_created_at1)
+        print(field_created_at2)
+        assert 0
+        self.assertTrue(
+            all(
+                f1 < f2 for f1, f2 in zip(field_created_at1, field_created_at2)
+            )
+        )
         self.assertTrue(
             all(c1 < c2 for c1, c2 in zip(created_at1, created_at2))
         )
@@ -3633,11 +3648,23 @@ class MultitaskImageDatasetTests(ImageDatasetTests):
             dataset_type=fo.types.LegacyFiftyOneDataset,
         )
 
+        field_created_at1 = [
+            f.created_at for f in dataset.get_field_schema().values()
+        ]
         created_at1 = dataset.values("created_at")
         last_modified_at1 = dataset.values("last_modified_at")
 
+        field_created_at2 = [
+            f.created_at for f in dataset2.get_field_schema().values()
+        ]
         created_at2 = dataset2.values("created_at")
         last_modified_at2 = dataset2.values("last_modified_at")
+
+        self.assertTrue(
+            all(
+                f1 < f2 for f1, f2 in zip(field_created_at1, field_created_at2)
+            )
+        )
 
         self.assertTrue(
             all(c1 < c2 for c1, c2 in zip(created_at1, created_at2))
@@ -4690,6 +4717,7 @@ class MultitaskVideoDatasetTests(VideoDatasetTests):
 
         export_dir = self._new_dir()
 
+        dataset.reload()
         dataset.export(
             export_dir=export_dir,
             dataset_type=fo.types.FiftyOneDataset,
@@ -4700,14 +4728,25 @@ class MultitaskVideoDatasetTests(VideoDatasetTests):
             dataset_type=fo.types.FiftyOneDataset,
         )
 
+        field_created_at1 = [
+            f.created_at for f in dataset.get_frame_field_schema().values()
+        ]
         created_at1 = dataset.values("frames.created_at", unwind=True)
         last_modified_at1 = dataset.values("last_modified_at", unwind=True)
 
+        field_created_at2 = [
+            f.created_at for f in dataset2.get_frame_field_schema().values()
+        ]
         created_at2 = dataset2.values("frames.created_at", unwind=True)
         last_modified_at2 = dataset2.values(
             "frames.last_modified_at", unwind=True
         )
 
+        self.assertTrue(
+            all(
+                f1 < f2 for f1, f2 in zip(field_created_at1, field_created_at2)
+            )
+        )
         self.assertTrue(
             all(c1 < c2 for c1, c2 in zip(created_at1, created_at2))
         )
@@ -4735,14 +4774,25 @@ class MultitaskVideoDatasetTests(VideoDatasetTests):
             dataset_type=fo.types.LegacyFiftyOneDataset,
         )
 
+        field_created_at1 = [
+            f.created_at for f in dataset.get_frame_field_schema().values()
+        ]
         created_at1 = dataset.values("frames.created_at", unwind=True)
         last_modified_at1 = dataset.values("last_modified_at", unwind=True)
 
+        field_created_at2 = [
+            f.created_at for f in dataset2.get_frame_field_schema().values()
+        ]
         created_at2 = dataset2.values("frames.created_at", unwind=True)
         last_modified_at2 = dataset2.values(
             "frames.last_modified_at", unwind=True
         )
 
+        self.assertTrue(
+            all(
+                f1 < f2 for f1, f2 in zip(field_created_at1, field_created_at2)
+            )
+        )
         self.assertTrue(
             all(c1 < c2 for c1, c2 in zip(created_at1, created_at2))
         )


### PR DESCRIPTION
## What changes are proposed in this pull request?

Adds `created_at` property to all `fo.Field`s. Default is `None` but it is populated on newly-created fields.
This is only stored in the dataset doc `sample_field` and `frame_field` embedded document list fields, so the footprint is small.

**Note**: `created_at` is not propagated through to embedded document fields. Could add this on later if desired but for now the feature achieved what I needed without doing so.

Depends on branch `last-modified-at` so must be merged there.
Also depends on some other bug fixes such as https://github.com/voxel51/fiftyone/pull/4729. But that was copied into the commit. Might just have merge conflicts.

## How is this patch tested? If it is not, please explain why.

Added automated tests checking field created_at is only updated when the field is new.

```python
from datetime import datetime
import time
import fiftyone as fo

def _assert_equalish(t1, t2):
  assert (t2-t1).total_seconds() < 0.1

now = datetime.utcnow()
ds = fo.Dataset()

for field in ds.get_field_schema().values():
  _assert_equalish(now, field.created_at)

time.sleep(1)
ds.add_sample_field("new_field", fo.StringField)
assert (ds.get_field("new_field").created_at - now).total_seconds() > 1
```

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

Added `created_at` property to every field.

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
