### PR TITLE
fix bug causing JS plugins to be permanently cached

### DIFF
--- a/app/packages/plugins/src/index.ts
+++ b/app/packages/plugins/src/index.ts
@@ -80,6 +80,7 @@ class PluginDefinition {
   pyEntry: string | null;
   jsBundleExists: boolean;
   jsBundleServerPath: string | null;
+  jsBundleHash: string | null;
   serverPath: string;
   hasPy: boolean;
   hasJS: boolean;
@@ -97,6 +98,7 @@ class PluginDefinition {
 
     this.jsBundleExists = json.js_bundle_exists;
     this.jsBundleServerPath = `${serverPathPrefix}${json.js_bundle_server_path}`;
+    this.jsBundleHash = json.js_bundle_hash;
     this.hasPy = json.has_py;
     this.hasJS = json.has_js;
     this.serverPath = `${serverPathPrefix}${json.server_path}`;
@@ -111,12 +113,13 @@ export async function loadPlugins() {
     if (plugin.hasJS) {
       const name = plugin.name;
       const scriptPath = plugin.jsBundleServerPath;
+      const cacheKey = plugin.jsBundleHash ? `?h=${plugin.jsBundleHash}` : '';
       if (usingRegistry().hasScript(name)) {
         console.debug(`Plugin "${name}": already loaded`);
         continue;
       }
       try {
-        await loadScript(name, pathPrefix + scriptPath);
+        await loadScript(name, pathPrefix + scriptPath + cacheKey);
       } catch (e) {
         console.error(`Plugin "${name}": failed to load!`);
         console.error(e);

--- a/fiftyone/plugins/definitions.py
+++ b/fiftyone/plugins/definitions.py
@@ -5,6 +5,7 @@ Plugin definitions.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+import hashlib
 import os
 
 import yaml
@@ -139,6 +140,20 @@ class PluginDefinition(object):
         if self.has_js:
             return os.path.join(self.server_path, self.js_bundle)
 
+    @property
+    def js_bundle_hash(self):
+        """A hash of the plugin's JS bundle file."""
+        if not self.has_js:
+            return None
+
+        try:
+            with open(self.js_bundle_path, "rb") as f:
+                h = hashlib.sha1()
+                h.update(f.read())
+                return h.hexdigest()
+        except:
+            return None
+
     def can_register_operator(self, name):
         """Whether the plugin can register the given operator.
 
@@ -185,6 +200,7 @@ class PluginDefinition(object):
             "py_entry": self.py_entry,
             "js_bundle_exists": self.has_js,
             "js_bundle_server_path": self.js_bundle_server_path,
+            "js_bundle_hash": self.js_bundle_hash,
             "has_py": self.has_py,
             "has_js": self.has_js,
             "server_path": self.server_path,


### PR DESCRIPTION
## What changes are proposed in this pull request?

This PR fixes a bug which causes JS plugins to be permanently cached.

When loading plugins, we construct a script URL based on the path to the plugin and the value of the plugin's `fiftyone.script` entry in its `package.json` file. This value defaults to `dist/index.umd.js` and is not expected to change between plugin versions or iterations. As a result, the resolved path to the plugin's script file does not change, and so the browser caches the file and returns the cached version even when the plugin's source changes.

This PR adds the JS file's SHA1 hash as additional metadata to the `/plugins` endpoint. The script source is modified to include this hash as a query parameter when it is present, which has the effect of bypassing the browser's cache whenever the file's source (and so its hash) changes.

## How is this patch tested? If it is not, please explain why.

Tested via a local installation of FiftyOne. Verified:
* The metadata returned by `/plugins` includes the file hash for JS plugins
* The script src is modified to include the hash and correctly serves updated plugin source files

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

JS plugin development did not function correctly prior to this change; additional steps were required (such as disabling the browser's cache) in order for the app to render the updated plugin.

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new property for managing JavaScript bundle versions, enhancing cache management during plugin loading.
	- Added a mechanism to compute and return a SHA-1 hash of the JavaScript bundle, improving integrity verification.

- **Improvements**
	- Updated data structures to include new properties, providing better access to versioning information for plugins.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->