### PR TITLE
fix TabsView getting reset to default value

### DIFF
--- a/app/packages/core/src/plugins/SchemaIO/components/TabsView.tsx
+++ b/app/packages/core/src/plugins/SchemaIO/components/TabsView.tsx
@@ -4,12 +4,14 @@ import HeaderView from "./HeaderView";
 import HelpTooltip from "./HelpTooltip";
 import RoundedTabs from "./RoundedTabs";
 import { getComponentProps } from "../utils";
+import { useKey } from "../hooks";
 
 export default function TabsView(props) {
   const { onChange, path, schema, data } = props;
   const { view = {}, default: defaultValue } = schema;
   const { choices = [], variant = "default" } = view;
   const [tab, setTab] = useState(data ?? (defaultValue || choices[0]?.value));
+  const [_, setUserChanged] = useKey(path, schema, data, true);
 
   useEffect(() => {
     if (typeof onChange === "function") onChange(path, tab);
@@ -30,7 +32,10 @@ export default function TabsView(props) {
           value={tab}
           variant="scrollable"
           scrollButtons="auto"
-          onChange={(e, value) => setTab(value)}
+          onChange={(e, value) => {
+            setTab(value);
+            setUserChanged();
+          }}
           sx={{ borderBottom: 1, borderColor: "divider" }}
           {...getComponentProps(props, "tabs")}
         >


### PR DESCRIPTION
## What changes are proposed in this pull request?

Fix TabsView state being reset to the default value provided.

## How is this patch tested? If it is not, please explain why.

Using an example operator:
```py
class TestTabs(foo.Operator):
    @property
    def config(self):
        return foo.OperatorConfig(name="test_tabs", label="Test: Tabs", dynamic=True)

    def resolve_input(self, ctx):
        inputs = types.Object()
        tabs = types.TabsView()
        tabs.add_choice("tab1", label="Tab 1")
        tabs.add_choice("tab2", label="Tab 2")
        tabs.add_choice("tab3", label="Tab 3")
        inputs.str("tab", label="Tab", required=True, view=tabs)
        inputs.md(f"### {ctx.params.get('tab', 'Tab 1')}")
        return types.Property(inputs)

    def execute(self, ctx):
        return {}

    def resolve_output(self, ctx):
        outputs = types.Object()
        return types.Property(outputs)
```

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

Fix TabsView state being reset to the default value provided

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced tab interaction tracking in the `TabsView` component, allowing for better management of user interactions.
- **Bug Fixes**
	- Improved tab change handling logic to ensure accurate updates when users switch tabs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->