### PR TITLE
Draft: Adding Med-SAM2 model and Med-SAM2 dataset to HF Collection

### DIFF
--- a/fiftyone/zoo/models/manifest-torch.json
+++ b/fiftyone/zoo/models/manifest-torch.json
@@ -449,6 +449,44 @@
             "date_added": "2024-08-05 14:38:20"
         },
         {
+            "base_name": "MedSAM2-video-torch",
+            "base_filename": "MedSAM2_pretrain.pth",
+            "version": null,
+            "description": "Fine-tuned SAM2-hiera-tiny model from paper: Medical SAM 2 - Segment Medical Images as Video via Segment Anything Model 2 <https://arxiv.org/abs/2408.00874>`_",
+            "source": "https://github.com/MedicineToken/Medical-SAM2",
+            "size_bytes": 155906050,
+            "manager": {
+                "type": "fiftyone.core.models.ModelManager",
+                "config": {
+                    "url": "https://huggingface.co/jiayuanz3/MedSAM2_pretrain/resolve/main/MedSAM2_pretrain.pth?download=true"
+                }
+            },
+            "default_deployment_config_dict": {
+                "type": "fiftyone.utils.sam2.SegmentAnything2VideoModel",
+                "config": {
+                    "entrypoint_fcn": "sam2.build_sam.build_sam2_video_predictor",
+                    "entrypoint_args": { "model_cfg": "sam2_hiera_t.yaml" }
+                }
+            },
+            "requirements": {
+                "packages": ["torch", "torchvision"],
+                "cpu": {
+                    "support": true
+                },
+                "gpu": {
+                    "support": true
+                }
+            },
+            "tags": [
+                "segment-anything",
+                "torch",
+                "zero-shot",
+                "video",
+                "MedSAM-2"
+            ],
+            "date_added": "2024-08-17 14:48:00"
+        },
+        {
             "base_name": "deeplabv3-resnet50-coco-torch",
             "base_filename": "deeplabv3_resnet50_coco-cd0a2569.pth",
             "version": null,


### PR DESCRIPTION
## What changes are proposed in this pull request?

This PR simply adds the 3D Med-SAM2 model to the model zoo. This model is a fine-tuning of SAM2 hiera-tiny, published on [Hugging Face](https://huggingface.co/datasets/jiayuanz3/REFUGE/tree/main) and the [Med-SAM2 Github repo](https://github.com/MedicineToken/Medical-SAM2) along with their paper: [Medical SAM 2: Segment Medical Images As Video Via Segment Anything Model 2](https://arxiv.org/abs/2408.00874).

Simultaneously, I have collected the BTCV imagery used to train Med-SAM2 and converted it into a Fiftyone video dataset. This dataset has been (is being) [uploaded](https://huggingface.co/datasets/Voxel51/BTCV-CT-as-video-MedSAM2-dataset/tree/main) to the Hugging Face Hub into the Voxel51 organization.

Soon, I will add a tutorial that guides users to load the BTCV dataset, load the Med-SAM2 model, and apply the model onto the test set of the dataset. The basic recipe is laid out below.

## How is this patch tested? If it is not, please explain why.

You must add the [SAM2](https://github.com/facebookresearch/segment-anything-2) package to your environment.
```python
import os
import fiftyone as fo
import fiftyone.zoo as foz
from fiftyone.utils.huggingface import load_from_hub

dataset = load_from_hub("Voxel51/BTCV-CT-as-video-MedSAM2-dataset")

# Form the prompt dataset (recommended settings with a GPU)
prompt_dataset = form_prompt_dataset(
    dataset.limit(5), 
    prompt_frames_fraction=0.25, 
    # max_prompt_frames=None,
    # prompt_organs=None,
)

# Form the prompt dataset (recommended settings without a GPU)
prompt_dataset = form_prompt_dataset(
    dataset.limit(2), 
    # prompt_frames_fraction=0.25, 
    max_prompt_frames=10,
    prompt_organs=["liver"],
)

model = foz.load_zoo_model("MedSAM2-video-torch")

# Prompt with boxes
prompt_dataset.apply_model(
    model,
    label_field="pred_segmentations",
    prompt_field="frames.gt_detections",
)
session = fo.launch_app(prompt_dataset)
```

```python
def form_prompt_dataset(
    dataset, prompt_frames_fraction=0.25, max_prompt_frames=None, prompt_organs=None, seed=51
):
    """
    Create a prompt dataset by selecting a subset of frames and organs from the input dataset.

    To recreate the MedSAM2 paper use the default values:
    - prompt_frames_fraction=0.25
    - max_prompt_frames=None

    Args:
        dataset: The input FiftyOne dataset.
        prompt_frames_fraction (float, optional): The fraction of frames to retain in the prompt dataset (0-1).
        max_prompt_frames (int, optional): The maximum number of frames to include in the prompt dataset.
        prompt_organs (list, optional): A list of organs to filter the prompt dataset by.

    Returns:
        FiftyOne dataset: The prompt dataset with selected frames and filtered labels.
    """
    from fiftyone import ViewField as F
    import random
    random.seed(seed)
    
    prompt_dataset = dataset.clone()
    
    # Get the frame IDs from the prompt dataset 
    # (a nested list of frame IDs per video sample)
    frame_ids = prompt_dataset.values("frames.id")
    
    frame_ids_to_delete = []

    for sample_frame_ids in frame_ids:
        random.shuffle(sample_frame_ids)
        
        num_prompt_frames = len(sample_frame_ids)

        if prompt_frames_fraction is not None:
            num_prompt_frames = int(len(sample_frame_ids) * prompt_frames_fraction)

        # Limit the number of prompt frames to the provided maximum value
        if max_prompt_frames is not None:
            num_prompt_frames = min(num_prompt_frames, max_prompt_frames)

        # Add the remaining frame IDs to the list of frame IDs to delete
        frame_ids_to_delete.extend(sample_frame_ids[num_prompt_frames:])

    # Delete the selected frames from the prompt dataset and remove their detections
    (
        prompt_dataset
        .select_frames(frame_ids_to_delete)
        .set_field("frames.gt_detections", None)
        .save()
    )
    # Filter the prompt dataset by the specified prompt organs, if provided
    if prompt_organs:
        (
            prompt_dataset
            .filter_labels(
                "frames.gt_detections", 
                filter=F("label").is_in(prompt_organs)
            )
            .save()
        )

    return prompt_dataset
```

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

Yes! This is a great example of the exciting capabilities of the new SAM2 model, and how it may be fine-tuned for improving performance in specific domains.

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

Building upon the recent integration of SAM 2, the specialized CT-scan model Med-SAM2 is now available in the FiftyOne Model Zoo! The dataset used to fine-tune this model is also available on Voxel51's Hugging Face Hub. By treating CT-scan imagery as videos, this model shows the exciting opportunities for fine-tuning SAM2 to specific domains.

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [x] Documentation: FiftyOne documentation changes
-   [ ] Other
