### PR TITLE
Fix Keypoint filtering

### DIFF
--- a/app/packages/state/src/recoil/pathFilters/index.test.ts
+++ b/app/packages/state/src/recoil/pathFilters/index.test.ts
@@ -1,0 +1,13 @@
+import { KEYPOINT_FIELD, KEYPOINTS_FIELD } from "@fiftyone/utilities";
+import { describe, expect, it } from "vitest";
+import { keypointFilter } from ".";
+
+describe("path filter handling", () => {
+  it("overrides keypoint object filters", () => {
+    const keypoint = keypointFilter("test", KEYPOINT_FIELD, () => false);
+    expect(keypoint({ test: [] })).toBe(true);
+
+    const keypoints = keypointFilter("test", KEYPOINTS_FIELD, () => false);
+    expect(keypoints({ test: [] })).toBe(true);
+  });
+});

--- a/app/packages/state/src/recoil/pathFilters/index.test.ts
+++ b/app/packages/state/src/recoil/pathFilters/index.test.ts
@@ -16,14 +16,6 @@ describe("path filter handling", () => {
     expect(keypoints({ test: [] })).toBe(true);
   });
 
-  it("overrides keypoint array filters", () => {
-    const keypoint = keypointFilter("test", KEYPOINT_FIELD, () => false);
-    expect(keypoint({ test: [] })).toBe(true);
-
-    const keypoints = keypointFilter("test", KEYPOINTS_FIELD, () => false);
-    expect(keypoints({ test: [] })).toBe(true);
-  });
-
   it("does not override other label fields", () => {
     const keypoint = keypointFilter("test", DETECTION_FIELD, () => false);
     expect(keypoint({ test: [] })).toBe(false);

--- a/app/packages/state/src/recoil/pathFilters/index.test.ts
+++ b/app/packages/state/src/recoil/pathFilters/index.test.ts
@@ -1,13 +1,34 @@
-import { KEYPOINT_FIELD, KEYPOINTS_FIELD } from "@fiftyone/utilities";
+import {
+  DETECTION_FIELD,
+  DETECTIONS_FIELD,
+  KEYPOINT_FIELD,
+  KEYPOINTS_FIELD,
+} from "@fiftyone/utilities";
 import { describe, expect, it } from "vitest";
 import { keypointFilter } from ".";
 
 describe("path filter handling", () => {
-  it("overrides keypoint object filters", () => {
+  it("overrides keypoint array filters", () => {
     const keypoint = keypointFilter("test", KEYPOINT_FIELD, () => false);
     expect(keypoint({ test: [] })).toBe(true);
 
     const keypoints = keypointFilter("test", KEYPOINTS_FIELD, () => false);
     expect(keypoints({ test: [] })).toBe(true);
+  });
+
+  it("overrides keypoint array filters", () => {
+    const keypoint = keypointFilter("test", KEYPOINT_FIELD, () => false);
+    expect(keypoint({ test: [] })).toBe(true);
+
+    const keypoints = keypointFilter("test", KEYPOINTS_FIELD, () => false);
+    expect(keypoints({ test: [] })).toBe(true);
+  });
+
+  it("does not override other label fields", () => {
+    const keypoint = keypointFilter("test", DETECTION_FIELD, () => false);
+    expect(keypoint({ test: [] })).toBe(false);
+
+    const keypoints = keypointFilter("test", DETECTIONS_FIELD, () => false);
+    expect(keypoints({ test: [] })).toBe(false);
   });
 });


### PR DESCRIPTION
## What changes are proposed in this pull request?

Single `Keypoint` fields (in the example below, the `keypoint` field) currently do not filter individual keypoint values, e.g. `confidence`

```python
import fiftyone.zoo as foz
from fiftyone import ViewField as F

dataset = (
    foz.load_zoo_dataset("coco-2017", max_samples=1, split="validation")
    .select_fields()
    .clone("test-keypoints")
)
model = foz.load_zoo_model("keypoint-rcnn-resnet50-fpn-coco-torch")
dataset.default_skeleton = model.skeleton
dataset.apply_model(model, label_field="model")

sample = dataset.first()
sample["keypoint"] = sample.model_keypoints.keypoints[0]
sample.save()
``` 

https://github.com/user-attachments/assets/692182e2-1b1b-4032-93e6-bb8e127a5cf6


## How is this patch tested? If it is not, please explain why.

Unit test for keypoint filter handling

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?


* Fixed individual point`|Keypoint|` filtering in the sidebar

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new filtering mechanism for handling keypoints and detections, enhancing data processing capabilities.
  - Added a modular `keypointFilter` function for improved filtering of keypoint data.

- **Tests**
  - Implemented a comprehensive suite of unit tests for the `keypointFilter` function to ensure reliable behavior across various scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->