### PR TITLE
Update `YOLOv5DatasetImporter` to support loading list of `.txt`

### DIFF
--- a/fiftyone/utils/yolo.py
+++ b/fiftyone/utils/yolo.py
@@ -506,25 +506,25 @@ class YOLOv5DatasetImporter(
             )
 
         dataset_path = d.get("path", "")
-        data = fos.normpath(os.path.join(dataset_path, d[self.split]))
+        split_info = d[self.split]
+        if isinstance(split_info, str):
+            split_info = [split_info]
+        data = [
+            fos.normpath(os.path.join(dataset_path, si)) for si in split_info
+        ]
         classes = _parse_yolo_classes(d.get("names", None))
 
-        if etau.is_str(data) and data.endswith(".txt"):
-            txt_path = _parse_yolo_v5_path(data, self.yaml_path)
-            image_paths = [
-                _parse_yolo_v5_path(fos.normpath(p), txt_path)
-                for p in _read_file_lines(txt_path)
-            ]
-        else:
-            if etau.is_str(data):
-                data_dirs = [data]
+        image_paths = []
+        for data_path in data:
+            if etau.is_str(data_path) and data_path.endswith(".txt"):
+                txt_path = _parse_yolo_v5_path(data_path, self.yaml_path)
+                image_paths.extend(
+                    _parse_yolo_v5_path(fos.normpath(p), txt_path)
+                    for p in _read_file_lines(txt_path)
+                )
             else:
-                data_dirs = data
-
-            image_paths = []
-            for data_dir in data_dirs:
                 data_dir = fos.normpath(
-                    _parse_yolo_v5_path(data_dir, self.yaml_path)
+                    _parse_yolo_v5_path(data_path, self.yaml_path)
                 )
                 image_paths.extend(
                     etau.list_files(data_dir, abs_paths=True, recursive=True)


### PR DESCRIPTION
## What changes are proposed in this pull request?

Currently, the `YOLOv5DatasetImporter` does not support loading a split contains list of `.txt`, e.g.:

```yaml
...
val:
  - one.txt
  - two.txt
  - three.txt
...
```

And, I make it support.

## How is this patch tested? If it is not, please explain why.

I have tested the following variants of YOLOv5 dataset:

* Single `folder` as a split.
* Single `txt` as a split.
* Multiple `folder` as a split.
* Multiple `txt` as a split.
* Multiple mixed `folder` and `txt` as a split.

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [x] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved handling of dataset paths, allowing for multiple split paths to be processed.
	- Enhanced flexibility in managing various input formats for image paths.
- **Bug Fixes**
	- Streamlined control flow for evaluating image paths, ensuring consistent processing of all provided paths.
- **Refactor**
	- Simplified and clarified the structure of the code for better maintainability and readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->