### PR TITLE
Plugin docs tweak

### DIFF
--- a/docs/source/plugins/developing_plugins.rst
+++ b/docs/source/plugins/developing_plugins.rst
@@ -189,9 +189,9 @@ fiftyone.yml
 ------------
 
 All plugins must contain a `fiftyone.yml` or `fiftyone.yaml` file, which is
-used to define the plugin's metadata, declare any operators that it exposes,
-and declare any :ref:`secrets <plugins-secrets>` that it may require. The
-following fields are available:
+used to define the plugin's metadata, declare any operators and panels that it
+exposes, and declare any :ref:`secrets <plugins-secrets>` that it may require.
+The following fields are available:
 
 -   `name` **(required)**: the name of the plugin
 -   `author`: the author of the plugin


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated plugin documentation to clarify that both operators and panels can be declared in the configuration file, enhancing user understanding of plugin functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->