### PR TITLE
Adding support for remotely-sourced zoo datasets

### DIFF
--- a/docs/source/cli/index.rst
+++ b/docs/source/cli/index.rst
@@ -2248,7 +2248,6 @@ List datasets in the FiftyOne Dataset Zoo.
 .. code-block:: text
 
     fiftyone zoo datasets list [-h] [-n] [-d] [-s SOURCE] [-t TAGS]
-                               [-b BASE_DIR]
 
 **Arguments**
 
@@ -2262,9 +2261,6 @@ List datasets in the FiftyOne Dataset Zoo.
       -s SOURCE, --source SOURCE
                             only show datasets available from the specified source
       -t TAGS, --tags TAGS  only show datasets with the specified tag or list,of,tags
-      -b BASE_DIR, --base-dir BASE_DIR
-                            a custom base directory in which to search for
-                            downloaded datasets
 
 **Examples**
 
@@ -2275,7 +2271,7 @@ List datasets in the FiftyOne Dataset Zoo.
 
 .. code-block:: shell
 
-    # List available datasets (names only)
+    # List available dataset names
     fiftyone zoo datasets list --names-only
 
 .. code-block:: shell
@@ -2298,18 +2294,18 @@ List datasets in the FiftyOne Dataset Zoo.
 Find zoo datasets on disk
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Locate the downloaded zoo dataset on disk.
+Locate a downloaded zoo dataset on disk.
 
 .. code-block:: text
 
-    fiftyone zoo datasets find [-h] [-s SPLIT] NAME
+    fiftyone zoo datasets find [-h] [-s SPLIT] NAME_OR_URL
 
 **Arguments**
 
 .. code-block:: text
 
     positional arguments:
-      NAME        the name of the dataset
+      NAME_OR_URL           the name or remote location of the dataset
 
     optional arguments:
       -h, --help            show this help message and exit
@@ -2319,12 +2315,18 @@ Locate the downloaded zoo dataset on disk.
 
 .. code-block:: shell
 
-    # Print the location of the downloaded zoo dataset on disk
+    # Print the location of a downloaded zoo dataset on disk
     fiftyone zoo datasets find <name>
 
 .. code-block:: shell
 
-    # Print the location of a specific split of the dataset
+    # Print the location of a remotely-sourced zoo dataset on disk
+    fiftyone zoo datasets info https://github.com/<user>/<repo>
+    fiftyone zoo datasets info <url>
+
+.. code-block:: shell
+
+    # Print the location of a specific split of a dataset
     fiftyone zoo datasets find <name> --split <split>
 
 .. _cli-fiftyone-zoo-datasets-info:
@@ -2336,20 +2338,17 @@ Print information about datasets in the FiftyOne Dataset Zoo.
 
 .. code-block:: text
 
-    fiftyone zoo datasets info [-h] [-b BASE_DIR] NAME
+    fiftyone zoo datasets info [-h] NAME_OR_URL
 
 **Arguments**
 
 .. code-block:: text
 
     positional arguments:
-      NAME                  the name of the dataset
+      NAME_OR_URL           the name or remote location of the dataset
 
     optional arguments:
       -h, --help            show this help message and exit
-      -b BASE_DIR, --base-dir BASE_DIR
-                            a custom base directory in which to search for
-                            downloaded datasets
 
 **Examples**
 
@@ -2358,34 +2357,52 @@ Print information about datasets in the FiftyOne Dataset Zoo.
     # Print information about a zoo dataset
     fiftyone zoo datasets info <name>
 
+.. code-block:: shell
+
+    # Print information about a remote zoo dataset
+    fiftyone zoo datasets info https://github.com/<user>/<repo>
+    fiftyone zoo datasets info <url>
+
 .. _cli-fiftyone-zoo-datasets-download:
 
 Download zoo datasets
 ~~~~~~~~~~~~~~~~~~~~~
 
-Download datasets from the FiftyOne Dataset Zoo.
+Download zoo datasets.
+
+When downloading remotely-sourced zoo datasets, you can provide any of the
+following formats:
+
+-   a GitHub repo URL like ``https://github.com/<user>/<repo>``
+-   a GitHub ref like ``https://github.com/<user>/<repo>/tree/<branch>`` or
+    ``https://github.com/<user>/<repo>/commit/<commit>``
+-   a GitHub ref string like ``<user>/<repo>[/<ref>]``
+-   a publicly accessible URL of an archive (eg zip or tar) file
+
+.. note::
+
+    To download from a private GitHub repository that you have access to,
+    provide your GitHub personal access token by setting the ``GITHUB_TOKEN``
+    environment variable.
 
 .. code-block:: text
 
     fiftyone zoo datasets download [-h] [-s SPLITS [SPLITS ...]]
-                                   [-d DATASET_DIR]
                                    [-k KEY=VAL [KEY=VAL ...]]
-                                   NAME
+                                   NAME_OR_URL
 
 **Arguments**
 
 .. code-block:: text
 
     positional arguments:
-      NAME                  the name of the dataset
+      NAME_OR_URL           the name or remote location of the dataset
 
     optional arguments:
 
       -h, --help            show this help message and exit
       -s SPLITS [SPLITS ...], --splits SPLITS [SPLITS ...]
                             the dataset splits to download
-      -d DATASET_DIR, --dataset-dir DATASET_DIR
-                            a custom directory to which to download the dataset
       -k KEY=VAL [KEY=VAL ...], --kwargs KEY=VAL [KEY=VAL ...]
                             optional dataset-specific keyword arguments for
                             `fiftyone.zoo.download_zoo_dataset()`
@@ -2394,18 +2411,19 @@ Download datasets from the FiftyOne Dataset Zoo.
 
 .. code-block:: shell
 
-    # Download the entire zoo dataset
+    # Download a zoo dataset
     fiftyone zoo datasets download <name>
 
 .. code-block:: shell
 
-    # Download the specified split(s) of the zoo dataset
-    fiftyone zoo datasets download <name> --splits <split1> ...
+    # Download a remotely-sourced zoo dataset
+    fiftyone zoo datasets download https://github.com/<user>/<repo>
+    fiftyone zoo datasets download <url>
 
 .. code-block:: shell
 
-    # Download the zoo dataset to a custom directory
-    fiftyone zoo datasets download <name> --dataset-dir <dataset-dir>
+    # Download the specified split(s) of a zoo dataset
+    fiftyone zoo datasets download <name> --splits <split1> ...
 
 .. code-block:: shell
 
@@ -2420,19 +2438,33 @@ Load zoo datasets
 
 Load zoo datasets as persistent FiftyOne datasets.
 
+When loading remotely-sourced zoo datasets, you can provide any of the
+following formats:
+
+-   a GitHub repo URL like ``https://github.com/<user>/<repo>``
+-   a GitHub ref like ``https://github.com/<user>/<repo>/tree/<branch>`` or
+    ``https://github.com/<user>/<repo>/commit/<commit>``
+-   a GitHub ref string like ``<user>/<repo>[/<ref>]``
+-   a publicly accessible URL of an archive (eg zip or tar) file
+
+.. note::
+
+    To download from a private GitHub repository that you have access to,
+    provide your GitHub personal access token by setting the ``GITHUB_TOKEN``
+    environment variable.
+
 .. code-block:: text
 
     fiftyone zoo datasets load [-h] [-s SPLITS [SPLITS ...]]
-                               [-n DATASET_NAME] [-d DATASET_DIR]
-                               [-k KEY=VAL [KEY=VAL ...]]
-                               NAME
+                               [-n DATASET_NAME] [-k KEY=VAL [KEY=VAL ...]]
+                               NAME_OR_URL
 
 **Arguments**
 
 .. code-block:: text
 
     positional arguments:
-      NAME                  the name of the dataset
+      NAME_OR_URL           the name or remote location of the dataset
 
     optional arguments:
       -h, --help            show this help message and exit
@@ -2440,8 +2472,6 @@ Load zoo datasets as persistent FiftyOne datasets.
                             the dataset splits to load
       -n DATASET_NAME, --dataset-name DATASET_NAME
                             a custom name to give the FiftyOne dataset
-      -d DATASET_DIR, --dataset-dir DATASET_DIR
-                            a custom directory in which the dataset is downloaded
       -k KEY=VAL [KEY=VAL ...], --kwargs KEY=VAL [KEY=VAL ...]
                             additional dataset-specific keyword arguments for
                             `fiftyone.zoo.load_zoo_dataset()`
@@ -2455,18 +2485,19 @@ Load zoo datasets as persistent FiftyOne datasets.
 
 .. code-block:: shell
 
-    # Load the specified split(s) of the zoo dataset
+    # Load a remotely-sourced zoo dataset
+    fiftyone zoo datasets load https://github.com/<user>/<repo>
+    fiftyone zoo datasets load <url>
+
+.. code-block:: shell
+
+    # Load the specified split(s) of a zoo dataset
     fiftyone zoo datasets load <name> --splits <split1> ...
 
 .. code-block:: shell
 
-    # Load the zoo dataset with a custom name
+    # Load a zoo dataset with a custom name
     fiftyone zoo datasets load <name> --dataset-name <dataset-name>
-
-.. code-block:: shell
-
-    # Load the zoo dataset from a custom directory
-    fiftyone zoo datasets load <name> --dataset-dir <dataset-dir>
 
 .. code-block:: shell
 

--- a/docs/source/cli/index.rst
+++ b/docs/source/cli/index.rst
@@ -2231,12 +2231,13 @@ Tools for working with the FiftyOne Dataset Zoo.
       --all-help            show help recursively and exit
 
     available commands:
-      {list,find,info,download,load}
+      {list,find,info,download,load,delete}
         list                List datasets in the FiftyOne Dataset Zoo.
-        find                Locate the downloaded zoo dataset on disk.
-        info                Print information about downloaded zoo datasets.
+        find                Locate a downloaded zoo dataset on disk.
+        info                Print information about datasets in the FiftyOne Dataset Zoo.
         download            Download zoo datasets.
         load                Load zoo datasets as persistent FiftyOne datasets.
+        delete              Deletes the local copy of the zoo dataset on disk.
 
 .. _cli-fiftyone-zoo-datasets-list:
 
@@ -2321,8 +2322,8 @@ Locate a downloaded zoo dataset on disk.
 .. code-block:: shell
 
     # Print the location of a remotely-sourced zoo dataset on disk
-    fiftyone zoo datasets info https://github.com/<user>/<repo>
-    fiftyone zoo datasets info <url>
+    fiftyone zoo datasets find https://github.com/<user>/<repo>
+    fiftyone zoo datasets find <url>
 
 .. code-block:: shell
 

--- a/docs/source/plugins/developing_plugins.rst
+++ b/docs/source/plugins/developing_plugins.rst
@@ -193,17 +193,37 @@ used to define the plugin's metadata, declare any operators and panels that it
 exposes, and declare any :ref:`secrets <plugins-secrets>` that it may require.
 The following fields are available:
 
--   `name` **(required)**: the name of the plugin
--   `author`: the author of the plugin
--   `version`: the version of the plugin
--   `url`: the page (eg GitHub repository) where the plugin's code lives
--   `license`: the license under which the plugin is distributed
--   `description`: a brief description of the plugin
--   `fiftyone.version`: a semver version specifier (or `*`) describing the
-    required FiftyOne version for the plugin to work properly
--   `operators`: a list of operator names registered by the plugin
--   `panels`: a list of panel names registred by the plugin
--   `secrets`: a list of secret keys that may be used by the plugin
+.. table::
+    :widths: 20,10,70
+
+    +------------------------------+-----------+-----------------------------------------------------------------------------+
+    | Field                        | Required? | Description                                                                 |
+    +==============================+===========+=============================================================================+
+    | `name`                       | **yes**   | The name of the plugin                                                      |
+    +------------------------------+-----------+-----------------------------------------------------------------------------+
+    | `type`                       |           | Declare that the directory defines a `plugin`. This can be omitted for      |
+    |                              |           | backwards compatibility, but it is recommended to specify this              |
+    +------------------------------+-----------+-----------------------------------------------------------------------------+
+    | `author`                     |           | The author of the plugin                                                    |
+    +------------------------------+-----------+-----------------------------------------------------------------------------+
+    | `version`                    |           | The version of the plugin                                                   |
+    +------------------------------+-----------+-----------------------------------------------------------------------------+
+    | `url`                        |           | The remote source (eg GitHub repository) where the directory containing     |
+    |                              |           | this file is hosted                                                         |
+    +------------------------------+-----------+-----------------------------------------------------------------------------+
+    | `license`                    |           | The license under which the plugin is distributed                           |
+    +------------------------------+-----------+-----------------------------------------------------------------------------+
+    | `description`                |           | A brief description of the plugin                                           |
+    +------------------------------+-----------+-----------------------------------------------------------------------------+
+    | `fiftyone.version`           |           | A semver version specifier (or `*`) describing the required                 |
+    |                              |           | FiftyOne version for the plugin to work properly                            |
+    +------------------------------+-----------+-----------------------------------------------------------------------------+
+    | `operators`                  |           | A list of operator names registered by the plugin, if any                   |
+    +------------------------------+-----------+-----------------------------------------------------------------------------+
+    | `panels`                     |           | A list of panel names registred by the plugin, if any                       |
+    +------------------------------+-----------+-----------------------------------------------------------------------------+
+    | `secrets`                    |           | A list of secret keys that may be used by the plugin, if any                |
+    +------------------------------+-----------+-----------------------------------------------------------------------------+
 
 For example, the
 `@voxel51/annotation <https://github.com/voxel51/fiftyone-plugins/blob/main/plugins/annotation/fiftyone.yml>`_
@@ -213,12 +233,14 @@ plugin's `fiftyone.yml` looks like this:
     :linenos:
 
     name: "@voxel51/annotation"
-    description: Utilities for integrating FiftyOne with annotation tools
+    type: plugin
+    author: Voxel51
     version: 1.0.0
-    fiftyone:
-      version: ">=0.22"
     url: https://github.com/voxel51/fiftyone-plugins/tree/main/plugins/annotation
     license: Apache 2.0
+    description: Utilities for integrating FiftyOne with annotation tools
+    fiftyone:
+      version: ">=0.22"
     operators:
       - request_annotations
       - load_annotations
@@ -331,12 +353,14 @@ defines both a JS Panel and a Python operator:
         :linenos:
 
         name: "@voxel51/hello-world"
-        description: An example of JS and Python components in a single plugin
+        type: plugin
+        author: Voxel51
         version: 1.0.0
-        fiftyone:
-          version: "*"
         url: https://github.com/voxel51/fiftyone-plugins/blob/main/plugins/hello-world/README.md
         license: Apache 2.0
+        description: An example of JS and Python components in a single plugin
+        fiftyone:
+          version: "*"
         operators:
           - count_samples
           - show_alert

--- a/docs/source/user_guide/dataset_zoo/api.rst
+++ b/docs/source/user_guide/dataset_zoo/api.rst
@@ -11,9 +11,7 @@ You can interact with the Dataset Zoo either via the Python library or the CLI:
 
   .. group-tab:: Python
 
-    The Dataset Zoo is accessible via the :mod:`fiftyone.zoo.datasets` package,
-    whose public methods are imported into the ``fiftyone.zoo`` namespace, for
-    convenience.
+    The Dataset Zoo is accessible via the :mod:`fiftyone.zoo` package.
 
   .. group-tab:: CLI
 

--- a/docs/source/user_guide/dataset_zoo/api.rst
+++ b/docs/source/user_guide/dataset_zoo/api.rst
@@ -1,19 +1,11 @@
 .. _dataset-zoo-api:
 
-Dataset Zoo API Reference
-=========================
+Dataset Zoo API
+===============
 
 .. default-role:: code
 
-This page describes the full API for working with the Dataset Zoo.
-
-.. _dataset-zoo-package:
-
-Dataset zoo package
--------------------
-
-You can interact with the Dataset Zoo either via the Python library or
-the CLI.
+You can interact with the Dataset Zoo either via the Python library or the CLI:
 
 .. tabs::
 
@@ -550,8 +542,8 @@ Deleting zoo datasets
 Adding datasets to the zoo
 --------------------------
 
-We frequently add new datasets to the Dataset Zoo, which will automatically
-become accessible to you when you update your FiftyOne package.
+We frequently add new built-in datasets to the Dataset Zoo, which will
+automatically become accessible to you when you update your FiftyOne package.
 
 .. note::
 

--- a/docs/source/user_guide/dataset_zoo/datasets.rst
+++ b/docs/source/user_guide/dataset_zoo/datasets.rst
@@ -1,16 +1,26 @@
 .. _dataset-zoo-datasets:
 
-Available Zoo Datasets
-======================
+Built-In Zoo Datasets
+=====================
 
 .. default-role:: code
 
-This page lists all of the datasets available in the Dataset Zoo.
+This page lists all of all natively available datasets in the FiftyOne Dataset
+Zoo.
+
+Check out the :ref:`API reference <dataset-zoo-api>` for complete instructions
+for using the Dataset Zoo.
 
 .. note::
 
-    Check out the :ref:`API reference <dataset-zoo-api>` for complete
-    instructions for using the Dataset Zoo.
+    Some datasets are loaded via the
+    `TorchVision Datasets <https://pytorch.org/vision/stable/datasets.html>`_
+    or `TensorFlow Datasets <https://www.tensorflow.org/datasets>`_ packages
+    under the hood.
+
+    If you do not have a :ref:`suitable package <dataset-zoo-ml-backend>`
+    installed when attempting to download a zoo dataset, you'll see an error
+    message that will help you install one.
 
 .. table::
     :widths: 40 60

--- a/docs/source/user_guide/dataset_zoo/datasets.rst
+++ b/docs/source/user_guide/dataset_zoo/datasets.rst
@@ -5,7 +5,7 @@ Built-In Zoo Datasets
 
 .. default-role:: code
 
-This page lists all of all natively available datasets in the FiftyOne Dataset
+This page lists all of the natively available datasets in the FiftyOne Dataset
 Zoo.
 
 Check out the :ref:`API reference <dataset-zoo-api>` for complete instructions

--- a/docs/source/user_guide/dataset_zoo/index.rst
+++ b/docs/source/user_guide/dataset_zoo/index.rst
@@ -8,7 +8,7 @@ FiftyOne Dataset Zoo
 The FiftyOne Dataset Zoo provides a powerful interface for downloading datasets
 and loading them into FiftyOne.
 
-It provides native access to dozens of popular benchmark datasets, and it even
+It provides native access to dozens of popular benchmark datasets, and it also
 supports downloading arbitrary public or private datasets whose
 download/preparation methods are provided via GitHub.
 
@@ -16,8 +16,7 @@ Built-in datasets
 -----------------
 
 The Dataset Zoo provides built-in access to dozens of datasets that you can
-load into FiftyOne with a single command. Click the link below to see all of
-the datasets in the zoo!
+load into FiftyOne with a single command.
 
 .. custombutton::
     :button_text: Explore the datasets in the zoo
@@ -27,7 +26,7 @@ Remotely-sourced datasets
 -------------------------
 
 The Dataset Zoo also supports loading datasets whose download/preparation
-methods are provided via GitHub repositories or URLs!
+methods are provided via GitHub repositories or URLs.
 
 .. custombutton::
     :button_text: Learn how to download remote datasets

--- a/docs/source/user_guide/dataset_zoo/index.rst
+++ b/docs/source/user_guide/dataset_zoo/index.rst
@@ -5,32 +5,33 @@ FiftyOne Dataset Zoo
 
 .. default-role:: code
 
-FiftyOne provides a Dataset Zoo that contains a collection of common datasets
-that you can download and load into FiftyOne via a few simple commands.
+The FiftyOne Dataset Zoo provides a powerful interface for downloading datasets
+and loading them into FiftyOne.
 
-.. note::
+It provides native access to dozens of popular benchmark datasets, and it even
+supports downloading arbitrary public or private datasets whose
+download/preparation methods are provided via GitHub.
 
-    For some datasets, FiftyOne's Dataset Zoo uses the
-    `TorchVision Datasets <https://pytorch.org/vision/stable/datasets.html>`_ or
-    `TensorFlow Datasets <https://www.tensorflow.org/datasets>`_, depending on
-    which ML library you have installed.
+Built-in datasets
+-----------------
 
-    If you do not have the proper packages installed when attempting to
-    download a zoo dataset, you will receive an error message that will help
-    you resolve the issue. See
-    :ref:`customizing your ML backend <dataset-zoo-ml-backend>` for more
-    information about configuring the backend behavior of the Dataset Zoo.
-
-Available datasets
-------------------
-
-The Dataset Zoo contains dozens of datasets that you can load into FiftyOne
-with a few simple commands. Click the link below to see all of the datasets in
-the zoo!
+The Dataset Zoo provides built-in access to dozens of datasets that you can
+load into FiftyOne with a single command. Click the link below to see all of
+the datasets in the zoo!
 
 .. custombutton::
     :button_text: Explore the datasets in the zoo
     :button_link: datasets.html
+
+Remotely-sourced datasets
+-------------------------
+
+The Dataset Zoo also supports loading datasets whose download/preparation
+methods are provided via GitHub repositories or URLs!
+
+.. custombutton::
+    :button_text: Learn how to download remote datasets
+    :button_link: remote.html
 
 API reference
 -------------
@@ -71,19 +72,14 @@ visualizing it in the App is shown below.
         # List available zoo datasets
         print(foz.list_zoo_datasets())
 
-        #
-        # Load the COCO-2017 validation split into a FiftyOne dataset
-        #
-        # This will download the dataset from the web, if necessary
-        #
+        # Download the COCO-2017 validation split and load it into FiftyOne
         dataset = foz.load_zoo_dataset("coco-2017", split="validation")
 
-        # Give the dataset a new name, and make it persistent so that you can
-        # work with it in future sessions
+        # Give the dataset a new name, and make it persistent
         dataset.name = "coco-2017-validation-example"
         dataset.persistent = True
 
-        # Visualize the in the App
+        # Visualize it in the App
         session = fo.launch_app(dataset)
 
   .. group-tab:: CLI
@@ -97,16 +93,14 @@ visualizing it in the App is shown below.
 
     .. code-block:: shell
 
-        #
-        # Load the COCO-2017 validation split into a FiftyOne dataset called
-        # `coco-2017-validation-example`
-        #
-        # This will download the dataset from the web, if necessary
-        #
+        # List available zoo datasets
+        fiftyone zoo datasets list
+
+        # Download the COCO-2017 validation split and load it into FiftyOne
         fiftyone zoo datasets load coco-2017 --split validation \
             --dataset-name coco-2017-validation-example
 
-        # Visualize the dataset in the App
+        # Visualize it in the App
         fiftyone app launch coco-2017-validation-example
 
 .. image:: /images/dataset_zoo_coco_2017.png
@@ -117,5 +111,6 @@ visualizing it in the App is shown below.
    :maxdepth: 1
    :hidden:
 
+   Built-in datasets <datasets>
+   Remote datasets <remote>
    API reference <api>
-   Available datasets <datasets>

--- a/docs/source/user_guide/dataset_zoo/index.rst
+++ b/docs/source/user_guide/dataset_zoo/index.rst
@@ -10,7 +10,7 @@ and loading them into FiftyOne.
 
 It provides native access to dozens of popular benchmark datasets, and it also
 supports downloading arbitrary public or private datasets whose
-download/preparation methods are provided via GitHub.
+download/preparation methods are provided via GitHub repositories or URLs.
 
 Built-in datasets
 -----------------
@@ -35,7 +35,7 @@ methods are provided via GitHub repositories or URLs.
 API reference
 -------------
 
-The Dataset Zoo can be accessed via Python library and the CLI. Consult the
+The Dataset Zoo can be accessed via the Python library and the CLI. Consult the
 API reference below to see how to download, load, and manage zoo datasets.
 
 .. custombutton::

--- a/docs/source/user_guide/dataset_zoo/remote.rst
+++ b/docs/source/user_guide/dataset_zoo/remote.rst
@@ -1,0 +1,443 @@
+.. _dataset-zoo-remote:
+
+Remotely-Sourced Zoo Datasets
+=============================
+
+.. default-role:: code
+
+This page describes how to work with and create zoo datasets whose
+download/preparation methods are hosted via GitHub repositories or public URLs.
+
+.. note::
+
+    To download from a private GitHub repository that you have access to,
+    provide your GitHub personal access token by setting the ``GITHUB_TOKEN``
+    environment variable.
+
+.. _dataset-zoo-remote-usage:
+
+Working with remotely-sourced datasets
+--------------------------------------
+
+Working with remotely-sourced zoo datasets is just like
+:ref:`built-in zoo datasets <dataset-zoo-datasets>`, as both varieties support
+the :ref:`full zoo API <dataset-zoo-api>`.
+
+When specifying remote sources, you can provide any of the following:
+
+-   A GitHub repo URL like ``https://github.com/<user>/<repo>``
+-   A GitHub ref like ``https://github.com/<user>/<repo>/tree/<branch>`` or
+    ``https://github.com/<user>/<repo>/commit/<commit>``
+-   A GitHub ref string like ``<user>/<repo>[/<ref>]``
+-   A publicly accessible URL of an archive (eg zip or tar) file
+
+Here's the basic recipe for working with remotely-sourced zoo datasets:
+
+.. tabs::
+
+  .. group-tab:: Python
+
+    Use :meth:`load_zoo_dataset() <fiftyone.zoo.datasets.load_zoo_dataset>` to
+    download and load a remotely-sourced zoo dataset into a FiftyOne dataset:
+
+    .. code-block:: python
+        :linenos:
+
+        import fiftyone as fo
+        import fiftyone.zoo as foz
+
+        dataset = foz.load_zoo_dataset(
+            "https://github.com/voxel51/coco-2017",
+            split="validation",
+        )
+
+        session = fo.launch_app(dataset)
+
+    Once you've downloaded all or part of a remotely-sourced zoo dataset, it
+    will subsequently appear as an available zoo dataset under the name in the
+    dataset's :ref:`YAML file <dataset-zoo-remote-publishing>` when you call
+    :meth:`list_zoo_datasets() <fiftyone.zoo.datasets.list_zoo_datasets>`:
+
+    .. code-block:: python
+        :linenos:
+
+        available_datasets = foz.list_zoo_datasets()
+
+        print(available_datasets)
+        # [..., "voxel51/coco-2017", ...]
+
+    You can also download a remotely-sourced zoo dataset without (yet) loading
+    it into a FiftyOne dataset by calling
+    :meth:`download_zoo_dataset() <fiftyone.zoo.datasets.download_zoo_dataset>`:
+
+    .. code-block:: python
+        :linenos:
+
+        dataset = foz.download_zoo_dataset(
+            "https://github.com/voxel51/coco-2017",
+            split="validation",
+        )
+
+    You can delete the local copy of a remotely-sourced zoo dataset (or
+    individual split(s) of it) via
+    :meth:`delete_zoo_dataset() <fiftyone.zoo.datasets.delete_zoo_dataset>`
+    by providing either the datasets's name or the remote source from which
+    you downloaded it:
+
+    .. code-block:: python
+        :linenos:
+
+        # These are equivalent
+        foz.delete_zoo_dataset("voxel51/coco-2017", split="validation")
+        foz.delete_zoo_dataset(
+            "https://github.com/voxel51/coco-2017", split="validation"
+        )
+
+        # These are equivalent
+        foz.delete_zoo_dataset("voxel51/coco-2017")
+        foz.delete_zoo_dataset("https://github.com/voxel51/coco-2017")
+
+  .. group-tab:: CLI
+
+    Use :ref:`fiftyone zoo datasets load <cli-fiftyone-zoo-datasets-load>` to
+    load a remotely-sourced zoo dataset into a FiftyOne dataset:
+
+    .. code-block:: shell
+
+        fiftyone zoo datasets load \
+            https://github.com/voxel51/coco-2017 \
+            --split validation \
+            --dataset-name 'voxel51/coco-2017-validation'
+
+        fiftyone app launch 'voxel51/coco-2017-validation'
+
+    Once you've downloaded all or part of a remotely-sourced zoo dataset, it
+    will subsequently appear as an available zoo dataset under the name in the
+    dataset's :ref:`YAML file <dataset-zoo-remote-publishing>` when you call
+    :ref:`fiftyone zoo datasets list <cli-fiftyone-zoo-datasets-list>`:
+
+    .. code-block:: shell
+
+        fiftyone zoo datasets list
+
+        # contains row(s) for a dataset 'voxel51/coco-2017'
+
+    You can also download a remotely-sourced zoo dataset without (yet) loading
+    it into a FiftyOne dataset by calling
+    :ref:`fiftyone zoo datasets download <cli-fiftyone-zoo-datasets-download>`:
+
+    .. code-block:: shell
+
+        fiftyone zoo datasets download \
+            https://github.com/voxel51/coco-2017 \
+            --split validation
+
+    You can delete the local copy of a remotely-sourced zoo dataset (or
+    individual split(s) of it) via
+    :ref:`fiftyone zoo datasets delete <cli-fiftyone-zoo-datasets-delete>`
+    by providing either the datasets's name or the remote source from which
+    you downloaded it:
+
+    .. code-block:: shell
+
+        # These are equivalent
+        fiftyone zoo datasets delete voxel51/coco-2017 --split validation
+        fiftyone zoo datasets delete \
+            https://github.com/voxel51/coco-2017 --split validation
+
+        # These are equivalent
+        fiftyone zoo datasets delete voxel51/coco-2017
+        fiftyone zoo datasets delete https://github.com/voxel51/coco-2017
+
+.. _dataset-zoo-remote-creation:
+
+Creating remotely-sourced datasets
+----------------------------------
+
+A remotely-sourced dataset is defined by a directory with the following
+contents:
+
+.. code-block:: text
+
+    fiftyone.yml
+    __init__.py
+        def download_and_prepare(dataset_dir, split=None, **kwargs):
+            pass
+
+        def load_dataset(dataset, dataset_dir, split=None, **kwargs):
+            pass
+
+Each component is described in detail below.
+
+.. note::
+
+    By convention, many datasets also contain an optional `README.md` file that
+    provides additional information about the dataset and example syntaxes for
+    downloading and working with it.
+
+.. _zoo-dataset-remote-fiftyone-yml:
+
+fiftyone.yml
+~~~~~~~~~~~~
+
+The dataset's `fiftyone.yml` or `fiftyone.yaml` file defines relevant metadata
+about the dataset:
+
+.. table::
+    :widths: 20,10,70
+
+    +------------------------------+-----------+-----------------------------------------------------------------------------+
+    | Field                        | Required? | Description                                                                 |
+    +==============================+===========+=============================================================================+
+    | `name`                       | **yes**   | The name of the dataset. Once you've downloaded all or part of a            |
+    |                              |           | remotely-sourced zoo dataset, it will subsequently appear as an available   |
+    |                              |           | zoo dataset under this name when using the                                  |
+    |                              |           | :ref:`zoo API <dataset-zoo-api>`                                            |
+    +------------------------------+-----------+-----------------------------------------------------------------------------+
+    | `type`                       |           | Declare that the directory defines a `dataset`. This can be omitted for     |
+    |                              |           | backwards compatibility, but it is recommended to specify this              |
+    +------------------------------+-----------+-----------------------------------------------------------------------------+
+    | `author`                     |           | The author of the dataset                                                   |
+    +------------------------------+-----------+-----------------------------------------------------------------------------+
+    | `version`                    |           | The version of the dataset                                                  |
+    +------------------------------+-----------+-----------------------------------------------------------------------------+
+    | `url`                        |           | The source (eg GitHub repository) where the directory containing this file  |
+    |                              |           | is hosted                                                                   |
+    +------------------------------+-----------+-----------------------------------------------------------------------------+
+    | `source`                     |           | The original source of the dataset                                          |
+    +------------------------------+-----------+-----------------------------------------------------------------------------+
+    | `license`                    |           | The license under which the dataset is distributed                          |
+    +------------------------------+-----------+-----------------------------------------------------------------------------+
+    | `description`                |           | A brief description of the dataset                                          |
+    +------------------------------+-----------+-----------------------------------------------------------------------------+
+    | `fiftyone.version`           |           | A semver version specifier (or `*`) describing the required                 |
+    |                              |           | FiftyOne version for the dataset to load properly                           |
+    +------------------------------+-----------+-----------------------------------------------------------------------------+
+    | `supports_partial_downloads` |           | Specify `true` or `false` whether parts of the dataset can be               |
+    |                              |           | downloaded/loaded by providing `kwargs` to                                  |
+    |                              |           | :meth:`download_zoo_dataset() <fiftyone.zoo.datasets.download_zoo_dataset>` |
+    |                              |           | or :meth:`load_zoo_dataset() <fiftyone.zoo.datasets.load_zoo_dataset>` as   |
+    |                              |           | described below. If omitted, this is assumed to be `false`                  |
+    +------------------------------+-----------+-----------------------------------------------------------------------------+
+    | `tags`                       |           | A list of tags for the dataset. Useful in conjunction with                  |
+    |                              |           | :meth:`list_zoo_datasets() <fiftyone.zoo.datasets.list_zoo_datasets>`       |
+    +------------------------------+-----------+-----------------------------------------------------------------------------+
+    | `splits`                     |           | A list of the dataset's splits. This should be omitted if the dataset does  |
+    |                              |           | not contain splits                                                          |
+    +------------------------------+-----------+-----------------------------------------------------------------------------+
+    | `size_samples`               |           | The totaal number of samples in the dataset, or a list of per-split sizes   |
+    +------------------------------+-----------+-----------------------------------------------------------------------------+
+
+Here are two example dataset YAML files:
+
+.. tabs::
+
+  .. group-tab:: Dataset with splits
+
+    .. code-block:: yaml
+        :linenos:
+
+        name: voxel51/coco-2017
+        type: dataset
+        author: The COCO Consortium
+        version: 1.0.0
+        url: https://github.com/voxel51/coco-2017
+        source: http://cocodataset.org/#home
+        license: https://cocodataset.org/#termsofuse
+        description: The COCO-2017 dataset
+        fiftyone:
+          version: "*"
+        supports_partial_downloads: true
+        tags:
+         - image
+         - detection
+         - segmentation
+        splits:
+         - train
+         - validation
+         - test
+        size_samples:
+         - train: 118287
+         - test: 40670
+         - validation: 5000
+
+  .. group-tab:: Dataset without splits
+
+    .. code-block:: yaml
+        :linenos:
+
+        name: voxel51/dr-wright-drives
+        type: dataset
+        description: The Dr Wright Drives dataset
+        version: 1.0.0
+        fiftyone:
+          version: ">=0.25"
+        url: https://github.com/voxel51/dr-wright-drives
+        supports_partial_downloads: false
+        tags:
+         - video
+         - automotive
+        size_samples: 1500
+
+Download and prepare
+~~~~~~~~~~~~~~~~~~~~
+
+All dataset's ``__init__.py`` files must define a ``download_and_prepare()``
+method with the signature below:
+
+.. code-block:: python
+    :linenos:
+
+    def download_and_prepare(dataset_dir, split=None, **kwargs):
+        """Downloads the dataset and prepares it for loading into FiftyOne.
+
+        Args:
+            dataset_dir: the directory in which to construct the dataset
+            split (None): a specific split to download, if the dataset supports
+                splits. The supported split values are defined by the dataset's
+                YAML file
+            **kwargs: optional keyword arguments that your dataset can define to
+                configure what/how the download is performed
+
+        Returns:
+            a tuple of
+
+            -   ``dataset_type``: a ``fiftyone.types.Dataset`` type that the
+                dataset is stored in locally, or None if the dataset provides
+                its own ``load_dataset()`` method
+            -   ``num_samples``: the total number of downloaded samples for the
+                dataset or split
+            -   ``classes``: a list of classes in the dataset, or None if not
+                applicable
+        """
+
+        # Download files and organize them in `dataset_dir`
+        ...
+
+        # Define how the data is stored
+        dataset_type = fo.types.ImageClassificationDirectoryTree
+        dataset_type = None  # custom ``load_dataset()`` method
+
+        # Indicate how many samples have been downloaded
+        # May be less than the total size if partial downloads have been used
+        num_samples = 10000
+
+        # Optionally report what classes exist in the dataset
+        classes = None
+        classes = ["cat", "dog", ...]
+
+        return dataset_type, num_samples, classes
+
+This method is called under-the-hood when a user calls
+:meth:`download_zoo_dataset() <fiftyone.zoo.datasets.download_zoo_dataset>` or
+:meth:`load_zoo_dataset() <fiftyone.zoo.datasets.load_zoo_dataset>`, and its
+job is to download any relevant files from the web and organize and/or prepare
+them as necessary into a format that's ready to be loaded into a FiftyOne
+dataset.
+
+The ``dataset_type`` that ``download_and_prepare()`` returns defines how it the
+dataset is ultimately loaded into FiftyOne:
+
+-   **Built-in importer**: in many cases, FiftyOne already contains a
+    :ref:`built-in importer <supported-import-formats>` that can be leveraged
+    to load data on disk into FiftyOne. Remotely-sourced datasets can take
+    advantage of this by simply returning the appropriate ``dataset_type`` from
+    ``download_and_prepare()``, which is then used to load the data into
+    FiftyOne as follows:
+
+.. code-block:: python
+    :linenos:
+
+    # If the dataset has splits, `dataset_dir` will be the split directory
+    dataset_importer_cls = dataset_type.get_dataset_importer_cls()
+    dataset_importer = dataset_importer_cls(dataset_dir=dataset_dir, **kwargs)
+
+    dataset.add_importer(dataset_importer, **kwargs)
+
+-   **Custom loader**: if ``dataset_type=None`` is returned, then
+    ``__init__.py`` must also contain a ``load_dataset()`` method as described
+    below that handles loading the data into FiftyOne as follows:
+
+.. code-block:: python
+    :linenos:
+
+    load_dataset(dataset, dataset_dir, **kwargs)
+
+Load dataset
+~~~~~~~~~~~~
+
+Datasets that don't use a built-in importer must also define a
+``load_dataset()`` method in their ``__init__.py`` with the signature below:
+
+.. code-block:: python
+    :linenos:
+
+    def load_dataset(dataset, dataset_dir, split=None, **kwargs):
+        """Loads the dataset into the given FiftyOne dataset.
+
+        Args:
+            dataset: a :class:`fiftyone.core.dataset.Dataset` to which to import
+            dataset_dir: the directory to which the dataset was downloaded
+            split (None): a split to load. The supported values are
+                ``("train", "validation", "test")``
+            **kwargs: optional keyword arguments that your dataset can define to
+                configure what/how the download is performed
+        """
+
+        # Load data into samples
+        samples = [...]
+
+        # Add samples to the dataset
+        dataset.add_samples(samples)
+
+This method's job is to load the filepaths and any relevant labels into
+|Sample| objects and then call
+:meth:`add_samples() <fiftyone.core.dataset.Dataset.add_samples>` or a similar
+method to add them to the provided |Dataset|.
+
+.. _dataset-zoo-remote-partial-downloads:
+
+Partial downloads
+-----------------
+
+Remotely-sourced datasets can support partial downloads, which is useful for a
+variety of reasons, including:
+
+-   A dataset may contain labels for multiple task types but the user is only
+    interested in a subset of them
+-   The dataset may be very large and the user only wants to download a small
+    subset of the samples to get familiar with the dataset
+
+Datasets that support partial downloads should declare this in their dataset
+YAML file:
+
+.. code-block:: yaml
+
+    supports_partial_downloads: true
+
+The partial download behavior itself is defined via ``**kwargs`` in the
+dataset's ``__init__.py`` methods:
+
+.. code-block:: python
+    :linenos:
+
+    def download_and_prepare(dataset_dir, split=None, **kwargs):
+        pass
+
+    def load_dataset(dataset, dataset_dir, split=None, **kwargs):
+        pass
+
+When
+:meth:`download_zoo_dataset(url, ..., **kwargs) <fiftyone.zoo.datasets.download_zoo_dataset>`
+is called, any `kwargs` declared by ``download_and_prepare()`` are passed
+through to it.
+
+When
+:meth:`load_zoo_dataset(name_or_url, ..., **kwargs) <fiftyone.zoo.datasets.load_zoo_dataset>`
+is called, any `kwargs` declared by ``download_and_prepare()`` and
+``load_dataset()`` are passed through to them, respectively.
+
+.. note::
+
+    Check out `this repository <https://github.com/voxel51/coco-2017>`_ for an
+    example of a remotely-sourced dataset that supports partial downloads.

--- a/docs/source/user_guide/dataset_zoo/remote.rst
+++ b/docs/source/user_guide/dataset_zoo/remote.rst
@@ -266,18 +266,21 @@ Here are two example dataset YAML files:
     .. code-block:: yaml
         :linenos:
 
-        name: voxel51/dr-wright-drives
+        name: voxel51/caltech101
         type: dataset
-        description: The Dr Wright Drives dataset
+        author: Fei-Fei1 Li, Marco Andreeto, Marc'Aurelio Ranzato, Pietro Perona
         version: 1.0.0
+        url: https://github.com/voxel51/caltech101
+        source: https://data.caltech.edu/records/mzrjq-6wc02
+        license: Creative Commons Attribution 4.0 International
+        description: The Caltech 101 dataset
         fiftyone:
-          version: ">=0.25"
-        url: https://github.com/voxel51/dr-wright-drives
+          version: "*"
         supports_partial_downloads: false
         tags:
-         - video
-         - automotive
-        size_samples: 1500
+         - image
+         - classification
+        size_samples: 9145
 
 Download and prepare
 ~~~~~~~~~~~~~~~~~~~~
@@ -439,5 +442,5 @@ is called, any `kwargs` declared by ``download_and_prepare()`` and
 
 .. note::
 
-    Check out `this repository <https://github.com/voxel51/coco-2017>`_ for an
-    example of a remotely-sourced dataset that supports partial downloads.
+    Check out `voxel51/coco-2017 <https://github.com/voxel51/coco-2017>`_ for
+    an example of a remotely-sourced dataset that supports partial downloads.

--- a/docs/source/user_guide/dataset_zoo/remote.rst
+++ b/docs/source/user_guide/dataset_zoo/remote.rst
@@ -385,7 +385,7 @@ Datasets that don't use a built-in importer must also define a
             split (None): a split to load. The supported values are
                 ``("train", "validation", "test")``
             **kwargs: optional keyword arguments that your dataset can define to
-                configure what/how the download is performed
+                configure what/how the load is performed
         """
 
         # Load data into samples

--- a/docs/source/user_guide/dataset_zoo/remote.rst
+++ b/docs/source/user_guide/dataset_zoo/remote.rst
@@ -55,8 +55,8 @@ Here's the basic recipe for working with remotely-sourced zoo datasets:
 
     Once you've downloaded all or part of a remotely-sourced zoo dataset, it
     will subsequently appear as an available zoo dataset under the name in the
-    dataset's :ref:`YAML file <dataset-zoo-remote-publishing>` when you call
-    :meth:`list_zoo_datasets() <fiftyone.zoo.datasets.list_zoo_datasets>`:
+    dataset's :ref:`fiftyone.yml <zoo-dataset-remote-fiftyone-yml>` when you
+    call :meth:`list_zoo_datasets() <fiftyone.zoo.datasets.list_zoo_datasets>`:
 
     .. code-block:: python
         :linenos:
@@ -113,8 +113,8 @@ Here's the basic recipe for working with remotely-sourced zoo datasets:
 
     Once you've downloaded all or part of a remotely-sourced zoo dataset, it
     will subsequently appear as an available zoo dataset under the name in the
-    dataset's :ref:`YAML file <dataset-zoo-remote-publishing>` when you call
-    :ref:`fiftyone zoo datasets list <cli-fiftyone-zoo-datasets-list>`:
+    dataset's :ref:`fiftyone.yml <zoo-dataset-remote-fiftyone-yml>` when you
+    call :ref:`fiftyone zoo datasets list <cli-fiftyone-zoo-datasets-list>`:
 
     .. code-block:: shell
 
@@ -171,7 +171,7 @@ Each component is described in detail below.
 
 .. note::
 
-    By convention, many datasets also contain an optional `README.md` file that
+    By convention, datasets also contain an optional `README.md` file that
     provides additional information about the dataset and example syntaxes for
     downloading and working with it.
 
@@ -217,13 +217,14 @@ about the dataset:
     |                              |           | downloaded/loaded by providing `kwargs` to                                  |
     |                              |           | :meth:`download_zoo_dataset() <fiftyone.zoo.datasets.download_zoo_dataset>` |
     |                              |           | or :meth:`load_zoo_dataset() <fiftyone.zoo.datasets.load_zoo_dataset>` as   |
-    |                              |           | described below. If omitted, this is assumed to be `false`                  |
+    |                              |           | :ref:`described here <dataset-zoo-remote-partial-downloads>`. If omitted,   |
+    |                              |           | this is assumed to be `false`                                               |
     +------------------------------+-----------+-----------------------------------------------------------------------------+
     | `tags`                       |           | A list of tags for the dataset. Useful in conjunction with                  |
     |                              |           | :meth:`list_zoo_datasets() <fiftyone.zoo.datasets.list_zoo_datasets>`       |
     +------------------------------+-----------+-----------------------------------------------------------------------------+
-    | `splits`                     |           | A list of the dataset's splits. This should be omitted if the dataset does  |
-    |                              |           | not contain splits                                                          |
+    | `splits`                     |           | A list of the dataset's supported splits. This should be omitted if the     |
+    |                              |           | dataset does not contain splits                                             |
     +------------------------------+-----------+-----------------------------------------------------------------------------+
     | `size_samples`               |           | The totaal number of samples in the dataset, or a list of per-split sizes   |
     +------------------------------+-----------+-----------------------------------------------------------------------------+
@@ -411,8 +412,8 @@ variety of reasons, including:
 -   The dataset may be very large and the user only wants to download a small
     subset of the samples to get familiar with the dataset
 
-Datasets that support partial downloads should declare this in their dataset
-YAML file:
+Datasets that support partial downloads should declare this in their
+:ref:`fiftyone.yml <zoo-dataset-remote-fiftyone-yml>`:
 
 .. code-block:: yaml
 

--- a/fiftyone/core/cli.py
+++ b/fiftyone/core/cli.py
@@ -1720,7 +1720,7 @@ class DatasetZooListCommand(Command):
         # List available datasets
         fiftyone zoo datasets list
 
-        # List available datasets (names only)
+        # List available dataset names
         fiftyone zoo datasets list --names-only
 
         # List downloaded datasets
@@ -1759,15 +1759,6 @@ class DatasetZooListCommand(Command):
             metavar="TAGS",
             help="only show datasets with the specified tag or list,of,tags",
         )
-        parser.add_argument(
-            "-b",
-            "--base-dir",
-            metavar="BASE_DIR",
-            help=(
-                "a custom base directory in which to search for downloaded "
-                "datasets"
-            ),
-        )
 
     @staticmethod
     def execute(parser, args):
@@ -1776,13 +1767,8 @@ class DatasetZooListCommand(Command):
         match_source = args.source
         match_tags = args.tags
 
-        all_datasets = fozd._get_zoo_datasets()
-        all_sources, default_source = fozd._get_zoo_dataset_sources()
-
-        base_dir = args.base_dir
-        downloaded_datasets = fozd.list_downloaded_zoo_datasets(
-            base_dir=base_dir
-        )
+        downloaded_datasets = fozd.list_downloaded_zoo_datasets()
+        all_datasets, all_sources, default_source = fozd._get_zoo_datasets()
 
         _print_zoo_dataset_list(
             downloaded_datasets,
@@ -1811,8 +1797,8 @@ def _print_zoo_dataset_list(
 
     available_datasets = defaultdict(dict)
     for source, datasets in all_datasets.items():
-        for name, zoo_dataset_cls in datasets.items():
-            available_datasets[name][source] = zoo_dataset_cls()
+        for name, zoo_dataset in datasets.items():
+            available_datasets[name][source] = zoo_dataset
 
     records = []
 
@@ -1827,9 +1813,9 @@ def _print_zoo_dataset_list(
             continue
 
         tags = None
-        for source, zoo_model in dataset_sources.items():
+        for source, zoo_dataset in dataset_sources.items():
             if tags is None or source == default_source:
-                tags = zoo_model.tags
+                tags = zoo_dataset.tags
 
         if (match_tags is not None) and (
             tags is None or not all(tag in tags for tag in match_tags)
@@ -1907,21 +1893,27 @@ def _print_zoo_dataset_list(
 
 
 class DatasetZooFindCommand(Command):
-    """Locate the downloaded zoo dataset on disk.
+    """Locate a downloaded zoo dataset on disk.
 
     Examples::
 
-        # Print the location of the downloaded zoo dataset on disk
+        # Print the location of a downloaded zoo dataset on disk
         fiftyone zoo datasets find <name>
 
-        # Print the location of a specific split of the dataset
+        # Print the location of a remotely-sourced zoo dataset on disk
+        fiftyone zoo datasets info https://github.com/<user>/<repo>
+        fiftyone zoo datasets info <url>
+
+        # Print the location of a specific split of a dataset
         fiftyone zoo datasets find <name> --split <split>
     """
 
     @staticmethod
     def setup(parser):
         parser.add_argument(
-            "name", metavar="NAME", help="the name of the dataset"
+            "name_or_url",
+            metavar="NAME_OR_URL",
+            help="the name or remote location of the dataset",
         )
         parser.add_argument(
             "-s",
@@ -1932,10 +1924,10 @@ class DatasetZooFindCommand(Command):
 
     @staticmethod
     def execute(parser, args):
-        name = args.name
+        name_or_url = args.name_or_url
         split = args.split
 
-        dataset_dir = fozd.find_zoo_dataset(name, split=split)
+        dataset_dir = fozd.find_zoo_dataset(name_or_url, split=split)
         print(dataset_dir)
 
 
@@ -1946,39 +1938,43 @@ class DatasetZooInfoCommand(Command):
 
         # Print information about a zoo dataset
         fiftyone zoo datasets info <name>
+
+        # Print information about a remote zoo dataset
+        fiftyone zoo datasets info https://github.com/<user>/<repo>
+        fiftyone zoo datasets info <url>
     """
 
     @staticmethod
     def setup(parser):
         parser.add_argument(
-            "name", metavar="NAME", help="the name of the dataset"
-        )
-        parser.add_argument(
-            "-b",
-            "--base-dir",
-            metavar="BASE_DIR",
-            help=(
-                "a custom base directory in which to search for downloaded "
-                "datasets"
-            ),
+            "name_or_url",
+            metavar="NAME_OR_URL",
+            help="the name or remote location of the dataset",
         )
 
     @staticmethod
     def execute(parser, args):
-        name = args.name
+        name_or_url = args.name_or_url
 
-        # Print dataset info
-        zoo_dataset = fozd.get_zoo_dataset(name)
-        print(
-            "***** Dataset description *****\n%s"
-            % textwrap.dedent("    " + zoo_dataset.__doc__)
-        )
+        zoo_dataset = fozd.get_zoo_dataset(name_or_url)
+        downloaded_datasets = fozd.list_downloaded_zoo_datasets()
 
-        # Check if dataset is downloaded
-        base_dir = args.base_dir
-        downloaded_datasets = fozd.list_downloaded_zoo_datasets(
-            base_dir=base_dir
-        )
+        if zoo_dataset.is_remote:
+            description = zoo_dataset.description
+            if description:
+                print("***** Dataset description *****\n%s\n" % description)
+
+            version = zoo_dataset.version
+            if version:
+                print("***** Dataset version *****\n%s\n" % version)
+
+            url = zoo_dataset.url
+            if url:
+                print("***** Dataset source *****\n%s\n" % url)
+        else:
+            description = textwrap.dedent("    " + zoo_dataset.__doc__)
+            if description:
+                print("***** Dataset description *****\n%s\n" % description)
 
         if zoo_dataset.has_tags:
             print("***** Tags *****")
@@ -1989,10 +1985,10 @@ class DatasetZooInfoCommand(Command):
             print("%s\n" % ", ".join(zoo_dataset.supported_splits))
 
         print("***** Dataset location *****")
-        if name not in downloaded_datasets:
-            print("Dataset '%s' is not downloaded" % name)
+        if zoo_dataset.name not in downloaded_datasets:
+            print("Dataset '%s' is not downloaded" % name_or_url)
         else:
-            dataset_dir, info = downloaded_datasets[name]
+            dataset_dir, info = downloaded_datasets[zoo_dataset.name]
             print(dataset_dir)
             print("\n***** Dataset info *****")
             print(info)
@@ -2001,16 +1997,32 @@ class DatasetZooInfoCommand(Command):
 class DatasetZooDownloadCommand(Command):
     """Download zoo datasets.
 
+    When downloading remotely-sourced zoo datasets, you can provide any of the
+    following formats:
+
+    -   a GitHub repo URL like ``https://github.com/<user>/<repo>``
+    -   a GitHub ref like ``https://github.com/<user>/<repo>/tree/<branch>`` or
+        ``https://github.com/<user>/<repo>/commit/<commit>``
+    -   a GitHub ref string like ``<user>/<repo>[/<ref>]``
+    -   a publicly accessible URL of an archive (eg zip or tar) file
+
+    .. note::
+
+        To download from a private GitHub repository that you have access to,
+        provide your GitHub personal access token by setting the
+        ``GITHUB_TOKEN`` environment variable.
+
     Examples::
 
-        # Download the entire zoo dataset
+        # Download a zoo dataset
         fiftyone zoo datasets download <name>
 
-        # Download the specified split(s) of the zoo dataset
-        fiftyone zoo datasets download <name> --splits <split1> ...
+        # Download a remotely-sourced zoo dataset
+        fiftyone zoo datasets download https://github.com/<user>/<repo>
+        fiftyone zoo datasets download <url>
 
-        # Download the zoo dataset to a custom directory
-        fiftyone zoo datasets download <name> --dataset-dir <dataset-dir>
+        # Download the specified split(s) of a zoo dataset
+        fiftyone zoo datasets download <name> --splits <split1> ...
 
         # Download a zoo dataset that requires extra keyword arguments
         fiftyone zoo datasets download <name> \\
@@ -2020,7 +2032,9 @@ class DatasetZooDownloadCommand(Command):
     @staticmethod
     def setup(parser):
         parser.add_argument(
-            "name", metavar="NAME", help="the name of the dataset"
+            "name_or_url",
+            metavar="NAME_OR_URL",
+            help="the name or remote location of the dataset",
         )
         parser.add_argument(
             "-s",
@@ -2028,12 +2042,6 @@ class DatasetZooDownloadCommand(Command):
             metavar="SPLITS",
             nargs="+",
             help="the dataset splits to download",
-        )
-        parser.add_argument(
-            "-d",
-            "--dataset-dir",
-            metavar="DATASET_DIR",
-            help="a custom directory to which to download the dataset",
         )
         parser.add_argument(
             "-k",
@@ -2049,32 +2057,45 @@ class DatasetZooDownloadCommand(Command):
 
     @staticmethod
     def execute(parser, args):
-        name = args.name
+        name_or_url = args.name_or_url
         splits = args.splits
-        dataset_dir = args.dataset_dir
         kwargs = args.kwargs or {}
 
-        fozd.download_zoo_dataset(
-            name, splits=splits, dataset_dir=dataset_dir, **kwargs
-        )
+        fozd.download_zoo_dataset(name_or_url, splits=splits, **kwargs)
 
 
 class DatasetZooLoadCommand(Command):
     """Load zoo datasets as persistent FiftyOne datasets.
+
+    When loading remotely-sourced zoo datasets, you can provide any of the
+    following formats:
+
+    -   a GitHub repo URL like ``https://github.com/<user>/<repo>``
+    -   a GitHub ref like ``https://github.com/<user>/<repo>/tree/<branch>`` or
+        ``https://github.com/<user>/<repo>/commit/<commit>``
+    -   a GitHub ref string like ``<user>/<repo>[/<ref>]``
+    -   a publicly accessible URL of an archive (eg zip or tar) file
+
+    .. note::
+
+        To download from a private GitHub repository that you have access to,
+        provide your GitHub personal access token by setting the
+        ``GITHUB_TOKEN`` environment variable.
 
     Examples::
 
         # Load the zoo dataset with the given name
         fiftyone zoo datasets load <name>
 
-        # Load the specified split(s) of the zoo dataset
+        # Load a remotely-sourced zoo dataset
+        fiftyone zoo datasets load https://github.com/<user>/<repo>
+        fiftyone zoo datasets load <url>
+
+        # Load the specified split(s) of a zoo dataset
         fiftyone zoo datasets load <name> --splits <split1> ...
 
-        # Load the zoo dataset with a custom name
+        # Load a zoo dataset with a custom name
         fiftyone zoo datasets load <name> --dataset-name <dataset-name>
-
-        # Load the zoo dataset from a custom directory
-        fiftyone zoo datasets load <name> --dataset-dir <dataset-dir>
 
         # Load a zoo dataset that requires custom keyword arguments
         fiftyone zoo datasets load <name> \\
@@ -2088,7 +2109,9 @@ class DatasetZooLoadCommand(Command):
     @staticmethod
     def setup(parser):
         parser.add_argument(
-            "name", metavar="NAME", help="the name of the dataset"
+            "name_or_url",
+            metavar="NAME_OR_URL",
+            help="the name or remote location of the dataset",
         )
         parser.add_argument(
             "-s",
@@ -2104,12 +2127,6 @@ class DatasetZooLoadCommand(Command):
             help="a custom name to give the FiftyOne dataset",
         )
         parser.add_argument(
-            "-d",
-            "--dataset-dir",
-            metavar="DATASET_DIR",
-            help="a custom directory in which the dataset is downloaded",
-        )
-        parser.add_argument(
             "-k",
             "--kwargs",
             nargs="+",
@@ -2123,17 +2140,15 @@ class DatasetZooLoadCommand(Command):
 
     @staticmethod
     def execute(parser, args):
-        name = args.name
+        name_or_url = args.name_or_url
         splits = args.splits
         dataset_name = args.dataset_name
-        dataset_dir = args.dataset_dir
         kwargs = args.kwargs or {}
 
         dataset = fozd.load_zoo_dataset(
-            name,
+            name_or_url,
             splits=splits,
             dataset_name=dataset_name,
-            dataset_dir=dataset_dir,
             persistent=True,
             **kwargs,
         )
@@ -2144,8 +2159,12 @@ class DatasetZooDeleteCommand(Command):
 
     Examples::
 
-        # Delete an entire zoo dataset from disk
+        # Delete a zoo dataset from disk
         fiftyone zoo datasets delete <name>
+
+        # Delete a remotely-sourced zoo dataset from disk
+        fiftyone zoo datasets delete https://github.com/<user>/<repo>
+        fiftyone zoo datasets delete <url>
 
         # Delete a specific split of a zoo dataset from disk
         fiftyone zoo datasets delete <name> --split <split>
@@ -2154,7 +2173,9 @@ class DatasetZooDeleteCommand(Command):
     @staticmethod
     def setup(parser):
         parser.add_argument(
-            "name", metavar="NAME", help="the name of the dataset"
+            "name_or_url",
+            metavar="NAME_OR_URL",
+            help="the name or remote location of the dataset",
         )
         parser.add_argument(
             "-s",
@@ -2165,9 +2186,9 @@ class DatasetZooDeleteCommand(Command):
 
     @staticmethod
     def execute(parser, args):
-        name = args.name
+        name_or_url = args.name_or_url
         split = args.split
-        fozd.delete_zoo_dataset(name, split=split)
+        fozd.delete_zoo_dataset(name_or_url, split=split)
 
 
 class ModelZooCommand(Command):

--- a/fiftyone/core/cli.py
+++ b/fiftyone/core/cli.py
@@ -1957,41 +1957,33 @@ class DatasetZooInfoCommand(Command):
         name_or_url = args.name_or_url
 
         zoo_dataset = fozd.get_zoo_dataset(name_or_url)
-        downloaded_datasets = fozd.list_downloaded_zoo_datasets()
+
+        try:
+            dataset_dir = fozd.find_zoo_dataset(name_or_url)
+        except:
+            dataset_dir = None
 
         if zoo_dataset.is_remote:
-            description = zoo_dataset.description
-            if description:
-                print("***** Dataset description *****\n%s\n" % description)
-
-            version = zoo_dataset.version
-            if version:
-                print("***** Dataset version *****\n%s\n" % version)
-
-            url = zoo_dataset.url
-            if url:
-                print("***** Dataset source *****\n%s\n" % url)
+            _print_dict_as_table(zoo_dataset.metadata)
+            print("")
         else:
             description = textwrap.dedent("    " + zoo_dataset.__doc__)
             if description:
-                print("***** Dataset description *****\n%s\n" % description)
+                print("***** Dataset description *****\n%s" % description)
 
-        if zoo_dataset.has_tags:
-            print("***** Tags *****")
-            print("%s\n" % ", ".join(zoo_dataset.tags))
+            if zoo_dataset.has_tags:
+                print("***** Tags *****")
+                print("%s\n" % ", ".join(zoo_dataset.tags))
 
-        if zoo_dataset.has_splits:
-            print("***** Supported splits *****")
-            print("%s\n" % ", ".join(zoo_dataset.supported_splits))
+            if zoo_dataset.has_splits:
+                print("***** Supported splits *****")
+                print("%s\n" % ", ".join(zoo_dataset.supported_splits))
 
         print("***** Dataset location *****")
-        if zoo_dataset.name not in downloaded_datasets:
-            print("Dataset '%s' is not downloaded" % name_or_url)
-        else:
-            dataset_dir, info = downloaded_datasets[zoo_dataset.name]
+        if dataset_dir is not None:
             print(dataset_dir)
-            print("\n***** Dataset info *****")
-            print(info)
+        else:
+            print("Dataset '%s' is not downloaded" % name_or_url)
 
 
 class DatasetZooDownloadCommand(Command):

--- a/fiftyone/core/cli.py
+++ b/fiftyone/core/cli.py
@@ -1901,8 +1901,8 @@ class DatasetZooFindCommand(Command):
         fiftyone zoo datasets find <name>
 
         # Print the location of a remotely-sourced zoo dataset on disk
-        fiftyone zoo datasets info https://github.com/<user>/<repo>
-        fiftyone zoo datasets info <url>
+        fiftyone zoo datasets find https://github.com/<user>/<repo>
+        fiftyone zoo datasets find <url>
 
         # Print the location of a specific split of a dataset
         fiftyone zoo datasets find <name> --split <split>

--- a/fiftyone/plugins/core.py
+++ b/fiftyone/plugins/core.py
@@ -207,9 +207,11 @@ def download_plugin(url_or_gh_repo, plugin_names=None, overwrite=False):
             logger.info(f"Downloading {url}...")
             _download_archive(url, tmpdir)
 
-        metadata_paths = list(_iter_plugin_metadata_files(root_dir=tmpdir))
+        metadata_paths = list(
+            _iter_plugin_metadata_files(root_dir=tmpdir, strict=True)
+        )
         if not metadata_paths:
-            logger.info(f"No {PLUGIN_METADATA_FILENAMES} files found in {url}")
+            logger.info(f"No plugin YAML files found in {url}")
 
         for metadata_path in metadata_paths:
             try:
@@ -469,10 +471,6 @@ def create_plugin(
     return plugin_dir
 
 
-def _is_plugin_metadata_file(path):
-    return os.path.basename(path) in PLUGIN_METADATA_FILENAMES
-
-
 def _find_plugin_metadata_file(dirpath):
     for filename in PLUGIN_METADATA_FILENAMES:
         metadata_path = os.path.join(dirpath, filename)
@@ -522,7 +520,7 @@ def _list_plugins_by_name(enabled=None, check_for_duplicates=True):
     return plugin_names
 
 
-def _iter_plugin_metadata_files(root_dir=None):
+def _iter_plugin_metadata_files(root_dir=None, strict=False):
     if root_dir is None:
         root_dir = fo.config.plugins_dir
 
@@ -532,10 +530,28 @@ def _iter_plugin_metadata_files(root_dir=None):
     for root, dirs, files in os.walk(root_dir, followlinks=True):
         # Ignore hidden directories
         dirs[:] = [d for d in dirs if not d.startswith(".")]
+
         for file in files:
-            if _is_plugin_metadata_file(file):
-                yield os.path.join(root, file)
-                dirs[:] = []  # stop traversing `root` once we find a plugin
+            if os.path.basename(file) in PLUGIN_METADATA_FILENAMES:
+                yaml_path = os.path.join(root, file)
+
+                # In strict mode we ensure this is a plugin YAML file
+                if strict:
+                    try:
+                        with open(yaml_path, "r") as f:
+                            type = yaml.safe_load(f).get("type")
+                    except:
+                        logger.warning("Failed to parse '%s'", yaml_path)
+                        continue
+
+                    # Note: if type is missing, we assume it is a plugin
+                    if type not in (None, "plugin"):
+                        continue
+
+                yield yaml_path
+
+                # Stop traversing `root` once we find a plugin
+                dirs[:] = []
                 break
 
 

--- a/fiftyone/plugins/core.py
+++ b/fiftyone/plugins/core.py
@@ -251,7 +251,7 @@ def download_plugin(url_or_gh_repo, plugin_names=None, overwrite=False):
 def _download_archive(url, outdir):
     archive_name = os.path.basename(url)
     if not os.path.splitext(archive_name)[1]:
-        raise ValueError("Cannot infer appropriate archive type for '{url}'")
+        raise ValueError(f"Cannot infer appropriate archive type for '{url}'")
 
     archive_path = os.path.join(outdir, archive_name)
     etaw.download_file(url, path=archive_path)

--- a/fiftyone/zoo/datasets/__init__.py
+++ b/fiftyone/zoo/datasets/__init__.py
@@ -1453,8 +1453,8 @@ class ZooDataset(object):
 
 
 class RemoteZooDataset(ZooDataset):
-    """Base class for remotely-sourced datasets that are compatible with the
-    FiftyOne Dataset Zoo.
+    """Class for working with remotely-sourced datasets that are compatible
+    with the FiftyOne Dataset Zoo.
 
     Args:
         dataset_dir: the dataset's local directory, which must contain a valid

--- a/fiftyone/zoo/datasets/__init__.py
+++ b/fiftyone/zoo/datasets/__init__.py
@@ -32,7 +32,9 @@ logger = logging.getLogger(__name__)
 
 
 def list_zoo_datasets(tags=None, source=None):
-    """Lists the available zoo datasets.
+    """Lists the available datasets in the FiftyOne Dataset Zoo.
+
+    Also includes any remotely-sourced zoo datasets that you've downloaded.
 
     Example usage::
 
@@ -159,7 +161,7 @@ def download_zoo_dataset(
     cleanup=True,
     **kwargs,
 ):
-    """Downloads given dataset from the FiftyOne Dataset Zoo.
+    """Downloads the specified dataset from the FiftyOne Dataset Zoo.
 
     Any dataset splits that have already been downloaded are not re-downloaded,
     unless ``overwrite == True`` is specified.
@@ -171,8 +173,8 @@ def download_zoo_dataset(
         ``GITHUB_TOKEN`` environment variable.
 
     Args:
-        name_or_url: the name of the zoo dataset to download, or the location
-            to download it from, which can be:
+        name_or_url: the name of the zoo dataset to download, or the remote
+            source to download it from, which can be:
 
             -   a GitHub repo URL like ``https://github.com/<user>/<repo>``
             -   a GitHub ref like
@@ -229,7 +231,7 @@ def load_zoo_dataset(
     progress=None,
     **kwargs,
 ):
-    """Loads the given dataset from the FiftyOne Dataset Zoo.
+    """Loads the specified dataset from the FiftyOne Dataset Zoo.
 
     By default, the dataset will be downloaded if necessary.
 
@@ -244,8 +246,8 @@ def load_zoo_dataset(
     dataset will be returned.
 
     Args:
-        name_or_url: the name of the zoo dataset to load, or the location to
-            load it from, which can be:
+        name_or_url: the name of the zoo dataset to load, or the remote source
+            to load it from, which can be:
 
             -   a GitHub repo URL like ``https://github.com/<user>/<repo>``
             -   a GitHub ref like
@@ -382,10 +384,10 @@ def load_zoo_dataset(
         logger.info("Deleting existing dataset '%s'", dataset_name)
         fo.delete_dataset(dataset_name)
 
-    dataset = fo.Dataset(dataset_name, persistent=persistent)
-
     if splits is None and zoo_dataset.has_splits:
         splits = zoo_dataset.supported_splits
+
+    dataset = fo.Dataset(dataset_name, persistent=persistent)
 
     if splits:
         for split in splits:
@@ -522,7 +524,7 @@ def get_zoo_dataset(name_or_url, overwrite=False, **kwargs):
     used.
 
     Args:
-        name_or_url: the name of the zoo dataset, or its remote location, which
+        name_or_url: the name of the zoo dataset, or its remote source, which
             can be:
 
             -   a GitHub repo URL like ``https://github.com/<user>/<repo>``
@@ -533,7 +535,7 @@ def get_zoo_dataset(name_or_url, overwrite=False, **kwargs):
             -   a publicly accessible URL of an archive (eg zip or tar) file
         overwrite (False): whether to overwrite an existing zoo dataset of the
             same name if one exists. Only applicable when ``name_or_url`` is a
-            remote location
+            remote source
         **kwargs: optional arguments for :class:`ZooDataset`
 
     Returns:
@@ -581,7 +583,7 @@ def delete_zoo_dataset(name_or_url, split=None):
     If a ``split`` is provided, only that split is deleted.
 
     Args:
-        name_or_url: the name of the zoo dataset, or its remote location, which
+        name_or_url: the name of the zoo dataset, or its remote source, which
             can be:
 
             -   a GitHub repo URL like ``https://github.com/<user>/<repo>``
@@ -1040,7 +1042,7 @@ class ZooDataset(object):
 
     @property
     def is_remote(self):
-        """Whether the dataset is remotely sourced."""
+        """Whether the dataset is remotely-sourced."""
         return False
 
     @property
@@ -1479,7 +1481,7 @@ class RemoteZooDataset(ZooDataset):
     Args:
         dataset_dir: the dataset's local directory, which must contain a valid
             dataset YAML file
-        url (None): the location the dataset was downloaded from, which can be:
+        url (None): the dataset's remote source, which can be:
 
             -   a GitHub repo URL like ``https://github.com/<user>/<repo>``
             -   a GitHub ref like

--- a/fiftyone/zoo/datasets/__init__.py
+++ b/fiftyone/zoo/datasets/__init__.py
@@ -196,7 +196,7 @@ def download_zoo_dataset(
         cleanup (True): whether to cleanup any temporary files generated during
             download
         **kwargs: optional arguments for the :class:`ZooDataset` constructor
-            or the remote dataset's ``download_and_prepare()` method
+            or the remote dataset's ``download_and_prepare()`` method
 
     Returns:
         a tuple of

--- a/fiftyone/zoo/datasets/__init__.py
+++ b/fiftyone/zoo/datasets/__init__.py
@@ -1485,6 +1485,7 @@ class RemoteZooDataset(ZooDataset):
             url = d.get("url")
 
         self._dataset_dir = dataset_dir
+        self._metadata = d
         self._url = url
         self._kwargs = kwargs
 
@@ -1512,6 +1513,10 @@ class RemoteZooDataset(ZooDataset):
             return (value,)
 
         return tuple(value)
+
+    @property
+    def metadata(self):
+        return self._metadata.copy()
 
     @property
     def name(self):
@@ -1659,10 +1664,15 @@ def _download_dataset_metadata(url_or_gh_repo, overwrite=False):
 
     with etau.TempDir() as tmpdir:
         logger.info(f"Downloading {url_or_gh_repo}...")
-        if repo is not None:
-            repo.download(tmpdir)
-        else:
-            _download_archive(url, tmpdir)
+        try:
+            if repo is not None:
+                repo.download(tmpdir)
+            else:
+                _download_archive(url, tmpdir)
+        except Exception as e:
+            raise ValueError(
+                f"Failed to retrieve dataset metadata from '{url_or_gh_repo}'"
+            ) from e
 
         yaml_path = _find_dataset_metadata(tmpdir)
 

--- a/fiftyone/zoo/datasets/__init__.py
+++ b/fiftyone/zoo/datasets/__init__.py
@@ -1301,9 +1301,7 @@ class ZooDataset(object):
                     dataset_type,
                     num_samples,
                     classes,
-                ) = self._download_and_prepare(
-                    split_dir, scratch_dir, split=split
-                )
+                ) = self._download_and_prepare(split_dir, scratch_dir, split)
 
                 # Add split to ZooDatasetInfo
                 if info is None:
@@ -1344,7 +1342,7 @@ class ZooDataset(object):
                     dataset_type,
                     num_samples,
                     classes,
-                ) = self._download_and_prepare(dataset_dir, scratch_dir)
+                ) = self._download_and_prepare(dataset_dir, scratch_dir, None)
 
                 if self.supports_partial_downloads and num_samples is None:
                     logger.info("Existing download is sufficient")
@@ -1364,7 +1362,7 @@ class ZooDataset(object):
 
         return info
 
-    def _download_and_prepare(self, dataset_dir, scratch_dir, split=None):
+    def _download_and_prepare(self, dataset_dir, scratch_dir, split):
         """Internal implementation of downloading the dataset and preparing it
         for use in the given directory.
 
@@ -1373,7 +1371,8 @@ class ZooDataset(object):
                 a ``split`` is provided, this is the directory for the split
             scratch_dir: a scratch directory to use to download and prepare
                 any required intermediate files
-            split (None): the split to download, if applicable
+            split: the split to download, or None if the dataset does not have
+                splits
 
         Returns:
             tuple of
@@ -1570,7 +1569,7 @@ class RemoteZooDataset(ZooDataset):
     def size_samples(self):
         return self._size_samples
 
-    def _download_and_prepare(self, dataset_dir, _, split=None):
+    def _download_and_prepare(self, dataset_dir, _, split):
         if split is not None:
             dataset_dir = os.path.dirname(dataset_dir)
 

--- a/fiftyone/zoo/datasets/__init__.py
+++ b/fiftyone/zoo/datasets/__init__.py
@@ -13,6 +13,7 @@ import importlib
 import inspect
 import logging
 import os
+import sys
 
 import yaml
 
@@ -1612,7 +1613,7 @@ class RemoteZooDataset(ZooDataset):
         ).replace("/", ".")
         spec = importlib.util.spec_from_file_location(module_name, module_path)
         module = importlib.util.module_from_spec(spec)
-        # sys.modules[module.__name__] = module
+        sys.modules[module.__name__] = module
         spec.loader.exec_module(module)
         return module
 


### PR DESCRIPTION
Adds support for loading zoo datasets whose download/preparation instructions are stored in a GitHub repository or publicly accessible URL! 🎉 

Example datasets published in this format:
- https://github.com/voxel51/coco-2017
- https://github.com/voxel51/caltech101

## Usage

```py
import fiftyone as fo
import fiftyone.zoo as foz

dataset = foz.load_zoo_dataset(
    "https://github.com/voxel51/coco-2017",
    split="validation",
    max_samples=50,
    shuffle=True,
)

dataset = foz.load_zoo_dataset("https://github.com/voxel51/caltech101")
```

Once downloaded, the rest of the zoo API (ie the `foz` module and `fiftyone zoo` CLI) "knows" about remotely-sourced datasets, and henceforward they may be referred to by either the `name` in their `fiftyone.yml` or by the source URL from which they were downloaded:

```shell
fiftyone zoo datasets list

# These are equivalent
fiftyone zoo datasets info voxel51/coco-2017
fiftyone zoo datasets info https://github.com/voxel51/coco-2017

# These are equivalent
fiftyone zoo datasets info voxel51/caltech101
fiftyone zoo datasets info https://github.com/voxel51/caltech101

fiftyone zoo datasets delete voxel51/coco-2017
fiftyone zoo datasets delete voxel51/caltech101
```

## Creating remotely-sourced datasets

This is extensively documented in the PR, but the basic ingredients to defining a remotely-sourced zoo dataset are a `fiftyone.yml` file:

```yaml
name: voxel51/coco-2017
type: dataset
author: The COCO Consortium
version: 1.0.0
url: https://github.com/voxel51/coco-2017
source: http://cocodataset.org/#home
license: https://cocodataset.org/#termsofuse
description: The COCO-2017 dataset
fiftyone:
  version: "*"
supports_partial_downloads: true
tags:
 - image
 - detection
 - segmentation
splits:
 - train
 - validation
 - test
size_samples:
 - train: 118287
 - test: 40670
 - validation: 5000
```

and an `__init__.py` file that contains a `download_and_prepare()` method:

```py
def download_and_prepare(dataset_dir, split=None, **kwargs):
    """Downloads the dataset and prepares it for loading into FiftyOne.

    Args:
        dataset_dir: the directory in which to construct the dataset
        split (None): a specific split to download, if the dataset supports
            splits. The supported split values are defined by the dataset's
            YAML file
        **kwargs: optional keyword arguments that your dataset can define to
            configure what/how the download is performed

    Returns:
        a tuple of

        -   ``dataset_type``: a ``fiftyone.types.Dataset`` type that the
            dataset is stored in locally, or None if the dataset provides
            its own ``load_dataset()`` method
        -   ``num_samples``: the total number of downloaded samples for the
            dataset or split
        -   ``classes``: a list of classes in the dataset, or None if not
            applicable
    """

    # Download files and organize them in `dataset_dir`
    ...

    # Define how the data is stored
    dataset_type = fo.types.ImageClassificationDirectoryTree
    dataset_type = None  # custom ``load_dataset()`` method

    # Indicate how many samples have been downloaded
    # May be less than the total size if partial downloads have been used
    num_samples = 10000

    # Optionally report what classes exist in the dataset
    classes = None
    classes = ["cat", "dog", ...]

    return dataset_type, num_samples, classes
```

and possibly a `load_dataset()` method:

```py
def load_dataset(dataset, dataset_dir, split=None, **kwargs):
    """Loads the dataset into the given FiftyOne dataset.

    Args:
        dataset: a :class:`fiftyone.core.dataset.Dataset` to which to import
        dataset_dir: the directory to which the dataset was downloaded
        split (None): a split to load. The supported values are
            ``("train", "validation", "test")``
        **kwargs: optional keyword arguments that your dataset can define to
            configure what/how the load is performed
    """

    # Load data into samples
    samples = [...]

    # Add samples to the dataset
    dataset.add_samples(samples)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added a `delete` command to the CLI for removing local dataset copies.
	- Introduced support for remote datasets in the Dataset Zoo, allowing users to specify dataset names or URLs.
	- Added a new section in documentation for managing remotely-sourced datasets.

- **Documentation**
	- Enhanced clarity and usability of CLI documentation with refined command descriptions and examples.
	- Updated user guide to clarify the distinction between built-in and remote datasets, along with dependencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->