### PR TITLE
fix set_data clobbering old values

### DIFF
--- a/fiftyone/operators/panel.py
+++ b/fiftyone/operators/panel.py
@@ -212,10 +212,7 @@ class PanelRefState(PanelRefBase):
             value (None): the value, if key is a string
         """
         d = key if isinstance(key, dict) else {key: value}
-
-        for k, v in d.items():
-            super().set(k, v)
-
+        super().set(d)
         self._ctx.ops.patch_panel_state(d)
 
     def clear(self):
@@ -249,10 +246,7 @@ class PanelRefData(PanelRefBase):
             value (None): the value, if key is a string
         """
         d = key if isinstance(key, dict) else {key: value}
-
-        for k, v in d.items():
-            super().set(k, v)
-
+        super().set(d)
         self._ctx.ops.patch_panel_data(d)
 
     def get(self, key, default=None):

--- a/fiftyone/operators/panel.py
+++ b/fiftyone/operators/panel.py
@@ -213,12 +213,10 @@ class PanelRefState(PanelRefBase):
         """
         d = key if isinstance(key, dict) else {key: value}
 
-        args = {}
         for k, v in d.items():
             super().set(k, v)
-            pydash.set_(args, k, v)
 
-        self._ctx.ops.patch_panel_state(args)
+        self._ctx.ops.patch_panel_state(d)
 
     def clear(self):
         """Clears the panel state."""
@@ -252,12 +250,10 @@ class PanelRefData(PanelRefBase):
         """
         d = key if isinstance(key, dict) else {key: value}
 
-        args = {}
         for k, v in d.items():
             super().set(k, v)
-            pydash.set_(args, k, v)
 
-        self._ctx.ops.patch_panel_data(args)
+        self._ctx.ops.patch_panel_data(d)
 
     def get(self, key, default=None):
         raise WriteOnlyError("Panel data is write-only")

--- a/tests/unittests/panels/panel_tests.py
+++ b/tests/unittests/panels/panel_tests.py
@@ -146,12 +146,6 @@ def test_panel_ref_data_setattr(mock_ctx):
     )
 
 
-def test_panel_ref_data_getattr_raises_write_only_error(mock_ctx):
-    data = PanelRefData(mock_ctx)
-    with pytest.raises(WriteOnlyError):
-        _ = data.test_key
-
-
 def test_panel_ref_data_clear(mock_ctx):
     data = PanelRefData(mock_ctx)
     data.test_key = "test_value"
@@ -209,18 +203,17 @@ def test_panel_ref_set_state_deep_path(mock_ctx):
 
 def test_panel_ref_set_state_deep_path_dict(mock_ctx):
     panel_ref = PanelRef(mock_ctx)
-    panel_ref.set_state({"nested": {"key": {"path": "test_value"}}})
+    panel_ref.set_state({"nested.key.path": "test_value"})
     assert panel_ref._state._data["nested"]["key"]["path"] == "test_value"
     mock_ctx.ops.patch_panel_state.assert_called_with(
         {"nested.key.path": "test_value"}
     )
 
 
-def test_panel_ref_get_state_raises_write_only_error(mock_ctx):
+def test_panel_ref_get_data_raises_write_only_error(mock_ctx):
     panel_ref = PanelRef(mock_ctx)
     with pytest.raises(WriteOnlyError):
-        # pylint: disable=no-member
-        _ = panel_ref.test_key
+        _ = panel_ref.data.get("test_key")
 
 
 def test_panel_ref_get_state(mock_ctx):
@@ -258,7 +251,7 @@ def test_panel_ref_set_data_deep_path(mock_ctx):
 
 def test_panel_ref_set_data_deep_path_dict(mock_ctx):
     panel_ref = PanelRef(mock_ctx)
-    panel_ref.set_data({"nested": {"key": {"path": "test_value"}}})
+    panel_ref.set_data({"nested.key.path": "test_value"})
     assert panel_ref._data._data["nested"]["key"]["path"] == "test_value"
     mock_ctx.ops.patch_panel_data.assert_called_with(
         {"nested.key.path": "test_value"}

--- a/tests/unittests/panels/panel_tests.py
+++ b/tests/unittests/panels/panel_tests.py
@@ -189,6 +189,40 @@ def test_panel_ref_set_state(mock_ctx):
     )
 
 
+def test_panel_ref_set_state_dict(mock_ctx):
+    panel_ref = PanelRef(mock_ctx)
+    panel_ref.set_state({"test_key": "test_value"})
+    assert panel_ref._state._data["test_key"] == "test_value"
+    mock_ctx.ops.patch_panel_state.assert_called_with(
+        {"test_key": "test_value"}
+    )
+
+
+def test_panel_ref_set_state_deep_path(mock_ctx):
+    panel_ref = PanelRef(mock_ctx)
+    panel_ref.set_state("nested.key.path", "test_value")
+    assert panel_ref._state._data["nested"]["key"]["path"] == "test_value"
+    mock_ctx.ops.patch_panel_state.assert_called_with(
+        {"nested.key.path": "test_value"}
+    )
+
+
+def test_panel_ref_set_state_deep_path_dict(mock_ctx):
+    panel_ref = PanelRef(mock_ctx)
+    panel_ref.set_state({"nested": {"key": {"path": "test_value"}}})
+    assert panel_ref._state._data["nested"]["key"]["path"] == "test_value"
+    mock_ctx.ops.patch_panel_state.assert_called_with(
+        {"nested.key.path": "test_value"}
+    )
+
+
+def test_panel_ref_get_state_raises_write_only_error(mock_ctx):
+    panel_ref = PanelRef(mock_ctx)
+    with pytest.raises(WriteOnlyError):
+        # pylint: disable=no-member
+        _ = panel_ref.test_key
+
+
 def test_panel_ref_get_state(mock_ctx):
     panel_ref = PanelRef(mock_ctx)
     panel_ref.set_state("test_key", "test_value")
@@ -201,4 +235,31 @@ def test_panel_ref_set_data(mock_ctx):
     assert panel_ref._data._data["test_key"] == "test_value"
     mock_ctx.ops.patch_panel_data.assert_called_with(
         {"test_key": "test_value"}
+    )
+
+
+def test_panel_ref_set_data_dict(mock_ctx):
+    panel_ref = PanelRef(mock_ctx)
+    panel_ref.set_data({"test_key": "test_value"})
+    assert panel_ref._data._data["test_key"] == "test_value"
+    mock_ctx.ops.patch_panel_data.assert_called_with(
+        {"test_key": "test_value"}
+    )
+
+
+def test_panel_ref_set_data_deep_path(mock_ctx):
+    panel_ref = PanelRef(mock_ctx)
+    panel_ref.set_data("nested.key.path", "test_value")
+    assert panel_ref._data._data["nested"]["key"]["path"] == "test_value"
+    mock_ctx.ops.patch_panel_data.assert_called_with(
+        {"nested.key.path": "test_value"}
+    )
+
+
+def test_panel_ref_set_data_deep_path_dict(mock_ctx):
+    panel_ref = PanelRef(mock_ctx)
+    panel_ref.set_data({"nested": {"key": {"path": "test_value"}}})
+    assert panel_ref._data._data["nested"]["key"]["path"] == "test_value"
+    mock_ctx.ops.patch_panel_data.assert_called_with(
+        {"nested.key.path": "test_value"}
     )


### PR DESCRIPTION
## What changes are proposed in this pull request?

`set_data|state("my.path", 42)` was resulting in:

```
# original state|data
{
  "foo": "bar"
}
# after call
{
  "my": {"path": 42}
}
# when it should be
{
  "foo": "bar",
  "my": {"path": 42}
}
```

This PR fixes the issue.

## How is this patch tested? If it is not, please explain why.

You can easily test this with following panel:

```python
class CounterExample(foo.Panel):
    @property
    def config(self):
        return foo.PanelConfig(
            name="example_counter",
            label="Examples: Counter",
        )

    def on_load(self, ctx):
        ctx.panel.state.my_count = 0
        ctx.panel.data.info = {"foo": "bar"}

    def increment(self, ctx):
        ctx.panel.state.my_count += 1
        ctx.panel.set_data("info.bat", "baz")

    def decrement(self, ctx):
        ctx.panel.state.my_count -= 1

    def reset(self, ctx):
        ctx.panel.state.my_count = 0

    def say_hi(self, ctx):
        ctx.ops.notify("Hi!")

    def render(self, ctx):
        panel = types.Object()

        # Add menu to panel
        menu = panel.menu("menu", variant="square", color="51")
        menu.btn(
            "increment",
            icon="add",
            label="Increment",
            on_click=self.increment,
        )
        menu.btn(
            "decrement",
            icon="remove",
            label="Decrement",
            on_click=self.decrement,
        )
        menu.btn("reset", icon="360", label="Reset", on_click=self.reset)
        menu.btn(
            "say_hi",
            icon="emoji_people",
            label="Say hi!",
            on_click=self.say_hi,
            variant="contained",
            color="white",
        )

        # Add counter info to panel
        panel.message("my_count", f"Count: {ctx.panel.state.my_count}")
        panel.obj("info", view=types.JSONView())

        return types.Property(
            panel,
            view=types.GridView(
                align_y="center",
                align_x="center",
                orientation="vertical",
                height=100,
            ),
        )
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Improvements**
	- Streamlined panel state update process for enhanced efficiency and clarity.
- **New Features**
	- Introduced new tests for the `PanelRef` class, covering various scenarios for setting state and data, including deep path strings and write-only property access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->