### PR TITLE
Fix bug with group_by(..., match_expr=)

### DIFF
--- a/fiftyone/core/stages.py
+++ b/fiftyone/core/stages.py
@@ -3416,7 +3416,7 @@ class GroupBy(ViewStage):
         )
 
         if match_expr is not None:
-            pipeline.append({"$match": match_expr})
+            pipeline.append({"$match": {"$expr": match_expr}})
 
         if sort_expr is not None:
             order = -1 if self._reverse else 1

--- a/tests/unittests/group_tests.py
+++ b/tests/unittests/group_tests.py
@@ -1979,6 +1979,15 @@ class DynamicGroupTests(unittest.TestCase):
         self.assertListEqual(view.values("frame_number"), [1, 1])
 
     @drop_datasets
+    def test_match_expr(self):
+        dataset = _make_group_by_dataset()
+
+        view = dataset.group_by(
+            "frame_number", flat=True, match_expr=(F().length() > 1)
+        )
+        self.assertDictEqual(view.count_values("frame_number"), {1: 2, 2: 2})
+
+    @drop_datasets
     def test_group_by_group_dataset(self):
         dataset = _make_group_by_group_dataset()
 


### PR DESCRIPTION
```py
import fiftyone as fo
import fiftyone.zoo as foz
from fiftyone import ViewField as F

dataset = foz.load_zoo_dataset("cifar10", split="test")

view = dataset.take(1000, seed=51)
view2 = view.group_by("ground_truth.label", flat=True, match_expr=F().length() > 100)

print(view.count_values("ground_truth.label"))

# Previously threw an exception; now works
print(view2.count_values("ground_truth.label"))
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced the matching process in the data pipeline to support more complex expressions, improving document filtering capabilities.
- **Tests**
	- Added a new test to validate the functionality of grouping and filtering logic with matching expressions, enhancing test coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->