### PR TITLE
Lightning filter fixes

### DIFF
--- a/app/packages/core/src/components/Filters/StringFilter/Checkboxes.tsx
+++ b/app/packages/core/src/components/Filters/StringFilter/Checkboxes.tsx
@@ -180,7 +180,7 @@ const Checkboxes = ({
   const show = useRecoilValue(showSearchSelector({ modal, path }));
   const getCount = useGetCount(modal, path);
 
-  if (loading) {
+  if (loading || (!show && results === null)) {
     return <LoadingDots text={"Loading"} />;
   }
 

--- a/app/packages/core/src/components/Filters/StringFilter/Checkboxes.tsx
+++ b/app/packages/core/src/components/Filters/StringFilter/Checkboxes.tsx
@@ -180,6 +180,7 @@ const Checkboxes = ({
   const show = useRecoilValue(showSearchSelector({ modal, path }));
   const getCount = useGetCount(modal, path);
 
+  // if results are null, and show is false, values are loading
   if (loading || (!show && results === null)) {
     return <LoadingDots text={"Loading"} />;
   }

--- a/app/packages/core/src/components/Filters/StringFilter/useSelected.ts
+++ b/app/packages/core/src/components/Filters/StringFilter/useSelected.ts
@@ -57,6 +57,7 @@ export default function (
   const shown =
     (resultsLoadable.state !== "loading" || lightning) &&
     (showSearch || length > CHECKBOX_LIMIT);
+
   return {
     results,
     useSearch: useRecoilValue(hasSearchResultsSelector(path))

--- a/app/packages/core/src/components/Sidebar/Entries/FilterablePathEntry/FilterItem.tsx
+++ b/app/packages/core/src/components/Sidebar/Entries/FilterablePathEntry/FilterItem.tsx
@@ -23,7 +23,7 @@ export const FILTERS = {
   [fou.INT_FIELD]: filters.NumericFieldFilter,
   [fou.OBJECT_ID_FIELD]: filters.StringFieldFilter,
   [fou.STRING_FIELD]: filters.StringFieldFilter,
-  ["_LABEL_TAGS"]: filters.LabelFieldFilter,
+  _LABEL_TAGS: filters.LabelFieldFilter,
 };
 
 const FilterItem = ({

--- a/app/packages/state/src/recoil/lightning.test.ts
+++ b/app/packages/state/src/recoil/lightning.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("recoil");
+vi.mock("recoil-relay");
+
+import { TestSelectorFamily, setMockAtoms } from "../../../../__mocks__/recoil";
+import * as lightning from "./lightning";
+
+describe("tests lightning selectors", () => {
+  it("resolves wildcard indexed fields with database path", () => {
+    const test = <TestSelectorFamily<typeof lightning.lightningPaths>>(
+      (<unknown>lightning.lightningPaths("ground_truth"))
+    );
+    setMockAtoms({
+      dbPath: (p) =>
+        p === "ground_truth.id" ? "ground_truth._id" : "ground_truth.label",
+      expandPath: () => "ground_truth",
+      fieldPaths: () => ["id", "label"],
+      indexesByPath: new Set(["ground_truth._id", "ground_truth.label"]),
+      isLabelPath: () => true,
+    });
+
+    expect(test()).toEqual(new Set(["ground_truth.id", "ground_truth.label"]));
+  });
+});

--- a/app/packages/state/src/recoil/lightning.ts
+++ b/app/packages/state/src/recoil/lightning.ts
@@ -169,7 +169,7 @@ export const lightningPaths = selectorFamily<Set<string>, string>({
             })
           )
             .map((p) => `${expanded}.${p}`)
-            .filter((p) => indexes.has(p))
+            .filter((p) => indexes.has(get(schemaAtoms.dbPath(p))))
         );
       }
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

Indexed id fields are incorrectly included as (unindexed) subfilters in lightning mode

Also fixes loading state with boolean lightning filters.

Note that indexed ObjectId fields offer indexed matches/querying but do not offer ixscan substring prefix search, so search results are not enabled. Only exact 24 hex character searches are allowed

### Before


https://github.com/user-attachments/assets/f2bb1301-ddc2-4917-957b-5fab6c779298



### After


https://github.com/user-attachments/assets/ae613edc-7804-47d9-9e71-2122700acc53



## How is this patch tested? If it is not, please explain why.

Selector test

## Release Notes

* Added indexed `id` fields to lightning filters

### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced loading indicator logic in the Filters component for improved user feedback during data loading.
	- Updated filtering logic in the lightning module for more dynamic path validation.

- **Bug Fixes**
	- Adjusted the FILTERS object key definition to ensure proper referencing.

- **Tests**
	- Introduced unit tests for the lightning module to validate selector functionality and improve test coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->