### PR TITLE
allow loading the app even when plugins fails to load

### DIFF
--- a/app/packages/app/src/Sync.tsx
+++ b/app/packages/app/src/Sync.tsx
@@ -29,11 +29,11 @@ import {
   type OperationType,
 } from "relay-runtime";
 import Setup from "./components/Setup";
+import type { IndexPageQuery } from "./pages/__generated__/IndexPageQuery.graphql";
 import type {
   DatasetPageQuery,
   DatasetPageQuery$data,
 } from "./pages/datasets/__generated__/DatasetPageQuery.graphql";
-import type { IndexPageQuery } from "./pages/__generated__/IndexPageQuery.graphql";
 import { useRouterContext, type Entry } from "./routing";
 import { AppReadyState } from "./useEvents/registerEvent";
 import useEventSource from "./useEventSource";
@@ -45,8 +45,6 @@ export const SessionContext = React.createContext<Session>(SESSION_DEFAULT);
 const Plugins = ({ children }: { children: React.ReactNode }) => {
   const plugins = usePlugins();
   if (plugins.isLoading) return <Loading>Pixelating...</Loading>;
-  if (plugins.hasError) return <Loading>Plugin error...</Loading>;
-
   return <>{children}</>;
 };
 

--- a/app/packages/core/src/components/Starter/index.tsx
+++ b/app/packages/core/src/components/Starter/index.tsx
@@ -5,6 +5,7 @@ import {
   useOperatorExecutor,
   usePromptOperatorInput,
 } from "@fiftyone/operators/src/state";
+import { datasetName as datasetNameAtom } from "@fiftyone/state";
 import {
   Button,
   ButtonProps,
@@ -15,9 +16,8 @@ import {
   Typography,
 } from "@mui/material";
 import React, { useCallback, useMemo } from "react";
-import { CONTENT_BY_MODE } from "./content";
 import { useRecoilValue } from "recoil";
-import { datasetName as datasetNameAtom } from "@fiftyone/state";
+import { CONTENT_BY_MODE } from "./content";
 
 const CREATE_DATASET_OPERATOR = "@voxel51/utils/create_dataset";
 const IMPORT_SAMPLES_OPERATOR = "@voxel51/io/import_samples";
@@ -30,12 +30,12 @@ const INSTALL_IO_PLUGIN_LABEL = "@voxel51/io";
 
 export function Starter(props: StarterPropsType) {
   const { mode } = props;
-  const ready = useOperators(true);
+  const { isLoading } = useOperators(true);
   const datasetName = useRecoilValue(datasetNameAtom);
 
   if (!mode) return null;
 
-  if (!ready) return <Loading>Pixelating...</Loading>;
+  if (isLoading) return <Loading>Pixelating...</Loading>;
 
   const { code, codeTitle, learnMoreLabel, learnMoreLink, title } =
     CONTENT_BY_MODE[mode];

--- a/app/packages/spaces/src/components/Workspaces/index.tsx
+++ b/app/packages/spaces/src/components/Workspaces/index.tsx
@@ -25,8 +25,13 @@ import { useWorkspaces } from "./hooks";
 export default function Workspaces() {
   const [open, setOpen] = useState(false);
   const [searchTerm, setSearchTerm] = useState("");
-  const { workspaces, loadWorkspace, initialized, listWorkspace } =
-    useWorkspaces();
+  const {
+    workspaces,
+    loadWorkspace,
+    initialized,
+    listWorkspace,
+    canInitialize,
+  } = useWorkspaces();
   const setWorkspaceEditorState = useSetRecoilState(workspaceEditorStateAtom);
   const canEditWorkSpace = useRecoilValue(canEditWorkspaces);
   const disabled = canEditWorkSpace.enabled !== true;
@@ -45,10 +50,12 @@ export default function Workspaces() {
   }, [workspaces, searchTerm]);
 
   useEffect(() => {
-    if (!initialized) {
+    if (!initialized && canInitialize) {
       listWorkspace();
     }
-  }, [open, initialized, listWorkspace]);
+  }, [open, initialized, listWorkspace, canInitialize]);
+
+  if (!canInitialize) return null;
 
   return (
     <Box>


### PR DESCRIPTION
## Caveats
 - When python plugins fails to load, workspaces feature will not work as it depends on built-in operators
 - Needs a follow-up to gracefully handle execution of non-existent operations
   - Deferred as the change is bit out of scope of this PR

## What changes are proposed in this pull request?

allow loading the app even when plugins fails to load

## How is this patch tested? If it is not, please explain why.

By redirecting plugins/operators request to non-existent port in fetch function to prevent loading of python plugins

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

allow loading the app even when plugins fails to load
### What areas of FiftyOne does this PR affect?

-   [x] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced state management in various components, providing clearer insights into loading and error states.
	- Introduced a notification mechanism for plugin initialization failures, improving user feedback.
	- Added a `canInitialize` property in the workspace hook to control component rendering based on initialization status.

- **Bug Fixes**
	- Improved error handling and visibility for plugin loading processes.

- **Refactor**
	- Streamlined control flow in multiple components for better clarity and responsiveness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->