### PR TITLE
Cherry pick #4715

### DIFF
--- a/fiftyone/operators/delegated.py
+++ b/fiftyone/operators/delegated.py
@@ -405,7 +405,8 @@ class DelegatedOperationService(object):
             outputs = await resolve_type_with_context(
                 request_params, "outputs"
             )
-            outputs_schema = outputs.to_json()
+            if outputs is not None:
+                outputs_schema = outputs.to_json()
         except (AttributeError, Exception):
             logger.warning(
                 "Failed to resolve output schema for the operation."


### PR DESCRIPTION
Cherry-picking #4715 for release.

**Benefits:** delegated operations will no longer emit spurious "failed to resolve output schema for the operation" warnings (regression in `fiftyone==0.25`).

**Risks:** none
