### PR TITLE
Dict safe get for `dataset. get_index_information `

### DIFF
--- a/fiftyone/core/collections.py
+++ b/fiftyone/core/collections.py
@@ -9091,7 +9091,7 @@ class SampleCollection(object):
                 if key in sample_info:
                     sample_info[key]["size"] = size
 
-            for key in cs["indexBuilds"]:
+            for key in cs.get("indexBuilds", []):
                 if key in sample_info:
                     sample_info[key]["in_progress"] = True
 
@@ -9113,7 +9113,7 @@ class SampleCollection(object):
                     if key in frame_info:
                         frame_info[key]["size"] = size
 
-                for key in cs["indexBuilds"]:
+                for key in cs.get("indexBuilds", []):
                     if key in frame_info:
                         frame_info[key]["in_progress"] = True
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

When I run db collection script, a small number of datasets error out because `indexBuilds` is not present in the result. This small bug fix addresses this problem.

## How is this patch tested? If it is not, please explain why.

* Manual testing (✅ )

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling for accessing index information, preventing potential interruptions due to missing keys.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->