### PR TITLE
Require pydicom<3

### DIFF
--- a/docs/source/user_guide/dataset_creation/datasets.rst
+++ b/docs/source/user_guide/dataset_creation/datasets.rst
@@ -4507,8 +4507,8 @@ of images and their associated properties stored in
 
 .. note::
 
-    You must have `pydicom <https://github.com/pydicom/pydicom>`_ installed in
-    order to load DICOM datasets.
+    You must have `pydicom<3 <https://github.com/pydicom/pydicom>`_ installed
+    in order to load DICOM datasets.
 
 The standard format for datasets of this type is the following:
 

--- a/fiftyone/utils/dicom.py
+++ b/fiftyone/utils/dicom.py
@@ -5,6 +5,7 @@ DICOM utilities.
 | `voxel51.com <https://voxel51.com/>`_
 |
 """
+
 import logging
 import os
 import warnings
@@ -16,7 +17,7 @@ import eta.core.utils as etau
 import fiftyone.core.utils as fou
 import fiftyone.utils.data as foud
 
-fou.ensure_package("pydicom")
+fou.ensure_package("pydicom<3")
 import pydicom
 from pydicom.fileset import FileInstance, FileSet
 

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,7 +1,7 @@
 open3d>=0.16.0
 itsdangerous==2.0.1
 werkzeug==3.0.3
-pydicom
+pydicom<3
 pytest==7.3.1
 pytest-cov==4.0.0
 pytest-mock==3.10.0


### PR DESCRIPTION
## What changes are proposed in this pull request?

`pydicom==3.0.0` was released yesterday and has breaking changes. Until 3.0 changes can be fully understood, I propose we require `pydicom<3` for the integration

## How is this patch tested? If it is not, please explain why.

Existing tests

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit


- **New Features**
	- Updated handling of DICOM data types, specifically for `PersonNameUnicode`, enhancing data processing accuracy.
- **Bug Fixes**
	- Adjusted the mapping of DICOM types to Python types to improve compatibility and functionality.
- **Documentation**
	- Clarified installation requirements for the `pydicom` library, specifying version constraint as `pydicom<3`.
- **Chores**
	- Updated version specification for the `pydicom` package to ensure compatibility with existing codebase.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->