### PR TITLE
Update labelstudio docs for multilabel classification

### DIFF
--- a/docs/source/integrations/labelstudio.rst
+++ b/docs/source/integrations/labelstudio.rst
@@ -27,6 +27,7 @@ and download annotations using Label Studio, all programmatically in Python.
 All of the following label types are supported for image datasets:
 
 - :ref:`Classification <classification>`
+- :ref:`Multilabel Classification <multilabel-classification>`
 - :ref:`Detections <object-detection>`
 - :ref:`Instance segmentations <instance-segmentation>`
 - :ref:`Polygons and polylines <polylines>`
@@ -417,6 +418,8 @@ more details:
 
     -   ``"classification"``: a single classification stored in
         |Classification| fields
+    -   ``"classifications"``: multilabel classifications stored in
+        |Classifications| fields
     -   ``"detections"``: object detections stored in |Detections| fields
     -   ``"instances"``: instance segmentations stored in |Detections| fields
         with their :attr:`mask <fiftyone.core.labels.Detection.mask>`
@@ -664,5 +667,6 @@ ________________
 
 .. note::
 
-    Special thanks to `Rustem Galiullin <https://github.com/Rusteam>`_ and
+    Special thanks to `Rustem Galiullin <https://github.com/Rusteam>`_,
+    `Ganesh Tata <https://github.com/tataganesh>`_, and
     `Emil Zakirov <https://github.com/bonlime>`_ for building this integration!

--- a/docs/source/integrations/labelstudio.rst
+++ b/docs/source/integrations/labelstudio.rst
@@ -27,7 +27,7 @@ and download annotations using Label Studio, all programmatically in Python.
 All of the following label types are supported for image datasets:
 
 - :ref:`Classification <classification>`
-- :ref:`Multilabel Classification <multilabel-classification>`
+- :ref:`Multilabel classification <multilabel-classification>`
 - :ref:`Detections <object-detection>`
 - :ref:`Instance segmentations <instance-segmentation>`
 - :ref:`Polygons and polylines <polylines>`


### PR DESCRIPTION
To be merged after: https://github.com/voxel51/fiftyone/pull/4725

## What changes are proposed in this pull request?

Updates the labelstudio integration documentation for the new support added in this PR: https://github.com/voxel51/fiftyone/pull/4725

## How is this patch tested? If it is not, please explain why.

Built the docs and verified the formatting.

## Release Notes

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [ ] No. You can skip the rest of this section.
-   [x] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.


"The Labelstudio integration now supports multilabel classification annotation thanks to [Ganesh Tata](https://github.com/tataganesh)"

### What areas of FiftyOne does this PR affect?

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [ ] Core: Core `fiftyone` Python library changes
-   [x] Documentation: FiftyOne documentation changes
-   [ ] Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated documentation for the Label Studio integration to include support for multilabel classification.
	- Expanded the description of classification types to clarify multilabel classifications.
	- Acknowledgments section updated to include contributor Ganesh Tata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->